### PR TITLE
[EDR Workflows] Fix artifact FTR tests broken by artifacts regrouping

### DIFF
--- a/x-pack/solutions/security/test/security_solution_endpoint/apps/integrations/artifact_entries_list.ts
+++ b/x-pack/solutions/security/test/security_solution_endpoint/apps/integrations/artifact_entries_list.ts
@@ -38,8 +38,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
     }
   };
 
-  // Failing: See https://github.com/elastic/kibana/issues/261850
-  describe.skip('For each artifact list under management', function () {
+  describe('For each artifact list under management', function () {
     targetTags(this, ['@ess', '@serverless']);
     this.timeout(60_000 * 5);
 
@@ -221,8 +220,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
     };
 
     for (const testData of getArtifactsListTestsData()) {
-      // Failing: See https://github.com/elastic/kibana/issues/261849
-      describe.skip(`When on the ${testData.title} entries list`, function () {
+      describe(`When on the ${testData.title} entries list`, function () {
         beforeEach(async () => {
           policyInfo = await policyTestResources.createPolicy();
           await removeAllArtifactLists();
@@ -237,8 +235,8 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
           }
         });
 
-        it(`should not show page title if there is no ${testData.title} entry`, async () => {
-          await testSubjects.missingOrFail('header-page-title');
+        it(`should show empty state if there is no ${testData.title} entry`, async () => {
+          await testSubjects.existOrFail(`${testData.pagePrefix}-emptyState`);
         });
 
         it(`should be able to add a new ${testData.title} entry`, async () => {
@@ -300,8 +298,8 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
           await deleteArtifact(testData);
           // We only expect one artifact to have been visible
           await testSubjects.missingOrFail(testData.delete.card);
-          // Header has gone because there is no artifact
-          await testSubjects.missingOrFail('header-page-title');
+          // Empty state is shown because there is no artifact
+          await testSubjects.existOrFail(`${testData.pagePrefix}-emptyState`);
         });
       });
     }

--- a/x-pack/solutions/security/test/security_solution_endpoint/apps/integrations/trusted_apps_list.ts
+++ b/x-pack/solutions/security/test/security_solution_endpoint/apps/integrations/trusted_apps_list.ts
@@ -14,16 +14,15 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
   const testSubjects = getService('testSubjects');
   const toasts = getService('toasts');
 
-  // Failing: See https://github.com/elastic/kibana/issues/261829
-  describe.skip('When on the Trusted Apps list', function () {
+  describe('When on the Trusted Apps list', function () {
     targetTags(this, ['@ess', '@serverless']);
 
     before(async () => {
       await pageObjects.trustedApps.navigateToTrustedAppsList();
     });
 
-    it('should not show page title if there is no trusted app', async () => {
-      await testSubjects.missingOrFail('header-page-title');
+    it('should show empty state if there is no trusted app', async () => {
+      await testSubjects.existOrFail('trustedAppsListPage-emptyState');
     });
 
     it('should be able to add a new trusted app and remove it', async () => {
@@ -50,8 +49,8 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
       await testSubjects.waitForDeleted('trustedAppsListPage-deleteModal-submitButton');
       // We only expect one trusted app to have been visible
       await testSubjects.missingOrFail('trustedAppsListPage-card');
-      // Header has gone because there is no trusted app
-      await testSubjects.missingOrFail('header-page-title');
+      // Empty state is shown because there is no trusted app
+      await testSubjects.existOrFail('trustedAppsListPage-emptyState');
     });
   });
 };


### PR DESCRIPTION
The artifacts regrouping PR (#257001) reorganized all endpoint artifacts into a unified page with tabs. This changed the page structure so that `header-page-title` now belongs to the unified "Artifacts" page and is always present, regardless of whether individual tabs have entries.

Previously, `trusted_apps_list.ts` was skipped (flaky). Our PR #261180 unskipped it after fixing the underlying flakiness — but by that point the regrouping had already landed, making the `header-page-title` assertions invalid. The test immediately started failing on merge.

`artifact_entries_list.ts` has the same `header-page-title` assertions for all artifact types (trusted apps, event filters, blocklist, host isolation exceptions) — these would fail for the same reason once hit.

**Fix:** Replace `missingOrFail('header-page-title')` with `existOrFail('*-emptyState')` in both test files. The empty state test subject is the correct indicator that a tab has no entries.

Closes https://github.com/elastic/kibana/issues/261827
Closes https://github.com/elastic/kibana/issues/261829
Closes https://github.com/elastic/kibana/issues/261833
Closes https://github.com/elastic/kibana/issues/261849
Closes https://github.com/elastic/kibana/issues/261850