### PR TITLE
[Automatic Import V2] Require Approval After Deleting Data Stream or Editting DS Pipeline

### DIFF
--- a/x-pack/platform/plugins/shared/automatic_import/server/integration_tests/automatic_import_service.test.ts
+++ b/x-pack/platform/plugins/shared/automatic_import/server/integration_tests/automatic_import_service.test.ts
@@ -19,6 +19,7 @@ import type {
 import type { AutomaticImportPluginStartDependencies } from '..';
 import { AutomaticImportService } from '../services/automatic_import_service';
 import type { AutomaticImportSavedObjectService } from '../services/saved_objects/saved_objects_service';
+import type { IntegrationAttributes } from '../services/saved_objects/schemas/types';
 import { TASK_STATUSES } from '../services/saved_objects/constants';
 import {
   mockAuthenticatedUser,
@@ -162,5 +163,110 @@ describe('AutomaticImportService Integration Tests', () => {
     await expect(
       automaticImportService.getDataStreamResults('itest-integration-failed', 'itest-ds-failed')
     ).rejects.toThrow('failed and has no results');
+  });
+
+  describe('resetApprovedStatus on data stream deletion', () => {
+    it('should reset approved integration to completed when a data stream is deleted', async () => {
+      const savedObjectService = (
+        automaticImportService as unknown as {
+          savedObjectService: AutomaticImportSavedObjectService;
+        }
+      ).savedObjectService;
+
+      const integrationId = 'itest-reset-approved';
+
+      // Create integration with two data streams
+      await savedObjectService.insertIntegration(
+        { ...mockIntegrationParams, integrationId },
+        mockAuthenticatedUser
+      );
+      await savedObjectService.insertDataStream(
+        {
+          ...mockDataStreamParams,
+          integrationId,
+          dataStreamId: 'itest-reset-ds-1',
+          jobInfo: {
+            jobId: 'job-r1',
+            jobType: 'autoImport-dataStream-task',
+            status: TASK_STATUSES.completed,
+          },
+        },
+        mockAuthenticatedUser
+      );
+      await savedObjectService.insertDataStream(
+        {
+          ...mockDataStreamParams,
+          integrationId,
+          dataStreamId: 'itest-reset-ds-2',
+          jobInfo: {
+            jobId: 'job-r2',
+            jobType: 'autoImport-dataStream-task',
+            status: TASK_STATUSES.completed,
+          },
+        },
+        mockAuthenticatedUser
+      );
+
+      // Manually set the integration to approved status
+      const integration = await savedObjectService.getIntegration(integrationId);
+      const approvedData: IntegrationAttributes = {
+        ...integration,
+        status: TASK_STATUSES.approved,
+      };
+      await savedObjectService.updateIntegration(approvedData, '1.0.0');
+
+      // Verify it's approved
+      const beforeDelete = await savedObjectService.getIntegration(integrationId);
+      expect(beforeDelete.status).toBe(TASK_STATUSES.approved);
+
+      // Delete one data stream
+      await automaticImportService.deleteDataStream(integrationId, 'itest-reset-ds-1');
+
+      // Integration should now be completed, not approved
+      const afterDelete = await savedObjectService.getIntegration(integrationId);
+      expect(afterDelete.status).toBe(TASK_STATUSES.completed);
+    });
+
+    it('should not change status of a non-approved integration on data stream deletion', async () => {
+      const savedObjectService = (
+        automaticImportService as unknown as {
+          savedObjectService: AutomaticImportSavedObjectService;
+        }
+      ).savedObjectService;
+
+      const integrationId = 'itest-no-reset';
+
+      // Create integration with a completed data stream (status remains completed, not approved)
+      await savedObjectService.insertIntegration(
+        { ...mockIntegrationParams, integrationId },
+        mockAuthenticatedUser
+      );
+      await savedObjectService.insertDataStream(
+        {
+          ...mockDataStreamParams,
+          integrationId,
+          dataStreamId: 'itest-no-reset-ds-1',
+          jobInfo: {
+            jobId: 'job-nr1',
+            jobType: 'autoImport-dataStream-task',
+            status: TASK_STATUSES.completed,
+          },
+        },
+        mockAuthenticatedUser
+      );
+
+      // Verify it's not approved
+      const beforeDelete = await savedObjectService.getIntegration(integrationId);
+      expect(beforeDelete.status).not.toBe(TASK_STATUSES.approved);
+
+      const statusBeforeDelete = beforeDelete.status;
+
+      // Delete the data stream
+      await automaticImportService.deleteDataStream(integrationId, 'itest-no-reset-ds-1');
+
+      // Status should remain unchanged
+      const afterDelete = await savedObjectService.getIntegration(integrationId);
+      expect(afterDelete.status).toBe(statusBeforeDelete);
+    });
   });
 });

--- a/x-pack/platform/plugins/shared/automatic_import/server/integration_tests/automatic_import_service.test.ts
+++ b/x-pack/platform/plugins/shared/automatic_import/server/integration_tests/automatic_import_service.test.ts
@@ -212,6 +212,14 @@ describe('AutomaticImportService Integration Tests', () => {
       const approvedData: IntegrationAttributes = {
         ...integration,
         status: TASK_STATUSES.approved,
+        changelog: [
+          {
+            version: '1.0.0',
+            changes: [
+              { description: 'Initial release of Test Integration', type: 'enhancement', link: '' },
+            ],
+          },
+        ],
       };
       await savedObjectService.updateIntegration(approvedData, '1.0.0');
 
@@ -228,11 +236,12 @@ describe('AutomaticImportService Integration Tests', () => {
 
       // Version should be bumped and a changelog entry added
       expect(afterDelete.metadata.version).toBe('1.1.0');
-      expect(afterDelete.changelog).toHaveLength(1);
+      expect(afterDelete.changelog).toHaveLength(2);
       expect(afterDelete.changelog![0]).toEqual({
         version: '1.1.0',
         changes: [{ description: 'Updated Test Integration', type: 'enhancement', link: '' }],
       });
+      expect(afterDelete.changelog![1].version).toBe('1.0.0');
     });
 
     it('should bump version and add changelog entry when resetting approved integration', async () => {

--- a/x-pack/platform/plugins/shared/automatic_import/server/integration_tests/automatic_import_service.test.ts
+++ b/x-pack/platform/plugins/shared/automatic_import/server/integration_tests/automatic_import_service.test.ts
@@ -225,6 +225,84 @@ describe('AutomaticImportService Integration Tests', () => {
       // Integration should now be completed, not approved
       const afterDelete = await savedObjectService.getIntegration(integrationId);
       expect(afterDelete.status).toBe(TASK_STATUSES.completed);
+
+      // Version should be bumped and a changelog entry added
+      expect(afterDelete.metadata.version).toBe('1.1.0');
+      expect(afterDelete.changelog).toHaveLength(1);
+      expect(afterDelete.changelog![0]).toEqual({
+        version: '1.1.0',
+        changes: [{ description: 'Updated Test Integration', type: 'enhancement', link: '' }],
+      });
+    });
+
+    it('should bump version and add changelog entry when resetting approved integration', async () => {
+      const savedObjectService = (
+        automaticImportService as unknown as {
+          savedObjectService: AutomaticImportSavedObjectService;
+        }
+      ).savedObjectService;
+
+      const integrationId = 'itest-reset-changelog';
+
+      await savedObjectService.insertIntegration(
+        { ...mockIntegrationParams, integrationId },
+        mockAuthenticatedUser
+      );
+      await savedObjectService.insertDataStream(
+        {
+          ...mockDataStreamParams,
+          integrationId,
+          dataStreamId: 'itest-reset-cl-ds-1',
+          jobInfo: {
+            jobId: 'job-cl1',
+            jobType: 'autoImport-dataStream-task',
+            status: TASK_STATUSES.completed,
+          },
+        },
+        mockAuthenticatedUser
+      );
+      await savedObjectService.insertDataStream(
+        {
+          ...mockDataStreamParams,
+          integrationId,
+          dataStreamId: 'itest-reset-cl-ds-2',
+          jobInfo: {
+            jobId: 'job-cl2',
+            jobType: 'autoImport-dataStream-task',
+            status: TASK_STATUSES.completed,
+          },
+        },
+        mockAuthenticatedUser
+      );
+
+      // Approve at version 2.0.0 with an existing changelog entry
+      const integration = await savedObjectService.getIntegration(integrationId);
+      const approvedData: IntegrationAttributes = {
+        ...integration,
+        status: TASK_STATUSES.approved,
+        changelog: [
+          {
+            version: '2.0.0',
+            changes: [
+              { description: 'Initial release of Test Integration', type: 'enhancement', link: '' },
+            ],
+          },
+        ],
+      };
+      await savedObjectService.updateIntegration(approvedData, '2.0.0');
+
+      // Delete a data stream — should bump to 2.0.1 and prepend changelog entry
+      await automaticImportService.deleteDataStream(integrationId, 'itest-reset-cl-ds-1');
+
+      const afterDelete = await savedObjectService.getIntegration(integrationId);
+      expect(afterDelete.status).toBe(TASK_STATUSES.completed);
+      expect(afterDelete.metadata.version).toBe('2.1.0');
+      expect(afterDelete.changelog).toHaveLength(2);
+      expect(afterDelete.changelog![0]).toEqual({
+        version: '2.1.0',
+        changes: [{ description: 'Updated Test Integration', type: 'enhancement', link: '' }],
+      });
+      expect(afterDelete.changelog![1].version).toBe('2.0.0');
     });
 
     it('should not change status of a non-approved integration on data stream deletion', async () => {
@@ -264,9 +342,10 @@ describe('AutomaticImportService Integration Tests', () => {
       // Delete the data stream
       await automaticImportService.deleteDataStream(integrationId, 'itest-no-reset-ds-1');
 
-      // Status should remain unchanged
+      // Status should remain unchanged and no changelog entry added
       const afterDelete = await savedObjectService.getIntegration(integrationId);
       expect(afterDelete.status).toBe(statusBeforeDelete);
+      expect(afterDelete.changelog).toBeUndefined();
     });
   });
 });

--- a/x-pack/platform/plugins/shared/automatic_import/server/services/automatic_import_service.ts
+++ b/x-pack/platform/plugins/shared/automatic_import/server/services/automatic_import_service.ts
@@ -404,8 +404,6 @@ export class AutomaticImportService {
       },
       authenticatedUser
     );
-
-    await this.resetApprovedStatus(dataStreamParams.integrationId);
   }
 
   public async getDataStream(

--- a/x-pack/platform/plugins/shared/automatic_import/server/services/automatic_import_service.ts
+++ b/x-pack/platform/plugins/shared/automatic_import/server/services/automatic_import_service.ts
@@ -404,6 +404,8 @@ export class AutomaticImportService {
       },
       authenticatedUser
     );
+
+    await this.resetApprovedStatus(dataStreamParams.integrationId);
   }
 
   public async getDataStream(
@@ -472,6 +474,8 @@ export class AutomaticImportService {
     }
 
     await this.savedObjectService.deleteDataStream(dataStreamId, integrationId, options);
+
+    await this.resetApprovedStatus(integrationId);
   }
 
   public async reanalyzeDataStream(
@@ -670,7 +674,26 @@ export class AutomaticImportService {
       status: TASK_STATUSES.completed,
     });
 
+    await this.resetApprovedStatus(integrationId);
+
     return this.getDataStreamResults(integrationId, dataStreamId);
+  }
+
+  private async resetApprovedStatus(integrationId: string): Promise<void> {
+    assert(this.savedObjectService, 'Saved Objects service not initialized.');
+    const integration = await this.savedObjectService.getIntegration(integrationId);
+    if (integration.status === TASK_STATUSES.approved) {
+      const currentVersion = integration.metadata?.version || '0.1.0';
+      const updateData: IntegrationAttributes = {
+        ...integration,
+        status: TASK_STATUSES.completed,
+      };
+
+      await this.savedObjectService.updateIntegration(updateData, currentVersion);
+      this.logger.debug(
+        `Integration ${integrationId} status reset from approved to completed after data stream mutation`
+      );
+    }
   }
 
   public stop() {

--- a/x-pack/platform/plugins/shared/automatic_import/server/services/automatic_import_service.ts
+++ b/x-pack/platform/plugins/shared/automatic_import/server/services/automatic_import_service.ts
@@ -333,17 +333,7 @@ export class AutomaticImportService {
     }
 
     const title = existing.metadata?.title ?? integrationId;
-    const isInitialRelease = !existing.changelog || existing.changelog.length === 0;
-    const changelogEntry: ChangelogEntry = {
-      version,
-      changes: [
-        {
-          description: isInitialRelease ? `Initial release of ${title}` : `Updated ${title}`,
-          type: 'enhancement',
-          link: '',
-        },
-      ],
-    };
+    const changelogEntry = this.createChangelogEntry(version, title, existing.changelog);
 
     const updateData: IntegrationAttributes = {
       ...existing,
@@ -682,16 +672,40 @@ export class AutomaticImportService {
     const integration = await this.savedObjectService.getIntegration(integrationId);
     if (integration.status === TASK_STATUSES.approved) {
       const currentVersion = integration.metadata?.version || '0.1.0';
+      const parts = currentVersion.split('.');
+      const newVersion =
+        parts.length === 3 ? `${parts[0]}.${parseInt(parts[1], 10) + 1}.0` : currentVersion;
+      const title = integration.metadata?.title ?? integrationId;
+      const changelogEntry = this.createChangelogEntry(newVersion, title, integration.changelog);
       const updateData: IntegrationAttributes = {
         ...integration,
         status: TASK_STATUSES.completed,
+        changelog: [changelogEntry, ...(integration.changelog ?? [])],
       };
 
-      await this.savedObjectService.updateIntegration(updateData, currentVersion);
+      await this.savedObjectService.updateIntegration(updateData, newVersion);
       this.logger.debug(
         `Integration ${integrationId} status reset from approved to completed after data stream mutation`
       );
     }
+  }
+
+  private createChangelogEntry(
+    version: string,
+    title: string,
+    existingChangelog?: ChangelogEntry[]
+  ): ChangelogEntry {
+    const isInitialRelease = !existingChangelog || existingChangelog.length === 0;
+    return {
+      version,
+      changes: [
+        {
+          description: isInitialRelease ? `Initial release of ${title}` : `Updated ${title}`,
+          type: 'enhancement',
+          link: '',
+        },
+      ],
+    };
   }
 
   public stop() {

--- a/x-pack/platform/plugins/shared/automatic_import/server/services/automatic_import_service_telemetry.test.ts
+++ b/x-pack/platform/plugins/shared/automatic_import/server/services/automatic_import_service_telemetry.test.ts
@@ -548,6 +548,7 @@ describe('AutomaticImportSetupService', () => {
       asPrivate(service).savedObjectService = {
         deleteDataStream: mockDeleteSavedObject,
         updateDataStreamStatus: mockUpdateStatus,
+        getIntegration: jest.fn().mockResolvedValue({ status: 'completed' }),
       } as unknown as AutomaticImportSavedObjectService;
 
       await service.deleteDataStream('integration-123', 'data-stream-456');
@@ -585,6 +586,7 @@ describe('AutomaticImportSetupService', () => {
       asPrivate(service).savedObjectService = {
         deleteDataStream: mockDeleteSavedObject,
         updateDataStreamStatus: mockUpdateStatus,
+        getIntegration: jest.fn().mockResolvedValue({ status: 'completed' }),
       } as unknown as AutomaticImportSavedObjectService;
 
       await service.deleteDataStream('integration-123', 'data-stream-456', options);
@@ -619,6 +621,7 @@ describe('AutomaticImportSetupService', () => {
       asPrivate(service).savedObjectService = {
         deleteDataStream: mockDeleteSavedObject,
         updateDataStreamStatus: mockUpdateStatus,
+        getIntegration: jest.fn().mockResolvedValue({ status: 'completed' }),
       } as unknown as AutomaticImportSavedObjectService;
 
       await service.deleteDataStream('integration-123', 'data-stream-456');
@@ -647,6 +650,7 @@ describe('AutomaticImportSetupService', () => {
       asPrivate(service).savedObjectService = {
         deleteDataStream: mockDeleteSavedObject,
         updateDataStreamStatus: mockUpdateStatus,
+        getIntegration: jest.fn().mockResolvedValue({ status: 'completed' }),
       } as unknown as AutomaticImportSavedObjectService;
 
       await service.deleteDataStream('integration-123', 'data-stream-456');
@@ -709,6 +713,7 @@ describe('AutomaticImportSetupService', () => {
       asPrivate(service).savedObjectService = {
         deleteDataStream: mockDeleteSavedObject,
         updateDataStreamStatus: mockUpdateStatus,
+        getIntegration: jest.fn().mockResolvedValue({ status: 'completed' }),
       } as unknown as AutomaticImportSavedObjectService;
 
       await service.deleteDataStream('integration-123', 'data-stream-456');

--- a/x-pack/platform/plugins/shared/automatic_import/server/services/saved_objects/saved_objects_service.ts
+++ b/x-pack/platform/plugins/shared/automatic_import/server/services/saved_objects/saved_objects_service.ts
@@ -139,6 +139,7 @@ export class AutomaticImportSavedObjectService {
           ...data.metadata,
           version: newVersion,
         },
+        changelog: data.changelog ?? existingIntegration.changelog,
       };
 
       return await this.savedObjectsClient.update<IntegrationAttributes>(


### PR DESCRIPTION
## Summary

Resets the approval status of the integration when we delete a data stream or edit the data stream via the data stream pipeline editor


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
~~- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~~
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
~~- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~~
~~- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.~~
~~- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed~~
~~- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)~~
~~- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.~~