### PR TITLE
fix(serverless,tests): switch Security Cypress tests to use UIAM authentication

### DIFF
--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/support/saml_auth.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/support/saml_auth.ts
@@ -17,6 +17,7 @@ import { resolve } from 'path';
 import axios from 'axios';
 import fs from 'fs';
 import yaml from 'js-yaml';
+import { MOCK_IDP_UIAM_ORGANIZATION_ID } from '@kbn/mock-idp-utils';
 import { DEFAULT_SERVERLESS_ROLE } from '../env_var_names_constants';
 
 export const samlAuthentication = async (
@@ -70,6 +71,11 @@ export const samlAuthentication = async (
     log,
     isCloud: config.env.CLOUD_SERVERLESS,
     cloudUsersFilePath,
+    serverless: {
+      uiam: true,
+      projectType: 'security',
+      organizationId: MOCK_IDP_UIAM_ORGANIZATION_ID,
+    },
   });
 
   const adminCookieHeader = await sessionManager.getApiCredentialsForRole('admin');

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/tsconfig.json
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/tsconfig.json
@@ -40,6 +40,7 @@
     "@kbn/security-plugin-types-common",
     "@kbn/securitysolution-utils",
     "@kbn/maintenance-windows-plugin",
-    "@kbn/test-saml-auth"
+    "@kbn/test-saml-auth",
+    "@kbn/mock-idp-utils"
   ]
 }


### PR DESCRIPTION
## Summary

Switch Security Cypress tests to use UIAM authentication.

__Related:__ https://github.com/elastic/kibana/pull/260546

