### PR TITLE
[Security Solution] add callout to flyout header in Discover if _id or _index are missing (mostly for ESQL)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2785,10 +2785,10 @@ x-pack/solutions/security/test/serverless/functional/configs/config.context_awar
 /x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details @elastic/security-threat-hunting-investigations
 /x-pack/solutions/security/plugins/security_solution/public/flyout/shared @elastic/security-threat-hunting-investigations
 /x-pack/solutions/security/plugins/security_solution/public/flyout/rule_details @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/investigation_guide @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared @elastic/security-threat-hunting-investigations
+/x-pack/solutions/security/plugins/security_solution/public/flyout_v2 @elastic/security-threat-hunting-investigations
 /x-pack/solutions/security/plugins/security_solution/public/notes @elastic/security-threat-hunting-investigations
 /x-pack/solutions/security/plugins/security_solution/public/onboarding @elastic/security-threat-hunting-investigations
+/x-pack/solutions/security/plugins/security_solution/public/one_discover @elastic/security-threat-hunting-investigations
 /x-pack/solutions/security/plugins/security_solution/public/overview @elastic/security-threat-hunting-investigations
 /x-pack/solutions/security/plugins/security_solution/public/resolver @elastic/security-threat-hunting-investigations
 /x-pack/solutions/security/plugins/security_solution/public/sourcerer @elastic/security-threat-hunting-investigations

--- a/x-pack/solutions/security/plugins/security_solution/public/one_discover/alert_flyout_header_component/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/one_discover/alert_flyout_header_component/index.test.tsx
@@ -75,7 +75,11 @@ describe('AlertFlyoutHeader', () => {
   } as unknown as StartServices;
 
   it('wraps the header in KibanaContextProvider and ReactQueryClientProvider', async () => {
-    const hit = { id: '1', raw: {}, flattened: {} } as unknown as DataTableRecord;
+    const hit = {
+      id: '1',
+      raw: { _id: '1', _index: 'test' },
+      flattened: {},
+    } as unknown as DataTableRecord;
     const store = createStore(() => ({}));
     const storePromise = Promise.resolve(store as never);
     const history = createMemoryHistory({ initialEntries: ['/discover'] });
@@ -115,7 +119,11 @@ describe('AlertFlyoutHeader', () => {
   });
 
   it('renders under an existing parent router without nesting another router', async () => {
-    const hit = { id: '1', raw: {}, flattened: {} } as unknown as DataTableRecord;
+    const hit = {
+      id: '1',
+      raw: { _id: '1', _index: 'test' },
+      flattened: {},
+    } as unknown as DataTableRecord;
     const store = createStore(() => ({}));
     const history = createMemoryHistory({ initialEntries: ['/discover'] });
 
@@ -136,7 +144,11 @@ describe('AlertFlyoutHeader', () => {
   });
 
   it('renders shared document header in Discover', async () => {
-    const hit = { id: '1', raw: {}, flattened: {} } as unknown as DataTableRecord;
+    const hit = {
+      id: '1',
+      raw: { _id: '1', _index: 'test' },
+      flattened: {},
+    } as unknown as DataTableRecord;
     const store = createStore(() => ({}));
     const history = createMemoryHistory({ initialEntries: ['/discover'] });
 
@@ -190,5 +202,61 @@ describe('AlertFlyoutHeader', () => {
         type: 'overlay',
       })
     );
+  });
+
+  it('shows a callout when _id or _index are missing from hit.raw', async () => {
+    const hit = { id: '1', raw: {}, flattened: {} } as unknown as DataTableRecord;
+    const store = createStore(() => ({}));
+    const history = createMemoryHistory({ initialEntries: ['/discover'] });
+
+    render(
+      <Router history={history}>
+        <AlertFlyoutHeader
+          hit={hit}
+          servicesPromise={Promise.resolve(servicesMock)}
+          storePromise={Promise.resolve(store as never)}
+          onAlertUpdated={jest.fn()}
+        />
+      </Router>
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          'Some of the content below might not be loading correctly. To ensure the best experience, please add `METADATA _id,_index` to your query.'
+        )
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('does not show the callout when both _id and _index are present in hit.raw', async () => {
+    const hit = {
+      id: '1',
+      raw: { _id: '1', _index: 'test' },
+      flattened: {},
+    } as unknown as DataTableRecord;
+    const store = createStore(() => ({}));
+    const history = createMemoryHistory({ initialEntries: ['/discover'] });
+
+    render(
+      <Router history={history}>
+        <AlertFlyoutHeader
+          hit={hit}
+          servicesPromise={Promise.resolve(servicesMock)}
+          storePromise={Promise.resolve(store as never)}
+          onAlertUpdated={jest.fn()}
+        />
+      </Router>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('MockDocumentHeader')).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByText(
+        'Some of the content below might not be loading correctly. To ensure the best experience, please add `METADATA _id,_index` to your query.'
+      )
+    ).not.toBeInTheDocument();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/one_discover/alert_flyout_header_component/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/one_discover/alert_flyout_header_component/index.tsx
@@ -6,14 +6,24 @@
  */
 
 import type { DataTableRecord } from '@kbn/discover-utils';
+import { EuiCallOut, EuiSpacer } from '@elastic/eui';
 import React, { useCallback, useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
+import { i18n } from '@kbn/i18n';
 import type { SecurityAppStore } from '../../common/store/types';
 import type { StartServices } from '../../types';
 import { Header } from '../../flyout_v2/document/header';
 import { NotesDetails } from '../../flyout_v2/notes';
 import { noopCellActionRenderer } from '../../flyout_v2/shared/components/cell_actions';
 import { flyoutProviders } from '../../flyout_v2/shared/components/flyout_provider';
+
+export const MISSING_METADATA_CALLOUT = i18n.translate(
+  'xpack.securitySolution.flyout.document.header.missingMetadataCallout',
+  {
+    defaultMessage:
+      'Some of the content below might not be loading correctly. To ensure the best experience, please add `METADATA _id,_index` to your query.',
+  }
+);
 
 export interface AlertFlyoutHeaderProps {
   /**
@@ -88,20 +98,33 @@ export const AlertFlyoutHeader = ({
     };
   }, [servicesPromise, storePromise]);
 
+  const isMissingMetadata = !hit.raw._id || !hit.raw._index;
+  const metadataCallout = isMissingMetadata ? (
+    <>
+      <EuiCallOut announceOnMount size="s" title={MISSING_METADATA_CALLOUT} />
+      <EuiSpacer size="s" />
+    </>
+  ) : null;
+
   if (!services || !store) {
-    return null;
+    return metadataCallout;
   }
 
-  return flyoutProviders({
-    services,
-    store,
-    children: (
-      <Header
-        hit={hit}
-        renderCellActions={noopCellActionRenderer}
-        onAlertUpdated={onAlertUpdated}
-        onShowNotes={openNotesFlyout}
-      />
-    ),
-  });
+  return (
+    <>
+      {metadataCallout}
+      {flyoutProviders({
+        services,
+        store,
+        children: (
+          <Header
+            hit={hit}
+            renderCellActions={noopCellActionRenderer}
+            onAlertUpdated={onAlertUpdated}
+            onShowNotes={openNotesFlyout}
+          />
+        ),
+      })}
+    </>
+  );
 };


### PR DESCRIPTION
## Summary

This PR adds a callout to the document flyout in Discover when in Security profile. The callout only appears if `_id` or `_index` are missing.
This will most likely show when users are using ESQL. They need to add `METADATA _id,_index` to their query to ensure the best experience, as a lot of the flyout's content relies on those to be present.

<img width="550" height="403" alt="Screenshot 2026-04-08 at 2 45 39 PM" src="https://github.com/user-attachments/assets/22599844-244d-4136-b790-93a163444d98" />

> [!NOTE]
> We will in a follow up PR add proper message to the different section of the flyout content that would require `_id` and `_index`.

## How to test

To see the new (emtpy) flyout in Security Solution, add this to your `kibana.dev.yml` file:
```xpack.securitySolution.enableExperimental: [ 'newFlyoutSystemEnabled' ]```

Too see the new (emtpy) flyout in Discover, add this to your `kibana.dev.yml` file:
```discover.experimental.enabledProfiles: [ 'enhanced-security-document-profile' ]```

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
