### PR TITLE
[ObsOnboarding] Add 'Check for data' button as manual monitoring trigger

### DIFF
--- a/x-pack/solutions/observability/plugins/observability_onboarding/public/application/quickstart_flows/kubernetes/index.tsx
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/public/application/quickstart_flows/kubernetes/index.tsx
@@ -7,7 +7,14 @@
 
 import React, { useEffect, useState } from 'react';
 import type { EuiStepStatus } from '@elastic/eui';
-import { EuiPanel, EuiSkeletonRectangle, EuiSkeletonText, EuiSpacer, EuiSteps } from '@elastic/eui';
+import {
+  EuiButton,
+  EuiPanel,
+  EuiSkeletonRectangle,
+  EuiSkeletonText,
+  EuiSpacer,
+  EuiSteps,
+} from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { usePerformanceContext } from '@kbn/ebt-tools';
@@ -58,7 +65,9 @@ export const KubernetesPanel: React.FC = () => {
     onboardingId: data?.onboardingId,
   });
 
-  const isMonitoringStepActive = windowBlurred || hasPreExistingDataEarly;
+  const [manuallyTriggered, setManuallyTriggered] = useState(false);
+
+  const isMonitoringStepActive = windowBlurred || hasPreExistingDataEarly || manuallyTriggered;
 
   useEffect(() => {
     if (data) {
@@ -153,16 +162,26 @@ export const KubernetesPanel: React.FC = () => {
         : isMonitoringStepActive
         ? 'current'
         : 'incomplete') as EuiStepStatus,
-      children: isMonitoringStepActive && data && (
-        <DataIngestStatus
-          onboardingId={data.onboardingId}
-          onboardingFlowType="kubernetes"
-          dataset="kubernetes"
-          integration="kubernetes"
-          actionLinks={kubernetesActionLinks}
-          onDataReceived={() => setDataReceived(true)}
-        />
-      ),
+      children:
+        isMonitoringStepActive && data ? (
+          <DataIngestStatus
+            onboardingId={data.onboardingId}
+            onboardingFlowType="kubernetes"
+            dataset="kubernetes"
+            integration="kubernetes"
+            actionLinks={kubernetesActionLinks}
+            onDataReceived={() => setDataReceived(true)}
+          />
+        ) : (
+          <EuiButton
+            data-test-subj="observabilityOnboardingKubernetesCheckForDataButton"
+            onClick={() => setManuallyTriggered(true)}
+          >
+            {i18n.translate('xpack.observability_onboarding.kubernetesPanel.checkForDataButton', {
+              defaultMessage: 'Check for data',
+            })}
+          </EuiButton>
+        ),
     },
   ];
 

--- a/x-pack/solutions/observability/plugins/observability_onboarding/public/application/quickstart_flows/otel_apm/index.tsx
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/public/application/quickstart_flows/otel_apm/index.tsx
@@ -13,6 +13,7 @@ import type { EuiBasicTableColumn } from '@elastic/eui';
 import type { EuiStepStatus } from '@elastic/eui';
 import {
   EuiBasicTable,
+  EuiButton,
   EuiButtonIcon,
   EuiFieldText,
   EuiFormRow,
@@ -76,7 +77,9 @@ export function OtelApmQuickstartFlow() {
     onboardingId: data?.onboardingId,
   });
 
-  const isMonitoringStepActive = windowBlurred || hasPreExistingDataEarly;
+  const [manuallyTriggered, setManuallyTriggered] = useState(false);
+
+  const isMonitoringStepActive = windowBlurred || hasPreExistingDataEarly || manuallyTriggered;
 
   // Set sessionStartTime when monitoring begins (first blur or early
   // pre-existing data detection) rather than on mount, to narrow the
@@ -236,7 +239,16 @@ export function OtelApmQuickstartFlow() {
                   </>
                 )}
               </>
-            ) : null,
+            ) : (
+              <EuiButton
+                data-test-subj="observabilityOnboardingOtelApmCheckForDataButton"
+                onClick={() => setManuallyTriggered(true)}
+              >
+                {i18n.translate('xpack.observability_onboarding.otelApm.checkForDataButton', {
+                  defaultMessage: 'Check for data',
+                })}
+              </EuiButton>
+            ),
           },
         ]}
       />

--- a/x-pack/solutions/observability/plugins/observability_onboarding/public/application/quickstart_flows/otel_kubernetes/otel_kubernetes_panel.tsx
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/public/application/quickstart_flows/otel_kubernetes/otel_kubernetes_panel.tsx
@@ -8,6 +8,7 @@
 import React, { useState, useEffect } from 'react';
 import type { EuiStepStatus } from '@elastic/eui';
 import {
+  EuiButton,
   EuiPanel,
   EuiSkeletonText,
   EuiSpacer,
@@ -102,7 +103,9 @@ export const OtelKubernetesPanel: React.FC = () => {
     onboardingId: data?.onboardingId,
   });
 
-  const isMonitoringStepActive = windowBlurred || hasPreExistingDataEarly;
+  const [manuallyTriggered, setManuallyTriggered] = useState(false);
+
+  const isMonitoringStepActive = windowBlurred || hasPreExistingDataEarly || manuallyTriggered;
   const logsLocatorParams = useWiredStreams ? { dataViewSpec: WIRED_OTEL_DATA_VIEW_SPEC } : {};
 
   useEffect(() => {
@@ -515,17 +518,28 @@ kubectl describe pod <myapp-pod-name> -n my-namespace`}
               : isMonitoringStepActive
               ? 'current'
               : 'incomplete') as EuiStepStatus,
-            children: isMonitoringStepActive && data && (
-              <DataIngestStatus
-                onboardingId={data.onboardingId}
-                onboardingFlowType="kubernetes_otel"
-                dataset="kubernetes"
-                integration="kubernetes_otel"
-                actionLinks={otelKubernetesActionLinks}
-                onDataReceived={() => setDataReceived(true)}
-                respectPreExistingData={useWiredStreams}
-              />
-            ),
+            children:
+              isMonitoringStepActive && data ? (
+                <DataIngestStatus
+                  onboardingId={data.onboardingId}
+                  onboardingFlowType="kubernetes_otel"
+                  dataset="kubernetes"
+                  integration="kubernetes_otel"
+                  actionLinks={otelKubernetesActionLinks}
+                  onDataReceived={() => setDataReceived(true)}
+                  respectPreExistingData={useWiredStreams}
+                />
+              ) : (
+                <EuiButton
+                  data-test-subj="observabilityOnboardingOtelKubernetesCheckForDataButton"
+                  onClick={() => setManuallyTriggered(true)}
+                >
+                  {i18n.translate(
+                    'xpack.observability_onboarding.otelKubernetesPanel.checkForDataButton',
+                    { defaultMessage: 'Check for data' }
+                  )}
+                </EuiButton>
+              ),
           },
         ]}
       />

--- a/x-pack/solutions/observability/plugins/observability_onboarding/public/application/quickstart_flows/otel_logs/index.tsx
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/public/application/quickstart_flows/otel_logs/index.tsx
@@ -106,7 +106,9 @@ export const OtelLogsPanel: React.FC = () => {
     onboardingId: setupData?.onboardingId,
   });
 
-  const isMonitoringStepActive = windowBlurred || hasPreExistingDataEarly;
+  const [manuallyTriggered, setManuallyTriggered] = useState(false);
+
+  const isMonitoringStepActive = windowBlurred || hasPreExistingDataEarly || manuallyTriggered;
 
   // Set sessionStartTime when monitoring begins, not on mount.
   const [sessionStartTime, setSessionStartTime] = useState<string | null>(null);
@@ -504,7 +506,19 @@ export const OtelLogsPanel: React.FC = () => {
                       </>
                     )}
                 </>
-              ) : null,
+              ) : (
+                <EuiButton
+                  data-test-subj="observabilityOnboardingOtelHostCheckForDataButton"
+                  onClick={() => setManuallyTriggered(true)}
+                >
+                  {i18n.translate(
+                    'xpack.observability_onboarding.otelLogsPanel.checkForDataButton',
+                    {
+                      defaultMessage: 'Check for data',
+                    }
+                  )}
+                </EuiButton>
+              ),
             },
           ]}
         />


### PR DESCRIPTION
Adds a manual override button to the last step of each onboarding flow

The existing behaviour was a little bit weird for the user, it felt unpredictable. Especially when accidentally refreshing the page. 

Affects: otel_apm, otel_logs, kubernetes, and otel_kubernetes flows.

**before**
https://github.com/user-attachments/assets/9c6df0ad-04d8-49e6-a34c-0359f8f5f0f8

**after**
https://github.com/user-attachments/assets/8e8dfa31-909e-4a68-ba4e-156f402e591d

