### PR TITLE
[Agent Builder] Add RBAC checks to new Agentic pages

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/agents/access_control.test.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/agents/access_control.test.ts
@@ -10,8 +10,10 @@ import {
   canChangeAgentVisibility,
   hasAgentReadAccess,
   hasAgentWriteAccess,
+  canCurrentUserEditAgent,
 } from './access_control';
-import { agentBuilderDefaultAgentId } from './definition';
+import type { AgentConfiguration, AgentDefinition } from './definition';
+import { agentBuilderDefaultAgentId, AgentType } from './definition';
 import { AgentVisibility } from './visibility';
 import type { UserIdAndName } from '../base/users';
 
@@ -259,6 +261,108 @@ describe('hasAgentWriteAccess', () => {
         owner,
         currentUser: otherUser,
         isAdmin: false,
+      })
+    ).toBe(true);
+  });
+});
+
+describe('canCurrentUserEditAgent', () => {
+  const publicAgent: AgentDefinition = {
+    readonly: false,
+    visibility: AgentVisibility.Public,
+    created_by: owner,
+    id: 'test-agent-id',
+    type: AgentType.chat,
+    name: 'test agent',
+    description: 'test agent description',
+    configuration: {} as AgentConfiguration,
+  };
+
+  test('returns false when agent is readonly', () => {
+    expect(
+      canCurrentUserEditAgent({
+        agent: { ...publicAgent, readonly: true },
+        manageAgents: true,
+        currentUser: otherUser,
+        isAdmin: false,
+      })
+    ).toBe(false);
+  });
+
+  test('returns false when manageAgents is false', () => {
+    expect(
+      canCurrentUserEditAgent({
+        agent: publicAgent,
+        manageAgents: false,
+        currentUser: otherUser,
+        isAdmin: false,
+      })
+    ).toBe(false);
+  });
+
+  test('returns false when isCurrentUserLoading is true', () => {
+    expect(
+      canCurrentUserEditAgent({
+        agent: publicAgent,
+        manageAgents: true,
+        currentUser: otherUser,
+        isAdmin: false,
+        isCurrentUserLoading: true,
+      })
+    ).toBe(false);
+  });
+
+  test('returns true for public non-readonly agent when user has manageAgents and write access', () => {
+    expect(
+      canCurrentUserEditAgent({
+        agent: publicAgent,
+        manageAgents: true,
+        currentUser: otherUser,
+        isAdmin: false,
+      })
+    ).toBe(true);
+  });
+
+  test('returns false for private agent when user is not owner', () => {
+    expect(
+      canCurrentUserEditAgent({
+        agent: { ...publicAgent, visibility: AgentVisibility.Private },
+        manageAgents: true,
+        currentUser: otherUser,
+        isAdmin: false,
+      })
+    ).toBe(false);
+  });
+
+  test('returns false for shared agent when user is not owner', () => {
+    expect(
+      canCurrentUserEditAgent({
+        agent: { ...publicAgent, visibility: AgentVisibility.Shared },
+        manageAgents: true,
+        currentUser: otherUser,
+        isAdmin: false,
+      })
+    ).toBe(false);
+  });
+
+  test('returns true for private agent when current user is owner', () => {
+    expect(
+      canCurrentUserEditAgent({
+        agent: { ...publicAgent, visibility: AgentVisibility.Private },
+        manageAgents: true,
+        currentUser,
+        isAdmin: false,
+      })
+    ).toBe(true);
+  });
+
+  test('returns true for private agent when isAdmin even if not owner', () => {
+    expect(
+      canCurrentUserEditAgent({
+        agent: { ...publicAgent, visibility: AgentVisibility.Private },
+        manageAgents: true,
+        currentUser: otherUser,
+        isAdmin: true,
       })
     ).toBe(true);
   });

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/agents/access_control.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/agents/access_control.ts
@@ -6,6 +6,7 @@
  */
 
 import type { UserIdAndName } from '../base/users';
+import type { AgentDefinition } from './definition';
 import { agentBuilderDefaultAgentId } from './definition';
 import { AgentVisibility } from './visibility';
 
@@ -80,4 +81,37 @@ export const hasAgentWriteAccess = ({
     isAgentOwner({ owner, currentUser }) ||
     effectiveVisibility === AgentVisibility.Public
   );
+};
+
+/**
+ * Whether the current user may edit agent settings, attach skills/tools, etc.
+ */
+export const canCurrentUserEditAgent = ({
+  agent,
+  manageAgents,
+  currentUser,
+  isAdmin,
+  isCurrentUserLoading = false,
+}: {
+  agent: AgentDefinition;
+  manageAgents: boolean;
+  currentUser?: UserIdAndName | null;
+  isAdmin: boolean;
+  /** When true deny edit to avoid flashing incorrect actions. */
+  isCurrentUserLoading?: boolean;
+}): boolean => {
+  if (agent.readonly || !manageAgents) {
+    return false;
+  }
+
+  if (isCurrentUserLoading) {
+    return false;
+  }
+
+  return hasAgentWriteAccess({
+    visibility: agent.visibility,
+    owner: agent.created_by,
+    currentUser,
+    isAdmin,
+  });
 };

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/agents/index.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/agents/index.ts
@@ -17,6 +17,7 @@ export {
 } from './definition';
 export { VISIBILITY_ICON, VISIBILITY_BADGE_COLOR, AgentVisibility } from './visibility';
 export {
+  canCurrentUserEditAgent,
   isAgentOwner,
   canChangeAgentVisibility,
   hasAgentReadAccess,

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/index.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/index.ts
@@ -110,6 +110,7 @@ export {
   canChangeAgentVisibility,
   hasAgentReadAccess,
   hasAgentWriteAccess,
+  canCurrentUserEditAgent,
   type AgentDefinition,
   type AgentConfiguration,
   type AgentConfigurationOverrides,

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/common/active_item_row.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/common/active_item_row.tsx
@@ -18,6 +18,7 @@ export interface ActiveItemRowProps {
   isRemoving?: boolean;
   removeAriaLabel: string;
   readOnlyContent?: React.ReactNode;
+  canEditAgent: boolean;
 }
 
 export const ActiveItemRow: React.FC<ActiveItemRowProps> = ({
@@ -28,6 +29,7 @@ export const ActiveItemRow: React.FC<ActiveItemRowProps> = ({
   isRemoving = false,
   removeAriaLabel,
   readOnlyContent,
+  canEditAgent,
 }) => {
   const { euiTheme } = useEuiTheme();
 
@@ -70,17 +72,18 @@ export const ActiveItemRow: React.FC<ActiveItemRowProps> = ({
       </EuiFlexItem>
       {isSelected && (
         <EuiFlexItem grow={false}>
-          {readOnlyContent ?? (
-            <EuiButtonIcon
-              iconType="cross"
-              aria-label={removeAriaLabel}
-              disabled={isRemoving}
-              onClick={(event: React.MouseEvent) => {
-                event.stopPropagation();
-                onRemove();
-              }}
-            />
-          )}
+          {readOnlyContent ??
+            (canEditAgent ? (
+              <EuiButtonIcon
+                iconType="cross"
+                aria-label={removeAriaLabel}
+                disabled={isRemoving}
+                onClick={(event: React.MouseEvent) => {
+                  event.stopPropagation();
+                  onRemove();
+                }}
+              />
+            ) : null)}
         </EuiFlexItem>
       )}
     </EuiFlexGroup>

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/list/agents_list.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/list/agents_list.tsx
@@ -22,8 +22,7 @@ import {
   EuiToolTip,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import type { UserIdAndName } from '@kbn/agent-builder-common';
-import { hasAgentWriteAccess, type AgentDefinition } from '@kbn/agent-builder-common';
+import { canCurrentUserEditAgent, type AgentDefinition } from '@kbn/agent-builder-common';
 import { countBy } from 'lodash';
 import React, { useMemo } from 'react';
 import { useDeleteAgent } from '../../../context/delete_agent_context';
@@ -66,35 +65,6 @@ const actionLabels = {
   checkingPermissions: i18n.translate('xpack.agentBuilder.agents.actions.checkingPermissions', {
     defaultMessage: 'Checking permissions…',
   }),
-};
-
-const canCurrentUserEditAgent = ({
-  agent,
-  manageAgents,
-  currentUser,
-  isAdmin,
-  isCurrentUserLoading,
-}: {
-  agent: AgentDefinition;
-  manageAgents: boolean;
-  currentUser?: UserIdAndName | null;
-  isAdmin: boolean;
-  isCurrentUserLoading: boolean;
-}) => {
-  if (agent.readonly || !manageAgents) {
-    return false;
-  }
-
-  if (isCurrentUserLoading) {
-    return false;
-  }
-
-  return hasAgentWriteAccess({
-    visibility: agent.visibility,
-    owner: agent.created_by,
-    currentUser,
-    isAdmin,
-  });
 };
 
 export const AgentsList: React.FC = () => {

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/overview/agent_overview.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/overview/agent_overview.tsx
@@ -15,8 +15,9 @@ import {
   useEuiTheme,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
-import { hasAgentWriteAccess, canChangeAgentVisibility } from '@kbn/agent-builder-common';
+import { canChangeAgentVisibility } from '@kbn/agent-builder-common';
 import { useAgentBuilderAgentById } from '../../../hooks/agents/use_agent_by_id';
+import { useCanEditAgent } from '../../../hooks/agents/use_can_edit_agent';
 import { useSkillsService } from '../../../hooks/skills/use_skills';
 import { usePluginsService } from '../../../hooks/plugins/use_plugins';
 import { useAgentBuilderServices } from '../../../hooks/use_agent_builder_service';
@@ -44,24 +45,14 @@ export const AgentOverview: React.FC = () => {
     services: { uiSettings },
   } = useKibana();
 
-  const { manageAgents, isAdmin } = useUiPrivileges();
+  const { isAdmin } = useUiPrivileges();
   const { currentUser } = useCurrentUser();
 
   const { agent, isLoading } = useAgentBuilderAgentById(agentId);
   const { skills: allSkills } = useSkillsService();
   const { plugins: allPlugins } = usePluginsService();
-
   const [isEditFlyoutOpen, setIsEditFlyoutOpen] = useState(false);
-
-  const canEditAgent = useMemo(() => {
-    if (!manageAgents || !agent) return false;
-    return hasAgentWriteAccess({
-      visibility: agent.visibility,
-      owner: agent.created_by,
-      currentUser: currentUser ?? undefined,
-      isAdmin,
-    });
-  }, [manageAgents, agent, currentUser, isAdmin]);
+  const canEditAgent = useCanEditAgent({ agent });
 
   const canChangeVisibility = useMemo(() => {
     if (!isExperimentalFeaturesEnabled || !agent) return false;
@@ -166,6 +157,7 @@ export const AgentOverview: React.FC = () => {
           currentInstructions={agent.configuration?.instructions ?? ''}
           showWorkflowSection={showWorkflowSection}
           workflowIds={agent.configuration?.workflow_ids ?? []}
+          canEditAgent={canEditAgent}
           onOpenEditFlyout={() => setIsEditFlyoutOpen(true)}
         />
 

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/overview/settings_section.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/overview/settings_section.tsx
@@ -41,6 +41,7 @@ export interface SettingsSectionProps {
   currentInstructions: string;
   showWorkflowSection: boolean;
   workflowIds: string[];
+  canEditAgent: boolean;
   onOpenEditFlyout: () => void;
 }
 
@@ -49,6 +50,7 @@ export const SettingsSection: React.FC<SettingsSectionProps> = ({
   currentInstructions,
   showWorkflowSection,
   workflowIds,
+  canEditAgent,
   onOpenEditFlyout,
 }) => {
   const { euiTheme } = useEuiTheme();
@@ -80,7 +82,7 @@ export const SettingsSection: React.FC<SettingsSectionProps> = ({
                 {currentInstructions || overviewLabels.customInstructionsOnboardingText}
               </EuiText>
             </div>
-            {!currentInstructions && (
+            {!currentInstructions && canEditAgent ? (
               <EuiButtonEmpty
                 size="s"
                 flush="left"
@@ -89,7 +91,7 @@ export const SettingsSection: React.FC<SettingsSectionProps> = ({
               >
                 {overviewLabels.addInstructionsLink}
               </EuiButtonEmpty>
-            )}
+            ) : null}
           </EuiPanel>
         </EuiFlexItem>
 

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/plugins/agent_plugins.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/plugins/agent_plugins.tsx
@@ -43,6 +43,7 @@ import { InstallPluginFlyout } from './install_plugin_flyout';
 import { PageWrapper } from '../common/page_wrapper';
 import { ICON_DIMENSIONS } from '../common/constants';
 import { useListDetailPageStyles } from '../common/styles';
+import { useCanEditAgent } from '../../../hooks/agents/use_can_edit_agent';
 
 export const AgentPlugins: React.FC = () => {
   const { agentId } = useParams<{ agentId: string }>();
@@ -54,6 +55,7 @@ export const AgentPlugins: React.FC = () => {
 
   const { agent, isLoading: agentLoading } = useAgentBuilderAgentById(agentId);
   const { plugins: allPlugins, isLoading: pluginsLoading } = usePluginsService();
+  const canEditAgent = useCanEditAgent({ agent });
 
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedPluginId, setSelectedPluginId] = useQueryState<string>(searchParamNames.pluginId);
@@ -337,6 +339,7 @@ export const AgentPlugins: React.FC = () => {
                       <EuiBadge color="hollow">{labels.agentPlugins.autoBadge}</EuiBadge>
                     ) : undefined
                   }
+                  canEditAgent={canEditAgent}
                 />
               ))
             )}

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/skills/active_skill_row.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/skills/active_skill_row.tsx
@@ -17,7 +17,8 @@ export interface ActiveSkillRowProps {
   onSelect: (skill: PublicSkillSummary) => void;
   onRemove: (skill: PublicSkillSummary) => void;
   isRemoving?: boolean;
-  readOnly?: boolean;
+  isAutoIncluded: boolean;
+  canEditAgent: boolean;
 }
 
 export const ActiveSkillRow: React.FC<ActiveSkillRowProps> = ({
@@ -26,7 +27,8 @@ export const ActiveSkillRow: React.FC<ActiveSkillRowProps> = ({
   onSelect,
   onRemove,
   isRemoving = false,
-  readOnly = false,
+  isAutoIncluded,
+  canEditAgent,
 }) => {
   return (
     <ActiveItemRow
@@ -37,8 +39,9 @@ export const ActiveSkillRow: React.FC<ActiveSkillRowProps> = ({
       onRemove={() => onRemove(skill)}
       isRemoving={isRemoving}
       removeAriaLabel={labels.agentSkills.removeSkillAriaLabel}
+      canEditAgent={canEditAgent}
       readOnlyContent={
-        readOnly ? (
+        isAutoIncluded ? (
           <EuiBadge color="hollow">{labels.agentSkills.elasticCapabilitiesReadOnlyBadge}</EuiBadge>
         ) : undefined
       }

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/skills/agent_skills.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/skills/agent_skills.tsx
@@ -43,6 +43,8 @@ import { SkillCreateFlyout } from './skill_create_flyout';
 import { PageWrapper } from '../common/page_wrapper';
 import { ICON_DIMENSIONS } from '../common/constants';
 import { useListDetailPageStyles } from '../common/styles';
+import { useUiPrivileges } from '../../../hooks/use_ui_privileges';
+import { useCanEditAgent } from '../../../hooks/agents/use_can_edit_agent';
 
 export const AgentSkills: React.FC = () => {
   const { agentId } = useParams<{ agentId: string }>();
@@ -54,6 +56,8 @@ export const AgentSkills: React.FC = () => {
 
   const { agent, isLoading: agentLoading } = useAgentBuilderAgentById(agentId);
   const { skills: allSkills, isLoading: skillsLoading } = useSkillsService();
+  const { manageSkills } = useUiPrivileges();
+  const canEditAgent = useCanEditAgent({ agent });
 
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedSkillId, setSelectedSkillId] = useQueryState<string>(searchParamNames.skillId);
@@ -237,44 +241,50 @@ export const AgentSkills: React.FC = () => {
                   {labels.agentSkills.manageAllSkills}
                 </EuiButtonEmpty>
               </EuiFlexItem>
-              <EuiFlexItem grow={false}>
-                <EuiPopover
-                  aria-label={labels.agentSkills.addSkillButton}
-                  button={
-                    <EuiButton
-                      fill
-                      iconType="plusInCircle"
-                      iconSide="left"
-                      onClick={() => setIsAddMenuOpen((prev) => !prev)}
-                    >
-                      {labels.agentSkills.addSkillButton}
-                    </EuiButton>
-                  }
-                  isOpen={isAddMenuOpen}
-                  closePopover={() => setIsAddMenuOpen(false)}
-                  anchorPosition="downLeft"
-                  panelPaddingSize="none"
-                >
-                  <EuiContextMenuPanel
-                    items={[
-                      <EuiContextMenuItem
-                        key="importFromLibrary"
-                        icon="importAction"
-                        onClick={handleImportFromLibrary}
+              {canEditAgent && (
+                <EuiFlexItem grow={false}>
+                  <EuiPopover
+                    aria-label={labels.agentSkills.addSkillButton}
+                    button={
+                      <EuiButton
+                        fill
+                        iconType="plusInCircle"
+                        iconSide="left"
+                        onClick={() => setIsAddMenuOpen((prev) => !prev)}
                       >
-                        {labels.agentSkills.importFromLibraryMenuItem}
-                      </EuiContextMenuItem>,
-                      <EuiContextMenuItem
-                        key="createSkill"
-                        icon="pencil"
-                        onClick={handleOpenCreateFlyout}
-                      >
-                        {labels.agentSkills.createSkillMenuItem}
-                      </EuiContextMenuItem>,
-                    ]}
-                  />
-                </EuiPopover>
-              </EuiFlexItem>
+                        {labels.agentSkills.addSkillButton}
+                      </EuiButton>
+                    }
+                    isOpen={isAddMenuOpen}
+                    closePopover={() => setIsAddMenuOpen(false)}
+                    anchorPosition="downLeft"
+                    panelPaddingSize="none"
+                  >
+                    <EuiContextMenuPanel
+                      items={[
+                        <EuiContextMenuItem
+                          key="importFromLibrary"
+                          icon="importAction"
+                          onClick={handleImportFromLibrary}
+                        >
+                          {labels.agentSkills.importFromLibraryMenuItem}
+                        </EuiContextMenuItem>,
+                        ...(manageSkills
+                          ? [
+                              <EuiContextMenuItem
+                                key="createSkill"
+                                icon="pencil"
+                                onClick={handleOpenCreateFlyout}
+                              >
+                                {labels.agentSkills.createSkillMenuItem}
+                              </EuiContextMenuItem>,
+                            ]
+                          : []),
+                      ]}
+                    />
+                  </EuiPopover>
+                </EuiFlexItem>
+              )}
             </EuiFlexGroup>
           </EuiFlexItem>
         </EuiFlexGroup>
@@ -315,7 +325,8 @@ export const AgentSkills: React.FC = () => {
                   onSelect={(s) => setSelectedSkillId(s.id)}
                   onRemove={handleRemoveSkill}
                   isRemoving={mutatingSkillId === skill.id}
-                  readOnly={enableElasticCapabilities && skill.readonly}
+                  isAutoIncluded={enableElasticCapabilities && skill.readonly}
+                  canEditAgent={canEditAgent}
                 />
               ))
             )}
@@ -328,10 +339,11 @@ export const AgentSkills: React.FC = () => {
               skillId={selectedSkillId}
               onEdit={() => setEditingSkillId(selectedSkillId)}
               onRemove={handleRemoveSelectedSkill}
-              isReadOnly={
+              isAutoIncluded={
                 enableElasticCapabilities &&
                 (activeSkills.find((s) => s.id === selectedSkillId)?.readonly ?? false)
               }
+              canEditAgent={canEditAgent}
             />
           ) : (
             <EuiFlexGroup

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/skills/skill_detail_panel.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/skills/skill_detail_panel.tsx
@@ -27,14 +27,16 @@ interface SkillDetailPanelProps {
   skillId: string;
   onEdit: () => void;
   onRemove: () => void;
-  isReadOnly?: boolean;
+  isAutoIncluded: boolean;
+  canEditAgent: boolean;
 }
 
 export const SkillDetailPanel: React.FC<SkillDetailPanelProps> = ({
   skillId,
   onEdit,
   onRemove,
-  isReadOnly = false,
+  isAutoIncluded = false,
+  canEditAgent,
 }) => {
   const { euiTheme } = useEuiTheme();
   const { skill, isLoading } = useSkill({ skillId });
@@ -46,7 +48,7 @@ export const SkillDetailPanel: React.FC<SkillDetailPanelProps> = ({
         isLoading={isLoading}
         isEmpty={!skill}
         title={skill?.name ?? skillId}
-        showAutoIcon={isReadOnly}
+        showAutoIcon={isAutoIncluded}
         headerContent={
           <>
             <EuiText
@@ -69,31 +71,17 @@ export const SkillDetailPanel: React.FC<SkillDetailPanelProps> = ({
             </EuiText>
           </>
         }
-        headerActions={(openConfirmRemove) =>
-          isReadOnly ? (
-            <EuiBadge color="hollow">{labels.agentSkills.autoIncludedBadgeLabel}</EuiBadge>
-          ) : (
-            <EuiFlexGroup gutterSize="s" responsive={false}>
-              {!skill?.readonly && (
-                <EuiFlexItem grow={false}>
-                  <EuiButtonEmpty iconType="pencil" size="xs" onClick={onEdit}>
-                    {labels.skills.editSkillButtonLabel}
-                  </EuiButtonEmpty>
-                </EuiFlexItem>
-              )}
-              <EuiFlexItem grow={false}>
-                <EuiButtonEmpty
-                  iconType="cross"
-                  size="xs"
-                  color="danger"
-                  onClick={openConfirmRemove}
-                >
-                  {labels.agentSkills.removeSkillButtonLabel}
-                </EuiButtonEmpty>
-              </EuiFlexItem>
-            </EuiFlexGroup>
-          )
-        }
+        headerActions={(openConfirmRemove) => (
+          <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
+            <SkillHeaderActions
+              openConfirmRemove={openConfirmRemove}
+              canEditAgent={canEditAgent}
+              isAutoIncluded={isAutoIncluded}
+              isReadOnly={skill?.readonly ?? false}
+              onEdit={onEdit}
+            />
+          </EuiFlexGroup>
+        )}
         confirmRemove={{
           title: labels.agentSkills.removeSkillConfirmTitle(skill?.name ?? skillId),
           body: labels.agentSkills.removeSkillConfirmBody,
@@ -130,6 +118,48 @@ export const SkillDetailPanel: React.FC<SkillDetailPanelProps> = ({
       {selectedToolId && (
         <ToolReadOnlyFlyout toolId={selectedToolId} onClose={() => setSelectedToolId(null)} />
       )}
+    </>
+  );
+};
+
+const SkillHeaderActions = ({
+  openConfirmRemove,
+  canEditAgent,
+  isAutoIncluded,
+  isReadOnly,
+  onEdit,
+}: {
+  openConfirmRemove: () => void;
+  canEditAgent: boolean;
+  isAutoIncluded: boolean;
+  isReadOnly: boolean;
+  onEdit: () => void;
+}) => {
+  if (isAutoIncluded) {
+    return (
+      <EuiFlexItem grow={false}>
+        <EuiBadge color="hollow">{labels.agentSkills.autoIncludedBadgeLabel}</EuiBadge>
+      </EuiFlexItem>
+    );
+  }
+  if (!canEditAgent) {
+    return null;
+  }
+
+  return (
+    <>
+      {!isReadOnly && (
+        <EuiFlexItem grow={false}>
+          <EuiButtonEmpty iconType="pencil" size="xs" onClick={onEdit}>
+            {labels.skills.editSkillButtonLabel}
+          </EuiButtonEmpty>
+        </EuiFlexItem>
+      )}
+      <EuiFlexItem grow={false}>
+        <EuiButtonEmpty iconType="cross" size="xs" color="danger" onClick={openConfirmRemove}>
+          {labels.agentSkills.removeSkillButtonLabel}
+        </EuiButtonEmpty>
+      </EuiFlexItem>
     </>
   );
 };

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/tools/agent_tools.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/tools/agent_tools.tsx
@@ -45,6 +45,7 @@ import { ToolDetailPanel } from './tool_detail_panel';
 import { PageWrapper } from '../common/page_wrapper';
 import { ICON_DIMENSIONS } from '../common/constants';
 import { useListDetailPageStyles } from '../common/styles';
+import { useCanEditAgent } from '../../../hooks/agents/use_can_edit_agent';
 
 const ActiveToolsList: React.FC<{
   filteredActiveTools: ToolDefinition[];
@@ -55,6 +56,7 @@ const ActiveToolsList: React.FC<{
   isRemoving: boolean;
   onSelect: (id: string) => void;
   onRemove: (tool: ToolDefinition) => void;
+  canEditAgent: boolean;
 }> = ({
   filteredActiveTools,
   searchQuery,
@@ -64,6 +66,7 @@ const ActiveToolsList: React.FC<{
   isRemoving,
   onSelect,
   onRemove,
+  canEditAgent,
 }) => {
   if (filteredActiveTools.length === 0) {
     return (
@@ -101,6 +104,7 @@ const ActiveToolsList: React.FC<{
                 <EuiBadge color="hollow">{labels.agentTools.readOnlyBadge}</EuiBadge>
               ) : undefined
             }
+            canEditAgent={canEditAgent}
           />
         );
       })}
@@ -118,6 +122,7 @@ export const AgentTools: React.FC = () => {
 
   const { agent, isLoading: agentLoading } = useAgentBuilderAgentById(agentId);
   const { tools: allTools, isLoading: toolsLoading } = useToolsService();
+  const canEditAgent = useCanEditAgent({ agent });
 
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedToolId, setSelectedToolId] = useQueryState<string>(searchParamNames.toolId);
@@ -272,11 +277,13 @@ export const AgentTools: React.FC = () => {
                   {labels.agentTools.manageAllTools}
                 </EuiButtonEmpty>
               </EuiFlexItem>
-              <EuiFlexItem grow={false}>
-                <EuiButton fill iconType="plusInCircle" iconSide="left" onClick={openLibrary}>
-                  {labels.agentTools.addToolButton}
-                </EuiButton>
-              </EuiFlexItem>
+              {canEditAgent && (
+                <EuiFlexItem grow={false}>
+                  <EuiButton fill iconType="plusInCircle" iconSide="left" onClick={openLibrary}>
+                    {labels.agentTools.addToolButton}
+                  </EuiButton>
+                </EuiFlexItem>
+              )}
             </EuiFlexGroup>
           </EuiFlexItem>
         </EuiFlexGroup>
@@ -309,6 +316,7 @@ export const AgentTools: React.FC = () => {
               isRemoving={updateToolsMutation.isLoading}
               onSelect={setSelectedToolId}
               onRemove={handleRemoveTool}
+              canEditAgent={canEditAgent}
             />
           </div>
         </EuiFlexItem>
@@ -319,6 +327,7 @@ export const AgentTools: React.FC = () => {
               toolId={selectedToolId}
               onRemove={handleRemoveSelectedTool}
               isAutoIncluded={enableElasticCapabilities && defaultToolIdSet.has(selectedToolId)}
+              canEditAgent={canEditAgent}
             />
           ) : (
             <EuiFlexGroup

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/tools/tool_detail_panel.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/tools/tool_detail_panel.tsx
@@ -26,19 +26,19 @@ import { DetailPanelLayout } from '../common/detail_panel_layout';
 interface ToolDetailPanelProps {
   toolId: string;
   onRemove: () => void;
-  isAutoIncluded?: boolean;
+  isAutoIncluded: boolean;
+  canEditAgent: boolean;
 }
 
 export const ToolDetailPanel: React.FC<ToolDetailPanelProps> = ({
   toolId,
   onRemove,
-  isAutoIncluded = false,
+  isAutoIncluded,
+  canEditAgent,
 }) => {
   const { euiTheme } = useEuiTheme();
   const { tool, isLoading } = useToolService(toolId);
-  const { createAgentBuilderUrl } = useNavigation();
-  const isReadOnly = tool?.readonly;
-  const editInLibraryUrl = createAgentBuilderUrl(appPaths.manage.toolDetails({ toolId }));
+  const isReadOnly = tool?.readonly ?? false;
 
   return (
     <DetailPanelLayout
@@ -59,47 +59,13 @@ export const ToolDetailPanel: React.FC<ToolDetailPanelProps> = ({
       }
       headerActions={(openConfirmRemove) => (
         <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
-          {isAutoIncluded ? (
-            <EuiFlexItem grow={false}>
-              <EuiBadge color="hollow">{labels.agentTools.autoIncludedBadgeLabel}</EuiBadge>
-            </EuiFlexItem>
-          ) : isReadOnly ? (
-            <>
-              <EuiFlexItem grow={false}>
-                <EuiBadge color="hollow" iconType="lock">
-                  {labels.agentTools.readOnlyBadge}
-                </EuiBadge>
-              </EuiFlexItem>
-              <EuiFlexItem grow={false}>
-                <EuiButtonEmpty
-                  iconType="cross"
-                  size="xs"
-                  color="danger"
-                  onClick={openConfirmRemove}
-                >
-                  {labels.agentTools.removeToolButtonLabel}
-                </EuiButtonEmpty>
-              </EuiFlexItem>
-            </>
-          ) : (
-            <>
-              <EuiFlexItem grow={false}>
-                <EuiLink href={editInLibraryUrl} target="_blank" external>
-                  {labels.agentTools.editInLibraryLink}
-                </EuiLink>
-              </EuiFlexItem>
-              <EuiFlexItem grow={false}>
-                <EuiButtonEmpty
-                  iconType="cross"
-                  size="xs"
-                  color="danger"
-                  onClick={openConfirmRemove}
-                >
-                  {labels.agentTools.removeToolButtonLabel}
-                </EuiButtonEmpty>
-              </EuiFlexItem>
-            </>
-          )}
+          <ToolHeaderActions
+            toolId={toolId}
+            openConfirmRemove={openConfirmRemove}
+            canEditAgent={canEditAgent}
+            isReadOnly={isReadOnly}
+            isAutoIncluded={isAutoIncluded}
+          />
         </EuiFlexGroup>
       )}
       confirmRemove={{
@@ -128,5 +94,56 @@ export const ToolDetailPanel: React.FC<ToolDetailPanelProps> = ({
         </EuiText>
       </div>
     </DetailPanelLayout>
+  );
+};
+
+const ToolHeaderActions = ({
+  openConfirmRemove,
+  canEditAgent,
+  isReadOnly,
+  isAutoIncluded,
+  toolId,
+}: {
+  openConfirmRemove: () => void;
+  canEditAgent: boolean;
+  isReadOnly: boolean;
+  isAutoIncluded: boolean;
+  toolId: string;
+}) => {
+  const { createAgentBuilderUrl } = useNavigation();
+  const editInLibraryUrl = createAgentBuilderUrl(appPaths.manage.toolDetails({ toolId }));
+
+  if (isAutoIncluded) {
+    return (
+      <EuiFlexItem grow={false}>
+        <EuiBadge color="hollow">{labels.agentTools.autoIncludedBadgeLabel}</EuiBadge>
+      </EuiFlexItem>
+    );
+  }
+  if (!canEditAgent) {
+    return null;
+  }
+
+  return (
+    <>
+      {isReadOnly ? (
+        <EuiFlexItem grow={false}>
+          <EuiBadge color="hollow" iconType="lock">
+            {labels.agentTools.readOnlyBadge}
+          </EuiBadge>
+        </EuiFlexItem>
+      ) : (
+        <EuiFlexItem grow={false}>
+          <EuiLink href={editInLibraryUrl} target="_blank" external>
+            {labels.agentTools.editInLibraryLink}
+          </EuiLink>
+        </EuiFlexItem>
+      )}
+      <EuiFlexItem grow={false}>
+        <EuiButtonEmpty iconType="cross" size="xs" color="danger" onClick={openConfirmRemove}>
+          {labels.agentTools.removeToolButtonLabel}
+        </EuiButtonEmpty>
+      </EuiFlexItem>
+    </>
   );
 };

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/hooks/agents/use_can_edit_agent.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/hooks/agents/use_can_edit_agent.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useMemo } from 'react';
+import type { AgentDefinition } from '@kbn/agent-builder-common';
+import { canCurrentUserEditAgent } from '@kbn/agent-builder-common';
+import { useUiPrivileges } from '../use_ui_privileges';
+import { useCurrentUser } from './use_current_user';
+
+export const useCanEditAgent = ({ agent }: { agent: AgentDefinition | null }): boolean => {
+  const { manageAgents, isAdmin } = useUiPrivileges();
+  const { currentUser, isLoading: isCurrentUserLoading } = useCurrentUser();
+
+  return useMemo(() => {
+    if (!agent) {
+      return false;
+    }
+    return canCurrentUserEditAgent({
+      agent,
+      manageAgents,
+      currentUser,
+      isAdmin,
+      isCurrentUserLoading,
+    });
+  }, [agent, manageAgents, currentUser, isAdmin, isCurrentUserLoading]);
+};


### PR DESCRIPTION
resolves: https://github.com/elastic/search-team/issues/13763

## Summary

This PR applies **role-based access control** to the newer Agent Builder agentic surfaces (agent overview, tools and skills). It also enforces agent visibility (public, private, shared).

**UI approach:** We **hide** add, edit, and delete actions when the user cannot modify the agent, rather than showing disabled controls. This is **for consistency with other Agent Builder pages**, which already avoid surfacing mutating actions when the user lacks permission.


### How to test

1. **Setup:** Kibana with Agent Builder enabled; two security roles or users that differ on **Manage Agents** / ability to edit a given agent (include a private or other-user-owned agent if you test ownership rules).
2. As a user **with** edit access: open the agents list, an agent **overview**, **edit**, and **tools/skills** — confirm save, add, edit, and remove actions appear where expected.
3. As a user **without** edit access: confirm **add / edit / delete / save** (as applicable) are **not shown**, matching other Agent Builder pages.
4. As a non-admin user **with** edit access: Open an shared agent and confirm **add / edit / delete / save** (as applicable) are **not shown**, matching other Agent Builder pages.

### Checklist

Check the PR satisfies following conditions.

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

