### PR TITLE
[Ingest pipelines] A11y: Fix Define as Json announcement

### DIFF
--- a/x-pack/platform/plugins/shared/ingest_pipelines/public/application/components/pipeline_editor/components/processor_form/field_components/xjson_toggle.tsx
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/public/application/components/pipeline_editor/components/processor_form/field_components/xjson_toggle.tsx
@@ -4,8 +4,8 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import type { FunctionComponent, MouseEventHandler } from 'react';
-import React, { useCallback, useEffect, useState, useMemo } from 'react';
+import type { FunctionComponent, MouseEventHandler, RefCallback } from 'react';
+import React, { useCallback, useEffect, useState, useMemo, useRef } from 'react';
 import { i18n } from '@kbn/i18n';
 
 import { FormattedMessage } from '@kbn/i18n-react';
@@ -29,6 +29,7 @@ interface ToggleProps {
   disabled?: boolean;
   toggleJson: MouseEventHandler;
   fieldType: FieldType;
+  toggleRef: RefCallback<HTMLAnchorElement>;
 }
 
 const FieldToToggle: FunctionComponent<ToggleProps> = ({
@@ -36,23 +37,31 @@ const FieldToToggle: FunctionComponent<ToggleProps> = ({
   disabled,
   toggleJson,
   fieldType,
+  toggleRef,
 }) => {
+  const labelAppend = (
+    <EuiText size="xs">
+      <EuiLink
+        ref={toggleRef}
+        onClick={toggleJson}
+        data-test-subj="toggleTextField"
+        disabled={disabled}
+      >
+        <FormattedMessage
+          id="xpack.ingestPipelines.pipelineEditor.toggleJson.useJsonFormat"
+          defaultMessage="Define as JSON"
+        />
+      </EuiLink>
+    </EuiText>
+  );
+
   if (fieldType === 'text') {
     return (
       <Field
         data-test-subj="textValueField"
         field={field}
         euiFieldProps={{ disabled }}
-        labelAppend={
-          <EuiText size="xs">
-            <EuiLink onClick={toggleJson} data-test-subj="toggleTextField" disabled={disabled}>
-              <FormattedMessage
-                id="xpack.ingestPipelines.pipelineEditor.toggleJson.useJsonFormat"
-                defaultMessage="Define as JSON"
-              />
-            </EuiLink>
-          </EuiText>
-        }
+        labelAppend={labelAppend}
       />
     );
   }
@@ -63,16 +72,7 @@ const FieldToToggle: FunctionComponent<ToggleProps> = ({
         data-test-subj="comboxValueField"
         field={field}
         euiFieldProps={{ disabled }}
-        labelAppend={
-          <EuiText size="xs">
-            <EuiLink onClick={toggleJson} data-test-subj="toggleTextField" disabled={disabled}>
-              <FormattedMessage
-                id="xpack.ingestPipelines.pipelineEditor.toggleJson.useJsonFormat"
-                defaultMessage="Define as JSON"
-              />
-            </EuiLink>
-          </EuiText>
-        }
+        labelAppend={labelAppend}
       />
     );
   }
@@ -86,10 +86,21 @@ export const XJsonToggle: FunctionComponent<Props> = ({
 }) => {
   const { value, setValue } = field;
   const [defineAsJson, setDefineAsJson] = useState<boolean | undefined>(undefined);
+  const toggleLinkRef = useRef<HTMLAnchorElement | null>(null);
+  const pendingFocusRef = useRef(false);
+
+  const toggleRef: RefCallback<HTMLAnchorElement> = useCallback((node) => {
+    toggleLinkRef.current = node;
+    if (pendingFocusRef.current && node) {
+      node.focus();
+      pendingFocusRef.current = false;
+    }
+  }, []);
 
   const toggleJson = useCallback(() => {
     const defaultValue = fieldType === 'text' ? '' : [];
     const newValueIsJson = !defineAsJson;
+    pendingFocusRef.current = true;
     setValue(newValueIsJson ? '{}' : defaultValue);
     setDefineAsJson(newValueIsJson);
     handleIsJson(newValueIsJson);
@@ -126,7 +137,12 @@ export const XJsonToggle: FunctionComponent<Props> = ({
         options: { readOnly: disabled },
         labelAppend: (
           <EuiText size="xs">
-            <EuiLink onClick={toggleJson} data-test-subj="toggleJsonField" disabled={disabled}>
+            <EuiLink
+              ref={toggleRef}
+              onClick={toggleJson}
+              data-test-subj="toggleJsonField"
+              disabled={disabled}
+            >
               <FormattedMessage
                 id="xpack.ingestPipelines.pipelineEditor.toggleJson.useTextFormat"
                 defaultMessage="Define as text"
@@ -141,6 +157,7 @@ export const XJsonToggle: FunctionComponent<Props> = ({
       field={field}
       disabled={disabled}
       toggleJson={toggleJson}
+      toggleRef={toggleRef}
       fieldType={fieldType}
     />
   );


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/218059
## Summary
- When toggling between "Define as JSON" and "Define as text" in the Append processor form (and any other processor that uses `XJsonToggle`), the focused link unmounted without restoring focus, leaving `document.activeElement` as `<body>`. NVDA then scanned from body and announced the first visited link in view — the "Ingest Pipelines" breadcrumb — confusing screen reader users.
- Fixed by sharing a callback ref across both toggle links. A pending-focus flag is set when the toggle is activated; when React mounts the replacement link, the flag is read and `focus()` is called immediately, keeping focus inside the form.
### Test plan
Manual — Windows 11 + NVDA:
1. Stack Management → Ingest Pipelines → Create pipeline.
2. Add a processor → select **Append**.
3. Activate the **Define as JSON** toggle (click or keyboard Enter).
   - Verify: focus is on "Define as text"; NVDA announces "Define as text button" (no breadcrumb or navigation announced).
4. Activate **Define as text**.
   - Verify: focus is on "Define as JSON"; NVDA announces "Define as JSON button".
### Evidence (screenshots / screen recording)
<img width="994" height="455" alt="Screenshot 2026-04-08 at 09 41 48" src="https://github.com/user-attachments/assets/6c9f84e2-e7e0-4196-a529-825593b796f5" />


<!--ONMERGE {"backportTargets":["8.19","9.2","9.3"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["9.2","9.3"]} ONMERGE-->