### PR TITLE
[Ingest pipelines] A11y: fix learn more focus

### DIFF
--- a/x-pack/platform/plugins/shared/ingest_pipelines/public/application/components/pipeline_editor/components/processors_empty_prompt.tsx
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/public/application/components/pipeline_editor/components/processors_empty_prompt.tsx
@@ -9,7 +9,7 @@ import type { FunctionComponent } from 'react';
 import React, { useRef } from 'react';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { EuiEmptyPrompt, EuiSpacer, EuiLink } from '@elastic/eui';
+import { EuiEmptyPrompt, EuiLink } from '@elastic/eui';
 import { useKibana } from '../../../../shared_imports';
 import { usePipelineProcessorsContext } from '../context';
 import { AddProcessorButton } from './add_processor_button';
@@ -56,23 +56,19 @@ export const ProcessorsEmptyPrompt: FunctionComponent<Props> = ({ onLoadJson }) 
           />
         </p>
       }
-      actions={
-        <>
-          <AddProcessorButton
-            ref={buttonRef}
-            onClick={() => {
-              onTreeAction({
-                type: 'addProcessor',
-                payload: { target: ['processors'], buttonRef },
-              });
-            }}
-          />
-
-          <EuiSpacer size="m" />
-
-          <LoadFromJsonButton onDone={onLoadJson} />
-        </>
-      }
+      actions={[
+        <AddProcessorButton
+          key="addProcessor"
+          ref={buttonRef}
+          onClick={() => {
+            onTreeAction({
+              type: 'addProcessor',
+              payload: { target: ['processors'], buttonRef },
+            });
+          }}
+        />,
+        <LoadFromJsonButton key="loadFromJson" onDone={onLoadJson} />,
+      ]}
     />
   );
 };

--- a/x-pack/platform/plugins/shared/ingest_pipelines/public/application/components/pipeline_editor/components/processors_tree/components/private_tree.tsx
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/public/application/components/pipeline_editor/components/processors_tree/components/private_tree.tsx
@@ -208,6 +208,7 @@ export const PrivateTree: FunctionComponent<PrivateProps> = ({
                       isScrolling={isScrolling}
                       onChildScroll={onChildScroll}
                       scrollTop={scrollTop}
+                      tabIndex={processors.length === 0 ? -1 : 0}
                       rowCount={processors.length}
                       rowHeight={({ index }) => {
                         const processor = processors[index];


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/218224
## Summary
- On the Ingest Pipelines edit pipeline page, keyboard users encountered an invisible Tab stop after the "Learn more." link in two places: the empty processors prompt and the Failure processors section.
- Fixed two independent root causes: (1) `EuiEmptyPrompt` was receiving `actions` as a React fragment instead of an array, collapsing both buttons into a shared div and breaking structural separation; (2) the react-virtualized `List` grid (`role="grid"`, `tabIndex={0}`) remained focusable even when the processor list was empty.
### Test plan
Manual — Windows 11 + NVDA:
1. Navigate to Stack Management → Ingest Pipelines → Create pipeline (empty state).
2. Tab to "Learn more." link → Tab once → focus must land on "Add a processor" with a visible outline.
3. Tab again → focus must land on "Import processors".
4. Add one processor → scroll to Failure processors section → Tab from its "Learn more." link → focus must land on "Add a processor" with no invisible stop in between.
### Evidence
**Empty prompt**

https://github.com/user-attachments/assets/7bfd8b00-7868-41c5-b4c4-f9c719d551e9

**Failure processors**

https://github.com/user-attachments/assets/b88ca19b-c6fe-4a64-a4a4-fd075d0a1d17



<!--ONMERGE {"backportTargets":["8.19","9.2","9.3"]} ONMERGE-->