### PR TITLE
[Cases] Omit `incremental_id` from api integration test checks

### DIFF
--- a/x-pack/platform/test/serverless/api_integration/services/svl_cases/omit.ts
+++ b/x-pack/platform/test/serverless/api_integration/services/svl_cases/omit.ts
@@ -6,6 +6,7 @@
  */
 
 import type { Case, Attachment } from '@kbn/cases-plugin/common/types/domain';
+import type { CasesFindResponse } from '@kbn/cases-plugin/common/types/api';
 import { omit } from 'lodash';
 import type { FtrProviderContext } from '../../ftr_provider_context';
 
@@ -39,7 +40,21 @@ export function SvlCasesOmitServiceProvider({}: FtrProviderContext) {
     },
 
     removeServerGeneratedPropertiesFromCase(theCase: Case): Partial<Case> {
-      return this.removeServerGeneratedPropertiesFromSavedObject<Case>(theCase, ['closed_at']);
+      return this.removeServerGeneratedPropertiesFromSavedObject<Case>(theCase, [
+        'closed_at',
+        'incremental_id',
+      ]);
+    },
+
+    removeServerGeneratedPropertiesFromFindCasesResponse(
+      response: CasesFindResponse
+    ): Omit<CasesFindResponse, 'cases'> & { cases: Array<Partial<Case>> } {
+      return {
+        ...response,
+        cases: response.cases.map((theCase) =>
+          this.removeServerGeneratedPropertiesFromCase(theCase)
+        ),
+      };
     },
 
     removeServerGeneratedPropertiesFromComments(

--- a/x-pack/solutions/observability/test/serverless/api_integration/test_suites/cases/find_cases.ts
+++ b/x-pack/solutions/observability/test/serverless/api_integration/test_suites/cases/find_cases.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { CasePostRequest } from '@kbn/cases-plugin/common/types/api';
+import type { CasePostRequest, CasesFindResponse } from '@kbn/cases-plugin/common/types/api';
 import expect from '@kbn/expect';
 import type { RoleCredentials } from '../../services';
 import type { FtrProviderContext } from '../../ftr_provider_context';
@@ -13,8 +13,10 @@ import type { FtrProviderContext } from '../../ftr_provider_context';
 export default ({ getService }: FtrProviderContext): void => {
   const svlCases = getService('svlCases');
   const svlUserManager = getService('svlUserManager');
+  const normalizeFindCasesResponse = (response: CasesFindResponse) =>
+    svlCases.omit.removeServerGeneratedPropertiesFromFindCasesResponse(response);
 
-  let findCasesResp: any;
+  let findCasesResp: CasesFindResponse;
   let postCaseReq: CasePostRequest;
 
   describe('find_cases', () => {
@@ -35,7 +37,7 @@ export default ({ getService }: FtrProviderContext): void => {
 
     it('should return empty response', async () => {
       const cases = await svlCases.api.findCases({}, roleAuthc);
-      expect(cases).to.eql(findCasesResp);
+      expect(normalizeFindCasesResponse(cases)).to.eql(normalizeFindCasesResponse(findCasesResp));
     });
 
     it('should return cases', async () => {
@@ -45,12 +47,14 @@ export default ({ getService }: FtrProviderContext): void => {
 
       const cases = await svlCases.api.findCases({}, roleAuthc);
 
-      expect(cases).to.eql({
-        ...findCasesResp,
-        total: 3,
-        cases: [a, b, c],
-        count_open_cases: 3,
-      });
+      expect(normalizeFindCasesResponse(cases)).to.eql(
+        normalizeFindCasesResponse({
+          ...findCasesResp,
+          total: 3,
+          cases: [a, b, c],
+          count_open_cases: 3,
+        })
+      );
     });
 
     it('returns empty response when trying to find cases with owner as cases', async () => {
@@ -60,7 +64,7 @@ export default ({ getService }: FtrProviderContext): void => {
         },
         roleAuthc
       );
-      expect(cases).to.eql(findCasesResp);
+      expect(normalizeFindCasesResponse(cases)).to.eql(normalizeFindCasesResponse(findCasesResp));
     });
 
     it('returns empty response when trying to find cases with owner as securitySolution', async () => {
@@ -70,7 +74,7 @@ export default ({ getService }: FtrProviderContext): void => {
         },
         roleAuthc
       );
-      expect(cases).to.eql(findCasesResp);
+      expect(normalizeFindCasesResponse(cases)).to.eql(normalizeFindCasesResponse(findCasesResp));
     });
   });
 };

--- a/x-pack/solutions/observability/test/serverless/api_integration/test_suites/cases/post_case.ts
+++ b/x-pack/solutions/observability/test/serverless/api_integration/test_suites/cases/post_case.ts
@@ -30,20 +30,26 @@ export default ({ getService }: FtrProviderContext): void => {
     });
 
     it('should create a case', async () => {
-      expect(
-        await svlCases.api.createCase(
-          svlCases.api.getPostCaseRequest('observability', {
-            connector: {
-              id: '123',
-              name: 'Jira',
-              type: ConnectorTypes.jira,
-              fields: { issueType: 'Task', priority: 'High', parent: null },
-            },
-          }),
-          roleAuthc,
-          200
-        )
+      const payload = svlCases.api.getPostCaseRequest('observability', {
+        connector: {
+          id: '123',
+          name: 'Jira',
+          type: ConnectorTypes.jira,
+          fields: { issueType: 'Task', priority: 'High', parent: null },
+        },
+      });
+      const postedCase = await svlCases.api.createCase(payload, roleAuthc, 200);
+
+      const { created_by: createdBy, ...data } =
+        svlCases.omit.removeServerGeneratedPropertiesFromCase(postedCase);
+      const { created_by: _, ...expected } = svlCases.api.postCaseResp(
+        'observability',
+        null,
+        payload
       );
+
+      expect(createdBy).to.have.keys('full_name', 'email', 'username');
+      expect(data).to.eql(expected);
     });
 
     it('should throw 403 when create a case with securitySolution as owner', async () => {

--- a/x-pack/solutions/security/test/serverless/api_integration/test_suites/cases/find_cases.ts
+++ b/x-pack/solutions/security/test/serverless/api_integration/test_suites/cases/find_cases.ts
@@ -6,15 +6,18 @@
  */
 
 import expect from '@kbn/expect';
+import type { CasePostRequest, CasesFindResponse } from '@kbn/cases-plugin/common/types/api';
 import type { RoleCredentials } from '../../services';
 import type { FtrProviderContext } from '../../ftr_provider_context';
 
 export default ({ getService }: FtrProviderContext): void => {
   const svlCases = getService('svlCases');
   const svlUserManager = getService('svlUserManager');
+  const normalizeFindCasesResponse = (response: CasesFindResponse) =>
+    svlCases.omit.removeServerGeneratedPropertiesFromFindCasesResponse(response);
 
-  let findCasesResp: any;
-  let postCaseReq: any;
+  let findCasesResp: CasesFindResponse;
+  let postCaseReq: CasePostRequest;
 
   describe('find_cases', () => {
     let roleAuthc: RoleCredentials;
@@ -31,7 +34,7 @@ export default ({ getService }: FtrProviderContext): void => {
 
       it('should return empty response', async () => {
         const cases = await svlCases.api.findCases({}, roleAuthc);
-        expect(cases).to.eql(findCasesResp);
+        expect(normalizeFindCasesResponse(cases)).to.eql(normalizeFindCasesResponse(findCasesResp));
       });
 
       it('should return cases', async () => {
@@ -41,17 +44,19 @@ export default ({ getService }: FtrProviderContext): void => {
 
         const cases = await svlCases.api.findCases({}, roleAuthc);
 
-        expect(cases).to.eql({
-          ...findCasesResp,
-          total: 3,
-          cases: [a, b, c],
-          count_open_cases: 3,
-        });
+        expect(normalizeFindCasesResponse(cases)).to.eql(
+          normalizeFindCasesResponse({
+            ...findCasesResp,
+            total: 3,
+            cases: [a, b, c],
+            count_open_cases: 3,
+          })
+        );
       });
 
       it('returns empty response when trying to find cases with owner as cases', async () => {
         const cases = await svlCases.api.findCases({ query: { owner: 'cases' } }, roleAuthc);
-        expect(cases).to.eql(findCasesResp);
+        expect(normalizeFindCasesResponse(cases)).to.eql(normalizeFindCasesResponse(findCasesResp));
       });
 
       it('returns empty response when trying to find cases with owner as observability', async () => {
@@ -61,7 +66,7 @@ export default ({ getService }: FtrProviderContext): void => {
           },
           roleAuthc
         );
-        expect(cases).to.eql(findCasesResp);
+        expect(normalizeFindCasesResponse(cases)).to.eql(normalizeFindCasesResponse(findCasesResp));
       });
     });
   });


### PR DESCRIPTION
## Summary

Fixes: https://github.com/elastic/kibana/issues/260869

The Cases API integration tests have become flaky due to `version` and `incremental_id` conflicts. See [this run](https://buildkite.com/elastic/appex-qa-serverless-kibana-ftr-tests/builds/8961) for an example.

This PR omits `incremental_id` from all compared requests/responses in the cases API integration tests.

<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->