### PR TITLE
[ES|QL] Supports views at the editor

### DIFF
--- a/src/platform/packages/shared/kbn-esql-language/src/commands/registry/from/index.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/registry/from/index.ts
@@ -26,7 +26,6 @@ export const fromCommand = {
   methods: fromCommandMethods,
   metadata: {
     type: 'source' as const,
-    viewsSupport: process.env.NODE_ENV === 'test' ? true : false, // Temporary until making it Preview
     description: i18n.translate('kbn-esql-language.esql.definitions.fromDoc', {
       defaultMessage:
         'Retrieves data from one or more data streams, indices, or aliases. In a query or subquery, you must use the from command first and it does not need a leading pipe. For example, to retrieve data from an index:',

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/registry/registry.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/registry/registry.ts
@@ -85,7 +85,6 @@ export interface ICommandMethods<TContext = ICommandContext> {
 
 export interface ICommandMetadata {
   preview?: boolean; // Optional property to indicate if the command is in preview mode
-  viewsSupport?: boolean; // Optional property to indicate if the command suggests/validates ES|QL views (ONLY FROM). This is temporary and we will remove it when views in FROM move to Preview.
   description: string; // Optional property for a brief description of the command
   declaration: string; // The pattern for declaring this command statement. Displayed in the autocomplete.
   examples: string[]; // A list of examples of how to use the command. Displayed in the autocomplete.

--- a/src/platform/packages/shared/kbn-esql-language/src/language/autocomplete/get_command_context.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/language/autocomplete/get_command_context.ts
@@ -15,7 +15,6 @@ import type { ParameterHint } from '../../..';
 import { getFunctionDefinition } from '../../commands/definitions/utils';
 import { parametersFromHintsResolvers } from '../../commands/definitions/utils/autocomplete/parameters_from_hints';
 import type { ICommandContext } from '../../commands/registry/types';
-import { esqlCommandRegistry } from '../../commands/registry';
 import { getPolicyHelper, getSourcesHelper } from '../shared/resources_helpers';
 
 export const getCommandContext = async (
@@ -53,10 +52,7 @@ export const getCommandContext = async (
         recommendedQueries: [],
         recommendedFields: [],
       };
-      const fromCommand = esqlCommandRegistry.getCommandByName('from');
-      // TODO: remove this once views support is on Technical Preview
-      const viewsSupport = fromCommand?.metadata?.viewsSupport ?? false;
-      const views = viewsSupport ? await callbacks?.getViews?.() : undefined;
+      const views = await callbacks?.getViews?.();
       context = {
         sources: await getSources(),
         editorExtensions,


### PR DESCRIPTION
## Summary

Moves views on tech preview at the editor. In reality I am just removing the temporary flag that is hiding them


