### PR TITLE
[Agent Builder] Remove horizontal padding on visualisation

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/esql/shared/styles.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/esql/shared/styles.ts
@@ -20,6 +20,10 @@ export const visualizationWrapper = (euiTheme: UseEuiTheme['euiTheme'], height: 
     '.echChart ul': {
       marginInlineStart: 0,
     },
+
+    '.expExpressionRenderer__expression': {
+      padding: `${euiTheme.size.s} 0`,
+    },
   });
 
 export const actionsContainer = (euiTheme: UseEuiTheme['euiTheme']) =>


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/search-team/issues/13679

For Lens visualisations created from the results of esql tool calls, we had an 8px padding left and right of the visualisation. We should remove this padding and have the visualisation full width of the chat.

**Before:**
<img width="655" height="286" alt="image" src="https://github.com/user-attachments/assets/c006fa59-2edd-46b0-b815-a9827f8d8473" />

**After:**
<img width="824" height="544" alt="image" src="https://github.com/user-attachments/assets/c2f64b97-1a77-48d8-9b65-b83ba14e5a7b" />

<img width="433" height="481" alt="image" src="https://github.com/user-attachments/assets/461487e9-8fb6-4c06-93cd-940a196e4570" />



