### PR TITLE
[OTel Tracing] Set root spans

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/setup.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/setup.ts
@@ -100,7 +100,11 @@ export async function setupFleet(
 ): Promise<SetupStatus> {
   return withActiveSpan(
     'fleet-setup',
-    { attributes: { 'transaction.type': 'fleet' } },
+    {
+      attributes: { 'transaction.type': 'fleet' },
+      // Make sure that this is a parent transaction (not a child of any other ongoing transaction)
+      root: true,
+    },
     async () => {
       const t = apm.startTransaction('fleet-setup', 'fleet');
       try {

--- a/x-pack/platform/plugins/shared/task_manager/server/task_claimers/strategy_mget.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_claimers/strategy_mget.ts
@@ -73,7 +73,11 @@ export async function claimAvailableTasksMget(
 ): Promise<ClaimOwnershipResult> {
   return withActiveSpan(
     'mark-task-as-claimed',
-    { attributes: { 'transaction.type': TASK_MANAGER_TRANSACTION_TYPE } },
+    {
+      attributes: { 'transaction.type': TASK_MANAGER_TRANSACTION_TYPE },
+      // Make sure that this is a parent transaction (not a child of any other ongoing transaction)
+      root: true,
+    },
     async () => {
       const apmTrans = apm.startTransaction(
         TASK_MANAGER_MARK_AS_CLAIMED,

--- a/x-pack/platform/plugins/shared/task_manager/server/task_claimers/strategy_update_by_query.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_claimers/strategy_update_by_query.ts
@@ -160,7 +160,11 @@ async function markAvailableTasksAsClaimed({
 
   return withActiveSpan(
     'mark-task-as-claimed',
-    { attributes: { 'transaction.type': TASK_MANAGER_TRANSACTION_TYPE } },
+    {
+      attributes: { 'transaction.type': TASK_MANAGER_TRANSACTION_TYPE },
+      // Make sure that this is a parent transaction (not a child of any other ongoing transaction)
+      root: true,
+    },
     async () => {
       const apmTrans = apm.startTransaction(
         TASK_MANAGER_MARK_AS_CLAIMED,

--- a/x-pack/platform/plugins/shared/task_manager/server/task_running/task_runner.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_running/task_runner.ts
@@ -383,6 +383,8 @@ export class TaskManagerRunner implements TaskRunner {
           'transaction.type': TASK_MANAGER_RUN_TRANSACTION_TYPE,
           'kibana.task.type': this.taskType,
         },
+        // Make sure that this is a parent transaction (not a child of any other ongoing transaction)
+        root: true,
       },
       async () => {
         const apmTrans = apm.startTransaction(this.taskType, TASK_MANAGER_RUN_TRANSACTION_TYPE, {
@@ -559,7 +561,11 @@ export class TaskManagerRunner implements TaskRunner {
 
     return withActiveSpan(
       'mark-task-as-running',
-      { attributes: { 'transaction.type': TASK_MANAGER_TRANSACTION_TYPE } },
+      {
+        attributes: { 'transaction.type': TASK_MANAGER_TRANSACTION_TYPE },
+        // Make sure that this is a parent transaction (not a child of any other ongoing transaction)
+        root: true,
+      },
       async () => {
         const apmTrans = apm.startTransaction(
           TASK_MANAGER_TRANSACTION_TYPE_MARK_AS_RUNNING,


### PR DESCRIPTION
## Summary

This PR adds the option `root: true` when creating the top-level spans for Fleet setup and Task Manager's transactions.

Without that option, the spans are shown in the APM UI as sub-spans of the `kibana-platform`-`server-start` top-level span (aka, transaction).

| Before | After |
|--------|--------|
| <img width="289" height="237" alt="image" src="https://github.com/user-attachments/assets/56be7ca9-db00-4fe9-a99b-8546bb0954fe" /> | <img width="303" height="314" alt="image" src="https://github.com/user-attachments/assets/641e81df-b9b1-4529-bb81-fd91d6466a2c" /> |

NOTE: `request` also shows in the Before, I just didn't collect any requests for that timerange.





