### PR TITLE
[Cases] Update cases workflow step icon

### DIFF
--- a/x-pack/platform/plugins/shared/cases/public/workflows/shared.ts
+++ b/x-pack/platform/plugins/shared/cases/public/workflows/shared.ts
@@ -23,7 +23,7 @@ export function createPublicCaseStepDefinition<
 >(definition: PublicStepDefinition<Input, Output, Config>) {
   return createPublicStepDefinition({
     icon: React.lazy(() =>
-      import('@elastic/eui/es/components/icon/assets/app_cases').then(({ icon }) => ({
+      import('@elastic/eui/es/components/icon/assets/briefcase').then(({ icon }) => ({
         default: icon,
       }))
     ),


### PR DESCRIPTION
## Summary

Updates the cases workflow step icon:

<img width="428" height="198" alt="Screenshot 2026-04-08 at 12 03 10" src="https://github.com/user-attachments/assets/e790001b-92c6-4f10-a4db-3444692b0dfa" />


<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->