### PR TITLE
[Fleet] Add source and target cluster types to agent migration telemetry

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/action_sender.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/action_sender.ts
@@ -13,6 +13,8 @@ import type { AgentActionType } from '../types';
 export interface AgentActionEvent {
   eventType: AgentActionType;
   agentCount: number;
+  sourceType?: 'serverless' | 'ech';
+  targetType?: 'serverless' | 'ech';
 }
 
 export const FLEET_ACTIONS_CHANNEL_NAME = 'fleet-actions';

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/detect_target_cluster_type.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/detect_target_cluster_type.test.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { detectTargetClusterType } from './detect_target_cluster_type';
+
+describe('detectTargetClusterType', () => {
+  describe('Serverless', () => {
+    it('detects production Serverless (AWS)', () => {
+      expect(
+        detectTargetClusterType(
+          'https://adbf8aa7744e4977836da61f5a43702a.fleet.eu-central-1.aws.elastic.cloud:443'
+        )
+      ).toBe('serverless');
+    });
+
+    it('detects staging Serverless (AWS)', () => {
+      expect(
+        detectTargetClusterType(
+          'https://d625a3c317a2456aa1ca34c78af287c3.fleet.eu-west-1.aws.qa.elastic.cloud:443'
+        )
+      ).toBe('serverless');
+    });
+  });
+
+  describe('ECH', () => {
+    it('detects production ECH on found.io (AWS)', () => {
+      expect(
+        detectTargetClusterType(
+          'https://cbe66fa0405648e0ba6046567645fc3c.fleet.eu-west-1.aws.found.io:443'
+        )
+      ).toBe('ech');
+    });
+
+    it('detects production ECH on cloud.es.io (GCP)', () => {
+      expect(detectTargetClusterType('https://abc123.fleet.us-central1.gcp.cloud.es.io:443')).toBe(
+        'ech'
+      );
+    });
+
+    it('detects production ECH on elastic-cloud.com (Azure)', () => {
+      expect(
+        detectTargetClusterType('https://abc123.fleet.westeurope.azure.elastic-cloud.com:443')
+      ).toBe('ech');
+    });
+
+    it('detects staging ECH on cld.elstc.co', () => {
+      expect(
+        detectTargetClusterType(
+          'https://28aeec9401da418384149b4afdfea825.fleet.eu-west-1.aws.qa.cld.elstc.co:443'
+        )
+      ).toBe('ech');
+    });
+
+    it('detects legacy staging ECH on foundit.no', () => {
+      expect(detectTargetClusterType('https://abc123.fleet.eu-west-1.aws.foundit.no:443')).toBe(
+        'ech'
+      );
+    });
+  });
+
+  describe('unclassified (undefined)', () => {
+    it('returns undefined for self-managed / custom domain', () => {
+      expect(detectTargetClusterType('https://192.168.1.113:8220')).toBeUndefined();
+    });
+
+    it('returns undefined for localhost', () => {
+      expect(detectTargetClusterType('https://localhost:8220')).toBeUndefined();
+    });
+
+    it('returns undefined for an invalid URL', () => {
+      expect(detectTargetClusterType('not-a-url')).toBeUndefined();
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/detect_target_cluster_type.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/detect_target_cluster_type.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+// Known Elastic Cloud Hosted (ECH) Fleet Server domains.
+// Note: newer ECH regions provisioned on elastic.cloud are not distinguishable from Serverless
+// by domain alone and will be classified as 'unknown'.
+const ECH_FLEET_DOMAINS = [
+  'found.io', // AWS ECH production
+  'cloud.es.io', // GCP ECH production
+  'elastic-cloud.com', // Azure ECH production
+  'cld.elstc.co', // ECH staging/QA
+  'foundit.no', // ECH legacy staging
+];
+
+// Known Serverless Fleet Server domains.
+const SERVERLESS_FLEET_DOMAINS = ['elastic.cloud'];
+
+export function detectTargetClusterType(uri: string): 'serverless' | 'ech' | undefined {
+  try {
+    const { hostname } = new URL(uri);
+    if (SERVERLESS_FLEET_DOMAINS.some((domain) => hostname.endsWith(`.${domain}`))) {
+      return 'serverless';
+    }
+    if (ECH_FLEET_DOMAINS.some((domain) => hostname.endsWith(`.${domain}`))) {
+      return 'ech';
+    }
+  } catch {
+    // invalid URL
+  }
+  return undefined;
+}

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/migrate.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/migrate.test.ts
@@ -11,13 +11,17 @@ import { v4 as uuidv4 } from 'uuid';
 import type { AgentPolicy, Agent } from '../../types';
 
 import { FleetError, FleetUnauthorizedError } from '../../errors';
+import { sendActionTelemetryEvents } from '../action_sender';
 
 import { bulkMigrateAgents, migrateSingleAgent } from './migrate';
 import { createAgentAction, createErrorActionResults } from './actions';
+import { detectTargetClusterType } from './detect_target_cluster_type';
 import { getAgentPolicyForAgents, getAgents } from './crud';
 
 // Mock the imported functions
 jest.mock('./actions');
+jest.mock('../action_sender');
+jest.mock('./detect_target_cluster_type');
 
 jest.mock('./crud', () => {
   return {
@@ -42,6 +46,7 @@ jest.mock('..', () => {
     appContextService: {
       getLogger: jest.fn(),
       getTelemetryEventsSender: jest.fn(),
+      getCloud: jest.fn(),
     },
   };
 });
@@ -81,9 +86,14 @@ const mockedPolicy: AgentPolicy = {
   namespace: 'default',
 };
 
+const mockedDetectTargetClusterType = detectTargetClusterType as jest.MockedFunction<
+  typeof detectTargetClusterType
+>;
+
 describe('Agent migration', () => {
   let esClientMock: ReturnType<typeof elasticsearchServiceMock.createInternalClient>;
   let mockLicenseService: any;
+  let mockAppContextService: any;
   const soClientMock = {
     getCurrentNamespace: jest.fn(),
   } as any;
@@ -93,10 +103,19 @@ describe('Agent migration', () => {
     jest.resetAllMocks();
     esClientMock = elasticsearchServiceMock.createInternalClient();
 
-    // Get the mocked license service
     mockLicenseService = jest.requireMock('..').licenseService;
-    // Default to having the required license
     mockLicenseService.hasAtLeast.mockReturnValue(true);
+
+    mockAppContextService = jest.requireMock('..').appContextService;
+    mockAppContextService.getLogger.mockReturnValue({ debug: jest.fn() });
+    mockAppContextService.getTelemetryEventsSender.mockReturnValue({
+      queueTelemetryEvents: jest.fn(),
+    });
+    mockAppContextService.getCloud.mockReturnValue({
+      isCloudEnabled: true,
+      isServerlessEnabled: false,
+      deploymentId: 'dep-123',
+    });
 
     (getAgentPolicyForAgents as jest.Mock).mockResolvedValue([mockedPolicy]);
 
@@ -112,6 +131,9 @@ describe('Agent migration', () => {
     mockedUuidv4.mockReturnValue('test-action-id' as any);
 
     mockedPolicy.is_protected = false;
+
+    // Default: target detected as ECH
+    mockedDetectTargetClusterType.mockReturnValue('ech');
   });
 
   describe('migrateSingleAgent', () => {
@@ -183,6 +205,67 @@ describe('Agent migration', () => {
             enrollment_token: options.enrollment_token,
           },
         })
+      );
+    });
+
+    it('should send telemetry with source ECH and detected serverless target', async () => {
+      mockedDetectTargetClusterType.mockReturnValue('serverless');
+
+      await migrateSingleAgent(esClientMock, soClientMock, 'agent-123', mockedPolicy, mockedAgent, {
+        policyId: 'policy-456',
+        enrollment_token: 'token',
+        uri: 'https://target.example.com',
+      });
+
+      expect(sendActionTelemetryEvents).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.any(Object),
+        expect.objectContaining({
+          eventType: 'MIGRATE',
+          agentCount: 1,
+          sourceType: 'ech',
+          targetType: 'serverless',
+        })
+      );
+    });
+
+    it('should send telemetry with undefined sourceType when not on cloud', async () => {
+      mockAppContextService.getCloud.mockReturnValue({
+        isCloudEnabled: false,
+        isServerlessEnabled: false,
+        deploymentId: undefined,
+      });
+
+      await migrateSingleAgent(esClientMock, soClientMock, 'agent-123', mockedPolicy, mockedAgent, {
+        policyId: 'policy-456',
+        enrollment_token: 'token',
+        uri: 'https://target.example.com',
+      });
+
+      expect(sendActionTelemetryEvents).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.any(Object),
+        expect.objectContaining({
+          eventType: 'MIGRATE',
+          agentCount: 1,
+          sourceType: undefined,
+        })
+      );
+    });
+
+    it('should send telemetry with undefined targetType when detection fails', async () => {
+      mockedDetectTargetClusterType.mockReturnValue(undefined);
+
+      await migrateSingleAgent(esClientMock, soClientMock, 'agent-123', mockedPolicy, mockedAgent, {
+        policyId: 'policy-456',
+        enrollment_token: 'token',
+        uri: 'https://target.example.com',
+      });
+
+      expect(sendActionTelemetryEvents).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.any(Object),
+        expect.objectContaining({ targetType: undefined })
       );
     });
 
@@ -382,6 +465,52 @@ describe('Agent migration', () => {
           secrets: {
             enrollment_token: options.enrollment_token,
           },
+        })
+      );
+    });
+
+    it('should send telemetry with source and target cluster types', async () => {
+      mockedDetectTargetClusterType.mockReturnValue('serverless');
+      (getAgents as jest.Mock).mockResolvedValue([mockedAgent]);
+
+      await bulkMigrateAgents(esClientMock, soClientMock, {
+        agentIds: [mockedAgent.id],
+        enrollment_token: 'token',
+        uri: 'https://target.example.com',
+      });
+
+      expect(sendActionTelemetryEvents).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.any(Object),
+        expect.objectContaining({
+          eventType: 'MIGRATE',
+          sourceType: 'ech',
+          targetType: 'serverless',
+        })
+      );
+    });
+
+    it('should send telemetry with undefined sourceType when not on cloud', async () => {
+      mockAppContextService.getCloud.mockReturnValue({
+        isCloudEnabled: false,
+        isServerlessEnabled: false,
+        deploymentId: undefined,
+      });
+      mockedDetectTargetClusterType.mockReturnValue('ech');
+      (getAgents as jest.Mock).mockResolvedValue([mockedAgent]);
+
+      await bulkMigrateAgents(esClientMock, soClientMock, {
+        agentIds: [mockedAgent.id],
+        enrollment_token: 'token',
+        uri: 'https://target.example.com',
+      });
+
+      expect(sendActionTelemetryEvents).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.any(Object),
+        expect.objectContaining({
+          eventType: 'MIGRATE',
+          sourceType: undefined,
         })
       );
     });

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/migrate.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/migrate.ts
@@ -26,6 +26,7 @@ import type { GetAgentsOptions } from './crud';
 import { getAgents, getAgentsByKuery, openPointInTime } from './crud';
 
 import { MigrateActionRunner, bulkMigrateAgentsBatch } from './migrate_action_runner';
+import { detectTargetClusterType } from './detect_target_cluster_type';
 
 export async function migrateSingleAgent(
   esClient: ElasticsearchClient,
@@ -64,6 +65,11 @@ export async function migrateSingleAgent(
       `Agent cannot be migrated. Migrate action is supported from version ${MINIMUM_MIGRATE_AGENT_VERSION}.`
     );
   }
+
+  const targetType = detectTargetClusterType(options.uri);
+  appContextService
+    .getLogger()
+    .debug(`Detected target cluster type for migration telemetry: ${targetType}`);
   const response = await createAgentAction(esClient, soClient, {
     agents: [agentId],
     created_at: new Date().toISOString(),
@@ -78,15 +84,32 @@ export async function migrateSingleAgent(
     }),
   });
 
-  sendTelemetryEvent(1);
+  const cloud = appContextService.getCloud();
+  sendTelemetryEvent(1, {
+    sourceType: cloud?.isCloudEnabled
+      ? cloud.isServerlessEnabled
+        ? 'serverless'
+        : 'ech'
+      : undefined,
+    targetType,
+  });
 
   return { actionId: response.id };
 }
 
-function sendTelemetryEvent(agentCount: number) {
+function sendTelemetryEvent(
+  agentCount: number,
+  clusterInfo: {
+    sourceType?: AgentActionEvent['sourceType'];
+    targetType?: AgentActionEvent['targetType'];
+  }
+) {
+  const { sourceType, targetType } = clusterInfo;
   const actionTelemetry: AgentActionEvent = {
     eventType: 'MIGRATE',
     agentCount,
+    sourceType,
+    targetType,
   };
   sendActionTelemetryEvents(
     appContextService.getLogger(),
@@ -113,6 +136,19 @@ export async function bulkMigrateAgents(
   }
 
   const currentSpaceId = getCurrentNamespace(soClient);
+  const targetType = detectTargetClusterType(options.uri);
+  appContextService
+    .getLogger()
+    .debug(`Detected target cluster type for migration telemetry: ${targetType}`);
+  const cloud = appContextService.getCloud();
+  const clusterInfo = {
+    sourceType: cloud?.isCloudEnabled
+      ? cloud.isServerlessEnabled
+        ? ('serverless' as const)
+        : ('ech' as const)
+      : undefined,
+    targetType,
+  };
 
   if ('agentIds' in options) {
     const givenAgents = await getAgents(esClient, soClient, options);
@@ -122,7 +158,7 @@ export async function bulkMigrateAgents(
       settings: options.settings,
       spaceId: currentSpaceId,
     });
-    sendTelemetryEvent(options.agentIds.length);
+    sendTelemetryEvent(options.agentIds.length, clusterInfo);
     return response;
   }
 
@@ -142,7 +178,7 @@ export async function bulkMigrateAgents(
       settings: options.settings,
       spaceId: currentSpaceId,
     });
-    sendTelemetryEvent(res.total);
+    sendTelemetryEvent(res.total, clusterInfo);
     return response;
   } else {
     const response = await new MigrateActionRunner(
@@ -156,7 +192,7 @@ export async function bulkMigrateAgents(
       },
       { pitId: await openPointInTime(esClient) }
     ).runActionAsyncTask();
-    sendTelemetryEvent(res.total);
+    sendTelemetryEvent(res.total, clusterInfo);
     return response;
   }
 }


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/ingest-dev/issues/7075

Enrich agent migration telemetry with two fields for storing the type of the source and target clusters:
```js
export interface AgentActionEvent {
  eventType: AgentActionType;
  agentCount: number;
  sourceType?: 'serverless' | 'ech';
  targetType?: 'serverless' | 'ech';
}
```

The main goal here is to track migrations from ECH to Serverless.

Considering the agent migration API only takes a Fleet Server host URL as input, the target cluster type is inferred from the domain in the URL. This is not an ideal solution, as the domains are hardcoded for reference and could eventually become outdated. In particular, ECH clusters on `elastic.cloud` could be incorrectly tagged as Serverless.

Note that these fields are optional: self-managed stacks should yield cluster type `undefined`.

Example logs:

From local dev to ECH:
```
[DEBUG][plugins.fleet] Detected target cluster type for migration telemetry: ech
[DEBUG][plugins.fleet.telemetry_events] [{"eventType":"MIGRATE","agentCount":1,"targetType":"ech","license_issued_to":"elasticsearch"}]
```

From local dev to Serverless:
```
[DEBUG][plugins.fleet] Detected target cluster type for migration telemetry: serverless
[DEBUG][plugins.fleet.telemetry_events] [{"eventType":"MIGRATE","agentCount":1,"targetType":"serverless","license_issued_to":"elasticsearch"}]
```

From local dev to local dev:
```
[DEBUG][plugins.fleet] Detected target cluster type for migration telemetry: undefined
[DEBUG][plugins.fleet.telemetry_events] [{"eventType":"MIGRATE","agentCount":1,"license_issued_to":"elasticsearch"}]
```

### Checklist

- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Domain lists are hardcoded and therefore susceptible to become stale. This implies a risk of incorrectly classifying ECH clusters on `elastic.cloud` as Serverless.

<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->