### PR TITLE
Fix user_details_left useTabs test for entity resolution tabs

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_details_left/tabs.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_details_left/tabs.test.tsx
@@ -97,5 +97,4 @@ describe('user_details_left useTabs', () => {
       expect.objectContaining({ id: EntityDetailsLeftPanelTab.RISK_INPUTS }),
     ]);
   });
-
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_details_left/tabs.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_details_left/tabs.test.tsx
@@ -18,8 +18,7 @@ jest.mock('../../../common/hooks/use_has_entity_resolution_license', () => ({
 
 const emptyManagedUser = {};
 
-// Failing: See https://github.com/elastic/kibana/issues/261914
-describe.skip('user_details_left useTabs', () => {
+describe('user_details_left useTabs', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     (useHasEntityResolutionLicense as jest.Mock).mockReturnValue(false);
@@ -99,30 +98,4 @@ describe.skip('user_details_left useTabs', () => {
     ]);
   });
 
-  it('can show only Resolution tab when no other tabs apply', () => {
-    (useHasEntityResolutionLicense as jest.Mock).mockReturnValue(true);
-    const { result } = renderHook(
-      () =>
-        useTabs(
-          emptyManagedUser,
-          'alice',
-          false,
-          'scope-1',
-          false,
-          false,
-          undefined,
-          undefined,
-          'stored-user-entity-1'
-        ),
-      { wrapper: TestProviders }
-    );
-
-    expect(result.current).toEqual([
-      expect.objectContaining({ id: EntityDetailsLeftPanelTab.GRAPH_VIEW }),
-      expect.objectContaining({
-        id: EntityDetailsLeftPanelTab.RESOLUTION_GROUP,
-        'data-test-subj': RESOLUTION_GROUP_TAB_TEST_ID,
-      }),
-    ]);
-  });
 });


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/261914

The test "can show only Resolution tab when no other tabs apply" was failing because the Risk Inputs tab condition changed to `isRiskScoreExist || entityStoreEntityId` — so having `entityStoreEntityId` set always includes the Risk Inputs tab, making the "only Resolution tab" scenario impossible.

The test became a duplicate of test 1 (both produce the same tabs when `entityStoreEntityId` is set with an active license). Removed the redundant test case and unskipped the suite. The remaining 3 tests fully cover the Resolution tab gating logic:

1. Both gates met (entityStoreEntityId + license) → Resolution tab present
2. No license → Resolution tab absent
3. No entityStoreEntityId → Resolution tab absent

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

No risks — this only removes a redundant test case and unskips the test suite.