### PR TITLE
[Entity Analytics][Bug Fix][Lead generation]Fixing bug for empty state when ff is disabled for leads generation

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/common/entity_analytics/lead_generation/constants.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/entity_analytics/lead_generation/constants.ts
@@ -18,4 +18,4 @@ export const DISABLE_LEAD_GENERATION_URL = `${LEAD_GENERATION_URL}/disable` as c
 export type LeadGenerationMode = 'adhoc' | 'scheduled';
 
 export const getLeadsIndexName = (spaceId: string, mode: LeadGenerationMode = 'adhoc'): string =>
-  `.internal.${mode}.entity-analytics.entity-leads.entity-${spaceId}`;
+  `entity-analytics.entity-leads-${mode}.entity-${spaceId}`;

--- a/x-pack/solutions/security/plugins/security_solution/common/entity_analytics/lead_generation/constants.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/entity_analytics/lead_generation/constants.ts
@@ -18,4 +18,4 @@ export const DISABLE_LEAD_GENERATION_URL = `${LEAD_GENERATION_URL}/disable` as c
 export type LeadGenerationMode = 'adhoc' | 'scheduled';
 
 export const getLeadsIndexName = (spaceId: string, mode: LeadGenerationMode = 'adhoc'): string =>
-  `entity-analytics.entity-leads-${mode}.entity-${spaceId}`;
+  `.entity-analytics.entity-leads-${mode}.entity-${spaceId}`;

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/threat_hunting/top_threat_hunting_leads/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/threat_hunting/top_threat_hunting_leads/index.test.tsx
@@ -87,12 +87,20 @@ describe('TopThreatHuntingLeads', () => {
     expect(screen.queryByTestId('leadCard-lead-6')).not.toBeInTheDocument();
   });
 
-  it('renders empty state when no leads', () => {
+  it('renders empty state when no leads and never generated', () => {
     render(<TopThreatHuntingLeads {...defaultProps} />);
 
     expect(screen.getByTestId('topThreatHuntingLeads')).toBeInTheDocument();
     expect(screen.getByTestId('leadsEmptyPrompt')).toBeInTheDocument();
+    expect(screen.getByText('No hunting leads yet')).toBeInTheDocument();
     expect(screen.queryByTestId('leadsLoadingSpinner')).not.toBeInTheDocument();
+  });
+
+  it('renders "no data found" empty state after generation with no results', () => {
+    render(<TopThreatHuntingLeads {...defaultProps} hasGenerated />);
+
+    expect(screen.getByTestId('leadsEmptyPrompt')).toBeInTheDocument();
+    expect(screen.getByText('No data found')).toBeInTheDocument();
   });
 
   it('renders loading state (spinner visible)', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/threat_hunting/top_threat_hunting_leads/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/threat_hunting/top_threat_hunting_leads/index.tsx
@@ -30,6 +30,7 @@ interface TopThreatHuntingLeadsProps {
   totalCount: number;
   isLoading: boolean;
   isGenerating: boolean;
+  hasGenerated?: boolean;
   onSeeAll: () => void;
   onLeadClick: (lead: HuntingLead) => void;
   onHuntInChat: () => void;
@@ -44,6 +45,7 @@ export const TopThreatHuntingLeads: React.FC<TopThreatHuntingLeadsProps> = ({
   totalCount,
   isLoading,
   isGenerating,
+  hasGenerated,
   onSeeAll,
   onLeadClick,
   onHuntInChat,
@@ -142,15 +144,15 @@ export const TopThreatHuntingLeads: React.FC<TopThreatHuntingLeadsProps> = ({
         </EuiFlexGroup>
       ) : leads.length === 0 ? (
         <EuiEmptyPrompt
-          iconType="searchProfilerApp"
-          title={<h3>{i18n.NO_LEADS_TITLE}</h3>}
-          body={<p>{i18n.NO_LEADS_DESCRIPTION}</p>}
+          iconType={hasGenerated ? 'inspect' : 'searchProfilerApp'}
+          title={<h3>{hasGenerated ? i18n.NO_DATA_TITLE : i18n.NO_LEADS_TITLE}</h3>}
+          body={<p>{hasGenerated ? i18n.NO_DATA_DESCRIPTION : i18n.NO_LEADS_DESCRIPTION}</p>}
           data-test-subj="leadsEmptyPrompt"
         />
       ) : (
         <EuiFlexGroup gutterSize="m" wrap responsive style={{ marginTop: 12 }}>
           {leads.slice(0, MAX_VISIBLE_CARDS).map((lead) => (
-            <EuiFlexItem key={lead.id} grow={false}>
+            <EuiFlexItem key={lead.id} grow={1}>
               <LeadCard lead={lead} onClick={onLeadClick} onInfoClick={onLeadInfoClick} />
             </EuiFlexItem>
           ))}

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/threat_hunting/top_threat_hunting_leads/lead_card.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/threat_hunting/top_threat_hunting_leads/lead_card.tsx
@@ -71,7 +71,7 @@ export const LeadCard: React.FC<LeadCardProps> = ({ lead, onClick, onInfoClick }
     >
       {onInfoClick && (
         <EuiButtonIcon
-          iconType="iInCircle"
+          iconType="info"
           aria-label={VIEW_LEAD_DETAILS}
           onClick={handleInfoClick}
           data-test-subj={`leadInfoButton-${lead.id}`}

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/threat_hunting/top_threat_hunting_leads/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/threat_hunting/top_threat_hunting_leads/translations.ts
@@ -50,6 +50,19 @@ export const NO_LEADS_DESCRIPTION = i18n.translate(
   }
 );
 
+export const NO_DATA_TITLE = i18n.translate(
+  'xpack.securitySolution.entityAnalytics.threatHunting.leads.noDataTitle',
+  { defaultMessage: 'No data found' }
+);
+
+export const NO_DATA_DESCRIPTION = i18n.translate(
+  'xpack.securitySolution.entityAnalytics.threatHunting.leads.noDataDescription',
+  {
+    defaultMessage:
+      'No entities, risk scores, or alerts were found to generate hunting leads. Ensure the Entity Store and Risk Engine are enabled with data available.',
+  }
+);
+
 export const ALL_HUNTING_LEADS_TITLE = i18n.translate(
   'xpack.securitySolution.entityAnalytics.threatHunting.leads.flyout.title',
   { defaultMessage: 'All Hunting Leads' }

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/threat_hunting/top_threat_hunting_leads/use_hunting_leads.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/threat_hunting/top_threat_hunting_leads/use_hunting_leads.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { useRef, useEffect } from 'react';
+import { useRef, useEffect, useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@kbn/react-query';
 import { useAppToasts } from '../../../../common/hooks/use_app_toasts';
 import { useEntityAnalyticsRoutes } from '../../../api/api';
@@ -13,8 +13,7 @@ import { fromApiLead } from './types';
 import * as i18n from './translations';
 
 const HUNTING_LEADS_QUERY_KEY = 'hunting-leads';
-const POLL_INTERVAL_MS = 2_000;
-const POLL_TIMEOUT_MS = 120_000;
+const INDEX_REFRESH_DELAY_MS = 2_000;
 
 const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -30,7 +29,7 @@ const FETCH_LEADS_PARAMS = {
   },
 };
 
-export const useHuntingLeads = () => {
+export const useHuntingLeads = (isEnabled: boolean = true) => {
   const {
     fetchLeads,
     generateLeads: generateLeadsApi,
@@ -41,6 +40,7 @@ export const useHuntingLeads = () => {
   const queryClient = useQueryClient();
   const { addSuccess, addError } = useAppToasts();
   const abortCtrl = useRef(new AbortController());
+  const [hasGenerated, setHasGenerated] = useState(false);
 
   useEffect(() => {
     return () => {
@@ -51,6 +51,7 @@ export const useHuntingLeads = () => {
   const { data, isLoading, refetch } = useQuery({
     queryKey: [HUNTING_LEADS_QUERY_KEY],
     queryFn: ({ signal }) => fetchLeads({ signal, ...FETCH_LEADS_PARAMS }),
+    enabled: isEnabled,
   });
 
   const { mutate: generate, isLoading: isGenerating } = useMutation({
@@ -60,20 +61,15 @@ export const useHuntingLeads = () => {
 
       await generateLeadsApi({ params: {} });
 
-      const deadline = Date.now() + POLL_TIMEOUT_MS;
-      while (Date.now() < deadline) {
-        if (signal.aborted) return;
-        await delay(POLL_INTERVAL_MS);
-        if (signal.aborted) return;
-        const result = await fetchLeads({ ...FETCH_LEADS_PARAMS, signal });
-        if (result.leads && result.leads.length > 0) {
-          queryClient.setQueryData([HUNTING_LEADS_QUERY_KEY], result);
-          return;
-        }
-      }
-      await queryClient.invalidateQueries({ queryKey: [HUNTING_LEADS_QUERY_KEY] });
+      if (signal.aborted) return;
+      await delay(INDEX_REFRESH_DELAY_MS);
+      if (signal.aborted) return;
+
+      const result = await fetchLeads({ ...FETCH_LEADS_PARAMS, signal });
+      queryClient.setQueryData([HUNTING_LEADS_QUERY_KEY], result);
     },
     onSuccess: () => {
+      setHasGenerated(true);
       addSuccess(i18n.GENERATE_SUCCESS);
     },
     onError: (error: Error) => {
@@ -84,6 +80,7 @@ export const useHuntingLeads = () => {
   const { data: statusData } = useQuery({
     queryKey: [LEAD_SCHEDULE_QUERY_KEY],
     queryFn: ({ signal }) => fetchLeadGenerationStatus({ signal }),
+    enabled: isEnabled,
   });
 
   const { mutate: toggleSchedule } = useMutation({
@@ -92,11 +89,14 @@ export const useHuntingLeads = () => {
     onError: (error: Error) => addError(error, { title: i18n.SCHEDULE_UPDATE_ERROR }),
   });
 
+  const hasEverGenerated = hasGenerated || statusData?.lastRun != null;
+
   return {
     leads: data?.leads?.map(fromApiLead) ?? [],
     totalCount: data?.total ?? 0,
     isLoading,
     isGenerating,
+    hasGenerated: hasEverGenerated,
     generate,
     refetch,
     isScheduled: statusData?.isEnabled ?? false,

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/pages/entity_analytics_home_page.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/pages/entity_analytics_home_page.tsx
@@ -66,6 +66,7 @@ export const EntityAnalyticsHomePage = () => {
     sourcererDataView: oldSourcererDataViewSpec,
   } = useSourcererDataView();
   const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
+  const leadGenerationEnabled = useIsExperimentalFeatureEnabled('leadGenerationEnabled');
   const leadDetailsEnabled = useIsExperimentalFeatureEnabled('leadGenerationDetailsEnabled');
   const { dataView, status } = useDataView(PageScope.explore);
 
@@ -74,10 +75,11 @@ export const EntityAnalyticsHomePage = () => {
     totalCount,
     isLoading: isLeadsLoading,
     isGenerating,
+    hasGenerated,
     generate,
     isScheduled,
     toggleSchedule,
-  } = useHuntingLeads();
+  } = useHuntingLeads(leadGenerationEnabled);
   const openAgentBuilderWithLead = useLeadAttachment();
 
   const [isFlyoutOpen, setIsFlyoutOpen] = useState(false);
@@ -184,21 +186,24 @@ export const EntityAnalyticsHomePage = () => {
           <EuiLoadingSpinner size="l" data-test-subj="entityAnalyticsHomePageLoader" />
         ) : (
           <EuiFlexGroup direction="column" gutterSize="l">
-            <EuiFlexItem>
-              <TopThreatHuntingLeads
-                leads={leads}
-                totalCount={totalCount}
-                isLoading={isLeadsLoading}
-                isGenerating={isGenerating}
-                onSeeAll={handleOpenFlyout}
-                onLeadClick={handleOpenLeadInChat}
-                onHuntInChat={handleHuntInChat}
-                onLeadInfoClick={leadDetailsEnabled ? handleLeadInfoClick : undefined}
-                onGenerate={generate}
-                isScheduled={isScheduled}
-                onToggleSchedule={toggleSchedule}
-              />
-            </EuiFlexItem>
+            {leadGenerationEnabled && (
+              <EuiFlexItem>
+                <TopThreatHuntingLeads
+                  leads={leads}
+                  totalCount={totalCount}
+                  isLoading={isLeadsLoading}
+                  isGenerating={isGenerating}
+                  hasGenerated={hasGenerated}
+                  onSeeAll={handleOpenFlyout}
+                  onLeadClick={handleOpenLeadInChat}
+                  onHuntInChat={handleHuntInChat}
+                  onLeadInfoClick={leadDetailsEnabled ? handleLeadInfoClick : undefined}
+                  onGenerate={generate}
+                  isScheduled={isScheduled}
+                  onToggleSchedule={toggleSchedule}
+                />
+              </EuiFlexItem>
+            )}
 
             <EuiFlexItem>
               <EuiFlexGroup
@@ -232,7 +237,7 @@ export const EntityAnalyticsHomePage = () => {
         )}
       </SecuritySolutionPageWrapper>
 
-      {isFlyoutOpen && (
+      {leadGenerationEnabled && isFlyoutOpen && (
         <ThreatHuntingLeadsFlyout
           onClose={handleCloseFlyout}
           onSelectLead={handleOpenLeadInChat}
@@ -240,7 +245,7 @@ export const EntityAnalyticsHomePage = () => {
         />
       )}
 
-      {provenanceLead && (
+      {leadGenerationEnabled && provenanceLead && (
         <LeadProvenanceFlyout
           lead={provenanceLead}
           onClose={handleCloseProvenance}


### PR DESCRIPTION
## Summary

Adding following capabilities to the lead generation.
1. Entity leads new index : `.entity-analytics.entity-leads-${mode}.entity-${spaceId}` instead of `.internal.${mode}.entity-analytics.entity-leads.entity-${spaceId}` because the older index name won't match existing `.entity-analytics.*` wildcard patterns that customers might already have in their roles.
2. Added a new state in the UI when no data is found for leads.
<img width="1687" height="343" alt="image" src="https://github.com/user-attachments/assets/b707374b-e9ef-4b54-88f8-b5ccaace581d" />
3.Fixed a bug where the check for ff `leadGenerationEnabled` did not happen in the UI which resulted in an unexpected UI state.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.




