### PR TITLE
[Agent Builder] Center text in agent avatar

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/common/agent_avatar.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/common/agent_avatar.tsx
@@ -87,6 +87,7 @@ export const AgentAvatar: React.FC<AgentAvatarProps> = (props) => {
   const shouldUseIcon = !symbol && (isBuiltIn || isDefaultAgent || Boolean(icon));
 
   const borderAndShapeStyles = css`
+    line-height: 1;
     border: 1px solid ${euiTheme.colors.borderBaseSubdued};
     ${shape === 'circle' ? 'border-radius: 50%;' : roundedBorderRadiusStyles}
   `;
@@ -100,7 +101,7 @@ export const AgentAvatar: React.FC<AgentAvatarProps> = (props) => {
     `;
     return (
       <EuiPanel hasBorder={false} hasShadow={false} css={panelStyles} paddingSize="xs">
-        <EuiIcon type={iconType} size={iconSize} />
+        <EuiIcon type={iconType} size={iconSize} aria-hidden={true} />
       </EuiPanel>
     );
   }


### PR DESCRIPTION
## Summary

Before:
<img width="180" height="142" alt="image" src="https://github.com/user-attachments/assets/bc4620b6-6731-4c46-956b-9ef15f9b6195" />

After
<img width="175" height="151" alt="image" src="https://github.com/user-attachments/assets/14f8178a-d4b2-4595-a6b6-0e8a6c41bb53" />

https://github.com/user-attachments/assets/b2b63c67-274f-476d-b525-ae1e6658636d





