### PR TITLE
[skip ci][scout] fix cps config for oblt project

### DIFF
--- a/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/cps_local/serverless/observability_complete.serverless.config.ts
+++ b/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/cps_local/serverless/observability_complete.serverless.config.ts
@@ -30,4 +30,12 @@ export const servers: ScoutServerConfig = {
     uiam: true,
     cps: true,
   },
+  kbnTestServer: {
+    ...uiamConfig.kbnTestServer,
+    serverArgs: [
+      ...uiamConfig.kbnTestServer.serverArgs,
+      '--cps.cpsEnabled=true',
+      '--xpack.alerting.rules.apiKeyType=uiam',
+    ],
+  },
 };


### PR DESCRIPTION
## Summary

Copying changes made in https://github.com/elastic/kibana/pull/259856 to `observability_complete`

<img width="1855" height="779" alt="Screenshot 2026-04-08 at 13 23 31" src="https://github.com/user-attachments/assets/f5eb6232-5cac-446b-95ec-02662e8cd5ef" />


Tested locally: 

```
node scripts/scout start-server --arch serverless --domain observability_complete --serverConfigSet cps_local
```



