### PR TITLE
[FeatureBranch/DoNotReview][Chrome Next] Add global search modal

### DIFF
--- a/src/core/packages/chrome/browser-components/src/project/sidenav/navigation/to_chrome_tool_slots.ts
+++ b/src/core/packages/chrome/browser-components/src/project/sidenav/navigation/to_chrome_tool_slots.ts
@@ -52,6 +52,7 @@ const getHeaderTools = (
       }),
       iconType: 'search',
       onClick: globalSearch.onClick,
+      shortcutKey: globalSearch.shortcutKey,
     });
   }
 

--- a/src/core/packages/chrome/browser/src/chrome_next/global_search.ts
+++ b/src/core/packages/chrome/browser/src/chrome_next/global_search.ts
@@ -13,4 +13,6 @@
 export interface ChromeNextGlobalSearchConfig {
   /** Called when the search icon button in the sidenav is clicked. */
   onClick: () => void;
+  /** The keyboard shortcut key to trigger the global search modal. */
+  shortcutKey?: string;
 }

--- a/src/core/packages/chrome/navigation/packaging/react/types.ts
+++ b/src/core/packages/chrome/navigation/packaging/react/types.ts
@@ -91,6 +91,7 @@ export interface ToolItem {
   popoverWidth?: number | string;
   badgeType?: BadgeType;
   'data-test-subj'?: string;
+  shortcutKey?: string;
 }
 
 /**

--- a/src/core/packages/chrome/navigation/src/components/navigation.tsx
+++ b/src/core/packages/chrome/navigation/src/components/navigation.tsx
@@ -44,6 +44,7 @@ import { useNavigation } from '../hooks/use_navigation';
 import { useNewItems } from '../hooks/use_new_items';
 import { useResponsiveMenu } from '../hooks/use_responsive_menu';
 import { getHighContrastSeparator } from '../hooks/use_high_contrast_mode_styles';
+import { useToolShortcuts } from '../hooks/use_tool_shortcuts';
 
 const navigationWrapperStyles = css`
   display: flex;
@@ -165,6 +166,8 @@ export const Navigation = ({
   const hasHeaderTools = headerTools.length > 0;
   const hasFooterTools = footerTools.length > 0;
   const showFooterToolbar = hasFooterTools || Boolean(collapseToggle);
+
+  useToolShortcuts({ tools: [...headerTools, ...footerTools] });
 
   const topSectionStyles = useMemo(() => getTopSectionStyles(euiThemeContext), [euiThemeContext]);
 
@@ -612,7 +615,15 @@ const renderToolItems = ({
   popoverItemPrefix,
 }: RenderToolItemsArgs) =>
   items.map((item) => {
-    const { onClick: itemOnClick, sections, renderContent, renderPopover, popoverWidth, ...itemProps } = item;
+    const {
+      onClick: itemOnClick,
+      sections,
+      renderContent,
+      renderPopover,
+      popoverWidth,
+      shortcutKey,
+      ...itemProps
+    } = item;
     const hasPopoverContent = getHasSubmenu(item);
     return (
       <SideNav.Popover

--- a/src/core/packages/chrome/navigation/src/components/navigation.tsx
+++ b/src/core/packages/chrome/navigation/src/components/navigation.tsx
@@ -46,6 +46,8 @@ import { useResponsiveMenu } from '../hooks/use_responsive_menu';
 import { getHighContrastSeparator } from '../hooks/use_high_contrast_mode_styles';
 import { useToolShortcuts } from '../hooks/use_tool_shortcuts';
 
+const EMPTY_TOOL_ITEMS: ToolItem[] = [];
+
 const navigationWrapperStyles = css`
   display: flex;
 `;
@@ -161,13 +163,14 @@ export const Navigation = ({
 
   const collapseToggle = onToggleCollapsed && !forcedCollapsed ? onToggleCollapsed : undefined;
 
-  const headerTools = tools?.headerTools ?? [];
-  const footerTools = tools?.footerTools ?? [];
+  const headerTools = tools?.headerTools ?? EMPTY_TOOL_ITEMS;
+  const footerTools = tools?.footerTools ?? EMPTY_TOOL_ITEMS;
   const hasHeaderTools = headerTools.length > 0;
   const hasFooterTools = footerTools.length > 0;
   const showFooterToolbar = hasFooterTools || Boolean(collapseToggle);
 
-  useToolShortcuts({ tools: [...headerTools, ...footerTools] });
+  const allTools = useMemo(() => [...headerTools, ...footerTools], [headerTools, footerTools]);
+  useToolShortcuts({ tools: allTools });
 
   const topSectionStyles = useMemo(() => getTopSectionStyles(euiThemeContext), [euiThemeContext]);
 

--- a/src/core/packages/chrome/navigation/src/hooks/use_tool_shortcuts.ts
+++ b/src/core/packages/chrome/navigation/src/hooks/use_tool_shortcuts.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { useCallback } from 'react';
+import useEvent from 'react-use/lib/useEvent';
+import { isMac } from '@kbn/shared-ux-utility';
+import type { ToolItem } from '../../types';
+
+/**
+ * Hook to handle keyboard shortcuts for tool items.
+ * @param tools - The tool items to handle shortcuts for.
+ */
+
+interface UseToolShortcutsProps {
+  tools: ToolItem[];
+}
+
+export const useToolShortcuts = ({ tools }: UseToolShortcutsProps) => {
+  const onKeyDown = useCallback(
+    (event: KeyboardEvent) => {
+      const toolWithShortcut = tools.find(
+        (tool) =>
+          tool.shortcutKey &&
+          event.key === tool.shortcutKey &&
+          (isMac ? event.metaKey : event.ctrlKey)
+      );
+      if (toolWithShortcut) {
+        event.preventDefault();
+        toolWithShortcut.onClick?.();
+      }
+    },
+    [tools]
+  );
+  useEvent('keydown', onKeyDown);
+};

--- a/src/core/packages/chrome/navigation/src/hooks/use_tool_shortcuts.ts
+++ b/src/core/packages/chrome/navigation/src/hooks/use_tool_shortcuts.ts
@@ -7,9 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { useCallback } from 'react';
-import useEvent from 'react-use/lib/useEvent';
-import { isMac } from '@kbn/shared-ux-utility';
+import { useCallback, useEffect } from 'react';
 import type { ToolItem } from '../../types';
 
 /**
@@ -20,6 +18,13 @@ import type { ToolItem } from '../../types';
 interface UseToolShortcutsProps {
   tools: ToolItem[];
 }
+
+const isMac = (() => {
+  if (typeof navigator === 'undefined') return false;
+  const nav = navigator as Navigator & { userAgentData?: { platform?: string } };
+  const platform = (nav.userAgentData?.platform ?? nav.userAgent ?? '').toLowerCase();
+  return platform.includes('mac');
+})();
 
 export const useToolShortcuts = ({ tools }: UseToolShortcutsProps) => {
   const onKeyDown = useCallback(
@@ -37,5 +42,9 @@ export const useToolShortcuts = ({ tools }: UseToolShortcutsProps) => {
     },
     [tools]
   );
-  useEvent('keydown', onKeyDown);
+
+  useEffect(() => {
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [onKeyDown]);
 };

--- a/src/core/packages/chrome/navigation/types.ts
+++ b/src/core/packages/chrome/navigation/types.ts
@@ -118,6 +118,7 @@ export interface ToolItem {
   popoverWidth?: number | string;
   badgeType?: BadgeType;
   'data-test-subj'?: string;
+  shortcutKey?: string;
 }
 
 /**

--- a/src/core/packages/overlays/browser/src/modal.ts
+++ b/src/core/packages/overlays/browser/src/modal.ts
@@ -68,4 +68,5 @@ export interface OverlayModalOpenOptions {
   'data-test-subj'?: string;
   maxWidth?: boolean | number | string;
   'aria-labelledby'?: EuiModalProps['aria-labelledby'];
+  outsideClickCloses?: boolean;
 }

--- a/x-pack/platform/plugins/private/global_search_bar/public/components/char_limit_exceeded_message.tsx
+++ b/x-pack/platform/plugins/private/global_search_bar/public/components/char_limit_exceeded_message.tsx
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { FormattedMessage } from '@kbn/i18n-react';
+import { EuiText } from '@elastic/eui';
+import React from 'react';
+import { SearchPlaceholder } from './search_placeholder';
+
+interface CharLimitExceededMessageProps {
+  basePathUrl: string;
+}
+
+export const CharLimitExceededMessage = ({ basePathUrl }: CharLimitExceededMessageProps) => {
+  const charLimitMessage = (
+    <>
+      <EuiText size="m">
+        <p data-test-subj="searchCharLimitExceededMessageHeading">
+          <FormattedMessage
+            id="xpack.globalSearchBar.searchBar.searchCharLimitExceededHeading"
+            defaultMessage="Search character limit exceeded"
+          />
+        </p>
+      </EuiText>
+      <p>
+        <FormattedMessage
+          id="xpack.globalSearchBar.searchBar.searchCharLimitExceeded"
+          defaultMessage="Try searching for applications, dashboards, visualizations, and more."
+        />
+      </p>
+    </>
+  );
+
+  return <SearchPlaceholder basePath={basePathUrl} customPlaceholderMessage={charLimitMessage} />;
+};

--- a/x-pack/platform/plugins/private/global_search_bar/public/components/empty_message.tsx
+++ b/x-pack/platform/plugins/private/global_search_bar/public/components/empty_message.tsx
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiFlexItem, EuiLoadingSpinner } from '@elastic/eui';
+
+import { EuiFlexGroup } from '@elastic/eui';
+import { css } from '@emotion/react';
+import React from 'react';
+
+export const EmptyMessage = () => {
+  return (
+    <EuiFlexGroup
+      alignItems="center"
+      direction="column"
+      justifyContent="center"
+      css={css`
+        min-height: 300px;
+      `}
+    >
+      <EuiFlexItem grow={false}>
+        <EuiLoadingSpinner size="xl" />
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+};

--- a/x-pack/platform/plugins/private/global_search_bar/public/components/search_bar.tsx
+++ b/x-pack/platform/plugins/private/global_search_bar/public/components/search_bar.tsx
@@ -5,16 +5,11 @@
  * 2.0.
  */
 
-import type { EuiSelectableTemplateSitewideOption } from '@elastic/eui';
 import {
   EuiButtonIcon,
-  EuiFlexGroup,
-  EuiFlexItem,
   EuiFormLabel,
   EuiHeaderSectionItemButton,
   EuiIcon,
-  EuiText,
-  EuiLoadingSpinner,
   EuiSelectableTemplateSitewide,
   euiSelectableTemplateSitewideRenderOptions,
   useEuiTheme,
@@ -22,72 +17,28 @@ import {
   mathWithUnits,
   useEuiMinBreakpoint,
 } from '@elastic/eui';
-import type { EuiSelectableOnChangeEvent } from '@elastic/eui/src/components/selectable/selectable';
 import { css } from '@emotion/react';
-import { FormattedMessage } from '@kbn/i18n-react';
-import type { GlobalSearchFindParams, GlobalSearchResult } from '@kbn/global-search-plugin/public';
-import type { FC } from 'react';
-import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { apm } from '@elastic/apm-rum';
-import useDebounce from 'react-use/lib/useDebounce';
+import React, { useCallback, useRef, useState } from 'react';
 import useEvent from 'react-use/lib/useEvent';
-import useMountedState from 'react-use/lib/useMountedState';
 import useObservable from 'react-use/lib/useObservable';
-import type { Subscription } from 'rxjs';
 import { isMac } from '@kbn/shared-ux-utility';
-import { blurEvent, sort } from '.';
-import { resultToOption, suggestionToOption } from '../lib';
-import { parseSearchParams } from '../search_syntax';
 import { i18nStrings } from '../strings';
-import type { SearchSuggestion } from '../suggestions';
-import { getSuggestions } from '../suggestions';
-import { PopoverFooter } from './popover_footer';
-import { PopoverPlaceholder } from './popover_placeholder';
+import { SearchFooter } from './search_footer';
+import { SearchPlaceholder } from './search_placeholder';
+import { useSearchState } from '../hooks/use_search_state';
+import { EmptyMessage } from './empty_message';
+import { CharLimitExceededMessage } from './char_limit_exceeded_message';
+import { blurEvent } from '.';
 import type { SearchBarProps } from './types';
 
-const SearchCharLimitExceededMessage = (props: { basePathUrl: string }) => {
-  const charLimitMessage = (
-    <>
-      <EuiText size="m">
-        <p data-test-subj="searchCharLimitExceededMessageHeading">
-          <FormattedMessage
-            id="xpack.globalSearchBar.searchBar.searchCharLimitExceededHeading"
-            defaultMessage="Search character limit exceeded"
-          />
-        </p>
-      </EuiText>
-      <p>
-        <FormattedMessage
-          id="xpack.globalSearchBar.searchBar.searchCharLimitExceeded"
-          defaultMessage="Try searching for applications, dashboards, visualizations, and more."
-        />
-      </p>
-    </>
-  );
-
-  return (
-    <PopoverPlaceholder basePath={props.basePathUrl} customPlaceholderMessage={charLimitMessage} />
-  );
-};
-
-const EmptyMessage = () => (
-  <EuiFlexGroup
-    direction="column"
-    justifyContent="center"
-    css={css`
-      min-height: 300px;
-    `}
-  >
-    <EuiFlexItem grow={false}>
-      <EuiLoadingSpinner size="xl" />
-    </EuiFlexItem>
-  </EuiFlexGroup>
-);
-
-export const SearchBar: FC<SearchBarProps> = (opts) => {
-  const { globalSearch, taggingApi, navigateToUrl, reportEvent, chromeStyle$, ...props } = opts;
-
-  const isMounted = useMountedState();
+export const SearchBar = ({
+  globalSearch,
+  taggingApi,
+  navigateToUrl,
+  reportEvent,
+  chromeStyle$,
+  basePathUrl,
+}: SearchBarProps) => {
   const { euiTheme } = useEuiTheme();
   const chromeStyle = useObservable(chromeStyle$);
 
@@ -95,18 +46,32 @@ export const SearchBar: FC<SearchBarProps> = (opts) => {
   const [isVisible, setIsVisible] = useState(false);
   const visibilityButtonRef = useRef<HTMLButtonElement | null>(null);
 
-  // General hooks
-  const [initialLoad, setInitialLoad] = useState(false);
-  const [searchValue, setSearchValue] = useState<string>('');
-  const [searchRef, setSearchRef] = useState<HTMLInputElement | null>(null);
   const [buttonRef, setButtonRef] = useState<HTMLDivElement | null>(null);
-  const searchSubscription = useRef<Subscription | null>(null);
-  const [options, setOptions] = useState<EuiSelectableTemplateSitewideOption[]>([]);
-  const [searchableTypes, setSearchableTypes] = useState<string[]>([]);
   const [showAppend, setShowAppend] = useState<boolean>(true);
-  const UNKNOWN_TAG_ID = '__unknown__';
-  const [isLoading, setIsLoading] = useState<boolean>(false);
-  const [searchCharLimitExceeded, setSearchCharLimitExceeded] = useState(false);
+
+  const {
+    searchValue,
+    setSearchValue,
+    options,
+    isLoading,
+    searchCharLimitExceeded,
+    onChange,
+    setSearchRef,
+    searchRef,
+    triggerInitialLoad,
+  } = useSearchState({
+    globalSearch,
+    taggingApi,
+    navigateToUrl,
+    reportEvent,
+    onResultSelect: () => {
+      (document.activeElement as HTMLElement).blur();
+      if (searchRef.current) {
+        setSearchValue('');
+        searchRef.current.dispatchEvent(blurEvent);
+      }
+    },
+  });
 
   const styles = css({
     [useEuiBreakpoint(['m', 'l'])]: {
@@ -116,130 +81,6 @@ export const SearchBar: FC<SearchBarProps> = (opts) => {
       width: mathWithUnits(euiTheme.size.xxl, (x) => x * 15),
     },
   });
-  // Initialize searchableTypes data
-  useEffect(() => {
-    if (initialLoad) {
-      const fetch = async () => {
-        const types = await globalSearch.getSearchableTypes();
-        setSearchableTypes(types);
-      };
-      fetch();
-    }
-  }, [globalSearch, initialLoad]);
-
-  // Whenever searchValue changes, isLoading = true
-  useEffect(() => {
-    setIsLoading(true);
-  }, [searchValue]);
-
-  const loadSuggestions = useCallback(
-    (term: string) => {
-      return getSuggestions({
-        searchTerm: term,
-        searchableTypes,
-        tagCache: taggingApi?.cache,
-      });
-    },
-    [taggingApi, searchableTypes]
-  );
-
-  const setDecoratedOptions = useCallback(
-    (
-      _options: GlobalSearchResult[],
-      suggestions: SearchSuggestion[],
-      searchTagIds: string[] = []
-    ) => {
-      setOptions([
-        ...suggestions.map(suggestionToOption),
-        ..._options.map((option) =>
-          resultToOption(
-            option,
-            searchTagIds?.filter((id) => id !== UNKNOWN_TAG_ID) ?? [],
-            taggingApi?.ui.getTagList
-          )
-        ),
-      ]);
-    },
-    [setOptions, taggingApi]
-  );
-
-  useDebounce(
-    () => {
-      if (initialLoad) {
-        // cancel pending search if not completed yet
-        if (searchSubscription.current) {
-          searchSubscription.current.unsubscribe();
-          searchSubscription.current = null;
-        }
-
-        if (searchValue.length > globalSearch.searchCharLimit) {
-          // setting this will display an error message to the user
-          setSearchCharLimitExceeded(true);
-          return;
-        } else {
-          setSearchCharLimitExceeded(false);
-        }
-
-        const suggestions = loadSuggestions(searchValue.toLowerCase());
-
-        let aggregatedResults: GlobalSearchResult[] = [];
-
-        if (searchValue.length !== 0) {
-          reportEvent.searchRequest();
-        }
-
-        const rawParams = parseSearchParams(searchValue.toLowerCase(), searchableTypes);
-        let tagIds: string[] | undefined;
-        if (taggingApi && rawParams.filters.tags) {
-          tagIds = rawParams.filters.tags.map(
-            (tagName) => taggingApi.ui.getTagIdFromName(tagName) ?? UNKNOWN_TAG_ID
-          );
-        } else {
-          tagIds = undefined;
-        }
-        const searchParams: GlobalSearchFindParams = {
-          term: rawParams.term,
-          types: rawParams.filters.types,
-          tags: tagIds,
-        };
-
-        searchSubscription.current = globalSearch.find(searchParams, {}).subscribe({
-          next: ({ results }) => {
-            if (!isMounted()) {
-              return;
-            }
-
-            if (searchValue.length > 0) {
-              aggregatedResults = [...results, ...aggregatedResults].sort(sort.byScore);
-              setDecoratedOptions(aggregatedResults, suggestions, searchParams.tags);
-              return;
-            }
-
-            // if searchbar is empty, filter to only applications and sort alphabetically
-            results = results.filter(({ type }: GlobalSearchResult) => type === 'application');
-            aggregatedResults = [...results, ...aggregatedResults].sort(sort.byTitle);
-            setDecoratedOptions(aggregatedResults, suggestions, searchParams.tags);
-          },
-          error: (err) => {
-            setIsLoading(false);
-
-            // Not doing anything on error right now because it'll either just show the previous
-            // results or empty results which is basically what we want anyways
-            apm.captureError(err, {
-              labels: {
-                SearchValue: searchValue,
-              },
-            });
-          },
-          complete: () => {
-            setIsLoading(false);
-          },
-        });
-      }
-    },
-    350,
-    [searchValue, loadSuggestions, searchableTypes, initialLoad]
-  );
 
   const onKeyDown = useCallback(
     (event: KeyboardEvent) => {
@@ -248,8 +89,8 @@ export const SearchBar: FC<SearchBarProps> = (opts) => {
         reportEvent.shortcutUsed();
         if (chromeStyle === 'project' && !isVisible) {
           visibilityButtonRef.current?.click();
-        } else if (searchRef) {
-          searchRef.focus();
+        } else if (searchRef.current) {
+          searchRef.current.focus();
         } else if (buttonRef) {
           (buttonRef.children[0] as HTMLButtonElement).click();
         }
@@ -257,81 +98,6 @@ export const SearchBar: FC<SearchBarProps> = (opts) => {
     },
     [chromeStyle, isVisible, buttonRef, searchRef, reportEvent]
   );
-
-  const onChange = useCallback(
-    (selection: EuiSelectableTemplateSitewideOption[], event: EuiSelectableOnChangeEvent) => {
-      let selectedRank: number | null = null;
-      const selected = selection.find(({ checked }, rank) => {
-        const isChecked = checked === 'on';
-        if (isChecked) {
-          selectedRank = rank + 1;
-        }
-        return isChecked;
-      });
-
-      if (!selected) {
-        return;
-      }
-
-      const selectedLabel = selected.label ?? null;
-
-      // @ts-ignore - ts error is "union type is too complex to express"
-      const { url, type, suggestion } = selected;
-
-      // if the type is a suggestion, we change the query on the input and trigger a new search
-      // by setting the searchValue (only setting the field value does not trigger a search)
-      if (type === '__suggestion__') {
-        setSearchValue(suggestion);
-        return;
-      }
-
-      // errors in tracking should not prevent selection behavior
-      try {
-        if (type === 'application') {
-          const key = selected.key ?? 'unknown';
-          const application = `${key.toLowerCase().replaceAll(' ', '_')}`;
-          reportEvent.navigateToApplication({
-            application,
-            searchValue,
-            selectedLabel,
-            selectedRank,
-          });
-        } else {
-          reportEvent.navigateToSavedObject({
-            type,
-            searchValue,
-            selectedLabel,
-            selectedRank,
-          });
-        }
-      } catch (err) {
-        apm.captureError(err, {
-          labels: {
-            SearchValue: searchValue,
-          },
-        });
-        // eslint-disable-next-line no-console
-        console.log('Error trying to track searchbar metrics', err);
-      }
-
-      if (event.shiftKey) {
-        window.open(url);
-      } else if (event.ctrlKey || event.metaKey) {
-        window.open(url, '_blank');
-      } else {
-        navigateToUrl(url);
-      }
-
-      (document.activeElement as HTMLElement).blur();
-      if (searchRef) {
-        clearField();
-        searchRef.dispatchEvent(blurEvent);
-      }
-    },
-    [reportEvent, navigateToUrl, searchRef, searchValue]
-  );
-
-  const clearField = () => setSearchValue('');
 
   const keyboardShortcutTooltip = `${i18nStrings.keyboardShortcutTooltip.prefix}: ${
     isMac ? i18nStrings.keyboardShortcutTooltip.onMac : i18nStrings.keyboardShortcutTooltip.onNotMac
@@ -411,7 +177,7 @@ export const SearchBar: FC<SearchBarProps> = (opts) => {
         placeholder: i18nStrings.placeholderText,
         onFocus: () => {
           reportEvent.searchFocus();
-          setInitialLoad(true);
+          triggerInitialLoad();
           setShowAppend(false);
         },
         onBlur: () => {
@@ -421,9 +187,11 @@ export const SearchBar: FC<SearchBarProps> = (opts) => {
         fullWidth: true,
         append: getAppendForChromeStyle(),
       }}
-      errorMessage={searchCharLimitExceeded ? <SearchCharLimitExceededMessage {...props} /> : null}
+      errorMessage={
+        searchCharLimitExceeded ? <CharLimitExceededMessage basePathUrl={basePathUrl} /> : null
+      }
       emptyMessage={<EmptyMessage />}
-      noMatchesMessage={<PopoverPlaceholder basePath={props.basePathUrl} />}
+      noMatchesMessage={<SearchPlaceholder basePath={basePathUrl} />}
       popoverProps={{
         zIndex: Number(euiTheme.levels.navigation),
         'data-test-subj': 'nav-search-popover',
@@ -437,7 +205,7 @@ export const SearchBar: FC<SearchBarProps> = (opts) => {
           <EuiIcon type="magnify" size="m" aria-hidden={true} />
         </EuiHeaderSectionItemButton>
       }
-      popoverFooter={<PopoverFooter />}
+      popoverFooter={<SearchFooter />}
     />
   );
 };

--- a/x-pack/platform/plugins/private/global_search_bar/public/components/search_footer.tsx
+++ b/x-pack/platform/plugins/private/global_search_bar/public/components/search_footer.tsx
@@ -5,13 +5,16 @@
  * 2.0.
  */
 
-import type { FC } from 'react';
 import React from 'react';
 import { EuiCode, EuiFlexGroup, EuiFlexItem, EuiText } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { isMac } from '@kbn/shared-ux-utility';
 
-export const PopoverFooter: FC = () => {
+interface SearchFooterProps {
+  shortcutKey?: string;
+}
+
+export const SearchFooter = ({ shortcutKey = '/' }: SearchFooterProps) => {
   return (
     <EuiFlexGroup
       alignItems="center"
@@ -56,12 +59,14 @@ export const PopoverFooter: FC = () => {
                     {isMac ? (
                       <FormattedMessage
                         id="xpack.globalSearchBar.searchBar.shortcutDescription.macCommandDescription"
-                        defaultMessage="Command + /"
+                        defaultMessage="Command + {key}"
+                        values={{ key: shortcutKey }}
                       />
                     ) : (
                       <FormattedMessage
                         id="xpack.globalSearchBar.searchBar.shortcutDescription.windowsCommandDescription"
-                        defaultMessage="Control + /"
+                        defaultMessage="Control + {key}"
+                        values={{ key: shortcutKey }}
                       />
                     )}
                   </EuiCode>

--- a/x-pack/platform/plugins/private/global_search_bar/public/components/search_modal.tsx
+++ b/x-pack/platform/plugins/private/global_search_bar/public/components/search_modal.tsx
@@ -1,0 +1,165 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  EuiHorizontalRule,
+  EuiIcon,
+  EuiModalBody,
+  EuiModalFooter,
+  EuiModalHeader,
+  EuiSelectable,
+  euiSelectableTemplateSitewideRenderOptions,
+  useEuiTheme,
+} from '@elastic/eui';
+import { css, Global } from '@emotion/react';
+import React, { useEffect } from 'react';
+import { i18nStrings } from '../strings';
+import { SearchFooter } from './search_footer';
+import { SearchPlaceholder } from './search_placeholder';
+import { useSearchState } from '../hooks/use_search_state';
+import type { SearchModalProps } from './types';
+import { EmptyMessage } from './empty_message';
+import {
+  SEARCH_MODAL_HEIGHT,
+  SEARCH_MODAL_KEYBOARD_SHORTCUT,
+  SEARCH_MODAL_ROW_HEIGHT,
+  SEARCH_MODAL_SELECTOR_PREFIX,
+  SEARCH_MODAL_WIDTH,
+} from './types';
+import { CharLimitExceededMessage } from './char_limit_exceeded_message';
+
+export const SearchModal = ({
+  globalSearch,
+  taggingApi,
+  navigateToUrl,
+  reportEvent,
+  basePathUrl,
+  onClose,
+}: SearchModalProps) => {
+  const { euiTheme } = useEuiTheme();
+  const {
+    searchValue,
+    setSearchValue,
+    options,
+    isLoading,
+    searchCharLimitExceeded,
+    onChange,
+    setSearchRef,
+    triggerInitialLoad,
+  } = useSearchState({
+    globalSearch,
+    taggingApi,
+    navigateToUrl,
+    reportEvent,
+    onResultSelect: onClose,
+  });
+
+  useEffect(() => {
+    triggerInitialLoad();
+    reportEvent.searchFocus();
+    return () => {
+      reportEvent.searchBlur();
+    };
+  }, [triggerInitialLoad, reportEvent]);
+
+  const formattedOptions = options.map((option) => ({
+    ...option,
+    prepend: option.icon ? <EuiIcon color="subdued" size="l" {...option.icon} /> : option.prepend,
+  }));
+
+  const modalOverlayStyles = css`
+    .${SEARCH_MODAL_SELECTOR_PREFIX} {
+      block-size: ${SEARCH_MODAL_HEIGHT}vh;
+      inline-size: ${SEARCH_MODAL_WIDTH}px;
+
+      .euiModal__closeIcon {
+        display: none;
+      }
+    }
+  `;
+
+  const selectableStyles = css`
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 auto;
+    overflow: hidden;
+  `;
+
+  const headerStyles = css`
+    padding-block: ${euiTheme.size.base};
+    padding-inline: ${euiTheme.size.base};
+  `;
+
+  const bodyStyles = css`
+    .euiModalBody__overflow {
+      padding-inline: 0;
+      padding-block: 0;
+      display: flex;
+      flex-direction: column;
+      justify-content: ${isLoading || options.length === 0 ? 'center' : 'flex-start'};
+    }
+  `;
+
+  const footerStyles = css`
+    padding-block: ${euiTheme.size.s};
+    padding-inline: ${euiTheme.size.base};
+  `;
+
+  return (
+    <>
+      <Global styles={modalOverlayStyles} />
+      <EuiSelectable
+        css={selectableStyles}
+        isLoading={isLoading}
+        isPreFiltered
+        onChange={onChange}
+        options={formattedOptions}
+        singleSelection={true}
+        renderOption={(option) => euiSelectableTemplateSitewideRenderOptions(option, searchValue)}
+        listProps={{
+          rowHeight: SEARCH_MODAL_ROW_HEIGHT,
+          showIcons: false,
+        }}
+        searchProps={{
+          autoFocus: true,
+          value: searchValue,
+          onInput: (e: React.UIEvent<HTMLInputElement>) => setSearchValue(e.currentTarget.value),
+          'data-test-subj': `${SEARCH_MODAL_SELECTOR_PREFIX}Input`,
+          inputRef: setSearchRef,
+          compressed: false,
+          'aria-label': i18nStrings.placeholderText,
+          placeholder: i18nStrings.placeholderText,
+          fullWidth: true,
+          isClearable: true,
+        }}
+        noMatchesMessage={
+          searchCharLimitExceeded ? undefined : <SearchPlaceholder basePath={basePathUrl} />
+        }
+        searchable
+        emptyMessage={<EmptyMessage />}
+      >
+        {(list, search) => (
+          <>
+            <EuiModalHeader css={headerStyles}>{search}</EuiModalHeader>
+            <EuiHorizontalRule margin="none" />
+            <EuiModalBody css={bodyStyles}>
+              {searchCharLimitExceeded ? (
+                <CharLimitExceededMessage basePathUrl={basePathUrl} />
+              ) : (
+                list
+              )}
+            </EuiModalBody>
+            <EuiHorizontalRule margin="none" />
+            <EuiModalFooter css={footerStyles}>
+              <SearchFooter shortcutKey={SEARCH_MODAL_KEYBOARD_SHORTCUT.toUpperCase()} />
+            </EuiModalFooter>
+          </>
+        )}
+      </EuiSelectable>
+    </>
+  );
+};

--- a/x-pack/platform/plugins/private/global_search_bar/public/components/search_modal.tsx
+++ b/x-pack/platform/plugins/private/global_search_bar/public/components/search_modal.tsx
@@ -5,161 +5,39 @@
  * 2.0.
  */
 
-import {
-  EuiHorizontalRule,
-  EuiIcon,
-  EuiModalBody,
-  EuiModalFooter,
-  EuiModalHeader,
-  EuiSelectable,
-  euiSelectableTemplateSitewideRenderOptions,
-  useEuiTheme,
-} from '@elastic/eui';
+import React from 'react';
 import { css, Global } from '@emotion/react';
-import React, { useEffect } from 'react';
-import { i18nStrings } from '../strings';
-import { SearchFooter } from './search_footer';
-import { SearchPlaceholder } from './search_placeholder';
-import { useSearchState } from '../hooks/use_search_state';
+import { dynamic } from '@kbn/shared-ux-utility';
+import { EuiLoadingSpinner, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import type { SearchModalProps } from './types';
-import { EmptyMessage } from './empty_message';
-import {
-  SEARCH_MODAL_HEIGHT,
-  SEARCH_MODAL_KEYBOARD_SHORTCUT,
-  SEARCH_MODAL_ROW_HEIGHT,
-  SEARCH_MODAL_SELECTOR_PREFIX,
-  SEARCH_MODAL_WIDTH,
-} from './types';
-import { CharLimitExceededMessage } from './char_limit_exceeded_message';
+import { SEARCH_MODAL_SELECTOR_PREFIX, SEARCH_MODAL_HEIGHT, SEARCH_MODAL_WIDTH } from './types';
 
-export const SearchModal = ({
-  globalSearch,
-  taggingApi,
-  navigateToUrl,
-  reportEvent,
-  basePathUrl,
-  onClose,
-}: SearchModalProps) => {
-  const { euiTheme } = useEuiTheme();
-  const {
-    searchValue,
-    setSearchValue,
-    options,
-    isLoading,
-    searchCharLimitExceeded,
-    onChange,
-    setSearchRef,
-    triggerInitialLoad,
-  } = useSearchState({
-    globalSearch,
-    taggingApi,
-    navigateToUrl,
-    reportEvent,
-    onResultSelect: onClose,
-  });
+const modalOverlayStyles = css`
+  .${SEARCH_MODAL_SELECTOR_PREFIX} {
+    block-size: ${SEARCH_MODAL_HEIGHT}vh;
+    inline-size: ${SEARCH_MODAL_WIDTH}px;
 
-  useEffect(() => {
-    triggerInitialLoad();
-    reportEvent.searchFocus();
-    return () => {
-      reportEvent.searchBlur();
-    };
-  }, [triggerInitialLoad, reportEvent]);
-
-  const formattedOptions = options.map((option) => ({
-    ...option,
-    prepend: option.icon ? <EuiIcon color="subdued" size="l" {...option.icon} /> : option.prepend,
-  }));
-
-  const modalOverlayStyles = css`
-    .${SEARCH_MODAL_SELECTOR_PREFIX} {
-      block-size: ${SEARCH_MODAL_HEIGHT}vh;
-      inline-size: ${SEARCH_MODAL_WIDTH}px;
-
-      .euiModal__closeIcon {
-        display: none;
-      }
+    .euiModal__closeIcon {
+      display: none;
     }
-  `;
+  }
+`;
 
-  const selectableStyles = css`
-    display: flex;
-    flex-direction: column;
-    flex: 1 1 auto;
-    overflow: hidden;
-  `;
-
-  const headerStyles = css`
-    padding-block: ${euiTheme.size.base};
-    padding-inline: ${euiTheme.size.base};
-  `;
-
-  const bodyStyles = css`
-    .euiModalBody__overflow {
-      padding-inline: 0;
-      padding-block: 0;
-      display: flex;
-      flex-direction: column;
-      justify-content: ${isLoading || options.length === 0 ? 'center' : 'flex-start'};
-    }
-  `;
-
-  const footerStyles = css`
-    padding-block: ${euiTheme.size.s};
-    padding-inline: ${euiTheme.size.base};
-  `;
-
-  return (
-    <>
-      <Global styles={modalOverlayStyles} />
-      <EuiSelectable
-        css={selectableStyles}
-        isLoading={isLoading}
-        isPreFiltered
-        onChange={onChange}
-        options={formattedOptions}
-        singleSelection={true}
-        renderOption={(option) => euiSelectableTemplateSitewideRenderOptions(option, searchValue)}
-        listProps={{
-          rowHeight: SEARCH_MODAL_ROW_HEIGHT,
-          showIcons: false,
-        }}
-        searchProps={{
-          autoFocus: true,
-          value: searchValue,
-          onInput: (e: React.UIEvent<HTMLInputElement>) => setSearchValue(e.currentTarget.value),
-          'data-test-subj': `${SEARCH_MODAL_SELECTOR_PREFIX}Input`,
-          inputRef: setSearchRef,
-          compressed: false,
-          'aria-label': i18nStrings.placeholderText,
-          placeholder: i18nStrings.placeholderText,
-          fullWidth: true,
-          isClearable: true,
-        }}
-        noMatchesMessage={
-          searchCharLimitExceeded ? undefined : <SearchPlaceholder basePath={basePathUrl} />
-        }
-        searchable
-        emptyMessage={<EmptyMessage />}
-      >
-        {(list, search) => (
-          <>
-            <EuiModalHeader css={headerStyles}>{search}</EuiModalHeader>
-            <EuiHorizontalRule margin="none" />
-            <EuiModalBody css={bodyStyles}>
-              {searchCharLimitExceeded ? (
-                <CharLimitExceededMessage basePathUrl={basePathUrl} />
-              ) : (
-                list
-              )}
-            </EuiModalBody>
-            <EuiHorizontalRule margin="none" />
-            <EuiModalFooter css={footerStyles}>
-              <SearchFooter shortcutKey={SEARCH_MODAL_KEYBOARD_SHORTCUT.toUpperCase()} />
-            </EuiModalFooter>
-          </>
-        )}
-      </EuiSelectable>
-    </>
-  );
-};
+const LazySearchModal = dynamic(
+  () => import('./search_modal_internal').then((mod) => ({ default: mod.SearchModalInternal })),
+  {
+    fallback: (
+      <EuiFlexGroup justifyContent="center" alignItems="center" style={{ height: '100%' }}>
+        <EuiFlexItem grow={false}>
+          <EuiLoadingSpinner size="m" />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    ),
+  }
+);
+export const SearchModal = (props: SearchModalProps) => (
+  <>
+    <Global styles={modalOverlayStyles} />
+    <LazySearchModal {...props} />
+  </>
+);

--- a/x-pack/platform/plugins/private/global_search_bar/public/components/search_modal_internal.tsx
+++ b/x-pack/platform/plugins/private/global_search_bar/public/components/search_modal_internal.tsx
@@ -1,0 +1,149 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  EuiHorizontalRule,
+  EuiIcon,
+  EuiModalBody,
+  EuiModalFooter,
+  EuiModalHeader,
+  EuiSelectable,
+  euiSelectableTemplateSitewideRenderOptions,
+  useEuiTheme,
+} from '@elastic/eui';
+import { css } from '@emotion/react';
+import React, { useEffect } from 'react';
+import { i18nStrings } from '../strings';
+import { SearchFooter } from './search_footer';
+import { SearchPlaceholder } from './search_placeholder';
+import { useSearchState } from '../hooks/use_search_state';
+import type { SearchModalProps } from './types';
+import { EmptyMessage } from './empty_message';
+import {
+  SEARCH_MODAL_KEYBOARD_SHORTCUT,
+  SEARCH_MODAL_ROW_HEIGHT,
+  SEARCH_MODAL_SELECTOR_PREFIX,
+} from './types';
+import { CharLimitExceededMessage } from './char_limit_exceeded_message';
+
+export const SearchModalInternal = ({
+  globalSearch,
+  taggingApi,
+  navigateToUrl,
+  reportEvent,
+  basePathUrl,
+  onClose,
+}: SearchModalProps) => {
+  const { euiTheme } = useEuiTheme();
+  const {
+    searchValue,
+    setSearchValue,
+    options,
+    isLoading,
+    searchCharLimitExceeded,
+    onChange,
+    setSearchRef,
+    triggerInitialLoad,
+  } = useSearchState({
+    globalSearch,
+    taggingApi,
+    navigateToUrl,
+    reportEvent,
+    onResultSelect: onClose,
+  });
+
+  useEffect(() => {
+    triggerInitialLoad();
+    reportEvent.searchFocus();
+    return () => {
+      reportEvent.searchBlur();
+    };
+  }, [triggerInitialLoad, reportEvent]);
+
+  const formattedOptions = options.map((option) => ({
+    ...option,
+    prepend: option.icon ? <EuiIcon color="subdued" size="l" {...option.icon} /> : option.prepend,
+  }));
+
+  const selectableStyles = css`
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 auto;
+    overflow: hidden;
+  `;
+
+  const headerStyles = css`
+    padding-block: ${euiTheme.size.base};
+    padding-inline: ${euiTheme.size.base};
+  `;
+
+  const bodyStyles = css`
+    .euiModalBody__overflow {
+      padding-inline: 0;
+      padding-block: 0;
+      display: flex;
+      flex-direction: column;
+      justify-content: ${isLoading || options.length === 0 ? 'center' : 'flex-start'};
+    }
+  `;
+
+  const footerStyles = css`
+    padding-block: ${euiTheme.size.s};
+    padding-inline: ${euiTheme.size.base};
+  `;
+
+  return (
+    <EuiSelectable
+      css={selectableStyles}
+      isLoading={isLoading}
+      isPreFiltered
+      onChange={onChange}
+      options={formattedOptions}
+      singleSelection={true}
+      renderOption={(option) => euiSelectableTemplateSitewideRenderOptions(option, searchValue)}
+      listProps={{
+        rowHeight: SEARCH_MODAL_ROW_HEIGHT,
+        showIcons: false,
+      }}
+      searchProps={{
+        autoFocus: true,
+        value: searchValue,
+        onInput: (e: React.UIEvent<HTMLInputElement>) => setSearchValue(e.currentTarget.value),
+        'data-test-subj': `${SEARCH_MODAL_SELECTOR_PREFIX}Input`,
+        inputRef: setSearchRef,
+        compressed: false,
+        'aria-label': i18nStrings.placeholderText,
+        placeholder: i18nStrings.placeholderText,
+        fullWidth: true,
+        isClearable: true,
+      }}
+      noMatchesMessage={
+        searchCharLimitExceeded ? undefined : <SearchPlaceholder basePath={basePathUrl} />
+      }
+      searchable
+      emptyMessage={<EmptyMessage />}
+    >
+      {(list, search) => (
+        <>
+          <EuiModalHeader css={headerStyles}>{search}</EuiModalHeader>
+          <EuiHorizontalRule margin="none" />
+          <EuiModalBody css={bodyStyles}>
+            {searchCharLimitExceeded ? (
+              <CharLimitExceededMessage basePathUrl={basePathUrl} />
+            ) : (
+              list
+            )}
+          </EuiModalBody>
+          <EuiHorizontalRule margin="none" />
+          <EuiModalFooter css={footerStyles}>
+            <SearchFooter shortcutKey={SEARCH_MODAL_KEYBOARD_SHORTCUT.toUpperCase()} />
+          </EuiModalFooter>
+        </>
+      )}
+    </EuiSelectable>
+  );
+};

--- a/x-pack/platform/plugins/private/global_search_bar/public/components/search_placeholder.tsx
+++ b/x-pack/platform/plugins/private/global_search_bar/public/components/search_placeholder.tsx
@@ -5,21 +5,20 @@
  * 2.0.
  */
 
-import type { FC } from 'react';
 import React from 'react';
 import { EuiImage, EuiText, EuiFlexGroup, EuiFlexItem, useEuiTheme } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 
-interface PopoverPlaceholderProps {
+interface SearchPlaceholderProps {
   basePath: string;
   customPlaceholderMessage?: React.ReactNode;
 }
 
-export const PopoverPlaceholder: FC<PopoverPlaceholderProps> = ({
+export const SearchPlaceholder = ({
   basePath,
   customPlaceholderMessage,
-}) => {
+}: SearchPlaceholderProps) => {
   const { colorMode } = useEuiTheme();
 
   return (

--- a/x-pack/platform/plugins/private/global_search_bar/public/components/types.ts
+++ b/x-pack/platform/plugins/private/global_search_bar/public/components/types.ts
@@ -5,19 +5,33 @@
  * 2.0.
  */
 
-import type { ChromeStyle } from '@kbn/core-chrome-browser';
 import type { ApplicationStart } from '@kbn/core/public';
 import type { GlobalSearchPluginStart } from '@kbn/global-search-plugin/public';
 import type { SavedObjectTaggingPluginStart } from '@kbn/saved-objects-tagging-plugin/public';
 import type { Observable } from 'rxjs';
+import type { ChromeStyle } from '@kbn/core-chrome-browser';
 import type { EventReporter } from '../telemetry';
 
+export const SEARCH_MODAL_SELECTOR_PREFIX = 'chromeProjectNextSearchModal';
+export const SEARCH_MODAL_HEIGHT = 50;
+export const SEARCH_MODAL_WIDTH = 800;
+export const SEARCH_MODAL_ROW_HEIGHT = 68;
+export const SEARCH_MODAL_KEYBOARD_SHORTCUT = 'k';
+
 /* @internal */
-export interface SearchBarProps {
+export interface SearchProps {
   globalSearch: GlobalSearchPluginStart & { searchCharLimit: number };
   navigateToUrl: ApplicationStart['navigateToUrl'];
   reportEvent: EventReporter;
   taggingApi?: SavedObjectTaggingPluginStart;
   basePathUrl: string;
+}
+
+/* @internal */
+export interface SearchBarProps extends SearchProps {
   chromeStyle$: Observable<ChromeStyle>;
+}
+/* @internal */
+export interface SearchModalProps extends SearchProps {
+  onClose: () => void;
 }

--- a/x-pack/platform/plugins/private/global_search_bar/public/hooks/use_search_state.ts
+++ b/x-pack/platform/plugins/private/global_search_bar/public/hooks/use_search_state.ts
@@ -1,0 +1,288 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { EuiSelectableTemplateSitewideOption } from '@elastic/eui';
+import type { EuiSelectableOnChangeEvent } from '@elastic/eui/src/components/selectable/selectable';
+import type { RefObject } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { Subscription } from 'rxjs';
+import type { GlobalSearchFindParams, GlobalSearchResult } from '@kbn/global-search-plugin/public';
+import useDebounce from 'react-use/lib/useDebounce';
+import { apm } from '@elastic/apm-rum';
+import useMountedState from 'react-use/lib/useMountedState';
+import type { SearchSuggestion } from '../suggestions';
+import { getSuggestions } from '../suggestions';
+import type { SearchProps } from '../components/types';
+import { resultToOption, suggestionToOption } from '../lib';
+import { parseSearchParams } from '../search_syntax';
+import { sort } from '../components';
+
+const UNKNOWN_TAG_ID = '__unknown__';
+
+interface UseSearchStateOptions extends Omit<SearchProps, 'basePathUrl'> {
+  /** Called after a result is selected and navigation is triggered. */
+  onResultSelect?: () => void;
+}
+
+export interface SearchStateResult {
+  searchValue: string;
+  setSearchValue: (value: string) => void;
+  options: EuiSelectableTemplateSitewideOption[];
+  isLoading: boolean;
+  searchCharLimitExceeded: boolean;
+  searchRef: RefObject<HTMLInputElement | null>;
+  setSearchRef: (ref: HTMLInputElement | null) => void;
+  triggerInitialLoad: () => void;
+  onChange: (
+    selection: EuiSelectableTemplateSitewideOption[],
+    event: EuiSelectableOnChangeEvent
+  ) => void;
+}
+
+export const useSearchState = ({
+  globalSearch,
+  taggingApi,
+  navigateToUrl,
+  reportEvent,
+  onResultSelect,
+}: UseSearchStateOptions): SearchStateResult => {
+  const isMounted = useMountedState();
+
+  const [initialLoad, setInitialLoad] = useState(false);
+  const [searchValue, setSearchValue] = useState<string>('');
+  const [options, setOptions] = useState<EuiSelectableTemplateSitewideOption[]>([]);
+  const [searchableTypes, setSearchableTypes] = useState<string[]>([]);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [searchCharLimitExceeded, setSearchCharLimitExceeded] = useState(false);
+
+  const searchSubscription = useRef<Subscription | null>(null);
+  const searchRef = useRef<HTMLInputElement | null>(null);
+
+  const setSearchRef = useCallback((ref: HTMLInputElement | null) => {
+    searchRef.current = ref;
+  }, []);
+
+  // Initialize searchableTypes data
+  useEffect(() => {
+    if (initialLoad) {
+      const fetch = async () => {
+        const types = await globalSearch.getSearchableTypes();
+        setSearchableTypes(types);
+      };
+      fetch();
+    }
+  }, [globalSearch, initialLoad]);
+
+  // Whenever searchValue changes, isLoading = true
+  useEffect(() => {
+    setIsLoading(true);
+  }, [searchValue]);
+
+  // Cleanup subscription when component unmounts
+  useEffect(() => {
+    return () => {
+      searchSubscription.current?.unsubscribe();
+    };
+  }, []);
+
+  const triggerInitialLoad = useCallback(() => {
+    setInitialLoad(true);
+  }, []);
+
+  const loadSuggestions = useCallback(
+    (term: string) => {
+      return getSuggestions({
+        searchTerm: term,
+        searchableTypes,
+        tagCache: taggingApi?.cache,
+      });
+    },
+    [taggingApi, searchableTypes]
+  );
+
+  const setDecoratedOptions = useCallback(
+    (
+      _options: GlobalSearchResult[],
+      suggestions: SearchSuggestion[],
+      searchTagIds: string[] = []
+    ) => {
+      setOptions([
+        ...suggestions.map(suggestionToOption),
+        ..._options.map((option) =>
+          resultToOption(
+            option,
+            searchTagIds?.filter((id) => id !== UNKNOWN_TAG_ID) ?? [],
+            taggingApi?.ui.getTagList
+          )
+        ),
+      ]);
+    },
+    [setOptions, taggingApi]
+  );
+
+  useDebounce(
+    () => {
+      if (initialLoad) {
+        // cancel pending search if not completed yet
+        if (searchSubscription.current) {
+          searchSubscription.current.unsubscribe();
+          searchSubscription.current = null;
+        }
+
+        if (searchValue.length > globalSearch.searchCharLimit) {
+          // setting this will display an error message to the user
+          setSearchCharLimitExceeded(true);
+          return;
+        } else {
+          setSearchCharLimitExceeded(false);
+        }
+
+        const suggestions = loadSuggestions(searchValue.toLowerCase());
+
+        let aggregatedResults: GlobalSearchResult[] = [];
+
+        if (searchValue.length !== 0) {
+          reportEvent.searchRequest();
+        }
+
+        const rawParams = parseSearchParams(searchValue.toLowerCase(), searchableTypes);
+        let tagIds: string[] | undefined;
+        if (taggingApi && rawParams.filters.tags) {
+          tagIds = rawParams.filters.tags.map(
+            (tagName) => taggingApi.ui.getTagIdFromName(tagName) ?? UNKNOWN_TAG_ID
+          );
+        } else {
+          tagIds = undefined;
+        }
+        const searchParams: GlobalSearchFindParams = {
+          term: rawParams.term,
+          types: rawParams.filters.types,
+          tags: tagIds,
+        };
+
+        searchSubscription.current = globalSearch.find(searchParams, {}).subscribe({
+          next: ({ results }) => {
+            if (!isMounted()) {
+              return;
+            }
+
+            if (searchValue.length > 0) {
+              aggregatedResults = [...results, ...aggregatedResults].sort(sort.byScore);
+              setDecoratedOptions(aggregatedResults, suggestions, searchParams.tags);
+              return;
+            }
+
+            // if searchbar is empty, filter to only applications and sort alphabetically
+            results = results.filter(({ type }: GlobalSearchResult) => type === 'application');
+            aggregatedResults = [...results, ...aggregatedResults].sort(sort.byTitle);
+            setDecoratedOptions(aggregatedResults, suggestions, searchParams.tags);
+          },
+          error: (err) => {
+            setIsLoading(false);
+
+            // Not doing anything on error right now because it'll either just show the previous
+            // results or empty results which is basically what we want anyways
+            apm.captureError(err, {
+              labels: {
+                SearchValue: searchValue,
+              },
+            });
+          },
+          complete: () => {
+            setIsLoading(false);
+          },
+        });
+      }
+    },
+    350,
+    [searchValue, loadSuggestions, searchableTypes, initialLoad]
+  );
+
+  const onResultSelectRef = useRef(onResultSelect);
+  onResultSelectRef.current = onResultSelect;
+
+  const onChange = useCallback(
+    (selection: EuiSelectableTemplateSitewideOption[], event: EuiSelectableOnChangeEvent) => {
+      let selectedRank: number | null = null;
+      const selected = selection.find(({ checked }, rank) => {
+        const isChecked = checked === 'on';
+        if (isChecked) {
+          selectedRank = rank + 1;
+        }
+        return isChecked;
+      });
+
+      if (!selected) {
+        return;
+      }
+
+      const selectedLabel = selected.label ?? null;
+
+      // @ts-ignore - ts error is "union type is too complex to express"
+      const { url, type, suggestion } = selected;
+
+      // if the type is a suggestion, we change the query on the input and trigger a new search
+      // by setting the searchValue (only setting the field value does not trigger a search)
+      if (type === '__suggestion__') {
+        setSearchValue(suggestion);
+        return;
+      }
+
+      // errors in tracking should not prevent selection behavior
+      try {
+        if (type === 'application') {
+          const key = selected.key ?? 'unknown';
+          const application = `${key.toLowerCase().replaceAll(' ', '_')}`;
+          reportEvent.navigateToApplication({
+            application,
+            searchValue,
+            selectedLabel,
+            selectedRank,
+          });
+        } else {
+          reportEvent.navigateToSavedObject({
+            type,
+            searchValue,
+            selectedLabel,
+            selectedRank,
+          });
+        }
+      } catch (err) {
+        apm.captureError(err, {
+          labels: {
+            SearchValue: searchValue,
+          },
+        });
+        // eslint-disable-next-line no-console
+        console.log('Error trying to track searchbar metrics', err);
+      }
+
+      if (event.shiftKey) {
+        window.open(url);
+      } else if (event.ctrlKey || event.metaKey) {
+        window.open(url, '_blank');
+      } else {
+        navigateToUrl(url);
+      }
+
+      onResultSelectRef.current?.();
+    },
+    [reportEvent, navigateToUrl, searchValue]
+  );
+
+  return {
+    searchValue,
+    setSearchValue,
+    options,
+    isLoading,
+    searchCharLimitExceeded,
+    onChange,
+    setSearchRef,
+    searchRef,
+    triggerInitialLoad,
+  };
+};

--- a/x-pack/platform/plugins/private/global_search_bar/public/plugin.tsx
+++ b/x-pack/platform/plugins/private/global_search_bar/public/plugin.tsx
@@ -5,14 +5,27 @@
  * 2.0.
  */
 
-import type { CoreSetup, CoreStart, Plugin, PluginInitializerContext } from '@kbn/core/public';
+import type {
+  CoreSetup,
+  CoreStart,
+  OverlayRef,
+  Plugin,
+  PluginInitializerContext,
+} from '@kbn/core/public';
 import type { GlobalSearchPluginStart } from '@kbn/global-search-plugin/public';
 import type { SavedObjectTaggingPluginStart } from '@kbn/saved-objects-tagging-plugin/public';
 import type { UsageCollectionSetup } from '@kbn/usage-collection-plugin/public';
 import React from 'react';
+import { toMountPoint } from '@kbn/react-kibana-mount';
 import { SearchBar } from './components/search_bar';
 import type { GlobalSearchBarConfigType } from './types';
 import { EventReporter, eventTypes } from './telemetry';
+import {
+  SEARCH_MODAL_KEYBOARD_SHORTCUT,
+  SEARCH_MODAL_SELECTOR_PREFIX,
+  type SearchProps,
+} from './components/types';
+import { SearchModal } from './components/search_modal';
 
 export interface GlobalSearchBarPluginStartDeps {
   globalSearch: GlobalSearchPluginStart;
@@ -40,26 +53,52 @@ export class GlobalSearchBarPlugin implements Plugin<{}, {}, {}, GlobalSearchBar
     const { application, http } = core;
     const reportEvent = new EventReporter({ analytics: core.analytics, usageCollection });
 
+    const searchProps: SearchProps = {
+      globalSearch: { ...globalSearch, searchCharLimit: this.config.input_max_limit },
+      navigateToUrl: application.navigateToUrl,
+      taggingApi: savedObjectsTagging,
+      basePathUrl: http.basePath.prepend('/plugins/globalSearchBar/assets/'),
+      reportEvent,
+    };
+
+    let activeModalRef: OverlayRef | null = null;
+
+    const toggleSearchModal = () => {
+      if (activeModalRef) {
+        activeModalRef.close();
+        activeModalRef = null;
+        return;
+      }
+      activeModalRef = core.overlays.openModal(
+        toMountPoint(
+          <SearchModal
+            {...searchProps}
+            onClose={() => {
+              activeModalRef?.close();
+              activeModalRef = null;
+            }}
+          />,
+          core
+        ),
+        {
+          className: SEARCH_MODAL_SELECTOR_PREFIX,
+          'data-test-subj': SEARCH_MODAL_SELECTOR_PREFIX,
+          outsideClickCloses: true,
+        }
+      );
+      activeModalRef.onClose.then(() => {
+        activeModalRef = null;
+      });
+    };
+
     core.chrome.next.globalSearch.set({
-      onClick: () => {
-        // TODO: open search modal
-        // eslint-disable-next-line no-console
-        console.log('[GlobalSearch] search button clicked — modal not yet implemented');
-      },
+      onClick: toggleSearchModal,
+      shortcutKey: SEARCH_MODAL_KEYBOARD_SHORTCUT,
     });
 
     core.chrome.navControls.registerCenter({
       order: 1000,
-      content: (
-        <SearchBar
-          globalSearch={{ ...globalSearch, searchCharLimit: this.config.input_max_limit }}
-          navigateToUrl={application.navigateToUrl}
-          taggingApi={savedObjectsTagging}
-          basePathUrl={http.basePath.prepend('/plugins/globalSearchBar/assets/')}
-          chromeStyle$={core.chrome.getChromeStyle$()}
-          reportEvent={reportEvent}
-        />
-      ),
+      content: <SearchBar {...searchProps} chromeStyle$={core.chrome.getChromeStyle$()} />,
     });
 
     return {};

--- a/x-pack/platform/plugins/private/global_search_bar/tsconfig.json
+++ b/x-pack/platform/plugins/private/global_search_bar/tsconfig.json
@@ -15,7 +15,8 @@
     "@kbn/saved-objects-tagging-oss-plugin",
     "@kbn/core-chrome-browser",
     "@kbn/config-schema",
-    "@kbn/shared-ux-utility"
+    "@kbn/shared-ux-utility",
+    "@kbn/react-kibana-mount"
   ],
   "exclude": [
     "target/**/*",


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/259116

## Summary

This PR adds the global search modal:
- Takes the existing global search and moves it into a modal
- Sets a width and height to keep the modal from changing size and position as you search
- Reuses existing global search functionality (navigate-to-app, navigate-to-saved-object...)
- Adds a listener in navigation to be able to open/close the modal with a keyboard shortcut (Cmd+K / Ctrl+K)

### Testing 

https://github.com/user-attachments/assets/14fa6d4c-29e7-49b0-be6c-68b0b65bbc31
