### PR TITLE
[Synthetics] Unskip SyncMaintenanceWindowsNonDefaultSpace flaky test

### DIFF
--- a/x-pack/solutions/observability/test/api_integration/apis/synthetics/sync_maintenance_windows_non_default_space.ts
+++ b/x-pack/solutions/observability/test/api_integration/apis/synthetics/sync_maintenance_windows_non_default_space.ts
@@ -17,8 +17,7 @@ import { comparePolicies, getTestSyntheticsPolicy } from './sample_data/test_pol
 import { omitMonitorKeys } from './add_monitor';
 
 export default function ({ getService }: FtrProviderContext) {
-  // FLAKY: https://github.com/elastic/kibana/issues/251844
-  describe.skip('SyncMaintenanceWindowsNonDefaultSpace', function () {
+  describe('SyncMaintenanceWindowsNonDefaultSpace', function () {
     this.tags('skipCloud');
     const supertestAPI = getService('supertest');
     const kServer = getService('kibanaServer');
@@ -35,6 +34,7 @@ export default function ({ getService }: FtrProviderContext) {
     const monitorTestService = new SyntheticsMonitorTestService(getService);
 
     before(async () => {
+      await testPrivateLocations.cleanupFleetPolicies();
       await kServer.savedObjects.cleanStandardList();
       await testPrivateLocations.installSyntheticsPackage();
 


### PR DESCRIPTION
## Summary

Unskips the `SyncMaintenanceWindowsNonDefaultSpace` test that was skipped due to flakiness (#251844).

### Root cause

The `before` hook calls `installSyntheticsPackage`, which DELETEs the synthetics package then immediately POSTs to reinstall it. The install would intermittently get a **404** because the deletion hadn't fully propagated or the EPM registry returned a transient error.

### Why this is already fixed

PR #256023 added `retry.try()` around the delete+install sequence in `PrivateLocationTestService.installSyntheticsPackage` (and `addFleetPolicy`), specifically to handle transient 404s. That fix resolved 5 other flaky test issues with the same root cause. However, this test was already `describe.skip`'d before the retry was added and was never unskipped.

### Changes

- Removed `describe.skip` and the `// FLAKY:` comment
- Added `cleanupFleetPolicies()` as the first step of the `before` hook, matching the pattern in `sync_global_params_spaces.ts`, to ensure a clean Fleet state before setup

### Verification

Ran the test **50 consecutive times** locally against a single FTR server: **50/50 passed, 0 failures**.

## Test plan

- [x] 50x local run: 50/50 passed
- [ ] CI green on this PR

Closes #251844

Made with [Cursor](https://cursor.com)

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->