### PR TITLE
[9.2] [Fleet] Send is_elastic_staff_owned to agentless-api (#259612)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/agentless_agent.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/agentless_agent.test.ts
@@ -181,6 +181,7 @@ describe('Agentless Agent service', () => {
           fleet_url: 'http://fleetserver:8220',
           policy_id: 'mocked-agentless-agent-policy-id',
           stack_version: 'mocked-kibana-version-infinite',
+          is_elastic_staff_owned: false,
           labels: {
             owner: {
               org: 'elastic',
@@ -198,6 +199,73 @@ describe('Agentless Agent service', () => {
         }),
         headers: expect.anything(),
         httpsAgent: expect.anything(),
+        method: 'POST',
+        url: 'http://api.agentless.com/api/v1/ess/deployments',
+      })
+    );
+  });
+
+  it('should include is_elastic_staff_owned when cloud reports elastic staff owned deployment', async () => {
+    jest.mocked(axios).mockResolvedValueOnce(mockAgentlessDeploymentResponse);
+    const soClient = getAgentPolicyCreateMock();
+    const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+    jest.spyOn(appContextService, 'getConfig').mockReturnValue({
+      agentless: {
+        enabled: true,
+        api: {
+          url: 'http://api.agentless.com',
+          tls: {
+            certificate: '/path/to/cert',
+            key: '/path/to/key',
+            ca: '/path/to/ca',
+          },
+        },
+        deploymentSecrets: {
+          fleetAppToken: 'fleet-app-token',
+          elasticsearchAppToken: 'es-app-token',
+        },
+      },
+    } as any);
+    jest
+      .spyOn(appContextService, 'getCloud')
+      .mockReturnValue({ isCloudEnabled: true, isElasticStaffOwned: true } as any);
+    jest
+      .spyOn(appContextService, 'getKibanaVersion')
+      .mockReturnValue('mocked-kibana-version-infinite');
+    mockedFleetServerHostService.get.mockResolvedValue({
+      id: 'mocked-fleet-server-id',
+      host: 'http://fleetserver:8220',
+      active: true,
+      is_default: true,
+      host_urls: ['http://fleetserver:8220'],
+    } as any);
+    mockedListEnrollmentApiKeys.mockResolvedValue({
+      items: [
+        {
+          id: 'mocked-fleet-enrollment-token-id',
+          policy_id: 'mocked-fleet-enrollment-policy-id',
+          api_key: 'mocked-fleet-enrollment-api-key',
+        },
+      ],
+    } as any);
+
+    await agentlessAgentService.createAgentlessAgent(esClient, soClient, {
+      id: 'mocked-agentless-agent-policy-id',
+      name: 'agentless agent policy',
+      namespace: 'default',
+      fleet_server_host_id: 'mock-fleet-default-fleet-server-host',
+      data_output_id: 'mock-fleet-default-output',
+      supports_agentless: true,
+    } as AgentPolicy);
+
+    expect(axios).toHaveBeenCalledTimes(1);
+    expect(axios).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          policy_id: 'mocked-agentless-agent-policy-id',
+          is_elastic_staff_owned: true,
+          stack_version: 'mocked-kibana-version-infinite',
+        }),
         method: 'POST',
         url: 'http://api.agentless.com/api/v1/ess/deployments',
       })

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/agentless_agent.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/agentless_agent.ts
@@ -166,6 +166,7 @@ class AgentlessAgentService {
     const cloudSetup = appContextService.getCloud();
     if (!cloudSetup?.isServerlessEnabled) {
       requestConfig.data.stack_version = appContextService.getKibanaVersion();
+      requestConfig.data.is_elastic_staff_owned = cloudSetup?.isElasticStaffOwned ?? false;
     }
 
     const requestConfigDebugStatus = this.createRequestConfigDebug(requestConfig);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[Fleet] Send is_elastic_staff_owned to agentless-api (#259612)](https://github.com/elastic/kibana/pull/259612)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Ruben Ruiz de Gauna","email":"ruben.ruizdegauna@elastic.co"},"sourceCommit":{"committedDate":"2026-04-08T10:38:00Z","message":"[Fleet] Send is_elastic_staff_owned to agentless-api (#259612)\n\n## Summary\n\n- Send `is_elastic_staff_owned` in the `POST /api/v1/ess/deployments`\npayload to agentless-api\n- Value is read from\n`appContextService.getCloud()?.isElasticStaffOwned`, defaulting to\n`false`\n- Added to the debug log output in `createRequestConfigDebug`\n\n## Context\n\nAgentless deployments in ECH lack the\n`k8s.elastic.co/created-by-internal-user` label that exists in\nServerless. This label is used for alert triage to distinguish\ninternal/test deployments. Kibana already knows whether the deployment\nis staff-owned via `xpack.cloud.is_elastic_staff_owned`, so we pass it\nthrough to agentless-api.\n\n## Deployment ordering\n\nThe corresponding agentless-api PR must be deployed **before** this\nKibana change. agentless-api uses `additionalProperties: false` in its\nOpenAPI spec, so it will reject unknown fields.\n\n## Test plan\n\n- [x] Updated existing ESS and Serverless tests to assert\n`is_elastic_staff_owned: false`\n- [x] New test verifying `is_elastic_staff_owned: true` when Cloud\nreports staff-owned deployment\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\n\n- [ ] The corresponding agentless-api PR must be deployed **before**\nthis Kibana change. agentless-api uses `additionalProperties: false` in\nits OpenAPI spec, so it will reject unknown fields.\n\n\nFixes: https://github.com/elastic/kibana/issues/259600","sha":"b56d4ce59e408a75750cfea21075b6053545f2d7","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Fleet","backport:all-open","ci:project-deploy-observability","v9.4.0","v9.3.3"],"title":"[Fleet] Send is_elastic_staff_owned to agentless-api","number":259612,"url":"https://github.com/elastic/kibana/pull/259612","mergeCommit":{"message":"[Fleet] Send is_elastic_staff_owned to agentless-api (#259612)\n\n## Summary\n\n- Send `is_elastic_staff_owned` in the `POST /api/v1/ess/deployments`\npayload to agentless-api\n- Value is read from\n`appContextService.getCloud()?.isElasticStaffOwned`, defaulting to\n`false`\n- Added to the debug log output in `createRequestConfigDebug`\n\n## Context\n\nAgentless deployments in ECH lack the\n`k8s.elastic.co/created-by-internal-user` label that exists in\nServerless. This label is used for alert triage to distinguish\ninternal/test deployments. Kibana already knows whether the deployment\nis staff-owned via `xpack.cloud.is_elastic_staff_owned`, so we pass it\nthrough to agentless-api.\n\n## Deployment ordering\n\nThe corresponding agentless-api PR must be deployed **before** this\nKibana change. agentless-api uses `additionalProperties: false` in its\nOpenAPI spec, so it will reject unknown fields.\n\n## Test plan\n\n- [x] Updated existing ESS and Serverless tests to assert\n`is_elastic_staff_owned: false`\n- [x] New test verifying `is_elastic_staff_owned: true` when Cloud\nreports staff-owned deployment\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\n\n- [ ] The corresponding agentless-api PR must be deployed **before**\nthis Kibana change. agentless-api uses `additionalProperties: false` in\nits OpenAPI spec, so it will reject unknown fields.\n\n\nFixes: https://github.com/elastic/kibana/issues/259600","sha":"b56d4ce59e408a75750cfea21075b6053545f2d7"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/259612","number":259612,"mergeCommit":{"message":"[Fleet] Send is_elastic_staff_owned to agentless-api (#259612)\n\n## Summary\n\n- Send `is_elastic_staff_owned` in the `POST /api/v1/ess/deployments`\npayload to agentless-api\n- Value is read from\n`appContextService.getCloud()?.isElasticStaffOwned`, defaulting to\n`false`\n- Added to the debug log output in `createRequestConfigDebug`\n\n## Context\n\nAgentless deployments in ECH lack the\n`k8s.elastic.co/created-by-internal-user` label that exists in\nServerless. This label is used for alert triage to distinguish\ninternal/test deployments. Kibana already knows whether the deployment\nis staff-owned via `xpack.cloud.is_elastic_staff_owned`, so we pass it\nthrough to agentless-api.\n\n## Deployment ordering\n\nThe corresponding agentless-api PR must be deployed **before** this\nKibana change. agentless-api uses `additionalProperties: false` in its\nOpenAPI spec, so it will reject unknown fields.\n\n## Test plan\n\n- [x] Updated existing ESS and Serverless tests to assert\n`is_elastic_staff_owned: false`\n- [x] New test verifying `is_elastic_staff_owned: true` when Cloud\nreports staff-owned deployment\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\n\n- [ ] The corresponding agentless-api PR must be deployed **before**\nthis Kibana change. agentless-api uses `additionalProperties: false` in\nits OpenAPI spec, so it will reject unknown fields.\n\n\nFixes: https://github.com/elastic/kibana/issues/259600","sha":"b56d4ce59e408a75750cfea21075b6053545f2d7"}},{"branch":"9.3","label":"v9.3.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/261942","number":261942,"state":"MERGED","mergeCommit":{"sha":"c5f5adacaccc8deb62da9b0059058d5b6169abf8","message":"[9.3] [Fleet] Send is_elastic_staff_owned to agentless-api (#259612) (#261942)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.3`:\n- [[Fleet] Send is_elastic_staff_owned to agentless-api\n(#259612)](https://github.com/elastic/kibana/pull/259612)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Ruben Ruiz de Gauna <ruben.ruizdegauna@elastic.co>"}}]}] BACKPORT-->