### PR TITLE
Increase navigation visibility timeout in Scout tests

### DIFF
--- a/src/platform/plugins/shared/navigation/test/scout/ui/fixtures/page_objects/navigation.ts
+++ b/src/platform/plugins/shared/navigation/test/scout/ui/fixtures/page_objects/navigation.ts
@@ -14,7 +14,9 @@ export class Navigation {
 
   async goToSecurity() {
     await this.page.gotoApp('security');
-    await this.page.testSubj.locator('kbnChromeLayoutNavigation').waitFor({ state: 'visible' });
+    await this.page.testSubj
+      .locator('kbnChromeLayoutNavigation')
+      .waitFor({ state: 'visible', timeout: 30_000 });
   }
 
   async clickLogo() {

--- a/src/platform/plugins/shared/navigation/test/scout/ui/tests/navigation.spec.ts
+++ b/src/platform/plugins/shared/navigation/test/scout/ui/tests/navigation.spec.ts
@@ -11,8 +11,7 @@ import { expect } from '@kbn/scout/ui';
 import { tags } from '@kbn/scout';
 import { test } from '../fixtures';
 
-// Failing: See https://github.com/elastic/kibana/issues/259488
-test.describe.skip('navigation', { tag: tags.serverless.security.complete }, () => {
+test.describe('navigation', { tag: tags.serverless.security.complete }, () => {
   test('has security serverless side nav', async ({ pageObjects, browserAuth }) => {
     await browserAuth.loginAsPrivilegedUser();
     await pageObjects.navigation.goToSecurity();


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/256410
Closes https://github.com/elastic/kibana/issues/259488
Closes https://github.com/elastic/kibana/issues/259586
Closes https://github.com/elastic/kibana/issues/261891

## Summary

Increases the `waitFor` timeout on `kbnChromeLayoutNavigation` in `Navigation.goToSecurity()` from the default 10s to 30s. All four flaky test failures originate from this single call timing out when Kibana is slow to render the chrome navigation on startup.