### PR TITLE
[Alerting v2] [Rule authoring] Rename recovery delay mode from 'breaches' to 'recoveries'

### DIFF
--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/field_groups/alert_conditions_field_group.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/field_groups/alert_conditions_field_group.tsx
@@ -26,7 +26,7 @@ import { RecoveryDelayField } from '../fields/recovery_delay_field';
  * - A dropdown to select recovery type (no_breach vs. custom query)
  * - When `query` type is selected:
  *     uses RecoveryBaseQueryOnlyField (full ES|QL editor with "not same as eval" validation)
- * - Recovery delay (recovering state transition: immediate / breaches / duration)
+ * - Recovery delay (recovering state transition: immediate / recoveries / duration)
  */
 export const AlertConditionsFieldGroup = () => {
   const { control } = useFormContext<FormValues>();

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/alert_delay_field.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/alert_delay_field.test.tsx
@@ -137,7 +137,7 @@ describe('AlertDelayField', () => {
         wrapper: createFormWrapper({
           kind: 'alert',
           stateTransitionAlertDelayMode: 'breaches',
-          stateTransitionRecoveryDelayMode: 'breaches',
+          stateTransitionRecoveryDelayMode: 'recoveries',
           stateTransition: {
             pendingCount: 2,
             pendingTimeframe: null,

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/alert_delay_field.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/alert_delay_field.tsx
@@ -64,8 +64,9 @@ export const AlertDelayField = () => {
   const { layout } = useRuleFormMeta();
   const stateTransition = useWatch({ control, name: 'stateTransition' });
   const selectedMode = useWatch({ control, name: 'stateTransitionAlertDelayMode' });
+  const derived = selectedMode ?? deriveAlertDelayModeFromStateTransition(stateTransition);
   const displayMode: DelayMode =
-    selectedMode ?? deriveAlertDelayModeFromStateTransition(stateTransition);
+    derived === 'immediate' || derived === 'duration' ? derived : 'breaches';
 
   const onModeChange = useCallback(
     (optionId: string) => {

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/recovery_delay_field.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/recovery_delay_field.test.tsx
@@ -47,11 +47,11 @@ describe('RecoveryDelayField', () => {
     expect(screen.getByText('No delay - Recovers on first non-breach')).toBeInTheDocument();
   });
 
-  it('shows breaches controls when recovery delay mode is breaches', () => {
+  it('shows recoveries controls when recovery delay mode is recoveries', () => {
     render(<RecoveryDelayField />, {
       wrapper: createFormWrapper({
         kind: 'alert',
-        stateTransitionRecoveryDelayMode: 'breaches',
+        stateTransitionRecoveryDelayMode: 'recoveries',
         stateTransition: { recoveringCount: 4 },
       }),
     });
@@ -71,7 +71,7 @@ describe('RecoveryDelayField', () => {
     expect(screen.getByTestId('recoveryTransitionTimeframeNumberInput')).toBeInTheDocument();
   });
 
-  it('switches to breaches mode when Recoveries button is clicked', () => {
+  it('switches to recoveries mode when Recoveries button is clicked', () => {
     render(<RecoveryDelayField />, {
       wrapper: createFormWrapper({ kind: 'alert' }),
     });
@@ -97,12 +97,12 @@ describe('RecoveryDelayField', () => {
     render(<RecoveryDelayField />, {
       wrapper: createFormWrapper({
         kind: 'alert',
-        stateTransitionRecoveryDelayMode: 'breaches',
+        stateTransitionRecoveryDelayMode: 'recoveries',
         stateTransition: { recoveringCount: 4 },
       }),
     });
 
-    // Start in breaches mode, switch to immediate
+    // Start in recoveries mode, switch to immediate
     fireEvent.click(screen.getByText('Immediate'));
 
     expect(screen.getByTestId('recoveryDelayImmediateDescription')).toBeInTheDocument();
@@ -137,7 +137,7 @@ describe('RecoveryDelayField', () => {
         wrapper: createFormWrapper({
           kind: 'alert',
           stateTransitionAlertDelayMode: 'breaches',
-          stateTransitionRecoveryDelayMode: 'breaches',
+          stateTransitionRecoveryDelayMode: 'recoveries',
           stateTransition: {
             pendingCount: 2,
             pendingTimeframe: null,

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/recovery_delay_field.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/recovery_delay_field.test.tsx
@@ -71,12 +71,12 @@ describe('RecoveryDelayField', () => {
     expect(screen.getByTestId('recoveryTransitionTimeframeNumberInput')).toBeInTheDocument();
   });
 
-  it('switches to breaches mode when Breaches button is clicked', () => {
+  it('switches to breaches mode when Recoveries button is clicked', () => {
     render(<RecoveryDelayField />, {
       wrapper: createFormWrapper({ kind: 'alert' }),
     });
 
-    fireEvent.click(screen.getByText('Breaches'));
+    fireEvent.click(screen.getByText('Recoveries'));
 
     expect(screen.getByTestId('recoveryTransitionCountInput')).toBeInTheDocument();
     expect(screen.queryByTestId('recoveryDelayImmediateDescription')).not.toBeInTheDocument();

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/recovery_delay_field.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/recovery_delay_field.tsx
@@ -33,7 +33,7 @@ const MODE_OPTIONS = [
   {
     id: MODE_OPTION_IDS.breaches,
     label: i18n.translate('xpack.alertingV2.ruleForm.recoveryDelay.delayModeBreaches', {
-      defaultMessage: 'Breaches',
+      defaultMessage: 'Recoveries',
     }),
   },
   {

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/recovery_delay_field.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/recovery_delay_field.tsx
@@ -15,11 +15,11 @@ import { StateTransitionCountField } from './state_transition_count_field';
 import { StateTransitionTimeframeField } from './state_transition_timeframe_field';
 import { useRuleFormMeta } from '../contexts';
 
-type DelayMode = 'immediate' | 'breaches' | 'duration';
+type DelayMode = 'immediate' | 'recoveries' | 'duration';
 
 const MODE_OPTION_IDS = {
   immediate: 'recovery_delay_mode_immediate',
-  breaches: 'recovery_delay_mode_breaches',
+  recoveries: 'recovery_delay_mode_recoveries',
   duration: 'recovery_delay_mode_duration',
 } as const;
 
@@ -31,8 +31,8 @@ const MODE_OPTIONS = [
     }),
   },
   {
-    id: MODE_OPTION_IDS.breaches,
-    label: i18n.translate('xpack.alertingV2.ruleForm.recoveryDelay.delayModeBreaches', {
+    id: MODE_OPTION_IDS.recoveries,
+    label: i18n.translate('xpack.alertingV2.ruleForm.recoveryDelay.delayModeRecoveries', {
       defaultMessage: 'Recoveries',
     }),
   },
@@ -47,13 +47,13 @@ const MODE_OPTIONS = [
 const modeFromOptionId = (id: string): DelayMode => {
   if (id === MODE_OPTION_IDS.immediate) return 'immediate';
   if (id === MODE_OPTION_IDS.duration) return 'duration';
-  return 'breaches';
+  return 'recoveries';
 };
 
 const optionIdForMode = (mode: DelayMode): string => {
   if (mode === 'immediate') return MODE_OPTION_IDS.immediate;
   if (mode === 'duration') return MODE_OPTION_IDS.duration;
-  return MODE_OPTION_IDS.breaches;
+  return MODE_OPTION_IDS.recoveries;
 };
 
 const DEFAULT_RECOVERING_COUNT = 2;
@@ -64,8 +64,9 @@ export const RecoveryDelayField = () => {
   const { layout } = useRuleFormMeta();
   const stateTransition = useWatch({ control, name: 'stateTransition' });
   const selectedMode = useWatch({ control, name: 'stateTransitionRecoveryDelayMode' });
+  const derived = selectedMode ?? deriveRecoveryDelayModeFromStateTransition(stateTransition);
   const displayMode: DelayMode =
-    selectedMode ?? deriveRecoveryDelayModeFromStateTransition(stateTransition);
+    derived === 'immediate' || derived === 'duration' ? derived : 'recoveries';
 
   const onModeChange = useCallback(
     (optionId: string) => {
@@ -84,8 +85,8 @@ export const RecoveryDelayField = () => {
             { shouldDirty: true, shouldTouch: true }
           );
           break;
-        case 'breaches':
-          setValue('stateTransitionRecoveryDelayMode', 'breaches', { shouldDirty: true });
+        case 'recoveries':
+          setValue('stateTransitionRecoveryDelayMode', 'recoveries', { shouldDirty: true });
           setValue(
             'stateTransition',
             {
@@ -141,11 +142,11 @@ export const RecoveryDelayField = () => {
             })}
           </EuiText>
         )}
-        {displayMode === 'breaches' && (
+        {displayMode === 'recoveries' && (
           <StateTransitionCountField
             variant="recovering"
             prependLabel={i18n.translate(
-              'xpack.alertingV2.ruleForm.recoveryDelay.inlineBreachesPrepend',
+              'xpack.alertingV2.ruleForm.recoveryDelay.inlineRecoveriesPrepend',
               { defaultMessage: 'Consecutive recoveries' }
             )}
           />

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/types.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/types.ts
@@ -9,7 +9,7 @@
 import type { RuleKind, RecoveryPolicyType } from '@kbn/alerting-v2-schemas';
 
 /** Alert / recovery delay segment control (matches `AlertDelayField` / `RecoveryDelayField`). */
-export type StateTransitionDelayMode = 'immediate' | 'breaches' | 'duration';
+export type StateTransitionDelayMode = 'immediate' | 'breaches' | 'recoveries' | 'duration';
 
 /**
  * Rule metadata containing identification and categorization info.

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/utils/rule_request_mappers.test.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/utils/rule_request_mappers.test.ts
@@ -165,7 +165,7 @@ describe('rule_request_mappers', () => {
         ...baseFormValues,
         kind: 'alert',
         stateTransitionAlertDelayMode: 'immediate',
-        stateTransitionRecoveryDelayMode: 'breaches',
+        stateTransitionRecoveryDelayMode: 'recoveries',
         stateTransition: {
           pendingCount: 2,
           pendingTimeframe: null,
@@ -201,7 +201,7 @@ describe('rule_request_mappers', () => {
         ...baseFormValues,
         kind: 'alert',
         stateTransitionAlertDelayMode: 'immediate',
-        stateTransitionRecoveryDelayMode: 'breaches',
+        stateTransitionRecoveryDelayMode: 'recoveries',
         stateTransition: { recoveringCount: 3 },
       };
 

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/utils/rule_request_mappers.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/utils/rule_request_mappers.ts
@@ -115,7 +115,7 @@ const mapStateTransition = (formValues: FormValues) => {
   }
 
   if (recoveryMode !== 'immediate') {
-    if (recoveryMode === 'recoveries' && stateTransition.recoveringCount != null) {
+    if (recoveryMode !== 'duration' && stateTransition.recoveringCount != null) {
       out.recovering_count = stateTransition.recoveringCount;
     }
     if (recoveryMode === 'duration') {

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/utils/rule_request_mappers.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/utils/rule_request_mappers.ts
@@ -83,7 +83,7 @@ export const deriveRecoveryDelayModeFromStateTransition = (
   stateTransition?: StateTransition | null
 ): FormValues['stateTransitionRecoveryDelayMode'] => {
   if (stateTransition?.recoveringTimeframe != null) return 'duration';
-  if (stateTransition?.recoveringCount != null) return 'breaches';
+  if (stateTransition?.recoveringCount != null) return 'recoveries';
   return 'immediate';
 };
 
@@ -115,7 +115,7 @@ const mapStateTransition = (formValues: FormValues) => {
   }
 
   if (recoveryMode !== 'immediate') {
-    if (recoveryMode === 'breaches' && stateTransition.recoveringCount != null) {
+    if (recoveryMode === 'recoveries' && stateTransition.recoveringCount != null) {
       out.recovering_count = stateTransition.recoveringCount;
     }
     if (recoveryMode === 'duration') {


### PR DESCRIPTION
## Summary

Closes #261883

The Recovery delay toggle group in the v2 alerting rule form reused the same "Breaches" tab label and internal identifiers as Alert delay. This is misleading — "Breaches" describes consecutive threshold violations, but Recovery delay counts consecutive *non*-breaching checks.

This PR renames the recovery delay mode from `breaches` to `recoveries` across the stack:

- **UI label**: tab now reads **Immediate | Recoveries | Duration**
- **i18n keys**: `delayModeBreaches` → `delayModeRecoveries`, `inlineBreachesPrepend` → `inlineRecoveriesPrepend`
- **Internal identifiers**: `MODE_OPTION_IDS.breaches` → `.recoveries`, DOM id `recovery_delay_mode_breaches` → `recovery_delay_mode_recoveries`
- **Form state value**: `stateTransitionRecoveryDelayMode` now uses `'recoveries'` instead of `'breaches'`
- **Shared type**: `StateTransitionDelayMode` widened to `'immediate' | 'breaches' | 'recoveries' | 'duration'` for backwards compatibility
- **Mapper**: `deriveRecoveryDelayModeFromStateTransition` returns `'recoveries'`; `mapStateTransition` checks `recoveryMode === 'recoveries'`

Alert delay is unchanged and continues to use `'breaches'` everywhere.

<img width="598" height="374" alt="image" src="https://github.com/user-attachments/assets/c5b3cbf3-12e8-43b9-a105-b3643c58bffa" />

## Test plan

- [ ] Open a rule creation/edit form with v2 alerting enabled
- [ ] Verify the **Alert delay** toggle still shows `Immediate | Breaches | Duration`
- [ ] Verify the **Recovery delay** toggle now shows `Immediate | Recoveries | Duration`
- [ ] Click "Recoveries" tab — confirm "Consecutive recoveries" input appears
- [ ] Set alert delay to "Breaches" and recovery delay to "Recoveries" simultaneously — confirm both work independently
- [ ] Save a rule with recovery delay set to "Recoveries" mode, reopen edit form — confirm it loads back correctly
- [ ] Switch recovery delay to "Immediate" while alert delay is on "Breaches" — confirm alert delay's pending count is preserved