### PR TITLE
feat(streams): add reset button for knowledge indicators data

### DIFF
--- a/x-pack/platform/plugins/shared/streams/server/routes/index.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/index.ts
@@ -34,6 +34,7 @@ import { internalOnboardingRoutes } from './internal/streams/onboarding/route';
 import { internalQueriesRoutes } from './internal/sig_events/queries/route';
 import { internalEligibleStreamsRoutes } from './internal/sig_events/extraction/eligible_streams_route';
 import { internalSignificantEventsSettingsRoutes } from './internal/sig_events/significant_events_settings/route';
+import { resetFeaturesRoutes } from './internal/sig_events/features/reset_route';
 import { timeSeriesRoutes } from './internal/streams/time_series/route';
 
 export const streamsRouteRepository = {
@@ -58,6 +59,7 @@ export const streamsRouteRepository = {
   ...internalQueriesRoutes,
   ...internalEligibleStreamsRoutes,
   ...internalSignificantEventsSettingsRoutes,
+  ...resetFeaturesRoutes,
   // public APIs
   ...docCountsRoutes,
   ...crudRoutes,

--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/sig_events/features/reset_route.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/sig_events/features/reset_route.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod/v4';
+import { createServerRoute } from '../../../create_server_route';
+import { assertSignificantEventsAccess } from '../../../utils/assert_significant_events_access';
+import { STREAMS_API_PRIVILEGES } from '../../../../../common/constants';
+
+export const resetFeaturesRoute = createServerRoute({
+  endpoint: 'POST /internal/streams/_significant_events/features/_reset',
+  options: {
+    access: 'internal',
+    summary: 'Reset knowledge indicators data',
+    description:
+      'Deletes all knowledge indicator data and the backing index template. The index is lazily recreated with the latest mappings on the next write.',
+  },
+  security: {
+    authz: {
+      requiredPrivileges: [STREAMS_API_PRIVILEGES.manage],
+    },
+  },
+  params: z.object({}),
+  handler: async ({ request, getScopedClients, server }): Promise<{ acknowledged: boolean }> => {
+    const { featureClient, licensing, uiSettingsClient } = await getScopedClients({ request });
+    await assertSignificantEventsAccess({ server, licensing, uiSettingsClient });
+
+    await featureClient.clean();
+
+    return { acknowledged: true };
+  },
+});
+
+export const resetFeaturesRoutes = {
+  ...resetFeaturesRoute,
+};

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/settings/tab.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/settings/tab.tsx
@@ -12,7 +12,9 @@ import {
   EuiButton,
   EuiButtonEmpty,
   EuiCallOut,
+  EuiConfirmModal,
   EuiFieldNumber,
+  useGeneratedHtmlId,
   EuiFlexGroup,
   EuiFlexItem,
   EuiForm,
@@ -68,6 +70,9 @@ export function SettingsTab() {
   });
 
   const [isSaving, setIsSaving] = useState(false);
+  const [isResetModalVisible, setIsResetModalVisible] = useState(false);
+  const [isResetting, setIsResetting] = useState(false);
+  const resetModalTitleId = useGeneratedHtmlId();
 
   const hasChanges = indexPatterns !== savedIndexPatterns || continuousExtraction.hasChanged;
 
@@ -107,6 +112,33 @@ export function SettingsTab() {
     savedIndexPatterns,
     continuousExtraction,
   ]);
+
+  const handleResetData = useCallback(async () => {
+    setIsResetting(true);
+    try {
+      await core.http.post('/internal/streams/_significant_events/features/_reset');
+      core.notifications.toasts.addSuccess({
+        title: i18n.translate(
+          'xpack.streams.significantEventsDiscovery.settings.resetSuccessTitle',
+          { defaultMessage: 'Knowledge indicators data reset' }
+        ),
+        text: i18n.translate('xpack.streams.significantEventsDiscovery.settings.resetSuccessText', {
+          defaultMessage:
+            'All knowledge indicators have been deleted. The index will be recreated with the latest mappings on next use.',
+        }),
+      });
+    } catch (err) {
+      core.notifications.toasts.addDanger({
+        title: i18n.translate('xpack.streams.significantEventsDiscovery.settings.resetErrorTitle', {
+          defaultMessage: 'Failed to reset knowledge indicators data',
+        }),
+        text: getFormattedError(err).message,
+      });
+    } finally {
+      setIsResetting(false);
+      setIsResetModalVisible(false);
+    }
+  }, [core.http, core.notifications.toasts]);
 
   return (
     <>
@@ -365,6 +397,99 @@ export function SettingsTab() {
           </EuiFlexGroup>
         </EuiPanel>
       </EuiPanel>
+
+      <EuiSpacer />
+
+      <EuiPanel hasBorder={true} hasShadow={false} paddingSize="none" grow={false}>
+        <EuiPanel hasShadow={false} color="subdued">
+          <EuiText size="s">
+            <h3>
+              {i18n.translate(
+                'xpack.streams.significantEventsDiscovery.settings.resetDataSectionTitle',
+                { defaultMessage: 'Reset knowledge indicators data' }
+              )}
+            </h3>
+          </EuiText>
+        </EuiPanel>
+        <EuiPanel hasShadow={false} hasBorder={false}>
+          <EuiFlexGroup alignItems="flexStart" gutterSize="l">
+            <EuiFlexItem grow={2}>
+              <EuiFlexGroup direction="column" gutterSize="xs">
+                <EuiFlexItem>
+                  <EuiText size="m">
+                    <h4>
+                      {i18n.translate(
+                        'xpack.streams.significantEventsDiscovery.settings.resetDataLabel',
+                        { defaultMessage: 'Delete all data' }
+                      )}
+                    </h4>
+                  </EuiText>
+                </EuiFlexItem>
+                <EuiFlexItem>
+                  <EuiText color="subdued" size="s">
+                    {i18n.translate(
+                      'xpack.streams.significantEventsDiscovery.settings.resetDataHelp',
+                      {
+                        defaultMessage:
+                          'Permanently deletes all discovered knowledge indicators and removes the backing index. The index is automatically recreated with the latest mappings on next use. This is useful when upgrading from an older version with outdated mappings.',
+                      }
+                    )}
+                  </EuiText>
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            </EuiFlexItem>
+            <EuiFlexItem grow={5}>
+              <EuiButton
+                data-test-subj="streams-settings-reset-data-button"
+                color="danger"
+                onClick={() => setIsResetModalVisible(true)}
+                isLoading={isResetting}
+              >
+                {i18n.translate(
+                  'xpack.streams.significantEventsDiscovery.settings.resetDataButton',
+                  { defaultMessage: 'Reset data' }
+                )}
+              </EuiButton>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiPanel>
+      </EuiPanel>
+
+      {isResetModalVisible && (
+        <EuiConfirmModal
+          aria-labelledby={resetModalTitleId}
+          data-test-subj="streams-settings-reset-data-confirm-modal"
+          title={i18n.translate(
+            'xpack.streams.significantEventsDiscovery.settings.resetConfirmTitle',
+            { defaultMessage: 'Reset knowledge indicators data?' }
+          )}
+          titleProps={{ id: resetModalTitleId }}
+          onCancel={() => setIsResetModalVisible(false)}
+          onConfirm={handleResetData}
+          cancelButtonText={i18n.translate(
+            'xpack.streams.significantEventsDiscovery.settings.resetConfirmCancel',
+            { defaultMessage: 'Cancel' }
+          )}
+          confirmButtonText={i18n.translate(
+            'xpack.streams.significantEventsDiscovery.settings.resetConfirmButton',
+            { defaultMessage: 'Reset data' }
+          )}
+          buttonColor="danger"
+          isLoading={isResetting}
+        >
+          <EuiText size="s">
+            <p>
+              {i18n.translate(
+                'xpack.streams.significantEventsDiscovery.settings.resetConfirmBody',
+                {
+                  defaultMessage:
+                    'This will permanently delete all discovered knowledge indicators. The index will be recreated with the latest mappings on next use. This action cannot be undone.',
+                }
+              )}
+            </p>
+          </EuiText>
+        </EuiConfirmModal>
+      )}
 
       {hasChanges && (
         <EuiBottomBar data-test-subj="streams-significant-events-settings-bottom-bar">


### PR DESCRIPTION
The .kibana_streams_features system index cannot be deleted through Dev Tools. When clusters migrate from older versions the index may retain stale mappings. This adds a "Reset data" button to the Significant Events settings that wipes the index and template so they are lazily recreated with the latest schema on next write.


<img width="1362" height="236" alt="Screenshot 2026-04-08 at 15 15 54" src="https://github.com/user-attachments/assets/0c8be41f-4e1e-4cb4-8c9d-a7feeb5e4c20" />
