### PR TITLE
[9.2] [Security/CSP] Fix missing accessible label on Findings flyout history button (WCAG 4.1.2) (#258571)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/shared/components/flyout_history.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/shared/components/flyout_history.tsx
@@ -36,6 +36,13 @@ const flyoutHistoryButtonTooltip = i18n.translate(
   }
 );
 
+const flyoutHistoryButtonAriaLabel = i18n.translate(
+  'xpack.securitySolution.flyout.right.header.flyoutHistoryButtonAriaLabel',
+  {
+    defaultMessage: 'Show history',
+  }
+);
+
 export interface HistoryProps {
   /**
    * A list of flyouts that have been opened
@@ -92,6 +99,7 @@ export const FlyoutHistory: FC<HistoryProps> = memo(({ history }) => {
               onClick={togglePopover}
               size="m"
               iconType={'clockCounter'}
+              aria-label={flyoutHistoryButtonAriaLabel}
               data-test-subj={FLYOUT_HISTORY_BUTTON_TEST_ID}
             />
           </EuiToolTip>


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[Security/CSP] Fix missing accessible label on Findings flyout history button (WCAG 4.1.2) (#258571)](https://github.com/elastic/kibana/pull/258571)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Copilot","email":"198982749+Copilot@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-03-25T10:45:26Z","message":"[Security/CSP] Fix missing accessible label on Findings flyout history button (WCAG 4.1.2) (#258571)","sha":"e681825d1fb35091de78c9263495763fde3eb8a3","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Project:Accessibility","release_note:skip","backport missing","💝community","backport:all-open","a11y:agent-pr"],"title":"[Security/CSP] Fix missing accessible label on Findings flyout history button (WCAG 4.1.2)","number":258571,"url":"https://github.com/elastic/kibana/pull/258571","mergeCommit":{"message":"[Security/CSP] Fix missing accessible label on Findings flyout history button (WCAG 4.1.2) (#258571)","sha":"e681825d1fb35091de78c9263495763fde3eb8a3"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"url":"https://github.com/elastic/kibana/pull/261990","number":261990,"branch":"9.3","state":"OPEN"}]}] BACKPORT-->