### PR TITLE
[Security Solution] fix multiple small UI issues in new document flyout

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/components/header_title.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/components/header_title.tsx
@@ -10,6 +10,7 @@ import { EuiBadge, EuiFlexGroup, EuiFlexItem, EuiSpacer } from '@elastic/eui';
 
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
+import { flyoutHeaderBlockStyles } from '../../../flyout_v2/document/constants/styles';
 import { FlyoutTitle } from '../../../flyout_v2/shared/components/flyout_title';
 import { PreferenceFormattedDate } from '../../../common/components/formatted_date';
 import { Status } from './status';
@@ -25,11 +26,6 @@ import {
 import { useHeaderData } from '../hooks/use_header_data';
 import { useAttackDetailsContext } from '../context';
 import { useNavigateToAttackDetailsLeftPanel } from '../hooks/use_navigate_to_attack_details_left_panel';
-
-// minWidth for each block, allows to switch for a 1 row 4 blocks to 2 rows with 2 block each
-const blockStyles = {
-  minWidth: 280,
-};
 
 const ATTACK_HEADER_BADGE = i18n.translate(
   'xpack.securitySolution.attackDetailsFlyout.header.badge.attackLabel',
@@ -66,7 +62,7 @@ export const HeaderTitle = memo(() => {
       <FlyoutTitle data-test-subj={HEADER_TITLE_TEST_ID} title={title} iconType={'bolt'} />
       <EuiSpacer size="m" />
       <EuiFlexGroup direction="row" gutterSize="s" responsive={false} wrap>
-        <EuiFlexItem css={blockStyles}>
+        <EuiFlexItem css={flyoutHeaderBlockStyles}>
           <EuiFlexGroup direction="row" gutterSize="s" responsive={false}>
             <EuiFlexItem>
               <Status />

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/about_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/about_section.tsx
@@ -145,7 +145,7 @@ export const AboutSection = memo(() => {
       title={ABOUT_SECTION_TITLE}
       localStorageKey={FLYOUT_STORAGE_KEYS.OVERVIEW_TAB_EXPANDED_SECTIONS}
       sectionId={KEY}
-      gutterSize="s"
+      gutterSize="none"
       data-test-subj={ABOUT_SECTION_TEST_ID}
     >
       {content}

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/alert_header_title.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/alert_header_title.tsx
@@ -9,6 +9,7 @@ import React, { memo, useCallback, useMemo } from 'react';
 import { buildDataTableRecord, type EsHitRecord } from '@kbn/discover-utils';
 import { EuiFlexGroup, EuiFlexItem, EuiSpacer } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { flyoutHeaderBlockStyles } from '../../../../flyout_v2/document/constants/styles';
 import { useRefetchByScope } from '../../../../flyout_v2/document/hooks/use_refetch_by_scope';
 import { useDocumentDetailsContext } from '../../shared/context';
 import { useNavigateToLeftPanel } from '../../shared/hooks/use_navigate_to_left_panel';
@@ -26,11 +27,6 @@ import { Status } from '../../../../flyout_v2/document/components/status';
 import type { CellActionRenderer } from '../../../../flyout_v2/shared/components/cell_actions';
 import { getEmptyTagValue } from '../../../../common/components/empty_value';
 import { CellActions } from '../../shared/components/cell_actions';
-
-// minWidth for each block, allows to switch for a 1 row 4 blocks to 2 rows with 2 block each
-const blockStyles = {
-  minWidth: 280,
-};
 
 /**
  * Alert details flyout right section header
@@ -96,7 +92,7 @@ export const AlertHeaderTitle = memo(() => {
         wrap
         data-test-subj={ALERT_SUMMARY_PANEL_TEST_ID}
       >
-        <EuiFlexItem css={blockStyles}>
+        <EuiFlexItem css={flyoutHeaderBlockStyles}>
           <EuiFlexGroup direction="row" gutterSize="s" responsive={false}>
             <EuiFlexItem>{status}</EuiFlexItem>
             <EuiFlexItem>
@@ -104,7 +100,7 @@ export const AlertHeaderTitle = memo(() => {
             </EuiFlexItem>
           </EuiFlexGroup>
         </EuiFlexItem>
-        <EuiFlexItem css={blockStyles}>
+        <EuiFlexItem css={flyoutHeaderBlockStyles}>
           <EuiFlexGroup direction="row" gutterSize="s" responsive={false}>
             <EuiFlexItem>
               <Assignees hit={hit} onAlertUpdated={onAlertUpdated} showAssignees={!isRulePreview} />

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/about_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/about_section.tsx
@@ -63,7 +63,7 @@ export const AboutSection = memo(({ hit }: AboutSectionProps) => {
     <ExpandableSection
       data-test-subj={ABOUT_SECTION_TEST_ID}
       expanded={expanded}
-      gutterSize="m"
+      gutterSize="none"
       localStorageKey={FLYOUT_STORAGE_KEYS.OVERVIEW_TAB_EXPANDED_SECTIONS}
       sectionId={LOCAL_STORAGE_SECTION_KEY}
       title={ABOUT_SECTION_TITLE}

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/alert_reason.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/alert_reason.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { EuiButtonEmpty, EuiFlexGroup, EuiFlexItem, EuiTitle } from '@elastic/eui';
+import { EuiButtonEmpty, EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiTitle } from '@elastic/eui';
 import { type DataTableRecord, getFieldValue } from '@kbn/discover-utils';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
@@ -90,42 +90,45 @@ export const AlertReason: FC<AlertReasonProps> = ({ hit, onShowFullReason }) => 
   );
 
   return (
-    <EuiFlexGroup direction="column" gutterSize="s">
-      <EuiFlexItem data-test-subj={REASON_TITLE_TEST_ID}>
-        <EuiTitle size="xxs">
-          <h5>
-            {isAlert ? (
-              <EuiFlexGroup
-                justifyContent="spaceBetween"
-                alignItems="center"
-                gutterSize="none"
-                responsive={false}
-              >
-                <EuiFlexItem grow={false}>
-                  <h5>
-                    <FormattedMessage
-                      id="xpack.securitySolution.flyout.document.about.reason.alertReasonTitle"
-                      defaultMessage="Alert reason"
-                    />
-                  </h5>
-                </EuiFlexItem>
-                {viewPreview}
-              </EuiFlexGroup>
-            ) : (
-              <p>
-                <FormattedMessage
-                  id="xpack.securitySolution.flyout.document.about.reason.documentReasonTitle"
-                  defaultMessage="Document reason"
-                />
-              </p>
-            )}
-          </h5>
-        </EuiTitle>
-      </EuiFlexItem>
-      <EuiFlexItem data-test-subj={REASON_DETAILS_TEST_ID}>
-        {isAlert ? alertReasonText : '-'}
-      </EuiFlexItem>
-    </EuiFlexGroup>
+    <>
+      <EuiSpacer size="m" />
+      <EuiFlexGroup direction="column" gutterSize="s">
+        <EuiFlexItem data-test-subj={REASON_TITLE_TEST_ID}>
+          <EuiTitle size="xxs">
+            <h5>
+              {isAlert ? (
+                <EuiFlexGroup
+                  justifyContent="spaceBetween"
+                  alignItems="center"
+                  gutterSize="none"
+                  responsive={false}
+                >
+                  <EuiFlexItem grow={false}>
+                    <h5>
+                      <FormattedMessage
+                        id="xpack.securitySolution.flyout.document.about.reason.alertReasonTitle"
+                        defaultMessage="Alert reason"
+                      />
+                    </h5>
+                  </EuiFlexItem>
+                  {viewPreview}
+                </EuiFlexGroup>
+              ) : (
+                <p>
+                  <FormattedMessage
+                    id="xpack.securitySolution.flyout.document.about.reason.documentReasonTitle"
+                    defaultMessage="Document reason"
+                  />
+                </p>
+              )}
+            </h5>
+          </EuiTitle>
+        </EuiFlexItem>
+        <EuiFlexItem data-test-subj={REASON_DETAILS_TEST_ID}>
+          {isAlert ? alertReasonText : '-'}
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </>
   );
 };
 

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/alert_status.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/alert_status.tsx
@@ -52,20 +52,25 @@ export const AlertStatus = memo(({ hit }: AlertStatusProps) => {
   }
 
   return (
-    <EuiFlexGroup direction="column" gutterSize="s">
-      <EuiSpacer size="xs" />
-      <EuiFlexItem data-test-subj={WORKFLOW_STATUS_TITLE_TEST_ID}>
-        <EuiTitle size="xxs">
-          <h5>
-            <FormattedMessage
-              id="xpack.securitySolution.flyout.document.about.status.statusHistoryTitle"
-              defaultMessage="Last alert status change"
-            />
-          </h5>
-        </EuiTitle>
-      </EuiFlexItem>
-      <EuiFlexItem data-test-subj={WORKFLOW_STATUS_DETAILS_TEST_ID}>{lastStatusChange}</EuiFlexItem>
-    </EuiFlexGroup>
+    <>
+      <EuiSpacer size="m" />
+      <EuiFlexGroup direction="column" gutterSize="s">
+        <EuiSpacer size="xs" />
+        <EuiFlexItem data-test-subj={WORKFLOW_STATUS_TITLE_TEST_ID}>
+          <EuiTitle size="xxs">
+            <h5>
+              <FormattedMessage
+                id="xpack.securitySolution.flyout.document.about.status.statusHistoryTitle"
+                defaultMessage="Last alert status change"
+              />
+            </h5>
+          </EuiTitle>
+        </EuiFlexItem>
+        <EuiFlexItem data-test-subj={WORKFLOW_STATUS_DETAILS_TEST_ID}>
+          {lastStatusChange}
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </>
   );
 });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/mitre_attack.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/mitre_attack.tsx
@@ -52,17 +52,20 @@ export const MitreAttack: FC<MitreAttackProps> = ({ hit }) => {
   }
 
   return (
-    <EuiFlexGroup direction="column" gutterSize="s">
+    <>
       <EuiSpacer size="m" />
-      <EuiFlexItem data-test-subj={MITRE_ATTACK_TITLE_TEST_ID}>
-        <EuiTitle size="xxs">
-          <h5>{threatDetails[0].title}</h5>
-        </EuiTitle>
-      </EuiFlexItem>
-      <EuiFlexItem data-test-subj={MITRE_ATTACK_DETAILS_TEST_ID}>
-        {threatDetails[0].description}
-      </EuiFlexItem>
-    </EuiFlexGroup>
+      <EuiFlexGroup direction="column" gutterSize="s">
+        <EuiSpacer size="m" />
+        <EuiFlexItem data-test-subj={MITRE_ATTACK_TITLE_TEST_ID}>
+          <EuiTitle size="xxs">
+            <h5>{threatDetails[0].title}</h5>
+          </EuiTitle>
+        </EuiFlexItem>
+        <EuiFlexItem data-test-subj={MITRE_ATTACK_DETAILS_TEST_ID}>
+          {threatDetails[0].description}
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </>
   );
 };
 

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/severity.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/severity.tsx
@@ -11,7 +11,7 @@ import { getFieldValue } from '@kbn/discover-utils';
 import { ALERT_SEVERITY } from '@kbn/rule-data-utils';
 import type { Severity } from '@kbn/securitysolution-io-ts-alerting-types';
 import { upperFirst } from 'lodash/fp';
-import { EuiBadge, useEuiTheme } from '@elastic/eui';
+import { EuiBadge, EuiSpacer, useEuiTheme } from '@elastic/eui';
 import { SEVERITY_VALUE_TEST_ID } from './test_ids';
 import { useRiskSeverityColors } from '../../../common/utils/risk_color_palette';
 
@@ -70,9 +70,12 @@ export const DocumentSeverity = memo(({ hit }: DocumentSeverityProps) => {
   return (
     <>
       {displayValue != null && (
-        <EuiBadge color={color} data-test-subj={SEVERITY_VALUE_TEST_ID}>
-          {displayValue}
-        </EuiBadge>
+        <>
+          <EuiBadge color={color} data-test-subj={SEVERITY_VALUE_TEST_ID}>
+            {displayValue}
+          </EuiBadge>
+          <EuiSpacer size="m" />
+        </>
       )}
     </>
   );

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/timestamp.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/timestamp.tsx
@@ -9,6 +9,7 @@ import React, { memo, useMemo } from 'react';
 import type { DataTableRecord } from '@kbn/discover-utils';
 import { getFieldValue } from '@kbn/discover-utils';
 import { TIMESTAMP } from '@kbn/rule-data-utils';
+import { EuiSpacer } from '@elastic/eui';
 import { PreferenceFormattedDate } from '../../../common/components/formatted_date';
 import { TIMESTAMP_TEST_ID } from './test_ids';
 
@@ -27,7 +28,12 @@ export const Timestamp = memo(({ hit }: DocumentTimestampProps) => {
 
   if (!timestamp) return null;
 
-  return <PreferenceFormattedDate value={new Date(timestamp)} data-test-subj={TIMESTAMP_TEST_ID} />;
+  return (
+    <>
+      <PreferenceFormattedDate value={new Date(timestamp)} data-test-subj={TIMESTAMP_TEST_ID} />
+      <EuiSpacer size="xs" />
+    </>
+  );
 });
 
 Timestamp.displayName = 'Timestamp';

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/visualizations_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/visualizations_section.tsx
@@ -123,7 +123,7 @@ export const VisualizationsSection = memo(
       <ExpandableSection
         data-test-subj={VISUALIZATION_SECTION_TEST_ID}
         expanded={expanded}
-        gutterSize="s"
+        gutterSize="m"
         localStorageKey={FLYOUT_STORAGE_KEYS.OVERVIEW_TAB_EXPANDED_SECTIONS}
         sectionId={LOCAL_STORAGE_SECTION_KEY}
         title={VISUALIZATION_SECTION_TITLE}

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/constants/styles.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/constants/styles.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * minWidth for each block rendered in the flyout header.
+ * Allows to switch for a 1 row 4 blocks to 2 rows with 2 block each
+ */
+export const flyoutHeaderBlockStyles = {
+  minWidth: 280,
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/header.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/header.tsx
@@ -11,6 +11,7 @@ import { EuiFlexGroup, EuiFlexItem, EuiSpacer } from '@elastic/eui';
 import type { DataTableRecord } from '@kbn/discover-utils';
 import { getFieldValue } from '@kbn/discover-utils';
 import { EVENT_KIND } from '@kbn/rule-data-utils';
+import { flyoutHeaderBlockStyles } from './constants/styles';
 import { EventKind } from './constants/event_kinds';
 import { Assignees } from './components/assignees';
 import { Title } from './components/title';
@@ -22,11 +23,6 @@ import { RiskScore } from './components/risk_score';
 import { ALERT_SUMMARY_PANEL_TEST_ID } from '../shared/components/test_ids';
 import type { CellActionRenderer } from '../shared/components/cell_actions';
 import { noopCellActionRenderer } from '../shared/components/cell_actions';
-
-// minWidth for each block, allows to switch for a 1 row 4 blocks to 2 rows with 2 block each
-const blockStyles = {
-  minWidth: 280,
-};
 
 export interface HeaderProps {
   /**
@@ -62,9 +58,7 @@ export const Header: FC<HeaderProps> = memo(
     return (
       <>
         <DocumentSeverity hit={hit} />
-        <EuiSpacer size="m" />
         <Timestamp hit={hit} />
-        <EuiSpacer size="xs" />
         <Title hit={hit} />
         {isAlert && (
           <>
@@ -76,7 +70,7 @@ export const Header: FC<HeaderProps> = memo(
               wrap
               data-test-subj={ALERT_SUMMARY_PANEL_TEST_ID}
             >
-              <EuiFlexItem css={blockStyles}>
+              <EuiFlexItem css={flyoutHeaderBlockStyles}>
                 <EuiFlexGroup direction="row" gutterSize="s" responsive={false}>
                   <EuiFlexItem>
                     <Status
@@ -90,7 +84,7 @@ export const Header: FC<HeaderProps> = memo(
                   </EuiFlexItem>
                 </EuiFlexGroup>
               </EuiFlexItem>
-              <EuiFlexItem css={blockStyles}>
+              <EuiFlexItem css={flyoutHeaderBlockStyles}>
                 <EuiFlexGroup direction="row" gutterSize="s" responsive={false}>
                   <EuiFlexItem>
                     <Assignees hit={hit} onAlertUpdated={onAlertUpdated} />

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/alert_header_block.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/alert_header_block.tsx
@@ -7,17 +7,22 @@
 
 import type { ReactElement, ReactNode } from 'react';
 import React, { memo } from 'react';
+import type { EuiFlexGroupProps } from '@elastic/eui';
 import { EuiFlexGroup, EuiFlexItem, EuiPanel, EuiTitle } from '@elastic/eui';
 
 export interface AlertHeaderBlockProps {
   /**
-   * React component to render as the title
-   */
-  title: ReactElement;
-  /**
    * React component to render as the value
    */
   children: ReactNode;
+  /**
+   * data-test-subj to use for the title
+   */
+  ['data-test-subj']?: string;
+  /**
+   * Gutter size (vertical) between title and content
+   */
+  gutterSize?: EuiFlexGroupProps['gutterSize'];
   /**
    * If true, adds a slight 1px border on all edges.
    * False by default.
@@ -25,9 +30,9 @@ export interface AlertHeaderBlockProps {
    */
   hasBorder?: boolean;
   /**
-   * data-test-subj to use for the title
+   * React component to render as the title
    */
-  ['data-test-subj']?: string;
+  title: ReactElement;
 }
 
 /**
@@ -35,13 +40,19 @@ export interface AlertHeaderBlockProps {
  */
 export const AlertHeaderBlock = memo(
   ({
-    title,
     children,
+    gutterSize = 's',
     hasBorder = false,
+    title,
     'data-test-subj': dataTestSubj,
   }: AlertHeaderBlockProps) => (
     <EuiPanel hasShadow={false} hasBorder={hasBorder} paddingSize="s">
-      <EuiFlexGroup direction="column" gutterSize="xs" responsive={false} alignItems="flexStart">
+      <EuiFlexGroup
+        direction="column"
+        gutterSize={gutterSize}
+        responsive={false}
+        alignItems="flexStart"
+      >
         <EuiFlexItem grow={false}>
           <EuiTitle size="xxs" data-test-subj={dataTestSubj}>
             <h3>{title}</h3>

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/notes.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/notes.tsx
@@ -159,6 +159,7 @@ export const Notes = memo(({ documentId, onShowNotes, disabled = false }: NotesP
 
   return (
     <AlertHeaderBlock
+      gutterSize="xs"
       hasBorder
       title={
         <FormattedMessage

--- a/x-pack/solutions/security/plugins/security_solution/public/one_discover/alert_flyout_overview_tab_component/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/one_discover/alert_flyout_overview_tab_component/index.tsx
@@ -8,6 +8,7 @@
 import React, { useEffect, useState } from 'react';
 import type { DataTableRecord } from '@kbn/discover-utils';
 import { useSelector } from 'react-redux';
+import { EuiSpacer } from '@elastic/eui';
 import { noopCellActionRenderer } from '../../flyout_v2/shared/components/cell_actions';
 import { OverviewTab } from '../../flyout_v2/document/tabs/overview_tab';
 import type { SecurityAppStore, State } from '../../common/store/types';
@@ -97,6 +98,7 @@ export const AlertFlyoutOverviewTab = ({
       <>
         <DataViewManagerBootstrap />
         {/* TODO: implement Discover cell actions - see https://github.com/elastic/kibana/issues/258858*/}
+        <EuiSpacer size="m" />
         <OverviewTab
           hit={hit}
           renderCellActions={noopCellActionRenderer}


### PR DESCRIPTION
## Summary

This PR fixes a few super small UI issues like missing spaces or too many spaces:


Missing space above the `About` section when rendered in Discover
And also too many spaces within the `About` section when components are not shown

| Before  | After |
| ------------- | ------------- |
| <img width="488" height="485" alt="Screenshot 2026-04-07 at 11 30 02 PM" src="https://github.com/user-attachments/assets/87f7b397-c61e-4da6-adcb-c6c685bd5793" /> | <img width="491" height="426" alt="Screenshot 2026-04-08 at 9 11 54 AM" src="https://github.com/user-attachments/assets/96a056b3-d7b3-4cb2-b524-2b3208ca660d" /> |

The old flyout remains untouched
<img width="401" height="544" alt="Screenshot 2026-04-08 at 9 16 19 AM" src="https://github.com/user-attachments/assets/835e4b36-3f50-4143-a671-6e353954c6f6" />

Remove unnecessary space above timestamp for event flyout

| Before  | After |
| ------------- | ------------- |
| <img width="498" height="212" alt="Screenshot 2026-04-08 at 9 16 52 AM" src="https://github.com/user-attachments/assets/2a314015-d9e1-4464-9c4b-a73752c21b3b" /> | <img width="503" height="211" alt="Screenshot 2026-04-08 at 9 18 27 AM" src="https://github.com/user-attachments/assets/d36f6c03-5d32-458c-91b8-0fa76becf9b2" /> |

Better align all the blocks in the alert header

| Before | After |
| ------------- | ------------- |
| <img width="736" height="83" alt="Screenshot 2026-04-08 at 9 36 05 AM" src="https://github.com/user-attachments/assets/16804ff8-f01a-4f4d-a363-977a63e9908b" /> | <img width="653" height="92" alt="Screenshot 2026-04-08 at 9 35 50 AM" src="https://github.com/user-attachments/assets/12d7291e-f006-44f6-a2a2-13afe9a63277" /> |

Fix space between analyzer and session view that was too small

| Before | After |
| ------------- | ------------- |
| <img width="550" height="376" alt="Screenshot 2026-04-08 at 9 38 11 AM" src="https://github.com/user-attachments/assets/17703505-4774-4b8b-8f69-286b935b147f" /> | <img width="547" height="380" alt="Screenshot 2026-04-08 at 9 37 43 AM" src="https://github.com/user-attachments/assets/a876a1e7-f38a-4886-a77e-4c7345d5aaa2" /> |

### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
