### PR TITLE
[8.19] [@kbn/scout] Fix flaky `openNewDashboard` (#260911)

### DIFF
--- a/src/platform/packages/shared/kbn-scout/src/playwright/page_objects/dashboard_app.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/page_objects/dashboard_app.ts
@@ -131,7 +131,7 @@ export class DashboardApp {
   /** Navigates to the new dashboard creation page and waits for the editor toolbar to load. */
   async openNewDashboard() {
     await this.page.gotoApp('dashboards', { hash: '/create' });
-    await expect(this.addTopNavButton).toBeVisible({ timeout: 20_000 });
+    await expect(this.addPanelButton).toBeVisible({ timeout: 20_000 });
   }
 
   private getSettingsFlyout() {

--- a/src/platform/packages/shared/kbn-scout/src/playwright/page_objects/dashboard_app.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/page_objects/dashboard_app.ts
@@ -128,10 +128,10 @@ export class DashboardApp {
     await this.waitForRenderComplete();
   }
 
-  /** Clicks "Create new dashboard" on the listing page and waits for the editor toolbar to load. */
+  /** Navigates to the new dashboard creation page and waits for the editor toolbar to load. */
   async openNewDashboard() {
-    await this.page.testSubj.click('newItemButton');
-    await expect(this.addPanelButton).toBeVisible();
+    await this.page.gotoApp('dashboards', { hash: '/create' });
+    await expect(this.addTopNavButton).toBeVisible({ timeout: 20_000 });
   }
 
   private getSettingsFlyout() {

--- a/src/platform/plugins/shared/dashboard/test/scout/ui/parallel_tests/dashboard_lens_by_value.spec.ts
+++ b/src/platform/plugins/shared/dashboard/test/scout/ui/parallel_tests/dashboard_lens_by_value.spec.ts
@@ -37,7 +37,6 @@ spaceTest.describe('Lens by-value panels (dashboard)', { tag: tags.deploymentAgn
 
   spaceTest.beforeEach(async ({ browserAuth, pageObjects }) => {
     await browserAuth.loginAsPrivilegedUser();
-    await pageObjects.dashboard.goto();
     await pageObjects.dashboard.openNewDashboard();
   });
 

--- a/src/platform/plugins/shared/dashboard/test/scout/ui/parallel_tests/dashboard_maps_by_value.spec.ts
+++ b/src/platform/plugins/shared/dashboard/test/scout/ui/parallel_tests/dashboard_maps_by_value.spec.ts
@@ -25,7 +25,6 @@ spaceTest.describe('Maps by-value panels (dashboard)', { tag: tags.deploymentAgn
 
   spaceTest.beforeEach(async ({ browserAuth, pageObjects, page }) => {
     await browserAuth.loginAsPrivilegedUser();
-    await pageObjects.dashboard.goto();
     await pageObjects.dashboard.openNewDashboard();
     dashboardUrl = page.url();
   });

--- a/src/platform/plugins/shared/dashboard/test/scout/ui/parallel_tests/dashboard_panel_listing.spec.ts
+++ b/src/platform/plugins/shared/dashboard/test/scout/ui/parallel_tests/dashboard_panel_listing.spec.ts
@@ -36,9 +36,8 @@ spaceTest.describe(
       await scoutSpace.uiSettings.setDefaultIndex(DASHBOARD_DEFAULT_INDEX_TITLE);
     });
 
-    spaceTest.beforeEach(async ({ browserAuth, pageObjects }) => {
+    spaceTest.beforeEach(async ({ browserAuth }) => {
       await browserAuth.loginAsPrivilegedUser();
-      await pageObjects.dashboard.goto();
     });
 
     spaceTest.afterAll(async ({ scoutSpace }) => {

--- a/src/platform/plugins/shared/dashboard/test/scout/ui/parallel_tests/dashboard_panel_listing_obs_group.spec.ts
+++ b/src/platform/plugins/shared/dashboard/test/scout/ui/parallel_tests/dashboard_panel_listing_obs_group.spec.ts
@@ -31,9 +31,8 @@ spaceTest.describe(
       await scoutSpace.uiSettings.setDefaultIndex(DASHBOARD_DEFAULT_INDEX_TITLE);
     });
 
-    spaceTest.beforeEach(async ({ browserAuth, pageObjects }) => {
+    spaceTest.beforeEach(async ({ browserAuth }) => {
       await browserAuth.loginAsPrivilegedUser();
-      await pageObjects.dashboard.goto();
     });
 
     spaceTest.afterAll(async ({ scoutSpace }) => {

--- a/src/platform/plugins/shared/dashboard/test/scout/ui/parallel_tests/dashboard_search_by_value.spec.ts
+++ b/src/platform/plugins/shared/dashboard/test/scout/ui/parallel_tests/dashboard_search_by_value.spec.ts
@@ -26,7 +26,6 @@ spaceTest.describe('Saved search panels (dashboard)', { tag: tags.deploymentAgno
 
   spaceTest.beforeEach(async ({ browserAuth, pageObjects }) => {
     await browserAuth.loginAsPrivilegedUser();
-    await pageObjects.dashboard.goto();
     await pageObjects.dashboard.openNewDashboard();
 
     // add saved search from library

--- a/src/platform/plugins/shared/dashboard/test/scout/ui/parallel_tests/panel_time_range.spec.ts
+++ b/src/platform/plugins/shared/dashboard/test/scout/ui/parallel_tests/panel_time_range.spec.ts
@@ -19,7 +19,6 @@ import {
 const DASHBOARD_NAME_PREFIX = 'Panel time range';
 
 const createDashboard = async (pageObjects: PageObjects, dashboardName: string) => {
-  await pageObjects.dashboard.goto();
   await pageObjects.dashboard.openNewDashboard();
   await pageObjects.dashboard.saveDashboard(dashboardName);
 };

--- a/src/platform/plugins/shared/dashboard/test/scout/ui/parallel_tests/panel_titles.spec.ts
+++ b/src/platform/plugins/shared/dashboard/test/scout/ui/parallel_tests/panel_titles.spec.ts
@@ -44,7 +44,6 @@ spaceTest.describe('Panel titles (dashboard)', { tag: tags.deploymentAgnostic },
 
   spaceTest.beforeEach(async ({ browserAuth, pageObjects }) => {
     await browserAuth.loginAsPrivilegedUser();
-    await pageObjects.dashboard.goto();
     await pageObjects.dashboard.openNewDashboard();
     await pageObjects.dashboard.waitForRenderComplete();
   });

--- a/src/platform/plugins/shared/dashboard/test/scout/ui/parallel_tests/sync_colors.spec.ts
+++ b/src/platform/plugins/shared/dashboard/test/scout/ui/parallel_tests/sync_colors.spec.ts
@@ -107,7 +107,6 @@ spaceTest.describe('Sync colors', { tag: tags.deploymentAgnostic }, () => {
     await page.addInitScript(() => {
       window._echDebugStateFlag = true;
     });
-    await pageObjects.dashboard.goto();
     await pageObjects.dashboard.openNewDashboard();
   });
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[@kbn/scout] Fix flaky `openNewDashboard` (#260911)](https://github.com/elastic/kibana/pull/260911)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Stelios Mavro","email":"81311181+steliosmavro@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-04-08T14:11:24Z","message":"[@kbn/scout] Fix flaky `openNewDashboard` (#260911)\n\n## Summary\n\n`openNewDashboard()` in the Scout `DashboardApp` page object was flaking\non cloud-serverless-search environments. After\n`goto('/app/dashboards')`, the listing page runs\n`syncGlobalQueryStateWithUrl()` which updates the URL hash as part of\nsyncing global query state. On slower environments this update was still\nin-flight when `page.testSubj.click('newItemButton')` was called.\nPlaywright's `click()` waits for any pending navigations to finish\nbefore acting, and on cloud serverless with a large archive, this wait\nexceeded the 10s timeout.\n\nCloses https://github.com/elastic/kibana/issues/259443\nCloses https://github.com/elastic/kibana/issues/259903\n\n## Changes\n\n- `openNewDashboard()` now navigates directly to\n`/app/dashboards#/create` instead of clicking `newItemButton` on the\nlisting page\n- Consistent with the existing `openDashboardWithId()` pattern right\nabove it\n- The `newItemButton` click was never the intent of any test using this\nhelper, it was just navigation boilerplate to reach a new empty\ndashboard","sha":"79017198c4d8ea211537639bd7d15019afafc8a8","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:all-open","test:scout","v9.4.0"],"title":"[@kbn/scout] Fix flaky `openNewDashboard`","number":260911,"url":"https://github.com/elastic/kibana/pull/260911","mergeCommit":{"message":"[@kbn/scout] Fix flaky `openNewDashboard` (#260911)\n\n## Summary\n\n`openNewDashboard()` in the Scout `DashboardApp` page object was flaking\non cloud-serverless-search environments. After\n`goto('/app/dashboards')`, the listing page runs\n`syncGlobalQueryStateWithUrl()` which updates the URL hash as part of\nsyncing global query state. On slower environments this update was still\nin-flight when `page.testSubj.click('newItemButton')` was called.\nPlaywright's `click()` waits for any pending navigations to finish\nbefore acting, and on cloud serverless with a large archive, this wait\nexceeded the 10s timeout.\n\nCloses https://github.com/elastic/kibana/issues/259443\nCloses https://github.com/elastic/kibana/issues/259903\n\n## Changes\n\n- `openNewDashboard()` now navigates directly to\n`/app/dashboards#/create` instead of clicking `newItemButton` on the\nlisting page\n- Consistent with the existing `openDashboardWithId()` pattern right\nabove it\n- The `newItemButton` click was never the intent of any test using this\nhelper, it was just navigation boilerplate to reach a new empty\ndashboard","sha":"79017198c4d8ea211537639bd7d15019afafc8a8"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/260911","number":260911,"mergeCommit":{"message":"[@kbn/scout] Fix flaky `openNewDashboard` (#260911)\n\n## Summary\n\n`openNewDashboard()` in the Scout `DashboardApp` page object was flaking\non cloud-serverless-search environments. After\n`goto('/app/dashboards')`, the listing page runs\n`syncGlobalQueryStateWithUrl()` which updates the URL hash as part of\nsyncing global query state. On slower environments this update was still\nin-flight when `page.testSubj.click('newItemButton')` was called.\nPlaywright's `click()` waits for any pending navigations to finish\nbefore acting, and on cloud serverless with a large archive, this wait\nexceeded the 10s timeout.\n\nCloses https://github.com/elastic/kibana/issues/259443\nCloses https://github.com/elastic/kibana/issues/259903\n\n## Changes\n\n- `openNewDashboard()` now navigates directly to\n`/app/dashboards#/create` instead of clicking `newItemButton` on the\nlisting page\n- Consistent with the existing `openDashboardWithId()` pattern right\nabove it\n- The `newItemButton` click was never the intent of any test using this\nhelper, it was just navigation boilerplate to reach a new empty\ndashboard","sha":"79017198c4d8ea211537639bd7d15019afafc8a8"}},{"url":"https://github.com/elastic/kibana/pull/262009","number":262009,"branch":"9.2","state":"OPEN"}]}] BACKPORT-->