### PR TITLE
[9.2] Update SAML logs and request ID retrieval (#249037)

### DIFF
--- a/packages/kbn-mock-idp-plugin/public/login_page.tsx
+++ b/packages/kbn-mock-idp-plugin/public/login_page.tsx
@@ -50,6 +50,7 @@ export const LoginPage = ({ config }: { config: ConfigType }) => {
         full_name: values.full_name,
         email: sanitizeEmail(values.full_name),
         roles: [values.role],
+        url: window.location.href,
       });
     },
   });

--- a/packages/kbn-mock-idp-plugin/public/role_switcher.tsx
+++ b/packages/kbn-mock-idp-plugin/public/role_switcher.tsx
@@ -125,6 +125,7 @@ export const RoleSwitcher = () => {
                   full_name: currentUserState.value!.full_name,
                   email: currentUserState.value!.email,
                   roles: [role],
+                  url: window.location.href,
                 });
                 setIsOpen(false);
               },

--- a/packages/kbn-mock-idp-plugin/server/plugin.ts
+++ b/packages/kbn-mock-idp-plugin/server/plugin.ts
@@ -21,6 +21,7 @@ import {
 } from '@kbn/es';
 import type { ServerlessProductTier } from '@kbn/es/src/utils';
 import { createSAMLResponse, MOCK_IDP_LOGIN_PATH, MOCK_IDP_LOGOUT_PATH } from '@kbn/mock-idp-utils';
+import { getSAMLRequestId } from '@kbn/mock-idp-utils/src/utils';
 
 import type { ConfigType } from './config';
 
@@ -33,6 +34,7 @@ const createSAMLResponseSchema = schema.object({
   full_name: schema.maybe(schema.nullable(schema.string())),
   email: schema.maybe(schema.nullable(schema.string())),
   roles: schema.arrayOf(schema.string()),
+  url: schema.string(),
 });
 
 // BOOKMARK - List of Kibana project types
@@ -141,29 +143,35 @@ export const plugin: PluginInitializer<void, void, PluginSetupDependencies> = as
         const { protocol, hostname, port } = core.http.getServerInfo();
         const pathname = core.http.basePath.prepend('/api/security/saml/callback');
 
-        const serverlessOptions = plugins.cloud?.serverless
-          ? {
-              serverless: {
-                organizationId: plugins.cloud.organizationId!,
-                projectType: plugins.cloud.serverless.projectType!,
-                uiamEnabled: !!config.uiam?.enabled,
-              },
-            }
-          : {};
+          const serverlessOptions = plugins.cloud?.serverless
+            ? {
+                serverless: {
+                  organizationId: plugins.cloud.organizationId!,
+                  projectType: plugins.cloud.serverless.projectType!,
+                  uiamEnabled: !!config.uiam?.enabled,
+                },
+              }
+            : {};
 
-        try {
-          return response.ok({
-            body: {
-              SAMLResponse: await createSAMLResponse({
-                kibanaUrl: `${protocol}://${hostname}:${port}${pathname}`,
-                username: request.body.username,
-                full_name: request.body.full_name ?? undefined,
-                email: request.body.email ?? undefined,
-                roles: request.body.roles,
-                ...serverlessOptions,
-              }),
-            },
-          });
+          try {
+            const requestId = await getSAMLRequestId(request.body.url);
+            if (requestId) {
+              logger.info(`Sending SAML response for request ID: ${requestId}`);
+            }
+
+            return response.ok({
+              body: {
+                SAMLResponse: await createSAMLResponse({
+                  kibanaUrl: `${protocol}://${hostname}:${port}${pathname}`,
+                  username: request.body.username,
+                  full_name: request.body.full_name ?? undefined,
+                  email: request.body.email ?? undefined,
+                  roles: request.body.roles,
+                  ...(requestId ? { authnRequestId: requestId } : {}),
+                  ...serverlessOptions,
+                }),
+              },
+            });
         } catch (err) {
           logger.error(`Failed to create SAMLResponse: ${err}`, err);
           throw err;

--- a/packages/kbn-mock-idp-plugin/server/plugin.ts
+++ b/packages/kbn-mock-idp-plugin/server/plugin.ts
@@ -143,35 +143,35 @@ export const plugin: PluginInitializer<void, void, PluginSetupDependencies> = as
         const { protocol, hostname, port } = core.http.getServerInfo();
         const pathname = core.http.basePath.prepend('/api/security/saml/callback');
 
-          const serverlessOptions = plugins.cloud?.serverless
-            ? {
-                serverless: {
-                  organizationId: plugins.cloud.organizationId!,
-                  projectType: plugins.cloud.serverless.projectType!,
-                  uiamEnabled: !!config.uiam?.enabled,
-                },
-              }
-            : {};
-
-          try {
-            const requestId = await getSAMLRequestId(request.body.url);
-            if (requestId) {
-              logger.info(`Sending SAML response for request ID: ${requestId}`);
-            }
-
-            return response.ok({
-              body: {
-                SAMLResponse: await createSAMLResponse({
-                  kibanaUrl: `${protocol}://${hostname}:${port}${pathname}`,
-                  username: request.body.username,
-                  full_name: request.body.full_name ?? undefined,
-                  email: request.body.email ?? undefined,
-                  roles: request.body.roles,
-                  ...(requestId ? { authnRequestId: requestId } : {}),
-                  ...serverlessOptions,
-                }),
+        const serverlessOptions = plugins.cloud?.serverless
+          ? {
+              serverless: {
+                organizationId: plugins.cloud.organizationId!,
+                projectType: plugins.cloud.serverless.projectType!,
+                uiamEnabled: !!config.uiam?.enabled,
               },
-            });
+            }
+          : {};
+
+        try {
+          const requestId = await getSAMLRequestId(request.body.url);
+          if (requestId) {
+            logger.info(`Sending SAML response for request ID: ${requestId}`);
+          }
+
+          return response.ok({
+            body: {
+              SAMLResponse: await createSAMLResponse({
+                kibanaUrl: `${protocol}://${hostname}:${port}${pathname}`,
+                username: request.body.username,
+                full_name: request.body.full_name ?? undefined,
+                email: request.body.email ?? undefined,
+                roles: request.body.roles,
+                ...(requestId ? { authnRequestId: requestId } : {}),
+                ...serverlessOptions,
+              }),
+            },
+          });
         } catch (err) {
           logger.error(`Failed to create SAMLResponse: ${err}`, err);
           throw err;

--- a/src/platform/packages/private/kbn-mock-idp-utils/jest.config.js
+++ b/src/platform/packages/private/kbn-mock-idp-utils/jest.config.js
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+module.exports = {
+  preset: '@kbn/test/jest_node',
+  rootDir: '../../../../..',
+  roots: ['<rootDir>/src/platform/packages/private/kbn-mock-idp-utils'],
+};

--- a/src/platform/packages/private/kbn-mock-idp-utils/moon.yml
+++ b/src/platform/packages/private/kbn-mock-idp-utils/moon.yml
@@ -24,9 +24,12 @@ tags:
   - dev
   - group-platform
   - private
+  - jest-unit-tests
 fileGroups:
   src:
     - '**/*.ts'
     - '**/*.tsx'
     - '!target/**/*'
+  jest-config:
+    - jest.config.js
 tasks: {}

--- a/src/platform/packages/private/kbn-mock-idp-utils/src/index.ts
+++ b/src/platform/packages/private/kbn-mock-idp-utils/src/index.ts
@@ -28,4 +28,9 @@ export {
   MOCK_IDP_UIAM_PROJECT_ID,
 } from './constants';
 
-export { createMockIdpMetadata, createSAMLResponse, ensureSAMLRoleMapping } from './utils';
+export {
+  createMockIdpMetadata,
+  createSAMLResponse,
+  ensureSAMLRoleMapping,
+  getSAMLRequestId,
+} from './utils';

--- a/src/platform/packages/private/kbn-mock-idp-utils/src/utils.test.ts
+++ b/src/platform/packages/private/kbn-mock-idp-utils/src/utils.test.ts
@@ -7,9 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import {
-  getSAMLRequestId,
-} from './utils';
+import { getSAMLRequestId } from './utils';
 
 describe('mock-idp-utils', () => {
   describe('getSAMLReuestId', () => {

--- a/src/platform/packages/private/kbn-mock-idp-utils/src/utils.test.ts
+++ b/src/platform/packages/private/kbn-mock-idp-utils/src/utils.test.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import {
+  getSAMLRequestId,
+} from './utils';
+
+describe('mock-idp-utils', () => {
+  describe('getSAMLReuestId', () => {
+    it('should extract SAMLRequest ID from URL', async () => {
+      const url =
+        'http://localhost:5601/mock_idp/login?SAMLRequest=fZJvT8IwEMa%2FSnPvYVsnExqGQYmRxD8Epi98Q0q5SWPXzl6H8u2dggYT4tvePc9z97sOLz4qw7boSTubQ9KNgaFVbq3tSw6PxXWnDxejIcnK8FqMm7Cxc3xrkAJrhZbEvpJD461wkjQJKyskEZRYjO9uBe%2FGovYuOOUMsDER%2BtBGXTlLTYV%2BgX6rFT7Ob3PYhFCLKDJOSbNxFEQvi5NI1joiVI3XYRd9pUVt2aykegU2aefQVobv2U%2FLK6del3pdt%2B8v2gKbTnJYxhivB6XkPDtL0wT755hgT2a9lA9kkpWDslTIy7TfthM1OLUUpA058JhnnTjpJL0iyQTvi5R3z1P%2BDGx2WPFS2z26%2F3is9k0kbopi1pk9LApgTz8naBvgAFx8p%2Ftj0v8byx%2B8MDpJYxgd%2B%2F6e9b41mk5mzmi1Y2Nj3PuVRxkwh1IaQohGB%2BHfHzD6BA%3D%3D';
+      const requestId = await getSAMLRequestId(url);
+      expect(requestId).toEqual('_0e0d9fa2264331e87e1e5a65329a16f9ffce2f38');
+    });
+
+    it('should return undefined if SAMLRequest parameter is missing', async () => {
+      const noParamUrl = 'http://localhost:5601/mock_idp/login';
+      const requestId = await getSAMLRequestId(noParamUrl);
+      expect(requestId).toBeUndefined();
+    });
+
+    it('should return undefined if SAMLRequest parameter is invalid', async () => {
+      const invalidUrl = 'http://localhost:5601/mock_idp/login?SAMLRequest=YmxhaCBibGFoIGJsYWg=';
+      const requestId = await getSAMLRequestId(invalidUrl);
+      expect(requestId).toBeUndefined();
+    });
+  });
+});

--- a/src/platform/packages/private/kbn-mock-idp-utils/src/utils.ts
+++ b/src/platform/packages/private/kbn-mock-idp-utils/src/utils.ts
@@ -10,7 +10,11 @@
 import type { Client } from '@elastic/elasticsearch';
 import { createHmac, randomBytes, X509Certificate } from 'crypto';
 import { readFile } from 'fs/promises';
+import Url from 'url';
+import { promisify } from 'util';
 import { SignedXml } from 'xml-crypto';
+import { parseString } from 'xml2js';
+import zlib from 'zlib';
 
 import { KBN_CERT_PATH, KBN_KEY_PATH } from '@kbn/dev-utils';
 
@@ -331,4 +335,28 @@ function createUiamSessionTokens({
       .digest('base64url')}`,
     refreshTokenExpiresAt: (iat + 3600) * 1000,
   };
+}
+
+const inflateRawAsync = promisify(zlib.inflateRaw);
+const parseStringAsync = promisify(parseString);
+
+export async function getSAMLRequestId(requestUrl: string): Promise<string | undefined> {
+  const samlRequest = Url.parse(requestUrl, true /* parseQueryString */).query.SAMLRequest;
+
+  let requestId: string | undefined;
+
+  if (samlRequest) {
+    try {
+      const inflatedSAMLRequest = (await inflateRawAsync(
+        Buffer.from(samlRequest as string, 'base64')
+      )) as Buffer;
+
+      const parsedSAMLRequest = (await parseStringAsync(inflatedSAMLRequest.toString())) as any;
+      requestId = parsedSAMLRequest['saml2p:AuthnRequest'].$.ID as string;
+    } catch (e) {
+      return undefined;
+    }
+  }
+
+  return requestId;
 }

--- a/x-pack/platform/plugins/shared/security/server/authentication/providers/saml.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/authentication/providers/saml.test.ts
@@ -56,6 +56,7 @@ describe('SAMLAuthenticationProvider', () => {
         refresh_token: 'some-refresh-token',
         realm: 'test-realm',
         authentication: mockUser,
+        in_response_to: mockSAMLSet1.requestId,
       });
 
       await expect(
@@ -105,6 +106,7 @@ describe('SAMLAuthenticationProvider', () => {
         refresh_token: 'some-refresh-token',
         realm: 'test-realm',
         authentication: mockUser,
+        in_response_to: mockSAMLSet1.requestId,
       });
 
       provider = new SAMLAuthenticationProvider(mockOptions, {
@@ -204,6 +206,7 @@ describe('SAMLAuthenticationProvider', () => {
         refresh_token: 'user-initiated-login-refresh-token',
         realm: 'test-realm',
         authentication: mockUser,
+        in_response_to: mockSAMLSet1.requestId,
       });
 
       await expect(
@@ -249,6 +252,7 @@ describe('SAMLAuthenticationProvider', () => {
         refresh_token: 'user-initiated-login-refresh-token',
         realm: 'test-realm',
         authentication: mockUser,
+        in_response_to: mockSAMLSet1.requestId,
       });
 
       provider = new SAMLAuthenticationProvider(mockOptions, {
@@ -368,6 +372,7 @@ describe('SAMLAuthenticationProvider', () => {
           refresh_token: 'some-refresh-token',
           realm: 'test-realm',
           authentication: mockUser,
+          in_response_to: mockSamlResponses.set25.requestId,
         });
 
         const requestIdMap: Record<string, { redirectURL: string }> = {};
@@ -1696,6 +1701,7 @@ describe('SAMLAuthenticationProvider', () => {
         refresh_token: 'some-refresh-token',
         realm: ELASTIC_CLOUD_SSO_REALM_NAME,
         authentication: mockUser,
+        in_response_to: mockSAMLSet1.requestId,
       });
       mockOptions.uiam?.getUserProfileGrant.mockReturnValue({
         type: 'uiamAccessToken',

--- a/x-pack/platform/plugins/shared/security/server/authentication/providers/saml.ts
+++ b/x-pack/platform/plugins/shared/security/server/authentication/providers/saml.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { errors } from '@elastic/elasticsearch';
 import Boom from '@hapi/boom';
 
 import type { KibanaRequest } from '@kbn/core/server';
@@ -386,6 +387,7 @@ export class SAMLAuthenticationProvider extends BaseAuthenticationProvider {
       refresh_token: string;
       realm: string;
       authentication: AuthenticationInfo;
+      in_response_to?: string;
     };
     try {
       // This operation should be performed on behalf of the user with a privilege that normal
@@ -402,10 +404,24 @@ export class SAMLAuthenticationProvider extends BaseAuthenticationProvider {
         },
       })) as any;
     } catch (err) {
+      let inResponseToRequestId;
+      if (err instanceof errors.ResponseError) {
+        const body = (err as errors.ResponseError).meta.body as
+          | { error: Record<string, string> }
+          | undefined;
+        inResponseToRequestId =
+          body?.error?.['security.saml.unsolicited_in_response_to'] ?? undefined;
+      }
+
       this.logger.error(
-        `Failed to log in with SAML response, ${
-          !isIdPInitiatedLogin ? `current requestIds: ${stateRequestIds}, ` : ''
-        } error: ${getDetailedErrorMessage(err)}`
+        [
+          'Failed to log in with SAML response',
+          inResponseToRequestId
+            ? `SP-initiated, unsolicited InResponseTo: ${inResponseToRequestId}`
+            : 'IDP-initiated',
+          state ? `current requestIds: [${stateRequestIds}]` : 'no state',
+          getDetailedErrorMessage(err),
+        ].join(', ')
       );
 
       // Since we don't know upfront what realm is targeted by the Identity Provider initiated login
@@ -443,7 +459,7 @@ export class SAMLAuthenticationProvider extends BaseAuthenticationProvider {
     let remainingRequestIdMap = stateRequestIdMap;
 
     if (!isIdPInitiatedLogin) {
-      const inResponseToRequestId = this.parseRequestIdFromSAMLResponse(samlResponse);
+      const inResponseToRequestId = result.in_response_to;
       this.logger.debug(`Login was performed with requestId: ${inResponseToRequestId}`);
 
       if (stateRequestIds.length && inResponseToRequestId) {
@@ -481,16 +497,8 @@ export class SAMLAuthenticationProvider extends BaseAuthenticationProvider {
     );
   }
 
-  private parseRequestIdFromSAMLResponse(samlResponse: string): string | null {
-    const samlResponseBuffer = Buffer.from(samlResponse, 'base64');
-    const samlResponseString = samlResponseBuffer.toString('utf-8');
-    const inResponseToRequestIdMatch = samlResponseString.match(/InResponseTo="([a-z0-9_]*)"/);
-
-    return inResponseToRequestIdMatch ? inResponseToRequestIdMatch[1] : null;
-  }
-
   private updateRemainingRequestIds(
-    requestIdToRemove: string | null,
+    requestIdToRemove: string | undefined,
     remainingRequestIds: Record<RequestId, { redirectURL: string }>
   ): [boolean, Record<RequestId, { redirectURL: string }>] {
     if (requestIdToRemove) {

--- a/x-pack/platform/test/cloud_integration/plugins/saml_provider/moon.yml
+++ b/x-pack/platform/test/cloud_integration/plugins/saml_provider/moon.yml
@@ -19,6 +19,7 @@ project:
 dependsOn:
   - '@kbn/core'
   - '@kbn/dev-utils'
+  - '@kbn/mock-idp-utils'
 tags:
   - plugin
   - prod

--- a/x-pack/platform/test/cloud_integration/plugins/saml_provider/server/saml_tools.ts
+++ b/x-pack/platform/test/cloud_integration/plugins/saml_provider/server/saml_tools.ts
@@ -8,10 +8,8 @@
 import crypto from 'crypto';
 import fs from 'fs';
 import { stringify } from 'query-string';
-import url from 'url';
 import zlib from 'zlib';
 import { promisify } from 'util';
-import { parseString } from 'xml2js';
 import { SignedXml } from 'xml-crypto';
 import { KBN_KEY_PATH } from '@kbn/dev-utils';
 import { CLOUD_USER_ID } from '../constants';
@@ -23,25 +21,13 @@ import { CLOUD_USER_ID } from '../constants';
  * http://docs.oasis-open.org/security/saml/v2.0/saml-bindings-2.0-os.pdf.
  */
 
-const inflateRawAsync = promisify(zlib.inflateRaw);
 const deflateRawAsync = promisify(zlib.deflateRaw);
-const parseStringAsync = promisify(parseString);
 
 const signingKey = fs.readFileSync(KBN_KEY_PATH);
 const signatureAlgorithm = 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256';
 const canonicalizationAlgorithm = 'http://www.w3.org/2001/10/xml-exc-c14n#';
 
-export async function getSAMLRequestId(urlWithSAMLRequestId: string) {
-  const inflatedSAMLRequest = (await inflateRawAsync(
-    Buffer.from(
-      url.parse(urlWithSAMLRequestId, true /* parseQueryString */).query.SAMLRequest as string,
-      'base64'
-    )
-  )) as Buffer;
-
-  const parsedSAMLRequest = (await parseStringAsync(inflatedSAMLRequest.toString())) as any;
-  return parsedSAMLRequest['saml2p:AuthnRequest'].$.ID;
-}
+export { getSAMLRequestId } from '@kbn/mock-idp-utils/src/utils';
 
 export async function getSAMLResponse({
   destination,

--- a/x-pack/platform/test/cloud_integration/plugins/saml_provider/tsconfig.json
+++ b/x-pack/platform/test/cloud_integration/plugins/saml_provider/tsconfig.json
@@ -13,5 +13,6 @@
   "kbn_references": [
     "@kbn/core",
     "@kbn/dev-utils",
+    "@kbn/mock-idp-utils",
   ]
 }

--- a/x-pack/platform/test/security_api_integration/packages/helpers/moon.yml
+++ b/x-pack/platform/test/security_api_integration/packages/helpers/moon.yml
@@ -18,6 +18,7 @@ project:
   sourceRoot: x-pack/platform/test/security_api_integration/packages/helpers
 dependsOn:
   - '@kbn/dev-utils'
+  - '@kbn/mock-idp-utils'
 tags:
   - shared-common
   - package

--- a/x-pack/platform/test/security_api_integration/packages/helpers/saml/saml_tools.ts
+++ b/x-pack/platform/test/security_api_integration/packages/helpers/saml/saml_tools.ts
@@ -8,10 +8,8 @@
 import crypto from 'crypto';
 import fs from 'fs';
 import { stringify } from 'query-string';
-import url from 'url';
 import { promisify } from 'util';
 import { SignedXml } from 'xml-crypto';
-import { parseString } from 'xml2js';
 import zlib from 'zlib';
 
 import { KBN_KEY_PATH } from '@kbn/dev-utils';
@@ -23,25 +21,13 @@ import { KBN_KEY_PATH } from '@kbn/dev-utils';
  * http://docs.oasis-open.org/security/saml/v2.0/saml-bindings-2.0-os.pdf.
  */
 
-const inflateRawAsync = promisify(zlib.inflateRaw);
 const deflateRawAsync = promisify(zlib.deflateRaw);
-const parseStringAsync = promisify(parseString);
 
 const signingKey = fs.readFileSync(KBN_KEY_PATH);
 const signatureAlgorithm = 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256';
 const canonicalizationAlgorithm = 'http://www.w3.org/2001/10/xml-exc-c14n#';
 
-export async function getSAMLRequestId(urlWithSAMLRequestId: string) {
-  const inflatedSAMLRequest = (await inflateRawAsync(
-    Buffer.from(
-      url.parse(urlWithSAMLRequestId, true /* parseQueryString */).query.SAMLRequest as string,
-      'base64'
-    )
-  )) as Buffer;
-
-  const parsedSAMLRequest = (await parseStringAsync(inflatedSAMLRequest.toString())) as any;
-  return parsedSAMLRequest['saml2p:AuthnRequest'].$.ID;
-}
+export { getSAMLRequestId } from '@kbn/mock-idp-utils/src/utils';
 
 export async function getSAMLResponse({
   destination,

--- a/x-pack/platform/test/security_api_integration/packages/helpers/tsconfig.json
+++ b/x-pack/platform/test/security_api_integration/packages/helpers/tsconfig.json
@@ -15,5 +15,6 @@
   ],
   "kbn_references": [
     "@kbn/dev-utils",
+    "@kbn/mock-idp-utils",
   ]
 }

--- a/x-pack/platform/test/security_api_integration/tests/login_selector/basic_functionality.ts
+++ b/x-pack/platform/test/security_api_integration/tests/login_selector/basic_functionality.ts
@@ -599,12 +599,14 @@ export default function ({ getService }: FtrProviderContext) {
 
           const cookie = parseCookie(samlHandshakeResponse.headers['set-cookie'][0])!;
           const samlRequestId = await getSAMLRequestId(samlHandshakeResponse.body.location);
+          expect(samlRequestId).not.to.be(undefined);
+
           const samlResponse = await createSAMLResponse({
             issuer: `http://www.elastic.co/saml2`,
             inResponseTo: samlRequestId,
           });
 
-          samlResponseMapByRequestId[samlRequestId] = { samlResponse, cookie };
+          samlResponseMapByRequestId[samlRequestId!] = { samlResponse, cookie };
         }
 
         const preparedCallbacks = [];

--- a/x-pack/platform/test/security_api_integration/tests/saml/saml_login.ts
+++ b/x-pack/platform/test/security_api_integration/tests/saml/saml_login.ts
@@ -189,7 +189,7 @@ export default function ({ getService }: FtrProviderContext) {
 
     describe('finishing handshake', () => {
       let handshakeCookie: Cookie;
-      let samlRequestId: string;
+      let samlRequestId: string | undefined;
 
       beforeEach(async () => {
         const handshakeResponse = await supertest


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [Update SAML logs and request ID retrieval (#249037)](https://github.com/elastic/kibana/pull/249037)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jeramy Soucy","email":"jeramy.soucy@elastic.co"},"sourceCommit":{"committedDate":"2026-01-22T18:23:53Z","message":"Update SAML logs and request ID retrieval (#249037)\n\nCloses https://github.com/elastic/kibana/issues/246963\n\n## Summary\n\nAdds logging of new \"unsolicited InResponseTo\" error condition returned\nfrom Elasticsearch. This will allow us to identify and filter this\nspecific scenario in serverless logs. Additionally, the request ID is\nnow retrieved directly from the Elasticsearch response metadata rather\nthan parsed from the SAML response.\n\nThis PR also adds parsing of request ID in our mock SAML IDP plugin.\nThis allows us to use the mock IDP for both SP (service provider)\ninitiated and IDP (identity provider) initiated logins.\n\nLastly, this PR moves the `getSAMLRequestId` utility function to the\nmock IDP utils package to remove duplication.\n\n### Testing\n\n#### Mock IDP\n- Start ES & KB locally in serverless mode\n- Navigate to the Kibana URL\n- Verify the redirect to the mock IDP with a SAML request parameter\n(http://localhost:5601/mock_idp/login?SAMLRequest=<encoded_value>)\n- Select a role and click Login\n- Verify logs\n```\n[INFO ][plugins.mockIdpPlugin] Sending SAML response for request ID: ` _SOME_ID`\n[INFO ][plugins.security.authentication] Performing login attempt with \"saml\" provider.\n[INFO ][plugins.security.saml.cloud-saml-kibana] Removing requestId _SAME_ID from the state.\n```\n- Log out\n- Navigate directly to the mock IDP\n(http://localhost:5601/mock_idp/login)\n- Select a role and click Login\n- Verify logs\n```\n[INFO ][plugins.security.authentication] Performing login attempt with \"saml\" provider.\n[INFO ][plugins.security.saml.cloud-saml-kibana] No requestId found in SAML response or state does not contain requestId.\n...\n[INFO ][plugins.security.authentication] Login attempt with \"saml\" provider succeeded (requires redirect: true).\n```\n\n#### Unsolicited InResponseTo\n- Start ES & KB locally in serverless mode\n- Navigate to the Kibana URL\n- Open the browser dev tools and delete the \"sid\" cookie\n- Click Login\n- Verify logs\n```\n[INFO ][plugins.mockIdpPlugin] Sending SAML response for request ID: _SOME_ID\n[INFO ][plugins.security.authentication] Performing login attempt with \"saml\" provider.\n[ERROR][plugins.security.saml.cloud-saml-kibana] Failed to log in with SAML response, SP-initiated, unsolicited InResponseTo: _SAME_ID, no state - possible delayed login, current requestIds: , error: {...}\n[ERROR][plugins.security.authentication] Login attempt with \"saml\" provider cannot be handled.\n```\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"f87355ace3f903f609fd7974e32db2474b795725","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Security","Feature:Security/Authentication","release_note:skip","backport:all-open","v9.3.0","v9.4.0"],"title":"Update SAML logs and request ID retrieval","number":249037,"url":"https://github.com/elastic/kibana/pull/249037","mergeCommit":{"message":"Update SAML logs and request ID retrieval (#249037)\n\nCloses https://github.com/elastic/kibana/issues/246963\n\n## Summary\n\nAdds logging of new \"unsolicited InResponseTo\" error condition returned\nfrom Elasticsearch. This will allow us to identify and filter this\nspecific scenario in serverless logs. Additionally, the request ID is\nnow retrieved directly from the Elasticsearch response metadata rather\nthan parsed from the SAML response.\n\nThis PR also adds parsing of request ID in our mock SAML IDP plugin.\nThis allows us to use the mock IDP for both SP (service provider)\ninitiated and IDP (identity provider) initiated logins.\n\nLastly, this PR moves the `getSAMLRequestId` utility function to the\nmock IDP utils package to remove duplication.\n\n### Testing\n\n#### Mock IDP\n- Start ES & KB locally in serverless mode\n- Navigate to the Kibana URL\n- Verify the redirect to the mock IDP with a SAML request parameter\n(http://localhost:5601/mock_idp/login?SAMLRequest=<encoded_value>)\n- Select a role and click Login\n- Verify logs\n```\n[INFO ][plugins.mockIdpPlugin] Sending SAML response for request ID: ` _SOME_ID`\n[INFO ][plugins.security.authentication] Performing login attempt with \"saml\" provider.\n[INFO ][plugins.security.saml.cloud-saml-kibana] Removing requestId _SAME_ID from the state.\n```\n- Log out\n- Navigate directly to the mock IDP\n(http://localhost:5601/mock_idp/login)\n- Select a role and click Login\n- Verify logs\n```\n[INFO ][plugins.security.authentication] Performing login attempt with \"saml\" provider.\n[INFO ][plugins.security.saml.cloud-saml-kibana] No requestId found in SAML response or state does not contain requestId.\n...\n[INFO ][plugins.security.authentication] Login attempt with \"saml\" provider succeeded (requires redirect: true).\n```\n\n#### Unsolicited InResponseTo\n- Start ES & KB locally in serverless mode\n- Navigate to the Kibana URL\n- Open the browser dev tools and delete the \"sid\" cookie\n- Click Login\n- Verify logs\n```\n[INFO ][plugins.mockIdpPlugin] Sending SAML response for request ID: _SOME_ID\n[INFO ][plugins.security.authentication] Performing login attempt with \"saml\" provider.\n[ERROR][plugins.security.saml.cloud-saml-kibana] Failed to log in with SAML response, SP-initiated, unsolicited InResponseTo: _SAME_ID, no state - possible delayed login, current requestIds: , error: {...}\n[ERROR][plugins.security.authentication] Login attempt with \"saml\" provider cannot be handled.\n```\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"f87355ace3f903f609fd7974e32db2474b795725"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.3","label":"v9.3.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/250168","number":250168,"state":"MERGED","mergeCommit":{"sha":"d03aa163b11d4729f20c19dd1bcefc87314ee927","message":"[9.3] Update SAML logs and request ID retrieval (#249037) (#250168)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.3`:\n- [Update SAML logs and request ID retrieval\n(#249037)](https://github.com/elastic/kibana/pull/249037)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n"}},{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/249037","number":249037,"mergeCommit":{"message":"Update SAML logs and request ID retrieval (#249037)\n\nCloses https://github.com/elastic/kibana/issues/246963\n\n## Summary\n\nAdds logging of new \"unsolicited InResponseTo\" error condition returned\nfrom Elasticsearch. This will allow us to identify and filter this\nspecific scenario in serverless logs. Additionally, the request ID is\nnow retrieved directly from the Elasticsearch response metadata rather\nthan parsed from the SAML response.\n\nThis PR also adds parsing of request ID in our mock SAML IDP plugin.\nThis allows us to use the mock IDP for both SP (service provider)\ninitiated and IDP (identity provider) initiated logins.\n\nLastly, this PR moves the `getSAMLRequestId` utility function to the\nmock IDP utils package to remove duplication.\n\n### Testing\n\n#### Mock IDP\n- Start ES & KB locally in serverless mode\n- Navigate to the Kibana URL\n- Verify the redirect to the mock IDP with a SAML request parameter\n(http://localhost:5601/mock_idp/login?SAMLRequest=<encoded_value>)\n- Select a role and click Login\n- Verify logs\n```\n[INFO ][plugins.mockIdpPlugin] Sending SAML response for request ID: ` _SOME_ID`\n[INFO ][plugins.security.authentication] Performing login attempt with \"saml\" provider.\n[INFO ][plugins.security.saml.cloud-saml-kibana] Removing requestId _SAME_ID from the state.\n```\n- Log out\n- Navigate directly to the mock IDP\n(http://localhost:5601/mock_idp/login)\n- Select a role and click Login\n- Verify logs\n```\n[INFO ][plugins.security.authentication] Performing login attempt with \"saml\" provider.\n[INFO ][plugins.security.saml.cloud-saml-kibana] No requestId found in SAML response or state does not contain requestId.\n...\n[INFO ][plugins.security.authentication] Login attempt with \"saml\" provider succeeded (requires redirect: true).\n```\n\n#### Unsolicited InResponseTo\n- Start ES & KB locally in serverless mode\n- Navigate to the Kibana URL\n- Open the browser dev tools and delete the \"sid\" cookie\n- Click Login\n- Verify logs\n```\n[INFO ][plugins.mockIdpPlugin] Sending SAML response for request ID: _SOME_ID\n[INFO ][plugins.security.authentication] Performing login attempt with \"saml\" provider.\n[ERROR][plugins.security.saml.cloud-saml-kibana] Failed to log in with SAML response, SP-initiated, unsolicited InResponseTo: _SAME_ID, no state - possible delayed login, current requestIds: , error: {...}\n[ERROR][plugins.security.authentication] Login attempt with \"saml\" provider cannot be handled.\n```\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"f87355ace3f903f609fd7974e32db2474b795725"}}]}] BACKPORT-->