### PR TITLE
[Search]Fix FTR tests remove default route test for search solution nav

### DIFF
--- a/x-pack/solutions/search/test/functional_solution_sidenav/tests/search_sidenav.ts
+++ b/x-pack/solutions/search/test/functional_solution_sidenav/tests/search_sidenav.ts
@@ -23,9 +23,6 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
         shouldUseHashForSubUrl: false,
       });
 
-      // Prevent GettingStartedRedirectGate from redirecting away from the home page
-      await browser.setLocalStorageItem('gettingStartedVisited', 'true');
-
       // Create a space with the search solution and navigate to its home page
       ({ cleanUp, space: spaceCreated } = await spaces.create({ solution: 'es' }));
       await browser.navigateTo(spaces.getRootUrl(spaceCreated.id));
@@ -40,12 +37,6 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       it('renders the correct nav and navigate to links', async () => {
         await solutionNavigation.expectExists();
         await solutionNavigation.breadcrumbs.expectExists();
-        // Navigate explicitly to the home page as a reliable starting point
-        await common.navigateToApp('elasticsearch/home', { basePath: `/s/${spaceCreated.id}` });
-        // check side nav links
-        await solutionNavigation.sidenav.expectLinkActive({
-          deepLinkId: 'searchHomepage',
-        });
 
         await solutionNavigation.sidenav.clickLink({
           deepLinkId: 'discover',
@@ -69,6 +60,13 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
         await solutionNavigation.sidenav.clickLink({ navId: 'stack_management' });
         await solutionNavigation.sidenav.expectLinkActive({ navId: 'stack_management' });
 
+        // navigate to getting started page
+        await solutionNavigation.sidenav.clickLink({
+          deepLinkId: 'searchGettingStarted',
+        });
+        await solutionNavigation.sidenav.expectLinkActive({
+          deepLinkId: 'searchGettingStarted',
+        });
         // navigate back to the home page using header logo
         await solutionNavigation.clickLogo();
         await solutionNavigation.sidenav.expectLinkActive({


### PR DESCRIPTION
## Summary

Fixes failing FTR test, removed set storage and default route test and added test for getting started page separately. 

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.


- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
