### PR TITLE
[8.19] [Ingest pipelines] Include input_output in inference processor (#260517)

### DIFF
--- a/x-pack/platform/plugins/shared/ingest_pipelines/public/application/components/pipeline_editor/__jest__/pipeline_processors_editor.test.tsx
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/public/application/components/pipeline_editor/__jest__/pipeline_processors_editor.test.tsx
@@ -165,6 +165,97 @@ describe('Pipeline Editor', () => {
       });
     });
 
+    it('preserves target_field as an unknown option when editing a non-inference processor', async () => {
+      // A non-inference processor that happens to have a `target_field` unknown option should
+      // keep it after saving, because `target_field` must only be treated as "known" for
+      // inference processors.
+      onUpdate = jest.fn();
+      rerenderWithProps({
+        value: {
+          processors: [
+            {
+              set: {
+                field: 'test',
+                value: 'test',
+                target_field: 'some_unknown_target',
+              },
+            },
+          ],
+        },
+        onFlyoutOpen: jest.fn(),
+        onUpdate,
+      });
+
+      fireEvent.click(getByTestSubjectSelector('processors>0.manageItemButton'));
+      expect(screen.getByTestId('editProcessorForm')).toBeInTheDocument();
+
+      const valueInput = getByTestSubjectSelector('editProcessorForm.textValueField.input');
+      fireEvent.change(valueInput, { target: { value: 'updated_value' } });
+      fireEvent.blur(valueInput);
+
+      fireEvent.click(getByTestSubjectSelector('editProcessorForm.submitButton'));
+
+      await waitFor(() => {
+        expect(onUpdate).toHaveBeenCalled();
+      });
+
+      const [onUpdateResult] = onUpdate.mock.calls[onUpdate.mock.calls.length - 1];
+      const { processors } = onUpdateResult.getData();
+      expect(processors[0].set).toEqual(
+        expect.objectContaining({
+          field: 'test',
+          value: 'updated_value',
+          // target_field must be preserved as an unknown option for non-inference processors
+          target_field: 'some_unknown_target',
+        })
+      );
+    });
+
+    it('drops inference-specific fields from unknownOptions when editing an inference processor', async () => {
+      // When editing an inference processor, input_output / target_field / field_map are
+      // "known" to the form, so they must NOT bleed through from unknownOptions into the
+      // serialized output (which would double-write or conflict with what the form emits).
+      onUpdate = jest.fn();
+      rerenderWithProps({
+        value: {
+          processors: [
+            {
+              inference: {
+                model_id: 'test_model',
+                input_output: [{ input_field: 'text_field', output_field: 'content_embedding' }],
+              },
+            },
+          ],
+        },
+        onFlyoutOpen: jest.fn(),
+        onUpdate,
+      });
+
+      fireEvent.click(getByTestSubjectSelector('processors>0.manageItemButton'));
+      expect(await screen.findByTestId('editProcessorForm')).toBeInTheDocument();
+
+      fireEvent.click(getByTestSubjectSelector('editProcessorForm.submitButton'));
+
+      await waitFor(() => {
+        expect(onUpdate).toHaveBeenCalled();
+      });
+
+      const [onUpdateResult] = onUpdate.mock.calls[onUpdate.mock.calls.length - 1];
+      const { processors } = onUpdateResult.getData();
+      // input_output must appear exactly once from the form; it must not be duplicated
+      // by being merged in again from unknownOptions.
+      expect(processors[0].inference).toEqual(
+        expect.objectContaining({
+          model_id: 'test_model',
+          input_output: [{ input_field: 'text_field', output_field: 'content_embedding' }],
+        })
+      );
+      // Confirm there is exactly one key for input_output (no duplication artefacts)
+      expect(Object.keys(processors[0].inference).filter((k) => k === 'input_output')).toHaveLength(
+        1
+      );
+    });
+
     it('allows to edit an existing processor and change its type', async () => {
       const { actions, exists, component, find } = testBed;
 

--- a/x-pack/platform/plugins/shared/ingest_pipelines/public/application/components/pipeline_editor/__jest__/pipeline_processors_editor.test.tsx
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/public/application/components/pipeline_editor/__jest__/pipeline_processors_editor.test.tsx
@@ -7,7 +7,8 @@
 
 import { act } from 'react-dom/test-utils';
 import { licensingMock } from '@kbn/licensing-plugin/server/mocks';
-import { setup, SetupResult } from './pipeline_processors_editor.helpers';
+import type { SetupResult } from './pipeline_processors_editor.helpers';
+import { setup } from './pipeline_processors_editor.helpers';
 import { Pipeline } from '../../../../../common/types';
 import {
   extractProcessorDetails,
@@ -170,7 +171,7 @@ describe('Pipeline Editor', () => {
       // keep it after saving, because `target_field` must only be treated as "known" for
       // inference processors.
       onUpdate = jest.fn();
-      rerenderWithProps({
+      testBed = await setup({
         value: {
           processors: [
             {
@@ -185,19 +186,15 @@ describe('Pipeline Editor', () => {
         onFlyoutOpen: jest.fn(),
         onUpdate,
       });
+      const { actions, exists, form } = testBed;
 
-      fireEvent.click(getByTestSubjectSelector('processors>0.manageItemButton'));
-      expect(screen.getByTestId('editProcessorForm')).toBeInTheDocument();
+      actions.openProcessorEditor('processors>0');
+      expect(exists('editProcessorForm')).toBeTruthy();
 
-      const valueInput = getByTestSubjectSelector('editProcessorForm.textValueField.input');
-      fireEvent.change(valueInput, { target: { value: 'updated_value' } });
-      fireEvent.blur(valueInput);
+      form.setInputValue('editProcessorForm.textValueField.input', 'updated_value');
+      jest.advanceTimersByTime(0);
 
-      fireEvent.click(getByTestSubjectSelector('editProcessorForm.submitButton'));
-
-      await waitFor(() => {
-        expect(onUpdate).toHaveBeenCalled();
-      });
+      await actions.submitProcessorForm();
 
       const [onUpdateResult] = onUpdate.mock.calls[onUpdate.mock.calls.length - 1];
       const { processors } = onUpdateResult.getData();
@@ -216,7 +213,7 @@ describe('Pipeline Editor', () => {
       // "known" to the form, so they must NOT bleed through from unknownOptions into the
       // serialized output (which would double-write or conflict with what the form emits).
       onUpdate = jest.fn();
-      rerenderWithProps({
+      testBed = await setup({
         value: {
           processors: [
             {
@@ -230,15 +227,12 @@ describe('Pipeline Editor', () => {
         onFlyoutOpen: jest.fn(),
         onUpdate,
       });
+      const { actions, exists } = testBed;
 
-      fireEvent.click(getByTestSubjectSelector('processors>0.manageItemButton'));
-      expect(await screen.findByTestId('editProcessorForm')).toBeInTheDocument();
+      actions.openProcessorEditor('processors>0');
+      expect(exists('editProcessorForm')).toBeTruthy();
 
-      fireEvent.click(getByTestSubjectSelector('editProcessorForm.submitButton'));
-
-      await waitFor(() => {
-        expect(onUpdate).toHaveBeenCalled();
-      });
+      await actions.submitProcessorForm();
 
       const [onUpdateResult] = onUpdate.mock.calls[onUpdate.mock.calls.length - 1];
       const { processors } = onUpdateResult.getData();

--- a/x-pack/platform/plugins/shared/ingest_pipelines/public/application/components/pipeline_editor/__jest__/processors/inference.test.tsx
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/public/application/components/pipeline_editor/__jest__/processors/inference.test.tsx
@@ -5,107 +5,371 @@
  * 2.0.
  */
 
-import { act } from 'react-dom/test-utils';
-import { setup, SetupResult, getProcessorValue, setupEnvironment } from './processor.helpers';
+import { fireEvent, screen, waitFor, within } from '@testing-library/react';
+import { getProcessorValue, renderProcessorEditor, setupEnvironment } from './processor.helpers';
 
 const INFERENCE_TYPE = 'inference';
 
-describe('Processor: Script', () => {
+describe('Processor: Inference', () => {
   let onUpdate: jest.Mock;
-  let testBed: SetupResult;
-  const { httpSetup } = setupEnvironment();
+  let httpSetup: ReturnType<typeof setupEnvironment>['httpSetup'];
 
-  beforeAll(() => {
-    jest.useFakeTimers({ legacyFakeTimers: true });
-    // disable all react-beautiful-dnd development warnings
-    (window as any)['__@hello-pangea/dnd-disable-dev-warnings'] = true;
-  });
+  const getToggleInput = () => screen.getByTestId('toggleInferenceInputMappingMode');
 
-  afterAll(() => {
-    jest.useRealTimers();
-    // enable all react-beautiful-dnd development warnings
-    (window as any)['__@hello-pangea/dnd-disable-dev-warnings'] = false;
-  });
+  const expectToggleOn = () => {
+    expect(getToggleInput()).toHaveAttribute('aria-checked', 'true');
+  };
 
-  beforeEach(async () => {
-    onUpdate = jest.fn();
+  const expectToggleOff = () => {
+    expect(getToggleInput()).toHaveAttribute('aria-checked', 'false');
+  };
 
-    await act(async () => {
-      testBed = await setup(httpSetup, {
+  const switchToTargetFieldAndFieldMapMode = () => {
+    fireEvent.click(screen.getByTestId('toggleInferenceInputMappingMode'));
+  };
+
+  describe('add inference processor', () => {
+    beforeEach(async () => {
+      jest.clearAllMocks();
+      ({ httpSetup } = setupEnvironment());
+      onUpdate = jest.fn();
+
+      renderProcessorEditor(httpSetup, {
         value: {
           processors: [],
         },
         onFlyoutOpen: jest.fn(),
         onUpdate,
       });
-    });
 
-    const { component, actions } = testBed;
-
-    component.update();
-
-    // Open flyout to add new processor
-    actions.addProcessor();
-    // Add type (the other fields are not visible until a type is selected)
-    await actions.addProcessorType(INFERENCE_TYPE);
-  });
-
-  test('prevents form submission if required fields are not provided', async () => {
-    const {
-      actions: { saveNewProcessor },
-      form,
-    } = testBed;
-
-    // Click submit button with only the type defined
-    await saveNewProcessor();
-
-    // Expect form error as "field" is a required parameter
-    expect(form.getErrorsMessages()).toEqual([
-      'A deployment, an inference, or a model ID value is required.',
-    ]);
-  });
-
-  test('accepts inference config and field maps that contains escaped characters', async () => {
-    const {
-      actions: { saveNewProcessor },
-      find,
-      form,
-      component,
-    } = testBed;
-
-    form.setInputValue('inferenceModelId.input', 'test_inference_processor');
-
-    await act(async () => {
-      find('inferenceConfig').simulate('change', {
-        jsonContent: '{"inf_conf_1":"""aaa"bbb""", "inf_conf_2": "aaa(bbb"}',
+      fireEvent.click(screen.getByTestId('addProcessorButton'));
+      fireEvent.change(within(screen.getByTestId('processorTypeSelector')).getByTestId('input'), {
+        target: { value: INFERENCE_TYPE },
       });
 
-      // advance timers to allow the form to validate
-      jest.advanceTimersByTime(0);
+      await screen.findByTestId('addProcessorForm');
     });
-    component.update();
 
-    await act(async () => {
-      find('fieldMap').simulate('change', {
-        jsonContent: '{"field_map_1":"""aaa"bbb""", "field_map_2": "aaa(bbb"}',
+    test('prevents form submission if required fields are not provided', async () => {
+      // Click submit button with only the type defined
+      // Expect form error as "field" is a required parameter
+      fireEvent.click(within(screen.getByTestId('addProcessorForm')).getByTestId('submitButton'));
+      expect(
+        await screen.findByText('A deployment, an inference, or a model ID value is required.')
+      ).toBeInTheDocument();
+    });
+
+    test('accepts inference config and field maps that contains escaped characters', async () => {
+      switchToTargetFieldAndFieldMapMode();
+      fireEvent.change(within(screen.getByTestId('inferenceModelId')).getByTestId('input'), {
+        target: { value: 'test_inference_processor' },
+      });
+      fireEvent.change(screen.getByTestId('inferenceConfig'), {
+        target: { value: '{"inf_conf_1":"""aaa"bbb""", "inf_conf_2": "aaa(bbb"}' },
+      });
+      fireEvent.change(screen.getByTestId('fieldMap'), {
+        target: { value: '{"field_map_1":"""aaa"bbb""", "field_map_2": "aaa(bbb"}' },
       });
 
-      // advance timers to allow the form to validate
-      jest.advanceTimersByTime(0);
+      // Save the field
+      fireEvent.click(within(screen.getByTestId('addProcessorForm')).getByTestId('submitButton'));
+      await waitFor(() => expect(onUpdate).toHaveBeenCalled());
+
+      const processors = getProcessorValue(onUpdate);
+
+      expect(processors[0][INFERENCE_TYPE]).toEqual({
+        model_id: 'test_inference_processor',
+
+        inference_config: { inf_conf_1: 'aaa"bbb', inf_conf_2: 'aaa(bbb' },
+
+        field_map: { field_map_1: 'aaa"bbb', field_map_2: 'aaa(bbb' },
+      });
     });
-    component.update();
 
-    // Save the field
-    await saveNewProcessor();
+    test('accepts input_output and strips field_map and target_field', async () => {
+      fireEvent.change(within(screen.getByTestId('inferenceModelId')).getByTestId('input'), {
+        target: { value: 'test_inference_processor' },
+      });
 
-    const processors = getProcessorValue(onUpdate, INFERENCE_TYPE);
+      fireEvent.change(screen.getByTestId('inputOutput'), {
+        target: {
+          value:
+            '[{"input_field":"content","output_field":"content_embedding","notes":"""aaa"bbb"""}]',
+        },
+      });
 
-    expect(processors[0][INFERENCE_TYPE]).toEqual({
-      model_id: 'test_inference_processor',
-      // eslint-disable-next-line prettier/prettier
-      inference_config: { inf_conf_1: 'aaa\"bbb', inf_conf_2: 'aaa(bbb' },
-      // eslint-disable-next-line prettier/prettier
-      field_map: { field_map_1: 'aaa\"bbb', field_map_2: 'aaa(bbb' },
+      // Save the field
+      fireEvent.click(within(screen.getByTestId('addProcessorForm')).getByTestId('submitButton'));
+      await waitFor(() => expect(onUpdate).toHaveBeenCalled());
+
+      const processors = getProcessorValue(onUpdate);
+
+      expect(processors[0][INFERENCE_TYPE]).toEqual({
+        model_id: 'test_inference_processor',
+        input_output: [
+          { input_field: 'content', output_field: 'content_embedding', notes: 'aaa"bbb' },
+        ],
+      });
+    });
+
+    test('rejects input_output when it is not a JSON array', async () => {
+      fireEvent.change(within(screen.getByTestId('inferenceModelId')).getByTestId('input'), {
+        target: { value: 'test_inference_processor' },
+      });
+
+      fireEvent.change(screen.getByTestId('inputOutput'), {
+        target: {
+          value:
+            '{"input_field":"content","output_field":"content_embedding","notes":"""aaa"bbb"""}',
+        },
+      });
+
+      // Save the field
+      fireEvent.click(within(screen.getByTestId('addProcessorForm')).getByTestId('submitButton'));
+      expect(await screen.findByText('Input/output must be a JSON array.')).toBeInTheDocument();
+    });
+
+    test('keeps input/output and target field + field map mutually exclusive when switching modes', async () => {
+      fireEvent.change(within(screen.getByTestId('inferenceModelId')).getByTestId('input'), {
+        target: { value: 'test_inference_processor' },
+      });
+
+      // Switch to target field & field map mode (toggle on)
+      fireEvent.click(getToggleInput());
+
+      fireEvent.change(within(screen.getByTestId('targetField')).getByTestId('input'), {
+        target: { value: 'ml.inference.my_tag' },
+      });
+
+      fireEvent.change(screen.getByTestId('fieldMap'), {
+        target: { value: '{"field_map_1":"value_1"}' },
+      });
+
+      // Switch to input/output mode (toggle off) and set input_output
+      fireEvent.click(getToggleInput());
+      fireEvent.change(screen.getByTestId('inputOutput'), {
+        target: { value: '[{"input_field":"content","output_field":"content_embedding"}]' },
+      });
+
+      fireEvent.click(within(screen.getByTestId('addProcessorForm')).getByTestId('submitButton'));
+      await waitFor(() => expect(onUpdate).toHaveBeenCalled());
+
+      const processors = getProcessorValue(onUpdate);
+
+      expect(processors[0][INFERENCE_TYPE]).toEqual({
+        model_id: 'test_inference_processor',
+        input_output: [{ input_field: 'content', output_field: 'content_embedding' }],
+      });
+    });
+
+    test('clears target_field when switching back to input/output mode', async () => {
+      fireEvent.change(within(screen.getByTestId('inferenceModelId')).getByTestId('input'), {
+        target: { value: 'test_inference_processor' },
+      });
+
+      // Switch to target field & field map mode (toggle on)
+      fireEvent.click(getToggleInput());
+      fireEvent.change(within(screen.getByTestId('targetField')).getByTestId('input'), {
+        target: { value: 'ml.inference.my_tag' },
+      });
+
+      // Switch back to input/output mode (toggle off) => should clear target_field
+      fireEvent.click(getToggleInput());
+
+      // Switch again to field map mode and verify the input is empty (cleared)
+      fireEvent.click(getToggleInput());
+      expect(within(screen.getByTestId('targetField')).getByTestId('input')).toHaveValue('');
+    });
+
+    test('strips input_output when switching to target_field + field_map mode', async () => {
+      fireEvent.change(within(screen.getByTestId('inferenceModelId')).getByTestId('input'), {
+        target: { value: 'test_inference_processor' },
+      });
+
+      fireEvent.change(screen.getByTestId('inputOutput'), {
+        target: {
+          value: '[{"input_field":"content","output_field":"content_embedding"}]',
+        },
+      });
+
+      // Switch to target field & field map mode (toggle on). Should clear input_output.
+      fireEvent.click(getToggleInput());
+
+      fireEvent.change(within(screen.getByTestId('targetField')).getByTestId('input'), {
+        target: { value: 'ml.inference.my_tag' },
+      });
+
+      fireEvent.change(screen.getByTestId('fieldMap'), {
+        target: { value: '{"field_map_1":"value_1"}' },
+      });
+
+      fireEvent.click(within(screen.getByTestId('addProcessorForm')).getByTestId('submitButton'));
+      await waitFor(() => expect(onUpdate).toHaveBeenCalled());
+
+      const processors = getProcessorValue(onUpdate);
+
+      expect(processors[0][INFERENCE_TYPE]).toEqual({
+        model_id: 'test_inference_processor',
+        target_field: 'ml.inference.my_tag',
+        field_map: { field_map_1: 'value_1' },
+      });
+    });
+  });
+
+  describe('edit saved inference processor defaults', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+      ({ httpSetup } = setupEnvironment());
+      onUpdate = jest.fn();
+    });
+
+    test('defaults to input/output mode for a saved processor with neither input_output nor target_field/field_map', async () => {
+      renderProcessorEditor(httpSetup, {
+        value: {
+          processors: [
+            {
+              [INFERENCE_TYPE]: {
+                model_id: 'saved_processor_no_mapping',
+              },
+            },
+          ],
+        },
+        onFlyoutOpen: jest.fn(),
+        onUpdate,
+      });
+
+      fireEvent.click(within(screen.getByTestId('processors>0')).getByTestId('manageItemButton'));
+      expect(await screen.findByTestId('editProcessorForm')).toBeInTheDocument();
+
+      expectToggleOff();
+      expect(screen.getByTestId('inputOutput')).toBeVisible();
+      expect(screen.queryByTestId('targetField')).toBeNull();
+      expect(screen.queryByTestId('fieldMap')).toBeNull();
+    });
+
+    test('defaults to target_field + field_map mode for a saved processor with target_field/field_map', async () => {
+      renderProcessorEditor(httpSetup, {
+        value: {
+          processors: [
+            {
+              [INFERENCE_TYPE]: {
+                model_id: 'saved_processor_field_map_mode',
+                target_field: 'ml.inference.my_tag',
+                field_map: {
+                  source: 'some_field',
+                },
+              },
+            },
+          ],
+        },
+        onFlyoutOpen: jest.fn(),
+        onUpdate,
+      });
+
+      fireEvent.click(within(screen.getByTestId('processors>0')).getByTestId('manageItemButton'));
+      expect(await screen.findByTestId('editProcessorForm')).toBeInTheDocument();
+
+      await waitFor(() => expectToggleOn());
+      expect(screen.getByTestId('targetField')).toBeVisible();
+      expect(screen.getByTestId('fieldMap')).toBeVisible();
+      expect(screen.queryByTestId('inputOutput')).toBeNull();
+    });
+
+    test('defaults to input/output mode for a saved processor with input_output', async () => {
+      renderProcessorEditor(httpSetup, {
+        value: {
+          processors: [
+            {
+              [INFERENCE_TYPE]: {
+                model_id: 'saved_processor_input_output_mode',
+                input_output: [{ input_field: 'content', output_field: 'content_embedding' }],
+              },
+            },
+          ],
+        },
+        onFlyoutOpen: jest.fn(),
+        onUpdate,
+      });
+
+      fireEvent.click(within(screen.getByTestId('processors>0')).getByTestId('manageItemButton'));
+      expect(await screen.findByTestId('editProcessorForm')).toBeInTheDocument();
+
+      expectToggleOff();
+      expect(screen.getByTestId('inputOutput')).toBeVisible();
+      expect(screen.queryByTestId('targetField')).toBeNull();
+      expect(screen.queryByTestId('fieldMap')).toBeNull();
+    });
+
+    test('shows field_map mode but blocks saving when field_map is an array string', async () => {
+      renderProcessorEditor(httpSetup, {
+        value: {
+          processors: [
+            {
+              [INFERENCE_TYPE]: {
+                model_id: 'saved_processor_field_map_array_string',
+                field_map: '[]',
+              },
+            },
+          ],
+        },
+        onFlyoutOpen: jest.fn(),
+        onUpdate,
+      });
+
+      fireEvent.click(within(screen.getByTestId('processors>0')).getByTestId('manageItemButton'));
+      expect(await screen.findByTestId('editProcessorForm')).toBeInTheDocument();
+
+      await waitFor(() => expectToggleOn());
+      expect(screen.getByTestId('fieldMap')).toBeVisible();
+      expect(screen.queryByTestId('inputOutput')).toBeNull();
+
+      const processorsBefore = getProcessorValue(onUpdate);
+
+      fireEvent.click(within(screen.getByTestId('editProcessorForm')).getByTestId('submitButton'));
+      expect(await screen.findByText('Field map must be a JSON object.')).toBeInTheDocument();
+
+      const processorsAfter = getProcessorValue(onUpdate);
+      expect(processorsAfter).toEqual(processorsBefore);
+    });
+
+    test('sanitizes a saved processor that has both input_output and target_field/field_map', async () => {
+      renderProcessorEditor(httpSetup, {
+        value: {
+          processors: [
+            {
+              [INFERENCE_TYPE]: {
+                model_id: 'saved_processor_both_configs',
+                // Both configured (backend rejects this)
+                input_output: [{ input_field: 'content', output_field: 'content_embedding' }],
+                target_field: 'ml.inference.my_tag',
+                field_map: { source: 'some_field' },
+              },
+            },
+          ],
+        },
+        onFlyoutOpen: jest.fn(),
+        onUpdate,
+      });
+
+      fireEvent.click(within(screen.getByTestId('processors>0')).getByTestId('manageItemButton'));
+      expect(await screen.findByTestId('editProcessorForm')).toBeInTheDocument();
+
+      // Prefer field_map mode when target_field/field_map exist.
+      await waitFor(() => expectToggleOn());
+      expect(screen.getByTestId('targetField')).toBeVisible();
+      expect(screen.getByTestId('fieldMap')).toBeVisible();
+      expect(screen.queryByTestId('inputOutput')).toBeNull();
+
+      fireEvent.click(within(screen.getByTestId('editProcessorForm')).getByTestId('submitButton'));
+      await waitFor(() => expect(onUpdate).toHaveBeenCalled());
+
+      const processors = getProcessorValue(onUpdate);
+      expect(processors[0][INFERENCE_TYPE]).toMatchObject({
+        model_id: 'saved_processor_both_configs',
+        target_field: 'ml.inference.my_tag',
+        field_map: { source: 'some_field' },
+      });
+      expect('input_output' in processors[0][INFERENCE_TYPE]).toBe(false);
     });
   });
 });

--- a/x-pack/platform/plugins/shared/ingest_pipelines/public/application/components/pipeline_editor/__jest__/processors/inference.test.tsx
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/public/application/components/pipeline_editor/__jest__/processors/inference.test.tsx
@@ -5,28 +5,28 @@
  * 2.0.
  */
 
-import { fireEvent, screen, waitFor, within } from '@testing-library/react';
-import { getProcessorValue, renderProcessorEditor, setupEnvironment } from './processor.helpers';
+import { act } from 'react-dom/test-utils';
+import type { SetupResult } from './processor.helpers';
+import { setup, getProcessorValue, setupEnvironment } from './processor.helpers';
 
 const INFERENCE_TYPE = 'inference';
 
 describe('Processor: Inference', () => {
   let onUpdate: jest.Mock;
+  let testBed: SetupResult;
   let httpSetup: ReturnType<typeof setupEnvironment>['httpSetup'];
 
-  const getToggleInput = () => screen.getByTestId('toggleInferenceInputMappingMode');
+  beforeAll(() => {
+    jest.useFakeTimers({ legacyFakeTimers: true });
+    // disable all react-beautiful-dnd development warnings
+    (window as any)['__@hello-pangea/dnd-disable-dev-warnings'] = true;
+  });
 
-  const expectToggleOn = () => {
-    expect(getToggleInput()).toHaveAttribute('aria-checked', 'true');
-  };
-
-  const expectToggleOff = () => {
-    expect(getToggleInput()).toHaveAttribute('aria-checked', 'false');
-  };
-
-  const switchToTargetFieldAndFieldMapMode = () => {
-    fireEvent.click(screen.getByTestId('toggleInferenceInputMappingMode'));
-  };
+  afterAll(() => {
+    jest.useRealTimers();
+    // enable all react-beautiful-dnd development warnings
+    (window as any)['__@hello-pangea/dnd-disable-dev-warnings'] = false;
+  });
 
   describe('add inference processor', () => {
     beforeEach(async () => {
@@ -34,127 +34,181 @@ describe('Processor: Inference', () => {
       ({ httpSetup } = setupEnvironment());
       onUpdate = jest.fn();
 
-      renderProcessorEditor(httpSetup, {
-        value: {
-          processors: [],
-        },
-        onFlyoutOpen: jest.fn(),
-        onUpdate,
+      await act(async () => {
+        testBed = await setup(httpSetup, {
+          value: {
+            processors: [],
+          },
+          onFlyoutOpen: jest.fn(),
+          onUpdate,
+        });
       });
 
-      fireEvent.click(screen.getByTestId('addProcessorButton'));
-      fireEvent.change(within(screen.getByTestId('processorTypeSelector')).getByTestId('input'), {
-        target: { value: INFERENCE_TYPE },
-      });
+      const { component, actions } = testBed;
+      component.update();
 
-      await screen.findByTestId('addProcessorForm');
+      // Open flyout to add new processor
+      actions.addProcessor();
+      // Add type (the other fields are not visible until a type is selected)
+      await actions.addProcessorType(INFERENCE_TYPE);
     });
 
     test('prevents form submission if required fields are not provided', async () => {
+      const {
+        actions: { saveNewProcessor },
+        form,
+      } = testBed;
+
       // Click submit button with only the type defined
+      await saveNewProcessor();
+
       // Expect form error as "field" is a required parameter
-      fireEvent.click(within(screen.getByTestId('addProcessorForm')).getByTestId('submitButton'));
-      expect(
-        await screen.findByText('A deployment, an inference, or a model ID value is required.')
-      ).toBeInTheDocument();
+      expect(form.getErrorsMessages()).toEqual([
+        'A deployment, an inference, or a model ID value is required.',
+      ]);
     });
 
     test('accepts inference config and field maps that contains escaped characters', async () => {
-      switchToTargetFieldAndFieldMapMode();
-      fireEvent.change(within(screen.getByTestId('inferenceModelId')).getByTestId('input'), {
-        target: { value: 'test_inference_processor' },
-      });
-      fireEvent.change(screen.getByTestId('inferenceConfig'), {
-        target: { value: '{"inf_conf_1":"""aaa"bbb""", "inf_conf_2": "aaa(bbb"}' },
-      });
-      fireEvent.change(screen.getByTestId('fieldMap'), {
-        target: { value: '{"field_map_1":"""aaa"bbb""", "field_map_2": "aaa(bbb"}' },
-      });
+      const {
+        actions: { saveNewProcessor },
+        find,
+        form,
+        component,
+      } = testBed;
 
-      // Save the field
-      fireEvent.click(within(screen.getByTestId('addProcessorForm')).getByTestId('submitButton'));
-      await waitFor(() => expect(onUpdate).toHaveBeenCalled());
+      // Switch to target field & field map mode
+      act(() => {
+        find('toggleInferenceInputMappingMode').simulate('click');
+      });
+      component.update();
 
-      const processors = getProcessorValue(onUpdate);
+      form.setInputValue('inferenceModelId.input', 'test_inference_processor');
+
+      await act(async () => {
+        find('inferenceConfig').simulate('change', {
+          jsonContent: '{"inf_conf_1":"""aaa"bbb""", "inf_conf_2": "aaa(bbb"}',
+        });
+        jest.advanceTimersByTime(0);
+      });
+      component.update();
+
+      await act(async () => {
+        find('fieldMap').simulate('change', {
+          jsonContent: '{"field_map_1":"""aaa"bbb""", "field_map_2": "aaa(bbb"}',
+        });
+        jest.advanceTimersByTime(0);
+      });
+      component.update();
+
+      await saveNewProcessor();
+
+      const processors = getProcessorValue(onUpdate, INFERENCE_TYPE);
 
       expect(processors[0][INFERENCE_TYPE]).toEqual({
         model_id: 'test_inference_processor',
-
-        inference_config: { inf_conf_1: 'aaa"bbb', inf_conf_2: 'aaa(bbb' },
-
-        field_map: { field_map_1: 'aaa"bbb', field_map_2: 'aaa(bbb' },
+        // eslint-disable-next-line prettier/prettier
+        inference_config: { inf_conf_1: 'aaa\"bbb', inf_conf_2: 'aaa(bbb' },
+        // eslint-disable-next-line prettier/prettier
+        field_map: { field_map_1: 'aaa\"bbb', field_map_2: 'aaa(bbb' },
       });
     });
 
     test('accepts input_output and strips field_map and target_field', async () => {
-      fireEvent.change(within(screen.getByTestId('inferenceModelId')).getByTestId('input'), {
-        target: { value: 'test_inference_processor' },
-      });
+      const {
+        actions: { saveNewProcessor },
+        find,
+        form,
+        component,
+      } = testBed;
 
-      fireEvent.change(screen.getByTestId('inputOutput'), {
-        target: {
-          value:
+      form.setInputValue('inferenceModelId.input', 'test_inference_processor');
+
+      await act(async () => {
+        find('inputOutput').simulate('change', {
+          jsonContent:
             '[{"input_field":"content","output_field":"content_embedding","notes":"""aaa"bbb"""}]',
-        },
+        });
+        jest.advanceTimersByTime(0);
       });
+      component.update();
 
-      // Save the field
-      fireEvent.click(within(screen.getByTestId('addProcessorForm')).getByTestId('submitButton'));
-      await waitFor(() => expect(onUpdate).toHaveBeenCalled());
+      await saveNewProcessor();
 
-      const processors = getProcessorValue(onUpdate);
+      const processors = getProcessorValue(onUpdate, INFERENCE_TYPE);
 
       expect(processors[0][INFERENCE_TYPE]).toEqual({
         model_id: 'test_inference_processor',
         input_output: [
-          { input_field: 'content', output_field: 'content_embedding', notes: 'aaa"bbb' },
+          // eslint-disable-next-line prettier/prettier
+          { input_field: 'content', output_field: 'content_embedding', notes: 'aaa\"bbb' },
         ],
       });
     });
 
     test('rejects input_output when it is not a JSON array', async () => {
-      fireEvent.change(within(screen.getByTestId('inferenceModelId')).getByTestId('input'), {
-        target: { value: 'test_inference_processor' },
-      });
+      const { find, form, component } = testBed;
 
-      fireEvent.change(screen.getByTestId('inputOutput'), {
-        target: {
-          value:
+      form.setInputValue('inferenceModelId.input', 'test_inference_processor');
+
+      await act(async () => {
+        find('inputOutput').simulate('change', {
+          jsonContent:
             '{"input_field":"content","output_field":"content_embedding","notes":"""aaa"bbb"""}',
-        },
+        });
+        jest.advanceTimersByTime(0);
       });
+      component.update();
 
-      // Save the field
-      fireEvent.click(within(screen.getByTestId('addProcessorForm')).getByTestId('submitButton'));
-      expect(await screen.findByText('Input/output must be a JSON array.')).toBeInTheDocument();
+      await act(async () => {
+        find('addProcessorForm.submitButton').simulate('click');
+        jest.runAllTimers();
+      });
+      component.update();
+
+      expect(form.getErrorsMessages()).toEqual(['Input/output must be a JSON array.']);
     });
 
     test('keeps input/output and target field + field map mutually exclusive when switching modes', async () => {
-      fireEvent.change(within(screen.getByTestId('inferenceModelId')).getByTestId('input'), {
-        target: { value: 'test_inference_processor' },
+      const {
+        actions: { saveNewProcessor },
+        find,
+        form,
+        component,
+      } = testBed;
+
+      form.setInputValue('inferenceModelId.input', 'test_inference_processor');
+
+      // Switch to target field & field map mode
+      act(() => {
+        find('toggleInferenceInputMappingMode').simulate('click');
       });
+      component.update();
 
-      // Switch to target field & field map mode (toggle on)
-      fireEvent.click(getToggleInput());
+      form.setInputValue('targetField.input', 'ml.inference.my_tag');
 
-      fireEvent.change(within(screen.getByTestId('targetField')).getByTestId('input'), {
-        target: { value: 'ml.inference.my_tag' },
+      await act(async () => {
+        find('fieldMap').simulate('change', { jsonContent: '{"field_map_1":"value_1"}' });
+        jest.advanceTimersByTime(0);
       });
+      component.update();
 
-      fireEvent.change(screen.getByTestId('fieldMap'), {
-        target: { value: '{"field_map_1":"value_1"}' },
+      // Switch back to input/output mode
+      act(() => {
+        find('toggleInferenceInputMappingMode').simulate('click');
       });
+      component.update();
 
-      // Switch to input/output mode (toggle off) and set input_output
-      fireEvent.click(getToggleInput());
-      fireEvent.change(screen.getByTestId('inputOutput'), {
-        target: { value: '[{"input_field":"content","output_field":"content_embedding"}]' },
+      await act(async () => {
+        find('inputOutput').simulate('change', {
+          jsonContent: '[{"input_field":"content","output_field":"content_embedding"}]',
+        });
+        jest.advanceTimersByTime(0);
       });
+      component.update();
 
-      fireEvent.click(within(screen.getByTestId('addProcessorForm')).getByTestId('submitButton'));
-      await waitFor(() => expect(onUpdate).toHaveBeenCalled());
+      await saveNewProcessor();
 
-      const processors = getProcessorValue(onUpdate);
+      const processors = getProcessorValue(onUpdate, INFERENCE_TYPE);
 
       expect(processors[0][INFERENCE_TYPE]).toEqual({
         model_id: 'test_inference_processor',
@@ -163,50 +217,68 @@ describe('Processor: Inference', () => {
     });
 
     test('clears target_field when switching back to input/output mode', async () => {
-      fireEvent.change(within(screen.getByTestId('inferenceModelId')).getByTestId('input'), {
-        target: { value: 'test_inference_processor' },
-      });
+      const { find, form, component } = testBed;
 
-      // Switch to target field & field map mode (toggle on)
-      fireEvent.click(getToggleInput());
-      fireEvent.change(within(screen.getByTestId('targetField')).getByTestId('input'), {
-        target: { value: 'ml.inference.my_tag' },
-      });
+      form.setInputValue('inferenceModelId.input', 'test_inference_processor');
 
-      // Switch back to input/output mode (toggle off) => should clear target_field
-      fireEvent.click(getToggleInput());
+      // Switch to target field & field map mode
+      act(() => {
+        find('toggleInferenceInputMappingMode').simulate('click');
+      });
+      component.update();
+
+      form.setInputValue('targetField.input', 'ml.inference.my_tag');
+
+      // Switch back to input/output mode => should clear target_field
+      act(() => {
+        find('toggleInferenceInputMappingMode').simulate('click');
+      });
+      component.update();
 
       // Switch again to field map mode and verify the input is empty (cleared)
-      fireEvent.click(getToggleInput());
-      expect(within(screen.getByTestId('targetField')).getByTestId('input')).toHaveValue('');
+      act(() => {
+        find('toggleInferenceInputMappingMode').simulate('click');
+      });
+      component.update();
+
+      expect(find('targetField.input').props().value).toBe('');
     });
 
     test('strips input_output when switching to target_field + field_map mode', async () => {
-      fireEvent.change(within(screen.getByTestId('inferenceModelId')).getByTestId('input'), {
-        target: { value: 'test_inference_processor' },
+      const {
+        actions: { saveNewProcessor },
+        find,
+        form,
+        component,
+      } = testBed;
+
+      form.setInputValue('inferenceModelId.input', 'test_inference_processor');
+
+      await act(async () => {
+        find('inputOutput').simulate('change', {
+          jsonContent: '[{"input_field":"content","output_field":"content_embedding"}]',
+        });
+        jest.advanceTimersByTime(0);
       });
+      component.update();
 
-      fireEvent.change(screen.getByTestId('inputOutput'), {
-        target: {
-          value: '[{"input_field":"content","output_field":"content_embedding"}]',
-        },
+      // Switch to target field & field map mode — should clear input_output
+      act(() => {
+        find('toggleInferenceInputMappingMode').simulate('click');
       });
+      component.update();
 
-      // Switch to target field & field map mode (toggle on). Should clear input_output.
-      fireEvent.click(getToggleInput());
+      form.setInputValue('targetField.input', 'ml.inference.my_tag');
 
-      fireEvent.change(within(screen.getByTestId('targetField')).getByTestId('input'), {
-        target: { value: 'ml.inference.my_tag' },
+      await act(async () => {
+        find('fieldMap').simulate('change', { jsonContent: '{"field_map_1":"value_1"}' });
+        jest.advanceTimersByTime(0);
       });
+      component.update();
 
-      fireEvent.change(screen.getByTestId('fieldMap'), {
-        target: { value: '{"field_map_1":"value_1"}' },
-      });
+      await saveNewProcessor();
 
-      fireEvent.click(within(screen.getByTestId('addProcessorForm')).getByTestId('submitButton'));
-      await waitFor(() => expect(onUpdate).toHaveBeenCalled());
-
-      const processors = getProcessorValue(onUpdate);
+      const processors = getProcessorValue(onUpdate, INFERENCE_TYPE);
 
       expect(processors[0][INFERENCE_TYPE]).toEqual({
         model_id: 'test_inference_processor',
@@ -224,146 +296,170 @@ describe('Processor: Inference', () => {
     });
 
     test('defaults to input/output mode for a saved processor with neither input_output nor target_field/field_map', async () => {
-      renderProcessorEditor(httpSetup, {
-        value: {
-          processors: [
-            {
-              [INFERENCE_TYPE]: {
-                model_id: 'saved_processor_no_mapping',
-              },
-            },
-          ],
-        },
-        onFlyoutOpen: jest.fn(),
-        onUpdate,
+      await act(async () => {
+        testBed = await setup(httpSetup, {
+          value: {
+            processors: [{ [INFERENCE_TYPE]: { model_id: 'saved_processor_no_mapping' } }],
+          },
+          onFlyoutOpen: jest.fn(),
+          onUpdate,
+        });
       });
+      const { component, find } = testBed;
+      component.update();
 
-      fireEvent.click(within(screen.getByTestId('processors>0')).getByTestId('manageItemButton'));
-      expect(await screen.findByTestId('editProcessorForm')).toBeInTheDocument();
+      await act(async () => {
+        find('processors>0.manageItemButton').simulate('click');
+      });
+      component.update();
 
-      expectToggleOff();
-      expect(screen.getByTestId('inputOutput')).toBeVisible();
-      expect(screen.queryByTestId('targetField')).toBeNull();
-      expect(screen.queryByTestId('fieldMap')).toBeNull();
+      expect(find('toggleInferenceInputMappingMode').prop('aria-checked')).toBe(false);
+      expect(find('inputOutput').exists()).toBe(true);
+      expect(find('targetField').exists()).toBe(false);
+      expect(find('fieldMap').exists()).toBe(false);
     });
 
     test('defaults to target_field + field_map mode for a saved processor with target_field/field_map', async () => {
-      renderProcessorEditor(httpSetup, {
-        value: {
-          processors: [
-            {
-              [INFERENCE_TYPE]: {
-                model_id: 'saved_processor_field_map_mode',
-                target_field: 'ml.inference.my_tag',
-                field_map: {
-                  source: 'some_field',
+      await act(async () => {
+        testBed = await setup(httpSetup, {
+          value: {
+            processors: [
+              {
+                [INFERENCE_TYPE]: {
+                  model_id: 'saved_processor_field_map_mode',
+                  target_field: 'ml.inference.my_tag',
+                  field_map: { source: 'some_field' },
                 },
               },
-            },
-          ],
-        },
-        onFlyoutOpen: jest.fn(),
-        onUpdate,
+            ],
+          },
+          onFlyoutOpen: jest.fn(),
+          onUpdate,
+        });
       });
+      const { component, find } = testBed;
+      component.update();
 
-      fireEvent.click(within(screen.getByTestId('processors>0')).getByTestId('manageItemButton'));
-      expect(await screen.findByTestId('editProcessorForm')).toBeInTheDocument();
+      await act(async () => {
+        find('processors>0.manageItemButton').simulate('click');
+      });
+      component.update();
 
-      await waitFor(() => expectToggleOn());
-      expect(screen.getByTestId('targetField')).toBeVisible();
-      expect(screen.getByTestId('fieldMap')).toBeVisible();
-      expect(screen.queryByTestId('inputOutput')).toBeNull();
+      expect(find('toggleInferenceInputMappingMode').prop('aria-checked')).toBe(true);
+      expect(find('targetField').exists()).toBe(true);
+      expect(find('fieldMap').exists()).toBe(true);
+      expect(find('inputOutput').exists()).toBe(false);
     });
 
     test('defaults to input/output mode for a saved processor with input_output', async () => {
-      renderProcessorEditor(httpSetup, {
-        value: {
-          processors: [
-            {
-              [INFERENCE_TYPE]: {
-                model_id: 'saved_processor_input_output_mode',
-                input_output: [{ input_field: 'content', output_field: 'content_embedding' }],
+      await act(async () => {
+        testBed = await setup(httpSetup, {
+          value: {
+            processors: [
+              {
+                [INFERENCE_TYPE]: {
+                  model_id: 'saved_processor_input_output_mode',
+                  input_output: [{ input_field: 'content', output_field: 'content_embedding' }],
+                },
               },
-            },
-          ],
-        },
-        onFlyoutOpen: jest.fn(),
-        onUpdate,
+            ],
+          },
+          onFlyoutOpen: jest.fn(),
+          onUpdate,
+        });
       });
+      const { component, find } = testBed;
+      component.update();
 
-      fireEvent.click(within(screen.getByTestId('processors>0')).getByTestId('manageItemButton'));
-      expect(await screen.findByTestId('editProcessorForm')).toBeInTheDocument();
+      await act(async () => {
+        find('processors>0.manageItemButton').simulate('click');
+      });
+      component.update();
 
-      expectToggleOff();
-      expect(screen.getByTestId('inputOutput')).toBeVisible();
-      expect(screen.queryByTestId('targetField')).toBeNull();
-      expect(screen.queryByTestId('fieldMap')).toBeNull();
+      expect(find('toggleInferenceInputMappingMode').prop('aria-checked')).toBe(false);
+      expect(find('inputOutput').exists()).toBe(true);
+      expect(find('targetField').exists()).toBe(false);
+      expect(find('fieldMap').exists()).toBe(false);
     });
 
     test('shows field_map mode but blocks saving when field_map is an array string', async () => {
-      renderProcessorEditor(httpSetup, {
-        value: {
-          processors: [
-            {
-              [INFERENCE_TYPE]: {
-                model_id: 'saved_processor_field_map_array_string',
-                field_map: '[]',
+      await act(async () => {
+        testBed = await setup(httpSetup, {
+          value: {
+            processors: [
+              {
+                [INFERENCE_TYPE]: {
+                  model_id: 'saved_processor_field_map_array_string',
+                  field_map: '[]',
+                },
               },
-            },
-          ],
-        },
-        onFlyoutOpen: jest.fn(),
-        onUpdate,
+            ],
+          },
+          onFlyoutOpen: jest.fn(),
+          onUpdate,
+        });
       });
+      const { component, find, form } = testBed;
+      component.update();
 
-      fireEvent.click(within(screen.getByTestId('processors>0')).getByTestId('manageItemButton'));
-      expect(await screen.findByTestId('editProcessorForm')).toBeInTheDocument();
+      await act(async () => {
+        find('processors>0.manageItemButton').simulate('click');
+      });
+      component.update();
 
-      await waitFor(() => expectToggleOn());
-      expect(screen.getByTestId('fieldMap')).toBeVisible();
-      expect(screen.queryByTestId('inputOutput')).toBeNull();
+      expect(find('toggleInferenceInputMappingMode').prop('aria-checked')).toBe(true);
+      expect(find('fieldMap').exists()).toBe(true);
+      expect(find('inputOutput').exists()).toBe(false);
 
-      const processorsBefore = getProcessorValue(onUpdate);
+      await act(async () => {
+        find('editProcessorForm.submitButton').simulate('click');
+        jest.runAllTimers();
+      });
+      component.update();
 
-      fireEvent.click(within(screen.getByTestId('editProcessorForm')).getByTestId('submitButton'));
-      expect(await screen.findByText('Field map must be a JSON object.')).toBeInTheDocument();
-
-      const processorsAfter = getProcessorValue(onUpdate);
-      expect(processorsAfter).toEqual(processorsBefore);
+      expect(form.getErrorsMessages()).toEqual(['Field map must be a JSON object.']);
     });
 
     test('sanitizes a saved processor that has both input_output and target_field/field_map', async () => {
-      renderProcessorEditor(httpSetup, {
-        value: {
-          processors: [
-            {
-              [INFERENCE_TYPE]: {
-                model_id: 'saved_processor_both_configs',
-                // Both configured (backend rejects this)
-                input_output: [{ input_field: 'content', output_field: 'content_embedding' }],
-                target_field: 'ml.inference.my_tag',
-                field_map: { source: 'some_field' },
+      await act(async () => {
+        testBed = await setup(httpSetup, {
+          value: {
+            processors: [
+              {
+                [INFERENCE_TYPE]: {
+                  model_id: 'saved_processor_both_configs',
+                  input_output: [{ input_field: 'content', output_field: 'content_embedding' }],
+                  target_field: 'ml.inference.my_tag',
+                  field_map: { source: 'some_field' },
+                },
               },
-            },
-          ],
-        },
-        onFlyoutOpen: jest.fn(),
-        onUpdate,
+            ],
+          },
+          onFlyoutOpen: jest.fn(),
+          onUpdate,
+        });
       });
+      const { component, find } = testBed;
+      component.update();
 
-      fireEvent.click(within(screen.getByTestId('processors>0')).getByTestId('manageItemButton'));
-      expect(await screen.findByTestId('editProcessorForm')).toBeInTheDocument();
+      await act(async () => {
+        find('processors>0.manageItemButton').simulate('click');
+      });
+      component.update();
 
-      // Prefer field_map mode when target_field/field_map exist.
-      await waitFor(() => expectToggleOn());
-      expect(screen.getByTestId('targetField')).toBeVisible();
-      expect(screen.getByTestId('fieldMap')).toBeVisible();
-      expect(screen.queryByTestId('inputOutput')).toBeNull();
+      // Prefer field_map mode when target_field/field_map exist
+      expect(find('toggleInferenceInputMappingMode').prop('aria-checked')).toBe(true);
+      expect(find('targetField').exists()).toBe(true);
+      expect(find('fieldMap').exists()).toBe(true);
+      expect(find('inputOutput').exists()).toBe(false);
 
-      fireEvent.click(within(screen.getByTestId('editProcessorForm')).getByTestId('submitButton'));
-      await waitFor(() => expect(onUpdate).toHaveBeenCalled());
+      await act(async () => {
+        find('editProcessorForm.submitButton').simulate('click');
+        jest.advanceTimersByTime(0);
+      });
+      component.update();
 
-      const processors = getProcessorValue(onUpdate);
+      const processors = getProcessorValue(onUpdate, INFERENCE_TYPE);
       expect(processors[0][INFERENCE_TYPE]).toMatchObject({
         model_id: 'saved_processor_both_configs',
         target_field: 'ml.inference.my_tag',

--- a/x-pack/platform/plugins/shared/ingest_pipelines/public/application/components/pipeline_editor/__jest__/processors/processor.helpers.tsx
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/public/application/components/pipeline_editor/__jest__/processors/processor.helpers.tsx
@@ -207,5 +207,11 @@ type TestSubject =
   | 'inferenceModelId.input'
   | 'inferenceConfig'
   | 'fieldMap'
+  | 'inputOutput'
+  | 'targetField'
+  | 'toggleInferenceInputMappingMode'
+  | 'editProcessorForm.submitButton'
+  | 'editProcessorForm'
+  | 'processors>0.manageItemButton'
   | 'toggleTextField'
   | 'jsonValueField';

--- a/x-pack/platform/plugins/shared/ingest_pipelines/public/application/components/pipeline_editor/components/processor_form/processors/inference.tsx
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/public/application/components/pipeline_editor/components/processor_form/processors/inference.tsx
@@ -5,10 +5,11 @@
  * 2.0.
  */
 
-import React, { FunctionComponent } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import type { ReactNode } from 'react';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { EuiCode, EuiLink } from '@elastic/eui';
+import { EuiCode, EuiFormRow, EuiLink, EuiSpacer, EuiSwitch } from '@elastic/eui';
 
 import {
   FIELD_TYPES,
@@ -16,12 +17,15 @@ import {
   UseField,
   Field,
   useKibana,
+  useFormContext,
 } from '../../../../../../shared_imports';
 
 import { TargetField } from './common_fields/target_field';
 
-import { FieldsConfig, to, from, EDITOR_PX_HEIGHT, isXJsonField } from './shared';
+import type { FieldsConfig, FormFieldsComponent } from './shared';
+import { to, from, EDITOR_PX_HEIGHT, isXJsonField } from './shared';
 import { XJsonEditor } from '../field_components';
+import { collapseEscapedStrings } from '../../../utils';
 
 const { emptyField } = fieldValidators;
 
@@ -34,7 +38,7 @@ const INFERENCE_CONFIG_DOCS = {
   },
 };
 
-function getInferenceConfigHelpText(documentationDocsLink: string): React.ReactNode {
+function getInferenceConfigHelpText(documentationDocsLink: string): ReactNode {
   return (
     <FormattedMessage
       id="xpack.ingestPipelines.pipelineEditor.inferenceForm.inferenceConfigurationHelpText"
@@ -49,6 +53,86 @@ function getInferenceConfigHelpText(documentationDocsLink: string): React.ReactN
     />
   );
 }
+
+const deserializeXJsonWithDefault =
+  (defaultValue: string) =>
+  (v: unknown): string => {
+    if (!v) {
+      return defaultValue;
+    }
+    if (typeof v === 'string') {
+      return v;
+    }
+    return JSON.stringify(v, null, 2);
+  };
+
+const isInputOutputArrayField =
+  (message: string) =>
+  ({ value }: { value: unknown }) => {
+    if (typeof value !== 'string') {
+      return;
+    }
+
+    const trimmed = collapseEscapedStrings(value).trim();
+    if (!trimmed || trimmed === '[]') {
+      return;
+    }
+
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (!Array.isArray(parsed)) {
+        return { message };
+      }
+    } catch {
+      // Invalid JSON is handled by the isXJsonField validator.
+    }
+  };
+
+const isFieldMapObjectField =
+  (message: string) =>
+  ({ value }: { value: unknown }) => {
+    if (typeof value !== 'string') {
+      return;
+    }
+
+    const trimmed = collapseEscapedStrings(value).trim();
+    if (!trimmed || trimmed === '{}') {
+      return;
+    }
+
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+        return { message };
+      }
+    } catch {
+      // Invalid JSON is handled by the isXJsonField validator.
+    }
+  };
+
+const mappingModeToggleLabel = i18n.translate(
+  'xpack.ingestPipelines.pipelineEditor.inferenceForm.inputMappingModeLabel',
+  {
+    defaultMessage: 'Use target field and field map instead of input/output',
+  }
+);
+
+const mappingModeToggleHelpText = (
+  <FormattedMessage
+    id="xpack.ingestPipelines.pipelineEditor.inferenceForm.inputMappingModeHelpText"
+    defaultMessage="Use {inputOutput} for NLP inference endpoints. Use {targetFieldAndFieldMap} for data frame analytics models."
+    values={{
+      inputOutput: <EuiCode>{'input_output'}</EuiCode>,
+      targetFieldAndFieldMap: (
+        <>
+          <EuiCode>{'target_field'}</EuiCode>
+          {' + '}
+          <EuiCode>{'field_map'}</EuiCode>
+        </>
+      ),
+    }}
+  />
+);
 
 const fieldsConfig: FieldsConfig = {
   /* Required fields config */
@@ -80,6 +164,47 @@ const fieldsConfig: FieldsConfig = {
   },
 
   /* Optional fields config */
+  input_output: {
+    type: FIELD_TYPES.TEXT,
+    // Default to an empty array literal for the editor.
+    deserializer: deserializeXJsonWithDefault('[]'),
+    serializer: from.optionalXJsonArray,
+    label: i18n.translate('xpack.ingestPipelines.pipelineEditor.inferenceForm.inputOutputLabel', {
+      defaultMessage: 'Input/output fields (optional)',
+    }),
+    helpText: (
+      <FormattedMessage
+        id="xpack.ingestPipelines.pipelineEditor.inferenceForm.inputOutputHelpText"
+        defaultMessage="List of input fields and output (destination) fields for inference results. Inference endpoints require {inputOutput}."
+        values={{
+          inputOutput: <EuiCode>{'input_output'}</EuiCode>,
+        }}
+      />
+    ),
+    validations: [
+      {
+        validator: isXJsonField(
+          i18n.translate(
+            'xpack.ingestPipelines.pipelineEditor.inferenceForm.inputOutputInvalidJSONError',
+            { defaultMessage: 'Invalid JSON' }
+          ),
+          {
+            allowEmptyString: true,
+          }
+        ),
+      },
+      {
+        validator: isInputOutputArrayField(
+          i18n.translate(
+            'xpack.ingestPipelines.pipelineEditor.inferenceForm.inputOutputArrayError',
+            {
+              defaultMessage: 'Input/output must be a JSON array.',
+            }
+          )
+        ),
+      },
+    ],
+  },
   field_map: {
     type: FIELD_TYPES.TEXT,
     deserializer: to.xJsonString,
@@ -104,6 +229,14 @@ const fieldsConfig: FieldsConfig = {
           {
             allowEmptyString: true,
           }
+        ),
+      },
+      {
+        validator: isFieldMapObjectField(
+          i18n.translate(
+            'xpack.ingestPipelines.pipelineEditor.inferenceForm.fieldMapMustBeObjectError',
+            { defaultMessage: 'Field map must be a JSON object.' }
+          )
         ),
       },
     ],
@@ -135,9 +268,96 @@ const fieldsConfig: FieldsConfig = {
   },
 };
 
-export const Inference: FunctionComponent = () => {
+export const Inference: FormFieldsComponent = ({ initialFieldValues }) => {
+  const form = useFormContext();
   const { services } = useKibana();
   const documentationDocsLink = services.documentation.getDocumentationUrl();
+  const initialUseFieldMapMode = useMemo(() => {
+    if (!initialFieldValues) {
+      return false;
+    }
+    return (
+      Object.prototype.hasOwnProperty.call(initialFieldValues, 'target_field') ||
+      Object.prototype.hasOwnProperty.call(initialFieldValues, 'field_map')
+    );
+  }, [initialFieldValues]);
+
+  const [useFieldMapMode, setUseFieldMapMode] = useState<boolean>(initialUseFieldMapMode);
+
+  useEffect(() => {
+    setUseFieldMapMode(initialUseFieldMapMode);
+  }, [initialUseFieldMapMode]);
+
+  const setRegisteredFieldValue = useCallback(
+    (path: string, value: unknown) => {
+      const field = form.getFields?.()[path];
+      if (field?.setValue) {
+        field.setValue(value);
+      }
+    },
+    [form]
+  );
+
+  const unsetField = useCallback(
+    (fieldKey: string) => {
+      const data = form.getFormData() as { fields?: Record<string, unknown> };
+      const currentFields = data.fields ?? {};
+      if (Object.prototype.hasOwnProperty.call(currentFields, fieldKey) === false) {
+        return;
+      }
+      const nextFields = { ...currentFields };
+      delete nextFields[fieldKey];
+      form.setFieldValue('fields', nextFields);
+    },
+    [form]
+  );
+
+  const clearInputOutput = useCallback(() => {
+    setRegisteredFieldValue('fields.input_output', '[]');
+    unsetField('input_output');
+  }, [setRegisteredFieldValue, unsetField]);
+
+  const clearFieldMapMode = useCallback(() => {
+    setRegisteredFieldValue('fields.target_field', '');
+    unsetField('target_field');
+    setRegisteredFieldValue('fields.field_map', '');
+    unsetField('field_map');
+  }, [setRegisteredFieldValue, unsetField]);
+
+  // Normalize existing saved processors on open to avoid incompatible configs.
+  // Avoid touching empty/new processors to prevent interfering with field registration.
+  useEffect(() => {
+    if (!initialFieldValues) return;
+
+    const hasInputOutput = Object.prototype.hasOwnProperty.call(initialFieldValues, 'input_output');
+    const hasFieldMapMode =
+      Object.prototype.hasOwnProperty.call(initialFieldValues, 'target_field') ||
+      Object.prototype.hasOwnProperty.call(initialFieldValues, 'field_map');
+
+    if (initialUseFieldMapMode) {
+      if (hasInputOutput) {
+        clearInputOutput();
+      }
+      return;
+    }
+
+    if (hasFieldMapMode) {
+      clearFieldMapMode();
+    }
+  }, [clearFieldMapMode, clearInputOutput, initialFieldValues, initialUseFieldMapMode]);
+
+  const toggleMappingMode = useCallback(() => {
+    setUseFieldMapMode((prev) => {
+      const next = !prev;
+      if (next) {
+        clearInputOutput();
+      } else {
+        clearFieldMapMode();
+      }
+      return next;
+    });
+  }, [clearFieldMapMode, clearInputOutput]);
+
   return (
     <>
       <UseField
@@ -146,30 +366,58 @@ export const Inference: FunctionComponent = () => {
         path="fields.model_id"
         data-test-subj="inferenceModelId"
       />
+      <EuiSpacer size="m" />
+      <EuiFormRow fullWidth helpText={mappingModeToggleHelpText}>
+        <EuiSwitch
+          label={mappingModeToggleLabel}
+          checked={useFieldMapMode}
+          onChange={toggleMappingMode}
+          data-test-subj="toggleInferenceInputMappingMode"
+        />
+      </EuiFormRow>
+      <EuiSpacer size="m" />
 
-      <TargetField
-        helpText={
-          <FormattedMessage
-            id="xpack.ingestPipelines.pipelineEditor.inferenceForm.targetFieldHelpText"
-            defaultMessage="Field used to contain inference processor results. Defaults to {targetField}."
-            values={{ targetField: <EuiCode>{'ml.inference.<processor_tag>'}</EuiCode> }}
+      {useFieldMapMode ? (
+        <>
+          <TargetField
+            helpText={
+              <FormattedMessage
+                id="xpack.ingestPipelines.pipelineEditor.inferenceForm.targetFieldHelpText"
+                defaultMessage="Field used to contain inference processor results. Defaults to {targetField}."
+                values={{ targetField: <EuiCode>{'ml.inference.<processor_tag>'}</EuiCode> }}
+              />
+            }
           />
-        }
-      />
 
-      <UseField
-        config={fieldsConfig.field_map}
-        component={XJsonEditor}
-        componentProps={{
-          editorProps: {
-            'data-test-subj': 'fieldMap',
-            height: EDITOR_PX_HEIGHT.medium,
-            options: { minimap: { enabled: false } },
-          },
-        }}
-        path="fields.field_map"
-      />
+          <UseField
+            config={fieldsConfig.field_map}
+            component={XJsonEditor}
+            componentProps={{
+              editorProps: {
+                'data-test-subj': 'fieldMap',
+                height: EDITOR_PX_HEIGHT.medium,
+                options: { minimap: { enabled: false } },
+              },
+            }}
+            path="fields.field_map"
+          />
+        </>
+      ) : (
+        <UseField
+          config={fieldsConfig.input_output}
+          component={XJsonEditor}
+          componentProps={{
+            editorProps: {
+              'data-test-subj': 'inputOutput',
+              height: EDITOR_PX_HEIGHT.medium,
+              options: { minimap: { enabled: false } },
+            },
+          }}
+          path="fields.input_output"
+        />
+      )}
 
+      <EuiSpacer size="s" />
       <UseField
         config={{
           ...fieldsConfig.inference_config,

--- a/x-pack/platform/plugins/shared/ingest_pipelines/public/application/components/pipeline_editor/components/processor_form/processors/shared.ts
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/public/application/components/pipeline_editor/components/processor_form/processors/shared.ts
@@ -150,6 +150,26 @@ export const from = {
     }
     return undefined;
   },
+  optionalXJsonArray: (v: string) => {
+    const trimmed = v.trim();
+    if (!trimmed) {
+      return undefined;
+    }
+    const collapsed = collapseEscapedStrings(trimmed);
+    try {
+      const parsed = JSON.parse(collapsed);
+      if (Array.isArray(parsed) && parsed.length === 0) {
+        return undefined;
+      }
+    } catch {
+      // If invalid JSON, keep the value; validation should catch invalid content.
+      // Fall back to the simplest empty array literal check.
+      if (collapsed === '[]') {
+        return undefined;
+      }
+    }
+    return v;
+  },
 };
 
 const isJSONString = (v: string) => {

--- a/x-pack/platform/plugins/shared/ingest_pipelines/public/application/components/pipeline_editor/context/processors_context.tsx
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/public/application/components/pipeline_editor/context/processors_context.tsx
@@ -159,6 +159,13 @@ export const PipelineProcessorsContextProvider: FunctionComponent<Props> = ({
             'internal_networks_field',
             'value',
             'copy_from',
+            // input_output, target_field, and field_map are mutually exclusive inference processor
+            // options. We only mark them as known when editing an inference processor so that
+            // target_field (which is also used by other processor types) is not accidentally
+            // stripped from unknownOptions when editing those other processors.
+            ...(processorTypeAndOptions.type === 'inference'
+              ? ['input_output', 'target_field', 'field_map']
+              : []),
           ];
 
           // If the processor type is changed while editing, we need to ignore unkownOptions as they

--- a/x-pack/platform/plugins/shared/ingest_pipelines/public/application/components/pipeline_editor/utils.test.ts
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/public/application/components/pipeline_editor/utils.test.ts
@@ -76,6 +76,7 @@ describe('convert processors to json', () => {
       processor: '{"1": """aaa"bbb"""}',
       inference_config: '{"1": """aaa"bbb"""}',
       field_map: '{"1": """aaa"bbb"""}',
+      input_output: '[{"1": """aaa"bbb"""}]',
       customOptions: '{"customProcessor": """aaa"bbb"""}',
     };
 
@@ -92,6 +93,8 @@ describe('convert processors to json', () => {
       // eslint-disable-next-line prettier/prettier
       field_map: { 1: "aaa\"bbb" },
       // eslint-disable-next-line prettier/prettier
+      input_output: [{ 1: "aaa\"bbb" }],
+      // eslint-disable-next-line prettier/prettier
       customProcessor: "aaa\"bbb"
     });
   });
@@ -102,6 +105,7 @@ describe('convert processors to json', () => {
       value: '',
       inference_config: '',
       field_map: '',
+      input_output: '',
       params: '',
       pattern_definitions: '',
       processor: '',
@@ -115,6 +119,7 @@ describe('convert processors to json', () => {
       value: '',
       inference_config: '',
       field_map: '',
+      input_output: '',
       params: '',
       pattern_definitions: '',
       processor: '',
@@ -124,6 +129,7 @@ describe('convert processors to json', () => {
     expect(result.value).toBe('');
     expect(result.inference_config).toBe('');
     expect(result.field_map).toBe('');
+    expect(result.input_output).toBe('');
     expect(result.params).toBe('');
     expect(result.pattern_definitions).toBe('');
     expect(result.processor).toBe('');

--- a/x-pack/platform/plugins/shared/ingest_pipelines/public/application/components/pipeline_editor/utils.ts
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/public/application/components/pipeline_editor/utils.ts
@@ -156,6 +156,7 @@ export const collapseEscapedStrings = (data: string): string => {
 const fieldToConvertToJson = [
   'inference_config',
   'field_map',
+  'input_output',
   'params',
   'pattern_definitions',
   'processor',


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Ingest pipelines] Include input_output in inference processor (#260517)](https://github.com/elastic/kibana/pull/260517)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Sonia Sanz Vivas","email":"sonia.sanzvivas@elastic.co"},"sourceCommit":{"committedDate":"2026-04-07T14:17:00Z","message":"[Ingest pipelines] Include input_output in inference processor (#260517)\n\nCloses https://github.com/elastic/kibana/issues/249076\n\n## Summary\n- Fixes inference processor creation in Stack Management → Ingest\nPipelines by supporting the two valid inference processor configuration\nshapes:\n  - `input_output`\n  - `target_field` + `field_map`\n- Both shapes are optional, but they are mutually exclusive (cannot be\nused at the same time).\n- Previously, Kibana only allowed configuring `target_field` +\n`field_map`, which caused pipeline tests to fail for NLP inference\nendpoints (for example `.elser-2-elastic`) that require `input_output`.\nNow users can select `input_output`; `target_field` + `field_map`\nremains available, but it will still fail for those NLP endpoints\nbecause it is not the correct configuration.\n\n### Test plan\n- Manual:\n- Prereqs: run Elastic Inference Service (EIS) locally and connect it to\nyour local Elasticsearch/Kibana. Follow the instructions in\n[@kbn/inference-cli\nREADME](https://github.com/elastic/kibana/blob/main/x-pack/platform/packages/shared/kbn-inference-cli/README.md)\n(EIS / Cloud Connected Mode section).\n- In Kibana: Stack Management → Ingest Pipelines → Create pipeline → add\nan inference processor and select the `input_output` configuration with:\n\n    ```json\n    {\n      \"model_id\": \".elser-2-elastic\",\n      \"input_output\": [\n        {\n          \"input_field\": \"text_field\",\n          \"output_field\": \"content_embedding\"\n        }\n      ]\n    }\n    ```\n\n  - Use “Test pipeline” with a document like:\n\n    ```json\n    { \"_source\": { \"text_field\": \"hello world\" } }\n    ```\n\n- Expected: the test completes successfully and the output includes\n`content_embedding` (no `status_exception` about `input_output` vs\n`field_map`).\n- Automated:\n- Updated/added Jest coverage for inference processor\nserialization/format selection.\n\n### Before/after notes\n- Before:\n- **Before**: Kibana only allowed configuring inference processors as\n`target_field` + `field_map`, so testing a pipeline with an NLP\ninference endpoint like `.elser-2-elastic` failed with a\n`status_exception` instructing to use `input_output` instead of\n`field_map` (see issue screenshot).\n- After:\n- **After**: Kibana allows choosing `input_output` (mutually exclusive\nwith `target_field` + `field_map`), so the same pipeline test succeeds\nand returns `content_embedding`. For NLP inference endpoints, using\n`target_field` + `field_map` still fails as expected because it is not\nthe correct configuration for those endpoints.\n\n### Evidence\n\n\nhttps://github.com/user-attachments/assets/9c9c729b-7783-409b-9dd9-5eaf3a665fff","sha":"f9bbce16860e5eb448e2db4173b5f170b7f25c9a","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Kibana Management","backport missing","Feature:Ingest Node Pipelines","backport:all-open","v9.4.0"],"title":"[Ingest pipelines] Include input_output in inference processor","number":260517,"url":"https://github.com/elastic/kibana/pull/260517","mergeCommit":{"message":"[Ingest pipelines] Include input_output in inference processor (#260517)\n\nCloses https://github.com/elastic/kibana/issues/249076\n\n## Summary\n- Fixes inference processor creation in Stack Management → Ingest\nPipelines by supporting the two valid inference processor configuration\nshapes:\n  - `input_output`\n  - `target_field` + `field_map`\n- Both shapes are optional, but they are mutually exclusive (cannot be\nused at the same time).\n- Previously, Kibana only allowed configuring `target_field` +\n`field_map`, which caused pipeline tests to fail for NLP inference\nendpoints (for example `.elser-2-elastic`) that require `input_output`.\nNow users can select `input_output`; `target_field` + `field_map`\nremains available, but it will still fail for those NLP endpoints\nbecause it is not the correct configuration.\n\n### Test plan\n- Manual:\n- Prereqs: run Elastic Inference Service (EIS) locally and connect it to\nyour local Elasticsearch/Kibana. Follow the instructions in\n[@kbn/inference-cli\nREADME](https://github.com/elastic/kibana/blob/main/x-pack/platform/packages/shared/kbn-inference-cli/README.md)\n(EIS / Cloud Connected Mode section).\n- In Kibana: Stack Management → Ingest Pipelines → Create pipeline → add\nan inference processor and select the `input_output` configuration with:\n\n    ```json\n    {\n      \"model_id\": \".elser-2-elastic\",\n      \"input_output\": [\n        {\n          \"input_field\": \"text_field\",\n          \"output_field\": \"content_embedding\"\n        }\n      ]\n    }\n    ```\n\n  - Use “Test pipeline” with a document like:\n\n    ```json\n    { \"_source\": { \"text_field\": \"hello world\" } }\n    ```\n\n- Expected: the test completes successfully and the output includes\n`content_embedding` (no `status_exception` about `input_output` vs\n`field_map`).\n- Automated:\n- Updated/added Jest coverage for inference processor\nserialization/format selection.\n\n### Before/after notes\n- Before:\n- **Before**: Kibana only allowed configuring inference processors as\n`target_field` + `field_map`, so testing a pipeline with an NLP\ninference endpoint like `.elser-2-elastic` failed with a\n`status_exception` instructing to use `input_output` instead of\n`field_map` (see issue screenshot).\n- After:\n- **After**: Kibana allows choosing `input_output` (mutually exclusive\nwith `target_field` + `field_map`), so the same pipeline test succeeds\nand returns `content_embedding`. For NLP inference endpoints, using\n`target_field` + `field_map` still fails as expected because it is not\nthe correct configuration for those endpoints.\n\n### Evidence\n\n\nhttps://github.com/user-attachments/assets/9c9c729b-7783-409b-9dd9-5eaf3a665fff","sha":"f9bbce16860e5eb448e2db4173b5f170b7f25c9a"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/260517","number":260517,"mergeCommit":{"message":"[Ingest pipelines] Include input_output in inference processor (#260517)\n\nCloses https://github.com/elastic/kibana/issues/249076\n\n## Summary\n- Fixes inference processor creation in Stack Management → Ingest\nPipelines by supporting the two valid inference processor configuration\nshapes:\n  - `input_output`\n  - `target_field` + `field_map`\n- Both shapes are optional, but they are mutually exclusive (cannot be\nused at the same time).\n- Previously, Kibana only allowed configuring `target_field` +\n`field_map`, which caused pipeline tests to fail for NLP inference\nendpoints (for example `.elser-2-elastic`) that require `input_output`.\nNow users can select `input_output`; `target_field` + `field_map`\nremains available, but it will still fail for those NLP endpoints\nbecause it is not the correct configuration.\n\n### Test plan\n- Manual:\n- Prereqs: run Elastic Inference Service (EIS) locally and connect it to\nyour local Elasticsearch/Kibana. Follow the instructions in\n[@kbn/inference-cli\nREADME](https://github.com/elastic/kibana/blob/main/x-pack/platform/packages/shared/kbn-inference-cli/README.md)\n(EIS / Cloud Connected Mode section).\n- In Kibana: Stack Management → Ingest Pipelines → Create pipeline → add\nan inference processor and select the `input_output` configuration with:\n\n    ```json\n    {\n      \"model_id\": \".elser-2-elastic\",\n      \"input_output\": [\n        {\n          \"input_field\": \"text_field\",\n          \"output_field\": \"content_embedding\"\n        }\n      ]\n    }\n    ```\n\n  - Use “Test pipeline” with a document like:\n\n    ```json\n    { \"_source\": { \"text_field\": \"hello world\" } }\n    ```\n\n- Expected: the test completes successfully and the output includes\n`content_embedding` (no `status_exception` about `input_output` vs\n`field_map`).\n- Automated:\n- Updated/added Jest coverage for inference processor\nserialization/format selection.\n\n### Before/after notes\n- Before:\n- **Before**: Kibana only allowed configuring inference processors as\n`target_field` + `field_map`, so testing a pipeline with an NLP\ninference endpoint like `.elser-2-elastic` failed with a\n`status_exception` instructing to use `input_output` instead of\n`field_map` (see issue screenshot).\n- After:\n- **After**: Kibana allows choosing `input_output` (mutually exclusive\nwith `target_field` + `field_map`), so the same pipeline test succeeds\nand returns `content_embedding`. For NLP inference endpoints, using\n`target_field` + `field_map` still fails as expected because it is not\nthe correct configuration for those endpoints.\n\n### Evidence\n\n\nhttps://github.com/user-attachments/assets/9c9c729b-7783-409b-9dd9-5eaf3a665fff","sha":"f9bbce16860e5eb448e2db4173b5f170b7f25c9a"}}]}] BACKPORT-->