### PR TITLE
[FeatureBranch/DoNotReview][Chrome Next] Make discover use ChromeNextHeader

### DIFF
--- a/src/core/packages/chrome/browser/src/chrome_next/header.ts
+++ b/src/core/packages/chrome/browser/src/chrome_next/header.ts
@@ -20,7 +20,7 @@ export interface ChromeNextHeaderConfig {
    * Can be the app name (e.g. "Discover") or a viewed object
    * (e.g. a saved dashboard name). Single-line, truncated by Chrome if too long.
    */
-  title: string;
+  title?: string;
 
   /**
    * Badges inline next to the title. Chrome shows 1–2 as-is; for 3+, first badge plus "+N" popover

--- a/src/core/packages/chrome/browser/tsconfig.json
+++ b/src/core/packages/chrome/browser/tsconfig.json
@@ -30,7 +30,8 @@
     "@kbn/deeplinks-workflows",
     "@kbn/deeplinks-agent-builder",
     "@kbn/core-chrome-navigation",
-    "@kbn/core-chrome-sidebar"
+    "@kbn/core-chrome-sidebar",
+    "@kbn/core-chrome-feature-flags",
   ],
   "exclude": [
     "target/**/*",

--- a/src/core/packages/chrome/browser/tsconfig.json
+++ b/src/core/packages/chrome/browser/tsconfig.json
@@ -31,7 +31,6 @@
     "@kbn/deeplinks-agent-builder",
     "@kbn/core-chrome-navigation",
     "@kbn/core-chrome-sidebar",
-    "@kbn/core-chrome-feature-flags",
   ],
   "exclude": [
     "target/**/*",

--- a/src/platform/plugins/shared/discover/public/__mocks__/services.ts
+++ b/src/platform/plugins/shared/discover/public/__mocks__/services.ts
@@ -331,6 +331,7 @@ export function createDiscoverServicesMock(): DiscoverServices {
       getCascadeLayoutEnabled: jest.fn(() => false),
       getIsEsqlDefault: jest.fn(() => false),
       getEmbeddableTransformsEnabled: jest.fn(() => true),
+      getIsNextChrome: jest.fn(() => false),
     },
     embeddableEditor: {
       isByValueEditor: jest.fn(() => false),

--- a/src/platform/plugins/shared/discover/public/application/main/components/single_tab_view/single_tab_view_with_app_menu.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/single_tab_view/single_tab_view_with_app_menu.tsx
@@ -7,19 +7,31 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React from 'react';
+import React, { useEffect } from 'react';
 import { AppMenu } from '@kbn/core-chrome-app-menu';
 import { SingleTabView, type SingleTabViewProps } from '.';
 import { useDiscoverServices } from '../../../../hooks/use_discover_services';
 import { useTopNavMenuItems } from '../top_nav/use_top_nav_menu_items';
 
 export const SingleTabViewWithAppMenu = (props: SingleTabViewProps) => {
-  const { chrome } = useDiscoverServices();
+  const { chrome, discoverFeatureFlags } = useDiscoverServices();
+  const isNextChrome = discoverFeatureFlags.getIsNextChrome();
   const topNavMenuItems = useTopNavMenuItems();
+
+  useEffect(() => {
+    if (isNextChrome && topNavMenuItems) {
+      chrome.next.header.set({ appMenu: topNavMenuItems });
+      return () => {
+        chrome.next.header.set(undefined);
+      };
+    }
+  }, [isNextChrome, topNavMenuItems, chrome.next.header]);
 
   return (
     <>
-      {topNavMenuItems && <AppMenu config={topNavMenuItems} setAppMenu={chrome.setAppMenu} />}
+      {!isNextChrome && topNavMenuItems && (
+        <AppMenu config={topNavMenuItems} setAppMenu={chrome.setAppMenu} />
+      )}
       <SingleTabView {...props} />
     </>
   );

--- a/src/platform/plugins/shared/discover/public/application/main/components/tabs_view/hide_tabs_bar.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/tabs_view/hide_tabs_bar.tsx
@@ -24,7 +24,8 @@ export const HideTabsBar: FC<{
   children: ReactNode;
 }> = ({ customizationContext, children }) => {
   const dispatch = useInternalStateDispatch();
-  const { chrome } = useDiscoverServices();
+  const { chrome, discoverFeatureFlags } = useDiscoverServices();
+  const isNextChrome = discoverFeatureFlags.getIsNextChrome();
   const topNavMenuItems = useTopNavMenuItems();
 
   useEffect(() => {
@@ -34,13 +35,22 @@ export const HideTabsBar: FC<{
     };
   }, [dispatch]);
 
+  useEffect(() => {
+    if (isNextChrome && customizationContext.displayMode === 'standalone' && topNavMenuItems) {
+      chrome.next.header.set({ appMenu: topNavMenuItems });
+      return () => {
+        chrome.next.header.set(undefined);
+      };
+    }
+  }, [isNextChrome, customizationContext.displayMode, topNavMenuItems, chrome.next.header]);
+
   return (
     <>
       {
         /**
          * The tabs bar renders the app menu, but it still needs to be shown when tabs are hidden
          */
-        customizationContext.displayMode === 'standalone' && topNavMenuItems && (
+        !isNextChrome && customizationContext.displayMode === 'standalone' && topNavMenuItems && (
           <AppMenu config={topNavMenuItems} setAppMenu={chrome.setAppMenu} />
         )
       }

--- a/src/platform/plugins/shared/discover/public/application/main/components/tabs_view/tabs_view.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/tabs_view/tabs_view.tsx
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { EuiResizeObserver } from '@elastic/eui';
 import { UnifiedTabs, type UnifiedTabsProps } from '@kbn/unified-tabs';
 import { AppMenuComponent } from '@kbn/core-chrome-app-menu-components';
@@ -39,6 +39,7 @@ export const TabsView = (props: SingleTabViewProps) => {
   const unsavedTabIds = useInternalStateSelector((state) => state.tabs.unsavedIds);
   const currentDataView = useCurrentTabRuntimeState((tab) => tab.currentDataView$);
   const scopedEbtManager = useCurrentTabRuntimeState((tab) => tab.scopedEbtManager$);
+  const isNextChrome = services.discoverFeatureFlags.getIsNextChrome();
 
   const {
     shouldCollapseAppMenu,
@@ -47,6 +48,15 @@ export const TabsView = (props: SingleTabViewProps) => {
     getAdditionalTabMenuItems,
     topNavMenuItems,
   } = useAppMenuData({ currentDataView });
+
+  useEffect(() => {
+    if (isNextChrome && topNavMenuItems) {
+      services.chrome.next.header.set({ appMenu: topNavMenuItems });
+      return () => {
+        services.chrome.next.header.set(undefined);
+      };
+    }
+  }, [isNextChrome, topNavMenuItems, services.chrome.next.header]);
 
   const onEvent: UnifiedTabsProps['onEBTEvent'] = useCallback(
     (event) => {
@@ -100,7 +110,9 @@ export const TabsView = (props: SingleTabViewProps) => {
             getTopTabMenuItems={getTopTabMenuItems}
             getAdditionalTabMenuItems={getAdditionalTabMenuItems}
             appendRight={
-              <AppMenuComponent config={topNavMenuItems} isCollapsed={shouldCollapseAppMenu} />
+              !isNextChrome ? (
+                <AppMenuComponent config={topNavMenuItems} isCollapsed={shouldCollapseAppMenu} />
+              ) : undefined
             }
           />
         </div>

--- a/src/platform/plugins/shared/discover/public/build_services.ts
+++ b/src/platform/plugins/shared/discover/public/build_services.ts
@@ -65,6 +65,7 @@ import type { LogsDataAccessPluginStart } from '@kbn/logs-data-access-plugin/pub
 import type { DiscoverSharedPublicStart } from '@kbn/discover-shared-plugin/public';
 import type { CPSPluginStart } from '@kbn/cps/public';
 import type { AlertingV2PublicStart } from '@kbn/alerting-v2-plugin/public';
+import { isNextChrome } from '@kbn/core-chrome-feature-flags';
 import type { DiscoverStartPlugins } from './types';
 import type { DiscoverContextAppLocator } from './application/context/services/locator';
 import type { DiscoverSingleDocLocator } from './application/doc/locator';
@@ -95,6 +96,7 @@ export interface DiscoverFeatureFlags {
   getCascadeLayoutEnabled: () => boolean;
   getIsEsqlDefault: () => boolean;
   getEmbeddableTransformsEnabled: () => boolean;
+  getIsNextChrome: () => boolean;
 }
 
 export interface DiscoverServices {
@@ -212,6 +214,7 @@ export const buildServices = ({
         core.featureFlags.getBooleanValue(IS_ESQL_DEFAULT_FEATURE_FLAG_KEY, false),
       getEmbeddableTransformsEnabled: () =>
         core.featureFlags.getBooleanValue(EMBEDDABLE_TRANSFORMS_FEATURE_FLAG_KEY, true),
+      getIsNextChrome: () => isNextChrome(core.featureFlags),
     },
     docLinks: core.docLinks,
     embeddable: plugins.embeddable,

--- a/src/platform/plugins/shared/discover/public/embeddable/utils/serialization_utils.test.ts
+++ b/src/platform/plugins/shared/discover/public/embeddable/utils/serialization_utils.test.ts
@@ -39,6 +39,7 @@ describe('Serialization utils', () => {
       getCascadeLayoutEnabled: jest.fn(() => false),
       getIsEsqlDefault: jest.fn(() => false),
       getEmbeddableTransformsEnabled: jest.fn(() => false),
+      getIsNextChrome: jest.fn(() => false),
     },
   } satisfies DiscoverServices;
 

--- a/src/platform/plugins/shared/discover/tsconfig.json
+++ b/src/platform/plugins/shared/discover/tsconfig.json
@@ -138,6 +138,7 @@
     "@kbn/presentation-util-plugin",
     "@kbn/core-saved-objects-common",
     "@kbn/as-code-filters-constants",
+    "@kbn/core-chrome-feature-flags",
   ],
   "exclude": ["target/**/*"]
 }


### PR DESCRIPTION
## Summary

This PR makes discover use the new app menu API when feature flag is on.

It also makes `title` optional, otherwise the setter would show TS errors: 
```
Argument of type '{ appMenu: AppMenuConfig; }' is not assignable to parameter of type 'ChromeNextHeaderConfig'.
  Property 'title' is missing in type '{ appMenu: AppMenuConfig; }' but required in type 'ChromeNextHeaderConfig'.
```

Closes: https://github.com/elastic/kibana/issues/261913


