### PR TITLE
POC - Remove breadcrumb for active tab

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/routing/templates/apm_service_template/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/routing/templates/apm_service_template/index.tsx
@@ -19,7 +19,6 @@ import { ApmIndexSettingsContextProvider } from '../../../../context/apm_index_s
 import { ApmServiceContextProvider } from '../../../../context/apm_service/apm_service_context';
 import { useApmServiceContext } from '../../../../context/apm_service/use_apm_service_context';
 import { ServiceSloContextProvider } from '../../../../context/service_slo/service_slo_context';
-import { useBreadcrumb } from '../../../../context/breadcrumbs/use_breadcrumb';
 import { ServiceAnomalyTimeseriesContextProvider } from '../../../../context/service_anomaly_timeseries/service_anomaly_timeseries_context';
 import { useApmParams } from '../../../../hooks/use_apm_params';
 import { useApmRouter } from '../../../../hooks/use_apm_router';
@@ -53,7 +52,7 @@ export function ApmServiceTemplate(props: Props) {
   );
 }
 
-function TemplateWithContext({ title, children, selectedTab, searchBarOptions }: Props) {
+function TemplateWithContext({ children, selectedTab, searchBarOptions }: Props) {
   const {
     path: { serviceName },
     query,
@@ -90,17 +89,6 @@ function TemplateWithContext({ title, children, selectedTab, searchBarOptions }:
     path: { serviceName },
     query,
   });
-
-  useBreadcrumb(
-    () => ({
-      title,
-      href: router.link(`/services/{serviceName}/${selectedTab}` as const, {
-        path: { serviceName },
-        query,
-      }),
-    }),
-    [query, router, selectedTab, serviceName, title]
-  );
 
   // Configure agent builder global flyout with the service attachment
   useEffect(() => {

--- a/x-pack/solutions/observability/plugins/apm/public/components/routing/templates/mobile_service_template/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/routing/templates/mobile_service_template/index.tsx
@@ -55,7 +55,7 @@ export function MobileServiceTemplate(props: Props) {
   );
 }
 
-function TemplateWithContext({ title, children, selectedTabKey, searchBarOptions }: Props) {
+function TemplateWithContext({ children, selectedTabKey, searchBarOptions }: Props) {
   const {
     path: { serviceName },
     query,
@@ -67,7 +67,6 @@ function TemplateWithContext({ title, children, selectedTabKey, searchBarOptions
   const router = useApmRouter();
 
   const tabs = useTabs({ selectedTabKey });
-  const selectedTab = tabs?.find(({ isSelected }) => isSelected);
 
   const servicesLink = router.link('/services', {
     query: { ...query },
@@ -81,23 +80,15 @@ function TemplateWithContext({ title, children, selectedTabKey, searchBarOptions
         }),
         href: servicesLink,
       },
-      ...(selectedTab
-        ? [
-            {
-              title: serviceName,
-              href: router.link('/mobile-services/{serviceName}', {
-                path: { serviceName },
-                query,
-              }),
-            },
-            {
-              title: selectedTab.label,
-              href: selectedTab.href,
-            } as { title: string; href: string },
-          ]
-        : []),
+      {
+        title: serviceName,
+        href: router.link('/mobile-services/{serviceName}', {
+          path: { serviceName },
+          query,
+        }),
+      },
     ],
-    [query, router, selectedTab, serviceName, servicesLink],
+    [query, router, serviceName, servicesLink],
     {
       omitRootOnServerless: true,
     }


### PR DESCRIPTION
## Summary

Remove final breadcrumb

#### Before
<img width="800" alt="CleanShot 2026-04-08 at 14 56 19@2x" src="https://github.com/user-attachments/assets/97ccb045-3256-4358-8467-a875a6fe9f6f" />

#### After
<img width="800" alt="CleanShot 2026-04-08 at 14 30 45@2x" src="https://github.com/user-attachments/assets/bd03eeb1-013c-48dc-8f62-cb769bd9e99a" />

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



