### PR TITLE
[Dashboards] Fix update payload from listing page flyout

### DIFF
--- a/src/platform/plugins/shared/dashboard/public/dashboard_client/dashboard_client.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_client/dashboard_client.ts
@@ -13,7 +13,12 @@ import { SavedObjectNotFound } from '@kbn/kibana-utils-plugin/public';
 import type { DeleteResult } from '@kbn/content-management-plugin/common';
 import type { SavedObjectAccessControl } from '@kbn/core-saved-objects-common';
 import type { SavedObjectsResolveResponse } from '@kbn/core/server';
-import type { DashboardSearchRequestParams, DashboardSearchResponseBody } from '../../server';
+import type {
+  DashboardCreateRequestBody,
+  DashboardSearchRequestParams,
+  DashboardSearchResponseBody,
+  DashboardUpdateRequestBody,
+} from '../../server';
 import {
   DASHBOARD_API_PATH,
   DASHBOARD_API_VERSION,
@@ -24,7 +29,6 @@ import {
 import type {
   DashboardCreateResponseBody,
   DashboardReadResponseBody,
-  DashboardState,
   DashboardUpdateResponseBody,
 } from '../../server';
 import { coreServices } from '../services/kibana_services';
@@ -50,7 +54,7 @@ const buildDashboardAppPath = (id: string) => buildPath(`${DASHBOARD_APP_API_PAT
 
 export const dashboardClient = {
   create: async (
-    dashboardState: DashboardState,
+    dashboardState: DashboardCreateRequestBody,
     accessMode?: SavedObjectAccessControl['accessMode']
   ) => {
     return coreServices.http.post<DashboardCreateResponseBody>(DASHBOARD_APP_API_PATH, {
@@ -113,7 +117,7 @@ export const dashboardClient = {
       },
     });
   },
-  update: async (id: string, dashboardState: DashboardState) => {
+  update: async (id: string, dashboardState: DashboardUpdateRequestBody) => {
     const updateResponse = await coreServices.http.put<DashboardUpdateResponseBody>(
       buildDashboardAppPath(id),
       {

--- a/src/platform/plugins/shared/dashboard/public/dashboard_listing/hooks/use_dashboard_listing_table.test.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_listing/hooks/use_dashboard_listing_table.test.tsx
@@ -7,8 +7,10 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import type { OpenContentEditorParams } from '@kbn/content-management-content-editor';
 import { renderHook, act } from '@testing-library/react';
 import { coreServices } from '../../services/kibana_services';
+import { dashboardClient, findService } from '../../dashboard_client';
 import { confirmCreateWithUnsaved } from '../confirm_overlays';
 import type { DashboardSavedObjectUserContent } from '../types';
 import { useDashboardListingTable } from './use_dashboard_listing_table';
@@ -43,11 +45,15 @@ jest.mock('../_dashboard_listing_strings', () => ({
   },
 }));
 
-const mockDeleteDashboards = jest.fn().mockResolvedValue(true);
 jest.mock('../../dashboard_client', () => ({
   dashboardClient: {
-    delete: () => mockDeleteDashboards(),
+    delete: jest.fn().mockResolvedValue(true),
+    update: jest.fn().mockResolvedValue(true),
   },
+  findService: {
+    findById: jest.fn(),
+  },
+  checkForDuplicateDashboardTitle: jest.fn(),
 }));
 
 describe('useDashboardListingTable', () => {
@@ -182,7 +188,7 @@ describe('useDashboardListingTable', () => {
       ]);
     });
 
-    expect(mockDeleteDashboards).toHaveBeenCalled();
+    expect(dashboardClient.delete).toHaveBeenCalled();
   });
 
   test('should call goToDashboard when editItem is called', () => {
@@ -233,6 +239,43 @@ describe('useDashboardListingTable', () => {
     expect(confirmCreateWithUnsaved).toHaveBeenCalled();
     expect(clearStateMock).toHaveBeenCalled();
     expect(goToDashboard).toHaveBeenCalled();
+  });
+
+  test('contentEditor.onSave should not include access_control in update payload', async () => {
+    (findService.findById as jest.Mock).mockResolvedValue({
+      id: 'test-id',
+      status: 'success',
+      attributes: {
+        title: 'Old title',
+        description: 'Old description',
+        access_control: { access_mode: 'default' },
+      },
+    });
+
+    const { result } = renderHook(() =>
+      useDashboardListingTable({
+        getDashboardUrl,
+        goToDashboard,
+      })
+    );
+
+    await act(async () => {
+      await result.current.tableListViewTableProps.contentEditor?.onSave?.({
+        id: 'test-id',
+        title: 'New title',
+      } as Parameters<Required<OpenContentEditorParams>['onSave']>[0]);
+    });
+
+    const payload = (dashboardClient.update as jest.Mock).mock.lastCall[1];
+    expect(dashboardClient.update).toHaveBeenCalledWith(
+      'test-id',
+      expect.objectContaining({
+        title: 'New title',
+        description: 'Old description',
+      })
+    );
+
+    expect(payload).not.toHaveProperty('access_control');
   });
 
   test('createItem should be undefined when showWriteControls equals false', () => {

--- a/src/platform/plugins/shared/dashboard/public/dashboard_listing/hooks/use_dashboard_listing_table.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_listing/hooks/use_dashboard_listing_table.tsx
@@ -116,8 +116,10 @@ export const useDashboardListingTable = ({
       if (dashboard.status === 'error') {
         return;
       }
+      // `access_control` can not be specified as part of the update payload
+      const { access_control, ...restOfAttributes } = dashboard.attributes;
       await dashboardClient.update(id, {
-        ...dashboard.attributes,
+        ...restOfAttributes,
         ...updatedState,
       });
 

--- a/src/platform/plugins/shared/dashboard/server/index.ts
+++ b/src/platform/plugins/shared/dashboard/server/index.ts
@@ -56,6 +56,7 @@ export type {
   DashboardReadResponseBody,
   DashboardSearchRequestParams,
   DashboardSearchResponseBody,
+  DashboardUpdateRequestBody,
   DashboardUpdateResponseBody,
   GridData,
 } from './api';


### PR DESCRIPTION
Fixes #262127

## Summary

Fixes the update button throwing an error from the Dashboard listing page flyout. This removes the unsupported `access_control` property from the update payload.

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->