### PR TITLE
[Security Solution] fallback to only Table and JSON tabs when event.kind is undefined

### DIFF
--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/security_document_profile/profile.test.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/security_document_profile/profile.test.ts
@@ -71,15 +71,11 @@ describe('createSecurityDocumentProfileProvider — getDocViewer', () => {
     });
   });
 
-  it('registers the overview tab when event.kind is absent', () => {
+  it('does NOT register the overview tab when event.kind is absent', () => {
     const registry = new DocViewsRegistry();
     const docViewer = getDocViewerFor(buildRecord({}));
     docViewer.docViewsRegistry(registry);
-    expect(registry.getAll()).toHaveLength(1);
-    expect(registry.getAll()[0]).toMatchObject({
-      id: 'doc_view_alerts_overview',
-      title: 'Event Overview',
-    });
+    expect(registry.getAll()).toHaveLength(0);
   });
 
   it('does NOT register the overview tab for a scheduled attack discovery alert', () => {

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/security_profile_providers.test.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/security_profile_providers.test.tsx
@@ -132,6 +132,26 @@ describe('createSecurityDocumentProfileProviders', () => {
       expect(registry.add).not.toHaveBeenCalled();
     });
 
+    it('does not override renderHeader when event.kind is absent', () => {
+      const { result, prevRenderHeader } = getDocViewerResult(createRecord({}));
+
+      expect(result.renderHeader).toBe(prevRenderHeader);
+    });
+
+    it('does not override renderFooter when event.kind is absent', () => {
+      const { result, prevRenderFooter } = getDocViewerResult(createRecord({}));
+
+      expect(result.renderFooter).toBe(prevRenderFooter);
+    });
+
+    it('does not add the overview tab to the registry when event.kind is absent', () => {
+      const { result } = getDocViewerResult(createRecord({}));
+      const registry = { add: jest.fn() };
+      result.docViewsRegistry(registry as never);
+
+      expect(registry.add).not.toHaveBeenCalled();
+    });
+
     it('does not override renderHeader for remote (CCS) alert documents', () => {
       const { result, prevRenderHeader } = getDocViewerResult(
         createRecord({

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/utils/is_alert_document.test.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/utils/is_alert_document.test.ts
@@ -23,8 +23,8 @@ describe('isEventDocument', () => {
     expect(isEventDocument(buildRecord({ 'event.kind': 'event' }))).toBe(true);
   });
 
-  it('returns true when event.kind is absent', () => {
-    expect(isEventDocument(buildRecord({}))).toBe(true);
+  it('returns false when event.kind is absent', () => {
+    expect(isEventDocument(buildRecord({}))).toBe(false);
   });
 });
 

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/utils/is_alert_document.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/utils/is_alert_document.ts
@@ -18,10 +18,12 @@ import {
 const ATTACK_DISCOVERY_AD_HOC_RULE_TYPE_ID = 'attack_discovery_ad_hoc_rule_type_id' as const;
 
 /**
- * Returns true if the document is not an alert or an attack (event.kind is not 'signal')
+ * Returns true if the document is not an alert or an attack (event.kind is defined and is not 'signal').
+ * Returns false when event.kind is absent, e.g. documents from complex ESQL queries.
  */
 export const isEventDocument = (record: DataTableRecord): boolean => {
-  return getFieldValue(record, EVENT_KIND) !== 'signal';
+  const eventKind = getFieldValue(record, EVENT_KIND);
+  return Boolean(eventKind) && eventKind !== 'signal';
 };
 
 /**


### PR DESCRIPTION
## Summary

This PR makes a very small change to the logic showing the flyout in Discover. This should only be visible in ESQL: if the user creates a query that ends up having a `hit` that does not have an `event.kind` field, then we can't choose which flyout header/content/footer to show (meaning event or alert).
In this case, we fallback to the most basic document flyout which only renders the Table and JSON tabs.

Alerts flyout is still working as before:
<img width="1341" height="781" alt="Screenshot 2026-04-08 at 6 12 28 PM" src="https://github.com/user-attachments/assets/17e51058-617e-4a29-90e1-e5079fdbfe16" />

Events flyout is still working as before:
<img width="1343" height="782" alt="Screenshot 2026-04-08 at 6 11 54 PM" src="https://github.com/user-attachments/assets/9cf56329-24cc-49da-9f8a-b42f1d1d337c" />

And if `event.kind` is `undefined, we show only the 2 tabs:
<img width="1344" height="783" alt="Screenshot 2026-04-08 at 6 11 33 PM" src="https://github.com/user-attachments/assets/5d77a825-e215-4846-8e07-fa8558378907" />

## How to test

To see the new (emtpy) flyout in Security Solution, add this to your `kibana.dev.yml` file:
```xpack.securitySolution.enableExperimental: [ 'newFlyoutSystemEnabled' ]```

Too see the new (emtpy) flyout in Discover, add this to your `kibana.dev.yml` file:
```discover.experimental.enabledProfiles: [ 'enhanced-security-document-profile' ]```

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
