### PR TITLE
[9.3] [scout] remove waitForLoadingIndicatorHidden and its usage (#261899)

### DIFF
--- a/src/platform/packages/private/kbn-scout-info/llms/what-is-scout.md
+++ b/src/platform/packages/private/kbn-scout-info/llms/what-is-scout.md
@@ -39,7 +39,7 @@ Scout makes it easy to run tests your way – sequentially, in parallel, and mor
 - Validates the Playwright configuration files to ensure consistent behavior across test suites.
 - Limits certain fixtures to provide only the functionality that a test would need.
   - For example, the ES archiver only allows tests to load archive data; unloading is disabled as we take care of that for you at the end of the test run.
-- Extends some of the existing Playwright fixtures with additional helper methods (e.g, `page.waitForLoadingIndicatorHidden()`).
+- Extends some of the existing Playwright fixtures with additional helper methods (e.g., `page.testSubj.click()`, `page.gotoApp()`).
 - Initializes page objects lazily, so that they are initialized only when your test uses them.
 
 ## Fixtures

--- a/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/test/performance/README.md
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/test/performance/README.md
@@ -19,7 +19,6 @@
   - Frames Per Second (FPS) (fps)
   - DOM Complexity Metrics (nodesCount, documentsCount)
 
-
 ### Usage: capturing JS bundles on page
 
 ```ts
@@ -105,7 +104,8 @@ test.describe(
 
       // Navigate to Discover app
       await pageObjects.collapsibleNav.clickItem('Discover');
-      await page.waitForLoadingIndicatorHidden();
+      await page.testSubj.waitForSelector('discoverLayoutResizableContainer');
+
       const currentUrl = page.url();
       expect(currentUrl).toContain('app/discover#/');
 

--- a/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/test/scout_page/index.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/test/scout_page/index.ts
@@ -28,12 +28,6 @@ export type ScoutPage = Page & {
    */
   gotoApp: (appName: string, pathOptions?: PathOptions) => ReturnType<Page['goto']>;
   /**
-   * Waits for the Kibana loading spinner indicator to disappear.
-   * @deprecated This method is flaky on CI. We strongly recommend waiting for specific elements instead: page.testSubj.waitForSelector('table-is-ready', { state: 'visible' })
-   * @returns A Promise resolving when the indicator is hidden.
-   */
-  waitForLoadingIndicatorHidden: () => ReturnType<Page['waitForSelector']>;
-  /**
    * Presses a key until the element with the css selector is in focus. If multiple elements match it will
    * press the key until the first occurrence of the element is focused.
    * @param selector - The css selector for the element.

--- a/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/test/scout_page/single_thread.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/test/scout_page/single_thread.ts
@@ -102,11 +102,6 @@ export function extendPlaywrightPage({
   // Method to navigate to specific Kibana apps
   extendedPage.gotoApp = (appName: string, pathOptions?: PathOptions) =>
     page.goto(kbnUrl.app(appName, { pathOptions }));
-  // Method to wait for global loading indicator to be hidden
-  extendedPage.waitForLoadingIndicatorHidden = () =>
-    extendedPage.testSubj.waitForSelector('globalLoadingIndicator-hidden', {
-      state: 'attached',
-    });
   // Method to press a key until an element with the provided selector is in focus.
   extendedPage.keyTo = async (
     selector: string,

--- a/src/platform/packages/shared/kbn-scout/src/playwright/page_objects/discover_app.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/page_objects/discover_app.ts
@@ -115,7 +115,6 @@ export class DiscoverApp {
   }
 
   async getHitCountInt(): Promise<number> {
-    await this.page.waitForLoadingIndicatorHidden();
     const hitCount = await this.page.testSubj.innerText('discoverQueryHits');
     return parseInt(hitCount.replace(/,/g, ''), 10);
   }

--- a/src/platform/plugins/shared/dashboard/test/scout_anonymous_authc/ui/tests/save_modal_no_access_control.spec.ts
+++ b/src/platform/plugins/shared/dashboard/test/scout_anonymous_authc/ui/tests/save_modal_no_access_control.spec.ts
@@ -39,7 +39,7 @@ test.describe(
       // Navigate directly to the create dashboard page to bypass the
       // listing page (which may redirect to the no-data prompt).
       await page.gotoApp('dashboards', { hash: '/create' });
-      await page.waitForLoadingIndicatorHidden();
+      await page.testSubj.waitForSelector('emptyDashboardWidget', { timeout: 20000 });
     });
 
     test.afterAll(async ({ kbnClient }) => {

--- a/x-pack/platform/plugins/private/discover_enhanced/test/scout/ui/tests/discover_cdp_perf.spec.ts
+++ b/x-pack/platform/plugins/private/discover_enhanced/test/scout/ui/tests/discover_cdp_perf.spec.ts
@@ -30,7 +30,7 @@ test.describe(
       cdp = await context.newCDPSession(page);
       await cdp.send('Network.enable');
       await page.gotoApp('home');
-      await page.waitForLoadingIndicatorHidden();
+      await page.testSubj.waitForSelector('homeApp', { timeout: 20000 });
       await perfTracker.waitForJsLoad(cdp); // Ensure JS bundles are fully loaded
     });
 
@@ -100,7 +100,7 @@ test.describe(
 
       // Navigate to Discover app
       await pageObjects.collapsibleNav.clickItem('Discover');
-      await page.waitForLoadingIndicatorHidden();
+      await page.testSubj.waitForSelector('discoverLayoutResizableContainer', { timeout: 20000 });
       const currentUrl = page.url();
       expect(currentUrl).toContain('app/discover#/');
 

--- a/x-pack/platform/plugins/private/discover_enhanced/test/scout/ui/tests/saved_search_embeddable.spec.ts
+++ b/x-pack/platform/plugins/private/discover_enhanced/test/scout/ui/tests/saved_search_embeddable.spec.ts
@@ -86,7 +86,7 @@ test.describe('Discover app - saved search embeddable', { tag: tags.deploymentAg
     });
 
     await page.reload();
-    await page.waitForLoadingIndicatorHidden();
+    await page.testSubj.waitForSelector('dashboardContainer', { timeout: 20000 });
     await expect(
       page.testSubj.locator('embeddableError'),
       'Embeddable error should be displayed'

--- a/x-pack/solutions/observability/plugins/apm/test/scout/ui/parallel_tests/transaction_details/span_stacktrace.spec.ts
+++ b/x-pack/solutions/observability/plugins/apm/test/scout/ui/parallel_tests/transaction_details/span_stacktrace.spec.ts
@@ -26,9 +26,12 @@ test.describe(
       page,
       pageObjects: { transactionDetailsPage },
     }) => {
-      await transactionDetailsPage.gotoServiceInventory('apm-generated', timeRange);
-      await page.getByText('Transaction A').click();
-      await page.waitForLoadingIndicatorHidden();
+      await transactionDetailsPage.goToTransactionDetails({
+        serviceName: 'apm-generated',
+        transactionName: 'Transaction A',
+        start: timeRange.rangeFrom,
+        end: timeRange.rangeTo,
+      });
 
       await test.step('opens span flyout', async () => {
         await page.getByText('Span A').click();
@@ -51,9 +54,12 @@ test.describe(
       page,
       pageObjects: { transactionDetailsPage },
     }) => {
-      await transactionDetailsPage.gotoServiceInventory('otel-generated', timeRange);
-      await page.getByText('Transaction A').click();
-      await page.waitForLoadingIndicatorHidden();
+      await transactionDetailsPage.goToTransactionDetails({
+        serviceName: 'otel-generated',
+        transactionName: 'Transaction A',
+        start: timeRange.rangeFrom,
+        end: timeRange.rangeTo,
+      });
 
       await test.step('opens span flyout', async () => {
         await page.getByText('Span A').click();

--- a/x-pack/solutions/observability/plugins/profiling/test/scout/ui/fixtures/index.ts
+++ b/x-pack/solutions/observability/plugins/profiling/test/scout/ui/fixtures/index.ts
@@ -59,3 +59,4 @@ export const test = base.extend<ExtendedScoutTestFixtures, ObltWorkerFixtures>({
 });
 
 export * as testData from '../../common/fixtures/constants';
+export const EXTENDED_TIMEOUT = 45000 as const;

--- a/x-pack/solutions/observability/plugins/profiling/test/scout/ui/fixtures/page_objects/differential_functions.ts
+++ b/x-pack/solutions/observability/plugins/profiling/test/scout/ui/fixtures/page_objects/differential_functions.ts
@@ -12,7 +12,9 @@ export class DifferentialFunctionsPage {
 
   async gotoDifferential() {
     await this.page.goto(`${this.kbnUrl.app('profiling')}/functions/differential`);
-    await this.page.waitForLoadingIndicatorHidden();
+    await this.page.testSubj
+      .locator('profilingNormalizationMenuButton')
+      .waitFor({ timeout: EXTENDED_TIMEOUT });
   }
 
   async gotoDifferentialWithTimeRange(
@@ -36,25 +38,32 @@ export class DifferentialFunctionsPage {
     await this.page.waitForLoadingIndicatorHidden();
   }
 
-  async getSummaryValue(id: string) {
+  getSummaryValue(id: string) {
     return this.page.testSubj.locator(`${id}_value`);
   }
 
-  async getSummaryComparisonValue(id: string) {
+  getSummaryComparisonValue(id: string) {
     return this.page.testSubj.locator(`${id}_comparison_value`);
   }
 
   async addKqlFilterToBaseline(key: string, value: string) {
-    const searchBar = this.page.testSubj.locator('profilingUnifiedSearchBar');
-    await searchBar.fill(`${key}:"${value}"`);
-    await searchBar.press('Enter');
-    await this.page.waitForLoadingIndicatorHidden();
+    await this.applyKqlFilter('profilingUnifiedSearchBar', key, value);
   }
 
   async addKqlFilterToComparison(key: string, value: string) {
-    const searchBar = this.page.testSubj.locator('profilingComparisonUnifiedSearchBar');
+    await this.applyKqlFilter('profilingComparisonUnifiedSearchBar', key, value);
+  }
+
+  private async applyKqlFilter(searchBarTestSubj: string, key: string, value: string) {
+    const searchBar = this.page.testSubj.locator(searchBarTestSubj);
     await searchBar.fill(`${key}:"${value}"`);
     await searchBar.press('Enter');
-    await this.page.waitForLoadingIndicatorHidden();
+    await this.waitForGridRefresh();
+  }
+
+  private async waitForGridRefresh() {
+    const grid = this.page.testSubj.locator('profilingDiffTopNFunctionsGrid');
+    await grid.waitFor({ state: 'hidden' });
+    await grid.waitFor({ state: 'visible' });
   }
 }

--- a/x-pack/solutions/observability/plugins/profiling/test/scout/ui/fixtures/page_objects/differential_functions.ts
+++ b/x-pack/solutions/observability/plugins/profiling/test/scout/ui/fixtures/page_objects/differential_functions.ts
@@ -6,6 +6,7 @@
  */
 
 import type { KibanaUrl, ScoutPage } from '@kbn/scout-oblt';
+import { EXTENDED_TIMEOUT } from '..';
 
 export class DifferentialFunctionsPage {
   constructor(public readonly page: ScoutPage, private readonly kbnUrl: KibanaUrl) {}
@@ -35,7 +36,9 @@ export class DifferentialFunctionsPage {
     await this.page.goto(
       `${this.kbnUrl.app('profiling')}/functions/differential?${params.toString()}`
     );
-    await this.page.waitForLoadingIndicatorHidden();
+    await this.page.testSubj
+      .locator('overallPerformance_value')
+      .waitFor({ timeout: EXTENDED_TIMEOUT });
   }
 
   getSummaryValue(id: string) {

--- a/x-pack/solutions/observability/plugins/profiling/test/scout/ui/fixtures/page_objects/functions.ts
+++ b/x-pack/solutions/observability/plugins/profiling/test/scout/ui/fixtures/page_objects/functions.ts
@@ -28,8 +28,8 @@ export class FunctionsPage {
 
   async goto() {
     await this.page.goto(`${this.kbnUrl.app('profiling')}/functions`);
-    await this.page.testSubj
-      .locator('profilingNormalizationMenuButton')
+    await this.page
+      .getByRole('tab', { name: 'TopN functions' })
       .waitFor({ timeout: EXTENDED_TIMEOUT });
   }
 
@@ -37,8 +37,8 @@ export class FunctionsPage {
     await this.page.goto(
       `${this.kbnUrl.app('profiling')}/functions?rangeFrom=${rangeFrom}&rangeTo=${rangeTo}`
     );
-    await this.page.testSubj
-      .locator('profilingNormalizationMenuButton')
+    await this.page
+      .getByRole('tab', { name: 'TopN functions' })
       .waitFor({ timeout: EXTENDED_TIMEOUT });
   }
 

--- a/x-pack/solutions/observability/plugins/profiling/test/scout/ui/fixtures/page_objects/functions.ts
+++ b/x-pack/solutions/observability/plugins/profiling/test/scout/ui/fixtures/page_objects/functions.ts
@@ -29,7 +29,7 @@ export class FunctionsPage {
   async goto() {
     await this.page.goto(`${this.kbnUrl.app('profiling')}/functions`);
     await this.page
-      .getByRole('tab', { name: 'TopN functions' })
+      .getByRole('tab', { name: 'TopN functions', exact: true })
       .waitFor({ timeout: EXTENDED_TIMEOUT });
   }
 
@@ -38,7 +38,7 @@ export class FunctionsPage {
       `${this.kbnUrl.app('profiling')}/functions?rangeFrom=${rangeFrom}&rangeTo=${rangeTo}`
     );
     await this.page
-      .getByRole('tab', { name: 'TopN functions' })
+      .getByRole('tab', { name: 'TopN functions', exact: true })
       .waitFor({ timeout: EXTENDED_TIMEOUT });
   }
 

--- a/x-pack/solutions/observability/plugins/profiling/test/scout/ui/fixtures/page_objects/functions.ts
+++ b/x-pack/solutions/observability/plugins/profiling/test/scout/ui/fixtures/page_objects/functions.ts
@@ -6,6 +6,7 @@
  */
 
 import type { KibanaUrl, Locator, ScoutPage } from '@kbn/scout-oblt';
+import { EXTENDED_TIMEOUT } from '..';
 
 export class FunctionsPage {
   public co2PerKWHField: Locator;
@@ -27,14 +28,18 @@ export class FunctionsPage {
 
   async goto() {
     await this.page.goto(`${this.kbnUrl.app('profiling')}/functions`);
-    await this.page.waitForLoadingIndicatorHidden();
+    await this.page.testSubj
+      .locator('profilingNormalizationMenuButton')
+      .waitFor({ timeout: EXTENDED_TIMEOUT });
   }
 
   async gotoWithTimeRange(rangeFrom: string, rangeTo: string) {
     await this.page.goto(
       `${this.kbnUrl.app('profiling')}/functions?rangeFrom=${rangeFrom}&rangeTo=${rangeTo}`
     );
-    await this.page.waitForLoadingIndicatorHidden();
+    await this.page.testSubj
+      .locator('profilingNormalizationMenuButton')
+      .waitFor({ timeout: EXTENDED_TIMEOUT });
   }
 
   // TopN Functions methods

--- a/x-pack/solutions/observability/plugins/profiling/test/scout/ui/fixtures/page_objects/home.ts
+++ b/x-pack/solutions/observability/plugins/profiling/test/scout/ui/fixtures/page_objects/home.ts
@@ -6,20 +6,25 @@
  */
 
 import type { KibanaUrl, ScoutPage } from '@kbn/scout-oblt';
+import { EXTENDED_TIMEOUT } from '..';
 
 export class ProfilingHomePage {
   constructor(public readonly page: ScoutPage, private readonly kbnUrl: KibanaUrl) {}
 
   async goto() {
     await this.page.goto(`${this.kbnUrl.app('profiling')}`);
-    await this.page.waitForLoadingIndicatorHidden();
+    await this.page.testSubj
+      .locator('profilingNormalizationMenuButton')
+      .waitFor({ timeout: EXTENDED_TIMEOUT });
   }
 
   async gotoWithTimeRange(rangeFrom: string, rangeTo: string) {
     await this.page.goto(
       `${this.kbnUrl.app('profiling')}?rangeFrom=${rangeFrom}&rangeTo=${rangeTo}`
     );
-    await this.page.waitForLoadingIndicatorHidden();
+    await this.page.testSubj
+      .locator('profilingNormalizationMenuButton')
+      .waitFor({ timeout: EXTENDED_TIMEOUT });
   }
 
   // Tab navigation methods

--- a/x-pack/solutions/observability/plugins/profiling/test/scout/ui/fixtures/page_objects/home.ts
+++ b/x-pack/solutions/observability/plugins/profiling/test/scout/ui/fixtures/page_objects/home.ts
@@ -14,7 +14,7 @@ export class ProfilingHomePage {
   async goto() {
     await this.page.goto(`${this.kbnUrl.app('profiling')}`);
     await this.page.testSubj
-      .locator('profilingNormalizationMenuButton')
+      .locator('stackTracesDisplayOptionButtonGroup')
       .waitFor({ timeout: EXTENDED_TIMEOUT });
   }
 
@@ -23,7 +23,7 @@ export class ProfilingHomePage {
       `${this.kbnUrl.app('profiling')}?rangeFrom=${rangeFrom}&rangeTo=${rangeTo}`
     );
     await this.page.testSubj
-      .locator('profilingNormalizationMenuButton')
+      .locator('stackTracesDisplayOptionButtonGroup')
       .waitFor({ timeout: EXTENDED_TIMEOUT });
   }
 

--- a/x-pack/solutions/observability/plugins/profiling/test/scout/ui/fixtures/page_objects/settings.ts
+++ b/x-pack/solutions/observability/plugins/profiling/test/scout/ui/fixtures/page_objects/settings.ts
@@ -6,13 +6,16 @@
  */
 
 import type { KibanaUrl, ScoutPage } from '@kbn/scout-oblt';
+import { EXTENDED_TIMEOUT } from '..';
 
 export class ProfilingSettingsPage {
   constructor(public readonly page: ScoutPage, private readonly kbnUrl: KibanaUrl) {}
 
   async goto() {
-    await this.page.goto(`${this.kbnUrl.app('profiling')}/settings`);
-    await this.page.waitForLoadingIndicatorHidden();
+    await this.page.goto(`${this.kbnUrl.app('profiling')} `);
+    await this.page.testSubj
+      .locator('profilingNormalizationMenuButton')
+      .waitFor({ timeout: EXTENDED_TIMEOUT });
   }
 
   // Settings Form methods

--- a/x-pack/solutions/observability/plugins/profiling/test/scout/ui/fixtures/page_objects/settings.ts
+++ b/x-pack/solutions/observability/plugins/profiling/test/scout/ui/fixtures/page_objects/settings.ts
@@ -12,7 +12,7 @@ export class ProfilingSettingsPage {
   constructor(public readonly page: ScoutPage, private readonly kbnUrl: KibanaUrl) {}
 
   async goto() {
-    await this.page.goto(`${this.kbnUrl.app('profiling')} `);
+    await this.page.goto(`${this.kbnUrl.app('profiling')}/settings`);
     await this.page.testSubj
       .locator('profilingNormalizationMenuButton')
       .waitFor({ timeout: EXTENDED_TIMEOUT });

--- a/x-pack/solutions/observability/plugins/profiling/test/scout/ui/fixtures/page_objects/settings.ts
+++ b/x-pack/solutions/observability/plugins/profiling/test/scout/ui/fixtures/page_objects/settings.ts
@@ -15,6 +15,7 @@ export class ProfilingSettingsPage {
     await this.page.goto(`${this.kbnUrl.app('profiling')}/settings`);
     await this.page.testSubj
       .locator('profilingSettingsLink')
+      .first()
       .waitFor({ timeout: EXTENDED_TIMEOUT });
   }
 

--- a/x-pack/solutions/observability/plugins/profiling/test/scout/ui/fixtures/page_objects/settings.ts
+++ b/x-pack/solutions/observability/plugins/profiling/test/scout/ui/fixtures/page_objects/settings.ts
@@ -15,6 +15,7 @@ export class ProfilingSettingsPage {
     await this.page.goto(`${this.kbnUrl.app('profiling')}/settings`);
     await this.page.testSubj
       .locator('profilingSettingsLink')
+      // eslint-disable-next-line playwright/no-nth-methods
       .first()
       .waitFor({ timeout: EXTENDED_TIMEOUT });
   }

--- a/x-pack/solutions/observability/plugins/profiling/test/scout/ui/fixtures/page_objects/settings.ts
+++ b/x-pack/solutions/observability/plugins/profiling/test/scout/ui/fixtures/page_objects/settings.ts
@@ -12,9 +12,9 @@ export class ProfilingSettingsPage {
   constructor(public readonly page: ScoutPage, private readonly kbnUrl: KibanaUrl) {}
 
   async goto() {
-    await this.page.goto(`${this.kbnUrl.app('profiling')} `);
+    await this.page.goto(`${this.kbnUrl.app('profiling')}/settings`);
     await this.page.testSubj
-      .locator('profilingNormalizationMenuButton')
+      .locator('profilingSettingsLink')
       .waitFor({ timeout: EXTENDED_TIMEOUT });
   }
 

--- a/x-pack/solutions/observability/plugins/profiling/test/scout/ui/fixtures/page_objects/storage_explorer.ts
+++ b/x-pack/solutions/observability/plugins/profiling/test/scout/ui/fixtures/page_objects/storage_explorer.ts
@@ -6,6 +6,7 @@
  */
 
 import type { KibanaUrl, Locator, ScoutPage } from '@kbn/scout-oblt';
+import { EXTENDED_TIMEOUT } from '..';
 
 export class ProfilingStorageExplorerPage {
   public pageTitle: Locator;
@@ -19,7 +20,9 @@ export class ProfilingStorageExplorerPage {
 
   async goto() {
     await this.page.goto(`${this.kbnUrl.app('profiling')}/storage-explorer`);
-    await this.page.waitForLoadingIndicatorHidden();
+    await this.page.testSubj
+      .locator('storageExplorer_hostBreakdownTab')
+      .waitFor({ timeout: EXTENDED_TIMEOUT });
   }
 
   async gotoWithTimeRange(rangeFrom: string, rangeTo: string, kuery?: string) {
@@ -30,7 +33,9 @@ export class ProfilingStorageExplorerPage {
       url += `&kuery=${encodeURIComponent(kuery)}`;
     }
     await this.page.goto(url);
-    await this.page.waitForLoadingIndicatorHidden();
+    await this.page.testSubj
+      .locator('storageExplorer_hostBreakdownTab')
+      .waitFor({ timeout: EXTENDED_TIMEOUT });
   }
 
   // Summary Stats methods

--- a/x-pack/solutions/observability/plugins/profiling/test/scout/ui/parallel_tests/differential_functions/differential_functions.spec.ts
+++ b/x-pack/solutions/observability/plugins/profiling/test/scout/ui/parallel_tests/differential_functions/differential_functions.spec.ts
@@ -38,33 +38,30 @@ test.describe('Differential Functions page', { tag: tags.stateful.classic }, () 
     const overallPerformanceTitle = page.getByTestId('overallPerformance_summary_title');
     await expect(overallPerformanceTitle).toContainText('Gained overall performance by');
 
-    const overallPerformanceValue = await differentialFunctionsPage.getSummaryValue(
-      'overallPerformance'
+    await expect(differentialFunctionsPage.getSummaryValue('overallPerformance')).toContainText(
+      '66.06%'
     );
-    await expect(overallPerformanceValue).toContainText('66.06%');
 
-    const annualizedCo2Value = await differentialFunctionsPage.getSummaryValue('annualizedCo2');
-    await expect(annualizedCo2Value).toContainText('76.06 lbs / 34.5 kg');
-    const annualizedCo2Comparison = await differentialFunctionsPage.getSummaryComparisonValue(
-      'annualizedCo2'
+    await expect(differentialFunctionsPage.getSummaryValue('annualizedCo2')).toContainText(
+      '76.06 lbs / 34.5 kg'
     );
-    await expect(annualizedCo2Comparison).toContainText('25.79 lbs / 11.7 kg (66.09%)');
+    await expect(
+      differentialFunctionsPage.getSummaryComparisonValue('annualizedCo2')
+    ).toContainText('25.79 lbs / 11.7 kg (66.09%)');
 
-    const annualizedCostValue = await differentialFunctionsPage.getSummaryValue('annualizedCost');
-    await expect(annualizedCostValue).toContainText('$325.27');
-    const annualizedCostComparison = await differentialFunctionsPage.getSummaryComparisonValue(
-      'annualizedCost'
+    await expect(differentialFunctionsPage.getSummaryValue('annualizedCost')).toContainText(
+      '$325.27'
     );
-    await expect(annualizedCostComparison).toContainText('$110.38 (66.06%)');
+    await expect(
+      differentialFunctionsPage.getSummaryComparisonValue('annualizedCost')
+    ).toContainText('$110.38 (66.06%)');
 
-    const totalSamplesValue = await differentialFunctionsPage.getSummaryValue(
-      'totalNumberOfSamples'
+    await expect(differentialFunctionsPage.getSummaryValue('totalNumberOfSamples')).toContainText(
+      '498'
     );
-    await expect(totalSamplesValue).toContainText('498');
-    const totalSamplesComparison = await differentialFunctionsPage.getSummaryComparisonValue(
-      'totalNumberOfSamples'
-    );
-    await expect(totalSamplesComparison).toContainText('169 (66.06%)');
+    await expect(
+      differentialFunctionsPage.getSummaryComparisonValue('totalNumberOfSamples')
+    ).toContainText('169 (66.06%)');
   });
 
   test('show lost performance when comparison data has more samples than baseline', async ({

--- a/x-pack/solutions/observability/plugins/profiling/test/scout/ui/parallel_tests/differential_functions/differential_functions.spec.ts
+++ b/x-pack/solutions/observability/plugins/profiling/test/scout/ui/parallel_tests/differential_functions/differential_functions.spec.ts
@@ -28,9 +28,6 @@ test.describe('Differential Functions page', { tag: tags.stateful.classic }, () 
       comparisonRangeFrom,
       comparisonRangeTo
     );
-    await page.waitForResponse((response) =>
-      response.url().includes('/internal/profiling/topn/functions')
-    );
 
     await expect(page.getByText('Baseline functions')).toBeVisible();
     await expect(page.getByText('Comparison functions')).toBeVisible();
@@ -74,9 +71,6 @@ test.describe('Differential Functions page', { tag: tags.stateful.classic }, () 
       rangeFrom,
       rangeTo
     );
-    await page.waitForResponse((response) =>
-      response.url().includes('/internal/profiling/topn/functions')
-    );
     const overallPerformanceTitle = page.getByTestId('overallPerformance_summary_title');
 
     await expect(overallPerformanceTitle).toContainText('Lost overall performance by');
@@ -111,9 +105,6 @@ test.describe('Differential Functions page', { tag: tags.stateful.classic }, () 
       comparisonRangeTo,
       rangeFrom,
       rangeTo
-    );
-    await page.waitForResponse((response) =>
-      response.url().includes('/internal/profiling/topn/functions')
     );
 
     await expect(


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[scout] remove waitForLoadingIndicatorHidden and its usage (#261899)](https://github.com/elastic/kibana/pull/261899)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Dzmitry Lemechko","email":"dzmitry.lemechko@elastic.co"},"sourceCommit":{"committedDate":"2026-04-08T15:00:58Z","message":"[scout] remove waitForLoadingIndicatorHidden and its usage (#261899)\n\n## Summary\n\nCloses https://github.com/elastic/appex-qa-team/issues/769\n\nThis PR removes `page.waitForLoadingIndicatorHidden()` and replaces its\nusages with waiting for page-specific locators.","sha":"a2b943f11716f24c39d57d58051d262b7a1b89da","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:all-open","v9.4.0","Team:obs-presentation"],"title":"[scout] remove waitForLoadingIndicatorHidden and its usage","number":261899,"url":"https://github.com/elastic/kibana/pull/261899","mergeCommit":{"message":"[scout] remove waitForLoadingIndicatorHidden and its usage (#261899)\n\n## Summary\n\nCloses https://github.com/elastic/appex-qa-team/issues/769\n\nThis PR removes `page.waitForLoadingIndicatorHidden()` and replaces its\nusages with waiting for page-specific locators.","sha":"a2b943f11716f24c39d57d58051d262b7a1b89da"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/261899","number":261899,"mergeCommit":{"message":"[scout] remove waitForLoadingIndicatorHidden and its usage (#261899)\n\n## Summary\n\nCloses https://github.com/elastic/appex-qa-team/issues/769\n\nThis PR removes `page.waitForLoadingIndicatorHidden()` and replaces its\nusages with waiting for page-specific locators.","sha":"a2b943f11716f24c39d57d58051d262b7a1b89da"}}]}] BACKPORT-->