### PR TITLE
[8.19] [scout] remove waitForLoadingIndicatorHidden and its usage (#261899)

### DIFF
--- a/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/test/performance/README.md
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/test/performance/README.md
@@ -19,7 +19,6 @@
   - Frames Per Second (FPS) (fps)
   - DOM Complexity Metrics (nodesCount, documentsCount)
 
-
 ### Usage: capturing JS bundles on page
 
 ```ts
@@ -106,7 +105,8 @@ test.describe(
 
       // Navigate to Discover app
       await pageObjects.collapsibleNav.clickItem('Discover');
-      await page.waitForLoadingIndicatorHidden();
+      await page.testSubj.waitForSelector('discoverLayoutResizableContainer');
+
       const currentUrl = page.url();
       expect(currentUrl).toContain('app/discover#/');
 

--- a/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/test/scout_page/index.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/test/scout_page/index.ts
@@ -28,12 +28,6 @@ export type ScoutPage = Page & {
    */
   gotoApp: (appName: string, pathOptions?: PathOptions) => ReturnType<Page['goto']>;
   /**
-   * Waits for the Kibana loading spinner indicator to disappear.
-   * @deprecated This method is flaky on CI. We strongly recommend waiting for specific elements instead: page.testSubj.waitForSelector('table-is-ready', { state: 'visible' })
-   * @returns A Promise resolving when the indicator is hidden.
-   */
-  waitForLoadingIndicatorHidden: () => ReturnType<Page['waitForSelector']>;
-  /**
    * Performs an accessibility (a11y) scan of the current page using axe-core.
    * Use this in tests to collect formatted violation summaries (one string per violation).
    *

--- a/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/test/scout_page/single_thread.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/test/scout_page/single_thread.ts
@@ -102,11 +102,6 @@ export function extendPlaywrightPage({
   // Method to navigate to specific Kibana apps
   extendedPage.gotoApp = (appName: string, pathOptions?: PathOptions) =>
     page.goto(kbnUrl.app(appName, { pathOptions }));
-  // Method to wait for global loading indicator to be hidden
-  extendedPage.waitForLoadingIndicatorHidden = () =>
-    extendedPage.testSubj.waitForSelector('globalLoadingIndicator-hidden', {
-      state: 'attached',
-    });
 
   extendedPage.checkA11y = (options) => checkA11y(page, options);
 

--- a/src/platform/packages/shared/kbn-scout/src/playwright/page_objects/discover_app.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/page_objects/discover_app.ts
@@ -115,7 +115,6 @@ export class DiscoverApp {
   }
 
   async getHitCountInt(): Promise<number> {
-    await this.page.waitForLoadingIndicatorHidden();
     const hitCount = await this.page.testSubj.innerText('discoverQueryHits');
     return parseInt(hitCount.replace(/,/g, ''), 10);
   }

--- a/src/platform/packages/shared/kbn-scout/src/playwright/page_objects/discover_app.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/page_objects/discover_app.ts
@@ -75,7 +75,6 @@ export class DiscoverApp {
     await this.page.testSubj.hover('discoverNewButton');
     await this.page.testSubj.click('discoverNewButton');
     await this.page.testSubj.hover('unifiedFieldListSidebar__toggle-collapse'); // cancel tooltips
-    await this.page.waitForLoadingIndicatorHidden();
   }
 
   async saveSearch(name: string) {

--- a/x-pack/platform/plugins/private/discover_enhanced/test/scout/ui/tests/discover_cdp_perf.spec.ts
+++ b/x-pack/platform/plugins/private/discover_enhanced/test/scout/ui/tests/discover_cdp_perf.spec.ts
@@ -29,7 +29,7 @@ test.describe(
       cdp = await context.newCDPSession(page);
       await cdp.send('Network.enable');
       await page.gotoApp('home');
-      await page.waitForLoadingIndicatorHidden();
+      await page.testSubj.waitForSelector('homeApp', { timeout: 20000 });
       await perfTracker.waitForJsLoad(cdp); // Ensure JS bundles are fully loaded
     });
 
@@ -105,7 +105,7 @@ test.describe(
 
       // Navigate to Discover app
       await pageObjects.collapsibleNav.clickItem('Discover');
-      await page.waitForLoadingIndicatorHidden();
+      await page.testSubj.waitForSelector('discoverLayoutResizableContainer', { timeout: 20000 });
       const currentUrl = page.url();
       expect(currentUrl).toContain('app/discover#/');
 

--- a/x-pack/platform/plugins/private/discover_enhanced/test/scout/ui/tests/saved_search_embeddable.spec.ts
+++ b/x-pack/platform/plugins/private/discover_enhanced/test/scout/ui/tests/saved_search_embeddable.spec.ts
@@ -85,7 +85,6 @@ test.describe('Discover app - saved search embeddable', { tag: tags.deploymentAg
     });
 
     await page.reload();
-    await page.testSubj.waitForSelector('dashboardContainer', { timeout: 20000 });
     await expect(
       page.testSubj.locator('embeddableError'),
       'Embeddable error should be displayed'

--- a/x-pack/platform/plugins/private/discover_enhanced/test/scout/ui/tests/saved_search_embeddable.spec.ts
+++ b/x-pack/platform/plugins/private/discover_enhanced/test/scout/ui/tests/saved_search_embeddable.spec.ts
@@ -85,7 +85,7 @@ test.describe('Discover app - saved search embeddable', { tag: tags.deploymentAg
     });
 
     await page.reload();
-    await page.waitForLoadingIndicatorHidden();
+    await page.testSubj.waitForSelector('dashboardContainer', { timeout: 20000 });
     await expect(
       page.testSubj.locator('embeddableError'),
       'Embeddable error should be displayed'


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[scout] remove waitForLoadingIndicatorHidden and its usage (#261899)](https://github.com/elastic/kibana/pull/261899)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Dzmitry Lemechko","email":"dzmitry.lemechko@elastic.co"},"sourceCommit":{"committedDate":"2026-04-08T15:00:58Z","message":"[scout] remove waitForLoadingIndicatorHidden and its usage (#261899)\n\n## Summary\n\nCloses https://github.com/elastic/appex-qa-team/issues/769\n\nThis PR removes `page.waitForLoadingIndicatorHidden()` and replaces its\nusages with waiting for page-specific locators.","sha":"a2b943f11716f24c39d57d58051d262b7a1b89da","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:all-open","v9.4.0","Team:obs-presentation"],"title":"[scout] remove waitForLoadingIndicatorHidden and its usage","number":261899,"url":"https://github.com/elastic/kibana/pull/261899","mergeCommit":{"message":"[scout] remove waitForLoadingIndicatorHidden and its usage (#261899)\n\n## Summary\n\nCloses https://github.com/elastic/appex-qa-team/issues/769\n\nThis PR removes `page.waitForLoadingIndicatorHidden()` and replaces its\nusages with waiting for page-specific locators.","sha":"a2b943f11716f24c39d57d58051d262b7a1b89da"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/261899","number":261899,"mergeCommit":{"message":"[scout] remove waitForLoadingIndicatorHidden and its usage (#261899)\n\n## Summary\n\nCloses https://github.com/elastic/appex-qa-team/issues/769\n\nThis PR removes `page.waitForLoadingIndicatorHidden()` and replaces its\nusages with waiting for page-specific locators.","sha":"a2b943f11716f24c39d57d58051d262b7a1b89da"}},{"url":"https://github.com/elastic/kibana/pull/262173","number":262173,"branch":"9.3","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/262174","number":262174,"branch":"9.2","state":"OPEN"}]}] BACKPORT-->