### PR TITLE
[Scout] Log test file name per worker for enhanced test failure troubleshooting

### DIFF
--- a/src/platform/packages/shared/kbn-scout/src/common/services/logger.ts
+++ b/src/platform/packages/shared/kbn-scout/src/common/services/logger.ts
@@ -62,5 +62,4 @@ export class ScoutLogger extends ToolingLog {
   public serviceMessage(name: string, message: string) {
     this.debug(`[${name}] ${message}`);
   }
-
 }

--- a/src/platform/packages/shared/kbn-scout/src/common/services/logger.ts
+++ b/src/platform/packages/shared/kbn-scout/src/common/services/logger.ts
@@ -68,6 +68,6 @@ export class ScoutLogger extends ToolingLog {
    * @param filePath relative path to the test file
    */
   public testFileStarted(filePath: string) {
-    this.info(`[testFile] Running tests: ${filePath}`);
+    this.debug(`[testFile] Running tests: ${filePath}`);
   }
 }

--- a/src/platform/packages/shared/kbn-scout/src/common/services/logger.ts
+++ b/src/platform/packages/shared/kbn-scout/src/common/services/logger.ts
@@ -62,4 +62,12 @@ export class ScoutLogger extends ToolingLog {
   public serviceMessage(name: string, message: string) {
     this.debug(`[${name}] ${message}`);
   }
+
+  /**
+   * Used to log the test file a worker is currently running
+   * @param filePath relative path to the test file
+   */
+  public testFileStarted(filePath: string) {
+    this.info(`[testFile] Running tests: ${filePath}`);
+  }
 }

--- a/src/platform/packages/shared/kbn-scout/src/common/services/logger.ts
+++ b/src/platform/packages/shared/kbn-scout/src/common/services/logger.ts
@@ -63,11 +63,4 @@ export class ScoutLogger extends ToolingLog {
     this.debug(`[${name}] ${message}`);
   }
 
-  /**
-   * Used to log the test file a worker is currently running
-   * @param filePath relative path to the test file
-   */
-  public testFileStarted(filePath: string) {
-    this.debug(`[testFile] Running tests: ${filePath}`);
-  }
 }

--- a/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/test/index.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/test/index.ts
@@ -18,3 +18,4 @@ export { persistentContextFixture } from './context/persistent_context';
 export { pageContextFixture } from './context/page_context';
 export { perfTrackerFixture } from './performance';
 export type { PerfTrackerFixture } from './performance';
+export { logTestFileFixture } from './log_test_file';

--- a/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/test/log_test_file/index.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/test/log_test_file/index.ts
@@ -26,7 +26,7 @@ export const logTestFileFixture = base.extend<{ logTestFile: void }, { log: Scou
       if (testInfo.file !== lastLoggedFile) {
         lastLoggedFile = testInfo.file;
         const relativePath = path.relative(REPO_ROOT, testInfo.file);
-        log.testFileStarted(relativePath);
+        log.debug(`[testFile] Running tests: ${relativePath}`);
       }
       await use();
     },

--- a/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/test/log_test_file/index.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/test/log_test_file/index.ts
@@ -9,7 +9,6 @@
 
 import path from 'path';
 import { test as base } from '@playwright/test';
-import { REPO_ROOT } from '@kbn/repo-info';
 import type { ScoutLogger } from '../../worker';
 
 let lastLoggedFile = '';
@@ -25,8 +24,7 @@ export const logTestFileFixture = base.extend<{ logTestFile: void }, { log: Scou
     async ({ log }, use, testInfo) => {
       if (testInfo.file !== lastLoggedFile) {
         lastLoggedFile = testInfo.file;
-        const relativePath = path.relative(REPO_ROOT, testInfo.file);
-        log.debug(`[testFile] Running tests: ${relativePath}`);
+        log.debug(`[testFile] ${path.basename(testInfo.file)}`);
       }
       await use();
     },

--- a/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/test/log_test_file/index.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/test/log_test_file/index.ts
@@ -26,7 +26,7 @@ export const logTestFileFixture = base.extend<{ logTestFile: void }, { log: Scou
       if (testInfo.file !== lastLoggedFile) {
         lastLoggedFile = testInfo.file;
         const relativePath = path.relative(REPO_ROOT, testInfo.file);
-        log.debug(`[testFile] Running tests: ${relativePath}`);
+        log.testFileStarted(relativePath);
       }
       await use();
     },

--- a/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/test/log_test_file/index.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/test/log_test_file/index.ts
@@ -26,7 +26,7 @@ export const logTestFileFixture = base.extend<{ logTestFile: void }, { log: Scou
       if (testInfo.file !== lastLoggedFile) {
         lastLoggedFile = testInfo.file;
         const relativePath = path.relative(REPO_ROOT, testInfo.file);
-        log.info(`[testFile] Running tests: ${relativePath}`);
+        log.debug(`[testFile] Running tests: ${relativePath}`);
       }
       await use();
     },

--- a/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/test/log_test_file/index.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/test/log_test_file/index.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import path from 'path';
+import { test as base } from '@playwright/test';
+import { REPO_ROOT } from '@kbn/repo-info';
+import type { ScoutLogger } from '../../worker';
+
+let lastLoggedFile = '';
+
+/**
+ * Auto-fixture that logs the test file path once per file per worker.
+ * Each Playwright worker runs in its own process, so the module-level
+ * variable naturally isolates per worker. Only logs when the worker
+ * picks up a new file, avoiding noise from repeated per-test logging.
+ */
+export const logTestFileFixture = base.extend<{ logTestFile: void }, { log: ScoutLogger }>({
+  logTestFile: [
+    async ({ log }, use, testInfo) => {
+      if (testInfo.file !== lastLoggedFile) {
+        lastLoggedFile = testInfo.file;
+        const relativePath = path.relative(REPO_ROOT, testInfo.file);
+        log.info(`[testFile] Running tests: ${relativePath}`);
+      }
+      await use();
+    },
+    { auto: true },
+  ],
+});

--- a/src/platform/packages/shared/kbn-scout/src/playwright/test/api/index.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/test/api/index.ts
@@ -18,6 +18,7 @@ import {
   defaultRolesFixture,
   requestAuthFixture,
 } from '../../fixtures/scope/worker';
+import { logTestFileFixture } from '../../fixtures/scope/test';
 import type {
   CoreWorkerFixtures,
   EsArchiverFixture,
@@ -80,5 +81,6 @@ export const apiTest = mergeTests(
   defaultRolesFixture,
   requestAuthFixture,
   esArchiverFixture,
-  linkedEsFixtures
+  linkedEsFixtures,
+  logTestFileFixture
 ) as unknown as TestType<{}, ApiWorkerFixtures>;

--- a/src/platform/packages/shared/kbn-scout/src/playwright/test/ui/parallel_run_fixtures.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/test/ui/parallel_run_fixtures.ts
@@ -29,6 +29,7 @@ import {
   browserAuthFixture,
   pageObjectsParallelFixture,
   validateTagsFixture,
+  logTestFileFixture,
 } from '../../fixtures/scope/test';
 import type { BrowserAuthFixture, ScoutPage, PageObjects } from '../../fixtures/scope/test';
 
@@ -42,7 +43,8 @@ export const scoutParallelFixtures = mergeTests(
   browserAuthFixture,
   scoutPageParallelFixture,
   pageObjectsParallelFixture,
-  validateTagsFixture
+  validateTagsFixture,
+  logTestFileFixture
 );
 
 export interface ScoutParallelTestFixtures {

--- a/src/platform/packages/shared/kbn-scout/src/playwright/test/ui/single_thread_fixtures.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/test/ui/single_thread_fixtures.ts
@@ -35,6 +35,7 @@ import {
   validateTagsFixture,
   persistentContextFixture,
   perfTrackerFixture,
+  logTestFileFixture,
 } from '../../fixtures/scope/test';
 import type {
   BrowserAuthFixture,
@@ -59,6 +60,7 @@ export const scoutFixtures = mergeTests(
   scoutPageFixture,
   pageObjectsFixture,
   validateTagsFixture,
+  logTestFileFixture,
   // performance fixtures
   perfTrackerFixture
 );


### PR DESCRIPTION
This PR adds a test-scoped auto-fixture that logs the test file name once per file per worker. This helps troubleshoot parallel test runs by showing which worker is running which file, making it easier to correlate failures when multiple tests run at the same time.

New log entry:

```
[testFile] product_intercepts_upgrade.spec.ts
```