### PR TITLE
Elastic Ramen: LLM gateway telemetry (ES data stream) + dashboard install

### DIFF
--- a/x-pack/platform/plugins/shared/elastic_console/server/dashboard/install_llm_gateway_dashboard.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/dashboard/install_llm_gateway_dashboard.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import { v4 as uuidv4 } from 'uuid';
 import type { CoreStart, Logger } from '@kbn/core/server';
 import { SavedObjectsClient, SavedObjectsErrorHelpers } from '@kbn/core/server';
 import { DASHBOARD_SAVED_OBJECT_TYPE } from '@kbn/dashboard-plugin/common/constants';
@@ -14,27 +13,22 @@ import {
   ELASTIC_RAMEN_LLM_GATEWAY_DASHBOARD_ID,
   ELASTIC_RAMEN_LLM_GATEWAY_DATA_VIEW_ID,
 } from './llm_gateway_dashboard_constants';
+import { buildLlmGatewayDashboardPanelsJson } from './llm_gateway_dashboard_panels';
 
 const DATA_VIEW_SAVED_OBJECT_TYPE = 'index-pattern';
 
-const markdownPanel = (content: string, grid: { x: number; y: number; w: number; h: number }) => {
-  const panelId = uuidv4();
-  return {
-    type: 'DASHBOARD_MARKDOWN' as const,
-    embeddableConfig: { content },
-    panelIndex: panelId,
-    gridData: {
-      i: panelId,
-      x: grid.x,
-      y: grid.y,
-      w: grid.w,
-      h: grid.h,
-    },
-  };
-};
+function llmGatewayDashboardOptions(): string {
+  return JSON.stringify({
+    useMargins: true,
+    syncColors: false,
+    syncCursor: true,
+    syncTooltips: false,
+  });
+}
 
 /**
- * Installs a default-space data view + dashboard for LLM gateway telemetry (idempotent).
+ * Installs a default-space data view + Lens dashboard for LLM gateway telemetry (idempotent).
+ * If the dashboard saved object id already exists, does nothing.
  */
 export async function installLlmGatewayDashboardIfMissing(
   coreStart: CoreStart,
@@ -44,17 +38,7 @@ export async function installLlmGatewayDashboardIfMissing(
   const internalRepo = coreStart.savedObjects.createInternalRepository();
   const soClient = new SavedObjectsClient(internalRepo);
 
-  try {
-    try {
-      await soClient.get(DASHBOARD_SAVED_OBJECT_TYPE, ELASTIC_RAMEN_LLM_GATEWAY_DASHBOARD_ID);
-      log.debug('LLM gateway telemetry dashboard already present; skipping install.');
-      return;
-    } catch (err) {
-      if (!SavedObjectsErrorHelpers.isNotFoundError(err)) {
-        throw err;
-      }
-    }
-
+  const ensureDataView = async () => {
     try {
       await soClient.get(DATA_VIEW_SAVED_OBJECT_TYPE, ELASTIC_RAMEN_LLM_GATEWAY_DATA_VIEW_ID);
     } catch (err) {
@@ -72,42 +56,31 @@ export async function installLlmGatewayDashboardIfMissing(
         { id: ELASTIC_RAMEN_LLM_GATEWAY_DATA_VIEW_ID }
       );
     }
+  };
 
-    const panelsJSON = JSON.stringify([
-      markdownPanel(
-        `## Elastic Ramen — LLM gateway telemetry
+  const lensPanelsJson = buildLlmGatewayDashboardPanelsJson(ELASTIC_RAMEN_LLM_GATEWAY_DATA_VIEW_ID);
 
-Telemetry documents are indexed into data stream \`${ELASTIC_RAMEN_LLM_GATEWAY_TELEMETRY_DATA_STREAM}\`.
+  try {
+    await soClient.get(DASHBOARD_SAVED_OBJECT_TYPE, ELASTIC_RAMEN_LLM_GATEWAY_DASHBOARD_ID);
+    log.debug('LLM gateway telemetry dashboard already present; skipping install.');
+    return;
+  } catch (err) {
+    if (!SavedObjectsErrorHelpers.isNotFoundError(err)) {
+      throw err;
+    }
+  }
 
-**Fields (examples)**  
-- \`gen_ai.usage.*\` — input, output, total, cache vs non-cached prompt tokens  
-- \`elastic_ramen.*\` — connector, model, tool calls, outcome  
-- \`event.outcome\` — success / failure
-
-**Discover** (default space): open Discover, pick data view *Elastic Ramen LLM gateway telemetry*, or filter:
-
-\`\`\`
-data_stream.dataset:"elastic_ramen.llm_gateway"
-\`\`\`
-
-Add **Lens** panels from this data view for charts (requests over time, token sums, cache ratio, etc.).`,
-        { x: 0, y: 0, w: 48, h: 18 }
-      ),
-    ]);
+  try {
+    await ensureDataView();
 
     await soClient.create(
       DASHBOARD_SAVED_OBJECT_TYPE,
       {
         title: 'Elastic Ramen — LLM gateway telemetry',
         description:
-          'Pre-installed dashboard scaffold for Elastic Ramen OpenAI-compatible gateway usage.',
-        panelsJSON,
-        optionsJSON: JSON.stringify({
-          useMargins: true,
-          syncColors: false,
-          syncCursor: true,
-          syncTooltips: false,
-        }),
+          'Elastic Ramen OpenAI-compatible gateway: completions, tokens, cache split, models, outcomes, tool calls.',
+        panelsJSON: lensPanelsJson,
+        optionsJSON: llmGatewayDashboardOptions(),
         timeRestore: true,
         timeFrom: 'now-7d',
         timeTo: 'now',
@@ -121,8 +94,8 @@ Add **Lens** panels from this data view for charts (requests over time, token su
     log.info(
       `Installed LLM gateway telemetry dashboard (id: ${ELASTIC_RAMEN_LLM_GATEWAY_DASHBOARD_ID}).`
     );
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
+  } catch (installErr) {
+    const message = installErr instanceof Error ? installErr.message : String(installErr);
     log.error(`Could not install LLM gateway telemetry dashboard: ${message}`);
   }
 }

--- a/x-pack/platform/plugins/shared/elastic_console/server/dashboard/install_llm_gateway_dashboard.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/dashboard/install_llm_gateway_dashboard.ts
@@ -1,0 +1,128 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { v4 as uuidv4 } from 'uuid';
+import type { CoreStart, Logger } from '@kbn/core/server';
+import { SavedObjectsClient, SavedObjectsErrorHelpers } from '@kbn/core/server';
+import { DASHBOARD_SAVED_OBJECT_TYPE } from '@kbn/dashboard-plugin/common/constants';
+import { ELASTIC_RAMEN_LLM_GATEWAY_TELEMETRY_DATA_STREAM } from '../telemetry/llm_gateway_telemetry';
+import {
+  ELASTIC_RAMEN_LLM_GATEWAY_DASHBOARD_ID,
+  ELASTIC_RAMEN_LLM_GATEWAY_DATA_VIEW_ID,
+} from './llm_gateway_dashboard_constants';
+
+const DATA_VIEW_SAVED_OBJECT_TYPE = 'index-pattern';
+
+const markdownPanel = (content: string, grid: { x: number; y: number; w: number; h: number }) => {
+  const panelId = uuidv4();
+  return {
+    type: 'DASHBOARD_MARKDOWN' as const,
+    embeddableConfig: { content },
+    panelIndex: panelId,
+    gridData: {
+      i: panelId,
+      x: grid.x,
+      y: grid.y,
+      w: grid.w,
+      h: grid.h,
+    },
+  };
+};
+
+/**
+ * Installs a default-space data view + dashboard for LLM gateway telemetry (idempotent).
+ */
+export async function installLlmGatewayDashboardIfMissing(
+  coreStart: CoreStart,
+  logger: Logger
+): Promise<void> {
+  const log = logger.get('llm_gateway_dashboard');
+  const internalRepo = coreStart.savedObjects.createInternalRepository();
+  const soClient = new SavedObjectsClient(internalRepo);
+
+  try {
+    try {
+      await soClient.get(DASHBOARD_SAVED_OBJECT_TYPE, ELASTIC_RAMEN_LLM_GATEWAY_DASHBOARD_ID);
+      log.debug('LLM gateway telemetry dashboard already present; skipping install.');
+      return;
+    } catch (err) {
+      if (!SavedObjectsErrorHelpers.isNotFoundError(err)) {
+        throw err;
+      }
+    }
+
+    try {
+      await soClient.get(DATA_VIEW_SAVED_OBJECT_TYPE, ELASTIC_RAMEN_LLM_GATEWAY_DATA_VIEW_ID);
+    } catch (err) {
+      if (!SavedObjectsErrorHelpers.isNotFoundError(err)) {
+        throw err;
+      }
+      await soClient.create(
+        DATA_VIEW_SAVED_OBJECT_TYPE,
+        {
+          title: ELASTIC_RAMEN_LLM_GATEWAY_TELEMETRY_DATA_STREAM,
+          name: 'Elastic Ramen LLM gateway telemetry',
+          timeFieldName: '@timestamp',
+          allowNoIndex: true,
+        },
+        { id: ELASTIC_RAMEN_LLM_GATEWAY_DATA_VIEW_ID }
+      );
+    }
+
+    const panelsJSON = JSON.stringify([
+      markdownPanel(
+        `## Elastic Ramen — LLM gateway telemetry
+
+Telemetry documents are indexed into data stream \`${ELASTIC_RAMEN_LLM_GATEWAY_TELEMETRY_DATA_STREAM}\`.
+
+**Fields (examples)**  
+- \`gen_ai.usage.*\` — input, output, total, cache vs non-cached prompt tokens  
+- \`elastic_ramen.*\` — connector, model, tool calls, outcome  
+- \`event.outcome\` — success / failure
+
+**Discover** (default space): open Discover, pick data view *Elastic Ramen LLM gateway telemetry*, or filter:
+
+\`\`\`
+data_stream.dataset:"elastic_ramen.llm_gateway"
+\`\`\`
+
+Add **Lens** panels from this data view for charts (requests over time, token sums, cache ratio, etc.).`,
+        { x: 0, y: 0, w: 48, h: 18 }
+      ),
+    ]);
+
+    await soClient.create(
+      DASHBOARD_SAVED_OBJECT_TYPE,
+      {
+        title: 'Elastic Ramen — LLM gateway telemetry',
+        description:
+          'Pre-installed dashboard scaffold for Elastic Ramen OpenAI-compatible gateway usage.',
+        panelsJSON,
+        optionsJSON: JSON.stringify({
+          useMargins: true,
+          syncColors: false,
+          syncCursor: true,
+          syncTooltips: false,
+        }),
+        timeRestore: true,
+        timeFrom: 'now-7d',
+        timeTo: 'now',
+        kibanaSavedObjectMeta: {
+          searchSourceJSON: '{}',
+        },
+      },
+      { id: ELASTIC_RAMEN_LLM_GATEWAY_DASHBOARD_ID }
+    );
+
+    log.info(
+      `Installed LLM gateway telemetry dashboard (id: ${ELASTIC_RAMEN_LLM_GATEWAY_DASHBOARD_ID}).`
+    );
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.error(`Could not install LLM gateway telemetry dashboard: ${message}`);
+  }
+}

--- a/x-pack/platform/plugins/shared/elastic_console/server/dashboard/llm_gateway_dashboard_constants.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/dashboard/llm_gateway_dashboard_constants.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/** Stable saved object id for idempotent install (default space). */
+export const ELASTIC_RAMEN_LLM_GATEWAY_DATA_VIEW_ID = 'elastic-ramen-llm-gateway-telemetry';
+
+export const ELASTIC_RAMEN_LLM_GATEWAY_DASHBOARD_ID = 'elastic-ramen-llm-gateway-telemetry';

--- a/x-pack/platform/plugins/shared/elastic_console/server/dashboard/llm_gateway_dashboard_panels.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/dashboard/llm_gateway_dashboard_panels.ts
@@ -1,0 +1,457 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/** Lens / dashboard panel serialization version (migrations upgrade on load). */
+const DASHBOARD_PANEL_VERSION = '10.2.0';
+
+const indexPatternRefs = (dataViewId: string, layerId: string) => [
+  {
+    type: 'index-pattern' as const,
+    id: dataViewId,
+    name: 'indexpattern-datasource-current-indexpattern',
+  },
+  {
+    type: 'index-pattern' as const,
+    id: dataViewId,
+    name: `indexpattern-datasource-layer-${layerId}`,
+  },
+];
+
+const xyCommonVisualizationChrome = {
+  legend: { isVisible: true, position: 'right' as const },
+  valueLabels: 'hide' as const,
+  fittingFunction: 'None' as const,
+  axisTitlesVisibilitySettings: { x: true, yLeft: true, yRight: true },
+  tickLabelsVisibilitySettings: { x: true, yLeft: true, yRight: true },
+  gridlinesVisibilitySettings: { x: true, yLeft: true, yRight: true },
+};
+
+function lensByValuePanel(args: {
+  title: string;
+  grid: { x: number; y: number; w: number; h: number };
+  panelIndex: string;
+  visualizationType: string;
+  state: Record<string, unknown>;
+  references: Array<{ type: 'index-pattern'; id: string; name: string }>;
+}) {
+  return {
+    version: DASHBOARD_PANEL_VERSION,
+    type: 'lens' as const,
+    gridData: {
+      x: args.grid.x,
+      y: args.grid.y,
+      w: args.grid.w,
+      h: args.grid.h,
+      i: args.panelIndex,
+    },
+    panelIndex: args.panelIndex,
+    embeddableConfig: {
+      title: args.title,
+      hidePanelTitles: false,
+      enhancements: {},
+      attributes: {
+        title: '',
+        description: '',
+        visualizationType: args.visualizationType,
+        type: 'lens',
+        state: args.state,
+        references: args.references,
+      },
+    },
+  };
+}
+
+/**
+ * Builds dashboard panelsJSON for LLM gateway telemetry (Lens by-value, form-based data view datasource).
+ */
+export function buildLlmGatewayDashboardPanelsJson(dataViewId: string): string {
+  // Stable layout ids (one-time install; avoids churn in git diffs)
+  const pCompletions = 'ramen-llm-p1-completions-9142-4c6a-9f3e-8a1b2c3d4e50';
+  const pTokenVol = 'ramen-llm-p2-tokenvol-9142-4c6a-9f3e-8a1b2c3d4e51';
+  const pCache = 'ramen-llm-p3-cache-9142-4c6a-9f3e-8a1b2c3d4e52';
+  const pModels = 'ramen-llm-p4-models-9142-4c6a-9f3e-8a1b2c3d4e53';
+  const pOutcome = 'ramen-llm-p5-outcome-9142-4c6a-9f3e-8a1b2c3d4e54';
+  const pTools = 'ramen-llm-p6-tools-9142-4c6a-9f3e-8a1b2c3d4e55';
+
+  const lCompletions = 'layer-ramen-completions-0a1b2c3d4e5f6789';
+  const lTokenVol = 'layer-ramen-tokenvol-0a1b2c3d4e5f678a';
+  const lCache = 'layer-ramen-cache-0a1b2c3d4e5f678b';
+  const lModels = 'layer-ramen-models-0a1b2c3d4e5f678c';
+  const lOutcome = 'layer-ramen-outcome-0a1b2c3d4e5f678d';
+  const lTools = 'layer-ramen-tools-0a1b2c3d4e5f678e';
+
+  const cTs1 = 'col-ts-comp-11111111-1111-4111-8111-111111111111';
+  const cCnt1 = 'col-cnt-comp-22222222-2222-4222-8222-222222222222';
+  const cTs2 = 'col-ts-tok-33333333-3333-4333-8333-333333333333';
+  const cIn2 = 'col-sum-in-44444444-4444-4444-8444-444444444444';
+  const cOut2 = 'col-sum-out-55555555-5555-4555-8555-555555555555';
+  const cTs3 = 'col-ts-cache-66666666-6666-4666-8666-666666666666';
+  const cCache3 = 'col-sum-cache-77777777-7777-4777-8777-777777777777';
+  const cUnc3 = 'col-sum-unc-88888888-8888-4888-8888-888888888888';
+  const cModel4 = 'col-terms-model-99999999-9999-4999-8999-999999999999';
+  const cCnt4 = 'col-cnt-model-aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+  const cOutcome5 = 'col-terms-out-bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+  const cCnt5 = 'col-cnt-out-cccccccc-cccc-4ccc-8ccc-cccccccccccc';
+  const cTs6 = 'col-ts-tools-dddddddd-dddd-4ddd-8ddd-dddddddddddd';
+  const cAvgTools6 = 'col-avg-tools-eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee';
+
+  const completions = lensByValuePanel({
+    title: 'Completions over time',
+    grid: { x: 0, y: 0, w: 48, h: 11 },
+    panelIndex: pCompletions,
+    visualizationType: 'lnsXY',
+    references: indexPatternRefs(dataViewId, lCompletions),
+    state: {
+      datasourceStates: {
+        formBased: {
+          layers: {
+            [lCompletions]: {
+              columnOrder: [cTs1, cCnt1],
+              columns: {
+                [cTs1]: {
+                  dataType: 'date',
+                  isBucketed: true,
+                  label: '@timestamp',
+                  operationType: 'date_histogram',
+                  params: { interval: 'auto', includeEmptyRows: false },
+                  scale: 'interval',
+                  sourceField: '@timestamp',
+                },
+                [cCnt1]: {
+                  dataType: 'number',
+                  isBucketed: false,
+                  label: 'Count of records',
+                  operationType: 'count',
+                  scale: 'ratio',
+                  sourceField: 'Records',
+                },
+              },
+              incompleteColumns: {},
+            },
+          },
+        },
+      },
+      filters: [],
+      query: { language: 'kuery', query: '' },
+      visualization: {
+        ...xyCommonVisualizationChrome,
+        preferredSeriesType: 'line',
+        layers: [
+          {
+            layerId: lCompletions,
+            layerType: 'data',
+            accessors: [cCnt1],
+            seriesType: 'line',
+            xAccessor: cTs1,
+          },
+        ],
+      },
+    },
+  });
+
+  const tokenVolume = lensByValuePanel({
+    title: 'Input / output tokens (sum over time)',
+    grid: { x: 0, y: 11, w: 48, h: 12 },
+    panelIndex: pTokenVol,
+    visualizationType: 'lnsXY',
+    references: indexPatternRefs(dataViewId, lTokenVol),
+    state: {
+      datasourceStates: {
+        formBased: {
+          layers: {
+            [lTokenVol]: {
+              columnOrder: [cTs2, cIn2, cOut2],
+              columns: {
+                [cTs2]: {
+                  dataType: 'date',
+                  isBucketed: true,
+                  label: '@timestamp',
+                  operationType: 'date_histogram',
+                  params: { interval: 'auto', includeEmptyRows: false },
+                  scale: 'interval',
+                  sourceField: '@timestamp',
+                },
+                [cIn2]: {
+                  dataType: 'number',
+                  isBucketed: false,
+                  label: 'Sum of input tokens',
+                  operationType: 'sum',
+                  scale: 'ratio',
+                  sourceField: 'gen_ai.usage.input_tokens',
+                },
+                [cOut2]: {
+                  dataType: 'number',
+                  isBucketed: false,
+                  label: 'Sum of output tokens',
+                  operationType: 'sum',
+                  scale: 'ratio',
+                  sourceField: 'gen_ai.usage.output_tokens',
+                },
+              },
+              incompleteColumns: {},
+            },
+          },
+        },
+      },
+      filters: [],
+      query: { language: 'kuery', query: '' },
+      visualization: {
+        ...xyCommonVisualizationChrome,
+        preferredSeriesType: 'area',
+        layers: [
+          {
+            layerId: lTokenVol,
+            layerType: 'data',
+            accessors: [cIn2, cOut2],
+            seriesType: 'area',
+            xAccessor: cTs2,
+          },
+        ],
+      },
+    },
+  });
+
+  const cacheSplit = lensByValuePanel({
+    title: 'Cached vs non-cached prompt tokens (sum)',
+    grid: { x: 0, y: 23, w: 24, h: 12 },
+    panelIndex: pCache,
+    visualizationType: 'lnsXY',
+    references: indexPatternRefs(dataViewId, lCache),
+    state: {
+      datasourceStates: {
+        formBased: {
+          layers: {
+            [lCache]: {
+              columnOrder: [cTs3, cCache3, cUnc3],
+              columns: {
+                [cTs3]: {
+                  dataType: 'date',
+                  isBucketed: true,
+                  label: '@timestamp',
+                  operationType: 'date_histogram',
+                  params: { interval: 'auto', includeEmptyRows: false },
+                  scale: 'interval',
+                  sourceField: '@timestamp',
+                },
+                [cCache3]: {
+                  dataType: 'number',
+                  isBucketed: false,
+                  label: 'Sum of cache_read_tokens',
+                  operationType: 'sum',
+                  scale: 'ratio',
+                  sourceField: 'gen_ai.usage.cache_read_tokens',
+                },
+                [cUnc3]: {
+                  dataType: 'number',
+                  isBucketed: false,
+                  label: 'Sum of non_cached_input_tokens',
+                  operationType: 'sum',
+                  scale: 'ratio',
+                  sourceField: 'gen_ai.usage.non_cached_input_tokens',
+                },
+              },
+              incompleteColumns: {},
+            },
+          },
+        },
+      },
+      filters: [],
+      query: { language: 'kuery', query: '' },
+      visualization: {
+        ...xyCommonVisualizationChrome,
+        preferredSeriesType: 'area',
+        layers: [
+          {
+            layerId: lCache,
+            layerType: 'data',
+            accessors: [cCache3, cUnc3],
+            seriesType: 'area',
+            xAccessor: cTs3,
+          },
+        ],
+      },
+    },
+  });
+
+  const topModels = lensByValuePanel({
+    title: 'Top request models',
+    grid: { x: 24, y: 23, w: 24, h: 12 },
+    panelIndex: pModels,
+    visualizationType: 'lnsXY',
+    references: indexPatternRefs(dataViewId, lModels),
+    state: {
+      datasourceStates: {
+        formBased: {
+          layers: {
+            [lModels]: {
+              columnOrder: [cModel4, cCnt4],
+              columns: {
+                [cModel4]: {
+                  dataType: 'string',
+                  isBucketed: true,
+                  label: 'Top values of elastic_ramen.model',
+                  operationType: 'terms',
+                  params: {
+                    size: 10,
+                    orderBy: { type: 'column', columnId: cCnt4 },
+                    orderDirection: 'desc',
+                    otherBucket: true,
+                    missingBucket: false,
+                  },
+                  scale: 'ordinal',
+                  sourceField: 'elastic_ramen.model',
+                },
+                [cCnt4]: {
+                  dataType: 'number',
+                  isBucketed: false,
+                  label: 'Count of records',
+                  operationType: 'count',
+                  scale: 'ratio',
+                  sourceField: 'Records',
+                },
+              },
+              incompleteColumns: {},
+            },
+          },
+        },
+      },
+      filters: [],
+      query: { language: 'kuery', query: '' },
+      visualization: {
+        ...xyCommonVisualizationChrome,
+        preferredSeriesType: 'bar_stacked',
+        layers: [
+          {
+            layerId: lModels,
+            layerType: 'data',
+            accessors: [cCnt4],
+            seriesType: 'bar_stacked',
+            xAccessor: cModel4,
+          },
+        ],
+      },
+    },
+  });
+
+  const outcomeDonut = lensByValuePanel({
+    title: 'Outcomes',
+    grid: { x: 0, y: 35, w: 16, h: 12 },
+    panelIndex: pOutcome,
+    visualizationType: 'lnsPie',
+    references: indexPatternRefs(dataViewId, lOutcome),
+    state: {
+      datasourceStates: {
+        formBased: {
+          layers: {
+            [lOutcome]: {
+              columnOrder: [cOutcome5, cCnt5],
+              columns: {
+                [cOutcome5]: {
+                  dataType: 'string',
+                  isBucketed: true,
+                  label: 'event.outcome',
+                  operationType: 'terms',
+                  params: {
+                    size: 5,
+                    orderBy: { type: 'column', columnId: cCnt5 },
+                    orderDirection: 'desc',
+                    otherBucket: true,
+                    missingBucket: false,
+                  },
+                  scale: 'ordinal',
+                  sourceField: 'event.outcome',
+                },
+                [cCnt5]: {
+                  dataType: 'number',
+                  isBucketed: false,
+                  label: 'Count of records',
+                  operationType: 'count',
+                  scale: 'ratio',
+                  sourceField: 'Records',
+                },
+              },
+              incompleteColumns: {},
+            },
+          },
+        },
+      },
+      filters: [],
+      query: { language: 'kuery', query: '' },
+      visualization: {
+        shape: 'donut',
+        layers: [
+          {
+            layerId: lOutcome,
+            layerType: 'data',
+            primaryGroups: [cOutcome5],
+            metrics: [cCnt5],
+            numberDisplay: 'percent',
+            categoryDisplay: 'default',
+            legendDisplay: 'default',
+            nestedLegend: false,
+          },
+        ],
+      },
+    },
+  });
+
+  const toolCalls = lensByValuePanel({
+    title: 'Average tool calls per completion',
+    grid: { x: 16, y: 35, w: 32, h: 12 },
+    panelIndex: pTools,
+    visualizationType: 'lnsXY',
+    references: indexPatternRefs(dataViewId, lTools),
+    state: {
+      datasourceStates: {
+        formBased: {
+          layers: {
+            [lTools]: {
+              columnOrder: [cTs6, cAvgTools6],
+              columns: {
+                [cTs6]: {
+                  dataType: 'date',
+                  isBucketed: true,
+                  label: '@timestamp',
+                  operationType: 'date_histogram',
+                  params: { interval: 'auto', includeEmptyRows: false },
+                  scale: 'interval',
+                  sourceField: '@timestamp',
+                },
+                [cAvgTools6]: {
+                  dataType: 'number',
+                  isBucketed: false,
+                  label: 'Average of elastic_ramen.tool_call_count',
+                  operationType: 'average',
+                  scale: 'ratio',
+                  sourceField: 'elastic_ramen.tool_call_count',
+                },
+              },
+              incompleteColumns: {},
+            },
+          },
+        },
+      },
+      filters: [],
+      query: { language: 'kuery', query: '' },
+      visualization: {
+        ...xyCommonVisualizationChrome,
+        preferredSeriesType: 'line',
+        layers: [
+          {
+            layerId: lTools,
+            layerType: 'data',
+            accessors: [cAvgTools6],
+            seriesType: 'line',
+            xAccessor: cTs6,
+          },
+        ],
+      },
+    },
+  });
+
+  return JSON.stringify([completions, tokenVolume, cacheSplit, topModels, outcomeDonut, toolCalls]);
+}

--- a/x-pack/platform/plugins/shared/elastic_console/server/lib/openai_format.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/lib/openai_format.ts
@@ -274,6 +274,9 @@ export const createFinalChunk = (
       prompt_tokens: tokenCount.prompt,
       completion_tokens: tokenCount.completion,
       total_tokens: tokenCount.total,
+      ...(tokenCount.cached !== undefined
+        ? { prompt_tokens_details: { cached_tokens: tokenCount.cached } }
+        : {}),
     };
   }
 
@@ -322,6 +325,9 @@ export const inferenceResponseToOpenAi = (
           prompt_tokens: response.tokens.prompt,
           completion_tokens: response.tokens.completion,
           total_tokens: response.tokens.total,
+          ...(response.tokens.cached !== undefined
+            ? { prompt_tokens_details: { cached_tokens: response.tokens.cached } }
+            : {}),
         }
       : undefined,
   };

--- a/x-pack/platform/plugins/shared/elastic_console/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/plugin.ts
@@ -15,6 +15,11 @@ import type {
 } from './types';
 import { registerUiSettings } from './ui_settings';
 import { registerRoutes } from './routes';
+import { installLlmGatewayDashboardIfMissing } from './dashboard/install_llm_gateway_dashboard';
+import {
+  createLlmGatewayTelemetryWriter,
+  registerLlmGatewayTelemetryDataStream,
+} from './telemetry/llm_gateway_telemetry';
 
 export class ElasticConsolePlugin
   implements
@@ -26,6 +31,8 @@ export class ElasticConsolePlugin
     >
 {
   private logger: Logger;
+  private llmGatewayTelemetryObserved = false;
+  private llmGatewayDashboardInstall: Promise<void> | undefined;
 
   constructor(context: PluginInitializerContext) {
     this.logger = context.logger.get();
@@ -36,6 +43,16 @@ export class ElasticConsolePlugin
     setupDeps: ElasticConsoleSetupDependencies
   ): ElasticConsolePluginSetup {
     registerUiSettings(coreSetup);
+    registerLlmGatewayTelemetryDataStream(coreSetup.dataStreams);
+
+    const pluginThis = this;
+    const writeLlmGatewayTelemetry = createLlmGatewayTelemetryWriter({
+      logger: this.logger,
+      coreSetup,
+      onFirstGatewayUse: () => {
+        pluginThis.onFirstLlmGatewayTelemetryObservation(coreSetup);
+      },
+    });
 
     const router = coreSetup.http.createRouter();
 
@@ -44,6 +61,7 @@ export class ElasticConsolePlugin
       coreSetup,
       logger: this.logger,
       cloud: setupDeps.cloud,
+      writeLlmGatewayTelemetry,
     });
 
     return {};
@@ -54,4 +72,22 @@ export class ElasticConsolePlugin
   }
 
   stop() {}
+
+  /**
+   * First Ramen LLM gateway traffic: kick off a one-time background check/install for the telemetry dashboard.
+   */
+  private onFirstLlmGatewayTelemetryObservation(
+    coreSetup: CoreSetup<ElasticConsoleStartDependencies, ElasticConsolePluginStart>
+  ): void {
+    if (this.llmGatewayTelemetryObserved) {
+      return;
+    }
+    this.llmGatewayTelemetryObserved = true;
+
+    if (!this.llmGatewayDashboardInstall) {
+      this.llmGatewayDashboardInstall = coreSetup
+        .getStartServices()
+        .then(([coreStart]) => installLlmGatewayDashboardIfMissing(coreStart, this.logger));
+    }
+  }
 }

--- a/x-pack/platform/plugins/shared/elastic_console/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/plugin.ts
@@ -16,10 +16,7 @@ import type {
 import { registerUiSettings } from './ui_settings';
 import { registerRoutes } from './routes';
 import { installLlmGatewayDashboardIfMissing } from './dashboard/install_llm_gateway_dashboard';
-import {
-  createLlmGatewayTelemetryWriter,
-  registerLlmGatewayTelemetryDataStream,
-} from './telemetry/llm_gateway_telemetry';
+import { createLlmGatewayTelemetryWriter } from './telemetry/llm_gateway_telemetry';
 
 export class ElasticConsolePlugin
   implements
@@ -43,12 +40,10 @@ export class ElasticConsolePlugin
     setupDeps: ElasticConsoleSetupDependencies
   ): ElasticConsolePluginSetup {
     registerUiSettings(coreSetup);
-    registerLlmGatewayTelemetryDataStream(coreSetup.dataStreams);
 
     const pluginThis = this;
     const writeLlmGatewayTelemetry = createLlmGatewayTelemetryWriter({
       logger: this.logger,
-      coreSetup,
       onFirstGatewayUse: () => {
         pluginThis.onFirstLlmGatewayTelemetryObservation(coreSetup);
       },

--- a/x-pack/platform/plugins/shared/elastic_console/server/routes/chat_completions.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/routes/chat_completions.ts
@@ -8,7 +8,7 @@
 import { v4 as uuidv4 } from 'uuid';
 import { schema } from '@kbn/config-schema';
 import { PassThrough } from 'stream';
-import type { CoreSetup, IRouter, Logger } from '@kbn/core/server';
+import type { CoreSetup, ElasticsearchClient, IRouter, Logger } from '@kbn/core/server';
 import {
   ChatCompletionEventType,
   type ChatCompletionChunkEvent,
@@ -125,6 +125,8 @@ export const registerChatCompletionsRoute = ({
     },
     async (ctx, request, response) => {
       const gatewayLogger = logger.get('llm_gateway');
+      const coreContext = await ctx.core;
+      const esClient = coreContext.elasticsearch.client.asCurrentUser;
       try {
         const [coreStart, { inference }] = await coreSetup.getStartServices();
 
@@ -172,6 +174,7 @@ export const registerChatCompletionsRoute = ({
             response,
             logger: gatewayLogger,
             writeLlmGatewayTelemetry,
+            esClient,
           });
         }
 
@@ -188,22 +191,26 @@ export const registerChatCompletionsRoute = ({
           response,
           logger: gatewayLogger,
           writeLlmGatewayTelemetry,
+          esClient,
         });
       } catch (error) {
         logger.error(`Chat completions error: ${error.message}`);
         // Return an OpenAI-compatible error response so AI SDKs can parse it
         const errorBody = createErrorResponse(error.message, request.body.model || 'default');
-        writeLlmGatewayTelemetry({
-          streaming: Boolean(request.body.stream),
-          connectorId:
-            typeof request.headers['x-connector-id'] === 'string'
-              ? request.headers['x-connector-id']
-              : request.body.model || 'default',
-          model: request.body.model || 'default',
-          toolCallCount: 0,
-          outcome: 'error',
-          errorMessage: error.message,
-        });
+        writeLlmGatewayTelemetry(
+          {
+            streaming: Boolean(request.body.stream),
+            connectorId:
+              typeof request.headers['x-connector-id'] === 'string'
+                ? request.headers['x-connector-id']
+                : request.body.model || 'default',
+            model: request.body.model || 'default',
+            toolCallCount: 0,
+            outcome: 'error',
+            errorMessage: error.message,
+          },
+          esClient
+        );
         return response.ok({
           headers: { 'Content-Type': 'application/json' },
           body: errorBody,
@@ -244,6 +251,7 @@ const handleStreamingRequest = async ({
   response,
   logger: routeLogger,
   writeLlmGatewayTelemetry,
+  esClient,
 }: {
   client: any;
   connectorId: string;
@@ -257,6 +265,7 @@ const handleStreamingRequest = async ({
   response: any;
   logger: Logger;
   writeLlmGatewayTelemetry: LlmGatewayTelemetryWriter;
+  esClient: ElasticsearchClient;
 }) => {
   const completionId = `chatcmpl-${uuidv4()}`;
   const passThrough = new PassThrough();
@@ -297,15 +306,18 @@ const handleStreamingRequest = async ({
     },
     error: (error: Error) => {
       routeLogger.error(`Streaming error: ${error.message}`);
-      writeLlmGatewayTelemetry({
-        streaming: true,
-        connectorId,
-        model,
-        toolCallCount: completionMessage?.toolCalls?.length ?? 0,
-        tokens: tokenCount,
-        outcome: 'error',
-        errorMessage: error.message,
-      });
+      writeLlmGatewayTelemetry(
+        {
+          streaming: true,
+          connectorId,
+          model,
+          toolCallCount: completionMessage?.toolCalls?.length ?? 0,
+          tokens: tokenCount,
+          outcome: 'error',
+          errorMessage: error.message,
+        },
+        esClient
+      );
       // Emit a valid OpenAI delta chunk with error content so AI SDKs can parse it
       const errorContentChunk = {
         id: completionId,
@@ -327,14 +339,17 @@ const handleStreamingRequest = async ({
       passThrough.end();
     },
     complete: () => {
-      writeLlmGatewayTelemetry({
-        streaming: true,
-        connectorId,
-        model,
-        toolCallCount: completionMessage?.toolCalls?.length ?? 0,
-        tokens: tokenCount,
-        outcome: 'success',
-      });
+      writeLlmGatewayTelemetry(
+        {
+          streaming: true,
+          connectorId,
+          model,
+          toolCallCount: completionMessage?.toolCalls?.length ?? 0,
+          tokens: tokenCount,
+          outcome: 'success',
+        },
+        esClient
+      );
       const finalChunk = createFinalChunk(model, completionId, hasToolCalls, tokenCount);
       passThrough.write(`data: ${JSON.stringify(finalChunk)}\n\n`);
       passThrough.write('data: [DONE]\n\n');
@@ -367,6 +382,7 @@ const handleNonStreamingRequest = async ({
   response,
   logger: routeLogger,
   writeLlmGatewayTelemetry,
+  esClient,
 }: {
   client: any;
   connectorId: string;
@@ -380,6 +396,7 @@ const handleNonStreamingRequest = async ({
   response: any;
   logger: Logger;
   writeLlmGatewayTelemetry: LlmGatewayTelemetryWriter;
+  esClient: ElasticsearchClient;
 }) => {
   try {
     const result = await client.chatComplete({
@@ -393,14 +410,17 @@ const handleNonStreamingRequest = async ({
     });
 
     const openAiResponse = inferenceResponseToOpenAi(result, model);
-    writeLlmGatewayTelemetry({
-      streaming: false,
-      connectorId,
-      model,
-      toolCallCount: result.toolCalls.length,
-      tokens: result.tokens,
-      outcome: 'success',
-    });
+    writeLlmGatewayTelemetry(
+      {
+        streaming: false,
+        connectorId,
+        model,
+        toolCallCount: result.toolCalls.length,
+        tokens: result.tokens,
+        outcome: 'success',
+      },
+      esClient
+    );
 
     return response.ok({
       headers: {
@@ -410,14 +430,17 @@ const handleNonStreamingRequest = async ({
     });
   } catch (error) {
     routeLogger.error(`Non-streaming completion error: ${error.message}`);
-    writeLlmGatewayTelemetry({
-      streaming: false,
-      connectorId,
-      model,
-      toolCallCount: 0,
-      outcome: 'error',
-      errorMessage: error.message,
-    });
+    writeLlmGatewayTelemetry(
+      {
+        streaming: false,
+        connectorId,
+        model,
+        toolCallCount: 0,
+        outcome: 'error',
+        errorMessage: error.message,
+      },
+      esClient
+    );
     return response.ok({
       headers: { 'Content-Type': 'application/json' },
       body: createErrorResponse(error.message, model),

--- a/x-pack/platform/plugins/shared/elastic_console/server/routes/chat_completions.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/routes/chat_completions.ts
@@ -12,7 +12,9 @@ import type { CoreSetup, IRouter, Logger } from '@kbn/core/server';
 import {
   ChatCompletionEventType,
   type ChatCompletionChunkEvent,
+  type ChatCompletionMessageEvent,
   type ChatCompletionTokenCount,
+  isChatCompletionMessageEvent,
 } from '@kbn/inference-common';
 import type { ElasticConsolePluginStart, ElasticConsoleStartDependencies } from '../types';
 import {
@@ -26,6 +28,7 @@ import {
 } from '../lib/openai_format';
 import { resolveConnector } from '../lib/resolve_connector';
 import { isElasticConsoleEnabled } from './is_enabled';
+import type { LlmGatewayTelemetryWriter } from '../telemetry/llm_gateway_telemetry';
 
 const SOCKET_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
 
@@ -33,10 +36,12 @@ export const registerChatCompletionsRoute = ({
   router,
   coreSetup,
   logger,
+  writeLlmGatewayTelemetry,
 }: {
   router: IRouter;
   coreSetup: CoreSetup<ElasticConsoleStartDependencies, ElasticConsolePluginStart>;
   logger: Logger;
+  writeLlmGatewayTelemetry: LlmGatewayTelemetryWriter;
 }) => {
   router.post(
     {
@@ -119,6 +124,7 @@ export const registerChatCompletionsRoute = ({
       },
     },
     async (ctx, request, response) => {
+      const gatewayLogger = logger.get('llm_gateway');
       try {
         const [coreStart, { inference }] = await coreSetup.getStartServices();
 
@@ -164,7 +170,8 @@ export const registerChatCompletionsRoute = ({
             model,
             request,
             response,
-            logger,
+            logger: gatewayLogger,
+            writeLlmGatewayTelemetry,
           });
         }
 
@@ -179,12 +186,24 @@ export const registerChatCompletionsRoute = ({
           model,
           request,
           response,
-          logger,
+          logger: gatewayLogger,
+          writeLlmGatewayTelemetry,
         });
       } catch (error) {
         logger.error(`Chat completions error: ${error.message}`);
         // Return an OpenAI-compatible error response so AI SDKs can parse it
         const errorBody = createErrorResponse(error.message, request.body.model || 'default');
+        writeLlmGatewayTelemetry({
+          streaming: Boolean(request.body.stream),
+          connectorId:
+            typeof request.headers['x-connector-id'] === 'string'
+              ? request.headers['x-connector-id']
+              : request.body.model || 'default',
+          model: request.body.model || 'default',
+          toolCallCount: 0,
+          outcome: 'error',
+          errorMessage: error.message,
+        });
         return response.ok({
           headers: { 'Content-Type': 'application/json' },
           body: errorBody,
@@ -224,6 +243,7 @@ const handleStreamingRequest = async ({
   request,
   response,
   logger: routeLogger,
+  writeLlmGatewayTelemetry,
 }: {
   client: any;
   connectorId: string;
@@ -236,11 +256,13 @@ const handleStreamingRequest = async ({
   request: any;
   response: any;
   logger: Logger;
+  writeLlmGatewayTelemetry: LlmGatewayTelemetryWriter;
 }) => {
   const completionId = `chatcmpl-${uuidv4()}`;
   const passThrough = new PassThrough();
   let hasToolCalls = false;
   let tokenCount: ChatCompletionTokenCount | undefined;
+  let completionMessage: ChatCompletionMessageEvent | undefined;
 
   const abortController = new AbortController();
   request.events.aborted$.subscribe(() => {
@@ -269,10 +291,21 @@ const handleStreamingRequest = async ({
         passThrough.write(`data: ${JSON.stringify(openAiChunk)}\n\n`);
       } else if (event.type === ChatCompletionEventType.ChatCompletionTokenCount) {
         tokenCount = event.tokens;
+      } else if (isChatCompletionMessageEvent(event)) {
+        completionMessage = event;
       }
     },
     error: (error: Error) => {
       routeLogger.error(`Streaming error: ${error.message}`);
+      writeLlmGatewayTelemetry({
+        streaming: true,
+        connectorId,
+        model,
+        toolCallCount: completionMessage?.toolCalls?.length ?? 0,
+        tokens: tokenCount,
+        outcome: 'error',
+        errorMessage: error.message,
+      });
       // Emit a valid OpenAI delta chunk with error content so AI SDKs can parse it
       const errorContentChunk = {
         id: completionId,
@@ -294,6 +327,14 @@ const handleStreamingRequest = async ({
       passThrough.end();
     },
     complete: () => {
+      writeLlmGatewayTelemetry({
+        streaming: true,
+        connectorId,
+        model,
+        toolCallCount: completionMessage?.toolCalls?.length ?? 0,
+        tokens: tokenCount,
+        outcome: 'success',
+      });
       const finalChunk = createFinalChunk(model, completionId, hasToolCalls, tokenCount);
       passThrough.write(`data: ${JSON.stringify(finalChunk)}\n\n`);
       passThrough.write('data: [DONE]\n\n');
@@ -325,6 +366,7 @@ const handleNonStreamingRequest = async ({
   request,
   response,
   logger: routeLogger,
+  writeLlmGatewayTelemetry,
 }: {
   client: any;
   connectorId: string;
@@ -337,6 +379,7 @@ const handleNonStreamingRequest = async ({
   request: any;
   response: any;
   logger: Logger;
+  writeLlmGatewayTelemetry: LlmGatewayTelemetryWriter;
 }) => {
   try {
     const result = await client.chatComplete({
@@ -350,6 +393,14 @@ const handleNonStreamingRequest = async ({
     });
 
     const openAiResponse = inferenceResponseToOpenAi(result, model);
+    writeLlmGatewayTelemetry({
+      streaming: false,
+      connectorId,
+      model,
+      toolCallCount: result.toolCalls.length,
+      tokens: result.tokens,
+      outcome: 'success',
+    });
 
     return response.ok({
       headers: {
@@ -359,6 +410,14 @@ const handleNonStreamingRequest = async ({
     });
   } catch (error) {
     routeLogger.error(`Non-streaming completion error: ${error.message}`);
+    writeLlmGatewayTelemetry({
+      streaming: false,
+      connectorId,
+      model,
+      toolCallCount: 0,
+      outcome: 'error',
+      errorMessage: error.message,
+    });
     return response.ok({
       headers: { 'Content-Type': 'application/json' },
       body: createErrorResponse(error.message, model),

--- a/x-pack/platform/plugins/shared/elastic_console/server/routes/index.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/routes/index.ts
@@ -8,6 +8,7 @@
 import type { CoreSetup, IRouter, Logger } from '@kbn/core/server';
 import type { CloudSetup } from '@kbn/cloud-plugin/server';
 import type { ElasticConsolePluginStart, ElasticConsoleStartDependencies } from '../types';
+import type { LlmGatewayTelemetryWriter } from '../telemetry/llm_gateway_telemetry';
 import { registerChatCompletionsRoute } from './chat_completions';
 import { registerConversationRoutes } from './conversations';
 import { registerModelsRoute } from './models';
@@ -18,13 +19,15 @@ export const registerRoutes = ({
   coreSetup,
   logger,
   cloud,
+  writeLlmGatewayTelemetry,
 }: {
   router: IRouter;
   coreSetup: CoreSetup<ElasticConsoleStartDependencies, ElasticConsolePluginStart>;
   logger: Logger;
   cloud?: CloudSetup;
+  writeLlmGatewayTelemetry: LlmGatewayTelemetryWriter;
 }) => {
-  registerChatCompletionsRoute({ router, coreSetup, logger });
+  registerChatCompletionsRoute({ router, coreSetup, logger, writeLlmGatewayTelemetry });
   registerConversationRoutes({ router, coreSetup, logger });
   registerModelsRoute({ router, coreSetup, logger });
   registerSetupRoute({ router, coreSetup, logger, cloud });

--- a/x-pack/platform/plugins/shared/elastic_console/server/telemetry/llm_gateway_telemetry.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/telemetry/llm_gateway_telemetry.ts
@@ -5,85 +5,13 @@
  * 2.0.
  */
 
-import type { CoreSetup } from '@kbn/core/server';
-import type {
-  DataStreamDefinition,
-  DataStreamsSetup,
-  IDataStreamClient,
-} from '@kbn/core-data-streams-server';
+import type { ElasticsearchClient } from '@kbn/core/server';
 import type { ChatCompletionTokenCount } from '@kbn/inference-common';
 import type { Logger } from '@kbn/logging';
-import type { GetFieldsOf, MappingsDefinition } from '@kbn/es-mappings';
-import { mappings } from '@kbn/es-mappings';
-import type { ElasticConsolePluginStart, ElasticConsoleStartDependencies } from '../types';
 
 /** Logs data stream on the Kibana Elasticsearch cluster (not Kibana server log files). */
 export const ELASTIC_RAMEN_LLM_GATEWAY_TELEMETRY_DATA_STREAM =
   'logs-elastic_ramen.llm_gateway-default';
-
-/** Bump when changing mappings or template settings. */
-const LLM_GATEWAY_TELEMETRY_DATA_STREAM_VERSION = 2;
-
-const llmGatewayTelemetryMappings = {
-  dynamic: false,
-  properties: {
-    '@timestamp': mappings.date(),
-    message: mappings.text(),
-    tags: mappings.keyword(),
-    data_stream: mappings.object({
-      properties: {
-        type: mappings.keyword(),
-        dataset: mappings.keyword(),
-        namespace: mappings.keyword(),
-      },
-    }),
-    event: mappings.object({
-      properties: {
-        action: mappings.keyword(),
-        kind: mappings.keyword(),
-        dataset: mappings.keyword(),
-        outcome: mappings.keyword(),
-      },
-    }),
-    gen_ai: mappings.object({
-      properties: {
-        system: mappings.keyword(),
-        operation: mappings.object({
-          properties: {
-            name: mappings.keyword(),
-          },
-        }),
-        request: mappings.object({
-          properties: {
-            model: mappings.keyword(),
-          },
-        }),
-        usage: mappings.object({
-          properties: {
-            input_tokens: mappings.long(),
-            output_tokens: mappings.long(),
-            total_tokens: mappings.long(),
-            /** Subset of prompt tokens served from the model provider cache (e.g. OpenAI `cached_tokens`). */
-            cache_read_tokens: mappings.long(),
-            /** Prompt tokens not served from cache: `input_tokens - cache_read_tokens` when cache is reported. */
-            non_cached_input_tokens: mappings.long(),
-            thinking_tokens: mappings.long(),
-          },
-        }),
-      },
-    }),
-    elastic_ramen: mappings.object({
-      properties: {
-        connector_id: mappings.keyword(),
-        model: mappings.keyword(),
-        streaming: mappings.boolean(),
-        tool_call_count: mappings.long(),
-        outcome: mappings.keyword(),
-        error: mappings.keyword({ ignore_above: 4096 }),
-      },
-    }),
-  },
-} satisfies MappingsDefinition;
 
 export interface LlmGatewayTelemetryParams {
   streaming: boolean;
@@ -95,8 +23,7 @@ export interface LlmGatewayTelemetryParams {
   errorMessage?: string;
 }
 
-export interface LlmGatewayTelemetryDocument
-  extends GetFieldsOf<typeof llmGatewayTelemetryMappings> {
+export interface LlmGatewayTelemetryDocument {
   '@timestamp': string;
   message: string;
   tags: string[];
@@ -132,24 +59,6 @@ export interface LlmGatewayTelemetryDocument
     outcome: string;
     error?: string;
   };
-}
-
-const llmGatewayTelemetryDataStreamDefinition: DataStreamDefinition<
-  typeof llmGatewayTelemetryMappings
-> = {
-  name: ELASTIC_RAMEN_LLM_GATEWAY_TELEMETRY_DATA_STREAM,
-  version: LLM_GATEWAY_TELEMETRY_DATA_STREAM_VERSION,
-  hidden: false,
-  template: {
-    mappings: llmGatewayTelemetryMappings,
-    settings: {
-      hidden: false,
-    },
-  },
-};
-
-export function registerLlmGatewayTelemetryDataStream(dataStreams: DataStreamsSetup): void {
-  dataStreams.registerDataStream(llmGatewayTelemetryDataStreamDefinition);
 }
 
 export function buildLlmGatewayTelemetryDocument(
@@ -204,49 +113,30 @@ export function buildLlmGatewayTelemetryDocument(
   return doc;
 }
 
-export type LlmGatewayTelemetryWriter = (params: LlmGatewayTelemetryParams) => void;
+export type LlmGatewayTelemetryWriter = (
+  params: LlmGatewayTelemetryParams,
+  esClient: ElasticsearchClient
+) => void;
 
 export function createLlmGatewayTelemetryWriter({
   logger,
-  coreSetup,
   onFirstGatewayUse,
 }: {
   logger: Logger;
-  coreSetup: CoreSetup<ElasticConsoleStartDependencies, ElasticConsolePluginStart>;
   onFirstGatewayUse?: () => void;
 }): LlmGatewayTelemetryWriter {
   let firstInvocation = true;
-  let clientPromise: Promise<
-    IDataStreamClient<typeof llmGatewayTelemetryMappings, LlmGatewayTelemetryDocument>
-  > | null = null;
 
-  const getClient = (): Promise<
-    IDataStreamClient<typeof llmGatewayTelemetryMappings, LlmGatewayTelemetryDocument>
-  > => {
-    if (!clientPromise) {
-      clientPromise = coreSetup
-        .getStartServices()
-        .then(([coreStart]) =>
-          coreStart.dataStreams.initializeClient<
-            typeof llmGatewayTelemetryMappings,
-            LlmGatewayTelemetryDocument
-          >(ELASTIC_RAMEN_LLM_GATEWAY_TELEMETRY_DATA_STREAM)
-        );
-    }
-    return clientPromise;
-  };
-
-  return (params: LlmGatewayTelemetryParams) => {
+  return (params: LlmGatewayTelemetryParams, esClient: ElasticsearchClient) => {
     if (firstInvocation) {
       firstInvocation = false;
       onFirstGatewayUse?.();
     }
-    void getClient()
-      .then((client) =>
-        client.create({
-          documents: [buildLlmGatewayTelemetryDocument(params)],
-        })
-      )
+    void esClient
+      .index({
+        index: ELASTIC_RAMEN_LLM_GATEWAY_TELEMETRY_DATA_STREAM,
+        document: buildLlmGatewayTelemetryDocument(params),
+      })
       .catch((err: Error) =>
         logger.error(`Failed to index Elastic Ramen LLM gateway telemetry: ${err.message}`)
       );

--- a/x-pack/platform/plugins/shared/elastic_console/server/telemetry/llm_gateway_telemetry.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/telemetry/llm_gateway_telemetry.ts
@@ -1,0 +1,254 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { CoreSetup } from '@kbn/core/server';
+import type {
+  DataStreamDefinition,
+  DataStreamsSetup,
+  IDataStreamClient,
+} from '@kbn/core-data-streams-server';
+import type { ChatCompletionTokenCount } from '@kbn/inference-common';
+import type { Logger } from '@kbn/logging';
+import type { GetFieldsOf, MappingsDefinition } from '@kbn/es-mappings';
+import { mappings } from '@kbn/es-mappings';
+import type { ElasticConsolePluginStart, ElasticConsoleStartDependencies } from '../types';
+
+/** Logs data stream on the Kibana Elasticsearch cluster (not Kibana server log files). */
+export const ELASTIC_RAMEN_LLM_GATEWAY_TELEMETRY_DATA_STREAM =
+  'logs-elastic_ramen.llm_gateway-default';
+
+/** Bump when changing mappings or template settings. */
+const LLM_GATEWAY_TELEMETRY_DATA_STREAM_VERSION = 2;
+
+const llmGatewayTelemetryMappings = {
+  dynamic: false,
+  properties: {
+    '@timestamp': mappings.date(),
+    message: mappings.text(),
+    tags: mappings.keyword(),
+    data_stream: mappings.object({
+      properties: {
+        type: mappings.keyword(),
+        dataset: mappings.keyword(),
+        namespace: mappings.keyword(),
+      },
+    }),
+    event: mappings.object({
+      properties: {
+        action: mappings.keyword(),
+        kind: mappings.keyword(),
+        dataset: mappings.keyword(),
+        outcome: mappings.keyword(),
+      },
+    }),
+    gen_ai: mappings.object({
+      properties: {
+        system: mappings.keyword(),
+        operation: mappings.object({
+          properties: {
+            name: mappings.keyword(),
+          },
+        }),
+        request: mappings.object({
+          properties: {
+            model: mappings.keyword(),
+          },
+        }),
+        usage: mappings.object({
+          properties: {
+            input_tokens: mappings.long(),
+            output_tokens: mappings.long(),
+            total_tokens: mappings.long(),
+            /** Subset of prompt tokens served from the model provider cache (e.g. OpenAI `cached_tokens`). */
+            cache_read_tokens: mappings.long(),
+            /** Prompt tokens not served from cache: `input_tokens - cache_read_tokens` when cache is reported. */
+            non_cached_input_tokens: mappings.long(),
+            thinking_tokens: mappings.long(),
+          },
+        }),
+      },
+    }),
+    elastic_ramen: mappings.object({
+      properties: {
+        connector_id: mappings.keyword(),
+        model: mappings.keyword(),
+        streaming: mappings.boolean(),
+        tool_call_count: mappings.long(),
+        outcome: mappings.keyword(),
+        error: mappings.keyword({ ignore_above: 4096 }),
+      },
+    }),
+  },
+} satisfies MappingsDefinition;
+
+export interface LlmGatewayTelemetryParams {
+  streaming: boolean;
+  connectorId: string;
+  model: string;
+  toolCallCount: number;
+  tokens?: ChatCompletionTokenCount;
+  outcome: 'success' | 'error';
+  errorMessage?: string;
+}
+
+export interface LlmGatewayTelemetryDocument
+  extends GetFieldsOf<typeof llmGatewayTelemetryMappings> {
+  '@timestamp': string;
+  message: string;
+  tags: string[];
+  data_stream: {
+    type: string;
+    dataset: string;
+    namespace: string;
+  };
+  event: {
+    action: string;
+    kind: string;
+    dataset: string;
+    outcome: string;
+  };
+  gen_ai?: {
+    system?: string;
+    operation?: { name?: string };
+    request?: { model?: string };
+    usage?: {
+      input_tokens?: number;
+      output_tokens?: number;
+      total_tokens?: number;
+      cache_read_tokens?: number;
+      non_cached_input_tokens?: number;
+      thinking_tokens?: number;
+    };
+  };
+  elastic_ramen: {
+    connector_id: string;
+    model: string;
+    streaming: boolean;
+    tool_call_count: number;
+    outcome: string;
+    error?: string;
+  };
+}
+
+const llmGatewayTelemetryDataStreamDefinition: DataStreamDefinition<
+  typeof llmGatewayTelemetryMappings
+> = {
+  name: ELASTIC_RAMEN_LLM_GATEWAY_TELEMETRY_DATA_STREAM,
+  version: LLM_GATEWAY_TELEMETRY_DATA_STREAM_VERSION,
+  hidden: false,
+  template: {
+    mappings: llmGatewayTelemetryMappings,
+    settings: {
+      hidden: false,
+    },
+  },
+};
+
+export function registerLlmGatewayTelemetryDataStream(dataStreams: DataStreamsSetup): void {
+  dataStreams.registerDataStream(llmGatewayTelemetryDataStreamDefinition);
+}
+
+export function buildLlmGatewayTelemetryDocument(
+  params: LlmGatewayTelemetryParams
+): LlmGatewayTelemetryDocument {
+  const doc: LlmGatewayTelemetryDocument = {
+    '@timestamp': new Date().toISOString(),
+    message: 'Elastic Ramen LLM gateway chat completion',
+    tags: ['elastic_ramen', 'llm_gateway'],
+    data_stream: {
+      type: 'logs',
+      dataset: 'elastic_ramen.llm_gateway',
+      namespace: 'default',
+    },
+    event: {
+      action: 'llm_gateway.chat_completion',
+      kind: 'event',
+      dataset: 'elastic_console.llm_gateway',
+      outcome: params.outcome === 'success' ? 'success' : 'failure',
+    },
+    elastic_ramen: {
+      connector_id: params.connectorId,
+      model: params.model,
+      streaming: params.streaming,
+      tool_call_count: params.toolCallCount,
+      outcome: params.outcome,
+      ...(params.errorMessage ? { error: params.errorMessage } : {}),
+    },
+  };
+
+  if (params.tokens) {
+    const { prompt, completion, total, cached, thinking } = params.tokens;
+    doc.gen_ai = {
+      system: 'elastic_ramen',
+      operation: { name: 'chat_completion' },
+      request: { model: params.model },
+      usage: {
+        input_tokens: prompt,
+        output_tokens: completion,
+        total_tokens: total,
+        ...(thinking !== undefined ? { thinking_tokens: thinking } : {}),
+        ...(cached !== undefined
+          ? {
+              cache_read_tokens: cached,
+              non_cached_input_tokens: Math.max(0, prompt - cached),
+            }
+          : {}),
+      },
+    };
+  }
+
+  return doc;
+}
+
+export type LlmGatewayTelemetryWriter = (params: LlmGatewayTelemetryParams) => void;
+
+export function createLlmGatewayTelemetryWriter({
+  logger,
+  coreSetup,
+  onFirstGatewayUse,
+}: {
+  logger: Logger;
+  coreSetup: CoreSetup<ElasticConsoleStartDependencies, ElasticConsolePluginStart>;
+  onFirstGatewayUse?: () => void;
+}): LlmGatewayTelemetryWriter {
+  let firstInvocation = true;
+  let clientPromise: Promise<
+    IDataStreamClient<typeof llmGatewayTelemetryMappings, LlmGatewayTelemetryDocument>
+  > | null = null;
+
+  const getClient = (): Promise<
+    IDataStreamClient<typeof llmGatewayTelemetryMappings, LlmGatewayTelemetryDocument>
+  > => {
+    if (!clientPromise) {
+      clientPromise = coreSetup
+        .getStartServices()
+        .then(([coreStart]) =>
+          coreStart.dataStreams.initializeClient<
+            typeof llmGatewayTelemetryMappings,
+            LlmGatewayTelemetryDocument
+          >(ELASTIC_RAMEN_LLM_GATEWAY_TELEMETRY_DATA_STREAM)
+        );
+    }
+    return clientPromise;
+  };
+
+  return (params: LlmGatewayTelemetryParams) => {
+    if (firstInvocation) {
+      firstInvocation = false;
+      onFirstGatewayUse?.();
+    }
+    void getClient()
+      .then((client) =>
+        client.create({
+          documents: [buildLlmGatewayTelemetryDocument(params)],
+        })
+      )
+      .catch((err: Error) =>
+        logger.error(`Failed to index Elastic Ramen LLM gateway telemetry: ${err.message}`)
+      );
+  };
+}

--- a/x-pack/platform/plugins/shared/elastic_console/tsconfig.json
+++ b/x-pack/platform/plugins/shared/elastic_console/tsconfig.json
@@ -25,6 +25,9 @@
     "@kbn/agent-builder-common",
     "@kbn/agent-builder-server",
     "@kbn/core-feature-flags-server",
+    "@kbn/core-data-streams-server",
+    "@kbn/dashboard-plugin",
+    "@kbn/es-mappings",
     "@kbn/logging"
   ]
 }

--- a/x-pack/platform/plugins/shared/elastic_console/tsconfig.json
+++ b/x-pack/platform/plugins/shared/elastic_console/tsconfig.json
@@ -25,9 +25,7 @@
     "@kbn/agent-builder-common",
     "@kbn/agent-builder-server",
     "@kbn/core-feature-flags-server",
-    "@kbn/core-data-streams-server",
     "@kbn/dashboard-plugin",
-    "@kbn/es-mappings",
     "@kbn/logging"
   ]
 }

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/openai/openai_adapter.test.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/openai/openai_adapter.test.ts
@@ -447,6 +447,23 @@ describe('openAIAdapter', () => {
       expect(getRequest().body.stream).toBe(true);
     });
 
+    it('sets stream_options.include_usage so usage (incl. cached prompt tokens) is sent on chunks', () => {
+      openAIAdapter
+        .chatComplete({
+          ...defaultArgs,
+          stream: true,
+          messages: [
+            {
+              role: MessageRole.User,
+              content: 'question',
+            },
+          ],
+        })
+        .subscribe(noop);
+
+      expect(getRequest().body.stream_options).toEqual({ include_usage: true });
+    });
+
     describe('when handling the response', () => {
       it('throws an error if the connector response is in error', async () => {
         executorMock.invoke.mockImplementation(async () => {

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/openai/openai_adapter.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/openai/openai_adapter.ts
@@ -48,6 +48,15 @@ export const openAIAdapter: InferenceConnectorAdapter = {
         ? !isNativeFunctionCallingSupported(connector)
         : functionCalling === 'simulated';
 
+    /** OpenAI Chat Completions only emits `usage` on stream chunks when this is set (incl. cached prompt tokens). */
+    const streamOptions =
+      stream === true
+        ? ({ stream_options: { include_usage: true } } satisfies Pick<
+            OpenAIRequest,
+            'stream_options'
+          >)
+        : {};
+
     let request: OpenAIRequest;
 
     if (useSimulatedFunctionCalling) {
@@ -59,6 +68,7 @@ export const openAIAdapter: InferenceConnectorAdapter = {
       });
       request = {
         stream,
+        ...streamOptions,
         ...getTemperatureIfValid(temperature, { connector, modelName }),
         model: modelName,
         messages: messagesToOpenAI({ system: wrapped.system, messages: wrapped.messages }),
@@ -69,6 +79,7 @@ export const openAIAdapter: InferenceConnectorAdapter = {
 
       request = {
         stream,
+        ...streamOptions,
         ...getTemperatureIfValid(temperature, { connector, modelName }),
         model: modelName,
         messages: messagesToOpenAI({ system, messages }),


### PR DESCRIPTION
## Summary

Elastic Ramen (`elasticConsole`) **LLM gateway telemetry** (Elasticsearch documents) plus a **pre-installed Lens dashboard** for the OpenAI-compatible chat completions route. This remains **draft / iterative** work.

## What this PR does

### Telemetry indexing

- Writes one document per chat completion (**streaming and non-streaming**, **success and failure**) to Elasticsearch data stream **`logs-elastic_ramen.llm_gateway-default`**.
- **Does not** register a custom Core `dataStreams` index template (that conflicted with the stack **`logs-*-*`** template at the same priority).
- Documents follow normal logs-style routing (`data_stream`, `@timestamp`, etc.) and rely on default / stack mappings for the stream name.
- Indexing uses the **request-scoped Elasticsearch client** (`asCurrentUser`), **not** `kibana_system`. The **authenticated caller** must have privileges to index / auto-create that data stream.

### Document shape (high level)

- **`gen_ai.usage`:** input / output / total tokens; optional **`cache_read_tokens`** and **`non_cached_input_tokens`** when the provider reports cached prompt tokens.
- **`elastic_ramen.*`:** connector, model, streaming, tool-call count, outcome, optional error text.
- **`event.*`:** outcome, action, etc.

### Inference: OpenAI streaming (`inference` plugin)

- OpenAI adapter sends **`stream_options: { include_usage: true }`** on **streaming** chat completion requests so **`usage`** (and thus OpenAI-style **`prompt_tokens_details.cached_tokens`**, when supported) can appear on chunks.

### Ramen OpenAI-compatible HTTP responses (`elastic_console`)

- When internal token counts include **`cached`**, **`usage`** in non-streaming JSON and in the streaming final chunk may include **`prompt_tokens_details: { cached_tokens }`** for OpenAI-shaped clients.

### Dashboard install

- On **first** gateway use, schedules a one-time background install: **data view** id **`elastic-ramen-llm-gateway-telemetry`**, **dashboard** id **`elastic-ramen-llm-gateway-telemetry`** (default space).
- **Idempotent:** if the dashboard saved object **already exists**, **nothing is updated** (no migrations or panel refreshes).
- **`panelsJSON`** is built server-side with **Lens by-value** visualizations using the **`formBased`** datasource state key (current Lens requirement). Panels target completions over time, token sums, cached vs non-cached prompt tokens, top models, outcomes, and average tool calls.

### Dependencies

- Drops **`@kbn/core-data-streams-server`** / **`@kbn/es-mappings`** from `elastic_console` where they were only used for the removed registration path.

## Limitations / known gaps (current state)

- **Dashboard:** Still **not finished**; panels may **error**, show empty states, or need Lens / field-mapping follow-up in real stacks.
- **No upgrade path:** To get a new panel definition after an install, **delete** the relevant saved objects (or change stable ids in code). Existing dashboards are **never** patched automatically.
- **Permissions:** Telemetry indexing fails if the user cannot write to the data stream; check the **`elasticConsole`** plugin log for errors.
- **Cached tokens:** Only when the **provider** returns usage that includes cached prompt tokens; absence of cache fields is normal for many models/connectors.
- **Spaces:** Install only runs for the **default** space (internal saved object client).
- **Draft:** Expect further iteration before merge.

## Testing

- `node scripts/check_changes.ts`
- `node scripts/jest x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/openai/openai_adapter.test.ts`

Made with [Cursor](https://cursor.com)
