### PR TITLE
Add waitForInput step to flow control menu

### DIFF
--- a/src/platform/plugins/shared/workflows_management/public/features/actions_menu_popover/lib/get_action_options.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/actions_menu_popover/lib/get_action_options.test.ts
@@ -119,13 +119,14 @@ describe('getActionOptions', () => {
 
     expect(flowControlGroup).toBeDefined();
     if (flowControlGroup && 'options' in flowControlGroup) {
-      expect(flowControlGroup.options).toHaveLength(7);
+      expect(flowControlGroup.options).toHaveLength(8);
       expect(flowControlGroup.options.map((opt) => opt.id)).toEqual([
         'if',
         'switch',
         'foreach',
         'while',
         'wait',
+        'waitForInput',
         'workflow.execute',
         'workflow.executeAsync',
       ]);

--- a/src/platform/plugins/shared/workflows_management/public/features/actions_menu_popover/lib/get_action_options.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/actions_menu_popover/lib/get_action_options.ts
@@ -217,6 +217,17 @@ export function getActionOptions(
         iconType: 'clock',
         iconColor: euiTheme.colors.vis.euiColorVis0,
       },
+      {
+        id: 'waitForInput',
+        label: i18n.translate('workflows.actionsMenu.waitForInput', {
+          defaultMessage: 'Wait For Input',
+        }),
+        description: i18n.translate('workflows.actionsMenu.waitForInputDescription', {
+          defaultMessage: 'Pause execution until external input is provided (human-in-the-loop)',
+        }),
+        iconType: 'user',
+        iconColor: euiTheme.colors.vis.euiColorVis0,
+      },
       ...(['workflow.execute', 'workflow.executeAsync'] as const)
         .map((stepId) => getBuiltInStepDefinition(stepId))
         .filter((def): def is NonNullable<typeof def> => def !== undefined)


### PR DESCRIPTION
Actions menu // waitForInput appears under Flow Control after using the same pattern as other built-in flow steps

<img width="1148" height="934" alt="image" src="https://github.com/user-attachments/assets/da01bd1b-6b72-4424-995a-6dd8fc0aabce" />

Fixes https://github.com/elastic/security-team/issues/16768