### PR TITLE
[SigEvents] Check inference feature connectors instead of global default

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/stream_detail_significant_events_view/empty_state/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/stream_detail_significant_events_view/empty_state/index.tsx
@@ -85,15 +85,15 @@ export function EmptyState({
             <EuiFlexItem>
               <EuiCallOut
                 announceOnMount
-                title={NO_DEFAULT_CONNECTOR_CALLOUT_TITLE}
+                title={NO_CONNECTOR_CALLOUT_TITLE}
                 color="warning"
                 iconType="warning"
               >
                 <p>
-                  {NO_DEFAULT_CONNECTOR_CALLOUT_DESCRIPTION}{' '}
+                  {NO_CONNECTOR_CALLOUT_DESCRIPTION}{' '}
                   {modelSettingsUrl && (
                     <EuiLink href={modelSettingsUrl} external>
-                      {NO_DEFAULT_CONNECTOR_CALLOUT_LINK_LABEL}
+                      {NO_CONNECTOR_CALLOUT_LINK_LABEL}
                     </EuiLink>
                   )}
                 </p>
@@ -116,7 +116,7 @@ export function EmptyState({
                     size="m"
                     color="primary"
                     isLoading={isGenerating}
-                    isDisabled={isGenerateDisabled || isGenerating}
+                    isDisabled={isGenerateDisabled || isGenerating || isConnectorLoading}
                     onClick={onGenerateSuggestionsClick}
                   >
                     {isGenerating
@@ -170,23 +170,23 @@ const CANCEL_GENERATION_BUTTON_ARIA_LABEL = i18n.translate(
   }
 );
 
-const NO_DEFAULT_CONNECTOR_CALLOUT_TITLE = i18n.translate(
-  'xpack.streams.significantEvents.emptyState.noDefaultConnectorCalloutTitle',
+const NO_CONNECTOR_CALLOUT_TITLE = i18n.translate(
+  'xpack.streams.significantEvents.emptyState.noConnectorCalloutTitle',
   {
     defaultMessage: 'No connector configured',
   }
 );
 
-const NO_DEFAULT_CONNECTOR_CALLOUT_DESCRIPTION = i18n.translate(
-  'xpack.streams.significantEvents.emptyState.noDefaultConnectorCalloutDescription',
+const NO_CONNECTOR_CALLOUT_DESCRIPTION = i18n.translate(
+  'xpack.streams.significantEvents.emptyState.noConnectorCalloutDescription',
   {
     defaultMessage:
       'Generating knowledge indicators requires an AI connector. Open Model Settings to configure one.',
   }
 );
 
-const NO_DEFAULT_CONNECTOR_CALLOUT_LINK_LABEL = i18n.translate(
-  'xpack.streams.significantEvents.emptyState.noDefaultConnectorCalloutLinkLabel',
+const NO_CONNECTOR_CALLOUT_LINK_LABEL = i18n.translate(
+  'xpack.streams.significantEvents.emptyState.noConnectorCalloutLinkLabel',
   {
     defaultMessage: 'Open Model Settings',
   }

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/stream_detail_significant_events_view/empty_state/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/stream_detail_significant_events_view/empty_state/index.tsx
@@ -17,13 +17,14 @@ import {
   EuiText,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import { GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR } from '@kbn/management-settings-ids';
+import {
+  STREAMS_SIG_EVENTS_KI_EXTRACTION_INFERENCE_FEATURE_ID,
+  STREAMS_SIG_EVENTS_KI_QUERY_GENERATION_INFERENCE_FEATURE_ID,
+} from '@kbn/streams-schema';
 import React from 'react';
-import { useKibana } from '../../../../hooks/use_kibana';
+import { useInferenceFeatureConnectors } from '../../../../hooks/sig_events/use_inference_feature_connectors';
 import { useModelSettingsUrl } from '../../../../hooks/use_model_settings_url';
 import noSigEventsImage from './no_sig_events.svg';
-
-const NO_DEFAULT_CONNECTOR = 'NO_DEFAULT_CONNECTOR';
 
 export function EmptyState({
   isGenerating,
@@ -38,12 +39,19 @@ export function EmptyState({
   onCancelGenerationClick: () => void;
   onGenerateSuggestionsClick: () => void;
 }) {
-  const { core } = useKibana();
-  const defaultConnector = core.uiSettings.get<string>(GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR);
-  const modelSettingsUrl = useModelSettingsUrl();
+  const featuresConnectors = useInferenceFeatureConnectors(
+    STREAMS_SIG_EVENTS_KI_EXTRACTION_INFERENCE_FEATURE_ID
+  );
+  const queriesConnectors = useInferenceFeatureConnectors(
+    STREAMS_SIG_EVENTS_KI_QUERY_GENERATION_INFERENCE_FEATURE_ID
+  );
 
-  const isDefaultAiConnectorMissing =
-    !defaultConnector || defaultConnector === NO_DEFAULT_CONNECTOR;
+  const isConnectorLoading = featuresConnectors.loading || queriesConnectors.loading;
+  const isConnectorMissing =
+    !isConnectorLoading &&
+    (!featuresConnectors.resolvedConnectorId || !queriesConnectors.resolvedConnectorId);
+
+  const modelSettingsUrl = useModelSettingsUrl();
 
   return (
     <EuiEmptyPrompt
@@ -73,7 +81,7 @@ export function EmptyState({
               })}
             </EuiText>
           </EuiFlexItem>
-          {isDefaultAiConnectorMissing ? (
+          {isConnectorMissing ? (
             <EuiFlexItem>
               <EuiCallOut
                 announceOnMount
@@ -165,7 +173,7 @@ const CANCEL_GENERATION_BUTTON_ARIA_LABEL = i18n.translate(
 const NO_DEFAULT_CONNECTOR_CALLOUT_TITLE = i18n.translate(
   'xpack.streams.significantEvents.emptyState.noDefaultConnectorCalloutTitle',
   {
-    defaultMessage: 'No default connector configured',
+    defaultMessage: 'No connector configured',
   }
 );
 
@@ -173,7 +181,7 @@ const NO_DEFAULT_CONNECTOR_CALLOUT_DESCRIPTION = i18n.translate(
   'xpack.streams.significantEvents.emptyState.noDefaultConnectorCalloutDescription',
   {
     defaultMessage:
-      'Generating significant events requires a default AI connector. Open Model Settings to configure one.',
+      'Generating knowledge indicators requires an AI connector. Open Model Settings to configure one.',
   }
 );
 


### PR DESCRIPTION
The Significant Events empty state was checking the global GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR UI setting to decide whether to show the "No default connector configured" warning. This was incorrect because KI generation does not use the global default connector — it resolves connectors per inference feature via the inference feature registry (admin override → recommended endpoints → platform default).

This meant the warning would appear even when per-feature connectors were properly configured in Model Settings, and conversely would not appear when only the global default was set but the feature-specific resolution would fail.

Replace the global UI setting check with useInferenceFeatureConnectors for the two features actually used by KI generation (extraction and query generation), aligning the client-side gate with the server-side resolution logic in resolveConnectorForFeature.

Screenshots of before and after (no settings change, just using EIS)

Before: 
<img width="720" height="791" alt="Screenshot 2026-04-09 at 11 06 18" src="https://github.com/user-attachments/assets/e12d1016-6783-4fa1-8d34-df2294afeb63" />

After
<img width="787" height="535" alt="Screenshot 2026-04-09 at 11 09 09" src="https://github.com/user-attachments/assets/f9ace0c0-297a-4e50-be29-f49ad144baa2" />
