### PR TITLE
[Scout] Fix Discover page load timeout in CI

### DIFF
--- a/src/platform/packages/shared/kbn-scout/src/playwright/page_objects/discover_app.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/page_objects/discover_app.ts
@@ -26,7 +26,7 @@ export class DiscoverApp {
   }
 
   private async waitForDiscoverPage() {
-    await expect(this.page.testSubj.locator('dscPage')).toBeVisible();
+    await expect(this.page.testSubj.locator('dscPage')).toBeVisible({ timeout: 30_000 });
   }
 
   private async getVisibleDataViewSwitch() {

--- a/src/platform/packages/shared/kbn-scout/src/playwright/page_objects/discover_app.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/page_objects/discover_app.ts
@@ -26,6 +26,8 @@ export class DiscoverApp {
   }
 
   private async waitForDiscoverPage() {
+    // Discover initialization in serverless CI environments regularly exceeds the default 10s,
+    // likely due to additional plugin overhead and root profile resolution.
     await expect(this.page.testSubj.locator('dscPage')).toBeVisible({ timeout: 30_000 });
   }
 

--- a/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/ui/tests/discover_alerts_menu.spec.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/ui/tests/discover_alerts_menu.spec.ts
@@ -11,8 +11,7 @@ import { test } from '../fixtures';
 
 const SAMPLE_DATA_SET = 'ecommerce';
 
-// Failing: See https://github.com/elastic/kibana/issues/261380
-test.describe.skip(
+test.describe(
   'Discover Alerts menu with alerting v2',
   {
     tag: [


### PR DESCRIPTION
## Summary

Fixes the consistently failing `Discover Alerts menu with alerting v2` Scout test that was skipped after 13/13 CI failures.

**Root cause**: `waitForDiscoverPage()` in the shared `DiscoverApp` page object used a bare `toBeVisible()` assertion with no explicit timeout, defaulting to the global `expect.timeout` of 10 seconds. In serverless CI environments, Discover's initialization exceeds 10s due to:

1. Double root-profile resolution in serverless mode (`getActiveSolutionNavId$()` emits `undefined` first, then the actual solution ID, restarting the initialization pipeline)
2. alerting_v2 plugin startup overhead (ILM policy and query view creation attempts against APIs unavailable in serverless)
3. General CI resource constraints

**Fix**:
- Increase the `dscPage` visibility timeout from 10s to 30s in `waitForDiscoverPage()`, aligning with other wait methods in the same page object (`waitForDocViewerFlyoutOpen`, `waitUntilSearchingHasFinished`, `waitForDocTableRendered`)
- Unskip the `discover_alerts_menu.spec.ts` test

**Verified locally**: Test passed twice against a real serverless security cluster (18.4s, 21.3s).

Closes #261380


Made with [Cursor](https://cursor.com)