### PR TITLE
fix(agent builder): sidebar connector width

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/input_actions/input_actions.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/input_actions/input_actions.tsx
@@ -6,9 +6,16 @@
  */
 
 import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import { css } from '@emotion/react';
 import React from 'react';
 import { ConversationActionButton } from './conversation_action_button';
 import { ConnectorSelector } from './connector_selector';
+
+const connectorFlexItemStyles = css`
+  flex-shrink: 1;
+  min-width: 0;
+  overflow: hidden;
+`;
 
 interface InputActionsProps {
   onSubmit: () => void;
@@ -30,7 +37,7 @@ export const InputActions: React.FC<InputActionsProps> = ({
       alignItems="center"
       justifyContent="spaceBetween"
     >
-      <EuiFlexItem grow={false}>
+      <EuiFlexItem grow={false} css={connectorFlexItemStyles}>
         <ConnectorSelector />
       </EuiFlexItem>
       <EuiFlexItem grow={false}>

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/input_actions/input_popover_button.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/input_actions/input_popover_button.tsx
@@ -11,6 +11,15 @@ import { css } from '@emotion/react';
 import type { PropsWithChildren } from 'react';
 import React from 'react';
 
+const truncateStyles = css`
+  max-width: 100%;
+  .euiButtonEmpty__text {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+`;
+
 export const InputPopoverButton: React.FC<
   PropsWithChildren<{
     open: boolean;
@@ -34,7 +43,7 @@ export const InputPopoverButton: React.FC<
   `;
   return (
     <EuiButtonEmpty
-      css={open && openStyles}
+      css={[truncateStyles, open && openStyles]}
       color="text"
       iconSide="left"
       flush="both"


### PR DESCRIPTION
Closes https://github.com/elastic/search-team/issues/13639

## Summary

CSS rule for truncating connector text in sidebar depending on maxWidth and open/closed state of sidebar. 

Before:
<img width="528" height="199" alt="Screenshot 2026-04-09 at 13 10 18" src="https://github.com/user-attachments/assets/39b148d5-0147-482a-abc9-e161377104fb" />

After: 

https://github.com/user-attachments/assets/326143fc-b77f-4a62-892c-7b71914c752f


