### PR TITLE
Log CPS enabled/disabled at Kibana startup

### DIFF
--- a/src/platform/plugins/shared/cps/server/plugin.ts
+++ b/src/platform/plugins/shared/cps/server/plugin.ts
@@ -48,6 +48,7 @@ export class CPSServerPlugin implements Plugin<CPSServerSetup, CPSServerStart | 
 
   public start(core: CoreStart): CPSServerStart | undefined {
     const { cpsEnabled } = this.config$;
+    this.log.info(`Cross-project search (CPS) is ${cpsEnabled ? 'enabled' : 'disabled'}`);
 
     if (!cpsEnabled) {
       return undefined;


### PR DESCRIPTION
## Summary

Adds an info-level log line when the CPS server plugin starts so startup logs clearly show whether cross-project search (CPS) is enabled or disabled.

## Change

- `CPSServerPlugin.start()`: log `Cross-project search (CPS) is enabled|disabled` based on `cpsEnabled` config.

Made with [Cursor](https://cursor.com)