### PR TITLE
[Agent Builder] Fix No llm present message appears on the sidebar with no action

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/access/prompts/add_llm_connection_prompt.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/access/prompts/add_llm_connection_prompt.tsx
@@ -8,12 +8,10 @@
 import { EuiButton, EuiButtonEmpty, EuiCallOut, useEuiTheme } from '@elastic/eui';
 import React from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
-import useObservable from 'react-use/lib/useObservable';
-import { MANAGEMENT_APP_ID } from '../../../hooks/use_navigation';
+import { useIsOnManagementLlmConnectorsPage } from '../../../hooks/use_navigation';
 import { ErrorPrompt } from '../../common/prompt/error_prompt';
 import { useAgentBuilderServices } from '../../../hooks/use_agent_builder_service';
 import { useAssetBasePath } from '../../../hooks/use_asset_base_path';
-import { useKibana } from '../../../hooks/use_kibana';
 import type { PromptLayoutVariant } from '../../common/prompt/layout';
 
 export interface AddLlmConnectionPromptProps {
@@ -25,13 +23,9 @@ export const AddLlmConnectionPrompt: React.FC<AddLlmConnectionPromptProps> = ({ 
   const { colorMode } = useEuiTheme();
   const assetBasePath = useAssetBasePath();
   const llmDocsHref = docLinksService.models;
-  const {
-    services: { application },
-  } = useKibana();
-  const currentAppId = useObservable(application.currentAppId$, undefined);
-  const isInManagementApp = currentAppId === MANAGEMENT_APP_ID;
+  const isOnLlmConnectorsManagementPage = useIsOnManagementLlmConnectorsPage();
 
-  const primaryAction = isInManagementApp ? (
+  const primaryAction = isOnLlmConnectorsManagementPage ? (
     <EuiCallOut
       announceOnMount
       size="s"

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/hooks/use_navigation.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/hooks/use_navigation.test.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook, waitFor } from '@testing-library/react';
+import { BehaviorSubject } from 'rxjs';
+import {
+  MANAGEMENT_APP_ID,
+  MANAGEMENT_LLM_CONNECTORS_PATH,
+  useIsOnManagementLlmConnectorsPage,
+} from './use_navigation';
+
+const currentAppId$ = new BehaviorSubject<string | undefined>(undefined);
+const currentLocation$ = new BehaviorSubject<string>('');
+
+const mockApplication = {
+  currentAppId$,
+  currentLocation$,
+};
+
+jest.mock('./use_kibana', () => ({
+  useKibana: () => ({
+    services: {
+      application: mockApplication,
+    },
+  }),
+}));
+
+describe('useIsOnManagementLlmConnectorsPage', () => {
+  beforeEach(() => {
+    currentAppId$.next(undefined);
+    currentLocation$.next('');
+  });
+
+  it('returns false when app id and location do not match', () => {
+    const { result } = renderHook(() => useIsOnManagementLlmConnectorsPage());
+
+    expect(result.current).toBe(false);
+  });
+
+  it('returns false when on management but not on LLM connectors path', () => {
+    currentAppId$.next(MANAGEMENT_APP_ID);
+    currentLocation$.next('/app/management/kibana/settings');
+
+    const { result } = renderHook(() => useIsOnManagementLlmConnectorsPage());
+
+    expect(result.current).toBe(false);
+  });
+
+  it('returns false when location matches path but app is not management', () => {
+    currentAppId$.next('discover');
+    currentLocation$.next(`/app/management${MANAGEMENT_LLM_CONNECTORS_PATH}`);
+
+    const { result } = renderHook(() => useIsOnManagementLlmConnectorsPage());
+
+    expect(result.current).toBe(false);
+  });
+
+  it('returns true when on management app and URL includes connectors path', () => {
+    currentAppId$.next(MANAGEMENT_APP_ID);
+    currentLocation$.next(`/s/default/app/management${MANAGEMENT_LLM_CONNECTORS_PATH}`);
+
+    const { result } = renderHook(() => useIsOnManagementLlmConnectorsPage());
+
+    expect(result.current).toBe(true);
+  });
+
+  it('updates when observables emit new values', async () => {
+    currentAppId$.next(MANAGEMENT_APP_ID);
+    currentLocation$.next('/app/management/kibana/settings');
+
+    const { result } = renderHook(() => useIsOnManagementLlmConnectorsPage());
+
+    expect(result.current).toBe(false);
+
+    currentLocation$.next(`/app/management${MANAGEMENT_LLM_CONNECTORS_PATH}#tab`);
+
+    await waitFor(() => {
+      expect(result.current).toBe(true);
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/hooks/use_navigation.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/hooks/use_navigation.ts
@@ -6,6 +6,8 @@
  */
 
 import { useCallback, useMemo } from 'react';
+import useObservable from 'react-use/lib/useObservable';
+import { combineLatest, map } from 'rxjs';
 import { AGENTBUILDER_APP_ID } from '../../../common/features';
 import { useKibana } from './use_kibana';
 
@@ -15,7 +17,28 @@ export interface LocationState {
 }
 
 export const MANAGEMENT_APP_ID = 'management';
-const manageConnectorsPath = '/insightsAndAlerting/triggersActionsConnectors/connectors';
+
+export const MANAGEMENT_LLM_CONNECTORS_PATH =
+  '/insightsAndAlerting/triggersActionsConnectors/connectors';
+
+export const useIsOnManagementLlmConnectorsPage = (): boolean => {
+  const {
+    services: { application },
+  } = useKibana();
+
+  const isOnPage$ = useMemo(
+    () =>
+      combineLatest([application.currentAppId$, application.currentLocation$]).pipe(
+        map(
+          ([appId, location]) =>
+            appId === MANAGEMENT_APP_ID && location.includes(MANAGEMENT_LLM_CONNECTORS_PATH)
+        )
+      ),
+    [application]
+  );
+
+  return useObservable(isOnPage$, false);
+};
 
 export const useNavigation = () => {
   const {
@@ -44,14 +67,14 @@ export const useNavigation = () => {
   );
 
   const navigateToManageConnectors = useCallback(
-    () => application.navigateToApp(MANAGEMENT_APP_ID, { path: manageConnectorsPath }),
+    () => application.navigateToApp(MANAGEMENT_APP_ID, { path: MANAGEMENT_LLM_CONNECTORS_PATH }),
     [application]
   );
 
   const manageConnectorsUrl = useMemo(
     () =>
       application.getUrlForApp(MANAGEMENT_APP_ID, {
-        path: manageConnectorsPath,
+        path: MANAGEMENT_LLM_CONNECTORS_PATH,
       }),
     [application]
   );


### PR DESCRIPTION
resolves https://github.com/elastic/search-team/issues/13807

## Summary

The “no LLM” sidebar prompt used **only** `currentAppId === management`, so on **any** Stack Management screen it showed the “Configure your LLM connection **on this page**” callout—even when you were not on the connectors page. That felt like a dead end. Detection now requires **both** the management app **and** a URL that includes the LLM connectors path (`MANAGEMENT_LLM_CONNECTORS_PATH`), aligned with navigation from Agent Builder.

**Implementation:** [`useIsOnManagementLlmConnectorsPage`](https://github.com/elastic/kibana/blob/main/x-pack/platform/plugins/shared/agent_builder/public/application/hooks/use_navigation.ts) in `use_navigation.ts`; consumed by [`add_llm_connection_prompt.tsx`](https://github.com/elastic/kibana/blob/main/x-pack/platform/plugins/shared/agent_builder/public/application/components/access/prompts/add_llm_connection_prompt.tsx).

### Visuals (from [search-team#13807](https://github.com/elastic/search-team/issues/13807))

**Bug** — user is in Stack Management but **not** on the LLM connectors screen; the sidebar still showed “configure on this page” (misleading):

<img width="600" alt="Bug — misleading “on this page” callout outside connectors" src="https://github.com/user-attachments/assets/6d4098fd-6afe-4a73-92b5-bbcd0c8c2919" />

**Intended behavior** — same in-context message only when actually on the connectors management view:

<img width="600" alt="Expected — callout only on connectors page" src="https://github.com/user-attachments/assets/4e29843c-3f0d-4866-90dd-ce0d247e6d52" />

_Screenshots and analysis: [issue description](https://github.com/elastic/search-team/issues/13807) and [this comment](https://github.com/elastic/search-team/issues/13807#issuecomment-4213874452)._

### How to test

1. Agent Builder with **no** LLM connector — sidebar should offer **Connect LLM**.
2. **Stack Management → Connectors** — sidebar should show the **in-context callout**, not a redundant connect action.
3. Another Management area (e.g. **Kibana → Settings**) — **Connect LLM** again, not the misleading callout.

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [x] **Low:** If `currentLocation$` ever diverges from real connector URLs, the wrong primary action could show—mitigated by using the same path as `navigateToManageConnectors` / `manageConnectorsUrl` and tests for `useIsOnManagementLlmConnectorsPage`.

### Release notes

Fix: Agent Builder “no LLM” sidebar shows **Connect LLM** unless you are already on Stack Management connectors; there it shows the in-context callout.

**Labels (suggestion):** Align `release_note:*` with this fix (`release_note:fix` if shipping as a bug fix). `Team:agent-builder`, `feature:agent-builder`; use `backport:*` per guidelines.
