### PR TITLE
[Dashboards in chat] Fix Unified Search interactions not working in dashboard attachment preview

### DIFF
--- a/x-pack/platform/plugins/shared/dashboard_agent/moon.yml
+++ b/x-pack/platform/plugins/shared/dashboard_agent/moon.yml
@@ -38,6 +38,11 @@ dependsOn:
   - '@kbn/lens-common'
   - '@kbn/presentation-publishing'
   - '@kbn/core-saved-objects-api-server'
+  - '@kbn/es-query'
+  - '@kbn/data-plugin'
+  - '@kbn/as-code-filters-transforms'
+  - '@kbn/as-code-shared-transforms'
+  - '@kbn/data-views-plugin'
 tags:
   - plugin
   - prod

--- a/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/canvas_integration/dashboard_canvas_content.test.tsx
+++ b/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/canvas_integration/dashboard_canvas_content.test.tsx
@@ -13,10 +13,6 @@ import { DashboardRenderer } from '@kbn/dashboard-plugin/public';
 import type { ActionButton } from '@kbn/agent-builder-browser/attachments';
 import type { DashboardAttachment } from '@kbn/dashboard-agent-common/types';
 import type { Filter, Query } from '@kbn/es-query';
-import {
-  clearUnifiedSearchPersistedState,
-  setPersistedState,
-} from './use_dashboard_preview_unified_search';
 import { DashboardCanvasContent } from './dashboard_canvas_content';
 import { DASHBOARD_ATTACHMENT_TYPE } from '@kbn/dashboard-agent-common';
 
@@ -89,16 +85,15 @@ describe('DashboardCanvasContent', () => {
   };
 
   const defaultProps = {
-    isSidebar: false,
     attachment: mockAttachment,
     conversationId: 'test-conversation-id',
+    isSidebar: false,
     dashboardLocator: undefined,
     searchBarComponent: MockSearchBar as any,
   };
 
   beforeEach(() => {
     jest.clearAllMocks();
-    clearUnifiedSearchPersistedState('test-dashboard-id');
   });
 
   const simulateDashboardApiAvailable = (mockApi: DashboardApi) => {
@@ -262,25 +257,6 @@ describe('DashboardCanvasContent', () => {
     expect(mockApi.setFilters).toHaveBeenCalledTimes(1);
   });
 
-  it('hydrates unified search state from persisted preview state', async () => {
-    setPersistedState('test-dashboard-id', {
-      filters: [{ meta: { key: 'host.name' } }] as Filter[],
-      query: { query: 'host.name: "web-01"', language: 'kuery' },
-      timeRange: { from: 'now-1h', to: 'now' },
-    });
-
-    await renderDashboardCanvasContent();
-
-    expect(getLatestSearchBarProps()).toEqual(
-      expect.objectContaining({
-        filters: [{ meta: { key: 'host.name' } }],
-        query: { query: 'host.name: "web-01"', language: 'kuery' },
-        dateRangeFrom: 'now-1h',
-        dateRangeTo: 'now',
-      })
-    );
-  });
-
   it('updates query bar index patterns when dashboard data views are published', async () => {
     const { mockApi } = await renderDashboardCanvasContent();
     const nextDataViews = [{ id: 'logs-*', title: 'logs-*' }];
@@ -332,11 +308,9 @@ describe('DashboardCanvasContent', () => {
   });
 
   describe('Edit in Dashboards button', () => {
-    it('should call closeCanvas and openSidebarConversation when isSidebar is false', async () => {
+    it('should call closeCanvas and openSidebarConversation', async () => {
       const { registerActionButtons, closeCanvas, openSidebarConversation, mockApi } =
-        await renderDashboardCanvasContent({
-          isSidebar: false,
-        });
+        await renderDashboardCanvasContent();
 
       const buttons: ActionButton[] = registerActionButtons.mock.calls.at(-1)?.[0] ?? [];
       const editButton = buttons.find((b) => b.label === 'Edit in Dashboards');
@@ -348,24 +322,6 @@ describe('DashboardCanvasContent', () => {
       expect(mockApi.locator?.navigate).toHaveBeenCalled();
       expect(closeCanvas).toHaveBeenCalled();
       expect(openSidebarConversation).toHaveBeenCalled();
-    });
-
-    it('should call closeCanvas but not openSidebarConversation when isSidebar is true', async () => {
-      const { registerActionButtons, closeCanvas, openSidebarConversation, mockApi } =
-        await renderDashboardCanvasContent({
-          isSidebar: true,
-        });
-
-      const buttons: ActionButton[] = registerActionButtons.mock.calls.at(-1)?.[0] ?? [];
-      const editButton = buttons.find((b) => b.label === 'Edit in Dashboards');
-
-      await act(async () => {
-        await editButton?.handler();
-      });
-
-      expect(mockApi.locator?.navigate).toHaveBeenCalled();
-      expect(closeCanvas).toHaveBeenCalled();
-      expect(openSidebarConversation).not.toHaveBeenCalled();
     });
 
     it('should navigate with correct dashboard state and time range', async () => {

--- a/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/canvas_integration/dashboard_canvas_content.test.tsx
+++ b/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/canvas_integration/dashboard_canvas_content.test.tsx
@@ -7,11 +7,16 @@
 
 import React from 'react';
 import { render, act, waitFor } from '@testing-library/react';
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, Subject } from 'rxjs';
 import type { DashboardApi } from '@kbn/dashboard-plugin/public';
 import { DashboardRenderer } from '@kbn/dashboard-plugin/public';
 import type { ActionButton } from '@kbn/agent-builder-browser/attachments';
 import type { DashboardAttachment } from '@kbn/dashboard-agent-common/types';
+import type { Filter, Query } from '@kbn/es-query';
+import {
+  clearUnifiedSearchPersistedState,
+  setPersistedState,
+} from './use_dashboard_preview_unified_search';
 import { DashboardCanvasContent } from './dashboard_canvas_content';
 import { DASHBOARD_ATTACHMENT_TYPE } from '@kbn/dashboard-agent-common';
 
@@ -22,18 +27,56 @@ jest.mock('@kbn/dashboard-plugin/public', () => ({
 const MockSearchBar = jest.fn(() => <div data-test-subj="searchBar" />);
 
 describe('DashboardCanvasContent', () => {
-  const createMockDashboardApi = (): DashboardApi =>
-    ({
+  const createMockFilterManager = () => {
+    let currentFilters: Filter[] = [];
+    const updates$ = new Subject<void>();
+
+    return {
+      getFilters: jest.fn(() => currentFilters),
+      getUpdates$: jest.fn(() => updates$.asObservable()),
+      setFilters: jest.fn((nextFilters: Filter[]) => {
+        currentFilters = nextFilters;
+        updates$.next();
+      }),
+      emitFilters: (nextFilters: Filter[]) => {
+        currentFilters = nextFilters;
+        updates$.next();
+      },
+    };
+  };
+
+  const createMockDashboardApi = (): DashboardApi & {
+    dataViews$: BehaviorSubject<any[]>;
+  } => {
+    const dataViews$ = new BehaviorSubject<any[]>([]);
+    const filters$ = new BehaviorSubject<Filter[]>([]);
+    const query$ = new BehaviorSubject<Query | undefined>(undefined);
+    const timeRange$ = new BehaviorSubject({ from: 'now-15m', to: 'now' });
+
+    return {
       locator: {
         navigate: jest.fn().mockResolvedValue(undefined),
       },
+      dataViews$,
+      filters$,
+      forceRefresh: jest.fn(),
+      query$,
       runQuickSave: jest.fn().mockResolvedValue(undefined),
       runInteractiveSave: jest.fn().mockResolvedValue({ id: 'new-dashboard-id' }),
       savedObjectId$: new BehaviorSubject<string | undefined>(undefined),
+      setFilters: jest.fn((nextFilters?: Filter[]) => filters$.next(nextFilters ?? [])),
+      setQuery: jest.fn((nextQuery?: Query) => query$.next(nextQuery)),
       setViewMode: jest.fn(),
-      setTimeRange: jest.fn(),
-      timeRange$: new BehaviorSubject({ from: 'now-15m', to: 'now' }),
-    } as unknown as DashboardApi);
+      setTimeRange: jest.fn((nextTimeRange?: { from: string; to: string }) => {
+        if (nextTimeRange) {
+          timeRange$.next(nextTimeRange);
+        }
+      }),
+      timeRange$,
+    } as unknown as DashboardApi & {
+      dataViews$: BehaviorSubject<any[]>;
+    };
+  };
 
   const mockAttachment: DashboardAttachment = {
     type: DASHBOARD_ATTACHMENT_TYPE,
@@ -55,6 +98,7 @@ describe('DashboardCanvasContent', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    clearUnifiedSearchPersistedState('test-dashboard-id');
   });
 
   const simulateDashboardApiAvailable = (mockApi: DashboardApi) => {
@@ -66,6 +110,9 @@ describe('DashboardCanvasContent', () => {
       });
     }
   };
+
+  const getLatestSearchBarProps = (): Record<string, any> | undefined =>
+    (MockSearchBar as jest.Mock).mock.calls.at(-1)?.[0] as Record<string, any> | undefined;
 
   type DashboardCanvasContentProps = React.ComponentProps<typeof DashboardCanvasContent>;
 
@@ -83,10 +130,12 @@ describe('DashboardCanvasContent', () => {
       DashboardCanvasContentProps['checkSavedDashboardExist']
     > = jest.fn().mockResolvedValue(false);
     const mockApi = createMockDashboardApi();
+    const mockFilterManager = createMockFilterManager();
     const openSidebarConversation = jest.fn();
 
     const props: DashboardCanvasContentProps = {
       ...defaultProps,
+      filterManager: mockFilterManager as any,
       registerActionButtons,
       updateOrigin,
       closeCanvas,
@@ -108,6 +157,7 @@ describe('DashboardCanvasContent', () => {
       ...renderResult,
       props,
       mockApi,
+      mockFilterManager,
       registerActionButtons,
       updateOrigin,
       closeCanvas,
@@ -119,8 +169,8 @@ describe('DashboardCanvasContent', () => {
   it('renders the dashboard renderer and search bar', async () => {
     const { queryByTestId } = await renderDashboardCanvasContent();
 
-    expect(queryByTestId('dashboardRenderer')).toBeInTheDocument();
-    expect(queryByTestId('searchBar')).toBeInTheDocument();
+    expect(queryByTestId('dashboardRenderer')).not.toBeNull();
+    expect(queryByTestId('searchBar')).not.toBeNull();
   });
 
   it('registers action buttons when dashboard API becomes available', async () => {
@@ -132,6 +182,153 @@ describe('DashboardCanvasContent', () => {
         expect.objectContaining({ label: 'Save' }),
       ])
     );
+  });
+
+  it('enables query input and filter pills for preview search', async () => {
+    await renderDashboardCanvasContent();
+
+    expect(getLatestSearchBarProps()).toEqual(
+      expect.objectContaining({
+        showQueryInput: true,
+        showFilterBar: true,
+        showDatePicker: true,
+        showQueryMenu: false,
+        useDefaultBehaviors: true,
+      })
+    );
+  });
+
+  it('updates dashboard query and time range from the preview search bar', async () => {
+    const { mockApi } = await renderDashboardCanvasContent();
+
+    act(() => {
+      getLatestSearchBarProps()?.onQuerySubmit({
+        dateRange: { from: 'now-1h', to: 'now' },
+        query: { query: 'host.name: "web-01"', language: 'kuery' },
+      });
+    });
+
+    expect(mockApi.setQuery).toHaveBeenCalledWith({
+      query: 'host.name: "web-01"',
+      language: 'kuery',
+    });
+    expect(mockApi.setTimeRange).toHaveBeenCalledWith({ from: 'now-1h', to: 'now' });
+    expect(mockApi.forceRefresh).toHaveBeenCalled();
+  });
+
+  it('clears the dashboard query when the preview query input is submitted empty', async () => {
+    const { mockApi } = await renderDashboardCanvasContent();
+
+    act(() => {
+      getLatestSearchBarProps()?.onQuerySubmit({
+        dateRange: { from: 'now-1h', to: 'now' },
+        query: { query: '   ', language: 'kuery' },
+      });
+    });
+
+    expect(mockApi.setQuery).toHaveBeenCalledWith(undefined);
+    expect(mockApi.forceRefresh).toHaveBeenCalled();
+  });
+
+  it('preserves non-string query payloads when submitted', async () => {
+    const { mockApi } = await renderDashboardCanvasContent();
+    const queryDsl = {
+      query: { bool: { filter: [{ term: { 'host.name': 'web-01' } }] } },
+      language: 'kuery',
+    } as Query;
+
+    act(() => {
+      getLatestSearchBarProps()?.onQuerySubmit({
+        dateRange: { from: 'now-1h', to: 'now' },
+        query: queryDsl,
+      });
+    });
+
+    expect(mockApi.setQuery).toHaveBeenCalledWith(queryDsl);
+    expect(mockApi.forceRefresh).toHaveBeenCalled();
+  });
+
+  it('updates dashboard filters from the preview filter bar', async () => {
+    const { mockApi, props } = await renderDashboardCanvasContent();
+    const nextFilters = [{ meta: { key: 'host.name' } }] as Filter[];
+
+    (mockApi.setFilters as jest.MockedFunction<typeof mockApi.setFilters>).mockClear();
+    act(() => {
+      getLatestSearchBarProps()?.onFiltersUpdated(nextFilters);
+    });
+
+    expect(props.filterManager.setFilters).toHaveBeenCalledWith(nextFilters);
+    expect(mockApi.setFilters).toHaveBeenCalledWith(nextFilters);
+    expect(mockApi.setFilters).toHaveBeenCalledTimes(1);
+  });
+
+  it('hydrates unified search state from persisted preview state', async () => {
+    setPersistedState('test-dashboard-id', {
+      filters: [{ meta: { key: 'host.name' } }] as Filter[],
+      query: { query: 'host.name: "web-01"', language: 'kuery' },
+      timeRange: { from: 'now-1h', to: 'now' },
+    });
+
+    await renderDashboardCanvasContent();
+
+    expect(getLatestSearchBarProps()).toEqual(
+      expect.objectContaining({
+        filters: [{ meta: { key: 'host.name' } }],
+        query: { query: 'host.name: "web-01"', language: 'kuery' },
+        dateRangeFrom: 'now-1h',
+        dateRangeTo: 'now',
+      })
+    );
+  });
+
+  it('updates query bar index patterns when dashboard data views are published', async () => {
+    const { mockApi } = await renderDashboardCanvasContent();
+    const nextDataViews = [{ id: 'logs-*', title: 'logs-*' }];
+
+    expect(getLatestSearchBarProps()).toEqual(
+      expect.objectContaining({
+        indexPatterns: [],
+      })
+    );
+
+    act(() => {
+      mockApi.dataViews$.next(nextDataViews as any);
+    });
+
+    expect(getLatestSearchBarProps()).toEqual(
+      expect.objectContaining({
+        indexPatterns: nextDataViews,
+      })
+    );
+  });
+
+  it('updates the preview filter pills when filters are created through the filter manager API', async () => {
+    const { mockApi, mockFilterManager } = await renderDashboardCanvasContent();
+    const nextFilters = [{ meta: { key: 'extension' } }] as Filter[];
+    const setFiltersMock = mockApi.setFilters as jest.Mock;
+
+    setFiltersMock.mockClear();
+    act(() => {
+      mockFilterManager.emitFilters(nextFilters);
+    });
+
+    expect(mockApi.setFilters).toHaveBeenCalledWith(nextFilters);
+    expect(mockApi.setFilters).toHaveBeenCalledTimes(1);
+    expect(getLatestSearchBarProps()).toEqual(
+      expect.objectContaining({
+        filters: nextFilters,
+      })
+    );
+  });
+
+  it('refreshes the embedded dashboard from the preview search bar', async () => {
+    const { mockApi } = await renderDashboardCanvasContent();
+
+    act(() => {
+      getLatestSearchBarProps()?.onRefresh();
+    });
+
+    expect(mockApi.forceRefresh).toHaveBeenCalled();
   });
 
   describe('Edit in Dashboards button', () => {
@@ -186,6 +383,34 @@ describe('DashboardCanvasContent', () => {
           viewMode: 'edit',
           title: 'Test Dashboard',
           description: 'Test Description',
+        })
+      );
+    });
+
+    it('should carry the live preview query, filters, and time range into dashboard navigation', async () => {
+      const { registerActionButtons, mockApi } = await renderDashboardCanvasContent();
+      const nextFilters = [{ meta: { key: 'host.name' } }] as Filter[];
+
+      act(() => {
+        getLatestSearchBarProps()?.onFiltersUpdated(nextFilters);
+        getLatestSearchBarProps()?.onQuerySubmit({
+          dateRange: { from: 'now-1h', to: 'now' },
+          query: { query: 'host.name: "web-01"', language: 'kuery' },
+        });
+      });
+
+      const buttons: ActionButton[] = registerActionButtons.mock.calls.at(-1)?.[0] ?? [];
+      const editButton = buttons.find((b) => b.label === 'Edit in Dashboards');
+
+      await act(async () => {
+        await editButton?.handler();
+      });
+
+      expect(mockApi.locator?.navigate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          filters: nextFilters,
+          query: { query: 'host.name: "web-01"', language: 'kuery' },
+          time_range: { from: 'now-1h', to: 'now' },
         })
       );
     });

--- a/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/canvas_integration/dashboard_canvas_content.tsx
+++ b/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/canvas_integration/dashboard_canvas_content.tsx
@@ -121,7 +121,6 @@ export const DashboardCanvasContent = ({
     [attachment.data]
   );
   const { filters, query, searchBarProps, timeRange } = useDashboardPreviewUnifiedSearch({
-    attachmentId: attachment.id,
     dashboardApi,
     dashboardState,
     filterManager,

--- a/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/canvas_integration/dashboard_canvas_content.tsx
+++ b/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/canvas_integration/dashboard_canvas_content.tsx
@@ -8,14 +8,17 @@
 import React, { useCallback, useMemo, useState, useEffect } from 'react';
 import { css } from '@emotion/react';
 import type { ActionButton, AttachmentRenderProps } from '@kbn/agent-builder-browser/attachments';
+import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
+import type { DashboardLocatorParams } from '@kbn/dashboard-plugin/common';
 import type { DashboardApi, DashboardRendererProps } from '@kbn/dashboard-plugin/public';
 import type { UnifiedSearchPublicPluginStart } from '@kbn/unified-search-plugin/public';
 import type { UseEuiTheme } from '@elastic/eui';
 import { DashboardRenderer } from '@kbn/dashboard-plugin/public';
 import { useMemoCss } from '@kbn/css-utils/public/use_memo_css';
 import type { DashboardAttachment } from '@kbn/dashboard-agent-common/types';
-import { DEFAULT_TIME_RANGE, attachmentDataToDashboardState } from '@kbn/dashboard-agent-common';
+import { attachmentDataToDashboardState } from '@kbn/dashboard-agent-common';
 import type { SavedObjectStatus } from './use_register_canvas_action_buttons';
+import { useDashboardPreviewUnifiedSearch } from './use_dashboard_preview_unified_search';
 import { useRegisterCanvasActionButtons } from './use_register_canvas_action_buttons';
 
 const dashboardCanvasContentStyles = {
@@ -66,6 +69,7 @@ export const DashboardCanvasContent = ({
   openSidebarConversation,
   dashboardLocator,
   searchBarComponent: SearchBar,
+  filterManager,
   checkSavedDashboardExist,
 }: AttachmentRenderProps<DashboardAttachment> & {
   registerActionButtons: (buttons: ActionButton[]) => void;
@@ -74,6 +78,7 @@ export const DashboardCanvasContent = ({
   dashboardLocator?: DashboardRendererProps['locator'];
   openSidebarConversation?: () => void;
   searchBarComponent: UnifiedSearchPublicPluginStart['ui']['SearchBar'];
+  filterManager: DataPublicPluginStart['query']['filterManager'];
   checkSavedDashboardExist: (dashboardId: string) => Promise<boolean>;
 }) => {
   const [dashboardApi, setDashboardApi] = useState<DashboardApi | undefined>();
@@ -116,10 +121,12 @@ export const DashboardCanvasContent = ({
     () => attachmentDataToDashboardState(attachment.data),
     [attachment.data]
   );
-
-  const [timeRange, setTimeRange] = useState<{ from: string; to: string }>(
-    dashboardState.time_range ?? DEFAULT_TIME_RANGE
-  );
+  const { filters, query, searchBarProps, timeRange } = useDashboardPreviewUnifiedSearch({
+    attachmentId: attachment.id,
+    dashboardApi,
+    dashboardState,
+    filterManager,
+  });
 
   const getCreationOptions = useCallback(
     () =>
@@ -129,45 +136,38 @@ export const DashboardCanvasContent = ({
     [dashboardState]
   );
 
+  const dashboardLocatorParams = useMemo<DashboardLocatorParams>(
+    () => ({
+      ...dashboardState,
+      filters,
+      query,
+      time_range: timeRange,
+    }),
+    [dashboardState, filters, query, timeRange]
+  );
+  const getExistingDashboardId = useCallback(
+    () =>
+      savedObjectStatus.status === 'resolved' && savedObjectStatus.exists
+        ? attachmentOrigin
+        : undefined,
+    [attachmentOrigin, savedObjectStatus]
+  );
+
   useRegisterCanvasActionButtons({
     dashboardApi,
     registerActionButtons,
     updateOrigin,
-    closeCanvas,
     openSidebarConversation,
-    timeRange,
-    dashboardState,
-    attachmentOrigin,
-    savedObjectStatus,
+    dashboardLocatorParams,
+    getExistingDashboardId,
     isSidebar,
+    closeCanvas,
   });
 
   return (
     <div css={styles.root}>
       <div css={styles.searchBar}>
-        <SearchBar
-          appName="dashboardAgent"
-          isAutoRefreshDisabled={true}
-          showQueryInput={false}
-          showDatePicker={true}
-          showFilterBar={false}
-          showQueryMenu={false}
-          query={undefined}
-          displayStyle="inPage"
-          useDefaultBehaviors={true}
-          disableQueryLanguageSwitcher
-          isDisabled={!dashboardApi}
-          dateRangeFrom={timeRange.from}
-          dateRangeTo={timeRange.to}
-          onQuerySubmit={({ dateRange }) => {
-            setTimeRange(dateRange);
-            dashboardApi?.setTimeRange(dateRange);
-          }}
-          onRefresh={() => {
-            dashboardApi?.forceRefresh();
-          }}
-          data-test-subj="dashboardCanvasSearchBar"
-        />
+        <SearchBar {...searchBarProps} />
       </div>
       <div css={styles.renderer}>
         {savedObjectStatus.status !== 'resolved' ? null : (
@@ -175,17 +175,9 @@ export const DashboardCanvasContent = ({
             getCreationOptions={getCreationOptions}
             showPlainSpinner
             locator={dashboardLocator}
-            savedObjectId={
-              savedObjectStatus.status === 'resolved' && savedObjectStatus.exists
-                ? attachmentOrigin
-                : undefined
-            }
+            savedObjectId={getExistingDashboardId()}
             onApiAvailable={(api) => {
               api.setViewMode('view');
-              const initialTimeRange = api.timeRange$.value;
-              if (initialTimeRange) {
-                api.setTimeRange(initialTimeRange);
-              }
               setDashboardApi(api);
             }}
           />

--- a/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/canvas_integration/dashboard_canvas_content.tsx
+++ b/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/canvas_integration/dashboard_canvas_content.tsx
@@ -61,7 +61,6 @@ const dashboardCanvasContentStyles = {
 };
 
 export const DashboardCanvasContent = ({
-  isSidebar,
   attachment,
   registerActionButtons,
   updateOrigin,
@@ -160,7 +159,6 @@ export const DashboardCanvasContent = ({
     openSidebarConversation,
     dashboardLocatorParams,
     getExistingDashboardId,
-    isSidebar,
     closeCanvas,
   });
 

--- a/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/canvas_integration/use_dashboard_preview_unified_search.ts
+++ b/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/canvas_integration/use_dashboard_preview_unified_search.ts
@@ -1,0 +1,264 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { toStoredFilters } from '@kbn/as-code-filters-transforms';
+import { toStoredQuery } from '@kbn/as-code-shared-transforms';
+import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
+import type { DataView } from '@kbn/data-views-plugin/common';
+import type { DashboardApi } from '@kbn/dashboard-plugin/public';
+import { isOfQueryType, type Filter, type Query, type TimeRange } from '@kbn/es-query';
+import { isEqual } from 'lodash';
+import type { DashboardState } from '@kbn/dashboard-plugin/server';
+import { DEFAULT_TIME_RANGE } from '@kbn/dashboard-agent-common';
+
+interface DashboardPreviewUnifiedSearchState {
+  filters: Filter[];
+  query?: Query;
+  timeRange: TimeRange;
+}
+
+const persistedStateByAttachmentId = new Map<string, DashboardPreviewUnifiedSearchState>();
+
+export const getPersistedState = (attachmentId: string) =>
+  persistedStateByAttachmentId.get(attachmentId);
+
+export const setPersistedState = (
+  attachmentId: string,
+  state: DashboardPreviewUnifiedSearchState
+) => {
+  persistedStateByAttachmentId.set(attachmentId, state);
+};
+
+export const clearUnifiedSearchPersistedState = (attachmentId: string) => {
+  persistedStateByAttachmentId.delete(attachmentId);
+};
+
+const usePersistedState = (attachmentId: string) => {
+  const persistedState = useMemo(() => getPersistedState(attachmentId), [attachmentId]);
+  const onStateChange = useCallback(
+    (state: DashboardPreviewUnifiedSearchState) => {
+      setPersistedState(attachmentId, state);
+    },
+    [attachmentId]
+  );
+
+  return {
+    persistedState,
+    onStateChange,
+  };
+};
+
+interface UseDashboardPreviewUnifiedSearchParams {
+  attachmentId: string;
+  dashboardApi: DashboardApi | undefined;
+  dashboardState: DashboardState;
+  filterManager: DataPublicPluginStart['query']['filterManager'];
+}
+
+export const useDashboardPreviewUnifiedSearch = ({
+  attachmentId,
+  dashboardApi,
+  dashboardState,
+  filterManager,
+}: UseDashboardPreviewUnifiedSearchParams) => {
+  const { persistedState, onStateChange } = usePersistedState(attachmentId);
+  const initialQuery = useMemo(() => toStoredQuery(dashboardState.query), [dashboardState.query]);
+  const initialFilters = useMemo(
+    () => toStoredFilters(dashboardState.filters) ?? [],
+    [dashboardState.filters]
+  );
+  const initialTimeRange = useMemo<TimeRange>(
+    () => dashboardState.time_range ?? DEFAULT_TIME_RANGE,
+    [dashboardState.time_range]
+  );
+
+  const [timeRange, setTimeRange] = useState<TimeRange>(
+    persistedState?.timeRange ?? initialTimeRange
+  );
+  const [query, setQuery] = useState<Query | undefined>(persistedState?.query ?? initialQuery);
+  const [filters, setFilters] = useState<Filter[]>(persistedState?.filters ?? initialFilters);
+  const [dataViews, setDataViews] = useState<DataView[]>([]);
+
+  const normalizeQuery = useCallback((nextQuery: Query | undefined) => {
+    if (!nextQuery) {
+      return undefined;
+    }
+
+    if (typeof nextQuery.query !== 'string') {
+      return nextQuery;
+    }
+
+    return nextQuery.query.trim() === '' ? undefined : nextQuery;
+  }, []);
+
+  useEffect(() => {
+    setQuery(persistedState?.query ?? initialQuery);
+    setFilters(persistedState?.filters ?? initialFilters);
+    setTimeRange(persistedState?.timeRange ?? initialTimeRange);
+  }, [attachmentId, initialFilters, initialQuery, initialTimeRange, persistedState]);
+
+  useEffect(() => {
+    onStateChange?.({
+      filters,
+      query,
+      timeRange,
+    });
+  }, [filters, onStateChange, query, timeRange]);
+
+  useEffect(() => {
+    const filterManagerSubscription = filterManager.getUpdates$().subscribe(() => {
+      const nextFilters = filterManager.getFilters();
+      setFilters((currentFilters) =>
+        isEqual(currentFilters, nextFilters) ? currentFilters : nextFilters
+      );
+    });
+
+    return () => {
+      filterManagerSubscription.unsubscribe();
+    };
+  }, [filterManager]);
+
+  useEffect(() => {
+    if (!dashboardApi) {
+      return;
+    }
+
+    dashboardApi.setQuery(query);
+  }, [dashboardApi, query]);
+
+  useEffect(() => {
+    if (!dashboardApi) {
+      return;
+    }
+
+    dashboardApi.setFilters(filters);
+  }, [dashboardApi, filters]);
+
+  useEffect(() => {
+    if (!dashboardApi) {
+      return;
+    }
+
+    dashboardApi.setTimeRange(timeRange);
+  }, [dashboardApi, timeRange]);
+
+  useEffect(() => {
+    if (!dashboardApi) {
+      setDataViews([]);
+      return;
+    }
+
+    setDataViews(dashboardApi.dataViews$.value ?? []);
+
+    const querySubscription = dashboardApi.query$.subscribe((nextQuery) => {
+      const resolvedQuery = normalizeQuery(
+        nextQuery && isOfQueryType(nextQuery) ? nextQuery : undefined
+      );
+      setQuery((currentQuery) =>
+        isEqual(currentQuery, resolvedQuery) ? currentQuery : resolvedQuery
+      );
+    });
+    const dataViewsSubscription = dashboardApi.dataViews$.subscribe((nextDataViews) => {
+      const resolvedDataViews = nextDataViews ?? [];
+      setDataViews((currentDataViews) =>
+        isEqual(currentDataViews, resolvedDataViews) ? currentDataViews : resolvedDataViews
+      );
+    });
+    const filtersSubscription = dashboardApi.filters$.subscribe((nextFilters) => {
+      const resolvedFilters = nextFilters ?? [];
+      setFilters((currentFilters) =>
+        isEqual(currentFilters, resolvedFilters) ? currentFilters : resolvedFilters
+      );
+    });
+    const timeRangeSubscription = dashboardApi.timeRange$.subscribe((nextTimeRange) => {
+      if (!nextTimeRange) {
+        return;
+      }
+
+      setTimeRange((currentTimeRange) =>
+        isEqual(currentTimeRange, nextTimeRange) ? currentTimeRange : nextTimeRange
+      );
+    });
+
+    return () => {
+      querySubscription.unsubscribe();
+      dataViewsSubscription.unsubscribe();
+      filtersSubscription.unsubscribe();
+      timeRangeSubscription.unsubscribe();
+    };
+  }, [dashboardApi, normalizeQuery]);
+
+  const onQuerySubmit = useCallback(
+    ({ dateRange, query: nextQuery }: { dateRange: TimeRange; query?: Query }) => {
+      const resolvedQuery = normalizeQuery(nextQuery);
+      setTimeRange(dateRange);
+      setQuery(resolvedQuery);
+      dashboardApi?.setTimeRange(dateRange);
+      dashboardApi?.setQuery(resolvedQuery);
+      dashboardApi?.forceRefresh();
+    },
+    [dashboardApi, normalizeQuery]
+  );
+
+  const onFiltersUpdated = useCallback(
+    (nextFilters: Filter[]) => {
+      setFilters(nextFilters);
+      filterManager.setFilters(nextFilters);
+    },
+    [filterManager]
+  );
+
+  const onRefresh = useCallback(() => {
+    dashboardApi?.forceRefresh();
+  }, [dashboardApi]);
+
+  const searchBarProps = useMemo(
+    () => ({
+      appName: 'dashboardAgent',
+      isAutoRefreshDisabled: true,
+      showQueryInput: true,
+      showDatePicker: true,
+      showFilterBar: true,
+      showQueryMenu: false,
+      query,
+      filters,
+      indexPatterns: dataViews,
+      screenTitle: dashboardState.title,
+      displayStyle: 'inPage' as const,
+      useDefaultBehaviors: true,
+      disableQueryLanguageSwitcher: true,
+      isDisabled: !dashboardApi,
+      dateRangeFrom: timeRange.from,
+      dateRangeTo: timeRange.to,
+      onQuerySubmit,
+      onFiltersUpdated,
+      onRefresh,
+      dataTestSubj: 'dashboardCanvasSearchBar',
+    }),
+    [
+      dashboardApi,
+      dashboardState.title,
+      dataViews,
+      filters,
+      onFiltersUpdated,
+      onQuerySubmit,
+      onRefresh,
+      query,
+      timeRange.from,
+      timeRange.to,
+    ]
+  );
+
+  return {
+    dataViews,
+    filters,
+    query,
+    searchBarProps,
+    timeRange,
+  };
+};

--- a/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/canvas_integration/use_dashboard_preview_unified_search.ts
+++ b/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/canvas_integration/use_dashboard_preview_unified_search.ts
@@ -17,63 +17,36 @@ import type { DashboardState } from '@kbn/dashboard-plugin/server';
 import { DEFAULT_TIME_RANGE } from '@kbn/dashboard-agent-common';
 
 interface UseDashboardPreviewUnifiedSearchParams {
-  attachmentId: string;
   dashboardApi: DashboardApi | undefined;
   dashboardState: DashboardState;
   filterManager: DataPublicPluginStart['query']['filterManager'];
 }
 
+const normalizeQuery = (nextQuery: Query | undefined) => {
+  if (!nextQuery) {
+    return undefined;
+  }
+
+  if (typeof nextQuery.query !== 'string') {
+    return nextQuery;
+  }
+
+  return nextQuery.query.trim() === '' ? undefined : nextQuery;
+};
+
 export const useDashboardPreviewUnifiedSearch = ({
-  attachmentId,
   dashboardApi,
   dashboardState,
   filterManager,
 }: UseDashboardPreviewUnifiedSearchParams) => {
-  const initialQuery = useMemo(() => toStoredQuery(dashboardState.query), [dashboardState.query]);
-  const initialFilters = useMemo(
-    () => toStoredFilters(dashboardState.filters) ?? [],
-    [dashboardState.filters]
+  const [timeRange, setTimeRange] = useState<TimeRange>(
+    dashboardState.time_range ?? DEFAULT_TIME_RANGE
   );
-  const initialTimeRange = useMemo<TimeRange>(
-    () => dashboardState.time_range ?? DEFAULT_TIME_RANGE,
-    [dashboardState.time_range]
+  const [query, setQuery] = useState<Query | undefined>(
+    normalizeQuery(toStoredQuery(dashboardState.query))
   );
-
-  const [timeRange, setTimeRange] = useState<TimeRange>(initialTimeRange);
-  const [query, setQuery] = useState<Query | undefined>(initialQuery);
-  const [filters, setFilters] = useState<Filter[]>(initialFilters);
+  const [filters, setFilters] = useState<Filter[]>(toStoredFilters(dashboardState.filters) ?? []);
   const [dataViews, setDataViews] = useState<DataView[]>([]);
-
-  const normalizeQuery = useCallback((nextQuery: Query | undefined) => {
-    if (!nextQuery) {
-      return undefined;
-    }
-
-    if (typeof nextQuery.query !== 'string') {
-      return nextQuery;
-    }
-
-    return nextQuery.query.trim() === '' ? undefined : nextQuery;
-  }, []);
-
-  useEffect(() => {
-    setQuery(initialQuery);
-    setFilters(initialFilters);
-    setTimeRange(initialTimeRange);
-  }, [attachmentId, initialFilters, initialQuery, initialTimeRange]);
-
-  useEffect(() => {
-    const filterManagerSubscription = filterManager.getUpdates$().subscribe(() => {
-      const nextFilters = filterManager.getFilters();
-      setFilters((currentFilters) =>
-        isEqual(currentFilters, nextFilters) ? currentFilters : nextFilters
-      );
-    });
-
-    return () => {
-      filterManagerSubscription.unsubscribe();
-    };
-  }, [filterManager]);
 
   useEffect(() => {
     if (!dashboardApi) {
@@ -81,23 +54,9 @@ export const useDashboardPreviewUnifiedSearch = ({
     }
 
     dashboardApi.setQuery(query);
-  }, [dashboardApi, query]);
-
-  useEffect(() => {
-    if (!dashboardApi) {
-      return;
-    }
-
     dashboardApi.setFilters(filters);
-  }, [dashboardApi, filters]);
-
-  useEffect(() => {
-    if (!dashboardApi) {
-      return;
-    }
-
     dashboardApi.setTimeRange(timeRange);
-  }, [dashboardApi, timeRange]);
+  }, [dashboardApi, query, filters, timeRange]);
 
   useEffect(() => {
     if (!dashboardApi) {
@@ -121,12 +80,6 @@ export const useDashboardPreviewUnifiedSearch = ({
         isEqual(currentDataViews, resolvedDataViews) ? currentDataViews : resolvedDataViews
       );
     });
-    const filtersSubscription = dashboardApi.filters$.subscribe((nextFilters) => {
-      const resolvedFilters = nextFilters ?? [];
-      setFilters((currentFilters) =>
-        isEqual(currentFilters, resolvedFilters) ? currentFilters : resolvedFilters
-      );
-    });
     const timeRangeSubscription = dashboardApi.timeRange$.subscribe((nextTimeRange) => {
       if (!nextTimeRange) {
         return;
@@ -140,34 +93,43 @@ export const useDashboardPreviewUnifiedSearch = ({
     return () => {
       querySubscription.unsubscribe();
       dataViewsSubscription.unsubscribe();
-      filtersSubscription.unsubscribe();
       timeRangeSubscription.unsubscribe();
     };
-  }, [dashboardApi, normalizeQuery]);
+  }, [dashboardApi]);
+
+  useEffect(() => {
+    const filterManagerSubscription = filterManager.getUpdates$().subscribe(() => {
+      const nextFilters = filterManager.getFilters();
+      setFilters((currentFilters) =>
+        isEqual(currentFilters, nextFilters) ? currentFilters : nextFilters
+      );
+    });
+
+    return () => {
+      filterManagerSubscription.unsubscribe();
+    };
+  }, [filterManager]);
+
+  const onRefresh = useCallback(() => {
+    dashboardApi?.forceRefresh();
+  }, [dashboardApi]);
 
   const onQuerySubmit = useCallback(
     ({ dateRange, query: nextQuery }: { dateRange: TimeRange; query?: Query }) => {
       const resolvedQuery = normalizeQuery(nextQuery);
       setTimeRange(dateRange);
       setQuery(resolvedQuery);
-      dashboardApi?.setTimeRange(dateRange);
-      dashboardApi?.setQuery(resolvedQuery);
       dashboardApi?.forceRefresh();
     },
-    [dashboardApi, normalizeQuery]
+    [dashboardApi]
   );
 
   const onFiltersUpdated = useCallback(
     (nextFilters: Filter[]) => {
-      setFilters(nextFilters);
       filterManager.setFilters(nextFilters);
     },
     [filterManager]
   );
-
-  const onRefresh = useCallback(() => {
-    dashboardApi?.forceRefresh();
-  }, [dashboardApi]);
 
   const searchBarProps = useMemo(
     () => ({

--- a/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/canvas_integration/use_dashboard_preview_unified_search.ts
+++ b/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/canvas_integration/use_dashboard_preview_unified_search.ts
@@ -16,43 +16,6 @@ import { isEqual } from 'lodash';
 import type { DashboardState } from '@kbn/dashboard-plugin/server';
 import { DEFAULT_TIME_RANGE } from '@kbn/dashboard-agent-common';
 
-interface DashboardPreviewUnifiedSearchState {
-  filters: Filter[];
-  query?: Query;
-  timeRange: TimeRange;
-}
-
-const persistedStateByAttachmentId = new Map<string, DashboardPreviewUnifiedSearchState>();
-
-export const getPersistedState = (attachmentId: string) =>
-  persistedStateByAttachmentId.get(attachmentId);
-
-export const setPersistedState = (
-  attachmentId: string,
-  state: DashboardPreviewUnifiedSearchState
-) => {
-  persistedStateByAttachmentId.set(attachmentId, state);
-};
-
-export const clearUnifiedSearchPersistedState = (attachmentId: string) => {
-  persistedStateByAttachmentId.delete(attachmentId);
-};
-
-const usePersistedState = (attachmentId: string) => {
-  const persistedState = useMemo(() => getPersistedState(attachmentId), [attachmentId]);
-  const onStateChange = useCallback(
-    (state: DashboardPreviewUnifiedSearchState) => {
-      setPersistedState(attachmentId, state);
-    },
-    [attachmentId]
-  );
-
-  return {
-    persistedState,
-    onStateChange,
-  };
-};
-
 interface UseDashboardPreviewUnifiedSearchParams {
   attachmentId: string;
   dashboardApi: DashboardApi | undefined;
@@ -66,7 +29,6 @@ export const useDashboardPreviewUnifiedSearch = ({
   dashboardState,
   filterManager,
 }: UseDashboardPreviewUnifiedSearchParams) => {
-  const { persistedState, onStateChange } = usePersistedState(attachmentId);
   const initialQuery = useMemo(() => toStoredQuery(dashboardState.query), [dashboardState.query]);
   const initialFilters = useMemo(
     () => toStoredFilters(dashboardState.filters) ?? [],
@@ -77,11 +39,9 @@ export const useDashboardPreviewUnifiedSearch = ({
     [dashboardState.time_range]
   );
 
-  const [timeRange, setTimeRange] = useState<TimeRange>(
-    persistedState?.timeRange ?? initialTimeRange
-  );
-  const [query, setQuery] = useState<Query | undefined>(persistedState?.query ?? initialQuery);
-  const [filters, setFilters] = useState<Filter[]>(persistedState?.filters ?? initialFilters);
+  const [timeRange, setTimeRange] = useState<TimeRange>(initialTimeRange);
+  const [query, setQuery] = useState<Query | undefined>(initialQuery);
+  const [filters, setFilters] = useState<Filter[]>(initialFilters);
   const [dataViews, setDataViews] = useState<DataView[]>([]);
 
   const normalizeQuery = useCallback((nextQuery: Query | undefined) => {
@@ -97,18 +57,10 @@ export const useDashboardPreviewUnifiedSearch = ({
   }, []);
 
   useEffect(() => {
-    setQuery(persistedState?.query ?? initialQuery);
-    setFilters(persistedState?.filters ?? initialFilters);
-    setTimeRange(persistedState?.timeRange ?? initialTimeRange);
-  }, [attachmentId, initialFilters, initialQuery, initialTimeRange, persistedState]);
-
-  useEffect(() => {
-    onStateChange?.({
-      filters,
-      query,
-      timeRange,
-    });
-  }, [filters, onStateChange, query, timeRange]);
+    setQuery(initialQuery);
+    setFilters(initialFilters);
+    setTimeRange(initialTimeRange);
+  }, [attachmentId, initialFilters, initialQuery, initialTimeRange]);
 
   useEffect(() => {
     const filterManagerSubscription = filterManager.getUpdates$().subscribe(() => {
@@ -219,26 +171,26 @@ export const useDashboardPreviewUnifiedSearch = ({
 
   const searchBarProps = useMemo(
     () => ({
+      query,
+      filters,
+      indexPatterns: dataViews,
+      dateRangeFrom: timeRange.from,
+      dateRangeTo: timeRange.to,
+      onQuerySubmit,
+      onFiltersUpdated,
+      onRefresh,
+      useDefaultBehaviors: true,
+      disableQueryLanguageSwitcher: true,
+      isDisabled: !dashboardApi,
+      dataTestSubj: 'dashboardCanvasSearchBar',
       appName: 'dashboardAgent',
       isAutoRefreshDisabled: true,
       showQueryInput: true,
       showDatePicker: true,
       showFilterBar: true,
       showQueryMenu: false,
-      query,
-      filters,
-      indexPatterns: dataViews,
       screenTitle: dashboardState.title,
       displayStyle: 'inPage' as const,
-      useDefaultBehaviors: true,
-      disableQueryLanguageSwitcher: true,
-      isDisabled: !dashboardApi,
-      dateRangeFrom: timeRange.from,
-      dateRangeTo: timeRange.to,
-      onQuerySubmit,
-      onFiltersUpdated,
-      onRefresh,
-      dataTestSubj: 'dashboardCanvasSearchBar',
     }),
     [
       dashboardApi,

--- a/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/canvas_integration/use_register_canvas_action_buttons.ts
+++ b/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/canvas_integration/use_register_canvas_action_buttons.ts
@@ -8,7 +8,7 @@
 import { useEffect } from 'react';
 import { ActionButtonType } from '@kbn/agent-builder-browser/attachments';
 import type { ActionButton } from '@kbn/agent-builder-browser/attachments';
-import type { DashboardState } from '@kbn/dashboard-plugin/common';
+import type { DashboardLocatorParams } from '@kbn/dashboard-plugin/common';
 import type { DashboardApi } from '@kbn/dashboard-plugin/public';
 import { i18n } from '@kbn/i18n';
 import useLatest from 'react-use/lib/useLatest';
@@ -22,13 +22,11 @@ interface UseRegisterCanvasActionButtonsParams {
   dashboardApi: DashboardApi | undefined;
   registerActionButtons: (buttons: ActionButton[]) => void;
   updateOrigin: (origin: string) => Promise<unknown>;
-  timeRange: { from: string; to: string };
-  dashboardState: Pick<DashboardState, 'title' | 'description' | 'panels' | 'time_range'>;
-  attachmentOrigin: string | undefined;
+  dashboardLocatorParams: DashboardLocatorParams;
+  getExistingDashboardId: () => string | undefined;
   isSidebar: boolean;
   closeCanvas: () => void;
   openSidebarConversation?: () => void;
-  savedObjectStatus: SavedObjectStatus;
 }
 
 export const useRegisterCanvasActionButtons = ({
@@ -37,17 +35,13 @@ export const useRegisterCanvasActionButtons = ({
   updateOrigin,
   closeCanvas,
   openSidebarConversation,
-  timeRange,
-  dashboardState,
-  attachmentOrigin,
+  dashboardLocatorParams,
+  getExistingDashboardId,
   isSidebar,
-  savedObjectStatus,
 }: UseRegisterCanvasActionButtonsParams) => {
-  const timeRangeRef = useLatest(timeRange);
-  const attachmentOriginRef = useLatest(attachmentOrigin);
-  const dashboardStateRef = useLatest(dashboardState);
+  const dashboardLocatorParamsRef = useLatest(dashboardLocatorParams);
+  const getExistingDashboardIdRef = useLatest(getExistingDashboardId);
   const openSidebarConversationRef = useLatest(openSidebarConversation);
-  const savedObjectStatusRef = useLatest(savedObjectStatus);
 
   useEffect(() => {
     if (!dashboardApi) {
@@ -65,15 +59,10 @@ export const useRegisterCanvasActionButtons = ({
         }),
         type: ActionButtonType.PRIMARY,
         handler: async () => {
-          const existingAttachmentOrigin =
-            savedObjectStatusRef.current.status === 'resolved' &&
-            savedObjectStatusRef.current.exists
-              ? attachmentOriginRef.current
-              : undefined;
+          const existingAttachmentOrigin = getExistingDashboardIdRef.current();
           await locator.navigate({
-            ...dashboardStateRef.current,
+            ...dashboardLocatorParamsRef.current,
             dashboardId: existingAttachmentOrigin,
-            time_range: timeRangeRef.current,
             viewMode: 'edit',
           });
           closeCanvas();
@@ -90,10 +79,7 @@ export const useRegisterCanvasActionButtons = ({
       icon: 'save',
       type: ActionButtonType.PRIMARY,
       handler: async () => {
-        const existingAttachmentOrigin =
-          savedObjectStatusRef.current.status === 'resolved' && savedObjectStatusRef.current.exists
-            ? attachmentOriginRef.current
-            : undefined;
+        const existingAttachmentOrigin = getExistingDashboardIdRef.current();
         if (existingAttachmentOrigin) {
           await dashboardApi.runQuickSave();
           await updateOrigin(existingAttachmentOrigin);
@@ -112,10 +98,8 @@ export const useRegisterCanvasActionButtons = ({
     updateOrigin,
     closeCanvas,
     openSidebarConversationRef,
-    timeRangeRef,
-    attachmentOriginRef,
-    dashboardStateRef,
-    savedObjectStatusRef,
+    dashboardLocatorParamsRef,
+    getExistingDashboardIdRef,
     isSidebar,
   ]);
 };

--- a/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/canvas_integration/use_register_canvas_action_buttons.ts
+++ b/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/canvas_integration/use_register_canvas_action_buttons.ts
@@ -12,6 +12,7 @@ import type { DashboardLocatorParams } from '@kbn/dashboard-plugin/common';
 import type { DashboardApi } from '@kbn/dashboard-plugin/public';
 import { i18n } from '@kbn/i18n';
 import useLatest from 'react-use/lib/useLatest';
+import { handleEditInDashboard } from '../handle_edit_in_dashboard';
 
 export type SavedObjectStatus =
   | { status: 'idle' }
@@ -24,7 +25,6 @@ interface UseRegisterCanvasActionButtonsParams {
   updateOrigin: (origin: string) => Promise<unknown>;
   dashboardLocatorParams: DashboardLocatorParams;
   getExistingDashboardId: () => string | undefined;
-  isSidebar: boolean;
   closeCanvas: () => void;
   openSidebarConversation?: () => void;
 }
@@ -37,7 +37,6 @@ export const useRegisterCanvasActionButtons = ({
   openSidebarConversation,
   dashboardLocatorParams,
   getExistingDashboardId,
-  isSidebar,
 }: UseRegisterCanvasActionButtonsParams) => {
   const dashboardLocatorParamsRef = useLatest(dashboardLocatorParams);
   const getExistingDashboardIdRef = useLatest(getExistingDashboardId);
@@ -59,16 +58,13 @@ export const useRegisterCanvasActionButtons = ({
         }),
         type: ActionButtonType.PRIMARY,
         handler: async () => {
-          const existingAttachmentOrigin = getExistingDashboardIdRef.current();
-          await locator.navigate({
-            ...dashboardLocatorParamsRef.current,
-            dashboardId: existingAttachmentOrigin,
-            viewMode: 'edit',
+          await handleEditInDashboard({
+            locator,
+            getExistingDashboardId: async () => getExistingDashboardIdRef.current(),
+            dashboardLocatorParams: dashboardLocatorParamsRef.current,
           });
           closeCanvas();
-          if (!isSidebar) {
-            openSidebarConversationRef.current?.();
-          }
+          openSidebarConversationRef.current?.();
         },
       });
     }
@@ -100,6 +96,5 @@ export const useRegisterCanvasActionButtons = ({
     openSidebarConversationRef,
     dashboardLocatorParamsRef,
     getExistingDashboardIdRef,
-    isSidebar,
   ]);
 };

--- a/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/handle_edit_in_dashboard.ts
+++ b/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/handle_edit_in_dashboard.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { DashboardRendererProps } from '@kbn/dashboard-plugin/public';
+
+export const handleEditInDashboard = async ({
+  locator,
+  getExistingDashboardId,
+  dashboardLocatorParams,
+}: {
+  locator: NonNullable<DashboardRendererProps['locator']>;
+  getExistingDashboardId: () => Promise<string | undefined>;
+  dashboardLocatorParams: Record<string, unknown>;
+}) => {
+  const dashboardId = await getExistingDashboardId();
+  await locator.navigate({
+    ...dashboardLocatorParams,
+    dashboardId,
+    viewMode: 'edit',
+  });
+};

--- a/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/index.test.tsx
+++ b/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/index.test.tsx
@@ -9,6 +9,7 @@ import { BehaviorSubject, Subject } from 'rxjs';
 import type { DashboardApi, DashboardStart } from '@kbn/dashboard-plugin/public';
 import type { DashboardSaveEvent } from '@kbn/dashboard-plugin/public';
 import type { AgentBuilderPluginStart } from '@kbn/agent-builder-plugin/public';
+import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
 import type { UnifiedSearchPublicPluginStart } from '@kbn/unified-search-plugin/public';
 import type { AttachmentUIDefinition } from '@kbn/agent-builder-browser/attachments';
 import type { DashboardAttachment } from '@kbn/dashboard-agent-common/types';
@@ -17,6 +18,11 @@ import type { ChatEvent, RoundCompleteEvent, ConversationRound } from '@kbn/agen
 import { ChatEventType } from '@kbn/agent-builder-common';
 import { ATTACHMENT_REF_OPERATION } from '@kbn/agent-builder-common/attachments';
 import type { VersionedAttachment } from '@kbn/agent-builder-common/attachments';
+import {
+  clearUnifiedSearchPersistedState,
+  getPersistedState,
+  setPersistedState,
+} from './canvas_integration/use_dashboard_preview_unified_search';
 import { registerDashboardAttachmentUiDefinition } from '.';
 
 jest.mock('@kbn/dashboard-plugin/public', () => ({
@@ -175,6 +181,14 @@ describe('registerDashboardAttachmentUiDefinition', () => {
       findDashboardsService,
     } as unknown as DashboardStart;
 
+    const data: DataPublicPluginStart = {
+      query: {
+        filterManager: {
+          setFilters: jest.fn(),
+        },
+      },
+    } as unknown as DataPublicPluginStart;
+
     const unifiedSearch: UnifiedSearchPublicPluginStart = {
       ui: { SearchBar: jest.fn() },
     } as unknown as UnifiedSearchPublicPluginStart;
@@ -182,6 +196,8 @@ describe('registerDashboardAttachmentUiDefinition', () => {
     return {
       agentBuilder,
       addAttachment: mockAddAttachment,
+      data,
+      filterManager: data.query.filterManager,
       dashboardPlugin,
       unifiedSearch,
       dashboardLocator: undefined,
@@ -195,6 +211,7 @@ describe('registerDashboardAttachmentUiDefinition', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    clearUnifiedSearchPersistedState('attachment-1');
     deps = createMockDeps();
     unregister = registerDashboardAttachmentUiDefinition(deps);
     uiDefinition = deps.addAttachmentType.mock.calls[0][1];
@@ -215,6 +232,45 @@ describe('registerDashboardAttachmentUiDefinition', () => {
         getActionButtons: expect.any(Function),
       })
     );
+  });
+
+  it('persists canvas unified search state per attachment across render calls', () => {
+    const attachment: DashboardAttachment = {
+      id: 'attachment-1',
+      type: DASHBOARD_ATTACHMENT_TYPE,
+      data: { title: 'Test Dashboard', description: '', panels: [] },
+    };
+
+    setPersistedState(attachment.id, {
+      filters: [{ meta: { key: 'host.name' } }],
+      query: { query: 'host.name: "web-01"', language: 'kuery' },
+      timeRange: { from: 'now-1h', to: 'now' },
+    });
+
+    expect(getPersistedState(attachment.id)).toEqual({
+      filters: [{ meta: { key: 'host.name' } }],
+      query: { query: 'host.name: "web-01"', language: 'kuery' },
+      timeRange: { from: 'now-1h', to: 'now' },
+    });
+  });
+
+  it('clears persisted canvas unified search state when attachment unmounts', () => {
+    const { getAttachment } = createMockAttachment('attachment-1');
+
+    setPersistedState('attachment-1', {
+      filters: [{ meta: { key: 'host.name' } }],
+      query: { query: 'host.name: "web-01"', language: 'kuery' },
+      timeRange: { from: 'now-1h', to: 'now' },
+    });
+
+    const cleanup = uiDefinition.onAttachmentMount!({
+      getAttachment,
+      updateOrigin,
+    });
+
+    cleanup?.();
+
+    expect(getPersistedState('attachment-1')).toBeUndefined();
   });
 
   describe('onAttachmentMount - origin sync', () => {

--- a/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/index.test.tsx
+++ b/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/index.test.tsx
@@ -18,11 +18,6 @@ import type { ChatEvent, RoundCompleteEvent, ConversationRound } from '@kbn/agen
 import { ChatEventType } from '@kbn/agent-builder-common';
 import { ATTACHMENT_REF_OPERATION } from '@kbn/agent-builder-common/attachments';
 import type { VersionedAttachment } from '@kbn/agent-builder-common/attachments';
-import {
-  clearUnifiedSearchPersistedState,
-  getPersistedState,
-  setPersistedState,
-} from './canvas_integration/use_dashboard_preview_unified_search';
 import { registerDashboardAttachmentUiDefinition } from '.';
 
 jest.mock('@kbn/dashboard-plugin/public', () => ({
@@ -211,7 +206,6 @@ describe('registerDashboardAttachmentUiDefinition', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    clearUnifiedSearchPersistedState('attachment-1');
     deps = createMockDeps();
     unregister = registerDashboardAttachmentUiDefinition(deps);
     uiDefinition = deps.addAttachmentType.mock.calls[0][1];
@@ -233,46 +227,6 @@ describe('registerDashboardAttachmentUiDefinition', () => {
       })
     );
   });
-
-  it('persists canvas unified search state per attachment across render calls', () => {
-    const attachment: DashboardAttachment = {
-      id: 'attachment-1',
-      type: DASHBOARD_ATTACHMENT_TYPE,
-      data: { title: 'Test Dashboard', description: '', panels: [] },
-    };
-
-    setPersistedState(attachment.id, {
-      filters: [{ meta: { key: 'host.name' } }],
-      query: { query: 'host.name: "web-01"', language: 'kuery' },
-      timeRange: { from: 'now-1h', to: 'now' },
-    });
-
-    expect(getPersistedState(attachment.id)).toEqual({
-      filters: [{ meta: { key: 'host.name' } }],
-      query: { query: 'host.name: "web-01"', language: 'kuery' },
-      timeRange: { from: 'now-1h', to: 'now' },
-    });
-  });
-
-  it('clears persisted canvas unified search state when attachment unmounts', () => {
-    const { getAttachment } = createMockAttachment('attachment-1');
-
-    setPersistedState('attachment-1', {
-      filters: [{ meta: { key: 'host.name' } }],
-      query: { query: 'host.name: "web-01"', language: 'kuery' },
-      timeRange: { from: 'now-1h', to: 'now' },
-    });
-
-    const cleanup = uiDefinition.onAttachmentMount!({
-      getAttachment,
-      updateOrigin,
-    });
-
-    cleanup?.();
-
-    expect(getPersistedState('attachment-1')).toBeUndefined();
-  });
-
   describe('onAttachmentMount - origin sync', () => {
     it('updates origin when new dashboard is saved', async () => {
       const { getAttachment } = createMockAttachment('attachment-1');

--- a/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/index.tsx
+++ b/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/index.tsx
@@ -22,7 +22,6 @@ import type {
 import type { UnifiedSearchPublicPluginStart } from '@kbn/unified-search-plugin/public';
 import type { AgentBuilderPluginStart } from '@kbn/agent-builder-plugin/public';
 import { DashboardCanvasContent } from './canvas_integration/dashboard_canvas_content';
-import { clearUnifiedSearchPersistedState } from './canvas_integration/use_dashboard_preview_unified_search';
 import { createDashboardAppIntegration$ } from './dashboard_integration/dashboard_app_integration';
 import { previewAttachmentInDashboard } from './dashboard_integration/preview_attachment';
 import { selectDashboardAttachmentForSync } from './dashboard_integration/select_dashboard_attachment_for_sync';
@@ -76,7 +75,6 @@ export const registerDashboardAttachmentUiDefinition = ({
     getIcon: () => 'productDashboard',
     onAttachmentMount: (params: AttachmentLifecycleParams<DashboardAttachment>) => {
       const mountedAttachmentId = nextMountedAttachmentId++;
-      const attachmentId = params.getAttachment().id;
       mountedDashboardAttachments.set(mountedAttachmentId, params.getAttachment);
       const apiSubscription = dashboardPlugin.dashboardAppClientApi$
         .pipe(
@@ -97,7 +95,6 @@ export const registerDashboardAttachmentUiDefinition = ({
       return () => {
         apiSubscription.unsubscribe();
         mountedDashboardAttachments.delete(mountedAttachmentId);
-        clearUnifiedSearchPersistedState(attachmentId);
       };
     },
     renderCanvasContent: (props, callbacks) => (

--- a/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/index.tsx
+++ b/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/index.tsx
@@ -13,6 +13,7 @@ import { ActionButtonType } from '@kbn/agent-builder-browser/attachments';
 import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
 import { DASHBOARD_ATTACHMENT_TYPE } from '@kbn/dashboard-agent-common';
 import type { DashboardAttachment } from '@kbn/dashboard-agent-common/types';
+import { attachmentDataToDashboardState } from '@kbn/dashboard-agent-common';
 import type {
   DashboardApi,
   DashboardRendererProps,
@@ -25,6 +26,7 @@ import { clearUnifiedSearchPersistedState } from './canvas_integration/use_dashb
 import { createDashboardAppIntegration$ } from './dashboard_integration/dashboard_app_integration';
 import { previewAttachmentInDashboard } from './dashboard_integration/preview_attachment';
 import { selectDashboardAttachmentForSync } from './dashboard_integration/select_dashboard_attachment_for_sync';
+import { handleEditInDashboard } from './handle_edit_in_dashboard';
 
 export const registerDashboardAttachmentUiDefinition = ({
   agentBuilder,
@@ -108,7 +110,7 @@ export const registerDashboardAttachmentUiDefinition = ({
         checkSavedDashboardExist={checkSavedDashboardExist}
       />
     ),
-    getActionButtons: ({ attachment, openCanvas, isCanvas, updateOrigin }) => {
+    getActionButtons: ({ attachment, openCanvas, isCanvas, isSidebar, updateOrigin }) => {
       if (isCanvas) {
         return [];
       }
@@ -120,6 +122,7 @@ export const registerDashboardAttachmentUiDefinition = ({
           icon: 'eye',
           type: ActionButtonType.SECONDARY,
           handler: () => {
+            // sidebar in dashboard experience - syncronize dashboard app to attachmen
             if (dashboardApi) {
               return previewAttachmentInDashboard({
                 attachment,
@@ -128,7 +131,25 @@ export const registerDashboardAttachmentUiDefinition = ({
                 updateOrigin,
               });
             }
-
+            // sidebar preview - open dashboard in sidebar if possible, otherwise open canvas preview
+            if (isSidebar && dashboardLocator) {
+              const dashboardState = attachmentDataToDashboardState(attachment.data);
+              return handleEditInDashboard({
+                locator: dashboardLocator,
+                getExistingDashboardId: async () => {
+                  if (!attachment.origin) {
+                    return undefined;
+                  }
+                  const exists = await checkSavedDashboardExist(attachment.origin);
+                  return exists ? attachment.origin : undefined;
+                },
+                dashboardLocatorParams: {
+                  ...dashboardState,
+                  viewMode: 'edit',
+                },
+              });
+            }
+            // full screen - open canvas
             openCanvas?.();
           },
         },

--- a/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/index.tsx
+++ b/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/index.tsx
@@ -10,6 +10,7 @@ import { EMPTY, switchMap } from 'rxjs';
 import { i18n } from '@kbn/i18n';
 import type { AttachmentLifecycleParams } from '@kbn/agent-builder-browser/attachments';
 import { ActionButtonType } from '@kbn/agent-builder-browser/attachments';
+import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
 import { DASHBOARD_ATTACHMENT_TYPE } from '@kbn/dashboard-agent-common';
 import type { DashboardAttachment } from '@kbn/dashboard-agent-common/types';
 import type {
@@ -20,6 +21,7 @@ import type {
 import type { UnifiedSearchPublicPluginStart } from '@kbn/unified-search-plugin/public';
 import type { AgentBuilderPluginStart } from '@kbn/agent-builder-plugin/public';
 import { DashboardCanvasContent } from './canvas_integration/dashboard_canvas_content';
+import { clearUnifiedSearchPersistedState } from './canvas_integration/use_dashboard_preview_unified_search';
 import { createDashboardAppIntegration$ } from './dashboard_integration/dashboard_app_integration';
 import { previewAttachmentInDashboard } from './dashboard_integration/preview_attachment';
 import { selectDashboardAttachmentForSync } from './dashboard_integration/select_dashboard_attachment_for_sync';
@@ -28,11 +30,13 @@ export const registerDashboardAttachmentUiDefinition = ({
   agentBuilder,
   dashboardLocator,
   unifiedSearch,
+  filterManager,
   dashboardPlugin,
 }: {
   agentBuilder: AgentBuilderPluginStart;
   dashboardLocator?: DashboardRendererProps['locator'];
   unifiedSearch: UnifiedSearchPublicPluginStart;
+  filterManager: DataPublicPluginStart['query']['filterManager'];
   dashboardPlugin: DashboardStart;
 }): (() => void) => {
   const { attachments } = agentBuilder;
@@ -70,6 +74,7 @@ export const registerDashboardAttachmentUiDefinition = ({
     getIcon: () => 'productDashboard',
     onAttachmentMount: (params: AttachmentLifecycleParams<DashboardAttachment>) => {
       const mountedAttachmentId = nextMountedAttachmentId++;
+      const attachmentId = params.getAttachment().id;
       mountedDashboardAttachments.set(mountedAttachmentId, params.getAttachment);
       const apiSubscription = dashboardPlugin.dashboardAppClientApi$
         .pipe(
@@ -90,6 +95,7 @@ export const registerDashboardAttachmentUiDefinition = ({
       return () => {
         apiSubscription.unsubscribe();
         mountedDashboardAttachments.delete(mountedAttachmentId);
+        clearUnifiedSearchPersistedState(attachmentId);
       };
     },
     renderCanvasContent: (props, callbacks) => (
@@ -98,6 +104,7 @@ export const registerDashboardAttachmentUiDefinition = ({
         {...callbacks}
         dashboardLocator={dashboardLocator}
         searchBarComponent={unifiedSearch.ui.SearchBar}
+        filterManager={filterManager}
         checkSavedDashboardExist={checkSavedDashboardExist}
       />
     ),

--- a/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/index.tsx
+++ b/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/index.tsx
@@ -119,7 +119,7 @@ export const registerDashboardAttachmentUiDefinition = ({
           icon: 'eye',
           type: ActionButtonType.SECONDARY,
           handler: () => {
-            // sidebar in dashboard experience - syncronize dashboard app to attachmen
+            // sidebar in dashboard experience - synchronize dashboard app to attachment
             if (dashboardApi) {
               return previewAttachmentInDashboard({
                 attachment,

--- a/x-pack/platform/plugins/shared/dashboard_agent/public/plugin.ts
+++ b/x-pack/platform/plugins/shared/dashboard_agent/public/plugin.ts
@@ -46,6 +46,7 @@ export class DashboardAgentPlugin
         agentBuilder: plugins.agentBuilder,
         dashboardLocator: plugins.share.url.locators.get(DASHBOARD_APP_LOCATOR),
         unifiedSearch: plugins.unifiedSearch,
+        filterManager: plugins.data.query.filterManager,
         dashboardPlugin: plugins.dashboard,
       });
     });

--- a/x-pack/platform/plugins/shared/dashboard_agent/public/types.ts
+++ b/x-pack/platform/plugins/shared/dashboard_agent/public/types.ts
@@ -6,6 +6,7 @@
  */
 
 import type { AgentBuilderPluginStart } from '@kbn/agent-builder-plugin/public';
+import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
 import type { DashboardStart } from '@kbn/dashboard-plugin/public';
 import type { SharePluginStart } from '@kbn/share-plugin/public';
 import type { UnifiedSearchPublicPluginStart } from '@kbn/unified-search-plugin/public';
@@ -21,6 +22,7 @@ export interface DashboardAgentPluginPublicSetupDependencies {}
 
 export interface DashboardAgentPluginPublicStartDependencies {
   agentBuilder: AgentBuilderPluginStart;
+  data: DataPublicPluginStart;
   dashboard: DashboardStart;
   share: SharePluginStart;
   unifiedSearch: UnifiedSearchPublicPluginStart;

--- a/x-pack/platform/plugins/shared/dashboard_agent/tsconfig.json
+++ b/x-pack/platform/plugins/shared/dashboard_agent/tsconfig.json
@@ -25,7 +25,12 @@
     "@kbn/core-elasticsearch-server",
     "@kbn/lens-common",
     "@kbn/presentation-publishing",
-    "@kbn/core-saved-objects-api-server"
+    "@kbn/core-saved-objects-api-server",
+    "@kbn/es-query",
+    "@kbn/data-plugin",
+    "@kbn/as-code-filters-transforms",
+    "@kbn/as-code-shared-transforms",
+    "@kbn/data-views-plugin"
   ],
   "exclude": ["target/**/*"]
 }


### PR DESCRIPTION
## Summary

Fixes an issue where dashboard attachment previews did not properly respond to Unified Search interactions.
When in sidebar, we redirect to dashboard instead of showing the canvas (this prevents the issue of having two Unified Searches on the page working buggy)

Previously, interactions such as clicking on charts or legends had no effect in the preview canvas, and search state (query, filters, time range) was not consistently applied or preserved. This PR resolves those inconsistencies and aligns the preview behavior with expected dashboard functionality.

### What’s fixed

* Restores chart click and legend interactions so they correctly update filters
* Enables filter pills, KQL input, and date picker synchronization within the preview
* Fixes dashboard refresh behavior inside the preview canvas
* Unified Search state (query, filters, time range) does not persist per attachment when reopening the preview or switching versions

### Related

Fixes https://github.com/elastic/kibana/issues/262180
(no nice-to haves from the issue except for "edit as DSL" have been implemented here)

<img width="1507" height="712" alt="Screenshot 2026-04-09 at 14 17 21" src="https://github.com/user-attachments/assets/dd81926e-c97d-43d5-a089-2d667ea506bd" />


<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->