### PR TITLE
feat(dhq): fetch both v1 and v2 health diagnostic query artifacts

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/diagnostic/health_diagnostic_service.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/diagnostic/health_diagnostic_service.test.ts
@@ -60,8 +60,11 @@ describe('Security Solution - Health Diagnostic Queries - HealthDiagnosticServic
   };
 
   const setupDefaultArtifact = (overrides = {}) => {
-    (artifactService.getArtifact as jest.Mock).mockResolvedValue({
-      data: createMockArtifactData(overrides),
+    (artifactService.getArtifact as jest.Mock).mockImplementation((artifactId: string) => {
+      if (artifactId === 'health-diagnostic-queries-v2') {
+        return Promise.resolve({ data: createMockArtifactData(overrides) });
+      }
+      return Promise.resolve({ data: '' }); // v1: empty by default
     });
   };
 
@@ -359,15 +362,53 @@ enabled: true`,
         expect(mockLogger.warn).not.toHaveBeenCalled();
       });
 
-      test('should handle artifact service errors gracefully', async () => {
+      test('should continue with v2 queries when v1 artifact fails', async () => {
         await startService();
+        (artifactService.getArtifact as jest.Mock).mockImplementation((artifactId: string) => {
+          if (artifactId === 'health-diagnostic-queries-v1') {
+            return Promise.reject(new Error('v1 not found'));
+          }
+          return Promise.resolve({ data: createMockArtifactData() });
+        });
+        mockQueryExecutor.search.mockReturnValue(of(mockDocument));
 
+        const result = await service.runHealthDiagnosticQueries({});
+
+        expect(result).toHaveLength(1);
+        expect(result[0].name).toBe('test-query');
+        expect(mockLogger.warn).toHaveBeenCalledWith(
+          'Error getting health diagnostic queries',
+          expect.any(Object)
+        );
+      });
+
+      test('should continue with v1 queries when v2 artifact fails', async () => {
+        await startService();
+        (artifactService.getArtifact as jest.Mock).mockImplementation((artifactId: string) => {
+          if (artifactId === 'health-diagnostic-queries-v2') {
+            return Promise.reject(new Error('v2 not found'));
+          }
+          return Promise.resolve({ data: createMockArtifactData() });
+        });
+        mockQueryExecutor.search.mockReturnValue(of(mockDocument));
+
+        const result = await service.runHealthDiagnosticQueries({});
+
+        expect(result).toHaveLength(1);
+        expect(result[0].name).toBe('test-query');
+        expect(mockLogger.warn).toHaveBeenCalledWith(
+          'Error getting health diagnostic queries',
+          expect.any(Object)
+        );
+      });
+
+      test('should return empty array when both artifacts fail', async () => {
+        await startService();
         (artifactService.getArtifact as jest.Mock).mockRejectedValue(
           new Error('Artifact not found')
         );
-        const lastExecutionByQuery = {};
 
-        const result = await service.runHealthDiagnosticQueries(lastExecutionByQuery);
+        const result = await service.runHealthDiagnosticQueries({});
 
         expect(result).toEqual([]);
         expect(mockLogger.warn).toHaveBeenCalledWith(

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/diagnostic/health_diagnostic_service.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/diagnostic/health_diagnostic_service.ts
@@ -36,6 +36,7 @@ import {
   fieldNames,
   shouldExecute as isDueForExecution,
   applyFilterlist,
+  mergeByPriority,
 } from './health_diagnostic_utils';
 import { parseHealthDiagnosticQueries } from './health_diagnostic_query_parser';
 import { type CircuitBreaker, ValidationError } from './health_diagnostic_circuit_breakers.types';
@@ -45,7 +46,7 @@ import {
   TELEMETRY_HEALTH_DIAGNOSTIC_QUERY_RESULT_EVENT,
   TELEMETRY_HEALTH_DIAGNOSTIC_QUERY_STATS_EVENT,
 } from '../event_based/events';
-import { artifactService } from '../artifact';
+import { artifactService, type Manifest } from '../artifact';
 import { newTelemetryLogger, withErrorMessage } from '../helpers';
 import { telemetryConfiguration } from '../configuration';
 import { RssGrowthCircuitBreaker } from './circuit_breakers/rss_growth_circuit_breaker';
@@ -63,7 +64,8 @@ const TASK_TYPE = 'security:health-diagnostic';
 const TASK_ID = `${TASK_TYPE}:1.0.0`;
 const INTERVAL = '1h';
 const TIMEOUT = '10m';
-const QUERY_ARTIFACT_ID = 'health-diagnostic-queries-v2';
+const QUERY_ARTIFACT_ID_V1 = 'health-diagnostic-queries-v1';
+const QUERY_ARTIFACT_ID_V2 = 'health-diagnostic-queries-v2';
 
 export class HealthDiagnosticServiceImpl implements HealthDiagnosticService {
   private readonly salt = 'c2a5d101-d0ef-49cc-871e-6ee55f9546f8';
@@ -399,12 +401,28 @@ export class HealthDiagnosticServiceImpl implements HealthDiagnosticService {
   }
 
   private async healthQueries(): Promise<HealthDiagnosticQuery[]> {
-    try {
-      const artifact = await artifactService.getArtifact(QUERY_ARTIFACT_ID);
-      return parseHealthDiagnosticQueries(artifact.data);
-    } catch (error) {
-      this.logger.warn('Error getting health diagnostic queries', withErrorMessage(error));
-      return [];
-    }
+    const [v1Result, v2Result] = await Promise.allSettled([
+      artifactService.getArtifact(QUERY_ARTIFACT_ID_V1),
+      artifactService.getArtifact(QUERY_ARTIFACT_ID_V2),
+    ]);
+
+    const toQueries = (
+      result: PromiseSettledResult<Manifest>,
+      artifactId: string
+    ): HealthDiagnosticQuery[] => {
+      if (result.status === 'rejected') {
+        this.logger.warn(
+          'Error getting health diagnostic queries',
+          withErrorMessage(result.reason, { artifactId } as LogMeta)
+        );
+        return [];
+      }
+      return parseHealthDiagnosticQueries(result.value.data);
+    };
+
+    return mergeByPriority(
+      toQueries(v1Result, QUERY_ARTIFACT_ID_V1),
+      toQueries(v2Result, QUERY_ARTIFACT_ID_V2)
+    );
   }
 }

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/diagnostic/health_diagnostic_utils.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/diagnostic/health_diagnostic_utils.test.ts
@@ -7,8 +7,19 @@
 
 import { generateKeyPairSync } from 'crypto';
 import { intervalFromDate } from '@kbn/task-manager-plugin/server/lib/intervals';
-import { shouldExecute, applyFilterlist, fieldNames } from './health_diagnostic_utils';
-import { Action } from './health_diagnostic_service.types';
+import {
+  shouldExecute,
+  applyFilterlist,
+  fieldNames,
+  mergeByPriority,
+} from './health_diagnostic_utils';
+import {
+  Action,
+  QueryType,
+  type HealthDiagnosticQueryV1,
+  type HealthDiagnosticQueryV2,
+  type ParseFailureQuery,
+} from './health_diagnostic_service.types';
 
 describe('Security Solution - Health Diagnostic Queries - utils', () => {
   describe('applyFilterlist', () => {
@@ -629,6 +640,104 @@ describe('Security Solution - Health Diagnostic Queries - utils', () => {
         'user.name',
         'user.roles[]',
       ]);
+    });
+  });
+
+  describe('mergeByPriority', () => {
+    const makeV1 = (id: string): HealthDiagnosticQueryV1 => ({
+      version: 1,
+      id,
+      name: `query-${id}`,
+      index: 'test-index',
+      type: QueryType.DSL,
+      query: '{"query":{"match_all":{}}}',
+      scheduleCron: '5m',
+      filterlist: { 'user.name': Action.KEEP },
+      enabled: true,
+    });
+
+    const makeV2 = (id: string): HealthDiagnosticQueryV2 => ({
+      version: 2,
+      id,
+      name: `query-${id}`,
+      integrations: ['endpoint.*'],
+      type: QueryType.DSL,
+      query: '{"query":{"match_all":{}}}',
+      scheduleCron: '5m',
+      filterlist: { 'user.name': Action.KEEP },
+      enabled: true,
+    });
+
+    const makeParseFailure = (id?: string): ParseFailureQuery => ({
+      ...(id !== undefined ? { id } : {}),
+      name: 'bad-query',
+      _raw: { version: 99 },
+    });
+
+    test('returns v2 queries unchanged when v1 is empty', () => {
+      const v2 = [makeV2('a'), makeV2('b')];
+      expect(mergeByPriority([], v2)).toEqual(v2);
+    });
+
+    test('returns v1 queries unchanged when v2 is empty', () => {
+      const v1 = [makeV1('a'), makeV1('b')];
+      expect(mergeByPriority(v1, [])).toEqual(v1);
+    });
+
+    test('returns empty array when both inputs are empty', () => {
+      expect(mergeByPriority([], [])).toEqual([]);
+    });
+
+    test('returns all queries when there is no id overlap', () => {
+      const v1 = [makeV1('a'), makeV1('b')];
+      const v2 = [makeV2('c'), makeV2('d')];
+      const result = mergeByPriority(v1, v2);
+      expect(result).toHaveLength(4);
+      const ids = result.map((q) => (q as { id: string }).id);
+      expect(ids).toContain('a');
+      expect(ids).toContain('b');
+      expect(ids).toContain('c');
+      expect(ids).toContain('d');
+    });
+
+    test('v2 version wins when both artifacts contain the same id', () => {
+      const v1Query = makeV1('shared-id');
+      const v2Query = makeV2('shared-id');
+      const result = mergeByPriority([v1Query], [v2Query]);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toBe(v2Query);
+    });
+
+    test('queries with the same name but different ids are both returned', () => {
+      const v1Query: HealthDiagnosticQueryV1 = { ...makeV1('id-1'), name: 'same-name' };
+      const v2Query: HealthDiagnosticQueryV2 = { ...makeV2('id-2'), name: 'same-name' };
+      const result = mergeByPriority([v1Query], [v2Query]);
+      expect(result).toHaveLength(2);
+    });
+
+    test('ParseFailureQuery with id participates in dedup (v2 wins)', () => {
+      const v1Failure = makeParseFailure('conflict-id');
+      const v2Query = makeV2('conflict-id');
+      const result = mergeByPriority([v1Failure], [v2Query]);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toBe(v2Query);
+    });
+
+    test('ParseFailureQuery without id is always included', () => {
+      const v2 = [makeV2('a')];
+      const failure = makeParseFailure();
+      const result = mergeByPriority([failure], v2);
+      expect(result).toHaveLength(2);
+      expect(result).toContain(failure);
+    });
+
+    test('multiple id-less ParseFailureQueries are all included', () => {
+      const f1 = makeParseFailure();
+      const f2 = makeParseFailure();
+      const result = mergeByPriority([f1], [f2]);
+      expect(result).toHaveLength(2);
+      expect(result).toContain(f1);
+      expect(result).toContain(f2);
     });
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/diagnostic/health_diagnostic_utils.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/diagnostic/health_diagnostic_utils.ts
@@ -9,6 +9,7 @@ import { randomUUID } from 'crypto';
 import { type Interval, intervalFromDate } from '@kbn/task-manager-plugin/server/lib/intervals';
 import {
   Action,
+  type HealthDiagnosticQuery,
   type HealthDiagnosticQueryBase,
   type HealthDiagnosticQueryStats,
 } from './health_diagnostic_service.types';
@@ -197,6 +198,30 @@ export async function applyFilterlist(
 
   return filteredResult;
 }
+
+/**
+ * Merges two query arrays with v2 taking precedence on `id` conflicts.
+ * Queries without an `id` (ParseFailureQuery with no id field) are always
+ * included — they will be reported as skipped at execution time.
+ */
+export const mergeByPriority = (
+  v1Queries: HealthDiagnosticQuery[],
+  v2Queries: HealthDiagnosticQuery[]
+): HealthDiagnosticQuery[] => {
+  const map = new Map<string, HealthDiagnosticQuery>();
+  const idless: HealthDiagnosticQuery[] = [];
+
+  for (const q of [...v1Queries, ...v2Queries]) {
+    const id = (q as { id?: string }).id;
+    if (id !== undefined) {
+      map.set(id, q); // v2 entries overwrite v1 for the same id
+    } else {
+      idless.push(q);
+    }
+  }
+
+  return [...map.values(), ...idless];
+};
 
 async function maskValue(value: string, salt: string): Promise<string> {
   const encoder = new TextEncoder();


### PR DESCRIPTION
## Summary

The Health Diagnostic task was only fetching queries from [the v2 artifact](https://github.com/elastic/kibana/pull/258418), causing all the legacy v1 artifact queries to be silently skipped on every run.

This PR updates the logic to fetch both artifacts and merge their contents before execution. When the same query appears in both (it should not happen), the v2 version takes precedence. Each artifact is fetched independently, so a failure in one does not prevent the other from running.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


<!--ONMERGE {"backportTargets":["8.19","9.2","9.3"]} ONMERGE-->