### PR TITLE
Fix log_patterns KI dropping rare patterns after global sort

### DIFF
--- a/x-pack/platform/packages/shared/kbn-streams-ai/src/features/computed/log_patterns.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-ai/src/features/computed/log_patterns.ts
@@ -11,7 +11,11 @@ import { createTracedEsClient } from '@kbn/traced-es-client';
 import type { ComputedFeatureGenerator } from './types';
 
 const LOG_MESSAGE_FIELDS = ['message', 'body.text'];
-const MAX_PATTERNS = 5;
+
+const RARE_PATTERN_COUNT_THRESHOLD = 50;
+const MAX_COMMON_PATTERNS = 3;
+const MAX_RARE_PATTERNS = 2;
+const MAX_PATTERNS = MAX_COMMON_PATTERNS + MAX_RARE_PATTERNS;
 
 export const logPatternsGenerator: ComputedFeatureGenerator = {
   type: LOG_PATTERNS_FEATURE_TYPE,
@@ -38,8 +42,17 @@ This is useful for understanding the types of logs in the stream and identifying
       fields: LOG_MESSAGE_FIELDS,
     });
 
+    const commonPatterns = patterns.filter((p) => p.count >= RARE_PATTERN_COUNT_THRESHOLD);
+    const rarePatterns = patterns.filter((p) => p.count < RARE_PATTERN_COUNT_THRESHOLD);
+
+    const selectedCommon = commonPatterns.slice(0, MAX_COMMON_PATTERNS);
+    const remainingBudget = MAX_PATTERNS - selectedCommon.length;
+    const selectedRare = rarePatterns.slice(0, remainingBudget);
+
+    const selectedPatterns = [...selectedCommon, ...selectedRare];
+
     return {
-      patterns: patterns.slice(0, MAX_PATTERNS).map(({ field, pattern, regex, count, sample }) => ({
+      patterns: selectedPatterns.map(({ field, pattern, regex, count, sample }) => ({
         pattern,
         regex,
         count,


### PR DESCRIPTION
The computed log_patterns feature merged common and rare aggregation results, sorted by count descending, then took the top five. Rare patterns (count < 50) never survived that cut.

Select up to three patterns with count >= 50 and fill remaining slots from patterns below the threshold, preserving a total budget of five. Aligns with the split used in getLogPatterns for the rare pass.

Fixes #258872
