### PR TITLE
[Significant events] Streams table in Significant events fix

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/streams_view/knowledge_indicators_column.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/streams_view/knowledge_indicators_column.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { EuiText } from '@elastic/eui';
+import { EuiI18nNumber, EuiText } from '@elastic/eui';
 import { css } from '@emotion/css';
 import type { OnboardingResult, Streams, TaskResult } from '@kbn/streams-schema';
 import React from 'react';
@@ -30,7 +30,7 @@ export function KnowledgeIndicatorsColumn({
         font-family: 'Roboto Mono', monospace;
       `}
     >
-      {features.length || '—'}
+      {features.length ? <EuiI18nNumber value={features.length} /> : '—'}
     </EuiText>
   );
 }

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/streams_view/queries_column.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/streams_view/queries_column.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { EuiText } from '@elastic/eui';
+import { EuiI18nNumber, EuiText } from '@elastic/eui';
 import { css } from '@emotion/css';
 import type { OnboardingResult, TaskResult } from '@kbn/streams-schema';
 import React from 'react';
@@ -32,7 +32,11 @@ export function QueriesColumn({ streamName, streamOnboardingResult }: QueriesCol
         font-family: 'Roboto Mono', monospace;
       `}
     >
-      {significantEventsFetchState.data?.significant_events.length || '—'}
+      {significantEventsFetchState.data?.significant_events.length ? (
+        <EuiI18nNumber value={significantEventsFetchState.data.significant_events.length} />
+      ) : (
+        '—'
+      )}
     </EuiText>
   );
 }

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/streams_view/significant_events_column.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/streams_view/significant_events_column.tsx
@@ -5,7 +5,14 @@
  * 2.0.
  */
 
-import { EuiFlexGroup, EuiFlexItem, EuiIconTip, EuiLoadingChart, useEuiTheme } from '@elastic/eui';
+import {
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiI18nNumber,
+  EuiIconTip,
+  EuiLoadingChart,
+  useEuiTheme,
+} from '@elastic/eui';
 import { css } from '@emotion/css';
 import { i18n } from '@kbn/i18n';
 import React from 'react';
@@ -13,6 +20,7 @@ import { useFetchSignificantEvents } from '../../../../../hooks/sig_events/use_f
 import { getFormattedError } from '../../../../../util/errors';
 import { SparkPlot } from '../../../../spark_plot';
 
+const COUNT_WIDTH = '60px';
 const CHART_WIDTH = '100px';
 const EMPTY_COUNT_SYMBOL = '—';
 
@@ -41,12 +49,14 @@ export function SignificantEventsColumn({ streamName }: SignificantEventsColumnP
   return (
     <EuiFlexGroup
       alignItems="center"
-      justifyContent="flexStart"
-      gutterSize="l"
-      css={{ height: euiTheme.size.xl }}
+      gutterSize="m"
+      css={{ height: euiTheme.size.xl, whiteSpace: 'nowrap' }}
     >
       <EventsCount count={significantEventsFetchState.data.total_occurrences} />
-      <EuiFlexItem css={{ maxWidth: CHART_WIDTH }}>
+      <EuiFlexItem
+        grow={false}
+        css={{ width: CHART_WIDTH, flexShrink: 0 }}
+      >
         <SparkPlot
           id={`significant-events-histogram-${streamName}`}
           name={i18n.translate('xpack.streams.significantEventsTable.histogramSeriesTitle', {
@@ -67,7 +77,6 @@ const LoadingPlaceholder = () => {
   return (
     <EuiFlexGroup
       alignItems="center"
-      justifyContent="flexStart"
       gutterSize="m"
       className={css`
         height: ${euiTheme.size.xl};
@@ -79,6 +88,7 @@ const LoadingPlaceholder = () => {
         grow={false}
         className={css`
           width: ${CHART_WIDTH};
+          flex-shrink: 0;
           display: flex;
           justify-content: center;
           align-items: center;
@@ -105,11 +115,13 @@ const EventsCount = ({ count }: { count: number }) => {
     <EuiFlexItem
       grow={false}
       className={css`
-        text-align: center;
+        width: ${COUNT_WIDTH};
+        flex-shrink: 0;
+        text-align: right;
         font-family: 'Roboto Mono', monospace;
       `}
     >
-      {count === 0 ? EMPTY_COUNT_SYMBOL : count}
+      {count === 0 ? EMPTY_COUNT_SYMBOL : <EuiI18nNumber value={count} />}
     </EuiFlexItem>
   );
 };

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/streams_view/significant_events_column.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/streams_view/significant_events_column.tsx
@@ -53,10 +53,7 @@ export function SignificantEventsColumn({ streamName }: SignificantEventsColumnP
       css={{ height: euiTheme.size.xl, whiteSpace: 'nowrap' }}
     >
       <EventsCount count={significantEventsFetchState.data.total_occurrences} />
-      <EuiFlexItem
-        grow={false}
-        css={{ width: CHART_WIDTH, flexShrink: 0 }}
-      >
+      <EuiFlexItem grow={false} css={{ width: CHART_WIDTH, flexShrink: 0 }}>
         <SparkPlot
           id={`significant-events-histogram-${streamName}`}
           name={i18n.translate('xpack.streams.significantEventsTable.histogramSeriesTitle', {

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/streams_view/translations.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/streams_view/translations.ts
@@ -14,7 +14,14 @@ export const NAME_COLUMN_HEADER = i18n.translate('xpack.streams.streamsTreeTable
 export const SIGNIFICANT_EVENTS_COLUMN_HEADER = i18n.translate(
   'xpack.streams.significantEventsDiscovery.streamsTree.significantEventsColumnName',
   {
-    defaultMessage: 'Significant Events',
+    defaultMessage: 'Events',
+  }
+);
+
+export const SIGNIFICANT_EVENTS_COLUMN_TOOLTIP = i18n.translate(
+  'xpack.streams.significantEventsDiscovery.streamsTree.significantEventsColumnTooltip',
+  {
+    defaultMessage: 'Number of results produced by created rules.',
   }
 );
 

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/streams_view/tree_table.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/streams_view/tree_table.tsx
@@ -39,6 +39,7 @@ import {
   QUERIES_COLUMN_HEADER,
   RUN_STREAM_ONBOARDING_BUTTON_LABEL,
   SIGNIFICANT_EVENTS_COLUMN_HEADER,
+  SIGNIFICANT_EVENTS_COLUMN_TOOLTIP,
   STOP_STREAM_ONBOARDING_BUTTON_LABEL,
   STREAMS_TABLE_CAPTION_ARIA_LABEL,
 } from './translations';
@@ -391,8 +392,20 @@ export function StreamsTreeTable({
               ),
             },
             {
-              name: SIGNIFICANT_EVENTS_COLUMN_HEADER,
-              width: '200px',
+              name: (
+                <EuiFlexGroup alignItems="center" gutterSize="xs" responsive={false}>
+                  <EuiFlexItem grow={false}>{SIGNIFICANT_EVENTS_COLUMN_HEADER}</EuiFlexItem>
+                  <EuiFlexItem grow={false}>
+                    <EuiIconTip
+                      type="info"
+                      color="subdued"
+                      content={SIGNIFICANT_EVENTS_COLUMN_TOOLTIP}
+                      size="s"
+                    />
+                  </EuiFlexItem>
+                </EuiFlexGroup>
+              ),
+              width: '210px',
               align: 'left',
               render: (item: TableRow) => <SignificantEventsColumn streamName={item.stream.name} />,
             },


### PR DESCRIPTION
## Summary

This is a simple PR to 
- fix the formatting of the streams table in Significant events
- rename the last column from Significant events to Events and add a tooltip explaining what it is
- fix the alignment so it looks nicer


_The formatting is the same as we have in the Streams main listing page for consistency._

<img width="7848" height="2568" alt="image" src="https://github.com/user-attachments/assets/c7d6185a-44eb-40e9-88e7-b01c979b1f9a" />
