### PR TITLE
[POC] AI Watchlist Creator — skill, tool, attachment, and service

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/common/constants.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/constants.ts
@@ -720,8 +720,10 @@ export enum SecurityAgentBuilderAttachments {
   alert = 'security.alert',
   entity = 'security.entity',
   rule = 'security.rule',
+  watchlist = 'security.watchlist',
 }
 
 export const SECURITY_RULE_ATTACHMENT_ID = 'ai-rule-creation';
+export const SECURITY_WATCHLIST_ATTACHMENT_ID = 'ai-watchlist-creation';
 
 export const THREAT_HUNTING_AGENT_ID = `${internalNamespaces.security}.agent`;

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/watchlist_attachment.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/watchlist_attachment.tsx
@@ -1,0 +1,236 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { i18n } from '@kbn/i18n';
+import {
+  EuiBadge,
+  EuiCallOut,
+  EuiCodeBlock,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiPanel,
+  EuiSpacer,
+  EuiText,
+} from '@elastic/eui';
+import type {
+  AttachmentUIDefinition,
+  AttachmentRenderProps,
+  AttachmentServiceStartContract,
+} from '@kbn/agent-builder-browser/attachments';
+import { ActionButtonType } from '@kbn/agent-builder-browser/attachments';
+import type { Attachment } from '@kbn/agent-builder-common/attachments';
+import type { ApplicationStart } from '@kbn/core-application-browser';
+import { SecurityAgentBuilderAttachments } from '../../../common/constants';
+import type { AiWatchlistService, AiCreatedWatchlist } from '../../detection_engine/common/ai_watchlist_service';
+
+type WatchlistAttachment = Attachment<string, { text: string; attachmentLabel?: string }>;
+
+const ENTITY_ANALYTICS_PATH = '/entity_analytics';
+
+const parseWatchlistFromAttachment = (attachment: WatchlistAttachment): AiCreatedWatchlist | null => {
+  try {
+    const parsed = JSON.parse(attachment.data.text);
+    if (!parsed || !parsed.name) return null;
+    return parsed as AiCreatedWatchlist;
+  } catch {
+    return null;
+  }
+};
+
+const getWatchlistName = (attachment: WatchlistAttachment): string | undefined =>
+  attachment?.data?.attachmentLabel ?? parseWatchlistFromAttachment(attachment)?.name;
+
+const EmptyWatchlistContent: React.FC = () => (
+  <EuiCallOut
+    size="s"
+    title={i18n.translate('xpack.securitySolution.agentBuilder.watchlistAttachment.emptyTitle', {
+      defaultMessage: 'New Watchlist',
+    })}
+    iconType="info"
+    color="primary"
+  >
+    <EuiText size="xs">
+      {i18n.translate(
+        'xpack.securitySolution.agentBuilder.watchlistAttachment.emptyDescription',
+        { defaultMessage: 'Describe the entities you want to monitor.' }
+      )}
+    </EuiText>
+  </EuiCallOut>
+);
+
+const SectionHeading: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <EuiText size="s">
+    <strong>{children}</strong>
+  </EuiText>
+);
+
+const EntityNameBadges: React.FC<{ names: string[]; limit?: number }> = ({
+  names,
+  limit = 10,
+}) => {
+  const visible = names.slice(0, limit);
+  const overflow = names.length - visible.length;
+
+  return (
+    <EuiFlexGroup responsive={false} gutterSize="xs" wrap>
+      {visible.map((name) => (
+        <EuiFlexItem grow={false} key={name}>
+          <EuiBadge color="hollow">{name}</EuiBadge>
+        </EuiFlexItem>
+      ))}
+      {overflow > 0 && (
+        <EuiFlexItem grow={false}>
+          <EuiBadge color="hollow">
+            {i18n.translate(
+              'xpack.securitySolution.agentBuilder.watchlistAttachment.moreEntities',
+              { defaultMessage: '+{count} more', values: { count: overflow } }
+            )}
+          </EuiBadge>
+        </EuiFlexItem>
+      )}
+    </EuiFlexGroup>
+  );
+};
+
+const WatchlistInlineContent: React.FC<AttachmentRenderProps<WatchlistAttachment>> = ({
+  attachment,
+}) => {
+  const watchlist = parseWatchlistFromAttachment(attachment);
+
+  if (!watchlist) {
+    return <EmptyWatchlistContent />;
+  }
+
+  const { name, description, riskModifier, entityCount, entityNames, generatedEsql } = watchlist;
+
+  return (
+    <EuiPanel paddingSize="m" hasShadow={false} hasBorder={false}>
+      {description && (
+        <>
+          <SectionHeading>
+            {i18n.translate(
+              'xpack.securitySolution.agentBuilder.watchlistAttachment.descriptionHeading',
+              { defaultMessage: 'Description' }
+            )}
+          </SectionHeading>
+          <EuiSpacer size="xs" />
+          <EuiText size="xs">{description}</EuiText>
+          <EuiSpacer size="s" />
+        </>
+      )}
+
+      <EuiText size="xs">
+        {entityCount != null && (
+          <>
+            <strong>
+              {i18n.translate(
+                'xpack.securitySolution.agentBuilder.watchlistAttachment.entityCountLabel',
+                { defaultMessage: 'Entities matched:' }
+              )}
+            </strong>{' '}
+            {entityCount}
+          </>
+        )}
+        {riskModifier != null && (
+          <>
+            {entityCount != null && ' | '}
+            <strong>
+              {i18n.translate(
+                'xpack.securitySolution.agentBuilder.watchlistAttachment.riskModifierLabel',
+                { defaultMessage: 'Risk modifier:' }
+              )}
+            </strong>{' '}
+            {riskModifier}×
+          </>
+        )}
+      </EuiText>
+
+      {entityNames && entityNames.length > 0 && (
+        <>
+          <EuiSpacer size="s" />
+          <SectionHeading>
+            {i18n.translate(
+              'xpack.securitySolution.agentBuilder.watchlistAttachment.entitiesHeading',
+              { defaultMessage: 'Entities' }
+            )}
+          </SectionHeading>
+          <EuiSpacer size="xs" />
+          <EntityNameBadges names={entityNames} />
+        </>
+      )}
+
+      {generatedEsql && (
+        <>
+          <EuiSpacer size="s" />
+          <SectionHeading>
+            {i18n.translate(
+              'xpack.securitySolution.agentBuilder.watchlistAttachment.esqlHeading',
+              { defaultMessage: 'Generated ES|QL' }
+            )}
+          </SectionHeading>
+          <EuiSpacer size="xs" />
+          <EuiCodeBlock language="esql" fontSize="s" paddingSize="s" overflowHeight={120}>
+            {generatedEsql}
+          </EuiCodeBlock>
+        </>
+      )}
+    </EuiPanel>
+  );
+};
+
+export const registerWatchlistAttachment = ({
+  attachments,
+  application,
+  aiWatchlist,
+}: {
+  attachments: AttachmentServiceStartContract;
+  application: ApplicationStart;
+  aiWatchlist: AiWatchlistService;
+}): void => {
+  attachments.addAttachmentType(
+    SecurityAgentBuilderAttachments.watchlist,
+    createWatchlistAttachmentDefinition({ application, aiWatchlist })
+  );
+};
+
+export const createWatchlistAttachmentDefinition = ({
+  application,
+  aiWatchlist,
+}: {
+  application: ApplicationStart;
+  aiWatchlist: AiWatchlistService;
+}): AttachmentUIDefinition<WatchlistAttachment> => ({
+  getLabel: (attachment) =>
+    getWatchlistName(attachment) ??
+    i18n.translate('xpack.securitySolution.agentBuilder.watchlistAttachment.label', {
+      defaultMessage: 'Security Watchlist',
+    }),
+  getIcon: () => 'list',
+  renderInlineContent: (props) => <WatchlistInlineContent {...props} />,
+  getActionButtons: ({ attachment }) => {
+    const watchlist = parseWatchlistFromAttachment(attachment);
+    if (!watchlist) return [];
+
+    return [
+      {
+        label: i18n.translate(
+          'xpack.securitySolution.agentBuilder.watchlistAttachment.viewWatchlists',
+          { defaultMessage: 'View watchlists' }
+        ),
+        icon: 'list',
+        type: ActionButtonType.PRIMARY,
+        handler: () => {
+          aiWatchlist.setAiCreatedWatchlist(watchlist);
+          application.navigateToApp('securitySolutionUI', {
+            path: ENTITY_ANALYTICS_PATH,
+          });
+        },
+      },
+    ];
+  },
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/common/ai_watchlist_service.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/common/ai_watchlist_service.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { BehaviorSubject } from 'rxjs';
+import type { WatchlistObject } from '../../../common/api/entity_analytics/watchlists/management/common.gen';
+
+export interface AiCreatedWatchlist extends WatchlistObject {
+  entityNames?: string[];
+  generatedEsql?: string;
+}
+
+export class AiWatchlistService {
+  private readonly watchlistSubject = new BehaviorSubject<AiCreatedWatchlist | null>(null);
+
+  public readonly aiCreatedWatchlist$ = this.watchlistSubject.asObservable();
+
+  public setAiCreatedWatchlist = (watchlist: AiCreatedWatchlist): void => {
+    this.watchlistSubject.next(watchlist);
+  };
+
+  public clearAiCreatedWatchlist = (): void => {
+    this.watchlistSubject.next(null);
+  };
+
+  public reset = (): void => {
+    this.watchlistSubject.next(null);
+  };
+}

--- a/x-pack/solutions/security/plugins/security_solution/public/plugin.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/plugin.tsx
@@ -75,6 +75,7 @@ import { defaultDeepLinks } from './app/links/default_deep_links';
 import { AIValueReportLocatorDefinition } from '../common/locators/ai_value_report/locator';
 import { registerAttachmentUiDefinitions } from './agent_builder/attachment_types';
 import { registerRuleAttachment } from './agent_builder/attachment_types/rule_attachment';
+import { registerWatchlistAttachment } from './agent_builder/attachment_types/watchlist_attachment';
 
 export class Plugin implements IPlugin<PluginSetup, PluginStart, SetupPlugins, StartPlugins> {
   private config: SecuritySolutionUiConfigType;
@@ -289,6 +290,11 @@ export class Plugin implements IPlugin<PluginSetup, PluginStart, SetupPlugins, S
         attachments: plugins.agentBuilder.attachments,
         application: core.application,
         aiRuleCreation: this.services.aiRuleCreation,
+      });
+      registerWatchlistAttachment({
+        attachments: plugins.agentBuilder.attachments,
+        application: core.application,
+        aiWatchlist: this.services.aiWatchlist,
       });
     }
 

--- a/x-pack/solutions/security/plugins/security_solution/public/plugin_services.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/plugin_services.ts
@@ -23,6 +23,7 @@ import { TopValuesPopoverService } from './app/components/top_values_popover/top
 import { createSiemMigrationsService } from './siem_migrations/service';
 import type { SecuritySolutionUiConfigType } from './common/types';
 import { AiRuleCreationService } from './detection_engine/common/ai_rule_creation_store';
+import { AiWatchlistService } from './detection_engine/common/ai_watchlist_service';
 import type {
   PluginStart,
   SetupPlugins,
@@ -38,6 +39,7 @@ export class PluginServices {
   private readonly storage = new Storage(localStorage);
   private readonly sessionStorage = new Storage(sessionStorage);
   public readonly aiRuleCreation = new AiRuleCreationService();
+  public readonly aiWatchlist = new AiWatchlistService();
 
   private readonly configSettings: ConfigSettings;
 
@@ -112,6 +114,7 @@ export class PluginServices {
     this.timelineQueryService.stop();
     licenseService.stop();
     this.aiRuleCreation.reset();
+    this.aiWatchlist.reset();
   }
 
   public async generateServices(
@@ -166,6 +169,7 @@ export class PluginServices {
       topValuesPopover: new TopValuesPopoverService(),
       productDocBase: startPlugins.productDocBase,
       aiRuleCreation: this.aiRuleCreation,
+      aiWatchlist: this.aiWatchlist,
       siemMigrations,
       ...(params && {
         onAppLeave: params.onAppLeave,

--- a/x-pack/solutions/security/plugins/security_solution/public/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/types.ts
@@ -105,6 +105,7 @@ import type { OnboardingService } from './onboarding/service';
 import type { TelemetryServiceStart } from './common/lib/telemetry';
 import type { SiemMigrationsService } from './siem_migrations/service';
 import type { AiRuleCreationService } from './detection_engine/common/ai_rule_creation_store';
+import type { AiWatchlistService } from './detection_engine/common/ai_watchlist_service';
 
 export interface SetupPlugins {
   cloud?: CloudSetup;
@@ -217,6 +218,7 @@ export type StartServices = CoreStart &
     productDocBase: ProductDocBasePluginStart;
     logger: Logger;
     aiRuleCreation: AiRuleCreationService;
+    aiWatchlist: AiWatchlistService;
   };
 
 export type StartRenderServices = Pick<

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/register_skills.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/register_skills.ts
@@ -11,6 +11,7 @@ import type { ExperimentalFeatures } from '../../../common/experimental_features
 import type { EndpointAppContextService } from '../../endpoint/endpoint_app_context_services';
 import { createAutomaticTroubleshootingSkill } from './automatic_troubleshooting';
 import { getDetectionRuleEditSkill } from './detection_rule_edit';
+import { getWatchlistSkill } from './watchlists';
 import { getEntityAnalyticsSkill } from './entity_analytics';
 import { threatHuntingSkill } from './threat_hunting';
 import { alertAnalysisSkill } from './alert_analysis';
@@ -53,6 +54,7 @@ export const registerSkills = async ({
   );
 
   agentBuilder.skills.register(getDetectionRuleEditSkill());
+  agentBuilder.skills.register(getWatchlistSkill());
   await agentBuilder.skills.register(
     getSecurityMlJobsSkill({ getStartServices, isEntityStoreV2Enabled, logger, ml })
   );

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/watchlists/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/watchlists/index.ts
@@ -1,0 +1,127 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { platformCoreTools } from '@kbn/agent-builder-common';
+import { defineSkillType } from '@kbn/agent-builder-server/skills/type_definition';
+import { SECURITY_CREATE_WATCHLIST_TOOL_ID } from '../../tools';
+
+export const getWatchlistSkill = () =>
+  defineSkillType({
+    id: 'watchlist-create',
+    name: 'watchlist-create',
+    basePath: 'skills/security/watchlists',
+    description:
+      'Guide to creating AI-generated watchlists from Entity Store data. Use when a user asks to create a watchlist, monitor a set of entities, or track users/hosts matching a risk or behavioral criterion.',
+    content: SKILL_CONTENT,
+    getRegistryTools: () => [
+      SECURITY_CREATE_WATCHLIST_TOOL_ID,
+      platformCoreTools.generateEsql,
+      platformCoreTools.productDocumentation,
+    ],
+  });
+
+const SKILL_CONTENT = `# AI Watchlist Creation
+
+## When to Use This Skill
+
+Use this skill when the user asks to:
+- Create a watchlist (e.g., "create a watchlist for high-risk users", "monitor hosts with critical asset criticality")
+- Track or watch a dynamic set of entities based on risk, behavior, or attributes
+- Populate a watchlist from Entity Store results
+
+## Core Workflow
+
+### Step 1: Clarify the Criteria (if needed)
+
+If the user's request is ambiguous, ask one focused clarifying question:
+- Which entity type? (user / host / service / all)
+- Which risk level or score threshold?
+- Any time constraint (e.g., last seen in the past 30 days)?
+
+Skip this step if the request is already specific enough.
+
+### Step 2: Call \`security.create_watchlist\`
+
+Always use the \`security.create_watchlist\` tool. Pass:
+- \`user_query\`: the natural language description of which entities to include
+- \`watchlist_name\` (optional): a human-friendly name; the tool derives one if omitted
+- \`risk_modifier\` (optional): 0.0–2.0 float; defaults to 1.0 (no modifier)
+
+The tool will:
+1. Generate an ES|QL query against the Entity Store
+2. Execute it to find matching entities
+3. Create a watchlist saved object with a live entity source (KQL-based)
+4. Return an attachment ID and version
+
+### Step 3: Render the Attachment
+
+After \`security.create_watchlist\` succeeds, **always** render the attachment inline:
+
+\`\`\`
+<render_attachment id="ATTACHMENT_ID" version="VERSION" />
+\`\`\`
+
+### Step 4: Report the Result
+
+Summarise in one or two sentences:
+- Watchlist name
+- Number of entities matched
+- The ES|QL query used (so the user can verify or refine)
+
+---
+
+## Field Reference for Entity Store
+
+| Field | Description |
+|---|---|
+| \`entity.name\` | Entity display name (username or hostname) |
+| \`entity.EngineMetadata.Type\` | \`user\`, \`host\`, \`service\`, \`generic\` |
+| \`entity.risk.calculated_score_norm\` | Normalised risk score 0–100 |
+| \`entity.risk.calculated_level\` | \`Unknown\`, \`Low\`, \`Moderate\`, \`High\`, \`Critical\` |
+| \`asset.criticality\` | \`low_impact\`, \`medium_impact\`, \`high_impact\`, \`extreme_impact\` |
+| \`entity.lifecycle.first_seen\` | ISO timestamp of first activity |
+| \`entity.lifecycle.last_activity\` | ISO timestamp of most recent activity |
+
+---
+
+## Risk Modifier Reference
+
+| Value | Effect |
+|---|---|
+| 0.0 | Removes all risk contribution |
+| 0.5 | Halves risk contribution |
+| 1.0 | No change (default) |
+| 1.5 | 50 % increase |
+| 2.0 | Doubles risk contribution |
+
+---
+
+## Example Interactions
+
+**User:** "Create a watchlist for users with the highest risk"
+
+1. Call \`security.create_watchlist\` with \`user_query: "users with the highest risk score"\`
+2. Render the returned attachment
+3. Report: "Created watchlist **AI Watchlist: users with the highest risk score** with 12 users. The entity source will stay live — any new high-risk users matching the query will automatically be included."
+
+---
+
+**User:** "Watch all hosts that haven't been seen in the last 7 days but have a high risk score"
+
+1. Call \`security.create_watchlist\` with:
+   \`user_query: "hosts with high risk score not seen in the last 7 days"\`
+2. Render attachment, report result.
+
+---
+
+## ⚠️ CRITICAL RULES
+
+1. ALWAYS call \`security.create_watchlist\` — never describe the steps without executing them.
+2. ALWAYS render the attachment after a successful call.
+3. The watchlist entity source is **live**: entities matching the KQL rule will be included on each sync. Communicate this to the user.
+4. If the tool returns 0 entities, tell the user clearly and suggest relaxing the criteria.
+`;

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/create_watchlist_tool.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/create_watchlist_tool.ts
@@ -1,0 +1,260 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod/v4';
+import { ToolType, ToolResultType } from '@kbn/agent-builder-common';
+import type { BuiltinToolDefinition, StaticToolRegistration } from '@kbn/agent-builder-server';
+import type { CoreSetup, Logger } from '@kbn/core/server';
+import { generateEsql, executeEsql } from '@kbn/agent-builder-genai-utils';
+import { getEntitiesAlias, ENTITY_LATEST } from '@kbn/entity-store/server';
+import {
+  SecurityAgentBuilderAttachments,
+  SECURITY_WATCHLIST_ATTACHMENT_ID,
+} from '../../../common/constants';
+import type {
+  SecuritySolutionPluginStart,
+  SecuritySolutionPluginStartDependencies,
+} from '../../plugin_contract';
+import { securityTool } from './constants';
+import { getAgentBuilderResourceAvailability } from '../utils/get_agent_builder_resource_availability';
+import { WatchlistConfigClient } from '../../lib/entity_analytics/watchlists/management/watchlist_config';
+import { WatchlistEntitySourceClient } from '../../lib/entity_analytics/watchlists/entity_sources/infra';
+
+export const SECURITY_CREATE_WATCHLIST_TOOL_ID = securityTool('create_watchlist');
+
+const createWatchlistSchema = z.object({
+  user_query: z
+    .string()
+    .describe(
+      'Natural language description of which entities to include in the watchlist, e.g. "users with the highest risk score" or "hosts with critical asset criticality and recent activity"'
+    ),
+  watchlist_name: z
+    .string()
+    .optional()
+    .describe(
+      'Name for the watchlist. If omitted, a name is derived from the query.'
+    ),
+  risk_modifier: z
+    .number()
+    .min(0)
+    .max(2)
+    .optional()
+    .describe(
+      'Risk score modifier applied to entities in this watchlist (0.0–2.0). Defaults to 1.0 (no change).'
+    ),
+});
+
+// Context injected into generateEsql so it knows entity store field semantics
+const ENTITY_STORE_QUERY_CONTEXT = `
+You are querying the Entity Store index. Key fields:
+- entity.name (keyword): display name of the entity (username or hostname)
+- entity.EngineMetadata.Type (keyword): entity type — 'user', 'host', 'service', or 'generic'
+- entity.risk.calculated_score_norm (float): normalized risk score 0–100
+- entity.risk.calculated_level (keyword): 'Unknown', 'Low', 'Moderate', 'High', or 'Critical'
+- asset.criticality (keyword): 'low_impact', 'medium_impact', 'high_impact', 'extreme_impact'
+- entity.lifecycle.first_seen (date): ISO timestamp of first observed activity
+- entity.lifecycle.last_activity (date): ISO timestamp of most recent activity
+- entity.attributes.watchlists (keyword[]): watchlist names the entity belongs to
+
+Rules:
+- ALWAYS include entity.name in the SELECT / KEEP clause
+- Sort by entity.risk.calculated_score_norm DESC for risk-based queries unless told otherwise
+- Default LIMIT to 50 unless the user specifies a different number
+`;
+
+const escapeKqlString = (value: string) =>
+  value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+
+const buildKqlFromEntityNames = (names: string[]): string => {
+  const escaped = names.map((n) => `"${escapeKqlString(n)}"`).join(' OR ');
+  return `entity.name: (${escaped})`;
+};
+
+const extractEntityNames = (
+  columns: Array<{ name: string }>,
+  values: unknown[][]
+): string[] => {
+  const colIdx = columns.findIndex((c) => c.name === 'entity.name');
+  if (colIdx === -1) return [];
+  return values
+    .map((row) => row[colIdx])
+    .filter((v): v is string => typeof v === 'string' && v.length > 0);
+};
+
+export function createWatchlistTool(
+  core: CoreSetup<SecuritySolutionPluginStartDependencies, SecuritySolutionPluginStart>,
+  logger: Logger
+): StaticToolRegistration<typeof createWatchlistSchema> {
+  const toolDefinition: BuiltinToolDefinition<typeof createWatchlistSchema> = {
+    id: SECURITY_CREATE_WATCHLIST_TOOL_ID,
+    type: ToolType.builtin,
+    description: `Creates a security watchlist by:
+1. Generating an ES|QL query from a natural language description
+2. Executing it against the Entity Store to find matching entities
+3. Creating a watchlist saved object with those entities as a live query-based entity source
+
+The tool stores the result as an attachment. Use the returned attachmentId and version with <render_attachment id="..." version="..."> to display it.`,
+    schema: createWatchlistSchema,
+    tags: ['security', 'watchlist', 'entity-analytics'],
+    availability: {
+      cacheMode: 'space',
+      handler: async ({ request }) =>
+        getAgentBuilderResourceAvailability({ core, request, logger }),
+    },
+    handler: async (
+      {
+        user_query: userQuery,
+        watchlist_name: watchlistName,
+        risk_modifier: riskModifier = 1.0,
+      },
+      { esClient, modelProvider, request, events, attachments, spaceId }
+    ) => {
+      try {
+        // ── Step 1: Generate ES|QL targeting the entity store ──────────────────
+        const entityIndex = getEntitiesAlias(ENTITY_LATEST, spaceId);
+
+        const model = await modelProvider.getDefaultModel();
+        const esqlResponse = await generateEsql({
+          model,
+          logger,
+          events,
+          nlQuery: userQuery,
+          esClient: esClient.asCurrentUser,
+          index: entityIndex,
+          additionalContext: ENTITY_STORE_QUERY_CONTEXT,
+        });
+
+        if (esqlResponse.error || !esqlResponse.query) {
+          return {
+            results: [
+              {
+                type: ToolResultType.error,
+                data: { message: esqlResponse.error ?? 'Failed to generate ES|QL query' },
+              },
+            ],
+          };
+        }
+
+        // ── Step 2: Execute the query against the Entity Store ─────────────────
+        const { columns, values } = await executeEsql({
+          query: esqlResponse.query,
+          esClient: esClient.asCurrentUser,
+        });
+
+        const entityNames = extractEntityNames(columns, values);
+        if (entityNames.length === 0) {
+          return {
+            results: [
+              {
+                type: ToolResultType.error,
+                data: {
+                  message:
+                    'No matching entities found in the Entity Store for the given description.',
+                  generatedQuery: esqlResponse.query,
+                },
+              },
+            ],
+          };
+        }
+
+        // ── Step 3: Build KQL rule and create watchlist ────────────────────────
+        const kqlQueryRule = buildKqlFromEntityNames(entityNames);
+        const resolvedName =
+          watchlistName ?? `AI Watchlist: ${userQuery.slice(0, 60).trimEnd()}`;
+
+        const [coreStart] = await core.getStartServices();
+        const soClient = coreStart.savedObjects.getScopedClient(request);
+
+        const watchlistClient = new WatchlistConfigClient({
+          logger,
+          namespace: spaceId,
+          soClient,
+          esClient: esClient.asCurrentUser,
+        });
+
+        const sourceClient = new WatchlistEntitySourceClient({
+          soClient,
+          namespace: spaceId,
+        });
+
+        const watchlist = await watchlistClient.create({
+          name: resolvedName,
+          description: `AI-generated watchlist. Original query: "${userQuery}"`,
+          riskModifier,
+          managed: false,
+        });
+
+        if (!watchlist.id) {
+          throw new Error('Watchlist created but no ID returned');
+        }
+
+        const entitySource = await sourceClient.create({
+          type: 'store',
+          name: `${resolvedName} — entity source`,
+          queryRule: kqlQueryRule,
+          enabled: true,
+        });
+
+        await watchlistClient.addEntitySourceReference(watchlist.id, entitySource.id);
+
+        const result = {
+          ...watchlist,
+          entityCount: entityNames.length,
+          entityNames,
+          generatedEsql: esqlResponse.query,
+        };
+
+        // ── Step 4: Persist as attachment ──────────────────────────────────────
+        const created = await attachments.add({
+          id: SECURITY_WATCHLIST_ATTACHMENT_ID,
+          type: SecurityAgentBuilderAttachments.watchlist,
+          data: {
+            text: JSON.stringify(result),
+            attachmentLabel: resolvedName,
+          },
+          description: `Watchlist: ${resolvedName}`,
+        });
+
+        return {
+          results: [
+            {
+              type: ToolResultType.other,
+              data: {
+                success: true,
+                watchlistId: watchlist.id,
+                watchlistName: resolvedName,
+                entityCount: entityNames.length,
+                attachmentId: created.id,
+                version: created.current_version,
+              },
+            },
+          ],
+        };
+      } catch (error) {
+        logger.error(
+          `${SECURITY_CREATE_WATCHLIST_TOOL_ID} failed: ${
+            error instanceof Error ? error.message : String(error)
+          }`
+        );
+        return {
+          results: [
+            {
+              type: ToolResultType.error,
+              data: {
+                message: `Failed to create watchlist: ${
+                  error instanceof Error ? error.message : String(error)
+                }`,
+              },
+            },
+          ],
+        };
+      }
+    },
+  };
+
+  return toolDefinition;
+}

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/index.ts
@@ -23,3 +23,7 @@ export {
   createDetectionRuleTool,
   SECURITY_CREATE_DETECTION_RULE_TOOL_ID,
 } from './create_detection_rule_tool';
+export {
+  createWatchlistTool,
+  SECURITY_CREATE_WATCHLIST_TOOL_ID,
+} from './create_watchlist_tool';

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/register_tools.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/register_tools.ts
@@ -13,6 +13,7 @@ import { attackDiscoverySearchTool } from './attack_discovery_search_tool';
 import { entityRiskScoreTool, getEntityTool, searchEntitiesTool } from './entity_analytics';
 import { alertsTool } from './alerts_tool';
 import { createDetectionRuleTool } from './create_detection_rule_tool';
+import { createWatchlistTool } from './create_watchlist_tool';
 import type { SecuritySolutionPluginCoreSetupDependencies } from '../../plugin_contract';
 
 /**
@@ -31,4 +32,5 @@ export const registerTools = async (
   agentBuilder.tools.register(alertsTool(core, logger));
   agentBuilder.tools.register(getEntityTool(core, logger, experimentalFeatures));
   agentBuilder.tools.register(searchEntitiesTool(core, logger, experimentalFeatures));
+  agentBuilder.tools.register(createWatchlistTool(core, logger));
 };


### PR DESCRIPTION
Implements a proof-of-concept for prompt-driven watchlist creation from the Entity Store via the agent builder skill system.

New files:
- server/agent_builder/tools/create_watchlist_tool.ts: generates ES|QL from a natural-language query, executes it against the Entity Store, builds a live KQL entity source, and creates a watchlist saved object
- server/agent_builder/skills/watchlists/index.ts: skill registered at skills/security/watchlists, triggers on watchlist creation requests
- public/detection_engine/common/ai_watchlist_service.ts: lightweight RxJS BehaviorSubject service (mirrors AiRuleCreationService)
- public/agent_builder/attachment_types/watchlist_attachment.tsx: renders entity names, count, risk modifier, and generated ES|QL in chat

Wiring:
- SecurityAgentBuilderAttachments.watchlist + SECURITY_WATCHLIST_ATTACHMENT_ID
- Tool registered in register_tools.ts and exported from tools/index.ts
- Skill registered in register_skills.ts
- AiWatchlistService instantiated in plugin_services.ts, typed in types.ts
- registerWatchlistAttachment called in plugin.tsx

## Desk testing

### Prerequisites
- Kibana running with a Platinum+ license
- Entity Store initialised and running (Security → Entity Analytics → Entity Store)
- Risk engine enabled so entities have risk scores
- At least one AI connector configured (Stack Management → Connectors)

### Feature flags
Enable the following in `kibana.dev.yml` before starting Kibana:

```yaml
xpack.securitySolution.enableExperimental:
  - entityAnalyticsEntityStoreV2
xpack.cloudLinks.enabled: true
```

### Setup
1. Go to **Stack Management → Advanced Settings**
2. Search for `agentBuilderExperimentalFeatures` and set it to `true`
3. Navigate to **Security Solution** and open the AI chat panel (One Workflow)

### Happy path — risk-based watchlist
1. Type: `create a watchlist for users with the highest risk`
2. Confirm the `watchlist-create` skill is invoked (skill label should appear)
3. Confirm the tool runs and a watchlist attachment renders in the chat showing:
   - Watchlist name
   - Entity count
   - Entity name badges
   - The generated ES|QL query
4. Click **View watchlists** on the attachment — should navigate to Entity Analytics
5. Go to **Security → Entity Analytics → Watchlists** and confirm:
   - New watchlist exists with the expected name
   - An entity source is linked with type `store` and a KQL `queryRule` like `entity.name: ("alice" OR "bob" OR ...)`

### Custom name and risk modifier
1. Type: `create a watchlist called "VIP Users" for hosts with critical asset criticality, risk modifier 1.5`
2. Confirm the watchlist is created with name `VIP Users` and `riskModifier: 1.5`

### No results case
1. Type a query unlikely to match anything, e.g. `create a watchlist for entities last seen in 1900`
2. Confirm the tool returns a clear "no matching entities" error message in the chat (no watchlist created)

### Skills mode off (agent mode)
1. Set `agentBuilderExperimentalFeatures` back to `false`
2. Confirm the threat hunting agent loads as normal and the watchlist tool is not exposed (expected — out of scope for this POC)

