### PR TITLE
[Synthetics] Add experimental feature flag for cross-cluster search (CCS)

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/server/config.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/config.ts
@@ -25,11 +25,22 @@ const uptimeConfig = schema.object({
   index: schema.maybe(schema.string()),
   service: schema.maybe(serviceConfig),
   enabled: schema.boolean({ defaultValue: true }),
+  experimental: schema.maybe(
+    schema.object({
+      ccs: schema.object({
+        enabled: schema.boolean({ defaultValue: false }),
+      }),
+    })
+  ),
 });
 
 export const config: PluginConfigDescriptor = {
   schema: uptimeConfig,
+  exposeToBrowser: {
+    experimental: true,
+  },
 };
 
 export type UptimeConfig = TypeOf<typeof uptimeConfig>;
 export type ServiceConfig = TypeOf<typeof serviceConfig>;
+export type ExperimentalFeatures = UptimeConfig['experimental'];


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/262319

Adds `xpack.synthetics.experimental.ccs.enabled` config option (`default: false`) to gate upcoming CCS functionality. The flag is exposed to the browser via `exposeToBrowser` so both server and client code can check it in subsequent PRs.

This is the first PR in the CCS/federated views epic (#259274). No behavioral changes — the flag is inert until later PRs wire up the gating logic.
