### PR TITLE
[Security Solution] change last event ingested logic to pull from more indices and correct space

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/alert_summary/use_integration_last_alert_ingested.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/alert_summary/use_integration_last_alert_ingested.ts
@@ -37,7 +37,7 @@ export interface UseIntegrationsLastAlertIngestedResult {
 
 /**
  * Hook that fetches the last alert ingested time for a specific integration.
- * We use the index pattern `logs-{integrationName}.alert-default` to query.
+ * We use the index pattern `logs-{integrationName}.*-*` to query.
  */
 export const useIntegrationLastAlertIngested = ({
   integrationName,
@@ -46,8 +46,10 @@ export const useIntegrationLastAlertIngested = ({
 
   // ESQL query to get the last alert ingested in the index
   // We only keep the event.ingested field as it contains the time we want to display on the Integration card.
+  // The first * is to support `alert` and `offense`.
+  // The second * is to support all the datastream namespaces tied to the integration.
   const query = useMemo(
-    () => `FROM ${`logs-${integrationName}.alert-default`}
+    () => `FROM ${`logs-${integrationName}.*-*`}
     | WHERE event.kind == "alert" OR event.kind == "event"
     | SORT ${FIELD} DESC
     | KEEP ${FIELD}


### PR DESCRIPTION
## Summary

This PR makes a very small adjustment to the way we pull information to display the last event ingested in the integration card at the top of the alert summary page in EASE:
- [this recent ticket](https://github.com/elastic/kibana/issues/259912) showed that we don't have a consistent way of creating indices for all our integrations. While until now, all the integrations were following `logs-{integrationName}.alert-{spaceId}`, the recent QRadar integration is using `logs-{integrationName}. offense-{spaceId}`. The change in the PR now supports all names: `logs-{integrationName}. *-{spaceId}`
- I also realized while making the change above that we were hardcoding `default` for our space id. This is not correct. We're now correctly showing the value for the current space. 

### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
