### PR TITLE
fix(dev): properly map Kibana solution name and project type CLI arg to a correct ES and UIAM project type

### DIFF
--- a/src/platform/packages/private/kbn-mock-idp-utils/src/utils.ts
+++ b/src/platform/packages/private/kbn-mock-idp-utils/src/utils.ts
@@ -300,16 +300,19 @@ export const projectTypeToAlias = new Map<string, string>([
   ['workplaceai', 'workplaceai'],
 ]);
 
-// Normalizes CLI aliases (e.g. 'oblt', 'es') to the canonical project type names
-// used in UIAM tokens and ES serverless configuration.
-// Note: 'es' maps to 'elasticsearch' for UIAM (not 'search' which is the Kibana solution name).
-const projectTypeAliases = new Map<string, string>([
-  ['oblt', 'observability'],
-  ['es', 'elasticsearch'],
-]);
+// Normalizes differences between Kibana solution names (`search`), CLI aliases (`es` and `oblt`),
+// and the canonical project type names used in UIAM and ES Serverless configuration.
+const normalizeProjectType = (projectType: string) => {
+  if (projectType === 'search' || projectType === 'es') {
+    return 'elasticsearch';
+  }
 
-const normalizeProjectType = (projectType: string): string =>
-  projectTypeAliases.get(projectType) ?? projectType;
+  if (projectType === 'oblt') {
+    return 'observability';
+  }
+
+  return projectType;
+};
 
 export async function createUiamSessionTokens({
   username,

--- a/src/platform/packages/shared/kbn-es/src/utils/docker.ts
+++ b/src/platform/packages/shared/kbn-es/src/utils/docker.ts
@@ -116,6 +116,12 @@ export const esProjectTypeFromKbn = new Map<string, string>([
   ['workplaceai', 'workplaceai'],
 ]);
 
+// ES operator/settings.json expects 'elasticsearch' for all `elasticsearch_*` project types.
+export const esSettingsProjectTypeFromKbn = new Map<string, string>([
+  ...esProjectTypeFromKbn.entries(),
+  ['es', 'elasticsearch'],
+]);
+
 export const kbnProjectTypeFromEs = new Map<string, string>([
   ['elasticsearch_general_purpose', 'es'],
   ['elasticsearch_search', 'es'],
@@ -909,7 +915,7 @@ export async function setupServerlessVolumes(
     ...getESp12Volume(),
     ...serverlessResources,
     ...(await getOperatorVolume(
-      esProjectTypeFromKbn.get(projectType)!,
+      esSettingsProjectTypeFromKbn.get(projectType)!,
       ssl,
       overrides?.projectId,
       overrides?.operatorPath
@@ -1239,7 +1245,8 @@ async function registerLinkedProjectInOriginSettings(log: ToolingLog, options: S
 
   const currentJson = JSON.parse(await Fsp.readFile(settingsPath, 'utf-8'));
 
-  const esProjectType = esProjectTypeFromKbn.get(options.projectType) ?? options.projectType;
+  const esProjectType =
+    esSettingsProjectTypeFromKbn.get(options.projectType) ?? options.projectType;
   const linkedNodeName = `es01${LINKED_CLUSTER_NAME_SUFFIX}`;
   const linkedEndpoint = `${linkedNodeName}:${REMOTE_CLUSTER_SERVER_PORT}`;
 


### PR DESCRIPTION
## Summary

Properly map Kibana solution name and project type CLI arg to a correct ES and UIAM project type.

We have a zoo of different aliases for serverless project types in Kibana:

- CLI args: `es`, `oblt`, `security`
- Solution names: `search`, `observability`, `security`

These should properly map to the high-level project types supported by ES and UIAM: `elasticsearch`, `observability`, and `security`. 

The Elasticsearch project type is the most complex, as it maps differently depending on the context: for the ES CLI project type argument (`serverless.project_type` - planned to be deprecated and removed), it uses `elasticsearch_general_purpose`, `elasticsearch_search`, `elasticsearch_vector`, and `elasticsearch_timeseries`, while the project type recorded in `operator/settings.json` is simply `elasticsearch`.

## How to test

Try to run Elastic Stack locally for all three supported project types and try to log in with `viewer` role:

```bash
# Elasticsearch
yarn es serverless --projectType elasticsearch_general_purpose
--
yarn start --serverless=es

# Observability
yarn es serverless --projectType observability
--
yarn start --serverless=oblt

# Security
yarn es serverless --projectType security
--
yarn start --serverless=security
```
