### PR TITLE
fix(security,uiam): log UIAM-misconfiguration warning only for authenticated sessions

### DIFF
--- a/x-pack/platform/plugins/shared/security/server/authentication/providers/saml.ts
+++ b/x-pack/platform/plugins/shared/security/server/authentication/providers/saml.ts
@@ -308,7 +308,7 @@ export class SAMLAuthenticationProvider extends BaseAuthenticationProvider<Provi
     // When the provider is in UIAM mode, the UIAM service is responsible for invalidating the user session tokens.
     // Additionally, when in UIAM mode, SAML Single Logout (SLO) is not supported. Therefore, the code should never
     // reach the `else if` branch below. However, even if it does, it will result in a no-op call to Elasticsearch.
-    if (state && this.isUiamToken(state.accessToken)) {
+    if (state?.accessToken && this.isUiamToken(state.accessToken)) {
       try {
         await this.options.uiam.invalidateSessionTokens(state.accessToken!, state.refreshToken!);
       } catch (err) {
@@ -917,7 +917,7 @@ export class SAMLAuthenticationProvider extends BaseAuthenticationProvider<Provi
    * transition period while we support both SAML and UIAM tokens at the same time.
    * @param token ES native or UIAM access or refresh token.
    */
-  private isUiamToken(token?: string): this is { options: { uiam: UiamServicePublic } } {
+  private isUiamToken(token: string): this is { options: { uiam: UiamServicePublic } } {
     const isUiamToken = !!token && isUiamCredential(token);
     if (isUiamToken && !this.useUiam) {
       this.logger.error('Detected UIAM token, but the provider is not configured to use UIAM.');


### PR DESCRIPTION
## Summary

Log UIAM-misconfiguration warning only for authenticated sessions.

Today, we record and track two types of UIAM-misconfiguration related warnings:

* `Detected UIAM token, but the provider is not configured to use UIAM.`
* `Detected non-UIAM token, but the provider is configured to use UIAM.`

In theory, we shouldn't see these anymore. However, we were seeing them from time to time in production with no apparent reason. I've dug into this and noticed that these warnings always occur close to the logout event, which allowed me to come up with a stable reproduction case (see the attached video). When dealing with multiple tabs and concurrent logins, one tab might detect an expired session and trigger a logout while another tab has just initiated a SAML handshake and created an intermediate session. The first tab then invalidates that session. During this process, we might mistakenly treat the intermediate session as a permanent one and log a warning, which is incorrect.

https://github.com/user-attachments/assets/a777ea6e-d3a2-4af6-85e0-7956362517fc
