### PR TITLE
Fix flaky risk score maintainer test in non-default spaces

### DIFF
--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/risk_score_maintainer/trial_license_complete_tier/task_execution_nondefault_spaces.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/risk_score_maintainer/trial_license_complete_tier/task_execution_nondefault_spaces.ts
@@ -132,14 +132,18 @@ export default ({ getService }: FtrProviderContext): void => {
 
         const scores = await readRiskScores(es, [index]);
         const normalized = normalizeScores(scores);
-        expect(normalized.length).to.eql(10);
 
-        const idValues = normalized.map(({ id_value: idValue }) => idValue).sort();
+        // there's a chance that the risk-score calculation happens twice;
+        // once on the schedule, and once because we explicitly trigger it using
+        // runSoon. therefore, we're going to make sure that unique set of ids is 10
+        const uniqueIds = [...new Set(normalized.map(({ id_value: idValue }) => idValue))];
+        expect(uniqueIds.length).to.eql(10);
+
         const expectedEuids = Array(10)
           .fill(0)
           .map((_, _index) => `host:host-${_index}`)
           .sort();
-        expect(idValues).to.eql(expectedEuids);
+        expect(uniqueIds.sort()).to.eql(expectedEuids);
       });
     });
   });


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/262344

The test `calculates and persists risk scores for alert documents` in `task_execution_nondefault_spaces.ts` intermittently fails with `expected 20 to sort of equal 10`.

**Suspected root cause:** `installEntityStoreV2` calls the `entity_maintainers/init` endpoint, which registers the maintainer task via `taskManager.ensureScheduled` without an explicit `runAt` -- making it eligible to run immediately. When task manager picks up and starts that auto-run before `waitForMaintainerRun` calls `runSoon`, the helper detects "already running" and intentionally forces a second run (incrementing `requiredNewRuns`). This results in two maintainer runs, each writing 10 risk score documents to the data stream (20 total), but the test asserted exactly 10.

**Fix:** Deduplicate scores by `id_value` before asserting. The test intent is to verify that each of the 10 entities has a risk score -- not that there are exactly 10 raw documents. Using a `Set` on `id_value` makes the assertion resilient to the maintainer running more than once.

## Test plan

- [ ] Verify the test passes locally: `node scripts/functional_tests --config x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/risk_score_maintainer/trial_license_complete_tier/configs/ess.config.ts`
- [ ] Confirm CI passes on this branch