### PR TITLE
[Alerting V2] Handle NotFoundError in notification policy state updates

### DIFF
--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/notification_policy_client/notification_policy_client.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/notification_policy_client/notification_policy_client.test.ts
@@ -1544,6 +1544,36 @@ describe('NotificationPolicyClient', () => {
         output: { statusCode: 404 },
       });
     });
+
+    it('throws 404 when update rejects with NotFoundError', async () => {
+      mockSavedObjectsClient.update.mockRejectedValueOnce(
+        SavedObjectsErrorHelpers.createGenericNotFoundError(
+          NOTIFICATION_POLICY_SAVED_OBJECT_TYPE,
+          'policy-id-enable-update-404'
+        )
+      );
+
+      await expect(
+        client.enableNotificationPolicy({ id: 'policy-id-enable-update-404' })
+      ).rejects.toMatchObject({
+        output: { statusCode: 404 },
+      });
+    });
+
+    it('throws 409 when update rejects with ConflictError', async () => {
+      mockSavedObjectsClient.update.mockRejectedValueOnce(
+        SavedObjectsErrorHelpers.createConflictError(
+          NOTIFICATION_POLICY_SAVED_OBJECT_TYPE,
+          'policy-id-enable-conflict'
+        )
+      );
+
+      await expect(
+        client.enableNotificationPolicy({ id: 'policy-id-enable-conflict' })
+      ).rejects.toMatchObject({
+        output: { statusCode: 409 },
+      });
+    });
   });
 
   describe('disableNotificationPolicy', () => {
@@ -1596,6 +1626,21 @@ describe('NotificationPolicyClient', () => {
 
       expect(res.id).toBe('policy-id-disable');
       expect(res.auth).not.toHaveProperty('apiKey');
+    });
+
+    it('throws 404 when update rejects with NotFoundError', async () => {
+      mockSavedObjectsClient.update.mockRejectedValueOnce(
+        SavedObjectsErrorHelpers.createGenericNotFoundError(
+          NOTIFICATION_POLICY_SAVED_OBJECT_TYPE,
+          'policy-id-disable-404'
+        )
+      );
+
+      await expect(
+        client.disableNotificationPolicy({ id: 'policy-id-disable-404' })
+      ).rejects.toMatchObject({
+        output: { statusCode: 404 },
+      });
     });
   });
 
@@ -1665,6 +1710,41 @@ describe('NotificationPolicyClient', () => {
       });
 
       expect(mockSavedObjectsClient.update).not.toHaveBeenCalled();
+    });
+
+    it('throws 404 when update rejects with NotFoundError', async () => {
+      mockSavedObjectsClient.update.mockRejectedValueOnce(
+        SavedObjectsErrorHelpers.createGenericNotFoundError(
+          NOTIFICATION_POLICY_SAVED_OBJECT_TYPE,
+          'policy-id-snooze-404'
+        )
+      );
+
+      await expect(
+        client.snoozeNotificationPolicy({
+          id: 'policy-id-snooze-404',
+          snoozedUntil: '2025-06-01T12:00:00.000Z',
+        })
+      ).rejects.toMatchObject({
+        output: { statusCode: 404 },
+      });
+    });
+  });
+
+  describe('unsnoozeNotificationPolicy', () => {
+    it('throws 404 when update rejects with NotFoundError', async () => {
+      mockSavedObjectsClient.update.mockRejectedValueOnce(
+        SavedObjectsErrorHelpers.createGenericNotFoundError(
+          NOTIFICATION_POLICY_SAVED_OBJECT_TYPE,
+          'policy-id-unsnooze-404'
+        )
+      );
+
+      await expect(
+        client.unsnoozeNotificationPolicy({ id: 'policy-id-unsnooze-404' })
+      ).rejects.toMatchObject({
+        output: { statusCode: 404 },
+      });
     });
   });
 

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/notification_policy_client/notification_policy_client.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/notification_policy_client/notification_policy_client.ts
@@ -550,15 +550,27 @@ export class NotificationPolicyClient {
     const userProfile = await this.getUserProfile();
     const now = new Date().toISOString();
 
-    await this.notificationPolicySavedObjectService.update({
-      id,
-      attrs: {
-        ...stateUpdate,
-        updatedBy: userProfile.uid,
-        updatedByUsername: userProfile.username,
-        updatedAt: now,
-      },
-    });
+    try {
+      await this.notificationPolicySavedObjectService.update({
+        id,
+        attrs: {
+          ...stateUpdate,
+          updatedBy: userProfile.uid,
+          updatedByUsername: userProfile.username,
+          updatedAt: now,
+        },
+      });
+    } catch (e) {
+      if (SavedObjectsErrorHelpers.isNotFoundError(e)) {
+        throw Boom.notFound(`Notification policy with id "${id}" not found`);
+      }
+      if (SavedObjectsErrorHelpers.isConflictError(e)) {
+        throw Boom.conflict(
+          `Notification policy with id "${id}" has already been updated by another user`
+        );
+      }
+      throw e;
+    }
 
     return this.getNotificationPolicy({ id });
   }


### PR DESCRIPTION
## Summary

Closes elastic/rna-program#228

`updatePolicyState` did not catch `NotFoundError` from `notificationPolicySavedObjectService.update()`, so calling `enableNotificationPolicy`, `disableNotificationPolicy`, `snoozeNotificationPolicy`, or `unsnoozeNotificationPolicy` on a non-existent policy threw a raw SavedObjects error instead of `Boom.notFound`.

This adds the same try/catch error handling pattern already used in `updateNotificationPolicy` and `updateNotificationPolicyApiKey` — catching `NotFoundError` (→ 404) and `ConflictError` (→ 409) and re-throwing as structured Boom errors.

### Changes

- **`notification_policy_client.ts`**: Wrapped the `update()` call in `updatePolicyState` with error handling for `NotFoundError` and `ConflictError`.
- **`notification_policy_client.test.ts`**: Added tests for the new error paths across `enable`, `disable`, `snooze`, and `unsnooze`. Also added a new `unsnoozeNotificationPolicy` describe block.

Made with [Cursor](https://cursor.com)