### PR TITLE
[Alerting V2] Fix checkbox alignment in notification policies table

### DIFF
--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/list_notification_policies_page/list_notification_policies_page.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/list_notification_policies_page/list_notification_policies_page.tsx
@@ -18,7 +18,6 @@ import {
   type CriteriaWithPagination,
   type EuiBasicTableColumn,
   type EuiTableSelectionType,
-  useEuiTheme,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
 import type {
@@ -75,7 +74,6 @@ export const ListNotificationPoliciesPage = () => {
   const [policyToUpdateApiKey, setPolicyToUpdateApiKey] = useState<string | null>(null);
   const [selectedPolicies, setSelectedPolicies] = useState<NotificationPolicyResponse[]>([]);
 
-  const { euiTheme } = useEuiTheme();
   const { navigateToUrl } = useService(CoreStart('application'));
   const { basePath } = useService(CoreStart('http'));
   const settings = useService(CoreStart('settings'));
@@ -478,8 +476,7 @@ export const ListNotificationPoliciesPage = () => {
                 display: none;
               }
               .euiTableRowCellCheckbox {
-                vertical-align: top;
-                padding-top: ${euiTheme.size.xs};
+                vertical-align: middle;
               }
             `}
             sorting={{


### PR DESCRIPTION
## Summary

Fixes the vertical alignment of row checkboxes in the notification policies list table. The checkboxes were using `vertical-align: top` with a manual `padding-top` which caused them to sit higher than the adjacent row content. Replaced with `vertical-align: middle` so checkboxes center naturally with the row.

### Before

<img width="444" height="261" alt="Screenshot 2026-04-09 at 5 01 12 PM" src="https://github.com/user-attachments/assets/63a0f293-8d86-43f7-b8f0-540dbc21a4bf" />

### After

<img width="418" height="259" alt="Screenshot 2026-04-09 at 5 02 52 PM" src="https://github.com/user-attachments/assets/b456c9ce-fef2-492f-98a8-d367f3ec0a44" />

## Test plan

- [x] Open the notification policies list page
- [x] Verify row checkboxes are vertically centered with the row content
- [x] Verify the header "select all" checkbox still aligns correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)