### PR TITLE
[8.19] [CI / FIPS] Fix FIPS not enabled for Jest integration (#262348)

### DIFF
--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order.ts
@@ -533,6 +533,7 @@ export async function pickTestGroupRunOrder() {
           timeout_in_minutes: 120,
           key: 'jest',
           agents: expandAgentQueue('n2-4-spot', 110),
+          env: envFromlabels,
           depends_on: JEST_CONFIGS_DEPS,
           retry: {
             automatic: [
@@ -553,6 +554,7 @@ export async function pickTestGroupRunOrder() {
           timeout_in_minutes: 75,
           key: 'jest-integration',
           agents: expandAgentQueue('n2-4-spot', 105),
+          env: envFromlabels,
           depends_on: JEST_CONFIGS_DEPS,
           retry: {
             automatic: [

--- a/.buildkite/scripts/common/env.sh
+++ b/.buildkite/scripts/common/env.sh
@@ -133,7 +133,7 @@ export TEST_GROUP_TYPE_FUNCTIONAL="Functional Tests"
 # tells the gh command what our default repo is
 export GH_REPO=github.com/elastic/kibana
 
-if [[ "${TEST_ENABLE_FIPS_VERSION:-}" == "140-2" ]] || [[ "${TEST_ENABLE_FIPS_VERSION:-}" == "140-3" ]] || is_pr_with_label "ci:enable-fips-140-2-agent" || is_pr_with_label "ci:enable-fips-140-3-agent"; then
+if should_enable_fips; then
   ES_SECURITY_ENABLED=true
   export ES_SECURITY_ENABLED
   # used by FIPS agents to link FIPS OpenSSL modules

--- a/.buildkite/scripts/common/util.sh
+++ b/.buildkite/scripts/common/util.sh
@@ -26,6 +26,16 @@ is_auto_commit_disabled() {
   is_pr_with_label "ci:no-auto-commit"
 }
 
+should_enable_fips() {
+  case "${TEST_ENABLE_FIPS_VERSION:-}" in
+    140-2|140-3)
+      return 0
+      ;;
+  esac
+
+  is_pr_with_label "ci:enable-fips-140-2-agent" || is_pr_with_label "ci:enable-fips-140-3-agent"
+}
+
 check_for_changed_files() {
   RED='\033[0;31m'
   YELLOW='\033[0;33m'

--- a/.buildkite/scripts/steps/test/jest_parallel.sh
+++ b/.buildkite/scripts/steps/test/jest_parallel.sh
@@ -62,7 +62,7 @@ while read -r config; do
   # Warning: Closing file descriptor 24 on garbage collection
   cmd="NODE_OPTIONS=\"--max-old-space-size=12288 --trace-warnings"
 
-  if [[ "${TEST_ENABLE_FIPS_VERSION:-}" == "140-2" ]] || [[ "${TEST_ENABLE_FIPS_VERSION:-}" == "140-3" ]] ; then
+  if should_enable_fips; then
     cmd=$cmd" --enable-fips --openssl-config=$HOME/nodejs.cnf"
   fi
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[CI / FIPS] Fix FIPS not enabled for Jest integration (#262348)](https://github.com/elastic/kibana/pull/262348)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Brad White","email":"Ikuni17@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-04-09T20:07:36Z","message":"[CI / FIPS] Fix FIPS not enabled for Jest integration (#262348)\n\n## Summary\n\n- Label to env var mappings were not being passed into Jest environments\nso having a FIPS PR via label was not enabling FIPS in the Jest\nenvironments. The daily FIPS pipeline it was enabled since it was\ntriggered with env var already.\n- Updates the `jest_parallel` executor to also check for the label as a\nfallback\n\n### Testing\n- 140-3 FIPS PR Run via label:\nhttps://buildkite.com/elastic/kibana-pull-request/builds/425020\n- Failures are expected and align with [140-3 daily\nrun](https://buildkite.com/elastic/kibana-fips/builds/1580) failures","sha":"6e18f0faba5281eac6c175c71a01d62fd9b6da23","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Operations","release_note:skip","backport:version","v9.4.0","v8.19.15"],"title":"[CI / FIPS] Fix FIPS not enabled for Jest integration","number":262348,"url":"https://github.com/elastic/kibana/pull/262348","mergeCommit":{"message":"[CI / FIPS] Fix FIPS not enabled for Jest integration (#262348)\n\n## Summary\n\n- Label to env var mappings were not being passed into Jest environments\nso having a FIPS PR via label was not enabling FIPS in the Jest\nenvironments. The daily FIPS pipeline it was enabled since it was\ntriggered with env var already.\n- Updates the `jest_parallel` executor to also check for the label as a\nfallback\n\n### Testing\n- 140-3 FIPS PR Run via label:\nhttps://buildkite.com/elastic/kibana-pull-request/builds/425020\n- Failures are expected and align with [140-3 daily\nrun](https://buildkite.com/elastic/kibana-fips/builds/1580) failures","sha":"6e18f0faba5281eac6c175c71a01d62fd9b6da23"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/262348","number":262348,"mergeCommit":{"message":"[CI / FIPS] Fix FIPS not enabled for Jest integration (#262348)\n\n## Summary\n\n- Label to env var mappings were not being passed into Jest environments\nso having a FIPS PR via label was not enabling FIPS in the Jest\nenvironments. The daily FIPS pipeline it was enabled since it was\ntriggered with env var already.\n- Updates the `jest_parallel` executor to also check for the label as a\nfallback\n\n### Testing\n- 140-3 FIPS PR Run via label:\nhttps://buildkite.com/elastic/kibana-pull-request/builds/425020\n- Failures are expected and align with [140-3 daily\nrun](https://buildkite.com/elastic/kibana-fips/builds/1580) failures","sha":"6e18f0faba5281eac6c175c71a01d62fd9b6da23"}},{"branch":"8.19","label":"v8.19.15","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->