### PR TITLE
fix flaky test: SLOs overview data retention tab poll timeout

### DIFF
--- a/x-pack/solutions/observability/plugins/slo/test/scout/ui/tests/slos_overview.spec.ts
+++ b/x-pack/solutions/observability/plugins/slo/test/scout/ui/tests/slos_overview.spec.ts
@@ -31,10 +31,10 @@ test.describe(
         await page.getByTestId('querySubmitButton').click();
 
         await expect
-          .poll(() => page.locator('text=Test Stack SLO').count(), { timeout: 1000 })
+          .poll(() => page.locator('text=Test Stack SLO').count(), { timeout: 30_000 })
           .toBeGreaterThan(5);
       }).toPass({
-        intervals: [10000],
+        intervals: [10_000],
         timeout: TEST_TIMEOUT,
       });
     });


### PR DESCRIPTION
## Summary

Closes #258671.

**Root cause:** The inner `expect.poll` had a 1000ms timeout — far too tight for the SLO query to return and render >5 results after clicking the submit button. In CI, network/rendering latency frequently exceeded 1s, causing the poll to fail with `Expected: > 5, Received: 0`.

**Fix:** Increased the inner poll timeout from 1s to 30s, giving each retry attempt adequate time to wait for the API response and DOM rendering. The outer `.toPass()` still retries every 10s up to the 3-minute test timeout, so the overall test duration is unchanged when things work quickly.

**Test type:** Scout (Playwright)
**Test file:** `x-pack/solutions/observability/plugins/slo/test/scout/ui/tests/slos_overview.spec.ts`
**Config:** `x-pack/solutions/observability/plugins/slo/test/scout/ui/playwright.config.ts`

## Validation

- [x] Passed 50/50 local runs (`--repeatEach 50`) before PR creation
- [ ] Validated against ECH
- [ ] Validated against MKI
- [ ] CI flaky test runner (50 runs) — triggered via `/flaky` comment below

## Checklist

- [ ] Flaky Test Runner was used on any tests changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)