### PR TITLE
[9.3] [Discover] Fix ES|QL multi-value filtering with `STATS` (#260998)

### DIFF
--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/append_to_query/append_where.test.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/append_to_query/append_where.test.ts
@@ -181,6 +181,54 @@ AND \`ip\` != "127.0.0.2/32"`
     );
   });
 
+  it('appends MV_CONTAINS clauses for multivalue fields with + operation when esFieldType is provided', () => {
+    expect(
+      appendWhereClauseToESQLQuery(
+        'from logstash-*',
+        'tags.keyword',
+        ['info', 'success'],
+        '+',
+        'string',
+        'keyword'
+      )
+    ).toBe(
+      `from logstash-*
+| WHERE MV_CONTAINS(\`tags.keyword\`, ["info", "success"]::keyword)`
+    );
+  });
+
+  it('appends NOT MV_CONTAINS clauses for multivalue fields with - operation when esFieldType is provided', () => {
+    expect(
+      appendWhereClauseToESQLQuery(
+        'from logstash-*',
+        'tags.keyword',
+        ['info', 'success'],
+        '-',
+        'string',
+        'keyword'
+      )
+    ).toBe(
+      `from logstash-*
+| WHERE NOT MV_CONTAINS(\`tags.keyword\`, ["info", "success"]::keyword)`
+    );
+  });
+
+  it('uses a scalar value for MV_CONTAINS when a single multivalue entry is selected', () => {
+    expect(
+      appendWhereClauseToESQLQuery(
+        'from logstash-*',
+        'tags.keyword',
+        ['info'],
+        '+',
+        'string',
+        'keyword'
+      )
+    ).toBe(
+      `from logstash-*
+| WHERE MV_CONTAINS(\`tags.keyword\`, "info"::keyword)`
+    );
+  });
+
   it('appends AND MATCH clauses for multivalue fields when WHERE clause already exists', () => {
     expect(
       appendWhereClauseToESQLQuery(
@@ -193,6 +241,79 @@ AND \`ip\` != "127.0.0.2/32"`
     ).toBe(
       `from logstash-* | WHERE country == "GR"
 AND MATCH(\`tags.keyword\`, "info") AND MATCH(\`tags.keyword\`, "success")`
+    );
+  });
+
+  it('appends AND MV_CONTAINS clauses for multivalue fields when WHERE clause already exists and esFieldType is provided', () => {
+    expect(
+      appendWhereClauseToESQLQuery(
+        'from logstash-* | WHERE country == "GR"',
+        'tags.keyword',
+        ['info', 'success'],
+        '+',
+        'string',
+        'keyword'
+      )
+    ).toBe(
+      `from logstash-* | WHERE country == "GR"
+AND MV_CONTAINS(\`tags.keyword\`, ["info", "success"]::keyword)`
+    );
+  });
+
+  it('does not append MV_CONTAINS clauses for multivalue fields when WHERE clause already exists with the same filter', () => {
+    expect(
+      appendWhereClauseToESQLQuery(
+        'from logstash-* | WHERE MV_CONTAINS(`tags.keyword`, ["info", "success"]::keyword)',
+        'tags.keyword',
+        ['info', 'success'],
+        '+',
+        'string',
+        'keyword'
+      )
+    ).toBe(`from logstash-* | WHERE MV_CONTAINS(\`tags.keyword\`, ["info", "success"]::keyword)`);
+  });
+
+  it('negates the MV_CONTAINS clause for multivalue fields when WHERE clause already exists with the same filter', () => {
+    expect(
+      appendWhereClauseToESQLQuery(
+        'from logstash-* | WHERE MV_CONTAINS(`tags.keyword`, ["info", "success"]::keyword)',
+        'tags.keyword',
+        ['info', 'success'],
+        '-',
+        'string',
+        'keyword'
+      )
+    ).toBe(
+      `from logstash-* | WHERE NOT MV_CONTAINS(\`tags.keyword\`, ["info", "success"]::keyword)`
+    );
+  });
+
+  it('negates existing MV_CONTAINS clauses without inline casts', () => {
+    expect(
+      appendWhereClauseToESQLQuery(
+        'from logstash-* | WHERE MV_CONTAINS(`tags.keyword`, ["info", "success"])',
+        'tags.keyword',
+        ['info', 'success'],
+        '-',
+        'string',
+        'keyword'
+      )
+    ).toBe(`from logstash-* | WHERE NOT MV_CONTAINS(\`tags.keyword\`, ["info", "success"])`);
+  });
+
+  it('appends a new MV_CONTAINS clause when an existing one only partially matches the selected values', () => {
+    expect(
+      appendWhereClauseToESQLQuery(
+        'from logstash-* | WHERE MV_CONTAINS(`tags.keyword`, "info"::keyword)',
+        'tags.keyword',
+        ['info', 'success'],
+        '+',
+        'string',
+        'keyword'
+      )
+    ).toBe(
+      `from logstash-* | WHERE MV_CONTAINS(\`tags.keyword\`, "info"::keyword)
+AND MV_CONTAINS(\`tags.keyword\`, ["info", "success"]::keyword)`
     );
   });
 

--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/append_to_query/append_where.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/append_to_query/append_where.ts
@@ -16,46 +16,98 @@ import {
   appendToESQLQuery,
   PARAM_TYPES_NO_NEED_IMPLICIT_STRING_CASTING,
   extractMatchFunctionDetails,
+  extractMvContainsFunctionDetails,
   getSupportedOperators,
   type SupportedOperators,
   type SupportedOperation,
 } from './utils';
 
+type MultiValueFilterFunction = 'match' | 'mv_contains';
+
+type FilterExpressionResult =
+  | {
+      expression: string;
+      isMultiValue: false;
+    }
+  | {
+      expression: string;
+      isMultiValue: true;
+      values: unknown[];
+      multiValueFilterFunction: MultiValueFilterFunction;
+    };
+
+/**
+ * Creates filter expression for multi-value arrays with the following logic:
+ * - When `esMappingType` is passed, it uses MV_CONTAINS
+ * - Otherwise it uses MATCH clauses combined with AND
+ * - Both cases use NOT for negation when the operation is '-'
+ */
+function buildMultiValueFilterExpression(
+  field: string,
+  values: unknown[],
+  operation: '+' | '-',
+  esMappingType?: string
+): { expression: string; multiValueFilterFunction: MultiValueFilterFunction } {
+  const fieldName = sanitazeESQLInput(field);
+  const multiValueFilterFunction = esMappingType ? 'mv_contains' : 'match';
+
+  if (!fieldName) {
+    return { expression: '', multiValueFilterFunction };
+  }
+
+  const escapedValues = values.map((val) =>
+    typeof val === 'string' ? escapeStringValue(val) : val
+  );
+
+  // If we have an ES mapping type, we can safely use MV_CONTAINS with casting
+  if (esMappingType) {
+    const mvContainsValue =
+      escapedValues.length === 1 ? escapedValues[0] : `[${escapedValues.join(', ')}]`;
+    return {
+      expression:
+        operation === '-'
+          ? `NOT MV_CONTAINS(${fieldName}, ${mvContainsValue}::${esMappingType})`
+          : `MV_CONTAINS(${fieldName}, ${mvContainsValue}::${esMappingType})`,
+      multiValueFilterFunction,
+    };
+  }
+
+  // Otherwise we fall back to using MATCH clauses combined with AND
+  const matchClauses = escapedValues.map((val) => `MATCH(${fieldName}, ${val})`);
+  return {
+    expression:
+      operation === '-'
+        ? matchClauses.map((clause) => `NOT ${clause}`).join(' AND ')
+        : matchClauses.join(' AND '),
+    multiValueFilterFunction,
+  };
+}
+
 /**
  * Creates filter expression for both single and multi-value cases
  * For single values, it creates standard comparison expressions
- * For multi-value arrays, it creates MATCH clauses combined with AND/NOT
+ * For multi-value arrays, it creates MV_CONTAINS or MATCH clauses
  */
 function createFilterExpression(
   field: string,
   value: unknown,
   operation: SupportedOperation,
-  fieldType?: string
-): { expression: string; isMultiValue?: boolean } {
+  kibanaFieldType?: string,
+  esMappingType?: string
+): FilterExpressionResult {
   // Handle is not null / is null operations
   if (operation === 'is_not_null' || operation === 'is_null') {
     const fieldName = sanitazeESQLInput(field);
     const operator = operation === 'is_not_null' ? 'is not null' : 'is null';
-    return { expression: `${fieldName} ${operator}` };
+    return { expression: `${fieldName} ${operator}`, isMultiValue: false };
   }
-  // Handle multi-value arrays with MATCH operator
+  // Handle multi-value arrays with MV_CONTAINS or MATCH
   if (Array.isArray(value)) {
-    const fieldName = sanitazeESQLInput(field);
-    if (!fieldName) {
-      return { expression: '', isMultiValue: true };
-    }
-    const matchClauses = value.map((val) => {
-      const escapedValue = typeof val === 'string' ? escapeStringValue(val) : val;
-      return `MATCH(${fieldName}, ${escapedValue})`;
-    });
-
-    if (operation === '-') {
-      return {
-        expression: matchClauses.map((clause) => `NOT ${clause}`).join(' AND '),
-        isMultiValue: true,
-      };
-    }
-    return { expression: matchClauses.join(' AND '), isMultiValue: true };
+    return {
+      isMultiValue: true,
+      values: value,
+      ...buildMultiValueFilterExpression(field, value, operation, esMappingType),
+    };
   }
 
   // Handle single values with standard operators
@@ -68,7 +120,10 @@ function createFilterExpression(
     return { expression: '', isMultiValue: false };
   }
 
-  if (fieldType === undefined || !PARAM_TYPES_NO_NEED_IMPLICIT_STRING_CASTING.includes(fieldType)) {
+  if (
+    kibanaFieldType === undefined ||
+    !PARAM_TYPES_NO_NEED_IMPLICIT_STRING_CASTING.includes(kibanaFieldType)
+  ) {
     fieldName = `${fieldName}::string`;
   }
 
@@ -105,76 +160,90 @@ function handleExistingFilter(
 }
 
 /**
- * Handles existing multi-value filters in the WHERE clause by checking existing MATCH functions
- * and determining whether to keep existing filters, negate them, or append new ones.
+ * Gets the original source text for a function expression so replacements preserve casts and formatting
+ */
+function getFunctionExpressionFromQuery(baseESQLQuery: string, esqlFunction: ESQLFunction) {
+  return baseESQLQuery.slice(esqlFunction.location.min, esqlFunction.location.max + 1);
+}
+
+/**
+ * Handles existing multi-value filters in the WHERE clause by checking existing MATCH or
+ * MV_CONTAINS functions and determining whether to keep existing filters, negate them,
+ * or append new ones.
  */
 function handleExistingFilterForMultiValues(
   baseESQLQuery: string,
   lastWhereCommand: any,
   field: string,
-  value: unknown,
-  operation: SupportedOperation,
-  filterExpression: string
+  values: unknown[],
+  operation: '+' | '-',
+  filterExpression: string,
+  multiValueFilterFunction: MultiValueFilterFunction
 ): string {
-  const existingMatchFunctionsList = Walker.findAll(
+  const existingMultiValueFunctions = Walker.findAll(
     lastWhereCommand,
-    (node) => node.type === 'function' && node.name === 'match'
-  );
+    (node) => node.type === 'function' && node.name === multiValueFilterFunction
+  ) as ESQLFunction[];
+  const existingFilterExpressions: string[] = [];
 
-  // Gather the values used in MATCH functions
-  const existingValues: string[] = [];
-  existingMatchFunctionsList.forEach((matchFunction) => {
-    const details = extractMatchFunctionDetails(matchFunction as ESQLFunction);
-    if (
-      details &&
-      details.columnName === field &&
-      Array.isArray(value) &&
-      value.includes(details.literalValue)
-    ) {
-      existingValues.push(details.literalValue);
+  if (multiValueFilterFunction === 'mv_contains') {
+    // Check if the MV_CONTAINS function already exists for the selected values
+    const existingMvContainsFilter = values.length
+      ? existingMultiValueFunctions.find((mvContainsFunction) => {
+          const details = extractMvContainsFunctionDetails(mvContainsFunction);
+          return (
+            details &&
+            details.columnName === field &&
+            values.every((val) =>
+              details.literalValues.some((literalValue) => literalValue === val)
+            )
+          );
+        })
+      : undefined;
+
+    if (existingMvContainsFilter) {
+      existingFilterExpressions.push(
+        getFunctionExpressionFromQuery(baseESQLQuery, existingMvContainsFilter)
+      );
     }
-  });
+  } else {
+    // Gather the values used in MATCH functions
+    const existingValues: string[] = [];
+    const matchingFilterExpressions: string[] = [];
 
-  // Check if all values in the array already exist as filters
-  const allValuesExist =
-    Array.isArray(value) &&
-    value.length > 0 &&
-    value.every((val) => existingValues.includes(String(val)));
+    existingMultiValueFunctions.forEach((matchFunction) => {
+      const details = extractMatchFunctionDetails(matchFunction);
+      if (details && details.columnName === field && values.includes(details.literalValue)) {
+        existingValues.push(details.literalValue);
+        matchingFilterExpressions.push(
+          getFunctionExpressionFromQuery(baseESQLQuery, matchFunction)
+        );
+      }
+    });
 
-  if (allValuesExist) {
-    if (operation === '+') {
-      // All positive filters already exist, no changes needed
-      return baseESQLQuery;
-    } else if (operation === '-') {
-      // All negative filters exist as positive - need to negate them
-      let updatedQuery = baseESQLQuery;
-
-      const matchesToNegate: string[] = [];
-      existingMatchFunctionsList.forEach((matchFunction) => {
-        const details = extractMatchFunctionDetails(matchFunction as ESQLFunction);
-        if (
-          details &&
-          details.columnName === field &&
-          Array.isArray(value) &&
-          value.includes(details.literalValue)
-        ) {
-          const fieldName = sanitazeESQLInput(field);
-          const escapedValue = escapeStringValue(details.literalValue);
-          const matchString = `MATCH(${fieldName}, ${escapedValue})`;
-          matchesToNegate.push(matchString);
-        }
-      });
-
-      // Replace each MATCH function with NOT MATCH
-      matchesToNegate.forEach((matchString) => {
-        updatedQuery = updatedQuery.replace(matchString, `NOT ${matchString}`);
-      });
-
-      return updatedQuery;
+    // Check if all values in the array already exist as filters
+    const allValuesExist =
+      values.length > 0 && values.every((val) => existingValues.includes(String(val)));
+    if (allValuesExist) {
+      existingFilterExpressions.push(...matchingFilterExpressions);
     }
   }
 
-  return appendToESQLQuery(baseESQLQuery, `AND ${filterExpression}`);
+  // Append a new filter when the selected values are not already present
+  if (existingFilterExpressions.length === 0) {
+    return appendToESQLQuery(baseESQLQuery, `AND ${filterExpression}`);
+  }
+
+  // All positive filters already exist, no changes needed
+  if (operation === '+') {
+    return baseESQLQuery;
+  }
+
+  // All negative filters exist as positive - need to negate them
+  return existingFilterExpressions.reduce(
+    (updatedQuery, expression) => updatedQuery.replace(expression, `NOT ${expression}`),
+    baseESQLQuery
+  );
 }
 
 /**
@@ -183,7 +252,8 @@ function handleExistingFilterForMultiValues(
  * @param field the field to filter on.
  * @param value the value to filter by.
  * @param operation the operation to perform ('+', '-', 'is_not_null', 'is_null').
- * @param fieldType the type of the field being filtered (optional).
+ * @param kibanaFieldType the type of the field being filtered (optional).
+ * @param esMappingType the ES mapping type of the field (optional, used to determine whether to use MV_CONTAINS).
  * @returns the modified ES|QL query string with the appended WHERE clause, or undefined if no changes were made.
  */
 export function appendWhereClauseToESQLQuery(
@@ -191,17 +261,19 @@ export function appendWhereClauseToESQLQuery(
   field: string,
   value: unknown,
   operation: SupportedOperation,
-  fieldType?: string
+  kibanaFieldType?: string,
+  esMappingType?: string
 ): string | undefined {
   const { root } = Parser.parse(baseESQLQuery);
   const lastCommand = root.commands[root.commands.length - 1];
   const isLastCommandWhere = lastCommand.name === 'where';
 
-  const { expression: filterExpression, isMultiValue } = createFilterExpression(
+  const { expression: filterExpression, ...filterExpressionResult } = createFilterExpression(
     field,
     value,
     operation,
-    fieldType
+    kibanaFieldType,
+    esMappingType
   );
 
   if (!filterExpression) {
@@ -227,14 +299,15 @@ export function appendWhereClauseToESQLQuery(
   }
 
   // Handles multi-value filters
-  if (isMultiValue) {
+  if (filterExpressionResult.isMultiValue) {
     return handleExistingFilterForMultiValues(
       baseESQLQuery,
       lastCommand,
       field,
-      value,
-      operation as '+' | '-',
-      filterExpression
+      filterExpressionResult.values,
+      operation,
+      filterExpression,
+      filterExpressionResult.multiValueFilterFunction
     );
   }
   // Handles single value filters

--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/append_to_query/utils.test.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/append_to_query/utils.test.ts
@@ -7,7 +7,10 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { Parser, Walker } from '@elastic/esql';
+import type { ESQLFunction } from '@elastic/esql/types';
 import { appendToESQLQuery, escapeStringValue } from './utils';
+import { extractMvContainsFunctionDetails } from './utils';
 
 describe('appendToESQLQuery', () => {
   it('append the text on a new line after the query', () => {
@@ -53,5 +56,65 @@ describe('escapeStringValue', () => {
 
   it('handles all special characters combined', () => {
     expect(escapeStringValue('a\\b"c\nd\re\tf')).toBe('"a\\\\b\\"c\\nd\\re\\tf"');
+  });
+});
+
+describe('extractMvContainsFunctionDetails', () => {
+  const getMvContainsFunction = (query: string): ESQLFunction => {
+    const { root } = Parser.parse(query);
+    const lastCommand = root.commands[root.commands.length - 1];
+
+    return Walker.findAll(
+      lastCommand,
+      (node) => node.type === 'function' && node.name === 'mv_contains'
+    )[0] as ESQLFunction;
+  };
+
+  it('extracts values from MV_CONTAINS lists with inline casts', () => {
+    expect(
+      extractMvContainsFunctionDetails(
+        getMvContainsFunction(
+          'from logstash-* | WHERE MV_CONTAINS(`tags.keyword`, ["info", "success"]::keyword)'
+        )
+      )
+    ).toEqual({
+      columnName: 'tags.keyword',
+      literalValues: ['info', 'success'],
+    });
+  });
+
+  it('extracts values from MV_CONTAINS lists without inline casts', () => {
+    expect(
+      extractMvContainsFunctionDetails(
+        getMvContainsFunction('from logstash-* | WHERE MV_CONTAINS(`bytes`, [1, 2])')
+      )
+    ).toEqual({
+      columnName: 'bytes',
+      literalValues: [1, 2],
+    });
+  });
+
+  it('extracts scalar values from MV_CONTAINS without inline casts', () => {
+    expect(
+      extractMvContainsFunctionDetails(
+        getMvContainsFunction('from logstash-* | WHERE MV_CONTAINS(`tags.keyword`, "info")')
+      )
+    ).toEqual({
+      columnName: 'tags.keyword',
+      literalValues: ['info'],
+    });
+  });
+
+  it('extracts scalar values from MV_CONTAINS with inline casts', () => {
+    expect(
+      extractMvContainsFunctionDetails(
+        getMvContainsFunction(
+          'from logstash-* | WHERE MV_CONTAINS(`tags.keyword`, "info"::keyword)'
+        )
+      )
+    ).toEqual({
+      columnName: 'tags.keyword',
+      literalValues: ['info'],
+    });
   });
 });

--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/append_to_query/utils.test.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/append_to_query/utils.test.ts
@@ -7,8 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { Parser, Walker } from '@elastic/esql';
-import type { ESQLFunction } from '@elastic/esql/types';
+import { Parser, Walker } from '@kbn/esql-ast';
+import type { ESQLFunction } from '@kbn/esql-ast';
 import { appendToESQLQuery, escapeStringValue } from './utils';
 import { extractMvContainsFunctionDetails } from './utils';
 

--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/append_to_query/utils.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/append_to_query/utils.ts
@@ -6,11 +6,13 @@
  * your election, the "Elastic License 2.0", the "GNU Affero General Public
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
-import { isColumn, isStringLiteral } from '@kbn/esql-ast';
+import { isColumn, isInlineCast, isLiteral, isStringLiteral } from '@kbn/esql-ast';
 import type {
   BinaryExpressionComparisonOperator,
+  ESQLAstItem,
   ESQLColumn,
   ESQLFunction,
+  ESQLLiteral,
   ESQLStringLiteral,
 } from '@kbn/esql-ast/src/types';
 
@@ -107,4 +109,63 @@ export function extractMatchFunctionDetails(matchFunction: ESQLFunction): {
   }
 
   return null;
+}
+
+/**
+ * MV_CONTAINS can receive bare literals/lists or inline-cast values, so unwrap casts
+ * and keep only the literal or list node used for value extraction
+ */
+function getMvContainsValueNode(valueArg: ESQLAstItem | undefined) {
+  if (!valueArg || Array.isArray(valueArg)) {
+    return null;
+  }
+
+  const unwrappedValueArg = isInlineCast(valueArg) ? valueArg.value : valueArg;
+  if (Array.isArray(unwrappedValueArg)) {
+    return null;
+  }
+
+  if (unwrappedValueArg.type === 'list') {
+    return unwrappedValueArg;
+  }
+
+  return isLiteral(unwrappedValueArg) ? unwrappedValueArg : null;
+}
+
+/**
+ * Extracts field name and values from an MV_CONTAINS function AST node,
+ * supporting both casted and uncast scalar or list values
+ */
+export function extractMvContainsFunctionDetails(mvContainsFunction: ESQLFunction): {
+  columnName: string;
+  literalValues: Array<string | number>;
+} | null {
+  const [column, valueArg] = mvContainsFunction.args;
+  const valueNode = getMvContainsValueNode(valueArg);
+  if (!isColumn(column) || !valueNode) {
+    return null;
+  }
+
+  let literalNodes: ESQLLiteral[];
+  if (valueNode.type === 'list') {
+    const filteredLiteralNodes = valueNode.values.filter(isLiteral);
+    if (filteredLiteralNodes.length === valueNode.values.length) {
+      literalNodes = filteredLiteralNodes;
+    } else {
+      literalNodes = [];
+    }
+  } else {
+    literalNodes = [valueNode];
+  }
+
+  if (literalNodes.length === 0) {
+    return null;
+  }
+
+  return {
+    columnName: (column as ESQLColumn).name,
+    literalValues: literalNodes.map((literal) =>
+      literal.literalType === 'keyword' ? literal.valueUnquoted : literal.value
+    ),
+  };
 }

--- a/src/platform/packages/shared/kbn-unified-doc-viewer/src/services/types.ts
+++ b/src/platform/packages/shared/kbn-unified-doc-viewer/src/services/types.ts
@@ -18,6 +18,7 @@ export interface FieldMapping {
   scripted?: boolean;
   rowCount?: number;
   type: string;
+  esTypes?: string[];
   name: string;
   displayName?: string;
 }

--- a/src/platform/plugins/shared/data/public/actions/filters/create_filters_from_value_click.ts
+++ b/src/platform/plugins/shared/data/public/actions/filters/create_filters_from_value_click.ts
@@ -285,7 +285,8 @@ export const appendFilterToESQLQueryFromValueClickAction = ({
           column.name,
           value,
           getOperationForWhere(value, negate || false),
-          column.meta?.type
+          column.meta?.type,
+          column.meta?.esType
         );
 
         if (queryWithWhere) {

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_layout.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_layout.tsx
@@ -232,6 +232,7 @@ export function DiscoverLayout({ stateContainer }: DiscoverLayoutProps) {
       const fieldName = typeof field === 'string' ? field : field.name;
       // send the field type for casting
       const fieldType = typeof field !== 'string' ? field.type : undefined;
+      const esFieldType = typeof field !== 'string' ? field.esTypes?.[0] : undefined;
       // weird existence logic from Discover components
       // in the field it comes the operator _exists_ and in the value the field
       // I need to take care of it here but I think it should be handled on the fieldlist instead
@@ -240,7 +241,8 @@ export function DiscoverLayout({ stateContainer }: DiscoverLayoutProps) {
         fieldName === '_exists_' ? String(values) : fieldName,
         fieldName === '_exists_' || values == null ? undefined : values,
         getOperator(fieldName, values, operation),
-        fieldType
+        fieldType,
+        esFieldType
       );
       if (!updatedQuery) {
         return;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Discover] Fix ES|QL multi-value filtering with `STATS` (#260998)](https://github.com/elastic/kibana/pull/260998)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Davis McPhee","email":"davis.mcphee@elastic.co"},"sourceCommit":{"committedDate":"2026-04-09T15:47:44Z","message":"[Discover] Fix ES|QL multi-value filtering with `STATS` (#260998)\n\n## Summary\n\nThis PR fixes an issue where using the table cell filter buttons on\nmulti-value fields while the query contains `STATS` results in an ES\nerror. This is because we were using `MATCH` for multi-value filtering,\nbut it's invalid after the `STATS` command.\n\nI've instead updated it to use `MV_CONTAINS` when we know the ES field\ntype and can properly cast it, which seems to work well. I haven't\nworked with multi-value fields in ES|QL much though, so not sure if\nthere's a reason this would be a bad idea.\n\nBefore:\n\n\nhttps://github.com/user-attachments/assets/41cd4146-6721-4bd7-85e0-09d52a317684\n\nAfter:\n\n\nhttps://github.com/user-attachments/assets/98116121-9896-4d70-a237-0dafde3c2358\n\nFixes #260995.\n\n### Checklist\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: Stratou <efstratia.kalafateli@elastic.co>","sha":"f24094f1cf678dbc8b38c77d327daa43d804607c","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:DataDiscovery","backport:version","v9.4.0","v9.3.3"],"title":"[Discover] Fix ES|QL multi-value filtering with `STATS`","number":260998,"url":"https://github.com/elastic/kibana/pull/260998","mergeCommit":{"message":"[Discover] Fix ES|QL multi-value filtering with `STATS` (#260998)\n\n## Summary\n\nThis PR fixes an issue where using the table cell filter buttons on\nmulti-value fields while the query contains `STATS` results in an ES\nerror. This is because we were using `MATCH` for multi-value filtering,\nbut it's invalid after the `STATS` command.\n\nI've instead updated it to use `MV_CONTAINS` when we know the ES field\ntype and can properly cast it, which seems to work well. I haven't\nworked with multi-value fields in ES|QL much though, so not sure if\nthere's a reason this would be a bad idea.\n\nBefore:\n\n\nhttps://github.com/user-attachments/assets/41cd4146-6721-4bd7-85e0-09d52a317684\n\nAfter:\n\n\nhttps://github.com/user-attachments/assets/98116121-9896-4d70-a237-0dafde3c2358\n\nFixes #260995.\n\n### Checklist\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: Stratou <efstratia.kalafateli@elastic.co>","sha":"f24094f1cf678dbc8b38c77d327daa43d804607c"}},"sourceBranch":"main","suggestedTargetBranches":["9.3"],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/260998","number":260998,"mergeCommit":{"message":"[Discover] Fix ES|QL multi-value filtering with `STATS` (#260998)\n\n## Summary\n\nThis PR fixes an issue where using the table cell filter buttons on\nmulti-value fields while the query contains `STATS` results in an ES\nerror. This is because we were using `MATCH` for multi-value filtering,\nbut it's invalid after the `STATS` command.\n\nI've instead updated it to use `MV_CONTAINS` when we know the ES field\ntype and can properly cast it, which seems to work well. I haven't\nworked with multi-value fields in ES|QL much though, so not sure if\nthere's a reason this would be a bad idea.\n\nBefore:\n\n\nhttps://github.com/user-attachments/assets/41cd4146-6721-4bd7-85e0-09d52a317684\n\nAfter:\n\n\nhttps://github.com/user-attachments/assets/98116121-9896-4d70-a237-0dafde3c2358\n\nFixes #260995.\n\n### Checklist\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: Stratou <efstratia.kalafateli@elastic.co>","sha":"f24094f1cf678dbc8b38c77d327daa43d804607c"}},{"branch":"9.3","label":"v9.3.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->