### PR TITLE
[9.3] [Observability Overview] Support OTel host metrics in Hosts table (#261564)

### DIFF
--- a/x-pack/solutions/observability/plugins/infra/server/routes/overview/index.ts
+++ b/x-pack/solutions/observability/plugins/infra/server/routes/overview/index.ts
@@ -8,6 +8,8 @@ import { createRouteValidationFunction } from '@kbn/io-ts-utils';
 import { TopNodesRequestRT } from '../../../common/http_api/overview_api';
 import type { InfraBackendLibs } from '../../lib/infra_types';
 import { createSearchClient } from '../../lib/create_search_client';
+import { getInfraMetricsClient } from '../../lib/helpers/get_infra_metrics_client';
+import { getPreferredSchema } from '../../lib/helpers/get_preferred_schema';
 import { queryTopNodes } from './lib/get_top_nodes';
 
 export const initOverviewRoute = (libs: InfraBackendLibs) => {
@@ -27,7 +29,22 @@ export const initOverviewRoute = (libs: InfraBackendLibs) => {
       const soClient = (await requestContext.core).savedObjects.client;
       const source = await libs.sources.getSourceConfiguration(soClient, options.sourceId);
 
-      const topNResponse = await queryTopNodes(options, client, source);
+      const infraMetricsClient = await getInfraMetricsClient({
+        request,
+        libs,
+        context: requestContext,
+      });
+
+      const { schemas } = await getPreferredSchema({
+        infraMetricsClient,
+        dataSource: 'host',
+        from: options.timerange.from,
+        to: options.timerange.to,
+      });
+
+      const activeSchemas = schemas.length > 0 ? schemas : ['ecs' as const];
+
+      const topNResponse = await queryTopNodes(options, client, source, activeSchemas);
 
       return response.ok({
         body: topNResponse,

--- a/x-pack/solutions/observability/plugins/infra/server/routes/overview/lib/convert_es_response_to_top_nodes_response.test.ts
+++ b/x-pack/solutions/observability/plugins/infra/server/routes/overview/lib/convert_es_response_to_top_nodes_response.test.ts
@@ -1,0 +1,152 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { InfraDatabaseSearchResponse } from '../../../lib/adapters/framework';
+import type { ESResponseForTopNodes, NodeBucket } from './types';
+import { convertESResponseToTopNodesResponse } from './convert_es_response_to_top_nodes_response';
+
+const makeNodeBucket = (overrides: Partial<NodeBucket> & { key: string }): NodeBucket => ({
+  doc_count: 100,
+  metadata: {
+    top: [
+      {
+        sort: ['2024-01-01T00:00:00.000Z'],
+        metrics: {
+          'host.name': overrides.key,
+          'host.os.platform': 'linux',
+          'cloud.provider': 'aws',
+        },
+      },
+    ],
+  },
+  cpu: { value: 0.5 },
+  load: { value: 2.0 },
+  timeseries: { buckets: [] },
+  ...overrides,
+});
+
+describe('convertESResponseToTopNodesResponse', () => {
+  it('returns empty series when no aggregations exist', () => {
+    const response = { aggregations: undefined } as unknown as InfraDatabaseSearchResponse<
+      {},
+      ESResponseForTopNodes
+    >;
+    expect(convertESResponseToTopNodesResponse(response)).toEqual({ series: [] });
+  });
+
+  it('converts a full ECS response with all metrics', () => {
+    const node = makeNodeBucket({
+      key: 'host-a',
+      uptime: { value: 123456 },
+      iowait: { value: 0.02 },
+      rx: { bytes: { value: 1024 } } as any,
+      tx: { bytes: { value: 2048 } } as any,
+    });
+
+    const response = {
+      aggregations: { nodes: { buckets: [node] } },
+    } as unknown as InfraDatabaseSearchResponse<{}, ESResponseForTopNodes>;
+
+    const result = convertESResponseToTopNodesResponse(response);
+    expect(result.series).toHaveLength(1);
+    expect(result.series[0]).toMatchObject({
+      id: 'host-a',
+      cpu: 0.5,
+      load: 2.0,
+      uptime: 123456,
+      iowait: 0.02,
+      rx: 1024,
+      tx: 2048,
+    });
+  });
+
+  it('handles semconv response with missing optional metrics', () => {
+    const node = makeNodeBucket({
+      key: 'otel-host',
+    });
+
+    const response = {
+      aggregations: { nodes: { buckets: [node] } },
+    } as unknown as InfraDatabaseSearchResponse<{}, ESResponseForTopNodes>;
+
+    const result = convertESResponseToTopNodesResponse(response);
+    expect(result.series).toHaveLength(1);
+    expect(result.series[0]).toMatchObject({
+      id: 'otel-host',
+      cpu: 0.5,
+      load: 2.0,
+      uptime: null,
+      iowait: null,
+      rx: null,
+      tx: null,
+    });
+  });
+
+  it('handles response with all metrics missing (including load)', () => {
+    const node: NodeBucket = {
+      key: 'empty-host',
+      doc_count: 0,
+      metadata: {
+        top: [
+          {
+            sort: ['2024-01-01T00:00:00.000Z'],
+            metrics: {
+              'host.name': 'empty-host',
+              'host.os.platform': null,
+              'cloud.provider': null,
+            },
+          },
+        ],
+      },
+      timeseries: { buckets: [] },
+    };
+
+    const response = {
+      aggregations: { nodes: { buckets: [node] } },
+    } as unknown as InfraDatabaseSearchResponse<{}, ESResponseForTopNodes>;
+
+    const result = convertESResponseToTopNodesResponse(response);
+    expect(result.series[0]).toMatchObject({
+      id: 'empty-host',
+      cpu: null,
+      load: null,
+      uptime: null,
+      iowait: null,
+      rx: null,
+      tx: null,
+    });
+  });
+
+  it('handles timeseries buckets with missing optional metrics', () => {
+    const node = makeNodeBucket({
+      key: 'otel-host',
+      timeseries: {
+        buckets: [
+          {
+            key: 1704067200000,
+            key_as_string: '2024-01-01T00:00:00.000Z',
+            doc_count: 10,
+            cpu: { value: 0.4 },
+            load: { value: 1.5 },
+          } as any,
+        ],
+      },
+    });
+
+    const response = {
+      aggregations: { nodes: { buckets: [node] } },
+    } as unknown as InfraDatabaseSearchResponse<{}, ESResponseForTopNodes>;
+
+    const result = convertESResponseToTopNodesResponse(response);
+    const ts = result.series[0].timeseries[0];
+    expect(ts.cpu).toBe(0.4);
+    expect(ts.load).toBe(1.5);
+    expect(ts.iowait).toBeNull();
+    expect(ts.rx).toBeNull();
+    expect(ts.tx).toBeNull();
+  });
+});

--- a/x-pack/solutions/observability/plugins/infra/server/routes/overview/lib/convert_es_response_to_top_nodes_response.ts
+++ b/x-pack/solutions/observability/plugins/infra/server/routes/overview/lib/convert_es_response_to_top_nodes_response.ts
@@ -24,19 +24,19 @@ export const convertESResponseToTopNodesResponse = (
         timeseries: node.timeseries.buckets.map((bucket) => {
           return {
             timestamp: bucket.key,
-            cpu: bucket.cpu.value,
-            iowait: bucket.iowait.value,
-            load: bucket.load.value,
-            rx: bucket.rx?.bytes.value || null,
-            tx: bucket.tx?.bytes.value || null,
+            cpu: bucket.cpu?.value ?? null,
+            iowait: bucket.iowait?.value ?? null,
+            load: bucket.load?.value ?? null,
+            rx: bucket.rx?.bytes?.value ?? null,
+            tx: bucket.tx?.bytes?.value ?? null,
           };
         }),
-        cpu: node.cpu.value,
-        iowait: node.iowait.value,
-        load: node.load.value,
-        uptime: node.uptime.value,
-        rx: node.rx?.bytes.value || null,
-        tx: node.tx?.bytes.value || null,
+        cpu: node.cpu?.value ?? null,
+        iowait: node.iowait?.value ?? null,
+        load: node.load?.value ?? null,
+        uptime: node.uptime?.value ?? null,
+        rx: node.rx?.bytes?.value ?? null,
+        tx: node.tx?.bytes?.value ?? null,
       };
     }),
   };

--- a/x-pack/solutions/observability/plugins/infra/server/routes/overview/lib/create_top_nodes_query.test.ts
+++ b/x-pack/solutions/observability/plugins/infra/server/routes/overview/lib/create_top_nodes_query.test.ts
@@ -1,0 +1,163 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { TopNodesRequest } from '../../../../common/http_api/overview_api';
+import type { MetricsSourceConfiguration } from '../../../../common/metrics_sources';
+import { createTopNodesQuery } from './create_top_nodes_query';
+
+const baseOptions: TopNodesRequest = {
+  sourceId: 'default',
+  size: 5,
+  bucketSize: '1m',
+  timerange: { from: 1000, to: 2000 },
+};
+
+const source = {
+  configuration: { metricAlias: 'metrics-*' },
+} as MetricsSourceConfiguration;
+
+describe('createTopNodesQuery', () => {
+  describe('ECS schema', () => {
+    it('uses the inventory model node filter for ECS', () => {
+      const query = createTopNodesQuery(baseOptions, source, 'ecs');
+      const filters = query.query.bool.filter;
+      const systemFilter = filters.find(
+        (f: Record<string, unknown>) =>
+          'bool' in f &&
+          (f as { bool: { should: Array<{ term: Record<string, string> }> } }).bool.should?.some(
+            (clause) => clause.term?.['event.module'] === 'system'
+          )
+      );
+      expect(systemFilter).toBeDefined();
+    });
+
+    it('includes runtime_mappings for rx/tx', () => {
+      const query = createTopNodesQuery(baseOptions, source, 'ecs');
+      expect(query.runtime_mappings).toBeDefined();
+      expect(query.runtime_mappings).toHaveProperty('rx_bytes_per_period');
+      expect(query.runtime_mappings).toHaveProperty('tx_bytes_per_period');
+    });
+
+    it('includes ECS-specific aggregations', () => {
+      const query = createTopNodesQuery(baseOptions, source, 'ecs');
+      const nodeAggs = query.aggs.nodes.aggs;
+      expect(nodeAggs).toHaveProperty('uptime');
+      expect(nodeAggs).toHaveProperty('cpu');
+      expect(nodeAggs).toHaveProperty('iowait');
+      expect(nodeAggs).toHaveProperty('load');
+      expect(nodeAggs).toHaveProperty('rx');
+      expect(nodeAggs).toHaveProperty('tx');
+    });
+
+    it('defaults sort to uptime for ECS', () => {
+      const query = createTopNodesQuery(baseOptions, source, 'ecs');
+      expect(query.aggs.nodes.terms.order).toEqual({ uptime: 'asc' });
+    });
+
+    it('defaults to ECS when no schema is provided', () => {
+      const query = createTopNodesQuery(baseOptions, source);
+      const filters = query.query.bool.filter;
+      const systemFilter = filters.find(
+        (f: Record<string, unknown>) =>
+          'bool' in f &&
+          (f as { bool: { should: Array<{ term: Record<string, string> }> } }).bool.should?.some(
+            (clause) => clause.term?.['event.module'] === 'system'
+          )
+      );
+      expect(systemFilter).toBeDefined();
+    });
+  });
+
+  describe('semconv schema', () => {
+    it('uses data_stream.dataset filter', () => {
+      const query = createTopNodesQuery(baseOptions, source, 'semconv');
+      const filters = query.query.bool.filter;
+      const datasetFilter = filters.find(
+        (f: Record<string, unknown>) =>
+          'bool' in f &&
+          (f as { bool: { filter: Array<{ term: Record<string, string> }> } }).bool.filter.some(
+            (ff) => ff.term?.['data_stream.dataset'] === 'hostmetricsreceiver.otel'
+          )
+      );
+      expect(datasetFilter).toBeDefined();
+    });
+
+    it('does not include runtime_mappings', () => {
+      const query = createTopNodesQuery(baseOptions, source, 'semconv');
+      expect(query.runtime_mappings).toBeUndefined();
+    });
+
+    it('includes semconv CPU aggregations with bucket_script', () => {
+      const query = createTopNodesQuery(baseOptions, source, 'semconv');
+      const nodeAggs = query.aggs.nodes.aggs;
+      expect(nodeAggs).toHaveProperty('cpu_idle');
+      expect(nodeAggs).toHaveProperty('cpu_idle_total');
+      expect(nodeAggs).toHaveProperty('cpu');
+      expect((nodeAggs as Record<string, any>).cpu).toHaveProperty('bucket_script');
+    });
+
+    it('uses semconv load field', () => {
+      const query = createTopNodesQuery(baseOptions, source, 'semconv');
+      const nodeAggs = query.aggs.nodes.aggs as Record<string, any>;
+      expect(nodeAggs.load.avg.field).toBe('system.cpu.load_average.15m');
+    });
+
+    it('does not include uptime, iowait, rx, or tx aggregations', () => {
+      const query = createTopNodesQuery(baseOptions, source, 'semconv');
+      const nodeAggs = query.aggs.nodes.aggs;
+      expect(nodeAggs).not.toHaveProperty('uptime');
+      expect(nodeAggs).not.toHaveProperty('iowait');
+      expect(nodeAggs).not.toHaveProperty('rx');
+      expect(nodeAggs).not.toHaveProperty('tx');
+    });
+
+    it('defaults sort to load for semconv', () => {
+      const query = createTopNodesQuery(baseOptions, source, 'semconv');
+      expect(query.aggs.nodes.terms.order).toEqual({ load: 'asc' });
+    });
+
+    it('includes semconv timeseries sub-aggregations', () => {
+      const query = createTopNodesQuery(baseOptions, source, 'semconv');
+      const timeseriesAggs = (query.aggs.nodes.aggs as Record<string, any>).timeseries.aggs;
+      expect(timeseriesAggs).toHaveProperty('cpu');
+      expect(timeseriesAggs).toHaveProperty('load');
+      expect(timeseriesAggs.cpu).toHaveProperty('bucket_script');
+      expect(timeseriesAggs).not.toHaveProperty('rx');
+      expect(timeseriesAggs).not.toHaveProperty('tx');
+      expect(timeseriesAggs).not.toHaveProperty('iowait');
+    });
+  });
+
+  describe('sort overrides', () => {
+    it('sorts by _key when sort is name', () => {
+      const opts = { ...baseOptions, sort: 'name' };
+      const query = createTopNodesQuery(opts, source, 'ecs');
+      expect(query.aggs.nodes.terms.order).toEqual({ _key: 'asc' });
+    });
+
+    it('uses custom sort field', () => {
+      const opts = { ...baseOptions, sort: 'cpu', sortDirection: 'desc' };
+      const query = createTopNodesQuery(opts, source, 'ecs');
+      expect(query.aggs.nodes.terms.order).toEqual({ cpu: 'desc' });
+    });
+
+    it.each(['uptime', 'iowait', 'rx', 'tx'])(
+      'falls back to load for semconv when sort is %s',
+      (sort) => {
+        const opts = { ...baseOptions, sort };
+        const query = createTopNodesQuery(opts, source, 'semconv');
+        expect(query.aggs.nodes.terms.order).toEqual({ load: 'asc' });
+      }
+    );
+
+    it('allows cpu sort for semconv', () => {
+      const opts = { ...baseOptions, sort: 'cpu', sortDirection: 'desc' };
+      const query = createTopNodesQuery(opts, source, 'semconv');
+      expect(query.aggs.nodes.terms.order).toEqual({ cpu: 'desc' });
+    });
+  });
+});

--- a/x-pack/solutions/observability/plugins/infra/server/routes/overview/lib/create_top_nodes_query.test.ts
+++ b/x-pack/solutions/observability/plugins/infra/server/routes/overview/lib/create_top_nodes_query.test.ts
@@ -24,7 +24,7 @@ describe('createTopNodesQuery', () => {
   describe('ECS schema', () => {
     it('uses the inventory model node filter for ECS', () => {
       const query = createTopNodesQuery(baseOptions, source, 'ecs');
-      const filters = query.query.bool.filter;
+      const filters = query.query.bool.filter as any[];
       const systemFilter = filters.find(
         (f: Record<string, unknown>) =>
           'bool' in f &&
@@ -60,7 +60,7 @@ describe('createTopNodesQuery', () => {
 
     it('defaults to ECS when no schema is provided', () => {
       const query = createTopNodesQuery(baseOptions, source);
-      const filters = query.query.bool.filter;
+      const filters = query.query.bool.filter as any[];
       const systemFilter = filters.find(
         (f: Record<string, unknown>) =>
           'bool' in f &&
@@ -75,7 +75,7 @@ describe('createTopNodesQuery', () => {
   describe('semconv schema', () => {
     it('uses data_stream.dataset filter', () => {
       const query = createTopNodesQuery(baseOptions, source, 'semconv');
-      const filters = query.query.bool.filter;
+      const filters = query.query.bool.filter as any[];
       const datasetFilter = filters.find(
         (f: Record<string, unknown>) =>
           'bool' in f &&

--- a/x-pack/solutions/observability/plugins/infra/server/routes/overview/lib/create_top_nodes_query.ts
+++ b/x-pack/solutions/observability/plugins/infra/server/routes/overview/lib/create_top_nodes_query.ts
@@ -5,49 +5,257 @@
  * 2.0.
  */
 
+import type { DataSchemaFormat } from '@kbn/metrics-data-access-plugin/common';
+import { findInventoryModel } from '@kbn/metrics-data-access-plugin/common';
 import type { MetricsSourceConfiguration } from '../../../../common/metrics_sources';
 import type { TopNodesRequest } from '../../../../common/http_api/overview_api';
 import { TIMESTAMP_FIELD } from '../../../../common/constants';
 
+const getNodeFilter = (schema: DataSchemaFormat) => {
+  const inventoryModel = findInventoryModel('host');
+  const filters = inventoryModel.nodeFilter?.({ schema }) ?? [];
+  return filters[0] ?? { match_all: {} };
+};
+
+const getEcsAggs = (options: TopNodesRequest) => ({
+  uptime: {
+    max: {
+      field: 'system.uptime.duration.ms',
+    },
+  },
+  cpu: {
+    avg: {
+      field: 'system.cpu.total.norm.pct',
+    },
+  },
+  iowait: {
+    avg: {
+      field: 'system.core.iowait.pct',
+    },
+  },
+  load: {
+    avg: {
+      field: 'system.load.15',
+    },
+  },
+  rx: {
+    filter: {
+      exists: {
+        field: 'host.network.ingress.bytes',
+      },
+    },
+    aggs: {
+      bytes: {
+        avg: {
+          field: 'rx_bytes_per_period',
+        },
+      },
+    },
+  },
+  tx: {
+    filter: {
+      exists: {
+        field: 'host.network.egress.bytes',
+      },
+    },
+    aggs: {
+      bytes: {
+        avg: {
+          field: 'tx_bytes_per_period',
+        },
+      },
+    },
+  },
+  timeseries: {
+    date_histogram: {
+      field: '@timestamp',
+      fixed_interval: options.bucketSize,
+      extended_bounds: {
+        min: options.timerange.from,
+        max: options.timerange.to,
+      },
+    },
+    aggs: {
+      cpu: {
+        avg: {
+          field: 'host.cpu.pct',
+        },
+      },
+      iowait: {
+        avg: {
+          field: 'system.core.iowait.pct',
+        },
+      },
+      load: {
+        avg: {
+          field: 'system.load.15',
+        },
+      },
+      rx: {
+        filter: {
+          exists: {
+            field: 'host.network.ingress.bytes',
+          },
+        },
+        aggs: {
+          bytes: {
+            avg: {
+              field: 'rx_bytes_per_period',
+            },
+          },
+        },
+      },
+      tx: {
+        filter: {
+          exists: {
+            field: 'host.network.egress.bytes',
+          },
+        },
+        aggs: {
+          bytes: {
+            avg: {
+              field: 'tx_bytes_per_period',
+            },
+          },
+        },
+      },
+    },
+  },
+});
+
+const getSemconvAggs = (options: TopNodesRequest) => ({
+  cpu_idle: {
+    terms: {
+      field: 'state',
+      include: ['idle'],
+    },
+    aggs: {
+      avg: {
+        avg: {
+          field: 'system.cpu.utilization',
+        },
+      },
+    },
+  },
+  cpu_idle_total: {
+    sum_bucket: {
+      buckets_path: 'cpu_idle.avg',
+    },
+  },
+  cpu: {
+    bucket_script: {
+      buckets_path: {
+        cpuIdleTotal: 'cpu_idle_total',
+      },
+      script: '1 - params.cpuIdleTotal',
+      gap_policy: 'skip',
+    },
+  },
+  load: {
+    avg: {
+      field: 'system.cpu.load_average.15m',
+    },
+  },
+  timeseries: {
+    date_histogram: {
+      field: '@timestamp',
+      fixed_interval: options.bucketSize,
+      extended_bounds: {
+        min: options.timerange.from,
+        max: options.timerange.to,
+      },
+    },
+    aggs: {
+      cpu_idle: {
+        terms: {
+          field: 'state',
+          include: ['idle'],
+        },
+        aggs: {
+          avg: {
+            avg: {
+              field: 'system.cpu.utilization',
+            },
+          },
+        },
+      },
+      cpu_idle_total: {
+        sum_bucket: {
+          buckets_path: 'cpu_idle.avg',
+        },
+      },
+      cpu: {
+        bucket_script: {
+          buckets_path: {
+            cpuIdleTotal: 'cpu_idle_total',
+          },
+          script: '1 - params.cpuIdleTotal',
+          gap_policy: 'skip',
+        },
+      },
+      load: {
+        avg: {
+          field: 'system.cpu.load_average.15m',
+        },
+      },
+    },
+  },
+});
+
 export const createTopNodesQuery = (
   options: TopNodesRequest,
-  source: MetricsSourceConfiguration
+  source: MetricsSourceConfiguration,
+  schema: DataSchemaFormat = 'ecs'
 ) => {
+  const isEcs = schema === 'ecs';
+
   const nestedSearchFields: { [key: string]: string } = {
     rx: 'rx>bytes',
     tx: 'tx>bytes',
   };
+  const SEMCONV_UNSUPPORTED_SORTS = new Set(['uptime', 'iowait', 'rx', 'tx']);
   const sortByHost = options.sort && options.sort === 'name';
-  const metricsSortField = options.sort
-    ? nestedSearchFields[options.sort] || options.sort
-    : 'uptime';
+
+  const defaultSortField = isEcs ? 'uptime' : 'load';
+  const effectiveSort =
+    !isEcs && options.sort && SEMCONV_UNSUPPORTED_SORTS.has(options.sort)
+      ? undefined
+      : options.sort;
+  const metricsSortField = effectiveSort
+    ? nestedSearchFields[effectiveSort] || effectiveSort
+    : defaultSortField;
   const sortField = sortByHost ? '_key' : metricsSortField;
   const sortDirection = options.sortDirection ?? 'asc';
+
   return {
-    runtime_mappings: {
-      rx_bytes_per_period: {
-        type: 'double',
-        script: {
-          source: `
-          if(doc[\'host.network.ingress.bytes\'].size() !=0)
+    ...(isEcs
+      ? {
+          runtime_mappings: {
+            rx_bytes_per_period: {
+              type: 'double',
+              script: {
+                source: `
+          if(doc['host.network.ingress.bytes'].size() !=0)
           {
-            emit((doc[\'host.network.ingress.bytes\'].value/(doc[\'metricset.period\'].value / 1000)));
+            emit((doc['host.network.ingress.bytes'].value/(doc['metricset.period'].value / 1000)));
           }
             `,
-        },
-      },
-      tx_bytes_per_period: {
-        type: 'double',
-        script: {
-          source: `
-            if(doc[\'host.network.egress.bytes\'].size() !=0)
+              },
+            },
+            tx_bytes_per_period: {
+              type: 'double',
+              script: {
+                source: `
+            if(doc['host.network.egress.bytes'].size() !=0)
           {
-            emit((doc[\'host.network.egress.bytes\'].value/(doc[\'metricset.period\'].value / 1000)));
+            emit((doc['host.network.egress.bytes'].value/(doc['metricset.period'].value / 1000)));
           }
             `,
-        },
-      },
-    },
+              },
+            },
+          },
+        }
+      : {}),
     size: 0,
     query: {
       bool: {
@@ -61,9 +269,7 @@ export const createTopNodesQuery = (
               },
             },
           },
-          {
-            match_phrase: { 'event.module': 'system' },
-          },
+          getNodeFilter(schema),
         ],
       },
     },
@@ -86,109 +292,7 @@ export const createTopNodesQuery = (
               size: 1,
             },
           },
-          uptime: {
-            max: {
-              field: 'system.uptime.duration.ms',
-            },
-          },
-          cpu: {
-            avg: {
-              field: 'system.cpu.total.norm.pct',
-            },
-          },
-          iowait: {
-            avg: {
-              field: 'system.core.iowait.pct',
-            },
-          },
-          load: {
-            avg: {
-              field: 'system.load.15',
-            },
-          },
-          rx: {
-            filter: {
-              exists: {
-                field: 'host.network.ingress.bytes',
-              },
-            },
-            aggs: {
-              bytes: {
-                avg: {
-                  field: 'rx_bytes_per_period',
-                },
-              },
-            },
-          },
-          tx: {
-            filter: {
-              exists: {
-                field: 'host.network.egress.bytes',
-              },
-            },
-            aggs: {
-              bytes: {
-                avg: {
-                  field: 'tx_bytes_per_period',
-                },
-              },
-            },
-          },
-          timeseries: {
-            date_histogram: {
-              field: '@timestamp',
-              fixed_interval: options.bucketSize,
-              extended_bounds: {
-                min: options.timerange.from,
-                max: options.timerange.to,
-              },
-            },
-            aggs: {
-              cpu: {
-                avg: {
-                  field: 'host.cpu.pct',
-                },
-              },
-              iowait: {
-                avg: {
-                  field: 'system.core.iowait.pct',
-                },
-              },
-              load: {
-                avg: {
-                  field: 'system.load.15',
-                },
-              },
-              rx: {
-                filter: {
-                  exists: {
-                    field: 'host.network.ingress.bytes',
-                  },
-                },
-                aggs: {
-                  bytes: {
-                    avg: {
-                      field: 'rx_bytes_per_period',
-                    },
-                  },
-                },
-              },
-              tx: {
-                filter: {
-                  exists: {
-                    field: 'host.network.egress.bytes',
-                  },
-                },
-                aggs: {
-                  bytes: {
-                    avg: {
-                      field: 'tx_bytes_per_period',
-                    },
-                  },
-                },
-              },
-            },
-          },
+          ...(isEcs ? getEcsAggs(options) : getSemconvAggs(options)),
         },
       },
     },

--- a/x-pack/solutions/observability/plugins/infra/server/routes/overview/lib/get_top_nodes.test.ts
+++ b/x-pack/solutions/observability/plugins/infra/server/routes/overview/lib/get_top_nodes.test.ts
@@ -1,0 +1,115 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { TopNodesResponse } from '../../../../common/http_api/overview_api';
+import { mergeTopNodesResponses } from './get_top_nodes';
+
+const makeSeries = (
+  overrides: Partial<TopNodesResponse['series'][number]> & { id: string }
+): TopNodesResponse['series'][number] => ({
+  name: overrides.id,
+  platform: 'linux',
+  provider: null,
+  cpu: 0.5,
+  iowait: null,
+  load: 1.0,
+  uptime: null,
+  rx: null,
+  tx: null,
+  timeseries: [],
+  ...overrides,
+});
+
+const defaultOptions = { size: 5, sort: undefined, sortDirection: undefined };
+
+describe('mergeTopNodesResponses', () => {
+  it('returns empty series when all responses are empty', () => {
+    const result = mergeTopNodesResponses([{ series: [] }, { series: [] }], defaultOptions);
+    expect(result.series).toEqual([]);
+  });
+
+  it('merges hosts from different schemas and sorts by load (default)', () => {
+    const ecsResponse: TopNodesResponse = {
+      series: [makeSeries({ id: 'host-a', load: 3.0 }), makeSeries({ id: 'host-b', load: 1.0 })],
+    };
+    const semconvResponse: TopNodesResponse = {
+      series: [makeSeries({ id: 'host-c', load: 2.0 }), makeSeries({ id: 'host-d', load: 0.5 })],
+    };
+
+    const result = mergeTopNodesResponses([ecsResponse, semconvResponse], defaultOptions);
+    expect(result.series).toHaveLength(4);
+    expect(result.series.map((s) => s.id)).toEqual(['host-d', 'host-b', 'host-c', 'host-a']);
+  });
+
+  it('sorts by cpu descending when requested', () => {
+    const responses: TopNodesResponse[] = [
+      { series: [makeSeries({ id: 'a', cpu: 0.1 }), makeSeries({ id: 'b', cpu: 0.9 })] },
+      { series: [makeSeries({ id: 'c', cpu: 0.5 })] },
+    ];
+
+    const result = mergeTopNodesResponses(responses, {
+      size: 5,
+      sort: 'cpu',
+      sortDirection: 'desc',
+    });
+    expect(result.series.map((s) => s.id)).toEqual(['b', 'c', 'a']);
+  });
+
+  it('sorts by name when requested', () => {
+    const responses: TopNodesResponse[] = [
+      { series: [makeSeries({ id: 'z-host', name: 'z-host' })] },
+      { series: [makeSeries({ id: 'a-host', name: 'a-host' })] },
+    ];
+
+    const result = mergeTopNodesResponses(responses, { size: 5, sort: 'name' });
+    expect(result.series.map((s) => s.id)).toEqual(['a-host', 'z-host']);
+  });
+
+  it('pushes null values to the end of sorted results', () => {
+    const responses: TopNodesResponse[] = [
+      {
+        series: [makeSeries({ id: 'no-cpu', cpu: null }), makeSeries({ id: 'low-cpu', cpu: 0.1 })],
+      },
+    ];
+
+    const result = mergeTopNodesResponses(responses, { size: 5, sort: 'cpu' });
+    expect(result.series.map((s) => s.id)).toEqual(['low-cpu', 'no-cpu']);
+  });
+
+  it('deduplicates by host.name, keeping first occurrence (ECS first)', () => {
+    const ecsResponse: TopNodesResponse = {
+      series: [makeSeries({ id: 'shared-host', cpu: 0.3, uptime: 100000 })],
+    };
+    const semconvResponse: TopNodesResponse = {
+      series: [makeSeries({ id: 'shared-host', cpu: 0.7, uptime: null })],
+    };
+
+    const result = mergeTopNodesResponses([ecsResponse, semconvResponse], defaultOptions);
+    expect(result.series).toHaveLength(1);
+    expect(result.series[0].cpu).toBe(0.3);
+    expect(result.series[0].uptime).toBe(100000);
+  });
+
+  it('trims results to the requested size', () => {
+    const response: TopNodesResponse = {
+      series: Array.from({ length: 10 }, (_, i) => makeSeries({ id: `host-${i}`, load: i * 0.1 })),
+    };
+
+    const result = mergeTopNodesResponses([response], { ...defaultOptions, size: 3 });
+    expect(result.series).toHaveLength(3);
+  });
+
+  it('handles a single response and re-sorts', () => {
+    const response: TopNodesResponse = {
+      series: [makeSeries({ id: 'host-b', load: 2.0 }), makeSeries({ id: 'host-a', load: 1.0 })],
+    };
+
+    const result = mergeTopNodesResponses([response], defaultOptions);
+    expect(result.series).toHaveLength(2);
+    expect(result.series.map((s) => s.id)).toEqual(['host-a', 'host-b']);
+  });
+});

--- a/x-pack/solutions/observability/plugins/infra/server/routes/overview/lib/get_top_nodes.ts
+++ b/x-pack/solutions/observability/plugins/infra/server/routes/overview/lib/get_top_nodes.ts
@@ -5,22 +5,91 @@
  * 2.0.
  */
 import type { ESSearchClient } from '@kbn/metrics-data-access-plugin/server';
-import type { TopNodesRequest } from '../../../../common/http_api/overview_api';
+import type { DataSchemaFormat } from '@kbn/metrics-data-access-plugin/common';
+import type { TopNodesRequest, TopNodesResponse } from '../../../../common/http_api/overview_api';
 import type { MetricsSourceConfiguration } from '../../../../common/metrics_sources';
 import { convertESResponseToTopNodesResponse } from './convert_es_response_to_top_nodes_response';
 import { createTopNodesQuery } from './create_top_nodes_query';
 import type { ESResponseForTopNodes } from './types';
 
-export const queryTopNodes = async (
+const queryTopNodesForSchema = async (
   options: TopNodesRequest,
   client: ESSearchClient,
-  source: MetricsSourceConfiguration
-) => {
+  source: MetricsSourceConfiguration,
+  schema: DataSchemaFormat
+): Promise<TopNodesResponse> => {
   const params = {
     index: source.configuration.metricAlias,
-    body: createTopNodesQuery(options, source),
+    body: createTopNodesQuery(options, source, schema),
   };
 
   const response = await client<{}, ESResponseForTopNodes>(params);
   return convertESResponseToTopNodesResponse(response);
+};
+
+const SORTABLE_METRIC_KEYS = new Set(['cpu', 'iowait', 'load', 'uptime', 'rx', 'tx']);
+
+type SeriesEntry = TopNodesResponse['series'][number];
+type SortableMetricKey = 'cpu' | 'iowait' | 'load' | 'uptime' | 'rx' | 'tx';
+
+export const mergeTopNodesResponses = (
+  responses: TopNodesResponse[],
+  options: Pick<TopNodesRequest, 'size' | 'sort' | 'sortDirection'>
+): TopNodesResponse => {
+  const hostMap = new Map<string, SeriesEntry>();
+
+  for (const { series } of responses) {
+    for (const entry of series) {
+      if (!hostMap.has(entry.id)) {
+        hostMap.set(entry.id, entry);
+      }
+    }
+  }
+
+  const merged = Array.from(hostMap.values());
+  const direction = options.sortDirection === 'desc' ? -1 : 1;
+
+  if (options.sort === 'name') {
+    merged.sort((a, b) => direction * (a.name ?? '').localeCompare(b.name ?? ''));
+  } else {
+    const sortKey: SortableMetricKey = SORTABLE_METRIC_KEYS.has(options.sort ?? '')
+      ? (options.sort as SortableMetricKey)
+      : 'load';
+    merged.sort((a, b) => {
+      const aVal = a[sortKey];
+      const bVal = b[sortKey];
+      if (aVal == null && bVal == null) return 0;
+      if (aVal == null) return 1;
+      if (bVal == null) return -1;
+      return direction * (aVal - bVal);
+    });
+  }
+
+  return { series: merged.slice(0, options.size) };
+};
+
+export const queryTopNodes = async (
+  options: TopNodesRequest,
+  client: ESSearchClient,
+  source: MetricsSourceConfiguration,
+  schemas: DataSchemaFormat[] = ['ecs']
+): Promise<TopNodesResponse> => {
+  if (schemas.length === 1) {
+    return queryTopNodesForSchema(options, client, source, schemas[0]);
+  }
+
+  const results = await Promise.allSettled(
+    schemas.map((schema) => queryTopNodesForSchema(options, client, source, schema))
+  );
+
+  const successfulResponses = results
+    .filter((r): r is PromiseFulfilledResult<TopNodesResponse> => r.status === 'fulfilled')
+    .map((r) => r.value);
+
+  if (successfulResponses.length === 0) {
+    const firstRejected = results.find((r): r is PromiseRejectedResult => r.status === 'rejected');
+    throw firstRejected?.reason ?? new Error('All schema queries failed');
+  }
+
+  return mergeTopNodesResponses(successfulResponses, options);
 };

--- a/x-pack/solutions/observability/plugins/infra/server/routes/overview/lib/types.ts
+++ b/x-pack/solutions/observability/plugins/infra/server/routes/overview/lib/types.ts
@@ -22,12 +22,12 @@ interface NodeMetric {
 
 interface NodeMetrics {
   doc_count: number;
-  uptime: NodeMetric;
-  cpu: NodeMetric;
-  iowait: NodeMetric;
-  load: NodeMetric;
-  rx: RuntimeField;
-  tx: RuntimeField;
+  cpu?: NodeMetric;
+  load?: NodeMetric;
+  uptime?: NodeMetric;
+  iowait?: NodeMetric;
+  rx?: RuntimeField;
+  tx?: RuntimeField;
 }
 
 interface TimeSeriesMetric extends NodeMetrics {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Observability Overview] Support OTel host metrics in Hosts table (#261564)](https://github.com/elastic/kibana/pull/261564)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Sergi Romeu","email":"sergi.romeu@elastic.co"},"sourceCommit":{"committedDate":"2026-04-10T07:14:36Z","message":"[Observability Overview] Support OTel host metrics in Hosts table (#261564)","sha":"98b5f2b121430a69e539d191f533fc3f8b362de7","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport:version","v9.4.0","Team:obs-presentation","v9.3.4"],"title":"[Observability Overview] Support OTel host metrics in Hosts table","number":261564,"url":"https://github.com/elastic/kibana/pull/261564","mergeCommit":{"message":"[Observability Overview] Support OTel host metrics in Hosts table (#261564)","sha":"98b5f2b121430a69e539d191f533fc3f8b362de7"}},"sourceBranch":"main","suggestedTargetBranches":["9.3"],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/261564","number":261564,"mergeCommit":{"message":"[Observability Overview] Support OTel host metrics in Hosts table (#261564)","sha":"98b5f2b121430a69e539d191f533fc3f8b362de7"}},{"branch":"9.3","label":"v9.3.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->