### PR TITLE
fix(agent builder): allow plugin selection when added to agent

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/plugins/agent_plugins.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/plugins/agent_plugins.tsx
@@ -374,7 +374,10 @@ export const AgentPlugins: React.FC = () => {
       )}
 
       {isInstallFlyoutOpen && (
-        <InstallPluginFlyout onClose={closeInstallFlyout} onPluginInstalled={handleAddPlugin} />
+        <InstallPluginFlyout
+          onClose={closeInstallFlyout}
+          onPluginInstalled={(plugin) => handleAddPlugin(plugin, { selectOnSuccess: true })}
+        />
       )}
     </PageWrapper>
   );


### PR DESCRIPTION
Closes https://github.com/elastic/search-team/issues/13861

## Summary

Fixes bug on agent plugin screen that didn't auto-select the plugin on add.



https://github.com/user-attachments/assets/6f827a87-26e7-42d8-8c31-018d065dc68f


