### PR TITLE
Fix CPS space NPRE using request.rewrittenUrl after Spaces pre-routing

### DIFF
--- a/src/core/packages/elasticsearch/client-server-internal/src/cps_request_handler/README.md
+++ b/src/core/packages/elasticsearch/client-server-internal/src/cps_request_handler/README.md
@@ -51,7 +51,7 @@ Stripping is always unconditional regardless of API or whether `meta.name` is se
 |-------------------|-------|---------|
 | `PROJECT_ROUTING_ORIGIN` | `_alias:_origin` | Route to the origin project (default) |
 | `PROJECT_ROUTING_ALL` | `_alias:*` | Route across all projects |
-| `getSpaceNPRE(request)` | `kibana_space_<id>_default` | Route to a specific Kibana space |
+| `getSpaceNPRE(request)` | `kibana_space_<id>_default` | Route to a specific Kibana space; uses `request.rewrittenUrl` when set so space is correct after Spaces pre-routing strips `/s/:id` from `request.url` |
 
 The factory maps routing options as follows:
 

--- a/src/core/packages/elasticsearch/server/src/client/types.ts
+++ b/src/core/packages/elasticsearch/server/src/client/types.ts
@@ -22,14 +22,17 @@ export interface FakeRequest {
  * A minimal synthetic request for space-level CPS routing (`projectRouting: 'space'`) in
  * non-HTTP contexts - for example, background tasks or scheduled jobs - where no real
  * {@link KibanaRequest} is available. The space is derived from the URL pathname
- * (e.g. `/s/<spaceId>/...`).
+ * (e.g. `/s/<spaceId>/...`) using `getSpaceNPRE` from `@kbn/cps-server-utils`.
  *
  * In route handlers, pass the incoming {@link KibanaRequest} directly - it already satisfies
  * {@link ScopeableUrlRequest} without needing this type.
  * @public
  */
 export interface UrlRequest extends FakeRequest {
-  /** The URL of the request, used to extract the current space for CPS routing. */
+  /**
+   * URL used to resolve the space for CPS. Synthetic callers set this to a path that includes
+   * `/s/<spaceId>/...` when applicable; there is no `rewrittenUrl` on this shape.
+   */
   url: URL;
 }
 
@@ -45,9 +48,12 @@ export type ScopeableRequest = KibanaRequest | FakeRequest;
 /**
  * A request that carries a URL, accepted by `asScoped` when `projectRouting: 'space'` is used.
  *
- * Covers both {@link KibanaRequest} (the typical caller from route handlers, whose URL is set by
- * the HTTP layer) and {@link UrlRequest} (a lightweight synthetic alternative for programmatic
- * use). In both cases the space is extracted from the URL pathname (e.g. `/s/<spaceId>/...`).
+ * Covers both {@link KibanaRequest} (the typical caller from route handlers) and
+ * {@link UrlRequest} (a lightweight synthetic alternative). Space resolution uses
+ * `getSpaceNPRE` from `@kbn/cps-server-utils`: for {@link KibanaRequest}, when
+ * `rewrittenUrl` is set (original URL before the first pre-routing `rewriteUrl`), that URL is
+ * preferred over `url` so the space segment remains visible after Spaces strips `/s/:spaceId`
+ * from `request.url`. Synthetic {@link UrlRequest} values only supply `url`.
  *
  * @public
  */

--- a/src/platform/packages/shared/kbn-cps-server-utils/README.md
+++ b/src/platform/packages/shared/kbn-cps-server-utils/README.md
@@ -6,7 +6,13 @@ Server-side Cross-Project Search (CPS) utilities.
 
 Returns the Named Project Routing Expression (NPRE) for a given space, using the convention `kibana_space_${spaceId}_default`.
 
-Accepts either a `spaceId` string or a `KibanaRequest` (from which the space is derived via the request URL path, without a dependency on the `spaces` plugin). A `FakeRequest` is not accepted — it does not carry a URL, so the space cannot be derived from it. Passing one will throw at runtime.
+Accepts either a `spaceId` string or a `ScopeableUrlRequest` (`KibanaRequest` or synthetic `UrlRequest` from `@kbn/core-elasticsearch-server`). The space is parsed from a URL pathname with `@kbn/spaces-utils` (`getSpaceIdFromPath`).
+
+For real HTTP requests, the Spaces plugin rewrites incoming URLs so `request.url` no longer contains `/s/<spaceId>`. Core stores the pre-rewrite URL on `request.rewrittenUrl` when the first pre-routing handler returns `rewriteUrl`. `getSpaceNPRE` uses `rewrittenUrl` when it is set, so non-default spaces resolve correctly. Synthetic `UrlRequest` objects only provide `url`.
+
+CPS runs on Serverless only, where Kibana does not use a custom `server.basePath`; `getSpaceNPRE` does not strip a server base path from the pathname before matching `/s/...`.
+
+A `FakeRequest` without `url` is not accepted and will throw at runtime.
 
 ```ts
 import { getSpaceNPRE } from '@kbn/cps-server-utils';
@@ -15,6 +21,6 @@ import { getSpaceNPRE } from '@kbn/cps-server-utils';
 getSpaceNPRE('my-space');  // '@kibana_space_my-space_default'
 getSpaceNPRE('');          // '@kibana_space_default_default'
 
-// From a KibanaRequest (extracts space from the URL path)
+// From a KibanaRequest (uses rewrittenUrl when present, else url.pathname)
 getSpaceNPRE(request);     // e.g. '@kibana_space_my-space_default'
 ```

--- a/src/platform/packages/shared/kbn-cps-server-utils/moon.yml
+++ b/src/platform/packages/shared/kbn-cps-server-utils/moon.yml
@@ -17,6 +17,7 @@ project:
   owner: '@elastic/kibana-core'
   sourceRoot: src/platform/packages/shared/kbn-cps-server-utils
 dependsOn:
+  - '@kbn/core-elasticsearch-server'
   - '@kbn/spaces-utils'
 tags:
   - shared-server

--- a/src/platform/packages/shared/kbn-cps-server-utils/src/get_space_npre.test.ts
+++ b/src/platform/packages/shared/kbn-cps-server-utils/src/get_space_npre.test.ts
@@ -7,9 +7,13 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import type { ScopeableUrlRequest } from '@kbn/core-elasticsearch-server';
 import { getSpaceNPRE } from './get_space_npre';
 
-const mockRequest = (pathname: string) => ({ url: new URL(`http://localhost:5601${pathname}`) });
+const mockRequest = (pathname: string) => ({
+  headers: {},
+  url: new URL(`http://localhost:5601${pathname}`),
+});
 
 describe('getSpaceNPRE', () => {
   describe('when called with a spaceId string', () => {
@@ -37,8 +41,35 @@ describe('getSpaceNPRE', () => {
       expect(getSpaceNPRE(mockRequest('/api/foo'))).toBe('@kibana_space_default_default');
     });
 
+    it('uses rewrittenUrl when present so space is resolved after Spaces strips /s/:id from url', () => {
+      const request = {
+        headers: {},
+        url: new URL('http://localhost:5601/api/foo'),
+        rewrittenUrl: new URL('http://localhost:5601/s/my-space/api/foo'),
+      };
+      expect(getSpaceNPRE(request)).toBe('@kibana_space_my-space_default');
+    });
+
+    it('prefers rewrittenUrl over url when both carry a space segment (first rewrite snapshot wins)', () => {
+      const request = {
+        headers: {},
+        url: new URL('http://localhost:5601/s/other-space/api/foo'),
+        rewrittenUrl: new URL('http://localhost:5601/s/my-space/api/foo'),
+      };
+      expect(getSpaceNPRE(request)).toBe('@kibana_space_my-space_default');
+    });
+
+    it('ignores rewrittenUrl when it is undefined and uses url pathname', () => {
+      const request = {
+        headers: {},
+        url: new URL('http://localhost:5601/s/my-space/api/foo'),
+        rewrittenUrl: undefined as URL | undefined,
+      };
+      expect(getSpaceNPRE(request)).toBe('@kibana_space_my-space_default');
+    });
+
     it('throws when the request has no url (e.g. a FakeRequest passed at runtime)', () => {
-      const badRequest = { headers: {} } as unknown as { url: URL };
+      const badRequest = { headers: {} } as unknown as ScopeableUrlRequest;
       expect(() => getSpaceNPRE(badRequest)).toThrow(
         `Cannot determine space NPRE: the Request object is missing a 'url' property.`
       );

--- a/src/platform/packages/shared/kbn-cps-server-utils/src/get_space_npre.ts
+++ b/src/platform/packages/shared/kbn-cps-server-utils/src/get_space_npre.ts
@@ -8,31 +8,38 @@
  */
 
 import { DEFAULT_SPACE_ID, getSpaceIdFromPath } from '@kbn/spaces-utils';
+import type { ScopeableUrlRequest } from '@kbn/core-elasticsearch-server';
 
 /**
  * Get the NPRE for a given space ID or a request carrying a URL.
  *
- * When a request object is provided, the space is extracted from the URL pathname.
+ * When a request object is provided, the space is taken from a URL pathname via
+ * {@link getSpaceIdFromPath}. If the request has a `rewrittenUrl` (set by core
+ * when the first `onPreRouting` handler returns `rewriteUrl`), that URL is
+ * used instead of `url`. This matches HTTP requests after the Spaces plugin
+ * strips `/s/:spaceId` from `request.url` during pre-routing: the original
+ * browser path (including the space segment) remains on `rewrittenUrl`.
  *
- * **Assumption**: this function assumes that the server base path is `/` (the
- * default). If Kibana is configured with a custom `server.basePath`, the base
- * path prefix will not be stripped before matching the space segment, causing
- * the function to always fall back to the default space. CPS is a
- * Serverless-only feature and Serverless deployments always run at the root
- * path, so this is not a practical concern today.
+ * **Server base path**: {@link getSpaceIdFromPath} is called with the pathname
+ * only; a non-root `server.basePath` is not stripped here. CPS is only
+ * available on Serverless, where custom base paths are not used, so this
+ * limitation is not a practical concern for CPS.
  *
- * @param spaceIdOrRequest - The space ID string, or an object with a `url: URL` property
+ * @param spaceIdOrRequest - Space ID string, or a `ScopeableUrlRequest` (incoming
+ *   `KibanaRequest` / synthetic `UrlRequest` from `@kbn/core-elasticsearch-server`).
  * @returns The NPRE
  * @throws {Error} if a Request-like object without a `url` is provided.
  *   This is not expected in normal use but guards against JavaScript callers
  *   bypassing the type system.
  */
-export function getSpaceNPRE(spaceIdOrRequest: string | { url: URL }): string {
+export function getSpaceNPRE(spaceIdOrRequest: string | ScopeableUrlRequest): string {
   if (typeof spaceIdOrRequest === 'string') {
     return `@kibana_space_${spaceIdOrRequest || DEFAULT_SPACE_ID}_default`;
   }
-  // Explicitly widen to URL | undefined so the defensive check below is valid.
-  const url: URL | undefined = spaceIdOrRequest.url;
+
+  const request = spaceIdOrRequest as ScopeableUrlRequest;
+  const url =
+    'rewrittenUrl' in request && request.rewrittenUrl ? request.rewrittenUrl : request.url;
   if (!url) {
     throw new Error(`Cannot determine space NPRE: the Request object is missing a 'url' property.`);
   }

--- a/src/platform/packages/shared/kbn-cps-server-utils/tsconfig.json
+++ b/src/platform/packages/shared/kbn-cps-server-utils/tsconfig.json
@@ -8,6 +8,7 @@
     "../../../../../typings/**/*",
   ],
   "kbn_references": [
+    "@kbn/core-elasticsearch-server",
     "@kbn/spaces-utils",
   ],
   "exclude": [


### PR DESCRIPTION
## Summary

When `projectRouting: 'space'`, `getSpaceNPRE(request)` must resolve the active Kibana space. The Spaces plugin strips `/s/:spaceId` from `request.url` during `onPreRouting` and records the pre-rewrite URL on `request.rewrittenUrl` (snapshot taken before the first `rewriteUrl` in the chain). Previously, space detection used only `request.url.pathname`, so non-default spaces were resolved as default.

## Changes

- `getSpaceNPRE` prefers `rewrittenUrl` when it is set; otherwise uses `url` (unchanged for synthetic `UrlRequest` and plain path-based mocks).
- Unit tests cover post-rewrite URLs, precedence, and explicit `rewrittenUrl: undefined`.
- JSDoc and README updates for `@kbn/cps-server-utils`, `ScopeableUrlRequest`, and the CPS request handler package doc.
- `@kbn/core-elasticsearch-server` added to `kbn-cps-server-utils` `kbn_references` / regenerated `moon.yml`.

## Context

CPS is Serverless-only; custom `server.basePath` is not used there, so pathname-based `getSpaceIdFromPath` without server base path stripping remains acceptable for this path.

Related: https://github.com/elastic/kibana/pull/261861 (alternate approach via basePath).

Made with [Cursor](https://cursor.com)