### PR TITLE
[9.3]  [Osquery] Add osquery response action privilege checks to external Api (#260947)

### DIFF
--- a/x-pack/platform/plugins/shared/osquery/server/lib/check_response_action_authz.test.ts
+++ b/x-pack/platform/plugins/shared/osquery/server/lib/check_response_action_authz.test.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { httpServerMock } from '@kbn/core/server/mocks';
+import type { CoreStart, KibanaRequest } from '@kbn/core/server';
+import { isOsqueryResponseActionAuthorized } from './check_response_action_authz';
+
+describe('isOsqueryResponseActionAuthorized', () => {
+  let request: KibanaRequest;
+  let mockCoreStart: CoreStart;
+
+  const createMockCoreStart = (capabilities: Record<string, boolean>): CoreStart =>
+    ({
+      capabilities: {
+        resolveCapabilities: jest.fn().mockResolvedValue({
+          osquery: capabilities,
+        }),
+      },
+    } as unknown as CoreStart);
+
+  beforeEach(() => {
+    request = httpServerMock.createKibanaRequest();
+  });
+
+  it('should return true when user has writeLiveQueries', async () => {
+    mockCoreStart = createMockCoreStart({ writeLiveQueries: true, runSavedQueries: false });
+
+    const result = await isOsqueryResponseActionAuthorized(mockCoreStart, request, {});
+    expect(result).toBe(true);
+  });
+
+  it('should return false when user lacks writeLiveQueries for direct query', async () => {
+    mockCoreStart = createMockCoreStart({ writeLiveQueries: false, runSavedQueries: false });
+
+    const result = await isOsqueryResponseActionAuthorized(mockCoreStart, request, {});
+    expect(result).toBe(false);
+  });
+
+  it('should return true when user has runSavedQueries with saved_query_id', async () => {
+    mockCoreStart = createMockCoreStart({ writeLiveQueries: false, runSavedQueries: true });
+
+    const result = await isOsqueryResponseActionAuthorized(mockCoreStart, request, {
+      saved_query_id: 'test-query-id',
+    });
+    expect(result).toBe(true);
+  });
+
+  it('should return true when user has runSavedQueries with pack_id', async () => {
+    mockCoreStart = createMockCoreStart({ writeLiveQueries: false, runSavedQueries: true });
+
+    const result = await isOsqueryResponseActionAuthorized(mockCoreStart, request, {
+      pack_id: 'test-pack-id',
+    });
+    expect(result).toBe(true);
+  });
+
+  it('should return false when user has runSavedQueries but no saved_query_id or pack_id', async () => {
+    mockCoreStart = createMockCoreStart({ writeLiveQueries: false, runSavedQueries: true });
+
+    const result = await isOsqueryResponseActionAuthorized(mockCoreStart, request, {});
+    expect(result).toBe(false);
+  });
+
+  it('should return false when user lacks both privileges with saved_query_id', async () => {
+    mockCoreStart = createMockCoreStart({ writeLiveQueries: false, runSavedQueries: false });
+
+    const result = await isOsqueryResponseActionAuthorized(mockCoreStart, request, {
+      saved_query_id: 'test-query-id',
+    });
+    expect(result).toBe(false);
+  });
+
+  it('should return true when user has writeLiveQueries regardless of saved_query_id', async () => {
+    mockCoreStart = createMockCoreStart({ writeLiveQueries: true, runSavedQueries: false });
+
+    const result = await isOsqueryResponseActionAuthorized(mockCoreStart, request, {
+      saved_query_id: 'test-query-id',
+    });
+    expect(result).toBe(true);
+  });
+
+  it('should call resolveCapabilities with the correct request and path', async () => {
+    mockCoreStart = createMockCoreStart({ writeLiveQueries: true, runSavedQueries: false });
+
+    await isOsqueryResponseActionAuthorized(mockCoreStart, request, {});
+
+    expect(mockCoreStart.capabilities.resolveCapabilities).toHaveBeenCalledWith(request, {
+      capabilityPath: 'osquery.*',
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/osquery/server/lib/check_response_action_authz.ts
+++ b/x-pack/platform/plugins/shared/osquery/server/lib/check_response_action_authz.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { CoreSetup, CoreStart, KibanaRequest } from '@kbn/core/server';
+import type { CheckResponseActionAuthzParams } from '../types';
+import { CustomHttpRequestError } from '../common/error';
+
+interface OsqueryCapabilities {
+  writeLiveQueries: boolean;
+  runSavedQueries: boolean;
+}
+
+// Cache capability resolution per request so bulk operations (e.g., duplicating
+// hundreds of rules) only call resolveCapabilities once per request.
+const capabilitiesCache = new WeakMap<KibanaRequest, Promise<OsqueryCapabilities>>();
+
+const resolveOsqueryCapabilities = (
+  coreStart: CoreStart,
+  request: KibanaRequest
+): Promise<OsqueryCapabilities> => {
+  let promise = capabilitiesCache.get(request);
+
+  if (!promise) {
+    promise = (async () => {
+      const resolved = await coreStart.capabilities.resolveCapabilities(request, {
+        capabilityPath: 'osquery.*',
+      });
+
+      return {
+        writeLiveQueries: !!resolved.osquery.writeLiveQueries,
+        runSavedQueries: !!resolved.osquery.runSavedQueries,
+      };
+    })();
+    capabilitiesCache.set(request, promise);
+  }
+
+  return promise;
+};
+
+/**
+ * Checks whether the requesting user has the required osquery privileges
+ * for a given action configuration.
+ *
+ * Privilege logic (mirrors create_live_query_route):
+ * - Direct query → needs writeLiveQueries
+ * - Saved query / pack → needs writeLiveQueries OR runSavedQueries
+ *
+ * @returns true if authorized, false otherwise
+ */
+export const isOsqueryResponseActionAuthorized = async (
+  coreStart: CoreStart,
+  request: KibanaRequest,
+  actionParams: CheckResponseActionAuthzParams
+): Promise<boolean> => {
+  const { writeLiveQueries, runSavedQueries } = await resolveOsqueryCapabilities(
+    coreStart,
+    request
+  );
+
+  return !!(
+    writeLiveQueries ||
+    (runSavedQueries && (actionParams.saved_query_id || actionParams.pack_id))
+  );
+};
+
+/**
+ * Validates that the requesting user has the required osquery privileges
+ * for the given response action configuration.
+ * Throws a 403 CustomHttpRequestError if the user lacks authorization.
+ *
+ * Used by security_solution when creating/updating detection rules
+ * that include osquery response actions.
+ */
+export const checkResponseActionAuthz = async (
+  core: CoreSetup,
+  request: KibanaRequest,
+  actionParams: CheckResponseActionAuthzParams
+): Promise<void> => {
+  const [coreStart] = await core.getStartServices();
+  const isAuthorized = await isOsqueryResponseActionAuthorized(coreStart, request, actionParams);
+
+  if (!isAuthorized) {
+    throw new CustomHttpRequestError(
+      'User is not authorized to create/update osquery response action',
+      403
+    );
+  }
+};

--- a/x-pack/platform/plugins/shared/osquery/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/osquery/server/plugin.ts
@@ -48,6 +48,11 @@ import { createDataViews } from './create_data_views';
 import { registerFeatures } from './utils/register_features';
 import { CASE_ATTACHMENT_TYPE_ID } from '../common/constants';
 import { createActionService } from './handlers/action/create_action_service';
+import { backfillScheduleIds } from './lib/backfill_schedule_ids';
+import { checkResponseActionAuthz } from './lib/check_response_action_authz';
+import { SchemaService } from './lib/schema_service';
+
+const BACKFILL_TASK_TYPE = 'osquery:backfillScheduleIds';
 
 export class OsqueryPlugin implements Plugin<OsqueryPluginSetup, OsqueryPluginStart> {
   private readonly logger: Logger;
@@ -55,14 +60,17 @@ export class OsqueryPlugin implements Plugin<OsqueryPluginSetup, OsqueryPluginSt
   private readonly osqueryAppContextService = new OsqueryAppContextService();
   private readonly telemetryReceiver: TelemetryReceiver;
   private readonly telemetryEventsSender: TelemetryEventsSender;
+  private coreStart: CoreStart | null = null;
   private licenseSubscription: Subscription | null = null;
   private createActionService: ReturnType<typeof createActionService> | null = null;
+  private readonly schemaService: SchemaService;
 
   constructor(private readonly initializerContext: PluginInitializerContext) {
     this.context = initializerContext;
     this.logger = initializerContext.logger.get();
     this.telemetryEventsSender = new TelemetryEventsSender(this.logger);
     this.telemetryReceiver = new TelemetryReceiver(this.logger);
+    this.schemaService = new SchemaService(this.logger);
   }
 
   public setup(core: CoreSetup<StartPlugins, OsqueryPluginStart>, plugins: SetupPlugins) {
@@ -99,7 +107,7 @@ export class OsqueryPlugin implements Plugin<OsqueryPluginSetup, OsqueryPluginSt
         );
 
         plugins.data.search.registerSearchStrategy('osquerySearchStrategy', osquerySearchStrategy);
-        defineRoutes(router, osqueryContext);
+        defineRoutes(router, osqueryContext, this.schemaService);
       })
       .catch(() => {
         // it shouldn't reject, but just in case
@@ -107,15 +115,48 @@ export class OsqueryPlugin implements Plugin<OsqueryPluginSetup, OsqueryPluginSt
 
     this.telemetryEventsSender.setup(this.telemetryReceiver, plugins.taskManager, core.analytics);
 
+    plugins.taskManager?.registerTaskDefinitions({
+      [BACKFILL_TASK_TYPE]: {
+        title: 'Backfill schedule IDs for osquery pack queries',
+        timeout: '5m',
+        maxAttempts: 3,
+        createTaskRunner: ({ taskInstance, abortController }) => ({
+          run: async () => {
+            if (taskInstance.state?.completed) {
+              this.logger.debug('backfillScheduleIds task: already completed, skipping');
+
+              return { state: { completed: true } };
+            }
+
+            if (!this.coreStart) {
+              throw new Error('Core not started');
+            }
+
+            const { hadFailures } = await backfillScheduleIds({
+              coreStart: this.coreStart,
+              osqueryContext: this.osqueryAppContextService,
+              logger: this.logger,
+              abortController,
+            });
+
+            return { state: { completed: !hadFailures } };
+          },
+        }),
+      },
+    });
+
     plugins.cases?.attachmentFramework.registerExternalReference({ id: CASE_ATTACHMENT_TYPE_ID });
 
     return {
       createActionService: this.createActionService,
-    };
+      checkResponseActionAuthz: (request, actionParams) =>
+        checkResponseActionAuthz(core, request, actionParams),
+    } satisfies OsqueryPluginSetup;
   }
 
   public start(core: CoreStart, plugins: StartPlugins) {
     this.logger.debug('osquery: Started');
+    this.coreStart = core;
     const registerIngestCallback = plugins.fleet?.registerExternalCallback;
     this.osqueryAppContextService.start({
       ...plugins.fleet,
@@ -157,6 +198,19 @@ export class OsqueryPlugin implements Plugin<OsqueryPluginSetup, OsqueryPluginSt
           // we do not want to wait for it
         });
 
+        plugins.taskManager
+          ?.ensureScheduled({
+            id: BACKFILL_TASK_TYPE,
+            taskType: BACKFILL_TASK_TYPE,
+            scope: ['osquery'],
+            schedule: { interval: '24h' },
+            params: {},
+            state: {},
+          })
+          .catch((err) => {
+            this.logger.warn(`Failed to schedule backfillScheduleIds task: ${err.message}`);
+          });
+
         if (registerIngestCallback) {
           registerIngestCallback(
             'packagePolicyCreate',
@@ -189,7 +243,8 @@ export class OsqueryPlugin implements Plugin<OsqueryPluginSetup, OsqueryPluginSt
                     newPackagePolicy,
                     spaceScopedClient,
                     allPacks.saved_objects,
-                    this.osqueryAppContextService
+                    this.osqueryAppContextService,
+                    soClient.getCurrentNamespace()
                   );
                 }
               }

--- a/x-pack/platform/plugins/shared/osquery/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/osquery/server/plugin.ts
@@ -48,11 +48,6 @@ import { createDataViews } from './create_data_views';
 import { registerFeatures } from './utils/register_features';
 import { CASE_ATTACHMENT_TYPE_ID } from '../common/constants';
 import { createActionService } from './handlers/action/create_action_service';
-import { backfillScheduleIds } from './lib/backfill_schedule_ids';
-import { checkResponseActionAuthz } from './lib/check_response_action_authz';
-import { SchemaService } from './lib/schema_service';
-
-const BACKFILL_TASK_TYPE = 'osquery:backfillScheduleIds';
 
 export class OsqueryPlugin implements Plugin<OsqueryPluginSetup, OsqueryPluginStart> {
   private readonly logger: Logger;
@@ -60,17 +55,14 @@ export class OsqueryPlugin implements Plugin<OsqueryPluginSetup, OsqueryPluginSt
   private readonly osqueryAppContextService = new OsqueryAppContextService();
   private readonly telemetryReceiver: TelemetryReceiver;
   private readonly telemetryEventsSender: TelemetryEventsSender;
-  private coreStart: CoreStart | null = null;
   private licenseSubscription: Subscription | null = null;
   private createActionService: ReturnType<typeof createActionService> | null = null;
-  private readonly schemaService: SchemaService;
 
   constructor(private readonly initializerContext: PluginInitializerContext) {
     this.context = initializerContext;
     this.logger = initializerContext.logger.get();
     this.telemetryEventsSender = new TelemetryEventsSender(this.logger);
     this.telemetryReceiver = new TelemetryReceiver(this.logger);
-    this.schemaService = new SchemaService(this.logger);
   }
 
   public setup(core: CoreSetup<StartPlugins, OsqueryPluginStart>, plugins: SetupPlugins) {
@@ -107,43 +99,13 @@ export class OsqueryPlugin implements Plugin<OsqueryPluginSetup, OsqueryPluginSt
         );
 
         plugins.data.search.registerSearchStrategy('osquerySearchStrategy', osquerySearchStrategy);
-        defineRoutes(router, osqueryContext, this.schemaService);
+        defineRoutes(router, osqueryContext);
       })
       .catch(() => {
         // it shouldn't reject, but just in case
       });
 
     this.telemetryEventsSender.setup(this.telemetryReceiver, plugins.taskManager, core.analytics);
-
-    plugins.taskManager?.registerTaskDefinitions({
-      [BACKFILL_TASK_TYPE]: {
-        title: 'Backfill schedule IDs for osquery pack queries',
-        timeout: '5m',
-        maxAttempts: 3,
-        createTaskRunner: ({ taskInstance, abortController }) => ({
-          run: async () => {
-            if (taskInstance.state?.completed) {
-              this.logger.debug('backfillScheduleIds task: already completed, skipping');
-
-              return { state: { completed: true } };
-            }
-
-            if (!this.coreStart) {
-              throw new Error('Core not started');
-            }
-
-            const { hadFailures } = await backfillScheduleIds({
-              coreStart: this.coreStart,
-              osqueryContext: this.osqueryAppContextService,
-              logger: this.logger,
-              abortController,
-            });
-
-            return { state: { completed: !hadFailures } };
-          },
-        }),
-      },
-    });
 
     plugins.cases?.attachmentFramework.registerExternalReference({ id: CASE_ATTACHMENT_TYPE_ID });
 
@@ -156,7 +118,6 @@ export class OsqueryPlugin implements Plugin<OsqueryPluginSetup, OsqueryPluginSt
 
   public start(core: CoreStart, plugins: StartPlugins) {
     this.logger.debug('osquery: Started');
-    this.coreStart = core;
     const registerIngestCallback = plugins.fleet?.registerExternalCallback;
     this.osqueryAppContextService.start({
       ...plugins.fleet,
@@ -198,19 +159,6 @@ export class OsqueryPlugin implements Plugin<OsqueryPluginSetup, OsqueryPluginSt
           // we do not want to wait for it
         });
 
-        plugins.taskManager
-          ?.ensureScheduled({
-            id: BACKFILL_TASK_TYPE,
-            taskType: BACKFILL_TASK_TYPE,
-            scope: ['osquery'],
-            schedule: { interval: '24h' },
-            params: {},
-            state: {},
-          })
-          .catch((err) => {
-            this.logger.warn(`Failed to schedule backfillScheduleIds task: ${err.message}`);
-          });
-
         if (registerIngestCallback) {
           registerIngestCallback(
             'packagePolicyCreate',
@@ -243,8 +191,7 @@ export class OsqueryPlugin implements Plugin<OsqueryPluginSetup, OsqueryPluginSt
                     newPackagePolicy,
                     spaceScopedClient,
                     allPacks.saved_objects,
-                    this.osqueryAppContextService,
-                    soClient.getCurrentNamespace()
+                    this.osqueryAppContextService
                   );
                 }
               }

--- a/x-pack/platform/plugins/shared/osquery/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/osquery/server/plugin.ts
@@ -48,6 +48,7 @@ import { createDataViews } from './create_data_views';
 import { registerFeatures } from './utils/register_features';
 import { CASE_ATTACHMENT_TYPE_ID } from '../common/constants';
 import { createActionService } from './handlers/action/create_action_service';
+import { checkResponseActionAuthz } from './lib/check_response_action_authz';
 
 export class OsqueryPlugin implements Plugin<OsqueryPluginSetup, OsqueryPluginStart> {
   private readonly logger: Logger;

--- a/x-pack/platform/plugins/shared/osquery/server/routes/live_query/create_live_query_route.ts
+++ b/x-pack/platform/plugins/shared/osquery/server/routes/live_query/create_live_query_route.ts
@@ -22,6 +22,7 @@ import type { OsqueryAppContext } from '../../lib/osquery_app_context_services';
 import { createActionHandler } from '../../handlers';
 import { parser as OsqueryParser } from './osquery_parser';
 import { getUserInfo } from '../../lib/get_user_info';
+import { isOsqueryResponseActionAuthorized } from '../../lib/check_response_action_authz';
 
 export const createLiveQueryRoute = (router: IRouter, osqueryContext: OsqueryAppContext) => {
   router.versioned
@@ -51,16 +52,10 @@ export const createLiveQueryRoute = (router: IRouter, osqueryContext: OsqueryApp
       async (context, request, response) => {
         const [coreStartServices] = await osqueryContext.getStartServices();
 
-        const {
-          osquery: { writeLiveQueries, runSavedQueries },
-        } = await coreStartServices.capabilities.resolveCapabilities(request, {
-          capabilityPath: 'osquery.*',
-        });
-
-        const isInvalid = !(
-          writeLiveQueries ||
-          (runSavedQueries && (request.body.saved_query_id || request.body.pack_id))
-        );
+        const isInvalid = !(await isOsqueryResponseActionAuthorized(coreStartServices, request, {
+          saved_query_id: request.body.saved_query_id,
+          pack_id: request.body.pack_id,
+        }));
 
         const client = await osqueryContext.service
           .getRuleRegistryService()

--- a/x-pack/platform/plugins/shared/osquery/server/types.ts
+++ b/x-pack/platform/plugins/shared/osquery/server/types.ts
@@ -23,11 +23,29 @@ import type { PluginStart as DataViewsPluginStart } from '@kbn/data-views-plugin
 import type { RuleRegistryPluginStartContract } from '@kbn/rule-registry-plugin/server';
 import type { CasesServerSetup } from '@kbn/cases-plugin/server';
 import type { LicensingPluginSetup } from '@kbn/licensing-plugin/server';
+import type { KibanaRequest } from '@kbn/core/server';
 import type { SpacesPluginSetup, SpacesPluginStart } from '@kbn/spaces-plugin/server';
 import type { createActionService } from './handlers/action/create_action_service';
 
+export interface CheckResponseActionAuthzParams {
+  saved_query_id?: string;
+  pack_id?: string;
+}
+
 export interface OsqueryPluginSetup {
   createActionService: ReturnType<typeof createActionService>;
+  /**
+   * Validates that the requesting user has the required osquery privileges
+   * for the given response action configuration.
+   * Throws a 403 CustomHttpRequestError if the user lacks authorization.
+   *
+   * Used by security_solution when creating/updating detection rules
+   * that include osquery response actions.
+   */
+  checkResponseActionAuthz: (
+    request: KibanaRequest,
+    actionParams: CheckResponseActionAuthzParams
+  ) => Promise<void>;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/actions/utils/rule_response_actions_validators.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/actions/utils/rule_response_actions_validators.test.ts
@@ -88,16 +88,20 @@ describe('Rules Endpoint response actions validators', () => {
       await expect(validateRuleResponseActions(options)).resolves.toBeUndefined();
     });
 
-    it('should only validate .endpoint response actions', async () => {
+    it('should validate both .endpoint and .osquery response actions independently', async () => {
       endpointAuthz.canIsolateHost = false;
+      const mockOsqueryAuthz = jest.fn().mockResolvedValue(undefined);
       rulePayload.response_actions = [
-        { action_type_id: '.osquery', params: {} },
+        { action_type_id: '.osquery', params: { query: 'SELECT 1' } },
         createRulePayloadResponseActionMock(),
       ];
+      options.checkOsqueryResponseActionAuthz = mockOsqueryAuthz;
 
       await expect(validateRuleResponseActions(options)).rejects.toThrow(
         'User is not authorized to create/update isolate response action'
       );
+      // Osquery authz was still called for the osquery action
+      expect(mockOsqueryAuthz).toHaveBeenCalledTimes(1);
     });
 
     interface AuthzTestCase {
@@ -286,6 +290,142 @@ describe('Rules Endpoint response actions validators', () => {
           ],
         }
       `);
+    });
+  });
+
+  describe('osquery response actions validation', () => {
+    let options: ValidateRuleResponseActionsOptions;
+    let mockOsqueryAuthz: jest.Mock;
+
+    beforeEach(() => {
+      mockOsqueryAuthz = jest.fn().mockResolvedValue(undefined);
+      options = {
+        rulePayload: {
+          response_actions: [
+            {
+              action_type_id: '.osquery' as const,
+              params: { query: 'SELECT * FROM processes' },
+            },
+          ],
+        },
+        endpointService,
+        endpointAuthz,
+        spaceId: 'foo',
+        checkOsqueryResponseActionAuthz: mockOsqueryAuthz,
+      };
+    });
+
+    it('should call osquery authz checker for .osquery actions', async () => {
+      await validateRuleResponseActions(options);
+
+      expect(mockOsqueryAuthz).toHaveBeenCalledWith({
+        saved_query_id: undefined,
+        pack_id: undefined,
+      });
+    });
+
+    it('should pass saved_query_id to osquery authz checker', async () => {
+      options.rulePayload = {
+        response_actions: [
+          {
+            action_type_id: '.osquery' as const,
+            params: { saved_query_id: 'test-saved-query' },
+          },
+        ],
+      };
+
+      await validateRuleResponseActions(options);
+
+      expect(mockOsqueryAuthz).toHaveBeenCalledWith({
+        saved_query_id: 'test-saved-query',
+        pack_id: undefined,
+      });
+    });
+
+    it('should pass pack_id to osquery authz checker', async () => {
+      options.rulePayload = {
+        response_actions: [
+          {
+            action_type_id: '.osquery' as const,
+            params: { pack_id: 'test-pack' },
+          },
+        ],
+      };
+
+      await validateRuleResponseActions(options);
+
+      expect(mockOsqueryAuthz).toHaveBeenCalledWith({
+        saved_query_id: undefined,
+        pack_id: 'test-pack',
+      });
+    });
+
+    it('should throw when osquery authz checker rejects', async () => {
+      const authzError: Error & { statusCode?: number } = new Error(
+        'User is not authorized to create/update osquery response action'
+      );
+      authzError.statusCode = 403;
+      mockOsqueryAuthz.mockRejectedValue(authzError);
+
+      await expect(validateRuleResponseActions(options)).rejects.toThrow(
+        'User is not authorized to create/update osquery response action'
+      );
+    });
+
+    it('should skip osquery validation when no authz checker is provided', async () => {
+      delete options.checkOsqueryResponseActionAuthz;
+
+      // Should not throw even though there are osquery actions
+      await expect(validateRuleResponseActions(options)).resolves.toBeUndefined();
+    });
+
+    it('should handle camelCase params from existing rule (savedQueryId)', async () => {
+      // Existing rule stores params in camelCase (RuleResponseOsqueryAction).
+      // When the action is modified, the old camelCase version appears in the xor diff.
+      options.rulePayload = { response_actions: [] };
+      existingRule.params.responseActions = [
+        { actionTypeId: '.osquery', params: { savedQueryId: 'existing-saved-query' } },
+      ] as RuleResponseAction[];
+      options.existingRule = existingRule;
+
+      await validateRuleResponseActions(options);
+
+      expect(mockOsqueryAuthz).toHaveBeenCalledWith({
+        saved_query_id: 'existing-saved-query',
+        pack_id: undefined,
+      });
+    });
+
+    it('should handle camelCase params from existing rule (packId)', async () => {
+      options.rulePayload = { response_actions: [] };
+      existingRule.params.responseActions = [
+        { actionTypeId: '.osquery', params: { packId: 'existing-pack' } },
+      ] as RuleResponseAction[];
+      options.existingRule = existingRule;
+
+      await validateRuleResponseActions(options);
+
+      expect(mockOsqueryAuthz).toHaveBeenCalledWith({
+        saved_query_id: undefined,
+        pack_id: 'existing-pack',
+      });
+    });
+
+    it('should not validate unchanged osquery actions on update', async () => {
+      const osqueryAction = {
+        action_type_id: '.osquery' as const,
+        params: { query: 'SELECT * FROM processes' },
+      };
+      options.rulePayload = { response_actions: [osqueryAction] };
+      existingRule.params.responseActions = [
+        { actionTypeId: '.osquery', params: { query: 'SELECT * FROM processes' } },
+      ] as RuleResponseAction[];
+      options.existingRule = existingRule;
+
+      await validateRuleResponseActions(options);
+
+      // Osquery authz should not be called since the action is unchanged
+      expect(mockOsqueryAuthz).not.toHaveBeenCalled();
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/actions/utils/rule_response_actions_validators.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/actions/utils/rule_response_actions_validators.ts
@@ -32,6 +32,11 @@ import { CustomHttpRequestError } from '../../../../utils/custom_http_request_er
 
 type RuleResponseActions = Pick<RuleResponse, 'response_actions'>;
 
+export type CheckOsqueryResponseActionAuthz = (actionParams: {
+  saved_query_id?: string;
+  pack_id?: string;
+}) => Promise<void>;
+
 export interface ValidateRuleResponseActionsOptions<
   T extends RuleResponseActions = RuleResponseActions
 > {
@@ -47,6 +52,12 @@ export interface ValidateRuleResponseActionsOptions<
    * are only applied to the response actions that have changed
    */
   existingRule?: RuleAlertType | null;
+  /**
+   * Optional callback to validate osquery response action authorization.
+   * Should be bound to the current request before passing in.
+   * When provided, osquery response actions will be validated for privileges.
+   */
+  checkOsqueryResponseActionAuthz?: CheckOsqueryResponseActionAuthz;
 }
 
 /**
@@ -61,6 +72,7 @@ export const validateRuleResponseActions = async <
   spaceId,
   rulePayload: { response_actions: ruleResponseActions },
   existingRule,
+  checkOsqueryResponseActionAuthz,
 }: ValidateRuleResponseActionsOptions<T>): Promise<void> => {
   const logger = endpointService.createLogger('validateRuleResponseActions');
   const existingRuleResponseActions = existingRule?.params?.responseActions;
@@ -112,12 +124,31 @@ export const validateRuleResponseActions = async <
           validateEndpointKillSuspendProcessResponseAction(actionData.params);
           break;
       }
+    } else if (isOsqueryResponseAction(actionData)) {
+      if (checkOsqueryResponseActionAuthz) {
+        const params = actionData.params;
+        // Params may be snake_case (from API payload: OsqueryResponseAction) or
+        // camelCase (from existing rule in ES: RuleResponseOsqueryAction)
+        await checkOsqueryResponseActionAuthz({
+          saved_query_id:
+            ('saved_query_id' in params ? params.saved_query_id : undefined) ??
+            ('savedQueryId' in params ? params.savedQueryId : undefined),
+          pack_id:
+            ('pack_id' in params ? params.pack_id : undefined) ??
+            ('packId' in params ? params.packId : undefined),
+        });
+      } else {
+        logger.debug(
+          () =>
+            `Skipping osquery response action validation - no osquery authz checker provided: ${stringify(
+              actionData
+            )}`
+        );
+      }
     } else {
       logger.debug(
         () =>
-          `Skipping validation of response action - action type id not '.endpoint': ${stringify(
-            actionData
-          )}`
+          `Skipping validation of response action - unknown action type: ${stringify(actionData)}`
       );
     }
   }
@@ -129,7 +160,10 @@ type ImportRuleResponseActions = Pick<RuleToImport, 'response_actions' | 'id' | 
 
 export type ValidateRuleImportResponseActionsOptions<
   T extends ImportRuleResponseActions = ImportRuleResponseActions
-> = Pick<ValidateRuleResponseActionsOptions, 'endpointAuthz' | 'endpointService' | 'spaceId'> & {
+> = Pick<
+  ValidateRuleResponseActionsOptions,
+  'endpointAuthz' | 'endpointService' | 'spaceId' | 'checkOsqueryResponseActionAuthz'
+> & {
   rulesToImport: T[];
 };
 
@@ -155,6 +189,7 @@ export const validateRuleImportResponseActions = async <
   endpointAuthz,
   spaceId,
   rulesToImport,
+  checkOsqueryResponseActionAuthz,
 }: ValidateRuleImportResponseActionsOptions<T>): Promise<
   ValidateRuleImportResponseActionsResult<T>
 > => {
@@ -172,6 +207,7 @@ export const validateRuleImportResponseActions = async <
           endpointService,
           spaceId,
           rulePayload: rule,
+          checkOsqueryResponseActionAuthz,
         });
 
         response.valid.push(rule);
@@ -228,6 +264,20 @@ const isEndpointResponseAction = (
   return (
     ('action_type_id' in ruleResponseAction && ruleResponseAction.action_type_id === '.endpoint') ||
     ('actionTypeId' in ruleResponseAction && ruleResponseAction.actionTypeId === '.endpoint')
+  );
+};
+
+/** @private */
+const isOsqueryResponseAction = (
+  ruleResponseAction:
+    | RuleResponseOsqueryAction
+    | RuleResponseEndpointAction
+    | OsqueryResponseAction
+    | EndpointResponseAction
+): ruleResponseAction is OsqueryResponseAction | RuleResponseOsqueryAction => {
+  return (
+    ('action_type_id' in ruleResponseAction && ruleResponseAction.action_type_id === '.osquery') ||
+    ('actionTypeId' in ruleResponseAction && ruleResponseAction.actionTypeId === '.osquery')
   );
 };
 

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/routes/__mocks__/request_context.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/routes/__mocks__/request_context.ts
@@ -158,6 +158,7 @@ const createSecuritySolutionRequestContextMock = (
     getEndpointAuthz: jest.fn(async () =>
       getEndpointAuthzInitialStateMock(overrides.endpointAuthz)
     ),
+    getCheckOsqueryResponseActionAuthz: jest.fn(() => jest.fn()),
     getEndpointService: jest.fn(() => {
       if (overrides.endpointAppServices) {
         return overrides.endpointAppServices;

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_actions/route.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_actions/route.test.ts
@@ -798,6 +798,7 @@ describe('Perform bulk action route', () => {
       await server.inject(request, requestContextMock.convertContext(context));
 
       expect(validateRuleResponseActionsMock).toHaveBeenCalledWith({
+        checkOsqueryResponseActionAuthz: expect.any(Function),
         endpointAuthz: expect.any(Object),
         endpointService: expect.any(Object),
         spaceId: 'default',

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_actions/route.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_actions/route.ts
@@ -300,6 +300,8 @@ export const performBulkActionRoute = (
                     rulePayload: {},
                     spaceId,
                     existingRule: rule,
+                    checkOsqueryResponseActionAuthz:
+                      ctx.securitySolution.getCheckOsqueryResponseActionAuthz(),
                   });
 
                   // during dry run only validation is getting performed and rule is not saved in ES, thus return early

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/create_rule/route.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/create_rule/route.ts
@@ -92,6 +92,8 @@ export const createRuleRoute = (router: SecuritySolutionPluginRouter): void => {
             endpointService: ctx.securitySolution.getEndpointService(),
             rulePayload: request.body,
             spaceId: ctx.securitySolution.getSpaceId(),
+            checkOsqueryResponseActionAuthz:
+              ctx.securitySolution.getCheckOsqueryResponseActionAuthz(),
           });
 
           const createdRule = await detectionRulesClient.createCustomRule({

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/import_rules/route.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/import_rules/route.ts
@@ -183,6 +183,8 @@ export const importRulesRoute = (
               endpointService,
               spaceId,
               rulesToImport: validatedActionRules,
+              checkOsqueryResponseActionAuthz:
+                ctx.securitySolution.getCheckOsqueryResponseActionAuthz(),
             });
 
           const ruleChunks = chunk(CHUNK_PARSED_OBJECT_SIZE, validatedResponseActionsRules);

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/patch_rule/route.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/patch_rule/route.ts
@@ -79,6 +79,8 @@ export const patchRuleRoute = (router: SecuritySolutionPluginRouter) => {
             rulePayload: request.body,
             spaceId: securitySolutionCtx.getSpaceId(),
             existingRule,
+            checkOsqueryResponseActionAuthz:
+              securitySolutionCtx.getCheckOsqueryResponseActionAuthz(),
           });
 
           checkDefaultRuleExceptionListReferences({ exceptionLists: params.exceptions_list });

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/update_rule/route.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/update_rule/route.ts
@@ -83,6 +83,8 @@ export const updateRuleRoute = (router: SecuritySolutionPluginRouter) => {
             rulePayload: request.body,
             spaceId: ctx.securitySolution.getSpaceId(),
             existingRule,
+            checkOsqueryResponseActionAuthz:
+              ctx.securitySolution.getCheckOsqueryResponseActionAuthz(),
           });
 
           const updatedRule = await detectionRulesClient.updateRule({

--- a/x-pack/solutions/security/plugins/security_solution/server/request_context_factory.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/request_context_factory.ts
@@ -191,6 +191,9 @@ export class RequestContextFactory implements IRequestContextFactory {
 
       getEndpointService: () => endpointAppContextService,
 
+      getCheckOsqueryResponseActionAuthz: () => (params) =>
+        plugins.osquery.checkResponseActionAuthz(request, params),
+
       getConfig: () => config,
 
       getFrameworkRequest: () => frameworkRequest,

--- a/x-pack/solutions/security/plugins/security_solution/server/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/types.ts
@@ -19,6 +19,7 @@ import type { FleetRequestHandlerContext } from '@kbn/fleet-plugin/server';
 import type { LicensingApiRequestHandlerContext } from '@kbn/licensing-plugin/server';
 import type { ExceptionListClient, ListsApiRequestHandlerContext } from '@kbn/lists-plugin/server';
 import type { AlertsClient, IRuleDataService } from '@kbn/rule-registry-plugin/server';
+import type { EntityStoreCRUDClient as EntityStoreUpdateClient } from '@kbn/entity-store/server';
 
 import type { Readable } from 'stream';
 import type { AuditLogger } from '@kbn/security-plugin-types-server';
@@ -50,6 +51,8 @@ import type { MonitoringEntitySourceDataClient } from './lib/entity_analytics/pr
 import type { MlAuthz } from './lib/machine_learning/authz';
 import type { SiemMigrationClients } from './lib/siem_migrations/types';
 import type { EntityStoreCrudClient } from './lib/entity_analytics/entity_store/entity_store_crud_client';
+import type { CheckOsqueryResponseActionAuthz } from './endpoint/services/actions/utils/rule_response_actions_validators';
+import type { DetectionRulesAuthz } from '../common/detection_engine/rule_management/authz';
 
 export { AppClient };
 
@@ -59,6 +62,7 @@ export interface SecuritySolutionApiRequestHandlerContext {
   getServerBasePath: () => string;
   getEndpointAuthz: () => Promise<Immutable<EndpointAuthz>>;
   getEndpointService: () => EndpointAppContextService;
+  getCheckOsqueryResponseActionAuthz: () => CheckOsqueryResponseActionAuthz;
   getConfig: () => ConfigType;
   getFrameworkRequest: () => FrameworkRequest;
   getAppClient: () => AppClient;
@@ -71,6 +75,7 @@ export interface SecuritySolutionApiRequestHandlerContext {
   getAuditLogger: () => AuditLogger | undefined;
   getLogger: () => Logger;
   getDataViewsService: () => DataViewsService;
+  getInternalDataViewsService: () => Promise<DataViewsService>;
   getEntityStoreApiKeyManager: () => EntityStoreApiKeyManager;
   getExceptionListClient: () => ExceptionListClient | null;
   getInternalFleetServices: () => EndpointInternalFleetServicesInterface;
@@ -79,6 +84,7 @@ export interface SecuritySolutionApiRequestHandlerContext {
   getAssetCriticalityDataClient: () => AssetCriticalityDataClient;
   getEntityStoreDataClient: () => EntityStoreDataClient;
   getEntityStoreCrudClient: () => EntityStoreCrudClient;
+  getEntityStoreUpdateClient: () => EntityStoreUpdateClient;
   getPrivilegeMonitoringDataClient: () => PrivilegeMonitoringDataClient;
   getMonitoringEntitySourceDataClient: () => MonitoringEntitySourceDataClient;
   getPrivilegedUserMonitoringApiKeyManager: () => PrivilegedUsersApiKeyManager;
@@ -88,6 +94,7 @@ export interface SecuritySolutionApiRequestHandlerContext {
   getAssetInventoryClient: () => AssetInventoryDataClient;
   getProductFeatureService: () => ProductFeaturesService;
   getMlAuthz: () => MlAuthz;
+  getRulesAuthz: () => DetectionRulesAuthz;
 }
 
 export type SecuritySolutionRequestHandlerContext = CustomRequestHandlerContext<{

--- a/x-pack/solutions/security/plugins/security_solution/server/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/types.ts
@@ -19,7 +19,6 @@ import type { FleetRequestHandlerContext } from '@kbn/fleet-plugin/server';
 import type { LicensingApiRequestHandlerContext } from '@kbn/licensing-plugin/server';
 import type { ExceptionListClient, ListsApiRequestHandlerContext } from '@kbn/lists-plugin/server';
 import type { AlertsClient, IRuleDataService } from '@kbn/rule-registry-plugin/server';
-import type { EntityStoreCRUDClient as EntityStoreUpdateClient } from '@kbn/entity-store/server';
 
 import type { Readable } from 'stream';
 import type { AuditLogger } from '@kbn/security-plugin-types-server';
@@ -52,7 +51,6 @@ import type { MlAuthz } from './lib/machine_learning/authz';
 import type { SiemMigrationClients } from './lib/siem_migrations/types';
 import type { EntityStoreCrudClient } from './lib/entity_analytics/entity_store/entity_store_crud_client';
 import type { CheckOsqueryResponseActionAuthz } from './endpoint/services/actions/utils/rule_response_actions_validators';
-import type { DetectionRulesAuthz } from '../common/detection_engine/rule_management/authz';
 
 export { AppClient };
 
@@ -75,7 +73,6 @@ export interface SecuritySolutionApiRequestHandlerContext {
   getAuditLogger: () => AuditLogger | undefined;
   getLogger: () => Logger;
   getDataViewsService: () => DataViewsService;
-  getInternalDataViewsService: () => Promise<DataViewsService>;
   getEntityStoreApiKeyManager: () => EntityStoreApiKeyManager;
   getExceptionListClient: () => ExceptionListClient | null;
   getInternalFleetServices: () => EndpointInternalFleetServicesInterface;
@@ -84,7 +81,6 @@ export interface SecuritySolutionApiRequestHandlerContext {
   getAssetCriticalityDataClient: () => AssetCriticalityDataClient;
   getEntityStoreDataClient: () => EntityStoreDataClient;
   getEntityStoreCrudClient: () => EntityStoreCrudClient;
-  getEntityStoreUpdateClient: () => EntityStoreUpdateClient;
   getPrivilegeMonitoringDataClient: () => PrivilegeMonitoringDataClient;
   getMonitoringEntitySourceDataClient: () => MonitoringEntitySourceDataClient;
   getPrivilegedUserMonitoringApiKeyManager: () => PrivilegedUsersApiKeyManager;
@@ -94,7 +90,6 @@ export interface SecuritySolutionApiRequestHandlerContext {
   getAssetInventoryClient: () => AssetInventoryDataClient;
   getProductFeatureService: () => ProductFeaturesService;
   getMlAuthz: () => MlAuthz;
-  getRulesAuthz: () => DetectionRulesAuthz;
 }
 
 export type SecuritySolutionRequestHandlerContext = CustomRequestHandlerContext<{


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [ [Osquery] Add osquery response action privilege checks to external Api (#260947)](https://github.com/elastic/kibana/pull/260947)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Tomasz Ciecierski","email":"tomasz.ciecierski@elastic.co"},"sourceCommit":{"committedDate":"2026-04-07T09:38:54Z","message":" [Osquery] Add osquery response action privilege checks to external Api (#260947)","sha":"cc6ce6db55108919a87587fbe24a5f4b0f4ebc52","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Defend Workflows","Osquery","backport:version","v9.4.0","v9.3.4","v8.19.15"],"title":" [Osquery] Add osquery response action privilege checks to external Api","number":260947,"url":"https://github.com/elastic/kibana/pull/260947","mergeCommit":{"message":" [Osquery] Add osquery response action privilege checks to external Api (#260947)","sha":"cc6ce6db55108919a87587fbe24a5f4b0f4ebc52"}},"sourceBranch":"main","suggestedTargetBranches":["9.3","8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/260947","number":260947,"mergeCommit":{"message":" [Osquery] Add osquery response action privilege checks to external Api (#260947)","sha":"cc6ce6db55108919a87587fbe24a5f4b0f4ebc52"}},{"branch":"9.3","label":"v9.3.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.15","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->