### PR TITLE
[8.19]  [Osquery] Add osquery response action privilege checks to external Api (#260947)

### DIFF
--- a/x-pack/platform/plugins/shared/osquery/server/lib/check_response_action_authz.test.ts
+++ b/x-pack/platform/plugins/shared/osquery/server/lib/check_response_action_authz.test.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { httpServerMock } from '@kbn/core/server/mocks';
+import type { CoreStart, KibanaRequest } from '@kbn/core/server';
+import { isOsqueryResponseActionAuthorized } from './check_response_action_authz';
+
+describe('isOsqueryResponseActionAuthorized', () => {
+  let request: KibanaRequest;
+  let mockCoreStart: CoreStart;
+
+  const createMockCoreStart = (capabilities: Record<string, boolean>): CoreStart =>
+    ({
+      capabilities: {
+        resolveCapabilities: jest.fn().mockResolvedValue({
+          osquery: capabilities,
+        }),
+      },
+    } as unknown as CoreStart);
+
+  beforeEach(() => {
+    request = httpServerMock.createKibanaRequest();
+  });
+
+  it('should return true when user has writeLiveQueries', async () => {
+    mockCoreStart = createMockCoreStart({ writeLiveQueries: true, runSavedQueries: false });
+
+    const result = await isOsqueryResponseActionAuthorized(mockCoreStart, request, {});
+    expect(result).toBe(true);
+  });
+
+  it('should return false when user lacks writeLiveQueries for direct query', async () => {
+    mockCoreStart = createMockCoreStart({ writeLiveQueries: false, runSavedQueries: false });
+
+    const result = await isOsqueryResponseActionAuthorized(mockCoreStart, request, {});
+    expect(result).toBe(false);
+  });
+
+  it('should return true when user has runSavedQueries with saved_query_id', async () => {
+    mockCoreStart = createMockCoreStart({ writeLiveQueries: false, runSavedQueries: true });
+
+    const result = await isOsqueryResponseActionAuthorized(mockCoreStart, request, {
+      saved_query_id: 'test-query-id',
+    });
+    expect(result).toBe(true);
+  });
+
+  it('should return true when user has runSavedQueries with pack_id', async () => {
+    mockCoreStart = createMockCoreStart({ writeLiveQueries: false, runSavedQueries: true });
+
+    const result = await isOsqueryResponseActionAuthorized(mockCoreStart, request, {
+      pack_id: 'test-pack-id',
+    });
+    expect(result).toBe(true);
+  });
+
+  it('should return false when user has runSavedQueries but no saved_query_id or pack_id', async () => {
+    mockCoreStart = createMockCoreStart({ writeLiveQueries: false, runSavedQueries: true });
+
+    const result = await isOsqueryResponseActionAuthorized(mockCoreStart, request, {});
+    expect(result).toBe(false);
+  });
+
+  it('should return false when user lacks both privileges with saved_query_id', async () => {
+    mockCoreStart = createMockCoreStart({ writeLiveQueries: false, runSavedQueries: false });
+
+    const result = await isOsqueryResponseActionAuthorized(mockCoreStart, request, {
+      saved_query_id: 'test-query-id',
+    });
+    expect(result).toBe(false);
+  });
+
+  it('should return true when user has writeLiveQueries regardless of saved_query_id', async () => {
+    mockCoreStart = createMockCoreStart({ writeLiveQueries: true, runSavedQueries: false });
+
+    const result = await isOsqueryResponseActionAuthorized(mockCoreStart, request, {
+      saved_query_id: 'test-query-id',
+    });
+    expect(result).toBe(true);
+  });
+
+  it('should call resolveCapabilities with the correct request and path', async () => {
+    mockCoreStart = createMockCoreStart({ writeLiveQueries: true, runSavedQueries: false });
+
+    await isOsqueryResponseActionAuthorized(mockCoreStart, request, {});
+
+    expect(mockCoreStart.capabilities.resolveCapabilities).toHaveBeenCalledWith(request, {
+      capabilityPath: 'osquery.*',
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/osquery/server/lib/check_response_action_authz.ts
+++ b/x-pack/platform/plugins/shared/osquery/server/lib/check_response_action_authz.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { CoreSetup, CoreStart, KibanaRequest } from '@kbn/core/server';
+import type { CheckResponseActionAuthzParams } from '../types';
+import { CustomHttpRequestError } from '../common/error';
+
+interface OsqueryCapabilities {
+  writeLiveQueries: boolean;
+  runSavedQueries: boolean;
+}
+
+// Cache capability resolution per request so bulk operations (e.g., duplicating
+// hundreds of rules) only call resolveCapabilities once per request.
+const capabilitiesCache = new WeakMap<KibanaRequest, Promise<OsqueryCapabilities>>();
+
+const resolveOsqueryCapabilities = (
+  coreStart: CoreStart,
+  request: KibanaRequest
+): Promise<OsqueryCapabilities> => {
+  let promise = capabilitiesCache.get(request);
+
+  if (!promise) {
+    promise = (async () => {
+      const resolved = await coreStart.capabilities.resolveCapabilities(request, {
+        capabilityPath: 'osquery.*',
+      });
+
+      return {
+        writeLiveQueries: !!resolved.osquery.writeLiveQueries,
+        runSavedQueries: !!resolved.osquery.runSavedQueries,
+      };
+    })();
+    capabilitiesCache.set(request, promise);
+  }
+
+  return promise;
+};
+
+/**
+ * Checks whether the requesting user has the required osquery privileges
+ * for a given action configuration.
+ *
+ * Privilege logic (mirrors create_live_query_route):
+ * - Direct query → needs writeLiveQueries
+ * - Saved query / pack → needs writeLiveQueries OR runSavedQueries
+ *
+ * @returns true if authorized, false otherwise
+ */
+export const isOsqueryResponseActionAuthorized = async (
+  coreStart: CoreStart,
+  request: KibanaRequest,
+  actionParams: CheckResponseActionAuthzParams
+): Promise<boolean> => {
+  const { writeLiveQueries, runSavedQueries } = await resolveOsqueryCapabilities(
+    coreStart,
+    request
+  );
+
+  return !!(
+    writeLiveQueries ||
+    (runSavedQueries && (actionParams.saved_query_id || actionParams.pack_id))
+  );
+};
+
+/**
+ * Validates that the requesting user has the required osquery privileges
+ * for the given response action configuration.
+ * Throws a 403 CustomHttpRequestError if the user lacks authorization.
+ *
+ * Used by security_solution when creating/updating detection rules
+ * that include osquery response actions.
+ */
+export const checkResponseActionAuthz = async (
+  core: CoreSetup,
+  request: KibanaRequest,
+  actionParams: CheckResponseActionAuthzParams
+): Promise<void> => {
+  const [coreStart] = await core.getStartServices();
+  const isAuthorized = await isOsqueryResponseActionAuthorized(coreStart, request, actionParams);
+
+  if (!isAuthorized) {
+    throw new CustomHttpRequestError(
+      'User is not authorized to create/update osquery response action',
+      403
+    );
+  }
+};

--- a/x-pack/platform/plugins/shared/osquery/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/osquery/server/plugin.ts
@@ -41,6 +41,7 @@ import { createDataViews } from './create_data_views';
 import { registerFeatures } from './utils/register_features';
 import { CASE_ATTACHMENT_TYPE_ID } from '../common/constants';
 import { createActionService } from './handlers/action/create_action_service';
+import { checkResponseActionAuthz } from './lib/check_response_action_authz';
 
 export class OsqueryPlugin implements Plugin<OsqueryPluginSetup, OsqueryPluginStart> {
   private readonly logger: Logger;
@@ -101,7 +102,9 @@ export class OsqueryPlugin implements Plugin<OsqueryPluginSetup, OsqueryPluginSt
 
     return {
       createActionService: this.createActionService,
-    };
+      checkResponseActionAuthz: (request, actionParams) =>
+        checkResponseActionAuthz(core, request, actionParams),
+    } satisfies OsqueryPluginSetup;
   }
 
   public start(core: CoreStart, plugins: StartPlugins) {

--- a/x-pack/platform/plugins/shared/osquery/server/routes/live_query/create_live_query_route.ts
+++ b/x-pack/platform/plugins/shared/osquery/server/routes/live_query/create_live_query_route.ts
@@ -21,6 +21,8 @@ import { buildRouteValidation } from '../../utils/build_validation/route_validat
 import type { OsqueryAppContext } from '../../lib/osquery_app_context_services';
 import { createActionHandler } from '../../handlers';
 import { parser as OsqueryParser } from './osquery_parser';
+import { getUserInfo } from '../../lib/get_user_info';
+import { isOsqueryResponseActionAuthorized } from '../../lib/check_response_action_authz';
 
 export const createLiveQueryRoute = (router: IRouter, osqueryContext: OsqueryAppContext) => {
   router.versioned
@@ -52,16 +54,10 @@ export const createLiveQueryRoute = (router: IRouter, osqueryContext: OsqueryApp
         const coreContext = await context.core;
         const soClient = coreContext.savedObjects.client;
 
-        const {
-          osquery: { writeLiveQueries, runSavedQueries },
-        } = await coreStartServices.capabilities.resolveCapabilities(request, {
-          capabilityPath: 'osquery.*',
-        });
-
-        const isInvalid = !(
-          writeLiveQueries ||
-          (runSavedQueries && (request.body.saved_query_id || request.body.pack_id))
-        );
+        const isInvalid = !(await isOsqueryResponseActionAuthorized(coreStartServices, request, {
+          saved_query_id: request.body.saved_query_id,
+          pack_id: request.body.pack_id,
+        }));
 
         const client = await osqueryContext.service
           .getRuleRegistryService()

--- a/x-pack/platform/plugins/shared/osquery/server/routes/live_query/create_live_query_route.ts
+++ b/x-pack/platform/plugins/shared/osquery/server/routes/live_query/create_live_query_route.ts
@@ -21,7 +21,6 @@ import { buildRouteValidation } from '../../utils/build_validation/route_validat
 import type { OsqueryAppContext } from '../../lib/osquery_app_context_services';
 import { createActionHandler } from '../../handlers';
 import { parser as OsqueryParser } from './osquery_parser';
-import { getUserInfo } from '../../lib/get_user_info';
 import { isOsqueryResponseActionAuthorized } from '../../lib/check_response_action_authz';
 
 export const createLiveQueryRoute = (router: IRouter, osqueryContext: OsqueryAppContext) => {

--- a/x-pack/platform/plugins/shared/osquery/server/types.ts
+++ b/x-pack/platform/plugins/shared/osquery/server/types.ts
@@ -23,10 +23,28 @@ import type { PluginStart as DataViewsPluginStart } from '@kbn/data-views-plugin
 import type { RuleRegistryPluginStartContract } from '@kbn/rule-registry-plugin/server';
 import type { CasesServerSetup } from '@kbn/cases-plugin/server';
 import type { LicensingPluginSetup } from '@kbn/licensing-plugin/server';
+import type { KibanaRequest } from '@kbn/core/server';
 import type { createActionService } from './handlers/action/create_action_service';
+
+export interface CheckResponseActionAuthzParams {
+  saved_query_id?: string;
+  pack_id?: string;
+}
 
 export interface OsqueryPluginSetup {
   createActionService: ReturnType<typeof createActionService>;
+  /**
+   * Validates that the requesting user has the required osquery privileges
+   * for the given response action configuration.
+   * Throws a 403 CustomHttpRequestError if the user lacks authorization.
+   *
+   * Used by security_solution when creating/updating detection rules
+   * that include osquery response actions.
+   */
+  checkResponseActionAuthz: (
+    request: KibanaRequest,
+    actionParams: CheckResponseActionAuthzParams
+  ) => Promise<void>;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/actions/utils/rule_response_actions_validators.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/actions/utils/rule_response_actions_validators.test.ts
@@ -88,16 +88,20 @@ describe('Rules Endpoint response actions validators', () => {
       await expect(validateRuleResponseActions(options)).resolves.toBeUndefined();
     });
 
-    it('should only validate .endpoint response actions', async () => {
+    it('should validate both .endpoint and .osquery response actions independently', async () => {
       endpointAuthz.canIsolateHost = false;
+      const mockOsqueryAuthz = jest.fn().mockResolvedValue(undefined);
       rulePayload.response_actions = [
-        { action_type_id: '.osquery', params: {} },
+        { action_type_id: '.osquery', params: { query: 'SELECT 1' } },
         createRulePayloadResponseActionMock(),
       ];
+      options.checkOsqueryResponseActionAuthz = mockOsqueryAuthz;
 
       await expect(validateRuleResponseActions(options)).rejects.toThrow(
         'User is not authorized to create/update isolate response action'
       );
+      // Osquery authz was still called for the osquery action
+      expect(mockOsqueryAuthz).toHaveBeenCalledTimes(1);
     });
 
     interface AuthzTestCase {
@@ -272,6 +276,142 @@ describe('Rules Endpoint response actions validators', () => {
           ],
         }
       `);
+    });
+  });
+
+  describe('osquery response actions validation', () => {
+    let options: ValidateRuleResponseActionsOptions;
+    let mockOsqueryAuthz: jest.Mock;
+
+    beforeEach(() => {
+      mockOsqueryAuthz = jest.fn().mockResolvedValue(undefined);
+      options = {
+        rulePayload: {
+          response_actions: [
+            {
+              action_type_id: '.osquery' as const,
+              params: { query: 'SELECT * FROM processes' },
+            },
+          ],
+        },
+        endpointService,
+        endpointAuthz,
+        spaceId: 'foo',
+        checkOsqueryResponseActionAuthz: mockOsqueryAuthz,
+      };
+    });
+
+    it('should call osquery authz checker for .osquery actions', async () => {
+      await validateRuleResponseActions(options);
+
+      expect(mockOsqueryAuthz).toHaveBeenCalledWith({
+        saved_query_id: undefined,
+        pack_id: undefined,
+      });
+    });
+
+    it('should pass saved_query_id to osquery authz checker', async () => {
+      options.rulePayload = {
+        response_actions: [
+          {
+            action_type_id: '.osquery' as const,
+            params: { saved_query_id: 'test-saved-query' },
+          },
+        ],
+      };
+
+      await validateRuleResponseActions(options);
+
+      expect(mockOsqueryAuthz).toHaveBeenCalledWith({
+        saved_query_id: 'test-saved-query',
+        pack_id: undefined,
+      });
+    });
+
+    it('should pass pack_id to osquery authz checker', async () => {
+      options.rulePayload = {
+        response_actions: [
+          {
+            action_type_id: '.osquery' as const,
+            params: { pack_id: 'test-pack' },
+          },
+        ],
+      };
+
+      await validateRuleResponseActions(options);
+
+      expect(mockOsqueryAuthz).toHaveBeenCalledWith({
+        saved_query_id: undefined,
+        pack_id: 'test-pack',
+      });
+    });
+
+    it('should throw when osquery authz checker rejects', async () => {
+      const authzError: Error & { statusCode?: number } = new Error(
+        'User is not authorized to create/update osquery response action'
+      );
+      authzError.statusCode = 403;
+      mockOsqueryAuthz.mockRejectedValue(authzError);
+
+      await expect(validateRuleResponseActions(options)).rejects.toThrow(
+        'User is not authorized to create/update osquery response action'
+      );
+    });
+
+    it('should skip osquery validation when no authz checker is provided', async () => {
+      delete options.checkOsqueryResponseActionAuthz;
+
+      // Should not throw even though there are osquery actions
+      await expect(validateRuleResponseActions(options)).resolves.toBeUndefined();
+    });
+
+    it('should handle camelCase params from existing rule (savedQueryId)', async () => {
+      // Existing rule stores params in camelCase (RuleResponseOsqueryAction).
+      // When the action is modified, the old camelCase version appears in the xor diff.
+      options.rulePayload = { response_actions: [] };
+      existingRule.params.responseActions = [
+        { actionTypeId: '.osquery', params: { savedQueryId: 'existing-saved-query' } },
+      ] as RuleResponseAction[];
+      options.existingRule = existingRule;
+
+      await validateRuleResponseActions(options);
+
+      expect(mockOsqueryAuthz).toHaveBeenCalledWith({
+        saved_query_id: 'existing-saved-query',
+        pack_id: undefined,
+      });
+    });
+
+    it('should handle camelCase params from existing rule (packId)', async () => {
+      options.rulePayload = { response_actions: [] };
+      existingRule.params.responseActions = [
+        { actionTypeId: '.osquery', params: { packId: 'existing-pack' } },
+      ] as RuleResponseAction[];
+      options.existingRule = existingRule;
+
+      await validateRuleResponseActions(options);
+
+      expect(mockOsqueryAuthz).toHaveBeenCalledWith({
+        saved_query_id: undefined,
+        pack_id: 'existing-pack',
+      });
+    });
+
+    it('should not validate unchanged osquery actions on update', async () => {
+      const osqueryAction = {
+        action_type_id: '.osquery' as const,
+        params: { query: 'SELECT * FROM processes' },
+      };
+      options.rulePayload = { response_actions: [osqueryAction] };
+      existingRule.params.responseActions = [
+        { actionTypeId: '.osquery', params: { query: 'SELECT * FROM processes' } },
+      ] as RuleResponseAction[];
+      options.existingRule = existingRule;
+
+      await validateRuleResponseActions(options);
+
+      // Osquery authz should not be called since the action is unchanged
+      expect(mockOsqueryAuthz).not.toHaveBeenCalled();
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/actions/utils/rule_response_actions_validators.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/actions/utils/rule_response_actions_validators.ts
@@ -32,6 +32,11 @@ import { CustomHttpRequestError } from '../../../../utils/custom_http_request_er
 
 type RuleResponseActions = Pick<RuleResponse, 'response_actions'>;
 
+export type CheckOsqueryResponseActionAuthz = (actionParams: {
+  saved_query_id?: string;
+  pack_id?: string;
+}) => Promise<void>;
+
 export interface ValidateRuleResponseActionsOptions<
   T extends RuleResponseActions = RuleResponseActions
 > {
@@ -47,6 +52,12 @@ export interface ValidateRuleResponseActionsOptions<
    * are only applied to the response actions that have changed
    */
   existingRule?: RuleAlertType | null;
+  /**
+   * Optional callback to validate osquery response action authorization.
+   * Should be bound to the current request before passing in.
+   * When provided, osquery response actions will be validated for privileges.
+   */
+  checkOsqueryResponseActionAuthz?: CheckOsqueryResponseActionAuthz;
 }
 
 /**
@@ -61,6 +72,7 @@ export const validateRuleResponseActions = async <
   spaceId,
   rulePayload: { response_actions: ruleResponseActions },
   existingRule,
+  checkOsqueryResponseActionAuthz,
 }: ValidateRuleResponseActionsOptions<T>): Promise<void> => {
   const logger = endpointService.createLogger('validateRuleResponseActions');
   const existingRuleResponseActions = existingRule?.params?.responseActions;
@@ -115,12 +127,31 @@ export const validateRuleResponseActions = async <
           validateEndpointKillSuspendProcessResponseAction(actionData.params);
           break;
       }
+    } else if (isOsqueryResponseAction(actionData)) {
+      if (checkOsqueryResponseActionAuthz) {
+        const params = actionData.params;
+        // Params may be snake_case (from API payload: OsqueryResponseAction) or
+        // camelCase (from existing rule in ES: RuleResponseOsqueryAction)
+        await checkOsqueryResponseActionAuthz({
+          saved_query_id:
+            ('saved_query_id' in params ? params.saved_query_id : undefined) ??
+            ('savedQueryId' in params ? params.savedQueryId : undefined),
+          pack_id:
+            ('pack_id' in params ? params.pack_id : undefined) ??
+            ('packId' in params ? params.packId : undefined),
+        });
+      } else {
+        logger.debug(
+          () =>
+            `Skipping osquery response action validation - no osquery authz checker provided: ${stringify(
+              actionData
+            )}`
+        );
+      }
     } else {
       logger.debug(
         () =>
-          `Skipping validation of response action - action type id not '.endpoint': ${stringify(
-            actionData
-          )}`
+          `Skipping validation of response action - unknown action type: ${stringify(actionData)}`
       );
     }
   }
@@ -132,7 +163,10 @@ type ImportRuleResponseActions = Pick<RuleToImport, 'response_actions' | 'id' | 
 
 export type ValidateRuleImportResponseActionsOptions<
   T extends ImportRuleResponseActions = ImportRuleResponseActions
-> = Pick<ValidateRuleResponseActionsOptions, 'endpointAuthz' | 'endpointService' | 'spaceId'> & {
+> = Pick<
+  ValidateRuleResponseActionsOptions,
+  'endpointAuthz' | 'endpointService' | 'spaceId' | 'checkOsqueryResponseActionAuthz'
+> & {
   rulesToImport: T[];
 };
 
@@ -158,6 +192,7 @@ export const validateRuleImportResponseActions = async <
   endpointAuthz,
   spaceId,
   rulesToImport,
+  checkOsqueryResponseActionAuthz,
 }: ValidateRuleImportResponseActionsOptions<T>): Promise<
   ValidateRuleImportResponseActionsResult<T>
 > => {
@@ -175,6 +210,7 @@ export const validateRuleImportResponseActions = async <
           endpointService,
           spaceId,
           rulePayload: rule,
+          checkOsqueryResponseActionAuthz,
         });
 
         response.valid.push(rule);
@@ -231,6 +267,20 @@ const isEndpointResponseAction = (
   return (
     ('action_type_id' in ruleResponseAction && ruleResponseAction.action_type_id === '.endpoint') ||
     ('actionTypeId' in ruleResponseAction && ruleResponseAction.actionTypeId === '.endpoint')
+  );
+};
+
+/** @private */
+const isOsqueryResponseAction = (
+  ruleResponseAction:
+    | RuleResponseOsqueryAction
+    | RuleResponseEndpointAction
+    | OsqueryResponseAction
+    | EndpointResponseAction
+): ruleResponseAction is OsqueryResponseAction | RuleResponseOsqueryAction => {
+  return (
+    ('action_type_id' in ruleResponseAction && ruleResponseAction.action_type_id === '.osquery') ||
+    ('actionTypeId' in ruleResponseAction && ruleResponseAction.actionTypeId === '.osquery')
   );
 };
 

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/routes/__mocks__/request_context.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/routes/__mocks__/request_context.ts
@@ -142,6 +142,7 @@ const createSecuritySolutionRequestContextMock = (
     getEndpointAuthz: jest.fn(async () =>
       getEndpointAuthzInitialStateMock(overrides.endpointAuthz)
     ),
+    getCheckOsqueryResponseActionAuthz: jest.fn(() => jest.fn()),
     getEndpointService: jest.fn(() => {
       throw new Error(
         `getEndpointService() not mocked. Needs to be done from withing testing context (due to circular dependencies)`

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_actions/route.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_actions/route.test.ts
@@ -756,6 +756,7 @@ describe('Perform bulk action route', () => {
       await server.inject(request, requestContextMock.convertContext(context));
 
       expect(validateRuleResponseActionsMock).toHaveBeenCalledWith({
+        checkOsqueryResponseActionAuthz: expect.any(Function),
         endpointAuthz: expect.any(Object),
         endpointService: expect.any(Object),
         spaceId: 'default',

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_actions/route.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_actions/route.ts
@@ -281,6 +281,8 @@ export const performBulkActionRoute = (
                     rulePayload: {},
                     spaceId,
                     existingRule: rule,
+                    checkOsqueryResponseActionAuthz:
+                      ctx.securitySolution.getCheckOsqueryResponseActionAuthz(),
                   });
 
                   // during dry run only validation is getting performed and rule is not saved in ES, thus return early

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/create_rule/route.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/create_rule/route.ts
@@ -94,6 +94,8 @@ export const createRuleRoute = (router: SecuritySolutionPluginRouter): void => {
             endpointService: ctx.securitySolution.getEndpointService(),
             rulePayload: request.body,
             spaceId: ctx.securitySolution.getSpaceId(),
+            checkOsqueryResponseActionAuthz:
+              ctx.securitySolution.getCheckOsqueryResponseActionAuthz(),
           });
 
           const createdRule = await detectionRulesClient.createCustomRule({

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/import_rules/route.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/import_rules/route.ts
@@ -182,6 +182,8 @@ export const importRulesRoute = (
               endpointService,
               spaceId,
               rulesToImport: validatedActionRules,
+              checkOsqueryResponseActionAuthz:
+                ctx.securitySolution.getCheckOsqueryResponseActionAuthz(),
             });
 
           const ruleChunks = chunk(CHUNK_PARSED_OBJECT_SIZE, validatedResponseActionsRules);

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/patch_rule/route.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/patch_rule/route.ts
@@ -78,6 +78,8 @@ export const patchRuleRoute = (router: SecuritySolutionPluginRouter) => {
             rulePayload: request.body,
             spaceId: securitySolutionCtx.getSpaceId(),
             existingRule,
+            checkOsqueryResponseActionAuthz:
+              securitySolutionCtx.getCheckOsqueryResponseActionAuthz(),
           });
 
           checkDefaultRuleExceptionListReferences({ exceptionLists: params.exceptions_list });

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/update_rule/route.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/update_rule/route.ts
@@ -82,6 +82,8 @@ export const updateRuleRoute = (router: SecuritySolutionPluginRouter) => {
             rulePayload: request.body,
             spaceId: ctx.securitySolution.getSpaceId(),
             existingRule,
+            checkOsqueryResponseActionAuthz:
+              ctx.securitySolution.getCheckOsqueryResponseActionAuthz(),
           });
 
           const updatedRule = await detectionRulesClient.updateRule({

--- a/x-pack/solutions/security/plugins/security_solution/server/request_context_factory.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/request_context_factory.ts
@@ -142,6 +142,9 @@ export class RequestContextFactory implements IRequestContextFactory {
 
       getEndpointService: () => endpointAppContextService,
 
+      getCheckOsqueryResponseActionAuthz: () => (params) =>
+        plugins.osquery.checkResponseActionAuthz(request, params),
+
       getConfig: () => config,
 
       getFrameworkRequest: () => frameworkRequest,

--- a/x-pack/solutions/security/plugins/security_solution/server/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/types.ts
@@ -43,6 +43,8 @@ import type { ApiKeyManager } from './lib/entity_analytics/entity_store/auth/api
 import type { ProductFeaturesService } from './lib/product_features_service';
 import type { MlAuthz } from './lib/machine_learning/authz';
 import type { EndpointAppContextService } from './endpoint/endpoint_app_context_services';
+import type { CheckOsqueryResponseActionAuthz } from './endpoint/services/actions/utils/rule_response_actions_validators';
+
 export { AppClient };
 
 export interface SecuritySolutionApiRequestHandlerContext {
@@ -51,6 +53,7 @@ export interface SecuritySolutionApiRequestHandlerContext {
   getServerBasePath: () => string;
   getEndpointAuthz: () => Promise<Immutable<EndpointAuthz>>;
   getEndpointService: () => EndpointAppContextService;
+  getCheckOsqueryResponseActionAuthz: () => CheckOsqueryResponseActionAuthz;
   getConfig: () => ConfigType;
   getFrameworkRequest: () => FrameworkRequest;
   getAppClient: () => AppClient;

--- a/x-pack/solutions/security/plugins/security_solution/server/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/types.ts
@@ -44,7 +44,6 @@ import type { ProductFeaturesService } from './lib/product_features_service';
 import type { MlAuthz } from './lib/machine_learning/authz';
 import type { EndpointAppContextService } from './endpoint/endpoint_app_context_services';
 import type { CheckOsqueryResponseActionAuthz } from './endpoint/services/actions/utils/rule_response_actions_validators';
-
 export { AppClient };
 
 export interface SecuritySolutionApiRequestHandlerContext {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [ [Osquery] Add osquery response action privilege checks to external Api (#260947)](https://github.com/elastic/kibana/pull/260947)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Tomasz Ciecierski","email":"tomasz.ciecierski@elastic.co"},"sourceCommit":{"committedDate":"2026-04-07T09:38:54Z","message":" [Osquery] Add osquery response action privilege checks to external Api (#260947)","sha":"cc6ce6db55108919a87587fbe24a5f4b0f4ebc52","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Defend Workflows","Osquery","backport:version","v9.4.0","v9.3.4","v8.19.15"],"title":" [Osquery] Add osquery response action privilege checks to external Api","number":260947,"url":"https://github.com/elastic/kibana/pull/260947","mergeCommit":{"message":" [Osquery] Add osquery response action privilege checks to external Api (#260947)","sha":"cc6ce6db55108919a87587fbe24a5f4b0f4ebc52"}},"sourceBranch":"main","suggestedTargetBranches":["9.3","8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/260947","number":260947,"mergeCommit":{"message":" [Osquery] Add osquery response action privilege checks to external Api (#260947)","sha":"cc6ce6db55108919a87587fbe24a5f4b0f4ebc52"}},{"branch":"9.3","label":"v9.3.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.15","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->