### PR TITLE
fix(streamlang): set processor validation treats falsy value as present

### DIFF
--- a/x-pack/platform/packages/shared/kbn-streamlang/types/processors/index.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/types/processors/index.ts
@@ -242,10 +242,17 @@ const setProcessorSchema = processorBaseWithWhereSchema
       .optional(StreamlangSourceField)
       .describe('Copy value from another field instead of providing a literal'),
   })
-  .refine((obj) => (obj.value && !obj.copy_from) || (!obj.value && obj.copy_from), {
-    message: 'Set processor must have either value or copy_from, but not both.',
-    path: ['value', 'copy_from'],
-  })
+  .refine(
+    (obj) => {
+      const hasValue = obj.value !== undefined;
+      const hasCopyFrom = obj.copy_from !== undefined;
+      return (hasValue && !hasCopyFrom) || (!hasValue && hasCopyFrom);
+    },
+    {
+      message: 'Set processor must have either value or copy_from, but not both.',
+      path: ['value', 'copy_from'],
+    }
+  )
   .describe(
     'Set processor - Assign a literal or copied value to a field (mutually exclusive inputs)'
   ) satisfies z.Schema<SetProcessor>;

--- a/x-pack/platform/packages/shared/kbn-streamlang/types/processors/set_processor_schema.test.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/types/processors/set_processor_schema.test.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { streamlangProcessorSchema } from '.';
+
+describe('setProcessorSchema (via streamlangProcessorSchema)', () => {
+  const base = { action: 'set' as const, to: 'attributes.field' };
+
+  it('accepts literal false as value (must not treat falsy value as absent)', () => {
+    expect(() =>
+      streamlangProcessorSchema.parse({
+        ...base,
+        value: false,
+      })
+    ).not.toThrow();
+  });
+
+  it('accepts other falsy literals as value when allowed by value schema', () => {
+    expect(() =>
+      streamlangProcessorSchema.parse({
+        ...base,
+        value: 0,
+      })
+    ).not.toThrow();
+
+    expect(() =>
+      streamlangProcessorSchema.parse({
+        ...base,
+        value: '',
+      })
+    ).not.toThrow();
+  });
+
+  it('rejects missing both value and copy_from', () => {
+    expect(() => streamlangProcessorSchema.parse({ ...base })).toThrow();
+  });
+
+  it('rejects both value and copy_from', () => {
+    expect(() =>
+      streamlangProcessorSchema.parse({
+        ...base,
+        value: true,
+        copy_from: 'other.field',
+      })
+    ).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

The Streamlang set processor Zod schema used truthiness to decide whether `value` was provided. That made literal `false` (and other falsy literals like `0` and `""`) fail validation even when `copy_from` was omitted, and produced the misleading "not both" error.

Validation is now aligned with the ESQL transpiler: presence is determined with `!== undefined` for both `value` and `copy_from`.

## Changes

- Replace truthy/falsy checks in `setProcessorSchema` refine with explicit undefined checks.
- Add `set_processor_schema.test.ts` covering `false`, `0`, `""`, missing both, and both set.

## Testing

- `node scripts/jest x-pack/platform/packages/shared/kbn-streamlang/types/processors/set_processor_schema.test.ts`
- `node scripts/eslint --fix` on touched files
- `node scripts/type_check --project x-pack/platform/packages/shared/kbn-streamlang/tsconfig.json`
- `node scripts/check_changes.ts`

Made with [Cursor](https://cursor.com)