### PR TITLE
chore(tests,security): ignore new user fields in PKI, Kerberos and Token tests

### DIFF
--- a/x-pack/platform/test/security_api_integration/tests/http_bearer/access_token.ts
+++ b/x-pack/platform/test/security_api_integration/tests/http_bearer/access_token.ts
@@ -43,7 +43,9 @@ export default function ({ getService }: FtrProviderContext) {
         .get('/internal/security/me')
         .set('kbn-xsrf', 'true')
         .set('authorization', `Bearer ${accessToken}`)
-        .expect(200, expectedUser);
+        .expect(200);
+
+      jestExpect(response.body).toMatchObject(expectedUser);
 
       // Make sure we don't automatically create a session
       expect(response.headers['set-cookie']).to.be(undefined);
@@ -53,18 +55,20 @@ export default function ({ getService }: FtrProviderContext) {
       const { accessToken, expectedUser } = await createToken();
 
       // try it once
-      await supertest
+      const responseOne = await supertest
         .get('/internal/security/me')
         .set('kbn-xsrf', 'true')
         .set('authorization', `Bearer ${accessToken}`)
-        .expect(200, expectedUser);
+        .expect(200);
+      jestExpect(responseOne.body).toMatchObject(expectedUser);
 
       // try it again to verity it isn't invalidated after a single request
-      await supertest
+      const responseTwo = await supertest
         .get('/internal/security/me')
         .set('kbn-xsrf', 'true')
         .set('authorization', `Bearer ${accessToken}`)
-        .expect(200, expectedUser);
+        .expect(200);
+      jestExpect(responseTwo.body).toMatchObject(expectedUser);
     });
 
     it('rejects invalid access token via authorization Bearer header', async () => {

--- a/x-pack/platform/test/security_api_integration/tests/kerberos/kerberos_login.ts
+++ b/x-pack/platform/test/security_api_integration/tests/kerberos/kerberos_login.ts
@@ -152,7 +152,7 @@ export default function ({ getService }: FtrProviderContext) {
           .set('Cookie', sessionCookie.cookieString())
           .expect(200);
 
-        jestExpect(spnegoResponse.body).toEqual({
+        jestExpect(spnegoResponse.body).toMatchObject({
           username: 'tester@TEST.ELASTIC.CO',
           roles: expectedUserRoles,
           full_name: null,

--- a/x-pack/platform/test/security_api_integration/tests/pki/pki_auth.ts
+++ b/x-pack/platform/test/security_api_integration/tests/pki/pki_auth.ts
@@ -152,7 +152,7 @@ export default function ({ getService }: FtrProviderContext) {
         .set('Cookie', sessionCookie.cookieString())
         .expect(200);
 
-      jestExpect(response.body).toEqual({
+      jestExpect(response.body).toMatchObject({
         username: 'first_client',
         roles: ['kibana_admin'],
         full_name: null,


### PR DESCRIPTION
## Summary

Ignore new user fields in PKI, Kerberos and Token tests (required after https://github.com/elastic/elasticsearch/pull/143255).

Promotion & Verification: 🟢 https://buildkite.com/elastic/kibana-elasticsearch-snapshot-verify/builds/7877

Fixes: https://github.com/elastic/kibana/issues/262411
Fixes: https://github.com/elastic/kibana/issues/262410
Fixes: https://github.com/elastic/kibana/issues/262409
Fixes: https://github.com/elastic/kibana/issues/262408
Fixes: https://github.com/elastic/kibana/issues/262407
Fixes: https://github.com/elastic/kibana/issues/262406



<!--ONMERGE {"backportTargets":["8.19","9.4"]} ONMERGE-->