### PR TITLE
[Fleet] only auto-install content packages newer than the installed version

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/tasks/auto_install_content_packages_task.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/tasks/auto_install_content_packages_task.test.ts
@@ -249,5 +249,56 @@ describe('AutoInstallContentPackagesTask', () => {
       expect(packageClientMock.installPackage).not.toHaveBeenCalled();
       expect(dataStreamService.getAllFleetDataStreams).not.toHaveBeenCalled();
     });
+
+    it('should not downgrade package when a newer prerelease version is installed', async () => {
+      // Registry has 1.1.0, but a prerelease 2.0.0-preview is already installed.
+      // The task must not downgrade to 1.1.0.
+      mockGetInstalledPackages.mockResolvedValue({
+        items: [
+          {
+            name: 'kubernetes_otel',
+            version: '2.0.0-preview',
+          },
+          {
+            name: 'test_package',
+            version: '2.0.0-preview',
+          },
+        ],
+      });
+
+      await runTask();
+
+      expect(packageClientMock.installPackage).not.toHaveBeenCalled();
+    });
+
+    it('should not downgrade one package while upgrading another', async () => {
+      // kubernetes_otel has a prerelease installed (must not downgrade),
+      // test_package has an older version installed (must upgrade).
+      mockGetInstalledPackages.mockResolvedValue({
+        items: [
+          {
+            name: 'kubernetes_otel',
+            version: '2.0.0-preview',
+          },
+          {
+            name: 'test_package',
+            version: '1.0.0',
+          },
+        ],
+      });
+
+      await runTask();
+
+      expect(packageClientMock.installPackage).toHaveBeenCalledTimes(1);
+      expect(packageClientMock.installPackage).toHaveBeenCalledWith({
+        pkgName: 'test_package',
+        pkgVersion: '1.1.0',
+        useStreaming: true,
+        automaticInstall: true,
+      });
+      expect(packageClientMock.installPackage).not.toHaveBeenCalledWith(
+        expect.objectContaining({ pkgName: 'kubernetes_otel' })
+      );
+    });
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/server/tasks/auto_install_content_packages_task.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/tasks/auto_install_content_packages_task.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 import pMap from 'p-map';
+import semverGt from 'semver/functions/gt';
 import { type CoreSetup, type ElasticsearchClient, type Logger } from '@kbn/core/server';
 import type {
   ConcreteTaskInstance,
@@ -234,7 +235,8 @@ export class AutoInstallContentPackagesTask {
       this.discoveryMap!
     ).reduce((acc, [dataset, mapValue]) => {
       const packages = mapValue.packages.filter(
-        (pkg) => !installedPackagesMap[pkg.name] || installedPackagesMap[pkg.name] !== pkg.version
+        (pkg) =>
+          !installedPackagesMap[pkg.name] || semverGt(pkg.version, installedPackagesMap[pkg.name])
       );
       if (packages.length > 0) {
         acc[dataset] = { packages };
@@ -251,7 +253,8 @@ export class AutoInstallContentPackagesTask {
         if (
           mapValue.packages.every(
             (pkg) =>
-              installedPackagesMap[pkg.name] && installedPackagesMap[pkg.name] === pkg.version
+              installedPackagesMap[pkg.name] &&
+              !semverGt(pkg.version, installedPackagesMap[pkg.name])
           )
         ) {
           acc.push(dataset);
@@ -275,7 +278,7 @@ export class AutoInstallContentPackagesTask {
 
       if (hasData) {
         for (const { name, version } of packages) {
-          if (!installedPackagesMap[name] || installedPackagesMap[name] !== version) {
+          if (!installedPackagesMap[name] || semverGt(version, installedPackagesMap[name])) {
             packagesToInstall[name] = version;
           }
         }


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/260677

The auto-install content packages task was using string equality (`!== version`) to decide whether to reinstall a package. This meant any version mismatch would trigger a reinstall, effectively downgrading packages. For example, if `2.0.0-preview` was installed and the registry listed `1.4.0` as the latest stable, the task would downgrade to `1.4.0`.

The fix replaces string equality with `semverGt` to make sure there are no downgrades happening.
A package is now only installed when the registry version is strictly newer than the installed version.

To verify:
- install prerelease version of a content package
```
POST kbn:/api/fleet/epm/packages/kubernetes_otel/2.0.0-preview5
{
    "force": true
}
```
- wait 10m until the auto install content packages task runs
- verify that the kubernetes_otel package is not downgraded

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...





<!--ONMERGE {"backportTargets":["9.2","9.3"]} ONMERGE-->