### PR TITLE
[Streams] Fix preconfiguring stream definitions

### DIFF
--- a/x-pack/platform/plugins/shared/streams/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/streams/server/plugin.ts
@@ -394,10 +394,8 @@ export class StreamsPlugin
               isSecurityEnabled: false,
             });
 
-            await streamsClient.enableStreams({ defer: true });
-
-            await streamsClient.bulkUpsert(
-              this.config.preconfigured.stream_definitions.map(({ name, ...definition }) => ({
+            const streamDefinitions = this.config.preconfigured.stream_definitions.map(
+              ({ name, ...definition }) => ({
                 name,
                 request: Streams.all.UpsertRequest.parse(
                   ROOT_STREAM_NAMES.includes(name)
@@ -416,8 +414,17 @@ export class StreamsPlugin
                       }
                     : definition
                 ),
-              }))
+              })
             );
+
+            if (streamDefinitions.length > 0) {
+              await streamsClient.enableStreams();
+
+              await streamsClient.bulkUpsert(streamDefinitions);
+            } else {
+              await streamsClient.enableStreams({ defer: true });
+            }
+
             this.logger.info('Streams preconfigured successfully');
           }
         }


### PR DESCRIPTION
## Summary

In https://github.com/elastic/kibana/pull/260387 we started deferring the creation of backing data streams when enabling wired streams on startup. This would cause `bulkUpsert` to fail with `index_not_found_exception: no such index [logs.otel]`, if a user had defined `xpack.streams.preconfigured.stream_definitions`.

This PR enables wired streams without deferring materialization of the backing data streams when user has defined stream definitions in config.