### PR TITLE
[Discover][Scout] Increase discoverDocTable visibility timeout in waitForDocTableRendered

### DIFF
--- a/src/platform/packages/shared/kbn-scout/src/playwright/page_objects/discover_app.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/page_objects/discover_app.ts
@@ -187,11 +187,11 @@ export class DiscoverApp {
   // Waits for the document table to be fully rendered and stable
   async waitForDocTableRendered() {
     const table = this.page.testSubj.locator('discoverDocTable');
-    await expect(table).toBeVisible();
-
     const minDurationMs = 2_000;
     const pollIntervalMs = 100;
     const totalTimeoutMs = 30_000;
+
+    await expect(table).toBeVisible({ timeout: totalTimeoutMs });
 
     let stableSince: number | null = null;
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/261438


`waitForDocTableRendered` in `discover_app.ts` waits for `discoverDocTable` to be visible before entering a 30s stability poll that checks `data-render-complete`. However, the initial `toBeVisible()` call had no explicit timeout, falling back to Playwright's default of 10s. On Elastic Cloud, where latency is higher and page load times are longer, this causes the assertion to time out before the table renders, even though the table eventually appears shortly after.

The fix moves `totalTimeoutMs` above the `toBeVisible()` call and passes it explicitly, making the initial visibility wait consistent with the stability poll budget that was already defined.

> [!NOTE]
> This was flagged by cloud pipeline failures in tests that navigate to Discover after an ES|QL query with chart rendering, which is inherently heavier than a local run. The root cause is not a product bug, the table renders correctly, just not within 10s on cloud. The 30s `totalTimeoutMs` was always defined in the function but was never applied to the first assertion.

