### PR TITLE
[8.19] Migrate SO tests from es-archiver to kbn-archiver (#261605)

### DIFF
--- a/x-pack/platform/test/common/lib/test_data_loader.ts
+++ b/x-pack/platform/test/common/lib/test_data_loader.ts
@@ -74,7 +74,83 @@ const OBJECTS_TO_SHARE: Array<{
   },
   {
     spacesToAdd: [SPACE_1.id, SPACE_2.id],
-    objects: [{ type: 'resolvetype', id: 'conflict-newid' }],
+    objects: [
+      { type: 'resolvetype', id: 'exact-match' },
+      { type: 'resolvetype', id: 'alias-match-newid' },
+      { type: 'resolvetype', id: 'conflict-newid' },
+      { type: 'sharedtype', id: 'conflict_1' },
+      { type: 'sharedtype', id: 'conflict_3' },
+      { type: 'sharedtype', id: 'conflict_4a' },
+    ],
+  },
+  {
+    spacesToAdd: ['*'],
+    spacesToRemove: ['default'],
+    objects: [
+      { type: 'sharedtype', id: 'outbound-missing-reference-conflict-1' },
+      { type: 'sharedtype', id: 'outbound-missing-reference-conflict-2a' },
+      { type: 'index-pattern', id: 'inbound-reference-origin-match-1-newId' },
+      { type: 'index-pattern', id: 'inbound-reference-origin-match-2a' },
+      { type: 'index-pattern', id: 'inbound-reference-origin-match-2b' },
+      { type: 'nestedtype', id: '1' },
+      { type: 'nestedtype', id: '2' },
+      { type: 'nestedtype', id: '3' },
+      { type: 'nestedtype', id: '4' },
+    ],
+  },
+];
+
+// These resolve-specific objects are created directly in ES (bypassing the
+// saved objects import API) because the import's origin-conflict detection
+// search for the ID "conflict" collides with other objects in the index.
+const RESOLVE_TEST_OBJECTS = [
+  {
+    _id: 'resolvetype:conflict',
+    _source: {
+      type: 'resolvetype',
+      updated_at: '2017-09-21T18:51:23.794Z',
+      resolvetype: { title: 'Resolve outcome conflict (1 of 2)' },
+      namespaces: ['default', SPACE_1.id, SPACE_2.id],
+    },
+  },
+  {
+    _id: 'resolvetype:all_spaces',
+    _source: {
+      type: 'resolvetype',
+      updated_at: '2017-09-21T18:51:23.794Z',
+      resolvetype: {
+        title:
+          "This is used to test that 1. the 'disabled' alias does not resolve to this target (because the alias is disabled), and 2. when this object that exists in all spaces is deleted, the alias that targets it is deleted too (even though the alias is disabled)",
+      },
+      namespaces: ['*'],
+    },
+  },
+];
+
+// These conflict objects are created directly in ES because the import API
+// doesn't preserve `updated_at`, and the _update_objects_spaces sharing call
+// also overwrites it. Tests assert on the exact `title` and `updatedAt` of
+// these objects in the ambiguous_conflict error response.
+const CONFLICT_DEST_OBJECTS = [
+  {
+    _id: 'sharedtype:conflict_2a',
+    _source: {
+      originId: 'conflict_2',
+      type: 'sharedtype',
+      updated_at: '2017-09-21T18:59:16.270Z',
+      sharedtype: { title: 'A shared saved-object in all spaces' },
+      namespaces: ['default', SPACE_1.id, SPACE_2.id],
+    },
+  },
+  {
+    _id: 'sharedtype:conflict_2b',
+    _source: {
+      originId: 'conflict_2',
+      type: 'sharedtype',
+      updated_at: '2017-09-21T18:59:16.270Z',
+      sharedtype: { title: 'A shared saved-object in all spaces' },
+      namespaces: ['default', SPACE_1.id, SPACE_2.id],
+    },
   },
 ];
 
@@ -125,6 +201,21 @@ export function getTestDataLoader({ getService }: Pick<FtrProviderContext, 'getS
           .send({ objects, spacesToAdd, spacesToRemove })
           .expect(200);
       }
+
+      // Ensure all sharing updates are visible to subsequent search operations.
+      await es.indices.refresh({ index: ALL_SAVED_OBJECT_INDICES });
+
+      // Create objects directly in ES that can't go through the import API.
+      await Promise.all(
+        [...RESOLVE_TEST_OBJECTS, ...CONFLICT_DEST_OBJECTS].map(async (obj) => {
+          await es.index({
+            id: obj._id,
+            index: '.kibana',
+            refresh: 'wait_for',
+            document: obj._source,
+          });
+        })
+      );
     },
 
     createLegacyUrlAliases: async (
@@ -141,7 +232,7 @@ export function getTestDataLoader({ getService }: Pick<FtrProviderContext, 'getS
 
           await Promise.all(
             aliases.map(async (alias) => {
-              await es.create({
+              await es.index({
                 id: `legacy-url-alias:${spaceString}:${alias.targetType}:${alias.sourceId}`,
                 index: '.kibana',
                 refresh: 'wait_for',
@@ -170,7 +261,10 @@ export function getTestDataLoader({ getService }: Pick<FtrProviderContext, 'getS
       await Promise.all(
         allSpacesIds.flatMap((spaceId) => [
           kbnServer.savedObjects.cleanStandardList({ space: spaceId }),
-          kbnServer.savedObjects.clean({ space: spaceId, types: ['sharedtype', 'isolatedtype'] }),
+          kbnServer.savedObjects.clean({
+            space: spaceId,
+            types: ['sharedtype', 'isolatedtype', 'resolvetype'],
+          }),
         ])
       );
     },
@@ -180,6 +274,7 @@ export function getTestDataLoader({ getService }: Pick<FtrProviderContext, 'getS
         index: ALL_SAVED_OBJECT_INDICES,
         ignore_unavailable: true,
         wait_for_completion: true,
+        refresh: true,
         conflicts: 'proceed',
         query: {
           bool: {

--- a/x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/default_space.json
+++ b/x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/default_space.json
@@ -93,7 +93,7 @@
 
 {
   "attributes": {
-    "title": "A sharedtype saved-object with id: conflict_1"
+    "title": "A shared saved-object in all spaces"
   },
   "id": "conflict_1",
   "type": "sharedtype",
@@ -103,27 +103,7 @@
 
 {
   "attributes": {
-    "title": "A sharedtype saved-object with id: conflict_2a"
-  },
-  "id": "conflict_2a",
-  "type": "sharedtype",
-  "updated_at": "2017-09-21T18:59:16.270Z",
-  "version": "WzQ4OCwxXQ=="
-}
-
-{
-  "attributes": {
-    "title": "A sharedtype saved-object with id: conflict_2b"
-  },
-  "id": "conflict_2b",
-  "type": "sharedtype",
-  "updated_at": "2017-09-21T18:59:16.270Z",
-  "version": "WzQ4OCwxXQ=="
-}
-
-{
-  "attributes": {
-    "title": "A sharedtype saved-object with id: conflict_3"
+    "title": "A shared saved-object in all spaces"
   },
   "id": "conflict_3",
   "type": "sharedtype",
@@ -133,9 +113,10 @@
 
 {
   "attributes": {
-    "title": "A sharedtype saved-object with id: conflict_4a"
+    "title": "A shared saved-object in all spaces"
   },
   "id": "conflict_4a",
+  "originId": "conflict_4",
   "type": "sharedtype",
   "updated_at": "2017-09-21T18:59:16.270Z",
   "version": "WzQ4OCwxXQ=="
@@ -168,6 +149,161 @@
   "id": "conflict-newid",
   "type": "resolvetype",
   "updated_at": "2017-09-21T18:51:23.794Z",
+  "version": "WzQ4OCwxXQ=="
+}
+
+{
+  "attributes": {
+    "title": "This is used to test if an imported object with a missing reference will have an exact match conflict when the missing reference is replaced"
+  },
+  "id": "outbound-missing-reference-conflict-1",
+  "type": "sharedtype",
+  "updated_at": "2017-09-21T18:59:16.270Z",
+  "version": "WzQ4OCwxXQ=="
+}
+
+{
+  "attributes": {
+    "title": "This is used to test if an imported object with a missing reference will have an inexact match conflict when the missing reference is replaced"
+  },
+  "id": "outbound-missing-reference-conflict-2a",
+  "originId": "outbound-missing-reference-conflict-2",
+  "type": "sharedtype",
+  "updated_at": "2017-09-21T18:59:16.270Z",
+  "version": "WzQ4OCwxXQ=="
+}
+
+{
+  "attributes": {
+    "title": "This is used to test if an imported object with a reference to this originId will be remapped properly"
+  },
+  "id": "inbound-reference-origin-match-1-newId",
+  "originId": "inbound-reference-origin-match-1",
+  "references": [],
+  "type": "index-pattern",
+  "updated_at": "2017-09-21T18:49:16.270Z",
+  "version": "WzQ4OCwxXQ=="
+}
+
+{
+  "attributes": {
+    "title": "This is used to test if an imported object with a reference to this originId will *not* be remapped"
+  },
+  "id": "inbound-reference-origin-match-2a",
+  "originId": "inbound-reference-origin-match-2",
+  "references": [],
+  "type": "index-pattern",
+  "updated_at": "2017-09-21T18:49:16.270Z",
+  "version": "WzQ4OCwxXQ=="
+}
+
+{
+  "attributes": {
+    "title": "This is used to test if an imported object with a reference to this originId will *not* be remapped"
+  },
+  "id": "inbound-reference-origin-match-2b",
+  "originId": "inbound-reference-origin-match-2",
+  "references": [],
+  "type": "index-pattern",
+  "updated_at": "2017-09-21T18:49:16.270Z",
+  "version": "WzQ4OCwxXQ=="
+}
+
+{
+  "attributes": {
+    "title": "elasticsearch",
+    "author": "John Doe",
+    "comments": [
+      {
+        "user": "bob",
+        "message": "very helpful",
+        "date": "2024-01-16",
+        "rating": 4
+      },
+      {
+        "user": "alice",
+        "message": "kibana and this one are great",
+        "date": "2024-01-15",
+        "rating": 5
+      }
+    ]
+  },
+  "id": "1",
+  "type": "nestedtype",
+  "updated_at": "2017-09-21T18:59:16.270Z",
+  "version": "WzQ4OCwxXQ=="
+}
+
+{
+  "attributes": {
+    "title": "kibana",
+    "author": "Jane Smith",
+    "comments": [
+      {
+        "user": "charlie",
+        "message": "excellent examples",
+        "date": "2024-02-10",
+        "rating": 5
+      },
+      {
+        "user": "diana",
+        "message": "could use more detail",
+        "date": "2024-02-12",
+        "rating": 3
+      }
+    ]
+  },
+  "id": "2",
+  "type": "nestedtype",
+  "updated_at": "2024-02-15T14:23:45.180Z",
+  "version": "WzQ4OCwxXQ=="
+}
+
+{
+  "attributes": {
+    "title": "logstash",
+    "author": "Mr Nobody",
+    "comments": [
+      {
+        "user": "frank",
+        "message": "perfect for beginners",
+        "date": "2024-03-05",
+        "rating": 4
+      },
+      {
+        "user": "bob",
+        "message": "charlie and diana's posts helped me",
+        "date": "2024-02-14",
+        "rating": 5
+      }
+    ]
+  },
+  "id": "3",
+  "type": "nestedtype",
+  "updated_at": "2024-03-11T09:15:32.450Z",
+  "version": "WzQ4OCwxXQ=="
+}
+
+{
+  "attributes": {
+    "title": "beats",
+    "author": "Deep Author",
+    "comments": [
+      {
+        "user": "grace",
+        "message": "deeply insightful",
+        "date": "2024-04-01",
+        "rating": 5,
+        "metadata": {
+          "author": "graceinternal",
+          "tag": "review"
+        }
+      }
+    ]
+  },
+  "id": "4",
+  "type": "nestedtype",
+  "updated_at": "2024-04-05T10:30:00.000Z",
   "version": "WzQ4OCwxXQ=="
 }
 

--- a/x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/legacy_url_aliases_all.json
+++ b/x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/legacy_url_aliases_all.json
@@ -1,0 +1,18 @@
+{
+  "sourceId": "alias-match",
+  "targetType": "resolvetype",
+  "targetId": "alias-match-newid"
+}
+
+{
+  "sourceId": "disabled",
+  "targetType": "resolvetype",
+  "targetId": "disabled-newid",
+  "disabled": true
+}
+
+{
+  "sourceId": "conflict",
+  "targetType": "resolvetype",
+  "targetId": "conflict-newid"
+}

--- a/x-pack/platform/test/saved_object_api_integration/common/suites/bulk_delete.ts
+++ b/x-pack/platform/test/saved_object_api_integration/common/suites/bulk_delete.ts
@@ -7,6 +7,7 @@
 
 import expect from '@kbn/expect';
 import type { SearchTotalHits } from '@elastic/elasticsearch/lib/api/types';
+import { getTestDataLoader, SPACE_1, SPACE_2 } from '../../../common/lib/test_data_loader';
 import { SAVED_OBJECT_TEST_CASES as CASES } from '../lib/saved_object_test_cases';
 import { SPACES } from '../lib/spaces';
 import { expectResponses, getUrlPrefix, getTestTitle } from '../lib/saved_object_test_utils';
@@ -46,10 +47,9 @@ export const TEST_CASES: Record<string, BulkDeleteTestCase> = Object.freeze({
 const createRequest = ({ type, id, force }: BulkDeleteTestCase) => ({ type, id, force });
 
 export function bulkDeleteTestSuiteFactory(context: FtrProviderContext) {
-  const esArchiver = context.getService('esArchiver');
+  const testDataLoader = getTestDataLoader(context);
   const supertest = context.getService('supertestWithoutAuth');
   const es = context.getService('es');
-  // const log = context.getService('log');
 
   const expectSavedObjectForbidden = expectResponses.forbiddenTypes('bulk_delete');
   const expectResponseBody =
@@ -120,16 +120,53 @@ export function bulkDeleteTestSuiteFactory(context: FtrProviderContext) {
       const { user, spaceId = SPACES.DEFAULT.spaceId, tests } = definition;
 
       describeFn(description, () => {
-        before(() =>
-          esArchiver.load(
-            'x-pack/platform/test/saved_object_api_integration/common/fixtures/es_archiver/saved_objects/spaces'
-          )
-        );
-        after(() =>
-          esArchiver.unload(
-            'x-pack/platform/test/saved_object_api_integration/common/fixtures/es_archiver/saved_objects/spaces'
-          )
-        );
+        before(async () => {
+          await testDataLoader.createFtrSpaces();
+          await testDataLoader.createFtrSavedObjectsData([
+            {
+              spaceName: null,
+              dataUrl:
+                'x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/default_space.json',
+            },
+            {
+              spaceName: SPACE_1.id,
+              dataUrl:
+                'x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/space_1.json',
+            },
+            {
+              spaceName: SPACE_2.id,
+              dataUrl:
+                'x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/space_2.json',
+            },
+          ]);
+          await testDataLoader.createLegacyUrlAliases([
+            {
+              spaceName: null,
+              dataUrl:
+                'x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/legacy_url_aliases_all.json',
+            },
+            {
+              spaceName: SPACE_1.id,
+              dataUrl:
+                'x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/legacy_url_aliases_all.json',
+            },
+            {
+              spaceName: 'space_x',
+              dataUrl:
+                'x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/legacy_url_aliases.json',
+            },
+            {
+              spaceName: 'space_y',
+              dataUrl:
+                'x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/legacy_url_aliases.json',
+              disabled: true,
+            },
+          ]);
+        });
+        after(async () => {
+          await testDataLoader.deleteAllSavedObjectsFromKibanaIndex();
+          await testDataLoader.deleteFtrSpaces();
+        });
 
         for (const test of tests) {
           it(`should return ${test.responseStatusCode} ${test.title} `, async () => {

--- a/x-pack/platform/test/saved_object_api_integration/common/suites/bulk_resolve.ts
+++ b/x-pack/platform/test/saved_object_api_integration/common/suites/bulk_resolve.ts
@@ -6,7 +6,7 @@
  */
 
 import expect from '@kbn/expect';
-import { Agent as SuperTestAgent } from 'supertest';
+import { getTestDataLoader, SPACE_1, SPACE_2 } from '../../../common/lib/test_data_loader';
 import { TEST_CASES } from './resolve';
 import { SPACES } from '../lib/spaces';
 import {
@@ -15,7 +15,8 @@ import {
   getUrlPrefix,
   getTestTitle,
 } from '../lib/saved_object_test_utils';
-import { ExpectResponseBody, TestCase, TestDefinition, TestSuite } from '../lib/types';
+import type { ExpectResponseBody, TestCase, TestDefinition, TestSuite } from '../lib/types';
+import type { FtrProviderContext } from '../ftr_provider_context';
 
 export interface BulkResolveTestDefinition extends TestDefinition {
   request: Array<{ type: string; id: string }>;
@@ -29,7 +30,9 @@ export interface BulkResolveTestCase extends TestCase {
 
 export { TEST_CASES }; // re-export the (non-bulk) resolve test cases
 
-export function bulkResolveTestSuiteFactory(esArchiver: any, supertest: SuperTestAgent) {
+export function bulkResolveTestSuiteFactory(context: FtrProviderContext) {
+  const testDataLoader = getTestDataLoader(context);
+  const supertest = context.getService('supertestWithoutAuth');
   const expectSavedObjectForbidden = expectResponses.forbiddenTypes('bulk_get');
   const expectResponseBody =
     (
@@ -104,16 +107,53 @@ export function bulkResolveTestSuiteFactory(esArchiver: any, supertest: SuperTes
       const { user, spaceId = SPACES.DEFAULT.spaceId, tests } = definition;
 
       describeFn(description, () => {
-        before(() =>
-          esArchiver.load(
-            'x-pack/platform/test/saved_object_api_integration/common/fixtures/es_archiver/saved_objects/spaces'
-          )
-        );
-        after(() =>
-          esArchiver.unload(
-            'x-pack/platform/test/saved_object_api_integration/common/fixtures/es_archiver/saved_objects/spaces'
-          )
-        );
+        before(async () => {
+          await testDataLoader.createFtrSpaces();
+          await testDataLoader.createFtrSavedObjectsData([
+            {
+              spaceName: null,
+              dataUrl:
+                'x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/default_space.json',
+            },
+            {
+              spaceName: SPACE_1.id,
+              dataUrl:
+                'x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/space_1.json',
+            },
+            {
+              spaceName: SPACE_2.id,
+              dataUrl:
+                'x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/space_2.json',
+            },
+          ]);
+          await testDataLoader.createLegacyUrlAliases([
+            {
+              spaceName: null,
+              dataUrl:
+                'x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/legacy_url_aliases_all.json',
+            },
+            {
+              spaceName: SPACE_1.id,
+              dataUrl:
+                'x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/legacy_url_aliases_all.json',
+            },
+            {
+              spaceName: 'space_x',
+              dataUrl:
+                'x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/legacy_url_aliases.json',
+            },
+            {
+              spaceName: 'space_y',
+              dataUrl:
+                'x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/legacy_url_aliases.json',
+              disabled: true,
+            },
+          ]);
+        });
+        after(async () => {
+          await testDataLoader.deleteAllSavedObjectsFromKibanaIndex();
+          await testDataLoader.deleteFtrSpaces();
+        });
 
         for (const test of tests) {
           it(`should return ${test.responseStatusCode} ${test.title}`, async () => {

--- a/x-pack/platform/test/saved_object_api_integration/common/suites/bulk_update.ts
+++ b/x-pack/platform/test/saved_object_api_integration/common/suites/bulk_update.ts
@@ -6,11 +6,12 @@
  */
 
 import expect from '@kbn/expect';
-import { Agent as SuperTestAgent } from 'supertest';
+import { getTestDataLoader, SPACE_1, SPACE_2 } from '../../../common/lib/test_data_loader';
 import { SAVED_OBJECT_TEST_CASES as CASES } from '../lib/saved_object_test_cases';
 import { SPACES } from '../lib/spaces';
 import { expectResponses, getUrlPrefix, getTestTitle } from '../lib/saved_object_test_utils';
-import { ExpectResponseBody, TestCase, TestDefinition, TestSuite } from '../lib/types';
+import type { ExpectResponseBody, TestCase, TestDefinition, TestSuite } from '../lib/types';
+import type { FtrProviderContext } from '../ftr_provider_context';
 
 export interface BulkUpdateTestDefinition extends TestDefinition {
   request: Array<{ type: string; id: string }>;
@@ -36,7 +37,9 @@ const createRequest = ({ type, id, namespace }: BulkUpdateTestCase) => ({
   ...(namespace && { namespace }), // individual "object namespace" string
 });
 
-export function bulkUpdateTestSuiteFactory(esArchiver: any, supertest: SuperTestAgent) {
+export function bulkUpdateTestSuiteFactory(context: FtrProviderContext) {
+  const testDataLoader = getTestDataLoader(context);
+  const supertest = context.getService('supertestWithoutAuth');
   const expectSavedObjectForbidden = expectResponses.forbiddenTypes('bulk_update');
   const expectResponseBody =
     (
@@ -100,16 +103,30 @@ export function bulkUpdateTestSuiteFactory(esArchiver: any, supertest: SuperTest
       const { user, spaceId = SPACES.DEFAULT.spaceId, tests } = definition;
 
       describeFn(description, () => {
-        before(() =>
-          esArchiver.load(
-            'x-pack/platform/test/saved_object_api_integration/common/fixtures/es_archiver/saved_objects/spaces'
-          )
-        );
-        after(() =>
-          esArchiver.unload(
-            'x-pack/platform/test/saved_object_api_integration/common/fixtures/es_archiver/saved_objects/spaces'
-          )
-        );
+        before(async () => {
+          await testDataLoader.createFtrSpaces();
+          await testDataLoader.createFtrSavedObjectsData([
+            {
+              spaceName: null,
+              dataUrl:
+                'x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/default_space.json',
+            },
+            {
+              spaceName: SPACE_1.id,
+              dataUrl:
+                'x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/space_1.json',
+            },
+            {
+              spaceName: SPACE_2.id,
+              dataUrl:
+                'x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/space_2.json',
+            },
+          ]);
+        });
+        after(async () => {
+          await testDataLoader.deleteFtrSavedObjectsData();
+          await testDataLoader.deleteFtrSpaces();
+        });
 
         const attrs = { attributes: { [NEW_ATTRIBUTE_KEY]: NEW_ATTRIBUTE_VAL } };
 

--- a/x-pack/platform/test/saved_object_api_integration/common/suites/create.ts
+++ b/x-pack/platform/test/saved_object_api_integration/common/suites/create.ts
@@ -6,7 +6,7 @@
  */
 
 import expect from '@kbn/expect';
-import { Agent as SuperTestAgent } from 'supertest';
+import { getTestDataLoader, SPACE_1, SPACE_2 } from '../../../common/lib/test_data_loader';
 import { SAVED_OBJECT_TEST_CASES as CASES } from '../lib/saved_object_test_cases';
 import { SPACES, ALL_SPACES_ID } from '../lib/spaces';
 import {
@@ -15,7 +15,14 @@ import {
   getTestTitle,
   getRedactedNamespaces,
 } from '../lib/saved_object_test_utils';
-import { ExpectResponseBody, TestCase, TestDefinition, TestSuite, TestUser } from '../lib/types';
+import type {
+  ExpectResponseBody,
+  TestCase,
+  TestDefinition,
+  TestSuite,
+  TestUser,
+} from '../lib/types';
+import type { FtrProviderContext } from '../ftr_provider_context';
 
 const {
   DEFAULT: { spaceId: DEFAULT_SPACE_ID },
@@ -85,7 +92,9 @@ const createRequest = ({ type, id, initialNamespaces }: CreateTestCase) => ({
   initialNamespaces,
 });
 
-export function createTestSuiteFactory(esArchiver: any, supertest: SuperTestAgent) {
+export function createTestSuiteFactory(context: FtrProviderContext) {
+  const testDataLoader = getTestDataLoader(context);
+  const supertest = context.getService('supertestWithoutAuth');
   const expectSavedObjectForbidden = expectResponses.forbiddenTypes('create');
   const expectResponseBody =
     (testCase: CreateTestCase, user?: TestUser): ExpectResponseBody =>
@@ -133,16 +142,53 @@ export function createTestSuiteFactory(esArchiver: any, supertest: SuperTestAgen
       const { user, spaceId = SPACES.DEFAULT.spaceId, tests } = definition;
 
       describeFn(description, () => {
-        before(() =>
-          esArchiver.load(
-            'x-pack/platform/test/saved_object_api_integration/common/fixtures/es_archiver/saved_objects/spaces'
-          )
-        );
-        after(() =>
-          esArchiver.unload(
-            'x-pack/platform/test/saved_object_api_integration/common/fixtures/es_archiver/saved_objects/spaces'
-          )
-        );
+        before(async () => {
+          await testDataLoader.createFtrSpaces();
+          await testDataLoader.createFtrSavedObjectsData([
+            {
+              spaceName: null,
+              dataUrl:
+                'x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/default_space.json',
+            },
+            {
+              spaceName: SPACE_1.id,
+              dataUrl:
+                'x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/space_1.json',
+            },
+            {
+              spaceName: SPACE_2.id,
+              dataUrl:
+                'x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/space_2.json',
+            },
+          ]);
+          await testDataLoader.createLegacyUrlAliases([
+            {
+              spaceName: null,
+              dataUrl:
+                'x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/legacy_url_aliases_all.json',
+            },
+            {
+              spaceName: SPACE_1.id,
+              dataUrl:
+                'x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/legacy_url_aliases_all.json',
+            },
+            {
+              spaceName: 'space_x',
+              dataUrl:
+                'x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/legacy_url_aliases.json',
+            },
+            {
+              spaceName: 'space_y',
+              dataUrl:
+                'x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/legacy_url_aliases.json',
+              disabled: true,
+            },
+          ]);
+        });
+        after(async () => {
+          await testDataLoader.deleteAllSavedObjectsFromKibanaIndex();
+          await testDataLoader.deleteFtrSpaces();
+        });
 
         for (const test of tests) {
           it(`should return ${test.responseStatusCode} ${test.title}`, async () => {

--- a/x-pack/platform/test/saved_object_api_integration/common/suites/delete.ts
+++ b/x-pack/platform/test/saved_object_api_integration/common/suites/delete.ts
@@ -5,14 +5,14 @@
  * 2.0.
  */
 
-import { Agent as SuperTestAgent } from 'supertest';
-import type { Client } from '@elastic/elasticsearch';
 import expect from '@kbn/expect';
 import type { SearchTotalHits } from '@elastic/elasticsearch/lib/api/types';
+import { getTestDataLoader, SPACE_1, SPACE_2 } from '../../../common/lib/test_data_loader';
 import { SAVED_OBJECT_TEST_CASES as CASES } from '../lib/saved_object_test_cases';
 import { SPACES } from '../lib/spaces';
 import { expectResponses, getUrlPrefix, getTestTitle } from '../lib/saved_object_test_utils';
-import { ExpectResponseBody, TestCase, TestDefinition, TestSuite } from '../lib/types';
+import type { ExpectResponseBody, TestCase, TestDefinition, TestSuite } from '../lib/types';
+import type { FtrProviderContext } from '../ftr_provider_context';
 
 export interface DeleteTestDefinition extends TestDefinition {
   request: { type: string; id: string; force?: boolean };
@@ -38,7 +38,10 @@ export const TEST_CASES: Record<string, DeleteTestCase> = Object.freeze({
  */
 const createRequest = ({ type, id, force }: DeleteTestCase) => ({ type, id, force });
 
-export function deleteTestSuiteFactory(es: Client, esArchiver: any, supertest: SuperTestAgent) {
+export function deleteTestSuiteFactory(context: FtrProviderContext) {
+  const testDataLoader = getTestDataLoader(context);
+  const supertest = context.getService('supertestWithoutAuth');
+  const es = context.getService('es');
   const expectSavedObjectForbidden = expectResponses.forbiddenTypes('delete');
   const expectResponseBody =
     (testCase: DeleteTestCase): ExpectResponseBody =>
@@ -101,16 +104,53 @@ export function deleteTestSuiteFactory(es: Client, esArchiver: any, supertest: S
       const { user, spaceId = SPACES.DEFAULT.spaceId, tests } = definition;
 
       describeFn(description, () => {
-        before(() =>
-          esArchiver.load(
-            'x-pack/platform/test/saved_object_api_integration/common/fixtures/es_archiver/saved_objects/spaces'
-          )
-        );
-        after(() =>
-          esArchiver.unload(
-            'x-pack/platform/test/saved_object_api_integration/common/fixtures/es_archiver/saved_objects/spaces'
-          )
-        );
+        before(async () => {
+          await testDataLoader.createFtrSpaces();
+          await testDataLoader.createFtrSavedObjectsData([
+            {
+              spaceName: null,
+              dataUrl:
+                'x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/default_space.json',
+            },
+            {
+              spaceName: SPACE_1.id,
+              dataUrl:
+                'x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/space_1.json',
+            },
+            {
+              spaceName: SPACE_2.id,
+              dataUrl:
+                'x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/space_2.json',
+            },
+          ]);
+          await testDataLoader.createLegacyUrlAliases([
+            {
+              spaceName: null,
+              dataUrl:
+                'x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/legacy_url_aliases_all.json',
+            },
+            {
+              spaceName: SPACE_1.id,
+              dataUrl:
+                'x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/legacy_url_aliases_all.json',
+            },
+            {
+              spaceName: 'space_x',
+              dataUrl:
+                'x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/legacy_url_aliases.json',
+            },
+            {
+              spaceName: 'space_y',
+              dataUrl:
+                'x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/legacy_url_aliases.json',
+              disabled: true,
+            },
+          ]);
+        });
+        after(async () => {
+          await testDataLoader.deleteAllSavedObjectsFromKibanaIndex();
+          await testDataLoader.deleteFtrSpaces();
+        });
 
         for (const test of tests) {
           it(`should return ${test.responseStatusCode} ${test.title}`, async () => {

--- a/x-pack/platform/test/saved_object_api_integration/common/suites/export.ts
+++ b/x-pack/platform/test/saved_object_api_integration/common/suites/export.ts
@@ -6,7 +6,7 @@
  */
 
 import expect from '@kbn/expect';
-import { Agent as SuperTestAgent } from 'supertest';
+import { getTestDataLoader, SPACE_1, SPACE_2 } from '../../../common/lib/test_data_loader';
 import {
   SAVED_OBJECT_TEST_CASES,
   CONFLICT_TEST_CASES,
@@ -14,7 +14,8 @@ import {
 } from '../lib/saved_object_test_cases';
 import { SPACES } from '../lib/spaces';
 import { expectResponses, getUrlPrefix } from '../lib/saved_object_test_utils';
-import { ExpectResponseBody, TestDefinition, TestSuite } from '../lib/types';
+import type { ExpectResponseBody, TestDefinition, TestSuite } from '../lib/types';
+import type { FtrProviderContext } from '../ftr_provider_context';
 
 const {
   DEFAULT: { spaceId: DEFAULT_SPACE_ID },
@@ -154,7 +155,9 @@ const EMPTY_RESULT = {
   missingReferences: [],
 };
 
-export function exportTestSuiteFactory(esArchiver: any, supertest: SuperTestAgent) {
+export function exportTestSuiteFactory(context: FtrProviderContext) {
+  const testDataLoader = getTestDataLoader(context);
+  const supertest = context.getService('supertestWithoutAuth');
   const expectSavedObjectForbiddenBulkGet = expectResponses.forbiddenTypes('bulk_get');
   const expectResponseBody =
     (testCase: ExportTestCase): ExpectResponseBody =>
@@ -244,16 +247,30 @@ export function exportTestSuiteFactory(esArchiver: any, supertest: SuperTestAgen
       const { user, spaceId = DEFAULT_SPACE_ID, tests } = definition;
 
       describeFn(description, () => {
-        before(() =>
-          esArchiver.load(
-            'x-pack/platform/test/saved_object_api_integration/common/fixtures/es_archiver/saved_objects/spaces'
-          )
-        );
-        after(() =>
-          esArchiver.unload(
-            'x-pack/platform/test/saved_object_api_integration/common/fixtures/es_archiver/saved_objects/spaces'
-          )
-        );
+        before(async () => {
+          await testDataLoader.createFtrSpaces();
+          await testDataLoader.createFtrSavedObjectsData([
+            {
+              spaceName: null,
+              dataUrl:
+                'x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/default_space.json',
+            },
+            {
+              spaceName: SPACE_1.id,
+              dataUrl:
+                'x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/space_1.json',
+            },
+            {
+              spaceName: SPACE_2.id,
+              dataUrl:
+                'x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/space_2.json',
+            },
+          ]);
+        });
+        after(async () => {
+          await testDataLoader.deleteFtrSavedObjectsData();
+          await testDataLoader.deleteFtrSpaces();
+        });
 
         for (const test of tests) {
           it(`should return ${test.responseStatusCode} ${test.title}`, async () => {

--- a/x-pack/platform/test/saved_object_api_integration/common/suites/find.ts
+++ b/x-pack/platform/test/saved_object_api_integration/common/suites/find.ts
@@ -6,8 +6,8 @@
  */
 
 import expect from '@kbn/expect';
-import { Agent as SuperTestAgent } from 'supertest';
 import querystring from 'querystring';
+import { getTestDataLoader, SPACE_1, SPACE_2 } from '../../../common/lib/test_data_loader';
 import {
   SAVED_OBJECT_TEST_CASES,
   CONFLICT_TEST_CASES,
@@ -19,7 +19,14 @@ import {
   isUserAuthorizedAtSpace,
   getRedactedNamespaces,
 } from '../lib/saved_object_test_utils';
-import { ExpectResponseBody, TestCase, TestDefinition, TestSuite, TestUser } from '../lib/types';
+import type {
+  ExpectResponseBody,
+  TestCase,
+  TestDefinition,
+  TestSuite,
+  TestUser,
+} from '../lib/types';
+import type { FtrProviderContext } from '../ftr_provider_context';
 
 const {
   DEFAULT: { spaceId: DEFAULT_SPACE_ID },
@@ -187,7 +194,9 @@ export const createRequest = ({ query }: FindTestCase) => ({ query });
 const getTestTitle = ({ failure, title }: FindTestCase) =>
   `${failure?.reason || 'success'} ["${title}"]`;
 
-export function findTestSuiteFactory(esArchiver: any, supertest: SuperTestAgent) {
+export function findTestSuiteFactory(context: FtrProviderContext) {
+  const testDataLoader = getTestDataLoader(context);
+  const supertest = context.getService('supertestWithoutAuth');
   const expectResponseBody =
     (testCase: FindTestCase, user?: TestUser): ExpectResponseBody =>
     async (response: Record<string, any>) => {
@@ -281,16 +290,30 @@ export function findTestSuiteFactory(esArchiver: any, supertest: SuperTestAgent)
       const { user, spaceId = DEFAULT_SPACE_ID, tests } = definition;
 
       describeFn(description, () => {
-        before(() =>
-          esArchiver.load(
-            'x-pack/platform/test/saved_object_api_integration/common/fixtures/es_archiver/saved_objects/spaces'
-          )
-        );
-        after(() =>
-          esArchiver.unload(
-            'x-pack/platform/test/saved_object_api_integration/common/fixtures/es_archiver/saved_objects/spaces'
-          )
-        );
+        before(async () => {
+          await testDataLoader.createFtrSpaces();
+          await testDataLoader.createFtrSavedObjectsData([
+            {
+              spaceName: null,
+              dataUrl:
+                'x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/default_space.json',
+            },
+            {
+              spaceName: SPACE_1.id,
+              dataUrl:
+                'x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/space_1.json',
+            },
+            {
+              spaceName: SPACE_2.id,
+              dataUrl:
+                'x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/space_2.json',
+            },
+          ]);
+        });
+        after(async () => {
+          await testDataLoader.deleteFtrSavedObjectsData();
+          await testDataLoader.deleteFtrSpaces();
+        });
 
         for (const test of tests) {
           it(`should return ${test.responseStatusCode} ${test.title}`, async () => {

--- a/x-pack/platform/test/saved_object_api_integration/common/suites/get.ts
+++ b/x-pack/platform/test/saved_object_api_integration/common/suites/get.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { Agent as SuperTestAgent } from 'supertest';
+import { getTestDataLoader, SPACE_1, SPACE_2 } from '../../../common/lib/test_data_loader';
 import { SAVED_OBJECT_TEST_CASES as CASES } from '../lib/saved_object_test_cases';
 import { SPACES } from '../lib/spaces';
 import {
@@ -14,7 +14,8 @@ import {
   getUrlPrefix,
   getTestTitle,
 } from '../lib/saved_object_test_utils';
-import { ExpectResponseBody, TestCase, TestDefinition, TestSuite } from '../lib/types';
+import type { ExpectResponseBody, TestCase, TestDefinition, TestSuite } from '../lib/types';
+import type { FtrProviderContext } from '../ftr_provider_context';
 
 export interface GetTestDefinition extends TestDefinition {
   request: { type: string; id: string };
@@ -25,7 +26,9 @@ export type GetTestCase = TestCase;
 const DOES_NOT_EXIST = Object.freeze({ type: 'dashboard', id: 'does-not-exist' });
 export const TEST_CASES: Record<string, GetTestCase> = Object.freeze({ ...CASES, DOES_NOT_EXIST });
 
-export function getTestSuiteFactory(esArchiver: any, supertest: SuperTestAgent) {
+export function getTestSuiteFactory(context: FtrProviderContext) {
+  const testDataLoader = getTestDataLoader(context);
+  const supertest = context.getService('supertestWithoutAuth');
   const expectSavedObjectForbidden = expectResponses.forbiddenTypes('get');
   const expectResponseBody =
     (testCase: GetTestCase): ExpectResponseBody =>
@@ -65,16 +68,30 @@ export function getTestSuiteFactory(esArchiver: any, supertest: SuperTestAgent) 
       const { user, spaceId = SPACES.DEFAULT.spaceId, tests } = definition;
 
       describeFn(description, () => {
-        before(() =>
-          esArchiver.load(
-            'x-pack/platform/test/saved_object_api_integration/common/fixtures/es_archiver/saved_objects/spaces'
-          )
-        );
-        after(() =>
-          esArchiver.unload(
-            'x-pack/platform/test/saved_object_api_integration/common/fixtures/es_archiver/saved_objects/spaces'
-          )
-        );
+        before(async () => {
+          await testDataLoader.createFtrSpaces();
+          await testDataLoader.createFtrSavedObjectsData([
+            {
+              spaceName: null,
+              dataUrl:
+                'x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/default_space.json',
+            },
+            {
+              spaceName: SPACE_1.id,
+              dataUrl:
+                'x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/space_1.json',
+            },
+            {
+              spaceName: SPACE_2.id,
+              dataUrl:
+                'x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/space_2.json',
+            },
+          ]);
+        });
+        after(async () => {
+          await testDataLoader.deleteFtrSavedObjectsData();
+          await testDataLoader.deleteFtrSpaces();
+        });
 
         for (const test of tests) {
           it(`should return ${test.responseStatusCode} ${test.title}`, async () => {

--- a/x-pack/platform/test/saved_object_api_integration/common/suites/import.ts
+++ b/x-pack/platform/test/saved_object_api_integration/common/suites/import.ts
@@ -6,13 +6,13 @@
  */
 
 import expect from '@kbn/expect';
-import { Agent as SuperTestAgent } from 'supertest';
-import type { Client } from '@elastic/elasticsearch';
 import type { SavedObjectReference } from '@kbn/core/server';
+import { getTestDataLoader, SPACE_1, SPACE_2 } from '../../../common/lib/test_data_loader';
 import { SAVED_OBJECT_TEST_CASES as CASES } from '../lib/saved_object_test_cases';
 import { SPACES } from '../lib/spaces';
 import { expectResponses, getUrlPrefix, getTestTitle } from '../lib/saved_object_test_utils';
-import { ExpectResponseBody, TestCase, TestDefinition, TestSuite } from '../lib/types';
+import type { ExpectResponseBody, TestCase, TestDefinition, TestSuite } from '../lib/types';
+import type { FtrProviderContext } from '../ftr_provider_context';
 
 export interface ImportTestDefinition extends TestDefinition {
   request: Array<{
@@ -121,7 +121,10 @@ export const importTestCaseFailures = {
     condition !== false ? { failureType: 'missing_references' } : {},
 };
 
-export function importTestSuiteFactory(es: Client, esArchiver: any, supertest: SuperTestAgent) {
+export function importTestSuiteFactory(context: FtrProviderContext) {
+  const testDataLoader = getTestDataLoader(context);
+  const supertest = context.getService('supertestWithoutAuth');
+  const es = context.getService('es');
   const expectSavedObjectForbidden = (action: string, typeOrTypes: string | string[]) =>
     expectResponses.forbiddenTypes(action)(typeOrTypes);
   const expectResponseBody =
@@ -285,16 +288,53 @@ export function importTestSuiteFactory(es: Client, esArchiver: any, supertest: S
       const { user, spaceId = SPACES.DEFAULT.spaceId, tests } = definition;
 
       describeFn(description, () => {
-        before(() =>
-          esArchiver.load(
-            'x-pack/platform/test/saved_object_api_integration/common/fixtures/es_archiver/saved_objects/spaces'
-          )
-        );
-        after(() =>
-          esArchiver.unload(
-            'x-pack/platform/test/saved_object_api_integration/common/fixtures/es_archiver/saved_objects/spaces'
-          )
-        );
+        before(async () => {
+          await testDataLoader.createFtrSpaces();
+          await testDataLoader.createFtrSavedObjectsData([
+            {
+              spaceName: null,
+              dataUrl:
+                'x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/default_space.json',
+            },
+            {
+              spaceName: SPACE_1.id,
+              dataUrl:
+                'x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/space_1.json',
+            },
+            {
+              spaceName: SPACE_2.id,
+              dataUrl:
+                'x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/space_2.json',
+            },
+          ]);
+          await testDataLoader.createLegacyUrlAliases([
+            {
+              spaceName: null,
+              dataUrl:
+                'x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/legacy_url_aliases_all.json',
+            },
+            {
+              spaceName: SPACE_1.id,
+              dataUrl:
+                'x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/legacy_url_aliases_all.json',
+            },
+            {
+              spaceName: 'space_x',
+              dataUrl:
+                'x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/legacy_url_aliases.json',
+            },
+            {
+              spaceName: 'space_y',
+              dataUrl:
+                'x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/legacy_url_aliases.json',
+              disabled: true,
+            },
+          ]);
+        });
+        after(async () => {
+          await testDataLoader.deleteAllSavedObjectsFromKibanaIndex();
+          await testDataLoader.deleteFtrSpaces();
+        });
 
         const attrs = { attributes: { [NEW_ATTRIBUTE_KEY]: NEW_ATTRIBUTE_VAL } };
 

--- a/x-pack/platform/test/saved_object_api_integration/common/suites/resolve.ts
+++ b/x-pack/platform/test/saved_object_api_integration/common/suites/resolve.ts
@@ -6,7 +6,7 @@
  */
 
 import expect from '@kbn/expect';
-import { Agent as SuperTestAgent } from 'supertest';
+import { getTestDataLoader, SPACE_1, SPACE_2 } from '../../../common/lib/test_data_loader';
 import { SAVED_OBJECT_TEST_CASES as CASES } from '../lib/saved_object_test_cases';
 import { SPACES } from '../lib/spaces';
 import {
@@ -15,7 +15,8 @@ import {
   getUrlPrefix,
   getTestTitle,
 } from '../lib/saved_object_test_utils';
-import { ExpectResponseBody, TestCase, TestDefinition, TestSuite } from '../lib/types';
+import type { ExpectResponseBody, TestCase, TestDefinition, TestSuite } from '../lib/types';
+import type { FtrProviderContext } from '../ftr_provider_context';
 
 const {
   DEFAULT: { spaceId: DEFAULT_SPACE_ID },
@@ -70,7 +71,9 @@ export const TEST_CASES = Object.freeze({
   HIDDEN: CASES.HIDDEN,
 });
 
-export function resolveTestSuiteFactory(esArchiver: any, supertest: SuperTestAgent) {
+export function resolveTestSuiteFactory(context: FtrProviderContext) {
+  const testDataLoader = getTestDataLoader(context);
+  const supertest = context.getService('supertestWithoutAuth');
   const expectSavedObjectForbidden = expectResponses.forbiddenTypes('bulk_get');
   const expectResponseBody =
     (testCase: ResolveTestCase): ExpectResponseBody =>
@@ -119,16 +122,53 @@ export function resolveTestSuiteFactory(esArchiver: any, supertest: SuperTestAge
       const { user, spaceId = SPACES.DEFAULT.spaceId, tests } = definition;
 
       describeFn(description, () => {
-        before(() =>
-          esArchiver.load(
-            'x-pack/platform/test/saved_object_api_integration/common/fixtures/es_archiver/saved_objects/spaces'
-          )
-        );
-        after(() =>
-          esArchiver.unload(
-            'x-pack/platform/test/saved_object_api_integration/common/fixtures/es_archiver/saved_objects/spaces'
-          )
-        );
+        before(async () => {
+          await testDataLoader.createFtrSpaces();
+          await testDataLoader.createFtrSavedObjectsData([
+            {
+              spaceName: null,
+              dataUrl:
+                'x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/default_space.json',
+            },
+            {
+              spaceName: SPACE_1.id,
+              dataUrl:
+                'x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/space_1.json',
+            },
+            {
+              spaceName: SPACE_2.id,
+              dataUrl:
+                'x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/space_2.json',
+            },
+          ]);
+          await testDataLoader.createLegacyUrlAliases([
+            {
+              spaceName: null,
+              dataUrl:
+                'x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/legacy_url_aliases_all.json',
+            },
+            {
+              spaceName: SPACE_1.id,
+              dataUrl:
+                'x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/legacy_url_aliases_all.json',
+            },
+            {
+              spaceName: 'space_x',
+              dataUrl:
+                'x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/legacy_url_aliases.json',
+            },
+            {
+              spaceName: 'space_y',
+              dataUrl:
+                'x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/legacy_url_aliases.json',
+              disabled: true,
+            },
+          ]);
+        });
+        after(async () => {
+          await testDataLoader.deleteAllSavedObjectsFromKibanaIndex();
+          await testDataLoader.deleteFtrSpaces();
+        });
 
         for (const test of tests) {
           it(`should return ${test.responseStatusCode} ${test.title}`, async () => {

--- a/x-pack/platform/test/saved_object_api_integration/common/suites/resolve_import_errors.ts
+++ b/x-pack/platform/test/saved_object_api_integration/common/suites/resolve_import_errors.ts
@@ -6,13 +6,13 @@
  */
 
 import expect from '@kbn/expect';
-import { Agent as SuperTestAgent } from 'supertest';
-import type { Client } from '@elastic/elasticsearch';
 import type { SavedObjectReference, SavedObjectsImportRetry } from '@kbn/core/server';
+import { getTestDataLoader, SPACE_1, SPACE_2 } from '../../../common/lib/test_data_loader';
 import { SAVED_OBJECT_TEST_CASES as CASES } from '../lib/saved_object_test_cases';
 import { SPACES } from '../lib/spaces';
 import { expectResponses, getUrlPrefix, getTestTitle } from '../lib/saved_object_test_utils';
-import { ExpectResponseBody, TestCase, TestDefinition, TestSuite } from '../lib/types';
+import type { ExpectResponseBody, TestCase, TestDefinition, TestSuite } from '../lib/types';
+import type { FtrProviderContext } from '../ftr_provider_context';
 
 export interface ResolveImportErrorsTestDefinition extends TestDefinition {
   request: {
@@ -194,11 +194,10 @@ export const resolveImportErrorsTestCaseFailures = {
     condition !== false ? { failureType: 'conflict' } : {},
 };
 
-export function resolveImportErrorsTestSuiteFactory(
-  es: Client,
-  esArchiver: any,
-  supertest: SuperTestAgent
-) {
+export function resolveImportErrorsTestSuiteFactory(context: FtrProviderContext) {
+  const testDataLoader = getTestDataLoader(context);
+  const supertest = context.getService('supertestWithoutAuth');
+  const es = context.getService('es');
   const expectSavedObjectForbidden = (action: string, typeOrTypes: string | string[]) =>
     expectResponses.forbiddenTypes(action)(typeOrTypes);
   const expectResponseBody =
@@ -352,16 +351,53 @@ export function resolveImportErrorsTestSuiteFactory(
       const { user, spaceId = SPACES.DEFAULT.spaceId, tests } = definition;
 
       describeFn(description, () => {
-        before(() =>
-          esArchiver.load(
-            'x-pack/platform/test/saved_object_api_integration/common/fixtures/es_archiver/saved_objects/spaces'
-          )
-        );
-        after(() =>
-          esArchiver.unload(
-            'x-pack/platform/test/saved_object_api_integration/common/fixtures/es_archiver/saved_objects/spaces'
-          )
-        );
+        before(async () => {
+          await testDataLoader.createFtrSpaces();
+          await testDataLoader.createFtrSavedObjectsData([
+            {
+              spaceName: null,
+              dataUrl:
+                'x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/default_space.json',
+            },
+            {
+              spaceName: SPACE_1.id,
+              dataUrl:
+                'x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/space_1.json',
+            },
+            {
+              spaceName: SPACE_2.id,
+              dataUrl:
+                'x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/space_2.json',
+            },
+          ]);
+          await testDataLoader.createLegacyUrlAliases([
+            {
+              spaceName: null,
+              dataUrl:
+                'x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/legacy_url_aliases_all.json',
+            },
+            {
+              spaceName: SPACE_1.id,
+              dataUrl:
+                'x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/legacy_url_aliases_all.json',
+            },
+            {
+              spaceName: 'space_x',
+              dataUrl:
+                'x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/legacy_url_aliases.json',
+            },
+            {
+              spaceName: 'space_y',
+              dataUrl:
+                'x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/legacy_url_aliases.json',
+              disabled: true,
+            },
+          ]);
+        });
+        after(async () => {
+          await testDataLoader.deleteAllSavedObjectsFromKibanaIndex();
+          await testDataLoader.deleteFtrSpaces();
+        });
 
         const attrs = { attributes: { [NEW_ATTRIBUTE_KEY]: NEW_ATTRIBUTE_VAL } };
 

--- a/x-pack/platform/test/saved_object_api_integration/common/suites/update.ts
+++ b/x-pack/platform/test/saved_object_api_integration/common/suites/update.ts
@@ -6,11 +6,12 @@
  */
 
 import expect from '@kbn/expect';
-import { Agent as SuperTestAgent } from 'supertest';
+import { getTestDataLoader, SPACE_1, SPACE_2 } from '../../../common/lib/test_data_loader';
 import { SAVED_OBJECT_TEST_CASES as CASES } from '../lib/saved_object_test_cases';
 import { SPACES } from '../lib/spaces';
 import { expectResponses, getUrlPrefix, getTestTitle } from '../lib/saved_object_test_utils';
-import { ExpectResponseBody, TestCase, TestDefinition, TestSuite } from '../lib/types';
+import type { ExpectResponseBody, TestCase, TestDefinition, TestSuite } from '../lib/types';
+import type { FtrProviderContext } from '../ftr_provider_context';
 
 export interface UpdateTestDefinition extends TestDefinition {
   request: { type: string; id: string; upsert?: boolean };
@@ -34,7 +35,9 @@ export const TEST_CASES: Record<string, UpdateTestCase> = Object.freeze({
 
 const createRequest = ({ type, id, upsert }: UpdateTestCase) => ({ type, id, upsert });
 
-export function updateTestSuiteFactory(esArchiver: any, supertest: SuperTestAgent) {
+export function updateTestSuiteFactory(context: FtrProviderContext) {
+  const testDataLoader = getTestDataLoader(context);
+  const supertest = context.getService('supertestWithoutAuth');
   const expectSavedObjectForbidden = expectResponses.forbiddenTypes('update');
   const expectResponseBody =
     (testCase: UpdateTestCase): ExpectResponseBody =>
@@ -76,16 +79,53 @@ export function updateTestSuiteFactory(esArchiver: any, supertest: SuperTestAgen
       const { user, spaceId = SPACES.DEFAULT.spaceId, tests } = definition;
 
       describeFn(description, () => {
-        before(() =>
-          esArchiver.load(
-            'x-pack/platform/test/saved_object_api_integration/common/fixtures/es_archiver/saved_objects/spaces'
-          )
-        );
-        after(() =>
-          esArchiver.unload(
-            'x-pack/platform/test/saved_object_api_integration/common/fixtures/es_archiver/saved_objects/spaces'
-          )
-        );
+        before(async () => {
+          await testDataLoader.createFtrSpaces();
+          await testDataLoader.createFtrSavedObjectsData([
+            {
+              spaceName: null,
+              dataUrl:
+                'x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/default_space.json',
+            },
+            {
+              spaceName: SPACE_1.id,
+              dataUrl:
+                'x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/space_1.json',
+            },
+            {
+              spaceName: SPACE_2.id,
+              dataUrl:
+                'x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/space_2.json',
+            },
+          ]);
+          await testDataLoader.createLegacyUrlAliases([
+            {
+              spaceName: null,
+              dataUrl:
+                'x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/legacy_url_aliases_all.json',
+            },
+            {
+              spaceName: SPACE_1.id,
+              dataUrl:
+                'x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/legacy_url_aliases_all.json',
+            },
+            {
+              spaceName: 'space_x',
+              dataUrl:
+                'x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/legacy_url_aliases.json',
+            },
+            {
+              spaceName: 'space_y',
+              dataUrl:
+                'x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/legacy_url_aliases.json',
+              disabled: true,
+            },
+          ]);
+        });
+        after(async () => {
+          await testDataLoader.deleteAllSavedObjectsFromKibanaIndex();
+          await testDataLoader.deleteFtrSpaces();
+        });
 
         for (const test of tests) {
           it(`should return ${test.responseStatusCode} ${test.title}`, async () => {

--- a/x-pack/platform/test/saved_object_api_integration/low-level/apis/bulk_update.ts
+++ b/x-pack/platform/test/saved_object_api_integration/low-level/apis/bulk_update.ts
@@ -14,12 +14,13 @@
 
 import expect from 'expect';
 import { getUrlPrefix } from '../../../alerting_api_integration/common/lib';
-import { FtrProviderContext } from '../../common/ftr_provider_context';
+import { getTestDataLoader, SPACE_1, SPACE_2 } from '../../../common/lib/test_data_loader';
+import type { FtrProviderContext } from '../../common/ftr_provider_context';
 
-export default function ({ getService }: FtrProviderContext) {
-  const supertest = getService('supertest');
-  const esArchiver = getService('esArchiver');
-  const es = getService('es');
+export default function (context: FtrProviderContext) {
+  const supertest = context.getService('supertest');
+  const es = context.getService('es');
+  const testDataLoader = getTestDataLoader(context);
 
   const defaultNamespace = 'default';
 
@@ -48,16 +49,30 @@ export default function ({ getService }: FtrProviderContext) {
   };
 
   describe('low-level saved object api integration', () => {
-    before(() =>
-      esArchiver.load(
-        'x-pack/platform/test/saved_object_api_integration/common/fixtures/es_archiver/saved_objects/spaces'
-      )
-    );
-    after(() =>
-      esArchiver.unload(
-        'x-pack/platform/test/saved_object_api_integration/common/fixtures/es_archiver/saved_objects/spaces'
-      )
-    );
+    before(async () => {
+      await testDataLoader.createFtrSpaces();
+      await testDataLoader.createFtrSavedObjectsData([
+        {
+          spaceName: null,
+          dataUrl:
+            'x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/default_space.json',
+        },
+        {
+          spaceName: SPACE_1.id,
+          dataUrl:
+            'x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/space_1.json',
+        },
+        {
+          spaceName: SPACE_2.id,
+          dataUrl:
+            'x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/space_2.json',
+        },
+      ]);
+    });
+    after(async () => {
+      await testDataLoader.deleteFtrSavedObjectsData();
+      await testDataLoader.deleteFtrSpaces();
+    });
 
     describe('with object namespace override', () => {
       describe('from the default space', () => {

--- a/x-pack/platform/test/saved_object_api_integration/security_and_spaces/apis/bulk_resolve.ts
+++ b/x-pack/platform/test/saved_object_api_integration/security_and_spaces/apis/bulk_resolve.ts
@@ -40,12 +40,9 @@ const createTestCases = (spaceId: string) => {
   return { normalTypes, hiddenType, allTypes };
 };
 
-export default function ({ getService }: FtrProviderContext) {
-  const supertest = getService('supertestWithoutAuth');
-  const esArchiver = getService('esArchiver');
-
+export default function (context: FtrProviderContext) {
   const { addTests, createTestDefinitions, expectSavedObjectForbidden } =
-    bulkResolveTestSuiteFactory(esArchiver, supertest);
+    bulkResolveTestSuiteFactory(context);
   const createTests = (spaceId: string) => {
     const { normalTypes, hiddenType, allTypes } = createTestCases(spaceId);
     // use singleRequest to reduce execution time and/or test combined cases

--- a/x-pack/platform/test/saved_object_api_integration/security_and_spaces/apis/bulk_update.ts
+++ b/x-pack/platform/test/saved_object_api_integration/security_and_spaces/apis/bulk_update.ts
@@ -61,12 +61,9 @@ const createTestCases = (spaceId: string) => {
   return { normalTypes, hiddenType, normalAndHidden, withObjectNamespaces };
 };
 
-export default function ({ getService }: FtrProviderContext) {
-  const supertest = getService('supertestWithoutAuth');
-  const esArchiver = getService('esArchiver');
-
+export default function (context: FtrProviderContext) {
   const { addTests, createTestDefinitions, expectSavedObjectForbidden } =
-    bulkUpdateTestSuiteFactory(esArchiver, supertest);
+    bulkUpdateTestSuiteFactory(context);
   const createTests = (spaceId: string) => {
     const { normalTypes, hiddenType, normalAndHidden, withObjectNamespaces } =
       createTestCases(spaceId);

--- a/x-pack/platform/test/saved_object_api_integration/security_and_spaces/apis/create.ts
+++ b/x-pack/platform/test/saved_object_api_integration/security_and_spaces/apis/create.ts
@@ -88,11 +88,8 @@ const createTestCases = (overwrite: boolean, spaceId: string) => {
   return { normalTypes, badRequests, crossNamespace, allTypes };
 };
 
-export default function ({ getService }: FtrProviderContext) {
-  const supertest = getService('supertestWithoutAuth');
-  const esArchiver = getService('esArchiver');
-
-  const { addTests, createTestDefinitions } = createTestSuiteFactory(esArchiver, supertest);
+export default function (context: FtrProviderContext) {
+  const { addTests, createTestDefinitions } = createTestSuiteFactory(context);
   const createTests = (overwrite: boolean, spaceId: string, user: TestUser) => {
     const { normalTypes, badRequests, crossNamespace, allTypes } = createTestCases(
       overwrite,

--- a/x-pack/platform/test/saved_object_api_integration/security_and_spaces/apis/delete.ts
+++ b/x-pack/platform/test/saved_object_api_integration/security_and_spaces/apis/delete.ts
@@ -60,12 +60,8 @@ const createTestCases = (spaceId: string) => {
   return { normalTypes, hiddenType, allTypes };
 };
 
-export default function ({ getService }: FtrProviderContext) {
-  const supertest = getService('supertestWithoutAuth');
-  const esArchiver = getService('esArchiver');
-  const es = getService('es');
-
-  const { addTests, createTestDefinitions } = deleteTestSuiteFactory(es, esArchiver, supertest);
+export default function (context: FtrProviderContext) {
+  const { addTests, createTestDefinitions } = deleteTestSuiteFactory(context);
   const createTests = (spaceId: string) => {
     const { normalTypes, hiddenType, allTypes } = createTestCases(spaceId);
     return {

--- a/x-pack/platform/test/saved_object_api_integration/security_and_spaces/apis/export.ts
+++ b/x-pack/platform/test/saved_object_api_integration/security_and_spaces/apis/export.ts
@@ -37,11 +37,8 @@ const createTestCases = (spaceId: string) => {
   return { exportableObjects, exportableTypes, nonExportableObjectsAndTypes, allObjectsAndTypes };
 };
 
-export default function ({ getService }: FtrProviderContext) {
-  const supertest = getService('supertestWithoutAuth');
-  const esArchiver = getService('esArchiver');
-
-  const { addTests, createTestDefinitions } = exportTestSuiteFactory(esArchiver, supertest);
+export default function (context: FtrProviderContext) {
+  const { addTests, createTestDefinitions } = exportTestSuiteFactory(context);
   const createTests = (spaceId: string) => {
     const { exportableObjects, exportableTypes, nonExportableObjectsAndTypes, allObjectsAndTypes } =
       createTestCases(spaceId);

--- a/x-pack/platform/test/saved_object_api_integration/security_and_spaces/apis/find.ts
+++ b/x-pack/platform/test/saved_object_api_integration/security_and_spaces/apis/find.ts
@@ -47,11 +47,8 @@ const createTestCases = (currentSpace: string, crossSpaceSearch?: string[]) => {
   };
 };
 
-export default function ({ getService }: FtrProviderContext) {
-  const supertest = getService('supertestWithoutAuth');
-  const esArchiver = getService('esArchiver');
-
-  const { addTests, createTestDefinitions } = findTestSuiteFactory(esArchiver, supertest);
+export default function (context: FtrProviderContext) {
+  const { addTests, createTestDefinitions } = findTestSuiteFactory(context);
   const createTests = (spaceId: string, user: TestUser) => {
     const currentSpaceCases = createTestCases(spaceId);
 

--- a/x-pack/platform/test/saved_object_api_integration/security_and_spaces/apis/get.ts
+++ b/x-pack/platform/test/saved_object_api_integration/security_and_spaces/apis/get.ts
@@ -49,11 +49,8 @@ const createTestCases = (spaceId: string) => {
   return { normalTypes, hiddenType, allTypes };
 };
 
-export default function ({ getService }: FtrProviderContext) {
-  const supertest = getService('supertestWithoutAuth');
-  const esArchiver = getService('esArchiver');
-
-  const { addTests, createTestDefinitions } = getTestSuiteFactory(esArchiver, supertest);
+export default function (context: FtrProviderContext) {
+  const { addTests, createTestDefinitions } = getTestSuiteFactory(context);
   const createTests = (spaceId: string) => {
     const { normalTypes, hiddenType, allTypes } = createTestCases(spaceId);
     // use singleRequest to reduce execution time and/or test combined cases

--- a/x-pack/platform/test/saved_object_api_integration/security_and_spaces/apis/import.ts
+++ b/x-pack/platform/test/saved_object_api_integration/security_and_spaces/apis/import.ts
@@ -138,16 +138,9 @@ const createTestCases = (overwrite: boolean, spaceId: string) => {
   };
 };
 
-export default function ({ getService }: FtrProviderContext) {
-  const supertest = getService('supertestWithoutAuth');
-  const esArchiver = getService('esArchiver');
-  const es = getService('es');
-
-  const { addTests, createTestDefinitions, expectSavedObjectForbidden } = importTestSuiteFactory(
-    es,
-    esArchiver,
-    supertest
-  );
+export default function (context: FtrProviderContext) {
+  const { addTests, createTestDefinitions, expectSavedObjectForbidden } =
+    importTestSuiteFactory(context);
   const createTests = (overwrite: boolean, createNewCopies: boolean, spaceId: string) => {
     const singleRequest = true;
 

--- a/x-pack/platform/test/saved_object_api_integration/security_and_spaces/apis/resolve.ts
+++ b/x-pack/platform/test/saved_object_api_integration/security_and_spaces/apis/resolve.ts
@@ -40,11 +40,8 @@ const createTestCases = (spaceId: string) => {
   return { normalTypes, hiddenType, allTypes };
 };
 
-export default function ({ getService }: FtrProviderContext) {
-  const supertest = getService('supertestWithoutAuth');
-  const esArchiver = getService('esArchiver');
-
-  const { addTests, createTestDefinitions } = resolveTestSuiteFactory(esArchiver, supertest);
+export default function (context: FtrProviderContext) {
+  const { addTests, createTestDefinitions } = resolveTestSuiteFactory(context);
   const createTests = (spaceId: string) => {
     const { normalTypes, hiddenType, allTypes } = createTestCases(spaceId);
     // use singleRequest to reduce execution time and/or test combined cases

--- a/x-pack/platform/test/saved_object_api_integration/security_and_spaces/apis/resolve_import_errors.ts
+++ b/x-pack/platform/test/saved_object_api_integration/security_and_spaces/apis/resolve_import_errors.ts
@@ -114,13 +114,9 @@ const createTestCases = (overwrite: boolean, spaceId: string) => {
   return { group1Importable, group1NonImportable, group1All, group2, refOrigins };
 };
 
-export default function ({ getService }: FtrProviderContext) {
-  const supertest = getService('supertestWithoutAuth');
-  const esArchiver = getService('esArchiver');
-  const es = getService('es');
-
+export default function (context: FtrProviderContext) {
   const { addTests, createTestDefinitions, expectSavedObjectForbidden } =
-    resolveImportErrorsTestSuiteFactory(es, esArchiver, supertest);
+    resolveImportErrorsTestSuiteFactory(context);
   const createTests = (overwrite: boolean, createNewCopies: boolean, spaceId: string) => {
     // use singleRequest to reduce execution time and/or test combined cases
     const singleRequest = true;

--- a/x-pack/platform/test/saved_object_api_integration/security_and_spaces/apis/update.ts
+++ b/x-pack/platform/test/saved_object_api_integration/security_and_spaces/apis/update.ts
@@ -51,11 +51,8 @@ const createTestCases = (spaceId: string) => {
   return { normalTypes, hiddenType, allTypes };
 };
 
-export default function ({ getService }: FtrProviderContext) {
-  const supertest = getService('supertestWithoutAuth');
-  const esArchiver = getService('esArchiver');
-
-  const { addTests, createTestDefinitions } = updateTestSuiteFactory(esArchiver, supertest);
+export default function (context: FtrProviderContext) {
+  const { addTests, createTestDefinitions } = updateTestSuiteFactory(context);
   const createTests = (spaceId: string) => {
     const { normalTypes, hiddenType, allTypes } = createTestCases(spaceId);
     return {

--- a/x-pack/platform/test/saved_object_api_integration/spaces_only/apis/bulk_resolve.ts
+++ b/x-pack/platform/test/saved_object_api_integration/spaces_only/apis/bulk_resolve.ts
@@ -31,11 +31,8 @@ const createTestCases = (spaceId: string) => [
   { ...CASES.DOES_NOT_EXIST, ...fail404() },
 ];
 
-export default function ({ getService }: FtrProviderContext) {
-  const supertest = getService('supertest');
-  const esArchiver = getService('esArchiver');
-
-  const { addTests, createTestDefinitions } = bulkResolveTestSuiteFactory(esArchiver, supertest);
+export default function (context: FtrProviderContext) {
+  const { addTests, createTestDefinitions } = bulkResolveTestSuiteFactory(context);
   const createTests = (spaceId: string) => {
     const testCases = createTestCases(spaceId);
     return createTestDefinitions(testCases, false, { spaceId, singleRequest: true });

--- a/x-pack/platform/test/saved_object_api_integration/spaces_only/apis/bulk_update.ts
+++ b/x-pack/platform/test/saved_object_api_integration/spaces_only/apis/bulk_update.ts
@@ -56,11 +56,8 @@ const createTestCases = (spaceId: string) => {
   return { normal, withObjectNamespaces };
 };
 
-export default function ({ getService }: FtrProviderContext) {
-  const supertest = getService('supertest');
-  const esArchiver = getService('esArchiver');
-
-  const { addTests, createTestDefinitions } = bulkUpdateTestSuiteFactory(esArchiver, supertest);
+export default function (context: FtrProviderContext) {
+  const { addTests, createTestDefinitions } = bulkUpdateTestSuiteFactory(context);
   const createTests = (spaceId: string) => {
     const { normal, withObjectNamespaces } = createTestCases(spaceId);
     return [

--- a/x-pack/platform/test/saved_object_api_integration/spaces_only/apis/create.ts
+++ b/x-pack/platform/test/saved_object_api_integration/spaces_only/apis/create.ts
@@ -77,11 +77,8 @@ const createTestCases = (overwrite: boolean, spaceId: string) => {
   ];
 };
 
-export default function ({ getService }: FtrProviderContext) {
-  const supertest = getService('supertestWithoutAuth');
-  const esArchiver = getService('esArchiver');
-
-  const { addTests, createTestDefinitions } = createTestSuiteFactory(esArchiver, supertest);
+export default function (context: FtrProviderContext) {
+  const { addTests, createTestDefinitions } = createTestSuiteFactory(context);
   const createTests = (overwrite: boolean, spaceId: string) => {
     const testCases = createTestCases(overwrite, spaceId);
     return createTestDefinitions(testCases, false, overwrite, { spaceId });

--- a/x-pack/platform/test/saved_object_api_integration/spaces_only/apis/delete.ts
+++ b/x-pack/platform/test/saved_object_api_integration/spaces_only/apis/delete.ts
@@ -51,12 +51,8 @@ const createTestCases = (spaceId: string) => [
   { ...CASES.DOES_NOT_EXIST, ...fail404() },
 ];
 
-export default function ({ getService }: FtrProviderContext) {
-  const supertest = getService('supertest');
-  const esArchiver = getService('esArchiver');
-  const es = getService('es');
-
-  const { addTests, createTestDefinitions } = deleteTestSuiteFactory(es, esArchiver, supertest);
+export default function (context: FtrProviderContext) {
+  const { addTests, createTestDefinitions } = deleteTestSuiteFactory(context);
   const createTests = (spaceId: string) => {
     const testCases = createTestCases(spaceId);
     return createTestDefinitions(testCases, false, { spaceId });

--- a/x-pack/platform/test/saved_object_api_integration/spaces_only/apis/export.ts
+++ b/x-pack/platform/test/saved_object_api_integration/spaces_only/apis/export.ts
@@ -14,11 +14,8 @@ const createTestCases = (spaceId: string) => {
   return Object.values(cases);
 };
 
-export default function ({ getService }: FtrProviderContext) {
-  const supertest = getService('supertest');
-  const esArchiver = getService('esArchiver');
-
-  const { addTests, createTestDefinitions } = exportTestSuiteFactory(esArchiver, supertest);
+export default function (context: FtrProviderContext) {
+  const { addTests, createTestDefinitions } = exportTestSuiteFactory(context);
   const createTests = (spaceId: string) => {
     const testCases = createTestCases(spaceId);
     return createTestDefinitions(testCases, false);

--- a/x-pack/platform/test/saved_object_api_integration/spaces_only/apis/find.ts
+++ b/x-pack/platform/test/saved_object_api_integration/spaces_only/apis/find.ts
@@ -21,11 +21,8 @@ const createTestCases = (spaceId: string, crossSpaceSearch?: string[]) => {
   return Object.values(cases);
 };
 
-export default function ({ getService }: FtrProviderContext) {
-  const supertest = getService('supertest');
-  const esArchiver = getService('esArchiver');
-
-  const { addTests, createTestDefinitions } = findTestSuiteFactory(esArchiver, supertest);
+export default function (context: FtrProviderContext) {
+  const { addTests, createTestDefinitions } = findTestSuiteFactory(context);
   const createTests = (spaceId: string, crossSpaceSearch?: string[]) => {
     const testCases = createTestCases(spaceId, crossSpaceSearch);
     return createTestDefinitions(testCases, false);

--- a/x-pack/platform/test/saved_object_api_integration/spaces_only/apis/get.ts
+++ b/x-pack/platform/test/saved_object_api_integration/spaces_only/apis/get.ts
@@ -40,11 +40,8 @@ const createTestCases = (spaceId: string) => [
   { ...CASES.DOES_NOT_EXIST, ...fail404() },
 ];
 
-export default function ({ getService }: FtrProviderContext) {
-  const supertest = getService('supertest');
-  const esArchiver = getService('esArchiver');
-
-  const { addTests, createTestDefinitions } = getTestSuiteFactory(esArchiver, supertest);
+export default function (context: FtrProviderContext) {
+  const { addTests, createTestDefinitions } = getTestSuiteFactory(context);
   const createTests = (spaceId: string) => {
     const testCases = createTestCases(spaceId);
     return createTestDefinitions(testCases, false, { spaceId });

--- a/x-pack/platform/test/saved_object_api_integration/spaces_only/apis/import.ts
+++ b/x-pack/platform/test/saved_object_api_integration/spaces_only/apis/import.ts
@@ -120,12 +120,8 @@ const createTestCases = (overwrite: boolean, spaceId: string) => {
   return { group1, group2, group3, group4, refOrigins };
 };
 
-export default function ({ getService }: FtrProviderContext) {
-  const supertest = getService('supertest');
-  const esArchiver = getService('esArchiver');
-  const es = getService('es');
-
-  const { addTests, createTestDefinitions } = importTestSuiteFactory(es, esArchiver, supertest);
+export default function (context: FtrProviderContext) {
+  const { addTests, createTestDefinitions } = importTestSuiteFactory(context);
   const createTests = (overwrite: boolean, createNewCopies: boolean, spaceId: string) => {
     const singleRequest = true;
     if (createNewCopies) {

--- a/x-pack/platform/test/saved_object_api_integration/spaces_only/apis/resolve.ts
+++ b/x-pack/platform/test/saved_object_api_integration/spaces_only/apis/resolve.ts
@@ -31,11 +31,8 @@ const createTestCases = (spaceId: string) => [
   { ...CASES.DOES_NOT_EXIST, ...fail404() },
 ];
 
-export default function ({ getService }: FtrProviderContext) {
-  const supertest = getService('supertest');
-  const esArchiver = getService('esArchiver');
-
-  const { addTests, createTestDefinitions } = resolveTestSuiteFactory(esArchiver, supertest);
+export default function (context: FtrProviderContext) {
+  const { addTests, createTestDefinitions } = resolveTestSuiteFactory(context);
   const createTests = (spaceId: string) => {
     const testCases = createTestCases(spaceId);
     return createTestDefinitions(testCases, false, { spaceId });

--- a/x-pack/platform/test/saved_object_api_integration/spaces_only/apis/resolve_import_errors.ts
+++ b/x-pack/platform/test/saved_object_api_integration/spaces_only/apis/resolve_import_errors.ts
@@ -107,16 +107,8 @@ const createTestCases = (overwrite: boolean, spaceId: string) => {
   ];
 };
 
-export default function ({ getService }: FtrProviderContext) {
-  const supertest = getService('supertest');
-  const esArchiver = getService('esArchiver');
-  const es = getService('es');
-
-  const { addTests, createTestDefinitions } = resolveImportErrorsTestSuiteFactory(
-    es,
-    esArchiver,
-    supertest
-  );
+export default function (context: FtrProviderContext) {
+  const { addTests, createTestDefinitions } = resolveImportErrorsTestSuiteFactory(context);
   const createTests = (overwrite: boolean, createNewCopies: boolean, spaceId: string) => {
     const singleRequest = true;
     if (createNewCopies) {

--- a/x-pack/platform/test/saved_object_api_integration/spaces_only/apis/update.ts
+++ b/x-pack/platform/test/saved_object_api_integration/spaces_only/apis/update.ts
@@ -42,11 +42,8 @@ const createTestCases = (spaceId: string) => [
   { ...CASES.DOES_NOT_EXIST, ...fail404() },
 ];
 
-export default function ({ getService }: FtrProviderContext) {
-  const supertest = getService('supertest');
-  const esArchiver = getService('esArchiver');
-
-  const { addTests, createTestDefinitions } = updateTestSuiteFactory(esArchiver, supertest);
+export default function (context: FtrProviderContext) {
+  const { addTests, createTestDefinitions } = updateTestSuiteFactory(context);
   const createTests = (spaceId: string) => {
     const testCases = createTestCases(spaceId);
     return createTestDefinitions(testCases, false);

--- a/x-pack/platform/test/saved_object_api_integration/user_profiles/apis/bulk_update.ts
+++ b/x-pack/platform/test/saved_object_api_integration/user_profiles/apis/bulk_update.ts
@@ -5,26 +5,41 @@
  * 2.0.
  */
 import expect from '@kbn/expect';
-import { FtrProviderContext } from '../../common/ftr_provider_context';
+import { getTestDataLoader, SPACE_1, SPACE_2 } from '../../../common/lib/test_data_loader';
+import type { FtrProviderContext } from '../../common/ftr_provider_context';
 import { loginAsInteractiveUser } from '../helpers';
 import { TEST_CASES } from '../../common/suites/create';
 import { AUTHENTICATION } from '../../common/lib/authentication';
 
 export default function ({ getService }: FtrProviderContext) {
   const supertest = getService('supertestWithoutAuth');
-  const esArchiver = getService('esArchiver');
+  const testDataLoader = getTestDataLoader({ getService });
 
   describe('bulk_update', function () {
     before(async () => {
-      await esArchiver.load(
-        'x-pack/platform/test/saved_object_api_integration/common/fixtures/es_archiver/saved_objects/spaces'
-      );
+      await testDataLoader.createFtrSpaces();
+      await testDataLoader.createFtrSavedObjectsData([
+        {
+          spaceName: null,
+          dataUrl:
+            'x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/default_space.json',
+        },
+        {
+          spaceName: SPACE_1.id,
+          dataUrl:
+            'x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/space_1.json',
+        },
+        {
+          spaceName: SPACE_2.id,
+          dataUrl:
+            'x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/space_2.json',
+        },
+      ]);
     });
 
     after(async () => {
-      await esArchiver.unload(
-        'x-pack/platform/test/saved_object_api_integration/common/fixtures/es_archiver/saved_objects/spaces'
-      );
+      await testDataLoader.deleteFtrSavedObjectsData();
+      await testDataLoader.deleteFtrSpaces();
     });
 
     it('updates updated_by with profile_id, created_by is untouched', async () => {

--- a/x-pack/platform/test/saved_object_api_integration/user_profiles/apis/update.ts
+++ b/x-pack/platform/test/saved_object_api_integration/user_profiles/apis/update.ts
@@ -5,26 +5,41 @@
  * 2.0.
  */
 import expect from '@kbn/expect';
-import { FtrProviderContext } from '../../common/ftr_provider_context';
+import { getTestDataLoader, SPACE_1, SPACE_2 } from '../../../common/lib/test_data_loader';
+import type { FtrProviderContext } from '../../common/ftr_provider_context';
 import { loginAsInteractiveUser } from '../helpers';
 import { TEST_CASES } from '../../common/suites/create';
 import { AUTHENTICATION } from '../../common/lib/authentication';
 
 export default function ({ getService }: FtrProviderContext) {
   const supertest = getService('supertestWithoutAuth');
-  const esArchiver = getService('esArchiver');
+  const testDataLoader = getTestDataLoader({ getService });
 
   describe('update', function () {
     before(async () => {
-      await esArchiver.load(
-        'x-pack/platform/test/saved_object_api_integration/common/fixtures/es_archiver/saved_objects/spaces'
-      );
+      await testDataLoader.createFtrSpaces();
+      await testDataLoader.createFtrSavedObjectsData([
+        {
+          spaceName: null,
+          dataUrl:
+            'x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/default_space.json',
+        },
+        {
+          spaceName: SPACE_1.id,
+          dataUrl:
+            'x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/space_1.json',
+        },
+        {
+          spaceName: SPACE_2.id,
+          dataUrl:
+            'x-pack/platform/test/saved_object_api_integration/common/fixtures/kbn_archiver/space_2.json',
+        },
+      ]);
     });
 
     after(async () => {
-      await esArchiver.unload(
-        'x-pack/platform/test/saved_object_api_integration/common/fixtures/es_archiver/saved_objects/spaces'
-      );
+      await testDataLoader.deleteFtrSavedObjectsData();
+      await testDataLoader.deleteFtrSpaces();
     });
 
     it('updates updated_by with profile_id, created_by is untouched', async () => {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Migrate SO tests from es-archiver to kbn-archiver (#261605)](https://github.com/elastic/kibana/pull/261605)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Larry Gregory","email":"larry.gregory@elastic.co"},"sourceCommit":{"committedDate":"2026-04-09T21:59:51Z","message":"Migrate SO tests from es-archiver to kbn-archiver (#261605)\n\nReplaces our usage of es-archiver with kbn-archiver within Saved Objects\nAPI tests.\n\nPart of https://github.com/elastic/kibana/issues/161497","sha":"ef52c4ae9b0605f7b62840b2ebe81c22165e37f3","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["chore","Team:Security","release_note:skip","backport:all-open","v9.4.0","v9.3.4","v9.2.9"],"title":"Migrate SO tests from es-archiver to kbn-archiver","number":261605,"url":"https://github.com/elastic/kibana/pull/261605","mergeCommit":{"message":"Migrate SO tests from es-archiver to kbn-archiver (#261605)\n\nReplaces our usage of es-archiver with kbn-archiver within Saved Objects\nAPI tests.\n\nPart of https://github.com/elastic/kibana/issues/161497","sha":"ef52c4ae9b0605f7b62840b2ebe81c22165e37f3"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/261605","number":261605,"mergeCommit":{"message":"Migrate SO tests from es-archiver to kbn-archiver (#261605)\n\nReplaces our usage of es-archiver with kbn-archiver within Saved Objects\nAPI tests.\n\nPart of https://github.com/elastic/kibana/issues/161497","sha":"ef52c4ae9b0605f7b62840b2ebe81c22165e37f3"}},{"branch":"9.3","label":"v9.3.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/262393","number":262393,"state":"MERGED","mergeCommit":{"sha":"6d1724d00c5872e1c709c47be879e9a45e2e10e6","message":"[9.3] Migrate SO tests from es-archiver to kbn-archiver (#261605) (#262393)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.3`:\n- [Migrate SO tests from es-archiver to kbn-archiver\n(#261605)](https://github.com/elastic/kibana/pull/261605)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Larry Gregory <larry.gregory@elastic.co>"}},{"branch":"9.2","label":"v9.2.9","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/262392","number":262392,"state":"MERGED","mergeCommit":{"sha":"b7df9aeb52488493c87997649426061a9277a62e","message":"[9.2] Migrate SO tests from es-archiver to kbn-archiver (#261605) (#262392)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.2`:\n- [Migrate SO tests from es-archiver to kbn-archiver\n(#261605)](https://github.com/elastic/kibana/pull/261605)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Larry Gregory <larry.gregory@elastic.co>"}}]}] BACKPORT-->