### PR TITLE
Serverless artifacts build - enforce devenv recreation

### DIFF
--- a/.buildkite/scripts/steps/artifacts/docker_image.sh
+++ b/.buildkite/scripts/steps/artifacts/docker_image.sh
@@ -215,6 +215,8 @@ steps:
         REMOTE_SERVICE_CONFIG: https://raw.githubusercontent.com/elastic/serverless-gitops/main/gen/gpctl/kibana/dev.yaml
         GPCTL_PROMOTE_DRY_RUN: ${DRY_RUN:-false}
         CHANGE_WINDOW_OVERRIDE: true
+        DEVCTL_CREATE_DIRECT: true
+        DEVCTL_VERSION: 0.7.1
 EOF
 
 else


### PR DESCRIPTION
## Summary

This PR enforces a devenv recreation as part of the serverless artifacts build (so it doesn't try to use a pooled devenv).