### PR TITLE
[CI] Gate ES snapshot promotion to release branches

### DIFF
--- a/.buildkite/scripts/steps/es_snapshots/trigger_promote.sh
+++ b/.buildkite/scripts/steps/es_snapshots/trigger_promote.sh
@@ -2,6 +2,28 @@
 
 set -euo pipefail
 
+REPO_ROOT="$(cd "$(dirname "$0")/../../../.." && pwd)"
+RELEASE_BRANCHES="$(jq -r '.versions[].branch' "$REPO_ROOT/versions.json" | tr '\n' ' ')"
+
+is_release_branch() {
+  for branch in $RELEASE_BRANCHES; do
+    if [[ "$BUILDKITE_BRANCH" == "$branch" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+if [[ "${FORCE_PROMOTE:-}" == "true" ]]; then
+  echo "--- FORCE_PROMOTE is set, triggering promotion from branch '$BUILDKITE_BRANCH'"
+elif is_release_branch; then
+  echo "--- Branch '$BUILDKITE_BRANCH' is a release branch, triggering promotion"
+else
+  echo "--- Skipping promotion: branch '$BUILDKITE_BRANCH' is not a release branch ($RELEASE_BRANCHES)"
+  echo "Set FORCE_PROMOTE=true to override"
+  exit 0
+fi
+
 # If ES_SNAPSHOT_MANIFEST is set dynamically during the verify job, rather than provided during the trigger,
 # such as if you provide it as input during a manual build,
 # the ES_SNAPSHOT_MANIFEST env var will be empty in the context of the pipeline.

--- a/.buildkite/scripts/steps/es_snapshots/trigger_promote.sh
+++ b/.buildkite/scripts/steps/es_snapshots/trigger_promote.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-REPO_ROOT="$(cd "$(dirname "$0")/../../../.." && pwd)"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
 RELEASE_BRANCHES="$(jq -r '.versions[].branch' "$REPO_ROOT/versions.json" | tr '\n' ' ')"
 
 is_release_branch() {


### PR DESCRIPTION
## Summary

Adds a branch guard to the ES snapshot promotion trigger step in the verify pipeline. Without this, **any** successful verify run (including manual builds from feature branches) would trigger a promotion — unintentionally promoting ES snapshots.

Promotion now only fires when:
- The build runs on a release branch (`main`, `9.3`, `9.2`, `8.19`), **or**
- `FORCE_PROMOTE=true` is explicitly set

This follows the same pattern used in the UIAM verify-and-promote pipeline.

Closes elastic/kibana-operations#499

## Test plan

- [ ] Verify the pipeline YAML is valid by triggering a manual verify build on `main` — promotion step should appear
- [ ] Trigger a manual verify build on a non-release branch without `FORCE_PROMOTE` — promotion step should be skipped
- [ ] Trigger a manual verify build on a non-release branch with `FORCE_PROMOTE=true` — promotion step should appear

Made with [Cursor](https://cursor.com)