### PR TITLE
[9.2] [DX] Align --help flag descriptions across CLI tools (#262122)

### DIFF
--- a/packages/kbn-ts-type-check-cli/run_type_check_contract_cli.ts
+++ b/packages/kbn-ts-type-check-cli/run_type_check_contract_cli.ts
@@ -70,18 +70,30 @@ export const runTypeCheckContractCli = () => {
       flags: {
         string: ['project', ...VALIDATION_RUN_STRING_FLAGS],
         boolean: ['clean-cache', 'cleanup', 'extended-diagnostics', 'with-archive'],
-        help: `
-        --project [path]        Path to a tsconfig.json file for direct-target execution
-${VALIDATION_RUN_HELP}
-        --help                  Show this message
-        --clean-cache           Delete any existing TypeScript caches before running type check
-        --cleanup               Pass to avoid leaving temporary tsconfig files on disk. Leaving these
-                                  files in place makes subsequent executions faster because ts can
-                                  identify that none of the imports have changed (it uses creation/update
-                                  times) but cleaning them prevents leaving garbage around the repo.
-        --extended-diagnostics  Turn on extended diagnostics in the TypeScript compiler
-        --with-archive          Restore cached artifacts before running and archive results afterwards
-      `,
+        help: [
+          {
+            flag: '--project [path]',
+            description: 'Path to a tsconfig.json file for direct-target execution',
+          },
+          ...VALIDATION_RUN_HELP,
+          {
+            flag: '--clean-cache',
+            description: 'Delete any existing TypeScript caches before running type check',
+          },
+          {
+            flag: '--cleanup',
+            description:
+              'Pass to avoid leaving temporary tsconfig files on disk. Leaving these\nfiles in place makes subsequent executions faster because ts can\nidentify that none of the imports have changed (it uses creation/update\ntimes) but cleaning them prevents leaving garbage around the repo.',
+          },
+          {
+            flag: '--extended-diagnostics',
+            description: 'Turn on extended diagnostics in the TypeScript compiler',
+          },
+          {
+            flag: '--with-archive',
+            description: 'Restore cached artifacts before running and archive results afterwards',
+          },
+        ],
       },
     }
   );

--- a/src/dev/eslint/run_eslint_contract.ts
+++ b/src/dev/eslint/run_eslint_contract.ts
@@ -174,10 +174,7 @@ export const runEslintContract = () => {
         default: {
           fix: true,
         },
-        help: `
-${VALIDATION_RUN_HELP}
-        --no-fix               Disable lint auto-fix
-      `,
+        help: [...VALIDATION_RUN_HELP, { flag: '--no-fix', description: 'Disable lint auto-fix' }],
       },
     }
   );

--- a/src/dev/run_check.test.ts
+++ b/src/dev/run_check.test.ts
@@ -20,7 +20,7 @@ jest.mock('@kbn/dev-cli-errors', () => ({
 jest.mock('@kbn/dev-validation-runner', () => ({
   readValidationRunFlags: jest.fn(),
   resolveValidationBaseContext: jest.fn(),
-  VALIDATION_RUN_HELP: '',
+  VALIDATION_RUN_HELP: [],
   VALIDATION_RUN_STRING_FLAGS: [],
 }));
 

--- a/src/dev/run_check.ts
+++ b/src/dev/run_check.ts
@@ -909,10 +909,7 @@ run(
       default: {
         fix: true,
       },
-      help: `
-${VALIDATION_RUN_HELP}
-      --no-fix               Disable lint auto-fix
-      `,
+      help: [...VALIDATION_RUN_HELP, { flag: '--no-fix', description: 'Disable lint auto-fix' }],
     },
   }
 );

--- a/src/platform/packages/shared/kbn-dev-cli-runner/src/flags/types.ts
+++ b/src/platform/packages/shared/kbn-dev-cli-runner/src/flags/types.ts
@@ -76,10 +76,15 @@ export type BaseFlags<TExtraFlags extends UnspecifiedFlags = {}> = {
 
 export type Flags = BaseFlags<UnspecifiedFlags>;
 
+export interface FlagHelpItem {
+  flag: string;
+  description: string;
+}
+
 export interface FlagOptions {
   allowUnexpected?: boolean;
   guessTypesForUnexpectedFlags?: boolean;
-  help?: string;
+  help?: string | FlagHelpItem[];
   examples?: string;
   alias?: { [key: string]: string | string[] };
   boolean?: string[];

--- a/src/platform/packages/shared/kbn-dev-cli-runner/src/help.ts
+++ b/src/platform/packages/shared/kbn-dev-cli-runner/src/help.ts
@@ -11,14 +11,31 @@ import Path from 'path';
 
 import chalk from 'chalk';
 import dedent from 'dedent';
-import { getLogLevelFlagsHelp } from '@kbn/tooling-log';
+import { getLogLevelFlagsHelp, getLogLevelFlagHelpItems } from '@kbn/tooling-log';
 
+import type { FlagHelpItem } from './flags/types';
 import type { Command } from './run/run_with_commands';
 
 const DEFAULT_GLOBAL_USAGE = `node ${Path.relative(process.cwd(), process.argv[1])}`;
 export const GLOBAL_FLAGS = dedent`
   --help             Show this message
 `;
+
+const GLOBAL_FLAG_ITEMS: FlagHelpItem[] = [{ flag: '--help', description: 'Show this message' }];
+
+export function formatFlagHelpItems(items: FlagHelpItem[]): string {
+  if (items.length === 0) return '';
+  const maxWidth = Math.max(...items.map((item) => item.flag.length));
+  const padWidth = maxWidth + 2;
+  return items
+    .map((item) => {
+      const lines = item.description.split('\n');
+      const firstLine = `${item.flag.padEnd(padWidth)}${lines[0]}`;
+      const rest = lines.slice(1).map((l) => ' '.repeat(padWidth) + l);
+      return [firstLine, ...rest].join('\n');
+    })
+    .join('\n');
+}
 
 export function indent(str: string, depth: number) {
   const prefix = ' '.repeat(depth);
@@ -41,15 +58,17 @@ export function getHelp({
 }: {
   description?: string;
   usage?: string;
-  flagHelp?: string;
+  flagHelp?: string | FlagHelpItem[];
   defaultLogLevel?: string;
   examples?: string;
 }) {
-  const optionHelp = joinAndTrimLines(
-    dedent(flagHelp || ''),
-    getLogLevelFlagsHelp(defaultLogLevel),
-    GLOBAL_FLAGS
-  );
+  const optionHelp = Array.isArray(flagHelp)
+    ? formatFlagHelpItems([
+        ...flagHelp,
+        ...getLogLevelFlagHelpItems(defaultLogLevel),
+        ...GLOBAL_FLAG_ITEMS,
+      ])
+    : joinAndTrimLines(dedent(flagHelp || ''), getLogLevelFlagsHelp(defaultLogLevel), GLOBAL_FLAGS);
 
   const examplesHelp = examples ? joinAndTrimLines('Examples:', examples) : '';
 
@@ -70,14 +89,19 @@ export function getCommandLevelHelp({
   command,
 }: {
   usage?: string;
-  globalFlagHelp?: string;
+  globalFlagHelp?: string | FlagHelpItem[];
   command: Command<any>;
 }) {
   const globalUsage = dedent(usage || '') || DEFAULT_GLOBAL_USAGE;
-  const globalHelp = joinAndTrimLines(dedent(globalFlagHelp || ''), GLOBAL_FLAGS);
+  const globalHelp = Array.isArray(globalFlagHelp)
+    ? formatFlagHelpItems([...globalFlagHelp, ...GLOBAL_FLAG_ITEMS])
+    : joinAndTrimLines(dedent(globalFlagHelp || ''), GLOBAL_FLAGS);
 
   const commandUsage = dedent(command.usage || '') || `${command.name} [...args]`;
-  const commandFlags = joinAndTrimLines(dedent(command.flags?.help || ''));
+  const commandHelp = command.flags?.help;
+  const commandFlags = Array.isArray(commandHelp)
+    ? formatFlagHelpItems(commandHelp)
+    : joinAndTrimLines(dedent(commandHelp || ''));
 
   return `
   ${globalUsage} ${commandUsage}
@@ -105,22 +129,26 @@ export function getHelpForAllCommands({
 }: {
   description?: string;
   usage?: string;
-  globalFlagHelp?: string;
+  globalFlagHelp?: string | FlagHelpItem[];
   commands: Array<Command<any>>;
 }) {
   const globalUsage = dedent(usage || '') || DEFAULT_GLOBAL_USAGE;
-  const globalHelp = joinAndTrimLines(dedent(globalFlagHelp || ''), GLOBAL_FLAGS);
+  const globalHelp = Array.isArray(globalFlagHelp)
+    ? formatFlagHelpItems([...globalFlagHelp, ...GLOBAL_FLAG_ITEMS])
+    : joinAndTrimLines(dedent(globalFlagHelp || ''), GLOBAL_FLAGS);
 
   const commandsHelp = commands
     .map((command) => {
-      const options = command.flags?.help
+      const commandHelp = command.flags?.help;
+      const optionText = Array.isArray(commandHelp)
+        ? formatFlagHelpItems(commandHelp)
+        : joinAndTrimLines(dedent(commandHelp || ''));
+
+      const options = commandHelp
         ? '\n' +
           dedent`
             Options:
-              ${indent(
-                joinAndTrimLines(dedent(command.flags?.help || '')),
-                '              '.length
-              )}
+              ${indent(optionText, '              '.length)}
           ` +
           '\n'
         : '';

--- a/src/platform/packages/shared/kbn-dev-validation-runner/moon.yml
+++ b/src/platform/packages/shared/kbn-dev-validation-runner/moon.yml
@@ -20,6 +20,7 @@ dependsOn:
   - '@kbn/dev-cli-errors'
   - '@kbn/dev-utils'
   - '@kbn/moon'
+  - '@kbn/dev-cli-runner'
 tags:
   - shared-common
   - package

--- a/src/platform/packages/shared/kbn-dev-validation-runner/src/validation_run_cli.ts
+++ b/src/platform/packages/shared/kbn-dev-validation-runner/src/validation_run_cli.ts
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import type { FlagHelpItem } from '@kbn/dev-cli-runner';
 import type { ResolvedValidationContract } from '@kbn/dev-utils';
 import type { MoonAffectedBase } from '@kbn/moon';
 import type { ValidationRunFlagsInput } from './resolve_validation_run_context';
@@ -23,15 +24,21 @@ export const VALIDATION_RUN_STRING_FLAGS = [
 
 const VALIDATION_RUN_FLAGS = new Set(VALIDATION_RUN_STRING_FLAGS.map((flag) => `--${flag}`));
 
-/** Shared validation help text block for CLI usage messages. */
-export const VALIDATION_RUN_HELP = `
-        --profile [name]        Validation profile: precommit, quick, agent, branch, pr, full (default: branch)
-        --scope [scope]         Scope: staged, local, branch, full
-        --test-mode [mode]      Test selection mode: related, affected, all
-        --base-ref [git-ref]    Base revision for branch scope
-        --head-ref [git-ref]    Head revision for branch scope (default: HEAD)
-        --downstream [mode]     Downstream mode for related/affected: none, direct, deep
-`;
+/** Shared validation flag help items for CLI usage messages. */
+export const VALIDATION_RUN_HELP: FlagHelpItem[] = [
+  {
+    flag: '--profile [name]',
+    description: 'Validation profile: precommit, quick, agent, branch, pr, full (default: branch)',
+  },
+  { flag: '--scope [scope]', description: 'Scope: staged, local, branch, full' },
+  { flag: '--test-mode [mode]', description: 'Test selection mode: related, affected, all' },
+  { flag: '--base-ref [git-ref]', description: 'Base revision for branch scope' },
+  { flag: '--head-ref [git-ref]', description: 'Head revision for branch scope (default: HEAD)' },
+  {
+    flag: '--downstream [mode]',
+    description: 'Downstream mode for related/affected: none, direct, deep',
+  },
+];
 
 /** Minimal flags reader contract needed to parse shared validation flags. */
 export interface ValidationRunFlagsReader {

--- a/src/platform/packages/shared/kbn-dev-validation-runner/tsconfig.json
+++ b/src/platform/packages/shared/kbn-dev-validation-runner/tsconfig.json
@@ -16,6 +16,7 @@
   "kbn_references": [
     "@kbn/dev-cli-errors",
     "@kbn/dev-utils",
-    "@kbn/moon"
+    "@kbn/moon",
+    "@kbn/dev-cli-runner"
   ]
 }

--- a/src/platform/packages/shared/kbn-test/src/jest/run_contract.test.ts
+++ b/src/platform/packages/shared/kbn-test/src/jest/run_contract.test.ts
@@ -21,7 +21,7 @@ jest.mock('@kbn/dev-validation-runner', () => ({
   formatReproductionCommand: jest.fn(),
   readValidationRunFlags: jest.fn(),
   resolveValidationBaseContext: jest.fn(),
-  VALIDATION_RUN_HELP: '',
+  VALIDATION_RUN_HELP: [],
   VALIDATION_RUN_STRING_FLAGS: [],
 }));
 

--- a/src/platform/packages/shared/kbn-test/src/jest/run_contract.ts
+++ b/src/platform/packages/shared/kbn-test/src/jest/run_contract.ts
@@ -677,9 +677,7 @@ export const runJestContract = () => {
       flags: {
         string: [...VALIDATION_RUN_STRING_FLAGS],
         allowUnexpected: true,
-        help: `
-${VALIDATION_RUN_HELP}
-        `,
+        help: [...VALIDATION_RUN_HELP],
       },
     }
   );

--- a/src/platform/packages/shared/kbn-tooling-log/index.ts
+++ b/src/platform/packages/shared/kbn-tooling-log/index.ts
@@ -18,6 +18,7 @@ export {
   pickLevelFromFlags,
   parseLogLevel,
   getLogLevelFlagsHelp,
+  getLogLevelFlagHelpItems,
 } from './src/log_levels';
 export { ToolingLogCollectingWriter } from './src/tooling_log_collecting_writer';
 export type { Writer } from './src/writer';

--- a/src/platform/packages/shared/kbn-tooling-log/src/log_levels.ts
+++ b/src/platform/packages/shared/kbn-tooling-log/src/log_levels.ts
@@ -25,34 +25,29 @@ export function pickLevelFromFlags(
 
 export const LOG_LEVEL_FLAGS: Array<{
   name: 'verbose' | 'info' | 'debug' | 'quiet' | 'silent';
-  help: string;
+  flag: string;
+  description: string;
 }> = [
-  {
-    name: 'verbose',
-    help: '--verbose, -v      Log verbosely',
-  },
-  {
-    name: 'info',
-    help: "--info             Don't log debug messages",
-  },
-  {
-    name: 'debug',
-    help: '--debug            Log debug messages (less than verbose)',
-  },
-  {
-    name: 'quiet',
-    help: '--quiet            Only log errors',
-  },
-  {
-    name: 'silent',
-    help: "--silent           Don't log anything",
-  },
+  { name: 'verbose', flag: '--verbose, -v', description: 'Log verbosely' },
+  { name: 'info', flag: '--info', description: "Don't log debug messages" },
+  { name: 'debug', flag: '--debug', description: 'Log debug messages (less than verbose)' },
+  { name: 'quiet', flag: '--quiet', description: 'Only log errors' },
+  { name: 'silent', flag: '--silent', description: "Don't log anything" },
 ];
 
+export function getLogLevelFlagHelpItems(
+  defaultLogLevel: string = DEFAULT_LOG_LEVEL
+): Array<{ flag: string; description: string }> {
+  return LOG_LEVEL_FLAGS.filter(({ name }) => name !== defaultLogLevel).map(
+    ({ flag, description }) => ({ flag, description })
+  );
+}
+
 export function getLogLevelFlagsHelp(defaultLogLevel: string = DEFAULT_LOG_LEVEL) {
-  return LOG_LEVEL_FLAGS.filter(({ name }) => name !== defaultLogLevel)
-    .map(({ help }) => help)
-    .join('\n');
+  const items = LOG_LEVEL_FLAGS.filter(({ name }) => name !== defaultLogLevel);
+  const maxWidth = Math.max(...items.map(({ flag }) => flag.length));
+  const pad = maxWidth + 2;
+  return items.map(({ flag, description }) => `${flag.padEnd(pad)}${description}`).join('\n');
 }
 
 export type ParsedLogLevel = ReturnType<typeof parseLogLevel>;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[DX] Align --help flag descriptions across CLI tools (#262122)](https://github.com/elastic/kibana/pull/262122)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Tyler Smalley","email":"tyler.smalley@elastic.co"},"sourceCommit":{"committedDate":"2026-04-09T18:11:29Z","message":"[DX] Align --help flag descriptions across CLI tools (#262122)\n\nReplace pre-formatted help strings with structured {flag, description}\ndata so the help renderer computes column width dynamically, ensuring\nall flags align consistently regardless of which package defines them.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"5207a3d98e33d48ee734bd0542a7c2ce4937872e","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:all-open","v9.4.0"],"title":"[DX] Align --help flag descriptions across CLI tools","number":262122,"url":"https://github.com/elastic/kibana/pull/262122","mergeCommit":{"message":"[DX] Align --help flag descriptions across CLI tools (#262122)\n\nReplace pre-formatted help strings with structured {flag, description}\ndata so the help renderer computes column width dynamically, ensuring\nall flags align consistently regardless of which package defines them.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"5207a3d98e33d48ee734bd0542a7c2ce4937872e"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/262122","number":262122,"mergeCommit":{"message":"[DX] Align --help flag descriptions across CLI tools (#262122)\n\nReplace pre-formatted help strings with structured {flag, description}\ndata so the help renderer computes column width dynamically, ensuring\nall flags align consistently regardless of which package defines them.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"5207a3d98e33d48ee734bd0542a7c2ce4937872e"}}]}] BACKPORT-->