### PR TITLE
Remove manage CPS button in spaces management page

### DIFF
--- a/x-pack/platform/plugins/shared/spaces/public/management/components/customize_cps/customize_cps.test.tsx
+++ b/x-pack/platform/plugins/shared/spaces/public/management/components/customize_cps/customize_cps.test.tsx
@@ -152,20 +152,6 @@ describe('CustomizeCps', () => {
     });
   });
 
-  describe('Settings Button', () => {
-    it('is visible', async () => {
-      renderComponent(defaultSpace);
-
-      expect(await screen.findByTestId('cpsDefaultScopePanel')).toBeInTheDocument();
-
-      await waitFor(() => {
-        expect(mockCpsManager.fetchProjects).toHaveBeenCalled();
-      });
-
-      expect(await screen.findByTestId('projectPickerSettingsPopover')).toBeInTheDocument();
-    });
-  });
-
   describe('Capabilities and permissions', () => {
     it('renders when user has manage_space_default capability', async () => {
       const capabilities = {

--- a/x-pack/platform/plugins/shared/spaces/public/management/components/customize_cps/customize_cps.tsx
+++ b/x-pack/platform/plugins/shared/spaces/public/management/components/customize_cps/customize_cps.tsx
@@ -5,21 +5,12 @@
  * 2.0.
  */
 
-import {
-  EuiButtonIcon,
-  EuiContextMenu,
-  EuiDescribedFormGroup,
-  EuiFormRow,
-  EuiPanel,
-  EuiPopover,
-  EuiTitle,
-} from '@elastic/eui';
-import { type FC, useCallback, useState } from 'react';
+import { EuiDescribedFormGroup, EuiFormRow, EuiPanel, EuiTitle } from '@elastic/eui';
+import { type FC, useCallback } from 'react';
 import React from 'react';
 
 import type { CPSPluginStart } from '@kbn/cps/public';
 import { ProjectPickerContent, useFetchProjects } from '@kbn/cps-utils';
-import { strings } from '@kbn/cps-utils/components/strings';
 import type { ProjectRouting } from '@kbn/es-query';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
@@ -59,61 +50,6 @@ export const CustomizeCps: FC<Props> = ({ space, onChange }) => {
   };
 
   const canEdit = () => application?.capabilities?.project_routing?.manage_space_default === true;
-  const [settingsIsOpen, setSettingsIsOpen] = useState(false);
-
-  const closePopover = () => setSettingsIsOpen(false);
-
-  const settingsButton = () => {
-    return (
-      <EuiPopover
-        data-test-subj="projectPickerSettingsPopover"
-        button={
-          <EuiButtonIcon
-            display="empty"
-            iconType="ellipsis"
-            aria-label={i18n.translate(
-              'xpack.spaces.management.manageSpacePage.customizeCps.settingsButtonLabel',
-              {
-                defaultMessage: 'Manage linked projects',
-              }
-            )}
-            onClick={() => setSettingsIsOpen(!settingsIsOpen)}
-            size="s"
-            color="text"
-          />
-        }
-        isOpen={settingsIsOpen}
-        closePopover={closePopover}
-        repositionOnScroll
-        anchorPosition="rightCenter"
-        ownFocus
-        panelPaddingSize="none"
-        aria-label={i18n.translate(
-          'xpack.spaces.management.manageSpacePage.customizeCps.settingsPopoverAriaLabel',
-          {
-            defaultMessage: 'Manage linked projects',
-          }
-        )}
-      >
-        <EuiContextMenu
-          initialPanelId={0}
-          panels={[
-            {
-              id: 0,
-              items: [
-                {
-                  name: strings.getManageCrossProjectSearchLabel(),
-                  icon: 'gear',
-                  'data-test-subj': 'spacesManageCpsSettingsMenuItem',
-                  onClick: closePopover, // TODO: redirect to CPS management - UI not ready yet
-                },
-              ],
-            },
-          ]}
-        />
-      </EuiPopover>
-    );
-  };
 
   return (
     <SectionPanel dataTestSubj="cpsDefaultScopePanel">
@@ -143,7 +79,6 @@ export const CustomizeCps: FC<Props> = ({ space, onChange }) => {
           label={i18n.translate('xpack.spaces.management.manageSpacePage.cpsDefaultScopeLabel', {
             defaultMessage: 'Cross-project search default scope',
           })}
-          labelAppend={settingsButton()}
         >
           <EuiPanel paddingSize="none" hasShadow={false} hasBorder>
             <ProjectPickerContent


### PR DESCRIPTION
Closes: https://github.com/elastic/kibana/issues/262573

## Summary

Removed the manage CPS button in the spaces management page as the intended page is not ready for tech preview

## Screenshots

Before:
<img width="2474" height="602" alt="image" src="https://github.com/user-attachments/assets/7ff6383b-8c75-4671-a8a1-13d7f5574798" />


After:
<img width="1540" height="293" alt="image" src="https://github.com/user-attachments/assets/ae09d347-bf7a-4125-b6f0-556609d725f2" />
