### PR TITLE
Set height based on content size on entities table

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/constants.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/constants.ts
@@ -17,7 +17,6 @@ export {
 
 export const MAX_ENTITIES_TO_LOAD = 500;
 export const DEFAULT_VISIBLE_ROWS_PER_PAGE = 25;
-export const DEFAULT_TABLE_SECTION_HEIGHT = 512;
 
 export const QUERY_KEY_GRID_DATA = 'entity_analytics_grid_data';
 export const QUERY_KEY_GROUPING_DATA = 'entity-analytics-grouping-data';

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/entities_data_table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/entities_data_table.tsx
@@ -7,6 +7,7 @@
 
 import React, { useContext, useState, useMemo, useEffect, useCallback } from 'react';
 import _ from 'lodash';
+import classNames from 'classnames';
 import { i18n } from '@kbn/i18n';
 import {
   UnifiedDataTable,
@@ -527,7 +528,9 @@ export const EntitiesDataTable = ({
     <CellActionsProvider getTriggerCompatibleActions={uiActions.getTriggerCompatibleActions}>
       <div
         data-test-subj={TEST_SUBJ_DATA_GRID}
-        className={styles.gridContainer}
+        className={classNames(styles.gridContainer, {
+          [styles.gridContainerLoading]: isLoadingGridData,
+        })}
         style={{
           height: computeDataTableRendering.wrapperHeight,
         }}

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/entities_table_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/entities_table_section.tsx
@@ -8,12 +8,7 @@ import React, { useState, useEffect, useRef, useMemo } from 'react';
 import type { Filter } from '@kbn/es-query';
 import { GroupWrapper } from '@kbn/cloud-security-posture';
 import type { EntityURLStateResult } from './hooks/use_entity_url_state';
-import {
-  DEFAULT_TABLE_SECTION_HEIGHT,
-  ENTITY_FIELDS,
-  TEST_SUBJ_GROUPING,
-  TEST_SUBJ_GROUPING_LOADING,
-} from './constants';
+import { ENTITY_FIELDS, TEST_SUBJ_GROUPING, TEST_SUBJ_GROUPING_LOADING } from './constants';
 import { useEntityGrouping } from './grouping/use_entity_grouping';
 
 const ENTITY_ANALYTICS_TEST_SUBJECTS = {
@@ -313,5 +308,5 @@ const DataTableWithLocalPagination = ({
     onChangeItemsPerPage: setTablePageSize,
   };
 
-  return <EntitiesDataTable state={newState} height={DEFAULT_TABLE_SECTION_HEIGHT} />;
+  return <EntitiesDataTable state={newState} />;
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/hooks/use_styles.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/hooks/use_styles.ts
@@ -12,9 +12,12 @@ export const useStyles = () => {
   const { euiTheme } = useEuiTheme();
 
   const gridContainer = css`
-    min-height: 400px;
     display: flex;
     flex-direction: column;
+  `;
+
+  const gridContainerLoading = css`
+    min-height: 400px;
   `;
 
   const gridProgressBar = css`
@@ -89,6 +92,7 @@ export const useStyles = () => {
   return {
     gridStyle,
     gridContainer,
+    gridContainerLoading,
     gridProgressBar,
   };
 };


### PR DESCRIPTION
## Summary

The grouped entities table was rendering with a fixed `height` of 512px regardless of content. Also `EntitiesDataTable` had a `min-height` of 400px so even without the fixed height it was not setting the height based on the content.

This PR removes the fixed height from the grouped path and changes the min-height to be set conditionally if the grid data is loading, preventing the container from collapsing while the loading spinner is shown.

## To test

1. Run ES and Kibana with all the entity store V2 feature flags
2. Seed some entity store V2 data
3. Navigate to the Entity Analytics home page on the Entities section
4. Group entities by resolution
5. Open the accordions and see that the height is based on the number of rows displayed
6. Change the _Group entities by_ option and see that the height is also correct there
7. Change the _Group entities by_ to none and see that the loading shows on a container with good height

### Before
<img width="1906" height="748" alt="Screenshot 2026-04-10 at 2 00 52 PM" src="https://github.com/user-attachments/assets/1f36de0e-6dc5-4b3c-a78d-9cc5f9570d78" />

### After
<img width="1913" height="736" alt="Screenshot 2026-04-10 at 1 53 05 PM" src="https://github.com/user-attachments/assets/f3cd4530-775b-4b4a-bfea-8360563f1303" />

<img width="1910" height="734" alt="Screenshot 2026-04-10 at 2 01 32 PM" src="https://github.com/user-attachments/assets/dae67aaa-5e1a-4d1b-a4be-d664a86669c5" />


<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->