### PR TITLE
[ci] Change API docs machine type

### DIFF
--- a/.buildkite/pipelines/build_api_docs.yml
+++ b/.buildkite/pipelines/build_api_docs.yml
@@ -19,9 +19,11 @@ steps:
       image: family/kibana-ubuntu-2404
       imageProject: elastic-images-prod
       provider: gcp
-      machineType: n2-highmem-4
+      machineType: c4d-highmem-4
+      diskType: hyperdisk-balanced
       preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
+      spotZones: us-central1-a,us-central1-b,us-central1-c
+      diskSizeGb: 105
     key: build_api_docs
     timeout_in_minutes: 50
     retry:

--- a/.buildkite/pipelines/on_merge.yml
+++ b/.buildkite/pipelines/on_merge.yml
@@ -190,9 +190,10 @@ steps:
       image: family/kibana-ubuntu-2404
       imageProject: elastic-images-prod
       provider: gcp
-      machineType: n2-highmem-4
+      machineType: c4d-highmem-4
+      diskType: hyperdisk-balanced
       preemptible: true
-      spotZones: us-central1-b,us-central1-c,us-central1-f
+      spotZones: us-central1-a,us-central1-b,us-central1-c
       diskSizeGb: 105
     timeout_in_minutes: 60
     retry:

--- a/.buildkite/pipelines/pull_request/base.yml
+++ b/.buildkite/pipelines/pull_request/base.yml
@@ -179,9 +179,10 @@ steps:
   - command: .buildkite/scripts/steps/api_docs/build_api_docs.sh
     label: 'Build API Docs'
     agents:
-      machineType: n2-highmem-4
+      machineType: c4d-highmem-4
+      diskType: hyperdisk-balanced
       preemptible: true
-      spotZones: us-central1-b,us-central1-c,us-central1-f
+      spotZones: us-central1-a,us-central1-b,us-central1-c
       diskSizeGb: 105
     key: build_api_docs
     timeout_in_minutes: 60


### PR DESCRIPTION
We need this step to run in < 1 hour and its near the limit.  

It's also a time sensitive step in on-merge: the earlier it finishes the quicker we have a metrics baseline to compare pull requests against.

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->