### PR TITLE
[kbn-evals] Add incremental exports of evaluation results

### DIFF
--- a/x-pack/platform/packages/shared/kbn-evals/index.ts
+++ b/x-pack/platform/packages/shared/kbn-evals/index.ts
@@ -36,6 +36,8 @@ export type {
   EvaluationResult,
   RanExperiment,
   EvalsExecutorClient,
+  EvaluationCompleteEvent,
+  OnEvaluationComplete,
 } from './src/types';
 export { KibanaEvalsClient } from './src/kibana_evals_executor/client';
 export { createQuantitativeCorrectnessEvaluators } from './src/evaluators/correctness';
@@ -71,11 +73,17 @@ export type {
 export { createTable } from './src/utils/reporting/report_table';
 export {
   EvaluationScoreRepository,
+  computeScoreDocumentId,
   type EvaluationScoreDocument,
   type EvaluatorStats,
   type RunStats,
 } from './src/utils/score_repository';
-export { mapToEvaluationScoreDocuments, exportEvaluations } from './src/utils/report_model_score';
+export {
+  mapToEvaluationScoreDocuments,
+  exportEvaluations,
+  buildSingleScoreDocument,
+  type BuildSingleScoreDocumentParams,
+} from './src/utils/report_model_score';
 
 export { parseSelectedEvaluators, selectEvaluators } from './src/evaluators/filter';
 /**

--- a/x-pack/platform/packages/shared/kbn-evals/src/evaluate.ts
+++ b/x-pack/platform/packages/shared/kbn-evals/src/evaluate.ts
@@ -330,7 +330,6 @@ export const evaluate = base.extend<{}, EvaluationSpecificWorkerFixtures>({
           }
         : undefined;
 
-      const incrementalTimestamp = new Date().toISOString();
       const incrementalGitMetadata = getGitMetadata();
       const incrementalHostName = osHostname();
 
@@ -348,7 +347,7 @@ export const evaluate = base.extend<{}, EvaluationSpecificWorkerFixtures>({
             evaluatorModel,
             runId: currentRunId,
             totalRepetitions: repetitions,
-            timestamp: incrementalTimestamp,
+            timestamp: new Date().toISOString(),
             gitMetadata: incrementalGitMetadata,
             hostName: incrementalHostName,
           });

--- a/x-pack/platform/packages/shared/kbn-evals/src/evaluate.ts
+++ b/x-pack/platform/packages/shared/kbn-evals/src/evaluate.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { hostname as osHostname } from 'os';
 import type { InferenceConnectorType, InferenceConnector, Model } from '@kbn/inference-common';
 import { getConnectorModel, getConnectorFamily, getConnectorProvider } from '@kbn/inference-common';
 import { createRestClient } from '@kbn/inference-plugin/common';
@@ -27,7 +28,12 @@ import {
   checkEvaluationsPluginEnabled,
 } from './utils/evaluations_kbn_client';
 import { createCriteriaEvaluator } from './evaluators/criteria';
-import { mapToEvaluationScoreDocuments, exportEvaluations } from './utils/report_model_score';
+import {
+  mapToEvaluationScoreDocuments,
+  exportEvaluations,
+  buildSingleScoreDocument,
+} from './utils/report_model_score';
+import { getGitMetadata } from './utils/git_metadata';
 import { createDefaultTerminalReporter } from './utils/reporting/evaluation_reporter';
 import { createConnectorFixture, resolveConnectorId } from './utils/create_connector_fixture';
 import { wrapInferenceClientWithEisConnectorTelemetry } from './utils/wrap_inference_client_with_connector_telemetry';
@@ -324,6 +330,10 @@ export const evaluate = base.extend<{}, EvaluationSpecificWorkerFixtures>({
           }
         : undefined;
 
+      const incrementalTimestamp = new Date().toISOString();
+      const incrementalGitMetadata = getGitMetadata();
+      const incrementalHostName = osHostname();
+
       const executorClient = new KibanaEvalsClient({
         log,
         model,
@@ -331,6 +341,19 @@ export const evaluate = base.extend<{}, EvaluationSpecificWorkerFixtures>({
         repetitions,
         upsertDataset,
         getDatasetByName,
+        onEvaluationComplete: async (event) => {
+          const document = buildSingleScoreDocument({
+            event,
+            taskModel: model,
+            evaluatorModel,
+            runId: currentRunId,
+            totalRepetitions: repetitions,
+            timestamp: incrementalTimestamp,
+            gitMetadata: incrementalGitMetadata,
+            hostName: incrementalHostName,
+          });
+          await scoreRepository.indexSingleScore(document);
+        },
       });
 
       await use(executorClient);

--- a/x-pack/platform/packages/shared/kbn-evals/src/kibana_evals_executor/client.test.ts
+++ b/x-pack/platform/packages/shared/kbn-evals/src/kibana_evals_executor/client.test.ts
@@ -411,7 +411,7 @@ describe('KibanaEvalsClient', () => {
         expect.objectContaining({
           exampleIndex: 0,
           repetition: 0,
-          output: { v: 1 },
+          output: { value: 1 },
         })
       );
       expect(event.evaluationRun).toEqual(

--- a/x-pack/platform/packages/shared/kbn-evals/src/kibana_evals_executor/client.test.ts
+++ b/x-pack/platform/packages/shared/kbn-evals/src/kibana_evals_executor/client.test.ts
@@ -354,4 +354,121 @@ describe('KibanaEvalsClient', () => {
       'KibanaEvalsClient runExperiment called with trustUpstreamDataset=true, but getDatasetByName is not configured'
     );
   });
+
+  describe('onEvaluationComplete callback', () => {
+    const dataset: EvaluationDataset = {
+      name: 'ds',
+      description: 'desc',
+      examples: [
+        { id: 'ex-1', input: { q: 1 }, output: { expected: 1 } },
+        { id: 'ex-2', input: { q: 2 }, output: { expected: 2 } },
+      ],
+    };
+
+    const evaluators: Array<Evaluator<EvaluationDataset['examples'][number], { value: number }>> = [
+      {
+        name: 'AlwaysOne',
+        kind: 'CODE',
+        evaluate: async () => ({ score: 1 }),
+      },
+      {
+        name: 'HasValue',
+        kind: 'CODE',
+        evaluate: async ({ output }) => ({ score: typeof output?.value === 'number' ? 1 : 0 }),
+      },
+    ];
+
+    it('invokes the callback once per evaluator per example per repetition', async () => {
+      const onEvaluationComplete = jest.fn().mockResolvedValue(undefined);
+      const client = createClient({ repetitions: 2, onEvaluationComplete });
+
+      await client.runExperiment({ dataset, task: async () => ({ value: 42 }) }, evaluators);
+
+      // 2 examples * 2 repetitions * 2 evaluators = 8 calls
+      expect(onEvaluationComplete).toHaveBeenCalledTimes(8);
+    });
+
+    it('passes correct event data to the callback', async () => {
+      const onEvaluationComplete = jest.fn().mockResolvedValue(undefined);
+      const client = createClient({ repetitions: 1, onEvaluationComplete });
+
+      const exp = await client.runExperiment(
+        {
+          dataset: { ...dataset, examples: [dataset.examples[0]] },
+          task: async () => ({ value: 1 }),
+        },
+        [evaluators[0]]
+      );
+
+      expect(onEvaluationComplete).toHaveBeenCalledTimes(1);
+      const event = onEvaluationComplete.mock.calls[0][0];
+
+      expect(event.experimentId).toBe(exp.id);
+      expect(event.datasetId).toBe(exp.datasetId);
+      expect(event.datasetName).toBe('ds');
+      expect(event.exampleId).toBe('ex-1');
+      expect(event.taskRun).toEqual(
+        expect.objectContaining({
+          exampleIndex: 0,
+          repetition: 0,
+          output: { v: 1 },
+        })
+      );
+      expect(event.evaluationRun).toEqual(
+        expect.objectContaining({
+          name: 'AlwaysOne',
+          result: { score: 1 },
+        })
+      );
+    });
+
+    it('uses stringified exampleIndex when example has no id', async () => {
+      const onEvaluationComplete = jest.fn().mockResolvedValue(undefined);
+      const client = createClient({ repetitions: 1, onEvaluationComplete });
+
+      const noIdDataset: EvaluationDataset = {
+        name: 'no-ids',
+        description: 'desc',
+        examples: [{ input: { q: 1 } }],
+      };
+
+      await client.runExperiment({ dataset: noIdDataset, task: async () => ({ value: 1 }) }, [
+        evaluators[0],
+      ]);
+
+      const event = onEvaluationComplete.mock.calls[0][0];
+      expect(event.exampleId).toBe('0');
+    });
+
+    it('does not abort the experiment when the callback throws', async () => {
+      const onEvaluationComplete = jest.fn().mockRejectedValue(new Error('ES write failed'));
+      const client = createClient({ repetitions: 1, onEvaluationComplete });
+
+      const exp = await client.runExperiment(
+        { dataset, task: async () => ({ value: 1 }) },
+        evaluators
+      );
+
+      // 2 examples * 1 rep * 2 evaluators = 4 calls, all throwing
+      expect(onEvaluationComplete).toHaveBeenCalledTimes(4);
+      expect(mockLog.warning).toHaveBeenCalledWith(
+        expect.stringContaining('Incremental score export failed')
+      );
+
+      // Experiment still completes and accumulates all results
+      expect(exp.evaluationRuns).toHaveLength(4);
+      expect(Object.values(exp.runs)).toHaveLength(2);
+    });
+
+    it('is not invoked when no callback is provided', async () => {
+      const client = createClient({ repetitions: 1 });
+
+      const exp = await client.runExperiment(
+        { dataset, task: async () => ({ value: 1 }) },
+        evaluators
+      );
+
+      expect(exp.evaluationRuns).toHaveLength(4);
+    });
+  });
 });

--- a/x-pack/platform/packages/shared/kbn-evals/src/kibana_evals_executor/client.ts
+++ b/x-pack/platform/packages/shared/kbn-evals/src/kibana_evals_executor/client.ts
@@ -18,6 +18,7 @@ import type {
   EvaluationDataset,
   EvaluationDatasetWithId,
   ExperimentTask,
+  OnEvaluationComplete,
   RanExperiment,
   TaskOutput,
 } from '../types';
@@ -40,6 +41,7 @@ export class KibanaEvalsClient implements EvalsExecutorClient {
       getDatasetByName?: (
         datasetName: string
       ) => Promise<EvaluationDataset | EvaluationDatasetWithId | null>;
+      onEvaluationComplete?: OnEvaluationComplete;
     }
   ) {}
 
@@ -181,15 +183,33 @@ export class KibanaEvalsClient implements EvalsExecutorClient {
                 })
               );
 
-              results.forEach(({ evaluatorName, result, evaluatorTraceId }) => {
-                evaluationRuns.push({
+              for (const { evaluatorName, result, evaluatorTraceId } of results) {
+                const evalRun = {
                   name: evaluatorName,
                   result,
                   experimentRunId: runKey,
                   traceId: evaluatorTraceId,
                   exampleId: example.id,
-                });
-              });
+                };
+                evaluationRuns.push(evalRun);
+
+                if (this.options.onEvaluationComplete) {
+                  try {
+                    await this.options.onEvaluationComplete({
+                      experimentId,
+                      datasetId,
+                      datasetName: resolvedDataset.name,
+                      taskRun: runs[runKey],
+                      evaluationRun: evalRun,
+                      exampleId: example.id ?? String(exampleIndex),
+                    });
+                  } catch (err) {
+                    this.options.log.warning(
+                      `Incremental score export failed (will retry in batch): ${err}`
+                    );
+                  }
+                }
+              }
             })
           );
         });

--- a/x-pack/platform/packages/shared/kbn-evals/src/types.ts
+++ b/x-pack/platform/packages/shared/kbn-evals/src/types.ts
@@ -185,6 +185,23 @@ export interface RanExperiment {
   experimentMetadata?: Record<string, unknown>;
 }
 
+/**
+ * Emitted by the executor client after each evaluator completes for a single
+ * example+repetition. Consumers (e.g. the Playwright fixture) can use this to
+ * incrementally export score documents to Elasticsearch so that results survive
+ * worker crashes.
+ */
+export interface EvaluationCompleteEvent {
+  experimentId: string;
+  datasetId: string;
+  datasetName: string;
+  taskRun: TaskRun;
+  evaluationRun: EvaluationRun;
+  exampleId: string;
+}
+
+export type OnEvaluationComplete = (event: EvaluationCompleteEvent) => Promise<void>;
+
 export interface ReportDisplayOptions {
   /**
    * Display options for individual evaluators, keyed by evaluator name.

--- a/x-pack/platform/packages/shared/kbn-evals/src/utils/report_model_score.test.ts
+++ b/x-pack/platform/packages/shared/kbn-evals/src/utils/report_model_score.test.ts
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
-import { mapToEvaluationScoreDocuments } from './report_model_score';
-import type { RanExperiment } from '../types';
+import { mapToEvaluationScoreDocuments, buildSingleScoreDocument } from './report_model_score';
+import type { RanExperiment, EvaluationCompleteEvent } from '../types';
 import { ModelProvider, ModelFamily } from '@kbn/inference-common';
 
 describe('mapToEvaluationScoreDocuments', () => {
@@ -137,5 +137,163 @@ describe('mapToEvaluationScoreDocuments', () => {
     });
 
     expect(docs[0].task.output).toEqual({ answer: 'yes' });
+  });
+});
+
+describe('buildSingleScoreDocument', () => {
+  const taskModel = {
+    id: 'gpt-4',
+    family: ModelFamily.GPT,
+    provider: ModelProvider.OpenAI,
+  };
+
+  const evaluatorModel = {
+    id: 'claude-3',
+    family: ModelFamily.Claude,
+    provider: ModelProvider.Anthropic,
+  };
+
+  const baseEvent: EvaluationCompleteEvent = {
+    experimentId: 'exp-1',
+    datasetId: 'dataset-1',
+    datasetName: 'Dataset 1',
+    taskRun: {
+      exampleIndex: 0,
+      repetition: 0,
+      input: { question: 'one' },
+      expected: undefined,
+      metadata: undefined,
+      output: { answer: 'yes' },
+      traceId: 'trace-task-1',
+    },
+    evaluationRun: {
+      name: 'Correctness',
+      experimentRunId: 'run-key-1',
+      result: { score: 0.9, label: 'PASS', explanation: 'Correct.' },
+      traceId: 'trace-eval-1',
+      exampleId: 'example-1',
+    },
+    exampleId: 'example-1',
+  };
+
+  it('builds a well-formed score document from an event', () => {
+    const doc = buildSingleScoreDocument({
+      event: baseEvent,
+      taskModel,
+      evaluatorModel,
+      runId: 'run-123',
+      totalRepetitions: 3,
+      timestamp: '2025-06-01T00:00:00Z',
+      gitMetadata: { branch: 'main', commitSha: 'abc123' },
+      hostName: 'test-host',
+    });
+
+    expect(doc['@timestamp']).toBe('2025-06-01T00:00:00Z');
+    expect(doc.run_id).toBe('run-123');
+    expect(doc.experiment_id).toBe('exp-1');
+    expect(doc.example).toEqual({
+      id: 'example-1',
+      index: 0,
+      input: { question: 'one' },
+      dataset: { id: 'dataset-1', name: 'Dataset 1' },
+    });
+    expect(doc.task).toEqual({
+      trace_id: 'trace-task-1',
+      repetition_index: 0,
+      output: { answer: 'yes' },
+      model: taskModel,
+    });
+    expect(doc.evaluator).toEqual({
+      name: 'Correctness',
+      score: 0.9,
+      label: 'PASS',
+      explanation: 'Correct.',
+      metadata: null,
+      trace_id: 'trace-eval-1',
+      model: evaluatorModel,
+    });
+    expect(doc.run_metadata).toEqual({
+      git_branch: 'main',
+      git_commit_sha: 'abc123',
+      total_repetitions: 3,
+    });
+    expect(doc.environment.hostname).toBe('test-host');
+  });
+
+  it('produces the same output as mapToEvaluationScoreDocuments for equivalent input', async () => {
+    const experiment: RanExperiment = {
+      id: 'exp-1',
+      datasetId: 'dataset-1',
+      datasetName: 'Dataset 1',
+      runs: {
+        'run-key-1': baseEvent.taskRun,
+      },
+      evaluationRuns: [baseEvent.evaluationRun],
+    };
+
+    const batchDocs = await mapToEvaluationScoreDocuments({
+      experiments: [experiment],
+      taskModel,
+      evaluatorModel,
+      runId: 'run-123',
+      totalRepetitions: 3,
+    });
+
+    const singleDoc = buildSingleScoreDocument({
+      event: baseEvent,
+      taskModel,
+      evaluatorModel,
+      runId: 'run-123',
+      totalRepetitions: 3,
+      timestamp: batchDocs[0]['@timestamp'],
+      gitMetadata: {
+        branch: batchDocs[0].run_metadata.git_branch,
+        commitSha: batchDocs[0].run_metadata.git_commit_sha,
+      },
+      hostName: batchDocs[0].environment.hostname,
+    });
+
+    expect(singleDoc).toEqual(batchDocs[0]);
+  });
+
+  it('handles null/missing values correctly', () => {
+    const sparseEvent: EvaluationCompleteEvent = {
+      experimentId: 'exp-2',
+      datasetId: 'ds-2',
+      datasetName: 'DS 2',
+      taskRun: {
+        exampleIndex: 1,
+        repetition: 0,
+        input: undefined,
+        expected: null,
+        metadata: undefined,
+        output: undefined,
+      },
+      evaluationRun: {
+        name: 'Eval',
+        experimentRunId: 'rk-1',
+      },
+      exampleId: '1',
+    };
+
+    const doc = buildSingleScoreDocument({
+      event: sparseEvent,
+      taskModel,
+      evaluatorModel,
+      runId: 'run-x',
+      totalRepetitions: 1,
+      timestamp: '2025-01-01T00:00:00Z',
+      gitMetadata: { branch: null, commitSha: null },
+      hostName: 'h',
+    });
+
+    expect(doc.example.input).toBeNull();
+    expect(doc.task.output).toBeNull();
+    expect(doc.task.trace_id).toBeNull();
+    expect(doc.evaluator.score).toBeNull();
+    expect(doc.evaluator.label).toBeNull();
+    expect(doc.evaluator.explanation).toBeNull();
+    expect(doc.evaluator.metadata).toBeNull();
+    expect(doc.evaluator.trace_id).toBeNull();
   });
 });

--- a/x-pack/platform/packages/shared/kbn-evals/src/utils/report_model_score.ts
+++ b/x-pack/platform/packages/shared/kbn-evals/src/utils/report_model_score.ts
@@ -11,11 +11,78 @@ import { hostname } from 'os';
 import type { Model } from '@kbn/inference-common';
 import type { EvaluationScoreRepository } from './score_repository';
 import { type EvaluationScoreDocument } from './score_repository';
-import { getGitMetadata } from './git_metadata';
-import type { RanExperiment, EvaluationRun, TaskRun } from '../types';
+import { getGitMetadata, type GitMetadata } from './git_metadata';
+import type { RanExperiment, EvaluationRun, EvaluationCompleteEvent, TaskRun } from '../types';
 
 function getTaskRun(evalRun: EvaluationRun, runs: RanExperiment['runs']): TaskRun {
   return runs[evalRun.experimentRunId];
+}
+
+export interface BuildSingleScoreDocumentParams {
+  event: EvaluationCompleteEvent;
+  taskModel: Model;
+  evaluatorModel: Model;
+  runId: string;
+  totalRepetitions: number;
+  timestamp: string;
+  gitMetadata: GitMetadata;
+  hostName: string;
+}
+
+/**
+ * Builds a single `EvaluationScoreDocument` from an incremental evaluation event.
+ * Used by the Playwright fixture callback to export each evaluator result as it completes.
+ * The same document structure is produced by `mapToEvaluationScoreDocuments` for the batch path.
+ */
+export function buildSingleScoreDocument({
+  event,
+  taskModel,
+  evaluatorModel,
+  runId,
+  totalRepetitions,
+  timestamp,
+  gitMetadata: git,
+  hostName,
+}: BuildSingleScoreDocumentParams): EvaluationScoreDocument {
+  const { experimentId, datasetId, datasetName, taskRun, evaluationRun, exampleId } = event;
+
+  return {
+    '@timestamp': timestamp,
+    run_id: runId,
+    experiment_id: experimentId,
+    example: {
+      id: exampleId,
+      index: taskRun.exampleIndex,
+      input: taskRun.input ?? null,
+      dataset: {
+        id: datasetId,
+        name: datasetName,
+      },
+    },
+    task: {
+      trace_id: taskRun.traceId ?? null,
+      repetition_index: taskRun.repetition,
+      output: taskRun.output ?? null,
+      model: taskModel,
+    },
+    evaluator: {
+      name: evaluationRun.name,
+      score: evaluationRun.result?.score ?? null,
+      label: evaluationRun.result?.label ?? null,
+      explanation: evaluationRun.result?.explanation ?? null,
+      metadata: evaluationRun.result?.metadata ?? null,
+      trace_id: evaluationRun.traceId ?? null,
+      model: evaluatorModel,
+    },
+    run_metadata: {
+      git_branch: git.branch,
+      git_commit_sha: git.commitSha,
+      total_repetitions: totalRepetitions,
+    },
+    environment: {
+      hostname: hostName,
+    },
+  };
 }
 
 export async function mapToEvaluationScoreDocuments({
@@ -33,7 +100,7 @@ export async function mapToEvaluationScoreDocuments({
 }): Promise<EvaluationScoreDocument[]> {
   const documents: EvaluationScoreDocument[] = [];
   const timestamp = new Date().toISOString();
-  const gitMetadata = getGitMetadata();
+  const git = getGitMetadata();
   const hostName = hostname();
 
   for (const experiment of experiments) {
@@ -48,43 +115,25 @@ export async function mapToEvaluationScoreDocuments({
       const taskRun = getTaskRun(evalRun, runs);
       const exampleId = evalRun.exampleId ?? String(taskRun.exampleIndex);
 
-      documents.push({
-        '@timestamp': timestamp,
-        run_id: runId,
-        experiment_id: experiment.id ?? '',
-        example: {
-          id: exampleId,
-          index: taskRun.exampleIndex,
-          input: taskRun.input ?? null,
-          dataset: {
-            id: datasetId,
-            name: datasetName,
+      documents.push(
+        buildSingleScoreDocument({
+          event: {
+            experimentId: experiment.id ?? '',
+            datasetId,
+            datasetName,
+            taskRun,
+            evaluationRun: evalRun,
+            exampleId,
           },
-        },
-        task: {
-          trace_id: taskRun.traceId ?? null,
-          repetition_index: taskRun.repetition,
-          output: taskRun.output ?? null,
-          model: taskModel,
-        },
-        evaluator: {
-          name: evalRun.name,
-          score: evalRun.result?.score ?? null,
-          label: evalRun.result?.label ?? null,
-          explanation: evalRun.result?.explanation ?? null,
-          metadata: evalRun.result?.metadata ?? null,
-          trace_id: evalRun.traceId ?? null,
-          model: evaluatorModel,
-        },
-        run_metadata: {
-          git_branch: gitMetadata.branch,
-          git_commit_sha: gitMetadata.commitSha,
-          total_repetitions: totalRepetitions,
-        },
-        environment: {
-          hostname: hostName,
-        },
-      });
+          taskModel,
+          evaluatorModel,
+          runId,
+          totalRepetitions,
+          timestamp,
+          gitMetadata: git,
+          hostName,
+        })
+      );
     }
   }
 

--- a/x-pack/platform/packages/shared/kbn-evals/src/utils/score_repository.test.ts
+++ b/x-pack/platform/packages/shared/kbn-evals/src/utils/score_repository.test.ts
@@ -5,7 +5,11 @@
  * 2.0.
  */
 
-import { EvaluationScoreRepository, type EvaluationScoreDocument } from './score_repository';
+import {
+  EvaluationScoreRepository,
+  computeScoreDocumentId,
+  type EvaluationScoreDocument,
+} from './score_repository';
 import type { Model } from '@kbn/inference-common';
 import { ModelFamily, ModelProvider } from '@kbn/inference-common';
 import type { SomeDevLog } from '@kbn/some-dev-log';
@@ -563,6 +567,94 @@ describe('EvaluationScoreRepository', () => {
         'Failed to retrieve scores for run ID run-123:',
         error
       );
+    });
+  });
+
+  describe('indexSingleScore', () => {
+    it('creates a single document with deterministic id and refresh: false', async () => {
+      const doc = createMockScoreDocument();
+      await repository.indexSingleScore(doc);
+
+      expect(mockEsClient.create).toHaveBeenCalledWith({
+        index: 'kibana-evaluations',
+        id: 'run-123-unknown-suite-gpt-4-dataset-1-example-1-Correctness-0',
+        document: doc,
+        refresh: false,
+      });
+    });
+
+    it('enriches the document with suite and buildkite metadata from options', async () => {
+      const doc = createMockScoreDocument();
+      await repository.indexSingleScore(doc, {
+        suiteId: 'my-suite',
+        buildkite: { build_id: 'bk-1', job_id: 'bk-j1' },
+      });
+
+      expect(mockEsClient.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'run-123-my-suite-gpt-4-dataset-1-example-1-Correctness-0',
+          document: expect.objectContaining({
+            suite: { id: 'my-suite' },
+            ci: { buildkite: { build_id: 'bk-1', job_id: 'bk-j1' } },
+          }),
+        })
+      );
+    });
+
+    it('treats 409 conflict as success', async () => {
+      mockEsClient.create.mockRejectedValueOnce({ statusCode: 409 });
+
+      await expect(repository.indexSingleScore(createMockScoreDocument())).resolves.toBeUndefined();
+    });
+
+    it('throws on non-409 errors', async () => {
+      const error = Object.assign(new Error('forbidden'), { statusCode: 403 });
+      mockEsClient.create.mockRejectedValueOnce(error);
+
+      await expect(repository.indexSingleScore(createMockScoreDocument())).rejects.toThrow(
+        'forbidden'
+      );
+    });
+  });
+
+  describe('computeScoreDocumentId', () => {
+    it('builds a deterministic id from document key fields', () => {
+      const doc = createMockScoreDocument();
+      expect(computeScoreDocumentId(doc)).toBe(
+        'run-123-unknown-suite-gpt-4-dataset-1-example-1-Correctness-0'
+      );
+    });
+
+    it('uses suite id when present', () => {
+      const doc = createMockScoreDocument({ suite: { id: 'attack-discovery' } });
+      expect(computeScoreDocumentId(doc)).toBe(
+        'run-123-attack-discovery-gpt-4-dataset-1-example-1-Correctness-0'
+      );
+    });
+
+    it('produces different ids for different evaluators on the same example', () => {
+      const docA = createMockScoreDocument();
+      const docB = createMockScoreDocument({
+        evaluator: { ...createMockScoreDocument().evaluator, name: 'Groundedness' },
+      });
+      expect(computeScoreDocumentId(docA)).not.toBe(computeScoreDocumentId(docB));
+    });
+
+    it('matches the id used by exportScores bulk onDocument', async () => {
+      const doc = createMockScoreDocument();
+
+      mockEsClient.helpers.bulk.mockResolvedValue({
+        total: 1,
+        failed: 0,
+        successful: 1,
+      } as any);
+
+      await repository.exportScores([doc]);
+
+      const bulkCall = mockEsClient.helpers.bulk.mock.calls[0][0];
+      const bulkDocId = bulkCall.onDocument(doc).create._id;
+
+      expect(bulkDocId).toBe(computeScoreDocumentId(doc));
     });
   });
 });

--- a/x-pack/platform/packages/shared/kbn-evals/src/utils/score_repository.ts
+++ b/x-pack/platform/packages/shared/kbn-evals/src/utils/score_repository.ts
@@ -223,6 +223,8 @@ function enrichDocument(
 }
 
 export class EvaluationScoreRepository {
+  private localExportTargetReady: Promise<void> | undefined;
+
   constructor(private readonly esClient: EsClient, private readonly log: SomeDevLog) {}
 
   private getErrorStatusCode(error: unknown): number | undefined {
@@ -421,9 +423,14 @@ export class EvaluationScoreRepository {
     }
   }
 
-  private async prepareLocalExportTarget(): Promise<void> {
-    await this.ensureIndexTemplate();
-    await this.ensureDatastream();
+  private prepareLocalExportTarget(): Promise<void> {
+    if (!this.localExportTargetReady) {
+      this.localExportTargetReady = (async () => {
+        await this.ensureIndexTemplate();
+        await this.ensureDatastream();
+      })();
+    }
+    return this.localExportTargetReady;
   }
 
   /**

--- a/x-pack/platform/packages/shared/kbn-evals/src/utils/score_repository.ts
+++ b/x-pack/platform/packages/shared/kbn-evals/src/utils/score_repository.ts
@@ -187,6 +187,41 @@ interface RunStatsAggregations {
 const EVALUATIONS_DATA_STREAM_ALIAS = 'kibana-evaluations';
 const EVALUATIONS_DATA_STREAM_WILDCARD = 'kibana-evaluations*';
 const EVALUATIONS_DATA_STREAM_TEMPLATE = 'kibana-evaluations-template';
+
+/**
+ * Builds a deterministic document ID from the score document's key fields.
+ * Used by both batch (`exportScores`) and incremental (`indexSingleScore`) paths
+ * to ensure idempotent writes — re-indexing the same result produces a 409 conflict
+ * rather than a duplicate.
+ */
+export function computeScoreDocumentId(doc: EvaluationScoreDocument): string {
+  const suiteIdPart = doc.suite?.id ?? 'unknown-suite';
+  return [
+    doc.run_id,
+    suiteIdPart,
+    doc.task.model.id,
+    doc.example.dataset.id,
+    doc.example.id,
+    doc.evaluator.name,
+    doc.task.repetition_index,
+  ].join('-');
+}
+
+function enrichDocument(
+  doc: EvaluationScoreDocument,
+  suiteId: string | undefined,
+  buildkite: BuildkiteCiMetadata | undefined
+): EvaluationScoreDocument {
+  if (!suiteId && !buildkite) {
+    return doc;
+  }
+  return {
+    ...doc,
+    suite: doc.suite ?? (suiteId ? { id: suiteId } : undefined),
+    ci: doc.ci ?? (buildkite ? { buildkite } : undefined),
+  };
+}
+
 export class EvaluationScoreRepository {
   constructor(private readonly esClient: EsClient, private readonly log: SomeDevLog) {}
 
@@ -484,45 +519,19 @@ export class EvaluationScoreRepository {
 
       const buildkite = options.buildkite ?? getBuildkiteCiMetadataFromEnv();
       const suiteId = options.suiteId ?? process.env.EVAL_SUITE_ID;
-      const enrichedDocuments =
-        suiteId || buildkite
-          ? documents.map((doc) => ({
-              ...doc,
-              suite: doc.suite ?? (suiteId ? { id: suiteId } : undefined),
-              ci: doc.ci ?? (buildkite ? { buildkite } : undefined),
-            }))
-          : documents;
+      const enrichedDocuments = documents.map((doc) => enrichDocument(doc, suiteId, buildkite));
 
-      // Bulk index documents
       if (enrichedDocuments.length > 0) {
         const dropped: Array<BulkDroppedDocument<EvaluationScoreDocument>> = [];
 
         const stats = await this.esClient.helpers.bulk({
           datasource: enrichedDocuments,
-          onDocument: (doc) => {
-            // Documents are exported from multiple suites *and* multiple task models/connectors.
-            // Keep IDs unique across that matrix while maintaining deterministic IDs for re-runs.
-            const suiteIdPart = doc.suite?.id ?? 'unknown-suite';
-            const docId = [
-              doc.run_id,
-              suiteIdPart,
-              doc.task.model.id,
-              doc.example.dataset.id,
-              doc.example.id,
-              doc.evaluator.name,
-              doc.task.repetition_index,
-            ].join('-');
-
-            return {
-              // Data streams only allow create operations. Use deterministic document IDs so:
-              // - Re-runs/retries don't create duplicates (they'll 409 conflict instead)
-              // - We can treat 409s as a no-op for idempotency
-              create: {
-                _index: EVALUATIONS_DATA_STREAM_ALIAS,
-                _id: docId,
-              },
-            };
-          },
+          onDocument: (doc) => ({
+            create: {
+              _index: EVALUATIONS_DATA_STREAM_ALIAS,
+              _id: computeScoreDocumentId(doc),
+            },
+          }),
           onDrop: (droppedDoc) => {
             dropped.push(droppedDoc as BulkDroppedDocument<EvaluationScoreDocument>);
           },
@@ -586,6 +595,42 @@ export class EvaluationScoreRepository {
       const cause = error instanceof Error ? error : new Error(String(error));
       this.log.error('Failed to export scores to Elasticsearch', cause);
       throw cause;
+    }
+  }
+
+  /**
+   * Indexes a single evaluation score document to Elasticsearch immediately.
+   * Used for incremental writes so results survive worker crashes.
+   *
+   * Uses `refresh: false` to avoid the shard refresh penalty on every write;
+   * documents become queryable within the default 5s refresh interval.
+   * Deterministic IDs (via {@link computeScoreDocumentId}) make this idempotent —
+   * the batch export at teardown will simply encounter 409 conflicts for
+   * already-written documents.
+   */
+  async indexSingleScore(
+    document: EvaluationScoreDocument,
+    options: ExportScoresOptions = {}
+  ): Promise<void> {
+    await this.prepareLocalExportTarget();
+
+    const buildkite = options.buildkite ?? getBuildkiteCiMetadataFromEnv();
+    const suiteId = options.suiteId ?? process.env.EVAL_SUITE_ID;
+    const enrichedDoc = enrichDocument(document, suiteId, buildkite);
+    const docId = computeScoreDocumentId(enrichedDoc);
+
+    try {
+      await this.esClient.create({
+        index: EVALUATIONS_DATA_STREAM_ALIAS,
+        id: docId,
+        document: enrichedDoc,
+        refresh: false,
+      });
+    } catch (error: unknown) {
+      if (this.getErrorStatusCode(error) === 409) {
+        return;
+      }
+      throw error;
     }
   }
 

--- a/x-pack/platform/packages/shared/kbn-evals/src/utils/score_repository.ts
+++ b/x-pack/platform/packages/shared/kbn-evals/src/utils/score_repository.ts
@@ -428,7 +428,10 @@ export class EvaluationScoreRepository {
       this.localExportTargetReady = (async () => {
         await this.ensureIndexTemplate();
         await this.ensureDatastream();
-      })();
+      })().catch((err) => {
+        this.localExportTargetReady = undefined;
+        throw err;
+      });
     }
     return this.localExportTargetReady;
   }


### PR DESCRIPTION
Closes https://github.com/elastic/obs-ai-team/issues/526

## Summary

Introduces incremental writes to the `@kbn/evals` export pipeline so evaluation score documents are written to Elasticsearch as each example+evaluator completes, rather than in a single batch at worker fixture teardown.

### Problem

The result export pipeline was fully batched - `KibanaEvalsClient` accumulated all results in memory, and the export to Elasticsearch only happened during Playwright worker fixture teardown:

```mermaid
sequenceDiagram
    participant Worker as Playwright Worker
    participant Client as KibanaEvalsClient
    participant Memory as In-Memory Array
    participant ES as Elasticsearch
    loop For each test / runExperiment call
        Worker->>Client: runExperiment()
        loop For each example × repetition × evaluator
            Client->>Client: run task + evaluators
            Client->>Memory: push to this.experiments[]
        end
    end
    Note over Worker: All tests done — fixture teardown begins
    Worker->>Client: getRanExperiments()
    Client-->>Worker: all accumulated experiments
    Worker->>ES: helpers.bulk() — single batch write
    Note over ES: Results appear for the first time
```

This meant:
- Data loss on crash: If a worker timed out mid-suite (common with 20-30 min CI timeouts), all accumulated results were lost
- No real-time visibility: CI operators must wait for the entire suite to finish to see any results
- No live dashboards: Kibana dashboards can't react to in-progress eval runs

### Solution
Each evaluator result is now written to Elasticsearch immediately via a new `onEvaluationComplete` callback on `KibanaEvalsClient`. The batch export at teardown remains as an idempotent safety net - deterministic document IDs mean duplicate writes are harmlessly rejected as 409 conflicts:

```mermaid
sequenceDiagram
    participant Worker as Playwright Worker
    participant Client as KibanaEvalsClient
    participant Memory as In-Memory Array
    participant ES as Elasticsearch

    loop For each test / runExperiment call
        loop For each example × repetition × evaluator
            Client->>Client: run task + evaluators
            Client->>Memory: push to this.experiments[]
            Client->>ES: esClient.create() — immediate write
            Note over ES: Result visible within ~5s
        end
    end

    Note over Worker: All tests done — fixture teardown begins
    Worker->>ES: helpers.bulk() — batch write (409 no-op for existing docs)
```

#### Key design decisions
- Callback on `KibanaEvalsClient`, not on `EvalsExecutorClient` interface - the interface is shared with Phoenix which can't support per-evaluator callbacks
- `refresh: false` for incremental writes - avoids ~1s shard refresh penalty per write; documents become queryable within the default 5s refresh interval
- Errors are warnings, not failures - a failing incremental write does not crash the experiment. The batch export at teardown serves as the reliability backstop
- Deterministic IDs ensure idempotency - both incremental and batch exports use the same `computeScoreDocumentId()` formula

### Screenshots

#### Build running:
<img width="2044" height="993" alt="image" src="https://github.com/user-attachments/assets/cfdae1fd-c053-4e39-82d1-7b0ad067b6db" />

#### Results are getting exported before the run finishes:
<img width="1530" height="248" alt="image" src="https://github.com/user-attachments/assets/a07f12f2-2bf1-4695-a01d-2266d0f6a99e" />

https://github.com/user-attachments/assets/2de75985-4718-41ae-aaf0-0caa19d3aa49

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.



