### PR TITLE
[8.19] [Jest] Use Moon for scoped jest execution (#262160)

### DIFF
--- a/src/dev/run_check.test.ts
+++ b/src/dev/run_check.test.ts
@@ -7,8 +7,6 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import Os from 'os';
-
 jest.mock('@kbn/dev-cli-runner', () => ({
   run: jest.fn(),
 }));
@@ -22,10 +20,6 @@ jest.mock('@kbn/dev-validation-runner', () => ({
   resolveValidationBaseContext: jest.fn(),
   VALIDATION_RUN_HELP: [],
   VALIDATION_RUN_STRING_FLAGS: [],
-}));
-
-jest.mock('@kbn/moon', () => ({
-  getMoonExecutablePath: jest.fn().mockResolvedValue('/mock/moon'),
 }));
 
 jest.mock('@kbn/repo-info', () => ({
@@ -55,8 +49,20 @@ jest.mock('@kbn/tooling-log', () => ({
   })),
 }));
 
-jest.mock('@kbn/repo-packages', () => ({
-  getPackages: jest.fn(),
+const mockRunJestViaMoon = jest.fn();
+const mockFindJestConfig = jest.fn();
+
+jest.mock('@kbn/test', () => ({
+  runJestViaMoon: (...args: unknown[]) => mockRunJestViaMoon(...args),
+  findJestConfig: (...args: unknown[]) => mockFindJestConfig(...args),
+  JEST_CONFIG_NAMES: [
+    'jest.config.dev.js',
+    'jest.config.js',
+    'jest.config.cjs',
+    'jest.config.mjs',
+    'jest.config.ts',
+    'jest.config.json',
+  ],
 }));
 
 jest.mock('fs', () => ({
@@ -76,7 +82,6 @@ const mockExecuteTypeCheckValidation = jest.requireMock('./type_check_validation
   .executeTypeCheckValidation as jest.Mock;
 const mockExecuteEslintValidation = jest.requireMock('./eslint/run_eslint_contract')
   .executeEslintValidation as jest.Mock;
-const mockGetPackages = jest.requireMock('@kbn/repo-packages').getPackages as jest.Mock;
 const mockExistsSync = jest.requireMock('fs').existsSync as jest.Mock;
 const mockExeca = mockExecaFn;
 
@@ -127,7 +132,6 @@ const baseContext = {
 
 describe('run_check', () => {
   let stdoutSpy: jest.SpyInstance;
-  let cpusSpy: jest.SpyInstance;
   let previousExitCode: typeof process.exitCode;
 
   beforeAll(() => {
@@ -140,7 +144,6 @@ describe('run_check', () => {
     previousExitCode = process.exitCode;
     process.exitCode = undefined;
     stdoutSpy = jest.spyOn(process.stdout, 'write').mockReturnValue(true);
-    cpusSpy = jest.spyOn(Os, 'cpus').mockReturnValue(new Array(8).fill({}) as any);
     mockReadValidationRunFlags.mockReturnValue({});
     mockResolveValidationBaseContext.mockResolvedValue(baseContext);
     mockExistsSync.mockImplementation(
@@ -154,25 +157,22 @@ describe('run_check', () => {
       warningCount: 0,
     });
     mockExecuteTypeCheckValidation.mockResolvedValue({ projectCount: 2 });
-    mockGetPackages.mockReturnValue([
-      { directory: '/repo/packages/foo' },
-      { directory: '/repo/packages/bar' },
-    ]);
 
-    // Mock Moon jest run (success, 1 config ran, 5 tests via --json)
-    mockExeca.mockResolvedValue({
+    // Default: successful Moon jest run
+    mockRunJestViaMoon.mockResolvedValue({
+      taskCount: 1,
+      cachedCount: 0,
+      totalTests: 5,
+      failed: [],
       exitCode: 0,
-      stdout: [
-        'pass RunTask(@kbn/foo:jest) (1s 200ms, abc123)',
-        '@kbn/foo:jest | {"success":true,"numTotalTests":5,"numPassedTests":5,"numFailedTests":0,"testResults":[]}',
-      ].join('\n'),
-      stderr: '',
     });
+
+    // For fast path tests
+    mockFindJestConfig.mockReturnValue('packages/foo/jest.config.js');
   });
 
   afterEach(() => {
     process.exitCode = previousExitCode;
-    cpusSpy.mockRestore();
     stdoutSpy.mockRestore();
   });
 
@@ -312,11 +312,7 @@ describe('run_check', () => {
     expect(output).toContain('node scripts/jest packages/foo/src/bar.test.ts');
   });
 
-  it('still invokes Moon for downstream Jest tasks when the changed package has no local config', async () => {
-    mockGetPackages.mockReturnValue([
-      { directory: '/repo/packages/baz' },
-      { directory: '/repo/packages/foo' },
-    ]);
+  it('passes downstream flag to runJestViaMoon', async () => {
     mockResolveValidationBaseContext.mockResolvedValue({
       ...baseContext,
       contract: {
@@ -335,54 +331,31 @@ describe('run_check', () => {
 
     await handler(createArgs());
 
-    expect(mockExeca).toHaveBeenCalledWith(
-      '/mock/moon',
-      expect.arrayContaining(['--affected', '--stdin', '--downstream', 'deep']),
-      expect.any(Object)
+    expect(mockRunJestViaMoon).toHaveBeenCalledWith(
+      expect.objectContaining({
+        changedFiles: ['packages/baz/src/index.ts'],
+        downstream: 'deep',
+      })
     );
 
     const output = stdoutSpy.mock.calls.map(([text]: [string]) => text).join('');
     expect(output).toContain('jest  ✓ 1 config ran, 5 tests');
   });
 
-  it('caps Moon concurrency at two for cache-heavy affected Jest runs', async () => {
-    mockGetPackages.mockReturnValue([
-      { directory: '/repo/packages/foo' },
-      { directory: '/repo/packages/bar' },
-      { directory: '/repo/packages/baz' },
-      { directory: '/repo/packages/qux' },
-    ]);
-    mockResolveValidationBaseContext.mockResolvedValue({
-      ...baseContext,
-      runContext: {
-        ...baseContext.runContext,
-        changedFiles: [
-          'packages/foo/src/index.ts',
-          'packages/bar/src/index.ts',
-          'packages/baz/src/index.ts',
-          'packages/qux/src/index.ts',
-        ],
-      },
-    });
-
-    await handler(createArgs());
-
-    expect(mockExeca).toHaveBeenCalledWith(
-      '/mock/moon',
-      expect.arrayContaining(['--concurrency', '2', '--maxWorkers=4']),
-      expect.any(Object)
-    );
-  });
-
   it('reports Moon Jest startup failures instead of saying no affected configs', async () => {
-    mockExeca.mockResolvedValue({
+    mockRunJestViaMoon.mockResolvedValue({
+      taskCount: 0,
+      cachedCount: 0,
+      totalTests: 0,
+      failed: [],
       exitCode: 1,
-      stdout: '',
-      stderr: [
+      failureExcerpt: [
         '@kbn/foo:jest | Error: task_runner::run_failed',
-        '@kbn/foo:jest | Broken startup before Jest JSON output',
-        'Error: task_runner::run_failed',
-      ].join('\n'),
+        'Broken startup before Jest JSON output',
+      ],
+      warnings: [
+        'Moon exited with code 1 but no Jest task output was parsed. The Jest task may have failed before producing JSON output — run jest directly to verify.',
+      ],
     });
 
     await handler(createArgs());
@@ -394,29 +367,38 @@ describe('run_check', () => {
     expect(output).not.toContain('jest  — no affected configs');
   });
 
-  it('uses the repo root Jest config when no package-level config is found', async () => {
-    mockExistsSync.mockImplementation((p: string) => p === '/repo/jest.config.js');
-    mockResolveValidationBaseContext.mockResolvedValue({
-      ...baseContext,
-      runContext: {
-        ...baseContext.runContext,
-        changedFiles: ['packages/foo/src/index.ts'],
-      },
-    });
-    mockExeca.mockResolvedValue({
-      exitCode: 0,
-      stdout: [
-        'fail RunTask(@kbn/foo:jest) (1s 200ms, abc123)',
-        '@kbn/foo:jest | {"success":false,"numTotalTests":1,"numPassedTests":0,"numFailedTests":1,"testResults":[{"name":"/repo/packages/foo/src/bar.test.ts","assertionResults":[{"status":"failed","fullName":"fails","failureMessages":["Error\\n    at /repo/packages/foo/src/bar.test.ts:12:3"]}]}]}',
-      ].join('\n'),
-      stderr: '',
+  it('reports failed Jest configs with failure details', async () => {
+    mockRunJestViaMoon.mockResolvedValue({
+      taskCount: 2,
+      cachedCount: 0,
+      totalTests: 3,
+      failed: [
+        {
+          project: '@kbn/foo',
+          configPath: 'packages/foo/jest.config.js',
+          cached: false,
+          passed: false,
+          testCount: 1,
+          failures: [
+            {
+              file: 'packages/foo/src/bar.test.ts',
+              line: 12,
+              name: 'bar should work',
+              message: 'Error: expected true\n    at /repo/packages/foo/src/bar.test.ts:12:3',
+            },
+          ],
+        },
+      ],
+      exitCode: 1,
     });
 
     await handler(createArgs());
 
     expect(process.exitCode).toBe(1);
     const output = stdoutSpy.mock.calls.map(([text]: [string]) => text).join('');
-    expect(output).toContain('node scripts/jest --config jest.config.js');
+    expect(output).toContain('jest  ✗');
+    expect(output).toContain('FAIL packages/foo/src/bar.test.ts:12');
+    expect(output).toContain('node scripts/jest --config packages/foo/jest.config.js');
   });
 
   it('uses the repo root tsconfig in the tsc rerun command when no nearer config exists', async () => {

--- a/src/dev/run_check.ts
+++ b/src/dev/run_check.ts
@@ -8,7 +8,6 @@
  */
 
 import { existsSync } from 'fs';
-import Os from 'os';
 import Path from 'path';
 
 import { run } from '@kbn/dev-cli-runner';
@@ -20,9 +19,14 @@ import {
   VALIDATION_RUN_HELP,
   VALIDATION_RUN_STRING_FLAGS,
 } from '@kbn/dev-validation-runner';
-import { getMoonExecutablePath } from '@kbn/moon';
 import { REPO_ROOT } from '@kbn/repo-info';
 import { ToolingLog, type Message, type Writer } from '@kbn/tooling-log';
+import {
+  runJestViaMoon,
+  findJestConfig,
+  type MoonJestResult,
+  type JestFailedTest,
+} from '@kbn/test';
 import { executeTypeCheckValidation } from './type_check_validation_loader';
 
 import { executeEslintValidation } from './eslint/run_eslint_contract';
@@ -130,408 +134,11 @@ const formatHeader = (baseContext: ValidationBaseContext) => {
 
 // ── Jest via Moon ───────────────────────────────────────────────────────────
 
-const JEST_CONFIG_NAMES = [
-  'jest.config.dev.js',
-  'jest.config.js',
-  'jest.config.cjs',
-  'jest.config.mjs',
-  'jest.config.ts',
-  'jest.config.json',
-] as const;
-
 const TEST_FILE_RE = /\.(?:test|spec)\.(js|mjs|ts|tsx)$/;
 
 const isTestFile = (filePath: string) => TEST_FILE_RE.test(filePath);
 
-interface JestFailedTest {
-  file: string;
-  line?: number;
-  name: string;
-  message: string;
-}
-
-interface MoonJestTaskResult {
-  project: string;
-  configPath?: string;
-  cached: boolean;
-  passed: boolean;
-  testCount: number;
-  failures: JestFailedTest[];
-}
-
 const stripAnsi = (s: string) => s.replace(/\x1B\[[0-9;]*[A-Za-z]/g, '');
-
-const findJestConfig = (testFilePath: string): string | undefined => {
-  let dir = Path.dirname(Path.resolve(REPO_ROOT, testFilePath));
-  while (true) {
-    for (const configName of JEST_CONFIG_NAMES) {
-      const configPath = Path.join(dir, configName);
-      if (existsSync(configPath)) {
-        return Path.relative(REPO_ROOT, configPath);
-      }
-    }
-
-    if (dir === REPO_ROOT || dir === Path.dirname(dir)) {
-      break;
-    }
-
-    dir = Path.dirname(dir);
-  }
-  return undefined;
-};
-
-interface MoonJestParseResult {
-  tasks: MoonJestTaskResult[];
-  parseFailures: string[];
-}
-
-const parseMoonJestOutput = (output: string): MoonJestParseResult => {
-  const results = new Map<string, MoonJestTaskResult>();
-  const cachedProjects = new Set<string>();
-  const parseFailures: string[] = [];
-
-  for (const rawLine of output.split('\n')) {
-    const stripped = stripAnsi(rawLine).trim();
-
-    // "pass RunTask(@kbn/foo:jest) (cached, ...)" from --summary detailed
-    const cachedMatch = stripped.match(/^pass RunTask\((@[^:]+):jest\) \(cached/);
-    if (cachedMatch) {
-      cachedProjects.add(cachedMatch[1]);
-      continue;
-    }
-
-    // Jest --json output: either prefixed "@kbn/foo:jest | {...}" or unprefixed "{...}"
-    const jsonPrefixMatch = stripped.match(/^(@[^:]+):jest \| \{/);
-    const isUnprefixedJson = !jsonPrefixMatch && stripped.startsWith('{"num');
-    if (jsonPrefixMatch || isUnprefixedJson) {
-      const project = jsonPrefixMatch ? jsonPrefixMatch[1] : '_single';
-      const jsonStr = stripped.replace(/^[^{]*/, '');
-      try {
-        const json = JSON.parse(jsonStr);
-        const failures: JestFailedTest[] = [];
-
-        for (const suite of json.testResults ?? []) {
-          const file = Path.relative(REPO_ROOT, suite.name);
-          for (const assertion of suite.assertionResults ?? []) {
-            if (assertion.status === 'failed') {
-              const message = (assertion.failureMessages ?? []).join('\n');
-              const lineMatch = stripAnsi(message).match(
-                new RegExp(`${suite.name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}:(\\d+)`)
-              );
-              failures.push({
-                file,
-                line: lineMatch ? parseInt(lineMatch[1], 10) : undefined,
-                name: assertion.fullName ?? assertion.title ?? 'unknown',
-                message,
-              });
-            }
-          }
-        }
-
-        const firstTestFile = json.testResults?.[0]?.name;
-        results.set(project, {
-          project,
-          configPath: firstTestFile
-            ? findJestConfig(Path.relative(REPO_ROOT, firstTestFile))
-            : undefined,
-          cached: false,
-          passed: json.success === true,
-          testCount: json.numTotalTests ?? 0,
-          failures,
-        });
-      } catch (err) {
-        parseFailures.push(
-          `Failed to parse Jest JSON from project ${project}: ${
-            err instanceof Error ? err.message : String(err)
-          }`
-        );
-      }
-    }
-  }
-
-  // Mark cached tasks (they replay JSON output, so they'll be in results already)
-  for (const project of cachedProjects) {
-    const existing = results.get(project);
-    if (existing) {
-      existing.cached = true;
-    } else {
-      results.set(project, {
-        project,
-        cached: true,
-        passed: true,
-        testCount: 0,
-        failures: [],
-      });
-    }
-  }
-
-  return { tasks: [...results.values()], parseFailures };
-};
-
-interface AffectedPackageInfo {
-  dirs: string[];
-  jestDirs: string[];
-}
-
-/** Find the owning package directory for a file (longest prefix match). */
-const findOwningPackage = (file: string, dirs: string[]): string | undefined => {
-  let best: string | undefined;
-  for (const dir of dirs) {
-    if (file.startsWith(dir + '/') && (!best || dir.length > best.length)) {
-      best = dir;
-    }
-  }
-  return best;
-};
-
-const resolveAffectedPackageInfo = async (files: string[]): Promise<AffectedPackageInfo> => {
-  const { getPackages } = await import('@kbn/repo-packages');
-  const sortedDirs = getPackages(REPO_ROOT)
-    .map((pkg) => Path.relative(REPO_ROOT, pkg.directory))
-    .sort();
-
-  const matched = new Set<string>();
-  for (const file of files) {
-    const owner = findOwningPackage(file, sortedDirs);
-    if (owner) {
-      matched.add(owner);
-    }
-  }
-
-  const dirs = [...matched];
-  const jestDirs = dirs.filter((dir) =>
-    JEST_CONFIG_NAMES.some((name) => existsSync(Path.resolve(REPO_ROOT, dir, name)))
-  );
-
-  return { dirs, jestDirs };
-};
-
-/**
- * Keep Moon concurrency low so cache-heavy affected runs do not starve the real
- * Jest work of CPU. Example: if 4 configs are scheduled and 3 are cached, we
- * want the 1 uncached Jest process to keep most cores instead of reserving them
- * for Moon slots that finish immediately.
- *
- * - maxWorkers never drops below 2
- * - Moon concurrency caps at 2
- */
-const computeJestParallelism = (estimatedTasks: number) => {
-  const cpus = Os.cpus().length;
-  const safeEstimatedTasks = Math.max(1, estimatedTasks);
-  const concurrency = Math.min(safeEstimatedTasks, 2);
-  const maxWorkers = Math.max(2, Math.floor(cpus / concurrency));
-  return { concurrency, maxWorkers };
-};
-
-interface JestPhaseResult {
-  taskCount: number;
-  cachedCount: number;
-  totalTests: number;
-  failed: MoonJestTaskResult[];
-  exitCode: number;
-  verboseDetail?: string;
-  failureExcerpt?: string[];
-  warnings?: string[];
-}
-
-interface JestPhaseProgress {
-  completedCount: number;
-}
-
-const extractMoonFailureExcerpt = (output: string) => {
-  return output
-    .split('\n')
-    .map((lineText) => stripAnsi(lineText).trim())
-    .filter(Boolean)
-    .filter((lineText) => !lineText.startsWith('{'))
-    .slice(-8);
-};
-
-const parseMoonJestProgressProject = (rawLine: string) => {
-  const stripped = stripAnsi(rawLine).trim();
-
-  const cachedSummaryMatch = stripped.match(/^pass RunTask\((@[^:]+):jest\) \(cached/);
-  if (cachedSummaryMatch) {
-    return cachedSummaryMatch[1];
-  }
-
-  const summaryMatch = stripped.match(/^(?:pass|fail) RunTask\((@[^:]+):jest\) \(/);
-  if (summaryMatch) {
-    return summaryMatch[1];
-  }
-
-  const jsonPrefixMatch = stripped.match(/^(@[^:]+):jest \| \{/);
-  if (jsonPrefixMatch) {
-    return jsonPrefixMatch[1];
-  }
-
-  return undefined;
-};
-
-const attachOutputLineListeners = ({
-  stream,
-  onChunk,
-  onLine,
-}: {
-  stream?: NodeJS.ReadableStream | null;
-  onChunk: (chunk: string) => void;
-  onLine: (line: string) => void;
-}) => {
-  if (!stream) {
-    return;
-  }
-
-  let pending = '';
-  stream.on('data', (chunk) => {
-    const text = chunk.toString();
-    onChunk(text);
-    pending += text;
-
-    while (true) {
-      const newlineIndex = pending.indexOf('\n');
-      if (newlineIndex === -1) {
-        break;
-      }
-
-      onLine(pending.slice(0, newlineIndex));
-      pending = pending.slice(newlineIndex + 1);
-    }
-  });
-
-  stream.on('end', () => {
-    if (pending.length > 0) {
-      onLine(pending);
-    }
-  });
-};
-
-const runJestViaMoon = async (
-  changedFiles: string[],
-  verbose: boolean,
-  downstream: string = 'none',
-  onProgress?: (progress: JestPhaseProgress) => void
-): Promise<JestPhaseResult | null> => {
-  const packageInfo = await resolveAffectedPackageInfo(changedFiles);
-  const changedFilesJson = JSON.stringify({ files: changedFiles });
-
-  const execa = (await import('execa')).default;
-  const moonExec = await getMoonExecutablePath();
-  const { concurrency, maxWorkers } = computeJestParallelism(
-    Math.max(packageInfo.jestDirs.length, packageInfo.dirs.length)
-  );
-  const cpus = Os.cpus().length;
-  const completedProjects = new Set<string>();
-
-  const subprocess = execa(
-    moonExec,
-    [
-      'run',
-      ':jest',
-      '--affected',
-      '--stdin',
-      ...(downstream !== 'none' ? ['--downstream', downstream] : []),
-      '--concurrency',
-      String(concurrency),
-      '--summary',
-      'detailed',
-      '--',
-      `--maxWorkers=${maxWorkers}`,
-      '--json',
-      '--passWithNoTests',
-    ],
-    {
-      cwd: REPO_ROOT,
-      input: changedFilesJson,
-      reject: false,
-      env: {
-        ...process.env,
-        CI_STATS_DISABLED: 'true',
-        FORCE_COLOR: '1',
-      },
-    }
-  );
-
-  let capturedStdout = '';
-  let capturedStderr = '';
-
-  const handleOutputLine = (lineText: string) => {
-    const project = parseMoonJestProgressProject(lineText);
-    if (!project || completedProjects.has(project)) {
-      return;
-    }
-
-    completedProjects.add(project);
-    onProgress?.({
-      completedCount: completedProjects.size,
-    });
-  };
-
-  attachOutputLineListeners({
-    stream: 'stdout' in subprocess ? subprocess.stdout : undefined,
-    onChunk: (chunk) => {
-      capturedStdout += chunk;
-    },
-    onLine: handleOutputLine,
-  });
-  attachOutputLineListeners({
-    stream: 'stderr' in subprocess ? subprocess.stderr : undefined,
-    onChunk: (chunk) => {
-      capturedStderr += chunk;
-    },
-    onLine: handleOutputLine,
-  });
-
-  const result = await subprocess;
-
-  const output =
-    (capturedStdout || result.stdout || '') + '\n' + (capturedStderr || result.stderr || '');
-  const { tasks, parseFailures } = parseMoonJestOutput(output);
-  const failed = tasks.filter((t) => !t.passed && !t.cached);
-  if (tasks.length === 0 && result.exitCode !== 0) {
-    const warnings = [
-      `Moon exited with code ${result.exitCode} but no Jest task output was parsed. ` +
-        `The Jest task may have failed before producing JSON output — run jest directly to verify.`,
-    ];
-    if (parseFailures.length > 0) {
-      warnings.push(...parseFailures);
-    }
-
-    const cachedCount = tasks.filter((t) => t.cached).length;
-    const ranCount = tasks.length - cachedCount;
-
-    return {
-      taskCount: tasks.length,
-      cachedCount,
-      totalTests: tasks.reduce((sum, t) => sum + t.testCount, 0),
-      failed,
-      exitCode: result.exitCode ?? 0,
-      failureExcerpt:
-        tasks.length === 0 && result.exitCode !== 0 ? extractMoonFailureExcerpt(output) : undefined,
-      warnings,
-      verboseDetail: verbose
-        ? `${packageInfo.jestDirs.length} packages, ${ranCount} ran, ${cachedCount} cached, ${cpus} cpus → concurrency=${concurrency}, maxWorkers=${maxWorkers}`
-        : undefined,
-    };
-  }
-
-  const warnings = parseFailures.length > 0 ? parseFailures : undefined;
-  const cachedCount = tasks.filter((t) => t.cached).length;
-  const ranCount = tasks.length - cachedCount;
-
-  return {
-    taskCount: tasks.length,
-    cachedCount,
-    totalTests: tasks.reduce((sum, t) => sum + t.testCount, 0),
-    failed,
-    exitCode: result.exitCode ?? 0,
-    failureExcerpt:
-      tasks.length === 0 && result.exitCode !== 0 ? extractMoonFailureExcerpt(output) : undefined,
-    warnings,
-    verboseDetail: verbose
-      ? `${packageInfo.jestDirs.length} packages, ${ranCount} ran, ${cachedCount} cached, ${cpus} cpus → concurrency=${concurrency}, maxWorkers=${maxWorkers}`
-      : undefined,
-  };
-};
 
 const runJestTestsDirectly = async (
   testFiles: string[]
@@ -702,8 +309,13 @@ run(
         try {
           const downstream =
             baseContext.mode === 'contract' ? baseContext.contract.downstream : 'none';
-          const result = await runJestViaMoon(changedFiles, verbose, downstream, (progress) => {
-            jestProgress.setDetail(`[${progress.completedCount} complete]`);
+          const result = await runJestViaMoon({
+            changedFiles,
+            verbose,
+            downstream,
+            onProgress: (progress) => {
+              jestProgress.setDetail(`[${progress.completedCount} complete]`);
+            },
           });
 
           const printVerbose = () => {
@@ -717,7 +329,7 @@ run(
             }
           };
 
-          const formatJestSummary = (r: JestPhaseResult) => {
+          const formatJestSummary = (r: MoonJestResult) => {
             const ran = r.taskCount - r.cachedCount;
             const parts = [];
             if (ran > 0) parts.push(`${pluralize(ran, 'config')} ran`);

--- a/src/dev/tsconfig.json
+++ b/src/dev/tsconfig.json
@@ -50,6 +50,5 @@
     "@kbn/sort-package-json",
     "@kbn/babel-register",
     "@kbn/dev-validation-runner",
-    "@kbn/moon",
   ]
 }

--- a/src/platform/packages/shared/kbn-dev-proc-runner/src/proc.ts
+++ b/src/platform/packages/shared/kbn-dev-proc-runner/src/proc.ts
@@ -33,6 +33,8 @@ export interface ProcOptions {
   env?: Record<string, string | undefined>;
   stdin?: string;
   writeLogsToPath?: string;
+  /** When provided, each output line (ANSI-stripped) is pushed to this array. */
+  captureOutputLines?: string[];
 }
 
 async function withTimeout(
@@ -134,6 +136,10 @@ export function startProc(name: string, options: ProcOptions, log: ToolingLog) {
   ).pipe(
     tap({
       next(line) {
+        if (options.captureOutputLines) {
+          options.captureOutputLines.push(stripAnsi(line));
+        }
+
         if (stdioTarget) {
           stdioTarget.write(stripAnsi(line) + '\n');
         } else {

--- a/src/platform/packages/shared/kbn-dev-proc-runner/src/proc_runner.ts
+++ b/src/platform/packages/shared/kbn-dev-proc-runner/src/proc_runner.ts
@@ -55,17 +55,8 @@ export class ProcRunner {
    *  Start a process, tracking it by `name`
    */
   async run(name: string, options: RunOptions) {
-    const {
-      args = [],
-      cwd = process.cwd(),
-      stdin = undefined,
-      wait = false,
-      waitTimeout = 15 * MINUTE,
-      env = process.env,
-      onEarlyExit,
-      writeLogsToPath,
-    } = options;
-    const cmd = options.cmd === 'node' ? process.execPath : options.cmd;
+    const { wait = false, waitTimeout = 15 * MINUTE, onEarlyExit, ...procOptions } = options;
+    const cmd = procOptions.cmd === 'node' ? process.execPath : procOptions.cmd;
 
     if (this.closing) {
       throw new Error('ProcRunner is closing');
@@ -80,12 +71,8 @@ export class ProcRunner {
     }
 
     const proc = this.startProc(name, {
+      ...procOptions,
       cmd,
-      args,
-      cwd,
-      env,
-      stdin,
-      writeLogsToPath,
     });
 
     if (onEarlyExit) {

--- a/src/platform/packages/shared/kbn-test/index.ts
+++ b/src/platform/packages/shared/kbn-test/index.ts
@@ -74,6 +74,18 @@ export {
 } from './src/jest/run_contract';
 export type { JestConfigResult, JestValidationResult } from './src/jest/run_contract';
 
+export {
+  runJestViaMoon,
+  parseMoonJestOutput,
+  findJestConfig,
+  JEST_CONFIG_NAMES,
+} from './src/jest/run_jest_via_moon';
+export type {
+  MoonJestResult,
+  MoonJestTaskResult,
+  JestFailedTest,
+} from './src/jest/run_jest_via_moon';
+
 export * from './src/kbn_archiver_cli';
 
 export * from '@kbn/kbn-client';

--- a/src/platform/packages/shared/kbn-test/moon.yml
+++ b/src/platform/packages/shared/kbn-test/moon.yml
@@ -42,6 +42,7 @@ dependsOn:
   - '@kbn/scout-info'
   - '@kbn/react-mute-legacy-root-warning'
   - '@kbn/babel-preset'
+  - '@kbn/moon'
 tags:
   - shared-common
   - package

--- a/src/platform/packages/shared/kbn-test/src/jest/run_contract.test.ts
+++ b/src/platform/packages/shared/kbn-test/src/jest/run_contract.test.ts
@@ -38,7 +38,7 @@ jest.mock('./run', () => ({
   runJest: jest.fn(),
 }));
 
-import { parseJestRunOutput, planJestContractRuns } from './run_contract';
+import { planJestContractRuns } from './run_contract';
 
 describe('planJestContractRuns', () => {
   it('forces a full config run for config-only changes', () => {
@@ -140,34 +140,5 @@ describe('planJestContractRuns', () => {
         mode: 'full',
       },
     ]);
-  });
-});
-
-describe('parseJestRunOutput', () => {
-  it('extracts failed test files and summary lines from jest stdout', () => {
-    expect(
-      parseJestRunOutput(`
-        PASS packages/foo/src/a.test.ts
-        FAIL packages/foo/src/b.test.ts
-        FAIL packages/foo/src/c.test.ts
-
-        Test Suites: 2 failed, 1 passed, 3 total
-        Tests:       4 failed, 10 passed, 14 total
-        Snapshots:   3 failed, 1 passed, 4 total
-      `)
-    ).toEqual({
-      excerpt: [
-        'PASS packages/foo/src/a.test.ts',
-        'FAIL packages/foo/src/b.test.ts',
-        'FAIL packages/foo/src/c.test.ts',
-        'Test Suites: 2 failed, 1 passed, 3 total',
-        'Tests:       4 failed, 10 passed, 14 total',
-        'Snapshots:   3 failed, 1 passed, 4 total',
-      ],
-      failedTestFiles: ['packages/foo/src/b.test.ts', 'packages/foo/src/c.test.ts'],
-      snapshots: 'Snapshots:   3 failed, 1 passed, 4 total',
-      suites: 'Test Suites: 2 failed, 1 passed, 3 total',
-      tests: 'Tests:       4 failed, 10 passed, 14 total',
-    });
   });
 });

--- a/src/platform/packages/shared/kbn-test/src/jest/run_contract.ts
+++ b/src/platform/packages/shared/kbn-test/src/jest/run_contract.ts
@@ -7,50 +7,31 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { existsSync } from 'fs';
-import * as Fsp from 'fs/promises';
-import Os from 'os';
 import Path from 'path';
-
-import { makeRe } from 'minimatch';
 
 import { run } from '@kbn/dev-cli-runner';
 import { createFailError } from '@kbn/dev-cli-errors';
-import { ProcRunner } from '@kbn/dev-proc-runner';
+import type { ProcRunner } from '@kbn/dev-proc-runner';
 import {
   buildValidationCliArgs,
   describeValidationNoTargetsScope,
   formatReproductionCommand,
   hasValidationRunFlags,
   readValidationRunFlags,
-  resolveValidationAffectedProjects,
   resolveValidationBaseContext,
   type ValidationBaseContext,
   VALIDATION_RUN_HELP,
   VALIDATION_RUN_STRING_FLAGS,
 } from '@kbn/dev-validation-runner';
 import { REPO_ROOT } from '@kbn/repo-info';
-import { ToolingLog, type Message, type Writer } from '@kbn/tooling-log';
+import type { ToolingLog } from '@kbn/tooling-log';
 
-import { testMatch } from '../../jest-preset';
-import { findConfigInDirectoryTree, runJest } from './run';
+import { runJest } from './run';
+import { runJestViaMoon, type MoonJestTaskResult } from './run_jest_via_moon';
 
 export const JEST_LABEL = 'jest';
 export const JEST_LOG_PREFIX = `[${JEST_LABEL}]`;
-const JEST_CONFIG_NAMES = [
-  'jest.config.dev.js',
-  'jest.config.js',
-  'jest.config.cjs',
-  'jest.config.mjs',
-  'jest.config.ts',
-  'jest.config.json',
-] as const;
-const testMatchers = (testMatch as string[]).flatMap((pattern) => {
-  const re = makeRe(pattern);
-  return re ? [re] : [];
-});
 
-type ProcRunnerLike = Pick<ProcRunner, 'run'>;
 type JestContractTestMode = 'related' | 'affected';
 
 interface JestConfigSelectionState {
@@ -91,16 +72,8 @@ export interface ExecuteJestValidationOptions {
   baseContext: ValidationBaseContext;
   log: ToolingLog;
   passthroughArgs?: string[];
-  procRunner: ProcRunnerLike;
+  procRunner: Pick<ProcRunner, 'run'>;
   onConfigResult?: (result: JestConfigResult) => void;
-}
-
-export interface ParsedJestRunOutput {
-  excerpt: string[];
-  failedTestFiles: string[];
-  snapshots?: string;
-  suites?: string;
-  tests?: string;
 }
 
 const hasArgFlag = (args: string[], flag: string) => {
@@ -126,160 +99,6 @@ const stripValidationArgs = (args: string[]) => {
   }
 
   return passthroughArgs;
-};
-
-const createProcLogFilter = (writer: Writer): Writer => ({
-  write(message: Message) {
-    if (message.source === 'ProcRunner') {
-      return false;
-    }
-
-    return writer.write(message);
-  },
-});
-
-const createQuietProcRunner = (log: ToolingLog) => {
-  const quietLog = new ToolingLog();
-  quietLog.setWriters(log.getWriters().map(createProcLogFilter));
-  return new ProcRunner(quietLog);
-};
-
-const createJestOutputPath = (configRepoRel: string) =>
-  Path.join(
-    Os.tmpdir(),
-    `kbn-jest-${configRepoRel.replace(/[\\/]/g, '_')}-${process.pid}-${Date.now()}.log`
-  );
-
-const wait = async (durationMs: number) => {
-  await new Promise((resolve) => setTimeout(resolve, durationMs));
-};
-
-const findSummaryLine = (lines: string[], prefix: string) =>
-  lines.find((line) => line.startsWith(`${prefix}:`));
-
-/** Parses Jest stdout/stderr into a compact summary for logging and failures. */
-export const parseJestRunOutput = (output: string): ParsedJestRunOutput => {
-  const lines = output
-    .split(/\r?\n/u)
-    .map((line) => line.trim())
-    .filter(Boolean);
-
-  return {
-    excerpt: lines.filter((line) => !line.startsWith('info yarn jest')).slice(-8),
-    failedTestFiles: lines
-      .filter((line) => line.startsWith('FAIL '))
-      .map((line) => line.slice('FAIL '.length).trim()),
-    snapshots: findSummaryLine(lines, 'Snapshots'),
-    suites: findSummaryLine(lines, 'Test Suites'),
-    tests: findSummaryLine(lines, 'Tests'),
-  };
-};
-
-/**
- * Reads Jest output from a log file, retrying until two consecutive reads
- * return identical content. This is a heuristic to wait for the ProcRunner
- * to finish flushing — there is no explicit "write complete" signal.
- */
-const readParsedJestRunOutput = async (outputPath: string) => {
-  let previousOutput = '';
-
-  for (let attempt = 0; attempt < 5; attempt += 1) {
-    try {
-      const output = await Fsp.readFile(outputPath, 'utf8');
-      if (output && output === previousOutput) {
-        return parseJestRunOutput(output);
-      }
-
-      previousOutput = output;
-    } catch {
-      previousOutput = '';
-    }
-
-    await wait(50);
-  }
-
-  return parseJestRunOutput(previousOutput);
-};
-
-const formatSummaryValue = (summaryLine: string | undefined, label: string) => {
-  if (!summaryLine) {
-    return undefined;
-  }
-
-  return `${label} ${summaryLine.replace(/^[^:]+:\s*/u, '')}`;
-};
-
-const formatJestRunSummary = (parsedOutput: ParsedJestRunOutput) =>
-  [
-    formatSummaryValue(parsedOutput.suites, 'suites'),
-    formatSummaryValue(parsedOutput.tests, 'tests'),
-    formatSummaryValue(parsedOutput.snapshots, 'snapshots'),
-  ]
-    .filter((value): value is string => value !== undefined)
-    .join('; ');
-
-const extractTestCount = (parsedOutput: ParsedJestRunOutput): number => {
-  const match = parsedOutput.tests?.match(/(\d+) total/);
-  return match ? parseInt(match[1], 10) : 0;
-};
-
-const buildJestFailureMessage = ({
-  commandForLog,
-  configRepoRel,
-  parsedOutput,
-}: {
-  commandForLog: string;
-  configRepoRel: string;
-  parsedOutput: ParsedJestRunOutput;
-}) => {
-  const lines = [`${JEST_LABEL} failed for ${configRepoRel}.`];
-  const summary = formatJestRunSummary(parsedOutput);
-
-  if (summary) {
-    lines.push(`Summary: ${summary}`);
-  }
-
-  if (parsedOutput.failedTestFiles.length > 0) {
-    lines.push('Failed test file(s):');
-    for (const failedTestFile of parsedOutput.failedTestFiles.slice(0, 5)) {
-      lines.push(`  ${failedTestFile}`);
-    }
-
-    if (parsedOutput.failedTestFiles.length > 5) {
-      lines.push(`  ... and ${parsedOutput.failedTestFiles.length - 5} more`);
-    }
-  }
-
-  if (!summary && parsedOutput.excerpt.length > 0) {
-    lines.push('Error excerpt:');
-    for (const line of parsedOutput.excerpt) {
-      lines.push(`  ${line}`);
-    }
-  }
-
-  lines.push('Re-run directly with:');
-  lines.push(`  ${commandForLog}`);
-
-  if (parsedOutput.snapshots?.includes('failed')) {
-    lines.push('Update snapshots with:');
-    lines.push(`  ${commandForLog} -u`);
-  }
-
-  return lines.join('\n');
-};
-
-const isUnitJestConfigFile = (repoRelPath: string) => {
-  const basename = Path.basename(repoRelPath);
-  return JEST_CONFIG_NAMES.includes(basename as (typeof JEST_CONFIG_NAMES)[number]);
-};
-
-const isTestFile = (repoRelPath: string) => {
-  return testMatchers.some((matcher) => matcher.test(repoRelPath));
-};
-
-const resolveOwningConfig = (repoRelPath: string) => {
-  const absolutePath = Path.resolve(REPO_ROOT, repoRelPath);
-  return findConfigInDirectoryTree(Path.dirname(absolutePath), [...JEST_CONFIG_NAMES]);
 };
 
 const isFullJestRun = (baseContext: ValidationBaseContext) => {
@@ -365,64 +184,11 @@ export const planJestContractRuns = ({
     });
 };
 
-const runJestForConfig = async ({
-  log,
-  procRunner,
-  configPath,
-  passthroughArgs,
-  relatedFiles,
-}: {
-  log: ToolingLog;
-  procRunner: ProcRunnerLike;
-  configPath: string;
-  passthroughArgs: string[];
-  relatedFiles?: string[];
-}): Promise<ParsedJestRunOutput> => {
-  const configRepoRel = Path.relative(REPO_ROOT, configPath);
-  const args = ['scripts/jest', '--config', configRepoRel];
-  const outputPath = createJestOutputPath(configRepoRel);
-
-  if (relatedFiles && relatedFiles.length > 0) {
-    args.push('--findRelatedTests', ...relatedFiles);
-  }
-
-  args.push('--passWithNoTests');
-  args.push(...passthroughArgs);
-
-  const commandForLog = `node ${args.join(' ')}`;
-
-  try {
-    await procRunner.run('jest', {
-      cmd: process.execPath,
-      args,
-      cwd: REPO_ROOT,
-      wait: true,
-      writeLogsToPath: outputPath,
-    });
-
-    const parsedOutput = await readParsedJestRunOutput(outputPath);
-    const summary = formatJestRunSummary(parsedOutput);
-    log.success(`${JEST_LOG_PREFIX} passed ${configRepoRel}${summary ? ` (${summary})` : ''}`);
-    return parsedOutput;
-  } catch {
-    const parsedOutput = await readParsedJestRunOutput(outputPath);
-    throw createFailError(
-      buildJestFailureMessage({
-        commandForLog,
-        configRepoRel,
-        parsedOutput,
-      })
-    );
-  } finally {
-    await Fsp.unlink(outputPath).catch(() => undefined);
-  }
-};
-
 const runJestAllConfigs = async ({
   procRunner,
   passthroughArgs,
 }: {
-  procRunner: ProcRunnerLike;
+  procRunner: Pick<ProcRunner, 'run'>;
   passthroughArgs: string[];
 }) => {
   const args = ['scripts/jest_all', ...passthroughArgs];
@@ -442,16 +208,59 @@ const runJestAllConfigs = async ({
   }
 };
 
+const stripAnsiCodes = (s: string) => s.replace(/\x1B\[[0-9;]*[A-Za-z]/g, '');
+
+const formatMoonFailure = (task: MoonJestTaskResult): string => {
+  const lines: string[] = [];
+
+  // Group failures by file
+  const byFile = new Map<string, typeof task.failures>();
+  for (const f of task.failures) {
+    const list = byFile.get(f.file) ?? [];
+    list.push(f);
+    byFile.set(f.file, list);
+  }
+
+  for (const [file, failures] of byFile) {
+    const firstLine = failures[0]?.line;
+    const fileRef = firstLine ? `${file}:${firstLine}` : file;
+    lines.push(`FAIL ${fileRef}`);
+    for (const f of failures) {
+      lines.push(`  ● ${f.name}`);
+      lines.push('');
+      const msgLines = stripAnsiCodes(f.message).split('\n');
+      let pastFirstStackFrame = false;
+      for (const msgLine of msgLines) {
+        const trimmedLine = msgLine.trim();
+        if (trimmedLine.startsWith('at ') && pastFirstStackFrame) {
+          continue;
+        }
+        if (trimmedLine.startsWith('at ')) {
+          pastFirstStackFrame = true;
+        }
+        lines.push(`    ${msgLine}`);
+      }
+      lines.push('');
+    }
+  }
+
+  const rerunCmd = task.configPath
+    ? `node scripts/jest --config ${task.configPath}`
+    : `node scripts/jest`;
+  lines.push(`Re-run with: ${rerunCmd}`);
+
+  return lines.join('\n');
+};
+
 /**
  * Resolves scoped Jest targets from the validation contract and executes the
- * required config runs, including downstream expansion when requested.
+ * required config runs via Moon, including downstream expansion when requested.
  */
 export const executeJestValidation = async ({
   baseContext,
   log,
   passthroughArgs = [],
   procRunner,
-  onConfigResult,
 }: ExecuteJestValidationOptions): Promise<JestValidationResult | null> => {
   if (baseContext.mode === 'direct_target') {
     throw createFailError(
@@ -496,117 +305,62 @@ export const executeJestValidation = async ({
     return null;
   }
 
-  const testMode = baseContext.contract.testMode;
-  if (testMode === 'all') {
-    throw new Error(
-      'Unexpected Jest contract state: testMode=all should have been handled earlier.'
-    );
-  }
+  const { downstream } = baseContext.contract;
 
-  const plans = planJestContractRuns({
-    entries: changedFiles.map((repoRelPath) => {
-      const owningConfigPath = isUnitJestConfigFile(repoRelPath)
-        ? undefined
-        : resolveOwningConfig(repoRelPath) ?? undefined;
+  log.info(`${JEST_LOG_PREFIX} running affected configs via Moon...`);
 
-      return {
-        repoRelPath,
-        owningConfigPath,
-        isConfigFile: isUnitJestConfigFile(repoRelPath),
-        isTestFile: isTestFile(repoRelPath),
-      };
-    }),
-    testMode,
+  const result = await runJestViaMoon({
+    changedFiles,
+    downstream,
   });
 
-  // When downstream expansion is requested (e.g. --profile pr), discover jest
-  // configs in downstream-affected Moon projects that aren't already covered.
-  const { downstream } = baseContext.contract;
-  if (downstream !== 'none' && changedFiles.length > 0) {
-    const changedFilesJson = JSON.stringify({ files: changedFiles });
-    const affected = await resolveValidationAffectedProjects({
-      changedFilesJson,
-      downstream,
-    });
-
-    const coveredConfigs = new Set(plans.map((p) => p.configPath));
-    for (const sourceRoot of affected.affectedSourceRoots) {
-      const absRoot = Path.resolve(REPO_ROOT, sourceRoot);
-      for (const configName of JEST_CONFIG_NAMES) {
-        const configPath = Path.join(absRoot, configName);
-        if (!coveredConfigs.has(configPath) && existsSync(configPath)) {
-          plans.push({ configPath, mode: 'full' });
-          coveredConfigs.add(configPath);
-        }
-      }
+  if (result.warnings) {
+    for (const warning of result.warnings) {
+      log.warning(warning);
     }
   }
 
-  if (plans.length === 0) {
-    const noTargetsLabel =
-      baseContext.contract.testMode === 'related'
-        ? 'No related Jest targets found'
-        : 'No affected Jest targets found';
-    log.info(`${noTargetsLabel} ${describeValidationNoTargetsScope(baseContext)}; skipping jest.`);
+  if (result.taskCount === 0 && result.exitCode !== 0) {
+    const excerptLines = result.failureExcerpt ?? [];
+    const message = [
+      `${JEST_LABEL} failed (Moon exited with code ${result.exitCode}).`,
+      ...excerptLines.map((l) => `  ${l}`),
+      'Re-run with: node scripts/jest --profile quick',
+    ].join('\n');
+    throw createFailError(message);
+  }
+
+  if (result.taskCount === 0) {
+    log.info(
+      `No affected Jest configs found ${describeValidationNoTargetsScope(
+        baseContext
+      )}; skipping jest.`
+    );
     return null;
   }
 
-  log.info(`${JEST_LOG_PREFIX} planned ${plans.length} config run(s).`);
-  let totalTests = 0;
+  const { cachedCount } = result;
+  const ranCount = result.taskCount - cachedCount;
 
-  for (const [index, plan] of plans.entries()) {
-    const configRepoRel = Path.relative(REPO_ROOT, plan.configPath);
-    const relatedFiles = plan.mode === 'related' ? plan.relatedFiles ?? [] : undefined;
-    const commandForLog = `node scripts/jest --config ${configRepoRel}${
-      relatedFiles ? ` --findRelatedTests ${relatedFiles.join(' ')}` : ''
-    }`;
-
-    if (plan.mode === 'full') {
-      log.info(`${JEST_LOG_PREFIX} ${index + 1}/${plans.length} full ${configRepoRel}`);
-    } else {
-      log.info(
-        `${JEST_LOG_PREFIX} ${index + 1}/${plans.length} related ${configRepoRel} (${
-          (relatedFiles ?? []).length
-        } file(s))`
-      );
+  if (result.failed.length > 0) {
+    for (const task of result.failed) {
+      log.write('');
+      log.error(formatMoonFailure(task));
     }
 
-    try {
-      const parsedOutput = await runJestForConfig({
-        log,
-        procRunner,
-        configPath: plan.configPath,
-        passthroughArgs,
-        relatedFiles,
-      });
-
-      const testCount = extractTestCount(parsedOutput);
-      totalTests += testCount;
-
-      onConfigResult?.({
-        index: index + 1,
-        total: plans.length,
-        config: configRepoRel,
-        passed: true,
-        testCount,
-        command: commandForLog,
-      });
-    } catch (error) {
-      onConfigResult?.({
-        index: index + 1,
-        total: plans.length,
-        config: configRepoRel,
-        passed: false,
-        testCount: 0,
-        failureOutput: error instanceof Error ? error.message : String(error),
-        command: commandForLog,
-      });
-      throw error;
-    }
+    log.write('');
+    throw createFailError(
+      `${JEST_LABEL} failed for ${result.failed.length} config(s) (${ranCount} ran, ${cachedCount} cached; ${result.totalTests} tests).`
+    );
   }
 
-  log.success(`${JEST_LABEL} contract run passed (${plans.length} config run(s)).`);
-  return { configCount: plans.length, testCount: totalTests };
+  const parts: string[] = [];
+  if (ranCount > 0) parts.push(`${ranCount} ran`);
+  if (cachedCount > 0) parts.push(`${cachedCount} cached`);
+  parts.push(`${result.totalTests} tests`);
+
+  log.success(`${JEST_LOG_PREFIX} passed (${parts.join(', ')})`);
+  return { configCount: result.taskCount, testCount: result.totalTests };
 };
 
 /** Runs the validation-contract-aware `scripts/jest` CLI entrypoint. */
@@ -641,21 +395,12 @@ export const runJestContract = () => {
         onWarning: (message) => log.warning(message),
       });
 
-      const shouldUseQuietProcRunner =
-        baseContext.mode !== 'contract' ||
-        (baseContext.runContext.kind !== 'full' && baseContext.contract.testMode !== 'all');
-      const quietProcRunner = shouldUseQuietProcRunner ? createQuietProcRunner(log) : undefined;
-
-      try {
-        await executeJestValidation({
-          baseContext,
-          log,
-          passthroughArgs,
-          procRunner: quietProcRunner ?? procRunner,
-        });
-      } finally {
-        await quietProcRunner?.teardown();
-      }
+      await executeJestValidation({
+        baseContext,
+        log,
+        passthroughArgs,
+        procRunner,
+      });
     },
     {
       description: `

--- a/src/platform/packages/shared/kbn-test/src/jest/run_jest_via_moon.test.ts
+++ b/src/platform/packages/shared/kbn-test/src/jest/run_jest_via_moon.test.ts
@@ -1,0 +1,121 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import Os from 'os';
+
+jest.mock('@kbn/repo-info', () => ({
+  REPO_ROOT: '/repo',
+}));
+
+import { parseMoonJestOutput, computeJestParallelism } from './run_jest_via_moon';
+
+describe('parseMoonJestOutput', () => {
+  it('parses successful Jest JSON output with project prefix', () => {
+    const output = [
+      'pass RunTask(@kbn/foo:jest) (1s 200ms, abc123)',
+      '@kbn/foo:jest | {"success":true,"numTotalTests":5,"numPassedTests":5,"numFailedTests":0,"testResults":[]}',
+    ].join('\n');
+
+    const result = parseMoonJestOutput(output);
+    expect(result.parseFailures).toEqual([]);
+    expect(result.tasks).toHaveLength(1);
+    expect(result.tasks[0]).toMatchObject({
+      project: '@kbn/foo',
+      passed: true,
+      testCount: 5,
+      failures: [],
+    });
+  });
+
+  it('marks cached tasks', () => {
+    const output = [
+      'pass RunTask(@kbn/foo:jest) (cached, 100ms, abc123)',
+      '@kbn/foo:jest | {"success":true,"numTotalTests":3,"numPassedTests":3,"numFailedTests":0,"testResults":[]}',
+    ].join('\n');
+
+    const result = parseMoonJestOutput(output);
+    expect(result.tasks).toHaveLength(1);
+    expect(result.tasks[0].cached).toBe(true);
+    expect(result.tasks[0].passed).toBe(true);
+  });
+
+  it('creates placeholder for cached tasks without JSON output', () => {
+    const output = 'pass RunTask(@kbn/bar:jest) (cached, 50ms, def456)';
+
+    const result = parseMoonJestOutput(output);
+    expect(result.tasks).toHaveLength(1);
+    expect(result.tasks[0]).toMatchObject({
+      project: '@kbn/bar',
+      cached: true,
+      passed: true,
+      testCount: 0,
+      failures: [],
+    });
+  });
+
+  it('extracts failure details from Jest JSON', () => {
+    const output = [
+      'fail RunTask(@kbn/foo:jest) (2s, abc123)',
+      '@kbn/foo:jest | {"success":false,"numTotalTests":2,"numPassedTests":1,"numFailedTests":1,"testResults":[{"name":"/repo/packages/foo/src/bar.test.ts","assertionResults":[{"status":"failed","fullName":"bar should work","failureMessages":["Error: expected true\\n    at /repo/packages/foo/src/bar.test.ts:12:3"]}]}]}',
+    ].join('\n');
+
+    const result = parseMoonJestOutput(output);
+    expect(result.tasks).toHaveLength(1);
+    expect(result.tasks[0].passed).toBe(false);
+    expect(result.tasks[0].failures).toHaveLength(1);
+    expect(result.tasks[0].failures[0]).toMatchObject({
+      file: 'packages/foo/src/bar.test.ts',
+      line: 12,
+      name: 'bar should work',
+    });
+  });
+
+  it('reports parse failures for malformed JSON', () => {
+    const output = '@kbn/bad:jest | {not valid json}';
+
+    const result = parseMoonJestOutput(output);
+    expect(result.parseFailures).toHaveLength(1);
+    expect(result.parseFailures[0]).toContain('Failed to parse Jest JSON from project @kbn/bad');
+  });
+});
+
+describe('computeJestParallelism', () => {
+  let cpusSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    cpusSpy = jest.spyOn(Os, 'cpus').mockReturnValue(new Array(8).fill({}) as any);
+  });
+
+  afterEach(() => {
+    cpusSpy.mockRestore();
+  });
+
+  it('caps Moon concurrency at 2', () => {
+    const { concurrency } = computeJestParallelism(10);
+    expect(concurrency).toBe(2);
+  });
+
+  it('uses single concurrency for 1 task', () => {
+    const { concurrency, maxWorkers } = computeJestParallelism(1);
+    expect(concurrency).toBe(1);
+    expect(maxWorkers).toBe(8);
+  });
+
+  it('splits CPUs across concurrent slots', () => {
+    const { concurrency, maxWorkers } = computeJestParallelism(4);
+    expect(concurrency).toBe(2);
+    expect(maxWorkers).toBe(4);
+  });
+
+  it('ensures maxWorkers is at least 2', () => {
+    cpusSpy.mockReturnValue(new Array(2).fill({}) as any);
+    const { maxWorkers } = computeJestParallelism(10);
+    expect(maxWorkers).toBe(2);
+  });
+});

--- a/src/platform/packages/shared/kbn-test/src/jest/run_jest_via_moon.ts
+++ b/src/platform/packages/shared/kbn-test/src/jest/run_jest_via_moon.ts
@@ -1,0 +1,414 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { existsSync } from 'fs';
+import Os from 'os';
+import Path from 'path';
+
+import execa from 'execa';
+
+import { getMoonExecutablePath } from '@kbn/moon';
+import { REPO_ROOT } from '@kbn/repo-info';
+
+// ── Constants ──────────────────────────────────────────────────────────────
+
+export const JEST_CONFIG_NAMES = [
+  'jest.config.dev.js',
+  'jest.config.js',
+  'jest.config.cjs',
+  'jest.config.mjs',
+  'jest.config.ts',
+  'jest.config.json',
+] as const;
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+export interface JestFailedTest {
+  file: string;
+  line?: number;
+  name: string;
+  message: string;
+}
+
+export interface MoonJestTaskResult {
+  project: string;
+  configPath?: string;
+  cached: boolean;
+  passed: boolean;
+  testCount: number;
+  failures: JestFailedTest[];
+}
+
+export interface MoonJestResult {
+  taskCount: number;
+  cachedCount: number;
+  totalTests: number;
+  failed: MoonJestTaskResult[];
+  exitCode: number;
+  verboseDetail?: string;
+  failureExcerpt?: string[];
+  warnings?: string[];
+}
+
+export interface MoonJestProgress {
+  completedCount: number;
+}
+
+export interface MoonJestParseResult {
+  tasks: MoonJestTaskResult[];
+  parseFailures: string[];
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+const stripAnsi = (s: string) => s.replace(/\x1B\[[0-9;]*[A-Za-z]/g, '');
+
+/** Walk up from a test file to find the nearest jest config. */
+export const findJestConfig = (testFilePath: string): string | undefined => {
+  let dir = Path.dirname(Path.resolve(REPO_ROOT, testFilePath));
+  while (true) {
+    for (const configName of JEST_CONFIG_NAMES) {
+      const configPath = Path.join(dir, configName);
+      if (existsSync(configPath)) {
+        return Path.relative(REPO_ROOT, configPath);
+      }
+    }
+
+    if (dir === REPO_ROOT || dir === Path.dirname(dir)) {
+      break;
+    }
+
+    dir = Path.dirname(dir);
+  }
+  return undefined;
+};
+
+/** Find the owning package directory for a file (longest prefix match). */
+const findOwningPackage = (file: string, dirs: string[]): string | undefined => {
+  let best: string | undefined;
+  for (const dir of dirs) {
+    if (file.startsWith(dir + '/') && (!best || dir.length > best.length)) {
+      best = dir;
+    }
+  }
+  return best;
+};
+
+interface AffectedPackageInfo {
+  dirs: string[];
+  jestDirs: string[];
+}
+
+const resolveAffectedPackageInfo = async (files: string[]): Promise<AffectedPackageInfo> => {
+  const { getPackages } = await import('@kbn/repo-packages');
+  const sortedDirs = getPackages(REPO_ROOT)
+    .map((pkg) => Path.relative(REPO_ROOT, pkg.directory))
+    .sort();
+
+  const matched = new Set<string>();
+  for (const file of files) {
+    const owner = findOwningPackage(file, sortedDirs);
+    if (owner) {
+      matched.add(owner);
+    }
+  }
+
+  const dirs = [...matched];
+  const jestDirs = dirs.filter((dir) =>
+    JEST_CONFIG_NAMES.some((name) => existsSync(Path.resolve(REPO_ROOT, dir, name)))
+  );
+
+  return { dirs, jestDirs };
+};
+
+/**
+ * Keep Moon concurrency low so cache-heavy affected runs do not starve the real
+ * Jest work of CPU. Example: if 4 configs are scheduled and 3 are cached, we
+ * want the 1 uncached Jest process to keep most cores instead of reserving them
+ * for Moon slots that finish immediately.
+ *
+ * - maxWorkers never drops below 2
+ * - Moon concurrency caps at 2
+ */
+export const computeJestParallelism = (estimatedTasks: number) => {
+  const cpus = Os.cpus().length;
+  const safeEstimatedTasks = Math.max(1, estimatedTasks);
+  const concurrency = Math.min(safeEstimatedTasks, 2);
+  const maxWorkers = Math.max(2, Math.floor(cpus / concurrency));
+  return { concurrency, maxWorkers };
+};
+
+// ── Output parsing ─────────────────────────────────────────────────────────
+
+export const parseMoonJestOutput = (output: string): MoonJestParseResult => {
+  const results = new Map<string, MoonJestTaskResult>();
+  const cachedProjects = new Set<string>();
+  const parseFailures: string[] = [];
+
+  for (const rawLine of output.split('\n')) {
+    const stripped = stripAnsi(rawLine).trim();
+
+    // "pass RunTask(@kbn/foo:jest) (cached, ...)" from --summary detailed
+    const cachedMatch = stripped.match(/^pass RunTask\((@[^:]+):jest\) \(cached/);
+    if (cachedMatch) {
+      cachedProjects.add(cachedMatch[1]);
+      continue;
+    }
+
+    // Jest --json output: either prefixed "@kbn/foo:jest | {...}" or unprefixed "{...}"
+    const jsonPrefixMatch = stripped.match(/^(@[^:]+):jest \| \{/);
+    const isUnprefixedJson = !jsonPrefixMatch && stripped.startsWith('{"num');
+    if (jsonPrefixMatch || isUnprefixedJson) {
+      const project = jsonPrefixMatch ? jsonPrefixMatch[1] : '_single';
+      const jsonStr = stripped.replace(/^[^{]*/, '');
+      try {
+        const json = JSON.parse(jsonStr);
+        const failures: JestFailedTest[] = [];
+
+        for (const suite of json.testResults ?? []) {
+          const file = Path.relative(REPO_ROOT, suite.name);
+          for (const assertion of suite.assertionResults ?? []) {
+            if (assertion.status === 'failed') {
+              const message = (assertion.failureMessages ?? []).join('\n');
+              const lineMatch = stripAnsi(message).match(
+                new RegExp(`${suite.name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}:(\\d+)`)
+              );
+              failures.push({
+                file,
+                line: lineMatch ? parseInt(lineMatch[1], 10) : undefined,
+                name: assertion.fullName ?? assertion.title ?? 'unknown',
+                message,
+              });
+            }
+          }
+        }
+
+        const firstTestFile = json.testResults?.[0]?.name;
+        results.set(project, {
+          project,
+          configPath: firstTestFile
+            ? findJestConfig(Path.relative(REPO_ROOT, firstTestFile))
+            : undefined,
+          cached: false,
+          passed: json.success === true,
+          testCount: json.numTotalTests ?? 0,
+          failures,
+        });
+      } catch (err) {
+        parseFailures.push(
+          `Failed to parse Jest JSON from project ${project}: ${
+            err instanceof Error ? err.message : String(err)
+          }`
+        );
+      }
+    }
+  }
+
+  // Mark cached tasks (they replay JSON output, so they'll be in results already)
+  for (const project of cachedProjects) {
+    const existing = results.get(project);
+    if (existing) {
+      existing.cached = true;
+    } else {
+      results.set(project, {
+        project,
+        cached: true,
+        passed: true,
+        testCount: 0,
+        failures: [],
+      });
+    }
+  }
+
+  return { tasks: [...results.values()], parseFailures };
+};
+
+const extractMoonFailureExcerpt = (output: string) => {
+  return output
+    .split('\n')
+    .map((lineText) => stripAnsi(lineText).trim())
+    .filter(Boolean)
+    .filter((lineText) => !lineText.startsWith('{'))
+    .slice(-8);
+};
+
+const parseMoonJestProgressProject = (rawLine: string) => {
+  const stripped = stripAnsi(rawLine).trim();
+
+  const cachedSummaryMatch = stripped.match(/^pass RunTask\((@[^:]+):jest\) \(cached/);
+  if (cachedSummaryMatch) {
+    return cachedSummaryMatch[1];
+  }
+
+  const summaryMatch = stripped.match(/^(?:pass|fail) RunTask\((@[^:]+):jest\) \(/);
+  if (summaryMatch) {
+    return summaryMatch[1];
+  }
+
+  const jsonPrefixMatch = stripped.match(/^(@[^:]+):jest \| \{/);
+  if (jsonPrefixMatch) {
+    return jsonPrefixMatch[1];
+  }
+
+  return undefined;
+};
+
+const attachOutputLineListeners = ({
+  stream,
+  onChunk,
+  onLine,
+}: {
+  stream?: NodeJS.ReadableStream | null;
+  onChunk: (chunk: string) => void;
+  onLine: (line: string) => void;
+}) => {
+  if (!stream) {
+    return;
+  }
+
+  let pending = '';
+  stream.on('data', (chunk) => {
+    const text = chunk.toString();
+    onChunk(text);
+    pending += text;
+
+    while (true) {
+      const newlineIndex = pending.indexOf('\n');
+      if (newlineIndex === -1) {
+        break;
+      }
+
+      onLine(pending.slice(0, newlineIndex));
+      pending = pending.slice(newlineIndex + 1);
+    }
+  });
+
+  stream.on('end', () => {
+    if (pending.length > 0) {
+      onLine(pending);
+    }
+  });
+};
+
+// ── Core execution ─────────────────────────────────────────────────────────
+
+export const runJestViaMoon = async ({
+  changedFiles,
+  verbose = false,
+  downstream = 'none',
+  onProgress,
+}: {
+  changedFiles: string[];
+  verbose?: boolean;
+  downstream?: string;
+  onProgress?: (progress: MoonJestProgress) => void;
+}): Promise<MoonJestResult> => {
+  const packageInfo = await resolveAffectedPackageInfo(changedFiles);
+  const changedFilesJson = JSON.stringify({ files: changedFiles });
+
+  const moonExec = await getMoonExecutablePath();
+  const { concurrency, maxWorkers } = computeJestParallelism(
+    Math.max(packageInfo.jestDirs.length, packageInfo.dirs.length)
+  );
+  const cpus = Os.cpus().length;
+  const completedProjects = new Set<string>();
+
+  const subprocess = execa(
+    moonExec,
+    [
+      'run',
+      ':jest',
+      '--affected',
+      '--stdin',
+      ...(downstream !== 'none' ? ['--downstream', downstream] : []),
+      '--concurrency',
+      String(concurrency),
+      '--summary',
+      'detailed',
+      '--',
+      `--maxWorkers=${maxWorkers}`,
+      '--json',
+      '--passWithNoTests',
+    ],
+    {
+      cwd: REPO_ROOT,
+      input: changedFilesJson,
+      reject: false,
+      env: {
+        ...process.env,
+        CI_STATS_DISABLED: 'true',
+        FORCE_COLOR: '1',
+      },
+    }
+  );
+
+  let capturedStdout = '';
+  let capturedStderr = '';
+
+  const handleOutputLine = (lineText: string) => {
+    const project = parseMoonJestProgressProject(lineText);
+    if (!project || completedProjects.has(project)) {
+      return;
+    }
+
+    completedProjects.add(project);
+    onProgress?.({
+      completedCount: completedProjects.size,
+    });
+  };
+
+  attachOutputLineListeners({
+    stream: 'stdout' in subprocess ? subprocess.stdout : undefined,
+    onChunk: (chunk) => {
+      capturedStdout += chunk;
+    },
+    onLine: handleOutputLine,
+  });
+  attachOutputLineListeners({
+    stream: 'stderr' in subprocess ? subprocess.stderr : undefined,
+    onChunk: (chunk) => {
+      capturedStderr += chunk;
+    },
+    onLine: handleOutputLine,
+  });
+
+  const result = await subprocess;
+
+  const output =
+    (capturedStdout || result.stdout || '') + '\n' + (capturedStderr || result.stderr || '');
+  const { tasks, parseFailures } = parseMoonJestOutput(output);
+  const failed = tasks.filter((t) => !t.passed && !t.cached);
+
+  const cachedCount = tasks.filter((t) => t.cached).length;
+  const ranCount = tasks.length - cachedCount;
+  const warnings =
+    tasks.length === 0 && result.exitCode !== 0
+      ? [
+          `Moon exited with code ${result.exitCode} but no Jest task output was parsed. ` +
+            `The Jest task may have failed before producing JSON output — run jest directly to verify.`,
+          ...parseFailures,
+        ]
+      : parseFailures.length > 0
+      ? parseFailures
+      : undefined;
+
+  return {
+    taskCount: tasks.length,
+    cachedCount,
+    totalTests: tasks.reduce((sum, t) => sum + t.testCount, 0),
+    failed,
+    exitCode: result.exitCode ?? 0,
+    failureExcerpt:
+      tasks.length === 0 && result.exitCode !== 0 ? extractMoonFailureExcerpt(output) : undefined,
+    warnings,
+    verboseDetail: verbose
+      ? `${packageInfo.jestDirs.length} packages, ${ranCount} ran, ${cachedCount} cached, ${cpus} cpus → concurrency=${concurrency}, maxWorkers=${maxWorkers}`
+      : undefined,
+  };
+};

--- a/src/platform/packages/shared/kbn-test/tsconfig.json
+++ b/src/platform/packages/shared/kbn-test/tsconfig.json
@@ -33,5 +33,6 @@
     "@kbn/scout-info",
     "@kbn/react-mute-legacy-root-warning",
     "@kbn/babel-preset",
+    "@kbn/moon"
   ]
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Jest] Use Moon for scoped jest execution (#262160)](https://github.com/elastic/kibana/pull/262160)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Tyler Smalley","email":"tyler.smalley@elastic.co"},"sourceCommit":{"committedDate":"2026-04-09T20:00:03Z","message":"[Jest] Use Moon for scoped jest execution (#262160)\n\nExtracts the Moon-based Jest execution from scripts/check into a shared\nmodule so that scripts/jest can also benefits from Moon's task caching\nand parallel execution.\n\nJust moving things around.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"77827fa8549b48dae4613a436d80f3543cca75db","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:all-open","v9.4.0"],"title":"[Jest] Use Moon for scoped jest execution","number":262160,"url":"https://github.com/elastic/kibana/pull/262160","mergeCommit":{"message":"[Jest] Use Moon for scoped jest execution (#262160)\n\nExtracts the Moon-based Jest execution from scripts/check into a shared\nmodule so that scripts/jest can also benefits from Moon's task caching\nand parallel execution.\n\nJust moving things around.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"77827fa8549b48dae4613a436d80f3543cca75db"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/262160","number":262160,"mergeCommit":{"message":"[Jest] Use Moon for scoped jest execution (#262160)\n\nExtracts the Moon-based Jest execution from scripts/check into a shared\nmodule so that scripts/jest can also benefits from Moon's task caching\nand parallel execution.\n\nJust moving things around.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"77827fa8549b48dae4613a436d80f3543cca75db"}}]}] BACKPORT-->