### PR TITLE
[Search] Hide index management links for users without privileges

### DIFF
--- a/x-pack/platform/test/ui_capabilities/security_and_spaces/tests/catalogue.ts
+++ b/x-pack/platform/test/ui_capabilities/security_and_spaces/tests/catalogue.ts
@@ -79,6 +79,7 @@ export default function catalogueTests({ getService }: FtrProviderContext) {
             const exceptions = [
               'ml_file_data_visualizer',
               'monitoring',
+              'elasticsearchIndexManagement',
               'enterpriseSearchAnalytics',
               'enterpriseSearchApplications',
               'searchPlayground',

--- a/x-pack/platform/test/ui_capabilities/security_and_spaces/tests/nav_links.ts
+++ b/x-pack/platform/test/ui_capabilities/security_and_spaces/tests/nav_links.ts
@@ -63,6 +63,7 @@ export default function navLinksTests({ getService }: FtrProviderContext) {
                 'searchPlayground',
                 'searchSynonyms',
                 'searchQueryRules',
+                { feature: 'enterpriseSearch', apps: ['elasticsearchIndexManagement'] },
                 'securitySolutionAssistant',
                 'securitySolutionAttackDiscovery',
                 'securitySolutionSiemMigrations',

--- a/x-pack/solutions/search/plugins/enterprise_search/server/plugin.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/plugin.ts
@@ -100,6 +100,13 @@ export class EnterpriseSearchPlugin implements Plugin<void, void, PluginsSetup, 
       SEARCH_INDEX_MANAGEMENT_APP_ID,
     ];
 
+    const READ_ONLY_PLUGIN_IDS = [
+      ENTERPRISE_SEARCH_HOME_PLUGIN.ID,
+      ENTERPRISE_SEARCH_DATA_PLUGIN.ID,
+      SEARCH_HOMEPAGE,
+      SEARCH_GETTING_STARTED,
+    ];
+
     if (customIntegrations) {
       registerEnterpriseSearchIntegrations(
         config,
@@ -130,9 +137,9 @@ export class EnterpriseSearchPlugin implements Plugin<void, void, PluginsSetup, 
           ui: [],
         },
         read: {
-          app: ['kibana', ...PLUGIN_IDS],
+          app: ['kibana', ...READ_ONLY_PLUGIN_IDS],
           api: [],
-          catalogue: PLUGIN_IDS,
+          catalogue: READ_ONLY_PLUGIN_IDS,
           savedObject: {
             all: [],
             read: [ES_TELEMETRY_NAME, AS_TELEMETRY_NAME, WS_TELEMETRY_NAME],

--- a/x-pack/solutions/search/plugins/search_navigation/kibana.jsonc
+++ b/x-pack/solutions/search/plugins/search_navigation/kibana.jsonc
@@ -16,8 +16,7 @@
     "optionalPlugins": [
       "serverless",
       "spaces",
-      "indexManagement",
-      "serverless"
+      "indexManagement"
     ],
     "requiredBundles": []
   }

--- a/x-pack/solutions/search/plugins/search_navigation/public/locator.ts
+++ b/x-pack/solutions/search/plugins/search_navigation/public/locator.ts
@@ -14,8 +14,8 @@ import { SEARCH_INDEX_MANAGEMENT_LOCATOR_ID } from './constants';
 export { SEARCH_INDEX_MANAGEMENT_LOCATOR_ID };
 
 export interface SearchIndexManagementLocatorDependencies {
-  /** Resolves chrome style at runtime (when getLocation is called) */
-  getChromeStyle: () => Promise<'classic' | 'project' | undefined>;
+  /** Gets chrome style at runtime (when getLocation is called) */
+  getChromeStyle: () => 'classic' | 'project' | undefined;
   /** Platform index management locator; used when chrome style is classic */
   indexManagementLocator?: LocatorPublic<IndexManagementLocatorParams>;
 }

--- a/x-pack/solutions/search/plugins/search_navigation/public/plugin.ts
+++ b/x-pack/solutions/search/plugins/search_navigation/public/plugin.ts
@@ -12,7 +12,7 @@ import type {
   PluginInitializerContext,
   ScopedHistory,
 } from '@kbn/core/public';
-import { firstValueFrom, type Subscription } from 'rxjs';
+import { type Subscription } from 'rxjs';
 import type { ChromeBreadcrumb, ChromeStyle } from '@kbn/core-chrome-browser';
 import { i18n } from '@kbn/i18n';
 import type { Logger } from '@kbn/logging';
@@ -27,7 +27,6 @@ import type {
   ClassicNavItem,
   SearchNavigationSetBreadcrumbsOptions,
   AppPluginStartDependencies,
-  AppPluginSetupDependencies,
 } from './types';
 import { classicNavigationFactory } from './classic_navigation';
 import { SearchIndexManagementLocatorDefinition } from './locator';
@@ -47,20 +46,7 @@ export class SearchNavigationPlugin
     this.logger = this.initializerContext.logger.get();
   }
 
-  public setup(core: CoreSetup, plugins: AppPluginSetupDependencies): SearchNavigationPluginSetup {
-    const indexManagementLocator = plugins.share.url.locators.get<IndexManagementLocatorParams>(
-      INDEX_MANAGEMENT_LOCATOR_ID
-    );
-    const getChromeStyle = async (): Promise<'classic' | 'project' | undefined> => {
-      const [coreStart] = await core.getStartServices();
-      return firstValueFrom(coreStart.chrome.getChromeStyle$());
-    };
-    plugins.share.url.locators.create(
-      new SearchIndexManagementLocatorDefinition({
-        getChromeStyle,
-        indexManagementLocator: indexManagementLocator ?? undefined,
-      })
-    );
+  public setup(_core: CoreSetup): SearchNavigationPluginSetup {
     return {};
   }
 
@@ -70,6 +56,22 @@ export class SearchNavigationPlugin
     this.chromeSub = core.chrome.getChromeStyle$().subscribe((value) => {
       this.currentChromeStyle = value;
     });
+
+    const { monitor, manageEnrich, monitorEnrich, manageIndexTemplates } =
+      core.application.capabilities.index_management;
+    if (monitor || manageEnrich || monitorEnrich || manageIndexTemplates) {
+      const indexManagementLocator =
+        this.pluginsStart.share.url.locators.get<IndexManagementLocatorParams>(
+          INDEX_MANAGEMENT_LOCATOR_ID
+        );
+      const getChromeStyle = (): 'classic' | 'project' | undefined => this.currentChromeStyle;
+      this.pluginsStart.share.url.locators.create(
+        new SearchIndexManagementLocatorDefinition({
+          getChromeStyle,
+          indexManagementLocator: indexManagementLocator ?? undefined,
+        })
+      );
+    }
 
     // Async loads classic nav items on start
     import('./base_classic_navigation_items').then(({ BaseClassicNavItems }) => {

--- a/x-pack/solutions/search/plugins/search_navigation/public/types.ts
+++ b/x-pack/solutions/search/plugins/search_navigation/public/types.ts
@@ -12,7 +12,7 @@ import type { ServerlessPluginStart } from '@kbn/serverless/public';
 import type { SolutionNavProps } from '@kbn/shared-ux-page-solution-nav';
 import type { SpacesPluginStart } from '@kbn/spaces-plugin/public';
 import type { IndexManagementLocatorParams } from '@kbn/index-management-shared-types';
-import type { SharePluginSetup } from '@kbn/share-plugin/public';
+import type { SharePluginSetup, SharePluginStart } from '@kbn/share-plugin/public';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface SearchNavigationPluginSetup {}
@@ -37,6 +37,7 @@ export interface AppPluginSetupDependencies {
 
 export interface AppPluginStartDependencies {
   serverless?: ServerlessPluginStart;
+  share: SharePluginStart;
   spaces?: SpacesPluginStart;
 }
 


### PR DESCRIPTION
## Summary

This PR hides links to index management pages from search plugins for any user without the required privileges. The privileges used to determine visibility are the same that are used in the platform index management plugin.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] ~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~
- [ ] ~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] ~If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- [ ] ~This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.~
- [ ] ~[Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed~
- [ ] ~The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)~
- [ ] ~Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.~



<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->