### PR TITLE
[Content List] Add content editor integration (PR 12)

### DIFF
--- a/src/platform/packages/shared/content-management/content_editor/index.ts
+++ b/src/platform/packages/shared/content-management/content_editor/index.ts
@@ -11,7 +11,6 @@ export { ContentEditorProvider, ContentEditorKibanaProvider, useOpenContentEdito
 export type {
   OpenContentEditorParams,
   ContentEditorItem,
-  ContentEditorItemTags,
   ContentEditorCustomValidators,
 } from './src';
 export type { SavedObjectsReference } from './src/services';

--- a/src/platform/packages/shared/content-management/content_editor/index.ts
+++ b/src/platform/packages/shared/content-management/content_editor/index.ts
@@ -8,5 +8,10 @@
  */
 
 export { ContentEditorProvider, ContentEditorKibanaProvider, useOpenContentEditor } from './src';
-export type { OpenContentEditorParams } from './src';
+export type {
+  OpenContentEditorParams,
+  ContentEditorItem,
+  ContentEditorItemTags,
+  ContentEditorCustomValidators,
+} from './src';
 export type { SavedObjectsReference } from './src/services';

--- a/src/platform/packages/shared/content-management/content_editor/src/components/editor_flyout_content.tsx
+++ b/src/platform/packages/shared/content-management/content_editor/src/components/editor_flyout_content.tsx
@@ -72,11 +72,17 @@ export const ContentEditorFlyoutContent: FC<Props> = ({
   const form = useMetadataForm({ item, customValidators });
 
   const hasNoChanges = () => {
-    const itemTags = item.tags.map((obj) => obj.id).sort();
+    // Normalize item tags to plain IDs for comparison.
+    // Tags may be string[] (plain IDs) or SavedObjectsReference[] (objects with .id).
+    const itemTags = item.tags
+      ? item.tags.map((tag) => (typeof tag === 'string' ? tag : tag.id)).sort()
+      : [];
     const formTags = form.tags.value.slice().sort();
 
     const compareTags = (arr1: string[], arr2: string[]) => {
-      if (arr1.length !== arr2.length) return false;
+      if (arr1.length !== arr2.length) {
+        return false;
+      }
       return arr1.every((tag: string, index) => tag === arr2[index]);
     };
 

--- a/src/platform/packages/shared/content-management/content_editor/src/components/editor_flyout_content.tsx
+++ b/src/platform/packages/shared/content-management/content_editor/src/components/editor_flyout_content.tsx
@@ -72,26 +72,15 @@ export const ContentEditorFlyoutContent: FC<Props> = ({
   const form = useMetadataForm({ item, customValidators });
 
   const hasNoChanges = () => {
-    // Normalize item tags to plain IDs for comparison.
-    // Tags may be string[] (plain IDs) or SavedObjectsReference[] (objects with .id).
-    const itemTags = item.tags
-      ? item.tags.map((tag) => (typeof tag === 'string' ? tag : tag.id)).sort()
-      : [];
+    const itemTags = item.tags.slice().sort();
     const formTags = form.tags.value.slice().sort();
-
-    const compareTags = (arr1: string[], arr2: string[]) => {
-      if (arr1.length !== arr2.length) {
-        return false;
-      }
-      return arr1.every((tag: string, index) => tag === arr2[index]);
-    };
-
     const description = item.description || '';
 
     return (
       item.title === form.title.value &&
       description === form.description.value &&
-      compareTags(itemTags, formTags)
+      itemTags.length === formTags.length &&
+      itemTags.every((tag, i) => tag === formTags[i])
     );
   };
 
@@ -143,7 +132,6 @@ export const ContentEditorFlyoutContent: FC<Props> = ({
               defaultMessage: 'To edit these details, contact your administrator for access.',
             })
           }
-          tagsReferences={item.tags}
           TagList={TagList}
           TagSelector={TagSelector}
         >

--- a/src/platform/packages/shared/content-management/content_editor/src/components/inspector_flyout_content.test.tsx
+++ b/src/platform/packages/shared/content-management/content_editor/src/components/inspector_flyout_content.test.tsx
@@ -32,10 +32,7 @@ describe('<ContentEditorFlyoutContent />', () => {
       id: '123',
       title: 'Foo',
       description: 'Some description',
-      tags: [
-        { id: 'id-1', name: 'tag1', type: 'tag' },
-        { id: 'id-2', name: 'tag2', type: 'tag' },
-      ],
+      tags: ['id-1', 'id-2'],
     };
 
     const mockedServices = getMockServices();
@@ -230,28 +227,18 @@ describe('<ContentEditorFlyoutContent />', () => {
       );
     });
 
-    test('should render tags in read-only mode when item.tags is string[]', async () => {
-      const stringTagItem: ContentEditorFlyoutContentProps['item'] = {
-        id: '456',
-        title: 'String Tags Item',
-        description: 'Item with plain string tag IDs',
-        tags: ['tag-1', 'tag-2'],
-      };
-
+    test('should render tags in read-only mode', async () => {
       await act(async () => {
-        testBed = await setup({ item: stringTagItem });
+        testBed = await setup();
       });
 
       const { exists, component } = testBed!;
 
-      // TagList should be rendered in read-only mode
       expect(exists('tagList')).toBe(true);
 
-      // The mock TagList renders tag.name for each reference.
-      // string[] tags are converted to SavedObjectsReference[] with name: 'tag-ref-{id}'.
       const tagListHtml = component.find('[data-test-subj="tagList"]').text();
-      expect(tagListHtml).toContain('tag-ref-tag-1');
-      expect(tagListHtml).toContain('tag-ref-tag-2');
+      expect(tagListHtml).toContain('id-1');
+      expect(tagListHtml).toContain('id-2');
     });
 
     test('should update the tag selection', async () => {

--- a/src/platform/packages/shared/content-management/content_editor/src/components/inspector_flyout_content.test.tsx
+++ b/src/platform/packages/shared/content-management/content_editor/src/components/inspector_flyout_content.test.tsx
@@ -230,6 +230,30 @@ describe('<ContentEditorFlyoutContent />', () => {
       );
     });
 
+    test('should render tags in read-only mode when item.tags is string[]', async () => {
+      const stringTagItem: ContentEditorFlyoutContentProps['item'] = {
+        id: '456',
+        title: 'String Tags Item',
+        description: 'Item with plain string tag IDs',
+        tags: ['tag-1', 'tag-2'],
+      };
+
+      await act(async () => {
+        testBed = await setup({ item: stringTagItem });
+      });
+
+      const { exists, component } = testBed!;
+
+      // TagList should be rendered in read-only mode
+      expect(exists('tagList')).toBe(true);
+
+      // The mock TagList renders tag.name for each reference.
+      // string[] tags are converted to SavedObjectsReference[] with name: 'tag-ref-{id}'.
+      const tagListHtml = component.find('[data-test-subj="tagList"]').text();
+      expect(tagListHtml).toContain('tag-ref-tag-1');
+      expect(tagListHtml).toContain('tag-ref-tag-2');
+    });
+
     test('should update the tag selection', async () => {
       const onSave = jest.fn();
 

--- a/src/platform/packages/shared/content-management/content_editor/src/components/metadata_form.tsx
+++ b/src/platform/packages/shared/content-management/content_editor/src/components/metadata_form.tsx
@@ -22,6 +22,7 @@ import {
 import { ContentEditorFlyoutWarningsCallOut } from './editor_flyout_warnings';
 import type { Field, MetadataFormState } from './use_metadata_form';
 import type { SavedObjectsReference, Services } from '../services';
+import type { ItemTags } from '../types';
 
 interface Props {
   form: MetadataFormState & {
@@ -29,7 +30,7 @@ interface Props {
   };
   isReadonly: boolean;
   readonlyReason: string;
-  tagsReferences: SavedObjectsReference[];
+  tagsReferences: ItemTags;
   TagList?: Services['TagList'];
   TagSelector?: Services['TagSelector'];
 }
@@ -124,7 +125,19 @@ export const MetadataForm: FC<React.PropsWithChildren<Props>> = ({
             fullWidth
             isDisabled={isReadonly}
           >
-            <TagList references={tagsReferences} />
+            <TagList
+              references={
+                typeof tagsReferences[0] === 'string'
+                  ? (tagsReferences as string[]).map(
+                      (tagId): SavedObjectsReference => ({
+                        type: 'tag',
+                        id: tagId,
+                        name: `tag-ref-${tagId}`,
+                      })
+                    )
+                  : (tagsReferences as SavedObjectsReference[])
+              }
+            />
           </EuiFormRow>
         </>
       )}

--- a/src/platform/packages/shared/content-management/content_editor/src/components/metadata_form.tsx
+++ b/src/platform/packages/shared/content-management/content_editor/src/components/metadata_form.tsx
@@ -21,8 +21,7 @@ import {
 
 import { ContentEditorFlyoutWarningsCallOut } from './editor_flyout_warnings';
 import type { Field, MetadataFormState } from './use_metadata_form';
-import type { SavedObjectsReference, Services } from '../services';
-import type { ItemTags } from '../types';
+import type { Services } from '../services';
 
 interface Props {
   form: MetadataFormState & {
@@ -30,7 +29,6 @@ interface Props {
   };
   isReadonly: boolean;
   readonlyReason: string;
-  tagsReferences: ItemTags;
   TagList?: Services['TagList'];
   TagSelector?: Services['TagSelector'];
 }
@@ -39,7 +37,6 @@ const isFormFieldValid = (field: Field) => !Boolean(field.errors?.length);
 
 export const MetadataForm: FC<React.PropsWithChildren<Props>> = ({
   form,
-  tagsReferences,
   TagList,
   TagSelector,
   isReadonly,
@@ -115,7 +112,7 @@ export const MetadataForm: FC<React.PropsWithChildren<Props>> = ({
         />
       </EuiFormRow>
 
-      {TagList && isReadonly && tagsReferences.length > 0 && (
+      {TagList && isReadonly && tags.value.length > 0 && (
         <>
           <EuiSpacer />
           <EuiFormRow
@@ -125,19 +122,7 @@ export const MetadataForm: FC<React.PropsWithChildren<Props>> = ({
             fullWidth
             isDisabled={isReadonly}
           >
-            <TagList
-              references={
-                typeof tagsReferences[0] === 'string'
-                  ? (tagsReferences as string[]).map(
-                      (tagId): SavedObjectsReference => ({
-                        type: 'tag',
-                        id: tagId,
-                        name: `tag-ref-${tagId}`,
-                      })
-                    )
-                  : (tagsReferences as SavedObjectsReference[])
-              }
-            />
+            <TagList tagIds={tags.value} />
           </EuiFormRow>
         </>
       )}

--- a/src/platform/packages/shared/content-management/content_editor/src/components/use_metadata_form.ts
+++ b/src/platform/packages/shared/content-management/content_editor/src/components/use_metadata_form.ts
@@ -10,7 +10,7 @@
 import { useState, useCallback, useMemo, useRef } from 'react';
 import { i18n } from '@kbn/i18n';
 
-import type { Item } from '../types';
+import type { Item, ItemTags } from '../types';
 
 export interface Field<TValueType = unknown> {
   value: TValueType;
@@ -96,6 +96,20 @@ const executeValidation = async <TField extends keyof Fields>(
   return results;
 };
 
+/**
+ * Normalize tags to plain string IDs.
+ * Accepts either `string[]` (plain IDs) or `SavedObjectsReference[]` (objects with `.id`).
+ */
+const normalizeTagIds = (tags: ItemTags | undefined): string[] => {
+  if (!tags || tags.length === 0) {
+    return [];
+  }
+  if (typeof tags[0] === 'string') {
+    return tags as string[];
+  }
+  return (tags as Array<{ id: string }>).map(({ id }) => id);
+};
+
 export const useMetadataForm = ({
   item,
   customValidators,
@@ -111,7 +125,7 @@ export const useMetadataForm = ({
       isChangingValue: false,
     },
     tags: {
-      value: item.tags ? item.tags.map(({ id }) => id) : [],
+      value: normalizeTagIds(item.tags),
       isChangingValue: false,
     },
   });

--- a/src/platform/packages/shared/content-management/content_editor/src/components/use_metadata_form.ts
+++ b/src/platform/packages/shared/content-management/content_editor/src/components/use_metadata_form.ts
@@ -10,7 +10,7 @@
 import { useState, useCallback, useMemo, useRef } from 'react';
 import { i18n } from '@kbn/i18n';
 
-import type { Item, ItemTags } from '../types';
+import type { Item } from '../types';
 
 export interface Field<TValueType = unknown> {
   value: TValueType;
@@ -96,19 +96,8 @@ const executeValidation = async <TField extends keyof Fields>(
   return results;
 };
 
-/**
- * Normalize tags to plain string IDs.
- * Accepts either `string[]` (plain IDs) or `SavedObjectsReference[]` (objects with `.id`).
- */
-const normalizeTagIds = (tags: ItemTags | undefined): string[] => {
-  if (!tags || tags.length === 0) {
-    return [];
-  }
-  if (typeof tags[0] === 'string') {
-    return tags as string[];
-  }
-  return (tags as Array<{ id: string }>).map(({ id }) => id);
-};
+/** Normalize tags, treating `undefined` as an empty array. */
+const normalizeTagIds = (tags: string[] | undefined): string[] => tags ?? [];
 
 export const useMetadataForm = ({
   item,

--- a/src/platform/packages/shared/content-management/content_editor/src/index.ts
+++ b/src/platform/packages/shared/content-management/content_editor/src/index.ts
@@ -10,5 +10,5 @@
 export { ContentEditorProvider, ContentEditorKibanaProvider } from './services';
 export { useOpenContentEditor } from './open_content_editor';
 export type { OpenContentEditorParams } from './open_content_editor';
-export type { Item as ContentEditorItem, ItemTags as ContentEditorItemTags } from './types';
+export type { Item as ContentEditorItem } from './types';
 export type { CustomValidators as ContentEditorCustomValidators } from './components/use_metadata_form';

--- a/src/platform/packages/shared/content-management/content_editor/src/index.ts
+++ b/src/platform/packages/shared/content-management/content_editor/src/index.ts
@@ -10,3 +10,5 @@
 export { ContentEditorProvider, ContentEditorKibanaProvider } from './services';
 export { useOpenContentEditor } from './open_content_editor';
 export type { OpenContentEditorParams } from './open_content_editor';
+export type { Item as ContentEditorItem, ItemTags as ContentEditorItemTags } from './types';
+export type { CustomValidators as ContentEditorCustomValidators } from './components/use_metadata_form';

--- a/src/platform/packages/shared/content-management/content_editor/src/mocks.tsx
+++ b/src/platform/packages/shared/content-management/content_editor/src/mocks.tsx
@@ -8,7 +8,7 @@
  */
 
 import React, { useEffect, useState, useCallback } from 'react';
-import type { TagSelectorProps, SavedObjectsReference } from './services';
+import type { TagSelectorProps } from './services';
 
 const tagsList = ['id-1', 'id-2', 'id-3', 'id-4', 'id-5'];
 
@@ -46,19 +46,13 @@ export const TagSelector = ({ initialSelection, onTagsSelected }: TagSelectorPro
 };
 
 export interface TagListProps {
-  references?: SavedObjectsReference[];
+  tagIds: string[];
 }
 
-export const TagList = ({ references }: TagListProps) => {
-  if (!references) {
-    return null;
-  }
-
-  return (
-    <ul data-test-subj="tagList">
-      {references.map((tag) => (
-        <li key={tag.name}>{tag.name}</li>
-      ))}
-    </ul>
-  );
-};
+export const TagList = ({ tagIds }: TagListProps) => (
+  <ul data-test-subj="tagList">
+    {tagIds.map((id) => (
+      <li key={id}>{id}</li>
+    ))}
+  </ul>
+);

--- a/src/platform/packages/shared/content-management/content_editor/src/services.test.tsx
+++ b/src/platform/packages/shared/content-management/content_editor/src/services.test.tsx
@@ -1,0 +1,106 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@kbn/react-query';
+import { UserProfilesProvider } from '@kbn/content-management-user-profiles';
+import type { ContentEditorKibanaDependencies, TagSelectorProps } from './services';
+import { ContentEditorKibanaProvider, useServices } from './services';
+
+type SavedObjectsTagging = NonNullable<ContentEditorKibanaDependencies['savedObjectsTagging']>;
+type PluginTagListProps = React.ComponentProps<SavedObjectsTagging['ui']['components']['TagList']>;
+
+const createCoreMock = (): ContentEditorKibanaDependencies['core'] =>
+  ({
+    analytics: {
+      reportEvent: jest.fn(),
+    },
+    i18n: {},
+    theme: {
+      theme$: {},
+    },
+    userProfile: {},
+    overlays: {
+      openSystemFlyout: jest.fn(() => ({
+        onClose: Promise.resolve(),
+        close: () => Promise.resolve(),
+      })),
+    },
+    notifications: {
+      toasts: {
+        addDanger: jest.fn(),
+      },
+    },
+    rendering: {
+      addContext: (element: React.ReactNode) => <>{element}</>,
+    },
+  } as unknown as ContentEditorKibanaDependencies['core']);
+
+const createWrapper = (
+  savedObjectsTagging: ContentEditorKibanaDependencies['savedObjectsTagging']
+) => {
+  const queryClient = new QueryClient();
+
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <UserProfilesProvider
+        bulkGetUserProfiles={jest.fn()}
+        getUserProfile={jest.fn()}
+        suggestUserProfiles={jest.fn()}
+      >
+        <ContentEditorKibanaProvider
+          core={createCoreMock()}
+          savedObjectsTagging={savedObjectsTagging}
+        >
+          {children}
+        </ContentEditorKibanaProvider>
+      </UserProfilesProvider>
+    </QueryClientProvider>
+  );
+};
+
+const TagListConsumer = ({ tagIds }: { tagIds: string[] }) => {
+  const { TagList } = useServices();
+
+  if (!TagList) {
+    return null;
+  }
+
+  return <TagList tagIds={tagIds} />;
+};
+
+describe('ContentEditorKibanaProvider', () => {
+  test('adapts tag IDs to saved object references for the plugin TagList', () => {
+    const PluginTagList = jest.fn<React.ReactElement | null, [PluginTagListProps]>(() => null);
+    const SavedObjectSaveModalTagSelector = jest.fn<React.ReactElement | null, [TagSelectorProps]>(
+      () => null
+    );
+
+    render(<TagListConsumer tagIds={['tag-1', 'tag-2']} />, {
+      wrapper: createWrapper({
+        ui: {
+          components: {
+            TagList: PluginTagList,
+            SavedObjectSaveModalTagSelector,
+          },
+        },
+      }),
+    });
+
+    expect(PluginTagList.mock.calls[0][0]).toEqual({
+      object: {
+        references: [
+          { id: 'tag-1', name: 'tag-tag-1', type: 'tag' },
+          { id: 'tag-2', name: 'tag-tag-2', type: 'tag' },
+        ],
+      },
+    });
+  });
+});

--- a/src/platform/packages/shared/content-management/content_editor/src/services.tsx
+++ b/src/platform/packages/shared/content-management/content_editor/src/services.tsx
@@ -47,7 +47,7 @@ export interface Theme {
 export interface Services {
   openSystemFlyout(node: ReactNode, options?: OverlaySystemFlyoutOpenOptions): OverlayRef;
   notifyError: NotifyFn;
-  TagList?: FC<{ references: SavedObjectsReference[] }>;
+  TagList?: FC<{ tagIds: string[] }>;
   TagSelector?: React.FC<TagSelectorProps>;
 }
 
@@ -133,11 +133,12 @@ export const ContentEditorKibanaProvider: FC<
   const { openSystemFlyout: coreOpenFlyout } = overlays;
 
   const TagList = useMemo(() => {
-    const Comp: Services['TagList'] = ({ references }) => {
+    const Comp: Services['TagList'] = ({ tagIds }) => {
       if (!savedObjectsTagging?.ui.components.TagList) {
         return null;
       }
       const PluginTagList = savedObjectsTagging.ui.components.TagList;
+      const references = tagIds.map((id) => ({ type: 'tag', id, name: `tag-${id}` }));
       return <PluginTagList object={{ references }} />;
     };
 

--- a/src/platform/packages/shared/content-management/content_editor/src/types.ts
+++ b/src/platform/packages/shared/content-management/content_editor/src/types.ts
@@ -7,23 +7,11 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { SavedObjectsReference } from './services';
-
-/**
- * Tags can be provided as either:
- * - `string[]` — plain tag IDs (used by Content List and other ID-based systems)
- * - `SavedObjectsReference[]` — full reference objects (used by legacy TableListView)
- *
- * The content editor normalizes both formats to `string[]` internally for form state
- * and `onSave` callbacks.
- */
-export type ItemTags = string[] | SavedObjectsReference[];
-
 export interface Item {
   id: string;
   title: string;
   description?: string;
-  tags: ItemTags;
+  tags: string[];
 
   createdAt?: string;
   createdBy?: string;

--- a/src/platform/packages/shared/content-management/content_editor/src/types.ts
+++ b/src/platform/packages/shared/content-management/content_editor/src/types.ts
@@ -9,11 +9,21 @@
 
 import type { SavedObjectsReference } from './services';
 
+/**
+ * Tags can be provided as either:
+ * - `string[]` — plain tag IDs (used by Content List and other ID-based systems)
+ * - `SavedObjectsReference[]` — full reference objects (used by legacy TableListView)
+ *
+ * The content editor normalizes both formats to `string[]` internally for form state
+ * and `onSave` callbacks.
+ */
+export type ItemTags = string[] | SavedObjectsReference[];
+
 export interface Item {
   id: string;
   title: string;
   description?: string;
-  tags: SavedObjectsReference[];
+  tags: ItemTags;
 
   createdAt?: string;
   createdBy?: string;

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-docs/src/core_extended_features.stories.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-docs/src/core_extended_features.stories.tsx
@@ -24,6 +24,7 @@ import {
   mockTagsService,
   mockContentListUserProfilesServices,
   StateDiagnosticPanel,
+  useInspectFlyout,
 } from './stories_helpers';
 
 // =============================================================================
@@ -65,8 +66,11 @@ const { Filters } = ContentListToolbar;
  * - [x] Starred column — star icon toggle per row
  * - [x] Starred filter — toggle to show only starred items
  * - [x] Created By filter — include/exclude by user (PR 10)
+ * - [x] Content editor — "View details" row action via `item.onInspect` (PR 12)
  */
 const CoreTagsStarredFeaturesWrapper = () => {
+  const { onInspect, flyout } = useInspectFlyout();
+
   const labels = useMemo(
     () => ({
       entity: 'dashboard',
@@ -111,8 +115,9 @@ const CoreTagsStarredFeaturesWrapper = () => {
       onDelete: async (_items: ContentListItem[]) => {
         await new Promise((resolve) => setTimeout(resolve, 300));
       },
+      onInspect,
     }),
-    []
+    [onInspect]
   );
 
   const tableChildren = useMemo(
@@ -123,6 +128,7 @@ const CoreTagsStarredFeaturesWrapper = () => {
         <Column.CreatedBy />
         <Column.UpdatedAt />
         <Column.Actions>
+          <Action.Inspect />
           <Action.Delete />
         </Column.Actions>
       </>
@@ -205,6 +211,7 @@ const CoreTagsStarredFeaturesWrapper = () => {
           <StateDiagnosticPanel defaultOpen element={displayElement} />
         </EuiFlexItem>
       </EuiFlexGroup>
+      {flyout}
     </ContentListProvider>
   );
 };

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-docs/src/playground/builder_panel.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-docs/src/playground/builder_panel.tsx
@@ -266,6 +266,13 @@ export const BuilderPanel = ({ state, dispatch }: BuilderPanelProps) => {
               onChange={(v) => dispatch({ type: 'SET_ITEM_PROP', key: 'onDelete', value: v })}
             />
           </JsxPropDisplay>
+          <JsxPropDisplay name="onInspect">
+            <InlineCheckbox
+              id={`${idPrefix}-onInspect`}
+              checked={item.onInspect}
+              onChange={(v) => dispatch({ type: 'SET_ITEM_PROP', key: 'onInspect', value: v })}
+            />
+          </JsxPropDisplay>
         </JsxPropBlock>
 
         {/* features prop */}
@@ -393,8 +400,9 @@ export const BuilderPanel = ({ state, dispatch }: BuilderPanelProps) => {
                         col.type === 'actions' &&
                         !item.onEdit &&
                         !item.onDelete &&
-                        !col.actions.some((a) => a.type !== 'edit' && a.type !== 'delete')
-                          ? 'This column is hidden because no item actions (onEdit, onDelete) are configured on the provider and no custom actions are present.'
+                        !item.onInspect &&
+                        !col.actions.some((a) => !['edit', 'delete', 'inspect'].includes(a.type))
+                          ? 'This column is hidden because no item actions (onEdit, onDelete, onInspect) are configured on the provider and no custom actions are present.'
                           : undefined
                       }
                     />

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-docs/src/playground/playground_builder.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-docs/src/playground/playground_builder.tsx
@@ -38,6 +38,7 @@ import {
   mockTagsService,
   mockContentListUserProfilesServices,
   toJsx,
+  useInspectFlyout,
 } from '../stories_helpers';
 import { BuilderPanel } from './builder_panel';
 import type { PlaygroundState } from './playground_state';
@@ -107,7 +108,7 @@ const { Filters } = ContentListToolbar;
  * - `consumerJsx` — a lightweight element tree (without EUI layout wrappers)
  *   used solely for JSX serialization via {@link toJsx}.
  */
-const usePreview = (state: PlaygroundState) => {
+const usePreview = (state: PlaygroundState, onInspect?: (item: ContentListItem) => void) => {
   const { provider, features, item: itemConfig, table, toolbar, data } = state;
 
   const labels = useMemo(
@@ -194,8 +195,11 @@ const usePreview = (state: PlaygroundState) => {
         await new Promise((resolve) => setTimeout(resolve, 300));
       };
     }
+    if (itemConfig.onInspect && onInspect) {
+      config.onInspect = onInspect;
+    }
     return Object.keys(config).length > 0 ? config : undefined;
-  }, [itemConfig, provider.entity]);
+  }, [itemConfig, provider.entity, onInspect]);
 
   const columns = useMemo(
     () =>
@@ -234,6 +238,8 @@ const usePreview = (state: PlaygroundState) => {
                   switch (act.type) {
                     case 'edit':
                       return <Action.Edit key={act.instanceId} />;
+                    case 'inspect':
+                      return <Action.Inspect key={act.instanceId} />;
                     case 'delete':
                       return <Action.Delete key={act.instanceId} />;
                     case 'export':
@@ -344,7 +350,11 @@ const usePreview = (state: PlaygroundState) => {
  */
 export const PlaygroundBuilder = () => {
   const [state, dispatch] = useReducer(playgroundReducer, INITIAL_STATE);
-  const { providerProps, toolbarElement, columns, tableTitle, consumerJsx } = usePreview(state);
+  const { onInspect, flyout } = useInspectFlyout();
+  const { providerProps, toolbarElement, columns, tableTitle, consumerJsx } = usePreview(
+    state,
+    onInspect
+  );
 
   const stateKey = JSON.stringify(state);
   const actionsCol = state.table.columns.find((c) => c.type === 'actions');
@@ -407,6 +417,7 @@ export const PlaygroundBuilder = () => {
                 </EuiFlexItem>
               </EuiFlexGroup>
             </ContentListProvider>
+            {flyout}
             <EuiSpacer size="l" />
             <EuiCodeBlock language="tsx" fontSize="s" paddingSize="s" overflowHeight={300}>
               {jsx}
@@ -415,7 +426,7 @@ export const PlaygroundBuilder = () => {
         ),
       },
     ],
-    [stateKey, providerProps, toolbarElement, tableTitle, columns, jsx]
+    [stateKey, providerProps, toolbarElement, tableTitle, columns, jsx, flyout]
   );
 
   return (

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-docs/src/playground/playground_state.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-docs/src/playground/playground_state.ts
@@ -21,7 +21,7 @@ export interface ActiveColumn {
   actions: ActiveAction[];
 }
 
-export type ActionType = 'edit' | 'delete' | 'export';
+export type ActionType = 'edit' | 'delete' | 'inspect' | 'export';
 
 export interface ActiveAction {
   instanceId: string;
@@ -55,6 +55,7 @@ export interface PlaygroundState {
     getEditUrl: boolean;
     onEdit: boolean;
     onDelete: boolean;
+    onInspect: boolean;
   };
   table: {
     columns: ActiveColumn[];
@@ -163,6 +164,7 @@ export const FILTER_DEFINITIONS: { type: FilterType; label: string }[] = [
 
 export const ACTION_DEFINITIONS: { type: ActionType; label: string }[] = [
   { type: 'edit', label: 'Action.Edit' },
+  { type: 'inspect', label: 'Action.Inspect' },
   { type: 'delete', label: 'Action.Delete' },
   { type: 'export', label: 'Action (Export)' },
 ];
@@ -222,6 +224,7 @@ export const INITIAL_STATE: PlaygroundState = {
     getEditUrl: false,
     onEdit: false,
     onDelete: false,
+    onInspect: false,
   },
   table: {
     columns: [],

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-docs/src/stories_helpers.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-docs/src/stories_helpers.tsx
@@ -7,16 +7,20 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React, { useMemo, useState } from 'react';
-import type { ReactElement } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
+import type { ReactElement, ReactNode } from 'react';
 import reactElementToJSXString from 'react-element-to-jsx-string';
 import { css } from '@emotion/react';
 import {
   EuiBadge,
   EuiButtonIcon,
   EuiCodeBlock,
+  EuiDescriptionList,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiFlyout,
+  EuiFlyoutBody,
+  EuiFlyoutHeader,
   EuiPanel,
   EuiSpacer,
   EuiText,
@@ -33,6 +37,7 @@ import {
   NO_CREATOR_USER_LABEL,
 } from '@kbn/content-list-provider';
 import type {
+  ContentListItem,
   FindItemsParams,
   FindItemsResult,
   FilterFacetConfig,
@@ -52,6 +57,68 @@ import {
 } from '@kbn/content-list-mock-data';
 
 export { mockTagsService, createMockFavoritesClient, mockContentListUserProfilesServices };
+
+// =============================================================================
+// Inspect Flyout (mock content editor)
+// =============================================================================
+
+/**
+ * Mock "View details" flyout for Storybook stories.
+ *
+ * Renders a lightweight EuiFlyout showing item metadata. Stands in for the
+ * real Kibana content editor flyout (`@kbn/content-management-content-editor`)
+ * which requires Kibana core services not available in Storybook.
+ */
+const InspectFlyout = ({ item, onClose }: { item: ContentListItem; onClose: () => void }) => (
+  <EuiFlyout onClose={onClose} size="s" ownFocus>
+    <EuiFlyoutHeader hasBorder>
+      <EuiTitle size="m">
+        <h2>{item.title}</h2>
+      </EuiTitle>
+    </EuiFlyoutHeader>
+    <EuiFlyoutBody>
+      <EuiDescriptionList
+        type="column"
+        compressed
+        listItems={[
+          { title: 'ID', description: item.id },
+          { title: 'Description', description: item.description || '—' },
+          { title: 'Type', description: item.type || '—' },
+          {
+            title: 'Updated',
+            description: item.updatedAt ? new Date(item.updatedAt).toLocaleString() : '—',
+          },
+          { title: 'Tags', description: item.tags?.join(', ') || '—' },
+        ]}
+      />
+    </EuiFlyoutBody>
+  </EuiFlyout>
+);
+
+/**
+ * Hook that manages the open/close state for a mock inspect flyout.
+ *
+ * Returns an `onInspect` callback suitable for `ContentListItemConfig.onInspect`
+ * and a `flyout` element to render in the component tree.
+ *
+ * @example
+ * ```tsx
+ * const { onInspect, flyout } = useInspectFlyout();
+ * // pass onInspect to item config, render {flyout} in JSX
+ * ```
+ */
+export const useInspectFlyout = (): {
+  onInspect: (item: ContentListItem) => void;
+  flyout: ReactNode;
+} => {
+  const [inspectedItem, setInspectedItem] = useState<ContentListItem | null>(null);
+  const onInspect = useCallback((item: ContentListItem) => setInspectedItem(item), []);
+  const flyout = inspectedItem ? (
+    <InspectFlyout item={inspectedItem} onClose={() => setInspectedItem(null)} />
+  ) : null;
+
+  return { onInspect, flyout };
+};
 
 // =============================================================================
 // Mock Data

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/index.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/index.ts
@@ -15,6 +15,9 @@ export type { ContentListClientProviderProps } from './src/provider';
 export { createClientStrategy } from './src/strategy';
 export type { ClientStrategy } from './src/strategy';
 
+// Content editor.
+export type { ContentEditorConfig } from './src/content_editor';
+
 // Types.
 export type {
   ContentListClientServices,

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/moon.yml
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/moon.yml
@@ -22,6 +22,8 @@ dependsOn:
   - '@kbn/management-settings-ids'
   - '@kbn/content-management-favorites-public'
   - '@kbn/content-management-tags'
+  - '@kbn/content-management-content-editor'
+  - '@kbn/i18n'
 tags:
   - shared-browser
   - package

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/content_editor/index.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/content_editor/index.ts
@@ -7,16 +7,5 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-// Declarative components.
-export { Action, EditAction, DeleteAction, InspectAction, action } from './part';
-
-// Types.
-export type {
-  ActionProps,
-  ActionNamespace,
-  EditActionProps,
-  DeleteActionProps,
-  InspectActionProps,
-  ActionOutput,
-  ActionBuilderContext,
-} from './types';
+export type { ContentEditorConfig } from './types';
+export { useContentEditorInspect } from './use_content_editor_inspect';

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/content_editor/types.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/content_editor/types.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ReactNode } from 'react';
+import type {
+  ContentEditorCustomValidators,
+  OpenContentEditorParams,
+} from '@kbn/content-management-content-editor';
+import type { ContentListItem } from '@kbn/content-list-provider';
+
+/**
+ * Content editor configuration for `ContentListClientProvider`.
+ *
+ * This is the Kibana-specific content editor integration. The base
+ * `ContentListProvider` only knows about a simple `onInspect` callback;
+ * this config produces that callback by wiring it to the Kibana content
+ * editor flyout.
+ */
+export interface ContentEditorConfig {
+  /**
+   * Callback to open the content editor flyout.
+   * Obtained from `useOpenContentEditor()` in `@kbn/content-management-content-editor`.
+   */
+  openContentEditor: (params: OpenContentEditorParams) => () => void;
+
+  /** Whether the content editor is readonly. Defaults to `false`. */
+  isReadonly?: boolean;
+
+  /** Custom validators for title/description fields. */
+  customValidators?: ContentEditorCustomValidators;
+
+  /**
+   * Called when the user saves metadata edits.
+   * Receives the updated metadata fields. The callback should persist changes
+   * and return a resolved promise on success.
+   */
+  onSave?: (args: {
+    id: string;
+    title: string;
+    description?: string;
+    tags: string[];
+  }) => Promise<void>;
+
+  /**
+   * Optional render prop for additional rows in the content editor flyout.
+   * Used by Dashboard to show content insights (panel counts, activity, etc.).
+   */
+  appendRows?: (item: ContentListItem) => ReactNode;
+}

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/content_editor/use_content_editor_inspect.test.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/content_editor/use_content_editor_inspect.test.ts
@@ -1,0 +1,204 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { renderHook, act } from '@testing-library/react';
+import type { OpenContentEditorParams } from '@kbn/content-management-content-editor';
+import { contentListQueryClient } from '@kbn/content-list-provider';
+import { useContentEditorInspect } from './use_content_editor_inspect';
+import type { ContentEditorConfig } from './types';
+
+const mockOpenContentEditor = jest.fn((_params: OpenContentEditorParams): (() => void) =>
+  jest.fn()
+);
+const mockOnSave = jest.fn(async () => {});
+
+jest.mock('@kbn/content-list-provider', () => {
+  const actual = jest.requireActual('@kbn/content-list-provider');
+  return {
+    ...actual,
+    contentListQueryClient: {
+      invalidateQueries: jest.fn(),
+    },
+  };
+});
+
+const defaultConfig: ContentEditorConfig = {
+  openContentEditor: mockOpenContentEditor,
+  onSave: mockOnSave,
+  isReadonly: false,
+};
+
+const defaultOptions = {
+  entityName: 'dashboard',
+  isReadOnly: false,
+  queryKeyScope: 'test-listing',
+};
+
+const testItem = {
+  id: '1',
+  title: 'My Dashboard',
+  description: 'A test dashboard',
+  tags: ['tag-1', 'tag-2'],
+  createdAt: '2024-01-01T00:00:00Z',
+  createdBy: 'user-1',
+  updatedAt: new Date('2024-06-15T12:00:00Z'),
+  updatedBy: 'user-2',
+  managed: false,
+};
+
+describe('useContentEditorInspect', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns undefined when contentEditor is not provided', () => {
+    const { result } = renderHook(() =>
+      useContentEditorInspect({ ...defaultOptions, contentEditor: undefined })
+    );
+
+    expect(result.current).toBeUndefined();
+  });
+
+  it('returns a callback when contentEditor is provided', () => {
+    const { result } = renderHook(() =>
+      useContentEditorInspect({ ...defaultOptions, contentEditor: defaultConfig })
+    );
+
+    expect(result.current).toBeInstanceOf(Function);
+  });
+
+  it('calls openContentEditor with transformed item', () => {
+    const { result } = renderHook(() =>
+      useContentEditorInspect({ ...defaultOptions, contentEditor: defaultConfig })
+    );
+
+    act(() => {
+      result.current!(testItem);
+    });
+
+    expect(mockOpenContentEditor).toHaveBeenCalledTimes(1);
+    const callArgs = mockOpenContentEditor.mock.calls[0][0];
+
+    expect(callArgs.item).toMatchObject({
+      id: '1',
+      title: 'My Dashboard',
+      description: 'A test dashboard',
+      tags: ['tag-1', 'tag-2'],
+      createdAt: '2024-01-01T00:00:00Z',
+      createdBy: 'user-1',
+      updatedAt: '2024-06-15T12:00:00.000Z',
+      updatedBy: 'user-2',
+      managed: false,
+    });
+    expect(callArgs.entityName).toBe('dashboard');
+    expect(callArgs.isReadonly).toBe(false);
+  });
+
+  it('forces read-only mode for managed items', () => {
+    const { result } = renderHook(() =>
+      useContentEditorInspect({ ...defaultOptions, contentEditor: defaultConfig })
+    );
+
+    act(() => {
+      result.current!({ ...testItem, managed: true });
+    });
+
+    const callArgs = mockOpenContentEditor.mock.calls[0][0];
+    expect(callArgs.isReadonly).toBe(true);
+    expect(callArgs.readonlyReason).toBeDefined();
+    expect(callArgs.onSave).toBeUndefined();
+  });
+
+  it('wraps onSave with query invalidation', async () => {
+    const { result } = renderHook(() =>
+      useContentEditorInspect({ ...defaultOptions, contentEditor: defaultConfig })
+    );
+
+    act(() => {
+      result.current!(testItem);
+    });
+
+    const callArgs = mockOpenContentEditor.mock.calls[0][0];
+    expect(callArgs.onSave).toBeDefined();
+
+    await act(async () => {
+      await callArgs.onSave!({ id: '1', title: 'Updated', tags: ['tag-1'] });
+    });
+
+    expect(mockOnSave).toHaveBeenCalledWith({ id: '1', title: 'Updated', tags: ['tag-1'] });
+    expect(contentListQueryClient.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ['content-list', 'test-listing'],
+    });
+  });
+
+  it('handles items with no tags', () => {
+    const { result } = renderHook(() =>
+      useContentEditorInspect({ ...defaultOptions, contentEditor: defaultConfig })
+    );
+
+    act(() => {
+      result.current!({ id: '2', title: 'No Tags' });
+    });
+
+    const callArgs = mockOpenContentEditor.mock.calls[0][0];
+    expect(callArgs.item.tags).toEqual([]);
+  });
+
+  it('does not suppress onSave for non-managed items when isReadonly is false', () => {
+    const { result } = renderHook(() =>
+      useContentEditorInspect({ ...defaultOptions, contentEditor: defaultConfig })
+    );
+
+    act(() => {
+      result.current!(testItem);
+    });
+
+    const callArgs = mockOpenContentEditor.mock.calls[0][0];
+    expect(callArgs.isReadonly).toBe(false);
+    expect(callArgs.onSave).toBeDefined();
+  });
+
+  it('defaults to read-only when isReadonly is not explicitly set to false', () => {
+    const viewOnlyConfig: ContentEditorConfig = {
+      openContentEditor: mockOpenContentEditor,
+      onSave: mockOnSave,
+      // isReadonly intentionally omitted — should default to read-only
+    };
+    const { result } = renderHook(() =>
+      useContentEditorInspect({ ...defaultOptions, contentEditor: viewOnlyConfig })
+    );
+
+    act(() => {
+      result.current!(testItem);
+    });
+
+    const callArgs = mockOpenContentEditor.mock.calls[0][0];
+    expect(callArgs.isReadonly).toBe(true);
+    expect(callArgs.onSave).toBeUndefined();
+  });
+
+  it('defaults to read-only when onSave is not provided', () => {
+    const noSaveConfig: ContentEditorConfig = {
+      openContentEditor: mockOpenContentEditor,
+      isReadonly: false,
+      // onSave intentionally omitted — should force read-only
+    };
+    const { result } = renderHook(() =>
+      useContentEditorInspect({ ...defaultOptions, contentEditor: noSaveConfig })
+    );
+
+    act(() => {
+      result.current!(testItem);
+    });
+
+    const callArgs = mockOpenContentEditor.mock.calls[0][0];
+    expect(callArgs.isReadonly).toBe(true);
+    expect(callArgs.onSave).toBeUndefined();
+  });
+});

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/content_editor/use_content_editor_inspect.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/content_editor/use_content_editor_inspect.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { useCallback } from 'react';
+import { i18n } from '@kbn/i18n';
+import {
+  contentListKeys,
+  contentListQueryClient,
+  type ContentListItem,
+} from '@kbn/content-list-provider';
+import type { ContentEditorConfig } from './types';
+
+const MANAGED_READONLY_REASON = i18n.translate(
+  'contentManagement.contentList.contentEditor.managedReadonlyReason',
+  { defaultMessage: 'This item is managed by Kibana and cannot be edited.' }
+);
+
+/**
+ * Creates an `onInspect` callback that opens the Kibana content editor flyout.
+ *
+ * This hook encapsulates all Kibana-specific content editor logic:
+ * - Transforming `ContentListItem` to the content editor's `Item` shape
+ * - Forcing managed items into read-only mode with an explanatory reason
+ * - Wrapping `onSave` with query invalidation (to trigger refetch) and flyout close
+ *
+ * Returns `undefined` when `contentEditor` is not provided, so the base provider's
+ * `item.onInspect` remains unset and the inspect action won't render.
+ *
+ * @internal Used by `ContentListClientProvider`.
+ */
+export const useContentEditorInspect = ({
+  contentEditor,
+  entityName,
+  isReadOnly,
+  queryKeyScope,
+}: {
+  contentEditor?: ContentEditorConfig;
+  entityName: string;
+  isReadOnly?: boolean;
+  queryKeyScope: string;
+}): ((item: ContentListItem) => void) | undefined => {
+  const inspectItem = useCallback(
+    (item: ContentListItem) => {
+      if (!contentEditor) {
+        return;
+      }
+
+      const { openContentEditor, onSave, isReadonly, customValidators, appendRows } = contentEditor;
+
+      // Read-only by default: the flyout opens in view mode unless the consumer
+      // explicitly opts in to editing by setting `isReadonly: false` AND providing
+      // `onSave`. Managed items always force read-only regardless of config.
+      // This matches the existing TableListView behavior and prevents a runtime
+      // throw from useOpenContentEditor when onSave is absent.
+      const itemIsReadonly = item.managed || isReadonly !== false || isReadOnly || !onSave;
+
+      const close = openContentEditor({
+        item: {
+          id: item.id,
+          title: item.title,
+          description: item.description,
+          tags: item.tags ?? [],
+          createdAt: item.createdAt,
+          createdBy: item.createdBy,
+          updatedAt: item.updatedAt instanceof Date ? item.updatedAt.toISOString() : item.updatedAt,
+          updatedBy: item.updatedBy,
+          managed: item.managed,
+        },
+        entityName,
+        isReadonly: itemIsReadonly,
+        ...(item.managed && { readonlyReason: MANAGED_READONLY_REASON }),
+        customValidators,
+        onSave:
+          !itemIsReadonly && onSave
+            ? async (args) => {
+                await onSave(args);
+                contentListQueryClient.invalidateQueries({
+                  queryKey: contentListKeys.all(queryKeyScope),
+                });
+                close();
+              }
+            : undefined,
+        appendRows: appendRows ? appendRows(item) : undefined,
+      });
+    },
+    [contentEditor, entityName, isReadOnly, queryKeyScope]
+  );
+
+  return contentEditor ? inspectItem : undefined;
+};

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/provider.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/provider.tsx
@@ -34,6 +34,8 @@ import type { TableListViewFindItemsFn, ContentListClientServices } from './type
 import { createClientStrategy, filterItems, getCreatorKey } from './strategy';
 import type { ItemDecorator } from './strategy';
 import { ProfilePrimeEffect } from './profile_prime_effect';
+import type { ContentEditorConfig } from './content_editor';
+import { useContentEditorInspect } from './content_editor';
 
 /**
  * Compute per-key item counts from the full item set.
@@ -120,6 +122,15 @@ export type ContentListClientProviderProps = ContentListCoreConfig & {
   services: ContentListClientServices;
   /** Called after each successful item fetch. */
   onFetchSuccess?: DataSourceConfig['onFetchSuccess'];
+  /**
+   * Content editor (metadata editing flyout) configuration.
+   *
+   * When provided, creates an `onInspect` callback on the item config that opens
+   * the Kibana content editor flyout. The consumer must wrap their component tree
+   * with `ContentEditorKibanaProvider` (from `@kbn/content-management-content-editor`)
+   * above this provider.
+   */
+  contentEditor?: ContentEditorConfig;
 };
 
 /**
@@ -150,6 +161,20 @@ export type ContentListClientProviderProps = ContentListCoreConfig & {
  *   <MyContentList />
  * </ContentListClientProvider>
  * ```
+ *
+ * @example With content editor
+ * ```tsx
+ * const openContentEditor = useOpenContentEditor();
+ *
+ * <ContentListClientProvider
+ *   id="my-dashboards"
+ *   labels={{ entity: 'dashboard', entityPlural: 'dashboards' }}
+ *   findItems={myExistingFindItems}
+ *   contentEditor={{ openContentEditor, onSave: handleSave }}
+ * >
+ *   <MyContentList />
+ * </ContentListClientProvider>
+ * ```
  */
 export const ContentListClientProvider = ({
   children,
@@ -157,6 +182,8 @@ export const ContentListClientProvider = ({
   features: featuresProp = {},
   services,
   onFetchSuccess,
+  contentEditor,
+  item: itemConfigProp,
   ...rest
 }: ContentListClientProviderProps): JSX.Element => {
   const favoritesClient = services?.favorites;
@@ -331,12 +358,33 @@ export const ContentListClientProvider = ({
     };
   }, [features, uiSettingsPageSize]);
 
+  // Derive queryKeyScope the same way the base provider does.
+  const queryKeyScope = rest.queryKeyScope ?? `${rest.id}-listing`;
+
+  // Create the onInspect callback from the content editor config.
+  const onInspect = useContentEditorInspect({
+    contentEditor,
+    entityName: rest.labels.entity,
+    isReadOnly: rest.isReadOnly,
+    queryKeyScope,
+  });
+
+  // Merge onInspect into the item config.
+  const itemConfig = useMemo(
+    () => ({
+      ...itemConfigProp,
+      ...(onInspect && { onInspect }),
+    }),
+    [itemConfigProp, onInspect]
+  );
+
   return (
     <ContentListProvider
       dataSource={dataSource}
       features={resolvedFeatures}
       services={services}
       profileCache={profileCache}
+      item={itemConfig}
       {...rest}
     >
       {starredEnabled && <FavoritesSyncEffect favoriteIdsRef={favoriteIdsRef} />}

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/strategy.test.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/strategy.test.ts
@@ -87,6 +87,41 @@ describe('createClientStrategy', () => {
       expect(result.total).toBe(2);
     });
 
+    it('transforms tags, managed, and audit metadata from UserContentCommonSchema', async () => {
+      const richItem: UserContentCommonSchema = {
+        id: 'rich-1',
+        type: 'dashboard',
+        updatedAt: '2024-06-15T12:00:00.000Z',
+        updatedBy: 'user-2',
+        createdAt: '2024-01-01T00:00:00.000Z',
+        createdBy: 'user-1',
+        managed: true,
+        references: [
+          { type: 'tag', id: 'tag-1', name: 'tag-ref-tag-1' },
+          { type: 'tag', id: 'tag-2', name: 'tag-ref-tag-2' },
+          { type: 'index-pattern', id: 'ip-1', name: 'some-pattern' },
+        ],
+        attributes: { title: 'Rich Dashboard', description: 'Has all fields' },
+      };
+      const mockFindItems = createMockFindItems([richItem]);
+      const { findItems } = createClientStrategy(mockFindItems);
+
+      const result = await findItems(createParams());
+
+      expect(result.items[0]).toEqual({
+        id: 'rich-1',
+        title: 'Rich Dashboard',
+        description: 'Has all fields',
+        type: 'dashboard',
+        updatedAt: new Date('2024-06-15T12:00:00.000Z'),
+        tags: ['tag-1', 'tag-2'],
+        createdAt: '2024-01-01T00:00:00.000Z',
+        createdBy: 'user-1',
+        updatedBy: 'user-2',
+        managed: true,
+      });
+    });
+
     it('handles empty results', async () => {
       const mockFindItems = createMockFindItems([]);
       const { findItems } = createClientStrategy(mockFindItems);

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/strategy.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/strategy.ts
@@ -275,6 +275,7 @@ const transformItem = (item: UserContentCommonSchema): ContentListItem => {
     updatedAt: _ua,
     createdAt: _ca,
     createdBy: _cb,
+    updatedBy: _ub,
     managed: _m,
     references: _refs,
     attributes: _attrs,
@@ -290,7 +291,9 @@ const transformItem = (item: UserContentCommonSchema): ContentListItem => {
     type: item.type,
     updatedAt: item.updatedAt ? new Date(item.updatedAt) : undefined,
     tags: extractTagIds(item.references),
+    createdAt: item.createdAt,
     createdBy: item.createdBy,
+    updatedBy: item.updatedBy,
     managed: item.managed,
   };
 };

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/tsconfig.json
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/tsconfig.json
@@ -16,5 +16,7 @@
     "@kbn/management-settings-ids",
     "@kbn/content-management-favorites-public",
     "@kbn/content-management-tags",
+    "@kbn/content-management-content-editor",
+    "@kbn/i18n"
   ]
 }

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/index.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/index.ts
@@ -118,4 +118,4 @@ export {
 } from './src/item';
 
 // Utilities.
-export { contentListKeys } from './src/query';
+export { contentListKeys, contentListQueryClient } from './src/query';

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/item/types.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/item/types.ts
@@ -87,6 +87,14 @@ export type ContentListItem<T = Record<string, unknown>> = T & {
   updatedAt?: Date;
   /** Optional array of tag IDs associated with this item. */
   tags?: string[];
+  /** Creation timestamp (ISO string). Used by the content editor. */
+  createdAt?: string;
+  /** User ID or profile ID of the item creator. Used by the content editor. */
+  createdBy?: string;
+  /** User ID or profile ID of the last editor. Used by the content editor. */
+  updatedBy?: string;
+  /** Whether this item is managed (system-owned). Used by the content editor. */
+  managed?: boolean;
 };
 
 /**
@@ -127,4 +135,15 @@ export interface ContentListItemConfig {
    * The callback should handle the actual deletion and return a resolved promise on success.
    */
   onDelete?: (items: ContentListItem[]) => Promise<void>;
+
+  /**
+   * Callback invoked to inspect an item (view/edit its metadata).
+   * When provided, enables the "View details" row action.
+   *
+   * This is a simple, UI-agnostic callback — the implementation decides what
+   * happens when the action fires (e.g., opening a flyout, navigating to a
+   * detail page). The Kibana content editor integration is handled by
+   * `ContentListClientProvider` in `@kbn/content-list-provider-client`.
+   */
+  onInspect?: (item: ContentListItem) => void;
 }

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/index.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/index.ts
@@ -55,8 +55,10 @@ export type { ColumnNamespace, ColumnProps } from './src/column';
 export {
   EditAction,
   DeleteAction,
+  InspectAction,
   type EditActionProps,
   type DeleteActionProps,
+  type InspectActionProps,
 } from './src/action';
 export type { ActionNamespace, ActionProps } from './src/action';
 

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/action/inspect/index.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/action/inspect/index.ts
@@ -7,16 +7,4 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-// Declarative components.
-export { Action, EditAction, DeleteAction, InspectAction, action } from './part';
-
-// Types.
-export type {
-  ActionProps,
-  ActionNamespace,
-  EditActionProps,
-  DeleteActionProps,
-  InspectActionProps,
-  ActionOutput,
-  ActionBuilderContext,
-} from './types';
+export { buildInspectAction } from './inspect_action';

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/action/inspect/inspect_action.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/action/inspect/inspect_action.test.tsx
@@ -26,6 +26,7 @@ const defaultContext: ActionBuilderContext = {
     selection: true,
     tags: false,
     starred: false,
+    userProfiles: false,
   },
 };
 

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/action/inspect/inspect_action.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/action/inspect/inspect_action.test.tsx
@@ -1,0 +1,87 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type React from 'react';
+import type { ActionBuilderContext } from '../types';
+import { buildInspectAction } from './inspect_action';
+
+const onInspect = jest.fn();
+
+const defaultContext: ActionBuilderContext = {
+  itemConfig: {
+    onInspect,
+  },
+  isReadOnly: false,
+  entityName: 'dashboard',
+  supports: {
+    sorting: true,
+    pagination: true,
+    search: true,
+    selection: true,
+    tags: false,
+    starred: false,
+  },
+};
+
+describe('inspect action builder', () => {
+  describe('buildInspectAction', () => {
+    it('returns an action when onInspect is configured', () => {
+      const result = buildInspectAction({}, defaultContext);
+
+      expect(result).toMatchObject({
+        description: expect.any(String),
+        icon: 'inspect',
+        type: 'icon',
+        'data-test-subj': 'content-list-table-action-inspect',
+      });
+    });
+
+    it('returns `undefined` when onInspect is not configured', () => {
+      const context: ActionBuilderContext = {
+        ...defaultContext,
+        itemConfig: {},
+      };
+      const result = buildInspectAction({}, context);
+
+      expect(result).toBeUndefined();
+    });
+
+    it('returns `undefined` when itemConfig is undefined', () => {
+      const context: ActionBuilderContext = {
+        ...defaultContext,
+        itemConfig: undefined,
+      };
+      const result = buildInspectAction({}, context);
+
+      expect(result).toBeUndefined();
+    });
+
+    it('generates a dynamic name including the item title', () => {
+      const result = buildInspectAction({}, defaultContext);
+      const item = { id: '1', title: 'My Dashboard' };
+
+      const name = typeof result?.name === 'function' ? result.name(item) : result?.name;
+      expect(name).toContain('My Dashboard');
+    });
+
+    it('calls onInspect when onClick is triggered', () => {
+      const result = buildInspectAction({}, defaultContext);
+      const item = { id: '1', title: 'Test' };
+
+      result?.onClick?.(item, {} as React.MouseEvent);
+      expect(onInspect).toHaveBeenCalledWith(item);
+    });
+
+    it('uses custom label when provided', () => {
+      const result = buildInspectAction({ label: 'Details' }, defaultContext);
+
+      expect(result).toMatchObject({ name: 'Details' });
+    });
+  });
+});

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/action/inspect/inspect_action.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/action/inspect/inspect_action.tsx
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { i18n } from '@kbn/i18n';
+import type { InspectActionProps, ActionOutput, ActionBuilderContext } from '../types';
+
+/** Default i18n-translated description for the inspect action. */
+const DEFAULT_INSPECT_DESCRIPTION = i18n.translate(
+  'contentManagement.contentList.table.action.inspect.description',
+  { defaultMessage: 'View details' }
+);
+
+/**
+ * Build a `DefaultItemAction` for the inspect (view details) action preset.
+ *
+ * Returns `undefined` when no `onInspect` handler is configured on the item config.
+ *
+ * @param attributes - The declarative attributes from the parsed `Action.Inspect` element.
+ * @param context - Builder context with provider configuration.
+ * @returns A `DefaultItemAction<ContentListItem>` for the inspect action, or `undefined` to skip.
+ */
+export const buildInspectAction = (
+  attributes: InspectActionProps,
+  context: ActionBuilderContext
+): ActionOutput | undefined => {
+  if (!context.itemConfig?.onInspect) {
+    return undefined;
+  }
+
+  const { onInspect } = context.itemConfig;
+
+  const label =
+    attributes.label ??
+    ((item) =>
+      i18n.translate('contentManagement.contentList.table.action.inspect.label', {
+        defaultMessage: 'View {itemTitle} details',
+        values: { itemTitle: item.title },
+      }));
+
+  return {
+    name: label,
+    description: DEFAULT_INSPECT_DESCRIPTION,
+    icon: 'inspect',
+    type: 'icon',
+    onClick: (item) => onInspect(item),
+    'data-test-subj': 'content-list-table-action-inspect',
+  };
+};

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/action/part.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/action/part.ts
@@ -11,12 +11,14 @@ import { table } from '../assembly';
 import type {
   EditActionProps,
   DeleteActionProps,
+  InspectActionProps,
   ActionOutput,
   ActionBuilderContext,
   ActionProps,
 } from './types';
 import { buildEditAction } from './edit/edit_action';
 import { buildDeleteAction } from './delete/delete_action';
+import { buildInspectAction } from './inspect/inspect_action';
 
 /**
  * Preset-to-props mapping for table actions.
@@ -24,6 +26,7 @@ import { buildDeleteAction } from './delete/delete_action';
 export interface ActionPresets {
   edit: EditActionProps;
   delete: DeleteActionProps;
+  inspect: InspectActionProps;
 }
 
 /** Part factory for table actions. */
@@ -115,6 +118,29 @@ export const EditAction = action.createPreset({ name: 'edit', resolve: buildEdit
  * ```
  */
 export const DeleteAction = action.createPreset({ name: 'delete', resolve: buildDeleteAction });
+
+/**
+ * Inspect action preset component for `ContentListTable`.
+ *
+ * This is a declarative component that doesn't render anything.
+ * It specifies the inspect (view details) action within a `Column.Actions` context.
+ * Opens the content editor flyout for the selected item.
+ *
+ * @example
+ * ```tsx
+ * const { Column, Action } = ContentListTable;
+ *
+ * <ContentListTable>
+ *   <Column.Name />
+ *   <Column.Actions>
+ *     <Action.Edit />
+ *     <Action.Inspect />
+ *     <Action.Delete />
+ *   </Column.Actions>
+ * </ContentListTable>
+ * ```
+ */
+export const InspectAction = action.createPreset({ name: 'inspect', resolve: buildInspectAction });
 
 /**
  * Custom action component for `ContentListTable`.

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/action/types.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/action/types.ts
@@ -61,12 +61,13 @@ export interface ActionProps {
  * Namespace interface for `Action` sub-components.
  *
  * The base `Action` accepts {@link ActionProps}; pre-built actions
- * are properties (e.g., `Action.Edit`, `Action.Delete`).
+ * are properties (e.g., `Action.Edit`, `Action.Delete`, `Action.Inspect`).
  */
 export interface ActionNamespace {
   (props: ActionProps): ReactNode;
   Edit: (props: EditActionProps) => ReactNode;
   Delete: (props: DeleteActionProps) => ReactNode;
+  Inspect: (props: InspectActionProps) => ReactNode;
 }
 
 /**
@@ -87,4 +88,12 @@ export interface DeleteActionProps {
   label?: string;
   /** Per-item guard. When provided, disables the action for items where this returns `false`. */
   enabled?: (item: ContentListItem) => boolean;
+}
+
+/**
+ * Props for the `Action.Inspect` preset component.
+ */
+export interface InspectActionProps {
+  /** Custom label for the inspect action. Defaults to `'View {itemTitle} details'`. */
+  label?: string | ((item: ContentListItem) => ReactNode);
 }

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/actions/actions_builder.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/actions/actions_builder.test.tsx
@@ -108,7 +108,7 @@ describe('actions column builder', () => {
         expect(result).toBeUndefined();
       });
 
-      it('returns `undefined` in read-only mode', () => {
+      it('returns `undefined` in read-only mode when onInspect is not configured', () => {
         const context: ColumnBuilderContext = {
           ...defaultContext,
           isReadOnly: true,
@@ -116,6 +116,36 @@ describe('actions column builder', () => {
         const result = buildActionsColumn({}, context);
 
         expect(result).toBeUndefined();
+      });
+
+      it('returns only inspect action in read-only mode when onInspect is configured', () => {
+        const context: ColumnBuilderContext = {
+          ...defaultContext,
+          isReadOnly: true,
+          itemConfig: { ...defaultContext.itemConfig, onInspect: jest.fn() },
+        };
+        const result = buildActionsColumn({}, context) as ActionsColumn;
+
+        expect(result).toBeDefined();
+        expect(result.actions).toHaveLength(1);
+        expect(result.actions[0]).toMatchObject({
+          icon: 'inspect',
+          'data-test-subj': 'content-list-table-action-inspect',
+        });
+      });
+
+      it('includes inspect action alongside edit and delete when onInspect is configured', () => {
+        const context: ColumnBuilderContext = {
+          ...defaultContext,
+          itemConfig: { ...defaultContext.itemConfig, onInspect: jest.fn() },
+        };
+        const result = buildActionsColumn({}, context) as ActionsColumn;
+
+        expect(result).toBeDefined();
+        expect(result.actions).toHaveLength(3);
+        expect(result.actions[0]).toMatchObject({ icon: 'pencil' });
+        expect(result.actions[1]).toMatchObject({ icon: 'trash' });
+        expect(result.actions[2]).toMatchObject({ icon: 'inspect' });
       });
     });
 

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/actions/actions_builder.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/actions/actions_builder.tsx
@@ -56,29 +56,41 @@ const getDefaultActionParts = (context: ColumnBuilderContext): ParsedPart[] => {
   const parts: ParsedPart[] = [];
   const { itemConfig, isReadOnly } = context;
 
-  if (isReadOnly) {
-    return parts;
+  // Edit and delete actions are suppressed in read-only mode, but inspect
+  // (view details) is always available when the content editor is enabled —
+  // matching the existing TableListView behavior where "View details" is
+  // shown regardless of read-only state.
+  if (!isReadOnly) {
+    const hasEdit = itemConfig?.getEditUrl || itemConfig?.onEdit;
+    const hasDelete = itemConfig?.onDelete;
+
+    if (hasEdit) {
+      parts.push({
+        type: 'part',
+        part: 'action',
+        preset: 'edit',
+        instanceId: 'edit',
+        attributes: {},
+      });
+    }
+
+    if (hasDelete) {
+      parts.push({
+        type: 'part',
+        part: 'action',
+        preset: 'delete',
+        instanceId: 'delete',
+        attributes: {},
+      });
+    }
   }
 
-  const hasEdit = itemConfig?.getEditUrl || itemConfig?.onEdit;
-  const hasDelete = itemConfig?.onDelete;
-
-  if (hasEdit) {
+  if (itemConfig?.onInspect) {
     parts.push({
       type: 'part',
       part: 'action',
-      preset: 'edit',
-      instanceId: 'edit',
-      attributes: {},
-    });
-  }
-
-  if (hasDelete) {
-    parts.push({
-      type: 'part',
-      part: 'action',
-      preset: 'delete',
-      instanceId: 'delete',
+      preset: 'inspect',
+      instanceId: 'inspect',
       attributes: {},
     });
   }

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/content_list_table.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/content_list_table.tsx
@@ -25,7 +25,7 @@ import {
   StarredColumn,
   CreatedByColumn,
 } from './column';
-import { Action as BaseAction, EditAction, DeleteAction } from './action';
+import { Action as BaseAction, EditAction, DeleteAction, InspectAction } from './action';
 import { useColumns, useSorting, useSelection } from './hooks';
 import { EmptyState } from './empty_state';
 
@@ -183,6 +183,7 @@ export const Column = Object.assign(BaseColumn, {
 export const Action = Object.assign(BaseAction, {
   Edit: EditAction,
   Delete: DeleteAction,
+  Inspect: InspectAction,
 });
 
 export const ContentListTable = Object.assign(ContentListTableComponent, {

--- a/src/platform/packages/shared/content-management/table_list_view_table/src/table_list_view_table.tsx
+++ b/src/platform/packages/shared/content-management/table_list_view_table/src/table_list_view_table.tsx
@@ -29,10 +29,7 @@ import {
   ManagedAvatarTip,
   NoCreatorTip,
 } from '@kbn/content-management-user-profiles';
-import type {
-  OpenContentEditorParams,
-  SavedObjectsReference,
-} from '@kbn/content-management-content-editor';
+import type { OpenContentEditorParams } from '@kbn/content-management-content-editor';
 import type { UserContentCommonSchema } from '@kbn/content-management-table-list-view-common';
 import type { RecentlyAccessed } from '@kbn/recently-accessed';
 import {
@@ -542,9 +539,7 @@ function TableListViewTableComp<T extends UserContentCommonSchema>({
 
   const inspectItem = useCallback(
     (item: T) => {
-      const tags = getTagIdsFromReferences(item.references).map((_id) => {
-        return item.references.find(({ id: refId }) => refId === _id) as SavedObjectsReference;
-      });
+      const tags = getTagIdsFromReferences(item.references);
 
       const close = openContentEditor({
         item: {


### PR DESCRIPTION
## Summary

- Adds metadata editing flyout support to the Content List architecture
- Updates `@kbn/content-management-content-editor` to accept `string[]` tags (removing the `ItemTags` union) and moves the `SavedObjectsReference` adapter into `ContentEditorKibanaProvider`
- Adds `Action.Inspect` ("View details") row action to `@kbn/content-list-table`
- Wires content editor flyout via `ContentListClientProvider.contentEditor` prop, keeping the base provider Kibana-agnostic
- Updates Playground and Core Features + Extended stories with inspect flyout

## Architecture

The base provider (`@kbn/content-list-provider`) exposes a simple `onInspect?: (item) => void` callback on `ContentListItemConfig`. It has no knowledge of Kibana's content editor.

The client provider (`@kbn/content-list-provider-client`) owns the Kibana coupling: it accepts a `contentEditor` config prop, creates the `onInspect` implementation (item transformation, managed-item read-only enforcement, post-save query invalidation), and passes it to the base provider.

`Item.tags` is now uniformly `string[]` throughout the content editor internals. The one place that bridges to the `savedObjectsTagging` plugin's `SavedObjectsReference[]` interface is the `TagList` adapter inside `ContentEditorKibanaProvider` — the correct architectural boundary for Kibana-specific concerns.

## Test plan

- [x] `node scripts/jest src/platform/packages/shared/content-management/content_list/kbn-content-list-provider` — 213 tests pass
- [x] `node scripts/jest src/platform/packages/shared/content-management/content_list/kbn-content-list-table` — 124 tests pass
- [x] `node scripts/jest src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client` — 37 tests pass
- [x] `node scripts/jest src/platform/packages/shared/content-management/content_editor` — 11 tests pass
- [x] `node scripts/check_changes.ts` — all pre-commit checks pass
- [x] Storybook: Playground "Action.Inspect" opens a mock flyout; Core Features + Extended shows inspect action

🤖 Generated with [Claude Code](https://claude.com/claude-code)