### PR TITLE
Fix flaky test by waiting for session completion before restore

### DIFF
--- a/x-pack/platform/test/search_sessions_integration/tests/apps/dashboard/async_search/sessions_in_space.ts
+++ b/x-pack/platform/test/search_sessions_integration/tests/apps/dashboard/async_search/sessions_in_space.ts
@@ -24,6 +24,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const kibanaServer = getService('kibanaServer');
   const toasts = getService('toasts');
   const dashboardExpect = getService('dashboardExpect');
+  const retry = getService('retry');
 
   describe('dashboard in space', () => {
     afterEach(async () => await clean());
@@ -52,6 +53,14 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         );
 
         if (!searchSessionItem) throw new Error(`Can\'t find session with id = ${savedSessionId}`);
+
+        // Wait for the session to complete before restoring, otherwise searches
+        // may not be served from cache and trigger "still running" warning toasts
+        await retry.waitFor('session should be in a completed status', async () => {
+          const updatedList = await searchSessionsManagement.getList();
+          const item = updatedList.find((session) => session.id === savedSessionId);
+          return item?.status === 'complete';
+        });
 
         // navigate to discover
         await searchSessionItem.view();


### PR DESCRIPTION
The 'Saves and restores a session' test in sessions_in_space.ts was flaky because it restored a search session before background searches had completed. When a search response during restore has isRestored=false, the search interceptor shows a 'still running' warning toast, causing the expect(toasts.getCount()).to.be(0) assertion to fail.

Add retry.waitFor to poll session status until 'complete' before clicking view(), matching the pattern used in session_searches_integration.ts.

Closes #255927

## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



