### PR TITLE
Remove panel shadow from console shell

### DIFF
--- a/src/platform/plugins/shared/console/public/application/containers/main/main.tsx
+++ b/src/platform/plugins/shared/console/public/application/containers/main/main.tsx
@@ -84,7 +84,7 @@ const useStyles = (isEmbeddable: boolean) => {
       // SASSTODO: Uncomment when tooltips are EUI-ified (inside portals)
       overflow: hidden;
       padding: ${euiTheme.size.m} 0;
-      borderRadius: none;
+      borderradius: none;
       gap: 0;
       ${isEmbeddable &&
       css`
@@ -252,7 +252,12 @@ export function Main({ currentTabProp, isEmbeddable = false }: MainProps) {
       <EuiScreenReaderOnly>
         <h1>{MAIN_PANEL_LABELS.consolePageHeading}</h1>
       </EuiScreenReaderOnly>
-      <EuiSplitPanel.Outer grow={true} borderRadius={isEmbeddable ? 'none' : 'm'} hasShadow={false} hasBorder={false}>
+      <EuiSplitPanel.Outer
+        grow={true}
+        borderRadius={isEmbeddable ? 'none' : 'm'}
+        hasShadow={false}
+        hasBorder={false}
+      >
         <EuiSplitPanel.Inner grow={false} css={styles.consoleTabs}>
           <EuiFlexGroup direction="row" alignItems="center" gutterSize="s" responsive={false}>
             <EuiFlexItem>

--- a/src/platform/plugins/shared/console/public/application/containers/main/main.tsx
+++ b/src/platform/plugins/shared/console/public/application/containers/main/main.tsx
@@ -83,7 +83,8 @@ const useStyles = (isEmbeddable: boolean) => {
       // Make sure the editor actions don't create scrollbars on this container
       // SASSTODO: Uncomment when tooltips are EUI-ified (inside portals)
       overflow: hidden;
-      padding: ${euiTheme.size.m};
+      padding: ${euiTheme.size.m} 0;
+      borderRadius: none;
       gap: 0;
       ${isEmbeddable &&
       css`
@@ -251,7 +252,7 @@ export function Main({ currentTabProp, isEmbeddable = false }: MainProps) {
       <EuiScreenReaderOnly>
         <h1>{MAIN_PANEL_LABELS.consolePageHeading}</h1>
       </EuiScreenReaderOnly>
-      <EuiSplitPanel.Outer grow={true} borderRadius={isEmbeddable ? 'none' : 'm'}>
+      <EuiSplitPanel.Outer grow={true} borderRadius={isEmbeddable ? 'none' : 'm'} hasShadow={false} hasBorder={false}>
         <EuiSplitPanel.Inner grow={false} css={styles.consoleTabs}>
           <EuiFlexGroup direction="row" alignItems="center" gutterSize="s" responsive={false}>
             <EuiFlexItem>


### PR DESCRIPTION
## Summary

Removes the panel shadow from the console shell in Dev tools.  While this worked well for the Classic nav, there's a double-shadow for solution navs. 

This change attempts to find a common simplified style that works for both.

This will be a somewhat temporary fix while further design updates are coming to console.

### Current
<img width="2926" height="1818" alt="CleanShot 2026-04-10 at 18 24 46@2x" src="https://github.com/user-attachments/assets/4009cba9-78fb-4393-b19a-b98ccd4ffc1f" />

### Updated
**Solution nav:**
<img width="2926" height="1804" alt="CleanShot 2026-04-10 at 18 20 31@2x" src="https://github.com/user-attachments/assets/4056ff8c-77b6-4f99-8d3b-95795d3622b2" />

**Classic nav:**
<img width="2926" height="1818" alt="CleanShot 2026-04-10 at 18 23 22@2x" src="https://github.com/user-attachments/assets/56d7c1d7-7320-4874-b7d2-4b5d3474b73a" />


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] ~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~
- [ ] ~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [ ] ~[Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios~
- [ ] ~If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- [ ] ~This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.~
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



