### PR TITLE
Fix false-positive JSDoc violations in check_package_docs

### DIFF
--- a/packages/kbn-docs-utils/src/build_api_declarations/build_arrow_fn_dec.ts
+++ b/packages/kbn-docs-utils/src/build_api_declarations/build_arrow_fn_dec.ts
@@ -19,7 +19,7 @@ import type { ApiDeclaration } from '../types';
 import { TypeKind } from '../types';
 import { buildApiDecsForParameters } from './build_parameter_decs';
 import { getSignature } from './get_signature';
-import { getJSDocReturnTagComment, getJSDocs } from './js_doc_utils';
+import { getJSDocReturnTagComment, getJSDocs, type PluginContext } from './js_doc_utils';
 import { buildBasicApiDeclaration } from './build_basic_api_declaration';
 import type { BuildApiDecOpts } from './types';
 
@@ -38,12 +38,16 @@ export function getArrowFunctionDec(
   initializer: ArrowFunction,
   opts: BuildApiDecOpts
 ): ApiDeclaration {
+  const pluginContext: PluginContext = {
+    pluginId: opts.currentPluginId,
+    scope: opts.scope,
+  };
   return {
     ...buildBasicApiDeclaration(node, opts),
     type: TypeKind.FunctionKind,
     children: buildApiDecsForParameters(initializer.getParameters(), opts, getJSDocs(node)),
     // need to override the signature - use the initializer, not the node.
     signature: getSignature(initializer, opts.plugins, opts.log),
-    returnComment: getJSDocReturnTagComment(node),
+    returnComment: getJSDocReturnTagComment(node, pluginContext),
   };
 }

--- a/packages/kbn-docs-utils/src/build_api_declarations/build_basic_api_declaration.ts
+++ b/packages/kbn-docs-utils/src/build_api_declarations/build_basic_api_declaration.ts
@@ -13,7 +13,7 @@ import type { ApiDeclaration } from '../types';
 import { maybeCollectReferences } from './get_references';
 import { getSignature } from './get_signature';
 import { getTypeKind } from './get_type_kind';
-import { getCommentsFromNode, getJSDocTags } from './js_doc_utils';
+import { getCommentsFromNode, getJSDocTags, type PluginContext } from './js_doc_utils';
 import type { BuildApiDecOpts } from './types';
 import { getSourceLocationForNode } from './utils';
 
@@ -22,6 +22,10 @@ import { getSourceLocationForNode } from './utils';
  * children or references, still need to be added in.
  */
 export function buildBasicApiDeclaration(node: Node, opts: BuildApiDecOpts): ApiDeclaration {
+  const pluginContext: PluginContext = {
+    pluginId: opts.currentPluginId,
+    scope: opts.scope,
+  };
   const tags = getJSDocTags(node);
   const deprecated = tags.find((t) => t.getTagName() === 'deprecated') !== undefined;
   const removeByTag = tags.find((t) => t.getTagName() === 'removeBy');
@@ -49,7 +53,7 @@ export function buildBasicApiDeclaration(node: Node, opts: BuildApiDecOpts): Api
     type: getTypeKind(node),
     tags: getTagNames(tags),
     label,
-    description: getCommentsFromNode(node),
+    description: getCommentsFromNode(node, pluginContext),
     signature: getSignature(node, opts.plugins, opts.log),
     path,
     lineNumber,

--- a/packages/kbn-docs-utils/src/build_api_declarations/build_call_signature_dec.ts
+++ b/packages/kbn-docs-utils/src/build_api_declarations/build_call_signature_dec.ts
@@ -8,25 +8,38 @@
  */
 
 import type { Node, Signature } from 'ts-morph';
+import { Node as MorphNode } from 'ts-morph';
 import type { ApiDeclaration } from '../types';
 import { buildApiDeclaration } from './build_api_declaration';
 import { buildBasicApiDeclaration } from './build_basic_api_declaration';
-import { getJSDocParamComment, getJSDocReturnTagComment } from './js_doc_utils';
+import { getJSDocParamComment, getJSDocReturnTagComment, type PluginContext } from './js_doc_utils';
 import type { BuildApiDecOpts } from './types';
 import { buildApiId, getOptsForChildWithName } from './utils';
 
 export function buildCallSignatureDec(node: Node, signature: Signature, opts: BuildApiDecOpts) {
+  const pluginContext: PluginContext = {
+    pluginId: opts.currentPluginId,
+    scope: opts.scope,
+  };
   return {
     ...buildBasicApiDeclaration(node, opts),
-    returnComment: getJSDocReturnTagComment(node),
+    returnComment: getJSDocReturnTagComment(node, pluginContext),
     children: signature.getParameters().reduce((kids, p, index) => {
       if (p.getDeclarations().length === 1) {
+        const decl = p.getDeclarations()[0];
+
+        // TypeScript uses synthetic names like `__0` for destructured parameters.
+        // Prefer the written name from the ParameterDeclaration when available.
+        const symbolName = p.getName();
+        const writtenName = MorphNode.isParameterDeclaration(decl) ? decl.getName() : symbolName;
+        const lookupNames = writtenName !== symbolName ? [writtenName, symbolName] : [symbolName];
+
         kids.push({
-          ...buildApiDeclaration(p.getDeclarations()[0], {
-            ...getOptsForChildWithName(p.getName(), opts),
+          ...buildApiDeclaration(decl, {
+            ...getOptsForChildWithName(writtenName, opts),
             id: buildApiId(`$${index + 1}`, opts.id),
           }),
-          description: getJSDocParamComment(node, p.getName()),
+          description: getJSDocParamComment(node, lookupNames, pluginContext),
         });
       } else {
         opts.log.warning(`Losing information on parameter ${p.getName()}`);

--- a/packages/kbn-docs-utils/src/build_api_declarations/build_function_dec.ts
+++ b/packages/kbn-docs-utils/src/build_api_declarations/build_function_dec.ts
@@ -19,7 +19,7 @@ import type {
 import { buildApiDecsForParameters } from './build_parameter_decs';
 import type { ApiDeclaration } from '../types';
 import { TypeKind } from '../types';
-import { getJSDocReturnTagComment, getJSDocs } from './js_doc_utils';
+import { getJSDocReturnTagComment, getJSDocs, type PluginContext } from './js_doc_utils';
 import { buildBasicApiDeclaration } from './build_basic_api_declaration';
 import type { BuildApiDecOpts } from './types';
 
@@ -36,11 +36,15 @@ export function buildFunctionDec(
     | CallSignatureDeclaration,
   opts: BuildApiDecOpts
 ): ApiDeclaration {
+  const pluginContext: PluginContext = {
+    pluginId: opts.currentPluginId,
+    scope: opts.scope,
+  };
   const fn = {
     ...buildBasicApiDeclaration(node, opts),
     type: TypeKind.FunctionKind,
     children: buildApiDecsForParameters(node.getParameters(), opts, getJSDocs(node)),
-    returnComment: getJSDocReturnTagComment(node),
+    returnComment: getJSDocReturnTagComment(node, pluginContext),
   };
   return fn;
 }

--- a/packages/kbn-docs-utils/src/build_api_declarations/build_function_type_dec.ts
+++ b/packages/kbn-docs-utils/src/build_api_declarations/build_function_type_dec.ts
@@ -13,7 +13,7 @@ import type { FunctionTypeNode } from 'ts-morph';
 import { buildApiDecsForParameters } from './build_parameter_decs';
 import type { ApiDeclaration } from '../types';
 import { TypeKind } from '../types';
-import { getJSDocReturnTagComment, getJSDocs } from './js_doc_utils';
+import { getJSDocReturnTagComment, getJSDocs, type PluginContext } from './js_doc_utils';
 import { buildBasicApiDeclaration } from './build_basic_api_declaration';
 import type { BuildApiDecOpts } from './types';
 
@@ -25,11 +25,15 @@ export function buildFunctionTypeDec(
   typeNode: FunctionTypeNode,
   opts: BuildApiDecOpts
 ): ApiDeclaration {
+  const pluginContext: PluginContext = {
+    pluginId: opts.currentPluginId,
+    scope: opts.scope,
+  };
   const fn = {
     ...buildBasicApiDeclaration(node, opts),
     type: TypeKind.FunctionKind,
     children: buildApiDecsForParameters(typeNode.getParameters(), opts, getJSDocs(node)),
-    returnComment: getJSDocReturnTagComment(node),
+    returnComment: getJSDocReturnTagComment(node, pluginContext),
   };
   return fn;
 }

--- a/packages/kbn-docs-utils/src/build_api_declarations/build_multiple_call_signatures_dec.ts
+++ b/packages/kbn-docs-utils/src/build_api_declarations/build_multiple_call_signatures_dec.ts
@@ -8,11 +8,12 @@
  */
 
 import type { Node, Signature } from 'ts-morph';
+import { Node as MorphNode } from 'ts-morph';
 import type { ApiDeclaration } from '../types';
 import { TypeKind } from '../types';
 import { buildApiDeclaration } from './build_api_declaration';
 import { buildBasicApiDeclaration } from './build_basic_api_declaration';
-import { getJSDocParamComment, getJSDocReturnTagComment } from './js_doc_utils';
+import { getJSDocParamComment, getJSDocReturnTagComment, type PluginContext } from './js_doc_utils';
 import type { BuildApiDecOpts } from './types';
 import { buildApiId, getOptsForChildWithName } from './utils';
 
@@ -31,28 +32,32 @@ export const buildMultipleCallSignaturesDec = (
   signatures: Signature[],
   opts: BuildApiDecOpts
 ): ApiDeclaration => {
+  const pluginContext: PluginContext = {
+    pluginId: opts.currentPluginId,
+    scope: opts.scope,
+  };
+
   // Use the first signature to extract parameter children for documentation.
   // This is a reasonable default since overloads typically share common parameters.
   const primarySignature = signatures[0];
 
   const children = primarySignature.getParameters().reduce((kids, p, index) => {
     const declarations = p.getDeclarations();
-    if (declarations.length === 1) {
+    if (declarations.length >= 1) {
+      const decl = declarations[0];
+
+      // TypeScript uses synthetic names like `__0` for destructured parameters.
+      // Prefer the written name from the ParameterDeclaration when available.
+      const symbolName = p.getName();
+      const writtenName = MorphNode.isParameterDeclaration(decl) ? decl.getName() : symbolName;
+      const lookupNames = writtenName !== symbolName ? [writtenName, symbolName] : [symbolName];
+
       kids.push({
-        ...buildApiDeclaration(declarations[0], {
-          ...getOptsForChildWithName(p.getName(), opts),
+        ...buildApiDeclaration(decl, {
+          ...getOptsForChildWithName(writtenName, opts),
           id: buildApiId(`$${index + 1}`, opts.id),
         }),
-        description: getJSDocParamComment(node, p.getName()),
-      });
-    } else if (declarations.length > 1) {
-      // Use the first declaration when multiple exist (common with overloads).
-      kids.push({
-        ...buildApiDeclaration(declarations[0], {
-          ...getOptsForChildWithName(p.getName(), opts),
-          id: buildApiId(`$${index + 1}`, opts.id),
-        }),
-        description: getJSDocParamComment(node, p.getName()),
+        description: getJSDocParamComment(node, lookupNames, pluginContext),
       });
     }
     return kids;
@@ -61,7 +66,7 @@ export const buildMultipleCallSignaturesDec = (
   return {
     ...buildBasicApiDeclaration(node, opts),
     type: TypeKind.FunctionKind,
-    returnComment: getJSDocReturnTagComment(node),
+    returnComment: getJSDocReturnTagComment(node, pluginContext),
     children,
   };
 };

--- a/packages/kbn-docs-utils/src/build_api_declarations/js_doc_utils.test.ts
+++ b/packages/kbn-docs-utils/src/build_api_declarations/js_doc_utils.test.ts
@@ -9,7 +9,7 @@
 
 import Path from 'path';
 import type { Node } from 'ts-morph';
-import { Project } from 'ts-morph';
+import { Project, SyntaxKind } from 'ts-morph';
 import {
   getJSDocParamComment,
   getJSDocReturnTagComment,
@@ -321,6 +321,67 @@ describe('getJSDocs', () => {
     const jsDocs = getJSDocs(varDecl!);
     expect(jsDocs).toBeDefined();
     expect(jsDocs!.length).toBeGreaterThan(0);
+  });
+
+  it('returns parent JSDoc for PropertyAssignment without its own comment', () => {
+    const testProject = new Project({ useInMemoryFileSystem: true });
+    const testSourceFile = testProject.createSourceFile(
+      'test.ts',
+      `
+      /**
+       * Parent description.
+       * @param scope - A scope string.
+       * @returns The key tuple.
+       */
+      export const keys = {
+        all: (scope: string) => ['list', scope] as const,
+      };
+      `
+    );
+
+    const varDecl = testSourceFile.getVariableDeclaration('keys');
+    expect(varDecl).toBeDefined();
+    const prop = varDecl!
+      .getInitializerIfKindOrThrow(SyntaxKind.ObjectLiteralExpression)
+      .getProperty('all')!;
+
+    const jsDocs = getJSDocs(prop);
+    expect(jsDocs).toBeDefined();
+    expect(jsDocs!.length).toBeGreaterThan(0);
+    expect(jsDocs![0].getDescription()).toContain('Parent description');
+  });
+
+  it('does not return parent JSDoc for PropertyAssignment with its own leading comment', () => {
+    const testProject = new Project({ useInMemoryFileSystem: true });
+    const testSourceFile = testProject.createSourceFile(
+      'test.ts',
+      `
+      /**
+       * Parent description.
+       */
+      export const obj = {
+        /** My own description. */
+        myProp: 'hi',
+      };
+      `
+    );
+
+    const varDecl = testSourceFile.getVariableDeclaration('obj');
+    expect(varDecl).toBeDefined();
+    const prop = varDecl!
+      .getInitializerIfKindOrThrow(SyntaxKind.ObjectLiteralExpression)
+      .getProperty('myProp')!;
+
+    // getJSDocs should return undefined so getCommentsFromNode falls through
+    // to leading comments, preserving the property's own description.
+    const jsDocs = getJSDocs(prop);
+    expect(jsDocs === undefined || jsDocs.length === 0).toBe(true);
+
+    // getCommentsFromNode should pick up the property's own leading comment.
+    const comments = getCommentsFromNode(prop);
+    expect(comments).toBeDefined();
+    expect(comments!.length).toBeGreaterThan(0);
+    expect(comments![0]).toContain('My own description');
   });
 });
 

--- a/packages/kbn-docs-utils/src/build_api_declarations/js_doc_utils.ts
+++ b/packages/kbn-docs-utils/src/build_api_declarations/js_doc_utils.ts
@@ -10,16 +10,29 @@
 import type { JSDoc, JSDocTag } from 'ts-morph';
 import { Node } from 'ts-morph';
 import type { TextWithLinks } from '../types';
+import type { ApiScope } from '../types';
+import { getPluginApiDocId, getApiSectionId } from '../utils';
+
+/**
+ * Plugin context needed to resolve {@link} tags into cross-reference links.
+ */
+export interface PluginContext {
+  pluginId: string;
+  scope: ApiScope;
+}
 
 /**
  * Extracts comments from a node to use as the description.
  * Prefers JSDoc descriptions over leading comments.
  */
-export const getCommentsFromNode = (node: Node): TextWithLinks | undefined => {
+export const getCommentsFromNode = (
+  node: Node,
+  pluginContext?: PluginContext
+): TextWithLinks | undefined => {
   const jsDocs = getJSDocs(node);
   if (jsDocs) {
     const description = jsDocs.map((jsDoc) => jsDoc.getDescription()).join('\n');
-    return getTextWithLinks(description);
+    return getTextWithLinks(description, pluginContext);
   }
 
   const leadingComments = node
@@ -27,7 +40,7 @@ export const getCommentsFromNode = (node: Node): TextWithLinks | undefined => {
     .map((c) => c.getText())
     .join('\n');
 
-  return getTextWithLinks(leadingComments);
+  return getTextWithLinks(leadingComments, pluginContext);
 };
 
 /**
@@ -36,7 +49,29 @@ export const getCommentsFromNode = (node: Node): TextWithLinks | undefined => {
  */
 export const getJSDocs = (node: Node): JSDoc[] | undefined => {
   if (Node.isJSDocable(node)) {
-    return node.getJsDocs();
+    const own = node.getJsDocs();
+    if (own.length > 0) {
+      return own;
+    }
+    // Return the empty array for JSDocable nodes without JSDoc so that
+    // getCommentsFromNode does not fall through to leading-comment ranges
+    // (which would pick up stray // comments as descriptions).
+    return own;
+  }
+
+  // PropertyAssignment nodes inside object literals are not JSDocable in
+  // current ts-morph versions, so their `/** ... */` comments appear only as
+  // leading comment ranges. Walk up to the enclosing VariableStatement's JSDoc
+  // only when the property has no leading comments of its own — otherwise
+  // getCommentsFromNode's leading-comment fallback should handle them.
+  if (Node.isPropertyAssignment(node) && node.getLeadingCommentRanges().length === 0) {
+    const varDec = node.getParent()?.getParent();
+    if (Node.isVariableDeclaration(varDec)) {
+      const varStmt = varDec.getParent()?.getParent();
+      if (Node.isJSDocable(varStmt)) {
+        return varStmt.getJsDocs();
+      }
+    }
   }
 
   if (Node.isVariableDeclaration(node)) {
@@ -53,10 +88,13 @@ export const getJSDocs = (node: Node): JSDoc[] | undefined => {
 /**
  * Extracts the @returns comment from a node or JSDoc array.
  */
-export const getJSDocReturnTagComment = (node: Node | JSDoc[]): TextWithLinks => {
+export const getJSDocReturnTagComment = (
+  node: Node | JSDoc[],
+  pluginContext?: PluginContext
+): TextWithLinks => {
   const tags = getJSDocTags(node);
   const returnTag = tags.find((tag) => Node.isJSDocReturnTag(tag));
-  return returnTag ? getTextWithLinks(returnTag.getCommentText()) : [];
+  return returnTag ? getTextWithLinks(returnTag.getCommentText(), pluginContext) : [];
 };
 
 /**
@@ -78,7 +116,11 @@ const matchesParamName = (tagName: string, normalizedNames: string[]): boolean =
  * Parses raw JSDoc text to find @param entries that ts-morph might not normalize.
  * Returns the comment text if a matching parameter is found.
  */
-const parseParamFromRawText = (text: string, normalizedNames: string[]): TextWithLinks | null => {
+const parseParamFromRawText = (
+  text: string,
+  normalizedNames: string[],
+  pluginContext?: PluginContext
+): TextWithLinks | null => {
   const lines = text.split(/\r?\n/);
 
   for (const line of lines) {
@@ -108,7 +150,7 @@ const parseParamFromRawText = (text: string, normalizedNames: string[]): TextWit
     const commentText = parts.slice(nameIndex + 1).join(' ');
 
     if (matchesParamName(nameToken, normalizedNames)) {
-      return getTextWithLinks(commentText.trim());
+      return getTextWithLinks(commentText.trim(), pluginContext);
     }
   }
 
@@ -121,7 +163,8 @@ const parseParamFromRawText = (text: string, normalizedNames: string[]): TextWit
  */
 export const getJSDocParamComment = (
   node: Node | JSDoc[],
-  name: string | string[]
+  name: string | string[],
+  pluginContext?: PluginContext
 ): TextWithLinks => {
   const names = Array.isArray(name) ? name : [name];
   const normalizedNames = names.map(normalizeParamName);
@@ -137,14 +180,14 @@ export const getJSDocParamComment = (
   });
 
   if (paramTag) {
-    return getTextWithLinks(paramTag.getCommentText());
+    return getTextWithLinks(paramTag.getCommentText(), pluginContext);
   }
 
   // Fallback: parse raw JSDoc text for @param entries that ts-morph might not normalize
   const jsDocs = node instanceof Array ? node : getJSDocs(node);
   if (jsDocs) {
     for (const jsDoc of jsDocs) {
-      const parsed = parseParamFromRawText(jsDoc.getText(), normalizedNames);
+      const parsed = parseParamFromRawText(jsDoc.getText(), normalizedNames, pluginContext);
       if (parsed) {
         return parsed;
       }
@@ -156,7 +199,7 @@ export const getJSDocParamComment = (
     const leadingCommentRanges = node.getLeadingCommentRanges();
     if (leadingCommentRanges.length > 0) {
       const leadingText = leadingCommentRanges.map((c) => c.getText()).join('\n');
-      const parsed = parseParamFromRawText(leadingText, normalizedNames);
+      const parsed = parseParamFromRawText(leadingText, normalizedNames, pluginContext);
       if (parsed) {
         return parsed;
       }
@@ -179,11 +222,60 @@ export const getJSDocTags = (node: Node | JSDoc[]): JSDocTag[] => {
 };
 
 /**
- * Converts text to TextWithLinks format.
- * TODO: This feature is not fully implemented yet. It will be used to create links for comments
- * that use {@link AnotherAPIItemInThisPlugin}.
+ * Converts text to TextWithLinks format, resolving `{@link Identifier}` tags into
+ * cross-reference links when plugin context is available.
+ *
+ * Supports two syntaxes:
+ * - `{@link Identifier}` — links to the identifier and displays its name.
+ * - `{@link Identifier | display text}` — links to the identifier with custom display text.
  */
-const getTextWithLinks = (text?: string): TextWithLinks => {
-  return text ? [text] : [];
-  // TODO: Replace `@links` in comments with relative api links.
+const getTextWithLinks = (text?: string, pluginContext?: PluginContext): TextWithLinks => {
+  if (!text) {
+    return [];
+  }
+
+  const linkPattern = /\{@link\s+([^|}]+?)(?:\s*\|\s*([^}]+?))?\}/g;
+  let match = linkPattern.exec(text);
+
+  // Fast path: no {@link} tags found, return as-is.
+  if (!match) {
+    return [text];
+  }
+
+  const parts: TextWithLinks = [];
+  let lastIndex = 0;
+
+  do {
+    // Add text before the link.
+    if (match.index > lastIndex) {
+      parts.push(text.slice(lastIndex, match.index));
+    }
+
+    const identifier = match[1].trim();
+    const displayText = match[2]?.trim() || identifier;
+
+    if (pluginContext) {
+      // Create a cross-reference link to the identifier within the current plugin.
+      parts.push({
+        pluginId: pluginContext.pluginId,
+        scope: pluginContext.scope,
+        docId: getPluginApiDocId(pluginContext.pluginId),
+        section: getApiSectionId({ id: identifier, scope: pluginContext.scope }),
+        text: displayText,
+      });
+    } else {
+      // Without plugin context, emit the display text as plain text.
+      parts.push(displayText);
+    }
+
+    lastIndex = match.index + match[0].length;
+    match = linkPattern.exec(text);
+  } while (match);
+
+  // Add remaining text after the last link.
+  if (lastIndex < text.length) {
+    parts.push(text.slice(lastIndex));
+  }
+
+  return parts;
 };

--- a/packages/kbn-docs-utils/src/integration_tests/__fixtures__/src/plugin_a/public/types.ts
+++ b/packages/kbn-docs-utils/src/integration_tests/__fixtures__/src/plugin_a/public/types.ts
@@ -106,13 +106,11 @@ export const overloadedFn: OverloadedFunction = ((input: string | number | strin
 }) as OverloadedFunction;
 
 // Expected issues:
-//   missing comments (15):
+//   missing comments (13):
 //     line 19 - TypeWithGeneric
 //     line 21 - ImAType
 //     line 28 - t
 //     line 28 - t
-//     line 36 - p
-//     line 36 - p
 //     line 36 - t
 //     line 52 - IRefANotExportedType
 //     line 53 - ImAnObject
@@ -122,8 +120,7 @@ export const overloadedFn: OverloadedFunction = ((input: string | number | strin
 //     line 62 - bar
 //     line 65 - AReactElementFn
 //     line 80 - input
-//   param doc mismatches (4):
-//     line 30 - FnTypeWithGeneric
+//   param doc mismatches (3):
 //     line 54 - foo
 //     line 62 - bar
 //     line 98 - overloadedFn

--- a/packages/kbn-docs-utils/src/integration_tests/snapshots/plugin_a.devdocs.json
+++ b/packages/kbn-docs-utils/src/integration_tests/snapshots/plugin_a.devdocs.json
@@ -2731,7 +2731,15 @@
           "tags": [],
           "label": "getSearchService2",
           "description": [
-            "\nThis uses an inlined object type rather than referencing an exported type, which is discouraged.\nprefer the way {@link getSearchService} is typed.\n"
+            "\nThis uses an inlined object type rather than referencing an exported type, which is discouraged.\nprefer the way ",
+            {
+              "pluginId": "pluginA",
+              "scope": "public",
+              "docId": "kibPluginAPluginApi",
+              "section": "def-public.getSearchService",
+              "text": "getSearchService"
+            },
+            " is typed.\n"
           ],
           "signature": [
             "(searchSpec: { username: string; password: string; }) => string"
@@ -3019,7 +3027,14 @@
           "trackAdoption": false,
           "children": [],
           "returnComment": [
-            "The currently selected {@link SearchLanguage }"
+            "The currently selected ",
+            {
+              "pluginId": "pluginA",
+              "scope": "public",
+              "docId": "kibPluginAPluginApi",
+              "section": "def-public.SearchLanguage",
+              "text": "SearchLanguage"
+            }
           ]
         }
       ],

--- a/packages/kbn-docs-utils/src/integration_tests/snapshots/plugin_a.mdx
+++ b/packages/kbn-docs-utils/src/integration_tests/snapshots/plugin_a.mdx
@@ -8,7 +8,7 @@ slug: /kibana-dev-docs/api/pluginA
 title: "pluginA"
 image: https://source.unsplash.com/400x175/?github
 description: API docs for the pluginA plugin
-date: 2026-02-23
+date: 2026-04-10
 tags: ['contributor', 'dev', 'apidocs', 'kibana', 'pluginA']
 ---
 import pluginAObj from './plugin_a.devdocs.json';
@@ -21,7 +21,7 @@ Contact Kibana Core for questions regarding this plugin.
 
 | Public API count  | Any count | Items lacking comments | Missing exports |
 |-------------------|-----------|------------------------|-----------------|
-| 145 | 1 | 65 | 2 |
+| 145 | 1 | 63 | 2 |
 
 ## Client
 

--- a/packages/kbn-docs-utils/src/integration_tests/snapshots/plugin_a.stats.json
+++ b/packages/kbn-docs-utils/src/integration_tests/snapshots/plugin_a.stats.json
@@ -2,8 +2,8 @@
   "counts": {
     "apiCount": 145,
     "missingExports": 2,
-    "missingComments": 65,
-    "paramDocMismatches": 14,
+    "missingComments": 63,
+    "paramDocMismatches": 13,
     "missingComplexTypeInfo": 15,
     "missingReturns": 24,
     "isAnyType": 1,
@@ -292,14 +292,6 @@
       "columnNumber": 37
     },
     {
-      "id": "def-public.ExampleInterface.fnTypeWithGeneric.$2",
-      "label": "p",
-      "path": "packages/kbn-docs-utils/src/integration_tests/__fixtures__/src/plugin_a/public/types.ts",
-      "type": "Object",
-      "lineNumber": 36,
-      "columnNumber": 43
-    },
-    {
       "id": "def-public.IReturnAReactComponent.component",
       "label": "component",
       "path": "packages/kbn-docs-utils/src/integration_tests/__fixtures__/src/plugin_a/public/classes.ts",
@@ -418,14 +410,6 @@
       "type": "Type",
       "lineNumber": 21,
       "columnNumber": 1
-    },
-    {
-      "id": "def-public.FnTypeWithGeneric.$2",
-      "label": "p",
-      "path": "packages/kbn-docs-utils/src/integration_tests/__fixtures__/src/plugin_a/public/types.ts",
-      "type": "Object",
-      "lineNumber": 36,
-      "columnNumber": 43
     },
     {
       "id": "def-public.IRefANotExportedType",
@@ -612,14 +596,6 @@
       "type": "Function",
       "lineNumber": 29,
       "columnNumber": 3
-    },
-    {
-      "id": "def-public.FnTypeWithGeneric",
-      "label": "FnTypeWithGeneric",
-      "path": "packages/kbn-docs-utils/src/integration_tests/__fixtures__/src/plugin_a/public/types.ts",
-      "type": "Type",
-      "lineNumber": 30,
-      "columnNumber": 1
     },
     {
       "id": "def-public.ImAnObject.foo",

--- a/packages/kbn-docs-utils/src/integration_tests/snapshots/plugin_a_foo.mdx
+++ b/packages/kbn-docs-utils/src/integration_tests/snapshots/plugin_a_foo.mdx
@@ -8,7 +8,7 @@ slug: /kibana-dev-docs/api/pluginA-foo
 title: "pluginA.foo"
 image: https://source.unsplash.com/400x175/?github
 description: API docs for the pluginA.foo plugin
-date: 2026-02-23
+date: 2026-04-10
 tags: ['contributor', 'dev', 'apidocs', 'kibana', 'pluginA.foo']
 ---
 import pluginAFooObj from './plugin_a_foo.devdocs.json';
@@ -21,7 +21,7 @@ Contact Kibana Core for questions regarding this plugin.
 
 | Public API count  | Any count | Items lacking comments | Missing exports |
 |-------------------|-----------|------------------------|-----------------|
-| 145 | 1 | 65 | 2 |
+| 145 | 1 | 63 | 2 |
 
 ## Client
 

--- a/packages/kbn-docs-utils/src/integration_tests/snapshots/plugin_b.mdx
+++ b/packages/kbn-docs-utils/src/integration_tests/snapshots/plugin_b.mdx
@@ -8,7 +8,7 @@ slug: /kibana-dev-docs/api/pluginB
 title: "pluginB"
 image: https://source.unsplash.com/400x175/?github
 description: API docs for the pluginB plugin
-date: 2026-02-23
+date: 2026-04-10
 tags: ['contributor', 'dev', 'apidocs', 'kibana', 'pluginB']
 ---
 import pluginBObj from './plugin_b.devdocs.json';
@@ -21,7 +21,7 @@ Contact Kibana Core for questions regarding this plugin.
 
 | Public API count  | Any count | Items lacking comments | Missing exports |
 |-------------------|-----------|------------------------|-----------------|
-| 2 | 0 | 2 | 0 |
+| 2 | 0 | 1 | 0 |
 
 ## Client
 

--- a/packages/kbn-docs-utils/src/stats.test.ts
+++ b/packages/kbn-docs-utils/src/stats.test.ts
@@ -932,6 +932,217 @@ describe('collectApiStatsForPlugin', () => {
     });
   });
 
+  describe('typed parameter relaxation', () => {
+    it('does not flag paramDocMismatches when destructured param has a named interface type', () => {
+      const pluginApi = createMockPluginApi({
+        client: [
+          createMockApiDeclaration({
+            id: 'fn-with-interface-param',
+            label: 'ContentListToolbar',
+            type: TypeKind.FunctionKind,
+            description: ['Toolbar component for content list pages.'],
+            children: [
+              createMockApiDeclaration({
+                id: 'fn-with-interface-param.$1',
+                label: 'props',
+                type: TypeKind.InterfaceKind,
+                // No description — the docs live on the ContentListToolbarProps interface.
+                description: undefined,
+                children: [
+                  createMockApiDeclaration({
+                    id: 'fn-with-interface-param.$1.title',
+                    label: 'title',
+                    type: TypeKind.StringKind,
+                    description: undefined,
+                  }),
+                  createMockApiDeclaration({
+                    id: 'fn-with-interface-param.$1.children',
+                    label: 'children',
+                    type: TypeKind.Uncategorized,
+                    description: undefined,
+                  }),
+                ],
+              }),
+            ],
+          }),
+        ],
+      });
+
+      const stats = collectApiStatsForPlugin(pluginApi, createEmptyIssues());
+
+      expect(stats.paramDocMismatches).toHaveLength(0);
+    });
+
+    it('does not flag paramDocMismatches when param has ObjectKind type with a named reference', () => {
+      const pluginApi = createMockPluginApi({
+        client: [
+          createMockApiDeclaration({
+            id: 'fn-with-object-param',
+            label: 'myFunction',
+            type: TypeKind.FunctionKind,
+            description: ['A function.'],
+            children: [
+              createMockApiDeclaration({
+                id: 'fn-with-object-param.$1',
+                label: 'options',
+                type: TypeKind.ObjectKind,
+                description: undefined,
+                signature: [
+                  {
+                    pluginId: 'test-plugin',
+                    scope: 'public' as const,
+                    docId: 'kibTestPluginPluginApi',
+                    section: 'def-public.MyOptions',
+                    text: 'MyOptions',
+                  },
+                ],
+              }),
+            ],
+          }),
+        ],
+      });
+
+      const stats = collectApiStatsForPlugin(pluginApi, createEmptyIssues());
+
+      expect(stats.paramDocMismatches).toHaveLength(0);
+    });
+
+    it('flags paramDocMismatches when param has ObjectKind type with inline type literal', () => {
+      const pluginApi = createMockPluginApi({
+        client: [
+          createMockApiDeclaration({
+            id: 'fn-with-inline-object-param',
+            label: 'myFunction',
+            type: TypeKind.FunctionKind,
+            description: ['A function.'],
+            children: [
+              createMockApiDeclaration({
+                id: 'fn-with-inline-object-param.$1',
+                label: 'options',
+                type: TypeKind.ObjectKind,
+                description: undefined,
+                signature: ['{ foo: string; bar: number }'],
+              }),
+            ],
+          }),
+        ],
+      });
+
+      const stats = collectApiStatsForPlugin(pluginApi, createEmptyIssues());
+
+      expect(stats.paramDocMismatches).toHaveLength(1);
+    });
+
+    it('does not flag paramDocMismatches when param has TypeKind type', () => {
+      const pluginApi = createMockPluginApi({
+        client: [
+          createMockApiDeclaration({
+            id: 'fn-with-type-param',
+            label: 'myFunction',
+            type: TypeKind.FunctionKind,
+            description: ['A function.'],
+            children: [
+              createMockApiDeclaration({
+                id: 'fn-with-type-param.$1',
+                label: 'config',
+                type: TypeKind.TypeKind,
+                description: undefined,
+              }),
+            ],
+          }),
+        ],
+      });
+
+      const stats = collectApiStatsForPlugin(pluginApi, createEmptyIssues());
+
+      expect(stats.paramDocMismatches).toHaveLength(0);
+    });
+
+    it('still flags paramDocMismatches for primitive-typed params without docs', () => {
+      const pluginApi = createMockPluginApi({
+        client: [
+          createMockApiDeclaration({
+            id: 'fn-with-primitive-param',
+            label: 'myFunction',
+            type: TypeKind.FunctionKind,
+            description: ['A function.'],
+            children: [
+              createMockApiDeclaration({
+                id: 'fn-with-primitive-param.$1',
+                label: 'name',
+                type: TypeKind.StringKind,
+                description: undefined,
+              }),
+            ],
+          }),
+        ],
+      });
+
+      const stats = collectApiStatsForPlugin(pluginApi, createEmptyIssues());
+
+      expect(stats.paramDocMismatches).toHaveLength(1);
+    });
+
+    it('suppresses missingComments for typed parameter nodes and their children', () => {
+      const pluginApi = createMockPluginApi({
+        client: [
+          createMockApiDeclaration({
+            id: 'fn-component',
+            label: 'ContentListToolbar',
+            type: TypeKind.FunctionKind,
+            description: ['Toolbar component.'],
+            children: [
+              createMockApiDeclaration({
+                id: 'fn-component.$1',
+                label: 'props',
+                type: TypeKind.InterfaceKind,
+                description: undefined, // No description — docs are on the interface.
+                children: [
+                  createMockApiDeclaration({
+                    id: 'fn-component.$1.title',
+                    label: 'title',
+                    type: TypeKind.StringKind,
+                    description: undefined, // No description — docs are on the interface member.
+                  }),
+                  createMockApiDeclaration({
+                    id: 'fn-component.$1.children',
+                    label: 'children',
+                    type: TypeKind.Uncategorized,
+                    description: undefined,
+                  }),
+                ],
+              }),
+            ],
+          }),
+        ],
+      });
+
+      const stats = collectApiStatsForPlugin(pluginApi, createEmptyIssues());
+
+      // Neither the .$1 param node nor its children should be flagged — the docs
+      // live on the referenced interface, which is rendered in its own section.
+      expect(stats.missingComments).toHaveLength(0);
+    });
+
+    it('still flags missingComments for non-parameter nodes', () => {
+      const pluginApi = createMockPluginApi({
+        client: [
+          createMockApiDeclaration({
+            id: 'interface-undocumented',
+            label: 'SomeInterface',
+            type: TypeKind.InterfaceKind,
+            description: undefined,
+          }),
+        ],
+      });
+
+      const stats = collectApiStatsForPlugin(pluginApi, createEmptyIssues());
+
+      expect(stats.missingComments).toHaveLength(1);
+      expect(stats.missingComments[0].id).toBe('interface-undocumented');
+    });
+  });
+
   describe('combined scenarios', () => {
     it('handles complex plugin API with multiple issues', () => {
       const pluginApi = createMockPluginApi({

--- a/packages/kbn-docs-utils/src/stats.ts
+++ b/packages/kbn-docs-utils/src/stats.ts
@@ -68,14 +68,29 @@ function collectAdoptionTrackedAPIStats(
   ).length;
 }
 
-function collectStatsForApi(doc: ApiDeclaration, stats: ApiStats, pluginApi: PluginApi): void {
+function collectStatsForApi(
+  doc: ApiDeclaration,
+  stats: ApiStats,
+  pluginApi: PluginApi,
+  insideTypedParam = false
+): void {
   const hasDescription = doc.description !== undefined && doc.description.length > 0;
   const childHasDescription =
     doc.children?.some(
       (child) => child.description !== undefined && child.description.length > 0
     ) ?? false;
   const isParameterNode = doc.id.includes('.$'); // parameters and destructured parameter nodes carry .$ in their id
-  const missingComment = !hasDescription && !(isParameterNode && childHasDescription);
+
+  // A parameter node whose type is a named reference (interface/type alias).
+  // Its property-level documentation lives on the referenced type's own ApiDeclaration.
+  const isTypedParam = isParameterNode && isNamedTypeParam(doc);
+
+  // Suppress missingComments for parameter nodes when the parameter (or an ancestor
+  // parameter) has a named type reference — the documentation is on the interface.
+  const suppressForTypedParam = isTypedParam || (isParameterNode && insideTypedParam);
+
+  const missingComment =
+    !suppressForTypedParam && !hasDescription && !(isParameterNode && childHasDescription);
   // Ignore all stats coming from third party libraries, we can't fix that!
   if (doc.path.includes('node_modules')) {
     return;
@@ -94,7 +109,7 @@ function collectStatsForApi(doc: ApiDeclaration, stats: ApiStats, pluginApi: Plu
   }
   if (doc.children) {
     doc.children.forEach((child) => {
-      collectStatsForApi(child, stats, pluginApi);
+      collectStatsForApi(child, stats, pluginApi, isTypedParam || insideTypedParam);
     });
   }
   if (!doc.references || doc.references.length === 0) {
@@ -123,12 +138,39 @@ const isFunctionLike = (doc: ApiDeclaration): boolean => {
 };
 
 /**
+ * Returns true when a parameter's type is a named reference (interface, object, or type alias)
+ * whose documentation lives on the referenced type's own ApiDeclaration, so the checker
+ * should not require per-property descriptions on the function parameter itself.
+ *
+ * Inline type-literal parameters (e.g. `{ foo: string }`) also resolve to ObjectKind,
+ * so we additionally require the signature to contain at least one Reference link — that
+ * distinguishes a named type reference from an anonymous inline type.
+ */
+const isNamedTypeParam = (param: ApiDeclaration): boolean => {
+  if (param.type === TypeKind.InterfaceKind || param.type === TypeKind.TypeKind) {
+    return true;
+  }
+  if (param.type === TypeKind.ObjectKind) {
+    // Only treat as named if the signature contains a Reference (non-string element),
+    // indicating it points to an externally defined type rather than an inline literal.
+    return (
+      param.signature !== undefined && param.signature.some((part) => typeof part !== 'string')
+    );
+  }
+  return false;
+};
+
+/**
  * Tracks functions where not all parameters have documentation.
  *
  * For function-like declarations, `children` represents the function's parameters.
  * This is distinct from interface/class children which represent properties/methods.
  * Each function-like member within an interface has its own declaration with its own
  * children (parameters), so we don't conflate interface properties with function parameters.
+ *
+ * Parameters whose type is a named reference (interface or type alias) are treated as
+ * documented without requiring their own description — the documentation lives on the
+ * referenced type, which is rendered in its own section.
  */
 const trackParamDocMismatches = (doc: ApiDeclaration, stats: ApiStats): void => {
   if (!isFunctionLike(doc)) {
@@ -138,7 +180,7 @@ const trackParamDocMismatches = (doc: ApiDeclaration, stats: ApiStats): void => 
     return;
   }
   const describedParams = doc.children.filter(
-    (param) => param.description && param.description.length > 0
+    (param) => (param.description && param.description.length > 0) || isNamedTypeParam(param)
   ).length;
   if (describedParams !== doc.children.length) {
     stats.paramDocMismatches.push(doc);


### PR DESCRIPTION
## Summary

Fixes #262069
Superseded by #262651

> [!NOTE]
> This PR fixed the issue, but in further investigation, #262651 was more complete fix.
>
> We could still ship this PR as a targeted fix of the issue, but would run into significant merge conflicts.

Resolves two bugs in `@kbn/docs-utils` that produce false-positive `missingReturns`, `paramDocMismatches`, and `missingComments` violations for common TypeScript patterns, plus implements `{@link}` tag resolution in JSDoc comments.

- **Bug 1 — PropertyAssignment JSDoc lookup**: `getJSDocs` now walks up from `PropertyAssignment` nodes to the enclosing `VariableStatement` when the property has no leading comments of its own. Properties with inline `/** ... */` comments are left alone. Also preserves the original empty-array return for JSDocable nodes without JSDoc to prevent `//` line comments from leaking into descriptions.

- **Bug 2 — Synthetic parameter names**: `buildCallSignatureDec` and `buildMultipleCallSignaturesDec` now prefer the written parameter name from `ParameterDeclaration.getName()` over TypeScript's synthetic symbol name (e.g. `__0` for destructured params). Also narrows `isNamedTypeParam` in stats to require a `Reference` in the signature for `ObjectKind` params, distinguishing named type references from inline type-literal params.

- **`{@link}` resolution**: `getTextWithLinks` now resolves `{@link Identifier}` and `{@link Identifier | text}` tags into cross-reference `Reference` objects using `getPluginApiDocId` and `getApiSectionId`. `PluginContext` is threaded through all function builders so `@returns` comments and descriptions resolve links consistently.

## Test plan

- [x] `node scripts/jest packages/kbn-docs-utils/src/build_api_declarations/js_doc_utils.test.ts` — 30 tests pass (includes new PropertyAssignment tests)
- [x] `node scripts/jest packages/kbn-docs-utils/src/stats.test.ts` — 46 tests pass (includes new ObjectKind signature gate tests)
- [x] `node scripts/jest_integration packages/kbn-docs-utils/src/integration_tests/api_doc_suite.test.ts` — 61 tests pass, snapshots match
- [x] `node scripts/check_changes.ts` — all pre-commit checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)