### PR TITLE
[One Workflow](fix): Invalid Date tooltip on pending workflow executions

### DIFF
--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_list/ui/workflow_execution_list.test.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_list/ui/workflow_execution_list.test.tsx
@@ -16,16 +16,19 @@ import { TestWrapper } from '../../../shared/test_utils';
 jest.mock('./workflow_execution_list_item', () => ({
   WorkflowExecutionListItem: ({
     status,
+    startedAt,
     onClick,
     selected,
   }: {
     status: string;
+    startedAt: Date | null;
     onClick: () => void;
     selected: boolean;
   }) => (
     <div
       data-test-subj="workflowExecutionListItem"
       data-selected={selected}
+      data-started-at={startedAt ? startedAt.toISOString() : 'null'}
       onClick={onClick}
       role="button"
       onKeyDown={() => {}}
@@ -205,6 +208,39 @@ describe('WorkflowExecutionList', () => {
       const setPaginationObserver = jest.fn();
       renderComponent({ setPaginationObserver });
       expect(setPaginationObserver).toHaveBeenCalled();
+    });
+  });
+
+  describe('startedAt date handling', () => {
+    it('passes a valid Date when startedAt is a valid ISO string', () => {
+      renderComponent();
+      const items = screen.getAllByTestId('workflowExecutionListItem');
+      expect(items[0]).toHaveAttribute('data-started-at', '2024-01-01T10:00:00.000Z');
+    });
+
+    it('passes null when startedAt is an empty string', () => {
+      const withEmptyStartedAt: WorkflowExecutionListDto = {
+        results: [
+          {
+            id: 'exec-empty',
+            spaceId: 'default',
+            status: ExecutionStatus.PENDING,
+            isTestRun: false,
+            startedAt: '',
+            finishedAt: '',
+            error: null,
+            duration: null,
+            workflowId: 'wf-1',
+            workflowName: 'Test Workflow',
+          },
+        ],
+        page: 1,
+        size: 100,
+        total: 1,
+      };
+      renderComponent({ executions: withEmptyStartedAt });
+      const items = screen.getAllByTestId('workflowExecutionListItem');
+      expect(items[0]).toHaveAttribute('data-started-at', 'null');
     });
   });
 

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_list/ui/workflow_execution_list.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_list/ui/workflow_execution_list.tsx
@@ -153,7 +153,7 @@ export const WorkflowExecutionList = ({
                 <WorkflowExecutionListItem
                   status={execution.status}
                   isTestRun={execution.isTestRun}
-                  startedAt={new Date(execution.startedAt)}
+                  startedAt={toValidDate(execution.startedAt)}
                   duration={execution.duration}
                   executedBy={execution.executedBy}
                   triggeredBy={execution.triggeredBy}
@@ -246,4 +246,9 @@ const componentStyles = {
     height: '100%',
     overflowY: 'auto',
   }),
+};
+
+const toValidDate = (value: string): Date | null => {
+  const date = new Date(value);
+  return isNaN(date.getTime()) ? null : date;
 };


### PR DESCRIPTION
## Summary

Fixes the "Invalid Date" tooltip shown when hovering over the date on pending workflow executions.

**Root cause:** Pending executions are created in Elasticsearch without a `startedAt` field, which is returned as an empty string. The execution list component passed this to `new Date("")`, which produces an Invalid Date object. Since Invalid Date is truthy, it passed the `startedAt ?` guard and was rendered — `FormattedRelativeEnhanced` has its own fallback to `new Date()` so the text showed "just now", but the tooltip independently called `useGetFormattedDateTime` on the Invalid Date, resulting in "Invalid Date".

**Fix:** Added a `toValidDate` helper that checks `isNaN(date.getTime())` before returning the parsed Date, returning `null` for invalid/empty values. When `startedAt` is `null`, the existing guard correctly renders "Not started" instead.

### Before
<img width="362" height="162" alt="image" src="https://github.com/user-attachments/assets/7e40c195-c2d1-434d-9e09-c98835e39f4b" />

### After
<img width="480" height="212" alt="image" src="https://github.com/user-attachments/assets/a6c8da98-50b8-49be-a6e7-c7f4d24ab7b5" />


<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->