### PR TITLE
[Securoty Solution] prevent flyout scroll jump when hover actions focus panel

### DIFF
--- a/src/platform/packages/shared/kbn-cell-actions/src/components/hover_actions_popover.tsx
+++ b/src/platform/packages/shared/kbn-cell-actions/src/components/hover_actions_popover.tsx
@@ -137,6 +137,9 @@ export const HoverActionsPopover: React.FC<Props> = ({
           hasArrow={false}
           isOpen={showHoverContent}
           offset={0}
+          // Avoid scrolling scrollable ancestors (e.g. flyout body) when focus moves into the panel;
+          // react-focus-on maps this to focusOptions: { preventScroll: true } on react-focus-lock.
+          focusTrapProps={{ preventScrollOnFocus: true }}
           panelPaddingSize="none"
           repositionOnScroll
           panelProps={{ 'data-test-subj': 'hoverActionsPopover' }}


### PR DESCRIPTION
## Summary

**Problem:** In **Mozilla Firefox**, scrolling the **Table** tab of the **alert / document details flyout** (the field/value list) could **jump to the bottom** after **hovering a row** so the **cell action** strip appears. The bad scroll often showed up on the **next** scroll gesture, making long field lists hard to use.

**Cause:** `EuiPopover` uses a focus trap by default. When the hover menu opens, focus moves into the action panel. The browser then **scrolls scrollable ancestors** (notably the flyout body) to keep the focused node in view—here that effectively **yanks** the flyout scroll position (often to the end of the scrollable area).

**Change:** Set `focusTrapProps={{ preventScrollOnFocus: true }}` on the `EuiPopover` in `HoverActionsPopover` (`@kbn/cell-actions`). That flows through `react-focus-on` / `react-focus-lock` as `focus({ preventScroll: true })` when focus enters the panel, so **ancestor scroll position is preserved** while keeping normal focus behavior for the actions.

**Scope:** Affects any UI that uses **hover** cell actions (`CellActionsMode.HOVER_DOWN` / `HOVER_RIGHT`), including the Security alert flyout **Table** view.

**Before**

https://github.com/user-attachments/assets/dbc91261-b178-4296-9116-3eca77dc6970

**After**

https://github.com/user-attachments/assets/e8869d17-4071-4893-9b3b-6fb6d888a772

---

## Release note (for the label / changelog)

> **Security — Alerts:** Fixed Firefox scroll position jumping to the bottom of the document details flyout **Table** tab after hovering field rows with cell actions.

---

## Risk

**Overall severity: low.** There are no HTTP, persistence, or security-control changes; this is a client-side focus/scroll interaction fix in `@kbn/cell-actions`.

| Area | Risk | Severity | Mitigation |
|------|------|-----------|------------|
| **Scroll / layout** | Suppressing scroll-on-focus fixes the flyout jump but means the browser **no longer auto-scrolls ancestors** to reveal the focused node when focus enters the panel. In edge cases (e.g. panel partly off-screen), the focused control might not be scrolled into view automatically. | Low | Hover popovers are anchored to the cell and `repositionOnScroll` updates position; primary bug was ancestor scroll (flyout body), not missing panel visibility. Smoke-test Firefox + Chromium on the alert flyout **Table** tab. |
| **Blast radius** | Every consumer of `CellActionsMode.HOVER_DOWN` / `HOVER_RIGHT` inherits the change (Security flyout, other tables using hover cell actions). | Low | Same behavior is desirable anywhere a scroll container wraps the grid/flyout; unintended regressions are unlikely. |
| **Accessibility** | Focus still moves into the action strip via the existing focus trap; only **`focus({ preventScroll: true })`** is added. Screen reader and keyboard users are not losing the trap or labels. | Low | Optional: tab through actions after hover-open in Firefox to confirm nothing regressed. |
| **Browser variance** | Issue was most visible in **Firefox**; other browsers may already have been less aggressive about scrolling ancestors. | Low | Treat Firefox as the validation target; spot-check Chrome or Edge. |
| **Performance** | Extra prop only; no new listeners or renders. | Negligible | None. |

See [RISK_MATRIX.mdx](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) for how Elastic frames severity in larger PRs; this change does not warrant escalation beyond routine review.

---

## Checklist — what to tick (this PR)

| Item | Tick? | Notes |
|------|--------|--------|
| EUI writing + i18n | **Yes** | No new user-visible strings; only a `focusTrapProps` prop and an English **code comment** (not product copy). |
| Documentation | **Yes** | Bugfix / UX correction; no new feature or workflow that needs dev docs. |
| Unit or functional tests | **Optional / your call** | **Not updated in branch.** Existing `hover_actions_popover.test.tsx` still covers hover behavior. You can **leave unchecked** and note “no test change; optional follow-up to assert `focusTrapProps.preventScrollOnFocus`”, or add a small test and then **check**. |
| Cloud / docker allowlist | **Yes** | No `kibana.yml` or plugin config keys changed. |
| Breaking HTTP API | **Yes** | No public HTTP or plugin contract changes. |
| Flaky Test Runner | **Yes** | No test files modified; FTR not applicable. |
| Release notes + `release_note:*` label | **You + reviewer** | Include the **Release note** line in the GitHub PR body; apply **`release_note:fix`** (or whatever your team uses for bugfixes)—confirm against [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process). |
| Backport labels | **Reviewer / RM** | Don’t guess—Security / SDH usually decides `backport:skip` vs target minors. Ask on PR if unsure. |
| Risks (RISK_MATRIX) | **Yes** | Low risk; see **Risk** section above. |

---

## Kibana PR checklist (paste into GitHub — suggested boxes)

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md) — **N/A: no new product copy**
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials — **N/A: bugfix**
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios — **optional:** add assertion for `preventScrollOnFocus`, or leave unchecked and note in PR
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker) — **N/A**
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations. — **N/A: no breaking changes**
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed — **N/A: no tests changed**
- [ ] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process) — **complete when you paste release note + label on open PR**
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels. — **reviewer**

- [x] Risks identified and assessed — see **Risk** section above (also [RISK_MATRIX](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) for context).