### PR TITLE
[Automatic Import] Disable Install if Package of Same Version is Installed

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/components/manage_integration_actions.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/components/manage_integration_actions.tsx
@@ -35,6 +35,7 @@ export type { ReviewIntegrationDetails } from './review_approve_modal';
 export const ManageIntegrationActions: React.FC<{
   integration: CreatedIntegrationRow;
   isPackageReady: boolean;
+  installedVersion?: string;
   inlineActionType?: 'reviewApprove' | 'editIntegration';
   showMenuButton?: boolean;
   onEdit: (integrationId: string) => void;
@@ -51,6 +52,7 @@ export const ManageIntegrationActions: React.FC<{
 }> = ({
   integration,
   isPackageReady,
+  installedVersion,
   inlineActionType,
   showMenuButton = true,
   onEdit,
@@ -124,6 +126,23 @@ export const ManageIntegrationActions: React.FC<{
   const closeReviewModal = useCallback(() => {
     setShowReviewModal(false);
   }, []);
+
+  const isSameVersionInstalled =
+    installedVersion !== undefined && installedVersion === integration.version;
+
+  const getInstallToClusterTooltip = () => {
+    if (isSameVersionInstalled) {
+      return i18n.translate(
+        'xpack.fleet.epmList.manageIntegrations.actions.installAlreadyInstalledHelp',
+        { defaultMessage: 'This integration is already installed.' }
+      );
+    }
+    if (!isApproved) {
+      return i18n.translate('xpack.fleet.epmList.manageIntegrations.actions.installDisabledHelp', {
+        defaultMessage: 'Install is available only for approved integrations.',
+      });
+    }
+  };
 
   const reviewApproveDisabled = !isPackageReady || isApproved;
   const reviewApproveTooltip = isApproved
@@ -218,18 +237,9 @@ export const ManageIntegrationActions: React.FC<{
               <EuiContextMenuItem
                 key="installToCluster"
                 icon="exportAction"
-                disabled={!isApproved || isInstalling}
+                disabled={!isApproved || isInstalling || isSameVersionInstalled}
                 data-test-subj="manageIntegrationInstallMenuItem"
-                toolTipContent={
-                  isApproved
-                    ? undefined
-                    : i18n.translate(
-                        'xpack.fleet.epmList.manageIntegrations.actions.installDisabledHelp',
-                        {
-                          defaultMessage: 'Install is available only for approved integrations.',
-                        }
-                      )
-                }
+                toolTipContent={getInstallToClusterTooltip()}
                 onClick={handleInstallToCluster}
               >
                 <FormattedMessage

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/components/manage_integrations_table.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/components/manage_integrations_table.tsx
@@ -33,12 +33,13 @@ import type {
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { useQuery } from '@kbn/react-query';
+import { useQuery, useQueryClient } from '@kbn/react-query';
 import type { UserProfileWithAvatar } from '@kbn/user-profile-components';
 import { UserAvatar } from '@kbn/user-profile-components';
 
 import { PackageIcon } from '../../../../../../../components/package_icon';
 
+import { useGetPackagesQuery } from '../../../../../../../hooks/use_request/epm';
 import { useStartServices } from '../../../../../hooks';
 
 import { ManageIntegrationActions } from './manage_integration_actions';
@@ -105,6 +106,18 @@ export const ManageIntegrationsTable: React.FC<{
   const [selectedItems, setSelectedItems] = useState<CreatedIntegrationRow[]>([]);
   const [isBulkDeleting, setIsBulkDeleting] = useState(false);
   const [isBulkInstalling, setIsBulkInstalling] = useState(false);
+
+  const queryClient = useQueryClient();
+  const { data: packagesData } = useGetPackagesQuery({});
+  const installedPackageVersions = useMemo(
+    () =>
+      new Map(
+        (packagesData?.items ?? [])
+          .filter((item) => item.status === 'installed')
+          .map((item) => [item.name, item.version])
+      ),
+    [packagesData]
+  );
   const { euiTheme } = useEuiTheme();
   const {
     application,
@@ -358,6 +371,7 @@ export const ManageIntegrationsTable: React.FC<{
           body: zipBlob as unknown as BodyInit,
         });
 
+        await queryClient.invalidateQueries({ queryKey: ['get-packages'] });
         notifications.toasts.addSuccess({
           title: i18n.translate(
             'xpack.fleet.epmList.manageIntegrations.actions.installSuccessTitle',
@@ -373,7 +387,7 @@ export const ManageIntegrationsTable: React.FC<{
         });
       }
     },
-    [http, notifications]
+    [http, notifications, queryClient]
   );
 
   const selection: EuiTableSelectionType<CreatedIntegrationRow> = useMemo(
@@ -394,7 +408,11 @@ export const ManageIntegrationsTable: React.FC<{
   }, [selectedItems, deleteIntegration]);
 
   const handleBulkInstall = useCallback(async () => {
-    const approvedItems = selectedItems.filter((item) => item.status === 'approved');
+    const approvedItems = selectedItems.filter(
+      (item) =>
+        item.status === 'approved' &&
+        installedPackageVersions.get(item.integrationId) !== item.version
+    );
     setIsBulkInstalling(true);
     try {
       await Promise.all(approvedItems.map((item) => installToCluster(item.integrationId)));
@@ -402,7 +420,7 @@ export const ManageIntegrationsTable: React.FC<{
     } finally {
       setIsBulkInstalling(false);
     }
-  }, [selectedItems, installToCluster]);
+  }, [selectedItems, installToCluster, installedPackageVersions]);
 
   const hasApprovedSelected = selectedItems.some((item) => item.status === 'approved');
 
@@ -571,6 +589,7 @@ export const ManageIntegrationsTable: React.FC<{
               <ManageIntegrationActions
                 integration={item}
                 isPackageReady={true}
+                installedVersion={installedPackageVersions.get(item.integrationId)}
                 inlineActionType="reviewApprove"
                 showMenuButton={false}
                 onEdit={goToEditIntegration}
@@ -601,6 +620,7 @@ export const ManageIntegrationsTable: React.FC<{
           <ManageIntegrationActions
             integration={item}
             isPackageReady={isIntegrationPackageReady(item)}
+            installedVersion={installedPackageVersions.get(item.integrationId)}
             onEdit={goToEditIntegration}
             onDelete={deleteIntegration}
             DataStreamResultsFlyoutComponent={automaticImport?.components.DataStreamResultsFlyout}
@@ -620,6 +640,7 @@ export const ManageIntegrationsTable: React.FC<{
       approveAndDeployIntegration,
       downloadZipPackage,
       installToCluster,
+      installedPackageVersions,
       automaticImport?.components.DataStreamResultsFlyout,
       euiTheme.colors.backgroundLightText,
       euiTheme.colors.textParagraph,


### PR DESCRIPTION

## Summary

This PR:

- Checks installed packages to see if current package and the version of the item from integration management table is already installed and will disable install
- If a new version is approved, install is allowed to proceed.

https://github.com/user-attachments/assets/876fd95f-d989-40bc-954e-74180a692e8f

This PR addresses:
https://github.com/elastic/kibana/issues/262223

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
~~- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~~
~~- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios~~
~~- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~~
~~- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.~~
~~- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed~~
~~- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)~~
~~- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.~~


<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->