### PR TITLE
[Chrome Next] Add badges

### DIFF
--- a/src/core/packages/chrome/browser-components/src/chrome_next/app_header/app_badge.tsx
+++ b/src/core/packages/chrome/browser-components/src/chrome_next/app_header/app_badge.tsx
@@ -49,8 +49,8 @@ export const AppBadge = ({ badge }: { badge: ChromeNextHeaderBadge }) => {
     <EuiBadge
       onClick={handleBadgeClick}
       onClickAriaLabel={badgeOnClickAriaLabel}
-      color={badge.color ?? 'hollow'}
-      data-test-subj={badge.testId}
+      color={badge?.color ?? 'hollow'}
+      data-test-subj={badge?.['data-test-subj']}
       css={badgeStyle}
     >
       {badge.label}

--- a/src/core/packages/chrome/browser-components/src/chrome_next/app_header/app_badge.tsx
+++ b/src/core/packages/chrome/browser-components/src/chrome_next/app_header/app_badge.tsx
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React, { useMemo } from 'react';
+import { EuiBadge, EuiToolTip } from '@elastic/eui';
+import type { ChromeNextHeaderBadge } from '@kbn/core-chrome-browser/src';
+import { css } from '@emotion/react';
+import { i18n } from '@kbn/i18n';
+
+const useBadgeStyle = () => {
+  return useMemo(() => {
+    const badge = css`
+      max-width: 200px;
+    `;
+
+    return { badge };
+  }, []);
+};
+
+export const AppBadge = ({ badge }: { badge: ChromeNextHeaderBadge }) => {
+  const { badge: badgeStyle } = useBadgeStyle();
+
+  // @ts-expect-error supported for backward compatibility. TODO: Remove it
+  if (badge?.renderCustomBadge) {
+    // @ts-expect-error supported for backward compatibility. TODO: Remove it
+    return badge.renderCustomBadge({ badgeText: badge.label });
+  }
+
+  const badgeOnClickAriaLabel =
+    badge?.onClickAriaLabel ??
+    i18n.translate('core.ui.chrome.appHeader.badge.ariaLabel', {
+      defaultMessage: 'Click {label} badge',
+      values: { label: badge.label },
+    });
+
+  const handleBadgeClick = () => {
+    if (badge?.onClick) {
+      badge.onClick();
+    }
+  };
+
+  const badgeComponent = (
+    <EuiBadge
+      onClick={handleBadgeClick}
+      onClickAriaLabel={badgeOnClickAriaLabel}
+      color={badge.color ?? 'hollow'}
+      data-test-subj={badge.testId}
+      css={badgeStyle}
+    >
+      {badge.label}
+    </EuiBadge>
+  );
+
+  if (badge?.tooltip) {
+    return <EuiToolTip content={badge.tooltip}>{badgeComponent}</EuiToolTip>;
+  }
+
+  return badgeComponent;
+};
+
+AppBadge.displayName = 'AppBadge';

--- a/src/core/packages/chrome/browser-components/src/chrome_next/app_header/app_badges.tsx
+++ b/src/core/packages/chrome/browser-components/src/chrome_next/app_header/app_badges.tsx
@@ -1,0 +1,103 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React, { memo, useMemo, useState } from 'react';
+import { EuiBadge, EuiFlexGroup, EuiFlexItem, EuiPopover, useEuiTheme } from '@elastic/eui';
+import { css } from '@emotion/react';
+import { i18n } from '@kbn/i18n';
+import { AppBadge } from './app_badge';
+import { useAppBadges } from './hooks/use_app_badges';
+
+const MAX_VISIBLE_BADGES = 2;
+
+const useBadgesStyle = () => {
+  const { euiTheme } = useEuiTheme();
+
+  return useMemo(() => {
+    const badgesContainer = css`
+      margin-left: ${euiTheme.size.s};
+    `;
+
+    return { badgesContainer };
+  }, [euiTheme]);
+};
+
+export const AppBadges = memo(() => {
+  const badges = useAppBadges();
+  const { badgesContainer } = useBadgesStyle();
+  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+
+  if (!badges || badges.length === 0) {
+    return null;
+  }
+
+  const visibleBadges = badges.slice(0, MAX_VISIBLE_BADGES);
+  const overflowBadges = badges.slice(MAX_VISIBLE_BADGES);
+
+  const handleClosePopover = () => {
+    setIsPopoverOpen(false);
+  };
+
+  const handleTogglePopover = () => {
+    setIsPopoverOpen((open) => !open);
+  };
+
+  return (
+    <EuiFlexGroup
+      gutterSize="xs"
+      alignItems="center"
+      responsive={false}
+      wrap={false}
+      css={badgesContainer}
+    >
+      {visibleBadges.map((badge) => (
+        <EuiFlexItem grow={false} key={badge.label}>
+          <AppBadge badge={badge} />
+        </EuiFlexItem>
+      ))}
+      {overflowBadges.length > 0 && (
+        <EuiFlexItem grow={false}>
+          <EuiPopover
+            aria-label={i18n.translate('core.ui.chrome.appHeader.badges.popoverAriaLabel', {
+              defaultMessage: 'More badges',
+            })}
+            button={
+              <EuiBadge
+                color="hollow"
+                onClick={handleTogglePopover}
+                onClickAriaLabel={i18n.translate(
+                  'core.ui.chrome.appHeader.badges.overflowAriaLabel',
+                  {
+                    defaultMessage: 'Show {count} more badges',
+                    values: { count: overflowBadges.length },
+                  }
+                )}
+              >
+                +{overflowBadges.length}
+              </EuiBadge>
+            }
+            isOpen={isPopoverOpen}
+            closePopover={handleClosePopover}
+            panelPaddingSize="s"
+          >
+            <EuiFlexGroup direction="column" gutterSize="xs">
+              {overflowBadges.map((badge) => (
+                <EuiFlexItem key={badge.label}>
+                  <AppBadge badge={badge} />
+                </EuiFlexItem>
+              ))}
+            </EuiFlexGroup>
+          </EuiPopover>
+        </EuiFlexItem>
+      )}
+    </EuiFlexGroup>
+  );
+});
+
+AppBadges.displayName = 'AppBadges';

--- a/src/core/packages/chrome/browser-components/src/chrome_next/app_header/app_header.tsx
+++ b/src/core/packages/chrome/browser-components/src/chrome_next/app_header/app_header.tsx
@@ -9,6 +9,7 @@
 
 import React from 'react';
 import { AppHeaderShell } from './app_header_shell';
+import { AppBadges } from './app_badges';
 import { BackButton } from './back_button';
 import { AppTitle } from './app_title';
 import { GlobalActions } from './global_actions';
@@ -18,6 +19,7 @@ export const AppHeader = React.memo(() => (
   <AppHeaderShell
     leading={<BackButton />}
     title={<AppTitle />}
+    badges={<AppBadges />}
     titleActions={<GlobalActions />}
     trailing={<AppMenu />}
   />

--- a/src/core/packages/chrome/browser-components/src/chrome_next/app_header/hooks/use_app_badges.ts
+++ b/src/core/packages/chrome/browser-components/src/chrome_next/app_header/hooks/use_app_badges.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { useMemo } from 'react';
+import type { ChromeNextHeaderBadge } from '@kbn/core-chrome-browser/src';
+import type { ChromeBadge, ChromeBreadcrumbsBadge } from '@kbn/core-chrome-browser';
+import { useObservable } from '@kbn/use-observable';
+import { useChromeService } from '@kbn/core-chrome-browser-context';
+import { useNextHeader } from '../../../shared/chrome_hooks';
+
+const breadcrumbsBadgeToHeaderBadge = (badge: ChromeBreadcrumbsBadge): ChromeNextHeaderBadge => ({
+  label: badge.badgeText,
+  tooltip: badge.toolTipProps?.content as string | undefined,
+  // @ts-expect-error supported for backward compatibility. TODO: Remove it
+  renderCustomBadge: badge.renderCustomBadge,
+});
+
+const legacyBadgeToHeaderBadge = (badge: ChromeBadge): ChromeNextHeaderBadge => ({
+  label: badge.text,
+  tooltip: badge.tooltip,
+});
+
+/**
+ * Fallback: `config.badges` from `chrome.next.header.set()` ->
+ * legacy `chrome.setBadge()` + `chrome.setBreadcrumbsBadges()` combined.
+ */
+export function useAppBadges(): ChromeNextHeaderBadge[] | undefined {
+  const config = useNextHeader();
+  const chrome = useChromeService();
+  const breadcrumbsBadges$ = useMemo(() => chrome.getBreadcrumbsBadges$(), [chrome]);
+  const breadcrumbsBadges = useObservable(breadcrumbsBadges$, []);
+  const legacyBadge$ = useMemo(() => chrome.getBadge$(), [chrome]);
+  const legacyBadge = useObservable(legacyBadge$, undefined);
+
+  if (config?.badges) {
+    return config.badges;
+  }
+
+  const fallback: ChromeNextHeaderBadge[] = [];
+
+  if (legacyBadge) {
+    fallback.push(legacyBadgeToHeaderBadge(legacyBadge));
+  }
+
+  if (breadcrumbsBadges.length > 0) {
+    fallback.push(...breadcrumbsBadges.map(breadcrumbsBadgeToHeaderBadge));
+  }
+
+  return fallback.length > 0 ? fallback : undefined;
+}

--- a/src/core/packages/chrome/browser-internal-types/index.ts
+++ b/src/core/packages/chrome/browser-internal-types/index.ts
@@ -15,6 +15,7 @@ import type {
   ChromeBadge,
   ChromeBreadcrumb,
   ChromeBreadcrumbsAppendExtension,
+  ChromeBreadcrumbsBadge,
   ChromeNext,
   ChromeNextAiButton,
   ChromeNextHeaderConfig,
@@ -62,6 +63,11 @@ export interface InternalChromeStart extends ChromeStart {
    * converted to extensions. Used by chrome layout components.
    */
   getBreadcrumbsAppendExtensionsWithBadges$(): Observable<ChromeBreadcrumbsAppendExtension[]>;
+
+  /**
+   * Get an observable of the current breadcrumbs badges set via setBreadcrumbsBadges().
+   */
+  getBreadcrumbsBadges$(): Observable<ChromeBreadcrumbsBadge[]>;
 
   /** Set global footer. Used by the developer toolbar. */
   setGlobalFooter(node: ReactNode): void;

--- a/src/core/packages/chrome/browser-internal/src/chrome_api.tsx
+++ b/src/core/packages/chrome/browser-internal/src/chrome_api.tsx
@@ -113,6 +113,7 @@ export function createChromeApi({ state, services, sidebar }: ChromeApiDeps): In
     },
     getBreadcrumbsAppendExtensions$: () => state.breadcrumbs.appendExtensions.$,
     getBreadcrumbsAppendExtensionsWithBadges$: () => state.breadcrumbs.appendExtensionsWithBadges$,
+    getBreadcrumbsBadges$: () => state.breadcrumbs.badges.$,
     setBreadcrumbsAppendExtension: (extension) => {
       state.breadcrumbs.appendExtensions.addSorted(
         extension,

--- a/src/core/packages/chrome/browser-mocks/src/chrome_service.mock.ts
+++ b/src/core/packages/chrome/browser-mocks/src/chrome_service.mock.ts
@@ -149,6 +149,7 @@ const createStartContractMock = () => {
     getAppMenu$: jest.fn().mockReturnValue(new BehaviorSubject(undefined)),
     setAppMenu: jest.fn(),
     setBreadcrumbsBadges: jest.fn(),
+    getBreadcrumbsBadges$: jest.fn().mockReturnValue(new BehaviorSubject([])),
   });
 
   return startContract;

--- a/src/core/packages/chrome/browser/src/chrome_next/header.ts
+++ b/src/core/packages/chrome/browser/src/chrome_next/header.ts
@@ -80,7 +80,7 @@ export interface ChromeNextHeaderBadge {
   tooltip?: string;
   onClick?: () => void;
   onClickAriaLabel?: string;
-  testId?: string;
+  'data-test-subj'?: string;
 }
 
 /**

--- a/src/core/packages/chrome/browser/src/chrome_next/header.ts
+++ b/src/core/packages/chrome/browser/src/chrome_next/header.ts
@@ -24,7 +24,7 @@ export interface ChromeNextHeaderConfig {
 
   /**
    * Badges inline next to the title. Chrome shows 1–2 as-is; for 3+, first badge plus "+N" popover
-   * for the rest. Max 200px per badge; `filled` is not exposed. TODO: render in `AppHeader`.
+   * for the rest. Max 200px per badge; `filled` is not exposed.
    */
   badges?: ChromeNextHeaderBadge[];
 
@@ -78,6 +78,9 @@ export interface ChromeNextHeaderBadge {
   /** EUI badge color. `filled` is intentionally excluded. */
   color?: 'hollow' | 'default' | 'primary' | 'success' | 'warning' | 'danger' | 'accent';
   tooltip?: string;
+  onClick?: () => void;
+  onClickAriaLabel?: string;
+  testId?: string;
 }
 
 /**

--- a/src/core/packages/chrome/browser/src/types.ts
+++ b/src/core/packages/chrome/browser/src/types.ts
@@ -21,6 +21,9 @@ export interface ChromeBadge {
 export type ChromeBreadcrumbsBadge = EuiBadgeProps & {
   badgeText: string;
   toolTipProps?: Partial<EuiToolTipProps>;
+  /**
+   * @deprecated
+   */
   renderCustomBadge?: (props: { badgeText: string }) => ReactElement;
 };
 


### PR DESCRIPTION
## Summary

This PR adds badges API for chrome next. It intentionally does NOT migrate badges that use `renderCustomBadge` as they use functionality that does not exist for chrome next badges (e.g. open popovers, have icons) and changing that requires design decisions.

Closes: https://github.com/elastic/kibana/issues/259987


