### PR TITLE
[CPS] Fix APM routing and settings

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/plugin.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/plugin.ts
@@ -541,11 +541,12 @@ export class ApmPlugin implements Plugin<ApmPluginSetup, ApmPluginStart> {
       )
     ) {
       plugins.cps?.cpsManager?.registerAppAccess('apm', () => ProjectRoutingAccess.EDITABLE);
+      setApmInternalServices({
+        cpsManager: plugins.cps?.cpsManager,
+      });
+    } else {
+      setApmInternalServices({});
     }
-
-    setApmInternalServices({
-      cpsManager: plugins.cps?.cpsManager,
-    });
 
     plugins.observabilityAIAssistant?.service.register(async ({ registerRenderFunction }) => {
       const mod = await import('./assistant_functions');

--- a/x-pack/solutions/observability/plugins/apm/server/agent_builder/utils/build_apm_tool_resources.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/agent_builder/utils/build_apm_tool_resources.ts
@@ -73,6 +73,10 @@ export async function buildApmToolResources({
 
   const apmEventClientPromise = getApmEventClient({
     context: contextAdapter,
+    core: {
+      setup: core,
+      start: () => core.getStartServices().then(([cs]) => cs),
+    },
     request,
     params: {
       query: {

--- a/x-pack/solutions/observability/plugins/apm/server/lib/helpers/get_apm_event_client.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/lib/helpers/get_apm_event_client.ts
@@ -16,16 +16,17 @@ import { inspectableEsQueriesMap } from '../../routes/apm_routes/register_apm_se
 
 export async function getApmEventClient({
   context,
+  core,
   params,
   getApmIndices,
   request,
 }: Pick<
   MinimalAPMRouteHandlerResources,
-  'context' | 'params' | 'getApmIndices' | 'request'
+  'context' | 'core' | 'params' | 'getApmIndices' | 'request'
 >): Promise<APMEventClient> {
   return withApmSpan('get_apm_event_client', async () => {
     const coreContext = await context.core;
-    const [indices, uiSettings] = await Promise.all([
+    const [indices, uiSettings, coreStart] = await Promise.all([
       getApmIndices(),
       withApmSpan('get_ui_settings', async () => {
         const includeFrozen = await coreContext.uiSettings.client.get<boolean>(
@@ -37,12 +38,18 @@ export async function getApmEventClient({
 
         return { includeFrozen, excludedDataTiers };
       }),
+      core.start(),
     ]);
 
-    const projectRouting = getProjectRoutingFromRequest(request);
+    const headerProjectRouting = getProjectRoutingFromRequest(request);
+    const elasticsearchClusterClient = coreStart.elasticsearch.client;
+    // Rule UIs may omit `x-project-routing`; align with alerting by using the space NPRE when absent.
+    const scopedClusterClient = headerProjectRouting
+      ? elasticsearchClusterClient.asScoped(request)
+      : elasticsearchClusterClient.asScoped(request, { projectRouting: 'space' });
 
     return new APMEventClient({
-      esClient: coreContext.elasticsearch.client.asCurrentUser,
+      esClient: scopedClusterClient.asCurrentUser,
       debug: params.query._inspect,
       request,
       indices,
@@ -50,7 +57,7 @@ export async function getApmEventClient({
         includeFrozen: uiSettings.includeFrozen,
         excludedDataTiers: uiSettings.excludedDataTiers,
         inspectableEsQueriesMap,
-        projectRouting,
+        projectRouting: headerProjectRouting,
       },
     });
   });

--- a/x-pack/solutions/observability/plugins/apm/server/plugin.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/plugin.ts
@@ -246,7 +246,7 @@ export class APMPlugin
     );
 
     plugins.observability.alertDetailsContextualInsightsService.registerHandler(
-      getAlertDetailsContextHandler(getCoreStart(), resourcePlugins, logger)
+      getAlertDetailsContextHandler({ setup: core, start: getCoreStart }, resourcePlugins, logger)
     );
 
     registerDataProviders({

--- a/x-pack/solutions/observability/plugins/apm/server/routes/assistant_functions/get_observability_alert_details_context/index.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/assistant_functions/get_observability_alert_details_context/index.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { CoreStart, Logger } from '@kbn/core/server';
+import type { Logger } from '@kbn/core/server';
 import type {
   AlertDetailsContextualInsight,
   AlertDetailsContextualInsightsHandler,
@@ -28,15 +28,17 @@ import { getServiceNameFromSignals } from './get_service_name_from_signals';
 import { getContainerIdFromSignals } from './get_container_id_from_signals';
 import { getExitSpanChangePoints, getServiceChangePoints } from '../get_changepoints';
 import type { APMRouteHandlerResources } from '../../apm_routes/register_apm_server_routes';
+import type { APMCore } from '../../typings';
 import { getApmErrors } from './get_apm_errors';
 
 export const getAlertDetailsContextHandler = (
-  coreStartPromise: Promise<CoreStart>,
+  apmCore: APMCore,
   resourcePlugins: APMRouteHandlerResources['plugins'],
   logger: Logger
 ): AlertDetailsContextualInsightsHandler => {
   return async (requestContext, query) => {
     const resources = {
+      core: apmCore,
       getApmIndices: async () => {
         const coreContext = await requestContext.core;
         return resourcePlugins.apmDataAccess.setup.getApmIndices(coreContext.savedObjects.client);
@@ -64,7 +66,7 @@ export const getAlertDetailsContextHandler = (
       },
     };
 
-    const coreStart = await coreStartPromise;
+    const coreStart = await apmCore.start();
     const [
       apmEventClient,
       annotationsClient,


### PR DESCRIPTION
Closes #262333
Closes #256211
Closes #256072
Closes #256190

## Summary

This PR tries to fix the CPS issues found: 

1. APM server: space CPS routing when `x-project-routing` is missing
Observability rule flows often call APM HTTP APIs without `x-project-routing`, so only origin routing applied. Alerting already uses `asScoped(fakeRequest, { projectRouting: 'space' })` so execution sees linked projects; APM previews/selectors now follow the same idea.

`getApmEventClient` resolves `core.start()`, then:

If `getProjectRoutingFromRequest(request)` is set -> `asScoped(request)` (same as before) and still pass that value through APMEventClient as explicit project_routing on requests.
If it is not set -> `asScoped(request, { projectRouting: 'space' })` so the platform injects the space NPRE (e.g.`_alias:*` when configured on the space), matching rule execution.

-----

2. [PR comment](https://github.com/elastic/kibana/pull/258886#discussion_r3066410936): setApmInternalServices only when CPS is enabled

So cpsManager is only exposed when the APM CPS feature flag is on, consistent with registerAppAccess.

## Testing
- The services from the linked project should be available in the alert chart and drop-down in the rule creation step, to check that: 
- Use a project with CPS enabled and linked project both with ingested data
- Go to APM > Alerts > Create rule (any rule) 
- Then check if the data from both projects is available

<img width="3074" height="1814" alt="image" src="https://github.com/user-attachments/assets/be57c28b-592e-48e9-91e7-e08fe0b22f83" />


- Go to Alerts > Create rules > Select an APM rule
- Then check if the data from both projects is available

<img width="3733" height="1909" alt="image" src="https://github.com/user-attachments/assets/bee28af9-86f6-4ab9-8c63-19284004750d" />


<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->