### PR TITLE
[9.1] [Securoty Solution] prevent flyout scroll jump when hover actions focus panel (#262682)

### DIFF
--- a/src/platform/packages/shared/kbn-cell-actions/src/components/hover_actions_popover.tsx
+++ b/src/platform/packages/shared/kbn-cell-actions/src/components/hover_actions_popover.tsx
@@ -136,7 +136,6 @@ export const HoverActionsPopover: React.FC<Props> = ({
           closePopover={closePopover}
           hasArrow={false}
           isOpen={showHoverContent}
-          offset={0}
           // Avoid scrolling scrollable ancestors (e.g. flyout body) when focus moves into the panel;
           // react-focus-on maps this to focusOptions: { preventScroll: true } on react-focus-lock.
           focusTrapProps={{ preventScrollOnFocus: true }}

--- a/src/platform/packages/shared/kbn-cell-actions/src/components/hover_actions_popover.tsx
+++ b/src/platform/packages/shared/kbn-cell-actions/src/components/hover_actions_popover.tsx
@@ -136,6 +136,10 @@ export const HoverActionsPopover: React.FC<Props> = ({
           closePopover={closePopover}
           hasArrow={false}
           isOpen={showHoverContent}
+          offset={0}
+          // Avoid scrolling scrollable ancestors (e.g. flyout body) when focus moves into the panel;
+          // react-focus-on maps this to focusOptions: { preventScroll: true } on react-focus-lock.
+          focusTrapProps={{ preventScrollOnFocus: true }}
           panelPaddingSize="none"
           repositionOnScroll
           panelProps={{ 'data-test-subj': 'hoverActionsPopover' }}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[Securoty Solution] prevent flyout scroll jump when hover actions focus panel (#262682)](https://github.com/elastic/kibana/pull/262682)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jon Wålstedt","email":"jon.walstedt@elastic.co"},"sourceCommit":{"committedDate":"2026-04-13T09:34:33Z","message":"[Securoty Solution] prevent flyout scroll jump when hover actions focus panel (#262682)\n\n## Summary\n\n**Problem:** In **Mozilla Firefox**, scrolling the **Table** tab of the\n**alert / document details flyout** (the field/value list) could **jump\nto the bottom** after **hovering a row** so the **cell action** strip\nappears. The bad scroll often showed up on the **next** scroll gesture,\nmaking long field lists hard to use.\n\n**Cause:** `EuiPopover` uses a focus trap by default. When the hover\nmenu opens, focus moves into the action panel. The browser then\n**scrolls scrollable ancestors** (notably the flyout body) to keep the\nfocused node in view—here that effectively **yanks** the flyout scroll\nposition (often to the end of the scrollable area).\n\n**Change:** Set `focusTrapProps={{ preventScrollOnFocus: true }}` on the\n`EuiPopover` in `HoverActionsPopover` (`@kbn/cell-actions`). That flows\nthrough `react-focus-on` / `react-focus-lock` as `focus({ preventScroll:\ntrue })` when focus enters the panel, so **ancestor scroll position is\npreserved** while keeping normal focus behavior for the actions.\n\n**Scope:** Affects any UI that uses **hover** cell actions\n(`CellActionsMode.HOVER_DOWN` / `HOVER_RIGHT`), including the Security\nalert flyout **Table** view.\n\nFixes: https://github.com/elastic/sdh-security-team/issues/1623\n\n**Before**\n\n\nhttps://github.com/user-attachments/assets/dbc91261-b178-4296-9116-3eca77dc6970\n\n**After**\n\n\nhttps://github.com/user-attachments/assets/e8869d17-4071-4893-9b3b-6fb6d888a772\n\n---\n\n## Release note (for the label / changelog)\n\n> **Security — Alerts:** Fixed Firefox scroll position jumping to the\nbottom of the document details flyout **Table** tab after hovering field\nrows with cell actions.\n\n---\n\n## Risk\n\n**Overall severity: low.** There are no HTTP, persistence, or\nsecurity-control changes; this is a client-side focus/scroll interaction\nfix in `@kbn/cell-actions`.\n\n| Area | Risk | Severity | Mitigation |\n|------|------|-----------|------------|\n| **Scroll / layout** | Suppressing scroll-on-focus fixes the flyout\njump but means the browser **no longer auto-scrolls ancestors** to\nreveal the focused node when focus enters the panel. In edge cases (e.g.\npanel partly off-screen), the focused control might not be scrolled into\nview automatically. | Low | Hover popovers are anchored to the cell and\n`repositionOnScroll` updates position; primary bug was ancestor scroll\n(flyout body), not missing panel visibility. Smoke-test Firefox +\nChromium on the alert flyout **Table** tab. |\n| **Blast radius** | Every consumer of `CellActionsMode.HOVER_DOWN` /\n`HOVER_RIGHT` inherits the change (Security flyout, other tables using\nhover cell actions). | Low | Same behavior is desirable anywhere a\nscroll container wraps the grid/flyout; unintended regressions are\nunlikely. |\n| **Accessibility** | Focus still moves into the action strip via the\nexisting focus trap; only **`focus({ preventScroll: true })`** is added.\nScreen reader and keyboard users are not losing the trap or labels. |\nLow | Optional: tab through actions after hover-open in Firefox to\nconfirm nothing regressed. |\n| **Browser variance** | Issue was most visible in **Firefox**; other\nbrowsers may already have been less aggressive about scrolling\nancestors. | Low | Treat Firefox as the validation target; spot-check\nChrome or Edge. |\n| **Performance** | Extra prop only; no new listeners or renders. |\nNegligible | None. |\n\nSee\n[RISK_MATRIX.mdx](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\nfor how Elastic frames severity in larger PRs; this change does not\nwarrant escalation beyond routine review.\n\n---\n\n## Checklist — what to tick (this PR)\n\n| Item | Tick? | Notes |\n|------|--------|--------|\n| EUI writing + i18n | **Yes** | No new user-visible strings; only a\n`focusTrapProps` prop and an English **code comment** (not product\ncopy). |\n| Documentation | **Yes** | Bugfix / UX correction; no new feature or\nworkflow that needs dev docs. |\n| Unit or functional tests | **Optional / your call** | **Not updated in\nbranch.** Existing `hover_actions_popover.test.tsx` still covers hover\nbehavior. You can **leave unchecked** and note “no test change; optional\nfollow-up to assert `focusTrapProps.preventScrollOnFocus`”, or add a\nsmall test and then **check**. |\n| Cloud / docker allowlist | **Yes** | No `kibana.yml` or plugin config\nkeys changed. |\n| Breaking HTTP API | **Yes** | No public HTTP or plugin contract\nchanges. |\n| Flaky Test Runner | **Yes** | No test files modified; FTR not\napplicable. |\n| Release notes + `release_note:*` label | **You + reviewer** | Include\nthe **Release note** line in the GitHub PR body; apply\n**`release_note:fix`** (or whatever your team uses for bugfixes)—confirm\nagainst\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process).\n|\n| Backport labels | **Reviewer / RM** | Don’t guess—Security / SDH\nusually decides `backport:skip` vs target minors. Ask on PR if unsure. |\n| Risks (RISK_MATRIX) | **Yes** | Low risk; see **Risk** section above.\n|\n\n---\n\n## Kibana PR checklist (paste into GitHub — suggested boxes)\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n— **N/A: no new product copy**\n- [x]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials — **N/A:\nbugfix**\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios — **optional:**\nadd assertion for `preventScrollOnFocus`, or leave unchecked and note in\nPR\n- [x] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n— **N/A**\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations. —\n**N/A: no breaking changes**\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed — **N/A: no tests changed**\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n— **complete when you paste release note + label on open PR**\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels. — **reviewer**\n\n- [x] Risks identified and assessed — see **Risk** section above (also\n[RISK_MATRIX](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\nfor context).","sha":"2a1da0d776ee9a5b980a29b79be60bb209cd7f77","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport:skip","Team:Threat Hunting","backport:all-open","v9.5.0"],"title":"[Securoty Solution] prevent flyout scroll jump when hover actions focus panel","number":262682,"url":"https://github.com/elastic/kibana/pull/262682","mergeCommit":{"message":"[Securoty Solution] prevent flyout scroll jump when hover actions focus panel (#262682)\n\n## Summary\n\n**Problem:** In **Mozilla Firefox**, scrolling the **Table** tab of the\n**alert / document details flyout** (the field/value list) could **jump\nto the bottom** after **hovering a row** so the **cell action** strip\nappears. The bad scroll often showed up on the **next** scroll gesture,\nmaking long field lists hard to use.\n\n**Cause:** `EuiPopover` uses a focus trap by default. When the hover\nmenu opens, focus moves into the action panel. The browser then\n**scrolls scrollable ancestors** (notably the flyout body) to keep the\nfocused node in view—here that effectively **yanks** the flyout scroll\nposition (often to the end of the scrollable area).\n\n**Change:** Set `focusTrapProps={{ preventScrollOnFocus: true }}` on the\n`EuiPopover` in `HoverActionsPopover` (`@kbn/cell-actions`). That flows\nthrough `react-focus-on` / `react-focus-lock` as `focus({ preventScroll:\ntrue })` when focus enters the panel, so **ancestor scroll position is\npreserved** while keeping normal focus behavior for the actions.\n\n**Scope:** Affects any UI that uses **hover** cell actions\n(`CellActionsMode.HOVER_DOWN` / `HOVER_RIGHT`), including the Security\nalert flyout **Table** view.\n\nFixes: https://github.com/elastic/sdh-security-team/issues/1623\n\n**Before**\n\n\nhttps://github.com/user-attachments/assets/dbc91261-b178-4296-9116-3eca77dc6970\n\n**After**\n\n\nhttps://github.com/user-attachments/assets/e8869d17-4071-4893-9b3b-6fb6d888a772\n\n---\n\n## Release note (for the label / changelog)\n\n> **Security — Alerts:** Fixed Firefox scroll position jumping to the\nbottom of the document details flyout **Table** tab after hovering field\nrows with cell actions.\n\n---\n\n## Risk\n\n**Overall severity: low.** There are no HTTP, persistence, or\nsecurity-control changes; this is a client-side focus/scroll interaction\nfix in `@kbn/cell-actions`.\n\n| Area | Risk | Severity | Mitigation |\n|------|------|-----------|------------|\n| **Scroll / layout** | Suppressing scroll-on-focus fixes the flyout\njump but means the browser **no longer auto-scrolls ancestors** to\nreveal the focused node when focus enters the panel. In edge cases (e.g.\npanel partly off-screen), the focused control might not be scrolled into\nview automatically. | Low | Hover popovers are anchored to the cell and\n`repositionOnScroll` updates position; primary bug was ancestor scroll\n(flyout body), not missing panel visibility. Smoke-test Firefox +\nChromium on the alert flyout **Table** tab. |\n| **Blast radius** | Every consumer of `CellActionsMode.HOVER_DOWN` /\n`HOVER_RIGHT` inherits the change (Security flyout, other tables using\nhover cell actions). | Low | Same behavior is desirable anywhere a\nscroll container wraps the grid/flyout; unintended regressions are\nunlikely. |\n| **Accessibility** | Focus still moves into the action strip via the\nexisting focus trap; only **`focus({ preventScroll: true })`** is added.\nScreen reader and keyboard users are not losing the trap or labels. |\nLow | Optional: tab through actions after hover-open in Firefox to\nconfirm nothing regressed. |\n| **Browser variance** | Issue was most visible in **Firefox**; other\nbrowsers may already have been less aggressive about scrolling\nancestors. | Low | Treat Firefox as the validation target; spot-check\nChrome or Edge. |\n| **Performance** | Extra prop only; no new listeners or renders. |\nNegligible | None. |\n\nSee\n[RISK_MATRIX.mdx](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\nfor how Elastic frames severity in larger PRs; this change does not\nwarrant escalation beyond routine review.\n\n---\n\n## Checklist — what to tick (this PR)\n\n| Item | Tick? | Notes |\n|------|--------|--------|\n| EUI writing + i18n | **Yes** | No new user-visible strings; only a\n`focusTrapProps` prop and an English **code comment** (not product\ncopy). |\n| Documentation | **Yes** | Bugfix / UX correction; no new feature or\nworkflow that needs dev docs. |\n| Unit or functional tests | **Optional / your call** | **Not updated in\nbranch.** Existing `hover_actions_popover.test.tsx` still covers hover\nbehavior. You can **leave unchecked** and note “no test change; optional\nfollow-up to assert `focusTrapProps.preventScrollOnFocus`”, or add a\nsmall test and then **check**. |\n| Cloud / docker allowlist | **Yes** | No `kibana.yml` or plugin config\nkeys changed. |\n| Breaking HTTP API | **Yes** | No public HTTP or plugin contract\nchanges. |\n| Flaky Test Runner | **Yes** | No test files modified; FTR not\napplicable. |\n| Release notes + `release_note:*` label | **You + reviewer** | Include\nthe **Release note** line in the GitHub PR body; apply\n**`release_note:fix`** (or whatever your team uses for bugfixes)—confirm\nagainst\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process).\n|\n| Backport labels | **Reviewer / RM** | Don’t guess—Security / SDH\nusually decides `backport:skip` vs target minors. Ask on PR if unsure. |\n| Risks (RISK_MATRIX) | **Yes** | Low risk; see **Risk** section above.\n|\n\n---\n\n## Kibana PR checklist (paste into GitHub — suggested boxes)\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n— **N/A: no new product copy**\n- [x]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials — **N/A:\nbugfix**\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios — **optional:**\nadd assertion for `preventScrollOnFocus`, or leave unchecked and note in\nPR\n- [x] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n— **N/A**\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations. —\n**N/A: no breaking changes**\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed — **N/A: no tests changed**\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n— **complete when you paste release note + label on open PR**\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels. — **reviewer**\n\n- [x] Risks identified and assessed — see **Risk** section above (also\n[RISK_MATRIX](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\nfor context).","sha":"2a1da0d776ee9a5b980a29b79be60bb209cd7f77"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/262682","number":262682,"mergeCommit":{"message":"[Securoty Solution] prevent flyout scroll jump when hover actions focus panel (#262682)\n\n## Summary\n\n**Problem:** In **Mozilla Firefox**, scrolling the **Table** tab of the\n**alert / document details flyout** (the field/value list) could **jump\nto the bottom** after **hovering a row** so the **cell action** strip\nappears. The bad scroll often showed up on the **next** scroll gesture,\nmaking long field lists hard to use.\n\n**Cause:** `EuiPopover` uses a focus trap by default. When the hover\nmenu opens, focus moves into the action panel. The browser then\n**scrolls scrollable ancestors** (notably the flyout body) to keep the\nfocused node in view—here that effectively **yanks** the flyout scroll\nposition (often to the end of the scrollable area).\n\n**Change:** Set `focusTrapProps={{ preventScrollOnFocus: true }}` on the\n`EuiPopover` in `HoverActionsPopover` (`@kbn/cell-actions`). That flows\nthrough `react-focus-on` / `react-focus-lock` as `focus({ preventScroll:\ntrue })` when focus enters the panel, so **ancestor scroll position is\npreserved** while keeping normal focus behavior for the actions.\n\n**Scope:** Affects any UI that uses **hover** cell actions\n(`CellActionsMode.HOVER_DOWN` / `HOVER_RIGHT`), including the Security\nalert flyout **Table** view.\n\nFixes: https://github.com/elastic/sdh-security-team/issues/1623\n\n**Before**\n\n\nhttps://github.com/user-attachments/assets/dbc91261-b178-4296-9116-3eca77dc6970\n\n**After**\n\n\nhttps://github.com/user-attachments/assets/e8869d17-4071-4893-9b3b-6fb6d888a772\n\n---\n\n## Release note (for the label / changelog)\n\n> **Security — Alerts:** Fixed Firefox scroll position jumping to the\nbottom of the document details flyout **Table** tab after hovering field\nrows with cell actions.\n\n---\n\n## Risk\n\n**Overall severity: low.** There are no HTTP, persistence, or\nsecurity-control changes; this is a client-side focus/scroll interaction\nfix in `@kbn/cell-actions`.\n\n| Area | Risk | Severity | Mitigation |\n|------|------|-----------|------------|\n| **Scroll / layout** | Suppressing scroll-on-focus fixes the flyout\njump but means the browser **no longer auto-scrolls ancestors** to\nreveal the focused node when focus enters the panel. In edge cases (e.g.\npanel partly off-screen), the focused control might not be scrolled into\nview automatically. | Low | Hover popovers are anchored to the cell and\n`repositionOnScroll` updates position; primary bug was ancestor scroll\n(flyout body), not missing panel visibility. Smoke-test Firefox +\nChromium on the alert flyout **Table** tab. |\n| **Blast radius** | Every consumer of `CellActionsMode.HOVER_DOWN` /\n`HOVER_RIGHT` inherits the change (Security flyout, other tables using\nhover cell actions). | Low | Same behavior is desirable anywhere a\nscroll container wraps the grid/flyout; unintended regressions are\nunlikely. |\n| **Accessibility** | Focus still moves into the action strip via the\nexisting focus trap; only **`focus({ preventScroll: true })`** is added.\nScreen reader and keyboard users are not losing the trap or labels. |\nLow | Optional: tab through actions after hover-open in Firefox to\nconfirm nothing regressed. |\n| **Browser variance** | Issue was most visible in **Firefox**; other\nbrowsers may already have been less aggressive about scrolling\nancestors. | Low | Treat Firefox as the validation target; spot-check\nChrome or Edge. |\n| **Performance** | Extra prop only; no new listeners or renders. |\nNegligible | None. |\n\nSee\n[RISK_MATRIX.mdx](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\nfor how Elastic frames severity in larger PRs; this change does not\nwarrant escalation beyond routine review.\n\n---\n\n## Checklist — what to tick (this PR)\n\n| Item | Tick? | Notes |\n|------|--------|--------|\n| EUI writing + i18n | **Yes** | No new user-visible strings; only a\n`focusTrapProps` prop and an English **code comment** (not product\ncopy). |\n| Documentation | **Yes** | Bugfix / UX correction; no new feature or\nworkflow that needs dev docs. |\n| Unit or functional tests | **Optional / your call** | **Not updated in\nbranch.** Existing `hover_actions_popover.test.tsx` still covers hover\nbehavior. You can **leave unchecked** and note “no test change; optional\nfollow-up to assert `focusTrapProps.preventScrollOnFocus`”, or add a\nsmall test and then **check**. |\n| Cloud / docker allowlist | **Yes** | No `kibana.yml` or plugin config\nkeys changed. |\n| Breaking HTTP API | **Yes** | No public HTTP or plugin contract\nchanges. |\n| Flaky Test Runner | **Yes** | No test files modified; FTR not\napplicable. |\n| Release notes + `release_note:*` label | **You + reviewer** | Include\nthe **Release note** line in the GitHub PR body; apply\n**`release_note:fix`** (or whatever your team uses for bugfixes)—confirm\nagainst\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process).\n|\n| Backport labels | **Reviewer / RM** | Don’t guess—Security / SDH\nusually decides `backport:skip` vs target minors. Ask on PR if unsure. |\n| Risks (RISK_MATRIX) | **Yes** | Low risk; see **Risk** section above.\n|\n\n---\n\n## Kibana PR checklist (paste into GitHub — suggested boxes)\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n— **N/A: no new product copy**\n- [x]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials — **N/A:\nbugfix**\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios — **optional:**\nadd assertion for `preventScrollOnFocus`, or leave unchecked and note in\nPR\n- [x] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n— **N/A**\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations. —\n**N/A: no breaking changes**\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed — **N/A: no tests changed**\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n— **complete when you paste release note + label on open PR**\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels. — **reviewer**\n\n- [x] Risks identified and assessed — see **Risk** section above (also\n[RISK_MATRIX](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\nfor context).","sha":"2a1da0d776ee9a5b980a29b79be60bb209cd7f77"}}]}] BACKPORT-->