### PR TITLE
[Security Solution] Prebuilt rule OOM investigation

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/prebuilt_rules/perform_rule_installation/perform_rule_installation_route.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/prebuilt_rules/perform_rule_installation/perform_rule_installation_route.ts
@@ -7,7 +7,7 @@
 import * as t from 'io-ts';
 import type { RuleResponse } from '../../model';
 import type { AggregatedPrebuiltRuleError } from '../model';
-
+// here
 export const RuleVersionSpecifier = t.exact(
   t.type({
     rule_id: t.string,

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/prebuilt_rules/review_rule_installation/review_rule_installation_route.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/prebuilt_rules/review_rule_installation/review_rule_installation_route.ts
@@ -10,7 +10,7 @@ import type { RuleTagArray } from '../../model';
 import type { RuleResponse } from '../../model/rule_schema';
 import { PrebuiltRuleAssetsFilter } from '../common/prebuilt_rule_assets_filter';
 import { PrebuiltRuleAssetsSort } from '../common/prebuilt_rule_assets_sort';
-
+// here
 export type ReviewRuleInstallationRequestBody = z.infer<typeof ReviewRuleInstallationRequestBody>;
 export const ReviewRuleInstallationRequestBody = z.object({
   /**

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/model/rule_assets/prebuilt_rule_asset.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/model/rule_assets/prebuilt_rule_asset.ts
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-
+// here
 import * as z from '@kbn/zod/v4';
 import {
   RuleSignatureId,


### PR DESCRIPTION
## Summary

This is an investigation for recent 9.4 SNAPSHOT OOM issues during prebuilt rule installation.

The idea is to continue [this investigation work](https://elastic.slack.com/archives/C5UDAFZQU/p1775899569442359?thread_ts=1775823310.262059&cid=C5UDAFZQU) (internal link) and figure out if we can rollback Zod schemas to v3 only for Prebuilt Detection Rules.

It is not intended to be merged.


