### PR TITLE
[Security solution][Attacks] Change "take action items" order to match alerts page items

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attacks_group_take_action_items.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attacks_group_take_action_items.tsx
@@ -201,14 +201,14 @@ export function AttacksGroupTakeActionItems({
     () => ({
       id: 0,
       items: [
-        ...workflowItems,
-        ...runWorkflowItems,
-        ...assignItems,
-        ...tagsItems,
-        ...investigateInTimelineItems,
         ...casesItems,
+        ...workflowItems,
+        ...tagsItems,
+        ...assignItems,
+        ...runWorkflowItems,
         ...viewInAiAssistantItems,
         ...datasetItems,
+        ...investigateInTimelineItems,
       ],
     }),
     [

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/bulk_action_items/use_bulk_attack_case_items.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/bulk_action_items/use_bulk_attack_case_items.test.tsx
@@ -122,7 +122,7 @@ describe('useBulkAttackCaseItems', () => {
       }
     );
 
-    await result.current.items[0]?.onClick?.(
+    await result.current.items[1]?.onClick?.(
       [
         {
           _id: 'attack-1',
@@ -166,7 +166,7 @@ describe('useBulkAttackCaseItems', () => {
       }
     );
 
-    await result.current.items[0]?.onClick?.(
+    await result.current.items[1]?.onClick?.(
       [
         {
           _id: 'attack-1',
@@ -195,7 +195,7 @@ describe('useBulkAttackCaseItems', () => {
       }
     );
 
-    await result.current.items[1]?.onClick?.(
+    await result.current.items[0]?.onClick?.(
       [
         {
           _id: 'attack-1',
@@ -239,7 +239,7 @@ describe('useBulkAttackCaseItems', () => {
       }
     );
 
-    await result.current.items[1]?.onClick?.(
+    await result.current.items[0]?.onClick?.(
       [
         {
           _id: 'attack-1',

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/bulk_action_items/use_bulk_attack_case_items.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/bulk_action_items/use_bulk_attack_case_items.tsx
@@ -121,15 +121,6 @@ export const useBulkAttackCaseItems = ({
       canCreateAndReadCases
         ? [
             {
-              name: ADD_TO_NEW_CASE,
-              label: ADD_TO_NEW_CASE,
-              key: 'attack-add-to-new-case',
-              'data-test-subj': 'attack-add-to-new-case',
-              disableOnQuery: true,
-              disable: isAddToNewCaseDisabled,
-              onClick: onAddToNewCaseClick,
-            },
-            {
               name: ADD_TO_EXISTING_CASE,
               label: ADD_TO_EXISTING_CASE,
               key: 'attack-add-to-existing-case',
@@ -137,6 +128,15 @@ export const useBulkAttackCaseItems = ({
               disableOnQuery: true,
               disable: isAddToExistingCaseDisabled,
               onClick: onAddToExistingCaseClick,
+            },
+            {
+              name: ADD_TO_NEW_CASE,
+              label: ADD_TO_NEW_CASE,
+              key: 'attack-add-to-new-case',
+              'data-test-subj': 'attack-add-to-new-case',
+              disableOnQuery: true,
+              disable: isAddToNewCaseDisabled,
+              onClick: onAddToNewCaseClick,
             },
           ]
         : [],


### PR DESCRIPTION
## Summary

Addresses #262266 

This PR changes the order of the action items in the new attack discovery page to match the order of similar items in the alerts page.

### Before

|alerts|attacks|
|---|---|
| <img width="272" height="530" alt="Screenshot 2026-04-13 at 11 30 16" src="https://github.com/user-attachments/assets/dcc82349-1331-4a37-b23f-3855cfdc9c61" /> | <img width="274" height="462" alt="Screenshot 2026-04-13 at 11 41 37" src="https://github.com/user-attachments/assets/f922c46c-057f-40a8-be5b-0d5a4d7ac584" /> |

### After

|alerts|attacks|
|---|---|
| <img width="272" height="530" alt="Screenshot 2026-04-13 at 11 30 16" src="https://github.com/user-attachments/assets/dcc82349-1331-4a37-b23f-3855cfdc9c61" /> | <img width="285" height="485" alt="Screenshot 2026-04-13 at 11 30 29" src="https://github.com/user-attachments/assets/e701fdfc-3735-47e5-985d-655a2f07cb8e" /> |