### PR TITLE
[AiButton] Fix mask handling with gradient for cross-browser compatibility

### DIFF
--- a/src/platform/packages/shared/shared-ux/ai-components/gradient_styles/use_ai_gradient_styles.ts
+++ b/src/platform/packages/shared/shared-ux/ai-components/gradient_styles/use_ai_gradient_styles.ts
@@ -141,6 +141,10 @@ const plainLabelCss = (euiTheme: UseEuiTheme['euiTheme'], color: string) => css`
 `;
 
 // Uses ::after so it doesn't collide with EUI's ::before interaction overlay.
+// Mask order matters: Firefox treats -webkit-mask as an alias for mask; each
+// mask shorthand resets mask-composite to add. Put -webkit-* first, then
+// mask + mask-composite: exclude last so exclude wins (xor is WebKit-only and
+// ignored in Firefox).
 const outlinedBorderGradientCss = (
   borderGradient: string,
   euiTheme: UseEuiTheme['euiTheme']
@@ -157,10 +161,10 @@ const outlinedBorderGradientCss = (
     padding: 1px;
     background: ${borderGradient};
     pointer-events: none;
-    mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
-    mask-composite: exclude;
     -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
     -webkit-mask-composite: xor;
+    mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+    mask-composite: exclude;
   }
 
   &:disabled::after {


### PR DESCRIPTION
### Summary

This PR resolves [[Bug] Open Elastic Agent button is broken on Firefox](https://github.com/elastic/search-team/issues/13870#issue-4239084553) issue.

On Firefox the button's background style for outlined variant was broken.

<img width="1722" height="448" alt="Screenshot 2026-04-13 at 13 03 26" src="https://github.com/user-attachments/assets/a7f46d9d-1d71-4518-abb1-2601265d79ce" />
<img width="1717" height="453" alt="Screenshot 2026-04-13 at 13 04 00" src="https://github.com/user-attachments/assets/7decdc9d-c2c3-430b-a7b4-40dd94bb8d20" />
<img width="1008" height="443" alt="Screenshot 2026-04-13 at 13 04 42" src="https://github.com/user-attachments/assets/048c3900-bd52-4d8a-84b2-52f57b6afc26" />

The solution was to reorder the CSS mask properties. Firefox was treating the WebKit-prefixed version (-webkit-mask) as an override, which cancelled out the correct behavior and caused the full gradient to fill the button instead of only the border.

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->