### PR TITLE
[9.3] [Cascade] add imperative API to get state changes within the cascade component (#253125)

### DIFF
--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/index.ts
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/index.ts
@@ -12,6 +12,7 @@ export type {
   GroupNode,
   LeafNode,
   DataCascadeProps,
+  DataCascadeImplRef,
   DataCascadeRowProps,
   DataCascadeRowCellProps,
   CascadeRowCellNestedVirtualizationAnchorProps,

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/data_cascade_impl/data_cascade_impl.tsx
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/data_cascade_impl/data_cascade_impl.tsx
@@ -26,6 +26,7 @@ import {
   calculateActiveStickyIndex,
   type VirtualizedCascadeListProps,
 } from '../../lib/core/virtualizer';
+import { useExposePublicApi } from '../../lib/core/api';
 import {
   useRegisterCascadeAccessibilityHelpers,
   useTreeGridContainerARIAAttributes,
@@ -63,6 +64,9 @@ export function DataCascadeImpl<G extends GroupNode, L extends LeafNode>({
   enableRowSelection = false,
   enableStickyGroupHeader = true,
   allowMultipleRowToggle = false,
+  initialScrollOffset,
+  initialRect,
+  cascadeRef,
 }: DataCascadeImplProps<G, L>) {
   const rowElement = Children.only(children);
 
@@ -132,6 +136,11 @@ export function DataCascadeImpl<G extends GroupNode, L extends LeafNode>({
     rowCell: cascadeRowCell,
   });
 
+  const { collectVirtualizerStateChanges } = useExposePublicApi<G, L>(cascadeRef, {
+    rows,
+    enableStickyGroupHeader,
+  });
+
   // persist the virtualizer instance to ref, so that invocations of getVirtualizer will always return the latest instance
   virtualizerInstance.current = useCascadeVirtualizer<G>({
     rows,
@@ -139,6 +148,9 @@ export function DataCascadeImpl<G extends GroupNode, L extends LeafNode>({
     getScrollElement,
     enableStickyGroupHeader,
     estimatedRowHeight: size === 's' ? 32 : size === 'm' ? 40 : 48,
+    onStateChange: collectVirtualizerStateChanges,
+    initialOffset: initialScrollOffset,
+    initialRect,
   });
 
   const {

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/data_cascade_impl/data_cascade_row_cell/cascade_row_cell.tsx
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/data_cascade_impl/data_cascade_row_cell/cascade_row_cell.tsx
@@ -106,26 +106,6 @@ export function CascadeRowCellPrimitive<G extends GroupNode, L extends LeafNode>
   const getScrollElement = useCallback(() => rootVirtualizer.scrollElement, [rootVirtualizer]);
   const getScrollOffset = useCallback(() => rootVirtualizer.scrollOffset ?? 0, [rootVirtualizer]);
 
-  useEffect(
-    () => () => {
-      // ensure that for a row that's been scrolled,
-      // if said row is technically still in view because it's cell is being rendered,
-      // when we are unmounting because the expand action from the cell's row was clicked,
-      // we want to ensure said row is the top most item in our list
-      if (
-        virtualRow?.index &&
-        !rootVirtualizer.isScrolling &&
-        getScrollOffset() > getScrollMargin()
-      ) {
-        rootVirtualizer.scrollToVirtualizedIndex(virtualRow.index, {
-          align: 'start',
-          behavior: 'auto',
-        });
-      }
-    },
-    [getScrollMargin, getScrollOffset, rootVirtualizer, virtualRow?.index]
-  );
-
   const memoizedChild = useMemo(() => {
     return React.createElement(children, {
       data: leafData,

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/data_cascade_impl/types.ts
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/data_cascade_impl/types.ts
@@ -13,6 +13,7 @@ import type { Table, CellContext, Row } from '@tanstack/react-table';
 import type { VirtualItem } from '@tanstack/react-virtual';
 import type { GroupNode, LeafNode } from '../../store_provider';
 import type { CascadeVirtualizerProps, useCascadeVirtualizer } from '../../lib/core/virtualizer';
+import type { DataCascadeImplRef } from '../../lib/core/api';
 import type { SelectionDropdownProps } from './data_cascade_header/group_selection_combobox/selection_dropdown';
 
 /**
@@ -246,7 +247,16 @@ interface DataCascadeImplBaseProps<G extends GroupNode, L extends LeafNode>
    * Whether to allow multiple group rows to be expanded at the same time, default is false.
    */
   allowMultipleRowToggle?: boolean;
+  /**
+   * Initial vertical scroll position in pixels. When set, the list and scroll container start at this offset.
+   */
+  initialScrollOffset?: number;
+  /**
+   * Initial scroll rectangle dimensions. When set, the list and scroll container start at this size.
+   */
+  initialRect?: { width: number; height: number };
   children: React.ReactElement<DataCascadeRowProps<G, L>>;
+  cascadeRef: React.ForwardedRef<DataCascadeImplRef<G, L>>;
 }
 
 export type DataCascadeImplProps<

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/index.tsx
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/index.tsx
@@ -7,26 +7,104 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React, { type ComponentProps } from 'react';
+import React, { forwardRef, useMemo, useRef, type ComponentProps, type ForwardedRef } from 'react';
 import { DataCascadeImpl, type DataCascadeImplProps } from './data_cascade_impl';
+import type { DataCascadeImplRef } from '../lib/core/api';
 import { DataCascadeProvider, type GroupNode, type LeafNode } from '../store_provider';
 
-export type { GroupNode, LeafNode, DataCascadeImplProps as DataCascadeProps };
+export type { GroupNode, LeafNode, DataCascadeImplProps as DataCascadeProps, DataCascadeImplRef };
+export type { DataCascadeUISnapshot } from '../lib/core/api';
 export { DataCascadeRow, DataCascadeRowCell } from './data_cascade_impl';
+
 export type {
   DataCascadeRowProps,
   DataCascadeRowCellProps,
   CascadeRowCellNestedVirtualizationAnchorProps,
 } from './data_cascade_impl';
 
-export function DataCascade<G extends GroupNode = GroupNode, L extends LeafNode = LeafNode>({
-  cascadeGroups,
-  initialGroupColumn,
-  ...props
-}: DataCascadeImplProps<G, L> & ComponentProps<typeof DataCascadeProvider>) {
-  return (
-    <DataCascadeProvider cascadeGroups={cascadeGroups} initialGroupColumn={initialGroupColumn}>
-      <DataCascadeImpl<G, L> {...props} />
-    </DataCascadeProvider>
+type DataCascadeProviderProps = ComponentProps<typeof DataCascadeProvider>;
+
+export type DataCascadeComponent = <G extends GroupNode = GroupNode, L extends LeafNode = LeafNode>(
+  props: Omit<DataCascadeImplProps<G, L>, 'cascadeRef'> &
+    DataCascadeProviderProps & { ref?: React.Ref<DataCascadeImplRef<G, L>> }
+) => React.ReactElement;
+
+/**
+ * Public data cascade component. Forwards the ref to DataCascadeImpl so consumers
+ * receive the imperative handle on the ref.
+ */
+export const DataCascade = forwardRef(function DataCascadeWithProvider<
+  G extends GroupNode,
+  L extends LeafNode
+>(
+  {
+    cascadeGroups,
+    initialGroupColumn,
+    customTableHeader,
+    tableTitleSlot,
+    initialTableState,
+    initialScrollOffset,
+    initialRect,
+    onCascadeGroupingChange,
+    size,
+    enableStickyGroupHeader,
+    allowMultipleRowToggle,
+    children,
+    enableRowSelection,
+    data,
+    overscan,
+  }: Omit<DataCascadeImplProps<G, L>, 'cascadeRef'> & DataCascadeProviderProps,
+  ref: ForwardedRef<DataCascadeImplRef<G, L>>
+) {
+  // create a stable reference for the component initializer props
+  const initialTableStateRef = useRef(initialTableState);
+  const initialScrollOffsetRef = useRef(initialScrollOffset);
+  const initialRectRef = useRef(initialRect);
+
+  const cascadeImplProps = useMemo<DataCascadeImplProps<G, L>>(() => {
+    const props = {
+      onCascadeGroupingChange,
+      size,
+      enableStickyGroupHeader,
+      allowMultipleRowToggle,
+      enableRowSelection,
+      data,
+      overscan,
+      children,
+      cascadeRef: ref,
+    };
+
+    return customTableHeader
+      ? { ...props, customTableHeader }
+      : { ...props, tableTitleSlot: tableTitleSlot! };
+  }, [
+    allowMultipleRowToggle,
+    children,
+    customTableHeader,
+    data,
+    enableRowSelection,
+    overscan,
+    onCascadeGroupingChange,
+    size,
+    enableStickyGroupHeader,
+    tableTitleSlot,
+    ref,
+  ]);
+
+  return useMemo(
+    () => (
+      <DataCascadeProvider<G, L>
+        cascadeGroups={cascadeGroups}
+        initialGroupColumn={initialGroupColumn}
+        initialTableState={initialTableStateRef.current}
+      >
+        <DataCascadeImpl<G, L>
+          {...cascadeImplProps}
+          initialScrollOffset={initialScrollOffsetRef.current}
+          initialRect={initialRectRef.current}
+        />
+      </DataCascadeProvider>
+    ),
+    [cascadeGroups, cascadeImplProps, initialGroupColumn]
   );
-}
+}) as DataCascadeComponent;

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/lib/core/api/index.test.tsx
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/lib/core/api/index.test.tsx
@@ -1,0 +1,191 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React, { useSyncExternalStore } from 'react';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useExposePublicApi, type DataCascadeImplRef } from '.';
+import { DataCascadeProvider, type GroupNode, type LeafNode } from '../../../store_provider';
+import type { UseVirtualizerReturnType } from '../virtualizer';
+
+describe('useExposePublicApi', () => {
+  it('should return the correct value', () => {
+    const mockRefObject: React.RefObject<DataCascadeImplRef<GroupNode, LeafNode>> = {
+      current: null,
+    };
+
+    const { result } = renderHook(
+      () => useExposePublicApi(mockRefObject, { rows: [], enableStickyGroupHeader: false }),
+      {
+        wrapper: ({ children }) => (
+          <DataCascadeProvider cascadeGroups={[]}>{children}</DataCascadeProvider>
+        ),
+      }
+    );
+
+    expect(result.current.collectVirtualizerStateChanges).toBeDefined();
+    // ref should be populated with public API method after mount
+    expect(mockRefObject.current?.getUISnapshotStore).toBeDefined();
+  });
+
+  describe('getUISnapshotStore', () => {
+    it('should return a store snapshot with the correct initial state', () => {
+      const mockRefObject: React.RefObject<DataCascadeImplRef<GroupNode, LeafNode>> = {
+        current: null,
+      };
+
+      const { result } = renderHook(
+        () => useExposePublicApi(mockRefObject, { rows: [], enableStickyGroupHeader: false }),
+        {
+          wrapper: ({ children }) => (
+            <DataCascadeProvider cascadeGroups={[]}>{children}</DataCascadeProvider>
+          ),
+        }
+      );
+
+      expect(result.current.collectVirtualizerStateChanges).toBeDefined();
+      expect(mockRefObject.current?.getUISnapshotStore).toBeDefined();
+
+      const snapshotStore = mockRefObject.current!.getUISnapshotStore();
+
+      expect(snapshotStore!.getSnapshot()).toEqual({
+        scrollOffset: 0,
+        range: null,
+        isScrolling: false,
+        activeStickyIndex: null,
+        totalRowCount: 0,
+        totalSize: 0,
+        expanded: {},
+        rowSelection: {},
+        scrollRect: { width: 0, height: 0 },
+      });
+    });
+
+    it('changes on the virtualizer instance should notify subscribers, and reflect changes in the store snapshot', async () => {
+      const mockRefObject: React.RefObject<DataCascadeImplRef<GroupNode, LeafNode>> = {
+        current: null,
+      };
+
+      const { result } = renderHook(
+        () => useExposePublicApi(mockRefObject, { rows: [], enableStickyGroupHeader: false }),
+        {
+          wrapper: ({ children }) => (
+            <DataCascadeProvider cascadeGroups={[]}>{children}</DataCascadeProvider>
+          ),
+        }
+      );
+
+      expect(result.current.collectVirtualizerStateChanges).toBeDefined();
+      expect(mockRefObject.current?.getUISnapshotStore).toBeDefined();
+
+      const uiSnapshotStore = mockRefObject.current!.getUISnapshotStore();
+
+      const subscriptionSpy = jest.fn();
+
+      const unsubscribe = uiSnapshotStore!.subscribe(subscriptionSpy);
+
+      const virtualizerInstance = {
+        range: { startIndex: 0, endIndex: 10 },
+        scrollOffset: 100,
+        isScrolling: false,
+        // it's fine to cast to unknown
+        // because we only need a minimal implementation of the virtualizer instance for the test
+      } as unknown as UseVirtualizerReturnType;
+
+      // simulate changes in the virtualizer instance
+      act(() => {
+        result.current.collectVirtualizerStateChanges(virtualizerInstance);
+      });
+
+      await waitFor(() => {
+        // wait for the debounce to complete
+        expect(subscriptionSpy).toHaveBeenCalled();
+      });
+
+      const updatedUISnapshot = uiSnapshotStore!.getSnapshot();
+
+      expect(updatedUISnapshot).toHaveProperty('scrollOffset', virtualizerInstance.scrollOffset);
+      expect(updatedUISnapshot).toHaveProperty('range', virtualizerInstance.range);
+      expect(updatedUISnapshot).toHaveProperty('isScrolling', virtualizerInstance.isScrolling);
+
+      // these properties did not change because we did not provide updates for them
+      expect(updatedUISnapshot).toHaveProperty('activeStickyIndex', null);
+      expect(updatedUISnapshot).toHaveProperty('totalRowCount', 0);
+      expect(updatedUISnapshot).toHaveProperty('totalSize', 0);
+      expect(updatedUISnapshot).toHaveProperty('expanded', {});
+      expect(updatedUISnapshot).toHaveProperty('rowSelection', {});
+      expect(updatedUISnapshot).toHaveProperty('scrollRect', { width: 0, height: 0 });
+
+      unsubscribe();
+    });
+
+    it('should be compatible with the useSyncExternalStore hook', async () => {
+      const mockRefObject: React.RefObject<DataCascadeImplRef<GroupNode, LeafNode>> = {
+        current: null,
+      };
+
+      const { result } = renderHook(
+        () => useExposePublicApi(mockRefObject, { rows: [], enableStickyGroupHeader: false }),
+        {
+          wrapper: ({ children }) => (
+            <DataCascadeProvider cascadeGroups={[]}>{children}</DataCascadeProvider>
+          ),
+        }
+      );
+
+      expect(result.current.collectVirtualizerStateChanges).toBeDefined();
+      expect(mockRefObject.current?.getUISnapshotStore).toBeDefined();
+
+      const snapshotStore = mockRefObject.current!.getUISnapshotStore();
+
+      const { result: externalSyncResult } = renderHook(() =>
+        useSyncExternalStore(
+          snapshotStore!.subscribe,
+          snapshotStore!.getSnapshot,
+          snapshotStore!.getServerSnapshot
+        )
+      );
+
+      expect(externalSyncResult.current).toEqual({
+        scrollOffset: 0,
+        range: null,
+        isScrolling: false,
+        activeStickyIndex: null,
+        totalRowCount: 0,
+        totalSize: 0,
+        expanded: {},
+        rowSelection: {},
+        scrollRect: { width: 0, height: 0 },
+      });
+
+      act(() => {
+        result.current.collectVirtualizerStateChanges({
+          range: { startIndex: 0, endIndex: 10 },
+          scrollOffset: 100,
+          isScrolling: false,
+          scrollRect: { width: 0, height: 0 },
+          getTotalSize: () => 0,
+        } as unknown as UseVirtualizerReturnType);
+      });
+
+      await waitFor(() => {
+        expect(externalSyncResult.current).toEqual({
+          scrollOffset: 100,
+          range: { startIndex: 0, endIndex: 10 },
+          isScrolling: false,
+          activeStickyIndex: null,
+          totalRowCount: 0,
+          totalSize: 0,
+          expanded: {},
+          rowSelection: {},
+          scrollRect: { width: 0, height: 0 },
+        });
+      });
+    });
+  });
+});

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/lib/core/api/index.ts
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/lib/core/api/index.ts
@@ -1,0 +1,230 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { Row } from '@tanstack/react-table';
+import { debounce } from 'lodash';
+import { useCallback, useLayoutEffect, useImperativeHandle, useMemo, useRef } from 'react';
+import {
+  useDataCascadeState,
+  type GroupNode,
+  type LeafNode,
+  type IStoreState,
+} from '../../../store_provider';
+import { calculateActiveStickyIndex, type UseVirtualizerReturnType } from '../virtualizer';
+
+/**
+ * Snapshot of data cascade ui state for use with useSyncExternalStore.
+ * Includes virtualizer-derived state and specific table state.
+ */
+export interface DataCascadeUISnapshot<
+  G extends GroupNode = GroupNode,
+  L extends LeafNode = LeafNode
+> extends Pick<IStoreState<G, L>['table'], 'expanded' | 'rowSelection'> {
+  scrollRect: { width: number; height: number };
+  scrollOffset: number;
+  range: { startIndex: number; endIndex: number } | null;
+  isScrolling: boolean;
+  activeStickyIndex: number | null;
+  totalRowCount: number;
+  totalSize: number;
+}
+
+/**
+ * useSyncExternalStore-compatible store for data cascade ui state.
+ */
+export interface DataCascadeUISnapshotStore<G extends GroupNode, L extends LeafNode> {
+  subscribe(onStoreChange: () => void): () => void;
+  getSnapshot(): DataCascadeUISnapshot<G, L>;
+  getServerSnapshot(): DataCascadeUISnapshot<G, L>;
+}
+
+/**
+ * Options for useExposePublicApi. Supplies table/UI state needed to build the snapshot.
+ */
+export interface UseExposePublicApiOptions<G extends GroupNode> {
+  rows: Row<G>[];
+  enableStickyGroupHeader: boolean;
+}
+
+/**
+ * Return value of useExposePublicApi.
+ */
+export interface UseExposePublicApiReturnValue {
+  /** Updates the store snapshot from virtualizer instance changes */
+  collectVirtualizerStateChanges: (instance: UseVirtualizerReturnType | undefined) => void;
+}
+
+const createDefaultUISnapshot = <G extends GroupNode, L extends LeafNode>(): DataCascadeUISnapshot<
+  G,
+  L
+> => ({
+  scrollOffset: 0,
+  scrollRect: { width: 0, height: 0 },
+  range: null,
+  isScrolling: false,
+  activeStickyIndex: null,
+  totalRowCount: 0,
+  totalSize: 0,
+  expanded: {},
+  rowSelection: {},
+});
+
+/**
+ * Definition of the public API ref for the data cascade component.
+ */
+export interface DataCascadeImplRef<G extends GroupNode, L extends LeafNode> {
+  /**
+   * Returns helpers to access a minimal readonly state of the data cascade component.
+   * This can be used as-is or put together leveraging useSyncExternalStore to create a more reactive
+   * component state.
+   *
+   * @example
+   * ```ts
+   * export function useDataCascadeSnapshot(ref: React.RefObject<DataCascadeImplRef | null>): DataCascadeSnapshot {
+   *   return useSyncExternalStore(
+   *     (onStoreChange) => ref.current?.getUISnapshotStore()?.subscribe(onStoreChange) ?? (() => {}),
+   *     () => ref.current?.getUISnapshotStore()?.getSnapshot() ?? DEFAULT_SNAPSHOT,
+   *     () => ref.current?.getUISnapshotStore()?.getServerSnapshot() ?? DEFAULT_SNAPSHOT
+   *   );
+   * }
+   * ```
+   */
+  getUISnapshotStore: () => DataCascadeUISnapshotStore<G, L> | null;
+}
+
+/**
+ * Hook that owns the public API ref: aggregates state + virtualizer into a snapshot store,
+ * updates the store when inputs change, and exposes getStateStore via useImperativeHandle.
+ * Call from the cascade impl with the ref and options; the ref will be populated after mount.
+ */
+export function useExposePublicApi<G extends GroupNode, L extends LeafNode>(
+  ref: React.Ref<DataCascadeImplRef<G, L>>,
+  options: UseExposePublicApiOptions<G>
+): UseExposePublicApiReturnValue {
+  // Use a stable handle object and only update its method.
+  const handleRef = useRef<DataCascadeImplRef<G, L>>({
+    getUISnapshotStore: () => null,
+  });
+
+  const { rows } = options;
+  const state = useDataCascadeState<G, L>();
+
+  const expanded = useMemo<DataCascadeUISnapshot<G, L>['expanded']>(
+    () =>
+      typeof state.table.expanded === 'object' && state.table.expanded !== null
+        ? state.table.expanded
+        : {},
+    [state.table.expanded]
+  );
+
+  const rowSelection = useMemo<DataCascadeUISnapshot<G, L>['rowSelection']>(
+    () => state.table.rowSelection ?? {},
+    [state.table.rowSelection]
+  );
+
+  const optionsRef = useRef(options);
+  const latestStateRef = useRef({ expanded, rowSelection });
+  optionsRef.current = options;
+  latestStateRef.current = { expanded, rowSelection };
+
+  const storeRef = useRef<{
+    listeners: Set<() => void>;
+    snapshot: DataCascadeUISnapshot<G, L>;
+  }>({
+    listeners: new Set(),
+    snapshot: createDefaultUISnapshot(),
+  });
+
+  const subscribe = useCallback((onUISnapshotChange: () => void) => {
+    storeRef.current.listeners.add(onUISnapshotChange);
+    return () => {
+      storeRef.current.listeners.delete(onUISnapshotChange);
+    };
+  }, []);
+
+  const getSnapshot = useCallback((): DataCascadeUISnapshot<G, L> => storeRef.current.snapshot, []);
+  const getServerSnapshot = useCallback(
+    (): DataCascadeUISnapshot<G, L> => storeRef.current.snapshot,
+    []
+  );
+
+  /** Notifies all subscribed listeners that the store snapshot may have changed. */
+  const notifyListeners = useMemo(
+    () =>
+      debounce(() => {
+        const opts = optionsRef.current;
+        const { expanded: exp, rowSelection: sel } = latestStateRef.current;
+
+        storeRef.current.snapshot = {
+          ...storeRef.current.snapshot,
+          totalRowCount: opts.rows.length,
+          expanded: exp,
+          rowSelection: sel,
+        };
+
+        storeRef.current.listeners.forEach((listener) => listener());
+      }, 100),
+    []
+  );
+
+  /** scans updates from virtualizer instance and updates the store snapshot. */
+  const collectVirtualizerStateChanges = useCallback(
+    (instance: UseVirtualizerReturnType | undefined) => {
+      const opts = optionsRef.current;
+
+      // if the virtualizer instance is not null, update the store snapshot
+      if (instance != null) {
+        const range =
+          instance.range != null
+            ? { startIndex: instance.range.startIndex, endIndex: instance.range.endIndex }
+            : null;
+        const activeStickyIndex = calculateActiveStickyIndex(
+          opts.rows,
+          range?.startIndex ?? 0,
+          opts.enableStickyGroupHeader
+        );
+
+        storeRef.current.snapshot = {
+          ...storeRef.current.snapshot,
+          scrollOffset: instance.scrollOffset ?? 0,
+          range,
+          isScrolling: instance.isScrolling ?? false,
+          activeStickyIndex,
+          scrollRect: instance.scrollRect ?? { width: 0, height: 0 },
+          totalSize: instance.getTotalSize ? instance.getTotalSize() : 0,
+        };
+
+        notifyListeners();
+      }
+    },
+    [notifyListeners]
+  );
+
+  useLayoutEffect(() => {
+    notifyListeners();
+  }, [notifyListeners, expanded, rowSelection, rows.length]);
+
+  const getStateStore = useCallback(
+    (): DataCascadeUISnapshotStore<G, L> => ({
+      subscribe,
+      getSnapshot,
+      getServerSnapshot,
+    }),
+    [subscribe, getSnapshot, getServerSnapshot]
+  );
+
+  handleRef.current = {
+    getUISnapshotStore: getStateStore,
+  };
+
+  // Populate the forwarded ref with the stable handle after mount
+  useImperativeHandle(ref, () => handleRef.current, []);
+
+  return { collectVirtualizerStateChanges };
+}

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/lib/core/virtualizer/index.tsx
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/lib/core/virtualizer/index.tsx
@@ -13,7 +13,57 @@ import { useVirtualizer, defaultRangeExtractor, type VirtualItem } from '@tansta
 import type { GroupNode } from '../../../store_provider';
 
 type UseVirtualizerOptions = Parameters<typeof useVirtualizer>[0];
-type UseVirtualizerReturnType = ReturnType<typeof useVirtualizer>;
+export type UseVirtualizerReturnType = ReturnType<typeof useVirtualizer>;
+
+export interface CascadeVirtualizerProps<G extends GroupNode>
+  extends Pick<
+    UseVirtualizerOptions,
+    'getScrollElement' | 'overscan' | 'initialOffset' | 'initialRect'
+  > {
+  rows: Row<G>[];
+  /**
+   * setting a value of true causes the active group root row
+   * to stick right under the header
+   */
+  enableStickyGroupHeader: boolean;
+  estimatedRowHeight?: number;
+  /**
+   * Called whenever the virtualizer updates (scroll, range, size, etc.).
+   * Used to conduit values into external state (e.g. public API store).
+   */
+  onStateChange?: (instance: UseVirtualizerReturnType) => void;
+}
+
+export interface UseVirtualizedRowScrollStateStoreOptions {
+  /**
+   * Function to get the parent virtualizer instance
+   */
+  getVirtualizer: () => ReturnType<typeof useCascadeVirtualizer>;
+  /**
+   * The index of the current row in the parent virtualizer
+   */
+  rowIndex: number;
+}
+
+export interface VirtualizedRowScrollState {
+  scrollOffset: number;
+  scrollMargin: number;
+}
+
+export interface VirtualizedCascadeListProps<G extends GroupNode>
+  extends Pick<
+    CascadeVirtualizerReturnValue,
+    'virtualizedRowComputedTranslateValue' | 'getVirtualItems'
+  > {
+  rows: Row<G>[];
+  activeStickyIndex: number | null;
+  listItemRenderer: (props: {
+    isActiveSticky: boolean;
+    virtualItem: VirtualItem;
+    virtualRowStyle: React.CSSProperties;
+    row: Row<G>;
+  }) => React.ReactNode;
+}
 
 /**
  * Calculates the active sticky index from the current visible range.
@@ -127,6 +177,9 @@ export const useCascadeVirtualizer = <G extends GroupNode>({
   estimatedRowHeight = 0,
   rows,
   getScrollElement,
+  onStateChange,
+  initialOffset,
+  initialRect,
 }: CascadeVirtualizerProps<G>): CascadeVirtualizerReturnValue => {
   const virtualizedRowsSizeCacheRef = useRef<Map<number, number>>(new Map());
   const rangeExtractor = useCascadeVirtualizerRangeExtractor<G>({
@@ -146,15 +199,27 @@ export const useCascadeVirtualizer = <G extends GroupNode>({
       getScrollElement,
       overscan,
       rangeExtractor,
-      useAnimationFrameWithResizeObserver: true,
+      initialOffset,
+      initialRect,
       onChange: (rowVirtualizerInstance) => {
         // @ts-expect-error -- the itemsSizeCache property does exist,
         // but it not included in the type definition because it is marked as a private property,
         // see {@link https://github.com/TanStack/virtual/blob/v3.13.2/packages/virtual-core/src/index.ts#L360}
         virtualizedRowsSizeCacheRef.current = rowVirtualizerInstance.itemSizeCache;
+        // propagate virtualizer state changes
+        onStateChange?.(rowVirtualizerInstance);
       },
     }),
-    [estimatedRowHeight, getScrollElement, overscan, rangeExtractor, rows.length]
+    [
+      estimatedRowHeight,
+      getScrollElement,
+      initialOffset,
+      initialRect,
+      overscan,
+      rangeExtractor,
+      rows.length,
+      onStateChange,
+    ]
   );
 
   const virtualizerImpl = useVirtualizer(virtualizerOptions);

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/store_provider/index.tsx
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/store_provider/index.tsx
@@ -20,9 +20,14 @@ import {
 } from './reducers';
 export type { GroupNode, LeafNode, IStoreState } from './reducers';
 
-interface IDataCascadeProviderProps {
+export interface IDataCascadeProviderProps {
   initialGroupColumn?: string[];
   cascadeGroups: string[];
+  /**
+   * Properties to set the initial table state on mount.
+   * Only expanded and rowSelection properties are supported for now.
+   */
+  initialTableState?: Pick<Partial<TableState>, 'expanded' | 'rowSelection'>;
 }
 
 interface IStoreContext<G extends GroupNode, L extends LeafNode> {
@@ -69,6 +74,7 @@ export function useCascadeLeafNode<G extends GroupNode, L extends LeafNode>(cach
 export function DataCascadeProvider<G extends GroupNode, L extends LeafNode>({
   cascadeGroups,
   initialGroupColumn,
+  initialTableState,
   children,
 }: PropsWithChildren<IDataCascadeProviderProps>) {
   const StoreContext = createStoreContext<G, L>();
@@ -81,7 +87,7 @@ export function DataCascadeProvider<G extends GroupNode, L extends LeafNode>({
 
   const { state, actions } = useCreateStore({
     initialState: {
-      table: {} as TableState,
+      table: (initialTableState ?? {}) as TableState,
       groupNodes: [] as G[],
       leafNodes: new Map<string, L[]>(), // TODO: consider externalizing this so the consumer might provide their own external cache
       groupByColumns: cascadeGroups,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Cascade] add imperative API to get state changes within the cascade component (#253125)](https://github.com/elastic/kibana/pull/253125)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Eyo O. Eyo","email":"7893459+eokoneyo@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-02-20T14:02:44Z","message":"[Cascade] add imperative API to get state changes within the cascade component (#253125)\n\n## Summary\n\n# Data Cascade – API and state restoration\n\nThis PR adds support for restoring the cascade to a previous UI state:\nref-based snapshot store, generic ref/snapshot types, and initial\nscroll/rect/table state props.\n\n---\n\n## Public API\n\n### Ref and imperative handle\n\n- **`DataCascade`** accepts a **ref** (via `forwardRef`), typed as\n**`DataCascadeImplRef<G, L>`** (generic over group and leaf nodes).\n- **`DataCascadeImplRef<G, L>`** exposes **`getUISnapshotStore():\nDataCascadeUISnapshotStore<G, L> | null`**.\n- **`DataCascadeUISnapshotStore<G, L>`** is a\n`useSyncExternalStore`-compatible store with\n**`subscribe(onStoreChange)`**, **`getSnapshot()`**, and\n**`getServerSnapshot()`**, all operating on **`DataCascadeUISnapshot<G,\nL>`**.\n\n### Snapshot shape\n\n**`DataCascadeUISnapshot<G, L>`** extends table state (`expanded`,\n`rowSelection`) and includes virtualizer-derived fields:\n\n- **`scrollRect`** – `{ width: number; height: number }` (scroll\ncontainer size)\n- **`scrollOffset`** – number\n- **`range`** – `{ startIndex: number; endIndex: number } | null`\n- **`isScrolling`** – boolean\n- **`activeStickyIndex`** – number | null\n- **`totalRowCount`** – number\n- **`totalSize`** – number\n- **`expanded`** / **`rowSelection`** – from table state\n\nStore updates are **debounced (100ms)**.\n\n### Internal API\n\n- **`useExposePublicApi(ref, options)`** returns\n**`collectVirtualizerStateChanges(instance)`**, which updates the UI\nsnapshot from the virtualizer (including `scrollRect`) and triggers\nstore listeners. Ref is passed into the impl as the **`cascadeRef`**\nprop.\n\n---\n\n## New props\n\n### On `DataCascade` / `DataCascadeProvider`\n\n**`initialTableState?: Pick<Partial<TableState>, 'expanded' |\n'rowSelection'>`**\n\n- **Where:** **`DataCascadeProvider`** (used by **`DataCascade`**).\n- **Meaning:** Initial table state on mount. Supports **`expanded`** and\n**`rowSelection`**.\n- **Semantics:** For a nested row to be visible, the full path from root\nto that row must be expanded (e.g. set the right ids in `expanded`).\nOnly affects initial state; later behavior still follows\n`allowMultipleRowToggle` and user interaction.\n- **Usage:** “Open this path on load” or “Restore expansion/selection\nfrom a saved snapshot” (e.g. from URL or persisted\n`DataCascadeUISnapshot`).\n\n**`initialScrollOffset?: number`**\n\n- **Where:** **`DataCascade`** (passed through to **`DataCascadeImpl`**\nand the cascade virtualizer).\n- **Meaning:** Initial vertical scroll position in **pixels**. When set,\nthe list and scroll container start at this offset on mount.\n- **Semantics:** Passed to the virtualizer as TanStack Virtual’s\n**`initialOffset`**. Intended to be used with a sync of the scroll\ncontainer’s `scrollTop` (or equivalent) so DOM and virtualizer stay in\nsync on first paint.\n- **Usage:** “Restore scroll position on load” (e.g. from\n`DataCascadeUISnapshot.scrollOffset` or URL).\n\n**`initialRect?: { width: number; height: number }`**\n\n- **Where:** **`DataCascade`** (passed through to **`DataCascadeImpl`**\nand the cascade virtualizer).\n- **Meaning:** Initial scroll container dimensions. When set, the\nvirtualizer uses this size before the scroll element is measured.\n- **Semantics:** Passed to the virtualizer as **`initialRect`**\n(TanStack Virtual option). Helps avoid layout jump when restoring a\nsnapshot that includes **`scrollRect`**.\n- **Usage:** “Restore scroll container size on load” (e.g. from\n`DataCascadeUISnapshot.scrollRect`).\n\n**Note:** `DataCascade` uses refs for **`initialTableState`**,\n**`initialScrollOffset`**, and **`initialRect`** so they are read only\non first render and do not force re-mounts when the parent re-renders.\n\n---\n\n## Summary for reviewers\n\n- **Ref:** Optional. When passed, consumers use\n**`ref.current?.getUISnapshotStore()`** and the returned\n**`DataCascadeUISnapshotStore<G, L>`** for subscription and snapshots\n(**`DataCascadeUISnapshot<G, L>`**).\n- **Generics:** **`DataCascadeImplRef<G, L>`**,\n**`DataCascadeUISnapshot<G, L>`**, and **`DataCascadeUISnapshotStore<G,\nL>`** are generic over group and leaf node types.\n- **Snapshot:** Includes **`scrollRect`** (width/height) in addition to\nscrollOffset, range, isScrolling, activeStickyIndex, totalRowCount,\ntotalSize, expanded, and rowSelection. Updates are debounced (100ms).\n- **Initial state:** **`initialTableState`** seeds expanded/rowSelection\non mount. **`initialScrollOffset`** and **`initialRect`** seed the\nvirtualizer (and optionally the scroll container) so scroll position and\nsize can be restored from a persisted snapshot.\n- **Breaking changes:** None; ref and new props are additive.\n\n### Example: subscribe and restore\n\n```ts\nconst subscriptionRef = useRef<() => void)>(null);\n\nconst acquireSnapshotSubscription = useCallback((_ref) => {\n  if (!subscriptionRef.current) {\n    subscriptionRef.current = _ref?.getUISnapshotStore()?.subscribe(() => {\n      const snapshot = store.getSnapshot();\n\t  console.log('snapshot changed:: %o \\n', { snapshot });\n      // Persist snapshot (e.g. scrollOffset, scrollRect, expanded, rowSelection)\n      // so you can pass them back as initialScrollOffset, initialRect, initialTableState.\n    });\n  }\n}, []);\n\nuseEffect(() => () => {\n  if (subscriptionRef.current) {\n   subscriptionRef.current()\n  }\n}, []);\n\nconst initialTableState = useMemo(() => ({\n    expanded: savedSnapshot?.expanded,\n    rowSelection: savedSnapshot?.rowSelection,\n}), []);\n\n// Restore on remount\n<DataCascade\n  ref={acquireSnapshotSubscription}\n  data={data}\n  initialScrollOffset={savedSnapshot?.scrollOffset}\n  initialRect={savedSnapshot?.scrollRect}\n  initialTableState={initialTableState}\n  cascadeGroups={cascadeGroups}\n  initialGroupColumn={initialGroupColumn}\n  tableTitleSlot={...}\n  ...\n/>\n```\n\n---\n\n_P.S. it's also possible to use the returned `getUISnapshotStore` with\nthe react primitive [`useSyncExternalStore`\n](https://react.dev/reference/react/useSyncExternalStore) ask your\nfavorite LLM about this._\n\n","sha":"e490f3d41b196d3f9e2e1d666e7da9034842318d","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","Team:SharedUX","v9.4.0","(do not use) backport:9.3"],"title":"[Cascade] add imperative API to get state changes within the cascade component","number":253125,"url":"https://github.com/elastic/kibana/pull/253125","mergeCommit":{"message":"[Cascade] add imperative API to get state changes within the cascade component (#253125)\n\n## Summary\n\n# Data Cascade – API and state restoration\n\nThis PR adds support for restoring the cascade to a previous UI state:\nref-based snapshot store, generic ref/snapshot types, and initial\nscroll/rect/table state props.\n\n---\n\n## Public API\n\n### Ref and imperative handle\n\n- **`DataCascade`** accepts a **ref** (via `forwardRef`), typed as\n**`DataCascadeImplRef<G, L>`** (generic over group and leaf nodes).\n- **`DataCascadeImplRef<G, L>`** exposes **`getUISnapshotStore():\nDataCascadeUISnapshotStore<G, L> | null`**.\n- **`DataCascadeUISnapshotStore<G, L>`** is a\n`useSyncExternalStore`-compatible store with\n**`subscribe(onStoreChange)`**, **`getSnapshot()`**, and\n**`getServerSnapshot()`**, all operating on **`DataCascadeUISnapshot<G,\nL>`**.\n\n### Snapshot shape\n\n**`DataCascadeUISnapshot<G, L>`** extends table state (`expanded`,\n`rowSelection`) and includes virtualizer-derived fields:\n\n- **`scrollRect`** – `{ width: number; height: number }` (scroll\ncontainer size)\n- **`scrollOffset`** – number\n- **`range`** – `{ startIndex: number; endIndex: number } | null`\n- **`isScrolling`** – boolean\n- **`activeStickyIndex`** – number | null\n- **`totalRowCount`** – number\n- **`totalSize`** – number\n- **`expanded`** / **`rowSelection`** – from table state\n\nStore updates are **debounced (100ms)**.\n\n### Internal API\n\n- **`useExposePublicApi(ref, options)`** returns\n**`collectVirtualizerStateChanges(instance)`**, which updates the UI\nsnapshot from the virtualizer (including `scrollRect`) and triggers\nstore listeners. Ref is passed into the impl as the **`cascadeRef`**\nprop.\n\n---\n\n## New props\n\n### On `DataCascade` / `DataCascadeProvider`\n\n**`initialTableState?: Pick<Partial<TableState>, 'expanded' |\n'rowSelection'>`**\n\n- **Where:** **`DataCascadeProvider`** (used by **`DataCascade`**).\n- **Meaning:** Initial table state on mount. Supports **`expanded`** and\n**`rowSelection`**.\n- **Semantics:** For a nested row to be visible, the full path from root\nto that row must be expanded (e.g. set the right ids in `expanded`).\nOnly affects initial state; later behavior still follows\n`allowMultipleRowToggle` and user interaction.\n- **Usage:** “Open this path on load” or “Restore expansion/selection\nfrom a saved snapshot” (e.g. from URL or persisted\n`DataCascadeUISnapshot`).\n\n**`initialScrollOffset?: number`**\n\n- **Where:** **`DataCascade`** (passed through to **`DataCascadeImpl`**\nand the cascade virtualizer).\n- **Meaning:** Initial vertical scroll position in **pixels**. When set,\nthe list and scroll container start at this offset on mount.\n- **Semantics:** Passed to the virtualizer as TanStack Virtual’s\n**`initialOffset`**. Intended to be used with a sync of the scroll\ncontainer’s `scrollTop` (or equivalent) so DOM and virtualizer stay in\nsync on first paint.\n- **Usage:** “Restore scroll position on load” (e.g. from\n`DataCascadeUISnapshot.scrollOffset` or URL).\n\n**`initialRect?: { width: number; height: number }`**\n\n- **Where:** **`DataCascade`** (passed through to **`DataCascadeImpl`**\nand the cascade virtualizer).\n- **Meaning:** Initial scroll container dimensions. When set, the\nvirtualizer uses this size before the scroll element is measured.\n- **Semantics:** Passed to the virtualizer as **`initialRect`**\n(TanStack Virtual option). Helps avoid layout jump when restoring a\nsnapshot that includes **`scrollRect`**.\n- **Usage:** “Restore scroll container size on load” (e.g. from\n`DataCascadeUISnapshot.scrollRect`).\n\n**Note:** `DataCascade` uses refs for **`initialTableState`**,\n**`initialScrollOffset`**, and **`initialRect`** so they are read only\non first render and do not force re-mounts when the parent re-renders.\n\n---\n\n## Summary for reviewers\n\n- **Ref:** Optional. When passed, consumers use\n**`ref.current?.getUISnapshotStore()`** and the returned\n**`DataCascadeUISnapshotStore<G, L>`** for subscription and snapshots\n(**`DataCascadeUISnapshot<G, L>`**).\n- **Generics:** **`DataCascadeImplRef<G, L>`**,\n**`DataCascadeUISnapshot<G, L>`**, and **`DataCascadeUISnapshotStore<G,\nL>`** are generic over group and leaf node types.\n- **Snapshot:** Includes **`scrollRect`** (width/height) in addition to\nscrollOffset, range, isScrolling, activeStickyIndex, totalRowCount,\ntotalSize, expanded, and rowSelection. Updates are debounced (100ms).\n- **Initial state:** **`initialTableState`** seeds expanded/rowSelection\non mount. **`initialScrollOffset`** and **`initialRect`** seed the\nvirtualizer (and optionally the scroll container) so scroll position and\nsize can be restored from a persisted snapshot.\n- **Breaking changes:** None; ref and new props are additive.\n\n### Example: subscribe and restore\n\n```ts\nconst subscriptionRef = useRef<() => void)>(null);\n\nconst acquireSnapshotSubscription = useCallback((_ref) => {\n  if (!subscriptionRef.current) {\n    subscriptionRef.current = _ref?.getUISnapshotStore()?.subscribe(() => {\n      const snapshot = store.getSnapshot();\n\t  console.log('snapshot changed:: %o \\n', { snapshot });\n      // Persist snapshot (e.g. scrollOffset, scrollRect, expanded, rowSelection)\n      // so you can pass them back as initialScrollOffset, initialRect, initialTableState.\n    });\n  }\n}, []);\n\nuseEffect(() => () => {\n  if (subscriptionRef.current) {\n   subscriptionRef.current()\n  }\n}, []);\n\nconst initialTableState = useMemo(() => ({\n    expanded: savedSnapshot?.expanded,\n    rowSelection: savedSnapshot?.rowSelection,\n}), []);\n\n// Restore on remount\n<DataCascade\n  ref={acquireSnapshotSubscription}\n  data={data}\n  initialScrollOffset={savedSnapshot?.scrollOffset}\n  initialRect={savedSnapshot?.scrollRect}\n  initialTableState={initialTableState}\n  cascadeGroups={cascadeGroups}\n  initialGroupColumn={initialGroupColumn}\n  tableTitleSlot={...}\n  ...\n/>\n```\n\n---\n\n_P.S. it's also possible to use the returned `getUISnapshotStore` with\nthe react primitive [`useSyncExternalStore`\n](https://react.dev/reference/react/useSyncExternalStore) ask your\nfavorite LLM about this._\n\n","sha":"e490f3d41b196d3f9e2e1d666e7da9034842318d"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/253125","number":253125,"mergeCommit":{"message":"[Cascade] add imperative API to get state changes within the cascade component (#253125)\n\n## Summary\n\n# Data Cascade – API and state restoration\n\nThis PR adds support for restoring the cascade to a previous UI state:\nref-based snapshot store, generic ref/snapshot types, and initial\nscroll/rect/table state props.\n\n---\n\n## Public API\n\n### Ref and imperative handle\n\n- **`DataCascade`** accepts a **ref** (via `forwardRef`), typed as\n**`DataCascadeImplRef<G, L>`** (generic over group and leaf nodes).\n- **`DataCascadeImplRef<G, L>`** exposes **`getUISnapshotStore():\nDataCascadeUISnapshotStore<G, L> | null`**.\n- **`DataCascadeUISnapshotStore<G, L>`** is a\n`useSyncExternalStore`-compatible store with\n**`subscribe(onStoreChange)`**, **`getSnapshot()`**, and\n**`getServerSnapshot()`**, all operating on **`DataCascadeUISnapshot<G,\nL>`**.\n\n### Snapshot shape\n\n**`DataCascadeUISnapshot<G, L>`** extends table state (`expanded`,\n`rowSelection`) and includes virtualizer-derived fields:\n\n- **`scrollRect`** – `{ width: number; height: number }` (scroll\ncontainer size)\n- **`scrollOffset`** – number\n- **`range`** – `{ startIndex: number; endIndex: number } | null`\n- **`isScrolling`** – boolean\n- **`activeStickyIndex`** – number | null\n- **`totalRowCount`** – number\n- **`totalSize`** – number\n- **`expanded`** / **`rowSelection`** – from table state\n\nStore updates are **debounced (100ms)**.\n\n### Internal API\n\n- **`useExposePublicApi(ref, options)`** returns\n**`collectVirtualizerStateChanges(instance)`**, which updates the UI\nsnapshot from the virtualizer (including `scrollRect`) and triggers\nstore listeners. Ref is passed into the impl as the **`cascadeRef`**\nprop.\n\n---\n\n## New props\n\n### On `DataCascade` / `DataCascadeProvider`\n\n**`initialTableState?: Pick<Partial<TableState>, 'expanded' |\n'rowSelection'>`**\n\n- **Where:** **`DataCascadeProvider`** (used by **`DataCascade`**).\n- **Meaning:** Initial table state on mount. Supports **`expanded`** and\n**`rowSelection`**.\n- **Semantics:** For a nested row to be visible, the full path from root\nto that row must be expanded (e.g. set the right ids in `expanded`).\nOnly affects initial state; later behavior still follows\n`allowMultipleRowToggle` and user interaction.\n- **Usage:** “Open this path on load” or “Restore expansion/selection\nfrom a saved snapshot” (e.g. from URL or persisted\n`DataCascadeUISnapshot`).\n\n**`initialScrollOffset?: number`**\n\n- **Where:** **`DataCascade`** (passed through to **`DataCascadeImpl`**\nand the cascade virtualizer).\n- **Meaning:** Initial vertical scroll position in **pixels**. When set,\nthe list and scroll container start at this offset on mount.\n- **Semantics:** Passed to the virtualizer as TanStack Virtual’s\n**`initialOffset`**. Intended to be used with a sync of the scroll\ncontainer’s `scrollTop` (or equivalent) so DOM and virtualizer stay in\nsync on first paint.\n- **Usage:** “Restore scroll position on load” (e.g. from\n`DataCascadeUISnapshot.scrollOffset` or URL).\n\n**`initialRect?: { width: number; height: number }`**\n\n- **Where:** **`DataCascade`** (passed through to **`DataCascadeImpl`**\nand the cascade virtualizer).\n- **Meaning:** Initial scroll container dimensions. When set, the\nvirtualizer uses this size before the scroll element is measured.\n- **Semantics:** Passed to the virtualizer as **`initialRect`**\n(TanStack Virtual option). Helps avoid layout jump when restoring a\nsnapshot that includes **`scrollRect`**.\n- **Usage:** “Restore scroll container size on load” (e.g. from\n`DataCascadeUISnapshot.scrollRect`).\n\n**Note:** `DataCascade` uses refs for **`initialTableState`**,\n**`initialScrollOffset`**, and **`initialRect`** so they are read only\non first render and do not force re-mounts when the parent re-renders.\n\n---\n\n## Summary for reviewers\n\n- **Ref:** Optional. When passed, consumers use\n**`ref.current?.getUISnapshotStore()`** and the returned\n**`DataCascadeUISnapshotStore<G, L>`** for subscription and snapshots\n(**`DataCascadeUISnapshot<G, L>`**).\n- **Generics:** **`DataCascadeImplRef<G, L>`**,\n**`DataCascadeUISnapshot<G, L>`**, and **`DataCascadeUISnapshotStore<G,\nL>`** are generic over group and leaf node types.\n- **Snapshot:** Includes **`scrollRect`** (width/height) in addition to\nscrollOffset, range, isScrolling, activeStickyIndex, totalRowCount,\ntotalSize, expanded, and rowSelection. Updates are debounced (100ms).\n- **Initial state:** **`initialTableState`** seeds expanded/rowSelection\non mount. **`initialScrollOffset`** and **`initialRect`** seed the\nvirtualizer (and optionally the scroll container) so scroll position and\nsize can be restored from a persisted snapshot.\n- **Breaking changes:** None; ref and new props are additive.\n\n### Example: subscribe and restore\n\n```ts\nconst subscriptionRef = useRef<() => void)>(null);\n\nconst acquireSnapshotSubscription = useCallback((_ref) => {\n  if (!subscriptionRef.current) {\n    subscriptionRef.current = _ref?.getUISnapshotStore()?.subscribe(() => {\n      const snapshot = store.getSnapshot();\n\t  console.log('snapshot changed:: %o \\n', { snapshot });\n      // Persist snapshot (e.g. scrollOffset, scrollRect, expanded, rowSelection)\n      // so you can pass them back as initialScrollOffset, initialRect, initialTableState.\n    });\n  }\n}, []);\n\nuseEffect(() => () => {\n  if (subscriptionRef.current) {\n   subscriptionRef.current()\n  }\n}, []);\n\nconst initialTableState = useMemo(() => ({\n    expanded: savedSnapshot?.expanded,\n    rowSelection: savedSnapshot?.rowSelection,\n}), []);\n\n// Restore on remount\n<DataCascade\n  ref={acquireSnapshotSubscription}\n  data={data}\n  initialScrollOffset={savedSnapshot?.scrollOffset}\n  initialRect={savedSnapshot?.scrollRect}\n  initialTableState={initialTableState}\n  cascadeGroups={cascadeGroups}\n  initialGroupColumn={initialGroupColumn}\n  tableTitleSlot={...}\n  ...\n/>\n```\n\n---\n\n_P.S. it's also possible to use the returned `getUISnapshotStore` with\nthe react primitive [`useSyncExternalStore`\n](https://react.dev/reference/react/useSyncExternalStore) ask your\nfavorite LLM about this._\n\n","sha":"e490f3d41b196d3f9e2e1d666e7da9034842318d"}}]}] BACKPORT-->