### PR TITLE
[Entity Store] Use v1 api version query

### DIFF
--- a/x-pack/solutions/security/plugins/entity_store/public/hooks/useInstallEntityStoreV2.tsx
+++ b/x-pack/solutions/security/plugins/entity_store/public/hooks/useInstallEntityStoreV2.tsx
@@ -30,7 +30,10 @@ const statusRequestQuery = {
 
 const getStatusRequest: HttpFetchOptionsWithPath = {
   path: ENTITY_STORE_ROUTES.public.STATUS,
-  query: statusRequestQuery,
+  query: {
+    ...statusRequestQuery,
+    apiVersion: '2023-10-31',
+  },
 };
 
 const getStatusV1Request: HttpFetchOptionsWithPath = {


### PR DESCRIPTION

 status api hitting this error, resulting in entity store not being installed on security solution page visits 
 
 
```
Please specify a version via elastic-api-version header. Available versions: [2023-10-31]
```