### PR TITLE
[9.3] Improve computation logic for sticky header (#260611)

### DIFF
--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/data_cascade_impl/data_cascade_impl.tsx
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/data_cascade_impl/data_cascade_impl.tsx
@@ -202,18 +202,10 @@ export function DataCascadeImpl<G extends GroupNode, L extends LeafNode>({
 
   const treeGridContainerARIAAttributes = useTreeGridContainerARIAAttributes(headerId);
 
-  const shouldRenderStickyHeader = useMemo(() => {
-    return (
-      enableStickyGroupHeader &&
-      activeStickyIndex !== null &&
-      (virtualizerScrollOffset ?? 0) > (virtualizedRowComputedTranslateValue.get(0) ?? 0)
-    );
-  }, [
-    activeStickyIndex,
-    enableStickyGroupHeader,
-    virtualizerScrollOffset,
-    virtualizedRowComputedTranslateValue,
-  ]);
+  const shouldRenderStickyHeader =
+    activeStickyIndex !== null &&
+    (virtualizerScrollOffset ?? 0) >
+      (virtualizerInstance.current?.virtualizedRowComputedTranslateValue.get(0) ?? 0);
 
   return (
     <div ref={cascadeWrapperRef} data-test-subj="data-cascade" css={styles.container}>


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Improve computation logic for sticky header (#260611)](https://github.com/elastic/kibana/pull/260611)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Eyo O. Eyo","email":"7893459+eokoneyo@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-04-01T10:31:49Z","message":"Improve computation logic for sticky header (#260611)\n\n## Summary\n\nThis PR improves the computation logic that determines wether a row\nshould become sticky or not, particularly addressing the reason why the\nfirst row wouldn't become sticky, it was previously within a `useMemo`\nand this meant we wouldn't recompute because the record for user\ninteraction (virtualizer's scrollOffset) doesn't cause a re-evaluation\nso it's not till the user has the second row expanded that the logic\nevaluates as true.\n\n#### Visuals\n\n\nhttps://github.com/user-attachments/assets/02b333c9-143c-4d99-948f-2c59d64581a4\n\n\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"a92949d0ce0c227a7a03d33b771e8c524dfbf31f","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","Team:SharedUX","backport:version","v9.4.0","v9.3.3"],"title":"Improve computation logic for sticky header","number":260611,"url":"https://github.com/elastic/kibana/pull/260611","mergeCommit":{"message":"Improve computation logic for sticky header (#260611)\n\n## Summary\n\nThis PR improves the computation logic that determines wether a row\nshould become sticky or not, particularly addressing the reason why the\nfirst row wouldn't become sticky, it was previously within a `useMemo`\nand this meant we wouldn't recompute because the record for user\ninteraction (virtualizer's scrollOffset) doesn't cause a re-evaluation\nso it's not till the user has the second row expanded that the logic\nevaluates as true.\n\n#### Visuals\n\n\nhttps://github.com/user-attachments/assets/02b333c9-143c-4d99-948f-2c59d64581a4\n\n\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"a92949d0ce0c227a7a03d33b771e8c524dfbf31f"}},"sourceBranch":"main","suggestedTargetBranches":["9.3"],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/260611","number":260611,"mergeCommit":{"message":"Improve computation logic for sticky header (#260611)\n\n## Summary\n\nThis PR improves the computation logic that determines wether a row\nshould become sticky or not, particularly addressing the reason why the\nfirst row wouldn't become sticky, it was previously within a `useMemo`\nand this meant we wouldn't recompute because the record for user\ninteraction (virtualizer's scrollOffset) doesn't cause a re-evaluation\nso it's not till the user has the second row expanded that the logic\nevaluates as true.\n\n#### Visuals\n\n\nhttps://github.com/user-attachments/assets/02b333c9-143c-4d99-948f-2c59d64581a4\n\n\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"a92949d0ce0c227a7a03d33b771e8c524dfbf31f"}},{"branch":"9.3","label":"v9.3.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->