### PR TITLE
[9.4] [APM] Handle Dagre layout failures on service map (#262240)

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/dagre_layout_failure_diagnostics.test.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/dagre_layout_failure_diagnostics.test.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getDagreLayoutFailureDiagnostics } from './dagre_layout_failure_diagnostics';
+
+describe('getDagreLayoutFailureDiagnostics', () => {
+  it('extracts name, message, and stack head from Error', () => {
+    const err = new TypeError("Cannot read properties of undefined (reading 'weight')");
+    err.stack = `TypeError: Cannot read properties of undefined (reading 'weight')
+    at calcCutValue (network-simplex.js:96:10)
+    at Object.layout (dagre.js:1:1)`;
+
+    const result = getDagreLayoutFailureDiagnostics(err);
+
+    expect(result.error_name).toBe('TypeError');
+    expect(result.error_message).toContain("reading 'weight'");
+    expect(result.stack_head).toContain('calcCutValue');
+    expect(result.stack_head).toContain('network-simplex.js');
+  });
+
+  it('truncates a long message', () => {
+    const longMessage = 'x'.repeat(400);
+    const err = new Error(longMessage);
+
+    const result = getDagreLayoutFailureDiagnostics(err);
+
+    expect(result.error_message.length).toBeLessThanOrEqual(256);
+  });
+
+  it('handles non-Error throws', () => {
+    const result = getDagreLayoutFailureDiagnostics('string failure');
+
+    expect(result).toEqual({
+      error_name: 'unknown',
+      error_message: 'string failure',
+      stack_head: '',
+    });
+  });
+});

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/dagre_layout_failure_diagnostics.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/dagre_layout_failure_diagnostics.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+const MAX_ERROR_MESSAGE_LEN = 256;
+const MAX_STACK_HEAD_LEN = 800;
+
+export interface DagreLayoutFailureDiagnostics {
+  error_name: string;
+  /**
+   * Truncated `Error.message` (length-capped only). Not redacted: we assume Dagre throws
+   * library-internal strings; if another error were wrapped here, content could vary.
+   */
+  error_message: string;
+  /**
+   * Truncated, flattened stack head. Not redacted; may include chunk URLs/lines for debugging.
+   */
+  stack_head: string;
+}
+
+function truncateSingleLine(str: string, max: number): string {
+  const single = str.replace(/\s+/g, ' ').trim();
+  return single.length <= max ? single : single.slice(0, max);
+}
+
+/**
+ * Builds telemetry fields when Dagre.layout throws. Does not attach the service map graph.
+ * Message and stack are taken from the caught value as-is (aside from truncation / whitespace
+ * folding); they are not scrubbed for PII—call only with errors originating from Dagre layout.
+ */
+export function getDagreLayoutFailureDiagnostics(error: unknown): DagreLayoutFailureDiagnostics {
+  if (error instanceof Error) {
+    const stackHead = error.stack
+      ? truncateSingleLine(error.stack.split('\n').slice(0, 6).join(' | '), MAX_STACK_HEAD_LEN)
+      : '';
+
+    return {
+      error_name: error.name,
+      error_message: truncateSingleLine(error.message, MAX_ERROR_MESSAGE_LEN),
+      stack_head: stackHead,
+    };
+  }
+
+  const asString = typeof error === 'string' ? error : String(error);
+
+  return {
+    error_name: 'unknown',
+    error_message: truncateSingleLine(asString, MAX_ERROR_MESSAGE_LEN),
+    stack_head: '',
+  };
+}

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/graph.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/graph.tsx
@@ -30,8 +30,11 @@ import {
   keys,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
+import { useKibana } from '@kbn/kibana-react-plugin/public';
 import '@xyflow/react/dist/style.css';
 import { css } from '@emotion/react';
+import type { ApmPluginStartDeps, ApmServices } from '../../../plugin';
+import { getDagreLayoutFailureDiagnostics } from './dagre_layout_failure_diagnostics';
 import { applyDagreLayout } from './layout';
 import { FIT_VIEW_PADDING, FIT_VIEW_DURATION, FIT_VIEW_DEFER_MS } from './constants';
 import { ServiceNode } from './service_node';
@@ -88,6 +91,8 @@ function GraphInner({
   onToggleFullscreen,
   fullMapHref,
 }: GraphProps) {
+  const { services } = useKibana<ApmPluginStartDeps & ApmServices>();
+  const { telemetry } = services;
   const { euiTheme } = useEuiTheme();
   const { fitView } = useReactFlow();
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
@@ -112,9 +117,19 @@ function GraphInner({
     [getAnimationDuration]
   );
 
+  // EBT + console fire once per failed layout computation (each useMemo re-run that throws),
+  // not strictly once per page visit—intentional for measuring failure frequency.
+  const onDagreLayoutFailure = useCallback(
+    (error: unknown) => {
+      telemetry.reportServiceMapDagreLayoutFallback(getDagreLayoutFailureDiagnostics(error));
+      console.error('[APM Service map] Dagre.layout failed; using grid fallback.', error);
+    },
+    [telemetry]
+  );
+
   const layoutedNodes = useMemo(
-    () => applyDagreLayout(initialNodes, initialEdges),
-    [initialNodes, initialEdges]
+    () => applyDagreLayout(initialNodes, initialEdges, {}, onDagreLayoutFailure),
+    [initialNodes, initialEdges, onDagreLayoutFailure]
   );
 
   const [nodes, setNodes, onNodesChange] = useNodesState<ServiceMapNode>(layoutedNodes);

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/layout.test.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/layout.test.ts
@@ -5,9 +5,16 @@
  * 2.0.
  */
 
+import Dagre from '@dagrejs/dagre';
 import type { Node, Edge } from '@xyflow/react';
 import { applyDagreLayout } from './layout';
-import { NODE_WIDTH, NODE_HEIGHT } from './constants';
+import {
+  NODE_WIDTH,
+  NODE_HEIGHT,
+  GRAPH_MARGIN,
+  NODE_SEPARATION,
+  RANK_SEPARATION,
+} from './constants';
 
 interface TestNodeData extends Record<string, unknown> {
   label: string;
@@ -263,6 +270,79 @@ describe('applyDagreLayout', () => {
           (node) => Number.isInteger(node.position.x) && Number.isInteger(node.position.y)
         )
       ).toBe(true);
+    });
+  });
+
+  describe('when Dagre.layout throws', () => {
+    let layoutSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      layoutSpy = jest.spyOn(Dagre, 'layout').mockImplementation(() => {
+        throw new TypeError("Cannot read properties of undefined (reading 'weight')");
+      });
+    });
+
+    afterEach(() => {
+      layoutSpy.mockRestore();
+    });
+
+    it('invokes onDagreLayoutFailure with the error', () => {
+      const nodes = [createNode('a', 'Node A'), createNode('b', 'Node B')];
+      const onFailure = jest.fn();
+
+      applyDagreLayout(nodes, [createEdge('a', 'b')], {}, onFailure);
+
+      expect(onFailure).toHaveBeenCalledTimes(1);
+      expect(onFailure.mock.calls[0][0]).toBeInstanceOf(TypeError);
+    });
+
+    it('applies grid fallback positions for three nodes', () => {
+      const nodes = [
+        createNode('a', 'Node A'),
+        createNode('b', 'Node B'),
+        createNode('c', 'Node C'),
+      ];
+      const stepX = NODE_WIDTH + NODE_SEPARATION;
+      const stepY = NODE_HEIGHT + RANK_SEPARATION;
+
+      const result = applyDagreLayout(nodes, [], {});
+
+      expect(result).toHaveLength(3);
+      expect(result[0].position).toEqual({
+        x: GRAPH_MARGIN,
+        y: GRAPH_MARGIN,
+      });
+      expect(result[1].position).toEqual({
+        x: GRAPH_MARGIN + stepX,
+        y: GRAPH_MARGIN,
+      });
+      expect(result[2].position).toEqual({
+        x: GRAPH_MARGIN,
+        y: GRAPH_MARGIN + stepY,
+      });
+    });
+
+    it('preserves node data and type on fallback', () => {
+      const nodes: Node<TestNodeData>[] = [
+        {
+          id: 'a',
+          position: { x: 0, y: 0 },
+          type: 'service',
+          data: { label: 'Node A', customField: 'value' },
+        },
+      ];
+
+      const result = applyDagreLayout(nodes, [], {});
+
+      expect(result[0]).toEqual(
+        expect.objectContaining({
+          type: 'service',
+          data: expect.objectContaining({
+            label: 'Node A',
+            customField: 'value',
+          }),
+        })
+      );
     });
   });
 });

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/layout.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/layout.ts
@@ -42,17 +42,42 @@ const DEFAULT_LAYOUT_OPTIONS: Required<LayoutOptions> = {
 };
 
 /**
+ * Places nodes on a square grid when Dagre layout fails (e.g. rare internal dagre bugs).
+ * Positions follow the **input array order** (index 0, 1, …), not graph topology—only
+ * a last-resort layout so the map stays usable.
+ */
+export function applyGridFallbackLayout<T extends Record<string, unknown>>(
+  nodes: Node<T>[],
+  opts: Required<LayoutOptions>
+): Node<T>[] {
+  const cols = Math.ceil(Math.sqrt(nodes.length));
+  return nodes.map((node, index) => {
+    const col = index % cols;
+    const row = Math.floor(index / cols);
+    return {
+      ...node,
+      position: {
+        x: Math.round(opts.marginx + col * (opts.nodeWidth + opts.nodesep)),
+        y: Math.round(opts.marginy + row * (opts.nodeHeight + opts.ranksep)),
+      },
+    };
+  });
+}
+
+/**
  * Apply dagre layout to position nodes in a hierarchical layout.
  *
  * @param nodes - Array of React Flow nodes to position
  * @param edges - Array of React Flow edges defining connections
  * @param options - Optional layout configuration
+ * @param onDagreLayoutFailure - Optional callback when Dagre throws (e.g. for telemetry)
  * @returns Array of nodes with calculated positions
  */
 export function applyDagreLayout<T extends Record<string, unknown>>(
   nodes: Node<T>[],
   edges: Edge[],
-  options: LayoutOptions = {}
+  options: LayoutOptions = {},
+  onDagreLayoutFailure?: (error: unknown) => void
 ): Node<T>[] {
   if (nodes.length === 0) {
     return nodes;
@@ -85,8 +110,12 @@ export function applyDagreLayout<T extends Record<string, unknown>>(
     }
   });
 
-  // Run layout algorithm
-  Dagre.layout(g);
+  try {
+    Dagre.layout(g);
+  } catch (error) {
+    onDagreLayoutFailure?.(error);
+    return applyGridFallbackLayout(nodes, opts);
+  }
 
   // Apply calculated positions to nodes
   return nodes.map((node) => {

--- a/x-pack/solutions/observability/plugins/apm/public/context/apm_plugin/mock_apm_plugin_storybook.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/context/apm_plugin/mock_apm_plugin_storybook.tsx
@@ -19,6 +19,7 @@ import React from 'react';
 import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
 import { Observable, of } from 'rxjs';
 import { apmRouter } from '../../components/routing/apm_route_config';
+import type { ITelemetryClient } from '../../services/telemetry/types';
 import { createCallApmApi } from '../../services/rest/create_call_apm_api';
 import type { APMServiceContextValue } from '../apm_service/apm_service_context';
 import { APMServiceContext } from '../apm_service/apm_service_context';
@@ -151,6 +152,16 @@ const mockCore = {
   },
 };
 
+/** Satisfies `useKibana` consumers (e.g. service map) that read `services.telemetry`. */
+const storybookTelemetry: ITelemetryClient = {
+  reportSearchQuerySubmitted: () => {},
+  reportSloOverviewFlyoutViewed: () => {},
+  reportSloOverviewFlyoutSearchQueried: () => {},
+  reportSloOverviewFlyoutStatusFiltered: () => {},
+  reportSloInfoShown: () => {},
+  reportServiceMapDagreLayoutFallback: () => {},
+};
+
 const mockUnifiedSearchBar = {
   ui: {
     SearchBar: () => <div />,
@@ -187,7 +198,7 @@ export function MockApmPluginStorybook({
   const contextMock = merge({}, mockApmPluginContext, apmContext);
   createCallApmApi(contextMock.core);
   const KibanaReactContext = createKibanaReactContext(
-    contextMock.core as unknown as Partial<CoreStart>
+    merge({}, contextMock.core, { telemetry: storybookTelemetry }) as unknown as Partial<CoreStart>
   );
 
   const history = createMemoryHistory({

--- a/x-pack/solutions/observability/plugins/apm/public/services/telemetry/__mocks__/telemetry_client_mock.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/services/telemetry/__mocks__/telemetry_client_mock.ts
@@ -13,4 +13,5 @@ export const mockTelemetryClient: ITelemetryClient = {
   reportSloOverviewFlyoutSearchQueried: jest.fn(),
   reportSloOverviewFlyoutStatusFiltered: jest.fn(),
   reportSloInfoShown: jest.fn(),
+  reportServiceMapDagreLayoutFallback: jest.fn(),
 };

--- a/x-pack/solutions/observability/plugins/apm/public/services/telemetry/telemetry_client.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/services/telemetry/telemetry_client.ts
@@ -9,6 +9,7 @@ import type { AnalyticsServiceSetup } from '@kbn/core-analytics-browser';
 import type {
   ITelemetryClient,
   SearchQuerySubmittedParams,
+  ServiceMapDagreLayoutFallbackParams,
   SloOverviewFlyoutSearchQueriedParams,
   SloOverviewFlyoutStatusFilteredParams,
 } from './types';
@@ -37,5 +38,11 @@ export class TelemetryClient implements ITelemetryClient {
 
   public reportSloInfoShown = (): void => {
     this.analytics.reportEvent(TelemetryEventTypes.SLO_INFO_SHOWN, {});
+  };
+
+  public reportServiceMapDagreLayoutFallback = (
+    params: ServiceMapDagreLayoutFallbackParams
+  ): void => {
+    this.analytics.reportEvent(TelemetryEventTypes.SERVICE_MAP_DAGRE_LAYOUT_FALLBACK, params);
   };
 }

--- a/x-pack/solutions/observability/plugins/apm/public/services/telemetry/telemetry_events.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/services/telemetry/telemetry_events.ts
@@ -69,10 +69,35 @@ const sloInfoShownEventType: TelemetryEvent = {
   schema: {},
 };
 
+const serviceMapDagreLayoutFallbackEventType: TelemetryEvent = {
+  eventType: TelemetryEventTypes.SERVICE_MAP_DAGRE_LAYOUT_FALLBACK,
+  schema: {
+    error_name: {
+      type: 'keyword',
+      _meta: {
+        description: 'Error constructor name when Dagre.layout throws',
+      },
+    },
+    error_message: {
+      type: 'text',
+      _meta: {
+        description: 'Truncated Error.message from Dagre (no APM graph payload)',
+      },
+    },
+    stack_head: {
+      type: 'text',
+      _meta: {
+        description: 'First stack frames when available; helps map minified chunks to Dagre',
+      },
+    },
+  },
+};
+
 export const apmTelemetryEventBasedTypes = [
   searchQuerySubmittedEventType,
   sloOverviewFlyoutViewedEventType,
   sloOverviewFlyoutSearchQueriedEventType,
   sloOverviewFlyoutStatusFilteredEventType,
   sloInfoShownEventType,
+  serviceMapDagreLayoutFallbackEventType,
 ];

--- a/x-pack/solutions/observability/plugins/apm/public/services/telemetry/types.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/services/telemetry/types.ts
@@ -28,12 +28,22 @@ export interface SloOverviewFlyoutStatusFilteredParams {
   statuses: string[];
 }
 
+export interface ServiceMapDagreLayoutFallbackParams {
+  /** Error constructor name (e.g. TypeError) */
+  error_name: string;
+  /** Truncated Error.message from Dagre (no graph / service data) */
+  error_message: string;
+  /** First stack frames flattened; locates Dagre/minified chunk line for investigation */
+  stack_head: string;
+}
+
 export interface ITelemetryClient {
   reportSearchQuerySubmitted(params: SearchQuerySubmittedParams): void;
   reportSloOverviewFlyoutViewed(): void;
   reportSloOverviewFlyoutSearchQueried(params: SloOverviewFlyoutSearchQueriedParams): void;
   reportSloOverviewFlyoutStatusFiltered(params: SloOverviewFlyoutStatusFilteredParams): void;
   reportSloInfoShown(): void;
+  reportServiceMapDagreLayoutFallback(params: ServiceMapDagreLayoutFallbackParams): void;
 }
 
 export enum TelemetryEventTypes {
@@ -42,6 +52,7 @@ export enum TelemetryEventTypes {
   SLO_OVERVIEW_FLYOUT_SEARCH_QUERIED = 'slo_overview_flyout_search_queried',
   SLO_OVERVIEW_FLYOUT_STATUS_FILTERED = 'slo_overview_flyout_status_filtered',
   SLO_INFO_SHOWN = 'slo_info_shown',
+  SERVICE_MAP_DAGRE_LAYOUT_FALLBACK = 'service_map_dagre_layout_fallback',
 }
 
 export type TelemetryEvent =
@@ -61,4 +72,8 @@ export type TelemetryEvent =
       eventType: TelemetryEventTypes.SLO_OVERVIEW_FLYOUT_STATUS_FILTERED;
       schema: RootSchema<SloOverviewFlyoutStatusFilteredParams>;
     }
-  | { eventType: TelemetryEventTypes.SLO_INFO_SHOWN; schema: {} };
+  | { eventType: TelemetryEventTypes.SLO_INFO_SHOWN; schema: {} }
+  | {
+      eventType: TelemetryEventTypes.SERVICE_MAP_DAGRE_LAYOUT_FALLBACK;
+      schema: RootSchema<ServiceMapDagreLayoutFallbackParams>;
+    };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[APM] Handle Dagre layout failures on service map (#262240)](https://github.com/elastic/kibana/pull/262240)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Sergi Romeu","email":"sergi.romeu@elastic.co"},"sourceCommit":{"committedDate":"2026-04-13T12:55:52Z","message":"[APM] Handle Dagre layout failures on service map (#262240)","sha":"80c78acbc38d4e9f4d250f60c9e1a385f791c87c","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport:version","v9.4.0","Team:obs-presentation","v9.5.0"],"title":"[APM] Handle Dagre layout failures on service map","number":262240,"url":"https://github.com/elastic/kibana/pull/262240","mergeCommit":{"message":"[APM] Handle Dagre layout failures on service map (#262240)","sha":"80c78acbc38d4e9f4d250f60c9e1a385f791c87c"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/262240","number":262240,"mergeCommit":{"message":"[APM] Handle Dagre layout failures on service map (#262240)","sha":"80c78acbc38d4e9f4d250f60c9e1a385f791c87c"}}]}] BACKPORT-->