### PR TITLE
[FeatureBranch/DoNotReview][Chrome Next] header: separators, help button, user profile slot

### DIFF
--- a/src/core/packages/chrome/browser-components/index.ts
+++ b/src/core/packages/chrome/browser-components/index.ts
@@ -12,8 +12,18 @@ export type { ChromeComponentsDeps } from './src/context';
 
 export { ClassicHeader } from './src/classic';
 export { ProjectHeader } from './src/project';
-export { AppHeader, AppHeaderShell, GlobalHeader, GlobalHeaderShell } from './src/chrome_next';
-export type { AppHeaderShellProps, GlobalHeaderShellProps } from './src/chrome_next';
+export {
+  AppHeader,
+  AppHeaderShell,
+  GlobalHeader,
+  GlobalHeaderShell,
+  HeaderActionButton,
+} from './src/chrome_next';
+export type {
+  AppHeaderShellProps,
+  GlobalHeaderShellProps,
+  HeaderActionButtonProps,
+} from './src/chrome_next';
 export { GridLayoutProjectSideNav } from './src/project/sidenav/grid_layout_sidenav';
 export { Sidebar } from './src/sidebar';
 export { AppMenuBar } from './src/project/app_menu';

--- a/src/core/packages/chrome/browser-components/src/chrome_next/global_header/global_header.tsx
+++ b/src/core/packages/chrome/browser-components/src/chrome_next/global_header/global_header.tsx
@@ -12,12 +12,14 @@ import { GlobalHeaderShell } from './global_header_shell';
 import { GlobalHeaderLogo } from './global_header_logo';
 import { AiButtonSlot } from './ai_button_slot';
 import { HelpButton } from './help_button';
+import { useUserMenu } from '../../shared/chrome_hooks';
 
 export const GlobalHeader = React.memo(() => (
   <GlobalHeaderShell
     logo={<GlobalHeaderLogo />}
     help={<HelpButton />}
     actions={<AiButtonSlot />}
+    userMenu={useUserMenu()}
   />
 ));
 

--- a/src/core/packages/chrome/browser-components/src/chrome_next/global_header/global_header.tsx
+++ b/src/core/packages/chrome/browser-components/src/chrome_next/global_header/global_header.tsx
@@ -11,9 +11,14 @@ import React from 'react';
 import { GlobalHeaderShell } from './global_header_shell';
 import { GlobalHeaderLogo } from './global_header_logo';
 import { AiButtonSlot } from './ai_button_slot';
+import { HelpButton } from './help_button';
 
 export const GlobalHeader = React.memo(() => (
-  <GlobalHeaderShell logo={<GlobalHeaderLogo />} actions={<AiButtonSlot />} />
+  <GlobalHeaderShell
+    logo={<GlobalHeaderLogo />}
+    help={<HelpButton />}
+    actions={<AiButtonSlot />}
+  />
 ));
 
 GlobalHeader.displayName = 'GlobalHeader';

--- a/src/core/packages/chrome/browser-components/src/chrome_next/global_header/global_header_shell.tsx
+++ b/src/core/packages/chrome/browser-components/src/chrome_next/global_header/global_header_shell.tsx
@@ -29,6 +29,7 @@ export interface GlobalHeaderShellProps {
   logo?: ReactNode;
   switcher?: ReactNode;
   search?: ReactNode;
+  help?: ReactNode;
   actions?: ReactNode;
 }
 
@@ -82,6 +83,11 @@ const useGlobalHeaderStyles = () => {
       gap: ${euiTheme.size.s};
     `;
 
+    const helpSlot = css`
+      display: flex;
+      align-items: center;
+    `;
+
     const separator = css`
       width: 1px;
       height: 20px;
@@ -89,12 +95,12 @@ const useGlobalHeaderStyles = () => {
       background: ${euiTheme.colors.borderBaseSubdued};
     `;
 
-    return { root, leftGroup, switcherSlot, spacer, rightGroup, searchSlot, actionsSlot, separator };
+    return { root, leftGroup, switcherSlot, spacer, rightGroup, searchSlot, actionsSlot, helpSlot, separator };
   }, [euiTheme]);
 };
 
 export const GlobalHeaderShell = React.memo<GlobalHeaderShellProps>(
-  ({ logo, switcher, search, actions }) => {
+  ({ logo, switcher, search, help, actions }) => {
     const { isCollapsed } = useSideNavCollapsed();
     const styles = useGlobalHeaderStyles();
     const logoWidth = isCollapsed ? COLLAPSED_WIDTH : EXPANDED_WIDTH;
@@ -118,6 +124,11 @@ export const GlobalHeaderShell = React.memo<GlobalHeaderShellProps>(
           {search && (
             <div css={styles.searchSlot} data-test-subj="chromeNextGlobalHeaderSearch">
               {search}
+            </div>
+          )}
+          {help && (
+            <div css={styles.helpSlot} data-test-subj="chromeNextGlobalHeaderHelp">
+              {help}
             </div>
           )}
           {actions && (

--- a/src/core/packages/chrome/browser-components/src/chrome_next/global_header/global_header_shell.tsx
+++ b/src/core/packages/chrome/browser-components/src/chrome_next/global_header/global_header_shell.tsx
@@ -31,6 +31,7 @@ export interface GlobalHeaderShellProps {
   search?: ReactNode;
   help?: ReactNode;
   actions?: ReactNode;
+  userMenu?: ReactNode;
 }
 
 const useGlobalHeaderStyles = () => {
@@ -88,6 +89,11 @@ const useGlobalHeaderStyles = () => {
       align-items: center;
     `;
 
+    const userMenuSlot = css`
+      display: flex;
+      align-items: center;
+    `;
+
     const separator = css`
       width: 1px;
       height: 20px;
@@ -95,12 +101,23 @@ const useGlobalHeaderStyles = () => {
       background: ${euiTheme.colors.borderBaseSubdued};
     `;
 
-    return { root, leftGroup, switcherSlot, spacer, rightGroup, searchSlot, actionsSlot, helpSlot, separator };
+    return {
+      root,
+      leftGroup,
+      switcherSlot,
+      spacer,
+      rightGroup,
+      searchSlot,
+      actionsSlot,
+      helpSlot,
+      userMenuSlot,
+      separator,
+    };
   }, [euiTheme]);
 };
 
 export const GlobalHeaderShell = React.memo<GlobalHeaderShellProps>(
-  ({ logo, switcher, search, help, actions }) => {
+  ({ logo, switcher, search, help, actions, userMenu }) => {
     const { isCollapsed } = useSideNavCollapsed();
     const styles = useGlobalHeaderStyles();
     const logoWidth = isCollapsed ? COLLAPSED_WIDTH : EXPANDED_WIDTH;
@@ -134,6 +151,11 @@ export const GlobalHeaderShell = React.memo<GlobalHeaderShellProps>(
           {actions && (
             <div css={styles.actionsSlot} data-test-subj="chromeNextGlobalHeaderActions">
               {actions}
+            </div>
+          )}
+          {userMenu && (
+            <div css={styles.userMenuSlot} data-test-subj="chromeNextGlobalHeaderUserMenu">
+              {userMenu}
             </div>
           )}
         </div>

--- a/src/core/packages/chrome/browser-components/src/chrome_next/global_header/global_header_shell.tsx
+++ b/src/core/packages/chrome/browser-components/src/chrome_next/global_header/global_header_shell.tsx
@@ -82,7 +82,14 @@ const useGlobalHeaderStyles = () => {
       gap: ${euiTheme.size.s};
     `;
 
-    return { root, leftGroup, switcherSlot, spacer, rightGroup, searchSlot, actionsSlot };
+    const separator = css`
+      width: 1px;
+      height: 20px;
+      flex-shrink: 0;
+      background: ${euiTheme.colors.borderBaseSubdued};
+    `;
+
+    return { root, leftGroup, switcherSlot, spacer, rightGroup, searchSlot, actionsSlot, separator };
   }, [euiTheme]);
 };
 
@@ -104,7 +111,9 @@ export const GlobalHeaderShell = React.memo<GlobalHeaderShellProps>(
             </div>
           )}
         </div>
+        <div css={styles.separator} />
         <div css={styles.spacer} />
+        <div css={styles.separator} />
         <div css={styles.rightGroup}>
           {search && (
             <div css={styles.searchSlot} data-test-subj="chromeNextGlobalHeaderSearch">

--- a/src/core/packages/chrome/browser-components/src/chrome_next/global_header/header_action_button.tsx
+++ b/src/core/packages/chrome/browser-components/src/chrome_next/global_header/header_action_button.tsx
@@ -1,0 +1,94 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ReactNode } from 'react';
+import React from 'react';
+import { css } from '@emotion/react';
+import { useEuiTheme } from '@elastic/eui';
+
+const ACTION_BUTTON_SIZE = 32;
+
+const baseStyles = css({
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  boxSizing: 'border-box',
+  width: ACTION_BUTTON_SIZE,
+  height: ACTION_BUTTON_SIZE,
+  padding: 0,
+  background: 'transparent',
+  cursor: 'pointer',
+  '&:hover': { background: 'var(--action-btn-hover)' },
+  '&:focus-visible': {
+    outline: '2px solid var(--action-btn-focus)',
+    outlineOffset: -2,
+  },
+});
+
+const borderedStyles = css({
+  border: '1px solid var(--action-btn-border)',
+});
+
+const plainStyles = css({
+  border: 'none',
+});
+
+export interface HeaderActionButtonProps
+  extends Pick<React.AriaAttributes, 'aria-expanded' | 'aria-haspopup'> {
+  variant: 'bordered' | 'plain';
+  children: ReactNode;
+  onClick: () => void;
+  'aria-label': string;
+  'data-test-subj'?: string;
+}
+
+export const HeaderActionButton = React.forwardRef<HTMLButtonElement, HeaderActionButtonProps>(
+  (
+    {
+      variant,
+      children,
+      onClick,
+      'aria-label': ariaLabel,
+      'aria-expanded': ariaExpanded,
+      'aria-haspopup': ariaHaspopup,
+      'data-test-subj': dataTestSubj,
+    },
+    ref
+  ) => {
+    const { euiTheme } = useEuiTheme();
+
+    return (
+      <button
+        ref={ref}
+        type="button"
+        aria-expanded={ariaExpanded}
+        aria-haspopup={ariaHaspopup}
+        aria-label={ariaLabel}
+        data-test-subj={dataTestSubj}
+        css={[
+          baseStyles,
+          variant === 'bordered' ? borderedStyles : plainStyles,
+          { borderRadius: euiTheme.border.radius.medium },
+        ]}
+        style={
+          {
+            '--action-btn-border': euiTheme.colors.borderBasePlain,
+            '--action-btn-hover': euiTheme.colors.backgroundBaseInteractiveHover,
+            '--action-btn-focus': euiTheme.colors.primary,
+          } as React.CSSProperties
+        }
+        onClick={onClick}
+      >
+        {children}
+      </button>
+    );
+  }
+);
+
+HeaderActionButton.displayName = 'HeaderActionButton';

--- a/src/core/packages/chrome/browser-components/src/chrome_next/global_header/help_button.tsx
+++ b/src/core/packages/chrome/browser-components/src/chrome_next/global_header/help_button.tsx
@@ -1,0 +1,74 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React, { useCallback } from 'react';
+import { css } from '@emotion/react';
+import { EuiIcon, useEuiTheme } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { HeaderHelpMenu } from '../../shared/header_help_menu';
+
+const HELP_BUTTON_SIZE = 32;
+
+const helpButtonBase = css({
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  boxSizing: 'border-box',
+  width: HELP_BUTTON_SIZE,
+  height: HELP_BUTTON_SIZE,
+  padding: 0,
+  background: 'transparent',
+  cursor: 'pointer',
+  '&:hover': { background: 'var(--help-btn-hover)' },
+  '&:focus-visible': {
+    outline: '2px solid var(--help-btn-focus)',
+    outlineOffset: -2,
+  },
+});
+
+const HELP_ARIA_LABEL = i18n.translate('core.ui.chrome.headerGlobalNav.helpMenuButtonAriaLabel', {
+  defaultMessage: 'Help menu',
+});
+
+export const HelpButton = React.memo(() => {
+  const { euiTheme } = useEuiTheme();
+
+  const renderButton = useCallback(
+    ({ isOpen, toggleMenu }: { isOpen: boolean; toggleMenu: () => void }) => (
+      <button
+        type="button"
+        aria-expanded={isOpen}
+        aria-haspopup="true"
+        aria-label={HELP_ARIA_LABEL}
+        data-test-subj="chromeNextGlobalHeaderHelpButton"
+        css={[
+          helpButtonBase,
+          {
+            border: `1px solid ${euiTheme.colors.borderBasePlain}`,
+            borderRadius: euiTheme.border.radius.medium,
+          },
+        ]}
+        style={
+          {
+            '--help-btn-hover': euiTheme.colors.backgroundBaseInteractiveHover,
+            '--help-btn-focus': euiTheme.colors.primary,
+          } as React.CSSProperties
+        }
+        onClick={toggleMenu}
+      >
+        <EuiIcon type="question" size="m" aria-hidden />
+      </button>
+    ),
+    [euiTheme]
+  );
+
+  return <HeaderHelpMenu renderButton={renderButton} />;
+});
+
+HelpButton.displayName = 'HelpButton';

--- a/src/core/packages/chrome/browser-components/src/chrome_next/global_header/help_button.tsx
+++ b/src/core/packages/chrome/browser-components/src/chrome_next/global_header/help_button.tsx
@@ -8,64 +8,30 @@
  */
 
 import React, { useCallback } from 'react';
-import { css } from '@emotion/react';
-import { EuiIcon, useEuiTheme } from '@elastic/eui';
+import { EuiIcon } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { HeaderHelpMenu } from '../../shared/header_help_menu';
-
-const HELP_BUTTON_SIZE = 32;
-
-const helpButtonBase = css({
-  display: 'inline-flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  boxSizing: 'border-box',
-  width: HELP_BUTTON_SIZE,
-  height: HELP_BUTTON_SIZE,
-  padding: 0,
-  background: 'transparent',
-  cursor: 'pointer',
-  '&:hover': { background: 'var(--help-btn-hover)' },
-  '&:focus-visible': {
-    outline: '2px solid var(--help-btn-focus)',
-    outlineOffset: -2,
-  },
-});
+import { HeaderActionButton } from './header_action_button';
 
 const HELP_ARIA_LABEL = i18n.translate('core.ui.chrome.headerGlobalNav.helpMenuButtonAriaLabel', {
   defaultMessage: 'Help menu',
 });
 
 export const HelpButton = React.memo(() => {
-  const { euiTheme } = useEuiTheme();
-
   const renderButton = useCallback(
     ({ isOpen, toggleMenu }: { isOpen: boolean; toggleMenu: () => void }) => (
-      <button
-        type="button"
+      <HeaderActionButton
+        variant="bordered"
+        onClick={toggleMenu}
         aria-expanded={isOpen}
-        aria-haspopup="true"
+        aria-haspopup={true}
         aria-label={HELP_ARIA_LABEL}
         data-test-subj="chromeNextGlobalHeaderHelpButton"
-        css={[
-          helpButtonBase,
-          {
-            border: `1px solid ${euiTheme.colors.borderBasePlain}`,
-            borderRadius: euiTheme.border.radius.medium,
-          },
-        ]}
-        style={
-          {
-            '--help-btn-hover': euiTheme.colors.backgroundBaseInteractiveHover,
-            '--help-btn-focus': euiTheme.colors.primary,
-          } as React.CSSProperties
-        }
-        onClick={toggleMenu}
       >
         <EuiIcon type="question" size="m" aria-hidden />
-      </button>
+      </HeaderActionButton>
     ),
-    [euiTheme]
+    []
   );
 
   return <HeaderHelpMenu renderButton={renderButton} />;

--- a/src/core/packages/chrome/browser-components/src/chrome_next/global_header/index.ts
+++ b/src/core/packages/chrome/browser-components/src/chrome_next/global_header/index.ts
@@ -10,3 +10,5 @@
 export { GlobalHeader } from './global_header';
 export { GlobalHeaderShell } from './global_header_shell';
 export type { GlobalHeaderShellProps } from './global_header_shell';
+export { HeaderActionButton } from './header_action_button';
+export type { HeaderActionButtonProps } from './header_action_button';

--- a/src/core/packages/chrome/browser-components/src/chrome_next/index.ts
+++ b/src/core/packages/chrome/browser-components/src/chrome_next/index.ts
@@ -9,5 +9,5 @@
 
 export { AppHeader, AppHeaderShell } from './app_header';
 export type { AppHeaderShellProps } from './app_header';
-export { GlobalHeader, GlobalHeaderShell } from './global_header';
-export type { GlobalHeaderShellProps } from './global_header';
+export { GlobalHeader, GlobalHeaderShell, HeaderActionButton } from './global_header';
+export type { GlobalHeaderShellProps, HeaderActionButtonProps } from './global_header';

--- a/src/core/packages/chrome/browser-components/src/shared/chrome_hooks.ts
+++ b/src/core/packages/chrome/browser-components/src/shared/chrome_hooks.ts
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import type { ReactNode } from 'react';
 import { useMemo } from 'react';
 import type { Observable } from 'rxjs';
 import { debounceTime, map } from 'rxjs';
@@ -248,6 +249,12 @@ export function useNextHeader(): ChromeNextHeaderConfig | undefined {
   const chrome = useChromeService();
   const config$ = useMemo(() => chrome.next.header.get$(), [chrome]);
   return useObservable(config$, undefined);
+}
+
+export function useUserMenu(): ReactNode {
+  const chrome = useChromeService();
+  const content$ = useMemo(() => chrome.next.userMenu.get$(), [chrome]);
+  return useObservable(content$, null);
 }
 
 /** Returns whether the next-chrome experience is enabled via feature flag. */

--- a/src/core/packages/chrome/browser-components/src/shared/header_help_menu.tsx
+++ b/src/core/packages/chrome/browser-components/src/shared/header_help_menu.tsx
@@ -43,7 +43,11 @@ const createCustomLink = (
   </Fragment>
 );
 
-export const HeaderHelpMenu = () => {
+interface HeaderHelpMenuProps {
+  renderButton?: (props: { isOpen: boolean; toggleMenu: () => void }) => React.ReactNode;
+}
+
+export const HeaderHelpMenu = ({ renderButton }: HeaderHelpMenuProps = {}) => {
   const [isOpen, setIsOpen] = useState(false);
   const closeMenu = useCallback(() => setIsOpen(false), []);
   const toggleMenu = useCallback(() => setIsOpen((prev) => !prev), []);
@@ -157,7 +161,9 @@ export const HeaderHelpMenu = () => {
     );
   }
 
-  const button = (
+  const button = renderButton ? (
+    renderButton({ isOpen, toggleMenu })
+  ) : (
     <EuiHeaderSectionItemButton
       aria-expanded={isOpen}
       aria-haspopup="true"

--- a/src/core/packages/chrome/browser-internal-types/index.ts
+++ b/src/core/packages/chrome/browser-internal-types/index.ts
@@ -21,7 +21,6 @@ import type {
   ChromeNextHeaderConfig,
   ChromeNextGlobalSearchConfig,
   ChromeNextSpaceSelectorConfig,
-  ChromeNextUserMenuConfig,
   ChromeProjectNavigationNode,
   ChromeSetProjectBreadcrumbsParams,
   ChromeUserBanner,
@@ -133,7 +132,7 @@ export interface InternalChromeNext extends ChromeNext {
     get$(): Observable<ChromeNextGlobalSearchConfig | undefined>;
   };
   userMenu: ChromeNext['userMenu'] & {
-    get$(): Observable<ChromeNextUserMenuConfig | undefined>;
+    get$(): Observable<ReactNode>;
   };
   spaceSelector: ChromeNext['spaceSelector'] & {
     get$(): Observable<ChromeNextSpaceSelectorConfig | undefined>;

--- a/src/core/packages/chrome/browser-internal/src/state/chrome_state.ts
+++ b/src/core/packages/chrome/browser-internal/src/state/chrome_state.ts
@@ -22,7 +22,6 @@ import type {
   ChromeNextAiButton,
   ChromeNextGlobalSearchConfig,
   ChromeNextSpaceSelectorConfig,
-  ChromeNextUserMenuConfig,
   ChromeUserBanner,
 } from '@kbn/core-chrome-browser';
 import type { AppMenuConfig } from '@kbn/core-chrome-app-menu-components';
@@ -70,7 +69,7 @@ export interface ChromeState {
   appMenu: State<AppMenuConfig | undefined>;
   aiButton: State<ReadonlySet<ChromeNextAiButton>>;
   globalSearch: State<ChromeNextGlobalSearchConfig | undefined>;
-  userMenu: State<ChromeNextUserMenuConfig | undefined>;
+  userMenu: State<ReactNode>;
   spaceSelector: State<ChromeNextSpaceSelectorConfig | undefined>;
 
   /** Help system */
@@ -117,7 +116,7 @@ export function createChromeState({ application, docLinks }: ChromeStateDeps): C
   const globalFooter = createState<ReactNode>(null);
   const aiButton = createState<ReadonlySet<ChromeNextAiButton>>(new Set());
   const globalSearch = createState<ChromeNextGlobalSearchConfig | undefined>(undefined);
-  const userMenu = createState<ChromeNextUserMenuConfig | undefined>(undefined);
+  const userMenu = createState<ReactNode>(null);
   const spaceSelector = createState<ChromeNextSpaceSelectorConfig | undefined>(undefined);
   const customNavLink = createState<ChromeNavLink | undefined>(undefined);
 

--- a/src/core/packages/chrome/browser-mocks/src/chrome_service.mock.ts
+++ b/src/core/packages/chrome/browser-mocks/src/chrome_service.mock.ts
@@ -9,13 +9,13 @@
 
 import { BehaviorSubject, of } from 'rxjs';
 import type { DeeplyMockedKeys } from '@kbn/utility-types-jest';
+import type { ReactNode } from 'react';
 import type {
   ChromeBadge,
   ChromeBreadcrumb,
   ChromeNextHeaderConfig,
   ChromeNextGlobalSearchConfig,
   ChromeNextSpaceSelectorConfig,
-  ChromeNextUserMenuConfig,
 } from '@kbn/core-chrome-browser';
 import type {
   InternalChromeSetup,
@@ -35,7 +35,7 @@ const createStartContractMock = () => {
   const nextGlobalSearchState$ = new BehaviorSubject<ChromeNextGlobalSearchConfig | undefined>(
     undefined
   );
-  const nextUserMenuState$ = new BehaviorSubject<ChromeNextUserMenuConfig | undefined>(undefined);
+  const nextUserMenuState$ = new BehaviorSubject<ReactNode>(null);
   const nextSpaceSelectorState$ = new BehaviorSubject<ChromeNextSpaceSelectorConfig | undefined>(
     undefined
   );
@@ -133,8 +133,8 @@ const createStartContractMock = () => {
       }),
       userMenu: lazyObject({
         get$: jest.fn().mockReturnValue(nextUserMenuState$),
-        set: jest.fn((config?: ChromeNextUserMenuConfig) => {
-          nextUserMenuState$.next(config);
+        set: jest.fn((content?: ReactNode) => {
+          nextUserMenuState$.next(content ?? null);
         }),
       }),
       spaceSelector: lazyObject({

--- a/src/core/packages/chrome/browser/index.ts
+++ b/src/core/packages/chrome/browser/index.ts
@@ -66,6 +66,4 @@ export type {
   ChromeNextHeaderMetadataSlotItem,
   ChromeNextHeaderTab,
   ChromeNextSpaceSelectorConfig,
-  ChromeNextUserMenuConfig,
-  ChromeNextUserMenuItem,
 } from './src';

--- a/src/core/packages/chrome/browser/src/chrome_next/chrome_next.ts
+++ b/src/core/packages/chrome/browser/src/chrome_next/chrome_next.ts
@@ -7,11 +7,11 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import type { ReactNode } from 'react';
 import type { ChromeNextAiButton } from './ai_button';
 import type { ChromeNextGlobalSearchConfig } from './global_search';
 import type { ChromeNextHeaderConfig } from './header';
 import type { ChromeNextSpaceSelectorConfig } from './space_selector';
-import type { ChromeNextUserMenuConfig } from './user_menu';
 
 /**
  * Chrome-Next APIs: header configuration, AI button slot, global search, user menu, and space selector.
@@ -48,11 +48,12 @@ export interface ChromeNext {
   };
   userMenu: {
     /**
-     * Set the user menu configuration for the Chrome-Next sidenav.
-     * Chrome renders a user avatar in the sidenav footer with a popover listing the provided items.
+     * Set the user menu content for the Chrome-Next global header.
+     * The provided ReactNode is rendered as-is in the header's user menu slot.
+     * The consumer owns the full UI (avatar button, popover, menu items).
      * Pass `undefined` to remove. Global — persists across app changes.
      */
-    set(config?: ChromeNextUserMenuConfig): void;
+    set(content?: ReactNode): void;
   };
   spaceSelector: {
     /**

--- a/src/core/packages/chrome/browser/src/chrome_next/index.ts
+++ b/src/core/packages/chrome/browser/src/chrome_next/index.ts
@@ -20,4 +20,3 @@ export type {
   ChromeNextHeaderTab,
 } from './header';
 export type { ChromeNextSpaceSelectorConfig } from './space_selector';
-export type { ChromeNextUserMenuConfig, ChromeNextUserMenuItem } from './user_menu';

--- a/src/core/packages/chrome/browser/src/chrome_next/user_menu.ts
+++ b/src/core/packages/chrome/browser/src/chrome_next/user_menu.ts
@@ -9,17 +9,4 @@
 
 import type { ReactNode } from 'react';
 
-export interface ChromeNextUserMenuConfig {
-  label: string;
-  renderAvatar: () => ReactNode;
-  items: ChromeNextUserMenuItem[];
-}
-
-export interface ChromeNextUserMenuItem {
-  id: string;
-  label: string;
-  href?: string;
-  isExternal?: boolean;
-  'data-test-subj'?: string;
-  onClick?: () => void;
-}
+export type ChromeNextUserMenu = ReactNode;

--- a/src/core/packages/chrome/browser/src/index.ts
+++ b/src/core/packages/chrome/browser/src/index.ts
@@ -72,6 +72,4 @@ export type {
   ChromeNextHeaderMetadataSlotItem,
   ChromeNextHeaderTab,
   ChromeNextSpaceSelectorConfig,
-  ChromeNextUserMenuConfig,
-  ChromeNextUserMenuItem,
 } from './chrome_next';

--- a/x-pack/platform/plugins/shared/security/moon.yml
+++ b/x-pack/platform/plugins/shared/security/moon.yml
@@ -104,6 +104,7 @@ dependsOn:
   - '@kbn/mock-idp-utils'
   - '@kbn/core-user-activity-server'
   - '@kbn/core-user-activity-server-mocks'
+  - '@kbn/core-chrome-browser-components'
 tags:
   - plugin
   - prod

--- a/x-pack/platform/plugins/shared/security/public/nav_control/nav_control_component.test.tsx
+++ b/x-pack/platform/plugins/shared/security/public/nav_control/nav_control_component.test.tsx
@@ -291,12 +291,25 @@ describe('SecurityNavControl', () => {
                     link3
                   </span>
                 </a>
-                <div>
-                  Dummy Component
-                </div>
-                <div
+                <button
+                  class="euiContextMenuItem emotion-euiContextMenuItem-s-center"
+                  data-test-subj="userMenuLink__dummyComponent"
+                  type="button"
+                >
+                  <span
+                    class="emotion-euiContextMenu__icon"
+                    data-euiicon-type="empty"
+                  />
+                  <span
+                    class="euiContextMenuItem__text emotion-euiContextMenuItem__text-s"
+                  >
+                    dummyComponent
+                  </span>
+                </button>
+                <button
                   class="euiContextMenuItem emotion-euiContextMenuItem-s-center"
                   data-test-subj="logoutLink"
+                  type="button"
                 >
                   <span
                     class="emotion-euiContextMenu__icon"
@@ -307,7 +320,7 @@ describe('SecurityNavControl', () => {
                   >
                     Log out
                   </span>
-                </div>
+                </button>
               </div>
             </div>
           </div>
@@ -413,9 +426,10 @@ describe('SecurityNavControl', () => {
                     link3
                   </span>
                 </a>
-                <div
+                <button
                   class="euiContextMenuItem emotion-euiContextMenuItem-s-center"
                   data-test-subj="logoutLink"
+                  type="button"
                 >
                   <span
                     class="emotion-euiContextMenu__icon"
@@ -426,7 +440,7 @@ describe('SecurityNavControl', () => {
                   >
                     Log out
                   </span>
-                </div>
+                </button>
               </div>
             </div>
           </div>
@@ -481,9 +495,10 @@ describe('SecurityNavControl', () => {
               tabindex="-1"
             >
               <div>
-                <div
+                <button
                   class="euiContextMenuItem emotion-euiContextMenuItem-s-center"
                   data-test-subj="logoutLink"
+                  type="button"
                 >
                   <span
                     class="emotion-euiContextMenu__icon"
@@ -494,7 +509,7 @@ describe('SecurityNavControl', () => {
                   >
                     Log in
                   </span>
-                </div>
+                </button>
               </div>
             </div>
           </div>

--- a/x-pack/platform/plugins/shared/security/public/nav_control/nav_control_component.tsx
+++ b/x-pack/platform/plugins/shared/security/public/nav_control/nav_control_component.tsx
@@ -15,8 +15,8 @@ import {
   EuiLoadingSpinner,
   EuiPopover,
 } from '@elastic/eui';
-import type { FunctionComponent } from 'react';
-import React, { useState } from 'react';
+import type { FunctionComponent, ReactNode } from 'react';
+import React, { useCallback, useState } from 'react';
 import useObservable from 'react-use/lib/useObservable';
 import type { Observable } from 'rxjs';
 
@@ -59,48 +59,65 @@ const ContextMenuContent = ({ items, closePopover }: ContextMenuProps) => {
   );
 };
 
+export interface SecurityNavControlRenderButtonProps {
+  isOpen: boolean;
+  toggleMenu: () => void;
+  avatar: ReactNode;
+}
+
 interface SecurityNavControlProps {
   editProfileUrl: string;
   logoutUrl: string;
   userMenuLinks$: Observable<UserMenuLink[]>;
+  renderButton?: (props: SecurityNavControlRenderButtonProps) => NonNullable<ReactNode>;
 }
 
 export const SecurityNavControl: FunctionComponent<SecurityNavControlProps> = ({
   editProfileUrl,
   logoutUrl,
   userMenuLinks$,
+  renderButton,
 }) => {
   const userMenuLinks = useObservable(userMenuLinks$, []);
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
 
   const userProfile = useUserProfile<{ avatar: UserProfileAvatarData }>('avatar,userSettings');
-  const currentUser = useCurrentUser(); // User profiles do not exist for anonymous users so need to fetch current user as well
+  const currentUser = useCurrentUser();
 
   const displayName = currentUser.value ? getUserDisplayName(currentUser.value) : '';
 
-  const button = (
+  const toggleMenu = useCallback(
+    () => setIsPopoverOpen((value) => (currentUser.value ? !value : false)),
+    [currentUser.value]
+  );
+
+  const avatar = userProfile.value ? (
+    <UserAvatar
+      user={userProfile.value.user}
+      avatar={userProfile.value.data.avatar}
+      size="s"
+      data-test-subj="userMenuAvatar"
+    />
+  ) : currentUser.value && userProfile.error ? (
+    <UserAvatar user={currentUser.value} size="s" data-test-subj="userMenuAvatar" />
+  ) : (
+    <EuiLoadingSpinner size="m" />
+  );
+
+  const button = renderButton ? (
+    renderButton({ isOpen: isPopoverOpen, toggleMenu, avatar })
+  ) : (
     <EuiHeaderSectionItemButton
       aria-expanded={isPopoverOpen}
       aria-haspopup="true"
       aria-label={i18n.translate('xpack.security.navControlComponent.accountMenuAriaLabel', {
         defaultMessage: 'Account menu',
       })}
-      onClick={() => setIsPopoverOpen((value) => (currentUser.value ? !value : false))}
+      onClick={toggleMenu}
       data-test-subj="userMenuButton"
       style={{ lineHeight: 'normal' }}
     >
-      {userProfile.value ? (
-        <UserAvatar
-          user={userProfile.value.user}
-          avatar={userProfile.value.data.avatar}
-          size="s"
-          data-test-subj="userMenuAvatar"
-        />
-      ) : currentUser.value && userProfile.error ? (
-        <UserAvatar user={currentUser.value} size="s" data-test-subj="userMenuAvatar" />
-      ) : (
-        <EuiLoadingSpinner size="m" />
-      )}
+      {avatar}
     </EuiHeaderSectionItemButton>
   );
 

--- a/x-pack/platform/plugins/shared/security/public/nav_control/nav_control_component.tsx
+++ b/x-pack/platform/plugins/shared/security/public/nav_control/nav_control_component.tsx
@@ -70,6 +70,7 @@ interface SecurityNavControlProps {
   logoutUrl: string;
   userMenuLinks$: Observable<UserMenuLink[]>;
   renderButton?: (props: SecurityNavControlRenderButtonProps) => NonNullable<ReactNode>;
+  avatarSize?: 's' | 'm' | 'l';
 }
 
 export const SecurityNavControl: FunctionComponent<SecurityNavControlProps> = ({
@@ -77,6 +78,7 @@ export const SecurityNavControl: FunctionComponent<SecurityNavControlProps> = ({
   logoutUrl,
   userMenuLinks$,
   renderButton,
+  avatarSize = 's',
 }) => {
   const userMenuLinks = useObservable(userMenuLinks$, []);
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
@@ -95,11 +97,11 @@ export const SecurityNavControl: FunctionComponent<SecurityNavControlProps> = ({
     <UserAvatar
       user={userProfile.value.user}
       avatar={userProfile.value.data.avatar}
-      size="s"
+      size={avatarSize}
       data-test-subj="userMenuAvatar"
     />
   ) : currentUser.value && userProfile.error ? (
-    <UserAvatar user={currentUser.value} size="s" data-test-subj="userMenuAvatar" />
+    <UserAvatar user={currentUser.value} size={avatarSize} data-test-subj="userMenuAvatar" />
   ) : (
     <EuiLoadingSpinner size="m" />
   );

--- a/x-pack/platform/plugins/shared/security/public/nav_control/nav_control_service.tsx
+++ b/x-pack/platform/plugins/shared/security/public/nav_control/nav_control_service.tsx
@@ -134,6 +134,7 @@ export class SecurityNavControlService {
           logoutUrl={this.logoutUrl}
           userMenuLinks$={this.userMenuLinks$}
           renderButton={chromeNextUserMenuButton}
+          avatarSize="m"
         />
       </Providers>
     );

--- a/x-pack/platform/plugins/shared/security/public/nav_control/nav_control_service.tsx
+++ b/x-pack/platform/plugins/shared/security/public/nav_control/nav_control_service.tsx
@@ -12,7 +12,7 @@ import type { Subscription } from 'rxjs';
 import { BehaviorSubject, map, ReplaySubject, takeUntil } from 'rxjs';
 
 import type { CoreStart } from '@kbn/core/public';
-import type { ChromeNextUserMenuItem } from '@kbn/core-chrome-browser';
+import { HeaderActionButton } from '@kbn/core-chrome-browser-components';
 import { i18n } from '@kbn/i18n';
 import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
 import type {
@@ -21,11 +21,10 @@ import type {
   UserMenuLink,
 } from '@kbn/security-plugin-types-public';
 import { RedirectAppLinks } from '@kbn/shared-ux-link-redirect-app';
-import { UserAvatar, type UserProfileAvatarData } from '@kbn/user-profile-components';
 
 import { SecurityNavControl } from './nav_control_component';
+import type { SecurityNavControlRenderButtonProps } from './nav_control_component';
 import type { SecurityLicense } from '../../common';
-import { getUserDisplayName, isUserAnonymous } from '../../common/model';
 import type { SecurityApiClients } from '../components';
 import { AuthenticationProvider, SecurityApiClientsProvider } from '../components';
 
@@ -128,102 +127,44 @@ export class SecurityNavControlService {
   }
 
   private registerChromeNextUserMenu(core: CoreStart, authc: AuthenticationServiceSetup) {
-    const editProfileUrl = core.http.basePath.prepend('/security/account');
-    const { userProfiles } = this.securityApiClients;
-
-    Promise.all([
-      authc.getCurrentUser(),
-      userProfiles
-        .getCurrent<{ avatar: UserProfileAvatarData }>({ dataPath: 'avatar' })
-        .catch(() => null),
-    ])
-      .then(([currentUser, userProfile]) => {
-        const userDisplayName = getUserDisplayName(currentUser);
-        const isAnonymous = isUserAnonymous(currentUser);
-
-        const renderAvatar = () =>
-          userProfile ? (
-            <UserAvatar
-              user={userProfile.user}
-              avatar={userProfile.data.avatar}
-              size="s"
-              data-test-subj="sideNavUserMenuAvatar"
-            />
-          ) : (
-            <UserAvatar user={currentUser} size="s" data-test-subj="sideNavUserMenuAvatar" />
-          );
-
-        const buildItems = (userMenuLinks: UserMenuLink[]): ChromeNextUserMenuItem[] => {
-          const items: ChromeNextUserMenuItem[] = [];
-
-          const sorted = this.sortUserMenuLinks(userMenuLinks);
-          const hasCustomProfileLinks = sorted.some(({ setAsProfile }) => setAsProfile === true);
-
-          if (!isAnonymous && !hasCustomProfileLinks) {
-            items.push({
-              id: 'profileLink',
-              label: i18n.translate('xpack.security.navControlComponent.editProfileLinkText', {
-                defaultMessage: 'Edit profile',
-              }),
-              href: editProfileUrl,
-              'data-test-subj': 'profileLink',
-            });
-          }
-
-          for (const link of sorted) {
-            if (!link.label || (!link.href && !link.onClick)) {
-              continue;
-            }
-            items.push({
-              id: `userMenuLink__${link.label}`,
-              label: link.label,
-              ...(link.href && { href: link.href }),
-              ...(link.onClick && {
-                onClick: () => {
-                  link.onClick?.();
-                },
-              }),
-              'data-test-subj': `userMenuLink__${link.label}`,
-            });
-          }
-
-          items.push({
-            id: 'logoutLink',
-            label: isAnonymous
-              ? i18n.translate('xpack.security.navControlComponent.loginLinkText', {
-                  defaultMessage: 'Log in',
-                })
-              : i18n.translate('xpack.security.navControlComponent.logoutLinkText', {
-                  defaultMessage: 'Log out',
-                }),
-            href: this.logoutUrl,
-            'data-test-subj': 'logoutLink',
-          });
-
-          return items;
-        };
-
-        const setConfig = (userMenuLinks: UserMenuLink[]) => {
-          core.chrome.next.userMenu.set({
-            label: userDisplayName,
-            renderAvatar,
-            items: buildItems(userMenuLinks),
-          });
-        };
-
-        setConfig(this.userMenuLinks$.value);
-
-        this.userMenuLinks$.pipe(takeUntil(this.stop$)).subscribe((links) => setConfig(links));
-      })
-      .catch(() => {
-        // Chrome Next user menu unavailable — legacy nav control still active
-      });
+    core.chrome.next.userMenu.set(
+      <Providers services={core} authc={authc} securityApiClients={this.securityApiClients}>
+        <SecurityNavControl
+          editProfileUrl={core.http.basePath.prepend('/security/account')}
+          logoutUrl={this.logoutUrl}
+          userMenuLinks$={this.userMenuLinks$}
+          renderButton={chromeNextUserMenuButton}
+        />
+      </Providers>
+    );
   }
 
   private sortUserMenuLinks(userMenuLinks: UserMenuLink[]) {
     return sortBy(userMenuLinks, 'order');
   }
 }
+
+const ACCOUNT_MENU_ARIA_LABEL = i18n.translate(
+  'xpack.security.navControlComponent.accountMenuAriaLabel',
+  { defaultMessage: 'Account menu' }
+);
+
+const chromeNextUserMenuButton = ({
+  isOpen,
+  toggleMenu,
+  avatar,
+}: SecurityNavControlRenderButtonProps) => (
+  <HeaderActionButton
+    variant="plain"
+    onClick={toggleMenu}
+    aria-expanded={isOpen}
+    aria-haspopup={true}
+    aria-label={ACCOUNT_MENU_ARIA_LABEL}
+    data-test-subj="chromeNextUserMenuButton"
+  >
+    {avatar}
+  </HeaderActionButton>
+);
 
 export interface ProvidersProps {
   authc: AuthenticationServiceSetup;

--- a/x-pack/platform/plugins/shared/security/tsconfig.json
+++ b/x-pack/platform/plugins/shared/security/tsconfig.json
@@ -97,7 +97,8 @@
     "@kbn/scout",
     "@kbn/mock-idp-utils",
     "@kbn/core-user-activity-server",
-    "@kbn/core-user-activity-server-mocks"
+    "@kbn/core-user-activity-server-mocks",
+    "@kbn/core-chrome-browser-components"
   ],
   "exclude": ["target/**/*"]
 }


### PR DESCRIPTION
## Summary

Catches up the Chrome-Next global header with the design prototype:

- **Vertical separators** between logo, spacer, and action groups
- **Help button** in the global header, reusing `HeaderHelpMenu` popover logic via a `renderButton` callback
- **User profile slot** — simplified `chrome.next.userMenu` API to accept a `ReactNode`; Security plugin provides `SecurityNavControl` with a `renderButton` prop so Chrome-Next controls the avatar button styling
- **`HeaderActionButton`** — shared 32px action button component (bordered/plain variants) used by both help and user menu buttons, consolidating header button styling in one place

<img width="1761" height="1265" alt="Screenshot 2026-04-13 at 16 48 05" src="https://github.com/user-attachments/assets/bd4b3456-97ef-4bb5-ae9b-8299c4ab0e2a" />
