### PR TITLE
[Streams] Skip failing UI and API Scout tests

### DIFF
--- a/x-pack/platform/plugins/shared/streams/test/scout/api/tests/insights_crud.spec.ts
+++ b/x-pack/platform/plugins/shared/streams/test/scout/api/tests/insights_crud.spec.ts
@@ -121,6 +121,7 @@ apiTest.describe(
     });
 
     // Test: List all insights
+    // Failing, see https://github.com/elastic/kibana/issues/262787
     apiTest('should list all insights', async ({ apiClient, samlAuth }) => {
       const { cookieHeader } = await samlAuth.asStreamsAdmin();
 
@@ -285,7 +286,8 @@ apiTest.describe(
     );
 
     // Test: Bulk create insights
-    apiTest('should bulk create insights', async ({ apiClient, samlAuth }) => {
+    // Failing, see https://github.com/elastic/kibana/issues/262787
+    apiTest.skip('should bulk create insights', async ({ apiClient, samlAuth }) => {
       const { cookieHeader } = await samlAuth.asStreamsAdmin();
 
       const bulkResponse = await apiClient.post('internal/streams/_insights/_bulk', {
@@ -371,6 +373,7 @@ apiTest.describe(
     });
 
     // Test: Bulk operations with mixed types
+    // Failing, see https://github.com/elastic/kibana/issues/262787
     apiTest('should handle mixed bulk operations', async ({ apiClient, samlAuth }) => {
       const { cookieHeader } = await samlAuth.asStreamsAdmin();
 
@@ -433,6 +436,7 @@ apiTest.describe(
     });
 
     // Test: Bulk operations with non-existent IDs should fail
+    // Failing, see https://github.com/elastic/kibana/issues/262787
     apiTest(
       'should fail bulk operations with non-existent IDs',
       async ({ apiClient, samlAuth }) => {

--- a/x-pack/platform/plugins/shared/streams/test/scout/api/tests/insights_crud.spec.ts
+++ b/x-pack/platform/plugins/shared/streams/test/scout/api/tests/insights_crud.spec.ts
@@ -437,7 +437,7 @@ apiTest.describe(
 
     // Test: Bulk operations with non-existent IDs should fail
     // Failing, see https://github.com/elastic/kibana/issues/262787
-    apiTest(
+    apiTest.skip(
       'should fail bulk operations with non-existent IDs',
       async ({ apiClient, samlAuth }) => {
         const { cookieHeader } = await samlAuth.asStreamsAdmin();

--- a/x-pack/platform/plugins/shared/streams/test/scout/api/tests/insights_crud.spec.ts
+++ b/x-pack/platform/plugins/shared/streams/test/scout/api/tests/insights_crud.spec.ts
@@ -122,7 +122,7 @@ apiTest.describe(
 
     // Test: List all insights
     // Failing, see https://github.com/elastic/kibana/issues/262787
-    apiTest('should list all insights', async ({ apiClient, samlAuth }) => {
+    apiTest.skip('should list all insights', async ({ apiClient, samlAuth }) => {
       const { cookieHeader } = await samlAuth.asStreamsAdmin();
 
       // Create a few insights
@@ -374,7 +374,7 @@ apiTest.describe(
 
     // Test: Bulk operations with mixed types
     // Failing, see https://github.com/elastic/kibana/issues/262787
-    apiTest('should handle mixed bulk operations', async ({ apiClient, samlAuth }) => {
+    apiTest.skip('should handle mixed bulk operations', async ({ apiClient, samlAuth }) => {
       const { cookieHeader } = await samlAuth.asStreamsAdmin();
 
       // Create an insight to update and another to delete

--- a/x-pack/platform/plugins/shared/streams/test/scout/api/tests/search_knowledge_indicators_tool.spec.ts
+++ b/x-pack/platform/plugins/shared/streams/test/scout/api/tests/search_knowledge_indicators_tool.spec.ts
@@ -40,7 +40,8 @@ import { getQueryLinkUuid } from '../../../../server/lib/streams/assets/query/qu
 
 const TOOL_ID = 'platform.streams.sig_events.search_kis';
 
-apiTest.describe(
+// Failing, see https://github.com/elastic/kibana/issues/262787
+apiTest.describe.skip(
   'search_kis tool',
   { tag: [...tags.stateful.classic, ...tags.serverless.observability.complete] },
   () => {

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/query_streams/create_query_stream.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/query_streams/create_query_stream.spec.ts
@@ -73,7 +73,8 @@ test.describe('Query streams - Create query stream', { tag: tags.stateful.classi
     expect(response.views![0].query).toBe(rootQueryStreamEsqlQuery);
   });
 
-  test('should create a query stream as a child of an ingest stream', async ({
+  // Failing, see: https://github.com/elastic/kibana/issues/262787
+  test.skip('should create a query stream as a child of an ingest stream', async ({
     page,
     pageObjects,
     esClient,


### PR DESCRIPTION
See https://github.com/elastic/kibana/issues/262787 for context on why these tests are being skipped. Reach out to the AppEx QA team for help on troubleshooting these tests. We're planning to merge this PR first (skips failing tests), and then https://github.com/elastic/kibana/pull/262748 (enables Streams tests back in the CI).

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->