### PR TITLE
[8.19] Remember user grid state when navigating back from edit (#261152)

### DIFF
--- a/x-pack/platform/plugins/shared/security/public/management/users/edit_user/create_user_page.tsx
+++ b/x-pack/platform/plugins/shared/security/public/management/users/edit_user/create_user_page.tsx
@@ -18,7 +18,13 @@ import { useCapabilities } from '../../../components/use_capabilities';
 export const CreateUserPage: FunctionComponent = () => {
   const history = useHistory();
   const readOnly = !useCapabilities('users').save;
-  const backToUsers = () => history.push('/');
+  const backToUsers = () => {
+    if (history.length > 1) {
+      history.goBack();
+    } else {
+      history.push('/');
+    }
+  };
 
   useEffect(() => {
     if (readOnly) {

--- a/x-pack/platform/plugins/shared/security/public/management/users/edit_user/edit_user_page.tsx
+++ b/x-pack/platform/plugins/shared/security/public/management/users/edit_user/edit_user_page.tsx
@@ -61,7 +61,13 @@ export const EditUserPage: FunctionComponent<EditUserPageProps> = ({ username })
   const [action, setAction] = useState<EditUserPageAction>('none');
   const readOnly = !useCapabilities('users').save;
 
-  const backToUsers = () => history.push('/');
+  const backToUsers = () => {
+    if (history.length > 1) {
+      history.goBack();
+    } else {
+      history.push('/');
+    }
+  };
 
   useEffect(() => {
     getUser();

--- a/x-pack/platform/plugins/shared/security/public/management/users/users_grid/users_grid_page.test.tsx
+++ b/x-pack/platform/plugins/shared/security/public/management/users/users_grid/users_grid_page.test.tsx
@@ -5,19 +5,19 @@
  * 2.0.
  */
 
-import { EuiBasicTable } from '@elastic/eui';
-import type { ReactWrapper } from 'enzyme';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import type { LocationDescriptorObject } from 'history';
 import React from 'react';
 
 import type { CoreStart, ScopedHistory } from '@kbn/core/public';
 import { coreMock, scopedHistoryMock } from '@kbn/core/public/mocks';
-import { findTestSubject, mountWithIntl, nextTick } from '@kbn/test-jest-helpers';
+import { I18nProvider } from '@kbn/i18n-react';
 
 import { UsersGridPage } from './users_grid_page';
-import type { User } from '../../../../common';
 import { rolesAPIClientMock } from '../../roles/index.mock';
 import { userAPIClientMock } from '../index.mock';
+
+const renderWithIntl = (ui: React.ReactElement) => render(<I18nProvider>{ui}</I18nProvider>);
 
 describe('UsersGridPage', () => {
   let history: ScopedHistory;
@@ -33,318 +33,7 @@ describe('UsersGridPage', () => {
 
   it('renders the list of users and create button', async () => {
     const apiClientMock = userAPIClientMock.create();
-    apiClientMock.getUsers.mockImplementation(() => {
-      return Promise.resolve<User[]>([
-        {
-          username: 'foo',
-          email: 'foo@bar.net',
-          full_name: 'foo bar',
-          roles: ['kibana_user'],
-          enabled: true,
-        },
-        {
-          username: 'reserved',
-          email: 'reserved@bar.net',
-          full_name: '',
-          roles: ['superuser'],
-          enabled: true,
-          metadata: {
-            _reserved: true,
-          },
-        },
-      ]);
-    });
-
-    const wrapper = mountWithIntl(
-      <UsersGridPage
-        userAPIClient={apiClientMock}
-        rolesAPIClient={rolesAPIClientMock.create()}
-        notifications={coreStart.notifications}
-        history={history}
-        navigateToApp={coreStart.application.navigateToApp}
-      />
-    );
-
-    await waitForRender(wrapper);
-
-    expect(apiClientMock.getUsers).toBeCalledTimes(1);
-    expect(wrapper.find('EuiInMemoryTable')).toHaveLength(1);
-    expect(wrapper.find('EuiTableRow')).toHaveLength(2);
-    expect(findTestSubject(wrapper, 'userDisabled')).toHaveLength(0);
-    expect(findTestSubject(wrapper, 'createUserButton')).toHaveLength(1);
-  });
-
-  it('renders the loading indication on the table when fetching user with data', async () => {
-    const apiClientMock = userAPIClientMock.create();
-    apiClientMock.getUsers.mockImplementation(() => {
-      return Promise.resolve<User[]>([
-        {
-          username: 'foo',
-          email: 'foo@bar.net',
-          full_name: 'foo bar',
-          roles: ['kibana_user'],
-          enabled: true,
-        },
-        {
-          username: 'reserved',
-          email: 'reserved@bar.net',
-          full_name: '',
-          roles: ['superuser'],
-          enabled: true,
-          metadata: {
-            _reserved: true,
-          },
-        },
-      ]);
-    });
-
-    const wrapper = mountWithIntl(
-      <UsersGridPage
-        userAPIClient={apiClientMock}
-        rolesAPIClient={rolesAPIClientMock.create()}
-        notifications={coreStart.notifications}
-        history={history}
-        navigateToApp={coreStart.application.navigateToApp}
-      />
-    );
-
-    expect(wrapper.find('.euiBasicTable-loading').exists()).toBeTruthy();
-    await waitForRender(wrapper);
-    expect(wrapper.find('.euiBasicTable-loading').exists()).toBeFalsy();
-  });
-
-  it('renders the loading indication on the table when fetching user with no data', async () => {
-    const apiClientMock = userAPIClientMock.create();
-    apiClientMock.getUsers.mockImplementation(() => {
-      return Promise.resolve<User[]>([]);
-    });
-
-    const wrapper = mountWithIntl(
-      <UsersGridPage
-        userAPIClient={apiClientMock}
-        rolesAPIClient={rolesAPIClientMock.create()}
-        notifications={coreStart.notifications}
-        history={history}
-        navigateToApp={coreStart.application.navigateToApp}
-      />
-    );
-
-    expect(wrapper.find('.euiBasicTable-loading').exists()).toBeTruthy();
-    await waitForRender(wrapper);
-    expect(wrapper.find('.euiBasicTable-loading').exists()).toBeFalsy();
-  });
-
-  it('generates valid links when usernames contain special characters', async () => {
-    const apiClientMock = userAPIClientMock.create();
-    apiClientMock.getUsers.mockImplementation(() => {
-      return Promise.resolve<User[]>([
-        {
-          username: 'username with some fun characters!@#$%^&*()',
-          email: 'foo@bar.net',
-          full_name: 'foo bar',
-          roles: ['kibana_user'],
-          enabled: true,
-        },
-      ]);
-    });
-
-    const wrapper = mountWithIntl(
-      <UsersGridPage
-        userAPIClient={apiClientMock}
-        rolesAPIClient={rolesAPIClientMock.create()}
-        notifications={coreStart.notifications}
-        history={history}
-        navigateToApp={coreStart.application.navigateToApp}
-      />
-    );
-
-    await waitForRender(wrapper);
-
-    const link = findTestSubject(wrapper, 'userRowUserName');
-    expect(link.props().href).toMatchInlineSnapshot(
-      `"/edit/username%20with%20some%20fun%20characters!%40%23%24%25%5E%26*()"`
-    );
-  });
-
-  it('renders a forbidden message if user is not authorized', async () => {
-    const apiClient = userAPIClientMock.create();
-    apiClient.getUsers.mockRejectedValue({ body: { statusCode: 403 } });
-
-    const wrapper = mountWithIntl(
-      <UsersGridPage
-        userAPIClient={apiClient}
-        rolesAPIClient={rolesAPIClientMock.create()}
-        notifications={coreStart.notifications}
-        history={history}
-        navigateToApp={coreStart.application.navigateToApp}
-      />
-    );
-
-    await waitForRender(wrapper);
-
-    expect(apiClient.getUsers).toBeCalledTimes(1);
-    expect(wrapper.find('[data-test-subj="permissionDeniedMessage"]')).toHaveLength(1);
-    expect(wrapper.find('EuiInMemoryTable')).toHaveLength(0);
-  });
-
-  it('renders disabled users', async () => {
-    const apiClientMock = userAPIClientMock.create();
-    apiClientMock.getUsers.mockImplementation(() => {
-      return Promise.resolve<User[]>([
-        {
-          username: 'foo',
-          email: 'foo@bar.net',
-          full_name: 'foo bar',
-          roles: ['kibana_user'],
-          enabled: false,
-        },
-      ]);
-    });
-
-    const wrapper = mountWithIntl(
-      <UsersGridPage
-        userAPIClient={apiClientMock}
-        rolesAPIClient={rolesAPIClientMock.create()}
-        notifications={coreStart.notifications}
-        history={history}
-        navigateToApp={coreStart.application.navigateToApp}
-      />
-    );
-
-    await waitForRender(wrapper);
-
-    expect(findTestSubject(wrapper, 'userDisabled')).toHaveLength(1);
-  });
-
-  it('renders deprecated users', async () => {
-    const apiClientMock = userAPIClientMock.create();
-    apiClientMock.getUsers.mockImplementation(() => {
-      return Promise.resolve<User[]>([
-        {
-          username: 'foo',
-          email: 'foo@bar.net',
-          full_name: 'foo bar',
-          roles: ['kibana_user'],
-          enabled: true,
-          metadata: {
-            _reserved: true,
-            _deprecated: true,
-            _deprecated_reason: 'This user is not cool anymore.',
-          },
-        },
-      ]);
-    });
-
-    const wrapper = mountWithIntl(
-      <UsersGridPage
-        userAPIClient={apiClientMock}
-        rolesAPIClient={rolesAPIClientMock.create()}
-        notifications={coreStart.notifications}
-        history={history}
-        navigateToApp={coreStart.application.navigateToApp}
-      />
-    );
-
-    await waitForRender(wrapper);
-
-    expect(findTestSubject(wrapper, 'userDeprecated')).toHaveLength(1);
-  });
-
-  it('renders a warning when a user is assigned a deprecated role', async () => {
-    const apiClientMock = userAPIClientMock.create();
-    apiClientMock.getUsers.mockImplementation(() => {
-      return Promise.resolve<User[]>([
-        {
-          username: 'foo',
-          email: 'foo@bar.net',
-          full_name: 'foo bar',
-          roles: ['kibana_user'],
-          enabled: true,
-        },
-        {
-          username: 'reserved',
-          email: 'reserved@bar.net',
-          full_name: '',
-          roles: ['superuser'],
-          enabled: true,
-          metadata: {
-            _reserved: true,
-          },
-        },
-      ]);
-    });
-
-    const roleAPIClientMock = rolesAPIClientMock.create();
-    roleAPIClientMock.getRoles.mockResolvedValue([
-      {
-        name: 'kibana_user',
-        metadata: {
-          _deprecated: true,
-          _deprecated_reason: `I don't like you.`,
-        },
-      },
-    ]);
-
-    const wrapper = mountWithIntl(
-      <UsersGridPage
-        userAPIClient={apiClientMock}
-        rolesAPIClient={roleAPIClientMock}
-        notifications={coreStart.notifications}
-        history={history}
-        navigateToApp={coreStart.application.navigateToApp}
-      />
-    );
-
-    await waitForRender(wrapper);
-
-    const deprecationTooltip = wrapper
-      .find('[data-test-subj="roleDeprecationTooltip"]')
-      .prop('content');
-
-    expect(deprecationTooltip).toMatchInlineSnapshot(
-      `"The kibana_user role is deprecated. I don't like you."`
-    );
-  });
-
-  it('hides reserved users when instructed to', async () => {
-    const apiClientMock = userAPIClientMock.create();
-    apiClientMock.getUsers.mockImplementation(() => {
-      return Promise.resolve<User[]>([
-        {
-          username: 'foo',
-          email: 'foo@bar.net',
-          full_name: 'foo bar',
-          roles: ['kibana_user'],
-          enabled: true,
-        },
-        {
-          username: 'reserved',
-          email: 'reserved@bar.net',
-          full_name: '',
-          roles: ['superuser'],
-          enabled: true,
-          metadata: {
-            _reserved: true,
-          },
-        },
-      ]);
-    });
-
-    const roleAPIClientMock = rolesAPIClientMock.create();
-
-    const wrapper = mountWithIntl(
-      <UsersGridPage
-        userAPIClient={apiClientMock}
-        rolesAPIClient={roleAPIClientMock}
-        notifications={coreStart.notifications}
-        history={history}
-        navigateToApp={coreStart.application.navigateToApp}
-      />
-    );
-
-    await waitForRender(wrapper);
-
-    expect(wrapper.find(EuiBasicTable).props().items).toEqual([
+    apiClientMock.getUsers.mockResolvedValue([
       {
         username: 'foo',
         email: 'foo@bar.net',
@@ -358,15 +47,400 @@ describe('UsersGridPage', () => {
         full_name: '',
         roles: ['superuser'],
         enabled: true,
+        metadata: { _reserved: true },
+      },
+    ]);
+
+    renderWithIntl(
+      <UsersGridPage
+        userAPIClient={apiClientMock}
+        rolesAPIClient={rolesAPIClientMock.create()}
+        notifications={coreStart.notifications}
+        history={history}
+        navigateToApp={coreStart.application.navigateToApp}
+      />
+    );
+
+    await waitFor(() => {
+      expect(apiClientMock.getUsers).toHaveBeenCalledTimes(1);
+      expect(screen.getByText('foo')).toBeInTheDocument();
+      expect(screen.getByText('reserved')).toBeInTheDocument();
+      expect(screen.queryByTestId('userDisabled')).not.toBeInTheDocument();
+      expect(screen.getByTestId('createUserButton')).toBeInTheDocument();
+    });
+  });
+
+  it('renders the loading indication on the table when fetching user with data', async () => {
+    const apiClientMock = userAPIClientMock.create();
+    apiClientMock.getUsers.mockResolvedValue([
+      {
+        username: 'foo',
+        email: 'foo@bar.net',
+        full_name: 'foo bar',
+        roles: ['kibana_user'],
+        enabled: true,
+      },
+      {
+        username: 'reserved',
+        email: 'reserved@bar.net',
+        full_name: '',
+        roles: ['superuser'],
+        enabled: true,
+        metadata: { _reserved: true },
+      },
+    ]);
+
+    const { container } = renderWithIntl(
+      <UsersGridPage
+        userAPIClient={apiClientMock}
+        rolesAPIClient={rolesAPIClientMock.create()}
+        notifications={coreStart.notifications}
+        history={history}
+        navigateToApp={coreStart.application.navigateToApp}
+      />
+    );
+
+    expect(container.querySelector('.euiBasicTable-loading')).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(container.querySelector('.euiBasicTable-loading')).not.toBeInTheDocument();
+    });
+  });
+
+  it('renders the loading indication on the table when fetching user with no data', async () => {
+    const apiClientMock = userAPIClientMock.create();
+    apiClientMock.getUsers.mockResolvedValue([]);
+
+    const { container } = renderWithIntl(
+      <UsersGridPage
+        userAPIClient={apiClientMock}
+        rolesAPIClient={rolesAPIClientMock.create()}
+        notifications={coreStart.notifications}
+        history={history}
+        navigateToApp={coreStart.application.navigateToApp}
+      />
+    );
+
+    expect(container.querySelector('.euiBasicTable-loading')).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(container.querySelector('.euiBasicTable-loading')).not.toBeInTheDocument();
+    });
+  });
+
+  it('generates valid links when usernames contain special characters', async () => {
+    const apiClientMock = userAPIClientMock.create();
+    apiClientMock.getUsers.mockResolvedValue([
+      {
+        username: 'username with some fun characters!@#$%^&*()',
+        email: 'foo@bar.net',
+        full_name: 'foo bar',
+        roles: ['kibana_user'],
+        enabled: true,
+      },
+    ]);
+
+    renderWithIntl(
+      <UsersGridPage
+        userAPIClient={apiClientMock}
+        rolesAPIClient={rolesAPIClientMock.create()}
+        notifications={coreStart.notifications}
+        history={history}
+        navigateToApp={coreStart.application.navigateToApp}
+      />
+    );
+
+    await waitFor(() => {
+      const link = screen.getByTestId('userRowUserName');
+      expect(link).toHaveAttribute(
+        'href',
+        '/edit/username%20with%20some%20fun%20characters!%40%23%24%25%5E%26*()'
+      );
+    });
+  });
+
+  it('renders a forbidden message if user is not authorized', async () => {
+    const apiClient = userAPIClientMock.create();
+    apiClient.getUsers.mockRejectedValue({ body: { statusCode: 403 } });
+
+    renderWithIntl(
+      <UsersGridPage
+        userAPIClient={apiClient}
+        rolesAPIClient={rolesAPIClientMock.create()}
+        notifications={coreStart.notifications}
+        history={history}
+        navigateToApp={coreStart.application.navigateToApp}
+      />
+    );
+
+    await waitFor(() => {
+      expect(apiClient.getUsers).toHaveBeenCalledTimes(1);
+      expect(screen.getByTestId('permissionDeniedMessage')).toBeInTheDocument();
+    });
+  });
+
+  it('renders disabled users', async () => {
+    const apiClientMock = userAPIClientMock.create();
+    apiClientMock.getUsers.mockResolvedValue([
+      {
+        username: 'foo',
+        email: 'foo@bar.net',
+        full_name: 'foo bar',
+        roles: ['kibana_user'],
+        enabled: false,
+      },
+    ]);
+
+    renderWithIntl(
+      <UsersGridPage
+        userAPIClient={apiClientMock}
+        rolesAPIClient={rolesAPIClientMock.create()}
+        notifications={coreStart.notifications}
+        history={history}
+        navigateToApp={coreStart.application.navigateToApp}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('userDisabled')).toBeInTheDocument();
+    });
+  });
+
+  it('renders deprecated users', async () => {
+    const apiClientMock = userAPIClientMock.create();
+    apiClientMock.getUsers.mockResolvedValue([
+      {
+        username: 'foo',
+        email: 'foo@bar.net',
+        full_name: 'foo bar',
+        roles: ['kibana_user'],
+        enabled: true,
         metadata: {
           _reserved: true,
+          _deprecated: true,
+          _deprecated_reason: 'This user is not cool anymore.',
         },
       },
     ]);
 
-    findTestSubject(wrapper, 'showReservedUsersSwitch').simulate('click');
+    renderWithIntl(
+      <UsersGridPage
+        userAPIClient={apiClientMock}
+        rolesAPIClient={rolesAPIClientMock.create()}
+        notifications={coreStart.notifications}
+        history={history}
+        navigateToApp={coreStart.application.navigateToApp}
+      />
+    );
 
-    expect(wrapper.find(EuiBasicTable).props().items).toEqual([
+    await waitFor(() => {
+      expect(screen.getByTestId('userDeprecated')).toBeInTheDocument();
+    });
+  });
+
+  it('renders a warning when a user is assigned a deprecated role', async () => {
+    const apiClientMock = userAPIClientMock.create();
+    apiClientMock.getUsers.mockResolvedValue([
+      {
+        username: 'foo',
+        email: 'foo@bar.net',
+        full_name: 'foo bar',
+        roles: ['kibana_user'],
+        enabled: true,
+      },
+      {
+        username: 'reserved',
+        email: 'reserved@bar.net',
+        full_name: '',
+        roles: ['superuser'],
+        enabled: true,
+        metadata: { _reserved: true },
+      },
+    ]);
+
+    const roleAPIClientMock = rolesAPIClientMock.create();
+    roleAPIClientMock.getRoles.mockResolvedValue([
+      {
+        name: 'kibana_user',
+        metadata: {
+          _deprecated: true,
+          _deprecated_reason: "I don't like you.",
+        },
+      },
+    ]);
+
+    const { container } = renderWithIntl(
+      <UsersGridPage
+        userAPIClient={apiClientMock}
+        rolesAPIClient={roleAPIClientMock}
+        notifications={coreStart.notifications}
+        history={history}
+        navigateToApp={coreStart.application.navigateToApp}
+      />
+    );
+
+    // EuiToolTip renders data-test-subj on the portal tooltip, not the anchor element,
+    // so check for the warning icon rendered inside the tooltip anchor instead.
+    await waitFor(() => {
+      expect(screen.getByText('kibana_user')).toBeInTheDocument();
+      expect(container.querySelector('[data-euiicon-type="warning"]')).toBeInTheDocument();
+    });
+  });
+
+  it('hides reserved users when instructed to', async () => {
+    const apiClientMock = userAPIClientMock.create();
+    apiClientMock.getUsers.mockResolvedValue([
+      {
+        username: 'foo',
+        email: 'foo@bar.net',
+        full_name: 'foo bar',
+        roles: ['kibana_user'],
+        enabled: true,
+      },
+      {
+        username: 'reserved',
+        email: 'reserved@bar.net',
+        full_name: '',
+        roles: ['superuser'],
+        enabled: true,
+        metadata: { _reserved: true },
+      },
+    ]);
+
+    renderWithIntl(
+      <UsersGridPage
+        userAPIClient={apiClientMock}
+        rolesAPIClient={rolesAPIClientMock.create()}
+        notifications={coreStart.notifications}
+        history={history}
+        navigateToApp={coreStart.application.navigateToApp}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('foo')).toBeInTheDocument();
+      expect(screen.getByText('reserved')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('showReservedUsersSwitch'));
+
+    await waitFor(() => {
+      expect(screen.getByText('foo')).toBeInTheDocument();
+      expect(screen.queryByText('reserved')).not.toBeInTheDocument();
+    });
+  });
+
+  it('restores pagination from URL query params', async () => {
+    history = scopedHistoryMock.create({ search: '?page=1&perPage=10' });
+    history.createHref = (location: LocationDescriptorObject) => {
+      return `${location.pathname}${location.search ? '?' + location.search : ''}`;
+    };
+
+    const users = Array.from({ length: 15 }, (_, i) => ({
+      username: `user_${String(i).padStart(2, '0')}`,
+      email: `user${i}@test.com`,
+      full_name: `User ${i}`,
+      roles: ['viewer'],
+      enabled: true,
+    }));
+
+    const apiClientMock = userAPIClientMock.create();
+    apiClientMock.getUsers.mockResolvedValue(users);
+
+    renderWithIntl(
+      <UsersGridPage
+        userAPIClient={apiClientMock}
+        rolesAPIClient={rolesAPIClientMock.create()}
+        notifications={coreStart.notifications}
+        history={history}
+        navigateToApp={coreStart.application.navigateToApp}
+      />
+    );
+
+    await waitFor(() => {
+      // Page 2 (index 1) with 10 per page should show users 10-14
+      expect(screen.getByText('user_10')).toBeInTheDocument();
+      expect(screen.queryByText('user_00')).not.toBeInTheDocument();
+    });
+  });
+
+  it('updates URL query params when page changes', async () => {
+    const users = Array.from({ length: 25 }, (_, i) => ({
+      username: `user_${String(i).padStart(2, '0')}`,
+      email: `user${i}@test.com`,
+      full_name: `User ${i}`,
+      roles: ['viewer'],
+      enabled: true,
+    }));
+
+    const apiClientMock = userAPIClientMock.create();
+    apiClientMock.getUsers.mockResolvedValue(users);
+
+    renderWithIntl(
+      <UsersGridPage
+        userAPIClient={apiClientMock}
+        rolesAPIClient={rolesAPIClientMock.create()}
+        notifications={coreStart.notifications}
+        history={history}
+        navigateToApp={coreStart.application.navigateToApp}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('user_00')).toBeInTheDocument();
+    });
+
+    // Navigate to page 2
+    const nextPageButton = screen.getByLabelText('Next page');
+    fireEvent.click(nextPageButton);
+
+    expect(history.replace).toHaveBeenCalledWith({ search: 'page=1' });
+  });
+
+  it('restores search filter from URL query params', async () => {
+    history = scopedHistoryMock.create({ search: '?q=reserved' });
+    history.createHref = (location: LocationDescriptorObject) => {
+      return `${location.pathname}${location.search ? '?' + location.search : ''}`;
+    };
+
+    const apiClientMock = userAPIClientMock.create();
+    apiClientMock.getUsers.mockResolvedValue([
+      {
+        username: 'foo',
+        email: 'foo@bar.net',
+        full_name: 'foo bar',
+        roles: ['kibana_user'],
+        enabled: true,
+      },
+      {
+        username: 'reserved',
+        email: 'reserved@bar.net',
+        full_name: '',
+        roles: ['superuser'],
+        enabled: true,
+        metadata: { _reserved: true },
+      },
+    ]);
+
+    renderWithIntl(
+      <UsersGridPage
+        userAPIClient={apiClientMock}
+        rolesAPIClient={rolesAPIClientMock.create()}
+        notifications={coreStart.notifications}
+        history={history}
+        navigateToApp={coreStart.application.navigateToApp}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('reserved')).toBeInTheDocument();
+      expect(screen.queryByText('foo')).not.toBeInTheDocument();
+    });
+  });
+
+  it('hides controls when readOnly is enabled', async () => {
+    const apiClientMock = userAPIClientMock.create();
+    apiClientMock.getUsers.mockResolvedValue([
       {
         username: 'foo',
         email: 'foo@bar.net',
@@ -375,33 +449,8 @@ describe('UsersGridPage', () => {
         enabled: true,
       },
     ]);
-  });
 
-  it('hides controls when `readOnly` is enabled', async () => {
-    const apiClientMock = userAPIClientMock.create();
-    apiClientMock.getUsers.mockImplementation(() => {
-      return Promise.resolve<User[]>([
-        {
-          username: 'foo',
-          email: 'foo@bar.net',
-          full_name: 'foo bar',
-          roles: ['kibana_user'],
-          enabled: true,
-        },
-        {
-          username: 'reserved',
-          email: 'reserved@bar.net',
-          full_name: '',
-          roles: ['superuser'],
-          enabled: true,
-          metadata: {
-            _reserved: true,
-          },
-        },
-      ]);
-    });
-
-    const wrapper = mountWithIntl(
+    renderWithIntl(
       <UsersGridPage
         userAPIClient={apiClientMock}
         rolesAPIClient={rolesAPIClientMock.create()}
@@ -412,13 +461,9 @@ describe('UsersGridPage', () => {
       />
     );
 
-    await waitForRender(wrapper);
-
-    expect(findTestSubject(wrapper, 'createUserButton')).toHaveLength(0);
+    await waitFor(() => {
+      expect(screen.getByText('foo')).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId('createUserButton')).not.toBeInTheDocument();
   });
 });
-
-async function waitForRender(wrapper: ReactWrapper<any, any>) {
-  await nextTick();
-  wrapper.update();
-}

--- a/x-pack/platform/plugins/shared/security/public/management/users/users_grid/users_grid_page.tsx
+++ b/x-pack/platform/plugins/shared/security/public/management/users/users_grid/users_grid_page.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { EuiBasicTableColumn, EuiSwitchEvent } from '@elastic/eui';
+import type { CriteriaWithPagination, EuiBasicTableColumn, EuiSwitchEvent } from '@elastic/eui';
 import {
   EuiButton,
   EuiEmptyPrompt,
@@ -53,6 +53,8 @@ interface State {
   filter: string;
   includeReservedUsers: boolean;
   isTableLoading: boolean;
+  pageIndex: number;
+  pageSize: number;
 }
 
 export class UsersGridPage extends Component<Props, State> {
@@ -60,8 +62,18 @@ export class UsersGridPage extends Component<Props, State> {
     readOnly: false,
   };
 
+  private static readonly PAGE_SIZE_OPTIONS = [10, 20, 50, 100] as const;
+  private static readonly DEFAULT_PAGE_SIZE = 20;
+
   constructor(props: Props) {
     super(props);
+
+    const params = new URLSearchParams(props.history.location.search);
+    const pageIndex = parseInt(params.get('page') ?? '', 10);
+    const pageSize = parseInt(params.get('perPage') ?? '', 10);
+    const filter = params.get('q') ?? '';
+    const includeReservedUsers = params.get('includeReserved') !== 'false';
+
     this.state = {
       users: [],
       visibleUsers: [],
@@ -69,9 +81,15 @@ export class UsersGridPage extends Component<Props, State> {
       selection: [],
       showDeleteConfirmation: false,
       permissionDenied: false,
-      filter: '',
-      includeReservedUsers: true,
+      filter,
+      includeReservedUsers,
       isTableLoading: false,
+      pageIndex: Number.isFinite(pageIndex) && pageIndex >= 0 ? pageIndex : 0,
+      pageSize:
+        Number.isFinite(pageSize) &&
+        (UsersGridPage.PAGE_SIZE_OPTIONS as readonly number[]).includes(pageSize)
+          ? pageSize
+          : UsersGridPage.DEFAULT_PAGE_SIZE,
     };
   }
 
@@ -185,8 +203,9 @@ export class UsersGridPage extends Component<Props, State> {
       },
     ];
     const pagination = {
-      initialPageSize: 20,
-      pageSizeOptions: [10, 20, 50, 100],
+      pageIndex: this.state.pageIndex,
+      pageSize: this.state.pageSize,
+      pageSizeOptions: [...UsersGridPage.PAGE_SIZE_OPTIONS],
     };
 
     const selectionConfig = {
@@ -199,19 +218,24 @@ export class UsersGridPage extends Component<Props, State> {
     const search = {
       toolsLeft: this.renderToolsLeft(),
       toolsRight: this.renderToolsRight(),
+      defaultQuery: this.state.filter,
       box: {
         incremental: true,
         'data-test-subj': 'searchUsers',
       },
       onChange: (query: any) => {
-        this.setState({
-          filter: query.queryText,
-          visibleUsers: this.getVisibleUsers(
-            this.state.users,
-            query.queryText,
-            this.state.includeReservedUsers
-          ),
-        });
+        this.setState(
+          {
+            filter: query.queryText,
+            pageIndex: 0,
+            visibleUsers: this.getVisibleUsers(
+              this.state.users,
+              query.queryText,
+              this.state.includeReservedUsers
+            ),
+          },
+          () => this.updateUrlParams()
+        );
       },
     };
     const sorting = {
@@ -282,6 +306,7 @@ export class UsersGridPage extends Component<Props, State> {
             loading={this.state.isTableLoading}
             search={search}
             sorting={sorting}
+            onTableChange={this.onTableChange}
             rowProps={rowProps}
           />
         }
@@ -375,10 +400,14 @@ export class UsersGridPage extends Component<Props, State> {
   }
 
   private onIncludeReservedUsersChange = (e: EuiSwitchEvent) => {
-    this.setState({
-      includeReservedUsers: e.target.checked,
-      visibleUsers: this.getVisibleUsers(this.state.users, this.state.filter, e.target.checked),
-    });
+    this.setState(
+      {
+        includeReservedUsers: e.target.checked,
+        pageIndex: 0,
+        visibleUsers: this.getVisibleUsers(this.state.users, this.state.filter, e.target.checked),
+      },
+      () => this.updateUrlParams()
+    );
   };
 
   private renderToolsRight() {
@@ -437,6 +466,36 @@ export class UsersGridPage extends Component<Props, State> {
         ))}
       </EuiFlexGroup>
     );
+  };
+
+  private updateUrlParams = () => {
+    const { pageIndex, pageSize, filter, includeReservedUsers } = this.state;
+    const params = new URLSearchParams();
+
+    if (pageIndex > 0) {
+      params.set('page', String(pageIndex));
+    }
+    if (pageSize !== UsersGridPage.DEFAULT_PAGE_SIZE) {
+      params.set('perPage', String(pageSize));
+    }
+    if (filter) {
+      params.set('q', filter);
+    }
+    if (!includeReservedUsers) {
+      params.set('includeReserved', 'false');
+    }
+
+    const search = params.toString();
+    if (search !== this.props.history.location.search.replace(/^\?/, '')) {
+      this.props.history.replace({ search });
+    }
+  };
+
+  private onTableChange = ({ page }: CriteriaWithPagination<User>) => {
+    if (page) {
+      const { index: pageIndex, size: pageSize } = page;
+      this.setState({ pageIndex, pageSize }, () => this.updateUrlParams());
+    }
   };
 
   private onCancelDelete = () => {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Remember user grid state when navigating back from edit (#261152)](https://github.com/elastic/kibana/pull/261152)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Larry Gregory","email":"larry.gregory@elastic.co"},"sourceCommit":{"committedDate":"2026-04-10T14:09:12Z","message":"Remember user grid state when navigating back from edit (#261152)","sha":"7559a606eb58203caeee6e248e31c42f836e6457","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:enhancement","Team:Security","Feature:Users/Roles/API Keys","backport missing","backport:all-open","v9.4.0"],"title":"Remember user grid state when navigating back from edit","number":261152,"url":"https://github.com/elastic/kibana/pull/261152","mergeCommit":{"message":"Remember user grid state when navigating back from edit (#261152)","sha":"7559a606eb58203caeee6e248e31c42f836e6457"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/261152","number":261152,"mergeCommit":{"message":"Remember user grid state when navigating back from edit (#261152)","sha":"7559a606eb58203caeee6e248e31c42f836e6457"}}]}] BACKPORT-->