### PR TITLE
[scout] run internal api tests against source

### DIFF
--- a/.buildkite/pipeline-utils/scout/pick_scout_test_group_run_order.ts
+++ b/.buildkite/pipeline-utils/scout/pick_scout_test_group_run_order.ts
@@ -63,7 +63,7 @@ export async function pickScoutTestGroupRunOrder(scoutConfigsPath: string) {
       ? process.env.SCOUT_CONFIGS_DEPS.split(',')
           .map((t) => t.trim())
           .filter(Boolean)
-      : ['build_scout_tests'];
+      : ['build_scout_tests', 'build'];
 
   const scoutCiRunGroups = modulesWithTests.map((module) => {
     // Check if any config in this module uses parallel workers

--- a/.buildkite/pipelines/chrome_forward_testing.yml
+++ b/.buildkite/pipelines/chrome_forward_testing.yml
@@ -76,10 +76,9 @@ steps:
       machineType: n2-standard-4
     key: build_scout_tests
     timeout_in_minutes: 15
-    depends_on:
-      - build
     env:
       SCOUT_TEST_DISTRIBUTION_STRATEGY: 'configs'
+      SCOUT_CONFIGS_DEPS: 'build_scout_tests,build'
       SCOUT_CONFIGS_SCRIPT: '.buildkite/scripts/steps/test/scout/configs.sh'
     retry:
       automatic:

--- a/.buildkite/pipelines/es_snapshots/verify.yml
+++ b/.buildkite/pipelines/es_snapshots/verify.yml
@@ -65,10 +65,9 @@ steps:
       machineType: n2-standard-4
     key: build_scout_tests
     timeout_in_minutes: 15
-    depends_on:
-      - build
     env:
       SCOUT_TEST_DISTRIBUTION_STRATEGY: 'configs'
+      SCOUT_CONFIGS_DEPS: 'build_scout_tests,build'
       SCOUT_CONFIGS_SCRIPT: '.buildkite/scripts/steps/test/scout/configs.sh'
     retry:
       automatic:

--- a/.buildkite/pipelines/fips.yml
+++ b/.buildkite/pipelines/fips.yml
@@ -71,11 +71,9 @@ steps:
       machineType: n2d-standard-8
     key: build_scout_tests
     timeout_in_minutes: 20
-    depends_on:
-      - build
     env:
       SCOUT_TEST_DISTRIBUTION_STRATEGY: 'configs'
-      SCOUT_CONFIGS_DEPS: 'build_scout_tests'
+      SCOUT_CONFIGS_DEPS: 'build_scout_tests,build'
       SCOUT_CONFIGS_SCRIPT: '.buildkite/scripts/steps/test/scout/configs.sh'
       SELECTIVE_TESTING_ENABLED: 'false'
     retry:

--- a/.buildkite/pipelines/fleet/package_registry.yml
+++ b/.buildkite/pipelines/fleet/package_registry.yml
@@ -58,10 +58,9 @@ steps:
       machineType: n2-standard-4
     key: build_scout_tests
     timeout_in_minutes: 15
-    depends_on:
-      - build
     env:
       SCOUT_TEST_DISTRIBUTION_STRATEGY: 'configs'
+      SCOUT_CONFIGS_DEPS: 'build_scout_tests,build'
       SCOUT_CONFIGS_SCRIPT: '.buildkite/scripts/steps/test/scout/configs.sh'
     retry:
       automatic:

--- a/.buildkite/pipelines/node_glibc_217.yml
+++ b/.buildkite/pipelines/node_glibc_217.yml
@@ -58,10 +58,9 @@ steps:
       machineType: n2-standard-4
     key: build_scout_tests
     timeout_in_minutes: 15
-    depends_on:
-      - build
     env:
       SCOUT_TEST_DISTRIBUTION_STRATEGY: 'configs'
+      SCOUT_CONFIGS_DEPS: 'build_scout_tests,build'
       SCOUT_CONFIGS_SCRIPT: '.buildkite/scripts/steps/test/scout/configs.sh'
     retry:
       automatic:

--- a/.buildkite/pipelines/node_pointer_compression.yml
+++ b/.buildkite/pipelines/node_pointer_compression.yml
@@ -60,10 +60,9 @@ steps:
       machineType: n2-standard-4
     key: build_scout_tests
     timeout_in_minutes: 15
-    depends_on:
-      - build
     env:
       SCOUT_TEST_DISTRIBUTION_STRATEGY: 'configs'
+      SCOUT_CONFIGS_DEPS: 'build_scout_tests,build'
       SCOUT_CONFIGS_SCRIPT: '.buildkite/scripts/steps/test/scout/configs.sh'
     retry:
       automatic:

--- a/.buildkite/pipelines/on_merge.yml
+++ b/.buildkite/pipelines/on_merge.yml
@@ -249,11 +249,9 @@ steps:
       diskSizeGb: 105
     key: build_scout_tests
     timeout_in_minutes: 20
-    depends_on:
-      - build
     env:
       SCOUT_TEST_DISTRIBUTION_STRATEGY: 'configs'
-      SCOUT_CONFIGS_DEPS: 'build_scout_tests'
+      SCOUT_CONFIGS_DEPS: 'build_scout_tests,build'
       SCOUT_CONFIGS_SCRIPT: '.buildkite/scripts/steps/test/scout/configs.sh'
     retry:
       automatic:

--- a/.buildkite/pipelines/pull_request/base.yml
+++ b/.buildkite/pipelines/pull_request/base.yml
@@ -150,8 +150,6 @@ steps:
       machineType: n2d-standard-8
     key: build_scout_tests
     timeout_in_minutes: 20
-    depends_on:
-      - build
     env:
       SCOUT_TEST_DISTRIBUTION_STRATEGY: 'configs'
       SCOUT_CONFIGS_DEPS: 'build_scout_tests'

--- a/.buildkite/pipelines/pull_request/base.yml
+++ b/.buildkite/pipelines/pull_request/base.yml
@@ -152,7 +152,7 @@ steps:
     timeout_in_minutes: 20
     env:
       SCOUT_TEST_DISTRIBUTION_STRATEGY: 'configs'
-      SCOUT_CONFIGS_DEPS: 'build_scout_tests'
+      SCOUT_CONFIGS_DEPS: 'build_scout_tests,build'
       SCOUT_CONFIGS_SCRIPT: '.buildkite/scripts/steps/test/scout/configs.sh'
       SELECTIVE_TESTING_ENABLED: 'true'
     retry:

--- a/.buildkite/pipelines/uiam/verify_and_promote.yml
+++ b/.buildkite/pipelines/uiam/verify_and_promote.yml
@@ -40,10 +40,9 @@ steps:
       diskSizeGb: 115
     key: build_scout_tests
     timeout_in_minutes: 30
-    depends_on:
-      - build
     env:
       SCOUT_TEST_DISTRIBUTION_STRATEGY: 'configs'
+      SCOUT_CONFIGS_DEPS: 'build_scout_tests,build'
       UIAM_DOCKER_IMAGE: $UIAM_IMAGE
       SERVERLESS_TESTS_ONLY: 'true'
       SCOUT_CONFIGS_SCRIPT: '.buildkite/scripts/steps/test/scout/configs.sh'

--- a/.buildkite/pipelines/uiam/verify_and_promote_cosmos_db_emulator.yml
+++ b/.buildkite/pipelines/uiam/verify_and_promote_cosmos_db_emulator.yml
@@ -40,10 +40,9 @@ steps:
       diskSizeGb: 115
     key: build_scout_tests
     timeout_in_minutes: 30
-    depends_on:
-      - build
     env:
       SCOUT_TEST_DISTRIBUTION_STRATEGY: 'configs'
+      SCOUT_CONFIGS_DEPS: 'build_scout_tests,build'
       UIAM_COSMOSDB_DOCKER_IMAGE: $UIAM_COSMOSDB_IMAGE
       SERVERLESS_TESTS_ONLY: 'true'
       SCOUT_CONFIGS_SCRIPT: '.buildkite/scripts/steps/test/scout/configs.sh'

--- a/.buildkite/scripts/steps/test/scout/test_run_builder.sh
+++ b/.buildkite/scripts/steps/test/scout/test_run_builder.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-source .buildkite/scripts/steps/functional/common.sh
+source .buildkite/scripts/bootstrap.sh
 
 echo '--- Verify Playwright CLI is functional'
 node scripts/scout run-playwright-test-check
@@ -77,13 +77,12 @@ else
   buildkite-agent artifact upload "scout_playwright_configs.json"
 fi
 
-echo '--- Running Scout API Integration Tests'
+echo '--- Running Scout API Integration Tests (against Kibana source code)'
 node scripts/scout.js run-tests \
   --location local \
   --arch stateful \
   --domain classic \
   --config src/platform/packages/shared/kbn-scout/test/scout/api/parallel.playwright.config.ts \
-  --kibanaInstallDir "$KIBANA_BUILD_LOCATION"
 
 source .buildkite/scripts/steps/test/scout/upload_report_events.sh
 

--- a/.buildkite/scripts/steps/test/scout/test_run_builder.sh
+++ b/.buildkite/scripts/steps/test/scout/test_run_builder.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 source .buildkite/scripts/bootstrap.sh
+.buildkite/scripts/setup_es_snapshot_cache.sh
 
 echo '--- Verify Playwright CLI is functional'
 node scripts/scout run-playwright-test-check


### PR DESCRIPTION
## Summary

Removes dependency on `Build Kibana Distribution` step from `Scout Test Run Builder` step by running internal api tests against Kibana source code. Both steps are run in **parallel**, so we can start run actual Scout tests as soon as build step is ready (no delay). 

It should allow us to start scout tests execution **~10 minutes ealier**.

Note: BK steps that run scout tests still depend on build step and won't be run before its ready.

<img width="1221" height="436" alt="Screenshot 2026-04-13 at 18 35 34" src="https://github.com/user-attachments/assets/9f9fe074-5a2c-4d86-a537-fad61a4ecb40" />


<!--ONMERGE {"backportTargets":["8.19","9.2","9.3","9.4"]} ONMERGE-->