### PR TITLE
Change CODEOWNERS for oas_docs/output to SKI Docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3235,7 +3235,7 @@ oas_docs/linters                              @elastic/experience-docs
 oas_docs/overlays                             @elastic/experience-docs
 oas_docs/kibana.info.serverless.yaml          @elastic/experience-docs
 oas_docs/kibana.info.yaml                     @elastic/experience-docs
-oas_docs/output                               @elastic/experience-docs
+oas_docs/output                               @elastic/ski-docs
 
 # Documentation settings files
 docs/settings-gen                             @elastic/experience-docs


### PR DESCRIPTION
Updates CODEOWNERS to change ownership of `oas_docs/output` from @elastic/experience-docs to @elastic/ski-docs.


