### PR TITLE
[Lens as code] Fix `title` property resolution in `api/dashboards`

### DIFF
--- a/x-pack/platform/plugins/shared/lens/common/transforms/transform_out.test.ts
+++ b/x-pack/platform/plugins/shared/lens/common/transforms/transform_out.test.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { LensConfigBuilder } from '@kbn/lens-embeddable-utils';
+import type { LensByValueSerializedState } from '@kbn/lens-common';
+
+import { simpleMetricAttributes } from '@kbn/lens-embeddable-utils/config_builder/tests/metric/lens_state_config.mock';
+import { getTransformOut } from './transform_out';
+
+describe('getTransformOut', () => {
+  const transformDrilldownsOut = jest.fn(<T extends { drilldowns?: unknown }>(state: T) => state);
+
+  it.each(['panel title', '', undefined])(
+    'should use panel title for "%s" and ignore attributes title',
+    (title) => {
+      const builder = new LensConfigBuilder(undefined, true);
+      const transformOut = getTransformOut(builder, transformDrilldownsOut, false);
+
+      const storedState: LensByValueSerializedState = {
+        title,
+        attributes: {
+          ...simpleMetricAttributes,
+          title: 'attributes title', // always ignored
+        },
+        references: [],
+      };
+
+      const result = transformOut(storedState, []);
+
+      expect(result.title).toEqual(title);
+    }
+  );
+});

--- a/x-pack/platform/plugins/shared/lens/common/transforms/transform_out.ts
+++ b/x-pack/platform/plugins/shared/lens/common/transforms/transform_out.ts
@@ -70,7 +70,10 @@ export const getTransformOut = (
       throw new Error(`Lens "${chartType}" chart type is not supported`);
     }
 
-    const apiConfig = builder.toAPIFormat({
+    const {
+      title: _, // ignore attributes title
+      ...apiConfig
+    } = builder.toAPIFormat({
       ...migratedAttributes,
       visualizationType: migratedAttributes.visualizationType ?? LENS_UNKNOWN_VIS,
     });


### PR DESCRIPTION
## Summary

Fixes an issue in `api/dashboards` for Lens by-value panels where the panel title was being overwritten by `attributes.title`. 

Fixes #262721

### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->