### PR TITLE
[Entity Analytics] Entity Graph - Updated relationship color

### DIFF
--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/relationship_node/relationship_node.test.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/relationship_node/relationship_node.test.tsx
@@ -189,6 +189,8 @@ describe('RelationshipNode', () => {
         borderStrongPrimary: '#0000DD',
         textInverse: '#FFFFFF',
         textPrimary: '#000000',
+        textParagraph: '#DDDDDD',
+        backgroundLightText: '#a1b2c3',
         backgroundFilledText: '#333333',
         borderBaseProminent: '#CCCCCC',
       },
@@ -197,9 +199,9 @@ describe('RelationshipNode', () => {
     it('should return relationship colors with dark background and light text', () => {
       const colors = getRelationshipColors(mockEuiTheme as EuiThemeComputed);
       expect(colors).toEqual({
-        backgroundColor: mockEuiTheme.colors.backgroundFilledText,
+        backgroundColor: mockEuiTheme.colors.backgroundLightText,
         borderColor: mockEuiTheme.colors.borderBaseProminent,
-        textColor: mockEuiTheme.colors.textInverse,
+        textColor: mockEuiTheme.colors.textParagraph,
       });
     });
 

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/styles.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/node/styles.tsx
@@ -205,9 +205,9 @@ export const getRelationshipColors = (
   euiTheme: EuiThemeComputed
 ): { backgroundColor: string; borderColor: string; textColor: string } => {
   return {
-    backgroundColor: euiTheme.colors.backgroundFilledText,
+    backgroundColor: euiTheme.colors.backgroundLightText,
     borderColor: euiTheme.colors.borderBaseProminent,
-    textColor: euiTheme.colors.textInverse,
+    textColor: euiTheme.colors.textParagraph,
   };
 };
 


### PR DESCRIPTION
## Summary

Closes: #262870

Updates relationship node color

Before:

<img width="449" height="89" alt="Screenshot 2026-04-13 at 19 22 32" src="https://github.com/user-attachments/assets/48b7a03c-75ea-4354-ab35-1a2a8cbb5734" />

After:

<img width="444" height="89" alt="Screenshot 2026-04-13 at 19 22 02" src="https://github.com/user-attachments/assets/06644847-7dcd-487c-9dbd-f5af9486054c" />


## How to test

Run: `yarn storybook cloud_security_posture_graph`
Go to Graph Components -> Relationship node


<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->