### PR TITLE
[Entity Analytics] Fixing broken filtering on entity analytics homepage

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/entities_data_table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/entities_data_table.tsx
@@ -166,6 +166,7 @@ export const EntitiesDataTable = ({
     sort,
     query,
     queryError,
+    filters,
     getRowsFromPages,
     onChangeItemsPerPage,
     onResetFilters,
@@ -361,13 +362,12 @@ export const EntitiesDataTable = ({
               operation,
               dataView
             );
-            filterManager.addFilters(newFilters);
             setUrlQuery({
-              filters: filterManager.getFilters(),
+              filters: [...filters, ...newFilters],
             });
           }
         : undefined,
-    [dataView, filterManager, setUrlQuery]
+    [dataView, filterManager, filters, setUrlQuery]
   );
 
   const onResize = (colSettings: { columnId: string; width: number | undefined }) => {

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/hooks/use_base_es_query.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/hooks/use_base_es_query.ts
@@ -45,9 +45,6 @@ const getBaseQuery = ({
 export const useBaseEsQuery = ({ filters = [], query, pageFilters = [] }: EntitiesBaseURLQuery) => {
   const {
     notifications: { toasts },
-    data: {
-      query: { filterManager, queryString },
-    },
     uiSettings,
   } = useKibana().services;
   const { dataView } = useContext(DataViewContext);
@@ -67,11 +64,6 @@ export const useBaseEsQuery = ({ filters = [], query, pageFilters = [] }: Entiti
     }
     return result;
   }, [dataView, filters, pageFilters, query, config, globalFilterQuery]);
-
-  useEffect(() => {
-    filterManager.setAppFilters(filters);
-    queryString.setQuery(query);
-  }, [filters, filterManager, queryString, query]);
 
   const handleMalformedQueryError = () => {
     const error = baseEsQuery instanceof Error ? baseEsQuery : undefined;

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/hooks/use_entity_url_state.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/hooks/use_entity_url_state.ts
@@ -4,10 +4,12 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { type Dispatch, type SetStateAction, useCallback } from 'react';
+import { type Dispatch, type SetStateAction, useCallback, useEffect, useRef } from 'react';
 import type { BoolQuery, Filter, Query } from '@kbn/es-query';
 import type { CriteriaWithPagination } from '@elastic/eui';
 import type { DataTableRecord } from '@kbn/discover-utils/types';
+import deepEqual from 'fast-deep-equal';
+import { useKibana } from '../../../../../common/lib/kibana';
 import { useUrlQuery } from './use_url_query';
 import { usePageSize } from './use_page_size';
 import { useBaseEsQuery } from './use_base_es_query';
@@ -65,6 +67,37 @@ export const useEntityURLState = ({
   const getPersistedDefaultQuery = usePersistedQuery<URLQuery>(defaultQuery);
   const { urlQuery, setUrlQuery } = useUrlQuery<URLQuery>(getPersistedDefaultQuery);
   const { pageSize, setPageSize } = usePageSize(paginationLocalStorageKey);
+
+  const {
+    data: {
+      query: { filterManager },
+    },
+  } = useKibana().services;
+
+  // Track current URL filters in a render-phase ref so the subscription below
+  // can detect whether a filterManager update was triggered by us (URL → filterManager)
+  // or by the user (e.g. removing a filter pill).
+  const urlFiltersRef = useRef<Filter[]>([]);
+  urlFiltersRef.current = urlQuery.filters || [];
+
+  // URL state → filterManager: keeps filter pills visible in the filter bar.
+  useEffect(() => {
+    filterManager.setAppFilters(urlQuery.filters || []);
+  }, [filterManager, urlQuery.filters]);
+
+  // filterManager → URL state: syncs removals made via the filter bar back to URL state.
+  // The deepEqual guard prevents a circular update when setAppFilters above causes
+  // filterManager to emit, since at that point urlFiltersRef already reflects the
+  // new URL state.
+  useEffect(() => {
+    const subscription = filterManager.getUpdates$().subscribe(() => {
+      const appFilters = filterManager.getAppFilters();
+      if (!deepEqual(appFilters, urlFiltersRef.current)) {
+        setUrlQuery({ filters: appFilters });
+      }
+    });
+    return () => subscription.unsubscribe();
+  }, [filterManager, setUrlQuery]);
 
   const onChangeItemsPerPage = useCallback(
     (newPageSize: number) => {

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/use_entity_store_data_view.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/use_entity_store_data_view.ts
@@ -6,16 +6,22 @@
  */
 
 import { useEffect, useState, useRef } from 'react';
-import type { DataView } from '@kbn/data-views-plugin/common';
+import { DataView } from '@kbn/data-views-plugin/public';
+import type { FieldFormatsStartCommon } from '@kbn/field-formats-plugin/common';
 import { useKibana } from '../../../common/lib/kibana';
+
 import { getEntitiesAlias, ENTITY_LATEST } from './constants';
+
+const INITIAL_DV = new DataView({
+  fieldFormats: {} as FieldFormatsStartCommon,
+});
 
 export const useEntityStoreDataView = (spaceId: string | undefined) => {
   const {
     data: { dataViews },
   } = useKibana().services;
 
-  const [dataView, setDataView] = useState<DataView | undefined>(undefined);
+  const [dataView, setDataView] = useState<DataView>(INITIAL_DV);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<Error | undefined>(undefined);
   const createdRef = useRef<string | undefined>(undefined);

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/pages/entity_analytics_home_page.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/pages/entity_analytics_home_page.tsx
@@ -25,10 +25,8 @@ import { InputsModelId } from '../../common/store/inputs/constants';
 import { FiltersGlobal } from '../../common/components/filters_global';
 import { SpyRoute } from '../../common/utils/route/spy_routes';
 import { useSourcererDataView } from '../../sourcerer/containers';
-import { useDataView } from '../../data_view_manager/hooks/use_data_view';
 import { useIsExperimentalFeatureEnabled } from '../../common/hooks/use_experimental_features';
 import { PageLoader } from '../../common/components/page_loader';
-import { PageScope } from '../../data_view_manager/constants';
 import { useSpaceId } from '../../common/hooks/use_space_id';
 import { EntityAnalyticsRecentAnomalies } from '../components/home/anomalies_panel';
 import { WatchlistFilter } from '../components/watchlists/watchlist_filter';
@@ -68,7 +66,9 @@ export const EntityAnalyticsHomePage = () => {
   const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
   const leadGenerationEnabled = useIsExperimentalFeatureEnabled('leadGenerationEnabled');
   const leadDetailsEnabled = useIsExperimentalFeatureEnabled('leadGenerationDetailsEnabled');
-  const { dataView, status } = useDataView(PageScope.explore);
+  const spaceId = useSpaceId();
+  const { dataView: entityDataView, isLoading: entityDataViewLoading } =
+    useEntityStoreDataView(spaceId);
 
   const {
     leads,
@@ -86,8 +86,8 @@ export const EntityAnalyticsHomePage = () => {
   const [provenanceLead, setProvenanceLead] = useState<HuntingLead | null>(null);
 
   const isSourcererLoading = useMemo(
-    () => (newDataViewPickerEnabled ? status !== 'ready' : oldIsSourcererLoading),
-    [newDataViewPickerEnabled, oldIsSourcererLoading, status]
+    () => (newDataViewPickerEnabled ? entityDataViewLoading : oldIsSourcererLoading),
+    [newDataViewPickerEnabled, oldIsSourcererLoading, entityDataViewLoading]
   );
 
   const location = useLocation();
@@ -122,8 +122,8 @@ export const EntityAnalyticsHomePage = () => {
   );
 
   const indicesExist = useMemo(
-    () => (newDataViewPickerEnabled ? !!dataView?.matchedIndices?.length : oldIndicesExist),
-    [dataView?.matchedIndices?.length, newDataViewPickerEnabled, oldIndicesExist]
+    () => (newDataViewPickerEnabled ? !entityDataViewLoading : oldIndicesExist),
+    [entityDataViewLoading, newDataViewPickerEnabled, oldIndicesExist]
   );
 
   const isXlScreen = useIsWithinBreakpoints(['l', 'xl']);
@@ -148,7 +148,7 @@ export const EntityAnalyticsHomePage = () => {
     }
   }, [leads, openAgentBuilderWithLead]);
 
-  if (newDataViewPickerEnabled && status === 'pristine') {
+  if (newDataViewPickerEnabled && entityDataViewLoading) {
     return <PageLoader />;
   }
 
@@ -160,7 +160,7 @@ export const EntityAnalyticsHomePage = () => {
     <>
       <FiltersGlobal>
         <SiemSearchBar
-          dataView={dataView}
+          dataView={entityDataView}
           id={InputsModelId.global}
           sourcererDataViewSpec={oldSourcererDataViewSpec}
         />
@@ -231,6 +231,8 @@ export const EntityAnalyticsHomePage = () => {
               <EntityAnalyticsEntitiesTable
                 watchlistId={selectedWatchlistId}
                 watchlistName={selectedWatchlistName}
+                entityDataView={entityDataView}
+                entityDataViewLoading={entityDataViewLoading}
               />
             </EuiPanel>
           </EuiFlexGroup>
@@ -261,15 +263,15 @@ export const EntityAnalyticsHomePage = () => {
 const EntityAnalyticsEntitiesTable = ({
   watchlistId,
   watchlistName,
+  entityDataView,
+  entityDataViewLoading,
 }: {
   watchlistId?: string;
   watchlistName?: string;
+  entityDataView: ReturnType<typeof useEntityStoreDataView>['dataView'];
+  entityDataViewLoading: boolean;
 }) => {
-  const spaceId = useSpaceId();
-  const { dataView: entityDataView, isLoading: entityDataViewLoading } =
-    useEntityStoreDataView(spaceId);
-
-  if (entityDataViewLoading || !entityDataView) {
+  if (entityDataViewLoading) {
     return <EuiLoadingSpinner size="l" data-test-subj="entityAnalyticsEntitiesTableLoader" />;
   }
 


### PR DESCRIPTION
## Summary

Fixing the filter pill behavior on the entity analytics homepage. 

**Filter pill not applying**
Filter pill was not working before because the homepage was loading the default security solution dataview while the data was actually being loaded from the entity store data view, which has different mappings. The fix was to update the home page to load the correct data view. 

**Could not remove filter pill**
The action to remove the filter pill was not being recognized so no action was being taken. The fix is to correctly update the URL state and the filter state so the removal is correctly reflected.

## To Verify

1. Start ES and Kibana with all the V2 feature flags enabled
2. Load up some V2 entity store data
3. Navigate to the Entity Analytics homepage and try to filter by any of the fields in the entity table
4. The filter pill should show the correct value and the UI should update to reflect the filters
5. Filter pill should be removable, editable, all the things filter pills can do should be do-able

https://github.com/user-attachments/assets/06d20093-aecf-4fcb-ad55-8ab560fb18be


<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->