### PR TITLE
[o11y] suppress Agent Builder announcement modal in e2e

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/ftr_e2e/cypress/support/commands.ts
+++ b/x-pack/solutions/observability/plugins/apm/ftr_e2e/cypress/support/commands.ts
@@ -11,7 +11,7 @@ import moment from 'moment';
 import '@frsource/cypress-plugin-visual-regression-diff';
 import { AXE_CONFIG, AXE_OPTIONS } from '@kbn/axe-config';
 import { ApmUsername } from '@kbn/apm-plugin/server/test_helpers/create_apm_users/authentication';
-import { suppressGlobalAnnouncements } from './suppress_global_announcements';
+import { resolveKibanaOrigin, suppressGlobalAnnouncements } from './suppress_global_announcements';
 
 Cypress.Commands.add('loginAsSuperUser', () => {
   return cy.loginAs({ username: 'elastic', password: 'changeme' });
@@ -60,7 +60,12 @@ Cypress.Commands.add(
     cy.session(
       username,
       () => {
-        const kibanaUrl = Cypress.env('KIBANA_URL');
+        const kibanaUrl = resolveKibanaOrigin();
+        if (!kibanaUrl) {
+          throw new Error(
+            'APM Cypress login requires Kibana origin: set Cypress env KIBANA_URL or cypress.config baseUrl'
+          );
+        }
         cy.log(`Logging in as ${username} on ${kibanaUrl}`);
         cy.visit('/');
         cy.request({

--- a/x-pack/solutions/observability/plugins/apm/ftr_e2e/cypress/support/commands.ts
+++ b/x-pack/solutions/observability/plugins/apm/ftr_e2e/cypress/support/commands.ts
@@ -11,6 +11,7 @@ import moment from 'moment';
 import '@frsource/cypress-plugin-visual-regression-diff';
 import { AXE_CONFIG, AXE_OPTIONS } from '@kbn/axe-config';
 import { ApmUsername } from '@kbn/apm-plugin/server/test_helpers/create_apm_users/authentication';
+import { suppressGlobalAnnouncements } from './suppress_global_announcements';
 
 Cypress.Commands.add('loginAsSuperUser', () => {
   return cy.loginAs({ username: 'elastic', password: 'changeme' });
@@ -55,6 +56,7 @@ Cypress.Commands.add('loginAsApmReadPrivilegesWithWriteSettingsUser', () => {
 Cypress.Commands.add(
   'loginAs',
   ({ username, password }: { username: string; password: string }) => {
+    suppressGlobalAnnouncements();
     cy.session(
       username,
       () => {
@@ -94,6 +96,7 @@ Cypress.Commands.add('changeTimeRange', (value: string) => {
 });
 
 Cypress.Commands.add('visitKibana', (url, options) => {
+  suppressGlobalAnnouncements();
   cy.visit(url, {
     onBeforeLoad(win) {
       if (options?.localStorageOptions && options.localStorageOptions.length > 0) {

--- a/x-pack/solutions/observability/plugins/apm/ftr_e2e/cypress/support/e2e.ts
+++ b/x-pack/solutions/observability/plugins/apm/ftr_e2e/cypress/support/e2e.ts
@@ -10,3 +10,8 @@ Cypress.on('uncaught:exception', (err, runnable) => {
 });
 
 import './commands';
+import { suppressGlobalAnnouncements } from './suppress_global_announcements';
+
+before(() => {
+  suppressGlobalAnnouncements();
+});

--- a/x-pack/solutions/observability/plugins/apm/ftr_e2e/cypress/support/suppress_global_announcements.ts
+++ b/x-pack/solutions/observability/plugins/apm/ftr_e2e/cypress/support/suppress_global_announcements.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-function resolveKibanaOrigin(): string | undefined {
+/** Kibana origin from `KIBANA_URL` or Cypress `baseUrl` (trimmed). Shared with `loginAs` and global_settings POST. */
+export function resolveKibanaOrigin(): string | undefined {
   const fromEnv = Cypress.env('KIBANA_URL') as string | undefined;
   const fromConfig = Cypress.config('baseUrl') as string | undefined;
   const raw = fromEnv ?? fromConfig;
@@ -29,7 +30,8 @@ export const suppressGlobalAnnouncements = (): Cypress.Chainable<Cypress.Respons
     cy.log(
       'suppressGlobalAnnouncements: skipping (set KIBANA_URL or cypress baseUrl for global_settings POST)'
     );
-    return cy.wrap(null, { log: false });
+    // No HTTP call; chain type matches cy.request for callers that do not read the body.
+    return cy.wrap(null as unknown as Cypress.Response<unknown>, { log: false });
   }
 
   return cy.request({

--- a/x-pack/solutions/observability/plugins/apm/ftr_e2e/cypress/support/suppress_global_announcements.ts
+++ b/x-pack/solutions/observability/plugins/apm/ftr_e2e/cypress/support/suppress_global_announcements.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+function resolveKibanaOrigin(): string | undefined {
+  const fromEnv = Cypress.env('KIBANA_URL') as string | undefined;
+  const fromConfig = Cypress.config('baseUrl') as string | undefined;
+  const raw = fromEnv ?? fromConfig;
+  if (!raw) {
+    return undefined;
+  }
+  return raw.replace(/\/+$/, '');
+}
+
+/**
+ * Persist `hideAnnouncements` globally so the Agent Builder announcement modal
+ * does not block UI (e.g. when running cypress:open without FTR uiSettings, or if
+ * global defaults have not applied before first paint).
+ */
+export const suppressGlobalAnnouncements = (): Cypress.Chainable<Cypress.Response<unknown>> => {
+  const kibanaOrigin = resolveKibanaOrigin();
+  const user = Cypress.env('ELASTICSEARCH_USERNAME') ?? 'elastic';
+  const pass = Cypress.env('ELASTICSEARCH_PASSWORD') ?? 'changeme';
+
+  if (!kibanaOrigin) {
+    cy.log(
+      'suppressGlobalAnnouncements: skipping (set KIBANA_URL or cypress baseUrl for global_settings POST)'
+    );
+    return cy.wrap(null, { log: false });
+  }
+
+  return cy.request({
+    method: 'POST',
+    url: `${kibanaOrigin}/internal/kibana/global_settings`,
+    body: { changes: { hideAnnouncements: true } },
+    headers: { 'kbn-xsrf': 'e2e_test' },
+    auth: { user, pass },
+    failOnStatusCode: false,
+  });
+};


### PR DESCRIPTION

## Summary

APM Cypress on-merge was failing with `CypressError: cy.click() failed … is being covered by another element: euiOverlayMask` (Agent Builder announcement modal) across onboarding, trace explorer, service inventory, diagnostics, mobile, and related specs.

This change **suppresses that modal in tests** by persisting the global UI setting **`hideAnnouncements: true`** via `POST /internal/kibana/global_settings`, aligned with Security Solution / Osquery patterns from [#260570](https://github.com/elastic/kibana/pull/260570).

**Implementation:**

- New helper `cypress/support/suppress_global_announcements.ts` — resolves Kibana origin from `Cypress.env('KIBANA_URL')` or `cypress.config('baseUrl')`, then POSTs `hideAnnouncements`.
- **`cy.visitKibana`** — calls `suppressGlobalAnnouncements()` before every `cy.visit` so app navigations are protected even when FTR `globalDefaults` race or for `cypress:open` without full FTR.
- **`cy.loginAs`** — calls `suppressGlobalAnnouncements()` at the start of every login (including cached `cy.session`), so each test run re-applies the flag before session setup.
- **`support/e2e.ts`** — root `before()` also invokes `suppressGlobalAnnouncements()` once per spec file.

No production UI or copy changes.

### Checklist

Check the PR satisfies following conditions.

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md) — **N/A** (test harness only; no user-facing strings).
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials — **N/A** (no product behavior change).
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios — **APM Cypress support/commands and e2e bootstrap updated** to stabilize E2E against the announcement modal.
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker) — **N/A**.
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations. — **N/A** (no API changes).
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed — **Author:** run per team policy for APM Cypress if required.
- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process) — **see below; use `release_note:skip` unless PM asks otherwise.**
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [x] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)

| Risk | Severity | Mitigation |
|------|-----------|------------|
| Extra `POST /internal/kibana/global_settings` per login + per `visitKibana` (and once per spec `before`) may add a small amount of test time | Low | Acceptable tradeoff for reliability; requests are small and idempotent (`hideAnnouncements: true`). |
| `suppressGlobalAnnouncements` uses admin-style credentials from FTR env (`ELASTICSEARCH_USERNAME` / `PASSWORD`); if missing or wrong, POST may no-op (`failOnStatusCode: false`) and tests could still flake | Low | Same pattern as other Cypress suites; FTR injects credentials; `KIBANA_URL` / `baseUrl` fallback reduces misconfiguration. |
| No impact on end-user Kibana behavior outside test runs | — | Settings apply to the test cluster / CI Kibana instance only. |

---

## Release notes

**Skip user-facing release notes** — test-only change.

Recommended label: **`release_note:skip`**

---

## How to verify locally

From `x-pack/solutions/observability/plugins/apm/ftr_e2e`:

```bash
node ../../../../security/plugins/security_solution/scripts/start_cypress_parallel.js run \
  --config-file ../observability/plugins/apm/ftr_e2e/cypress.config.ts \
  --ftr-config-file ../../../test/apm_cypress/cli_config.ts \
  --spec cypress/e2e/trace_explorer/trace_explorer.cy.ts
```

(Requires `yarn kbn bootstrap` and time for ES + Kibana to start.)

*PR created with Cursor and composer-2-fast**

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->