### PR TITLE
[9.3] [scout] run internal api tests against source (#262819)

### DIFF
--- a/.buildkite/pipeline-utils/scout/pick_scout_test_group_run_order.ts
+++ b/.buildkite/pipeline-utils/scout/pick_scout_test_group_run_order.ts
@@ -55,7 +55,7 @@ export async function pickScoutTestGroupRunOrder(scoutConfigsPath: string) {
       ? process.env.SCOUT_CONFIGS_DEPS.split(',')
           .map((t) => t.trim())
           .filter(Boolean)
-      : ['build_scout_tests'];
+      : ['build_scout_tests', 'build'];
 
   const scoutCiRunGroups = modulesWithTests.map((module) => {
     // Check if any config in this module uses parallel workers

--- a/.buildkite/pipelines/chrome_forward_testing.yml
+++ b/.buildkite/pipelines/chrome_forward_testing.yml
@@ -76,10 +76,9 @@ steps:
       machineType: n2-standard-4
     key: build_scout_tests
     timeout_in_minutes: 15
-    depends_on:
-      - build
     env:
       SCOUT_TEST_DISTRIBUTION_STRATEGY: 'configs'
+      SCOUT_CONFIGS_DEPS: 'build_scout_tests,build'
       SCOUT_CONFIGS_SCRIPT: '.buildkite/scripts/steps/test/scout/configs.sh'
     retry:
       automatic:

--- a/.buildkite/pipelines/es_snapshots/verify.yml
+++ b/.buildkite/pipelines/es_snapshots/verify.yml
@@ -65,10 +65,9 @@ steps:
       machineType: n2-standard-4
     key: build_scout_tests
     timeout_in_minutes: 15
-    depends_on:
-      - build
     env:
       SCOUT_TEST_DISTRIBUTION_STRATEGY: 'configs'
+      SCOUT_CONFIGS_DEPS: 'build_scout_tests,build'
       SCOUT_CONFIGS_SCRIPT: '.buildkite/scripts/steps/test/scout/configs.sh'
     retry:
       automatic:

--- a/.buildkite/pipelines/fleet/package_registry.yml
+++ b/.buildkite/pipelines/fleet/package_registry.yml
@@ -58,10 +58,9 @@ steps:
       machineType: n2-standard-4
     key: build_scout_tests
     timeout_in_minutes: 15
-    depends_on:
-      - build
     env:
       SCOUT_TEST_DISTRIBUTION_STRATEGY: 'configs'
+      SCOUT_CONFIGS_DEPS: 'build_scout_tests,build'
       SCOUT_CONFIGS_SCRIPT: '.buildkite/scripts/steps/test/scout/configs.sh'
     retry:
       automatic:

--- a/.buildkite/pipelines/on_merge.yml
+++ b/.buildkite/pipelines/on_merge.yml
@@ -214,11 +214,9 @@ steps:
       diskSizeGb: 105
     key: build_scout_tests
     timeout_in_minutes: 20
-    depends_on:
-      - build
     env:
       SCOUT_TEST_DISTRIBUTION_STRATEGY: 'configs'
-      SCOUT_CONFIGS_DEPS: 'build_scout_tests'
+      SCOUT_CONFIGS_DEPS: 'build_scout_tests,build'
       SCOUT_CONFIGS_SCRIPT: '.buildkite/scripts/steps/test/scout/configs.sh'
     retry:
       automatic:

--- a/.buildkite/pipelines/pointer_compression.yml
+++ b/.buildkite/pipelines/pointer_compression.yml
@@ -60,10 +60,9 @@ steps:
       machineType: n2-standard-4
     key: build_scout_tests
     timeout_in_minutes: 15
-    depends_on:
-      - build
     env:
       SCOUT_TEST_DISTRIBUTION_STRATEGY: 'configs'
+      SCOUT_CONFIGS_DEPS: 'build_scout_tests,build'
       SCOUT_CONFIGS_SCRIPT: '.buildkite/scripts/steps/test/scout/configs.sh'
     retry:
       automatic:

--- a/.buildkite/pipelines/pull_request/base.yml
+++ b/.buildkite/pipelines/pull_request/base.yml
@@ -134,11 +134,9 @@ steps:
       machineType: n2d-standard-8
     key: build_scout_tests
     timeout_in_minutes: 20
-    depends_on:
-      - build
     env:
       SCOUT_TEST_DISTRIBUTION_STRATEGY: 'configs'
-      SCOUT_CONFIGS_DEPS: 'build_scout_tests'
+      SCOUT_CONFIGS_DEPS: 'build_scout_tests,build'
       SCOUT_CONFIGS_SCRIPT: '.buildkite/scripts/steps/test/scout/configs.sh'
       SELECTIVE_TESTING_ENABLED: 'true'
     retry:

--- a/.buildkite/scripts/steps/test/scout/test_run_builder.sh
+++ b/.buildkite/scripts/steps/test/scout/test_run_builder.sh
@@ -2,7 +2,8 @@
 
 set -euo pipefail
 
-source .buildkite/scripts/steps/functional/common.sh
+source .buildkite/scripts/bootstrap.sh
+.buildkite/scripts/setup_es_snapshot_cache.sh
 
 echo '--- Verify Playwright CLI is functional'
 node scripts/scout run-playwright-test-check
@@ -77,13 +78,12 @@ else
   buildkite-agent artifact upload "scout_playwright_configs.json"
 fi
 
-echo '--- Running Scout API Integration Tests'
+echo '--- Running Scout API Integration Tests (against Kibana source code)'
 node scripts/scout.js run-tests \
   --location local \
   --arch stateful \
   --domain classic \
   --config src/platform/packages/shared/kbn-scout/test/scout/api/parallel.playwright.config.ts \
-  --kibanaInstallDir "$KIBANA_BUILD_LOCATION"
 
 source .buildkite/scripts/steps/test/scout/upload_report_events.sh
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[scout] run internal api tests against source (#262819)](https://github.com/elastic/kibana/pull/262819)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Dzmitry Lemechko","email":"dzmitry.lemechko@elastic.co"},"sourceCommit":{"committedDate":"2026-04-13T18:12:49Z","message":"[scout] run internal api tests against source (#262819)\n\n## Summary\n\nRemoves dependency on `Build Kibana Distribution` step from `Scout Test\nRun Builder` step by running internal api tests against Kibana source\ncode. Both steps are run in **parallel**, so we can start run actual\nScout tests as soon as build step is ready (no delay).\n\nIt should allow us to start scout tests execution **~10 minutes\nealier**.\n\nNote: BK steps that run scout tests still depend on build step and won't\nbe run before its ready.\n\n<img width=\"1221\" height=\"436\" alt=\"Screenshot 2026-04-13 at 18 35 34\"\nsrc=\"https://github.com/user-attachments/assets/9f9fe074-5a2c-4d86-a537-fad61a4ecb40\"\n/>\n\n---------\n\nCo-authored-by: Jon <jon@budzenski.me>","sha":"d105ad6f0f1e912c46e95cb00620aee1b3af2da5","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:all-open","test:scout","v9.4.0","v9.5.0"],"title":"[scout] run internal api tests against source","number":262819,"url":"https://github.com/elastic/kibana/pull/262819","mergeCommit":{"message":"[scout] run internal api tests against source (#262819)\n\n## Summary\n\nRemoves dependency on `Build Kibana Distribution` step from `Scout Test\nRun Builder` step by running internal api tests against Kibana source\ncode. Both steps are run in **parallel**, so we can start run actual\nScout tests as soon as build step is ready (no delay).\n\nIt should allow us to start scout tests execution **~10 minutes\nealier**.\n\nNote: BK steps that run scout tests still depend on build step and won't\nbe run before its ready.\n\n<img width=\"1221\" height=\"436\" alt=\"Screenshot 2026-04-13 at 18 35 34\"\nsrc=\"https://github.com/user-attachments/assets/9f9fe074-5a2c-4d86-a537-fad61a4ecb40\"\n/>\n\n---------\n\nCo-authored-by: Jon <jon@budzenski.me>","sha":"d105ad6f0f1e912c46e95cb00620aee1b3af2da5"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/262878","number":262878,"state":"MERGED","mergeCommit":{"sha":"f59d0f58fbc8deda594476f655ddf302059713de","message":"[9.4] [scout] run internal api tests against source (#262819) (#262878)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.4`:\n- [[scout] run internal api tests against source\n(#262819)](https://github.com/elastic/kibana/pull/262819)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Dzmitry Lemechko <dzmitry.lemechko@elastic.co>\nCo-authored-by: Jon <jon@budzenski.me>"}},{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/262819","number":262819,"mergeCommit":{"message":"[scout] run internal api tests against source (#262819)\n\n## Summary\n\nRemoves dependency on `Build Kibana Distribution` step from `Scout Test\nRun Builder` step by running internal api tests against Kibana source\ncode. Both steps are run in **parallel**, so we can start run actual\nScout tests as soon as build step is ready (no delay).\n\nIt should allow us to start scout tests execution **~10 minutes\nealier**.\n\nNote: BK steps that run scout tests still depend on build step and won't\nbe run before its ready.\n\n<img width=\"1221\" height=\"436\" alt=\"Screenshot 2026-04-13 at 18 35 34\"\nsrc=\"https://github.com/user-attachments/assets/9f9fe074-5a2c-4d86-a537-fad61a4ecb40\"\n/>\n\n---------\n\nCo-authored-by: Jon <jon@budzenski.me>","sha":"d105ad6f0f1e912c46e95cb00620aee1b3af2da5"}}]}] BACKPORT-->