### PR TITLE
[`@kbn/dev-utils`] Exclude `target` dirs from search

### DIFF
--- a/packages/kbn-managed-vscode-config/src/managed_config_keys.ts
+++ b/packages/kbn-managed-vscode-config/src/managed_config_keys.ts
@@ -39,6 +39,7 @@ export const MANAGED_CONFIG_KEYS: ManagedConfigKey[] = [
     key: 'search.exclude',
     value: {
       ['**/api_docs']: true,
+      ['**/target']: true,
       ['**/tsconfig.tsbuildinfo']: true,
       ['**/*.map']: true,
     },


### PR DESCRIPTION
## Summary

Excluded all `target/` directories from search results in VSCode or Cursor. This PR adds a managed exclude setting for `target` so everyone to enjoy!

I kept seeing `target/` dirs when doing a global search in VSCode or Cursor when using an includes path. It works normally and excludes the `target/` by default with nothing in the include input.

<img width="50%" src="https://github.com/user-attachments/assets/e9930941-8f51-46a6-8b42-cdbbed4182d3">

### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.