### PR TITLE
[9.3]  [Osquery] extend query execution timeout to 24h (#262008)

### DIFF
--- a/src/platform/packages/shared/kbn-osquery-io-ts-types/src/live_query/index.ts
+++ b/src/platform/packages/shared/kbn-osquery-io-ts-types/src/live_query/index.ts
@@ -51,7 +51,7 @@ export type Interval = t.TypeOf<typeof interval>;
 export const intervalOrUndefined = t.union([interval, t.undefined]);
 export type IntervalOrUndefined = t.TypeOf<typeof intervalOrUndefined>;
 
-export const timeout = inRangeRt(60, 60 * 15);
+export const timeout = inRangeRt(60, 60 * 60 * 24);
 export type Timeout = t.TypeOf<typeof timeout>;
 export const timeoutOrUndefined = t.union([timeout, t.undefined]);
 export type TimeoutOrUndefined = t.TypeOf<typeof timeoutOrUndefined>;

--- a/x-pack/platform/plugins/shared/osquery/common/constants.ts
+++ b/x-pack/platform/plugins/shared/osquery/common/constants.ts
@@ -30,6 +30,11 @@ export const API_VERSIONS = {
   },
 };
 
+/**
+ * How long osqueryd on the agent is allowed to execute a single query.
+ * Validated server-side via inRangeRt() in @kbn/osquery-io-ts-types and client-side in timeout_field.tsx.
+ * The max of 24h matches what osquerybeat actually supports.
+ */
 export enum QUERY_TIMEOUT {
   DEFAULT = 60,
   MAX = 86400,

--- a/x-pack/platform/plugins/shared/osquery/common/constants.ts
+++ b/x-pack/platform/plugins/shared/osquery/common/constants.ts
@@ -31,6 +31,14 @@ export const API_VERSIONS = {
 };
 
 export enum QUERY_TIMEOUT {
-  DEFAULT = 60, // 60 seconds
-  MAX = 900, // 15 minutes (matches backend inRangeRt(60, 60 * 15))
+  DEFAULT = 60,
+  MAX = 86400,
 }
+
+/**
+ * How long Fleet Server holds an undelivered action for offline agents.
+ * Agents that check in within this window will receive the query; after that, the action expires.
+ * Set to 2 weeks to match endpoint response actions (isolate/release) and cover
+ * extended offline periods (weekends, travel, intermittent connectivity).
+ */
+export const ACTION_EXPIRATION_WEEKS = 2;

--- a/x-pack/platform/plugins/shared/osquery/cypress/e2e/all/live_query.cy.ts
+++ b/x-pack/platform/plugins/shared/osquery/cypress/e2e/all/live_query.cy.ts
@@ -37,12 +37,12 @@ describe('ALL - Live Query', { tags: ['@ess', '@serverless'] }, () => {
     cy.contains('Query is a required field').should('not.exist');
     checkResults();
     getAdvancedButton().click();
-    fillInQueryTimeout('901');
+    fillInQueryTimeout('86401');
     submitQuery();
-    cy.contains('The timeout value must be 900 seconds or lower.');
-    fillInQueryTimeout('890');
+    cy.contains('The timeout value must be 86400 seconds or lower.');
+    fillInQueryTimeout('120');
     submitQuery();
-    cy.contains('The timeout value must be 900 seconds or lower.').should('not.exist');
+    cy.contains('The timeout value must be 86400 seconds or lower.').should('not.exist');
     typeInOsqueryFieldInput('days{downArrow}{enter}');
     submitQuery();
     cy.contains('ECS field is required.');
@@ -53,9 +53,9 @@ describe('ALL - Live Query', { tags: ['@ess', '@serverless'] }, () => {
     cy.contains('ECS field is required.').should('not.exist');
     cy.wait('@postQuery').then((interception) => {
       expect(interception.request.body).to.have.property('query', 'select * from uptime;');
-      expect(interception.request.body).to.have.property('timeout', 890);
+      expect(interception.request.body).to.have.property('timeout', 120);
       expect(interception.response?.statusCode).to.eq(200);
-      expect(interception.response?.body.data.queries[0]).to.have.property('timeout', 890);
+      expect(interception.response?.body.data.queries[0]).to.have.property('timeout', 120);
     });
     checkResults();
     const firstCell = '[data-gridcell-column-index="0"][data-gridcell-row-index="0"]';

--- a/x-pack/platform/plugins/shared/osquery/server/handlers/action/create_action_handler.ts
+++ b/x-pack/platform/plugins/shared/osquery/server/handlers/action/create_action_handler.ts
@@ -16,7 +16,7 @@ import { parseAgentSelection } from '../../lib/parse_agent_groups';
 import { packSavedObjectType } from '../../../common/types';
 import type { OsqueryAppContext } from '../../lib/osquery_app_context_services';
 import { convertSOQueriesToPack } from '../../routes/pack/utils';
-import { ACTIONS_INDEX, QUERY_TIMEOUT } from '../../../common/constants';
+import { ACTIONS_INDEX, ACTION_EXPIRATION_WEEKS, QUERY_TIMEOUT } from '../../../common/constants';
 import { TELEMETRY_EBT_LIVE_QUERY_EVENT } from '../../lib/telemetry/constants';
 import type { PackSavedObject } from '../../common/types';
 import { CustomHttpRequestError } from '../../common/error';
@@ -83,7 +83,7 @@ export const createActionHandler = async (
   const osqueryAction = {
     action_id: uuidv4(),
     '@timestamp': moment().toISOString(),
-    expiration: moment().add(5, 'minutes').toISOString(),
+    expiration: moment().add(ACTION_EXPIRATION_WEEKS, 'weeks').toISOString(),
     type: 'INPUT_ACTION',
     input_type: 'osquery',
     alert_ids: params.alert_ids,
@@ -138,7 +138,7 @@ export const createActionHandler = async (
         (query) => ({
           action_id: query.action_id,
           '@timestamp': moment().toISOString(),
-          expiration: moment().add(5, 'minutes').toISOString(),
+          expiration: moment().add(ACTION_EXPIRATION_WEEKS, 'weeks').toISOString(),
           type: 'INPUT_ACTION',
           input_type: 'osquery',
           agents: query.agents,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [ [Osquery] extend query execution timeout to 24h (#262008)](https://github.com/elastic/kibana/pull/262008)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Tomasz Ciecierski","email":"tomasz.ciecierski@elastic.co"},"sourceCommit":{"committedDate":"2026-04-13T19:33:06Z","message":" [Osquery] extend query execution timeout to 24h (#262008)","sha":"bb4ca8d1ca3cd745cacf2abff9703a671977ced5","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Defend Workflows","backport:version","v9.4.0","v9.5.0","v9.3.4"],"title":" [Osquery] extend query execution timeout to 24h","number":262008,"url":"https://github.com/elastic/kibana/pull/262008","mergeCommit":{"message":" [Osquery] extend query execution timeout to 24h (#262008)","sha":"bb4ca8d1ca3cd745cacf2abff9703a671977ced5"}},"sourceBranch":"main","suggestedTargetBranches":["9.3"],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/262896","number":262896,"state":"MERGED","mergeCommit":{"sha":"4274e2675daee411bf69c5563e92ef8dfbe1129f","message":"[9.4]  [Osquery] extend query execution timeout to 24h (#262008) (#262896)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.4`:\n- [ [Osquery] extend query execution timeout to 24h\n(#262008)](https://github.com/elastic/kibana/pull/262008)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Tomasz Ciecierski <tomasz.ciecierski@elastic.co>"}},{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/262008","number":262008,"mergeCommit":{"message":" [Osquery] extend query execution timeout to 24h (#262008)","sha":"bb4ca8d1ca3cd745cacf2abff9703a671977ced5"}},{"branch":"9.3","label":"v9.3.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->