### PR TITLE
[9.4] [Streams] Make featureClient/queryClient lazy to avoid ELSER probing on every request (#262859)

### DIFF
--- a/x-pack/platform/plugins/shared/streams/server/agent_builder/tools/search_knowledge_indicators/tool.ts
+++ b/x-pack/platform/plugins/shared/streams/server/agent_builder/tools/search_knowledge_indicators/tool.ts
@@ -110,10 +110,15 @@ export function createSearchKnowledgeIndicatorsTool({
       const { request } = context;
 
       try {
-        const { streamsClient, featureClient, queryClient, licensing, uiSettingsClient } =
+        const { streamsClient, getFeatureClient, getQueryClient, licensing, uiSettingsClient } =
           await getScopedClients({ request });
 
         await assertSignificantEventsAccess({ server, licensing, uiSettingsClient });
+
+        const [featureClient, queryClient] = await Promise.all([
+          getFeatureClient(),
+          getQueryClient(),
+        ]);
 
         const output = await searchKnowledgeIndicatorsToolHandler({
           streamsClient,

--- a/x-pack/platform/plugins/shared/streams/server/lib/sig_events/tasks/insights_discovery.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/sig_events/tasks/insights_discovery.ts
@@ -59,11 +59,13 @@ export function createStreamsInsightsDiscoveryTask(taskContext: TaskContext) {
                 scopedClusterClient,
                 streamsClient,
                 inferenceClient,
-                queryClient,
+                getQueryClient,
                 insightClient,
               } = await taskContext.getScopedClients({
                 request: runContext.fakeRequest,
               });
+
+              const queryClient = await getQueryClient();
 
               const taskLogger = taskContext.logger.get('insights_discovery');
               const connectorId =

--- a/x-pack/platform/plugins/shared/streams/server/lib/sig_events/tasks/significant_events_queries_generation.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/sig_events/tasks/significant_events_queries_generation.ts
@@ -65,11 +65,13 @@ export function createStreamsSignificantEventsQueriesGenerationTask(taskContext:
                 streamsClient,
                 inferenceClient,
                 soClient,
-                featureClient,
+                getFeatureClient,
                 scopedClusterClient,
               } = await taskContext.getScopedClients({
                 request: runContext.fakeRequest,
               });
+
+              const featureClient = await getFeatureClient();
 
               const taskLogger = taskContext.logger.get('significant_events_queries_generation');
               const connectorId =

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/client.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/client.ts
@@ -78,8 +78,8 @@ export class StreamsClient {
       esClientAsInternalUser: ElasticsearchClient;
       esClient: ElasticsearchClient;
       attachmentClient: AttachmentClient;
-      queryClient?: QueryClient;
-      featureClient?: FeatureClient;
+      getQueryClient?: () => Promise<QueryClient>;
+      getFeatureClient?: () => Promise<FeatureClient>;
       storageClient: StreamsStorageClient;
       logger: Logger;
       isServerless: boolean;
@@ -321,9 +321,10 @@ export class StreamsClient {
         }
       );
 
-      const { attachmentClient, queryClient, storageClient } = this.dependencies;
-      const cleanOps = [attachmentClient.clean(), storageClient.clean()];
-      if (queryClient) {
+      const { attachmentClient, getQueryClient, storageClient } = this.dependencies;
+      const cleanOps: Array<Promise<unknown>> = [attachmentClient.clean(), storageClient.clean()];
+      if (getQueryClient) {
+        const queryClient = await getQueryClient();
         cleanOps.push(queryClient.clean());
       }
       await Promise.all(cleanOps);
@@ -1013,8 +1014,9 @@ export class StreamsClient {
       ),
     ];
 
-    if (this.dependencies.queryClient) {
-      ops.push(this.dependencies.queryClient.syncQueries(definition, queries));
+    if (this.dependencies.getQueryClient) {
+      const queryClient = await this.dependencies.getQueryClient();
+      ops.push(queryClient.syncQueries(definition, queries));
     }
 
     await Promise.all(ops);

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/service.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/service.ts
@@ -24,16 +24,16 @@ export class StreamsService {
 
   async getClient({
     attachmentClient,
-    queryClient,
-    featureClient,
+    getQueryClient,
+    getFeatureClient,
     esClient,
     esClientAsInternalUser,
     uiSettingsClient,
     isSecurityEnabled,
   }: {
     attachmentClient: AttachmentClient;
-    queryClient?: QueryClient;
-    featureClient?: FeatureClient;
+    getQueryClient?: () => Promise<QueryClient>;
+    getFeatureClient?: () => Promise<FeatureClient>;
     esClient: ElasticsearchClient;
     esClientAsInternalUser: ElasticsearchClient;
     uiSettingsClient: IUiSettingsClient;
@@ -50,9 +50,9 @@ export class StreamsService {
 
     return new StreamsClient({
       attachmentClient,
-      queryClient,
+      getQueryClient,
       logger,
-      featureClient,
+      getFeatureClient,
       esClient,
       esClientAsInternalUser,
       lockManager: new LockManagerService(this.coreSetup, logger),

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/execution_plan/execution_plan.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/execution_plan/execution_plan.ts
@@ -278,11 +278,11 @@ export class ExecutionPlan {
       return;
     }
 
-    const { queryClient } = this.dependencies;
-    if (!queryClient) {
+    const { getQueryClient } = this.dependencies;
+    if (!getQueryClient) {
       throw new Error('queryClient is required for deleteQueries but was not provided');
     }
-
+    const queryClient = await getQueryClient();
     return Promise.all(actions.map((action) => queryClient.deleteAll(action.request.definition)));
   }
 
@@ -309,11 +309,11 @@ export class ExecutionPlan {
       return;
     }
 
-    const { featureClient } = this.dependencies;
-    if (!featureClient) {
+    const { getFeatureClient } = this.dependencies;
+    if (!getFeatureClient) {
       throw new Error('featureClient is required for unlinkFeatures but was not provided');
     }
-
+    const featureClient = await getFeatureClient();
     return Promise.all(actions.map((action) => featureClient.deleteFeatures(action.request.name)));
   }
 

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/types.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/types.ts
@@ -33,8 +33,8 @@ export interface StateDependencies {
   storageClient: StreamsStorageClient;
   esClient: ElasticsearchClient;
   attachmentClient: AttachmentClient;
-  queryClient?: QueryClient;
-  featureClient?: FeatureClient;
+  getQueryClient?: () => Promise<QueryClient>;
+  getFeatureClient?: () => Promise<FeatureClient>;
   isServerless: boolean;
   isSecurityEnabled: boolean;
   isWiredStreamViewsEnabled: boolean;

--- a/x-pack/platform/plugins/shared/streams/server/lib/tasks/task_definitions/features_identification/index.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/tasks/task_definitions/features_identification/index.ts
@@ -392,13 +392,15 @@ export function createStreamsFeaturesIdentificationTask(taskContext: TaskContext
               const {
                 taskClient,
                 scopedClusterClient,
-                featureClient,
+                getFeatureClient,
                 streamsClient,
                 inferenceClient,
                 soClient,
               } = await taskContext.getScopedClients({
                 request: runContext.fakeRequest,
               });
+
+              const featureClient = await getFeatureClient();
 
               const taskLogger = taskContext.logger.get('features_identification', streamName);
               const connectorId =

--- a/x-pack/platform/plugins/shared/streams/server/lib/tasks/task_definitions/onboarding.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/tasks/task_definitions/onboarding.ts
@@ -75,8 +75,8 @@ async function areFeaturesUpToDate({
 
   return Boolean(
     featuresTask.last_completed_at &&
-    Date.now() - new Date(featuresTask.last_completed_at).getTime() <
-      FEATURES_IDENTIFICATION_RECENCY_MS
+      Date.now() - new Date(featuresTask.last_completed_at).getTime() <
+        FEATURES_IDENTIFICATION_RECENCY_MS
   );
 }
 

--- a/x-pack/platform/plugins/shared/streams/server/lib/tasks/task_definitions/onboarding.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/tasks/task_definitions/onboarding.ts
@@ -75,8 +75,8 @@ async function areFeaturesUpToDate({
 
   return Boolean(
     featuresTask.last_completed_at &&
-      Date.now() - new Date(featuresTask.last_completed_at).getTime() <
-        FEATURES_IDENTIFICATION_RECENCY_MS
+    Date.now() - new Date(featuresTask.last_completed_at).getTime() <
+      FEATURES_IDENTIFICATION_RECENCY_MS
   );
 }
 
@@ -96,11 +96,10 @@ export function createStreamsOnboardingTask(taskContext: TaskContext) {
               const { streamName, from, to, steps, saveQueries, connectors, _task } = runContext
                 .taskInstance.params as TaskParams<OnboardingTaskParams>;
 
-              const { taskClient, queryClient, streamsClient } = await taskContext.getScopedClients(
-                {
+              const { taskClient, getQueryClient, streamsClient } =
+                await taskContext.getScopedClients({
                   request: fakeRequest,
-                }
-              );
+                });
 
               try {
                 let featuresTaskResult: TaskResult<IdentifyFeaturesResult> | undefined;
@@ -170,7 +169,7 @@ export function createStreamsOnboardingTask(taskContext: TaskContext) {
 
                       if (saveQueries) {
                         await persistQueries(streamName, queriesTaskResult.queries, {
-                          queryClient,
+                          queryClient: await getQueryClient(),
                           streamsClient,
                         });
                       }

--- a/x-pack/platform/plugins/shared/streams/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/streams/server/plugin.ts
@@ -80,12 +80,15 @@ export const config: PluginConfigDescriptor<StreamsConfig> = {
   exposeToBrowser: exposeToBrowserConfig,
 };
 
-export class StreamsPlugin implements Plugin<
-  StreamsPluginSetup,
-  StreamsPluginStart,
-  StreamsPluginSetupDependencies,
-  StreamsPluginStartDependencies
-> {
+export class StreamsPlugin
+  implements
+    Plugin<
+      StreamsPluginSetup,
+      StreamsPluginStart,
+      StreamsPluginSetupDependencies,
+      StreamsPluginStartDependencies
+    >
+{
   public config: StreamsConfig;
   public logger: Logger;
   public server?: StreamsServer;

--- a/x-pack/platform/plugins/shared/streams/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/streams/server/plugin.ts
@@ -50,6 +50,8 @@ import type {
 import { createStreamsGlobalSearchResultProvider } from './lib/streams/create_streams_global_search_result_provider';
 import { backfillWiredStreamViews } from './lib/streams/esql_views/backfill_wired_stream_views';
 import { FeatureService } from './lib/streams/feature/feature_service';
+import type { FeatureClient } from './lib/streams/feature/feature_client';
+import type { QueryClient } from './lib/streams/assets/query/query_client';
 import { ProcessorSuggestionsService } from './lib/streams/ingest_pipelines/processor_suggestions_service';
 import { registerStreamsSavedObjects } from './lib/saved_objects/register_saved_objects';
 import { TaskService } from './lib/tasks/task_service';
@@ -78,15 +80,12 @@ export const config: PluginConfigDescriptor<StreamsConfig> = {
   exposeToBrowser: exposeToBrowserConfig,
 };
 
-export class StreamsPlugin
-  implements
-    Plugin<
-      StreamsPluginSetup,
-      StreamsPluginStart,
-      StreamsPluginSetupDependencies,
-      StreamsPluginStartDependencies
-    >
-{
+export class StreamsPlugin implements Plugin<
+  StreamsPluginSetup,
+  StreamsPluginStart,
+  StreamsPluginSetupDependencies,
+  StreamsPluginStartDependencies
+> {
   public config: StreamsConfig;
   public logger: Logger;
   public server?: StreamsServer;
@@ -171,32 +170,44 @@ export class StreamsPlugin
         this.logger
       );
 
-      const [attachmentClient, featureClient, insightClient, contentClient, queryClient] =
-        await Promise.all([
-          attachmentService.getClient({
-            soClient,
-            rulesClient: await pluginsStart.alerting.getRulesClientWithRequest(request),
-          }),
-          featureService.getClient(),
-          insightService.getInternalClient(),
-          contentService.getClient(),
-          queryService.getClient({
+      const [attachmentClient, insightClient, contentClient] = await Promise.all([
+        attachmentService.getClient({
+          soClient,
+          rulesClient: await pluginsStart.alerting.getRulesClientWithRequest(request),
+        }),
+        insightService.getInternalClient(),
+        contentService.getClient(),
+      ]);
+
+      let featureClientPromise: Promise<FeatureClient> | undefined;
+      const getFeatureClient = (): Promise<FeatureClient> => {
+        featureClientPromise ??= featureService.getClient();
+        return featureClientPromise;
+      };
+
+      let queryClientPromise: Promise<QueryClient> | undefined;
+      const getQueryClient = (): Promise<QueryClient> => {
+        queryClientPromise ??= (async () => {
+          const rulesClient = await pluginsStart.alerting.getRulesClientWithRequestInSpace(
+            request,
+            DEFAULT_SPACE_ID
+          );
+          return queryService.getClient({
             esClient: coreStart.elasticsearch.client.asInternalUser,
             soClient,
-            rulesClient: await pluginsStart.alerting.getRulesClientWithRequestInSpace(
-              request,
-              DEFAULT_SPACE_ID
-            ),
-          }),
-        ]);
+            rulesClient,
+          });
+        })();
+        return queryClientPromise;
+      };
 
       const license = await licensing.getLicense();
       const isSecurityEnabled = license.getFeature('security').isEnabled;
 
       const streamsClient = await streamsService.getClient({
         attachmentClient,
-        queryClient,
-        featureClient,
+        getQueryClient,
+        getFeatureClient,
         esClient: scopedClusterClient.asCurrentUser,
         esClientAsInternalUser: coreStart.elasticsearch.client.asInternalUser,
         uiSettingsClient,
@@ -213,11 +224,11 @@ export class StreamsPlugin
         soClient,
         attachmentClient,
         streamsClient,
-        featureClient,
+        getFeatureClient,
         insightClient,
         inferenceClient,
         contentClient,
-        queryClient,
+        getQueryClient,
         fieldsMetadataClient,
         licensing,
         uiSettingsClient,

--- a/x-pack/platform/plugins/shared/streams/server/routes/content/route.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/content/route.ts
@@ -60,7 +60,7 @@ const exportContentRoute = createServerRoute({
   async handler({ params, request, response, context, getScopedClients }) {
     await checkEnabled(context);
 
-    const { queryClient, streamsClient } = await getScopedClients({ request });
+    const { getQueryClient, streamsClient } = await getScopedClients({ request });
 
     const root = await streamsClient.getStream(params.path.name);
     if (!Streams.WiredStream.Definition.is(root)) {
@@ -72,6 +72,7 @@ const exportContentRoute = createServerRoute({
       streamsClient.getDescendants(params.path.name),
     ]);
 
+    const queryClient = await getQueryClient();
     const queryLinks = await queryClient.getStreamToQueryLinksMap([
       params.path.name,
       ...descendants.map((stream) => stream.name),
@@ -174,7 +175,7 @@ const importContentRoute = createServerRoute({
   async handler({ params, request, context, getScopedClients }) {
     await checkEnabled(context);
 
-    const { queryClient, streamsClient } = await getScopedClients({ request });
+    const { getQueryClient, streamsClient } = await getScopedClients({ request });
 
     const root = await streamsClient.getStream(params.path.name);
     if (!Streams.WiredStream.Definition.is(root)) {
@@ -184,6 +185,7 @@ const importContentRoute = createServerRoute({
     const contentPack = await parseArchive(params.body.content);
 
     const descendants = await streamsClient.getDescendants(params.path.name);
+    const queryClient = await getQueryClient();
     const queryLinks = await queryClient.getStreamToQueryLinksMap([
       params.path.name,
       ...descendants.map(({ name }) => name),

--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/sig_events/features/route.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/sig_events/features/route.ts
@@ -48,13 +48,16 @@ export const upsertFeatureRoute = createServerRoute({
     getScopedClients,
     server,
   }): Promise<{ acknowledged: boolean }> => {
-    const { featureClient, licensing, uiSettingsClient, streamsClient } = await getScopedClients({
-      request,
-    });
+    const { getFeatureClient, licensing, uiSettingsClient, streamsClient } = await getScopedClients(
+      {
+        request,
+      }
+    );
 
     await assertSignificantEventsAccess({ server, licensing, uiSettingsClient });
     await streamsClient.ensureStream(params.path.name);
 
+    const featureClient = await getFeatureClient();
     await featureClient.bulk(params.path.name, [
       {
         index: {
@@ -93,13 +96,16 @@ export const deleteFeatureRoute = createServerRoute({
     getScopedClients,
     server,
   }): Promise<{ acknowledged: boolean }> => {
-    const { featureClient, licensing, uiSettingsClient, streamsClient } = await getScopedClients({
-      request,
-    });
+    const { getFeatureClient, licensing, uiSettingsClient, streamsClient } = await getScopedClients(
+      {
+        request,
+      }
+    );
 
     await assertSignificantEventsAccess({ server, licensing, uiSettingsClient });
     await streamsClient.ensureStream(params.path.name);
 
+    const featureClient = await getFeatureClient();
     await featureClient.deleteFeature(params.path.name, params.path.uuid);
 
     return { acknowledged: true };
@@ -134,13 +140,16 @@ export const listFeaturesRoute = createServerRoute({
     getScopedClients,
     server,
   }): Promise<{ features: Feature[] }> => {
-    const { featureClient, licensing, uiSettingsClient, streamsClient } = await getScopedClients({
-      request,
-    });
+    const { getFeatureClient, licensing, uiSettingsClient, streamsClient } = await getScopedClients(
+      {
+        request,
+      }
+    );
 
     await assertSignificantEventsAccess({ server, licensing, uiSettingsClient });
     await streamsClient.ensureStream(params.path.name);
 
+    const featureClient = await getFeatureClient();
     const {
       query,
       search_mode: searchMode,
@@ -180,15 +189,18 @@ export const listAllFeaturesRoute = createServerRoute({
     getScopedClients,
     server,
   }): Promise<{ features: Feature[] }> => {
-    const { featureClient, licensing, uiSettingsClient, streamsClient } = await getScopedClients({
-      request,
-    });
+    const { getFeatureClient, licensing, uiSettingsClient, streamsClient } = await getScopedClients(
+      {
+        request,
+      }
+    );
 
     await assertSignificantEventsAccess({ server, licensing, uiSettingsClient });
 
     const streams = await streamsClient.listStreams();
     const streamNames = streams.map((stream) => stream.name);
 
+    const featureClient = await getFeatureClient();
     const { query, search_mode: searchMode } = params?.query ?? {};
     const { hits: features } = query
       ? await featureClient.findFeatures(streamNames, query, { searchMode })
@@ -245,9 +257,11 @@ export const bulkFeaturesRoute = createServerRoute({
     getScopedClients,
     server,
   }): Promise<{ acknowledged: boolean }> => {
-    const { featureClient, streamsClient, licensing, uiSettingsClient } = await getScopedClients({
-      request,
-    });
+    const { getFeatureClient, streamsClient, licensing, uiSettingsClient } = await getScopedClients(
+      {
+        request,
+      }
+    );
 
     await assertSignificantEventsAccess({ server, licensing, uiSettingsClient });
 
@@ -258,6 +272,7 @@ export const bulkFeaturesRoute = createServerRoute({
 
     await streamsClient.ensureStream(name);
 
+    const featureClient = await getFeatureClient();
     await featureClient.bulk(name, operations);
 
     return { acknowledged: true };

--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/sig_events/queries/route.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/sig_events/queries/route.ts
@@ -47,12 +47,13 @@ export const getUnbackedQueriesCountRoute = createServerRoute({
   },
   params: z.object({}),
   handler: async ({ request, getScopedClients, server }): Promise<{ count: number }> => {
-    const { queryClient, licensing, uiSettingsClient } = await getScopedClients({
+    const { getQueryClient, licensing, uiSettingsClient } = await getScopedClients({
       request,
     });
 
     await assertSignificantEventsAccess({ server, licensing, uiSettingsClient });
 
+    const queryClient = await getQueryClient();
     const count = await queryClient.getUnbackedQueriesCount();
     return { count };
   },
@@ -85,12 +86,13 @@ export const promoteUnbackedQueriesRoute = createServerRoute({
     server,
     logger,
   }): Promise<{ promoted: number }> => {
-    const { queryClient, streamsClient, licensing, uiSettingsClient } = await getScopedClients({
+    const { getQueryClient, streamsClient, licensing, uiSettingsClient } = await getScopedClients({
       request,
     });
 
     await assertSignificantEventsAccess({ server, licensing, uiSettingsClient });
 
+    const queryClient = await getQueryClient();
     const all = await queryClient.getAllUnbackedQueries();
     const requestedQueryIds = params?.body?.queryIds ?? [];
 
@@ -153,12 +155,13 @@ export const demoteBackedQueriesRoute = createServerRoute({
     server,
     logger,
   }): Promise<{ demoted: number }> => {
-    const { queryClient, streamsClient, licensing, uiSettingsClient } = await getScopedClients({
+    const { getQueryClient, streamsClient, licensing, uiSettingsClient } = await getScopedClients({
       request,
     });
 
     await assertSignificantEventsAccess({ server, licensing, uiSettingsClient });
 
+    const queryClient = await getQueryClient();
     const toDemote = await queryClient.getQueryLinks([], {
       ruleUnbacked: 'exclude',
       queryIds: params.body.queryIds,
@@ -222,7 +225,7 @@ const getDiscoveryQueriesRoute = createServerRoute({
     },
   },
   handler: async ({ params, request, getScopedClients, server }): Promise<QueriesGetResponse> => {
-    const { queryClient, scopedClusterClient, licensing, uiSettingsClient } =
+    const { getQueryClient, scopedClusterClient, licensing, uiSettingsClient } =
       await getScopedClients({
         request,
       });
@@ -241,6 +244,7 @@ const getDiscoveryQueriesRoute = createServerRoute({
       searchMode,
     } = params.query;
 
+    const queryClient = await getQueryClient();
     const { significant_events: queries } = await readSignificantEventsFromAlertsIndices(
       {
         from,
@@ -288,7 +292,7 @@ const getDiscoveryQueriesOccurrencesRoute = createServerRoute({
     getScopedClients,
     server,
   }): Promise<QueriesOccurrencesGetResponse> => {
-    const { queryClient, scopedClusterClient, licensing, uiSettingsClient } =
+    const { getQueryClient, scopedClusterClient, licensing, uiSettingsClient } =
       await getScopedClients({
         request,
       });
@@ -297,6 +301,7 @@ const getDiscoveryQueriesOccurrencesRoute = createServerRoute({
 
     const { from, to, bucketSize, query, streamNames } = params.query;
 
+    const queryClient = await getQueryClient();
     const { aggregated_occurrences: aggregatedOccurrenceBuckets } =
       await readSignificantEventsFromAlertsIndices(
         {

--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/sig_events/significant_events/route.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/sig_events/significant_events/route.ts
@@ -179,7 +179,7 @@ const readAllSignificantEventsRoute = createServerRoute({
     getScopedClients,
     server,
   }): Promise<SignificantEventsGetResponse> => {
-    const { queryClient, scopedClusterClient, licensing, uiSettingsClient } =
+    const { getQueryClient, scopedClusterClient, licensing, uiSettingsClient } =
       await getScopedClients({
         request,
       });
@@ -187,6 +187,7 @@ const readAllSignificantEventsRoute = createServerRoute({
 
     const { from, to, bucketSize, query, streamNames, searchMode } = params.query;
 
+    const queryClient = await getQueryClient();
     return readSignificantEventsFromAlertsIndices(
       {
         from,

--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/management/suggest_partitions_route.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/management/suggest_partitions_route.ts
@@ -74,7 +74,7 @@ export const suggestPartitionsRoute = createServerRoute({
       throw new SecurityError('Cannot access API on the current pricing tier');
     }
 
-    const { inferenceClient, scopedClusterClient, streamsClient, featureClient } =
+    const { inferenceClient, scopedClusterClient, streamsClient, getFeatureClient } =
       await getScopedClients({
         request,
       });
@@ -99,6 +99,7 @@ export const suggestPartitionsRoute = createServerRoute({
       existingPartitions: params.body.existing_partitions,
       refinementHistory: params.body.refinement_history,
       getFeatures: async (filters) => {
+        const featureClient = await getFeatureClient();
         const { hits } = await featureClient.getFeatures(params.path.name, filters);
         return hits;
       },

--- a/x-pack/platform/plugins/shared/streams/server/routes/sig_events/queries/route.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/sig_events/queries/route.ts
@@ -54,7 +54,7 @@ const listQueriesRoute = createServerRoute({
     },
   },
   async handler({ params, request, getScopedClients }): Promise<ListQueriesResponse> {
-    const { queryClient, streamsClient, licensing } = await getScopedClients({ request });
+    const { getQueryClient, streamsClient, licensing } = await getScopedClients({ request });
     await assertEnterpriseLicense(licensing);
     await streamsClient.ensureStream(params.path.name);
 
@@ -62,6 +62,7 @@ const listQueriesRoute = createServerRoute({
       path: { name: streamName },
     } = params;
 
+    const queryClient = await getQueryClient();
     const { [streamName]: queryLinks } = await queryClient.getStreamToQueryLinksMap([streamName]);
 
     return {
@@ -94,7 +95,7 @@ const upsertQueryRoute = createServerRoute({
     body: upsertStreamQueryRequestSchema,
   }),
   handler: async ({ params, request, getScopedClients }): Promise<UpsertQueryResponse> => {
-    const { streamsClient, queryClient, licensing } = await getScopedClients({ request });
+    const { streamsClient, getQueryClient, licensing } = await getScopedClients({ request });
     const {
       path: { name: streamName, queryId },
       body,
@@ -108,6 +109,7 @@ const upsertQueryRoute = createServerRoute({
       stream: definition,
     });
 
+    const queryClient = await getQueryClient();
     await queryClient.upsert(definition, {
       id: queryId,
       title: body.title,
@@ -146,7 +148,7 @@ const deleteQueryRoute = createServerRoute({
     }),
   }),
   handler: async ({ params, request, getScopedClients, logger }): Promise<DeleteQueryResponse> => {
-    const { streamsClient, queryClient, licensing } = await getScopedClients({
+    const { streamsClient, getQueryClient, licensing } = await getScopedClients({
       request,
     });
     await assertEnterpriseLicense(licensing);
@@ -157,6 +159,7 @@ const deleteQueryRoute = createServerRoute({
 
     const definition = await streamsClient.getStream(streamName);
 
+    const queryClient = await getQueryClient();
     const queryLink = await queryClient.bulkGetByIds(streamName, [queryId]);
     if (queryLink.length === 0) {
       throw new QueryNotFoundError(`Query [${queryId}] not found in stream [${streamName}]`);
@@ -211,7 +214,7 @@ const bulkQueriesRoute = createServerRoute({
     getScopedClients,
     logger,
   }): Promise<BulkUpdateAssetsResponse> => {
-    const { streamsClient, queryClient, licensing } = await getScopedClients({ request });
+    const { streamsClient, getQueryClient, licensing } = await getScopedClients({ request });
     await assertEnterpriseLicense(licensing);
 
     const {
@@ -242,6 +245,7 @@ const bulkQueriesRoute = createServerRoute({
       });
     }
 
+    const queryClient = await getQueryClient();
     await queryClient.bulk(definition, operations);
 
     logger

--- a/x-pack/platform/plugins/shared/streams/server/routes/sig_events/streams/significant_events/route.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/sig_events/streams/significant_events/route.ts
@@ -125,7 +125,7 @@ const readStreamSignificantEventsRoute = createServerRoute({
     getScopedClients,
     server,
   }): Promise<SignificantEventsGetResponse> => {
-    const { streamsClient, queryClient, scopedClusterClient, licensing, uiSettingsClient } =
+    const { streamsClient, getQueryClient, scopedClusterClient, licensing, uiSettingsClient } =
       await getScopedClients({
         request,
       });
@@ -135,6 +135,7 @@ const readStreamSignificantEventsRoute = createServerRoute({
     const { name } = params.path;
     const { from, to, bucketSize, query, searchMode } = params.query;
 
+    const queryClient = await getQueryClient();
     return readSignificantEventsFromAlertsIndices(
       {
         streamNames: [name],
@@ -201,7 +202,7 @@ const generateSignificantEventsRoute = createServerRoute({
       inferenceClient,
       uiSettingsClient,
       soClient,
-      featureClient,
+      getFeatureClient,
       scopedClusterClient,
     } = await getScopedClients({ request });
 
@@ -215,11 +216,13 @@ const generateSignificantEventsRoute = createServerRoute({
     });
 
     // Get connector info for error enrichment
-    const [connector, definition, { significantEventsPromptOverride }] = await Promise.all([
-      inferenceClient.getConnectorById(connectorId),
-      streamsClient.getStream(params.path.name),
-      new PromptsConfigService({ soClient, logger }).getPrompt(),
-    ]);
+    const [connector, definition, { significantEventsPromptOverride }, featureClient] =
+      await Promise.all([
+        inferenceClient.getConnectorById(connectorId),
+        streamsClient.getStream(params.path.name),
+        new PromptsConfigService({ soClient, logger }).getPrompt(),
+        getFeatureClient(),
+      ]);
 
     return fromRxjs(
       generateSignificantEventDefinitions(

--- a/x-pack/platform/plugins/shared/streams/server/routes/streams/crud/route.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/streams/crud/route.ts
@@ -63,11 +63,12 @@ export const readStreamRoute = createServerRoute({
     server,
     logger,
   }): Promise<Streams.all.GetResponse> => {
-    const { queryClient, attachmentClient, streamsClient, scopedClusterClient } =
+    const { getQueryClient, attachmentClient, streamsClient, scopedClusterClient } =
       await getScopedClients({
         request,
       });
 
+    const queryClient = await getQueryClient();
     const body = await readStream({
       name: params.path.name,
       queryClient,

--- a/x-pack/platform/plugins/shared/streams/server/routes/streams/ingest/route.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/streams/ingest/route.ts
@@ -231,7 +231,7 @@ const upsertIngestRoute = createServerRoute({
     }),
   }),
   handler: async ({ params, request, getScopedClients }) => {
-    const { streamsClient, queryClient, attachmentClient } = await getScopedClients({
+    const { streamsClient, getQueryClient, attachmentClient } = await getScopedClients({
       request,
     });
 
@@ -252,6 +252,8 @@ const upsertIngestRoute = createServerRoute({
         'Cannot modify ingest settings of a replicated stream. It is managed by the source cluster via cross-cluster replication.'
       );
     }
+
+    const queryClient = await getQueryClient();
 
     if (WiredIngestUpsertRequest.is(ingest)) {
       return await updateWiredIngest({

--- a/x-pack/platform/plugins/shared/streams/server/routes/streams/query/route.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/streams/query/route.ts
@@ -125,7 +125,7 @@ const upsertQueryStreamRoute = createServerRoute({
     }),
   }),
   handler: async ({ params, request, getScopedClients, context, logger }) => {
-    const { streamsClient, queryClient, attachmentClient } = await getScopedClients({
+    const { streamsClient, getQueryClient, attachmentClient } = await getScopedClients({
       request,
     });
 
@@ -178,6 +178,7 @@ const upsertQueryStreamRoute = createServerRoute({
     }
 
     // Get existing assets and attachments to preserve them
+    const queryClient = await getQueryClient();
     const [assets, attachments] = await Promise.all([
       queryClient.getAssets(name),
       attachmentClient.getAttachments(name),

--- a/x-pack/platform/plugins/shared/streams/server/routes/types.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/types.ts
@@ -39,11 +39,11 @@ export interface RouteHandlerScopedClients {
   soClient: SavedObjectsClientContract;
   attachmentClient: AttachmentClient;
   streamsClient: StreamsClient;
-  featureClient: FeatureClient;
+  getFeatureClient: () => Promise<FeatureClient>;
   insightClient: InsightClient;
   inferenceClient: InferenceClient;
   contentClient: ContentClient;
-  queryClient: QueryClient;
+  getQueryClient: () => Promise<QueryClient>;
   licensing: LicensingPluginStart;
   uiSettingsClient: IUiSettingsClient;
   globalUiSettingsClient: IUiSettingsClient;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Streams] Make featureClient/queryClient lazy to avoid ELSER probing on every request (#262859)](https://github.com/elastic/kibana/pull/262859)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Joe Reuter","email":"johannes.reuter@elastic.co"},"sourceCommit":{"committedDate":"2026-04-13T19:08:57Z","message":"[Streams] Make featureClient/queryClient lazy to avoid ELSER probing on every request (#262859)\n\n## Summary\n\nCloses the remaining ELSER lazy-deployment issue left after #260387\n(enable wired streams by default).\n\n### Root cause\n\n`getScopedClients` in `plugin.ts` called `featureService.getClient()`\nand `queryService.getClient()` **eagerly for every streams HTTP\nrequest**, including lightweight read routes like `GET\n/api/streams/_status`. Both service `getClient()` methods call\n`resolveInference()` → `probeInference()`, which sends a test input to\nthe ELSER inference API (`esClient.inference.inference({ input: 'test',\n... })`). This triggers lazy ELSER model deployment even when the route\ndoesn't need semantic search at all.\n\n#260387 fixed the *startup preconfiguration* path, but every HTTP\nrequest to any streams route still probed ELSER via `getScopedClients`.\n\n### Fix\n\nReplace `featureClient: FeatureClient` and `queryClient: QueryClient` in\n`RouteHandlerScopedClients` with lazy getter functions:\n\n```ts\ngetFeatureClient: () => Promise<FeatureClient>\ngetQueryClient: () => Promise<QueryClient>\n```\n\nThe getters memoize their promise within the request lifecycle —\n`featureService.getClient()` / `queryService.getClient()` are now only\ncalled by routes that actually need semantic search. Routes that don't\n(status checks, listing, etc.) no longer trigger any inference probe.\n\nUpdated `StateDependencies`, `StreamsClient`, `StreamsService`, the\nexecution plan (`deleteQueries`, `unlinkFeatures`), all route handlers,\nand all task runners to use the getter pattern.\n\n## Test plan\n\n- [ ] Type check passes\n- [ ] ML tests no longer see unexpected ELSER model deployments when\nstreams features are not actively used\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\nCo-authored-by: Claude Sonnet 4.6 (1M context) <noreply@anthropic.com>","sha":"984bc3ab0d6c4a810b1010250cfdc5fd7df0f8c8","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:obs-onboarding","backport:version","Feature:Streams","v9.4.0","Team:SigEvents","v9.5.0"],"title":"[Streams] Make featureClient/queryClient lazy to avoid ELSER probing on every request","number":262859,"url":"https://github.com/elastic/kibana/pull/262859","mergeCommit":{"message":"[Streams] Make featureClient/queryClient lazy to avoid ELSER probing on every request (#262859)\n\n## Summary\n\nCloses the remaining ELSER lazy-deployment issue left after #260387\n(enable wired streams by default).\n\n### Root cause\n\n`getScopedClients` in `plugin.ts` called `featureService.getClient()`\nand `queryService.getClient()` **eagerly for every streams HTTP\nrequest**, including lightweight read routes like `GET\n/api/streams/_status`. Both service `getClient()` methods call\n`resolveInference()` → `probeInference()`, which sends a test input to\nthe ELSER inference API (`esClient.inference.inference({ input: 'test',\n... })`). This triggers lazy ELSER model deployment even when the route\ndoesn't need semantic search at all.\n\n#260387 fixed the *startup preconfiguration* path, but every HTTP\nrequest to any streams route still probed ELSER via `getScopedClients`.\n\n### Fix\n\nReplace `featureClient: FeatureClient` and `queryClient: QueryClient` in\n`RouteHandlerScopedClients` with lazy getter functions:\n\n```ts\ngetFeatureClient: () => Promise<FeatureClient>\ngetQueryClient: () => Promise<QueryClient>\n```\n\nThe getters memoize their promise within the request lifecycle —\n`featureService.getClient()` / `queryService.getClient()` are now only\ncalled by routes that actually need semantic search. Routes that don't\n(status checks, listing, etc.) no longer trigger any inference probe.\n\nUpdated `StateDependencies`, `StreamsClient`, `StreamsService`, the\nexecution plan (`deleteQueries`, `unlinkFeatures`), all route handlers,\nand all task runners to use the getter pattern.\n\n## Test plan\n\n- [ ] Type check passes\n- [ ] ML tests no longer see unexpected ELSER model deployments when\nstreams features are not actively used\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\nCo-authored-by: Claude Sonnet 4.6 (1M context) <noreply@anthropic.com>","sha":"984bc3ab0d6c4a810b1010250cfdc5fd7df0f8c8"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/262859","number":262859,"mergeCommit":{"message":"[Streams] Make featureClient/queryClient lazy to avoid ELSER probing on every request (#262859)\n\n## Summary\n\nCloses the remaining ELSER lazy-deployment issue left after #260387\n(enable wired streams by default).\n\n### Root cause\n\n`getScopedClients` in `plugin.ts` called `featureService.getClient()`\nand `queryService.getClient()` **eagerly for every streams HTTP\nrequest**, including lightweight read routes like `GET\n/api/streams/_status`. Both service `getClient()` methods call\n`resolveInference()` → `probeInference()`, which sends a test input to\nthe ELSER inference API (`esClient.inference.inference({ input: 'test',\n... })`). This triggers lazy ELSER model deployment even when the route\ndoesn't need semantic search at all.\n\n#260387 fixed the *startup preconfiguration* path, but every HTTP\nrequest to any streams route still probed ELSER via `getScopedClients`.\n\n### Fix\n\nReplace `featureClient: FeatureClient` and `queryClient: QueryClient` in\n`RouteHandlerScopedClients` with lazy getter functions:\n\n```ts\ngetFeatureClient: () => Promise<FeatureClient>\ngetQueryClient: () => Promise<QueryClient>\n```\n\nThe getters memoize their promise within the request lifecycle —\n`featureService.getClient()` / `queryService.getClient()` are now only\ncalled by routes that actually need semantic search. Routes that don't\n(status checks, listing, etc.) no longer trigger any inference probe.\n\nUpdated `StateDependencies`, `StreamsClient`, `StreamsService`, the\nexecution plan (`deleteQueries`, `unlinkFeatures`), all route handlers,\nand all task runners to use the getter pattern.\n\n## Test plan\n\n- [ ] Type check passes\n- [ ] ML tests no longer see unexpected ELSER model deployments when\nstreams features are not actively used\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\nCo-authored-by: Claude Sonnet 4.6 (1M context) <noreply@anthropic.com>","sha":"984bc3ab0d6c4a810b1010250cfdc5fd7df0f8c8"}}]}] BACKPORT-->