### PR TITLE
[Security Solution][Attacks/Alerts] Add cell value actions to entity badges in Attack details flyout

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/components/ai_summary_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/components/ai_summary_section.tsx
@@ -9,6 +9,7 @@ import React, { memo, useCallback, useState } from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { EuiIcon, EuiPanel, EuiSpacer, EuiSwitch, EuiTitle } from '@elastic/eui';
 import { css } from '@emotion/react';
+import { TableId } from '@kbn/securitysolution-data-table';
 import { AttackDiscoveryMarkdownFormatter } from '../../../attack_discovery/pages/results/attack_discovery_markdown_formatter';
 import { useOverviewTabData } from '../hooks/use_overview_tab_data';
 import { ExpandableSection } from '../../../flyout_v2/shared/components/expandable_section';
@@ -84,7 +85,8 @@ export const AISummarySection = memo(() => {
       <EuiPanel hasBorder data-test-subj="overview-tab-ai-summary-panel">
         <div data-test-subj="overview-tab-ai-summary-content">
           <AttackDiscoveryMarkdownFormatter
-            disableActions
+            scopeId={TableId.alertsOnAttacksPage}
+            disableActions={showAnonymized}
             markdown={showAnonymized ? summaryMarkdown : summaryMarkdownWithReplacements}
           />
         </div>
@@ -104,7 +106,8 @@ export const AISummarySection = memo(() => {
 
         <div data-test-subj="overview-tab-ai-background-content">
           <AttackDiscoveryMarkdownFormatter
-            disableActions
+            disableActions={showAnonymized}
+            scopeId={TableId.alertsOnAttacksPage}
             markdown={showAnonymized ? detailsMarkdown : detailsMarkdownWithReplacements}
           />
         </div>


### PR DESCRIPTION
## Summary

Closes: https://github.com/elastic/kibana/issues/262342
Enables Attack Discovery markdown formatter actions in the attack details flyout `AI summary`.

Previously, `AttackDiscoveryMarkdownFormatter` was always passed `disableActions`, so alert-related actions never appeared. Actions are now tied to the anonymized toggle: they stay off while **anonymized** output is shown, and turn on for the normal (de-anonymized) view.

`scopeId` is set to `TableId.alertsOnAttacksPage` so those actions resolve in the same context as alerts on the attacks page.


## Testing

- [ ] Open an attack’s details flyout → Overview → AI summary
- [ ] With **anonymized** off: confirm formatter actions behave as expected.
- [ ] With **anonymized** on: confirm actions remain disabled for the scrubbed view.


https://github.com/user-attachments/assets/e6221e48-76d7-48bb-99fb-f9831a4cacd5





<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->