### PR TITLE
[Significant events] Make run discovery button a global for the app

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/insights/summary.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/insights/summary.tsx
@@ -39,25 +39,13 @@ export function Summary({ count }: { count: number }) {
   } = useKibana();
   const { euiTheme } = useEuiTheme();
 
-  const {
-    scheduleInsightsDiscoveryTask,
-    getInsightsDiscoveryTaskStatus,
-    acknowledgeInsightsDiscoveryTask,
-    cancelInsightsDiscoveryTask,
-  } = useInsightsDiscoveryApi();
+  const { getInsightsDiscoveryTaskStatus, cancelInsightsDiscoveryTask } =
+    useInsightsDiscoveryApi();
 
   const [insights, setInsights] = useState<Insight[] | null>(null);
   const [selectedInsight, setSelectedInsight] = useState<Insight | null>(null);
 
   const [{ value: task }, getTaskStatus] = useAsyncFn(getInsightsDiscoveryTaskStatus);
-  const [{ loading: isSchedulingTask }, scheduleTask] = useAsyncFn(async () => {
-    /**
-     * Combining scheduling and immediate status update to prevent
-     * React updating the UI in between states causing flickering
-     */
-    await scheduleInsightsDiscoveryTask();
-    await getTaskStatus();
-  }, [scheduleInsightsDiscoveryTask, getTaskStatus]);
 
   useEffect(() => {
     getTaskStatus();
@@ -71,7 +59,7 @@ export function Summary({ count }: { count: number }) {
 
     if (task?.status === TaskStatus.InProgress && previousStatus !== TaskStatus.InProgress) {
       setInsights(null);
-      setSelectedInsight(null); // <-- add this
+      setSelectedInsight(null);
       return;
     }
 
@@ -109,14 +97,6 @@ export function Summary({ count }: { count: number }) {
 
   const handleSelectInsight = useCallback((insight: Insight) => setSelectedInsight(insight), []);
   const handleCloseFlyout = useCallback(() => setSelectedInsight(null), []);
-
-  const onRunDiscoveryClick = async () => {
-    await acknowledgeInsightsDiscoveryTask();
-    await scheduleTask();
-  };
-
-  const isTaskPending =
-    task?.status === TaskStatus.InProgress || isCancellingTask || isSchedulingTask;
 
   const columns = useMemo<Array<EuiBasicTableColumn<Insight>>>(
     () => [
@@ -223,44 +203,22 @@ export function Summary({ count }: { count: number }) {
   if (insights && insights.length > 0) {
     return (
       <>
-        <EuiFlexGroup direction="column" gutterSize="s">
-          <EuiFlexItem grow={false}>
-            <EuiFlexGroup justifyContent="flexEnd" responsive={false}>
-              <EuiFlexItem grow={false}>
-                <EuiButton
-                  size="s"
-                  iconType="sparkles"
-                  onClick={onRunDiscoveryClick}
-                  isDisabled={isSchedulingTask}
-                  isLoading={isSchedulingTask}
-                  data-test-subj="significant_events_run_discovery_button"
-                >
-                  {i18n.translate('xpack.streams.insights.runDiscoveryButtonLabel', {
-                    defaultMessage: 'Run a discovery',
-                  })}
-                </EuiButton>
-              </EuiFlexItem>
-            </EuiFlexGroup>
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiBasicTable
-              data-test-subj="streamsInsightsTable"
-              columns={columns}
-              items={insights}
-              itemId="id"
-              tableLayout="fixed"
-              rowProps={(insight: Insight) => ({
-                style: {
-                  height: '68px',
-                  background:
-                    selectedInsight?.id === insight.id
-                      ? euiTheme.colors.backgroundBaseInteractiveSelect
-                      : undefined,
-                },
-              })}
-            />
-          </EuiFlexItem>
-        </EuiFlexGroup>
+        <EuiBasicTable
+          data-test-subj="streamsInsightsTable"
+          columns={columns}
+          items={insights}
+          itemId="id"
+          tableLayout="fixed"
+          rowProps={(insight: Insight) => ({
+            style: {
+              height: '68px',
+              background:
+                selectedInsight?.id === insight.id
+                  ? euiTheme.colors.backgroundBaseInteractiveSelect
+                  : undefined,
+            },
+          })}
+        />
         {selectedInsight && <InsightFlyout insight={selectedInsight} onClose={handleCloseFlyout} />}
       </>
     );
@@ -295,40 +253,21 @@ export function Summary({ count }: { count: number }) {
         </p>
       }
       actions={
-        <EuiFlexGroup gutterSize="s" responsive={false} justifyContent="center">
+        task?.status === TaskStatus.InProgress || isCancellingTask ? (
           <EuiButton
-            fill
-            size="m"
-            iconType="sparkles"
-            onClick={() => scheduleTask()}
-            isDisabled={isTaskPending}
-            isLoading={isTaskPending}
-            data-test-subj="significant_events_generate_insights_button"
+            onClick={cancelTask}
+            isDisabled={isCancellingTask}
+            data-test-subj="significant_events_cancel_insights_generation_button"
           >
-            {task?.status === TaskStatus.InProgress
-              ? i18n.translate('xpack.streams.insights.generatingButtonLabel', {
-                  defaultMessage: 'Discovering Significant Events',
+            {isCancellingTask
+              ? i18n.translate('xpack.streams.insights.cancellingTaskButtonLabel', {
+                  defaultMessage: 'Cancelling',
                 })
-              : i18n.translate('xpack.streams.insights.generateButtonLabel', {
-                  defaultMessage: 'Discover Significant Events',
+              : i18n.translate('xpack.streams.insights.cancelTaskButtonLabel', {
+                  defaultMessage: 'Cancel',
                 })}
           </EuiButton>
-          {(task?.status === TaskStatus.InProgress || isCancellingTask) && (
-            <EuiButton
-              onClick={cancelTask}
-              isDisabled={isCancellingTask}
-              data-test-subj="significant_events_cancel_insights_generation_button"
-            >
-              {isCancellingTask
-                ? i18n.translate('xpack.streams.insights.cancellingTaskButtonLabel', {
-                    defaultMessage: 'Cancelling',
-                  })
-                : i18n.translate('xpack.streams.insights.cancelTaskButtonLabel', {
-                    defaultMessage: 'Cancel',
-                  })}
-            </EuiButton>
-          )}
-        </EuiFlexGroup>
+        ) : undefined
       }
     />
   );

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/significant_events_discovery_discover_button.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/significant_events_discovery_discover_button.tsx
@@ -6,7 +6,7 @@
  */
 
 import { EuiButton, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import useAsyncFn from 'react-use/lib/useAsyncFn';
 import { toMountPoint } from '@kbn/react-kibana-mount';
 import { TaskStatus } from '@kbn/streams-schema';
@@ -48,8 +48,11 @@ export function SignificantEventsDiscoveryDiscoverButton({
     displayDiscoveryConnectorId,
   } = connectorConfig;
 
-  const { scheduleInsightsDiscoveryTask, getInsightsDiscoveryTaskStatus } =
-    useInsightsDiscoveryApi();
+  const {
+    scheduleInsightsDiscoveryTask,
+    getInsightsDiscoveryTaskStatus,
+    cancelInsightsDiscoveryTask,
+  } = useInsightsDiscoveryApi();
   const [{ value: insightsTask }, getInsightsTaskStatus] = useAsyncFn(
     getInsightsDiscoveryTaskStatus
   );
@@ -58,11 +61,16 @@ export function SignificantEventsDiscoveryDiscoverButton({
     getInsightsTaskStatus();
   }, [getInsightsTaskStatus]);
 
-  useTaskPolling({
+  const { cancelTask, isCancellingTask } = useTaskPolling({
     task: insightsTask,
     onPoll: getInsightsDiscoveryTaskStatus,
     onRefresh: getInsightsTaskStatus,
+    onCancel: cancelInsightsDiscoveryTask,
   });
+
+  const onStopDiscovering = useCallback(async () => {
+    await cancelTask();
+  }, [cancelTask]);
 
   const [{ loading: isSchedulingInsights }, scheduleInsightsTask] = useAsyncFn(async () => {
     const streamNames = undefined;
@@ -85,7 +93,13 @@ export function SignificantEventsDiscoveryDiscoverButton({
 
   useEffect(() => {
     if (!isWaitingForInsightsTask || !insightsTask) return;
-    if (insightsTask.status !== TaskStatus.Completed && insightsTask.status !== TaskStatus.Failed) {
+
+    const isTerminal =
+      insightsTask.status === TaskStatus.Completed ||
+      insightsTask.status === TaskStatus.Failed ||
+      insightsTask.status === TaskStatus.Canceled;
+
+    if (!isTerminal) {
       return;
     }
     setIsWaitingForInsightsTask(false);
@@ -129,6 +143,12 @@ export function SignificantEventsDiscoveryDiscoverButton({
     }
   }, [isWaitingForInsightsTask, insightsTask, toasts, router, core]);
 
+  const isDiscovering =
+    isSchedulingInsights ||
+    isWaitingForInsightsTask ||
+    insightsTask?.status === TaskStatus.InProgress ||
+    insightsTask?.status === TaskStatus.BeingCanceled;
+
   return (
     <InsightsSplitButton
       allConnectors={allConnectors}
@@ -137,11 +157,10 @@ export function SignificantEventsDiscoveryDiscoverButton({
       displayConnectorId={displayDiscoveryConnectorId}
       onConnectorChange={setDiscoveryConnectorOverride}
       onRun={scheduleInsightsTask}
-      isLoading={
-        isSchedulingInsights ||
-        isWaitingForInsightsTask ||
-        insightsTask?.status === TaskStatus.InProgress
-      }
+      onStopDiscovering={onStopDiscovering}
+      isDiscovering={isDiscovering}
+      isCancellingDiscovering={isCancellingTask}
+      isSecondaryLoading={isDiscovering}
       isDisabled={isConnectorCatalogUnavailable || discoveryConnectors.loading}
     />
   );

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/significant_events_discovery_discover_button.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/significant_events_discovery_discover_button.tsx
@@ -1,0 +1,148 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiButton, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import React, { useEffect, useState } from 'react';
+import useAsyncFn from 'react-use/lib/useAsyncFn';
+import { toMountPoint } from '@kbn/react-kibana-mount';
+import { TaskStatus } from '@kbn/streams-schema';
+import type { UseConnectorConfigResult } from '../../../../hooks/sig_events/use_connector_config';
+import { useInsightsDiscoveryApi } from '../../../../hooks/sig_events/use_insights_discovery_api';
+import { useKibana } from '../../../../hooks/use_kibana';
+import { useStreamsAppRouter } from '../../../../hooks/use_streams_app_router';
+import { useTaskPolling } from '../../../../hooks/use_task_polling';
+import { getFormattedError } from '../../../../util/errors';
+import { InsightsSplitButton } from './streams_view/insights_split_button';
+import {
+  getInsightsCompleteToastTitle,
+  INSIGHTS_COMPLETE_TOAST_VIEW_BUTTON,
+  INSIGHTS_SCHEDULING_FAILURE_TITLE,
+  NO_INSIGHTS_TOAST_TITLE,
+} from './streams_view/translations';
+
+export function SignificantEventsDiscoveryDiscoverButton({
+  connectorConfig,
+}: {
+  connectorConfig: UseConnectorConfigResult;
+}) {
+  const {
+    core,
+    core: {
+      notifications: { toasts },
+    },
+  } = useKibana();
+  const router = useStreamsAppRouter();
+  const [isWaitingForInsightsTask, setIsWaitingForInsightsTask] = useState(false);
+
+  const {
+    allConnectors,
+    connectorError,
+    isConnectorCatalogUnavailable,
+    discoveryConnectors,
+    discoveryConnectorOverride,
+    setDiscoveryConnectorOverride,
+    displayDiscoveryConnectorId,
+  } = connectorConfig;
+
+  const { scheduleInsightsDiscoveryTask, getInsightsDiscoveryTaskStatus } =
+    useInsightsDiscoveryApi();
+  const [{ value: insightsTask }, getInsightsTaskStatus] = useAsyncFn(
+    getInsightsDiscoveryTaskStatus
+  );
+
+  useEffect(() => {
+    getInsightsTaskStatus();
+  }, [getInsightsTaskStatus]);
+
+  useTaskPolling({
+    task: insightsTask,
+    onPoll: getInsightsDiscoveryTaskStatus,
+    onRefresh: getInsightsTaskStatus,
+  });
+
+  const [{ loading: isSchedulingInsights }, scheduleInsightsTask] = useAsyncFn(async () => {
+    const streamNames = undefined;
+    try {
+      await scheduleInsightsDiscoveryTask(streamNames, discoveryConnectorOverride);
+      setIsWaitingForInsightsTask(true);
+      await getInsightsTaskStatus();
+    } catch (error) {
+      toasts.addError(getFormattedError(error), {
+        title: INSIGHTS_SCHEDULING_FAILURE_TITLE,
+      });
+      throw error;
+    }
+  }, [
+    scheduleInsightsDiscoveryTask,
+    discoveryConnectorOverride,
+    toasts,
+    getInsightsTaskStatus,
+  ]);
+
+  useEffect(() => {
+    if (!isWaitingForInsightsTask || !insightsTask) return;
+    if (insightsTask.status !== TaskStatus.Completed && insightsTask.status !== TaskStatus.Failed) {
+      return;
+    }
+    setIsWaitingForInsightsTask(false);
+    if (insightsTask.status === TaskStatus.Failed) {
+      toasts.addError(getFormattedError(new Error(insightsTask.error)), {
+        title: INSIGHTS_SCHEDULING_FAILURE_TITLE,
+      });
+      return;
+    }
+    if (insightsTask.status === TaskStatus.Completed) {
+      const count = insightsTask.insights?.length ?? 0;
+      if (count === 0) {
+        toasts.addInfo({
+          title: NO_INSIGHTS_TOAST_TITLE,
+        });
+      } else {
+        const toast = toasts.addSuccess({
+          title: getInsightsCompleteToastTitle(count),
+          text: toMountPoint(
+            <EuiFlexGroup justifyContent="flexEnd" gutterSize="s">
+              <EuiFlexItem grow={false}>
+                <EuiButton                  
+                  size="s"
+                  data-test-subj="significant_events_view_insights_toast_button"
+                  onClick={() => {
+                    toasts.remove(toast);
+                    router.push('/_discovery/{tab}', {
+                      path: { tab: 'significant_events' },
+                      query: {},
+                    });
+                  }}
+                >
+                  {INSIGHTS_COMPLETE_TOAST_VIEW_BUTTON}
+                </EuiButton>
+              </EuiFlexItem>
+            </EuiFlexGroup>,
+            core
+          ),
+        });
+      }
+    }
+  }, [isWaitingForInsightsTask, insightsTask, toasts, router, core]);
+
+  return (
+    <InsightsSplitButton
+      allConnectors={allConnectors}
+      connectorError={connectorError}
+      resolvedConnectorId={discoveryConnectors.resolvedConnectorId}
+      displayConnectorId={displayDiscoveryConnectorId}
+      onConnectorChange={setDiscoveryConnectorOverride}
+      onRun={scheduleInsightsTask}
+      isLoading={
+        isSchedulingInsights ||
+        isWaitingForInsightsTask ||
+        insightsTask?.status === TaskStatus.InProgress
+      }
+      isDisabled={isConnectorCatalogUnavailable || discoveryConnectors.loading}
+    />
+  );
+}

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/streams_view/context_menu_split_button.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/streams_view/context_menu_split_button.tsx
@@ -16,11 +16,31 @@ import {
   useGeneratedHtmlId,
 } from '@elastic/eui';
 import type { EuiContextMenuPanelDescriptor } from '@elastic/eui';
+import { css } from '@emotion/react';
 import { useBoolean } from '@kbn/react-hooks';
 import React, { useCallback, useMemo, useState } from 'react';
 import type { ComponentProps } from 'react';
 import { useModelSettingsUrl } from '../../../../../hooks/use_model_settings_url';
 import { MODEL_SETTINGS_LABEL } from './translations';
+
+/**
+ * The secondary action is wrapped in `EuiPopover`. The anchor uses styles such as
+ * `vertical-align: middle`, so in a split button row it can sit a few pixels off the
+ * primary segment. Stretch the popover anchor and match the icon control height.
+ */
+const splitButtonPopoverAnchorStretchCss = css`
+  align-items: stretch;
+
+  & > .euiPopover {
+    align-self: stretch;
+    display: flex;
+    align-items: stretch;
+  }
+
+  & > .euiPopover .euiSplitButtonActionSecondary {
+    height: 100%;
+  }
+`;
 
 const modelSettingsMenuName = (
   <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
@@ -53,6 +73,8 @@ interface ContextMenuSplitButtonProps {
   errorTitle?: string;
 
   color?: ComponentProps<typeof EuiSplitButton>['color'];
+  fill?: ComponentProps<typeof EuiSplitButton>['fill'];
+  size?: ComponentProps<typeof EuiSplitButton>['size'];
   isLoading?: boolean;
   'data-test-subj'?: string;
 }
@@ -70,6 +92,8 @@ export const ContextMenuSplitButton = ({
   error,
   errorTitle,
   color,
+  fill,
+  size = 'm',
   isLoading,
   'data-test-subj': dataTestSubj,
 }: ContextMenuSplitButtonProps) => {
@@ -124,7 +148,14 @@ export const ContextMenuSplitButton = ({
   );
 
   return (
-    <EuiSplitButton size="m" color={color} isLoading={isLoading} data-test-subj={dataTestSubj}>
+    <EuiSplitButton
+      size={size}
+      color={color}
+      fill={fill}
+      isLoading={isLoading}
+      data-test-subj={dataTestSubj}
+      css={splitButtonPopoverAnchorStretchCss}
+    >
       <EuiSplitButton.ActionPrimary
         onClick={onPrimaryClick}
         isDisabled={isPrimaryDisabled}

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/streams_view/context_menu_split_button.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/streams_view/context_menu_split_button.tsx
@@ -75,6 +75,8 @@ interface ContextMenuSplitButtonProps {
   color?: ComponentProps<typeof EuiSplitButton>['color'];
   fill?: ComponentProps<typeof EuiSplitButton>['fill'];
   size?: ComponentProps<typeof EuiSplitButton>['size'];
+  /** When set, loading spinner appears only on the secondary action (not the primary). */
+  isSecondaryLoading?: boolean;
   isLoading?: boolean;
   'data-test-subj'?: string;
 }
@@ -94,9 +96,14 @@ export const ContextMenuSplitButton = ({
   color,
   fill,
   size = 'm',
+  isSecondaryLoading,
   isLoading,
   'data-test-subj': dataTestSubj,
 }: ContextMenuSplitButtonProps) => {
+  const splitButtonIsLoading =
+    isSecondaryLoading !== undefined ? false : Boolean(isLoading);
+  const secondaryIsLoading =
+    isSecondaryLoading !== undefined ? Boolean(isSecondaryLoading) : Boolean(isLoading);
   const { euiTheme } = useEuiTheme();
   const [isOpen, { off: close, toggle }] = useBoolean(false);
   const [menuResetKey, setMenuResetKey] = useState(0);
@@ -152,7 +159,7 @@ export const ContextMenuSplitButton = ({
       size={size}
       color={color}
       fill={fill}
-      isLoading={isLoading}
+      isLoading={splitButtonIsLoading}
       data-test-subj={dataTestSubj}
       css={splitButtonPopoverAnchorStretchCss}
     >
@@ -168,6 +175,7 @@ export const ContextMenuSplitButton = ({
         iconType="arrowDown"
         aria-label={secondaryAriaLabel}
         isDisabled={isSecondaryDisabled}
+        isLoading={secondaryIsLoading}
         data-test-subj={secondaryDataTestSubj}
         onClick={toggle}
         popoverProps={{

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/streams_view/insights_split_button.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/streams_view/insights_split_button.tsx
@@ -64,6 +64,7 @@ export const InsightsSplitButton = ({
     <ContextMenuSplitButton
       primaryLabel={DISCOVER_INSIGHTS_BUTTON_LABEL}
       onPrimaryClick={onRun}
+      primaryIconType="sparkles"
       isPrimaryDisabled={isDisabled || isLoading}
       primaryDataTestSubj="significant_events_discover_insights_button"
       secondaryAriaLabel={DISCOVER_INSIGHTS_CONFIG_ARIA_LABEL}
@@ -71,7 +72,8 @@ export const InsightsSplitButton = ({
       buildPanels={buildPanels}
       error={connectorError}
       errorTitle={CONNECTOR_LOAD_ERROR}
-      color="text"
+      color="primary"
+      size="s"
       isLoading={isLoading}
       data-test-subj="significant_events_discover_insights_split_button"
     />

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/streams_view/insights_split_button.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/streams_view/insights_split_button.tsx
@@ -11,6 +11,7 @@ import {
   CONNECTOR_LOAD_ERROR,
   DISCOVER_INSIGHTS_BUTTON_LABEL,
   DISCOVER_INSIGHTS_CONFIG_ARIA_LABEL,
+  STOP_DISCOVERING_INSIGHTS_BUTTON_LABEL,
 } from './translations';
 import { buildConnectorMenuItem, buildConnectorSelectionPanel } from './context_menu_helpers';
 import { ContextMenuSplitButton } from './context_menu_split_button';
@@ -23,7 +24,10 @@ interface InsightsSplitButtonProps {
   displayConnectorId: string | undefined;
   onConnectorChange: (connectorId: string) => void;
   onRun: () => void;
-  isLoading: boolean;
+  onStopDiscovering: () => void | Promise<void>;
+  isDiscovering: boolean;
+  isCancellingDiscovering: boolean;
+  isSecondaryLoading: boolean;
   isDisabled: boolean;
 }
 
@@ -34,7 +38,10 @@ export const InsightsSplitButton = ({
   displayConnectorId,
   onConnectorChange,
   onRun,
-  isLoading,
+  onStopDiscovering,
+  isDiscovering,
+  isCancellingDiscovering,
+  isSecondaryLoading,
   isDisabled,
 }: InsightsSplitButtonProps) => {
   const discoveryConnector = useMemo(
@@ -62,19 +69,22 @@ export const InsightsSplitButton = ({
 
   return (
     <ContextMenuSplitButton
-      primaryLabel={DISCOVER_INSIGHTS_BUTTON_LABEL}
-      onPrimaryClick={onRun}
-      primaryIconType="sparkles"
-      isPrimaryDisabled={isDisabled || isLoading}
+      primaryLabel={
+        isDiscovering ? STOP_DISCOVERING_INSIGHTS_BUTTON_LABEL : DISCOVER_INSIGHTS_BUTTON_LABEL
+      }
+      onPrimaryClick={() => (isDiscovering ? onStopDiscovering() : onRun())}
+      primaryIconType={isDiscovering ? 'stop' : 'sparkles'}
+      isPrimaryDisabled={isDisabled || (isDiscovering && isCancellingDiscovering)}
       primaryDataTestSubj="significant_events_discover_insights_button"
       secondaryAriaLabel={DISCOVER_INSIGHTS_CONFIG_ARIA_LABEL}
+      isSecondaryDisabled={isDisabled || isDiscovering}
       secondaryDataTestSubj="significant_events_insights_connector_trigger"
       buildPanels={buildPanels}
       error={connectorError}
       errorTitle={CONNECTOR_LOAD_ERROR}
       color="primary"
       size="s"
-      isLoading={isLoading}
+      isSecondaryLoading={isSecondaryLoading}
       data-test-subj="significant_events_discover_insights_split_button"
     />
   );

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/streams_view/streams_view.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/streams_view/streams_view.tsx
@@ -6,34 +6,24 @@
  */
 
 import type { EuiSearchBarProps, Query } from '@elastic/eui';
-import { EuiButton, EuiFlexGroup, EuiFlexItem, EuiSearchBar, EuiText } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiSearchBar, EuiText } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
-import { toMountPoint } from '@kbn/react-kibana-mount';
 import type { OnboardingResult, TaskResult } from '@kbn/streams-schema';
 import { OnboardingStep, TaskStatus } from '@kbn/streams-schema';
 import pMap from 'p-map';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import useAsyncFn from 'react-use/lib/useAsyncFn';
 import type { TableRow } from './utils';
+import type { UseConnectorConfigResult } from '../../../../../hooks/sig_events/use_connector_config';
 import { useIndexPatternsConfig } from '../../../../../hooks/use_index_patterns_config';
 import { useKibana } from '../../../../../hooks/use_kibana';
-import { useInsightsDiscoveryApi } from '../../../../../hooks/sig_events/use_insights_discovery_api';
-import { useConnectorConfig } from '../../../../../hooks/sig_events/use_connector_config';
 import type { ScheduleOnboardingOptions } from '../../../../../hooks/use_onboarding_api';
 import { useOnboardingApi } from '../../../../../hooks/use_onboarding_api';
-import { useStreamsAppRouter } from '../../../../../hooks/use_streams_app_router';
-import { useTaskPolling } from '../../../../../hooks/use_task_polling';
 import { getFormattedError } from '../../../../../util/errors';
 import { StreamsAppSearchBar } from '../../../../streams_app_search_bar';
 import { useOnboardingStatusUpdateQueue } from '../../hooks/use_onboarding_status_update_queue';
 import { GenerateSplitButton } from './generate_split_button';
-import { InsightsSplitButton } from './insights_split_button';
 import {
-  getInsightsCompleteToastTitle,
-  INSIGHTS_COMPLETE_TOAST_VIEW_BUTTON,
-  INSIGHTS_SCHEDULING_FAILURE_TITLE,
-  NO_INSIGHTS_TOAST_TITLE,
   ONBOARDING_FAILURE_TITLE,
   ONBOARDING_SCHEDULING_FAILURE_TITLE,
   STREAMS_TABLE_SEARCH_ARIA_LABEL,
@@ -51,33 +41,28 @@ const datePickerStyle = css`
 
 interface StreamsViewProps {
   refreshUnbackedQueriesCount: () => void;
+  connectorConfig: UseConnectorConfigResult;
 }
 
-export function StreamsView({ refreshUnbackedQueriesCount }: StreamsViewProps) {
+export function StreamsView({ refreshUnbackedQueriesCount, connectorConfig }: StreamsViewProps) {
   const {
-    core,
     core: {
       notifications: { toasts },
     },
   } = useKibana();
   const isInitialStatusUpdateDone = useRef(false);
   const [searchQuery, setSearchQuery] = useState<Query | undefined>();
-  const [isWaitingForInsightsTask, setIsWaitingForInsightsTask] = useState(false);
   const { filterStreamsByIndexPatterns } = useIndexPatternsConfig();
 
   const {
     featuresConnectors,
     queriesConnectors,
-    discoveryConnectors,
     allConnectors,
     connectorError,
     isConnectorCatalogUnavailable,
-    discoveryConnectorOverride,
-    setDiscoveryConnectorOverride,
-    displayDiscoveryConnectorId,
     onboardingConfig,
     setOnboardingConfig,
-  } = useConnectorConfig();
+  } = connectorConfig;
 
   const streamsListFetch = useFetchStreams({
     select: (result) => {
@@ -95,86 +80,7 @@ export function StreamsView({ refreshUnbackedQueriesCount }: StreamsViewProps) {
   const [streamOnboardingResultMap, setStreamOnboardingResultMap] = useState<
     Record<string, TaskResult<OnboardingResult>>
   >({});
-  const router = useStreamsAppRouter();
   const { scheduleOnboardingTask, cancelOnboardingTask } = useOnboardingApi();
-  const { scheduleInsightsDiscoveryTask, getInsightsDiscoveryTaskStatus } =
-    useInsightsDiscoveryApi();
-  const [{ value: insightsTask }, getInsightsTaskStatus] = useAsyncFn(
-    getInsightsDiscoveryTaskStatus
-  );
-  useTaskPolling({
-    task: insightsTask,
-    onPoll: getInsightsDiscoveryTaskStatus,
-    onRefresh: getInsightsTaskStatus,
-  });
-
-  const [{ loading: isSchedulingInsights }, scheduleInsightsTask] = useAsyncFn(async () => {
-    const streamNames =
-      selectedStreams.length > 0 ? selectedStreams.map((row) => row.stream.name) : undefined;
-    try {
-      await scheduleInsightsDiscoveryTask(streamNames, discoveryConnectorOverride);
-      setIsWaitingForInsightsTask(true);
-      await getInsightsTaskStatus();
-    } catch (error) {
-      toasts.addError(getFormattedError(error), {
-        title: INSIGHTS_SCHEDULING_FAILURE_TITLE,
-      });
-      throw error;
-    }
-  }, [
-    scheduleInsightsDiscoveryTask,
-    selectedStreams,
-    discoveryConnectorOverride,
-    toasts,
-    getInsightsTaskStatus,
-  ]);
-
-  // When we started the insights task from this view and it completes, show toast
-  useEffect(() => {
-    if (!isWaitingForInsightsTask || !insightsTask) return;
-    if (insightsTask.status !== TaskStatus.Completed && insightsTask.status !== TaskStatus.Failed) {
-      return;
-    }
-    setIsWaitingForInsightsTask(false);
-    if (insightsTask.status === TaskStatus.Failed) {
-      toasts.addError(getFormattedError(new Error(insightsTask.error)), {
-        title: INSIGHTS_SCHEDULING_FAILURE_TITLE,
-      });
-      return;
-    }
-    if (insightsTask.status === TaskStatus.Completed) {
-      const count = insightsTask.insights?.length ?? 0;
-      if (count === 0) {
-        toasts.addInfo({
-          title: NO_INSIGHTS_TOAST_TITLE,
-        });
-      } else {
-        const toast = toasts.addSuccess({
-          title: getInsightsCompleteToastTitle(count),
-          text: toMountPoint(
-            <EuiFlexGroup justifyContent="flexEnd" gutterSize="s">
-              <EuiFlexItem grow={false}>
-                <EuiButton
-                  size="s"
-                  data-test-subj="significant_events_view_insights_toast_button"
-                  onClick={() => {
-                    toasts.remove(toast);
-                    router.push('/_discovery/{tab}', {
-                      path: { tab: 'significant_events' },
-                      query: {},
-                    });
-                  }}
-                >
-                  {INSIGHTS_COMPLETE_TOAST_VIEW_BUTTON}
-                </EuiButton>
-              </EuiFlexItem>
-            </EuiFlexGroup>,
-            core
-          ),
-        });
-      }
-    }
-  }, [isWaitingForInsightsTask, insightsTask, toasts, router, core]);
 
   const onStreamStatusUpdate = useCallback(
     (streamName: string, taskResult: TaskResult<OnboardingResult>) => {
@@ -334,18 +240,6 @@ export function StreamsView({ refreshUnbackedQueriesCount }: StreamsViewProps) {
                 queriesConnectors.loading
               }
               isConfigDisabled={selectedStreams.length === 0}
-            />
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <InsightsSplitButton
-              allConnectors={allConnectors}
-              connectorError={connectorError}
-              resolvedConnectorId={discoveryConnectors.resolvedConnectorId}
-              displayConnectorId={displayDiscoveryConnectorId}
-              onConnectorChange={setDiscoveryConnectorOverride}
-              onRun={scheduleInsightsTask}
-              isLoading={isSchedulingInsights || isWaitingForInsightsTask}
-              isDisabled={isConnectorCatalogUnavailable || discoveryConnectors.loading}
             />
           </EuiFlexItem>
         </EuiFlexGroup>

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/streams_view/translations.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/streams_view/translations.ts
@@ -110,7 +110,7 @@ export const ONBOARDING_SCHEDULING_FAILURE_TITLE = i18n.translate(
 export const DISCOVER_INSIGHTS_BUTTON_LABEL = i18n.translate(
   'xpack.streams.significantEventsDiscovery.streamsView.discoverInsightsButtonLabel',
   {
-    defaultMessage: 'Discover Significant Events',
+    defaultMessage: 'Run Discovery',
   }
 );
 

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/streams_view/translations.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/streams_view/translations.ts
@@ -114,6 +114,13 @@ export const DISCOVER_INSIGHTS_BUTTON_LABEL = i18n.translate(
   }
 );
 
+export const STOP_DISCOVERING_INSIGHTS_BUTTON_LABEL = i18n.translate(
+  'xpack.streams.significantEventsDiscovery.streamsView.stopDiscoveringInsightsButtonLabel',
+  {
+    defaultMessage: 'Stop discovering',
+  }
+);
+
 export const INSIGHTS_SCHEDULING_FAILURE_TITLE = i18n.translate(
   'xpack.streams.significantEventsDiscovery.streamsView.insightsSchedulingErrorTitle',
   {

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/page.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/page.tsx
@@ -5,14 +5,7 @@
  * 2.0.
  */
 
-import {
-  EuiBadge,
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiLoadingElastic,
-  EuiLoadingSpinner,
-  useEuiTheme,
-} from '@elastic/eui';
+import { EuiBadge, EuiLoadingElastic, EuiLoadingSpinner, useEuiTheme } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
 import React from 'react';
@@ -21,11 +14,13 @@ import { useStreamsAppBreadcrumbs } from '../../../hooks/use_streams_app_breadcr
 import { useStreamsAppParams } from '../../../hooks/use_streams_app_params';
 import { useStreamsAppRouter } from '../../../hooks/use_streams_app_router';
 import { useStreamsPrivileges } from '../../../hooks/use_streams_privileges';
+import { useConnectorConfig } from '../../../hooks/sig_events/use_connector_config';
 import { useUnbackedQueriesCount } from '../../../hooks/sig_events/use_unbacked_queries_count';
 import { RedirectTo } from '../../redirect_to';
 import { StreamsAppPageTemplate } from '../../streams_app_page_template';
 import { FeaturesTable } from './components/features_table/features_table';
 import { QueriesTable } from './components/queries_table/queries_table';
+import { SignificantEventsDiscoveryDiscoverButton } from './components/significant_events_discovery_discover_button';
 import { StreamsView } from './components/streams_view/streams_view';
 import { InsightsTab } from './components/insights/tab';
 import { SettingsTab } from './components/settings/tab';
@@ -54,6 +49,7 @@ export function SignificantEventsDiscoveryPage() {
     features: { significantEventsDiscovery },
   } = useStreamsPrivileges();
   const { euiTheme } = useEuiTheme();
+  const connectorConfig = useConnectorConfig();
   const { count: unbackedQueriesCount, refetch } = useUnbackedQueriesCount();
 
   const isPromotingQueries = useIsMutating({ mutationKey: ['promoteAll'] }) > 0;
@@ -137,26 +133,21 @@ export function SignificantEventsDiscoveryPage() {
         css={css`
           background: ${euiTheme.colors.backgroundBasePlain};
         `}
-        pageTitle={
-          <EuiFlexGroup
-            justifyContent="spaceBetween"
-            gutterSize="s"
-            responsive={false}
-            alignItems="center"
-          >
-            <EuiFlexItem>
-              <EuiFlexGroup alignItems="center" gutterSize="m">
-                {i18n.translate('xpack.streams.significantEventsDiscovery.pageHeaderTitle', {
-                  defaultMessage: 'Significant Events',
-                })}
-              </EuiFlexGroup>
-            </EuiFlexItem>
-          </EuiFlexGroup>
-        }
+        pageTitle={i18n.translate('xpack.streams.significantEventsDiscovery.pageHeaderTitle', {
+          defaultMessage: 'Significant Events',
+        })}
+        rightSideItems={[
+          <SignificantEventsDiscoveryDiscoverButton
+            key="significantEventsDiscoveryDiscover"
+            connectorConfig={connectorConfig}
+          />,
+        ]}
         tabs={tabs}
       />
       <StreamsAppPageTemplate.Body grow>
-        {tab === 'streams' && <StreamsView refreshUnbackedQueriesCount={refetch} />}
+        {tab === 'streams' && (
+          <StreamsView refreshUnbackedQueriesCount={refetch} connectorConfig={connectorConfig} />
+        )}
         {tab === 'knowledge_indicators' && <FeaturesTable />}
         {tab === 'queries' && <QueriesTable />}
         {tab === 'significant_events' && <InsightsTab />}

--- a/x-pack/platform/plugins/shared/streams_app/public/hooks/sig_events/use_connector_config.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/hooks/sig_events/use_connector_config.ts
@@ -73,3 +73,5 @@ export function useConnectorConfig() {
     setOnboardingConfig,
   };
 }
+
+export type UseConnectorConfigResult = ReturnType<typeof useConnectorConfig>;


### PR DESCRIPTION
## Summary

PR to move the Run Discovery button on the top of the Significant event project and remove it from Streams and Significant events tabs.


Before
Streams tab
<img width="3744" height="1834" alt="image" src="https://github.com/user-attachments/assets/1bf7bea4-6b18-439b-be83-1297c6e27b9a" />

Significant events tabs empty
<img width="3744" height="1834" alt="image" src="https://github.com/user-attachments/assets/4327e2db-b581-4f5c-80ee-582102ce8286" />



After
Streams tab
<img width="3524" height="1738" alt="image" src="https://github.com/user-attachments/assets/4e4a054d-75bc-4488-8143-5774dbb662a3" />


Significant events tabs results
<img width="3744" height="1834" alt="image" src="https://github.com/user-attachments/assets/a7f17451-6c1d-4105-9b63-cd2f10130931" />


Significant events tabs results
<img width="3744" height="1834" alt="image" src="https://github.com/user-attachments/assets/a6823f5f-2deb-4ad4-82b4-7e6e58107d9b" />
