### PR TITLE
[Discover] [Flaky Test] Change URL splitting for field data test

### DIFF
--- a/src/platform/test/functional/apps/discover/group5/_field_data_with_fields_api.ts
+++ b/src/platform/test/functional/apps/discover/group5/_field_data_with_fields_api.ts
@@ -92,7 +92,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await queryBar.setQuery('election');
         await queryBar.submitQuery();
         const currentUrl = await browser.getCurrentUrl();
-        const [, hash] = currentUrl.split('#/');
+        const [, hash] = currentUrl.split('#');
         await common.navigateToUrl(
           'discover',
           hash.replace('columns:!()', 'columns:!(relatedContent)'),
@@ -115,7 +115,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       // we used to add _source as a column by default when `discover:searchFieldsFromSource` existed
       it('should show @timestamp and Summary columns for legacy links with _source as a column', async function () {
         const currentUrl = await browser.getCurrentUrl();
-        const [, hash] = currentUrl.split('#/');
+        const [, hash] = currentUrl.split('#');
         const nextHash = hash
           .replace('columns:!(relatedContent)', 'columns:!(_source)')
           .replace('election', 'club');


### PR DESCRIPTION
## Summary

Fixes #255669

Hypothesis: the test splits the current URL by `#/`, which strips the leading `/` from the hash. When `navigateToUrl` reconstructs the URL, it produces 
```http://localhost/app/discover#?_tab=(tabId:%27695a6546-7734-4f67-95d2-5d03faae7da3%27)&_g=(filters:!(),refreshInterval:(pause:!t,value:60000),time:(from:%272015-09-19T06:31:44.000Z%27,to:%272015-09-23T18:31:44.000Z%27))&_a=(columns:!(_source),dataSource:(dataViewId:%27logstash-*%27,type:dataView),filters:!(),interval:auto,query:(language:kuery,query:club),sort:!(!(%27@timestamp%27,desc)))```

instead of 

```http://localhost/app/discover#/?_tab=(tabId:%27695a6546-7734-4f67-95d2-5d03faae7da3%27)&_g=(filters:!(),refreshInterval:(pause:!t,value:60000),time:(from:%272015-09-19T06:31:44.000Z%27,to:%272015-09-23T18:31:44.000Z%27))&_a=(columns:!(_source),dataSource:(dataViewId:%27logstash-*%27,type:dataView),filters:!(),interval:auto,query:(language:kuery,query:club),sort:!(!(%27@timestamp%27,desc)))```

(lack of slash after `discover#/`).

After navigation, Discover's hash router normalizes the URL back to `discover#/`. Test is timing-dependent, so sometimes `getCurrentUrl()` is called before the router normalizes the URL.

Fix: change url splitting so the hash retains and reconstructed URL will be `discover#/` which matches the browser's actual URL.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->