### PR TITLE
[Security Solution][Attacks/Alerts] Move "Attack" badge underneath title in flyout

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/components/header_title.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/components/header_title.tsx
@@ -44,6 +44,14 @@ export const HeaderTitle = memo(() => {
 
   return (
     <>
+      {timestamp && (
+        <>
+          <PreferenceFormattedDate value={new Date(timestamp)} />
+          <EuiSpacer size="xs" />
+        </>
+      )}
+      <FlyoutTitle data-test-subj={HEADER_TITLE_TEST_ID} title={title} iconType={'bolt'} />
+      <EuiSpacer size="s" />
       <EuiBadge
         aria-label={ATTACK_HEADER_BADGE}
         color="hollow"
@@ -52,14 +60,6 @@ export const HeaderTitle = memo(() => {
       >
         {ATTACK_HEADER_BADGE}
       </EuiBadge>
-      <EuiSpacer size="m" />
-      {timestamp && (
-        <>
-          <PreferenceFormattedDate value={new Date(timestamp)} />
-          <EuiSpacer size="xs" />
-        </>
-      )}
-      <FlyoutTitle data-test-subj={HEADER_TITLE_TEST_ID} title={title} iconType={'bolt'} />
       <EuiSpacer size="m" />
       <EuiFlexGroup direction="row" gutterSize="s" responsive={false} wrap>
         <EuiFlexItem css={flyoutHeaderBlockStyles}>


### PR DESCRIPTION
## Summary

Closes: https://github.com/elastic/kibana/issues/262343

Reorders the **attack details** flyout header so the **timestamp** and **title** render first, then the **“Attack”** badge and the rest of the header actions. The badge is no longer the first element above the title in order to match Host flyout styles.

- Host flyout badge position:

<img width="226" height="71" alt="Screenshot 2026-04-14 at 11 21 07" src="https://github.com/user-attachments/assets/64bdd184-a501-49a2-87a7-435b15b2f7e7" />

- **NEW** Attack flyout badge position:

<img width="451" height="91" alt="Screenshot 2026-04-14 at 11 20 27" src="https://github.com/user-attachments/assets/62e473ec-467e-4da4-a1f0-c674d65240b3" />



<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->