### PR TITLE
[Security Solution] fix AT-AB cypress test

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/management/cypress/e2e/endpoint_details/insights_ab.cy.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/cypress/e2e/endpoint_details/insights_ab.cy.ts
@@ -29,8 +29,7 @@ const {
   connectorSelectorExists,
 } = workflowInsightsSelectors;
 
-// Failing: See https://github.com/elastic/kibana/issues/262661
-describe.skip(
+describe(
   'Workflow Insights (AB path)',
   {
     env: {
@@ -94,6 +93,10 @@ describe.skip(
 
       connectorSelectorExists();
       scanButtonShouldBe('enabled');
+
+      // Override pending stub to return running execution BEFORE clicking scan.
+      // Without this, the post-click poll immediately gets [] and completes the scan.
+      fetchRunningWorkflowInsights();
       clickScanButton();
 
       cy.wait('@createWorkflowInsights', { timeout: 30 * 1000 });


### PR DESCRIPTION
## Summary

Fixes and unskips the Automatic Troubleshooting Agent Builder path cypress tests.

Fixes https://github.com/elastic/kibana/issues/262661