### PR TITLE
[Links as Code] Change savedObjectId to ref_id and improve schema metas

### DIFF
--- a/src/platform/plugins/private/links/common/embeddable/transforms/transform_in.test.ts
+++ b/src/platform/plugins/private/links/common/embeddable/transforms/transform_in.test.ts
@@ -18,7 +18,7 @@ describe('transformIn', () => {
   test('should extract saved object reference from "by reference" state', () => {
     const byReferenceState = {
       title: 'Custom title',
-      savedObjectId: '123',
+      ref_id: '123',
     };
     expect(transformIn(byReferenceState)).toMatchInlineSnapshot(`
       Object {

--- a/src/platform/plugins/private/links/common/embeddable/transforms/transform_in.ts
+++ b/src/platform/plugins/private/links/common/embeddable/transforms/transform_in.ts
@@ -12,15 +12,15 @@ import { extractReferences } from './references';
 import type { LinksByReferenceState, LinksByValueState, LinksEmbeddableState } from '../types';
 
 export function transformIn(state: LinksEmbeddableState) {
-  if ((state as LinksByReferenceState).savedObjectId) {
-    const { savedObjectId, ...rest } = state as LinksByReferenceState;
+  if ((state as LinksByReferenceState).ref_id) {
+    const { ref_id, ...rest } = state as LinksByReferenceState;
     return {
       state: rest,
       references: [
         {
           name: 'savedObjectRef',
           type: LINKS_SAVED_OBJECT_TYPE,
-          id: savedObjectId,
+          id: ref_id,
         },
       ],
     };

--- a/src/platform/plugins/private/links/common/embeddable/transforms/transform_out.test.ts
+++ b/src/platform/plugins/private/links/common/embeddable/transforms/transform_out.test.ts
@@ -190,7 +190,7 @@ describe('transformOut', () => {
     ];
     expect(transformOut(byReferenceState, references)).toMatchInlineSnapshot(`
       Object {
-        "savedObjectId": "820b40ee-307f-427a-ab61-5a5cdc5af7cd",
+        "ref_id": "820b40ee-307f-427a-ab61-5a5cdc5af7cd",
         "title": "Custom title",
       }
     `);

--- a/src/platform/plugins/private/links/common/embeddable/transforms/transform_out.ts
+++ b/src/platform/plugins/private/links/common/embeddable/transforms/transform_out.ts
@@ -37,7 +37,7 @@ export function transformOut(
   if (savedObjectRef) {
     return {
       ...state,
-      savedObjectId: savedObjectRef.id,
+      ref_id: savedObjectRef.id,
     };
   }
 

--- a/src/platform/plugins/private/links/public/actions/add_links_panel_action.ts
+++ b/src/platform/plugins/private/links/public/actions/add_links_panel_action.ts
@@ -44,18 +44,18 @@ export const addLinksPanelAction: ActionDefinition<EmbeddableApiContext> = {
       core: coreServices,
       parentApi: embeddable,
       loadContent: async ({ closeFlyout }) => {
-        return await getEditorFlyout({
+        return getEditorFlyout({
           parentDashboard: embeddable,
           closeFlyout,
           onCompleteEdit: async (newState) => {
             if (!newState) return;
 
-            const { layout, links, savedObjectId } = newState;
+            const { layout, links, refId } = newState;
 
             function serializeState() {
-              if (savedObjectId !== undefined) {
+              if (refId !== undefined) {
                 return {
-                  savedObjectId,
+                  ref_id: refId,
                 };
               }
 

--- a/src/platform/plugins/private/links/public/components/dashboard_link/dashboard_link_component.test.tsx
+++ b/src/platform/plugins/private/links/public/components/dashboard_link/dashboard_link_component.test.tsx
@@ -31,7 +31,7 @@ function createMockLinksParent({
   initialFilters?: Filter[];
 }) {
   const parent = {
-    ...getMockLinksParentApi({ savedObjectId: '456' }),
+    ...getMockLinksParentApi({ ref_id: '456' }),
     locator: {
       getRedirectUrl: jest.fn().mockReturnValue('https://my-kibana.com/dashboard/123'),
       navigate: jest.fn(),

--- a/src/platform/plugins/private/links/public/content_management/save_to_library.tsx
+++ b/src/platform/plugins/private/links/public/content_management/save_to_library.tsx
@@ -64,7 +64,7 @@ export const runSaveToLibrary = async (newState: EditorState): Promise<EditorSta
           ...newState,
           title: newTitle,
           description: newDescription,
-          savedObjectId: id,
+          refId: id,
         });
         return { id };
       } catch (error) {

--- a/src/platform/plugins/private/links/public/editor/get_editor_flyout.tsx
+++ b/src/platform/plugins/private/links/public/editor/get_editor_flyout.tsx
@@ -21,7 +21,7 @@ export interface EditorState {
   description?: string;
   layout?: LinksLayoutType;
   links?: ResolvedLink[];
-  savedObjectId?: string;
+  refId?: string;
   title?: string;
   error?: Error;
 }
@@ -53,10 +53,10 @@ export function getEditorFlyout({
           links: newLinks,
           layout: newLayout,
         };
-        if (initialState?.savedObjectId) {
-          const { savedObjectId, ...updateState } = newState;
+        if (initialState?.refId) {
+          const { refId, ...updateState } = newState;
           await linksClient.update({
-            id: initialState.savedObjectId,
+            id: initialState.refId,
             data: {
               ...updateState,
               links: serializeResolvedLinks(newLinks),
@@ -87,7 +87,7 @@ export function getEditorFlyout({
           ? parentDashboard.savedObjectId$.value
           : undefined
       }
-      isByReference={Boolean(initialState?.savedObjectId)}
+      isByReference={Boolean(initialState?.refId)}
     />
   );
 }

--- a/src/platform/plugins/private/links/public/editor/on_visualizations_edit.ts
+++ b/src/platform/plugins/private/links/public/editor/on_visualizations_edit.ts
@@ -14,13 +14,13 @@ import { resolveLinks } from '../lib/resolve_links';
 import { coreServices } from '../services/kibana_services';
 import type { LinksState } from '../../server';
 
-export async function onVisualizationsEdit(savedObjectId: string) {
+export async function onVisualizationsEdit(refId: string) {
   openLazyFlyout({
     core: coreServices,
     loadContent: async ({ closeFlyout }) => {
       let linksState: LinksState | undefined;
       try {
-        linksState = await loadFromLibrary(savedObjectId);
+        linksState = await loadFromLibrary(refId);
       } catch (error) {
         coreServices.notifications.toasts.addWarning(error.message);
         return;
@@ -28,7 +28,7 @@ export async function onVisualizationsEdit(savedObjectId: string) {
 
       return getEditorFlyout({
         initialState: {
-          savedObjectId,
+          refId,
           ...linksState,
           links: await resolveLinks(linksState.links ?? []),
         },

--- a/src/platform/plugins/private/links/public/embeddable/get_panel_placement.ts
+++ b/src/platform/plugins/private/links/public/embeddable/get_panel_placement.ts
@@ -20,10 +20,8 @@ export async function getPanelPlacement(serializedState?: LinksEmbeddableState) 
   let layout = LINKS_HORIZONTAL_LAYOUT;
   let numLinks = 1;
   try {
-    const savedObjectId = (serializedState as { savedObjectId?: string }).savedObjectId;
-    const linksState = savedObjectId
-      ? await loadFromLibrary(savedObjectId)
-      : (serializedState as LinksState);
+    const refId = (serializedState as { ref_id?: string }).ref_id;
+    const linksState = refId ? await loadFromLibrary(refId) : (serializedState as LinksState);
     if (linksState.layout) layout = linksState.layout;
     if (linksState.links) numLinks = linksState.links.length;
   } catch (error) {

--- a/src/platform/plugins/private/links/public/embeddable/links_embeddable.test.tsx
+++ b/src/platform/plugins/private/links/public/embeddable/links_embeddable.test.tsx
@@ -90,7 +90,7 @@ jest.mock('../content_management', () => {
 
 jest.mock('../content_management/load_from_library', () => {
   return {
-    loadFromLibrary: jest.fn((savedObjectId) => {
+    loadFromLibrary: jest.fn((refId) => {
       return Promise.resolve({
         title: 'links 001',
         description: 'some links',
@@ -128,7 +128,7 @@ describe('getLinksEmbeddableFactory', () => {
       description: 'just a few links',
       hide_title: false,
       hide_border: false,
-      savedObjectId: '123',
+      ref_id: '123',
     };
 
     test('component renders', async () => {
@@ -148,7 +148,7 @@ describe('getLinksEmbeddableFactory', () => {
         description: 'just a few links',
         hide_title: false,
         hide_border: false,
-        savedObjectId: '123',
+        ref_id: '123',
       });
       expect(await api.canUnlinkFromLibrary()).toBe(true);
       expect(api.defaultTitle$?.value).toBe('links 001');
@@ -219,7 +219,7 @@ describe('getLinksEmbeddableFactory', () => {
         description: 'just a few links',
         hide_title: true,
         hide_border: true,
-        savedObjectId: '333',
+        ref_id: '333',
       });
     });
   });

--- a/src/platform/plugins/private/links/public/embeddable/links_embeddable.tsx
+++ b/src/platform/plugins/private/links/public/embeddable/links_embeddable.tsx
@@ -50,14 +50,12 @@ export const getLinksEmbeddableFactory = () => {
   const linksEmbeddableFactory: EmbeddableFactory<LinksEmbeddableState, LinksApi> = {
     type: LINKS_EMBEDDABLE_TYPE,
     buildEmbeddable: async ({ initialState, finalizeApi, uuid, parentApi }) => {
-      const savedObjectId = (initialState as LinksByReferenceState).savedObjectId;
-      const intialLinksState = savedObjectId
-        ? await loadFromLibrary(savedObjectId)
-        : (initialState as LinksState);
+      const refId = (initialState as LinksByReferenceState).ref_id;
+      const intialLinksState = refId ? await loadFromLibrary(refId) : (initialState as LinksState);
 
       const titleManager = initializeTitleManager(initialState);
 
-      const isByReference = savedObjectId !== undefined;
+      const isByReference = refId !== undefined;
 
       const blockingError$ = new BehaviorSubject<Error | undefined>(undefined);
       if (!isParentApiCompatible(parentApi)) blockingError$.next(new PanelIncompatibleError());
@@ -74,7 +72,7 @@ export const getLinksEmbeddableFactory = () => {
       function serializeByReference(libraryId: string) {
         return {
           ...titleManager.getLatestState(),
-          savedObjectId: libraryId,
+          ref_id: libraryId,
         };
       }
 
@@ -87,7 +85,7 @@ export const getLinksEmbeddableFactory = () => {
       }
 
       const serializeState = () =>
-        isByReference ? serializeByReference(savedObjectId) : serializeByValue();
+        isByReference ? serializeByReference(refId) : serializeByValue();
 
       const unsavedChangesApi = initializeUnsavedChanges<LinksEmbeddableState>({
         uuid,
@@ -118,12 +116,12 @@ export const getLinksEmbeddableFactory = () => {
                   });
                   return !hasLinkDifference;
                 },
-            savedObjectId: 'skip',
+            ref_id: 'skip',
           };
         },
         onReset: async (lastSaved) => {
           titleManager.reinitializeState(lastSaved);
-          if (!savedObjectId) {
+          if (!refId) {
             layout$.next((lastSaved as LinksByValueState)?.layout);
             resolvedLinks$.next(await resolveLinks((lastSaved as LinksByValueState)?.links ?? []));
           }
@@ -182,21 +180,21 @@ export const getLinksEmbeddableFactory = () => {
                   layout: layout$.getValue(),
                   links: resolvedLinks$.getValue(),
                   title: titleManager.api.title$.getValue() ?? defaultTitle$.getValue(),
-                  savedObjectId,
+                  refId,
                 },
                 parentDashboard: parentApi,
                 onCompleteEdit: async (newState) => {
                   if (!newState) return;
 
                   // if the by reference state has changed during this edit, reinitialize the panel.
-                  const nextSavedObjectId = newState?.savedObjectId;
-                  const nextIsByReference = nextSavedObjectId !== undefined;
+                  const nextRefId = newState?.refId;
+                  const nextIsByReference = nextRefId !== undefined;
                   if (
                     nextIsByReference !== isByReference &&
                     apiIsPresentationContainer(api.parentApi)
                   ) {
                     const serializedState = nextIsByReference
-                      ? serializeByReference(nextSavedObjectId)
+                      ? serializeByReference(nextRefId)
                       : serializeByValue();
                     (serializedState as SerializedTitles).title = newState.title;
 

--- a/src/platform/plugins/private/links/public/plugin.ts
+++ b/src/platform/plugins/private/links/public/plugin.ts
@@ -71,7 +71,7 @@ export class LinksPlugin
             {
               panelType: LINKS_EMBEDDABLE_TYPE,
               serializedState: {
-                savedObjectId: savedObject.id,
+                ref_id: savedObject.id,
               },
             },
             {
@@ -120,11 +120,11 @@ export class LinksPlugin
                 id,
                 title,
                 editor: {
-                  onEdit: async (savedObjectId: string) => {
+                  onEdit: async (refId: string) => {
                     const { onVisualizationsEdit } = await import(
                       './editor/on_visualizations_edit'
                     );
-                    onVisualizationsEdit(savedObjectId);
+                    onVisualizationsEdit(refId);
                   },
                 },
                 description,

--- a/src/platform/plugins/private/links/server/embeddable_schemas.ts
+++ b/src/platform/plugins/private/links/server/embeddable_schemas.ts
@@ -27,7 +27,7 @@ const linksByReferenceStateSchema = schema.object({
   ref_id: schema.string({
     meta: {
       title: 'Reference ID',
-      description: 'The ID of the Links embeddable linked from the libray',
+      description: 'The unique identifier of the Links library item',
     },
   }),
 });

--- a/src/platform/plugins/private/links/server/embeddable_schemas.ts
+++ b/src/platform/plugins/private/links/server/embeddable_schemas.ts
@@ -18,10 +18,9 @@ const linksByValueStateSchema = schema.object({
   links: linksArraySchema,
 });
 
-// Links by-reference state schema (contains savedObjectId)
+// Links by-reference state schema (contains ref_id)
 const linksByReferenceStateSchema = schema.object({
-  // TODO change to ref_id
-  savedObjectId: schema.string({
+  ref_id: schema.string({
     meta: { description: 'The ID of the saved links object' },
   }),
 });

--- a/src/platform/plugins/private/links/server/embeddable_schemas.ts
+++ b/src/platform/plugins/private/links/server/embeddable_schemas.ts
@@ -9,7 +9,11 @@
 
 import type { TypeOf } from '@kbn/config-schema';
 import { schema } from '@kbn/config-schema';
-import { serializedTitlesSchema } from '@kbn/presentation-publishing-schemas';
+import {
+  BY_REF_SCHEMA_META,
+  BY_VALUE_SCHEMA_META,
+  serializedTitlesSchema,
+} from '@kbn/presentation-publishing-schemas';
 import { linksArraySchema, layoutSchema } from './content_management/schema/v1/cm_services';
 
 // Links by-value state schema (contains layout and links)
@@ -21,7 +25,10 @@ const linksByValueStateSchema = schema.object({
 // Links by-reference state schema (contains ref_id)
 const linksByReferenceStateSchema = schema.object({
   ref_id: schema.string({
-    meta: { description: 'The ID of the saved links object' },
+    meta: {
+      title: 'Reference ID',
+      description: 'The ID of the Links embeddable linked from the libray',
+    },
   }),
 });
 
@@ -29,9 +36,7 @@ const linksByReferenceStateSchema = schema.object({
 const linksByValueEmbeddableSchema = schema.allOf(
   [linksByValueStateSchema, serializedTitlesSchema],
   {
-    meta: {
-      description: 'Links by-value embeddable schema',
-    },
+    meta: BY_VALUE_SCHEMA_META,
   }
 );
 
@@ -39,9 +44,7 @@ const linksByValueEmbeddableSchema = schema.allOf(
 const linksByReferenceEmbeddableSchema = schema.allOf(
   [linksByReferenceStateSchema, serializedTitlesSchema],
   {
-    meta: {
-      description: 'Links by-reference embeddable schema',
-    },
+    meta: BY_REF_SCHEMA_META,
   }
 );
 

--- a/src/platform/plugins/private/links/server/plugin.ts
+++ b/src/platform/plugins/private/links/server/plugin.ts
@@ -21,7 +21,6 @@ import type { LinksState } from './content_management';
 import { LinksStorage } from './content_management';
 import { linksSavedObjectType } from './saved_objects';
 import { transforms } from '../common/embeddable/transforms/transforms';
-import { linksEmbeddableSchema } from './embeddable_schemas';
 
 export class LinksServerPlugin implements Plugin<object, object> {
   private readonly logger: Logger;
@@ -52,7 +51,8 @@ export class LinksServerPlugin implements Plugin<object, object> {
 
     plugins.embeddable.registerTransforms(LINKS_EMBEDDABLE_TYPE, {
       getTransforms: () => transforms,
-      getSchema: () => linksEmbeddableSchema,
+      // do not publish - not finalized
+      // getSchema: () => linksEmbeddableSchema,
     });
 
     return {};

--- a/src/platform/plugins/private/links/server/plugin.ts
+++ b/src/platform/plugins/private/links/server/plugin.ts
@@ -21,6 +21,7 @@ import type { LinksState } from './content_management';
 import { LinksStorage } from './content_management';
 import { linksSavedObjectType } from './saved_objects';
 import { transforms } from '../common/embeddable/transforms/transforms';
+import { linksEmbeddableSchema } from './embeddable_schemas';
 
 export class LinksServerPlugin implements Plugin<object, object> {
   private readonly logger: Logger;
@@ -51,8 +52,7 @@ export class LinksServerPlugin implements Plugin<object, object> {
 
     plugins.embeddable.registerTransforms(LINKS_EMBEDDABLE_TYPE, {
       getTransforms: () => transforms,
-      // do not publish - not finalized
-      // getSchema: () => linksEmbeddableSchema,
+      getSchema: () => linksEmbeddableSchema,
     });
 
     return {};


### PR DESCRIPTION
## Summary

Converts the last camelCased holdout in the links embeddable schema: `savedObjectId` is now `ref_id`.

Adds a transform for previously saved embeddables that refer to `savedObjectId`.

Referred to as camelCase `refId` only in code related to frontend editor functions to stick with ESLint style guides on variable naming. `refId` gets converted back to `ref_id` before pushing it back to the server.


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios



