### PR TITLE
[ES|QL] Reports correctly the controls server side errors

### DIFF
--- a/src/platform/plugins/shared/esql/public/triggers/esql_controls/control_flyout/value_control_form.tsx
+++ b/src/platform/plugins/shared/esql/public/triggers/esql_controls/control_flyout/value_control_form.tsx
@@ -181,7 +181,7 @@ export function ValueControlForm({
 
       try {
         const timezone = core.uiSettings.get<'Browser' | string>(UI_SETTINGS.DATEFORMAT_TZ);
-        getESQLResults({
+        const results = await getESQLResults({
           esqlQuery: query,
           search,
           signal: controller.signal,
@@ -190,30 +190,29 @@ export function ValueControlForm({
           timeRange,
           timezone,
           variables: esqlVariables,
-        }).then((results) => {
-          if (!isMounted() || controller.signal.aborted) {
-            return;
-          }
-          const columns = results.response.columns.map((col) => col.name);
-          setQueryColumns(columns);
-          setShowValuesPreview(true);
-
-          if (columns.length === 1) {
-            const valuesArray = results.response.values.map((value) => value[0]);
-            const options = valuesArray
-              .filter((v) => v)
-              .map((option) => {
-                return {
-                  label: String(option),
-                  key: String(option),
-                  'data-test-subj': String(option),
-                };
-              });
-            setSelectedValues(options);
-            setAvailableValuesOptions(options);
-            setEsqlQueryErrors([]);
-          }
         });
+        if (!isMounted() || controller.signal.aborted) {
+          return;
+        }
+        const columns = results.response.columns.map((col) => col.name);
+        setQueryColumns(columns);
+        setShowValuesPreview(true);
+
+        if (columns.length === 1) {
+          const valuesArray = results.response.values.map((value) => value[0]);
+          const options = valuesArray
+            .filter((v) => v)
+            .map((option) => {
+              return {
+                label: String(option),
+                key: String(option),
+                'data-test-subj': String(option),
+              };
+            });
+          setSelectedValues(options);
+          setAvailableValuesOptions(options);
+          setEsqlQueryErrors([]);
+        }
         setValuesQuery(query);
       } catch (e) {
         if (e instanceof DOMException && e.name === 'AbortError') {


### PR DESCRIPTION
## Summary

In the ES|QL controls we don't pass the server side errors correctly so they are not displayed at the editor. This PR is fixing it

<img width="577" height="337" alt="image" src="https://github.com/user-attachments/assets/01bfb2ff-a1fe-4c77-89e4-a93c5dd24ec0" />






<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->