### PR TITLE
[Streams] Avoid `@kbn/streams-schema` barrel in Scout `search_kis` spec

### DIFF
--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/assets/query/query_client.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/assets/query/query_client.ts
@@ -14,13 +14,13 @@ import type {
   StorageClientSearchRequest,
   StorageClientSearchResponse,
 } from '@kbn/storage-adapter';
+import { deriveQueryType } from '@kbn/streams-schema/src/helpers/esql_helpers';
+import type { Streams } from '@kbn/streams-schema/src/models/streams';
 import {
   type QueryType,
   type StreamQuery,
-  type Streams,
   QUERY_TYPE_STATS,
-  deriveQueryType,
-} from '@kbn/streams-schema';
+} from '@kbn/streams-schema/src/queries';
 import objectHash from 'object-hash';
 import pLimit from 'p-limit';
 import {


### PR DESCRIPTION
## Summary

`npx playwright test --list` for Streams API Scout is still failing with `SyntaxError: Unexpected token 'export'` when loading `search_knowledge_indicators_tool.spec.ts`, because that spec imported server code that pulled in `@kbn/streams-schema` via the package entry (`index.ts`). Playwright does not run that through the same TS pipeline as the rest of Kibana.

[PR #262748](https://github.com/elastic/kibana/pull/262748) narrowed `@kbn/streams-schema` imports in several Scout-related files, but did not cover this import path (spec → `query_client` → barrel).

## How to verify

The following command should return "Total: 124 tests in 9 files":
```bash
npx playwright test --list --project local --config x-pack/platform/plugins/shared/streams/test/scout/api/playwright.config.ts
```

<!--ONMERGE {"backportTargets":["8.19","9.2","9.3","9.4"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->