### PR TITLE
[Agent Builder] update copy for the announcement modal

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/announcement_modal/agent_builder_announcement_modal.test.tsx
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/announcement_modal/agent_builder_announcement_modal.test.tsx
@@ -57,13 +57,19 @@ describe('AgentBuilderAnnouncementModal', () => {
     expect(defaultProps.onContinue).toHaveBeenCalled();
   });
 
-  it('hides revert and shows read-only copy when canRevertToAssistant is false', () => {
+  it('hides revert, omits bullets and history callout, and shows documentation link when canRevertToAssistant is false', () => {
     renderWithEui(<AgentBuilderAnnouncementModal {...defaultProps} canRevertToAssistant={false} />);
 
     expect(screen.queryByTestId('agentBuilderAnnouncementRevertButton')).not.toBeInTheDocument();
-    expect(
-      screen.getByText(/Only a user with permission to change space-level Gen AI settings/i)
-    ).toBeInTheDocument();
+    expect(screen.queryByText('What to expect:')).not.toBeInTheDocument();
+    expect(screen.queryByText('Need your history?')).not.toBeInTheDocument();
+    expect(screen.getByTestId('agentBuilderAnnouncementLearnMoreCallout')).toBeInTheDocument();
+    const docLink = screen.getByTestId('agentBuilderAnnouncementDocumentationLink');
+    expect(docLink).toHaveAttribute(
+      'href',
+      'https://www.elastic.co/docs/explore-analyze/ai-features/elastic-agent-builder'
+    );
+    expect(screen.getByText(/Learn more in our/i)).toBeInTheDocument();
     expect(screen.getByTestId('agentBuilderAnnouncementContinueButton')).toHaveTextContent(
       'Got it'
     );

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/announcement_modal/agent_builder_announcement_modal.tsx
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/announcement_modal/agent_builder_announcement_modal.tsx
@@ -13,6 +13,7 @@ import {
   EuiCallOut,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiLink,
   EuiModal,
   EuiModalBody,
   EuiModalFooter,
@@ -26,12 +27,15 @@ import { css } from '@emotion/react';
 import { FormattedMessage } from '@kbn/i18n-react';
 import * as i18n from './translations';
 
+const AGENT_BUILDER_DOCUMENTATION_URL =
+  'https://www.elastic.co/docs/explore-analyze/ai-features/elastic-agent-builder';
+
 export interface AgentBuilderAnnouncementModalProps {
   onRevert: () => void;
   onContinue: () => void;
   /**
-   * When false, the revert action is hidden and copy explains that only admins with
-   * Gen AI / space settings access can switch the space back to the legacy Assistant.
+   * When false, the revert action is hidden and the body shows a short FYI plus a link to
+   * documentation (no bullets or history callout), since the user cannot change Gen AI settings.
    */
   canRevertToAssistant?: boolean;
 }
@@ -50,8 +54,8 @@ export const AgentBuilderAnnouncementModal: React.FC<AgentBuilderAnnouncementMod
     }
   `;
 
-  const textCss = css`
-    margin-bottom: ${euiTheme.size.l};
+  const calloutAfterBodyWrapperCss = css`
+    margin-top: 2em;
   `;
 
   return (
@@ -68,7 +72,7 @@ export const AgentBuilderAnnouncementModal: React.FC<AgentBuilderAnnouncementMod
       </EuiModalHeader>
 
       <EuiModalBody>
-        <EuiText size="s" css={textCss}>
+        <EuiText size="s">
           <p>
             <FormattedMessage
               id="xpack.agentBuilder.announcementModal.modalDescription"
@@ -77,28 +81,77 @@ export const AgentBuilderAnnouncementModal: React.FC<AgentBuilderAnnouncementMod
             />
           </p>
 
-          <p>
-            <em>{i18n.WHAT_TO_EXPECT}</em>
-          </p>
+          {canRevertToAssistant ? (
+            <>
+              <p>
+                <em>{i18n.WHAT_TO_EXPECT}</em>
+              </p>
 
-          <ul css={listCss}>
-            <li>
-              <strong>{i18n.DUAL_EXPERIENCES_TITLE}</strong> {i18n.DUAL_EXPERIENCES_BODY}
-            </li>
-            <li>
-              <strong>{i18n.DATA_ISOLATION_TITLE}</strong> {i18n.DATA_ISOLATION_BODY}
-            </li>
-            <li>
-              <strong>{i18n.FEATURE_PARITY_TITLE}</strong> {i18n.FEATURE_PARITY_BODY}
-            </li>
-          </ul>
+              <ul css={listCss}>
+                <li>
+                  <strong>{i18n.DUAL_EXPERIENCES_TITLE}</strong> {i18n.DUAL_EXPERIENCES_BODY}
+                </li>
+                <li>
+                  <strong>{i18n.DATA_ISOLATION_TITLE}</strong> {i18n.DATA_ISOLATION_BODY}
+                </li>
+                <li>
+                  <strong>{i18n.FEATURE_PARITY_TITLE}</strong> {i18n.FEATURE_PARITY_BODY}
+                </li>
+              </ul>
+            </>
+          ) : null}
         </EuiText>
 
-        <EuiCallOut title={i18n.NEED_HISTORY_TITLE} iconType="hourglass" color="primary" size="s">
-          <EuiText size="s">
-            <p>{canRevertToAssistant ? i18n.NEED_HISTORY_BODY : i18n.NEED_HISTORY_BODY_READONLY}</p>
-          </EuiText>
-        </EuiCallOut>
+        {canRevertToAssistant ? null : (
+          <div css={calloutAfterBodyWrapperCss}>
+            <EuiCallOut
+              announceOnMount={false}
+              title={i18n.LEARN_MORE_CALLOUT_TITLE}
+              iconType="bulb"
+              color="primary"
+              size="s"
+              data-test-subj="agentBuilderAnnouncementLearnMoreCallout"
+            >
+              <EuiText size="s">
+                <p>
+                  <FormattedMessage
+                    id="xpack.agentBuilder.announcementModal.learnMoreDescriptionDetail"
+                    defaultMessage="Learn more in our {documentationLink}."
+                    values={{
+                      documentationLink: (
+                        <EuiLink
+                          href={AGENT_BUILDER_DOCUMENTATION_URL}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          external
+                          data-test-subj="agentBuilderAnnouncementDocumentationLink"
+                        >
+                          {i18n.DOCUMENTATION_LINK_TEXT}
+                        </EuiLink>
+                      ),
+                    }}
+                  />
+                </p>
+              </EuiText>
+            </EuiCallOut>
+          </div>
+        )}
+
+        {canRevertToAssistant ? (
+          <div css={calloutAfterBodyWrapperCss}>
+            <EuiCallOut
+              announceOnMount={false}
+              title={i18n.NEED_HISTORY_TITLE}
+              iconType="hourglass"
+              color="primary"
+              size="s"
+            >
+              <EuiText size="s">
+                <p>{i18n.NEED_HISTORY_BODY}</p>
+              </EuiText>
+            </EuiCallOut>
+          </div>
+        ) : null}
       </EuiModalBody>
 
       <EuiModalFooter>

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/announcement_modal/translations.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/announcement_modal/translations.ts
@@ -71,12 +71,14 @@ export const NEED_HISTORY_BODY = i18n.translate(
   }
 );
 
-export const NEED_HISTORY_BODY_READONLY = i18n.translate(
-  'xpack.agentBuilder.announcementModal.needHistoryBodyReadonly',
-  {
-    defaultMessage:
-      'Your AI Assistant history and data remain available where your access allows. Only a user with permission to change space-level Gen AI settings can switch this space back to the legacy Assistant. Contact your Kibana administrator if you need that change.',
-  }
+export const LEARN_MORE_CALLOUT_TITLE = i18n.translate(
+  'xpack.agentBuilder.announcementModal.learnMoreCalloutTitle',
+  { defaultMessage: 'Explore Agent Builder' }
+);
+
+export const DOCUMENTATION_LINK_TEXT = i18n.translate(
+  'xpack.agentBuilder.announcementModal.documentationLinkText',
+  { defaultMessage: 'documentation' }
 );
 
 export const REVERT_BUTTON = i18n.translate('xpack.agentBuilder.announcementModal.revertButton', {

--- a/x-pack/platform/plugins/shared/agent_builder/public/components/announcement/agent_builder_announcement_modal_controller.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/components/announcement/agent_builder_announcement_modal_controller.test.tsx
@@ -231,8 +231,11 @@ describe('AgentBuilderAnnouncementModalController', () => {
       expect(screen.getByTestId('agentBuilderAnnouncementContinueButton')).toBeInTheDocument();
     });
     expect(screen.queryByTestId('agentBuilderAnnouncementRevertButton')).not.toBeInTheDocument();
-    expect(
-      screen.getByText(/Only a user with permission to change space-level Gen AI settings/i)
-    ).toBeInTheDocument();
+    expect(screen.queryByText('Need your history?')).not.toBeInTheDocument();
+    expect(screen.getByTestId('agentBuilderAnnouncementLearnMoreCallout')).toBeInTheDocument();
+    expect(screen.getByTestId('agentBuilderAnnouncementDocumentationLink')).toHaveAttribute(
+      'href',
+      'https://www.elastic.co/docs/explore-analyze/ai-features/elastic-agent-builder'
+    );
   });
 });


### PR DESCRIPTION
## Summary

Updates the **Agent Builder announcement modal** (`AgentBuilderAnnouncementModal`) so copy matches the user’s ability to change the **Gen AI / chat experience** setting for the space.

**Users who can change the setting** (`canRevertToAssistant` / `canUserChangeSpaceChatExperience`) see the **unchanged** experience: intro, “What to expect” bullets, “Need your history?” callout, **Revert to AI Assistant**, and **Continue with AI Agent**.

**Users who cannot change the setting** (for example, viewers without access to Gen AI settings) no longer see messaging that assumes they can opt out to the legacy Assistant or that emphasizes Assistant history. Instead they get a short FYI (same opening paragraph as everyone else), then an **Explore Agent Builder** callout with a **bulb** icon and a **Learn more in our documentation** link to the Elastic docs on Agent Builder (`https://www.elastic.co/docs/explore-analyze/ai-features/elastic-agent-builder`), and a **Got it** primary action.


<img width="618" height="349" alt="Screenshot 2026-04-14 at 11 53 29" src="https://github.com/user-attachments/assets/d297ff58-d542-45d4-ab66-84427b902776" />

### Checklist

Check the PR satisfies following conditions.

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [x] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)

**Risk: Misleading or unclear copy for a subset of roles**

- **Severity:** Low.
- **Mitigation:** Copy was aligned with PM/design feedback for users who cannot change Gen AI settings; privileged users keep the original modal. Reviewers should sanity-check both capability paths in the UI.

**Risk: External documentation link**

- **Severity:** Low.
- **Mitigation:** Link points to official Elastic documentation; opens in a new tab with standard `rel` attributes. If the doc URL changes, update the constant in `agent_builder_announcement_modal.tsx`.

- [ ] No additional risks identified.

### Suggested release notes

**User-facing:** Improves the AI Agent announcement modal for users who cannot change Gen AI space settings: simpler, documentation-focused message and clearer layout; users who can change settings still see the full announcement with opt-out to the legacy Assistant.

**PR created with Cursor CLI and Composer 2 Fast**

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->