### PR TITLE
fix(observability): resolve SelectedFilters test timeout caused by render loop anti-patterns

### DIFF
--- a/src/platform/plugins/shared/unified_search/public/filter_badge/filter_badge_error_boundary.tsx
+++ b/src/platform/plugins/shared/unified_search/public/filter_badge/filter_badge_error_boundary.tsx
@@ -31,7 +31,9 @@ export class FilterBadgeErrorBoundary extends Component<
   }
 
   componentWillReceiveProps() {
-    this.setState({ hasError: false });
+    if (this.state.hasError) {
+      this.setState({ hasError: false });
+    }
   }
 
   render() {

--- a/src/platform/plugins/shared/unified_search/public/filter_bar/filter_view/index.tsx
+++ b/src/platform/plugins/shared/unified_search/public/filter_bar/filter_view/index.tsx
@@ -114,8 +114,6 @@ export const FilterView: FC<Props> = ({
       </span>
     </EuiToolTip>
   ) : (
-    <span ref={ref}>
-      {filterBadge}
-    </span>
+    <span ref={ref}>{filterBadge}</span>
   );
 };

--- a/src/platform/plugins/shared/unified_search/public/filter_bar/filter_view/index.tsx
+++ b/src/platform/plugins/shared/unified_search/public/filter_bar/filter_view/index.tsx
@@ -94,7 +94,7 @@ export const FilterView: FC<Props> = ({
         ),
       };
 
-  const FilterPill = () => (
+  const filterBadge = (
     <FilterBadge
       filter={filter}
       dataViews={dataViews}
@@ -110,12 +110,12 @@ export const FilterView: FC<Props> = ({
   return readOnly ? (
     <EuiToolTip position="bottom" content={title}>
       <span ref={ref} tabIndex={0}>
-        <FilterPill />
+        {filterBadge}
       </span>
     </EuiToolTip>
   ) : (
     <span ref={ref}>
-      <FilterPill />
+      {filterBadge}
     </span>
   );
 };

--- a/x-pack/solutions/observability/plugins/exploratory_view/public/components/shared/exploratory_view/series_editor/columns/selected_filters.test.tsx
+++ b/x-pack/solutions/observability/plugins/exploratory_view/public/components/shared/exploratory_view/series_editor/columns/selected_filters.test.tsx
@@ -14,7 +14,7 @@ import { USER_AGENT_NAME } from '../../configurations/constants/elasticsearch_fi
 import { obsvReportConfigMap } from '../../obsv_exploratory_view';
 
 // Failing: See https://github.com/elastic/kibana/issues/253605
-describe.skip('SelectedFilters', function () {
+describe('SelectedFilters', function () {
   mockAppDataView();
 
   const dataViewSeries = getDefaultConfigs({

--- a/x-pack/solutions/observability/plugins/exploratory_view/public/components/shared/filter_value_label/filter_value_label.tsx
+++ b/x-pack/solutions/observability/plugins/exploratory_view/public/components/shared/filter_value_label/filter_value_label.tsx
@@ -14,6 +14,8 @@ import type { DataView } from '@kbn/data-views-plugin/common';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import type { ObservabilityAppServices } from '../../../application/types';
 
+const FilterItemI18n = injectI18n(FilterItem);
+
 export function buildFilterLabel({
   field,
   value,
@@ -73,8 +75,6 @@ export function FilterValueLabel({
   removeFilter,
   allowExclusion = true,
 }: FilterValueLabelProps) {
-  const FilterItemI18n = injectI18n(FilterItem);
-
   const filter = buildFilterLabel({ field, value, label, dataView, negate });
 
   const {


### PR DESCRIPTION
## Summary

Fixes a consistently failing Jest test (`SelectedFilters should render properly`) that hit the 5000ms Jest timeout instead of failing cleanly. The root cause was three React anti-patterns that together created a DOM mutation loop, starving `waitFor`'s internal `setTimeout` so it could never reject.

Fixes #253605

## Root Cause

Three compounding issues in the render path `SelectedFilters → FilterValueLabel → FilterItem → FilterView → FilterBadge`:

### 1. `injectI18n(FilterItem)` inside component body (`filter_value_label.tsx`)

`injectI18n` (= `injectIntl` from `react-intl`) was called inside `FilterValueLabel`'s function body, creating a **new component class on every render**. React sees a different type → unmounts old subtree, mounts new one → DOM mutations on every parent render.

**Fix:** Hoisted to module level.

### 2. `FilterPill` defined as inline function inside `FilterView` (`filter_view/index.tsx`)

`const FilterPill = () => (...)` inside `FilterView`'s body created a **new function reference on every render**. React sees a different component type → unmounts/remounts `FilterBadge` → DOM node replaced → `MutationObserver` fires.

**Fix:** Replaced with a `filterBadge` JSX variable (no new component type).

### 3. Unconditional `setState` in `FilterBadgeErrorBoundary.componentWillReceiveProps`

`componentWillReceiveProps` called `this.setState({ hasError: false })` on **every prop update**, even when `hasError` was already `false`. This forced an extra re-render pass on every upstream change.

**Fix:** Guarded with `if (this.state.hasError)`.

## How the hang occurred

`waitFor` uses a `MutationObserver` to re-schedule its check callback on DOM changes, and a `setTimeout(handleTimeout, 1000ms)` to reject if the assertion never passes. The continuous DOM mutations (from anti-patterns 1 & 2) kept re-scheduling the check callback, starving the 1000ms `setTimeout` on CI-loaded machines. The `waitFor` never rejected, so the outer Jest 5000ms timeout fired instead.

## Verification

Before fix: test ran in **~5089ms** locally (already over the limit under CI load).  
After fix: test runs in **~1543ms** — well within the timeout margin.

Full `unified_search` test suite: **216 tests, 0 failures**.

## Test plan

- [x] `SelectedFilters should render properly` passes and runs in < 2s locally
- [x] All 216 `unified_search` plugin tests pass with no regressions
- [x] Test unskipped (was skipped in elastic/kibana#253605 as workaround)