### PR TITLE
[Agent Builder] Fix resetting of agent id bug

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/layout/unified_sidebar/shared/sidebar_header.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/layout/unified_sidebar/shared/sidebar_header.tsx
@@ -18,6 +18,7 @@ import {
 import { i18n } from '@kbn/i18n';
 import { css } from '@emotion/react';
 
+import { getLastAgentId } from '../../../../hooks/use_last_agent_id';
 import { useNavigation } from '../../../../hooks/use_navigation';
 import { appPaths } from '../../../../utils/app_paths';
 import { AgentSelector } from './agent_selector';
@@ -118,7 +119,7 @@ export const SidebarHeader: React.FC<SidebarHeaderProps> = ({
               size="s"
               flush="both"
               color="text"
-              onClick={() => navigate(appPaths.root)}
+              onClick={() => navigate(appPaths.agent.root({ agentId: getLastAgentId() }))}
             >
               {labels.manageComponents}
             </EuiButtonEmpty>

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/layout/unified_sidebar/unified_sidebar.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/layout/unified_sidebar/unified_sidebar.test.tsx
@@ -28,6 +28,7 @@ jest.mock('../../../hooks/agents/use_validate_agent_id', () => ({
 
 jest.mock('../../../hooks/use_last_agent_id', () => ({
   useLastAgentId: () => 'test-agent',
+  getLastAgentId: () => 'test-agent',
 }));
 
 jest.mock('../../../hooks/use_conversation_list', () => ({

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/layout/unified_sidebar/unified_sidebar.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/layout/unified_sidebar/unified_sidebar.tsx
@@ -12,10 +12,10 @@ import useLocalStorage from 'react-use/lib/useLocalStorage';
 import { EuiFlexGroup, EuiPanel, useEuiTheme } from '@elastic/eui';
 import { css } from '@emotion/react';
 
-import { agentBuilderDefaultAgentId } from '@kbn/agent-builder-common';
 import { storageKeys } from '../../../storage_keys';
 import { getSidebarViewForRoute, getAgentIdFromPath } from '../../../route_config';
 import { useAgentBuilderAgents } from '../../../hooks/agents/use_agents';
+import { getLastAgentId } from '../../../hooks/use_last_agent_id';
 import { useValidateAgentId } from '../../../hooks/agents/use_validate_agent_id';
 import { ConversationSidebarView } from './views/conversation_view';
 import { ManageSidebarView } from './views/manage_view';
@@ -80,7 +80,7 @@ export const UnifiedSidebar: React.FC<UnifiedSidebarProps> = ({
     >
       <SidebarHeader
         sidebarView={sidebarView}
-        agentId={agentIdFromUrl ?? agentBuilderDefaultAgentId}
+        agentId={agentIdFromUrl ?? getLastAgentId()}
         getNavigationPath={getNavigationPath}
         isCondensed={isCondensed}
         onToggleCondensed={onToggleCondensed}

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/layout/unified_sidebar/unified_sidebar.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/layout/unified_sidebar/unified_sidebar.tsx
@@ -36,18 +36,18 @@ export const UnifiedSidebar: React.FC<UnifiedSidebarProps> = ({
 }) => {
   const location = useLocation();
   const sidebarView = getSidebarViewForRoute(location.pathname);
-  const agentIdFromPath = getAgentIdFromPath(location.pathname) ?? agentBuilderDefaultAgentId;
+  const agentIdFromUrl = getAgentIdFromPath(location.pathname);
   const [, setStoredAgentId] = useLocalStorage<string>(storageKeys.agentId);
   const { isFetched: isAgentsFetched } = useAgentBuilderAgents();
   const validateAgentId = useValidateAgentId();
   const { euiTheme } = useEuiTheme();
 
   useEffect(() => {
-    // Wait for agents to load before validating — prevents falsely skipping valid IDs during initial load
-    if (isAgentsFetched && agentIdFromPath && validateAgentId(agentIdFromPath)) {
-      setStoredAgentId(agentIdFromPath);
+    // Only persist agent ID when it's explicitly in the URL path
+    if (isAgentsFetched && agentIdFromUrl && validateAgentId(agentIdFromUrl)) {
+      setStoredAgentId(agentIdFromUrl);
     }
-  }, [isAgentsFetched, agentIdFromPath, validateAgentId, setStoredAgentId]);
+  }, [isAgentsFetched, agentIdFromUrl, validateAgentId, setStoredAgentId]);
 
   const getNavigationPath = useCallback(
     (newAgentId: string) => appPaths.agent.root({ agentId: newAgentId }),
@@ -80,7 +80,7 @@ export const UnifiedSidebar: React.FC<UnifiedSidebarProps> = ({
     >
       <SidebarHeader
         sidebarView={sidebarView}
-        agentId={agentIdFromPath}
+        agentId={agentIdFromUrl ?? agentBuilderDefaultAgentId}
         getNavigationPath={getNavigationPath}
         isCondensed={isCondensed}
         onToggleCondensed={onToggleCondensed}

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/hooks/use_last_agent_id.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/hooks/use_last_agent_id.ts
@@ -10,6 +10,21 @@ import { agentBuilderDefaultAgentId } from '@kbn/agent-builder-common';
 
 import { storageKeys } from '../storage_keys';
 
+/**
+ * Reads the last used agent ID directly from localStorage.
+ * Unlike useLastAgentId, this is not a hook and can be called conditionally
+ * or inside callbacks to get the current value at call time.
+ */
+export const getLastAgentId = (): string => {
+  const stored = localStorage.getItem(storageKeys.agentId);
+  if (!stored) return agentBuilderDefaultAgentId;
+  try {
+    return JSON.parse(stored);
+  } catch {
+    return stored;
+  }
+};
+
 export const useLastAgentId = (): string => {
   const [agentIdStorage] = useLocalStorage<string>(storageKeys.agentId);
   return agentIdStorage ?? agentBuilderDefaultAgentId;


### PR DESCRIPTION
closes https://github.com/elastic/search-team/issues/13923

## Summary

Problem: Change the agent to something other than the default. Navigate to the Manage Components at the bottom left. If you hit the <, it will switch back to the default agent.

Fix:


https://github.com/user-attachments/assets/78d999a6-829e-40f5-a66b-e866f5558534







<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->