### PR TITLE
[Entity Store] Update `LOG_EXTRACTION_MAX_LOGS_PER_PAGE_DEFAULT`

### DIFF
--- a/x-pack/solutions/security/plugins/entity_store/server/domain/saved_objects/global_state/constants.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/saved_objects/global_state/constants.ts
@@ -12,9 +12,10 @@ export const DEFAULT_HISTORY_SNAPSHOT_FREQUENCY = '24h';
 export const LOG_EXTRACTION_DELAY_DEFAULT = '1m';
 export const LOG_EXTRACTION_LOOKBACK_PERIOD_DEFAULT = '3h';
 export const LOG_EXTRACTION_FREQUENCY_DEFAULT = '30s';
+// Max amount of entities to extract in one ESQL query
 export const LOG_EXTRACTION_DOCS_LIMIT_DEFAULT = 10000;
-/** Max raw log documents per log slice for local LOOKUP extraction (bounded scan). */
-export const LOG_EXTRACTION_MAX_LOGS_PER_PAGE_DEFAULT = 5000;
+// Max raw log documents per logs to be processed in a query (inside elastic search)
+export const LOG_EXTRACTION_MAX_LOGS_PER_PAGE_DEFAULT = 40000;
 export const LOG_EXTRACTION_TIMEOUT_DEFAULT = '25s';
 
 export type LogExtractionConfig = z.infer<typeof LogExtractionConfig>;


### PR DESCRIPTION
In previous PR https://github.com/elastic/kibana/pull/262022 we have introduced `LOG_EXTRACTION_MAX_LOGS_PER_PAGE_DEFAULT`.

The value 5k was due to a local test. But the intended value was actually 40k. 

This value was derived from testing against serverless, which seems to be the optimal default value to not hit circuit breakers.

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->