### PR TITLE
[SigEvents] Simplify knowledge indicators table

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/knowledge_indicators_table/translations.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/knowledge_indicators_table/translations.ts
@@ -27,11 +27,6 @@ export const QUERY_TYPE_LABEL = i18n.translate(
   { defaultMessage: 'Query' }
 );
 
-export const CONFIDENCE_COLUMN_LABEL = i18n.translate(
-  'xpack.streams.knowledgeIndicators.columns.confidenceLabel',
-  { defaultMessage: 'Confidence' }
-);
-
 export const STREAM_COLUMN_LABEL = i18n.translate(
   'xpack.streams.knowledgeIndicators.columns.streamLabel',
   { defaultMessage: 'Stream' }

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/knowledge_indicators_table/use_knowledge_indicators_columns.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/knowledge_indicators_table/use_knowledge_indicators_columns.tsx
@@ -67,6 +67,7 @@ export const useKnowledgeIndicatorsColumns = ({
       {
         name: TITLE_COLUMN_LABEL,
         truncateText: true,
+        width: '20em',
         render: (ki: KnowledgeIndicator) => {
           const title = getKnowledgeIndicatorTitle(ki);
           const isExpanded = selectedKnowledgeIndicatorId === getKnowledgeIndicatorItemId(ki);
@@ -90,7 +91,7 @@ export const useKnowledgeIndicatorsColumns = ({
       },
       {
         name: EVENTS_COLUMN_LABEL,
-        width: '110px',
+        width: '7em',
         render: (ki: KnowledgeIndicator) => {
           if (ki.kind !== 'query' || !ki.rule.backed) {
             return null;
@@ -115,7 +116,7 @@ export const useKnowledgeIndicatorsColumns = ({
       },
       {
         name: TYPE_COLUMN_LABEL,
-        width: '90px',
+        width: '7.5em',
         render: (ki: KnowledgeIndicator) => {
           if (ki.kind === 'feature') {
             return (
@@ -129,7 +130,7 @@ export const useKnowledgeIndicatorsColumns = ({
       },
       {
         name: CONFIDENCE_COLUMN_LABEL,
-        width: '70px',
+        width: '6.5em',
         render: (ki: KnowledgeIndicator) => {
           if (ki.kind !== 'feature') return null;
           return (
@@ -141,14 +142,14 @@ export const useKnowledgeIndicatorsColumns = ({
       },
       {
         name: STREAM_COLUMN_LABEL,
-        width: '110px',
+        width: '9.5em',
         render: (ki: KnowledgeIndicator) => {
           return <EuiBadge color="hollow">{getKnowledgeIndicatorStreamName(ki)}</EuiBadge>;
         },
       },
       {
         name: BACKED_STATUS_COLUMN,
-        width: '100px',
+        width: '7.5em',
         render: (ki: KnowledgeIndicator) => {
           if (ki.kind !== 'query') return null;
           return (
@@ -166,7 +167,7 @@ export const useKnowledgeIndicatorsColumns = ({
       },
       {
         name: ACTIONS_COLUMN_LABEL,
-        width: '60px',
+        width: '4em',
         align: 'right',
         render: (ki: KnowledgeIndicator) => (
           <KnowledgeIndicatorActionsCell

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/knowledge_indicators_table/use_knowledge_indicators_columns.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/knowledge_indicators_table/use_knowledge_indicators_columns.tsx
@@ -6,13 +6,7 @@
  */
 
 import type { EuiBasicTableColumn } from '@elastic/eui';
-import {
-  EuiBadge,
-  EuiButtonIcon,
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiLink,
-} from '@elastic/eui';
+import { EuiBadge, EuiButtonIcon, EuiFlexGroup, EuiFlexItem, EuiLink } from '@elastic/eui';
 import { css } from '@emotion/react';
 import type { KnowledgeIndicator } from '@kbn/streams-ai';
 import React, { useMemo } from 'react';

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/knowledge_indicators_table/use_knowledge_indicators_columns.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/knowledge_indicators_table/use_knowledge_indicators_columns.tsx
@@ -11,32 +11,21 @@ import {
   EuiButtonIcon,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiHealth,
   EuiLink,
-  EuiToolTip,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
 import type { KnowledgeIndicator } from '@kbn/streams-ai';
 import React, { useMemo } from 'react';
 import { SparkPlot } from '../../../../spark_plot';
-import { getConfidenceColor } from '../../../stream_detail_significant_events_view/utils/get_confidence_color';
 import { KnowledgeIndicatorActionsCell } from '../../../stream_detail_significant_events_view/knowledge_indicator_actions_cell';
 import { getKnowledgeIndicatorItemId } from '../../../stream_detail_significant_events_view/utils/get_knowledge_indicator_item_id';
 import { getKnowledgeIndicatorStreamName } from '../../../stream_detail_significant_events_view/utils/get_knowledge_indicator_stream_name';
-import {
-  BACKED_STATUS_COLUMN,
-  PROMOTED_BADGE_LABEL,
-  NOT_PROMOTED_BADGE_LABEL,
-  PROMOTED_TOOLTIP_CONTENT,
-  NOT_PROMOTED_TOOLTIP_CONTENT,
-} from '../queries_table/translations';
 import { getKnowledgeIndicatorTitle } from './use_knowledge_indicators_table';
 import {
   TITLE_COLUMN_LABEL,
   EVENTS_COLUMN_LABEL,
   TYPE_COLUMN_LABEL,
   QUERY_TYPE_LABEL,
-  CONFIDENCE_COLUMN_LABEL,
   STREAM_COLUMN_LABEL,
   ACTIONS_COLUMN_LABEL,
   VIEW_DETAILS_ARIA_LABEL,
@@ -129,40 +118,10 @@ export const useKnowledgeIndicatorsColumns = ({
         },
       },
       {
-        name: CONFIDENCE_COLUMN_LABEL,
-        width: '6.5em',
-        render: (ki: KnowledgeIndicator) => {
-          if (ki.kind !== 'feature') return null;
-          return (
-            <EuiHealth color={getConfidenceColor(ki.feature.confidence)}>
-              {ki.feature.confidence}
-            </EuiHealth>
-          );
-        },
-      },
-      {
         name: STREAM_COLUMN_LABEL,
         width: '9.5em',
         render: (ki: KnowledgeIndicator) => {
           return <EuiBadge color="hollow">{getKnowledgeIndicatorStreamName(ki)}</EuiBadge>;
-        },
-      },
-      {
-        name: BACKED_STATUS_COLUMN,
-        width: '7.5em',
-        render: (ki: KnowledgeIndicator) => {
-          if (ki.kind !== 'query') return null;
-          return (
-            <EuiToolTip
-              content={ki.rule.backed ? PROMOTED_TOOLTIP_CONTENT : NOT_PROMOTED_TOOLTIP_CONTENT}
-            >
-              <span tabIndex={0}>
-                <EuiBadge color={ki.rule.backed ? 'hollow' : 'warning'}>
-                  {ki.rule.backed ? PROMOTED_BADGE_LABEL : NOT_PROMOTED_BADGE_LABEL}
-                </EuiBadge>
-              </span>
-            </EuiToolTip>
-          );
         },
       },
       {


### PR DESCRIPTION
## Summary

- Fix column proportions in the knowledge indicators table (title column had no explicit width, causing it to greedily absorb all remaining space)
- Remove the **Confidence** column (only applied to features, empty for queries)
- Remove the **Backed/Status** column (only applied to queries, empty for features)

These two columns added visual noise since each only rendered content for one kind of knowledge indicator, leaving blank cells for the other kind.

Before:
<img width="1508" height="828" alt="Screenshot 2026-04-15 at 11 31 00" src="https://github.com/user-attachments/assets/131cfc50-acfb-48df-964d-3efb8d520e7e" />

After:
<img width="758" height="416" alt="Screenshot 2026-04-15 at 11 08 26" src="https://github.com/user-attachments/assets/2bc5a708-8876-4b38-a0cd-939e127c71ba" />
