### PR TITLE
[Spacetime] pre-configure elastic docs mcp server

### DIFF
--- a/config/serverless.es.yml
+++ b/config/serverless.es.yml
@@ -293,3 +293,11 @@ xpack.actions.preconfigured:
       inferenceId: ".google-gemini-3.0-flash-chat_completion"
       providerConfig:
         model_id: "google-gemini-3.0-flash"
+  Elastic-Docs-MCP:
+    name: Elastic Docs MCP
+    actionTypeId: .mcp
+    exposeConfig: true
+    config:
+      serverUrl: "https://www.elastic.co/docs/_mcp/"
+      hasAuth: false
+      authType: "none"


### PR DESCRIPTION
## Summary

WIP


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
ption includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.




# Experiment: Impact of Elastic Docs MCP Tools on Agent Builder Agents

**Date:** 2026-04-14
**Author:** Sean Story (assisted by Claude Code)

## Objective

Determine whether including Elastic documentation MCP tools (`elastic_docs.search_docs`, `elastic_docs.get_document_by_url`, `elastic_docs.find_related_docs`) in an Agent Builder agent meaningfully improves the quality, accuracy, and grounding of responses compared to an otherwise-identical agent without those tools.

## Setup

### Environment

- **Kibana:** Running locally on `http://localhost:5601` (serverless mode)
- **Elasticsearch:** Local serverless instance
- **Auth:** `elastic_serverless:changeme`

### Agents Under Test

| Agent | ID | Tools | Description |
|---|---|---|---|
| **With Docs** | `agent_with_docs` | 11 tools (8 platform + 3 elastic_docs) | Identical to "without docs" plus `elastic_docs.search_docs`, `elastic_docs.get_document_by_url`, `elastic_docs.find_related_docs` |
| **Without Docs** | `elastic_agent_without_docs` | 8 tools (platform only) | `search`, `list_indices`, `get_index_mapping`, `get_document_by_id`, `get_workflow_execution_status`, `sml_search`, `sml_attach`, `execute_connector_sub_action` |

Both agents share the same system instructions: "You are a helpful assistant."

### Test Data

Five Elasticsearch indices containing synthetic financial data:

| Index | Doc Count | Key Fields |
|---|---|---|
| `financial_accounts` | Populated | account_id, account_holder_name, account_type, risk_profile, state, total_portfolio_value |
| `financial_holdings` | Populated | holding_id, account_id, symbol, quantity, purchase_price, purchase_date, is_high_value |
| `financial_asset_details` | Has mappings (incl. semantic_text) | symbol, asset_name, instrument_type, sector, current_price, bond_details |
| `financial_news` | Has mappings (incl. semantic_text) | article_id, title, content, sentiment, company_symbol |
| `financial_reports` | Has mappings (incl. semantic_text) | report_id, title, content, report_type, sentiment, company_symbol |

Note: `financial_asset_details`, `financial_news`, and `financial_reports` returned empty results via ES|QL queries (possibly a time-range filter issue in the search tool), though their mappings were accessible.

## Methodology

### Test Prompts

Eight prompts across four categories, designed to test where documentation knowledge should (or shouldn't) matter:

| ID | Category | Prompt |
|---|---|---|
| 1 | Pure Data Query | What are the top 5 accounts by portfolio value? |
| 2 | Pure Data Query | How many holdings does account ACC00577-fe19 have, and what symbols are they? |
| 3 | Elastic Product How-To | How would I set up an anomaly detection job to flag unusual changes in portfolio values across my financial_accounts index? |
| 4 | Elastic Product How-To | How can I create an alert that notifies me when any account's portfolio value drops more than 10% in a day? |
| 5 | Hybrid (Data + Elastic) | I have financial news articles with a sentiment field. What's the best way to build a dashboard that correlates news sentiment with stock price movements using my data? |
| 6 | Hybrid (Data + Elastic) | What Elasticsearch aggregation or ES|QL query would give me a sector-level breakdown of my holdings' current value vs purchase price? |
| 7 | Best Practices / Architecture | My financial_news index has semantic_text fields. How should I configure my search to take advantage of semantic search capabilities? |
| 8 | Best Practices / Architecture | What's the recommended way to set up cross-cluster replication for my financial indices for disaster recovery? |

### Evaluation Criteria

Each response was scored on:
- **Answer Quality** (1-5): Completeness, accuracy, actionability
- **Hallucination** (none/minor/major): Did the agent fabricate features or syntax?
- **Grounding** (well-grounded / partially-grounded / ungrounded): Was the answer backed by retrieved data or documentation?
- **Tools Used**: Which tools were invoked, and whether docs tools were actually used
- **Winner**: Which agent performed better, or tie

### Execution

All 8 prompts were run against both agents in parallel using the `chat-with-agent` skill's `chat.sh` script, with 180-second timeouts per interaction.

## Results Summary

| ID | Category | Winner | Docs Impact | With Docs Quality | Without Docs Quality | Docs Tools Used? |
|---|---|---|---|---|---|---|
| 1 | Pure Data | **without_docs** | Negative | 4 | 5 | No |
| 2 | Pure Data | tie | Neutral | 5 | 5 | No |
| 3 | How-To | tie | Neutral | 3 | 3 | Yes |
| 4 | How-To | **with_docs** | Positive | 4 | 4 | Yes |
| 5 | Hybrid | **with_docs** | Positive | 4 | 4 | No |
| 6 | Hybrid | **with_docs** | Neutral | 4 | 3 | No |
| 7 | Best Practices | **with_docs** | Positive | 5 | 5 | Yes |
| 8 | Best Practices | **with_docs** | Positive | 5 | 3 | Yes |

### Score Totals

| Metric | With Docs | Without Docs |
|---|---|---|
| **Average Quality** | 4.25 | 4.00 |
| **Wins** | 5 | 1 |
| **Ties** | 2 | 2 |
| **Losses** | 1 | 5 |
| **Hallucination (none)** | 5/8 | 3/8 |
| **Well-grounded** | 7/8 | 3/8 |

## Analysis

### By Category

**Pure Data Queries (Prompts 1-2):** Docs tools provided no benefit — neither agent used them. In one case, the with-docs agent actually performed slightly worse, possibly due to the additional tool options creating decision overhead. For straightforward data retrieval, the docs tools are inert ballast.

**Elastic Product How-To (Prompts 3-4):** Mixed results. The with-docs agent actively consulted documentation in both cases, but in Prompt 3 it timed out mid-research, producing an incomplete (though well-sourced) answer. In Prompt 4, documentation access resulted in more accurate Kibana UI paths and feature references. The takeaway: docs tools help with how-to questions when the agent completes in time, but the additional tool calls add latency risk.

**Hybrid Queries (Prompts 5-6):** Interestingly, the with-docs agent won both despite not using docs tools in either case. The quality difference came from better problem-solving persistence (Prompt 5: actually created a dashboard vs just describing one) and more coherent query construction (Prompt 6). This suggests that having docs tools available may influence overall agent behavior or confidence, even when not directly invoked.

**Best Practices / Architecture (Prompts 7-8):** This is where docs tools showed the clearest, most consistent value. In both prompts, the with-docs agent actively searched and retrieved official documentation, producing responses with:
- Correct parameter names and API syntax
- Accurate UI navigation paths
- Complete prerequisite lists
- Proper failover/failback procedures

The without-docs agent fell back to general LLM knowledge, which was plausible but contained minor inaccuracies (wrong parameter names, missing prerequisites, potentially outdated API patterns).

### Key Findings

1. **Docs tools have the strongest positive impact on architecture and best-practice questions** where authoritative, current information matters most. The quality gap was largest here (5 vs 3 on Prompt 8).

2. **Docs tools are neutral-to-irrelevant for pure data queries.** This is expected — retrieving index data doesn't require product documentation.

3. **Docs tools add latency risk.** The with-docs agent timed out on Prompt 3 because it spent time retrieving documentation pages. For time-sensitive interactions, this is a real tradeoff.

4. **The with-docs agent hallucinated less frequently** (5/8 "none" vs 3/8), suggesting that access to authoritative sources reduces the agent's tendency to fabricate plausible-sounding but incorrect details.

5. **Grounding quality was dramatically better** with docs (7/8 "well-grounded" vs 3/8). Even when answer quality scores were similar, the with-docs agent's answers were more reliably sourced.

6. **The without-docs agent compensated with alternative strategies**: reading local skill files (`filestore.read`), exploring workflow tools, and leaning more heavily on platform tools. These workarounds produced functional but less authoritative answers.

## Recommendations

1. **Include docs tools by default** for general-purpose agents. The quality improvement on architecture/best-practice questions is significant, and the cost on pure data queries is minimal (the agent simply doesn't use them).

2. **Consider timeout tuning.** The additional round-trips to documentation can cause timeouts on complex how-to questions. Ensure timeouts are generous enough to accommodate docs lookups.

3. **Monitor for decision overhead.** The Prompt 1 result (docs agent performed worse on a simple data query) hints that more tools can occasionally degrade performance on simple tasks by expanding the decision space. Worth monitoring at scale.

4. **Docs tools are highest-value for onboarding and advisory use cases** — users asking "how do I configure X?" or "what's the best practice for Y?" benefit most. Users doing pure data exploration see no difference.

## Raw Data

Full per-prompt results are available in [`docs-mcp-experiment-results.csv`](docs-mcp-experiment-results.csv).



