### PR TITLE
fix: use member SLO budgeting method in composite SLO summary calculation

### DIFF
--- a/x-pack/solutions/observability/plugins/slo/server/services/composite_historical_summary_client.test.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/composite_historical_summary_client.test.ts
@@ -257,7 +257,7 @@ describe('CompositeHistoricalSummaryClient', () => {
     expect(mockHistoricalProvider.fetch).not.toHaveBeenCalled();
   });
 
-  it('passes composite budgetingMethod to the historical summary provider', async () => {
+  it('passes member budgetingMethod to the historical summary provider', async () => {
     const sloA = createSLO({
       id: 'slo-a',
       budgetingMethod: 'timeslices',
@@ -286,7 +286,7 @@ describe('CompositeHistoricalSummaryClient', () => {
       list: [
         expect.objectContaining({
           sloId: sloA.id,
-          budgetingMethod: 'occurrences',
+          budgetingMethod: 'timeslices',
         }),
       ],
     });

--- a/x-pack/solutions/observability/plugins/slo/server/services/composite_historical_summary_client.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/composite_historical_summary_client.ts
@@ -72,7 +72,7 @@ export class CompositeHistoricalSummaryClient {
         sloId: slo.id,
         instanceId: member.instanceId ?? ALL_VALUE,
         timeWindow: composite.timeWindow,
-        budgetingMethod: composite.budgetingMethod,
+        budgetingMethod: slo.budgetingMethod,
         groupBy: slo.groupBy,
         revision: slo.revision,
         objective: slo.objective,

--- a/x-pack/solutions/observability/plugins/slo/server/services/get_composite_slo.test.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/get_composite_slo.test.ts
@@ -391,7 +391,6 @@ describe('GetCompositeSLO', () => {
         slo: sloA,
         instanceId: 'my-instance',
         timeWindowOverride: composite.timeWindow,
-        budgetingMethodOverride: composite.budgetingMethod,
       },
     ]);
     expect(result.members[0].instanceId).toBe('my-instance');

--- a/x-pack/solutions/observability/plugins/slo/server/services/get_composite_slo.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/get_composite_slo.ts
@@ -72,7 +72,6 @@ export class GetCompositeSLO {
       slo: memberDefinitionMap.get(member.sloId)!,
       instanceId: member.instanceId ?? ALL_VALUE,
       timeWindowOverride: compositeSlo.timeWindow,
-      budgetingMethodOverride: compositeSlo.budgetingMethod,
     }));
 
     const summaryResults = await this.summaryClient.computeSummaries(summaryParams);

--- a/x-pack/solutions/observability/plugins/slo/server/services/summary_client.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/summary_client.ts
@@ -11,7 +11,6 @@ import type {
   AggregationsTopHitsAggregate,
 } from '@elastic/elasticsearch/lib/api/types';
 import type { ElasticsearchClient } from '@kbn/core/server';
-import type { BudgetingMethod } from '@kbn/slo-schema';
 import {
   ALL_VALUE,
   calendarAlignedTimeWindowSchema,
@@ -34,7 +33,6 @@ interface Params {
   instanceId?: string;
   remoteName?: string;
   timeWindowOverride?: TimeWindow;
-  budgetingMethodOverride?: BudgetingMethod;
 }
 
 export interface BurnRateWindow {
@@ -68,7 +66,6 @@ interface ResolvedParams {
   dateRange: DateRange;
   shouldIncludeInstanceIdFilter: boolean;
   index: string;
-  budgetingMethodOverride?: BudgetingMethod;
 }
 
 const resolveIndex = (remoteName?: string) =>
@@ -79,7 +76,6 @@ const resolveParams = ({
   instanceId,
   remoteName,
   timeWindowOverride,
-  budgetingMethodOverride,
 }: Params): ResolvedParams => {
   const dateRange = toDateRange(timeWindowOverride ?? slo.timeWindow);
   const isDefinedWithGroupBy = ![slo.groupBy].flat().includes(ALL_VALUE);
@@ -93,7 +89,6 @@ const resolveParams = ({
     dateRange,
     shouldIncludeInstanceIdFilter,
     index: resolveIndex(remoteName),
-    budgetingMethodOverride,
   };
 };
 
@@ -160,8 +155,7 @@ const toSummaryResult = (
   slo: SLODefinition,
   dateRange: DateRange,
   aggregations: SummaryAggregations | undefined,
-  burnRates: BurnRateWindow[],
-  budgetingMethodOverride?: BudgetingMethod
+  burnRates: BurnRateWindow[]
 ): SummaryResult => {
   const source = aggregations?.last_doc?.hits?.hits?.[0]?._source as
     | {
@@ -173,7 +167,7 @@ const toSummaryResult = (
     | undefined;
   const groupings = source?.slo?.groupings;
 
-  const sliValue = computeSliValue(slo, dateRange, aggregations, budgetingMethodOverride);
+  const sliValue = computeSliValue(slo, dateRange, aggregations);
   const errorBudget = computeErrorBudget(slo, sliValue);
 
   return {
@@ -196,7 +190,7 @@ export class DefaultSummaryClient implements SummaryClient {
 
   async computeSummary(params: Params): Promise<SummaryResult> {
     const resolved = resolveParams(params);
-    const { slo, instanceId, remoteName, dateRange, index, budgetingMethodOverride } = resolved;
+    const { slo, instanceId, remoteName, dateRange, index } = resolved;
 
     const result = await this.esClient.search<any, SummaryAggregations>({
       index,
@@ -210,7 +204,7 @@ export class DefaultSummaryClient implements SummaryClient {
       remoteName
     );
 
-    return toSummaryResult(slo, dateRange, result.aggregations, burnRates, budgetingMethodOverride);
+    return toSummaryResult(slo, dateRange, result.aggregations, burnRates);
   }
 
   async computeSummaries(paramsList: Params[]): Promise<SummaryResult[]> {
@@ -243,12 +237,12 @@ export class DefaultSummaryClient implements SummaryClient {
       this.burnRatesClient.calculateBatch(burnRateBatchParams),
     ]);
 
-    return resolvedList.map(({ slo, dateRange, budgetingMethodOverride }, i) => {
+    return resolvedList.map(({ slo, dateRange }, i) => {
       const aggs = summaryAggregations[i];
       if (!aggs) {
         return buildNoDataResult(slo);
       }
-      return toSummaryResult(slo, dateRange, aggs, allBurnRates[i], budgetingMethodOverride);
+      return toSummaryResult(slo, dateRange, aggs, allBurnRates[i]);
     });
   }
 
@@ -391,14 +385,12 @@ interface BurnRateBucket {
 function computeSliValue(
   slo: SLODefinition,
   dateRange: DateRange,
-  bucket: BurnRateBucket | undefined,
-  budgetingMethodOverride?: BudgetingMethod
+  bucket: BurnRateBucket | undefined
 ) {
   const good = bucket?.good?.value ?? 0;
   const total = bucket?.total?.value ?? 0;
-  const budgetingMethod = budgetingMethodOverride ?? slo.budgetingMethod;
 
-  if (timeslicesBudgetingMethodSchema.is(budgetingMethod) && slo.objective.timesliceWindow) {
+  if (timeslicesBudgetingMethodSchema.is(slo.budgetingMethod) && slo.objective.timesliceWindow) {
     const totalSlices = getSlicesFromDateRange(dateRange, slo.objective.timesliceWindow);
 
     return computeSLI(good, total, totalSlices);


### PR DESCRIPTION
## Summary

- **Fixed a bug** where the composite SLO summary calculation was overriding each member SLO's budgeting method with the composite's own budgeting method (always `occurrences`).
- This caused a mismatch: ES aggregations fetched data using the member's budgeting method (e.g. `timeslices` members read from `slo.isGoodSlice`), but the SLI formula interpreted the results using the composite's method (`occurrences`), leading to semantically incorrect SLI values for `timeslices` members.
- Now each member's SLI is computed using its own budgeting method before being aggregated into the composite via weighted average. This affects both the live composite summary (`GetCompositeSLO`) and historical composite summaries (`CompositeHistoricalSummaryClient`).

### Changes

| File | Change |
|------|--------|
| `get_composite_slo.ts` | Removed `budgetingMethodOverride` from summary params so each member uses its own budgeting method |
| `composite_historical_summary_client.ts` | Changed from `composite.budgetingMethod` to `slo.budgetingMethod` when fetching historical data |
| `get_composite_slo.test.ts` | Updated test assertion to no longer expect `budgetingMethodOverride` |
| `composite_historical_summary_client.test.ts` | Updated test to assert member's budgeting method (`timeslices`) is passed instead of composite's (`occurrences`) |

## Test plan

- [x] Unit tests pass (19/19)
- [ ] Verify composite SLO with mixed `occurrences` and `timeslices` members computes correct SLI values
- [ ] Verify composite historical summary uses member budgeting methods correctly


Made with [Cursor](https://cursor.com)