### PR TITLE
Chrome-next logo, separators, and home nav item

### DIFF
--- a/src/core/packages/chrome/browser-components/src/chrome_next/global_header/global_header_logo.tsx
+++ b/src/core/packages/chrome/browser-components/src/chrome_next/global_header/global_header_logo.tsx
@@ -8,22 +8,45 @@
  */
 
 import { i18n } from '@kbn/i18n';
+import { css } from '@emotion/react';
 import React from 'react';
 import { useProjectHome, useBasePath, useCustomBranding } from '../../shared/chrome_hooks';
 import { LoadingIndicator } from '../../shared/loading_indicator';
+import { headerButtonBaseStyles, useHeaderButtonStyleVars } from './header_action_button';
 
 const LOGO_ARIA_LABEL = i18n.translate('core.ui.chrome.globalHeader.logoAriaLabel', {
   defaultMessage: 'Elastic home',
 });
 
+const logoLinkStyles = css`
+  ${headerButtonBaseStyles};
+  width: 32px;
+  justify-content: center;
+  border: none;
+  text-decoration: none;
+  color: inherit;
+
+  svg {
+    width: 20px;
+    height: 20px;
+  }
+`;
+
 export const GlobalHeaderLogo = React.memo(() => {
   const basePath = useBasePath();
   const homeHref = basePath.prepend(useProjectHome());
   const { logo: customLogo } = useCustomBranding();
+  const styleVars = useHeaderButtonStyleVars();
 
   return (
-    <a href={homeHref} aria-label={LOGO_ARIA_LABEL} data-test-subj="chromeNextGlobalHeaderLogo">
-      <LoadingIndicator customLogo={customLogo} />
+    <a
+      href={homeHref}
+      aria-label={LOGO_ARIA_LABEL}
+      data-test-subj="chromeNextGlobalHeaderLogo"
+      css={logoLinkStyles}
+      style={styleVars}
+    >
+      <LoadingIndicator customLogo={customLogo} elasticLogoColor={'text'} />
     </a>
   );
 });

--- a/src/core/packages/chrome/browser-components/src/chrome_next/global_header/global_header_shell.tsx
+++ b/src/core/packages/chrome/browser-components/src/chrome_next/global_header/global_header_shell.tsx
@@ -96,7 +96,7 @@ const useGlobalHeaderStyles = () => {
 
     const separator = css`
       width: 1px;
-      height: 20px;
+      height: 24px;
       flex-shrink: 0;
       background: ${euiTheme.colors.borderBaseSubdued};
     `;

--- a/src/core/packages/chrome/browser-components/src/project/sidenav/navigation/navigation.tsx
+++ b/src/core/packages/chrome/browser-components/src/project/sidenav/navigation/navigation.tsx
@@ -28,6 +28,7 @@ export interface ChromeNavigationProps {
 
 export const Navigation = (props: ChromeNavigationProps) => {
   const state = useNavigationItems();
+  const isNextChrome = useIsNextChrome();
 
   if (!state) {
     return null;
@@ -44,6 +45,7 @@ export const Navigation = (props: ChromeNavigationProps) => {
         setWidth={props.setWidth}
         onToggleCollapsed={props.onToggleCollapsed}
         activeItemId={activeItemId}
+        showTopSeparator={isNextChrome}
         data-test-subj={classnames(`${solutionId}SideNav`, 'projectSideNav', 'projectSideNavV2')}
       />
     </KibanaSectionErrorBoundary>
@@ -71,7 +73,8 @@ const useNavigationItems = (): NavigationState | null => {
         const { navItems, logoItem, activeItemId } = toNavigationItems(
           nav.navigationTree,
           nav.activeNodes,
-          panelStateManager
+          panelStateManager,
+          isNextChrome
         );
         return {
           solutionId: nav.solutionId,

--- a/src/core/packages/chrome/browser-components/src/project/sidenav/navigation/to_navigation_items.tsx
+++ b/src/core/packages/chrome/browser-components/src/project/sidenav/navigation/to_navigation_items.tsx
@@ -28,7 +28,7 @@ import { isActiveFromUrl } from './utils/is_active_from_url';
 const SKIP_WARNINGS = process.env.NODE_ENV === 'production';
 
 export interface NavigationItems {
-  logoItem: SideNavLogo;
+  logoItem?: SideNavLogo;
   navItems: NavigationStructure;
   activeItemId?: string;
 }
@@ -58,12 +58,11 @@ export interface NavigationItems {
 export const toNavigationItems = (
   navigationTree: NavigationTreeDefinitionUI,
   activeNodes: ChromeProjectNavigationNode[][],
-  panelStateManager: PanelStateManager
+  panelStateManager: PanelStateManager,
+  isNextChrome: boolean = false
 ): NavigationItems => {
-  // HACK: extract the logo, primary and footer nodes from the navigation tree
-  let logoNode: ChromeProjectNavigationNode | null = null;
-  let primaryNodes: ChromeProjectNavigationNode[] = [];
-  let footerNodes: ChromeProjectNavigationNode[] = [];
+  let primaryNodes: ChromeProjectNavigationNode[] = navigationTree.body;
+  const footerNodes: ChromeProjectNavigationNode[] = navigationTree.footer ?? [];
 
   let deepestActiveItemId: string | undefined;
   let currentActiveItemIdLevel = -1;
@@ -102,27 +101,30 @@ export const toNavigationItems = (
     );
   };
 
-  primaryNodes = navigationTree.body;
-  footerNodes = navigationTree.footer ?? [];
+  let logoItem: SideNavLogo | undefined;
 
   const homeNodeIndex = primaryNodes.findIndex((node) => node.renderAs === 'home');
   if (homeNodeIndex !== -1) {
-    logoNode = primaryNodes[homeNodeIndex];
-    primaryNodes = primaryNodes.filter((_, index) => index !== homeNodeIndex); // Remove the logo node from primary items
-    maybeMarkActive(logoNode, 0);
+    const homeNode = primaryNodes[homeNodeIndex];
+    maybeMarkActive(homeNode, 0);
+
+    if (isNextChrome) {
+      primaryNodes[homeNodeIndex] = { ...homeNode, title: 'Home', icon: 'home' };
+    } else {
+      primaryNodes = primaryNodes.filter((_, i) => i !== homeNodeIndex);
+      logoItem = {
+        href: warnIfMissing(homeNode, 'href', '/missing-href-😭'),
+        iconType: getIcon(homeNode),
+        id: warnIfMissing(homeNode, 'id', 'kibana'),
+        label: warnIfMissing(homeNode, 'title', 'Kibana'),
+        'data-test-subj': getTestSubj(homeNode, ['nav-item-home']),
+      };
+    }
   } else {
     warnOnce(
       `No "home" node found in primary nodes. There should be a logo node with solution logo, name and home page href. renderAs: "home" is expected.`
     );
   }
-
-  const logoItem: SideNavLogo = {
-    href: warnIfMissing(logoNode, 'href', '/missing-href-😭'),
-    iconType: getIcon(logoNode),
-    id: warnIfMissing(logoNode, 'id', 'kibana'),
-    label: warnIfMissing(logoNode, 'title', 'Kibana'),
-    'data-test-subj': logoNode ? getTestSubj(logoNode, ['nav-item-home']) : undefined,
-  };
 
   const toMenuItem = (navNode: ChromeProjectNavigationNode): MenuItem[] | MenuItem | null => {
     if (!navNode) return null;
@@ -358,13 +360,12 @@ function warnAboutDuplicates(
 }
 
 function warnAboutDuplicateIcons(
-  logoItem: SideNavLogo,
+  logoItem: SideNavLogo | undefined,
   primaryItems: MenuItem[],
   footerItems: MenuItem[]
 ) {
   if (SKIP_WARNINGS) return;
-  // Collect all items with icons (only logo + primary items, excluding fallback)
-  const icons = [logoItem, ...primaryItems, ...footerItems]
+  const icons = [...(logoItem ? [logoItem] : []), ...primaryItems, ...footerItems]
     .filter(
       (item) =>
         item.iconType && item.iconType !== FALLBACK_ICON && typeof item.iconType === 'string'
@@ -379,13 +380,12 @@ function warnAboutDuplicateIcons(
 }
 
 function warnAboutDuplicateIds(
-  logoItem: SideNavLogo,
+  logoItem: SideNavLogo | undefined,
   primaryItems: MenuItem[],
   footerItems: MenuItem[]
 ) {
   if (SKIP_WARNINGS) return;
-  // Collect all IDs from all items, including secondary menu items
-  let allIds: string[] = [logoItem.id];
+  let allIds: string[] = logoItem ? [logoItem.id] : [];
 
   // Helper to extract IDs from menu items including their secondary sections
   const collectIds = (items: MenuItem[]) => {

--- a/src/core/packages/chrome/browser-components/src/shared/loading_indicator.tsx
+++ b/src/core/packages/chrome/browser-components/src/shared/loading_indicator.tsx
@@ -16,9 +16,14 @@ import { useIsLoading } from './chrome_hooks';
 export interface LoadingIndicatorProps {
   showAsBar?: boolean;
   customLogo?: string;
+  elasticLogoColor?: string;
 }
 
-export const LoadingIndicator = ({ showAsBar = false, customLogo }: LoadingIndicatorProps) => {
+export const LoadingIndicator = ({
+  showAsBar = false,
+  customLogo,
+  elasticLogoColor,
+}: LoadingIndicatorProps) => {
   const isLoading = useIsLoading();
 
   const loadingSubj = isLoading ? 'globalLoadingIndicator' : 'globalLoadingIndicator-hidden';
@@ -42,6 +47,7 @@ export const LoadingIndicator = ({ showAsBar = false, customLogo }: LoadingIndic
     <EuiIcon
       type={'logoElastic'}
       size="l"
+      color={elasticLogoColor}
       data-test-subj={testSubj}
       aria-label={i18n.translate('core.ui.chrome.headerGlobalNav.logoAriaLabel', {
         defaultMessage: 'Elastic Logo',

--- a/src/core/packages/chrome/navigation/packaging/react/types.ts
+++ b/src/core/packages/chrome/navigation/packaging/react/types.ts
@@ -118,6 +118,8 @@ export interface NavigationProps {
   onItemClick?: (item: MenuItem | SecondaryMenuItem | SideNavLogo) => void;
   /** Callback fired when the collapse button is toggled. Omit to hide the toggle button. */
   onToggleCollapsed?: (isCollapsed: boolean) => void;
+  /** When true, renders a centered horizontal separator at the top of the side nav. */
+  showTopSeparator?: boolean;
   /** Content to display inside the side panel footer. */
   sidePanelFooter?: ReactNode;
   /** Optional `data-test-subj` attribute for testing purposes. */

--- a/src/core/packages/chrome/navigation/src/components/navigation.tsx
+++ b/src/core/packages/chrome/navigation/src/components/navigation.tsx
@@ -11,7 +11,7 @@ import React, { useState, type ReactNode } from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
-import { useIsWithinBreakpoints } from '@elastic/eui';
+import { useEuiTheme, useIsWithinBreakpoints } from '@elastic/eui';
 
 import type { NavigationStructure, SideNavLogo, MenuItem, SecondaryMenuItem } from '../../types';
 import {
@@ -29,6 +29,7 @@ import { useLayoutWidth } from '../hooks/use_layout_width';
 import { useNavigation } from '../hooks/use_navigation';
 import { useNewItems } from '../hooks/use_new_items';
 import { useResponsiveMenu } from '../hooks/use_responsive_menu';
+import { getHighContrastSeparator } from '../hooks/use_high_contrast_mode_styles';
 
 const navigationWrapperStyles = css`
   display: flex;
@@ -50,7 +51,7 @@ export interface NavigationProps {
   /**
    * The logo object containing the route ID, href, label, and type.
    */
-  logo: SideNavLogo;
+  logo?: SideNavLogo;
   /**
    * Required by the grid layout to set the width of the navigation slot.
    */
@@ -71,6 +72,11 @@ export interface NavigationProps {
    */
   sidePanelFooter?: ReactNode;
   /**
+   * When true, renders a centered horizontal separator at the top of the side nav,
+   * between the global header and the logo/primary menu.
+   */
+  showTopSeparator?: boolean;
+  /**
    * (optional) data-test-subj attribute for testing purposes.
    */
   'data-test-subj'?: string;
@@ -84,11 +90,20 @@ export const Navigation = ({
   onItemClick,
   onToggleCollapsed,
   setWidth,
+  showTopSeparator = false,
   sidePanelFooter,
   ...rest
 }: NavigationProps) => {
   const forcedCollapsed = useIsWithinBreakpoints(['xs', 's']);
   const isCollapsed = forcedCollapsed || isCollapsedProp;
+  const euiThemeContext = useEuiTheme();
+
+  const topSeparatorStyles = css`
+    position: relative;
+    flex-shrink: 0;
+    ${getHighContrastSeparator(euiThemeContext, { side: 'bottom' })}
+  `;
+
   const popoverItemPrefix = `${NAVIGATION_SELECTOR_PREFIX}-popoverItem`;
   const popoverFooterItemPrefix = `${NAVIGATION_SELECTOR_PREFIX}-popoverFooterItem`;
   const sidePanelItemPrefix = `${NAVIGATION_SELECTOR_PREFIX}-sidePanelItem`;
@@ -100,7 +115,7 @@ export const Navigation = ({
     visuallyActiveSubpageId,
     isSidePanelOpen,
     openerNode,
-  } = useNavigation(isCollapsed, items, logo.id, activeItemId);
+  } = useNavigation(isCollapsed, items, logo?.id, activeItemId);
 
   const [isAnyPopoverLocked, setIsAnyPopoverLocked] = useState(false);
 
@@ -131,13 +146,16 @@ export const Navigation = ({
       id={NAVIGATION_ROOT_SELECTOR}
     >
       <SideNav isCollapsed={isCollapsed}>
-        <SideNav.Logo
-          isCollapsed={isCollapsed}
-          isCurrent={actualActiveItemId === logo.id}
-          isHighlighted={visuallyActivePageId === logo.id}
-          onClick={() => onItemClick?.(logo)}
-          {...logo}
-        />
+        {showTopSeparator && <div css={topSeparatorStyles} aria-hidden />}
+        {logo && (
+          <SideNav.Logo
+            isCollapsed={isCollapsed}
+            isCurrent={actualActiveItemId === logo.id}
+            isHighlighted={visuallyActivePageId === logo.id}
+            onClick={() => onItemClick?.(logo)}
+            {...logo}
+          />
+        )}
 
         <SideNav.PrimaryMenu ref={primaryMenuRef} isCollapsed={isCollapsed}>
           {({ mainNavigationInstructionsId }) => (

--- a/src/core/packages/chrome/navigation/src/hooks/use_navigation.ts
+++ b/src/core/packages/chrome/navigation/src/hooks/use_navigation.ts
@@ -39,7 +39,7 @@ interface NavigationState {
 export const useNavigation = (
   isCollapsed: boolean,
   items: NavigationStructure,
-  logoId: string,
+  logoId: string | undefined,
   activeItemId?: string
 ) => {
   const { primaryItem, secondaryItem, isLogoActive } = useMemo(


### PR DESCRIPTION
## Summary

- Global header logo is now a proper 32x32 square with focus ring, hover state, and full click area (reuses `HeaderActionButton` shared styles)
- Top separator between global header and side nav (chrome-next only) using `getHighContrastSeparator`
- Vertical separator height bumped to 24px
- Home node stays in `primaryItems` in chrome-next (with forced Home icon/title) instead of being extracted as a separate logo item


<img width="1627" height="1041" alt="Screenshot 2026-04-14 at 16 26 31" src="https://github.com/user-attachments/assets/eecb5c26-0412-4d3a-8ef0-18c3a9c66c71" />
