### PR TITLE
[Discover] [Flaky Test] Wait for Dashboard rendering to be completed

### DIFF
--- a/src/platform/test/functional/apps/discover/group2_data_grid3/_data_grid_column_widths.ts
+++ b/src/platform/test/functional/apps/discover/group2_data_grid3/_data_grid_column_widths.ts
@@ -134,6 +134,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await dashboard.saveDashboard('test');
       await browser.refresh();
       await header.waitUntilLoadingHasFinished();
+      await dashboard.waitForRenderComplete();
       const initialWidth = (await (await dataGrid.getHeaderElement('_source')).getSize()).width;
       expect(initialWidth).to.be(newWidth);
     });


### PR DESCRIPTION
## Summary

Fixes #262674 

**Hypothesis:** the test was reading the column width before the data grid finished applying saved widths - getting EUI's default 100px instead of expected 418px.

**Fix:** this PR adds `await dashboard.waitForRenderComplete()` which waits for all dashboard panels to finish rendering, so also for width to be applied.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.



<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->