### PR TITLE
[Dashboard Markdown] Enable the Apply button when the user changes a setting

### DIFF
--- a/src/platform/plugins/shared/dashboard_markdown/public/components/markdown_editor.test.tsx
+++ b/src/platform/plugins/shared/dashboard_markdown/public/components/markdown_editor.test.tsx
@@ -8,7 +8,7 @@
  */
 
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { BehaviorSubject } from 'rxjs';
 import type { MarkdownEditorProps } from './markdown_editor';
 import { MarkdownEditor } from './markdown_editor';
@@ -69,6 +69,19 @@ it('calls onSave with current value when Apply clicked', async () => {
   await userEvent.type(textarea, ' Added Paragraph');
   await userEvent.click(screen.getByRole('button', { name: /Apply/i }));
   expect(onSave).toHaveBeenCalledWith(testedContent + ' Added Paragraph');
+});
+
+it('enables Apply when only the open links in new tab setting changes', async () => {
+  renderMarkdownEditor();
+
+  expect(screen.getByRole('button', { name: /Apply/i })).toBeDisabled();
+
+  await userEvent.click(screen.getByRole('button', { name: /Settings/i }));
+  // Use fireEvent instead of userEvent to bypass pointer events check. Waiting
+  // for the EUI CSS animation to end before continuing the test is potentially flaky.
+  fireEvent.click(await screen.findByTestId('openLinksInNewTabSwitch'));
+
+  expect(screen.getByRole('button', { name: /Apply/i })).toBeEnabled();
 });
 
 // this is a guard to not accidentally change the implementation so we can keep the scroll position for editor when switching between editor/preview mode

--- a/src/platform/plugins/shared/dashboard_markdown/public/components/markdown_editor.tsx
+++ b/src/platform/plugins/shared/dashboard_markdown/public/components/markdown_editor.tsx
@@ -13,7 +13,7 @@ import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
 import type { PublishingSubject } from '@kbn/presentation-publishing';
 import { useBatchedPublishingSubjects } from '@kbn/presentation-publishing';
-import React, { useCallback, useLayoutEffect, useRef } from 'react';
+import React, { useCallback, useLayoutEffect, useRef, useState } from 'react';
 import { useMemoCss } from '@kbn/css-utils/public/use_memo_css';
 import type { BehaviorSubject } from 'rxjs';
 import { SHORT_CONTAINER_QUERY, FOOTER_HELP_TEXT, MarkdownFooter } from './markdown_footer';
@@ -92,17 +92,19 @@ export const MarkdownEditor = ({
 }: MarkdownEditorProps) => {
   const styles = useMemoCss(componentStyles);
   const [isPreview, settings] = useBatchedPublishingSubjects(isPreview$, settings$);
-  const [value, onChange] = React.useState(content);
+  const [value, onChange] = useState(content);
 
   const editorRef = useRef<EuiMarkdownEditorRef>(null);
   const cancelButtonRef = useRef<HTMLButtonElement>(null);
 
   useCaretPosition(editorRef, !isPreview);
-  const isSaveable = Boolean(value === '' || value !== content);
+  const [haveSettingsChanged, setHaveSettingsChanged] = useState(false);
+  const isSaveable = Boolean(value === '' || value !== content || haveSettingsChanged);
 
   const updateSettings = useCallback(
     (nextSettings: Partial<MarkdownSettingsState>) => {
       settings$.next({ ...settings, ...nextSettings } as MarkdownSettingsState);
+      setHaveSettingsChanged(true);
     },
     [settings, settings$]
   );

--- a/src/platform/plugins/shared/dashboard_markdown/public/components/markdown_editor_settings_popover.tsx
+++ b/src/platform/plugins/shared/dashboard_markdown/public/components/markdown_editor_settings_popover.tsx
@@ -69,6 +69,7 @@ export function MarkdownEditorSettingsPopover({ settings, updateSettings }: Prop
         color="primary"
         checked={Boolean(openLinksInNewTab)}
         onChange={(e) => setOpenLinksInNewTab(e.target.checked)}
+        data-test-subj="openLinksInNewTabSwitch"
       />
     </EuiPopover>
   );


### PR DESCRIPTION
## Summary

When the user edits a markdown panel and changes the Open Links In New Tab setting, without changing any of the text content, the Apply button will now be enabled.

<img width="888" height="452" alt="Screenshot 2026-04-14 at 4 51 43 PM" src="https://github.com/user-attachments/assets/73ca6f36-0b8e-4921-ac14-be5aa97b6c93" />
<img width="879" height="463" alt="Screenshot 2026-04-14 at 4 51 52 PM" src="https://github.com/user-attachments/assets/0d4cde9b-649a-425e-9901-d503ef87e840" />

### Testing

1. Create a Markdown panel and save it
2. Edit the panel, note the Apply button is grayed out before you do anything
3. Do not change the text, just open the settings and toggle `Open links in new tab`
4. Ensure this enables the Apply button

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->