### PR TITLE
feat(apm): Service map Alert badges links and adding SLO and Alerts badges in the popover

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/constants.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/constants.ts
@@ -113,7 +113,7 @@ export const MOCK_EUI_THEME_FOR_USE_THEME = {
     radius: { small: '4px', medium: '6px' },
     width: { thin: '1px', thick: '2px' },
   },
-  levels: { content: 1000, header: 2000, menu: 2000 },
+  levels: { content: 1000, header: 2000, menu: 2000, flyout: 1000 },
   shadows: { s: '0 1px 2px rgba(0,0,0,0.1)' },
   font: { family: '"Inter", sans-serif' },
   animation: { fast: '150ms' },

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/popover.test.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/popover.test.tsx
@@ -45,8 +45,17 @@ jest.mock('../../../context/apm_plugin/use_apm_plugin_context', () => ({
       uiSettings: {
         get: jest.fn().mockReturnValue(false),
       },
+      application: {
+        capabilities: {
+          slo: { read: true },
+        },
+      },
     },
   }),
+}));
+
+jest.mock('../../../hooks/use_apm_route_path', () => ({
+  useApmRoutePath: () => '/services/{serviceName}/service-map',
 }));
 
 // Mock APM router

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/popover.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/popover.tsx
@@ -216,7 +216,8 @@ export function MapPopover({
         closePopover={onClose}
         isOpen={isOpen}
         ref={popoverRef}
-        zIndex={Number(euiTheme.levels.menu)}
+        // Below EUI flyouts so nested SLO / alert flyouts stay on top; above map canvas (content).
+        zIndex={Number(euiTheme.levels.flyout) - 1}
         data-test-subj="serviceMapPopover"
         aria-label={popoverAriaLabel}
         panelProps={{

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/popover/popover_content.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/popover/popover_content.tsx
@@ -17,6 +17,7 @@ import {
   type ServiceMapNode,
   type ServiceMapEdge,
 } from '../../../../../common/service_map';
+import { ServiceMapPopoverTitleBadges } from '../service_map_popover_title_badges';
 import { isEdge, type ServiceMapSelection } from './utils';
 import { POPOVER_WIDTH } from './constants';
 import { DependencyContents } from './dependency_contents';
@@ -125,20 +126,29 @@ export function PopoverContent({
       data-test-subj="serviceMapPopoverContent"
     >
       <EuiFlexItem>
-        <EuiTitle size="xxs">
-          <h3 style={{ wordBreak: 'break-all' }} data-test-subj="serviceMapPopoverTitle">
-            {getPopoverTitle(selection)}
-            {kuery && (
-              <EuiIconTip
-                position="bottom"
-                content={i18n.translate('xpack.apm.serviceMap.kqlFilterInfo', {
-                  defaultMessage: 'The KQL filter is not applied in the displayed stats.',
-                })}
-                type="info"
-              />
-            )}
-          </h3>
-        </EuiTitle>
+        <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false} wrap>
+          <EuiFlexItem grow style={{ minWidth: 0 }}>
+            <EuiTitle size="xxs">
+              <h3 style={{ wordBreak: 'break-all' }} data-test-subj="serviceMapPopoverTitle">
+                {getPopoverTitle(selection)}
+                {kuery && (
+                  <EuiIconTip
+                    position="bottom"
+                    content={i18n.translate('xpack.apm.serviceMap.kqlFilterInfo', {
+                      defaultMessage: 'The KQL filter is not applied in the displayed stats.',
+                    })}
+                    type="info"
+                  />
+                )}
+              </h3>
+            </EuiTitle>
+          </EuiFlexItem>
+          {!isEdge(selection) && selection.data != null && isServiceNodeData(selection.data) && (
+            <EuiFlexItem grow={false}>
+              <ServiceMapPopoverTitleBadges nodeData={selection.data} />
+            </EuiFlexItem>
+          )}
+        </EuiFlexGroup>
         <EuiHorizontalRule margin="xs" />
       </EuiFlexItem>
       <ContentsComponent

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/service_map_popover_title_badges.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/service_map_popover_title_badges.tsx
@@ -1,0 +1,88 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiBadge, EuiFlexGroup, EuiFlexItem, EuiToolTip } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import React from 'react';
+import { useApmPluginContext } from '../../../context/apm_plugin/use_apm_plugin_context';
+import type { ServiceNodeData } from '../../../../common/service_map';
+import { SloStatusBadge } from '../../shared/slo_status_badge';
+import { useServiceMapSloFlyout } from './service_map_slo_flyout_context';
+import { useServiceMapAlertsTabNavigate } from './use_service_map_alerts_tab_href';
+
+interface Props {
+  nodeData: ServiceNodeData;
+}
+
+/**
+ * Alert and SLO badges next to the service map popover title — same behaviour as
+ * {@link ServiceNode} badges on the map.
+ */
+export function ServiceMapPopoverTitleBadges({ nodeData }: Props) {
+  const { core } = useApmPluginContext();
+  const canReadSlos = !!core.application?.capabilities?.slo?.read;
+  const { onSloBadgeClick } = useServiceMapSloFlyout();
+
+  const serviceName = nodeData.label;
+  const navigateToAlertsTab = useServiceMapAlertsTabNavigate(serviceName);
+
+  const showAlertsBadge = nodeData.alertsCount !== undefined && nodeData.alertsCount > 0;
+  const showSloBadge =
+    canReadSlos && (nodeData.sloStatus === 'violated' || nodeData.sloStatus === 'degrading');
+
+  if (!showAlertsBadge && !showSloBadge) {
+    return null;
+  }
+
+  const alertsTooltip = i18n.translate('xpack.apm.serviceHeader.alertsBadge.tooltip', {
+    defaultMessage: '{count, plural, one {# active alert} other {# active alerts}}. Click to view.',
+    values: { count: nodeData.alertsCount ?? 0 },
+  });
+
+  return (
+    <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
+      {showAlertsBadge && (
+        <EuiFlexItem grow={false}>
+          <span onClick={(e) => e.stopPropagation()} onKeyDown={(e) => e.stopPropagation()}>
+            <EuiToolTip position="bottom" content={alertsTooltip}>
+              <EuiBadge
+                data-test-subj="serviceMapPopoverAlertsBadge"
+                color="danger"
+                iconType="warning"
+                onClick={navigateToAlertsTab}
+                tabIndex={0}
+                role="button"
+                onClickAriaLabel={alertsTooltip}
+              >
+                {nodeData.alertsCount}
+              </EuiBadge>
+            </EuiToolTip>
+          </span>
+        </EuiFlexItem>
+      )}
+      {showSloBadge && nodeData.sloStatus && (
+        <EuiFlexItem grow={false}>
+          <span onClick={(e) => e.stopPropagation()} onKeyDown={(e) => e.stopPropagation()}>
+            <SloStatusBadge
+              sloStatus={nodeData.sloStatus}
+              sloCount={nodeData.sloCount}
+              serviceName={serviceName}
+              {...(onSloBadgeClick
+                ? {
+                    onClick: (e) => {
+                      e.stopPropagation();
+                      onSloBadgeClick(serviceName, nodeData.agentName);
+                    },
+                  }
+                : { hideTooltip: true })}
+            />
+          </span>
+        </EuiFlexItem>
+      )}
+    </EuiFlexGroup>
+  );
+}

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/service_node.test.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/service_node.test.tsx
@@ -10,6 +10,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { ReactFlowProvider } from '@xyflow/react';
 import { ServiceNode } from './service_node';
 import { ServiceMapSloFlyoutProvider } from './service_map_slo_flyout_context';
+import { useServiceMapAlertsTabNavigate } from './use_service_map_alerts_tab_href';
 import { ServiceHealthStatus } from '../../../../common/service_health_status';
 import type { ServiceNodeData } from '../../../../common/service_map';
 import { MOCK_EUI_THEME, MOCK_DEFAULT_COLOR, MOCK_EUI_THEME_FOR_USE_THEME } from './constants';
@@ -40,6 +41,11 @@ jest.mock('../../../context/apm_plugin/use_apm_plugin_context', () => ({
       },
     },
   }),
+}));
+
+jest.mock('./use_service_map_alerts_tab_href', () => ({
+  useServiceMapAlertsTabHref: jest.fn(() => '/app/apm/services/Test%20Service/alerts'),
+  useServiceMapAlertsTabNavigate: jest.fn(() => jest.fn()),
 }));
 
 // Mock getServiceHealthStatusColor
@@ -202,6 +208,17 @@ describe('ServiceNode', () => {
       );
       fireEvent.click(screen.getByTestId('apmSloBadge'));
       expect(onSloBadgeClick).toHaveBeenCalledWith('Test Service', 'java');
+    });
+  });
+
+  describe('Alerts badge', () => {
+    it('calls the alerts navigation handler when the alerts badge is clicked', () => {
+      const navigateCb = jest.fn();
+      jest.mocked(useServiceMapAlertsTabNavigate).mockReturnValue(navigateCb);
+
+      renderServiceNode(createServiceNodeData({ alertsCount: 2 }));
+      fireEvent.click(screen.getByTestId('serviceMapNodeAlertsBadge'));
+      expect(navigateCb).toHaveBeenCalled();
     });
   });
 });

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/service_node.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/service_node.tsx
@@ -7,7 +7,7 @@
 
 import React, { useMemo, memo } from 'react';
 import { Handle, Position, type Node, type NodeProps } from '@xyflow/react';
-import { useEuiTheme, EuiBadge, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import { useEuiTheme, EuiBadge, EuiFlexGroup, EuiFlexItem, EuiToolTip } from '@elastic/eui';
 import { getAgentIcon } from '@kbn/custom-icons';
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
@@ -26,6 +26,7 @@ import { NodeLabel } from './node_label';
 import { useApmPluginContext } from '../../../context/apm_plugin/use_apm_plugin_context';
 import { SloStatusBadge } from '../../shared/slo_status_badge';
 import { useServiceMapSloFlyout } from './service_map_slo_flyout_context';
+import { useServiceMapAlertsTabNavigate } from './use_service_map_alerts_tab_href';
 
 type ServiceNodeType = Node<ServiceNodeData, 'service'>;
 
@@ -36,6 +37,7 @@ export const ServiceNode = memo(
     const { capabilities } = core.application;
     const canReadSlos = !!capabilities.slo?.read;
     const { onSloBadgeClick } = useServiceMapSloFlyout();
+    const navigateToAlertsTab = useServiceMapAlertsTabNavigate(data.label);
     const isDarkMode = colorMode === 'DARK';
 
     const borderColor = useMemo(() => {
@@ -161,8 +163,9 @@ export const ServiceNode = memo(
     const showSloBadge =
       canReadSlos && (data.sloStatus === 'violated' || data.sloStatus === 'degrading');
 
-    const alertsTooltip = i18n.translate('xpack.apm.serviceMap.serviceNode.alertsBadgeTooltip', {
-      defaultMessage: '{count, plural, one {# active alert} other {# active alerts}}',
+    const alertsTooltip = i18n.translate('xpack.apm.serviceHeader.alertsBadge.tooltip', {
+      defaultMessage:
+        '{count, plural, one {# active alert} other {# active alerts}}. Click to view.',
       values: { count: data.alertsCount ?? 0 },
     });
 
@@ -201,15 +204,24 @@ export const ServiceNode = memo(
               css={badgesRowStyles}
             >
               {showAlertsBadge && (
-                <span css={badgePointerEventsStyles}>
-                  <EuiBadge
-                    data-test-subj="serviceMapNodeAlertsBadge"
-                    color="danger"
-                    iconType="warning"
-                    title={alertsTooltip}
-                  >
-                    {data.alertsCount}
-                  </EuiBadge>
+                <span
+                  css={badgePointerEventsStyles}
+                  onClick={(e) => e.stopPropagation()}
+                  onKeyDown={(e) => e.stopPropagation()}
+                >
+                  <EuiToolTip position="bottom" content={alertsTooltip}>
+                    <EuiBadge
+                      data-test-subj="serviceMapNodeAlertsBadge"
+                      color="danger"
+                      iconType="warning"
+                      onClick={navigateToAlertsTab}
+                      tabIndex={0}
+                      role="button"
+                      onClickAriaLabel={alertsTooltip}
+                    >
+                      {data.alertsCount}
+                    </EuiBadge>
+                  </EuiToolTip>
                 </span>
               )}
               {showSloBadge && data.sloStatus && (

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/use_service_map_alerts_tab_href.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/use_service_map_alerts_tab_href.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { KeyboardEvent, MouseEvent } from 'react';
+import { useCallback, useMemo } from 'react';
+import { useApmPluginContext } from '../../../context/apm_plugin/use_apm_plugin_context';
+import { useAnyOfApmParams } from '../../../hooks/use_apm_params';
+import { useApmRoutePath } from '../../../hooks/use_apm_route_path';
+import { useApmRouter } from '../../../hooks/use_apm_router';
+
+/**
+ * Alerts tab URL for a service on the service map, matching the service header
+ * badge destination for the current map context (global, service detail, mobile).
+ */
+export function useServiceMapAlertsTabHref(serviceName: string) {
+  const apmRouter = useApmRouter();
+  const routePath = useApmRoutePath();
+  const { query } = useAnyOfApmParams(
+    '/service-map',
+    '/services/{serviceName}/service-map',
+    '/mobile-services/{serviceName}/service-map'
+  );
+
+  return useMemo(() => {
+    const isMobileContext = String(routePath).includes('mobile-services');
+    if (isMobileContext) {
+      return apmRouter.link('/mobile-services/{serviceName}/alerts', {
+        path: { serviceName },
+        query,
+      });
+    }
+    return apmRouter.link('/services/{serviceName}/alerts', {
+      path: { serviceName },
+      query,
+    });
+  }, [apmRouter, query, routePath, serviceName]);
+}
+
+/**
+ * SPA navigation to the alerts tab (avoids full page reload from a plain anchor href).
+ */
+export function useServiceMapAlertsTabNavigate(serviceName: string) {
+  const alertsTabHref = useServiceMapAlertsTabHref(serviceName);
+  const {
+    core: {
+      application: { navigateToUrl },
+    },
+  } = useApmPluginContext();
+
+  return useCallback(
+    (e: MouseEvent | KeyboardEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      navigateToUrl(alertsTabHref);
+    },
+    [alertsTabHref, navigateToUrl]
+  );
+}

--- a/x-pack/solutions/observability/plugins/apm/public/components/routing/templates/apm_service_template/service_header_badges.test.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/routing/templates/apm_service_template/service_header_badges.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
 import { ServiceHeaderBadges } from './service_header_badges';
 import { FETCH_STATUS } from '../../../../hooks/use_fetcher';
@@ -17,6 +17,7 @@ jest.mock('../../../../context/service_slo/use_service_slo_context', () => ({
   useServiceSloContext: () => mockUseServiceSloContext(),
 }));
 
+const mockNavigateToUrl = jest.fn();
 const mockUseApmPluginContext = jest.fn();
 jest.mock('../../../../context/apm_plugin/use_apm_plugin_context', () => ({
   useApmPluginContext: () => mockUseApmPluginContext(),
@@ -77,6 +78,7 @@ function setupMocks({
   mockUseApmPluginContext.mockReturnValue({
     core: {
       application: {
+        navigateToUrl: mockNavigateToUrl,
         capabilities: {
           slo: { read: canReadSlos },
           apm: {
@@ -111,6 +113,7 @@ function setupMocks({
 describe('ServiceHeaderBadges', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockNavigateToUrl.mockClear();
   });
 
   it('shows alerts badge when there are active alerts', () => {
@@ -122,12 +125,13 @@ describe('ServiceHeaderBadges', () => {
     expect(badge).toHaveTextContent('5');
   });
 
-  it('shows alerts badge with correct href', () => {
+  it('navigates to alerts tab via SPA when the alerts badge is clicked', () => {
     setupMocks({ alertsCount: 3 });
     renderBadges();
 
     const badge = screen.getByTestId('serviceHeaderAlertsBadge');
-    expect(badge).toHaveAttribute('href', '/services/test-service/alerts');
+    fireEvent.click(badge);
+    expect(mockNavigateToUrl).toHaveBeenCalledWith('/services/test-service/alerts');
   });
 
   it('hides alerts badge when alertsCount is 0', () => {

--- a/x-pack/solutions/observability/plugins/apm/public/components/routing/templates/apm_service_template/service_header_badges.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/routing/templates/apm_service_template/service_header_badges.tsx
@@ -35,7 +35,7 @@ export function ServiceHeaderBadges({
 }: ServiceHeaderBadgesProps) {
   const { euiTheme } = useEuiTheme();
   const { core, plugins } = useApmPluginContext();
-  const { capabilities } = core.application;
+  const { capabilities, navigateToUrl } = core.application;
   const { isAlertingAvailable, canReadAlerts } = getAlertingCapabilities(plugins, capabilities);
   const canReadSlos = !!capabilities.slo?.read;
 
@@ -79,6 +79,16 @@ export function ServiceHeaderBadges({
     return null;
   }
 
+  const alertsTooltip = i18n.translate('xpack.apm.serviceHeader.alertsBadge.tooltip', {
+    defaultMessage: '{count, plural, one {# active alert} other {# active alerts}}. Click to view.',
+    values: { count: alertsCount },
+  });
+
+  const onAlertsBadgeClick = (e: React.MouseEvent | React.KeyboardEvent) => {
+    e.preventDefault();
+    navigateToUrl(alertsTabHref);
+  };
+
   return (
     <EuiFlexGroup
       gutterSize="s"
@@ -88,19 +98,15 @@ export function ServiceHeaderBadges({
     >
       {showAlertsBadge && (
         <EuiFlexItem grow={false}>
-          <EuiToolTip
-            position="bottom"
-            content={i18n.translate('xpack.apm.serviceHeader.alertsBadge.tooltip', {
-              defaultMessage:
-                '{count, plural, one {# active alert} other {# active alerts}}. Click to view.',
-              values: { count: alertsCount },
-            })}
-          >
+          <EuiToolTip position="bottom" content={alertsTooltip}>
             <EuiBadge
               data-test-subj="serviceHeaderAlertsBadge"
               color="danger"
               iconType="warning"
-              href={alertsTabHref}
+              onClick={onAlertsBadgeClick}
+              tabIndex={0}
+              role="button"
+              onClickAriaLabel={alertsTooltip}
             >
               {alertsCount}
             </EuiBadge>


### PR DESCRIPTION
Closes #262082

## Summary

**Enhancement** — improves APM service map UX (badge parity, navigation, and layering); not a regression fix.

- **Popover title badges**: Service map node popover shows the same **alerts** and **SLO** badges as on the map nodes (`ServiceMapPopoverTitleBadges`), sharing URL and navigation helpers.
- **SPA navigation to Alerts**: Uses `core.application.navigateToUrl` instead of plain `href` for the alerts count badge on the **map**, **popover**, and **service header** to avoid a full page reload.
- **Layering**: Map popover `zIndex` is `euiTheme.levels.flyout - 1` so flyouts (e.g. SLO detail with nested Alerts) render above the popover; theme test mock includes `flyout`.
- **Tests**: Updates for `service_node` and `service_header_badges` navigation behavior.

<img width="1569" height="868" alt="image" src="https://github.com/user-attachments/assets/6e8c09f0-add8-487a-9f14-68e7cbb19788" />


## Testing

-  Alerts badge 
  
  https://github.com/user-attachments/assets/624b2742-fbbc-438f-9f6e-5ac8851264b4   

- SLO badge 

  https://github.com/user-attachments/assets/8c2d8a07-e7d4-47cf-a45f-a05d1d357622 


### Manual

- Select a service on the map → popover title shows badges aligned with the node.
- Click alerts badge on node, popover, and service header → in-app navigation only.
- Open SLO from badge → nested flyouts stay above the map popover.

