### PR TITLE
[Security Solution] fix new tools flyout header wrongly showing in the old notes, correlations, prevalence and threat intelligence section of the expandable flyout

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/correlations_details.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/correlations_details.test.tsx
@@ -16,8 +16,8 @@ import type { CorrelationsDetailsProps } from '../../../../flyout_v2/correlation
 
 jest.mock('@kbn/expandable-flyout');
 
-jest.mock('../../../../flyout_v2/correlations', () => ({
-  CorrelationsDetails: ({ scopeId, isRulePreview, onShowAttack }: CorrelationsDetailsProps) => (
+jest.mock('../../../../flyout_v2/correlations/components/correlations_details_view', () => ({
+  CorrelationsDetailsView: ({ scopeId, isRulePreview, onShowAttack }: CorrelationsDetailsProps) => (
     <div
       data-test-subj="correlationsDetailsV2Mock"
       data-scope-id={scopeId}

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/correlations_details.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/correlations_details.tsx
@@ -9,7 +9,7 @@ import React, { useCallback, useMemo } from 'react';
 import { buildDataTableRecord, type EsHitRecord } from '@kbn/discover-utils';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { useDocumentDetailsContext } from '../../shared/context';
-import { CorrelationsDetails as CorrelationsDetailsV2 } from '../../../../flyout_v2/correlations';
+import { CorrelationsDetailsView } from '../../../../flyout_v2/correlations/components/correlations_details_view';
 import { DocumentDetailsPreviewPanelKey } from '../../shared/constants/panel_keys';
 import { ALERT_PREVIEW_BANNER } from '../../preview/constants';
 import { AttackDetailsPreviewPanelKey } from '../../../attack_details/constants/panel_keys';
@@ -45,7 +45,7 @@ export const CorrelationsDetails: React.FC = () => {
   const hit = useMemo(() => buildDataTableRecord(searchHit as EsHitRecord), [searchHit]);
 
   return (
-    <CorrelationsDetailsV2
+    <CorrelationsDetailsView
       hit={hit}
       scopeId={scopeId}
       isRulePreview={isRulePreview}

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/prevalence_details.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/prevalence_details.test.tsx
@@ -9,7 +9,7 @@ import { fireEvent, render } from '@testing-library/react';
 import React from 'react';
 import { DocumentDetailsContext } from '../../shared/context';
 import { PrevalenceDetails } from './prevalence_details';
-import { resetColdFrozenTierCalloutDismissedStateForTests } from '../../../../flyout_v2/prevalence/prevalence';
+import { resetColdFrozenTierCalloutDismissedStateForTests } from '../../../../flyout_v2/prevalence/components/prevalence_details_view';
 import {
   PREVALENCE_DETAILS_COLD_FROZEN_TIER_CALLOUT_DISMISS_BUTTON_TEST_ID,
   PREVALENCE_DETAILS_COLD_FROZEN_TIER_CALLOUT_TEST_ID,

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/prevalence_details.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/prevalence_details.tsx
@@ -18,7 +18,7 @@ import { useDocumentDetailsContext } from '../../shared/context';
 import { PreviewLink } from '../../../shared/components/preview_link';
 import { CellActions } from '../../shared/components/cell_actions';
 import type { IdentityFields } from '../../shared/utils';
-import { PrevalenceDetails as PrevalenceDetailsContent } from '../../../../flyout_v2/prevalence/prevalence';
+import { PrevalenceDetailsView } from '../../../../flyout_v2/prevalence/components/prevalence_details_view';
 import type { PrevalenceDetailsRow } from '../../../../flyout_v2/prevalence/utils/get_columns';
 import {
   alertCountColumn,
@@ -86,7 +86,7 @@ export const PrevalenceDetails: React.FC = () => {
   const hit = useMemo(() => buildDataTableRecord(searchHit as EsHitRecord), [searchHit]);
 
   return (
-    <PrevalenceDetailsContent
+    <PrevalenceDetailsView
       hit={hit}
       investigationFields={investigationFields}
       scopeId={scopeId}

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/tabs/insights_tab.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/tabs/insights_tab.tsx
@@ -24,10 +24,8 @@ import { useDocumentDetailsContext } from '../../shared/context';
 import { DocumentDetailsLeftPanelKey } from '../../shared/constants/panel_keys';
 import { LeftPanelInsightsTab } from '..';
 import { EntitiesDetails } from '../components/entities_details';
-import {
-  THREAT_INTELLIGENCE_TAB_ID,
-  ThreatIntelligenceDetails,
-} from '../../../../flyout_v2/threat_intelligence';
+import { THREAT_INTELLIGENCE_TAB_ID } from '../../../../flyout_v2/threat_intelligence';
+import { ThreatIntelligenceDetailsView } from '../../../../flyout_v2/threat_intelligence/components/threat_intelligence_details_view';
 import { PREVALENCE_TAB_ID, PrevalenceDetails } from '../components/prevalence_details';
 import { CORRELATIONS_TAB_ID, CorrelationsDetails } from '../components/correlations_details';
 import { getField } from '../../shared/utils';
@@ -143,7 +141,9 @@ export const InsightsTab = memo(() => {
       />
       <EuiSpacer size="m" />
       {activeInsightsId === ENTITIES_TAB_ID && <EntitiesDetails />}
-      {activeInsightsId === THREAT_INTELLIGENCE_TAB_ID && <ThreatIntelligenceDetails hit={hit} />}
+      {activeInsightsId === THREAT_INTELLIGENCE_TAB_ID && (
+        <ThreatIntelligenceDetailsView hit={hit} />
+      )}
       {activeInsightsId === PREVALENCE_TAB_ID && <PrevalenceDetails />}
       {activeInsightsId === CORRELATIONS_TAB_ID && <CorrelationsDetails />}
     </>

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/tabs/notes_tab.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/tabs/notes_tab.tsx
@@ -7,7 +7,13 @@
 
 import React, { memo, useMemo } from 'react';
 import { buildDataTableRecord, type EsHitRecord } from '@kbn/discover-utils';
-import { NotesDetails } from '../../../../flyout_v2/notes';
+import { useSelector } from 'react-redux';
+import { EuiPanel } from '@elastic/eui';
+import type { State } from '../../../../common/store';
+import { timelineSelectors } from '../../../../timelines/store';
+import { TimelineId } from '../../../../../common/types';
+import { useTimelineConfig } from '../../../../flyout_v2/notes/hooks/use_timeline_config';
+import { NotesDetailsContent } from '../../../../flyout_v2/notes/components/notes_details_content';
 import { useDocumentDetailsContext } from '../../shared/context';
 
 /**
@@ -16,8 +22,18 @@ import { useDocumentDetailsContext } from '../../shared/context';
 export const NotesTab = memo(() => {
   const { searchHit } = useDocumentDetailsContext();
   const hit = useMemo(() => buildDataTableRecord(searchHit as unknown as EsHitRecord), [searchHit]);
+  const eventId = hit.raw._id ?? '';
 
-  return <NotesDetails hit={hit} />;
+  const isTimelineOpen = useSelector(
+    (state: State) => timelineSelectors.selectTimelineById(state, TimelineId.active)?.show ?? false
+  );
+  const timelineConfig = useTimelineConfig(eventId, isTimelineOpen);
+
+  return (
+    <EuiPanel hasBorder={false} hasShadow={false}>
+      <NotesDetailsContent hit={hit} timelineConfig={timelineConfig} hideTimelineIcon={false} />
+    </EuiPanel>
+  );
 });
 
 NotesTab.displayName = 'NotesTab';

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/correlations/components/correlations_details_view.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/correlations/components/correlations_details_view.test.tsx
@@ -1,0 +1,259 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { CorrelationsDetailsView } from './correlations_details_view';
+import { TestProviders } from '../../../common/mock';
+import { useShowRelatedAlertsByAncestry } from '../hooks/use_show_related_alerts_by_ancestry';
+import { useShowRelatedAlertsBySameSourceEvent } from '../hooks/use_show_related_alerts_by_same_source_event';
+import { useShowRelatedAlertsBySession } from '../hooks/use_show_related_alerts_by_session';
+import { useShowRelatedAttacks } from '../hooks/use_show_related_attacks';
+import { useShowRelatedCases } from '../hooks/use_show_related_cases';
+import { useShowSuppressedAlerts } from '../hooks/use_show_suppressed_alerts';
+import {
+  CORRELATIONS_DETAILS_BY_ANCESTRY_SECTION_TABLE_TEST_ID,
+  CORRELATIONS_DETAILS_BY_SESSION_SECTION_TABLE_TEST_ID,
+  CORRELATIONS_DETAILS_BY_SOURCE_SECTION_TABLE_TEST_ID,
+  CORRELATIONS_DETAILS_CASES_SECTION_TABLE_TEST_ID,
+  CORRELATIONS_DETAILS_RELATED_ATTACKS_SECTION_TABLE_TEST_ID,
+  CORRELATIONS_DETAILS_SUPPRESSED_ALERTS_SECTION_TEST_ID,
+} from './test_ids';
+import { useFetchRelatedAlertsBySession } from '../../document/hooks/use_fetch_related_alerts_by_session';
+import { useFetchRelatedAlertsByAncestry } from '../../document/hooks/use_fetch_related_alerts_by_ancestry';
+import { useFetchRelatedAlertsBySameSourceEvent } from '../../document/hooks/use_fetch_related_alerts_by_same_source_event';
+import { useFetchRelatedCases } from '../../document/hooks/use_fetch_related_cases';
+import { EXPANDABLE_PANEL_HEADER_TITLE_TEXT_TEST_ID } from '../../shared/components/test_ids';
+import { useSecurityDefaultPatterns } from '../../../data_view_manager/hooks/use_security_default_patterns';
+import { useIsExperimentalFeatureEnabled } from '../../../common/hooks/use_experimental_features';
+import { useAlertsPrivileges } from '../../../detections/containers/detection_engine/alerts/use_alerts_privileges';
+import type { DataTableRecord } from '@kbn/discover-utils';
+
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom');
+  return { ...actual, useLocation: jest.fn().mockReturnValue({ pathname: '' }) };
+});
+jest.mock('../hooks/use_show_related_alerts_by_ancestry');
+jest.mock('../hooks/use_show_related_alerts_by_same_source_event');
+jest.mock('../hooks/use_show_related_alerts_by_session');
+jest.mock('../hooks/use_show_related_attacks');
+jest.mock('../hooks/use_show_related_cases');
+jest.mock('../hooks/use_show_suppressed_alerts');
+jest.mock('../../document/hooks/use_fetch_related_alerts_by_session');
+jest.mock('../../document/hooks/use_fetch_related_alerts_by_ancestry');
+jest.mock('../../document/hooks/use_fetch_related_alerts_by_same_source_event');
+jest.mock('../../document/hooks/use_fetch_related_cases');
+jest.mock('../../../data_view_manager/hooks/use_security_default_patterns');
+jest.mock('../../../common/hooks/use_experimental_features');
+jest.mock('../../../detections/containers/detection_engine/alerts/use_alerts_privileges');
+
+const mockHit: DataTableRecord = {
+  id: 'test-id',
+  raw: { _id: 'test-id', _index: 'test-index', _source: {} },
+  flattened: {},
+  isAnchor: false,
+} as DataTableRecord;
+
+const mockOnShowAlert = jest.fn();
+
+const renderCorrelationsDetailsView = ({
+  isRulePreview = false,
+  hidePreviewLink = true,
+}: {
+  isRulePreview?: boolean;
+  hidePreviewLink?: boolean;
+} = {}) =>
+  render(
+    <TestProviders>
+      <CorrelationsDetailsView
+        hit={mockHit}
+        scopeId="test-scope"
+        isRulePreview={isRulePreview}
+        onShowAlert={mockOnShowAlert}
+        hidePreviewLink={hidePreviewLink}
+      />
+    </TestProviders>
+  );
+
+const SUPPRESSED_ALERTS_TITLE_TEST_ID = EXPANDABLE_PANEL_HEADER_TITLE_TEXT_TEST_ID(
+  CORRELATIONS_DETAILS_SUPPRESSED_ALERTS_SECTION_TEST_ID
+);
+
+const NO_DATA_MESSAGE = 'No correlations data available.';
+
+const mockAllShowHooksTrue = () => {
+  jest
+    .mocked(useShowRelatedAlertsByAncestry)
+    .mockReturnValue({ show: true, ancestryDocumentId: 'event-id' });
+  jest
+    .mocked(useShowRelatedAlertsBySameSourceEvent)
+    .mockReturnValue({ show: true, originalEventId: 'originalEventId' });
+  jest.mocked(useShowRelatedAlertsBySession).mockReturnValue({ show: true, entityId: 'entityId' });
+  jest.mocked(useShowRelatedAttacks).mockReturnValue({ show: true, attackIds: ['attack-id'] });
+  jest.mocked(useShowRelatedCases).mockReturnValue(true);
+  jest.mocked(useShowSuppressedAlerts).mockReturnValue({ show: true, alertSuppressionCount: 1 });
+};
+
+const mockAllShowHooksFalse = () => {
+  jest
+    .mocked(useShowRelatedAlertsByAncestry)
+    .mockReturnValue({ show: false, ancestryDocumentId: 'event-id' });
+  jest
+    .mocked(useShowRelatedAlertsBySameSourceEvent)
+    .mockReturnValue({ show: false, originalEventId: 'originalEventId' });
+  jest.mocked(useShowRelatedAlertsBySession).mockReturnValue({ show: false, entityId: 'entityId' });
+  jest.mocked(useShowRelatedAttacks).mockReturnValue({ show: false, attackIds: [] });
+  jest.mocked(useShowRelatedCases).mockReturnValue(false);
+  jest.mocked(useShowSuppressedAlerts).mockReturnValue({ show: false, alertSuppressionCount: 0 });
+};
+
+const mockFetchHooksEmpty = () => {
+  (useFetchRelatedAlertsByAncestry as jest.Mock).mockReturnValue({
+    loading: false,
+    error: false,
+    data: [],
+    dataCount: 1,
+  });
+  (useFetchRelatedAlertsBySameSourceEvent as jest.Mock).mockReturnValue({
+    loading: false,
+    error: false,
+    data: [],
+    dataCount: 1,
+  });
+  (useFetchRelatedAlertsBySession as jest.Mock).mockReturnValue({
+    loading: false,
+    error: false,
+    data: [],
+    dataCount: 1,
+  });
+  (useFetchRelatedCases as jest.Mock).mockReturnValue({
+    loading: false,
+    error: false,
+    data: [],
+    dataCount: 1,
+  });
+};
+
+describe('CorrelationsDetailsView', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useIsExperimentalFeatureEnabled as jest.Mock).mockReturnValue(true);
+    (useSecurityDefaultPatterns as jest.Mock).mockReturnValue({ indexPatterns: ['index'] });
+    (useAlertsPrivileges as jest.Mock).mockReturnValue({ hasAlertsRead: true });
+  });
+
+  it('renders all sections when all show flags are true', () => {
+    mockAllShowHooksTrue();
+    mockFetchHooksEmpty();
+
+    const { getByTestId, queryByText } = renderCorrelationsDetailsView();
+
+    expect(getByTestId(CORRELATIONS_DETAILS_BY_ANCESTRY_SECTION_TABLE_TEST_ID)).toBeInTheDocument();
+    expect(getByTestId(CORRELATIONS_DETAILS_BY_SOURCE_SECTION_TABLE_TEST_ID)).toBeInTheDocument();
+    expect(getByTestId(CORRELATIONS_DETAILS_BY_SESSION_SECTION_TABLE_TEST_ID)).toBeInTheDocument();
+    expect(
+      getByTestId(CORRELATIONS_DETAILS_RELATED_ATTACKS_SECTION_TABLE_TEST_ID)
+    ).toBeInTheDocument();
+    expect(getByTestId(CORRELATIONS_DETAILS_CASES_SECTION_TABLE_TEST_ID)).toBeInTheDocument();
+    expect(getByTestId(SUPPRESSED_ALERTS_TITLE_TEST_ID)).toBeInTheDocument();
+    expect(queryByText(NO_DATA_MESSAGE)).not.toBeInTheDocument();
+  });
+
+  it('renders no sections and shows no-data message when all show flags are false', () => {
+    mockAllShowHooksFalse();
+
+    const { getByText, queryByTestId } = renderCorrelationsDetailsView();
+
+    expect(
+      queryByTestId(CORRELATIONS_DETAILS_BY_ANCESTRY_SECTION_TABLE_TEST_ID)
+    ).not.toBeInTheDocument();
+    expect(
+      queryByTestId(CORRELATIONS_DETAILS_BY_SOURCE_SECTION_TABLE_TEST_ID)
+    ).not.toBeInTheDocument();
+    expect(
+      queryByTestId(CORRELATIONS_DETAILS_BY_SESSION_SECTION_TABLE_TEST_ID)
+    ).not.toBeInTheDocument();
+    expect(
+      queryByTestId(CORRELATIONS_DETAILS_RELATED_ATTACKS_SECTION_TABLE_TEST_ID)
+    ).not.toBeInTheDocument();
+    expect(queryByTestId(CORRELATIONS_DETAILS_CASES_SECTION_TABLE_TEST_ID)).not.toBeInTheDocument();
+    expect(queryByTestId(SUPPRESSED_ALERTS_TITLE_TEST_ID)).not.toBeInTheDocument();
+    expect(getByText(NO_DATA_MESSAGE)).toBeInTheDocument();
+  });
+
+  it('renders only the ancestry section when only that flag is true', () => {
+    mockAllShowHooksFalse();
+    jest
+      .mocked(useShowRelatedAlertsByAncestry)
+      .mockReturnValue({ show: true, ancestryDocumentId: 'event-id' });
+    (useFetchRelatedAlertsByAncestry as jest.Mock).mockReturnValue({
+      loading: false,
+      error: false,
+      data: [],
+      dataCount: 1,
+    });
+
+    const { getByTestId, queryByTestId, queryByText } = renderCorrelationsDetailsView();
+
+    expect(getByTestId(CORRELATIONS_DETAILS_BY_ANCESTRY_SECTION_TABLE_TEST_ID)).toBeInTheDocument();
+    expect(
+      queryByTestId(CORRELATIONS_DETAILS_BY_SOURCE_SECTION_TABLE_TEST_ID)
+    ).not.toBeInTheDocument();
+    expect(
+      queryByTestId(CORRELATIONS_DETAILS_BY_SESSION_SECTION_TABLE_TEST_ID)
+    ).not.toBeInTheDocument();
+    expect(queryByText(NO_DATA_MESSAGE)).not.toBeInTheDocument();
+  });
+
+  it('renders only the cases section when only that flag is true', () => {
+    mockAllShowHooksFalse();
+    jest.mocked(useShowRelatedCases).mockReturnValue(true);
+    (useFetchRelatedCases as jest.Mock).mockReturnValue({
+      loading: false,
+      error: false,
+      data: [],
+      dataCount: 1,
+    });
+
+    const { getByTestId, queryByTestId, queryByText } = renderCorrelationsDetailsView();
+
+    expect(getByTestId(CORRELATIONS_DETAILS_CASES_SECTION_TABLE_TEST_ID)).toBeInTheDocument();
+    expect(
+      queryByTestId(CORRELATIONS_DETAILS_BY_ANCESTRY_SECTION_TABLE_TEST_ID)
+    ).not.toBeInTheDocument();
+    expect(queryByText(NO_DATA_MESSAGE)).not.toBeInTheDocument();
+  });
+
+  it('does not render the session section when entityId is absent', () => {
+    mockAllShowHooksFalse();
+    jest.mocked(useShowRelatedAlertsBySession).mockReturnValue({ show: true, entityId: undefined });
+
+    const { queryByTestId } = renderCorrelationsDetailsView();
+
+    expect(
+      queryByTestId(CORRELATIONS_DETAILS_BY_SESSION_SECTION_TABLE_TEST_ID)
+    ).not.toBeInTheDocument();
+  });
+
+  it('passes hidePreviewLink=false down to source and session sections', () => {
+    mockAllShowHooksFalse();
+    jest
+      .mocked(useShowRelatedAlertsBySameSourceEvent)
+      .mockReturnValue({ show: true, originalEventId: 'originalEventId' });
+    (useFetchRelatedAlertsBySameSourceEvent as jest.Mock).mockReturnValue({
+      loading: false,
+      error: false,
+      data: [],
+      dataCount: 1,
+    });
+
+    // Should render without errors when hidePreviewLink is false
+    const { getByTestId } = renderCorrelationsDetailsView({ hidePreviewLink: false });
+
+    expect(getByTestId(CORRELATIONS_DETAILS_BY_SOURCE_SECTION_TABLE_TEST_ID)).toBeInTheDocument();
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/correlations/components/correlations_details_view.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/correlations/components/correlations_details_view.tsx
@@ -1,0 +1,173 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { memo, useMemo } from 'react';
+import { EuiFlexGroup, EuiFlexItem, EuiPanel } from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n-react';
+import type { DataTableRecord } from '@kbn/discover-utils';
+import type { EcsSecurityExtension as Ecs } from '@kbn/securitysolution-ecs';
+import { useShowRelatedAttacks } from '../hooks/use_show_related_attacks';
+import { useShowRelatedAlertsByAncestry } from '../hooks/use_show_related_alerts_by_ancestry';
+import { useShowRelatedAlertsBySameSourceEvent } from '../hooks/use_show_related_alerts_by_same_source_event';
+import { useShowRelatedAlertsBySession } from '../hooks/use_show_related_alerts_by_session';
+import { useShowRelatedCases } from '../hooks/use_show_related_cases';
+import { useShowSuppressedAlerts } from '../hooks/use_show_suppressed_alerts';
+import { SuppressedAlerts } from './suppressed_alerts';
+import { RelatedCases } from './related_cases';
+import { RelatedAlertsBySameSourceEvent } from './related_alerts_by_same_source_event';
+import { RelatedAlertsBySession } from './related_alerts_by_session';
+import { RelatedAlertsByAncestry } from './related_alerts_by_ancestry';
+import { RelatedAttacks } from './related_attacks';
+
+export interface CorrelationsDetailsViewProps {
+  /**
+   * Alert/event document
+   */
+  hit: DataTableRecord;
+  /**
+   * Scope ID for the document
+   */
+  scopeId: string;
+  /**
+   * Whether the document is being displayed in a rule preview
+   */
+  isRulePreview: boolean;
+  /**
+   * Callback to open an alert preview when clicking the preview button in the correlations table
+   */
+  onShowAlert: (id: string, indexName: string) => void;
+  /**
+   * Callback to open an attack preview when clicking the expand button in the related attacks table.
+   * When not provided, the expand button column is hidden.
+   * // TODO make required once we have an attack flyout in the new flyout system
+   */
+  onShowAttack?: (id: string, indexName: string) => void;
+  /**
+   * Whether to hide the rule preview link in the correlations table.
+   * Defaults to true (hidden) for the new tools flyout which has no expandable flyout context.
+   */
+  hidePreviewLink?: boolean;
+}
+
+/**
+ * Correlations content view. Renders the correlations sections without any flyout chrome,
+ * so it can be used both inside a flyout body and inline in a tab panel.
+ */
+export const CorrelationsDetailsView = memo(
+  ({
+    hit,
+    scopeId,
+    isRulePreview,
+    onShowAlert,
+    onShowAttack,
+    hidePreviewLink = true,
+  }: CorrelationsDetailsViewProps) => {
+    const eventId = hit.raw._id ?? '';
+    const ecsData = useMemo<Ecs>(
+      () => ({
+        ...(hit.raw._source ?? {}),
+        _id: hit.raw._id ?? '',
+        _index: hit.raw._index,
+      }),
+      [hit]
+    );
+
+    const { show: showAlertsByAncestry, ancestryDocumentId } = useShowRelatedAlertsByAncestry({
+      hit,
+      isRulePreview,
+    });
+    const { show: showSameSourceAlerts, originalEventId } = useShowRelatedAlertsBySameSourceEvent({
+      hit,
+    });
+    const { show: showAlertsBySession, entityId } = useShowRelatedAlertsBySession({ hit });
+    const showCases = useShowRelatedCases({ hit });
+    const { show: showSuppressedAlerts, alertSuppressionCount } = useShowSuppressedAlerts({
+      hit,
+    });
+    const { show: showRelatedAttacks, attackIds } = useShowRelatedAttacks({ hit });
+
+    const canShowAtLeastOneInsight =
+      showAlertsByAncestry ||
+      showSameSourceAlerts ||
+      showAlertsBySession ||
+      showRelatedAttacks ||
+      showCases ||
+      showSuppressedAlerts;
+
+    return (
+      <EuiPanel color="transparent">
+        {canShowAtLeastOneInsight ? (
+          <EuiFlexGroup gutterSize="l" direction="column">
+            {showSuppressedAlerts && (
+              <EuiFlexItem>
+                <SuppressedAlerts
+                  alertSuppressionCount={alertSuppressionCount}
+                  ecsData={ecsData}
+                  showInvestigateInTimeline={!isRulePreview}
+                />
+              </EuiFlexItem>
+            )}
+            {showCases && (
+              <EuiFlexItem>
+                <RelatedCases eventId={eventId} />
+              </EuiFlexItem>
+            )}
+            {showSameSourceAlerts && (
+              <EuiFlexItem>
+                <RelatedAlertsBySameSourceEvent
+                  originalEventId={originalEventId}
+                  scopeId={scopeId}
+                  eventId={eventId}
+                  onShowAlert={onShowAlert}
+                  hidePreviewLink={hidePreviewLink}
+                />
+              </EuiFlexItem>
+            )}
+            {showAlertsBySession && entityId && (
+              <EuiFlexItem>
+                <RelatedAlertsBySession
+                  entityId={entityId}
+                  scopeId={scopeId}
+                  eventId={eventId}
+                  onShowAlert={onShowAlert}
+                  hidePreviewLink={hidePreviewLink}
+                />
+              </EuiFlexItem>
+            )}
+            {showAlertsByAncestry && (
+              <EuiFlexItem>
+                <RelatedAlertsByAncestry
+                  scopeId={scopeId}
+                  documentId={ancestryDocumentId}
+                  onShowAlert={onShowAlert}
+                  hidePreviewLink={hidePreviewLink}
+                />
+              </EuiFlexItem>
+            )}
+            {showRelatedAttacks && (
+              <EuiFlexItem>
+                <RelatedAttacks
+                  attackIds={attackIds}
+                  scopeId={scopeId}
+                  eventId={eventId}
+                  onShowAttack={onShowAttack}
+                />
+              </EuiFlexItem>
+            )}
+          </EuiFlexGroup>
+        ) : (
+          <FormattedMessage
+            id="xpack.securitySolution.flyout.correlations.noDataDescription"
+            defaultMessage="No correlations data available."
+          />
+        )}
+      </EuiPanel>
+    );
+  }
+);
+
+CorrelationsDetailsView.displayName = 'CorrelationsDetailsView';

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/correlations/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/correlations/index.tsx
@@ -5,33 +5,17 @@
  * 2.0.
  */
 
-import React, { memo, useMemo } from 'react';
+import React, { memo } from 'react';
 import { css } from '@emotion/react';
-import {
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiFlyoutBody,
-  EuiFlyoutHeader,
-  EuiPanel,
-  useEuiTheme,
-} from '@elastic/eui';
-import { FormattedMessage } from '@kbn/i18n-react';
+import { EuiFlyoutBody, EuiFlyoutHeader, useEuiTheme } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import type { DataTableRecord } from '@kbn/discover-utils';
-import type { EcsSecurityExtension as Ecs } from '@kbn/securitysolution-ecs';
 import { ToolsFlyoutHeader } from '../shared/components/tools_flyout_header';
-import { useShowRelatedAttacks } from './hooks/use_show_related_attacks';
-import { useShowRelatedAlertsByAncestry } from './hooks/use_show_related_alerts_by_ancestry';
-import { useShowRelatedAlertsBySameSourceEvent } from './hooks/use_show_related_alerts_by_same_source_event';
-import { useShowRelatedAlertsBySession } from './hooks/use_show_related_alerts_by_session';
-import { useShowRelatedCases } from './hooks/use_show_related_cases';
-import { useShowSuppressedAlerts } from './hooks/use_show_suppressed_alerts';
-import { SuppressedAlerts } from './components/suppressed_alerts';
-import { RelatedCases } from './components/related_cases';
-import { RelatedAlertsBySameSourceEvent } from './components/related_alerts_by_same_source_event';
-import { RelatedAlertsBySession } from './components/related_alerts_by_session';
-import { RelatedAlertsByAncestry } from './components/related_alerts_by_ancestry';
-import { RelatedAttacks } from './components/related_attacks';
+import { CorrelationsDetailsView } from './components/correlations_details_view';
+
+const TITLE = i18n.translate('xpack.securitySolution.flyout.correlations.title', {
+  defaultMessage: 'Correlations',
+});
 
 export interface CorrelationsDetailsProps {
   /**
@@ -63,10 +47,6 @@ export interface CorrelationsDetailsProps {
   hidePreviewLink?: boolean;
 }
 
-const TITLE = i18n.translate('xpack.securitySolution.flyout.correlations.title', {
-  defaultMessage: 'Correlations',
-});
-
 /**
  * Displays the full correlations details for a given alert/event document.
  * This component is meant to be used in a tools flyout, with the new EUI flyout system.
@@ -81,37 +61,6 @@ export const CorrelationsDetails = memo(
     hidePreviewLink = true,
   }: CorrelationsDetailsProps) => {
     const { euiTheme } = useEuiTheme();
-    const eventId = hit.raw._id ?? '';
-    const ecsData = useMemo<Ecs>(
-      () => ({
-        ...(hit.raw._source ?? {}),
-        _id: hit.raw._id ?? '',
-        _index: hit.raw._index,
-      }),
-      [hit]
-    );
-
-    const { show: showAlertsByAncestry, ancestryDocumentId } = useShowRelatedAlertsByAncestry({
-      hit,
-      isRulePreview,
-    });
-    const { show: showSameSourceAlerts, originalEventId } = useShowRelatedAlertsBySameSourceEvent({
-      hit,
-    });
-    const { show: showAlertsBySession, entityId } = useShowRelatedAlertsBySession({ hit });
-    const showCases = useShowRelatedCases({ hit });
-    const { show: showSuppressedAlerts, alertSuppressionCount } = useShowSuppressedAlerts({
-      hit,
-    });
-    const { show: showRelatedAttacks, attackIds } = useShowRelatedAttacks({ hit });
-
-    const canShowAtLeastOneInsight =
-      showAlertsByAncestry ||
-      showSameSourceAlerts ||
-      showAlertsBySession ||
-      showRelatedAttacks ||
-      showCases ||
-      showSuppressedAlerts;
 
     return (
       <>
@@ -124,73 +73,14 @@ export const CorrelationsDetails = memo(
           <ToolsFlyoutHeader hit={hit} title={TITLE} />
         </EuiFlyoutHeader>
         <EuiFlyoutBody>
-          <EuiPanel color="transparent">
-            {canShowAtLeastOneInsight ? (
-              <EuiFlexGroup gutterSize="l" direction="column">
-                {showSuppressedAlerts && (
-                  <EuiFlexItem>
-                    <SuppressedAlerts
-                      alertSuppressionCount={alertSuppressionCount}
-                      ecsData={ecsData}
-                      showInvestigateInTimeline={!isRulePreview}
-                    />
-                  </EuiFlexItem>
-                )}
-                {showCases && (
-                  <EuiFlexItem>
-                    <RelatedCases eventId={eventId} />
-                  </EuiFlexItem>
-                )}
-                {showSameSourceAlerts && (
-                  <EuiFlexItem>
-                    <RelatedAlertsBySameSourceEvent
-                      originalEventId={originalEventId}
-                      scopeId={scopeId}
-                      eventId={eventId}
-                      onShowAlert={onShowAlert}
-                      hidePreviewLink={hidePreviewLink}
-                    />
-                  </EuiFlexItem>
-                )}
-                {showAlertsBySession && entityId && (
-                  <EuiFlexItem>
-                    <RelatedAlertsBySession
-                      entityId={entityId}
-                      scopeId={scopeId}
-                      eventId={eventId}
-                      onShowAlert={onShowAlert}
-                      hidePreviewLink={hidePreviewLink}
-                    />
-                  </EuiFlexItem>
-                )}
-                {showAlertsByAncestry && (
-                  <EuiFlexItem>
-                    <RelatedAlertsByAncestry
-                      scopeId={scopeId}
-                      documentId={ancestryDocumentId}
-                      onShowAlert={onShowAlert}
-                      hidePreviewLink={hidePreviewLink}
-                    />
-                  </EuiFlexItem>
-                )}
-                {showRelatedAttacks && (
-                  <EuiFlexItem>
-                    <RelatedAttacks
-                      attackIds={attackIds}
-                      scopeId={scopeId}
-                      eventId={eventId}
-                      onShowAttack={onShowAttack}
-                    />
-                  </EuiFlexItem>
-                )}
-              </EuiFlexGroup>
-            ) : (
-              <FormattedMessage
-                id="xpack.securitySolution.flyout.correlations.noDataDescription"
-                defaultMessage="No correlations data available."
-              />
-            )}
-          </EuiPanel>
+          <CorrelationsDetailsView
+            hit={hit}
+            scopeId={scopeId}
+            isRulePreview={isRulePreview}
+            onShowAlert={onShowAlert}
+            onShowAttack={onShowAttack}
+            hidePreviewLink={hidePreviewLink}
+          />
         </EuiFlyoutBody>
       </>
     );

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/prevalence/components/prevalence_details_view.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/prevalence/components/prevalence_details_view.test.tsx
@@ -8,11 +8,14 @@
 import { fireEvent, render } from '@testing-library/react';
 import React from 'react';
 import { buildDataTableRecord, type EsHitRecord } from '@kbn/discover-utils';
-import { PrevalenceDetails } from './prevalence';
-import { resetColdFrozenTierCalloutDismissedStateForTests } from './components/prevalence_details_view';
+import {
+  PrevalenceDetailsView,
+  resetColdFrozenTierCalloutDismissedStateForTests,
+} from './prevalence_details_view';
 import {
   PREVALENCE_DETAILS_COLD_FROZEN_TIER_CALLOUT_DISMISS_BUTTON_TEST_ID,
   PREVALENCE_DETAILS_COLD_FROZEN_TIER_CALLOUT_TEST_ID,
+  PREVALENCE_DETAILS_DATE_PICKER_TEST_ID,
   PREVALENCE_DETAILS_TABLE_ALERT_COUNT_CELL_TEST_ID,
   PREVALENCE_DETAILS_TABLE_COUNT_TEXT_BUTTON_TEST_ID,
   PREVALENCE_DETAILS_TABLE_DOC_COUNT_CELL_TEST_ID,
@@ -24,22 +27,22 @@ import {
   PREVALENCE_DETAILS_TABLE_USER_PREVALENCE_CELL_TEST_ID,
   PREVALENCE_DETAILS_TABLE_VALUE_CELL_TEST_ID,
   PREVALENCE_DETAILS_UPSELL_TEST_ID,
-} from './test_ids';
-import type { CellActionRenderer } from '../shared/components/cell_actions';
-import { getColumns } from './utils/get_columns';
-import { usePrevalence } from './hooks/use_prevalence';
-import { TestProviders } from '../../common/mock';
-import { licenseService } from '../../common/hooks/use_license';
-import { createTelemetryServiceMock } from '../../common/lib/telemetry/telemetry_service.mock';
-import { useUserPrivileges } from '../../common/components/user_privileges';
+} from '../test_ids';
+import type { CellActionRenderer } from '../../shared/components/cell_actions';
+import { getColumns } from '../utils/get_columns';
+import { usePrevalence } from '../hooks/use_prevalence';
+import { TestProviders } from '../../../common/mock';
+import { licenseService } from '../../../common/hooks/use_license';
+import { createTelemetryServiceMock } from '../../../common/lib/telemetry/telemetry_service.mock';
+import { useUserPrivileges } from '../../../common/components/user_privileges';
 
-jest.mock('../../common/components/user_privileges');
+jest.mock('../../../common/components/user_privileges');
 
 const mockedTelemetry = createTelemetryServiceMock();
 const mockStorage = jest.fn();
 const mockUiSettingsGet = jest.fn();
 let mockServerless: unknown;
-jest.mock('../../common/lib/kibana', () => {
+jest.mock('../../../common/lib/kibana', () => {
   return {
     useKibana: () => ({
       services: {
@@ -54,7 +57,7 @@ jest.mock('../../common/lib/kibana', () => {
   };
 });
 
-jest.mock('./hooks/use_prevalence');
+jest.mock('../hooks/use_prevalence');
 
 const mockDispatch = jest.fn();
 jest.mock('react-redux', () => {
@@ -64,7 +67,7 @@ jest.mock('react-redux', () => {
     useDispatch: () => mockDispatch,
   };
 });
-jest.mock('../../common/hooks/use_license', () => {
+jest.mock('../../../common/hooks/use_license', () => {
   const licenseServiceInstance = {
     isPlatinumPlus: jest.fn(),
   };
@@ -77,6 +80,7 @@ jest.mock('../../common/hooks/use_license', () => {
 });
 
 const NO_DATA_MESSAGE = 'No prevalence data available.';
+const UPSELL_MESSAGE = 'Host and user prevalence are only available with a';
 
 const SCOPE_ID = 'scopeId';
 const mockHit = buildDataTableRecord({
@@ -84,9 +88,7 @@ const mockHit = buildDataTableRecord({
   _index: 'indexName',
 } as EsHitRecord);
 
-const UPSELL_MESSAGE = 'Host and user prevalence are only available with a';
-
-const mockPrevelanceReturnValue = {
+const mockPrevalenceReturnValue = {
   loading: false,
   error: false,
   data: [
@@ -127,7 +129,7 @@ const mockPrevelanceReturnValue = {
 
 const renderCellActions: CellActionRenderer = ({ children }) => <>{children}</>;
 
-const renderPrevalenceDetails = ({
+const renderPrevalenceDetailsView = ({
   hit = mockHit,
   isTimelineEnabled = true,
 }: {
@@ -137,12 +139,17 @@ const renderPrevalenceDetails = ({
   const columns = getColumns(renderCellActions, isTimelineEnabled, SCOPE_ID);
   return render(
     <TestProviders>
-      <PrevalenceDetails hit={hit} investigationFields={[]} scopeId={SCOPE_ID} columns={columns} />
+      <PrevalenceDetailsView
+        hit={hit}
+        investigationFields={[]}
+        scopeId={SCOPE_ID}
+        columns={columns}
+      />
     </TestProviders>
   );
 };
 
-describe('PrevalenceDetails', () => {
+describe('PrevalenceDetailsView', () => {
   const licenseServiceMock = licenseService as jest.Mocked<typeof licenseService>;
 
   beforeEach(() => {
@@ -152,18 +159,22 @@ describe('PrevalenceDetails', () => {
     mockUiSettingsGet.mockReturnValue(true);
     licenseServiceMock.isPlatinumPlus.mockReturnValue(true);
     (useUserPrivileges as jest.Mock).mockReturnValue({ timelinePrivileges: { read: true } });
+    (usePrevalence as jest.Mock).mockReturnValue(mockPrevalenceReturnValue);
   });
 
-  it('should render the table with all data if license is platinum', () => {
-    (usePrevalence as jest.Mock).mockReturnValue(mockPrevelanceReturnValue);
-    const { getByTestId, getAllByTestId, queryByTestId, queryByText } = renderPrevalenceDetails();
+  it('renders the date picker', () => {
+    const { getByTestId } = renderPrevalenceDetailsView();
+
+    expect(getByTestId(PREVALENCE_DETAILS_DATE_PICKER_TEST_ID)).toBeInTheDocument();
+  });
+
+  it('renders the table with all data when license is platinum', () => {
+    const { getByTestId, getAllByTestId, queryByTestId, queryByText } =
+      renderPrevalenceDetailsView();
 
     expect(getByTestId(PREVALENCE_DETAILS_TABLE_TEST_ID)).toBeInTheDocument();
     expect(getAllByTestId(PREVALENCE_DETAILS_TABLE_FIELD_CELL_TEST_ID).length).toBeGreaterThan(1);
     expect(getAllByTestId(PREVALENCE_DETAILS_TABLE_VALUE_CELL_TEST_ID).length).toBeGreaterThan(1);
-    expect(getAllByTestId(PREVALENCE_DETAILS_TABLE_DOC_COUNT_CELL_TEST_ID).length).toBeGreaterThan(
-      1
-    );
     expect(getAllByTestId(PREVALENCE_DETAILS_TABLE_DOC_COUNT_CELL_TEST_ID).length).toBeGreaterThan(
       1
     );
@@ -177,28 +188,14 @@ describe('PrevalenceDetails', () => {
     expect(queryByText(NO_DATA_MESSAGE)).not.toBeInTheDocument();
   });
 
-  it('should render host and user name values in the table', () => {
-    (usePrevalence as jest.Mock).mockReturnValue(mockPrevelanceReturnValue);
-
-    const { getAllByTestId } = renderPrevalenceDetails();
-    const valueCells = getAllByTestId(PREVALENCE_DETAILS_TABLE_VALUE_CELL_TEST_ID);
-
-    expect(valueCells[0]).toHaveTextContent('value1');
-    expect(valueCells[1]).toHaveTextContent('value2');
-    expect(valueCells[2]).toHaveTextContent('test host');
-    expect(valueCells[3]).toHaveTextContent('test user');
-  });
-
-  it('should hide data in prevalence columns if license is not platinum', () => {
-    const field1 = 'field1';
-
+  it('renders the upsell callout and hides prevalence data when license is not platinum', () => {
     licenseServiceMock.isPlatinumPlus.mockReturnValue(false);
     (usePrevalence as jest.Mock).mockReturnValue({
       loading: false,
       error: false,
       data: [
         {
-          field: field1,
+          field: 'field1',
           values: ['value1'],
           alertCount: 1,
           docCount: 1,
@@ -208,9 +205,8 @@ describe('PrevalenceDetails', () => {
       ],
     });
 
-    const { getByTestId, getAllByTestId } = renderPrevalenceDetails();
+    const { getByTestId, getAllByTestId } = renderPrevalenceDetailsView();
 
-    expect(getByTestId(PREVALENCE_DETAILS_TABLE_TEST_ID)).toBeInTheDocument();
     expect(getByTestId(PREVALENCE_DETAILS_UPSELL_TEST_ID)).toHaveTextContent(UPSELL_MESSAGE);
     expect(getAllByTestId(PREVALENCE_DETAILS_TABLE_UPSELL_CELL_TEST_ID).length).toEqual(2);
     expect(
@@ -221,7 +217,16 @@ describe('PrevalenceDetails', () => {
     ).not.toHaveTextContent('10%');
   });
 
-  it('should render formatted numbers for the alert and document count columns and be clickable buttons', () => {
+  it('does not render upsell callout when there is an error', () => {
+    licenseServiceMock.isPlatinumPlus.mockReturnValue(false);
+    (usePrevalence as jest.Mock).mockReturnValue({ loading: false, error: true, data: [] });
+
+    const { queryByTestId } = renderPrevalenceDetailsView();
+
+    expect(queryByTestId(PREVALENCE_DETAILS_UPSELL_TEST_ID)).not.toBeInTheDocument();
+  });
+
+  it('renders formatted numbers in alert and document count columns as clickable buttons', () => {
     (usePrevalence as jest.Mock).mockReturnValue({
       loading: false,
       error: false,
@@ -237,9 +242,8 @@ describe('PrevalenceDetails', () => {
       ],
     });
 
-    const { getByTestId, getAllByTestId } = renderPrevalenceDetails();
+    const { getByTestId, getAllByTestId } = renderPrevalenceDetailsView();
 
-    expect(getByTestId(PREVALENCE_DETAILS_TABLE_TEST_ID)).toBeInTheDocument();
     expect(getByTestId(PREVALENCE_DETAILS_TABLE_FIELD_CELL_TEST_ID)).toHaveTextContent('field1');
     expect(getByTestId(PREVALENCE_DETAILS_TABLE_VALUE_CELL_TEST_ID)).toHaveTextContent('value1');
     expect(getByTestId(PREVALENCE_DETAILS_TABLE_ALERT_COUNT_CELL_TEST_ID)).toHaveTextContent('1k');
@@ -250,13 +254,12 @@ describe('PrevalenceDetails', () => {
     expect(getByTestId(PREVALENCE_DETAILS_TABLE_USER_PREVALENCE_CELL_TEST_ID)).toHaveTextContent(
       '10%'
     );
-
     expect(
       getAllByTestId(PREVALENCE_DETAILS_TABLE_INVESTIGATE_IN_TIMELINE_BUTTON_TEST_ID).length
     ).toBeGreaterThan(1);
   });
 
-  it('should render formatted numbers as text when timeline interactions are disabled', () => {
+  it('renders count columns as plain text when timeline interactions are disabled', () => {
     (usePrevalence as jest.Mock).mockReturnValue({
       loading: false,
       error: false,
@@ -272,7 +275,7 @@ describe('PrevalenceDetails', () => {
       ],
     });
 
-    const { getAllByTestId, queryAllByTestId } = renderPrevalenceDetails({
+    const { getAllByTestId, queryAllByTestId } = renderPrevalenceDetailsView({
       isTimelineEnabled: false,
     });
 
@@ -282,7 +285,7 @@ describe('PrevalenceDetails', () => {
     ).toBe(0);
   });
 
-  it('should render formatted numbers as text if user lacks timeline read privileges', () => {
+  it('renders count columns as plain text when user lacks timeline read privileges', () => {
     (useUserPrivileges as jest.Mock).mockReturnValue({ timelinePrivileges: { read: false } });
     (usePrevalence as jest.Mock).mockReturnValue({
       loading: false,
@@ -299,119 +302,29 @@ describe('PrevalenceDetails', () => {
       ],
     });
 
-    const { getByTestId, queryAllByTestId } = renderPrevalenceDetails();
-
-    expect(getByTestId(PREVALENCE_DETAILS_TABLE_TEST_ID)).toBeInTheDocument();
-    expect(getByTestId(PREVALENCE_DETAILS_TABLE_FIELD_CELL_TEST_ID)).toHaveTextContent('field1');
-    expect(getByTestId(PREVALENCE_DETAILS_TABLE_VALUE_CELL_TEST_ID)).toHaveTextContent('value1');
-    expect(getByTestId(PREVALENCE_DETAILS_TABLE_ALERT_COUNT_CELL_TEST_ID)).toHaveTextContent('1k');
-    expect(getByTestId(PREVALENCE_DETAILS_TABLE_DOC_COUNT_CELL_TEST_ID)).toHaveTextContent('2M');
-    expect(getByTestId(PREVALENCE_DETAILS_TABLE_HOST_PREVALENCE_CELL_TEST_ID)).toHaveTextContent(
-      '5%'
-    );
-    expect(getByTestId(PREVALENCE_DETAILS_TABLE_USER_PREVALENCE_CELL_TEST_ID)).toHaveTextContent(
-      '10%'
-    );
+    const { queryAllByTestId } = renderPrevalenceDetailsView();
 
     expect(
       queryAllByTestId(PREVALENCE_DETAILS_TABLE_INVESTIGATE_IN_TIMELINE_BUTTON_TEST_ID).length
     ).not.toBeGreaterThan(1);
   });
 
-  it('should render multiple values in value column', () => {
-    (usePrevalence as jest.Mock).mockReturnValue({
-      loading: false,
-      error: false,
-      data: [
-        {
-          field: 'field1',
-          values: ['value1', 'value2'],
-          alertCount: 1000,
-          docCount: 2000000,
-          hostPrevalence: 0.05,
-          userPrevalence: 0.1,
-        },
-      ],
-    });
+  it('renders no data message when the fetch errors out', () => {
+    (usePrevalence as jest.Mock).mockReturnValue({ loading: false, error: true, data: [] });
 
-    const { getByTestId } = renderPrevalenceDetails();
-
-    expect(getByTestId(PREVALENCE_DETAILS_TABLE_TEST_ID)).toBeInTheDocument();
-    expect(getByTestId(PREVALENCE_DETAILS_TABLE_VALUE_CELL_TEST_ID)).toHaveTextContent('value1');
-    expect(getByTestId(PREVALENCE_DETAILS_TABLE_VALUE_CELL_TEST_ID)).toHaveTextContent('value2');
-  });
-
-  it('should render the table with only basic columns if license is not platinum', () => {
-    const field1 = 'field1';
-    const field2 = 'field2';
-    (usePrevalence as jest.Mock).mockReturnValue({
-      loading: false,
-      error: false,
-      data: [
-        {
-          field: field1,
-          values: ['value1'],
-          alertCount: 1,
-          docCount: 1,
-          hostPrevalence: 0.05,
-          userPrevalence: 0.1,
-        },
-        {
-          field: field2,
-          values: ['value2'],
-          alertCount: 1,
-          docCount: 1,
-          hostPrevalence: 0.5,
-          userPrevalence: 0.05,
-        },
-      ],
-    });
-    licenseServiceMock.isPlatinumPlus.mockReturnValue(false);
-
-    const { getByTestId, getAllByTestId } = renderPrevalenceDetails();
-
-    expect(getByTestId(PREVALENCE_DETAILS_TABLE_TEST_ID)).toBeInTheDocument();
-    expect(getAllByTestId(PREVALENCE_DETAILS_TABLE_FIELD_CELL_TEST_ID).length).toBeGreaterThan(1);
-    expect(getAllByTestId(PREVALENCE_DETAILS_TABLE_VALUE_CELL_TEST_ID).length).toBeGreaterThan(1);
-    expect(getAllByTestId(PREVALENCE_DETAILS_TABLE_DOC_COUNT_CELL_TEST_ID).length).toBeGreaterThan(
-      1
-    );
-    expect(getAllByTestId(PREVALENCE_DETAILS_TABLE_DOC_COUNT_CELL_TEST_ID).length).toBeGreaterThan(
-      1
-    );
-    expect(
-      getAllByTestId(PREVALENCE_DETAILS_TABLE_HOST_PREVALENCE_CELL_TEST_ID).length
-    ).toBeGreaterThan(1);
-    expect(
-      getAllByTestId(PREVALENCE_DETAILS_TABLE_USER_PREVALENCE_CELL_TEST_ID).length
-    ).toBeGreaterThan(1);
-    expect(getByTestId(PREVALENCE_DETAILS_UPSELL_TEST_ID)).toBeInTheDocument();
-  });
-
-  it('should render no data message if call errors out', () => {
-    (usePrevalence as jest.Mock).mockReturnValue({
-      loading: false,
-      error: true,
-      data: [],
-    });
-
-    const { getByText } = renderPrevalenceDetails();
+    const { getByText } = renderPrevalenceDetailsView();
     expect(getByText(NO_DATA_MESSAGE)).toBeInTheDocument();
   });
 
-  it('should render no data message if no data', () => {
-    (usePrevalence as jest.Mock).mockReturnValue({
-      loading: false,
-      error: false,
-      data: [],
-    });
+  it('renders no data message when data is empty', () => {
+    (usePrevalence as jest.Mock).mockReturnValue({ loading: false, error: false, data: [] });
 
-    const { getByText } = renderPrevalenceDetails();
+    const { getByText } = renderPrevalenceDetailsView();
     expect(getByText(NO_DATA_MESSAGE)).toBeInTheDocument();
   });
 
-  it('should render excluded cold and frozen tiers callout text when ui setting is enabled', () => {
-    const { getByTestId } = renderPrevalenceDetails();
+  it('renders cold/frozen tier callout with excluded state text when ui setting is enabled', () => {
+    const { getByTestId } = renderPrevalenceDetailsView();
 
     expect(getByTestId(PREVALENCE_DETAILS_COLD_FROZEN_TIER_CALLOUT_TEST_ID)).toHaveTextContent(
       'Some data excluded'
@@ -421,10 +334,10 @@ describe('PrevalenceDetails', () => {
     );
   });
 
-  it('should render included cold and frozen tiers callout text when ui setting is disabled', () => {
+  it('renders cold/frozen tier callout with performance optimization text when ui setting is disabled', () => {
     mockUiSettingsGet.mockReturnValue(false);
 
-    const { getByTestId } = renderPrevalenceDetails();
+    const { getByTestId } = renderPrevalenceDetailsView();
 
     expect(getByTestId(PREVALENCE_DETAILS_COLD_FROZEN_TIER_CALLOUT_TEST_ID)).toHaveTextContent(
       'Performance optimization'
@@ -434,18 +347,18 @@ describe('PrevalenceDetails', () => {
     );
   });
 
-  it('should not render cold and frozen tiers callout in serverless', () => {
+  it('does not render cold/frozen tier callout in serverless', () => {
     mockServerless = {};
 
-    const { queryByTestId } = renderPrevalenceDetails();
+    const { queryByTestId } = renderPrevalenceDetailsView();
 
     expect(
       queryByTestId(PREVALENCE_DETAILS_COLD_FROZEN_TIER_CALLOUT_TEST_ID)
     ).not.toBeInTheDocument();
   });
 
-  it('should keep callout hidden in same tab session after dismissing and opening another alert flyout', () => {
-    const { getByTestId, queryByTestId, unmount } = renderPrevalenceDetails();
+  it('keeps callout hidden in the same tab session after dismissing', () => {
+    const { getByTestId, queryByTestId, unmount } = renderPrevalenceDetailsView();
 
     fireEvent.click(
       getByTestId(PREVALENCE_DETAILS_COLD_FROZEN_TIER_CALLOUT_DISMISS_BUTTON_TEST_ID)
@@ -461,17 +374,17 @@ describe('PrevalenceDetails', () => {
       _index: 'indexName',
     } as EsHitRecord);
 
-    const { queryByTestId: queryByTestIdAfterOpeningAnotherFlyout } = renderPrevalenceDetails({
+    const { queryByTestId: queryByTestIdAfterReopening } = renderPrevalenceDetailsView({
       hit: anotherHit,
     });
 
     expect(
-      queryByTestIdAfterOpeningAnotherFlyout(PREVALENCE_DETAILS_COLD_FROZEN_TIER_CALLOUT_TEST_ID)
+      queryByTestIdAfterReopening(PREVALENCE_DETAILS_COLD_FROZEN_TIER_CALLOUT_TEST_ID)
     ).not.toBeInTheDocument();
   });
 
-  it('should show callout again after page refresh', () => {
-    const { getByTestId, queryByTestId } = renderPrevalenceDetails();
+  it('shows callout again after tab session reset', () => {
+    const { getByTestId, queryByTestId } = renderPrevalenceDetailsView();
 
     fireEvent.click(
       getByTestId(PREVALENCE_DETAILS_COLD_FROZEN_TIER_CALLOUT_DISMISS_BUTTON_TEST_ID)
@@ -481,15 +394,15 @@ describe('PrevalenceDetails', () => {
     ).not.toBeInTheDocument();
 
     resetColdFrozenTierCalloutDismissedStateForTests();
-    const { getByTestId: getByTestIdAfterRefresh } = renderPrevalenceDetails();
+    const { getByTestId: getByTestIdAfterReset } = renderPrevalenceDetailsView();
 
     expect(
-      getByTestIdAfterRefresh(PREVALENCE_DETAILS_COLD_FROZEN_TIER_CALLOUT_TEST_ID)
+      getByTestIdAfterReset(PREVALENCE_DETAILS_COLD_FROZEN_TIER_CALLOUT_TEST_ID)
     ).toBeInTheDocument();
   });
 
-  it('should use default interval values to fetch prevalence data', () => {
-    renderPrevalenceDetails();
+  it('uses default interval values to fetch prevalence data', () => {
+    renderPrevalenceDetailsView();
 
     expect(usePrevalence).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -498,10 +411,10 @@ describe('PrevalenceDetails', () => {
     );
   });
 
-  it('should use values from local storage to fetch prevalence data', () => {
+  it('uses values from local storage to fetch prevalence data', () => {
     mockStorage.mockReturnValue({ start: 'now-7d', end: 'now-3d' });
 
-    renderPrevalenceDetails();
+    renderPrevalenceDetailsView();
 
     expect(usePrevalence).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/prevalence/components/prevalence_details_view.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/prevalence/components/prevalence_details_view.tsx
@@ -1,0 +1,293 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import dateMath from '@elastic/datemath';
+import React, { useCallback, useMemo, useState } from 'react';
+import { i18n } from '@kbn/i18n';
+import type { EuiBasicTableColumn, OnTimeChangeProps } from '@elastic/eui';
+import {
+  EuiButton,
+  EuiCallOut,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiInMemoryTable,
+  EuiLink,
+  EuiPanel,
+  EuiSpacer,
+  EuiSuperDatePicker,
+} from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n-react';
+import { useEntityStoreEuidApi } from '@kbn/entity-store/public';
+import type { DataTableRecord } from '@kbn/discover-utils';
+import type { PrevalenceDetailsRow } from '../utils/get_columns';
+import { EXCLUDE_COLD_AND_FROZEN_TIERS_IN_PREVALENCE } from '../../../../common/constants';
+import { useKibana } from '../../../common/lib/kibana';
+import { FLYOUT_STORAGE_KEYS } from '../../document/constants/local_storage';
+import { useLicense } from '../../../common/hooks/use_license';
+import { usePrevalence } from '../hooks/use_prevalence';
+import {
+  PREVALENCE_DETAILS_COLD_FROZEN_TIER_CALLOUT_DISMISS_BUTTON_TEST_ID,
+  PREVALENCE_DETAILS_COLD_FROZEN_TIER_CALLOUT_TEST_ID,
+  PREVALENCE_DETAILS_DATE_PICKER_TEST_ID,
+  PREVALENCE_DETAILS_TABLE_TEST_ID,
+  PREVALENCE_DETAILS_UPSELL_TEST_ID,
+} from '../test_ids';
+import { useUserPrivileges } from '../../../common/components/user_privileges';
+
+const DEFAULT_FROM = 'now-30d';
+const DEFAULT_TO = 'now';
+
+// This variable is used to track if the cold/frozen tier callout has been dismissed in the current tab session.
+let isColdFrozenTierCalloutDismissedInTab = false;
+// This function is used in tests to reset the callout dismissed state between tests, as the variable is shared across the entire tab session.
+export const resetColdFrozenTierCalloutDismissedStateForTests = () => {
+  isColdFrozenTierCalloutDismissedInTab = false;
+};
+
+export interface PrevalenceDetailsViewProps {
+  /**
+   * Alert/event document
+   */
+  hit: DataTableRecord;
+  /**
+   * List of investigation fields retrieved from the rule
+   */
+  investigationFields: string[];
+  /**
+   * Scope id, used for cell actions
+   */
+  scopeId: string;
+  /**
+   * Set of columns to render in the table
+   */
+  columns: Array<EuiBasicTableColumn<PrevalenceDetailsRow>>;
+}
+
+/**
+ * Prevalence content view. Renders the date picker and table without any flyout chrome,
+ * so it can be used both inside a flyout body and inline in a tab panel.
+ */
+export const PrevalenceDetailsView: React.FC<PrevalenceDetailsViewProps> = ({
+  hit,
+  investigationFields,
+  scopeId,
+  columns,
+}) => {
+  const { storage, uiSettings, serverless } = useKibana().services;
+  const isServerless = !!serverless;
+  const isColdAndFrozenTiersExcluded = uiSettings.get<boolean>(
+    EXCLUDE_COLD_AND_FROZEN_TIERS_IN_PREVALENCE
+  );
+
+  const {
+    timelinePrivileges: { read: canUseTimeline },
+  } = useUserPrivileges();
+
+  const isPlatinumPlus = useLicense().isPlatinumPlus();
+
+  const timeSavedInLocalStorage = storage.get(FLYOUT_STORAGE_KEYS.PREVALENCE_TIME_RANGE);
+
+  // these two are used by the usePrevalence hook to fetch the data
+  const [start, setStart] = useState(timeSavedInLocalStorage?.start || DEFAULT_FROM);
+  const [end, setEnd] = useState(timeSavedInLocalStorage?.end || DEFAULT_TO);
+
+  // these two are used to pass to timeline
+  const [absoluteStart, setAbsoluteStart] = useState(
+    (dateMath.parse(timeSavedInLocalStorage?.start || DEFAULT_FROM) || new Date()).toISOString()
+  );
+  const [absoluteEnd, setAbsoluteEnd] = useState(
+    (dateMath.parse(timeSavedInLocalStorage?.end || DEFAULT_TO) || new Date()).toISOString()
+  );
+  const [isColdFrozenTierCalloutDismissed, setIsColdFrozenTierCalloutDismissed] = useState(
+    isColdFrozenTierCalloutDismissedInTab
+  );
+
+  // TODO update the logic to use a single set of start/end dates
+  //  currently as we're using this InvestigateInTimelineButton component we need to pass the timeRange
+  //  as an AbsoluteTimeRange, which requires from/to values
+  const onTimeChange = useCallback(
+    ({ start: s, end: e, isInvalid }: OnTimeChangeProps) => {
+      if (isInvalid) return;
+
+      storage.set(FLYOUT_STORAGE_KEYS.PREVALENCE_TIME_RANGE, { start: s, end: e });
+
+      setStart(s);
+      setEnd(e);
+
+      const from = dateMath.parse(s);
+      if (from && from.isValid()) {
+        setAbsoluteStart(from.toISOString());
+      }
+
+      const to = dateMath.parse(e);
+      if (to && to.isValid()) {
+        setAbsoluteEnd(to.toISOString());
+      }
+    },
+    [storage]
+  );
+
+  const onDismiss = useCallback(() => {
+    isColdFrozenTierCalloutDismissedInTab = true;
+    setIsColdFrozenTierCalloutDismissed(true);
+  }, []);
+
+  const { loading, error, data } = usePrevalence({
+    hit,
+    investigationFields,
+    interval: {
+      from: start,
+      to: end,
+    },
+  });
+
+  const euidApi = useEntityStoreEuidApi();
+  const documentHostEntityIdentifiers = useMemo(
+    () =>
+      hit.flattened ? euidApi?.euid.getEntityIdentifiersFromDocument('host', hit.flattened) : null,
+    [hit.flattened, euidApi?.euid]
+  );
+  const documentUserEntityIdentifiers = useMemo(
+    () =>
+      hit.flattened ? euidApi?.euid.getEntityIdentifiersFromDocument('user', hit.flattened) : null,
+    [hit.flattened, euidApi?.euid]
+  );
+
+  // add timeRange to pass it down to timeline and license to drive the rendering of the last 2 prevalence columns
+  const items = useMemo(
+    () =>
+      data.map((item) => ({
+        ...item,
+        from: absoluteStart,
+        to: absoluteEnd,
+        isPlatinumPlus,
+        scopeId,
+        canUseTimeline,
+        documentHostEntityIdentifiers,
+        documentUserEntityIdentifiers,
+      })),
+    [
+      data,
+      absoluteStart,
+      absoluteEnd,
+      canUseTimeline,
+      isPlatinumPlus,
+      scopeId,
+      documentHostEntityIdentifiers,
+      documentUserEntityIdentifiers,
+    ]
+  );
+
+  const upsell = (
+    <>
+      <EuiCallOut data-test-subj={PREVALENCE_DETAILS_UPSELL_TEST_ID}>
+        <FormattedMessage
+          id="xpack.securitySolution.flyout.prevalence.tableAlertUpsellDescription"
+          defaultMessage="Host and user prevalence are only available with a {subscription}."
+          values={{
+            subscription: (
+              <EuiLink href="https://www.elastic.co/pricing/" target="_blank">
+                <FormattedMessage
+                  id="xpack.securitySolution.flyout.prevalence.tableAlertUpsellLinkText"
+                  defaultMessage="Platinum or higher subscription"
+                />
+              </EuiLink>
+            ),
+          }}
+        />
+      </EuiCallOut>
+      <EuiSpacer size="s" />
+    </>
+  );
+
+  const coldFrozenTierCallout = (
+    <>
+      <EuiCallOut
+        data-test-subj={PREVALENCE_DETAILS_COLD_FROZEN_TIER_CALLOUT_TEST_ID}
+        title={
+          <FormattedMessage
+            id="xpack.securitySolution.flyout.prevalence.coldAndFrozenTiers.calloutTitle"
+            defaultMessage="{state}"
+            values={{
+              state: isColdAndFrozenTiersExcluded
+                ? 'Some data excluded'
+                : 'Performance optimization',
+            }}
+          />
+        }
+        iconType="snowflake"
+      >
+        <EuiFlexGroup alignItems="flexStart" gutterSize="l" responsive={false}>
+          <EuiFlexItem>
+            <FormattedMessage
+              id="xpack.securitySolution.flyout.prevalence.coldAndFrozenTiers.calloutDescription"
+              defaultMessage="{state}, go to Advanced Settings or contact your administrator."
+              values={{
+                state: isColdAndFrozenTiersExcluded
+                  ? 'Cold and frozen tiers are excluded to improve performance. To include them'
+                  : 'This view loads more slowly because cold and frozen tiers are included. To change this',
+              }}
+            />
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiButton
+              aria-label={i18n.translate(
+                'xpack.securitySolution.flyout.prevalence.coldAndFrozenTiers.dismissButtonAriaLabel',
+                { defaultMessage: 'Dismiss cold and frozen tier callout' }
+              )}
+              data-test-subj={PREVALENCE_DETAILS_COLD_FROZEN_TIER_CALLOUT_DISMISS_BUTTON_TEST_ID}
+              onClick={onDismiss}
+            >
+              <FormattedMessage
+                id="xpack.securitySolution.flyout.prevalence.coldAndFrozenTiers.dismissButtonLabel"
+                defaultMessage="Dismiss"
+              />
+            </EuiButton>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiCallOut>
+      <EuiSpacer size="s" />
+    </>
+  );
+
+  return (
+    <>
+      {!error && !isPlatinumPlus && upsell}
+      <EuiPanel>
+        {!isServerless && !isColdFrozenTierCalloutDismissed && coldFrozenTierCallout}
+        <EuiSuperDatePicker
+          start={start}
+          end={end}
+          onTimeChange={onTimeChange}
+          data-test-subj={PREVALENCE_DETAILS_DATE_PICKER_TEST_ID}
+          width="full"
+        />
+        <EuiSpacer size="m" />
+        <EuiInMemoryTable
+          items={error ? [] : items}
+          columns={columns}
+          loading={loading}
+          data-test-subj={PREVALENCE_DETAILS_TABLE_TEST_ID}
+          tableCaption={i18n.translate(
+            'xpack.securitySolution.flyout.prevalence.prevalenceCaption',
+            {
+              defaultMessage: 'Prevalence insights',
+            }
+          )}
+          noItemsMessage={
+            <FormattedMessage
+              id="xpack.securitySolution.flyout.prevalence.noDataDescription"
+              defaultMessage="No prevalence data available."
+            />
+          }
+        />
+      </EuiPanel>
+    </>
+  );
+};
+
+PrevalenceDetailsView.displayName = 'PrevalenceDetailsView';

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/prevalence/prevalence.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/prevalence/prevalence.tsx
@@ -5,53 +5,15 @@
  * 2.0.
  */
 
-import dateMath from '@elastic/datemath';
 import { css } from '@emotion/react';
-import React, { useCallback, useMemo, useState } from 'react';
+import React from 'react';
 import { i18n } from '@kbn/i18n';
-import type { EuiBasicTableColumn, OnTimeChangeProps } from '@elastic/eui';
-import {
-  EuiButton,
-  EuiCallOut,
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiFlyoutBody,
-  EuiFlyoutHeader,
-  EuiInMemoryTable,
-  EuiLink,
-  EuiPanel,
-  EuiSpacer,
-  EuiSuperDatePicker,
-  useEuiTheme,
-} from '@elastic/eui';
-import { FormattedMessage } from '@kbn/i18n-react';
-import { useEntityStoreEuidApi } from '@kbn/entity-store/public';
+import type { EuiBasicTableColumn } from '@elastic/eui';
+import { EuiFlyoutBody, EuiFlyoutHeader, useEuiTheme } from '@elastic/eui';
 import type { DataTableRecord } from '@kbn/discover-utils';
 import { ToolsFlyoutHeader } from '../shared/components/tools_flyout_header';
 import type { PrevalenceDetailsRow } from './utils/get_columns';
-import { EXCLUDE_COLD_AND_FROZEN_TIERS_IN_PREVALENCE } from '../../../common/constants';
-import { useKibana } from '../../common/lib/kibana';
-import { FLYOUT_STORAGE_KEYS } from '../document/constants/local_storage';
-import { useLicense } from '../../common/hooks/use_license';
-import { usePrevalence } from './hooks/use_prevalence';
-import {
-  PREVALENCE_DETAILS_COLD_FROZEN_TIER_CALLOUT_DISMISS_BUTTON_TEST_ID,
-  PREVALENCE_DETAILS_COLD_FROZEN_TIER_CALLOUT_TEST_ID,
-  PREVALENCE_DETAILS_DATE_PICKER_TEST_ID,
-  PREVALENCE_DETAILS_TABLE_TEST_ID,
-  PREVALENCE_DETAILS_UPSELL_TEST_ID,
-} from './test_ids';
-import { useUserPrivileges } from '../../common/components/user_privileges';
-
-const DEFAULT_FROM = 'now-30d';
-const DEFAULT_TO = 'now';
-
-// This variable is used to track if the cold/frozen tier callout has been dismissed in the current tab session.
-let isColdFrozenTierCalloutDismissedInTab = false;
-// This function is used in tests to reset the callout dismissed state between tests, as the variable is shared across the entire tab session.
-export const resetColdFrozenTierCalloutDismissedStateForTests = () => {
-  isColdFrozenTierCalloutDismissedInTab = false;
-};
+import { PrevalenceDetailsView } from './components/prevalence_details_view';
 
 const TITLE = i18n.translate('xpack.securitySolution.flyout.prevalence.title', {
   defaultMessage: 'Prevalence',
@@ -77,7 +39,7 @@ export interface PrevalenceDetailsProps {
 }
 
 /**
- * Prevalence table displayed in the document details expandable flyout left section under the Insights tab
+ * Prevalence flyout — header + body shell wrapping PrevalenceDetailsView.
  */
 export const PrevalenceDetails: React.FC<PrevalenceDetailsProps> = ({
   hit,
@@ -86,182 +48,6 @@ export const PrevalenceDetails: React.FC<PrevalenceDetailsProps> = ({
   columns,
 }) => {
   const { euiTheme } = useEuiTheme();
-  const { storage, uiSettings, serverless } = useKibana().services;
-  const isServerless = !!serverless;
-  const isColdAndFrozenTiersExcluded = uiSettings.get<boolean>(
-    EXCLUDE_COLD_AND_FROZEN_TIERS_IN_PREVALENCE
-  );
-
-  const {
-    timelinePrivileges: { read: canUseTimeline },
-  } = useUserPrivileges();
-
-  const isPlatinumPlus = useLicense().isPlatinumPlus();
-
-  const timeSavedInLocalStorage = storage.get(FLYOUT_STORAGE_KEYS.PREVALENCE_TIME_RANGE);
-
-  // these two are used by the usePrevalence hook to fetch the data
-  const [start, setStart] = useState(timeSavedInLocalStorage?.start || DEFAULT_FROM);
-  const [end, setEnd] = useState(timeSavedInLocalStorage?.end || DEFAULT_TO);
-
-  // these two are used to pass to timeline
-  const [absoluteStart, setAbsoluteStart] = useState(
-    (dateMath.parse(timeSavedInLocalStorage?.start || DEFAULT_FROM) || new Date()).toISOString()
-  );
-  const [absoluteEnd, setAbsoluteEnd] = useState(
-    (dateMath.parse(timeSavedInLocalStorage?.end || DEFAULT_TO) || new Date()).toISOString()
-  );
-  const [isColdFrozenTierCalloutDismissed, setIsColdFrozenTierCalloutDismissed] = useState(
-    isColdFrozenTierCalloutDismissedInTab
-  );
-
-  // TODO update the logic to use a single set of start/end dates
-  //  currently as we're using this InvestigateInTimelineButton component we need to pass the timeRange
-  //  as an AbsoluteTimeRange, which requires from/to values
-  const onTimeChange = useCallback(
-    ({ start: s, end: e, isInvalid }: OnTimeChangeProps) => {
-      if (isInvalid) return;
-
-      storage.set(FLYOUT_STORAGE_KEYS.PREVALENCE_TIME_RANGE, { start: s, end: e });
-
-      setStart(s);
-      setEnd(e);
-
-      const from = dateMath.parse(s);
-      if (from && from.isValid()) {
-        setAbsoluteStart(from.toISOString());
-      }
-
-      const to = dateMath.parse(e);
-      if (to && to.isValid()) {
-        setAbsoluteEnd(to.toISOString());
-      }
-    },
-    [storage]
-  );
-
-  const onDismiss = useCallback(() => {
-    isColdFrozenTierCalloutDismissedInTab = true;
-    setIsColdFrozenTierCalloutDismissed(true);
-  }, []);
-
-  const { loading, error, data } = usePrevalence({
-    hit,
-    investigationFields,
-    interval: {
-      from: start,
-      to: end,
-    },
-  });
-
-  const euidApi = useEntityStoreEuidApi();
-  const documentHostEntityIdentifiers = useMemo(
-    () =>
-      hit.flattened ? euidApi?.euid.getEntityIdentifiersFromDocument('host', hit.flattened) : null,
-    [hit.flattened, euidApi?.euid]
-  );
-  const documentUserEntityIdentifiers = useMemo(
-    () =>
-      hit.flattened ? euidApi?.euid.getEntityIdentifiersFromDocument('user', hit.flattened) : null,
-    [hit.flattened, euidApi?.euid]
-  );
-
-  // add timeRange to pass it down to timeline and license to drive the rendering of the last 2 prevalence columns
-  const items = useMemo(
-    () =>
-      data.map((item) => ({
-        ...item,
-        from: absoluteStart,
-        to: absoluteEnd,
-        isPlatinumPlus,
-        scopeId,
-        canUseTimeline,
-        documentHostEntityIdentifiers,
-        documentUserEntityIdentifiers,
-      })),
-    [
-      data,
-      absoluteStart,
-      absoluteEnd,
-      canUseTimeline,
-      isPlatinumPlus,
-      scopeId,
-      documentHostEntityIdentifiers,
-      documentUserEntityIdentifiers,
-    ]
-  );
-
-  const upsell = (
-    <>
-      <EuiCallOut data-test-subj={PREVALENCE_DETAILS_UPSELL_TEST_ID}>
-        <FormattedMessage
-          id="xpack.securitySolution.flyout.prevalence.tableAlertUpsellDescription"
-          defaultMessage="Host and user prevalence are only available with a {subscription}."
-          values={{
-            subscription: (
-              <EuiLink href="https://www.elastic.co/pricing/" target="_blank">
-                <FormattedMessage
-                  id="xpack.securitySolution.flyout.prevalence.tableAlertUpsellLinkText"
-                  defaultMessage="Platinum or higher subscription"
-                />
-              </EuiLink>
-            ),
-          }}
-        />
-      </EuiCallOut>
-      <EuiSpacer size="s" />
-    </>
-  );
-
-  const coldFrozenTierCallout = (
-    <>
-      <EuiCallOut
-        data-test-subj={PREVALENCE_DETAILS_COLD_FROZEN_TIER_CALLOUT_TEST_ID}
-        title={
-          <FormattedMessage
-            id="xpack.securitySolution.flyout.prevalence.coldAndFrozenTiers.calloutTitle"
-            defaultMessage="{state}"
-            values={{
-              state: isColdAndFrozenTiersExcluded
-                ? 'Some data excluded'
-                : 'Performance optimization',
-            }}
-          />
-        }
-        iconType="snowflake"
-      >
-        <EuiFlexGroup alignItems="flexStart" gutterSize="l" responsive={false}>
-          <EuiFlexItem>
-            <FormattedMessage
-              id="xpack.securitySolution.flyout.prevalence.coldAndFrozenTiers.calloutDescription"
-              defaultMessage="{state}, go to Advanced Settings or contact your administrator."
-              values={{
-                state: isColdAndFrozenTiersExcluded
-                  ? 'Cold and frozen tiers are excluded to improve performance. To include them'
-                  : 'This view loads more slowly because cold and frozen tiers are included. To change this',
-              }}
-            />
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiButton
-              aria-label={i18n.translate(
-                'xpack.securitySolution.flyout.prevalence.coldAndFrozenTiers.dismissButtonAriaLabel',
-                { defaultMessage: 'Dismiss cold and frozen tier callout' }
-              )}
-              data-test-subj={PREVALENCE_DETAILS_COLD_FROZEN_TIER_CALLOUT_DISMISS_BUTTON_TEST_ID}
-              onClick={onDismiss}
-            >
-              <FormattedMessage
-                id="xpack.securitySolution.flyout.prevalence.coldAndFrozenTiers.dismissButtonLabel"
-                defaultMessage="Dismiss"
-              />
-            </EuiButton>
-          </EuiFlexItem>
-        </EuiFlexGroup>
-      </EuiCallOut>
-      <EuiSpacer size="s" />
-    </>
-  );
 
   return (
     <>
@@ -274,36 +60,12 @@ export const PrevalenceDetails: React.FC<PrevalenceDetailsProps> = ({
         <ToolsFlyoutHeader hit={hit} title={TITLE} />
       </EuiFlyoutHeader>
       <EuiFlyoutBody>
-        {!error && !isPlatinumPlus && upsell}
-        <EuiPanel>
-          {!isServerless && !isColdFrozenTierCalloutDismissed && coldFrozenTierCallout}
-          <EuiSuperDatePicker
-            start={start}
-            end={end}
-            onTimeChange={onTimeChange}
-            data-test-subj={PREVALENCE_DETAILS_DATE_PICKER_TEST_ID}
-            width="full"
-          />
-          <EuiSpacer size="m" />
-          <EuiInMemoryTable
-            items={error ? [] : items}
-            columns={columns}
-            loading={loading}
-            data-test-subj={PREVALENCE_DETAILS_TABLE_TEST_ID}
-            tableCaption={i18n.translate(
-              'xpack.securitySolution.flyout.prevalence.prevalenceCaption',
-              {
-                defaultMessage: 'Prevalence insights',
-              }
-            )}
-            noItemsMessage={
-              <FormattedMessage
-                id="xpack.securitySolution.flyout.prevalence.noDataDescription"
-                defaultMessage="No prevalence data available."
-              />
-            }
-          />
-        </EuiPanel>
+        <PrevalenceDetailsView
+          hit={hit}
+          investigationFields={investigationFields}
+          scopeId={scopeId}
+          columns={columns}
+        />
       </EuiFlyoutBody>
     </>
   );

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/threat_intelligence/components/threat_intelligence_details_view.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/threat_intelligence/components/threat_intelligence_details_view.test.tsx
@@ -1,0 +1,118 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import type { DataTableRecord } from '@kbn/discover-utils';
+import { TestProviders } from '../../../common/mock';
+import {
+  THREAT_INTELLIGENCE_DETAILS_ENRICHMENTS_TEST_ID,
+  THREAT_INTELLIGENCE_DETAILS_LOADING_TEST_ID,
+  THREAT_INTELLIGENCE_ENRICHMENTS_TEST_ID,
+  THREAT_INTELLIGENCE_MATCHES_TEST_ID,
+} from './test_ids';
+import { ThreatIntelligenceDetailsView } from './threat_intelligence_details_view';
+import { useThreatIntelligenceDetails } from '../hooks/use_threat_intelligence_details';
+import { buildEventEnrichmentMock } from '../../../../common/search_strategy/security_solution/cti/index.mock';
+
+jest.mock('../hooks/use_threat_intelligence_details');
+
+const mockHit: DataTableRecord = {
+  id: '1',
+  raw: {},
+  flattened: {},
+  isAnchor: false,
+};
+
+const defaultHookReturn = {
+  isLoading: false,
+  enrichments: [],
+  isEventDataLoading: false,
+  isEnrichmentsLoading: false,
+  range: { from: '', to: '' },
+  setRange: () => {},
+  eventFields: {},
+};
+
+const renderView = () =>
+  render(
+    <TestProviders>
+      <ThreatIntelligenceDetailsView hit={mockHit} />
+    </TestProviders>
+  );
+
+describe('<ThreatIntelligenceDetailsView />', () => {
+  it('renders loading spinner when event data is loading', () => {
+    jest.mocked(useThreatIntelligenceDetails).mockReturnValue({
+      ...defaultHookReturn,
+      isEventDataLoading: true,
+    });
+
+    const { getByTestId, queryByTestId } = renderView();
+
+    expect(getByTestId(THREAT_INTELLIGENCE_DETAILS_LOADING_TEST_ID)).toBeInTheDocument();
+    expect(queryByTestId(THREAT_INTELLIGENCE_DETAILS_ENRICHMENTS_TEST_ID)).not.toBeInTheDocument();
+  });
+
+  it('renders indicator match enrichments section', () => {
+    jest.mocked(useThreatIntelligenceDetails).mockReturnValue({
+      ...defaultHookReturn,
+      enrichments: [buildEventEnrichmentMock({ 'matched.type': ['indicator_match_rule'] })],
+    });
+
+    const { getByTestId } = renderView();
+
+    expect(getByTestId(THREAT_INTELLIGENCE_DETAILS_ENRICHMENTS_TEST_ID)).toBeInTheDocument();
+  });
+
+  it('renders investigation time enrichments section when eventFields is non-empty', () => {
+    jest.mocked(useThreatIntelligenceDetails).mockReturnValue({
+      ...defaultHookReturn,
+      enrichments: [buildEventEnrichmentMock()],
+      eventFields: { 'source.ip': '1.2.3.4' },
+    });
+
+    const { getByTestId } = renderView();
+
+    expect(getByTestId(THREAT_INTELLIGENCE_ENRICHMENTS_TEST_ID)).toBeInTheDocument();
+  });
+
+  it('does not render investigation time enrichments section when eventFields is empty', () => {
+    jest.mocked(useThreatIntelligenceDetails).mockReturnValue({
+      ...defaultHookReturn,
+      enrichments: [buildEventEnrichmentMock()],
+      eventFields: {},
+    });
+
+    const { queryByTestId } = renderView();
+
+    expect(queryByTestId(THREAT_INTELLIGENCE_ENRICHMENTS_TEST_ID)).not.toBeInTheDocument();
+  });
+
+  it('renders matches-with-no-type section when enrichments have no type', () => {
+    // Omit 'matched.type' entirely so groupBy places it in the undefined bucket
+    // without leaving an explicit undefined value that downstream iteration would crash on.
+    const { 'matched.type': _removed, ...enrichmentWithNoType } = buildEventEnrichmentMock();
+    jest.mocked(useThreatIntelligenceDetails).mockReturnValue({
+      ...defaultHookReturn,
+      enrichments: [enrichmentWithNoType as ReturnType<typeof buildEventEnrichmentMock>],
+    });
+
+    const { getByTestId } = renderView();
+
+    expect(getByTestId(THREAT_INTELLIGENCE_MATCHES_TEST_ID)).toBeInTheDocument();
+  });
+
+  it('renders without crashing when there are no enrichments', () => {
+    jest.mocked(useThreatIntelligenceDetails).mockReturnValue(defaultHookReturn);
+
+    const { getByTestId } = renderView();
+
+    expect(getByTestId(THREAT_INTELLIGENCE_DETAILS_ENRICHMENTS_TEST_ID)).toBeInTheDocument();
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/threat_intelligence/components/threat_intelligence_details_view.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/threat_intelligence/components/threat_intelligence_details_view.tsx
@@ -1,0 +1,98 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { memo } from 'react';
+import { EuiHorizontalRule, EuiPanel, EuiSpacer } from '@elastic/eui';
+import { groupBy, isEmpty } from 'lodash';
+import type { DataTableRecord } from '@kbn/discover-utils';
+import { EnrichmentSection } from './threat_details_view_enrichment_section';
+import { ENRICHMENT_TYPES } from '../../../../common/cti/constants';
+import { EnrichmentRangePicker } from './threat_intelligence_view_enrichment_range_picker';
+import { useThreatIntelligenceDetails } from '../hooks/use_threat_intelligence_details';
+import {
+  THREAT_INTELLIGENCE_DETAILS_ENRICHMENTS_TEST_ID,
+  THREAT_INTELLIGENCE_DETAILS_LOADING_TEST_ID,
+  THREAT_INTELLIGENCE_ENRICHMENTS_TEST_ID,
+  THREAT_INTELLIGENCE_MATCHES_TEST_ID,
+} from './test_ids';
+import { FlyoutLoading } from '../../../flyout/shared/components/flyout_loading';
+
+export interface ThreatIntelligenceDetailsViewProps {
+  /**
+   * The document hit to display threat intelligence for
+   */
+  hit: DataTableRecord;
+}
+
+/**
+ * Threat intelligence content view. Renders the enrichment sections without any flyout chrome,
+ * so it can be used both inside a flyout body and inline in a tab panel.
+ */
+export const ThreatIntelligenceDetailsView = memo(({ hit }: ThreatIntelligenceDetailsViewProps) => {
+  const {
+    enrichments,
+    eventFields,
+    isEnrichmentsLoading,
+    isEventDataLoading,
+    isLoading,
+    range,
+    setRange,
+  } = useThreatIntelligenceDetails({ hit });
+
+  const showInvestigationTimeEnrichments = !isEmpty(eventFields);
+  const {
+    [ENRICHMENT_TYPES.IndicatorMatchRule]: indicatorMatches,
+    [ENRICHMENT_TYPES.InvestigationTime]: threatIntelEnrichments,
+    undefined: matchesWithNoType,
+  } = groupBy(enrichments, 'matched.type');
+
+  if (isEventDataLoading) {
+    return <FlyoutLoading data-test-subj={THREAT_INTELLIGENCE_DETAILS_LOADING_TEST_ID} />;
+  }
+
+  return (
+    <EuiPanel hasShadow={false} hasBorder={false}>
+      <EnrichmentSection
+        dataTestSubj={THREAT_INTELLIGENCE_DETAILS_ENRICHMENTS_TEST_ID}
+        enrichments={indicatorMatches}
+        type={ENRICHMENT_TYPES.IndicatorMatchRule}
+      />
+
+      {showInvestigationTimeEnrichments ? (
+        <>
+          <EuiHorizontalRule />
+          <EnrichmentSection
+            dataTestSubj={THREAT_INTELLIGENCE_ENRICHMENTS_TEST_ID}
+            enrichments={threatIntelEnrichments}
+            type={ENRICHMENT_TYPES.InvestigationTime}
+            loading={isLoading}
+          >
+            <EnrichmentRangePicker
+              setRange={setRange}
+              loading={isEnrichmentsLoading}
+              range={range}
+            />
+            <EuiSpacer size="m" />
+          </EnrichmentSection>
+        </>
+      ) : null}
+
+      {matchesWithNoType ? (
+        <>
+          <EuiHorizontalRule />
+          {indicatorMatches && <EuiSpacer size="l" />}
+          <EnrichmentSection
+            enrichments={matchesWithNoType}
+            dataTestSubj={THREAT_INTELLIGENCE_MATCHES_TEST_ID}
+          />
+        </>
+      ) : null}
+    </EuiPanel>
+  );
+});
+
+ThreatIntelligenceDetailsView.displayName = 'ThreatIntelligenceDetailsView';

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/threat_intelligence/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/threat_intelligence/index.tsx
@@ -7,29 +7,11 @@
 
 import { css } from '@emotion/react';
 import React, { memo } from 'react';
-import {
-  EuiFlyoutBody,
-  EuiFlyoutHeader,
-  EuiHorizontalRule,
-  EuiPanel,
-  EuiSpacer,
-  useEuiTheme,
-} from '@elastic/eui';
+import { EuiFlyoutBody, EuiFlyoutHeader, useEuiTheme } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import { groupBy, isEmpty } from 'lodash';
 import type { DataTableRecord } from '@kbn/discover-utils';
 import { ToolsFlyoutHeader } from '../shared/components/tools_flyout_header';
-import { EnrichmentSection } from './components/threat_details_view_enrichment_section';
-import { ENRICHMENT_TYPES } from '../../../common/cti/constants';
-import { EnrichmentRangePicker } from './components/threat_intelligence_view_enrichment_range_picker';
-import { useThreatIntelligenceDetails } from './hooks/use_threat_intelligence_details';
-import {
-  THREAT_INTELLIGENCE_DETAILS_ENRICHMENTS_TEST_ID,
-  THREAT_INTELLIGENCE_DETAILS_LOADING_TEST_ID,
-  THREAT_INTELLIGENCE_ENRICHMENTS_TEST_ID,
-  THREAT_INTELLIGENCE_MATCHES_TEST_ID,
-} from './components/test_ids';
-import { FlyoutLoading } from '../../flyout/shared/components/flyout_loading';
+import { ThreatIntelligenceDetailsView } from './components/threat_intelligence_details_view';
 
 export const THREAT_INTELLIGENCE_TAB_ID = 'threatIntelligence';
 
@@ -45,26 +27,10 @@ export interface ThreatIntelligenceDetailsProps {
 }
 
 /**
- * Threat intelligence displayed in the document details expandable flyout left section under the Insights tab
+ * Threat intelligence flyout — header + body shell wrapping ThreatIntelligenceDetailsView.
  */
 export const ThreatIntelligenceDetails = memo(({ hit }: ThreatIntelligenceDetailsProps) => {
   const { euiTheme } = useEuiTheme();
-  const {
-    enrichments,
-    eventFields,
-    isEnrichmentsLoading,
-    isEventDataLoading,
-    isLoading,
-    range,
-    setRange,
-  } = useThreatIntelligenceDetails({ hit });
-
-  const showInvestigationTimeEnrichments = !isEmpty(eventFields);
-  const {
-    [ENRICHMENT_TYPES.IndicatorMatchRule]: indicatorMatches,
-    [ENRICHMENT_TYPES.InvestigationTime]: threatIntelEnrichments,
-    undefined: matchesWithNoType,
-  } = groupBy(enrichments, 'matched.type');
 
   return (
     <>
@@ -77,47 +43,7 @@ export const ThreatIntelligenceDetails = memo(({ hit }: ThreatIntelligenceDetail
         <ToolsFlyoutHeader hit={hit} title={TITLE} />
       </EuiFlyoutHeader>
       <EuiFlyoutBody>
-        {isEventDataLoading ? (
-          <FlyoutLoading data-test-subj={THREAT_INTELLIGENCE_DETAILS_LOADING_TEST_ID} />
-        ) : (
-          <EuiPanel hasShadow={false} hasBorder={false}>
-            <EnrichmentSection
-              dataTestSubj={THREAT_INTELLIGENCE_DETAILS_ENRICHMENTS_TEST_ID}
-              enrichments={indicatorMatches}
-              type={ENRICHMENT_TYPES.IndicatorMatchRule}
-            />
-
-            {showInvestigationTimeEnrichments ? (
-              <>
-                <EuiHorizontalRule />
-                <EnrichmentSection
-                  dataTestSubj={THREAT_INTELLIGENCE_ENRICHMENTS_TEST_ID}
-                  enrichments={threatIntelEnrichments}
-                  type={ENRICHMENT_TYPES.InvestigationTime}
-                  loading={isLoading}
-                >
-                  <EnrichmentRangePicker
-                    setRange={setRange}
-                    loading={isEnrichmentsLoading}
-                    range={range}
-                  />
-                  <EuiSpacer size="m" />
-                </EnrichmentSection>
-              </>
-            ) : null}
-
-            {matchesWithNoType ? (
-              <>
-                <EuiHorizontalRule />
-                {indicatorMatches && <EuiSpacer size="l" />}
-                <EnrichmentSection
-                  enrichments={matchesWithNoType}
-                  dataTestSubj={THREAT_INTELLIGENCE_MATCHES_TEST_ID}
-                />
-              </>
-            ) : null}
-          </EuiPanel>
-        )}
+        <ThreatIntelligenceDetailsView hit={hit} />
       </EuiFlyoutBody>
     </>
   );


### PR DESCRIPTION
## Summary

This previous [PR](https://github.com/elastic/kibana/pull/261443) added a header to all tools flyout, including the notes one, threat intelligence, prevalence and correlations ones.

I had not realized that the old expandable flyout Notes tab, Prevalence, Correlations and Threat Intelligence section under the Insights tab were using the tools flyout components directly, that now contains the header. When adding the header to the tools flyout, it also showed in the old expandable flyout.

> [!TIP]
> While there seems to be lots of code changes, almost all the code was just moved into new components.

This PR fixes that by doing the following:
- create new view component for Correlations, Threat Intelligence and Prevalence components. The code was just moved to the new components. The only left in the parent components are the `EuiFlyoutHeader` and `EuiFlyoutBody` calling these new components
- update the old flyout to point to the new `view` components instead of their parent that contains the header.

### Current broken behavior

https://github.com/user-attachments/assets/903808d7-a999-4462-9297-ff138556d033

### New fixes behavior

https://github.com/user-attachments/assets/586cdc2d-714a-4ed6-b6be-5d2e3e323181

### The new tools flyout are still working as expected

https://github.com/user-attachments/assets/e09c03ac-ed58-4135-9fd6-05ce4da44323

> [!NOTE]
> There is some weird spacing in the new tools flyout. These will be fixed in a follow up PR.

### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

_PR developed with Cursor + gpt-5.3-codex and Claude_

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->