### PR TITLE
[APM] Align serverless APM service nav with stateful

### DIFF
--- a/x-pack/solutions/observability/plugins/serverless_observability/public/navigation_tree.ts
+++ b/x-pack/solutions/observability/plugins/serverless_observability/public/navigation_tree.ts
@@ -116,12 +116,24 @@ export const createNavigationTree = ({
                 title: i18n.translate('xpack.serverlessObservability.nav.apm.services', {
                   defaultMessage: 'Service inventory',
                 }),
+                getIsActive: ({ pathNameSerialized }) => {
+                  const regex = /app\/apm\/.*service.*/;
+
+                  return regex.test(pathNameSerialized);
+                },
               },
               {
                 link: 'apm:service-map',
                 title: i18n.translate('xpack.serverlessObservability.nav.apm.serviceMap', {
                   defaultMessage: 'Service map',
                 }),
+                sideNavStatus: 'hidden',
+              },
+              {
+                link: 'apm:service-groups-list',
+                getIsActive: ({ pathNameSerialized, prepend }) => {
+                  return pathNameSerialized.startsWith(prepend('/app/apm/service-groups'));
+                },
                 sideNavStatus: 'hidden',
               },
               { link: 'apm:traces' },


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/263118

- Register hidden `apm:service-groups-list` in the serverless Observability navigation tree so project chrome can resolve `/app/apm/service-groups` like stateful.
- Add `getIsActive` on `apm:services` (same regex as stateful) so **Service inventory** stays active on service map, groups, and related paths.

## Demo

### Before

https://github.com/user-attachments/assets/9abca4ee-b765-485d-839f-17c91981a25e

### After

https://github.com/user-attachments/assets/df1e6c8f-3bd4-4999-8c26-0f4ea0ae3b1f



<!--ONMERGE {"backportTargets":["8.19","9.3","9.4"]} ONMERGE-->