### PR TITLE
[Entity Analytics] Setting watchlist index to hidden

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/management/watchlist_config.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/management/watchlist_config.ts
@@ -100,6 +100,7 @@ export class WatchlistConfigClient {
       options: {
         index: getIndexForWatchlist(this.deps.namespace),
         mappings: generateWatchlistEntityIndexMappings(),
+        settings: { hidden: true },
       },
     });
 


### PR DESCRIPTION
## Summary

Setting watchlist index to hidden when installing on startup.

## To Verify

1. Start ES and Kibana with all the feature flags
2. In Dev Console, get the index settings for the watchlists index:

```
GET .entity_analytics.watchlists.default/_settings
```

3. Verify you see `hidden` in the response

```
{
  ".entity_analytics.watchlists.default": {
    "settings": {
      "index": {
        "routing": {
          "allocation": {
            "include": {
              "_tier_preference": "data_content"
            }
          }
        },
        "hidden": "true",
        "number_of_shards": "1",
        "provided_name": ".entity_analytics.watchlists.default",
        "creation_date": "1776181342986",
        "number_of_replicas": "1",
        "uuid": "qSTETFEMQiaPsTKCLvjZAw",
        "version": {
          "created": "9094000"
        }
      }
    }
  }
}
```