### PR TITLE
[9.3] [Security Solution][Alert KPI] Fix white space bug in alert KPIs (#260803)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/alerts_summary_charts_panel/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/alerts_summary_charts_panel/index.tsx
@@ -64,12 +64,7 @@ export const AlertsSummaryChartsPanel: React.FC<Props> = ({
   );
 
   return (
-    <KpiPanel
-      $toggleStatus={isExpanded}
-      data-test-subj="alerts-charts-panel"
-      hasBorder
-      height={panelHeight}
-    >
+    <KpiPanel $toggleStatus={isExpanded} data-test-subj="alerts-charts-panel" hasBorder>
       <HeaderSection
         alignHeader={alignHeader}
         outerDirection="row"
@@ -82,12 +77,7 @@ export const AlertsSummaryChartsPanel: React.FC<Props> = ({
         toggleQuery={toggleQuery}
       />
       {isExpanded && (
-        <StyledFlexGroup
-          data-test-subj="alerts-charts-container"
-          className="eui-yScroll"
-          wrap
-          gutterSize="m"
-        >
+        <StyledFlexGroup data-test-subj="alerts-charts-container" wrap gutterSize="m">
           <StyledFlexItem>
             <SeverityLevelPanel
               filters={filters}

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/alerts_treemap_panel/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/alerts_treemap_panel/index.test.tsx
@@ -166,17 +166,7 @@ describe('AlertsTreemapPanel', () => {
     );
   });
 
-  it('renders the panel with the expected class to style the overflow-y scroll bar', async () => {
-    render(
-      <TestProviders>
-        <AlertsTreemapPanel {...defaultProps} />
-      </TestProviders>
-    );
-
-    await waitFor(() => expect(screen.getByTestId('treemapPanel')).toHaveClass('eui-yScroll'));
-  });
-
-  it('renders the panel with an auto overflow-y to allow vertical scrolling when necessary when the panel is expanded', async () => {
+  it('renders the panel with a hidden overflow-y when the panel is expanded, delegating scrolling to the inner content', async () => {
     render(
       <TestProviders>
         <AlertsTreemapPanel {...defaultProps} />
@@ -184,7 +174,7 @@ describe('AlertsTreemapPanel', () => {
     );
 
     await waitFor(() =>
-      expect(screen.getByTestId('treemapPanel')).toHaveStyleRule('overflow-y', 'auto')
+      expect(screen.getByTestId('treemapPanel')).toHaveStyleRule('overflow-y', 'hidden')
     );
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/alerts_treemap_panel/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/alerts_treemap_panel/index.tsx
@@ -8,6 +8,7 @@
 import type { MappingRuntimeFields } from '@elastic/elasticsearch/lib/api/types';
 import type { EuiComboBox } from '@elastic/eui';
 import { EuiProgress } from '@elastic/eui';
+import styled from '@emotion/styled';
 import type { Filter, Query } from '@kbn/es-query';
 import { buildEsQuery } from '@kbn/es-query';
 import { getEsQueryConfig } from '@kbn/data-plugin/common';
@@ -28,6 +29,12 @@ import type { AlertsTreeMapAggregation } from './alerts_treemap/types';
 import { useKibana } from '../../../../common/lib/kibana';
 
 const DEFAULT_HEIGHT = DEFAULT_MIN_CHART_HEIGHT + 134; // px
+
+const ScrollableContent = styled.div`
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+`;
 
 const COLLAPSED_HEIGHT = 64; // px
 
@@ -162,11 +169,9 @@ const AlertsTreemapPanelComponent: React.FC<Props> = ({
   return (
     <InspectButtonContainer>
       <KpiPanel
-        className="eui-yScroll"
         data-test-subj="treemapPanel"
         hasBorder
         height={isPanelExpanded ? height : COLLAPSED_HEIGHT}
-        $overflowY={isPanelExpanded ? 'auto' : 'hidden'}
         $toggleStatus
       >
         <HeaderSection
@@ -203,13 +208,15 @@ const AlertsTreemapPanelComponent: React.FC<Props> = ({
         ) : (
           <>
             {alertsData != null && isPanelExpanded && (
-              <AlertsTreemap
-                addFilter={addFilter}
-                data={alertsData}
-                maxBuckets={DEFAULT_STACK_BY_FIELD0_SIZE}
-                stackByField0={stackByField0}
-                stackByField1={stackByField1}
-              />
+              <ScrollableContent>
+                <AlertsTreemap
+                  addFilter={addFilter}
+                  data={alertsData}
+                  maxBuckets={DEFAULT_STACK_BY_FIELD0_SIZE}
+                  stackByField0={stackByField0}
+                  stackByField1={stackByField1}
+                />
+              </ScrollableContent>
             )}
           </>
         )}

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/chart_panels/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/chart_panels/index.tsx
@@ -172,7 +172,7 @@ const ChartPanelsComponent: React.FC<Props> = ({
   ]);
 
   return (
-    <div data-test-subj="chartPanels">
+    <div data-test-subj="chartPanels" css={{ 'max-height': CHART_PANEL_HEIGHT, overflow: 'auto' }}>
       {alertViewSelection === 'trend' && (
         <FullHeightFlexItem grow={2}>
           {isLoadingIndexPattern ? (

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/common/components.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/common/components.tsx
@@ -10,7 +10,6 @@ import { EuiPanel, EuiComboBox } from '@elastic/eui';
 import styled from 'styled-components';
 import type { LegacyRef } from 'react';
 import React, { useCallback, useMemo } from 'react';
-import { PANEL_HEIGHT, MOBILE_PANEL_HEIGHT } from './config';
 import { useStackByFields } from './hooks';
 import * as i18n from './translations';
 
@@ -37,18 +36,7 @@ export const KpiPanel = styled(EuiPanel)<{
   position: relative;
   overflow-x: hidden;
   overflow-y: ${({ $overflowY }) => $overflowY ?? 'hidden'};
-  @media only screen and (min-width: ${(props) => props.theme.eui.euiBreakpoints.m}) {
-    ${({ height, $toggleStatus }) =>
-      $toggleStatus &&
-      `
-      height: ${height != null ? height : PANEL_HEIGHT}px;
-  `}
-  }
-  ${({ $toggleStatus }) =>
-    $toggleStatus &&
-    `
-    height: ${MOBILE_PANEL_HEIGHT}px;
-  `}
+  ${({ height }) => height != null && `height: ${height}px;`}
 `;
 interface StackedBySelectProps {
   'aria-label'?: string;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Security Solution][Alert KPI] Fix white space bug in alert KPIs (#260803)](https://github.com/elastic/kibana/pull/260803)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Kelvin Tan","email":"141756464+kelvtanv@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-04-14T13:05:29Z","message":"[Security Solution][Alert KPI] Fix white space bug in alert KPIs (#260803)\n\n## Summary\n\n[See issue](https://github.com/elastic/kibana/issues/225838)\n\n- Happens on both the new attacks page and alerts page for any kpi that\nhas an arbitrary list of items\n- Caused by content overflowing parent container \n- For example within the `Alerts by name` kpi, if there are many rows,\nthe content is hidden and scrollable but still (invisibly) takes up\nspace within the parent container\n- Fix the tree map kpi to be bounded within the parent container (so\nborder does not overlap with content) and only make the graph portion\nscrollable\n\n### To test\n1. Setup lots of rules (enough to overflow the kpi)\n2. Generate a bunch of alerts from those rules\n3. Alternatively, generate a bunch of alerts with unique hostnames to\noverflow the `Top alerts by` kpi when sorting by `host.name`\n4. Go to the summary section in alerts kpi and notice the large\nscrollable white space\n5. Go to the tree map and make sure the graph is large, notice the graph\noverlaps the border of the bounding container and scrolling scrolls the\nentire bounding container\n\nBefore:\n\n\nhttps://github.com/user-attachments/assets/be6683c7-8590-495f-bc89-fce7182af135\n\nAfter:\n\n\n\nhttps://github.com/user-attachments/assets/7b4d53c7-cfd4-406f-8955-80217b5dd09e\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"58479ea7a8c04967d6805239f5f7e192f1d9b584","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Threat Hunting:Investigations","backport:all-open","v9.4.0","v9.5.0"],"title":"[Security Solution][Alert KPI] Fix white space bug in alert KPIs","number":260803,"url":"https://github.com/elastic/kibana/pull/260803","mergeCommit":{"message":"[Security Solution][Alert KPI] Fix white space bug in alert KPIs (#260803)\n\n## Summary\n\n[See issue](https://github.com/elastic/kibana/issues/225838)\n\n- Happens on both the new attacks page and alerts page for any kpi that\nhas an arbitrary list of items\n- Caused by content overflowing parent container \n- For example within the `Alerts by name` kpi, if there are many rows,\nthe content is hidden and scrollable but still (invisibly) takes up\nspace within the parent container\n- Fix the tree map kpi to be bounded within the parent container (so\nborder does not overlap with content) and only make the graph portion\nscrollable\n\n### To test\n1. Setup lots of rules (enough to overflow the kpi)\n2. Generate a bunch of alerts from those rules\n3. Alternatively, generate a bunch of alerts with unique hostnames to\noverflow the `Top alerts by` kpi when sorting by `host.name`\n4. Go to the summary section in alerts kpi and notice the large\nscrollable white space\n5. Go to the tree map and make sure the graph is large, notice the graph\noverlaps the border of the bounding container and scrolling scrolls the\nentire bounding container\n\nBefore:\n\n\nhttps://github.com/user-attachments/assets/be6683c7-8590-495f-bc89-fce7182af135\n\nAfter:\n\n\n\nhttps://github.com/user-attachments/assets/7b4d53c7-cfd4-406f-8955-80217b5dd09e\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"58479ea7a8c04967d6805239f5f7e192f1d9b584"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/263070","number":263070,"state":"MERGED","mergeCommit":{"sha":"421b14f38b985ea8cec5ede61aebcbb71abd22dd","message":"[9.4] [Security Solution][Alert KPI] Fix white space bug in alert KPIs (#260803) (#263070)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.4`:\n- [[Security Solution][Alert KPI] Fix white space bug in alert KPIs\n(#260803)](https://github.com/elastic/kibana/pull/260803)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Kelvin Tan <141756464+kelvtanv@users.noreply.github.com>"}},{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/260803","number":260803,"mergeCommit":{"message":"[Security Solution][Alert KPI] Fix white space bug in alert KPIs (#260803)\n\n## Summary\n\n[See issue](https://github.com/elastic/kibana/issues/225838)\n\n- Happens on both the new attacks page and alerts page for any kpi that\nhas an arbitrary list of items\n- Caused by content overflowing parent container \n- For example within the `Alerts by name` kpi, if there are many rows,\nthe content is hidden and scrollable but still (invisibly) takes up\nspace within the parent container\n- Fix the tree map kpi to be bounded within the parent container (so\nborder does not overlap with content) and only make the graph portion\nscrollable\n\n### To test\n1. Setup lots of rules (enough to overflow the kpi)\n2. Generate a bunch of alerts from those rules\n3. Alternatively, generate a bunch of alerts with unique hostnames to\noverflow the `Top alerts by` kpi when sorting by `host.name`\n4. Go to the summary section in alerts kpi and notice the large\nscrollable white space\n5. Go to the tree map and make sure the graph is large, notice the graph\noverlaps the border of the bounding container and scrolling scrolls the\nentire bounding container\n\nBefore:\n\n\nhttps://github.com/user-attachments/assets/be6683c7-8590-495f-bc89-fce7182af135\n\nAfter:\n\n\n\nhttps://github.com/user-attachments/assets/7b4d53c7-cfd4-406f-8955-80217b5dd09e\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"58479ea7a8c04967d6805239f5f7e192f1d9b584"}}]}] BACKPORT-->