### PR TITLE
fix flaky test: synthetics create_monitor_private_location cleanup

### DIFF
--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/create_monitor_private_location.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/create_monitor_private_location.ts
@@ -533,12 +533,9 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
         } catch (e) {
           // ignore cleanup errors
         }
-        // Restore the package to the latest version so subsequent tests aren't affected
-        try {
-          await testPrivateLocations.installSyntheticsPackage();
-        } catch (e) {
-          // ignore cleanup errors
-        }
+        // Restore the package to the latest version — this MUST succeed
+        // or subsequent tests will run against the wrong version
+        await testPrivateLocations.installSyntheticsPackage();
       }
     });
 
@@ -557,7 +554,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
     });
 
     it('can create valid monitors without all defaults', async () => {
-      // Delete a required property to make payload invalid
+      let monitorId = '';
       const newMonitor = {
         name: 'Sample name',
         type: 'http',
@@ -565,18 +562,24 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
         locations: [privateLocations[0]],
       };
 
-      const { body: apiResponse } = await addMonitorAPI(newMonitor);
+      try {
+        const { body: apiResponse, rawBody } = await addMonitorAPI(newMonitor);
+        monitorId = rawBody.id;
 
-      expect(apiResponse).eql(
-        omitMonitorKeys({
-          ...DEFAULT_FIELDS[MonitorTypeEnum.HTTP],
-          ...newMonitor,
-          spaces: ['default'],
-        })
-      );
+        expect(apiResponse).eql(
+          omitMonitorKeys({
+            ...DEFAULT_FIELDS[MonitorTypeEnum.HTTP],
+            ...newMonitor,
+            spaces: ['default'],
+          })
+        );
+      } finally {
+        await deleteMonitor(monitorId);
+      }
     });
 
     it('can disable retries', async () => {
+      let monitorId = '';
       const maxAttempts = 1;
       const newMonitor = {
         max_attempts: maxAttempts,
@@ -586,12 +589,18 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
         locations: [privateLocations[0]],
       };
 
-      const { body: apiResponse } = await addMonitorAPI(newMonitor);
+      try {
+        const { body: apiResponse, rawBody } = await addMonitorAPI(newMonitor);
+        monitorId = rawBody.id;
 
-      rawExpect(apiResponse).toEqual(rawExpect.objectContaining({ retest_on_failure: false }));
+        rawExpect(apiResponse).toEqual(rawExpect.objectContaining({ retest_on_failure: false }));
+      } finally {
+        await deleteMonitor(monitorId);
+      }
     });
 
     it('can enable retries with max attempts', async () => {
+      let monitorId = '';
       const maxAttempts = 2;
       const newMonitor = {
         max_attempts: maxAttempts,
@@ -601,12 +610,18 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
         locations: [privateLocations[0]],
       };
 
-      const { body: apiResponse } = await addMonitorAPI(newMonitor);
+      try {
+        const { body: apiResponse, rawBody } = await addMonitorAPI(newMonitor);
+        monitorId = rawBody.id;
 
-      rawExpect(apiResponse).toEqual(rawExpect.objectContaining({ retest_on_failure: true }));
+        rawExpect(apiResponse).toEqual(rawExpect.objectContaining({ retest_on_failure: true }));
+      } finally {
+        await deleteMonitor(monitorId);
+      }
     });
 
     it('can enable retries', async () => {
+      let monitorId = '';
       const newMonitor = {
         retest_on_failure: false,
         urls: 'https://elastic.co',
@@ -615,9 +630,14 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
         locations: [privateLocations[0]],
       };
 
-      const { body: apiResponse } = await addMonitorAPI(newMonitor);
+      try {
+        const { body: apiResponse, rawBody } = await addMonitorAPI(newMonitor);
+        monitorId = rawBody.id;
 
-      rawExpect(apiResponse).toEqual(rawExpect.objectContaining({ retest_on_failure: false }));
+        rawExpect(apiResponse).toEqual(rawExpect.objectContaining({ retest_on_failure: false }));
+      } finally {
+        await deleteMonitor(monitorId);
+      }
     });
 
     it('cannot create a invalid monitor without a monitor type', async () => {


### PR DESCRIPTION
## Summary

Fixes flaky test "can create valid monitors without all defaults" in `create_monitor_private_location.ts`.

Related: #204204, #257547, #258046

**Root cause:** The "handles auto upgrading policies" test downgrades the synthetics package to v1.1.1, then in its `finally` block wraps the restoration call in a try/catch that silently swallows errors. When package restoration fails, all subsequent tests run against the wrong package version, causing `DEFAULT_FIELDS` comparison mismatches that manifest as flaky failures.

**Fix:**
- Remove the error-swallowing try/catch around `installSyntheticsPackage()` in the `finally` block. The method already uses `retry.try()` internally; failures should propagate rather than silently corrupt state for downstream tests.
- Add `try/finally` with `deleteMonitor` cleanup to 4 tests that were leaking monitors (matching the pattern already used by other tests in the same file).
- Remove misleading copy-paste comment.

**Test type:** FTR (deployment-agnostic API integration)
**Test file:** `x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/create_monitor_private_location.ts`
**Config:** `x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/stateful/oblt.stateful.config.ts`

## Checklist

- [ ] Flaky Test Runner was used on any tests changed

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->