### PR TITLE
[Observability:Streams] Fix failing query streams tests

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/query_streams/create_query_stream.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/query_streams/create_query_stream.spec.ts
@@ -16,12 +16,16 @@ import {
   enableQueryStreams,
 } from '../../fixtures/query_stream_helpers';
 
+const ROOT_STREAM_NAMES = ['logs.ecs', 'logs.otel'];
 const STREAM_NAMES_CREATED_BY_SPEC = ['logs.ecs.host-1', 'test-query-stream'];
 
 test.describe('Query streams - Create query stream', { tag: tags.stateful.classic }, () => {
-  test.beforeEach(async ({ browserAuth, kbnClient, pageObjects, esClient }) => {
+  test.beforeEach(async ({ browserAuth, kbnClient, pageObjects, esClient, apiServices }) => {
     await browserAuth.loginAsAdmin();
     await enableQueryStreams(kbnClient);
+    for (const rootStreamName of ROOT_STREAM_NAMES) {
+      await apiServices.streams.restoreDataStream(rootStreamName);
+    }
     await createRootStreamViews(esClient);
     await pageObjects.streams.gotoStreamMainPage();
   });
@@ -73,8 +77,7 @@ test.describe('Query streams - Create query stream', { tag: tags.stateful.classi
     expect(response.views![0].query).toBe(rootQueryStreamEsqlQuery);
   });
 
-  // Failing, see: https://github.com/elastic/kibana/issues/262787
-  test.skip('should create a query stream as a child of an ingest stream', async ({
+  test('should create a query stream as a child of an ingest stream', async ({
     page,
     pageObjects,
     esClient,
@@ -95,10 +98,6 @@ test.describe('Query streams - Create query stream', { tag: tags.stateful.classi
 
     // child query stream created appears in the UI
     await expect(pageObjects.streams.childQueryStreamCreatedSuccessToast).toBeVisible();
-    // Wait for query mode to be unselected before we click it
-    await expect(
-      pageObjects.streams.childStreamTypeSelector.getByTestId('queryMode')
-    ).toHaveAttribute('aria-pressed', 'false');
     await pageObjects.streams.selectChildStreamType('Query');
     await expect(
       page.getByTestId(`queryStream-${parentStreamName}.${childStreamName}`)


### PR DESCRIPTION
## Summary
We had an issue recently where [query stream tests were not being included in CI](https://github.com/elastic/kibana/pull/262748). This led to some test failures slipping through the cracks without the safety net of a CI check. This PR fixes those tests, of which there are two:
1. Creating a root query stream - failed due to the recent change of defering creating underlying data streams for root streams, I was able to fix this by restoring them
2. Creating a child query stream - a change was made to fix the Query/Index default behavior, so our previous check on the toggle was no longer needed. I fixed this test by removing that check. 

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->