### PR TITLE
[Security Solution] fix tools flyout title

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/title.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/title.tsx
@@ -25,11 +25,6 @@ export interface TitleProps {
    */
   hit: DataTableRecord;
   /**
-   * Optional boolean to render the title in a smaller font size.
-   * Should be used when the component is displayed in a tools flyout header.
-   */
-  isCompact?: boolean;
-  /**
    * Optional boolean to suppress the rule details link even when a rule ID is present.
    * Should be used when the component is displayed in a rule preview context.
    */
@@ -41,7 +36,7 @@ export interface TitleProps {
  * For alerts: shows the rule name with a warning icon, linked to the rule details page.
  * For events: shows the event title with an analyzeEvent icon.
  */
-export const Title: FC<TitleProps> = memo(({ hit, isCompact = false, hideLink = false }) => {
+export const Title: FC<TitleProps> = memo(({ hit, hideLink = false }) => {
   const { services } = useKibana();
 
   const isAlert = useMemo(
@@ -73,25 +68,12 @@ export const Title: FC<TitleProps> = memo(({ hit, isCompact = false, hideLink = 
         external={false}
         data-test-subj={TITLE_LINK_TEST_ID}
       >
-        <FlyoutTitle
-          title={title}
-          iconType={iconType}
-          isLink
-          isCompact={isCompact}
-          data-test-subj={TITLE_TEST_ID}
-        />
+        <FlyoutTitle title={title} iconType={iconType} isLink data-test-subj={TITLE_TEST_ID} />
       </EuiLink>
     );
   }
 
-  return (
-    <FlyoutTitle
-      title={title}
-      iconType={iconType}
-      isCompact={isCompact}
-      data-test-subj={TITLE_TEST_ID}
-    />
-  );
+  return <FlyoutTitle title={title} iconType={iconType} data-test-subj={TITLE_TEST_ID} />;
 });
 
 Title.displayName = 'Title';

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/flyout_title.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/flyout_title.tsx
@@ -38,11 +38,6 @@ export interface FlyoutTitleProps {
    */
   isLink?: boolean;
   /**
-   * Optional boolean to render the title in a smaller font size (`xs` instead of `s`).
-   * Should be used when the component is displayed in a tools flyout header.
-   */
-  isCompact?: boolean;
-  /**
    * Optional data test subject string
    */
   'data-test-subj'?: string;
@@ -57,7 +52,6 @@ export const FlyoutTitle: FC<FlyoutTitleProps> = memo(
     iconType,
     iconColor,
     isLink = false,
-    isCompact = false,
     'data-test-subj': dataTestSubj = 'flyoutTitle',
   }) => {
     const { euiTheme } = useEuiTheme();
@@ -80,13 +74,13 @@ export const FlyoutTitle: FC<FlyoutTitleProps> = memo(
 
     const titleComponent = useMemo(() => {
       return (
-        <EuiTitle size={isCompact ? 'xs' : 's'} data-test-subj={`${dataTestSubj}Text`}>
+        <EuiTitle size="s" data-test-subj={`${dataTestSubj}Text`}>
           <EuiTextColor color={isLink ? euiTheme.colors.textPrimary : undefined}>
             <span>{title}</span>
           </EuiTextColor>
         </EuiTitle>
       );
-    }, [dataTestSubj, isCompact, isLink, title, euiTheme.colors.textPrimary]);
+    }, [dataTestSubj, isLink, title, euiTheme.colors.textPrimary]);
 
     const linkIcon = useMemo(() => {
       return (

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/test_ids.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/test_ids.ts
@@ -36,5 +36,4 @@ export const NOTES_COUNT_TEST_ID = `${PREFIX}HeaderNotesCount` as const;
 export const NOTES_LOADING_TEST_ID = `${PREFIX}HeaderNotesLoading` as const;
 
 export const TOOLS_FLYOUT_HEADER_TEST_ID = `${PREFIX}ToolsFlyoutHeader` as const;
-export const TOOLS_FLYOUT_HEADER_EXPAND_BUTTON_TEST_ID =
-  `${PREFIX}ToolsFlyoutHeaderExpandButton` as const;
+export const TOOLS_FLYOUT_HEADER_TITLE_TEST_ID = `${PREFIX}ToolsFlyoutHeaderTitle` as const;

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/tools_flyout_header.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/tools_flyout_header.test.tsx
@@ -6,49 +6,15 @@
  */
 
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
 import type { DataTableRecord } from '@kbn/discover-utils';
 import { ToolsFlyoutHeader } from './tools_flyout_header';
-import { TOOLS_FLYOUT_HEADER_TEST_ID, TOOLS_FLYOUT_HEADER_EXPAND_BUTTON_TEST_ID } from './test_ids';
+import { TOOLS_FLYOUT_HEADER_TEST_ID } from './test_ids';
 
-const mockOpenSystemFlyout = jest.fn();
-
-jest.mock('../../../common/lib/kibana', () => ({
-  useKibana: () => ({
-    services: {
-      overlays: {
-        openSystemFlyout: mockOpenSystemFlyout,
-      },
-    },
-  }),
-}));
-
-jest.mock('react-redux', () => ({
-  ...jest.requireActual('react-redux'),
-  useStore: () => ({}),
-}));
-
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-  useHistory: () => ({ push: jest.fn() }),
-}));
-
-jest.mock('../hooks/use_default_flyout_properties', () => ({
-  useDefaultDocumentFlyoutProperties: () => ({ size: 'm' }),
-}));
-
-jest.mock('./flyout_provider', () => ({
-  flyoutProviders: jest.fn(({ children }: { children: React.ReactNode }) => children),
-}));
-
-jest.mock('../../document', () => ({
-  DocumentFlyout: () => <div data-test-subj="mockDocumentFlyout" />,
-}));
-
-jest.mock('../../document/components/title', () => ({
-  Title: ({ hit }: { hit: DataTableRecord }) => (
-    <div data-test-subj="mockTitle">{String(hit.id)}</div>
+jest.mock('./tools_flyout_title', () => ({
+  ToolsFlyoutTitle: ({ hit }: { hit: DataTableRecord }) => (
+    <div data-test-subj="mockToolsFlyoutTitle">{String(hit.id)}</div>
   ),
 }));
 
@@ -78,10 +44,6 @@ const renderHeader = (props: Partial<Parameters<typeof ToolsFlyoutHeader>[0]> = 
 };
 
 describe('<ToolsFlyoutHeader />', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
   it('should render the header container', () => {
     const { getByTestId } = renderHeader();
     expect(getByTestId(TOOLS_FLYOUT_HEADER_TEST_ID)).toBeInTheDocument();
@@ -92,20 +54,9 @@ describe('<ToolsFlyoutHeader />', () => {
     expect(getByText('Session view')).toBeInTheDocument();
   });
 
-  it('should render the expand button', () => {
+  it('should render ToolsFlyoutTitle', () => {
     const { getByTestId } = renderHeader();
-    expect(getByTestId(TOOLS_FLYOUT_HEADER_EXPAND_BUTTON_TEST_ID)).toBeInTheDocument();
-  });
-
-  it('should call openSystemFlyout when the expand button is clicked', () => {
-    const { getByTestId } = renderHeader();
-    fireEvent.click(getByTestId(TOOLS_FLYOUT_HEADER_EXPAND_BUTTON_TEST_ID));
-    expect(mockOpenSystemFlyout).toHaveBeenCalledTimes(1);
-  });
-
-  it('should render the document title', () => {
-    const { getByTestId } = renderHeader();
-    expect(getByTestId('mockTitle')).toBeInTheDocument();
+    expect(getByTestId('mockToolsFlyoutTitle')).toBeInTheDocument();
   });
 
   it('should render the document severity', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/tools_flyout_header.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/tools_flyout_header.tsx
@@ -6,29 +6,17 @@
  */
 
 import type { FC, ReactNode } from 'react';
-import React, { memo, useCallback } from 'react';
-import { EuiButtonIcon, EuiFlexGroup, EuiFlexItem, EuiTitle } from '@elastic/eui';
-import { i18n } from '@kbn/i18n';
+import React, { memo } from 'react';
+import { EuiFlexGroup, EuiFlexItem, EuiTitle } from '@elastic/eui';
 import type { DataTableRecord } from '@kbn/discover-utils';
-import { useHistory } from 'react-router-dom';
-import { useStore } from 'react-redux';
 import { Timestamp } from '../../document/components/timestamp';
-import { Title } from '../../document/components/title';
 import { DocumentSeverity } from '../../document/components/severity';
-import { useKibana } from '../../../common/lib/kibana';
 import type { CellActionRenderer } from './cell_actions';
 import { noopCellActionRenderer } from './cell_actions';
-import { flyoutProviders } from './flyout_provider';
-import { DocumentFlyout } from '../../document';
-import { useDefaultDocumentFlyoutProperties } from '../hooks/use_default_flyout_properties';
-import { TOOLS_FLYOUT_HEADER_EXPAND_BUTTON_TEST_ID, TOOLS_FLYOUT_HEADER_TEST_ID } from './test_ids';
+import { ToolsFlyoutTitle } from './tools_flyout_title';
+import { TOOLS_FLYOUT_HEADER_TEST_ID } from './test_ids';
 
 const noop = () => {};
-
-const EXPAND_BUTTON_ARIA_LABEL = i18n.translate(
-  'xpack.securitySolution.flyout.toolsFlyoutHeader.expandButtonAriaLabel',
-  { defaultMessage: 'Open document details' }
-);
 
 export interface ToolsFlyoutHeaderProps {
   /**
@@ -55,29 +43,6 @@ export interface ToolsFlyoutHeaderProps {
  */
 export const ToolsFlyoutHeader: FC<ToolsFlyoutHeaderProps> = memo(
   ({ hit, title, renderCellActions = noopCellActionRenderer, onAlertUpdated = noop }) => {
-    const { services } = useKibana();
-    const store = useStore();
-    const history = useHistory();
-    const defaultFlyoutProperties = useDefaultDocumentFlyoutProperties();
-
-    const onShowDocument = useCallback(() => {
-      services.overlays?.openSystemFlyout(
-        flyoutProviders({
-          services,
-          store,
-          history,
-          children: (
-            <DocumentFlyout
-              hit={hit}
-              renderCellActions={renderCellActions}
-              onAlertUpdated={onAlertUpdated}
-            />
-          ),
-        }),
-        { ...defaultFlyoutProperties, session: 'inherit' }
-      );
-    }, [defaultFlyoutProperties, history, hit, onAlertUpdated, renderCellActions, services, store]);
-
     return (
       <EuiFlexGroup
         justifyContent="spaceBetween"
@@ -92,21 +57,15 @@ export const ToolsFlyoutHeader: FC<ToolsFlyoutHeaderProps> = memo(
           </EuiTitle>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiFlexGroup alignItems="flexEnd" direction="column" gutterSize="xs">
+          <EuiFlexGroup alignItems="flexEnd" direction="column" gutterSize="none">
             <EuiFlexItem>
-              <EuiFlexGroup alignItems="center" gutterSize="m" responsive={false} wrap={false}>
+              <EuiFlexGroup alignItems="center" gutterSize="xs" responsive={false} wrap={false}>
                 <EuiFlexItem grow={false}>
-                  <EuiButtonIcon
-                    iconType="expand"
-                    onClick={onShowDocument}
-                    aria-label={EXPAND_BUTTON_ARIA_LABEL}
-                    size="xs"
-                    color="primary"
-                    data-test-subj={TOOLS_FLYOUT_HEADER_EXPAND_BUTTON_TEST_ID}
+                  <ToolsFlyoutTitle
+                    hit={hit}
+                    renderCellActions={renderCellActions}
+                    onAlertUpdated={onAlertUpdated}
                   />
-                </EuiFlexItem>
-                <EuiFlexItem grow={false}>
-                  <Title hit={hit} isCompact={true} />
                 </EuiFlexItem>
                 <EuiFlexItem grow={false}>
                   <DocumentSeverity hit={hit} />

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/tools_flyout_title.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/tools_flyout_title.test.tsx
@@ -1,0 +1,89 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import type { DataTableRecord } from '@kbn/discover-utils';
+import { ToolsFlyoutTitle } from './tools_flyout_title';
+import { TOOLS_FLYOUT_HEADER_TITLE_TEST_ID } from './test_ids';
+
+const mockOpenSystemFlyout = jest.fn();
+
+jest.mock('../../../common/lib/kibana', () => ({
+  useKibana: () => ({
+    services: {
+      overlays: {
+        openSystemFlyout: mockOpenSystemFlyout,
+      },
+    },
+  }),
+}));
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useStore: () => ({}),
+}));
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useHistory: () => ({ push: jest.fn() }),
+}));
+
+jest.mock('../hooks/use_default_flyout_properties', () => ({
+  useDefaultDocumentFlyoutProperties: () => ({ size: 'm' }),
+}));
+
+jest.mock('./flyout_provider', () => ({
+  flyoutProviders: jest.fn(({ children }: { children: React.ReactNode }) => children),
+}));
+
+jest.mock('../../document', () => ({
+  DocumentFlyout: () => <div data-test-subj="mockDocumentFlyout" />,
+}));
+
+const createMockHit = (flattened: DataTableRecord['flattened']): DataTableRecord =>
+  ({
+    id: '1',
+    raw: {},
+    flattened,
+    isAnchor: false,
+  } as DataTableRecord);
+
+const alertHit = createMockHit({
+  'event.kind': 'signal',
+  'kibana.alert.rule.name': 'Test Rule Name',
+});
+
+const eventHit = createMockHit({
+  'event.kind': 'event',
+  'event.category': 'process',
+  'process.name': 'test-process',
+});
+
+const renderToolsFlyoutTitle = (hit: DataTableRecord) => render(<ToolsFlyoutTitle hit={hit} />);
+
+describe('<ToolsFlyoutTitle />', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render the alert title', () => {
+    const { getByTestId } = renderToolsFlyoutTitle(alertHit);
+    expect(getByTestId(TOOLS_FLYOUT_HEADER_TITLE_TEST_ID)).toHaveTextContent('Test Rule Name');
+  });
+
+  it('should render the event title', () => {
+    const { getByTestId } = renderToolsFlyoutTitle(eventHit);
+    expect(getByTestId(TOOLS_FLYOUT_HEADER_TITLE_TEST_ID)).toHaveTextContent('test-process');
+  });
+
+  it('should open the document flyout when clicked', () => {
+    const { getByTestId } = renderToolsFlyoutTitle(alertHit);
+    fireEvent.click(getByTestId(TOOLS_FLYOUT_HEADER_TITLE_TEST_ID));
+    expect(mockOpenSystemFlyout).toHaveBeenCalledTimes(1);
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/tools_flyout_title.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/tools_flyout_title.tsx
@@ -1,0 +1,100 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FC } from 'react';
+import React, { memo, useCallback, useMemo } from 'react';
+import { EuiButtonEmpty, EuiIcon, useEuiTheme } from '@elastic/eui';
+import type { DataTableRecord } from '@kbn/discover-utils';
+import { getFieldValue } from '@kbn/discover-utils';
+import { EVENT_KIND } from '@kbn/rule-data-utils';
+import { useHistory } from 'react-router-dom';
+import { useStore } from 'react-redux';
+import { EventKind } from '../../document/constants/event_kinds';
+import { getDocumentTitle } from '../../document/utils/get_header_title';
+import { useKibana } from '../../../common/lib/kibana';
+import type { CellActionRenderer } from './cell_actions';
+import { noopCellActionRenderer } from './cell_actions';
+import { flyoutProviders } from './flyout_provider';
+import { DocumentFlyout } from '../../document';
+import { useDefaultDocumentFlyoutProperties } from '../hooks/use_default_flyout_properties';
+import { TOOLS_FLYOUT_HEADER_TITLE_TEST_ID } from './test_ids';
+
+const noop = () => {};
+
+export interface ToolsFlyoutTitleProps {
+  /**
+   * The document to display
+   */
+  hit: DataTableRecord;
+  /**
+   * Optional cell action renderer passed to the document flyout.
+   */
+  renderCellActions?: CellActionRenderer;
+  /**
+   * Optional callback invoked after alert mutations in the document flyout.
+   */
+  onAlertUpdated?: () => void;
+}
+
+/**
+ * Clickable title used in tools flyout headers. Renders an expand icon followed by the
+ * document type icon and title. Clicking any part of the component opens the document flyout.
+ */
+export const ToolsFlyoutTitle: FC<ToolsFlyoutTitleProps> = memo(
+  ({ hit, renderCellActions = noopCellActionRenderer, onAlertUpdated = noop }) => {
+    const { euiTheme } = useEuiTheme();
+    const { services } = useKibana();
+    const store = useStore();
+    const history = useHistory();
+    const defaultFlyoutProperties = useDefaultDocumentFlyoutProperties();
+
+    const isAlert = useMemo(
+      () => (getFieldValue(hit, EVENT_KIND) as string) === EventKind.signal,
+      [hit]
+    );
+    const title = useMemo(() => getDocumentTitle(hit), [hit]);
+    const iconType = isAlert ? 'warning' : 'analyzeEvent';
+
+    const onShowDocument = useCallback(() => {
+      services.overlays?.openSystemFlyout(
+        flyoutProviders({
+          services,
+          store,
+          history,
+          children: (
+            <DocumentFlyout
+              hit={hit}
+              renderCellActions={renderCellActions}
+              onAlertUpdated={onAlertUpdated}
+            />
+          ),
+        }),
+        { ...defaultFlyoutProperties, session: 'inherit' }
+      );
+    }, [defaultFlyoutProperties, history, hit, onAlertUpdated, renderCellActions, services, store]);
+
+    return (
+      <EuiButtonEmpty
+        onClick={onShowDocument}
+        iconType="expand"
+        size="s"
+        flush="left"
+        data-test-subj={TOOLS_FLYOUT_HEADER_TITLE_TEST_ID}
+      >
+        <EuiIcon
+          type={iconType}
+          size="m"
+          aria-hidden={true}
+          css={{ marginRight: euiTheme.size.xs }}
+        />
+        {title}
+      </EuiButtonEmpty>
+    );
+  }
+);
+
+ToolsFlyoutTitle.displayName = 'ToolsFlyoutTitle';


### PR DESCRIPTION
## Summary

This PR changes the behavior of the title in all our tools flyout (behavior introduced in this previous [PR](https://github.com/elastic/kibana/pull/261443)). I had misunderstood the requirements:
- we should not be showing the icon to the right of the rule name
- when clicked, we should not navigate to the rule details page, instead we should just open the child flyout (which I had applied only to the most left expand icon)

The PR combines the expand icon, the other icon and the title into a single button. The text will always be blue, both icon to the left will always be shown.

> [!NOTE]
> Do not pay attention to the different sections not perfectly vertically aligned in the tools flyout header. I have a follow up PR that takes care of that alongside other spaces/padding/margin fixes. I didn't want to increase the scope of this current PR.

### Previous behavior

Uploading Screen Recording 2026-04-14 at 1.09.05 PM.mov…

### New behavior

https://github.com/user-attachments/assets/aa28fe19-9698-4fe6-b6ca-da183db1f6e5

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->