### PR TITLE
[Security Solution] fix various spaces in the new flyout

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/prevalence_details.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/prevalence_details.tsx
@@ -7,7 +7,7 @@
 
 import React, { useMemo } from 'react';
 import type { EuiBasicTableColumn } from '@elastic/eui';
-import { EuiFlexGroup, EuiFlexItem, EuiText } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiPanel, EuiText } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { buildDataTableRecord, type EsHitRecord } from '@kbn/discover-utils';
 import {
@@ -86,12 +86,14 @@ export const PrevalenceDetails: React.FC = () => {
   const hit = useMemo(() => buildDataTableRecord(searchHit as EsHitRecord), [searchHit]);
 
   return (
-    <PrevalenceDetailsView
-      hit={hit}
-      investigationFields={investigationFields}
-      scopeId={scopeId}
-      columns={columns}
-    />
+    <EuiPanel hasBorder={false} hasShadow={false}>
+      <PrevalenceDetailsView
+        hit={hit}
+        investigationFields={investigationFields}
+        scopeId={scopeId}
+        columns={columns}
+      />
+    </EuiPanel>
   );
 };
 

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/alert_header_title.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/alert_header_title.tsx
@@ -79,10 +79,12 @@ export const AlertHeaderTitle = memo(() => {
 
   return (
     <>
-      <DocumentSeverity hit={hit} />
-      <EuiSpacer size="m" />
-      <Timestamp hit={hit} />
-      <EuiSpacer size="xs" />
+      <DocumentSeverity hit={hit}>
+        <EuiSpacer size="m" />
+      </DocumentSeverity>
+      <Timestamp hit={hit}>
+        <EuiSpacer size="xs" />
+      </Timestamp>
       <Title hit={hit} hideLink={isRulePreview} />
       <EuiSpacer size="m" />
       <EuiFlexGroup

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/event_header_title.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/event_header_title.tsx
@@ -8,10 +8,8 @@
 import React, { memo, useMemo } from 'react';
 import { EuiSpacer } from '@elastic/eui';
 import { buildDataTableRecord, type EsHitRecord } from '@kbn/discover-utils';
-import { getFieldValue } from '@kbn/discover-utils';
-import { TIMESTAMP } from '@kbn/rule-data-utils';
+import { Timestamp } from '../../../../flyout_v2/document/components/timestamp';
 import { useDocumentDetailsContext } from '../../shared/context';
-import { PreferenceFormattedDate } from '../../../../common/components/formatted_date';
 import { DocumentSeverity } from '../../../../flyout_v2/document/components/severity';
 import { FlyoutTitle } from '../../../../flyout_v2/shared/components/flyout_title';
 import { getDocumentTitle } from '../../../../flyout_v2/document/utils/get_header_title';
@@ -24,14 +22,15 @@ export const EventHeaderTitle = memo(() => {
   const { searchHit } = useDocumentDetailsContext();
   const hit = useMemo(() => buildDataTableRecord(searchHit as EsHitRecord), [searchHit]);
   const title = useMemo(() => getDocumentTitle(hit), [hit]);
-  const timestamp = useMemo(() => getFieldValue(hit, TIMESTAMP) as string, [hit]);
 
   return (
     <>
-      <DocumentSeverity hit={hit} />
-      <EuiSpacer size="m" />
-      {timestamp && <PreferenceFormattedDate value={new Date(timestamp)} />}
-      <EuiSpacer size="xs" />
+      <DocumentSeverity hit={hit}>
+        <EuiSpacer size="m" />
+      </DocumentSeverity>
+      <Timestamp hit={hit}>
+        <EuiSpacer size="xs" />
+      </Timestamp>
       <FlyoutTitle title={title} iconType={'analyzeEvent'} data-test-subj={EVENT_TITLE_TEST_ID} />
     </>
   );

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/analyzer/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/analyzer/index.tsx
@@ -70,7 +70,7 @@ export const AnalyzerGraph = memo(
         <EuiFlyoutHeader
           hasBorder
           css={css`
-            padding-block-end: ${euiTheme.size.m} !important;
+            padding-block: ${euiTheme.size.s} !important;
           `}
         >
           <ToolsFlyoutHeader

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/correlations/components/correlations_details_view.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/correlations/components/correlations_details_view.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { memo, useMemo } from 'react';
-import { EuiFlexGroup, EuiFlexItem, EuiPanel } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import type { DataTableRecord } from '@kbn/discover-utils';
 import type { EcsSecurityExtension as Ecs } from '@kbn/securitysolution-ecs';
@@ -99,7 +99,7 @@ export const CorrelationsDetailsView = memo(
       showSuppressedAlerts;
 
     return (
-      <EuiPanel color="transparent">
+      <>
         {canShowAtLeastOneInsight ? (
           <EuiFlexGroup gutterSize="l" direction="column">
             {showSuppressedAlerts && (
@@ -165,7 +165,7 @@ export const CorrelationsDetailsView = memo(
             defaultMessage="No correlations data available."
           />
         )}
-      </EuiPanel>
+      </>
     );
   }
 );

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/correlations/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/correlations/index.tsx
@@ -67,7 +67,7 @@ export const CorrelationsDetails = memo(
         <EuiFlyoutHeader
           hasBorder
           css={css`
-            padding-block-end: ${euiTheme.size.m} !important;
+            padding-block: ${euiTheme.size.s} !important;
           `}
         >
           <ToolsFlyoutHeader hit={hit} title={TITLE} />

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/insights_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/insights_section.tsx
@@ -26,7 +26,7 @@ import { useExpandSection } from '../../shared/hooks/use_expand_section';
 import { ThreatIntelligenceOverview } from './threat_intelligence_overview';
 import { CorrelationsOverview } from './correlations_overview';
 import { PrevalenceOverview } from './prevalence_overview';
-import { PrevalenceDetails } from '../../prevalence/prevalence';
+import { PrevalenceDetails } from '../../prevalence';
 import { flyoutProviders } from '../../shared/components/flyout_provider';
 import { useIsInSecurityApp } from '../../../common/hooks/is_in_security_app';
 import { CorrelationsDetails } from '../../correlations';

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/severity.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/severity.test.tsx
@@ -78,4 +78,32 @@ describe('<DocumentSeverity />', () => {
 
     expect(container).toBeEmptyDOMElement();
   });
+
+  it('should render children after the badge', () => {
+    const hit = createMockHit({ 'kibana.alert.severity': 'low' });
+
+    const { getByText } = render(
+      <TestProviders>
+        <DocumentSeverity hit={hit}>
+          <div>{'test'}</div>
+        </DocumentSeverity>
+      </TestProviders>
+    );
+
+    expect(getByText('test')).toBeInTheDocument();
+  });
+
+  it('should not render children when severity is absent', () => {
+    const hit = createMockHit({});
+
+    const { queryByText } = render(
+      <TestProviders>
+        <DocumentSeverity hit={hit}>
+          <div>{'test'}</div>
+        </DocumentSeverity>
+      </TestProviders>
+    );
+
+    expect(queryByText('test')).not.toBeInTheDocument();
+  });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/severity.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/severity.tsx
@@ -6,12 +6,13 @@
  */
 
 import React, { memo, useMemo } from 'react';
+import type { ReactNode } from 'react';
 import type { DataTableRecord } from '@kbn/discover-utils';
 import { getFieldValue } from '@kbn/discover-utils';
 import { ALERT_SEVERITY } from '@kbn/rule-data-utils';
 import type { Severity } from '@kbn/securitysolution-io-ts-alerting-types';
 import { upperFirst } from 'lodash/fp';
-import { EuiBadge, EuiSpacer, useEuiTheme } from '@elastic/eui';
+import { EuiBadge, useEuiTheme } from '@elastic/eui';
 import { SEVERITY_VALUE_TEST_ID } from './test_ids';
 import { useRiskSeverityColors } from '../../../common/utils/risk_color_palette';
 
@@ -25,12 +26,17 @@ export interface DocumentSeverityProps {
    * The document to display
    */
   hit: DataTableRecord;
+  /**
+   * Optional content rendered after the badge (e.g. a spacer).
+   * When omitted nothing is rendered after the badge.
+   */
+  children?: ReactNode;
 }
 
 /**
  * Document details severity displayed in flyout right section header
  */
-export const DocumentSeverity = memo(({ hit }: DocumentSeverityProps) => {
+export const DocumentSeverity = memo(({ hit, children }: DocumentSeverityProps) => {
   const { euiTheme } = useEuiTheme();
 
   const severityToColorMap = useRiskSeverityColors();
@@ -74,7 +80,7 @@ export const DocumentSeverity = memo(({ hit }: DocumentSeverityProps) => {
           <EuiBadge color={color} data-test-subj={SEVERITY_VALUE_TEST_ID}>
             {displayValue}
           </EuiBadge>
-          <EuiSpacer size="m" />
+          {children}
         </>
       )}
     </>

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/timestamp.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/timestamp.test.tsx
@@ -45,4 +45,32 @@ describe('<Timestamp />', () => {
 
     expect(container).toBeEmptyDOMElement();
   });
+
+  it('should render children after the timestamp', () => {
+    const hit = createMockHit({ '@timestamp': '2024-01-15T10:30:00.000Z' });
+
+    const { getByText } = render(
+      <TestProviders>
+        <Timestamp hit={hit}>
+          <div>{'test'}</div>
+        </Timestamp>
+      </TestProviders>
+    );
+
+    expect(getByText('test')).toBeInTheDocument();
+  });
+
+  it('should not render children when timestamp is absent', () => {
+    const hit = createMockHit({});
+
+    const { queryByText } = render(
+      <TestProviders>
+        <Timestamp hit={hit}>
+          <div>{'test'}</div>
+        </Timestamp>
+      </TestProviders>
+    );
+
+    expect(queryByText('test')).not.toBeInTheDocument();
+  });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/timestamp.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/timestamp.tsx
@@ -6,10 +6,10 @@
  */
 
 import React, { memo, useMemo } from 'react';
+import type { ReactNode } from 'react';
 import type { DataTableRecord } from '@kbn/discover-utils';
 import { getFieldValue } from '@kbn/discover-utils';
 import { TIMESTAMP } from '@kbn/rule-data-utils';
-import { EuiSpacer } from '@elastic/eui';
 import { PreferenceFormattedDate } from '../../../common/components/formatted_date';
 import { TIMESTAMP_TEST_ID } from './test_ids';
 
@@ -18,12 +18,17 @@ export interface DocumentTimestampProps {
    * The document to display
    */
   hit: DataTableRecord;
+  /**
+   * Optional content rendered after the formatted date (e.g. a spacer).
+   * When omitted nothing is rendered after the date.
+   */
+  children?: ReactNode;
 }
 
 /**
  * Renders the document timestamp as a formatted date, or nothing if absent.
  */
-export const Timestamp = memo(({ hit }: DocumentTimestampProps) => {
+export const Timestamp = memo(({ hit, children }: DocumentTimestampProps) => {
   const timestamp = useMemo(() => getFieldValue(hit, TIMESTAMP) as string, [hit]);
 
   if (!timestamp) return null;
@@ -31,7 +36,7 @@ export const Timestamp = memo(({ hit }: DocumentTimestampProps) => {
   return (
     <>
       <PreferenceFormattedDate value={new Date(timestamp)} data-test-subj={TIMESTAMP_TEST_ID} />
-      <EuiSpacer size="xs" />
+      {children}
     </>
   );
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/header.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/header.tsx
@@ -57,8 +57,12 @@ export const Header: FC<HeaderProps> = memo(
 
     return (
       <>
-        <DocumentSeverity hit={hit} />
-        <Timestamp hit={hit} />
+        <DocumentSeverity hit={hit}>
+          <EuiSpacer size="m" />
+        </DocumentSeverity>
+        <Timestamp hit={hit}>
+          <EuiSpacer size="xs" />
+        </Timestamp>
         <Title hit={hit} />
         {isAlert && (
           <>

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/investigation_guide/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/investigation_guide/index.tsx
@@ -60,7 +60,7 @@ export const InvestigationGuide = memo(({ hit }: InvestigationGuideProps) => {
       <EuiFlyoutHeader
         hasBorder
         css={css`
-          padding-block-end: ${euiTheme.size.m} !important;
+          padding-block: ${euiTheme.size.s} !important;
         `}
       >
         <ToolsFlyoutHeader hit={hit} title={TITLE} />

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/notes/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/notes/index.tsx
@@ -8,7 +8,7 @@
 import { css } from '@emotion/react';
 import React, { memo } from 'react';
 import type { DataTableRecord } from '@kbn/discover-utils';
-import { EuiFlyoutBody, EuiFlyoutHeader, EuiPanel, useEuiTheme } from '@elastic/eui';
+import { EuiFlyoutBody, EuiFlyoutHeader, useEuiTheme } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { useSelector } from 'react-redux';
 import { ToolsFlyoutHeader } from '../shared/components/tools_flyout_header';
@@ -57,19 +57,17 @@ export const NotesDetails = memo(({ hit }: NotesDetailsProps) => {
       <EuiFlyoutHeader
         hasBorder
         css={css`
-          padding-block-end: ${euiTheme.size.m} !important;
+          padding-block: ${euiTheme.size.s} !important;
         `}
       >
         <ToolsFlyoutHeader hit={hit} title={TITLE} />
       </EuiFlyoutHeader>
-      <EuiFlyoutBody>
-        <EuiPanel data-test-subj={NOTES_DETAILS_TEST_ID} hasBorder={false} hasShadow={false}>
-          <NotesDetailsContent
-            hit={hit}
-            timelineConfig={timelineConfig}
-            hideTimelineIcon={!isInSecurityApp}
-          />
-        </EuiPanel>
+      <EuiFlyoutBody data-test-subj={NOTES_DETAILS_TEST_ID}>
+        <NotesDetailsContent
+          hit={hit}
+          timelineConfig={timelineConfig}
+          hideTimelineIcon={!isInSecurityApp}
+        />
       </EuiFlyoutBody>
     </>
   );

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/prevalence/components/prevalence_details_view.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/prevalence/components/prevalence_details_view.tsx
@@ -16,7 +16,6 @@ import {
   EuiFlexItem,
   EuiInMemoryTable,
   EuiLink,
-  EuiPanel,
   EuiSpacer,
   EuiSuperDatePicker,
 } from '@elastic/eui';
@@ -257,35 +256,30 @@ export const PrevalenceDetailsView: React.FC<PrevalenceDetailsViewProps> = ({
   return (
     <>
       {!error && !isPlatinumPlus && upsell}
-      <EuiPanel>
-        {!isServerless && !isColdFrozenTierCalloutDismissed && coldFrozenTierCallout}
-        <EuiSuperDatePicker
-          start={start}
-          end={end}
-          onTimeChange={onTimeChange}
-          data-test-subj={PREVALENCE_DETAILS_DATE_PICKER_TEST_ID}
-          width="full"
-        />
-        <EuiSpacer size="m" />
-        <EuiInMemoryTable
-          items={error ? [] : items}
-          columns={columns}
-          loading={loading}
-          data-test-subj={PREVALENCE_DETAILS_TABLE_TEST_ID}
-          tableCaption={i18n.translate(
-            'xpack.securitySolution.flyout.prevalence.prevalenceCaption',
-            {
-              defaultMessage: 'Prevalence insights',
-            }
-          )}
-          noItemsMessage={
-            <FormattedMessage
-              id="xpack.securitySolution.flyout.prevalence.noDataDescription"
-              defaultMessage="No prevalence data available."
-            />
-          }
-        />
-      </EuiPanel>
+      {!isServerless && !isColdFrozenTierCalloutDismissed && coldFrozenTierCallout}
+      <EuiSuperDatePicker
+        start={start}
+        end={end}
+        onTimeChange={onTimeChange}
+        data-test-subj={PREVALENCE_DETAILS_DATE_PICKER_TEST_ID}
+        width="full"
+      />
+      <EuiSpacer size="m" />
+      <EuiInMemoryTable
+        items={error ? [] : items}
+        columns={columns}
+        loading={loading}
+        data-test-subj={PREVALENCE_DETAILS_TABLE_TEST_ID}
+        tableCaption={i18n.translate('xpack.securitySolution.flyout.prevalence.prevalenceCaption', {
+          defaultMessage: 'Prevalence insights',
+        })}
+        noItemsMessage={
+          <FormattedMessage
+            id="xpack.securitySolution.flyout.prevalence.noDataDescription"
+            defaultMessage="No prevalence data available."
+          />
+        }
+      />
     </>
   );
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/prevalence/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/prevalence/index.test.tsx
@@ -8,7 +8,7 @@
 import { fireEvent, render } from '@testing-library/react';
 import React from 'react';
 import { buildDataTableRecord, type EsHitRecord } from '@kbn/discover-utils';
-import { PrevalenceDetails } from './prevalence';
+import { PrevalenceDetails } from '.';
 import { resetColdFrozenTierCalloutDismissedStateForTests } from './components/prevalence_details_view';
 import {
   PREVALENCE_DETAILS_COLD_FROZEN_TIER_CALLOUT_DISMISS_BUTTON_TEST_ID,

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/prevalence/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/prevalence/index.tsx
@@ -54,7 +54,7 @@ export const PrevalenceDetails: React.FC<PrevalenceDetailsProps> = ({
       <EuiFlyoutHeader
         hasBorder
         css={css`
-          padding-block-end: ${euiTheme.size.m} !important;
+          padding-block: ${euiTheme.size.s} !important;
         `}
       >
         <ToolsFlyoutHeader hit={hit} title={TITLE} />

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/session_view/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/session_view/index.tsx
@@ -208,7 +208,7 @@ export const SessionView: FC<SessionViewProps> = memo(
         <EuiFlyoutHeader
           hasBorder
           css={css`
-            padding-block-end: ${euiTheme.size.m} !important;
+            padding-block: ${euiTheme.size.s} !important;
           `}
         >
           <ToolsFlyoutHeader

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/hooks/use_default_flyout_properties.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/hooks/use_default_flyout_properties.ts
@@ -19,6 +19,7 @@ export const useDefaultDocumentFlyoutProperties = (): OverlaySystemFlyoutOpenOpt
     maxWidth: euiTheme.breakpoint.xl,
     minWidth: euiTheme.base * 24,
     ownFocus: false,
+    paddingSize: 'm',
     resizable: true,
     size: 's',
   };
@@ -29,6 +30,7 @@ export const useDefaultDocumentFlyoutProperties = (): OverlaySystemFlyoutOpenOpt
  */
 export const defaultToolsFlyoutProperties: OverlaySystemFlyoutOpenOptions = {
   ownFocus: false,
+  paddingSize: 'm',
   resizable: true,
   size: 'm',
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/threat_intelligence/components/threat_intelligence_details_view.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/threat_intelligence/components/threat_intelligence_details_view.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { memo } from 'react';
-import { EuiHorizontalRule, EuiPanel, EuiSpacer } from '@elastic/eui';
+import { EuiHorizontalRule, EuiSpacer } from '@elastic/eui';
 import { groupBy, isEmpty } from 'lodash';
 import type { DataTableRecord } from '@kbn/discover-utils';
 import { EnrichmentSection } from './threat_details_view_enrichment_section';
@@ -55,7 +55,7 @@ export const ThreatIntelligenceDetailsView = memo(({ hit }: ThreatIntelligenceDe
   }
 
   return (
-    <EuiPanel hasShadow={false} hasBorder={false}>
+    <>
       <EnrichmentSection
         dataTestSubj={THREAT_INTELLIGENCE_DETAILS_ENRICHMENTS_TEST_ID}
         enrichments={indicatorMatches}
@@ -91,7 +91,7 @@ export const ThreatIntelligenceDetailsView = memo(({ hit }: ThreatIntelligenceDe
           />
         </>
       ) : null}
-    </EuiPanel>
+    </>
   );
 });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/threat_intelligence/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/threat_intelligence/index.tsx
@@ -37,7 +37,7 @@ export const ThreatIntelligenceDetails = memo(({ hit }: ThreatIntelligenceDetail
       <EuiFlyoutHeader
         hasBorder
         css={css`
-          padding-block-end: ${euiTheme.size.m} !important;
+          padding-block: ${euiTheme.size.s} !important;
         `}
       >
         <ToolsFlyoutHeader hit={hit} title={TITLE} />


### PR DESCRIPTION
## Summary

This PR makes various small UI improvements to the new flyout, mostly wrong spaces and unwanted EuiPanel:

### Code changes

- remove unwanted `EuiPanel` in the `PrevalenceDetails`, `CorrelationsDetails`, `NotesDetails` and `ThreatIntelligenceDetails` components used in the new tools flyout (and add necessary changes to the old flyout to keep identical UI there)
- change `EuiFlyoutHeader` padding for all tools flyout to better match the mocks
- set default padding for all flyouts to `m` to mimick what Discover does (and follow more closely mocks)
- fix spacing in the tools flyout header to be vertically correctly aligned and have correct padding/spacing 

One extra change for file name consistency:
- rename `prevalence.tsx` to `index.tsx` to match other tools flyouts folder and file structure

### UI changes

#### Old remains untouched

https://github.com/user-attachments/assets/01759f78-a835-4e79-a116-c5f7258bef2c

#### Changes for the new flyout

Document flyout

| Before | After |
| ------------- | ------------- |
| <img width="425" height="893" alt="Screenshot 2026-04-15 at 12 25 13 AM" src="https://github.com/user-attachments/assets/1314d9bb-58dc-47f8-b75d-3bf86680f66e" /> | <img width="433" height="897" alt="Screenshot 2026-04-15 at 12 21 54 AM" src="https://github.com/user-attachments/assets/aba2b3e4-bdfc-469b-945e-a2e2acd15ddf" /> |

Notes

| Before | After |
| ------------- | ------------- |
| <img width="855" height="648" alt="Screenshot 2026-04-15 at 12 25 20 AM" src="https://github.com/user-attachments/assets/cc0ce4f6-9615-4c1e-ac22-b56256d15407" /> | <img width="857" height="620" alt="Screenshot 2026-04-15 at 12 22 03 AM" src="https://github.com/user-attachments/assets/bb0f7eff-2308-472f-9880-aa18cac4e2f1" /> |

Investigation guide

| Before | After |
| ------------- | ------------- |
| <img width="858" height="706" alt="Screenshot 2026-04-15 at 12 25 31 AM" src="https://github.com/user-attachments/assets/704b6601-25cf-42e0-bc76-17771fb7cab1" /> | <img width="863" height="678" alt="Screenshot 2026-04-15 at 12 22 12 AM" src="https://github.com/user-attachments/assets/8d998bd1-edab-41ab-94ab-2fbdd84a7f00" /> |

Analyzer

| Before | After |
| ------------- | ------------- |
| <img width="855" height="618" alt="Screenshot 2026-04-15 at 12 25 43 AM" src="https://github.com/user-attachments/assets/02262d48-8851-469c-a022-5fa89d096418" /> | <img width="856" height="668" alt="Screenshot 2026-04-15 at 12 22 22 AM" src="https://github.com/user-attachments/assets/826e5310-9d67-4d86-ad92-8162321e7f15" /> |

Prevalence

| Before | After |
| ------------- | ------------- |
| <img width="860" height="778" alt="Screenshot 2026-04-15 at 12 26 12 AM" src="https://github.com/user-attachments/assets/761cf6c2-443c-45a2-b33b-4a5d4e375e3d" /> | <img width="859" height="778" alt="Screenshot 2026-04-15 at 12 22 54 AM" src="https://github.com/user-attachments/assets/38db6e88-f679-4cac-80c3-b8a530c31071" /> |

Correlations

| Before | After |
| ------------- | ------------- |
| <img width="859" height="784" alt="Screenshot 2026-04-15 at 12 26 03 AM" src="https://github.com/user-attachments/assets/b0f80ff7-cca2-4666-8150-5f29f12662ce" /> | <img width="855" height="804" alt="Screenshot 2026-04-15 at 12 22 42 AM" src="https://github.com/user-attachments/assets/ebc63e10-555f-4cdb-9293-f51bc46ea488" /> |

Threat Intelligence

| Before | After |
| ------------- | ------------- |
| <img width="855" height="510" alt="Screenshot 2026-04-15 at 12 25 54 AM" src="https://github.com/user-attachments/assets/8ce1057b-e255-4900-bbc3-96ef23b0c8d2" /> | <img width="858" height="504" alt="Screenshot 2026-04-15 at 12 22 31 AM" src="https://github.com/user-attachments/assets/88ee83f9-94d3-4fe6-b178-25c82b4ebf52" /> |

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->