### PR TITLE
[9.4] [Agent Builder] Agent Customizations Optimistic Updates (#260821)

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/plugins/agent_plugins.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/plugins/agent_plugins.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useMemo, useState, useEffect, useRef, useCallback } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import {
   EuiBadge,
@@ -23,7 +23,6 @@ import {
   EuiTitle,
 } from '@elastic/eui';
 import type { PluginDefinition } from '@kbn/agent-builder-common';
-import { useMutation, useQueryClient } from '@kbn/react-query';
 import { useQueryState } from '../../../hooks/use_query_state';
 import { searchParamNames } from '../../../search_param_names';
 import { labels } from '../../../utils/i18n';
@@ -31,9 +30,6 @@ import { appPaths } from '../../../utils/app_paths';
 import { useNavigation } from '../../../hooks/use_navigation';
 import { usePluginsService } from '../../../hooks/plugins/use_plugins';
 import { useAgentBuilderAgentById } from '../../../hooks/agents/use_agent_by_id';
-import { useAgentBuilderServices } from '../../../hooks/use_agent_builder_service';
-import { useToasts } from '../../../hooks/use_toasts';
-import { queryKeys } from '../../../query_keys';
 import { useFlyoutState } from '../../../hooks/use_flyout_state';
 import { ActiveItemRow } from '../common/active_item_row';
 import { PluginLibraryPanel } from './plugin_library_panel';
@@ -42,14 +38,12 @@ import { InstallPluginFlyout } from './install_plugin_flyout';
 import { PageWrapper } from '../common/page_wrapper';
 import { useListDetailPageStyles } from '../common/styles';
 import { useCanEditAgent } from '../../../hooks/agents/use_can_edit_agent';
+import { usePluginsMutation } from './use_plugins_mutation';
 
 export const AgentPlugins: React.FC = () => {
   const { agentId } = useParams<{ agentId: string }>();
   const styles = useListDetailPageStyles();
   const { createAgentBuilderUrl } = useNavigation();
-  const { agentService } = useAgentBuilderServices();
-  const { addSuccessToast, addErrorToast } = useToasts();
-  const queryClient = useQueryClient();
 
   const { agent, isLoading: agentLoading } = useAgentBuilderAgentById(agentId);
   const { plugins: allPlugins, isLoading: pluginsLoading } = usePluginsService();
@@ -59,7 +53,7 @@ export const AgentPlugins: React.FC = () => {
   const [selectedPluginId, setSelectedPluginId] = useQueryState<string>(searchParamNames.pluginId);
   const pendingSelectPluginIdRef = useRef<string | null>(null);
   const [isAddMenuOpen, setIsAddMenuOpen] = useState(false);
-  const [mutatingPluginId, setMutatingPluginId] = useState<string | null>(null);
+  const { handleAddPlugin, handleRemovePlugin } = usePluginsMutation({ agent });
   const {
     isOpen: isLibraryOpen,
     openFlyout: openLibrary,
@@ -113,6 +107,7 @@ export const AgentPlugins: React.FC = () => {
   useEffect(() => {
     if (agentLoading || pluginsLoading) return;
 
+    // When a newly added plugin is pending to be selected. Once it is active, select it.
     if (pendingSelectPluginIdRef.current) {
       const pendingInActive = activePlugins.some((p) => p.id === pendingSelectPluginIdRef.current);
       if (pendingInActive) {
@@ -122,15 +117,18 @@ export const AgentPlugins: React.FC = () => {
       }
     }
 
+    // Select first plugin when no plugin is currently selected, like on first render
     if (!selectedPluginId) {
       if (activePlugins.length > 0) {
         setSelectedPluginId(activePlugins[0].id);
       }
-    } else {
-      const stillActive = activePlugins.some((p) => p.id === selectedPluginId);
-      if (!stillActive) {
-        setSelectedPluginId(activePlugins[0]?.id ?? null);
-      }
+      return;
+    }
+
+    // Selected plugin is no longer active, for example after deleting a skill
+    const selectedPluginNotActive = activePlugins.every((p) => p.id !== selectedPluginId);
+    if (selectedPluginNotActive) {
+      setSelectedPluginId(activePlugins[0]?.id ?? null);
     }
   }, [activePlugins, selectedPluginId, setSelectedPluginId, agentLoading, pluginsLoading]);
 
@@ -141,56 +139,6 @@ export const AgentPlugins: React.FC = () => {
       (p) => p.name.toLowerCase().includes(lower) || p.description.toLowerCase().includes(lower)
     );
   }, [activePlugins, searchQuery]);
-
-  const updatePluginsMutation = useMutation({
-    mutationFn: (newPluginIds: string[]) => {
-      return agentService.update(agentId!, { configuration: { plugin_ids: newPluginIds } });
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.agentProfiles.byId(agentId) });
-    },
-    onError: () => {
-      addErrorToast({ title: labels.agentPlugins.updatePluginsErrorToast });
-    },
-  });
-
-  const handleAddPlugin = useCallback(
-    async (
-      plugin: PluginDefinition,
-      { selectOnSuccess = false }: { selectOnSuccess?: boolean } = {}
-    ) => {
-      const currentIds = agentPluginIds ?? [];
-      if (currentIds.includes(plugin.id)) return;
-      const newIds = [...currentIds, plugin.id];
-      setMutatingPluginId(plugin.id);
-      try {
-        await updatePluginsMutation.mutateAsync(newIds);
-        if (selectOnSuccess) {
-          pendingSelectPluginIdRef.current = plugin.id;
-        }
-        addSuccessToast({ title: labels.agentPlugins.addPluginSuccessToast(plugin.name) });
-      } finally {
-        setMutatingPluginId(null);
-      }
-    },
-    [agentPluginIds, updatePluginsMutation, addSuccessToast]
-  );
-
-  const handleRemovePlugin = useCallback(
-    (plugin: PluginDefinition) => {
-      const currentIds = agentPluginIds ?? [];
-      const newIds = currentIds.filter((id) => id !== plugin.id);
-      setMutatingPluginId(plugin.id);
-      updatePluginsMutation.mutate(newIds, {
-        onSuccess: () => {
-          setSelectedPluginId(null);
-          addSuccessToast({ title: labels.agentPlugins.removePluginSuccessToast(plugin.name) });
-        },
-        onSettled: () => setMutatingPluginId(null),
-      });
-    },
-    [agentPluginIds, updatePluginsMutation, addSuccessToast, setSelectedPluginId]
-  );
 
   const handleTogglePlugin = useCallback(
     (plugin: PluginDefinition, isActive: boolean) => {
@@ -323,7 +271,6 @@ export const AgentPlugins: React.FC = () => {
                   isSelected={selectedPluginId === plugin.id}
                   onSelect={() => setSelectedPluginId(plugin.id)}
                   onRemove={() => handleRemovePlugin(plugin)}
-                  isRemoving={updatePluginsMutation.isLoading}
                   removeAriaLabel={labels.agentPlugins.removePluginAriaLabel}
                   readOnlyContent={
                     enableElasticCapabilities && plugin.readonly ? (
@@ -360,14 +307,19 @@ export const AgentPlugins: React.FC = () => {
           allPlugins={allPlugins}
           activePluginIdSet={libraryActivePluginIdSet}
           onTogglePlugin={handleTogglePlugin}
-          mutatingPluginId={mutatingPluginId}
         />
       )}
 
       {isInstallFlyoutOpen && (
         <InstallPluginFlyout
           onClose={closeInstallFlyout}
-          onPluginInstalled={(plugin) => handleAddPlugin(plugin, { selectOnSuccess: true })}
+          onPluginInstalled={(plugin) =>
+            handleAddPlugin(plugin, {
+              onSuccess: () => {
+                pendingSelectPluginIdRef.current = plugin.id;
+              },
+            })
+          }
         />
       )}
     </PageWrapper>

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/plugins/plugin_library_panel.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/plugins/plugin_library_panel.tsx
@@ -42,7 +42,6 @@ interface PluginLibraryPanelProps {
   allPlugins: PluginDefinition[];
   activePluginIdSet: Set<string>;
   onTogglePlugin: (plugin: PluginDefinition, isActive: boolean) => void;
-  mutatingPluginId: string | null;
   autoPluginIdSet?: Set<string>;
 }
 
@@ -51,7 +50,6 @@ export const PluginLibraryPanel: React.FC<PluginLibraryPanelProps> = ({
   allPlugins,
   activePluginIdSet,
   onTogglePlugin,
-  mutatingPluginId,
   autoPluginIdSet,
 }) => {
   const readOnlyItemIdSet = useMemo(
@@ -65,7 +63,7 @@ export const PluginLibraryPanel: React.FC<PluginLibraryPanelProps> = ({
       allItems={allPlugins}
       activeItemIdSet={activePluginIdSet}
       onToggleItem={onTogglePlugin}
-      mutatingItemId={mutatingPluginId}
+      mutatingItemId={null}
       flyoutTitleId="pluginLibraryFlyoutTitle"
       libraryLabels={libraryLabels}
       manageLibraryPath={appPaths.plugins.list}

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/plugins/use_plugins_mutation.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/plugins/use_plugins_mutation.ts
@@ -1,0 +1,97 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useCallback, useMemo } from 'react';
+import { useMutation, useQueryClient } from '@kbn/react-query';
+import type { AgentDefinition, PluginDefinition } from '@kbn/agent-builder-common';
+import { useAgentBuilderServices } from '../../../hooks/use_agent_builder_service';
+import { queryKeys } from '../../../query_keys';
+import { labels } from '../../../utils/i18n';
+import { useToasts } from '../../../hooks/use_toasts';
+
+export const usePluginsMutation = ({ agent }: { agent: AgentDefinition | null }) => {
+  const { agentService } = useAgentBuilderServices();
+  const queryClient = useQueryClient();
+  const { addSuccessToast, addErrorToast } = useToasts();
+  const { id: agentId, configuration } = agent ?? {};
+  const { plugin_ids: agentPluginIds } = configuration ?? {};
+
+  const agentQueryKey = queryKeys.agentProfiles.byId(agentId);
+
+  const updatePluginsMutation = useMutation({
+    mutationFn: (newPluginIds: string[]) => {
+      if (!agentId) {
+        throw new Error('Agent id is required to update plugins');
+      }
+      return agentService.update(agentId, {
+        configuration: { plugin_ids: newPluginIds },
+      });
+    },
+    onMutate: async (newPluginIds: string[]) => {
+      await queryClient.cancelQueries({ queryKey: agentQueryKey });
+
+      const previousAgent = queryClient.getQueryData<AgentDefinition>(agentQueryKey);
+
+      if (previousAgent) {
+        queryClient.setQueryData<AgentDefinition>(agentQueryKey, {
+          ...previousAgent,
+          configuration: {
+            ...previousAgent.configuration,
+            plugin_ids: newPluginIds,
+          },
+        });
+      }
+
+      return { previousAgent };
+    },
+    onError: (_err, _newPluginIds, context) => {
+      if (context?.previousAgent) {
+        queryClient.setQueryData<AgentDefinition>(agentQueryKey, context.previousAgent);
+      }
+      addErrorToast({ title: labels.agentPlugins.updatePluginsErrorToast });
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: agentQueryKey });
+    },
+  });
+
+  const handleAddPlugin = useCallback(
+    (plugin: PluginDefinition, { onSuccess }: { onSuccess?: (pluginId: string) => void } = {}) => {
+      const currentIds = agentPluginIds ?? [];
+      if (currentIds.includes(plugin.id)) return;
+      const newIds = [...currentIds, plugin.id];
+
+      updatePluginsMutation.mutate(newIds, {
+        onSuccess: () => {
+          onSuccess?.(plugin.id);
+          addSuccessToast({ title: labels.agentPlugins.addPluginSuccessToast(plugin.name) });
+        },
+      });
+    },
+    [agentPluginIds, updatePluginsMutation, addSuccessToast]
+  );
+
+  const handleRemovePlugin = useCallback(
+    (plugin: PluginDefinition) => {
+      const currentIds = agentPluginIds ?? [];
+      const newIds = currentIds.filter((id) => id !== plugin.id);
+      updatePluginsMutation.mutate(newIds, {
+        onSuccess: () => {
+          addSuccessToast({ title: labels.agentPlugins.removePluginSuccessToast(plugin.name) });
+        },
+      });
+    },
+    [agentPluginIds, updatePluginsMutation, addSuccessToast]
+  );
+
+  const handlers = useMemo(
+    () => ({ handleAddPlugin, handleRemovePlugin }),
+    [handleAddPlugin, handleRemovePlugin]
+  );
+
+  return handlers;
+};

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/skills/agent_skills.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/skills/agent_skills.tsx
@@ -5,8 +5,6 @@
  * 2.0.
  */
 
-import React, { useMemo, useState, useEffect, useRef } from 'react';
-import { useParams } from 'react-router-dom';
 import {
   EuiButton,
   EuiButtonEmpty,
@@ -21,35 +19,34 @@ import {
   EuiText,
   EuiTitle,
 } from '@elastic/eui';
-import type { PublicSkillDefinition, PublicSkillSummary } from '@kbn/agent-builder-common';
-import { useMutation, useQueryClient } from '@kbn/react-query';
-import { searchParamNames } from '../../../search_param_names';
-import { useQueryState } from '../../../hooks/use_query_state';
-import { labels } from '../../../utils/i18n';
-import { appPaths } from '../../../utils/app_paths';
-import { useNavigation } from '../../../hooks/use_navigation';
-import { useSkillsService } from '../../../hooks/skills/use_skills';
+import type { PublicSkillSummary } from '@kbn/agent-builder-common';
+import { useQueryClient } from '@kbn/react-query';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { useParams } from 'react-router-dom';
 import { useAgentBuilderAgentById } from '../../../hooks/agents/use_agent_by_id';
-import { useAgentBuilderServices } from '../../../hooks/use_agent_builder_service';
-import { useToasts } from '../../../hooks/use_toasts';
-import { queryKeys } from '../../../query_keys';
+import { useCanEditAgent } from '../../../hooks/agents/use_can_edit_agent';
+import { useSkillsService } from '../../../hooks/skills/use_skills';
 import { useFlyoutState } from '../../../hooks/use_flyout_state';
-import { SkillLibraryPanel } from './skill_library_panel';
-import { ActiveSkillRow } from './active_skill_row';
-import { SkillDetailPanel } from './skill_detail_panel';
-import { SkillEditFlyout } from './skill_edit_flyout';
-import { SkillCreateFlyout } from './skill_create_flyout';
+import { useNavigation } from '../../../hooks/use_navigation';
+import { useQueryState } from '../../../hooks/use_query_state';
+import { useUiPrivileges } from '../../../hooks/use_ui_privileges';
+import { queryKeys } from '../../../query_keys';
+import { searchParamNames } from '../../../search_param_names';
+import { appPaths } from '../../../utils/app_paths';
+import { labels } from '../../../utils/i18n';
 import { PageWrapper } from '../common/page_wrapper';
 import { useListDetailPageStyles } from '../common/styles';
-import { useUiPrivileges } from '../../../hooks/use_ui_privileges';
-import { useCanEditAgent } from '../../../hooks/agents/use_can_edit_agent';
+import { ActiveSkillRow } from './active_skill_row';
+import { SkillCreateFlyout } from './skill_create_flyout';
+import { SkillDetailPanel } from './skill_detail_panel';
+import { SkillEditFlyout } from './skill_edit_flyout';
+import { SkillLibraryPanel } from './skill_library_panel';
+import { useSkillsMutation } from './use_skills_mutation';
 
 export const AgentSkills: React.FC = () => {
   const { agentId } = useParams<{ agentId: string }>();
   const styles = useListDetailPageStyles();
   const { createAgentBuilderUrl } = useNavigation();
-  const { agentService } = useAgentBuilderServices();
-  const { addSuccessToast, addErrorToast } = useToasts();
   const queryClient = useQueryClient();
 
   const { agent, isLoading: agentLoading } = useAgentBuilderAgentById(agentId);
@@ -63,7 +60,7 @@ export const AgentSkills: React.FC = () => {
   const [editingSkillId, setEditingSkillId] = useState<string | null>(null);
   const [isCreateFlyoutOpen, setIsCreateFlyoutOpen] = useState(false);
   const [isAddMenuOpen, setIsAddMenuOpen] = useState(false);
-  const [mutatingSkillId, setMutatingSkillId] = useState<string | null>(null);
+  const { handleAddSkill, handleRemoveSkill } = useSkillsMutation({ agent });
   const {
     isOpen: isLibraryOpen,
     openFlyout: openLibrary,
@@ -111,6 +108,7 @@ export const AgentSkills: React.FC = () => {
   useEffect(() => {
     if (agentLoading || skillsLoading) return;
 
+    // When a newly added skill is pending to be selected. Once it is active, select it.
     if (pendingSelectSkillIdRef.current) {
       const pendingInActive = activeSkills.some((s) => s.id === pendingSelectSkillIdRef.current);
       if (pendingInActive) {
@@ -120,15 +118,18 @@ export const AgentSkills: React.FC = () => {
       }
     }
 
+    // Select first skill when no skill is currently selected, like on first render
     if (!selectedSkillId) {
       if (activeSkills.length > 0) {
         setSelectedSkillId(activeSkills[0].id);
       }
-    } else {
-      const stillActive = activeSkills.some((s) => s.id === selectedSkillId);
-      if (!stillActive) {
-        setSelectedSkillId(activeSkills[0]?.id ?? null);
-      }
+      return;
+    }
+
+    // Selected skill is no longer active, for example after deleting a skill
+    const selectedSkillNotActive = activeSkills.every((s) => s.id !== selectedSkillId);
+    if (selectedSkillNotActive) {
+      setSelectedSkillId(activeSkills[0]?.id ?? null);
     }
   }, [activeSkills, selectedSkillId, setSelectedSkillId, agentLoading, skillsLoading]);
 
@@ -139,50 +140,6 @@ export const AgentSkills: React.FC = () => {
       (s) => s.name.toLowerCase().includes(lower) || s.description.toLowerCase().includes(lower)
     );
   }, [activeSkills, searchQuery]);
-
-  const updateSkillsMutation = useMutation({
-    mutationFn: (newSkillIds: string[]) => {
-      return agentService.update(agentId!, { configuration: { skill_ids: newSkillIds } });
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.agentProfiles.byId(agentId) });
-    },
-    onError: () => {
-      addErrorToast({ title: labels.agentSkills.updateSkillsErrorToast });
-    },
-  });
-
-  const handleAddSkill = (
-    skill: PublicSkillSummary | PublicSkillDefinition,
-    { selectOnSuccess = false }: { selectOnSuccess?: boolean } = {}
-  ) => {
-    const currentIds = agentSkillIds ?? [];
-    if (currentIds.includes(skill.id)) return;
-    const newIds = [...currentIds, skill.id];
-    setMutatingSkillId(skill.id);
-    updateSkillsMutation.mutate(newIds, {
-      onSuccess: () => {
-        if (selectOnSuccess) {
-          pendingSelectSkillIdRef.current = skill.id;
-        }
-        addSuccessToast({ title: labels.agentSkills.addSkillSuccessToast(skill.name) });
-      },
-      onSettled: () => setMutatingSkillId(null),
-    });
-  };
-
-  const handleRemoveSkill = (skill: PublicSkillSummary) => {
-    const currentIds = agentSkillIds ?? [];
-    const newIds = currentIds.filter((id) => id !== skill.id);
-    setMutatingSkillId(skill.id);
-    updateSkillsMutation.mutate(newIds, {
-      onSuccess: () => {
-        setSelectedSkillId(null);
-        addSuccessToast({ title: labels.agentSkills.removeSkillSuccessToast(skill.name) });
-      },
-      onSettled: () => setMutatingSkillId(null),
-    });
-  };
 
   const handleToggleSkill = (skill: PublicSkillSummary, isActive: boolean) => {
     if (enableElasticCapabilities && skill.readonly) return;
@@ -319,7 +276,6 @@ export const AgentSkills: React.FC = () => {
                   isSelected={selectedSkillId === skill.id}
                   onSelect={(s) => setSelectedSkillId(s.id)}
                   onRemove={handleRemoveSkill}
-                  isRemoving={mutatingSkillId === skill.id}
                   isAutoIncluded={enableElasticCapabilities && skill.readonly}
                   canEditAgent={canEditAgent}
                 />
@@ -360,7 +316,6 @@ export const AgentSkills: React.FC = () => {
           allSkills={allSkills}
           activeSkillIdSet={libraryActiveSkillIdSet}
           onToggleSkill={handleToggleSkill}
-          mutatingSkillId={mutatingSkillId}
           enableElasticCapabilities={enableElasticCapabilities}
           builtinSkillIdSet={builtinSkillIdSet}
         />
@@ -380,7 +335,13 @@ export const AgentSkills: React.FC = () => {
       {isCreateFlyoutOpen && (
         <SkillCreateFlyout
           onClose={() => setIsCreateFlyoutOpen(false)}
-          onSkillCreated={(skill) => handleAddSkill(skill, { selectOnSuccess: true })}
+          onSkillCreated={(skill) =>
+            handleAddSkill(skill, {
+              onSuccess: () => {
+                pendingSelectSkillIdRef.current = skill.id;
+              },
+            })
+          }
         />
       )}
     </PageWrapper>

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/skills/skill_library_panel.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/skills/skill_library_panel.tsx
@@ -42,7 +42,6 @@ interface SkillLibraryPanelProps {
   allSkills: PublicSkillSummary[];
   activeSkillIdSet: Set<string>;
   onToggleSkill: (skill: PublicSkillSummary, isActive: boolean) => void;
-  mutatingSkillId: string | null;
   enableElasticCapabilities?: boolean;
   builtinSkillIdSet?: Set<string>;
 }
@@ -52,7 +51,6 @@ export const SkillLibraryPanel: React.FC<SkillLibraryPanelProps> = ({
   allSkills,
   activeSkillIdSet,
   onToggleSkill,
-  mutatingSkillId,
   enableElasticCapabilities = false,
   builtinSkillIdSet,
 }) => {
@@ -71,7 +69,7 @@ export const SkillLibraryPanel: React.FC<SkillLibraryPanelProps> = ({
       allItems={allSkills}
       activeItemIdSet={activeSkillIdSet}
       onToggleItem={onToggleSkill}
-      mutatingItemId={mutatingSkillId}
+      mutatingItemId={null}
       flyoutTitleId="skillLibraryFlyoutTitle"
       libraryLabels={libraryLabels}
       manageLibraryPath={appPaths.manage.skills}

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/skills/use_skills_mutation.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/skills/use_skills_mutation.ts
@@ -1,0 +1,104 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useMutation, useQueryClient } from '@kbn/react-query';
+import type {
+  AgentDefinition,
+  PublicSkillDefinition,
+  PublicSkillSummary,
+} from '@kbn/agent-builder-common';
+import { useCallback, useMemo } from 'react';
+import { useAgentBuilderServices } from '../../../hooks/use_agent_builder_service';
+import { queryKeys } from '../../../query_keys';
+import { labels } from '../../../utils/i18n';
+import { useToasts } from '../../../hooks/use_toasts';
+
+export const useSkillsMutation = ({ agent }: { agent: AgentDefinition | null }) => {
+  const { agentService } = useAgentBuilderServices();
+  const queryClient = useQueryClient();
+  const { addSuccessToast, addErrorToast } = useToasts();
+  const { id: agentId, configuration } = agent ?? {};
+  const { skill_ids: agentSkillIds } = configuration ?? {};
+
+  const agentQueryKey = queryKeys.agentProfiles.byId(agentId);
+
+  const updateSkillsMutation = useMutation({
+    mutationFn: (newSkillIds: string[]) => {
+      if (!agentId) {
+        throw new Error('Agent id is required to update skills');
+      }
+      return agentService.update(agentId, {
+        configuration: { skill_ids: newSkillIds },
+      });
+    },
+    onMutate: async (newSkillIds: string[]) => {
+      await queryClient.cancelQueries({ queryKey: agentQueryKey });
+
+      const previousAgent = queryClient.getQueryData<AgentDefinition>(agentQueryKey);
+
+      if (previousAgent) {
+        queryClient.setQueryData<AgentDefinition>(agentQueryKey, {
+          ...previousAgent,
+          configuration: {
+            ...previousAgent.configuration,
+            skill_ids: newSkillIds,
+          },
+        });
+      }
+
+      return { previousAgent };
+    },
+    onError: (_err, _newSkillIds, context) => {
+      if (context?.previousAgent) {
+        queryClient.setQueryData<AgentDefinition>(agentQueryKey, context.previousAgent);
+      }
+      addErrorToast({ title: labels.agentSkills.updateSkillsErrorToast });
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: agentQueryKey });
+    },
+  });
+
+  const handleAddSkill = useCallback(
+    (
+      skill: PublicSkillSummary | PublicSkillDefinition,
+      { onSuccess }: { onSuccess?: (skillId: string) => void } = {}
+    ) => {
+      const currentIds = agentSkillIds ?? [];
+      if (currentIds.includes(skill.id)) return;
+      const newIds = [...currentIds, skill.id];
+
+      updateSkillsMutation.mutate(newIds, {
+        onSuccess: () => {
+          onSuccess?.(skill.id);
+          addSuccessToast({ title: labels.agentSkills.addSkillSuccessToast(skill.name) });
+        },
+      });
+    },
+    [agentSkillIds, updateSkillsMutation, addSuccessToast]
+  );
+
+  const handleRemoveSkill = useCallback(
+    (skill: PublicSkillSummary) => {
+      const currentIds = agentSkillIds ?? [];
+      const newIds = currentIds.filter((id) => id !== skill.id);
+      updateSkillsMutation.mutate(newIds, {
+        onSuccess: () => {
+          addSuccessToast({ title: labels.agentSkills.removeSkillSuccessToast(skill.name) });
+        },
+      });
+    },
+    [agentSkillIds, updateSkillsMutation, addSuccessToast]
+  );
+
+  const handlers = useMemo(
+    () => ({ handleAddSkill, handleRemoveSkill }),
+    [handleAddSkill, handleRemoveSkill]
+  );
+
+  return handlers;
+};

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/hooks/plugins/use_delete_plugin.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/hooks/plugins/use_delete_plugin.ts
@@ -73,7 +73,7 @@ export const useDeletePluginService = ({
     mutationFn: ({ pluginId, force }) => pluginsService.delete({ pluginId, force }),
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.plugins.all });
-      queryClient.invalidateQueries({ queryKey: queryKeys.skills.all });
+      queryClient.invalidateQueries({ queryKey: queryKeys.skills.list });
       queryClient.invalidateQueries({ queryKey: queryKeys.agentProfiles.all });
     },
     onSuccess,

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/hooks/skills/use_create_skill.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/hooks/skills/use_create_skill.ts
@@ -41,7 +41,7 @@ export const useCreateSkillService = ({ onSuccess, onError }: UseCreateSkillServ
     mutationFn: (skill) => skillsService.create(skill),
     onSuccess,
     onError,
-    onSettled: () => queryClient.invalidateQueries({ queryKey: queryKeys.skills.all }),
+    onSettled: () => queryClient.invalidateQueries({ queryKey: queryKeys.skills.list }),
   });
 
   return { createSkillSync: mutate, createSkill: mutateAsync, isLoading };

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/hooks/skills/use_delete_skill.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/hooks/skills/use_delete_skill.ts
@@ -64,7 +64,7 @@ export const useDeleteSkillService = ({
     DeleteSkillMutationVariables
   >({
     mutationFn: ({ skillId, force }) => skillsService.delete({ skillId, force }),
-    onSettled: () => queryClient.invalidateQueries({ queryKey: queryKeys.skills.all }),
+    onSettled: () => queryClient.invalidateQueries({ queryKey: queryKeys.skills.list }),
     onSuccess,
     onError,
   });

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/hooks/skills/use_edit_skill.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/hooks/skills/use_edit_skill.ts
@@ -47,7 +47,10 @@ export const useEditSkillService = ({ onSuccess, onError }: UseEditSkillServiceP
     mutationFn: ({ skillId, skill }) => skillsService.update({ skillId, ...skill }),
     onSuccess,
     onError,
-    onSettled: () => queryClient.invalidateQueries({ queryKey: queryKeys.skills.all }),
+    onSettled: (skill) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.skills.list });
+      queryClient.invalidateQueries({ queryKey: queryKeys.skills.byId(skill?.id) });
+    },
   });
 
   return { updateSkillSync: mutate, updateSkill: mutateAsync, isLoading };

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/hooks/skills/use_skills.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/hooks/skills/use_skills.ts
@@ -18,7 +18,7 @@ export const useSkillsService = () => {
   const { skillsService } = useAgentBuilderServices();
 
   const { data, isLoading, error, isError } = useQuery({
-    queryKey: queryKeys.skills.all,
+    queryKey: queryKeys.skills.list,
     queryFn: () => skillsService.list(),
     keepPreviousData: true,
   });

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/query_keys.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/query_keys.ts
@@ -45,7 +45,8 @@ export const queryKeys = {
     },
   },
   skills: {
-    all: ['skills', 'list'] as const,
+    all: ['skills'] as const,
+    list: ['skills', 'list'] as const,
     byId: (skillId?: string) => ['skills', skillId],
     byAgent: (agentId?: string) => ['skills', 'byAgent', agentId],
   },


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Agent Builder] Agent Customizations Optimistic Updates (#260821)](https://github.com/elastic/kibana/pull/260821)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Zachary Parikh","email":"zachary.parikh@elastic.co"},"sourceCommit":{"committedDate":"2026-04-13T18:48:06Z","message":"[Agent Builder] Agent Customizations Optimistic Updates (#260821)\n\n## Summary\n\nAdds optimistic update logic to adding and removing skills and plugins\non the agent skills page.\n\n## Additional changes\n\nAdjusts the query key naming for skills, changing `skills.all:\n['skills', 'list']` to `skills.list: ['skills', 'list']`, and then added\n`skills.all: ['skills']`. I wanted to make this change because the\nnaming `skills.all` would make it seem like it is a parent of all the\nskill queries and that if you invalidate `skills.all` then that should\nalso invalidate any `skills.byId()` queries. However with the query key\n`['skills', 'list']`, that is _not_ the case, and it would only\ninvalidate the query for the list itself, not the queries for individual\nskills. Currently the `skills.all` query key is not being used anywhere\nfor invalidation, but it makes it clearer what is happening when we\ninvalidate `skills.list`.\n(This blog post is a lot clearer about what I'm trying to explain here\nhttps://tkdodo.eu/blog/effective-react-query-keys)\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...","sha":"b8671248da1e6f019a14cecaa11bda18db19d7db","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","feature:agent-builder","v9.5.0"],"title":"[Agent Builder] Agent Customizations Optimistic Updates","number":260821,"url":"https://github.com/elastic/kibana/pull/260821","mergeCommit":{"message":"[Agent Builder] Agent Customizations Optimistic Updates (#260821)\n\n## Summary\n\nAdds optimistic update logic to adding and removing skills and plugins\non the agent skills page.\n\n## Additional changes\n\nAdjusts the query key naming for skills, changing `skills.all:\n['skills', 'list']` to `skills.list: ['skills', 'list']`, and then added\n`skills.all: ['skills']`. I wanted to make this change because the\nnaming `skills.all` would make it seem like it is a parent of all the\nskill queries and that if you invalidate `skills.all` then that should\nalso invalidate any `skills.byId()` queries. However with the query key\n`['skills', 'list']`, that is _not_ the case, and it would only\ninvalidate the query for the list itself, not the queries for individual\nskills. Currently the `skills.all` query key is not being used anywhere\nfor invalidation, but it makes it clearer what is happening when we\ninvalidate `skills.list`.\n(This blog post is a lot clearer about what I'm trying to explain here\nhttps://tkdodo.eu/blog/effective-react-query-keys)\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...","sha":"b8671248da1e6f019a14cecaa11bda18db19d7db"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/260821","number":260821,"mergeCommit":{"message":"[Agent Builder] Agent Customizations Optimistic Updates (#260821)\n\n## Summary\n\nAdds optimistic update logic to adding and removing skills and plugins\non the agent skills page.\n\n## Additional changes\n\nAdjusts the query key naming for skills, changing `skills.all:\n['skills', 'list']` to `skills.list: ['skills', 'list']`, and then added\n`skills.all: ['skills']`. I wanted to make this change because the\nnaming `skills.all` would make it seem like it is a parent of all the\nskill queries and that if you invalidate `skills.all` then that should\nalso invalidate any `skills.byId()` queries. However with the query key\n`['skills', 'list']`, that is _not_ the case, and it would only\ninvalidate the query for the list itself, not the queries for individual\nskills. Currently the `skills.all` query key is not being used anywhere\nfor invalidation, but it makes it clearer what is happening when we\ninvalidate `skills.list`.\n(This blog post is a lot clearer about what I'm trying to explain here\nhttps://tkdodo.eu/blog/effective-react-query-keys)\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...","sha":"b8671248da1e6f019a14cecaa11bda18db19d7db"}}]}] BACKPORT-->