### PR TITLE
[Security Solution] Add Threat Coverage Initialization workflow and tools

### DIFF
--- a/src/platform/plugins/shared/workflows_extensions/test/scout/api/fixtures/approved_trigger_definitions.ts
+++ b/src/platform/plugins/shared/workflows_extensions/test/scout/api/fixtures/approved_trigger_definitions.ts
@@ -28,6 +28,14 @@
  */
 export const APPROVED_TRIGGER_DEFINITIONS: Array<{ id: string; schemaHash: string }> = [
   {
+    id: 'fleet.integrationInstalled',
+    schemaHash: 'a4dfd7950378128d350b42493bce26ad8ece5e8ce133165938dbdbfd7d6686f5',
+  },
+  {
+    id: 'security.setupComplete',
+    schemaHash: 'cebc79d9d38f29f51328eae1a81251545c6b9f1fda4758be49ae20165efbeeaf',
+  },
+  {
     id: 'workflows.failed',
     schemaHash: '2ac7a279823d7ca59c4d47de93ea7bd7103b1953ea484cef7f489d12d0c81980',
   },

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/base/namespaces.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/base/namespaces.ts
@@ -16,6 +16,7 @@ export const internalNamespaces = {
   platformStreams: 'platform.streams',
   filestore: 'filestore',
   attachments: 'attachments',
+  fleet: 'fleet',
   observability: 'observability',
   search: 'search',
   security: 'security',
@@ -31,6 +32,7 @@ export const protectedNamespaces: string[] = [
   internalNamespaces.platformAlerting,
   internalNamespaces.attachments,
   internalNamespaces.filestore,
+  internalNamespaces.fleet,
   internalNamespaces.observability,
   internalNamespaces.platformDashboard, // Owned by dashboard_agent plugin
   internalNamespaces.platformStreams,

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-server/allow_lists.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-server/allow_lists.ts
@@ -52,6 +52,7 @@ export const AGENT_BUILDER_BUILTIN_TOOLS = [
   `${internalNamespaces.security}.search_entities`,
   `${internalNamespaces.security}.find_prebuilt_rules`,
   `${internalNamespaces.security}.install_prebuilt_rules`,
+  `${internalNamespaces.security}.bulk_actions`,
 
   // Streams
   `${internalNamespaces.streams}.inspect_streams`,

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-server/allow_lists.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-server/allow_lists.ts
@@ -21,6 +21,9 @@ export const AGENT_BUILDER_BUILTIN_TOOLS = [
   // Alerting
   `${internalNamespaces.platformAlerting}.manage_rule`,
 
+  // Fleet
+  `${internalNamespaces.fleet}.list_installed_integrations`,
+
   // Observability
   `${internalNamespaces.observability}.get_anomaly_detection_jobs`,
   `${internalNamespaces.observability}.run_log_rate_analysis`,

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-server/allow_lists.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-server/allow_lists.ts
@@ -51,6 +51,7 @@ export const AGENT_BUILDER_BUILTIN_TOOLS = [
   `${internalNamespaces.security}.get_entity`,
   `${internalNamespaces.security}.search_entities`,
   `${internalNamespaces.security}.find_prebuilt_rules`,
+  `${internalNamespaces.security}.install_prebuilt_rules`,
 
   // Streams
   `${internalNamespaces.streams}.inspect_streams`,

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-server/allow_lists.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-server/allow_lists.ts
@@ -137,6 +137,7 @@ export const AGENT_BUILDER_BUILTIN_SKILLS = [
   'detection-rule-edit',
   'threat-hunting',
   'threat-coverage-initialization',
+  'detection-coverage-onboarding',
 
   // O11Y
   'observability.rca',

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-server/allow_lists.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-server/allow_lists.ts
@@ -50,6 +50,7 @@ export const AGENT_BUILDER_BUILTIN_TOOLS = [
   `${internalNamespaces.security}.alerts`,
   `${internalNamespaces.security}.get_entity`,
   `${internalNamespaces.security}.search_entities`,
+  `${internalNamespaces.security}.find_prebuilt_rules`,
 
   // Streams
   `${internalNamespaces.streams}.inspect_streams`,

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-server/allow_lists.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-server/allow_lists.ts
@@ -135,6 +135,7 @@ export const AGENT_BUILDER_BUILTIN_SKILLS = [
   'alert-analysis',
   'detection-rule-edit',
   'threat-hunting',
+  'threat-coverage-initialization',
 
   // O11Y
   'observability.rca',

--- a/x-pack/platform/plugins/shared/alerting/server/rules_client_factory.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/rules_client_factory.ts
@@ -369,7 +369,15 @@ export class RulesClientFactory {
           return false;
         }
         const user = securityService.authc.getCurrentUser(request);
-        return user && user.authentication_type ? user.authentication_type === 'api_key' : false;
+        if (user?.authentication_type) {
+          return user.authentication_type === 'api_key';
+        }
+        // getCurrentUser may return null for Task Manager fake requests that
+        // are authenticated via API key but haven't gone through Kibana's HTTP
+        // authentication pipeline. Fall back to inspecting the Authorization
+        // header scheme directly.
+        const authHeader = HTTPAuthorizationHeader.parseFromRequest(request);
+        return authHeader?.scheme.toLowerCase() === 'apikey';
       },
       getAuthenticationAPIKey(name: string) {
         const authorizationHeader = HTTPAuthorizationHeader.parseFromRequest(request);

--- a/x-pack/platform/plugins/shared/fleet/common/triggers/integration_installed_trigger.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/triggers/integration_installed_trigger.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod/v4';
+import type { CommonTriggerDefinition } from '@kbn/workflows-extensions/common';
+
+export const FLEET_INTEGRATION_INSTALLED_TRIGGER_ID = 'fleet.integrationInstalled' as const;
+
+export const integrationInstalledEventSchema = z.object({
+  package_name: z.string().describe('The name of the installed integration package.'),
+  package_version: z.string().describe('The version of the installed integration package.'),
+  install_source: z
+    .enum(['registry', 'upload', 'bundled', 'custom'])
+    .describe('The source from which the package was installed.'),
+});
+
+export type IntegrationInstalledEvent = z.infer<typeof integrationInstalledEventSchema>;
+
+export const integrationInstalledTriggerDefinition: CommonTriggerDefinition = {
+  id: FLEET_INTEGRATION_INSTALLED_TRIGGER_ID,
+  eventSchema: integrationInstalledEventSchema,
+};

--- a/x-pack/platform/plugins/shared/fleet/kibana.jsonc
+++ b/x-pack/platform/plugins/shared/fleet/kibana.jsonc
@@ -31,6 +31,7 @@
       "spaces"
     ],
     "optionalPlugins": [
+      "agentBuilder",
       "features",
       "cloud",
       "usageCollection",

--- a/x-pack/platform/plugins/shared/fleet/kibana.jsonc
+++ b/x-pack/platform/plugins/shared/fleet/kibana.jsonc
@@ -43,7 +43,8 @@
       "automaticImport",
       "alerting",
       "sloShared",
-      "reporting"
+      "reporting",
+      "workflowsExtensions"
     ],
     "requiredBundles": [
       "kibanaReact",

--- a/x-pack/platform/plugins/shared/fleet/public/plugin.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/plugin.ts
@@ -58,6 +58,7 @@ import type { AutomaticImportPluginStart } from '@kbn/automatic-import-plugin/pu
 import type { LogsDataAccessPluginStart } from '@kbn/logs-data-access-plugin/public';
 import type { EmbeddableStart } from '@kbn/embeddable-plugin/public';
 import type { ReportingStart } from '@kbn/reporting-plugin/public';
+import type { WorkflowsExtensionsPublicPluginSetup } from '@kbn/workflows-extensions/public';
 
 import type { FleetAuthz } from '../common';
 import { appRoutesService, INTEGRATIONS_PLUGIN_ID, PLUGIN_ID, setupRouteService } from '../common';
@@ -79,6 +80,7 @@ import { API_VERSIONS } from '../common/constants';
 import { CUSTOM_LOGS_INTEGRATION_NAME, INTEGRATIONS_BASE_PATH } from './constants';
 import type { RequestError } from './hooks';
 import { licenseService, sendGetBulkAssets } from './hooks';
+import { registerTriggerDefinitions } from './triggers';
 import { setHttpClient } from './hooks/use_request';
 import { createExtensionRegistrationCallback } from './services/ui_extensions';
 import { ExperimentalFeaturesService } from './services/experimental_features';
@@ -124,6 +126,7 @@ export interface FleetSetupDeps {
   globalSearch?: GlobalSearchPluginSetup;
   customIntegrations: CustomIntegrationsSetup;
   usageCollection?: UsageCollectionSetup;
+  workflowsExtensions?: WorkflowsExtensionsPublicPluginSetup;
 }
 
 export interface FleetStartDeps {
@@ -317,6 +320,10 @@ export class FleetPlugin implements Plugin<FleetSetup, FleetStart, FleetSetupDep
         .catch(() => {
           this.logger.error('Failed to load search providers.');
         });
+    }
+
+    if (deps.workflowsExtensions) {
+      registerTriggerDefinitions(deps.workflowsExtensions);
     }
 
     return {};

--- a/x-pack/platform/plugins/shared/fleet/public/triggers/eui_icons.d.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/triggers/eui_icons.d.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+declare module '@elastic/eui/es/components/icon/assets/*' {
+  import type * as React from 'react';
+
+  interface SVGRProps {
+    title?: string;
+    titleId?: string;
+  }
+  export const icon: ({
+    title,
+    titleId,
+    ...props
+  }: React.SVGProps<SVGSVGElement> & SVGRProps) => React.JSX.Element;
+  export {};
+}

--- a/x-pack/platform/plugins/shared/fleet/public/triggers/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/triggers/index.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { WorkflowsExtensionsPublicPluginSetup } from '@kbn/workflows-extensions/public';
+
+export const registerTriggerDefinitions = (
+  workflowsExtensions: WorkflowsExtensionsPublicPluginSetup
+): void => {
+  workflowsExtensions.registerTriggerDefinition(() =>
+    import('./integration_installed_trigger').then(
+      (m) => m.integrationInstalledPublicTriggerDefinition
+    )
+  );
+};

--- a/x-pack/platform/plugins/shared/fleet/public/triggers/integration_installed_trigger.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/triggers/integration_installed_trigger.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { i18n } from '@kbn/i18n';
+import type { PublicTriggerDefinition } from '@kbn/workflows-extensions/public';
+import {
+  FLEET_INTEGRATION_INSTALLED_TRIGGER_ID,
+  integrationInstalledTriggerDefinition,
+} from '../../common/triggers/integration_installed_trigger';
+
+export const integrationInstalledPublicTriggerDefinition: PublicTriggerDefinition = {
+  ...integrationInstalledTriggerDefinition,
+  title: i18n.translate('xpack.fleet.triggers.integrationInstalled.title', {
+    defaultMessage: 'Integration installed',
+  }),
+  description: i18n.translate('xpack.fleet.triggers.integrationInstalled.description', {
+    defaultMessage:
+      'Emitted when a Fleet integration package is installed. Use to automate post-installation setup such as configuring detection rules or dashboards.',
+  }),
+  icon: React.lazy(() =>
+    import('@elastic/eui/es/components/icon/assets/package').then(({ icon }) => ({
+      default: icon,
+    }))
+  ),
+  documentation: {
+    details: i18n.translate('xpack.fleet.triggers.integrationInstalled.documentation.details', {
+      defaultMessage:
+        'Emitted when a Fleet integration is installed. The event includes `package_name`, `package_version`, and `install_source` (registry, upload, bundled, or custom). Use KQL in `on.condition` to filter by package name or install source.',
+    }),
+    examples: [
+      i18n.translate(
+        'xpack.fleet.triggers.integrationInstalled.documentation.exampleFilterByPackage',
+        {
+          defaultMessage: `## Filter by package name
+\`\`\`yaml
+triggers:
+  - type: {triggerId}
+    on:
+      condition: 'event.package_name: "endpoint"'
+\`\`\``,
+          values: { triggerId: FLEET_INTEGRATION_INSTALLED_TRIGGER_ID },
+        }
+      ),
+      i18n.translate(
+        'xpack.fleet.triggers.integrationInstalled.documentation.exampleFilterBySource',
+        {
+          defaultMessage: `## Filter by install source
+\`\`\`yaml
+triggers:
+  - type: {triggerId}
+    on:
+      condition: 'event.install_source: "registry"'
+\`\`\``,
+          values: { triggerId: FLEET_INTEGRATION_INSTALLED_TRIGGER_ID },
+        }
+      ),
+    ],
+  },
+  snippets: {
+    condition: 'event.package_name: "endpoint"',
+  },
+};

--- a/x-pack/platform/plugins/shared/fleet/server/agent_builder/list_installed_integrations_tool.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/agent_builder/list_installed_integrations_tool.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod/v4';
+import { ToolType } from '@kbn/agent-builder-common';
+import { ToolResultType } from '@kbn/agent-builder-common/tools/tool_result';
+import type { BuiltinToolDefinition } from '@kbn/agent-builder-server';
+import { createErrorResult } from '@kbn/agent-builder-server';
+import type { CoreSetup } from '@kbn/core/server';
+
+import type { FleetStartContract, FleetStartDeps } from '../plugin';
+
+export const FLEET_LIST_INSTALLED_INTEGRATIONS_TOOL_ID = 'fleet.list_installed_integrations';
+
+const PER_PAGE = 50;
+
+const listInstalledIntegrationsSchema = z.object({
+  nameQuery: z
+    .string()
+    .optional()
+    .describe(
+      'Optional search query to filter integrations by name. Only use if the user specified a name to search for.'
+    ),
+  dataStreamType: z
+    .enum(['logs', 'metrics', 'traces', 'synthetics', 'profiling'])
+    .optional()
+    .describe('Optional filter to return only integrations with data streams of a specific type.'),
+});
+
+export const listInstalledIntegrationsTool = (
+  coreSetup: CoreSetup<FleetStartDeps, FleetStartContract>
+): BuiltinToolDefinition<typeof listInstalledIntegrationsSchema> => ({
+  id: FLEET_LIST_INSTALLED_INTEGRATIONS_TOOL_ID,
+  type: ToolType.builtin,
+  description: `List Fleet integrations installed in the current Kibana deployment.
+
+Returns the name, version, status, title, description, and associated data streams for each installed integration.
+
+Use this tool when the user asks about installed integrations, available data sources, or which integrations are configured in the system.`,
+  schema: listInstalledIntegrationsSchema,
+  handler: async ({ nameQuery, dataStreamType }, { request, logger }) => {
+    try {
+      const [, , fleetStart] = await coreSetup.getStartServices();
+      const packageClient = fleetStart.packageService.asScoped(request);
+
+      const response = await packageClient.getInstalledPackages({
+        perPage: PER_PAGE,
+        sortOrder: 'asc',
+        ...(nameQuery ? { nameQuery } : {}),
+        ...(dataStreamType ? { dataStreamType } : {}),
+      });
+
+      const integrations = response.items.map((item) => ({
+        name: item.name,
+        version: item.version,
+        status: item.status,
+        title: item.title,
+        description: item.description,
+        dataStreams: item.dataStreams.map((ds) => ({
+          name: ds.name,
+          title: ds.title,
+        })),
+      }));
+
+      return {
+        results: [
+          {
+            type: ToolResultType.other,
+            data: {
+              integrations,
+              total: response.total,
+            },
+          },
+        ],
+      };
+    } catch (error) {
+      logger.error(`Error fetching installed integrations: ${error.message}`);
+      return {
+        results: [createErrorResult(`Failed to fetch installed integrations: ${error.message}`)],
+      };
+    }
+  },
+  tags: ['fleet', 'integration'],
+});

--- a/x-pack/platform/plugins/shared/fleet/server/agent_builder/register_tools.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/agent_builder/register_tools.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { CoreSetup } from '@kbn/core/server';
+import type { AgentBuilderPluginSetup } from '@kbn/agent-builder-plugin/server';
+
+import type { FleetStartContract, FleetStartDeps } from '../plugin';
+
+import { listInstalledIntegrationsTool } from './list_installed_integrations_tool';
+
+export const registerAgentBuilderTools = ({
+  agentBuilder,
+  core,
+}: {
+  agentBuilder: AgentBuilderPluginSetup;
+  core: CoreSetup<FleetStartDeps, FleetStartContract>;
+}) => {
+  agentBuilder.tools.register(listInstalledIntegrationsTool(core));
+};

--- a/x-pack/platform/plugins/shared/fleet/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/plugin.ts
@@ -48,6 +48,7 @@ import type {
 } from '@kbn/task-manager-plugin/server';
 import type { AlertingServerStart } from '@kbn/alerting-plugin/server/plugin';
 import type { AgentBuilderPluginSetup } from '@kbn/agent-builder-plugin/server';
+import type { WorkflowsExtensionsServerPluginSetup } from '@kbn/workflows-extensions/server';
 import type { CloudSetup } from '@kbn/cloud-plugin/server';
 import type { SpacesPluginStart } from '@kbn/spaces-plugin/server';
 import type { SavedObjectTaggingStart } from '@kbn/saved-objects-tagging-plugin/server';
@@ -70,6 +71,8 @@ import {
   AGENT_POLICY_SAVED_OBJECT_TYPE,
   LEGACY_AGENT_POLICY_SAVED_OBJECT_TYPE,
 } from '../common/constants';
+
+import { integrationInstalledTriggerDefinition } from '../common/triggers/integration_installed_trigger';
 
 import { runWithCache } from './services/epm/packages/cache';
 
@@ -190,6 +193,7 @@ export interface FleetSetupDeps {
   telemetry?: TelemetryPluginSetup;
   taskManager: TaskManagerSetupContract;
   fieldsMetadata: FieldsMetadataServerSetup;
+  workflowsExtensions?: WorkflowsExtensionsServerPluginSetup;
 }
 
 export interface FleetStartDeps {
@@ -705,6 +709,10 @@ export class FleetPlugin
 
     if (deps.agentBuilder) {
       registerAgentBuilderTools({ agentBuilder: deps.agentBuilder, core });
+    }
+
+    if (deps.workflowsExtensions) {
+      deps.workflowsExtensions.registerTriggerDefinition(integrationInstalledTriggerDefinition);
     }
 
     // Register tasks

--- a/x-pack/platform/plugins/shared/fleet/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/plugin.ts
@@ -47,6 +47,7 @@ import type {
   TaskManagerStartContract,
 } from '@kbn/task-manager-plugin/server';
 import type { AlertingServerStart } from '@kbn/alerting-plugin/server/plugin';
+import type { AgentBuilderPluginSetup } from '@kbn/agent-builder-plugin/server';
 import type { CloudSetup } from '@kbn/cloud-plugin/server';
 import type { SpacesPluginStart } from '@kbn/spaces-plugin/server';
 import type { SavedObjectTaggingStart } from '@kbn/saved-objects-tagging-plugin/server';
@@ -145,6 +146,7 @@ import { getPackageSpecTagId } from './services/epm/kibana/assets/tag_assets';
 import { FleetMetricsTask } from './services/metrics/fleet_metrics_task';
 import { fetchAgentMetrics } from './services/metrics/fetch_agent_metrics';
 import { registerFieldsMetadataExtractors } from './services/register_fields_metadata_extractors';
+import { registerAgentBuilderTools } from './agent_builder/register_tools';
 import { registerUpgradeManagedPackagePoliciesTask } from './services/setup/managed_package_policies';
 import { registerDeployAgentPoliciesTask } from './services/agent_policies/deploy_agent_policies_task';
 import { DeleteUnenrolledAgentsTask } from './tasks/delete_unenrolled_agents_task';
@@ -178,6 +180,7 @@ import { registerReassignAgentsToVersionSpecificPoliciesTask } from './services/
 import { VersionSpecificPolicyAssignmentTask } from './tasks/version_specific_policy_assignment_task';
 
 export interface FleetSetupDeps {
+  agentBuilder?: AgentBuilderPluginSetup;
   security: SecurityPluginSetup;
   features?: FeaturesPluginSetup;
   encryptedSavedObjects: EncryptedSavedObjectsPluginSetup;
@@ -699,6 +702,11 @@ export class FleetPlugin
     registerRoutes(fleetAuthzRouter, config, isServerless);
 
     this.telemetryEventsSender.setup(deps.telemetry);
+
+    if (deps.agentBuilder) {
+      registerAgentBuilderTools({ agentBuilder: deps.agentBuilder, core });
+    }
+
     // Register tasks
     registerUpgradeManagedPackagePoliciesTask(deps.taskManager);
     registerDeployAgentPoliciesTask(deps.taskManager);

--- a/x-pack/platform/plugins/shared/fleet/server/routes/epm/handlers.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/epm/handlers.ts
@@ -117,6 +117,7 @@ import { DatasetNamePrefixError } from '../../services/epm/packages/custom_integ
 import { UPLOAD_RETRY_AFTER_MS } from '../../services/epm/packages/install';
 import { getPackagePoliciesCountByPackageName } from '../../services/package_policies/package_policies_aggregation';
 import { getPackageKnowledgeBase } from '../../services/epm/packages';
+import { emitIntegrationInstalledEvent } from '../../services/epm/packages/emit_integration_installed_event';
 
 import { getPackagePolicyIdsForCurrentUser } from './bulk_handler';
 
@@ -397,6 +398,18 @@ export const installPackageFromRegistryHandler: FleetRequestHandler<
         name: pkgName,
       },
     };
+
+    // Fire-and-forget: notify subscribed workflows about the new integration
+    emitIntegrationInstalledEvent({
+      context,
+      payload: {
+        package_name: pkgName,
+        package_version: pkgVersion ?? 'latest',
+        install_source: res.installSource ?? installSource,
+      },
+      logger: appContextService.getLogger(),
+    });
+
     return response.ok({ body });
   } else {
     throw res.error;
@@ -560,6 +573,18 @@ export const installPackageByUploadHandler: FleetRequestHandler<
         name: res.pkgName,
       },
     };
+
+    // Fire-and-forget: notify subscribed workflows about the new integration
+    emitIntegrationInstalledEvent({
+      context,
+      payload: {
+        package_name: res.pkgName,
+        package_version: 'uploaded',
+        install_source: res.installSource ?? installSource,
+      },
+      logger: appContextService.getLogger(),
+    });
+
     return response.ok({ body });
   } else {
     if (res.error instanceof FleetTooManyRequestsError) {

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/emit_integration_installed_event.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/emit_integration_installed_event.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Logger, RequestHandlerContext } from '@kbn/core/server';
+
+import {
+  FLEET_INTEGRATION_INSTALLED_TRIGGER_ID,
+  type IntegrationInstalledEvent,
+} from '../../../../common/triggers/integration_installed_trigger';
+
+/**
+ * Emits a `fleet.integrationInstalled` workflow trigger event after a
+ * successful package installation. Silently catches errors so that a
+ * missing or misconfigured workflowsExtensions plugin never blocks the
+ * install flow.
+ */
+export const emitIntegrationInstalledEvent = async ({
+  context,
+  payload,
+  logger,
+}: {
+  context: RequestHandlerContext;
+  payload: IntegrationInstalledEvent;
+  logger: Logger;
+}): Promise<void> => {
+  try {
+    const workflows = await (context as RequestHandlerContext & { workflows?: Promise<unknown> })
+      .workflows;
+    if (!workflows || typeof workflows !== 'object') {
+      return;
+    }
+    const client = (
+      workflows as { getWorkflowsClient: () => { emitEvent: Function } }
+    ).getWorkflowsClient();
+    await client.emitEvent(FLEET_INTEGRATION_INSTALLED_TRIGGER_ID, payload);
+    logger.debug(
+      `Emitted ${FLEET_INTEGRATION_INSTALLED_TRIGGER_ID} event for package "${payload.package_name}@${payload.package_version}"`
+    );
+  } catch (error) {
+    logger.debug(
+      `Could not emit ${FLEET_INTEGRATION_INSTALLED_TRIGGER_ID} event for package "${payload.package_name}@${payload.package_version}": ${error.message}`
+    );
+  }
+};

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/emit_integration_installed_event.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/emit_integration_installed_event.ts
@@ -28,20 +28,23 @@ export const emitIntegrationInstalledEvent = async ({
   logger: Logger;
 }): Promise<void> => {
   try {
-    const workflows = await (context as RequestHandlerContext & { workflows?: Promise<unknown> })
-      .workflows;
-    if (!workflows || typeof workflows !== 'object') {
+    const workflows = await (
+      context as RequestHandlerContext & {
+        workflows?: Promise<{
+          isWorkflowsAvailable: boolean;
+          emitEvent: (triggerId: string, payload: Record<string, unknown>) => Promise<void>;
+        }>;
+      }
+    ).workflows;
+    if (!workflows || typeof workflows.emitEvent !== 'function') {
       return;
     }
-    const client = (
-      workflows as { getWorkflowsClient: () => { emitEvent: Function } }
-    ).getWorkflowsClient();
-    await client.emitEvent(FLEET_INTEGRATION_INSTALLED_TRIGGER_ID, payload);
+    await workflows.emitEvent(FLEET_INTEGRATION_INSTALLED_TRIGGER_ID, payload);
     logger.debug(
       `Emitted ${FLEET_INTEGRATION_INSTALLED_TRIGGER_ID} event for package "${payload.package_name}@${payload.package_version}"`
     );
   } catch (error) {
-    logger.debug(
+    logger.warn(
       `Could not emit ${FLEET_INTEGRATION_INSTALLED_TRIGGER_ID} event for package "${payload.package_name}@${payload.package_version}": ${error.message}`
     );
   }

--- a/x-pack/platform/plugins/shared/fleet/server/services/package_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/package_policy.ts
@@ -788,7 +788,9 @@ class PackagePolicyClientImpl implements PackagePolicyClient {
       'packagePolicyPostCreate',
       createdPackagePolicy,
       soClient,
-      esClient
+      esClient,
+      context,
+      request
     );
   }
 

--- a/x-pack/solutions/security/plugins/security_solution/common/constants.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/constants.ts
@@ -727,3 +727,6 @@ export const SECURITY_RULE_ATTACHMENT_ID = 'ai-rule-creation';
 export const REGISTER_ALERT_VALIDATION_STEPS_FEATURE_FLAG =
   'securitySolution.registerAlertValidationStepsEnabled' as const;
 export const REGISTER_ALERT_VALIDATION_STEP_FEATURE_FLAG_DEFAULT = false as const;
+
+export const THREAT_COVERAGE_INITIALIZATION_WORKFLOW_ID =
+  'workflow-f9c107e9-e0e5-5038-ae51-baf24c0b851a';

--- a/x-pack/solutions/security/plugins/security_solution/common/triggers/setup_complete_trigger.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/triggers/setup_complete_trigger.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod/v4';
+import type { CommonTriggerDefinition } from '@kbn/workflows-extensions/common';
+
+export const SECURITY_SETUP_COMPLETE_TRIGGER_ID = 'security.setupComplete' as const;
+
+export const setupCompleteEventSchema = z.object({
+  completed_cards: z
+    .array(z.string())
+    .describe('List of onboarding card IDs that were completed at the time of triggering.'),
+});
+
+export type SetupCompleteEvent = z.infer<typeof setupCompleteEventSchema>;
+
+export const setupCompleteTriggerDefinition: CommonTriggerDefinition = {
+  id: SECURITY_SETUP_COMPLETE_TRIGGER_ID,
+  eventSchema: setupCompleteEventSchema,
+};

--- a/x-pack/solutions/security/plugins/security_solution/kibana.jsonc
+++ b/x-pack/solutions/security/plugins/security_solution/kibana.jsonc
@@ -89,7 +89,8 @@
       "workflowsExtensions",
       "cps",
       "searchInferenceEndpoints",
-      "workflowsExtensions"
+      "workflowsExtensions",
+      "workflowsManagement"
     ],
     "requiredBundles": [
       "esUiShared",

--- a/x-pack/solutions/security/plugins/security_solution/kibana.jsonc
+++ b/x-pack/solutions/security/plugins/security_solution/kibana.jsonc
@@ -88,7 +88,8 @@
       "llmTasks",
       "workflowsExtensions",
       "cps",
-      "searchInferenceEndpoints"
+      "searchInferenceEndpoints",
+      "workflowsExtensions"
     ],
     "requiredBundles": [
       "esUiShared",

--- a/x-pack/solutions/security/plugins/security_solution/public/plugin.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/plugin.tsx
@@ -82,6 +82,7 @@ import {
 } from './agent_builder/attachment_types';
 import type { SecurityCanvasEmbeddedBundle } from './agent_builder/components/security_redux_embedded_provider';
 import { registerWorkflowSteps } from './workflows/step_types';
+import { registerTriggerDefinitions } from './triggers';
 
 export class Plugin implements IPlugin<PluginSetup, PluginStart, SetupPlugins, StartPlugins> {
   private config: SecuritySolutionUiConfigType;
@@ -129,6 +130,10 @@ export class Plugin implements IPlugin<PluginSetup, PluginStart, SetupPlugins, S
 
     const { home, usageCollection, management, cases, share, workflowsExtensions } = plugins;
     const { productFeatureKeys$ } = this.contract;
+
+    if (workflowsExtensions) {
+      registerTriggerDefinitions(workflowsExtensions);
+    }
 
     if (share) {
       share.url.locators.create(new AIValueReportLocatorDefinition());

--- a/x-pack/solutions/security/plugins/security_solution/public/triggers/eui_icons.d.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/triggers/eui_icons.d.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+declare module '@elastic/eui/es/components/icon/assets/*' {
+  import type * as React from 'react';
+
+  interface SVGRProps {
+    title?: string;
+    titleId?: string;
+  }
+  export const icon: ({
+    title,
+    titleId,
+    ...props
+  }: React.SVGProps<SVGSVGElement> & SVGRProps) => React.JSX.Element;
+  export {};
+}

--- a/x-pack/solutions/security/plugins/security_solution/public/triggers/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/triggers/index.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { WorkflowsExtensionsPublicPluginSetup } from '@kbn/workflows-extensions/public';
+
+export const registerTriggerDefinitions = (
+  workflowsExtensions: WorkflowsExtensionsPublicPluginSetup
+): void => {
+  workflowsExtensions.registerTriggerDefinition(() =>
+    import('./setup_complete_trigger').then((m) => m.setupCompletePublicTriggerDefinition)
+  );
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/triggers/setup_complete_trigger.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/triggers/setup_complete_trigger.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { i18n } from '@kbn/i18n';
+import type { PublicTriggerDefinition } from '@kbn/workflows-extensions/public';
+import {
+  SECURITY_SETUP_COMPLETE_TRIGGER_ID,
+  setupCompleteTriggerDefinition,
+} from '../../common/triggers/setup_complete_trigger';
+
+export const setupCompletePublicTriggerDefinition: PublicTriggerDefinition = {
+  ...setupCompleteTriggerDefinition,
+  title: i18n.translate('xpack.securitySolution.triggers.setupComplete.title', {
+    defaultMessage: 'Security setup complete',
+  }),
+  description: i18n.translate('xpack.securitySolution.triggers.setupComplete.description', {
+    defaultMessage:
+      'Emitted when the Security Solution setup completes. Use to bootstrap detection coverage or perform post-setup automation.',
+  }),
+  icon: React.lazy(() =>
+    import('@elastic/eui/es/components/icon/assets/check_circle_fill').then(({ icon }) => ({
+      default: icon,
+    }))
+  ),
+  documentation: {
+    details: i18n.translate('xpack.securitySolution.triggers.setupComplete.documentation.details', {
+      defaultMessage:
+        'Emitted when the Security Solution onboarding setup completes. The event includes `completed_cards`, a list of onboarding card IDs that were completed. Use KQL in `on.condition` to filter by specific completed cards.',
+    }),
+    examples: [
+      i18n.translate(
+        'xpack.securitySolution.triggers.setupComplete.documentation.exampleBasic',
+        {
+          defaultMessage: `## Run on any setup completion
+\`\`\`yaml
+triggers:
+  - type: {triggerId}
+\`\`\``,
+          values: { triggerId: SECURITY_SETUP_COMPLETE_TRIGGER_ID },
+        }
+      ),
+    ],
+  },
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/types.ts
@@ -71,7 +71,6 @@ import type { KqlPluginStart } from '@kbn/kql/public';
 import type { AgentBuilderPluginStart } from '@kbn/agent-builder-browser';
 import type { Logger } from '@kbn/logging';
 import type { CPSPluginStart } from '@kbn/cps/public';
-import type { WorkflowsExtensionsPublicPluginSetup } from '@kbn/workflows-extensions/public';
 import type { EvalsPublicStart } from '@kbn/evals-plugin/public';
 import type { ResolverPluginSetup } from './resolver/types';
 import type { Inspect } from '../common/search_strategy';

--- a/x-pack/solutions/security/plugins/security_solution/public/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/types.ts
@@ -39,6 +39,7 @@ import type { DashboardStart } from '@kbn/dashboard-plugin/public';
 import type { IndexPatternFieldEditorStart } from '@kbn/data-view-field-editor-plugin/public';
 import type { UnifiedSearchPublicPluginStart } from '@kbn/unified-search-plugin/public';
 import type { CloudSetup, CloudStart } from '@kbn/cloud-plugin/public';
+import type { WorkflowsExtensionsPublicPluginSetup } from '@kbn/workflows-extensions/public';
 import type { CloudDefendPluginStart } from '@kbn/cloud-defend-plugin/public';
 import type { CspClientPluginStart } from '@kbn/cloud-security-posture-plugin/public';
 import type { ApmBase } from '@elastic/apm-rum';

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/detection_coverage_onboarding/detection_coverage_onboarding_skill.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/detection_coverage_onboarding/detection_coverage_onboarding_skill.ts
@@ -1,0 +1,730 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Logger } from '@kbn/core/server';
+import type { KibanaRequest } from '@kbn/core-http-server';
+import { ToolType } from '@kbn/agent-builder-common/tools';
+import { ToolResultType } from '@kbn/agent-builder-common/tools/tool_result';
+import { defineSkillType } from '@kbn/agent-builder-server/skills/type_definition';
+import { z } from '@kbn/zod/v4';
+import { GET_INSTALLED_INTEGRATIONS_URL } from '../../../../common/api/detection_engine/fleet_integrations';
+import {
+  GET_PREBUILT_RULES_STATUS_URL,
+  REVIEW_RULE_INSTALLATION_URL,
+  PERFORM_RULE_INSTALLATION_URL,
+} from '../../../../common/api/detection_engine/prebuilt_rules/urls';
+import {
+  DEFAULT_ALERTS_INDEX,
+  DETECTION_ENGINE_RULES_URL_FIND,
+} from '../../../../common/constants';
+import type { SecuritySolutionPluginCoreSetupDependencies } from '../../../plugin_contract';
+
+interface InstalledIntegration {
+  package_name: string;
+  package_title: string;
+  package_version: string;
+  integration_name?: string;
+  integration_title?: string;
+  is_enabled: boolean;
+}
+
+interface RelatedIntegration {
+  package: string;
+  version: string;
+  integration?: string;
+}
+
+interface ReviewRuleResult {
+  rule_id: string;
+  version: number;
+  name: string;
+  description: string;
+  severity: string;
+  risk_score: number;
+  tags: string[];
+  related_integrations: RelatedIntegration[];
+  type: string;
+}
+
+const buildFetchHeaders = (request: KibanaRequest): Record<string, string> => {
+  const headers: Record<string, string> = {
+    'content-type': 'application/json',
+    'kbn-xsrf': 'true',
+    'x-elastic-internal-origin': 'kibana',
+    'elastic-api-version': '1',
+  };
+  const rawHeaders = request.headers;
+  if (rawHeaders.authorization) {
+    headers.authorization = String(rawHeaders.authorization);
+  }
+  if (rawHeaders.cookie) {
+    headers.cookie = String(rawHeaders.cookie);
+  }
+  return headers;
+};
+
+const fetchKibanaApi = async <T>({
+  baseUrl,
+  path,
+  method = 'GET',
+  body,
+  headers,
+}: {
+  baseUrl: string;
+  path: string;
+  method?: string;
+  body?: Record<string, unknown>;
+  headers: Record<string, string>;
+}): Promise<T> => {
+  const response = await fetch(`${baseUrl}${path}`, {
+    method,
+    headers,
+    ...(body ? { body: JSON.stringify(body) } : {}),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Kibana API ${method} ${path} returned ${response.status}: ${errorText}`);
+  }
+
+  return (await response.json()) as T;
+};
+
+export const createDetectionCoverageOnboardingSkill = (
+  core: SecuritySolutionPluginCoreSetupDependencies,
+  logger: Logger
+) =>
+  defineSkillType({
+    id: 'detection-coverage-onboarding',
+    name: 'detection-coverage-onboarding',
+    basePath: 'skills/security/rules',
+    description:
+      'Analyze installed Fleet integrations, find matching prebuilt detection rules, and install them. ' +
+      'Helps new customers onboard detection coverage by recommending appropriate rules for their data sources.',
+    content: `# Detection Coverage Onboarding
+
+## When to Use This Skill
+
+Use this skill when:
+- A user wants to know which detection rules to enable for their data
+- New Fleet integrations have been installed and matching rules should be activated
+- A user asks about detection coverage gaps or wants rule recommendations
+- A user is onboarding to Elastic Security and needs help setting up detection rules
+
+## Workflow
+
+### Step 1: Assess Current State
+Use 'security.detection-coverage.get-rules-status' to check how many prebuilt rules are installed vs available.
+This gives you the big picture before diving into specifics.
+
+### Step 2: List Installed Integrations
+Use 'security.detection-coverage.list-installed-integrations' to discover what data sources the user has configured.
+Report the list of integrations with their enabled status.
+
+### Step 3: Find Matching Rules
+Use 'security.detection-coverage.find-matching-rules' to discover which available prebuilt rules match the installed integrations.
+The tool matches rules by their related_integrations metadata against installed Fleet packages.
+
+Present the findings clearly:
+- Total matching rules available for installation
+- Breakdown by integration (e.g., "Okta: 47 rules, AWS CloudTrail: 23 rules")
+- Breakdown by severity (critical, high, medium, low)
+
+### Step 4: Install Critical Severity Rules
+The find-matching-rules tool only returns critical severity rules in 'rules_to_install'.
+These cover the most impactful threats while avoiding alert fatigue.
+High, medium, and low severity rules are reported in the summary but not included for installation.
+
+Use 'security.detection-coverage.install-rules' to install the rules from 'rules_to_install.critical'.
+Report the installation results: how many succeeded, skipped, or failed.
+
+### Step 5: Monitor Rule Health
+After installing rules, use 'security.detection-coverage.check-rule-health' to verify rules are working:
+- Check for failing rules (execution errors)
+- Check for noisy rules (>100 alerts in 24 hours)
+- Check for warnings (execution gaps, missing indices)
+
+If problems are found:
+- Report which rules are problematic and why
+- Suggest disabling noisy rules or investigating failures
+- For noisy rules, consider adding exceptions or adjusting the rule query
+
+### Step 6: Summary
+Provide a clear summary of what was done:
+- Which integrations were detected
+- How many rules were installed and at what severity levels
+- Health status of installed rules
+- Any rules that failed to install or are problematic
+- Suggestions for next steps (monitor for false positives, review rule tuning)
+
+## Best Practices
+- Always check the current state before making changes
+- Present findings before taking action — let the user confirm
+- Start with critical/high severity rules to avoid alert fatigue
+- If no integrations are installed, suggest the user install integrations first via Fleet
+- If no matching rules are found, explain that the prebuilt rules package may need to be bootstrapped first
+- After installation, always check rule health to catch issues early`,
+    getInlineTools: () => [
+      {
+        id: 'security.detection-coverage.get-rules-status',
+        type: ToolType.builtin,
+        description:
+          'Get the current status of prebuilt detection rules: how many are installed, ' +
+          'how many are available for installation, and how many can be upgraded.',
+        schema: z.object({}),
+        handler: async (_params, context) => {
+          try {
+            const [coreStart] = await core.getStartServices();
+            const { protocol, hostname, port } = coreStart.http.getServerInfo();
+            const basePath = coreStart.http.basePath.serverBasePath;
+            const baseUrl = `${protocol}://${hostname}:${port}${basePath}`;
+            const headers = buildFetchHeaders(context.request);
+
+            const status = await fetchKibanaApi<{
+              stats: {
+                num_prebuilt_rules_installed: number;
+                num_prebuilt_rules_to_install: number;
+                num_prebuilt_rules_to_upgrade: number;
+                num_prebuilt_rules_total_in_package: number;
+              };
+            }>({
+              baseUrl,
+              path: GET_PREBUILT_RULES_STATUS_URL,
+              headers,
+            });
+
+            return {
+              results: [
+                {
+                  type: ToolResultType.other,
+                  data: {
+                    installed: status.stats.num_prebuilt_rules_installed,
+                    available_to_install: status.stats.num_prebuilt_rules_to_install,
+                    available_to_upgrade: status.stats.num_prebuilt_rules_to_upgrade,
+                    total_in_package: status.stats.num_prebuilt_rules_total_in_package,
+                    summary:
+                      status.stats.num_prebuilt_rules_total_in_package === 0
+                        ? 'No prebuilt rules package found. The rules package may need to be bootstrapped first.'
+                        : `${status.stats.num_prebuilt_rules_installed} rules installed out of ${status.stats.num_prebuilt_rules_total_in_package} total. ${status.stats.num_prebuilt_rules_to_install} available for installation, ${status.stats.num_prebuilt_rules_to_upgrade} available for upgrade.`,
+                  },
+                },
+              ],
+            };
+          } catch (error) {
+            return {
+              results: [
+                {
+                  type: ToolResultType.error,
+                  data: {
+                    message: `Failed to get prebuilt rules status: ${
+                      error instanceof Error ? error.message : String(error)
+                    }`,
+                  },
+                },
+              ],
+            };
+          }
+        },
+      },
+      {
+        id: 'security.detection-coverage.list-installed-integrations',
+        type: ToolType.builtin,
+        description:
+          'List all Fleet integrations currently installed in the system. ' +
+          'Returns integration package names, titles, and whether they are enabled.',
+        schema: z.object({}),
+        handler: async (_params, context) => {
+          try {
+            const [coreStart] = await core.getStartServices();
+            const { protocol, hostname, port } = coreStart.http.getServerInfo();
+            const basePath = coreStart.http.basePath.serverBasePath;
+            const baseUrl = `${protocol}://${hostname}:${port}${basePath}`;
+            const headers = buildFetchHeaders(context.request);
+
+            const response = await fetchKibanaApi<{
+              installed_integrations: InstalledIntegration[];
+            }>({
+              baseUrl,
+              path: GET_INSTALLED_INTEGRATIONS_URL,
+              headers,
+            });
+
+            const integrations = response.installed_integrations;
+
+            // Deduplicate by package name to get unique packages
+            const uniquePackages = new Map<
+              string,
+              { package_name: string; package_title: string; integrations: string[]; is_enabled: boolean }
+            >();
+            for (const integration of integrations) {
+              const existing = uniquePackages.get(integration.package_name);
+              if (existing) {
+                if (integration.integration_title) {
+                  existing.integrations.push(integration.integration_title);
+                }
+                if (integration.is_enabled) {
+                  existing.is_enabled = true;
+                }
+              } else {
+                uniquePackages.set(integration.package_name, {
+                  package_name: integration.package_name,
+                  package_title: integration.package_title,
+                  integrations: integration.integration_title
+                    ? [integration.integration_title]
+                    : [],
+                  is_enabled: integration.is_enabled,
+                });
+              }
+            }
+
+            const packages = Array.from(uniquePackages.values());
+
+            return {
+              results: [
+                {
+                  type: ToolResultType.other,
+                  data: {
+                    total_integrations: integrations.length,
+                    total_packages: packages.length,
+                    packages,
+                    raw_integrations: integrations,
+                    summary:
+                      integrations.length === 0
+                        ? 'No Fleet integrations are currently installed. The user should install integrations via Fleet to get detection rule recommendations.'
+                        : `Found ${packages.length} installed package(s) with ${integrations.length} integration(s) total.`,
+                  },
+                },
+              ],
+            };
+          } catch (error) {
+            return {
+              results: [
+                {
+                  type: ToolResultType.error,
+                  data: {
+                    message: `Failed to list installed integrations: ${
+                      error instanceof Error ? error.message : String(error)
+                    }`,
+                  },
+                },
+              ],
+            };
+          }
+        },
+      },
+      {
+        id: 'security.detection-coverage.find-matching-rules',
+        type: ToolType.builtin,
+        description:
+          'Find prebuilt detection rules that match installed Fleet integrations. ' +
+          'Returns available (not yet installed) rules grouped by integration and severity. ' +
+          'Optionally filter by specific integration package names.',
+        schema: z.object({
+          integrations: z
+            .array(z.string())
+            .optional()
+            .describe(
+              'Optional list of integration package names to filter by (e.g., ["okta", "aws"]). ' +
+                'If not provided, matches against all installed integrations.'
+            ),
+        }),
+        handler: async (params, context) => {
+          try {
+            const filterIntegrations = (params as { integrations?: string[] }).integrations;
+            const [coreStart] = await core.getStartServices();
+            const { protocol, hostname, port } = coreStart.http.getServerInfo();
+            const basePath = coreStart.http.basePath.serverBasePath;
+            const baseUrl = `${protocol}://${hostname}:${port}${basePath}`;
+            const headers = buildFetchHeaders(context.request);
+
+            // Step 1: Get installed integrations if no filter provided
+            let targetPackages: Set<string>;
+            if (filterIntegrations && filterIntegrations.length > 0) {
+              targetPackages = new Set(filterIntegrations);
+            } else {
+              const integrationsResponse = await fetchKibanaApi<{
+                installed_integrations: InstalledIntegration[];
+              }>({
+                baseUrl,
+                path: GET_INSTALLED_INTEGRATIONS_URL,
+                headers,
+              });
+
+              targetPackages = new Set(
+                integrationsResponse.installed_integrations.map((i) => i.package_name)
+              );
+
+              if (targetPackages.size === 0) {
+                return {
+                  results: [
+                    {
+                      type: ToolResultType.other,
+                      data: {
+                        total_matching: 0,
+                        summary:
+                          'No installed integrations found. Install Fleet integrations first to get rule recommendations.',
+                      },
+                    },
+                  ],
+                };
+              }
+            }
+
+            // Step 2: Get all available (not yet installed) prebuilt rules
+            const reviewResponse = await fetchKibanaApi<{
+              rules: ReviewRuleResult[];
+              total: number;
+              stats: { num_rules_to_install: number; tags: string[] };
+            }>({
+              baseUrl,
+              path: REVIEW_RULE_INSTALLATION_URL,
+              method: 'POST',
+              body: { page: 1, per_page: 10000 },
+              headers,
+            });
+
+            // Step 3: Filter rules by matching related_integrations
+            const matchingRules = reviewResponse.rules.filter((rule) =>
+              (rule.related_integrations ?? []).some((ri) => targetPackages.has(ri.package))
+            );
+
+            // Step 4: Group by integration (counts only, not full rule lists)
+            const byIntegration: Record<
+              string,
+              { count: number; severity: { critical: number; high: number; medium: number; low: number } }
+            > = {};
+            for (const rule of matchingRules) {
+              for (const ri of rule.related_integrations ?? []) {
+                if (targetPackages.has(ri.package)) {
+                  if (!byIntegration[ri.package]) {
+                    byIntegration[ri.package] = {
+                      count: 0,
+                      severity: { critical: 0, high: 0, medium: 0, low: 0 },
+                    };
+                  }
+                  byIntegration[ri.package].count += 1;
+                  const sev = rule.severity as keyof typeof byIntegration[string]['severity'];
+                  if (sev in byIntegration[ri.package].severity) {
+                    byIntegration[ri.package].severity[sev] += 1;
+                  }
+                }
+              }
+            }
+
+            // Step 5: Severity breakdown
+            const severityBreakdown = { critical: 0, high: 0, medium: 0, low: 0 };
+            for (const rule of matchingRules) {
+              const sev = rule.severity as keyof typeof severityBreakdown;
+              if (sev in severityBreakdown) {
+                severityBreakdown[sev] += 1;
+              }
+            }
+
+            // Return compact data: summary stats + rule_id/version pairs for installation
+            // Only include critical severity rules to avoid alert fatigue and keep install fast
+            const rulesBySeverity: Record<string, Array<{ rule_id: string; version: number }>> = {
+              critical: [],
+            };
+            for (const rule of matchingRules) {
+              const sev = rule.severity;
+              if (sev in rulesBySeverity) {
+                rulesBySeverity[sev].push({ rule_id: rule.rule_id, version: rule.version });
+              }
+            }
+
+            return {
+              results: [
+                {
+                  type: ToolResultType.other,
+                  data: {
+                    total_available_to_install: reviewResponse.total,
+                    total_matching: matchingRules.length,
+                    target_integrations: Array.from(targetPackages),
+                    severity_breakdown: severityBreakdown,
+                    by_integration: byIntegration,
+                    rules_to_install: rulesBySeverity,
+                    summary: `Found ${matchingRules.length} installable rules matching ${targetPackages.size} integration(s) out of ${reviewResponse.total} total available. Severity breakdown: ${severityBreakdown.critical} critical, ${severityBreakdown.high} high, ${severityBreakdown.medium} medium, ${severityBreakdown.low} low.`,
+                  },
+                },
+              ],
+            };
+          } catch (error) {
+            return {
+              results: [
+                {
+                  type: ToolResultType.error,
+                  data: {
+                    message: `Failed to find matching rules: ${
+                      error instanceof Error ? error.message : String(error)
+                    }`,
+                  },
+                },
+              ],
+            };
+          }
+        },
+      },
+      {
+        id: 'security.detection-coverage.install-rules',
+        type: ToolType.builtin,
+        description:
+          'Install specific prebuilt detection rules by their rule IDs. ' +
+          'Each rule must be specified with its rule_id and version number.',
+        schema: z.object({
+          rules: z
+            .array(
+              z.object({
+                rule_id: z.string().describe('The prebuilt rule ID (e.g., "rule-id-abc-123")'),
+                version: z.number().describe('The rule version number to install'),
+              })
+            )
+            .min(1)
+            .describe('Array of rules to install, each with rule_id and version'),
+        }),
+        handler: async ({ rules }, context) => {
+          try {
+            const [coreStart] = await core.getStartServices();
+            const { protocol, hostname, port } = coreStart.http.getServerInfo();
+            const basePath = coreStart.http.basePath.serverBasePath;
+            const baseUrl = `${protocol}://${hostname}:${port}${basePath}`;
+            const headers = buildFetchHeaders(context.request);
+
+            const installResponse = await fetchKibanaApi<{
+              summary: {
+                total: number;
+                succeeded: number;
+                skipped: number;
+                failed: number;
+              };
+              results: {
+                created: Array<{ rule_id: string; name: string; severity: string }>;
+                skipped: Array<{ rule_id: string; reason: string }>;
+              };
+              errors: Array<{ message: string; rules: Array<{ rule_id: string }> }>;
+            }>({
+              baseUrl,
+              path: PERFORM_RULE_INSTALLATION_URL,
+              method: 'POST',
+              body: {
+                mode: 'SPECIFIC_RULES',
+                rules,
+              },
+              headers,
+            });
+
+            const { summary } = installResponse;
+
+            return {
+              results: [
+                {
+                  type: ToolResultType.other,
+                  data: {
+                    summary,
+                    created: installResponse.results.created.map((r) => ({
+                      rule_id: r.rule_id,
+                      name: r.name,
+                      severity: r.severity,
+                    })),
+                    skipped: installResponse.results.skipped,
+                    errors: installResponse.errors,
+                    verdict:
+                      summary.failed === 0
+                        ? `Successfully installed ${summary.succeeded} rule(s). ${summary.skipped} skipped (already installed).`
+                        : `Installed ${summary.succeeded} rule(s), but ${summary.failed} failed. Check errors for details.`,
+                  },
+                },
+              ],
+            };
+          } catch (error) {
+            return {
+              results: [
+                {
+                  type: ToolResultType.error,
+                  data: {
+                    message: `Failed to install rules: ${
+                      error instanceof Error ? error.message : String(error)
+                    }`,
+                  },
+                },
+              ],
+            };
+          }
+        },
+      },
+      {
+        id: 'security.detection-coverage.check-rule-health',
+        type: ToolType.builtin,
+        description:
+          'Check the health of installed prebuilt detection rules. ' +
+          'Returns execution status (running, failed, warning) and alert counts for recently installed rules. ' +
+          'Use this after installing rules to verify they are working correctly.',
+        schema: z.object({
+          max_rules: z
+            .number()
+            .min(1)
+            .max(100)
+            .default(20)
+            .optional()
+            .describe('Maximum number of rules to check (default 20, most recently installed first)'),
+        }),
+        handler: async (params, context) => {
+          try {
+            const maxRules = (params as { max_rules?: number }).max_rules ?? 20;
+            const [coreStart] = await core.getStartServices();
+            const { protocol, hostname, port } = coreStart.http.getServerInfo();
+            const basePath = coreStart.http.basePath.serverBasePath;
+            const baseUrl = `${protocol}://${hostname}:${port}${basePath}`;
+            const headers = {
+              ...buildFetchHeaders(context.request),
+              'elastic-api-version': '2023-10-31',
+            };
+
+            // Step 1: Find installed prebuilt rules sorted by updated_at (most recent first)
+            const findResponse = await fetchKibanaApi<{
+              data: Array<{
+                id: string;
+                name: string;
+                rule_id: string;
+                enabled: boolean;
+                severity: string;
+                execution_summary?: {
+                  last_execution: {
+                    date: string;
+                    status: string;
+                    status_order: number;
+                    message: string;
+                    metrics: {
+                      total_search_duration_ms?: number;
+                      execution_gap_duration_s?: number;
+                    };
+                  };
+                };
+              }>;
+              total: number;
+            }>({
+              baseUrl,
+              path: `${DETECTION_ENGINE_RULES_URL_FIND}?filter=alert.attributes.params.immutable:true&sort_field=updatedAt&sort_order=desc&per_page=${maxRules}`,
+              headers,
+            });
+
+            // Step 2: Check alert counts for each rule (last 24h)
+            const alertsIndex = `${DEFAULT_ALERTS_INDEX}-${context.spaceId}`;
+            const ruleIds = findResponse.data.map((r) => r.id);
+
+            let alertCountsByRule: Record<string, number> = {};
+            if (ruleIds.length > 0) {
+              const alertsQuery = await context.esClient.asCurrentUser.search({
+                index: alertsIndex,
+                size: 0,
+                query: {
+                  bool: {
+                    filter: [
+                      { terms: { 'kibana.alert.rule.uuid': ruleIds } },
+                      { range: { '@timestamp': { gte: 'now-24h' } } },
+                    ],
+                  },
+                },
+                aggs: {
+                  by_rule: {
+                    terms: { field: 'kibana.alert.rule.uuid', size: maxRules },
+                  },
+                },
+                ignore_unavailable: true,
+              });
+
+              const buckets =
+                (alertsQuery.aggregations?.by_rule as { buckets?: Array<{ key: string; doc_count: number }> })
+                  ?.buckets ?? [];
+              alertCountsByRule = Object.fromEntries(
+                buckets.map((b) => [b.key, b.doc_count])
+              );
+            }
+
+            // Step 3: Build health report
+            const NOISY_THRESHOLD = 100;
+            const rules = findResponse.data.map((rule) => {
+              const alertCount24h = alertCountsByRule[rule.id] ?? 0;
+              const execStatus = rule.execution_summary?.last_execution?.status ?? 'unknown';
+              const execMessage = rule.execution_summary?.last_execution?.message ?? '';
+              const execGap =
+                rule.execution_summary?.last_execution?.metrics?.execution_gap_duration_s;
+
+              let health: string;
+              if (execStatus === 'failed') {
+                health = 'failing';
+              } else if (alertCount24h > NOISY_THRESHOLD) {
+                health = 'noisy';
+              } else if (execStatus === 'warning' || (execGap && execGap > 300)) {
+                health = 'warning';
+              } else if (execStatus === 'succeeded' || execStatus === 'running') {
+                health = 'healthy';
+              } else {
+                health = 'unknown';
+              }
+
+              return {
+                id: rule.id,
+                rule_id: rule.rule_id,
+                name: rule.name,
+                enabled: rule.enabled,
+                severity: rule.severity,
+                health,
+                execution_status: execStatus,
+                execution_message: execMessage.substring(0, 200),
+                alerts_last_24h: alertCount24h,
+                execution_gap_seconds: execGap,
+              };
+            });
+
+            const failing = rules.filter((r) => r.health === 'failing');
+            const noisy = rules.filter((r) => r.health === 'noisy');
+            const warnings = rules.filter((r) => r.health === 'warning');
+            const healthy = rules.filter((r) => r.health === 'healthy');
+
+            return {
+              results: [
+                {
+                  type: ToolResultType.other,
+                  data: {
+                    total_checked: rules.length,
+                    total_in_system: findResponse.total,
+                    summary: {
+                      healthy: healthy.length,
+                      failing: failing.length,
+                      noisy: noisy.length,
+                      warning: warnings.length,
+                    },
+                    failing_rules: failing,
+                    noisy_rules: noisy,
+                    warning_rules: warnings,
+                    all_rules: rules,
+                    verdict:
+                      failing.length === 0 && noisy.length === 0
+                        ? `All ${rules.length} checked rules are healthy. ${healthy.length} running normally.`
+                        : `Issues found: ${failing.length} failing, ${noisy.length} noisy (>${NOISY_THRESHOLD} alerts/24h), ${warnings.length} warnings. Review details below.`,
+                  },
+                },
+              ],
+            };
+          } catch (error) {
+            return {
+              results: [
+                {
+                  type: ToolResultType.error,
+                  data: {
+                    message: `Failed to check rule health: ${
+                      error instanceof Error ? error.message : String(error)
+                    }`,
+                  },
+                },
+              ],
+            };
+          }
+        },
+      },
+    ],
+  });

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/detection_coverage_onboarding/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/detection_coverage_onboarding/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { createDetectionCoverageOnboardingSkill } from './detection_coverage_onboarding_skill';

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/index.ts
@@ -6,6 +6,7 @@
  */
 
 export { alertAnalysisSkill } from './alert_analysis';
+export { threatCoverageInitializationSkill } from './threat_coverage_initialization';
 export { threatHuntingSkill } from './threat_hunting';
 export { createAutomaticTroubleshootingSkill } from './automatic_troubleshooting';
 export { getDetectionRuleEditSkill } from './detection_rule_edit';

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/register_skills.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/register_skills.ts
@@ -14,12 +14,15 @@ import { getDetectionRuleEditSkill } from './detection_rule_edit';
 import { getEntityAnalyticsSkill } from './entity_analytics';
 import { threatHuntingSkill } from './threat_hunting';
 import { alertAnalysisSkill } from './alert_analysis';
+import { createDetectionCoverageOnboardingSkill } from './detection_coverage_onboarding';
 import type { EntityAnalyticsRoutesDeps } from '../../lib/entity_analytics/types';
 import { findSecurityMlJobsSkill } from './find_security_ml_jobs';
 import { threatCoverageInitializationSkill } from './threat_coverage_initialization';
+import type { SecuritySolutionPluginCoreSetupDependencies } from '../../plugin_contract';
 
 interface RegisterSkillsOpts {
   agentBuilder: AgentBuilderPluginSetup;
+  core: SecuritySolutionPluginCoreSetupDependencies;
   experimentalFeatures: ExperimentalFeatures;
   getStartServices: EntityAnalyticsRoutesDeps['getStartServices'];
   kibanaVersion: string;
@@ -35,6 +38,7 @@ interface RegisterSkillsOpts {
  */
 export const registerSkills = async ({
   agentBuilder,
+  core,
   experimentalFeatures,
   getStartServices,
   kibanaVersion,
@@ -61,4 +65,5 @@ export const registerSkills = async ({
   await agentBuilder.skills.register(threatHuntingSkill);
   await agentBuilder.skills.register(alertAnalysisSkill);
   await agentBuilder.skills.register(threatCoverageInitializationSkill);
+  await agentBuilder.skills.register(createDetectionCoverageOnboardingSkill(core, logger));
 };

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/register_skills.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/register_skills.ts
@@ -16,6 +16,7 @@ import { threatHuntingSkill } from './threat_hunting';
 import { alertAnalysisSkill } from './alert_analysis';
 import type { EntityAnalyticsRoutesDeps } from '../../lib/entity_analytics/types';
 import { findSecurityMlJobsSkill } from './find_security_ml_jobs';
+import { threatCoverageInitializationSkill } from './threat_coverage_initialization';
 
 interface RegisterSkillsOpts {
   agentBuilder: AgentBuilderPluginSetup;
@@ -59,4 +60,5 @@ export const registerSkills = async ({
 
   await agentBuilder.skills.register(threatHuntingSkill);
   await agentBuilder.skills.register(alertAnalysisSkill);
+  await agentBuilder.skills.register(threatCoverageInitializationSkill);
 };

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/skills.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/skills.test.ts
@@ -9,8 +9,9 @@ import { platformCoreTools } from '@kbn/agent-builder-common';
 import { validateSkillDefinition } from '@kbn/agent-builder-server/skills/type_definition';
 import { threatHuntingSkill } from './threat_hunting';
 import { alertAnalysisSkill } from './alert_analysis';
+import { threatCoverageInitializationSkill } from './threat_coverage_initialization';
 
-const ALL_SKILLS = [threatHuntingSkill, alertAnalysisSkill];
+const ALL_SKILLS = [threatHuntingSkill, alertAnalysisSkill, threatCoverageInitializationSkill];
 
 describe('Security Skills', () => {
   describe('threat-hunting skill', () => {
@@ -95,6 +96,45 @@ describe('Security Skills', () => {
 
     it('content references entity-analytics skill for deeper profiling', () => {
       expect(alertAnalysisSkill.content).toContain('entity-analytics');
+    });
+  });
+
+  describe('threat-coverage-initialization skill', () => {
+    it('validates successfully via validateSkillDefinition', async () => {
+      await expect(
+        validateSkillDefinition(threatCoverageInitializationSkill)
+      ).resolves.toBeDefined();
+    });
+
+    it('has non-empty content', () => {
+      expect(threatCoverageInitializationSkill.content.length).toBeGreaterThan(100);
+    });
+
+    it('has description under 1024 characters', () => {
+      expect(threatCoverageInitializationSkill.description.length).toBeLessThanOrEqual(1024);
+    });
+
+    it('returns 4 registry tools', () => {
+      const tools = threatCoverageInitializationSkill.getRegistryTools!();
+      expect(tools).toHaveLength(4);
+    });
+
+    it('includes platform.core.list_indices for data discovery', () => {
+      const tools = threatCoverageInitializationSkill.getRegistryTools!();
+      expect(tools).toContain(platformCoreTools.listIndices);
+    });
+
+    it('includes fleet.list_installed_integrations for integration assessment', () => {
+      const tools = threatCoverageInitializationSkill.getRegistryTools!();
+      expect(tools).toContain('fleet.list_installed_integrations');
+    });
+
+    it('content mentions MITRE ATT&CK mapping', () => {
+      expect(threatCoverageInitializationSkill.content).toContain('MITRE ATT&CK');
+    });
+
+    it('has no inline tools', () => {
+      expect(threatCoverageInitializationSkill.getInlineTools).toBeUndefined();
     });
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/threat_coverage_initialization/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/threat_coverage_initialization/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { threatCoverageInitializationSkill } from './threat_coverage_initialization_skill';

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/threat_coverage_initialization/threat_coverage_initialization_skill.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/threat_coverage_initialization/threat_coverage_initialization_skill.ts
@@ -125,7 +125,8 @@ Before installing rules, present the user with a coverage plan:
 ### Step 6: Add "auto-installed" tag
 
 - Use '${SECURITY_BULK_ACTIONS_TOOL_ID}' to add tags to rules
-- Add 'auto-install' tag to the rules installed at the Step 5
+- Add 'auto-installed' tag to the rules installed at the Step 5
+- Add tags to rules in batches (max 1000 rules per call)
 
 ### Step 7: Enable installed rules
 

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/threat_coverage_initialization/threat_coverage_initialization_skill.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/threat_coverage_initialization/threat_coverage_initialization_skill.ts
@@ -1,0 +1,153 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { platformCoreTools } from '@kbn/agent-builder-common';
+import { defineSkillType } from '@kbn/agent-builder-server/skills/type_definition';
+import {
+  SECURITY_FIND_PREBUILT_RULES_TOOL_ID,
+  SECURITY_INSTALL_PREBUILT_RULES_TOOL_ID,
+} from '../../tools';
+
+const FLEET_LIST_INSTALLED_INTEGRATIONS_TOOL_ID = 'fleet.list_installed_integrations';
+
+export const threatCoverageInitializationSkill = defineSkillType({
+  id: 'threat-coverage-initialization',
+  name: 'threat-coverage-initialization',
+  basePath: 'skills/security',
+  description:
+    'Closed-loop security posture automation that initializes threat detection coverage. ' +
+    'Assesses available security log data and installed integrations, maps data sources to MITRE ATT&CK ' +
+    'tactics and techniques, identifies coverage gaps, finds matching prebuilt detection rules, and installs them. ' +
+    'Use when a user wants to bootstrap detection coverage, assess their security posture, or close detection gaps.',
+  content: `# Threat Coverage Initialization Guide
+
+## When to Use This Skill
+
+Use this skill when:
+- Setting up initial detection coverage for a new or existing deployment
+- Assessing what security data sources are available and what detection rules should be enabled
+- Closing detection gaps by mapping available data to MITRE ATT&CK coverage
+- Bootstrapping security posture after installing new integrations
+- Answering questions like "What detection rules should I enable?" or "What threats am I not covered for?"
+
+## Threat Coverage Initialization Process
+
+This is a closed-loop process: assess data → map to MITRE ATT&CK → identify gaps → find rules → install rules.
+
+### Step 1: Assess Available Security Data
+
+First, determine what security telemetry is available in the environment.
+
+#### 1a. Discover Log Indices
+- Use 'platform.core.list_indices' with pattern \`logs-*\` to discover available security log indices
+- Look for key security data sources:
+  - \`logs-endpoint.events.*\` — Elastic Endpoint (process, network, file, registry events)
+  - \`logs-windows.*\` or \`winlogbeat-*\` — Windows event logs (Sysmon, Security, PowerShell)
+  - \`logs-system.*\` — System logs (auth, syslog)
+  - \`logs-azure.*\`, \`logs-aws.*\`, \`logs-gcp.*\` — Cloud provider logs
+  - \`logs-o365.*\` — Microsoft 365 audit logs
+  - \`logs-okta.*\` — Okta identity logs
+  - \`logs-network_traffic.*\` or \`packetbeat-*\` — Network traffic
+  - \`logs-firewall.*\`, \`logs-cisco.*\`, \`logs-paloalto.*\` — Firewall logs
+  - \`filebeat-*\` — General log collection
+- Note which index patterns exist and have data — these determine what detection rules can run
+
+#### 1b. Check Installed Integrations
+- Use 'fleet.list_installed_integrations' to list all installed Fleet integrations
+- Filter by \`dataStreamType: "logs"\` to focus on log-producing integrations
+- Each integration maps to specific data sources and MITRE ATT&CK coverage areas
+- Key integration-to-coverage mappings:
+  - **endpoint** → Process, network, file monitoring (broad MITRE coverage)
+  - **windows** → Windows event logs (Persistence, Privilege Escalation, Credential Access)
+  - **system** → Authentication events (Initial Access, Credential Access)
+  - **aws/azure/gcp** → Cloud infrastructure (Initial Access, Persistence, Defense Evasion in cloud)
+  - **o365** → Email/collaboration (Initial Access via phishing, Collection)
+  - **okta** → Identity provider (Initial Access, Persistence, Credential Access)
+  - **network_traffic** → Network monitoring (Command and Control, Lateral Movement, Exfiltration)
+
+### Step 2: Map Data to MITRE ATT&CK Tactics
+
+Based on the discovered data sources, determine which MITRE ATT&CK tactics can be covered:
+
+| Data Source | Primary MITRE Tactics |
+|---|---|
+| Endpoint process events | Execution, Persistence, Privilege Escalation, Defense Evasion, Discovery |
+| Endpoint network events | Command and Control, Lateral Movement, Exfiltration |
+| Endpoint file events | Persistence, Defense Evasion, Collection |
+| Windows Security logs | Initial Access, Credential Access, Lateral Movement |
+| Windows Sysmon | Execution, Persistence, Defense Evasion, Discovery |
+| Windows PowerShell | Execution, Defense Evasion |
+| System auth logs | Initial Access, Credential Access, Persistence |
+| Cloud provider logs | Initial Access, Persistence, Privilege Escalation, Defense Evasion (cloud) |
+| Identity provider logs | Initial Access, Credential Access, Persistence |
+| Network traffic | Command and Control, Lateral Movement, Exfiltration |
+| Email/O365 logs | Initial Access (phishing), Collection |
+| Firewall logs | Command and Control, Exfiltration, Initial Access |
+
+### Step 3: Find Matching Prebuilt Rules
+
+For each MITRE ATT&CK tactic that the available data can support, search for prebuilt rules:
+
+- Use 'security.find_prebuilt_rules' with the \`mitre_tactic\` parameter to find rules for each covered tactic
+- Cross-reference rule \`related_integrations\` with the installed integrations from Step 1b
+- Prioritize rules that:
+  1. Match installed integrations (the data source exists)
+  2. Cover high-impact tactics (Initial Access, Execution, Persistence, Credential Access)
+  3. Have higher severity (critical and high first)
+- Use \`mitre_technique_id\` for more targeted searches when specific technique coverage is needed
+- Use \`tags\` to filter by OS platform (e.g., "Windows", "Linux", "macOS") matching the environment
+- Request up to 50 rules per query using the \`limit\` parameter to get comprehensive results
+
+### Step 4: Present Coverage Plan
+
+Before installing rules, present the user with a coverage plan:
+- Group recommended rules by MITRE ATT&CK tactic
+- Show rule name, severity, and the data source it requires
+- Highlight any coverage gaps where data exists but no rules were found
+- Highlight tactics where no data sources are available (true blind spots)
+- Let the user review and approve the selection before proceeding
+
+### Step 5: Install Selected Rules
+
+- Use 'security.install_prebuilt_rules' to install the approved rules
+- Install in batches grouped by tactic or severity (max 50 rules per call)
+- Report results: successfully installed, already installed (skipped), and any failures
+- After installation, summarize the new coverage:
+  - Total rules installed by tactic
+  - Remaining coverage gaps
+  - Recommendations for additional data sources to close blind spots
+
+## Coverage Assessment Template
+
+When presenting results, use this structure:
+
+### Data Sources Available
+- List discovered indices and installed integrations
+
+### MITRE ATT&CK Coverage Map
+- For each tactic: data source → available rules → recommended rules
+
+### Recommendations
+- **Install now**: Rules that match existing data (high confidence)
+- **Install after data onboarding**: Rules that need additional integrations
+- **Blind spots**: Tactics with no data source coverage
+
+## Best Practices
+- Always assess data sources before searching for rules — rules without matching data generate false negatives or fail to run
+- Prioritize breadth of tactic coverage over depth within a single tactic during initial setup
+- Start with high and critical severity rules, then expand to medium and low
+- Cross-reference rule \`related_integrations\` with installed integrations to ensure rules will have data
+- Present the coverage plan to the user before installing — let them make informed decisions
+- After installation, recommend a review cycle to tune rules and reduce false positives
+- Suggest additional integrations to close identified blind spots`,
+  getRegistryTools: () => [
+    platformCoreTools.listIndices,
+    FLEET_LIST_INSTALLED_INTEGRATIONS_TOOL_ID,
+    SECURITY_FIND_PREBUILT_RULES_TOOL_ID,
+    SECURITY_INSTALL_PREBUILT_RULES_TOOL_ID,
+  ],
+});

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/threat_coverage_initialization/threat_coverage_initialization_skill.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/threat_coverage_initialization/threat_coverage_initialization_skill.ts
@@ -10,6 +10,7 @@ import { defineSkillType } from '@kbn/agent-builder-server/skills/type_definitio
 import {
   SECURITY_FIND_PREBUILT_RULES_TOOL_ID,
   SECURITY_INSTALL_PREBUILT_RULES_TOOL_ID,
+  SECURITY_BULK_ACTIONS_TOOL_ID,
 } from '../../tools';
 
 const FLEET_LIST_INSTALLED_INTEGRATIONS_TOOL_ID = 'fleet.list_installed_integrations';
@@ -92,7 +93,7 @@ Based on the discovered data sources, determine which MITRE ATT&CK tactics can b
 
 For each MITRE ATT&CK tactic that the available data can support, search for prebuilt rules:
 
-- Use 'security.find_prebuilt_rules' with the \`mitre_tactic\` parameter to find rules for each covered tactic
+- Use '${SECURITY_FIND_PREBUILT_RULES_TOOL_ID}' with the \`mitre_tactic\` parameter to find rules for each covered tactic
 - Cross-reference rule \`related_integrations\` with the installed integrations from Step 1b
 - Prioritize rules that:
   1. Match installed integrations (the data source exists)
@@ -113,13 +114,25 @@ Before installing rules, present the user with a coverage plan:
 
 ### Step 5: Install Selected Rules
 
-- Use 'security.install_prebuilt_rules' to install the approved rules
+- Use '${SECURITY_INSTALL_PREBUILT_RULES_TOOL_ID}' to install the approved rules
 - Install in batches grouped by tactic or severity (max 50 rules per call)
 - Report results: successfully installed, already installed (skipped), and any failures
 - After installation, summarize the new coverage:
   - Total rules installed by tactic
   - Remaining coverage gaps
   - Recommendations for additional data sources to close blind spots
+
+### Step 6: Add "auto-installed" tag
+
+- Use '${SECURITY_BULK_ACTIONS_TOOL_ID}' to add tags to rules
+- Add 'auto-install' tag to the rules installed at the Step 5
+
+### Step 7: Enable installed rules
+
+- Use '${SECURITY_BULK_ACTIONS_TOOL_ID}' to enable rules
+- Enable the prebuilt rules previously installed at the Step 5
+- Enable rules in batches (max 1000 rules per call)
+- Report results: N rules were enabled
 
 ## Coverage Assessment Template
 
@@ -149,5 +162,6 @@ When presenting results, use this structure:
     FLEET_LIST_INSTALLED_INTEGRATIONS_TOOL_ID,
     SECURITY_FIND_PREBUILT_RULES_TOOL_ID,
     SECURITY_INSTALL_PREBUILT_RULES_TOOL_ID,
+    SECURITY_BULK_ACTIONS_TOOL_ID,
   ],
 });

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/threat_coverage_initialization/threat_coverage_initialization_skill.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/threat_coverage_initialization/threat_coverage_initialization_skill.ts
@@ -41,8 +41,6 @@ This is a closed-loop process: assess data → map to MITRE ATT&CK → identify 
 
 ### Step 1: Assess Available Security Data
 
-First, determine what security telemetry is available in the environment.
-
 #### 1a. Discover Log Indices
 - Use 'platform.core.list_indices' with pattern \`logs-*\` to discover available security log indices
 - Look for key security data sources:
@@ -95,43 +93,39 @@ For each MITRE ATT&CK tactic that the available data can support, search for pre
 
 - Use '${SECURITY_FIND_PREBUILT_RULES_TOOL_ID}' with the \`mitre_tactic\` parameter to find rules for each covered tactic
 - Cross-reference rule \`related_integrations\` with the installed integrations from Step 1b
-- Prioritize rules that:
-  1. Match installed integrations (the data source exists)
-  2. Cover high-impact tactics (Initial Access, Execution, Persistence, Credential Access)
-  3. Have higher severity (critical and high first)
+- **Hard requirements (do not deviate):**
+  1. Only consider rules with severity \`critical\`, \`high\`, or \`medium\`. **Never** include rules with \`low\` severity.
+  2. Each rule's \`related_integrations\` must intersect the installed integrations from Step 1b.
+  3. The final selection installed in Step 5 must be **at most 15 rules total**, across all tactics combined.
+- **Selection priority** within the 15-rule budget:
+  1. Critical severity first, then high, then medium
+  2. Within the same severity, prefer high-impact tactics (Initial Access, Execution, Persistence, Credential Access)
+  3. Within the same severity and tactic, prefer broader integration coverage
 - Use \`mitre_technique_id\` for more targeted searches when specific technique coverage is needed
 - Use \`tags\` to filter by OS platform (e.g., "Windows", "Linux", "macOS") matching the environment
-- Request up to 50 rules per query using the \`limit\` parameter to get comprehensive results
+- Request up to 50 rules per query using the \`limit\` parameter so you can rank and pick the best 15
 
-### Step 4: Present Coverage Plan
-
-Before installing rules, present the user with a coverage plan:
-- Group recommended rules by MITRE ATT&CK tactic
-- Show rule name, severity, and the data source it requires
-- Highlight any coverage gaps where data exists but no rules were found
-- Highlight tactics where no data sources are available (true blind spots)
-- Let the user review and approve the selection before proceeding
-
-### Step 5: Install Selected Rules
+### Step 4: Install Selected Rules
 
 - Use '${SECURITY_INSTALL_PREBUILT_RULES_TOOL_ID}' to install the approved rules
-- Install in batches grouped by tactic or severity (max 50 rules per call)
+- Install **at most 15 rules** in a single call (the budget cap from Step 3)
+- Never install rules with \`low\` severity
 - Report results: successfully installed, already installed (skipped), and any failures
 - After installation, summarize the new coverage:
   - Total rules installed by tactic
   - Remaining coverage gaps
   - Recommendations for additional data sources to close blind spots
 
-### Step 6: Add "auto-installed" tag
+### Step 5: Add "auto-installed" tag
 
 - Use '${SECURITY_BULK_ACTIONS_TOOL_ID}' to add tags to rules
 - Add 'auto-installed' tag to the rules installed at the Step 5
 - Add tags to rules in batches (max 1000 rules per call)
 
-### Step 7: Enable installed rules
+### Step 6: Enable installed rules
 
 - Use '${SECURITY_BULK_ACTIONS_TOOL_ID}' to enable rules
-- Enable the prebuilt rules previously installed at the Step 5
+- Enable the prebuilt rules previously installed at the Step 4
 - Enable rules in batches (max 1000 rules per call)
 - Report results: N rules were enabled
 
@@ -153,7 +147,8 @@ When presenting results, use this structure:
 ## Best Practices
 - Always assess data sources before searching for rules — rules without matching data generate false negatives or fail to run
 - Prioritize breadth of tactic coverage over depth within a single tactic during initial setup
-- Start with high and critical severity rules, then expand to medium and low
+- Install only critical, high, and medium severity rules; never install low severity
+- Stay within the 15-rule total budget — quality over quantity
 - Cross-reference rule \`related_integrations\` with installed integrations to ensure rules will have data
 - Present the coverage plan to the user before installing — let them make informed decisions
 - After installation, recommend a review cycle to tune rules and reduce false positives

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/bulk_actions_tool.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/bulk_actions_tool.ts
@@ -88,7 +88,7 @@ export const bulkActionsTool = (
   return {
     id: SECURITY_BULK_ACTIONS_TOOL_ID,
     type: ToolType.builtin,
-    description: `Apply bulk actions to security detection rules. Supports enabling, disabling, deleting, and managing tags on multiple rules at once. Rules can be identified by their saved object IDs ("rule_ids") or rule signature IDs ("rule_signature_ids"). Use the alerts tool or find_prebuilt_rules tool first to discover rule IDs, then use this tool to perform actions on them.`,
+    description: `Apply bulk actions to security detection rules. Supports enabling, disabling, deleting, and managing tags on multiple rules at once. Rules can be identified by their saved object IDs ("ids") or rule signature IDs ("rule_ids"). Use the alerts tool or find_prebuilt_rules tool first to discover rule IDs, then use this tool to perform actions on them.`,
     schema: bulkActionsSchema,
     availability: {
       cacheMode: 'space',

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/bulk_actions_tool.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/bulk_actions_tool.ts
@@ -30,12 +30,42 @@ import { createPrebuiltRuleAssetsClient } from '../../lib/detection_engine/prebu
 import { fetchRulesByQueryOrIds } from '../../lib/detection_engine/rule_management/api/rules/bulk_actions/fetch_rules_by_query_or_ids';
 import { bulkEnableDisableRules } from '../../lib/detection_engine/rule_management/api/rules/bulk_actions/bulk_enable_disable_rules';
 import { bulkEditRules } from '../../lib/detection_engine/rule_management/logic/bulk_actions/bulk_edit_rules';
+import { findRules } from '../../lib/detection_engine/rule_management/logic/search/find_rules';
 import type { ProductFeaturesService } from '../../lib/product_features_service';
 import type { RuleAlertType } from '../../lib/detection_engine/rule_schema';
 
-const MAX_RULES_PER_BULK_ACTION = 50;
+const MAX_RULES_PER_BULK_ACTION = 1000;
 
-type BulkAction = 'enable' | 'disable' | 'delete' | 'add_tags' | 'delete_tags' | 'set_tags';
+const bulkActionsSchema = z.object({
+  action: z
+    .enum(['enable', 'disable', 'delete', 'add_tags', 'delete_tags', 'set_tags'])
+    .describe(
+      'The bulk action to perform. "enable" enables rules, "disable" disables rules, "delete" deletes rules, "add_tags" adds tags to rules, "delete_tags" removes tags from rules, "set_tags" overwrites all tags on rules.'
+    ),
+  ids: z
+    .array(z.string())
+    .min(1)
+    .max(MAX_RULES_PER_BULK_ACTION)
+    .optional()
+    .describe(
+      'Array of rule saved object IDs (the alerting framework "id") to apply the action to. At least one of "rule_ids" or "rule_signature_ids" must be provided.'
+    ),
+  rule_ids: z
+    .array(z.string())
+    .min(1)
+    .max(MAX_RULES_PER_BULK_ACTION)
+    .optional()
+    .describe(
+      'Array of rule signature IDs ("rule_id") to apply the action to. At least one of "rule_ids" or "rule_signature_ids" must be provided.'
+    ),
+  tags: z
+    .array(z.string())
+    .min(1)
+    .optional()
+    .describe(
+      'Tags to add, remove, or set. Required for add_tags, delete_tags, and set_tags actions. Ignored for enable, disable, and delete actions.'
+    ),
+});
 
 interface ActionDependencies {
   rulesClient: RulesClient;
@@ -47,29 +77,210 @@ interface ActionDependencies {
   productFeaturesService: ProductFeaturesService;
 }
 
-const bulkActionsSchema = z.object({
-  action: z
-    .enum(['enable', 'disable', 'delete', 'add_tags', 'delete_tags', 'set_tags'])
-    .describe(
-      'The bulk action to perform. "enable" enables rules, "disable" disables rules, "delete" deletes rules, "add_tags" adds tags to rules, "delete_tags" removes tags from rules, "set_tags" overwrites all tags on rules.'
-    ),
-  rule_ids: z
-    .array(z.string())
-    .min(1)
-    .max(MAX_RULES_PER_BULK_ACTION)
-    .describe(
-      'Array of rule IDs (the alerting framework "id", not "rule_id") to apply the action to. Use the alerts tool or find_prebuilt_rules tool to discover rule IDs first.'
-    ),
-  tags: z
-    .array(z.string())
-    .min(1)
-    .optional()
-    .describe(
-      'Tags to add, remove, or set. Required for add_tags, delete_tags, and set_tags actions. Ignored for enable, disable, and delete actions.'
-    ),
-});
-
 export const SECURITY_BULK_ACTIONS_TOOL_ID = securityTool('bulk_actions');
+
+export const bulkActionsTool = (
+  core: SecuritySolutionPluginCoreSetupDependencies,
+  logger: Logger,
+  plugins: SecuritySolutionPluginSetupDependencies,
+  productFeaturesService: ProductFeaturesService
+): BuiltinToolDefinition<typeof bulkActionsSchema> => {
+  return {
+    id: SECURITY_BULK_ACTIONS_TOOL_ID,
+    type: ToolType.builtin,
+    description: `Apply bulk actions to security detection rules. Supports enabling, disabling, deleting, and managing tags on multiple rules at once. Rules can be identified by their saved object IDs ("rule_ids") or rule signature IDs ("rule_signature_ids"). Use the alerts tool or find_prebuilt_rules tool first to discover rule IDs, then use this tool to perform actions on them.`,
+    schema: bulkActionsSchema,
+    availability: {
+      cacheMode: 'space',
+      handler: async ({ request }) => {
+        return getAgentBuilderResourceAvailability({ core, request, logger });
+      },
+    },
+    handler: async (params, { request, savedObjectsClient }) => {
+      const { action, rule_ids: ids, rule_ids: ruleIds, tags } = params;
+
+      const totalRequested = (ids?.length ?? 0) + (ruleIds?.length ?? 0);
+
+      try {
+        logger.debug(
+          `${SECURITY_BULK_ACTIONS_TOOL_ID} tool called with action="${action}" for ${totalRequested} rules`
+        );
+
+        if (totalRequested === 0) {
+          return {
+            results: [
+              {
+                type: ToolResultType.error,
+                data: {
+                  message: 'At least one of "ids" or "rule_ids" must be provided.',
+                },
+              },
+            ],
+          };
+        }
+
+        if (totalRequested > MAX_RULES_PER_BULK_ACTION) {
+          return {
+            results: [
+              {
+                type: ToolResultType.error,
+                data: {
+                  message: `The total number of rules across "ids" and "rule_ids" must not exceed ${MAX_RULES_PER_BULK_ACTION}.`,
+                },
+              },
+            ],
+          };
+        }
+
+        const isTagAction =
+          action === 'add_tags' || action === 'delete_tags' || action === 'set_tags';
+
+        if (isTagAction && (!tags || tags.length === 0)) {
+          return {
+            results: [
+              {
+                type: ToolResultType.error,
+                data: {
+                  message: `The "tags" parameter is required for the "${action}" action.`,
+                },
+              },
+            ],
+          };
+        }
+
+        const [coreStart, startPlugins] = await core.getStartServices();
+
+        const rulesClient = await startPlugins.alerting.getRulesClientWithRequest(request);
+        const actionsClient = await startPlugins.actions.getActionsClientWithRequest(request);
+        const license = await firstValueFrom(startPlugins.licensing.license$);
+
+        const mlAuthz = buildMlAuthz({
+          license,
+          ml: plugins.ml,
+          request,
+          savedObjectsClient,
+        });
+
+        const rulesAuthz = await calculateRulesAuthz({ coreStart, request });
+
+        const deps: ActionDependencies = {
+          rulesClient,
+          actionsClient,
+          savedObjectsClient,
+          mlAuthz,
+          rulesAuthz,
+          license,
+          productFeaturesService,
+        };
+
+        const rules: RuleAlertType[] = [];
+        const fetchErrors: string[] = [];
+
+        // Fetch rules by saved object IDs
+        if (ids && ids.length > 0) {
+          const fetchOutcome = await fetchRulesByQueryOrIds({
+            rulesClient,
+            query: undefined,
+            ids: ids,
+            maxRules: MAX_RULES_PER_BULK_ACTION,
+          });
+
+          rules.push(...fetchOutcome.results.map(({ result }) => result));
+          fetchErrors.push(
+            ...fetchOutcome.errors.map(
+              ({ item, error }) =>
+                `Rule ${item}: ${error instanceof Error ? error.message : String(error)}`
+            )
+          );
+        }
+
+        // Fetch rules by signature IDs (rule_id)
+        if (ruleIds && ruleIds.length > 0) {
+          const resolvedIds = new Set(rules.map((rule) => rule.id));
+
+          for (const signatureId of ruleIds) {
+            try {
+              const { data } = await findRules({
+                rulesClient,
+                filter: `alert.attributes.params.ruleId: "${signatureId}"`,
+                page: 1,
+                perPage: 1,
+                fields: undefined,
+                sortField: undefined,
+                sortOrder: undefined,
+              });
+
+              if (data.length > 0 && !resolvedIds.has(data[0].id)) {
+                rules.push(data[0]);
+                resolvedIds.add(data[0].id);
+              } else if (data.length === 0) {
+                fetchErrors.push(`Rule with rule_id "${signatureId}": Rule not found`);
+              }
+            } catch (error) {
+              fetchErrors.push(
+                `Rule with rule_id "${signatureId}": ${
+                  error instanceof Error ? error.message : String(error)
+                }`
+              );
+            }
+          }
+        }
+
+        if (rules.length === 0) {
+          return {
+            results: [
+              {
+                type: ToolResultType.error,
+                data: {
+                  message: `No rules found for the provided IDs.`,
+                  ...(fetchErrors.length > 0 && { errors: fetchErrors }),
+                },
+              },
+            ],
+          };
+        }
+
+        const result = await executeAction(action, rules, tags, deps);
+
+        return {
+          results: [
+            {
+              type: ToolResultType.other,
+              data: {
+                summary: {
+                  action,
+                  ...(isTagAction && { tags }),
+                  total: totalRequested,
+                  succeeded: result.succeeded,
+                  ...('skipped' in result && { skipped: result.skipped }),
+                  failed: result.errors.length,
+                  not_found: fetchErrors.length,
+                },
+                ...result.data,
+                ...(result.errors.length > 0 && { errors: result.errors }),
+                ...(fetchErrors.length > 0 && { fetch_errors: fetchErrors }),
+              },
+            },
+          ],
+        };
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        logger.error(`Error in ${SECURITY_BULK_ACTIONS_TOOL_ID} tool: ${errorMessage}`);
+        return {
+          results: [
+            {
+              type: ToolResultType.error,
+              data: {
+                message: `Error performing bulk action "${action}": ${errorMessage}`,
+              },
+            },
+          ],
+        };
+      }
+    },
+    tags: ['security', 'detection', 'rules', 'bulk-actions'],
+  };
+};
 
 const handleEnableDisable = async (
   action: 'enable' | 'disable',
@@ -185,6 +396,8 @@ const handleTagEdit = async (
   };
 };
 
+type BulkAction = 'enable' | 'disable' | 'delete' | 'add_tags' | 'delete_tags' | 'set_tags';
+
 const executeAction = async (
   action: BulkAction,
   rules: RuleAlertType[],
@@ -202,140 +415,4 @@ const executeAction = async (
     case 'set_tags':
       return handleTagEdit(action, rules, tags as string[], deps);
   }
-};
-
-export const bulkActionsTool = (
-  core: SecuritySolutionPluginCoreSetupDependencies,
-  logger: Logger,
-  plugins: SecuritySolutionPluginSetupDependencies,
-  productFeaturesService: ProductFeaturesService
-): BuiltinToolDefinition<typeof bulkActionsSchema> => {
-  return {
-    id: SECURITY_BULK_ACTIONS_TOOL_ID,
-    type: ToolType.builtin,
-    description: `Apply bulk actions to security detection rules. Supports enabling, disabling, deleting, and managing tags on multiple rules at once. Use the alerts tool or find_prebuilt_rules tool first to discover rule IDs, then use this tool to perform actions on them.`,
-    schema: bulkActionsSchema,
-    availability: {
-      cacheMode: 'space',
-      handler: async ({ request }) => {
-        return getAgentBuilderResourceAvailability({ core, request, logger });
-      },
-    },
-    handler: async (params, { request, savedObjectsClient }) => {
-      const { action, rule_ids: ruleIds, tags } = params;
-
-      try {
-        logger.debug(
-          `${SECURITY_BULK_ACTIONS_TOOL_ID} tool called with action="${action}" for ${ruleIds.length} rules`
-        );
-
-        const isTagAction =
-          action === 'add_tags' || action === 'delete_tags' || action === 'set_tags';
-
-        if (isTagAction && (!tags || tags.length === 0)) {
-          return {
-            results: [
-              {
-                type: ToolResultType.error,
-                data: {
-                  message: `The "tags" parameter is required for the "${action}" action.`,
-                },
-              },
-            ],
-          };
-        }
-
-        const [coreStart, startPlugins] = await core.getStartServices();
-
-        const rulesClient = await startPlugins.alerting.getRulesClientWithRequest(request);
-        const actionsClient = await startPlugins.actions.getActionsClientWithRequest(request);
-        const license = await firstValueFrom(startPlugins.licensing.license$);
-
-        const mlAuthz = buildMlAuthz({
-          license,
-          ml: plugins.ml,
-          request,
-          savedObjectsClient,
-        });
-
-        const rulesAuthz = await calculateRulesAuthz({ coreStart, request });
-
-        const deps: ActionDependencies = {
-          rulesClient,
-          actionsClient,
-          savedObjectsClient,
-          mlAuthz,
-          rulesAuthz,
-          license,
-          productFeaturesService,
-        };
-
-        // Fetch the rules by their IDs
-        const fetchOutcome = await fetchRulesByQueryOrIds({
-          rulesClient,
-          query: undefined,
-          ids: ruleIds,
-          maxRules: MAX_RULES_PER_BULK_ACTION,
-        });
-
-        const rules = fetchOutcome.results.map(({ result }) => result);
-        const fetchErrors = fetchOutcome.errors.map(
-          ({ item, error }) =>
-            `Rule ${item}: ${error instanceof Error ? error.message : String(error)}`
-        );
-
-        if (rules.length === 0) {
-          return {
-            results: [
-              {
-                type: ToolResultType.error,
-                data: {
-                  message: `No rules found for the provided IDs.`,
-                  ...(fetchErrors.length > 0 && { errors: fetchErrors }),
-                },
-              },
-            ],
-          };
-        }
-
-        const result = await executeAction(action, rules, tags, deps);
-
-        return {
-          results: [
-            {
-              type: ToolResultType.other,
-              data: {
-                summary: {
-                  action,
-                  ...(isTagAction && { tags }),
-                  total: ruleIds.length,
-                  succeeded: result.succeeded,
-                  ...('skipped' in result && { skipped: result.skipped }),
-                  failed: result.errors.length,
-                  not_found: fetchErrors.length,
-                },
-                ...result.data,
-                ...(result.errors.length > 0 && { errors: result.errors }),
-                ...(fetchErrors.length > 0 && { fetch_errors: fetchErrors }),
-              },
-            },
-          ],
-        };
-      } catch (error) {
-        const errorMessage = error instanceof Error ? error.message : String(error);
-        logger.error(`Error in ${SECURITY_BULK_ACTIONS_TOOL_ID} tool: ${errorMessage}`);
-        return {
-          results: [
-            {
-              type: ToolResultType.error,
-              data: {
-                message: `Error performing bulk action "${action}": ${errorMessage}`,
-              },
-            },
-          ],
-        };
-      }
-    },
-    tags: ['security', 'detection', 'rules', 'bulk-actions'],
-  };
 };

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/bulk_actions_tool.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/bulk_actions_tool.ts
@@ -1,0 +1,341 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod/v4';
+import { firstValueFrom } from 'rxjs';
+import { ToolType, ToolResultType } from '@kbn/agent-builder-common';
+import type { BuiltinToolDefinition } from '@kbn/agent-builder-server';
+import type { Logger } from '@kbn/logging';
+import type { RulesClient } from '@kbn/alerting-plugin/server';
+import type { ActionsClient } from '@kbn/actions-plugin/server';
+import type { SavedObjectsClientContract } from '@kbn/core/server';
+import type { ILicense } from '@kbn/licensing-types';
+import type { BulkActionEditPayload } from '../../../common/api/detection_engine/rule_management';
+import type { DetectionRulesAuthz } from '../../../common/detection_engine/rule_management/authz';
+import { securityTool } from './constants';
+import { getAgentBuilderResourceAvailability } from '../utils/get_agent_builder_resource_availability';
+import type {
+  SecuritySolutionPluginCoreSetupDependencies,
+  SecuritySolutionPluginSetupDependencies,
+} from '../../plugin_contract';
+import { buildMlAuthz } from '../../lib/machine_learning/authz';
+import type { MlAuthz } from '../../lib/machine_learning/authz';
+import { calculateRulesAuthz } from '../../lib/detection_engine/rule_management/authz';
+import { createDetectionRulesClient } from '../../lib/detection_engine/rule_management/logic/detection_rules_client/detection_rules_client';
+import { createPrebuiltRuleAssetsClient } from '../../lib/detection_engine/prebuilt_rules/logic/rule_assets/prebuilt_rule_assets_client';
+import { fetchRulesByQueryOrIds } from '../../lib/detection_engine/rule_management/api/rules/bulk_actions/fetch_rules_by_query_or_ids';
+import { bulkEnableDisableRules } from '../../lib/detection_engine/rule_management/api/rules/bulk_actions/bulk_enable_disable_rules';
+import { bulkEditRules } from '../../lib/detection_engine/rule_management/logic/bulk_actions/bulk_edit_rules';
+import type { ProductFeaturesService } from '../../lib/product_features_service';
+import type { RuleAlertType } from '../../lib/detection_engine/rule_schema';
+
+const MAX_RULES_PER_BULK_ACTION = 50;
+
+type BulkAction = 'enable' | 'disable' | 'delete' | 'add_tags' | 'delete_tags' | 'set_tags';
+
+interface ActionDependencies {
+  rulesClient: RulesClient;
+  actionsClient: ActionsClient;
+  savedObjectsClient: SavedObjectsClientContract;
+  mlAuthz: MlAuthz;
+  rulesAuthz: DetectionRulesAuthz;
+  license: ILicense;
+  productFeaturesService: ProductFeaturesService;
+}
+
+const bulkActionsSchema = z.object({
+  action: z
+    .enum(['enable', 'disable', 'delete', 'add_tags', 'delete_tags', 'set_tags'])
+    .describe(
+      'The bulk action to perform. "enable" enables rules, "disable" disables rules, "delete" deletes rules, "add_tags" adds tags to rules, "delete_tags" removes tags from rules, "set_tags" overwrites all tags on rules.'
+    ),
+  rule_ids: z
+    .array(z.string())
+    .min(1)
+    .max(MAX_RULES_PER_BULK_ACTION)
+    .describe(
+      'Array of rule IDs (the alerting framework "id", not "rule_id") to apply the action to. Use the alerts tool or find_prebuilt_rules tool to discover rule IDs first.'
+    ),
+  tags: z
+    .array(z.string())
+    .min(1)
+    .optional()
+    .describe(
+      'Tags to add, remove, or set. Required for add_tags, delete_tags, and set_tags actions. Ignored for enable, disable, and delete actions.'
+    ),
+});
+
+export const SECURITY_BULK_ACTIONS_TOOL_ID = securityTool('bulk_actions');
+
+const handleEnableDisable = async (
+  action: 'enable' | 'disable',
+  rules: RuleAlertType[],
+  deps: ActionDependencies
+) => {
+  const { updatedRules, errors } = await bulkEnableDisableRules({
+    rules,
+    isDryRun: false,
+    rulesClient: deps.rulesClient,
+    action,
+    mlAuthz: deps.mlAuthz,
+    rulesAuthz: deps.rulesAuthz,
+  });
+
+  return {
+    succeeded: updatedRules.length,
+    errors: errors.map(({ item, error }) => `Rule "${item.name}" (${item.id}): ${error.message}`),
+    data: {
+      ...(updatedRules.length > 0 && {
+        updated_rules: updatedRules.map((rule) => ({
+          id: rule.id,
+          name: rule.name,
+          enabled: rule.enabled,
+        })),
+      }),
+    },
+  };
+};
+
+const handleDelete = async (rules: RuleAlertType[], deps: ActionDependencies) => {
+  const detectionRulesClient = createDetectionRulesClient({
+    actionsClient: deps.actionsClient,
+    rulesClient: deps.rulesClient,
+    savedObjectsClient: deps.savedObjectsClient,
+    mlAuthz: deps.mlAuthz,
+    rulesAuthz: deps.rulesAuthz,
+    productFeaturesService: deps.productFeaturesService,
+    license: deps.license,
+  });
+
+  const deleteResult = await detectionRulesClient.bulkDeleteRules({
+    ruleIds: rules.map((rule) => rule.id),
+  });
+
+  return {
+    succeeded: deleteResult.rules.length,
+    errors: deleteResult.errors.map(
+      (err) => `Rule "${err.rule.name}" (${err.rule.id}): ${err.message}`
+    ),
+    data: {
+      ...(deleteResult.rules.length > 0 && {
+        deleted_rules: deleteResult.rules.map((rule) => ({
+          id: rule.id,
+          name: rule.name,
+        })),
+      }),
+    },
+  };
+};
+
+const handleTagEdit = async (
+  action: 'add_tags' | 'delete_tags' | 'set_tags',
+  rules: RuleAlertType[],
+  tags: string[],
+  deps: ActionDependencies
+) => {
+  const editActions: BulkActionEditPayload[] = [{ type: action, value: tags }];
+
+  const prebuiltRuleAssetClient = createPrebuiltRuleAssetsClient(deps.savedObjectsClient);
+  const detectionRulesClient = createDetectionRulesClient({
+    actionsClient: deps.actionsClient,
+    rulesClient: deps.rulesClient,
+    savedObjectsClient: deps.savedObjectsClient,
+    mlAuthz: deps.mlAuthz,
+    rulesAuthz: deps.rulesAuthz,
+    productFeaturesService: deps.productFeaturesService,
+    license: deps.license,
+  });
+
+  const editResult = await bulkEditRules({
+    actionsClient: deps.actionsClient,
+    rulesClient: deps.rulesClient,
+    prebuiltRuleAssetClient,
+    rules,
+    actions: editActions,
+    mlAuthz: deps.mlAuthz,
+    rulesAuthz: deps.rulesAuthz,
+    ruleCustomizationStatus: detectionRulesClient.getRuleCustomizationStatus(),
+  });
+
+  return {
+    succeeded: editResult.rules.length,
+    skipped: editResult.skipped.length,
+    errors: editResult.errors.map(
+      (err) => `Rule "${err.rule.name}" (${err.rule.id}): ${err.message}`
+    ),
+    data: {
+      ...(editResult.rules.length > 0 && {
+        updated_rules: editResult.rules.map((rule) => ({
+          id: rule.id,
+          name: rule.name,
+          tags: rule.tags,
+        })),
+      }),
+      ...(editResult.skipped.length > 0 && {
+        skipped_rules: editResult.skipped.map((skip) => ({
+          id: skip.id,
+          name: skip.name,
+        })),
+      }),
+    },
+  };
+};
+
+const executeAction = async (
+  action: BulkAction,
+  rules: RuleAlertType[],
+  tags: string[] | undefined,
+  deps: ActionDependencies
+) => {
+  switch (action) {
+    case 'enable':
+    case 'disable':
+      return handleEnableDisable(action, rules, deps);
+    case 'delete':
+      return handleDelete(rules, deps);
+    case 'add_tags':
+    case 'delete_tags':
+    case 'set_tags':
+      return handleTagEdit(action, rules, tags as string[], deps);
+  }
+};
+
+export const bulkActionsTool = (
+  core: SecuritySolutionPluginCoreSetupDependencies,
+  logger: Logger,
+  plugins: SecuritySolutionPluginSetupDependencies,
+  productFeaturesService: ProductFeaturesService
+): BuiltinToolDefinition<typeof bulkActionsSchema> => {
+  return {
+    id: SECURITY_BULK_ACTIONS_TOOL_ID,
+    type: ToolType.builtin,
+    description: `Apply bulk actions to security detection rules. Supports enabling, disabling, deleting, and managing tags on multiple rules at once. Use the alerts tool or find_prebuilt_rules tool first to discover rule IDs, then use this tool to perform actions on them.`,
+    schema: bulkActionsSchema,
+    availability: {
+      cacheMode: 'space',
+      handler: async ({ request }) => {
+        return getAgentBuilderResourceAvailability({ core, request, logger });
+      },
+    },
+    handler: async (params, { request, savedObjectsClient }) => {
+      const { action, rule_ids: ruleIds, tags } = params;
+
+      try {
+        logger.debug(
+          `${SECURITY_BULK_ACTIONS_TOOL_ID} tool called with action="${action}" for ${ruleIds.length} rules`
+        );
+
+        const isTagAction =
+          action === 'add_tags' || action === 'delete_tags' || action === 'set_tags';
+
+        if (isTagAction && (!tags || tags.length === 0)) {
+          return {
+            results: [
+              {
+                type: ToolResultType.error,
+                data: {
+                  message: `The "tags" parameter is required for the "${action}" action.`,
+                },
+              },
+            ],
+          };
+        }
+
+        const [coreStart, startPlugins] = await core.getStartServices();
+
+        const rulesClient = await startPlugins.alerting.getRulesClientWithRequest(request);
+        const actionsClient = await startPlugins.actions.getActionsClientWithRequest(request);
+        const license = await firstValueFrom(startPlugins.licensing.license$);
+
+        const mlAuthz = buildMlAuthz({
+          license,
+          ml: plugins.ml,
+          request,
+          savedObjectsClient,
+        });
+
+        const rulesAuthz = await calculateRulesAuthz({ coreStart, request });
+
+        const deps: ActionDependencies = {
+          rulesClient,
+          actionsClient,
+          savedObjectsClient,
+          mlAuthz,
+          rulesAuthz,
+          license,
+          productFeaturesService,
+        };
+
+        // Fetch the rules by their IDs
+        const fetchOutcome = await fetchRulesByQueryOrIds({
+          rulesClient,
+          query: undefined,
+          ids: ruleIds,
+          maxRules: MAX_RULES_PER_BULK_ACTION,
+        });
+
+        const rules = fetchOutcome.results.map(({ result }) => result);
+        const fetchErrors = fetchOutcome.errors.map(
+          ({ item, error }) =>
+            `Rule ${item}: ${error instanceof Error ? error.message : String(error)}`
+        );
+
+        if (rules.length === 0) {
+          return {
+            results: [
+              {
+                type: ToolResultType.error,
+                data: {
+                  message: `No rules found for the provided IDs.`,
+                  ...(fetchErrors.length > 0 && { errors: fetchErrors }),
+                },
+              },
+            ],
+          };
+        }
+
+        const result = await executeAction(action, rules, tags, deps);
+
+        return {
+          results: [
+            {
+              type: ToolResultType.other,
+              data: {
+                summary: {
+                  action,
+                  ...(isTagAction && { tags }),
+                  total: ruleIds.length,
+                  succeeded: result.succeeded,
+                  ...('skipped' in result && { skipped: result.skipped }),
+                  failed: result.errors.length,
+                  not_found: fetchErrors.length,
+                },
+                ...result.data,
+                ...(result.errors.length > 0 && { errors: result.errors }),
+                ...(fetchErrors.length > 0 && { fetch_errors: fetchErrors }),
+              },
+            },
+          ],
+        };
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        logger.error(`Error in ${SECURITY_BULK_ACTIONS_TOOL_ID} tool: ${errorMessage}`);
+        return {
+          results: [
+            {
+              type: ToolResultType.error,
+              data: {
+                message: `Error performing bulk action "${action}": ${errorMessage}`,
+              },
+            },
+          ],
+        };
+      }
+    },
+    tags: ['security', 'detection', 'rules', 'bulk-actions'],
+  };
+};

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/bulk_actions_tool.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/bulk_actions_tool.ts
@@ -161,7 +161,11 @@ export const bulkActionsTool = (
           savedObjectsClient,
         });
 
-        const rulesAuthz = await calculateRulesAuthz({ coreStart, request });
+        const rulesAuthz = await calculateRulesAuthz({
+          coreStart,
+          request,
+          security: startPlugins.security.authz,
+        });
 
         const deps: ActionDependencies = {
           rulesClient,
@@ -181,7 +185,7 @@ export const bulkActionsTool = (
           const fetchOutcome = await fetchRulesByQueryOrIds({
             rulesClient,
             query: undefined,
-            ids: ids,
+            ids,
             maxRules: MAX_RULES_PER_BULK_ACTION,
           });
 

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/bulk_actions_tool.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/bulk_actions_tool.ts
@@ -48,7 +48,7 @@ const bulkActionsSchema = z.object({
     .max(MAX_RULES_PER_BULK_ACTION)
     .optional()
     .describe(
-      'Array of rule saved object IDs (the alerting framework "id") to apply the action to. At least one of "rule_ids" or "rule_signature_ids" must be provided.'
+      'Array of rule saved object IDs (the alerting framework "id") to apply the action to. At least one of "ids" or "rule_ids" must be provided.'
     ),
   rule_ids: z
     .array(z.string())
@@ -56,7 +56,7 @@ const bulkActionsSchema = z.object({
     .max(MAX_RULES_PER_BULK_ACTION)
     .optional()
     .describe(
-      'Array of rule signature IDs ("rule_id") to apply the action to. At least one of "rule_ids" or "rule_signature_ids" must be provided.'
+      'Array of rule signature IDs ("rule_id") to apply the action to. At least one of "ids" or "rule_ids" must be provided.'
     ),
   tags: z
     .array(z.string())
@@ -97,7 +97,7 @@ export const bulkActionsTool = (
       },
     },
     handler: async (params, { request, savedObjectsClient }) => {
-      const { action, rule_ids: ids, rule_ids: ruleIds, tags } = params;
+      const { action, ids, rule_ids: ruleIds, tags } = params;
 
       const totalRequested = (ids?.length ?? 0) + (ruleIds?.length ?? 0);
 

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/find_prebuilt_rules_tool.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/find_prebuilt_rules_tool.ts
@@ -14,6 +14,7 @@ import { getAgentBuilderResourceAvailability } from '../utils/get_agent_builder_
 import type { SecuritySolutionPluginCoreSetupDependencies } from '../../plugin_contract';
 import { createPrebuiltRuleAssetsClient } from '../../lib/detection_engine/prebuilt_rules/logic/rule_assets/prebuilt_rule_assets_client';
 import type { PrebuiltRuleAsset } from '../../lib/detection_engine/prebuilt_rules/model/rule_assets/prebuilt_rule_asset';
+import { PREBUILT_RULES_PACKAGE_NAME } from '../../../common/detection_engine/constants';
 
 const findPrebuiltRulesSchema = z.object({
   search: z
@@ -144,7 +145,21 @@ export const findPrebuiltRulesTool = (
         );
 
         const ruleAssetsClient = createPrebuiltRuleAssetsClient(savedObjectsClient);
-        const allRules = await ruleAssetsClient.fetchLatestAssets();
+        let allRules = await ruleAssetsClient.fetchLatestAssets();
+
+        if (allRules.length === 0) {
+          logger.debug(
+            `${SECURITY_FIND_PREBUILT_RULES_TOOL_ID} tool: No prebuilt rule assets found. Installing ${PREBUILT_RULES_PACKAGE_NAME} Fleet package.`
+          );
+
+          const [, startPlugins] = await core.getStartServices();
+
+          await startPlugins.fleet?.packageService.asInternalUser.ensureInstalledPackage({
+            pkgName: PREBUILT_RULES_PACKAGE_NAME,
+          });
+
+          allRules = await ruleAssetsClient.fetchLatestAssets();
+        }
 
         let filtered = allRules;
 

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/find_prebuilt_rules_tool.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/find_prebuilt_rules_tool.ts
@@ -1,0 +1,215 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod/v4';
+import { ToolType, ToolResultType } from '@kbn/agent-builder-common';
+import type { BuiltinToolDefinition } from '@kbn/agent-builder-server';
+import type { Logger } from '@kbn/logging';
+import { securityTool } from './constants';
+import { getAgentBuilderResourceAvailability } from '../utils/get_agent_builder_resource_availability';
+import type { SecuritySolutionPluginCoreSetupDependencies } from '../../plugin_contract';
+import { createPrebuiltRuleAssetsClient } from '../../lib/detection_engine/prebuilt_rules/logic/rule_assets/prebuilt_rule_assets_client';
+import type { PrebuiltRuleAsset } from '../../lib/detection_engine/prebuilt_rules/model/rule_assets/prebuilt_rule_asset';
+
+const findPrebuiltRulesSchema = z.object({
+  search: z
+    .string()
+    .optional()
+    .describe(
+      'Search term to match against rule names and descriptions. Case-insensitive partial match.'
+    ),
+  tags: z
+    .array(z.string())
+    .optional()
+    .describe(
+      'Filter by tags. All specified tags must be present on a rule. Examples: "Windows", "Elastic", "Persistence", "Domain: Endpoint"'
+    ),
+  severity: z
+    .enum(['low', 'medium', 'high', 'critical'])
+    .optional()
+    .describe('Filter by severity level'),
+  rule_type: z
+    .enum([
+      'query',
+      'eql',
+      'threshold',
+      'threat_match',
+      'machine_learning',
+      'new_terms',
+      'saved_query',
+      'esql',
+    ])
+    .optional()
+    .describe('Filter by detection rule type'),
+  mitre_tactic: z
+    .string()
+    .optional()
+    .describe(
+      'Filter by MITRE ATT&CK tactic name. Case-insensitive partial match. Examples: "Initial Access", "Persistence", "Credential Access"'
+    ),
+  mitre_technique_id: z
+    .string()
+    .optional()
+    .describe(
+      'Filter by MITRE ATT&CK technique or subtechnique ID. Examples: "T1059", "T1059.001"'
+    ),
+  limit: z
+    .number()
+    .min(1)
+    .max(50)
+    .optional()
+    .describe('Maximum number of rules to return. Defaults to 10.'),
+});
+
+export const SECURITY_FIND_PREBUILT_RULES_TOOL_ID = securityTool('find_prebuilt_rules');
+
+const matchesThreatTactic = (rule: PrebuiltRuleAsset, tactic: string): boolean => {
+  const tacticLower = tactic.toLowerCase();
+  return rule.threat?.some((t) => t.tactic.name.toLowerCase().includes(tacticLower)) ?? false;
+};
+
+const matchesThreatTechniqueId = (rule: PrebuiltRuleAsset, techniqueId: string): boolean => {
+  const techIdUpper = techniqueId.toUpperCase();
+  return (
+    rule.threat?.some((t) =>
+      t.technique?.some(
+        (tech) =>
+          tech.id.toUpperCase() === techIdUpper ||
+          tech.subtechnique?.some((sub) => sub.id.toUpperCase() === techIdUpper)
+      )
+    ) ?? false
+  );
+};
+
+const formatRuleResult = (rule: PrebuiltRuleAsset) => ({
+  rule_id: rule.rule_id,
+  name: rule.name,
+  description: rule.description,
+  severity: rule.severity,
+  risk_score: rule.risk_score,
+  type: rule.type,
+  version: rule.version,
+  tags: rule.tags,
+  threat: rule.threat?.map((t) => ({
+    tactic: t.tactic.name,
+    techniques: t.technique?.map((tech) => ({
+      id: tech.id,
+      name: tech.name,
+      subtechniques: tech.subtechnique?.map((sub) => ({
+        id: sub.id,
+        name: sub.name,
+      })),
+    })),
+  })),
+  ...('query' in rule && rule.query ? { query: rule.query } : {}),
+  ...('language' in rule && rule.language ? { language: rule.language } : {}),
+  ...(rule.related_integrations ? { related_integrations: rule.related_integrations } : {}),
+});
+
+export const findPrebuiltRulesTool = (
+  core: SecuritySolutionPluginCoreSetupDependencies,
+  logger: Logger
+): BuiltinToolDefinition<typeof findPrebuiltRulesSchema> => {
+  return {
+    id: SECURITY_FIND_PREBUILT_RULES_TOOL_ID,
+    type: ToolType.builtin,
+    description: `Search for Elastic Security prebuilt detection rules by name, tags, severity, rule type, or MITRE ATT&CK tactic/technique. Returns rule details including name, description, severity, risk score, rule type, MITRE ATT&CK mappings, and query information. Use this tool when a user asks about available detection rules, wants to find rules for a specific threat, or needs to understand what prebuilt coverage exists.`,
+    schema: findPrebuiltRulesSchema,
+    availability: {
+      cacheMode: 'space',
+      handler: async ({ request }) => {
+        return getAgentBuilderResourceAvailability({ core, request, logger });
+      },
+    },
+    handler: async (params, { savedObjectsClient }) => {
+      const {
+        search,
+        tags,
+        severity,
+        rule_type: ruleType,
+        mitre_tactic: mitreTactic,
+        mitre_technique_id: mitreTechniqueId,
+        limit = 10,
+      } = params;
+
+      try {
+        logger.debug(
+          `${SECURITY_FIND_PREBUILT_RULES_TOOL_ID} tool called with params: ${JSON.stringify(
+            params
+          )}`
+        );
+
+        const ruleAssetsClient = createPrebuiltRuleAssetsClient(savedObjectsClient);
+        const allRules = await ruleAssetsClient.fetchLatestAssets();
+
+        let filtered = allRules;
+
+        if (search) {
+          const searchLower = search.toLowerCase();
+          filtered = filtered.filter(
+            (rule) =>
+              rule.name.toLowerCase().includes(searchLower) ||
+              rule.description?.toLowerCase().includes(searchLower)
+          );
+        }
+
+        if (tags?.length) {
+          filtered = filtered.filter((rule) =>
+            tags.every((tag) =>
+              rule.tags?.some((ruleTag) => ruleTag.toLowerCase() === tag.toLowerCase())
+            )
+          );
+        }
+
+        if (severity) {
+          filtered = filtered.filter((rule) => rule.severity === severity);
+        }
+
+        if (ruleType) {
+          filtered = filtered.filter((rule) => rule.type === ruleType);
+        }
+
+        if (mitreTactic) {
+          filtered = filtered.filter((rule) => matchesThreatTactic(rule, mitreTactic));
+        }
+
+        if (mitreTechniqueId) {
+          filtered = filtered.filter((rule) => matchesThreatTechniqueId(rule, mitreTechniqueId));
+        }
+
+        const rules = filtered.slice(0, limit).map(formatRuleResult);
+
+        return {
+          results: [
+            {
+              type: ToolResultType.other,
+              data: {
+                total_matching: filtered.length,
+                returned: rules.length,
+                rules,
+              },
+            },
+          ],
+        };
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        logger.error(`Error in ${SECURITY_FIND_PREBUILT_RULES_TOOL_ID} tool: ${errorMessage}`);
+        return {
+          results: [
+            {
+              type: ToolResultType.error,
+              data: {
+                message: `Error searching prebuilt rules: ${errorMessage}`,
+              },
+            },
+          ],
+        };
+      }
+    },
+    tags: ['security', 'detection', 'prebuilt-rules', 'search'],
+  };
+};

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/index.ts
@@ -31,3 +31,4 @@ export {
   installPrebuiltRulesTool,
   SECURITY_INSTALL_PREBUILT_RULES_TOOL_ID,
 } from './install_prebuilt_rules_tool';
+export { bulkActionsTool, SECURITY_BULK_ACTIONS_TOOL_ID } from './bulk_actions_tool';

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/index.ts
@@ -24,6 +24,10 @@ export {
   SECURITY_CREATE_DETECTION_RULE_TOOL_ID,
 } from './create_detection_rule_tool';
 export {
+  findPrebuiltRulesTool,
+  SECURITY_FIND_PREBUILT_RULES_TOOL_ID,
+} from './find_prebuilt_rules_tool';
+export {
   installPrebuiltRulesTool,
   SECURITY_INSTALL_PREBUILT_RULES_TOOL_ID,
 } from './install_prebuilt_rules_tool';

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/index.ts
@@ -23,3 +23,7 @@ export {
   createDetectionRuleTool,
   SECURITY_CREATE_DETECTION_RULE_TOOL_ID,
 } from './create_detection_rule_tool';
+export {
+  installPrebuiltRulesTool,
+  SECURITY_INSTALL_PREBUILT_RULES_TOOL_ID,
+} from './install_prebuilt_rules_tool';

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/install_prebuilt_rules_tool.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/install_prebuilt_rules_tool.test.ts
@@ -1,0 +1,365 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ToolResultType } from '@kbn/agent-builder-common';
+import type { ToolHandlerStandardReturn } from '@kbn/agent-builder-server/tools';
+import { BehaviorSubject } from 'rxjs';
+import {
+  createToolHandlerContext,
+  createToolTestMocks,
+  setupMockCoreStartServices,
+} from '../__mocks__/test_helpers';
+import {
+  installPrebuiltRulesTool,
+  SECURITY_INSTALL_PREBUILT_RULES_TOOL_ID,
+} from './install_prebuilt_rules_tool';
+import { createPrebuiltRuleAssetsClient } from '../../lib/detection_engine/prebuilt_rules/logic/rule_assets/prebuilt_rule_assets_client';
+import { createPrebuiltRuleObjectsClient } from '../../lib/detection_engine/prebuilt_rules/logic/rule_objects/prebuilt_rule_objects_client';
+import { createPrebuiltRules } from '../../lib/detection_engine/prebuilt_rules/logic/rule_objects/create_prebuilt_rules';
+import { createDetectionRulesClient } from '../../lib/detection_engine/rule_management/logic/detection_rules_client/detection_rules_client';
+import { buildMlAuthz } from '../../lib/machine_learning/authz';
+import { calculateRulesAuthz } from '../../lib/detection_engine/rule_management/authz';
+import type { ProductFeaturesService } from '../../lib/product_features_service';
+import type { SecuritySolutionPluginSetupDependencies } from '../../plugin_contract';
+
+jest.mock(
+  '../../lib/detection_engine/prebuilt_rules/logic/rule_assets/prebuilt_rule_assets_client',
+  () => ({ createPrebuiltRuleAssetsClient: jest.fn() })
+);
+jest.mock(
+  '../../lib/detection_engine/prebuilt_rules/logic/rule_objects/prebuilt_rule_objects_client',
+  () => ({ createPrebuiltRuleObjectsClient: jest.fn() })
+);
+jest.mock(
+  '../../lib/detection_engine/prebuilt_rules/logic/rule_objects/create_prebuilt_rules',
+  () => ({ createPrebuiltRules: jest.fn() })
+);
+jest.mock(
+  '../../lib/detection_engine/rule_management/logic/detection_rules_client/detection_rules_client',
+  () => ({ createDetectionRulesClient: jest.fn() })
+);
+jest.mock('../../lib/machine_learning/authz', () => ({ buildMlAuthz: jest.fn() }));
+jest.mock('../../lib/detection_engine/rule_management/authz', () => ({
+  calculateRulesAuthz: jest.fn(),
+}));
+
+const mockCreatePrebuiltRuleAssetsClient = createPrebuiltRuleAssetsClient as jest.Mock;
+const mockCreatePrebuiltRuleObjectsClient = createPrebuiltRuleObjectsClient as jest.Mock;
+const mockCreatePrebuiltRules = createPrebuiltRules as jest.Mock;
+const mockCreateDetectionRulesClient = createDetectionRulesClient as jest.Mock;
+const mockBuildMlAuthz = buildMlAuthz as jest.Mock;
+const mockCalculateRulesAuthz = calculateRulesAuthz as jest.Mock;
+
+const createMockRuleAsset = (ruleId: string, name: string) => ({
+  rule_id: ruleId,
+  name,
+  description: `Description for ${name}`,
+  severity: 'high' as const,
+  risk_score: 73,
+  type: 'query' as const,
+  version: 1,
+  tags: ['Elastic', 'Windows'],
+  language: 'kuery',
+  query: `test query for ${ruleId}`,
+});
+
+const createMockRuleResponse = (ruleId: string, name: string) => ({
+  rule_id: ruleId,
+  name,
+  severity: 'high',
+  id: `rule-object-id-${ruleId}`,
+});
+
+describe('installPrebuiltRulesTool', () => {
+  const { mockCore, mockLogger, mockEsClient, mockRequest } = createToolTestMocks();
+
+  const mockPlugins = {
+    ml: undefined,
+  } as unknown as SecuritySolutionPluginSetupDependencies;
+
+  const mockProductFeaturesService = {} as ProductFeaturesService;
+
+  const mockRulesClient = { find: jest.fn() };
+  const mockActionsClient = { getAll: jest.fn() };
+  const mockLicense$ = new BehaviorSubject({ isActive: true, type: 'platinum' });
+  const mockDetectionRulesClient = { createPrebuiltRule: jest.fn() };
+  const mockMlAuthz = { validateRuleType: jest.fn() };
+  const mockRulesAuthz = { canReadRules: true, canEditRules: true };
+
+  const mockFetchLatestAssets = jest.fn();
+  const mockFetchInstalledRuleVersions = jest.fn();
+
+  const tool = installPrebuiltRulesTool(
+    mockCore,
+    mockLogger,
+    mockPlugins,
+    mockProductFeaturesService
+  );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    const mockCoreStart = setupMockCoreStartServices(mockCore, mockEsClient);
+    const mockSavedObjectsClient = { find: jest.fn(), get: jest.fn() };
+    Object.assign(mockCoreStart.savedObjects, {
+      getScopedClient: jest.fn().mockReturnValue(mockSavedObjectsClient),
+    });
+
+    mockCore.getStartServices.mockResolvedValue([
+      mockCoreStart,
+      {
+        alerting: { getRulesClientWithRequest: jest.fn().mockResolvedValue(mockRulesClient) },
+        actions: { getActionsClientWithRequest: jest.fn().mockResolvedValue(mockActionsClient) },
+        licensing: { license$: mockLicense$ },
+      },
+      {},
+    ]);
+
+    mockCreatePrebuiltRuleAssetsClient.mockReturnValue({
+      fetchLatestAssets: mockFetchLatestAssets,
+    });
+    mockCreatePrebuiltRuleObjectsClient.mockReturnValue({
+      fetchInstalledRuleVersions: mockFetchInstalledRuleVersions,
+    });
+    mockCreateDetectionRulesClient.mockReturnValue(mockDetectionRulesClient);
+    mockBuildMlAuthz.mockReturnValue(mockMlAuthz);
+    mockCalculateRulesAuthz.mockResolvedValue(mockRulesAuthz);
+  });
+
+  describe('schema', () => {
+    it('validates a valid input with rule_ids', () => {
+      const result = tool.schema.safeParse({ rule_ids: ['rule-1', 'rule-2'] });
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects an empty rule_ids array', () => {
+      const result = tool.schema.safeParse({ rule_ids: [] });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects more than 50 rule_ids', () => {
+      const ruleIds = Array.from({ length: 51 }, (_, i) => `rule-${i}`);
+      const result = tool.schema.safeParse({ rule_ids: ruleIds });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects missing rule_ids', () => {
+      const result = tool.schema.safeParse({});
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects non-string rule_ids', () => {
+      const result = tool.schema.safeParse({ rule_ids: [123] });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('tool properties', () => {
+    it('returns correct tool id', () => {
+      expect(tool.id).toBe(SECURITY_INSTALL_PREBUILT_RULES_TOOL_ID);
+    });
+
+    it('has correct tags', () => {
+      expect(tool.tags).toEqual(['security', 'detection', 'prebuilt-rules', 'install']);
+    });
+
+    it('has confirmation policy set to always', () => {
+      expect(tool.confirmation?.askUser).toBe('always');
+    });
+  });
+
+  describe('handler', () => {
+    const getResultData = (result: unknown) => {
+      const standardResult = result as ToolHandlerStandardReturn;
+      return standardResult.results[0].data as Record<string, unknown>;
+    };
+
+    it('installs rules successfully', async () => {
+      const ruleAsset = createMockRuleAsset('rule-1', 'Test Rule 1');
+      mockFetchLatestAssets.mockResolvedValue([ruleAsset]);
+      mockFetchInstalledRuleVersions.mockResolvedValue([]);
+      mockCreatePrebuiltRules.mockResolvedValue({
+        results: [{ result: createMockRuleResponse('rule-1', 'Test Rule 1') }],
+        errors: [],
+      });
+
+      const result = await tool.handler(
+        { rule_ids: ['rule-1'] },
+        createToolHandlerContext(mockRequest, mockEsClient, mockLogger)
+      );
+
+      const standardResult = result as ToolHandlerStandardReturn;
+      expect(standardResult.results[0].type).toBe(ToolResultType.other);
+      const data = getResultData(result);
+      expect(data.summary).toEqual({
+        total: 1,
+        installed: 1,
+        already_installed: 0,
+        not_found: 0,
+        failed: 0,
+      });
+      expect(data.installed_rules).toEqual([
+        { rule_id: 'rule-1', name: 'Test Rule 1', severity: 'high' },
+      ]);
+    });
+
+    it('skips already installed rules', async () => {
+      const ruleAsset = createMockRuleAsset('rule-1', 'Test Rule 1');
+      mockFetchLatestAssets.mockResolvedValue([ruleAsset]);
+      mockFetchInstalledRuleVersions.mockResolvedValue([
+        { rule_id: 'rule-1', version: 1, id: 'obj-1', tags: [] },
+      ]);
+      mockCreatePrebuiltRules.mockResolvedValue({ results: [], errors: [] });
+
+      const result = await tool.handler(
+        { rule_ids: ['rule-1'] },
+        createToolHandlerContext(mockRequest, mockEsClient, mockLogger)
+      );
+
+      const data = getResultData(result);
+      expect(data.summary).toEqual({
+        total: 1,
+        installed: 0,
+        already_installed: 1,
+        not_found: 0,
+        failed: 0,
+      });
+      expect(data.already_installed_rule_ids).toEqual(['rule-1']);
+      expect(mockCreatePrebuiltRules).toHaveBeenCalledWith(
+        expect.anything(),
+        [],
+        expect.anything()
+      );
+    });
+
+    it('reports not found rules', async () => {
+      mockFetchLatestAssets.mockResolvedValue([]);
+      mockFetchInstalledRuleVersions.mockResolvedValue([]);
+      mockCreatePrebuiltRules.mockResolvedValue({ results: [], errors: [] });
+
+      const result = await tool.handler(
+        { rule_ids: ['nonexistent-rule'] },
+        createToolHandlerContext(mockRequest, mockEsClient, mockLogger)
+      );
+
+      const data = getResultData(result);
+      expect(data.summary).toEqual({
+        total: 1,
+        installed: 0,
+        already_installed: 0,
+        not_found: 1,
+        failed: 0,
+      });
+      expect(data.not_found_rule_ids).toEqual(['nonexistent-rule']);
+    });
+
+    it('handles mixed results (install, skip, not found)', async () => {
+      const ruleAsset1 = createMockRuleAsset('rule-1', 'Rule 1');
+      const ruleAsset2 = createMockRuleAsset('rule-2', 'Rule 2');
+      mockFetchLatestAssets.mockResolvedValue([ruleAsset1, ruleAsset2]);
+      mockFetchInstalledRuleVersions.mockResolvedValue([
+        { rule_id: 'rule-2', version: 1, id: 'obj-2', tags: [] },
+      ]);
+      mockCreatePrebuiltRules.mockResolvedValue({
+        results: [{ result: createMockRuleResponse('rule-1', 'Rule 1') }],
+        errors: [],
+      });
+
+      const result = await tool.handler(
+        { rule_ids: ['rule-1', 'rule-2', 'rule-3'] },
+        createToolHandlerContext(mockRequest, mockEsClient, mockLogger)
+      );
+
+      const data = getResultData(result);
+      expect(data.summary).toEqual({
+        total: 3,
+        installed: 1,
+        already_installed: 1,
+        not_found: 1,
+        failed: 0,
+      });
+    });
+
+    it('reports failed rules', async () => {
+      const ruleAsset = createMockRuleAsset('rule-1', 'Test Rule 1');
+      mockFetchLatestAssets.mockResolvedValue([ruleAsset]);
+      mockFetchInstalledRuleVersions.mockResolvedValue([]);
+      mockCreatePrebuiltRules.mockResolvedValue({
+        results: [],
+        errors: [{ item: ruleAsset, error: new Error('ML validation failed') }],
+      });
+
+      const result = await tool.handler(
+        { rule_ids: ['rule-1'] },
+        createToolHandlerContext(mockRequest, mockEsClient, mockLogger)
+      );
+
+      const data = getResultData(result);
+      expect(data.summary).toEqual({
+        total: 1,
+        installed: 0,
+        already_installed: 0,
+        not_found: 0,
+        failed: 1,
+      });
+      expect(data.failed_rules).toEqual([{ rule_id: 'rule-1', error: 'ML validation failed' }]);
+    });
+
+    it('returns error result on unexpected failure', async () => {
+      mockFetchLatestAssets.mockRejectedValue(new Error('Saved objects unavailable'));
+
+      const result = await tool.handler(
+        { rule_ids: ['rule-1'] },
+        createToolHandlerContext(mockRequest, mockEsClient, mockLogger)
+      );
+
+      const standardResult = result as ToolHandlerStandardReturn;
+      expect(standardResult.results[0].type).toBe(ToolResultType.error);
+      const data = getResultData(result);
+      expect(data.message).toContain('Saved objects unavailable');
+      expect(mockLogger.error).toHaveBeenCalled();
+    });
+
+    it('passes correct arguments to createPrebuiltRules', async () => {
+      const ruleAsset = createMockRuleAsset('rule-1', 'Test Rule 1');
+      mockFetchLatestAssets.mockResolvedValue([ruleAsset]);
+      mockFetchInstalledRuleVersions.mockResolvedValue([]);
+      mockCreatePrebuiltRules.mockResolvedValue({ results: [], errors: [] });
+
+      await tool.handler(
+        { rule_ids: ['rule-1'] },
+        createToolHandlerContext(mockRequest, mockEsClient, mockLogger)
+      );
+
+      expect(mockCreatePrebuiltRules).toHaveBeenCalledWith(
+        mockDetectionRulesClient,
+        [ruleAsset],
+        mockLogger
+      );
+    });
+
+    it('constructs detection rules client with correct dependencies', async () => {
+      mockFetchLatestAssets.mockResolvedValue([]);
+      mockFetchInstalledRuleVersions.mockResolvedValue([]);
+      mockCreatePrebuiltRules.mockResolvedValue({ results: [], errors: [] });
+
+      await tool.handler(
+        { rule_ids: ['rule-1'] },
+        createToolHandlerContext(mockRequest, mockEsClient, mockLogger)
+      );
+
+      expect(mockCreateDetectionRulesClient).toHaveBeenCalledWith({
+        actionsClient: mockActionsClient,
+        rulesClient: mockRulesClient,
+        savedObjectsClient: expect.anything(),
+        mlAuthz: mockMlAuthz,
+        rulesAuthz: mockRulesAuthz,
+        productFeaturesService: mockProductFeaturesService,
+        license: expect.objectContaining({ isActive: true }),
+      });
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/install_prebuilt_rules_tool.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/install_prebuilt_rules_tool.test.ts
@@ -114,6 +114,7 @@ describe('installPrebuiltRulesTool', () => {
         alerting: { getRulesClientWithRequest: jest.fn().mockResolvedValue(mockRulesClient) },
         actions: { getActionsClientWithRequest: jest.fn().mockResolvedValue(mockActionsClient) },
         licensing: { license$: mockLicense$ },
+        security: { authz: {} },
       },
       {},
     ]);

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/install_prebuilt_rules_tool.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/install_prebuilt_rules_tool.ts
@@ -75,7 +75,11 @@ export const installPrebuiltRulesTool = (
           savedObjectsClient,
         });
 
-        const rulesAuthz = await calculateRulesAuthz({ coreStart, request });
+        const rulesAuthz = await calculateRulesAuthz({
+          coreStart,
+          request,
+          security: startPlugins.security.authz,
+        });
 
         const detectionRulesClient = createDetectionRulesClient({
           actionsClient,

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/install_prebuilt_rules_tool.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/install_prebuilt_rules_tool.ts
@@ -53,18 +53,6 @@ export const installPrebuiltRulesTool = (
         return getAgentBuilderResourceAvailability({ core, request, logger });
       },
     },
-    confirmation: {
-      askUser: 'always',
-      getConfirmation: ({ toolParams }) => {
-        const ruleIds = (toolParams as z.infer<typeof installPrebuiltRulesSchema>).rule_ids;
-        return {
-          title: 'Install prebuilt rules',
-          message: `Install ${ruleIds.length} prebuilt detection rule${
-            ruleIds.length > 1 ? 's' : ''
-          }?`,
-        };
-      },
-    },
     handler: async (params, { request, savedObjectsClient }) => {
       const { rule_ids: ruleIds } = params;
 

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/install_prebuilt_rules_tool.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/install_prebuilt_rules_tool.ts
@@ -1,0 +1,184 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod/v4';
+import { firstValueFrom } from 'rxjs';
+import { ToolType, ToolResultType } from '@kbn/agent-builder-common';
+import type { BuiltinToolDefinition } from '@kbn/agent-builder-server';
+import type { Logger } from '@kbn/logging';
+import { securityTool } from './constants';
+import { getAgentBuilderResourceAvailability } from '../utils/get_agent_builder_resource_availability';
+import type {
+  SecuritySolutionPluginCoreSetupDependencies,
+  SecuritySolutionPluginSetupDependencies,
+} from '../../plugin_contract';
+import { createPrebuiltRuleAssetsClient } from '../../lib/detection_engine/prebuilt_rules/logic/rule_assets/prebuilt_rule_assets_client';
+import { createPrebuiltRuleObjectsClient } from '../../lib/detection_engine/prebuilt_rules/logic/rule_objects/prebuilt_rule_objects_client';
+import { createPrebuiltRules } from '../../lib/detection_engine/prebuilt_rules/logic/rule_objects/create_prebuilt_rules';
+import { createDetectionRulesClient } from '../../lib/detection_engine/rule_management/logic/detection_rules_client/detection_rules_client';
+import { buildMlAuthz } from '../../lib/machine_learning/authz';
+import { calculateRulesAuthz } from '../../lib/detection_engine/rule_management/authz';
+import type { ProductFeaturesService } from '../../lib/product_features_service';
+
+const installPrebuiltRulesSchema = z.object({
+  rule_ids: z
+    .array(z.string())
+    .min(1)
+    .max(50)
+    .describe(
+      'Array of prebuilt rule IDs to install. Use the find_prebuilt_rules tool first to discover available rule IDs.'
+    ),
+});
+
+export const SECURITY_INSTALL_PREBUILT_RULES_TOOL_ID = securityTool('install_prebuilt_rules');
+
+export const installPrebuiltRulesTool = (
+  core: SecuritySolutionPluginCoreSetupDependencies,
+  logger: Logger,
+  plugins: SecuritySolutionPluginSetupDependencies,
+  productFeaturesService: ProductFeaturesService
+): BuiltinToolDefinition<typeof installPrebuiltRulesSchema> => {
+  return {
+    id: SECURITY_INSTALL_PREBUILT_RULES_TOOL_ID,
+    type: ToolType.builtin,
+    description: `Install selected Elastic Security prebuilt detection rules by their rule IDs. Use the find_prebuilt_rules tool first to discover available rules and their rule_ids, then use this tool to install the desired ones. Returns a summary of installed, skipped (already installed), and failed rules.`,
+    schema: installPrebuiltRulesSchema,
+    availability: {
+      cacheMode: 'space',
+      handler: async ({ request }) => {
+        return getAgentBuilderResourceAvailability({ core, request, logger });
+      },
+    },
+    confirmation: {
+      askUser: 'always',
+      getConfirmation: ({ toolParams }) => {
+        const ruleIds = (toolParams as z.infer<typeof installPrebuiltRulesSchema>).rule_ids;
+        return {
+          title: 'Install prebuilt rules',
+          message: `Install ${ruleIds.length} prebuilt detection rule${
+            ruleIds.length > 1 ? 's' : ''
+          }?`,
+        };
+      },
+    },
+    handler: async (params, { request, savedObjectsClient }) => {
+      const { rule_ids: ruleIds } = params;
+
+      try {
+        logger.debug(
+          `${SECURITY_INSTALL_PREBUILT_RULES_TOOL_ID} tool called with ${ruleIds.length} rule_ids`
+        );
+
+        const [coreStart, startPlugins] = await core.getStartServices();
+
+        // Build required clients
+        const rulesClient = await startPlugins.alerting.getRulesClientWithRequest(request);
+        const actionsClient = await startPlugins.actions.getActionsClientWithRequest(request);
+        const license = await firstValueFrom(startPlugins.licensing.license$);
+
+        const mlAuthz = buildMlAuthz({
+          license,
+          ml: plugins.ml,
+          request,
+          savedObjectsClient,
+        });
+
+        const rulesAuthz = await calculateRulesAuthz({ coreStart, request });
+
+        const detectionRulesClient = createDetectionRulesClient({
+          actionsClient,
+          rulesClient,
+          savedObjectsClient,
+          mlAuthz,
+          rulesAuthz,
+          productFeaturesService,
+          license,
+        });
+
+        // Fetch available prebuilt rule assets
+        const ruleAssetsClient = createPrebuiltRuleAssetsClient(savedObjectsClient);
+        const allRuleAssets = await ruleAssetsClient.fetchLatestAssets();
+        const ruleAssetsMap = new Map(allRuleAssets.map((rule) => [rule.rule_id, rule]));
+
+        // Check which rules are already installed
+        const ruleObjectsClient = createPrebuiltRuleObjectsClient(rulesClient);
+        const installedVersions = await ruleObjectsClient.fetchInstalledRuleVersions();
+        const installedRuleIds = new Set(installedVersions.map((r) => r.rule_id));
+
+        // Categorize requested rules
+        const rulesToInstall = [];
+        const skippedAlreadyInstalled = [];
+        const notFound = [];
+
+        for (const ruleId of ruleIds) {
+          const asset = ruleAssetsMap.get(ruleId);
+
+          if (!asset) {
+            notFound.push(ruleId);
+          } else if (installedRuleIds.has(ruleId)) {
+            skippedAlreadyInstalled.push(ruleId);
+          } else {
+            rulesToInstall.push(asset);
+          }
+        }
+
+        // Install rules
+        const { results: installedRules, errors: installErrors } = await createPrebuiltRules(
+          detectionRulesClient,
+          rulesToInstall,
+          logger
+        );
+
+        const failedRules = installErrors.map((err) => ({
+          rule_id: err.item.rule_id,
+          error: err.error instanceof Error ? err.error.message : String(err.error),
+        }));
+
+        return {
+          results: [
+            {
+              type: ToolResultType.other,
+              data: {
+                summary: {
+                  total: ruleIds.length,
+                  installed: installedRules.length,
+                  already_installed: skippedAlreadyInstalled.length,
+                  not_found: notFound.length,
+                  failed: failedRules.length,
+                },
+                installed_rules: installedRules.map(({ result }) => ({
+                  rule_id: result.rule_id,
+                  name: result.name,
+                  severity: result.severity,
+                })),
+                ...(skippedAlreadyInstalled.length > 0 && {
+                  already_installed_rule_ids: skippedAlreadyInstalled,
+                }),
+                ...(notFound.length > 0 && { not_found_rule_ids: notFound }),
+                ...(failedRules.length > 0 && { failed_rules: failedRules }),
+              },
+            },
+          ],
+        };
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        logger.error(`Error in ${SECURITY_INSTALL_PREBUILT_RULES_TOOL_ID} tool: ${errorMessage}`);
+        return {
+          results: [
+            {
+              type: ToolResultType.error,
+              data: {
+                message: `Error installing prebuilt rules: ${errorMessage}`,
+              },
+            },
+          ],
+        };
+      }
+    },
+    tags: ['security', 'detection', 'prebuilt-rules', 'install'],
+  };
+};

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/register_tools.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/register_tools.ts
@@ -13,6 +13,7 @@ import { attackDiscoverySearchTool } from './attack_discovery_search_tool';
 import { entityRiskScoreTool, getEntityTool, searchEntitiesTool } from './entity_analytics';
 import { alertsTool } from './alerts_tool';
 import { createDetectionRuleTool } from './create_detection_rule_tool';
+import { findPrebuiltRulesTool } from './find_prebuilt_rules_tool';
 import type { SecuritySolutionPluginCoreSetupDependencies } from '../../plugin_contract';
 
 /**
@@ -31,4 +32,5 @@ export const registerTools = async (
   agentBuilder.tools.register(alertsTool(core, logger));
   agentBuilder.tools.register(getEntityTool(core, logger, experimentalFeatures));
   agentBuilder.tools.register(searchEntitiesTool(core, logger, experimentalFeatures));
+  agentBuilder.tools.register(findPrebuiltRulesTool(core, logger));
 };

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/register_tools.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/register_tools.ts
@@ -15,6 +15,7 @@ import { alertsTool } from './alerts_tool';
 import { createDetectionRuleTool } from './create_detection_rule_tool';
 import { findPrebuiltRulesTool } from './find_prebuilt_rules_tool';
 import { installPrebuiltRulesTool } from './install_prebuilt_rules_tool';
+import { bulkActionsTool } from './bulk_actions_tool';
 import type {
   SecuritySolutionPluginCoreSetupDependencies,
   SecuritySolutionPluginSetupDependencies,
@@ -43,4 +44,5 @@ export const registerTools = async (
   agentBuilder.tools.register(
     installPrebuiltRulesTool(core, logger, plugins, productFeaturesService)
   );
+  agentBuilder.tools.register(bulkActionsTool(core, logger, plugins, productFeaturesService));
 };

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/register_tools.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/register_tools.ts
@@ -14,7 +14,12 @@ import { entityRiskScoreTool, getEntityTool, searchEntitiesTool } from './entity
 import { alertsTool } from './alerts_tool';
 import { createDetectionRuleTool } from './create_detection_rule_tool';
 import { findPrebuiltRulesTool } from './find_prebuilt_rules_tool';
-import type { SecuritySolutionPluginCoreSetupDependencies } from '../../plugin_contract';
+import { installPrebuiltRulesTool } from './install_prebuilt_rules_tool';
+import type {
+  SecuritySolutionPluginCoreSetupDependencies,
+  SecuritySolutionPluginSetupDependencies,
+} from '../../plugin_contract';
+import type { ProductFeaturesService } from '../../lib/product_features_service';
 
 /**
  * Registers all security agent builder tools with the agentBuilder plugin
@@ -23,7 +28,9 @@ export const registerTools = async (
   agentBuilder: AgentBuilderPluginSetup,
   core: SecuritySolutionPluginCoreSetupDependencies,
   logger: Logger,
-  experimentalFeatures: ExperimentalFeatures
+  experimentalFeatures: ExperimentalFeatures,
+  plugins: SecuritySolutionPluginSetupDependencies,
+  productFeaturesService: ProductFeaturesService
 ) => {
   agentBuilder.tools.register(entityRiskScoreTool(core, logger));
   agentBuilder.tools.register(attackDiscoverySearchTool(core, logger));
@@ -33,4 +40,7 @@ export const registerTools = async (
   agentBuilder.tools.register(getEntityTool(core, logger, experimentalFeatures));
   agentBuilder.tools.register(searchEntitiesTool(core, logger, experimentalFeatures));
   agentBuilder.tools.register(findPrebuiltRulesTool(core, logger));
+  agentBuilder.tools.register(
+    installPrebuiltRulesTool(core, logger, plugins, productFeaturesService)
+  );
 };

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/authz.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/authz.ts
@@ -7,7 +7,17 @@
 
 import type { CoreStart } from '@kbn/core-lifecycle-server';
 import type { KibanaRequest } from '@kbn/core-http-server';
+import type { AuthorizationServiceSetup } from '@kbn/security-plugin/server';
 import {
+  RULES_API_READ,
+  RULES_API_ALL,
+  EXCEPTIONS_API_READ,
+  EXCEPTIONS_API_ALL,
+  ENABLE_DISABLE_RULES_API_PRIVILEGE,
+  MANUAL_RUN_RULES_API_PRIVILEGE,
+  RULES_MANAGEMENT_SETTINGS_API_PRIVILEGE,
+  CUSTOM_HIGHLIGHTED_FIELDS_API_EDIT,
+  INVESTIGATION_GUIDE_API_EDIT,
   RULES_UI_READ,
   RULES_UI_EDIT,
   EXCEPTIONS_UI_READ,
@@ -24,19 +34,95 @@ import { RULES_FEATURE_ID } from '../../../../common';
 interface CalculateRulesAuthzProps {
   coreStart: CoreStart;
   request: KibanaRequest;
+  security?: AuthorizationServiceSetup;
 }
 
 /**
  * Calculates the detection rules authorization context for the current user.
- * Resolves the user's capabilities from Kibana's capability service and maps them
- * to the DetectionRulesAuthz interface.
+ *
+ * When the Security plugin's authorization service is provided, resolves
+ * permissions by checking Kibana API privileges directly. This works reliably
+ * for all request types, including Task Manager fake requests authenticated
+ * via API keys (where `resolveCapabilities` fails because
+ * `request.auth.isAuthenticated` is `false`).
+ *
+ * Falls back to resolving UI capabilities when the authorization service is
+ * not provided.
  *
  * @returns A DetectionRulesAuthz object containing the user's permissions
  */
 export const calculateRulesAuthz = async ({
   coreStart,
   request,
+  security,
 }: CalculateRulesAuthzProps): Promise<DetectionRulesAuthz> => {
+  if (security) {
+    return calculateRulesAuthzFromApiPrivileges({ request, security });
+  }
+
+  return calculateRulesAuthzFromCapabilities({ coreStart, request });
+};
+
+const API_PRIVILEGES = [
+  RULES_API_READ,
+  RULES_API_ALL,
+  EXCEPTIONS_API_READ,
+  EXCEPTIONS_API_ALL,
+  ENABLE_DISABLE_RULES_API_PRIVILEGE,
+  MANUAL_RUN_RULES_API_PRIVILEGE,
+  CUSTOM_HIGHLIGHTED_FIELDS_API_EDIT,
+  INVESTIGATION_GUIDE_API_EDIT,
+  RULES_MANAGEMENT_SETTINGS_API_PRIVILEGE,
+] as const;
+
+/**
+ * Resolves detection rules authorization by checking Kibana API privileges
+ * via the Security plugin. Works for both real HTTP requests and Task Manager
+ * fake requests with API key authentication.
+ */
+const calculateRulesAuthzFromApiPrivileges = async ({
+  request,
+  security,
+}: {
+  request: KibanaRequest;
+  security: AuthorizationServiceSetup;
+}): Promise<DetectionRulesAuthz> => {
+  const checkPrivileges = security.checkPrivilegesDynamicallyWithRequest(request);
+
+  const { privileges } = await checkPrivileges({
+    kibana: API_PRIVILEGES.map((privilege) => security.actions.api.get(privilege)),
+  });
+
+  const hasPrivilege = (privilege: string): boolean =>
+    privileges.kibana.some(
+      (p) => p.privilege === security.actions.api.get(privilege) && p.authorized
+    );
+
+  return {
+    canReadRules: hasPrivilege(RULES_API_READ),
+    canEditRules: hasPrivilege(RULES_API_ALL),
+    canReadExceptions: hasPrivilege(EXCEPTIONS_API_READ),
+    canEditExceptions: hasPrivilege(EXCEPTIONS_API_ALL),
+    canEnableDisableRules: hasPrivilege(ENABLE_DISABLE_RULES_API_PRIVILEGE),
+    canManualRunRules: hasPrivilege(MANUAL_RUN_RULES_API_PRIVILEGE),
+    canEditCustomHighlightedFields: hasPrivilege(CUSTOM_HIGHLIGHTED_FIELDS_API_EDIT),
+    canEditInvestigationGuides: hasPrivilege(INVESTIGATION_GUIDE_API_EDIT),
+    canAccessRulesManagementSettings: hasPrivilege(RULES_MANAGEMENT_SETTINGS_API_PRIVILEGE),
+  };
+};
+
+/**
+ * Resolves detection rules authorization from Kibana UI capabilities.
+ * Only works for real HTTP requests where `request.auth.isAuthenticated`
+ * is `true`.
+ */
+const calculateRulesAuthzFromCapabilities = async ({
+  coreStart,
+  request,
+}: {
+  coreStart: CoreStart;
+  request: KibanaRequest;
+}): Promise<DetectionRulesAuthz> => {
   const { [RULES_FEATURE_ID]: capabilities } = await coreStart.capabilities.resolveCapabilities(
     request,
     {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/initialization/register_initialization_routes.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/initialization/register_initialization_routes.ts
@@ -7,7 +7,7 @@
 
 import type { Logger } from '@kbn/core/server';
 import type { SecuritySolutionPluginRouter } from '../../types';
-import { initializeRoute } from './routes';
+import { initializeRoute, setupCompleteRoute } from './routes';
 
 export interface InitializationRoutesDeps {
   router: SecuritySolutionPluginRouter;
@@ -19,4 +19,5 @@ export const registerInitializationRoutes = ({
   logger,
 }: InitializationRoutesDeps): void => {
   initializeRoute(router, logger);
+  setupCompleteRoute(router, logger);
 };

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/initialization/routes/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/initialization/routes/index.ts
@@ -6,3 +6,4 @@
  */
 
 export { initializeRoute } from './initialize_route';
+export { setupCompleteRoute } from './setup_complete_route';

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/initialization/routes/setup_complete_route.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/initialization/routes/setup_complete_route.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { IKibanaResponse, Logger, RequestHandlerContext } from '@kbn/core/server';
+import { transformError } from '@kbn/securitysolution-es-utils';
+import { buildRouteValidationWithZod } from '@kbn/zod-helpers/v4';
+import {
+  SECURITY_SETUP_COMPLETE_TRIGGER_ID,
+  setupCompleteEventSchema,
+} from '../../../../common/triggers/setup_complete_trigger';
+import type { SecuritySolutionPluginRouter } from '../../../types';
+import { buildSiemResponse } from '../../detection_engine/routes/utils';
+
+export const SETUP_COMPLETE_URL = '/api/security_solution/setup_complete' as const;
+
+export const setupCompleteRoute = (router: SecuritySolutionPluginRouter, logger: Logger) => {
+  router.versioned
+    .post({
+      access: 'internal',
+      path: SETUP_COMPLETE_URL,
+      security: {
+        authz: {
+          requiredPrivileges: ['securitySolution'],
+        },
+      },
+    })
+    .addVersion(
+      {
+        version: '1',
+        validate: {
+          request: {
+            body: buildRouteValidationWithZod(setupCompleteEventSchema),
+          },
+        },
+      },
+      async (context, request, response): Promise<IKibanaResponse> => {
+        const siemResponse = buildSiemResponse(response);
+
+        try {
+          const workflows = await (
+            context as RequestHandlerContext & { workflows?: Promise<unknown> }
+          ).workflows;
+
+          if (workflows && typeof workflows === 'object') {
+            const client = (
+              workflows as { getWorkflowsClient: () => { emitEvent: Function } }
+            ).getWorkflowsClient();
+            await client.emitEvent(SECURITY_SETUP_COMPLETE_TRIGGER_ID, {
+              completed_cards: request.body.completed_cards,
+            });
+            logger.debug(
+              `Emitted ${SECURITY_SETUP_COMPLETE_TRIGGER_ID} event with cards: ${request.body.completed_cards.join(
+                ', '
+              )}`
+            );
+          } else {
+            logger.debug(
+              `Workflows plugin not available, skipping ${SECURITY_SETUP_COMPLETE_TRIGGER_ID} event emission`
+            );
+          }
+
+          return response.ok({ body: { ok: true } });
+        } catch (err) {
+          const error = transformError(err);
+          return siemResponse.error({
+            body: error.message,
+            statusCode: error.statusCode,
+          });
+        }
+      }
+    );
+};

--- a/x-pack/solutions/security/plugins/security_solution/server/plugin.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/plugin.ts
@@ -23,6 +23,7 @@ import { registerScriptsLibraryRoutes } from './endpoint/routes/scripts_library'
 import { registerAttachments } from './agent_builder/attachments/register_attachments';
 import { registerTools } from './agent_builder/tools/register_tools';
 import { registerSkills } from './agent_builder/skills/register_skills';
+import { setupCompleteTriggerDefinition } from '../common/triggers/setup_complete_trigger';
 import { migrateEndpointDataToSupportSpaces } from './endpoint/migrations/space_awareness_migration';
 import { SavedObjectsClientFactory } from './endpoint/services/saved_objects';
 import { registerEntityStoreDataViewRefreshTask } from './lib/entity_analytics/entity_store/tasks/data_view_refresh/data_view_refresh_task';
@@ -825,6 +826,7 @@ export class Plugin implements ISecuritySolutionPlugin {
 
     if (plugins.workflowsExtensions) {
       registerWorkflowSteps(plugins.workflowsExtensions, core);
+      plugins.workflowsExtensions.registerTriggerDefinition(setupCompleteTriggerDefinition);
     }
 
     setupAlertsCapabilitiesSwitcher({

--- a/x-pack/solutions/security/plugins/security_solution/server/plugin.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/plugin.ts
@@ -267,7 +267,14 @@ export class Plugin implements ISecuritySolutionPlugin {
     const experimentalFeatures = this.config.experimentalFeatures;
     const endpointAppContextService = this.endpointAppContextService;
 
-    registerTools(agentBuilder, core, logger, experimentalFeatures).catch((error) => {
+    registerTools(
+      agentBuilder,
+      core,
+      logger,
+      experimentalFeatures,
+      plugins,
+      this.productFeaturesService
+    ).catch((error) => {
       this.logger.error(`Error registering security tools: ${error}`);
     });
     registerAttachments(agentBuilder).catch((error) => {

--- a/x-pack/solutions/security/plugins/security_solution/server/plugin.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/plugin.ts
@@ -289,6 +289,7 @@ export class Plugin implements ISecuritySolutionPlugin {
     });
     registerSkills({
       agentBuilder,
+      core,
       experimentalFeatures,
       getStartServices: core.getStartServices,
       kibanaVersion: this.pluginContext.env.packageInfo.version,

--- a/x-pack/solutions/security/plugins/security_solution/server/plugin.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/plugin.ts
@@ -19,11 +19,16 @@ import type { ILicense } from '@kbn/licensing-types';
 import type { NewPackagePolicy, UpdatePackagePolicy } from '@kbn/fleet-plugin/common';
 import { FLEET_ENDPOINT_PACKAGE } from '@kbn/fleet-plugin/common';
 
+import { kibanaRequestFactory } from '@kbn/core-http-server-utils';
 import { registerScriptsLibraryRoutes } from './endpoint/routes/scripts_library';
 import { registerAttachments } from './agent_builder/attachments/register_attachments';
 import { registerTools } from './agent_builder/tools/register_tools';
 import { registerSkills } from './agent_builder/skills/register_skills';
 import { setupCompleteTriggerDefinition } from '../common/triggers/setup_complete_trigger';
+import {
+  createThreatCoverageInitializationWorkflowService,
+  type ThreatCoverageInitializationWorkflowService,
+} from './workflows/threat_coverage_initialization_workflow';
 import { migrateEndpointDataToSupportSpaces } from './endpoint/migrations/space_awareness_migration';
 import { SavedObjectsClientFactory } from './endpoint/services/saved_objects';
 import { registerEntityStoreDataViewRefreshTask } from './lib/entity_analytics/entity_store/tasks/data_view_refresh/data_view_refresh_task';
@@ -206,6 +211,7 @@ export class Plugin implements ISecuritySolutionPlugin {
   private usageCollection?: UsageCollectionSetup;
 
   private isServerless: boolean;
+  private threatCoverageInitializationWorkflowService?: ThreatCoverageInitializationWorkflowService;
 
   constructor(context: PluginInitializerContext) {
     const serverConfig = createConfig(context);
@@ -829,6 +835,14 @@ export class Plugin implements ISecuritySolutionPlugin {
       plugins.workflowsExtensions.registerTriggerDefinition(setupCompleteTriggerDefinition);
     }
 
+    if (plugins.workflowsManagement) {
+      this.threatCoverageInitializationWorkflowService =
+        createThreatCoverageInitializationWorkflowService(
+          this.logger,
+          plugins.workflowsManagement.management
+        );
+    }
+
     setupAlertsCapabilitiesSwitcher({
       core,
       logger: this.logger,
@@ -858,6 +872,24 @@ export class Plugin implements ISecuritySolutionPlugin {
     ).catch(() => {});
 
     this.ruleMonitoringService.start(core, plugins);
+
+    if (this.threatCoverageInitializationWorkflowService) {
+      const fakeRequest = kibanaRequestFactory({
+        headers: {},
+        path: '/',
+        route: { settings: {} },
+        url: { href: {}, hash: '' } as URL,
+        raw: { req: { url: '/' } } as never,
+      });
+
+      this.threatCoverageInitializationWorkflowService
+        .ensureWorkflow({ enabled: true, request: fakeRequest })
+        .catch((error) => {
+          this.logger.error(
+            `Failed to ensure threat coverage initialization workflow: ${error.message}`
+          );
+        });
+    }
 
     const savedObjectsClient = new SavedObjectsClient(
       core.savedObjects.createInternalRepository([

--- a/x-pack/solutions/security/plugins/security_solution/server/plugin.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/plugin.ts
@@ -1136,6 +1136,34 @@ export class Plugin implements ISecuritySolutionPlugin {
           return packagePolicy;
         }
       );
+
+      const workflowsExtensionsStart = plugins.workflowsExtensions;
+      if (workflowsExtensionsStart) {
+        const logger = this.logger;
+        registerIngestCallback(
+          'packagePolicyPostCreate',
+          async (packagePolicy, _soClient, _esClient, _context, request) => {
+            const pkg = packagePolicy.package;
+            if (pkg && request) {
+              try {
+                const client = await workflowsExtensionsStart.getClient(request);
+                await client.emitEvent('fleet.integrationInstalled', {
+                  package_name: pkg.name,
+                  package_version: pkg.version,
+                  install_source: 'registry',
+                });
+              } catch (error) {
+                logger.warn(
+                  `Failed to emit fleet.integrationInstalled for "${pkg.name}@${pkg.version}": ${
+                    error instanceof Error ? error.message : String(error)
+                  }`
+                );
+              }
+            }
+            return packagePolicy;
+          }
+        );
+      }
     }
 
     if (plugins.taskManager) {

--- a/x-pack/solutions/security/plugins/security_solution/server/plugin_contract.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/plugin_contract.ts
@@ -59,6 +59,7 @@ import type {
 import type { EntityStoreSetupContract, EntityStoreStartContract } from '@kbn/entity-store/server';
 import type { SearchInferenceEndpointsPluginSetup } from '@kbn/search-inference-endpoints/server';
 import type { WorkflowsExtensionsServerPluginSetup } from '@kbn/workflows-extensions/server';
+import type { WorkflowsServerPluginSetup } from '@kbn/workflows-management-plugin/server';
 import type { ProductFeaturesService } from './lib/product_features_service/product_features_service';
 import type { ExperimentalFeatures } from '../common';
 
@@ -89,6 +90,7 @@ export interface SecuritySolutionPluginSetupDependencies {
   entityStore?: EntityStoreSetupContract;
   searchInferenceEndpoints?: SearchInferenceEndpointsPluginSetup;
   workflowsExtensions?: WorkflowsExtensionsServerPluginSetup;
+  workflowsManagement?: WorkflowsServerPluginSetup;
 }
 
 export interface SecuritySolutionPluginStartDependencies {

--- a/x-pack/solutions/security/plugins/security_solution/server/plugin_contract.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/plugin_contract.ts
@@ -58,6 +58,7 @@ import type {
 } from '@kbn/workflows-extensions/server';
 import type { EntityStoreSetupContract, EntityStoreStartContract } from '@kbn/entity-store/server';
 import type { SearchInferenceEndpointsPluginSetup } from '@kbn/search-inference-endpoints/server';
+import type { WorkflowsExtensionsServerPluginSetup } from '@kbn/workflows-extensions/server';
 import type { ProductFeaturesService } from './lib/product_features_service/product_features_service';
 import type { ExperimentalFeatures } from '../common';
 
@@ -87,6 +88,7 @@ export interface SecuritySolutionPluginSetupDependencies {
   workflowsExtensions?: WorkflowsExtensionsServerPluginSetup;
   entityStore?: EntityStoreSetupContract;
   searchInferenceEndpoints?: SearchInferenceEndpointsPluginSetup;
+  workflowsExtensions?: WorkflowsExtensionsServerPluginSetup;
 }
 
 export interface SecuritySolutionPluginStartDependencies {

--- a/x-pack/solutions/security/plugins/security_solution/server/workflows/examples/detection_coverage_onboarding.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/server/workflows/examples/detection_coverage_onboarding.yaml
@@ -1,0 +1,58 @@
+version: '1'
+name: Detection Coverage Onboarding
+description: >
+  When a new Fleet integration is installed, automatically analyzes matching
+  prebuilt detection rules, installs critical and high severity rules, creates
+  a case documenting the changes, and monitors rule health.
+enabled: true
+
+triggers:
+  - type: fleet.integrationInstalled
+  - type: manual
+
+steps:
+  - name: log_trigger
+    type: console
+    with:
+      message: >
+        Detection coverage onboarding triggered.
+        Package: {{ event.package_name | default: "manual trigger" }}
+        Version: {{ event.package_version | default: "N/A" }}
+        Source: {{ event.install_source | default: "N/A" }}
+
+  - name: onboard_coverage
+    type: ai.agent
+    agent-id: detection-coverage-agent
+    with:
+      message: |
+        A new Fleet integration was just installed: {{ event.package_name | default: "unknown" }} (version {{ event.package_version | default: "unknown" }}).
+
+        Please run the full detection coverage onboarding workflow:
+        1. Check the current prebuilt rules status
+        2. List all installed integrations
+        3. Find prebuilt rules matching the installed integrations
+        4. Install all critical severity matching rules automatically — do NOT ask for confirmation, just install them
+        5. Check the health of the newly installed rules
+        6. Provide a summary of what was installed and the health status
+
+        Be concise in your response. Focus on the data: what was found, what was installed, and any issues.
+    timeout: 600s
+
+  - name: create_case
+    type: cases.createCase
+    with:
+      title: "Detection Coverage: rules installed for {{ event.package_name | default: 'new integrations' }}"
+      description: |
+        ## Automated Detection Coverage Onboarding
+
+        **Trigger:** New integration installed — {{ event.package_name | default: "manual trigger" }} ({{ event.package_version | default: "N/A" }})
+
+        **Agent Summary:**
+        {{ steps.onboard_coverage.output.message | default: "Agent did not return a summary." }}
+
+        ---
+        *This case was created automatically by the Detection Coverage Onboarding workflow.*
+      tags:
+        - detection-coverage
+        - automated
+        - "{{ event.package_name | default: 'manual' }}"

--- a/x-pack/solutions/security/plugins/security_solution/server/workflows/threat_coverage_initialization_workflow.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/workflows/threat_coverage_initialization_workflow.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { KibanaRequest, Logger } from '@kbn/core/server';
+import type { WorkflowsServerPluginSetup } from '@kbn/workflows-management-plugin/server';
+import { DEFAULT_SPACE_ID } from '@kbn/spaces-plugin/common';
+import { THREAT_COVERAGE_INITIALIZATION_WORKFLOW_ID } from '../../common/constants';
+import WORKFLOW_YAML from './threat_coverage_initialization_workflow.yaml';
+
+export interface ThreatCoverageInitializationWorkflowService {
+  ensureWorkflow(params: { enabled: boolean; request: KibanaRequest }): Promise<void>;
+}
+
+export const createThreatCoverageInitializationWorkflowService = (
+  logger: Logger,
+  managementApi: WorkflowsServerPluginSetup['management']
+): ThreatCoverageInitializationWorkflowService => {
+  const log = logger.get('threat-coverage-initialization-workflow');
+
+  return {
+    async ensureWorkflow({ enabled, request }) {
+      const existing = await managementApi.getWorkflow(
+        THREAT_COVERAGE_INITIALIZATION_WORKFLOW_ID,
+        DEFAULT_SPACE_ID
+      );
+      const currentlyEnabled = existing?.enabled ?? false;
+
+      if (enabled === currentlyEnabled) {
+        log.debug(() => `Workflow already ${enabled ? 'enabled' : 'disabled'}, no-op`);
+        return;
+      }
+
+      if (existing) {
+        const { deleted, failures } = await managementApi.deleteWorkflows(
+          [THREAT_COVERAGE_INITIALIZATION_WORKFLOW_ID],
+          DEFAULT_SPACE_ID,
+          request,
+          { force: true }
+        );
+
+        if (deleted === 0 && failures.length > 0) {
+          const reasons = failures.map((f) => `${f.id}: ${f.error}`).join('; ');
+          throw new Error(
+            `Failed to delete workflow ${THREAT_COVERAGE_INITIALIZATION_WORKFLOW_ID}: ${reasons}`
+          );
+        }
+
+        log.info(`Deleted workflow ${THREAT_COVERAGE_INITIALIZATION_WORKFLOW_ID}`);
+      }
+
+      if (!enabled) {
+        return;
+      }
+
+      await managementApi.createWorkflow(
+        { yaml: WORKFLOW_YAML, id: THREAT_COVERAGE_INITIALIZATION_WORKFLOW_ID },
+        DEFAULT_SPACE_ID,
+        request
+      );
+
+      log.info(
+        `Created threat coverage initialization workflow ${THREAT_COVERAGE_INITIALIZATION_WORKFLOW_ID}`
+      );
+    },
+  };
+};

--- a/x-pack/solutions/security/plugins/security_solution/server/workflows/threat_coverage_initialization_workflow.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/workflows/threat_coverage_initialization_workflow.ts
@@ -28,8 +28,9 @@ export const createThreatCoverageInitializationWorkflowService = (
         DEFAULT_SPACE_ID
       );
       const currentlyEnabled = existing?.enabled ?? false;
+      const yamlChanged = existing != null && existing.yaml !== WORKFLOW_YAML;
 
-      if (enabled === currentlyEnabled) {
+      if (enabled === currentlyEnabled && !yamlChanged) {
         log.debug(() => `Workflow already ${enabled ? 'enabled' : 'disabled'}, no-op`);
         return;
       }

--- a/x-pack/solutions/security/plugins/security_solution/server/workflows/threat_coverage_initialization_workflow.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/server/workflows/threat_coverage_initialization_workflow.yaml
@@ -1,0 +1,46 @@
+version: '1'
+name: Threat Coverage Initialization
+description: >-
+  Automatically initializes threat detection coverage when the Security Solution
+  setup completes or a new Fleet integration is installed. Invokes the AI agent
+  with the threat-coverage-initialization skill to assess available security data,
+  map it to MITRE ATT&CK tactics, find matching prebuilt detection rules, and
+  install them.
+enabled: true
+tags:
+  - Security
+  - Detection Coverage
+  - MITRE ATT&CK
+  - Automation
+
+triggers:
+  - type: security.setupComplete
+  - type: fleet.integrationInstalled
+
+steps:
+  - name: initialize_threat_coverage
+    type: ai.agent
+    with:
+      message: >-
+        {%- if event.trigger_id == "fleet.integrationInstalled" -%}
+        A new Fleet integration "{{ event.package_name }}" (version {{ event.package_version }}) has
+        just been installed. Use the threat-coverage-initialization skill to assess
+        the available security data including this newly installed integration, map
+        data sources to MITRE ATT&CK tactics, find matching prebuilt detection rules
+        that leverage the new integration data, and install the recommended rules.
+        Focus especially on detection rules related to the "{{ event.package_name }}" integration.
+        {%- else -%}
+        The Security Solution setup has just been completed. Use the
+        threat-coverage-initialization skill to perform a full assessment of the
+        available security data and installed integrations, map all data sources to
+        MITRE ATT&CK tactics, identify coverage gaps, find matching prebuilt
+        detection rules, and install the recommended rules to bootstrap detection
+        coverage for this deployment.
+        {%- endif -%}
+
+  - name: log_completion
+    type: console
+    with:
+      message: >-
+        Threat coverage initialization completed.
+        Agent response: {{ steps.initialize_threat_coverage.output.message }}

--- a/x-pack/solutions/security/plugins/security_solution/server/workflows/threat_coverage_initialization_workflow.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/server/workflows/threat_coverage_initialization_workflow.yaml
@@ -1,6 +1,7 @@
 version: '1'
-name: Threat Coverage Initialization
+name: .security-threat-coverage-initialization
 description: >-
+  This workflow is used by the system and should not be modified.
   Automatically initializes threat detection coverage when the Security Solution
   setup completes or a new Fleet integration is installed. Invokes the AI agent
   with the threat-coverage-initialization skill to assess available security data,

--- a/x-pack/solutions/security/plugins/security_solution/server/workflows/threat_coverage_initialization_workflow.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/server/workflows/threat_coverage_initialization_workflow.yaml
@@ -17,10 +17,13 @@ tags:
 triggers:
   - type: security.setupComplete
   - type: fleet.integrationInstalled
+    on:
+      condition: 'not event.package_name: "system"'
 
 steps:
   - name: initialize_threat_coverage
     type: ai.agent
+    connector-id: gpt-5-1
     with:
       message: >-
         {%- if event.trigger_id == "fleet.integrationInstalled" -%}

--- a/x-pack/solutions/security/plugins/security_solution/tsconfig.json
+++ b/x-pack/solutions/security/plugins/security_solution/tsconfig.json
@@ -284,6 +284,7 @@
     "@kbn/esql-language",
     "@kbn/workflows-ui",
     "@kbn/workflows",
+    "@kbn/workflows-management-plugin",
     "@kbn/deeplinks-workflows",
     "@kbn/core-rendering-browser",
     "@kbn/controls-constants",


### PR DESCRIPTION
## Summary

- Adds `fleet.list_installed_integrations` agent builder tool to list installed Fleet integrations
- Adds `security.find_prebuilt_rules` and `security.install_prebuilt_rules` agent builder tools for prebuilt detection rules management
- Adds `security.bulk_actions` agent builder tool for detection rules management in bulk (enable/disable and tags)
- Adds `threat-coverage-initialization` agent builder skill that orchestrates integration-aware rule installation
- Adds Threat Coverage Initialization workflow definition (YAML) tying the skill and tools together
- Adds `setup_complete` trigger and route for Security Solution initialization flow
- Adds `integration_installed` trigger and event emission in Fleet

## Test plan

- [ ] Verify `fleet.list_installed_integrations` tool returns installed integrations correctly
- [ ] Verify `security.find_prebuilt_rules` tool finds rules matching installed integrations
- [ ] Verify `security.install_prebuilt_rules` tool installs selected prebuilt rules
- [ ] Verify the threat-coverage-initialization skill orchestrates the full flow end-to-end
- [ ] Verify the workflow YAML is valid and triggers correctly
- [ ] Run existing unit tests: `node scripts/jest x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/install_prebuilt_rules_tool.test.ts`
- [ ] Run existing skill tests: `node scripts/jest x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/skills.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)