### PR TITLE
[Scout/FTR] Nudge developers to run the flaky test runner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3275,7 +3275,7 @@ x-pack/solutions/observability/plugins/synthetics/server/saved_objects/synthetic
 /**/scout/.meta/**
 /**/scout_*/.meta/**
 
-# Macroscope
+# Macroscope Check Run Agents
 /.macroscope/scout-review.md @elastic/appex-qa
 /.macroscope/flaky-test-runner-nudge.md @elastic/appex-qa
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3275,6 +3275,10 @@ x-pack/solutions/observability/plugins/synthetics/server/saved_objects/synthetic
 /**/scout/.meta/**
 /**/scout_*/.meta/**
 
+# Macroscope
+/.macroscope/scout-review.md @elastic/appex-qa
+/.macroscope/flaky-test-runner-nudge.md @elastic/appex-qa
+
 # These files influence agent behavior and are loaded into every new agent session.
 # Changes here can have repo-wide impact (what instructions/tools/context an agent sees), so require
 # tech lead review by default.

--- a/.macroscope/flaky-test-runner-nudge.md
+++ b/.macroscope/flaky-test-runner-nudge.md
@@ -18,7 +18,7 @@ exclude:
 conclusion: neutral
 ---
 
-Decide whether this PR should nudge the author to run the **Flaky Test Runner**. That takes two steps: (1) paths in scope, (2) changes that could realistically affect flakiness (see **When to nudge**). When a nudge applies, output **only** the markdown block in **Output format** below. When it does not apply, leave no comment on the PR.
+Decide whether this PR should nudge the author to run the **Flaky Test Runner**. That takes two steps: (1) paths in scope, (2) changes that could realistically affect flakiness (see **When to nudge**). When a nudge applies, follow **Output format** (verbatim PR markdown plus resolved `/flaky` lines per **Rules**). When it does not apply, leave no comment on the PR.
 
 ## When this applies (paths)
 
@@ -57,10 +57,10 @@ If a PR touches **both** Scout and FTR paths, judge **each runner separately**. 
 
 Each PR comment body must start with **`/flaky `** followed by **exactly one** clause: `<kind>:<path>:<count>` (for example `/flaky scoutConfig:path/to/playwright.config.ts:30`). The workflow runs **per comment**, so **do not** put Scout and FTR in the same comment. If you need **both** runners, post **two** comments on the PR: first `/flaky` line in one comment, second `/flaky` line in another.
 
-**Why not a generic `type`?** The GitHub workflow (`.github/workflows/trigger-flaky.yml`) only recognizes the **exact** tokens **`scoutConfig`** and **`ftrConfig`**. They select which CI job runs (Scout/Playwright vs FTR). Replace placeholders with those literals, not the word `type`.
+**Why not a generic `type`?** The `/flaky` handler only accepts the **exact** tokens **`scoutConfig`** and **`ftrConfig`**. They select which CI job runs (Scout/Playwright vs FTR). Replace placeholders with those literals, not the word `type`.
 
 - **`scoutConfig`:** path to the **Playwright** config `.ts` file.
-- **`ftrConfig`:** path to the **FTR** leaf config `.ts` file passed to `node scripts/functional_tests --config`.
+- **`ftrConfig`:** path to the **FTR** leaf config `.ts` file.
 
 **Examples:**
 
@@ -110,15 +110,17 @@ Both Scout and FTR (two separate comments on the PR):
 - `x-pack/platform/test/serverless/**`
 - `x-pack/solutions/<solution>/test/serverless/**`
 
-**Recognize FTR:** mocha suites with **`FtrProviderContext`** (`getService`, `loadTestFile`, …), **`@kbn/expect`**, or leaf **`config*.ts`** used by `node scripts/functional_tests --config`.
+**Recognize FTR:** mocha suites with **`FtrProviderContext`** (`getService`, `loadTestFile`, …), **`@kbn/expect`**, or leaf **`config*.ts`** for an FTR suite.
 
 **Not FTR:** Scout (`**/test/scout/**`), Cypress (`*.cy.ts` and `*cypress*` driver trees), plain Jest units without FTR.
 
 ## Output format (follow verbatim)
 
-When a nudge is warranted per **When to nudge (substance)**, output **only** the following markdown block (wording is fixed; you resolve paths). Include **`scoutConfig`** lines only for qualifying Scout changes; **`ftrConfig`** lines only for qualifying FTR changes. Replace `<KIND>` / `<CONFIG_PATH>` with literals and real paths (see **GitHub comment format**).
+When a nudge is warranted per **When to nudge (substance)**, output two parts:
 
-If **one** runner qualifies, use **one** `text` block with a **single** `/flaky` line. If **both** qualify, use **two** `text` blocks in a row (Scout first, then FTR), each block containing **one** `/flaky` line. The author must post each block as a **separate** PR comment.
+1. **PR markdown (verbatim block below):** fixed wording only. Do **not** put placeholder `/flaky` lines, copy-paste fences, or explanations about kinds, paths, or multiple blocks in this block. Developers get the exact `/flaky` command(s) from automation; this section is just the nudge and the two ways to run.
+
+2. **Resolved commands (Rules):** you still resolve paths per **Scout** / **FTR** / **GitHub comment format** so automation (or follow-up tooling) can post the right `/flaky` line(s).
 
 ````markdown
 ## Run the Flaky Test Runner (recommended)
@@ -127,21 +129,13 @@ If **one** runner qualifies, use **one** `text` block with a **single** `/flaky`
 
 **Two ways to run it:**
 
-1. Open the [Flaky Test Runner UI](https://ci-stats.kibana.dev/trigger_flaky_test_runner) or
-2. Post each `/flaky` line below as its **own** comment on this PR (one trigger per comment):
-
-```text
-/flaky <KIND>:<CONFIG_PATH>:30
-```
-
-`<KIND>` must be the literal token `scoutConfig` or `ftrConfig`. `<CONFIG_PATH>` is the repo-relative config for that runner. If both runners qualify, add a **second** `text` block with the other kind (two comments total).
+1. Open the [Flaky Test Runner UI](https://ci-stats.kibana.dev/trigger_flaky_test_runner)
+2. Use the `/flaky` PR comment(s) prepared automatically for this change (exact `scoutConfig` / `ftrConfig` lines are injected for you; post one comment per runner when both apply).
 ````
 
 **Rules**
 
-- Each `text` fence must contain **exactly one** `/flaky` line (one `scoutConfig:` **or** one `ftrConfig:` clause, never both in the same fence).
-- If both runners qualify, output **two** `text` blocks (two separate paste targets for two PR comments).
+- After the verbatim block, output the **resolved** `/flaky` line(s) automation needs: one line if one runner qualifies, **two** lines (Scout first, then FTR) if both qualify. Each line must be a full `/flaky scoutConfig:…:30` or `/flaky ftrConfig:…:30` with repo-relative paths and **`:30`**. Never use `<KIND>` or `<CONFIG_PATH>` placeholders there.
 - Always append **`:30`** after **each** path (never omit the count).
-- Do not rephrase the heading, recommendation, or two-way instructions; do not add severity labels or extra sections.
-- The `/flaky` lines you show must be **fully resolved** (no literal `<KIND>` or `<CONFIG_PATH>` left in what you publish).
-- Never invent a second command for a runner that did not qualify.
+- Do not rephrase the heading, recommendation, or two-way instructions inside the verbatim block; do not add severity labels or extra sections there.
+- Never invent a command for a runner that did not qualify.

--- a/.macroscope/flaky-test-runner-nudge.md
+++ b/.macroscope/flaky-test-runner-nudge.md
@@ -1,3 +1,4 @@
+`````markdown
 ---
 title: Flaky Test Runner nudge
 model: claude-opus-4-6
@@ -22,9 +23,7 @@ Decide whether this PR needs a Flaky Test Runner nudge. If not, post nothing.
 
 ## Step 1: Are any in-scope files changed?
 
-- **Scout**
-  - **`**/test/scout\*/**`:** specs, fixtures, and plugin-local Scout test code (each tree usually has a Playwright config next to it).
-  - **`**/kbn-scout*/**`:** shared Scout packages (for example `@kbn/scout`, `@kbn/scout-oblt`, `@kbn/scout-search`, `@kbn/scout-security`): page objects, framework code, and helpers that tests import. This layout is **not** covered by `\*\*/test/scout*/\*\*`alone; changes here can still affect many suites even when there is no`playwright.config.ts` beside the file.
+- **Scout:** `**/test/scout*/**` or `**/kbn-scout*/**`
 - **FTR:** `src/platform/test/**`, `x-pack/platform/test/**`, `x-pack/solutions/*/test/**`
 
 If nothing matches, stop.
@@ -39,29 +38,19 @@ Evaluate Scout and FTR independently. Only nudge the side(s) that qualify.
 
 ## Step 3: Resolve the config path
 
-**FTR:** Walk up from the changed file to the nearest leaf `config*.ts` (skip `*.base.ts` files). If none is found, use `browse_code` to find which config’s `testFiles` / `loadTestFile` includes the changed file.
+**FTR:** Walk up from the changed file to the nearest leaf `config*.ts` (skip `*.base.ts`). If none found, use `browse_code` to find which config's `testFiles`/`loadTestFile` includes the changed file.
 
-Sample FTR config path: `x-pack/platform/test/serverless/functional/configs/search/config.group7.ts`
+Example: `x-pack/platform/test/serverless/functional/configs/search/config.group7.ts`
 
-**Scout (two cases)**
+**Scout — changed file is under `**/test/scout\*/**`:** Walk up to the nearest `playwright.config.ts` or `parallel.playwright.config.ts` (prefer `parallel` if the path contains `parallel_tests/`).
 
-1. **Change is under `**/test/scout*/**`:** Walk up to the nearest `playwright.config.ts` or `parallel.playwright.config.ts`. Prefer `parallel.playwright.config.ts` when the changed path contains `parallel_tests/`. You can emit `/flaky scoutConfig:<that-path>:30`.
+Example: `x-pack/platform/plugins/shared/streams_app/test/scout/ui/playwright.config.ts`
 
-   Sample: `x-pack/platform/plugins/shared/streams_app/test/scout/ui/playwright.config.ts`
-
-2. **Change is under `**/kbn-scout*/**` (or other shared Scout package code) with no Playwright config in an ancestor directory:** Do **not** guess a path from the package file path alone. **First, derive a config from the changed code:**
-   - Search the repo for **imports of the changed module(s)** (the file you edited, its barrel `index.ts`, or the package subpath that changed). Prioritize hits under `**/test/scout*/**` (specs, fixtures, page objects in plugin trees that re-export or wrap the package).
-   - From each relevant hit, **walk up** to the nearest `playwright.config.ts` or `parallel.playwright.config.ts` (same rules as case 1). That is the `scoutConfig` for suites that actually exercise this change.
-   - If **one** clear config covers the change, use **Output B** with that path. If **several** configs are justified (widely shared symbol), pick the **most representative** config from the search, or emit **B** for the narrowest scope first; mention in a short line that other suites may also import this code if needed.
-   - Use **`browse_code`** and **`grep`** freely to follow imports and fixture wiring.
-
-   **Only if** no `playwright.config.ts` can be tied to the change after that search, use **Output C** (author picks a suite in the UI or manually).
+**Scout — changed file is under `**/kbn-scout*/**`:** Search the repo for imports of the changed module, prioritising hits under `\*\*/test/scout*/\*\*`. From each hit, walk up to the nearest Playwright config as above. If no config can be linked after tracing imports, tell the author to pick a suite manually using the UI.
 
 ## Output
 
-Pick **A**, **B**, or **C** depending on Step 3. Prefer **B** for Scout whenever you can resolve a Playwright config (including case 2 after import tracing). Use **C** only when shared package code changes and **no** config can be linked to the change after searching imports from that code into `**/test/scout*/**`.
-
-**A. FTR only (resolved `ftrConfig`)**
+Post one comment on the PR. Include only the `/flaky` line(s) for the runner(s) that qualify:
 
 ````markdown
 ## Catch flakiness early (recommended)
@@ -71,46 +60,12 @@ Pick **A**, **B**, or **C** depending on Step 3. Prefer **B** for Scout whenever
 Trigger a run with the [Flaky Test Runner UI](https://ci-stats.kibana.dev/trigger_flaky_test_runner) or post this comment on the PR:
 
 ```
-/flaky ftrConfig:<resolved-ftr-config-path>:30
+/flaky <scoutConfig or ftrConfig>:<resolved-ftr-config-path>:30
 ```
 ````
+`````
 
-**B. Scout with a resolved Playwright config**
-
-````markdown
-## Catch flakiness early (recommended)
-
-**Recommended before merge**: run the flaky test runner against this PR to catch flakiness early.
-
-Trigger a run with the [Flaky Test Runner UI](https://ci-stats.kibana.dev/trigger_flaky_test_runner) or post this comment on the PR:
-
-```
-/flaky scoutConfig:<resolved-playwright-config-path>:30
-```
-````
-
-**C. Scout shared package (import tracing did not resolve a config)**
-
-Use only when Step 3 case **2** still has **no** Playwright config after searching imports from the changed code into `**/test/scout*/**`. Do not paste a guessed `scoutConfig` path.
-
-````markdown
-## Catch flakiness early (recommended)
-
-**Recommended before merge**: run the flaky test runner for suites that **cover this change**.
-
-This PR touches **shared Scout package** code (for example under `kbn-scout*`). No Playwright config could be tied to this diff by following imports from the changed files into plugin `test/scout/` trees, so pick the right run yourself:
-
-1. Use the [Flaky Test Runner UI](https://ci-stats.kibana.dev/trigger_flaky_test_runner) and select a suite whose tests exercise the code you changed, **or**
-2. Manually find a plugin `test/scout/**/playwright.config.ts` or `parallel.playwright.config.ts` for a suite that uses this package, then post:
-
-```
-/flaky scoutConfig:<path-to-that-playwright-config>:30
-```
-````
-
-**Both Scout and FTR:** Post **two** comments (one FTR from **A**, one Scout from **B** or **C** as appropriate).
-
-**Samples (for A and B only)**
+Replace the example paths with the resolved paths from Step 3. Drop whichever line doesn't apply. If Scout config could not be resolved (shared `kbn-scout*` package with no traceable imports), replace the `scoutConfig` line with a note asking the author to pick a suite manually in the UI. Sample commands:
 
 Scout:
 
@@ -123,3 +78,5 @@ FTR:
 ```
 /flaky ftrConfig:x-pack/platform/test/serverless/functional/configs/search/config.group7.ts:30
 ```
+
+Always use 30: this tells the runner to execute the test config 30 times.

--- a/.macroscope/flaky-test-runner-nudge.md
+++ b/.macroscope/flaky-test-runner-nudge.md
@@ -40,20 +40,38 @@ Evaluate Scout and FTR independently. Only nudge the side(s) that qualify.
 
 **Scout:** Walk up from the changed file to the nearest `playwright.config.ts` or `parallel.playwright.config.ts`. Use `parallel.playwright.config.ts` if the path contains `parallel_tests/`.
 
+Sample Scout config path: `x-pack/platform/plugins/shared/streams_app/test/scout/ui/playwright.config.ts`
+
 **FTR:** Walk up to the nearest leaf `config*.ts` (skip `*.base.ts` files). If none found, check which config's `testFiles`/`loadTestFile` includes the changed file.
+
+Sample FTR config path: `x-pack/platform/test/serverless/functional/configs/search/config.group7.ts`
 
 ## Output
 
 Post exactly one PR comment:
 
-```markdown
-## Run the Flaky Test Runner (recommended)
+````markdown
+## Catch flakiness early (recommended)
 
 **Recommended before merge**: run the flaky test runner against this PR to catch flakiness early.
 
 Trigger a run with the [Flaky Test Runner UI](https://ci-stats.kibana.dev/trigger_flaky_test_runner) or post a comment in the PR:
 
+```
 /flaky <ftrConfig or scoutConfig here>:<resolved-path>:30
 ```
+````
 
 Include only the `/flaky` line(s) for the runner(s) that qualify. Replace each `<resolved-path>` with the actual config path from Step 3. Replace "ftrConfig or scoutConfig here" with the actual test runner.
+
+Sample Scout command:
+
+```
+/flaky scoutConfig:x-pack/platform/plugins/shared/streams_app/test/scout/ui/playwright.config.ts:30
+```
+
+Sample FTR command:
+
+```
+/flaky ftrConfig:x-pack/platform/test/serverless/functional/configs/search/config.group7.ts:30
+```

--- a/.macroscope/flaky-test-runner-nudge.md
+++ b/.macroscope/flaky-test-runner-nudge.md
@@ -1,0 +1,107 @@
+---
+title: Flaky Test Runner nudge
+model: claude-opus-4-6
+reasoning: high
+effort: medium
+input: full_diff
+exclude:
+  - 'api_docs/**'
+  - 'config/**'
+  - 'dev_docs/**'
+  - 'docs/**'
+  - 'legacy_rfcs/**'
+  - 'licenses/**'
+  - 'node_modules/**'
+  - 'oas_docs/**'
+  - 'typings/**'
+  - '.buildkite/**'
+conclusion: neutral
+---
+
+Your only job is to decide whether this PR should nudge the author to run the **Flaky Test Runner**, and to output the **exact** PR comment text below. Do not add anything else.
+
+## When this applies
+
+Process **only** changed files that match **either**:
+
+1. **Scout (Playwright):** paths under `**/test/scout*/**` (specs, fixtures, page objects, API services, global setup, etc.), or under `**/kbn-scout*/**` when the change is under that package’s own `**/test/scout/**` tree.
+2. **FTR (Functional Test Runner):** see **FTR locations and patterns** below.
+
+If **no** changed file matches Scout or FTR test work, output **exactly** this single line (verbatim, nothing else):
+
+`No Scout or FTR test paths changed in this PR. No flaky test runner nudge needed.`
+
+## Constants (do not change)
+
+- **RUN_COUNT** is always **`30`** in the `/flaky` comment (same order of magnitude as the 20–50 guidance in `docs/extend/scout/best-practices.md`).
+- Paths are **repo-root-relative**, **no leading slash**, **no `..`** (same as `node scripts/functional_tests --config` and Playwright `--config`).
+
+## GitHub comment format
+
+PR comments are parsed as: `/flaky <type>:<path>:<count> [<type>:<path>:<count> ...]` where `<type>` is `scoutConfig` or `ftrConfig` (see `.github/workflows/trigger-flaky.yml`). The `<path>` for **`ftrConfig`** is the **full path to the FTR config file** passed to `node scripts/functional_tests --config` (Buildkite sets `FTR_CONFIG` to this string). The `<path>` for **`scoutConfig`** is the **Playwright config** `.ts` file.
+
+## Scout: resolve `scoutConfig` path
+
+1. Config files live under `**/test/scout/**`, usually `playwright.config.ts` and/or `parallel.playwright.config.ts` (sometimes other `*.playwright.config.ts`).
+2. From each changed file, walk **up**; use the **nearest** ancestor directory that contains such a file.
+3. If **both** `playwright.config.ts` and `parallel.playwright.config.ts` exist in that directory: use **`parallel.playwright.config.ts`** when the changed path includes a `parallel_tests/` segment; otherwise use **`playwright.config.ts`**. If a shared helper can affect both suites, include **two** `scoutConfig:` entries in the same `/flaky` line.
+4. If the changed file **is** a Playwright config, that file’s path is the `scoutConfig` path.
+
+## FTR: resolve `ftrConfig` path
+
+1. From each changed FTR test/support file’s directory, walk **up** toward the repo root. At each directory, look for a **leaf** FTR config file: usually `config.ts`, but often `config.group1.ts`, `config.feature_flags.ts`, `cli_config.ts`, or another `config*.ts` under `configs/`. **Skip** base-only files (`config.base.ts`, `*.config.base.ts`, `config.*.base.ts`). Keep walking until you hit a concrete suite config.
+2. If the changed file **is** such a leaf config, use that path.
+3. If no candidate appears on the walk (common under `x-pack/platform/test/serverless/**` and other grouped layouts), use `browse_code` to find which config’s `testFiles` / `loadTestFile` includes the changed file, or cross-check paths that appear in `.buildkite/ftr_*_configs.yml` (see `.buildkite/ftr_configs_manifests.json` for which YAML files list enabled configs).
+4. If multiple leaf configs apply, include multiple `ftrConfig:` clauses on the **same** `/flaky` line, space-separated.
+
+## FTR locations and patterns
+
+**Typical folder roots** (FTR tests and configs are almost always under a `test/` tree; many suites use a leaf `config.ts`):
+
+| Area                       | Example paths                                                                                                                                                                                                                     |
+| -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Platform OSS functional    | `src/platform/test/functional/`                                                                                                                                                                                                   |
+| Platform x-pack functional | `x-pack/platform/test/functional/`                                                                                                                                                                                                |
+| Platform API integration   | `x-pack/platform/test/api_integration/`                                                                                                                                                                                           |
+| Other platform suites      | `x-pack/platform/test/alerting_api_integration/`, `fleet_api_integration/`, `plugin_functional/`, `functional_with_es_ssl/`, `functional_basic/`, `serverless/`, `api_integration_deployment_agnostic/`, `ui_capabilities/`, etc. |
+| Observability              | `x-pack/solutions/observability/test/functional/`, `**/observability/test/api_integration/`, `api_integration_deployment_agnostic/`                                                                                               |
+| Security                   | `x-pack/solutions/security/test/functional/`, `plugin_functional/`, `security_solution_endpoint/`, etc.                                                                                                                           |
+| Search                     | `x-pack/solutions/search/test/` (e.g. `functional_search/`)                                                                                                                                                                       |
+| Workplace AI               | `x-pack/solutions/workplaceai/test/serverless/` (and similar)                                                                                                                                                                     |
+
+**What makes a file an FTR test (heuristics)**
+
+- It is loaded by the Functional Test Runner: default export is a function of **`FtrProviderContext`** with **`getService`**, **`getPageObjects`**, **`loadTestFile`**, and tests use mocha **`describe`/`it`** with **`@kbn/expect`** (or re-export), **or** it is referenced from such a file via **`loadTestFile`**.
+- Config files: **`export default async function`** (or default export) receiving **`FtrConfigProviderContext`** with **`readConfigFile`**, defining **`testFiles`**, **`services`**, etc.
+
+**Not FTR**
+
+- Scout: `**/test/scout/**/*.spec.ts` and Playwright configs listed above.
+- Cypress: `**/*.cy.ts` in plugin cypress trees, and Cypress **driver** config trees (e.g. `**/fleet_cypress/**`, `**/security_solution_cypress/**`). Those use Cypress flaky flows, not `ftrConfig:` here.
+- Plain Jest unit tests under `src/**` (no FTR provider).
+
+## Output format (mandatory, follow verbatim)
+
+When Scout and/or FTR paths **do** change, output **only** the following markdown block. Replace `<SCOUT_PLAYWRIGHT_CONFIG_PATH>` and/or `<FTR_CONFIG_TS_PATH>` with resolved repo-relative paths; delete the unused placeholder clause from the `/flaky` line when only one suite type applies.
+
+````markdown
+## Flaky Test Runner
+
+This PR changes Kibana automated tests. Please post the following comment on this pull request to trigger the Flaky Test Runner (Elastic members only). This helps catch timing and order flakes before merge.
+
+Trigger UI: https://ci-stats.kibana.dev/trigger_flaky_test_runner
+
+**Copy-paste for the PR comment (single line):**
+
+```text
+/flaky scoutConfig:<SCOUT_PLAYWRIGHT_CONFIG_PATH>:30 ftrConfig:<FTR_CONFIG_TS_PATH>:30
+```
+
+Use `scoutConfig:…` only when this PR touches Scout paths; use `ftrConfig:…` only when this PR touches FTR paths. If only one applies, the line must contain only that clause, for example `/flaky scoutConfig:src/platform/plugins/shared/dashboard/test/scout/ui/parallel.playwright.config.ts:30` or `/flaky ftrConfig:x-pack/platform/test/functional/apps/maps/group3/config.ts:30`.
+````
+
+**Rules**
+
+- The inner fenced `text` block must contain **exactly one** `/flaky` line (that line may list several `scoutConfig:` / `ftrConfig:` clauses separated by spaces).
+- Always append **`:30`** after **each** path (never omit the count).
+- Do not add extra commentary, severity labels, or alternate wordings outside the template above.

--- a/.macroscope/flaky-test-runner-nudge.md
+++ b/.macroscope/flaky-test-runner-nudge.md
@@ -1,22 +1,21 @@
+---
 title: Flaky Test Runner nudge
 model: claude-opus-4-6
 reasoning: high
 effort: high
 input: full_diff
 exclude:
-
-- 'api_docs/\*\*'
-- 'config/\*\*'
-- 'dev_docs/\*\*'
-- 'docs/\*\*'
-- 'legacy_rfcs/\*\*'
-- 'licenses/\*\*'
-- 'node_modules/\*\*'
-- 'oas_docs/\*\*'
-- 'typings/\*\*'
-- '.buildkite/\*\*'
-  conclusion: neutral
-
+  - 'api_docs/**'
+  - 'config/**'
+  - 'dev_docs/**'
+  - 'docs/**'
+  - 'legacy_rfcs/**'
+  - 'licenses/**'
+  - 'node_modules/**'
+  - 'oas_docs/**'
+  - 'typings/**'
+  - '.buildkite/**'
+conclusion: neutral
 ---
 
 Decide whether this PR needs a Flaky Test Runner nudge. If not, post nothing.

--- a/.macroscope/flaky-test-runner-nudge.md
+++ b/.macroscope/flaky-test-runner-nudge.md
@@ -1,141 +1,59 @@
----
 title: Flaky Test Runner nudge
 model: claude-opus-4-6
 reasoning: high
 effort: high
 input: full_diff
 exclude:
-  - 'api_docs/**'
-  - 'config/**'
-  - 'dev_docs/**'
-  - 'docs/**'
-  - 'legacy_rfcs/**'
-  - 'licenses/**'
-  - 'node_modules/**'
-  - 'oas_docs/**'
-  - 'typings/**'
-  - '.buildkite/**'
-conclusion: neutral
+
+- 'api_docs/\*\*'
+- 'config/\*\*'
+- 'dev_docs/\*\*'
+- 'docs/\*\*'
+- 'legacy_rfcs/\*\*'
+- 'licenses/\*\*'
+- 'node_modules/\*\*'
+- 'oas_docs/\*\*'
+- 'typings/\*\*'
+- '.buildkite/\*\*'
+  conclusion: neutral
+
 ---
 
-Decide whether this PR should nudge the author to run the **Flaky Test Runner**. That takes two steps: (1) paths in scope, (2) changes that could realistically affect flakiness (see **When to nudge**). When a nudge applies, follow **Output format** (verbatim PR markdown plus resolved `/flaky` lines per **Rules**). When it does not apply, leave no comment on the PR.
+Decide whether this PR needs a Flaky Test Runner nudge. If not, post nothing.
 
-## When this applies (paths)
+## Step 1 — Are any in-scope files changed?
 
-Consider changed files under **either**:
+- **Scout:** `**/test/scout*/**` or `**/kbn-scout*/**/test/scout/**`
+- **FTR:** `src/platform/test/**`, `x-pack/platform/test/**`, `x-pack/solutions/*/test/**`
 
-1. **Scout (Playwright):** `**/test/scout*/**` (specs, fixtures, page objects, API services, global setup, etc.), or `**/kbn-scout*/**` only when the change is under that package’s own `**/test/scout/**` tree.
-2. **FTR (Functional Test Runner):** see **FTR locations and patterns** below.
+If nothing matches, stop.
 
-If **nothing** in the diff falls in those trees, **stop** (no comment).
+## Step 2 — Do the changes affect stability?
 
-## When to nudge (substance)
+**Nudge if:** test logic, assertions, selectors, fixtures, page objects, config files, hooks, timeouts, waits, API calls, new/removed/skipped tests.
 
-Path match alone is not enough. **Nudge** only when at least one in-scope change could affect timing, execution, or stability. **Skip** when edits are unlikely to do that.
+**Skip if:** comments only, pure formatting, import reorder, trivial copy changes.
 
-**Usually worth a nudge**
+Evaluate Scout and FTR independently. Only nudge the side(s) that qualify.
 
-- Any change to **Playwright or FTR config** (`playwright.config.ts`, `parallel.playwright.config.ts`, leaf FTR `config*.ts`, `testFiles`, workers, hooks).
-- **Test body or helper logic**: assertions, `expect`, selectors/locators, `data-test-subj`, navigation, clicks/typing, API calls, payloads, retries, `waitFor`, timeouts, `test.step`, conditional flow, loops.
-- **Fixtures / services / page objects** used by tests: setup/teardown, archives, `before`/`after`, shared waits or navigation.
-- **New, removed, skipped, or materially rewritten** tests.
+## Step 3 — Resolve the config path
 
-**Often skip (no nudge)**
+**Scout:** Walk up from the changed file to the nearest `playwright.config.ts` or `parallel.playwright.config.ts`. Use `parallel.playwright.config.ts` if the path contains `parallel_tests/`.
 
-- **Comments only**, or docblocks that do not change behavior.
-- **Pure formatting** or import reorder with no runtime effect.
-- **Trivial copy** in descriptions or titles that does not touch selectors, routes, or assertions (use judgment; renames of user-visible strings tied to `getBy*` may still matter).
+**FTR:** Walk up to the nearest leaf `config*.ts` (skip `*.base.ts` files). If none found, check which config's `testFiles`/`loadTestFile` includes the changed file.
 
-If a PR touches **both** Scout and FTR paths, judge **each runner separately**. Include a `scoutConfig:` nudge only if Scout-side changes qualify; include `ftrConfig:` only if FTR-side changes qualify. If **neither** side qualifies, **stop** (no comment). If **both** qualify, give **two** separate `/flaky` commands (one **Scout** line and one **FTR** line), each in its **own** PR comment (see **GitHub comment format**).
+## Output
 
-## Constants (do not change)
+Post exactly one PR comment:
 
-- **RUN_COUNT** is always **`30`** in the `/flaky` comment.
-- Paths are **repo-root-relative**, **no leading slash**, **no `..`**
-
-## GitHub comment format
-
-Each PR comment body must start with **`/flaky `** followed by **exactly one** clause: `<kind>:<path>:<count>` (for example `/flaky scoutConfig:path/to/playwright.config.ts:30`). The workflow runs **per comment**, so **do not** put Scout and FTR in the same comment. If you need **both** runners, post **two** comments on the PR: first `/flaky` line in one comment, second `/flaky` line in another.
-
-**Why not a generic `type`?** The `/flaky` handler only accepts the **exact** tokens **`scoutConfig`** and **`ftrConfig`**. They select which CI job runs (Scout/Playwright vs FTR). Replace placeholders with those literals, not the word `type`.
-
-- **`scoutConfig`:** path to the **Playwright** config `.ts` file.
-- **`ftrConfig`:** path to the **FTR** leaf config `.ts` file.
-
-**Examples:**
-
-Scout only (one comment):
-
-```
-/flaky scoutConfig:src/platform/plugins/shared/dashboard/test/scout/ui/parallel.playwright.config.ts:30
-```
-
-FTR only (one comment):
-
-```
-/flaky ftrConfig:src/platform/test/functional/apps/visualize/group10/config.ts:30
-```
-
-Both Scout and FTR (two separate comments on the PR):
-
-```
-/flaky scoutConfig:src/platform/plugins/shared/dashboard/test/scout/ui/parallel.playwright.config.ts:30
-```
-
-```
-/flaky ftrConfig:src/platform/test/functional/apps/visualize/group10/config.ts:30
-```
-
-## Scout: resolve `scoutConfig` path
-
-1. Config files live under `**/test/scout/**`, usually `playwright.config.ts` and/or `parallel.playwright.config.ts` (sometimes other `*.playwright.config.ts`).
-2. From each changed file, walk **up**; use the **nearest** ancestor directory that contains such a file.
-3. If **both** `playwright.config.ts` and `parallel.playwright.config.ts` exist in that directory: use **`parallel.playwright.config.ts`** when the changed path includes a `parallel_tests/` segment; otherwise use **`playwright.config.ts`**. If a shared helper can affect both suites, give **two** `/flaky` comments (each with one `scoutConfig:`), one per Playwright config.
-4. If the changed file **is** a Playwright config, that file’s path is the `scoutConfig` path.
-
-## FTR: resolve `ftrConfig` path
-
-1. From each changed FTR test/support file’s directory, walk **up** toward the repo root. At each directory, look for a **leaf** FTR config file: usually `config.ts`, but often `config.group1.ts`, `config.feature_flags.ts`, `cli_config.ts`, or another `config*.ts` under `configs/`. **Skip** base-only files (`config.base.ts`, `*.config.base.ts`, `config.*.base.ts`). Keep walking until you hit a concrete suite config.
-2. If the changed file **is** such a leaf config, use that path.
-3. If no candidate appears on the walk (common under `x-pack/platform/test/serverless/**` and other grouped layouts), use `browse_code` to find which config’s `testFiles` / `loadTestFile` includes the changed file, or cross-check paths that appear in `.buildkite/ftr_*_configs.yml` (see `.buildkite/ftr_configs_manifests.json` for which YAML files list enabled configs).
-4. If multiple leaf configs apply, use **one** `/flaky` PR comment per config (each comment: `/flaky ftrConfig:<that-config.ts>:30`).
-
-## FTR locations and patterns
-
-**Where FTR tests live** (prefixes, repo-relative):
-
-- `src/platform/test/**`
-- `x-pack/platform/test/**`
-- `x-pack/solutions/<solution>/test/**` (`<solution>` examples: `observability`, `security`, `search`, `workplaceai`)
-- `x-pack/platform/test/serverless/**`
-- `x-pack/solutions/<solution>/test/serverless/**`
-
-**Recognize FTR:** mocha suites with **`FtrProviderContext`** (`getService`, `loadTestFile`, …), **`@kbn/expect`**, or leaf **`config*.ts`** for an FTR suite.
-
-**Not FTR:** Scout (`**/test/scout/**`), Cypress (`*.cy.ts` and `*cypress*` driver trees), plain Jest units without FTR.
-
-## Output format (follow verbatim)
-
-When a nudge is warranted per **When to nudge (substance)**, output two parts:
-
-1. **PR markdown (verbatim block below):** fixed wording only. Do **not** put placeholder `/flaky` lines, copy-paste fences, or explanations about kinds, paths, or multiple blocks in this block. Developers get the exact `/flaky` command(s) from automation; this section is just the nudge and the two ways to run.
-
-2. **Resolved commands (Rules):** you still resolve paths per **Scout** / **FTR** / **GitHub comment format** so automation (or follow-up tooling) can post the right `/flaky` line(s).
-
-````markdown
+```markdown
 ## Run the Flaky Test Runner (recommended)
 
 **Recommended before merge**: run the flaky test runner against this PR to catch flakiness early.
 
-**Two ways to run it:**
+Trigger a run with the [Flaky Test Runner UI](https://ci-stats.kibana.dev/trigger_flaky_test_runner) or post a comment in the PR:
 
-1. Open the [Flaky Test Runner UI](https://ci-stats.kibana.dev/trigger_flaky_test_runner)
-2. Use the `/flaky` PR comment(s) prepared automatically for this change (exact `scoutConfig` / `ftrConfig` lines are injected for you; post one comment per runner when both apply).
-````
+/flaky <ftrConfig or scoutConfig here>:<resolved-path>:30
+```
 
-**Rules**
-
-- After the verbatim block, output the **resolved** `/flaky` line(s) automation needs: one line if one runner qualifies, **two** lines (Scout first, then FTR) if both qualify. Each line must be a full `/flaky scoutConfig:…:30` or `/flaky ftrConfig:…:30` with repo-relative paths and **`:30`**. Never use `<KIND>` or `<CONFIG_PATH>` placeholders there.
-- Always append **`:30`** after **each** path (never omit the count).
-- Do not rephrase the heading, recommendation, or two-way instructions inside the verbatim block; do not add severity labels or extra sections there.
-- Never invent a command for a runner that did not qualify.
+Include only the `/flaky` line(s) for the runner(s) that qualify. Replace each `<resolved-path>` with the actual config path from Step 3. Replace "ftrConfig or scoutConfig here" with the actual test runner.

--- a/.macroscope/flaky-test-runner-nudge.md
+++ b/.macroscope/flaky-test-runner-nudge.md
@@ -18,7 +18,7 @@ exclude:
 conclusion: neutral
 ---
 
-Your only job is to decide whether this PR should nudge the author to run the **Flaky Test Runner**, and to output the **exact** PR comment text below. Do not add anything else.
+Decide whether this PR should nudge the author to run the **Flaky Test Runner**. When a nudge applies, output **only** the markdown block in **Output format** below. When it does not apply, output nothing and leave no comment.
 
 ## When this applies
 
@@ -27,13 +27,11 @@ Process **only** changed files that match **either**:
 1. **Scout (Playwright):** paths under `**/test/scout*/**` (specs, fixtures, page objects, API services, global setup, etc.), or under `**/kbn-scout*/**` when the change is under that package’s own `**/test/scout/**` tree.
 2. **FTR (Functional Test Runner):** see **FTR locations and patterns** below.
 
-If **no** changed file matches Scout or FTR test work, output **exactly** this single line (verbatim, nothing else):
-
-`No Scout or FTR test paths changed in this PR. No flaky test runner nudge needed.`
+If **no** changed file matches Scout or FTR test work, **stop**. Do not output any text.
 
 ## Constants (do not change)
 
-- **RUN_COUNT** is always **`30`** in the `/flaky` comment (same order of magnitude as the 20–50 guidance in `docs/extend/scout/best-practices.md`).
+- **RUN_COUNT** is always **`30`** in the `/flaky` comment (same order of magnitude as the 20 to 50 range in `docs/extend/scout/best-practices.md`).
 - Paths are **repo-root-relative**, **no leading slash**, **no `..`** (same as `node scripts/functional_tests --config` and Playwright `--config`).
 
 ## GitHub comment format
@@ -56,29 +54,17 @@ PR comments are parsed as: `/flaky <type>:<path>:<count> [<type>:<path>:<count> 
 
 ## FTR locations and patterns
 
-**Typical folder roots** (FTR tests and configs are almost always under a `test/` tree; many suites use a leaf `config.ts`):
+**Where FTR tests live** (prefixes, repo-relative):
 
-| Area                       | Example paths                                                                                                                                                                                                                     |
-| -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Platform OSS functional    | `src/platform/test/functional/`                                                                                                                                                                                                   |
-| Platform x-pack functional | `x-pack/platform/test/functional/`                                                                                                                                                                                                |
-| Platform API integration   | `x-pack/platform/test/api_integration/`                                                                                                                                                                                           |
-| Other platform suites      | `x-pack/platform/test/alerting_api_integration/`, `fleet_api_integration/`, `plugin_functional/`, `functional_with_es_ssl/`, `functional_basic/`, `serverless/`, `api_integration_deployment_agnostic/`, `ui_capabilities/`, etc. |
-| Observability              | `x-pack/solutions/observability/test/functional/`, `**/observability/test/api_integration/`, `api_integration_deployment_agnostic/`                                                                                               |
-| Security                   | `x-pack/solutions/security/test/functional/`, `plugin_functional/`, `security_solution_endpoint/`, etc.                                                                                                                           |
-| Search                     | `x-pack/solutions/search/test/` (e.g. `functional_search/`)                                                                                                                                                                       |
-| Workplace AI               | `x-pack/solutions/workplaceai/test/serverless/` (and similar)                                                                                                                                                                     |
+- `src/platform/test/**`
+- `x-pack/platform/test/**`
+- `x-pack/solutions/<solution>/test/**` (`<solution>` examples: `observability`, `security`, `search`, `workplaceai`)
+- `x-pack/platform/test/serverless/**`
+- `x-pack/solutions/<solution>/test/serverless/**`
 
-**What makes a file an FTR test (heuristics)**
+**Recognize FTR:** mocha suites with **`FtrProviderContext`** (`getService`, `loadTestFile`, …), **`@kbn/expect`**, or leaf **`config*.ts`** used by `node scripts/functional_tests --config`.
 
-- It is loaded by the Functional Test Runner: default export is a function of **`FtrProviderContext`** with **`getService`**, **`getPageObjects`**, **`loadTestFile`**, and tests use mocha **`describe`/`it`** with **`@kbn/expect`** (or re-export), **or** it is referenced from such a file via **`loadTestFile`**.
-- Config files: **`export default async function`** (or default export) receiving **`FtrConfigProviderContext`** with **`readConfigFile`**, defining **`testFiles`**, **`services`**, etc.
-
-**Not FTR**
-
-- Scout: `**/test/scout/**/*.spec.ts` and Playwright configs listed above.
-- Cypress: `**/*.cy.ts` in plugin cypress trees, and Cypress **driver** config trees (e.g. `**/fleet_cypress/**`, `**/security_solution_cypress/**`). Those use Cypress flaky flows, not `ftrConfig:` here.
-- Plain Jest unit tests under `src/**` (no FTR provider).
+**Not FTR:** Scout (`**/test/scout/**`), Cypress (`*.cy.ts` and `*cypress*` driver trees), plain Jest units without FTR.
 
 ## Output format (mandatory, follow verbatim)
 

--- a/.macroscope/flaky-test-runner-nudge.md
+++ b/.macroscope/flaky-test-runner-nudge.md
@@ -2,7 +2,7 @@
 title: Flaky Test Runner nudge
 model: claude-opus-4-6
 reasoning: high
-effort: medium
+effort: high
 input: full_diff
 exclude:
   - 'api_docs/**'
@@ -118,7 +118,7 @@ Both Scout and FTR (two separate comments on the PR):
 
 When a nudge is warranted per **When to nudge (substance)**, output **only** the following markdown block (wording is fixed; you resolve paths). Include **`scoutConfig`** lines only for qualifying Scout changes; **`ftrConfig`** lines only for qualifying FTR changes. Replace `<KIND>` / `<CONFIG_PATH>` with literals and real paths (see **GitHub comment format**).
 
-If **one** runner qualifies, use **one** ```text``` block with a **single** `/flaky` line. If **both** qualify, use **two** ```text``` blocks in a row (Scout first, then FTR), each block containing **one** `/flaky` line. The author must post each block as a **separate** PR comment.
+If **one** runner qualifies, use **one** `text` block with a **single** `/flaky` line. If **both** qualify, use **two** `text` blocks in a row (Scout first, then FTR), each block containing **one** `/flaky` line. The author must post each block as a **separate** PR comment.
 
 ````markdown
 ## Run the Flaky Test Runner (recommended)
@@ -134,13 +134,13 @@ If **one** runner qualifies, use **one** ```text``` block with a **single** `/fl
 /flaky <KIND>:<CONFIG_PATH>:30
 ```
 
-`<KIND>` must be the literal token `scoutConfig` or `ftrConfig`. `<CONFIG_PATH>` is the repo-relative config for that runner. If both runners qualify, add a **second** ```text``` block with the other kind (two comments total).
+`<KIND>` must be the literal token `scoutConfig` or `ftrConfig`. `<CONFIG_PATH>` is the repo-relative config for that runner. If both runners qualify, add a **second** `text` block with the other kind (two comments total).
 ````
 
 **Rules**
 
-- Each ```text``` fence must contain **exactly one** `/flaky` line (one `scoutConfig:` **or** one `ftrConfig:` clause, never both in the same fence).
-- If both runners qualify, output **two** ```text``` blocks (two separate paste targets for two PR comments).
+- Each `text` fence must contain **exactly one** `/flaky` line (one `scoutConfig:` **or** one `ftrConfig:` clause, never both in the same fence).
+- If both runners qualify, output **two** `text` blocks (two separate paste targets for two PR comments).
 - Always append **`:30`** after **each** path (never omit the count).
 - Do not rephrase the heading, recommendation, or two-way instructions; do not add severity labels or extra sections.
 - The `/flaky` lines you show must be **fully resolved** (no literal `<KIND>` or `<CONFIG_PATH>` left in what you publish).

--- a/.macroscope/flaky-test-runner-nudge.md
+++ b/.macroscope/flaky-test-runner-nudge.md
@@ -23,8 +23,8 @@ Decide whether this PR needs a Flaky Test Runner nudge. If not, post nothing.
 ## Step 1: Are any in-scope files changed?
 
 - **Scout**
-  - **`**/test/scout*/**`:** specs, fixtures, and plugin-local Scout test code (each tree usually has a Playwright config next to it).
-  - **`**/kbn-scout*/**`:** shared Scout packages (for example `@kbn/scout`, `@kbn/scout-oblt`, `@kbn/scout-search`, `@kbn/scout-security`): page objects, framework code, and helpers that tests import. This layout is **not** covered by `**/test/scout*/**` alone; changes here can still affect many suites even when there is no `playwright.config.ts` beside the file.
+  - **`**/test/scout\*/**`:** specs, fixtures, and plugin-local Scout test code (each tree usually has a Playwright config next to it).
+  - **`**/kbn-scout*/**`:** shared Scout packages (for example `@kbn/scout`, `@kbn/scout-oblt`, `@kbn/scout-search`, `@kbn/scout-security`): page objects, framework code, and helpers that tests import. This layout is **not** covered by `\*\*/test/scout*/\*\*`alone; changes here can still affect many suites even when there is no`playwright.config.ts` beside the file.
 - **FTR:** `src/platform/test/**`, `x-pack/platform/test/**`, `x-pack/solutions/*/test/**`
 
 If nothing matches, stop.
@@ -49,11 +49,17 @@ Sample FTR config path: `x-pack/platform/test/serverless/functional/configs/sear
 
    Sample: `x-pack/platform/plugins/shared/streams_app/test/scout/ui/playwright.config.ts`
 
-2. **Change is under `**/kbn-scout*/**` (or other shared Scout package code) with no Playwright config in an ancestor directory:** Do **not** invent a `scoutConfig` path from the file location. Treat this as **no resolved config next to the change**. In the PR comment, use the **Output: shared Scout package** template below. Tell the author to either use the Flaky Test Runner UI to pick a suite that exercises the change, or to find a plugin `test/scout/**/playwright.config.ts` (or `parallel.playwright.config.ts`) whose tests import or cover this code, then post `/flaky scoutConfig:<that-config>:30` for that file. Use `browse_code` or import search if needed to suggest a plausible config.
+2. **Change is under `**/kbn-scout*/**` (or other shared Scout package code) with no Playwright config in an ancestor directory:** Do **not** guess a path from the package file path alone. **First, derive a config from the changed code:**
+   - Search the repo for **imports of the changed module(s)** (the file you edited, its barrel `index.ts`, or the package subpath that changed). Prioritize hits under `**/test/scout*/**` (specs, fixtures, page objects in plugin trees that re-export or wrap the package).
+   - From each relevant hit, **walk up** to the nearest `playwright.config.ts` or `parallel.playwright.config.ts` (same rules as case 1). That is the `scoutConfig` for suites that actually exercise this change.
+   - If **one** clear config covers the change, use **Output B** with that path. If **several** configs are justified (widely shared symbol), pick the **most representative** config from the search, or emit **B** for the narrowest scope first; mention in a short line that other suites may also import this code if needed.
+   - Use **`browse_code`** and **`grep`** freely to follow imports and fixture wiring.
+
+   **Only if** no `playwright.config.ts` can be tied to the change after that search, use **Output C** (author picks a suite in the UI or manually).
 
 ## Output
 
-Pick **A**, **B**, or **C** depending on Step 3. Use **C** when shared Scout package files change and no `playwright.config.ts` exists in an ancestor path (Step 3 case 2).
+Pick **A**, **B**, or **C** depending on Step 3. Prefer **B** for Scout whenever you can resolve a Playwright config (including case 2 after import tracing). Use **C** only when shared package code changes and **no** config can be linked to the change after searching imports from that code into `**/test/scout*/**`.
 
 **A. FTR only (resolved `ftrConfig`)**
 
@@ -83,19 +89,19 @@ Trigger a run with the [Flaky Test Runner UI](https://ci-stats.kibana.dev/trigge
 ```
 ````
 
-**C. Scout shared package (no Playwright config beside the changed files)**
+**C. Scout shared package (import tracing did not resolve a config)**
 
-Use when Step 3 case **2** applies. Do not paste a fake `scoutConfig` path.
+Use only when Step 3 case **2** still has **no** Playwright config after searching imports from the changed code into `**/test/scout*/**`. Do not paste a guessed `scoutConfig` path.
 
 ````markdown
 ## Catch flakiness early (recommended)
 
 **Recommended before merge**: run the flaky test runner for suites that **cover this change**.
 
-This PR touches **shared Scout package** code (for example under `kbn-scout*`). There is no single Playwright config next to those files, so pick the right run yourself:
+This PR touches **shared Scout package** code (for example under `kbn-scout*`). No Playwright config could be tied to this diff by following imports from the changed files into plugin `test/scout/` trees, so pick the right run yourself:
 
 1. Use the [Flaky Test Runner UI](https://ci-stats.kibana.dev/trigger_flaky_test_runner) and select a suite whose tests exercise the code you changed, **or**
-2. Find a plugin `test/scout/**/playwright.config.ts` or `parallel.playwright.config.ts` for a suite that imports or uses this package, then post a PR comment:
+2. Manually find a plugin `test/scout/**/playwright.config.ts` or `parallel.playwright.config.ts` for a suite that uses this package, then post:
 
 ```
 /flaky scoutConfig:<path-to-that-playwright-config>:30

--- a/.macroscope/flaky-test-runner-nudge.md
+++ b/.macroscope/flaky-test-runner-nudge.md
@@ -18,31 +18,79 @@ exclude:
 conclusion: neutral
 ---
 
-Decide whether this PR should nudge the author to run the **Flaky Test Runner**. When a nudge applies, output **only** the markdown block in **Output format** below. When it does not apply, output nothing and leave no comment.
+Decide whether this PR should nudge the author to run the **Flaky Test Runner**. That takes two steps: (1) paths in scope, (2) changes that could realistically affect flakiness (see **When to nudge**). When a nudge applies, output **only** the markdown block in **Output format** below. When it does not apply, leave no comment on the PR.
 
-## When this applies
+## When this applies (paths)
 
-Process **only** changed files that match **either**:
+Consider changed files under **either**:
 
-1. **Scout (Playwright):** paths under `**/test/scout*/**` (specs, fixtures, page objects, API services, global setup, etc.), or under `**/kbn-scout*/**` when the change is under that package’s own `**/test/scout/**` tree.
+1. **Scout (Playwright):** `**/test/scout*/**` (specs, fixtures, page objects, API services, global setup, etc.), or `**/kbn-scout*/**` only when the change is under that package’s own `**/test/scout/**` tree.
 2. **FTR (Functional Test Runner):** see **FTR locations and patterns** below.
 
-If **no** changed file matches Scout or FTR test work, **stop**. Do not output any text.
+If **nothing** in the diff falls in those trees, **stop** (no comment).
+
+## When to nudge (substance)
+
+Path match alone is not enough. **Nudge** only when at least one in-scope change could affect timing, execution, or stability. **Skip** when edits are unlikely to do that.
+
+**Usually worth a nudge**
+
+- Any change to **Playwright or FTR config** (`playwright.config.ts`, `parallel.playwright.config.ts`, leaf FTR `config*.ts`, `testFiles`, workers, hooks).
+- **Test body or helper logic**: assertions, `expect`, selectors/locators, `data-test-subj`, navigation, clicks/typing, API calls, payloads, retries, `waitFor`, timeouts, `test.step`, conditional flow, loops.
+- **Fixtures / services / page objects** used by tests: setup/teardown, archives, `before`/`after`, shared waits or navigation.
+- **New, removed, skipped, or materially rewritten** tests.
+
+**Often skip (no nudge)**
+
+- **Comments only**, or docblocks that do not change behavior.
+- **Pure formatting** or import reorder with no runtime effect.
+- **Trivial copy** in descriptions or titles that does not touch selectors, routes, or assertions (use judgment; renames of user-visible strings tied to `getBy*` may still matter).
+
+If a PR touches **both** Scout and FTR paths, judge **each runner separately**. Include a `scoutConfig:` nudge only if Scout-side changes qualify; include `ftrConfig:` only if FTR-side changes qualify. If **neither** side qualifies, **stop** (no comment). If **both** qualify, give **two** separate `/flaky` commands (one **Scout** line and one **FTR** line), each in its **own** PR comment (see **GitHub comment format**).
 
 ## Constants (do not change)
 
-- **RUN_COUNT** is always **`30`** in the `/flaky` comment (same order of magnitude as the 20 to 50 range in `docs/extend/scout/best-practices.md`).
-- Paths are **repo-root-relative**, **no leading slash**, **no `..`** (same as `node scripts/functional_tests --config` and Playwright `--config`).
+- **RUN_COUNT** is always **`30`** in the `/flaky` comment.
+- Paths are **repo-root-relative**, **no leading slash**, **no `..`**
 
 ## GitHub comment format
 
-PR comments are parsed as: `/flaky <type>:<path>:<count> [<type>:<path>:<count> ...]` where `<type>` is `scoutConfig` or `ftrConfig` (see `.github/workflows/trigger-flaky.yml`). The `<path>` for **`ftrConfig`** is the **full path to the FTR config file** passed to `node scripts/functional_tests --config` (Buildkite sets `FTR_CONFIG` to this string). The `<path>` for **`scoutConfig`** is the **Playwright config** `.ts` file.
+Each PR comment body must start with **`/flaky `** followed by **exactly one** clause: `<kind>:<path>:<count>` (for example `/flaky scoutConfig:path/to/playwright.config.ts:30`). The workflow runs **per comment**, so **do not** put Scout and FTR in the same comment. If you need **both** runners, post **two** comments on the PR: first `/flaky` line in one comment, second `/flaky` line in another.
+
+**Why not a generic `type`?** The GitHub workflow (`.github/workflows/trigger-flaky.yml`) only recognizes the **exact** tokens **`scoutConfig`** and **`ftrConfig`**. They select which CI job runs (Scout/Playwright vs FTR). Replace placeholders with those literals, not the word `type`.
+
+- **`scoutConfig`:** path to the **Playwright** config `.ts` file.
+- **`ftrConfig`:** path to the **FTR** leaf config `.ts` file passed to `node scripts/functional_tests --config`.
+
+**Examples:**
+
+Scout only (one comment):
+
+```
+/flaky scoutConfig:src/platform/plugins/shared/dashboard/test/scout/ui/parallel.playwright.config.ts:30
+```
+
+FTR only (one comment):
+
+```
+/flaky ftrConfig:src/platform/test/functional/apps/visualize/group10/config.ts:30
+```
+
+Both Scout and FTR (two separate comments on the PR):
+
+```
+/flaky scoutConfig:src/platform/plugins/shared/dashboard/test/scout/ui/parallel.playwright.config.ts:30
+```
+
+```
+/flaky ftrConfig:src/platform/test/functional/apps/visualize/group10/config.ts:30
+```
 
 ## Scout: resolve `scoutConfig` path
 
 1. Config files live under `**/test/scout/**`, usually `playwright.config.ts` and/or `parallel.playwright.config.ts` (sometimes other `*.playwright.config.ts`).
 2. From each changed file, walk **up**; use the **nearest** ancestor directory that contains such a file.
-3. If **both** `playwright.config.ts` and `parallel.playwright.config.ts` exist in that directory: use **`parallel.playwright.config.ts`** when the changed path includes a `parallel_tests/` segment; otherwise use **`playwright.config.ts`**. If a shared helper can affect both suites, include **two** `scoutConfig:` entries in the same `/flaky` line.
+3. If **both** `playwright.config.ts` and `parallel.playwright.config.ts` exist in that directory: use **`parallel.playwright.config.ts`** when the changed path includes a `parallel_tests/` segment; otherwise use **`playwright.config.ts`**. If a shared helper can affect both suites, give **two** `/flaky` comments (each with one `scoutConfig:`), one per Playwright config.
 4. If the changed file **is** a Playwright config, that file’s path is the `scoutConfig` path.
 
 ## FTR: resolve `ftrConfig` path
@@ -50,7 +98,7 @@ PR comments are parsed as: `/flaky <type>:<path>:<count> [<type>:<path>:<count> 
 1. From each changed FTR test/support file’s directory, walk **up** toward the repo root. At each directory, look for a **leaf** FTR config file: usually `config.ts`, but often `config.group1.ts`, `config.feature_flags.ts`, `cli_config.ts`, or another `config*.ts` under `configs/`. **Skip** base-only files (`config.base.ts`, `*.config.base.ts`, `config.*.base.ts`). Keep walking until you hit a concrete suite config.
 2. If the changed file **is** such a leaf config, use that path.
 3. If no candidate appears on the walk (common under `x-pack/platform/test/serverless/**` and other grouped layouts), use `browse_code` to find which config’s `testFiles` / `loadTestFile` includes the changed file, or cross-check paths that appear in `.buildkite/ftr_*_configs.yml` (see `.buildkite/ftr_configs_manifests.json` for which YAML files list enabled configs).
-4. If multiple leaf configs apply, include multiple `ftrConfig:` clauses on the **same** `/flaky` line, space-separated.
+4. If multiple leaf configs apply, use **one** `/flaky` PR comment per config (each comment: `/flaky ftrConfig:<that-config.ts>:30`).
 
 ## FTR locations and patterns
 
@@ -66,28 +114,34 @@ PR comments are parsed as: `/flaky <type>:<path>:<count> [<type>:<path>:<count> 
 
 **Not FTR:** Scout (`**/test/scout/**`), Cypress (`*.cy.ts` and `*cypress*` driver trees), plain Jest units without FTR.
 
-## Output format (mandatory, follow verbatim)
+## Output format (follow verbatim)
 
-When Scout and/or FTR paths **do** change, output **only** the following markdown block. Replace `<SCOUT_PLAYWRIGHT_CONFIG_PATH>` and/or `<FTR_CONFIG_TS_PATH>` with resolved repo-relative paths; delete the unused placeholder clause from the `/flaky` line when only one suite type applies.
+When a nudge is warranted per **When to nudge (substance)**, output **only** the following markdown block (wording is fixed; you resolve paths). Include **`scoutConfig`** lines only for qualifying Scout changes; **`ftrConfig`** lines only for qualifying FTR changes. Replace `<KIND>` / `<CONFIG_PATH>` with literals and real paths (see **GitHub comment format**).
+
+If **one** runner qualifies, use **one** ```text``` block with a **single** `/flaky` line. If **both** qualify, use **two** ```text``` blocks in a row (Scout first, then FTR), each block containing **one** `/flaky` line. The author must post each block as a **separate** PR comment.
 
 ````markdown
-## Flaky Test Runner
+## Run the Flaky Test Runner (recommended)
 
-This PR changes Kibana automated tests. Please post the following comment on this pull request to trigger the Flaky Test Runner (Elastic members only). This helps catch timing and order flakes before merge.
+**Recommended before merge**: run the flaky test runner against this PR to catch flakiness early.
 
-Trigger UI: https://ci-stats.kibana.dev/trigger_flaky_test_runner
+**Two ways to run it:**
 
-**Copy-paste for the PR comment (single line):**
+1. Open the [Flaky Test Runner UI](https://ci-stats.kibana.dev/trigger_flaky_test_runner) or
+2. Post each `/flaky` line below as its **own** comment on this PR (one trigger per comment):
 
 ```text
-/flaky scoutConfig:<SCOUT_PLAYWRIGHT_CONFIG_PATH>:30 ftrConfig:<FTR_CONFIG_TS_PATH>:30
+/flaky <KIND>:<CONFIG_PATH>:30
 ```
 
-Use `scoutConfig:…` only when this PR touches Scout paths; use `ftrConfig:…` only when this PR touches FTR paths. If only one applies, the line must contain only that clause, for example `/flaky scoutConfig:src/platform/plugins/shared/dashboard/test/scout/ui/parallel.playwright.config.ts:30` or `/flaky ftrConfig:x-pack/platform/test/functional/apps/maps/group3/config.ts:30`.
+`<KIND>` must be the literal token `scoutConfig` or `ftrConfig`. `<CONFIG_PATH>` is the repo-relative config for that runner. If both runners qualify, add a **second** ```text``` block with the other kind (two comments total).
 ````
 
 **Rules**
 
-- The inner fenced `text` block must contain **exactly one** `/flaky` line (that line may list several `scoutConfig:` / `ftrConfig:` clauses separated by spaces).
+- Each ```text``` fence must contain **exactly one** `/flaky` line (one `scoutConfig:` **or** one `ftrConfig:` clause, never both in the same fence).
+- If both runners qualify, output **two** ```text``` blocks (two separate paste targets for two PR comments).
 - Always append **`:30`** after **each** path (never omit the count).
-- Do not add extra commentary, severity labels, or alternate wordings outside the template above.
+- Do not rephrase the heading, recommendation, or two-way instructions; do not add severity labels or extra sections.
+- The `/flaky` lines you show must be **fully resolved** (no literal `<KIND>` or `<CONFIG_PATH>` left in what you publish).
+- Never invent a second command for a runner that did not qualify.

--- a/.macroscope/flaky-test-runner-nudge.md
+++ b/.macroscope/flaky-test-runner-nudge.md
@@ -20,14 +20,16 @@ conclusion: neutral
 
 Decide whether this PR needs a Flaky Test Runner nudge. If not, post nothing.
 
-## Step 1 — Are any in-scope files changed?
+## Step 1: Are any in-scope files changed?
 
-- **Scout:** `**/test/scout*/**` or `**/kbn-scout*/**/test/scout/**`
+- **Scout**
+  - **`**/test/scout*/**`:** specs, fixtures, and plugin-local Scout test code (each tree usually has a Playwright config next to it).
+  - **`**/kbn-scout*/**`:** shared Scout packages (for example `@kbn/scout`, `@kbn/scout-oblt`, `@kbn/scout-search`, `@kbn/scout-security`): page objects, framework code, and helpers that tests import. This layout is **not** covered by `**/test/scout*/**` alone; changes here can still affect many suites even when there is no `playwright.config.ts` beside the file.
 - **FTR:** `src/platform/test/**`, `x-pack/platform/test/**`, `x-pack/solutions/*/test/**`
 
 If nothing matches, stop.
 
-## Step 2 — Do the changes affect stability?
+## Step 2: Do the changes affect stability?
 
 **Nudge if:** test logic, assertions, selectors, fixtures, page objects, config files, hooks, timeouts, waits, API calls, new/removed/skipped tests.
 
@@ -35,41 +37,82 @@ If nothing matches, stop.
 
 Evaluate Scout and FTR independently. Only nudge the side(s) that qualify.
 
-## Step 3 — Resolve the config path
+## Step 3: Resolve the config path
 
-**Scout:** Walk up from the changed file to the nearest `playwright.config.ts` or `parallel.playwright.config.ts`. Use `parallel.playwright.config.ts` if the path contains `parallel_tests/`.
-
-Sample Scout config path: `x-pack/platform/plugins/shared/streams_app/test/scout/ui/playwright.config.ts`
-
-**FTR:** Walk up to the nearest leaf `config*.ts` (skip `*.base.ts` files). If none found, check which config's `testFiles`/`loadTestFile` includes the changed file.
+**FTR:** Walk up from the changed file to the nearest leaf `config*.ts` (skip `*.base.ts` files). If none is found, use `browse_code` to find which config’s `testFiles` / `loadTestFile` includes the changed file.
 
 Sample FTR config path: `x-pack/platform/test/serverless/functional/configs/search/config.group7.ts`
 
+**Scout (two cases)**
+
+1. **Change is under `**/test/scout*/**`:** Walk up to the nearest `playwright.config.ts` or `parallel.playwright.config.ts`. Prefer `parallel.playwright.config.ts` when the changed path contains `parallel_tests/`. You can emit `/flaky scoutConfig:<that-path>:30`.
+
+   Sample: `x-pack/platform/plugins/shared/streams_app/test/scout/ui/playwright.config.ts`
+
+2. **Change is under `**/kbn-scout*/**` (or other shared Scout package code) with no Playwright config in an ancestor directory:** Do **not** invent a `scoutConfig` path from the file location. Treat this as **no resolved config next to the change**. In the PR comment, use the **Output: shared Scout package** template below. Tell the author to either use the Flaky Test Runner UI to pick a suite that exercises the change, or to find a plugin `test/scout/**/playwright.config.ts` (or `parallel.playwright.config.ts`) whose tests import or cover this code, then post `/flaky scoutConfig:<that-config>:30` for that file. Use `browse_code` or import search if needed to suggest a plausible config.
+
 ## Output
 
-Post exactly one PR comment:
+Pick **A**, **B**, or **C** depending on Step 3. Use **C** when shared Scout package files change and no `playwright.config.ts` exists in an ancestor path (Step 3 case 2).
+
+**A. FTR only (resolved `ftrConfig`)**
 
 ````markdown
 ## Catch flakiness early (recommended)
 
 **Recommended before merge**: run the flaky test runner against this PR to catch flakiness early.
 
-Trigger a run with the [Flaky Test Runner UI](https://ci-stats.kibana.dev/trigger_flaky_test_runner) or post a comment in the PR:
+Trigger a run with the [Flaky Test Runner UI](https://ci-stats.kibana.dev/trigger_flaky_test_runner) or post this comment on the PR:
 
 ```
-/flaky <ftrConfig or scoutConfig here>:<resolved-path>:30
+/flaky ftrConfig:<resolved-ftr-config-path>:30
 ```
 ````
 
-Include only the `/flaky` line(s) for the runner(s) that qualify. Replace each `<resolved-path>` with the actual config path from Step 3. Replace "ftrConfig or scoutConfig here" with the actual test runner.
+**B. Scout with a resolved Playwright config**
 
-Sample Scout command:
+````markdown
+## Catch flakiness early (recommended)
+
+**Recommended before merge**: run the flaky test runner against this PR to catch flakiness early.
+
+Trigger a run with the [Flaky Test Runner UI](https://ci-stats.kibana.dev/trigger_flaky_test_runner) or post this comment on the PR:
+
+```
+/flaky scoutConfig:<resolved-playwright-config-path>:30
+```
+````
+
+**C. Scout shared package (no Playwright config beside the changed files)**
+
+Use when Step 3 case **2** applies. Do not paste a fake `scoutConfig` path.
+
+````markdown
+## Catch flakiness early (recommended)
+
+**Recommended before merge**: run the flaky test runner for suites that **cover this change**.
+
+This PR touches **shared Scout package** code (for example under `kbn-scout*`). There is no single Playwright config next to those files, so pick the right run yourself:
+
+1. Use the [Flaky Test Runner UI](https://ci-stats.kibana.dev/trigger_flaky_test_runner) and select a suite whose tests exercise the code you changed, **or**
+2. Find a plugin `test/scout/**/playwright.config.ts` or `parallel.playwright.config.ts` for a suite that imports or uses this package, then post a PR comment:
+
+```
+/flaky scoutConfig:<path-to-that-playwright-config>:30
+```
+````
+
+**Both Scout and FTR:** Post **two** comments (one FTR from **A**, one Scout from **B** or **C** as appropriate).
+
+**Samples (for A and B only)**
+
+Scout:
 
 ```
 /flaky scoutConfig:x-pack/platform/plugins/shared/streams_app/test/scout/ui/playwright.config.ts:30
 ```
 
-Sample FTR command:
+FTR:
 
 ```
 /flaky ftrConfig:x-pack/platform/test/serverless/functional/configs/search/config.group7.ts:30

--- a/.macroscope/scout-review.md
+++ b/.macroscope/scout-review.md
@@ -30,7 +30,7 @@ Only review files that are:
 
 Skip all other changed files entirely.
 
-If no matching files were changed in this PR, report "No Scout files in this PR — nothing to review" and conclude with no comments.
+If no matching files were changed in this PR, report "No Scout files in this PR. Nothing to review." and conclude with no comments.
 
 ## Best practices reference
 
@@ -40,6 +40,7 @@ Read `docs/extend/scout/best-practices.md` with `browse_code` and enforce all ru
 
 - Before creating new helpers, use `browse_code` to check what's already available in `@kbn/scout`, solution Scout packages (`@kbn/scout-oblt`, `@kbn/scout-search`, `@kbn/scout-security`), and plugin-local `test/scout/` directories.
 - When adding helpers, place them in the correct scope: plugin-local `test/scout/` for plugin-specific, solution Scout package for cross-plugin within a solution, `@kbn/scout` for cross-solution.
+- Flaky Test Runner nudges for PRs: `.macroscope/flaky-test-runner-nudge.md` (Scout and FTR).
 
 ## Output Format
 

--- a/.macroscope/scout-review.md
+++ b/.macroscope/scout-review.md
@@ -5,19 +5,19 @@ reasoning: high
 effort: high
 input: full_diff
 exclude:
-  - "api_docs/**"
-  - "config/**"
-  - "dev_docs/**"
-  - "docs/**"
-  - "legacy_rfcs/**"
-  - "licenses/**"
-  - "node_modules/**"
-  - "oas_docs/**"
-  - "packages/**"
-  - "plugins/**"
-  - "scripts/**"
-  - "typings/**"
-  - ".buildkite/**"
+  - 'api_docs/**'
+  - 'config/**'
+  - 'dev_docs/**'
+  - 'docs/**'
+  - 'legacy_rfcs/**'
+  - 'licenses/**'
+  - 'node_modules/**'
+  - 'oas_docs/**'
+  - 'packages/**'
+  - 'plugins/**'
+  - 'scripts/**'
+  - 'typings/**'
+  - '.buildkite/**'
 conclusion: neutral
 ---
 
@@ -30,7 +30,7 @@ Only review files that are:
 
 Skip all other changed files entirely.
 
-If no matching files were changed in this PR, report "No Scout files in this PR. Nothing to review." and conclude with no comments.
+If no matching files were changed in this PR, report "No Scout files in this PR — nothing to review" and conclude with no comments.
 
 ## Best practices reference
 


### PR DESCRIPTION
The first step to combat flakiness is to spot it early with several test runs. This PR adds a new Macroscope [check run agent](https://docs.macroscope.com/check-run-agents) to nudge developers to run the flaky test runner when appropriate. The agent will format the message to include a ready-to-post flaky test run command developers can post on their PR.

Sample message:

---

## Catch flakiness early (recommended)

**Recommended before merge**: run the flaky test runner against this PR to catch flakiness early.

Trigger a run with the [Flaky Test Runner UI](https://ci-stats.kibana.dev/trigger_flaky_test_runner) or post a comment in the PR:

```
/flaky scoutConfig:x-pack/platform/plugins/shared/streams_app/test/scout/ui/playwright.config.ts:30
```

---