### PR TITLE
[9.3] a11y: fix `@elastic/eui/require-aria-label-for-modals` violations across 18 security/spaces files (#260696)

### DIFF
--- a/packages/kbn-mock-idp-plugin/moon.yml
+++ b/packages/kbn-mock-idp-plugin/moon.yml
@@ -33,6 +33,7 @@ dependsOn:
   - '@kbn/cloud-plugin'
   - '@kbn/es'
   - '@kbn/core-user-profile-browser'
+  - '@kbn/i18n'
 tags:
   - plugin
   - dev

--- a/packages/kbn-mock-idp-plugin/public/role_switcher.tsx
+++ b/packages/kbn-mock-idp-plugin/public/role_switcher.tsx
@@ -12,6 +12,7 @@ import React, { useEffect, useState } from 'react';
 import useAsyncFn from 'react-use/lib/useAsyncFn';
 
 import type { CoreStart } from '@kbn/core-lifecycle-browser';
+import { i18n } from '@kbn/i18n';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { MOCK_IDP_REALM_NAME, MOCK_IDP_REALM_TYPE } from '@kbn/mock-idp-utils/src/constants';
 import type { AuthenticatedUser } from '@kbn/security-plugin-types-common';
@@ -109,6 +110,9 @@ export const RoleSwitcher = () => {
       repositionToCrossAxis={false}
       isOpen={isOpen}
       closePopover={() => setIsOpen(false)}
+      aria-label={i18n.translate('kbnMockIdpPlugin.roleSwitcher.popoverAriaLabel', {
+        defaultMessage: 'Switch role',
+      })}
     >
       <EuiContextMenu
         initialPanelId={0}

--- a/packages/kbn-mock-idp-plugin/tsconfig.json
+++ b/packages/kbn-mock-idp-plugin/tsconfig.json
@@ -27,5 +27,6 @@
     "@kbn/cloud-plugin",
     "@kbn/es",
     "@kbn/core-user-profile-browser",
+    "@kbn/i18n",
   ]
 }

--- a/src/platform/plugins/private/interactive_setup/public/cluster_configuration_form.tsx
+++ b/src/platform/plugins/private/interactive_setup/public/cluster_configuration_form.tsx
@@ -510,6 +510,9 @@ export const ForgotPasswordPopover: FunctionComponent<ForgotPasswordPopoverProps
       anchorPosition="rightCenter"
       isOpen={isPopoverOpen}
       closePopover={() => setIsPopoverOpen(false)}
+      aria-label={i18n.translate('interactiveSetup.forgotPasswordPopover.ariaLabel', {
+        defaultMessage: 'Forgot password',
+      })}
     >
       <EuiText size="s" grow={false}>
         <p>

--- a/src/platform/plugins/private/interactive_setup/public/enrollment_token_form.tsx
+++ b/src/platform/plugins/private/interactive_setup/public/enrollment_token_form.tsx
@@ -245,6 +245,9 @@ export const EnrollmentTokenHelpPopover = () => {
       anchorPosition="rightCenter"
       isOpen={isPopoverOpen}
       closePopover={() => setIsPopoverOpen(false)}
+      aria-label={i18n.translate('interactiveSetup.enrollmentTokenHelpPopover.ariaLabel', {
+        defaultMessage: 'Enrollment token help',
+      })}
     >
       <EuiText size="s" grow={false}>
         <p>

--- a/src/platform/plugins/private/interactive_setup/public/use_verification.tsx
+++ b/src/platform/plugins/private/interactive_setup/public/use_verification.tsx
@@ -12,6 +12,7 @@ import constate from 'constate';
 import type { FC, PropsWithChildren } from 'react';
 import React, { useEffect, useRef, useState } from 'react';
 
+import { i18n } from '@kbn/i18n';
 import { euiThemeVars } from '@kbn/ui-theme';
 
 import { useKibana } from './use_kibana';
@@ -57,7 +58,13 @@ const InnerVerificationProvider: FC<PropsWithChildren<unknown>> = ({ children })
   return (
     <>
       {status === 'unverified' && (
-        <EuiModal onClose={() => setStatus('unknown')} maxWidth={euiThemeVars.euiBreakpoints.s}>
+        <EuiModal
+          aria-label={i18n.translate('interactiveSetup.verificationModal.ariaLabel', {
+            defaultMessage: 'Verification required',
+          })}
+          onClose={() => setStatus('unknown')}
+          maxWidth={euiThemeVars.euiBreakpoints.s}
+        >
           <EuiModalHeader>
             <VerificationCodeForm
               onSuccess={(values) => {

--- a/x-pack/platform/packages/private/security/ui_components/src/kibana_privilege_table/change_all_privileges.tsx
+++ b/x-pack/platform/packages/private/security/ui_components/src/kibana_privilege_table/change_all_privileges.tsx
@@ -133,6 +133,12 @@ export class ChangeAllPrivilegesControl extends Component<Props, State> {
         closePopover={this.closePopover}
         panelPaddingSize="none"
         anchorPosition="downLeft"
+        aria-label={i18n.translate(
+          'xpack.security.management.editRole.changeAllPrivileges.popoverAriaLabel',
+          {
+            defaultMessage: 'Bulk actions',
+          }
+        )}
       >
         <EuiContextMenuPanel items={items} />
       </EuiPopover>

--- a/x-pack/platform/packages/shared/security/api_key_management/src/components/token_field.tsx
+++ b/x-pack/platform/packages/shared/security/api_key_management/src/components/token_field.tsx
@@ -107,6 +107,9 @@ export const SelectableTokenField: FunctionComponent<SelectableTokenFieldProps> 
           isOpen={isPopoverOpen}
           panelPaddingSize="none"
           closePopover={closePopover}
+          aria-label={i18n.translate('xpack.security.copyTokenField.tokenFormatSelectorAriaLabel', {
+            defaultMessage: 'Select API key format',
+          })}
         >
           <EuiContextMenuPanel
             initialFocusedItemIndex={selectedIndex}

--- a/x-pack/platform/plugins/shared/security/public/account_management/user_profile/user_profile.tsx
+++ b/x-pack/platform/plugins/shared/security/public/account_management/user_profile/user_profile.tsx
@@ -791,6 +791,12 @@ const UserRoles: FunctionComponent<UserRoleProps> = ({ user }) => {
         isOpen={isPopoverOpen}
         closePopover={closePopover}
         data-test-subj="userRolesPopover"
+        aria-label={i18n.translate(
+          'xpack.security.accountManagement.userProfile.moreRolesPopoverAriaLabel',
+          {
+            defaultMessage: 'More roles',
+          }
+        )}
       >
         <EuiBadgeGroup
           gutterSize="xs"

--- a/x-pack/platform/plugins/shared/security/public/management/role_mappings/edit_role_mapping/rule_editor_panel/add_rule_button.tsx
+++ b/x-pack/platform/plugins/shared/security/public/management/role_mappings/edit_role_mapping/rule_editor_panel/add_rule_button.tsx
@@ -8,6 +8,7 @@
 import { EuiButtonEmpty, EuiContextMenuItem, EuiContextMenuPanel, EuiPopover } from '@elastic/eui';
 import React, { useState } from 'react';
 
+import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 
 import type { Rule } from '../../model';
@@ -77,6 +78,12 @@ export const AddRuleButton = (props: Props) => {
       closePopover={() => setIsMenuOpen(false)}
       panelPaddingSize="none"
       anchorPosition="downLeft"
+      aria-label={i18n.translate(
+        'xpack.security.management.editRoleMapping.addRulePopoverAriaLabel',
+        {
+          defaultMessage: 'Add rule options',
+        }
+      )}
     >
       <EuiContextMenuPanel title="Add rule" items={options} />
     </EuiPopover>

--- a/x-pack/platform/plugins/shared/security/public/management/role_mappings/edit_role_mapping/rule_editor_panel/rule_group_title.tsx
+++ b/x-pack/platform/plugins/shared/security/public/management/role_mappings/edit_role_mapping/rule_editor_panel/rule_group_title.tsx
@@ -16,6 +16,7 @@ import {
 } from '@elastic/eui';
 import React, { useState } from 'react';
 
+import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 
 import type { RuleGroup } from '../../model';
@@ -81,7 +82,17 @@ export const RuleGroupTitle = (props: Props) => {
   );
 
   const ruleTypeSelector = (
-    <EuiPopover button={ruleButton} isOpen={isMenuOpen} closePopover={() => setIsMenuOpen(false)}>
+    <EuiPopover
+      button={ruleButton}
+      isOpen={isMenuOpen}
+      closePopover={() => setIsMenuOpen(false)}
+      aria-label={i18n.translate(
+        'xpack.security.management.editRoleMapping.ruleGroupTitlePopoverAriaLabel',
+        {
+          defaultMessage: 'Change rule group type',
+        }
+      )}
+    >
       <EuiContextMenuPanel
         items={availableRuleTypes.map((rt, index) => {
           const isSelected = rt.getDisplayTitle() === props.rule.getDisplayTitle();

--- a/x-pack/platform/plugins/shared/security/public/management/roles/edit_role/privileges/kibana/privilege_summary/privilege_summary.tsx
+++ b/x-pack/platform/plugins/shared/security/public/management/roles/edit_role/privileges/kibana/privilege_summary/privilege_summary.tsx
@@ -13,6 +13,7 @@ import {
   EuiFlyoutFooter,
   EuiFlyoutHeader,
   EuiTitle,
+  useGeneratedHtmlId,
 } from '@elastic/eui';
 import React, { Fragment, useState } from 'react';
 
@@ -32,6 +33,7 @@ interface Props {
 }
 export const PrivilegeSummary = (props: Props) => {
   const [isOpen, setIsOpen] = useState(false);
+  const flyoutTitleId = useGeneratedHtmlId();
 
   const numberOfPrivilegeDefinitions = props.role.kibana.length;
   const flyoutSize = numberOfPrivilegeDefinitions > 5 ? 'l' : 'm';
@@ -49,10 +51,11 @@ export const PrivilegeSummary = (props: Props) => {
           onClose={() => setIsOpen(false)}
           size={flyoutSize}
           maskProps={{ headerZindexLocation: 'below' }}
+          aria-labelledby={flyoutTitleId}
         >
           <EuiFlyoutHeader>
             <EuiTitle size="m">
-              <h2>
+              <h2 id={flyoutTitleId}>
                 <FormattedMessage
                   id="xpack.security.management.editRole.privilegeSummary.modalHeaderTitle"
                   defaultMessage="Privilege summary"

--- a/x-pack/platform/plugins/shared/security/public/management/roles/edit_role/privileges/kibana/space_aware_privilege_section/privilege_space_form.tsx
+++ b/x-pack/platform/plugins/shared/security/public/management/roles/edit_role/privileges/kibana/space_aware_privilege_section/privilege_space_form.tsx
@@ -99,6 +99,21 @@ export class PrivilegeSpaceForm extends Component<Props, State> {
         size="m"
         maxWidth={true}
         maskProps={{ headerZindexLocation: 'below' }}
+        aria-label={
+          this.state.mode === 'create'
+            ? i18n.translate(
+                'xpack.security.management.editRole.spacePrivilegeForm.assignRoleFlyoutAriaLabel',
+                {
+                  defaultMessage: 'Assign role to spaces',
+                }
+              )
+            : i18n.translate(
+                'xpack.security.management.editRole.spacePrivilegeForm.editRoleFlyoutAriaLabel',
+                {
+                  defaultMessage: 'Edit role privileges for spaces',
+                }
+              )
+        }
       >
         <EuiFlyoutHeader hasBorder>
           <EuiTitle size="m">

--- a/x-pack/platform/plugins/shared/security/public/management/roles/edit_role/spaces_popover_list/spaces_popover_list.tsx
+++ b/x-pack/platform/plugins/shared/security/public/management/roles/edit_role/spaces_popover_list/spaces_popover_list.tsx
@@ -75,6 +75,12 @@ export class SpacesPopoverList extends Component<Props, State> {
         panelPaddingSize="none"
         anchorPosition="downLeft"
         ownFocus={false}
+        aria-label={i18n.translate(
+          'xpack.security.management.editRole.spacesPopoverList.popoverAriaLabel',
+          {
+            defaultMessage: 'Spaces',
+          }
+        )}
       >
         <EuiFocusTrap>{this.getMenuPanel()}</EuiFocusTrap>
       </EuiPopover>

--- a/x-pack/platform/plugins/shared/security/public/nav_control/nav_control_component.tsx
+++ b/x-pack/platform/plugins/shared/security/public/nav_control/nav_control_component.tsx
@@ -177,6 +177,9 @@ export const SecurityNavControl: FunctionComponent<SecurityNavControlProps> = ({
       closePopover={() => setIsPopoverOpen(false)}
       panelPaddingSize="none"
       buffer={0}
+      aria-label={i18n.translate('xpack.security.navControlComponent.popoverAriaLabel', {
+        defaultMessage: 'Account menu',
+      })}
     >
       <EuiContextMenu
         className="chrNavControl__userMenu"

--- a/x-pack/platform/plugins/shared/spaces/public/copy_saved_objects_to_space/components/resolve_all_conflicts.test.tsx
+++ b/x-pack/platform/plugins/shared/spaces/public/copy_saved_objects_to_space/components/resolve_all_conflicts.test.tsx
@@ -88,6 +88,7 @@ describe('ResolveAllConflicts', () => {
     expect(wrapper).toMatchInlineSnapshot(`
       <EuiPopover
         anchorPosition="downLeft"
+        aria-label="Resolve all conflicts"
         button={
           <ResolveAllButton
             onButtonClick={[Function]}

--- a/x-pack/platform/plugins/shared/spaces/public/copy_saved_objects_to_space/components/resolve_all_conflicts.tsx
+++ b/x-pack/platform/plugins/shared/spaces/public/copy_saved_objects_to_space/components/resolve_all_conflicts.tsx
@@ -103,6 +103,12 @@ export class ResolveAllConflicts extends Component<ResolveAllConflictsProps, Sta
         closePopover={this.closePopover}
         panelPaddingSize="none"
         anchorPosition="downLeft"
+        aria-label={i18n.translate(
+          'xpack.spaces.management.copyToSpace.resolveAllConflictsPopoverAriaLabel',
+          {
+            defaultMessage: 'Resolve all conflicts',
+          }
+        )}
       >
         <EuiContextMenuPanel items={items} />
       </EuiPopover>

--- a/x-pack/platform/plugins/shared/spaces/public/management/components/enabled_features/toggle_all_features.tsx
+++ b/x-pack/platform/plugins/shared/spaces/public/management/components/enabled_features/toggle_all_features.tsx
@@ -96,6 +96,9 @@ export class ToggleAllFeatures extends Component<Props, State> {
         closePopover={this.closePopover}
         panelPaddingSize="none"
         anchorPosition="downLeft"
+        aria-label={i18n.translate('xpack.spaces.management.toggleAllFeatures.popoverAriaLabel', {
+          defaultMessage: 'Change feature visibility',
+        })}
       >
         <EuiContextMenuPanel items={items} />
       </EuiPopover>

--- a/x-pack/platform/plugins/shared/spaces/public/management/edit_space/roles/component/space_assigned_roles_table.tsx
+++ b/x-pack/platform/plugins/shared/spaces/public/management/edit_space/roles/component/space_assigned_roles_table.tsx
@@ -369,6 +369,10 @@ export const SpaceAssignedRolesTable = ({
                       isOpen={isBulkActionContextOpen}
                       closePopover={setBulkActionContextOpen.bind(null, false)}
                       anchorPosition="downCenter"
+                      aria-label={i18n.translate(
+                        'xpack.spaces.management.spaceDetails.rolesTable.bulkActionsPopoverAriaLabel',
+                        { defaultMessage: 'Bulk actions' }
+                      )}
                       button={
                         <EuiButtonEmpty
                           size="s"

--- a/x-pack/platform/plugins/shared/spaces/public/nav_control/nav_control_popover.tsx
+++ b/x-pack/platform/plugins/shared/spaces/public/nav_control/nav_control_popover.tsx
@@ -185,6 +185,9 @@ const NavControlPopoverUI = ({
         panelProps={{
           'data-test-subj': 'spaceMenuPopoverPanel',
         }}
+        aria-label={i18n.translate('xpack.spaces.navControl.popover.ariaLabel', {
+          defaultMessage: 'Spaces navigation',
+        })}
       >
         <SpacesMenu
           id={popoutContentId}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [a11y: fix `@elastic/eui/require-aria-label-for-modals` violations across 18 security/spaces files (#260696)](https://github.com/elastic/kibana/pull/260696)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Copilot","email":"198982749+Copilot@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-04-09T17:49:18Z","message":"a11y: fix `@elastic/eui/require-aria-label-for-modals` violations across 18 security/spaces files (#260696)\n\nCloses: https://github.com/elastic/kibana/issues/260635\n\n18 `EuiPopover`, `EuiFlyout`, and `EuiModal` components were missing\nrequired `aria-label` or `aria-labelledby` props, causing WCAG 2.2 AA\nviolations flagged by the `@elastic/eui/require-aria-label-for-modals`\nESLint rule.\n\n## Changes\n\n**EuiPopover (16 components)** — added `aria-label` via\n`i18n.translate()` describing each popover's purpose:\n- `role_switcher.tsx`, `cluster_configuration_form.tsx`,\n`enrollment_token_form.tsx`, `change_all_privileges.tsx`,\n`token_field.tsx`, `user_profile.tsx`, `add_rule_button.tsx`,\n`rule_group_title.tsx`, `spaces_popover_list.tsx`,\n`nav_control_component.tsx`, `resolve_all_conflicts.tsx`,\n`customize_cps.tsx`, `toggle_all_features.tsx`,\n`space_assigned_roles_table.tsx`, `nav_control_popover.tsx`\n\n**EuiFlyout — `privilege_summary.tsx`** — preferred `aria-labelledby`\npattern using `useGeneratedHtmlId`:\n```tsx\nconst flyoutTitleId = useGeneratedHtmlId();\n// ...\n<EuiFlyout aria-labelledby={flyoutTitleId}>\n  <EuiFlyoutHeader>\n    <EuiTitle><h2 id={flyoutTitleId}>Privilege summary</h2></EuiTitle>\n```\n\n**EuiFlyout — `privilege_space_form.tsx`** — class component; used\n`aria-label` with a value derived from `this.state.mode` since hooks are\nunavailable.\n\n**EuiModal — `use_verification.tsx`** — added `aria-label=\"Verification\nrequired\"`.\n\nNew `i18n` imports added to the 4 files that lacked them\n(`role_switcher.tsx`, `use_verification.tsx`, `add_rule_button.tsx`,\n`rule_group_title.tsx`).\n\n---------\n\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: alexwizp <20072247+alexwizp@users.noreply.github.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Alexey Antonov <alexwizp@gmail.com>\nCo-authored-by: Aleh Zasypkin <aleh.zasypkin@elastic.co>","sha":"dfef6b44a3b6f7cfbf39cf025fff5e8a0e36c538","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Project:Accessibility","release_note:skip","backport missing","💝community","backport:version","v9.4.0","v9.3.3","a11y:agent-pr"],"title":"a11y: fix `@elastic/eui/require-aria-label-for-modals` violations across 18 security/spaces files","number":260696,"url":"https://github.com/elastic/kibana/pull/260696","mergeCommit":{"message":"a11y: fix `@elastic/eui/require-aria-label-for-modals` violations across 18 security/spaces files (#260696)\n\nCloses: https://github.com/elastic/kibana/issues/260635\n\n18 `EuiPopover`, `EuiFlyout`, and `EuiModal` components were missing\nrequired `aria-label` or `aria-labelledby` props, causing WCAG 2.2 AA\nviolations flagged by the `@elastic/eui/require-aria-label-for-modals`\nESLint rule.\n\n## Changes\n\n**EuiPopover (16 components)** — added `aria-label` via\n`i18n.translate()` describing each popover's purpose:\n- `role_switcher.tsx`, `cluster_configuration_form.tsx`,\n`enrollment_token_form.tsx`, `change_all_privileges.tsx`,\n`token_field.tsx`, `user_profile.tsx`, `add_rule_button.tsx`,\n`rule_group_title.tsx`, `spaces_popover_list.tsx`,\n`nav_control_component.tsx`, `resolve_all_conflicts.tsx`,\n`customize_cps.tsx`, `toggle_all_features.tsx`,\n`space_assigned_roles_table.tsx`, `nav_control_popover.tsx`\n\n**EuiFlyout — `privilege_summary.tsx`** — preferred `aria-labelledby`\npattern using `useGeneratedHtmlId`:\n```tsx\nconst flyoutTitleId = useGeneratedHtmlId();\n// ...\n<EuiFlyout aria-labelledby={flyoutTitleId}>\n  <EuiFlyoutHeader>\n    <EuiTitle><h2 id={flyoutTitleId}>Privilege summary</h2></EuiTitle>\n```\n\n**EuiFlyout — `privilege_space_form.tsx`** — class component; used\n`aria-label` with a value derived from `this.state.mode` since hooks are\nunavailable.\n\n**EuiModal — `use_verification.tsx`** — added `aria-label=\"Verification\nrequired\"`.\n\nNew `i18n` imports added to the 4 files that lacked them\n(`role_switcher.tsx`, `use_verification.tsx`, `add_rule_button.tsx`,\n`rule_group_title.tsx`).\n\n---------\n\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: alexwizp <20072247+alexwizp@users.noreply.github.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Alexey Antonov <alexwizp@gmail.com>\nCo-authored-by: Aleh Zasypkin <aleh.zasypkin@elastic.co>","sha":"dfef6b44a3b6f7cfbf39cf025fff5e8a0e36c538"}},"sourceBranch":"main","suggestedTargetBranches":["9.3"],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/260696","number":260696,"mergeCommit":{"message":"a11y: fix `@elastic/eui/require-aria-label-for-modals` violations across 18 security/spaces files (#260696)\n\nCloses: https://github.com/elastic/kibana/issues/260635\n\n18 `EuiPopover`, `EuiFlyout`, and `EuiModal` components were missing\nrequired `aria-label` or `aria-labelledby` props, causing WCAG 2.2 AA\nviolations flagged by the `@elastic/eui/require-aria-label-for-modals`\nESLint rule.\n\n## Changes\n\n**EuiPopover (16 components)** — added `aria-label` via\n`i18n.translate()` describing each popover's purpose:\n- `role_switcher.tsx`, `cluster_configuration_form.tsx`,\n`enrollment_token_form.tsx`, `change_all_privileges.tsx`,\n`token_field.tsx`, `user_profile.tsx`, `add_rule_button.tsx`,\n`rule_group_title.tsx`, `spaces_popover_list.tsx`,\n`nav_control_component.tsx`, `resolve_all_conflicts.tsx`,\n`customize_cps.tsx`, `toggle_all_features.tsx`,\n`space_assigned_roles_table.tsx`, `nav_control_popover.tsx`\n\n**EuiFlyout — `privilege_summary.tsx`** — preferred `aria-labelledby`\npattern using `useGeneratedHtmlId`:\n```tsx\nconst flyoutTitleId = useGeneratedHtmlId();\n// ...\n<EuiFlyout aria-labelledby={flyoutTitleId}>\n  <EuiFlyoutHeader>\n    <EuiTitle><h2 id={flyoutTitleId}>Privilege summary</h2></EuiTitle>\n```\n\n**EuiFlyout — `privilege_space_form.tsx`** — class component; used\n`aria-label` with a value derived from `this.state.mode` since hooks are\nunavailable.\n\n**EuiModal — `use_verification.tsx`** — added `aria-label=\"Verification\nrequired\"`.\n\nNew `i18n` imports added to the 4 files that lacked them\n(`role_switcher.tsx`, `use_verification.tsx`, `add_rule_button.tsx`,\n`rule_group_title.tsx`).\n\n---------\n\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: alexwizp <20072247+alexwizp@users.noreply.github.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Alexey Antonov <alexwizp@gmail.com>\nCo-authored-by: Aleh Zasypkin <aleh.zasypkin@elastic.co>","sha":"dfef6b44a3b6f7cfbf39cf025fff5e8a0e36c538"}},{"branch":"9.3","label":"v9.3.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->