### PR TITLE
fix(synthetics): update Failed Tests by Step panel to respect time range changes

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/hooks/use_failed_tests_by_step.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/hooks/use_failed_tests_by_step.tsx
@@ -75,9 +75,9 @@ export function useFailedTestByStep({ to, from }: { to: string; from: string }) 
 
   const { data, loading } = useReduxEsSearch<Ping, typeof params>(
     params,
-    [lastRefresh, monitorId],
+    [lastRefresh, monitorId, from, to],
     {
-      name: `getFailedTestsByStep/${monitorId}`,
+      name: `getFailedTestsByStep/${monitorId}/${from}/${to}`,
       isRequestReady: !!selectedLocation,
     }
   );


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/263319

## Summary

Fixes the "Failed Tests by Step" panel on the Synthetics Monitor Errors tab not updating when the user changes the date picker time range.

**Root cause:** The `useFailedTestByStep` hook was missing `from` and `to` in both:
1. The dependency array passed to `useReduxEsSearch` — so the hook never re-triggered when the time range changed
2. The request name — so even if re-triggered, the Redux saga would deduplicate the request (same name = already in-flight), silently dropping the new query

**Fix:** Added `from` and `to` to both the dependency array and the request name, matching the pattern already used by the correctly implemented `useMonitorErrors` hook.


Made with [Cursor](https://cursor.com)