### PR TITLE
[9.3] [a11y] Fix `@elastic/eui/icon-accessibility-rules` violations across 55 kibana-presentation files (#260694)

### DIFF
--- a/src/platform/packages/private/kbn-grid-layout/grid/grid_panel/drag_handle/default_drag_handle.tsx
+++ b/src/platform/packages/private/kbn-grid-layout/grid/grid_panel/drag_handle/default_drag_handle.tsx
@@ -26,7 +26,7 @@ export const DefaultDragHandle = React.memo(
         data-test-subj="kbnGridPanel--dragHandle"
         css={styles}
       >
-        <EuiIcon type="grabOmnidirectional" />
+        <EuiIcon type="grabOmnidirectional" aria-hidden={true} />
       </button>
     );
   }

--- a/src/platform/packages/shared/kbn-cps-utils/components/project_list_item.tsx
+++ b/src/platform/packages/shared/kbn-cps-utils/components/project_list_item.tsx
@@ -72,7 +72,7 @@ export const ProjectListItem = ({ project, index, isOriginProject }: ProjectList
         <EuiFlexItem grow={false}>
           <EuiFlexGroup responsive={false} gutterSize="s">
             <EuiFlexItem grow={false}>
-              <EuiIcon type={getSolutionIcon(project._type)} />
+              <EuiIcon type={getSolutionIcon(project._type)} aria-hidden={true} />
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
               <EuiText size="s" color="text">

--- a/src/platform/plugins/private/links/public/components/editor/links_editor_single_link.tsx
+++ b/src/platform/plugins/private/links/public/components/editor/links_editor_single_link.tsx
@@ -97,7 +97,7 @@ export const LinksEditorSingleLink = ({
             aria-label={LinksStrings.editor.panelEditor.getDragHandleAriaLabel()}
             data-test-subj="panelEditorLink--dragHandle"
           >
-            <EuiIcon type="grab" />
+            <EuiIcon type="grab" aria-hidden={true} />
           </EuiPanel>
         </EuiFlexItem>
         <EuiFlexItem className="linksPanelEditorLinkText">

--- a/src/platform/plugins/private/presentation_panel/public/panel_component/panel_header/presentation_panel_title.tsx
+++ b/src/platform/plugins/private/presentation_panel/public/panel_component/panel_header/presentation_panel_title.tsx
@@ -152,6 +152,9 @@ export const PresentationPanelTitle = ({
             color="subdued"
             data-test-subj="embeddablePanelTitleDescriptionIcon"
             tabIndex={0}
+            aria-label={i18n.translate('presentationPanel.header.descriptionIconAriaLabel', {
+              defaultMessage: 'Description',
+            })}
           />
         </div>
       </EuiToolTip>

--- a/src/platform/plugins/shared/controls/public/control_group/components/control_clone.tsx
+++ b/src/platform/plugins/shared/controls/public/control_group/components/control_clone.tsx
@@ -54,7 +54,7 @@ export const ControlClone = ({
       {isTwoLine && <EuiFormLabel>{panelTitle ?? defaultPanelTitle}</EuiFormLabel>}
       <EuiFlexGroup responsive={false} gutterSize="none" css={styles.dragContainer}>
         <EuiFlexItem grow={false}>
-          <EuiIcon type="grabHorizontal" css={styles.grabIcon} />
+          <EuiIcon type="grabHorizontal" css={styles.grabIcon} aria-hidden={true} />
         </EuiFlexItem>
         {!isTwoLine && (
           <EuiFlexItem>

--- a/src/platform/plugins/shared/controls/public/control_group/components/drag_handle.tsx
+++ b/src/platform/plugins/shared/controls/public/control_group/components/drag_handle.tsx
@@ -35,7 +35,7 @@ export const DragHandle = ({ isEditable, controlTitle = '', ...rest }: DragHandl
       })}
       css={dragHandleStyles}
     >
-      <EuiIcon type="grabHorizontal" />
+      <EuiIcon type="grabHorizontal" aria-hidden={true} />
     </button>
   );
 };

--- a/src/platform/plugins/shared/controls/public/controls/data_controls/data_control_editor.tsx
+++ b/src/platform/plugins/shared/controls/public/controls/data_controls/data_control_editor.tsx
@@ -145,7 +145,7 @@ const CompatibleControlTypesComponent = ({
               onClick={() => setSelectedControlType(factory.type)}
               label={factory.getDisplayName()}
             >
-              <EuiIcon type={factory.getIconType()} size="l" />
+              <EuiIcon type={factory.getIconType()} size="l" aria-hidden={true} />
             </EuiKeyPadMenuItem>
           );
 

--- a/src/platform/plugins/shared/controls/public/controls/data_controls/options_list_control/components/options_list_popover_empty_message.tsx
+++ b/src/platform/plugins/shared/controls/public/controls/data_controls/options_list_control/components/options_list_popover_empty_message.tsx
@@ -48,6 +48,7 @@ export const OptionsListPopoverEmptyMessage = ({
       <EuiIcon
         type={searchStringValid ? 'minusInCircle' : 'alert'}
         color={searchStringValid ? 'default' : 'danger'}
+        aria-hidden={true}
       />
       <EuiSpacer size="xs" />
       {noResultsMessage}

--- a/src/platform/plugins/shared/inspector/public/views/requests/components/details/req_details_stats.tsx
+++ b/src/platform/plugins/shared/inspector/public/views/requests/components/details/req_details_stats.tsx
@@ -45,7 +45,7 @@ const StatRow = ({ stat }: { stat: RequestDetailsStatRow }) => {
               content={stat.description}
             />
           ) : (
-            <EuiIcon type="empty" />
+            <EuiIcon type="empty" aria-hidden={true} />
           )}
         </span>
       </EuiTableRowCell>

--- a/src/platform/plugins/shared/presentation_util/public/components/labs/labs_beaker_button.tsx
+++ b/src/platform/plugins/shared/presentation_util/public/components/labs/labs_beaker_button.tsx
@@ -34,7 +34,7 @@ export const LabsBeakerButton = ({ solutions, ...props }: Props) => {
   return (
     <>
       <EuiButton {...props} onClick={onButtonClick} minWidth={0}>
-        <EuiIcon type="beaker" />
+        <EuiIcon type="beaker" aria-hidden={true} />
         {overrideCount > 0 ? (
           <EuiNotificationBadge color="subdued" css={{ marginLeft: 2 }}>
             {overrideCount}

--- a/src/platform/plugins/shared/presentation_util/public/components/labs/labs_flyout.tsx
+++ b/src/platform/plugins/shared/presentation_util/public/components/labs/labs_flyout.tsx
@@ -143,7 +143,7 @@ export const LabsFlyout = (props: Props) => {
           <h2 id={flyoutTitleId}>
             <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
               <EuiFlexItem grow={false}>
-                <EuiIcon type="beaker" size="l" />
+                <EuiIcon type="beaker" size="l" aria-hidden={true} />
               </EuiFlexItem>
               <EuiFlexItem>{strings.getTitleLabel()}</EuiFlexItem>
             </EuiFlexGroup>

--- a/src/platform/plugins/shared/ui_actions_enhanced/public/drilldowns/drilldown_manager/components/drilldown_hello_bar/drilldown_hello_bar.tsx
+++ b/src/platform/plugins/shared/ui_actions_enhanced/public/drilldowns/drilldown_manager/components/drilldown_hello_bar/drilldown_hello_bar.tsx
@@ -33,7 +33,7 @@ export const DrilldownHelloBar: React.FC<DrilldownHelloBarProps> = ({ docsLink, 
     <EuiCallOut data-test-subj={WELCOME_MESSAGE_TEST_SUBJ}>
       <EuiFlexGroup responsive={false}>
         <EuiFlexItem grow={false}>
-          <EuiIcon type="question" />
+          <EuiIcon type="question" aria-hidden={true} />
         </EuiFlexItem>
         <EuiFlexItem grow={1}>
           <EuiText size={'s'}>

--- a/src/platform/plugins/shared/ui_actions_enhanced/public/drilldowns/drilldown_manager/components/text_with_icon/text_with_icon.tsx
+++ b/src/platform/plugins/shared/ui_actions_enhanced/public/drilldowns/drilldown_manager/components/text_with_icon/text_with_icon.tsx
@@ -42,7 +42,7 @@ export const TextWithIcon: FC<PropsWithChildren<TextWithIconProps>> = ({
           {!!iconTooltip ? (
             <EuiIconTip content={iconTooltip} type={icon} color={iconColor} />
           ) : (
-            <EuiIcon color={iconColor} type={icon} />
+            <EuiIcon color={iconColor} type={icon} aria-hidden={true} />
           )}
         </EuiFlexItem>
       )}

--- a/src/platform/plugins/shared/unified_search/public/dataview_picker/change_dataview.tsx
+++ b/src/platform/plugins/shared/unified_search/public/dataview_picker/change_dataview.tsx
@@ -147,7 +147,7 @@ export function ChangeDataView({
           css={{ maxWidth: '100%' }}
         >
           {/* we don't want to display the adHoc icon on text based mode */}
-          {isAdHocSelected && <EuiIcon type={adhoc} color="primary" size="s" />}
+          {isAdHocSelected && <EuiIcon type={adhoc} color="primary" size="s" aria-hidden={true} />}
           <span className="eui-textTruncate">{trigger.label}</span>
         </EuiFlexGroup>
       </EuiFormControlButton>

--- a/src/platform/plugins/shared/unified_search/public/filter_bar/filter_editor/filter_editor.tsx
+++ b/src/platform/plugins/shared/unified_search/public/filter_bar/filter_editor/filter_editor.tsx
@@ -424,7 +424,7 @@ class FilterEditorComponent extends Component<FilterEditorProps, State> {
                   id="unifiedSearch.filter.filterBar.preview"
                   defaultMessage="{icon} Preview"
                   values={{
-                    icon: <EuiIcon type="inspect" size="s" />,
+                    icon: <EuiIcon type="inspect" size="s" aria-hidden={true} />,
                   }}
                 />
               </strong>

--- a/src/platform/plugins/shared/unified_search/public/saved_query_management/saved_query_management_list.tsx
+++ b/src/platform/plugins/shared/unified_search/public/saved_query_management/saved_query_management_list.tsx
@@ -164,7 +164,16 @@ const itemLabel = (attributes: SavedQueryAttributes) => {
   if (attributes.description) {
     label = (
       <>
-        {label} <EuiIcon type="info" color="subdued" size="s" />
+        {label}{' '}
+        <EuiIcon
+          type="info"
+          color="subdued"
+          size="s"
+          aria-label={i18n.translate(
+            'unifiedSearch.search.searchBar.savedQueryHasDescriptionAriaLabel',
+            { defaultMessage: 'Has description' }
+          )}
+        />
       </>
     );
   }
@@ -172,7 +181,16 @@ const itemLabel = (attributes: SavedQueryAttributes) => {
   if (attributes.timefilter) {
     label = (
       <>
-        {label} <EuiIcon type="clock" color="subdued" size="s" />
+        {label}{' '}
+        <EuiIcon
+          type="clock"
+          color="subdued"
+          size="s"
+          aria-label={i18n.translate(
+            'unifiedSearch.search.searchBar.savedQueryHasTimeFilterAriaLabel',
+            { defaultMessage: 'Has time filter' }
+          )}
+        />
       </>
     );
   }

--- a/src/platform/plugins/shared/unified_search/public/typeahead/suggestion_component.tsx
+++ b/src/platform/plugins/shared/unified_search/public/typeahead/suggestion_component.tsx
@@ -88,7 +88,7 @@ export const SuggestionComponent = React.memo(function SuggestionComponent(props
         })}
       >
         <div className="kbnSuggestionItem__type">
-          <EuiIcon type={getEuiIconType(props.suggestion.type)} />
+          <EuiIcon type={getEuiIconType(props.suggestion.type)} aria-hidden={true} />
         </div>
         <div className="kbnSuggestionItem__text" data-test-subj="autoCompleteSuggestionText">
           {props.suggestion.text}

--- a/x-pack/platform/plugins/private/canvas/canvas_plugin_src/renderers/error/components/error_component.tsx
+++ b/x-pack/platform/plugins/private/canvas/canvas_plugin_src/renderers/error/components/error_component.tsx
@@ -53,6 +53,9 @@ function ErrorComponent({ onLoaded, parentNode, error }: ErrorComponentProps) {
               width: buttonSize,
             }}
             type="warning"
+            aria-label={i18n.translate('xpack.canvas.errorComponent.errorIconAriaLabel', {
+              defaultMessage: 'View error details',
+            })}
           />
         }
         isOpen={isPopoverOpen}

--- a/x-pack/platform/plugins/private/canvas/public/components/arg_form/arg_label.js
+++ b/x-pack/platform/plugins/private/canvas/public/components/arg_form/arg_label.js
@@ -35,7 +35,7 @@ export const ArgLabel = (props) => {
           label={
             <EuiToolTip content={help}>
               <span tabIndex={0}>
-                {label} <EuiIcon type="info" color="subdued" />
+                {label} <EuiIcon type="info" color="subdued" aria-hidden />
               </span>
             </EuiToolTip>
           }

--- a/x-pack/platform/plugins/private/canvas/public/components/asset_picker/asset_picker.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/asset_picker/asset_picker.tsx
@@ -57,7 +57,13 @@ export class AssetPicker extends PureComponent<Props> {
             >
               <EuiImage url={asset.value} alt={strings.getAssetAltText()} />
               {asset.id === selected && (
-                <EuiIcon className="canvasAssetPicker__selected" type="checkInCircleFilled" />
+                <EuiIcon
+                  className="canvasAssetPicker__selected"
+                  type="checkInCircleFilled"
+                  aria-label={i18n.translate('xpack.canvas.assetpicker.selectedIconAriaLabel', {
+                    defaultMessage: 'Selected',
+                  })}
+                />
               )}
             </EuiLink>
           </EuiFlexItem>

--- a/x-pack/platform/plugins/private/canvas/public/components/color_palette/color_palette.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/color_palette/color_palette.tsx
@@ -54,7 +54,12 @@ export const ColorPalette: FC<Props> = ({
         {(color) => {
           const match = chroma(color).hex() === chroma(value).hex();
           const icon = match ? (
-            <EuiIcon type="check" className="selected-color" color={readableColor(value)} />
+            <EuiIcon
+              type="check"
+              className="selected-color"
+              color={readableColor(value)}
+              aria-hidden={true}
+            />
           ) : null;
 
           return (

--- a/x-pack/platform/plugins/private/canvas/public/components/datasource/datasource_component.js
+++ b/x-pack/platform/plugins/private/canvas/public/components/datasource/datasource_component.js
@@ -171,7 +171,11 @@ export class DatasourceComponent extends PureComponent {
             size="s"
             data-test-subj="canvasChangeDatasourceButton"
           >
-            <EuiIcon type={stateDatasource.image} className="canvasDataSource__triggerButtonIcon" />
+            <EuiIcon
+              type={stateDatasource.image}
+              className="canvasDataSource__triggerButtonIcon"
+              aria-hidden
+            />
             {stateDatasource.displayName}
           </EuiButtonEmpty>
           <EuiSpacer size="s" />

--- a/x-pack/platform/plugins/private/canvas/public/components/datasource/datasource_selector.js
+++ b/x-pack/platform/plugins/private/canvas/public/components/datasource/datasource_selector.js
@@ -17,7 +17,7 @@ export const DatasourceSelector = ({ onSelect, datasources, current }) => (
         title={d.displayName}
         titleElement="h5"
         titleSize="xs"
-        icon={<EuiIcon type={d.image} size="l" />}
+        icon={<EuiIcon type={d.image} size="l" aria-hidden />}
         description={d.help}
         layout="horizontal"
         className="canvasDataSource__card"

--- a/x-pack/platform/plugins/private/canvas/public/components/datatable/datatable.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/datatable/datatable.tsx
@@ -41,7 +41,7 @@ const getIcon = (type: DatatableColumnType | null) => {
       icon = 'question';
   }
 
-  return <EuiIcon type={icon} color="subdued" />;
+  return <EuiIcon type={icon} color="subdued" aria-hidden={true} />;
 };
 
 const getColumnName = (col: DatatableColumn) => (typeof col === 'string' ? col : col.name);

--- a/x-pack/platform/plugins/private/canvas/public/components/element_card/element_card.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/element_card/element_card.tsx
@@ -43,7 +43,7 @@ export const ElementCard = ({ title, description, image, tags = [], onClick, ...
     description={description}
     footer={<TagList tags={tags} tagType={tagType} />}
     image={image}
-    icon={image ? undefined : <EuiIcon type="canvasApp" size="xxl" />}
+    icon={image ? undefined : <EuiIcon type="canvasApp" size="xxl" aria-hidden={true} />}
     onClick={onClick}
     {...rest}
   />

--- a/x-pack/platform/plugins/private/canvas/public/components/loading/loading.test.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/loading/loading.test.tsx
@@ -17,6 +17,7 @@ describe('<Loading />', () => {
         class="canvasLoading"
       >
         <span
+          aria-hidden="true"
           color="ghost"
           data-euiicon-type="clock"
         />

--- a/x-pack/platform/plugins/private/canvas/public/components/loading/loading.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/loading/loading.tsx
@@ -51,7 +51,7 @@ export const Loading: FC<Props> = ({
           &nbsp;
         </span>
       )}
-      <EuiIcon color={color} type="clock" />
+      <EuiIcon color={color} type="clock" aria-hidden={true} />
     </div>
   );
 };

--- a/x-pack/platform/plugins/private/canvas/public/components/page_config/page_config.js
+++ b/x-pack/platform/plugins/private/canvas/public/components/page_config/page_config.js
@@ -65,7 +65,8 @@ export const PageConfig = ({
         label={
           <EuiToolTip content={strings.getBackgroundColorDescription()}>
             <span tabIndex={0}>
-              {strings.getBackgroundColorLabel()} <EuiIcon type="question" color="subdued" />
+              {strings.getBackgroundColorLabel()}{' '}
+              <EuiIcon type="question" color="subdued" aria-hidden />
             </span>
           </EuiToolTip>
         }

--- a/x-pack/platform/plugins/private/canvas/public/components/page_manager/page_manager.component.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/page_manager/page_manager.component.tsx
@@ -242,8 +242,9 @@ export class PageManager extends Component<Props, State> {
                   onClick={onAddPage}
                   className="canvasPageManager__addPage kbn-resetFocusState"
                   data-test-subj="canvasAddPageButton"
+                  aria-label={strings.getAddPageTooltip()}
                 >
-                  <EuiIcon color="ghost" type="plusInCircle" size="l" />
+                  <EuiIcon color="ghost" type="plusInCircle" size="l" aria-hidden={true} />
                 </button>
               </EuiToolTip>
             </EuiFlexItem>

--- a/x-pack/platform/plugins/private/canvas/public/components/var_config/delete_var.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/var_config/delete_var.tsx
@@ -52,7 +52,7 @@ export const DeleteVar: FC<Props> = ({ selectedVar, onCancel, onDelete }) => {
       <div className="canvasVarHeader__triggerWrapper">
         <button className="canvasVarHeader__button" type="button" onClick={() => onCancel()}>
           <span className="canvasVarHeader__iconWrapper">
-            <EuiIcon type="sortLeft" style={{ verticalAlign: 'top' }} />
+            <EuiIcon type="sortLeft" style={{ verticalAlign: 'top' }} aria-hidden={true} />
           </span>
           <span>
             <span className="canvasVarHeader__anchor">{strings.getTitle()}</span>

--- a/x-pack/platform/plugins/private/canvas/public/components/var_config/edit_var.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/var_config/edit_var.tsx
@@ -142,7 +142,7 @@ export const EditVar: FC<Props> = ({ variables, selectedVar, onCancel, onSave })
       <div className="canvasVarHeader__triggerWrapper">
         <button className="canvasVarHeader__button" type="button" onClick={() => onCancel()}>
           <span className="canvasVarHeader__iconWrapper">
-            <EuiIcon type="sortLeft" style={{ verticalAlign: 'top' }} />
+            <EuiIcon type="sortLeft" style={{ verticalAlign: 'top' }} aria-hidden={true} />
           </span>
           <span>
             <span className="canvasVarHeader__anchor">

--- a/x-pack/platform/plugins/private/canvas/public/components/workpad_header/edit_menu/edit_menu.component.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/workpad_header/edit_menu/edit_menu.component.tsx
@@ -263,7 +263,7 @@ export const EditMenu: FunctionComponent<Props> = ({
       ? {
           name: strings.getUngroupMenuItemLabel(),
           className: CONTEXT_MENU_TOP_BORDER_CLASSNAME,
-          icon: <EuiIcon type="empty" size="m" />,
+          icon: <EuiIcon type="empty" size="m" aria-hidden={true} />,
           onClick: () => {
             ungroupNodes();
             closePopover();
@@ -272,7 +272,7 @@ export const EditMenu: FunctionComponent<Props> = ({
       : {
           name: strings.getGroupMenuItemLabel(),
           className: CONTEXT_MENU_TOP_BORDER_CLASSNAME,
-          icon: <EuiIcon type="empty" size="m" />,
+          icon: <EuiIcon type="empty" size="m" aria-hidden={true} />,
           disabled: selectedNodes.length < 2,
           onClick: () => {
             groupNodes();
@@ -283,7 +283,7 @@ export const EditMenu: FunctionComponent<Props> = ({
     const orderMenuItem = {
       name: strings.getOrderMenuItemLabel(),
       disabled: selectedNodes.length !== 1, // TODO: change to === 0 when we support relayering multiple elements
-      icon: <EuiIcon type="empty" size="m" />,
+      icon: <EuiIcon type="empty" size="m" aria-hidden={true} />,
       panel: {
         id: 1,
         title: strings.getOrderMenuItemLabel(),
@@ -316,7 +316,7 @@ export const EditMenu: FunctionComponent<Props> = ({
       name: strings.getAlignmentMenuItemLabel(),
       className: 'canvasContextMenu',
       disabled: groupIsSelected || selectedNodes.length < 2,
-      icon: <EuiIcon type="empty" size="m" />,
+      icon: <EuiIcon type="empty" size="m" aria-hidden={true} />,
       panel: {
         id: 2,
         title: strings.getAlignmentMenuItemLabel(),
@@ -377,7 +377,7 @@ export const EditMenu: FunctionComponent<Props> = ({
       name: strings.getDistributionMenuItemLabel(),
       className: 'canvasContextMenu',
       disabled: groupIsSelected || selectedNodes.length < 3,
-      icon: <EuiIcon type="empty" size="m" />,
+      icon: <EuiIcon type="empty" size="m" aria-hidden={true} />,
       panel: {
         id: 3,
         title: strings.getAlignmentMenuItemLabel(),
@@ -404,7 +404,7 @@ export const EditMenu: FunctionComponent<Props> = ({
 
     const savedElementMenuItem = {
       name: strings.getSaveElementMenuItemLabel(),
-      icon: <EuiIcon type="indexOpen" size="m" />,
+      icon: <EuiIcon type="indexOpen" size="m" aria-hidden={true} />,
       disabled: selectedNodes.length < 1,
       className: CONTEXT_MENU_TOP_BORDER_CLASSNAME,
       'data-test-subj': 'canvasWorkpadEditMenu__saveElementButton',
@@ -418,7 +418,7 @@ export const EditMenu: FunctionComponent<Props> = ({
       {
         // TODO: check history and disable when there are no more changes to revert
         name: strings.getUndoMenuItemLabel(),
-        icon: <EuiIcon type="editorUndo" size="m" />,
+        icon: <EuiIcon type="editorUndo" size="m" aria-hidden={true} />,
         onClick: () => {
           undoHistory();
         },
@@ -426,14 +426,14 @@ export const EditMenu: FunctionComponent<Props> = ({
       {
         // TODO: check history and disable when there are no more changes to reapply
         name: strings.getRedoMenuItemLabel(),
-        icon: <EuiIcon type="editorRedo" size="m" />,
+        icon: <EuiIcon type="editorRedo" size="m" aria-hidden={true} />,
         onClick: () => {
           redoHistory();
         },
       },
       {
         name: shortcutHelp.CUT,
-        icon: <EuiIcon type="cut" size="m" />,
+        icon: <EuiIcon type="cut" size="m" aria-hidden={true} />,
         className: CONTEXT_MENU_TOP_BORDER_CLASSNAME,
         disabled: selectedNodes.length < 1,
         onClick: () => {
@@ -444,14 +444,14 @@ export const EditMenu: FunctionComponent<Props> = ({
       {
         name: shortcutHelp.COPY,
         disabled: selectedNodes.length < 1,
-        icon: <EuiIcon type="copy" size="m" />,
+        icon: <EuiIcon type="copy" size="m" aria-hidden={true} />,
         onClick: () => {
           copyNodes();
         },
       },
       {
         name: shortcutHelp.PASTE, // TODO: can this be disabled if clipboard is empty?
-        icon: <EuiIcon type="copyClipboard" size="m" />,
+        icon: <EuiIcon type="copyClipboard" size="m" aria-hidden={true} />,
         disabled: !hasPasteData,
         onClick: () => {
           pasteNodes();
@@ -460,7 +460,7 @@ export const EditMenu: FunctionComponent<Props> = ({
       },
       {
         name: shortcutHelp.DELETE,
-        icon: <EuiIcon type="trash" size="m" />,
+        icon: <EuiIcon type="trash" size="m" aria-hidden={true} />,
         disabled: selectedNodes.length < 1,
         onClick: () => {
           deleteNodes();
@@ -470,7 +470,7 @@ export const EditMenu: FunctionComponent<Props> = ({
       },
       {
         name: shortcutHelp.CLONE,
-        icon: <EuiIcon type="empty" size="m" />,
+        icon: <EuiIcon type="empty" size="m" aria-hidden={true} />,
         disabled: selectedNodes.length < 1,
         onClick: () => {
           cloneNodes();

--- a/x-pack/platform/plugins/private/canvas/public/components/workpad_header/element_menu/element_menu.component.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/workpad_header/element_menu/element_menu.component.tsx
@@ -158,7 +158,7 @@ export const ElementMenu: FunctionComponent<Props> = ({ elements, addElement }) 
       if (elementList.length > 1) {
         return {
           name,
-          icon: <EuiIcon type={icon} size="m" />,
+          icon: <EuiIcon type={icon} size="m" aria-hidden={true} />,
           panel: {
             id: getId('element-type'),
             title: name,
@@ -185,7 +185,7 @@ export const ElementMenu: FunctionComponent<Props> = ({ elements, addElement }) 
           name: strings.getMyElementsMenuItemLabel(),
           className: CONTEXT_MENU_TOP_BORDER_CLASSNAME,
           'data-test-subj': 'saved-elements-menu-option',
-          icon: <EuiIcon type="empty" size="m" />,
+          icon: <EuiIcon type="empty" size="m" aria-hidden={true} />,
           onClick: () => {
             showSavedElementsModal();
             closePopover();
@@ -193,7 +193,7 @@ export const ElementMenu: FunctionComponent<Props> = ({ elements, addElement }) 
         },
         {
           name: strings.getAssetsMenuItemLabel(),
-          icon: <EuiIcon type="empty" size="m" />,
+          icon: <EuiIcon type="empty" size="m" aria-hidden={true} />,
           onClick: () => {
             showAssetModal();
             closePopover();

--- a/x-pack/platform/plugins/private/canvas/public/components/workpad_header/share_menu/share_menu.component.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/workpad_header/share_menu/share_menu.component.tsx
@@ -62,7 +62,7 @@ export const ShareMenu = ({ ReportingComponent, onExport }: Props) => {
     items: [
       {
         name: strings.getShareDownloadJSONTitle(),
-        icon: <EuiIcon type="exportAction" size="m" />,
+        icon: <EuiIcon type="exportAction" size="m" aria-hidden={true} />,
         onClick: () => {
           onExport('json');
           closePopover();

--- a/x-pack/platform/plugins/private/canvas/public/components/workpad_header/view_menu/view_menu.component.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/workpad_header/view_menu/view_menu.component.tsx
@@ -243,7 +243,7 @@ export const ViewMenu: FunctionComponent<Props> = ({
       },
       {
         name: strings.getFullscreenMenuItemLabel(),
-        icon: <EuiIcon type="fullScreen" size="m" />,
+        icon: <EuiIcon type="fullScreen" size="m" aria-hidden={true} />,
         className: CONTEXT_MENU_TOP_BORDER_CLASSNAME,
         onClick: () => {
           enterFullscreen();
@@ -266,7 +266,7 @@ export const ViewMenu: FunctionComponent<Props> = ({
       },
       {
         name: isWriteable ? strings.getHideEditModeLabel() : strings.getShowEditModeLabel(),
-        icon: <EuiIcon type={isWriteable ? 'eyeClosed' : 'eye'} size="m" />,
+        icon: <EuiIcon type={isWriteable ? 'eyeClosed' : 'eye'} size="m" aria-hidden={true} />,
         className: CONTEXT_MENU_TOP_BORDER_CLASSNAME,
         onClick: () => {
           toggleWriteable();

--- a/x-pack/platform/plugins/shared/maps/public/classes/layers/ems_vector_tile_layer/ems_vector_tile_layer.tsx
+++ b/x-pack/platform/plugins/shared/maps/public/classes/layers/ems_vector_tile_layer/ems_vector_tile_layer.tsx
@@ -497,7 +497,7 @@ export class EmsVectorTileLayer extends AbstractLayer {
 
   getLayerIcon(): LayerIcon {
     return {
-      icon: <EuiIcon size="m" type="grid" />,
+      icon: <EuiIcon size="m" type="grid" aria-hidden={true} />,
       tooltipContent: i18n.translate('xpack.maps.emsVectorTileLayer.layerDescription', {
         defaultMessage: `Reference map provided by Elastic Maps Service (EMS).`,
       }),

--- a/x-pack/platform/plugins/shared/maps/public/classes/layers/layer.tsx
+++ b/x-pack/platform/plugins/shared/maps/public/classes/layers/layer.tsx
@@ -289,7 +289,7 @@ export class AbstractLayer implements ILayer {
 
   getLayerIcon(isTocIcon: boolean): LayerIcon {
     return {
-      icon: <EuiIcon size="m" type={this.getLayerTypeIconName()} />,
+      icon: <EuiIcon size="m" type={this.getLayerTypeIconName()} aria-hidden={true} />,
     };
   }
 

--- a/x-pack/platform/plugins/shared/maps/public/classes/layers/layer_group/layer_group.tsx
+++ b/x-pack/platform/plugins/shared/maps/public/classes/layers/layer_group/layer_group.tsx
@@ -168,7 +168,7 @@ export class LayerGroup implements ILayer {
 
   getLayerIcon(isTocIcon: boolean): LayerIcon {
     return {
-      icon: <EuiIcon size="m" type="layers" />,
+      icon: <EuiIcon size="m" type="layers" aria-hidden={true} />,
       tooltipContent: '',
     };
   }

--- a/x-pack/platform/plugins/shared/maps/public/classes/layers/vector_layer/geojson_vector_layer/geojson_vector_layer.tsx
+++ b/x-pack/platform/plugins/shared/maps/public/classes/layers/vector_layer/geojson_vector_layer/geojson_vector_layer.tsx
@@ -122,7 +122,7 @@ export class GeoJsonVectorLayer extends AbstractVectorLayer {
       this.getSource().getSourceStatus(sourceDataRequest);
     return {
       icon: isDeprecated ? (
-        <EuiIcon type="warning" color="danger" />
+        <EuiIcon type="warning" color="danger" aria-hidden={true} />
       ) : (
         this.getCurrentStyle().getIcon(isTocIcon && areResultsTrimmed)
       ),

--- a/x-pack/platform/plugins/shared/maps/public/classes/layers/vector_layer/vector_layer.tsx
+++ b/x-pack/platform/plugins/shared/maps/public/classes/layers/vector_layer/vector_layer.tsx
@@ -135,7 +135,9 @@ export interface IVectorLayer extends ILayer {
   getMasks(): Mask[];
 }
 
-export const noResultsIcon = <EuiIcon size="m" color="subdued" type="minusInCircle" />;
+export const noResultsIcon = (
+  <EuiIcon size="m" color="subdued" type="minusInCircle" aria-hidden={true} />
+);
 export const NO_RESULTS_ICON_AND_TOOLTIPCONTENT = {
   icon: noResultsIcon,
   tooltipContent: i18n.translate('xpack.maps.vectorLayer.noResultsFoundTooltip', {

--- a/x-pack/platform/plugins/shared/maps/public/classes/sources/es_geo_grid_source/render_as_select/show_as_label.tsx
+++ b/x-pack/platform/plugins/shared/maps/public/classes/sources/es_geo_grid_source/render_as_select/show_as_label.tsx
@@ -57,7 +57,7 @@ export function ShowAsLabel(props: Props) {
     >
       <span tabIndex={0}>
         <FormattedMessage id="xpack.maps.source.esGeoGrid.showAsLabel" defaultMessage="Show as" />{' '}
-        <EuiIcon type="question" color="subdued" />
+        <EuiIcon type="question" color="subdued" aria-hidden={true} />
       </span>
     </EuiToolTip>
   );

--- a/x-pack/platform/plugins/shared/maps/public/classes/sources/es_geo_line_source/geo_line_form/group_by_label.tsx
+++ b/x-pack/platform/plugins/shared/maps/public/classes/sources/es_geo_line_source/geo_line_form/group_by_label.tsx
@@ -43,7 +43,7 @@ export function GroupByLabel() {
     >
       <span tabIndex={0}>
         <FormattedMessage id="xpack.maps.source.esGeoGrid.groupByLabel" defaultMessage="Group by" />{' '}
-        <EuiIcon type="question" color="subdued" />
+        <EuiIcon type="question" color="subdued" aria-hidden={true} />
       </span>
     </EuiToolTip>
   );

--- a/x-pack/platform/plugins/shared/maps/public/classes/styles/heatmap/heatmap_style.tsx
+++ b/x-pack/platform/plugins/shared/maps/public/classes/styles/heatmap/heatmap_style.tsx
@@ -66,7 +66,7 @@ export class HeatmapStyle implements IStyle {
   }
 
   getIcon() {
-    return <EuiIcon size="m" type="heatmap" />;
+    return <EuiIcon size="m" type="heatmap" aria-hidden={true} />;
   }
 
   setMBPaintProperties({

--- a/x-pack/platform/plugins/shared/maps/public/classes/styles/vector/components/symbol/custom_icon_modal.tsx
+++ b/x-pack/platform/plugins/shared/maps/public/classes/styles/vector/components/symbol/custom_icon_modal.tsx
@@ -55,7 +55,7 @@ const strings = {
         {i18n.translate('xpack.maps.customIconModal.cutoffRangeLabel', {
           defaultMessage: 'Alpha threshold',
         })}{' '}
-        <EuiIcon color="subdued" type="question" />
+        <EuiIcon color="subdued" type="question" aria-hidden={true} />
       </>
     </EuiToolTip>
   ),
@@ -91,7 +91,7 @@ const strings = {
         {i18n.translate('xpack.maps.customIconModal.radiusRangeLabel', {
           defaultMessage: 'Radius',
         })}{' '}
-        <EuiIcon color="subdued" type="question" />
+        <EuiIcon color="subdued" type="question" aria-hidden={true} />
       </>
     </EuiToolTip>
   ),

--- a/x-pack/platform/plugins/shared/maps/public/classes/styles/vector/components/symbol/icon_preview.tsx
+++ b/x-pack/platform/plugins/shared/maps/public/classes/styles/vector/components/symbol/icon_preview.tsx
@@ -182,7 +182,7 @@ export class IconPreview extends Component<Props, State> {
                     {i18n.translate('xpack.maps.customIconModal.elementPreviewTitle', {
                       defaultMessage: 'Render preview',
                     })}{' '}
-                    <EuiIcon color="subdued" type="question" />
+                    <EuiIcon color="subdued" type="question" aria-hidden={true} />
                   </>
                 </EuiToolTip>
               </h4>

--- a/x-pack/platform/plugins/shared/maps/public/components/action_select.tsx
+++ b/x-pack/platform/plugins/shared/maps/public/components/action_select.tsx
@@ -63,7 +63,9 @@ export class ActionSelect extends Component<Props, State> {
         value: action.id,
         inputDisplay: (
           <div>
-            {iconType ? <EuiIcon className="mapActionSelectIcon" type={iconType} /> : null}
+            {iconType ? (
+              <EuiIcon className="mapActionSelectIcon" type={iconType} aria-hidden={true} />
+            ) : null}
             {action.getDisplayName(actionContext)}
           </div>
         ),

--- a/x-pack/platform/plugins/shared/maps/public/connected_components/add_layer_panel/flyout_body/__snapshots__/layer_wizard_select.test.tsx.snap
+++ b/x-pack/platform/plugins/shared/maps/public/connected_components/add_layer_panel/flyout_body/__snapshots__/layer_wizard_select.test.tsx.snap
@@ -74,6 +74,7 @@ exports[`LayerWizardSelect Should render layer select after layer wizards are lo
         description="mock wizard with icon"
         icon={
           <EuiIcon
+            aria-hidden={true}
             size="l"
             type="logoObservability"
           />

--- a/x-pack/platform/plugins/shared/maps/public/connected_components/add_layer_panel/flyout_body/layer_wizard_select.tsx
+++ b/x-pack/platform/plugins/shared/maps/public/connected_components/add_layer_panel/flyout_body/layer_wizard_select.tsx
@@ -151,7 +151,9 @@ export class LayerWizardSelect extends Component<Props, State> {
           : true;
       })
       .map((layerWizard: LayerWizardWithMeta) => {
-        const icon = layerWizard.icon ? <EuiIcon type={layerWizard.icon} size="l" /> : undefined;
+        const icon = layerWizard.icon ? (
+          <EuiIcon type={layerWizard.icon} size="l" aria-hidden={true} />
+        ) : undefined;
 
         const onClick = () => {
           this.props.onSelect(layerWizard);

--- a/x-pack/platform/plugins/shared/maps/public/connected_components/edit_layer_panel/__snapshots__/edit_layer_panel.test.tsx.snap
+++ b/x-pack/platform/plugins/shared/maps/public/connected_components/edit_layer_panel/__snapshots__/edit_layer_panel.test.tsx.snap
@@ -33,6 +33,7 @@ exports[`EditLayerPanel is rendered 1`] = `
           grow={false}
         >
           <EuiIcon
+            aria-hidden={true}
             type="vector"
           />
         </EuiFlexItem>

--- a/x-pack/platform/plugins/shared/maps/public/connected_components/edit_layer_panel/edit_layer_panel.tsx
+++ b/x-pack/platform/plugins/shared/maps/public/connected_components/edit_layer_panel/edit_layer_panel.tsx
@@ -214,7 +214,10 @@ export class EditLayerPanel extends Component<Props, State> {
           <EuiFlyoutHeader hasBorder className="mapLayerPanel__header">
             <EuiFlexGroup responsive={false} alignItems="center" gutterSize="s">
               <EuiFlexItem grow={false}>
-                <EuiIcon type={this.props.selectedLayer.getLayerTypeIconName()} />
+                <EuiIcon
+                  type={this.props.selectedLayer.getLayerTypeIconName()}
+                  aria-hidden={true}
+                />
               </EuiFlexItem>
               <EuiFlexItem>
                 <EuiTitle size="s">

--- a/x-pack/platform/plugins/shared/maps/public/connected_components/mb_map/tooltip_control/features_tooltip/__snapshots__/feature_properties.test.tsx.snap
+++ b/x-pack/platform/plugins/shared/maps/public/connected_components/mb_map/tooltip_control/features_tooltip/__snapshots__/feature_properties.test.tsx.snap
@@ -84,6 +84,7 @@ exports[`FeatureProperties should show filter button for filterable properties 1
             title="Filter on property"
           >
             <EuiIcon
+              aria-hidden={true}
               type="filter"
             />
           </EuiButtonEmpty>
@@ -140,6 +141,7 @@ exports[`FeatureProperties should show view actions button when there are availa
               title="Filter on property"
             >
               <EuiIcon
+                aria-hidden={true}
                 type="filter"
               />
             </EuiButtonEmpty>
@@ -151,6 +153,7 @@ exports[`FeatureProperties should show view actions button when there are availa
               title="View filter actions"
             >
               <EuiIcon
+                aria-hidden={true}
                 type="arrowRight"
               />
             </EuiButtonEmpty>

--- a/x-pack/platform/plugins/shared/maps/public/connected_components/mb_map/tooltip_control/features_tooltip/feature_properties.tsx
+++ b/x-pack/platform/plugins/shared/maps/public/connected_components/mb_map/tooltip_control/features_tooltip/feature_properties.tsx
@@ -203,7 +203,7 @@ export class FeatureProperties extends Component<Props, State> {
           const name = action.getDisplayName(actionContext);
           return {
             name: name ? name : action.id,
-            icon: iconType ? <EuiIcon type={iconType} /> : undefined,
+            icon: iconType ? <EuiIcon type={iconType} aria-hidden={true} /> : undefined,
             onClick: async () => {
               this.props.onCloseTooltip();
 
@@ -265,7 +265,7 @@ export class FeatureProperties extends Component<Props, State> {
         })}
         data-test-subj="mapTooltipCreateFilterButton"
       >
-        <EuiIcon type="filter" />
+        <EuiIcon type="filter" aria-hidden={true} />
       </EuiButtonEmpty>
     );
 
@@ -295,7 +295,7 @@ export class FeatureProperties extends Component<Props, State> {
             })}
             data-test-subj="mapTooltipMoreActionsButton"
           >
-            <EuiIcon type="arrowRight" />
+            <EuiIcon type="arrowRight" aria-hidden={true} />
           </EuiButtonEmpty>
         </span>
       </td>

--- a/x-pack/platform/plugins/shared/maps/public/connected_components/right_side_controls/layer_control/expand_button.tsx
+++ b/x-pack/platform/plugins/shared/maps/public/connected_components/right_side_controls/layer_control/expand_button.tsx
@@ -34,7 +34,7 @@ export function ExpandButton({ hasErrorsOrWarnings, isLoading, onClick }: Props)
           <EuiLoadingSpinner />
         </div>
       ) : (
-        <EuiIcon type={hasErrorsOrWarnings ? 'warning' : 'menuLeft'} />
+        <EuiIcon type={hasErrorsOrWarnings ? 'warning' : 'menuLeft'} aria-hidden={true} />
       )}
     </EuiButtonEmpty>
   );

--- a/x-pack/platform/plugins/shared/maps/public/connected_components/right_side_controls/layer_control/layer_toc/toc_entry/__snapshots__/toc_entry.test.tsx.snap
+++ b/x-pack/platform/plugins/shared/maps/public/connected_components/right_side_controls/layer_control/layer_toc/toc_entry/__snapshots__/toc_entry.test.tsx.snap
@@ -74,6 +74,7 @@ exports[`TOCEntry is rendered 1`] = `
       title="Show layer details"
     >
       <EuiIcon
+        aria-hidden={true}
         className="eui-alignBaseline"
         size="s"
         type="arrowDown"
@@ -161,6 +162,7 @@ exports[`TOCEntry props Should indent child layer 1`] = `
       title="Show layer details"
     >
       <EuiIcon
+        aria-hidden={true}
         className="eui-alignBaseline"
         size="s"
         type="arrowDown"
@@ -244,6 +246,7 @@ exports[`TOCEntry props Should shade background when not selected layer 1`] = `
       title="Show layer details"
     >
       <EuiIcon
+        aria-hidden={true}
         className="eui-alignBaseline"
         size="s"
         type="arrowDown"
@@ -327,6 +330,7 @@ exports[`TOCEntry props Should shade background when selected layer 1`] = `
       title="Show layer details"
     >
       <EuiIcon
+        aria-hidden={true}
         className="eui-alignBaseline"
         size="s"
         type="arrowDown"
@@ -395,6 +399,7 @@ exports[`TOCEntry props isReadOnly 1`] = `
       title="Show layer details"
     >
       <EuiIcon
+        aria-hidden={true}
         className="eui-alignBaseline"
         size="s"
         type="arrowDown"
@@ -500,6 +505,7 @@ exports[`TOCEntry props should display layer details when isLegendDetailsOpen is
       title="Hide layer details"
     >
       <EuiIcon
+        aria-hidden={true}
         className="eui-alignBaseline"
         size="s"
         type="arrowUp"

--- a/x-pack/platform/plugins/shared/maps/public/connected_components/right_side_controls/layer_control/layer_toc/toc_entry/toc_entry.tsx
+++ b/x-pack/platform/plugins/shared/maps/public/connected_components/right_side_controls/layer_control/layer_toc/toc_entry/toc_entry.tsx
@@ -277,6 +277,7 @@ export class TOCEntry extends Component<Props, State> {
             className="eui-alignBaseline"
             type={isLegendDetailsOpen ? 'arrowUp' : 'arrowDown'}
             size="s"
+            aria-hidden={true}
           />
         </button>
       </span>
@@ -357,7 +358,7 @@ export class TOCEntry extends Component<Props, State> {
 
         {this.props.isFeatureEditorOpenForLayer && (
           <div className="mapTocEntry-isInEditingMode__row">
-            <EuiIcon type="vector" size="s" />
+            <EuiIcon type="vector" size="s" aria-hidden={true} />
             <span className="mapTocEntry-isInEditingMode__editFeatureText">
               <FormattedMessage
                 id="xpack.maps.layerControl.tocEntry.EditFeatures"

--- a/x-pack/platform/plugins/shared/maps/public/connected_components/right_side_controls/layer_control/layer_toc/toc_entry/toc_entry_actions_popover/__snapshots__/toc_entry_actions_popover.test.tsx.snap
+++ b/x-pack/platform/plugins/shared/maps/public/connected_components/right_side_controls/layer_control/layer_toc/toc_entry/toc_entry_actions_popover/__snapshots__/toc_entry_actions_popover.test.tsx.snap
@@ -57,6 +57,7 @@ exports[`TOCEntryActionsPopover is rendered 1`] = `
                 "data-test-subj": "fitToBoundsButton",
                 "disabled": false,
                 "icon": <EuiIcon
+                  aria-hidden={true}
                   size="m"
                   type="expand"
                 />,
@@ -67,6 +68,7 @@ exports[`TOCEntryActionsPopover is rendered 1`] = `
               Object {
                 "data-test-subj": "layerVisibilityToggleButton",
                 "icon": <EuiIcon
+                  aria-hidden={true}
                   size="m"
                   type="eyeClosed"
                 />,
@@ -78,6 +80,7 @@ exports[`TOCEntryActionsPopover is rendered 1`] = `
                 "data-test-subj": "layerSettingsButton",
                 "disabled": false,
                 "icon": <EuiIcon
+                  aria-hidden={true}
                   size="m"
                   type="pencil"
                 />,
@@ -88,6 +91,7 @@ exports[`TOCEntryActionsPopover is rendered 1`] = `
               Object {
                 "data-test-subj": "cloneLayerButton",
                 "icon": <EuiIcon
+                  aria-hidden={true}
                   size="m"
                   type="copy"
                 />,
@@ -98,6 +102,7 @@ exports[`TOCEntryActionsPopover is rendered 1`] = `
               Object {
                 "data-test-subj": "removeLayerButton",
                 "icon": <EuiIcon
+                  aria-hidden={true}
                   size="m"
                   type="trash"
                 />,
@@ -172,6 +177,7 @@ exports[`TOCEntryActionsPopover should disable Edit features when edit mode acti
                 "data-test-subj": "fitToBoundsButton",
                 "disabled": false,
                 "icon": <EuiIcon
+                  aria-hidden={true}
                   size="m"
                   type="expand"
                 />,
@@ -182,6 +188,7 @@ exports[`TOCEntryActionsPopover should disable Edit features when edit mode acti
               Object {
                 "data-test-subj": "layerVisibilityToggleButton",
                 "icon": <EuiIcon
+                  aria-hidden={true}
                   size="m"
                   type="eyeClosed"
                 />,
@@ -193,6 +200,7 @@ exports[`TOCEntryActionsPopover should disable Edit features when edit mode acti
                 "data-test-subj": "layerSettingsButton",
                 "disabled": false,
                 "icon": <EuiIcon
+                  aria-hidden={true}
                   size="m"
                   type="pencil"
                 />,
@@ -203,6 +211,7 @@ exports[`TOCEntryActionsPopover should disable Edit features when edit mode acti
               Object {
                 "data-test-subj": "cloneLayerButton",
                 "icon": <EuiIcon
+                  aria-hidden={true}
                   size="m"
                   type="copy"
                 />,
@@ -213,6 +222,7 @@ exports[`TOCEntryActionsPopover should disable Edit features when edit mode acti
               Object {
                 "data-test-subj": "removeLayerButton",
                 "icon": <EuiIcon
+                  aria-hidden={true}
                   size="m"
                   type="trash"
                 />,
@@ -287,6 +297,7 @@ exports[`TOCEntryActionsPopover should disable fit to data when supportsFitToBou
                 "data-test-subj": "fitToBoundsButton",
                 "disabled": true,
                 "icon": <EuiIcon
+                  aria-hidden={true}
                   size="m"
                   type="expand"
                 />,
@@ -297,6 +308,7 @@ exports[`TOCEntryActionsPopover should disable fit to data when supportsFitToBou
               Object {
                 "data-test-subj": "layerVisibilityToggleButton",
                 "icon": <EuiIcon
+                  aria-hidden={true}
                   size="m"
                   type="eyeClosed"
                 />,
@@ -308,6 +320,7 @@ exports[`TOCEntryActionsPopover should disable fit to data when supportsFitToBou
                 "data-test-subj": "layerSettingsButton",
                 "disabled": false,
                 "icon": <EuiIcon
+                  aria-hidden={true}
                   size="m"
                   type="pencil"
                 />,
@@ -318,6 +331,7 @@ exports[`TOCEntryActionsPopover should disable fit to data when supportsFitToBou
               Object {
                 "data-test-subj": "cloneLayerButton",
                 "icon": <EuiIcon
+                  aria-hidden={true}
                   size="m"
                   type="copy"
                 />,
@@ -328,6 +342,7 @@ exports[`TOCEntryActionsPopover should disable fit to data when supportsFitToBou
               Object {
                 "data-test-subj": "removeLayerButton",
                 "icon": <EuiIcon
+                  aria-hidden={true}
                   size="m"
                   type="trash"
                 />,
@@ -403,6 +418,7 @@ exports[`TOCEntryActionsPopover should have "show layer" action when layer is no
                 "data-test-subj": "fitToBoundsButton",
                 "disabled": false,
                 "icon": <EuiIcon
+                  aria-hidden={true}
                   size="m"
                   type="expand"
                 />,
@@ -413,6 +429,7 @@ exports[`TOCEntryActionsPopover should have "show layer" action when layer is no
               Object {
                 "data-test-subj": "layerVisibilityToggleButton",
                 "icon": <EuiIcon
+                  aria-hidden={true}
                   size="m"
                   type="eye"
                 />,
@@ -424,6 +441,7 @@ exports[`TOCEntryActionsPopover should have "show layer" action when layer is no
                 "data-test-subj": "layerSettingsButton",
                 "disabled": false,
                 "icon": <EuiIcon
+                  aria-hidden={true}
                   size="m"
                   type="pencil"
                 />,
@@ -434,6 +452,7 @@ exports[`TOCEntryActionsPopover should have "show layer" action when layer is no
               Object {
                 "data-test-subj": "cloneLayerButton",
                 "icon": <EuiIcon
+                  aria-hidden={true}
                   size="m"
                   type="copy"
                 />,
@@ -444,6 +463,7 @@ exports[`TOCEntryActionsPopover should have "show layer" action when layer is no
               Object {
                 "data-test-subj": "removeLayerButton",
                 "icon": <EuiIcon
+                  aria-hidden={true}
                   size="m"
                   type="trash"
                 />,
@@ -518,6 +538,7 @@ exports[`TOCEntryActionsPopover should not show edit actions in read only mode 1
                 "data-test-subj": "fitToBoundsButton",
                 "disabled": false,
                 "icon": <EuiIcon
+                  aria-hidden={true}
                   size="m"
                   type="expand"
                 />,
@@ -528,6 +549,7 @@ exports[`TOCEntryActionsPopover should not show edit actions in read only mode 1
               Object {
                 "data-test-subj": "layerVisibilityToggleButton",
                 "icon": <EuiIcon
+                  aria-hidden={true}
                   size="m"
                   type="eyeClosed"
                 />,
@@ -602,6 +624,7 @@ exports[`TOCEntryActionsPopover should show "show this layer only" action when t
                 "data-test-subj": "fitToBoundsButton",
                 "disabled": false,
                 "icon": <EuiIcon
+                  aria-hidden={true}
                   size="m"
                   type="expand"
                 />,
@@ -612,6 +635,7 @@ exports[`TOCEntryActionsPopover should show "show this layer only" action when t
               Object {
                 "data-test-subj": "layerVisibilityToggleButton",
                 "icon": <EuiIcon
+                  aria-hidden={true}
                   size="m"
                   type="eyeClosed"
                 />,
@@ -622,6 +646,7 @@ exports[`TOCEntryActionsPopover should show "show this layer only" action when t
               Object {
                 "data-test-subj": "showThisLayerOnlyButton",
                 "icon": <EuiIcon
+                  aria-hidden={true}
                   size="m"
                   type="eye"
                 />,
@@ -633,6 +658,7 @@ exports[`TOCEntryActionsPopover should show "show this layer only" action when t
                 "data-test-subj": "layerSettingsButton",
                 "disabled": false,
                 "icon": <EuiIcon
+                  aria-hidden={true}
                   size="m"
                   type="pencil"
                 />,
@@ -643,6 +669,7 @@ exports[`TOCEntryActionsPopover should show "show this layer only" action when t
               Object {
                 "data-test-subj": "cloneLayerButton",
                 "icon": <EuiIcon
+                  aria-hidden={true}
                   size="m"
                   type="copy"
                 />,
@@ -653,6 +680,7 @@ exports[`TOCEntryActionsPopover should show "show this layer only" action when t
               Object {
                 "data-test-subj": "removeLayerButton",
                 "icon": <EuiIcon
+                  aria-hidden={true}
                   size="m"
                   type="trash"
                 />,

--- a/x-pack/platform/plugins/shared/maps/public/connected_components/right_side_controls/layer_control/layer_toc/toc_entry/toc_entry_actions_popover/toc_entry_actions_popover.tsx
+++ b/x-pack/platform/plugins/shared/maps/public/connected_components/right_side_controls/layer_control/layer_toc/toc_entry/toc_entry_actions_popover/toc_entry_actions_popover.tsx
@@ -123,7 +123,7 @@ export class TOCEntryActionsPopover extends Component<Props, State> {
     const actionItems = [
       {
         name: FIT_TO_DATA_LABEL,
-        icon: <EuiIcon type="expand" size="m" />,
+        icon: <EuiIcon type="expand" size="m" aria-hidden={true} />,
         'data-test-subj': 'fitToBoundsButton',
         toolTipContent: this.props.supportsFitToBounds
           ? null
@@ -138,7 +138,13 @@ export class TOCEntryActionsPopover extends Component<Props, State> {
       },
       {
         name: getVisibilityToggleLabel(this.props.layer.isVisible()),
-        icon: <EuiIcon type={getVisibilityToggleIcon(this.props.layer.isVisible())} size="m" />,
+        icon: (
+          <EuiIcon
+            type={getVisibilityToggleIcon(this.props.layer.isVisible())}
+            size="m"
+            aria-hidden={true}
+          />
+        ),
         'data-test-subj': 'layerVisibilityToggleButton',
         toolTipContent: null,
         onClick: () => {
@@ -152,7 +158,7 @@ export class TOCEntryActionsPopover extends Component<Props, State> {
         name: i18n.translate('xpack.maps.layerTocActions.showThisLayerOnlyTitle', {
           defaultMessage: 'Show this layer only',
         }),
-        icon: <EuiIcon type="eye" size="m" />,
+        icon: <EuiIcon type="eye" size="m" aria-hidden={true} />,
         'data-test-subj': 'showThisLayerOnlyButton',
         toolTipContent: null,
         onClick: () => {
@@ -166,7 +172,7 @@ export class TOCEntryActionsPopover extends Component<Props, State> {
       actionItems.push({
         disabled: this.props.isEditButtonDisabled,
         name: EDIT_LAYER_SETTINGS_LABEL,
-        icon: <EuiIcon type="pencil" size="m" />,
+        icon: <EuiIcon type="pencil" size="m" aria-hidden={true} />,
         'data-test-subj': 'layerSettingsButton',
         toolTipContent: null,
         onClick: () => {
@@ -177,7 +183,7 @@ export class TOCEntryActionsPopover extends Component<Props, State> {
       if (this.state.supportsFeatureEditing) {
         actionItems.push({
           name: EDIT_FEATURES_LABEL,
-          icon: <EuiIcon type="vector" size="m" />,
+          icon: <EuiIcon type="vector" size="m" aria-hidden={true} />,
           'data-test-subj': 'editLayerButton',
           toolTipContent: this.state.isFeatureEditingEnabled
             ? null
@@ -206,7 +212,7 @@ export class TOCEntryActionsPopover extends Component<Props, State> {
         name: i18n.translate('xpack.maps.layerTocActions.cloneLayerTitle', {
           defaultMessage: 'Clone layer',
         }),
-        icon: <EuiIcon type="copy" size="m" />,
+        icon: <EuiIcon type="copy" size="m" aria-hidden={true} />,
         toolTipContent: null,
         'data-test-subj': 'cloneLayerButton',
         onClick: () => {
@@ -219,7 +225,7 @@ export class TOCEntryActionsPopover extends Component<Props, State> {
           name: i18n.translate('xpack.maps.layerTocActions.ungroupLayerTitle', {
             defaultMessage: 'Ungroup layers',
           }),
-          icon: <EuiIcon type="layers" size="m" />,
+          icon: <EuiIcon type="layers" size="m" aria-hidden={true} />,
           toolTipContent: null,
           'data-test-subj': 'removeLayerButton',
           onClick: () => {
@@ -233,7 +239,7 @@ export class TOCEntryActionsPopover extends Component<Props, State> {
         name: i18n.translate('xpack.maps.layerTocActions.removeLayerTitle', {
           defaultMessage: 'Remove layer',
         }),
-        icon: <EuiIcon type="trash" size="m" />,
+        icon: <EuiIcon type="trash" size="m" aria-hidden={true} />,
         toolTipContent: null,
         'data-test-subj': 'removeLayerButton',
         onClick: () => {

--- a/x-pack/platform/plugins/shared/maps/public/connected_components/right_side_controls/layer_control/layer_toc/toc_entry/toc_entry_button/toc_entry_button.tsx
+++ b/x-pack/platform/plugins/shared/maps/public/connected_components/right_side_controls/layer_control/layer_toc/toc_entry/toc_entry_button/toc_entry_button.tsx
@@ -79,6 +79,7 @@ export class TOCEntryButton extends Component<Props, State> {
           type="error"
           color="danger"
           data-test-subj={`layerTocErrorIcon${this.props.escapedDisplayName}`}
+          aria-hidden={true}
         />
       );
       return isLayerGroup(this.props.layer)
@@ -98,7 +99,7 @@ export class TOCEntryButton extends Component<Props, State> {
 
     if (!this.props.layer.isVisible()) {
       return {
-        icon: <EuiIcon size="m" type="eyeClosed" />,
+        icon: <EuiIcon size="m" type="eyeClosed" aria-hidden={true} />,
         tooltipContent: i18n.translate('xpack.maps.layer.layerHiddenTooltip', {
           defaultMessage: `Layer is hidden.`,
         }),
@@ -110,7 +111,7 @@ export class TOCEntryButton extends Component<Props, State> {
       const minZoom = this.props.layer.getMinZoom();
       const maxZoom = this.props.layer.getMaxZoom();
       return {
-        icon: <EuiIcon size="m" type="expand" />,
+        icon: <EuiIcon size="m" type="expand" aria-hidden={true} />,
         tooltipContent: i18n.translate('xpack.maps.layer.zoomFeedbackTooltip', {
           defaultMessage: `Layer is visible between zoom levels {minZoom} and {maxZoom}.`,
           values: { minZoom, maxZoom },
@@ -135,6 +136,7 @@ export class TOCEntryButton extends Component<Props, State> {
         type="warning"
         color="warning"
         data-test-subj={`layerTocWarningIcon${this.props.escapedDisplayName}`}
+        aria-hidden={true}
       />
     ) : (
       layerIcon
@@ -152,7 +154,7 @@ export class TOCEntryButton extends Component<Props, State> {
     const footnotes = [];
     if (this.props.isUsingSearch && this.props.layer.getQueryableIndexPatternIds().length) {
       footnotes.push({
-        icon: <EuiIcon color="subdued" type="filter" size="s" />,
+        icon: <EuiIcon color="subdued" type="filter" size="s" aria-hidden={true} />,
         message: i18n.translate('xpack.maps.layer.isUsingSearchMsg', {
           defaultMessage: 'Results narrowed by global search',
         }),
@@ -160,7 +162,7 @@ export class TOCEntryButton extends Component<Props, State> {
     }
     if (this.state.isFilteredByGlobalTime) {
       footnotes.push({
-        icon: <EuiIcon color="subdued" type="clock" size="s" />,
+        icon: <EuiIcon color="subdued" type="clock" size="s" aria-hidden={true} />,
         message: i18n.translate('xpack.maps.layer.isUsingTimeFilter', {
           defaultMessage: 'Results narrowed by global time',
         }),
@@ -172,7 +174,7 @@ export class TOCEntryButton extends Component<Props, State> {
       (source as IVectorSource).isFilterByMapBounds()
     ) {
       footnotes.push({
-        icon: <EuiIcon color="subdued" type="stop" size="s" />,
+        icon: <EuiIcon color="subdued" type="stop" size="s" aria-hidden={true} />,
         message: i18n.translate('xpack.maps.layer.isUsingBoundsFilter', {
           defaultMessage: 'Results narrowed by visible map area',
         }),

--- a/x-pack/platform/plugins/shared/maps/public/connected_components/toolbar_overlay/set_view_control/set_view_form.tsx
+++ b/x-pack/platform/plugins/shared/maps/public/connected_components/toolbar_overlay/set_view_control/set_view_form.tsx
@@ -82,7 +82,7 @@ export const SetViewForm = React.memo<SetViewFormProps>(({ settings, zoom, cente
         label={
           <EuiFlexGroup gutterSize="s">
             <EuiFlexItem grow={false}>
-              <EuiIcon type="controlsHorizontal" />
+              <EuiIcon type="controlsHorizontal" aria-hidden={true} />
             </EuiFlexItem>
             <EuiFlexItem>
               <FormattedMessage


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[a11y] Fix `@elastic/eui/icon-accessibility-rules` violations across 55 kibana-presentation files (#260694)](https://github.com/elastic/kibana/pull/260694)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Copilot","email":"198982749+Copilot@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-04-09T17:54:07Z","message":"[a11y] Fix `@elastic/eui/icon-accessibility-rules` violations across 55 kibana-presentation files (#260694)\n\nCloses: https://github.com/elastic/kibana/issues/260637\n\nResolves 88 ESLint violations of `@elastic/eui/icon-accessibility-rules`\nacross 55 files owned by `@elastic/kibana-presentation`. Every `EuiIcon`\nmust have either an accessible label (`aria-label`, `title`, or\n`aria-labelledby`) or be marked `aria-hidden={true}` if decorative.\n\n## Strategy\n\n**`aria-hidden={true}`** — applied to the majority of icons that are\ndecorative: drag handles inside labeled containers, icons in context\nmenu items (where the `name` field provides the label), icons alongside\nvisible text, and status icons inside tooltipped wrappers.\n\n```tsx\n// before\n<EuiIcon type=\"grabHorizontal\" />\n\n// after — parent div already carries aria-label\n<EuiIcon type=\"grabHorizontal\" aria-hidden={true} />\n```\n\n**`aria-label` via `i18n.translate()`** — applied to icons that\nindependently convey meaning or are interactive:\n\n| File | Icon | Fix |\n|---|---|---|\n| `presentation_panel_title.tsx` | `info` with `tabIndex={0}` |\n`aria-label=\"Description\"` |\n| `error_component.tsx` | `warning` with `onClick` | `aria-label=\"View\nerror details\"` |\n| `asset_picker.tsx` | `checkInCircleFilled` (selected state) |\n`aria-label=\"Selected\"` |\n| `saved_query_management_list.tsx` | `info` / `clock` metadata\nindicators | `aria-label=\"Has description\"` / `aria-label=\"Has time\nfilter\"` |\n\n**`aria-label` on parent + `aria-hidden` on icon** —\n`page_manager.component.tsx` had an unlabeled native `<button>` whose\nonly content was an icon; added `aria-label` to the button and\n`aria-hidden={true}` to the icon.\n\n---------\n\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: alexwizp <20072247+alexwizp@users.noreply.github.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Alexey Antonov <alexwizp@gmail.com>","sha":"2aae6fb02757a7df7fc19d02abe9f4c2833aa9b2","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Embedding","Project:Accessibility","release_note:skip","Feature:Drilldowns","backport missing","💝community","backport:version","v9.4.0","v9.3.3"],"title":"[a11y] Fix `@elastic/eui/icon-accessibility-rules` violations across 55 kibana-presentation files","number":260694,"url":"https://github.com/elastic/kibana/pull/260694","mergeCommit":{"message":"[a11y] Fix `@elastic/eui/icon-accessibility-rules` violations across 55 kibana-presentation files (#260694)\n\nCloses: https://github.com/elastic/kibana/issues/260637\n\nResolves 88 ESLint violations of `@elastic/eui/icon-accessibility-rules`\nacross 55 files owned by `@elastic/kibana-presentation`. Every `EuiIcon`\nmust have either an accessible label (`aria-label`, `title`, or\n`aria-labelledby`) or be marked `aria-hidden={true}` if decorative.\n\n## Strategy\n\n**`aria-hidden={true}`** — applied to the majority of icons that are\ndecorative: drag handles inside labeled containers, icons in context\nmenu items (where the `name` field provides the label), icons alongside\nvisible text, and status icons inside tooltipped wrappers.\n\n```tsx\n// before\n<EuiIcon type=\"grabHorizontal\" />\n\n// after — parent div already carries aria-label\n<EuiIcon type=\"grabHorizontal\" aria-hidden={true} />\n```\n\n**`aria-label` via `i18n.translate()`** — applied to icons that\nindependently convey meaning or are interactive:\n\n| File | Icon | Fix |\n|---|---|---|\n| `presentation_panel_title.tsx` | `info` with `tabIndex={0}` |\n`aria-label=\"Description\"` |\n| `error_component.tsx` | `warning` with `onClick` | `aria-label=\"View\nerror details\"` |\n| `asset_picker.tsx` | `checkInCircleFilled` (selected state) |\n`aria-label=\"Selected\"` |\n| `saved_query_management_list.tsx` | `info` / `clock` metadata\nindicators | `aria-label=\"Has description\"` / `aria-label=\"Has time\nfilter\"` |\n\n**`aria-label` on parent + `aria-hidden` on icon** —\n`page_manager.component.tsx` had an unlabeled native `<button>` whose\nonly content was an icon; added `aria-label` to the button and\n`aria-hidden={true}` to the icon.\n\n---------\n\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: alexwizp <20072247+alexwizp@users.noreply.github.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Alexey Antonov <alexwizp@gmail.com>","sha":"2aae6fb02757a7df7fc19d02abe9f4c2833aa9b2"}},"sourceBranch":"main","suggestedTargetBranches":["9.3"],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/260694","number":260694,"mergeCommit":{"message":"[a11y] Fix `@elastic/eui/icon-accessibility-rules` violations across 55 kibana-presentation files (#260694)\n\nCloses: https://github.com/elastic/kibana/issues/260637\n\nResolves 88 ESLint violations of `@elastic/eui/icon-accessibility-rules`\nacross 55 files owned by `@elastic/kibana-presentation`. Every `EuiIcon`\nmust have either an accessible label (`aria-label`, `title`, or\n`aria-labelledby`) or be marked `aria-hidden={true}` if decorative.\n\n## Strategy\n\n**`aria-hidden={true}`** — applied to the majority of icons that are\ndecorative: drag handles inside labeled containers, icons in context\nmenu items (where the `name` field provides the label), icons alongside\nvisible text, and status icons inside tooltipped wrappers.\n\n```tsx\n// before\n<EuiIcon type=\"grabHorizontal\" />\n\n// after — parent div already carries aria-label\n<EuiIcon type=\"grabHorizontal\" aria-hidden={true} />\n```\n\n**`aria-label` via `i18n.translate()`** — applied to icons that\nindependently convey meaning or are interactive:\n\n| File | Icon | Fix |\n|---|---|---|\n| `presentation_panel_title.tsx` | `info` with `tabIndex={0}` |\n`aria-label=\"Description\"` |\n| `error_component.tsx` | `warning` with `onClick` | `aria-label=\"View\nerror details\"` |\n| `asset_picker.tsx` | `checkInCircleFilled` (selected state) |\n`aria-label=\"Selected\"` |\n| `saved_query_management_list.tsx` | `info` / `clock` metadata\nindicators | `aria-label=\"Has description\"` / `aria-label=\"Has time\nfilter\"` |\n\n**`aria-label` on parent + `aria-hidden` on icon** —\n`page_manager.component.tsx` had an unlabeled native `<button>` whose\nonly content was an icon; added `aria-label` to the button and\n`aria-hidden={true}` to the icon.\n\n---------\n\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: alexwizp <20072247+alexwizp@users.noreply.github.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Alexey Antonov <alexwizp@gmail.com>","sha":"2aae6fb02757a7df7fc19d02abe9f4c2833aa9b2"}},{"branch":"9.3","label":"v9.3.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->