### PR TITLE
[9.3] [Fleet] Fix screen reader announcement for actions buttons across Fleet tables (#258559)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/components/actions_menu.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/components/actions_menu.tsx
@@ -7,6 +7,7 @@
 
 import React, { memo, useState, useMemo, useCallback } from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { i18n } from '@kbn/i18n';
 import { EuiContextMenuItem, EuiPortal } from '@elastic/eui';
 
 import type { AgentPolicy } from '../../../types';
@@ -86,6 +87,13 @@ export const AgentPolicyActionMenu = memo<{
         return () => setIsEnrollmentFlyoutOpen(false);
       }
     }, [onCancelEnrollment, setIsEnrollmentFlyoutOpen]);
+
+    const actionsAriaLabel = fullButton
+      ? undefined
+      : i18n.translate('xpack.fleet.agentPolicyActionMenu.actionsAriaLabel', {
+          defaultMessage: 'Actions for {policyName}',
+          values: { policyName: agentPolicy.name },
+        });
 
     return (
       <AgentPolicyCopyProvider>
@@ -349,6 +357,7 @@ export const AgentPolicyActionMenu = memo<{
               <ContextMenuActions
                 isOpen={isContextMenuOpen}
                 onChange={onContextMenuChange}
+                aria-label={actionsAriaLabel}
                 button={
                   fullButton
                     ? {

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/data_stream/list_page/components/data_stream_row_actions.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/data_stream/list_page/components/data_stream_row_actions.tsx
@@ -19,6 +19,11 @@ export const DataStreamRowActions = memo<{ datastream: DataStream }>(({ datastre
   const { dashboards } = datastream;
   const dashboardLocator = useDashboardLocator();
 
+  const actionsAriaLabel = i18n.translate('xpack.fleet.dataStreamList.rowActionsAriaLabel', {
+    defaultMessage: 'Actions for {dataset}',
+    values: { dataset: datastream.dataset },
+  });
+
   const actionNameSingular = (
     <FormattedMessage
       id="xpack.fleet.dataStreamList.viewDashboardActionText"
@@ -58,7 +63,7 @@ export const DataStreamRowActions = memo<{ datastream: DataStream }>(({ datastre
         ],
       },
     ];
-    return <ContextMenuActions panels={apmItem} />;
+    return <ContextMenuActions panels={apmItem} aria-label={actionsAriaLabel} />;
   }
 
   if (!dashboards || dashboards.length === 0) {
@@ -74,7 +79,7 @@ export const DataStreamRowActions = memo<{ datastream: DataStream }>(({ datastre
         ],
       },
     ];
-    return <ContextMenuActions panels={disabledItems} />;
+    return <ContextMenuActions panels={disabledItems} aria-label={actionsAriaLabel} />;
   }
 
   if (dashboards.length === 1) {
@@ -91,7 +96,7 @@ export const DataStreamRowActions = memo<{ datastream: DataStream }>(({ datastre
         ],
       },
     ];
-    return <ContextMenuActions panels={panelItems} />;
+    return <ContextMenuActions panels={panelItems} aria-label={actionsAriaLabel} />;
   }
 
   const panelItems = [
@@ -119,5 +124,5 @@ export const DataStreamRowActions = memo<{ datastream: DataStream }>(({ datastre
     },
   ];
 
-  return <ContextMenuActions panels={panelItems} />;
+  return <ContextMenuActions panels={panelItems} aria-label={actionsAriaLabel} />;
 });

--- a/x-pack/platform/plugins/shared/fleet/public/components/context_menu_actions.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/components/context_menu_actions.tsx
@@ -27,6 +27,7 @@ type Props = {
   isOpen?: boolean;
   isManaged?: boolean;
   onChange?: (isOpen: boolean) => void;
+  'aria-label'?: string;
 } & (
   | {
       items: EuiContextMenuPanelProps['items'];
@@ -36,64 +37,69 @@ type Props = {
     }
 );
 
-export const ContextMenuActions = React.memo<Props>(({ button, onChange, isOpen, ...props }) => {
-  const [isOpenState, setIsOpenState] = useState(false);
-  const handleCloseMenu = useCallback(() => {
-    if (onChange) {
-      onChange(false);
-    } else {
-      setIsOpenState(false);
-    }
-  }, [setIsOpenState, onChange]);
-  const handleToggleMenu = useCallback(() => {
-    if (onChange) {
-      onChange(!isOpen);
-    } else {
-      setIsOpenState(!isOpenState);
-    }
-  }, [isOpenState, onChange, isOpen]);
-
-  const actionButton = button ? (
-    <EuiButton {...button.props} onClick={handleToggleMenu} isDisabled={props.isManaged}>
-      {button.children}
-    </EuiButton>
-  ) : (
-    <EuiButtonIcon
-      isDisabled={props.isManaged}
-      iconType="boxesHorizontal"
-      onClick={handleToggleMenu}
-      aria-label={i18n.translate('xpack.fleet.genericActionsMenuText', {
-        defaultMessage: 'Open',
-      })}
-      data-test-subj="agentActionsBtn"
-    />
-  );
-
-  return (
-    <EuiPopover
-      anchorPosition="downRight"
-      panelPaddingSize="none"
-      button={
-        props.isManaged ? (
-          <EuiToolTip
-            title={i18n.translate('xpack.fleet.externallyManagedLabel', {
-              defaultMessage: 'This is externally managed integration policy.',
-            })}
-          >
-            {actionButton}
-          </EuiToolTip>
-        ) : (
-          actionButton
-        )
+export const ContextMenuActions = React.memo<Props>(
+  ({ button, onChange, isOpen, 'aria-label': ariaLabel, ...props }) => {
+    const [isOpenState, setIsOpenState] = useState(false);
+    const handleCloseMenu = useCallback(() => {
+      if (onChange) {
+        onChange(false);
+      } else {
+        setIsOpenState(false);
       }
-      isOpen={isOpen === undefined ? isOpenState : isOpen}
-      closePopover={handleCloseMenu}
-    >
-      {'items' in props ? (
-        <EuiContextMenuPanel items={props.items} />
-      ) : (
-        <EuiContextMenu panels={props.panels} initialPanelId={0} />
-      )}
-    </EuiPopover>
-  );
-});
+    }, [setIsOpenState, onChange]);
+    const handleToggleMenu = useCallback(() => {
+      if (onChange) {
+        onChange(!isOpen);
+      } else {
+        setIsOpenState(!isOpenState);
+      }
+    }, [isOpenState, onChange, isOpen]);
+
+    const actionButton = button ? (
+      <EuiButton {...button.props} onClick={handleToggleMenu} isDisabled={props.isManaged}>
+        {button.children}
+      </EuiButton>
+    ) : (
+      <EuiButtonIcon
+        isDisabled={props.isManaged}
+        iconType="boxesHorizontal"
+        onClick={handleToggleMenu}
+        aria-label={
+          ariaLabel ??
+          i18n.translate('xpack.fleet.genericActionsMenuText', {
+            defaultMessage: 'Actions',
+          })
+        }
+        data-test-subj="agentActionsBtn"
+      />
+    );
+
+    return (
+      <EuiPopover
+        anchorPosition="downRight"
+        panelPaddingSize="none"
+        button={
+          props.isManaged ? (
+            <EuiToolTip
+              title={i18n.translate('xpack.fleet.externallyManagedLabel', {
+                defaultMessage: 'This is externally managed integration policy.',
+              })}
+            >
+              {actionButton}
+            </EuiToolTip>
+          ) : (
+            actionButton
+          )
+        }
+        isOpen={isOpen === undefined ? isOpenState : isOpen}
+        closePopover={handleCloseMenu}
+      >
+        {'items' in props ? (
+          <EuiContextMenuPanel items={props.items} />
+        ) : (
+          <EuiContextMenu panels={props.panels} initialPanelId={0} />
+        )}
+      </EuiPopover>
+    );
+  }
+);

--- a/x-pack/platform/plugins/shared/fleet/public/components/package_policy_actions_menu.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/components/package_policy_actions_menu.tsx
@@ -8,6 +8,7 @@
 import React, { useMemo, useState } from 'react';
 import { EuiContextMenuItem, EuiPortal } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { i18n } from '@kbn/i18n';
 
 import type { AgentPolicy, InMemoryPackagePolicy } from '../types';
 import { useAgentPolicyRefresh, useAuthz, useLink } from '../hooks';
@@ -191,6 +192,10 @@ export const PackagePolicyActionsMenu: React.FunctionComponent<{
         isOpen={isActionsMenuOpen}
         items={menuItems}
         onChange={(open) => setIsActionsMenuOpen(open)}
+        aria-label={i18n.translate('xpack.fleet.packagePolicyActionsMenu.actionsAriaLabel', {
+          defaultMessage: 'Actions for {policyName}',
+          values: { policyName: packagePolicy.name },
+        })}
       />
     </>
   );


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Fleet] Fix screen reader announcement for actions buttons across Fleet tables (#258559)](https://github.com/elastic/kibana/pull/258559)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Copilot","email":"198982749+Copilot@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-04-14T21:20:32Z","message":"[Fleet] Fix screen reader announcement for actions buttons across Fleet tables (#258559)","sha":"3303bb4d2182153a16be2632d0c012031ca0271b","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Project:Accessibility","release_note:skip","💝community","Team:Fleet","backport:version","v9.4.0","a11y:agent-pr","v9.5.0","v9.3.4"],"title":"[Fleet] Fix screen reader announcement for actions buttons across Fleet tables","number":258559,"url":"https://github.com/elastic/kibana/pull/258559","mergeCommit":{"message":"[Fleet] Fix screen reader announcement for actions buttons across Fleet tables (#258559)","sha":"3303bb4d2182153a16be2632d0c012031ca0271b"}},"sourceBranch":"main","suggestedTargetBranches":["9.3"],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/263207","number":263207,"state":"MERGED","mergeCommit":{"sha":"8ef171d45c78eb301827446fd3cdc189f586c132","message":"[9.4] [Fleet] Fix screen reader announcement for actions buttons across Fleet tables (#258559) (#263207)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.4`:\n- [[Fleet] Fix screen reader announcement for actions buttons across\nFleet tables (#258559)](https://github.com/elastic/kibana/pull/258559)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Copilot <198982749+Copilot@users.noreply.github.com>"}},{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/258559","number":258559,"mergeCommit":{"message":"[Fleet] Fix screen reader announcement for actions buttons across Fleet tables (#258559)","sha":"3303bb4d2182153a16be2632d0c012031ca0271b"}},{"branch":"9.3","label":"v9.3.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->