### PR TITLE
[9.3] [EDR Workflows] Restore CrowdStrike runscript output display (#262470)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_response_actions_list/components/action_response_outputs.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_response_actions_list/components/action_response_outputs.test.tsx
@@ -1,0 +1,108 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EndpointActionGenerator } from '../../../../../common/endpoint/data_generators/endpoint_action_generator';
+import type { AppContextTestRender } from '../../../../common/mock/endpoint';
+import { createAppRootMockRenderer } from '../../../../common/mock/endpoint';
+import type {
+  ActionDetails,
+  ResponseActionRunScriptOutputContent,
+} from '../../../../../common/endpoint/types';
+import { ActionResponseOutputs } from './action_response_outputs';
+
+import { useUserPrivileges as _useUserPrivileges } from '../../../../common/components/user_privileges';
+import { responseActionsHttpMocks } from '../../../mocks/response_actions_http_mocks';
+
+jest.mock('../../../../common/components/user_privileges');
+
+const useUserPrivilegesMock = _useUserPrivileges as jest.Mock;
+
+describe('ActionResponseOutputs component', () => {
+  let appTestContext: AppContextTestRender;
+  let renderResult: ReturnType<AppContextTestRender['render']>;
+  let setUserPrivileges: ReturnType<AppContextTestRender['getUserPrivilegesMockSetter']>;
+
+  beforeEach(() => {
+    appTestContext = createAppRootMockRenderer();
+    setUserPrivileges = appTestContext.getUserPrivilegesMockSetter(useUserPrivilegesMock);
+    setUserPrivileges.set({
+      canWriteFileOperations: true,
+      canReadActionsLogManagement: true,
+      canAccessEndpointActionsLogManagement: true,
+      canWriteExecuteOperations: true,
+    });
+
+    responseActionsHttpMocks(appTestContext.coreStart.http);
+  });
+
+  afterEach(() => {
+    setUserPrivileges.reset();
+  });
+
+  describe('CrowdStrike runscript actions', () => {
+    it('should render runscript output instead of generic "submitted successfully" message', () => {
+      const action: ActionDetails<ResponseActionRunScriptOutputContent> =
+        new EndpointActionGenerator('seed').generateActionDetails({
+          agents: ['agent-a'],
+          agentType: 'crowdstrike',
+          command: 'runscript',
+          wasSuccessful: true,
+          isCompleted: true,
+        });
+      action.outputs = {
+        'agent-a': {
+          type: 'text',
+          content: {
+            code: '200',
+            stdout: 'crowdstrike script output',
+            stderr: '',
+          },
+        },
+      };
+
+      renderResult = appTestContext.render(
+        <ActionResponseOutputs action={action} data-test-subj="test" />
+      );
+
+      // Should NOT show the generic "submitted successfully" message for runscript
+      expect(renderResult.container.textContent).not.toContain('submitted successfully');
+    });
+
+    it('should show "submitted successfully" for CrowdStrike isolate actions', () => {
+      const action = new EndpointActionGenerator('seed').generateActionDetails({
+        agents: ['agent-a'],
+        agentType: 'crowdstrike',
+        command: 'isolate',
+        wasSuccessful: true,
+        isCompleted: true,
+      });
+
+      renderResult = appTestContext.render(
+        <ActionResponseOutputs action={action} data-test-subj="test" />
+      );
+
+      expect(renderResult.container.textContent).toContain('submitted successfully');
+    });
+
+    it('should show "submitted successfully" for CrowdStrike release actions', () => {
+      const action = new EndpointActionGenerator('seed').generateActionDetails({
+        agents: ['agent-a'],
+        agentType: 'crowdstrike',
+        command: 'unisolate',
+        wasSuccessful: true,
+        isCompleted: true,
+      });
+
+      renderResult = appTestContext.render(
+        <ActionResponseOutputs action={action} data-test-subj="test" />
+      );
+
+      expect(renderResult.container.textContent).toContain('submitted successfully');
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_response_actions_list/components/action_response_outputs.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_response_actions_list/components/action_response_outputs.tsx
@@ -128,6 +128,7 @@ export const ActionResponseOutputs = memo<ActionResponseOutputsProps>(
                 hostOutput = (
                   <RunscriptActionResult
                     action={action}
+                    agentId={agentId}
                     data-test-subj={getTestId('actionsLogTray')}
                     textSize="xs"
                   />
@@ -145,8 +146,8 @@ export const ActionResponseOutputs = memo<ActionResponseOutputsProps>(
                 );
               }
 
-              // CrowdStrike Isolate/Release actions
-              if (action.agentType === 'crowdstrike') {
+              // CrowdStrike Isolate/Release actions (runscript has its own output via RunscriptActionResult)
+              if (action.agentType === 'crowdstrike' && !isRunScriptAction(action)) {
                 hostOutput = <>{OUTPUT_MESSAGES.submittedSuccessfully(consoleCommandName)}</>;
               }
             }

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/runscript_action_result/crowdstrike_runscript_output.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/runscript_action_result/crowdstrike_runscript_output.test.tsx
@@ -1,0 +1,133 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EndpointActionGenerator } from '../../../../common/endpoint/data_generators/endpoint_action_generator';
+import type { AppContextTestRender } from '../../../common/mock/endpoint';
+import { createAppRootMockRenderer } from '../../../common/mock/endpoint';
+import type {
+  ActionDetails,
+  ResponseActionRunScriptOutputContent,
+} from '../../../../common/endpoint/types';
+import { CrowdstrikeRunscriptOutput } from './crowdstrike_runscript_output';
+
+describe('CrowdstrikeRunscriptOutput component', () => {
+  let appTestContext: AppContextTestRender;
+  let renderResult: ReturnType<AppContextTestRender['render']>;
+  let render: () => ReturnType<AppContextTestRender['render']>;
+  let action: ActionDetails<ResponseActionRunScriptOutputContent>;
+
+  beforeEach(() => {
+    action = new EndpointActionGenerator('seed').generateActionDetails({
+      agents: ['agent-a'],
+      agentType: 'crowdstrike',
+      command: 'runscript',
+    });
+
+    appTestContext = createAppRootMockRenderer();
+
+    render = () => {
+      renderResult = appTestContext.render(
+        <CrowdstrikeRunscriptOutput action={action} agentId={'agent-a'} data-test-subj="test" />
+      );
+
+      return renderResult;
+    };
+  });
+
+  it('should display stdout output when present', () => {
+    action.outputs = {
+      'agent-a': {
+        content: {
+          code: '200',
+          stdout: 'script output here',
+          stderr: '',
+        },
+        type: 'text',
+      },
+    };
+
+    render();
+
+    expect(renderResult.getByTestId('test-stdout')).toBeInTheDocument();
+    expect(renderResult.getByTestId('test-stdout-title')).toHaveTextContent('Runscript output');
+    expect(renderResult.queryByTestId('test-stderr')).toBeNull();
+  });
+
+  it('should display stderr output when present', () => {
+    action.outputs = {
+      'agent-a': {
+        content: {
+          code: '200',
+          stdout: '',
+          stderr: 'error output here',
+        },
+        type: 'text',
+      },
+    };
+
+    render();
+
+    expect(renderResult.getByTestId('test-stderr')).toBeInTheDocument();
+    expect(renderResult.getByTestId('test-stderr-title')).toHaveTextContent('Runscript error');
+    expect(renderResult.queryByTestId('test-stdout')).toBeNull();
+  });
+
+  it('should display both stdout and stderr when both are present', () => {
+    action.outputs = {
+      'agent-a': {
+        content: {
+          code: '200',
+          stdout: 'standard output',
+          stderr: 'error output',
+        },
+        type: 'text',
+      },
+    };
+
+    render();
+
+    expect(renderResult.getByTestId('test-stderr')).toBeInTheDocument();
+    expect(renderResult.getByTestId('test-stdout')).toBeInTheDocument();
+  });
+
+  it('should display no-output message when output content is missing', () => {
+    action.outputs = {};
+    render();
+
+    const noOutput = renderResult.getByTestId('test-no-output');
+    expect(noOutput).toBeInTheDocument();
+    expect(noOutput).toHaveTextContent('No output was returned for this runscript action.');
+  });
+
+  it('should not reference file download in no-output message', () => {
+    action.outputs = {};
+    render();
+
+    const noOutput = renderResult.getByTestId('test-no-output');
+    expect(noOutput.textContent).not.toContain('download');
+  });
+
+  it('should render nothing visible when stdout and stderr are both empty', () => {
+    action.outputs = {
+      'agent-a': {
+        content: {
+          code: '200',
+          stdout: '',
+          stderr: '',
+        },
+        type: 'text',
+      },
+    };
+
+    render();
+
+    expect(renderResult.queryByTestId('test-stdout')).toBeNull();
+    expect(renderResult.queryByTestId('test-stderr')).toBeNull();
+    expect(renderResult.queryByTestId('test-no-output')).toBeNull();
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/runscript_action_result/crowdstrike_runscript_output.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/runscript_action_result/crowdstrike_runscript_output.tsx
@@ -1,0 +1,145 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { memo, useMemo } from 'react';
+import {
+  EuiAccordion,
+  EuiFlexItem,
+  EuiSpacer,
+  EuiText,
+  useGeneratedHtmlId,
+  type EuiTextProps,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { css } from '@emotion/react';
+
+import { useTestIdGenerator } from '../../hooks/use_test_id_generator';
+import type {
+  ActionDetails,
+  MaybeImmutable,
+  ResponseActionRunScriptOutputContent,
+} from '../../../../common/endpoint/types';
+
+const ACCORDION_BUTTON_TEXT = Object.freeze({
+  output: i18n.translate('xpack.securitySolution.crowdstrikeRunscriptAccordion.outputButtonText', {
+    defaultMessage: 'Runscript output',
+  }),
+  error: i18n.translate('xpack.securitySolution.crowdstrikeRunscriptAccordion.errorButtonText', {
+    defaultMessage: 'Runscript error',
+  }),
+});
+
+const NO_OUTPUT_MESSAGE = i18n.translate(
+  'xpack.securitySolution.crowdstrikeRunscriptAccordion.noOutputMessage',
+  {
+    defaultMessage: 'No output was returned for this runscript action.',
+  }
+);
+
+const styledTextCss = css`
+  white-space: pre-wrap;
+  line-break: anywhere;
+`;
+
+interface CrowdstrikeRunscriptAccordionProps {
+  content?: string;
+  initialIsOpen?: boolean;
+  textSize?: Exclude<EuiTextProps['size'], 'm' | 'relative'>;
+  type: 'error' | 'output';
+  'data-test-subj'?: string;
+}
+
+const CrowdstrikeRunscriptAccordion = memo<CrowdstrikeRunscriptAccordionProps>(
+  ({ content, initialIsOpen = false, textSize = 'xs', type, 'data-test-subj': dataTestSubj }) => {
+    const getTestId = useTestIdGenerator(dataTestSubj);
+    const id = useGeneratedHtmlId({
+      prefix: 'crowdstrikeRunscriptAccordion',
+      suffix: type,
+    });
+
+    const accordionButtonContent = useMemo(
+      () => (
+        <EuiText size={textSize} data-test-subj={getTestId('title')}>
+          {ACCORDION_BUTTON_TEXT[type]}
+        </EuiText>
+      ),
+      [getTestId, textSize, type]
+    );
+
+    return (
+      <EuiAccordion
+        id={id}
+        initialIsOpen={initialIsOpen}
+        buttonContent={accordionButtonContent}
+        paddingSize="s"
+        data-test-subj={dataTestSubj}
+      >
+        <EuiText size={textSize} css={styledTextCss}>
+          <p>{content}</p>
+        </EuiText>
+      </EuiAccordion>
+    );
+  }
+);
+CrowdstrikeRunscriptAccordion.displayName = 'CrowdstrikeRunscriptAccordion';
+
+export interface CrowdstrikeRunscriptOutputProps {
+  action: MaybeImmutable<ActionDetails<ResponseActionRunScriptOutputContent>>;
+  agentId: string;
+  'data-test-subj'?: string;
+  textSize?: Exclude<EuiTextProps['size'], 'm' | 'relative'>;
+}
+
+export const CrowdstrikeRunscriptOutput = memo<CrowdstrikeRunscriptOutputProps>(
+  ({ action, agentId, 'data-test-subj': dataTestSubj, textSize = 'xs' }) => {
+    const outputContent = useMemo(
+      () => action.outputs && action.outputs[agentId] && action.outputs[agentId].content,
+      [action.outputs, agentId]
+    );
+
+    if (!outputContent) {
+      return (
+        <EuiFlexItem>
+          <EuiText size={textSize} data-test-subj={`${dataTestSubj}-no-output`}>
+            {NO_OUTPUT_MESSAGE}
+          </EuiText>
+        </EuiFlexItem>
+      );
+    }
+
+    const { stderr, stdout } = outputContent;
+    const hasErrorOutput = stderr && stderr.length > 0;
+    const hasStdOutput = stdout && stdout.length > 0;
+
+    return (
+      <EuiFlexItem>
+        {hasErrorOutput && (
+          <CrowdstrikeRunscriptAccordion
+            content={stderr}
+            data-test-subj={`${dataTestSubj}-stderr`}
+            initialIsOpen
+            textSize={textSize}
+            type="error"
+          />
+        )}
+        {hasStdOutput && (
+          <>
+            {hasErrorOutput && <EuiSpacer size="m" />}
+            <CrowdstrikeRunscriptAccordion
+              content={stdout}
+              data-test-subj={`${dataTestSubj}-stdout`}
+              initialIsOpen
+              textSize={textSize}
+              type="output"
+            />
+          </>
+        )}
+      </EuiFlexItem>
+    );
+  }
+);
+CrowdstrikeRunscriptOutput.displayName = 'CrowdstrikeRunscriptOutput';

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/runscript_action_result/runscript_action_result.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/runscript_action_result/runscript_action_result.test.tsx
@@ -67,8 +67,53 @@ describe('#RunscriptActionResult component', () => {
     setUserPrivileges.reset();
   });
 
-  it('should display file link for `microsoft_defender_endpoint` agent type', async () => {
+  it('should display no output if sentinel_one agent type does not support outputs', () => {
+    action.agentType = 'sentinel_one';
     render();
+    expect(renderResult.queryByTestId('test-output')).toBeNull();
+  });
+
+  it.each(['crowdstrike', 'microsoft_defender_endpoint', 'sentinel_one'] as const)(
+    'should display no download link for %s when user has no authz',
+    (agentType) => {
+      setUserPrivileges.set({ canWriteExecuteOperations: false });
+      action.agentType = agentType;
+      render();
+
+      expect(renderResult.queryByTestId('test-download')).toBeNull();
+    }
+  );
+
+  describe('for CrowdStrike', () => {
+    beforeEach(() => {
+      action.agentType = 'crowdstrike';
+    });
+
+    it('should display output content when stdout is present', () => {
+      action.outputs = {
+        'agent-a': {
+          type: 'text',
+          content: {
+            code: '200',
+            stdout: 'crowdstrike script output',
+            stderr: '',
+          },
+        },
+      };
+      render();
+
+      expect(renderResult.getByTestId('test-output-stdout')).toBeInTheDocument();
+    });
+
+    it('should not display file download link', () => {
+      render();
+      expect(renderResult.queryByTestId('test-download')).toBeNull();
+    });
+  });
+
+  describe('for Microsoft Defender Endpoint', () => {
+    it('should display file link for `microsoft_defender_endpoint` agent type', async () => {
+      render();
 
     await waitFor(
       () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/runscript_action_result/runscript_action_result.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/runscript_action_result/runscript_action_result.test.tsx
@@ -5,13 +5,6 @@
  * 2.0.
  */
 
-/*
- * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0; you may not use this file except in compliance with the Elastic License
- * 2.0.
- */
-
 import React from 'react';
 import { EndpointActionGenerator } from '../../../../common/endpoint/data_generators/endpoint_action_generator';
 import type { AppContextTestRender } from '../../../common/mock/endpoint';
@@ -115,50 +108,31 @@ describe('#RunscriptActionResult component', () => {
     it('should display file link for `microsoft_defender_endpoint` agent type', async () => {
       render();
 
-    await waitFor(
-      () => {
-        expect(renderResult.getByTestId('test-download')).toBeTruthy();
-      },
-      { timeout: 5000 }
-    );
-  }, 10000);
-
-  it('should display output content for `microsoft_defender_endpoint` agent', () => {
-    action.outputs = {
-      'agent-a': {
-        type: 'json',
-        content: {
-          code: '0',
-          stdout: 'script output',
-          stderr: '',
+      await waitFor(
+        () => {
+          expect(renderResult.getByTestId('test-download')).toBeTruthy();
         },
-      },
-    };
+        { timeout: 5000 }
+      );
+    }, 10000);
 
-    render();
+    it('should display output content for `microsoft_defender_endpoint` agent', () => {
+      action.outputs = {
+        'agent-a': {
+          type: 'json',
+          content: {
+            code: '0',
+            stdout: 'script output',
+            stderr: '',
+          },
+        },
+      };
 
-    const stdoutAccordion = renderResult.getByTestId('test-output-stdout-title');
-    expect(stdoutAccordion).toBeInTheDocument();
-    expect(stdoutAccordion).toHaveTextContent('Runscript output');
+      render();
+
+      const stdoutAccordion = renderResult.getByTestId('test-output-stdout-title');
+      expect(stdoutAccordion).toBeInTheDocument();
+      expect(stdoutAccordion).toHaveTextContent('Runscript output');
+    });
   });
-
-  it.each(['crowdstrike', 'sentinel_one'] as const)(
-    'should display no output if %s agent type does not support outputs',
-    (agentType) => {
-      action.agentType = agentType;
-      render();
-      expect(renderResult.queryByTestId('test-output')).toBeNull();
-    }
-  );
-
-  it.each(['crowdstrike', 'microsoft_defender_endpoint', 'sentinel_one'] as const)(
-    'should display no download link for %s when user has no authz',
-    (agentType) => {
-      setUserPrivileges.set({ canWriteExecuteOperations: false });
-      action.agentType = agentType;
-      render();
-
-      expect(renderResult.queryByTestId('test-download')).toBeNull();
-    }
-  );
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/runscript_action_result/runscript_action_result.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/runscript_action_result/runscript_action_result.tsx
@@ -16,6 +16,7 @@ import type {
   ResponseActionRunScriptOutputContent,
 } from '../../../../common/endpoint/types';
 import { RunscriptOutput } from './runscript_action_output';
+import { CrowdstrikeRunscriptOutput } from './crowdstrike_runscript_output';
 
 export interface RunscriptActionResultProps {
   action: MaybeImmutable<ActionDetails<ResponseActionRunScriptOutputContent>>;
@@ -41,13 +42,49 @@ export interface RunscriptActionResultProps {
 export const RunscriptActionResult = memo<RunscriptActionResultProps>(
   ({ action, 'data-test-subj': dataTestSubj, textSize = 's' }) => {
     const { canWriteExecuteOperations } = useUserPrivileges().endpointPrivileges;
-
     const agentId = action.agents[0];
-    const showFile = useMemo(() => action.agentType !== 'crowdstrike', [action.agentType]);
+    const showFile = action.agentType !== 'crowdstrike';
     const shouldShowOutput = useMemo(
       () => action.agentType === 'microsoft_defender_endpoint',
       [action.agentType]
     );
+    const executionOutput = useMemo(() => {
+      if (action.agentType === 'microsoft_defender_endpoint') {
+        return (
+          <RunscriptOutput
+            action={action}
+            agentId={agentId}
+            data-test-subj={`${dataTestSubj}-output`}
+            textSize={textSize}
+          />
+        );
+      }
+
+      if (action.agentType === 'crowdstrike') {
+        return (
+          <CrowdstrikeRunscriptOutput
+            action={action}
+            agentId={agentId}
+            data-test-subj={`${dataTestSubj}-output`}
+            textSize={textSize}
+          />
+        );
+      }
+
+      if (action.agentType === 'endpoint' && action.outputs?.[agentId]?.content) {
+        return (
+          <EndpointHostExecutionResponseOutput
+            outputContent={
+              action.outputs[agentId].content as ResponseActionEndpointRunScriptOutputContent
+            }
+            textSize="s"
+            data-test-subj={`${dataTestSubj}-output`}
+          />
+        );
+      }
+
+      return null;
+    }, [action, agentId, dataTestSubj, textSize]);
 
     return (
       <>

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/runscript_action_result/runscript_action_result.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/runscript_action_result/runscript_action_result.tsx
@@ -8,7 +8,6 @@
 import React, { memo, useMemo } from 'react';
 import { EuiFlexItem, EuiSpacer, type EuiTextProps } from '@elastic/eui';
 import { useUserPrivileges } from '../../../common/components/user_privileges';
-import type { ResponseActionAgentType } from '../../../../common/endpoint/service/response_actions/constants';
 import { ResponseActionFileDownloadLink } from '../response_action_file_download_link';
 import type {
   ActionDetails,
@@ -20,7 +19,8 @@ import { CrowdstrikeRunscriptOutput } from './crowdstrike_runscript_output';
 
 export interface RunscriptActionResultProps {
   action: MaybeImmutable<ActionDetails<ResponseActionRunScriptOutputContent>>;
-  agentType?: ResponseActionAgentType;
+  /** Defaults to the first agent on the list if left undefined */
+  agentId?: string;
   'data-test-subj'?: string;
   textSize?: Exclude<EuiTextProps['size'], 'm' | 'relative'>;
 }
@@ -40,14 +40,9 @@ export interface RunscriptActionResultProps {
  * @returns {React.Element} A React component that renders a text block with a file download link.
  */
 export const RunscriptActionResult = memo<RunscriptActionResultProps>(
-  ({ action, 'data-test-subj': dataTestSubj, textSize = 's' }) => {
+  ({ action, agentId = action.agents[0], 'data-test-subj': dataTestSubj, textSize = 's' }) => {
     const { canWriteExecuteOperations } = useUserPrivileges().endpointPrivileges;
-    const agentId = action.agents[0];
     const showFile = action.agentType !== 'crowdstrike';
-    const shouldShowOutput = useMemo(
-      () => action.agentType === 'microsoft_defender_endpoint',
-      [action.agentType]
-    );
     const executionOutput = useMemo(() => {
       if (action.agentType === 'microsoft_defender_endpoint') {
         return (
@@ -67,18 +62,6 @@ export const RunscriptActionResult = memo<RunscriptActionResultProps>(
             agentId={agentId}
             data-test-subj={`${dataTestSubj}-output`}
             textSize={textSize}
-          />
-        );
-      }
-
-      if (action.agentType === 'endpoint' && action.outputs?.[agentId]?.content) {
-        return (
-          <EndpointHostExecutionResponseOutput
-            outputContent={
-              action.outputs[agentId].content as ResponseActionEndpointRunScriptOutputContent
-            }
-            textSize="s"
-            data-test-subj={`${dataTestSubj}-output`}
           />
         );
       }
@@ -104,15 +87,10 @@ export const RunscriptActionResult = memo<RunscriptActionResultProps>(
             />
           </EuiFlexItem>
         )}
-        {shouldShowOutput && (
+        {executionOutput && (
           <>
             <EuiSpacer size="l" />
-            <RunscriptOutput
-              action={action}
-              agentId={agentId}
-              data-test-subj={`${dataTestSubj}-output`}
-              textSize={textSize}
-            />
+            {executionOutput}
           </>
         )}
       </>

--- a/x-pack/solutions/security/plugins/security_solution/scripts/endpoint/common/fleet_services.ts
+++ b/x-pack/solutions/security/plugins/security_solution/scripts/endpoint/common/fleet_services.ts
@@ -2213,6 +2213,10 @@ export const addCrowdStrikeIntegrationToAgentPolicy = async ({
                 value: false,
                 type: 'bool',
               },
+              gov_cloud: {
+                value: false,
+                type: 'bool',
+              },
               processors: {
                 type: 'yaml',
               },


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[EDR Workflows] Restore CrowdStrike runscript output display (#262470)](https://github.com/elastic/kibana/pull/262470)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Tomasz Ciecierski","email":"tomasz.ciecierski@elastic.co"},"sourceCommit":{"committedDate":"2026-04-14T11:15:09Z","message":"[EDR Workflows] Restore CrowdStrike runscript output display (#262470)","sha":"2f9ac5220f28e40e626a30c73eab6d13ac4124ef","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Defend Workflows","backport:version","v9.4.0","v9.5.0","v9.3.4"],"title":"[EDR Workflows] Restore CrowdStrike runscript output display","number":262470,"url":"https://github.com/elastic/kibana/pull/262470","mergeCommit":{"message":"[EDR Workflows] Restore CrowdStrike runscript output display (#262470)","sha":"2f9ac5220f28e40e626a30c73eab6d13ac4124ef"}},"sourceBranch":"main","suggestedTargetBranches":["9.3"],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/263031","number":263031,"state":"MERGED","mergeCommit":{"sha":"ecc38908b5acff9ab32c92726c2b4490a2550b77","message":"[9.4] [EDR Workflows] Restore CrowdStrike runscript output display (#262470) (#263031)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.4`:\n- [[EDR Workflows] Restore CrowdStrike runscript output display\n(#262470)](https://github.com/elastic/kibana/pull/262470)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Tomasz Ciecierski <tomasz.ciecierski@elastic.co>"}},{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/262470","number":262470,"mergeCommit":{"message":"[EDR Workflows] Restore CrowdStrike runscript output display (#262470)","sha":"2f9ac5220f28e40e626a30c73eab6d13ac4124ef"}},{"branch":"9.3","label":"v9.3.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->