### PR TITLE
[Entity Store] Delay the first run of Snaphsot task by 24h (frequency)

### DIFF
--- a/x-pack/solutions/security/plugins/entity_store/server/tasks/history_snapshot_task.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/tasks/history_snapshot_task.ts
@@ -13,6 +13,7 @@ import {
 } from '@kbn/task-manager-plugin/server';
 import type { Logger } from '@kbn/logging';
 import type { KibanaRequest } from '@kbn/core/server';
+import { parseDurationToMs } from '../infra/time';
 import { TasksConfig } from './config';
 import { EntityStoreTaskType } from './constants';
 import type { EntityStoreCoreSetup } from '../types';
@@ -147,10 +148,13 @@ export async function scheduleHistorySnapshotTasks({
 }): Promise<void> {
   try {
     const taskId = getHistorySnapshotTaskId(namespace);
+    // Delay the first run by the frequency interval (24h by default).
+    const firstRunAt = new Date(Date.now() + parseDurationToMs(frequency));
     await taskManager.ensureScheduled(
       {
         id: taskId,
         taskType: config.type,
+        runAt: firstRunAt,
         schedule: { interval: frequency },
         state: { namespace },
         params: {},


### PR DESCRIPTION
## Summary

Inspired by: <https://github.com/elastic/kibana/pull/263321>

Right now the Snapshot Task starts as soon as Entity Store installs. This results in an empty snaphsot being created in the first seconds of its operation. This PR introduces a delay equal to frequency (24h by default), postponing this first run.


<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->