### PR TITLE
[Osquery] Fix table stretch/misalignment on fullscreen exit in Status tab

### DIFF
--- a/x-pack/platform/plugins/shared/osquery/public/action_results/unified_action_results_summary.tsx
+++ b/x-pack/platform/plugins/shared/osquery/public/action_results/unified_action_results_summary.tsx
@@ -229,6 +229,14 @@ const UnifiedActionResultsSummaryComponent: React.FC<ActionResultsSummaryProps> 
     currentAgentCountRef.current = agentIds?.length;
   }, [agentIds?.length, data.aggregations.totalResponded, error, expired]);
 
+  // Remount the grid on fullscreen exit to reset internal EuiDataGrid column widths that persist from the wider viewport.
+  const [gridKey, setGridKey] = useState(0);
+  const handleFullScreenChange = useCallback((isFullScreen: boolean) => {
+    if (!isFullScreen) {
+      setGridKey((k) => k + 1);
+    }
+  }, []);
+
   if (!dataView) {
     return null;
   }
@@ -241,6 +249,7 @@ const UnifiedActionResultsSummaryComponent: React.FC<ActionResultsSummaryProps> 
         <div css={tableWrapperCss} data-test-subj="osqueryStatusTable">
           <CellActionsProvider getTriggerCompatibleActions={uiActions.getTriggerCompatibleActions}>
             <UnifiedDataTable
+              key={gridKey}
               ariaLabelledBy="osquery-status-results"
               dataView={dataView}
               columns={DEFAULT_COLUMNS}
@@ -250,6 +259,7 @@ const UnifiedActionResultsSummaryComponent: React.FC<ActionResultsSummaryProps> 
               sort={EMPTY_SORT}
               showTimeCol={false}
               showFullScreenButton={appName === OSQUERY_PLUGIN_NAME}
+              onFullScreenChange={handleFullScreenChange}
               canDragAndDropColumns={false}
               isSortEnabled={false}
               isPaginationEnabled={false}


### PR DESCRIPTION

## Summary

Applies the existing fullscreen-exit remount fix to the Status tab's `UnifiedActionResultsSummary` component, resolving a persistent layout bug where the `UnifiedDataTable` grid would stretch and misalign after exiting fullscreen mode.

PR #259728 previously fixed this on the Results tab (`unified_results_table.tsx`) by forcing a remount of `UnifiedDataTable` via a `key` increment whenever fullscreen exits. The root cause is that `EuiDataGrid` caches column widths computed at the wider fullscreen viewport and does not recalculate them when returning to the normal layout. The Status tab (`unified_action_results_summary.tsx`) exposes the same fullscreen button and renders the same `UnifiedDataTable` component but was missing this fix.

## Implementation Details

- **Approach**: React `key` remount pattern — incrementing a `gridKey` state value forces React to unmount and re-mount `UnifiedDataTable`, causing `EuiDataGrid` to recompute column widths at the restored viewport size.
- **Key Changes**:
  - Added `gridKey` state (`useState(0)`) to `UnifiedActionResultsSummaryComponent`
  - Added `handleFullScreenChange` callback (`useCallback`) that increments `gridKey` when `isFullScreen` transitions to `false`
  - Passed `key={gridKey}` and `onFullScreenChange={handleFullScreenChange}` to the `UnifiedDataTable` instance in the Status tab
- **Integration Points**: The `onFullScreenChange` prop is an existing `UnifiedDataTable` API. No new props, hooks, or dependencies were introduced. The fix is purely additive and self-contained within the component.

## Breaking Changes

None.

## Testing Strategy

- **Unit Tests**: All 109 existing Jest test suites (981 tests) pass without modification. No new unit tests required — the change is a one-to-one application of an already-tested pattern.
- **Integration Tests**: No integration test changes required.
- **Manual Testing**: Reproduce via the Status tab of any live query action: enter fullscreen, exit fullscreen, confirm the grid columns render at the correct widths without stretching or misalignment.

## Review Focus

- **Security**: No security implications.
- **Performance**: The remount is triggered only on fullscreen exit, which is an infrequent, explicit user action. No performance impact on normal rendering.
- **Architecture**: The `key` increment remount is the minimal correct fix for `EuiDataGrid` viewport caching. The identical pattern is already established in `unified_results_table.tsx` (lines 331–332, 592, 609), so this PR closes the gap between the two sibling components.

## Related Context

- **Plan**: No architectural plan.
- **Issues**: Fixes #259326. Follow-up to #259728 (which applied the same fix to the Results tab only).


<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->