### PR TITLE
[8.19] [APM] Align serverless APM service nav with stateful (#263119)

### DIFF
--- a/x-pack/solutions/observability/plugins/serverless_observability/public/navigation_tree.ts
+++ b/x-pack/solutions/observability/plugins/serverless_observability/public/navigation_tree.ts
@@ -113,6 +113,25 @@ export const createNavigationTree = ({
                     title: i18n.translate('xpack.serverlessObservability.nav.apm.services', {
                       defaultMessage: 'Service inventory',
                     }),
+                    getIsActive: ({ pathNameSerialized }) => {
+                      const regex = /app\/apm\/.*service.*/;
+
+                      return regex.test(pathNameSerialized);
+                    },
+                  },
+                  {
+                    link: 'apm:service-map',
+                    title: i18n.translate('xpack.serverlessObservability.nav.apm.serviceMap', {
+                      defaultMessage: 'Service map',
+                    }),
+                    sideNavStatus: 'hidden',
+                  },
+                  {
+                    link: 'apm:service-groups-list',
+                    getIsActive: ({ pathNameSerialized, prepend }) => {
+                      return pathNameSerialized.startsWith(prepend('/app/apm/service-groups'));
+                    },
+                    sideNavStatus: 'hidden',
                   },
                   { link: 'apm:traces' },
                   { link: 'apm:dependencies' },


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[APM] Align serverless APM service nav with stateful (#263119)](https://github.com/elastic/kibana/pull/263119)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Sergi Romeu","email":"sergi.romeu@elastic.co"},"sourceCommit":{"committedDate":"2026-04-14T19:30:16Z","message":"[APM] Align serverless APM service nav with stateful (#263119)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/263118\n\n- Register hidden `apm:service-groups-list` in the serverless\nObservability navigation tree so project chrome can resolve\n`/app/apm/service-groups` like stateful.\n- Add `getIsActive` on `apm:services` (same regex as stateful) so\n**Service inventory** stays active on service map, groups, and related\npaths.\n\n## Demo\n\n### Before\n\n\nhttps://github.com/user-attachments/assets/9abca4ee-b765-485d-839f-17c91981a25e\n\n### After\n\n\nhttps://github.com/user-attachments/assets/df1e6c8f-3bd4-4999-8c26-0f4ea0ae3b1f","sha":"577515182472ea2dd496690d086e996e56dc69c8","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","ci:project-deploy-observability","backport:version","v9.4.0","Team:obs-presentation","v9.5.0","v9.3.4","v8.19.15"],"title":"[APM] Align serverless APM service nav with stateful","number":263119,"url":"https://github.com/elastic/kibana/pull/263119","mergeCommit":{"message":"[APM] Align serverless APM service nav with stateful (#263119)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/263118\n\n- Register hidden `apm:service-groups-list` in the serverless\nObservability navigation tree so project chrome can resolve\n`/app/apm/service-groups` like stateful.\n- Add `getIsActive` on `apm:services` (same regex as stateful) so\n**Service inventory** stays active on service map, groups, and related\npaths.\n\n## Demo\n\n### Before\n\n\nhttps://github.com/user-attachments/assets/9abca4ee-b765-485d-839f-17c91981a25e\n\n### After\n\n\nhttps://github.com/user-attachments/assets/df1e6c8f-3bd4-4999-8c26-0f4ea0ae3b1f","sha":"577515182472ea2dd496690d086e996e56dc69c8"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/263199","number":263199,"state":"MERGED","mergeCommit":{"sha":"c31cbe19fb4c873bc58e98c59dbbb1de538fccbd","message":"[9.4] [APM] Align serverless APM service nav with stateful (#263119) (#263199)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.4`:\n- [[APM] Align serverless APM service nav with stateful\n(#263119)](https://github.com/elastic/kibana/pull/263119)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Sergi Romeu <sergi.romeu@elastic.co>"}},{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/263119","number":263119,"mergeCommit":{"message":"[APM] Align serverless APM service nav with stateful (#263119)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/263118\n\n- Register hidden `apm:service-groups-list` in the serverless\nObservability navigation tree so project chrome can resolve\n`/app/apm/service-groups` like stateful.\n- Add `getIsActive` on `apm:services` (same regex as stateful) so\n**Service inventory** stays active on service map, groups, and related\npaths.\n\n## Demo\n\n### Before\n\n\nhttps://github.com/user-attachments/assets/9abca4ee-b765-485d-839f-17c91981a25e\n\n### After\n\n\nhttps://github.com/user-attachments/assets/df1e6c8f-3bd4-4999-8c26-0f4ea0ae3b1f","sha":"577515182472ea2dd496690d086e996e56dc69c8"}},{"branch":"9.3","label":"v9.3.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/263198","number":263198,"state":"OPEN"},{"branch":"8.19","label":"v8.19.15","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->