### PR TITLE
[Discover] [Flaky Test] Add waiting for dashboards rendering to more flaky places

### DIFF
--- a/src/platform/test/functional/apps/discover/group2_data_grid3/_data_grid_column_widths.ts
+++ b/src/platform/test/functional/apps/discover/group2_data_grid3/_data_grid_column_widths.ts
@@ -120,6 +120,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await dashboardAddPanel.clickAddFromLibrary();
       await dashboardAddPanel.addSavedSearch('A Saved Search');
       await header.waitUntilLoadingHasFinished();
+      await dashboard.waitForRenderComplete();
       await testResizeColumn('_source');
     });
 
@@ -129,6 +130,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await dashboardAddPanel.clickAddFromLibrary();
       await dashboardAddPanel.addSavedSearch('A Saved Search');
       await header.waitUntilLoadingHasFinished();
+      await dashboard.waitForRenderComplete();
       const { originalWidth, newWidth } = await dataGrid.resizeColumn('_source', -100);
       expect(newWidth).to.be(originalWidth - 100);
       await dashboard.saveDashboard('test');


### PR DESCRIPTION
## Summary

Fixes #259427

Hypothesis and fix exactly the same as: [[Discover] [Flaky Test] Wait for Dashboard rendering to be completed](https://github.com/elastic/kibana/pull/263103#top)

I also added it to one more potentially flaky place, to avoid third PR for the same root cause and file.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->