### PR TITLE
[9.4] [Synthetics] Harden flaky auto-upgrade, suggestions, and legacy policy tests

### DIFF
--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/create_monitor_private_location.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/create_monitor_private_location.ts
@@ -473,16 +473,8 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
     });
 
     it('handles auto upgrading policies', async function () {
-      // force a lower version
       const lowerVersion = '1.1.1';
-
-      // Check if the lower version is available in the package registry.
-      // The package-registry-verify-and-promote pipeline may use a registry
-      // that doesn't include old versions — skip gracefully instead of timing out.
-      const pkgCheck = await supertestWithAuth
-        .get(`/api/fleet/epm/packages/synthetics/${lowerVersion}`)
-        .set('kbn-xsrf', 'true');
-      if (pkgCheck.status === 404) {
+      if (!(await testPrivateLocations.isSyntheticsPackageVersionAvailable(lowerVersion))) {
         this.skip();
       }
 
@@ -492,6 +484,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
 
       const monitor = {
         ...httpMonitorJson,
+        locations: [],
         name: `Test monitor ${uuidv4()}`,
         [ConfigKey.NAMESPACE]: 'default',
         private_locations: [privateLocation.id],
@@ -516,29 +509,48 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
           (pkgPolicy: PackagePolicy) => pkgPolicy.id === monitorId + '-' + privateLocation.id
         );
 
-        expect(packagePolicy.package.version).eql(lowerVersion);
-        await supertestWithAuth.post('/api/fleet/setup').set('kbn-xsrf', 'true').send().expect(200);
-        await retry.tryForTime(120 * 1000, async () => {
-          const policyResponseAfterUpgrade = await supertestWithAuth.get(
-            '/api/fleet/package_policies?page=1&perPage=2000&kuery=ingest-package-policies.package.name%3A%20synthetics'
-          );
-          const packagePolicyAfterUpgrade = policyResponseAfterUpgrade.body.items.find(
-            (pkgPolicy: PackagePolicy) => pkgPolicy.id === monitorId + '-' + privateLocation.id
-          );
-          expect(semver.gt(packagePolicyAfterUpgrade.package.version, lowerVersion)).eql(true);
-        });
+        expect(packagePolicy).not.be(
+          undefined,
+          `Missing synthetics package policy for monitor ${monitorId} and location ${privateLocation.id}`
+        );
+
+        const policyVersion = packagePolicy!.package.version;
+        expect(semver.gte(policyVersion, lowerVersion)).equal(
+          true,
+          `Expected policy version ${policyVersion} to be >= ${lowerVersion}`
+        );
+
+        if (!semver.gt(policyVersion, lowerVersion)) {
+          await supertestWithAuth
+            .post('/api/fleet/setup')
+            .set('kbn-xsrf', 'true')
+            .send()
+            .expect(200);
+          await retry.tryForTime(120 * 1000, async () => {
+            const policyResponseAfterUpgrade = await supertestWithAuth.get(
+              '/api/fleet/package_policies?page=1&perPage=2000&kuery=ingest-package-policies.package.name%3A%20synthetics'
+            );
+            const packagePolicyAfterUpgrade = policyResponseAfterUpgrade.body.items.find(
+              (pkgPolicy: PackagePolicy) => pkgPolicy.id === monitorId + '-' + privateLocation.id
+            );
+            expect(packagePolicyAfterUpgrade).not.be(
+              undefined,
+              `Missing synthetics package policy after upgrade wait for monitor ${monitorId}`
+            );
+            const afterVersion = packagePolicyAfterUpgrade!.package.version;
+            expect(semver.gt(afterVersion, lowerVersion)).equal(
+              true,
+              `Expected ${afterVersion} to be greater than ${lowerVersion}`
+            );
+          });
+        }
       } finally {
         try {
           await deleteMonitor(monitorId);
-        } catch (e) {
-          // ignore cleanup errors
+        } catch {
+          // ignore cleanup failures
         }
-        // Restore the package to the latest version so subsequent tests aren't affected
-        try {
-          await testPrivateLocations.installSyntheticsPackage();
-        } catch (e) {
-          // ignore cleanup errors
-        }
+        await testPrivateLocations.reinstallLatestSyntheticsPackage();
       }
     });
 

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/create_monitor_private_location.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/create_monitor_private_location.ts
@@ -509,7 +509,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
           (pkgPolicy: PackagePolicy) => pkgPolicy.id === monitorId + '-' + privateLocation.id
         );
 
-        expect(packagePolicy).not.be(
+        expect(packagePolicy).not.to.equal(
           undefined,
           `Missing synthetics package policy for monitor ${monitorId} and location ${privateLocation.id}`
         );
@@ -533,7 +533,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
             const packagePolicyAfterUpgrade = policyResponseAfterUpgrade.body.items.find(
               (pkgPolicy: PackagePolicy) => pkgPolicy.id === monitorId + '-' + privateLocation.id
             );
-            expect(packagePolicyAfterUpgrade).not.be(
+            expect(packagePolicyAfterUpgrade).not.to.equal(
               undefined,
               `Missing synthetics package policy after upgrade wait for monitor ${monitorId}`
             );

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/migrate_legacy_policies.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/migrate_legacy_policies.ts
@@ -58,28 +58,30 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
     ): Promise<string> => {
       const legacyPolicyId = `${monitorId}-${privateLocation.id}-${spaceId}`;
 
-      const response = await supertestAdmin.post('/api/fleet/package_policies').send({
-        id: legacyPolicyId,
-        name: `legacy-${legacyPolicyId}`,
-        namespace: 'default',
-        policy_ids: [testFleetPolicyID],
-        package: {
-          name: 'synthetics',
-          version: syntheticsPackageVersion,
-        },
-        inputs: [
-          {
-            type: 'synthetics/http',
-            enabled: true,
-            streams: [],
+      await retry.try(async () => {
+        const response = await supertestAdmin.post('/api/fleet/package_policies').send({
+          id: legacyPolicyId,
+          name: `legacy-${legacyPolicyId}`,
+          namespace: 'default',
+          policy_ids: [testFleetPolicyID],
+          package: {
+            name: 'synthetics',
+            version: syntheticsPackageVersion,
           },
-        ],
-      });
+          inputs: [
+            {
+              type: 'synthetics/http',
+              enabled: true,
+              streams: [],
+            },
+          ],
+        });
 
-      expect(response.status).to.eql(
-        200,
-        `Failed to create legacy policy: ${JSON.stringify(response.body)}`
-      );
+        expect(response.status).to.eql(
+          200,
+          `Failed to create legacy policy: ${JSON.stringify(response.body)}`
+        );
+      });
 
       // Fleet's create API drops is_managed, but the cleanup task filters on it.
       // We need to set it manually.

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/suggestions.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/suggestions.ts
@@ -145,75 +145,77 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
         { concurrency: 1 }
       );
 
-      const apiResponse = await supertest
-        .get(`/s/${SPACE_ID}${SYNTHETICS_API_URLS.SUGGESTIONS}`)
-        .set(editorUser.apiKeyHeader)
-        .set(samlAuth.getInternalRequestHeader())
-        .expect(200);
+      await retry.tryForTime(60 * 1000, async () => {
+        const apiResponse = await supertest
+          .get(`/s/${SPACE_ID}${SYNTHETICS_API_URLS.SUGGESTIONS}`)
+          .set(editorUser.apiKeyHeader)
+          .set(samlAuth.getInternalRequestHeader())
+          .expect(200);
 
-      expect(apiResponse.body.locations).toEqual([
-        {
-          count: 22,
-          label: privateLocation.label,
-          value: privateLocation.id,
-        },
-      ]);
-      const expectedIds = [
-        ...monitors.map((monitor) => ({
-          count: 1,
-          label: monitor.name,
-          value: expect.any(String),
-        })),
-        ...projectMonitors.monitors.slice(0, 2).map((monitor) => ({
-          count: 1,
-          label: monitor.name,
-          value: expect.any(String),
-        })),
-      ];
-      expect(apiResponse.body.monitorIds).toEqual(expect.arrayContaining(expectedIds));
-      expect(apiResponse.body.monitorTypes).toEqual([
-        {
-          count: 20,
-          label: 'http',
-          value: 'http',
-        },
-        {
-          count: 2,
-          label: 'icmp',
-          value: 'icmp',
-        },
-      ]);
-      expect(apiResponse.body.projects).toEqual([
-        {
-          count: 2,
-          label: project,
-          value: project,
-        },
-      ]);
-      expect(apiResponse.body.tags).toEqual(
-        expect.arrayContaining([
+        expect(apiResponse.body.locations).toEqual([
           {
-            count: 21,
-            label: 'tag1',
-            value: 'tag1',
+            count: 22,
+            label: privateLocation.label,
+            value: privateLocation.id,
           },
-          {
-            count: 21,
-            label: 'tag2',
-            value: 'tag2',
-          },
-          {
+        ]);
+        const expectedIds = [
+          ...monitors.map((monitor) => ({
             count: 1,
-            label: 'org:google',
-            value: 'org:google',
+            label: monitor.name,
+            value: expect.any(String),
+          })),
+          ...projectMonitors.monitors.slice(0, 2).map((monitor) => ({
+            count: 1,
+            label: monitor.name,
+            value: expect.any(String),
+          })),
+        ];
+        expect(apiResponse.body.monitorIds).toEqual(expect.arrayContaining(expectedIds));
+        expect(apiResponse.body.monitorTypes).toEqual([
+          {
+            count: 20,
+            label: 'http',
+            value: 'http',
           },
           {
-            count: 1,
-            label: 'service:smtp',
-            value: 'service:smtp',
+            count: 2,
+            label: 'icmp',
+            value: 'icmp',
           },
-        ])
-      );
+        ]);
+        expect(apiResponse.body.projects).toEqual([
+          {
+            count: 2,
+            label: project,
+            value: project,
+          },
+        ]);
+        expect(apiResponse.body.tags).toEqual(
+          expect.arrayContaining([
+            {
+              count: 21,
+              label: 'tag1',
+              value: 'tag1',
+            },
+            {
+              count: 21,
+              label: 'tag2',
+              value: 'tag2',
+            },
+            {
+              count: 1,
+              label: 'org:google',
+              value: 'org:google',
+            },
+            {
+              count: 1,
+              label: 'service:smtp',
+              value: 'service:smtp',
+            },
+          ])
+        );
+      });
     });
 
     it('handles query params for projects', async () => {

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/services/synthetics_private_location.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/services/synthetics_private_location.ts
@@ -33,6 +33,13 @@ export class PrivateLocationTestService {
     return res.body?.item?.version ?? DEFAULT_SYNTHETICS_VERSION;
   }
 
+  async isSyntheticsPackageVersionAvailable(version: string): Promise<boolean> {
+    const res = await this.supertestWithAuth
+      .get(`/api/fleet/epm/packages/synthetics/${version}`)
+      .set('kbn-xsrf', 'true');
+    return res.status === 200;
+  }
+
   async installSyntheticsPackage({ version }: { version?: string } = {}) {
     await this.retry.try(async () => {
       await this.supertestWithAuth
@@ -57,6 +64,31 @@ export class PrivateLocationTestService {
       if (installedVersion !== resolvedVersion) {
         throw new Error(
           `Package version mismatch after install: expected ${resolvedVersion} but got ${installedVersion}`
+        );
+      }
+    });
+  }
+
+  async reinstallLatestSyntheticsPackage() {
+    await this.retry.try(async () => {
+      await this.supertestWithAuth
+        .post('/api/fleet/setup')
+        .set('kbn-xsrf', 'true')
+        .send()
+        .expect(200);
+      await this.supertestWithAuth
+        .delete(`/api/fleet/epm/packages/synthetics`)
+        .set('kbn-xsrf', 'true');
+      const resolvedVersion = await this.fetchSyntheticsPackageVersion();
+      await this.supertestWithAuth
+        .post(`/api/fleet/epm/packages/synthetics/${resolvedVersion}`)
+        .set('kbn-xsrf', 'true')
+        .send({ force: true })
+        .expect(200);
+      const installedVersion = await this.fetchSyntheticsPackageVersion();
+      if (installedVersion !== resolvedVersion) {
+        throw new Error(
+          `Version mismatch after reinstallLatest: expected ${resolvedVersion} but got ${installedVersion}`
         );
       }
     });


### PR DESCRIPTION
## Summary

Backport of #263123 to `9.4`.

Hardens three flaky Synthetics API integration tests that were failing intermittently in CI:

- **`handles auto upgrading policies`** — Fixed a deterministic 500 error when running in isolation (via `--grep`) by explicitly setting `locations: []` since the test only uses `private_locations`. Also replaced bare `.eql(true)` assertions with descriptive messages, added a registry preflight check, relaxed the initial version assertion to `semver.gte`, conditionally skips the upgrade wait when already upgraded, and restores latest package version in `finally` to prevent cross-test pollution.

- **`returns the suggestions`** — Wrapped assertions in `retry.tryForTime(60s)` to tolerate indexing lag that causes transient count mismatches.

- **`should migrate legacy policies to new format when cleanup runs`** — Wrapped `createLegacyPackagePolicy` in `retry.try` to handle transient 502 / backend-closed-connection errors.

### New service methods on `PrivateLocationTestService`:
- `isSyntheticsPackageVersionAvailable(version)` — preflight check for registry availability
- `reinstallLatestSyntheticsPackage()` — delete + reinstall latest to restore clean state after version pinning

## Test plan

- Same coverage as #263123 — test hardening only, no functional changes