### PR TITLE
[CI] remove local dependency description from kbn-yaml-loader

### DIFF
--- a/src/platform/packages/shared/kbn-yaml-loader/moon.yml
+++ b/src/platform/packages/shared/kbn-yaml-loader/moon.yml
@@ -9,8 +9,6 @@ owners:
   defaultOwner: '@elastic/fleet'
 toolchains:
   default: node
-  javascript:
-    rootPackageDependenciesOnly: false
 language: typescript
 project:
   title: '@kbn/yaml-loader'

--- a/src/platform/packages/shared/kbn-yaml-loader/package.json
+++ b/src/platform/packages/shared/kbn-yaml-loader/package.json
@@ -4,8 +4,5 @@
   "version": "1.0.0",
   "license": "Elastic License 2.0 OR AGPL-3.0-only OR SSPL-1.0",
   "main": "index.ts",
-  "types": "index.ts",
-  "dependencies": {
-    "yaml": "2.8.1"
-  }
+  "types": "index.ts"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -36250,11 +36250,6 @@ yaml@2.7.1:
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.7.1.tgz#44a247d1b88523855679ac7fa7cda6ed7e135cf6"
   integrity sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==
 
-yaml@2.8.1:
-  version "2.8.1"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.8.1.tgz#1870aa02b631f7e8328b93f8bc574fac5d6c4d79"
-  integrity sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==
-
 yaml@2.8.3:
   version "2.8.3"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.8.3.tgz#a0d6bd2efb3dd03c59370223701834e60409bd7d"


### PR DESCRIPTION
## Summary
Clean installs will fail with 
```
error Error: ENOENT: no such file or directory, lstat '/Users/tkajtoch/dev/kibana/src/platform/packages/shared/kbn-yaml-loader/node_modules/yaml
```
It's probably because we have locally installed specific version of the package. Some of our conventions in Kibana rely on not using locally setup dependencies, but we relied on central dep management in the root. 

This PR removes the local dependency