### PR TITLE
added report stats

### DIFF
--- a/x-pack/solutions/security/plugins/entity_store/server/tasks/entity_maintainers/entity_maintainers.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/tasks/entity_maintainers/entity_maintainers.test.ts
@@ -13,7 +13,8 @@ import {
   scheduleEntityMaintainerTask,
 } from '.';
 import type { RegisterEntityMaintainerConfig } from './types';
-import { EntityMaintainerTaskStatus } from './types';
+import { EntityMaintainerTaskStatus, EntityMaintainerTelemetryEventType } from './types';
+import { ENTITY_MAINTAINER_EVENT } from '../../telemetry/events';
 
 const mockEnsureScheduled = jest.fn();
 const mockRegisterTaskDefinitions = jest.fn();
@@ -259,8 +260,97 @@ describe('entity_maintainer task', () => {
           logger: expect.anything(),
           fakeRequest: expect.anything(),
           esClient: expect.anything(),
+          reportStats: expect.any(Function),
         })
       );
+    });
+
+    it('should emit ENTITY_MAINTAINER_EVENT with type stats when run calls reportStats', async () => {
+      const { logger, taskManagerSetup, core, analytics } = createMockDeps();
+      const statsPayload = [{ name: 'integrations_queried', values: ['logs'] as const }];
+      const run = jest.fn().mockImplementation(async ({ reportStats }) => {
+        reportStats(statsPayload);
+        return {};
+      });
+      const config = createMockConfig({ run });
+
+      registerEntityMaintainerTask({
+        taskManager: taskManagerSetup as any,
+        logger,
+        config,
+        core: core as any,
+        analytics,
+      });
+      await core.getStartServices();
+
+      const [defs] = mockRegisterTaskDefinitions.mock.calls[0];
+      const taskType = 'entity_store:v2:entity_maintainer_task:test-maintainer';
+      const createTaskRunner = defs[taskType].createTaskRunner;
+      const runner = createTaskRunner({
+        taskInstance: {
+          id: 'test-maintainer:default',
+          state: {
+            namespace: 'default',
+            taskStatus: EntityMaintainerTaskStatus.STARTED,
+            metadata: { runs: 1 },
+          },
+        },
+        abortController: new AbortController(),
+        fakeRequest: { headers: {} } as KibanaRequest,
+      });
+
+      await runner.run();
+
+      expect(analytics.reportEvent).toHaveBeenCalledWith(
+        ENTITY_MAINTAINER_EVENT,
+        expect.objectContaining({
+          id: 'test-maintainer',
+          namespace: 'default',
+          type: EntityMaintainerTelemetryEventType.STATS,
+          stats: statsPayload,
+        })
+      );
+    });
+
+    it('should not emit stats telemetry when reportStats is called with an empty array', async () => {
+      const { logger, taskManagerSetup, core, analytics } = createMockDeps();
+      const run = jest.fn().mockImplementation(async ({ reportStats }) => {
+        reportStats([]);
+        return {};
+      });
+      const config = createMockConfig({ run });
+
+      registerEntityMaintainerTask({
+        taskManager: taskManagerSetup as any,
+        logger,
+        config,
+        core: core as any,
+        analytics,
+      });
+      await core.getStartServices();
+
+      const [defs] = mockRegisterTaskDefinitions.mock.calls[0];
+      const taskType = 'entity_store:v2:entity_maintainer_task:test-maintainer';
+      const createTaskRunner = defs[taskType].createTaskRunner;
+      const runner = createTaskRunner({
+        taskInstance: {
+          id: 'test-maintainer:default',
+          state: {
+            namespace: 'default',
+            taskStatus: EntityMaintainerTaskStatus.STARTED,
+            metadata: { runs: 1 },
+          },
+        },
+        abortController: new AbortController(),
+        fakeRequest: { headers: {} } as KibanaRequest,
+      });
+
+      await runner.run();
+
+      const statsCalls = analytics.reportEvent.mock.calls.filter(
+        (call) => call[1]?.type === EntityMaintainerTelemetryEventType.STATS
+      );
+      expect(statsCalls).toHaveLength(0);
     });
 
     it('should not call run when license check is not valid', async () => {

--- a/x-pack/solutions/security/plugins/entity_store/server/tasks/entity_maintainers/index.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/tasks/entity_maintainers/index.ts
@@ -13,6 +13,7 @@ import type { LicenseCheckState, LicenseType } from '@kbn/licensing-types';
 import {
   EntityMaintainerTaskStatus,
   EntityMaintainerTelemetryEventType,
+  type EntityMaintainerStatTelemetry,
   type EntityMaintainerStatus,
   type EntityMaintainerTaskMethod,
   type RegisterEntityMaintainerConfig,
@@ -215,6 +216,17 @@ async function runEntityMaintainerTask({
   analytics: TelemetryReporter;
 }): Promise<{ state: EntityMaintainerStatus }> {
   const namespace = currentStatus.metadata.namespace;
+  const reportStats = (stats: ReadonlyArray<EntityMaintainerStatTelemetry>) => {
+    if (stats.length === 0) {
+      return;
+    }
+    analytics.reportEvent(ENTITY_MAINTAINER_EVENT, {
+      id,
+      namespace,
+      type: EntityMaintainerTelemetryEventType.STATS,
+      stats,
+    });
+  };
   const onAbort = () => {
     logger.debug(`Abort signal received, stopping Entity Maintainer`);
     analytics.reportEvent(ENTITY_MAINTAINER_EVENT, {
@@ -235,6 +247,7 @@ async function runEntityMaintainerTask({
         fakeRequest,
         esClient,
         crudClient,
+        reportStats,
       });
       analytics.reportEvent(ENTITY_MAINTAINER_EVENT, {
         id,
@@ -250,6 +263,7 @@ async function runEntityMaintainerTask({
       fakeRequest,
       esClient,
       crudClient,
+      reportStats,
     });
     analytics.reportEvent(ENTITY_MAINTAINER_EVENT, {
       id,

--- a/x-pack/solutions/security/plugins/entity_store/server/tasks/entity_maintainers/types.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/tasks/entity_maintainers/types.ts
@@ -28,10 +28,20 @@ export const EntityMaintainerTelemetryEventType = {
   STOP: 'stop',
   START: 'start',
   DELETE: 'delete',
+  STATS: 'stats',
 } as const;
 
 export type EntityMaintainerTelemetryEventType =
   (typeof EntityMaintainerTelemetryEventType)[keyof typeof EntityMaintainerTelemetryEventType];
+
+/**
+ * One named stat bucket reported by an entity maintainer (e.g. integration queried, counts).
+ * Prefer `values` as either all strings or all numbers within a single row so downstream analysis stays meaningful.
+ */
+export interface EntityMaintainerStatTelemetry {
+  readonly name: string;
+  readonly values: ReadonlyArray<string | number>;
+}
 
 export interface EntityMaintainerRegistryData {
   interval: string;
@@ -69,6 +79,7 @@ interface EntityMaintainerTaskMethodContext {
   fakeRequest: KibanaRequest;
   esClient: ElasticsearchClient;
   crudClient: EntityUpdateClient;
+  reportStats: (stats: ReadonlyArray<EntityMaintainerStatTelemetry>) => void;
 }
 
 export type EntityMaintainerTaskMethod = (

--- a/x-pack/solutions/security/plugins/entity_store/server/telemetry/events.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/telemetry/events.ts
@@ -7,7 +7,10 @@
 
 import type { AnalyticsServiceSetup } from '@kbn/core/server';
 import type { EventTypeOpts } from '@kbn/core/server';
-import type { EntityMaintainerTelemetryEventType } from '../tasks/entity_maintainers/types';
+import type {
+  EntityMaintainerStatTelemetry,
+  EntityMaintainerTelemetryEventType,
+} from '../tasks/entity_maintainers/types';
 
 // ------------------------------------
 //  Event types
@@ -58,6 +61,7 @@ interface EntityMaintainerEvent {
   namespace?: string;
   type: EntityMaintainerTelemetryEventType;
   errorMessage?: string;
+  stats?: ReadonlyArray<EntityMaintainerStatTelemetry>;
 }
 
 // ------------------------------------
@@ -162,13 +166,21 @@ export const ENTITY_MAINTAINER_EVENT = {
       type: 'keyword',
       _meta: {
         description:
-          'Entity maintainer telemetry event type (register, abort, setup, run, error, stop, start, delete)',
+          'Entity maintainer telemetry event type (register, abort, setup, run, error, stop, start, delete, stats)',
       },
     },
     errorMessage: {
       type: 'keyword',
       _meta: {
         description: 'Optional error message for error events',
+        optional: true,
+      },
+    },
+    stats: {
+      type: 'pass_through',
+      _meta: {
+        description:
+          'Optional maintainer-supplied stats as an array of { name, values }. Prefer homogeneous values per row (all numbers or all strings) for meaningful analysis.',
         optional: true,
       },
     },


### PR DESCRIPTION
### Summary

Adds `reportStats` on the entity maintainer task context so maintainers can send maintainer-scoped usage stats on the same channel as other maintainer telemetry (`ENTITY_MAINTAINER_EVENT` / `entity_store_entity_maintainer`), instead of overloading unrelated events such as entity store initialization.

### What changed

- **Context API:** `EntityMaintainerTaskMethodContext` now includes `reportStats(stats)` where `stats` is `ReadonlyArray<EntityMaintainerStatTelemetry>` (each row has `name` and `values`). Maintainers only pass `stats`; **id** and **namespace** are filled in by the framework when reporting.
- **Types layout:** `EntityMaintainerStatTelemetry` is defined and exported from `server/tasks/entity_maintainers/types.ts` so `server/telemetry/events.ts` can import it without a types ↔ telemetry circular dependency. The `ENTITY_MAINTAINER_EVENT` schema text for the `type` field documents the new `stats` keyword.

### Usage

From `setup` or `run`, call:

```ts
context.reportStats([{ name: '…', values: […] }]);
```
Passing an empty array does not emit a stats event.

### Testing
`entity_maintainers.test.ts` - asserts a stats shaped `ENTITY_MAINTAINER_EVENT` when `reportStats` is called with data, and no stats event when `reportStats([])`.