### PR TITLE
[Osquery] Fix flaky saved query "ID must be unique" test by preventing form submission during ID loading

### DIFF
--- a/x-pack/platform/plugins/shared/osquery/cypress/e2e/all/saved_queries.cy.ts
+++ b/x-pack/platform/plugins/shared/osquery/cypress/e2e/all/saved_queries.cy.ts
@@ -212,15 +212,15 @@ describe('ALL - Saved queries', { tags: ['@ess', '@serverless'] }, () => {
     });
 
     it('shows ID must be unique error', () => {
-      cy.intercept('GET', '**/api/osquery/saved_queries**').as('savedQueriesLoaded');
       cy.contains('Queries').click();
-      cy.wait('@savedQueriesLoaded');
       cy.contains('Create query').click();
       cy.get('input[name="id"]').type(`${duplicateTestQueryId}{downArrow}{enter}`);
 
       cy.contains('ID must be unique').should('not.exist');
       inputQuery('test');
-      cy.contains('Save query').click();
+      // The "Save query" button is disabled while saved query IDs are loading.
+      // Wait for it to become enabled so the ID uniqueness validation has data.
+      cy.contains('Save query').should('not.be.disabled').click();
       cy.contains('ID must be unique').should('exist');
     });
   });

--- a/x-pack/platform/plugins/shared/osquery/package.json
+++ b/x-pack/platform/plugins/shared/osquery/package.json
@@ -12,7 +12,7 @@
     "cypress:changed-specs-only": "yarn cypress:run --changed-specs-only --env burn=2",
     "cypress": "node ../../../../solutions/security/plugins/security_solution/scripts/start_cypress_parallel --config-file ../../../x-pack/platform/plugins/shared/osquery/cypress/cypress.config.ts --ftr-config-file ../../../../../x-pack/solutions/security/test/osquery_cypress/cli_config",
     "cypress:open": "yarn cypress open",
-    "cypress:run": "yarn cypress run --spec ./cypress/e2e/all/saved_queries.cy.ts",
+    "cypress:run": "yarn cypress run",
     "cypress:serverless": "node ../../../../solutions/security/plugins/security_solution/scripts/start_cypress_parallel --config-file ../../../x-pack/platform/plugins/shared/osquery/cypress/serverless_cypress.config.ts --ftr-config-file ../../../../../x-pack/solutions/security/test/osquery_cypress/serverless_cli_config",
     "cypress:serverless:open": "yarn cypress:serverless open",
     "cypress:serverless:run": "yarn cypress:serverless run",

--- a/x-pack/platform/plugins/shared/osquery/package.json
+++ b/x-pack/platform/plugins/shared/osquery/package.json
@@ -12,7 +12,7 @@
     "cypress:changed-specs-only": "yarn cypress:run --changed-specs-only --env burn=2",
     "cypress": "node ../../../../solutions/security/plugins/security_solution/scripts/start_cypress_parallel --config-file ../../../x-pack/platform/plugins/shared/osquery/cypress/cypress.config.ts --ftr-config-file ../../../../../x-pack/solutions/security/test/osquery_cypress/cli_config",
     "cypress:open": "yarn cypress open",
-    "cypress:run": "yarn cypress run",
+    "cypress:run": "yarn cypress run --spec ./cypress/e2e/all/saved_queries.cy.ts",
     "cypress:serverless": "node ../../../../solutions/security/plugins/security_solution/scripts/start_cypress_parallel --config-file ../../../x-pack/platform/plugins/shared/osquery/cypress/serverless_cypress.config.ts --ftr-config-file ../../../../../x-pack/solutions/security/test/osquery_cypress/serverless_cli_config",
     "cypress:serverless:open": "yarn cypress:serverless open",
     "cypress:serverless:run": "yarn cypress:serverless run",

--- a/x-pack/platform/plugins/shared/osquery/public/routes/saved_queries/edit/form.tsx
+++ b/x-pack/platform/plugins/shared/osquery/public/routes/saved_queries/edit/form.tsx
@@ -47,6 +47,7 @@ const EditSavedQueryFormComponent: React.FC<EditSavedQueryFormProps> = ({
   const {
     serializer,
     idSet,
+    isLoadingIds,
     handleSubmit: formSubmit,
     formState: { isSubmitting, isDirty },
   } = hooksForm;
@@ -87,6 +88,7 @@ const EditSavedQueryFormComponent: React.FC<EditSavedQueryFormProps> = ({
                     <EuiButton
                       data-test-subj="update-query-button"
                       isLoading={isSubmitting}
+                      isDisabled={isLoadingIds}
                       color="primary"
                       fill
                       size="m"

--- a/x-pack/platform/plugins/shared/osquery/public/routes/saved_queries/new/form.tsx
+++ b/x-pack/platform/plugins/shared/osquery/public/routes/saved_queries/new/form.tsx
@@ -43,6 +43,7 @@ const NewSavedQueryFormComponent: React.FC<NewSavedQueryFormProps> = ({
   const {
     serializer,
     idSet,
+    isLoadingIds,
     handleSubmit: formSubmit,
     formState: { isSubmitting, errors },
   } = hooksForm;
@@ -70,6 +71,7 @@ const NewSavedQueryFormComponent: React.FC<NewSavedQueryFormProps> = ({
               <EuiFlexItem grow={false}>
                 <EuiButton
                   isLoading={isSubmitting}
+                  isDisabled={isLoadingIds}
                   color="primary"
                   fill
                   size="m"

--- a/x-pack/platform/plugins/shared/osquery/public/saved_queries/form/use_saved_query_form.tsx
+++ b/x-pack/platform/plugins/shared/osquery/public/saved_queries/form/use_saved_query_form.tsx
@@ -80,7 +80,7 @@ export const savedQueryDataSerializer = (payload: SavedQueryFormData): SavedQuer
   });
 
 export const useSavedQueryForm = ({ defaultValue }: UseSavedQueryFormProps) => {
-  const { data } = useSavedQueries({});
+  const { data, isLoading: isLoadingIds } = useSavedQueries({});
   const ids: string[] = useMemo<string[]>(() => map(data?.data, 'id') ?? [], [data]);
   const idSet = useMemo<Set<string>>(() => {
     const res = new Set<string>(ids);
@@ -92,6 +92,7 @@ export const useSavedQueryForm = ({ defaultValue }: UseSavedQueryFormProps) => {
   return {
     serializer: savedQueryDataSerializer,
     idSet,
+    isLoadingIds,
     ...useHookForm<SavedQueryFormData>({
       defaultValues: defaultValue
         ? deserializer(defaultValue)

--- a/x-pack/platform/plugins/shared/osquery/public/saved_queries/saved_query_flyout.tsx
+++ b/x-pack/platform/plugins/shared/osquery/public/saved_queries/saved_query_flyout.tsx
@@ -41,6 +41,7 @@ const SavedQueryFlyoutComponent: React.FC<AddQueryFlyoutProps> = ({ defaultValue
   const {
     serializer,
     idSet,
+    isLoadingIds,
     handleSubmit,
     formState: { isSubmitting },
   } = hooksForm;
@@ -98,6 +99,7 @@ const SavedQueryFlyoutComponent: React.FC<AddQueryFlyoutProps> = ({ defaultValue
               <EuiButton
                 data-test-subj="savedQueryFlyoutSaveButton"
                 isLoading={isSubmitting}
+                isDisabled={isLoadingIds}
                 onClick={handleSubmit(onSubmit)}
                 fill
               >


### PR DESCRIPTION
## Summary

Fixes a flaky Cypress test ([#263184](https://github.com/elastic/kibana/issues/263184)) where the saved query "ID must be unique" validation intermittently failed to trigger.

The root cause was a race condition: the saved query create/edit forms allow submission before the `useSavedQueries` data has loaded. Since the "ID must be unique" check is purely client-side (validating against an in-memory `Set` of existing IDs), submitting before that set is populated bypasses the validation entirely — the form submits to the server, which does not enforce `id` uniqueness, and the page navigates away without ever showing the error.

### Changes

- **`use_saved_query_form.tsx`** — expose `isLoadingIds` from the `useSavedQueries` hook
- **`new/form.tsx`** — disable "Save query" button while IDs are loading
- **`edit/form.tsx`** — disable "Update query" button while IDs are loading
- **`saved_query_flyout.tsx`** — disable "Save" button while IDs are loading
- **`saved_queries.cy.ts`** — remove brittle `cy.intercept`/`cy.wait` pattern; instead assert the button is enabled before clicking (`should('not.be.disabled')`)

### Why this approach

The previous test used `cy.wait('@savedQueriesLoaded')` to wait for the listing page API call, but with `queryHistoryRework` enabled the listing page fires **two** API calls (parent component at `pageSize=10000` and `SavedQueriesTable` at `pageSize=10`). Waiting for only one left a window where the form's React Query cache key wasn't populated yet.

Rather than adding fragile API-call-counting in the test, this PR makes the form itself safe: submit buttons stay disabled until the ID set is available. The Cypress test simply waits for the button to become enabled — no implementation coupling required.

## Test plan

- [x] `node scripts/jest --config x-pack/platform/plugins/shared/osquery/jest.config.js` — 109 suites, 981 tests pass
- [x] `node scripts/type_check --project x-pack/platform/plugins/shared/osquery/tsconfig.json` — passes
- [x] Run the specific Cypress test via Flaky Test Runner (50x) to confirm stability - https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/11624 - failures not related to issue

Closes #263184

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->


<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->