### PR TITLE
[8.19] [Typed React Router Config] Implement self-healing mechanism for malformed urls (#257245)

### DIFF
--- a/src/platform/packages/shared/kbn-typed-react-router-config/src/create_router.test.tsx
+++ b/src/platform/packages/shared/kbn-typed-react-router-config/src/create_router.test.tsx
@@ -11,6 +11,7 @@ import React from 'react';
 import * as t from 'io-ts';
 import { toNumberRt } from '@kbn/io-ts-utils';
 import { createRouter } from './create_router';
+import { InvalidRouteParamsException } from './errors/invalid_route_params_exception';
 import { createMemoryHistory } from 'history';
 import { last } from 'lodash';
 
@@ -437,6 +438,231 @@ describe('createRouter', () => {
       expect(
         router.getRoutePath(last(router.getRoutesToMatch('/services/opbeans-java/errors'))!)
       ).toBe('/services/{serviceName}/errors');
+    });
+  });
+
+  describe('invalid query params recovery', () => {
+    it('throws InvalidRouteParamsException when a query param has null value and a default exists', () => {
+      // ?rangeFrom (bare key, parsed as null by query-string) + valid rangeTo
+      history.push('/services?rangeFrom&rangeTo=now&transactionType=request');
+
+      expect(() => {
+        router.getParams('/services', history.location);
+      }).toThrow(InvalidRouteParamsException);
+
+      try {
+        router.getParams('/services', history.location);
+      } catch (e) {
+        const error = e as InvalidRouteParamsException;
+        // rangeFrom should be replaced with default, rangeTo and transactionType preserved
+        expect(error.patched.query).toEqual(
+          expect.objectContaining({
+            rangeFrom: 'now-30m',
+            rangeTo: 'now',
+            transactionType: 'request',
+          })
+        );
+      }
+    });
+
+    it('throws InvalidRouteParamsException preserving valid params when a codec fails and param is optional', () => {
+      const recoverableRoutes = {
+        '/': {
+          element: <></>,
+          params: t.type({
+            query: t.intersection([
+              t.type({
+                rangeFrom: t.string,
+                rangeTo: t.string,
+              }),
+              t.partial({
+                page: toNumberRt,
+              }),
+            ]),
+          }),
+        },
+      };
+
+      const recoverableRouter = createRouter(recoverableRoutes);
+
+      // page=abc will fail toNumberRt; rangeFrom and rangeTo are valid
+      history.push('/?rangeFrom=now-15m&rangeTo=now&page=abc');
+
+      expect(() => {
+        recoverableRouter.getParams('/', history.location);
+      }).toThrow(InvalidRouteParamsException);
+
+      try {
+        recoverableRouter.getParams('/', history.location);
+      } catch (e) {
+        const error = e as InvalidRouteParamsException;
+        // page has no default so it should be removed; rangeFrom and rangeTo preserved
+        expect(error.patched.query).toEqual(
+          expect.objectContaining({
+            rangeFrom: 'now-15m',
+            rangeTo: 'now',
+          })
+        );
+        expect(error.patched.query).not.toHaveProperty('page');
+      }
+    });
+
+    it('throws a plain Error when recovery with defaults also fails', () => {
+      // rangeTo is required with no default — removing the invalid param still won't satisfy the codec
+      history.push('/services?transactionType=request');
+
+      expect(() => {
+        router.getParams('/services', history.location);
+      }).not.toThrow(InvalidRouteParamsException);
+
+      expect(() => {
+        router.getParams('/services', history.location);
+      }).toThrow(Error);
+    });
+
+    it('does not throw when all query params are valid', () => {
+      history.push('/services?rangeFrom=now-15m&rangeTo=now&transactionType=request');
+
+      expect(() => {
+        router.getParams('/services', history.location);
+      }).not.toThrow();
+    });
+
+    it('throws InvalidParamsException when a child route param is null and the child has its own default', () => {
+      const parentChildRoutes = {
+        '/': {
+          element: <></>,
+          params: t.type({
+            query: t.type({
+              rangeFrom: t.string,
+              rangeTo: t.string,
+            }),
+          }),
+          defaults: {
+            query: {
+              rangeFrom: 'now-30m',
+            },
+          },
+          children: {
+            '/inventory': {
+              element: <></>,
+              params: t.type({
+                query: t.type({
+                  sortField: t.string,
+                }),
+              }),
+              defaults: {
+                query: {
+                  sortField: 'name',
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const parentChildRouter = createRouter(parentChildRoutes);
+
+      // sortField is null (bare key); parent params are valid
+      history.push('/inventory?rangeFrom=now-15m&rangeTo=now&sortField');
+
+      expect(() => {
+        parentChildRouter.getParams('/inventory', history.location);
+      }).toThrow(InvalidRouteParamsException);
+
+      try {
+        parentChildRouter.getParams('/inventory', history.location);
+      } catch (e) {
+        const error = e as InvalidRouteParamsException;
+        // sortField should be replaced with child's default; parent params preserved in query
+        expect(error.patched.query).toEqual(
+          expect.objectContaining({
+            rangeFrom: 'now-15m',
+            rangeTo: 'now',
+            sortField: 'name',
+          })
+        );
+      }
+    });
+
+    it('recovers both parent and child null params in a single InvalidParamsException', () => {
+      const parentChildRoutes = {
+        '/': {
+          element: <></>,
+          params: t.type({
+            query: t.type({
+              rangeFrom: t.string,
+              rangeTo: t.string,
+            }),
+          }),
+          defaults: {
+            query: {
+              rangeFrom: 'now-30m',
+            },
+          },
+          children: {
+            '/inventory': {
+              element: <></>,
+              params: t.type({
+                query: t.type({
+                  sortField: t.string,
+                }),
+              }),
+              defaults: {
+                query: {
+                  sortField: 'name',
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const parentChildRouter = createRouter(parentChildRoutes);
+
+      // Both rangeFrom (parent) and sortField (child) are null bare keys
+      history.push('/inventory?rangeFrom&rangeTo=now&sortField');
+
+      expect(() => {
+        parentChildRouter.getParams('/inventory', history.location);
+      }).toThrow(InvalidRouteParamsException);
+
+      try {
+        parentChildRouter.getParams('/inventory', history.location);
+      } catch (e) {
+        const error = e as InvalidRouteParamsException;
+        // Both should be recovered: rangeFrom from parent default, sortField from child default
+        expect(error.patched.query).toEqual(
+          expect.objectContaining({
+            rangeFrom: 'now-30m',
+            rangeTo: 'now',
+            sortField: 'name',
+          })
+        );
+      }
+    });
+
+    it('respects codecs that accept null as a valid value', () => {
+      const nullableRoutes = {
+        '/': {
+          element: <></>,
+          params: t.type({
+            query: t.type({
+              filter: t.union([t.string, t.null]),
+            }),
+          }),
+        },
+      };
+
+      const nullableRouter = createRouter(nullableRoutes);
+
+      // ?filter (bare key, parsed as null) should pass because t.null is in the union
+      history.push('/?filter');
+      const params = nullableRouter.getParams('/', history.location);
+      expect(params).toEqual({
+        path: {},
+        query: { filter: null },
+      });
     });
   });
 });

--- a/src/platform/packages/shared/kbn-typed-react-router-config/src/create_router.ts
+++ b/src/platform/packages/shared/kbn-typed-react-router-config/src/create_router.ts
@@ -8,8 +8,9 @@
  */
 
 import { deepExactRt, mergeRt } from '@kbn/io-ts-utils';
-import { isLeft } from 'fp-ts/lib/Either';
-import { Location } from 'history';
+import { isLeft, isRight } from 'fp-ts/Either';
+import type { Location } from 'history';
+import type { Errors } from 'io-ts';
 import { PathReporter } from 'io-ts/lib/PathReporter';
 import { compact, findLastIndex, mapValues, merge, orderBy } from 'lodash';
 import qs from 'query-string';
@@ -20,15 +21,33 @@ import {
 } from 'react-router-config';
 import { FlattenRoutesOf, Route, RouteMap, Router, RouteWithPath } from './types';
 import { encodePath } from './encode_path';
+import { InvalidRouteParamsException } from './errors/invalid_route_params_exception';
+import { NotFoundRouteException } from './errors';
 
 function toReactRouterPath(path: string) {
   return path.replace(/(?:{([^\/]+)})/g, ':$1');
 }
 
-export class NotFoundRouteException extends Error {
-  constructor(message: string) {
-    super(message);
+function extractFailingQueryKeys(errors: Errors): Set<string> {
+  const keys = new Set<string>();
+  for (const error of errors) {
+    const { context } = error;
+    let foundQuery = false;
+    for (let i = 0; i < context.length; i++) {
+      if (!foundQuery) {
+        if (context[i].key === 'query') {
+          foundQuery = true;
+        }
+      } else {
+        // Skip numeric keys from intersection/union wrappers
+        if (context[i].key && !Number.isInteger(Number(context[i].key))) {
+          keys.add(context[i].key);
+          break;
+        }
+      }
+    }
   }
+  return keys;
 }
 
 export function createRouter<TRoutes extends RouteMap>(routes: TRoutes): Router<TRoutes> {
@@ -134,43 +153,96 @@ export function createRouter<TRoutes extends RouteMap>(routes: TRoutes): Router<
       throw new NotFoundRouteException('No route was matched');
     }
 
-    return matches.slice(0, matchIndex + 1).map((matchedRoute) => {
+    const parsedQuery = qs.parse(location.search, { decode: true });
+    const results: Array<{ match: any; route: Route | undefined }> = [];
+    const allPatchedKeys = new Map<string, any>();
+    const errorMessages: string[] = [];
+    let hasUnrecoverableError = false;
+
+    for (const matchedRoute of matches.slice(0, matchIndex + 1)) {
       const route = routesByReactRouterConfig.get(matchedRoute.route);
 
-      if (route?.params) {
-        const decoded = deepExactRt(route.params).decode(
-          merge({}, route.defaults ?? {}, {
-            path: mapValues(matchedRoute.match.params, (value) => {
-              return decodeURIComponent(value);
-            }),
-            query: qs.parse(location.search, { decode: true }),
-          })
-        );
-
-        if (isLeft(decoded)) {
-          throw new Error(PathReporter.report(decoded).join('\n'));
-        }
-
-        return {
-          match: {
-            ...matchedRoute.match,
-            params: decoded.right,
-          },
+      if (!route?.params) {
+        results.push({
+          match: { ...matchedRoute.match, params: { path: {}, query: {} } },
           route,
-        };
+        });
+        continue;
       }
 
-      return {
-        match: {
-          ...matchedRoute.match,
-          params: {
-            path: {},
-            query: {},
-          },
-        },
-        route,
-      };
-    });
+      const pathParams = mapValues(matchedRoute.match.params, (value) => {
+        return decodeURIComponent(value);
+      });
+
+      const decoded = deepExactRt(route.params).decode(
+        merge({}, route.defaults ?? {}, {
+          path: pathParams,
+          query: parsedQuery,
+        })
+      );
+
+      if (isRight(decoded)) {
+        results.push({
+          match: { ...matchedRoute.match, params: decoded.right },
+          route,
+        });
+        continue;
+      }
+
+      const failingKeys = extractFailingQueryKeys(decoded.left);
+      const defaultQuery = (route.defaults?.query as Record<string, string>) ?? {};
+      const patchedQuery: Record<string, any> = { ...parsedQuery };
+
+      for (const key of failingKeys) {
+        if (key in defaultQuery) {
+          patchedQuery[key] = defaultQuery[key];
+        } else {
+          delete patchedQuery[key];
+        }
+      }
+
+      const retryDecoded = deepExactRt(route.params).decode(
+        merge({}, route.defaults ?? {}, {
+          path: pathParams,
+          query: patchedQuery,
+        })
+      );
+
+      if (isRight(retryDecoded)) {
+        errorMessages.push(PathReporter.report(decoded).join('\n'));
+        for (const key of failingKeys) {
+          allPatchedKeys.set(key, patchedQuery[key]);
+        }
+        results.push({
+          match: { ...matchedRoute.match, params: retryDecoded.right },
+          route,
+        });
+      } else {
+        hasUnrecoverableError = true;
+        errorMessages.push(PathReporter.report(decoded).join('\n'));
+      }
+    }
+
+    if (hasUnrecoverableError) {
+      throw new Error(errorMessages.join('\n'));
+    }
+
+    if (allPatchedKeys.size > 0) {
+      const mergedQuery: Record<string, any> = { ...parsedQuery };
+      for (const [key, value] of allPatchedKeys) {
+        if (value === undefined) {
+          delete mergedQuery[key];
+        } else {
+          mergedQuery[key] = value;
+        }
+      }
+      throw new InvalidRouteParamsException(errorMessages.join('\n'), {
+        path: results[results.length - 1]?.match.params.path ?? {},
+        query: mergedQuery,
+      });
+    }
+
+    return results;
   };
 
   const link = (path: string, ...args: any[]) => {

--- a/src/platform/packages/shared/kbn-typed-react-router-config/src/errors/index.ts
+++ b/src/platform/packages/shared/kbn-typed-react-router-config/src/errors/index.ts
@@ -7,16 +7,5 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export * from './src/create_router';
-export * from './src/errors';
-export * from './src/encode_path';
-export type * from './src/types';
-export * from './src/outlet';
-export * from './src/route_renderer';
-export * from './src/router_provider';
-export * from './src/use_current_route';
-export * from './src/use_match_routes';
-export * from './src/use_params';
-export * from './src/use_router';
-export * from './src/use_route_path';
-export * from './src/breadcrumbs';
+export * from './invalid_route_params_exception';
+export * from './not_found_route_exception';

--- a/src/platform/packages/shared/kbn-typed-react-router-config/src/errors/invalid_route_params_exception.ts
+++ b/src/platform/packages/shared/kbn-typed-react-router-config/src/errors/invalid_route_params_exception.ts
@@ -7,16 +7,12 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export * from './src/create_router';
-export * from './src/errors';
-export * from './src/encode_path';
-export type * from './src/types';
-export * from './src/outlet';
-export * from './src/route_renderer';
-export * from './src/router_provider';
-export * from './src/use_current_route';
-export * from './src/use_match_routes';
-export * from './src/use_params';
-export * from './src/use_router';
-export * from './src/use_route_path';
-export * from './src/breadcrumbs';
+export class InvalidRouteParamsException extends Error {
+  constructor(
+    message: string,
+    public readonly patched: { path: Record<string, any>; query: Record<string, any> }
+  ) {
+    super(message);
+    this.name = 'InvalidRouteParamsException';
+  }
+}

--- a/src/platform/packages/shared/kbn-typed-react-router-config/src/errors/not_found_route_exception.ts
+++ b/src/platform/packages/shared/kbn-typed-react-router-config/src/errors/not_found_route_exception.ts
@@ -7,16 +7,9 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export * from './src/create_router';
-export * from './src/errors';
-export * from './src/encode_path';
-export type * from './src/types';
-export * from './src/outlet';
-export * from './src/route_renderer';
-export * from './src/router_provider';
-export * from './src/use_current_route';
-export * from './src/use_match_routes';
-export * from './src/use_params';
-export * from './src/use_router';
-export * from './src/use_route_path';
-export * from './src/breadcrumbs';
+export class NotFoundRouteException extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'NotFoundRouteException';
+  }
+}

--- a/src/platform/packages/shared/kbn-typed-react-router-config/src/route_self_heal_error_boundary.test.tsx
+++ b/src/platform/packages/shared/kbn-typed-react-router-config/src/route_self_heal_error_boundary.test.tsx
@@ -1,0 +1,105 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { useHistory, useLocation } from 'react-router-dom';
+import qs from 'query-string';
+import { RouteSelfHealErrorBoundary } from './route_self_heal_error_boundary';
+import { InvalidRouteParamsException } from './errors';
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useHistory: jest.fn(),
+  useLocation: jest.fn(),
+}));
+
+// Captures errors that propagate out of RouteSelfHealErrorBoundary.
+let caughtError: Error | null = null;
+
+class CatchAllBoundary extends React.Component<
+  { children: React.ReactNode },
+  { hasError: boolean }
+> {
+  state = { hasError: false };
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error) {
+    caughtError = error;
+  }
+
+  render() {
+    return this.state.hasError ? null : this.props.children;
+  }
+}
+
+describe('RouteSelfHealErrorBoundary', () => {
+  const mockReplace = jest.fn();
+  const baseLocation = { pathname: '/test', search: '', hash: '' };
+
+  beforeEach(() => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    mockReplace.mockClear();
+    caughtError = null;
+    (useHistory as jest.Mock).mockReturnValue({ replace: mockReplace });
+    (useLocation as jest.Mock).mockReturnValue({ ...baseLocation });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('catches InvalidRouteParamsException and calls history.replace with the patched query', () => {
+    const patchedQuery = { rangeFrom: 'now-30m', rangeTo: 'now' };
+    const error = new InvalidRouteParamsException('invalid params', {
+      path: {},
+      query: patchedQuery,
+    });
+
+    const ThrowingComponent = () => {
+      throw error;
+    };
+
+    render(
+      <CatchAllBoundary>
+        <RouteSelfHealErrorBoundary>
+          <ThrowingComponent />
+        </RouteSelfHealErrorBoundary>
+      </CatchAllBoundary>
+    );
+
+    expect(mockReplace).toHaveBeenCalledTimes(1);
+    expect(mockReplace).toHaveBeenCalledWith(
+      expect.objectContaining({ search: qs.stringify(patchedQuery) })
+    );
+    expect(caughtError).toBeNull();
+  });
+
+  it('re-throws non-InvalidRouteParamsException errors without calling history.replace', () => {
+    const nonRouteError = new Error('some unrelated error');
+
+    const ThrowingComponent = () => {
+      throw nonRouteError;
+    };
+
+    render(
+      <CatchAllBoundary>
+        <RouteSelfHealErrorBoundary>
+          <ThrowingComponent />
+        </RouteSelfHealErrorBoundary>
+      </CatchAllBoundary>
+    );
+
+    expect(caughtError).toBe(nonRouteError);
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+});

--- a/src/platform/packages/shared/kbn-typed-react-router-config/src/route_self_heal_error_boundary.tsx
+++ b/src/platform/packages/shared/kbn-typed-react-router-config/src/route_self_heal_error_boundary.tsx
@@ -1,0 +1,80 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React, { useCallback } from 'react';
+import { useHistory, useLocation } from 'react-router-dom';
+import qs from 'query-string';
+import { InvalidRouteParamsException } from './errors';
+
+class ErrorBoundary extends React.Component<{
+  children: React.ReactNode;
+  pathname: string;
+  search: string;
+  onError: (error: Error) => void;
+}> {
+  state = { hasError: false };
+
+  componentDidUpdate(prevProps: { pathname: string; search: string }) {
+    if (
+      (this.props.pathname !== prevProps.pathname || this.props.search !== prevProps.search) &&
+      this.state.hasError
+    ) {
+      this.setState({ hasError: false });
+    }
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error) {
+    this.props.onError(error);
+  }
+
+  render() {
+    return this.state.hasError ? null : this.props.children;
+  }
+}
+
+/**
+ * Error boundary that intercepts {@link InvalidRouteParamsException} thrown by
+ * `router.matchRoutes` (or the `useMatchRoutes` hook) and attempts to self-heal
+ * the URL by replacing malformed query parameters with their route-defined defaults.
+ *
+ * When an `InvalidRouteParamsException` is caught, the component calls
+ * `history.replace` with the corrected query string carried in the exception's
+ * `patched` payload, triggering a re-render with valid params.
+ *
+ * Errors that are **not** `InvalidRouteParamsException` (including unrecoverable
+ * decode failures) are always re-thrown upward.
+ */
+export function RouteSelfHealErrorBoundary({ children }: { children: React.ReactNode }) {
+  const history = useHistory();
+  const location = useLocation();
+
+  const handleError = useCallback(
+    (error: Error) => {
+      if (error instanceof InvalidRouteParamsException) {
+        history.replace({
+          ...location,
+          search: qs.stringify(error.patched.query),
+        });
+      } else {
+        throw error;
+      }
+    },
+    [history, location]
+  );
+
+  return (
+    <ErrorBoundary onError={handleError} pathname={location.pathname} search={location.search}>
+      {children}
+    </ErrorBoundary>
+  );
+}

--- a/src/platform/packages/shared/kbn-typed-react-router-config/src/router_provider.tsx
+++ b/src/platform/packages/shared/kbn-typed-react-router-config/src/router_provider.tsx
@@ -13,6 +13,7 @@ import { Router as ReactRouter } from '@kbn/shared-ux-router';
 
 import { RouteMap, Router } from './types';
 import { RouterContextProvider } from './use_router';
+import { RouteSelfHealErrorBoundary } from './route_self_heal_error_boundary';
 
 export function RouterProvider({
   children,
@@ -25,7 +26,9 @@ export function RouterProvider({
 }) {
   return (
     <ReactRouter history={history}>
-      <RouterContextProvider router={router}>{children}</RouterContextProvider>
+      <RouterContextProvider router={router}>
+        <RouteSelfHealErrorBoundary>{children}</RouteSelfHealErrorBoundary>
+      </RouterContextProvider>
     </ReactRouter>
   );
 }

--- a/src/platform/packages/shared/kbn-typed-react-router-config/src/use_route_path.tsx
+++ b/src/platform/packages/shared/kbn-typed-react-router-config/src/use_route_path.tsx
@@ -8,9 +8,9 @@
  */
 
 import { last } from 'lodash';
-import { NotFoundRouteException } from './create_router';
 import { useMatchRoutes } from './use_match_routes';
 import { useRouter } from './use_router';
+import { NotFoundRouteException } from './errors';
 
 export function useRoutePath() {
   const lastRouteMatch = last(useMatchRoutes());


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Typed React Router Config] Implement self-healing mechanism for malformed urls (#257245)](https://github.com/elastic/kibana/pull/257245)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Alex Fernandez","email":"47327793+AlejandroFrndz@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-04-14T15:16:34Z","message":"[Typed React Router Config] Implement self-healing mechanism for malformed urls (#257245)\n\n## Summary\n\nCloses #256295\n\n### The problem\n\nThe APM app (and all other plugins using\n`@kbn/typed-react-router-config`) can crash at runtime when a URL\ncontains malformed query parameters — specifically bare keys like\n`?rangeFrom` (no `=value`).\n\n**Root cause:** `query-string` v6.13.2's `qs.parse()` returns `null` for\nbare keys:\n\n```\nURL: /services?rangeFrom&rangeTo=now\nParsed: { rangeFrom: null, rangeTo: 'now' }\n```\n\nRoute definitions validate query params using io-ts codecs (typically\n`t.type({ rangeFrom: t.string })`), which expect `string`. When `null`\narrives, io-ts decode fails, an unhandled error is thrown inside\n`matchRoutes`, and the entire React tree crashes with no recovery path.\nUsers would be stuck in a crash loop unless they navigate away from the\nbroken URL because even when an application-level error boundary catches\nthe error, the usual recovery path offered is to reload the page. But,\ngiven that the error is in the URL itself, reloading will only lead to\nanother crash\n\nThis can happen via:\n- Bookmarks or shared links with truncated/corrupted query strings\n- Browser extensions or tools that strip query values\n- Manual URL editing in the address bar\n- Redirects from external systems that don't preserve full query\nparameters\n\n---\n\n### The approach: self-healing route decode\n\nMy first instinct was to, during parameter parsing, strip out any `null`\nproperties essentially replacing their values for `undefined` which\nwould be handled better by the io-ts codecs. Any parameter marked\noptional (`t.partial`) or required but that has defaults defined\nwouldn't break when using `undefined` instead of `null`.\n\nBut then I realised we just *happened* to record the bug in the case of\n`null` values. But the problem would still be the same for any other\nmalformed URL values that wouldn't necessarily have to be `null` Think a\nparameter that is expected to be a number but somehow ends up with a\nmalformed value that cannot be coerced into a valid number. Validation\nwould fail as well and the stripping `nulls` approach wouldn't help\nhere.\n\nRather than stripping `null` values at the parsing layer, we implemented\na **two-attempt decode with selective patching** strategy:\n\n1. **First attempt**: decode params as normal through the io-ts codec\n2. **On failure**: inspect the io-ts validation errors to identify which\nspecific query keys failed\n3. **Patch**: for each failing key, replace it with the route's declared\ndefault (if one exists) or remove it entirely\n4. **Retry**: decode again with the patched query\n5. **If retry succeeds**: the URL is recoverable → throw\n`InvalidRouteParamsException` carrying the corrected query\n6. **If retry also fails**: the URL is truly broken → throw a plain\n`Error` (existing behavior)\n\nAn error boundary (`RouteSelfHealErrorBoundary`) catches\n`InvalidRouteParamsException` and performs a `history.replace` with the\ncorrected query string, effectively healing the URL in a single\nredirect.\n\n---\n\n### Self-healing, not a silver bullet\n\nAs detailed in the process explanation above, this self-heal mechanism\nis not infalible. Although the route will do it best to recover, some\nsituations might just be impossible to get out from. If a required\nparameter is declared that does not provide a default value registered\nvia io-ts codecs it will never be able to recover.\n\nThis is left up to consuming plugins to resolve. If proper route\nconfiguration is done, required parameters should have defaults register\nin the route codec. When registering proper defaults via codec is not\npossible, there are other solutions to ensure required parameters are\nalways present and contain valid values. For instance, the APM plugin\nuses a custom component\n[RedirectWithDefaultDateRange](https://github.com/elastic/kibana/blob/main/x-pack/solutions/observability/plugins/apm/public/components/routing/app_root/redirect_with_default_date_range/index.tsx)\nthat handles setting required URL params (rangeFrom, rangeTo) with\ndefault values that can be customised via ui settings in Kibana. Each\nconsuming plugin should determine the approach that better suits their\nneeds in a case by case basis for each parameters as the business logic\nin each case can vary.\n\nWhile this change in the package will benefit from defaults registered\nat codec level, this is not enforced and plugins could opt to take other\napproaches as shown for APM. Even both approaches are valid (APM does\nso) where some parameters can be fixed automatically via defaults and\nothers can be handled with custom redirects\n\n---\n\n### Design decisions and safety measures\n\n#### Accumulated patching across parent + child routes\n\nRoutes in `@kbn/typed-react-router-config` are hierarchical — a URL like\n`/services/foo` matches both a parent route `/` (with\n`rangeFrom`/`rangeTo` params) and a child route\n`/services/{serviceName}` (with `transactionType`/`environment` params).\nEach route segment is decoded independently.\n\nThe initial implementation threw on the first failing route segment\n(parent), which meant:\n1. Parent fails → error boundary redirects, fixing only parent's params\n2. Re-render → child fails → error boundary's `retried` flag is `true` →\nre-throw → crash\n\nWe fixed this by refactoring the decode loop from `.map()` (which throws\nimmediately) to a `for` loop that **accumulates all recoverable patches\nacross all route segments** before throwing a single\n`InvalidRouteParamsException` with a merged query. This guarantees the\nerror boundary only needs one redirect cycle.\n\n---\n\n#### Handling io-ts intersection types\n\nio-ts intersection types (e.g., `t.intersection([t.type({...}),\nt.partial({...})])`) insert numeric branch indices in the validation\nerror context path:\n\n```\nExpected: ['', 'query', 'page']\nActual:   ['', 'query', '1', 'page']\n                         ↑ intersection branch index\n```\n\nThe `extractFailingQueryKeys` helper handles this by skipping numeric\nkeys when walking the context path after the `'query'` key.\n\n---\n\n#### Codecs that accept `null`\n\nAlthough we currently don't have any route parameter that can have\n`null` as a valid value, this solution also future proofs the system to\nallow these to exists. If I had went with the route of stripping `nulls`\nthis situation would have been problematic should it ever present itself\nin the future (unlikely as it may be however)\n\nIf a route codec explicitly accepts `null` (e.g., `t.union([t.string,\nt.null])`), the first decode attempt succeeds and no patching occurs.\nThe self-healing logic only activates when the codec actually rejects\nthe value.\n\n---\n\n### What changed\n\n#### `@kbn/typed-react-router-config` (core package)\n\n| File | Change |\n|---|---|\n| `src/errors/invalid_route_params_exception.ts` | New —\n`InvalidRouteParamsException` class with `patched` payload |\n| `src/errors/not_found_route_exception.ts` | Moved from inline class in\n`create_router.ts` |\n| `src/errors/index.ts` | New — barrel export for error classes |\n| `src/create_router.ts` | Added `extractFailingQueryKeys` helper;\nrefactored `matchRoutes` decode loop to accumulate patches across\nparent/child routes |\n| `src/route_self_heal_error_boundary.tsx` | New —\n`RouteSelfHealErrorBoundary` component with JSDoc documenting placement\nrequirements |\n| `src/create_router.test.tsx` | 7 new test cases covering all recovery\nand edge-case scenarios |\n\n---\n\n### Manual testing\n\n#### How the test works\n\nThe self-healing mechanism activates when a query parameter cannot be\ndecoded by its io-ts codec. The simplest way to trigger this is to use a\n**bare query key** (e.g., `?rangeFrom` without `=value`), which\n`query-string` parses as `null`. If the route defines a default for that\nparameter, the URL should automatically correct itself. If you see a\ncrash / white screen instead, the error boundary might not be working.\nKeep in mind some parameters, by virtue of how they're configured at\nroute level, won't be able to be recovered.\n\nIf you're looking at the dev console in the browser, expect to see\nerrors regarding parameters being logged. This is just how React error\nboundaries work. Even though the UI will be handled and even able to\nself-heal React still reports the error event and thus you will see it\nin the console and in error monitoring tools. While this could be worked\naround with some hacking at the error boundary level, I decided to keep\nit in as a high amount of errors in the same URL and parameter could\nindicate issues somewhere in the app with how URLs for redirection are\nbeing generated. It's not every day that users will mess their URLs up.\nA couple of errors with different parameters might be accidental but a\nhigh amount of errors for the same parameter would uncover deeper\nissues.\n\n---\n\n#### Test matrix\n\nFor each test case:\n1. Navigate to the URL in the browser address bar\n2. **Expected:** the page loads normally and the URL is rewritten with\nthe default value applied\n3. **Not expected:** blank page, crash, or infinite redirect\n\n---\n\n#### What to look for if something goes wrong\n\n| Symptom | Likely cause |\n|---|---|\n| White screen / crash | `RouteSelfHealErrorBoundary` is not in the\nright position in the component tree, or the error is not an\n`InvalidRouteParamsException` |\n| Infinite redirect (URL keeps changing) | The `retried` flag is not\nresetting properly — check browser network tab for repeated navigation\nentries |\n| URL corrected but page shows stale data | The component tree\nre-rendered but downstream hooks are caching the old query — unrelated\nto this PR |\n| Param removed instead of defaulted | The route definition is missing a\n`defaults` block for that param — expected behavior, param is simply\ndropped |\n\n---\n\n### Unit Test coverage\n\n| Test | What it verifies |\n|---|---|\n| null value with existing default | Parent `rangeFrom` is `null`,\ndefault `'now-30m'` applied, other params preserved |\n| codec failure on optional param (intersection type) | `page=abc` fails\n`toNumberRt` inside `t.intersection`, page removed, valid params\npreserved |\n| unrecoverable error | Required param missing with no default → plain\n`Error`, not `InvalidRouteParamsException` |\n| valid params | No error thrown when everything is correct |\n| child route with own default | Child's `sortField` is `null`, child's\ndefault `'name'` applied |\n| parent + child simultaneous recovery | Both parent and child have\n`null` params → single `InvalidRouteParamsException` with both defaults\nmerged |\n| codec accepting null | `t.union([t.string, t.null])` — bare `?filter`\npasses without error |\n\n---\n\n### Identify risks\n\n| Risk | Severity | Mitigation |\n|---|---|---|\n| Recovery logic masks a genuinely broken URL, making it harder to debug\n| Low | The original io-ts error message is preserved in the\n`InvalidRouteParamsException` and logged. The URL is replaced (not\npushed) so it doesn't pollute browser history. |\n| `extractFailingQueryKeys` fails to identify keys for an unusual codec\nstructure | Low | If key extraction fails, the retry also fails and we\nfall through to the existing plain `Error` behavior — no regression. |\n\n---\n\n## Release note\n\nFixes an issue where some plugins would crash when receiving malformed\nurls. This instances will now attempt to recover automatically avoiding\ncrashes whenever possible","sha":"0998beebffd5fc8e288b2e2bec7a3475ead547ba","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport:all-open","ci:project-deploy-observability","Team:obs-presentation","v9.5.0"],"title":"[Typed React Router Config] Implement self-healing mechanism for malformed urls","number":257245,"url":"https://github.com/elastic/kibana/pull/257245","mergeCommit":{"message":"[Typed React Router Config] Implement self-healing mechanism for malformed urls (#257245)\n\n## Summary\n\nCloses #256295\n\n### The problem\n\nThe APM app (and all other plugins using\n`@kbn/typed-react-router-config`) can crash at runtime when a URL\ncontains malformed query parameters — specifically bare keys like\n`?rangeFrom` (no `=value`).\n\n**Root cause:** `query-string` v6.13.2's `qs.parse()` returns `null` for\nbare keys:\n\n```\nURL: /services?rangeFrom&rangeTo=now\nParsed: { rangeFrom: null, rangeTo: 'now' }\n```\n\nRoute definitions validate query params using io-ts codecs (typically\n`t.type({ rangeFrom: t.string })`), which expect `string`. When `null`\narrives, io-ts decode fails, an unhandled error is thrown inside\n`matchRoutes`, and the entire React tree crashes with no recovery path.\nUsers would be stuck in a crash loop unless they navigate away from the\nbroken URL because even when an application-level error boundary catches\nthe error, the usual recovery path offered is to reload the page. But,\ngiven that the error is in the URL itself, reloading will only lead to\nanother crash\n\nThis can happen via:\n- Bookmarks or shared links with truncated/corrupted query strings\n- Browser extensions or tools that strip query values\n- Manual URL editing in the address bar\n- Redirects from external systems that don't preserve full query\nparameters\n\n---\n\n### The approach: self-healing route decode\n\nMy first instinct was to, during parameter parsing, strip out any `null`\nproperties essentially replacing their values for `undefined` which\nwould be handled better by the io-ts codecs. Any parameter marked\noptional (`t.partial`) or required but that has defaults defined\nwouldn't break when using `undefined` instead of `null`.\n\nBut then I realised we just *happened* to record the bug in the case of\n`null` values. But the problem would still be the same for any other\nmalformed URL values that wouldn't necessarily have to be `null` Think a\nparameter that is expected to be a number but somehow ends up with a\nmalformed value that cannot be coerced into a valid number. Validation\nwould fail as well and the stripping `nulls` approach wouldn't help\nhere.\n\nRather than stripping `null` values at the parsing layer, we implemented\na **two-attempt decode with selective patching** strategy:\n\n1. **First attempt**: decode params as normal through the io-ts codec\n2. **On failure**: inspect the io-ts validation errors to identify which\nspecific query keys failed\n3. **Patch**: for each failing key, replace it with the route's declared\ndefault (if one exists) or remove it entirely\n4. **Retry**: decode again with the patched query\n5. **If retry succeeds**: the URL is recoverable → throw\n`InvalidRouteParamsException` carrying the corrected query\n6. **If retry also fails**: the URL is truly broken → throw a plain\n`Error` (existing behavior)\n\nAn error boundary (`RouteSelfHealErrorBoundary`) catches\n`InvalidRouteParamsException` and performs a `history.replace` with the\ncorrected query string, effectively healing the URL in a single\nredirect.\n\n---\n\n### Self-healing, not a silver bullet\n\nAs detailed in the process explanation above, this self-heal mechanism\nis not infalible. Although the route will do it best to recover, some\nsituations might just be impossible to get out from. If a required\nparameter is declared that does not provide a default value registered\nvia io-ts codecs it will never be able to recover.\n\nThis is left up to consuming plugins to resolve. If proper route\nconfiguration is done, required parameters should have defaults register\nin the route codec. When registering proper defaults via codec is not\npossible, there are other solutions to ensure required parameters are\nalways present and contain valid values. For instance, the APM plugin\nuses a custom component\n[RedirectWithDefaultDateRange](https://github.com/elastic/kibana/blob/main/x-pack/solutions/observability/plugins/apm/public/components/routing/app_root/redirect_with_default_date_range/index.tsx)\nthat handles setting required URL params (rangeFrom, rangeTo) with\ndefault values that can be customised via ui settings in Kibana. Each\nconsuming plugin should determine the approach that better suits their\nneeds in a case by case basis for each parameters as the business logic\nin each case can vary.\n\nWhile this change in the package will benefit from defaults registered\nat codec level, this is not enforced and plugins could opt to take other\napproaches as shown for APM. Even both approaches are valid (APM does\nso) where some parameters can be fixed automatically via defaults and\nothers can be handled with custom redirects\n\n---\n\n### Design decisions and safety measures\n\n#### Accumulated patching across parent + child routes\n\nRoutes in `@kbn/typed-react-router-config` are hierarchical — a URL like\n`/services/foo` matches both a parent route `/` (with\n`rangeFrom`/`rangeTo` params) and a child route\n`/services/{serviceName}` (with `transactionType`/`environment` params).\nEach route segment is decoded independently.\n\nThe initial implementation threw on the first failing route segment\n(parent), which meant:\n1. Parent fails → error boundary redirects, fixing only parent's params\n2. Re-render → child fails → error boundary's `retried` flag is `true` →\nre-throw → crash\n\nWe fixed this by refactoring the decode loop from `.map()` (which throws\nimmediately) to a `for` loop that **accumulates all recoverable patches\nacross all route segments** before throwing a single\n`InvalidRouteParamsException` with a merged query. This guarantees the\nerror boundary only needs one redirect cycle.\n\n---\n\n#### Handling io-ts intersection types\n\nio-ts intersection types (e.g., `t.intersection([t.type({...}),\nt.partial({...})])`) insert numeric branch indices in the validation\nerror context path:\n\n```\nExpected: ['', 'query', 'page']\nActual:   ['', 'query', '1', 'page']\n                         ↑ intersection branch index\n```\n\nThe `extractFailingQueryKeys` helper handles this by skipping numeric\nkeys when walking the context path after the `'query'` key.\n\n---\n\n#### Codecs that accept `null`\n\nAlthough we currently don't have any route parameter that can have\n`null` as a valid value, this solution also future proofs the system to\nallow these to exists. If I had went with the route of stripping `nulls`\nthis situation would have been problematic should it ever present itself\nin the future (unlikely as it may be however)\n\nIf a route codec explicitly accepts `null` (e.g., `t.union([t.string,\nt.null])`), the first decode attempt succeeds and no patching occurs.\nThe self-healing logic only activates when the codec actually rejects\nthe value.\n\n---\n\n### What changed\n\n#### `@kbn/typed-react-router-config` (core package)\n\n| File | Change |\n|---|---|\n| `src/errors/invalid_route_params_exception.ts` | New —\n`InvalidRouteParamsException` class with `patched` payload |\n| `src/errors/not_found_route_exception.ts` | Moved from inline class in\n`create_router.ts` |\n| `src/errors/index.ts` | New — barrel export for error classes |\n| `src/create_router.ts` | Added `extractFailingQueryKeys` helper;\nrefactored `matchRoutes` decode loop to accumulate patches across\nparent/child routes |\n| `src/route_self_heal_error_boundary.tsx` | New —\n`RouteSelfHealErrorBoundary` component with JSDoc documenting placement\nrequirements |\n| `src/create_router.test.tsx` | 7 new test cases covering all recovery\nand edge-case scenarios |\n\n---\n\n### Manual testing\n\n#### How the test works\n\nThe self-healing mechanism activates when a query parameter cannot be\ndecoded by its io-ts codec. The simplest way to trigger this is to use a\n**bare query key** (e.g., `?rangeFrom` without `=value`), which\n`query-string` parses as `null`. If the route defines a default for that\nparameter, the URL should automatically correct itself. If you see a\ncrash / white screen instead, the error boundary might not be working.\nKeep in mind some parameters, by virtue of how they're configured at\nroute level, won't be able to be recovered.\n\nIf you're looking at the dev console in the browser, expect to see\nerrors regarding parameters being logged. This is just how React error\nboundaries work. Even though the UI will be handled and even able to\nself-heal React still reports the error event and thus you will see it\nin the console and in error monitoring tools. While this could be worked\naround with some hacking at the error boundary level, I decided to keep\nit in as a high amount of errors in the same URL and parameter could\nindicate issues somewhere in the app with how URLs for redirection are\nbeing generated. It's not every day that users will mess their URLs up.\nA couple of errors with different parameters might be accidental but a\nhigh amount of errors for the same parameter would uncover deeper\nissues.\n\n---\n\n#### Test matrix\n\nFor each test case:\n1. Navigate to the URL in the browser address bar\n2. **Expected:** the page loads normally and the URL is rewritten with\nthe default value applied\n3. **Not expected:** blank page, crash, or infinite redirect\n\n---\n\n#### What to look for if something goes wrong\n\n| Symptom | Likely cause |\n|---|---|\n| White screen / crash | `RouteSelfHealErrorBoundary` is not in the\nright position in the component tree, or the error is not an\n`InvalidRouteParamsException` |\n| Infinite redirect (URL keeps changing) | The `retried` flag is not\nresetting properly — check browser network tab for repeated navigation\nentries |\n| URL corrected but page shows stale data | The component tree\nre-rendered but downstream hooks are caching the old query — unrelated\nto this PR |\n| Param removed instead of defaulted | The route definition is missing a\n`defaults` block for that param — expected behavior, param is simply\ndropped |\n\n---\n\n### Unit Test coverage\n\n| Test | What it verifies |\n|---|---|\n| null value with existing default | Parent `rangeFrom` is `null`,\ndefault `'now-30m'` applied, other params preserved |\n| codec failure on optional param (intersection type) | `page=abc` fails\n`toNumberRt` inside `t.intersection`, page removed, valid params\npreserved |\n| unrecoverable error | Required param missing with no default → plain\n`Error`, not `InvalidRouteParamsException` |\n| valid params | No error thrown when everything is correct |\n| child route with own default | Child's `sortField` is `null`, child's\ndefault `'name'` applied |\n| parent + child simultaneous recovery | Both parent and child have\n`null` params → single `InvalidRouteParamsException` with both defaults\nmerged |\n| codec accepting null | `t.union([t.string, t.null])` — bare `?filter`\npasses without error |\n\n---\n\n### Identify risks\n\n| Risk | Severity | Mitigation |\n|---|---|---|\n| Recovery logic masks a genuinely broken URL, making it harder to debug\n| Low | The original io-ts error message is preserved in the\n`InvalidRouteParamsException` and logged. The URL is replaced (not\npushed) so it doesn't pollute browser history. |\n| `extractFailingQueryKeys` fails to identify keys for an unusual codec\nstructure | Low | If key extraction fails, the retry also fails and we\nfall through to the existing plain `Error` behavior — no regression. |\n\n---\n\n## Release note\n\nFixes an issue where some plugins would crash when receiving malformed\nurls. This instances will now attempt to recover automatically avoiding\ncrashes whenever possible","sha":"0998beebffd5fc8e288b2e2bec7a3475ead547ba"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/257245","number":257245,"mergeCommit":{"message":"[Typed React Router Config] Implement self-healing mechanism for malformed urls (#257245)\n\n## Summary\n\nCloses #256295\n\n### The problem\n\nThe APM app (and all other plugins using\n`@kbn/typed-react-router-config`) can crash at runtime when a URL\ncontains malformed query parameters — specifically bare keys like\n`?rangeFrom` (no `=value`).\n\n**Root cause:** `query-string` v6.13.2's `qs.parse()` returns `null` for\nbare keys:\n\n```\nURL: /services?rangeFrom&rangeTo=now\nParsed: { rangeFrom: null, rangeTo: 'now' }\n```\n\nRoute definitions validate query params using io-ts codecs (typically\n`t.type({ rangeFrom: t.string })`), which expect `string`. When `null`\narrives, io-ts decode fails, an unhandled error is thrown inside\n`matchRoutes`, and the entire React tree crashes with no recovery path.\nUsers would be stuck in a crash loop unless they navigate away from the\nbroken URL because even when an application-level error boundary catches\nthe error, the usual recovery path offered is to reload the page. But,\ngiven that the error is in the URL itself, reloading will only lead to\nanother crash\n\nThis can happen via:\n- Bookmarks or shared links with truncated/corrupted query strings\n- Browser extensions or tools that strip query values\n- Manual URL editing in the address bar\n- Redirects from external systems that don't preserve full query\nparameters\n\n---\n\n### The approach: self-healing route decode\n\nMy first instinct was to, during parameter parsing, strip out any `null`\nproperties essentially replacing their values for `undefined` which\nwould be handled better by the io-ts codecs. Any parameter marked\noptional (`t.partial`) or required but that has defaults defined\nwouldn't break when using `undefined` instead of `null`.\n\nBut then I realised we just *happened* to record the bug in the case of\n`null` values. But the problem would still be the same for any other\nmalformed URL values that wouldn't necessarily have to be `null` Think a\nparameter that is expected to be a number but somehow ends up with a\nmalformed value that cannot be coerced into a valid number. Validation\nwould fail as well and the stripping `nulls` approach wouldn't help\nhere.\n\nRather than stripping `null` values at the parsing layer, we implemented\na **two-attempt decode with selective patching** strategy:\n\n1. **First attempt**: decode params as normal through the io-ts codec\n2. **On failure**: inspect the io-ts validation errors to identify which\nspecific query keys failed\n3. **Patch**: for each failing key, replace it with the route's declared\ndefault (if one exists) or remove it entirely\n4. **Retry**: decode again with the patched query\n5. **If retry succeeds**: the URL is recoverable → throw\n`InvalidRouteParamsException` carrying the corrected query\n6. **If retry also fails**: the URL is truly broken → throw a plain\n`Error` (existing behavior)\n\nAn error boundary (`RouteSelfHealErrorBoundary`) catches\n`InvalidRouteParamsException` and performs a `history.replace` with the\ncorrected query string, effectively healing the URL in a single\nredirect.\n\n---\n\n### Self-healing, not a silver bullet\n\nAs detailed in the process explanation above, this self-heal mechanism\nis not infalible. Although the route will do it best to recover, some\nsituations might just be impossible to get out from. If a required\nparameter is declared that does not provide a default value registered\nvia io-ts codecs it will never be able to recover.\n\nThis is left up to consuming plugins to resolve. If proper route\nconfiguration is done, required parameters should have defaults register\nin the route codec. When registering proper defaults via codec is not\npossible, there are other solutions to ensure required parameters are\nalways present and contain valid values. For instance, the APM plugin\nuses a custom component\n[RedirectWithDefaultDateRange](https://github.com/elastic/kibana/blob/main/x-pack/solutions/observability/plugins/apm/public/components/routing/app_root/redirect_with_default_date_range/index.tsx)\nthat handles setting required URL params (rangeFrom, rangeTo) with\ndefault values that can be customised via ui settings in Kibana. Each\nconsuming plugin should determine the approach that better suits their\nneeds in a case by case basis for each parameters as the business logic\nin each case can vary.\n\nWhile this change in the package will benefit from defaults registered\nat codec level, this is not enforced and plugins could opt to take other\napproaches as shown for APM. Even both approaches are valid (APM does\nso) where some parameters can be fixed automatically via defaults and\nothers can be handled with custom redirects\n\n---\n\n### Design decisions and safety measures\n\n#### Accumulated patching across parent + child routes\n\nRoutes in `@kbn/typed-react-router-config` are hierarchical — a URL like\n`/services/foo` matches both a parent route `/` (with\n`rangeFrom`/`rangeTo` params) and a child route\n`/services/{serviceName}` (with `transactionType`/`environment` params).\nEach route segment is decoded independently.\n\nThe initial implementation threw on the first failing route segment\n(parent), which meant:\n1. Parent fails → error boundary redirects, fixing only parent's params\n2. Re-render → child fails → error boundary's `retried` flag is `true` →\nre-throw → crash\n\nWe fixed this by refactoring the decode loop from `.map()` (which throws\nimmediately) to a `for` loop that **accumulates all recoverable patches\nacross all route segments** before throwing a single\n`InvalidRouteParamsException` with a merged query. This guarantees the\nerror boundary only needs one redirect cycle.\n\n---\n\n#### Handling io-ts intersection types\n\nio-ts intersection types (e.g., `t.intersection([t.type({...}),\nt.partial({...})])`) insert numeric branch indices in the validation\nerror context path:\n\n```\nExpected: ['', 'query', 'page']\nActual:   ['', 'query', '1', 'page']\n                         ↑ intersection branch index\n```\n\nThe `extractFailingQueryKeys` helper handles this by skipping numeric\nkeys when walking the context path after the `'query'` key.\n\n---\n\n#### Codecs that accept `null`\n\nAlthough we currently don't have any route parameter that can have\n`null` as a valid value, this solution also future proofs the system to\nallow these to exists. If I had went with the route of stripping `nulls`\nthis situation would have been problematic should it ever present itself\nin the future (unlikely as it may be however)\n\nIf a route codec explicitly accepts `null` (e.g., `t.union([t.string,\nt.null])`), the first decode attempt succeeds and no patching occurs.\nThe self-healing logic only activates when the codec actually rejects\nthe value.\n\n---\n\n### What changed\n\n#### `@kbn/typed-react-router-config` (core package)\n\n| File | Change |\n|---|---|\n| `src/errors/invalid_route_params_exception.ts` | New —\n`InvalidRouteParamsException` class with `patched` payload |\n| `src/errors/not_found_route_exception.ts` | Moved from inline class in\n`create_router.ts` |\n| `src/errors/index.ts` | New — barrel export for error classes |\n| `src/create_router.ts` | Added `extractFailingQueryKeys` helper;\nrefactored `matchRoutes` decode loop to accumulate patches across\nparent/child routes |\n| `src/route_self_heal_error_boundary.tsx` | New —\n`RouteSelfHealErrorBoundary` component with JSDoc documenting placement\nrequirements |\n| `src/create_router.test.tsx` | 7 new test cases covering all recovery\nand edge-case scenarios |\n\n---\n\n### Manual testing\n\n#### How the test works\n\nThe self-healing mechanism activates when a query parameter cannot be\ndecoded by its io-ts codec. The simplest way to trigger this is to use a\n**bare query key** (e.g., `?rangeFrom` without `=value`), which\n`query-string` parses as `null`. If the route defines a default for that\nparameter, the URL should automatically correct itself. If you see a\ncrash / white screen instead, the error boundary might not be working.\nKeep in mind some parameters, by virtue of how they're configured at\nroute level, won't be able to be recovered.\n\nIf you're looking at the dev console in the browser, expect to see\nerrors regarding parameters being logged. This is just how React error\nboundaries work. Even though the UI will be handled and even able to\nself-heal React still reports the error event and thus you will see it\nin the console and in error monitoring tools. While this could be worked\naround with some hacking at the error boundary level, I decided to keep\nit in as a high amount of errors in the same URL and parameter could\nindicate issues somewhere in the app with how URLs for redirection are\nbeing generated. It's not every day that users will mess their URLs up.\nA couple of errors with different parameters might be accidental but a\nhigh amount of errors for the same parameter would uncover deeper\nissues.\n\n---\n\n#### Test matrix\n\nFor each test case:\n1. Navigate to the URL in the browser address bar\n2. **Expected:** the page loads normally and the URL is rewritten with\nthe default value applied\n3. **Not expected:** blank page, crash, or infinite redirect\n\n---\n\n#### What to look for if something goes wrong\n\n| Symptom | Likely cause |\n|---|---|\n| White screen / crash | `RouteSelfHealErrorBoundary` is not in the\nright position in the component tree, or the error is not an\n`InvalidRouteParamsException` |\n| Infinite redirect (URL keeps changing) | The `retried` flag is not\nresetting properly — check browser network tab for repeated navigation\nentries |\n| URL corrected but page shows stale data | The component tree\nre-rendered but downstream hooks are caching the old query — unrelated\nto this PR |\n| Param removed instead of defaulted | The route definition is missing a\n`defaults` block for that param — expected behavior, param is simply\ndropped |\n\n---\n\n### Unit Test coverage\n\n| Test | What it verifies |\n|---|---|\n| null value with existing default | Parent `rangeFrom` is `null`,\ndefault `'now-30m'` applied, other params preserved |\n| codec failure on optional param (intersection type) | `page=abc` fails\n`toNumberRt` inside `t.intersection`, page removed, valid params\npreserved |\n| unrecoverable error | Required param missing with no default → plain\n`Error`, not `InvalidRouteParamsException` |\n| valid params | No error thrown when everything is correct |\n| child route with own default | Child's `sortField` is `null`, child's\ndefault `'name'` applied |\n| parent + child simultaneous recovery | Both parent and child have\n`null` params → single `InvalidRouteParamsException` with both defaults\nmerged |\n| codec accepting null | `t.union([t.string, t.null])` — bare `?filter`\npasses without error |\n\n---\n\n### Identify risks\n\n| Risk | Severity | Mitigation |\n|---|---|---|\n| Recovery logic masks a genuinely broken URL, making it harder to debug\n| Low | The original io-ts error message is preserved in the\n`InvalidRouteParamsException` and logged. The URL is replaced (not\npushed) so it doesn't pollute browser history. |\n| `extractFailingQueryKeys` fails to identify keys for an unusual codec\nstructure | Low | If key extraction fails, the retry also fails and we\nfall through to the existing plain `Error` behavior — no regression. |\n\n---\n\n## Release note\n\nFixes an issue where some plugins would crash when receiving malformed\nurls. This instances will now attempt to recover automatically avoiding\ncrashes whenever possible","sha":"0998beebffd5fc8e288b2e2bec7a3475ead547ba"}},{"url":"https://github.com/elastic/kibana/pull/263112","number":263112,"branch":"9.2","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/263113","number":263113,"branch":"9.3","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/263115","number":263115,"branch":"9.4","state":"OPEN"}]}] BACKPORT-->