### PR TITLE
[9.4] Temporarily skip synthetics API tests in cloud runs

### DIFF
--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/index.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/index.ts
@@ -8,7 +8,10 @@
 import type { DeploymentAgnosticFtrProviderContext } from '../../ftr_provider_context';
 
 export default function ({ loadTestFile }: DeploymentAgnosticFtrProviderContext) {
-  describe('SyntheticsAPITests', () => {
+  describe('SyntheticsAPITests', function () {
+    // temporarily skipping for cloud runs until stability fix is in place
+    this.tags(['skipCloud']);
+
     loadTestFile(require.resolve('./legacy_and_multispace_monitor_api'));
     loadTestFile(require.resolve('./create_monitor_private_location'));
     loadTestFile(require.resolve('./create_monitor_project_private_location'));


### PR DESCRIPTION
## Summary

This PR temporarily skips the synthetics API tests for cloud test runs until the stability fix can land.


