### PR TITLE
[Index Management] Inject NotificationService via app dependencies

### DIFF
--- a/x-pack/platform/plugins/shared/index_management/__jest__/client_integration/helpers/setup_environment.tsx
+++ b/x-pack/platform/plugins/shared/index_management/__jest__/client_integration/helpers/setup_environment.tsx
@@ -42,7 +42,7 @@ import { AppContextProvider } from '../../../public/application/app_context';
 import { httpService } from '../../../public/application/services/http';
 import { breadcrumbService } from '../../../public/application/services/breadcrumbs';
 import { documentationService } from '../../../public/application/services/documentation';
-import { notificationService } from '../../../public/application/services/notification';
+import { NotificationService } from '../../../public/application/services/notification';
 import { ExtensionsService } from '../../../public/services';
 import { UiMetricService } from '../../../public/application/services/ui_metric';
 import { setUiMetricService } from '../../../public/application/services/api';
@@ -57,10 +57,11 @@ import { init as initHttpRequests } from './http_requests';
 const { GlobalFlyoutProvider } = GlobalFlyout;
 
 export const createServices = () => {
+  const notifications = notificationServiceMock.createStartContract();
   const services: AppDependencies['services'] = {
     extensionsService: new ExtensionsService(),
     uiMetricService: new UiMetricService('index_management'),
-    notificationService,
+    notificationService: new NotificationService(notifications.toasts),
     httpService,
   };
   services.uiMetricService.setup(usageCollectionPluginMock.createSetupContract());
@@ -145,7 +146,6 @@ export const kibanaVersion = new SemVer(MAJOR_VERSION);
 export const setupEnvironment = () => {
   breadcrumbService.setup(() => undefined);
   documentationService.setup(docLinksServiceMock.createStartContract());
-  notificationService.setup(notificationServiceMock.createStartContract());
 
   // Reset httpService singleton to ensure clean state between tests
   // This is critical - if httpService.httpClient is undefined, components will crash

--- a/x-pack/platform/plugins/shared/index_management/__jest__/client_integration/home/data_streams_project_level_retention.test.ts
+++ b/x-pack/platform/plugins/shared/index_management/__jest__/client_integration/home/data_streams_project_level_retention.test.ts
@@ -7,13 +7,11 @@
 
 import { screen } from '@testing-library/react';
 import { within } from '@testing-library/react';
-import { notificationServiceMock } from '@kbn/core/public/mocks';
 
 import { breadcrumbService } from '../../../public/application/services/breadcrumbs';
 import { MAX_DATA_RETENTION } from '../../../common/constants';
 import { setupEnvironment } from '../helpers/setup_environment';
 import { renderHome } from '../helpers/render_home';
-import { notificationService } from '../../../public/application/services/notification';
 
 import {
   createDataStreamTabActions,
@@ -42,8 +40,6 @@ describe('Data Streams - Project level max retention', () => {
   let httpRequestsMockHelpers: ReturnType<typeof setupEnvironment>['httpRequestsMockHelpers'];
   jest.spyOn(breadcrumbService, 'setBreadcrumbs');
 
-  const notificationsServiceMock = notificationServiceMock.createStartContract();
-
   beforeEach(() => {
     jest.clearAllMocks();
     const env = setupEnvironment();
@@ -67,8 +63,6 @@ describe('Data Streams - Project level max retention', () => {
     httpRequestsMockHelpers.setLoadDataStreamsResponse([ds1]);
     httpRequestsMockHelpers.setLoadDataStreamResponse(ds1.name, ds1);
     httpRequestsMockHelpers.setLoadTemplatesResponse({ templates: [], legacyTemplates: [] });
-
-    notificationService.setup(notificationsServiceMock);
 
     await renderHome(httpSetup, {
       initialEntries: ['/data_streams'],

--- a/x-pack/platform/plugins/shared/index_management/__jest__/client_integration/home/enrich_policies.test.tsx
+++ b/x-pack/platform/plugins/shared/index_management/__jest__/client_integration/home/enrich_policies.test.tsx
@@ -15,7 +15,7 @@ import {
   createEnrichPoliciesActions,
   getEnrichPoliciesTableRowCount,
 } from '../helpers/actions/enrich_policies_actions';
-import { notificationService } from '../../../public/application/services/notification';
+import { NotificationService } from '../../../public/application/services/notification';
 
 jest.mock('@kbn/code-editor');
 
@@ -147,8 +147,6 @@ describe('Enrich policies tab', () => {
       const notificationsServiceMock = notificationServiceMock.createStartContract();
 
       beforeEach(async () => {
-        notificationService.setup(notificationsServiceMock);
-
         httpRequestsMockHelpers.setLoadEnrichPoliciesResponse([
           createTestEnrichPolicy('policy-match', 'match'),
         ]);
@@ -158,6 +156,11 @@ describe('Enrich policies tab', () => {
         it('can delete a policy', async () => {
           await renderHome(httpSetup, {
             initialEntries: ['/enrich_policies'],
+            dependenciesOverrides: {
+              services: {
+                notificationService: new NotificationService(notificationsServiceMock.toasts),
+              },
+            },
           });
 
           await screen.findByTestId('enrichPoliciesTable');
@@ -186,6 +189,11 @@ describe('Enrich policies tab', () => {
         test('displays an error toast if it fails', async () => {
           await renderHome(httpSetup, {
             initialEntries: ['/enrich_policies'],
+            dependenciesOverrides: {
+              services: {
+                notificationService: new NotificationService(notificationsServiceMock.toasts),
+              },
+            },
           });
 
           await screen.findByTestId('enrichPoliciesTable');
@@ -219,6 +227,11 @@ describe('Enrich policies tab', () => {
         it('can execute a policy', async () => {
           await renderHome(httpSetup, {
             initialEntries: ['/enrich_policies'],
+            dependenciesOverrides: {
+              services: {
+                notificationService: new NotificationService(notificationsServiceMock.toasts),
+              },
+            },
           });
 
           await screen.findByTestId('enrichPoliciesTable');
@@ -247,6 +260,11 @@ describe('Enrich policies tab', () => {
         test('displays an error toast if it fails', async () => {
           await renderHome(httpSetup, {
             initialEntries: ['/enrich_policies'],
+            dependenciesOverrides: {
+              services: {
+                notificationService: new NotificationService(notificationsServiceMock.toasts),
+              },
+            },
           });
 
           await screen.findByTestId('enrichPoliciesTable');

--- a/x-pack/platform/plugins/shared/index_management/__jest__/components/index_table.helpers.tsx
+++ b/x-pack/platform/plugins/shared/index_management/__jest__/components/index_table.helpers.tsx
@@ -26,7 +26,7 @@ import { AppWithoutRouter } from '../../public/application/app';
 import { loadIndicesSuccess } from '../../public/application/store/actions';
 import { breadcrumbService } from '../../public/application/services/breadcrumbs';
 import { UiMetricService } from '../../public/application/services/ui_metric';
-import { notificationService } from '../../public/application/services/notification';
+import { NotificationService } from '../../public/application/services/notification';
 import { httpService } from '../../public/application/services/http';
 import { setUiMetricService } from '../../public/application/services/api';
 import { indexManagementStore } from '../../public/application/store';
@@ -179,10 +179,11 @@ export const renderIndexApp = async (options?: {
   httpRequestsMockHelpers.setReloadIndicesResponse(reloadIndicesResponse ?? indices);
 
   // Mock initialization of services
+  const notifications = notificationServiceMock.createStartContract();
   const services: AppDependencies['services'] = {
     extensionsService: new ExtensionsService(),
     uiMetricService: new UiMetricService('index_management'),
-    notificationService,
+    notificationService: new NotificationService(notifications.toasts),
     httpService,
   };
   services.uiMetricService.setup(usageCollectionPluginMock.createSetupContract());
@@ -191,7 +192,6 @@ export const renderIndexApp = async (options?: {
 
   httpService.setup(httpSetup);
   breadcrumbService.setup(() => undefined);
-  notificationService.setup(notificationServiceMock.createStartContract());
 
   const store = indexManagementStore(services);
 

--- a/x-pack/platform/plugins/shared/index_management/public/application/components/component_templates/component_templates_flyout_with_context.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/components/component_templates/component_templates_flyout_with_context.tsx
@@ -17,7 +17,7 @@ import { i18n } from '@kbn/i18n';
 import type { IndexManagementLocatorParams } from '@kbn/index-management-shared-types';
 import type { ComponentTemplatesFlyoutWithContextProps } from './component_templates_flyout_with_context_types';
 import { httpService } from '../../services/http';
-import { notificationService } from '../../services/notification';
+import { NotificationService } from '../../services/notification';
 import { UiMetricService } from '../../services/ui_metric';
 import { documentationService } from '../../services';
 import { UIM_APP_NAME } from '../../../../common/constants/ui_metric';
@@ -37,8 +37,8 @@ export const ComponentTemplatesFlyoutWithContext: React.FC<
   // can't do it in an effect because then the first http call fails as the instantiation happens after first render
   if (!httpService.httpClient) {
     httpService.setup(core.http);
-    notificationService.setup(core.notifications);
   }
+  const notificationService = new NotificationService(core.notifications.toasts);
   documentationService.setup(core.docLinks);
 
   const uiMetricService = new UiMetricService(UIM_APP_NAME);
@@ -92,7 +92,12 @@ export const ComponentTemplatesFlyoutWithContext: React.FC<
   ];
   return (
     <IndexManagementAppContext core={core} dependencies={newDependencies}>
-      <EuiFlyout onClose={onClose}>
+      <EuiFlyout
+        onClose={onClose}
+        aria-label={i18n.translate('xpack.idxMgmt.componentTemplateDetails.flyoutAriaLabel', {
+          defaultMessage: 'Component template details',
+        })}
+      >
         <ComponentTemplateDetailsFlyoutContent
           componentTemplateName={componentTemplateName}
           onClose={onClose}

--- a/x-pack/platform/plugins/shared/index_management/public/application/components/template_delete_modal.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/components/template_delete_modal.tsx
@@ -19,7 +19,7 @@ import { FormattedMessage } from '@kbn/i18n-react';
 
 import { DeleteManagedAssetsCallout } from '@kbn/delete-managed-asset-callout';
 import { deleteTemplates } from '../services/api';
-import { notificationService } from '../services/notification';
+import { useServices } from '../app_context';
 
 export const TemplateDeleteModal = ({
   templatesToDelete,
@@ -28,6 +28,7 @@ export const TemplateDeleteModal = ({
   templatesToDelete: Array<{ name: string; isLegacy?: boolean; type?: string }>;
   callback: (data?: { hasDeletedTemplates: boolean }) => void;
 }) => {
+  const { notificationService } = useServices();
   const [isDeleteConfirmed, setIsDeleteConfirmed] = useState<boolean>(false);
 
   const modalTitleId = useGeneratedHtmlId();

--- a/x-pack/platform/plugins/shared/index_management/public/application/mount_management_section.ts
+++ b/x-pack/platform/plugins/shared/index_management/public/application/mount_management_section.ts
@@ -21,7 +21,7 @@ import { UiMetricService } from './services';
 
 import { renderApp } from '.';
 import { setReindexService, setUiMetricService } from './services/api';
-import { notificationService } from './services/notification';
+import { NotificationService } from './services/notification';
 import { httpService } from './services/http';
 import type { ExtensionsService } from '../services/extensions_service';
 import type { StartDependencies } from '../types';
@@ -38,7 +38,7 @@ function initSetup({
   const { http, notifications } = core;
 
   httpService.setup(http);
-  notificationService.setup(notifications);
+  const notificationService = new NotificationService(notifications.toasts);
 
   const uiMetricService = new UiMetricService(UIM_APP_NAME);
   setUiMetricService(uiMetricService);
@@ -46,7 +46,7 @@ function initSetup({
 
   setReindexService(reindexService);
 
-  return { uiMetricService };
+  return { uiMetricService, notificationService };
 }
 
 export function getIndexManagementDependencies({
@@ -60,6 +60,7 @@ export function getIndexManagementDependencies({
   cloud,
   startDependencies,
   uiMetricService,
+  notificationService,
   canUseSyntheticSource,
   reindexService,
 }: {
@@ -73,6 +74,7 @@ export function getIndexManagementDependencies({
   cloud?: CloudSetup;
   startDependencies: StartDependencies;
   uiMetricService: UiMetricService;
+  notificationService: NotificationService;
   canUseSyntheticSource: boolean;
   reindexService: ReindexServicePublicStart;
 }): AppDependencies {
@@ -157,7 +159,7 @@ export async function mountManagementSection({
   breadcrumbService.setup(setBreadcrumbs);
   documentationService.setup(docLinks);
 
-  const { uiMetricService } = initSetup({
+  const { uiMetricService, notificationService } = initSetup({
     usageCollection,
     core,
     reindexService: reindexService?.reindexService,
@@ -175,6 +177,7 @@ export async function mountManagementSection({
     usageCollection,
     canUseSyntheticSource,
     reindexService,
+    notificationService,
   });
 
   const unmountAppCallback = renderApp(element, { core, dependencies: appDependencies });

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/data_stream_list/data_stream_detail_panel/data_stream_flyout_with_context.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/data_stream_list/data_stream_detail_panel/data_stream_flyout_with_context.tsx
@@ -14,7 +14,7 @@
 import React from 'react';
 import type { DataStreamFlyoutWithContextProps } from './data_stream_flyout_with_context_types';
 import { httpService } from '../../../../services/http';
-import { notificationService } from '../../../../services/notification';
+import { NotificationService } from '../../../../services/notification';
 import { UiMetricService } from '../../../../services/ui_metric';
 import { documentationService } from '../../../../services';
 import { UIM_APP_NAME } from '../../../../../../common/constants/ui_metric';
@@ -36,8 +36,8 @@ export const DataStreamFlyoutWithContext: React.FC<DataStreamFlyoutWithContextPr
   // can't do it in an effect because then the first http call fails as the instantiation happens after first render
   if (!httpService.httpClient) {
     httpService.setup(core.http);
-    notificationService.setup(core.notifications);
   }
+  const notificationService = new NotificationService(core.notifications.toasts);
   documentationService.setup(core.docLinks);
 
   const uiMetricService = new UiMetricService(UIM_APP_NAME);

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/data_stream_list/delete_data_stream_confirmation_modal/delete_data_stream_confirmation_modal.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/data_stream_list/delete_data_stream_confirmation_modal/delete_data_stream_confirmation_modal.tsx
@@ -11,7 +11,7 @@ import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 
 import { deleteDataStreams } from '../../../../services/api';
-import { notificationService } from '../../../../services/notification';
+import { useServices } from '../../../../app_context';
 
 interface Props {
   dataStreams: string[];
@@ -25,6 +25,7 @@ export const DeleteDataStreamConfirmationModal: React.FunctionComponent<Props> =
   dataStreams: string[];
   onClose: (data?: { hasDeletedDataStreams: boolean }) => void;
 }) => {
+  const { notificationService } = useServices();
   const [isLoading, setLoading] = useState(false);
 
   const modalTitleId = useGeneratedHtmlId();

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/create_index/create_index_modal.test.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/create_index/create_index_modal.test.tsx
@@ -11,18 +11,17 @@ import userEvent from '@testing-library/user-event';
 import { EuiThemeProvider } from '@elastic/eui';
 import { I18nProvider } from '@kbn/i18n-react';
 import { CreateIndexModal } from './create_index_modal';
+import { AppContextProvider } from '../../../../app_context';
+import type { AppDependencies } from '../../../../app_context';
+import { NotificationService } from '../../../../services/notification';
 
 const mockCreateIndex = jest.fn();
 jest.mock('../../../../services', () => ({
   createIndex: (...args: unknown[]) => mockCreateIndex(...args),
 }));
 
-const mockShowSuccessToast = jest.fn();
-jest.mock('../../../../services/notification', () => ({
-  notificationService: {
-    showSuccessToast: (...args: unknown[]) => mockShowSuccessToast(...args),
-  },
-}));
+let notificationService: NotificationService;
+let showSuccessToastSpy: jest.SpyInstance;
 
 jest.mock('./utils', () => ({
   generateRandomIndexName: () => 'search-abcd',
@@ -38,10 +37,18 @@ const renderModal = (props: Partial<React.ComponentProps<typeof CreateIndexModal
     loadIndices: jest.fn(),
   };
 
+  const ctx = {
+    services: {
+      notificationService,
+    },
+  } as unknown as AppDependencies;
+
   return render(
     <I18nProvider>
       <EuiThemeProvider>
-        <CreateIndexModal {...defaultProps} {...props} />
+        <AppContextProvider value={ctx}>
+          <CreateIndexModal {...defaultProps} {...props} />
+        </AppContextProvider>
       </EuiThemeProvider>
     </I18nProvider>
   );
@@ -50,6 +57,9 @@ const renderModal = (props: Partial<React.ComponentProps<typeof CreateIndexModal
 describe('CreateIndexModal', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    const toasts = { add: jest.fn() } as any;
+    notificationService = new NotificationService(toasts);
+    showSuccessToastSpy = jest.spyOn(notificationService, 'showSuccessToast');
   });
 
   it('renders the modal with title and description', () => {
@@ -133,7 +143,7 @@ describe('CreateIndexModal', () => {
     });
 
     await waitFor(() => {
-      expect(mockShowSuccessToast).toHaveBeenCalled();
+      expect(showSuccessToastSpy).toHaveBeenCalled();
       expect(closeModal).toHaveBeenCalled();
       expect(loadIndices).toHaveBeenCalled();
     });
@@ -152,7 +162,7 @@ describe('CreateIndexModal', () => {
     });
 
     await waitFor(() => {
-      expect(mockShowSuccessToast).toHaveBeenCalled();
+      expect(showSuccessToastSpy).toHaveBeenCalled();
       expect(closeModal).toHaveBeenCalled();
       expect(loadIndices).toHaveBeenCalled();
     });

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/create_index/create_index_modal.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/create_index/create_index_modal.tsx
@@ -36,7 +36,7 @@ import {
 import { LOOKUP_INDEX_MODE, STANDARD_INDEX_MODE } from '../../../../../../common/constants';
 import { indexModeDescriptions, indexModeLabels } from '../../../../lib/index_mode_labels';
 import { createIndex } from '../../../../services';
-import { notificationService } from '../../../../services/notification';
+import { useServices } from '../../../../app_context';
 
 import { generateRandomIndexName, isValidIndexName } from './utils';
 
@@ -57,6 +57,7 @@ export interface CreateIndexModalProps {
 }
 
 export const CreateIndexModal = ({ closeModal, loadIndices }: CreateIndexModalProps) => {
+  const { notificationService } = useServices();
   const modalTitleId = useGeneratedHtmlId();
   const { euiTheme } = useEuiTheme();
 
@@ -98,7 +99,7 @@ export const CreateIndexModal = ({ closeModal, loadIndices }: CreateIndexModalPr
       setIsSaving(false);
       setCreateError(e.message);
     }
-  }, [closeModal, indexMode, indexName, loadIndices]);
+  }, [closeModal, indexMode, indexName, loadIndices, notificationService]);
 
   const onSave = () => {
     if (isValidIndexName(indexName)) {

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/convert_to_lookup_index_modal/convert_to_lookup_index_modal_container.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/convert_to_lookup_index_modal/convert_to_lookup_index_modal_container.tsx
@@ -10,7 +10,7 @@ import { i18n } from '@kbn/i18n';
 import { useConvertIndexToLookup } from '../../../../../hooks/use_convert_index_to_lookup/use_convert_index_to_lookup';
 import { ConvertToLookupIndexModal } from './convert_to_lookup_index_modal';
 
-import { notificationService } from '../../../../../services/notification';
+import { useServices } from '../../../../../app_context';
 
 export const ConvertToLookupIndexModalContainer = ({
   onCloseModal,
@@ -21,6 +21,7 @@ export const ConvertToLookupIndexModalContainer = ({
   onSuccess: (lookupIndexName: string) => void;
   sourceIndexName: string;
 }) => {
+  const { notificationService } = useServices();
   const { isConverting, errorMessage, convert } = useConvertIndexToLookup({
     sourceIndexName,
     onSuccess,

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/details_page_mappings_content.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/details_page_mappings_content.tsx
@@ -56,7 +56,6 @@ import { MappingsFilter } from './details_page_filter_fields';
 
 import { useMappingsStateListener } from '../../../../components/mappings_editor/use_state_listener';
 import { updateIndexMappings, useUserPrivileges } from '../../../../services/api';
-import { notificationService } from '../../../../services/notification';
 import { SemanticTextBanner } from './semantic_text_banner';
 import { TrainedModelsDeploymentModal } from './trained_models_deployment_modal';
 import { parseMappings } from '../../../../shared/parse_mappings';
@@ -81,6 +80,7 @@ export const DetailsPageMappingsContent: FunctionComponent<{
     config,
     overlays,
     history,
+    services: { notificationService },
   } = useAppContext();
   const { data: userPrivilege } = useUserPrivileges(index.name);
   const hasUpdateMappingsPrivilege = userPrivilege?.privileges?.canManageIndex === true;

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/details_page_settings_content.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/details_page_settings_content.tsx
@@ -31,7 +31,6 @@ import { monaco as monacoEditor } from '@kbn/monaco';
 import type { IndexSettingsResponse } from '../../../../../../common';
 import type { Error } from '../../../../../shared_imports';
 import { documentationService, updateIndexSettings } from '../../../../services';
-import { notificationService } from '../../../../services/notification';
 import { flattenObject } from '../../../../lib/flatten_object';
 import {
   readOnlySettings,
@@ -83,6 +82,7 @@ export const DetailsPageSettingsContent: FunctionComponent<Props> = ({
 }) => {
   const [isEditMode, setIsEditMode] = useState(false);
   const {
+    services: { notificationService },
     config: { editableIndexSettings },
   } = useAppContext();
   const onEditModeChange = (event: EuiSwitchEvent) => {
@@ -148,7 +148,7 @@ export const DetailsPageSettingsContent: FunctionComponent<Props> = ({
         }),
       });
     }
-  }, [originalSettings, editableSettings, indexName, reloadIndexSettings]);
+  }, [originalSettings, editableSettings, indexName, reloadIndexSettings, notificationService]);
   const settingsSchemaProperties = {} as Record<string, unknown>;
   Object.keys(originalSettings).forEach(
     // allow any type of value
@@ -175,7 +175,7 @@ export const DetailsPageSettingsContent: FunctionComponent<Props> = ({
         <EuiPanel grow={false} paddingSize="l">
           <EuiFlexGroup alignItems="center" gutterSize="s">
             <EuiFlexItem grow={false}>
-              <EuiIcon type="pencil" />
+              <EuiIcon type="pencil" aria-hidden={true} />
             </EuiFlexItem>
             <EuiFlexItem>
               <EuiText>

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/manage_index_button.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/manage_index_button.tsx
@@ -20,8 +20,8 @@ import {
   openIndices as openIndicesRequest,
   refreshIndices as refreshIndicesRequest,
 } from '../../../../services';
-import { notificationService } from '../../../../services/notification';
 import { httpService } from '../../../../services/http';
+import { useServices } from '../../../../app_context';
 
 import type { IndexActionsContextMenuProps } from '../index_actions_context_menu/index_actions_context_menu';
 import { IndexActionsContextMenu } from '../index_actions_context_menu/index_actions_context_menu';
@@ -59,6 +59,7 @@ export const ManageIndexButton: FunctionComponent<Props> = ({
   onIndexRefresh,
   fill = false,
 }) => {
+  const { notificationService } = useServices();
   const [isLoading, setIsLoading] = useState(false);
 
   // the "index actions context menu" component is expecting an array of indices, the same as on the indices list
@@ -90,7 +91,7 @@ export const ManageIndexButton: FunctionComponent<Props> = ({
       setIsLoading(false);
       notificationService.showDangerToast(error.body.message);
     }
-  }, [reloadIndices, indexNames]);
+  }, [reloadIndices, indexNames, notificationService]);
 
   const openIndices = useCallback(async () => {
     setIsLoading(true);
@@ -108,7 +109,7 @@ export const ManageIndexButton: FunctionComponent<Props> = ({
       setIsLoading(false);
       notificationService.showDangerToast(error.body.message);
     }
-  }, [reloadIndices, indexNames]);
+  }, [reloadIndices, indexNames, notificationService]);
 
   const flushIndices = useCallback(async () => {
     setIsLoading(true);
@@ -126,7 +127,7 @@ export const ManageIndexButton: FunctionComponent<Props> = ({
       setIsLoading(false);
       notificationService.showDangerToast(error.body.message);
     }
-  }, [reloadIndices, indexNames]);
+  }, [reloadIndices, indexNames, notificationService]);
 
   const refreshIndices = useCallback(async () => {
     setIsLoading(true);
@@ -145,7 +146,7 @@ export const ManageIndexButton: FunctionComponent<Props> = ({
       setIsLoading(false);
       notificationService.showDangerToast(error.body.message);
     }
-  }, [reloadIndices, indexNames, onIndexRefresh]);
+  }, [reloadIndices, indexNames, onIndexRefresh, notificationService]);
 
   const clearCacheIndices = useCallback(async () => {
     setIsLoading(true);
@@ -163,7 +164,7 @@ export const ManageIndexButton: FunctionComponent<Props> = ({
       setIsLoading(false);
       notificationService.showDangerToast(error.body.message);
     }
-  }, [reloadIndices, indexNames]);
+  }, [reloadIndices, indexNames, notificationService]);
 
   const forcemergeIndices = useCallback(
     async (maxNumSegments: string) => {
@@ -183,7 +184,7 @@ export const ManageIndexButton: FunctionComponent<Props> = ({
         notificationService.showDangerToast(error.body.message);
       }
     },
-    [reloadIndices, indexNames]
+    [reloadIndices, indexNames, notificationService]
   );
 
   const deleteIndices = useCallback(async () => {
@@ -202,7 +203,7 @@ export const ManageIndexButton: FunctionComponent<Props> = ({
       setIsLoading(false);
       notificationService.showDangerToast(error.body.message);
     }
-  }, [navigateToIndicesList, indexNames]);
+  }, [navigateToIndicesList, indexNames, notificationService]);
 
   const performExtensionAction = useCallback(
     async (
@@ -220,7 +221,7 @@ export const ManageIndexButton: FunctionComponent<Props> = ({
         notificationService.showDangerToast(error.body.message);
       }
     },
-    [reloadIndices, indexNames]
+    [reloadIndices, indexNames, notificationService]
   );
 
   return (

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/update_elser_mappings/update_elser_mappings_modal.test.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/update_elser_mappings/update_elser_mappings_modal.test.tsx
@@ -15,9 +15,11 @@ import {
   isElserOnMlNodeSemanticField,
 } from '../../../../../components/mappings_editor/lib/utils';
 import * as apiService from '../../../../../services/api';
-import { notificationService } from '../../../../../services/notification';
 import type { NormalizedFields, State } from '../../../../../components/mappings_editor/types';
 import { UpdateElserMappingsModal } from './update_elser_mappings_modal';
+import { AppContextProvider } from '../../../../../app_context';
+import type { AppDependencies } from '../../../../../app_context';
+import { NotificationService } from '../../../../../services/notification';
 import {
   createMappingViewFieldsFixture,
   defaultDenormalizedMappings,
@@ -51,36 +53,47 @@ jest.mock('../../../../../services', () => ({
   },
 }));
 
-jest.mock('../../../../../services/notification', () => ({
-  notificationService: { showSuccessToast: jest.fn(), showDangerToast: jest.fn() },
-}));
-
 const deNormalizeMock = jest.mocked(deNormalize);
 const prepareFieldsForEisUpdateMock = jest.mocked(prepareFieldsForEisUpdate);
 const isElserOnMlNodeSemanticFieldMock = jest.mocked(isElserOnMlNodeSemanticField);
 const mappingsContextMock = jest.mocked(mappingsContext);
-const notificationServiceMock = jest.mocked(notificationService);
 const updateIndexMappingsMock = jest.mocked(apiService.updateIndexMappings);
+
+let notificationService: NotificationService;
+let showSuccessToastSpy: jest.SpyInstance;
+let showDangerToastSpy: jest.SpyInstance;
 
 const renderEisUpdateCallout = ({
   hasUpdatePrivileges = true,
 }: {
   hasUpdatePrivileges?: boolean;
 } = {}) => {
+  const ctx = {
+    services: {
+      notificationService,
+    },
+  } as unknown as AppDependencies;
+
   return render(
-    <UpdateElserMappingsModal
-      indexName="test-index"
-      refetchMapping={refetchMapping}
-      setIsModalOpen={setIsModalOpen}
-      hasUpdatePrivileges={hasUpdatePrivileges}
-      modalId="test-modal-id"
-    />
+    <AppContextProvider value={ctx}>
+      <UpdateElserMappingsModal
+        indexName="test-index"
+        refetchMapping={refetchMapping}
+        setIsModalOpen={setIsModalOpen}
+        hasUpdatePrivileges={hasUpdatePrivileges}
+        modalId="test-modal-id"
+      />
+    </AppContextProvider>
   );
 };
 
 describe('UpdateElserMappingsModal', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    const toasts = { add: jest.fn() } as any;
+    notificationService = new NotificationService(toasts);
+    showSuccessToastSpy = jest.spyOn(notificationService, 'showSuccessToast');
+    showDangerToastSpy = jest.spyOn(notificationService, 'showDangerToast');
     const fieldsById: NormalizedFields = createMappingViewFieldsFixture();
 
     mappingsContextMock.useMappingsState.mockReturnValue({
@@ -144,7 +157,7 @@ describe('UpdateElserMappingsModal', () => {
     await userEvent.click(applyBtn);
 
     expect(updateIndexMappingsMock).toHaveBeenCalledTimes(1);
-    expect(notificationServiceMock.showSuccessToast).toHaveBeenCalledTimes(1);
+    expect(showSuccessToastSpy).toHaveBeenCalledTimes(1);
     expect(setIsModalOpen).toHaveBeenCalledWith(false);
     expect(refetchMapping).toHaveBeenCalled();
   });
@@ -166,7 +179,7 @@ describe('UpdateElserMappingsModal', () => {
     await userEvent.click(applyBtn);
 
     expect(updateIndexMappingsMock).toHaveBeenCalledTimes(1);
-    expect(notificationServiceMock.showDangerToast).toHaveBeenCalledTimes(1);
+    expect(showDangerToastSpy).toHaveBeenCalledTimes(1);
     expect(setIsModalOpen).toHaveBeenCalledWith(false);
   });
 

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/update_elser_mappings/update_elser_mappings_modal.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/update_elser_mappings/update_elser_mappings_modal.tsx
@@ -32,8 +32,8 @@ import {
 import { useMappingsState } from '../../../../../components/mappings_editor/mappings_state_context';
 import { documentationService } from '../../../../../services';
 import { updateIndexMappings } from '../../../../../services/api';
-import { notificationService } from '../../../../../services/notification';
 import type { NormalizedFields } from '../../../../../components/mappings_editor/types';
+import { useServices } from '../../../../../app_context';
 
 export interface MappingsOptionData {
   name: string;
@@ -54,6 +54,7 @@ export function UpdateElserMappingsModal({
   hasUpdatePrivileges,
   modalId,
 }: UpdateElserMappingsModalProps) {
+  const { notificationService } = useServices();
   const state = useMappingsState();
   const [options, setOptions] = useState<EuiSelectableOption<MappingsOptionData>[]>([]);
   const [isUpdating, setIsUpdating] = useState<boolean>(false);
@@ -84,25 +85,31 @@ export function UpdateElserMappingsModal({
     );
   }, []);
 
-  const handleError = (error: string | undefined) => {
-    const errorToastTitle = i18n.translate(
-      'xpack.idxMgmt.indexDetails.updateElserMappingsModal.error.title',
-      {
-        defaultMessage: 'Error updating mappings',
-      }
-    );
+  const handleError = useCallback(
+    (error: string | undefined) => {
+      const errorToastTitle = i18n.translate(
+        'xpack.idxMgmt.indexDetails.updateElserMappingsModal.error.title',
+        {
+          defaultMessage: 'Error updating mappings',
+        }
+      );
 
-    const errorMessage = error
-      ? i18n.translate('xpack.idxMgmt.indexDetails.updateElserMappingsModal.error.message', {
-          defaultMessage: '{error}',
-          values: { error },
-        })
-      : i18n.translate('xpack.idxMgmt.indexDetails.updateElserMappingsModal.error.defaultMessage', {
-          defaultMessage: 'Mappings could not be updated. Please try again.',
-        });
+      const errorMessage = error
+        ? i18n.translate('xpack.idxMgmt.indexDetails.updateElserMappingsModal.error.message', {
+            defaultMessage: '{error}',
+            values: { error },
+          })
+        : i18n.translate(
+            'xpack.idxMgmt.indexDetails.updateElserMappingsModal.error.defaultMessage',
+            {
+              defaultMessage: 'Mappings could not be updated. Please try again.',
+            }
+          );
 
-    notificationService.showDangerToast(errorToastTitle, errorMessage);
-  };
+      notificationService.showDangerToast(errorToastTitle, errorMessage);
+    },
+    [notificationService]
+  );
 
   const handleApply = useCallback(async () => {
     setIsUpdating(true);
@@ -138,7 +145,15 @@ export function UpdateElserMappingsModal({
       setIsUpdating(false);
       setIsModalOpen(false);
     }
-  }, [indexName, refetchMapping, options, setIsModalOpen, state.mappingViewFields]);
+  }, [
+    indexName,
+    refetchMapping,
+    options,
+    setIsModalOpen,
+    state.mappingViewFields,
+    handleError,
+    notificationService,
+  ]);
 
   useEffect(() => {
     const elserOptions = buildElserOptions(state.mappingViewFields);

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/with_context_components/index_mapping_with_context.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/with_context_components/index_mapping_with_context.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 import { documentationService } from '../../../../../services';
 import { UIM_APP_NAME } from '../../../../../../../common/constants/ui_metric';
 import { httpService } from '../../../../../services/http';
-import { notificationService } from '../../../../../services/notification';
+import { NotificationService } from '../../../../../services/notification';
 import { UiMetricService } from '../../../../../services/ui_metric';
 import type { AppDependencies } from '../../../../..';
 import { IndexManagementAppContext } from '../../../../..';
@@ -28,8 +28,8 @@ export const IndexMappingWithContext: React.FC<IndexMappingWithContextProps> = (
   // can't do it in an effect because then the first http call fails as the instantiation happens after first render
   if (!httpService.httpClient) {
     httpService.setup(core.http);
-    notificationService.setup(core.notifications);
   }
+  const notificationService = new NotificationService(core.notifications.toasts);
   documentationService.setup(core.docLinks);
 
   const newDependencies: AppDependencies = {

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/with_context_components/index_settings_with_context.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/with_context_components/index_settings_with_context.tsx
@@ -8,7 +8,7 @@ import React from 'react';
 import { documentationService } from '../../../../../services';
 import { UIM_APP_NAME } from '../../../../../../../common/constants/ui_metric';
 import { httpService } from '../../../../../services/http';
-import { notificationService } from '../../../../../services/notification';
+import { NotificationService } from '../../../../../services/notification';
 import { UiMetricService } from '../../../../../services/ui_metric';
 import type { AppDependencies } from '../../../../..';
 import { IndexManagementAppContext } from '../../../../..';
@@ -29,8 +29,8 @@ export const IndexSettingsWithContext: React.FC<IndexSettingWithContextProps> = 
   // can't do it in an effect because then the first http call fails as the instantiation happens after first render
   if (!httpService.httpClient) {
     httpService.setup(core.http);
-    notificationService.setup(core.notifications);
   }
+  const notificationService = new NotificationService(core.notifications.toasts);
   documentationService.setup(core.docLinks);
 
   const uiMetricService = new UiMetricService(UIM_APP_NAME);

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/index_actions_context_menu/index_actions_context_menu.test.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/index_actions_context_menu/index_actions_context_menu.test.tsx
@@ -15,7 +15,7 @@ import { AppContextProvider } from '../../../../app_context';
 import type { AppDependencies } from '../../../../app_context';
 import { IndexActionsContextMenu } from './index_actions_context_menu';
 import type { Index } from '@kbn/index-management-shared-types';
-import { notificationService } from '../../../../services/notification';
+import { NotificationService } from '../../../../services/notification';
 import { getIndexDetailsLink } from '../../../../services/routing';
 import { type DocCountResult, RequestResultType } from '../index_table/get_doc_count';
 
@@ -26,14 +26,6 @@ const user = userEvent.setup({ pointerEventsCheck: 0, delay: null });
 jest.mock('../../../../services/routing', () => ({
   ...jest.requireActual('../../../../services/routing'),
   getIndexDetailsLink: jest.fn(() => '/indices/some/stats'),
-}));
-
-jest.mock('../../../../services/notification', () => ({
-  ...jest.requireActual('../../../../services/notification'),
-  notificationService: {
-    showSuccessToast: jest.fn(),
-    showDangerToast: jest.fn(),
-  },
 }));
 
 jest.mock(
@@ -58,6 +50,7 @@ jest.mock(
 );
 
 const getIndexManagementCtx = (overrides: Partial<AppDependencies> = {}): AppDependencies => {
+  const toasts = { add: jest.fn() } as any;
   const base: AppDependencies = {
     core: {
       fatalErrors: {} as unknown as AppDependencies['core']['fatalErrors'],
@@ -92,7 +85,7 @@ const getIndexManagementCtx = (overrides: Partial<AppDependencies> = {}): AppDep
       } as unknown as AppDependencies['services']['extensionsService'],
       uiMetricService: {} as unknown as AppDependencies['services']['uiMetricService'],
       httpService: {} as unknown as AppDependencies['services']['httpService'],
-      notificationService,
+      notificationService: new NotificationService(toasts),
     },
     config: {
       enableIndexActions: true,

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/index_actions_context_menu/modal_host/modal_host.test.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/index_actions_context_menu/modal_host/modal_host.test.tsx
@@ -11,17 +11,17 @@ import userEvent from '@testing-library/user-event';
 import { I18nProvider } from '@kbn/i18n-react';
 import { ModalHost, type ModalHostHandles } from './modal_host';
 import { getIndexDetailsLink } from '../../../../../services/routing';
-import { notificationService } from '../../../../../services/notification';
+import { AppContextProvider } from '../../../../../app_context';
+import type { AppDependencies } from '../../../../../app_context';
+import { NotificationService } from '../../../../../services/notification';
 
 jest.mock('../../../../../services/routing', () => ({
   ...jest.requireActual('../../../../../services/routing'),
   getIndexDetailsLink: jest.fn().mockReturnValue('/mocked-link'),
 }));
 
-jest.mock('../../../../../services/notification', () => ({
-  ...jest.requireActual('../../../../../services/notification'),
-  notificationService: { showSuccessToast: jest.fn(), showDangerToast: jest.fn() },
-}));
+let notificationService: NotificationService;
+let showSuccessToastSpy: jest.SpyInstance;
 
 jest.mock(
   '../../details_page/convert_to_lookup_index_modal/convert_to_lookup_index_modal_container',
@@ -63,12 +63,25 @@ const baseProps: React.ComponentProps<typeof ModalHost> = {
 };
 
 const renderWithI18n = (ui: React.ReactElement) => {
-  return render(<I18nProvider>{ui}</I18nProvider>);
+  const ctx = {
+    services: {
+      notificationService,
+    },
+  } as unknown as AppDependencies;
+
+  return render(
+    <I18nProvider>
+      <AppContextProvider value={ctx}>{ui}</AppContextProvider>
+    </I18nProvider>
+  );
 };
 
 describe('ModalHost', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    const toasts = { add: jest.fn() } as any;
+    notificationService = new NotificationService(toasts);
+    showSuccessToastSpy = jest.spyOn(notificationService, 'showSuccessToast');
   });
 
   describe('WHEN rendering and opening modals', () => {
@@ -277,7 +290,7 @@ describe('ModalHost', () => {
 
           expect(getIndexDetailsLink).toHaveBeenCalled();
           expect(baseProps.history.push).toHaveBeenCalledWith('/mocked-link');
-          expect(notificationService.showSuccessToast).toHaveBeenCalled();
+          expect(showSuccessToastSpy).toHaveBeenCalled();
         });
       });
 

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/index_actions_context_menu/modal_host/modal_host.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/index_actions_context_menu/modal_host/modal_host.tsx
@@ -21,10 +21,10 @@ import type { ApplicationStart, ScopedHistory } from '@kbn/core/public';
 import type { ExtensionsService } from '../../../../../../services/extensions_service';
 
 import { ConvertToLookupIndexModalContainer } from '../../details_page/convert_to_lookup_index_modal/convert_to_lookup_index_modal_container';
-import { notificationService } from '../../../../../services/notification';
 import { getIndexDetailsLink } from '../../../../../services/routing';
 import { IndexDetailsSection } from '../../../../../../../common/constants';
 import type { Index } from '../../../../../../../common';
+import { useServices } from '../../../../../app_context';
 
 export type ModalOpenRequest =
   | { kind: 'forcemerge' }
@@ -106,6 +106,7 @@ export const ModalHost = memo(
     },
     ref
   ) {
+    const { notificationService } = useServices();
     const [state, dispatch] = useReducer(modalReducer, initialModalState);
 
     useImperativeHandle(ref, () => ({

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/template_list/template_details/index_template_flyout_with_context.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/template_list/template_details/index_template_flyout_with_context.tsx
@@ -15,9 +15,10 @@ import React, { useCallback, useMemo } from 'react';
 import { EuiFlyout } from '@elastic/eui';
 import type { IndexManagementLocatorParams } from '@kbn/index-management-shared-types';
 import { attemptToURIDecode } from '@kbn/es-ui-shared-plugin/public';
+import { i18n } from '@kbn/i18n';
 import type { IndexTemplateFlyoutWithContextProps } from './index_template_flyout_with_context_types';
 import { httpService } from '../../../../services/http';
-import { notificationService } from '../../../../services/notification';
+import { NotificationService } from '../../../../services/notification';
 import { UiMetricService } from '../../../../services/ui_metric';
 import { documentationService } from '../../../../services';
 import { UIM_APP_NAME } from '../../../../../../common/constants/ui_metric';
@@ -41,8 +42,8 @@ export const IndexTemplateFlyoutWithContext: React.FC<IndexTemplateFlyoutWithCon
   // can't do it in an effect because then the first http call fails as the instantiation happens after first render
   if (!httpService.httpClient) {
     httpService.setup(core.http);
-    notificationService.setup(core.notifications);
   }
+  const notificationService = new NotificationService(core.notifications.toasts);
   documentationService.setup(core.docLinks);
 
   const uiMetricService = new UiMetricService(UIM_APP_NAME);
@@ -85,7 +86,12 @@ export const IndexTemplateFlyoutWithContext: React.FC<IndexTemplateFlyoutWithCon
   );
   return (
     <IndexManagementAppContext core={core} dependencies={newDependencies}>
-      <EuiFlyout onClose={onClose}>
+      <EuiFlyout
+        onClose={onClose}
+        aria-label={i18n.translate('xpack.idxMgmt.indexTemplateDetails.flyoutAriaLabel', {
+          defaultMessage: 'Index template details',
+        })}
+      >
         <TemplateDetailsContent
           template={indexTemplate}
           onClose={onClose}

--- a/x-pack/platform/plugins/shared/index_management/public/application/services/notification.ts
+++ b/x-pack/platform/plugins/shared/index_management/public/application/services/notification.ts
@@ -8,11 +8,7 @@
 import type { NotificationsStart } from '@kbn/core/public';
 
 export class NotificationService {
-  private _toasts!: NotificationsStart['toasts'];
-
-  public setup(notifications: NotificationsStart): void {
-    this._toasts = notifications.toasts;
-  }
+  constructor(private readonly _toasts: NotificationsStart['toasts']) {}
 
   public get toasts() {
     return this._toasts;
@@ -46,5 +42,3 @@ export class NotificationService {
     this.addToasts(title, 'primary', text);
   }
 }
-
-export const notificationService = new NotificationService();

--- a/x-pack/platform/plugins/shared/index_management/public/application/store/actions/clear_cache_indices.ts
+++ b/x-pack/platform/plugins/shared/index_management/public/application/store/actions/clear_cache_indices.ts
@@ -9,16 +9,20 @@ import { createAction } from 'redux-actions';
 import { i18n } from '@kbn/i18n';
 
 import { clearCacheIndices as request } from '../../services';
-import { notificationService } from '../../services/notification';
 
 import { clearRowStatus, reloadIndices } from '.';
 import type { AppDispatch } from '../types';
 import { getHttpErrorToastMessage } from '../http_error';
+import type { AppDependencies } from '../../app_context';
 
 export const clearCacheIndicesStart = createAction('INDEX_MANAGEMENT_CLEAR_CACHE_INDICES_START');
 export const clearCacheIndices =
   ({ indexNames }: { indexNames: string[] }) =>
-  async (dispatch: AppDispatch) => {
+  async (
+    dispatch: AppDispatch,
+    _getState: () => unknown,
+    { notificationService }: AppDependencies['services']
+  ) => {
     dispatch(clearCacheIndicesStart({ indexNames }));
     try {
       await request(indexNames);

--- a/x-pack/platform/plugins/shared/index_management/public/application/store/actions/close_indices.ts
+++ b/x-pack/platform/plugins/shared/index_management/public/application/store/actions/close_indices.ts
@@ -8,15 +8,19 @@
 import { createAction } from 'redux-actions';
 import { i18n } from '@kbn/i18n';
 import { closeIndices as request } from '../../services';
-import { notificationService } from '../../services/notification';
 import { clearRowStatus, reloadIndices } from '.';
 import type { AppDispatch } from '../types';
 import { getHttpErrorToastMessage } from '../http_error';
+import type { AppDependencies } from '../../app_context';
 
 export const closeIndicesStart = createAction('INDEX_MANAGEMENT_CLOSE_INDICES_START');
 export const closeIndices =
   ({ indexNames }: { indexNames: string[] }) =>
-  async (dispatch: AppDispatch) => {
+  async (
+    dispatch: AppDispatch,
+    _getState: () => unknown,
+    { notificationService }: AppDependencies['services']
+  ) => {
     dispatch(closeIndicesStart({ indexNames }));
     try {
       await request(indexNames);

--- a/x-pack/platform/plugins/shared/index_management/public/application/store/actions/delete_indices.ts
+++ b/x-pack/platform/plugins/shared/index_management/public/application/store/actions/delete_indices.ts
@@ -9,14 +9,18 @@ import { createAction } from 'redux-actions';
 import { i18n } from '@kbn/i18n';
 import type { AppDispatch } from '../types';
 import { deleteIndices as request } from '../../services';
-import { notificationService } from '../../services/notification';
 import { clearRowStatus } from '.';
 import { getHttpErrorToastMessage } from '../http_error';
+import type { AppDependencies } from '../../app_context';
 
 export const deleteIndicesSuccess = createAction('INDEX_MANAGEMENT_DELETE_INDICES_SUCCESS');
 export const deleteIndices =
   ({ indexNames }: { indexNames: string[] }) =>
-  async (dispatch: AppDispatch) => {
+  async (
+    dispatch: AppDispatch,
+    _getState: () => unknown,
+    { notificationService }: AppDependencies['services']
+  ) => {
     try {
       await request(indexNames);
     } catch (error) {

--- a/x-pack/platform/plugins/shared/index_management/public/application/store/actions/extension_action.ts
+++ b/x-pack/platform/plugins/shared/index_management/public/application/store/actions/extension_action.ts
@@ -7,10 +7,10 @@
 
 import type { HttpSetup } from '@kbn/core-http-browser';
 import { reloadIndices } from '.';
-import { notificationService } from '../../services/notification';
 import { httpService } from '../../services/http';
 import type { AppDispatch } from '../types';
 import { getHttpErrorToastMessage } from '../http_error';
+import type { AppDependencies } from '../../app_context';
 
 export const performExtensionAction =
   ({
@@ -22,7 +22,11 @@ export const performExtensionAction =
     indexNames: string[];
     successMessage: string;
   }) =>
-  async (dispatch: AppDispatch) => {
+  async (
+    dispatch: AppDispatch,
+    _getState: () => unknown,
+    { notificationService }: AppDependencies['services']
+  ) => {
     try {
       await requestMethod(indexNames, httpService.httpClient);
     } catch (error) {

--- a/x-pack/platform/plugins/shared/index_management/public/application/store/actions/flush_indices.ts
+++ b/x-pack/platform/plugins/shared/index_management/public/application/store/actions/flush_indices.ts
@@ -9,15 +9,19 @@ import { createAction } from 'redux-actions';
 import { i18n } from '@kbn/i18n';
 import { flushIndices as request } from '../../services';
 import { clearRowStatus, reloadIndices } from '.';
-import { notificationService } from '../../services/notification';
 import type { AppDispatch } from '../types';
 import { getHttpErrorToastMessage } from '../http_error';
+import type { AppDependencies } from '../../app_context';
 
 export const flushIndicesStart = createAction('INDEX_MANAGEMENT_FLUSH_INDICES_START');
 
 export const flushIndices =
   ({ indexNames }: { indexNames: string[] }) =>
-  async (dispatch: AppDispatch) => {
+  async (
+    dispatch: AppDispatch,
+    _getState: () => unknown,
+    { notificationService }: AppDependencies['services']
+  ) => {
     dispatch(flushIndicesStart({ indexNames }));
     try {
       await request(indexNames);

--- a/x-pack/platform/plugins/shared/index_management/public/application/store/actions/forcemerge_indices.ts
+++ b/x-pack/platform/plugins/shared/index_management/public/application/store/actions/forcemerge_indices.ts
@@ -9,15 +9,19 @@ import { createAction } from 'redux-actions';
 import { i18n } from '@kbn/i18n';
 import { forcemergeIndices as request } from '../../services';
 import { clearRowStatus, reloadIndices } from '.';
-import { notificationService } from '../../services/notification';
 import type { AppDispatch } from '../types';
 import { getHttpErrorToastMessage } from '../http_error';
+import type { AppDependencies } from '../../app_context';
 
 export const forcemergeIndicesStart = createAction('INDEX_MANAGEMENT_FORCEMERGE_INDICES_START');
 
 export const forcemergeIndices =
   ({ indexNames, maxNumSegments }: { indexNames: string[]; maxNumSegments: string }) =>
-  async (dispatch: AppDispatch) => {
+  async (
+    dispatch: AppDispatch,
+    _getState: () => unknown,
+    { notificationService }: AppDependencies['services']
+  ) => {
     dispatch(forcemergeIndicesStart({ indexNames }));
     try {
       await request(indexNames, maxNumSegments);

--- a/x-pack/platform/plugins/shared/index_management/public/application/store/actions/open_indices.ts
+++ b/x-pack/platform/plugins/shared/index_management/public/application/store/actions/open_indices.ts
@@ -9,15 +9,19 @@ import { createAction } from 'redux-actions';
 import { i18n } from '@kbn/i18n';
 import { openIndices as request } from '../../services';
 import { clearRowStatus, reloadIndices } from '.';
-import { notificationService } from '../../services/notification';
 import type { AppDispatch } from '../types';
 import { getHttpErrorToastMessage } from '../http_error';
+import type { AppDependencies } from '../../app_context';
 
 export const openIndicesStart = createAction('INDEX_MANAGEMENT_OPEN_INDICES_START');
 
 export const openIndices =
   ({ indexNames }: { indexNames: string[] }) =>
-  async (dispatch: AppDispatch) => {
+  async (
+    dispatch: AppDispatch,
+    _getState: () => unknown,
+    { notificationService }: AppDependencies['services']
+  ) => {
     dispatch(openIndicesStart({ indexNames }));
     try {
       await request(indexNames);

--- a/x-pack/platform/plugins/shared/index_management/public/application/store/actions/refresh_indices.ts
+++ b/x-pack/platform/plugins/shared/index_management/public/application/store/actions/refresh_indices.ts
@@ -10,14 +10,18 @@ import { i18n } from '@kbn/i18n';
 
 import { refreshIndices as request } from '../../services';
 import { clearRowStatus, reloadIndices } from '.';
-import { notificationService } from '../../services/notification';
 import type { AppDispatch } from '../types';
 import { getHttpErrorToastMessage } from '../http_error';
+import type { AppDependencies } from '../../app_context';
 
 export const refreshIndicesStart = createAction('INDEX_MANAGEMENT_REFRESH_INDICES_START');
 export const refreshIndices =
   ({ indexNames }: { indexNames: string[] }) =>
-  async (dispatch: AppDispatch) => {
+  async (
+    dispatch: AppDispatch,
+    _getState: () => unknown,
+    { notificationService }: AppDependencies['services']
+  ) => {
     dispatch(refreshIndicesStart({ indexNames }));
     try {
       await request(indexNames);

--- a/x-pack/platform/plugins/shared/index_management/public/application/store/actions/reload_indices.ts
+++ b/x-pack/platform/plugins/shared/index_management/public/application/store/actions/reload_indices.ts
@@ -10,14 +10,18 @@ import { i18n } from '@kbn/i18n';
 import type { Index } from '../../../../common';
 import { reloadIndices as request } from '../../services';
 import { loadIndices } from './load_indices';
-import { notificationService } from '../../services/notification';
 import type { AppDispatch } from '../types';
 import { toHttpError } from '../http_error';
+import type { AppDependencies } from '../../app_context';
 
 export const reloadIndicesSuccess = createAction('INDEX_MANAGEMENT_RELOAD_INDICES_SUCCESS');
 export const reloadIndices =
   (indexNames: string[], options?: { asSystemRequest?: boolean }) =>
-  async (dispatch: AppDispatch) => {
+  async (
+    dispatch: AppDispatch,
+    _getState: () => unknown,
+    { notificationService }: AppDependencies['services']
+  ) => {
     let indices: Index[] | undefined;
     try {
       indices = await request(indexNames, options);

--- a/x-pack/platform/plugins/shared/index_management/public/application/store/store.ts
+++ b/x-pack/platform/plugins/shared/index_management/public/application/store/store.ts
@@ -7,14 +7,14 @@
 
 import { createStore, applyMiddleware, compose } from 'redux';
 import thunk from 'redux-thunk';
-import type { Store } from 'redux';
+import type { Store, StoreEnhancer } from 'redux';
 import type { AppDependencies } from '../app_context';
 import { defaultTableState } from './reducers/table_state';
 
 import { getReducer } from './reducers';
 import type { IndexManagementState } from './types';
 
-type ReduxDevToolsExtension = () => ReturnType<typeof applyMiddleware>;
+type ReduxDevToolsExtension = () => StoreEnhancer;
 
 declare global {
   interface Window {
@@ -30,7 +30,7 @@ export function indexManagementStore(
     toggleNameToVisibleMap[toggleExtension.name] = false;
   });
   const initialState = { tableState: { ...defaultTableState, toggleNameToVisibleMap } };
-  const enhancers = [applyMiddleware(thunk)];
+  const enhancers: StoreEnhancer[] = [applyMiddleware(thunk.withExtraArgument(services))];
 
   if (window.__REDUX_DEVTOOLS_EXTENSION__) {
     enhancers.push(window.__REDUX_DEVTOOLS_EXTENSION__());

--- a/x-pack/platform/plugins/shared/index_management/public/application/store/types.ts
+++ b/x-pack/platform/plugins/shared/index_management/public/application/store/types.ts
@@ -10,6 +10,7 @@ import type { AnyAction } from 'redux';
 import type { ThunkDispatch } from 'redux-thunk';
 import type { Error as EsUiError } from '@kbn/es-ui-shared-plugin/public';
 import type { Index } from '../../../common';
+import type { AppDependencies } from '../app_context';
 
 export interface HttpError {
   status?: number;
@@ -41,4 +42,8 @@ export interface IndexManagementState {
   tableState: TableState;
 }
 
-export type AppDispatch = ThunkDispatch<IndexManagementState, void, AnyAction>;
+export type AppDispatch = ThunkDispatch<
+  IndexManagementState,
+  AppDependencies['services'],
+  AnyAction
+>;


### PR DESCRIPTION
## Summary
- Construct `NotificationService` at mount time and pass it through Index Management app dependencies.
- Remove the global `notificationService` singleton and wire thunk extra args to `AppDependencies['services']`.

Planned follow-up from https://github.com/elastic/kibana/pull/260603#discussion_r3083398937

## Test plan
- `node scripts/check_changes.ts`


Made with [Cursor](https://cursor.com)