### PR TITLE
[Macroscope] Follow-up Markdown formatting fix

### DIFF
--- a/.macroscope/flaky-test-runner-nudge.md
+++ b/.macroscope/flaky-test-runner-nudge.md
@@ -59,7 +59,7 @@ Post one comment on the PR. Include only the `/flaky` line(s) for the runner(s) 
 Trigger a run with the [Flaky Test Runner UI](https://ci-stats.kibana.dev/trigger_flaky_test_runner) or post this comment on the PR:
 
 ```
-/flaky <scoutConfig or ftrConfig>:<resolved-ftr-config-path>:30
+/flaky <scoutConfig or ftrConfig>:<resolved-scout-or-ftr-config-path>:30
 ```
 ````
 

--- a/.macroscope/flaky-test-runner-nudge.md
+++ b/.macroscope/flaky-test-runner-nudge.md
@@ -1,4 +1,3 @@
-`````markdown
 ---
 title: Flaky Test Runner nudge
 model: claude-opus-4-6
@@ -63,7 +62,6 @@ Trigger a run with the [Flaky Test Runner UI](https://ci-stats.kibana.dev/trigge
 /flaky <scoutConfig or ftrConfig>:<resolved-ftr-config-path>:30
 ```
 ````
-`````
 
 Replace the example paths with the resolved paths from Step 3. Drop whichever line doesn't apply. If Scout config could not be resolved (shared `kbn-scout*` package with no traceable imports), replace the `scoutConfig` line with a note asking the author to pick a suite manually in the UI. Sample commands:
 


### PR DESCRIPTION
I noticed we forgot to remove some Markdown formatting in https://github.com/elastic/kibana/pull/263290. This PR fixes it.