### PR TITLE
[9.4] Temporarily skip failing synthetics tests in cloud runs

### DIFF
--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/create_monitor_private_location.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/create_monitor_private_location.ts
@@ -30,6 +30,7 @@ import { SyntheticsMonitorTestService } from '../../services/synthetics_monitor'
 
 export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
   describe('PrivateLocationCreateMonitor', function () {
+    this.tags(['skipCloud']);
     const kibanaServer = getService('kibanaServer');
     const supertestWithoutAuth = getService('supertestWithoutAuth');
     // TODO: Replace with roleScopedSupertest for deployment-agnostic compatibility

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/create_monitor_project_private_location.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/create_monitor_project_private_location.ts
@@ -31,6 +31,7 @@ import { comparePolicies } from './sample_data/test_policy';
 
 export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
   describe('AddProjectMonitorsPrivateLocations', function () {
+    this.tags(['skipCloud']);
     const supertestWithoutAuth = getService('supertestWithoutAuth');
     // TODO: Replace with roleScopedSupertest for deployment-agnostic compatibility
     // eslint-disable-next-line @kbn/eslint/deployment_agnostic_test_context

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/edit_monitor_public_api_private_location.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/edit_monitor_public_api_private_location.ts
@@ -20,6 +20,7 @@ import { PrivateLocationTestService } from '../../services/synthetics_private_lo
 
 export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
   describe('EditMonitorsPublicAPI - Private Location', function () {
+    this.tags(['skipCloud']);
     const supertestAPI = getService('supertestWithoutAuth');
     const kibanaServer = getService('kibanaServer');
     const samlAuth = getService('samlAuth');

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/edit_private_location.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/edit_private_location.ts
@@ -20,6 +20,7 @@ import type { SupertestWithRoleScopeType } from '../../services';
 
 export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
   describe('EditPrivateLocationAPI', function () {
+    this.tags(['skipCloud']);
     const kibanaServer = getService('kibanaServer');
     const supertestWithoutAuth = getService('supertestWithoutAuth');
     const samlAuth = getService('samlAuth');

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/migrate_legacy_policies.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/migrate_legacy_policies.ts
@@ -28,6 +28,7 @@ import { SyntheticsMonitorTestService } from '../../services/synthetics_monitor'
  */
 export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
   describe('MigrateLegacyPolicies', function () {
+    this.tags(['skipCloud']);
     const kibanaServer = getService('kibanaServer');
     const supertestWithoutAuth = getService('supertestWithoutAuth');
     const roleScopedSupertest = getService('roleScopedSupertest');


### PR DESCRIPTION
Temporarily skip failing synthetics tests in cloud runs