### PR TITLE
[9.4] [Security Solution] Re-validate EQL query when index pattern changes (#261027)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation/components/eql_query_edit/eql_query_bar.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation/components/eql_query_edit/eql_query_bar.test.tsx
@@ -55,6 +55,40 @@ describe('EqlQueryBar', () => {
     expect(wrapper.find('[data-test-subj="eqlFilterBar"]')).toHaveLength(1);
   });
 
+  it('re-validates when index pattern id or title changes', () => {
+    const validate = jest.fn();
+    mockField = useFormFieldMock({
+      value: mockQueryBar,
+      validate,
+    });
+
+    const { rerender } = render(
+      <TestProviders>
+        <EqlQueryBar
+          dataTestSubj="myQueryBar"
+          field={mockField}
+          isLoading={false}
+          indexPattern={mockIndexPattern}
+        />
+      </TestProviders>
+    );
+
+    expect(validate).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <TestProviders>
+        <EqlQueryBar
+          dataTestSubj="myQueryBar"
+          field={mockField}
+          isLoading={false}
+          indexPattern={{ ...mockIndexPattern, title: 'other-*' }}
+        />
+      </TestProviders>
+    );
+
+    expect(validate).toHaveBeenCalledTimes(2);
+  });
+
   it('should set the field value on input change', () => {
     render(
       <TestProviders>

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation/components/eql_query_edit/eql_query_bar.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation/components/eql_query_edit/eql_query_bar.tsx
@@ -54,6 +54,8 @@ export const EqlQueryBar: FC<EqlQueryBarProps> = ({
   const { addError } = useAppToasts();
   const { uiSettings } = useKibana().services;
   const filterManager = useRef<FilterManager>(new FilterManager(uiSettings));
+  const validateRef = useRef(field.validate);
+  validateRef.current = field.validate;
   const { isValidating, value: fieldValue, setValue: setFieldValue, isValid, errors } = field;
   const errorMessages = useMemo(() => errors.map((x) => x.message), [errors]);
 
@@ -82,6 +84,14 @@ export const EqlQueryBar: FC<EqlQueryBarProps> = ({
       addError(requestError.message, { title: i18n.EQL_VALIDATION_REQUEST_ERROR });
     }
   }, [errors, addError]);
+
+  // `use_field` only re-runs validators when the field value changes. The EQL validator closes
+  // over the current data view / index pattern, so errors from a previous index can stick around
+  // after switching back to a valid index until the user edits the query. Re-validate whenever
+  // the index pattern identity changes.
+  useEffect(() => {
+    void validateRef.current();
+  }, [indexPattern.id, indexPattern.title]);
 
   useEffect(() => {
     if (onValidatingChange) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Security Solution] Re-validate EQL query when index pattern changes (#261027)](https://github.com/elastic/kibana/pull/261027)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Devin W. Hurley","email":"devin.hurley@elastic.co"},"sourceCommit":{"committedDate":"2026-04-13T18:40:43Z","message":"[Security Solution] Re-validate EQL query when index pattern changes (#261027)\n\n## Summary\n\nFixes https://github.com/elastic/kibana/issues/260991\n\nWhen editing an EQL detection rule, switching the index pattern / data\nview (e.g. valid index → closed index → valid index) without changing\nthe query text left stale validation errors on screen. The hook form\nlibrary only re-runs validators when the **field value** changes, while\nthe EQL validator already closes over the updated data view from\n`EqlQueryEdit`.\n\n## Changes\n\n- **`eql_query_bar.tsx`**: Call `field.validate()` in an effect when\n`indexPattern.id` or `indexPattern.title` changes. Use a ref to hold the\nlatest `validate` so we do not depend on `validate` in the effect deps\n(which would re-run on every keystroke and duplicate debounced EQL\nvalidation).\n- **`eql_query_bar.test.tsx`**: Unit test that `validate` runs on mount\nand again when the index pattern title changes.\n\n## Release note\n\nFixes EQL rule creation so the query field re-validates after changing\nthe index pattern, clearing errors when the query is valid for the newly\nselected data view.\n\nMade with [Cursor](https://cursor.com)","sha":"bce427afe5dcf5db3959a39dbc04a80130cb0423","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["review","release_note:fix","backport missing","Feature:Detection Rules","Feature:Event Correlation (EQL) Rule","Feature:Rule Creation","Team:Detection Engine","Feature:Rule Edit","backport:version","v9.4.0","v9.5.0","v9.3.4","v9.2.9","v8.19.15"],"title":"[Security Solution] Re-validate EQL query when index pattern changes","number":261027,"url":"https://github.com/elastic/kibana/pull/261027","mergeCommit":{"message":"[Security Solution] Re-validate EQL query when index pattern changes (#261027)\n\n## Summary\n\nFixes https://github.com/elastic/kibana/issues/260991\n\nWhen editing an EQL detection rule, switching the index pattern / data\nview (e.g. valid index → closed index → valid index) without changing\nthe query text left stale validation errors on screen. The hook form\nlibrary only re-runs validators when the **field value** changes, while\nthe EQL validator already closes over the updated data view from\n`EqlQueryEdit`.\n\n## Changes\n\n- **`eql_query_bar.tsx`**: Call `field.validate()` in an effect when\n`indexPattern.id` or `indexPattern.title` changes. Use a ref to hold the\nlatest `validate` so we do not depend on `validate` in the effect deps\n(which would re-run on every keystroke and duplicate debounced EQL\nvalidation).\n- **`eql_query_bar.test.tsx`**: Unit test that `validate` runs on mount\nand again when the index pattern title changes.\n\n## Release note\n\nFixes EQL rule creation so the query field re-validates after changing\nthe index pattern, clearing errors when the query is valid for the newly\nselected data view.\n\nMade with [Cursor](https://cursor.com)","sha":"bce427afe5dcf5db3959a39dbc04a80130cb0423"}},"sourceBranch":"main","suggestedTargetBranches":["9.4","9.3","9.2","8.19"],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/261027","number":261027,"mergeCommit":{"message":"[Security Solution] Re-validate EQL query when index pattern changes (#261027)\n\n## Summary\n\nFixes https://github.com/elastic/kibana/issues/260991\n\nWhen editing an EQL detection rule, switching the index pattern / data\nview (e.g. valid index → closed index → valid index) without changing\nthe query text left stale validation errors on screen. The hook form\nlibrary only re-runs validators when the **field value** changes, while\nthe EQL validator already closes over the updated data view from\n`EqlQueryEdit`.\n\n## Changes\n\n- **`eql_query_bar.tsx`**: Call `field.validate()` in an effect when\n`indexPattern.id` or `indexPattern.title` changes. Use a ref to hold the\nlatest `validate` so we do not depend on `validate` in the effect deps\n(which would re-run on every keystroke and duplicate debounced EQL\nvalidation).\n- **`eql_query_bar.test.tsx`**: Unit test that `validate` runs on mount\nand again when the index pattern title changes.\n\n## Release note\n\nFixes EQL rule creation so the query field re-validates after changing\nthe index pattern, clearing errors when the query is valid for the newly\nselected data view.\n\nMade with [Cursor](https://cursor.com)","sha":"bce427afe5dcf5db3959a39dbc04a80130cb0423"}},{"branch":"9.3","label":"v9.3.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.2","label":"v9.2.9","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.15","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->