### PR TITLE
[Security Solution] add AT telemetry

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/routes/workflow_insights/create_insights.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/routes/workflow_insights/create_insights.test.ts
@@ -294,6 +294,103 @@ describe('Create Insights Route Handler', () => {
     });
   });
 
+  describe('telemetry', () => {
+    it('reports scan_triggered event on successful scan', async () => {
+      const reportEventMock = jest.fn();
+      (mockEndpointContext.service.getTelemetryService as jest.Mock).mockReturnValue({
+        reportEvent: reportEventMock,
+      });
+
+      await callRoute({
+        insightTypes: ['incompatible_antivirus'],
+        endpointIds: ['endpoint-1'],
+        connectorId: 'my-connector',
+      });
+
+      expect(reportEventMock).toHaveBeenCalledWith(
+        'endpoint_workflow_insights_scan_triggered_event',
+        {
+          insightTypes: ['incompatible_antivirus'],
+          endpointCount: 1,
+          hasConnectorId: true,
+          newExecutions: 1,
+          deduplicatedExecutions: 0,
+          failures: 0,
+        }
+      );
+    });
+
+    it('reports correct counts when some executions are deduplicated', async () => {
+      const reportEventMock = jest.fn();
+      (mockEndpointContext.service.getTelemetryService as jest.Mock).mockReturnValue({
+        reportEvent: reportEventMock,
+      });
+
+      mockAgentBuilder.execution.findExecutions.mockResolvedValue([
+        {
+          executionId: 'existing-exec-id',
+          status: ExecutionStatus.running,
+          metadata: {
+            source: AUTOMATIC_TROUBLESHOOTING_TAG,
+            insightType: 'incompatible_antivirus',
+            endpointId: 'endpoint-1',
+          },
+          '@timestamp': '2024-01-01T00:00:00Z',
+          agentId: 'agent-1',
+          spaceId: 'default',
+          agentParams: { conversationId: 'existing-conv-id' },
+          eventCount: 0,
+          events: [],
+        },
+      ]);
+
+      await callRoute({
+        insightTypes: ['incompatible_antivirus', 'policy_response_failure'],
+        endpointIds: ['endpoint-1'],
+      });
+
+      expect(reportEventMock).toHaveBeenCalledWith(
+        'endpoint_workflow_insights_scan_triggered_event',
+        {
+          insightTypes: ['incompatible_antivirus', 'policy_response_failure'],
+          endpointCount: 1,
+          hasConnectorId: false,
+          newExecutions: 1,
+          deduplicatedExecutions: 1,
+          failures: 0,
+        }
+      );
+    });
+
+    it('reports failure count when executions fail to start', async () => {
+      const reportEventMock = jest.fn();
+      (mockEndpointContext.service.getTelemetryService as jest.Mock).mockReturnValue({
+        reportEvent: reportEventMock,
+      });
+
+      mockAgentBuilder.execution.executeAgent
+        .mockResolvedValueOnce({ executionId: 'exec-1', events$: EMPTY })
+        .mockRejectedValueOnce(new Error('connector not configured'));
+
+      await callRoute({
+        insightTypes: ['incompatible_antivirus', 'policy_response_failure'],
+        endpointIds: ['endpoint-1'],
+      });
+
+      expect(reportEventMock).toHaveBeenCalledWith(
+        'endpoint_workflow_insights_scan_triggered_event',
+        {
+          insightTypes: ['incompatible_antivirus', 'policy_response_failure'],
+          endpointCount: 1,
+          hasConnectorId: false,
+          newExecutions: 1,
+          deduplicatedExecutions: 0,
+          failures: 1,
+        }
+      );
+    });
+  });
+
   describe('authorization', () => {
     it('returns forbidden when user lacks canWriteWorkflowInsights', async () => {
       await callRoute(

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/routes/workflow_insights/create_insights.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/routes/workflow_insights/create_insights.ts
@@ -10,6 +10,7 @@ import pMap from 'p-map';
 import type { IKibanaResponse, RequestHandler } from '@kbn/core/server';
 import { ExecutionStatus } from '@kbn/agent-builder-plugin/server';
 import { AgentExecutionMode } from '@kbn/agent-builder-common';
+import { ENDPOINT_WORKFLOW_INSIGHTS_SCAN_TRIGGERED_EVENT } from '../../../lib/telemetry/event_based/events';
 import type { CreateWorkflowInsightRequestBody } from '../../../../common/api/endpoint/workflow_insights';
 import { CreateWorkflowInsightRequestSchema } from '../../../../common/api/endpoint/workflow_insights/workflow_insights';
 import type { WorkflowInsightType } from '../../../../common/endpoint/types/workflow_insights';
@@ -217,6 +218,20 @@ const createInsightsRouteHandler = (
 
       // Include deduplicated (already-running) executions so the FE can always start polling
       const executions: ExecutionResult[] = [...alreadyRunning, ...createdExecutions];
+
+      try {
+        const telemetry = endpointContext.service.getTelemetryService();
+        telemetry.reportEvent(ENDPOINT_WORKFLOW_INSIGHTS_SCAN_TRIGGERED_EVENT.eventType, {
+          insightTypes,
+          endpointCount: endpointIds.length,
+          hasConnectorId: !!connectorId,
+          newExecutions: createdExecutions.length,
+          deduplicatedExecutions: alreadyRunning.length,
+          failures: failures.length,
+        });
+      } catch (e) {
+        logger.debug(`Failed to report scan_triggered telemetry: ${e.message}`);
+      }
 
       return response.ok({
         body: { executions, ...(failures.length > 0 ? { failures } : {}) },

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/routes/workflow_insights/update_insight.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/routes/workflow_insights/update_insight.test.ts
@@ -307,7 +307,9 @@ describe('Update Insights Route Handler', () => {
         reportEvent: reportEventMock,
       });
 
-      fetchMock.mockResolvedValue([{ _id: '1', _index: 'index-123', _source: {} }]);
+      fetchMock.mockResolvedValue([
+        { _id: '1', _index: 'index-123', _source: { type: 'incompatible_antivirus' } },
+      ]);
       updateMock.mockResolvedValue({ id: 1 });
 
       await callRoute(
@@ -322,6 +324,34 @@ describe('Update Insights Route Handler', () => {
 
       expect(reportEventMock).toHaveBeenCalledWith('endpoint_workflow_insights_remediated_event', {
         insightId: '1',
+        insightType: 'incompatible_antivirus',
+      });
+    });
+
+    it('should report telemetry when action.type is dismissed', async () => {
+      const reportEventMock = jest.fn();
+      const mockEndpointContext = createMockEndpointAppContext();
+      mockEndpointContext.service.getTelemetryService = jest.fn().mockReturnValue({
+        reportEvent: reportEventMock,
+      });
+
+      fetchMock.mockResolvedValue([
+        { _id: '1', _index: 'index-123', _source: { type: 'policy_response_failure' } },
+      ]);
+      updateMock.mockResolvedValue({ id: 1 });
+
+      await callRoute(
+        { insightId: '1' },
+        { action: { type: 'dismissed' } },
+        {
+          canWriteWorkflowInsights: false,
+          canReadWorkflowInsights: true,
+        },
+        mockEndpointContext
+      );
+
+      expect(reportEventMock).toHaveBeenCalledWith('endpoint_workflow_insights_dismissed_event', {
+        insightType: 'policy_response_failure',
       });
     });
 

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/routes/workflow_insights/update_insight.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/routes/workflow_insights/update_insight.ts
@@ -6,7 +6,10 @@
  */
 
 import type { RequestHandler } from '@kbn/core/server';
-import { ENDPOINT_WORKFLOW_INSIGHTS_REMEDIATED_EVENT } from '../../../lib/telemetry/event_based/events';
+import {
+  ENDPOINT_WORKFLOW_INSIGHTS_REMEDIATED_EVENT,
+  ENDPOINT_WORKFLOW_INSIGHTS_DISMISSED_EVENT,
+} from '../../../lib/telemetry/event_based/events';
 import type {
   UpdateWorkflowInsightsRequestBody,
   UpdateWorkflowInsightsRequestParams,
@@ -81,19 +84,11 @@ const updateInsightsRouteHandler = (
       });
     }
 
+    const actionType = request.body.action?.type;
     const onlyActionTypeUpdate = isOnlyActionTypeUpdate(request.body);
 
     if (!canWriteWorkflowInsights && !onlyActionTypeUpdate) {
       return response.forbidden({ body: 'Unauthorized to update workflow insights' });
-    }
-
-    if (onlyActionTypeUpdate) {
-      if (request.body.action?.type === 'remediated') {
-        const telemetry = endpointContext.service.getTelemetryService();
-        telemetry.reportEvent(ENDPOINT_WORKFLOW_INSIGHTS_REMEDIATED_EVENT.eventType, {
-          insightId,
-        });
-      }
     }
 
     logger.debug(`Updating insight ${insightId}`);
@@ -130,6 +125,26 @@ const updateInsightsRouteHandler = (
         request.body as Partial<SecurityWorkflowInsight>,
         backingIndex
       );
+
+      if (onlyActionTypeUpdate) {
+        try {
+          const telemetry = endpointContext.service.getTelemetryService();
+          const insightType = retrievedInsight._source?.type ?? 'unknown';
+          if (actionType === 'remediated') {
+            telemetry.reportEvent(ENDPOINT_WORKFLOW_INSIGHTS_REMEDIATED_EVENT.eventType, {
+              insightId,
+              insightType,
+            });
+          } else if (actionType === 'dismissed') {
+            telemetry.reportEvent(ENDPOINT_WORKFLOW_INSIGHTS_DISMISSED_EVENT.eventType, {
+              insightType,
+            });
+          }
+        } catch (e) {
+          logger.debug(`Failed to report workflow insights telemetry: ${e.message}`);
+        }
+      }
+
       return response.ok({ body });
     } catch (e) {
       return errorHandler(logger, response, e);

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/workflow_insights/index.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/workflow_insights/index.test.ts
@@ -234,6 +234,59 @@ describe('SecurityWorkflowInsightsService', () => {
   });
 
   describe('createFromDefendInsights', () => {
+    it('should report insight_created telemetry event', async () => {
+      const reportEventMock = jest.fn();
+      mockEndpointAppContextService.getTelemetryService = jest.fn().mockReturnValue({
+        reportEvent: reportEventMock,
+      });
+
+      const insight: DefendInsight = {
+        group: 'TestAV',
+        events: [
+          {
+            id: 'event-1',
+            endpointId: 'endpoint-1',
+            value: '/path/to/process',
+          },
+        ],
+      };
+
+      const workflowInsights: SecurityWorkflowInsight[] = [getDefaultInsight()];
+      (buildWorkflowInsights as jest.Mock).mockResolvedValueOnce(workflowInsights);
+
+      const esClientIndexResp = {
+        _index: DATA_STREAM_NAME,
+        _id: '1',
+        result: 'created' as const,
+        _shards: { total: 1, successful: 1, failed: 0 },
+        _version: 1,
+      };
+      jest.spyOn(esClient, 'index').mockResolvedValue(esClientIndexResp);
+
+      securityWorkflowInsightsService.setup({
+        kibanaVersion: kibanaPackageJson.version,
+        logger,
+        endpointContext: mockEndpointAppContextService,
+      });
+      await securityWorkflowInsightsService.start({
+        esClient,
+        registerDefendInsightsCallback: jest.fn(),
+      });
+
+      await securityWorkflowInsightsService.createFromDefendInsights(
+        [insight],
+        ['endpoint-1'],
+        WorkflowInsightType.enum.incompatible_antivirus,
+        'connector-id',
+        'model-name'
+      );
+
+      expect(reportEventMock).toHaveBeenCalledWith('endpoint_workflow_insights_created_event', {
+        insightType: 'incompatible_antivirus',
+        count: 1,
+      });
+    });
+
     it('should create workflow insights from defend insights', async () => {
       const insight = {
         group: 'AVGAntivirus',

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/workflow_insights/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/workflow_insights/index.ts
@@ -27,6 +27,7 @@ import type {
 } from '../../../../common/endpoint/types/workflow_insights';
 import { WorkflowInsightActionType } from '../../../../common/endpoint/types/workflow_insights';
 
+import { ENDPOINT_WORKFLOW_INSIGHTS_CREATED_EVENT } from '../../../lib/telemetry/event_based/events';
 import type { EndpointAppContextService } from '../../endpoint_app_context_services';
 import { SecurityWorkflowInsightsFailedInitialized } from './errors';
 import {
@@ -321,7 +322,19 @@ class SecurityWorkflowInsightsService {
 
     const uniqueInsights = getUniqueInsights(workflowInsights);
 
-    return Promise.all(uniqueInsights.map((insight) => this.create(insight)));
+    const results = await Promise.all(uniqueInsights.map((insight) => this.create(insight)));
+
+    try {
+      const telemetry = this.endpointContext.getTelemetryService();
+      telemetry.reportEvent(ENDPOINT_WORKFLOW_INSIGHTS_CREATED_EVENT.eventType, {
+        insightType,
+        count: uniqueInsights.length,
+      });
+    } catch (e) {
+      this.logger.debug(`Failed to report insight creation telemetry: ${e.message}`);
+    }
+
+    return results;
   }
 
   public async ensureAgentIdsInCurrentSpace(

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/event_based/events.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/event_based/events.ts
@@ -1849,13 +1849,123 @@ export const ENDPOINT_RESPONSE_ACTION_STATUS_CHANGE_EVENT: EventTypeOpts<{
 
 export const ENDPOINT_WORKFLOW_INSIGHTS_REMEDIATED_EVENT: EventTypeOpts<{
   insightId: string;
+  insightType: string;
 }> = {
   eventType: 'endpoint_workflow_insights_remediated_event',
   schema: {
     insightId: {
       type: 'keyword',
       _meta: {
-        description: 'The ID of the action that was sent to the endpoint',
+        description: 'The ID of the workflow insight that was remediated',
+        optional: false,
+      },
+    },
+    insightType: {
+      type: 'keyword',
+      _meta: {
+        description:
+          'The type of the workflow insight (e.g. incompatible_antivirus, policy_response_failure)',
+        optional: false,
+      },
+    },
+  },
+};
+
+export const ENDPOINT_WORKFLOW_INSIGHTS_SCAN_TRIGGERED_EVENT: EventTypeOpts<{
+  insightTypes: string[];
+  endpointCount: number;
+  hasConnectorId: boolean;
+  newExecutions: number;
+  deduplicatedExecutions: number;
+  failures: number;
+}> = {
+  eventType: 'endpoint_workflow_insights_scan_triggered_event',
+  schema: {
+    insightTypes: {
+      type: 'array',
+      items: {
+        type: 'keyword',
+        _meta: {
+          description: 'An insight type requested in the scan',
+          optional: false,
+        },
+      },
+      _meta: {
+        description: 'The insight types requested in the scan',
+        optional: false,
+      },
+    },
+    endpointCount: {
+      type: 'long',
+      _meta: {
+        description: 'Number of endpoints targeted by the scan',
+        optional: false,
+      },
+    },
+    hasConnectorId: {
+      type: 'boolean',
+      _meta: {
+        description: 'Whether a specific connector was selected for the scan',
+        optional: false,
+      },
+    },
+    newExecutions: {
+      type: 'long',
+      _meta: {
+        description: 'Number of new agent executions created',
+        optional: false,
+      },
+    },
+    deduplicatedExecutions: {
+      type: 'long',
+      _meta: {
+        description: 'Number of executions skipped because they were already in-flight',
+        optional: false,
+      },
+    },
+    failures: {
+      type: 'long',
+      _meta: {
+        description: 'Number of executions that failed to start',
+        optional: false,
+      },
+    },
+  },
+};
+
+export const ENDPOINT_WORKFLOW_INSIGHTS_CREATED_EVENT: EventTypeOpts<{
+  insightType: string;
+  count: number;
+}> = {
+  eventType: 'endpoint_workflow_insights_created_event',
+  schema: {
+    insightType: {
+      type: 'keyword',
+      _meta: {
+        description: 'The type of insights created',
+        optional: false,
+      },
+    },
+    count: {
+      type: 'long',
+      _meta: {
+        description: 'Number of insights created in this batch',
+        optional: false,
+      },
+    },
+  },
+};
+
+export const ENDPOINT_WORKFLOW_INSIGHTS_DISMISSED_EVENT: EventTypeOpts<{
+  insightType: string;
+}> = {
+  eventType: 'endpoint_workflow_insights_dismissed_event',
+  schema: {
+    insightType: {
+      type: 'keyword',
+      _meta: {
+        description:
+          'The type of the workflow insight (e.g. incompatible_antivirus, policy_response_failure)',
         optional: false,
       },
     },
@@ -1961,6 +2071,9 @@ export const events = [
   ENDPOINT_RESPONSE_ACTION_SENT_ERROR_EVENT,
   ENDPOINT_RESPONSE_ACTION_STATUS_CHANGE_EVENT,
   ENDPOINT_WORKFLOW_INSIGHTS_REMEDIATED_EVENT,
+  ENDPOINT_WORKFLOW_INSIGHTS_SCAN_TRIGGERED_EVENT,
+  ENDPOINT_WORKFLOW_INSIGHTS_CREATED_EVENT,
+  ENDPOINT_WORKFLOW_INSIGHTS_DISMISSED_EVENT,
   FIELD_RETENTION_ENRICH_POLICY_EXECUTION_EVENT,
   ENTITY_STORE_DATA_VIEW_REFRESH_EXECUTION_EVENT,
   ENTITY_STORE_SNAPSHOT_TASK_EXECUTION_EVENT,


### PR DESCRIPTION
## Summary

Adds additional event based telemetry for Automatic Troubleshooting:
- scan triggered
- insight created
- insight dismissed


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios