### PR TITLE
[FeatureBranch/DoNotReview][Chrome Next] Add context switcher UI package

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -452,6 +452,7 @@ src/platform/packages/shared/content-management/table_list_view @elastic/appex-s
 src/platform/packages/shared/content-management/table_list_view_common @elastic/appex-sharedux
 src/platform/packages/shared/content-management/table_list_view_table @elastic/appex-sharedux
 src/platform/packages/shared/content-management/user_profiles @elastic/appex-sharedux
+src/platform/packages/shared/context-switcher-components @elastic/appex-sharedux
 src/platform/packages/shared/controls/control-group-renderer @elastic/kibana-presentation
 src/platform/packages/shared/controls/controls-constants @elastic/kibana-presentation
 src/platform/packages/shared/controls/controls-schemas @elastic/kibana-presentation

--- a/package.json
+++ b/package.json
@@ -318,6 +318,7 @@
     "@kbn/content-management-user-profiles": "link:src/platform/packages/shared/content-management/user_profiles",
     "@kbn/content-management-utils": "link:src/platform/packages/shared/kbn-content-management-utils",
     "@kbn/content-packs-schema": "link:x-pack/platform/packages/shared/kbn-content-packs-schema",
+    "@kbn/context-switcher-components": "link:src/platform/packages/shared/context-switcher-components",
     "@kbn/control-group-renderer": "link:src/platform/packages/shared/controls/control-group-renderer",
     "@kbn/controls-constants": "link:src/platform/packages/shared/controls/controls-constants",
     "@kbn/controls-example-plugin": "link:examples/controls_example",

--- a/src/dev/storybook/aliases.ts
+++ b/src/dev/storybook/aliases.ts
@@ -24,6 +24,8 @@ export const storybookAliases = {
   content_management:
     'src/platform/packages/shared/content-management/kbn-content-management-storybook',
   content_management_examples: 'examples/content_management_examples/.storybook',
+  context_switcher_components:
+    'src/platform/packages/shared/context-switcher-components/.storybook',
   classic_stream_flyout: 'x-pack/platform/packages/shared/kbn-classic-stream-flyout/.storybook',
   custom_icons: 'src/platform/packages/shared/kbn-custom-icons/.storybook',
   custom_integrations: 'src/platform/plugins/shared/custom_integrations/storybook',

--- a/src/platform/packages/shared/context-switcher-components/.storybook/main.js
+++ b/src/platform/packages/shared/context-switcher-components/.storybook/main.js
@@ -1,0 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+module.exports = require('@kbn/storybook').defaultConfig;

--- a/src/platform/packages/shared/context-switcher-components/README.md
+++ b/src/platform/packages/shared/context-switcher-components/README.md
@@ -1,0 +1,3 @@
+# @kbn/context-switcher-components
+
+Context switcher components.

--- a/src/platform/packages/shared/context-switcher-components/index.ts
+++ b/src/platform/packages/shared/context-switcher-components/index.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export { ContextSwitcher } from './src/components/context_switcher';
+export type {
+  ContextSwitcherProps,
+  ContextSwitcherSpacesConfig,
+  ContextSwitcherEnvironmentConfig,
+  SpaceItem,
+  LinksListItem,
+  FooterAction,
+} from './src/components/types';

--- a/src/platform/packages/shared/context-switcher-components/jest.config.js
+++ b/src/platform/packages/shared/context-switcher-components/jest.config.js
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+module.exports = {
+  preset: '@kbn/test',
+  rootDir: '../../../../..',
+  roots: ['<rootDir>/src/platform/packages/shared/context-switcher-components'],
+};

--- a/src/platform/packages/shared/context-switcher-components/kibana.jsonc
+++ b/src/platform/packages/shared/context-switcher-components/kibana.jsonc
@@ -1,0 +1,7 @@
+{
+  "type": "shared-browser",
+  "id": "@kbn/context-switcher-components",
+  "owner": "@elastic/appex-sharedux",
+  "group": "platform",
+  "visibility": "shared"
+}

--- a/src/platform/packages/shared/context-switcher-components/package.json
+++ b/src/platform/packages/shared/context-switcher-components/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@kbn/context-switcher-components",
+  "private": true,
+  "version": "1.0.0",
+  "license": "Elastic License 2.0 OR AGPL-3.0-only OR SSPL-1.0",
+  "sideEffects": false
+}

--- a/src/platform/packages/shared/context-switcher-components/src/components/context_row.tsx
+++ b/src/platform/packages/shared/context-switcher-components/src/components/context_row.tsx
@@ -1,0 +1,78 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import { EuiFlexGroup, EuiFlexItem, EuiIcon, EuiListGroupItem, EuiText } from '@elastic/eui';
+import { css } from '@emotion/react';
+import { CONTEXT_ROW_HEIGHT, type ContextRowModel } from './types';
+
+export interface ContextRowProps {
+  readonly row: ContextRowModel;
+  readonly onClick: () => void;
+}
+
+/**
+ * The row component for the context switcher that contains the avatar, the title, the subtitle and the chevron.
+ */
+
+export const ContextRow = ({ row, onClick }: ContextRowProps) => {
+  const rowStyles = css`
+    && .euiListGroupItem__label {
+      flex: 1 1 auto;
+      min-width: 0;
+    }
+    && .euiListGroupItem__button {
+      min-height: ${CONTEXT_ROW_HEIGHT}px;
+    }
+    /* no underline */
+    && .euiListGroupItem__button:hover,
+    && .euiListGroupItem__button:focus {
+      text-decoration: none;
+    }
+  `;
+
+  const truncateCss = css`
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  `;
+
+  const rowLabel = (
+    <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
+      <EuiFlexItem grow>
+        <EuiText size="s" css={truncateCss}>
+          {row.label}
+        </EuiText>
+        {row.value != null && (
+          <EuiText size="xs" color="subdued" css={truncateCss}>
+            {row.value}
+          </EuiText>
+        )}
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiIcon type="arrowRight" size="m" color="subdued" aria-hidden={true} />
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+
+  return (
+    <EuiListGroupItem
+      css={rowStyles}
+      label={rowLabel}
+      icon={row.prepend}
+      onClick={onClick}
+      isDisabled={row.disabled}
+      aria-label={row.ariaLabel}
+      data-test-subj={row['data-test-subj']}
+      size="s"
+      color="text"
+    />
+  );
+};

--- a/src/platform/packages/shared/context-switcher-components/src/components/context_switcher.stories.tsx
+++ b/src/platform/packages/shared/context-switcher-components/src/components/context_switcher.stories.tsx
@@ -1,0 +1,219 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React, { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+import { EuiAvatar, EuiBadge, EuiButtonEmpty, EuiPanel } from '@elastic/eui';
+
+import { ContextSwitcher } from './context_switcher';
+import type { SpaceItem, LinksListItem } from './types';
+
+interface StoryArgs {
+  searchThreshold: number;
+}
+
+const meta: Meta<StoryArgs> = {
+  title: 'Context switcher',
+  parameters: { layout: 'centered' },
+  argTypes: {
+    searchThreshold: {
+      control: { type: 'number', min: 1, max: 15 },
+      description: 'Number of spaces required to show the search box',
+    },
+  },
+  args: {
+    searchThreshold: 15,
+  },
+};
+
+export default meta;
+type Story = StoryObj<StoryArgs>;
+
+const MOCK_SPACES: Array<SpaceItem> = [
+  { id: 'default', name: 'Default', solution: 'Security', solutionIcon: 'logoSecurity' },
+  {
+    id: 'obs',
+    name: 'My awesome space',
+    solution: 'Observability',
+    solutionIcon: 'logoObservability',
+  },
+  {
+    id: 'search',
+    name: 'One more space',
+    solution: 'Elasticsearch',
+    solutionIcon: 'logoElasticsearch',
+  },
+  { id: 'sec', name: 'Another awesome space', solution: 'Security', solutionIcon: 'logoSecurity' },
+  {
+    id: 'data',
+    name: 'Data Insight Realm',
+    solution: 'Elasticsearch',
+    solutionIcon: 'logoElasticsearch',
+  },
+  {
+    id: 'k',
+    name: 'Knowledge Discovery',
+    solution: 'Observability',
+    solutionIcon: 'logoObservability',
+  },
+];
+
+const MOCK_FOOTER_LINKS: LinksListItem[] = [
+  {
+    id: 'connection-details',
+    label: 'Connection details',
+    onClick: () => action('connection-details')(),
+    iconType: 'plugs',
+  },
+  {
+    id: 'manage-deployments',
+    label: 'Manage deployments',
+    onClick: () => action('manage-deployments')(),
+    iconType: 'gear',
+  },
+  {
+    id: 'invite-users',
+    label: 'Invite users',
+    href: 'https://example.com',
+    iconType: 'user',
+    external: true,
+  },
+];
+
+const buildSpaceItems = (showBadges: boolean): SpaceItem[] =>
+  MOCK_SPACES.map((s) => ({
+    ...s,
+    avatar: <EuiAvatar type="space" name={s.name} size="s" />,
+    badge: showBadges ? (
+      <EuiBadge color="hollow" iconType={s.solutionIcon}>
+        {s.solution}
+      </EuiBadge>
+    ) : undefined,
+  }));
+
+const buildManageAction = () => (
+  <EuiButtonEmpty size="s" onClick={action('manage-spaces')}>
+    Manage
+  </EuiButtonEmpty>
+);
+
+const useSpacesConfig = (showBadges: boolean, searchThreshold?: number) => {
+  const [activeSpaceId, setActiveSpaceId] = useState('obs');
+  const activeSpace = MOCK_SPACES.find((s) => s.id === activeSpaceId)!;
+  return {
+    active: activeSpace,
+    items: buildSpaceItems(showBadges),
+    onSelect: (spaceId: string) => {
+      action('select-space')(spaceId);
+      setActiveSpaceId(spaceId);
+    },
+    headerAction: buildManageAction(),
+    footerAction: SPACES_FOOTER_ACTION,
+    search: searchThreshold != null ? { threshold: searchThreshold } : undefined,
+  };
+};
+
+const SPACES_FOOTER_ACTION = {
+  id: 'create-space',
+  label: 'Create space',
+  onClick: () => action('create-space')(),
+};
+
+const CloudScenario = ({ searchThreshold }: { searchThreshold: number }) => {
+  const spaces = useSpacesConfig(true, searchThreshold);
+
+  return (
+    <EuiPanel color="subdued" paddingSize="m" hasBorder hasShadow={false}>
+      <ContextSwitcher
+        spaces={spaces}
+        environmentContext={{
+          environmentType: 'deployment',
+          name: 'My Favorite Deployment',
+          submenuItems: [
+            {
+              id: 'manage-discovery-insights',
+              label: 'Manage Discovery Insights',
+              iconType: 'gear',
+              onClick: () => action('manage-discovery-insights')(),
+            },
+            {
+              id: 'view-all-deployments',
+              label: 'View all deployments',
+              iconType: 'grid',
+              onClick: () => action('view-all-deployments')(),
+            },
+          ],
+          submenuFooterAction: {
+            id: 'create-deployment',
+            label: 'Create deployment',
+            onClick: () => action('create-deployment')(),
+          },
+        }}
+        footerLinks={MOCK_FOOTER_LINKS}
+      />
+    </EuiPanel>
+  );
+};
+
+const ServerlessScenario = ({ searchThreshold }: { searchThreshold: number }) => {
+  const spaces = useSpacesConfig(false, searchThreshold);
+
+  return (
+    <EuiPanel color="subdued" paddingSize="m" hasBorder hasShadow={false}>
+      <ContextSwitcher
+        spaces={spaces}
+        environmentContext={{
+          environmentType: 'project',
+          name: 'My Favorite Project',
+          submenuItems: [
+            {
+              id: 'manage-insightful-analytics',
+              label: 'Manage Insightful Analytics',
+              iconType: 'gear',
+              onClick: () => action('manage-insightful-analytics')(),
+            },
+            {
+              id: 'view-all-projects',
+              label: 'View all projects',
+              iconType: 'grid',
+              onClick: () => action('view-all-projects')(),
+            },
+          ],
+          submenuFooterAction: {
+            id: 'create-project',
+            label: 'Create project',
+            onClick: () => action('create-project')(),
+          },
+        }}
+        footerLinks={MOCK_FOOTER_LINKS}
+      />
+    </EuiPanel>
+  );
+};
+
+const SelfHostedScenario = ({ searchThreshold }: { searchThreshold: number }) => {
+  const spaces = useSpacesConfig(true, searchThreshold);
+
+  return (
+    <EuiPanel color="subdued" paddingSize="m" hasBorder hasShadow={false}>
+      <ContextSwitcher spaces={spaces} />
+    </EuiPanel>
+  );
+};
+
+export const CloudMode: Story = {
+  render: (args) => <CloudScenario searchThreshold={args.searchThreshold} />,
+};
+export const ServerlessMode: Story = {
+  render: (args) => <ServerlessScenario searchThreshold={args.searchThreshold} />,
+};
+export const SelfHostedMode: Story = {
+  render: (args) => <SelfHostedScenario searchThreshold={args.searchThreshold} />,
+};

--- a/src/platform/packages/shared/context-switcher-components/src/components/context_switcher.tsx
+++ b/src/platform/packages/shared/context-switcher-components/src/components/context_switcher.tsx
@@ -1,0 +1,240 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ReactElement } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
+import {
+  EuiAvatar,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiIcon,
+  EuiPopover,
+  useEuiTheme,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { SpacesListView } from './views/spaces_list';
+import type { SpacesListViewProps } from './views/spaces_list';
+import { ContextMenuView } from './views/context_menu';
+import type { ContextMenuViewProps } from './views/context_menu';
+import { ContextSubmenuView } from './views/context_submenu';
+import type { ContextSubmenuViewProps } from './views/context_submenu';
+import { ContextSwitcherTriggerButton } from './context_switcher_trigger_button';
+import { POPOVER_WIDTH, type ContextSwitcherProps, type SpaceItem } from './types';
+import type { SelectableListItem } from './selectable_list';
+
+const SEARCH_THRESHOLD = 15;
+
+const SUBMENU_TITLES: Record<'project' | 'deployment', string> = {
+  project: i18n.translate('contextSwitcherComponents.submenuTitle.projects', {
+    defaultMessage: 'My projects',
+  }),
+  deployment: i18n.translate('contextSwitcherComponents.submenuTitle.deployments', {
+    defaultMessage: 'My deployments',
+  }),
+};
+
+const SPACES_TITLE = i18n.translate('contextSwitcherComponents.spacesTitle', {
+  defaultMessage: 'Spaces',
+});
+
+const CONTEXT_SWITCHER_ARIA_LABEL = i18n.translate('contextSwitcherComponents.popover.ariaLabel', {
+  defaultMessage: 'Context switcher',
+});
+
+const mapSpaceToSelectableItem = (space: SpaceItem, activeId: string): SelectableListItem => ({
+  id: space.id,
+  label: space.name,
+  checked: space.id === activeId,
+  prepend: space.avatar ?? <EuiAvatar type="space" name={space.name} size="s" />,
+  append: space.badge,
+  'data-test-subj': `space-${space.id}`,
+});
+
+type PopoverViewId = 'root' | 'environment' | 'spaces';
+
+interface TwoStepContentProps {
+  readonly rootView: Omit<ContextMenuViewProps, 'onClickEnvironmentRow' | 'onClickSpacesRow'>;
+  readonly environmentSubmenuView: Omit<ContextSubmenuViewProps, 'onBack'>;
+  readonly spacesSubmenuView: Omit<SpacesListViewProps, 'onBack'>;
+}
+
+const TwoStepContent = ({
+  rootView,
+  environmentSubmenuView,
+  spacesSubmenuView,
+}: TwoStepContentProps) => {
+  const [view, setView] = useState<PopoverViewId>('root');
+
+  if (view === 'environment') {
+    return <ContextSubmenuView {...environmentSubmenuView} onBack={() => setView('root')} />;
+  }
+  if (view === 'spaces') {
+    return <SpacesListView {...spacesSubmenuView} onBack={() => setView('root')} />;
+  }
+  return (
+    <ContextMenuView
+      {...rootView}
+      onClickEnvironmentRow={() => setView('environment')}
+      onClickSpacesRow={() => setView('spaces')}
+    />
+  );
+};
+
+/**
+ * The context switcher component.
+ * It shows a trigger button and a popover.
+ * The popover can be a single step or a two step content.
+ * The single step content is the spaces list.
+ * The two step content is the context menu and the spaces list.
+ */
+export const ContextSwitcher = ({
+  spaces,
+  environmentContext,
+  footerLinks,
+}: ContextSwitcherProps) => {
+  const { euiTheme } = useEuiTheme();
+
+  const [isOpen, setIsOpen] = useState(false);
+  const togglePopover = useCallback(() => setIsOpen((prev) => !prev), []);
+  const closePopover = useCallback(() => setIsOpen(false), []);
+
+  const triggerButtonIcon = spaces.active.solutionIcon ?? 'logoElastic';
+
+  const selectableItems = useMemo(
+    () => spaces.items.map((space) => mapSpaceToSelectableItem(space, spaces.active.id)),
+    [spaces.items, spaces.active.id]
+  );
+
+  const handleSpaceSelect = useCallback<SpacesListViewProps['onSelect']>(
+    ({ item }) => {
+      spaces.onSelect(item.id);
+      closePopover();
+    },
+    [spaces, closePopover]
+  );
+
+  const searchConfig =
+    selectableItems.length >= (spaces.search?.threshold ?? SEARCH_THRESHOLD)
+      ? {
+          enabled: true,
+          props: {
+            placeholder:
+              spaces.search?.placeholder ??
+              i18n.translate('contextSwitcherComponents.searchPlaceholder', {
+                defaultMessage: 'Find a space',
+              }),
+            compressed: true,
+            isClearable: true,
+          },
+        }
+      : undefined;
+
+  const spacesViewProps = {
+    id: 'contextSwitcherSpacesList',
+    title: SPACES_TITLE,
+    headerAction: spaces.headerAction,
+    items: selectableItems,
+    onSelect: handleSpaceSelect,
+    search: searchConfig,
+    isLoading: spaces.isLoading,
+    footerAction: spaces.footerAction,
+  };
+
+  const environmentDescription =
+    environmentContext && spaces.active.solution
+      ? i18n.translate('contextSwitcherComponents.environmentContext.description', {
+          defaultMessage: '{solution} {kind}',
+          values: {
+            solution: spaces.active.solution,
+            kind: environmentContext.environmentType,
+          },
+        })
+      : undefined;
+
+  const environmentIcon: ReactElement | undefined =
+    environmentContext?.environmentType === 'project' && spaces.active.solutionIcon ? (
+      <EuiAvatar
+        type="space"
+        name={spaces.active.solution ?? ''}
+        iconType={spaces.active.solutionIcon}
+        iconSize="m"
+        size="l"
+        color={euiTheme.colors.backgroundBaseSubdued}
+      />
+    ) : undefined;
+
+  const spacesDescription =
+    spaces.active.solution && environmentContext?.environmentType === 'deployment' ? (
+      <EuiFlexGroup alignItems="center" gutterSize="xs" responsive={false} component="span">
+        {spaces.active.solutionIcon && (
+          <EuiFlexItem grow={false} component="span">
+            <EuiIcon type={spaces.active.solutionIcon} size="s" aria-hidden={true} />
+          </EuiFlexItem>
+        )}
+        <EuiFlexItem grow={false} component="span">
+          {i18n.translate('contextSwitcherComponents.spacesRow.description', {
+            defaultMessage: '{solution} space',
+            values: { solution: spaces.active.solution },
+          })}
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    ) : undefined;
+
+  return (
+    <EuiPopover
+      aria-label={CONTEXT_SWITCHER_ARIA_LABEL}
+      button={
+        <ContextSwitcherTriggerButton
+          solutionIcon={triggerButtonIcon}
+          spaceName={spaces.active.name}
+          onClick={togglePopover}
+          isSelected={isOpen}
+        />
+      }
+      isOpen={isOpen}
+      closePopover={closePopover}
+      anchorPosition="downLeft"
+      panelStyle={{ width: POPOVER_WIDTH }}
+      panelPaddingSize="s"
+      ownFocus
+      repositionOnScroll
+      data-test-subj="contextSwitcherPopover"
+    >
+      {!environmentContext ? (
+        <SpacesListView {...spacesViewProps} />
+      ) : (
+        <TwoStepContent
+          rootView={{
+            environmentRow: {
+              id: environmentContext.environmentType,
+              label: environmentContext.name,
+              value: environmentDescription,
+              prepend: environmentIcon,
+            },
+            spacesRow: {
+              id: 'spaces',
+              label: spaces.active.name,
+              prepend: spaces.active.avatar ?? (
+                <EuiAvatar type="space" name={spaces.active.name} size="l" />
+              ),
+              value: spacesDescription,
+            },
+            footerLinks,
+          }}
+          environmentSubmenuView={{
+            title: SUBMENU_TITLES[environmentContext.environmentType],
+            items: environmentContext.submenuItems,
+            footerAction: environmentContext.submenuFooterAction,
+          }}
+          spacesSubmenuView={spacesViewProps}
+        />
+      )}
+    </EuiPopover>
+  );
+};

--- a/src/platform/packages/shared/context-switcher-components/src/components/context_switcher_trigger_button.tsx
+++ b/src/platform/packages/shared/context-switcher-components/src/components/context_switcher_trigger_button.tsx
@@ -1,0 +1,64 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import type { ReactElement } from 'react';
+import type { IconType } from '@elastic/eui';
+import { EuiButtonEmpty, EuiIcon, useEuiTheme } from '@elastic/eui';
+import { css } from '@emotion/react';
+import { i18n } from '@kbn/i18n';
+
+const CONTEXT_SWITCHER_BUTTON_ARIA_LABEL = i18n.translate(
+  'contextSwitcherComponents.triggerButton.ariaLabel',
+  {
+    defaultMessage: 'Open context switcher',
+  }
+);
+
+interface ContextSwitcherTriggerButtonProps {
+  readonly solutionIcon: IconType;
+  readonly spaceName: string;
+  readonly onClick: () => void;
+  readonly isSelected?: boolean;
+}
+
+/**
+ * Trigger button UI for the context switcher popover.
+ * Solution logo (left), space name (middle), down arrow (right).
+ */
+export const ContextSwitcherTriggerButton = ({
+  solutionIcon,
+  spaceName,
+  onClick,
+  isSelected,
+}: ContextSwitcherTriggerButtonProps): ReactElement => {
+  const { euiTheme } = useEuiTheme();
+
+  return (
+    <EuiButtonEmpty
+      color="text"
+      size="m"
+      onClick={onClick}
+      iconType="arrowDown"
+      iconSide="right"
+      isSelected={isSelected}
+      aria-label={CONTEXT_SWITCHER_BUTTON_ARIA_LABEL}
+      data-test-subj="contextSwitcherTriggerButton"
+    >
+      <EuiIcon type={solutionIcon} size="m" aria-hidden={true} />
+      <span
+        css={css`
+          padding-left: ${euiTheme.size.s};
+        `}
+      >
+        {spaceName}
+      </span>
+    </EuiButtonEmpty>
+  );
+};

--- a/src/platform/packages/shared/context-switcher-components/src/components/footer.tsx
+++ b/src/platform/packages/shared/context-switcher-components/src/components/footer.tsx
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import { EuiListGroup, EuiListGroupItem } from '@elastic/eui';
+import type { FooterAction } from './types';
+
+export interface FooterProps {
+  readonly action?: FooterAction;
+}
+
+/**
+ * Renders a single footer action row.
+ */
+export const Footer = ({ action }: FooterProps) => {
+  if (!action) return null;
+
+  return (
+    <EuiListGroup gutterSize="none" flush>
+      <EuiListGroupItem
+        label={action.label}
+        iconType={'plus'}
+        href={action.href}
+        onClick={action.onClick}
+        external={action.external}
+        isDisabled={action.disabled}
+        size="s"
+        color="text"
+        data-test-subj={action['data-test-subj']}
+      />
+    </EuiListGroup>
+  );
+};

--- a/src/platform/packages/shared/context-switcher-components/src/components/links_list.tsx
+++ b/src/platform/packages/shared/context-switcher-components/src/components/links_list.tsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import { EuiListGroup, EuiListGroupItem } from '@elastic/eui';
+import { css } from '@emotion/react';
+import type { LinksListItem } from './types';
+
+export interface LinksListProps {
+  readonly items: ReadonlyArray<LinksListItem>;
+}
+
+/**
+ * Renders a list of links.
+ */
+
+export const LinksList = ({ items }: LinksListProps) => {
+  const itemCss = css`
+    /* no underline */
+    && .euiListGroupItem__button:hover,
+    && .euiListGroupItem__button:focus {
+      text-decoration: none;
+    }
+  `;
+
+  return (
+    <EuiListGroup gutterSize="none" flush>
+      {items.map((item) => (
+        <EuiListGroupItem
+          css={itemCss}
+          key={item.id}
+          label={item.label}
+          href={item.href}
+          onClick={item.onClick}
+          external={item.external}
+          isDisabled={item.disabled}
+          iconType={item.iconType}
+          size="s"
+          color="text"
+          data-test-subj={item['data-test-subj']}
+        />
+      ))}
+    </EuiListGroup>
+  );
+};

--- a/src/platform/packages/shared/context-switcher-components/src/components/selectable_list.tsx
+++ b/src/platform/packages/shared/context-switcher-components/src/components/selectable_list.tsx
@@ -1,0 +1,185 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React, { useCallback, useMemo } from 'react';
+import type { ComponentProps, ReactElement, ReactNode } from 'react';
+import { EuiSelectable, useEuiTheme } from '@elastic/eui';
+import type { EuiSelectableOption } from '@elastic/eui';
+import { css } from '@emotion/react';
+import { FormattedMessage } from '@kbn/i18n-react';
+import classNames from 'classnames';
+import { SELECTABLE_ROW_HEIGHT } from './types';
+
+const SELECTABLE_LIST_CHECKED_ITEM_CLASS = 'kbnContextSwitcherSelectableListItem--checked';
+
+type EuiSelectableChangeHandler = NonNullable<ComponentProps<typeof EuiSelectable>['onChange']>;
+type EuiSelectableChangeEvent = Parameters<EuiSelectableChangeHandler>[1];
+
+export interface SelectableListSearchConfig {
+  readonly enabled: boolean;
+  readonly props?: ComponentProps<typeof EuiSelectable>['searchProps'];
+}
+
+export interface SelectableListItem {
+  readonly id: string;
+  readonly label: string;
+  readonly prepend?: ReactNode;
+  readonly append?: ReactNode;
+  readonly checked?: boolean;
+  readonly disabled?: boolean;
+  readonly className?: string;
+  readonly ['data-test-subj']?: string;
+}
+
+export interface SelectableListProps {
+  readonly id: string;
+  readonly items: ReadonlyArray<SelectableListItem>;
+  readonly isLoading?: boolean;
+  readonly loadingMessage?: string;
+  readonly noMatchesMessage?: ReactElement;
+  readonly search?: SelectableListSearchConfig;
+  readonly onSelect: (args: {
+    readonly item: SelectableListItem;
+    readonly event: EuiSelectableChangeEvent;
+    readonly previousSelectedId?: string;
+  }) => void;
+  readonly children?: (nodes: {
+    readonly list: ReactNode;
+    readonly search?: ReactNode;
+  }) => ReactNode;
+}
+
+/**
+ * Generic selectable list for context-switcher:
+ * - Single selection (always)
+ * - Optional search UI
+ * - Supports prepend/append per item
+ */
+export const SelectableList = ({
+  id,
+  items,
+  isLoading = false,
+  loadingMessage,
+  noMatchesMessage,
+  search,
+  onSelect,
+  children,
+}: SelectableListProps) => {
+  const { euiTheme } = useEuiTheme();
+
+  const previousSelectedId = useMemo(() => items.find((i) => i.checked)?.id, [items]);
+
+  const itemById = useMemo(() => {
+    const map = new Map<string, SelectableListItem>();
+    for (const item of items) map.set(item.id, item);
+    return map;
+  }, [items]);
+
+  const options: Array<EuiSelectableOption> = useMemo(
+    () =>
+      items.map((item) => ({
+        key: item.id,
+        label: item.label,
+        prepend: item.prepend,
+        append: item.append,
+        checked: item.checked ? ('on' as const) : undefined,
+        disabled: item.disabled,
+        className: classNames(item.className, item.checked && SELECTABLE_LIST_CHECKED_ITEM_CLASS),
+        'data-test-subj': item['data-test-subj'],
+      })),
+    [items]
+  );
+
+  const defaultNoMatchesMessage = (
+    <FormattedMessage
+      id="contextSwitcherComponents.selectableList.noMatchesFound"
+      defaultMessage="No matches found"
+    />
+  );
+
+  const handleChange = useCallback<EuiSelectableChangeHandler>(
+    (newOptions, event) => {
+      const selected = newOptions.find((o) => o.checked === 'on');
+      const selectedId = selected?.key != null ? String(selected.key) : undefined;
+      if (!selectedId) return;
+
+      const item = itemById.get(selectedId);
+      if (!item) return;
+
+      onSelect({ item, event, previousSelectedId });
+    },
+    [itemById, onSelect, previousSelectedId]
+  );
+
+  const selectableStyles = css`
+    /* no underline */
+    .euiSelectableListItem:hover .euiSelectableListItem__text,
+    .euiSelectableListItem.euiSelectableListItem-isFocused .euiSelectableListItem__text {
+      text-decoration: none;
+    }
+    /* blue background color and rounded corners */
+    .euiSelectableListItem {
+      &:hover:not([aria-disabled='true']),
+      &.euiSelectableListItem-isFocused:not([aria-disabled='true']),
+      &.${SELECTABLE_LIST_CHECKED_ITEM_CLASS} {
+        background-color: ${euiTheme.colors.backgroundBaseInteractiveSelect};
+        border-radius: ${euiTheme.border.radius.small};
+      }
+    }
+    /* blue icon color */
+    .euiSelectableListItem__icon {
+      color: ${euiTheme.colors.textPrimary};
+    }
+    /* badges: no background + no border */
+    .euiSelectableListItem__append .euiBadge:not(.euiSelectableListItem__onFocusBadge) {
+      --euiBadgeTextColor: ${euiTheme.colors.textSubdued};
+      background-color: transparent;
+      border: 0;
+      box-shadow: none;
+    }
+    /* no bottom border between items */
+    .euiSelectableListItem:not(:last-of-type) {
+      border-bottom: 0;
+    }
+  `;
+
+  const searchableProps = search?.enabled
+    ? { searchable: true as const, searchProps: search.props }
+    : { searchable: false as const };
+
+  return (
+    <EuiSelectable
+      id={id}
+      options={options}
+      singleSelection="always"
+      onChange={handleChange}
+      isLoading={isLoading}
+      loadingMessage={loadingMessage}
+      noMatchesMessage={noMatchesMessage ?? defaultNoMatchesMessage}
+      css={selectableStyles}
+      listProps={{
+        rowHeight: SELECTABLE_ROW_HEIGHT,
+        showIcons: true,
+        onFocusBadge: false,
+      }}
+      {...searchableProps}
+    >
+      {(list, searchNode) => {
+        if (children) return <>{children({ list, search: searchNode ?? undefined })}</>;
+
+        return (
+          <>
+            {searchNode}
+            {list}
+          </>
+        );
+      }}
+    </EuiSelectable>
+  );
+};

--- a/src/platform/packages/shared/context-switcher-components/src/components/types.ts
+++ b/src/platform/packages/shared/context-switcher-components/src/components/types.ts
@@ -15,84 +15,84 @@ export const SELECTABLE_ROW_HEIGHT = 40;
 export const CONTEXT_ROW_HEIGHT = 48;
 
 export interface SpaceItem {
-  readonly id: string;
-  readonly name: string;
+  id: string;
+  name: string;
   /** Avatar or icon to display. */
-  readonly avatar?: ReactElement;
+  avatar?: ReactElement;
   /** Optional solution badge or metadata shown alongside. */
-  readonly badge?: ReactNode;
+  badge?: ReactNode;
   /** Solution name (e.g. "Security", "Observability"). Used to derive labels and icons. */
-  readonly solution?: string;
+  solution?: string;
   /** Solution icon type (e.g. "logoSecurity"). Used for trigger button and environment row avatar. */
-  readonly solutionIcon?: IconType;
+  solutionIcon?: IconType;
 }
 
 export interface ContextSwitcherSpacesConfig {
   /** The currently active space. */
-  readonly active: SpaceItem;
+  active: SpaceItem;
   /** All available spaces (including the active one). */
-  readonly items: ReadonlyArray<SpaceItem>;
+  items: SpaceItem[];
   /** Called when user selects a space. */
-  readonly onSelect: (spaceId: string) => void;
+  onSelect: (spaceId: string) => void;
   /** Optional search config. */
-  readonly search?: { readonly placeholder?: string; readonly threshold?: number };
+  search?: { placeholder?: string; threshold?: number };
   /** Header action (e.g. "Manage" button). */
-  readonly headerAction?: ReactNode;
+  headerAction?: ReactNode;
   /** Footer action (e.g. "Create space"). */
-  readonly footerAction?: FooterAction;
-  readonly isLoading?: boolean;
+  footerAction?: FooterAction;
+  isLoading?: boolean;
 }
 
 export interface ContextSwitcherEnvironmentConfig {
   /** Determines static labels (e.g. "My projects" vs "My deployments"). */
-  readonly environmentType: 'project' | 'deployment';
-  readonly name: string;
+  environmentType: 'project' | 'deployment';
+  name: string;
   /** Submenu link items (e.g. "Manage project", "View all deployments"). */
-  readonly submenuItems: ReadonlyArray<LinksListItem>;
+  submenuItems: LinksListItem[];
   /** Submenu footer action (e.g. "Create project"). */
-  readonly submenuFooterAction?: FooterAction;
+  submenuFooterAction?: FooterAction;
 }
 
 export interface ContextSwitcherProps {
   /** Active space info + full list of spaces. */
-  readonly spaces: ContextSwitcherSpacesConfig;
+  spaces: ContextSwitcherSpacesConfig;
   /**
    * If provided, enables the root menu with an environment row
    * (project or deployment) + submenu navigation.
    * When absent, the popover shows only the spaces list.
    */
-  readonly environmentContext?: ContextSwitcherEnvironmentConfig;
+  environmentContext?: ContextSwitcherEnvironmentConfig;
   /** Optional footer links (e.g. "Connection details", "Manage deployments"). */
-  readonly footerLinks?: ReadonlyArray<LinksListItem>;
+  footerLinks?: LinksListItem[];
 }
 
 export interface LinksListItem {
-  readonly id: string;
-  readonly label: ReactNode;
-  readonly href?: string;
-  readonly onClick?: () => void;
-  readonly external?: boolean;
-  readonly disabled?: boolean;
-  readonly iconType?: IconType;
-  readonly ['data-test-subj']?: string;
+  id: string;
+  label: ReactNode;
+  href?: string;
+  onClick?: () => void;
+  external?: boolean;
+  disabled?: boolean;
+  iconType?: IconType;
+  ['data-test-subj']?: string;
 }
 
 export interface FooterAction {
-  readonly id: string;
-  readonly label: string;
-  readonly href?: string;
-  readonly onClick?: () => void;
-  readonly external?: boolean;
-  readonly disabled?: boolean;
-  readonly ['data-test-subj']?: string;
+  id: string;
+  label: string;
+  href?: string;
+  onClick?: () => void;
+  external?: boolean;
+  disabled?: boolean;
+  ['data-test-subj']?: string;
 }
 
 export interface ContextRowModel {
-  readonly id: string;
-  readonly label: ReactNode;
-  readonly value?: ReactNode;
-  readonly prepend?: ReactElement;
-  readonly disabled?: boolean;
-  readonly ariaLabel?: string;
-  readonly ['data-test-subj']?: string;
+  id: string;
+  label: ReactNode;
+  value?: ReactNode;
+  prepend?: ReactElement;
+  disabled?: boolean;
+  ariaLabel?: string;
+  ['data-test-subj']?: string;
 }

--- a/src/platform/packages/shared/context-switcher-components/src/components/types.ts
+++ b/src/platform/packages/shared/context-switcher-components/src/components/types.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ReactElement, ReactNode } from 'react';
+import type { IconType } from '@elastic/eui';
+
+export const POPOVER_WIDTH = 400;
+export const SELECTABLE_ROW_HEIGHT = 40;
+export const CONTEXT_ROW_HEIGHT = 48;
+
+export interface SpaceItem {
+  readonly id: string;
+  readonly name: string;
+  /** Avatar or icon to display. */
+  readonly avatar?: ReactElement;
+  /** Optional solution badge or metadata shown alongside. */
+  readonly badge?: ReactNode;
+  /** Solution name (e.g. "Security", "Observability"). Used to derive labels and icons. */
+  readonly solution?: string;
+  /** Solution icon type (e.g. "logoSecurity"). Used for trigger button and environment row avatar. */
+  readonly solutionIcon?: IconType;
+}
+
+export interface ContextSwitcherSpacesConfig {
+  /** The currently active space. */
+  readonly active: SpaceItem;
+  /** All available spaces (including the active one). */
+  readonly items: ReadonlyArray<SpaceItem>;
+  /** Called when user selects a space. */
+  readonly onSelect: (spaceId: string) => void;
+  /** Optional search config. */
+  readonly search?: { readonly placeholder?: string; readonly threshold?: number };
+  /** Header action (e.g. "Manage" button). */
+  readonly headerAction?: ReactNode;
+  /** Footer action (e.g. "Create space"). */
+  readonly footerAction?: FooterAction;
+  readonly isLoading?: boolean;
+}
+
+export interface ContextSwitcherEnvironmentConfig {
+  /** Determines static labels (e.g. "My projects" vs "My deployments"). */
+  readonly environmentType: 'project' | 'deployment';
+  readonly name: string;
+  /** Submenu link items (e.g. "Manage project", "View all deployments"). */
+  readonly submenuItems: ReadonlyArray<LinksListItem>;
+  /** Submenu footer action (e.g. "Create project"). */
+  readonly submenuFooterAction?: FooterAction;
+}
+
+export interface ContextSwitcherProps {
+  /** Active space info + full list of spaces. */
+  readonly spaces: ContextSwitcherSpacesConfig;
+  /**
+   * If provided, enables the root menu with an environment row
+   * (project or deployment) + submenu navigation.
+   * When absent, the popover shows only the spaces list.
+   */
+  readonly environmentContext?: ContextSwitcherEnvironmentConfig;
+  /** Optional footer links (e.g. "Connection details", "Manage deployments"). */
+  readonly footerLinks?: ReadonlyArray<LinksListItem>;
+}
+
+export interface LinksListItem {
+  readonly id: string;
+  readonly label: ReactNode;
+  readonly href?: string;
+  readonly onClick?: () => void;
+  readonly external?: boolean;
+  readonly disabled?: boolean;
+  readonly iconType?: IconType;
+  readonly ['data-test-subj']?: string;
+}
+
+export interface FooterAction {
+  readonly id: string;
+  readonly label: string;
+  readonly href?: string;
+  readonly onClick?: () => void;
+  readonly external?: boolean;
+  readonly disabled?: boolean;
+  readonly ['data-test-subj']?: string;
+}
+
+export interface ContextRowModel {
+  readonly id: string;
+  readonly label: ReactNode;
+  readonly value?: ReactNode;
+  readonly prepend?: ReactElement;
+  readonly disabled?: boolean;
+  readonly ariaLabel?: string;
+  readonly ['data-test-subj']?: string;
+}

--- a/src/platform/packages/shared/context-switcher-components/src/components/views/context_menu.tsx
+++ b/src/platform/packages/shared/context-switcher-components/src/components/views/context_menu.tsx
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import { EuiHorizontalRule, EuiListGroup } from '@elastic/eui';
+
+import { ContextRow } from '../context_row';
+import { LinksList } from '../links_list';
+import type { ContextRowModel } from '../types';
+import { type LinksListItem } from '../types';
+
+export interface ContextMenuViewProps {
+  readonly environmentRow: ContextRowModel;
+  readonly spacesRow: ContextRowModel;
+  readonly footerLinks?: ReadonlyArray<LinksListItem>;
+  readonly onClickEnvironmentRow: () => void;
+  readonly onClickSpacesRow: () => void;
+}
+
+/**
+ * The menu view for the context switcher that contains the environment row and the spaces row.
+ */
+
+export const ContextMenuView = ({
+  environmentRow,
+  spacesRow,
+  onClickEnvironmentRow,
+  onClickSpacesRow,
+  footerLinks,
+}: ContextMenuViewProps) => {
+  return (
+    <>
+      <EuiListGroup gutterSize="none" flush>
+        <ContextRow row={environmentRow} onClick={onClickEnvironmentRow} />
+        <ContextRow row={spacesRow} onClick={onClickSpacesRow} />
+      </EuiListGroup>
+
+      {!!footerLinks?.length && (
+        <>
+          <EuiHorizontalRule margin="xs" />
+          <LinksList items={footerLinks} />
+        </>
+      )}
+    </>
+  );
+};

--- a/src/platform/packages/shared/context-switcher-components/src/components/views/context_submenu.tsx
+++ b/src/platform/packages/shared/context-switcher-components/src/components/views/context_submenu.tsx
@@ -1,0 +1,83 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import type { ReactNode } from 'react';
+import {
+  EuiButtonIcon,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiHorizontalRule,
+  EuiPopoverTitle,
+} from '@elastic/eui';
+import { css } from '@emotion/react';
+
+import { i18n } from '@kbn/i18n';
+import { LinksList } from '../links_list';
+import { Footer } from '../footer';
+import { type FooterAction, type LinksListItem } from '../types';
+
+const BACK_BUTTON_ARIA_LABEL = i18n.translate(
+  'contextSwitcherComponents.contextSubmenuView.backButtonAriaLabel',
+  {
+    defaultMessage: 'Back',
+  }
+);
+export interface ContextSubmenuViewProps {
+  readonly title: ReactNode;
+  readonly onBack: () => void;
+  readonly items: ReadonlyArray<LinksListItem>;
+  readonly footerAction?: FooterAction;
+}
+
+/**
+ * The submenu view for the environment context that contains the title, the links list and the footer action.
+ */
+
+export const ContextSubmenuView = ({
+  title,
+  onBack,
+  items,
+  footerAction,
+}: ContextSubmenuViewProps) => {
+  return (
+    <>
+      <EuiPopoverTitle
+        css={css`
+          border-bottom: 0;
+          padding-bottom: 0;
+        `}
+      >
+        <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
+          <EuiFlexItem grow={false}>
+            <EuiButtonIcon
+              iconType="arrowLeft"
+              aria-label={BACK_BUTTON_ARIA_LABEL}
+              color="text"
+              display="empty"
+              size="s"
+              onClick={onBack}
+              data-test-subj="contextSwitcherSubmenuBackButton"
+            />
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>{title}</EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiPopoverTitle>
+
+      <LinksList items={items} />
+
+      {footerAction && (
+        <>
+          <EuiHorizontalRule margin="xs" />
+          <Footer action={footerAction} />
+        </>
+      )}
+    </>
+  );
+};

--- a/src/platform/packages/shared/context-switcher-components/src/components/views/spaces_list.tsx
+++ b/src/platform/packages/shared/context-switcher-components/src/components/views/spaces_list.tsx
@@ -1,0 +1,149 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import type { ReactElement, ReactNode } from 'react';
+import {
+  EuiButtonIcon,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiHorizontalRule,
+  EuiPopoverTitle,
+  EuiSpacer,
+  useEuiTheme,
+} from '@elastic/eui';
+import { css } from '@emotion/react';
+
+import { i18n } from '@kbn/i18n';
+import { SelectableList } from '../selectable_list';
+import type {
+  SelectableListItem,
+  SelectableListProps,
+  SelectableListSearchConfig,
+} from '../selectable_list';
+
+import { Footer } from '../footer';
+import { type FooterAction } from '../types';
+
+const BACK_BUTTON_ARIA_LABEL = i18n.translate(
+  'contextSwitcherComponents.spacesListView.backButtonAriaLabel',
+  {
+    defaultMessage: 'Back',
+  }
+);
+export interface SpacesListViewProps {
+  readonly id: string;
+  readonly title: string;
+  readonly headerAction?: ReactNode;
+  readonly items: ReadonlyArray<SelectableListItem>;
+  readonly search?: SelectableListSearchConfig;
+  readonly isLoading?: boolean;
+  readonly loadingMessage?: string;
+  readonly noMatchesMessage?: ReactElement;
+  readonly footerAction?: FooterAction;
+  readonly onBack?: () => void;
+  readonly onSelect: SelectableListProps['onSelect'];
+}
+
+/**
+ * The list view for the spaces that contains the title, the selectable list and the footer action.
+ */
+
+export const SpacesListView = ({
+  id,
+  title,
+  onBack,
+  headerAction,
+  items,
+  onSelect,
+  search,
+  isLoading,
+  loadingMessage,
+  noMatchesMessage,
+  footerAction,
+}: SpacesListViewProps) => {
+  const { euiTheme } = useEuiTheme();
+  return (
+    <>
+      <SelectableList
+        id={id}
+        items={items}
+        isLoading={isLoading}
+        loadingMessage={loadingMessage}
+        noMatchesMessage={noMatchesMessage}
+        search={search}
+        onSelect={onSelect}
+      >
+        {({ list, search: searchNode }) => (
+          <>
+            <EuiPopoverTitle
+              css={css`
+                border-bottom: 0;
+                padding-bottom: 0;
+              `}
+            >
+              <EuiFlexGroup
+                alignItems="center"
+                justifyContent="spaceBetween"
+                gutterSize="s"
+                responsive={false}
+              >
+                <EuiFlexItem grow={false}>
+                  <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
+                    {onBack && (
+                      <EuiFlexItem grow={false}>
+                        <EuiButtonIcon
+                          iconType="arrowLeft"
+                          aria-label={BACK_BUTTON_ARIA_LABEL}
+                          color="text"
+                          display="empty"
+                          size="s"
+                          onClick={onBack}
+                          data-test-subj="contextSwitcherSpacesBackButton"
+                        />
+                      </EuiFlexItem>
+                    )}
+                    <EuiFlexItem
+                      grow={false}
+                      css={
+                        !onBack
+                          ? css`
+                              padding-left: ${euiTheme.size.xs};
+                            `
+                          : undefined
+                      }
+                    >
+                      {title}
+                    </EuiFlexItem>
+                  </EuiFlexGroup>
+                </EuiFlexItem>
+                {headerAction && <EuiFlexItem grow={false}>{headerAction}</EuiFlexItem>}
+              </EuiFlexGroup>
+
+              {searchNode && (
+                <>
+                  <EuiSpacer size="s" />
+                  {searchNode}
+                </>
+              )}
+            </EuiPopoverTitle>
+            {list}
+          </>
+        )}
+      </SelectableList>
+
+      {footerAction && (
+        <>
+          <EuiHorizontalRule margin="xs" />
+          <Footer action={footerAction} />
+        </>
+      )}
+    </>
+  );
+};

--- a/src/platform/packages/shared/context-switcher-components/tsconfig.json
+++ b/src/platform/packages/shared/context-switcher-components/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "@kbn/tsconfig-base/tsconfig.json",
+  "compilerOptions": {
+    "outDir": "target/types",
+  },
+  "include": [
+    "**/*.ts",
+    "**/*.tsx",
+  ],
+  "exclude": [
+    "target/**/*"
+  ],
+  "kbn_references": [
+    "@kbn/storybook",
+  ]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -344,6 +344,8 @@
       "@kbn/content-management-utils/*": ["src/platform/packages/shared/kbn-content-management-utils/*"],
       "@kbn/content-packs-schema": ["x-pack/platform/packages/shared/kbn-content-packs-schema"],
       "@kbn/content-packs-schema/*": ["x-pack/platform/packages/shared/kbn-content-packs-schema/*"],
+      "@kbn/context-switcher-components": ["src/platform/packages/shared/context-switcher-components"],
+      "@kbn/context-switcher-components/*": ["src/platform/packages/shared/context-switcher-components/*"],
       "@kbn/control-group-renderer": ["src/platform/packages/shared/controls/control-group-renderer"],
       "@kbn/control-group-renderer/*": ["src/platform/packages/shared/controls/control-group-renderer/*"],
       "@kbn/controls-constants": ["src/platform/packages/shared/controls/controls-constants"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -5231,6 +5231,10 @@
   version "0.0.0"
   uid ""
 
+"@kbn/context-switcher-components@link:src/platform/packages/shared/context-switcher-components":
+  version "0.0.0"
+  uid ""
+
 "@kbn/control-group-renderer@link:src/platform/packages/shared/controls/control-group-renderer":
   version "0.0.0"
   uid ""


### PR DESCRIPTION
Relates to https://github.com/elastic/kibana/issues/259992

## Summary

- This PR introduces a new shared UI package for the context switcher that will be rendered in the Kibana global header

## Testing 

- Run `node scripts/storybook context-switcher-components` and verify all three stories render correctly