### PR TITLE
fix(security): prevent session cleanup race on first-ever serverless project bootstrap

### DIFF
--- a/x-pack/platform/plugins/shared/security/server/session_management/session_index.ts
+++ b/x-pack/platform/plugins/shared/security/server/session_management/session_index.ts
@@ -877,6 +877,10 @@ export class SessionIndex {
       });
     }
 
+    // Only 404 is passed in `ignore` so the client returns it as a normal response rather than
+    // throwing. Any other error status (including 503 / no_shard_available_action_exception) is
+    // thrown as a ResponseError and caught by the `cleanUp` caller, which handles it via the
+    // `shardMissingCounter` retry mechanism.
     let response = await this.options.elasticsearchClient.openPointInTime(
       {
         index: this.aliasName,
@@ -896,8 +900,6 @@ export class SessionIndex {
         },
         { meta: true }
       );
-    } else if (response.statusCode === 503) {
-      throw new errors.ResponseError(response);
     }
 
     const openPitResponse = response.body;

--- a/x-pack/platform/plugins/shared/security/server/session_management/session_management_service.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/session_management/session_management_service.test.ts
@@ -171,6 +171,33 @@ describe('SessionManagementService', () => {
       expect(mockScheduleRetry).not.toHaveBeenCalled();
     });
 
+    it('schedules cleanup task only after session index initialization completes', async () => {
+      const mockStatusSubject = new Subject<OnlineStatusRetryScheduler>();
+
+      const initOrder: string[] = [];
+      mockSessionIndexInitialize.mockImplementation(async () => {
+        initOrder.push('initialize');
+      });
+      mockTaskManager.ensureScheduled.mockImplementation(async () => {
+        initOrder.push('ensureScheduled');
+        return undefined as any;
+      });
+
+      service.start({
+        audit: auditSetupMock,
+        elasticsearchClient: elasticsearchServiceMock.createElasticsearchClient(),
+        kibanaIndexName: '.kibana',
+        online$: mockStatusSubject.asObservable(),
+        taskManager: mockTaskManager,
+      });
+
+      const mockScheduleRetry = jest.fn();
+      mockStatusSubject.next({ scheduleRetry: mockScheduleRetry });
+      await nextTick();
+
+      expect(initOrder).toEqual(['initialize', 'ensureScheduled']);
+    });
+
     it('removes old cleanup task if cleanup interval changes', async () => {
       const mockStatusSubject = new Subject<OnlineStatusRetryScheduler>();
       service.start({
@@ -250,18 +277,20 @@ describe('SessionManagementService', () => {
       mockStatusSubject.next({ scheduleRetry: mockScheduleRetry });
       await nextTick();
       expect(mockSessionIndexInitialize).toHaveBeenCalledTimes(1);
-      expect(mockTaskManager.ensureScheduled).toHaveBeenCalledTimes(1);
+      // Cleanup task must not be scheduled when initialization fails — Task Manager fires new
+      // tasks immediately, so scheduling before the index is ready would trigger a PIT on
+      // unavailable shards.
+      expect(mockTaskManager.ensureScheduled).not.toHaveBeenCalled();
       expect(mockScheduleRetry).toHaveBeenCalledTimes(1);
 
-      // Still fails, but cleanup task is scheduled already
-      mockTaskManager.get.mockResolvedValue({ schedule: { interval: '3600s' } } as any);
+      // Still fails.
       mockStatusSubject.next({ scheduleRetry: mockScheduleRetry });
       await nextTick();
       expect(mockSessionIndexInitialize).toHaveBeenCalledTimes(2);
-      expect(mockTaskManager.ensureScheduled).toHaveBeenCalledTimes(1);
+      expect(mockTaskManager.ensureScheduled).not.toHaveBeenCalled();
       expect(mockScheduleRetry).toHaveBeenCalledTimes(2);
 
-      // And finally succeeds, retry is not scheduled.
+      // And finally succeeds — cleanup task is scheduled and retry is not triggered.
       mockSessionIndexInitialize.mockResolvedValue(undefined);
 
       mockStatusSubject.next({ scheduleRetry: mockScheduleRetry });

--- a/x-pack/platform/plugins/shared/security/server/session_management/session_management_service.ts
+++ b/x-pack/platform/plugins/shared/security/server/session_management/session_management_service.ts
@@ -95,10 +95,13 @@ export class SessionManagementService {
       .pipe(
         switchMap(async ({ scheduleRetry }) => {
           try {
-            await Promise.all([
-              this.sessionIndex.initialize(),
-              this.scheduleCleanupTask(taskManager),
-            ]);
+            // Initialize the index first so the session index and its shards are fully ready
+            // before the cleanup task is registered. Task Manager fires newly created tasks
+            // immediately, so registering before initialization completes would cause the
+            // cleanup task to open a PIT on an index whose shards may not yet be available,
+            // resulting in 503 errors on first-ever project bootstrap.
+            await this.sessionIndex.initialize();
+            await this.scheduleCleanupTask(taskManager);
           } catch (err) {
             scheduleRetry();
           }

--- a/x-pack/platform/test/security_api_integration/tests/session_shard_missing/shard_missing.ts
+++ b/x-pack/platform/test/security_api_integration/tests/session_shard_missing/shard_missing.ts
@@ -67,11 +67,11 @@ export default function ({ getService }: FtrProviderContext) {
 
   async function resetCleanupTask() {
     log.debug('Resetting cleanup task state to 0');
-    await runCleanupTaskSoon();
+
     let shardMissingCounter = -1;
     while (shardMissingCounter !== 0) {
+      await runCleanupTaskSoon(); // trigger on every iteration
       await setTimeoutAsync(5000);
-
       const state = await getCleanupTaskStatus();
       log.debug(`Task status: ${JSON.stringify(state)}`);
       shardMissingCounter = state.shardMissingCounter ?? 0;

--- a/x-pack/platform/test/security_functional/plugins/test_endpoints/server/init_routes.ts
+++ b/x-pack/platform/test/security_functional/plugins/test_endpoints/server/init_routes.ts
@@ -402,20 +402,28 @@ export function initRoutes(
         esClient.openPointInTime = async function (params, options) {
           const { index } = params;
           if (index.includes('kibana_security_session')) {
-            return {
+            // Throw a ResponseError to match the real ES client behaviour: the client never
+            // returns a plain 503 response object; it always throws for non-ignored status codes.
+            // `cleanUp` in session_index.ts catches ResponseError with statusCode 503 and
+            // message matching 'no_shard_available_action_exception' to increment the counter.
+            throw new errors.ResponseError({
               statusCode: 503,
-              meta: {},
               body: {
                 error: {
+                  root_cause: [
+                    {
+                      type: 'no_shard_available_action_exception',
+                      reason: 'no shard available for [open]',
+                    },
+                  ],
                   type: 'no_shard_available_action_exception',
                   reason: 'no shard available for [open]',
                 },
+                status: 503,
               },
-            };
-            return {
-              statusCode: 503,
-              message: 'no_shard_available_action_exception',
-            } as unknown as DiagnosticResult;
+              warnings: null,
+              headers: {},
+            } as DiagnosticResult);
           }
           return originalOpenPointInTime.call(this, params, options);
         };


### PR DESCRIPTION
## Summary

Reduces the frequency of `503 no_shard_available_action_exception` errors on `/.kibana_security_session/_pit` during first-ever serverless project creation (SEV4 incident, first observed 2026-03-25).

### Background: the ES-side gap

The session index is created with `number_of_replicas: 0` and `auto_expand_replicas: 0-1`. Because there are zero replicas at creation time, neither `waitForActiveShards` nor the refresh block applies. The `indices.create()` default (`waitForActiveShards=1`) is satisfied by the `INDEX_ONLY` (primary) shard alone, so ES responds before the autoscaler bumps replicas to 1 and the `SEARCH_ONLY` shard begins recovery. A complementary ES-side fix ([elasticsearch#146248](https://github.com/elastic/elasticsearch/pull/146248)) addresses the missing refresh block for auto-expand replicas.

### Root cause of the Kibana-side race

`SessionManagementService.start()` was running `sessionIndex.initialize()` and `scheduleCleanupTask()` concurrently via `Promise.all`. Task Manager fires **newly created tasks immediately**, so on first bootstrap the `session_cleanup` task fired and opened a PIT while `indices.create()` was still in-flight — before even the `INDEX_ONLY` shard was ready. This is confirmed by proxy logs showing PIT requests arriving before the `create index` response.

### Fix 1 — narrow the race (sequential initialization)

`scheduleCleanupTask()` now runs **after** `initialize()` resolves. This ensures the cleanup task is not registered until `indices.create()` has at least responded (i.e., the `INDEX_ONLY` shard is up). In practice, Task Manager's polling interval adds enough additional delay that the `SEARCH_ONLY` shard recovery (typically ~730ms) completes before the task is first claimed and executed.

**Known limitations:**
- This fix relies on Task Manager's polling interval being longer than the `SEARCH_ONLY` shard recovery window. It does not provide a hard guarantee by construction; that requires the ES-side fix.
- In a **multi-Kibana-instance** scenario, the instance that loses the `indices.create()` race gets a `resource_already_exists_exception` back immediately (before the `SEARCH_ONLY` shard is ready) and proceeds to schedule the cleanup task. This edge case is unaffected by this fix but is handled gracefully by the existing `shardMissingCounter` mechanism (silent skip + warn log).

### Fix 2 — remove unreachable dead code in `getSessionValuesInBatches`

An `else if (response.statusCode === 503)` branch existed after the `openPointInTime` call. Because `503` is not listed in the ES client's `ignore` option, the client **throws** a `ResponseError` on 503 — this branch can never be reached. The actual 503 resilience (via `shardMissingCounter` in the `cleanUp` catch block) is left unchanged; a comment is added to make the error-handling flow explicit.

### Existing resilience: `shardMissingCounter`

For any 503 that does reach the cleanup task (multi-instance edge case, slow TM pickup, unrelated ES issues), the existing `shardMissingCounter` in `cleanUp` catches `no_shard_available_action_exception`, logs a warning, and silently skips the run — retrying on the next scheduled interval (default 1h). This provides defense-in-depth regardless of timing.

### Testing

- Updated `session_management_service.test.ts`: the "schedules retry if index initialization fails" test now correctly asserts that `ensureScheduled` is **not** called when `initialize()` fails (previously it was called due to concurrent execution).
- Added a new test: "schedules cleanup task only after session index initialization completes" — explicitly verifies the sequential order using call-order tracking.
- All 70 existing `session_index` tests pass unchanged.