### PR TITLE
[FeatureBranch/DoNotReview] Chrome-next: header API partial-merge, back button popover, title wiring

### DIFF
--- a/src/core/packages/chrome/browser-components/src/chrome_next/app_header/app_header.tsx
+++ b/src/core/packages/chrome/browser-components/src/chrome_next/app_header/app_header.tsx
@@ -10,15 +10,13 @@
 import React from 'react';
 import { AppHeaderShell } from './app_header_shell';
 import { AppBadges } from './app_badges';
-import { BackButton } from './back_button';
-import { AppTitle } from './app_title';
+import { TitleArea } from './title_area';
 import { GlobalActions } from './global_actions';
 import { AppMenu } from './app_menu';
 
 export const AppHeader = React.memo(() => (
   <AppHeaderShell
-    leading={<BackButton />}
-    title={<AppTitle />}
+    title={<TitleArea />}
     badges={<AppBadges />}
     titleActions={<GlobalActions />}
     trailing={<AppMenu />}

--- a/src/core/packages/chrome/browser-components/src/chrome_next/app_header/app_header_shell.tsx
+++ b/src/core/packages/chrome/browser-components/src/chrome_next/app_header/app_header_shell.tsx
@@ -13,11 +13,9 @@ import { css } from '@emotion/react';
 import React, { useMemo } from 'react';
 import { useReportTopBarHeight } from './hooks';
 
-/** Minimum row height; aligns with project layout `applicationTopBarHeight`. */
-const APPLICATION_TOP_BAR_HEIGHT_PX = 48;
+const APPLICATION_TOP_BAR_MIN_HEIGHT_PX = 48;
 
 export interface AppHeaderShellProps {
-  leading?: ReactNode;
   title?: ReactNode;
   badges?: ReactNode;
   titleActions?: ReactNode;
@@ -35,20 +33,26 @@ const useHeaderStyles = () => {
       display: flex;
       flex-direction: column;
       min-width: 0;
-      min-height: ${APPLICATION_TOP_BAR_HEIGHT_PX}px;
+      min-height: ${APPLICATION_TOP_BAR_MIN_HEIGHT_PX}px;
       box-sizing: border-box;
-      padding: 0 ${euiTheme.size.s};
+      padding: 0 ${euiTheme.size.m};
       background: ${euiTheme.colors.backgroundBasePlain};
       border-bottom: ${euiTheme.border.thin};
       margin-bottom: -${euiTheme.border.width.thin};
+
+      &:hover .titleActionsReveal,
+      &:focus-within .titleActionsReveal {
+        opacity: 1;
+        pointer-events: auto;
+      }
     `;
 
     const primaryRow = css`
       display: flex;
       align-items: center;
-      gap: ${euiTheme.size.xs};
+      gap: ${euiTheme.size.m};
       min-width: 0;
-      min-height: ${APPLICATION_TOP_BAR_HEIGHT_PX}px;
+      min-height: ${APPLICATION_TOP_BAR_MIN_HEIGHT_PX}px;
     `;
 
     const titleCluster = css`
@@ -88,12 +92,23 @@ const useHeaderStyles = () => {
       align-items: stretch;
     `;
 
+    const titleActionsReveal = css`
+      display: flex;
+      flex-shrink: 0;
+      align-items: center;
+      gap: ${euiTheme.size.xs};
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity ${euiTheme.animation.fast} ease;
+    `;
+
     return {
       root,
       primaryRow,
       titleCluster,
       titleGroup,
       titleClusterSpacer,
+      titleActionsReveal,
       metadataRow,
       calloutRow,
       tabsRow,
@@ -102,19 +117,22 @@ const useHeaderStyles = () => {
 };
 
 export const AppHeaderShell = React.memo<AppHeaderShellProps>(
-  ({ leading, title, badges, titleActions, trailing, metadata, callout, tabs }) => {
+  ({ title, badges, titleActions, trailing, metadata, callout, tabs }) => {
     const styles = useHeaderStyles();
     const heightRef = useReportTopBarHeight();
 
     return (
       <div ref={heightRef} css={styles.root} data-test-subj="chromeNextAppHeader">
         <div css={styles.primaryRow}>
-          {leading}
           <div css={styles.titleCluster}>
             <div css={styles.titleGroup}>
               {title}
               {badges}
-              {titleActions}
+              {titleActions && (
+                <div className="titleActionsReveal" css={styles.titleActionsReveal}>
+                  {titleActions}
+                </div>
+              )}
             </div>
             <div css={styles.titleClusterSpacer} aria-hidden />
           </div>

--- a/src/core/packages/chrome/browser-components/src/chrome_next/app_header/back_button.tsx
+++ b/src/core/packages/chrome/browser-components/src/chrome_next/app_header/back_button.tsx
@@ -66,9 +66,7 @@ export const BackButton = React.memo(() => {
       css={{ color: euiTheme.colors.textSubdued }}
       aria-label={tooltip}
       data-test-subj="chromeNextAppHeaderBack"
-      {...(targets.length > 1
-        ? { onClick: togglePopover }
-        : { href: primary.backHref })}
+      {...(targets.length > 1 ? { onClick: togglePopover } : { href: primary.backHref })}
     />
   );
 

--- a/src/core/packages/chrome/browser-components/src/chrome_next/app_header/back_button.tsx
+++ b/src/core/packages/chrome/browser-components/src/chrome_next/app_header/back_button.tsx
@@ -15,6 +15,7 @@ import {
   EuiToolTip,
   useEuiTheme,
 } from '@elastic/eui';
+import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
 import React, { useCallback, useMemo, useState } from 'react';
 import { useBackButton } from './hooks';
@@ -29,8 +30,20 @@ const getBackToLabel = (destination: string) =>
     values: { destination },
   });
 
-export const BackButton = React.memo(() => {
+const useBackButtonStyles = () => {
   const { euiTheme } = useEuiTheme();
+
+  return useMemo(() => {
+    const button = css`
+      color: ${euiTheme.colors.textSubdued};
+    `;
+
+    return { button };
+  }, [euiTheme]);
+};
+
+export const BackButton = React.memo(() => {
+  const styles = useBackButtonStyles();
   const targets = useBackButton();
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
 
@@ -38,20 +51,9 @@ export const BackButton = React.memo(() => {
   const closePopover = useCallback(() => setIsPopoverOpen(false), []);
 
   const primary = targets[0];
-
-  const tooltip = useMemo(() => {
-    if (!primary) return '';
-    return primary.backDestinationLabel ? getBackToLabel(primary.backDestinationLabel) : backLabel;
-  }, [primary]);
-
-  const menuItems = useMemo(() => {
-    if (targets.length < 2) return [];
-    return targets.map((target, idx) => (
-      <EuiContextMenuItem key={idx} href={target.backHref} size="s">
-        {target.backDestinationLabel ?? target.backHref}
-      </EuiContextMenuItem>
-    ));
-  }, [targets]);
+  const tooltip = primary?.backDestinationLabel
+    ? getBackToLabel(primary.backDestinationLabel)
+    : backLabel;
 
   if (!primary) {
     return null;
@@ -63,7 +65,7 @@ export const BackButton = React.memo(() => {
       color="text"
       display="empty"
       size="xs"
-      css={{ color: euiTheme.colors.textSubdued }}
+      css={styles.button}
       aria-label={tooltip}
       data-test-subj="chromeNextAppHeaderBack"
       {...(targets.length > 1
@@ -85,7 +87,14 @@ export const BackButton = React.memo(() => {
         panelPaddingSize="none"
         anchorPosition="downLeft"
       >
-        <EuiContextMenuPanel items={menuItems} size="s" />
+        <EuiContextMenuPanel
+          items={targets.map((target, idx) => (
+            <EuiContextMenuItem key={idx} href={target.backHref} size="s">
+              {target.backDestinationLabel ?? target.backHref}
+            </EuiContextMenuItem>
+          ))}
+          size="s"
+        />
       </EuiPopover>
     );
   }

--- a/src/core/packages/chrome/browser-components/src/chrome_next/app_header/back_button.tsx
+++ b/src/core/packages/chrome/browser-components/src/chrome_next/app_header/back_button.tsx
@@ -7,43 +7,93 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { EuiButtonIcon } from '@elastic/eui';
+import {
+  EuiButtonIcon,
+  EuiContextMenuItem,
+  EuiContextMenuPanel,
+  EuiPopover,
+  EuiToolTip,
+  useEuiTheme,
+} from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import React, { useMemo } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { useBackButton } from './hooks';
 
+const backLabel = i18n.translate('core.ui.chrome.appHeader.backButtonAriaLabel', {
+  defaultMessage: 'Back',
+});
+
+const getBackToLabel = (destination: string) =>
+  i18n.translate('core.ui.chrome.appHeader.backButtonAriaLabelWithDestination', {
+    defaultMessage: 'Back to {destination}',
+    values: { destination },
+  });
+
 export const BackButton = React.memo(() => {
-  const back = useBackButton();
+  const { euiTheme } = useEuiTheme();
+  const targets = useBackButton();
+  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
 
-  const ariaLabel = useMemo(() => {
-    if (!back) {
-      return '';
-    }
-    if (back.backDestinationLabel) {
-      return i18n.translate('core.ui.chrome.appHeader.backButtonAriaLabelWithDestination', {
-        defaultMessage: 'Back to {destination}',
-        values: { destination: back.backDestinationLabel },
-      });
-    }
-    return i18n.translate('core.ui.chrome.appHeader.backButtonAriaLabel', {
-      defaultMessage: 'Back',
-    });
-  }, [back]);
+  const togglePopover = useCallback(() => setIsPopoverOpen((open) => !open), []);
+  const closePopover = useCallback(() => setIsPopoverOpen(false), []);
 
-  if (!back) {
+  const primary = targets[0];
+
+  const tooltip = useMemo(() => {
+    if (!primary) return '';
+    return primary.backDestinationLabel ? getBackToLabel(primary.backDestinationLabel) : backLabel;
+  }, [primary]);
+
+  const menuItems = useMemo(() => {
+    if (targets.length < 2) return [];
+    return targets.map((target, idx) => (
+      <EuiContextMenuItem key={idx} href={target.backHref} size="s">
+        {target.backDestinationLabel ?? target.backHref}
+      </EuiContextMenuItem>
+    ));
+  }, [targets]);
+
+  if (!primary) {
     return null;
   }
 
-  return (
+  const buttonIcon = (
     <EuiButtonIcon
-      iconType="arrowLeft"
+      iconType="sortLeft"
       color="text"
       display="empty"
-      size="s"
-      aria-label={ariaLabel}
+      size="xs"
+      css={{ color: euiTheme.colors.textSubdued }}
+      aria-label={tooltip}
       data-test-subj="chromeNextAppHeaderBack"
-      href={back.backHref}
+      {...(targets.length > 1
+        ? { onClick: togglePopover }
+        : { href: primary.backHref })}
     />
+  );
+
+  if (targets.length > 1) {
+    return (
+      <EuiPopover
+        button={
+          <EuiToolTip content={tooltip} delay="long">
+            {buttonIcon}
+          </EuiToolTip>
+        }
+        isOpen={isPopoverOpen}
+        closePopover={closePopover}
+        panelPaddingSize="none"
+        anchorPosition="downLeft"
+      >
+        <EuiContextMenuPanel items={menuItems} size="s" />
+      </EuiPopover>
+    );
+  }
+
+  return (
+    <EuiToolTip content={tooltip} delay="long">
+      {buttonIcon}
+    </EuiToolTip>
   );
 });
 

--- a/src/core/packages/chrome/browser-components/src/chrome_next/app_header/hooks/use_back_button.ts
+++ b/src/core/packages/chrome/browser-components/src/chrome_next/app_header/hooks/use_back_button.ts
@@ -8,46 +8,67 @@
  */
 
 import { useMemo } from 'react';
+import type { AppDeepLinkId, ChromeBreadcrumb } from '@kbn/core-chrome-browser';
 import { useNextHeader, useProjectBreadcrumbs } from '../../../shared/chrome_hooks';
 import { getBreadcrumbPlainText } from '../../../shared/breadcrumb_utils';
 
+const EXCLUDED_BACK_DEEP_LINKS = new Set<AppDeepLinkId>([]);
+const EXCLUDED_BACK_HREFS = [/\/app\/management\/?$/];
+
+const isExcludedBackTarget = (crumb: ChromeBreadcrumb): boolean => {
+  if (crumb.deepLinkId && EXCLUDED_BACK_DEEP_LINKS.has(crumb.deepLinkId)) {
+    return true;
+  }
+  if (crumb.href) {
+    return EXCLUDED_BACK_HREFS.some((re) => re.test(crumb.href!));
+  }
+  return false;
+};
+
 export interface BackNavigation {
   backHref: string;
-  /** Plain-text title of the destination crumb (for `aria-label` on the back control). */
   backDestinationLabel?: string;
 }
 
+const EMPTY: BackNavigation[] = [];
+
 /**
- * Resolution: explicit `chrome.next.header` `back.href` (and optional `back.label`) -> else the
- * last non-last project breadcrumb with a truthy `href` (scanning right to left). Returns
- * `undefined` if neither applies.
+ * Returns all valid back-navigation targets derived from project breadcrumbs
+ * (scanning right-to-left, so the immediate parent is first).
+ *
+ * An explicit `chrome.next.header` `back.href` takes priority and produces a
+ * single-element array.
  */
-export function useBackButton(): BackNavigation | undefined {
+export function useBackButton(): BackNavigation[] {
   const config = useNextHeader();
   const breadcrumbs = useProjectBreadcrumbs();
 
   return useMemo(() => {
-    const explicitHref = config?.back?.href?.trim();
-    if (explicitHref) {
-      return {
-        backHref: explicitHref,
-        backDestinationLabel: config?.back?.label,
-      };
+    if (config?.back) {
+      const backItems = Array.isArray(config.back) ? config.back : [config.back];
+      const explicit = backItems
+        .filter((b) => b.href?.trim())
+        .map((b) => ({ backHref: b.href, backDestinationLabel: b.label }));
+      if (explicit.length > 0) {
+        return explicit;
+      }
     }
 
     if (breadcrumbs.length < 2) {
-      return undefined;
+      return EMPTY;
     }
+
+    const targets: BackNavigation[] = [];
     for (let i = breadcrumbs.length - 2; i >= 0; i--) {
       const crumb = breadcrumbs[i];
       const href = crumb.href;
-      if (href) {
-        return {
+      if (href && !isExcludedBackTarget(crumb)) {
+        targets.push({
           backHref: href,
           backDestinationLabel: getBreadcrumbPlainText(crumb),
-        };
+        });
       }
     }
-    return undefined;
+    return targets.length > 0 ? targets : EMPTY;
   }, [breadcrumbs, config]);
 }

--- a/src/core/packages/chrome/browser-components/src/chrome_next/app_header/hooks/use_title.ts
+++ b/src/core/packages/chrome/browser-components/src/chrome_next/app_header/hooks/use_title.ts
@@ -7,29 +7,9 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { useNextHeader, useProjectBreadcrumbs } from '../../../shared/chrome_hooks';
-import { getBreadcrumbPlainText } from '../../../shared/breadcrumb_utils';
+import { useNextHeader } from '../../../shared/chrome_hooks';
 
-/**
- * Resolution: explicit `config.title` -> last project breadcrumb text -> `undefined`.
- */
 export function useTitle(): string | undefined {
   const config = useNextHeader();
-  const breadcrumbs = useProjectBreadcrumbs();
-
-  if (config?.title) {
-    return config.title;
-  }
-
-  if (breadcrumbs.length === 0) {
-    return undefined;
-  }
-
-  const crumbForTitle = breadcrumbs[breadcrumbs.length - 1];
-  const plain = getBreadcrumbPlainText(crumbForTitle);
-  if (plain) {
-    return plain;
-  }
-
-  return undefined;
+  return config?.title;
 }

--- a/src/core/packages/chrome/browser-components/src/chrome_next/app_header/title_area.tsx
+++ b/src/core/packages/chrome/browser-components/src/chrome_next/app_header/title_area.tsx
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { EuiTitle, useEuiTheme } from '@elastic/eui';
+import { css } from '@emotion/react';
+import React, { useMemo } from 'react';
+import { useBackButton, useTitle } from './hooks';
+import { BackButton } from './back_button';
+
+export const TitleArea = React.memo(() => {
+  const { euiTheme } = useEuiTheme();
+  const backTargets = useBackButton();
+  const hasBack = backTargets.length > 0;
+  const title = useTitle();
+
+  const styles = useMemo(() => {
+    const wrapper = css`
+      display: flex;
+      align-items: center;
+      gap: ${euiTheme.size.m};
+      flex: 0 1 auto;
+      min-width: 0;
+      max-width: 100%;
+    `;
+
+    const titleOffset = css`
+      padding-left: ${euiTheme.size.xs};
+    `;
+
+    return { wrapper, titleOffset };
+  }, [euiTheme]);
+
+  if (!title && !hasBack) {
+    return null;
+  }
+
+  return (
+    <div css={styles.wrapper}>
+      {hasBack && <BackButton />}
+      {title && (
+        <EuiTitle size="xs" css={!hasBack ? styles.titleOffset : undefined}>
+          <h1 className="eui-textTruncate">{title}</h1>
+        </EuiTitle>
+      )}
+    </div>
+  );
+});
+
+TitleArea.displayName = 'TitleArea';

--- a/src/core/packages/chrome/browser-internal/src/chrome_api.tsx
+++ b/src/core/packages/chrome/browser-internal/src/chrome_api.tsx
@@ -176,6 +176,7 @@ export function createChromeApi({ state, services, sidebar }: ChromeApiDeps): In
       header: {
         get$: services.nextHeader.get$,
         set: services.nextHeader.set,
+        reset: services.nextHeader.reset,
       },
       aiButton: {
         get$: () => state.aiButton.$.pipe(map((buttons) => [...buttons])),

--- a/src/core/packages/chrome/browser-internal/src/services/next_header/next_header_service.ts
+++ b/src/core/packages/chrome/browser-internal/src/services/next_header/next_header_service.ts
@@ -26,7 +26,9 @@ export class NextHeaderService {
             (next as Record<string, unknown>)[key] = value;
           }
         }
-        this.config.set(Object.keys(next).length > 0 ? (next as ChromeNextHeaderConfig) : undefined);
+        this.config.set(
+          Object.keys(next).length > 0 ? (next as ChromeNextHeaderConfig) : undefined
+        );
       },
       reset: (...keys: Array<keyof ChromeNextHeaderConfig>) => {
         if (keys.length === 0) {

--- a/src/core/packages/chrome/browser-internal/src/services/next_header/next_header_service.ts
+++ b/src/core/packages/chrome/browser-internal/src/services/next_header/next_header_service.ts
@@ -18,9 +18,29 @@ export class NextHeaderService {
   public start() {
     return {
       get$: () => this.config.$,
-      set: (value?: ChromeNextHeaderConfig) => this.config.set(value),
-      /** @internal Reset to initial state (e.g. on app change). */
-      reset: () => this.config.set(undefined),
+      set: (partial: Partial<ChromeNextHeaderConfig>) => {
+        const current = this.config.get() ?? {};
+        const next = { ...current };
+        for (const [key, value] of Object.entries(partial)) {
+          if (value !== undefined) {
+            (next as Record<string, unknown>)[key] = value;
+          }
+        }
+        this.config.set(Object.keys(next).length > 0 ? (next as ChromeNextHeaderConfig) : undefined);
+      },
+      reset: (...keys: Array<keyof ChromeNextHeaderConfig>) => {
+        if (keys.length === 0) {
+          this.config.set(undefined);
+          return;
+        }
+        const current = this.config.get();
+        if (!current) return;
+        const next = { ...current };
+        for (const key of keys) {
+          delete next[key];
+        }
+        this.config.set(Object.keys(next).length > 0 ? next : undefined);
+      },
     };
   }
 

--- a/src/core/packages/chrome/browser-mocks/src/chrome_service.mock.ts
+++ b/src/core/packages/chrome/browser-mocks/src/chrome_service.mock.ts
@@ -117,8 +117,27 @@ const createStartContractMock = () => {
     next: lazyObject({
       header: lazyObject({
         get$: jest.fn().mockReturnValue(nextHeaderState$),
-        set: jest.fn((config?: ChromeNextHeaderConfig) => {
-          nextHeaderState$.next(config);
+        set: jest.fn((config: Partial<ChromeNextHeaderConfig>) => {
+          const current = nextHeaderState$.getValue();
+          const next = { ...current, ...config };
+          nextHeaderState$.next(
+            Object.keys(next).length > 0 ? (next as ChromeNextHeaderConfig) : undefined
+          );
+        }),
+        reset: jest.fn((...keys: Array<keyof ChromeNextHeaderConfig>) => {
+          if (keys.length === 0) {
+            nextHeaderState$.next(undefined);
+            return;
+          }
+          const current = nextHeaderState$.getValue();
+          if (!current) return;
+          const next = { ...current };
+          for (const key of keys) {
+            delete next[key];
+          }
+          nextHeaderState$.next(
+            Object.keys(next).length > 0 ? (next as ChromeNextHeaderConfig) : undefined
+          );
         }),
       }),
       aiButton: lazyObject({

--- a/src/core/packages/chrome/browser/src/chrome_next/chrome_next.ts
+++ b/src/core/packages/chrome/browser/src/chrome_next/chrome_next.ts
@@ -20,13 +20,19 @@ import type { ChromeNextSpaceSelectorConfig } from './space_selector';
 export interface ChromeNext {
   header: {
     /**
-     * Set the Chrome-Next header configuration for the current page.
-     * Chrome renders the title, metadata, global actions, and app menu.
-     *
-     * Pass `undefined` to clear (e.g. on unmount or route change).
-     * Automatically cleared on app change.
+     * Shallow-merge fields into the current Chrome-Next header configuration.
+     * Only provided keys are updated; `undefined` values in the partial are ignored.
+     * Use {@link reset} to clear fields.
      */
-    set(config?: ChromeNextHeaderConfig): void;
+    set(config: Partial<ChromeNextHeaderConfig>): void;
+
+    /**
+     * Clear Chrome-Next header configuration.
+     * Called with no arguments: clears everything.
+     * Called with key names: clears only those fields.
+     * Automatically called with no arguments on app change.
+     */
+    reset(...keys: Array<keyof ChromeNextHeaderConfig>): void;
   };
   aiButton: {
     /**

--- a/src/core/packages/chrome/browser/src/chrome_next/header.ts
+++ b/src/core/packages/chrome/browser/src/chrome_next/header.ts
@@ -61,9 +61,10 @@ export interface ChromeNextHeaderConfig {
 
   /**
    * Optional explicit back navigation for the Chrome-Next header back control.
-   * When `href` is set, overrides breadcrumb-derived back destination.
+   * When set, overrides breadcrumb-derived back destinations.
+   * A single object produces a direct link; an array produces a popover menu.
    */
-  back?: ChromeNextHeaderBack;
+  back?: ChromeNextHeaderBack | ChromeNextHeaderBack[];
 }
 
 /** Explicit back target for {@link ChromeNextHeaderConfig.back}. */

--- a/src/platform/plugins/shared/dashboard/public/dashboard_top_nav/internal_dashboard_top_nav.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_top_nav/internal_dashboard_top_nav.tsx
@@ -323,10 +323,10 @@ export function InternalDashboardTopNav({
 
     coreServices.chrome.next.header.set({
       title: title ?? '',
-      globalActions: Object.keys(globalActions).length > 0 ? globalActions : undefined,
+      ...(Object.keys(globalActions).length > 0 ? { globalActions } : {}),
     });
     return () => {
-      coreServices.chrome.next.header.set(undefined);
+      coreServices.chrome.next.header.reset();
     };
   }, [title, chromeNextHeaderShareGlobalAction, chromeNextHeaderFavoriteGlobalAction]);
 

--- a/src/platform/plugins/shared/discover/public/application/main/components/single_tab_view/single_tab_view_with_app_menu.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/single_tab_view/single_tab_view_with_app_menu.tsx
@@ -22,7 +22,7 @@ export const SingleTabViewWithAppMenu = (props: SingleTabViewProps) => {
     if (isNextChrome && topNavMenuItems) {
       chrome.next.header.set({ appMenu: topNavMenuItems });
       return () => {
-        chrome.next.header.set(undefined);
+        chrome.next.header.reset('appMenu');
       };
     }
   }, [isNextChrome, topNavMenuItems, chrome.next.header]);

--- a/src/platform/plugins/shared/discover/public/application/main/components/tabs_view/hide_tabs_bar.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/tabs_view/hide_tabs_bar.tsx
@@ -39,7 +39,7 @@ export const HideTabsBar: FC<{
     if (isNextChrome && customizationContext.displayMode === 'standalone' && topNavMenuItems) {
       chrome.next.header.set({ appMenu: topNavMenuItems });
       return () => {
-        chrome.next.header.set(undefined);
+        chrome.next.header.reset('appMenu');
       };
     }
   }, [isNextChrome, customizationContext.displayMode, topNavMenuItems, chrome.next.header]);

--- a/src/platform/plugins/shared/discover/public/application/main/components/tabs_view/tabs_view.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/tabs_view/tabs_view.tsx
@@ -53,7 +53,7 @@ export const TabsView = (props: SingleTabViewProps) => {
     if (isNextChrome && topNavMenuItems) {
       services.chrome.next.header.set({ appMenu: topNavMenuItems });
       return () => {
-        services.chrome.next.header.set(undefined);
+        services.chrome.next.header.reset('appMenu');
       };
     }
   }, [isNextChrome, topNavMenuItems, services.chrome.next.header]);

--- a/src/platform/plugins/shared/discover/public/application/main/discover_main_route.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/discover_main_route.tsx
@@ -220,9 +220,16 @@ const DiscoverMainRouteContent = (props: SingleTabViewProps) => {
         titleBreadcrumbText: persistedDiscoverSession?.title,
         services,
       });
+      chrome.next.header.set({
+        title: persistedDiscoverSession?.title || 'Discover',
+      });
     }
+    return () => {
+      chrome.next.header.reset('title');
+    };
   }, [
     chrome.docTitle,
+    chrome.next.header,
     persistedDiscoverSession?.title,
     customizationContext.displayMode,
     services,


### PR DESCRIPTION
## Summary

- Refactor `chrome.next.header` API: `set()` now shallow-merges (undefined values ignored), new `reset()` clears all or specific keys
- Enhance back button with tooltip ("Back to ..."), popover menu for multiple targets, and extensible exclusion lists (deep link IDs + href patterns)
- `back` config now accepts a single object or an array for explicit multi-target back navigation
- Remove breadcrumb fallback from `useTitle` — apps must explicitly set title via the header API
- Wire Discover to set title on mount/unmount, update Discover and Dashboard to use new `reset()` API
- Exclude Stack Management root from back button breadcrumb fallback targets