### PR TITLE
[Macroscope] Further improvements to the flaky test runner nudger

### DIFF
--- a/.macroscope/flaky-test-runner-nudge.md
+++ b/.macroscope/flaky-test-runner-nudge.md
@@ -20,7 +20,10 @@ conclusion: neutral
 
 Decide whether this PR needs a Flaky Test Runner nudge. If not, post nothing.
 
-IMPORTANT: Ensure we never post the same flaky test runner comment twice on the same PR. We should only post the comment once.
+**Important:**
+
+- Never post the flaky test runner comment more than once on the same PR.
+- Do not run this check on backport PRs.
 
 ## Step 1: Are any in-scope files changed?
 
@@ -63,6 +66,8 @@ Trigger a run with the [Flaky Test Runner UI](https://ci-stats.kibana.dev/trigge
 ```
 /flaky <scoutConfig or ftrConfig>:<resolved-scout-or-ftr-config-path>:30
 ```
+
+Provide feedback in the #appex-qa channel.
 ````
 
 Replace the example paths with the resolved paths from Step 3. Drop whichever line doesn't apply.

--- a/.macroscope/flaky-test-runner-nudge.md
+++ b/.macroscope/flaky-test-runner-nudge.md
@@ -20,9 +20,11 @@ conclusion: neutral
 
 Decide whether this PR needs a Flaky Test Runner nudge. If not, post nothing.
 
+IMPORTANT: Ensure we never post the same flaky test runner comment twice on the same PR. We should only post the comment once.
+
 ## Step 1: Are any in-scope files changed?
 
-- **Scout:** `**/test/scout*/**` or `**/kbn-scout*/**`
+- **Scout:** `**/test/scout*/**`
 - **FTR:** `src/platform/test/**`, `x-pack/platform/test/**`, `x-pack/solutions/*/test/**`
 
 If nothing matches, stop.
@@ -45,8 +47,6 @@ Example: `x-pack/platform/test/serverless/functional/configs/search/config.group
 
 Example: `x-pack/platform/plugins/shared/streams_app/test/scout/ui/playwright.config.ts`
 
-**Scout — changed file is under `**/kbn-scout*/**`:** Search the repo for imports of the changed module, prioritising hits under `\*\*/test/scout*/\*\*`. From each hit, walk up to the nearest Playwright config as above. If no config can be linked after tracing imports, tell the author to pick a suite manually using the UI.
-
 ## Output
 
 Post one comment on the PR. Include only the `/flaky` line(s) for the runner(s) that qualify:
@@ -63,7 +63,9 @@ Trigger a run with the [Flaky Test Runner UI](https://ci-stats.kibana.dev/trigge
 ```
 ````
 
-Replace the example paths with the resolved paths from Step 3. Drop whichever line doesn't apply. If Scout config could not be resolved (shared `kbn-scout*` package with no traceable imports), replace the `scoutConfig` line with a note asking the author to pick a suite manually in the UI. Sample commands:
+Replace the example paths with the resolved paths from Step 3. Drop whichever line doesn't apply.
+
+Sample commands:
 
 Scout:
 

--- a/.macroscope/flaky-test-runner-nudge.md
+++ b/.macroscope/flaky-test-runner-nudge.md
@@ -67,7 +67,7 @@ Trigger a run with the [Flaky Test Runner UI](https://ci-stats.kibana.dev/trigge
 /flaky <scoutConfig or ftrConfig>:<resolved-scout-or-ftr-config-path>:30
 ```
 
-Provide feedback in the #appex-qa channel.
+This check is experimental. Share your feedback in the #appex-qa channel.
 ````
 
 Replace the example paths with the resolved paths from Step 3. Drop whichever line doesn't apply.

--- a/.macroscope/flaky-test-runner-nudge.md
+++ b/.macroscope/flaky-test-runner-nudge.md
@@ -47,6 +47,8 @@ Example: `x-pack/platform/test/serverless/functional/configs/search/config.group
 
 Example: `x-pack/platform/plugins/shared/streams_app/test/scout/ui/playwright.config.ts`
 
+Ensure the new or updated tests actually belong to the config.
+
 ## Output
 
 Post one comment on the PR. Include only the `/flaky` line(s) for the runner(s) that qualify:
@@ -80,3 +82,5 @@ FTR:
 ```
 
 Always use 30: this tells the runner to execute the test config 30 times.
+
+Always ensure the Playwright config exists in the project, otherwise don't post it.


### PR DESCRIPTION
This PR update the Flaky Test Runner Nudger Macroscope [check run agent](https://docs.macroscope.com/check-run-agents) so that:

1. It only posts one comment per PR (no matter how often the PR was changed) to reduce noise
2. It verifies the Playwright config it recommends running the flaky test runner on actually exists
4. It doesn't post a nudge on PRs updating Scout packages (at least for now)
5. Do not run check on backport PRs 