### PR TITLE
[Fleet] Allow defining dynamic_namespace/dataset in input packages

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/common/services/policy_template.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/policy_template.test.ts
@@ -276,10 +276,7 @@ describe('getNormalizedDataStreams', () => {
       {
         type: 'foo',
         dataset: 'nginx.bar',
-        elasticsearch: {
-          dynamic_dataset: true,
-          dynamic_namespace: true,
-        },
+        elasticsearch: {},
         title: expect.any(String),
         release: 'ga',
         package: 'nginx',
@@ -365,10 +362,7 @@ describe('getNormalizedDataStreams', () => {
   const expectedInputPackageDataStream: RegistryDataStream = {
     type: 'logs',
     dataset: 'log.logs',
-    elasticsearch: {
-      dynamic_dataset: true,
-      dynamic_namespace: true,
-    },
+    elasticsearch: {},
     title: expect.any(String),
     release: 'ga',
     package: 'log',

--- a/x-pack/platform/plugins/shared/fleet/common/services/policy_template.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/policy_template.ts
@@ -234,12 +234,6 @@ export function getNormalizedDataStreams(
       ],
     };
 
-    dataStream.elasticsearch = {
-      ...dataStream.elasticsearch,
-      dynamic_dataset: true,
-      dynamic_namespace: true,
-    };
-
     return dataStream;
   });
 }

--- a/x-pack/platform/plugins/shared/fleet/common/types/models/package_spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/types/models/package_spec.ts
@@ -66,7 +66,11 @@ export interface PackageSpecManifest {
   owner: { github?: string; type?: 'elastic' | 'partner' | 'community' };
   elasticsearch?: Pick<
     RegistryElasticsearch,
-    'index_template.settings' | 'index_template.mappings' | 'index_template.data_stream'
+    | 'index_template.settings'
+    | 'index_template.mappings'
+    | 'index_template.data_stream'
+    | 'dynamic_dataset'
+    | 'dynamic_namespace'
   >;
   agent?: {
     privileges?: { root?: boolean };

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/package_policies_to_agent_permissions.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/package_policies_to_agent_permissions.test.ts
@@ -1296,6 +1296,91 @@ describe('storedPackagePoliciesToAgentPermissions()', () => {
       expect(permissions).toMatchObject({
         'package-policy-dynamic-signal': {
           indices: [
+            { names: ['logs-otel.dataset-default'], privileges: ['auto_configure', 'create_doc'] },
+            {
+              names: ['metrics-otel.dataset-default'],
+              privileges: ['auto_configure', 'create_doc'],
+            },
+            {
+              names: ['traces-otel.dataset-default'],
+              privileges: ['auto_configure', 'create_doc'],
+            },
+          ],
+        },
+      });
+    });
+
+    it('uses elasticsearch.dynamic_dataset/dynamic_namespace from the stream for dynamic_signal_types permissions', async () => {
+      const packagePolicies: PackagePolicy[] = [
+        {
+          id: 'package-policy-dynamic-wildcard',
+          name: 'otel-policy-wildcard',
+          namespace: 'default',
+          enabled: true,
+          package: { name: 'input_otel', version: '1.0.0', title: 'Input OTel' },
+          inputs: [
+            {
+              type: 'otelcol',
+              enabled: true,
+              streams: [
+                {
+                  id: 'stream-1',
+                  enabled: true,
+                  data_stream: {
+                    type: 'logs',
+                    dataset: 'otel.dataset',
+                    elasticsearch: { dynamic_dataset: true, dynamic_namespace: true },
+                  },
+                  vars: {},
+                } as any,
+              ],
+            },
+          ],
+          created_at: '',
+          updated_at: '',
+          created_by: '',
+          updated_by: '',
+          revision: 1,
+          policy_id: '',
+          policy_ids: [''],
+        },
+      ];
+
+      const agentInputs = [
+        {
+          id: 'otelcol-input-1',
+          type: 'otelcol',
+          streams: [
+            {
+              id: 'stream-1',
+              service: {
+                pipelines: {
+                  'logs/otlp': {
+                    receivers: ['otlp'],
+                  },
+                  'metrics/otlp': {
+                    receivers: ['otlp'],
+                  },
+                  'traces/otlp': {
+                    receivers: ['otlp'],
+                  },
+                },
+              },
+            },
+          ],
+        },
+      ] as any;
+
+      const permissions = await storedPackagePoliciesToAgentPermissions(
+        packageInfoCache,
+        'default',
+        packagePolicies,
+        agentInputs
+      );
+      expect(permissions?.['package-policy-dynamic-wildcard']?.indices).toHaveLength(3);
+      expect(permissions).toMatchObject({
+        'package-policy-dynamic-wildcard': {
+          indices: [
             { names: ['logs-*-*'], privileges: ['auto_configure', 'create_doc'] },
             { names: ['metrics-*-*'], privileges: ['auto_configure', 'create_doc'] },
             { names: ['traces-*-*'], privileges: ['auto_configure', 'create_doc'] },
@@ -1422,8 +1507,11 @@ describe('storedPackagePoliciesToAgentPermissions()', () => {
       expect(permissions).toMatchObject({
         'package-policy-partial-signals': {
           indices: [
-            { names: ['logs-*-*'], privileges: ['auto_configure', 'create_doc'] },
-            { names: ['metrics-*-*'], privileges: ['auto_configure', 'create_doc'] },
+            { names: ['logs-otel.dataset-default'], privileges: ['auto_configure', 'create_doc'] },
+            {
+              names: ['metrics-otel.dataset-default'],
+              privileges: ['auto_configure', 'create_doc'],
+            },
             // No traces pipeline - should only grant logs and metrics permissions
           ],
         },
@@ -1650,7 +1738,7 @@ describe('storedPackagePoliciesToAgentPermissions()', () => {
       );
 
       // The logfile input is non-dynamic — should get a concrete data stream permission,
-      // NOT the wildcard logs-*-* / metrics-*-* / traces-*-* from the otelcol template.
+      // NOT the dynamic_signal_types otelcol permissions (per-signal-type entries).
       expect(permissions?.['policy-logfile']?.indices).toHaveLength(1);
       expect(permissions?.['policy-logfile']?.indices?.[0].names).toEqual([
         'logs-mixed_multi_template_pkg.app-default',

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/package_policies_to_agent_permissions.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/package_policies_to_agent_permissions.ts
@@ -158,7 +158,8 @@ export function storedPackagePoliciesToAgentPermissions(
       default:
         // - Packages with dynamic_signal_types (input-only or composable integration) produce data
         //   for signal types defined in OTel pipelines; grant index permissions per signal type
-        //   pattern (e.g., logs-*-*, metrics-*-*) derived from agentInputs pipelines.
+        //   derived from agentInputs pipelines. Dataset/namespace breadth follows each stream's
+        //   elasticsearch.dynamic_dataset / dynamic_namespace (manifest), not dynamic_signal_types.
         if (isDynamicInput) {
           const otelcolPipelines = agentInputs?.find((i) => i.type === OTEL_COLLECTOR_INPUT_TYPE)
             ?.streams?.[0]?.service?.pipelines;
@@ -172,14 +173,33 @@ export function storedPackagePoliciesToAgentPermissions(
             signalTypes = [];
           }
 
-          const baseMeta: DataStreamMeta = {
-            type: 'logs',
-            dataset: '',
-            elasticsearch: { dynamic_dataset: true, dynamic_namespace: true },
-          };
+          const enabledStreams = packagePolicy.inputs
+            .filter((input) => input.enabled)
+            .flatMap((input) => input.streams?.filter((stream) => stream.enabled) ?? []);
+
+          const firstStream = enabledStreams[0];
+          let dataset =
+            firstStream?.compiled_stream?.data_stream?.dataset ??
+            firstStream?.data_stream?.dataset ??
+            '';
+
+          if (!dataset) {
+            const dynamicInput = packagePolicy.inputs.find(
+              (input) =>
+                input.enabled && packagePolicyInputAllowsUndefinedDataStreamType(pkg, input)
+            );
+            const policyTemplateName = dynamicInput?.policy_template;
+            if (policyTemplateName) {
+              dataset = `${pkg.name}.${policyTemplateName}`;
+            }
+          }
+
+          const elasticsearch = firstStream?.data_stream?.elasticsearch;
+
           dataStreamsForPermissions = signalTypes.map((type) => ({
-            ...baseMeta,
             type,
+            dataset,
+            elasticsearch,
           }));
         } else {
           // - Normal packages store some of the `data_stream` metadata in
@@ -233,7 +253,7 @@ export function storedPackagePoliciesToAgentPermissions(
                   dataStreams_.push(ds);
 
                   if (isOtelInput && stream.data_stream.type === 'traces') {
-                    // Span events are logs-*-* using the same data_stream.dataset as OTTL routing
+                    // Span events use logs-{dataset}-{namespace} with optional dynamic_namespace; same dataset as OTTL routing
                     // (getFullInputStreams + generateOtelTypeTransforms spanevent); include stream var override.
                     const baseDataset =
                       stream.compiled_stream?.data_stream?.dataset ?? stream.data_stream.dataset;

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/archive/parse.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/archive/parse.test.ts
@@ -317,6 +317,16 @@ describe('parseTopLevelElasticsearchEntry', () => {
       },
     });
   });
+  it('Should handle dynamic_dataset', () => {
+    expect(parseTopLevelElasticsearchEntry({ dynamic_dataset: true })).toEqual({
+      dynamic_dataset: true,
+    });
+  });
+  it('Should handle dynamic_namespace', () => {
+    expect(parseTopLevelElasticsearchEntry({ dynamic_namespace: true })).toEqual({
+      dynamic_namespace: true,
+    });
+  });
 });
 
 describe('parseAndVerifyArchive', () => {

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/archive/parse.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/archive/parse.ts
@@ -785,6 +785,19 @@ export function parseTopLevelElasticsearchEntry(elasticsearch?: Record<string, a
       expandedElasticsearch.index_template.settings
     );
   }
+
+  // @ts-expect-error upgrade typescript v5.1.6
+  if (expandedElasticsearch?.dynamic_dataset) {
+    // @ts-expect-error upgrade typescript v5.1.6
+    parsedElasticsearchEntry.dynamic_dataset = expandedElasticsearch.dynamic_dataset;
+  }
+
+  // @ts-expect-error upgrade typescript v5.1.6
+  if (expandedElasticsearch?.dynamic_namespace) {
+    // @ts-expect-error upgrade typescript v5.1.6
+    parsedElasticsearchEntry.dynamic_namespace = expandedElasticsearch.dynamic_namespace;
+  }
+
   return parsedElasticsearchEntry;
 }
 


### PR DESCRIPTION
It is currently hard-coded to true, giving broad permissions.