### PR TITLE
[docs] Fix 'occured' -> 'occurred' typo in audit_logging dev guide

### DIFF
--- a/dev_docs/key_concepts/audit_logging.mdx
+++ b/dev_docs/key_concepts/audit_logging.mdx
@@ -112,7 +112,7 @@ inherent tradeoff between the following logging approaches:
 - Actions that kick off **background tasks** should be logged as separate
   events, one for creating the task and another one for executing it.
 - **Internal checks**, which have been carried out in order to perform an
-  operation, or **errors** that occured as a result of an operation should be
+  operation, or **errors** that occurred as a result of an operation should be
   logged as an outcome of the operation itself, using the ECS `event.outcome`
   and `error` fields, instead of logging a separate event.
 - Multiple events that were part of the same request can be correlated in the


### PR DESCRIPTION
`dev_docs/key_concepts/audit_logging.mdx:115` used `errors that occured as a result of an operation`. Doc-only fix in the developer audit logging guide.