### PR TITLE
[One Workflow] Add more availability checks and plugin reorg

### DIFF
--- a/src/platform/plugins/shared/workflows_extensions/server/emit_event.ts
+++ b/src/platform/plugins/shared/workflows_extensions/server/emit_event.ts
@@ -7,9 +7,38 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import type { KibanaRequest } from '@kbn/core/server';
+import type { EventChainContext } from './event_chain_context';
 import { getEventChainContext } from './event_chain_context';
 import type { TriggerRegistry } from './trigger_registry/trigger_registry';
-import type { EmitEventParams, TriggerEventHandler } from './types';
+
+/**
+ * Parameters passed to the trigger event handler when an event is emitted.
+ */
+export interface TriggerEventHandlerParams {
+  timestamp: string;
+  triggerId: string;
+  spaceId: string;
+  payload: Record<string, unknown>;
+  request: KibanaRequest;
+  eventChainContext?: EventChainContext;
+}
+
+/**
+ * Handler invoked by the extensions plugin when emitEvent is called.
+ * Registered during setup to resolve subscriptions and run workflows.
+ */
+export type TriggerEventHandler = (params: TriggerEventHandlerParams) => Promise<void>;
+
+/**
+ * Parameters for emitEvent.
+ */
+export interface EmitEventParams {
+  triggerId: string;
+  spaceId: string;
+  payload: Record<string, unknown>;
+  request: KibanaRequest;
+}
 
 export interface EmitEventDeps {
   triggerRegistry: TriggerRegistry;

--- a/src/platform/plugins/shared/workflows_extensions/server/index.ts
+++ b/src/platform/plugins/shared/workflows_extensions/server/index.ts
@@ -19,13 +19,8 @@ export async function plugin(initializerContext: PluginInitializerContext) {
 }
 
 export type {
-  EmitEventFn,
-  EmitEventParams,
   EventChainContext,
   ServerTriggerDefinition,
-  TriggerEventHandlerParams,
-  WorkflowsClient,
-  WorkflowsRouteHandlerContext,
   WorkflowsExtensionsServerPluginSetup,
   WorkflowsExtensionsServerPluginStart,
   WorkflowsExtensionsServerPluginSetupDeps,

--- a/src/platform/plugins/shared/workflows_extensions/server/mocks.ts
+++ b/src/platform/plugins/shared/workflows_extensions/server/mocks.ts
@@ -26,7 +26,7 @@ const createStartMock: () => jest.Mocked<WorkflowsExtensionsServerPluginStart> =
     hasStepDefinition: jest.fn(),
     getAllStepDefinitions: jest.fn(),
     getAllTriggerDefinitions: jest.fn(),
-    emitEvent: jest.fn(),
+    getEventEmitter: jest.fn(),
   };
 };
 

--- a/src/platform/plugins/shared/workflows_extensions/server/plugin.ts
+++ b/src/platform/plugins/shared/workflows_extensions/server/plugin.ts
@@ -7,14 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type {
-  CoreSetup,
-  CoreStart,
-  CustomRequestHandlerContext,
-  Logger,
-  Plugin,
-  PluginInitializerContext,
-} from '@kbn/core/server';
+import type { CoreSetup, CoreStart, Plugin, PluginInitializerContext } from '@kbn/core/server';
 import { emitEvent } from './emit_event';
 import { registerGetStepDefinitionsRoute } from './routes/get_step_definitions';
 import { registerGetTriggerDefinitionsRoute } from './routes/get_trigger_definitions';
@@ -23,18 +16,12 @@ import { registerInternalStepDefinitions } from './steps';
 import { TriggerRegistry } from './trigger_registry';
 import { registerInternalTriggerDefinitions } from './triggers';
 import type {
-  EmitEventParams,
-  TriggerEventHandler,
+  GetEventEmitter,
   WorkflowsExtensionsServerPluginSetup,
   WorkflowsExtensionsServerPluginSetupDeps,
   WorkflowsExtensionsServerPluginStart,
   WorkflowsExtensionsServerPluginStartDeps,
-  WorkflowsRouteHandlerContext,
 } from './types';
-
-type WorkflowsExtensionsRequestHandlerContext = CustomRequestHandlerContext<{
-  workflows: WorkflowsRouteHandlerContext;
-}>;
 
 export class WorkflowsExtensionsServerPlugin
   implements
@@ -45,14 +32,10 @@ export class WorkflowsExtensionsServerPlugin
       WorkflowsExtensionsServerPluginStartDeps
     >
 {
-  private readonly logger: Logger;
   private readonly stepRegistry: ServerStepRegistry;
   private readonly triggerRegistry: TriggerRegistry;
-  private triggerEventHandler: TriggerEventHandler | null = null;
-  private emitEventFn: ((params: EmitEventParams) => Promise<void>) | null = null;
 
-  constructor(initializerContext: PluginInitializerContext) {
-    this.logger = initializerContext.logger.get();
+  constructor(_initializerContext: PluginInitializerContext) {
     this.stepRegistry = new ServerStepRegistry();
     this.triggerRegistry = new TriggerRegistry();
   }
@@ -67,26 +50,9 @@ export class WorkflowsExtensionsServerPlugin
     registerGetStepDefinitionsRoute(router, this.stepRegistry);
     // Register HTTP route to expose trigger definitions for testing
     registerGetTriggerDefinitionsRoute(router, this.triggerRegistry);
+
     registerInternalStepDefinitions(core, this.stepRegistry);
     registerInternalTriggerDefinitions(this.triggerRegistry);
-
-    core.http.registerRouteHandlerContext<WorkflowsExtensionsRequestHandlerContext, 'workflows'>(
-      'workflows',
-      async (_context, request) => {
-        const [, plugins] = await core.getStartServices();
-        const spaceId = plugins.spaces?.spacesService.getSpaceId(request) ?? 'default';
-        const emitEventFn = this.emitEventFn;
-        if (!emitEventFn) {
-          throw new Error('Workflows extensions plugin not started: emitEvent is not available.');
-        }
-        return {
-          getWorkflowsClient: () => ({
-            emitEvent: (triggerId: string, payload: Record<string, unknown>) =>
-              emitEventFn({ triggerId, spaceId, payload, request }),
-          }),
-        };
-      }
-    );
 
     return {
       registerStepDefinition: (definition) => {
@@ -95,28 +61,26 @@ export class WorkflowsExtensionsServerPlugin
       registerTriggerDefinition: (definition) => {
         this.triggerRegistry.register(definition);
       },
-      registerTriggerEventHandler: (handler) => {
-        if (this.triggerEventHandler !== null) {
-          this.logger.warn(
-            'A trigger event handler was already registered; it will be overwritten. Only one handler should register (e.g. workflows_management).'
-          );
-        }
-        this.triggerEventHandler = handler;
-      },
     };
   }
 
   public start(
     _core: CoreStart,
-    _plugins: WorkflowsExtensionsServerPluginStartDeps
+    plugins: WorkflowsExtensionsServerPluginStartDeps
   ): WorkflowsExtensionsServerPluginStart {
     this.triggerRegistry.freeze();
-    // Store so the route handler context provider (registered in setup) can call it when requests arrive.
-    this.emitEventFn = (params: EmitEventParams) =>
-      emitEvent(params, {
-        triggerRegistry: this.triggerRegistry,
-        triggerEventHandler: this.triggerEventHandler,
-      });
+
+    const spacesService = plugins.spaces?.spacesService;
+
+    const getEventEmitter: GetEventEmitter = (request, triggerEventHandler) => {
+      const spaceId = spacesService?.getSpaceId(request) ?? 'default';
+      return async (triggerId, payload) => {
+        emitEvent(
+          { triggerId, payload, request, spaceId },
+          { triggerRegistry: this.triggerRegistry, triggerEventHandler }
+        );
+      };
+    };
 
     return {
       getStepDefinition: (stepTypeId: string) => {
@@ -131,7 +95,7 @@ export class WorkflowsExtensionsServerPlugin
       getAllTriggerDefinitions: () => {
         return this.triggerRegistry.list();
       },
-      emitEvent: this.emitEventFn.bind(this),
+      getEventEmitter,
     };
   }
 

--- a/src/platform/plugins/shared/workflows_extensions/server/types.ts
+++ b/src/platform/plugins/shared/workflows_extensions/server/types.ts
@@ -24,35 +24,18 @@ export type ServerTriggerDefinition<EventSchema extends z.ZodType = z.ZodType> =
 
 export type { EventChainContext };
 
+/**
+ * Emit an event for the given trigger. Subscribed workflows in the current request's space will run.
+ * @param triggerId - Must match a trigger registered via registerTriggerDefinition
+ * @param payload - Event payload; available in workflows as context.event
+ * @throws Error if triggerId is not registered
+ */
 export type EventEmitter = (triggerId: string, payload: Record<string, unknown>) => Promise<void>;
 
 export type GetEventEmitter = (
   request: KibanaRequest,
   triggerEventHandler: TriggerEventHandler
 ) => EventEmitter;
-/**
- * Request-scoped client for emitting workflow trigger events.
- * Use from route handlers via ctx.workflows.getWorkflowsClient().
- */
-export interface WorkflowsClient {
-  /**
-   * Emit an event for the given trigger. Subscribed workflows in the current request's space will run.
-   * @param triggerId - Must match a trigger registered via registerTriggerDefinition
-   * @param payload - Event payload; available in workflows as context.event
-   * @throws Error if triggerId is not registered
-   */
-  emitEvent(triggerId: string, payload: Record<string, unknown>): Promise<void>;
-}
-
-/**
- * Workflows route handler context. Available as ctx.workflows for plugins that depend on workflows_extensions.
- */
-export interface WorkflowsRouteHandlerContext {
-  /**
-   * Returns a request-scoped client bound to the current request and space.
-   */
-  getWorkflowsClient(): WorkflowsClient;
-}
 
 /**
  * Server-side plugin setup contract.

--- a/src/platform/plugins/shared/workflows_extensions/server/types.ts
+++ b/src/platform/plugins/shared/workflows_extensions/server/types.ts
@@ -12,6 +12,7 @@ import type { KibanaRequest } from '@kbn/core/server';
 import type { InferenceServerStart } from '@kbn/inference-plugin/server';
 import type { SpacesPluginStart } from '@kbn/spaces-plugin/server';
 import type { z } from '@kbn/zod/v4';
+import type { TriggerEventHandler } from './emit_event';
 import type { EventChainContext } from './event_chain_context';
 import type { ServerStepDefinition } from './step_registry/types';
 import type { CommonTriggerDefinition } from '../common';
@@ -23,40 +24,12 @@ export type ServerTriggerDefinition<EventSchema extends z.ZodType = z.ZodType> =
 
 export type { EventChainContext };
 
-/**
- * Parameters passed to the trigger event handler when an event is emitted.
- */
-export interface TriggerEventHandlerParams {
-  timestamp: string;
-  triggerId: string;
-  spaceId: string;
-  payload: Record<string, unknown>;
-  request: KibanaRequest;
-  eventChainContext?: EventChainContext;
-}
+export type EventEmitter = (triggerId: string, payload: Record<string, unknown>) => Promise<void>;
 
-/**
- * Handler invoked by the extensions plugin when emitEvent is called.
- * Registered during setup to resolve subscriptions and run workflows.
- */
-export type TriggerEventHandler = (params: TriggerEventHandlerParams) => Promise<void>;
-
-/**
- * Parameters for emitEvent.
- */
-export interface EmitEventParams {
-  triggerId: string;
-  spaceId: string;
-  payload: Record<string, unknown>;
-  request: KibanaRequest;
-}
-
-/**
- * Emits a trigger event. Validates trigger id, then invokes the registered handler (which logs and runs subscribed workflows).
- * @throws Error if triggerId is not registered
- */
-export type EmitEventFn = (params: EmitEventParams) => Promise<void>;
-
+export type GetEventEmitter = (
+  request: KibanaRequest,
+  triggerEventHandler: TriggerEventHandler
+) => EventEmitter;
 /**
  * Request-scoped client for emitting workflow trigger events.
  * Use from route handlers via ctx.workflows.getWorkflowsClient().
@@ -103,14 +76,6 @@ export interface WorkflowsExtensionsServerPluginSetup {
    * @throws Error if trigger id is already registered, validation fails, or registration is attempted after setup
    */
   registerTriggerDefinition(definition: ServerTriggerDefinition): void;
-
-  /**
-   * Register the handler invoked when emitEvent is called.
-   * Should be called during the plugin's setup phase.
-   *
-   * @param handler - Function called with triggerId, spaceId, and payload when an event is emitted
-   */
-  registerTriggerEventHandler(handler: TriggerEventHandler): void;
 }
 
 /**
@@ -129,7 +94,7 @@ export type WorkflowsExtensionsServerPluginStart =
      * Emit a trigger event.
      * @throws Error if triggerId is not registered
      */
-    emitEvent: EmitEventFn;
+    getEventEmitter: GetEventEmitter;
   };
 
 /**

--- a/src/platform/plugins/shared/workflows_management/public/components/workflows_availability/workflows_availability_wrapper.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/components/workflows_availability/workflows_availability_wrapper.tsx
@@ -144,7 +144,12 @@ const ServerlessTierAccessDenied = React.memo<{
   const [billingUrl, setBillingUrl] = useState<string | undefined>();
 
   useEffect(() => {
-    cloud?.getPrivilegedUrls().then(({ billingUrl: url }) => setBillingUrl(url));
+    if (cloud) {
+      cloud
+        .getPrivilegedUrls()
+        .then((urls) => setBillingUrl(urls.billingUrl))
+        .catch(() => {});
+    }
   }, [cloud]);
 
   const actions = useMemo(() => {

--- a/src/platform/plugins/shared/workflows_management/server/api/constants.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/constants.ts
@@ -7,11 +7,6 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { registerDisableAllWorkflowsRoute } from './disable_all_workflows';
-import { registerGetConfigRoute } from './get_config';
-import type { RouteDependencies } from '../types';
+import type { LicenseType } from '@kbn/licensing-types';
 
-export function registerInternalRoutes(deps: RouteDependencies) {
-  registerGetConfigRoute(deps);
-  registerDisableAllWorkflowsRoute(deps);
-}
+export const REQUIRED_LICENSE_TYPE: LicenseType = 'enterprise';

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/executions/cancel_execution.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/executions/cancel_execution.ts
@@ -13,7 +13,7 @@ import { API_VERSION, AVAILABILITY, OAS_TAG } from '../utils/route_constants';
 import { handleRouteError } from '../utils/route_error_handlers';
 import { WORKFLOW_EXECUTION_CANCEL_SECURITY } from '../utils/route_security';
 import { executionIdParamSchema } from '../utils/schemas';
-import { withLicenseCheck } from '../utils/with_license_check';
+import { withAvailabilityCheck } from '../utils/with_availability_check';
 
 export function registerCancelExecutionRoute(deps: RouteDependencies) {
   const { router, api, spaces, audit } = deps;
@@ -41,7 +41,7 @@ export function registerCancelExecutionRoute(deps: RouteDependencies) {
           },
         },
       },
-      withLicenseCheck(async (context, request, response) => {
+      withAvailabilityCheck(async (context, request, response) => {
         try {
           const { executionId } = request.params;
           const spaceId = spaces.getSpaceId(request);

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/executions/cancel_workflow_executions.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/executions/cancel_workflow_executions.ts
@@ -13,7 +13,7 @@ import { API_VERSION, AVAILABILITY, OAS_TAG } from '../utils/route_constants';
 import { handleRouteError } from '../utils/route_error_handlers';
 import { WORKFLOW_EXECUTION_CANCEL_SECURITY } from '../utils/route_security';
 import { workflowIdParamSchema } from '../utils/schemas';
-import { withLicenseCheck } from '../utils/with_license_check';
+import { withAvailabilityCheck } from '../utils/with_availability_check';
 
 export function registerCancelWorkflowExecutionsRoute({ router, api, spaces }: RouteDependencies) {
   router.versioned
@@ -42,7 +42,7 @@ export function registerCancelWorkflowExecutionsRoute({ router, api, spaces }: R
           },
         },
       },
-      withLicenseCheck(async (context, request, response) => {
+      withAvailabilityCheck(async (context, request, response) => {
         try {
           const { workflowId } = request.params;
           const spaceId = spaces.getSpaceId(request);

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/executions/get_children_executions.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/executions/get_children_executions.ts
@@ -13,7 +13,7 @@ import { API_VERSION, AVAILABILITY, OAS_TAG } from '../utils/route_constants';
 import { handleRouteError } from '../utils/route_error_handlers';
 import { WORKFLOW_EXECUTION_READ_SECURITY } from '../utils/route_security';
 import { executionIdParamSchema } from '../utils/schemas';
-import { withLicenseCheck } from '../utils/with_license_check';
+import { withAvailabilityCheck } from '../utils/with_availability_check';
 
 export function registerGetChildrenExecutionsRoute({ router, api, spaces }: RouteDependencies) {
   router.versioned
@@ -42,7 +42,7 @@ export function registerGetChildrenExecutionsRoute({ router, api, spaces }: Rout
           },
         },
       },
-      withLicenseCheck(async (context, request, response) => {
+      withAvailabilityCheck(async (context, request, response) => {
         try {
           const { executionId } = request.params;
           const spaceId = spaces.getSpaceId(request);

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/executions/get_execution.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/executions/get_execution.ts
@@ -14,7 +14,7 @@ import { API_VERSION, AVAILABILITY, OAS_TAG } from '../utils/route_constants';
 import { handleRouteError } from '../utils/route_error_handlers';
 import { WORKFLOW_EXECUTION_READ_SECURITY } from '../utils/route_security';
 import { executionIdParamSchema } from '../utils/schemas';
-import { withLicenseCheck } from '../utils/with_license_check';
+import { withAvailabilityCheck } from '../utils/with_availability_check';
 
 export function registerGetExecutionRoute({ router, api, spaces }: RouteDependencies) {
   router.versioned
@@ -51,7 +51,7 @@ export function registerGetExecutionRoute({ router, api, spaces }: RouteDependen
           },
         },
       },
-      withLicenseCheck(async (context, request, response) => {
+      withAvailabilityCheck(async (context, request, response) => {
         try {
           const { executionId } = request.params;
           const { includeInput, includeOutput } = request.query;

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/executions/get_execution_logs.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/executions/get_execution_logs.ts
@@ -14,7 +14,7 @@ import { API_VERSION, AVAILABILITY, MAX_PAGE_SIZE, OAS_TAG } from '../utils/rout
 import { handleRouteError } from '../utils/route_error_handlers';
 import { WORKFLOW_EXECUTION_READ_SECURITY } from '../utils/route_security';
 import { executionIdParamSchema } from '../utils/schemas';
-import { withLicenseCheck } from '../utils/with_license_check';
+import { withAvailabilityCheck } from '../utils/with_availability_check';
 
 export function registerGetExecutionLogsRoute({ router, api, spaces }: RouteDependencies) {
   router.versioned
@@ -68,7 +68,7 @@ export function registerGetExecutionLogsRoute({ router, api, spaces }: RouteDepe
           },
         },
       },
-      withLicenseCheck(async (context, request, response) => {
+      withAvailabilityCheck(async (context, request, response) => {
         try {
           const { executionId } = request.params;
           const { size, page, sortField, sortOrder, stepExecutionId } = request.query;

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/executions/get_step_execution.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/executions/get_step_execution.ts
@@ -13,7 +13,7 @@ import type { RouteDependencies } from '../types';
 import { API_VERSION, AVAILABILITY, OAS_TAG } from '../utils/route_constants';
 import { handleRouteError } from '../utils/route_error_handlers';
 import { WORKFLOW_EXECUTION_READ_SECURITY } from '../utils/route_security';
-import { withLicenseCheck } from '../utils/with_license_check';
+import { withAvailabilityCheck } from '../utils/with_availability_check';
 
 export function registerGetStepExecutionRoute({ router, api, spaces }: RouteDependencies) {
   router.versioned
@@ -43,7 +43,7 @@ export function registerGetStepExecutionRoute({ router, api, spaces }: RouteDepe
           },
         },
       },
-      withLicenseCheck(async (context, request, response) => {
+      withAvailabilityCheck(async (context, request, response) => {
         try {
           const { executionId, stepExecutionId } = request.params;
           const stepExecution = await api.getStepExecution(

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/executions/get_workflow_executions.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/executions/get_workflow_executions.ts
@@ -17,7 +17,7 @@ import { API_VERSION, AVAILABILITY, MAX_PAGE_SIZE, OAS_TAG } from '../utils/rout
 import { handleRouteError } from '../utils/route_error_handlers';
 import { WORKFLOW_EXECUTION_READ_SECURITY } from '../utils/route_security';
 import { workflowIdParamSchema } from '../utils/schemas';
-import { withLicenseCheck } from '../utils/with_license_check';
+import { withAvailabilityCheck } from '../utils/with_availability_check';
 
 const executionStatusSchema = schema.oneOf(
   ExecutionStatusValues.map((type) => schema.literal(type)) as [Type<ExecutionStatus>]
@@ -99,7 +99,7 @@ export function registerGetWorkflowExecutionsRoute({ router, api, spaces }: Rout
           },
         },
       },
-      withLicenseCheck(async (context, request, response) => {
+      withAvailabilityCheck(async (context, request, response) => {
         try {
           const spaceId = spaces.getSpaceId(request);
           const { workflowId } = request.params;

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/executions/get_workflow_step_executions.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/executions/get_workflow_step_executions.ts
@@ -15,7 +15,7 @@ import { API_VERSION, AVAILABILITY, MAX_PAGE_SIZE, OAS_TAG } from '../utils/rout
 import { handleRouteError } from '../utils/route_error_handlers';
 import { WORKFLOW_EXECUTION_READ_SECURITY } from '../utils/route_security';
 import { workflowIdParamSchema } from '../utils/schemas';
-import { withLicenseCheck } from '../utils/with_license_check';
+import { withAvailabilityCheck } from '../utils/with_availability_check';
 
 export function registerGetWorkflowStepExecutionsRoute({ router, api, spaces }: RouteDependencies) {
   router.versioned
@@ -63,7 +63,7 @@ export function registerGetWorkflowStepExecutionsRoute({ router, api, spaces }: 
           },
         },
       },
-      withLicenseCheck(async (context, request, response) => {
+      withAvailabilityCheck(async (context, request, response) => {
         try {
           const spaceId = spaces.getSpaceId(request);
           const { workflowId } = request.params;

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/executions/resume_execution.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/executions/resume_execution.ts
@@ -14,7 +14,7 @@ import { API_VERSION, AVAILABILITY, OAS_TAG } from '../utils/route_constants';
 import { handleRouteError } from '../utils/route_error_handlers';
 import { WORKFLOW_EXECUTION_RESUME_SECURITY } from '../utils/route_security';
 import { executionIdParamSchema } from '../utils/schemas';
-import { withLicenseCheck } from '../utils/with_license_check';
+import { withAvailabilityCheck } from '../utils/with_availability_check';
 
 export function registerResumeExecutionRoute(deps: RouteDependencies) {
   const { router, api, spaces, audit } = deps;
@@ -47,7 +47,7 @@ export function registerResumeExecutionRoute(deps: RouteDependencies) {
           },
         },
       },
-      withLicenseCheck(async (context, request, response) => {
+      withAvailabilityCheck(async (context, request, response) => {
         try {
           const { executionId } = request.params;
           const { input } = request.body;

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/executions/run_workflow.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/executions/run_workflow.ts
@@ -16,7 +16,7 @@ import { API_VERSION, AVAILABILITY, OAS_TAG } from '../utils/route_constants';
 import { handleRouteError } from '../utils/route_error_handlers';
 import { WORKFLOW_EXECUTE_SECURITY } from '../utils/route_security';
 import { idParamSchema } from '../utils/schemas';
-import { withLicenseCheck } from '../utils/with_license_check';
+import { withAvailabilityCheck } from '../utils/with_availability_check';
 
 export function registerRunWorkflowRoute(deps: RouteDependencies) {
   const { router, api, logger, spaces, audit } = deps;
@@ -55,7 +55,7 @@ export function registerRunWorkflowRoute(deps: RouteDependencies) {
           },
         },
       },
-      withLicenseCheck(async (context, request, response) => {
+      withAvailabilityCheck(async (context, request, response) => {
         try {
           const { id } = request.params;
           const spaceId = spaces.getSpaceId(request);

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/executions/test_step.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/executions/test_step.ts
@@ -13,7 +13,7 @@ import type { RouteDependencies } from '../types';
 import { API_VERSION, AVAILABILITY, OAS_TAG } from '../utils/route_constants';
 import { handleRouteError } from '../utils/route_error_handlers';
 import { WORKFLOW_EXECUTE_SECURITY } from '../utils/route_security';
-import { withLicenseCheck } from '../utils/with_license_check';
+import { withAvailabilityCheck } from '../utils/with_availability_check';
 
 export function registerTestStepRoute(deps: RouteDependencies) {
   const { router, api, spaces, audit } = deps;
@@ -57,7 +57,7 @@ export function registerTestStepRoute(deps: RouteDependencies) {
           },
         },
       },
-      withLicenseCheck(async (context, request, response) => {
+      withAvailabilityCheck(async (context, request, response) => {
         try {
           const spaceId = spaces.getSpaceId(request);
           const workflowExecutionId = await api.testStep(

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/executions/test_workflow.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/executions/test_workflow.ts
@@ -14,7 +14,7 @@ import type { RouteDependencies } from '../types';
 import { API_VERSION, AVAILABILITY, OAS_TAG } from '../utils/route_constants';
 import { handleRouteError } from '../utils/route_error_handlers';
 import { WORKFLOW_EXECUTE_SECURITY } from '../utils/route_security';
-import { withLicenseCheck } from '../utils/with_license_check';
+import { withAvailabilityCheck } from '../utils/with_availability_check';
 
 export function registerTestWorkflowRoute(deps: RouteDependencies) {
   const { router, api, logger, spaces, audit } = deps;
@@ -53,7 +53,7 @@ export function registerTestWorkflowRoute(deps: RouteDependencies) {
           },
         },
       },
-      withLicenseCheck(async (context, request, response) => {
+      withAvailabilityCheck(async (context, request, response) => {
         try {
           const { workflowId, workflowYaml, inputs: rawInputs } = request.body;
 

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/index.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/index.ts
@@ -23,9 +23,9 @@ export function defineRoutes(
   api: WorkflowsManagementApi,
   logger: Logger,
   spaces: SpacesServiceStart,
-  services: WorkflowsService
+  service: WorkflowsService
 ) {
-  const audit = new WorkflowManagementAuditLog({ services });
+  const audit = new WorkflowManagementAuditLog({ service });
 
   const deps: RouteDependencies = {
     router,
@@ -33,7 +33,7 @@ export function defineRoutes(
     logger,
     spaces,
     audit,
-    services,
+    service,
   };
 
   registerWorkflowRoutes(deps);

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/index.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/index.ts
@@ -8,9 +8,7 @@
  */
 
 import type { Logger } from '@kbn/core/server';
-import type { SecurityServiceStart } from '@kbn/core-security-server';
 import type { SpacesServiceStart } from '@kbn/spaces-plugin/server';
-import type { WorkflowsExecutionEnginePluginStart } from '@kbn/workflows-execution-engine/server';
 import { registerExecutionRoutes } from './executions';
 import { registerInternalRoutes } from './internal';
 import type { RouteDependencies } from './types';
@@ -18,16 +16,16 @@ import { WorkflowManagementAuditLog } from './utils/workflow_audit_logging';
 import { registerWorkflowRoutes } from './workflows';
 import type { WorkflowsRouter } from '../../types';
 import type { WorkflowsManagementApi } from '../workflows_management_api';
+import type { WorkflowsService } from '../workflows_management_service';
 
 export function defineRoutes(
   router: WorkflowsRouter,
   api: WorkflowsManagementApi,
   logger: Logger,
   spaces: SpacesServiceStart,
-  getWorkflowExecutionEngine: () => Promise<WorkflowsExecutionEnginePluginStart>,
-  getSecurityServiceStart: () => SecurityServiceStart | undefined
+  services: WorkflowsService
 ) {
-  const audit = new WorkflowManagementAuditLog({ getSecurityServiceStart });
+  const audit = new WorkflowManagementAuditLog({ services });
 
   const deps: RouteDependencies = {
     router,
@@ -35,9 +33,10 @@ export function defineRoutes(
     logger,
     spaces,
     audit,
+    services,
   };
 
   registerWorkflowRoutes(deps);
   registerExecutionRoutes(deps);
-  registerInternalRoutes(deps, getWorkflowExecutionEngine);
+  registerInternalRoutes(deps);
 }

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/internal/disable_all_workflows.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/internal/disable_all_workflows.ts
@@ -10,7 +10,7 @@
 import type { RouteDependencies } from '../types';
 import { INTERNAL_API_VERSION } from '../utils/route_constants';
 import { WORKFLOW_UPDATE_SECURITY } from '../utils/route_security';
-import { withLicenseCheck } from '../utils/with_license_check';
+import { withAvailabilityCheck } from '../utils/with_availability_check';
 
 export function registerDisableAllWorkflowsRoute({ router, api }: RouteDependencies) {
   router.versioned
@@ -24,7 +24,7 @@ export function registerDisableAllWorkflowsRoute({ router, api }: RouteDependenc
         version: INTERNAL_API_VERSION,
         validate: false,
       },
-      withLicenseCheck(async (_context, _request, response) => {
+      withAvailabilityCheck(async (_context, _request, response) => {
         const result = await api.disableAllWorkflows();
         return response.ok({
           body: result,

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/internal/get_config.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/internal/get_config.ts
@@ -12,7 +12,7 @@ import { INTERNAL_API_VERSION } from '../utils/route_constants';
 import { WORKFLOW_READ_SECURITY } from '../utils/route_security';
 import { withAvailabilityCheck } from '../utils/with_availability_check';
 
-export function registerGetConfigRoute({ router, services }: RouteDependencies) {
+export function registerGetConfigRoute({ router, service }: RouteDependencies) {
   router.versioned
     .get({
       path: '/internal/workflows/config',
@@ -25,7 +25,7 @@ export function registerGetConfigRoute({ router, services }: RouteDependencies) 
         validate: false,
       },
       withAvailabilityCheck(async (_context, _request, response) => {
-        const engine = await services.getWorkflowsExecutionEngine();
+        const engine = await service.getWorkflowsExecutionEngine();
         return response.ok({
           body: {
             eventDrivenExecutionEnabled: engine.isEventDrivenExecutionEnabled(),

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/internal/get_config.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/internal/get_config.ts
@@ -7,16 +7,12 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { WorkflowsExecutionEnginePluginStart } from '@kbn/workflows-execution-engine/server';
 import type { RouteDependencies } from '../types';
 import { INTERNAL_API_VERSION } from '../utils/route_constants';
 import { WORKFLOW_READ_SECURITY } from '../utils/route_security';
-import { withLicenseCheck } from '../utils/with_license_check';
+import { withAvailabilityCheck } from '../utils/with_availability_check';
 
-export function registerGetConfigRoute(
-  { router }: RouteDependencies,
-  getWorkflowExecutionEngine: () => Promise<WorkflowsExecutionEnginePluginStart>
-) {
+export function registerGetConfigRoute({ router, services }: RouteDependencies) {
   router.versioned
     .get({
       path: '/internal/workflows/config',
@@ -28,8 +24,8 @@ export function registerGetConfigRoute(
         version: INTERNAL_API_VERSION,
         validate: false,
       },
-      withLicenseCheck(async (_context, _request, response) => {
-        const engine = await getWorkflowExecutionEngine();
+      withAvailabilityCheck(async (_context, _request, response) => {
+        const engine = await services.getWorkflowsExecutionEngine();
         return response.ok({
           body: {
             eventDrivenExecutionEnabled: engine.isEventDrivenExecutionEnabled(),

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/tests/route_privilege_consistency.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/tests/route_privilege_consistency.test.ts
@@ -7,8 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-jest.mock('../utils/with_license_check', () => ({
-  withLicenseCheck: (handler: any) => handler,
+jest.mock('../utils/with_availability_check', () => ({
+  withAvailabilityCheck: (handler: any) => handler,
 }));
 jest.mock('../utils/route_error_handlers', () => ({
   handleRouteError: jest.fn(),
@@ -486,12 +486,12 @@ describe('Route privilege/ES-operation consistency', () => {
 
     const mockLogger = loggerMock.create();
 
-    const getCoreStart = jest.fn().mockResolvedValue({
+    const mockCoreStart = {
       ...coreMock.createStart(),
       elasticsearch: { client: { asInternalUser: mockEsClient } },
-    });
+    };
 
-    const getPluginsStart = jest.fn().mockResolvedValue({
+    const mockPluginsStart = {
       workflowsExecutionEngine: mockExecutionEngineStart,
       actions: {
         getUnsecuredActionsClient: jest.fn().mockResolvedValue({
@@ -507,15 +507,15 @@ describe('Route privilege/ES-operation consistency', () => {
       workflowsExtensions: {
         getAllTriggerDefinitions: jest.fn().mockReturnValue([]),
       },
-    });
+    };
 
-    const service = new WorkflowsService(mockLogger, getCoreStart, getPluginsStart);
+    const startServices = jest.fn().mockResolvedValue([mockCoreStart, mockPluginsStart]) as any;
+    const service = new WorkflowsService(startServices, mockLogger);
     await new Promise((resolve) => setTimeout(resolve, 0));
 
     // ── WorkflowsManagementApi ──
 
-    const getExecutionEngine = jest.fn().mockResolvedValue(mockExecutionEngineStart);
-    const api = new WorkflowsManagementApi(service, getExecutionEngine);
+    const api = new WorkflowsManagementApi(service, true);
 
     // ── Capturing mock router ──
 
@@ -549,11 +549,12 @@ describe('Route privilege/ES-operation consistency', () => {
     } as unknown as jest.Mocked<WorkflowsRouter>;
 
     const mockSpaces = { getSpaceId: jest.fn().mockReturnValue('default') } as any;
-    const mockAudit = new WorkflowManagementAuditLog({ getSecurityServiceStart: () => undefined });
+    const mockAudit = new WorkflowManagementAuditLog({ service });
 
     const deps: RouteDependencies = {
       router: mockRouter,
       api: api as any,
+      service: service,
       logger: mockLogger,
       spaces: mockSpaces,
       audit: mockAudit,

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/types.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/types.ts
@@ -12,10 +12,12 @@ import type { SpacesServiceStart } from '@kbn/spaces-plugin/server';
 import type { WorkflowManagementAuditLog } from './utils/workflow_audit_logging';
 import type { WorkflowsRouter } from '../../types';
 import type { WorkflowsManagementApi } from '../workflows_management_api';
+import type { WorkflowsService } from '../workflows_management_service';
 
 export interface RouteDependencies {
   router: WorkflowsRouter;
   api: WorkflowsManagementApi;
+  services: WorkflowsService;
   logger: Logger;
   spaces: SpacesServiceStart;
   audit: WorkflowManagementAuditLog;

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/types.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/types.ts
@@ -17,7 +17,7 @@ import type { WorkflowsService } from '../workflows_management_service';
 export interface RouteDependencies {
   router: WorkflowsRouter;
   api: WorkflowsManagementApi;
-  services: WorkflowsService;
+  service: WorkflowsService;
   logger: Logger;
   spaces: SpacesServiceStart;
   audit: WorkflowManagementAuditLog;

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/utils/with_availability_check.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/utils/with_availability_check.ts
@@ -10,10 +10,8 @@
 import type { RequestHandler, RouteMethod } from '@kbn/core/server';
 import { i18n } from '@kbn/i18n';
 import { type CheckLicense, wrapRouteWithLicenseCheck } from '@kbn/licensing-plugin/server';
-import type { LicenseType } from '@kbn/licensing-types';
 import type { WorkflowsRequestHandlerContext } from '../../../types';
-
-const RequiredLicenseType: LicenseType = 'enterprise';
+import { REQUIRED_LICENSE_TYPE } from '../../constants';
 
 const checkLicense: CheckLicense = (license) => {
   if (!license.isAvailable || !license.isActive) {
@@ -26,13 +24,13 @@ const checkLicense: CheckLicense = (license) => {
     };
   }
 
-  if (!license.hasAtLeast(RequiredLicenseType)) {
+  if (!license.hasAtLeast(REQUIRED_LICENSE_TYPE)) {
     return {
       valid: false,
       message: i18n.translate('plugins.workflowsManagement.checkLicense.invalidLicense', {
         defaultMessage:
-          'Your {licenseType} license does not support Workflows. Please upgrade to an {requiredLicenseType} license.',
-        values: { licenseType: license.type, requiredLicenseType: RequiredLicenseType },
+          'Your {licenseType} license does not have Workflows available. Please upgrade to an {requiredLicenseType} license.',
+        values: { licenseType: license.type, requiredLicenseType: REQUIRED_LICENSE_TYPE },
       }),
     };
   }
@@ -40,11 +38,28 @@ const checkLicense: CheckLicense = (license) => {
   return { valid: true, message: null };
 };
 
+const withServerlessAvailabilityCheck =
+  <P = unknown, Q = unknown, B = unknown, Method extends RouteMethod = never>(
+    handler: RequestHandler<P, Q, B, WorkflowsRequestHandlerContext, Method>
+  ): RequestHandler<P, Q, B, WorkflowsRequestHandlerContext, Method> =>
+  async (context, request, response) => {
+    const { isWorkflowsAvailable } = await context.workflows;
+    if (!isWorkflowsAvailable) {
+      return response.forbidden({
+        body: {
+          message:
+            'Your project does not have Workflows available. Please upgrade your tier subscription.',
+        },
+      });
+    }
+    return handler(context, request, response);
+  };
+
 /**
- * Wraps a request handler with a license check.
- * If the license is not valid, it will return a 403 error with a message.
+ * Wraps a request handler with a license and serverless availability check.
+ * If workflows are not available in this environment, it will return a 403 (FORBIDDEN) error with a message.
  */
-export const withLicenseCheck = <
+export const withAvailabilityCheck = <
   P = unknown,
   Q = unknown,
   B = unknown,
@@ -52,4 +67,4 @@ export const withLicenseCheck = <
 >(
   handler: RequestHandler<P, Q, B, WorkflowsRequestHandlerContext, Method>
 ): RequestHandler<P, Q, B, WorkflowsRequestHandlerContext, Method> =>
-  wrapRouteWithLicenseCheck(checkLicense, handler);
+  wrapRouteWithLicenseCheck(checkLicense, withServerlessAvailabilityCheck(handler));

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/utils/workflow_audit_logging.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/utils/workflow_audit_logging.ts
@@ -10,6 +10,7 @@
 import type { KibanaRequest } from '@kbn/core-http-server';
 import type { SecurityServiceStart } from '@kbn/core-security-server';
 import type { AuditEvent } from '@kbn/security-plugin-types-server';
+import type { WorkflowsService } from '../../workflows_management_service';
 
 /**
  * Stable action names for xpack.security.audit.ignore_filters.
@@ -66,7 +67,7 @@ function createEvent(
 }
 
 interface WorkflowManagementAuditLogDeps {
-  getSecurityServiceStart: () => SecurityServiceStart | undefined;
+  services: WorkflowsService;
 }
 
 /**
@@ -75,15 +76,20 @@ interface WorkflowManagementAuditLogDeps {
  * Best-effort: sync throws are caught; audit never affects HTTP responses.
  */
 export class WorkflowManagementAuditLog {
-  constructor(private readonly deps: WorkflowManagementAuditLogDeps) {}
+  private security?: SecurityServiceStart;
+
+  constructor(private readonly deps: WorkflowManagementAuditLogDeps) {
+    this.deps.services.getCoreStart().then((coreStart) => {
+      this.security = coreStart.security; // security service is initialized
+    });
+  }
 
   private log(request: KibanaRequest, event: AuditEvent): void {
     try {
-      const security = this.deps.getSecurityServiceStart();
-      if (!security) {
+      if (!this.security) {
         return;
       }
-      security.audit.asScoped(request).log(event);
+      this.security.audit.asScoped(request).log(event);
     } catch {
       // Best-effort only: never let audit affect the HTTP response.
     }

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/utils/workflow_audit_logging.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/utils/workflow_audit_logging.ts
@@ -67,7 +67,7 @@ function createEvent(
 }
 
 interface WorkflowManagementAuditLogDeps {
-  services: WorkflowsService;
+  service: WorkflowsService;
 }
 
 /**
@@ -79,7 +79,7 @@ export class WorkflowManagementAuditLog {
   private security?: SecurityServiceStart;
 
   constructor(private readonly deps: WorkflowManagementAuditLogDeps) {
-    this.deps.services.getCoreStart().then((coreStart) => {
+    this.deps.service.getCoreStart().then((coreStart) => {
       this.security = coreStart.security; // security service is initialized
     });
   }

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/workflows/bulk_create_workflows.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/workflows/bulk_create_workflows.ts
@@ -14,7 +14,7 @@ import type { RouteDependencies } from '../types';
 import { API_VERSION, AVAILABILITY, OAS_TAG } from '../utils/route_constants';
 import { handleRouteError } from '../utils/route_error_handlers';
 import { WORKFLOW_BULK_CREATE_SECURITY } from '../utils/route_security';
-import { withLicenseCheck } from '../utils/with_license_check';
+import { withAvailabilityCheck } from '../utils/with_availability_check';
 
 export function registerBulkCreateWorkflowsRoute(deps: RouteDependencies) {
   const { router, api, spaces, audit } = deps;
@@ -49,7 +49,7 @@ export function registerBulkCreateWorkflowsRoute(deps: RouteDependencies) {
           },
         },
       },
-      withLicenseCheck(async (context, request, response) => {
+      withAvailabilityCheck(async (context, request, response) => {
         try {
           const spaceId = spaces.getSpaceId(request);
           const { overwrite } = request.query;

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/workflows/bulk_delete_workflows.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/workflows/bulk_delete_workflows.ts
@@ -13,7 +13,7 @@ import type { RouteDependencies } from '../types';
 import { API_VERSION, AVAILABILITY, OAS_TAG } from '../utils/route_constants';
 import { handleRouteError } from '../utils/route_error_handlers';
 import { WORKFLOW_DELETE_SECURITY } from '../utils/route_security';
-import { withLicenseCheck } from '../utils/with_license_check';
+import { withAvailabilityCheck } from '../utils/with_availability_check';
 
 const MAX_BULK_DELETE_BATCH_SIZE = 1000;
 
@@ -60,7 +60,7 @@ export function registerBulkDeleteWorkflowsRoute(deps: RouteDependencies) {
           },
         },
       },
-      withLicenseCheck(async (context, request, response) => {
+      withAvailabilityCheck(async (context, request, response) => {
         const { force } = request.query;
         try {
           const { ids } = request.body;

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/workflows/clone_workflow.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/workflows/clone_workflow.ts
@@ -13,7 +13,7 @@ import { API_VERSION, AVAILABILITY, OAS_TAG } from '../utils/route_constants';
 import { handleRouteError } from '../utils/route_error_handlers';
 import { WORKFLOW_CLONE_SECURITY } from '../utils/route_security';
 import { idParamSchema } from '../utils/schemas';
-import { withLicenseCheck } from '../utils/with_license_check';
+import { withAvailabilityCheck } from '../utils/with_availability_check';
 
 export function registerCloneWorkflowRoute(deps: RouteDependencies) {
   const { router, api, spaces, audit } = deps;
@@ -41,7 +41,7 @@ export function registerCloneWorkflowRoute(deps: RouteDependencies) {
           },
         },
       },
-      withLicenseCheck(async (context, request, response) => {
+      withAvailabilityCheck(async (context, request, response) => {
         try {
           const { id } = request.params;
           const spaceId = spaces.getSpaceId(request);

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/workflows/create_workflow.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/workflows/create_workflow.ts
@@ -13,7 +13,7 @@ import type { RouteDependencies } from '../types';
 import { API_VERSION, AVAILABILITY, OAS_TAG } from '../utils/route_constants';
 import { handleRouteError } from '../utils/route_error_handlers';
 import { WORKFLOW_CREATE_SECURITY } from '../utils/route_security';
-import { withLicenseCheck } from '../utils/with_license_check';
+import { withAvailabilityCheck } from '../utils/with_availability_check';
 
 export function registerCreateWorkflowRoute(deps: RouteDependencies) {
   const { router, api, spaces, audit } = deps;
@@ -42,7 +42,7 @@ export function registerCreateWorkflowRoute(deps: RouteDependencies) {
           },
         },
       },
-      withLicenseCheck(async (context, request, response) => {
+      withAvailabilityCheck(async (context, request, response) => {
         try {
           const spaceId = spaces.getSpaceId(request);
           const createdWorkflow = await api.createWorkflow(request.body, spaceId, request);

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/workflows/delete_workflow.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/workflows/delete_workflow.ts
@@ -14,7 +14,7 @@ import { API_VERSION, AVAILABILITY, OAS_TAG } from '../utils/route_constants';
 import { handleRouteError } from '../utils/route_error_handlers';
 import { WORKFLOW_DELETE_SECURITY } from '../utils/route_security';
 import { idParamSchema } from '../utils/schemas';
-import { withLicenseCheck } from '../utils/with_license_check';
+import { withAvailabilityCheck } from '../utils/with_availability_check';
 
 export function registerDeleteWorkflowRoute(deps: RouteDependencies) {
   const { router, api, spaces, audit } = deps;
@@ -51,7 +51,7 @@ export function registerDeleteWorkflowRoute(deps: RouteDependencies) {
           },
         },
       },
-      withLicenseCheck(async (context, request, response) => {
+      withAvailabilityCheck(async (context, request, response) => {
         const { force } = request.query;
         try {
           const { id } = request.params;

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/workflows/export_workflows.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/workflows/export_workflows.ts
@@ -16,7 +16,7 @@ import type { RouteDependencies } from '../types';
 import { API_VERSION, AVAILABILITY, OAS_TAG } from '../utils/route_constants';
 import { handleRouteError } from '../utils/route_error_handlers';
 import { WORKFLOW_READ_SECURITY } from '../utils/route_security';
-import { withLicenseCheck } from '../utils/with_license_check';
+import { withAvailabilityCheck } from '../utils/with_availability_check';
 
 export function registerExportWorkflowsRoute(deps: RouteDependencies) {
   const { router, api, logger, spaces, audit } = deps;
@@ -53,7 +53,7 @@ export function registerExportWorkflowsRoute(deps: RouteDependencies) {
           },
         },
       },
-      withLicenseCheck(async (context, request, response) => {
+      withAvailabilityCheck(async (context, request, response) => {
         try {
           const spaceId = spaces.getSpaceId(request);
           const { ids } = request.body;

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/workflows/get_aggs.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/workflows/get_aggs.ts
@@ -13,7 +13,7 @@ import type { RouteDependencies } from '../types';
 import { API_VERSION, AVAILABILITY, OAS_TAG } from '../utils/route_constants';
 import { handleRouteError } from '../utils/route_error_handlers';
 import { WORKFLOW_READ_SECURITY } from '../utils/route_security';
-import { withLicenseCheck } from '../utils/with_license_check';
+import { withAvailabilityCheck } from '../utils/with_availability_check';
 
 const MAX_AGG_FIELDS = 25;
 
@@ -51,7 +51,7 @@ export function registerGetAggsRoute({ router, api, spaces }: RouteDependencies)
           },
         },
       },
-      withLicenseCheck(async (context, request, response) => {
+      withAvailabilityCheck(async (context, request, response) => {
         try {
           const { fields } = request.query;
           const spaceId = spaces.getSpaceId(request);

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/workflows/get_connectors.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/workflows/get_connectors.ts
@@ -12,7 +12,7 @@ import type { RouteDependencies } from '../types';
 import { API_VERSION, AVAILABILITY, OAS_TAG } from '../utils/route_constants';
 import { handleRouteError } from '../utils/route_error_handlers';
 import { WORKFLOW_READ_SECURITY } from '../utils/route_security';
-import { withLicenseCheck } from '../utils/with_license_check';
+import { withAvailabilityCheck } from '../utils/with_availability_check';
 
 export function registerGetConnectorsRoute({ router, api, logger, spaces }: RouteDependencies) {
   router.versioned
@@ -36,7 +36,7 @@ export function registerGetConnectorsRoute({ router, api, logger, spaces }: Rout
         },
         validate: false,
       },
-      withLicenseCheck(async (context, request, response) => {
+      withAvailabilityCheck(async (context, request, response) => {
         try {
           const spaceId = spaces.getSpaceId(request);
           const { connectorTypes, totalConnectors } = await api.getAvailableConnectors(

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/workflows/get_schema.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/workflows/get_schema.ts
@@ -13,7 +13,7 @@ import type { RouteDependencies } from '../types';
 import { API_VERSION, AVAILABILITY, OAS_TAG } from '../utils/route_constants';
 import { handleRouteError } from '../utils/route_error_handlers';
 import { WORKFLOW_READ_SECURITY } from '../utils/route_security';
-import { withLicenseCheck } from '../utils/with_license_check';
+import { withAvailabilityCheck } from '../utils/with_availability_check';
 
 export function registerGetSchemaRoute({ router, api, spaces }: RouteDependencies) {
   router.versioned
@@ -48,7 +48,7 @@ export function registerGetSchemaRoute({ router, api, spaces }: RouteDependencie
           },
         },
       },
-      withLicenseCheck(async (context, request, response) => {
+      withAvailabilityCheck(async (context, request, response) => {
         try {
           const { loose } = request.query;
           const spaceId = spaces.getSpaceId(request);

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/workflows/get_stats.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/workflows/get_stats.ts
@@ -13,7 +13,7 @@ import type { RouteDependencies } from '../types';
 import { API_VERSION, AVAILABILITY, OAS_TAG } from '../utils/route_constants';
 import { handleRouteError } from '../utils/route_error_handlers';
 import { WORKFLOW_READ_OR_READ_EXECUTIONS_SECURITY } from '../utils/route_security';
-import { withLicenseCheck } from '../utils/with_license_check';
+import { withAvailabilityCheck } from '../utils/with_availability_check';
 
 export function registerGetStatsRoute({ router, api, spaces }: RouteDependencies) {
   router.versioned
@@ -37,7 +37,7 @@ export function registerGetStatsRoute({ router, api, spaces }: RouteDependencies
         },
         validate: false,
       },
-      withLicenseCheck(async (context, request, response) => {
+      withAvailabilityCheck(async (context, request, response) => {
         try {
           if (request.authzResult?.[WorkflowsManagementApiActions.read] !== true) {
             return response.forbidden();

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/workflows/get_workflow.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/workflows/get_workflow.ts
@@ -13,7 +13,7 @@ import { API_VERSION, AVAILABILITY, OAS_TAG } from '../utils/route_constants';
 import { handleRouteError } from '../utils/route_error_handlers';
 import { WORKFLOW_READ_SECURITY } from '../utils/route_security';
 import { idParamSchema } from '../utils/schemas';
-import { withLicenseCheck } from '../utils/with_license_check';
+import { withAvailabilityCheck } from '../utils/with_availability_check';
 
 export function registerGetWorkflowRoute(deps: RouteDependencies) {
   const { router, api, spaces, audit } = deps;
@@ -41,7 +41,7 @@ export function registerGetWorkflowRoute(deps: RouteDependencies) {
           },
         },
       },
-      withLicenseCheck(async (context, request, response) => {
+      withAvailabilityCheck(async (context, request, response) => {
         try {
           const { id } = request.params;
           const spaceId = spaces.getSpaceId(request);

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/workflows/get_workflows.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/workflows/get_workflows.ts
@@ -21,7 +21,7 @@ import {
 } from '../utils/route_constants';
 import { handleRouteError } from '../utils/route_error_handlers';
 import { WORKFLOW_READ_OR_READ_EXECUTIONS_SECURITY } from '../utils/route_security';
-import { withLicenseCheck } from '../utils/with_license_check';
+import { withAvailabilityCheck } from '../utils/with_availability_check';
 
 const querySchema = schema.object({
   query: schema.maybe(schema.string({ meta: { description: 'Free-text search query.' } })),
@@ -69,7 +69,7 @@ export function registerGetWorkflowsRoute({ router, api, spaces }: RouteDependen
         },
         validate: { request: { query: querySchema } },
       },
-      withLicenseCheck(async (context, request, response) => {
+      withAvailabilityCheck(async (context, request, response) => {
         try {
           if (request.authzResult?.[WorkflowsManagementApiActions.read] !== true) {
             return response.forbidden();

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/workflows/mget_workflows.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/workflows/mget_workflows.ts
@@ -13,7 +13,7 @@ import type { RouteDependencies } from '../types';
 import { API_VERSION, AVAILABILITY, OAS_TAG } from '../utils/route_constants';
 import { handleRouteError } from '../utils/route_error_handlers';
 import { WORKFLOW_READ_SECURITY } from '../utils/route_security';
-import { withLicenseCheck } from '../utils/with_license_check';
+import { withAvailabilityCheck } from '../utils/with_availability_check';
 
 export function registerMgetWorkflowsRoute(deps: RouteDependencies) {
   const { router, api, spaces, audit } = deps;
@@ -61,7 +61,7 @@ export function registerMgetWorkflowsRoute(deps: RouteDependencies) {
           },
         },
       },
-      withLicenseCheck(async (context, request, response) => {
+      withAvailabilityCheck(async (context, request, response) => {
         try {
           const spaceId = spaces.getSpaceId(request);
           const { ids, source } = request.body;

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/workflows/update_workflow.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/workflows/update_workflow.ts
@@ -14,7 +14,7 @@ import { API_VERSION, AVAILABILITY, OAS_TAG } from '../utils/route_constants';
 import { handleRouteError } from '../utils/route_error_handlers';
 import { WORKFLOW_UPDATE_SECURITY } from '../utils/route_security';
 import { idParamSchema } from '../utils/schemas';
-import { withLicenseCheck } from '../utils/with_license_check';
+import { withAvailabilityCheck } from '../utils/with_availability_check';
 
 export function registerUpdateWorkflowRoute(deps: RouteDependencies) {
   const { router, api, spaces, audit } = deps;
@@ -44,7 +44,7 @@ export function registerUpdateWorkflowRoute(deps: RouteDependencies) {
           },
         },
       },
-      withLicenseCheck(async (context, request, response) => {
+      withAvailabilityCheck(async (context, request, response) => {
         try {
           const { id } = request.params;
           const spaceId = spaces.getSpaceId(request);

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/workflows/validate_workflow.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/workflows/validate_workflow.ts
@@ -13,7 +13,7 @@ import { MAX_WORKFLOW_YAML_LENGTH } from '@kbn/workflows';
 import type { RouteDependencies } from '../types';
 import { AVAILABILITY, INTERNAL_API_VERSION, OAS_TAG } from '../utils/route_constants';
 import { WORKFLOW_READ_SECURITY } from '../utils/route_security';
-import { withLicenseCheck } from '../utils/with_license_check';
+import { withAvailabilityCheck } from '../utils/with_availability_check';
 
 export function registerValidateWorkflowRoute({ router, api, spaces, logger }: RouteDependencies) {
   router.versioned
@@ -46,7 +46,7 @@ export function registerValidateWorkflowRoute({ router, api, spaces, logger }: R
           },
         },
       },
-      withLicenseCheck(async (context, request, response) => {
+      withAvailabilityCheck(async (context, request, response) => {
         try {
           const spaceId = spaces.getSpaceId(request);
           const result = await api.validateWorkflow(request.body.yaml, spaceId, request);

--- a/src/platform/plugins/shared/workflows_management/server/api/workflows_management_api.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/workflows_management_api.ts
@@ -143,8 +143,12 @@ export class WorkflowsManagementApi {
 
   constructor(
     private readonly workflowsService: WorkflowsService,
-    private readonly getWorkflowsExecutionEngine: () => Promise<WorkflowsExecutionEnginePluginStart>
+    public readonly isWorkflowsAvailable: boolean
   ) {}
+
+  private async getWorkflowsExecutionEngine(): Promise<WorkflowsExecutionEnginePluginStart> {
+    return this.workflowsService.getWorkflowsExecutionEngine();
+  }
 
   public setSmlIndexAttachment(fn: SmlIndexAttachmentFn, logger: Logger): void {
     this.smlIndexAttachment = fn;

--- a/src/platform/plugins/shared/workflows_management/server/api/workflows_management_service.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/workflows_management_service.ts
@@ -1742,12 +1742,12 @@ export class WorkflowsService {
   }
 
   public async getExecutionLogs(params: ExecutionLogsParams): Promise<LogSearchResult> {
-    this.ensureInitialized();
+    await this.ensureInitialized();
     return this.workflowsExecutionEngine.workflowEventLoggerService.getExecutionLogs(params);
   }
 
   public async getStepLogs(params: StepLogsParams): Promise<LogSearchResult> {
-    this.ensureInitialized();
+    await this.ensureInitialized();
     return this.workflowsExecutionEngine.workflowEventLoggerService.getStepLogs(params);
   }
 

--- a/src/platform/plugins/shared/workflows_management/server/api/workflows_management_service.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/workflows_management_service.ts
@@ -10,17 +10,15 @@
 import type { estypes } from '@elastic/elasticsearch';
 import { v4 as generateUuid } from 'uuid';
 import { WorkflowsConnectorFeatureId } from '@kbn/actions-plugin/common/connector_feature_config';
-import type { ActionsClient, IUnsecuredActionsClient } from '@kbn/actions-plugin/server';
-import type { FindActionResult } from '@kbn/actions-plugin/server/types';
+import type { ActionsPlugin, FindActionResult } from '@kbn/actions-plugin/server/types';
 import type {
   CoreStart,
   ElasticsearchClient,
   KibanaRequest,
   Logger,
-  SecurityServiceStart,
+  StartServicesAccessor,
 } from '@kbn/core/server';
 import { isResponseError } from '@kbn/es-errors';
-import type { PublicMethodsOf } from '@kbn/utility-types';
 import {
   ExecutionType,
   NonTerminalExecutionStatuses,
@@ -53,8 +51,8 @@ import type {
   WorkflowPartialDetailDto,
 } from '@kbn/workflows/types/v1';
 import type {
-  IWorkflowEventLoggerService,
   LogSearchResult,
+  WorkflowsExecutionEnginePluginStart,
 } from '@kbn/workflows-execution-engine/server';
 import type {
   ExecutionLogsParams,
@@ -85,7 +83,7 @@ import { getAuthenticatedUser } from '../lib/get_user';
 import { hasScheduledTriggers } from '../lib/schedule_utils';
 import type { WorkflowProperties, WorkflowStorage } from '../storage/workflow_storage';
 import { createStorage, workflowIndexName } from '../storage/workflow_storage';
-import type { WorkflowTaskScheduler } from '../tasks/workflow_task_scheduler';
+import { WorkflowTaskScheduler } from '../tasks/workflow_task_scheduler';
 import type { WorkflowsServerPluginStartDeps } from '../types';
 
 /** Derives a list of trigger type ids from a workflow definition (e.g. ['manual', 'scheduled', 'cases.updated']). */
@@ -111,63 +109,57 @@ export interface SearchWorkflowExecutionsParams {
 }
 
 export class WorkflowsService {
-  private esClient!: ElasticsearchClient;
+  // The following attributes require `ensureInitialized` to be called before use
+  private coreStart!: CoreStart;
+  private workflowsExecutionEngine!: WorkflowsExecutionEnginePluginStart;
   private workflowStorage!: WorkflowStorage;
-  private workflowEventLoggerService!: IWorkflowEventLoggerService;
-  private taskScheduler: WorkflowTaskScheduler | null = null;
-  private readonly logger: Logger;
-  private security?: SecurityServiceStart;
-  private workflowsExtensions: WorkflowsExtensionsServerPluginStart | undefined;
-  private getActionsClient: () => Promise<IUnsecuredActionsClient>;
-  private getActionsClientWithRequest: (
-    request: KibanaRequest
-  ) => Promise<PublicMethodsOf<ActionsClient>>;
+  private taskScheduler!: WorkflowTaskScheduler;
+  private esClient!: ElasticsearchClient;
+  private actions!: ActionsPlugin['start'];
+  private workflowsExtensions!: WorkflowsExtensionsServerPluginStart;
+
   private readonly initPromise: Promise<void>;
 
   constructor(
-    logger: Logger,
-    getCoreStart: () => Promise<CoreStart>,
-    getPluginsStart: () => Promise<WorkflowsServerPluginStartDeps>
+    startServices: StartServicesAccessor<WorkflowsServerPluginStartDeps>,
+    private readonly logger: Logger
   ) {
-    this.logger = logger;
-    this.getActionsClient = () =>
-      getPluginsStart().then((plugins) => plugins.actions.getUnsecuredActionsClient());
-    this.getActionsClientWithRequest = (request: KibanaRequest) =>
-      getPluginsStart().then((plugins) => plugins.actions.getActionsClientWithRequest(request));
-
-    this.initPromise = this.initialize(getCoreStart, getPluginsStart);
-  }
-
-  public setTaskScheduler(taskScheduler: WorkflowTaskScheduler) {
-    this.taskScheduler = taskScheduler;
-  }
-
-  public setSecurityService(security: SecurityServiceStart) {
-    this.security = security;
+    this.initPromise = this.initialize(startServices);
   }
 
   private async ensureInitialized(): Promise<void> {
     await this.initPromise;
   }
 
-  private async initialize(
-    getCoreStart: () => Promise<CoreStart>,
-    getPluginsStart: () => Promise<WorkflowsServerPluginStartDeps>
-  ) {
-    const coreStart = await getCoreStart();
-    const pluginsStart = await getPluginsStart();
+  private async initialize(startServices: StartServicesAccessor<WorkflowsServerPluginStartDeps>) {
+    const [coreStart, pluginsStart] = await startServices();
+    this.coreStart = coreStart;
+    this.taskScheduler = new WorkflowTaskScheduler(this.logger, pluginsStart.taskManager);
 
+    this.actions = pluginsStart.actions;
     this.esClient = coreStart.elasticsearch.client.asInternalUser;
 
-    // Initialize workflow storage
     this.workflowStorage = createStorage({
       logger: this.logger,
       esClient: this.esClient,
     });
 
-    this.workflowEventLoggerService =
-      pluginsStart.workflowsExecutionEngine.workflowEventLoggerService;
+    this.workflowsExecutionEngine = pluginsStart.workflowsExecutionEngine;
     this.workflowsExtensions = pluginsStart.workflowsExtensions;
+  }
+
+  public async getWorkflowsExecutionEngine(): Promise<WorkflowsExecutionEnginePluginStart> {
+    await this.ensureInitialized();
+    return this.workflowsExecutionEngine;
+  }
+  public async getWorkflowsExtensions(): Promise<WorkflowsExtensionsServerPluginStart> {
+    await this.ensureInitialized();
+    return this.workflowsExtensions;
+  }
+
+  public async getCoreStart(): Promise<CoreStart> {
+    await this.ensureInitialized();
+    return this.coreStart;
   }
 
   public async getWorkflow(id: string, spaceId: string): Promise<WorkflowDetailDto | null> {
@@ -233,7 +225,9 @@ export class WorkflowsService {
     spaceId: string,
     source?: string[]
   ): Promise<WorkflowPartialDetailDto[]> {
-    if (!this.workflowStorage || ids.length === 0) {
+    await this.ensureInitialized();
+
+    if (ids.length === 0) {
       return [];
     }
 
@@ -350,7 +344,7 @@ export class WorkflowsService {
     }
 
     const zodSchema = await this.getWorkflowZodSchema({ loose: false }, spaceId, request);
-    const authenticatedUser = getAuthenticatedUser(request, this.security);
+    const authenticatedUser = getAuthenticatedUser(request, this.coreStart.security);
     const now = new Date();
     const triggerDefinitions = this.workflowsExtensions?.getAllTriggerDefinitions() ?? [];
 
@@ -396,9 +390,9 @@ export class WorkflowsService {
     await this.ensureInitialized();
 
     const zodSchema = await this.getWorkflowZodSchema({ loose: false }, spaceId, request);
-    const authenticatedUser = getAuthenticatedUser(request, this.security);
+    const authenticatedUser = getAuthenticatedUser(request, this.coreStart.security);
     const now = new Date();
-    const triggerDefinitions = this.workflowsExtensions?.getAllTriggerDefinitions() ?? [];
+    const triggerDefinitions = this.workflowsExtensions.getAllTriggerDefinitions();
 
     const created: WorkflowDetailDto[] = [];
     const failed: Array<{ index: number; id: string; error: string }> = [];
@@ -495,6 +489,8 @@ export class WorkflowsService {
     id: string,
     spaceId: string
   ): Promise<{ source: WorkflowProperties }> {
+    await this.ensureInitialized();
+
     const searchResponse = await this.workflowStorage.getClient().search({
       query: {
         bool: {
@@ -529,8 +525,10 @@ export class WorkflowsService {
     validationErrors: string[];
     shouldUpdateScheduler: boolean;
   }> {
+    await this.ensureInitialized();
+
     const zodSchema = await this.getWorkflowZodSchema({ loose: false }, spaceId, request);
-    const triggerDefinitions = this.workflowsExtensions?.getAllTriggerDefinitions() ?? [];
+    const triggerDefinitions = this.workflowsExtensions.getAllTriggerDefinitions();
     const validation = validateWorkflowYaml(workflowYaml, zodSchema, { triggerDefinitions });
 
     if (!validation.valid || !validation.parsedWorkflow) {
@@ -657,7 +655,7 @@ export class WorkflowsService {
 
     try {
       const { source: existingSource } = await this.getExistingWorkflowDocument(id, spaceId);
-      const authenticatedUser = getAuthenticatedUser(request, this.security);
+      const authenticatedUser = getAuthenticatedUser(request, this.coreStart.security);
       const now = new Date();
       const validationErrors: string[] = [];
       let updatedData: Partial<WorkflowProperties> = {
@@ -1744,19 +1742,13 @@ export class WorkflowsService {
   }
 
   public async getExecutionLogs(params: ExecutionLogsParams): Promise<LogSearchResult> {
-    if (!this.workflowEventLoggerService) {
-      throw new Error('WorkflowEventLoggerService not initialized');
-    }
-
-    return this.workflowEventLoggerService.getExecutionLogs(params);
+    this.ensureInitialized();
+    return this.workflowsExecutionEngine.workflowEventLoggerService.getExecutionLogs(params);
   }
 
   public async getStepLogs(params: StepLogsParams): Promise<LogSearchResult> {
-    if (!this.workflowEventLoggerService) {
-      throw new Error('WorkflowEventLoggerService not initialized');
-    }
-
-    return this.workflowEventLoggerService.getStepLogs(params);
+    this.ensureInitialized();
+    return this.workflowsExecutionEngine.workflowEventLoggerService.getStepLogs(params);
   }
 
   public async getStepExecution(
@@ -1821,8 +1813,9 @@ export class WorkflowsService {
     spaceId: string,
     request: KibanaRequest
   ): Promise<GetAvailableConnectorsResponse> {
-    const actionsClient = await this.getActionsClient();
-    const actionsClientWithRequest = await this.getActionsClientWithRequest(request);
+    await this.ensureInitialized();
+    const actionsClient = this.actions.getUnsecuredActionsClient();
+    const actionsClientWithRequest = await this.actions.getActionsClientWithRequest(request);
 
     // Get both connectors and action types
     const [connectors, actionTypes] = await Promise.all([

--- a/src/platform/plugins/shared/workflows_management/server/api/workflows_route_handler_context_provider.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/workflows_route_handler_context_provider.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { IContextProvider, Logger } from '@kbn/core/server';
+import { REQUIRED_LICENSE_TYPE } from './constants';
+import type { WorkflowsManagementApi } from './workflows_management_api';
+import type { WorkflowsService } from './workflows_management_service';
+import { createTriggerEventHandler } from '../event_driven/trigger_event_handler';
+import type { WorkflowsRequestHandlerContext } from '../types';
+
+export const createWorkflowsRouteHandlerContextProvider = (
+  api: WorkflowsManagementApi,
+  workflowsService: WorkflowsService,
+  logger: Logger
+): IContextProvider<WorkflowsRequestHandlerContext, 'workflows'> => {
+  const triggerEventHandler = createTriggerEventHandler({ logger, api, workflowsService });
+
+  return async (context, request) => {
+    const workflowsExtensions = await workflowsService.getWorkflowsExtensions();
+    const { license } = await context.licensing;
+
+    // license for stateful and config.available for serverless
+    const isWorkflowsAvailable =
+      license.hasAtLeast(REQUIRED_LICENSE_TYPE) && api.isWorkflowsAvailable;
+
+    return {
+      isWorkflowsAvailable,
+      getWorkflowsClient: () => {
+        if (isWorkflowsAvailable) {
+          return {
+            emitEvent: workflowsExtensions.getEventEmitter(request, triggerEventHandler),
+          };
+        }
+        return {
+          emitEvent: async (triggerId) => {
+            logger.warn(
+              `Workflows event '${triggerId}' ignored: workflows is not available in this environment.`
+            );
+          },
+        };
+      },
+    };
+  };
+};

--- a/src/platform/plugins/shared/workflows_management/server/connectors/workflows/index.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/connectors/workflows/index.test.ts
@@ -18,13 +18,20 @@ import {
   type GetWorkflowsConnectorTypeArgs,
   resolveAlertStates,
 } from '.';
+import type { WorkflowsManagementApi } from '../../api/workflows_management_api';
+
+const mockWorkflowsManagementApi = {
+  getWorkflow: jest.fn(),
+  runWorkflow: jest.fn(),
+  scheduleWorkflow: jest.fn(),
+} as unknown as WorkflowsManagementApi;
 
 describe('Workflows Connector', () => {
   const mockLogger = loggingSystemMock.create().get() as jest.Mocked<Logger>;
 
   describe('getConnectorType', () => {
     it('should return correct connector type configuration', () => {
-      const connectorType = getConnectorType();
+      const connectorType = getConnectorType(mockWorkflowsManagementApi);
 
       expect(connectorType.id).toBe('.workflows');
       expect(connectorType.minimumLicenseRequired).toBe('gold');
@@ -37,7 +44,7 @@ describe('Workflows Connector', () => {
     });
 
     it('should have correct validation schemas', () => {
-      const connectorType = getConnectorType();
+      const connectorType = getConnectorType(mockWorkflowsManagementApi);
 
       expect(connectorType.validate).toBeDefined();
       expect(connectorType.validate.config).toBeDefined();

--- a/src/platform/plugins/shared/workflows_management/server/connectors/workflows/index.ts
+++ b/src/platform/plugins/shared/workflows_management/server/connectors/workflows/index.ts
@@ -15,6 +15,7 @@ import type {
 } from '@kbn/actions-plugin/server/types';
 import type { ConnectorAdapter } from '@kbn/alerting-plugin/server';
 import type { KibanaRequest } from '@kbn/core/server';
+import type { TriggerType, WorkflowExecutionEngineModel } from '@kbn/workflows';
 import { z } from '@kbn/zod/v4';
 import { api } from './api';
 import { ExecutorParamsSchema, WorkflowsRuleActionParamsSchema } from './schema';
@@ -31,7 +32,9 @@ import type {
   WorkflowsActionParamsType,
   WorkflowsExecutorResultData,
 } from './types';
+import { validateWorkflowForExecution } from './validate_workflow_for_execution';
 import { buildAlertEvent } from '../../../common/utils/build_alert_event';
+import type { WorkflowsManagementApi } from '../../api/workflows_management_api';
 
 const supportedSubActions: string[] = ['run'];
 export type ActionParamsType = WorkflowsActionParamsType;
@@ -55,13 +58,14 @@ export interface GetWorkflowsConnectorTypeArgs {
 
 // connector type definition
 export function getConnectorType(
-  deps?: GetWorkflowsConnectorTypeArgs
+  workflowsManagementApi: WorkflowsManagementApi
 ): ConnectorType<
   Record<string, unknown>,
   Record<string, unknown>,
   ExecutorParams,
   WorkflowsExecutorResultData
 > {
+  const args = getWorkflowsConnectorTypeArgs(workflowsManagementApi);
   return {
     id: ConnectorTypeId,
     minimumLicenseRequired: 'gold',
@@ -77,10 +81,74 @@ export function getConnectorType(
         schema: z.object({}).strict(),
       },
     },
-    executor: (execOptions) => executor(execOptions, deps),
+    executor: (execOptions) => executor(execOptions, args),
     supportedFeatureIds: [AlertingConnectorFeatureId, SecurityConnectorFeatureId],
     isSystemActionType: true,
     allowMultipleSystemActions: true,
+  };
+}
+
+function getWorkflowsConnectorTypeArgs(
+  workflowsManagementApi: WorkflowsManagementApi
+): GetWorkflowsConnectorTypeArgs {
+  // Create workflows service function for the connector
+  const getWorkflowsService = async (request: KibanaRequest) => {
+    // Return a function that will be called by the connector
+    return async (workflowId: string, spaceId: string, inputs: Record<string, unknown>) => {
+      // Get the workflow and validate it is in a runnable state
+      const workflow = await workflowsManagementApi.getWorkflow(workflowId, spaceId);
+      validateWorkflowForExecution(workflow, workflowId);
+
+      const workflowToRun: WorkflowExecutionEngineModel = {
+        id: workflow.id,
+        name: workflow.name,
+        enabled: workflow.enabled,
+        definition: workflow.definition,
+        yaml: workflow.yaml,
+      };
+
+      // Run the workflow, @tb: maybe switch to scheduler?
+      return workflowsManagementApi.runWorkflow(workflowToRun, spaceId, inputs, request);
+    };
+  };
+
+  // Create workflows scheduling service function for per-alert execution
+  const getScheduleWorkflowService = async (request: KibanaRequest) => {
+    return async (
+      workflowId: string,
+      spaceId: string,
+      inputs: Record<string, unknown>,
+      triggeredBy: TriggerType
+    ) => {
+      if (!api) {
+        throw new Error('Workflows management API not initialized');
+      }
+
+      // Get the workflow and validate it is in a runnable state
+      const workflow = await workflowsManagementApi.getWorkflow(workflowId, spaceId);
+      validateWorkflowForExecution(workflow, workflowId);
+
+      const workflowToSchedule: WorkflowExecutionEngineModel = {
+        id: workflow.id,
+        name: workflow.name,
+        enabled: workflow.enabled,
+        definition: workflow.definition,
+        yaml: workflow.yaml,
+      };
+
+      return workflowsManagementApi.scheduleWorkflow(
+        workflowToSchedule,
+        spaceId,
+        inputs,
+        request,
+        triggeredBy
+      );
+    };
+  };
+
+  return {
+    getWorkflowsService,
+    getScheduleWorkflowService,
   };
 }
 

--- a/src/platform/plugins/shared/workflows_management/server/connectors/workflows/index.ts
+++ b/src/platform/plugins/shared/workflows_management/server/connectors/workflows/index.ts
@@ -120,7 +120,7 @@ function getWorkflowsConnectorTypeArgs(
       inputs: Record<string, unknown>,
       triggeredBy: TriggerType
     ) => {
-      if (!api) {
+      if (!workflowsManagementApi) {
         throw new Error('Workflows management API not initialized');
       }
 

--- a/src/platform/plugins/shared/workflows_management/server/event_driven/trigger_event_handler.ts
+++ b/src/platform/plugins/shared/workflows_management/server/event_driven/trigger_event_handler.ts
@@ -9,12 +9,10 @@
 
 import pLimit from 'p-limit';
 import { v4 as generateUuid } from 'uuid';
-import type { Logger } from '@kbn/core/server';
+import type { KibanaRequest, Logger } from '@kbn/core/server';
 import type { WorkflowDetailDto, WorkflowExecutionEngineModel } from '@kbn/workflows';
-import type {
-  EventChainContext,
-  TriggerEventHandlerParams,
-} from '@kbn/workflows-extensions/server';
+import type { EventChainContext } from '@kbn/workflows-extensions/server';
+import type { TriggerEventHandlerParams } from '@kbn/workflows-extensions/server/emit_event';
 import { resolveMatchingWorkflowSubscriptions } from './resolve_workflow_subscriptions';
 import {
   createEmptyTriggerScheduleStats,
@@ -92,7 +90,7 @@ async function scheduleMatchingWorkflows(
   spaceId: string,
   eventParams: ScheduleEventParams,
   maxEventChainDepth: number,
-  request: TriggerEventHandlerParams['request'],
+  request: KibanaRequest,
   logger: Logger
 ): Promise<TriggerEventScheduleStats> {
   if (workflows.length === 0) {
@@ -189,19 +187,23 @@ export function createTriggerEventHandler({
 }: CreateTriggerEventHandlerParams): (params: TriggerEventHandlerParams) => Promise<void> {
   const telemetryClient = new WorkflowsManagementTelemetryClient({ logger, workflowsService });
 
-  const triggerEventsClientPromise = new Promise<TriggerEventsDataStreamClient>(async (resolve) => {
-    try {
-      const { dataStreams } = await workflowsService.getCoreStart();
-      const client = await initializeTriggerEventsClient(dataStreams);
-      resolve(client);
-    } catch (error) {
-      logger.warn(
-        `Failed to initialize trigger events data stream client: ${
-          error instanceof Error ? error.message : String(error)
-        }. Event audit logging will be skipped.`
-      );
+  const triggerEventsClientPromise = new Promise<TriggerEventsDataStreamClient>(
+    async (resolve, reject) => {
+      try {
+        const { dataStreams } = await workflowsService.getCoreStart();
+        const client = await initializeTriggerEventsClient(dataStreams);
+        resolve(client);
+      } catch (error) {
+        reject(
+          new Error(
+            `Failed to initialize trigger events data stream client: ${
+              error instanceof Error ? error.message : String(error)
+            }. Event audit logging will be skipped.`
+          )
+        );
+      }
     }
-  });
+  );
 
   return async (params: TriggerEventHandlerParams): Promise<void> => {
     const triggerEventsClient = await triggerEventsClientPromise;

--- a/src/platform/plugins/shared/workflows_management/server/event_driven/trigger_event_handler.ts
+++ b/src/platform/plugins/shared/workflows_management/server/event_driven/trigger_event_handler.ts
@@ -11,24 +11,24 @@ import pLimit from 'p-limit';
 import { v4 as generateUuid } from 'uuid';
 import type { Logger } from '@kbn/core/server';
 import type { WorkflowDetailDto, WorkflowExecutionEngineModel } from '@kbn/workflows';
-import type { WorkflowsExecutionEnginePluginStart } from '@kbn/workflows-execution-engine/server';
 import type {
   EventChainContext,
   TriggerEventHandlerParams,
 } from '@kbn/workflows-extensions/server';
-import type {
-  ResolveMatchingWorkflowSubscriptionsParams,
-  ResolveMatchingWorkflowSubscriptionsResult,
-} from './resolve_workflow_subscriptions';
+import { resolveMatchingWorkflowSubscriptions } from './resolve_workflow_subscriptions';
 import {
   createEmptyTriggerScheduleStats,
   type TriggerEventScheduleStats,
 } from './trigger_event_stats';
 import type { WorkflowsManagementApi } from '../api/workflows_management_api';
+import type { WorkflowsService } from '../api/workflows_management_service';
 import { validateWorkflowForExecution } from '../connectors/workflows/validate_workflow_for_execution';
-import { type TriggerEventDispatchedTelemetryEvent } from '../telemetry/events';
-import type { WorkflowsManagementTelemetryClient } from '../telemetry/workflows_management_telemetry_client';
-import { type TriggerEventsDataStreamClient, writeTriggerEvent } from '../trigger_events_log';
+import { WorkflowsManagementTelemetryClient } from '../telemetry/workflows_management_telemetry_client';
+import {
+  initializeTriggerEventsClient,
+  type TriggerEventsDataStreamClient,
+  writeTriggerEvent,
+} from '../trigger_events_log';
 
 const SCHEDULE_CONCURRENCY = 20;
 
@@ -171,13 +171,8 @@ async function scheduleMatchingWorkflows(
 
 export interface CreateTriggerEventHandlerParams {
   api: WorkflowsManagementApi;
+  workflowsService: WorkflowsService;
   logger: Logger;
-  telemetryClient: Pick<WorkflowsManagementTelemetryClient, 'reportTriggerEventDispatched'>;
-  getTriggerEventsClient: () => TriggerEventsDataStreamClient | null;
-  getWorkflowExecutionEngine: () => Promise<WorkflowsExecutionEnginePluginStart>;
-  resolveMatchingWorkflowSubscriptions: (
-    params: ResolveMatchingWorkflowSubscriptionsParams
-  ) => Promise<ResolveMatchingWorkflowSubscriptionsResult>;
 }
 
 /**
@@ -190,16 +185,27 @@ export interface CreateTriggerEventHandlerParams {
 export function createTriggerEventHandler({
   api,
   logger,
-  telemetryClient,
-  getTriggerEventsClient,
-  getWorkflowExecutionEngine,
-  resolveMatchingWorkflowSubscriptions,
+  workflowsService,
 }: CreateTriggerEventHandlerParams): (params: TriggerEventHandlerParams) => Promise<void> {
-  const reportDispatchedEvent = (event: TriggerEventDispatchedTelemetryEvent): void =>
-    telemetryClient.reportTriggerEventDispatched(event);
+  const telemetryClient = new WorkflowsManagementTelemetryClient({ logger, workflowsService });
+
+  const triggerEventsClientPromise = new Promise<TriggerEventsDataStreamClient>(async (resolve) => {
+    try {
+      const { dataStreams } = await workflowsService.getCoreStart();
+      const client = await initializeTriggerEventsClient(dataStreams);
+      resolve(client);
+    } catch (error) {
+      logger.warn(
+        `Failed to initialize trigger events data stream client: ${
+          error instanceof Error ? error.message : String(error)
+        }. Event audit logging will be skipped.`
+      );
+    }
+  });
 
   return async (params: TriggerEventHandlerParams): Promise<void> => {
-    const engine = await getWorkflowExecutionEngine();
+    const triggerEventsClient = await triggerEventsClientPromise;
+    const engine = await workflowsService.getWorkflowsExecutionEngine();
     const executionEnabled = engine.isEventDrivenExecutionEnabled();
     const logEventsEnabled = engine.isLogTriggerEventsEnabled();
     const baseTelemetry = {
@@ -225,11 +231,14 @@ export function createTriggerEventHandler({
       eventChainDepth: 1,
     };
     const resolutionStartMs = Date.now();
-    const { workflows, stats: resolutionStats } = await resolveMatchingWorkflowSubscriptions({
-      triggerId,
-      spaceId,
-      eventContext: eventContextForResolution,
-    });
+    const { workflows, stats: resolutionStats } = await resolveMatchingWorkflowSubscriptions(
+      {
+        triggerId,
+        spaceId,
+        eventContext: eventContextForResolution,
+      },
+      { api, logger }
+    );
     const subscriberResolutionMs = Math.max(0, Date.now() - resolutionStartMs);
     logger.trace(
       `Workflows trigger resolution funnel: triggerId=${triggerId} ${JSON.stringify(
@@ -239,7 +248,7 @@ export function createTriggerEventHandler({
     const subscriptions = workflows.map((w) => w.id);
 
     await writeTriggerEvents(
-      getTriggerEventsClient(),
+      triggerEventsClient,
       logEventsEnabled,
       {
         timestamp,
@@ -274,7 +283,7 @@ export function createTriggerEventHandler({
         )}`
       );
     }
-    reportDispatchedEvent({
+    telemetryClient.reportTriggerEventDispatched({
       ...baseTelemetry,
       eventChainDepth: eventChainContext?.depth ?? 0,
       eventId,

--- a/src/platform/plugins/shared/workflows_management/server/plugin.ts
+++ b/src/platform/plugins/shared/workflows_management/server/plugin.ts
@@ -7,46 +7,29 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 import type {
-  AnalyticsServiceStart,
   CoreSetup,
   CoreStart,
-  KibanaRequest,
   Logger,
   Plugin,
   PluginInitializerContext,
 } from '@kbn/core/server';
-import type { SecurityServiceStart } from '@kbn/core-security-server';
-import type { SpacesServiceStart } from '@kbn/spaces-plugin/server';
-import type { TriggerType } from '@kbn/workflows';
-import type { WorkflowExecutionEngineModel } from '@kbn/workflows/types/latest';
 import { registerWorkflowAgentBuilderIntegration } from './agent_builder';
 import { defineRoutes } from './api/routes';
 import { type SmlIndexAttachmentFn, WorkflowsManagementApi } from './api/workflows_management_api';
 import { WorkflowsService } from './api/workflows_management_service';
+import { createWorkflowsRouteHandlerContextProvider } from './api/workflows_route_handler_context_provider';
 import type { WorkflowsManagementConfig } from './config';
 import {
   getWorkflowsConnectorAdapter,
   getConnectorType as getWorkflowsConnectorType,
 } from './connectors/workflows';
-import { validateWorkflowForExecution } from './connectors/workflows/validate_workflow_for_execution';
-import {
-  resolveMatchingWorkflowSubscriptions,
-  type ResolveMatchingWorkflowSubscriptionsParams,
-} from './event_driven/resolve_workflow_subscriptions';
-import { createTriggerEventHandler } from './event_driven/trigger_event_handler';
 import { WorkflowsManagementFeatureConfig } from './features';
-import { WorkflowTaskScheduler } from './tasks/workflow_task_scheduler';
 import {
   triggerEventDispatchedSchema,
   WORKFLOWS_TRIGGER_EVENT_DISPATCHED,
 } from './telemetry/events';
 import { WorkflowsAiTelemetryClient } from './telemetry/workflows_ai_telemetry_client';
-import { WorkflowsManagementTelemetryClient } from './telemetry/workflows_management_telemetry_client';
-import {
-  initializeTriggerEventsClient,
-  initializeTriggerEventsDataStream,
-  type TriggerEventsDataStreamClient,
-} from './trigger_events_log';
+import { initializeTriggerEventsDataStream } from './trigger_events_log';
 import type {
   AgentBuilderPluginSetupContract,
   WorkflowsRequestHandlerContext,
@@ -68,19 +51,12 @@ export class WorkflowsPlugin
     >
 {
   private readonly logger: Logger;
-  private workflowsService: WorkflowsService | null = null;
-  private workflowTaskScheduler: WorkflowTaskScheduler | null = null;
-  private api: WorkflowsManagementApi | null = null;
-  private spaces?: SpacesServiceStart | null = null;
-  private securityStart?: SecurityServiceStart;
-  private triggerEventsClient: TriggerEventsDataStreamClient | null = null;
-  private analytics?: AnalyticsServiceStart;
   private aiTelemetryClient: WorkflowsAiTelemetryClient | null = null;
   private config: WorkflowsManagementConfig;
 
   constructor(initializerContext: PluginInitializerContext<WorkflowsManagementConfig>) {
     this.logger = initializerContext.logger.get();
-    this.config = initializerContext.config.get();
+    this.config = initializerContext.config.get<WorkflowsManagementConfig>();
   }
 
   public setup(
@@ -97,73 +73,24 @@ export class WorkflowsPlugin
       schema: triggerEventDispatchedSchema,
     });
 
-    initializeTriggerEventsDataStream(core.dataStreams);
+    // Register the workflows management feature and its privileges
+    plugins.features?.registerKibanaFeature(WorkflowsManagementFeatureConfig);
+
+    this.logger.debug('Workflows Management: Creating workflows service');
+
+    const workflowsService = new WorkflowsService(core.getStartServices, this.logger);
+
+    const api = new WorkflowsManagementApi(workflowsService, this.config.available);
+
+    const spaces = plugins.spaces?.spacesService;
+    if (!spaces) {
+      throw new Error('Spaces service not initialized');
+    }
 
     // Register workflows connector if actions plugin is available
     if (plugins.actions) {
-      // Create workflows service function for the connector
-      const getWorkflowsService = async (request: KibanaRequest) => {
-        // Return a function that will be called by the connector
-        return async (workflowId: string, spaceId: string, inputs: Record<string, unknown>) => {
-          if (!this.api) {
-            throw new Error('Workflows management API not initialized');
-          }
-
-          // Get the workflow and validate it is in a runnable state
-          const workflow = await this.api.getWorkflow(workflowId, spaceId);
-          validateWorkflowForExecution(workflow, workflowId);
-
-          const workflowToRun: WorkflowExecutionEngineModel = {
-            id: workflow.id,
-            name: workflow.name,
-            enabled: workflow.enabled,
-            definition: workflow.definition,
-            yaml: workflow.yaml,
-          };
-
-          // Run the workflow, @tb: maybe switch to scheduler?
-          return this.api.runWorkflow(workflowToRun, spaceId, inputs, request);
-        };
-      };
-
-      // Create workflows scheduling service function for per-alert execution
-      const getScheduleWorkflowService = async (request: KibanaRequest) => {
-        return async (
-          workflowId: string,
-          spaceId: string,
-          inputs: Record<string, unknown>,
-          triggeredBy: TriggerType
-        ) => {
-          if (!this.api) {
-            throw new Error('Workflows management API not initialized');
-          }
-
-          // Get the workflow and validate it is in a runnable state
-          const workflow = await this.api.getWorkflow(workflowId, spaceId);
-          validateWorkflowForExecution(workflow, workflowId);
-
-          const workflowToSchedule: WorkflowExecutionEngineModel = {
-            id: workflow.id,
-            name: workflow.name,
-            enabled: workflow.enabled,
-            definition: workflow.definition,
-            yaml: workflow.yaml,
-          };
-
-          return this.api.scheduleWorkflow(
-            workflowToSchedule,
-            spaceId,
-            inputs,
-            request,
-            triggeredBy
-          );
-        };
-      };
-
       // Register the workflows connector
-      plugins.actions.registerType(
-        getWorkflowsConnectorType({ getWorkflowsService, getScheduleWorkflowService })
-      );
+      plugins.actions.registerType(getWorkflowsConnectorType(api));
 
       // Register connector adapter for alerting if available
       if (plugins.alerting) {
@@ -171,63 +98,15 @@ export class WorkflowsPlugin
       }
     }
 
-    // Register the workflows management feature and its privileges
-    plugins.features?.registerKibanaFeature(WorkflowsManagementFeatureConfig);
+    initializeTriggerEventsDataStream(core.dataStreams);
 
-    this.logger.debug('Workflows Management: Creating workflows service');
+    core.http.registerRouteHandlerContext(
+      'workflows',
+      createWorkflowsRouteHandlerContextProvider(api, workflowsService, this.logger)
+    );
 
-    const getCoreStart = () => core.getStartServices().then(([coreStart]) => coreStart);
-    const getPluginsStart = () => core.getStartServices().then(([, pluginsStart]) => pluginsStart);
-    const getWorkflowExecutionEngine = () =>
-      getPluginsStart().then(({ workflowsExecutionEngine }) => workflowsExecutionEngine);
-
-    this.workflowsService = new WorkflowsService(this.logger, getCoreStart, getPluginsStart);
-
-    this.api = new WorkflowsManagementApi(this.workflowsService, getWorkflowExecutionEngine);
-    this.spaces = plugins.spaces?.spacesService;
-
-    if (!this.spaces) {
-      throw new Error('Spaces service not initialized');
-    }
-
-    if (!this.api) {
-      throw new Error('Workflows management API not initialized');
-    }
-    const api = this.api;
-    const resolveMatchingWorkflowSubscriptionsFn = (
-      params: ResolveMatchingWorkflowSubscriptionsParams
-    ) => resolveMatchingWorkflowSubscriptions(params, { api, logger: this.logger });
-    const telemetryClient = new WorkflowsManagementTelemetryClient({
-      logger: this.logger,
-      getAnalytics: () => this.analytics,
-    });
-
-    const triggerEventHandler = createTriggerEventHandler({
-      api: this.api,
-      logger: this.logger,
-      telemetryClient,
-      getTriggerEventsClient: () => this.triggerEventsClient,
-      getWorkflowExecutionEngine,
-      resolveMatchingWorkflowSubscriptions: resolveMatchingWorkflowSubscriptionsFn,
-    });
-
-    plugins.workflowsExtensions.registerTriggerEventHandler(triggerEventHandler);
-
-    this.logger.debug('Workflows Management: Creating router');
     const router = core.http.createRouter<WorkflowsRequestHandlerContext>();
-
-    if (this.config.available) {
-      // Register server side APIs only when the plugin is available (only set to false in serverless)
-      // TODO: improve this logic and define all the routes but respond with a 403 when the plugin is not available
-      defineRoutes(
-        router,
-        this.api,
-        this.logger,
-        this.spaces,
-        getWorkflowExecutionEngine,
-        () => this.securityStart
-      );
-    }
+    defineRoutes(router, api, this.logger, spaces, workflowsService);
 
     this.setupAiIntegration(core, api, this.aiTelemetryClient);
 
@@ -238,30 +117,10 @@ export class WorkflowsPlugin
 
   public start(core: CoreStart, plugins: WorkflowsServerPluginStartDeps) {
     this.logger.debug('Workflows Management: Start');
-    this.analytics = core.analytics;
-
-    this.securityStart = core.security;
-
-    void this.initializeTriggerEventsClient(core);
 
     stepSchemas.initialize(plugins.workflowsExtensions);
 
-    // Initialize workflow task scheduler with the start contract
-    this.workflowTaskScheduler = new WorkflowTaskScheduler(this.logger, plugins.taskManager);
-
-    // Set task scheduler and security service in workflows service
-    if (this.workflowsService) {
-      this.workflowsService.setTaskScheduler(this.workflowTaskScheduler);
-      if (plugins.security) {
-        this.workflowsService.setSecurityService(core.security);
-      }
-    }
-
-    const actionsTypes = plugins.actions.getAllTypes();
-    this.logger.debug(`Available action types: ${actionsTypes.join(', ')}`);
-
     this.logger.debug('Workflows Management: Started');
-
     return {};
   }
 
@@ -311,18 +170,6 @@ export class WorkflowsPlugin
           `Workflows Management: Failed to wire SML indexing with Agent Builder: ${message}`
         );
       });
-  }
-
-  private async initializeTriggerEventsClient(core: CoreStart): Promise<void> {
-    try {
-      this.triggerEventsClient = await initializeTriggerEventsClient(core.dataStreams);
-    } catch (error) {
-      this.logger.warn(
-        `Failed to initialize trigger events data stream client: ${
-          error instanceof Error ? error.message : String(error)
-        }. Event audit logging will be skipped.`
-      );
-    }
   }
 
   public stop() {}

--- a/src/platform/plugins/shared/workflows_management/server/telemetry/workflows_management_telemetry_client.ts
+++ b/src/platform/plugins/shared/workflows_management/server/telemetry/workflows_management_telemetry_client.ts
@@ -12,18 +12,25 @@ import {
   type TriggerEventDispatchedTelemetryEvent,
   WORKFLOWS_TRIGGER_EVENT_DISPATCHED,
 } from './events';
+import type { WorkflowsService } from '../api/workflows_management_service';
 
 interface WorkflowsManagementTelemetryClientDeps {
   logger: Logger;
-  getAnalytics?: () => AnalyticsServiceStart | undefined;
+  workflowsService: WorkflowsService;
 }
 
 export class WorkflowsManagementTelemetryClient {
-  constructor(private readonly deps: WorkflowsManagementTelemetryClientDeps) {}
+  private analytics: AnalyticsServiceStart | undefined;
+
+  constructor(private readonly deps: WorkflowsManagementTelemetryClientDeps) {
+    this.deps.workflowsService.getCoreStart().then(({ analytics }) => {
+      this.analytics = analytics;
+    });
+  }
 
   reportTriggerEventDispatched(event: TriggerEventDispatchedTelemetryEvent): void {
     try {
-      this.deps.getAnalytics?.()?.reportEvent(WORKFLOWS_TRIGGER_EVENT_DISPATCHED, event);
+      this.analytics?.reportEvent(WORKFLOWS_TRIGGER_EVENT_DISPATCHED, event);
     } catch (error) {
       this.deps.logger.warn(
         `Failed to report ${WORKFLOWS_TRIGGER_EVENT_DISPATCHED} telemetry: ${

--- a/src/platform/plugins/shared/workflows_management/server/types.ts
+++ b/src/platform/plugins/shared/workflows_management/server/types.ts
@@ -37,6 +37,7 @@ import type {
   WorkflowsExtensionsServerPluginSetup,
   WorkflowsExtensionsServerPluginStart,
 } from '@kbn/workflows-extensions/server';
+import type { EventEmitter } from '@kbn/workflows-extensions/server/types';
 import type { ZodObject } from '@kbn/zod/v4';
 import type { SmlTypeDefinition } from './agent_builder/sml_types/types';
 import type { WorkflowsManagementApi } from './api/workflows_management_api';
@@ -92,7 +93,20 @@ export interface WorkflowsServerPluginStartDeps {
   workflowsExtensions: WorkflowsExtensionsServerPluginStart;
 }
 
+export interface WorkflowsClient {
+  emitEvent: EventEmitter;
+}
+export interface WorkflowsApiRequestHandlerContext {
+  isWorkflowsAvailable: boolean;
+  getWorkflowsClient: () => WorkflowsClient;
+}
+
+export type WorkflowsRouteHandlerContext = CustomRequestHandlerContext<{
+  workflows: WorkflowsApiRequestHandlerContext;
+}>;
+
 export type WorkflowsRequestHandlerContext = CustomRequestHandlerContext<{
+  workflows: WorkflowsApiRequestHandlerContext;
   actions: ActionsApiRequestHandlerContext;
   alerting: AlertingApiRequestHandlerContext;
   licensing: LicensingApiRequestHandlerContext;


### PR DESCRIPTION
## Summary

Refactors the Workflows Management and Workflows Extensions plugins to introduce proper API availability checks and simplify the plugin architecture.

**Availability checks:**
- Renames `withLicenseCheck` to `withAvailabilityCheck`, which now composes a license check (stateful) with a serverless tier check via a new `workflows` route handler context.
- Routes are now **always registered** and return 403 at request time when workflows are unavailable, instead of conditionally skipping route registration when `config.available` is `false`.
- The `emitEvent` function in the workflows client (route context) now also checks availability: when workflows are not available, events are silently dropped with a warning log instead of executing.

**Plugin simplification:**
- `WorkflowsService` now self-initializes from `StartServicesAccessor`, eliminating the need for manual setter calls (`setTaskScheduler`, `setSecurityService`) during `start()`.
- The `workflows` route handler context is now registered by `workflows_management` (where availability is determined), not by `workflows_extensions`.
- Connector registration logic, trigger event handler creation, and telemetry wiring are moved out of the plugin class into self-contained helpers.
- Removes `registerTriggerEventHandler` from the extensions setup contract; the trigger event handler is now composed directly in the route handler context provider.
