### PR TITLE
Alerting v2: rule form GUI/YAML mode, hub entry cards, ES|QL builder UX

### DIFF
--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/components/edit_mode_toggle.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/components/edit_mode_toggle.test.tsx
@@ -17,18 +17,18 @@ describe('EditModeToggle', () => {
     jest.clearAllMocks();
   });
 
-  it('renders Form and YAML buttons', () => {
+  it('renders GUI and YAML buttons', () => {
     render(<EditModeToggle editMode="form" onChange={mockOnChange} />);
 
-    expect(screen.getByText('Form')).toBeInTheDocument();
+    expect(screen.getByText('GUI')).toBeInTheDocument();
     expect(screen.getByText('YAML')).toBeInTheDocument();
   });
 
-  it('shows Form as selected when editMode is form', () => {
+  it('shows GUI as selected when editMode is form', () => {
     render(<EditModeToggle editMode="form" onChange={mockOnChange} />);
 
-    const formButton = screen.getByText('Form').closest('button');
-    expect(formButton).toHaveClass('euiButtonGroupButton-isSelected');
+    const guiButton = screen.getByText('GUI').closest('button');
+    expect(guiButton).toHaveClass('euiButtonGroupButton-isSelected');
   });
 
   it('shows YAML as selected when editMode is yaml', () => {
@@ -46,10 +46,10 @@ describe('EditModeToggle', () => {
     expect(mockOnChange).toHaveBeenCalledWith('yaml');
   });
 
-  it('calls onChange with "form" when Form button is clicked', async () => {
+  it('calls onChange with "form" when GUI button is clicked', async () => {
     render(<EditModeToggle editMode="yaml" onChange={mockOnChange} />);
 
-    await userEvent.click(screen.getByText('Form'));
+    await userEvent.click(screen.getByText('GUI'));
 
     expect(mockOnChange).toHaveBeenCalledWith('form');
   });
@@ -57,7 +57,7 @@ describe('EditModeToggle', () => {
   it('disables buttons when disabled prop is true', () => {
     render(<EditModeToggle editMode="form" onChange={mockOnChange} disabled />);
 
-    const formButton = screen.getByText('Form').closest('button');
+    const formButton = screen.getByText('GUI').closest('button');
     const yamlButton = screen.getByText('YAML').closest('button');
 
     expect(formButton).toBeDisabled();

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/components/edit_mode_toggle.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/components/edit_mode_toggle.tsx
@@ -20,10 +20,9 @@ interface EditModeToggleProps {
 const toggleButtons = [
   {
     id: 'form',
-    label: i18n.translate('xpack.alertingV2.ruleForm.editMode.form', {
-      defaultMessage: 'Form',
+    label: i18n.translate('xpack.alertingV2.ruleForm.editMode.gui', {
+      defaultMessage: 'GUI',
     }),
-    iconType: 'productDashboard',
     'data-test-subj': 'ruleV2FormEditModeFormButton',
   },
   {
@@ -31,7 +30,6 @@ const toggleButtons = [
     label: i18n.translate('xpack.alertingV2.ruleForm.editMode.yaml', {
       defaultMessage: 'YAML',
     }),
-    iconType: 'code',
     'data-test-subj': 'ruleV2FormEditModeYamlButton',
   },
 ];
@@ -50,7 +48,6 @@ export const EditModeToggle = ({ editMode, onChange, disabled }: EditModeToggleP
       idSelected={editMode}
       onChange={handleChange}
       buttonSize="compressed"
-      isIconOnly
       isFullWidth={false}
       isDisabled={disabled}
       data-test-subj="ruleV2FormEditModeToggle"

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/components/request_code_block.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/components/request_code_block.test.tsx
@@ -20,7 +20,7 @@ describe('RequestCodeBlock', () => {
   };
 
   it('renders create request with POST method and correct path', () => {
-    render(<RequestCodeBlock activeTab="create" data-test-subj="codeBlock" />, {
+    render(<RequestCodeBlock activeTab="create" viewMode="request" data-test-subj="codeBlock" />, {
       wrapper: createFormWrapper(formValues),
     });
 
@@ -30,7 +30,12 @@ describe('RequestCodeBlock', () => {
 
   it('renders update request with PATCH method and rule ID in path', () => {
     render(
-      <RequestCodeBlock activeTab="update" ruleId="rule-abc-123" data-test-subj="codeBlock" />,
+      <RequestCodeBlock
+        activeTab="update"
+        viewMode="request"
+        ruleId="rule-abc-123"
+        data-test-subj="codeBlock"
+      />,
       { wrapper: createFormWrapper(formValues) }
     );
 
@@ -39,7 +44,7 @@ describe('RequestCodeBlock', () => {
   });
 
   it('renders pretty-printed JSON body for create', () => {
-    render(<RequestCodeBlock activeTab="create" data-test-subj="codeBlock" />, {
+    render(<RequestCodeBlock activeTab="create" viewMode="request" data-test-subj="codeBlock" />, {
       wrapper: createFormWrapper(formValues),
     });
 
@@ -52,7 +57,12 @@ describe('RequestCodeBlock', () => {
 
   it('renders update body without kind field', () => {
     render(
-      <RequestCodeBlock activeTab="update" ruleId="rule-abc-123" data-test-subj="codeBlock" />,
+      <RequestCodeBlock
+        activeTab="update"
+        viewMode="request"
+        ruleId="rule-abc-123"
+        data-test-subj="codeBlock"
+      />,
       { wrapper: createFormWrapper(formValues) }
     );
 
@@ -62,7 +72,7 @@ describe('RequestCodeBlock', () => {
   });
 
   it('renders copyable code block', () => {
-    render(<RequestCodeBlock activeTab="create" data-test-subj="codeBlock" />, {
+    render(<RequestCodeBlock activeTab="create" viewMode="request" data-test-subj="codeBlock" />, {
       wrapper: createFormWrapper(formValues),
     });
 
@@ -77,7 +87,7 @@ describe('RequestCodeBlock', () => {
         throw new Error('serialization error');
       });
 
-    render(<RequestCodeBlock activeTab="create" data-test-subj="codeBlock" />, {
+    render(<RequestCodeBlock activeTab="create" viewMode="request" data-test-subj="codeBlock" />, {
       wrapper: createFormWrapper(formValues),
     });
 
@@ -85,5 +95,15 @@ describe('RequestCodeBlock', () => {
     expect(content).toContain('Error serializing rule request');
 
     createMapperSpy.mockRestore();
+  });
+
+  it('renders YAML when viewMode is yaml', () => {
+    render(<RequestCodeBlock activeTab="create" viewMode="yaml" data-test-subj="codeBlock" />, {
+      wrapper: createFormWrapper(formValues),
+    });
+
+    const content = screen.getByTestId('codeBlock').textContent!;
+    expect(content).toContain('kind:');
+    expect(content).not.toContain('POST kbn:');
   });
 });

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/components/request_code_block.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/components/request_code_block.tsx
@@ -11,6 +11,7 @@ import { useFormContext } from 'react-hook-form';
 import { i18n } from '@kbn/i18n';
 import { ALERTING_V2_RULE_API_PATH } from '@kbn/alerting-v2-constants';
 import type { FormValues } from '../types';
+import { serializeFormToYaml } from '../utils/yaml_form_utils';
 import {
   mapFormValuesToCreateRequest,
   mapFormValuesToUpdateRequest,
@@ -18,10 +19,27 @@ import {
 
 export type ShowRequestActivePage = 'create' | 'update';
 
+export type ShowRequestViewMode = 'request' | 'yaml';
+
 const SHOW_REQUEST_ERROR = i18n.translate(
   'xpack.alertingV2.ruleForm.showRequest.errorSerializing',
   { defaultMessage: 'Error serializing rule request' }
 );
+
+const SHOW_YAML_ERROR = i18n.translate(
+  'xpack.alertingV2.ruleForm.showRequest.errorSerializingYaml',
+  {
+    defaultMessage: 'Error serializing rule YAML',
+  }
+);
+
+const stringifyYaml = (formValues: FormValues): string => {
+  try {
+    return serializeFormToYaml(formValues);
+  } catch {
+    return SHOW_YAML_ERROR;
+  }
+};
 
 const stringifyRequest = (formValues: FormValues, activeTab: ShowRequestActivePage): string => {
   try {
@@ -37,17 +55,28 @@ const stringifyRequest = (formValues: FormValues, activeTab: ShowRequestActivePa
 
 interface RequestCodeBlockProps {
   activeTab: ShowRequestActivePage;
+  viewMode: ShowRequestViewMode;
   ruleId?: string;
   'data-test-subj'?: string;
 }
 
 export const RequestCodeBlock = ({
   activeTab,
+  viewMode,
   ruleId,
   'data-test-subj': dataTestSubj,
 }: RequestCodeBlockProps) => {
   const { getValues } = useFormContext<FormValues>();
   const formValues = getValues();
+
+  if (viewMode === 'yaml') {
+    const yaml = stringifyYaml(formValues);
+    return (
+      <EuiCodeBlock language="yaml" isCopyable data-test-subj={dataTestSubj}>
+        {yaml}
+      </EuiCodeBlock>
+    );
+  }
 
   const formattedRequest = stringifyRequest(formValues, activeTab);
 

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/components/show_request_modal.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/components/show_request_modal.test.tsx
@@ -99,6 +99,43 @@ describe('ShowRequestModal', () => {
     expect(screen.getByTestId('showRequestModalCodeBlock')).toBeInTheDocument();
   });
 
+  it('renders request and YAML view toggle', () => {
+    render(<ShowRequestModal onClose={onClose} />, { wrapper: createFormWrapper() });
+
+    expect(screen.getByTestId('showRequestViewFormatToggle')).toBeInTheDocument();
+    expect(screen.getByTestId('showRequestViewRequestButton')).toBeInTheDocument();
+    expect(screen.getByTestId('showRequestViewYamlButton')).toBeInTheDocument();
+  });
+
+  it('switches to YAML title and subtitle when YAML is selected', async () => {
+    const user = userEvent.setup();
+
+    render(<ShowRequestModal onClose={onClose} />, { wrapper: createFormWrapper() });
+
+    await user.click(screen.getByTestId('showRequestViewYamlButton'));
+
+    expect(screen.getByTestId('showRequestModalTitle')).toHaveTextContent(
+      'Rule YAML configuration'
+    );
+    expect(screen.getByTestId('showRequestModalSubtitle')).toHaveTextContent(
+      'YAML representation of the current rule configuration.'
+    );
+  });
+
+  it('hides create/update tabs when YAML view is selected', async () => {
+    const user = userEvent.setup();
+
+    render(<ShowRequestModal ruleId="rule-123" onClose={onClose} />, {
+      wrapper: createFormWrapper(),
+    });
+
+    expect(screen.getByTestId('showRequestCreateTab')).toBeInTheDocument();
+
+    await user.click(screen.getByTestId('showRequestViewYamlButton'));
+
+    expect(screen.queryByTestId('showRequestCreateTab')).not.toBeInTheDocument();
+  });
+
   it('calls onClose when modal close button is clicked', () => {
     render(<ShowRequestModal onClose={onClose} />, { wrapper: createFormWrapper() });
 

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/components/show_request_modal.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/components/show_request_modal.tsx
@@ -7,6 +7,7 @@
 
 import React, { useState } from 'react';
 import {
+  EuiButtonGroup,
   EuiFlexGroup,
   EuiFlexItem,
   EuiModal,
@@ -19,7 +20,11 @@ import {
   EuiTextColor,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import { RequestCodeBlock, type ShowRequestActivePage } from './request_code_block';
+import {
+  RequestCodeBlock,
+  type ShowRequestActivePage,
+  type ShowRequestViewMode,
+} from './request_code_block';
 
 const TITLE_CREATE = i18n.translate('xpack.alertingV2.ruleForm.showRequest.titleCreate', {
   defaultMessage: 'Create alerting rule request',
@@ -45,6 +50,46 @@ const TAB_UPDATE = i18n.translate('xpack.alertingV2.ruleForm.showRequest.tabUpda
   defaultMessage: 'Update',
 });
 
+const TITLE_YAML = i18n.translate('xpack.alertingV2.ruleForm.showRequest.titleYaml', {
+  defaultMessage: 'Rule YAML configuration',
+});
+
+const SUBTITLE_YAML = i18n.translate('xpack.alertingV2.ruleForm.showRequest.subtitleYaml', {
+  defaultMessage: 'YAML representation of the current rule configuration.',
+});
+
+const VIEW_REQUEST = i18n.translate('xpack.alertingV2.ruleForm.showRequest.viewRequest', {
+  defaultMessage: 'Request',
+});
+
+const VIEW_YAML = i18n.translate('xpack.alertingV2.ruleForm.showRequest.viewYaml', {
+  defaultMessage: 'YAML',
+});
+
+const VIEW_FORMAT_LEGEND = i18n.translate(
+  'xpack.alertingV2.ruleForm.showRequest.viewFormatLegend',
+  {
+    defaultMessage: 'Show request or YAML',
+  }
+);
+
+const viewFormatButtons: Array<{
+  id: ShowRequestViewMode;
+  label: string;
+  'data-test-subj': string;
+}> = [
+  {
+    id: 'request',
+    label: VIEW_REQUEST,
+    'data-test-subj': 'showRequestViewRequestButton',
+  },
+  {
+    id: 'yaml',
+    label: VIEW_YAML,
+    'data-test-subj': 'showRequestViewYamlButton',
+  },
+];
+
 interface ShowRequestModalProps {
   ruleId?: string;
   onClose: () => void;
@@ -52,9 +97,16 @@ interface ShowRequestModalProps {
 
 export const ShowRequestModal = ({ ruleId, onClose }: ShowRequestModalProps) => {
   const [activeTab, setActiveTab] = useState<ShowRequestActivePage>(ruleId ? 'update' : 'create');
+  const [viewMode, setViewMode] = useState<ShowRequestViewMode>('request');
 
-  const title = activeTab === 'update' ? TITLE_UPDATE : TITLE_CREATE;
-  const subtitle = activeTab === 'update' ? SUBTITLE_UPDATE : SUBTITLE_CREATE;
+  const title =
+    viewMode === 'yaml' ? TITLE_YAML : activeTab === 'update' ? TITLE_UPDATE : TITLE_CREATE;
+  const subtitle =
+    viewMode === 'yaml'
+      ? SUBTITLE_YAML
+      : activeTab === 'update'
+      ? SUBTITLE_UPDATE
+      : SUBTITLE_CREATE;
 
   return (
     <EuiModal
@@ -76,7 +128,17 @@ export const ShowRequestModal = ({ ruleId, onClose }: ShowRequestModalProps) => 
               </p>
             </EuiText>
           </EuiFlexItem>
-          {ruleId && (
+          <EuiFlexItem grow={false} style={{ alignSelf: 'flex-start' }}>
+            <EuiButtonGroup
+              legend={VIEW_FORMAT_LEGEND}
+              options={viewFormatButtons}
+              idSelected={viewMode}
+              onChange={(id) => setViewMode(id as ShowRequestViewMode)}
+              buttonSize="compressed"
+              data-test-subj="showRequestViewFormatToggle"
+            />
+          </EuiFlexItem>
+          {ruleId && viewMode === 'request' && (
             <EuiTabs>
               <EuiTab
                 isSelected={activeTab === 'create'}
@@ -99,6 +161,7 @@ export const ShowRequestModal = ({ ruleId, onClose }: ShowRequestModalProps) => 
       <EuiModalBody>
         <RequestCodeBlock
           activeTab={activeTab}
+          viewMode={viewMode}
           ruleId={ruleId}
           data-test-subj="showRequestModalCodeBlock"
         />

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/components/submission_buttons.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/components/submission_buttons.tsx
@@ -53,7 +53,7 @@ export const SubmissionButtons = ({
   return (
     <>
       <EuiHorizontalRule />
-      <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
+      <EuiFlexGroup justifyContent="spaceBetween" alignItems="center" style={{ width: '100%' }}>
         {onCancel && (
           <EuiFlexItem grow={false}>
             <EuiButtonEmpty

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/contexts/index.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/contexts/index.ts
@@ -12,4 +12,5 @@ export {
   type RuleFormServices,
   type RuleFormMeta,
   type RuleFormLayout,
+  type RuleBuilderCatalogEntry,
 } from './rule_form_context';

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/contexts/rule_form_context.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/contexts/rule_form_context.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { PropsWithChildren } from 'react';
+import type { PropsWithChildren, ReactNode } from 'react';
 import React, { createContext, useContext, useMemo } from 'react';
 import type { ApplicationStart, HttpStart, NotificationsStart } from '@kbn/core/public';
 import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
@@ -26,6 +26,25 @@ export type RuleFormLayout = 'page' | 'flyout';
 export interface RuleFormMeta {
   /** Whether the form is rendered on a full page or inside a flyout. */
   layout: RuleFormLayout;
+  /**
+   * When true, the main evaluation UI is the ES|QL editor; when false, guided builder (or read-only
+   * query) mode. The Rule Summary preview shows the generated ES|QL code block only when this is false.
+   */
+  includeQueryEditor?: boolean;
+  /**
+   * Optional actions rendered in the Rule evaluation section header (e.g. ES|QL entry affordances).
+   */
+  ruleEvaluationHeaderActions?: ReactNode;
+  /**
+   * When set (e.g. `threshold_alert` from the create-rule URL), the form can show builder-specific
+   * evaluation controls instead of the default ES|QL editor.
+   */
+  ruleBuilderId?: string;
+  /**
+   * Short label for the current rule configuration mode (builder name or ES|QL), shown next to the
+   * Rule configuration section title.
+   */
+  ruleEvaluationModeLabel?: string;
 }
 
 interface RuleFormContextValue {

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/contexts/rule_form_context.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/contexts/rule_form_context.tsx
@@ -19,9 +19,21 @@ export interface RuleFormServices {
   notifications: NotificationsStart;
   application: ApplicationStart;
   lens: LensPublicStart;
+  /**
+   * When set, Rule Summary (Threshold guided builder) can link to Discover with the ES|QL query.
+   * Return undefined when Discover or ES|QL is unavailable.
+   */
+  getDiscoverHrefForEsql?: (esql: string) => string | undefined;
 }
 
 export type RuleFormLayout = 'page' | 'flyout';
+
+/** Entry for the guided-builder picker (title + description shown in the dropdown). */
+export interface RuleBuilderCatalogEntry {
+  id: string;
+  title: string;
+  description: string;
+}
 
 export interface RuleFormMeta {
   /** Whether the form is rendered on a full page or inside a flyout. */
@@ -42,9 +54,16 @@ export interface RuleFormMeta {
   ruleBuilderId?: string;
   /**
    * Short label for the current rule configuration mode (builder name or ES|QL), shown next to the
-   * Rule configuration section title.
+   * Rule configuration section title when {@link ruleBuilderCatalog} is not used.
    */
   ruleEvaluationModeLabel?: string;
+  /**
+   * When set with {@link onRuleBuilderIdChange}, guided mode shows a super select instead of a
+   * mode badge so users can switch rule builders.
+   */
+  ruleBuilderCatalog?: RuleBuilderCatalogEntry[];
+  /** Called when the user picks a different builder from the super select. */
+  onRuleBuilderIdChange?: (id: string) => void;
 }
 
 interface RuleFormContextValue {

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/dynamic_rule_form.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/dynamic_rule_form.tsx
@@ -28,10 +28,6 @@ export interface DynamicRuleFormProps {
   /** Callback invoked after a successful internal submission (useCreateRule). */
   onSuccess?: () => void;
   onCancel?: () => void;
-  /** Whether to include YAML editor toggle (default: false) */
-  includeYaml?: boolean;
-  /** Whether the form is in a loading/disabled state */
-  isDisabled?: boolean;
   /** Whether the form is currently submitting (controls button loading state) */
   isSubmitting?: boolean;
   /** Whether to show submit/cancel buttons (default: false) */
@@ -58,8 +54,6 @@ export const DynamicRuleForm = ({
   layout,
   onSubmit,
   onSuccess,
-  includeYaml = false,
-  isDisabled = false,
   isSubmitting = false,
   includeSubmission = false,
   onCancel,
@@ -97,8 +91,6 @@ export const DynamicRuleForm = ({
         onSubmit={onSubmit}
         onSuccess={onSuccess}
         includeQueryEditor={false}
-        includeYaml={includeYaml}
-        isDisabled={isDisabled}
         isSubmitting={isSubmitting}
         includeSubmission={includeSubmission}
         onCancel={onCancel}

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/field_groups/attachment_runbook_field_group.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/field_groups/attachment_runbook_field_group.test.tsx
@@ -22,21 +22,21 @@ const getRunbookModal = () => {
   return modal as HTMLElement;
 };
 
-const openAttachmentsSection = async () => {
+const openArtifactsSection = async () => {
   const isContentVisible =
     !!screen.queryByTestId('addRunbookButton') ||
     !!screen.queryByLabelText('Edit Runbook') ||
     !!screen.queryByLabelText('Delete Runbook');
 
   if (!isContentVisible) {
-    await userEvent.click(screen.getByRole('button', { name: 'Toggle Attachments' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Toggle Artifacts' }));
   }
 };
 
 const addRunbookText = async (text: string) => {
   const user = userEvent.setup();
 
-  await openAttachmentsSection();
+  await openArtifactsSection();
   await user.click(screen.getByTestId('addRunbookButton'));
 
   const modal = getRunbookModal();
@@ -46,10 +46,10 @@ const addRunbookText = async (text: string) => {
 };
 
 describe('AttachmentRunbookFieldGroup', () => {
-  it('renders attachments title and keeps section closed initially', () => {
+  it('renders artifacts title and keeps section closed initially', () => {
     render(<AttachmentRunbookFieldGroup />, { wrapper: createFormWrapper() });
 
-    expect(screen.getByText('Attachments')).toBeInTheDocument();
+    expect(screen.getByText('Artifacts')).toBeInTheDocument();
     expect(screen.queryByTestId('addRunbookButton')).not.toBeInTheDocument();
     expect(screen.queryByLabelText('Edit Runbook')).not.toBeInTheDocument();
     expect(screen.queryByLabelText('Delete Runbook')).not.toBeInTheDocument();
@@ -59,7 +59,7 @@ describe('AttachmentRunbookFieldGroup', () => {
     const user = userEvent.setup();
     render(<AttachmentRunbookFieldGroup />, { wrapper: createFormWrapper() });
 
-    await openAttachmentsSection();
+    await openArtifactsSection();
     await user.click(screen.getByTestId('addRunbookButton'));
     expect(screen.getByRole('heading', { name: 'Add Runbook' })).toBeInTheDocument();
 

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/field_groups/attachment_runbook_field_group.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/field_groups/attachment_runbook_field_group.tsx
@@ -71,8 +71,8 @@ export const AttachmentRunbookFieldGroup: React.FC = () => {
   return (
     <>
       <FieldGroup
-        title={i18n.translate('xpack.alertingV2.ruleForm.attachmentsGroupTitle', {
-          defaultMessage: 'Attachments',
+        title={i18n.translate('xpack.alertingV2.ruleForm.artifactsGroupTitle', {
+          defaultMessage: 'Artifacts',
         })}
         defaultOpen={false}
       >

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/field_groups/condition_field_group.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/field_groups/condition_field_group.tsx
@@ -7,13 +7,19 @@
 
 import React from 'react';
 import { i18n } from '@kbn/i18n';
-import { EuiSpacer, EuiFormRow, EuiCodeBlock } from '@elastic/eui';
+import { EuiBadge, EuiSpacer, EuiFormRow, EuiCodeBlock } from '@elastic/eui';
 import { useFormContext, useWatch } from 'react-hook-form';
 import type { FormValues } from '../types';
+import { useRuleFormMeta } from '../contexts';
 import { FieldGroup } from './field_group';
 import { EvaluationQueryField } from '../fields/evaluation_query_field';
 import { GroupFieldSelect } from '../fields/group_field_select';
 import { TimeFieldSelect } from '../fields/time_field_select';
+import { ThresholdDataSourceField } from '../fields/threshold_data_source_field';
+import { ThresholdStatsField } from '../fields/threshold_stats_field';
+import { ThresholdAlertConditionsField } from '../fields/threshold_alert_conditions_field';
+import { useSyncThresholdEvaluationQuery } from '../hooks/use_sync_threshold_evaluation_query';
+import { useEnsureThresholdBuilderDefaults } from '../hooks/use_ensure_threshold_builder_defaults';
 
 interface ConditionFieldGroupProps {
   /**
@@ -35,43 +41,81 @@ interface ConditionFieldGroupProps {
  */
 export const ConditionFieldGroup = ({ includeBase = false }: ConditionFieldGroupProps) => {
   const { control } = useFormContext<FormValues>();
+  const { ruleEvaluationHeaderActions, ruleBuilderId, ruleEvaluationModeLabel } = useRuleFormMeta();
 
   // Read the base query from form state (initialized via useFormDefaults)
   const baseQuery = useWatch({ control, name: 'evaluation.query.base' });
 
+  const isThresholdBuilderUi = ruleBuilderId === 'threshold_alert' && !includeBase;
+
+  useSyncThresholdEvaluationQuery(isThresholdBuilderUi);
+  useEnsureThresholdBuilderDefaults(isThresholdBuilderUi);
+
+  const titleRight =
+    ruleEvaluationHeaderActions && (includeBase || isThresholdBuilderUi)
+      ? ruleEvaluationHeaderActions
+      : undefined;
+
+  const titleBadge = ruleEvaluationModeLabel ? (
+    <EuiBadge color="hollow">{ruleEvaluationModeLabel}</EuiBadge>
+  ) : undefined;
+
+  const fieldGroupTitle = isThresholdBuilderUi
+    ? i18n.translate('xpack.alertingV2.ruleForm.thresholdRuleConditionSectionTitle', {
+        defaultMessage: 'Rule condition',
+      })
+    : i18n.translate('xpack.alertingV2.ruleForm.conditionSectionTitle', {
+        defaultMessage: 'Rule configuration',
+      });
+
   return (
     <FieldGroup
-      title={i18n.translate('xpack.alertingV2.ruleForm.condition', {
-        defaultMessage: 'Rule evaluation',
-      })}
+      title={fieldGroupTitle}
+      titleBadge={titleBadge}
+      sectionDomId="ruleEvaluationSection"
+      titleRight={titleRight}
     >
-      {includeBase ? (
+      {isThresholdBuilderUi ? (
+        <>
+          <ThresholdDataSourceField />
+          <EuiSpacer size="m" />
+          <GroupFieldSelect />
+          <TimeFieldSelect />
+          <EuiSpacer size="m" />
+          <ThresholdStatsField />
+          <EuiSpacer size="m" />
+          <ThresholdAlertConditionsField />
+        </>
+      ) : includeBase ? (
         // Editable base query
         <>
           <EvaluationQueryField />
           <EuiSpacer size="m" />
+          <GroupFieldSelect />
+          <TimeFieldSelect />
         </>
       ) : (
         // Read-only base query (only show if there's a query to display)
-        baseQuery && (
-          <>
-            <EuiFormRow
-              label={i18n.translate('xpack.alertingV2.ruleForm.baseQueryLabel', {
-                defaultMessage: 'Base query',
-              })}
-              fullWidth
-            >
-              <EuiCodeBlock language="esql" fontSize="m" paddingSize="m" isCopyable>
-                {baseQuery}
-              </EuiCodeBlock>
-            </EuiFormRow>
-            <EuiSpacer size="m" />
-          </>
-        )
+        <>
+          {baseQuery && (
+            <>
+              <EuiFormRow
+                label={i18n.translate('xpack.alertingV2.ruleForm.baseQueryLabel', {
+                  defaultMessage: 'Base query',
+                })}
+                fullWidth
+              >
+                <EuiCodeBlock language="esql" fontSize="m" paddingSize="m" isCopyable>
+                  {baseQuery}
+                </EuiCodeBlock>
+              </EuiFormRow>
+              <EuiSpacer size="m" />
+            </>
+          )}
+          <GroupFieldSelect />
+          <TimeFieldSelect />
+        </>
       )}
-
-      <GroupFieldSelect />
-      <TimeFieldSelect />
     </FieldGroup>
   );
 };

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/field_groups/condition_field_group.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/field_groups/condition_field_group.tsx
@@ -5,9 +5,24 @@
  * 2.0.
  */
 
-import React from 'react';
+import React, { useMemo } from 'react';
+import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
-import { EuiBadge, EuiSpacer, EuiFormRow, EuiCodeBlock } from '@elastic/eui';
+import {
+  EuiBadge,
+  EuiSpacer,
+  EuiFormRow,
+  EuiFormLabel,
+  EuiCodeBlock,
+  EuiSuperSelect,
+  EuiText,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiTextArea,
+  useEuiTheme,
+  useGeneratedHtmlId,
+  type EuiSuperSelectOption,
+} from '@elastic/eui';
 import { useFormContext, useWatch } from 'react-hook-form';
 import type { FormValues } from '../types';
 import { useRuleFormMeta } from '../contexts';
@@ -40,33 +55,152 @@ interface ConditionFieldGroupProps {
  * trigger condition (e.g. a trailing WHERE clause).
  */
 export const ConditionFieldGroup = ({ includeBase = false }: ConditionFieldGroupProps) => {
+  const { euiTheme } = useEuiTheme();
   const { control } = useFormContext<FormValues>();
-  const { ruleEvaluationHeaderActions, ruleBuilderId, ruleEvaluationModeLabel } = useRuleFormMeta();
+  const {
+    ruleEvaluationHeaderActions,
+    ruleBuilderId,
+    ruleEvaluationModeLabel,
+    ruleBuilderCatalog,
+    onRuleBuilderIdChange,
+  } = useRuleFormMeta();
 
   // Read the base query from form state (initialized via useFormDefaults)
   const baseQuery = useWatch({ control, name: 'evaluation.query.base' });
 
   const isThresholdBuilderUi = ruleBuilderId === 'threshold_alert' && !includeBase;
 
+  /** Guided builder selected, but not the Threshold Alert implementation yet — minimal fields only. */
+  const isNonThresholdGuidedBuilderUi =
+    !includeBase && Boolean(ruleBuilderId) && ruleBuilderId !== 'threshold_alert';
+
   useSyncThresholdEvaluationQuery(isThresholdBuilderUi);
   useEnsureThresholdBuilderDefaults(isThresholdBuilderUi);
 
-  const titleRight =
-    ruleEvaluationHeaderActions && (includeBase || isThresholdBuilderUi)
-      ? ruleEvaluationHeaderActions
+  const ruleBuilderCatalogControlId = useGeneratedHtmlId({
+    prefix: 'ruleFormRuleBuilderCatalog',
+  });
+
+  const builderCatalogOptions = useMemo((): Array<EuiSuperSelectOption<string>> => {
+    if (!ruleBuilderCatalog?.length) {
+      return [];
+    }
+    return ruleBuilderCatalog.map((entry) => ({
+      value: entry.id,
+      inputDisplay: entry.title,
+      dropdownDisplay: (
+        <EuiFlexGroup gutterSize="s" alignItems="flexStart" responsive={false}>
+          <EuiFlexItem grow={true}>
+            <EuiText size="s">
+              <strong>{entry.title}</strong>
+            </EuiText>
+            <EuiText size="xs" color="subdued">
+              {entry.description}
+            </EuiText>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      ),
+    }));
+  }, [ruleBuilderCatalog]);
+
+  const showBuilderCatalogSelect =
+    !includeBase &&
+    Boolean(ruleBuilderCatalog?.length && onRuleBuilderIdChange && builderCatalogOptions.length);
+
+  const builderCatalogValueOfSelected = useMemo(() => {
+    if (!builderCatalogOptions.length) {
+      return '';
+    }
+    if (ruleBuilderId && builderCatalogOptions.some((o) => o.value === ruleBuilderId)) {
+      return ruleBuilderId;
+    }
+    return builderCatalogOptions[0].value;
+  }, [builderCatalogOptions, ruleBuilderId]);
+
+  const ruleBuilderCatalogLabel = i18n.translate(
+    'xpack.alertingV2.ruleForm.ruleBuilderCatalog.label',
+    {
+      defaultMessage: 'Rule builder',
+    }
+  );
+
+  const titleBadge = showBuilderCatalogSelect
+    ? undefined
+    : ruleEvaluationModeLabel
+      ? (
+          <EuiBadge color="hollow">{ruleEvaluationModeLabel}</EuiBadge>
+        )
       : undefined;
 
-  const titleBadge = ruleEvaluationModeLabel ? (
-    <EuiBadge color="hollow">{ruleEvaluationModeLabel}</EuiBadge>
-  ) : undefined;
+  const titleRight =
+    showBuilderCatalogSelect || ruleEvaluationHeaderActions ? (
+      <EuiFlexGroup
+        gutterSize="m"
+        alignItems="center"
+        justifyContent="flexEnd"
+        responsive={false}
+      >
+        {showBuilderCatalogSelect ? (
+          <EuiFlexItem grow={false}>
+            <EuiFlexGroup
+              gutterSize="s"
+              alignItems="center"
+              responsive={false}
+              wrap={false}
+            >
+              <EuiFlexItem grow={false}>
+                <EuiFormLabel
+                  htmlFor={ruleBuilderCatalogControlId}
+                  style={{ whiteSpace: 'nowrap' }}
+                >
+                  {ruleBuilderCatalogLabel}
+                </EuiFormLabel>
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <div style={{ width: 220, minWidth: 220 }}>
+                  <EuiSuperSelect
+                    id={ruleBuilderCatalogControlId}
+                    options={builderCatalogOptions}
+                    valueOfSelected={builderCatalogValueOfSelected}
+                    onChange={(id) => onRuleBuilderIdChange?.(id)}
+                    compressed
+                    fullWidth
+                    hasDividers
+                    data-test-subj="ruleFormRuleBuilderCatalog"
+                  />
+                </div>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </EuiFlexItem>
+        ) : null}
+        {ruleEvaluationHeaderActions ? (
+          <EuiFlexItem grow={false}>{ruleEvaluationHeaderActions}</EuiFlexItem>
+        ) : null}
+      </EuiFlexGroup>
+    ) : undefined;
 
-  const fieldGroupTitle = isThresholdBuilderUi
-    ? i18n.translate('xpack.alertingV2.ruleForm.thresholdRuleConditionSectionTitle', {
-        defaultMessage: 'Rule condition',
-      })
-    : i18n.translate('xpack.alertingV2.ruleForm.conditionSectionTitle', {
-        defaultMessage: 'Rule configuration',
-      });
+  const fieldGroupTitle =
+    isThresholdBuilderUi || isNonThresholdGuidedBuilderUi
+      ? i18n.translate('xpack.alertingV2.ruleForm.thresholdRuleConditionSectionTitle', {
+          defaultMessage: 'Rule condition',
+        })
+      : i18n.translate('xpack.alertingV2.ruleForm.conditionSectionTitle', {
+          defaultMessage: 'Rule configuration',
+        });
+
+  const nonThresholdPrototypeNotice = i18n.translate(
+    'xpack.alertingV2.ruleForm.nonThresholdBuilder.prototypeNotice',
+    {
+      defaultMessage: 'This form is under construction. Prototype purpose only.',
+    }
+  );
+
+  const nonThresholdPrototypeNoticeAriaLabel = i18n.translate(
+    'xpack.alertingV2.ruleForm.nonThresholdBuilder.prototypeNoticeAriaLabel',
+    {
+      defaultMessage: 'Prototype notice',
+    }
+  );
 
   return (
     <FieldGroup
@@ -85,6 +219,25 @@ export const ConditionFieldGroup = ({ includeBase = false }: ConditionFieldGroup
           <ThresholdStatsField />
           <EuiSpacer size="m" />
           <ThresholdAlertConditionsField />
+        </>
+      ) : isNonThresholdGuidedBuilderUi ? (
+        <>
+          <EuiFormRow label={false} fullWidth>
+            <EuiTextArea
+              readOnly
+              value={nonThresholdPrototypeNotice}
+              fullWidth
+              rows={3}
+              aria-label={nonThresholdPrototypeNoticeAriaLabel}
+              data-test-subj="ruleFormNonThresholdBuilderPrototypeNotice"
+              css={css`
+                color: ${euiTheme.colors.dangerText};
+              `}
+            />
+          </EuiFormRow>
+          <EuiSpacer size="m" />
+          <GroupFieldSelect />
+          <TimeFieldSelect />
         </>
       ) : includeBase ? (
         // Editable base query

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/field_groups/field_group.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/field_groups/field_group.tsx
@@ -5,13 +5,15 @@
  * 2.0.
  */
 
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useState, type ReactNode } from 'react';
+import type { IconType } from '@elastic/eui';
 import {
   EuiAccordion,
   EuiButtonIcon,
   EuiFlexGroup,
   EuiFlexItem,
   EuiHorizontalRule,
+  EuiIcon,
   EuiTitle,
   EuiSplitPanel,
   useGeneratedHtmlId,
@@ -22,6 +24,14 @@ import { useRuleFormMeta } from '../contexts';
 
 interface BaseFieldGroupProps {
   title: string;
+  /** Optional content aligned to the right of the title row (page layout only). */
+  titleRight?: ReactNode;
+  /** Optional badge next to the title (e.g. builder / ES|QL mode). */
+  titleBadge?: ReactNode;
+  /** Sets `id` on the section root for in-page anchors. */
+  sectionDomId?: string;
+  /** Optional icon before the title (page and flyout layouts). */
+  titleLeadingIconType?: IconType;
   children: React.ReactNode;
 }
 
@@ -61,7 +71,7 @@ const isUncontrolledFieldGroup = (
 };
 
 export const FieldGroup = (props: FieldGroupProps) => {
-  const { title, children } = props;
+  const { title, titleRight, titleBadge, sectionDomId, titleLeadingIconType, children } = props;
   const { layout } = useRuleFormMeta();
   const id = useGeneratedHtmlId({ prefix: 'fieldGroup' });
   const isControlled = isControlledFieldGroup(props);
@@ -98,13 +108,35 @@ export const FieldGroup = (props: FieldGroupProps) => {
     return (
       <>
         <EuiAccordion
-          id={id}
+          id={sectionDomId ?? id}
           buttonContent={
-            <EuiTitle size="xxs">
-              <h3>
-                <strong>{title}</strong>
-              </h3>
-            </EuiTitle>
+            <EuiFlexGroup
+              gutterSize="s"
+              alignItems="center"
+              justifyContent="spaceBetween"
+              responsive={false}
+            >
+              <EuiFlexItem grow={false}>
+                <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false} wrap>
+                  {titleLeadingIconType ? (
+                    <EuiFlexItem grow={false}>
+                      <EuiIcon type={titleLeadingIconType} size="m" aria-hidden={true} />
+                    </EuiFlexItem>
+                  ) : null}
+                  <EuiTitle size="xxs">
+                    <h3>
+                      <strong>{title}</strong>
+                    </h3>
+                  </EuiTitle>
+                  {titleBadge ?? null}
+                </EuiFlexGroup>
+              </EuiFlexItem>
+              {titleRight ? (
+                <EuiFlexItem grow={false}>
+                  <div style={{ marginInlineEnd: 8 }}>{titleRight}</div>
+                </EuiFlexItem>
+              ) : null}
+            </EuiFlexGroup>
           }
           paddingSize="s"
           {...accordionProps}
@@ -118,32 +150,54 @@ export const FieldGroup = (props: FieldGroupProps) => {
   }
 
   return (
-    <EuiSplitPanel.Outer hasShadow={false} hasBorder={true}>
+    <EuiSplitPanel.Outer hasShadow={false} hasBorder={true} id={sectionDomId}>
       <EuiSplitPanel.Inner color="subdued" paddingSize="s">
-        <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
-          {isCollapsible ? (
+        <EuiFlexGroup
+          gutterSize="s"
+          alignItems="center"
+          responsive={true}
+          justifyContent="spaceBetween"
+        >
+          <EuiFlexItem grow={false}>
+            <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false} wrap>
+              {isCollapsible ? (
+                <EuiFlexItem grow={false}>
+                  <EuiButtonIcon
+                    iconType={isOpen ? 'arrowDown' : 'arrowRight'}
+                    onClick={onToggle}
+                    aria-label={i18n.translate(
+                      'xpack.alertingV2.ruleForm.fieldGroup.toggleButtonLabel',
+                      {
+                        defaultMessage: 'Toggle {title}',
+                        values: { title },
+                      }
+                    )}
+                    color="text"
+                  />
+                </EuiFlexItem>
+              ) : null}
+              <EuiFlexItem grow={false}>
+                <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false} wrap>
+                  {titleLeadingIconType ? (
+                    <EuiFlexItem grow={false}>
+                      <EuiIcon type={titleLeadingIconType} size="m" aria-hidden={true} />
+                    </EuiFlexItem>
+                  ) : null}
+                  <EuiTitle size="xxs">
+                    <h3>
+                      <strong>{title}</strong>
+                    </h3>
+                  </EuiTitle>
+                  {titleBadge ?? null}
+                </EuiFlexGroup>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </EuiFlexItem>
+          {titleRight ? (
             <EuiFlexItem grow={false}>
-              <EuiButtonIcon
-                iconType={isOpen ? 'arrowDown' : 'arrowRight'}
-                onClick={onToggle}
-                aria-label={i18n.translate(
-                  'xpack.alertingV2.ruleForm.fieldGroup.toggleButtonLabel',
-                  {
-                    defaultMessage: 'Toggle {title}',
-                    values: { title },
-                  }
-                )}
-                color="text"
-              />
+              <div style={{ flexShrink: 0 }}>{titleRight}</div>
             </EuiFlexItem>
           ) : null}
-          <EuiFlexItem grow={false}>
-            <EuiTitle size="xxs">
-              <h3>
-                <strong>{title}</strong>
-              </h3>
-            </EuiTitle>
-          </EuiFlexItem>
         </EuiFlexGroup>
       </EuiSplitPanel.Inner>
       {isOpen ? <EuiSplitPanel.Inner>{children}</EuiSplitPanel.Inner> : null}

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/field_groups/rule_details_field_group.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/field_groups/rule_details_field_group.test.tsx
@@ -7,12 +7,11 @@
 
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import { createFormWrapper } from '../../test_utils';
 import { RuleDetailsFieldGroup } from './rule_details_field_group';
 
 describe('RuleDetailsFieldGroup', () => {
-  it('renders without a field group wrapper', () => {
+  it('renders Rule details in a split panel field group', () => {
     const Wrapper = createFormWrapper();
 
     const { container } = render(
@@ -21,13 +20,11 @@ describe('RuleDetailsFieldGroup', () => {
       </Wrapper>
     );
 
-    // Should not render the FieldGroup panel
-    expect(container.querySelector('.euiSplitPanel')).not.toBeInTheDocument();
-    // Should not render a "Rule details" title
-    expect(screen.queryByText('Rule details')).not.toBeInTheDocument();
+    expect(container.querySelector('.euiSplitPanel')).toBeInTheDocument();
+    expect(screen.getByText('Rule details')).toBeInTheDocument();
   });
 
-  it('renders the tags field with optional label', () => {
+  it('renders name, description, and tags fields', () => {
     const Wrapper = createFormWrapper();
 
     render(
@@ -36,34 +33,9 @@ describe('RuleDetailsFieldGroup', () => {
       </Wrapper>
     );
 
-    expect(screen.getByText('Tags')).toBeInTheDocument();
-    expect(screen.getByText('optional')).toBeInTheDocument();
-  });
-
-  it('renders the add description button initially', () => {
-    const Wrapper = createFormWrapper();
-
-    render(
-      <Wrapper>
-        <RuleDetailsFieldGroup />
-      </Wrapper>
-    );
-
-    expect(screen.getByText('Add description')).toBeInTheDocument();
-  });
-
-  it('renders the description field when add description is clicked', async () => {
-    const Wrapper = createFormWrapper();
-
-    render(
-      <Wrapper>
-        <RuleDetailsFieldGroup />
-      </Wrapper>
-    );
-
-    await userEvent.click(screen.getByText('Add description'));
-
+    expect(screen.getByText('Rule name')).toBeInTheDocument();
     expect(screen.getByText('Description')).toBeInTheDocument();
+    expect(screen.getByText('Tags')).toBeInTheDocument();
   });
 
   it('does not render enabled or kind fields', () => {
@@ -78,7 +50,5 @@ describe('RuleDetailsFieldGroup', () => {
     expect(screen.queryByText('Enabled')).not.toBeInTheDocument();
     expect(screen.queryByRole('switch')).not.toBeInTheDocument();
     expect(screen.queryByText('Rule kind')).not.toBeInTheDocument();
-    expect(screen.queryByText('Alert')).not.toBeInTheDocument();
-    expect(screen.queryByText('Monitor')).not.toBeInTheDocument();
   });
 });

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/field_groups/rule_details_field_group.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/field_groups/rule_details_field_group.tsx
@@ -6,16 +6,22 @@
  */
 
 import React from 'react';
+import { i18n } from '@kbn/i18n';
 import { NameField } from '../fields/name_field';
 import { TagsField } from '../fields/tags_field';
 import { DescriptionField } from '../fields/description_field';
+import { FieldGroup } from './field_group';
 
 export const RuleDetailsFieldGroup = () => {
   return (
-    <>
+    <FieldGroup
+      title={i18n.translate('xpack.alertingV2.ruleForm.ruleDetailsSectionTitle', {
+        defaultMessage: 'Rule details',
+      })}
+    >
       <NameField />
-      <TagsField />
       <DescriptionField />
-    </>
+      <TagsField />
+    </FieldGroup>
   );
 };

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/description_field.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/description_field.test.tsx
@@ -12,30 +12,26 @@ import { DescriptionField } from './description_field';
 import { createFormWrapper, createMockServices } from '../../test_utils';
 
 describe('DescriptionField', () => {
-  it('renders "Add description" button when no description value exists', () => {
+  it('renders textarea with Description label', () => {
     render(<DescriptionField />, { wrapper: createFormWrapper() });
-
-    expect(screen.getByTestId('addDescriptionButton')).toBeInTheDocument();
-    expect(screen.getByText('Add description')).toBeInTheDocument();
-  });
-
-  it('does not render textarea initially when no description', () => {
-    render(<DescriptionField />, { wrapper: createFormWrapper() });
-
-    expect(screen.queryByTestId('ruleDescriptionInput')).not.toBeInTheDocument();
-  });
-
-  it('shows textarea when "Add description" button is clicked', async () => {
-    const user = userEvent.setup();
-    render(<DescriptionField />, { wrapper: createFormWrapper() });
-
-    await user.click(screen.getByTestId('addDescriptionButton'));
 
     expect(screen.getByTestId('ruleDescriptionInput')).toBeInTheDocument();
     expect(screen.getByText('Description')).toBeInTheDocument();
   });
 
-  it('displays textarea directly when initial description value exists', () => {
+  it('shows optional label append', () => {
+    render(<DescriptionField />, { wrapper: createFormWrapper() });
+
+    expect(screen.getAllByText('optional').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('displays placeholder text', () => {
+    render(<DescriptionField />, { wrapper: createFormWrapper() });
+
+    expect(screen.getByPlaceholderText('Add rule description')).toBeInTheDocument();
+  });
+
+  it('displays initial description value', () => {
     const Wrapper = createFormWrapper({
       metadata: {
         name: 'Test Rule',
@@ -46,54 +42,24 @@ describe('DescriptionField', () => {
 
     render(<DescriptionField />, { wrapper: Wrapper });
 
-    expect(screen.getByTestId('ruleDescriptionInput')).toBeInTheDocument();
     expect(screen.getByTestId('ruleDescriptionInput')).toHaveValue('Initial description');
-    expect(screen.queryByTestId('addDescriptionButton')).not.toBeInTheDocument();
-  });
-
-  it('displays placeholder text in textarea', async () => {
-    const user = userEvent.setup();
-    render(<DescriptionField />, { wrapper: createFormWrapper() });
-
-    await user.click(screen.getByTestId('addDescriptionButton'));
-
-    expect(
-      screen.getByPlaceholderText('Add an optional description for this rule...')
-    ).toBeInTheDocument();
   });
 
   it('updates value when user types in textarea', async () => {
     const user = userEvent.setup();
     render(<DescriptionField />, { wrapper: createFormWrapper() });
 
-    await user.click(screen.getByTestId('addDescriptionButton'));
     const textarea = screen.getByTestId('ruleDescriptionInput');
     await user.type(textarea, 'My new description');
 
     expect(textarea).toHaveValue('My new description');
   });
 
-  it('renders correctly in flyout layout', async () => {
-    const user = userEvent.setup();
+  it('renders correctly in flyout layout', () => {
     render(<DescriptionField />, {
       wrapper: createFormWrapper({}, createMockServices(), { layout: 'flyout' }),
     });
 
-    await user.click(screen.getByTestId('addDescriptionButton'));
-
-    expect(screen.getByTestId('ruleDescriptionInput')).toBeInTheDocument();
-  });
-
-  it('keeps textarea visible after clearing the value', async () => {
-    const user = userEvent.setup();
-    render(<DescriptionField />, { wrapper: createFormWrapper() });
-
-    await user.click(screen.getByTestId('addDescriptionButton'));
-    const textarea = screen.getByTestId('ruleDescriptionInput');
-    await user.type(textarea, 'test');
-    await user.clear(textarea);
-
-    // Textarea should still be visible even though value is cleared
     expect(screen.getByTestId('ruleDescriptionInput')).toBeInTheDocument();
   });
 });

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/description_field.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/description_field.tsx
@@ -5,9 +5,9 @@
  * 2.0.
  */
 
-import React, { useState, useCallback, useEffect } from 'react';
+import React from 'react';
 import { i18n } from '@kbn/i18n';
-import { EuiFormRow, EuiTextArea, EuiButtonEmpty, EuiSpacer } from '@elastic/eui';
+import { EuiFormRow, EuiTextArea } from '@elastic/eui';
 import { Controller, useFormContext } from 'react-hook-form';
 import type { FormValues } from '../types';
 import { useRuleFormMeta } from '../contexts';
@@ -15,43 +15,8 @@ import { useRuleFormMeta } from '../contexts';
 const DESCRIPTION_ROW_ID = 'ruleV2FormDescriptionField';
 
 export const DescriptionField = () => {
-  const { control, watch } = useFormContext<FormValues>();
+  const { control } = useFormContext<FormValues>();
   const { layout } = useRuleFormMeta();
-  const descriptionValue = watch('metadata.description');
-
-  // Show the input if there's already a description value
-  const [isInputVisible, setIsInputVisible] = useState(() => Boolean(descriptionValue));
-
-  // Update visibility if description value changes externally (e.g., form reset)
-  useEffect(() => {
-    if (descriptionValue && !isInputVisible) {
-      setIsInputVisible(true);
-    }
-  }, [descriptionValue, isInputVisible]);
-
-  const handleAddDescription = useCallback(() => {
-    setIsInputVisible(true);
-  }, []);
-
-  if (!isInputVisible) {
-    return (
-      <>
-        <EuiSpacer size="s" />
-        <EuiButtonEmpty
-          iconType="plusInCircle"
-          onClick={handleAddDescription}
-          size="xs"
-          data-test-subj="addDescriptionButton"
-          color="text"
-        >
-          {i18n.translate('xpack.alertingV2.ruleForm.addDescriptionButton', {
-            defaultMessage: 'Add description',
-          })}
-        </EuiButtonEmpty>
-        <EuiSpacer size="s" />
-      </>
-    );
-  }
 
   return (
     <Controller
@@ -63,19 +28,23 @@ export const DescriptionField = () => {
           label={i18n.translate('xpack.alertingV2.ruleForm.descriptionLabel', {
             defaultMessage: 'Description',
           })}
+          labelAppend={i18n.translate('xpack.alertingV2.ruleForm.descriptionOptional', {
+            defaultMessage: 'optional',
+          })}
           fullWidth
           isInvalid={!!error}
           error={error?.message}
         >
           <EuiTextArea
             {...field}
+            value={field.value ?? ''}
             inputRef={ref}
-            rows={2}
+            rows={4}
             fullWidth
             isInvalid={!!error}
             compressed={layout === 'flyout'}
             placeholder={i18n.translate('xpack.alertingV2.ruleForm.descriptionPlaceholder', {
-              defaultMessage: 'Add an optional description for this rule...',
+              defaultMessage: 'Add rule description',
             })}
             data-test-subj="ruleDescriptionInput"
           />

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/group_field_select.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/group_field_select.test.tsx
@@ -40,7 +40,7 @@ describe('GroupFieldSelect', () => {
       wrapper: createFormWrapper({ evaluation: { query: { base: defaultQuery } } }, mockServices),
     });
 
-    expect(screen.getByText('Group Fields')).toBeInTheDocument();
+    expect(screen.getByText('Group fields')).toBeInTheDocument();
   });
 
   it('displays columns as options', async () => {

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/group_field_select.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/group_field_select.tsx
@@ -57,7 +57,7 @@ export const GroupFieldSelect = () => {
           <EuiFormRow
             id={groupByRowId}
             label={i18n.translate('xpack.alertingV2.ruleForm.groupingKeyLabel', {
-              defaultMessage: 'Group Fields',
+              defaultMessage: 'Group fields',
             })}
             labelAppend={i18n.translate('xpack.alertingV2.ruleForm.groupingKeyOptional', {
               defaultMessage: 'optional',

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/kind_field.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/kind_field.test.tsx
@@ -18,10 +18,10 @@ describe('KindField', () => {
     expect(screen.getByText('Track active and recovered state over time')).toBeInTheDocument();
   });
 
-  it('renders the description text', () => {
+  it('renders an info tooltip for the kind field', () => {
     render(<KindField />, { wrapper: createFormWrapper() });
 
-    expect(screen.getByText(/Enables lifecycle management/)).toBeInTheDocument();
+    expect(screen.getByTestId('kindFieldTooltip')).toBeInTheDocument();
   });
 
   it('is checked when kind is alert (default)', () => {

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/kind_field.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/kind_field.tsx
@@ -6,12 +6,24 @@
  */
 
 import React from 'react';
-import { EuiCheckableCard, EuiText } from '@elastic/eui';
+import { EuiCheckableCard, EuiFlexGroup, EuiFlexItem, EuiIconTip } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { Controller, useFormContext } from 'react-hook-form';
 import type { FormValues } from '../types';
 
 const CARD_ID = 'ruleV2KindField';
+
+const KIND_FIELD_TOOLTIP = i18n.translate('xpack.alertingV2.ruleForm.kindField.tooltip', {
+  defaultMessage:
+    'Enables lifecycle management: the system will track state transitions across alert events for each series, manage episodes, and dispatch to notification policies. Without this, alert events are observation-only records.',
+});
+
+const KIND_FIELD_TOOLTIP_ARIA_LABEL = i18n.translate(
+  'xpack.alertingV2.ruleForm.kindField.tooltipAriaLabel',
+  {
+    defaultMessage: 'More information about tracking active and recovered state over time',
+  }
+);
 
 export const KindField = () => {
   const { control } = useFormContext<FormValues>();
@@ -28,23 +40,33 @@ export const KindField = () => {
             id={CARD_ID}
             checkableType="checkbox"
             label={
-              <strong>
-                {i18n.translate('xpack.alertingV2.ruleForm.kindField.checkboxLabel', {
-                  defaultMessage: 'Track active and recovered state over time',
-                })}
-              </strong>
+              <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
+                <EuiFlexItem grow={false}>
+                  <strong>
+                    {i18n.translate('xpack.alertingV2.ruleForm.kindField.checkboxLabel', {
+                      defaultMessage: 'Track active and recovered state over time',
+                    })}
+                  </strong>
+                </EuiFlexItem>
+                <EuiFlexItem grow={false}>
+                  <span
+                    onClick={(event) => event.stopPropagation()}
+                    onKeyDown={(event) => event.stopPropagation()}
+                  >
+                    <EuiIconTip
+                      type="info"
+                      content={KIND_FIELD_TOOLTIP}
+                      aria-label={KIND_FIELD_TOOLTIP_ARIA_LABEL}
+                      iconProps={{ 'data-test-subj': 'kindFieldTooltip' }}
+                    />
+                  </span>
+                </EuiFlexItem>
+              </EuiFlexGroup>
             }
             checked={isChecked}
             onChange={() => onChange(isChecked ? 'signal' : 'alert')}
             data-test-subj="kindField"
-          >
-            <EuiText size="s" color="subdued">
-              {i18n.translate('xpack.alertingV2.ruleForm.kindField.checkboxDescription', {
-                defaultMessage:
-                  'Enables lifecycle management: the system will track state transitions across alert events for each series, manage episodes, and dispatch to notification policies. Without this, alert events are observation-only records.',
-              })}
-            </EuiText>
-          </EuiCheckableCard>
+          />
         );
       }}
     />

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/name_field.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/name_field.test.tsx
@@ -21,10 +21,10 @@ import type { FormValues } from '../types';
 import { RuleFormProvider } from '../contexts';
 
 describe('NameField', () => {
-  it('renders with a Name label', () => {
+  it('renders with a Rule name label', () => {
     render(<NameField />, { wrapper: createFormWrapper() });
 
-    expect(screen.getByLabelText('Name')).toBeInTheDocument();
+    expect(screen.getByLabelText('Rule name')).toBeInTheDocument();
   });
 
   it('renders a text input with placeholder', () => {
@@ -32,7 +32,7 @@ describe('NameField', () => {
 
     const input = screen.getByTestId('ruleNameInput');
     expect(input).toBeInTheDocument();
-    expect(input).toHaveAttribute('placeholder', 'Untitled rule');
+    expect(input).toHaveAttribute('placeholder', 'Add a rule name');
   });
 
   it('displays initial value from form context', () => {

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/name_field.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/name_field.tsx
@@ -42,7 +42,7 @@ export const NameField = () => {
         <EuiFormRow
           id={NAME_ROW_ID}
           label={i18n.translate('xpack.alertingV2.ruleForm.nameLabel', {
-            defaultMessage: 'Name',
+            defaultMessage: 'Rule name',
           })}
           fullWidth
           isInvalid={!!error}
@@ -56,7 +56,7 @@ export const NameField = () => {
             isInvalid={!!error}
             compressed={layout === 'flyout'}
             placeholder={i18n.translate('xpack.alertingV2.ruleForm.namePlaceholder', {
-              defaultMessage: 'Untitled rule',
+              defaultMessage: 'Add a rule name',
             })}
             aria-label={i18n.translate('xpack.alertingV2.ruleForm.nameAriaLabel', {
               defaultMessage: 'Rule name',

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/query_results_grid.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/query_results_grid.test.tsx
@@ -36,6 +36,7 @@ const defaultProps: QueryResultsGridProps = {
   isLoading: false,
   isError: false,
   error: null,
+  lookback: '1m',
 };
 
 const renderGrid = (overrides: Partial<QueryResultsGridProps> = {}) =>
@@ -74,9 +75,15 @@ describe('QueryResultsGrid', () => {
     expect(screen.getByText('Showing 2 of 200 rows returned by the query.')).toBeInTheDocument();
   });
 
-  it('renders a loading spinner when isLoading is true', () => {
-    renderGrid({ isLoading: true, columns: [], rows: [], totalRowCount: 0 });
-    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+  it('renders when isLoading is true without a header refresh control', () => {
+    renderGrid({
+      isLoading: true,
+      columns: [],
+      rows: [],
+      totalRowCount: 0,
+    });
+    expect(screen.queryByTestId('ruleResultsPreviewRefreshButton')).not.toBeInTheDocument();
+    expect(screen.getByText('Test preview')).toBeInTheDocument();
   });
 
   it('renders the empty prompt when no query data is present', () => {

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/query_results_grid.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/query_results_grid.tsx
@@ -8,6 +8,7 @@
 import React, { useCallback, useMemo, useState } from 'react';
 import {
   EuiBadge,
+  EuiButtonEmpty,
   EuiCallOut,
   EuiDataGrid,
   type EuiDataGridCellValueElementProps,
@@ -15,7 +16,6 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiIcon,
-  EuiLoadingSpinner,
   EuiPanel,
   EuiSpacer,
   EuiText,
@@ -70,6 +70,8 @@ export interface QueryResultsGridProps {
   timeField?: string;
   /** The lookback duration string for the chart time range (e.g. '5m', '1h') */
   lookback?: string;
+  /** When set, shows an “Open in Discover” control opening this URL in a new tab */
+  openInDiscoverHref?: string;
 }
 
 /**
@@ -98,6 +100,7 @@ export const QueryResultsGrid = ({
   query,
   timeField,
   lookback,
+  openInDiscoverHref,
 }: QueryResultsGridProps) => {
   const [pagination, setPagination] = useState({ pageIndex: 0, pageSize: DEFAULT_PAGE_SIZE });
 
@@ -163,17 +166,24 @@ export const QueryResultsGrid = ({
 
   const hasQuery = hasValidQuery || columns.length > 0 || rows.length > 0 || isLoading || isError;
 
+  const openInDiscoverLabel = i18n.translate(
+    'xpack.alertingV2.ruleForm.queryResultsGrid.openInDiscover',
+    {
+      defaultMessage: 'Open in Discover',
+    }
+  );
+
   return (
     <EuiPanel hasShadow={false} hasBorder paddingSize="m">
-      <EuiFlexGroup justifyContent="spaceBetween" alignItems="center" responsive={false}>
-        <EuiFlexItem grow={false}>
-          <EuiTitle size="xs">
-            <h3>{title}</h3>
-          </EuiTitle>
-        </EuiFlexItem>
-        <EuiFlexItem grow={false}>
-          <EuiFlexGroup gutterSize="m" alignItems="center" responsive={false}>
-            {lookback && (
+      <EuiFlexGroup justifyContent="spaceBetween" alignItems="center" responsive={true} wrap>
+        <EuiFlexItem grow={true}>
+          <EuiFlexGroup gutterSize="s" alignItems="center" responsive={true} wrap>
+            <EuiFlexItem grow={false}>
+              <EuiTitle size="xs">
+                <h3>{title}</h3>
+              </EuiTitle>
+            </EuiFlexItem>
+            {lookback ? (
               <EuiFlexItem grow={false}>
                 <EuiText size="xs" color="subdued">
                   {i18n.translate('xpack.alertingV2.ruleForm.queryResultsGrid.timeRangeLabel', {
@@ -182,14 +192,24 @@ export const QueryResultsGrid = ({
                   })}
                 </EuiText>
               </EuiFlexItem>
-            )}
-            {isLoading && (
-              <EuiFlexItem grow={false}>
-                <EuiLoadingSpinner size="m" />
-              </EuiFlexItem>
-            )}
+            ) : null}
           </EuiFlexGroup>
         </EuiFlexItem>
+        {openInDiscoverHref ? (
+          <EuiFlexItem grow={false}>
+            <EuiButtonEmpty
+              data-test-subj="ruleResultsOpenInDiscoverButton"
+              size="xs"
+              color="text"
+              iconType="discoverApp"
+              href={openInDiscoverHref}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {openInDiscoverLabel}
+            </EuiButtonEmpty>
+          </EuiFlexItem>
+        ) : null}
       </EuiFlexGroup>
 
       {rows.length > 0 && query && timeField && lookback && (

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/recovery_results_preview.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/recovery_results_preview.test.tsx
@@ -53,6 +53,7 @@ const mockPreviewResult: PreviewResult = {
   hasValidQuery: true,
   query: 'FROM logs-* | STATS count() BY host.name | WHERE count < 5',
   timeField: '@timestamp',
+  refetch: jest.fn(),
   lookback: '1m',
 };
 

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/recovery_results_preview.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/recovery_results_preview.tsx
@@ -5,9 +5,10 @@
  * 2.0.
  */
 
-import React from 'react';
+import React, { useMemo } from 'react';
 import { i18n } from '@kbn/i18n';
 import { useRecoveryPreview } from '../hooks/use_recovery_preview';
+import { useRuleFormServices } from '../contexts';
 import { QueryResultsGrid } from './query_results_grid';
 
 /**
@@ -19,6 +20,7 @@ import { QueryResultsGrid } from './query_results_grid';
  * `QueryResultsGrid`.
  */
 export const RecoveryResultsPreview = () => {
+  const { getDiscoverHrefForEsql } = useRuleFormServices();
   const {
     columns,
     rows,
@@ -33,6 +35,14 @@ export const RecoveryResultsPreview = () => {
     timeField,
     lookback,
   } = useRecoveryPreview();
+
+  const openInDiscoverHref = useMemo(() => {
+    const trimmed = query?.trim();
+    if (!trimmed || !getDiscoverHrefForEsql) {
+      return undefined;
+    }
+    return getDiscoverHrefForEsql(trimmed);
+  }, [getDiscoverHrefForEsql, query]);
 
   return (
     <QueryResultsGrid
@@ -63,6 +73,7 @@ export const RecoveryResultsPreview = () => {
       query={query}
       timeField={timeField}
       lookback={lookback}
+      openInDiscoverHref={openInDiscoverHref}
     />
   );
 };

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/rule_preview_panel.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/rule_preview_panel.test.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
-import { createFormWrapper } from '../../test_utils';
+import { createFormWrapper, createMockServices } from '../../test_utils';
 import { RulePreviewPanel } from './rule_preview_panel';
 import * as useRulePreviewModule from '../hooks/use_rule_preview';
 import type { RulePreviewResult } from '../hooks/use_rule_preview';
@@ -39,6 +39,7 @@ const mockPreviewResult: RulePreviewResult = {
   query: 'FROM logs-*',
   timeField: '@timestamp',
   lookback: '1m',
+  refetch: jest.fn(),
 };
 
 const defaultFormValues = {
@@ -94,6 +95,43 @@ describe('RulePreviewPanel', () => {
       expect(screen.getByTestId('ruleSummaryBuilderEsqlCodeBlock')).toHaveTextContent(
         'FROM metrics-*'
       );
+    });
+
+    it('renders Open in Discover when getDiscoverHrefForEsql returns a URL', () => {
+      const discoverUrl = 'https://test/discover';
+      render(<RulePreviewPanel />, {
+        wrapper: createFormWrapper(
+          {
+            ...defaultFormValues,
+            evaluation: { query: { base: 'FROM logs-*\n| LIMIT 10' } },
+          },
+          {
+            ...createMockServices(),
+            getDiscoverHrefForEsql: () => discoverUrl,
+          },
+          { layout: 'page', ruleBuilderId: 'threshold_alert', includeQueryEditor: false }
+        ),
+      });
+
+      const link = screen.getByTestId('ruleSummaryOpenInDiscoverButton');
+      expect(link).toHaveAttribute('href', discoverUrl);
+      expect(link).toHaveAttribute('target', '_blank');
+      expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+    });
+
+    it('does not render Open in Discover when getDiscoverHrefForEsql is omitted', () => {
+      render(<RulePreviewPanel />, {
+        wrapper: createFormWrapper(
+          {
+            ...defaultFormValues,
+            evaluation: { query: { base: 'FROM logs-*' } },
+          },
+          createMockServices(),
+          { layout: 'page', ruleBuilderId: 'threshold_alert', includeQueryEditor: false }
+        ),
+      });
+
+      expect(screen.queryByTestId('ruleSummaryOpenInDiscoverButton')).not.toBeInTheDocument();
     });
 
     it('does not render recovery preview when recovery type is no_breach', () => {

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/rule_preview_panel.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/rule_preview_panel.test.tsx
@@ -21,7 +21,6 @@ jest.mock('./recovery_results_preview', () => ({
     <div data-test-subj="recoveryResultsPreview">Recovery Preview Mock</div>
   ),
 }));
-
 const mockUseRulePreview = jest.mocked(useRulePreviewModule.useRulePreview);
 
 const mockPreviewResult: RulePreviewResult = {
@@ -64,9 +63,37 @@ describe('RulePreviewPanel', () => {
         wrapper: createFormWrapper(defaultFormValues, undefined, { layout: 'page' }),
       });
 
+      expect(screen.getByTestId('ruleSummaryPreviewPanel')).toBeInTheDocument();
+      expect(
+        screen.getByText('Updates as you edit the Rule configuration section.')
+      ).toBeInTheDocument();
+      expect(screen.getByText('Rule Summary')).toBeInTheDocument();
+      expect(screen.getByTestId('ruleSummaryDetailsGrid')).toBeInTheDocument();
+      expect(screen.getByText('Data source')).toBeInTheDocument();
+      expect(screen.queryByTestId('ruleSummaryEsqlQueryShell')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('ruleSummaryBuilderEsqlCodeBlock')).not.toBeInTheDocument();
       expect(screen.getByText('Rule results preview')).toBeInTheDocument();
       expect(screen.getByTestId('ruleResultsPreviewGrid')).toBeInTheDocument();
       expect(screen.queryByTestId('rulePreviewTriggerButton')).not.toBeInTheDocument();
+    });
+
+    it('renders ES|QL code block summary for the Threshold Alert builder', () => {
+      render(<RulePreviewPanel />, {
+        wrapper: createFormWrapper(
+          {
+            ...defaultFormValues,
+            evaluation: { query: { base: 'FROM metrics-*\n| STATS COUNT(*) AS c' } },
+          },
+          undefined,
+          { layout: 'page', ruleBuilderId: 'threshold_alert', includeQueryEditor: false }
+        ),
+      });
+
+      expect(screen.getByTestId('ruleSummaryBuilderEsqlCodeBlock')).toBeInTheDocument();
+      expect(screen.getByText('ES|QL query')).toBeInTheDocument();
+      expect(screen.getByTestId('ruleSummaryBuilderEsqlCodeBlock')).toHaveTextContent(
+        'FROM metrics-*'
+      );
     });
 
     it('does not render recovery preview when recovery type is no_breach', () => {

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/rule_preview_panel.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/rule_preview_panel.tsx
@@ -33,14 +33,6 @@ export const RulePreviewPanel = () => {
       <>
         <RuleSummaryPreview />
         <EuiSpacer size="m" />
-        <EuiTitle size="xxs">
-          <h3>
-            {i18n.translate('xpack.alertingV2.ruleForm.ruleEvaluationPreviewRail.resultsHeading', {
-              defaultMessage: 'Results preview',
-            })}
-          </h3>
-        </EuiTitle>
-        <EuiSpacer size="s" />
         <RuleResultsPreview />
         {showRecoveryPreview && (
           <>

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/rule_preview_panel.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/rule_preview_panel.tsx
@@ -13,12 +13,12 @@ import type { FormValues } from '../types';
 import { useRuleFormMeta } from '../contexts';
 import { RuleResultsPreview } from './rule_results_preview';
 import { RecoveryResultsPreview } from './recovery_results_preview';
+import { RuleSummaryPreview } from './rule_summary_preview';
 
 /**
  * Layout-aware wrapper for the rule and recovery results previews.
  *
- * - **Page layout**: Renders both previews inline (for side-by-side placement).
- *   The recovery preview is only shown when the recovery policy type is `'query'`.
+ * - **Page layout**: Renders a Rule Summary prototype (ES|QL code or descriptive list), then rule (and optionally recovery) results.
  * - **Flyout layout**: Renders a trigger button that opens a nested flyout
  *   containing both previews.
  */
@@ -31,6 +31,16 @@ export const RulePreviewPanel = () => {
   if (layout === 'page') {
     return (
       <>
+        <RuleSummaryPreview />
+        <EuiSpacer size="m" />
+        <EuiTitle size="xxs">
+          <h3>
+            {i18n.translate('xpack.alertingV2.ruleForm.ruleEvaluationPreviewRail.resultsHeading', {
+              defaultMessage: 'Results preview',
+            })}
+          </h3>
+        </EuiTitle>
+        <EuiSpacer size="s" />
         <RuleResultsPreview />
         {showRecoveryPreview && (
           <>

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/rule_results_preview.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/rule_results_preview.test.tsx
@@ -48,6 +48,7 @@ const mockPreviewResult: RulePreviewResult = {
   query: 'FROM logs-*',
   timeField: '@timestamp',
   lookback: '1m',
+  refetch: jest.fn(),
 };
 
 describe('RuleResultsPreview', () => {

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/rule_results_preview.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/rule_results_preview.tsx
@@ -5,9 +5,10 @@
  * 2.0.
  */
 
-import React from 'react';
+import React, { useMemo } from 'react';
 import { i18n } from '@kbn/i18n';
 import { useRulePreview } from '../hooks/use_rule_preview';
+import { useRuleFormServices } from '../contexts';
 import { QueryResultsGrid } from './query_results_grid';
 
 /**
@@ -18,6 +19,7 @@ import { QueryResultsGrid } from './query_results_grid';
  * when results are available. Delegates rendering to `QueryResultsGrid`.
  */
 export const RuleResultsPreview = () => {
+  const { getDiscoverHrefForEsql } = useRuleFormServices();
   const {
     columns,
     rows,
@@ -32,6 +34,14 @@ export const RuleResultsPreview = () => {
     timeField,
     lookback,
   } = useRulePreview();
+
+  const openInDiscoverHref = useMemo(() => {
+    const trimmed = query?.trim();
+    if (!trimmed || !getDiscoverHrefForEsql) {
+      return undefined;
+    }
+    return getDiscoverHrefForEsql(trimmed);
+  }, [getDiscoverHrefForEsql, query]);
 
   return (
     <QueryResultsGrid
@@ -59,6 +69,7 @@ export const RuleResultsPreview = () => {
       query={query}
       timeField={timeField}
       lookback={lookback}
+      openInDiscoverHref={openInDiscoverHref}
     />
   );
 };

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/rule_summary_preview.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/rule_summary_preview.tsx
@@ -1,0 +1,281 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useMemo } from 'react';
+import { EuiCodeBlock, EuiDescriptionList, EuiPanel, EuiSpacer, EuiText, EuiTitle } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { useFormContext, useWatch } from 'react-hook-form';
+import type { FormValues } from '../types';
+import { useRuleFormMeta } from '../contexts';
+
+const EMPTY_VALUE = '—';
+
+const PLACEHOLDER_QUERY = 'FROM …\n| STATS …';
+
+const RULE_SUMMARY_SUBTITLE = i18n.translate(
+  'xpack.alertingV2.ruleForm.ruleEvaluationPreviewRail.subtitle',
+  {
+    defaultMessage: 'Updates as you edit the Rule configuration section.',
+  }
+);
+
+/** Best-effort: first `FROM …` target in the evaluation query (non-threshold summary). */
+const extractFromTarget = (query: string): string => {
+  const trimmed = query.trim();
+  if (!trimmed) {
+    return EMPTY_VALUE;
+  }
+  const lines = trimmed.split('\n');
+  for (const line of lines) {
+    const m = line.match(/^\s*FROM\s+(.+)$/i);
+    if (m?.[1]) {
+      return m[1].trim();
+    }
+  }
+  return EMPTY_VALUE;
+};
+
+const formatAlertDelayPreview = (
+  mode: FormValues['stateTransitionAlertDelayMode'],
+  stateTransition: FormValues['stateTransition']
+): string => {
+  const n = stateTransition?.pendingCount;
+  if (typeof n === 'number' && n > 0) {
+    return i18n.translate('xpack.alertingV2.ruleForm.ruleSummary.alertDelayAfterMatches', {
+      defaultMessage: 'After {count} matches',
+      values: { count: n },
+    });
+  }
+  if (mode === 'immediate') {
+    return i18n.translate('xpack.alertingV2.ruleForm.ruleSummary.alertDelayImmediate', {
+      defaultMessage: 'Immediate',
+    });
+  }
+  return String(mode);
+};
+
+const formatSchedulePreview = (every?: string, lookback?: string): string => {
+  if (!every?.trim()) {
+    return EMPTY_VALUE;
+  }
+  const everyTrim = every.trim();
+  if (!lookback?.trim()) {
+    return i18n.translate('xpack.alertingV2.ruleForm.ruleSummary.scheduleEveryOnly', {
+      defaultMessage: 'Every {every}',
+      values: { every: everyTrim },
+    });
+  }
+  return i18n.translate('xpack.alertingV2.ruleForm.ruleSummary.scheduleEveryWithLookback', {
+    defaultMessage: 'Every {every} (lookback {lookback})',
+    values: { every: everyTrim, lookback: lookback.trim() },
+  });
+};
+
+/**
+ * Rule Summary for the evaluation preview column.
+ *
+ * - **Guided builder** (`includeQueryEditor === false`): read-only {@link EuiCodeBlock} for the
+ *   generated ES|QL (from `evaluation.query.base`, updated by the form) plus a details list.
+ * - **ES|QL editor mode** (`includeQueryEditor !== false`): details list only.
+ */
+export const RuleSummaryPreview = () => {
+  const { includeQueryEditor, ruleBuilderId } = useRuleFormMeta();
+  const { control } = useFormContext<FormValues>();
+
+  /** `undefined` treated like ES|QL mode (same default as {@link RuleForm}). */
+  const isGuidedBuilderMode = includeQueryEditor === false;
+
+  const evaluationQuery = useWatch({ control, name: 'evaluation.query.base' });
+  const thresholdDataSource = useWatch({ control, name: 'thresholdDataSource' });
+  const timeField = useWatch({ control, name: 'timeField' });
+  const schedule = useWatch({ control, name: 'schedule' });
+  const groupingFields = useWatch({ control, name: 'grouping.fields' });
+  const recoveryPolicy = useWatch({ control, name: 'recoveryPolicy' });
+  const recoveryQueryBase = useWatch({ control, name: 'recoveryPolicy.query.base' });
+  const stateTransition = useWatch({ control, name: 'stateTransition' });
+  const stateTransitionAlertDelayMode = useWatch({
+    control,
+    name: 'stateTransitionAlertDelayMode',
+  });
+
+  const isThresholdBuilder = ruleBuilderId === 'threshold_alert';
+
+  const panelTitle = i18n.translate('xpack.alertingV2.ruleForm.ruleSummary.panelTitle', {
+    defaultMessage: 'Rule Summary',
+  });
+
+  const esqlSectionLabel = i18n.translate('xpack.alertingV2.ruleForm.ruleSummary.esqlQuerySubtitle', {
+    defaultMessage: 'ES|QL query',
+  });
+
+  const recoveryEsqlSectionLabel = i18n.translate(
+    'xpack.alertingV2.ruleForm.ruleSummary.esqlRecoveryQuerySubtitle',
+    {
+      defaultMessage: 'ES|QL recovery query',
+    }
+  );
+
+  const queryText = (evaluationQuery ?? '').trim() || PLACEHOLDER_QUERY;
+  const recoveryQueryText = (recoveryQueryBase ?? '').trim() || PLACEHOLDER_QUERY;
+
+  const listItems = useMemo(() => {
+    const base = evaluationQuery ?? '';
+    const dataSource = isThresholdBuilder
+      ? thresholdDataSource?.trim() || EMPTY_VALUE
+      : extractFromTarget(base);
+
+    const recoveryDescription =
+      recoveryPolicy?.type === 'query'
+        ? i18n.translate('xpack.alertingV2.ruleForm.ruleSummary.recoveryEsqlQuery', {
+            defaultMessage: 'ES|QL recovery query',
+          })
+        : i18n.translate('xpack.alertingV2.ruleForm.ruleSummary.recoveryNoBreach', {
+            defaultMessage: 'No breach',
+          });
+
+    return [
+      {
+        title: i18n.translate('xpack.alertingV2.ruleForm.ruleSummary.dataSource', {
+          defaultMessage: 'Data source',
+        }),
+        description: dataSource,
+      },
+      {
+        title: i18n.translate('xpack.alertingV2.ruleForm.ruleSummary.groupKey', {
+          defaultMessage: 'Group key',
+        }),
+        description: groupingFields && groupingFields.length > 0 ? groupingFields.join(', ') : EMPTY_VALUE,
+      },
+      {
+        title: i18n.translate('xpack.alertingV2.ruleForm.ruleSummary.timeField', {
+          defaultMessage: 'Time field',
+        }),
+        description: timeField?.trim() || EMPTY_VALUE,
+      },
+      {
+        title: i18n.translate('xpack.alertingV2.ruleForm.ruleSummary.schedule', {
+          defaultMessage: 'Schedule',
+        }),
+        description: formatSchedulePreview(schedule?.every, schedule?.lookback),
+      },
+      {
+        title: i18n.translate('xpack.alertingV2.ruleForm.ruleSummary.mode', {
+          defaultMessage: 'Mode',
+        }),
+        description: i18n.translate('xpack.alertingV2.ruleForm.ruleSummary.modeDetectOnly', {
+          defaultMessage: 'Detect only',
+        }),
+      },
+      {
+        title: i18n.translate('xpack.alertingV2.ruleForm.ruleSummary.recovery', {
+          defaultMessage: 'Recovery',
+        }),
+        description: recoveryDescription,
+      },
+      {
+        title: i18n.translate('xpack.alertingV2.ruleForm.ruleSummary.alertDelay', {
+          defaultMessage: 'Alert delay',
+        }),
+        description: formatAlertDelayPreview(stateTransitionAlertDelayMode, stateTransition),
+      },
+      {
+        title: i18n.translate('xpack.alertingV2.ruleForm.ruleSummary.noDataConfig', {
+          defaultMessage: 'No data config',
+        }),
+        description: EMPTY_VALUE,
+      },
+    ];
+  }, [
+    evaluationQuery,
+    groupingFields,
+    isThresholdBuilder,
+    recoveryPolicy?.type,
+    schedule?.every,
+    schedule?.lookback,
+    stateTransition,
+    stateTransitionAlertDelayMode,
+    thresholdDataSource,
+    timeField,
+  ]);
+
+  const showRecoveryQueryBlock =
+    isGuidedBuilderMode && recoveryPolicy?.type === 'query';
+
+  return (
+    <EuiPanel hasBorder hasShadow={false} paddingSize="m" data-test-subj="ruleSummaryPreviewPanel">
+      <EuiTitle size="xs">
+        <h3>{panelTitle}</h3>
+      </EuiTitle>
+      <EuiText size="xs" color="subdued">
+        <p>{RULE_SUMMARY_SUBTITLE}</p>
+      </EuiText>
+      <EuiSpacer size="m" />
+
+      {isGuidedBuilderMode ? (
+        <>
+          <EuiText size="s">
+            <p>
+              <strong>{esqlSectionLabel}</strong>
+            </p>
+          </EuiText>
+          <EuiSpacer size="s" />
+          <EuiPanel
+            color="subdued"
+            paddingSize="s"
+            hasShadow={false}
+            hasBorder={false}
+            data-test-subj="ruleSummaryEsqlQueryShell"
+          >
+            <div data-test-subj="ruleSummaryBuilderEsqlCodeBlock">
+              <EuiCodeBlock language="esql" fontSize="s" paddingSize="m" isCopyable>
+                {queryText}
+              </EuiCodeBlock>
+            </div>
+          </EuiPanel>
+          <EuiSpacer size="m" />
+        </>
+      ) : (
+        <EuiSpacer size="xs" />
+      )}
+
+      <EuiPanel paddingSize="none" hasShadow={false} hasBorder={false}>
+        <EuiDescriptionList
+          type="responsiveColumn"
+          columnWidths={[1, 2]}
+          compressed
+          listItems={listItems}
+          data-test-subj="ruleSummaryDetailsGrid"
+        />
+      </EuiPanel>
+
+      {showRecoveryQueryBlock ? (
+        <>
+          <EuiSpacer size="m" />
+          <EuiText size="s">
+            <p>
+              <strong>{recoveryEsqlSectionLabel}</strong>
+            </p>
+          </EuiText>
+          <EuiSpacer size="s" />
+          <EuiPanel
+            color="subdued"
+            paddingSize="s"
+            hasShadow={false}
+            hasBorder={false}
+            data-test-subj="ruleSummaryRecoveryEsqlShell"
+          >
+            <div data-test-subj="ruleSummaryRecoveryEsqlCodeBlock">
+              <EuiCodeBlock language="esql" fontSize="s" paddingSize="m" isCopyable>
+                {recoveryQueryText}
+              </EuiCodeBlock>
+            </div>
+          </EuiPanel>
+        </>
+      ) : null}
+    </EuiPanel>
+  );
+};

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/rule_summary_preview.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/rule_summary_preview.tsx
@@ -6,11 +6,21 @@
  */
 
 import React, { useMemo } from 'react';
-import { EuiCodeBlock, EuiDescriptionList, EuiPanel, EuiSpacer, EuiText, EuiTitle } from '@elastic/eui';
+import {
+  EuiButtonEmpty,
+  EuiCodeBlock,
+  EuiDescriptionList,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiPanel,
+  EuiSpacer,
+  EuiText,
+  EuiTitle,
+} from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { useFormContext, useWatch } from 'react-hook-form';
 import type { FormValues } from '../types';
-import { useRuleFormMeta } from '../contexts';
+import { useRuleFormMeta, useRuleFormServices } from '../contexts';
 
 const EMPTY_VALUE = '—';
 
@@ -84,6 +94,7 @@ const formatSchedulePreview = (every?: string, lookback?: string): string => {
  */
 export const RuleSummaryPreview = () => {
   const { includeQueryEditor, ruleBuilderId } = useRuleFormMeta();
+  const { getDiscoverHrefForEsql } = useRuleFormServices();
   const { control } = useFormContext<FormValues>();
 
   /** `undefined` treated like ES|QL mode (same default as {@link RuleForm}). */
@@ -112,6 +123,10 @@ export const RuleSummaryPreview = () => {
     defaultMessage: 'ES|QL query',
   });
 
+  const openInDiscoverLabel = i18n.translate('xpack.alertingV2.ruleForm.ruleSummary.openInDiscover', {
+    defaultMessage: 'Open in Discover',
+  });
+
   const recoveryEsqlSectionLabel = i18n.translate(
     'xpack.alertingV2.ruleForm.ruleSummary.esqlRecoveryQuerySubtitle',
     {
@@ -119,8 +134,17 @@ export const RuleSummaryPreview = () => {
     }
   );
 
-  const queryText = (evaluationQuery ?? '').trim() || PLACEHOLDER_QUERY;
+  const rawEvaluationQuery = (evaluationQuery ?? '').trim();
+  const queryText = rawEvaluationQuery || PLACEHOLDER_QUERY;
   const recoveryQueryText = (recoveryQueryBase ?? '').trim() || PLACEHOLDER_QUERY;
+
+  const discoverHrefForEvaluation =
+    isThresholdBuilder &&
+    isGuidedBuilderMode &&
+    rawEvaluationQuery &&
+    getDiscoverHrefForEsql
+      ? getDiscoverHrefForEsql(rawEvaluationQuery)
+      : undefined;
 
   const listItems = useMemo(() => {
     const base = evaluationQuery ?? '';
@@ -217,11 +241,35 @@ export const RuleSummaryPreview = () => {
 
       {isGuidedBuilderMode ? (
         <>
-          <EuiText size="s">
-            <p>
-              <strong>{esqlSectionLabel}</strong>
-            </p>
-          </EuiText>
+          <EuiFlexGroup
+            alignItems="center"
+            justifyContent="spaceBetween"
+            responsive={true}
+            wrap={true}
+          >
+            <EuiFlexItem grow={false}>
+              <EuiText size="s">
+                <p>
+                  <strong>{esqlSectionLabel}</strong>
+                </p>
+              </EuiText>
+            </EuiFlexItem>
+            {discoverHrefForEvaluation ? (
+              <EuiFlexItem grow={false}>
+                <EuiButtonEmpty
+                  data-test-subj="ruleSummaryOpenInDiscoverButton"
+                  size="xs"
+                  color="text"
+                  iconType="discoverApp"
+                  href={discoverHrefForEvaluation}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {openInDiscoverLabel}
+                </EuiButtonEmpty>
+              </EuiFlexItem>
+            ) : null}
+          </EuiFlexGroup>
           <EuiSpacer size="s" />
           <EuiPanel
             color="subdued"

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/threshold_alert_conditions_field.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/threshold_alert_conditions_field.tsx
@@ -1,0 +1,250 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { Fragment, useMemo } from 'react';
+import {
+  EuiButtonEmpty,
+  EuiButtonIcon,
+  EuiFieldText,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFormRow,
+  EuiHorizontalRule,
+  EuiSelect,
+  EuiSpacer,
+  EuiTitle,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { useFieldArray, useFormContext, useWatch } from 'react-hook-form';
+import type { FormValues, ThresholdConditionOperator } from '../types';
+import { useRuleFormMeta } from '../contexts';
+import { isCompleteThresholdStatRow } from '../utils/build_threshold_evaluation_query';
+
+const OPERATOR_OPTIONS: Array<{ value: ThresholdConditionOperator; text: string }> = [
+  {
+    value: 'gt',
+    text: i18n.translate('xpack.alertingV2.ruleForm.thresholdAlertConditions.op.gt', {
+      defaultMessage: 'is above',
+    }),
+  },
+  {
+    value: 'lt',
+    text: i18n.translate('xpack.alertingV2.ruleForm.thresholdAlertConditions.op.lt', {
+      defaultMessage: 'is below',
+    }),
+  },
+  {
+    value: 'gte',
+    text: i18n.translate('xpack.alertingV2.ruleForm.thresholdAlertConditions.op.gte', {
+      defaultMessage: 'is at or above',
+    }),
+  },
+  {
+    value: 'lte',
+    text: i18n.translate('xpack.alertingV2.ruleForm.thresholdAlertConditions.op.lte', {
+      defaultMessage: 'is at or below',
+    }),
+  },
+  {
+    value: 'eq',
+    text: i18n.translate('xpack.alertingV2.ruleForm.thresholdAlertConditions.op.eq', {
+      defaultMessage: 'equals',
+    }),
+  },
+  {
+    value: 'neq',
+    text: i18n.translate('xpack.alertingV2.ruleForm.thresholdAlertConditions.op.neq', {
+      defaultMessage: 'does not equal',
+    }),
+  },
+];
+
+const VALUE_PLACEHOLDER = i18n.translate(
+  'xpack.alertingV2.ruleForm.thresholdAlertConditions.valuePlaceholder',
+  {
+    defaultMessage: 'Type text',
+  }
+);
+
+export const ThresholdAlertConditionsField = () => {
+  const { layout } = useRuleFormMeta();
+  const { control, register } = useFormContext<FormValues>();
+  const thresholdStats = useWatch({ control, name: 'thresholdStats' });
+
+  const { fields, append, remove } = useFieldArray({
+    control,
+    name: 'thresholdConditions',
+  });
+
+  const compressed = layout === 'flyout';
+
+  const statOptions = useMemo(() => {
+    const rows = thresholdStats ?? [];
+    const seen = new Set<string>();
+    const out: Array<{ value: string; text: string }> = [];
+    for (const r of rows) {
+      if (!r || !isCompleteThresholdStatRow(r)) {
+        continue;
+      }
+      const label = r.label.trim();
+      if (!label.length || seen.has(label)) {
+        continue;
+      }
+      seen.add(label);
+      out.push({ value: label, text: label });
+    }
+    return out;
+  }, [thresholdStats]);
+
+  const statSelectOptions = useMemo(() => {
+    const empty = {
+      value: '',
+      text: i18n.translate('xpack.alertingV2.ruleForm.thresholdAlertConditions.statPlaceholder', {
+        defaultMessage: 'Select a stat',
+      }),
+    };
+    return [empty, ...statOptions];
+  }, [statOptions]);
+
+  const addLabel = i18n.translate(
+    'xpack.alertingV2.ruleForm.thresholdAlertConditions.addAnotherCondition',
+    {
+      defaultMessage: 'Add another condition',
+    }
+  );
+
+  const sectionTitle = i18n.translate(
+    'xpack.alertingV2.ruleForm.thresholdAlertConditions.triggerSectionTitle',
+    {
+      defaultMessage: 'Trigger condition',
+    }
+  );
+
+  return (
+    <>
+      <EuiTitle size="xs">
+        <h3>{sectionTitle}</h3>
+      </EuiTitle>
+      <EuiSpacer size="m" />
+
+      {fields.map((field, index) => (
+        <Fragment key={field.id}>
+          {index > 0 ? <EuiHorizontalRule margin="m" /> : null}
+          <div
+            style={{
+              position: 'relative',
+              ...(fields.length > 1 ? { paddingInlineEnd: 36 } : {}),
+            }}
+          >
+            {fields.length > 1 ? (
+              <EuiButtonIcon
+                aria-label={i18n.translate(
+                  'xpack.alertingV2.ruleForm.thresholdAlertConditions.removeCondition',
+                  {
+                    defaultMessage: 'Remove condition',
+                  }
+                )}
+                iconType="cross"
+                size="s"
+                color="danger"
+                display="empty"
+                style={{ position: 'absolute', insetInlineEnd: 0, top: 0 }}
+                onClick={() => remove(index)}
+              />
+            ) : null}
+            <EuiFlexGroup gutterSize="s" alignItems="flexStart" responsive={true}>
+              <EuiFlexItem grow={2}>
+                <EuiFormRow
+                  label={
+                    index === 0
+                      ? i18n.translate(
+                          'xpack.alertingV2.ruleForm.thresholdAlertConditions.labelColumn',
+                          {
+                            defaultMessage: 'label',
+                          }
+                        )
+                      : undefined
+                  }
+                  fullWidth
+                >
+                  <EuiSelect
+                    fullWidth
+                    compressed={compressed}
+                    options={statSelectOptions}
+                    {...register(`thresholdConditions.${index}.statLabel` as const)}
+                    disabled={statOptions.length === 0}
+                  />
+                </EuiFormRow>
+              </EuiFlexItem>
+              <EuiFlexItem grow={2}>
+                <EuiFormRow
+                  label={
+                    index === 0
+                      ? i18n.translate(
+                          'xpack.alertingV2.ruleForm.thresholdAlertConditions.operatorColumn',
+                          {
+                            defaultMessage: 'operator',
+                          }
+                        )
+                      : undefined
+                  }
+                  fullWidth
+                >
+                  <EuiSelect
+                    fullWidth
+                    compressed={compressed}
+                    options={OPERATOR_OPTIONS}
+                    {...register(`thresholdConditions.${index}.operator` as const)}
+                  />
+                </EuiFormRow>
+              </EuiFlexItem>
+              <EuiFlexItem grow={3}>
+                <EuiFormRow
+                  label={
+                    index === 0
+                      ? i18n.translate(
+                          'xpack.alertingV2.ruleForm.thresholdAlertConditions.valueColumn',
+                          {
+                            defaultMessage: 'value',
+                          }
+                        )
+                      : undefined
+                  }
+                  fullWidth
+                >
+                  <EuiFieldText
+                    fullWidth
+                    compressed={compressed}
+                    placeholder={VALUE_PLACEHOLDER}
+                    {...register(`thresholdConditions.${index}.value` as const)}
+                  />
+                </EuiFormRow>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </div>
+        </Fragment>
+      ))}
+
+      <EuiSpacer size="s" />
+      <EuiButtonEmpty
+        color="text"
+        iconType="plusInCircle"
+        size="s"
+        data-test-subj="thresholdAlertConditionsAdd"
+        onClick={() =>
+          append({
+            statLabel: '',
+            operator: 'gt',
+            value: '',
+          })
+        }
+      >
+        {addLabel}
+      </EuiButtonEmpty>
+    </>
+  );
+};

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/threshold_data_source_field.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/threshold_data_source_field.tsx
@@ -1,0 +1,123 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useCallback, useEffect, useState } from 'react';
+import { Controller, useFormContext } from 'react-hook-form';
+import { EuiFormRow, EuiSuperSelect, type EuiSuperSelectOption } from '@elastic/eui';
+import type { DataViewListItem } from '@kbn/data-views-plugin/common';
+import { i18n } from '@kbn/i18n';
+import type { FormValues } from '../types';
+import { useRuleFormMeta, useRuleFormServices } from '../contexts';
+import {
+  DEFAULT_THRESHOLD_DATA_SOURCE,
+  THRESHOLD_DATA_SOURCE_CHOICES,
+} from '../threshold_builder_constants';
+
+const toSelectOptions = (titles: string[]): Array<EuiSuperSelectOption<string>> =>
+  titles.map((title) => ({ value: title, inputDisplay: title }));
+
+export const ThresholdDataSourceField = () => {
+  const { dataViews } = useRuleFormServices();
+  const { layout } = useRuleFormMeta();
+  const { control } = useFormContext<FormValues>();
+  const compressed = layout === 'flyout';
+
+  const [dataViewList, setDataViewList] = useState<DataViewListItem[]>([]);
+  const [listError, setListError] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const list = await dataViews.getIdsWithTitle();
+        if (!cancelled) {
+          setDataViewList(list);
+          setListError(false);
+        }
+      } catch {
+        if (!cancelled) {
+          setListError(true);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [dataViews]);
+
+  const buildOptionsForValue = useCallback(
+    (selected: string | undefined): Array<EuiSuperSelectOption<string>> => {
+      const titlesFromViews = [...dataViewList]
+        .map((d) => d.title)
+        .filter((t): t is string => Boolean(t?.trim()))
+        .sort((a, b) => a.localeCompare(b));
+
+      const baseTitles =
+        listError || titlesFromViews.length === 0
+          ? [...THRESHOLD_DATA_SOURCE_CHOICES]
+          : titlesFromViews;
+
+      const merged = new Set(baseTitles);
+      const trimmedSelected = selected?.trim();
+      if (trimmedSelected && !merged.has(trimmedSelected)) {
+        merged.add(trimmedSelected);
+      }
+
+      return toSelectOptions([...merged].sort((a, b) => a.localeCompare(b)));
+    },
+    [dataViewList, listError]
+  );
+
+  const dataSourceRowId = 'ruleV2FormThresholdDataSource';
+
+  return (
+    <Controller
+      name="thresholdDataSource"
+      control={control}
+      defaultValue={DEFAULT_THRESHOLD_DATA_SOURCE}
+      render={({ field, fieldState: { error } }) => {
+        const options = buildOptionsForValue(field.value);
+
+        const valueOfSelected =
+          field.value && options.some((o) => o.value === field.value)
+            ? field.value
+            : options[0]?.value ?? DEFAULT_THRESHOLD_DATA_SOURCE;
+
+        return (
+          <EuiFormRow
+            id={dataSourceRowId}
+            label={i18n.translate('xpack.alertingV2.ruleForm.thresholdDataSource.label', {
+              defaultMessage: 'Data source',
+            })}
+            isInvalid={!!error}
+            error={error?.message}
+            fullWidth
+          >
+            <EuiSuperSelect
+              id={dataSourceRowId}
+              data-test-subj="ruleV2FormThresholdDataSource"
+              options={options}
+              valueOfSelected={valueOfSelected}
+              onChange={field.onChange}
+              onBlur={field.onBlur}
+              buttonRef={field.ref}
+              compressed={compressed}
+              fullWidth
+              hasDividers
+              aria-label={i18n.translate(
+                'xpack.alertingV2.ruleForm.thresholdDataSource.ariaLabel',
+                {
+                  defaultMessage: 'Data source',
+                }
+              )}
+            />
+          </EuiFormRow>
+        );
+      }}
+    />
+  );
+};

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/threshold_stats_field.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/threshold_stats_field.tsx
@@ -1,0 +1,198 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { Fragment, useMemo } from 'react';
+import {
+  EuiButtonEmpty,
+  EuiButtonIcon,
+  EuiFieldText,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFormRow,
+  EuiHorizontalRule,
+  EuiSelect,
+  EuiSpacer,
+  EuiTitle,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { useFieldArray, useFormContext } from 'react-hook-form';
+import type { FormValues, ThresholdAggregation } from '../types';
+import { useRuleFormMeta } from '../contexts';
+
+const AGGREGATION_OPTIONS: Array<{ value: ThresholdAggregation; text: string }> = [
+  {
+    value: 'avg',
+    text: i18n.translate('xpack.alertingV2.ruleForm.thresholdStats.agg.avg', {
+      defaultMessage: 'Average',
+    }),
+  },
+  {
+    value: 'max',
+    text: i18n.translate('xpack.alertingV2.ruleForm.thresholdStats.agg.max', {
+      defaultMessage: 'Max',
+    }),
+  },
+  {
+    value: 'min',
+    text: i18n.translate('xpack.alertingV2.ruleForm.thresholdStats.agg.min', {
+      defaultMessage: 'Min',
+    }),
+  },
+  {
+    value: 'sum',
+    text: i18n.translate('xpack.alertingV2.ruleForm.thresholdStats.agg.sum', {
+      defaultMessage: 'Sum',
+    }),
+  },
+  {
+    value: 'p95',
+    text: i18n.translate('xpack.alertingV2.ruleForm.thresholdStats.agg.p95', {
+      defaultMessage: 'P95',
+    }),
+  },
+  {
+    value: 'p99',
+    text: i18n.translate('xpack.alertingV2.ruleForm.thresholdStats.agg.p99', {
+      defaultMessage: 'P99',
+    }),
+  },
+  {
+    value: 'count',
+    text: i18n.translate('xpack.alertingV2.ruleForm.thresholdStats.agg.count', {
+      defaultMessage: 'Count',
+    }),
+  },
+  {
+    value: 'cardinality',
+    text: i18n.translate('xpack.alertingV2.ruleForm.thresholdStats.agg.cardinality', {
+      defaultMessage: 'Cardinality',
+    }),
+  },
+];
+
+export const ThresholdStatsField = () => {
+  const { layout } = useRuleFormMeta();
+  const { control, register } = useFormContext<FormValues>();
+  const { fields, append, remove } = useFieldArray({
+    control,
+    name: 'thresholdStats',
+  });
+
+  const compressed = layout === 'flyout';
+
+  const addButtonLabel = useMemo(
+    () =>
+      i18n.translate('xpack.alertingV2.ruleForm.thresholdStats.addAnotherStats', {
+        defaultMessage: 'Add another stats',
+      }),
+    []
+  );
+
+  const statsTitle = i18n.translate('xpack.alertingV2.ruleForm.thresholdStats.sectionTitleStats', {
+    defaultMessage: 'Stats',
+    description: 'Section heading in the threshold rule builder for aggregation rows (STATS in ES|QL).',
+  });
+
+  return (
+    <>
+      <EuiTitle size="xs">
+        <h3>{statsTitle}</h3>
+      </EuiTitle>
+      <EuiSpacer size="m" />
+
+      {fields.map((field, index) => (
+        <Fragment key={field.id}>
+          {index > 0 ? <EuiHorizontalRule margin="m" /> : null}
+          <div
+            style={{
+              position: 'relative',
+              ...(fields.length > 1 ? { paddingInlineEnd: 36 } : {}),
+            }}
+          >
+            {fields.length > 1 ? (
+              <EuiButtonIcon
+                aria-label={i18n.translate('xpack.alertingV2.ruleForm.thresholdStats.removeStat', {
+                  defaultMessage: 'Remove stat',
+                })}
+                iconType="cross"
+                size="s"
+                color="danger"
+                display="empty"
+                style={{ position: 'absolute', insetInlineEnd: 0, top: 0 }}
+                onClick={() => remove(index)}
+              />
+            ) : null}
+            <EuiFlexGroup gutterSize="s" alignItems="flexStart" responsive={true}>
+              <EuiFlexItem grow={2}>
+                <EuiFormRow
+                  label={i18n.translate('xpack.alertingV2.ruleForm.thresholdStats.labelColumn', {
+                    defaultMessage: 'label',
+                  })}
+                  fullWidth
+                >
+                  <EuiFieldText
+                    fullWidth
+                    compressed={compressed}
+                    {...register(`thresholdStats.${index}.label` as const)}
+                  />
+                </EuiFormRow>
+              </EuiFlexItem>
+              <EuiFlexItem grow={2}>
+                <EuiFormRow
+                  label={i18n.translate(
+                    'xpack.alertingV2.ruleForm.thresholdStats.aggregationColumn',
+                    {
+                      defaultMessage: 'aggregation',
+                    }
+                  )}
+                  fullWidth
+                >
+                  <EuiSelect
+                    fullWidth
+                    compressed={compressed}
+                    options={AGGREGATION_OPTIONS}
+                    {...register(`thresholdStats.${index}.aggregation` as const)}
+                  />
+                </EuiFormRow>
+              </EuiFlexItem>
+              <EuiFlexItem grow={5}>
+                <EuiFormRow
+                  label={i18n.translate('xpack.alertingV2.ruleForm.thresholdStats.fieldColumn', {
+                    defaultMessage: 'field',
+                  })}
+                  fullWidth
+                >
+                  <EuiFieldText
+                    fullWidth
+                    compressed={compressed}
+                    {...register(`thresholdStats.${index}.field` as const)}
+                  />
+                </EuiFormRow>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </div>
+        </Fragment>
+      ))}
+
+      <EuiSpacer size="s" />
+      <EuiButtonEmpty
+        color="text"
+        iconType="plusInCircle"
+        size="s"
+        onClick={() =>
+          append({
+            label: '',
+            aggregation: 'avg',
+            field: '',
+          })
+        }
+      >
+        {addButtonLabel}
+      </EuiButtonEmpty>
+    </>
+  );
+};

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/time_field_select.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/time_field_select.test.tsx
@@ -41,7 +41,15 @@ describe('TimeFieldSelect', () => {
   it('renders the time field label', () => {
     render(<TimeFieldSelect />, { wrapper: createFormWrapper({}, mockServices) });
 
-    expect(screen.getByText('Time Field')).toBeInTheDocument();
+    expect(screen.getByText('Time field')).toBeInTheDocument();
+  });
+
+  it('renders help text under the time field', () => {
+    render(<TimeFieldSelect />, { wrapper: createFormWrapper({}, mockServices) });
+
+    expect(
+      screen.getByText('Select the timestamp field to use for time-based queries')
+    ).toBeInTheDocument();
   });
 
   it('renders a select input', () => {

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/time_field_select.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/time_field_select.tsx
@@ -84,7 +84,10 @@ export const TimeFieldSelect = () => {
         return (
           <EuiFormRow
             label={i18n.translate('xpack.alertingV2.ruleForm.timeFieldLabel', {
-              defaultMessage: 'Time Field',
+              defaultMessage: 'Time field',
+            })}
+            helpText={i18n.translate('xpack.alertingV2.ruleForm.timeFieldHelpText', {
+              defaultMessage: 'Select the timestamp field to use for time-based queries',
             })}
             isInvalid={!!error}
             error={error?.message}

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/gui_rule_form.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/gui_rule_form.tsx
@@ -27,7 +27,7 @@ export interface GuiRuleFormProps {
  * GUI-based rule form with standard form fields.
  *
  * This component renders the visual form interface with field groups for:
- * - Rule details (name, tags, description — no wrapper panel)
+ * - Rule details (name, description, tags in a Rule details panel)
  * - Rule evaluation (full ES|QL query)
  * - Rule execution settings (schedule, lookback)
  * - Rule kind (alert vs monitor)

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/hooks/use_ensure_threshold_builder_defaults.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/hooks/use_ensure_threshold_builder_defaults.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useEffect } from 'react';
+import { useFormContext } from 'react-hook-form';
+import type { FormValues } from '../types';
+import { DEFAULT_THRESHOLD_DATA_SOURCE } from '../threshold_builder_constants';
+
+/**
+ * Ensures threshold builder slice fields exist when the guided threshold UI is shown
+ * (for example after toggling from ES|QL on a create flow that did not deep-link with ?builder=).
+ */
+export const useEnsureThresholdBuilderDefaults = (enabled: boolean): void => {
+  const { getValues, setValue } = useFormContext<FormValues>();
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+    const stats = getValues('thresholdStats');
+    if (!stats || stats.length === 0) {
+      setValue('thresholdStats', [{ label: '', aggregation: 'avg', field: '' }], {
+        shouldDirty: false,
+      });
+    }
+    if (getValues('thresholdConditionCombinator') === undefined) {
+      setValue('thresholdConditionCombinator', 'and', { shouldDirty: false });
+    }
+    const conditions = getValues('thresholdConditions');
+    if (!conditions || conditions.length === 0) {
+      setValue('thresholdConditions', [{ statLabel: '', operator: 'gt', value: '' }], {
+        shouldDirty: false,
+      });
+    }
+    if (!getValues('thresholdDataSource')) {
+      setValue('thresholdDataSource', DEFAULT_THRESHOLD_DATA_SOURCE, { shouldDirty: false });
+    }
+  }, [enabled, getValues, setValue]);
+};

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/hooks/use_preview.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/hooks/use_preview.ts
@@ -51,6 +51,8 @@ export interface PreviewResult {
   timeField: string;
   /** The lookback duration string (e.g. '5m', '1h') */
   lookback: string;
+  /** Re-runs the preview query (same key as the automatic fetch). */
+  refetch: () => void;
 }
 
 export interface UsePreviewParams {
@@ -160,6 +162,7 @@ export const usePreview = ({
     isLoading,
     isError,
     error,
+    refetch,
   } = useQuery({
     queryKey: ruleFormKeys.preview(debouncedQuery, timeField, lookback),
     queryFn: fetchPreview,
@@ -224,5 +227,8 @@ export const usePreview = ({
     query,
     timeField,
     lookback,
+    refetch: () => {
+      void refetch();
+    },
   };
 };

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/hooks/use_sync_threshold_evaluation_query.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/hooks/use_sync_threshold_evaluation_query.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useEffect } from 'react';
+import { useFormContext, useWatch } from 'react-hook-form';
+import type { FormValues } from '../types';
+import { buildThresholdEvaluationQuery } from '../utils/build_threshold_evaluation_query';
+
+/**
+ * Keeps `evaluation.query.base` in sync with threshold stat rows and group fields
+ * when the threshold alert builder is active.
+ */
+export const useSyncThresholdEvaluationQuery = (enabled: boolean): void => {
+  const { control, setValue } = useFormContext<FormValues>();
+  const thresholdStats = useWatch({ control, name: 'thresholdStats' });
+  const thresholdDataSource = useWatch({ control, name: 'thresholdDataSource' });
+  const thresholdConditions = useWatch({ control, name: 'thresholdConditions' });
+  const thresholdConditionCombinator = useWatch({ control, name: 'thresholdConditionCombinator' });
+  const groupingFields = useWatch({ control, name: 'grouping.fields' });
+  const timeField = useWatch({ control, name: 'timeField' });
+  const scheduleEvery = useWatch({ control, name: 'schedule.every' });
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+    const query = buildThresholdEvaluationQuery(
+      thresholdStats,
+      groupingFields,
+      thresholdDataSource,
+      thresholdConditions,
+      thresholdConditionCombinator,
+      timeField,
+      scheduleEvery
+    );
+    setValue('evaluation.query.base', query, { shouldValidate: true, shouldDirty: true });
+  }, [
+    enabled,
+    thresholdStats,
+    thresholdDataSource,
+    thresholdConditions,
+    thresholdConditionCombinator,
+    groupingFields,
+    timeField,
+    scheduleEvery,
+    setValue,
+  ]);
+};

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/index.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/index.tsx
@@ -59,7 +59,7 @@ export type {
 } from './types';
 export type { DynamicRuleFormProps } from './dynamic_rule_form';
 export type { StandaloneRuleFormProps } from './standalone_rule_form';
-export type { RuleFormServices, RuleFormMeta, RuleFormLayout } from './contexts';
+export type { RuleFormServices, RuleFormMeta, RuleFormLayout, RuleBuilderCatalogEntry } from './contexts';
 export { RuleFormProvider, useRuleFormServices, useRuleFormMeta } from './contexts';
 export {
   DEFAULT_THRESHOLD_DATA_SOURCE,

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/index.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/index.tsx
@@ -48,11 +48,23 @@ export const RuleResultsPreview = () => (
   </Suspense>
 );
 
-export type { FormValues, StateTransitionDelayMode } from './types';
+export type {
+  FormValues,
+  StateTransitionDelayMode,
+  ThresholdAggregation,
+  ThresholdStatRow,
+  ThresholdConditionCombinator,
+  ThresholdConditionOperator,
+  ThresholdConditionRow,
+} from './types';
 export type { DynamicRuleFormProps } from './dynamic_rule_form';
 export type { StandaloneRuleFormProps } from './standalone_rule_form';
 export type { RuleFormServices, RuleFormMeta, RuleFormLayout } from './contexts';
 export { RuleFormProvider, useRuleFormServices, useRuleFormMeta } from './contexts';
+export {
+  DEFAULT_THRESHOLD_DATA_SOURCE,
+  THRESHOLD_DATA_SOURCE_CHOICES,
+} from './threshold_builder_constants';
 export {
   deriveAlertDelayModeFromStateTransition,
   deriveRecoveryDelayModeFromStateTransition,

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/rule_form.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/rule_form.test.tsx
@@ -63,6 +63,14 @@ jest.mock('./gui_rule_form', () => ({
   ),
 }));
 
+jest.mock('./yaml_rule_form', () => ({
+  YamlRuleForm: () => (
+    <form id="ruleV2Form" data-test-subj="mockYamlRuleForm">
+      <div>YAML Form</div>
+    </form>
+  ),
+}));
+
 describe('RuleForm', () => {
   const mockServices = createMockServices();
 
@@ -81,6 +89,24 @@ describe('RuleForm', () => {
 
       expect(screen.getByTestId('mockGuiRuleForm')).toBeInTheDocument();
       expect(screen.getByText('GUI Form')).toBeInTheDocument();
+    });
+
+    it('renders Form/YAML toggle with GUI form selected by default', () => {
+      render(<RuleForm {...defaultProps} />, { wrapper: createFormWrapper() });
+
+      expect(screen.getByTestId('ruleV2FormEditModeToggle')).toBeInTheDocument();
+      expect(screen.getByTestId('ruleV2FormEditModeFormButton')).toBeInTheDocument();
+      expect(screen.getByTestId('ruleV2FormEditModeYamlButton')).toBeInTheDocument();
+    });
+
+    it('shows YAML editor mock when YAML mode is selected', async () => {
+      const user = userEvent.setup();
+      render(<RuleForm {...defaultProps} />, { wrapper: createFormWrapper() });
+
+      await user.click(screen.getByTestId('ruleV2FormEditModeYamlButton'));
+
+      expect(screen.getByTestId('mockYamlRuleForm')).toBeInTheDocument();
+      expect(screen.queryByTestId('mockGuiRuleForm')).not.toBeInTheDocument();
     });
 
     it('renders ErrorCallOut from RuleFormContent', () => {

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/rule_form.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/rule_form.test.tsx
@@ -63,23 +63,6 @@ jest.mock('./gui_rule_form', () => ({
   ),
 }));
 
-// Mock YamlRuleForm to avoid monaco editor setup
-jest.mock('./yaml_rule_form', () => ({
-  YamlRuleForm: ({ onSubmit, isDisabled }: { onSubmit: () => void; isDisabled?: boolean }) => (
-    <form
-      id="ruleV2Form"
-      data-test-subj="mockYamlRuleForm"
-      onSubmit={(e) => {
-        e.preventDefault();
-        onSubmit();
-      }}
-    >
-      <div>YAML Form</div>
-      <textarea data-test-subj="ruleV2FormYamlEditor" disabled={isDisabled} />
-    </form>
-  ),
-}));
-
 describe('RuleForm', () => {
   const mockServices = createMockServices();
 
@@ -124,76 +107,6 @@ describe('RuleForm', () => {
       render(<RuleForm {...defaultProps} />, { wrapper: createFormWrapper() });
 
       expect(screen.getByText('Query Editor')).toBeInTheDocument();
-    });
-  });
-
-  describe('YAML mode toggle', () => {
-    it('does not show edit mode toggle when includeYaml is false', () => {
-      render(<RuleForm {...defaultProps} includeYaml={false} />, { wrapper: createFormWrapper() });
-
-      expect(screen.queryByTestId('ruleV2FormEditModeToggle')).not.toBeInTheDocument();
-    });
-
-    it('shows edit mode toggle when includeYaml is true', () => {
-      render(<RuleForm {...defaultProps} includeYaml />, { wrapper: createFormWrapper() });
-
-      expect(screen.getByTestId('ruleV2FormEditModeToggle')).toBeInTheDocument();
-      expect(screen.getByTestId('ruleV2FormEditModeFormButton')).toBeInTheDocument();
-      expect(screen.getByTestId('ruleV2FormEditModeYamlButton')).toBeInTheDocument();
-    });
-
-    it('shows Rule configuration heading when includeYaml is true', () => {
-      render(<RuleForm {...defaultProps} includeYaml />, { wrapper: createFormWrapper() });
-
-      expect(screen.getByText('Rule configuration')).toBeInTheDocument();
-    });
-
-    it('does not show Rule configuration heading when includeYaml is false', () => {
-      render(<RuleForm {...defaultProps} includeYaml={false} />, { wrapper: createFormWrapper() });
-
-      expect(screen.queryByText('Rule configuration')).not.toBeInTheDocument();
-    });
-
-    it('starts in form mode by default', () => {
-      render(<RuleForm {...defaultProps} includeYaml />, { wrapper: createFormWrapper() });
-
-      expect(screen.getByTestId('mockGuiRuleForm')).toBeInTheDocument();
-      expect(screen.queryByTestId('mockYamlRuleForm')).not.toBeInTheDocument();
-    });
-
-    it('switches to YAML mode when YAML toggle is clicked', async () => {
-      const user = userEvent.setup();
-
-      render(<RuleForm {...defaultProps} includeYaml />, { wrapper: createFormWrapper() });
-
-      await user.click(screen.getByTestId('ruleV2FormEditModeYamlButton'));
-
-      expect(screen.getByTestId('mockYamlRuleForm')).toBeInTheDocument();
-      expect(screen.queryByTestId('mockGuiRuleForm')).not.toBeInTheDocument();
-    });
-
-    it('switches back to form mode when Form toggle is clicked', async () => {
-      const user = userEvent.setup();
-
-      render(<RuleForm {...defaultProps} includeYaml />, { wrapper: createFormWrapper() });
-
-      // Switch to YAML
-      await user.click(screen.getByTestId('ruleV2FormEditModeYamlButton'));
-      expect(screen.getByTestId('mockYamlRuleForm')).toBeInTheDocument();
-
-      // Switch back to Form
-      await user.click(screen.getByTestId('ruleV2FormEditModeFormButton'));
-      expect(screen.getByTestId('mockGuiRuleForm')).toBeInTheDocument();
-      expect(screen.queryByTestId('mockYamlRuleForm')).not.toBeInTheDocument();
-    });
-
-    it('disables toggle when isDisabled is true', () => {
-      render(<RuleForm {...defaultProps} includeYaml isDisabled />, {
-        wrapper: createFormWrapper(),
-      });
-
-      expect(screen.getByTestId('ruleV2FormEditModeFormButton')).toBeDisabled();
-      expect(screen.getByTestId('ruleV2FormEditModeYamlButton')).toBeDisabled();
     });
   });
 
@@ -271,18 +184,13 @@ describe('RuleForm', () => {
       expect(onCancel).toHaveBeenCalledTimes(1);
     });
 
-    it('shows submission buttons in YAML mode', async () => {
-      const user = userEvent.setup();
-
-      render(<RuleForm {...defaultProps} includeSubmission includeYaml />, {
+    it('shows submission buttons with the GUI form', () => {
+      render(<RuleForm {...defaultProps} includeSubmission />, {
         wrapper: createFormWrapper(),
       });
 
-      // Switch to YAML mode
-      await user.click(screen.getByTestId('ruleV2FormEditModeYamlButton'));
-
-      // Submission buttons should still be visible
       expect(screen.getByTestId('ruleV2FormSubmitButton')).toBeInTheDocument();
+      expect(screen.getByTestId('mockGuiRuleForm')).toBeInTheDocument();
     });
   });
 

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/rule_form.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/rule_form.tsx
@@ -5,17 +5,26 @@
  * 2.0.
  */
 
-import React, { useCallback, useRef, useMemo } from 'react';
-import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import React, { useCallback, useRef, useMemo, useState } from 'react';
+import { EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiTitle } from '@elastic/eui';
+import { useFormContext } from 'react-hook-form';
 import { QueryClient, QueryClientProvider } from '@kbn/react-query';
+import { i18n } from '@kbn/i18n';
 import type { FormValues } from './types';
 import { SubmissionButtons } from './components/submission_buttons';
+import { EditModeToggle, type EditMode } from './components/edit_mode_toggle';
+import { YamlRuleForm } from './yaml_rule_form';
+import {
+  parseYamlToFormValuesForGuiSwitch,
+  serializeFormToYaml,
+} from './utils/yaml_form_utils';
 import {
   RuleFormProvider,
   useRuleFormServices,
   useRuleFormMeta,
   type RuleFormServices,
   type RuleFormLayout,
+  type RuleBuilderCatalogEntry,
 } from './contexts';
 import { GuiRuleForm } from './gui_rule_form';
 import { RulePreviewPanel } from './fields/rule_preview_panel';
@@ -24,6 +33,14 @@ import { useCreateRule } from './hooks/use_create_rule';
 import { useUpdateRule } from './hooks/use_update_rule';
 
 export type { RuleFormServices } from './contexts';
+
+const mergeYamlParsedIntoFormValues = (previous: FormValues, parsed: FormValues): FormValues => ({
+  ...previous,
+  ...parsed,
+  metadata: { ...previous.metadata, ...parsed.metadata },
+  schedule: { ...previous.schedule, ...parsed.schedule },
+  evaluation: { ...previous.evaluation, ...parsed.evaluation },
+});
 
 export interface RuleFormProps {
   services: RuleFormServices;
@@ -37,6 +54,10 @@ export interface RuleFormProps {
   ruleBuilderId?: string;
   /** Shown as a badge on the Rule evaluation section (builder name or ES|QL). */
   ruleEvaluationModeLabel?: string;
+  /** Guided mode: builder list for the section-title super select. */
+  ruleBuilderCatalog?: RuleBuilderCatalogEntry[];
+  /** Guided mode: invoked when the user selects a builder from the super select. */
+  onRuleBuilderIdChange?: (id: string) => void;
   /**
    * External submit handler. When provided, form submission delegates to this callback.
    * When omitted and `includeSubmission` is true, the form uses `useCreateRule` internally.
@@ -79,6 +100,10 @@ const RuleFormContent = ({
   const services = useRuleFormServices();
   const { layout } = useRuleFormMeta();
   const { http, notifications } = services;
+  const { getValues, reset } = useFormContext<FormValues>();
+
+  const [editMode, setEditMode] = useState<EditMode>('form');
+  const [yamlDraft, setYamlDraft] = useState('');
 
   const { createRule, isLoading: isCreating } = useCreateRule({
     http,
@@ -104,10 +129,79 @@ const RuleFormContent = ({
   const onSubmit = externalOnSubmit ?? internalSubmit;
   const isSubmitting = externalIsSubmitting || isCreating || isUpdating;
 
+  const ruleConfigurationHeaderTitle = i18n.translate(
+    'xpack.alertingV2.ruleForm.conditionSectionTitle',
+    {
+      defaultMessage: 'Rule configuration',
+    }
+  );
+
+  const onEditModeChange = useCallback(
+    (next: EditMode) => {
+      if (next === 'yaml') {
+        setYamlDraft(serializeFormToYaml(getValues()));
+        setEditMode('yaml');
+        return;
+      }
+
+      const result = parseYamlToFormValuesForGuiSwitch(getValues(), yamlDraft);
+      if (result.error || !result.values) {
+        notifications.toasts.addDanger({
+          title: i18n.translate('xpack.alertingV2.ruleForm.editMode.invalidYamlTitle', {
+            defaultMessage: 'Cannot switch to GUI view',
+          }),
+          text: result.error ?? undefined,
+        });
+        return;
+      }
+
+      reset(mergeYamlParsedIntoFormValues(getValues(), result.values));
+      setEditMode('form');
+    },
+    [getValues, reset, yamlDraft, notifications.toasts]
+  );
+
+  const editModeToggle = (
+    <>
+      <EuiFlexGroup
+        justifyContent="spaceBetween"
+        alignItems="center"
+        responsive={false}
+      >
+        <EuiFlexItem grow={false}>
+          <EuiTitle size="s">
+            <h3>
+              <strong>{ruleConfigurationHeaderTitle}</strong>
+            </h3>
+          </EuiTitle>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EditModeToggle
+            editMode={editMode}
+            onChange={onEditModeChange}
+            disabled={isSubmitting}
+          />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+      <EuiSpacer size="m" />
+    </>
+  );
+
   const mainFormFields = (
     <>
+      {editModeToggle}
       <ErrorCallOut />
-      <GuiRuleForm onSubmit={onSubmit} includeQueryEditor={includeQueryEditor} />
+      {editMode === 'form' ? (
+        <GuiRuleForm onSubmit={onSubmit} includeQueryEditor={includeQueryEditor} />
+      ) : (
+        <YamlRuleForm
+          services={services}
+          onSubmit={onSubmit}
+          isSubmitting={isSubmitting}
+          yaml={yamlDraft}
+          onYamlChange={setYamlDraft}
+        />
+      )}
     </>
   );
 
@@ -182,6 +276,8 @@ export const RuleForm = ({
   ruleEvaluationHeaderActions,
   ruleBuilderId,
   ruleEvaluationModeLabel,
+  ruleBuilderCatalog,
+  onRuleBuilderIdChange,
   includeQueryEditor = true,
   ...props
 }: RuleFormProps) => {
@@ -205,8 +301,18 @@ export const RuleForm = ({
       ruleEvaluationHeaderActions,
       ruleBuilderId,
       ruleEvaluationModeLabel,
+      ruleBuilderCatalog,
+      onRuleBuilderIdChange,
     }),
-    [layout, includeQueryEditor, ruleEvaluationHeaderActions, ruleBuilderId, ruleEvaluationModeLabel]
+    [
+      layout,
+      includeQueryEditor,
+      ruleEvaluationHeaderActions,
+      ruleBuilderId,
+      ruleEvaluationModeLabel,
+      ruleBuilderCatalog,
+      onRuleBuilderIdChange,
+    ]
   );
 
   return (

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/rule_form.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/rule_form.tsx
@@ -5,13 +5,10 @@
  * 2.0.
  */
 
-import React, { useCallback, useRef, useMemo, useState } from 'react';
-import { EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiTitle } from '@elastic/eui';
-import { useFormContext } from 'react-hook-form';
+import React, { useCallback, useRef, useMemo } from 'react';
+import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { QueryClient, QueryClientProvider } from '@kbn/react-query';
-import { FormattedMessage } from '@kbn/i18n-react';
 import type { FormValues } from './types';
-import { EditModeToggle, type EditMode } from './components/edit_mode_toggle';
 import { SubmissionButtons } from './components/submission_buttons';
 import {
   RuleFormProvider,
@@ -20,7 +17,6 @@ import {
   type RuleFormServices,
   type RuleFormLayout,
 } from './contexts';
-import { YamlRuleForm } from './yaml_rule_form';
 import { GuiRuleForm } from './gui_rule_form';
 import { RulePreviewPanel } from './fields/rule_preview_panel';
 import { ErrorCallOut } from './error_callout';
@@ -33,6 +29,14 @@ export interface RuleFormProps {
   services: RuleFormServices;
   /** Layout mode: 'page' renders the preview side-by-side; 'flyout' uses a nested flyout. Default: 'page'. */
   layout?: RuleFormLayout;
+  /** Rendered in the Rule evaluation panel header (see {@link RuleFormMeta.ruleEvaluationHeaderActions}). */
+  ruleEvaluationHeaderActions?: React.ReactNode;
+  /**
+   * Deep-linked rule builder id (for example `threshold_alert`). Passed through to {@link RuleFormMeta}.
+   */
+  ruleBuilderId?: string;
+  /** Shown as a badge on the Rule evaluation section (builder name or ES|QL). */
+  ruleEvaluationModeLabel?: string;
   /**
    * External submit handler. When provided, form submission delegates to this callback.
    * When omitted and `includeSubmission` is true, the form uses `useCreateRule` internally.
@@ -43,9 +47,6 @@ export interface RuleFormProps {
   onCancel?: () => void;
   /** Whether to include the ES|QL query editor (default: true) */
   includeQueryEditor?: boolean;
-  /** Whether to include YAML editor toggle (default: false) */
-  includeYaml?: boolean;
-  isDisabled?: boolean;
   /** Whether the form is currently submitting (controls button loading state) */
   isSubmitting?: boolean;
   /** Whether to show submit/cancel buttons (default: false) */
@@ -57,7 +58,7 @@ export interface RuleFormProps {
 }
 
 /**
- * Inner content component that renders the appropriate form based on edit mode.
+ * Inner content component that renders the GUI rule form.
  *
  * When an external `onSubmit` is provided, form submission delegates to it.
  * Otherwise, the component uses `useCreateRule` or `useUpdateRule` internally
@@ -68,8 +69,6 @@ const RuleFormContent = ({
   onSubmit: externalOnSubmit,
   onSuccess,
   includeQueryEditor = true,
-  includeYaml = false,
-  isDisabled = false,
   isSubmitting: externalIsSubmitting = false,
   includeSubmission = false,
   onCancel,
@@ -77,14 +76,10 @@ const RuleFormContent = ({
   cancelLabel,
   ruleId,
 }: RuleFormProps) => {
-  const { reset } = useFormContext<FormValues>();
   const services = useRuleFormServices();
   const { layout } = useRuleFormMeta();
   const { http, notifications } = services;
-  const [editMode, setEditMode] = useState<EditMode>('form');
 
-  // Internal submission hooks — always initialised so hooks are stable,
-  // but only the appropriate one is used when no external onSubmit is provided.
   const { createRule, isLoading: isCreating } = useCreateRule({
     http,
     notifications,
@@ -96,12 +91,9 @@ const RuleFormContent = ({
     ruleId: ruleId ?? '',
   });
 
-  // Keep a stable ref so the internalSubmit callback doesn't re-create on every render
   const onSuccessRef = useRef(onSuccess);
   onSuccessRef.current = onSuccess;
 
-  // Resolve the effective submit handler: external callback takes precedence,
-  // otherwise use updateRule for edits (ruleId present) or createRule for new rules.
   const internalSubmit = useCallback(
     (values: FormValues) => {
       const mutate = ruleId ? updateRule : createRule;
@@ -112,96 +104,60 @@ const RuleFormContent = ({
   const onSubmit = externalOnSubmit ?? internalSubmit;
   const isSubmitting = externalIsSubmitting || isCreating || isUpdating;
 
-  const handleModeChange = useCallback(
-    (newMode: EditMode) => {
-      if (newMode === editMode) return;
-      setEditMode(newMode);
-    },
-    [editMode]
-  );
-
-  // Wrapper that syncs YAML changes back to form state before submitting
-  const handleYamlSubmit = useCallback(
-    (values: FormValues) => {
-      reset(values);
-      onSubmit(values);
-    },
-    [reset, onSubmit]
-  );
-
-  const isYamlMode = editMode === 'yaml';
-
-  const formContent = (
+  const mainFormFields = (
     <>
       <ErrorCallOut />
-      {includeYaml && (
-        <EuiFlexGroup
-          alignItems="center"
-          justifyContent="spaceBetween"
-          responsive={false}
-          gutterSize="m"
-        >
-          <EuiFlexItem grow={false}>
-            <EuiTitle size="xs">
-              <h3>
-                <FormattedMessage
-                  id="xpack.alertingV2.ruleForm.ruleConfigurationHeading"
-                  defaultMessage="Rule configuration"
-                />
-              </h3>
-            </EuiTitle>
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EditModeToggle
-              editMode={editMode}
-              onChange={handleModeChange}
-              disabled={isDisabled || isSubmitting}
-            />
-          </EuiFlexItem>
-        </EuiFlexGroup>
-      )}
-      <EuiSpacer size="m" />
-
-      {isYamlMode && includeYaml ? (
-        <YamlRuleForm
-          services={services}
-          onSubmit={handleYamlSubmit}
-          isDisabled={isDisabled}
-          isSubmitting={isSubmitting}
-        />
-      ) : (
-        <GuiRuleForm onSubmit={onSubmit} includeQueryEditor={includeQueryEditor} />
-      )}
-
-      {includeSubmission && (
-        <SubmissionButtons
-          isSubmitting={isSubmitting}
-          onCancel={onCancel}
-          submitLabel={submitLabel}
-          cancelLabel={cancelLabel}
-          ruleId={ruleId}
-        />
-      )}
+      <GuiRuleForm onSubmit={onSubmit} includeQueryEditor={includeQueryEditor} />
     </>
   );
 
+  const submissionFooter = includeSubmission ? (
+    <SubmissionButtons
+      isSubmitting={isSubmitting}
+      onCancel={onCancel}
+      submitLabel={submitLabel}
+      cancelLabel={cancelLabel}
+      ruleId={ruleId}
+    />
+  ) : null;
+
   if (layout === 'page') {
     return (
-      <EuiFlexGroup gutterSize="l" alignItems="flexStart">
-        <EuiFlexItem grow={1} style={{ minWidth: 0 }}>
-          {formContent}
+      <EuiFlexGroup direction="column" gutterSize="l" alignItems="stretch">
+        <EuiFlexItem grow={false}>
+          <EuiFlexGroup gutterSize="l" alignItems="flexStart">
+            <EuiFlexItem grow={3} style={{ minWidth: 0 }}>
+              {mainFormFields}
+            </EuiFlexItem>
+            <EuiFlexItem
+              grow={2}
+              style={{
+                minWidth: 0,
+                position: 'sticky',
+                top: 24,
+                alignSelf: 'flex-start',
+                maxHeight: 'calc(100vh - 96px)',
+                overflowY: 'auto',
+              }}
+              data-test-subj="ruleEvaluationPreviewRail"
+            >
+              <RulePreviewPanel />
+            </EuiFlexItem>
+          </EuiFlexGroup>
         </EuiFlexItem>
-        <EuiFlexItem grow={1} style={{ minWidth: 0 }}>
-          <RulePreviewPanel />
-        </EuiFlexItem>
+        {submissionFooter !== null ? (
+          <EuiFlexItem grow={false} style={{ width: '100%' }}>
+            {submissionFooter}
+          </EuiFlexItem>
+        ) : null}
       </EuiFlexGroup>
     );
   }
 
-  // Flyout layout: form with nested flyout preview
   return (
     <>
-      {formContent}
+      {mainFormFields}
+      {submissionFooter}
       <RulePreviewPanel />
     </>
   );
@@ -221,7 +177,14 @@ const RuleFormContent = ({
  * Includes its own QueryClientProvider for react-query hooks used by field components.
  * Services and layout metadata are provided via RuleFormProvider context, eliminating prop drilling.
  */
-export const RuleForm = ({ layout = 'page', ...props }: RuleFormProps) => {
+export const RuleForm = ({
+  layout = 'page',
+  ruleEvaluationHeaderActions,
+  ruleBuilderId,
+  ruleEvaluationModeLabel,
+  includeQueryEditor = true,
+  ...props
+}: RuleFormProps) => {
   const queryClient = useMemo(
     () =>
       new QueryClient({
@@ -235,12 +198,21 @@ export const RuleForm = ({ layout = 'page', ...props }: RuleFormProps) => {
     []
   );
 
-  const meta = useMemo(() => ({ layout }), [layout]);
+  const meta = useMemo(
+    () => ({
+      layout,
+      includeQueryEditor,
+      ruleEvaluationHeaderActions,
+      ruleBuilderId,
+      ruleEvaluationModeLabel,
+    }),
+    [layout, includeQueryEditor, ruleEvaluationHeaderActions, ruleBuilderId, ruleEvaluationModeLabel]
+  );
 
   return (
     <QueryClientProvider client={queryClient}>
       <RuleFormProvider services={props.services} meta={meta}>
-        <RuleFormContent {...props} />
+        <RuleFormContent {...props} layout={layout} includeQueryEditor={includeQueryEditor} />
       </RuleFormProvider>
     </QueryClientProvider>
   );

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/standalone_rule_form.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/standalone_rule_form.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useMemo } from 'react';
+import React, { useMemo, type ReactNode } from 'react';
 import { useForm, FormProvider } from 'react-hook-form';
 import type { FormValues } from './types';
 import { RuleForm } from './rule_form';
@@ -26,10 +26,6 @@ export interface StandaloneRuleFormProps {
   /** Callback invoked after a successful internal submission (useCreateRule). */
   onSuccess?: () => void;
   onCancel?: () => void;
-  /** Whether to include YAML editor toggle (default: false). Requires services.application. */
-  includeYaml?: boolean;
-  /** Whether the form is in a loading/disabled state */
-  isDisabled?: boolean;
   /** Whether the form is currently submitting (controls button loading state) */
   isSubmitting?: boolean;
   /** Whether to show submit/cancel buttons (default: false) */
@@ -43,6 +39,14 @@ export interface StandaloneRuleFormProps {
   initialValues?: Partial<FormValues>;
   /** When provided, the form operates in edit mode and uses PATCH instead of POST on submission. */
   ruleId?: string;
+  /** Optional controls for the Rule evaluation section header (e.g. switch from ES|QL entry to a builder). */
+  ruleEvaluationHeaderActions?: ReactNode;
+  /** When false, hides the ES|QL editor (for example threshold builder mode). Default: true. */
+  includeQueryEditor?: boolean;
+  /** Create-rule URL builder deep link (for example `threshold_alert`). */
+  ruleBuilderId?: string;
+  /** Badge text for the Rule evaluation section (builder name or ES|QL). */
+  ruleEvaluationModeLabel?: string;
 }
 
 /**
@@ -65,8 +69,6 @@ export const StandaloneRuleForm = ({
   layout,
   onSubmit,
   onSuccess,
-  includeYaml = false,
-  isDisabled = false,
   isSubmitting = false,
   includeSubmission = false,
   onCancel,
@@ -74,6 +76,10 @@ export const StandaloneRuleForm = ({
   cancelLabel,
   initialValues,
   ruleId,
+  ruleEvaluationHeaderActions,
+  includeQueryEditor = true,
+  ruleBuilderId,
+  ruleEvaluationModeLabel,
 }: StandaloneRuleFormProps) => {
   const queryDefaults = useFormDefaults({ query });
 
@@ -108,8 +114,22 @@ export const StandaloneRuleForm = ({
       stateTransitionRecoveryDelayMode:
         initialValues?.stateTransitionRecoveryDelayMode ??
         queryDefaults.stateTransitionRecoveryDelayMode,
+      ...(initialValues?.thresholdStats !== undefined
+        ? { thresholdStats: initialValues.thresholdStats }
+        : {}),
+      ...(initialValues?.thresholdDataSource !== undefined
+        ? { thresholdDataSource: initialValues.thresholdDataSource }
+        : {}),
+      ...(ruleBuilderId === 'threshold_alert'
+        ? {
+            thresholdConditionCombinator: initialValues?.thresholdConditionCombinator ?? 'and',
+            thresholdConditions: initialValues?.thresholdConditions ?? [
+              { statLabel: '', operator: 'gt', value: '' },
+            ],
+          }
+        : {}),
     }),
-    [queryDefaults, initialValues]
+    [queryDefaults, initialValues, ruleBuilderId]
   );
 
   const methods = useForm<FormValues>({
@@ -124,14 +144,16 @@ export const StandaloneRuleForm = ({
         layout={layout}
         onSubmit={onSubmit}
         onSuccess={onSuccess}
-        includeYaml={includeYaml}
-        isDisabled={isDisabled}
         isSubmitting={isSubmitting}
         includeSubmission={includeSubmission}
         onCancel={onCancel}
         submitLabel={submitLabel}
         cancelLabel={cancelLabel}
         ruleId={ruleId}
+        ruleEvaluationHeaderActions={ruleEvaluationHeaderActions}
+        includeQueryEditor={includeQueryEditor}
+        ruleBuilderId={ruleBuilderId}
+        ruleEvaluationModeLabel={ruleEvaluationModeLabel}
       />
     </FormProvider>
   );

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/standalone_rule_form.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/standalone_rule_form.tsx
@@ -9,7 +9,7 @@ import React, { useMemo, type ReactNode } from 'react';
 import { useForm, FormProvider } from 'react-hook-form';
 import type { FormValues } from './types';
 import { RuleForm } from './rule_form';
-import type { RuleFormServices, RuleFormLayout } from './contexts';
+import type { RuleFormServices, RuleFormLayout, RuleBuilderCatalogEntry } from './contexts';
 import { useFormDefaults } from './hooks/use_form_defaults';
 
 export interface StandaloneRuleFormProps {
@@ -47,6 +47,10 @@ export interface StandaloneRuleFormProps {
   ruleBuilderId?: string;
   /** Badge text for the Rule evaluation section (builder name or ES|QL). */
   ruleEvaluationModeLabel?: string;
+  /** Guided mode: builders shown in the section-title super select. */
+  ruleBuilderCatalog?: RuleBuilderCatalogEntry[];
+  /** Guided mode: called when the user selects a builder from the super select. */
+  onRuleBuilderIdChange?: (id: string) => void;
 }
 
 /**
@@ -80,6 +84,8 @@ export const StandaloneRuleForm = ({
   includeQueryEditor = true,
   ruleBuilderId,
   ruleEvaluationModeLabel,
+  ruleBuilderCatalog,
+  onRuleBuilderIdChange,
 }: StandaloneRuleFormProps) => {
   const queryDefaults = useFormDefaults({ query });
 
@@ -154,6 +160,8 @@ export const StandaloneRuleForm = ({
         includeQueryEditor={includeQueryEditor}
         ruleBuilderId={ruleBuilderId}
         ruleEvaluationModeLabel={ruleEvaluationModeLabel}
+        ruleBuilderCatalog={ruleBuilderCatalog}
+        onRuleBuilderIdChange={onRuleBuilderIdChange}
       />
     </FormProvider>
   );

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/threshold_builder_constants.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/threshold_builder_constants.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/** Default index / data stream shown in the threshold alert builder data source control. */
+export const DEFAULT_THRESHOLD_DATA_SOURCE = 'metrics-system.cpu-default';
+
+/** Preset data sources for the threshold builder (ES|QL `FROM` targets). */
+export const THRESHOLD_DATA_SOURCE_CHOICES = [
+  'metrics-system.cpu-default',
+  'logs-*',
+  'metrics-*',
+  'traces-*',
+] as const;

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/types.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/types.ts
@@ -49,6 +49,38 @@ export interface RuleArtifact {
   value: string;
 }
 
+/** Aggregation options for the threshold alert builder stats UI. */
+export type ThresholdAggregation =
+  | 'avg'
+  | 'max'
+  | 'min'
+  | 'sum'
+  | 'p95'
+  | 'p99'
+  | 'count'
+  | 'cardinality';
+
+/** One computed statistic row in the threshold alert builder. */
+export interface ThresholdStatRow {
+  label: string;
+  aggregation: ThresholdAggregation;
+  field: string;
+}
+
+/** Comparison operators for threshold alert rule conditions (maps to ES|QL). */
+export type ThresholdConditionOperator = 'gt' | 'lt' | 'gte' | 'lte' | 'eq' | 'neq';
+
+/** One row in the threshold alert “Alert condition” UI. */
+export interface ThresholdConditionRow {
+  /** Matches a stat row label; the STATS column alias is derived the same way as in the query. */
+  statLabel: string;
+  operator: ThresholdConditionOperator;
+  value: string;
+}
+
+/** How multiple threshold conditions are combined in the generated `WHERE` clause. */
+export type ThresholdConditionCombinator = 'and' | 'or';
+
 /**
  * State transition configuration for alert-type rules.
  */
@@ -76,4 +108,24 @@ export interface FormValues {
   stateTransitionAlertDelayMode: StateTransitionDelayMode;
   stateTransitionRecoveryDelayMode: StateTransitionDelayMode;
   artifacts?: RuleArtifact[];
+  /**
+   * Threshold alert builder only: stat definitions used to generate the evaluation ES|QL query.
+   * Not sent to the API — persisted via `evaluation.query.base`.
+   */
+  thresholdStats?: ThresholdStatRow[];
+  /**
+   * Threshold alert builder only: ES|QL `FROM` source (index pattern or data stream name).
+   * Not sent to the API — persisted via `evaluation.query.base`.
+   */
+  thresholdDataSource?: string;
+  /**
+   * Threshold alert builder only: combine multiple conditions with AND or OR in `WHERE`.
+   * Not sent to the API — persisted via `evaluation.query.base`.
+   */
+  thresholdConditionCombinator?: ThresholdConditionCombinator;
+  /**
+   * Threshold alert builder only: alert conditions referencing STATS column labels.
+   * Not sent to the API — persisted via `evaluation.query.base`.
+   */
+  thresholdConditions?: ThresholdConditionRow[];
 }

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/utils/build_threshold_evaluation_query.test.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/utils/build_threshold_evaluation_query.test.ts
@@ -1,0 +1,131 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  buildThresholdEvaluationQuery,
+  escapeStatsFieldReference,
+  formatScheduleEveryToEsqlDuration,
+  formatThresholdFromClause,
+  THRESHOLD_BUILDER_DEFAULT_FROM,
+} from './build_threshold_evaluation_query';
+
+describe('formatScheduleEveryToEsqlDuration', () => {
+  it('maps short intervals to ES|QL duration literals', () => {
+    expect(formatScheduleEveryToEsqlDuration('5m')).toBe('5 minutes');
+    expect(formatScheduleEveryToEsqlDuration('1m')).toBe('1 minute');
+    expect(formatScheduleEveryToEsqlDuration('1h')).toBe('1 hour');
+    expect(formatScheduleEveryToEsqlDuration('30s')).toBe('30 seconds');
+  });
+
+  it('passes through values that already contain spaces', () => {
+    expect(formatScheduleEveryToEsqlDuration('5 minutes')).toBe('5 minutes');
+  });
+});
+
+describe('buildThresholdEvaluationQuery', () => {
+  it('returns a minimal query when there are no complete stat rows', () => {
+    expect(buildThresholdEvaluationQuery([], [])).toBe(
+      `${THRESHOLD_BUILDER_DEFAULT_FROM}\n| LIMIT 1`
+    );
+    expect(buildThresholdEvaluationQuery([{ label: '', aggregation: 'avg', field: 'x' }], [])).toBe(
+      `${THRESHOLD_BUILDER_DEFAULT_FROM}\n| LIMIT 1`
+    );
+  });
+
+  it('builds STATS with ES|QL alias = agg syntax and optional BY', () => {
+    const q = buildThresholdEvaluationQuery(
+      [
+        { label: 'avg_cpu', aggregation: 'avg', field: 'system.cpu.total.norm.pct' },
+        { label: 'max_mem', aggregation: 'max', field: 'system.memory.used.pct' },
+      ],
+      ['host.name']
+    );
+    expect(q).toContain('| STATS');
+    expect(q).toContain('avg_cpu = AVG(');
+    expect(q).toContain('max_mem = MAX(');
+    expect(q).toMatch(/,\n {8}max_mem = MAX/);
+    expect(q).toContain('\n    BY ');
+    expect(q).toContain(escapeStatsFieldReference('host.name'));
+  });
+
+  it('supports COUNT without a field using COUNT(*)', () => {
+    const q = buildThresholdEvaluationQuery(
+      [{ label: 'events', aggregation: 'count', field: '' }],
+      []
+    );
+    expect(q).toContain('events = COUNT(*)');
+  });
+
+  it('uses the selected data source in the FROM clause', () => {
+    const q = buildThresholdEvaluationQuery(
+      [{ label: 'events', aggregation: 'count', field: '' }],
+      [],
+      'metrics-system.cpu-default'
+    );
+    expect(q.startsWith('FROM metrics-system.cpu-default\n')).toBe(true);
+  });
+
+  it('defaults FROM to logs-* when data source is empty or omitted', () => {
+    expect(formatThresholdFromClause(undefined)).toBe(THRESHOLD_BUILDER_DEFAULT_FROM);
+    expect(formatThresholdFromClause('   ')).toBe(THRESHOLD_BUILDER_DEFAULT_FROM);
+  });
+
+  it('appends BY with BUCKET when time field and schedule every are provided', () => {
+    const q = buildThresholdEvaluationQuery(
+      [{ label: 'c', aggregation: 'count', field: '' }],
+      ['host.name'],
+      'metrics-system.cpu-default',
+      undefined,
+      undefined,
+      '@timestamp',
+      '5m'
+    );
+    expect(q).toContain('\n    BY ');
+    expect(q).toContain(escapeStatsFieldReference('host.name'));
+    expect(q).toContain('ts = BUCKET(');
+    expect(q).toContain(escapeStatsFieldReference('@timestamp'));
+    expect(q).toContain('5 minutes');
+  });
+
+  it('appends WHERE with AND when threshold conditions are set', () => {
+    const q = buildThresholdEvaluationQuery(
+      [
+        { label: 'avg_cpu', aggregation: 'avg', field: 'system.cpu.total.norm.pct' },
+        { label: 'max_mem', aggregation: 'max', field: 'system.memory.used.pct' },
+      ],
+      [],
+      'metrics-*',
+      [
+        { statLabel: 'avg_cpu', operator: 'gt', value: '0.8' },
+        { statLabel: 'max_mem', operator: 'gt', value: '0.9' },
+      ],
+      'and'
+    );
+    expect(q).toContain('\n| WHERE ');
+    expect(q).toContain('AND');
+    expect(q).toContain('avg_cpu > 0.8');
+    expect(q).toContain('max_mem > 0.9');
+  });
+
+  it('combines threshold conditions with OR when combinator is or', () => {
+    const q = buildThresholdEvaluationQuery(
+      [
+        { label: 'a', aggregation: 'count', field: '' },
+        { label: 'b', aggregation: 'count', field: '' },
+      ],
+      [],
+      undefined,
+      [
+        { statLabel: 'a', operator: 'lt', value: '1' },
+        { statLabel: 'b', operator: 'eq', value: '2' },
+      ],
+      'or'
+    );
+    expect(q).toContain('\n| WHERE ');
+    expect(q).toMatch(/a < 1 OR b == 2/);
+  });
+});

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/utils/build_threshold_evaluation_query.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/utils/build_threshold_evaluation_query.ts
@@ -1,0 +1,245 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type {
+  ThresholdConditionCombinator,
+  ThresholdConditionOperator,
+  ThresholdConditionRow,
+  ThresholdStatRow,
+} from '../types';
+
+/** Default index pattern when no data source is selected. */
+export const THRESHOLD_BUILDER_DEFAULT_FROM = 'FROM logs-*';
+
+/**
+ * Builds the `FROM …` clause for the threshold builder evaluation query.
+ */
+export const formatThresholdFromClause = (dataSource: string | undefined): string => {
+  const raw = dataSource?.trim();
+  if (!raw) {
+    return THRESHOLD_BUILDER_DEFAULT_FROM;
+  }
+  if (/^[a-zA-Z0-9_*.@-]+$/.test(raw)) {
+    return `FROM ${raw}`;
+  }
+  return `FROM \`${raw.replace(/`/g, '``')}\``;
+};
+
+/**
+ * Escapes a field reference for use inside STATS aggregate functions.
+ * Uses backticks so dotted metric names are valid identifiers.
+ */
+export const escapeStatsFieldReference = (field: string): string => {
+  const trimmed = field.trim();
+  if (!trimmed) {
+    return '*';
+  }
+  return `\`${trimmed.replace(/`/g, '``')}\``;
+};
+
+/** Maps a user stat label to the STATS column alias (left-hand side of `alias = agg(...)`). */
+export const sanitizeThresholdStatColumnAlias = (label: string): string => {
+  const trimmed = label.trim();
+  const sanitized = trimmed.replace(/[^a-zA-Z0-9_]/g, '_');
+  return sanitized.length > 0 ? sanitized : 'stat';
+};
+
+export const isCompleteThresholdStatRow = (row: ThresholdStatRow | undefined): boolean => {
+  if (!row) {
+    return false;
+  }
+  if (!(row.label ?? '').trim()) {
+    return false;
+  }
+  if (row.aggregation === 'count') {
+    return true;
+  }
+  return Boolean((row.field ?? '').trim());
+};
+
+const aggregationToEsql = (row: ThresholdStatRow): string | undefined => {
+  const { aggregation, field } = row;
+  const ref = escapeStatsFieldReference(field);
+
+  switch (aggregation) {
+    case 'avg':
+      return `AVG(${ref})`;
+    case 'max':
+      return `MAX(${ref})`;
+    case 'min':
+      return `MIN(${ref})`;
+    case 'sum':
+      return `SUM(${ref})`;
+    case 'p95':
+      return `PERCENTILE(${ref}, 95)`;
+    case 'p99':
+      return `PERCENTILE(${ref}, 99)`;
+    case 'count':
+      return field.trim() ? `COUNT(${ref})` : `COUNT(*)`;
+    case 'cardinality':
+      return `COUNT_DISTINCT(${ref})`;
+    default:
+      return undefined;
+  }
+};
+
+const operatorToEsql = (op: ThresholdConditionOperator): string => {
+  switch (op) {
+    case 'gt':
+      return '>';
+    case 'lt':
+      return '<';
+    case 'gte':
+      return '>=';
+    case 'lte':
+      return '<=';
+    case 'eq':
+      return '==';
+    case 'neq':
+      return '!=';
+    default:
+      return '>';
+  }
+};
+
+const formatThresholdConditionValue = (raw: string): string => {
+  const t = raw.trim();
+  if (t === '') {
+    return '0';
+  }
+  if (/^-?\d+(\.\d+)?([eE][+-]?\d+)?$/.test(t)) {
+    return t;
+  }
+  return `"${t.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+};
+
+const buildThresholdWhereClause = (
+  conditions: ThresholdConditionRow[] | undefined,
+  combinator: ThresholdConditionCombinator | undefined,
+  stats: ThresholdStatRow[] | undefined
+): string | undefined => {
+  const validColumns = new Set(
+    (stats ?? [])
+      .filter(isCompleteThresholdStatRow)
+      .map((r) => sanitizeThresholdStatColumnAlias(r.label))
+  );
+  const parts: string[] = [];
+  for (const c of conditions ?? []) {
+    const label = c.statLabel.trim();
+    const valueRaw = c.value.trim();
+    if (!label || !valueRaw) {
+      continue;
+    }
+    const col = sanitizeThresholdStatColumnAlias(label);
+    if (!validColumns.has(col)) {
+      continue;
+    }
+    const op = operatorToEsql(c.operator);
+    const rhs = formatThresholdConditionValue(valueRaw);
+    parts.push(`${col} ${op} ${rhs}`);
+  }
+  if (parts.length === 0) {
+    return undefined;
+  }
+  const joiner = combinator === 'or' ? ' OR ' : ' AND ';
+  return parts.join(joiner);
+};
+
+/**
+ * Maps short schedule intervals (for example `5m`, `1h`) to ES|QL duration literals for {@link BUCKET}.
+ */
+export const formatScheduleEveryToEsqlDuration = (every: string | undefined): string | undefined => {
+  const raw = every?.trim();
+  if (!raw) {
+    return undefined;
+  }
+  if (/\s/.test(raw)) {
+    return raw;
+  }
+  const m = raw.match(/^(\d+)(ms|s|m|h|d)$/i);
+  if (!m) {
+    return undefined;
+  }
+  const n = parseInt(m[1], 10);
+  const u = m[2].toLowerCase();
+  switch (u) {
+    case 'ms':
+      return `${n} millisecond${n === 1 ? '' : 's'}`;
+    case 's':
+      return `${n} second${n === 1 ? '' : 's'}`;
+    case 'm':
+      return `${n} minute${n === 1 ? '' : 's'}`;
+    case 'h':
+      return `${n} hour${n === 1 ? '' : 's'}`;
+    case 'd':
+      return `${n} day${n === 1 ? '' : 's'}`;
+    default:
+      return undefined;
+  }
+};
+
+/**
+ * Builds the evaluation ES|QL query for the threshold alert builder from stat rows and group fields.
+ * Incomplete rows are skipped. When nothing usable is defined, returns a minimal valid query.
+ *
+ * Output follows common ES|QL layout: `alias = AGG(field)` in STATS, optional multi-line clauses,
+ * `BY` including `BUCKET` on the time field when interval is known, and WHERE on stat aliases.
+ */
+export const buildThresholdEvaluationQuery = (
+  stats: ThresholdStatRow[] | undefined,
+  groupingFields: string[] | undefined,
+  dataSource?: string,
+  conditions?: ThresholdConditionRow[],
+  conditionCombinator?: ThresholdConditionCombinator,
+  timeField?: string,
+  scheduleEvery?: string
+): string => {
+  const fromClause = formatThresholdFromClause(dataSource);
+  const completeRows = (stats ?? []).filter(isCompleteThresholdStatRow);
+  const groups = (groupingFields ?? []).map((g) => g.trim()).filter(Boolean);
+
+  if (completeRows.length === 0) {
+    return `${fromClause}\n| LIMIT 1`;
+  }
+
+  const statClauses = completeRows
+    .map((row) => {
+      const expr = aggregationToEsql(row);
+      if (!expr) {
+        return undefined;
+      }
+      const alias = sanitizeThresholdStatColumnAlias(row.label);
+      return `${alias} = ${expr}`;
+    })
+    .filter((clause): clause is string => Boolean(clause));
+
+  if (statClauses.length === 0) {
+    return `${fromClause}\n| LIMIT 1`;
+  }
+
+  const statsSegment = `| STATS ${statClauses.join(',\n        ')}`;
+
+  const byParts: string[] = [];
+  for (const g of groups) {
+    byParts.push(escapeStatsFieldReference(g));
+  }
+
+  const bucketDuration = formatScheduleEveryToEsqlDuration(scheduleEvery);
+  const tf = timeField?.trim();
+  if (tf && bucketDuration) {
+    byParts.push(`ts = BUCKET(${escapeStatsFieldReference(tf)}, ${bucketDuration})`);
+  }
+
+  const bySegment = byParts.length > 0 ? `\n    BY ${byParts.join(', ')}` : '';
+
+  let query = `${fromClause}\n${statsSegment}${bySegment}`;
+  const whereClause = buildThresholdWhereClause(conditions, conditionCombinator, stats);
+  if (whereClause) {
+    query += `\n| WHERE ${whereClause}`;
+  }
+  return query;
+};

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/utils/yaml_form_utils.test.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/utils/yaml_form_utils.test.ts
@@ -9,6 +9,7 @@ import { dump } from 'js-yaml';
 import {
   formValuesToYamlObject,
   parseYamlToFormValues,
+  parseYamlToFormValuesForGuiSwitch,
   serializeFormToYaml,
 } from './yaml_form_utils';
 import { defaultTestFormValues } from '../../test_utils';
@@ -421,6 +422,49 @@ describe('yaml_form_utils', () => {
       expect(result.values?.stateTransition).toBeUndefined();
       expect(result.values?.stateTransitionAlertDelayMode).toBe('immediate');
       expect(result.values?.stateTransitionRecoveryDelayMode).toBe('immediate');
+    });
+  });
+
+  describe('parseYamlToFormValuesForGuiSwitch', () => {
+    it('uses fallback when name and query are blank in YAML', () => {
+      const fallback: FormValues = {
+        ...defaultTestFormValues,
+        metadata: { ...defaultTestFormValues.metadata, name: 'Kept Name' },
+        evaluation: { query: { base: 'FROM logs-* | LIMIT 10' } },
+      };
+      const yaml = dump({
+        kind: 'alert',
+        metadata: { name: '', enabled: true },
+        time_field: '@timestamp',
+        schedule: { every: '5m', lookback: '1m' },
+        evaluation: { query: { base: '' } },
+      });
+
+      const result = parseYamlToFormValuesForGuiSwitch(fallback, yaml);
+
+      expect(result.error).toBeNull();
+      expect(result.values?.metadata.name).toBe('Kept Name');
+      expect(result.values?.evaluation.query.base).toBe('FROM logs-* | LIMIT 10');
+    });
+
+    it('allows switching to GUI when metadata.name is blank in YAML and fallback', () => {
+      const fallback: FormValues = {
+        ...defaultTestFormValues,
+        metadata: { ...defaultTestFormValues.metadata, name: '' },
+        evaluation: { query: { base: 'FROM logs-* | LIMIT 10' } },
+      };
+      const yaml = dump({
+        kind: 'alert',
+        metadata: { name: '', enabled: true },
+        time_field: '@timestamp',
+        schedule: { every: '5m', lookback: '1m' },
+        evaluation: { query: { base: 'FROM logs-* | LIMIT 10' } },
+      });
+
+      const result = parseYamlToFormValuesForGuiSwitch(fallback, yaml);
+
+      expect(result.error).toBeNull();
+      expect(result.values?.metadata.name).toBe('');
     });
   });
 

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/utils/yaml_form_utils.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/utils/yaml_form_utils.ts
@@ -192,6 +192,136 @@ export const parseYamlToFormValues = (yamlString: string): YamlParseResult => {
 };
 
 /**
+ * Parses YAML when switching from the YAML editor back to the GUI. If
+ * `evaluation.query.base` is missing or blank in the YAML, the value from
+ * `fallback` is used. `metadata.name` may be blank; it is not required for
+ * this switch. Content from {@link serializeFormToYaml} (including empty
+ * strings) still round-trips while preserving builder-only fields via the
+ * subsequent merge with current form state.
+ */
+export const parseYamlToFormValuesForGuiSwitch = (
+  fallback: FormValues,
+  yamlString: string
+): YamlParseResult => {
+  let parsed: unknown;
+  try {
+    parsed = load(yamlString);
+  } catch (error) {
+    return {
+      values: null,
+      error: i18n.translate('xpack.alertingV2.yamlRuleForm.yamlSyntaxError', {
+        defaultMessage: 'Invalid YAML syntax.',
+      }),
+    };
+  }
+
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return {
+      values: null,
+      error: i18n.translate('xpack.alertingV2.yamlRuleForm.yamlObjectError', {
+        defaultMessage: 'YAML must be an object.',
+      }),
+    };
+  }
+
+  const obj = parsed as Record<string, unknown>;
+  const metadata = obj.metadata as Record<string, unknown> | undefined;
+  const schedule = obj.schedule as Record<string, unknown> | undefined;
+  const evaluation = obj.evaluation as Record<string, unknown> | undefined;
+  const evalQuery = evaluation?.query as Record<string, unknown> | undefined;
+  const grouping = obj.grouping as Record<string, unknown> | undefined;
+  const artifacts = parseArtifacts(obj.artifacts);
+  const stateTransitionObj = obj.state_transition as Record<string, unknown> | undefined;
+  const stateTransition: StateTransition | undefined = stateTransitionObj
+    ? {
+        pendingCount:
+          typeof stateTransitionObj.pending_count === 'number'
+            ? stateTransitionObj.pending_count
+            : null,
+        pendingTimeframe:
+          typeof stateTransitionObj.pending_timeframe === 'string'
+            ? stateTransitionObj.pending_timeframe
+            : null,
+        recoveringCount:
+          typeof stateTransitionObj.recovering_count === 'number'
+            ? stateTransitionObj.recovering_count
+            : null,
+        recoveringTimeframe:
+          typeof stateTransitionObj.recovering_timeframe === 'string'
+            ? stateTransitionObj.recovering_timeframe
+            : null,
+      }
+    : undefined;
+
+  const kind = obj.kind;
+  if (kind !== undefined && kind !== 'alert' && kind !== 'signal') {
+    return {
+      values: null,
+      error: i18n.translate('xpack.alertingV2.yamlRuleForm.invalidKindError', {
+        defaultMessage: 'Kind must be "alert" or "signal".',
+      }),
+    };
+  }
+
+  const nameFromYaml = typeof metadata?.name === 'string' ? metadata.name.trim() : '';
+  const nameFromFallback = typeof fallback.metadata.name === 'string'
+    ? fallback.metadata.name.trim()
+    : '';
+  const resolvedName = nameFromYaml || nameFromFallback;
+
+  const queryFromYaml = typeof evalQuery?.base === 'string' ? evalQuery.base.trim() : '';
+  const queryFromFallback = fallback.evaluation.query.base.trim();
+  const resolvedQueryBase = queryFromYaml || queryFromFallback;
+  if (!resolvedQueryBase) {
+    return {
+      values: null,
+      error: i18n.translate('xpack.alertingV2.yamlRuleForm.queryRequiredError', {
+        defaultMessage: 'evaluation.query.base is required.',
+      }),
+    };
+  }
+
+  const queryValidationError = validateEsqlQuery(resolvedQueryBase);
+  if (queryValidationError) {
+    return {
+      values: null,
+      error: queryValidationError,
+    };
+  }
+
+  return {
+    values: {
+      kind: (kind as 'alert' | 'signal') ?? 'alert',
+      metadata: {
+        name: resolvedName,
+        enabled: metadata?.enabled !== false,
+        description: typeof metadata?.description === 'string' ? metadata.description : undefined,
+        owner: typeof metadata?.owner === 'string' ? metadata.owner : undefined,
+        tags: Array.isArray(metadata?.tags) ? (metadata.tags as string[]) : undefined,
+      },
+      timeField: typeof obj.time_field === 'string' ? obj.time_field : '@timestamp',
+      schedule: {
+        every: typeof schedule?.every === 'string' ? schedule.every : '5m',
+        lookback: typeof schedule?.lookback === 'string' ? schedule.lookback : '1m',
+      },
+      evaluation: {
+        query: {
+          base: resolvedQueryBase,
+        },
+      },
+      grouping: Array.isArray(grouping?.fields)
+        ? { fields: grouping.fields as string[] }
+        : undefined,
+      artifacts,
+      stateTransition,
+      stateTransitionAlertDelayMode: deriveAlertDelayModeFromStateTransition(stateTransition),
+      stateTransitionRecoveryDelayMode: deriveRecoveryDelayModeFromStateTransition(stateTransition),
+    },
+    error: null,
+  };
+};
+
+/**
  * Serialize current form values to YAML string
  */
 export const serializeFormToYaml = (values: FormValues): string => {

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/yaml_rule_form.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/yaml_rule_form.tsx
@@ -29,6 +29,11 @@ export interface YamlRuleFormProps {
   onSubmit: (values: FormValues) => void;
   isDisabled?: boolean;
   isSubmitting?: boolean;
+  /**
+   * When both are set, YAML content is controlled by the parent (for example Form/YAML mode toggle).
+   */
+  yaml?: string;
+  onYamlChange?: (yaml: string) => void;
 }
 
 /**
@@ -42,12 +47,18 @@ export const YamlRuleForm = ({
   onSubmit,
   isDisabled = false,
   isSubmitting = false,
+  yaml: controlledYaml,
+  onYamlChange,
 }: YamlRuleFormProps) => {
   const { getValues } = useFormContext<FormValues>();
-  const [yaml, setYaml] = useState<string>(() => {
+  const [internalYaml, setInternalYaml] = useState<string>(() => {
     const values = getValues();
     return serializeFormToYaml(values);
   });
+  const isControlled =
+    typeof controlledYaml === 'string' && typeof onYamlChange === 'function';
+  const yaml = isControlled ? controlledYaml : internalYaml;
+  const setYaml = isControlled ? onYamlChange : setInternalYaml;
   const [error, setError] = useState<string | null>(null);
 
   const esqlCallbacks = useEsqlCallbacks({
@@ -74,11 +85,13 @@ export const YamlRuleForm = ({
     [yaml, onSubmit]
   );
 
-  const handleYamlChange = useCallback((newYaml: string) => {
-    setYaml(newYaml);
-    // Clear error when user starts editing
-    setError(null);
-  }, []);
+  const handleYamlChange = useCallback(
+    (newYaml: string) => {
+      setYaml(newYaml);
+      setError(null);
+    },
+    [setYaml]
+  );
 
   const isReadOnly = isDisabled || isSubmitting;
 

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/index.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/index.ts
@@ -17,6 +17,7 @@ export {
 
 // Constants
 export { RULE_FORM_ID, DEFAULT_RULE_NAME } from './form/constants';
+export { DEFAULT_THRESHOLD_DATA_SOURCE, THRESHOLD_DATA_SOURCE_CHOICES } from './form';
 
 // Form components (lazy loaded) - for embedding in custom forms
 export { DynamicRuleForm, StandaloneRuleForm } from './form';
@@ -41,6 +42,11 @@ export {
 export type {
   FormValues,
   StateTransitionDelayMode,
+  ThresholdAggregation,
+  ThresholdStatRow,
+  ThresholdConditionCombinator,
+  ThresholdConditionOperator,
+  ThresholdConditionRow,
   DynamicRuleFormProps,
   StandaloneRuleFormProps,
   RuleFormServices,

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/index.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/index.ts
@@ -52,6 +52,7 @@ export type {
   RuleFormServices,
   RuleFormMeta,
   RuleFormLayout,
+  RuleBuilderCatalogEntry,
   RuleRequestCommon,
 } from './form';
 

--- a/x-pack/platform/plugins/shared/alerting_v2/kibana.jsonc
+++ b/x-pack/platform/plugins/shared/alerting_v2/kibana.jsonc
@@ -29,7 +29,7 @@
       "kibanaUtils",
       "share"
     ],
-    "optionalPlugins": ["usageCollection"],
+    "optionalPlugins": ["usageCollection", "agentBuilder"],
     "requiredBundles": ["alerting", "kibanaReact"],
     "extraPublicDirs": []
   }

--- a/x-pack/platform/plugins/shared/alerting_v2/public/application/rules_app.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/application/rules_app.tsx
@@ -8,6 +8,7 @@
 import React from 'react';
 import { Route, Routes } from '@kbn/shared-ux-router';
 import { RuleFormPage } from '../pages/rule_form_page/rule_form_page';
+import { RuleCreateHubPage } from '../pages/rule_create_hub_page/rule_create_hub_page';
 import { RulesListPage } from '../pages/rules_list_page/rules_list_page';
 import { RuleDetailsRoute } from '../routes/rule_details_route';
 
@@ -17,8 +18,11 @@ export const RulesApp = () => {
       <Route path="/edit/:id">
         <RuleFormPage />
       </Route>
-      <Route path="/create">
+      <Route path="/create/form">
         <RuleFormPage />
+      </Route>
+      <Route path="/create">
+        <RuleCreateHubPage />
       </Route>
       <Route exact path="/:ruleId">
         <RuleDetailsRoute />

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/rule_details_actions_menu.test.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/rule_details_actions_menu.test.tsx
@@ -91,7 +91,7 @@ describe('RuleDetailsActionsMenu', () => {
     fireEvent.click(screen.getByTestId('ruleDetailsActionsButton'));
     fireEvent.click(screen.getByTestId('ruleDetailsCloneButton'));
     expect(mockNavigateToUrl).toHaveBeenCalledWith(
-      '/app/management/alertingV2/rules/create?cloneFrom=rule-1'
+      '/app/management/alertingV2/rules/create/form?cloneFrom=rule-1'
     );
   });
 

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/rule_details_actions_menu.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/rule_details_actions_menu.tsx
@@ -37,7 +37,9 @@ export const RuleDetailsActionsMenu: React.FunctionComponent<RuleDetailsActionsM
 
   const handleClone = () => {
     setIsPopoverOpen(false);
-    navigateToUrl(basePath.prepend(`${paths.ruleCreate}?cloneFrom=${encodeURIComponent(rule.id)}`));
+    navigateToUrl(
+      basePath.prepend(`${paths.ruleCreateForm}?cloneFrom=${encodeURIComponent(rule.id)}`)
+    );
   };
 
   const handleDelete = () => {

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_evaluation_esql_header_actions.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_evaluation_esql_header_actions.tsx
@@ -6,28 +6,8 @@
  */
 
 import React, { useMemo, useState } from 'react';
-import {
-  EuiButton,
-  EuiButtonEmpty,
-  EuiButtonGroup,
-  EuiCallOut,
-  EuiConfirmModal,
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiLink,
-  EuiModal,
-  EuiModalBody,
-  EuiModalFooter,
-  EuiModalHeader,
-  EuiModalHeaderTitle,
-  EuiSpacer,
-} from '@elastic/eui';
-import type { IconType } from '@elastic/eui';
+import { EuiButtonGroup, EuiConfirmModal, EuiFlexGroup, EuiFlexItem, EuiSpacer } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import { FormattedMessage } from '@kbn/i18n-react';
-import { paths } from '../constants';
-import { RuleBuilderGrid } from '../rule_builders/rule_builder_grid';
-import type { RuleBuilderId } from '../rule_builders/rule_builder_definitions';
 
 /** Remember which builder to return to when toggling ES|QL → builder. */
 export const RULE_EVALUATION_LAST_BUILDER_SESSION_KEY =
@@ -38,35 +18,16 @@ export const RULE_EVALUATION_DEFAULT_BUILDER_ID = 'threshold_alert';
 export interface RuleEvaluationEsqlHeaderActionsProps {
   /** Current mode shown in the rule evaluation header. */
   selectedMode: 'esql' | 'builder';
-  /** Switches to ES|QL after any confirmation handled here. */
+  /** Switches to ES|QL after any confirmation handled here, or to guided builder. */
   onChange: (next: 'esql' | 'builder') => void;
-  /** Switches to guided builder with the chosen builder id (from the picker modal). */
-  onPickBuilder: (builderId: string) => void;
-  /** Icon for the guided builder action (matches the active or last builder). */
-  builderIconType: IconType;
-  basePath: { prepend: (path: string) => string };
-  showAgentBuilderButton?: boolean;
-  onOpenAgentBuilder?: () => void;
 }
 
 export const RuleEvaluationEsqlHeaderActions = ({
   selectedMode,
   onChange,
-  onPickBuilder,
-  builderIconType,
-  basePath,
-  showAgentBuilderButton,
-  onOpenAgentBuilder,
 }: RuleEvaluationEsqlHeaderActionsProps) => {
-  const [isBuilderPickerOpen, setIsBuilderPickerOpen] = useState(false);
   const [isEsqlSwitchConfirmOpen, setIsEsqlSwitchConfirmOpen] = useState(false);
-
-  const useGuidedBuilderLabel = i18n.translate(
-    'xpack.alertingV2.ruleForm.ruleConfigurationMode.useGuidedBuilder',
-    {
-      defaultMessage: 'Use guided builder',
-    }
-  );
+  const [isBuilderSwitchConfirmOpen, setIsBuilderSwitchConfirmOpen] = useState(false);
 
   const toggleLegend = i18n.translate('xpack.alertingV2.ruleForm.ruleConfigurationMode.legend', {
     defaultMessage: 'Rule configuration: guided builder or ES|QL',
@@ -83,22 +44,36 @@ export const RuleEvaluationEsqlHeaderActions = ({
     }
   );
 
+  const builderTooltip = i18n.translate(
+    'xpack.alertingV2.ruleForm.ruleConfigurationMode.builderTooltip',
+    {
+      defaultMessage:
+        'Guided builder: configure the rule with structured fields and controls instead of raw ES|QL.',
+    }
+  );
+
+  const esqlTooltip = i18n.translate('xpack.alertingV2.ruleForm.ruleConfigurationMode.esqlTooltip', {
+    defaultMessage: 'ES|QL: edit the evaluation query directly with the ES|QL editor.',
+  });
+
   const modeToggleButtons = useMemo(
     () => [
       {
         id: 'builder',
         label: builderAria,
-        iconType: builderIconType,
+        iconType: 'dashboardApp' as const,
         'data-test-subj': 'ruleEvaluationModeBuilder',
+        toolTipContent: builderTooltip,
       },
       {
         id: 'esql',
         label: esqlAria,
         iconType: 'editorCodeBlock' as const,
         'data-test-subj': 'ruleEvaluationModeEsql',
+        toolTipContent: esqlTooltip,
       },
     ],
-    [builderAria, builderIconType, esqlAria]
+    [builderAria, builderTooltip, esqlAria, esqlTooltip]
   );
 
   const handleButtonGroupChange = (optionId: string) => {
@@ -110,7 +85,10 @@ export const RuleEvaluationEsqlHeaderActions = ({
       setIsEsqlSwitchConfirmOpen(true);
       return;
     }
-    onChange(next);
+    if (next === 'builder') {
+      setIsBuilderSwitchConfirmOpen(true);
+      return;
+    }
   };
 
   const confirmSwitchToEsql = () => {
@@ -122,19 +100,14 @@ export const RuleEvaluationEsqlHeaderActions = ({
     setIsEsqlSwitchConfirmOpen(false);
   };
 
-  const handlePickBuilderFromModal = (id: RuleBuilderId) => {
-    setIsBuilderPickerOpen(false);
-    onPickBuilder(id);
+  const confirmSwitchToBuilder = () => {
+    setIsBuilderSwitchConfirmOpen(false);
+    onChange('builder');
   };
 
-  const hubHref = basePath.prepend(paths.ruleCreate);
-
-  const builderPickerTitle = i18n.translate(
-    'xpack.alertingV2.ruleForm.ruleConfigurationMode.builderPickerTitle',
-    {
-      defaultMessage: 'Choose a rule builder',
-    }
-  );
+  const cancelSwitchToBuilder = () => {
+    setIsBuilderSwitchConfirmOpen(false);
+  };
 
   const esqlSwitchTitle = i18n.translate(
     'xpack.alertingV2.ruleForm.ruleConfigurationMode.switchToEsqlTitle',
@@ -157,80 +130,43 @@ export const RuleEvaluationEsqlHeaderActions = ({
     }
   );
 
-  if (selectedMode === 'esql') {
-    return (
-      <>
-        <EuiButton
-          size="s"
-          fill={false}
-          color="text"
-          onClick={() => setIsBuilderPickerOpen(true)}
-          data-test-subj="ruleEvaluationUseGuidedBuilder"
-        >
-          {useGuidedBuilderLabel}
-        </EuiButton>
+  const switchModeSharedExplanation = i18n.translate(
+    'xpack.alertingV2.ruleForm.ruleConfigurationMode.switchModeSharedExplanation',
+    {
+      defaultMessage:
+        'We will try to carry over all relevant data when you switch. Some fields you already selected may not transfer and could be reset.',
+    }
+  );
 
-        {isBuilderPickerOpen ? (
-          <EuiModal
-            onClose={() => setIsBuilderPickerOpen(false)}
-            style={{ width: 880, maxWidth: '90vw' }}
-          >
-            <EuiModalHeader>
-              <EuiModalHeaderTitle>{builderPickerTitle}</EuiModalHeaderTitle>
-            </EuiModalHeader>
-            <EuiModalBody>
-              <RuleBuilderGrid variant="all" onSelectBuilder={handlePickBuilderFromModal} />
-              <EuiSpacer size="m" />
-              <EuiFlexGroup
-                alignItems="center"
-                justifyContent="spaceBetween"
-                wrap
-                responsive={false}
-              >
-                <EuiFlexItem grow={false}>
-                  <EuiLink href={hubHref} data-test-subj="ruleEvaluationBuilderPickerHubLink">
-                    <FormattedMessage
-                      id="xpack.alertingV2.ruleForm.ruleConfigurationMode.viewCreateHub"
-                      defaultMessage="Open create hub (all options)"
-                    />
-                  </EuiLink>
-                </EuiFlexItem>
-                {showAgentBuilderButton && onOpenAgentBuilder ? (
-                  <EuiFlexItem grow={false}>
-                    <EuiButton
-                      size="s"
-                      color="text"
-                      iconType="productAgent"
-                      data-test-subj="ruleEvaluationBuilderPickerAgentButton"
-                      onClick={() => {
-                        setIsBuilderPickerOpen(false);
-                        onOpenAgentBuilder();
-                      }}
-                    >
-                      <FormattedMessage
-                        id="xpack.alertingV2.ruleForm.ruleConfigurationMode.askAiAgent"
-                        defaultMessage="Ask AI Agent"
-                      />
-                    </EuiButton>
-                  </EuiFlexItem>
-                ) : null}
-              </EuiFlexGroup>
-            </EuiModalBody>
-            <EuiModalFooter>
-              <EuiButtonEmpty onClick={() => setIsBuilderPickerOpen(false)}>
-                {i18n.translate(
-                  'xpack.alertingV2.ruleForm.ruleConfigurationMode.builderPickerClose',
-                  {
-                    defaultMessage: 'Close',
-                  }
-                )}
-              </EuiButtonEmpty>
-            </EuiModalFooter>
-          </EuiModal>
-        ) : null}
-      </>
-    );
-  }
+  const switchToEsqlSupplement = i18n.translate(
+    'xpack.alertingV2.ruleForm.ruleConfigurationMode.switchToEsqlSupplement',
+    {
+      defaultMessage:
+        'After switching, raw ES|QL can be harder to map back to the guided builder. Continue only if you intend to edit the query directly.',
+    }
+  );
+
+  const builderSwitchTitle = i18n.translate(
+    'xpack.alertingV2.ruleForm.ruleConfigurationMode.switchToBuilderTitle',
+    {
+      defaultMessage: 'Switch to guided builder?',
+    }
+  );
+
+  const switchToBuilderSupplement = i18n.translate(
+    'xpack.alertingV2.ruleForm.ruleConfigurationMode.switchToBuilderSupplement',
+    {
+      defaultMessage:
+        'The guided builder may reorganize or replace parts of your ES|QL query into structured steps.',
+    }
+  );
+
+  const builderSwitchConfirm = i18n.translate(
+    'xpack.alertingV2.ruleForm.ruleConfigurationMode.switchToBuilderConfirm',
+    {
+      defaultMessage: 'Switch to guided builder',
+    }
+  );
 
   return (
     <>
@@ -260,26 +196,26 @@ export const RuleEvaluationEsqlHeaderActions = ({
           buttonColor="warning"
           data-test-subj="ruleEvaluationSwitchToEsqlConfirm"
         >
-          <EuiCallOut
-            color="warning"
-            title={i18n.translate(
-              'xpack.alertingV2.ruleForm.ruleConfigurationMode.switchToEsqlCalloutTitle',
-              {
-                defaultMessage: 'You may not be able to return to the guided builder',
-              }
-            )}
-            iconType="alert"
-          >
-            <p>
-              {i18n.translate(
-                'xpack.alertingV2.ruleForm.ruleConfigurationMode.switchToEsqlCalloutBody',
-                {
-                  defaultMessage:
-                    'Switching to ES|QL replaces the guided builder for this section. Values you entered only in the builder may be lost, and raw ES|QL can be harder to map back to the builder. Continue only if you intend to edit the query directly.',
-                }
-              )}
-            </p>
-          </EuiCallOut>
+          <p>{switchModeSharedExplanation}</p>
+          <EuiSpacer size="s" />
+          <p>{switchToEsqlSupplement}</p>
+        </EuiConfirmModal>
+      ) : null}
+
+      {isBuilderSwitchConfirmOpen ? (
+        <EuiConfirmModal
+          title={builderSwitchTitle}
+          onCancel={cancelSwitchToBuilder}
+          onConfirm={confirmSwitchToBuilder}
+          cancelButtonText={esqlSwitchCancel}
+          confirmButtonText={builderSwitchConfirm}
+          defaultFocusedButton="cancel"
+          buttonColor="warning"
+          data-test-subj="ruleEvaluationSwitchToBuilderConfirm"
+        >
+          <p>{switchModeSharedExplanation}</p>
+          <EuiSpacer size="s" />
+          <p>{switchToBuilderSupplement}</p>
         </EuiConfirmModal>
       ) : null}
     </>

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_evaluation_esql_header_actions.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_evaluation_esql_header_actions.tsx
@@ -1,0 +1,287 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useMemo, useState } from 'react';
+import {
+  EuiButton,
+  EuiButtonEmpty,
+  EuiButtonGroup,
+  EuiCallOut,
+  EuiConfirmModal,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiLink,
+  EuiModal,
+  EuiModalBody,
+  EuiModalFooter,
+  EuiModalHeader,
+  EuiModalHeaderTitle,
+  EuiSpacer,
+} from '@elastic/eui';
+import type { IconType } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n-react';
+import { paths } from '../constants';
+import { RuleBuilderGrid } from '../rule_builders/rule_builder_grid';
+import type { RuleBuilderId } from '../rule_builders/rule_builder_definitions';
+
+/** Remember which builder to return to when toggling ES|QL → builder. */
+export const RULE_EVALUATION_LAST_BUILDER_SESSION_KEY =
+  'alerting-v2.ruleForm.lastEvaluationBuilderId';
+
+export const RULE_EVALUATION_DEFAULT_BUILDER_ID = 'threshold_alert';
+
+export interface RuleEvaluationEsqlHeaderActionsProps {
+  /** Current mode shown in the rule evaluation header. */
+  selectedMode: 'esql' | 'builder';
+  /** Switches to ES|QL after any confirmation handled here. */
+  onChange: (next: 'esql' | 'builder') => void;
+  /** Switches to guided builder with the chosen builder id (from the picker modal). */
+  onPickBuilder: (builderId: string) => void;
+  /** Icon for the guided builder action (matches the active or last builder). */
+  builderIconType: IconType;
+  basePath: { prepend: (path: string) => string };
+  showAgentBuilderButton?: boolean;
+  onOpenAgentBuilder?: () => void;
+}
+
+export const RuleEvaluationEsqlHeaderActions = ({
+  selectedMode,
+  onChange,
+  onPickBuilder,
+  builderIconType,
+  basePath,
+  showAgentBuilderButton,
+  onOpenAgentBuilder,
+}: RuleEvaluationEsqlHeaderActionsProps) => {
+  const [isBuilderPickerOpen, setIsBuilderPickerOpen] = useState(false);
+  const [isEsqlSwitchConfirmOpen, setIsEsqlSwitchConfirmOpen] = useState(false);
+
+  const useGuidedBuilderLabel = i18n.translate(
+    'xpack.alertingV2.ruleForm.ruleConfigurationMode.useGuidedBuilder',
+    {
+      defaultMessage: 'Use guided builder',
+    }
+  );
+
+  const toggleLegend = i18n.translate('xpack.alertingV2.ruleForm.ruleConfigurationMode.legend', {
+    defaultMessage: 'Rule configuration: guided builder or ES|QL',
+  });
+
+  const esqlAria = i18n.translate('xpack.alertingV2.ruleForm.ruleConfigurationMode.esqlAria', {
+    defaultMessage: 'ES|QL editor',
+  });
+
+  const builderAria = i18n.translate(
+    'xpack.alertingV2.ruleForm.ruleConfigurationMode.builderAria',
+    {
+      defaultMessage: 'Guided builder',
+    }
+  );
+
+  const modeToggleButtons = useMemo(
+    () => [
+      {
+        id: 'builder',
+        label: builderAria,
+        iconType: builderIconType,
+        'data-test-subj': 'ruleEvaluationModeBuilder',
+      },
+      {
+        id: 'esql',
+        label: esqlAria,
+        iconType: 'editorCodeBlock' as const,
+        'data-test-subj': 'ruleEvaluationModeEsql',
+      },
+    ],
+    [builderAria, builderIconType, esqlAria]
+  );
+
+  const handleButtonGroupChange = (optionId: string) => {
+    const next = optionId as 'esql' | 'builder';
+    if (next === selectedMode) {
+      return;
+    }
+    if (next === 'esql') {
+      setIsEsqlSwitchConfirmOpen(true);
+      return;
+    }
+    onChange(next);
+  };
+
+  const confirmSwitchToEsql = () => {
+    setIsEsqlSwitchConfirmOpen(false);
+    onChange('esql');
+  };
+
+  const cancelSwitchToEsql = () => {
+    setIsEsqlSwitchConfirmOpen(false);
+  };
+
+  const handlePickBuilderFromModal = (id: RuleBuilderId) => {
+    setIsBuilderPickerOpen(false);
+    onPickBuilder(id);
+  };
+
+  const hubHref = basePath.prepend(paths.ruleCreate);
+
+  const builderPickerTitle = i18n.translate(
+    'xpack.alertingV2.ruleForm.ruleConfigurationMode.builderPickerTitle',
+    {
+      defaultMessage: 'Choose a rule builder',
+    }
+  );
+
+  const esqlSwitchTitle = i18n.translate(
+    'xpack.alertingV2.ruleForm.ruleConfigurationMode.switchToEsqlTitle',
+    {
+      defaultMessage: 'Switch to ES|QL?',
+    }
+  );
+
+  const esqlSwitchConfirm = i18n.translate(
+    'xpack.alertingV2.ruleForm.ruleConfigurationMode.switchToEsqlConfirm',
+    {
+      defaultMessage: 'Switch to ES|QL',
+    }
+  );
+
+  const esqlSwitchCancel = i18n.translate(
+    'xpack.alertingV2.ruleForm.ruleConfigurationMode.switchToEsqlCancel',
+    {
+      defaultMessage: 'Cancel',
+    }
+  );
+
+  if (selectedMode === 'esql') {
+    return (
+      <>
+        <EuiButton
+          size="s"
+          fill={false}
+          color="text"
+          onClick={() => setIsBuilderPickerOpen(true)}
+          data-test-subj="ruleEvaluationUseGuidedBuilder"
+        >
+          {useGuidedBuilderLabel}
+        </EuiButton>
+
+        {isBuilderPickerOpen ? (
+          <EuiModal
+            onClose={() => setIsBuilderPickerOpen(false)}
+            style={{ width: 880, maxWidth: '90vw' }}
+          >
+            <EuiModalHeader>
+              <EuiModalHeaderTitle>{builderPickerTitle}</EuiModalHeaderTitle>
+            </EuiModalHeader>
+            <EuiModalBody>
+              <RuleBuilderGrid variant="all" onSelectBuilder={handlePickBuilderFromModal} />
+              <EuiSpacer size="m" />
+              <EuiFlexGroup
+                alignItems="center"
+                justifyContent="spaceBetween"
+                wrap
+                responsive={false}
+              >
+                <EuiFlexItem grow={false}>
+                  <EuiLink href={hubHref} data-test-subj="ruleEvaluationBuilderPickerHubLink">
+                    <FormattedMessage
+                      id="xpack.alertingV2.ruleForm.ruleConfigurationMode.viewCreateHub"
+                      defaultMessage="Open create hub (all options)"
+                    />
+                  </EuiLink>
+                </EuiFlexItem>
+                {showAgentBuilderButton && onOpenAgentBuilder ? (
+                  <EuiFlexItem grow={false}>
+                    <EuiButton
+                      size="s"
+                      color="text"
+                      iconType="productAgent"
+                      data-test-subj="ruleEvaluationBuilderPickerAgentButton"
+                      onClick={() => {
+                        setIsBuilderPickerOpen(false);
+                        onOpenAgentBuilder();
+                      }}
+                    >
+                      <FormattedMessage
+                        id="xpack.alertingV2.ruleForm.ruleConfigurationMode.askAiAgent"
+                        defaultMessage="Ask AI Agent"
+                      />
+                    </EuiButton>
+                  </EuiFlexItem>
+                ) : null}
+              </EuiFlexGroup>
+            </EuiModalBody>
+            <EuiModalFooter>
+              <EuiButtonEmpty onClick={() => setIsBuilderPickerOpen(false)}>
+                {i18n.translate(
+                  'xpack.alertingV2.ruleForm.ruleConfigurationMode.builderPickerClose',
+                  {
+                    defaultMessage: 'Close',
+                  }
+                )}
+              </EuiButtonEmpty>
+            </EuiModalFooter>
+          </EuiModal>
+        ) : null}
+      </>
+    );
+  }
+
+  return (
+    <>
+      <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false} justifyContent="flexEnd">
+        <EuiFlexItem grow={false}>
+          <EuiButtonGroup
+            legend={toggleLegend}
+            options={modeToggleButtons}
+            idSelected={selectedMode}
+            onChange={handleButtonGroupChange}
+            buttonSize="compressed"
+            isIconOnly
+            isFullWidth={false}
+            data-test-subj="ruleEvaluationModeToggle"
+          />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+
+      {isEsqlSwitchConfirmOpen ? (
+        <EuiConfirmModal
+          title={esqlSwitchTitle}
+          onCancel={cancelSwitchToEsql}
+          onConfirm={confirmSwitchToEsql}
+          cancelButtonText={esqlSwitchCancel}
+          confirmButtonText={esqlSwitchConfirm}
+          defaultFocusedButton="cancel"
+          buttonColor="warning"
+          data-test-subj="ruleEvaluationSwitchToEsqlConfirm"
+        >
+          <EuiCallOut
+            color="warning"
+            title={i18n.translate(
+              'xpack.alertingV2.ruleForm.ruleConfigurationMode.switchToEsqlCalloutTitle',
+              {
+                defaultMessage: 'You may not be able to return to the guided builder',
+              }
+            )}
+            iconType="alert"
+          >
+            <p>
+              {i18n.translate(
+                'xpack.alertingV2.ruleForm.ruleConfigurationMode.switchToEsqlCalloutBody',
+                {
+                  defaultMessage:
+                    'Switching to ES|QL replaces the guided builder for this section. Values you entered only in the builder may be lost, and raw ES|QL can be harder to map back to the builder. Continue only if you intend to edit the query directly.',
+                }
+              )}
+            </p>
+          </EuiCallOut>
+        </EuiConfirmModal>
+      ) : null}
+    </>
+  );
+};

--- a/x-pack/platform/plugins/shared/alerting_v2/public/constants.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/constants.ts
@@ -25,7 +25,12 @@ export {
 } from '@kbn/alerting-v2-constants';
 
 export const paths = {
+  /** Choose rule builder (hub); then user continues to {@link ruleCreateForm}. */
   ruleCreate: `${ALERTING_V2_RULES_BASE_PATH}/create`,
+  /** Alerting V2 rule form (create, clone, or builder deep link). Edit uses {@link ruleEdit}. */
+  ruleCreateForm: `${ALERTING_V2_RULES_BASE_PATH}/create/form`,
+  /** Create-rule form with ES|QL-focused deep link (skips builder presets). */
+  ruleCreateFormEsqlAdvanced: `${ALERTING_V2_RULES_BASE_PATH}/create/form?mode=esql`,
   ruleEdit: (id: string) => `${ALERTING_V2_RULES_BASE_PATH}/edit/${encodeURIComponent(id)}`,
   ruleDetails: (id: string) => `${ALERTING_V2_RULES_BASE_PATH}/${encodeURIComponent(id)}`,
   ruleList: ALERTING_V2_RULES_BASE_PATH,
@@ -37,3 +42,7 @@ export const paths = {
   alertEpisodeDetails: (episodeId: string) =>
     `${ALERTING_V2_EPISODES_BASE_PATH}/${encodeURIComponent(episodeId)}`,
 };
+
+/** Stack alerting overview (create and manage rules). Mirrors DocLinks.links.alerting.guide. */
+export const ALERTING_RULES_GUIDE_DOC_URL =
+  'https://www.elastic.co/docs/explore-analyze/alerts-cases/alerts/create-manage-rules';

--- a/x-pack/platform/plugins/shared/alerting_v2/public/hooks/use_breadcrumbs.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/hooks/use_breadcrumbs.test.ts
@@ -47,6 +47,19 @@ describe('useBreadcrumbs', () => {
     expect(breadcrumbs[1]).toMatchObject({ text: 'Rules' });
   });
 
+  it('should set breadcrumbs for the create hub page with root and list link', () => {
+    renderHook(() => useBreadcrumbs('create_hub'));
+
+    const breadcrumbs = mockSetBreadcrumbs.mock.calls[0][0];
+    expect(breadcrumbs).toHaveLength(3);
+    expect(breadcrumbs[0]).toMatchObject({ text: 'Alerting V2' });
+    expect(breadcrumbs[1]).toMatchObject({
+      text: 'Rules',
+      href: '/',
+    });
+    expect(breadcrumbs[2]).toMatchObject({ text: 'Create rule' });
+  });
+
   it('should set breadcrumbs for the create page with root and list link', () => {
     renderHook(() => useBreadcrumbs('create'));
 

--- a/x-pack/platform/plugins/shared/alerting_v2/public/hooks/use_breadcrumbs.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/hooks/use_breadcrumbs.ts
@@ -48,6 +48,9 @@ export function useBreadcrumbs(
       case 'rules_list':
         breadcrumbs = [rootBreadcrumb, { ...getAlertingV2Breadcrumb('rules_list') }];
         break;
+      case 'create_hub':
+        breadcrumbs = [rootBreadcrumb, rulesListBreadcrumb, getAlertingV2Breadcrumb('create_hub')];
+        break;
       case 'create':
         breadcrumbs = [rootBreadcrumb, rulesListBreadcrumb, getAlertingV2Breadcrumb('create')];
         break;

--- a/x-pack/platform/plugins/shared/alerting_v2/public/index.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/index.ts
@@ -14,6 +14,7 @@ import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
 import type { DataViewsPublicPluginStart } from '@kbn/data-views-plugin/public';
 import type { ExpressionsStart } from '@kbn/expressions-plugin/public';
 import type { LensPublicStart } from '@kbn/lens-plugin/public';
+import type { SharePluginStart } from '@kbn/share-plugin/public';
 import type { UiActionsStart } from '@kbn/ui-actions-plugin/public';
 import {
   ALERTING_V2_SECTION_ID,
@@ -25,6 +26,7 @@ import { NotificationPoliciesApi } from './services/notification_policies_api';
 import { RulesApi } from './services/rules_api';
 import { WorkflowsApi } from './services/workflows_api';
 import { setKibanaServices } from './kibana_services';
+import { getDiscoverHrefForRuleQuery } from './utils/discover_href_for_episode';
 import { DynamicRuleFormFlyout } from './create_rule_form_flyout';
 import type { AlertingV2PublicStart } from './types';
 
@@ -43,15 +45,25 @@ export const module = new ContainerModule(({ bind }) => {
 
     getStartServices().then(([coreStart]) => {
       const diContainer = coreStart.injection.getContainer();
+      const data = diContainer.get(PluginStart('data')) as DataPublicPluginStart;
+      const share = diContainer.get(PluginStart('share')) as SharePluginStart;
       setKibanaServices({
         http: coreStart.http,
         notifications: coreStart.notifications,
         application: coreStart.application,
-        data: diContainer.get(PluginStart('data')) as DataPublicPluginStart,
+        data,
         dataViews: diContainer.get(PluginStart('dataViews')) as DataViewsPublicPluginStart,
         lens: diContainer.get(PluginStart('lens')) as LensPublicStart,
         expressions: diContainer.get(PluginStart('expressions')) as ExpressionsStart,
         uiActions: diContainer.get(PluginStart('uiActions')) as UiActionsStart,
+        getDiscoverHrefForEsql: (esql: string) =>
+          getDiscoverHrefForRuleQuery({
+            share,
+            capabilities: coreStart.application.capabilities,
+            uiSettings: coreStart.uiSettings,
+            timeRange: data.query.timefilter.timefilter.getTime(),
+            ruleEsql: esql,
+          }),
       });
     });
 

--- a/x-pack/platform/plugins/shared/alerting_v2/public/lib/breadcrumb.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/lib/breadcrumb.ts
@@ -10,6 +10,7 @@ import { i18n } from '@kbn/i18n';
 export type AlertingV2BreadcrumbPage =
   | 'root'
   | 'rules_list'
+  | 'create_hub'
   | 'create'
   | 'edit'
   | 'rule_details'
@@ -34,6 +35,12 @@ export const getAlertingV2Breadcrumb = (
       return {
         text: i18n.translate('xpack.alertingV2.breadcrumbs.rulesListTitle', {
           defaultMessage: 'Rules',
+        }),
+      };
+    case 'create_hub':
+      return {
+        text: i18n.translate('xpack.alertingV2.breadcrumbs.createHubTitle', {
+          defaultMessage: 'Create rule',
         }),
       };
     case 'create':

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/rule_create_hub_page/rule_create_hub_page.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/rule_create_hub_page/rule_create_hub_page.tsx
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiPageHeader, EuiPageTemplate, EuiSpacer, EuiText, EuiTitle } from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n-react';
+import { useBreadcrumbs } from '../../hooks/use_breadcrumbs';
+import { RuleBuilderGrid } from '../../rule_builders/rule_builder_grid';
+
+export const RuleCreateHubPage = () => {
+  useBreadcrumbs('create_hub');
+
+  return (
+    <EuiPageTemplate.Section paddingSize="none" restrictWidth={true}>
+      <EuiPageHeader
+        pageTitle={
+          <FormattedMessage
+            id="xpack.alertingV2.ruleCreateHub.pageTitle"
+            defaultMessage="New Alerting Experience"
+          />
+        }
+        description={
+          <EuiText size="m" color="subdued">
+            <p>
+              <FormattedMessage
+                id="xpack.alertingV2.ruleCreateHub.intro"
+                defaultMessage="Powerful ES|QL-driven rules and support for external alerts — consistent, high-quality alert data in a unified experience. Start from a rule builder below."
+              />
+            </p>
+          </EuiText>
+        }
+      />
+      <EuiSpacer size="l" />
+      <EuiTitle size="xs">
+        <h2>
+          <FormattedMessage
+            id="xpack.alertingV2.ruleCreateHub.sectionTitle"
+            defaultMessage="Start from a rule builder"
+          />
+        </h2>
+      </EuiTitle>
+      <EuiSpacer size="m" />
+      <RuleBuilderGrid variant="all" />
+    </EuiPageTemplate.Section>
+  );
+};

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/rule_create_hub_page/rule_create_hub_page.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/rule_create_hub_page/rule_create_hub_page.tsx
@@ -8,11 +8,26 @@
 import React from 'react';
 import { EuiPageHeader, EuiPageTemplate, EuiSpacer, EuiText, EuiTitle } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { PluginStart } from '@kbn/core-di';
+import { CoreStart, useService } from '@kbn/core-di-browser';
+import type { AgentBuilderPluginStart } from '@kbn/agent-builder-plugin/public';
+import { paths } from '../../constants';
 import { useBreadcrumbs } from '../../hooks/use_breadcrumbs';
+import { RuleCreationEntryCards } from '../../rule_builders/rule_creation_entry_cards';
 import { RuleBuilderGrid } from '../../rule_builders/rule_builder_grid';
 
 export const RuleCreateHubPage = () => {
   useBreadcrumbs('create_hub');
+
+  const { basePath } = useService(CoreStart('http'));
+  const application = useService(CoreStart('application'));
+  const agentBuilder = useService(PluginStart('agentBuilder'), {
+    optional: true,
+  }) as AgentBuilderPluginStart | undefined;
+
+  const esqlAdvancedHref = basePath.prepend(paths.ruleCreateFormEsqlAdvanced);
+  const canOpenAgentBuilder = application.capabilities.agentBuilder?.show === true;
+  const showAskAiAgentButton = canOpenAgentBuilder && Boolean(agentBuilder);
 
   return (
     <EuiPageTemplate.Section paddingSize="none" restrictWidth={true}>
@@ -28,10 +43,18 @@ export const RuleCreateHubPage = () => {
             <p>
               <FormattedMessage
                 id="xpack.alertingV2.ruleCreateHub.intro"
-                defaultMessage="Powerful ES|QL-driven rules and support for external alerts — consistent, high-quality alert data in a unified experience. Start from a rule builder below."
+                defaultMessage="Powerful ES|QL-driven rules and support for external alerts — consistent, high-quality alert data in a unified experience. Start with ES|QL, AI, or a rule builder below."
               />
             </p>
           </EuiText>
+        }
+      />
+      <EuiSpacer size="l" />
+      <RuleCreationEntryCards
+        esqlHref={esqlAdvancedHref}
+        showAiCard={showAskAiAgentButton}
+        onCreateWithAi={
+          showAskAiAgentButton ? () => agentBuilder?.toggleChat() : undefined
         }
       />
       <EuiSpacer size="l" />

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/rule_form_page/rule_form_page.test.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/rule_form_page/rule_form_page.test.tsx
@@ -74,9 +74,9 @@ const createQueryClient = () =>
 const renderCreatePage = () => {
   return render(
     <QueryClientProvider client={createQueryClient()}>
-      <MemoryRouter initialEntries={['/create']}>
+      <MemoryRouter initialEntries={['/create/form']}>
         <I18nProvider>
-          <Route path="/create">
+          <Route path="/create/form">
             <RuleFormPage />
           </Route>
         </I18nProvider>
@@ -102,9 +102,9 @@ const renderEditPage = (ruleId: string = 'rule-1') => {
 const renderClonePage = (sourceRuleId: string = 'rule-1') => {
   return render(
     <QueryClientProvider client={createQueryClient()}>
-      <MemoryRouter initialEntries={[`/create?cloneFrom=${sourceRuleId}`]}>
+      <MemoryRouter initialEntries={[`/create/form?cloneFrom=${sourceRuleId}`]}>
         <I18nProvider>
-          <Route path="/create">
+          <Route path="/create/form">
             <RuleFormPage />
           </Route>
         </I18nProvider>

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/rule_form_page/rule_form_page.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/rule_form_page/rule_form_page.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import {
   EuiCallOut,
   EuiLoadingSpinner,
@@ -18,22 +18,55 @@ import { PluginStart } from '@kbn/core-di';
 import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
 import type { DataViewsPublicPluginStart } from '@kbn/data-views-plugin/public';
 import type { LensPublicStart } from '@kbn/lens-plugin/public';
+import type { AgentBuilderPluginStart } from '@kbn/agent-builder-plugin/public';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { useParams, useLocation } from 'react-router-dom';
 import { useQueryClient } from '@kbn/react-query';
-import { StandaloneRuleForm, mapRuleResponseToFormValues } from '@kbn/alerting-v2-rule-form';
+import {
+  StandaloneRuleForm,
+  mapRuleResponseToFormValues,
+  DEFAULT_THRESHOLD_DATA_SOURCE,
+} from '@kbn/alerting-v2-rule-form';
 import type { FormValues } from '@kbn/alerting-v2-rule-form';
 import { i18n } from '@kbn/i18n';
 import { useFetchRule } from '../../hooks/use_fetch_rule';
 import { ruleKeys } from '../../hooks/query_key_factory';
 import { useBreadcrumbs } from '../../hooks/use_breadcrumbs';
 import { paths } from '../../constants';
+import {
+  RuleEvaluationEsqlHeaderActions,
+  RULE_EVALUATION_DEFAULT_BUILDER_ID,
+  RULE_EVALUATION_LAST_BUILDER_SESSION_KEY,
+} from '../../components/rule_evaluation_esql_header_actions';
+import { RULE_BUILDERS } from '../../rule_builders/rule_builder_definitions';
 
 const DEFAULT_QUERY = 'FROM logs-*\n| LIMIT 1';
 
 const CLONE_NAME_SUFFIX = i18n.translate('xpack.alertingV2.ruleFormPage.cloneNameSuffix', {
   defaultMessage: ' (clone)',
 });
+
+type EvaluationPanelState = {
+  mode: 'esql' | 'builder';
+  /** Active / last builder id for guided UI and for ES|QL summary when mode is esql */
+  builderId: string | undefined;
+};
+
+const readInitialEvaluationPanel = (): EvaluationPanelState => {
+  const sp = new URLSearchParams(typeof window !== 'undefined' ? window.location.search : '');
+  const builder = sp.get('builder');
+  if (builder) {
+    return { mode: 'builder', builderId: builder };
+  }
+  if (sp.get('mode') === 'esql') {
+    const fromSession =
+      typeof window !== 'undefined'
+        ? window.sessionStorage.getItem(RULE_EVALUATION_LAST_BUILDER_SESSION_KEY) ?? undefined
+        : undefined;
+    return { mode: 'esql', builderId: fromSession };
+  }
+  return { mode: 'esql', builderId: undefined };
+};
 
 export const RuleFormPage = () => {
   const { id: ruleId } = useParams<{ id?: string }>();
@@ -128,6 +161,8 @@ interface RuleFormPageContentProps {
 
 const RuleFormPageContent = ({ ruleId, initialQuery, initialValues }: RuleFormPageContentProps) => {
   const isEditing = Boolean(ruleId);
+  const [evaluationPanel, setEvaluationPanel] = useState<EvaluationPanelState>(readInitialEvaluationPanel);
+
   const http = useService(CoreStart('http'));
   const notifications = useService(CoreStart('notifications'));
   const application = useService(CoreStart('application'));
@@ -136,7 +171,14 @@ const RuleFormPageContent = ({ ruleId, initialQuery, initialValues }: RuleFormPa
   const data = useService(PluginStart('data')) as DataPublicPluginStart;
   const dataViews = useService(PluginStart('dataViews')) as DataViewsPublicPluginStart;
   const lens = useService(PluginStart('lens')) as LensPublicStart;
+  const agentBuilder = useService(PluginStart('agentBuilder'), {
+    optional: true,
+  }) as AgentBuilderPluginStart | undefined;
   const queryClient = useQueryClient();
+
+  const showAskAiAgentButton = Boolean(
+    agentBuilder && application.capabilities.agentBuilder?.show === true
+  );
 
   useBreadcrumbs(isEditing ? 'edit' : 'create');
 
@@ -176,21 +218,151 @@ const RuleFormPageContent = ({ ruleId, initialQuery, initialValues }: RuleFormPa
     <FormattedMessage id="xpack.alertingV2.createRule.submitLabel" defaultMessage="Create rule" />
   );
 
+  /** Create/clone: ES|QL vs builder is local state only (no history.replace) so the rest of the page stays stable. */
+  const includeQueryEditor = isEditing || evaluationPanel.mode === 'esql';
+
+  const ruleBuilderIdForForm = isEditing ? undefined : evaluationPanel.builderId;
+
+  const resolveBuilderIdForToggle = useCallback(() => {
+    if (evaluationPanel.builderId) {
+      return evaluationPanel.builderId;
+    }
+    if (typeof window !== 'undefined') {
+      return (
+        window.sessionStorage.getItem(RULE_EVALUATION_LAST_BUILDER_SESSION_KEY) ??
+        RULE_EVALUATION_DEFAULT_BUILDER_ID
+      );
+    }
+    return RULE_EVALUATION_DEFAULT_BUILDER_ID;
+  }, [evaluationPanel.builderId]);
+
+  const selectEsqlMode = useCallback(() => {
+    setEvaluationPanel((prev) => {
+      if (prev.mode === 'builder' && prev.builderId && typeof window !== 'undefined') {
+        window.sessionStorage.setItem(RULE_EVALUATION_LAST_BUILDER_SESSION_KEY, prev.builderId);
+      }
+      const nextBuilderId =
+        prev.builderId ??
+        (typeof window !== 'undefined'
+          ? window.sessionStorage.getItem(RULE_EVALUATION_LAST_BUILDER_SESSION_KEY) ?? undefined
+          : undefined);
+      return { mode: 'esql', builderId: nextBuilderId };
+    });
+  }, []);
+
+  const selectBuilderMode = useCallback(() => {
+    const id = resolveBuilderIdForToggle();
+    if (typeof window !== 'undefined') {
+      window.sessionStorage.setItem(RULE_EVALUATION_LAST_BUILDER_SESSION_KEY, id);
+    }
+    setEvaluationPanel({ mode: 'builder', builderId: id });
+  }, [resolveBuilderIdForToggle]);
+
+  const onPickBuilder = useCallback((id: string) => {
+    if (typeof window !== 'undefined') {
+      window.sessionStorage.setItem(RULE_EVALUATION_LAST_BUILDER_SESSION_KEY, id);
+    }
+    setEvaluationPanel({ mode: 'builder', builderId: id });
+  }, []);
+
+  const builderIconType = useMemo(() => {
+    const id =
+      evaluationPanel.builderId ??
+      (typeof window !== 'undefined'
+        ? window.sessionStorage.getItem(RULE_EVALUATION_LAST_BUILDER_SESSION_KEY) ??
+          RULE_EVALUATION_DEFAULT_BUILDER_ID
+        : RULE_EVALUATION_DEFAULT_BUILDER_ID);
+    return RULE_BUILDERS.find((b) => b.id === id)?.iconType ?? 'aggregate';
+  }, [evaluationPanel.builderId]);
+
+  const ruleEvaluationHeaderActions = useMemo(() => {
+    if (isEditing) {
+      return undefined;
+    }
+    return (
+      <RuleEvaluationEsqlHeaderActions
+        selectedMode={evaluationPanel.mode === 'esql' ? 'esql' : 'builder'}
+        onChange={(next) => {
+          if (next === 'esql') {
+            selectEsqlMode();
+          } else {
+            selectBuilderMode();
+          }
+        }}
+        onPickBuilder={onPickBuilder}
+        builderIconType={builderIconType}
+        basePath={basePath}
+        showAgentBuilderButton={showAskAiAgentButton}
+        onOpenAgentBuilder={agentBuilder ? () => agentBuilder.toggleChat() : undefined}
+      />
+    );
+  }, [
+    isEditing,
+    evaluationPanel.mode,
+    selectEsqlMode,
+    selectBuilderMode,
+    onPickBuilder,
+    builderIconType,
+    basePath,
+    showAskAiAgentButton,
+    agentBuilder,
+  ]);
+
+  const needsThresholdDefaults =
+    !ruleId &&
+    evaluationPanel.mode === 'builder' &&
+    evaluationPanel.builderId === 'threshold_alert';
+
+  const mergedInitialValues = useMemo(() => {
+    if (!needsThresholdDefaults) {
+      return initialValues;
+    }
+    return {
+      ...initialValues,
+      thresholdDataSource: initialValues?.thresholdDataSource ?? DEFAULT_THRESHOLD_DATA_SOURCE,
+      thresholdStats: initialValues?.thresholdStats ?? [
+        { label: '', aggregation: 'avg' as const, field: '' },
+      ],
+      thresholdConditionCombinator: initialValues?.thresholdConditionCombinator ?? 'and',
+      thresholdConditions: initialValues?.thresholdConditions ?? [
+        { statLabel: '', operator: 'gt' as const, value: '' },
+      ],
+    };
+  }, [needsThresholdDefaults, initialValues]);
+
+  const ruleEvaluationModeLabel = useMemo(() => {
+    if (evaluationPanel.mode === 'esql') {
+      return i18n.translate('xpack.alertingV2.ruleFormPage.evaluationModeEsql', {
+        defaultMessage: 'ES|QL',
+      });
+    }
+    if (evaluationPanel.builderId) {
+      const def = RULE_BUILDERS.find((b) => b.id === evaluationPanel.builderId);
+      return def?.title ?? evaluationPanel.builderId;
+    }
+    return undefined;
+  }, [evaluationPanel.mode, evaluationPanel.builderId]);
+
+  const standaloneFormKey = ruleId ? `rule-form-edit-${ruleId}` : 'rule-form-create';
+
   return (
     <>
       <EuiPageHeader pageTitle={pageTitle} />
       <EuiSpacer size="m" />
       <StandaloneRuleForm
+        key={standaloneFormKey}
         query={initialQuery ?? DEFAULT_QUERY}
         services={ruleFormServices}
-        includeYaml
-        isDisabled={false}
         includeSubmission
         onSuccess={onSuccess}
         onCancel={onCancel}
         ruleId={ruleId}
-        initialValues={initialValues}
+        initialValues={mergedInitialValues}
         submitLabel={submitLabel}
+        ruleEvaluationHeaderActions={ruleEvaluationHeaderActions}
+        includeQueryEditor={includeQueryEditor}
+        ruleBuilderId={ruleBuilderIdForForm}
+        ruleEvaluationModeLabel={ruleEvaluationModeLabel}
       />
     </>
   );

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/rule_form_page/rule_form_page.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/rule_form_page/rule_form_page.tsx
@@ -6,6 +6,8 @@
  */
 
 import React, { useCallback, useMemo, useState } from 'react';
+import { PluginStart } from '@kbn/core-di';
+import type { SharePluginStart } from '@kbn/share-plugin/public';
 import {
   EuiCallOut,
   EuiLoadingSpinner,
@@ -14,11 +16,9 @@ import {
   EuiSpacer,
 } from '@elastic/eui';
 import { useService, CoreStart } from '@kbn/core-di-browser';
-import { PluginStart } from '@kbn/core-di';
 import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
 import type { DataViewsPublicPluginStart } from '@kbn/data-views-plugin/public';
 import type { LensPublicStart } from '@kbn/lens-plugin/public';
-import type { AgentBuilderPluginStart } from '@kbn/agent-builder-plugin/public';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { useParams, useLocation } from 'react-router-dom';
 import { useQueryClient } from '@kbn/react-query';
@@ -39,6 +39,7 @@ import {
   RULE_EVALUATION_LAST_BUILDER_SESSION_KEY,
 } from '../../components/rule_evaluation_esql_header_actions';
 import { RULE_BUILDERS } from '../../rule_builders/rule_builder_definitions';
+import { getDiscoverHrefForRuleQuery } from '../../utils/discover_href_for_episode';
 
 const DEFAULT_QUERY = 'FROM logs-*\n| LIMIT 1';
 
@@ -166,21 +167,28 @@ const RuleFormPageContent = ({ ruleId, initialQuery, initialValues }: RuleFormPa
   const http = useService(CoreStart('http'));
   const notifications = useService(CoreStart('notifications'));
   const application = useService(CoreStart('application'));
+  const uiSettings = useService(CoreStart('uiSettings'));
+  const share = useService(PluginStart('share')) as SharePluginStart;
   const { navigateToUrl } = application;
   const { basePath } = http;
   const data = useService(PluginStart('data')) as DataPublicPluginStart;
   const dataViews = useService(PluginStart('dataViews')) as DataViewsPublicPluginStart;
   const lens = useService(PluginStart('lens')) as LensPublicStart;
-  const agentBuilder = useService(PluginStart('agentBuilder'), {
-    optional: true,
-  }) as AgentBuilderPluginStart | undefined;
   const queryClient = useQueryClient();
 
-  const showAskAiAgentButton = Boolean(
-    agentBuilder && application.capabilities.agentBuilder?.show === true
-  );
-
   useBreadcrumbs(isEditing ? 'edit' : 'create');
+
+  const getDiscoverHrefForEsql = useCallback(
+    (esql: string) =>
+      getDiscoverHrefForRuleQuery({
+        share,
+        capabilities: application.capabilities,
+        uiSettings,
+        timeRange: data.query.timefilter.timefilter.getTime(),
+        ruleEsql: esql,
+      }),
+    [share, application.capabilities, uiSettings, data]
+  );
 
   const ruleFormServices = useMemo(
     () => ({
@@ -190,8 +198,9 @@ const RuleFormPageContent = ({ ruleId, initialQuery, initialValues }: RuleFormPa
       notifications,
       application,
       lens,
+      getDiscoverHrefForEsql,
     }),
-    [http, data, dataViews, notifications, application, lens]
+    [http, data, dataViews, notifications, application, lens, getDiscoverHrefForEsql]
   );
 
   const onSuccess = useCallback(() => {
@@ -265,15 +274,10 @@ const RuleFormPageContent = ({ ruleId, initialQuery, initialValues }: RuleFormPa
     setEvaluationPanel({ mode: 'builder', builderId: id });
   }, []);
 
-  const builderIconType = useMemo(() => {
-    const id =
-      evaluationPanel.builderId ??
-      (typeof window !== 'undefined'
-        ? window.sessionStorage.getItem(RULE_EVALUATION_LAST_BUILDER_SESSION_KEY) ??
-          RULE_EVALUATION_DEFAULT_BUILDER_ID
-        : RULE_EVALUATION_DEFAULT_BUILDER_ID);
-    return RULE_BUILDERS.find((b) => b.id === id)?.iconType ?? 'aggregate';
-  }, [evaluationPanel.builderId]);
+  const ruleBuilderCatalog = useMemo(
+    () => RULE_BUILDERS.map((b) => ({ id: b.id, title: b.title, description: b.description })),
+    []
+  );
 
   const ruleEvaluationHeaderActions = useMemo(() => {
     if (isEditing) {
@@ -289,24 +293,9 @@ const RuleFormPageContent = ({ ruleId, initialQuery, initialValues }: RuleFormPa
             selectBuilderMode();
           }
         }}
-        onPickBuilder={onPickBuilder}
-        builderIconType={builderIconType}
-        basePath={basePath}
-        showAgentBuilderButton={showAskAiAgentButton}
-        onOpenAgentBuilder={agentBuilder ? () => agentBuilder.toggleChat() : undefined}
       />
     );
-  }, [
-    isEditing,
-    evaluationPanel.mode,
-    selectEsqlMode,
-    selectBuilderMode,
-    onPickBuilder,
-    builderIconType,
-    basePath,
-    showAskAiAgentButton,
-    agentBuilder,
-  ]);
+  }, [isEditing, evaluationPanel.mode, selectEsqlMode, selectBuilderMode]);
 
   const needsThresholdDefaults =
     !ruleId &&
@@ -363,6 +352,8 @@ const RuleFormPageContent = ({ ruleId, initialQuery, initialValues }: RuleFormPa
         includeQueryEditor={includeQueryEditor}
         ruleBuilderId={ruleBuilderIdForForm}
         ruleEvaluationModeLabel={ruleEvaluationModeLabel}
+        ruleBuilderCatalog={ruleBuilderCatalog}
+        onRuleBuilderIdChange={onPickBuilder}
       />
     </>
   );

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/rules_list_page/rules_list_page.test.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/rules_list_page/rules_list_page.test.tsx
@@ -18,26 +18,40 @@ const mockGetUrlForApp = jest.fn((appId: string, options?: { path?: string }) =>
   return `/app/${appId}${path}`;
 });
 const mockDocTitleChange = jest.fn();
+const mockAgentBuilderToggleChat = jest.fn();
 
 jest.mock('../../application/breadcrumb_context', () => ({
   useSetBreadcrumbs: () => jest.fn(),
 }));
 
-jest.mock('@kbn/core-di-browser', () => ({
-  useService: (token: unknown) => {
-    if (token === 'application') {
-      return { navigateToUrl: mockNavigateToUrl, getUrlForApp: mockGetUrlForApp };
-    }
-    if (token === 'chrome') {
-      return { docTitle: { change: mockDocTitleChange } };
-    }
-    if (token === 'http') {
-      return { basePath: { prepend: (p: string) => p } };
-    }
-    return {};
-  },
-  CoreStart: (key: string) => key,
-}));
+jest.mock('@kbn/core-di-browser', () => {
+  const actual = jest.requireActual('@kbn/core-di-browser');
+  const { PluginStart } = jest.requireActual('@kbn/core-di');
+  return {
+    ...actual,
+    useService: (token: unknown, options?: { optional?: boolean }) => {
+      if (token === actual.CoreStart('http')) {
+        return { basePath: { prepend: (p: string) => p } };
+      }
+      if (token === actual.CoreStart('chrome')) {
+        return { docTitle: { change: mockDocTitleChange } };
+      }
+      if (token === actual.CoreStart('application')) {
+        return {
+          navigateToUrl: mockNavigateToUrl,
+          getUrlForApp: mockGetUrlForApp,
+          capabilities: { agentBuilder: { show: true } },
+        };
+      }
+      if (token === PluginStart('agentBuilder')) {
+        return options?.optional === true
+          ? { toggleChat: mockAgentBuilderToggleChat }
+          : { toggleChat: mockAgentBuilderToggleChat };
+      }
+      return {};
+    },
+  };
+});
 
 const mockUseFetchRules = jest.fn();
 jest.mock('../../hooks/use_fetch_rules', () => ({
@@ -771,7 +785,7 @@ describe('RulesListPage', () => {
     fireEvent.click(screen.getByTestId('cloneRule-rule-1'));
 
     expect(mockNavigateToUrl).toHaveBeenCalledWith(
-      '/app/management/alertingV2/rules/create?cloneFrom=rule-1'
+      '/app/management/alertingV2/rules/create/form?cloneFrom=rule-1'
     );
   });
 

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/rules_list_page/rules_list_page.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/rules_list_page/rules_list_page.tsx
@@ -28,6 +28,7 @@ import { useFetchRuleTags } from '../../hooks/use_fetch_rule_tags';
 import { useBreadcrumbs } from '../../hooks/use_breadcrumbs';
 import { paths } from '../../constants';
 import { RulesListTableContainer } from './rules_list_table_container';
+import { RulesListEmptyState } from '../../rule_builders/rules_list_empty_state';
 import type { RulesListTableSortField } from './rules_list_table';
 import { ModeFilterPopover } from '../../components/rule/popovers/mode_filter_popover';
 import { StatusFilterPopover } from '../../components/rule/popovers/status_filter_popover';
@@ -110,6 +111,9 @@ export const RulesListPage = () => {
 
   const hasActiveFilters = Boolean(filter);
 
+  const showEmptyTenantState =
+    !isError && !isLoading && data?.total === 0 && !debouncedSearch && !hasActiveFilters;
+
   return (
     <div>
       <EuiPageHeader
@@ -133,7 +137,7 @@ export const RulesListPage = () => {
           </EuiButton>,
         ]}
       />
-      <EuiSpacer size="m" />
+      {(!showEmptyTenantState || isError) && <EuiSpacer size="m" />}
       {isError ? (
         <>
           <EuiCallOut
@@ -152,7 +156,8 @@ export const RulesListPage = () => {
           <EuiSpacer />
         </>
       ) : null}
-      {!isError ? (
+      {!isError && showEmptyTenantState ? <RulesListEmptyState /> : null}
+      {!isError && !showEmptyTenantState ? (
         <>
           <EuiFlexGroup gutterSize="s">
             <EuiFlexItem>

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/rules_list_page/rules_list_table_container.test.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/rules_list_page/rules_list_table_container.test.tsx
@@ -138,7 +138,7 @@ describe('RulesListTableContainer', () => {
       fireEvent.click(screen.getByTestId('cloneRule-rule-1'));
 
       expect(mockNavigateToUrl).toHaveBeenCalledWith(
-        '/app/management/alertingV2/rules/create?cloneFrom=rule-1'
+        '/app/management/alertingV2/rules/create/form?cloneFrom=rule-1'
       );
     });
   });

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/rules_list_page/rules_list_table_container.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/rules_list_page/rules_list_table_container.tsx
@@ -135,7 +135,7 @@ export const RulesListTableContainer: React.FC<RulesListTableContainerProps> = (
         onEdit={(r) => navigateToUrl(basePath.prepend(paths.ruleEdit(r.id)))}
         onClone={(r) =>
           navigateToUrl(
-            basePath.prepend(`${paths.ruleCreate}?cloneFrom=${encodeURIComponent(r.id)}`)
+            basePath.prepend(`${paths.ruleCreateForm}?cloneFrom=${encodeURIComponent(r.id)}`)
           )
         }
         onDelete={(r) => setRuleToDelete(r)}

--- a/x-pack/platform/plugins/shared/alerting_v2/public/rule_builders/rule_builder_card.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/rule_builders/rule_builder_card.tsx
@@ -41,6 +41,8 @@ export interface RuleBuilderCardProps {
   onPick?: () => void;
   /** `vertical` (default): icon above text. `horizontal`: icon beside text (e.g. create hub). */
   layout?: 'vertical' | 'horizontal';
+  /** When true, card is non-interactive and styled as unavailable. */
+  isDisabled?: boolean;
   'data-test-subj'?: string;
 }
 
@@ -49,6 +51,7 @@ export const RuleBuilderCard = ({
   href,
   onPick,
   layout: cardLayout = 'vertical',
+  isDisabled = false,
   'data-test-subj': dataTestSubj,
 }: RuleBuilderCardProps) => {
   const betaBadgeProps =
@@ -59,35 +62,48 @@ export const RuleBuilderCard = ({
         }
       : undefined;
 
+  const description = (
+    <>
+      <EuiText size="s">
+        <p>{builder.description}</p>
+      </EuiText>
+      <EuiSpacer size="s" />
+      <EuiText size="xs" color="subdued">
+        {i18n.translate('xpack.alertingV2.ruleBuilders.replacesLabel', {
+          defaultMessage: 'Replaces: {list}',
+          values: { list: builder.replaces },
+        })}
+      </EuiText>
+    </>
+  );
+
+  const icon = <EuiIcon type={builder.iconType} size="l" color="text" aria-hidden={true} />;
+
+  const sharedCardProps = {
+    'data-test-subj': dataTestSubj ?? `ruleBuilderCard-${builder.id}`,
+    icon,
+    title: builder.title,
+    titleElement: 'h3' as const,
+    titleSize: 'xs' as const,
+    description,
+    betaBadgeProps,
+    href: isDisabled ? undefined : onPick ? undefined : href,
+    onClick: isDisabled ? undefined : onPick,
+    isDisabled,
+    hasBorder: true,
+    display: 'plain' as const,
+  };
+
+  if (cardLayout === 'horizontal') {
+    return <EuiCard {...sharedCardProps} layout="horizontal" />;
+  }
+
   return (
     <EuiCard
-      data-test-subj={dataTestSubj ?? `ruleBuilderCard-${builder.id}`}
-      layout={cardLayout}
-      textAlign={cardLayout === 'vertical' ? 'left' : undefined}
-      css={cardLayout === 'vertical' ? verticalCardTextLeftCss : undefined}
-      icon={<EuiIcon type={builder.iconType} size="l" color="text" aria-hidden={true} />}
-      title={builder.title}
-      titleElement="h3"
-      titleSize="xs"
-      description={
-        <>
-          <EuiText size="s">
-            <p>{builder.description}</p>
-          </EuiText>
-          <EuiSpacer size="s" />
-          <EuiText size="xs" color="subdued">
-            {i18n.translate('xpack.alertingV2.ruleBuilders.replacesLabel', {
-              defaultMessage: 'Replaces: {list}',
-              values: { list: builder.replaces },
-            })}
-          </EuiText>
-        </>
-      }
-      betaBadgeProps={betaBadgeProps}
-      href={onPick ? undefined : href}
-      onClick={onPick}
-      hasBorder
-      display="plain"
+      {...sharedCardProps}
+      layout="vertical"
+      textAlign="left"
+      css={verticalCardTextLeftCss}
     />
   );
 };

--- a/x-pack/platform/plugins/shared/alerting_v2/public/rule_builders/rule_builder_card.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/rule_builders/rule_builder_card.tsx
@@ -1,0 +1,93 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { css } from '@emotion/react';
+import { EuiCard, EuiIcon, EuiSpacer, EuiText } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import type { RuleBuilderDefinition } from './rule_builder_definitions';
+
+const verticalCardTextLeftCss = css({
+  textAlign: 'left',
+  '& .euiCard__top': {
+    alignSelf: 'flex-start',
+  },
+  '& .euiCard__icon': {
+    marginInlineStart: 0,
+    marginInlineEnd: 0,
+  },
+});
+
+const badgeLabel = (badge: NonNullable<RuleBuilderDefinition['badge']>) => {
+  if (badge === 'advanced') {
+    return i18n.translate('xpack.alertingV2.ruleBuilders.badge.advanced', {
+      defaultMessage: 'Advanced',
+    });
+  }
+  return i18n.translate('xpack.alertingV2.ruleBuilders.badge.requiresTsdb', {
+    defaultMessage: 'Requires TSDB',
+  });
+};
+
+export interface RuleBuilderCardProps {
+  builder: RuleBuilderDefinition;
+  /** When set, card navigates on selection. Omit when using `onPick`. */
+  href?: string;
+  /** In-place selection (for example a builder picker modal). */
+  onPick?: () => void;
+  /** `vertical` (default): icon above text. `horizontal`: icon beside text (e.g. create hub). */
+  layout?: 'vertical' | 'horizontal';
+  'data-test-subj'?: string;
+}
+
+export const RuleBuilderCard = ({
+  builder,
+  href,
+  onPick,
+  layout: cardLayout = 'vertical',
+  'data-test-subj': dataTestSubj,
+}: RuleBuilderCardProps) => {
+  const betaBadgeProps =
+    builder.badge !== undefined
+      ? {
+          label: badgeLabel(builder.badge),
+          alignment: 'middle' as const,
+        }
+      : undefined;
+
+  return (
+    <EuiCard
+      data-test-subj={dataTestSubj ?? `ruleBuilderCard-${builder.id}`}
+      layout={cardLayout}
+      textAlign={cardLayout === 'vertical' ? 'left' : undefined}
+      css={cardLayout === 'vertical' ? verticalCardTextLeftCss : undefined}
+      icon={<EuiIcon type={builder.iconType} size="l" color="text" aria-hidden={true} />}
+      title={builder.title}
+      titleElement="h3"
+      titleSize="xs"
+      description={
+        <>
+          <EuiText size="s">
+            <p>{builder.description}</p>
+          </EuiText>
+          <EuiSpacer size="s" />
+          <EuiText size="xs" color="subdued">
+            {i18n.translate('xpack.alertingV2.ruleBuilders.replacesLabel', {
+              defaultMessage: 'Replaces: {list}',
+              values: { list: builder.replaces },
+            })}
+          </EuiText>
+        </>
+      }
+      betaBadgeProps={betaBadgeProps}
+      href={onPick ? undefined : href}
+      onClick={onPick}
+      hasBorder
+      display="plain"
+    />
+  );
+};

--- a/x-pack/platform/plugins/shared/alerting_v2/public/rule_builders/rule_builder_definitions.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/rule_builders/rule_builder_definitions.ts
@@ -1,0 +1,150 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { IconType } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+
+export type RuleBuilderId =
+  | 'threshold_alert'
+  | 'service_latency'
+  | 'slo_burn_rate'
+  | 'change_point_detection'
+  | 'rate_ratio'
+  | 'event_rate'
+  | 'counter_rate';
+
+export type RuleBuilderBadge = 'advanced' | 'requires_tsdb';
+
+export interface RuleBuilderDefinition {
+  id: RuleBuilderId;
+  title: string;
+  description: string;
+  replaces: string;
+  iconType: IconType;
+  badge?: RuleBuilderBadge;
+}
+
+/** Shown on the rules list empty state (subset of all builders). */
+export const FEATURED_RULE_BUILDER_IDS: RuleBuilderId[] = [
+  'threshold_alert',
+  'service_latency',
+  'change_point_detection',
+];
+
+export const RULE_BUILDERS: RuleBuilderDefinition[] = [
+  {
+    id: 'threshold_alert',
+    title: i18n.translate('xpack.alertingV2.ruleBuilders.thresholdAlert.title', {
+      defaultMessage: 'Threshold Alert',
+    }),
+    description: i18n.translate('xpack.alertingV2.ruleBuilders.thresholdAlert.description', {
+      defaultMessage:
+        'Monitor one or more metrics and alert when they cross a threshold. Multi-condition support with custom aggregations.',
+    }),
+    replaces: i18n.translate('xpack.alertingV2.ruleBuilders.thresholdAlert.replaces', {
+      defaultMessage: 'Custom threshold, Metric threshold',
+    }),
+    iconType: 'bell',
+  },
+  {
+    id: 'service_latency',
+    title: i18n.translate('xpack.alertingV2.ruleBuilders.serviceLatency.title', {
+      defaultMessage: 'Service Latency',
+    }),
+    description: i18n.translate('xpack.alertingV2.ruleBuilders.serviceLatency.description', {
+      defaultMessage:
+        "Alert when a service's response time exceeds a threshold. Pick service, transaction type, percentile, and environment.",
+    }),
+    replaces: i18n.translate('xpack.alertingV2.ruleBuilders.serviceLatency.replaces', {
+      defaultMessage: 'APM latency rule',
+    }),
+    iconType: 'apmTrace',
+  },
+  {
+    id: 'slo_burn_rate',
+    title: i18n.translate('xpack.alertingV2.ruleBuilders.sloBurnRate.title', {
+      defaultMessage: 'SLO Burn Rate',
+    }),
+    description: i18n.translate('xpack.alertingV2.ruleBuilders.sloBurnRate.description', {
+      defaultMessage:
+        "Alert when an SLO's error budget is being consumed too fast, using multi-window burn rate detection with automatic severity.",
+    }),
+    replaces: i18n.translate('xpack.alertingV2.ruleBuilders.sloBurnRate.replaces', {
+      defaultMessage: 'SLO burn rate rule',
+    }),
+    iconType: 'flag',
+    badge: 'advanced',
+  },
+  {
+    id: 'change_point_detection',
+    title: i18n.translate('xpack.alertingV2.ruleBuilders.changePointDetection.title', {
+      defaultMessage: 'Change Point Detection',
+    }),
+    description: i18n.translate('xpack.alertingV2.ruleBuilders.changePointDetection.description', {
+      defaultMessage:
+        'Detect statistically significant changes in a metric automatically. No manual thresholds — uses ES|QL CHANGE_POINT.',
+    }),
+    replaces: i18n.translate('xpack.alertingV2.ruleBuilders.changePointDetection.replaces', {
+      defaultMessage: 'New capability (no v1 equivalent)',
+    }),
+    iconType: 'analyzeEvent',
+  },
+  {
+    id: 'rate_ratio',
+    title: i18n.translate('xpack.alertingV2.ruleBuilders.rateRatio.title', {
+      defaultMessage: 'Rate / Ratio',
+    }),
+    description: i18n.translate('xpack.alertingV2.ruleBuilders.rateRatio.description', {
+      defaultMessage:
+        'Alert when the ratio of matching events exceeds a threshold. Error rates, success rates, cache hit ratios, conversion rates, etc.',
+    }),
+    replaces: i18n.translate('xpack.alertingV2.ruleBuilders.rateRatio.replaces', {
+      defaultMessage: 'APM error rate, Transaction error rate',
+    }),
+    iconType: 'percent',
+  },
+  {
+    id: 'event_rate',
+    title: i18n.translate('xpack.alertingV2.ruleBuilders.eventRate.title', {
+      defaultMessage: 'Event Rate',
+    }),
+    description: i18n.translate('xpack.alertingV2.ruleBuilders.eventRate.description', {
+      defaultMessage:
+        'Alert when the volume of events exceeds a threshold. Simple count-based monitoring per time unit.',
+    }),
+    replaces: i18n.translate('xpack.alertingV2.ruleBuilders.eventRate.replaces', {
+      defaultMessage: 'Log threshold (document count)',
+    }),
+    iconType: 'document',
+  },
+  {
+    id: 'counter_rate',
+    title: i18n.translate('xpack.alertingV2.ruleBuilders.counterRate.title', {
+      defaultMessage: 'Counter Rate',
+    }),
+    description: i18n.translate('xpack.alertingV2.ruleBuilders.counterRate.description', {
+      defaultMessage:
+        'Alert on the rate of change of a counter metric. Pod restarts, network bytes, request counts — uses ES|QL TS command with rate().',
+    }),
+    replaces: i18n.translate('xpack.alertingV2.ruleBuilders.counterRate.replaces', {
+      defaultMessage: 'Custom threshold (counter metrics)',
+    }),
+    iconType: 'metric',
+    badge: 'requires_tsdb',
+  },
+];
+
+export const getBuildersForDisplay = (
+  mode: 'featured' | 'all',
+  featuredIds: RuleBuilderId[] = FEATURED_RULE_BUILDER_IDS
+): RuleBuilderDefinition[] => {
+  if (mode === 'all') {
+    return RULE_BUILDERS;
+  }
+  const idSet = new Set(featuredIds);
+  return RULE_BUILDERS.filter((b) => idSet.has(b.id));
+};

--- a/x-pack/platform/plugins/shared/alerting_v2/public/rule_builders/rule_builder_definitions.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/rule_builders/rule_builder_definitions.ts
@@ -133,7 +133,7 @@ export const RULE_BUILDERS: RuleBuilderDefinition[] = [
     replaces: i18n.translate('xpack.alertingV2.ruleBuilders.counterRate.replaces', {
       defaultMessage: 'Custom threshold (counter metrics)',
     }),
-    iconType: 'metric',
+    iconType: 'metricsApp',
     badge: 'requires_tsdb',
   },
 ];

--- a/x-pack/platform/plugins/shared/alerting_v2/public/rule_builders/rule_builder_grid.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/rule_builders/rule_builder_grid.tsx
@@ -1,0 +1,61 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useMemo } from 'react';
+import { EuiFlexGrid, EuiFlexItem } from '@elastic/eui';
+import { CoreStart, useService } from '@kbn/core-di-browser';
+import { paths } from '../constants';
+import {
+  FEATURED_RULE_BUILDER_IDS,
+  getBuildersForDisplay,
+  type RuleBuilderId,
+} from './rule_builder_definitions';
+import { RuleBuilderCard } from './rule_builder_card';
+
+export interface RuleBuilderGridProps {
+  /** `featured`: three cards for empty list. `all`: full set for create hub. */
+  variant: 'featured' | 'all';
+  /** Optional override of which builders show in featured mode */
+  featuredIds?: RuleBuilderId[];
+  /** When set, cards call this instead of navigating via `href`. */
+  onSelectBuilder?: (id: RuleBuilderId) => void;
+}
+
+export const RuleBuilderGrid = ({
+  variant,
+  featuredIds,
+  onSelectBuilder,
+}: RuleBuilderGridProps) => {
+  const { basePath } = useService(CoreStart('http'));
+
+  const builders = useMemo(
+    () => getBuildersForDisplay(variant, featuredIds ?? FEATURED_RULE_BUILDER_IDS),
+    [variant, featuredIds]
+  );
+
+  const columns = variant === 'featured' ? 3 : 2;
+
+  return (
+    <EuiFlexGrid columns={columns} gutterSize="m">
+      {builders.map((builder) => (
+        <EuiFlexItem key={builder.id}>
+          <RuleBuilderCard
+            builder={builder}
+            layout={variant === 'featured' ? 'vertical' : 'horizontal'}
+            {...(onSelectBuilder
+              ? { onPick: () => onSelectBuilder(builder.id) }
+              : {
+                  href: basePath.prepend(
+                    `${paths.ruleCreateForm}?builder=${encodeURIComponent(builder.id)}`
+                  ),
+                })}
+          />
+        </EuiFlexItem>
+      ))}
+    </EuiFlexGrid>
+  );
+};

--- a/x-pack/platform/plugins/shared/alerting_v2/public/rule_builders/rule_creation_entry_cards.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/rule_builders/rule_creation_entry_cards.tsx
@@ -1,0 +1,112 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { css } from '@emotion/react';
+import { EuiCard, EuiFlexGrid, EuiFlexItem, EuiIcon, EuiText } from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n-react';
+
+const verticalCardTextLeftCss = css({
+  textAlign: 'left',
+  '& .euiCard__top': {
+    alignSelf: 'flex-start',
+  },
+  '& .euiCard__icon': {
+    marginInlineStart: 0,
+    marginInlineEnd: 0,
+  },
+});
+
+export interface RuleCreationEntryCardsProps {
+  esqlHref: string;
+  showAiCard: boolean;
+  onCreateWithAi?: () => void;
+}
+
+/**
+ * Primary entry cards: ES|QL-first creation and optional AI-assisted flow,
+ * shown before the rule builder grid on the rules list empty state.
+ */
+export const RuleCreationEntryCards = ({
+  esqlHref,
+  showAiCard,
+  onCreateWithAi,
+}: RuleCreationEntryCardsProps) => {
+  const esqlIcon = <EuiIcon type="editorCodeBlock" size="l" color="text" aria-hidden={true} />;
+  const aiIcon = <EuiIcon type="productAgent" size="l" color="text" aria-hidden={true} />;
+
+  const esqlDescription = (
+    <EuiText size="s">
+      <p>
+        <FormattedMessage
+          id="xpack.alertingV2.rulesList.emptyStateCreateWithEsqlCardDescription"
+          defaultMessage="Open the create rule form in ES|QL mode to write and edit your evaluation query directly."
+        />
+      </p>
+    </EuiText>
+  );
+
+  const aiDescription = (
+    <EuiText size="s">
+      <p>
+        <FormattedMessage
+          id="xpack.alertingV2.rulesList.emptyStateCreateWithAiCardDescription"
+          defaultMessage="Use AI to help you draft or refine your rule configuration in context."
+        />
+      </p>
+    </EuiText>
+  );
+
+  return (
+    <EuiFlexGrid columns={showAiCard ? 2 : 1} gutterSize="m">
+      <EuiFlexItem>
+        <EuiCard
+          data-test-subj="rulesListEmptyStateCreateWithEsqlCard"
+          icon={esqlIcon}
+          layout="vertical"
+          textAlign="left"
+          css={verticalCardTextLeftCss}
+          title={
+            <FormattedMessage
+              id="xpack.alertingV2.rulesList.emptyStateCreateWithEsqlCardTitle"
+              defaultMessage="Create with ES|QL"
+            />
+          }
+          titleElement="h3"
+          titleSize="xs"
+          description={esqlDescription}
+          href={esqlHref}
+          hasBorder={true}
+          display="plain"
+        />
+      </EuiFlexItem>
+      {showAiCard ? (
+        <EuiFlexItem>
+          <EuiCard
+            data-test-subj="rulesListEmptyStateCreateWithAiCard"
+            icon={aiIcon}
+            layout="vertical"
+            textAlign="left"
+            css={verticalCardTextLeftCss}
+            title={
+              <FormattedMessage
+                id="xpack.alertingV2.rulesList.emptyStateCreateWithAiCardTitle"
+                defaultMessage="Create with AI"
+              />
+            }
+            titleElement="h3"
+            titleSize="xs"
+            description={aiDescription}
+            onClick={onCreateWithAi}
+            hasBorder={true}
+            display="plain"
+          />
+        </EuiFlexItem>
+      ) : null}
+    </EuiFlexGrid>
+  );
+};

--- a/x-pack/platform/plugins/shared/alerting_v2/public/rule_builders/rules_list_empty_state.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/rule_builders/rules_list_empty_state.tsx
@@ -1,0 +1,167 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { css } from '@emotion/react';
+import {
+  EuiButton,
+  EuiEmptyPrompt,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiLink,
+  EuiSpacer,
+  EuiText,
+} from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n-react';
+import { PluginStart } from '@kbn/core-di';
+import { CoreStart, useService } from '@kbn/core-di-browser';
+import type { AgentBuilderPluginStart } from '@kbn/agent-builder-plugin/public';
+import { ALERTING_RULES_GUIDE_DOC_URL, paths } from '../constants';
+import { RuleBuilderGrid } from './rule_builder_grid';
+
+/** EUI defaults `euiEmptyPrompt__content` to max-width 36em (~576px); widen to match layout spec. */
+const RULES_EMPTY_PROMPT_MAX_WIDTH_PX = 850;
+
+const rulesListEmptyPromptCss = css({
+  width: '100%',
+  maxWidth: RULES_EMPTY_PROMPT_MAX_WIDTH_PX,
+  marginInline: 'auto',
+  '& .euiEmptyPrompt__main': {
+    width: '100%',
+    maxWidth: RULES_EMPTY_PROMPT_MAX_WIDTH_PX,
+  },
+  '& .euiEmptyPrompt__content': {
+    maxWidth: `${RULES_EMPTY_PROMPT_MAX_WIDTH_PX}px`,
+    width: '100%',
+  },
+});
+
+export const RulesListEmptyState = () => {
+  const { basePath } = useService(CoreStart('http'));
+  const application = useService(CoreStart('application'));
+  const agentBuilder = useService(PluginStart('agentBuilder'), {
+    optional: true,
+  }) as AgentBuilderPluginStart | undefined;
+
+  const esqlAdvancedHref = basePath.prepend(paths.ruleCreateFormEsqlAdvanced);
+  const hubHref = basePath.prepend(paths.ruleCreate);
+  const docUrl = ALERTING_RULES_GUIDE_DOC_URL;
+  const canOpenAgentBuilder = application.capabilities.agentBuilder?.show === true;
+  const showAskAiAgentButton = canOpenAgentBuilder && Boolean(agentBuilder);
+
+  return (
+    <div
+      data-test-subj="rulesListEmptyState"
+      css={{
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        width: '100%',
+        minHeight: 'min(78vh, 920px)',
+        paddingBlock: 24,
+        paddingInline: 16,
+        boxSizing: 'border-box',
+      }}
+    >
+      <div css={{ maxWidth: RULES_EMPTY_PROMPT_MAX_WIDTH_PX, width: '100%' }}>
+        <EuiEmptyPrompt
+          css={rulesListEmptyPromptCss}
+          color="plain"
+          hasBorder
+          title={
+            <h2>
+              <FormattedMessage
+                id="xpack.alertingV2.rulesList.emptyStateTitle"
+                defaultMessage="Welcome to the new Alerting experience"
+              />
+            </h2>
+          }
+          body={
+            <p>
+              <FormattedMessage
+                id="xpack.alertingV2.rulesList.emptyStateDescription"
+                defaultMessage="With powerful ES|QL-driven rules and support for external alerts, it delivers consistent, high-quality alert data into a unified experience."
+              />
+            </p>
+          }
+          actions={
+            <div css={{ width: '100%' }}>
+              <RuleBuilderGrid variant="featured" />
+              <EuiSpacer size="m" />
+              <EuiText size="s" textAlign="center">
+                <EuiLink href={hubHref} data-test-subj="rulesListEmptyStateViewAllBuildersLink">
+                  <FormattedMessage
+                    id="xpack.alertingV2.rulesList.emptyStateViewAllBuilders"
+                    defaultMessage="View all rule builders"
+                  />
+                </EuiLink>
+              </EuiText>
+              <EuiSpacer size="m" />
+              <EuiFlexGroup alignItems="center" justifyContent="center" gutterSize="s" wrap>
+                <EuiFlexItem grow={false}>
+                  <EuiButton
+                    size="s"
+                    href={esqlAdvancedHref}
+                    color="text"
+                    data-test-subj="rulesListEmptyStateEsqlAdvancedButton"
+                  >
+                    <FormattedMessage
+                      id="xpack.alertingV2.rulesList.emptyStateEsqlAdvancedLink"
+                      defaultMessage="Create with ES|QL"
+                    />
+                  </EuiButton>
+                </EuiFlexItem>
+                {showAskAiAgentButton ? (
+                  <EuiFlexItem grow={false}>
+                    <EuiButton
+                      size="s"
+                      color="text"
+                      iconType="productAgent"
+                      data-test-subj="rulesListEmptyStateAgentBuilderButton"
+                      onClick={() => {
+                        agentBuilder?.toggleChat();
+                      }}
+                    >
+                      <FormattedMessage
+                        id="xpack.alertingV2.rulesList.emptyStateAskAiAgentButton"
+                        defaultMessage="Ask AI Agent"
+                      />
+                    </EuiButton>
+                  </EuiFlexItem>
+                ) : null}
+              </EuiFlexGroup>
+            </div>
+          }
+          footer={
+            <EuiText size="s" textAlign="center">
+              <FormattedMessage
+                id="xpack.alertingV2.rulesList.emptyStateDocFooter"
+                defaultMessage="Want to learn more? {docLink}"
+                values={{
+                  docLink: (
+                    <EuiLink
+                      href={docUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      external
+                      data-test-subj="rulesListEmptyStateDocumentationLink"
+                    >
+                      <FormattedMessage
+                        id="xpack.alertingV2.rulesList.emptyStateDocLinkText"
+                        defaultMessage="Read documentation"
+                      />
+                    </EuiLink>
+                  ),
+                }}
+              />
+            </EuiText>
+          }
+        />
+      </div>
+    </div>
+  );
+};

--- a/x-pack/platform/plugins/shared/alerting_v2/public/rule_builders/rules_list_empty_state.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/rule_builders/rules_list_empty_state.tsx
@@ -12,9 +12,11 @@ import {
   EuiEmptyPrompt,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiHorizontalRule,
   EuiLink,
   EuiSpacer,
   EuiText,
+  EuiTitle,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { PluginStart } from '@kbn/core-di';
@@ -90,6 +92,15 @@ export const RulesListEmptyState = () => {
           }
           actions={
             <div css={{ width: '100%' }}>
+              <EuiTitle size="xs">
+                <h3>
+                  <FormattedMessage
+                    id="xpack.alertingV2.rulesList.emptyStateRuleBuilderSectionTitle"
+                    defaultMessage="Create using a Rule builder"
+                  />
+                </h3>
+              </EuiTitle>
+              <EuiSpacer size="s" />
               <RuleBuilderGrid variant="featured" />
               <EuiSpacer size="m" />
               <EuiText size="s" textAlign="center">
@@ -100,6 +111,28 @@ export const RulesListEmptyState = () => {
                   />
                 </EuiLink>
               </EuiText>
+              <EuiSpacer size="l" />
+              <EuiFlexGroup
+                alignItems="center"
+                responsive={false}
+                gutterSize="s"
+                data-test-subj="rulesListEmptyStateOrSeparator"
+              >
+                <EuiFlexItem grow css={{ minWidth: 0 }}>
+                  <EuiHorizontalRule margin="none" />
+                </EuiFlexItem>
+                <EuiFlexItem grow={false}>
+                  <EuiText size="xs" color="subdued">
+                    <FormattedMessage
+                      id="xpack.alertingV2.rulesList.emptyStateOrSeparator"
+                      defaultMessage="or"
+                    />
+                  </EuiText>
+                </EuiFlexItem>
+                <EuiFlexItem grow css={{ minWidth: 0 }}>
+                  <EuiHorizontalRule margin="none" />
+                </EuiFlexItem>
+              </EuiFlexGroup>
               <EuiSpacer size="m" />
               <EuiFlexGroup alignItems="center" justifyContent="center" gutterSize="s" wrap>
                 <EuiFlexItem grow={false}>
@@ -128,7 +161,7 @@ export const RulesListEmptyState = () => {
                     >
                       <FormattedMessage
                         id="xpack.alertingV2.rulesList.emptyStateAskAiAgentButton"
-                        defaultMessage="Ask AI Agent"
+                        defaultMessage="Create with AI Agent"
                       />
                     </EuiButton>
                   </EuiFlexItem>

--- a/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/ui/fixtures/page_objects/rule_form_page.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/ui/fixtures/page_objects/rule_form_page.ts
@@ -17,7 +17,7 @@ export class RuleFormPage {
   }
 
   async gotoCreate() {
-    await this.page.gotoApp('management/alertingV2/rules/create');
+    await this.page.gotoApp('management/alertingV2/rules/create/form');
   }
 
   async gotoRulesList() {

--- a/x-pack/platform/plugins/shared/alerting_v2/tsconfig.json
+++ b/x-pack/platform/plugins/shared/alerting_v2/tsconfig.json
@@ -94,7 +94,8 @@
     "@kbn/utility-types",
     "@kbn/usage-collection-plugin",
     "@kbn/share-plugin",
-    "@kbn/deeplinks-analytics"
+    "@kbn/deeplinks-analytics",
+    "@kbn/agent-builder-plugin"
   ],
   "exclude": ["target/**/*"]
 }


### PR DESCRIPTION
> This is a UX prototype. The code generated is **not ready for implementation**.

## Summary
Prototype and UX improvements for Alerting v2 rule authoring: GUI/YAML editing, create hub entry points, and ES|QL vs rule builder switching.

### Rule form (`alerting-v2-rule-form`)
- **GUI / YAML** toggle at the top of the form with full-form switch between `GuiRuleForm` and `YamlRuleForm`; controlled YAML draft and `parseYamlToFormValuesForGuiSwitch` when returning to GUI.
- **Condition field group**: prototype notice placement and danger text color; rule builder row with label alignment and `EuiSuperSelect`.
- **Tests**: `rule_form`, `edit_mode_toggle`, `yaml_form_utils`; preview-related tests updated where mocks/context changed.

### `alerting_v2` plugin
- **ES|QL header actions**: tooltips on mode icons; confirmation when switching to builder or ES|QL with shared explanation about data carryover.
- **Rule create hub**: `RuleCreationEntryCards` for ES|QL and AI; empty state restored to featured grid + ES|QL/AI buttons.
- **Counter Rate** builder icon fix: `metricsApp` (replaces invalid `metric`).

### Checklist (author)
- [ ] `node scripts/check_changes.ts`
- [ ] `node scripts/i18n_check --fix` if needed
- [ ] Scoped tests / eslint as appropriate

Made with [Cursor](https://cursor.com)