### PR TITLE
[Agent Builder] Fix - Conversation - add padding for scrollbar and wrap long links

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation.tsx
@@ -138,6 +138,7 @@ export const Conversation: React.FC<{}> = () => {
   const scrollableStyles = css`
     ${useEuiScrollBar()}
     ${useEuiOverflowScroll('y')}
+    scrollbar-gutter: stable both-edges;
   `;
 
   const inputPaddingStyles = css`

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/external_link_modal.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/external_link_modal.tsx
@@ -5,9 +5,14 @@
  * 2.0.
  */
 
-import { EuiConfirmModal, useGeneratedHtmlId } from '@elastic/eui';
+import { EuiConfirmModal, euiTextBreakWord, useGeneratedHtmlId } from '@elastic/eui';
 import React from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { css } from '@emotion/react';
+
+const linkStyles = css`
+  ${euiTextBreakWord()}
+`;
 
 interface ExternalLinkModalProps {
   url: string | null;
@@ -55,7 +60,7 @@ export const ExternalLinkModal: React.FC<ExternalLinkModalProps> = ({ url, onClo
           defaultMessage="You are about to navigate to an external site:{lineBreak}{url}"
           values={{
             lineBreak: <br />,
-            url: <strong>{url}</strong>,
+            url: <strong css={linkStyles}>{url}</strong>,
           }}
         />
       </p>


### PR DESCRIPTION


## Summary

Add `scrollbar-gutter: stable both-edges` to conversation rounds scrollable area

<img width="1912" height="1232" alt="Screenshot 2026-04-15 at 3 24 27 PM" src="https://github.com/user-attachments/assets/08723a1e-3788-4fd4-9a8d-f62264fda91f" />

## Additional changes
- Small bugfix for adding break word wrapping for long external links

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...





<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->