### PR TITLE
[Discover][Metrics] Prioritize metrics profile resolution over logs profile

### DIFF
--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/register_profile_providers.test.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/register_profile_providers.test.ts
@@ -15,6 +15,8 @@ import { createExampleDataSourceProfileProvider } from './example/example_data_s
 import { createExampleDocumentProfileProvider } from './example/example_document_profile';
 import { registerProfileProviders } from './register_profile_providers';
 import type { BaseProfileProvider } from '../profile_service';
+import { SolutionType } from '../profiles';
+import { METRICS_DATA_SOURCE_PROFILE_ID } from './common/metrics_data_source_profile/profile';
 
 const levels = ['root', 'data-source', 'document'];
 let mockAllCollectedProfiles: Array<{ level: string; profileId: string }> = [];
@@ -142,6 +144,32 @@ describe('registerProfileProviders', () => {
 
     const allCollectedProfileIds = mockAllCollectedProfiles.map((p) => p.profileId);
     expect(allCollectedProfileIds).toEqual(uniq(allCollectedProfileIds));
+  });
+
+  it('should resolve metrics profile for TS queries against index patterns matching logs base patterns', async () => {
+    const profileProviderServices = createProfileProviderSharedServicesMock();
+    jest.spyOn(profileProviderServices.core.pricing, 'isFeatureAvailable').mockReturnValue(true);
+    const { rootProfileServiceMock, dataSourceProfileServiceMock, documentProfileServiceMock } =
+      createContextAwarenessMocks({
+        shouldRegisterProviders: false,
+      });
+    registerProfileProviders({
+      rootProfileService: rootProfileServiceMock,
+      dataSourceProfileService: dataSourceProfileServiceMock,
+      documentProfileService: documentProfileServiceMock,
+      enabledExperimentalProfileIds: [],
+      sharedServices: profileProviderServices,
+      services: profileProviderServices,
+    });
+    const rootContext = await rootProfileServiceMock.resolve({
+      solutionNavId: SolutionType.Observability,
+    });
+    const dataSourceContext = await dataSourceProfileServiceMock.resolve({
+      rootContext,
+      dataSource: createEsqlDataSource(),
+      query: { esql: 'TS metrics-logstash.otel-default' },
+    });
+    expect(dataSourceContext.profileId).toBe(METRICS_DATA_SOURCE_PROFILE_ID);
   });
 
   it('all profile ids should be named appropriate to their context level', async () => {

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/register_profile_providers.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/register_profile_providers.ts
@@ -121,9 +121,9 @@ const createDataSourceProfileProviders = (providerServices: ProfileProviderServi
   createExampleDataSourceProfileProvider(),
   createPatternsDataSourceProfileProvider(providerServices),
   createDeprecationLogsDataSourceProfileProvider(),
+  createMetricsDataSourceProfileProvider(),
   ...createObservabilityLogsDataSourceProfileProviders(providerServices),
   ...createObservabilityTracesDataSourceProfileProviders(providerServices),
-  createMetricsDataSourceProfileProvider(),
 ];
 
 /**


### PR DESCRIPTION
## Summary

Resolves elastic/kibana#263137.

When querying a time-series data stream whose name contains "log" (e.g.,`metrics-logstash.otel-default`) with a `TS` command, the logs data source profile was incorrectly matching before the metrics profile could resolve. This caused the metrics grid to not appear, showing a logs-style document list instead.

The fix moves `createMetricsDataSourceProfileProvider()` ahead of the logs and traces providers in the profile resolution order. This is safe because the metrics profile only matches queries where every ES|QL command is in its supported set (`ts`, `limit`, `sort`, `where`); `FROM` queries still fall through to the logs and traces profiles as before.

## Test plan

- Start Kibana with the Observability solution type
- Create a time-series data stream with "log" in the name (e.g.,
  `metrics-logstash.otel-default`) configured with `time_series_metric`
  and `time_series_dimension` mappings
- Open Discover, switch to ES|QL mode
- Query `TS metrics-logstash.otel-default`
- Verify the metrics grid appears (not the logs document list)
- Query `FROM logs-*` and verify the logs profile still activates correctly


<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->