### PR TITLE
[Detection Engine][9.2] Fix Missing Add Exception Button

### DIFF
--- a/x-pack/solutions/security/packages/kbn-securitysolution-exception-list-components/src/search_bar/index.tsx
+++ b/x-pack/solutions/security/packages/kbn-securitysolution-exception-list-components/src/search_bar/index.tsx
@@ -98,7 +98,7 @@ const SearchBarComponent: FC<SearchBarProps> = ({
           onChange={handleOnSearch}
         />
       </EuiFlexItem>
-      {!canAddException && (
+      {canAddException && (
         <EuiFlexItem grow={false}>
           <EuiButton
             data-test-subj={`${dataTestSubj || ''}Button`}

--- a/x-pack/solutions/security/packages/kbn-securitysolution-exception-list-components/src/search_bar/search_bar.test.tsx
+++ b/x-pack/solutions/security/packages/kbn-securitysolution-exception-list-components/src/search_bar/search_bar.test.tsx
@@ -20,7 +20,7 @@ describe('SearchBar', () => {
         onSearch={jest.fn()}
         onAddExceptionClick={jest.fn()}
         isSearching={false}
-        canAddException
+        canAddException={false}
         dataTestSubj="searchBar"
       />
     );
@@ -32,7 +32,7 @@ describe('SearchBar', () => {
     const mockOnAddExceptionClick = jest.fn();
     const wrapper = render(
       <SearchBar
-        canAddException={false}
+        canAddException
         listType={ExceptionListTypeEnum.DETECTION}
         isSearching={false}
         onSearch={jest.fn()}
@@ -53,7 +53,7 @@ describe('SearchBar', () => {
     const mockOnAddExceptionClick = jest.fn();
     const wrapper = render(
       <SearchBar
-        canAddException={false}
+        canAddException
         listType={ExceptionListTypeEnum.ENDPOINT}
         isSearching={false}
         onSearch={jest.fn()}

--- a/x-pack/solutions/security/plugins/security_solution/public/exceptions/components/list_with_search/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/exceptions/components/list_with_search/index.tsx
@@ -17,6 +17,7 @@ import {
   EmptyViewerState,
   ViewerStatus,
 } from '@kbn/securitysolution-exception-list-components';
+import { useUserPrivileges } from '../../../common/components/user_privileges';
 import { useEndpointExceptionsCapability } from '../../hooks/use_endpoint_exceptions_capability';
 import { AddExceptionFlyout } from '../../../detection_engine/rule_exceptions/components/add_exception_flyout';
 import { EditExceptionFlyout } from '../../../detection_engine/rule_exceptions/components/edit_exception_flyout';
@@ -59,6 +60,10 @@ const ListWithSearchComponent: FC<ListWithSearchComponentProps> = ({
     handleConfirmExceptionFlyout,
   } = useListWithSearchComponent(list, refreshExceptions);
   const canWriteEndpointExceptions = useEndpointExceptionsCapability('crudEndpointExceptions');
+  const canEditExceptions = useUserPrivileges().kibanaSecuritySolutionsPrivileges.crud;
+
+  const canAddException =
+    listType === ExceptionListTypeEnum.ENDPOINT ? canWriteEndpointExceptions : canEditExceptions;
 
   return (
     <>
@@ -109,9 +114,7 @@ const ListWithSearchComponent: FC<ListWithSearchComponentProps> = ({
               isSearching={viewerStatus === ViewerStatus.SEARCHING}
               isButtonFilled={false}
               buttonIconType="plusInCircle"
-              canAddException={
-                !(listType === ExceptionListTypeEnum.ENDPOINT && canWriteEndpointExceptions)
-              }
+              canAddException={canAddException}
             />
             <ListExceptionItems
               viewerStatus={exceptionViewerStatus as ViewerStatus}


### PR DESCRIPTION
## Summary

Fixes [#263640](https://github.com/elastic/kibana/issues/263640).

Fixes a regression where the "Add exception item" button was always hidden in Shared Exception Lists.

**Root cause:** Two bugs combined to create a double-negation:
1. `list_with_search/index.tsx` passed `!(listType === ENDPOINT && canWrite)` as `canAddException` which is always `true` for non-endpoint lists
2. `search_bar/index.tsx` rendered the button when `!canAddException` so it was always hidden

**Fix** (cherry-picked from [#245722](https://github.com/elastic/kibana/pull/245722/changes#diff-030b6cf0fb1839dea00ef2c38526b8cf81e3a05265c5db3d47435ef009720a97R65)):
- Compute `canAddException` correctly based on list type and user privileges
- Render the button when `canAddException` is `true`