### PR TITLE
Unskip flaky space awareness and metadata tests on 9.3

### DIFF
--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/edr_workflows/metadata/trial_license_complete_tier/metadata.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/edr_workflows/metadata/trial_license_complete_tier/metadata.ts
@@ -41,10 +41,9 @@ export default function ({ getService }: FtrProviderContext) {
   const endpointDataStreamHelpers = getService('endpointDataStreamHelpers');
   const utils = getService('securitySolutionUtils');
 
-  // FLAKY: https://github.com/elastic/kibana/issues/246567
   // @skipInServerlessMKI - this test uses internal index manipulation in before/after hooks
   // @skipInServerlessMKI - if you are removing this annotation, make sure to add the test suite to the MKI pipeline in .buildkite/pipelines/security_solution_quality_gate/mki_periodic/mki_periodic_defend_workflows.yml
-  describe.skip('@ess @serverless @skipInServerlessMKI test metadata apis', function () {
+  describe('@ess @serverless @skipInServerlessMKI test metadata apis', function () {
     let adminSupertest: TestAgent;
     let t1AnalystSupertest: TestAgent;
 

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/edr_workflows/spaces/trial_license_complete_tier/response_actions.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/edr_workflows/spaces/trial_license_complete_tier/response_actions.ts
@@ -44,8 +44,7 @@ export default function ({ getService }: FtrProviderContext) {
   const esClient = getService('es');
   const log = getService('log');
 
-  // Failing: See https://github.com/elastic/kibana/issues/249464
-  describe.skip('@ess @skipInServerless, @skipInServerlessMKI Response actions space awareness support', () => {
+  describe('@ess @skipInServerless, @skipInServerlessMKI Response actions space awareness support', () => {
     const afterEachDataCleanup: Array<{ cleanup: () => Promise<void> }> = [];
     let counter = 1;
     let spaceOneId = '';

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/edr_workflows/spaces/trial_license_complete_tier/space_awareness.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/edr_workflows/spaces/trial_license_complete_tier/space_awareness.ts
@@ -24,8 +24,7 @@ export default function ({ getService }: FtrProviderContext) {
   const kbnServer = getService('kibanaServer');
   const log = getService('log');
 
-  // FLAKY: https://github.com/elastic/kibana/issues/247374
-  describe.skip('@ess @serverless @skipInServerlessMKI Endpoint management space awareness support', function () {
+  describe('@ess @serverless @skipInServerlessMKI Endpoint management space awareness support', function () {
     let adminSupertest: TestAgent;
     let dataSpaceA: Awaited<ReturnType<typeof endpointTestresources.loadEndpointData>>;
     let dataSpaceB: Awaited<ReturnType<typeof endpointTestresources.loadEndpointData>>;

--- a/x-pack/solutions/security/test/security_solution_endpoint/apps/integrations/policy_details.ts
+++ b/x-pack/solutions/security/test/security_solution_endpoint/apps/integrations/policy_details.ts
@@ -28,9 +28,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
   const endpointTestResources = getService('endpointTestResources');
   const retry = getService('retry');
   const timeout = 150_000;
-  // FLAKY: https://github.com/elastic/kibana/issues/246399
-  // FLAKY: https://github.com/elastic/kibana/issues/246400
-  describe.skip('When on the Endpoint Policy Details Page', function () {
+  describe('When on the Endpoint Policy Details Page', function () {
     targetTags(this, ['@ess', '@serverless']);
 
     let indexedData: IndexedHostsAndAlertsResponse;


### PR DESCRIPTION
## Summary

Unskip tests that were auto-skipped due to transient flakiness. These tests are already unskipped and passing on `main` — the underlying flakiness was environmental, no utility code changes needed.

### Files unskipped
- `space_awareness.ts` — endpoint management space awareness (#247374)
- `response_actions.ts` — response actions space awareness (#249464)
- `metadata.ts` — outer metadata APIs suite (#246567)
- `policy_details.ts` — endpoint policy details (#246399, #246400)

Note: `index.ts` is not included because it was already unskipped on 9.3.

Closes #247374
Closes #249464
Closes #246567
Closes #246399