### PR TITLE
[9.3] [Dashboards] Use archiver for control chaining test instead of console UI (#254581)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1744,6 +1744,7 @@ x-pack/solutions/observability/plugins/observability/server/lib/esql_extensions 
 /src/platform/test/functional/page_objects/dashboard_page* @elastic/kibana-presentation
 /src/platform/test/functional/firefox/dashboard.config.ts @elastic/kibana-presentation # Assigned per: https://github.com/elastic/kibana/issues/15023
 /src/platform/test/functional/fixtures/es_archiver/dashboard @elastic/kibana-presentation # Assigned per: https://github.com/elastic/kibana/issues/15023
+/src/platform/test/functional/fixtures/es_archiver/dashboard_elements @elastic/kibana-presentation
 /src/platform/test/accessibility/apps/dashboard.ts @elastic/kibana-presentation
 /src/platform/test/accessibility/apps/filter_panel.ts @elastic/kibana-presentation
 /x-pack/platform/test/functional/apps/dashboard @elastic/kibana-presentation

--- a/src/platform/test/functional/apps/dashboard_elements/controls/common/control_group_chaining.ts
+++ b/src/platform/test/functional/apps/dashboard_elements/controls/common/control_group_chaining.ts
@@ -18,7 +18,9 @@ import type { FtrProviderContext } from '../../../../ftr_provider_context';
 export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const retry = getService('retry');
   const security = getService('security');
-  const { common, console, dashboard, dashboardControls, header, timePicker } = getPageObjects([
+  const esArchiver = getService('esArchiver');
+  const es = getService('es');
+  const { dashboard, dashboardControls, timePicker } = getPageObjects([
     'dashboardControls',
     'timePicker',
     'dashboard',
@@ -28,31 +30,14 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   ]);
 
   describe('Dashboard control group hierarchical chaining', () => {
-    const newDocuments: Array<{ index: string; id: string }> = [];
     let controlIds: string[];
-
-    const addDocument = async (index: string, document: string) => {
-      await console.enterText('\nPOST ' + index + '/_doc/\n{\n ' + document + '\n}');
-      await console.clickPlay();
-      await header.waitUntilLoadingHasFinished();
-      const response = JSON.parse(await console.getOutputText());
-      newDocuments.push({ index, id: response._id });
-    };
 
     before(async () => {
       await security.testUser.setRoles(['kibana_admin', 'test_logstash_reader', 'animals']);
 
       /* start by adding some incomplete data so that we can test `exists` query */
-      await common.navigateToApp('console');
-      await console.skipTourIfExists();
-      await console.clearEditorText();
-      await addDocument(
-        'animals-cats-2018-01-01',
-        '"@timestamp": "2018-01-01T16:00:00.000Z", \n"animal": "cat"'
-      );
-      await addDocument(
-        'animals-dogs-2018-01-01',
-        '"@timestamp": "2018-01-01T16:00:00.000Z", \n"name": "Max", \n"sound": "woof"'
+      await esArchiver.load(
+        'src/platform/test/functional/fixtures/es_archiver/dashboard_elements/controls'
       );
 
       /* then, create our testing dashboard */
@@ -87,13 +72,8 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     });
 
     after(async () => {
-      await common.navigateToApp('console');
-      await console.clearEditorText();
-      for (const { index, id } of newDocuments) {
-        await console.enterText(`\nDELETE /${index}/_doc/${id}`);
-        await console.clickPlay();
-        await header.waitUntilLoadingHasFinished();
-      }
+      await es.delete({ index: 'animals-cats-2018-01-01', id: 'control-chaining-cat' });
+      await es.delete({ index: 'animals-dogs-2018-01-01', id: 'control-chaining-dog' });
       await security.testUser.restoreDefaults();
     });
 

--- a/src/platform/test/functional/fixtures/es_archiver/dashboard_elements/controls/data.json
+++ b/src/platform/test/functional/fixtures/es_archiver/dashboard_elements/controls/data.json
@@ -1,0 +1,24 @@
+{
+  "type": "doc",
+  "value": {
+    "id": "control-chaining-cat",
+    "index": "animals-cats-2018-01-01",
+    "source": {
+      "@timestamp": "2018-01-01T16:00:00.000Z",
+      "animal": "cat"
+    }
+  }
+}
+
+{
+  "type": "doc",
+  "value": {
+    "id": "control-chaining-dog",
+    "index": "animals-dogs-2018-01-01",
+    "source": {
+      "@timestamp": "2018-01-01T16:00:00.000Z",
+      "name": "Max",
+      "sound": "woof"
+    }
+  }
+}


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/240916

# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Dashboards] Use archiver for control chaining test instead of console UI (#254581)](https://github.com/elastic/kibana/pull/254581)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Zac Xeper","email":"Zacqary@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-02-24T22:24:33Z","message":"[Dashboards] Use archiver for control chaining test instead of console UI (#254581)\n\n## Summary\n\nCloses #248856\n\nReduces flakiness for control chaining tests by uploading their data\nthrough `esArchiver` instead of the console UI","sha":"c4f2a144328741a38ebe3472c484209db7c30638","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Presentation","loe:small","release_note:skip","impact:critical","backport:version","v9.4.0","v9.5.0","v9.3.4"],"title":"[Dashboards] Use archiver for control chaining test instead of console UI","number":254581,"url":"https://github.com/elastic/kibana/pull/254581","mergeCommit":{"message":"[Dashboards] Use archiver for control chaining test instead of console UI (#254581)\n\n## Summary\n\nCloses #248856\n\nReduces flakiness for control chaining tests by uploading their data\nthrough `esArchiver` instead of the console UI","sha":"c4f2a144328741a38ebe3472c484209db7c30638"}},"sourceBranch":"main","suggestedTargetBranches":["9.3"],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/254581","number":254581,"mergeCommit":{"message":"[Dashboards] Use archiver for control chaining test instead of console UI (#254581)\n\n## Summary\n\nCloses #248856\n\nReduces flakiness for control chaining tests by uploading their data\nthrough `esArchiver` instead of the console UI","sha":"c4f2a144328741a38ebe3472c484209db7c30638"}},{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.3","label":"v9.3.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->