### PR TITLE
Upgrade defu from 6.1.4 to 6.1.5

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -19991,9 +19991,9 @@ defined@^1.0.0, defined@^1.0.1:
   integrity sha512-hsBd2qSVCRE+5PmNdHt1uzyrFu5d3RwmFDKzyNZMFq/EwDNJF7Ee5+D5oEKF0hU6LhtoUF1macFvOe4AskQC1Q==
 
 defu@^6.1.4:
-  version "6.1.4"
-  resolved "https://registry.yarnpkg.com/defu/-/defu-6.1.4.tgz#4e0c9cf9ff68fe5f3d7f2765cc1a012dfdcb0479"
-  integrity sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==
+  version "6.1.5"
+  resolved "https://registry.yarnpkg.com/defu/-/defu-6.1.5.tgz#6dc1b8419ce7c39e709a3fa6dde860bd3de69831"
+  integrity sha512-pwdBJxJuJXmqrLO6s0VBmfbRz+G7FUzkjldAsdi9Yrv86mPyzq0ll1o8+8gB4Gsr6GJHbK1Lh3ngllgTInDCjA==
 
 degenerator@^5.0.0:
   version "5.0.1"


### PR DESCRIPTION
## Summary

Upgrade defu from 6.1.4 to 6.1.5




<!--ONMERGE {"backportTargets":["8.19","9.2","9.3","9.4"]} ONMERGE-->