### PR TITLE
[Chrome Next] Add app menu static items

### DIFF
--- a/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/app_menu.stories.tsx
+++ b/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/app_menu.stories.tsx
@@ -327,3 +327,29 @@ export const OverflowAndOrdering: Story = {
     config: overflowAndOrderingConfig,
   },
 };
+
+const staticItem: AppMenuWrapperProps['staticItems'] = [
+  {
+    id: 'feedback',
+    order: 1,
+    label: 'Feedback',
+    run: action('feedback-clicked'),
+    iconType: 'comment',
+    testId: 'feedbackButton',
+  },
+];
+
+export const StandaloneStaticItem: Story = {
+  name: 'Static items - standalone',
+  args: {
+    staticItems: staticItem,
+  },
+};
+
+export const DashboardEditModeWithStaticItems: Story = {
+  name: 'Dashboard edit mode with static items',
+  args: {
+    config: dashboardEditModeConfig,
+    staticItems: staticItem,
+  },
+};

--- a/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/components/app_menu.tsx
+++ b/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/components/app_menu.tsx
@@ -9,11 +9,11 @@
 
 import React, { useState } from 'react';
 import { EuiHeaderLinks, useIsWithinBreakpoints } from '@elastic/eui';
-import { getAppMenuItems } from '../utils';
+import { getAppMenuItems, processStaticItems } from '../utils';
 import { AppMenuActionButton } from './app_menu_action_button';
 import { AppMenuItem } from './app_menu_item';
 import { AppMenuOverflowButton } from './app_menu_overflow_button';
-import type { AppMenuConfig } from '../types';
+import type { AppMenuConfig, AppMenuItemType } from '../types';
 
 export interface AppMenuItemsProps {
   config?: AppMenuConfig;
@@ -24,6 +24,10 @@ export interface AppMenuItemsProps {
    * TODO: Remove this in favour of container queries once EUI supports them https://github.com/elastic/eui/issues/8822
    */
   isCollapsed?: boolean;
+  /**
+   * Static items that always appear at the end of the overflow menu.
+   */
+  staticItems?: AppMenuItemType[];
 }
 
 const hasNoItems = (config: AppMenuConfig) => !config.items?.length && !config?.primaryActionItem;
@@ -32,12 +36,19 @@ export const AppMenuComponent = ({
   config,
   visible = true,
   isCollapsed = false,
+  staticItems,
 }: AppMenuItemsProps) => {
   const [openPopoverId, setOpenPopoverId] = useState<string | null>(null);
   const isBetweenMandXlBreakpoint = useIsWithinBreakpoints(['m', 'l']);
   const isAboveXlBreakpoint = useIsWithinBreakpoints(['xl']);
 
-  if (!config || hasNoItems(config) || !visible) {
+  const hasStaticItems = !!staticItems?.length;
+
+  if ((!config || hasNoItems(config)) && !hasStaticItems) {
+    return null;
+  }
+
+  if (!visible) {
     return null;
   }
 
@@ -51,9 +62,18 @@ export const AppMenuComponent = ({
     className: 'kbnTopNavMenu__wrapper',
   };
 
-  const { displayedItems, overflowItems, shouldOverflow } = getAppMenuItems({
+  const {
+    displayedItems,
+    overflowItems,
+    shouldOverflow: shouldOverflowBase,
+  } = getAppMenuItems({
     config,
   });
+
+  const processedStaticItems = processStaticItems(staticItems);
+
+  const allOverflowItems = [...overflowItems];
+  const shouldOverflow = shouldOverflowBase || processedStaticItems.length > 0;
 
   const handlePopoverToggle = (id: string) => {
     setOpenPopoverId(openPopoverId === id ? null : id);
@@ -76,7 +96,8 @@ export const AppMenuComponent = ({
 
   const collapsedComponent = (
     <AppMenuOverflowButton
-      items={[...displayedItems, ...overflowItems]}
+      items={[...displayedItems, ...allOverflowItems]}
+      staticItems={processedStaticItems}
       isPopoverOpen={openPopoverId === showMoreButtonId}
       primaryActionItem={primaryActionItem}
       onPopoverToggle={() => handlePopoverToggle(showMoreButtonId)}
@@ -92,7 +113,8 @@ export const AppMenuComponent = ({
     return (
       <EuiHeaderLinks {...headerLinksProps}>
         <AppMenuOverflowButton
-          items={[...displayedItems, ...overflowItems]}
+          items={[...displayedItems, ...allOverflowItems]}
+          staticItems={processedStaticItems}
           isPopoverOpen={openPopoverId === showMoreButtonId}
           onPopoverToggle={() => handlePopoverToggle(showMoreButtonId)}
           onPopoverClose={handleOnPopoverClose}
@@ -117,7 +139,8 @@ export const AppMenuComponent = ({
           ))}
         {shouldOverflow && (
           <AppMenuOverflowButton
-            items={overflowItems}
+            items={allOverflowItems}
+            staticItems={processedStaticItems}
             isPopoverOpen={openPopoverId === showMoreButtonId}
             onPopoverToggle={() => handlePopoverToggle(showMoreButtonId)}
             onPopoverClose={handleOnPopoverClose}

--- a/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/components/app_menu_overflow_button.tsx
+++ b/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/components/app_menu_overflow_button.tsx
@@ -17,6 +17,7 @@ import type { AppMenuItemType, AppMenuPrimaryActionItem } from '../types';
 
 interface AppMenuShowMoreButtonProps {
   items: AppMenuItemType[];
+  staticItems?: AppMenuItemType[];
   isPopoverOpen: boolean;
   primaryActionItem?: AppMenuPrimaryActionItem;
   onPopoverToggle: () => void;
@@ -25,6 +26,7 @@ interface AppMenuShowMoreButtonProps {
 
 export const AppMenuOverflowButton = ({
   items,
+  staticItems,
   isPopoverOpen,
   primaryActionItem,
   onPopoverToggle,
@@ -32,7 +34,7 @@ export const AppMenuOverflowButton = ({
 }: AppMenuShowMoreButtonProps) => {
   const { euiTheme } = useEuiTheme();
 
-  if (items.length === 0) {
+  if (items.length === 0 && (!staticItems || staticItems.length === 0)) {
     return null;
   }
 
@@ -52,7 +54,7 @@ export const AppMenuOverflowButton = ({
 
   const button = (
     <EuiButtonIcon
-      iconType="boxesVertical" // TODO: Change to "ellipsis" when it's available in EUI.
+      iconType="ellipsis"
       size="xs"
       aria-label={i18n.translate('core.chrome.appMenu.showMoreButtonLabel', {
         defaultMessage: 'More',
@@ -69,6 +71,7 @@ export const AppMenuOverflowButton = ({
   return (
     <AppMenuPopover
       items={items}
+      staticItems={staticItems}
       anchorElement={button}
       tooltipContent={i18n.translate('core.chrome.appMenu.showMoreButtonTooltip', {
         defaultMessage: 'More',

--- a/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/components/app_menu_popover.tsx
+++ b/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/components/app_menu_popover.tsx
@@ -10,7 +10,7 @@
 import React, { useMemo, type ReactElement } from 'react';
 import { EuiContextMenu, EuiPopover, EuiToolTip } from '@elastic/eui';
 import { getPopoverPanels, getTooltip } from '../utils';
-import type { AppMenuPopoverItem, AppMenuPrimaryActionItem } from '../types';
+import type { AppMenuItemType, AppMenuPopoverItem, AppMenuPrimaryActionItem } from '../types';
 
 interface AppMenuContextMenuProps {
   tooltipContent?: string | (() => string | undefined);
@@ -18,6 +18,7 @@ interface AppMenuContextMenuProps {
   anchorElement: ReactElement;
   anchorDomElement?: HTMLElement;
   items: AppMenuPopoverItem[];
+  staticItems?: AppMenuItemType[];
   isOpen: boolean;
   popoverWidth?: number;
   primaryActionItem?: AppMenuPrimaryActionItem;
@@ -28,6 +29,7 @@ interface AppMenuContextMenuProps {
 
 export const AppMenuPopover = ({
   items,
+  staticItems,
   anchorElement,
   anchorDomElement,
   tooltipContent,
@@ -43,6 +45,7 @@ export const AppMenuPopover = ({
     () =>
       getPopoverPanels({
         items,
+        staticItems,
         primaryActionItem,
         rootPanelWidth: popoverWidth,
         rootPopoverTestId: popoverTestId,
@@ -52,6 +55,7 @@ export const AppMenuPopover = ({
       }),
     [
       items,
+      staticItems,
       primaryActionItem,
       popoverWidth,
       popoverTestId,

--- a/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/utils.test.tsx
+++ b/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/utils.test.tsx
@@ -17,9 +17,10 @@ import {
   getPopoverActionItems,
   getPopoverPanels,
   getIsSelectedColor,
+  processStaticItems,
 } from './utils';
 import { APP_MENU_ITEM_LIMIT } from './constants';
-import type { AppMenuPopoverItem } from './types';
+import type { AppMenuItemType, AppMenuPopoverItem } from './types';
 
 describe('utils', () => {
   describe('createReturnFocus', () => {
@@ -633,6 +634,77 @@ describe('utils', () => {
       expect(sharePanel?.['data-test-subj']).toBe('sharePopoverPanel');
       expect(mainPanel?.['data-test-subj']).toBeUndefined(); // Main panel has no test ID by default
     });
+
+    it('should append staticItems after regular items in the main panel', () => {
+      const items: AppMenuPopoverItem[] = [
+        { id: '1', label: 'Item 1', run: jest.fn(), order: 2 },
+        { id: '2', label: 'Item 2', run: jest.fn(), order: 1 },
+      ];
+      const staticItems: AppMenuPopoverItem[] = [
+        { id: 'static1', label: 'Static 1', run: jest.fn(), order: 1 },
+      ];
+
+      const panels = getPopoverPanels({ items, staticItems });
+
+      expect(panels).toHaveLength(1);
+      const panelItems = panels[0].items as Array<{ key?: string }>;
+      // Regular items sorted by order: Item 2 (order 1), Item 1 (order 2), then static
+      expect(panelItems.map((i) => i.key)).toEqual(['2', '1', 'static1']);
+    });
+
+    it('should not re-sort staticItems together with regular items', () => {
+      const items: AppMenuPopoverItem[] = [
+        { id: 'regular', label: 'Regular', run: jest.fn(), order: 10 },
+      ];
+      const staticItems: AppMenuPopoverItem[] = [
+        { id: 'static1', label: 'Static', run: jest.fn(), order: 1 },
+      ];
+
+      const panels = getPopoverPanels({ items, staticItems });
+
+      const panelItems = panels[0].items as Array<{ key?: string }>;
+      // Static item with order 1 should still come after regular item with order 10
+      expect(panelItems[0].key).toBe('regular');
+      expect(panelItems[panelItems.length - 1].key).toBe('static1');
+    });
+
+    it('should handle staticItems with nested sub-items', () => {
+      const items: AppMenuPopoverItem[] = [{ id: '1', label: 'Item 1', run: jest.fn(), order: 1 }];
+      const staticItems: AppMenuPopoverItem[] = [
+        {
+          id: 'static-parent',
+          label: 'Static Parent',
+          order: 1,
+          items: [{ id: 'static-child', label: 'Static Child', run: jest.fn(), order: 1 }],
+        },
+      ];
+
+      const panels = getPopoverPanels({ items, staticItems });
+
+      // Main panel + child panel for static item
+      expect(panels).toHaveLength(2);
+      const childPanel = panels.find((p) => p.title === 'Static Parent');
+      expect(childPanel).toBeDefined();
+    });
+
+    it('should place staticItems before action items', () => {
+      const items: AppMenuPopoverItem[] = [{ id: '1', label: 'Item 1', run: jest.fn(), order: 1 }];
+      const staticItems: AppMenuPopoverItem[] = [
+        { id: 'static1', label: 'Static', run: jest.fn(), order: 1 },
+      ];
+
+      const panels = getPopoverPanels({
+        items,
+        staticItems,
+        primaryActionItem: { id: 'save', label: 'Save', run: jest.fn(), iconType: 'save' },
+      });
+
+      const panelItems = panels[0].items as Array<{ key?: string }>;
+      // Order: regular item, separator, static, action-separator, action-items
+      const staticIndex = panelItems.findIndex((i) => i.key === 'static1');
+      const actionIndex = panelItems.findIndex((i) => i.key === 'action-items');
+      expect(staticIndex).toBeLessThan(actionIndex);
+    });
   });
 
   describe('getIsSelectedColor', () => {
@@ -688,6 +760,79 @@ describe('utils', () => {
       });
 
       expect(result).toBe('#fallback');
+    });
+  });
+
+  describe('processStaticItems', () => {
+    const createStaticItem = (overrides: Record<string, unknown> = {}): AppMenuItemType =>
+      ({
+        id: 'item1',
+        order: 1,
+        label: 'Item 1',
+        run: jest.fn(),
+        iconType: 'gear',
+        ...overrides,
+      } as AppMenuItemType);
+
+    it('should return an empty array when no items are provided', () => {
+      expect(processStaticItems()).toEqual([]);
+      expect(processStaticItems([])).toEqual([]);
+    });
+
+    it('should set overflow to true on all items', () => {
+      const items = [
+        createStaticItem({ id: 'a', order: 1 }),
+        createStaticItem({ id: 'b', order: 2 }),
+      ];
+      const result = processStaticItems(items);
+
+      expect(result.every((item) => item.overflow === true)).toBe(true);
+    });
+
+    it('should add separator "above" only to the first item', () => {
+      const items = [
+        createStaticItem({ id: 'a', order: 1 }),
+        createStaticItem({ id: 'b', order: 2 }),
+        createStaticItem({ id: 'c', order: 3 }),
+      ];
+      const result = processStaticItems(items);
+
+      expect(result[0].separator).toBe('above');
+      expect(result[1].separator).toBeUndefined();
+      expect(result[2].separator).toBeUndefined();
+    });
+
+    it('should strip existing separator values from non-first items', () => {
+      const items = [
+        createStaticItem({ id: 'a', order: 1, separator: 'below' }),
+        createStaticItem({ id: 'b', order: 2, separator: 'above' }),
+      ];
+      const result = processStaticItems(items);
+
+      expect(result[0].separator).toBe('above');
+      expect(result[1].separator).toBeUndefined();
+    });
+
+    it('should sort items by order', () => {
+      const items = [
+        createStaticItem({ id: 'c', order: 3 }),
+        createStaticItem({ id: 'a', order: 1 }),
+        createStaticItem({ id: 'b', order: 2 }),
+      ];
+      const result = processStaticItems(items);
+
+      expect(result.map((item) => item.id)).toEqual(['a', 'b', 'c']);
+    });
+
+    it('should add separator "above" to the first item after sorting', () => {
+      const items = [
+        createStaticItem({ id: 'c', order: 3 }),
+        createStaticItem({ id: 'a', order: 1 }),
+      ];
+      const result = processStaticItems(items);
+
+      expect(result[0].id).toBe('a');
+      expect(result[0].separator).toBe('above');
     });
   });
 });

--- a/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/utils.tsx
+++ b/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/utils.tsx
@@ -23,10 +23,14 @@ import { AppMenuPopoverActionButtons } from './components/app_menu_popover_actio
 import type {
   AppMenuConfig,
   AppMenuItemCommon,
+  AppMenuItemType,
   AppMenuPopoverItem,
   AppMenuPrimaryActionItem,
 } from './types';
 import { APP_MENU_ITEM_LIMIT, DEFAULT_POPOVER_WIDTH } from './constants';
+
+const sortByOrder = <T extends { order: number }>(items: T[]): T[] =>
+  [...items].sort((a, b) => a.order - b.order);
 
 /**
  * Calculate how many items can be displayed.
@@ -67,8 +71,8 @@ export const getShouldOverflow = ({
 /**
  * Split the items into displayed and overflow based on the configuration.
  */
-export const getAppMenuItems = ({ config }: { config: AppMenuConfig }) => {
-  if (!config.items) {
+export const getAppMenuItems = ({ config }: { config?: AppMenuConfig }) => {
+  if (!config || !config.items) {
     return {
       displayedItems: [],
       overflowItems: [],
@@ -79,7 +83,7 @@ export const getAppMenuItems = ({ config }: { config: AppMenuConfig }) => {
   const displayedItemsAllowedAmount = getDisplayedItemsAllowedAmount(config);
   const shouldOverflow = getShouldOverflow({ config, displayedItemsAllowedAmount });
 
-  const sortedItems = [...config.items].sort((a, b) => a.order - b.order);
+  const sortedItems = sortByOrder(config.items);
   const nonOverflowItems = sortedItems.filter((item) => !item.overflow);
 
   if (!shouldOverflow) {
@@ -100,6 +104,13 @@ export const getAppMenuItems = ({ config }: { config: AppMenuConfig }) => {
     shouldOverflow: overflowItems.length > 0,
   };
 };
+
+export const processStaticItems = (staticItems?: AppMenuItemType[]): AppMenuItemType[] =>
+  sortByOrder(staticItems ?? []).map(({ separator, ...item }, index) => ({
+    ...item,
+    overflow: true,
+    ...(index === 0 ? { separator: 'above' as const } : {}),
+  }));
 
 export const isDisabled = (disableButton: AppMenuItemCommon['disableButton']) =>
   Boolean(isFunction(disableButton) ? disableButton() : disableButton);
@@ -258,6 +269,7 @@ export const getPopoverActionItems = ({
  */
 export const getPopoverPanels = ({
   items,
+  staticItems,
   primaryActionItem,
   startPanelId = 0,
   rootPanelWidth = DEFAULT_POPOVER_WIDTH,
@@ -267,6 +279,7 @@ export const getPopoverPanels = ({
   anchorDomElement,
 }: {
   items: AppMenuPopoverItem[];
+  staticItems?: AppMenuPopoverItem[];
   primaryActionItem?: AppMenuPrimaryActionItem;
   startPanelId?: number;
   rootPanelWidth?: number;
@@ -356,6 +369,29 @@ export const getPopoverPanels = ({
     parentPopoverTestId: rootPopoverTestId,
     parentPopoverWidth: rootPanelWidth,
   });
+
+  /**
+   * Static items are appended to the main panel after the sorted regular items,
+   * preserving their own order without being re-sorted with regular items.
+   */
+  if (staticItems && staticItems.length > 0) {
+    const staticPanelId = -1;
+    processItems({
+      itemsToProcess: staticItems,
+      panelId: staticPanelId,
+    });
+
+    const staticPanel = panels.find((panel) => panel.id === staticPanelId);
+    const mainPanel = panels.find((panel) => panel.id === startPanelId);
+
+    if (staticPanel && mainPanel) {
+      mainPanel.items = [
+        ...(mainPanel.items as EuiContextMenuPanelItemDescriptor[]),
+        ...(staticPanel.items as EuiContextMenuPanelItemDescriptor[]),
+      ];
+      panels.splice(panels.indexOf(staticPanel), 1);
+    }
+  }
 
   /**
    * Action items are only added to the main panel and only in lower breakpoints (below "m").


### PR DESCRIPTION
## Summary

This PR adds the architecture for allowing app menu to have static items - items that are always in overflow menu and appear below all other items. 

<img width="271" height="344" alt="Screenshot 2026-04-16 at 00 14 50" src="https://github.com/user-attachments/assets/6a39b06c-28c9-4a9a-b660-8d7669f1adbb" />


