### PR TITLE
[Macroscope] Flaky test runner nudge improvements (address edge cases)

### DIFF
--- a/.macroscope/flaky-test-runner-nudge.md
+++ b/.macroscope/flaky-test-runner-nudge.md
@@ -4,17 +4,10 @@ model: claude-opus-4-6
 reasoning: high
 effort: high
 input: full_diff
-exclude:
-  - 'api_docs/**'
-  - 'config/**'
-  - 'dev_docs/**'
-  - 'docs/**'
-  - 'legacy_rfcs/**'
-  - 'licenses/**'
-  - 'node_modules/**'
-  - 'oas_docs/**'
-  - 'typings/**'
-  - '.buildkite/**'
+include:
+  - '**/test/scout*/**'
+  - 'src/platform/test/**'
+  - 'x-pack/**/test/**'
 conclusion: neutral
 ---
 
@@ -28,33 +21,33 @@ Decide whether this PR needs a Flaky Test Runner nudge. If not, post nothing.
 ## Step 1: Are any in-scope files changed?
 
 - **Scout:** `**/test/scout*/**`
-- **FTR:** `src/platform/test/**`, `x-pack/platform/test/**`, `x-pack/solutions/*/test/**`
+- **FTR:** `src/platform/test/**`, `x-pack/**/test/**`
 
 If nothing matches, stop.
 
 ## Step 2: Do the changes affect stability?
 
-**Nudge if:** test logic, assertions, selectors, fixtures, page objects, config files, hooks, timeouts, waits, API calls, new/removed/skipped tests.
+**Nudge if:** test logic, assertions, selectors, fixtures, page objects, test config files, hooks, timeouts, waits, API calls, new/updated/unskipped tests.
 
 **Skip if:** comments only, pure formatting, import reorder, trivial copy changes.
 
 Evaluate Scout and FTR independently. Only nudge the side(s) that qualify.
 
-## Step 3: Resolve the config path
+## Step 3: Resolve the config paths
 
-**FTR:** Walk up from the changed file to the nearest leaf `config*.ts` (skip `*.base.ts`). If none found, use `browse_code` to find which config's `testFiles`/`loadTestFile` includes the changed file.
+**FTR:** Walk up from the changed file and collect all leaf `config*.ts` files (skip `*.base.ts`). For each candidate, use `browse_code` to verify it actually references the changed file via `testFiles` or `loadTestFile` (directly or via glob). Only include configs that pass this check. If no candidate is found walking up, use `browse_code` to search for which config includes the changed file.
 
 Example: `x-pack/platform/test/serverless/functional/configs/search/config.group7.ts`
 
-**Scout — changed file is under `**/test/scout\*/**`:** Walk up to the nearest `playwright.config.ts` or `parallel.playwright.config.ts` (prefer `parallel` if the path contains `parallel_tests/`).
+**Scout:** Walk up from the changed file to the nearest `playwright.config.ts` or `parallel.playwright.config.ts` (prefer `parallel` if the path contains `parallel_tests/`). Verify the config actually runs the changed file.
 
 Example: `x-pack/platform/plugins/shared/streams_app/test/scout/ui/playwright.config.ts`
 
-Ensure the new or updated tests actually belong to the config.
+If multiple changed files resolve to the same config, include it only once.
 
 ## Output
 
-Post one comment on the PR. Include only the `/flaky` line(s) for the runner(s) that qualify:
+Post one comment on the PR with a single `/flaky` command. Include tokens only for runner types that qualify. All configs — any number, any mix of Scout and FTR — go space-separated on the same line. Format:
 
 ````markdown
 ## Catch flakiness early (recommended)
@@ -64,28 +57,40 @@ Post one comment on the PR. Include only the `/flaky` line(s) for the runner(s) 
 Trigger a run with the [Flaky Test Runner UI](https://ci-stats.kibana.dev/trigger_flaky_test_runner) or post this comment on the PR:
 
 ```
-/flaky <scoutConfig or ftrConfig>:<resolved-scout-or-ftr-config-path>:30
+/flaky <type>:<path>:25 [<type>:<path>:25 ...]
 ```
 
 This check is experimental. Share your feedback in the #appex-qa channel.
 ````
 
-Replace the example paths with the resolved paths from Step 3. Drop whichever line doesn't apply.
+Examples:
 
-Sample commands:
-
-Scout:
+Scout-only:
 
 ```
-/flaky scoutConfig:x-pack/platform/plugins/shared/streams_app/test/scout/ui/playwright.config.ts:30
+/flaky scoutConfig:x-pack/platform/plugins/shared/streams_app/test/scout/ui/playwright.config.ts:25
 ```
 
-FTR:
+FTR-only (multiple configs):
 
 ```
-/flaky ftrConfig:x-pack/platform/test/serverless/functional/configs/search/config.group7.ts:30
+/flaky ftrConfig:x-pack/platform/test/serverless/functional/configs/search/config.group7.ts:25 ftrConfig:x-pack/platform/test/serverless/functional/configs/search/config.group8.ts:25
 ```
 
-Always use 30: this tells the runner to execute the test config 30 times.
+Mixed Scout + FTR:
 
-Always ensure the Playwright config exists in the project, otherwise don't post it.
+```
+/flaky scoutConfig:x-pack/platform/plugins/shared/streams_app/test/scout/ui/playwright.config.ts:25 ftrConfig:x-pack/platform/test/serverless/functional/configs/search/config.group7.ts:25 ftrConfig:x-pack/platform/test/serverless/functional/configs/search/config.group8.ts:25
+```
+
+**Rules:**
+
+- Always use `:25` on every token.
+- Only include config paths that are verified to exist and run the changed tests.
+- Always post a single `/flaky` line — never multiple.
+- Deduplicate: include each config path only once.
+- If no valid config can be resolved for a runner after walking up and searching, include a note in the comment asking the author to identify the correct config path manually, rather than omitting the runner entirely:
+
+```
+> ⚠️ Could not resolve a config for [Scout/FTR] — please identify the correct config path and run manually via the [Flaky Test Runner UI](https://ci-stats.kibana.dev/trigger_flaky_test_runner).
+```

--- a/.macroscope/flaky-test-runner-nudge.md
+++ b/.macroscope/flaky-test-runner-nudge.md
@@ -57,7 +57,7 @@ Post one comment on the PR with a single `/flaky` command. Include tokens only f
 Trigger a run with the [Flaky Test Runner UI](https://ci-stats.kibana.dev/trigger_flaky_test_runner) or post this comment on the PR:
 
 ```
-/flaky <type>:<path>:25 [<type>:<path>:25 ...]
+/flaky <type>:<path>:30 [<type>:<path>:30 ...]
 ```
 
 This check is experimental. Share your feedback in the #appex-qa channel.
@@ -68,24 +68,24 @@ Examples:
 Scout-only:
 
 ```
-/flaky scoutConfig:x-pack/platform/plugins/shared/streams_app/test/scout/ui/playwright.config.ts:25
+/flaky scoutConfig:x-pack/platform/plugins/shared/streams_app/test/scout/ui/playwright.config.ts:30
 ```
 
 FTR-only (multiple configs):
 
 ```
-/flaky ftrConfig:x-pack/platform/test/serverless/functional/configs/search/config.group7.ts:25 ftrConfig:x-pack/platform/test/serverless/functional/configs/search/config.group8.ts:25
+/flaky ftrConfig:x-pack/platform/test/serverless/functional/configs/search/config.group7.ts:30 ftrConfig:x-pack/platform/test/serverless/functional/configs/search/config.group8.ts:30
 ```
 
 Mixed Scout + FTR:
 
 ```
-/flaky scoutConfig:x-pack/platform/plugins/shared/streams_app/test/scout/ui/playwright.config.ts:25 ftrConfig:x-pack/platform/test/serverless/functional/configs/search/config.group7.ts:25 ftrConfig:x-pack/platform/test/serverless/functional/configs/search/config.group8.ts:25
+/flaky scoutConfig:x-pack/platform/plugins/shared/streams_app/test/scout/ui/playwright.config.ts:30 ftrConfig:x-pack/platform/test/serverless/functional/configs/search/config.group7.ts:30 ftrConfig:x-pack/platform/test/serverless/functional/configs/search/config.group8.ts:30
 ```
 
 **Rules:**
 
-- Always use `:25` on every token.
+- Always use `:30` on every token.
 - Only include config paths that are verified to exist and run the changed tests.
 - Always post a single `/flaky` line — never multiple.
 - Deduplicate: include each config path only once.

--- a/.macroscope/scout-review.md
+++ b/.macroscope/scout-review.md
@@ -32,6 +32,8 @@ Skip all other changed files entirely.
 
 If no matching files were changed in this PR, report "No Scout files in this PR — nothing to review" and conclude with no comments.
 
+Do NOT post flaky test runner nudges. A separate agent will take care of this.
+
 ## Best practices reference
 
 Read `docs/extend/scout/best-practices.md` with `browse_code` and enforce all rules documented there. The sections below cover additional conventions NOT in that document.
@@ -40,7 +42,6 @@ Read `docs/extend/scout/best-practices.md` with `browse_code` and enforce all ru
 
 - Before creating new helpers, use `browse_code` to check what's already available in `@kbn/scout`, solution Scout packages (`@kbn/scout-oblt`, `@kbn/scout-search`, `@kbn/scout-security`), and plugin-local `test/scout/` directories.
 - When adding helpers, place them in the correct scope: plugin-local `test/scout/` for plugin-specific, solution Scout package for cross-plugin within a solution, `@kbn/scout` for cross-solution.
-- Flaky Test Runner nudges for PRs: `.macroscope/flaky-test-runner-nudge.md` (Scout and FTR).
 
 ## Output Format
 

--- a/.macroscope/scout-review.md
+++ b/.macroscope/scout-review.md
@@ -4,9 +4,20 @@ model: claude-opus-4-6
 reasoning: high
 effort: high
 input: full_diff
-include:
-  - '**/test/scout*/**'
-  - '**/kbn-scout*/**'
+exclude:
+  - 'api_docs/**'
+  - 'config/**'
+  - 'dev_docs/**'
+  - 'docs/**'
+  - 'legacy_rfcs/**'
+  - 'licenses/**'
+  - 'node_modules/**'
+  - 'oas_docs/**'
+  - 'packages/**'
+  - 'plugins/**'
+  - 'scripts/**'
+  - 'typings/**'
+  - '.buildkite/**'
 conclusion: neutral
 ---
 

--- a/.macroscope/scout-review.md
+++ b/.macroscope/scout-review.md
@@ -4,20 +4,9 @@ model: claude-opus-4-6
 reasoning: high
 effort: high
 input: full_diff
-exclude:
-  - 'api_docs/**'
-  - 'config/**'
-  - 'dev_docs/**'
-  - 'docs/**'
-  - 'legacy_rfcs/**'
-  - 'licenses/**'
-  - 'node_modules/**'
-  - 'oas_docs/**'
-  - 'packages/**'
-  - 'plugins/**'
-  - 'scripts/**'
-  - 'typings/**'
-  - '.buildkite/**'
+include:
+  - '**/test/scout*/**'
+  - '**/kbn-scout*/**'
 conclusion: neutral
 ---
 


### PR DESCRIPTION
This PR updates the existing [flaky test runner nudger](https://github.com/elastic/kibana/blob/main/.macroscope/flaky-test-runner-nudge.md) Macroscope [check run agent](https://docs.macroscope.com/check-run-agents) to

* Run the check on files that match the `include:` frontmatter glob pattern (this is a new feature in Macroscope)
* Have the agent reference one or multiple configs within the same `/flaky` command invocation (instead of multiple `/flaky` commands)
* Update the Scout Test Review agent to stop posting flaky test runner nudges, leading to duplicate nudges