### PR TITLE
[Discover] [Flaky Test] Fix flaky restoring session with TSVB & Timelion

### DIFF
--- a/x-pack/platform/test/search_sessions_integration/tests/apps/dashboard/async_search/save_search_session.ts
+++ b/x-pack/platform/test/search_sessions_integration/tests/apps/dashboard/async_search/save_search_session.ts
@@ -119,7 +119,10 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       it('Restore session with TSVB & Timelion', async () => {
         await dashboard.loadSavedDashboard('TSVBwithTimelion + Delay 5s');
         await dashboard.waitForRenderComplete();
-        await searchSessions.save({ isSubmitButton: true, withRefresh: true });
+        await queryBar.clickQuerySubmitButton();
+        await header.waitUntilLoadingHasFinished();
+        await dashboard.waitForRenderComplete();
+        await searchSessions.save({ isSubmitButton: true });
 
         const savedSessionId = await dashboardPanelActions.getSearchSessionIdByTitle('TSVB');
 


### PR DESCRIPTION
## Summary

**Hypothesis: ** the test fails intermittently with only 1 out of 3 panel searches getting captured in the saved searches. The `save({ withRefresh: true }}` helper clicks the refresh button and immediately clicks the save button with no wait in between. On a 3-panel dashboard the save can fire before all panels have initialed their async searches, so only the first search is captured.

**Proposed fix: ** moving refresh out of `save` function and replace it with a standard pattern already used in other places. This should ensure all 3 searches are tracked before saving the session.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


