### PR TITLE
[Entity Store] Make check_privileges route internal

### DIFF
--- a/x-pack/solutions/security/plugins/entity_store/common/index.ts
+++ b/x-pack/solutions/security/plugins/entity_store/common/index.ts
@@ -52,7 +52,6 @@ export const ENTITY_STORE_ROUTES = {
     STATUS: `${PUBLIC_BASE_ROUTE}/status`,
     START: `${PUBLIC_BASE_ROUTE}/start`,
     STOP: `${PUBLIC_BASE_ROUTE}/stop`,
-    CHECK_PRIVILEGES: `${PUBLIC_BASE_ROUTE}/check_privileges`,
     CRUD_CREATE: `${PUBLIC_BASE_ROUTE}/entities/{entityType}`,
     CRUD_UPDATE: `${PUBLIC_BASE_ROUTE}/entities/{entityType}`,
     CRUD_BULK_UPDATE: `${PUBLIC_BASE_ROUTE}/entities/bulk`,
@@ -63,6 +62,7 @@ export const ENTITY_STORE_ROUTES = {
     RESOLUTION_GROUP: `${PUBLIC_BASE_ROUTE}/resolution/group`,
   },
   internal: {
+    CHECK_PRIVILEGES: `${INTERNAL_BASE_ROUTE}/check_privileges`,
     FORCE_LOG_EXTRACTION: `${INTERNAL_BASE_ROUTE}/{entityType}/force_log_extraction`,
     FORCE_CCS_EXTRACT_TO_UPDATES: `${INTERNAL_BASE_ROUTE}/{entityType}/force_ccs_extract_to_updates`,
     FORCE_HISTORY_SNAPSHOT: `${INTERNAL_BASE_ROUTE}/force_history_snapshot`,

--- a/x-pack/solutions/security/plugins/entity_store/server/routes/apis/check_privileges.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/routes/apis/check_privileges.ts
@@ -19,8 +19,8 @@ import { checkAndFormatPrivileges } from './utils/check_and_format_privileges';
 export function registerCheckPrivileges(router: EntityStorePluginRouter) {
   router.versioned
     .get({
-      path: ENTITY_STORE_ROUTES.public.CHECK_PRIVILEGES,
-      access: 'public',
+      path: ENTITY_STORE_ROUTES.internal.CHECK_PRIVILEGES,
+      access: 'internal',
       security: {
         authz: DEFAULT_ENTITY_STORE_PERMISSIONS,
       },
@@ -28,7 +28,7 @@ export function registerCheckPrivileges(router: EntityStorePluginRouter) {
     })
     .addVersion(
       {
-        version: API_VERSIONS.public.v1,
+        version: API_VERSIONS.internal.v2,
         validate: false,
       },
       wrapMiddlewares(async (ctx, req, res): Promise<IKibanaResponse> => {

--- a/x-pack/solutions/security/plugins/entity_store/test/scout/api/fixtures/constants.ts
+++ b/x-pack/solutions/security/plugins/entity_store/test/scout/api/fixtures/constants.ts
@@ -46,7 +46,6 @@ export const ENTITY_STORE_ROUTES = {
     START: `${PUBLIC_BASE}/start`,
     STOP: `${PUBLIC_BASE}/stop`,
     UNINSTALL: `${PUBLIC_BASE}/uninstall`,
-    CHECK_PRIVILEGES: `${PUBLIC_BASE}/check_privileges`,
     CRUD_CREATE: (entityType: string) => `${PUBLIC_BASE}/entities/${entityType}`,
     CRUD_UPDATE: (entityType: string) => `${PUBLIC_BASE}/entities/${entityType}`,
     CRUD_BULK_UPDATE: `${PUBLIC_BASE}/entities/bulk`,
@@ -57,6 +56,7 @@ export const ENTITY_STORE_ROUTES = {
     RESOLUTION_GROUP: `${PUBLIC_BASE}/resolution/group`,
   },
   internal: {
+    CHECK_PRIVILEGES: `${INTERNAL_BASE}/check_privileges`,
     FORCE_LOG_EXTRACTION: (entityType: string) =>
       `${INTERNAL_BASE}/${entityType}/force_log_extraction`,
     FORCE_CCS_EXTRACT_TO_UPDATES: (entityType: string) =>

--- a/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/check_privileges.spec.ts
+++ b/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/check_privileges.spec.ts
@@ -7,7 +7,7 @@
 
 import { apiTest } from '@kbn/scout-security';
 import { expect } from '@kbn/scout-security/api';
-import { PUBLIC_HEADERS, ENTITY_STORE_ROUTES, ENTITY_STORE_TAGS } from '../fixtures/constants';
+import { INTERNAL_HEADERS, ENTITY_STORE_ROUTES, ENTITY_STORE_TAGS } from '../fixtures/constants';
 import { FF_ENABLE_ENTITY_STORE_V2, getEntitiesAlias, ENTITY_LATEST } from '../../../../common';
 
 apiTest.describe('Entity Store check privileges API', { tag: ENTITY_STORE_TAGS }, () => {
@@ -22,8 +22,8 @@ apiTest.describe('Entity Store check privileges API', { tag: ENTITY_STORE_TAGS }
   apiTest('Should return full privileges for admin user', async ({ apiClient, samlAuth }) => {
     const { cookieHeader } = await samlAuth.asInteractiveUser('admin');
 
-    const response = await apiClient.get(ENTITY_STORE_ROUTES.public.CHECK_PRIVILEGES, {
-      headers: { ...cookieHeader, ...PUBLIC_HEADERS },
+    const response = await apiClient.get(ENTITY_STORE_ROUTES.internal.CHECK_PRIVILEGES, {
+      headers: { ...cookieHeader, ...INTERNAL_HEADERS },
       responseType: 'json',
     });
 
@@ -43,8 +43,8 @@ apiTest.describe('Entity Store check privileges API', { tag: ENTITY_STORE_TAGS }
         kibana: [{ base: [], feature: { discover: ['all'] }, spaces: ['*'] }],
       });
 
-      const response = await apiClient.get(ENTITY_STORE_ROUTES.public.CHECK_PRIVILEGES, {
-        headers: { ...cookieHeader, ...PUBLIC_HEADERS },
+      const response = await apiClient.get(ENTITY_STORE_ROUTES.internal.CHECK_PRIVILEGES, {
+        headers: { ...cookieHeader, ...INTERNAL_HEADERS },
         responseType: 'json',
       });
 
@@ -66,8 +66,8 @@ apiTest.describe('Entity Store check privileges API', { tag: ENTITY_STORE_TAGS }
         ],
       });
 
-      const response = await apiClient.get(ENTITY_STORE_ROUTES.public.CHECK_PRIVILEGES, {
-        headers: { ...cookieHeader, ...PUBLIC_HEADERS },
+      const response = await apiClient.get(ENTITY_STORE_ROUTES.internal.CHECK_PRIVILEGES, {
+        headers: { ...cookieHeader, ...INTERNAL_HEADERS },
         responseType: 'json',
       });
 
@@ -97,8 +97,8 @@ apiTest.describe('Entity Store check privileges API', { tag: ENTITY_STORE_TAGS }
         ],
       });
 
-      const response = await apiClient.get(ENTITY_STORE_ROUTES.public.CHECK_PRIVILEGES, {
-        headers: { ...cookieHeader, ...PUBLIC_HEADERS },
+      const response = await apiClient.get(ENTITY_STORE_ROUTES.internal.CHECK_PRIVILEGES, {
+        headers: { ...cookieHeader, ...INTERNAL_HEADERS },
         responseType: 'json',
       });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/api.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/api.ts
@@ -410,8 +410,8 @@ export const useEntityAnalyticsRoutes = () => {
      * Get Entity Store v2 privileges
      */
     const fetchEntityStoreV2Privileges = () =>
-      http.fetch<EntityAnalyticsPrivileges>(ENTITY_STORE_ROUTES.public.CHECK_PRIVILEGES, {
-        version: ENTITY_STORE_API_VERSIONS.public.v1,
+      http.fetch<EntityAnalyticsPrivileges>(ENTITY_STORE_ROUTES.internal.CHECK_PRIVILEGES, {
+        version: ENTITY_STORE_API_VERSIONS.internal.v2,
         method: 'GET',
       });
 


### PR DESCRIPTION
## Summary

Switches CHECK_PRIVILEGES back to being an internal route. Updates the single use of it to the new route. Updates tests.

### Checklist

Check the PR satisfies following conditions.

Reviewers should verify this PR satisfies this list as well.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->