### PR TITLE
[9.4] fix(streams): materialize deferred root data streams on non-deferred enableStreams call (#262964)

### DIFF
--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/client.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/client.ts
@@ -21,7 +21,6 @@ import type { RoutingStatus } from '@kbn/streams-schema';
 import {
   Streams,
   convertUpsertRequestIntoDefinition,
-  deriveQueryType,
   getAncestors,
   getParentId,
   LOGS_ROOT_STREAM_NAME,

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/client.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/client.ts
@@ -19,15 +19,15 @@ import type { LockManagerService } from '@kbn/lock-manager';
 import type { Condition } from '@kbn/streamlang';
 import type { RoutingStatus } from '@kbn/streams-schema';
 import {
+  Streams,
+  convertUpsertRequestIntoDefinition,
+  deriveQueryType,
+  getAncestors,
+  getParentId,
   LOGS_ROOT_STREAM_NAME,
   LOGS_OTEL_STREAM_NAME,
   LOGS_ECS_STREAM_NAME,
-} from '@kbn/streams-schema';
-import {
-  Streams,
-  convertUpsertRequestIntoDefinition,
-  getAncestors,
-  getParentId,
+  ROOT_STREAM_NAMES,
 } from '@kbn/streams-schema';
 import type { QueryClient } from './assets/query/query_client';
 import type { AttachmentClient } from './attachments/attachment_client';
@@ -42,6 +42,7 @@ import { createRootStreamDefinition } from './root_stream_definition';
 import { State } from './state_management/state';
 import type { StreamsStorageClient } from './storage/streams_storage_client';
 import { checkAccess, checkAccessBulk } from './stream_crud';
+import { upsertDataStream } from './data_streams/manage_data_streams';
 import type { FeatureClient } from './feature';
 
 interface AcknowledgeResponse<TResult extends Result> {
@@ -203,6 +204,49 @@ export class StreamsClient {
   }
 
   /**
+   * Materializes backing data streams for root wired streams that exist in
+   * Kibana storage but are missing their backing ES data stream. This can
+   * happen when enableStreams was previously called with defer: true.
+   *
+   * Returns true if any data streams were materialized, false otherwise.
+   */
+  private async materializeDeferredRootDataStreams(
+    kibanaStreams: Record<string, boolean>
+  ): Promise<boolean> {
+    const existingRootStreamNames = ROOT_STREAM_NAMES.filter(
+      (name) => kibanaStreams[name as keyof typeof kibanaStreams]
+    );
+
+    const rootsNeedingMaterialization = (
+      await Promise.all(
+        existingRootStreamNames.map(async (name) => {
+          const dataStreamExists = await this.dependencies.esClient.indices.exists({
+            index: name,
+          });
+          return { name, exists: dataStreamExists as boolean };
+        })
+      )
+    )
+      .filter(({ exists }) => !exists)
+      .map(({ name }) => name);
+
+    if (rootsNeedingMaterialization.length === 0) {
+      return false;
+    }
+
+    await Promise.all(
+      rootsNeedingMaterialization.map((name) =>
+        upsertDataStream({
+          esClient: this.dependencies.esClient,
+          name,
+          logger: this.dependencies.logger,
+        })
+      )
+    );
+    return true;
+  }
+
+  /**
    * Enabling streams means creating the necessary root streams.
    * For fresh installs: creates logs.otel and logs.ecs
    * For existing users: keeps logs, adds logs.otel and logs.ecs
@@ -244,6 +288,12 @@ export class StreamsClient {
 
     // Step 3: Check if this is a noop
     if (streamsToCreate.length === 0 && streamsToEnableInES.length === 0) {
+      if (!defer) {
+        const materialized = await this.materializeDeferredRootDataStreams(kibanaStreams);
+        if (materialized) {
+          return { acknowledged: true, result: 'created' };
+        }
+      }
       return { acknowledged: true, result: 'noop' };
     }
 

--- a/x-pack/platform/test/api_integration_deployment_agnostic/apis/streams/deferred_data_stream.ts
+++ b/x-pack/platform/test/api_integration_deployment_agnostic/apis/streams/deferred_data_stream.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+import type { DeploymentAgnosticFtrProviderContext } from '../../ftr_provider_context';
+import type { StreamsSupertestRepositoryClient } from './helpers/repository_client';
+import { createStreamsRepositoryAdminClient } from './helpers/repository_client';
+import { disableStreams, enableStreams, indexDocument } from './helpers/requests';
+
+export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
+  const roleScopedSupertest = getService('roleScopedSupertest');
+  const esClient = getService('es');
+  const config = getService('config');
+  const retry = getService('retry');
+  const isServerless = !!config.get('serverless');
+
+  let apiClient: StreamsSupertestRepositoryClient;
+
+  describe('Deferred data stream materialization', function () {
+    before(async () => {
+      apiClient = await createStreamsRepositoryAdminClient(roleScopedSupertest);
+      // Wait for startup enableStreams to finish (may hold a lock)
+      await retry.tryForTime(30000, async () => {
+        await enableStreams(apiClient);
+      });
+    });
+
+    after(async () => {
+      await disableStreams(apiClient);
+    });
+
+    if (!isServerless) {
+      it('materializes missing backing data streams for root streams on enable', async () => {
+        await enableStreams(apiClient);
+
+        for (const rootStream of ['logs.otel', 'logs.ecs']) {
+          const dsBefore = await esClient.indices.getDataStream({ name: rootStream });
+          expect(dsBefore.data_streams).to.have.length(1);
+          expect(dsBefore.data_streams[0].name).to.be(rootStream);
+        }
+
+        await esClient.indices.deleteDataStream({ name: 'logs.otel' });
+        await esClient.indices.deleteDataStream({ name: 'logs.ecs' });
+
+        for (const rootStream of ['logs.otel', 'logs.ecs']) {
+          const dsCheck = await esClient.indices.exists({ index: rootStream });
+          expect(dsCheck).to.be(false);
+        }
+
+        const enableResponse = await apiClient
+          .fetch('POST /api/streams/_enable 2023-10-31')
+          .expect(200);
+        expect(enableResponse.body.result).to.eql('created');
+
+        for (const rootStream of ['logs.otel', 'logs.ecs']) {
+          const dsAfter = await esClient.indices.getDataStream({ name: rootStream });
+          expect(dsAfter.data_streams).to.have.length(1);
+          expect(dsAfter.data_streams[0].name).to.be(rootStream);
+        }
+      });
+
+      it('returns noop when all backing data streams already exist', async () => {
+        await enableStreams(apiClient);
+
+        const enableResponse = await apiClient
+          .fetch('POST /api/streams/_enable 2023-10-31')
+          .expect(200);
+        expect(enableResponse.body.result).to.eql('noop');
+      });
+
+      it('allows indexing to root streams after materializing deferred data streams', async () => {
+        await enableStreams(apiClient);
+
+        await esClient.indices.deleteDataStream({ name: 'logs.otel' });
+
+        await enableStreams(apiClient);
+
+        const doc = {
+          '@timestamp': '2024-01-01T00:00:00.000Z',
+          message: JSON.stringify({
+            '@timestamp': '2024-01-01T00:00:00.000Z',
+            'log.level': 'info',
+            'log.logger': 'deferred_test',
+            message: 'test deferred materialization',
+          }),
+        };
+        const response = await indexDocument(esClient, 'logs.otel', doc);
+        expect(response.result).to.eql('created');
+      });
+    }
+  });
+}

--- a/x-pack/platform/test/api_integration_deployment_agnostic/apis/streams/index.ts
+++ b/x-pack/platform/test/api_integration_deployment_agnostic/apis/streams/index.ts
@@ -38,5 +38,6 @@ export default function ({ loadTestFile }: DeploymentAgnosticFtrProviderContext)
     loadTestFile(require.resolve('./doc_counts'));
     loadTestFile(require.resolve('./snapshot_restore'));
     loadTestFile(require.resolve('./query_streams'));
+    loadTestFile(require.resolve('./deferred_data_stream'));
   });
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [fix(streams): materialize deferred root data streams on non-deferred enableStreams call (#262964)](https://github.com/elastic/kibana/pull/262964)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Joe Reuter","email":"johannes.reuter@elastic.co"},"sourceCommit":{"committedDate":"2026-04-16T11:06:33Z","message":"fix(streams): materialize deferred root data streams on non-deferred enableStreams call (#262964)\n\n## Summary\n\nFixes a bug where `enableStreams()` with `defer: false` (the default)\nwould short-circuit as a noop when root wired streams already had their\nKibana definitions and ES-native streams enabled, even if their backing\nES data streams were never materialized due to a prior `defer: true`\ncall during Kibana startup.\n\nCloses elastic/streams-program#1136\n\n## Root cause\n\nDuring startup, the Streams plugin calls `enableStreams({ defer: true\n})`, which creates Kibana definitions, index templates, ingest\npipelines, and enables ES-native streams — but **skips creating the\nbacking data streams** for root streams. When a subsequent\n`enableStreams()` call (with default `defer: false`) is made, the noop\ncheck sees that both `checkRootStreamsExistence()` and\n`checkElasticsearchStreamsStatus()` return true, so it returns `{\nresult: 'noop' }` without ever evaluating the `defer` parameter or\nmaterializing the missing data streams.\n\n## Changes\n\n- **`client.ts`**: In the noop path of `enableStreams()`, when `defer`\nis false, check if any root wired streams that exist in Kibana are\nmissing their backing ES data streams. If so, materialize them via\n`upsertDataStream()` and return `result: 'created'` instead of `result:\n'noop'`.\n- **`deferred_data_stream.ts`** (new): API integration test that\nvalidates:\n- `enableStreams` returns `created` (not `noop`) when root data streams\nare missing\n  - Backing data streams are re-created after being deleted\n  - Indexing works after materialization\n  - `noop` is returned when all data streams already exist\n\n## How to validate\n\n- All 59 existing streams unit test suites pass\n- `check_changes.ts` passes (lint + typecheck)\n- New API integration test validates the fix end-to-end","sha":"1176416a2e9a2cee6395b7d17660ac216c872def","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:obs-onboarding","backport:version","Feature:Streams","v9.4.0","v9.5.0"],"title":"fix(streams): materialize deferred root data streams on non-deferred enableStreams call","number":262964,"url":"https://github.com/elastic/kibana/pull/262964","mergeCommit":{"message":"fix(streams): materialize deferred root data streams on non-deferred enableStreams call (#262964)\n\n## Summary\n\nFixes a bug where `enableStreams()` with `defer: false` (the default)\nwould short-circuit as a noop when root wired streams already had their\nKibana definitions and ES-native streams enabled, even if their backing\nES data streams were never materialized due to a prior `defer: true`\ncall during Kibana startup.\n\nCloses elastic/streams-program#1136\n\n## Root cause\n\nDuring startup, the Streams plugin calls `enableStreams({ defer: true\n})`, which creates Kibana definitions, index templates, ingest\npipelines, and enables ES-native streams — but **skips creating the\nbacking data streams** for root streams. When a subsequent\n`enableStreams()` call (with default `defer: false`) is made, the noop\ncheck sees that both `checkRootStreamsExistence()` and\n`checkElasticsearchStreamsStatus()` return true, so it returns `{\nresult: 'noop' }` without ever evaluating the `defer` parameter or\nmaterializing the missing data streams.\n\n## Changes\n\n- **`client.ts`**: In the noop path of `enableStreams()`, when `defer`\nis false, check if any root wired streams that exist in Kibana are\nmissing their backing ES data streams. If so, materialize them via\n`upsertDataStream()` and return `result: 'created'` instead of `result:\n'noop'`.\n- **`deferred_data_stream.ts`** (new): API integration test that\nvalidates:\n- `enableStreams` returns `created` (not `noop`) when root data streams\nare missing\n  - Backing data streams are re-created after being deleted\n  - Indexing works after materialization\n  - `noop` is returned when all data streams already exist\n\n## How to validate\n\n- All 59 existing streams unit test suites pass\n- `check_changes.ts` passes (lint + typecheck)\n- New API integration test validates the fix end-to-end","sha":"1176416a2e9a2cee6395b7d17660ac216c872def"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/262964","number":262964,"mergeCommit":{"message":"fix(streams): materialize deferred root data streams on non-deferred enableStreams call (#262964)\n\n## Summary\n\nFixes a bug where `enableStreams()` with `defer: false` (the default)\nwould short-circuit as a noop when root wired streams already had their\nKibana definitions and ES-native streams enabled, even if their backing\nES data streams were never materialized due to a prior `defer: true`\ncall during Kibana startup.\n\nCloses elastic/streams-program#1136\n\n## Root cause\n\nDuring startup, the Streams plugin calls `enableStreams({ defer: true\n})`, which creates Kibana definitions, index templates, ingest\npipelines, and enables ES-native streams — but **skips creating the\nbacking data streams** for root streams. When a subsequent\n`enableStreams()` call (with default `defer: false`) is made, the noop\ncheck sees that both `checkRootStreamsExistence()` and\n`checkElasticsearchStreamsStatus()` return true, so it returns `{\nresult: 'noop' }` without ever evaluating the `defer` parameter or\nmaterializing the missing data streams.\n\n## Changes\n\n- **`client.ts`**: In the noop path of `enableStreams()`, when `defer`\nis false, check if any root wired streams that exist in Kibana are\nmissing their backing ES data streams. If so, materialize them via\n`upsertDataStream()` and return `result: 'created'` instead of `result:\n'noop'`.\n- **`deferred_data_stream.ts`** (new): API integration test that\nvalidates:\n- `enableStreams` returns `created` (not `noop`) when root data streams\nare missing\n  - Backing data streams are re-created after being deleted\n  - Indexing works after materialization\n  - `noop` is returned when all data streams already exist\n\n## How to validate\n\n- All 59 existing streams unit test suites pass\n- `check_changes.ts` passes (lint + typecheck)\n- New API integration test validates the fix end-to-end","sha":"1176416a2e9a2cee6395b7d17660ac216c872def"}}]}] BACKPORT-->