### PR TITLE
[Lens as Code] Revert heatmap 'axes' property to 'axis'

### DIFF
--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/charts/heatmap.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/charts/heatmap.ts
@@ -97,7 +97,7 @@ const heatmapSharedStateSchema = {
   ),
   ...sharedPanelInfoSchema,
   ...layerSettingsSchema,
-  axes: schema.maybe(
+  axis: schema.maybe(
     schema.object(
       {
         x: schema.maybe(

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/heatmap/from_api.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/heatmap/from_api.ts
@@ -52,7 +52,7 @@ function buildVisualizationState(config: HeatmapState): HeatmapVisualizationStat
     layer.metric.color && !isAutoColor(layer.metric.color)
       ? fromColorByValueAPIToLensState(layer.metric.color)
       : undefined;
-  const xAxisLabelRotation = axisLabelOrientationCompat.toState(layer.axes?.x?.labels?.orientation);
+  const xAxisLabelRotation = axisLabelOrientationCompat.toState(layer.axis?.x?.labels?.orientation);
 
   return {
     layerId: DEFAULT_LAYER_ID,
@@ -64,16 +64,16 @@ function buildVisualizationState(config: HeatmapState): HeatmapVisualizationStat
     gridConfig: {
       type: HEATMAP_GRID_NAME,
       isCellLabelVisible: layer.styling?.cells?.labels?.visible ?? false,
-      isXAxisLabelVisible: layer.axes?.x?.labels?.visible ?? true,
-      isXAxisTitleVisible: layer.axes?.x?.title?.visible ?? false,
-      isYAxisLabelVisible: layer.axes?.y?.labels?.visible ?? true,
-      isYAxisTitleVisible: layer.axes?.y?.title?.visible ?? false,
+      isXAxisLabelVisible: layer.axis?.x?.labels?.visible ?? true,
+      isXAxisTitleVisible: layer.axis?.x?.title?.visible ?? false,
+      isYAxisLabelVisible: layer.axis?.y?.labels?.visible ?? true,
+      isYAxisTitleVisible: layer.axis?.y?.title?.visible ?? false,
       ...stripUndefined<HeatmapGridConfigResult>({
-        xTitle: layer.axes?.x?.title?.text,
-        yTitle: layer.axes?.y?.title?.text,
+        xTitle: layer.axis?.x?.title?.text,
+        yTitle: layer.axis?.y?.title?.text,
         xAxisLabelRotation,
-        xSortPredicate: layer.axes?.x?.sort,
-        ySortPredicate: layer.axes?.y?.sort,
+        xSortPredicate: layer.axis?.x?.sort,
+        ySortPredicate: layer.axis?.y?.sort,
       }),
     },
     legend: {

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/heatmap/to_api.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/heatmap/to_api.ts
@@ -53,7 +53,7 @@ function getLegendProps(legend: HeatmapVisualizationState['legend']): HeatmapSta
 function getGridConfigProps(
   gridConfig: HeatmapVisualizationState['gridConfig'],
   xAxisScale?: XScaleSchemaType
-): HeatmapState['axes'] {
+): HeatmapState['axis'] {
   return {
     x: {
       labels: {
@@ -104,7 +104,7 @@ function reverseBuildVisualizationState(
     ...generateApiLayer(layer),
     type: HEATMAP_NAME,
     legend: getLegendProps(visualization.legend),
-    axes: getGridConfigProps(visualization.gridConfig, xAxisScale),
+    axis: getGridConfigProps(visualization.gridConfig, xAxisScale),
     styling: {
       cells: {
         labels: { visible: visualization.gridConfig.isCellLabelVisible },


### PR DESCRIPTION
## Summary

Part of #257034. Follow up to #259636.

Reverts Heatmap `axes` -> `axis` to be actually in line with xy charts.

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->