### PR TITLE
[Agent Builder] Suppress announcement modal in automated browsers via navigator.webdriver

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/public/components/announcement/agent_builder_announcement_modal_controller.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/components/announcement/agent_builder_announcement_modal_controller.test.tsx
@@ -117,6 +117,28 @@ describe('AgentBuilderAnnouncementModalController', () => {
     });
   });
 
+  it('does not render the modal when running in an automated browser (navigator.webdriver)', async () => {
+    Object.defineProperty(navigator, 'webdriver', {
+      value: true,
+      writable: true,
+      configurable: true,
+    });
+    const { services } = buildServices();
+    renderController(services);
+
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId('agentBuilderAnnouncementContinueButton')
+      ).not.toBeInTheDocument();
+    });
+
+    Object.defineProperty(navigator, 'webdriver', {
+      value: undefined,
+      writable: true,
+      configurable: true,
+    });
+  });
+
   it('does not render the modal when the user has already seen it in their profile', async () => {
     const { services } = buildServices({ announcementSeenInProfile: true });
     renderController(services);

--- a/x-pack/platform/plugins/shared/agent_builder/public/components/announcement/agent_builder_announcement_modal_controller.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/components/announcement/agent_builder_announcement_modal_controller.tsx
@@ -41,7 +41,7 @@ export function AgentBuilderAnnouncementModalController() {
   const [isDismissed, setIsDismissed] = useState(false);
 
   if (!space) return null;
-  if (hideAnnouncements || isDismissed) return null;
+  if (hideAnnouncements || isDismissed || navigator.webdriver) return null;
   if (!isReady) return null;
   if (isSeen) return null;
 


### PR DESCRIPTION
## Summary

Suppresses the `AgentBuilderAnnouncementModal` in automated browsers (Cypress, Playwright, Selenium, Elastic Synthetics) by checking `navigator.webdriver` before rendering.

The modal was appearing during e2e test runs and synthetic monitor executions, interfering with test assertions in Observability and Security pages. The existing `hideAnnouncements` global setting works when tests explicitly call the suppression API in a setup phase, but **synthetic monitors have no setup phase** — they navigate directly to a page against a deployed instance, so the modal appears unexpectedly.

`navigator.webdriver` is a W3C standard property that is automatically set to `true` by all WebDriver-controlled browsers (Playwright used by Elastic Synthetics/Heartbeat, Cypress, Selenium) and is `undefined` or `false` in real user browsers. Checking it at the source requires zero changes in any test or monitor configuration file and cannot be forgotten for new test suites.

See https://developer.mozilla.org/en-US/docs/Web/API/Navigator/webdriver

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

- [ ] Low risk. The change is a one-line guard on a modal render path. `navigator.webdriver` is `undefined` (falsy) in all real user browsers, so the modal behaviour for end users is completely unchanged. The only affected path is automated browser sessions, where the modal was already considered unwanted noise.

**PR developed with Claude Code, Sonnet 4.6**


<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->