### PR TITLE
[DoNotReview/FeatureBranch] [Chrome Next] Add feedback global app menu item

### DIFF
--- a/packages/kbn-optimizer/limits.yml
+++ b/packages/kbn-optimizer/limits.yml
@@ -70,7 +70,7 @@ pageLoadAssetSize:
   expressionTagcloud: 14009
   expressionXY: 45000
   features: 4145
-  feedback: 7000
+  feedback: 7500
   fieldFormats: 64634
   fieldsMetadata: 4901
   files: 6037

--- a/src/core/packages/chrome/browser-components/src/chrome_next/app_header/app_menu.tsx
+++ b/src/core/packages/chrome/browser-components/src/chrome_next/app_header/app_menu.tsx
@@ -17,15 +17,15 @@ const AppMenuComponent = lazy(async () => {
   return { default: Component };
 });
 
-/** Fallback chain: AppMenuConfig -> legacy HeaderActionMenu -> nothing. */
+/** Fallback chain: AppMenuConfig + staticItems -> Legacy HeaderActionMenu -> nothing. */
 export const AppMenu = React.memo(() => {
-  const appMenuConfig = useAppHeaderMenu();
+  const { config, staticItems } = useAppHeaderMenu();
   const hasLegacyActionMenu = useHasLegacyActionMenu();
 
-  if (appMenuConfig) {
+  if (config) {
     return (
       <Suspense>
-        <AppMenuComponent config={appMenuConfig} />
+        <AppMenuComponent config={config} staticItems={staticItems} />
       </Suspense>
     );
   }

--- a/src/core/packages/chrome/browser-components/src/chrome_next/app_header/hooks/use_app_header_menu.ts
+++ b/src/core/packages/chrome/browser-components/src/chrome_next/app_header/hooks/use_app_header_menu.ts
@@ -10,14 +10,24 @@
 import { useMemo } from 'react';
 import type { AppMenuConfig, AppMenuItemType } from '@kbn/core-chrome-app-menu-components';
 import { APP_MENU_SHARE_ID, getTooltip } from '@kbn/core-chrome-app-menu-components';
+import { useChromeService } from '@kbn/core-chrome-browser-context';
+import { useObservable } from '@kbn/use-observable';
 import { useAppMenu, useNextHeader } from '../../../shared/chrome_hooks';
+
+const createFeedbackMenuItem = (feedbackHandler: () => void): AppMenuItemType => ({
+  label: 'Feedback',
+  id: 'feedback',
+  iconType: 'comment',
+  order: 1,
+  run: feedbackHandler,
+});
 
 interface ResolvedAppMenu {
   menu: AppMenuConfig | undefined;
   shareItem: AppMenuItemType | undefined;
 }
 
-function useResolvedAppMenu(): ResolvedAppMenu {
+const useResolvedAppMenu = (): ResolvedAppMenu => {
   const config = useNextHeader();
   const globalAppMenu = useAppMenu();
   const menu = config?.appMenu ?? globalAppMenu;
@@ -37,14 +47,24 @@ function useResolvedAppMenu(): ResolvedAppMenu {
       shareItem,
     };
   }, [menu, hasExplicitShare]);
-}
+};
 
 /**
  * Returns the resolved app menu with the `share` item stripped out.
  * The share action is auto-promoted to the global actions area by Chrome.
  */
-export function useAppHeaderMenu(): AppMenuConfig | undefined {
-  return useResolvedAppMenu().menu;
+export function useAppHeaderMenu(): {
+  config: AppMenuConfig | undefined;
+  staticItems: AppMenuItemType[];
+} {
+  const { menu } = useResolvedAppMenu();
+  const chrome = useChromeService();
+  const feedbackHandler = useObservable(chrome.getFeedbackHandler$(), undefined);
+
+  return {
+    config: menu,
+    staticItems: feedbackHandler ? [createFeedbackMenuItem(feedbackHandler)] : [],
+  };
 }
 
 export interface ShareAction {

--- a/src/core/packages/chrome/browser-internal/src/chrome_api.tsx
+++ b/src/core/packages/chrome/browser-internal/src/chrome_api.tsx
@@ -206,6 +206,14 @@ export function createChromeApi({ state, services, sidebar }: ChromeApiDeps): In
     },
 
     sidebar,
+
+    registerFeedbackHandler: (handler: () => void) => {
+      state.feedbackHandler.set(handler);
+      return () => {
+        state.feedbackHandler.update((current) => (current === handler ? undefined : current));
+      };
+    },
+    getFeedbackHandler$: () => state.feedbackHandler.$,
   };
 
   return chromeStart;

--- a/src/core/packages/chrome/browser-internal/src/state/chrome_state.ts
+++ b/src/core/packages/chrome/browser-internal/src/state/chrome_state.ts
@@ -78,6 +78,9 @@ export interface ChromeState {
     supportUrl: State<string>;
     globalMenuLinks: ArrayState<ChromeGlobalHelpExtensionMenuLink>;
   };
+
+  /** Feedback handler registered by the feedback plugin */
+  feedbackHandler: State<(() => void) | undefined>;
 }
 
 export interface ChromeStateDeps {
@@ -125,6 +128,9 @@ export function createChromeState({ application, docLinks }: ChromeStateDeps): C
   const helpSupportUrl = createState<string>(docLinks.links.kibana.askElastic);
   const globalHelpMenuLinks = createArrayState<ChromeGlobalHelpExtensionMenuLink>();
 
+  // Feedback
+  const feedbackHandler = createState<(() => void) | undefined>(undefined);
+
   return {
     visibility,
     style,
@@ -152,5 +158,6 @@ export function createChromeState({ application, docLinks }: ChromeStateDeps): C
       supportUrl: helpSupportUrl,
       globalMenuLinks: globalHelpMenuLinks,
     },
+    feedbackHandler,
   };
 }

--- a/src/core/packages/chrome/browser/src/contracts.ts
+++ b/src/core/packages/chrome/browser/src/contracts.ts
@@ -327,6 +327,19 @@ export interface ChromeStart {
   next: ChromeNext;
 
   /**
+   * Register a handler that opens the feedback UI.
+   * Called by the feedback plugin during `start`.
+   *
+   * @returns A function to unregister the handler.
+   */
+  registerFeedbackHandler(handler: () => void): () => void;
+
+  /**
+   * Get an observable of the currently registered feedback handler, or `undefined` if none.
+   */
+  getFeedbackHandler$(): Observable<(() => void) | undefined>;
+
+  /**
    * Used only by the rendering service and KibanaRenderingContextProvider to wrap the rendering tree in the Chrome context providers
    */
   withProvider(component: ReactNode): ReactNode;

--- a/src/platform/packages/shared/feedback-components/index.ts
+++ b/src/platform/packages/shared/feedback-components/index.ts
@@ -7,4 +7,4 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export { FeedbackTriggerButton } from './src';
+export { FeedbackTriggerButton, FeedbackContainer } from './src';

--- a/src/platform/packages/shared/feedback-components/src/components/index.ts
+++ b/src/platform/packages/shared/feedback-components/src/components/index.ts
@@ -8,6 +8,7 @@
  */
 
 export { FeedbackTriggerButton } from './feedback_trigger_button';
+export { FeedbackContainer } from './feedback_container';
 
 export { FeedbackHeader } from './header';
 
@@ -21,5 +22,3 @@ export { FeedbackBody } from './body';
 
 export { SendFeedbackButton } from './footer';
 export { FeedbackFooter } from './footer';
-
-export { FeedbackContainer } from './feedback_container';

--- a/src/platform/packages/shared/feedback-components/src/index.ts
+++ b/src/platform/packages/shared/feedback-components/src/index.ts
@@ -7,4 +7,4 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export { FeedbackTriggerButton } from './components';
+export { FeedbackTriggerButton, FeedbackContainer } from './components';

--- a/x-pack/platform/plugins/private/feedback/public/plugin.tsx
+++ b/x-pack/platform/plugins/private/feedback/public/plugin.tsx
@@ -6,12 +6,17 @@
  */
 
 import React, { lazy, Suspense } from 'react';
+import { EuiModal } from '@elastic/eui';
+import { css } from '@emotion/react';
 import type { CoreSetup, CoreStart, Plugin } from '@kbn/core/public';
 import type { CloudSetup, CloudStart } from '@kbn/cloud-plugin/public';
 import type { TelemetryPluginStart } from '@kbn/telemetry-plugin/public';
 import type { SpacesPluginStart } from '@kbn/spaces-plugin/public';
 import type { FeedbackRegistryEntry } from '@kbn/feedback-registry';
 import { getFeedbackQuestionsForApp } from '@kbn/feedback-registry';
+import { isNextChrome } from '@kbn/core-chrome-feature-flags';
+import { toMountPoint } from '@kbn/react-kibana-mount';
+import { i18n } from '@kbn/i18n';
 import type { FeedbackFormData } from '../common';
 import { getAppDetails } from './src/utils';
 
@@ -28,6 +33,12 @@ interface FeedbackPluginStartDependencies {
 const LazyFeedbackTriggerButton = lazy(() =>
   import('@kbn/feedback-components').then(({ FeedbackTriggerButton }) => ({
     default: FeedbackTriggerButton,
+  }))
+);
+
+const LazyFeedbackContainer = lazy(() =>
+  import('@kbn/feedback-components').then(({ FeedbackContainer }) => ({
+    default: FeedbackContainer,
   }))
 );
 
@@ -101,6 +112,40 @@ export class FeedbackPlugin implements Plugin {
         return false;
       }
     };
+
+    if (isNextChrome(core.featureFlags)) {
+      const modalCss = css`
+        overflow-y: auto;
+      `;
+
+      core.chrome.registerFeedbackHandler(() => {
+        const modal = core.overlays.openModal(
+          toMountPoint(
+            core.rendering.addContext(
+              <EuiModal
+                onClose={() => modal.close()}
+                aria-label={i18n.translate('feedback.modal.ariaLabel', {
+                  defaultMessage: 'Feedback form',
+                })}
+                css={modalCss}
+              >
+                <Suspense fallback={null}>
+                  <LazyFeedbackContainer
+                    getQuestions={getQuestions}
+                    getAppDetails={getAppDetailsWrapper}
+                    getCurrentUserEmail={getCurrentUserEmail}
+                    sendFeedback={sendFeedback}
+                    showToast={showToast}
+                    hideFeedbackContainer={() => modal.close()}
+                  />
+                </Suspense>
+              </EuiModal>
+            ),
+            core
+          )
+        );
+      });
+    }
 
     core.chrome.navControls.registerRight({
       order: 1001,


### PR DESCRIPTION
## Summary

This PR adds global feedback button to app menu. Only apps with an already existing app menu will see the global items, to avoid flickering when rendering app menu.

Closes: https://github.com/elastic/kibana/issues/261959


