### PR TITLE
[Macroscope] Scout Test Review Check Run Agent refinements

### DIFF
--- a/.macroscope/scout-review.md
+++ b/.macroscope/scout-review.md
@@ -23,7 +23,7 @@ Do NOT post flaky test runner nudges. A separate agent handles this.
 
 ## Review instructions
 
-Follow the skill at `.agents/skills/scout-best-practices-reviewer/SKILL.md` for scope, checklist, reuse rules, migration parity, and output structure. The output format below applies to this agent. Ignore any output formatting instructions in the skill file.
+Follow the skill at `.agents/skills/scout-best-practices-reviewer/SKILL.md` for scope, checklist, reuse rules and migration parity. The output format below applies to this agent. Ignore any output formatting instructions in the skill file.
 
 ## Output
 

--- a/.macroscope/scout-review.md
+++ b/.macroscope/scout-review.md
@@ -4,52 +4,34 @@ model: claude-opus-4-6
 reasoning: high
 effort: high
 input: full_diff
-exclude:
-  - 'api_docs/**'
-  - 'config/**'
-  - 'dev_docs/**'
-  - 'docs/**'
-  - 'legacy_rfcs/**'
-  - 'licenses/**'
-  - 'node_modules/**'
-  - 'oas_docs/**'
-  - 'packages/**'
-  - 'plugins/**'
-  - 'scripts/**'
-  - 'typings/**'
-  - '.buildkite/**'
+include:
+  - '**/test/scout*/**'
+  - '**/kbn-scout*/**'
 conclusion: neutral
 ---
 
-Review this PR for compliance with Kibana Scout test best practices.
+Review this PR for compliance with Kibana's UI and API testing framework Scout.
 
-Only review files that are:
+If no matching files were changed in this PR, conclude with no comments.
 
-1. **Scout test code**: files under `**/test/scout*/**` paths (spec files, fixtures, page objects, API services, constants, global setup hooks).
-2. **Scout packages**: files under `**/kbn-scout*/**` (the core framework and solution-specific Scout packages).
+Do NOT post flaky test runner nudges. A separate agent handles this.
 
-Skip all other changed files entirely.
+## Review instructions
 
-If no matching files were changed in this PR, report "No Scout files in this PR — nothing to review" and conclude with no comments.
+Follow the skill at `.agents/skills/scout-best-practices-reviewer/SKILL.md` for scope, checklist, reuse rules, migration parity, and output structure.
 
-Do NOT post flaky test runner nudges. A separate agent will take care of this.
+## Output
 
-## Best practices reference
-
-Read `docs/extend/scout/best-practices.md` with `browse_code` and enforce all rules documented there. The sections below cover additional conventions NOT in that document.
-
-## Reuse
-
-- Before creating new helpers, use `browse_code` to check what's already available in `@kbn/scout`, solution Scout packages (`@kbn/scout-oblt`, `@kbn/scout-search`, `@kbn/scout-security`), and plugin-local `test/scout/` directories.
-- When adding helpers, place them in the correct scope: plugin-local `test/scout/` for plugin-specific, solution Scout package for cross-plugin within a solution, `@kbn/scout` for cross-solution.
-
-## Output Format
+Post findings as **GitHub PR comments**. If no issues are found, don't post any comments.
 
 Group findings by severity: 🔴 Blocker → 🟡 Major → 🔵 Minor → ⚪ Nit. For each finding:
 
-- State the rule violated (use the section heading from `docs/extend/scout/best-practices.md` or from this file)
+- State the rule violated (use the section heading from `docs/extend/scout/best-practices.md`)
 - Quote the file and line
 - Explain the issue in 1–2 sentences
 - Suggest a concrete fix
 
-If all Scout best practices are followed, report "All Scout test best practices are followed. No issues found."
+IMPORTANT:
+
+- If all Scout best practices are followed, report "All Scout test best practices are followed. No issues found.
+- If the developer makes updates to PR contents, you're free to suggest improvements but don't overwhelm developers with nitpicks.

--- a/.macroscope/scout-review.md
+++ b/.macroscope/scout-review.md
@@ -10,7 +10,7 @@ include:
 conclusion: neutral
 ---
 
-Review this PR for compliance with Kibana's UI and API testing framework Scout.
+Review this PR for compliance with Kibana Scout test best practices.
 
 Only review files that are:
 

--- a/.macroscope/scout-review.md
+++ b/.macroscope/scout-review.md
@@ -23,7 +23,7 @@ Do NOT post flaky test runner nudges. A separate agent handles this.
 
 ## Review instructions
 
-Follow the skill at `.agents/skills/scout-best-practices-reviewer/SKILL.md` for scope, checklist, reuse rules and migration parity. The output format below applies to this agent. Ignore any output formatting instructions in the skill file. You can use the `browse_code` tool to explore the codebase.
+Follow the skill at `.agents/skills/scout-best-practices-reviewer/SKILL.md` for scope, checklist, reuse rules, and migration parity. The output format below applies to this agent; ignore any output formatting instructions in the skill file. You can use the `browse_code` tool to explore the codebase.
 
 ## Output
 
@@ -38,12 +38,12 @@ Group findings by severity: 🔴 Blocker → 🟡 Major → 🔵 Minor → ⚪ N
 
 ### Positive reinforcement
 
-If a PR is adding or updating Scout tests following our best practices particularly well, post a single extra comment highlighting all the good practices it's already following.
+If a PR adds or updates Scout tests that follow our best practices particularly well, post a single extra comment highlighting what it does right.
 
-### Link to a specific section of the Best practices document when possible
+### Link to specific sections of the Best Practices document when possible
 
-When possible, link to a specific section of the [Best practices for Scout tests document](https://www.elastic.co/docs/extend/kibana/scout/best-practices) so developers can learn more about a specific best practice. A link scoped to a specific section looks like this: https://www.elastic.co/docs/extend/kibana/scout/best-practices#avoid-conditional-logic-in-page-objects. You can infer the #anchor by looking at the `docs/extend/scout/best-practices.md` file (e.g., `[avoid-conditional-logic-in-page-objects]`).
+Where applicable, link to a specific section of the [Best Practices for Scout Tests](https://www.elastic.co/docs/extend/kibana/scout/best-practices) document so developers can learn more. A section-scoped link looks like this: `https://www.elastic.co/docs/extend/kibana/scout/best-practices#avoid-conditional-logic-in-page-objects`. You can infer the `#anchor` from the `docs/extend/scout/best-practices.md` file (e.g., `[avoid-conditional-logic-in-page-objects]`).
 
-### New updates
+### Updates to the PR
 
-If the developer makes updates to PR contents, suggest improvements on the newer code blocks while keeping in mind to keep the review high signal and not too nitpicky.
+When a developer updates the PR, review the newer code blocks and suggest improvements while keeping the review high-signal and focused — avoid being overly nitpicky.

--- a/.macroscope/scout-review.md
+++ b/.macroscope/scout-review.md
@@ -12,13 +12,18 @@ conclusion: neutral
 
 Review this PR for compliance with Kibana's UI and API testing framework Scout.
 
-If no matching files were changed in this PR, conclude with no comments.
+Only review files that are:
+
+1. **Scout test code**: files under `**/test/scout*/**` paths (spec files, fixtures, page objects, API services, constants, global setup hooks).
+2. **Scout packages**: files under `**/kbn-scout*/**` (the core framework and solution-specific Scout packages).
+
+Skip all other changed files entirely. If no matching files were changed in this PR, conclude with no comments.
 
 Do NOT post flaky test runner nudges. A separate agent handles this.
 
 ## Review instructions
 
-Follow the skill at `.agents/skills/scout-best-practices-reviewer/SKILL.md` for scope, checklist, reuse rules, migration parity, and output structure.
+Follow the skill at `.agents/skills/scout-best-practices-reviewer/SKILL.md` for scope, checklist, reuse rules, migration parity, and output structure. The output format below applies to this agent. Ignore any output formatting instructions in the skill file.
 
 ## Output
 
@@ -31,7 +36,4 @@ Group findings by severity: 🔴 Blocker → 🟡 Major → 🔵 Minor → ⚪ N
 - Explain the issue in 1–2 sentences
 - Suggest a concrete fix
 
-IMPORTANT:
-
-- If all Scout best practices are followed, report "All Scout test best practices are followed. No issues found.
-- If the developer makes updates to PR contents, you're free to suggest improvements but don't overwhelm developers with nitpicks.
+If the developer makes updates to PR contents, you're free to suggest improvements on the newer code blocks.

--- a/.macroscope/scout-review.md
+++ b/.macroscope/scout-review.md
@@ -23,11 +23,11 @@ Do NOT post flaky test runner nudges. A separate agent handles this.
 
 ## Review instructions
 
-Follow the skill at `.agents/skills/scout-best-practices-reviewer/SKILL.md` for scope, checklist, reuse rules and migration parity. The output format below applies to this agent. Ignore any output formatting instructions in the skill file.
+Follow the skill at `.agents/skills/scout-best-practices-reviewer/SKILL.md` for scope, checklist, reuse rules and migration parity. The output format below applies to this agent. Ignore any output formatting instructions in the skill file. You can use the `browse_code` tool to explore the codebase.
 
 ## Output
 
-Post findings as **GitHub PR comments**. If no issues are found, don't post any comments.
+Post findings as **GitHub PR comments**.
 
 Group findings by severity: 🔴 Blocker → 🟡 Major → 🔵 Minor → ⚪ Nit. For each finding:
 
@@ -36,4 +36,14 @@ Group findings by severity: 🔴 Blocker → 🟡 Major → 🔵 Minor → ⚪ N
 - Explain the issue in 1–2 sentences
 - Suggest a concrete fix
 
-If the developer makes updates to PR contents, you're free to suggest improvements on the newer code blocks.
+### Positive reinforcement
+
+If a PR is adding or updating Scout tests following our best practices particularly well, post a single extra comment highlighting all the good practices it's already following.
+
+### Link to a specific section of the Best practices document when possible
+
+When possible, link to a specific section of the [Best practices for Scout tests document](https://www.elastic.co/docs/extend/kibana/scout/best-practices) so developers can learn more about a specific best practice. A link scoped to a specific section looks like this: https://www.elastic.co/docs/extend/kibana/scout/best-practices#avoid-conditional-logic-in-page-objects. You can infer the #anchor by looking at the `docs/extend/scout/best-practices.md` file (e.g., `[avoid-conditional-logic-in-page-objects]`).
+
+### New updates
+
+If the developer makes updates to PR contents, suggest improvements on the newer code blocks while keeping in mind to keep the review high signal and not too nitpicky.


### PR DESCRIPTION
This PR updates the existing Scout Test Review Macroscope check run agent so that it references the contents of the existing `scout-best-practices-reviewer` skill. We also use the new `include` glob pattern so that this check run agent isn't run for every single PR, but for just those PRs with file changes that match the pattern.