### PR TITLE
[9.2] [scout] move internal api tests to scout steps (#263021)

### DIFF
--- a/.buildkite/scout_ci_config.yml
+++ b/.buildkite/scout_ci_config.yml
@@ -25,12 +25,9 @@ plugins:
 
 packages:
   enabled:
+    - kbn-scout
     - kbn-streamlang-tests
   disabled:
-    # Scout's own tests are executed first to validate the Scout framework
-    # (see .buildkite/scripts/steps/test/scout/test_run_builder.sh). Excluded here
-    # so they don't rerun alongside plugin/package Scout tests discovered later.
-    - kbn-scout
     - kbn-scout-release-testing # Release tests will run separately as part of the release process
 
 # Define test configs to be excluded from automatic discovery & execution in CI environment (process.env.CI=true)

--- a/.buildkite/scripts/steps/test/scout/test_run_builder.sh
+++ b/.buildkite/scripts/steps/test/scout/test_run_builder.sh
@@ -79,7 +79,8 @@ else
     SELECTIVE_SCOUT_DISCOVERY_FLAG=(--selective-testing)
     echo "Selective testing: enabled (--selective-testing flag will be passed to discover-playwright-configs)"
   else
-    echo "Selective testing: disabled — reason: SELECTIVE_TESTING_ENABLED=${SELECTIVE_TESTING_ENABLED:-false}, scout:run-all-tests label=$(is_pr_with_label "scout:run-all-tests" && echo yes || echo no), critical files touched=${SCOUT_CRITICAL_FILES_TOUCHED}"
+    echo "Selective testing is disabled"
+    echo "Reason: SELECTIVE_TESTING_ENABLED=${SELECTIVE_TESTING_ENABLED:-false}, 'scout:run-all-tests' label=$(is_pr_with_label "scout:run-all-tests" && echo yes || echo no), 'critical files touched'=${SCOUT_CRITICAL_FILES_TOUCHED}"
   fi
   node scripts/scout discover-playwright-configs \
     --include-custom-servers \
@@ -90,14 +91,6 @@ else
   cp .scout/test_configs/scout_playwright_configs.json scout_playwright_configs.json
   buildkite-agent artifact upload "scout_playwright_configs.json"
 fi
-
-echo '--- Running Scout API Integration Tests'
-node scripts/scout.js run-tests \
-  --location local \
-  --arch stateful \
-  --domain classic \
-  --config src/platform/packages/shared/kbn-scout/test/scout/api/parallel.playwright.config.ts \
-  --kibanaInstallDir "$KIBANA_BUILD_LOCATION"
 
 source .buildkite/scripts/steps/test/scout/upload_report_events.sh
 

--- a/src/platform/packages/shared/kbn-scout/test/scout/api/parallel_tests/api_services/fleet.spec.ts
+++ b/src/platform/packages/shared/kbn-scout/test/scout/api/parallel_tests/api_services/fleet.spec.ts
@@ -172,82 +172,78 @@ apiTest.describe(
   }
 );
 
-apiTest.describe(
-  'Fleet Outputs Management',
-  { tag: [...tags.serverless.security.complete, ...tags.stateful.classic] },
-  () => {
-    let outputId: string;
+apiTest.describe('Fleet Outputs Management', { tag: [...tags.stateful.classic] }, () => {
+  let outputId: string;
 
-    apiTest.afterEach(async ({ apiServices }) => {
-      // Clean up output
-      if (outputId) {
-        await apiServices.fleet.outputs.delete(outputId);
+  apiTest.afterEach(async ({ apiServices }) => {
+    // Clean up output
+    if (outputId) {
+      await apiServices.fleet.outputs.delete(outputId);
+    }
+    outputId = '';
+  });
+
+  apiTest('should get all outputs', async ({ apiServices }) => {
+    const response = await apiServices.fleet.outputs.getOutputs();
+
+    expect(response).toHaveStatusCode(200);
+    expect(response.data).toBeDefined();
+    expect(response.data.items).toBeDefined();
+  });
+
+  apiTest('should get a specific output by ID', async ({ apiServices }) => {
+    // First get all outputs to find an existing one
+    const allOutputsResponse = await apiServices.fleet.outputs.getOutputs();
+    const existingOutput = allOutputsResponse.data.items[0];
+
+    // Only proceed if we have an existing output
+    expect(existingOutput).toBeDefined();
+
+    const response = await apiServices.fleet.outputs.getOutput(existingOutput.id);
+
+    expect(response).toHaveStatusCode(200);
+    expect(response.data.item.id).toBe(existingOutput.id);
+  });
+
+  apiTest('should create an output with additional parameters', async ({ apiServices }) => {
+    const outputName = `test-output-params-${Date.now()}`;
+    const outputHosts = ['https://localhost:9200'];
+
+    const response = await apiServices.fleet.outputs.create(
+      outputName,
+      outputHosts,
+      'elasticsearch',
+      {
+        is_default: false,
+        ca_trusted_fingerprint: 'test-fingerprint',
       }
-      outputId = '';
-    });
+    );
 
-    apiTest('should get all outputs', async ({ apiServices }) => {
-      const response = await apiServices.fleet.outputs.getOutputs();
+    expect(response).toHaveStatusCode(200);
+    expect(response.data.item.name).toBe(outputName);
+    expect(response.data.item.is_default).toBe(false);
 
-      expect(response).toHaveStatusCode(200);
-      expect(response.data).toBeDefined();
-      expect(response.data.items).toBeDefined();
-    });
+    outputId = response.data.item.id;
+  });
 
-    apiTest('should get a specific output by ID', async ({ apiServices }) => {
-      // First get all outputs to find an existing one
-      const allOutputsResponse = await apiServices.fleet.outputs.getOutputs();
-      const existingOutput = allOutputsResponse.data.items[0];
+  apiTest('should delete an output', async ({ apiServices }) => {
+    const outputName = `test-output-delete-${Date.now()}`;
 
-      // Only proceed if we have an existing output
-      expect(existingOutput).toBeDefined();
+    // First create an output
+    const createResponse = await apiServices.fleet.outputs.create(
+      outputName,
+      ['https://localhost:9200'],
+      'elasticsearch'
+    );
+    const deleteOutputId = createResponse.data.item.id;
 
-      const response = await apiServices.fleet.outputs.getOutput(existingOutput.id);
+    // Then delete it
+    const response = await apiServices.fleet.outputs.delete(deleteOutputId);
 
-      expect(response).toHaveStatusCode(200);
-      expect(response.data.item.id).toBe(existingOutput.id);
-    });
-
-    apiTest('should create an output with additional parameters', async ({ apiServices }) => {
-      const outputName = `test-output-params-${Date.now()}`;
-      const outputHosts = ['https://localhost:9200'];
-
-      const response = await apiServices.fleet.outputs.create(
-        outputName,
-        outputHosts,
-        'elasticsearch',
-        {
-          is_default: false,
-          ca_trusted_fingerprint: 'test-fingerprint',
-        }
-      );
-
-      expect(response).toHaveStatusCode(200);
-      expect(response.data.item.name).toBe(outputName);
-      expect(response.data.item.is_default).toBe(false);
-
-      outputId = response.data.item.id;
-    });
-
-    apiTest('should delete an output', async ({ apiServices }) => {
-      const outputName = `test-output-delete-${Date.now()}`;
-
-      // First create an output
-      const createResponse = await apiServices.fleet.outputs.create(
-        outputName,
-        ['https://localhost:9200'],
-        'elasticsearch'
-      );
-      const deleteOutputId = createResponse.data.item.id;
-
-      // Then delete it
-      const response = await apiServices.fleet.outputs.delete(deleteOutputId);
-
-      expect(response).toHaveStatusCode(200);
-      // Don't set outputId since we already deleted it
-    });
-  }
-);
+    expect(response).toHaveStatusCode(200);
+    // Don't set outputId since we already deleted it
+  });
+});
 
 apiTest.describe(
   'Fleet Server Hosts Management',


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[scout] move internal api tests to scout steps (#263021)](https://github.com/elastic/kibana/pull/263021)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Dzmitry Lemechko","email":"dzmitry.lemechko@elastic.co"},"sourceCommit":{"committedDate":"2026-04-14T23:06:13Z","message":"[scout] move internal api tests to scout steps (#263021)\n\n## Summary\n\nCloses https://github.com/elastic/appex-qa-team/issues/850\n\nWith selective testing enabled, it makes sense to move scout internal\napi tests running together with other tests, so that they can be skipped\ncompletely when there are 0 affected modules.\n\nI also noticed that running tests without building plugins might be not\nreliable, so let's run internal tests against build as any other tests.\n\n<img width=\"1132\" height=\"467\" alt=\"Screenshot 2026-04-14 at 15 35 28\"\nsrc=\"https://github.com/user-attachments/assets/1cc6453a-74ad-45be-b855-ecccc28fc20f\"\n/>","sha":"a34ca6bba5d837d4c1b5b230d830f9669897344f","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:all-open","v9.4.0","v9.5.0","v9.3.4","v8.19.15"],"title":"[scout] move internal api tests to scout steps","number":263021,"url":"https://github.com/elastic/kibana/pull/263021","mergeCommit":{"message":"[scout] move internal api tests to scout steps (#263021)\n\n## Summary\n\nCloses https://github.com/elastic/appex-qa-team/issues/850\n\nWith selective testing enabled, it makes sense to move scout internal\napi tests running together with other tests, so that they can be skipped\ncompletely when there are 0 affected modules.\n\nI also noticed that running tests without building plugins might be not\nreliable, so let's run internal tests against build as any other tests.\n\n<img width=\"1132\" height=\"467\" alt=\"Screenshot 2026-04-14 at 15 35 28\"\nsrc=\"https://github.com/user-attachments/assets/1cc6453a-74ad-45be-b855-ecccc28fc20f\"\n/>","sha":"a34ca6bba5d837d4c1b5b230d830f9669897344f"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/263219","number":263219,"state":"MERGED","mergeCommit":{"sha":"6934b187917412faff8668be7e490602d4b20d17","message":"[9.4] [scout] move internal api tests to scout steps (#263021) (#263219)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.4`:\n- [[scout] move internal api tests to scout steps\n(#263021)](https://github.com/elastic/kibana/pull/263021)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Dzmitry Lemechko <dzmitry.lemechko@elastic.co>"}},{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/263021","number":263021,"mergeCommit":{"message":"[scout] move internal api tests to scout steps (#263021)\n\n## Summary\n\nCloses https://github.com/elastic/appex-qa-team/issues/850\n\nWith selective testing enabled, it makes sense to move scout internal\napi tests running together with other tests, so that they can be skipped\ncompletely when there are 0 affected modules.\n\nI also noticed that running tests without building plugins might be not\nreliable, so let's run internal tests against build as any other tests.\n\n<img width=\"1132\" height=\"467\" alt=\"Screenshot 2026-04-14 at 15 35 28\"\nsrc=\"https://github.com/user-attachments/assets/1cc6453a-74ad-45be-b855-ecccc28fc20f\"\n/>","sha":"a34ca6bba5d837d4c1b5b230d830f9669897344f"}},{"branch":"9.3","label":"v9.3.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/263218","number":263218,"state":"MERGED","mergeCommit":{"sha":"17444c9abc507f13d4ee90a83411844eec9b0837","message":"[9.3] [scout] move internal api tests to scout steps (#263021) (#263218)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.3`:\n- [[scout] move internal api tests to scout steps\n(#263021)](https://github.com/elastic/kibana/pull/263021)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Dzmitry Lemechko <dzmitry.lemechko@elastic.co>"}},{"branch":"8.19","label":"v8.19.15","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/263297","number":263297,"state":"MERGED","mergeCommit":{"sha":"91890b4c461cf00a2116db60626a3fd5a541aeb8","message":"[8.19] [scout] move internal api tests to scout steps (#263021) (#263297)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.19`:\n- [[scout] move internal api tests to scout steps\n(#263021)](https://github.com/elastic/kibana/pull/263021)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n"}}]}] BACKPORT-->