### PR TITLE
[Agent Builder] [Bug Bash] Weird layout and button for Connector Details page

### DIFF
--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/action_connector_form/edit_connector_flyout/header.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/action_connector_form/edit_connector_flyout/header.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { memo, useCallback } from 'react';
+import React, { memo, Suspense, useCallback } from 'react';
 import { css } from '@emotion/react';
 import type { IconType } from '@elastic/eui';
 import {
@@ -74,15 +74,17 @@ const FlyoutHeaderComponent: React.FC<{
     <EuiFlyoutHeader hasBorder data-test-subj="edit-connector-flyout-header">
       <EuiFlexGroup gutterSize="s" alignItems="center">
         {icon ? (
-          <EuiFlexItem grow={false}>
-            <EuiIcon type={icon} size="m" data-test-subj="edit-connector-flyout-header-icon" />
-          </EuiFlexItem>
+          <Suspense fallback={null}>
+            <EuiFlexItem grow={false}>
+              <EuiIcon type={icon} size="m" data-test-subj="edit-connector-flyout-header-icon" />
+            </EuiFlexItem>
+          </Suspense>
         ) : null}
         <EuiFlexItem grow={false}>
           {isPreconfigured ? (
             <>
               <EuiFlexGroup gutterSize="s" justifyContent="center" alignItems="center">
-                <EuiFlexItem grow={false}>
+                <EuiFlexItem autoFocus={true} grow={false}>
                   <EuiTitle size="s">
                     <h3 id="flyoutTitle">
                       <FormattedMessage

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/action_connector_form/edit_connector_flyout/header.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/action_connector_form/edit_connector_flyout/header.tsx
@@ -83,8 +83,8 @@ const FlyoutHeaderComponent: React.FC<{
         <EuiFlexItem grow={false}>
           {isPreconfigured ? (
             <>
-              <EuiFlexGroup gutterSize="s" justifyContent="center" alignItems="center">
-                <EuiFlexItem autoFocus={true} grow={false}>
+              <EuiFlexGroup gutterSize="s" alignItems="center" wrap={true}>
+                <EuiFlexItem autoFocus={true} grow={false} style={{ minWidth: '200px' }}>
                   <EuiTitle size="s">
                     <h3 id="flyoutTitle">
                       <FormattedMessage
@@ -125,8 +125,8 @@ const FlyoutHeaderComponent: React.FC<{
               </EuiText>
             </>
           ) : (
-            <EuiFlexGroup gutterSize="s" justifyContent="center" alignItems="center">
-              <EuiFlexItem>
+            <EuiFlexGroup gutterSize="s" alignItems="center" wrap={true}>
+              <EuiFlexItem style={{ minWidth: '200px' }}>
                 <EuiTitle size="s">
                   <h3 id="flyoutTitle">
                     <FormattedMessage

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/action_connector_form/edit_connector_flyout/read_only.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/action_connector_form/edit_connector_flyout/read_only.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React from 'react';
+import React, { Suspense } from 'react';
 import { EuiLink, EuiSpacer, EuiText } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
@@ -34,7 +34,9 @@ export const ReadOnlyConnectorMessage: React.FC<{
       {ExtraComponent && (
         <>
           <EuiSpacer size="m" />
-          <ExtraComponent connectorId={connectorId} connectorName={connectorName} />
+          <Suspense fallback={null}>
+            <ExtraComponent connectorId={connectorId} connectorName={connectorName} />
+          </Suspense>
         </>
       )}
     </>


### PR DESCRIPTION
## Summary
closes - https://github.com/elastic/search-team/issues/13835

This PR fixes two issues in the Edit Connector flyout:
1. **Accessibility bug:** The "Skip to main content" button erroneously appeared when opening the flyout. This was caused by async components (`React.lazy` and `EuiIcon`) suspending the render and breaking the `EuiFlyout` focus trap.
2. **UI layout bug:** On smaller screens or when resizing, the flyout title would compress too much alongside the badges.

## Changes
* **Focus fix:** Wrapped `<EuiIcon>` and `<ExtraComponent>` in `<Suspense fallback={null}>` to localize render suspension. Added explicit `autoFocus` to the title to ensure stable focus management.
* **Header layout fix:** Added `wrap={true}` to the header's `EuiFlexGroup` and `minWidth: '200px'` to the title item so badges neatly wrap to the next line when space is limited.

<img width="895" height="469" alt="Screenshot 2026-04-16 at 17 42 52" src="https://github.com/user-attachments/assets/e0b43d5e-e590-49d1-9d5c-5830feac12f9" />
