### PR TITLE
[9.4] [Agent Builder] Fix - Agent custom instructions readability and layout (#263580)

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/overview/settings_section.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/overview/settings_section.tsx
@@ -24,8 +24,17 @@ import { labels } from '../../../utils/i18n';
 
 const { agentOverview: overviewLabels } = labels;
 
+const CARD_BODY_BLOCK_SIZE = '275px';
+
 const settingRowStyles = css`
   width: 100%;
+`;
+const instructionsContainerStyles = css`
+  max-block-size: ${CARD_BODY_BLOCK_SIZE};
+  overflow: auto;
+`;
+const instructionsTextStyles = css`
+  white-space: pre-wrap;
 `;
 
 export interface SettingsSectionProps {
@@ -61,7 +70,7 @@ export const SettingsSection: React.FC<SettingsSectionProps> = ({
 
       <EuiSpacer size="m" />
 
-      <EuiFlexGroup gutterSize="m" alignItems="stretch">
+      <EuiFlexGroup gutterSize="m" alignItems="flexStart">
         {/* Custom Instructions Card */}
         <EuiFlexItem grow={1}>
           <EuiCard
@@ -71,7 +80,7 @@ export const SettingsSection: React.FC<SettingsSectionProps> = ({
             title={overviewLabels.customInstructionsTitle}
             titleElement="h3"
             titleSize="xs"
-            description={currentInstructions || overviewLabels.customInstructionsOnboardingText}
+            description={overviewLabels.customInstructionsSubtitle}
             textAlign="left"
             onClick={canEditAgent ? onOpenEditFlyout : undefined}
             footer={
@@ -91,7 +100,18 @@ export const SettingsSection: React.FC<SettingsSectionProps> = ({
                 color: ${euiTheme.colors.textSubdued};
               }
             `}
-          />
+          >
+            {currentInstructions && (
+              <>
+                <EuiSpacer size="l" />
+                <div css={instructionsContainerStyles}>
+                  <EuiText size="s" color="subdued">
+                    <p css={instructionsTextStyles}>{currentInstructions}</p>
+                  </EuiText>
+                </div>
+              </>
+            )}
+          </EuiCard>
         </EuiFlexItem>
 
         {/* Agent Settings Card */}
@@ -106,93 +126,91 @@ export const SettingsSection: React.FC<SettingsSectionProps> = ({
             description={overviewLabels.agentSettingsCardSubtitle}
             textAlign="left"
             onClick={canEditAgent ? onOpenEditFlyout : undefined}
-            footer={
-              <EuiFlexGroup
-                direction="column"
-                gutterSize="s"
-                responsive={false}
-                css={settingRowStyles}
-              >
-                {/* Include built-in capabilities row */}
-                <EuiFlexItem grow={false}>
-                  <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
-                    <EuiFlexItem grow>
-                      <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
-                        <EuiFlexItem grow={false}>
-                          <EuiText
-                            color={enableElasticCapabilities ? 'textPrimary' : 'subdued'}
-                            size="s"
-                          >
-                            {overviewLabels.autoIncludeTitle}
-                          </EuiText>
-                        </EuiFlexItem>
-                        <EuiFlexItem
-                          grow={false}
-                          css={enableElasticCapabilities ? undefined : textDisabledStyles}
-                        >
-                          <EuiIcon type="info" size="s" aria-hidden={true} />
-                        </EuiFlexItem>
-                      </EuiFlexGroup>
-                    </EuiFlexItem>
-                    <EuiFlexItem grow={false}>
-                      {enableElasticCapabilities ? (
-                        <EuiBadge color="success" data-test-subj="agentOverviewAutoIncludeBadge">
-                          {overviewLabels.enabledBadge}
-                        </EuiBadge>
-                      ) : (
-                        <EuiBadge color="default" data-test-subj="agentOverviewAutoIncludeBadge">
-                          {overviewLabels.notSetBadge}
-                        </EuiBadge>
-                      )}
-                    </EuiFlexItem>
-                  </EuiFlexGroup>
-                </EuiFlexItem>
-
-                {/* Pre-execution workflows row */}
-                {showWorkflowSection && (
-                  <>
-                    <EuiHorizontalRule margin="none" />
-
-                    <EuiFlexItem grow={false}>
-                      <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
-                        <EuiFlexItem grow>
-                          <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
-                            <EuiFlexItem grow={false}>
-                              <EuiText size="s" color={hasWorkflows ? 'textPrimary' : 'subdued'}>
-                                {overviewLabels.preExecutionWorkflowTitle}
-                              </EuiText>
-                            </EuiFlexItem>
-                            <EuiFlexItem
-                              grow={false}
-                              css={hasWorkflows ? undefined : textDisabledStyles}
-                            >
-                              <EuiIcon type="info" size="s" aria-hidden={true} />
-                            </EuiFlexItem>
-                          </EuiFlexGroup>
-                        </EuiFlexItem>
-                        <EuiFlexItem grow={false}>
-                          <EuiBadge
-                            color={hasWorkflows ? 'success' : 'default'}
-                            data-test-subj="agentOverviewWorkflowsBadge"
-                          >
-                            {hasWorkflows
-                              ? overviewLabels.enabledBadge
-                              : overviewLabels.notSetBadge}
-                          </EuiBadge>
-                        </EuiFlexItem>
-                      </EuiFlexGroup>
-                    </EuiFlexItem>
-                  </>
-                )}
-              </EuiFlexGroup>
-            }
             css={css`
               height: 100%;
               .euiCard__content p {
                 color: ${euiTheme.colors.textSubdued};
               }
             `}
-          />
+          >
+            <EuiSpacer size="l" />
+            <EuiFlexGroup
+              direction="column"
+              gutterSize="s"
+              responsive={false}
+              css={settingRowStyles}
+            >
+              {/* Include built-in capabilities row */}
+              <EuiFlexItem grow={false}>
+                <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
+                  <EuiFlexItem grow>
+                    <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
+                      <EuiFlexItem grow={false}>
+                        <EuiText
+                          color={enableElasticCapabilities ? 'textPrimary' : 'subdued'}
+                          size="s"
+                        >
+                          {overviewLabels.autoIncludeTitle}
+                        </EuiText>
+                      </EuiFlexItem>
+                      <EuiFlexItem
+                        grow={false}
+                        css={enableElasticCapabilities ? undefined : textDisabledStyles}
+                      >
+                        <EuiIcon type="info" size="s" aria-hidden={true} />
+                      </EuiFlexItem>
+                    </EuiFlexGroup>
+                  </EuiFlexItem>
+                  <EuiFlexItem grow={false}>
+                    {enableElasticCapabilities ? (
+                      <EuiBadge color="success" data-test-subj="agentOverviewAutoIncludeBadge">
+                        {overviewLabels.enabledBadge}
+                      </EuiBadge>
+                    ) : (
+                      <EuiBadge color="default" data-test-subj="agentOverviewAutoIncludeBadge">
+                        {overviewLabels.notSetBadge}
+                      </EuiBadge>
+                    )}
+                  </EuiFlexItem>
+                </EuiFlexGroup>
+              </EuiFlexItem>
+
+              {/* Pre-execution workflows row */}
+              {showWorkflowSection && (
+                <>
+                  <EuiHorizontalRule margin="none" />
+
+                  <EuiFlexItem grow={false}>
+                    <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
+                      <EuiFlexItem grow>
+                        <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
+                          <EuiFlexItem grow={false}>
+                            <EuiText size="s" color={hasWorkflows ? 'textPrimary' : 'subdued'}>
+                              {overviewLabels.preExecutionWorkflowTitle}
+                            </EuiText>
+                          </EuiFlexItem>
+                          <EuiFlexItem
+                            grow={false}
+                            css={hasWorkflows ? undefined : textDisabledStyles}
+                          >
+                            <EuiIcon type="info" size="s" aria-hidden={true} />
+                          </EuiFlexItem>
+                        </EuiFlexGroup>
+                      </EuiFlexItem>
+                      <EuiFlexItem grow={false}>
+                        <EuiBadge
+                          color={hasWorkflows ? 'success' : 'default'}
+                          data-test-subj="agentOverviewWorkflowsBadge"
+                        >
+                          {hasWorkflows ? overviewLabels.enabledBadge : overviewLabels.notSetBadge}
+                        </EuiBadge>
+                      </EuiFlexItem>
+                    </EuiFlexGroup>
+                  </EuiFlexItem>
+                </>
+              )}
+            </EuiFlexGroup>
+          </EuiCard>
         </EuiFlexItem>
       </EuiFlexGroup>
     </>

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/utils/i18n.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/utils/i18n.ts
@@ -2021,7 +2021,7 @@ export const labels = {
         defaultMessage: 'Custom instructions',
       }
     ),
-    customInstructionsOnboardingText: i18n.translate(
+    customInstructionsSubtitle: i18n.translate(
       'xpack.agentBuilder.overview.customizations.instructionsOnboardingText',
       {
         defaultMessage: 'Shape how the agent responds to questions and tasks.',


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Agent Builder] Fix - Agent custom instructions readability and layout (#263580)](https://github.com/elastic/kibana/pull/263580)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Zachary Parikh","email":"zachary.parikh@elastic.co"},"sourceCommit":{"committedDate":"2026-04-16T13:55:39Z","message":"[Agent Builder] Fix - Agent custom instructions readability and layout (#263580)\n\n## Summary\n\nMakes the custom instruction text more readable and adds a scrollable\narea for the custom instructions text.\n\n\n\nhttps://github.com/user-attachments/assets/bcee57da-bf41-490a-855d-c96ac8930be5\n\n\n\n## Additional changes\n- Small fix for the DOM structure for a loading capability card.\nPreviously was nesting a div inside of a p element and causing the\nbrowser to complain\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...","sha":"a3f24a947dde6c4f6656638f473134cfa611851a","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:version","v9.4.0","feature:agent-builder","v9.5.0"],"title":"[Agent Builder] Fix - Agent custom instructions readability and layout","number":263580,"url":"https://github.com/elastic/kibana/pull/263580","mergeCommit":{"message":"[Agent Builder] Fix - Agent custom instructions readability and layout (#263580)\n\n## Summary\n\nMakes the custom instruction text more readable and adds a scrollable\narea for the custom instructions text.\n\n\n\nhttps://github.com/user-attachments/assets/bcee57da-bf41-490a-855d-c96ac8930be5\n\n\n\n## Additional changes\n- Small fix for the DOM structure for a loading capability card.\nPreviously was nesting a div inside of a p element and causing the\nbrowser to complain\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...","sha":"a3f24a947dde6c4f6656638f473134cfa611851a"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/263580","number":263580,"mergeCommit":{"message":"[Agent Builder] Fix - Agent custom instructions readability and layout (#263580)\n\n## Summary\n\nMakes the custom instruction text more readable and adds a scrollable\narea for the custom instructions text.\n\n\n\nhttps://github.com/user-attachments/assets/bcee57da-bf41-490a-855d-c96ac8930be5\n\n\n\n## Additional changes\n- Small fix for the DOM structure for a loading capability card.\nPreviously was nesting a div inside of a p element and causing the\nbrowser to complain\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...","sha":"a3f24a947dde6c4f6656638f473134cfa611851a"}}]}] BACKPORT-->