### PR TITLE
[POC][One Workflow] Context variable autocomplete — custom suggest widget

### DIFF
--- a/poc/workflow_suggest_widget.html
+++ b/poc/workflow_suggest_widget.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<title>POC: Custom Workflow Suggest Widget</title>
+<title>POC: Custom Workflow Suggest Widget (IContentWidget + Context Keys)</title>
 <style>
   * { margin: 0; padding: 0; box-sizing: border-box; }
 
@@ -71,11 +71,42 @@
     overflow: hidden;
   }
 
+  /* Debug bar */
+  .debug-bar {
+    padding: 6px 20px;
+    background: #25262e;
+    border-top: 1px solid #343741;
+    font-size: 11px;
+    font-family: 'SF Mono', monospace;
+    color: #69707d;
+    display: flex;
+    gap: 24px;
+    flex-shrink: 0;
+  }
+
+  .debug-bar .ctx-key {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  .debug-bar .ctx-key .dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: #343741;
+  }
+
+  .debug-bar .ctx-key .dot.active { background: #7ee2a8; }
+
   /* ─── Custom Suggest Widget ─── */
 
-  .suggest-widget-custom {
-    position: absolute;
-    z-index: 1000;
+  /* Monaco sets `display: block; position: fixed; visibility: inherit;`
+     as inline styles on IContentWidget DOM nodes. Since inline styles
+     override class selectors, we hide the inner wrapper instead —
+     Monaco doesn't touch that. */
+
+  .suggest-widget-inner {
     display: flex;
     background: #1d1e24;
     border: 1px solid #343741;
@@ -85,7 +116,7 @@
     max-height: 340px;
   }
 
-  .suggest-widget-custom.hidden { display: none; }
+  .suggest-widget-inner.hidden { display: none; }
 
   /* ── Left panel: Suggestion list ── */
 
@@ -307,7 +338,7 @@
 <body>
 
 <div class="header">
-  <h1>Workflow YAML Editor — Custom Suggest Widget POC</h1>
+  <h1>POC v2 — IContentWidget + Context Keys + addAction keybindings</h1>
   <span class="hint">Press <kbd>Ctrl</kbd>+<kbd>Space</kbd> to trigger, or type after a key</span>
   <div class="scenario-tabs">
     <button class="scenario-tab active" data-scenario="connector-types">Connector Types</button>
@@ -318,11 +349,25 @@
 
 <div id="editor-container"></div>
 
+<div class="debug-bar">
+  <div class="ctx-key">
+    <span class="dot" id="dot-visible"></span>
+    <span>customSuggestWidgetVisible</span>
+  </div>
+  <div class="ctx-key">
+    <span class="dot" id="dot-focus"></span>
+    <span>editorTextFocus</span>
+  </div>
+  <div id="debug-position" style="margin-left: auto;">—</div>
+  <div id="debug-filter">filter: ""</div>
+  <div id="debug-widget-type">widget: IContentWidget</div>
+</div>
+
 <script src="https://cdn.jsdelivr.net/npm/monaco-editor@0.44.0/min/vs/loader.js"></script>
 <script>
 
 // ─────────────────────────────────────────────────────────────
-// Suggestion Data
+// Suggestion Data (unchanged from v1)
 // ─────────────────────────────────────────────────────────────
 
 const SUGGESTION_DATA = {
@@ -474,9 +519,8 @@ steps:
 `,
 };
 
-// Cursor positions (line, column) where the widget should appear
 const SCENARIO_CURSOR = {
-  'connector-types': { lineNumber: 13, column: 11 },
+  'connector-types': { lineNumber: 11, column: 11 },
   'connector-params': { lineNumber: 12, column: 7 },
   'template-vars': { lineNumber: 22, column: 16 },
 };
@@ -498,12 +542,10 @@ function fuzzyMatch(pattern, text) {
     }
   }
   if (pi < pLower.length) return { matches: false, indices: [], score: -1 };
-
-  // Score: consecutive matches are better, earlier matches are better
   let score = 0;
   for (let i = 0; i < indices.length; i++) {
-    score -= indices[i]; // earlier = better
-    if (i > 0 && indices[i] === indices[i - 1] + 1) score += 10; // consecutive bonus
+    score -= indices[i];
+    if (i > 0 && indices[i] === indices[i - 1] + 1) score += 10;
   }
   return { matches: true, indices, score };
 }
@@ -531,6 +573,8 @@ require.config({ paths: { vs: 'https://cdn.jsdelivr.net/npm/monaco-editor@0.44.0
 
 require(['vs/editor/editor.main'], function (monaco) {
 
+  // Enable fixedOverflowWidgets so content widgets can escape the editor bounds
+  // (same option Kibana uses in code_editor.tsx)
   const editor = monaco.editor.create(document.getElementById('editor-container'), {
     value: SCENARIO_YAML['connector-types'],
     language: 'yaml',
@@ -543,43 +587,270 @@ require(['vs/editor/editor.main'], function (monaco) {
     scrollBeyondLastLine: false,
     padding: { top: 12 },
     tabSize: 2,
-    quickSuggestions: false,
+    fixedOverflowWidgets: true,   // KEY: allows content widgets to overflow editor bounds
+    quickSuggestions: false,       // Suppress built-in suggest widget
     suggestOnTriggerCharacters: false,
     wordBasedSuggestions: 'off',
     parameterHints: { enabled: false },
   });
 
-  // ─── Custom Suggest Widget ───
+  // ─────────────────────────────────────────────────────────────
+  // Context Keys (public API: editor.createContextKey)
+  //
+  // These gate keybindings so arrow/enter/escape only intercept
+  // when the custom widget is visible. Same mechanism Monaco uses
+  // internally for `suggestWidgetVisible`.
+  // ─────────────────────────────────────────────────────────────
+
+  const ctxWidgetVisible = editor.createContextKey('customSuggestWidgetVisible', false);
+
+  // Debug: update status bar dots
+  function updateDebugBar() {
+    document.getElementById('dot-visible').classList.toggle('active', !!ctxWidgetVisible.get());
+    document.getElementById('debug-filter').textContent = `filter: "${filterText}"`;
+    const pos = editor.getPosition();
+    document.getElementById('debug-position').textContent = pos
+      ? `Ln ${pos.lineNumber}, Col ${pos.column}`
+      : '—';
+  }
+
+  // ─────────────────────────────────────────────────────────────
+  // Custom Suggest Widget as IContentWidget
+  //
+  // IContentWidget positions relative to text content (line/col),
+  // scrolls with the text, and auto-flips ABOVE/BELOW based on
+  // available space. allowEditorOverflow lets it extend beyond
+  // the editor viewport (same as Monaco's built-in suggest widget).
+  // ─────────────────────────────────────────────────────────────
 
   let currentScenario = 'connector-types';
-  let widgetVisible = false;
   let selectedIndex = 0;
   let filterText = '';
   let filteredItems = [];
+  let anchorPosition = null; // {lineNumber, column} where widget was triggered
 
   // Create widget DOM
   const widgetEl = document.createElement('div');
-  widgetEl.className = 'suggest-widget-custom hidden';
+  widgetEl.className = 'suggest-widget-custom';
+  // Set explicit width so Monaco's max-width doesn't clip the flex children
+  widgetEl.style.width = '702px'; // 320 + 1 (border) + 380 + 1 (border)
   widgetEl.innerHTML = `
-    <div class="suggest-list-panel">
-      <div class="suggest-list-header">Suggested</div>
-      <div class="suggest-list"></div>
-    </div>
-    <div class="suggest-details-panel">
-      <div class="detail-empty">Select a suggestion to see details</div>
+    <div class="suggest-widget-inner hidden">
+      <div class="suggest-list-panel">
+        <div class="suggest-list-header">Suggested</div>
+        <div class="suggest-list"></div>
+      </div>
+      <div class="suggest-details-panel">
+        <div class="detail-empty">Select a suggestion to see details</div>
+      </div>
     </div>
   `;
+  const innerEl = widgetEl.querySelector('.suggest-widget-inner');
+
+  // Prevent clicks on the widget from stealing editor focus
+  widgetEl.addEventListener('mousedown', (e) => {
+    e.preventDefault();
+  });
 
   const listEl = widgetEl.querySelector('.suggest-list');
   const detailsEl = widgetEl.querySelector('.suggest-details-panel');
 
-  // Register as overlay widget
-  const overlayWidget = {
+  // ─── IContentWidget implementation ───
+
+  const contentWidget = {
     getId: () => 'custom.suggest.widget',
+
     getDomNode: () => widgetEl,
-    getPosition: () => null, // we position manually
+
+    // allowEditorOverflow: the widget DOM is placed in the overflow container
+    // (outside editor's scrollable area), so it can extend beyond the viewport.
+    // In Kibana this renders into [data-test-subj="kbnCodeEditorEditorOverflowWidgetsContainer"].
+    allowEditorOverflow: true,
+
+    // suppressMouseDown: prevents the editor from receiving mousedown events
+    // that originate on this widget (keeps editor focus stable when clicking suggestions).
+    suppressMouseDown: true,
+
+    getPosition: () => {
+      if (!anchorPosition) return null;
+      return {
+        position: anchorPosition,
+        preference: [
+          // Try below cursor first, flip above if not enough space
+          monaco.editor.ContentWidgetPositionPreference.BELOW,
+          monaco.editor.ContentWidgetPositionPreference.ABOVE,
+        ],
+      };
+    },
   };
-  editor.addOverlayWidget(overlayWidget);
+
+  // Register the widget once. We show/hide via CSS class and
+  // call layoutContentWidget() to reposition when anchor changes.
+  editor.addContentWidget(contentWidget);
+
+  // ─────────────────────────────────────────────────────────────
+  // Keybindings via editor.addAction (precondition-gated)
+  //
+  // These actions ONLY fire when customSuggestWidgetVisible is true.
+  // When the widget is hidden, arrow keys, Enter, Escape all
+  // behave normally (Monaco's default behavior).
+  //
+  // addAction is the recommended public API for conditional
+  // keybindings — it creates proper keybinding rules internally.
+  // ─────────────────────────────────────────────────────────────
+
+  editor.addAction({
+    id: 'customSuggest.selectPrevious',
+    label: 'Custom Suggest: Select Previous',
+    precondition: 'customSuggestWidgetVisible',
+    keybindings: [monaco.KeyCode.UpArrow],
+    run: () => {
+      selectedIndex = Math.max(0, selectedIndex - 1);
+      renderList();
+    },
+  });
+
+  editor.addAction({
+    id: 'customSuggest.selectNext',
+    label: 'Custom Suggest: Select Next',
+    precondition: 'customSuggestWidgetVisible',
+    keybindings: [monaco.KeyCode.DownArrow],
+    run: () => {
+      selectedIndex = Math.min(filteredItems.length - 1, selectedIndex + 1);
+      renderList();
+    },
+  });
+
+  editor.addAction({
+    id: 'customSuggest.accept',
+    label: 'Custom Suggest: Accept',
+    precondition: 'customSuggestWidgetVisible',
+    keybindings: [monaco.KeyCode.Enter, monaco.KeyCode.Tab],
+    run: () => {
+      acceptSuggestion();
+    },
+  });
+
+  editor.addAction({
+    id: 'customSuggest.dismiss',
+    label: 'Custom Suggest: Dismiss',
+    precondition: 'customSuggestWidgetVisible',
+    keybindings: [monaco.KeyCode.Escape],
+    run: () => {
+      hideWidget();
+    },
+  });
+
+  // Page Up / Page Down for fast scrolling
+  editor.addAction({
+    id: 'customSuggest.pageUp',
+    label: 'Custom Suggest: Page Up',
+    precondition: 'customSuggestWidgetVisible',
+    keybindings: [monaco.KeyCode.PageUp],
+    run: () => {
+      selectedIndex = Math.max(0, selectedIndex - 8);
+      renderList();
+    },
+  });
+
+  editor.addAction({
+    id: 'customSuggest.pageDown',
+    label: 'Custom Suggest: Page Down',
+    precondition: 'customSuggestWidgetVisible',
+    keybindings: [monaco.KeyCode.PageDown],
+    run: () => {
+      selectedIndex = Math.min(filteredItems.length - 1, selectedIndex + 8);
+      renderList();
+    },
+  });
+
+  // Trigger widget: Ctrl+Space (always available)
+  editor.addAction({
+    id: 'customSuggest.trigger',
+    label: 'Custom Suggest: Trigger',
+    keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.Space],
+    run: () => {
+      showWidget();
+    },
+  });
+
+  // ─────────────────────────────────────────────────────────────
+  // Filter text tracking via onDidChangeModelContent
+  //
+  // Instead of fragile onKeyDown char-matching, we listen to
+  // actual model content changes to track what the user typed
+  // since the widget opened. This handles all input methods
+  // (keyboard, paste, IME, etc.)
+  // ─────────────────────────────────────────────────────────────
+
+  editor.onDidChangeModelContent((e) => {
+    if (!ctxWidgetVisible.get() || isAccepting) return;
+
+    for (const change of e.changes) {
+      if (change.text.length > 0 && change.rangeLength === 0) {
+        // Insertion — append to filter (handles single chars, paste, IME)
+        filterText += change.text;
+      } else if (change.text.length === 0 && change.rangeLength > 0) {
+        // Deletion — trim filter from the end
+        filterText = filterText.slice(0, Math.max(0, filterText.length - change.rangeLength));
+      } else if (change.text.length > 0 && change.rangeLength > 0) {
+        // Replacement — trim deleted, then append inserted
+        filterText = filterText.slice(0, Math.max(0, filterText.length - change.rangeLength));
+        filterText += change.text;
+      }
+    }
+
+    selectedIndex = 0;
+    renderList();
+    updateDebugBar();
+
+    // If filter becomes empty from backspace, dismiss
+    if (filterText.length === 0 && e.changes.some(c => c.rangeLength > 0)) {
+      hideWidget();
+    }
+  });
+
+  // ─── Dismiss on cursor moving to a different line ───
+
+  editor.onDidChangeCursorPosition((e) => {
+    if (!ctxWidgetVisible.get()) return;
+
+    // If cursor moved to a completely different line, dismiss
+    if (anchorPosition && e.position.lineNumber !== anchorPosition.lineNumber) {
+      hideWidget();
+      return;
+    }
+
+    updateDebugBar();
+  });
+
+  // Dismiss on click outside widget
+  editor.onMouseDown(() => {
+    if (ctxWidgetVisible.get()) {
+      hideWidget();
+    }
+  });
+
+  // Reposition on scroll (IContentWidget auto-handles this, but
+  // we may need to update visibility for edge cases)
+  editor.onDidScrollChange(() => {
+    if (ctxWidgetVisible.get()) {
+      editor.layoutContentWidget(contentWidget);
+    }
+  });
+
+  // Track editor focus for debug bar
+  editor.onDidFocusEditorText(() => {
+    document.getElementById('dot-focus').classList.add('active');
+  });
+  editor.onDidBlurEditorText(() => {
+    document.getElementById('dot-focus').classList.remove('active');
+    // Optionally dismiss on blur (in production, delay to allow widget clicks)
+  });
+
+  // ─────────────────────────────────────────────────────────────
+  // Widget show/hide/accept logic
+  // ─────────────────────────────────────────────────────────────
 
   function getIconForKind(kind) {
     switch (kind) {
@@ -623,7 +894,6 @@ require(['vs/editor/editor.main'], function (monaco) {
       </div>
     `).join('');
 
-    // Click handlers
     listEl.querySelectorAll('.suggest-item').forEach(el => {
       el.addEventListener('mousedown', (e) => {
         e.preventDefault();
@@ -632,13 +902,14 @@ require(['vs/editor/editor.main'], function (monaco) {
         acceptSuggestion();
       });
       el.addEventListener('mouseover', () => {
-        selectedIndex = parseInt(el.dataset.index);
-        renderList();
-        renderDetails();
+        const idx = parseInt(el.dataset.index);
+        if (idx !== selectedIndex) {
+          selectedIndex = idx;
+          renderList();
+        }
       });
     });
 
-    // Scroll selected into view
     const selectedEl = listEl.querySelector('.suggest-item.selected');
     if (selectedEl) {
       selectedEl.scrollIntoView({ block: 'nearest' });
@@ -708,51 +979,38 @@ require(['vs/editor/editor.main'], function (monaco) {
     `;
   }
 
-  function positionWidget() {
+  // Flag to suppress onDidChangeModelContent during acceptSuggestion
+  let isAccepting = false;
+
+  function showWidget() {
     const pos = editor.getPosition();
     if (!pos) return;
 
-    const scrolledPos = editor.getScrolledVisiblePosition(pos);
-    if (!scrolledPos) return;
-
-    const editorDom = editor.getDomNode();
-    if (!editorDom) return;
-
-    const editorRect = editorDom.getBoundingClientRect();
-    const lineHeight = editor.getOption(monaco.editor.EditorOption.lineHeight);
-
-    let top = scrolledPos.top + lineHeight + 4;
-    let left = scrolledPos.left;
-
-    // If widget would go below the editor, show above
-    const widgetHeight = 340;
-    if (top + widgetHeight > editorRect.height) {
-      top = scrolledPos.top - widgetHeight - 4;
-    }
-
-    // Clamp left so widget doesn't go off-screen
-    const widgetWidth = 700;
-    if (left + widgetWidth > editorRect.width) {
-      left = Math.max(0, editorRect.width - widgetWidth - 20);
-    }
-
-    widgetEl.style.top = top + 'px';
-    widgetEl.style.left = left + 'px';
-  }
-
-  function showWidget() {
     filterText = '';
     selectedIndex = 0;
-    widgetEl.classList.remove('hidden');
-    widgetVisible = true;
-    positionWidget();
+    anchorPosition = { lineNumber: pos.lineNumber, column: pos.column };
+
+    // Set context key BEFORE showing — this enables the keybindings
+    ctxWidgetVisible.set(true);
+
+    innerEl.classList.remove('hidden');
+
+    // Tell Monaco to (re-)position the content widget at the anchor
+    editor.layoutContentWidget(contentWidget);
+
     renderList();
+    updateDebugBar();
   }
 
   function hideWidget() {
-    widgetEl.classList.add('hidden');
-    widgetVisible = false;
+    innerEl.classList.add('hidden');
+
+    // Clear context key — this disables the keybindings
+    ctxWidgetVisible.set(false);
+
     filterText = '';
+    anchorPosition = null;
+    updateDebugBar();
   }
 
   function acceptSuggestion() {
@@ -763,23 +1021,19 @@ require(['vs/editor/editor.main'], function (monaco) {
     const pos = editor.getPosition();
     if (!pos) return;
 
-    // Determine what text to insert
     let insertText = item.label;
-
-    // For params, add ": " suffix
     if (item.kind === 'param') {
       insertText = item.label + ': ';
     }
-    // For template vars, just the path
-    if (item.kind === 'variable') {
-      insertText = item.label;
-    }
 
-    // Calculate the range to replace (from start of typed filter to cursor)
-    const lineContent = editor.getModel().getLineContent(pos.lineNumber);
-    const startCol = pos.column - filterText.length;
-
+    // Replace from anchor column (where widget was triggered) to current cursor
+    const startCol = anchorPosition ? anchorPosition.column : pos.column - filterText.length;
     const range = new monaco.Range(pos.lineNumber, startCol, pos.lineNumber, pos.column);
+
+    // Suppress the onDidChangeModelContent handler during the edit —
+    // otherwise it would re-filter with the inserted text and keep the widget open
+    isAccepting = true;
+    hideWidget();
 
     editor.executeEdits('custom-suggest', [{
       range,
@@ -787,115 +1041,9 @@ require(['vs/editor/editor.main'], function (monaco) {
       forceMoveMarkers: true,
     }]);
 
-    hideWidget();
+    isAccepting = false;
     editor.focus();
   }
-
-  // ─── Key handling ───
-
-  editor.onKeyDown((e) => {
-    if (!widgetVisible) {
-      // Ctrl+Space to trigger
-      if (e.keyCode === monaco.KeyCode.Space && (e.ctrlKey || e.metaKey)) {
-        e.preventDefault();
-        e.stopPropagation();
-        showWidget();
-        return;
-      }
-      return;
-    }
-
-    // Widget is visible — handle navigation
-    switch (e.keyCode) {
-      case monaco.KeyCode.UpArrow:
-        e.preventDefault();
-        e.stopPropagation();
-        selectedIndex = Math.max(0, selectedIndex - 1);
-        renderList();
-        break;
-
-      case monaco.KeyCode.DownArrow:
-        e.preventDefault();
-        e.stopPropagation();
-        selectedIndex = Math.min(filteredItems.length - 1, selectedIndex + 1);
-        renderList();
-        break;
-
-      case monaco.KeyCode.Enter:
-      case monaco.KeyCode.Tab:
-        e.preventDefault();
-        e.stopPropagation();
-        acceptSuggestion();
-        break;
-
-      case monaco.KeyCode.Escape:
-        e.preventDefault();
-        e.stopPropagation();
-        hideWidget();
-        break;
-
-      case monaco.KeyCode.Backspace:
-        // Let the editor handle the delete, then update filter
-        setTimeout(() => {
-          if (filterText.length > 0) {
-            filterText = filterText.slice(0, -1);
-            selectedIndex = 0;
-            renderList();
-          } else {
-            hideWidget();
-          }
-        }, 0);
-        break;
-
-      default:
-        // For printable characters, update filter after editor processes the keystroke
-        if (e.keyCode >= monaco.KeyCode.KeyA && e.keyCode <= monaco.KeyCode.KeyZ ||
-            e.keyCode >= monaco.KeyCode.Digit0 && e.keyCode <= monaco.KeyCode.Digit9 ||
-            e.keyCode === monaco.KeyCode.Period ||
-            e.keyCode === monaco.KeyCode.Minus ||
-            e.keyCode === monaco.KeyCode.Underline) {
-          setTimeout(() => {
-            // Get the character that was just typed
-            const pos = editor.getPosition();
-            if (!pos) return;
-            const lineContent = editor.getModel().getLineContent(pos.lineNumber);
-            const charBefore = lineContent[pos.column - 2];
-            if (charBefore) {
-              filterText += charBefore;
-              selectedIndex = 0;
-              renderList();
-              positionWidget();
-            }
-          }, 0);
-        }
-        break;
-    }
-  });
-
-  // Dismiss on click outside
-  editor.onMouseDown((e) => {
-    if (widgetVisible) {
-      // Check if click is on the widget
-      const target = e.event.browserEvent.target;
-      if (!widgetEl.contains(target)) {
-        hideWidget();
-      }
-    }
-  });
-
-  // Dismiss on scroll
-  editor.onDidScrollChange(() => {
-    if (widgetVisible) {
-      positionWidget();
-    }
-  });
-
-  // Reposition on layout change
-  editor.onDidLayoutChange(() => {
-    if (widgetVisible) {
-      positionWidget();
-    }
-  });
 
   // ─── Scenario switching ───
 
@@ -903,16 +1051,13 @@ require(['vs/editor/editor.main'], function (monaco) {
     currentScenario = scenario;
     hideWidget();
 
-    // Update tab UI
     document.querySelectorAll('.scenario-tab').forEach(tab => {
       tab.classList.toggle('active', tab.dataset.scenario === scenario);
     });
 
-    // Update editor content
     const model = editor.getModel();
     model.setValue(SCENARIO_YAML[scenario]);
 
-    // Set cursor position and show widget
     const cursor = SCENARIO_CURSOR[scenario];
     setTimeout(() => {
       editor.setPosition(cursor);

--- a/poc/workflow_suggest_widget.html
+++ b/poc/workflow_suggest_widget.html
@@ -339,7 +339,7 @@
 
 <div class="header">
   <h1>POC v2 — IContentWidget + Context Keys + addAction keybindings</h1>
-  <span class="hint">Press <kbd>Ctrl</kbd>+<kbd>Space</kbd> to trigger, or type after a key</span>
+  <span class="hint">Press <kbd>Cmd</kbd>+<kbd>I</kbd> to trigger, or type after a key</span>
   <div class="scenario-tabs">
     <button class="scenario-tab active" data-scenario="connector-types">Connector Types</button>
     <button class="scenario-tab" data-scenario="connector-params">Connector Params</button>
@@ -764,15 +764,48 @@ require(['vs/editor/editor.main'], function (monaco) {
     },
   });
 
-  // Trigger widget: Ctrl+Space (always available)
+  // Trigger widget: Cmd+I on Mac / Ctrl+I on Win/Linux
+  // (Cmd+Space is Spotlight on Mac, Ctrl+Space triggers Monaco's built-in suggest)
   editor.addAction({
     id: 'customSuggest.trigger',
     label: 'Custom Suggest: Trigger',
-    keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.Space],
+    keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyI],
     run: () => {
       showWidget();
     },
   });
+
+  // Suppress Monaco's built-in suggest widget entirely.
+  // The built-in trigger is Ctrl+Space — unbind it so it doesn't conflict.
+  // Also suppress the built-in accept/navigation keybindings when our widget is open.
+  monaco.editor.addKeybindingRules([
+    // Unbind Ctrl+Space from built-in suggest (we use Cmd+I instead)
+    {
+      keybinding: monaco.KeyMod.CtrlCmd | monaco.KeyCode.Space,
+      command: null,
+    },
+    {
+      keybinding: monaco.KeyCode.Space | monaco.KeyMod.WinCtrl,
+      command: null,
+    },
+    // When our widget is visible, suppress built-in suggest navigation
+    // so our addAction handlers take priority
+    {
+      keybinding: monaco.KeyCode.Enter,
+      command: null,
+      when: 'customSuggestWidgetVisible && !suggestWidgetVisible',
+    },
+    {
+      keybinding: monaco.KeyCode.Tab,
+      command: null,
+      when: 'customSuggestWidgetVisible && !suggestWidgetVisible',
+    },
+    {
+      keybinding: monaco.KeyCode.Escape,
+      command: null,
+      when: 'customSuggestWidgetVisible && !suggestWidgetVisible',
+    },
+  ]);
 
   // ─────────────────────────────────────────────────────────────
   // Filter text tracking via onDidChangeModelContent

--- a/poc/workflow_suggest_widget.html
+++ b/poc/workflow_suggest_widget.html
@@ -1,0 +1,942 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>POC: Custom Workflow Suggest Widget</title>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+
+  body {
+    font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    background: #1d1e24;
+    color: #dfe5ef;
+    height: 100vh;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .header {
+    padding: 12px 20px;
+    background: #25262e;
+    border-bottom: 1px solid #343741;
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    flex-shrink: 0;
+  }
+
+  .header h1 {
+    font-size: 14px;
+    font-weight: 600;
+    color: #98a2b3;
+  }
+
+  .header .hint {
+    font-size: 12px;
+    color: #69707d;
+  }
+
+  .header .hint kbd {
+    background: #343741;
+    border: 1px solid #4a4f5c;
+    border-radius: 3px;
+    padding: 1px 5px;
+    font-family: inherit;
+    font-size: 11px;
+  }
+
+  .scenario-tabs {
+    display: flex;
+    gap: 4px;
+    margin-left: auto;
+  }
+
+  .scenario-tab {
+    padding: 4px 12px;
+    border-radius: 4px;
+    border: 1px solid #343741;
+    background: transparent;
+    color: #98a2b3;
+    font-size: 12px;
+    cursor: pointer;
+    transition: all 0.15s;
+  }
+
+  .scenario-tab:hover { background: #343741; }
+  .scenario-tab.active { background: #006bb8; color: #fff; border-color: #006bb8; }
+
+  #editor-container {
+    flex: 1;
+    overflow: hidden;
+  }
+
+  /* ─── Custom Suggest Widget ─── */
+
+  .suggest-widget-custom {
+    position: absolute;
+    z-index: 1000;
+    display: flex;
+    background: #1d1e24;
+    border: 1px solid #343741;
+    border-radius: 6px;
+    box-shadow: 0 8px 32px rgba(0,0,0,0.5), 0 2px 8px rgba(0,0,0,0.3);
+    overflow: hidden;
+    max-height: 340px;
+  }
+
+  .suggest-widget-custom.hidden { display: none; }
+
+  /* ── Left panel: Suggestion list ── */
+
+  .suggest-list-panel {
+    width: 320px;
+    display: flex;
+    flex-direction: column;
+    border-right: 1px solid #343741;
+  }
+
+  .suggest-list-header {
+    padding: 8px 12px;
+    font-size: 11px;
+    font-weight: 600;
+    color: #69707d;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    border-bottom: 1px solid #2a2b33;
+    flex-shrink: 0;
+  }
+
+  .suggest-list {
+    overflow-y: auto;
+    flex: 1;
+  }
+
+  .suggest-list::-webkit-scrollbar { width: 6px; }
+  .suggest-list::-webkit-scrollbar-track { background: transparent; }
+  .suggest-list::-webkit-scrollbar-thumb { background: #4a4f5c; border-radius: 3px; }
+  .suggest-list::-webkit-scrollbar-thumb:hover { background: #69707d; }
+
+  .suggest-item {
+    padding: 6px 12px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    cursor: pointer;
+    font-size: 13px;
+    color: #dfe5ef;
+    line-height: 1.4;
+  }
+
+  .suggest-item:hover { background: #25262e; }
+  .suggest-item.selected { background: #006bb8; color: #fff; }
+
+  .suggest-item-icon {
+    flex-shrink: 0;
+    width: 20px;
+    height: 20px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 11px;
+    font-weight: 700;
+    color: #69707d;
+    background: #25262e;
+    border-radius: 3px;
+    font-family: 'SF Mono', 'Fira Code', monospace;
+  }
+
+  .suggest-item.selected .suggest-item-icon {
+    color: #fff;
+    background: rgba(255,255,255,0.15);
+  }
+
+  .suggest-item-label {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace;
+    font-size: 12px;
+  }
+
+  .suggest-item-label .match {
+    font-weight: 700;
+    color: #fec514;
+  }
+
+  .suggest-item.selected .suggest-item-label .match {
+    color: #fff;
+  }
+
+  .suggest-item-kind {
+    font-size: 10px;
+    color: #69707d;
+    flex-shrink: 0;
+  }
+
+  .suggest-item.selected .suggest-item-kind {
+    color: rgba(255,255,255,0.7);
+  }
+
+  /* ── Right panel: Details ── */
+
+  .suggest-details-panel {
+    width: 380px;
+    padding: 14px 16px;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .suggest-details-panel::-webkit-scrollbar { width: 6px; }
+  .suggest-details-panel::-webkit-scrollbar-track { background: transparent; }
+  .suggest-details-panel::-webkit-scrollbar-thumb { background: #4a4f5c; border-radius: 3px; }
+
+  .detail-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+  }
+
+  .detail-context {
+    font-size: 11px;
+    color: #69707d;
+    margin-bottom: 2px;
+  }
+
+  .detail-name {
+    font-size: 16px;
+    font-weight: 600;
+    color: #dfe5ef;
+    font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace;
+  }
+
+  .detail-code-link {
+    flex-shrink: 0;
+    width: 24px;
+    height: 24px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #69707d;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: background 0.15s;
+  }
+
+  .detail-code-link:hover {
+    background: #343741;
+    color: #98a2b3;
+  }
+
+  .detail-section {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .detail-label {
+    font-size: 11px;
+    font-weight: 600;
+    color: #69707d;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+  }
+
+  .detail-type-badges {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+  }
+
+  .type-badge {
+    padding: 2px 8px;
+    border-radius: 10px;
+    font-size: 11px;
+    font-weight: 500;
+    font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace;
+  }
+
+  .type-badge.string { background: #1b4332; color: #7ee2a8; }
+  .type-badge.number { background: #1a3a5c; color: #6dccf8; }
+  .type-badge.boolean { background: #4a2c1a; color: #f5a623; }
+  .type-badge.array { background: #3b1f5c; color: #c084fc; }
+  .type-badge.object { background: #1a3a3a; color: #5de0d6; }
+  .type-badge.unknown { background: #343741; color: #98a2b3; }
+  .type-badge.integer { background: #1a3a5c; color: #6dccf8; }
+  .type-badge.enum { background: #3b2f1a; color: #fec514; }
+
+  .detail-required {
+    font-size: 13px;
+    color: #dfe5ef;
+  }
+
+  .detail-required.yes {
+    color: #f66;
+    font-weight: 600;
+  }
+
+  .detail-description {
+    font-size: 13px;
+    color: #98a2b3;
+    line-height: 1.5;
+  }
+
+  .detail-default {
+    font-size: 12px;
+    color: #98a2b3;
+    font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace;
+    background: #25262e;
+    padding: 4px 8px;
+    border-radius: 4px;
+  }
+
+  .detail-empty {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+    color: #4a4f5c;
+    font-size: 13px;
+    font-style: italic;
+  }
+</style>
+</head>
+<body>
+
+<div class="header">
+  <h1>Workflow YAML Editor — Custom Suggest Widget POC</h1>
+  <span class="hint">Press <kbd>Ctrl</kbd>+<kbd>Space</kbd> to trigger, or type after a key</span>
+  <div class="scenario-tabs">
+    <button class="scenario-tab active" data-scenario="connector-types">Connector Types</button>
+    <button class="scenario-tab" data-scenario="connector-params">Connector Params</button>
+    <button class="scenario-tab" data-scenario="template-vars">Template Variables</button>
+  </div>
+</div>
+
+<div id="editor-container"></div>
+
+<script src="https://cdn.jsdelivr.net/npm/monaco-editor@0.44.0/min/vs/loader.js"></script>
+<script>
+
+// ─────────────────────────────────────────────────────────────
+// Suggestion Data
+// ─────────────────────────────────────────────────────────────
+
+const SUGGESTION_DATA = {
+  'connector-types': {
+    context: 'Step Type',
+    items: [
+      { label: 'elasticsearch.search', kind: 'connector', types: ['action'], description: 'Search for documents in an Elasticsearch index. Supports full Query DSL, aggregations, and runtime fields.', required: false },
+      { label: 'elasticsearch.index', kind: 'connector', types: ['action'], description: 'Index a document into Elasticsearch. Creates or updates a document with the specified ID.', required: false },
+      { label: 'elasticsearch.delete', kind: 'connector', types: ['action'], description: 'Delete a document from an Elasticsearch index by ID.', required: false },
+      { label: 'slack.sendMessage', kind: 'connector', types: ['action'], description: 'Send a message to a Slack channel or user via the Slack Web API.', required: false },
+      { label: 'slack.postBlockKit', kind: 'connector', types: ['action'], description: 'Post a rich Block Kit message to a Slack channel with interactive components.', required: false },
+      { label: 'http', kind: 'step', types: ['action'], description: 'Make an HTTP request to any URL. Supports GET, POST, PUT, PATCH, DELETE methods with headers and body.', required: false },
+      { label: 'data.set', kind: 'step', types: ['transform'], description: 'Set a value in the workflow data context. Use Liquid templates to compute derived values.', required: false },
+      { label: 'data.filter', kind: 'step', types: ['transform'], description: 'Filter an array using a Liquid condition. Returns items matching the predicate.', required: false },
+      { label: 'wait', kind: 'step', types: ['control'], description: 'Pause workflow execution for a specified duration. Accepts seconds, minutes, or hours.', required: false },
+      { label: 'condition', kind: 'step', types: ['control'], description: 'Branch workflow execution based on a Liquid expression. Supports if/else paths.', required: false },
+      { label: 'loop', kind: 'step', types: ['control'], description: 'Iterate over an array and execute sub-steps for each element.', required: false },
+      { label: 'kubernetes_api.invoke', kind: 'connector', types: ['action'], description: 'Make a Kubernetes API call. Supports list, get, create, patch, and delete operations.', required: false },
+      { label: 'kubernetes_api.get_version', kind: 'connector', types: ['action'], description: 'Get the Kubernetes cluster version info.', required: false },
+    ],
+  },
+
+  'connector-params': {
+    context: 'Elasticsearch.search Parameter',
+    items: [
+      { label: 'query', kind: 'param', types: ['object'], required: true, description: 'The search query in Elasticsearch Query DSL format. Supports match, bool, range, term, and all other query types.', defaultValue: '{}' },
+      { label: 'index', kind: 'param', types: ['string', 'array'], required: true, description: 'Target index or indices to search. Accepts a single index name, comma-separated names, or a wildcard pattern.', defaultValue: '"*"' },
+      { label: 'size', kind: 'param', types: ['number'], required: false, description: 'Maximum number of hits to return. Defaults to 10. Set to 0 to only return aggregation results.', defaultValue: '10' },
+      { label: 'from', kind: 'param', types: ['number'], required: false, description: 'Starting offset for returned hits. Used with size for pagination.', defaultValue: '0' },
+      { label: '_source', kind: 'param', types: ['boolean', 'object'], required: false, description: 'Control which fields of _source are returned. Set to false to disable, or specify includes/excludes.', defaultValue: 'true' },
+      { label: '_source_includes', kind: 'param', types: ['string', 'array'], required: false, description: 'Comma-separated list of source fields to include in the response.', defaultValue: undefined },
+      { label: '_source_excludes', kind: 'param', types: ['string', 'array'], required: false, description: 'Comma-separated list of source fields to exclude from the response.', defaultValue: undefined },
+      { label: 'sort', kind: 'param', types: ['string', 'array', 'object'], required: false, description: 'Sort order for results. Accepts field name, array of fields, or full sort objects with order and mode.', defaultValue: undefined },
+      { label: 'aggs', kind: 'param', types: ['object'], required: false, description: 'Aggregation definitions. Supports all Elasticsearch aggregation types: terms, histogram, date_histogram, etc.', defaultValue: '{}' },
+      { label: 'highlight', kind: 'param', types: ['object'], required: false, description: 'Highlighting configuration. Specify fields and highlight options for matched query terms.', defaultValue: undefined },
+      { label: 'timeout', kind: 'param', types: ['string'], required: false, description: 'Search timeout as a time value (e.g., "30s"). Limits the time each shard can process the query.', defaultValue: undefined },
+      { label: 'seq_no_primary_term', kind: 'param', types: ['boolean'], required: false, description: 'If true, returns sequence number and primary term of the last modification of each hit.', defaultValue: 'false' },
+      { label: 'suggest_field', kind: 'param', types: ['string'], required: false, description: 'Field to use for term or phrase suggestions.', defaultValue: undefined },
+      { label: 'suggest_size', kind: 'param', types: ['number'], required: false, description: 'Maximum number of suggestions to return per suggest text term.', defaultValue: '5' },
+      { label: 'batched_reduce_size', kind: 'param', types: ['number'], required: false, description: 'Number of shard results to reduce on each batch. Reduces memory for large number of shards.', defaultValue: '512' },
+      { label: 'pre_filter_shard_size', kind: 'param', types: ['number'], required: false, description: 'Threshold for pre-filtering shards based on query rewriting. Shards below this are skipped.', defaultValue: '128' },
+      { label: 'force_synthetic_source', kind: 'param', types: ['boolean'], required: false, description: 'Force the use of synthetic _source, even if the mapping does not enable it.', defaultValue: 'false' },
+      { label: 'track_total_hits', kind: 'param', types: ['boolean', 'integer'], required: false, description: 'Whether to track the total number of matching documents. Set to true or an integer threshold.', defaultValue: '10000' },
+    ],
+  },
+
+  'template-vars': {
+    context: 'Template Variable',
+    items: [
+      { label: 'steps.search_alerts.result', kind: 'variable', types: ['object'], required: false, description: 'The output of the "search_alerts" step. Contains the full response body from the connector action.' },
+      { label: 'steps.search_alerts.result.hits.hits', kind: 'variable', types: ['array'], required: false, description: 'Array of matching documents from the search step. Each hit contains _source, _id, and _score.' },
+      { label: 'steps.search_alerts.result.hits.total.value', kind: 'variable', types: ['number'], required: false, description: 'Total number of documents matching the search query.' },
+      { label: 'steps.notify_slack.result', kind: 'variable', types: ['object'], required: false, description: 'The response from the Slack notification step. Contains ok, channel, ts, and message fields.' },
+      { label: 'steps.enrich_data.result', kind: 'variable', types: ['object'], required: false, description: 'Output of the data enrichment step.' },
+      { label: 'inputs.threshold', kind: 'variable', types: ['number'], required: false, description: 'User-provided threshold value. Defined in the workflow inputs section.', defaultValue: '100' },
+      { label: 'inputs.channel', kind: 'variable', types: ['string'], required: false, description: 'Target Slack channel for notifications. Defined in the workflow inputs section.', defaultValue: '"#alerts"' },
+      { label: 'inputs.index_pattern', kind: 'variable', types: ['string'], required: false, description: 'Elasticsearch index pattern to query. Defined in the workflow inputs section.', defaultValue: '".alerts-*"' },
+      { label: 'inputs.severity', kind: 'variable', types: ['enum'], required: false, description: 'Alert severity filter. Defined in the workflow inputs section. One of: critical, high, medium, low.', defaultValue: '"critical"' },
+      { label: 'consts.max_retries', kind: 'variable', types: ['number'], required: false, description: 'Maximum retry attempts for failed steps. Defined in the workflow constants section.', defaultValue: '3' },
+      { label: 'consts.api_base_url', kind: 'variable', types: ['string'], required: false, description: 'Base URL for external API calls. Defined in the workflow constants section.' },
+      { label: 'trigger.alert', kind: 'variable', types: ['object'], required: false, description: 'The alert payload that triggered this workflow. Contains alert ID, severity, message, and context.' },
+      { label: 'trigger.alert.severity', kind: 'variable', types: ['string'], required: false, description: 'Severity level of the triggering alert: critical, high, medium, or low.' },
+      { label: 'trigger.timestamp', kind: 'variable', types: ['string'], required: false, description: 'ISO 8601 timestamp of when the workflow was triggered.' },
+    ],
+  },
+};
+
+const SCENARIO_YAML = {
+  'connector-types': `name: Alert Triage Workflow
+enabled: true
+
+triggers:
+  - type: alert
+    rule_ids:
+      - "high-severity-rule"
+
+steps:
+  - name: search_alerts
+    type: \x20
+    connector-id: my-es-connector
+    with:
+      index: ".alerts-security.*"
+      query:
+        bool:
+          filter:
+            - term:
+                kibana.alert.severity: critical
+
+  - name: notify_team
+    type: slack.sendMessage
+    connector-id: my-slack-connector
+    with:
+      channel: "#security-alerts"
+      message: "Found {{ steps.search_alerts.result.hits.total.value }} critical alerts"
+`,
+
+  'connector-params': `name: Alert Triage Workflow
+enabled: true
+
+triggers:
+  - type: alert
+
+steps:
+  - name: search_alerts
+    type: elasticsearch.search
+    connector-id: my-es-connector
+    with:
+      index: ".alerts-security.*"
+      \x20
+      query:
+        bool:
+          filter:
+            - term:
+                kibana.alert.severity: critical
+`,
+
+  'template-vars': `name: Alert Triage Workflow
+enabled: true
+
+inputs:
+  threshold:
+    type: number
+    default: 100
+  channel:
+    type: string
+    default: "#alerts"
+
+consts:
+  max_retries: 3
+  api_base_url: "https://api.example.com"
+
+triggers:
+  - type: alert
+
+steps:
+  - name: search_alerts
+    type: elasticsearch.search
+    connector-id: my-es-connector
+    with:
+      index: ".alerts-security.*"
+      size: "{{ }}"
+
+  - name: notify_team
+    type: slack.sendMessage
+    connector-id: my-slack-connector
+    with:
+      channel: "{{ inputs.channel }}"
+      message: "Found {{ steps.search_alerts.result.hits.total.value }} alerts"
+`,
+};
+
+// Cursor positions (line, column) where the widget should appear
+const SCENARIO_CURSOR = {
+  'connector-types': { lineNumber: 13, column: 11 },
+  'connector-params': { lineNumber: 12, column: 7 },
+  'template-vars': { lineNumber: 22, column: 16 },
+};
+
+// ─────────────────────────────────────────────────────────────
+// Fuzzy Match
+// ─────────────────────────────────────────────────────────────
+
+function fuzzyMatch(pattern, text) {
+  if (!pattern) return { matches: true, indices: [], score: 0 };
+  const pLower = pattern.toLowerCase();
+  const tLower = text.toLowerCase();
+  const indices = [];
+  let pi = 0;
+  for (let ti = 0; ti < tLower.length && pi < pLower.length; ti++) {
+    if (tLower[ti] === pLower[pi]) {
+      indices.push(ti);
+      pi++;
+    }
+  }
+  if (pi < pLower.length) return { matches: false, indices: [], score: -1 };
+
+  // Score: consecutive matches are better, earlier matches are better
+  let score = 0;
+  for (let i = 0; i < indices.length; i++) {
+    score -= indices[i]; // earlier = better
+    if (i > 0 && indices[i] === indices[i - 1] + 1) score += 10; // consecutive bonus
+  }
+  return { matches: true, indices, score };
+}
+
+function highlightLabel(label, indices) {
+  if (!indices.length) return escapeHtml(label);
+  const set = new Set(indices);
+  let html = '';
+  for (let i = 0; i < label.length; i++) {
+    const ch = escapeHtml(label[i]);
+    html += set.has(i) ? `<span class="match">${ch}</span>` : ch;
+  }
+  return html;
+}
+
+function escapeHtml(s) {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+// ─────────────────────────────────────────────────────────────
+// Monaco Setup
+// ─────────────────────────────────────────────────────────────
+
+require.config({ paths: { vs: 'https://cdn.jsdelivr.net/npm/monaco-editor@0.44.0/min/vs' } });
+
+require(['vs/editor/editor.main'], function (monaco) {
+
+  const editor = monaco.editor.create(document.getElementById('editor-container'), {
+    value: SCENARIO_YAML['connector-types'],
+    language: 'yaml',
+    theme: 'vs-dark',
+    fontSize: 13,
+    fontFamily: "'SF Mono', 'Fira Code', Consolas, monospace",
+    minimap: { enabled: false },
+    lineNumbers: 'on',
+    renderLineHighlight: 'all',
+    scrollBeyondLastLine: false,
+    padding: { top: 12 },
+    tabSize: 2,
+    quickSuggestions: false,
+    suggestOnTriggerCharacters: false,
+    wordBasedSuggestions: 'off',
+    parameterHints: { enabled: false },
+  });
+
+  // ─── Custom Suggest Widget ───
+
+  let currentScenario = 'connector-types';
+  let widgetVisible = false;
+  let selectedIndex = 0;
+  let filterText = '';
+  let filteredItems = [];
+
+  // Create widget DOM
+  const widgetEl = document.createElement('div');
+  widgetEl.className = 'suggest-widget-custom hidden';
+  widgetEl.innerHTML = `
+    <div class="suggest-list-panel">
+      <div class="suggest-list-header">Suggested</div>
+      <div class="suggest-list"></div>
+    </div>
+    <div class="suggest-details-panel">
+      <div class="detail-empty">Select a suggestion to see details</div>
+    </div>
+  `;
+
+  const listEl = widgetEl.querySelector('.suggest-list');
+  const detailsEl = widgetEl.querySelector('.suggest-details-panel');
+
+  // Register as overlay widget
+  const overlayWidget = {
+    getId: () => 'custom.suggest.widget',
+    getDomNode: () => widgetEl,
+    getPosition: () => null, // we position manually
+  };
+  editor.addOverlayWidget(overlayWidget);
+
+  function getIconForKind(kind) {
+    switch (kind) {
+      case 'connector': return '>_';
+      case 'step': return 'fn';
+      case 'param': return 'P';
+      case 'variable': return '$';
+      default: return '?';
+    }
+  }
+
+  function getFilteredItems() {
+    const data = SUGGESTION_DATA[currentScenario];
+    if (!data) return [];
+    if (!filterText) return data.items.map((item, i) => ({ ...item, matchIndices: [], score: 0, origIndex: i }));
+
+    return data.items
+      .map((item, i) => {
+        const result = fuzzyMatch(filterText, item.label);
+        return { ...item, matchIndices: result.indices, score: result.score, matches: result.matches, origIndex: i };
+      })
+      .filter(item => item.matches)
+      .sort((a, b) => b.score - a.score);
+  }
+
+  function renderList() {
+    filteredItems = getFilteredItems();
+    if (filteredItems.length === 0) {
+      hideWidget();
+      return;
+    }
+
+    selectedIndex = Math.min(selectedIndex, filteredItems.length - 1);
+    selectedIndex = Math.max(selectedIndex, 0);
+
+    listEl.innerHTML = filteredItems.map((item, i) => `
+      <div class="suggest-item ${i === selectedIndex ? 'selected' : ''}" data-index="${i}">
+        <span class="suggest-item-icon">${getIconForKind(item.kind)}</span>
+        <span class="suggest-item-label">${highlightLabel(item.label, item.matchIndices)}</span>
+        <span class="suggest-item-kind">${item.kind}</span>
+      </div>
+    `).join('');
+
+    // Click handlers
+    listEl.querySelectorAll('.suggest-item').forEach(el => {
+      el.addEventListener('mousedown', (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        selectedIndex = parseInt(el.dataset.index);
+        acceptSuggestion();
+      });
+      el.addEventListener('mouseover', () => {
+        selectedIndex = parseInt(el.dataset.index);
+        renderList();
+        renderDetails();
+      });
+    });
+
+    // Scroll selected into view
+    const selectedEl = listEl.querySelector('.suggest-item.selected');
+    if (selectedEl) {
+      selectedEl.scrollIntoView({ block: 'nearest' });
+    }
+
+    renderDetails();
+  }
+
+  function renderDetails() {
+    if (filteredItems.length === 0) {
+      detailsEl.innerHTML = '<div class="detail-empty">No matching suggestions</div>';
+      return;
+    }
+
+    const item = filteredItems[selectedIndex];
+    if (!item) return;
+
+    const data = SUGGESTION_DATA[currentScenario];
+    const contextLabel = data.context;
+
+    const typeBadgesHtml = (item.types || []).map(t =>
+      `<span class="type-badge ${t}">${escapeHtml(t)}</span>`
+    ).join('');
+
+    const requiredHtml = item.required !== undefined
+      ? `<div class="detail-section">
+           <div class="detail-label">Required</div>
+           <div class="detail-required ${item.required ? 'yes' : ''}">${item.required ? 'Yes' : 'No'}</div>
+         </div>`
+      : '';
+
+    const defaultHtml = item.defaultValue !== undefined
+      ? `<div class="detail-section">
+           <div class="detail-label">Default</div>
+           <div class="detail-default">${escapeHtml(String(item.defaultValue))}</div>
+         </div>`
+      : '';
+
+    detailsEl.innerHTML = `
+      <div class="detail-header">
+        <div>
+          <div class="detail-context">${escapeHtml(contextLabel)}:</div>
+          <div class="detail-name">${escapeHtml(item.label)}</div>
+        </div>
+        <div class="detail-code-link" title="View schema">
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+            <path d="M5.854 4.146a.5.5 0 0 1 0 .708L3.207 7.5H10.5a.5.5 0 0 1 0 1H3.207l2.647 2.646a.5.5 0 0 1-.708.708l-3.5-3.5a.5.5 0 0 1 0-.708l3.5-3.5a.5.5 0 0 1 .708 0zM11 4a.5.5 0 0 1 .5-.5h2a.5.5 0 0 1 0 1h-2A.5.5 0 0 1 11 4zm0 4a.5.5 0 0 1 .5-.5h2a.5.5 0 0 1 0 1h-2A.5.5 0 0 1 11 8zm0 4a.5.5 0 0 1 .5-.5h2a.5.5 0 0 1 0 1h-2a.5.5 0 0 1-.5-.5z"/>
+          </svg>
+        </div>
+      </div>
+
+      ${typeBadgesHtml ? `
+      <div class="detail-section">
+        <div class="detail-label">Type</div>
+        <div class="detail-type-badges">${typeBadgesHtml}</div>
+      </div>` : ''}
+
+      ${requiredHtml}
+
+      ${item.description ? `
+      <div class="detail-section">
+        <div class="detail-label">Description</div>
+        <div class="detail-description">${escapeHtml(item.description)}</div>
+      </div>` : ''}
+
+      ${defaultHtml}
+    `;
+  }
+
+  function positionWidget() {
+    const pos = editor.getPosition();
+    if (!pos) return;
+
+    const scrolledPos = editor.getScrolledVisiblePosition(pos);
+    if (!scrolledPos) return;
+
+    const editorDom = editor.getDomNode();
+    if (!editorDom) return;
+
+    const editorRect = editorDom.getBoundingClientRect();
+    const lineHeight = editor.getOption(monaco.editor.EditorOption.lineHeight);
+
+    let top = scrolledPos.top + lineHeight + 4;
+    let left = scrolledPos.left;
+
+    // If widget would go below the editor, show above
+    const widgetHeight = 340;
+    if (top + widgetHeight > editorRect.height) {
+      top = scrolledPos.top - widgetHeight - 4;
+    }
+
+    // Clamp left so widget doesn't go off-screen
+    const widgetWidth = 700;
+    if (left + widgetWidth > editorRect.width) {
+      left = Math.max(0, editorRect.width - widgetWidth - 20);
+    }
+
+    widgetEl.style.top = top + 'px';
+    widgetEl.style.left = left + 'px';
+  }
+
+  function showWidget() {
+    filterText = '';
+    selectedIndex = 0;
+    widgetEl.classList.remove('hidden');
+    widgetVisible = true;
+    positionWidget();
+    renderList();
+  }
+
+  function hideWidget() {
+    widgetEl.classList.add('hidden');
+    widgetVisible = false;
+    filterText = '';
+  }
+
+  function acceptSuggestion() {
+    if (!filteredItems.length) return;
+    const item = filteredItems[selectedIndex];
+    if (!item) return;
+
+    const pos = editor.getPosition();
+    if (!pos) return;
+
+    // Determine what text to insert
+    let insertText = item.label;
+
+    // For params, add ": " suffix
+    if (item.kind === 'param') {
+      insertText = item.label + ': ';
+    }
+    // For template vars, just the path
+    if (item.kind === 'variable') {
+      insertText = item.label;
+    }
+
+    // Calculate the range to replace (from start of typed filter to cursor)
+    const lineContent = editor.getModel().getLineContent(pos.lineNumber);
+    const startCol = pos.column - filterText.length;
+
+    const range = new monaco.Range(pos.lineNumber, startCol, pos.lineNumber, pos.column);
+
+    editor.executeEdits('custom-suggest', [{
+      range,
+      text: insertText,
+      forceMoveMarkers: true,
+    }]);
+
+    hideWidget();
+    editor.focus();
+  }
+
+  // ─── Key handling ───
+
+  editor.onKeyDown((e) => {
+    if (!widgetVisible) {
+      // Ctrl+Space to trigger
+      if (e.keyCode === monaco.KeyCode.Space && (e.ctrlKey || e.metaKey)) {
+        e.preventDefault();
+        e.stopPropagation();
+        showWidget();
+        return;
+      }
+      return;
+    }
+
+    // Widget is visible — handle navigation
+    switch (e.keyCode) {
+      case monaco.KeyCode.UpArrow:
+        e.preventDefault();
+        e.stopPropagation();
+        selectedIndex = Math.max(0, selectedIndex - 1);
+        renderList();
+        break;
+
+      case monaco.KeyCode.DownArrow:
+        e.preventDefault();
+        e.stopPropagation();
+        selectedIndex = Math.min(filteredItems.length - 1, selectedIndex + 1);
+        renderList();
+        break;
+
+      case monaco.KeyCode.Enter:
+      case monaco.KeyCode.Tab:
+        e.preventDefault();
+        e.stopPropagation();
+        acceptSuggestion();
+        break;
+
+      case monaco.KeyCode.Escape:
+        e.preventDefault();
+        e.stopPropagation();
+        hideWidget();
+        break;
+
+      case monaco.KeyCode.Backspace:
+        // Let the editor handle the delete, then update filter
+        setTimeout(() => {
+          if (filterText.length > 0) {
+            filterText = filterText.slice(0, -1);
+            selectedIndex = 0;
+            renderList();
+          } else {
+            hideWidget();
+          }
+        }, 0);
+        break;
+
+      default:
+        // For printable characters, update filter after editor processes the keystroke
+        if (e.keyCode >= monaco.KeyCode.KeyA && e.keyCode <= monaco.KeyCode.KeyZ ||
+            e.keyCode >= monaco.KeyCode.Digit0 && e.keyCode <= monaco.KeyCode.Digit9 ||
+            e.keyCode === monaco.KeyCode.Period ||
+            e.keyCode === monaco.KeyCode.Minus ||
+            e.keyCode === monaco.KeyCode.Underline) {
+          setTimeout(() => {
+            // Get the character that was just typed
+            const pos = editor.getPosition();
+            if (!pos) return;
+            const lineContent = editor.getModel().getLineContent(pos.lineNumber);
+            const charBefore = lineContent[pos.column - 2];
+            if (charBefore) {
+              filterText += charBefore;
+              selectedIndex = 0;
+              renderList();
+              positionWidget();
+            }
+          }, 0);
+        }
+        break;
+    }
+  });
+
+  // Dismiss on click outside
+  editor.onMouseDown((e) => {
+    if (widgetVisible) {
+      // Check if click is on the widget
+      const target = e.event.browserEvent.target;
+      if (!widgetEl.contains(target)) {
+        hideWidget();
+      }
+    }
+  });
+
+  // Dismiss on scroll
+  editor.onDidScrollChange(() => {
+    if (widgetVisible) {
+      positionWidget();
+    }
+  });
+
+  // Reposition on layout change
+  editor.onDidLayoutChange(() => {
+    if (widgetVisible) {
+      positionWidget();
+    }
+  });
+
+  // ─── Scenario switching ───
+
+  function switchScenario(scenario) {
+    currentScenario = scenario;
+    hideWidget();
+
+    // Update tab UI
+    document.querySelectorAll('.scenario-tab').forEach(tab => {
+      tab.classList.toggle('active', tab.dataset.scenario === scenario);
+    });
+
+    // Update editor content
+    const model = editor.getModel();
+    model.setValue(SCENARIO_YAML[scenario]);
+
+    // Set cursor position and show widget
+    const cursor = SCENARIO_CURSOR[scenario];
+    setTimeout(() => {
+      editor.setPosition(cursor);
+      editor.focus();
+      showWidget();
+    }, 100);
+  }
+
+  document.querySelectorAll('.scenario-tab').forEach(tab => {
+    tab.addEventListener('click', () => switchScenario(tab.dataset.scenario));
+  });
+
+  // ─── Auto-show widget on load ───
+
+  window.addEventListener('resize', () => editor.layout());
+
+  setTimeout(() => {
+    const cursor = SCENARIO_CURSOR['connector-types'];
+    editor.setPosition(cursor);
+    editor.focus();
+    showWidget();
+  }, 300);
+
+});
+</script>
+</body>
+</html>

--- a/src/platform/packages/shared/kbn-workflows/spec/schema.ts
+++ b/src/platform/packages/shared/kbn-workflows/spec/schema.ts
@@ -946,11 +946,22 @@ const WorkflowInputValueSchema: z.ZodType<unknown> = z.lazy(() =>
 );
 
 export const WorkflowContextSchema = z.object({
-  event: AlertEventSchema.optional(),
-  execution: WorkflowExecutionContextSchema,
-  workflow: WorkflowDataContextSchema,
-  kibanaUrl: z.string(),
-  inputs: z.record(z.string(), WorkflowInputValueSchema).optional(),
+  event: AlertEventSchema.optional().describe(
+    'The event that triggered this run — for alert triggers includes the matched alerts and rule details.'
+  ),
+  execution: WorkflowExecutionContextSchema.describe(
+    'Metadata about the current execution: id, start time, the Kibana URL for this run, and who or what triggered it.'
+  ),
+  workflow: WorkflowDataContextSchema.describe(
+    'The workflow being executed: id, name, enabled flag, space, and tags.'
+  ),
+  kibanaUrl: z
+    .string()
+    .describe('Public Kibana URL, useful for deep links back into the UI from notifications.'),
+  inputs: z
+    .record(z.string(), WorkflowInputValueSchema)
+    .optional()
+    .describe('User-provided inputs defined at the top of the workflow, keyed by input name.'),
   output: z
     .record(
       z.string(),
@@ -961,29 +972,50 @@ export const WorkflowContextSchema = z.object({
         z.union([z.array(z.string()), z.array(z.number()), z.array(z.boolean())]),
       ])
     )
-    .optional(),
-  consts: z.record(z.string(), z.any()).optional(),
-  now: z.date().optional(),
+    .optional()
+    .describe('Named outputs declared by the workflow that callers or subsequent steps can read.'),
+  consts: z
+    .record(z.string(), z.any())
+    .optional()
+    .describe('Constants declared at the top of the workflow — fixed values reused across steps.'),
+  now: z
+    .date()
+    .optional()
+    .describe('Timestamp captured when the expression is evaluated; handy for time-aware logic.'),
   parent: z
     .object({
       workflowId: z.string(),
       executionId: z.string(),
       depth: z.number().optional(),
     })
-    .optional(),
-  metadata: z.record(z.string(), z.unknown()).optional(),
+    .optional()
+    .describe('The parent workflow when this run was triggered by another workflow.'),
+  metadata: z
+    .record(z.string(), z.unknown())
+    .optional()
+    .describe('Free-form metadata attached to the execution (reserved for internal tooling).'),
 });
 export type WorkflowContext = z.infer<typeof WorkflowContextSchema>;
 
 export const DynamicWorkflowContextSchema = WorkflowContextSchema.extend({
   // overriding record with object to avoid type mismatch when
-  // extending with actual inputs, outputs and consts of different types
-  inputs: z.object({}),
-  output: z.object({}),
-  consts: z.object({}),
+  // extending with actual inputs, outputs and consts of different types.
+  // Descriptions are repeated on the overrides because .extend() replaces
+  // the field entirely, dropping the base .describe() metadata.
+  inputs: z
+    .object({})
+    .describe('User-provided inputs defined at the top of the workflow, keyed by input name.'),
+  output: z
+    .object({})
+    .describe('Named outputs declared by the workflow that callers or subsequent steps can read.'),
+  consts: z
+    .object({})
+    .describe('Constants declared at the top of the workflow — fixed values reused across steps.'),
   // overriding event with base event schema (spaceId only) so it can be
   // dynamically extended with trigger-specific properties (e.g., alerts, rule)
-  event: BaseEventSchema.optional(),
+  event: BaseEventSchema.optional().describe(
+    'The event that triggered this run — trigger-specific properties (alerts, rule, …) are added dynamically.'
+  ),
 });
 export type DynamicWorkflowContext = z.infer<typeof DynamicWorkflowContextSchema>;
 
@@ -1015,17 +1047,29 @@ export const WhileContextSchema = z.object({
 export type WhileContext = z.infer<typeof WhileContextSchema>;
 
 export const StepContextSchema = WorkflowContextSchema.extend({
-  steps: z.record(z.string(), StepDataSchema),
-  foreach: ForEachContextSchema.optional(),
-  while: WhileContextSchema.optional(),
-  variables: z.record(z.string(), z.unknown()).optional(),
-  error: BaseSerializedErrorSchema.optional(),
+  steps: z
+    .record(z.string(), StepDataSchema)
+    .describe('Outputs of previously executed steps in this run, keyed by step name.'),
+  foreach: ForEachContextSchema.optional().describe(
+    'Current iteration state inside a foreach step (item, index, total).'
+  ),
+  while: WhileContextSchema.optional().describe('Current iteration count inside a while step.'),
+  variables: z
+    .record(z.string(), z.unknown())
+    .optional()
+    .describe('Step-scoped variables defined via set/var steps during this run.'),
+  error: BaseSerializedErrorSchema.optional().describe(
+    'Error details from the most recent step — available inside on-failure branches.'
+  ),
 });
 export type StepContext = z.infer<typeof StepContextSchema>;
 
 export const DynamicStepContextSchema = DynamicWorkflowContextSchema.extend({
   // overriding record with object to avoid type mismatch when
-  // extending with actual step ids and different output types
-  steps: z.object({}),
+  // extending with actual step ids and different output types.
+  // Description repeated because .extend() drops the base describe metadata.
+  steps: z
+    .object({})
+    .describe('Outputs of previously executed steps in this run, keyed by step name.'),
 });
 export type DynamicStepContext = z.infer<typeof DynamicStepContextSchema>;

--- a/src/platform/packages/shared/shared-ux/code_editor/impl/code_editor.tsx
+++ b/src/platform/packages/shared/shared-ux/code_editor/impl/code_editor.tsx
@@ -313,6 +313,9 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
         // If the inspect tokens widget is open then we want to let monaco handle ESCAPE for it,
         // otherwise widget will not close.
         if (inspectTokensWidget) return;
+        // If a keybinding already handled this ESC (e.g., a custom suggest widget
+        // registered via addAction with precondition), don't also exit editing mode.
+        if (ev.browserEvent.defaultPrevented) return;
         // If the autocompletion context menu is open then we want to let ESCAPE close it but
         // **not** exit out of editing mode.
         if (!isSuggestionMenuOpen.current) {

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_context/lib/get_context_for_path.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_context/lib/get_context_for_path.ts
@@ -49,6 +49,14 @@ export function getContextSchemaForStep(
 
   const extension: Record<string, z.ZodType> = {};
 
+  // Zod's .extend() replaces fields entirely, dropping any .describe() text
+  // from the base. Re-apply descriptions so the suggest widget can render
+  // human-friendly hover text for dynamically-built fields.
+  const STEP_FIELD_DESCRIBE: Record<string, string> = {
+    steps: 'Outputs of previously executed steps in this run, keyed by step name.',
+    variables: 'Step-scoped variables defined via set/var steps during this run.',
+  };
+
   const stepsCollectionSchema = getStepsCollectionSchema(
     baseSchema,
     workflowGraph,
@@ -56,10 +64,12 @@ export function getContextSchemaForStep(
     predecessors
   );
   if (Object.keys(stepsCollectionSchema.shape).length > 0) {
-    extension.steps = stepsCollectionSchema;
+    extension.steps = stepsCollectionSchema.describe(STEP_FIELD_DESCRIBE.steps);
   }
 
-  extension.variables = getVariablesSchema(workflowGraph, stepName, predecessors);
+  extension.variables = getVariablesSchema(workflowGraph, stepName, predecessors).describe(
+    STEP_FIELD_DESCRIBE.variables
+  );
 
   let schema = baseSchema.extend(extension) as typeof DynamicStepContextSchema;
 
@@ -121,20 +131,31 @@ function getStepContextSchemaEnrichmentEntries(
   const enrichments: { key: 'foreach' | 'while' | 'item' | 'index'; value: z.ZodType }[] = [];
   const stack = workflowExecutionGraph.getNodeStack(stepId);
 
+  // Hover-text for dynamically-added enrichment fields. Matches the wording
+  // used on StepContextSchema in @kbn/workflows/spec/schema.ts.
+  const ENRICHMENT_DESCRIBE = {
+    foreach: 'Current iteration state inside a foreach step (item, index, total).',
+    while: 'Current iteration count inside a while step.',
+    item: 'The current item from the foreach collection.',
+    index: 'Zero-based position of the current item in the foreach collection.',
+  } as const;
+
   for (const nodeId of stack) {
     const node = workflowExecutionGraph.getNode(nodeId);
 
     if (isEnterForeach(node)) {
       enrichments.push({
         key: 'foreach',
-        value: getForeachStateSchema(stepContextSchema, node.configuration),
+        value: getForeachStateSchema(stepContextSchema, node.configuration).describe(
+          ENRICHMENT_DESCRIBE.foreach
+        ),
       });
     }
 
     if (isEnterWhile(node)) {
       enrichments.push({
         key: 'while',
-        value: WhileContextSchema,
+        value: WhileContextSchema.describe(ENRICHMENT_DESCRIBE.while),
       });
     }
   }
@@ -147,7 +168,10 @@ function getStepContextSchemaEnrichmentEntries(
   const selfNode = workflowExecutionGraph.getStepNode(stepId);
   if (selfNode) {
     if (isEnterWhile(selfNode) && !enrichments.some((e) => e.key === 'while')) {
-      enrichments.push({ key: 'while', value: WhileContextSchema });
+      enrichments.push({
+        key: 'while',
+        value: WhileContextSchema.describe(ENRICHMENT_DESCRIBE.while),
+      });
     }
 
     if (selfNode.stepType === DataMapStepTypeId && isAtomic(selfNode)) {
@@ -155,8 +179,8 @@ function getStepContextSchemaEnrichmentEntries(
         stepContextSchema,
         selfNode.configuration?.items
       );
-      enrichments.push({ key: 'item', value: item });
-      enrichments.push({ key: 'index', value: index });
+      enrichments.push({ key: 'item', value: item.describe(ENRICHMENT_DESCRIBE.item) });
+      enrichments.push({ key: 'index', value: index.describe(ENRICHMENT_DESCRIBE.index) });
     }
   }
 

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_context/lib/get_workflow_context_schema.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_context/lib/get_workflow_context_schema.ts
@@ -101,17 +101,25 @@ export function getWorkflowContextSchema(
 
   const eventSchema = buildEventSchemaFromTriggers(definition.triggers ?? []);
 
+  // Re-apply .describe() from the base schema because Zod's .extend() replaces
+  // the field entirely, dropping the description metadata that the autocomplete
+  // uses to populate the suggest widget's DESCRIPTION panel.
+  const describeFrom = (key: keyof typeof DynamicWorkflowContextSchema.shape): string | undefined =>
+    (DynamicWorkflowContextSchema.shape[key] as { description?: string }).description;
+
   return DynamicWorkflowContextSchema.extend({
-    inputs: buildFieldsZodValidator(normalizedInputs),
-    output: buildFieldsZodValidator(normalizedOutputs),
-    consts: z.object({
-      ...Object.fromEntries(
-        Object.entries(definition.consts ?? {}).map(([key, value]) => [
-          key,
-          inferZodType(value, { isConst: true }),
-        ])
-      ),
-    }),
-    event: eventSchema,
+    inputs: buildFieldsZodValidator(normalizedInputs).describe(describeFrom('inputs') ?? ''),
+    output: buildFieldsZodValidator(normalizedOutputs).describe(describeFrom('output') ?? ''),
+    consts: z
+      .object({
+        ...Object.fromEntries(
+          Object.entries(definition.consts ?? {}).map(([key, value]) => [
+            key,
+            inferZodType(value, { isConst: true }),
+          ])
+        ),
+      })
+      .describe(describeFrom('consts') ?? ''),
+    event: eventSchema.describe(describeFrom('event') ?? ''),
   }) as typeof DynamicWorkflowContextSchema;
 }

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/get_completion_item_provider.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/get_completion_item_provider.ts
@@ -15,6 +15,11 @@ import { isInWorkflowOutputWithBlock } from './suggestions/workflow/get_workflow
 import type { WorkflowKqlCompletionServices } from './suggestions/workflow_kql_completion_services';
 import { isDeprecatedStepType } from '../../../../../common/schema';
 import type { WorkflowDetailState } from '../../../../entities/workflows/store';
+import {
+  emitSuggestions,
+  type EnrichedSuggestionItem,
+  type SuggestionCategory,
+} from '../custom_suggest_widget';
 
 // Unique identifier for the workflow completion provider
 export const WORKFLOW_COMPLETION_PROVIDER_ID = 'workflows-yaml-completion-provider';
@@ -85,6 +90,107 @@ function mapSuggestions(
       }
     }
   }
+}
+
+/**
+ * Map a CompletionItemKind to a SuggestionCategory for the custom widget.
+ */
+function inferCategory(item: monaco.languages.CompletionItem): SuggestionCategory {
+  const { CompletionItemKind } = monaco.languages;
+  switch (item.kind) {
+    case CompletionItemKind.Struct:
+    case CompletionItemKind.Module:
+    case CompletionItemKind.Function:
+      return 'connector';
+    case CompletionItemKind.Method:
+    case CompletionItemKind.Keyword:
+    case CompletionItemKind.Class:
+    case CompletionItemKind.Constant:
+    case CompletionItemKind.Event:
+    case CompletionItemKind.Interface:
+      return 'step';
+    case CompletionItemKind.Field:
+      return 'variable';
+    case CompletionItemKind.Property:
+      return 'param';
+    case CompletionItemKind.Value:
+    case CompletionItemKind.EnumMember:
+      return 'value';
+    default:
+      return 'param';
+  }
+}
+
+/**
+ * Extract structured metadata from a CompletionItem's existing string fields.
+ * This is a v1 approach — future versions can attach __enrichment at creation time.
+ */
+function enrichCompletionItem(
+  item: monaco.languages.CompletionItem,
+  matchType: string
+): EnrichedSuggestionItem {
+  const label = typeof item.label === 'string' ? item.label : item.label.label;
+  const detail = typeof item.detail === 'string' ? item.detail : '';
+  const doc =
+    typeof item.documentation === 'string'
+      ? item.documentation
+      : typeof item.documentation === 'object' && item.documentation !== null
+      ? item.documentation.value
+      : '';
+
+  const category = inferCategory(item);
+
+  // Parse type info from detail field (patterns like "string", "object: description", "Built-in workflow step")
+  let types: string[] = [];
+  let description = doc;
+  let required: boolean | null = null;
+  let contextLabel: string | undefined;
+
+  if (matchType === 'type' && (category === 'connector' || category === 'step')) {
+    // Connector/step type suggestions: detail = connectorType, documentation = description
+    contextLabel = 'Step Type';
+    if (detail.startsWith('Built-in')) {
+      types = ['step'];
+    } else {
+      types = ['action'];
+    }
+  } else if (category === 'variable') {
+    // Variable suggestions: detail = "type: description" or "type"
+    contextLabel = 'Template Variable';
+    const colonIdx = detail.indexOf(':');
+    if (colonIdx > 0) {
+      types = [detail.slice(0, colonIdx).replace('?', '').trim()];
+      description = detail.slice(colonIdx + 1).trim() || doc;
+      required = !detail.includes('?');
+    } else if (detail) {
+      types = [detail.replace('?', '').trim()];
+      required = !detail.includes('?');
+    }
+  } else if (category === 'param' || category === 'value') {
+    // Parameter/value suggestions from JSON schema or custom properties
+    contextLabel = 'Parameter';
+    if (detail && detail !== 'Enum Value') {
+      types = [detail];
+    }
+  }
+
+  return {
+    label,
+    insertText: typeof item.insertText === 'string' ? item.insertText : label,
+    insertTextRules: item.insertTextRules,
+    kind: item.kind ?? monaco.languages.CompletionItemKind.Text,
+    range: item.range as monaco.IRange,
+    filterText: item.filterText,
+    sortText: item.sortText,
+    additionalTextEdits: item.additionalTextEdits,
+    preselect: item.preselect,
+    command: item.command,
+    types,
+    required,
+    description: description || detail || label,
+    category,
+    contextLabel,
+  };
 }
 
 export function getCompletionItemProvider(
@@ -185,8 +291,21 @@ export function getCompletionItemProvider(
         });
       }
 
+      // Enrich suggestions with structured metadata and emit to the custom
+      // suggest widget via the side-channel store. Return empty to Monaco so
+      // the built-in suggest widget never appears.
+      const enrichedItems = suggestions.map((s) => enrichCompletionItem(s, matchType));
+      emitSuggestions({
+        items: enrichedItems,
+        anchorPosition: { lineNumber: position.lineNumber, column: position.column },
+        triggerKind:
+          completionContext.triggerKind === monaco.languages.CompletionTriggerKind.Invoke
+            ? 'manual'
+            : 'auto',
+      });
+
       return {
-        suggestions,
+        suggestions: [],
         incomplete: isIncomplete,
       };
     },

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/get_completion_item_provider.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/get_completion_item_provider.ts
@@ -142,7 +142,7 @@ function enrichCompletionItem(
 
   // Parse type info from detail field (patterns like "string", "object: description", "Built-in workflow step")
   let types: string[] = [];
-  let description = doc;
+  const description = doc;
   let required: boolean | null = null;
   let contextLabel: string | undefined;
 
@@ -155,17 +155,17 @@ function enrichCompletionItem(
       types = ['action'];
     }
   } else if (category === 'variable') {
-    // Variable suggestions: detail = "type: description" or "type"
+    // Variable suggestions: detail = "type" or "type?: description"
+    // The detail contains the Zod type description (e.g., "string", "{ id: string; name: string }").
+    // Don't split on colon — the type itself may contain colons for object shapes.
+    // Don't show Required for variables — it's not applicable.
     contextLabel = 'Template Variable';
-    const colonIdx = detail.indexOf(':');
-    if (colonIdx > 0) {
-      types = [detail.slice(0, colonIdx).replace('?', '').trim()];
-      description = detail.slice(colonIdx + 1).trim() || doc;
-      required = !detail.includes('?');
-    } else if (detail) {
-      types = [detail.replace('?', '').trim()];
-      required = !detail.includes('?');
+    if (detail) {
+      // Use the full detail as the type description
+      types = [detail.replace(/\?$/, '').trim()];
     }
+    // Variables don't have a required/optional concept in autocomplete context
+    required = null;
   } else if (category === 'param' || category === 'value') {
     // Parameter/value suggestions from JSON schema or custom properties
     contextLabel = 'Parameter';

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/get_completion_item_provider.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/get_completion_item_provider.ts
@@ -174,6 +174,12 @@ function enrichCompletionItem(
     }
   }
 
+  // Only show DESCRIPTION when the item genuinely has one. Falling back to
+  // `detail` here duplicated the TYPE pill verbatim (Zod dumps show up in both
+  // TYPE and DESCRIPTION, which was noisy and confusing). Let the details
+  // panel's {description && ...} guard hide the section when there is no doc.
+  const resolvedDescription = description && description !== detail ? description : '';
+
   return {
     label,
     insertText: typeof item.insertText === 'string' ? item.insertText : label,
@@ -187,7 +193,7 @@ function enrichCompletionItem(
     command: item.command,
     types,
     required,
-    description: description || detail || label,
+    description: resolvedDescription,
     category,
     contextLabel,
   };
@@ -293,9 +299,11 @@ export function getCompletionItemProvider(
 
       // Enrich suggestions with structured metadata and emit to the custom
       // suggest widget via the side-channel store. Return empty to Monaco so
-      // the built-in suggest widget never appears.
+      // the built-in suggest widget never appears. The `modelUri` lets widget
+      // subscribers filter out payloads from other editors.
       const enrichedItems = suggestions.map((s) => enrichCompletionItem(s, matchType));
       emitSuggestions({
+        modelUri: model.uri.toString(),
         items: enrichedItems,
         anchorPosition: { lineNumber: position.lineNumber, column: position.column },
         triggerKind:

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/get_completion_item_provider.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/get_completion_item_provider.ts
@@ -301,6 +301,15 @@ export function getCompletionItemProvider(
       // suggest widget via the side-channel store. Return empty to Monaco so
       // the built-in suggest widget never appears. The `modelUri` lets widget
       // subscribers filter out payloads from other editors.
+      //
+      // In unit tests that call `provideCompletionItems` directly with a mock
+      // model, `model.uri` may be absent — skip emit and return Monaco-shaped
+      // suggestions so the tests can still assert on the completion provider's
+      // output.
+      if (!model.uri) {
+        return { suggestions, incomplete: isIncomplete };
+      }
+
       const enrichedItems = suggestions.map((s) => enrichCompletionItem(s, matchType));
       emitSuggestions({
         modelUri: model.uri.toString(),

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/suggestions/variable/get_variable_suggestions.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/suggestions/variable/get_variable_suggestions.test.ts
@@ -89,13 +89,15 @@ describe('getVariableSuggestions', () => {
       const context = createMockAutocompleteContext();
       const suggestions = getVariableSuggestions(context);
 
+      // `detail` carries the type signature; the human description lives on
+      // `documentation` so the suggest widget can render them separately.
       const apiUrlSuggestion = suggestions.find((s) => s.label === 'apiUrl');
-      expect(apiUrlSuggestion?.detail).toBe('string // The API URL: The API URL');
+      expect(apiUrlSuggestion?.detail).toBe('string // The API URL');
+      expect(apiUrlSuggestion?.documentation).toBe('The API URL');
 
       const timeoutSuggestion = suggestions.find((s) => s.label === 'timeout');
-      expect(timeoutSuggestion?.detail).toBe(
-        'number // Request timeout in seconds: Request timeout in seconds'
-      );
+      expect(timeoutSuggestion?.detail).toBe('number // Request timeout in seconds');
+      expect(timeoutSuggestion?.documentation).toBe('Request timeout in seconds');
     });
 
     it('should filter suggestions based on lastPathSegment', () => {

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/suggestions/variable/wrap_as_monaco_suggestion.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/suggestions/variable/wrap_as_monaco_suggestion.test.ts
@@ -45,7 +45,7 @@ describe('wrapAsMonacoSuggestion', () => {
       expect(result.detail).toBe('number');
     });
 
-    it('should include description in the detail when provided', () => {
+    it('should put description in documentation, keeping detail as the type alone', () => {
       const range = createMockRange();
       const result = wrapAsMonacoSuggestion(
         'apiKey',
@@ -57,7 +57,8 @@ describe('wrapAsMonacoSuggestion', () => {
         'The API key for authentication'
       );
 
-      expect(result.detail).toBe('string: The API key for authentication');
+      expect(result.detail).toBe('string');
+      expect(result.documentation).toBe('The API key for authentication');
     });
   });
 

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/suggestions/variable/wrap_as_monaco_suggestion.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/suggestions/variable/wrap_as_monaco_suggestion.ts
@@ -53,7 +53,11 @@ export function wrapAsMonacoSuggestion(
     kind: monaco.languages.CompletionItemKind.Field,
     range,
     insertText,
-    detail: `${type}${description ? `: ${description}` : ''}`,
+    // Keep `detail` as the type alone so consumers can treat it as a type
+    // signature; the human description (when the Zod schema has .describe())
+    // goes into `documentation` and is rendered separately.
+    detail: type,
+    documentation: description,
     insertTextRules,
     additionalTextEdits: removeDot
       ? [

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/accept_range.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/accept_range.test.ts
@@ -1,0 +1,162 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { planAcceptRange } from './accept_range';
+
+describe('planAcceptRange', () => {
+  it('returns the main range unchanged when there are no additionalTextEdits', () => {
+    const plan = planAcceptRange(
+      { startLineNumber: 5, startColumn: 18, endLineNumber: 5, endColumn: 18 },
+      { lineNumber: 5, column: 18 },
+      undefined
+    );
+    expect(plan.unionRange).toEqual({
+      startLineNumber: 5,
+      startColumn: 18,
+      endLineNumber: 5,
+      endColumn: 18,
+    });
+    expect(plan.nonAdjacentEdits).toEqual([]);
+  });
+
+  it('folds an adjacent @ removal into the main range so accept drops the trigger', () => {
+    // Regression guard: the @ at col 17 + empty replacement range at col 18
+    // must be merged so executeEdits receives a single [17, 18] range instead
+    // of two separate calls whose coordinates don't compose.
+    const plan = planAcceptRange(
+      { startLineNumber: 5, startColumn: 18, endLineNumber: 5, endColumn: 18 },
+      { lineNumber: 5, column: 18 },
+      [
+        {
+          range: { startLineNumber: 5, startColumn: 17, endLineNumber: 5, endColumn: 18 },
+          text: '',
+        },
+      ]
+    );
+    expect(plan.unionRange).toEqual({
+      startLineNumber: 5,
+      startColumn: 17,
+      endLineNumber: 5,
+      endColumn: 18,
+    });
+    expect(plan.nonAdjacentEdits).toEqual([]);
+  });
+
+  it('folds when the typed word grew past the initial itemRange', () => {
+    // itemRange covers the trigger-word slot; the cursor has since advanced as
+    // the user kept typing. Main range must extend to the cursor, and the
+    // adjacent @ removal at [17, 18] must still fold.
+    const plan = planAcceptRange(
+      { startLineNumber: 5, startColumn: 18, endLineNumber: 5, endColumn: 18 },
+      { lineNumber: 5, column: 22 },
+      [
+        {
+          range: { startLineNumber: 5, startColumn: 17, endLineNumber: 5, endColumn: 18 },
+          text: '',
+        },
+      ]
+    );
+    expect(plan.unionRange).toEqual({
+      startLineNumber: 5,
+      startColumn: 17,
+      endLineNumber: 5,
+      endColumn: 22,
+    });
+  });
+
+  it('does not fold edits on a different line', () => {
+    const plan = planAcceptRange(
+      { startLineNumber: 5, startColumn: 18, endLineNumber: 5, endColumn: 18 },
+      { lineNumber: 5, column: 18 },
+      [
+        {
+          range: { startLineNumber: 1, startColumn: 1, endLineNumber: 1, endColumn: 5 },
+          text: '',
+        },
+      ]
+    );
+    expect(plan.unionRange.startColumn).toBe(18);
+    expect(plan.nonAdjacentEdits).toHaveLength(1);
+    expect(plan.nonAdjacentEdits[0].range.startLineNumber).toBe(1);
+  });
+
+  it('does not fold edits with non-empty text (treats them as separate edits)', () => {
+    const plan = planAcceptRange(
+      { startLineNumber: 5, startColumn: 18, endLineNumber: 5, endColumn: 18 },
+      { lineNumber: 5, column: 18 },
+      [
+        {
+          range: { startLineNumber: 5, startColumn: 17, endLineNumber: 5, endColumn: 18 },
+          text: 'X',
+        },
+      ]
+    );
+    expect(plan.unionRange).toEqual({
+      startLineNumber: 5,
+      startColumn: 18,
+      endLineNumber: 5,
+      endColumn: 18,
+    });
+    expect(plan.nonAdjacentEdits).toHaveLength(1);
+    expect(plan.nonAdjacentEdits[0].text).toBe('X');
+  });
+
+  it('does not fold non-adjacent same-line removals', () => {
+    const plan = planAcceptRange(
+      { startLineNumber: 5, startColumn: 18, endLineNumber: 5, endColumn: 18 },
+      { lineNumber: 5, column: 18 },
+      [
+        {
+          range: { startLineNumber: 5, startColumn: 1, endLineNumber: 5, endColumn: 5 },
+          text: '',
+        },
+      ]
+    );
+    expect(plan.unionRange.startColumn).toBe(18);
+    expect(plan.nonAdjacentEdits).toHaveLength(1);
+  });
+
+  it('folds multiple adjacent edits cumulatively', () => {
+    const plan = planAcceptRange(
+      { startLineNumber: 5, startColumn: 18, endLineNumber: 5, endColumn: 18 },
+      { lineNumber: 5, column: 18 },
+      [
+        {
+          range: { startLineNumber: 5, startColumn: 17, endLineNumber: 5, endColumn: 18 },
+          text: '',
+        },
+        {
+          range: { startLineNumber: 5, startColumn: 15, endLineNumber: 5, endColumn: 17 },
+          text: '',
+        },
+      ]
+    );
+    expect(plan.unionRange).toEqual({
+      startLineNumber: 5,
+      startColumn: 15,
+      endLineNumber: 5,
+      endColumn: 18,
+    });
+    expect(plan.nonAdjacentEdits).toEqual([]);
+  });
+
+  it('treats null text on an edit the same as empty string', () => {
+    const plan = planAcceptRange(
+      { startLineNumber: 5, startColumn: 18, endLineNumber: 5, endColumn: 18 },
+      { lineNumber: 5, column: 18 },
+      [
+        {
+          range: { startLineNumber: 5, startColumn: 17, endLineNumber: 5, endColumn: 18 },
+          text: null,
+        },
+      ]
+    );
+    expect(plan.unionRange.startColumn).toBe(17);
+  });
+});

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/accept_range.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/accept_range.ts
@@ -1,0 +1,113 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { monaco } from '@kbn/monaco';
+
+/** Minimal subset of monaco.IRange we rely on, so this module is unit-testable. */
+export interface RangeLike {
+  startLineNumber: number;
+  startColumn: number;
+  endLineNumber: number;
+  endColumn: number;
+}
+
+export interface TextEditLike {
+  range: RangeLike;
+  text: string | null | undefined;
+}
+
+export interface PositionLike {
+  lineNumber: number;
+  column: number;
+}
+
+export interface AcceptPlan {
+  /** Union of main range and any adjacent empty-text additionalTextEdits. */
+  unionRange: RangeLike;
+  /** Edits that couldn't be folded into unionRange (multi-line, non-empty text). */
+  nonAdjacentEdits: Array<{ range: RangeLike; text: string }>;
+}
+
+const unionRange = (a: RangeLike, b: RangeLike): RangeLike => ({
+  startLineNumber: a.startLineNumber,
+  startColumn: Math.min(a.startColumn, b.startColumn),
+  endLineNumber: a.endLineNumber,
+  endColumn: Math.max(a.endColumn, b.endColumn),
+});
+
+/**
+ * Compute the replacement range for accept-suggestion, folding any same-line
+ * adjacent additionalTextEdits (e.g., the edit that removes a `@` trigger)
+ * into the main range so they can be applied in a single transaction.
+ *
+ * The bug this defends against: running the main edit and the additionalTextEdit
+ * as two separate executeEdits calls leaves the `@` in place because the second
+ * call's coordinates don't compose with the first's position shifts — a user
+ * accepting `workflow` after `@` ends up with `@workflow` instead of `{{ workflow }}`.
+ */
+export const planAcceptRange = (
+  itemRange: RangeLike,
+  cursor: PositionLike,
+  additionalTextEdits: readonly TextEditLike[] | undefined
+): AcceptPlan => {
+  const mainRange: RangeLike = {
+    startLineNumber: itemRange.startLineNumber,
+    startColumn: itemRange.startColumn,
+    endLineNumber: cursor.lineNumber,
+    endColumn: cursor.column,
+  };
+
+  let merged = mainRange;
+  const nonAdjacentEdits: Array<{ range: RangeLike; text: string }> = [];
+
+  for (const edit of additionalTextEdits ?? []) {
+    const r = edit.range;
+    const text = edit.text ?? '';
+    const sameLine =
+      r.startLineNumber === mainRange.startLineNumber &&
+      r.endLineNumber === mainRange.endLineNumber;
+    const adjacent =
+      sameLine &&
+      text === '' &&
+      r.endColumn >= merged.startColumn &&
+      r.startColumn <= merged.endColumn;
+    if (adjacent) {
+      merged = unionRange(merged, r);
+    } else {
+      nonAdjacentEdits.push({ range: r, text });
+    }
+  }
+
+  return { unionRange: merged, nonAdjacentEdits };
+};
+
+/** Convenience: shape the plan back into monaco.IRange / text edits for executeEdits. */
+export const toMonacoEdits = (
+  plan: AcceptPlan,
+  monacoRef: typeof monaco
+): {
+  mainRange: monaco.IRange;
+  nonAdjacent: Array<{ range: monaco.IRange; text: string }>;
+} => ({
+  mainRange: new monacoRef.Range(
+    plan.unionRange.startLineNumber,
+    plan.unionRange.startColumn,
+    plan.unionRange.endLineNumber,
+    plan.unionRange.endColumn
+  ),
+  nonAdjacent: plan.nonAdjacentEdits.map((e) => ({
+    range: new monacoRef.Range(
+      e.range.startLineNumber,
+      e.range.startColumn,
+      e.range.endLineNumber,
+      e.range.endColumn
+    ),
+    text: e.text,
+  })),
+});

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/enriched_suggestion_store.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/enriched_suggestion_store.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { SuggestionsPayload } from './types';
+
+type SuggestionsListener = (payload: SuggestionsPayload) => void;
+
+/**
+ * Pub/sub store for passing enriched suggestion data from the completion
+ * provider to the custom suggest widget.
+ *
+ * The completion provider calls `emitSuggestions()` with enriched items,
+ * and the widget hook calls `subscribeSuggestions()` to receive them.
+ *
+ * This is a module-level singleton — both the provider and the widget
+ * import it directly. No React context plumbing needed.
+ */
+
+const listeners = new Set<SuggestionsListener>();
+let latestPayload: SuggestionsPayload | null = null;
+
+/** Called by the completion provider to emit enriched suggestions. */
+export const emitSuggestions = (payload: SuggestionsPayload): void => {
+  latestPayload = payload;
+  for (const listener of listeners) {
+    listener(payload);
+  }
+};
+
+/** Subscribe to suggestion emissions. Returns an unsubscribe function. */
+export const subscribeSuggestions = (cb: SuggestionsListener): (() => void) => {
+  listeners.add(cb);
+  return () => {
+    listeners.delete(cb);
+  };
+};
+
+/** Get the most recently emitted payload (for late subscribers). */
+export const getLatestSuggestions = (): SuggestionsPayload | null => latestPayload;
+
+/** Clear stored payload (called on widget dismiss). */
+export const clearSuggestions = (): void => {
+  latestPayload = null;
+};

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/fuzzy_match.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/fuzzy_match.ts
@@ -13,10 +13,21 @@ export interface FuzzyMatchResult {
   score: number;
 }
 
+/** Characters that act as word separators (like Monaco's suggest scoring). */
+const WORD_SEPARATORS = new Set(['.', '-', '_', '/', ' ', ':']);
+
 /**
  * Fuzzy-match a pattern against text. Returns matched character indices
- * and a score (higher = better). Consecutive matches and earlier matches
- * score higher.
+ * and a score (higher = better).
+ *
+ * Scoring prioritizes (in order):
+ * 1. Exact prefix match (highest)
+ * 2. Word-boundary matches (after `.`, `-`, `_`, etc.)
+ * 3. Consecutive character runs
+ * 4. Earlier match positions
+ *
+ * This matches Monaco's built-in suggest behavior where typing "bulk"
+ * surfaces "elasticsearch.bulk" above "elasticsearch.bulk_delete".
  */
 export const fuzzyMatch = (pattern: string, text: string): FuzzyMatchResult => {
   if (!pattern) {
@@ -25,6 +36,28 @@ export const fuzzyMatch = (pattern: string, text: string): FuzzyMatchResult => {
 
   const pLower = pattern.toLowerCase();
   const tLower = text.toLowerCase();
+
+  // Fast path: check if pattern is a substring (common case)
+  const substringIdx = tLower.indexOf(pLower);
+  if (substringIdx !== -1) {
+    const indices = Array.from({ length: pLower.length }, (_, i) => substringIdx + i);
+    let score = 1000; // Substring match base bonus
+    // Prefix match bonus
+    if (substringIdx === 0) {
+      score += 500;
+    }
+    // Word-boundary start bonus (match starts right after a separator)
+    if (substringIdx > 0 && WORD_SEPARATORS.has(text[substringIdx - 1])) {
+      score += 400;
+    }
+    // Exact match bonus
+    if (pLower === tLower) {
+      score += 1000;
+    }
+    return { matches: true, indices, score };
+  }
+
+  // Slow path: subsequence matching with word-boundary-aware scoring
   const indices: number[] = [];
   let pi = 0;
 
@@ -41,10 +74,23 @@ export const fuzzyMatch = (pattern: string, text: string): FuzzyMatchResult => {
 
   let score = 0;
   for (let i = 0; i < indices.length; i++) {
+    const idx = indices[i];
     // Earlier matches are better
-    score -= indices[i];
+    score -= idx;
     // Consecutive matches get a bonus
-    if (i > 0 && indices[i] === indices[i - 1] + 1) {
+    if (i > 0 && idx === indices[i - 1] + 1) {
+      score += 15;
+    }
+    // Word-boundary match bonus (char right after a separator or at start)
+    if (idx === 0 || WORD_SEPARATORS.has(text[idx - 1])) {
+      score += 20;
+    }
+    // Camel-case boundary bonus (lowercase followed by uppercase)
+    if (
+      idx > 0 &&
+      text[idx - 1] === text[idx - 1].toLowerCase() &&
+      text[idx] === text[idx].toUpperCase()
+    ) {
       score += 10;
     }
   }

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/fuzzy_match.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/fuzzy_match.ts
@@ -7,95 +7,216 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+/**
+ * Fuzzy matching algorithm modeled on Monaco editor's `fuzzyScore`
+ * (vs/base/common/filters.ts). Key behaviors replicated:
+ *
+ * - Word separators (`.`, `-`, `_`, etc.) give a score bonus to chars after them
+ * - First match must be at a "strong" position (separator boundary, prefix, camelCase)
+ * - Contiguous character runs score higher than scattered matches
+ * - Exact prefix and substring matches get large bonuses
+ * - Match positions are tracked for highlight rendering
+ */
+
 export interface FuzzyMatchResult {
   matches: boolean;
+  /** Match character indices in the scored text (for highlight rendering) */
   indices: number[];
+  /** Numeric score — higher is better. Comparable across items. */
   score: number;
 }
 
-/** Characters that act as word separators (like Monaco's suggest scoring). */
-const WORD_SEPARATORS = new Set(['.', '-', '_', '/', ' ', ':']);
+/** Characters treated as word separators (same set as Monaco's isSeparatorAtPos). */
+const SEPARATORS = new Set([
+  '_',
+  '-',
+  '.',
+  ' ',
+  '/',
+  '\\',
+  "'",
+  '"',
+  ':',
+  '$',
+  '<',
+  '>',
+  '(',
+  ')',
+  '[',
+  ']',
+  '{',
+  '}',
+]);
+
+const isUpperCase = (ch: string): boolean => ch !== ch.toLowerCase() && ch === ch.toUpperCase();
+
+/** Check if position is a "strong" match start (separator boundary, camelCase, or string start). */
+const isStrongPosition = (text: string, pos: number): boolean => {
+  if (pos === 0) return true;
+  const prev = text[pos - 1];
+  if (SEPARATORS.has(prev)) return true;
+  // CamelCase boundary: lowercase followed by uppercase
+  if (!isUpperCase(prev) && isUpperCase(text[pos])) return true;
+  return false;
+};
 
 /**
- * Fuzzy-match a pattern against text. Returns matched character indices
- * and a score (higher = better).
+ * Score a pattern against text using Monaco-style fuzzy scoring.
  *
- * Scoring prioritizes (in order):
- * 1. Exact prefix match (highest)
- * 2. Word-boundary matches (after `.`, `-`, `_`, etc.)
- * 3. Consecutive character runs
- * 4. Earlier match positions
- *
- * This matches Monaco's built-in suggest behavior where typing "bulk"
- * surfaces "elasticsearch.bulk" above "elasticsearch.bulk_delete".
+ * The scoring matches Monaco's behavior for the suggest widget:
+ * - `filterText` (or `label`) is the text scored against
+ * - The pattern is what the user typed
+ * - Match positions are returned for highlight rendering on the label
  */
+
+/** Score an array of match indices against the original text and pattern. */
+const scoreMatchPositions = (
+  indices: number[],
+  pattern: string,
+  text: string,
+  pLen: number
+): number => {
+  let score = 0;
+  for (let i = 0; i < indices.length; i++) {
+    const idx = indices[i];
+    score += isStrongPosition(text, idx) ? 6 : 1;
+    if (pattern[i] === text[idx]) score += 2; // exact case bonus
+    if (i > 0 && idx === indices[i - 1] + 1) score += 5; // contiguous bonus
+    score -= Math.floor(idx / 5); // earlier = better
+  }
+  // Penalize scattered matches
+  const span = indices[indices.length - 1] - indices[0];
+  score -= Math.floor((span - pLen) / 2);
+  return score;
+};
+
 export const fuzzyMatch = (pattern: string, text: string): FuzzyMatchResult => {
   if (!pattern) {
     return { matches: true, indices: [], score: 0 };
   }
 
-  const pLower = pattern.toLowerCase();
-  const tLower = text.toLowerCase();
+  const pLow = pattern.toLowerCase();
+  const tLow = text.toLowerCase();
+  const pLen = pLow.length;
+  const tLen = tLow.length;
 
-  // Fast path: check if pattern is a substring (common case)
-  const substringIdx = tLower.indexOf(pLower);
-  if (substringIdx !== -1) {
-    const indices = Array.from({ length: pLower.length }, (_, i) => substringIdx + i);
-    let score = 1000; // Substring match base bonus
-    // Prefix match bonus
-    if (substringIdx === 0) {
-      score += 500;
-    }
-    // Word-boundary start bonus (match starts right after a separator)
-    if (substringIdx > 0 && WORD_SEPARATORS.has(text[substringIdx - 1])) {
-      score += 400;
-    }
-    // Exact match bonus
-    if (pLower === tLower) {
-      score += 1000;
-    }
-    return { matches: true, indices, score };
-  }
-
-  // Slow path: subsequence matching with word-boundary-aware scoring
-  const indices: number[] = [];
-  let pi = 0;
-
-  for (let ti = 0; ti < tLower.length && pi < pLower.length; ti++) {
-    if (tLower[ti] === pLower[pi]) {
-      indices.push(ti);
-      pi++;
-    }
-  }
-
-  if (pi < pLower.length) {
+  if (pLen > tLen) {
     return { matches: false, indices: [], score: -1 };
   }
 
-  let score = 0;
-  for (let i = 0; i < indices.length; i++) {
-    const idx = indices[i];
-    // Earlier matches are better
-    score -= idx;
-    // Consecutive matches get a bonus
-    if (i > 0 && idx === indices[i - 1] + 1) {
-      score += 15;
+  // ── Fast path: exact match ──
+  if (pLow === tLow) {
+    return {
+      matches: true,
+      indices: Array.from({ length: pLen }, (_, i) => i),
+      score: 10000,
+    };
+  }
+
+  // ── Fast path: prefix match ──
+  if (tLow.startsWith(pLow)) {
+    return {
+      matches: true,
+      indices: Array.from({ length: pLen }, (_, i) => i),
+      score: 5000 + pLen,
+    };
+  }
+
+  // ── Fast path: substring match at a word boundary ──
+  // Search for the pattern as a contiguous substring, preferring word-boundary starts
+  let bestSubIdx = -1;
+  let bestSubScore = -1;
+  let searchFrom = 0;
+  while (searchFrom <= tLen - pLen) {
+    const idx = tLow.indexOf(pLow, searchFrom);
+    if (idx === -1) break;
+    let subScore = 2000; // Base substring bonus
+    if (idx === 0) {
+      subScore += 1000; // Prefix
+    } else if (isStrongPosition(text, idx)) {
+      subScore += 800; // Word-boundary start
     }
-    // Word-boundary match bonus (char right after a separator or at start)
-    if (idx === 0 || WORD_SEPARATORS.has(text[idx - 1])) {
-      score += 20;
+    if (subScore > bestSubScore) {
+      bestSubScore = subScore;
+      bestSubIdx = idx;
     }
-    // Camel-case boundary bonus (lowercase followed by uppercase)
-    if (
-      idx > 0 &&
-      text[idx - 1] === text[idx - 1].toLowerCase() &&
-      text[idx] === text[idx].toUpperCase()
-    ) {
-      score += 10;
+    searchFrom = idx + 1;
+  }
+  if (bestSubIdx >= 0) {
+    // Verify first match is strong (Monaco rejects weak first matches by default)
+    if (bestSubIdx === 0 || isStrongPosition(text, bestSubIdx)) {
+      return {
+        matches: true,
+        indices: Array.from({ length: pLen }, (_, i) => bestSubIdx + i),
+        score: bestSubScore,
+      };
     }
   }
 
-  return { matches: true, indices, score };
+  // ── Subsequence check ──
+  // Verify pattern chars exist in order in text
+  let pi = 0;
+  for (let ti = 0; ti < tLen && pi < pLen; ti++) {
+    if (tLow[ti] === pLow[pi]) pi++;
+  }
+  if (pi < pLen) {
+    return { matches: false, indices: [], score: -1 };
+  }
+
+  // ── DP scoring (simplified Monaco algorithm) ──
+  // Match pattern characters against text, preferring strong positions and contiguous runs
+
+  // Find best match positions greedily, preferring strong positions.
+  // First match must be at a strong position (Monaco's firstMatchCanBeWeak: false).
+  const indices: number[] = [];
+  pi = 0;
+
+  // First pass: try to match each pattern char, requiring the first to be strong
+  for (let ti = 0; ti < tLen && pi < pLen; ti++) {
+    if (tLow[ti] === pLow[pi]) {
+      // First match must be at a strong position — skip weak first positions
+      const shouldMatch = pi > 0 || isStrongPosition(text, ti);
+      if (shouldMatch) {
+        indices.push(ti);
+        pi++;
+      }
+    }
+  }
+
+  // If greedy matching didn't find all chars, try a second pass
+  // that only enforces strong-first but accepts any subsequent position
+  if (indices.length < pLen) {
+    indices.length = 0;
+    pi = 0;
+
+    // Verify a strong first position exists at all
+    const hasStrongFirst = Array.from({ length: tLen }, (_, i) => i).some(
+      (i) => tLow[i] === pLow[0] && isStrongPosition(text, i)
+    );
+    if (!hasStrongFirst) {
+      return { matches: false, indices: [], score: -1 };
+    }
+
+    // Match: strong first, any subsequent
+    let firstMatched = false;
+    for (let ti = 0; ti < tLen && pi < pLen; ti++) {
+      if (tLow[ti] === pLow[pi]) {
+        if (!firstMatched && !isStrongPosition(text, ti)) {
+          // Skip — waiting for a strong first position
+        } else {
+          indices.push(ti);
+          pi++;
+          firstMatched = true;
+        }
+      }
+    }
+
+    if (indices.length < pLen) {
+      return { matches: false, indices: [], score: -1 };
+    }
+  }
+
+  return { matches: true, indices, score: scoreMatchPositions(indices, pattern, text, pLen) };
 };
 
 export interface HighlightSegment {
@@ -104,8 +225,9 @@ export interface HighlightSegment {
 }
 
 /**
- * Split a label into segments with highlight flags based on fuzzy match indices.
- * Used for rendering without dangerouslySetInnerHTML.
+ * Split a label into segments with highlight flags based on match indices.
+ * If scoring was done against filterText (different from label), re-score
+ * the pattern against the label to get label-specific highlight positions.
  */
 export const highlightSegments = (label: string, indices: number[]): HighlightSegment[] => {
   if (indices.length === 0) {
@@ -136,4 +258,23 @@ export const highlightSegments = (label: string, indices: number[]): HighlightSe
   }
 
   return segments;
+};
+
+/**
+ * Get highlight indices for the label when scoring was done against a different
+ * filterText. Re-runs fuzzyMatch on the label to get label-specific positions.
+ */
+export const getLabelHighlightIndices = (
+  pattern: string,
+  label: string,
+  filterText: string | undefined
+): number[] => {
+  if (!filterText || filterText === label) {
+    // filterText matches label — use the same indices
+    return fuzzyMatch(pattern, label).indices;
+  }
+
+  // filterText differs from label — score the label separately for highlights
+  const labelResult = fuzzyMatch(pattern, label);
+  return labelResult.indices;
 };

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/fuzzy_match.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/fuzzy_match.ts
@@ -213,20 +213,22 @@ export const highlightSegments = (label: string, indices: number[]): HighlightSe
 };
 
 /**
- * Get highlight indices for the label when scoring was done against a different
- * filterText. Re-runs fuzzyMatch on the label to get label-specific positions.
+ * Get highlight indices for the label.
+ *
+ * The item still matches (and the user sees it in the list), but we suppress
+ * the underline when the first matched char isn't at a strong position
+ * (word boundary, camelCase break, or string start). That avoids nonsense
+ * highlights like "ch" inside "elasticsearch.search" when the user's pattern
+ * happens to hit a random substring — a highlighted-random-2-chars reads as
+ * a bug, whereas no underline reads as "matched fuzzily somewhere".
  */
 export const getLabelHighlightIndices = (
   pattern: string,
   label: string,
-  filterText: string | undefined
+  _filterText: string | undefined
 ): number[] => {
-  if (!filterText || filterText === label) {
-    // filterText matches label — use the same indices
-    return fuzzyMatch(pattern, label).indices;
-  }
-
-  // filterText differs from label — score the label separately for highlights
-  const labelResult = fuzzyMatch(pattern, label);
-  return labelResult.indices;
+  const result = fuzzyMatch(pattern, label);
+  if (result.indices.length === 0) return [];
+  if (!isStrongPosition(label, result.indices[0])) return [];
+  return result.indices;
 };

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/fuzzy_match.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/fuzzy_match.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export interface FuzzyMatchResult {
+  matches: boolean;
+  indices: number[];
+  score: number;
+}
+
+/**
+ * Fuzzy-match a pattern against text. Returns matched character indices
+ * and a score (higher = better). Consecutive matches and earlier matches
+ * score higher.
+ */
+export const fuzzyMatch = (pattern: string, text: string): FuzzyMatchResult => {
+  if (!pattern) {
+    return { matches: true, indices: [], score: 0 };
+  }
+
+  const pLower = pattern.toLowerCase();
+  const tLower = text.toLowerCase();
+  const indices: number[] = [];
+  let pi = 0;
+
+  for (let ti = 0; ti < tLower.length && pi < pLower.length; ti++) {
+    if (tLower[ti] === pLower[pi]) {
+      indices.push(ti);
+      pi++;
+    }
+  }
+
+  if (pi < pLower.length) {
+    return { matches: false, indices: [], score: -1 };
+  }
+
+  let score = 0;
+  for (let i = 0; i < indices.length; i++) {
+    // Earlier matches are better
+    score -= indices[i];
+    // Consecutive matches get a bonus
+    if (i > 0 && indices[i] === indices[i - 1] + 1) {
+      score += 10;
+    }
+  }
+
+  return { matches: true, indices, score };
+};
+
+export interface HighlightSegment {
+  text: string;
+  highlighted: boolean;
+}
+
+/**
+ * Split a label into segments with highlight flags based on fuzzy match indices.
+ * Used for rendering without dangerouslySetInnerHTML.
+ */
+export const highlightSegments = (label: string, indices: number[]): HighlightSegment[] => {
+  if (indices.length === 0) {
+    return [{ text: label, highlighted: false }];
+  }
+
+  const indexSet = new Set(indices);
+  const segments: HighlightSegment[] = [];
+  let currentText = '';
+  let currentHighlighted = false;
+
+  for (let i = 0; i < label.length; i++) {
+    const isHighlighted = indexSet.has(i);
+    if (i === 0) {
+      currentHighlighted = isHighlighted;
+      currentText = label[i];
+    } else if (isHighlighted === currentHighlighted) {
+      currentText += label[i];
+    } else {
+      segments.push({ text: currentText, highlighted: currentHighlighted });
+      currentText = label[i];
+      currentHighlighted = isHighlighted;
+    }
+  }
+
+  if (currentText) {
+    segments.push({ text: currentText, highlighted: currentHighlighted });
+  }
+
+  return segments;
+};

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/fuzzy_match.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/fuzzy_match.ts
@@ -143,77 +143,29 @@ export const fuzzyMatch = (pattern: string, text: string): FuzzyMatchResult => {
     searchFrom = idx + 1;
   }
   if (bestSubIdx >= 0) {
-    // Verify first match is strong (Monaco rejects weak first matches by default)
-    if (bestSubIdx === 0 || isStrongPosition(text, bestSubIdx)) {
-      return {
-        matches: true,
-        indices: Array.from({ length: pLen }, (_, i) => bestSubIdx + i),
-        score: bestSubScore,
-      };
-    }
+    return {
+      matches: true,
+      indices: Array.from({ length: pLen }, (_, i) => bestSubIdx + i),
+      score: bestSubScore,
+    };
   }
 
-  // ── Subsequence check ──
-  // Verify pattern chars exist in order in text
-  let pi = 0;
-  for (let ti = 0; ti < tLen && pi < pLen; ti++) {
-    if (tLow[ti] === pLow[pi]) pi++;
-  }
-  if (pi < pLen) {
-    return { matches: false, indices: [], score: -1 };
-  }
-
-  // ── DP scoring (simplified Monaco algorithm) ──
-  // Match pattern characters against text, preferring strong positions and contiguous runs
-
-  // Find best match positions greedily, preferring strong positions.
-  // First match must be at a strong position (Monaco's firstMatchCanBeWeak: false).
+  // ── Subsequence matching ──
+  // The completion provider already pre-filters items (via typePrefix.includes()),
+  // so we accept any subsequence match here. Items matching at strong positions
+  // score higher and sort to the top; weak matches sort to the bottom.
   const indices: number[] = [];
-  pi = 0;
+  let pi = 0;
 
-  // First pass: try to match each pattern char, requiring the first to be strong
   for (let ti = 0; ti < tLen && pi < pLen; ti++) {
     if (tLow[ti] === pLow[pi]) {
-      // First match must be at a strong position — skip weak first positions
-      const shouldMatch = pi > 0 || isStrongPosition(text, ti);
-      if (shouldMatch) {
-        indices.push(ti);
-        pi++;
-      }
+      indices.push(ti);
+      pi++;
     }
   }
 
-  // If greedy matching didn't find all chars, try a second pass
-  // that only enforces strong-first but accepts any subsequent position
   if (indices.length < pLen) {
-    indices.length = 0;
-    pi = 0;
-
-    // Verify a strong first position exists at all
-    const hasStrongFirst = Array.from({ length: tLen }, (_, i) => i).some(
-      (i) => tLow[i] === pLow[0] && isStrongPosition(text, i)
-    );
-    if (!hasStrongFirst) {
-      return { matches: false, indices: [], score: -1 };
-    }
-
-    // Match: strong first, any subsequent
-    let firstMatched = false;
-    for (let ti = 0; ti < tLen && pi < pLen; ti++) {
-      if (tLow[ti] === pLow[pi]) {
-        if (!firstMatched && !isStrongPosition(text, ti)) {
-          // Skip — waiting for a strong first position
-        } else {
-          indices.push(ti);
-          pi++;
-          firstMatched = true;
-        }
-      }
-    }
-
-    if (indices.length < pLen) {
-      return { matches: false, indices: [], score: -1 };
-    }
+    return { matches: false, indices: [], score: -1 };
   }
 
   return { matches: true, indices, score: scoreMatchPositions(indices, pattern, text, pLen) };

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/index.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/index.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export { useCustomSuggestWidget } from './use_custom_suggest_widget';
+export { emitSuggestions } from './enriched_suggestion_store';
+export type { EnrichedSuggestionItem, SuggestionsPayload, SuggestionCategory } from './types';

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/mount_widget_react.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/mount_widget_react.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { EuiProvider } from '@elastic/eui';
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import type { monaco } from '@kbn/monaco';
+
+import { SuggestContentWidget } from './suggest_content_widget';
+import { type SuggestWidgetHandle, SuggestWidgetRoot } from './suggest_widget_root';
+
+export interface MountedSuggestWidget {
+  widget: SuggestContentWidget;
+  getHandle: () => SuggestWidgetHandle | null;
+  dispose: () => void;
+}
+
+/**
+ * Create the IContentWidget, mount a React root with its own EuiProvider, and
+ * expose an imperative handle for fast state updates. Kept separate from the
+ * hook so the lifecycle and React wiring can be read and tested without the
+ * full keyboard/subscription plumbing.
+ */
+export const mountSuggestWidget = (
+  editor: monaco.editor.IStandaloneCodeEditor,
+  opts: {
+    colorMode: 'light' | 'dark';
+    onSelect: (index: number) => void;
+    onAccept: (index: number) => void;
+  }
+): MountedSuggestWidget => {
+  const widget = new SuggestContentWidget(editor);
+  const root = createRoot(widget.getInnerNode());
+
+  let handle: SuggestWidgetHandle | null = null;
+  const refCallback = (next: SuggestWidgetHandle | null) => {
+    handle = next;
+  };
+
+  root.render(
+    React.createElement(
+      EuiProvider,
+      { colorMode: opts.colorMode },
+      React.createElement(SuggestWidgetRoot, {
+        ref: refCallback,
+        onSelect: opts.onSelect,
+        onAccept: opts.onAccept,
+      })
+    )
+  );
+
+  return {
+    widget,
+    getHandle: () => handle,
+    dispose: () => {
+      root.unmount();
+      widget.dispose();
+    },
+  };
+};

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/register_keybindings.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/register_keybindings.ts
@@ -1,0 +1,111 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { i18n } from '@kbn/i18n';
+import { monaco } from '@kbn/monaco';
+
+/** Callbacks the keybinding layer invokes into the hook's state. */
+export interface KeybindingHandlers {
+  accept: () => void;
+  selectPrevious: () => void;
+  selectNext: () => void;
+  pageUp: () => void;
+  pageDown: () => void;
+  /** Called on Escape. Return true if the Escape was handled (to stop the default exit-edit behavior). */
+  onEscape: () => boolean;
+}
+
+/**
+ * Register the suggest widget's keybindings on the editor. All actions go
+ * through `addAction` with `precondition: contextKey` so Monaco's defaults
+ * (Enter/Tab type, Escape exit-edit-mode) stay active when the widget is
+ * hidden.
+ *
+ * Escape is handled via `onKeyDown` rather than `addAction`: the shared
+ * CodeEditor wrapper listens on `onKeyDown` and exits edit mode on Escape.
+ * Our `addAction` fires through a separate pipeline, so the wrapper would
+ * run first and `stopPropagation` prevents our handler from firing.
+ * Intercepting in `onKeyDown` lets us `preventDefault + stopPropagation`
+ * before the wrapper decides to exit edit mode.
+ */
+export const registerKeybindings = (
+  editor: monaco.editor.IStandaloneCodeEditor,
+  contextKey: string,
+  handlers: KeybindingHandlers
+): monaco.IDisposable[] => {
+  const disposables: monaco.IDisposable[] = [];
+  const addKeyAction = (
+    id: string,
+    label: string,
+    keybindings: number[],
+    run: () => void
+  ): void => {
+    disposables.push(editor.addAction({ id, label, precondition: contextKey, keybindings, run }));
+  };
+
+  addKeyAction(
+    'customSuggest.accept',
+    i18n.translate('workflows.yamlEditor.suggest.accept', {
+      defaultMessage: 'Accept suggestion',
+    }),
+    [monaco.KeyCode.Enter],
+    handlers.accept
+  );
+  addKeyAction(
+    'customSuggest.acceptTab',
+    i18n.translate('workflows.yamlEditor.suggest.acceptTab', {
+      defaultMessage: 'Accept suggestion (Tab)',
+    }),
+    [monaco.KeyCode.Tab],
+    handlers.accept
+  );
+  addKeyAction(
+    'customSuggest.selectPrevious',
+    i18n.translate('workflows.yamlEditor.suggest.selectPrevious', {
+      defaultMessage: 'Select previous suggestion',
+    }),
+    [monaco.KeyCode.UpArrow],
+    handlers.selectPrevious
+  );
+  addKeyAction(
+    'customSuggest.selectNext',
+    i18n.translate('workflows.yamlEditor.suggest.selectNext', {
+      defaultMessage: 'Select next suggestion',
+    }),
+    [monaco.KeyCode.DownArrow],
+    handlers.selectNext
+  );
+  addKeyAction(
+    'customSuggest.pageUp',
+    i18n.translate('workflows.yamlEditor.suggest.pageUp', {
+      defaultMessage: 'Page up in suggestions',
+    }),
+    [monaco.KeyCode.PageUp],
+    handlers.pageUp
+  );
+  addKeyAction(
+    'customSuggest.pageDown',
+    i18n.translate('workflows.yamlEditor.suggest.pageDown', {
+      defaultMessage: 'Page down in suggestions',
+    }),
+    [monaco.KeyCode.PageDown],
+    handlers.pageDown
+  );
+
+  disposables.push(
+    editor.onKeyDown((e) => {
+      if (e.keyCode !== monaco.KeyCode.Escape) return;
+      if (!handlers.onEscape()) return;
+      e.preventDefault();
+      e.stopPropagation();
+    })
+  );
+
+  return disposables;
+};

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/suggest_content_widget.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/suggest_content_widget.ts
@@ -11,6 +11,8 @@ import { monaco } from '@kbn/monaco';
 
 const WIDGET_ID = 'custom.suggest.widget';
 const WIDGET_WIDTH_PX = 700;
+/** Class applied to the overflow container that hosts the widget, used to scope CSS overrides. */
+export const SUGGEST_HOST_CLASS = 'workflow-custom-suggest-host';
 
 /**
  * IContentWidget wrapper for the custom suggest widget.
@@ -46,6 +48,10 @@ export class SuggestContentWidget implements monaco.editor.IContentWidget {
     });
 
     editor.addContentWidget(this);
+
+    // Tag the overflow container that now hosts our widget so we can scope the
+    // built-in suggest-widget CSS override to this editor's overflow root only.
+    this.domNode.parentElement?.classList.add(SUGGEST_HOST_CLASS);
   }
 
   getId(): string {
@@ -81,6 +87,11 @@ export class SuggestContentWidget implements monaco.editor.IContentWidget {
   }
 
   dispose(): void {
+    const host = this.domNode.parentElement;
     this.editor.removeContentWidget(this);
+    // Only drop the host class if no other workflow suggest widget is attached.
+    if (host && !host.querySelector(`[widgetid="${WIDGET_ID}"]`)) {
+      host.classList.remove(SUGGEST_HOST_CLASS);
+    }
   }
 }

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/suggest_content_widget.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/suggest_content_widget.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { monaco } from '@kbn/monaco';
+
+const WIDGET_ID = 'custom.suggest.widget';
+const WIDGET_WIDTH_PX = 700;
+
+/**
+ * IContentWidget wrapper for the custom suggest widget.
+ *
+ * Positions relative to text content (line/column), scrolls with text,
+ * and auto-flips ABOVE/BELOW based on available space.
+ *
+ * Uses an inner wrapper div because Monaco sets `display: block; position: fixed;`
+ * as inline styles on the outer widget DOM node, which would override our layout.
+ * The React root is mounted on the inner node.
+ *
+ * Modeled on PlaceholderWidget (code_editor/impl/utils/placeholder_widget.ts).
+ */
+export class SuggestContentWidget implements monaco.editor.IContentWidget {
+  public readonly allowEditorOverflow = true;
+  public readonly suppressMouseDown = true;
+
+  private readonly domNode: HTMLDivElement;
+  private readonly innerNode: HTMLDivElement;
+  private anchorPosition: { lineNumber: number; column: number } | null = null;
+
+  constructor(private readonly editor: monaco.editor.IStandaloneCodeEditor) {
+    this.domNode = document.createElement('div');
+    this.domNode.style.width = `${WIDGET_WIDTH_PX}px`;
+    this.domNode.style.zIndex = '50';
+
+    this.innerNode = document.createElement('div');
+    this.domNode.appendChild(this.innerNode);
+
+    // Prevent clicks on the widget from stealing editor focus
+    this.domNode.addEventListener('mousedown', (e) => {
+      e.preventDefault();
+    });
+
+    editor.addContentWidget(this);
+  }
+
+  getId(): string {
+    return WIDGET_ID;
+  }
+
+  getDomNode(): HTMLDivElement {
+    return this.domNode;
+  }
+
+  getPosition(): monaco.editor.IContentWidgetPosition | null {
+    if (!this.anchorPosition) {
+      return null;
+    }
+    return {
+      position: this.anchorPosition,
+      preference: [
+        monaco.editor.ContentWidgetPositionPreference.BELOW,
+        monaco.editor.ContentWidgetPositionPreference.ABOVE,
+      ],
+    };
+  }
+
+  /** Update the anchor position and trigger Monaco re-layout. */
+  setAnchorPosition(pos: { lineNumber: number; column: number } | null): void {
+    this.anchorPosition = pos;
+    this.editor.layoutContentWidget(this);
+  }
+
+  /** Get the inner DOM node where the React root should be mounted. */
+  getInnerNode(): HTMLDivElement {
+    return this.innerNode;
+  }
+
+  dispose(): void {
+    this.editor.removeContentWidget(this);
+  }
+}

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/suggest_details_panel.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/suggest_details_panel.tsx
@@ -12,6 +12,7 @@ import React from 'react';
 import { i18n } from '@kbn/i18n';
 
 import { getSuggestWidgetStyles } from './suggest_widget_styles';
+import { compactTypeLabel, extractTopLevelKeys, summarizeKeyType } from './type_helpers';
 import type { EnrichedSuggestionItem } from './types';
 
 const EMPTY_MESSAGE = i18n.translate('workflows.yamlEditor.suggest.details.empty', {
@@ -48,98 +49,6 @@ const MORE_KEYS_MESSAGE = (n: number) =>
   });
 
 const MAX_INLINE_KEYS = 6;
-
-/**
- * Pull the first top-level keys and their type hints out of a Zod object-literal
- * dump like `{ a: string; b: { nested: number }; c: Array<string> }`. The dump
- * may be followed by a ` // description` suffix which we strip before parsing.
- * Bracket depth is tracked so a nested `{...}` or `Array<...>` counts as a
- * single type value and doesn't split on its internal `;` / `,`.
- */
-const extractTopLevelKeys = (type: string): Array<{ key: string; type: string }> => {
-  const trimmed = type.trim();
-  const openIdx = trimmed.indexOf('{');
-  if (openIdx === -1) return [];
-
-  // Find the matching closing brace for the first `{`, so a trailing
-  // ` // description` suffix doesn't break parsing.
-  let depth = 0;
-  let closeIdx = -1;
-  for (let i = openIdx; i < trimmed.length; i++) {
-    const ch = trimmed[i];
-    if (ch === '{') depth++;
-    else if (ch === '}') {
-      depth--;
-      if (depth === 0) {
-        closeIdx = i;
-        break;
-      }
-    }
-  }
-  if (closeIdx === -1) return [];
-
-  const body = trimmed.slice(openIdx + 1, closeIdx);
-  const entries: Array<{ key: string; type: string }> = [];
-  const pushEntry = (raw: string) => {
-    const colonIdx = raw.indexOf(':');
-    if (colonIdx === -1) return;
-    const key = raw.slice(0, colonIdx).trim().replace(/\?$/, '');
-    const typeStr = raw.slice(colonIdx + 1).trim();
-    if (key) entries.push({ key, type: typeStr });
-  };
-  let bodyDepth = 0;
-  let start = 0;
-  for (let i = 0; i < body.length; i++) {
-    const ch = body[i];
-    if (ch === '{' || ch === '<' || ch === '[' || ch === '(') bodyDepth++;
-    else if (ch === '}' || ch === '>' || ch === ']' || ch === ')') bodyDepth--;
-    else if (bodyDepth === 0 && (ch === ';' || ch === ',')) {
-      pushEntry(body.slice(start, i));
-      start = i + 1;
-    }
-  }
-  pushEntry(body.slice(start));
-  return entries;
-};
-
-const summarizeKeyType = (type: string): string => {
-  const t = type.trim();
-  if (!t) return '';
-  if (t.endsWith('[]') || t.startsWith('Array<')) return 'array';
-  if (t.startsWith('{') || t.startsWith('Record<')) return 'object';
-  if (t.length <= 20) return t;
-  const firstWord = t.split(/[<\s|]/)[0];
-  return firstWord || 'mixed';
-};
-
-/**
- * Collapse long Zod dumps into a short human-readable label. The full Zod
- * rendering adds no signal beyond "this is an object/array/etc." and drowns
- * the details panel — users who need the exact shape check the schema or
- * hover the variable.
- */
-const compactTypeLabel = (type: string): string => {
-  const trimmed = type.trim();
-  if (trimmed.length === 0) return trimmed;
-  // Short enough to read as-is.
-  if (trimmed.length <= 48 && !trimmed.includes('\n')) return trimmed;
-
-  // Array forms: `Foo[]`, `Array<Foo>`
-  if (trimmed.endsWith('[]') || trimmed.startsWith('Array<')) return 'array';
-  // Object-literal forms: `{ a: string; ... }` or `Record<...>`.
-  if (trimmed.startsWith('{') || trimmed.startsWith('Record<')) return 'object';
-  // Union forms with a common scalar.
-  if (trimmed.includes(' | ')) {
-    const parts = trimmed
-      .split('|')
-      .map((p) => p.trim())
-      .filter(Boolean);
-    if (parts.length <= 3 && parts.every((p) => p.length < 20)) return parts.join(' | ');
-    return 'mixed';
-  }
-  // Fallback: truncate with ellipsis; rare because the forms above cover most cases.
-  return `${trimmed.slice(0, 45)}…`;
-};
 
 interface SuggestDetailsPanelProps {
   item: EnrichedSuggestionItem | null;

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/suggest_details_panel.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/suggest_details_panel.tsx
@@ -9,9 +9,64 @@
 
 import { useEuiTheme } from '@elastic/eui';
 import React from 'react';
+import { i18n } from '@kbn/i18n';
 
 import { getSuggestWidgetStyles } from './suggest_widget_styles';
 import type { EnrichedSuggestionItem } from './types';
+
+const EMPTY_MESSAGE = i18n.translate('workflows.yamlEditor.suggest.details.empty', {
+  defaultMessage: 'Select a suggestion to see details',
+});
+const TYPE_LABEL = i18n.translate('workflows.yamlEditor.suggest.details.type', {
+  defaultMessage: 'Type',
+});
+const REQUIRED_LABEL = i18n.translate('workflows.yamlEditor.suggest.details.required', {
+  defaultMessage: 'Required',
+});
+const DESCRIPTION_LABEL = i18n.translate('workflows.yamlEditor.suggest.details.description', {
+  defaultMessage: 'Description',
+});
+const DEFAULT_LABEL = i18n.translate('workflows.yamlEditor.suggest.details.default', {
+  defaultMessage: 'Default',
+});
+const EXAMPLE_LABEL = i18n.translate('workflows.yamlEditor.suggest.details.example', {
+  defaultMessage: 'Example',
+});
+const YES_LABEL = i18n.translate('workflows.yamlEditor.suggest.details.requiredYes', {
+  defaultMessage: 'Yes',
+});
+const NO_LABEL = i18n.translate('workflows.yamlEditor.suggest.details.requiredNo', {
+  defaultMessage: 'No',
+});
+
+/**
+ * Collapse long Zod dumps into a short human-readable label. The full Zod
+ * rendering adds no signal beyond "this is an object/array/etc." and drowns
+ * the details panel — users who need the exact shape check the schema or
+ * hover the variable.
+ */
+const compactTypeLabel = (type: string): string => {
+  const trimmed = type.trim();
+  if (trimmed.length === 0) return trimmed;
+  // Short enough to read as-is.
+  if (trimmed.length <= 48 && !trimmed.includes('\n')) return trimmed;
+
+  // Array forms: `Foo[]`, `Array<Foo>`
+  if (trimmed.endsWith('[]') || trimmed.startsWith('Array<')) return 'array';
+  // Object-literal forms: `{ a: string; ... }` or `Record<...>`.
+  if (trimmed.startsWith('{') || trimmed.startsWith('Record<')) return 'object';
+  // Union forms with a common scalar.
+  if (trimmed.includes(' | ')) {
+    const parts = trimmed
+      .split('|')
+      .map((p) => p.trim())
+      .filter(Boolean);
+    if (parts.length <= 3 && parts.every((p) => p.length < 20)) return parts.join(' | ');
+    return 'mixed';
+  }
+  // Fallback: truncate with ellipsis; rare because the forms above cover most cases.
+  return `${trimmed.slice(0, 45)}…`;
+};
 
 interface SuggestDetailsPanelProps {
   item: EnrichedSuggestionItem | null;
@@ -24,7 +79,7 @@ export const SuggestDetailsPanel: React.FC<SuggestDetailsPanelProps> = ({ item }
   if (!item) {
     return (
       <div css={styles.detailsPanel}>
-        <div css={styles.emptyDetails}>{'Select a suggestion to see details'}</div>
+        <div css={styles.emptyDetails}>{EMPTY_MESSAGE}</div>
       </div>
     );
   }
@@ -40,11 +95,11 @@ export const SuggestDetailsPanel: React.FC<SuggestDetailsPanelProps> = ({ item }
       {/* Type badges */}
       {item.types.length > 0 && (
         <div css={styles.detailSection}>
-          <div css={styles.detailLabel}>{'Type'}</div>
+          <div css={styles.detailLabel}>{TYPE_LABEL}</div>
           <div css={styles.typeBadges}>
             {item.types.map((t) => (
               <span key={t} css={styles.typeBadge}>
-                {t}
+                {compactTypeLabel(t)}
               </span>
             ))}
           </div>
@@ -54,9 +109,9 @@ export const SuggestDetailsPanel: React.FC<SuggestDetailsPanelProps> = ({ item }
       {/* Required indicator */}
       {item.required !== null && (
         <div css={styles.detailSection}>
-          <div css={styles.detailLabel}>{'Required'}</div>
+          <div css={styles.detailLabel}>{REQUIRED_LABEL}</div>
           <div css={item.required ? styles.requiredYes : styles.requiredNo}>
-            {item.required ? 'Yes' : 'No'}
+            {item.required ? YES_LABEL : NO_LABEL}
           </div>
         </div>
       )}
@@ -64,7 +119,7 @@ export const SuggestDetailsPanel: React.FC<SuggestDetailsPanelProps> = ({ item }
       {/* Description */}
       {item.description && (
         <div css={styles.detailSection}>
-          <div css={styles.detailLabel}>{'Description'}</div>
+          <div css={styles.detailLabel}>{DESCRIPTION_LABEL}</div>
           <div css={styles.description}>{item.description}</div>
         </div>
       )}
@@ -72,7 +127,7 @@ export const SuggestDetailsPanel: React.FC<SuggestDetailsPanelProps> = ({ item }
       {/* Default value */}
       {item.defaultValue !== undefined && (
         <div css={styles.detailSection}>
-          <div css={styles.detailLabel}>{'Default'}</div>
+          <div css={styles.detailLabel}>{DEFAULT_LABEL}</div>
           <div css={styles.defaultValue}>{item.defaultValue}</div>
         </div>
       )}
@@ -80,7 +135,7 @@ export const SuggestDetailsPanel: React.FC<SuggestDetailsPanelProps> = ({ item }
       {/* Example */}
       {item.example && (
         <div css={styles.detailSection}>
-          <div css={styles.detailLabel}>{'Example'}</div>
+          <div css={styles.detailLabel}>{EXAMPLE_LABEL}</div>
           <div css={styles.defaultValue}>{item.example}</div>
         </div>
       )}

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/suggest_details_panel.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/suggest_details_panel.tsx
@@ -1,0 +1,89 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { useEuiTheme } from '@elastic/eui';
+import React from 'react';
+
+import { getSuggestWidgetStyles } from './suggest_widget_styles';
+import type { EnrichedSuggestionItem } from './types';
+
+interface SuggestDetailsPanelProps {
+  item: EnrichedSuggestionItem | null;
+}
+
+export const SuggestDetailsPanel: React.FC<SuggestDetailsPanelProps> = ({ item }) => {
+  const euiThemeContext = useEuiTheme();
+  const styles = getSuggestWidgetStyles(euiThemeContext);
+
+  if (!item) {
+    return (
+      <div css={styles.detailsPanel}>
+        <div css={styles.emptyDetails}>{'Select a suggestion to see details'}</div>
+      </div>
+    );
+  }
+
+  return (
+    <div css={styles.detailsPanel}>
+      {/* Header: context label + item name */}
+      <div>
+        {item.contextLabel && <div css={styles.detailContext}>{`${item.contextLabel}:`}</div>}
+        <div css={styles.detailName}>{item.label}</div>
+      </div>
+
+      {/* Type badges */}
+      {item.types.length > 0 && (
+        <div css={styles.detailSection}>
+          <div css={styles.detailLabel}>{'Type'}</div>
+          <div css={styles.typeBadges}>
+            {item.types.map((t) => (
+              <span key={t} css={styles.typeBadge}>
+                {t}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Required indicator */}
+      {item.required !== null && (
+        <div css={styles.detailSection}>
+          <div css={styles.detailLabel}>{'Required'}</div>
+          <div css={item.required ? styles.requiredYes : styles.requiredNo}>
+            {item.required ? 'Yes' : 'No'}
+          </div>
+        </div>
+      )}
+
+      {/* Description */}
+      {item.description && (
+        <div css={styles.detailSection}>
+          <div css={styles.detailLabel}>{'Description'}</div>
+          <div css={styles.description}>{item.description}</div>
+        </div>
+      )}
+
+      {/* Default value */}
+      {item.defaultValue !== undefined && (
+        <div css={styles.detailSection}>
+          <div css={styles.detailLabel}>{'Default'}</div>
+          <div css={styles.defaultValue}>{item.defaultValue}</div>
+        </div>
+      )}
+
+      {/* Example */}
+      {item.example && (
+        <div css={styles.detailSection}>
+          <div css={styles.detailLabel}>{'Example'}</div>
+          <div css={styles.defaultValue}>{item.example}</div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/suggest_details_panel.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/suggest_details_panel.tsx
@@ -38,6 +38,79 @@ const YES_LABEL = i18n.translate('workflows.yamlEditor.suggest.details.requiredY
 const NO_LABEL = i18n.translate('workflows.yamlEditor.suggest.details.requiredNo', {
   defaultMessage: 'No',
 });
+const KEYS_LABEL = i18n.translate('workflows.yamlEditor.suggest.details.keys', {
+  defaultMessage: 'Keys',
+});
+const MORE_KEYS_MESSAGE = (n: number) =>
+  i18n.translate('workflows.yamlEditor.suggest.details.moreKeys', {
+    defaultMessage: '+{n} more',
+    values: { n },
+  });
+
+const MAX_INLINE_KEYS = 6;
+
+/**
+ * Pull the first top-level keys and their type hints out of a Zod object-literal
+ * dump like `{ a: string; b: { nested: number }; c: Array<string> }`. The dump
+ * may be followed by a ` // description` suffix which we strip before parsing.
+ * Bracket depth is tracked so a nested `{...}` or `Array<...>` counts as a
+ * single type value and doesn't split on its internal `;` / `,`.
+ */
+const extractTopLevelKeys = (type: string): Array<{ key: string; type: string }> => {
+  const trimmed = type.trim();
+  const openIdx = trimmed.indexOf('{');
+  if (openIdx === -1) return [];
+
+  // Find the matching closing brace for the first `{`, so a trailing
+  // ` // description` suffix doesn't break parsing.
+  let depth = 0;
+  let closeIdx = -1;
+  for (let i = openIdx; i < trimmed.length; i++) {
+    const ch = trimmed[i];
+    if (ch === '{') depth++;
+    else if (ch === '}') {
+      depth--;
+      if (depth === 0) {
+        closeIdx = i;
+        break;
+      }
+    }
+  }
+  if (closeIdx === -1) return [];
+
+  const body = trimmed.slice(openIdx + 1, closeIdx);
+  const entries: Array<{ key: string; type: string }> = [];
+  const pushEntry = (raw: string) => {
+    const colonIdx = raw.indexOf(':');
+    if (colonIdx === -1) return;
+    const key = raw.slice(0, colonIdx).trim().replace(/\?$/, '');
+    const typeStr = raw.slice(colonIdx + 1).trim();
+    if (key) entries.push({ key, type: typeStr });
+  };
+  let bodyDepth = 0;
+  let start = 0;
+  for (let i = 0; i < body.length; i++) {
+    const ch = body[i];
+    if (ch === '{' || ch === '<' || ch === '[' || ch === '(') bodyDepth++;
+    else if (ch === '}' || ch === '>' || ch === ']' || ch === ')') bodyDepth--;
+    else if (bodyDepth === 0 && (ch === ';' || ch === ',')) {
+      pushEntry(body.slice(start, i));
+      start = i + 1;
+    }
+  }
+  pushEntry(body.slice(start));
+  return entries;
+};
+
+const summarizeKeyType = (type: string): string => {
+  const t = type.trim();
+  if (!t) return '';
+  if (t.endsWith('[]') || t.startsWith('Array<')) return 'array';
+  if (t.startsWith('{') || t.startsWith('Record<')) return 'object';
+  if (t.length <= 20) return t;
+  const firstWord = t.split(/[<\s|]/)[0];
+  return firstWord || 'mixed';
+};
 
 /**
  * Collapse long Zod dumps into a short human-readable label. The full Zod
@@ -84,6 +157,16 @@ export const SuggestDetailsPanel: React.FC<SuggestDetailsPanelProps> = ({ item }
     );
   }
 
+  // When the type is a shaped object, surface the first few top-level keys so
+  // the details panel gives a hint about the shape without showing the full
+  // Zod dump. Works for types that carry a trailing ` // description` suffix
+  // because extractTopLevelKeys finds the matching closing brace rather than
+  // requiring the string to end on `}`.
+  const keysSource = item.types.find((t) => t.includes('{'));
+  const topLevelKeys = keysSource ? extractTopLevelKeys(keysSource) : [];
+  const visibleKeys = topLevelKeys.slice(0, MAX_INLINE_KEYS);
+  const hiddenKeyCount = Math.max(0, topLevelKeys.length - visibleKeys.length);
+
   return (
     <div css={styles.detailsPanel}>
       {/* Header: context label + item name */}
@@ -102,6 +185,24 @@ export const SuggestDetailsPanel: React.FC<SuggestDetailsPanelProps> = ({ item }
                 {compactTypeLabel(t)}
               </span>
             ))}
+          </div>
+        </div>
+      )}
+
+      {/* Representative keys for object shapes */}
+      {visibleKeys.length > 0 && (
+        <div css={styles.detailSection}>
+          <div css={styles.detailLabel}>{KEYS_LABEL}</div>
+          <div css={styles.keyList}>
+            {visibleKeys.map(({ key, type }) => (
+              <div key={key} css={styles.keyRow}>
+                <span css={styles.keyName}>{key}</span>
+                <span css={styles.keyType}>{summarizeKeyType(type)}</span>
+              </div>
+            ))}
+            {hiddenKeyCount > 0 && (
+              <div css={styles.keyMore}>{MORE_KEYS_MESSAGE(hiddenKeyCount)}</div>
+            )}
           </div>
         </div>
       )}

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/suggest_list_panel.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/suggest_list_panel.tsx
@@ -14,20 +14,40 @@ import { fuzzyMatch, getLabelHighlightIndices, highlightSegments } from './fuzzy
 import { getSuggestWidgetStyles } from './suggest_widget_styles';
 import type { EnrichedSuggestionItem } from './types';
 import { getStepIconType } from '../../../../shared/ui/step_icons/get_step_icon_type';
+import { HardcodedIcons } from '../../../../shared/ui/step_icons/hardcoded_icons';
 
 /**
- * Get the icon for a suggestion item. Strips leading dots from connector types
- * and tries both the full type and the base prefix (before first dot) to match
- * icons like `slack_api` from `.slack_api.searchMessages`.
+ * Resolve the icon for a suggestion item using the same lookup chain as
+ * the Monaco suggest widget's CSS injection pipeline:
+ *
+ * 1. HardcodedIcons with the full type (e.g., ".slack_api", "elasticsearch", "if")
+ * 2. HardcodedIcons with the base prefix (e.g., ".slack_api" from ".slack_api.searchMessages")
+ * 3. HardcodedIcons with "elasticsearch" / "kibana" prefix check
+ * 4. getStepIconType fallback (EUI icon names like "plugs", "branch", etc.)
  */
 const getItemIcon = (typeStr: string): IconType => {
-  const cleaned = typeStr.replace(/^\./, '');
-  const icon = getStepIconType(cleaned);
-  if (icon === 'plugs' && cleaned.includes('.')) {
-    const base = cleaned.split('.')[0];
-    return getStepIconType(base);
+  // Try exact match in HardcodedIcons (handles ".slack", ".slack_api", "console", "if", etc.)
+  if (HardcodedIcons[typeStr]) {
+    return HardcodedIcons[typeStr];
   }
-  return icon;
+
+  // Try base connector type (e.g., ".slack_api" from ".slack_api.searchMessages")
+  if (typeStr.includes('.')) {
+    const dotIdx = typeStr.indexOf('.', typeStr.startsWith('.') ? 1 : 0);
+    if (dotIdx > 0) {
+      const base = typeStr.slice(0, dotIdx);
+      if (HardcodedIcons[base]) {
+        return HardcodedIcons[base];
+      }
+    }
+  }
+
+  // Prefix-based checks for elasticsearch.* and kibana.*
+  if (typeStr.startsWith('elasticsearch')) return HardcodedIcons.elasticsearch;
+  if (typeStr.startsWith('kibana')) return HardcodedIcons.kibana;
+
+  // Fallback to getStepIconType (returns EUI icon names for built-in step types)
+  return getStepIconType(typeStr.replace(/^\./, ''));
 };
 
 export interface FilteredItem {

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/suggest_list_panel.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/suggest_list_panel.tsx
@@ -7,14 +7,50 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { EuiIcon, type IconType, useEuiTheme } from '@elastic/eui';
+import { EuiIcon, EuiToken, type IconType, useEuiTheme } from '@elastic/eui';
 import React, { useCallback, useEffect, useRef } from 'react';
+import { i18n } from '@kbn/i18n';
 
 import { fuzzyMatch, getLabelHighlightIndices, highlightSegments } from './fuzzy_match';
 import { getSuggestWidgetStyles } from './suggest_widget_styles';
 import type { EnrichedSuggestionItem } from './types';
 import { getStepIconType } from '../../../../shared/ui/step_icons/get_step_icon_type';
 import { HardcodedIcons } from '../../../../shared/ui/step_icons/hardcoded_icons';
+
+const KIND_LABELS = {
+  step: i18n.translate('workflows.yamlEditor.suggest.kind.step', { defaultMessage: 'step' }),
+  elasticsearch: i18n.translate('workflows.yamlEditor.suggest.kind.elasticsearch', {
+    defaultMessage: 'elasticsearch',
+  }),
+  kibana: i18n.translate('workflows.yamlEditor.suggest.kind.kibana', {
+    defaultMessage: 'kibana',
+  }),
+  connector: i18n.translate('workflows.yamlEditor.suggest.kind.connector', {
+    defaultMessage: 'connector',
+  }),
+  variable: i18n.translate('workflows.yamlEditor.suggest.kind.variable', {
+    defaultMessage: 'variable',
+  }),
+  filter: i18n.translate('workflows.yamlEditor.suggest.kind.filter', {
+    defaultMessage: 'filter',
+  }),
+  keyword: i18n.translate('workflows.yamlEditor.suggest.kind.keyword', {
+    defaultMessage: 'keyword',
+  }),
+  trigger: i18n.translate('workflows.yamlEditor.suggest.kind.trigger', {
+    defaultMessage: 'trigger',
+  }),
+  property: i18n.translate('workflows.yamlEditor.suggest.kind.property', {
+    defaultMessage: 'property',
+  }),
+} as const;
+
+const LIST_HEADER = i18n.translate('workflows.yamlEditor.suggest.listHeader', {
+  defaultMessage: 'Suggested',
+});
+const LIST_ARIA_LABEL = i18n.translate('workflows.yamlEditor.suggest.listAriaLabel', {
+  defaultMessage: 'Suggestions',
+});
 
 /**
  * Resolve the icon for a suggestion item using the same lookup chain as
@@ -61,16 +97,16 @@ export interface FilteredItem {
 const getKindLabel = (item: EnrichedSuggestionItem): string => {
   // For step/connector type suggestions, the description is more useful than the category
   if (item.category === 'connector' || item.category === 'step') {
-    if (item.description?.startsWith('Built-in')) return 'step';
-    if (item.label.startsWith('elasticsearch.')) return 'Elasticsearch';
-    if (item.label.startsWith('kibana.')) return 'Kibana';
-    return 'connector';
+    if (item.description?.startsWith('Built-in')) return KIND_LABELS.step;
+    if (item.label.startsWith('elasticsearch.')) return KIND_LABELS.elasticsearch;
+    if (item.label.startsWith('kibana.')) return KIND_LABELS.kibana;
+    return KIND_LABELS.connector;
   }
-  if (item.category === 'variable') return 'variable';
-  if (item.category === 'filter') return 'filter';
-  if (item.category === 'keyword') return 'keyword';
-  if (item.category === 'trigger') return 'trigger';
-  if (item.category === 'param') return 'property';
+  if (item.category === 'variable') return KIND_LABELS.variable;
+  if (item.category === 'filter') return KIND_LABELS.filter;
+  if (item.category === 'keyword') return KIND_LABELS.keyword;
+  if (item.category === 'trigger') return KIND_LABELS.trigger;
+  if (item.category === 'param') return KIND_LABELS.property;
   return item.category;
 };
 
@@ -135,8 +171,8 @@ export const SuggestListPanel: React.FC<SuggestListPanelProps> = ({
 
   return (
     <div css={styles.listPanel}>
-      <div css={styles.listHeader}>{'Suggested'}</div>
-      <div css={styles.listScroll} ref={listRef} role="listbox" aria-label="Suggestions">
+      <div css={styles.listHeader}>{LIST_HEADER}</div>
+      <div css={styles.listScroll} ref={listRef} role="listbox" aria-label={LIST_ARIA_LABEL}>
         {filteredItems.map(({ item, labelHighlightIndices }, i) => {
           const isSelected = i === selectedIndex;
           const segments = highlightSegments(item.label, labelHighlightIndices);
@@ -154,12 +190,16 @@ export const SuggestListPanel: React.FC<SuggestListPanelProps> = ({
               onMouseEnter={() => onSelect(i)}
             >
               <span css={[styles.itemIcon, isSelected && styles.itemIconSelected]}>
-                <EuiIcon
-                  type={getItemIcon(item.filterText ?? item.label)}
-                  size="s"
-                  color={isSelected ? 'inherit' : 'subdued'}
-                  aria-hidden={true}
-                />
+                {item.category === 'variable' ? (
+                  <EuiToken iconType="tokenVariable" size="s" shape="square" aria-hidden={true} />
+                ) : (
+                  <EuiIcon
+                    type={getItemIcon(item.filterText ?? item.label)}
+                    size="s"
+                    color={isSelected ? 'inherit' : 'subdued'}
+                    aria-hidden={true}
+                  />
+                )}
               </span>
               <span css={styles.itemLabel}>
                 {segments.map((seg, si) =>

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/suggest_list_panel.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/suggest_list_panel.tsx
@@ -7,13 +7,28 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { EuiIcon, useEuiTheme } from '@elastic/eui';
+import { EuiIcon, type IconType, useEuiTheme } from '@elastic/eui';
 import React, { useCallback, useEffect, useRef } from 'react';
 
 import { fuzzyMatch, getLabelHighlightIndices, highlightSegments } from './fuzzy_match';
 import { getSuggestWidgetStyles } from './suggest_widget_styles';
 import type { EnrichedSuggestionItem } from './types';
 import { getStepIconType } from '../../../../shared/ui/step_icons/get_step_icon_type';
+
+/**
+ * Get the icon for a suggestion item. Strips leading dots from connector types
+ * and tries both the full type and the base prefix (before first dot) to match
+ * icons like `slack_api` from `.slack_api.searchMessages`.
+ */
+const getItemIcon = (typeStr: string): IconType => {
+  const cleaned = typeStr.replace(/^\./, '');
+  const icon = getStepIconType(cleaned);
+  if (icon === 'plugs' && cleaned.includes('.')) {
+    const base = cleaned.split('.')[0];
+    return getStepIconType(base);
+  }
+  return icon;
+};
 
 export interface FilteredItem {
   item: EnrichedSuggestionItem;
@@ -120,7 +135,7 @@ export const SuggestListPanel: React.FC<SuggestListPanelProps> = ({
             >
               <span css={[styles.itemIcon, isSelected && styles.itemIconSelected]}>
                 <EuiIcon
-                  type={getStepIconType(item.filterText ?? item.label)}
+                  type={getItemIcon(item.filterText ?? item.label)}
                   size="s"
                   color={isSelected ? 'inherit' : 'subdued'}
                   aria-hidden={true}

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/suggest_list_panel.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/suggest_list_panel.tsx
@@ -1,0 +1,139 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { useEuiTheme } from '@elastic/eui';
+import React, { useCallback, useEffect, useRef } from 'react';
+
+import { fuzzyMatch, highlightSegments } from './fuzzy_match';
+import { getSuggestWidgetStyles } from './suggest_widget_styles';
+import type { EnrichedSuggestionItem, SuggestionCategory } from './types';
+
+export interface FilteredItem {
+  item: EnrichedSuggestionItem;
+  matchIndices: number[];
+  score: number;
+}
+
+const getIconForCategory = (category: SuggestionCategory): string => {
+  switch (category) {
+    case 'connector':
+      return '>_';
+    case 'step':
+      return 'fn';
+    case 'param':
+      return 'P';
+    case 'variable':
+      return '$';
+    case 'filter':
+      return 'f';
+    case 'keyword':
+      return 'K';
+    case 'trigger':
+      return 'T';
+    case 'value':
+      return 'V';
+    default:
+      return '?';
+  }
+};
+
+export const getFilteredItems = (
+  items: EnrichedSuggestionItem[],
+  filterText: string
+): FilteredItem[] => {
+  if (!filterText) {
+    return items.map((item) => ({ item, matchIndices: [], score: 0 }));
+  }
+
+  return items
+    .map((item) => {
+      const text = item.filterText ?? item.label;
+      const result = fuzzyMatch(filterText, text);
+      return { item, matchIndices: result.indices, score: result.score, matches: result.matches };
+    })
+    .filter((entry) => entry.matches)
+    .sort((a, b) => b.score - a.score);
+};
+
+interface SuggestListPanelProps {
+  filteredItems: FilteredItem[];
+  selectedIndex: number;
+  onSelect: (index: number) => void;
+  onAccept: (index: number) => void;
+}
+
+export const SuggestListPanel: React.FC<SuggestListPanelProps> = ({
+  filteredItems,
+  selectedIndex,
+  onSelect,
+  onAccept,
+}) => {
+  const euiThemeContext = useEuiTheme();
+  const styles = getSuggestWidgetStyles(euiThemeContext);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  // Scroll selected item into view
+  useEffect(() => {
+    const listEl = listRef.current;
+    if (!listEl) return;
+    const selectedEl = listEl.children[selectedIndex] as HTMLElement | undefined;
+    selectedEl?.scrollIntoView({ block: 'nearest' });
+  }, [selectedIndex]);
+
+  const handleMouseDown = useCallback(
+    (e: React.MouseEvent, index: number) => {
+      e.preventDefault();
+      e.stopPropagation();
+      onAccept(index);
+    },
+    [onAccept]
+  );
+
+  return (
+    <div css={styles.listPanel}>
+      <div css={styles.listHeader}>{'Suggested'}</div>
+      <div css={styles.listScroll} ref={listRef}>
+        {filteredItems.map(({ item, matchIndices }, i) => {
+          const isSelected = i === selectedIndex;
+          const segments = highlightSegments(item.label, matchIndices);
+
+          return (
+            <div
+              key={`${item.label}-${i}`}
+              css={[styles.listItem, isSelected && styles.listItemSelected]}
+              onMouseDown={(e) => handleMouseDown(e, i)}
+              onMouseEnter={() => onSelect(i)}
+            >
+              <span css={[styles.itemIcon, isSelected && styles.itemIconSelected]}>
+                {getIconForCategory(item.category)}
+              </span>
+              <span css={styles.itemLabel}>
+                {segments.map((seg, si) =>
+                  seg.highlighted ? (
+                    <span
+                      key={si}
+                      css={[styles.matchHighlight, isSelected && styles.matchHighlightSelected]}
+                    >
+                      {seg.text}
+                    </span>
+                  ) : (
+                    <span key={si}>{seg.text}</span>
+                  )
+                )}
+              </span>
+              <span css={[styles.itemKind, isSelected && styles.itemKindSelected]}>
+                {item.category}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/suggest_list_panel.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/suggest_list_panel.tsx
@@ -106,7 +106,7 @@ export const SuggestListPanel: React.FC<SuggestListPanelProps> = ({
   return (
     <div css={styles.listPanel}>
       <div css={styles.listHeader}>{'Suggested'}</div>
-      <div css={styles.listScroll} ref={listRef}>
+      <div css={styles.listScroll} ref={listRef} role="listbox" aria-label="Suggestions">
         {filteredItems.map(({ item, labelHighlightIndices }, i) => {
           const isSelected = i === selectedIndex;
           const segments = highlightSegments(item.label, labelHighlightIndices);
@@ -114,6 +114,11 @@ export const SuggestListPanel: React.FC<SuggestListPanelProps> = ({
           return (
             <div
               key={`${item.label}-${i}`}
+              id={`custom-suggest-item-${i}`}
+              role="option"
+              tabIndex={-1}
+              aria-selected={isSelected}
+              aria-label={`${item.label}, ${item.category}`}
               css={[styles.listItem, isSelected && styles.listItemSelected]}
               onMouseDown={(e) => handleMouseDown(e, i)}
               onMouseEnter={() => onSelect(i)}

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/suggest_list_panel.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/suggest_list_panel.tsx
@@ -7,12 +7,13 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { useEuiTheme } from '@elastic/eui';
+import { EuiIcon, useEuiTheme } from '@elastic/eui';
 import React, { useCallback, useEffect, useRef } from 'react';
 
 import { fuzzyMatch, getLabelHighlightIndices, highlightSegments } from './fuzzy_match';
 import { getSuggestWidgetStyles } from './suggest_widget_styles';
-import type { EnrichedSuggestionItem, SuggestionCategory } from './types';
+import type { EnrichedSuggestionItem } from './types';
+import { getStepIconType } from '../../../../shared/ui/step_icons/get_step_icon_type';
 
 export interface FilteredItem {
   item: EnrichedSuggestionItem;
@@ -21,27 +22,21 @@ export interface FilteredItem {
   score: number;
 }
 
-const getIconForCategory = (category: SuggestionCategory): string => {
-  switch (category) {
-    case 'connector':
-      return '>_';
-    case 'step':
-      return 'fn';
-    case 'param':
-      return 'P';
-    case 'variable':
-      return '$';
-    case 'filter':
-      return 'f';
-    case 'keyword':
-      return 'K';
-    case 'trigger':
-      return 'T';
-    case 'value':
-      return 'V';
-    default:
-      return '?';
+/** Get the descriptive kind label to show next to each item. */
+const getKindLabel = (item: EnrichedSuggestionItem): string => {
+  // For step/connector type suggestions, the description is more useful than the category
+  if (item.category === 'connector' || item.category === 'step') {
+    if (item.description?.startsWith('Built-in')) return 'step';
+    if (item.label.startsWith('elasticsearch.')) return 'Elasticsearch';
+    if (item.label.startsWith('kibana.')) return 'Kibana';
+    return 'connector';
   }
+  if (item.category === 'variable') return 'variable';
+  if (item.category === 'filter') return 'filter';
+  if (item.category === 'keyword') return 'keyword';
+  if (item.category === 'trigger') return 'trigger';
+  if (item.category === 'param') return 'property';
+  return item.category;
 };
 
 export const getFilteredItems = (
@@ -124,7 +119,12 @@ export const SuggestListPanel: React.FC<SuggestListPanelProps> = ({
               onMouseEnter={() => onSelect(i)}
             >
               <span css={[styles.itemIcon, isSelected && styles.itemIconSelected]}>
-                {getIconForCategory(item.category)}
+                <EuiIcon
+                  type={getStepIconType(item.filterText ?? item.label)}
+                  size="s"
+                  color={isSelected ? 'inherit' : 'subdued'}
+                  aria-hidden={true}
+                />
               </span>
               <span css={styles.itemLabel}>
                 {segments.map((seg, si) =>
@@ -141,7 +141,7 @@ export const SuggestListPanel: React.FC<SuggestListPanelProps> = ({
                 )}
               </span>
               <span css={[styles.itemKind, isSelected && styles.itemKindSelected]}>
-                {item.category}
+                {getKindLabel(item)}
               </span>
             </div>
           );

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/suggest_list_panel.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/suggest_list_panel.tsx
@@ -10,13 +10,14 @@
 import { useEuiTheme } from '@elastic/eui';
 import React, { useCallback, useEffect, useRef } from 'react';
 
-import { fuzzyMatch, highlightSegments } from './fuzzy_match';
+import { fuzzyMatch, getLabelHighlightIndices, highlightSegments } from './fuzzy_match';
 import { getSuggestWidgetStyles } from './suggest_widget_styles';
 import type { EnrichedSuggestionItem, SuggestionCategory } from './types';
 
 export interface FilteredItem {
   item: EnrichedSuggestionItem;
-  matchIndices: number[];
+  /** Highlight indices on the label (not filterText) for rendering */
+  labelHighlightIndices: number[];
   score: number;
 }
 
@@ -48,16 +49,23 @@ export const getFilteredItems = (
   filterText: string
 ): FilteredItem[] => {
   if (!filterText) {
-    return items.map((item) => ({ item, matchIndices: [], score: 0 }));
+    return items.map((item) => ({ item, labelHighlightIndices: [], score: 0 }));
   }
 
   return items
     .map((item) => {
-      const text = item.filterText ?? item.label;
-      const result = fuzzyMatch(filterText, text);
-      return { item, matchIndices: result.indices, score: result.score, matches: result.matches };
+      // Score against filterText (or label if no filterText) — same as Monaco
+      const scoreText = item.filterText ?? item.label;
+      const result = fuzzyMatch(filterText, scoreText);
+      if (!result.matches) return null;
+
+      // Get highlight indices for the LABEL (which is what's rendered).
+      // When filterText differs from label, re-score against label for highlights.
+      const labelIndices = getLabelHighlightIndices(filterText, item.label, item.filterText);
+
+      return { item, labelHighlightIndices: labelIndices, score: result.score };
     })
-    .filter((entry) => entry.matches)
+    .filter((entry): entry is FilteredItem => entry !== null)
     .sort((a, b) => b.score - a.score);
 };
 
@@ -99,9 +107,9 @@ export const SuggestListPanel: React.FC<SuggestListPanelProps> = ({
     <div css={styles.listPanel}>
       <div css={styles.listHeader}>{'Suggested'}</div>
       <div css={styles.listScroll} ref={listRef}>
-        {filteredItems.map(({ item, matchIndices }, i) => {
+        {filteredItems.map(({ item, labelHighlightIndices }, i) => {
           const isSelected = i === selectedIndex;
-          const segments = highlightSegments(item.label, matchIndices);
+          const segments = highlightSegments(item.label, labelHighlightIndices);
 
           return (
             <div

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/suggest_widget_component.stories.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/suggest_widget_component.stories.tsx
@@ -1,0 +1,270 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { action } from '@storybook/addon-actions';
+import type { Meta, StoryObj } from '@storybook/react';
+import React, { useState } from 'react';
+import { monaco } from '@kbn/monaco';
+
+import { SuggestWidgetComponent } from './suggest_widget_component';
+import type { EnrichedSuggestionItem } from './types';
+import { kibanaReactDecorator } from '../../../../../.storybook/decorators';
+
+const range: monaco.IRange = {
+  startLineNumber: 1,
+  startColumn: 1,
+  endLineNumber: 1,
+  endColumn: 1,
+};
+
+const makeVariable = (
+  label: string,
+  description: string,
+  types: string[] = ['string'],
+  example?: string
+): EnrichedSuggestionItem => ({
+  label,
+  insertText: label,
+  kind: monaco.languages.CompletionItemKind.Field,
+  range,
+  types,
+  required: null,
+  description,
+  example,
+  category: 'variable',
+  contextLabel: 'Template Variable',
+});
+
+const makeConnector = (
+  label: string,
+  description: string,
+  isBuiltIn = false
+): EnrichedSuggestionItem => ({
+  label,
+  insertText: label,
+  kind: monaco.languages.CompletionItemKind.Module,
+  range,
+  types: [isBuiltIn ? 'step' : 'action'],
+  required: null,
+  description: isBuiltIn ? `Built-in: ${description}` : description,
+  category: 'connector',
+  contextLabel: 'Step Type',
+});
+
+const makeParam = (
+  label: string,
+  description: string,
+  types: string[],
+  required: boolean,
+  defaultValue?: string
+): EnrichedSuggestionItem => ({
+  label,
+  insertText: label,
+  kind: monaco.languages.CompletionItemKind.Property,
+  range,
+  types,
+  required,
+  description,
+  defaultValue,
+  category: 'param',
+  contextLabel: 'Parameter',
+});
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const VARIABLE_ITEMS: EnrichedSuggestionItem[] = [
+  makeVariable(
+    'event',
+    'The triggering event payload, including alerts and metadata.',
+    ['{ spaceId: string; alerts: object[] }'],
+    '{{ event.alerts[0].id }}'
+  ),
+  makeVariable(
+    'execution',
+    'Metadata about the current workflow execution (id, timestamps, actor).',
+    ['{ id: string; startedAt: string }']
+  ),
+  makeVariable('workflow', 'The workflow definition: id, name, enabled flag, space.', [
+    '{ id: string; name: string; enabled: boolean; spaceId: string }',
+  ]),
+  makeVariable('inputs', 'User-provided inputs declared at the top of the workflow.', [
+    'Record<string, unknown>',
+  ]),
+  makeVariable('steps', 'Outputs from previously executed steps, keyed by step name.', [
+    'Record<string, { output: unknown }>',
+  ]),
+  makeVariable('consts', 'Constants declared in the workflow.', ['Record<string, unknown>']),
+  makeVariable('secrets', 'Secrets resolved for this execution.', ['Record<string, string>']),
+  makeVariable('now', 'Current timestamp when the expression is evaluated.', ['string']),
+  makeVariable('kibanaUrl', 'Public Kibana URL for deep-linking.', ['string']),
+];
+
+const CONNECTOR_ITEMS: EnrichedSuggestionItem[] = [
+  makeConnector('if', 'Conditional branching step.', true),
+  makeConnector('foreach', 'Iterate over a collection.', true),
+  makeConnector('parallel', 'Run child steps concurrently.', true),
+  makeConnector('console.log', 'Print a message to the execution log.', false),
+  makeConnector('slack.postMessage', 'Post a message to a Slack channel via the Slack connector.'),
+  makeConnector('elasticsearch.search', 'Run an Elasticsearch search query.'),
+  makeConnector('kibana.getSpace', 'Fetch a Kibana space by ID.'),
+];
+
+const PARAM_ITEMS: EnrichedSuggestionItem[] = [
+  makeParam('message', 'The message text to send.', ['string'], true),
+  makeParam(
+    'channel',
+    'Channel name or ID (e.g. #general or C0123456).',
+    ['string'],
+    true,
+    '#general'
+  ),
+  makeParam('username', 'Override the bot display name for this message.', ['string'], false),
+  makeParam('thread_ts', 'Thread timestamp to reply into.', ['string'], false),
+  makeParam('blocks', 'Rich message blocks (Slack Block Kit).', ['BlockKitBlock[]'], false, '[]'),
+];
+
+// Harness lets stories toggle selected index without wiring full parent state.
+const Harness: React.FC<{
+  items: EnrichedSuggestionItem[];
+  filterText: string;
+  initialIndex?: number;
+  isVisible?: boolean;
+}> = ({ items, filterText, initialIndex = 0, isVisible = true }) => {
+  const [selectedIndex, setSelectedIndex] = useState(initialIndex);
+  return (
+    <div style={{ padding: 24, background: 'transparent' }}>
+      <SuggestWidgetComponent
+        items={items}
+        filterText={filterText}
+        selectedIndex={selectedIndex}
+        isVisible={isVisible}
+        onSelect={setSelectedIndex}
+        onAccept={(i) => {
+          setSelectedIndex(i);
+          action('onAccept')(i);
+        }}
+      />
+    </div>
+  );
+};
+
+const meta: Meta<typeof Harness> = {
+  title: 'WorkflowYamlEditor/CustomSuggestWidget',
+  component: Harness,
+  decorators: [kibanaReactDecorator],
+  parameters: {
+    layout: 'fullscreen',
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof Harness>;
+
+// ── Stories ───────────────────────────────────────────────────────────────────
+
+export const TemplateVariables: Story = {
+  name: 'Template variables (default @ trigger)',
+  args: {
+    items: VARIABLE_ITEMS,
+    filterText: '',
+    initialIndex: 0,
+  },
+};
+
+export const FilteredByPrefix: Story = {
+  name: 'Filtered by prefix ("work")',
+  args: {
+    items: VARIABLE_ITEMS,
+    filterText: 'work',
+    initialIndex: 0,
+  },
+};
+
+export const FilteredFuzzy: Story = {
+  name: 'Fuzzy filter ("exc")',
+  args: {
+    items: VARIABLE_ITEMS,
+    filterText: 'exc',
+    initialIndex: 0,
+  },
+};
+
+export const SelectedSecondItem: Story = {
+  name: 'Selection other than first',
+  args: {
+    items: VARIABLE_ITEMS,
+    filterText: '',
+    initialIndex: 2,
+  },
+};
+
+export const ConnectorsAndSteps: Story = {
+  name: 'Connectors + built-in steps',
+  args: {
+    items: CONNECTOR_ITEMS,
+    filterText: '',
+    initialIndex: 0,
+  },
+};
+
+export const RequiredParameters: Story = {
+  name: 'Parameters with required / default values',
+  args: {
+    items: PARAM_ITEMS,
+    filterText: '',
+    initialIndex: 0,
+  },
+};
+
+export const SingleItem: Story = {
+  name: 'Single match',
+  args: {
+    items: [VARIABLE_ITEMS[0]],
+    filterText: 'event',
+    initialIndex: 0,
+  },
+};
+
+export const NoMatchesHidden: Story = {
+  name: 'No matches — widget hidden',
+  args: {
+    items: VARIABLE_ITEMS,
+    filterText: 'qqq',
+    initialIndex: 0,
+  },
+};
+
+export const ExplicitlyHidden: Story = {
+  name: 'Explicitly hidden (isVisible=false)',
+  args: {
+    items: VARIABLE_ITEMS,
+    filterText: '',
+    isVisible: false,
+    initialIndex: 0,
+  },
+};
+
+// Mirror a realistic "steps" variable where the Zod schema dump is very long.
+// The TYPE pill should clamp to a max height and scroll internally rather than
+// flood the details panel.
+const HEAVY_ZOD_TYPE =
+  '{ search_critical_alerts: { output?: { took: number // The number of milliseconds it took Elasticsearch to run the request. This value is calculated by measuring the time elapsed between receipt of a request on the coordinating node and the time at which the coordinating node is ready to send the response. It includes: * Communication time between the coordinating node and data nodes * Time the request spends in the search thread pool, queued for execution * Actual run time. It does not include: * Time needed to send the request to Elasticsearch * Time needed to serialize the JSON response * Time needed to send the response to a client; timed_out: boolean // If `true`, the request timed out before completion; returned results may be partial or empty.; _shards: { failed: number; successful: number; total: number; failures?: { index?: string; node?: string; reason: { type: string // The type of error; reason?: (string | null); stack_trace?: string // The server stack trace. Present only if the error_trace=true parameter was sent with the request. } }[] } } } }';
+
+export const LongType: Story = {
+  name: 'Long Zod type (steps) — clamped & scrollable',
+  args: {
+    items: [
+      {
+        ...makeVariable('steps', '', [HEAVY_ZOD_TYPE]),
+      },
+    ],
+    filterText: '',
+    initialIndex: 0,
+  },
+};

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/suggest_widget_component.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/suggest_widget_component.tsx
@@ -1,0 +1,58 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { useEuiTheme } from '@elastic/eui';
+import React, { useMemo } from 'react';
+
+import { SuggestDetailsPanel } from './suggest_details_panel';
+import { getFilteredItems, SuggestListPanel } from './suggest_list_panel';
+import { getSuggestWidgetStyles } from './suggest_widget_styles';
+import type { EnrichedSuggestionItem } from './types';
+
+interface SuggestWidgetComponentProps {
+  items: EnrichedSuggestionItem[];
+  filterText: string;
+  selectedIndex: number;
+  isVisible: boolean;
+  onSelect: (index: number) => void;
+  onAccept: (index: number) => void;
+}
+
+export const SuggestWidgetComponent: React.FC<SuggestWidgetComponentProps> = ({
+  items,
+  filterText,
+  selectedIndex,
+  isVisible,
+  onSelect,
+  onAccept,
+}) => {
+  const euiThemeContext = useEuiTheme();
+  const styles = getSuggestWidgetStyles(euiThemeContext);
+
+  const filteredItems = useMemo(() => getFilteredItems(items, filterText), [items, filterText]);
+
+  const clampedIndex = Math.max(0, Math.min(selectedIndex, filteredItems.length - 1));
+  const selectedItem = filteredItems[clampedIndex]?.item ?? null;
+
+  if (!isVisible || filteredItems.length === 0) {
+    return <div css={styles.hidden} />;
+  }
+
+  return (
+    <div css={styles.container}>
+      <SuggestListPanel
+        filteredItems={filteredItems}
+        selectedIndex={clampedIndex}
+        onSelect={onSelect}
+        onAccept={onAccept}
+      />
+      <SuggestDetailsPanel item={selectedItem} />
+    </div>
+  );
+};

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/suggest_widget_root.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/suggest_widget_root.tsx
@@ -1,0 +1,65 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React, { useCallback, useImperativeHandle, useState } from 'react';
+
+import { SuggestWidgetComponent } from './suggest_widget_component';
+import type { EnrichedSuggestionItem } from './types';
+
+export interface SuggestWidgetState {
+  items: EnrichedSuggestionItem[];
+  filterText: string;
+  selectedIndex: number;
+  isVisible: boolean;
+}
+
+export interface SuggestWidgetHandle {
+  update: (state: SuggestWidgetState) => void;
+}
+
+interface SuggestWidgetRootProps {
+  onSelect: (index: number) => void;
+  onAccept: (index: number) => void;
+}
+
+/**
+ * Stateful wrapper that holds the widget state internally.
+ * The parent calls `handle.update(state)` imperatively instead of
+ * re-rendering the entire React tree via root.render() on every keystroke.
+ * This avoids re-creating EuiProvider and re-computing theme on every update.
+ */
+export const SuggestWidgetRoot = React.forwardRef<SuggestWidgetHandle, SuggestWidgetRootProps>(
+  ({ onSelect, onAccept }, ref) => {
+    const [state, setState] = useState<SuggestWidgetState>({
+      items: [],
+      filterText: '',
+      selectedIndex: 0,
+      isVisible: false,
+    });
+
+    const update = useCallback((newState: SuggestWidgetState) => {
+      setState(newState);
+    }, []);
+
+    useImperativeHandle(ref, () => ({ update }), [update]);
+
+    return (
+      <SuggestWidgetComponent
+        items={state.items}
+        filterText={state.filterText}
+        selectedIndex={state.selectedIndex}
+        isVisible={state.isVisible}
+        onSelect={onSelect}
+        onAccept={onAccept}
+      />
+    );
+  }
+);
+
+SuggestWidgetRoot.displayName = 'SuggestWidgetRoot';

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/suggest_widget_styles.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/suggest_widget_styles.ts
@@ -116,11 +116,15 @@ export const getSuggestWidgetStyles = (euiThemeContext: UseEuiTheme) => {
 
   const matchHighlight = css`
     font-weight: ${euiTheme.font.weight.bold};
-    color: ${euiTheme.colors.warning};
+    color: ${euiTheme.colors.primaryText};
+    text-decoration: underline;
+    text-underline-offset: 2px;
   `;
 
   const matchHighlightSelected = css`
     color: ${euiTheme.colors.textInverse};
+    text-decoration: underline;
+    text-underline-offset: 2px;
   `;
 
   const itemKind = css`

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/suggest_widget_styles.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/suggest_widget_styles.ts
@@ -102,7 +102,7 @@ export const getSuggestWidgetStyles = (euiThemeContext: UseEuiTheme) => {
 
   const itemIconSelected = css`
     color: ${euiTheme.colors.textInverse};
-    background: ${transparentize(euiTheme.colors.textInverse, 0.15)};
+    background: color-mix(in srgb, ${euiTheme.colors.textInverse} 15%, transparent);
   `;
 
   const itemLabel = css`
@@ -130,7 +130,7 @@ export const getSuggestWidgetStyles = (euiThemeContext: UseEuiTheme) => {
   `;
 
   const itemKindSelected = css`
-    color: ${transparentize(euiTheme.colors.textInverse, 0.7)};
+    color: color-mix(in srgb, ${euiTheme.colors.textInverse} 70%, transparent);
   `;
 
   const detailsPanel = css`

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/suggest_widget_styles.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/suggest_widget_styles.ts
@@ -236,6 +236,45 @@ export const getSuggestWidgetStyles = (euiThemeContext: UseEuiTheme) => {
     font-style: italic;
   `;
 
+  const keyList = css`
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    background: ${euiTheme.colors.backgroundBaseSubdued};
+    border-radius: ${euiTheme.border.radius.small};
+    padding: 6px 8px;
+  `;
+
+  const keyRow = css`
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: ${euiTheme.size.s};
+    font-family: ${euiTheme.font.familyCode};
+    font-size: 12px;
+    line-height: 1.4;
+  `;
+
+  const keyName = css`
+    color: ${euiTheme.colors.textParagraph};
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  `;
+
+  const keyType = css`
+    color: ${euiTheme.colors.textSubdued};
+    font-size: 11px;
+    flex-shrink: 0;
+  `;
+
+  const keyMore = css`
+    font-size: 11px;
+    color: ${euiTheme.colors.textSubdued};
+    font-style: italic;
+    margin-top: 2px;
+  `;
+
   return {
     container,
     hidden,
@@ -263,5 +302,10 @@ export const getSuggestWidgetStyles = (euiThemeContext: UseEuiTheme) => {
     description,
     defaultValue,
     emptyDetails,
+    keyList,
+    keyRow,
+    keyName,
+    keyType,
+    keyMore,
   };
 };

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/suggest_widget_styles.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/suggest_widget_styles.ts
@@ -1,0 +1,263 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { euiShadow, type UseEuiTheme } from '@elastic/eui';
+import { css } from '@emotion/react';
+
+export const getSuggestWidgetStyles = (euiThemeContext: UseEuiTheme) => {
+  const { euiTheme } = euiThemeContext;
+
+  const container = css`
+    display: flex;
+    background: ${euiTheme.colors.backgroundBasePlain};
+    border: ${euiTheme.border.thin};
+    border-radius: ${euiTheme.border.radius.medium};
+    ${euiShadow(euiThemeContext, 'm')}
+    overflow: hidden;
+    max-height: 340px;
+  `;
+
+  const hidden = css`
+    display: none;
+  `;
+
+  const listPanel = css`
+    width: 320px;
+    display: flex;
+    flex-direction: column;
+    border-right: ${euiTheme.border.thin};
+  `;
+
+  const listHeader = css`
+    padding: ${euiTheme.size.s} ${euiTheme.size.m};
+    font-size: ${euiTheme.size.m};
+    font-weight: ${euiTheme.font.weight.semiBold};
+    color: ${euiTheme.colors.textSubdued};
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    border-bottom: ${euiTheme.border.thin};
+    flex-shrink: 0;
+  `;
+
+  const listScroll = css`
+    overflow-y: auto;
+    flex: 1;
+
+    &::-webkit-scrollbar {
+      width: 6px;
+    }
+    &::-webkit-scrollbar-track {
+      background: transparent;
+    }
+    &::-webkit-scrollbar-thumb {
+      background: ${euiTheme.colors.borderBaseSubdued};
+      border-radius: 3px;
+    }
+  `;
+
+  const listItem = css`
+    padding: 6px ${euiTheme.size.m};
+    display: flex;
+    align-items: center;
+    gap: ${euiTheme.size.s};
+    cursor: pointer;
+    font-size: ${euiTheme.size.m};
+    color: ${euiTheme.colors.textParagraph};
+    line-height: 1.4;
+
+    &:hover {
+      background: ${euiTheme.colors.backgroundBaseSubdued};
+    }
+  `;
+
+  const listItemSelected = css`
+    background: ${euiTheme.colors.primary};
+    color: ${euiTheme.colors.textInverse};
+
+    &:hover {
+      background: ${euiTheme.colors.primary};
+    }
+  `;
+
+  const itemIcon = css`
+    flex-shrink: 0;
+    width: 20px;
+    height: 20px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 11px;
+    font-weight: ${euiTheme.font.weight.bold};
+    color: ${euiTheme.colors.textSubdued};
+    background: ${euiTheme.colors.backgroundBaseSubdued};
+    border-radius: ${euiTheme.border.radius.small};
+    font-family: ${euiTheme.font.familyCode};
+  `;
+
+  const itemIconSelected = css`
+    color: ${euiTheme.colors.textInverse};
+    background: ${transparentize(euiTheme.colors.textInverse, 0.15)};
+  `;
+
+  const itemLabel = css`
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-family: ${euiTheme.font.familyCode};
+    font-size: 12px;
+  `;
+
+  const matchHighlight = css`
+    font-weight: ${euiTheme.font.weight.bold};
+    color: ${euiTheme.colors.warning};
+  `;
+
+  const matchHighlightSelected = css`
+    color: ${euiTheme.colors.textInverse};
+  `;
+
+  const itemKind = css`
+    font-size: 10px;
+    color: ${euiTheme.colors.textSubdued};
+    flex-shrink: 0;
+  `;
+
+  const itemKindSelected = css`
+    color: ${transparentize(euiTheme.colors.textInverse, 0.7)};
+  `;
+
+  const detailsPanel = css`
+    width: 380px;
+    padding: ${euiTheme.size.m} ${euiTheme.size.base};
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: ${euiTheme.size.m};
+
+    &::-webkit-scrollbar {
+      width: 6px;
+    }
+    &::-webkit-scrollbar-track {
+      background: transparent;
+    }
+    &::-webkit-scrollbar-thumb {
+      background: ${euiTheme.colors.borderBaseSubdued};
+      border-radius: 3px;
+    }
+  `;
+
+  const detailContext = css`
+    font-size: 11px;
+    color: ${euiTheme.colors.textSubdued};
+    margin-bottom: 2px;
+  `;
+
+  const detailName = css`
+    font-size: 16px;
+    font-weight: ${euiTheme.font.weight.semiBold};
+    color: ${euiTheme.colors.textParagraph};
+    font-family: ${euiTheme.font.familyCode};
+  `;
+
+  const detailSection = css`
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  `;
+
+  const detailLabel = css`
+    font-size: 11px;
+    font-weight: ${euiTheme.font.weight.semiBold};
+    color: ${euiTheme.colors.textSubdued};
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+  `;
+
+  const typeBadges = css`
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+  `;
+
+  const typeBadge = css`
+    padding: 2px 8px;
+    border-radius: 10px;
+    font-size: 11px;
+    font-weight: ${euiTheme.font.weight.medium};
+    font-family: ${euiTheme.font.familyCode};
+    background: ${euiTheme.colors.backgroundBaseSubdued};
+    color: ${euiTheme.colors.textSubdued};
+  `;
+
+  const requiredYes = css`
+    color: ${euiTheme.colors.danger};
+    font-weight: ${euiTheme.font.weight.semiBold};
+    font-size: 13px;
+  `;
+
+  const requiredNo = css`
+    color: ${euiTheme.colors.textParagraph};
+    font-size: 13px;
+  `;
+
+  const description = css`
+    font-size: 13px;
+    color: ${euiTheme.colors.textSubdued};
+    line-height: 1.5;
+  `;
+
+  const defaultValue = css`
+    font-size: 12px;
+    color: ${euiTheme.colors.textSubdued};
+    font-family: ${euiTheme.font.familyCode};
+    background: ${euiTheme.colors.backgroundBaseSubdued};
+    padding: 4px 8px;
+    border-radius: ${euiTheme.border.radius.small};
+  `;
+
+  const emptyDetails = css`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+    color: ${euiTheme.colors.textDisabled};
+    font-size: 13px;
+    font-style: italic;
+  `;
+
+  return {
+    container,
+    hidden,
+    listPanel,
+    listHeader,
+    listScroll,
+    listItem,
+    listItemSelected,
+    itemIcon,
+    itemIconSelected,
+    itemLabel,
+    matchHighlight,
+    matchHighlightSelected,
+    itemKind,
+    itemKindSelected,
+    detailsPanel,
+    detailContext,
+    detailName,
+    detailSection,
+    detailLabel,
+    typeBadges,
+    typeBadge,
+    requiredYes,
+    requiredNo,
+    description,
+    defaultValue,
+    emptyDetails,
+  };
+};

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/type_helpers.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/type_helpers.test.ts
@@ -1,0 +1,125 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { compactTypeLabel, extractTopLevelKeys, summarizeKeyType } from './type_helpers';
+
+describe('extractTopLevelKeys', () => {
+  it('returns empty for non-object types', () => {
+    expect(extractTopLevelKeys('string')).toEqual([]);
+    expect(extractTopLevelKeys('Array<string>')).toEqual([]);
+    expect(extractTopLevelKeys('')).toEqual([]);
+  });
+
+  it('extracts top-level keys from a flat object literal', () => {
+    expect(extractTopLevelKeys('{ a: string; b: number }')).toEqual([
+      { key: 'a', type: 'string' },
+      { key: 'b', type: 'number' },
+    ]);
+  });
+
+  it('strips optional marker from keys', () => {
+    expect(extractTopLevelKeys('{ a?: string; b: number }')).toEqual([
+      { key: 'a', type: 'string' },
+      { key: 'b', type: 'number' },
+    ]);
+  });
+
+  it('treats nested object as a single value and does not split on inner separators', () => {
+    expect(extractTopLevelKeys('{ a: { nested: string; other: number }; b: boolean }')).toEqual([
+      { key: 'a', type: '{ nested: string; other: number }' },
+      { key: 'b', type: 'boolean' },
+    ]);
+  });
+
+  it('treats generic parameters as a single value', () => {
+    expect(extractTopLevelKeys('{ items: Array<string>; map: Record<string, number> }')).toEqual([
+      { key: 'items', type: 'Array<string>' },
+      { key: 'map', type: 'Record<string, number>' },
+    ]);
+  });
+
+  it('strips a trailing // description suffix after the matching closing brace', () => {
+    expect(
+      extractTopLevelKeys('{ id: string; name: string } // The workflow being executed.')
+    ).toEqual([
+      { key: 'id', type: 'string' },
+      { key: 'name', type: 'string' },
+    ]);
+  });
+
+  it('handles commas as well as semicolons as separators', () => {
+    expect(extractTopLevelKeys('{ a: string, b: number }')).toEqual([
+      { key: 'a', type: 'string' },
+      { key: 'b', type: 'number' },
+    ]);
+  });
+
+  it('returns empty for an unbalanced object', () => {
+    expect(extractTopLevelKeys('{ a: string; b: number')).toEqual([]);
+  });
+
+  it('ignores entries without a colon', () => {
+    expect(extractTopLevelKeys('{ a: string; orphan }')).toEqual([{ key: 'a', type: 'string' }]);
+  });
+});
+
+describe('summarizeKeyType', () => {
+  it('returns "array" for array forms', () => {
+    expect(summarizeKeyType('string[]')).toBe('array');
+    expect(summarizeKeyType('Array<string>')).toBe('array');
+  });
+
+  it('returns "object" for object and record forms', () => {
+    expect(summarizeKeyType('{ a: string }')).toBe('object');
+    expect(summarizeKeyType('Record<string, unknown>')).toBe('object');
+  });
+
+  it('returns the short form verbatim', () => {
+    expect(summarizeKeyType('string')).toBe('string');
+    expect(summarizeKeyType('number')).toBe('number');
+  });
+
+  it('returns the first word for longer forms', () => {
+    expect(summarizeKeyType('SomeExtremelyLongCustomType')).toBe('SomeExtremelyLongCustomType');
+    expect(summarizeKeyType('AVeryVeryLongTypeName<withParam>')).toBe('AVeryVeryLongTypeName');
+  });
+
+  it('returns empty for empty input', () => {
+    expect(summarizeKeyType('')).toBe('');
+    expect(summarizeKeyType('   ')).toBe('');
+  });
+});
+
+describe('compactTypeLabel', () => {
+  it('passes short values through unchanged', () => {
+    expect(compactTypeLabel('string')).toBe('string');
+    expect(compactTypeLabel('{ a: string; b: number }')).toBe('{ a: string; b: number }');
+  });
+
+  it('collapses long object literals to "object"', () => {
+    const long = '{ alpha: string; beta: number; gamma: boolean; delta: string }';
+    expect(compactTypeLabel(long)).toBe('object');
+  });
+
+  it('collapses long array forms to "array"', () => {
+    expect(compactTypeLabel('Array<SomeVeryLongType<With<Many<DeeplyNested<Parameters>>>>>')).toBe(
+      'array'
+    );
+  });
+
+  it('keeps short unions as-is, collapses larger unions to "mixed"', () => {
+    expect(compactTypeLabel('string | number | boolean')).toBe('string | number | boolean');
+    const long = 'LongTypeOne | LongTypeTwo | LongTypeThree | LongTypeFour | AnotherLongType';
+    expect(compactTypeLabel(long)).toBe('mixed');
+  });
+
+  it('collapses multiline types', () => {
+    expect(compactTypeLabel('string\nnumber')).toContain('…');
+  });
+});

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/type_helpers.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/type_helpers.ts
@@ -1,0 +1,103 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export interface ExtractedKey {
+  key: string;
+  type: string;
+}
+
+/**
+ * Pull the first top-level keys and their type hints out of a Zod object-literal
+ * dump like `{ a: string; b: { nested: number }; c: Array<string> }`. The dump
+ * may be followed by a ` // description` suffix which is stripped by finding
+ * the matching closing brace rather than requiring the string to end on `}`.
+ * Bracket depth is tracked so a nested `{...}` or `Array<...>` counts as a
+ * single type value and doesn't split on its internal `;` / `,`.
+ */
+export const extractTopLevelKeys = (type: string): ExtractedKey[] => {
+  const trimmed = type.trim();
+  const openIdx = trimmed.indexOf('{');
+  if (openIdx === -1) return [];
+
+  let depth = 0;
+  let closeIdx = -1;
+  for (let i = openIdx; i < trimmed.length; i++) {
+    const ch = trimmed[i];
+    if (ch === '{') depth++;
+    else if (ch === '}') {
+      depth--;
+      if (depth === 0) {
+        closeIdx = i;
+        break;
+      }
+    }
+  }
+  if (closeIdx === -1) return [];
+
+  const body = trimmed.slice(openIdx + 1, closeIdx);
+  const entries: ExtractedKey[] = [];
+  const pushEntry = (raw: string) => {
+    const colonIdx = raw.indexOf(':');
+    if (colonIdx === -1) return;
+    const key = raw.slice(0, colonIdx).trim().replace(/\?$/, '');
+    const typeStr = raw.slice(colonIdx + 1).trim();
+    if (key) entries.push({ key, type: typeStr });
+  };
+  let bodyDepth = 0;
+  let start = 0;
+  for (let i = 0; i < body.length; i++) {
+    const ch = body[i];
+    if (ch === '{' || ch === '<' || ch === '[' || ch === '(') bodyDepth++;
+    else if (ch === '}' || ch === '>' || ch === ']' || ch === ')') bodyDepth--;
+    else if (bodyDepth === 0 && (ch === ';' || ch === ',')) {
+      pushEntry(body.slice(start, i));
+      start = i + 1;
+    }
+  }
+  pushEntry(body.slice(start));
+  return entries;
+};
+
+/**
+ * Render a single key's type as a compact hint: `string`, `array`, `object`,
+ * or the first word of a longer form (e.g. `Record<string, unknown>` → `Record`).
+ */
+export const summarizeKeyType = (type: string): string => {
+  const t = type.trim();
+  if (!t) return '';
+  if (t.endsWith('[]') || t.startsWith('Array<')) return 'array';
+  if (t.startsWith('{') || t.startsWith('Record<')) return 'object';
+  if (t.length <= 20) return t;
+  const firstWord = t.split(/[<\s|]/)[0];
+  return firstWord || 'mixed';
+};
+
+/**
+ * Collapse long Zod dumps into a short human-readable label for the TYPE pill.
+ * The full Zod rendering adds no signal beyond "this is an object/array/etc."
+ * and drowns the details panel; users who need the exact shape can check the
+ * schema or hover the variable.
+ */
+export const compactTypeLabel = (type: string): string => {
+  const trimmed = type.trim();
+  if (trimmed.length === 0) return trimmed;
+  if (trimmed.length <= 48 && !trimmed.includes('\n')) return trimmed;
+
+  if (trimmed.endsWith('[]') || trimmed.startsWith('Array<')) return 'array';
+  if (trimmed.startsWith('{') || trimmed.startsWith('Record<')) return 'object';
+  if (trimmed.includes(' | ')) {
+    const parts = trimmed
+      .split('|')
+      .map((p) => p.trim())
+      .filter(Boolean);
+    if (parts.length <= 3 && parts.every((p) => p.length < 20)) return parts.join(' | ');
+    return 'mixed';
+  }
+  return `${trimmed.slice(0, 45)}…`;
+};

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/types.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/types.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { type monaco } from '@kbn/monaco';
+
+/** Category of suggestion, used for icon selection and context label. */
+export type SuggestionCategory =
+  | 'connector'
+  | 'step'
+  | 'param'
+  | 'variable'
+  | 'filter'
+  | 'keyword'
+  | 'value'
+  | 'trigger';
+
+/**
+ * A suggestion item enriched with structured metadata for the custom suggest widget.
+ * Carries both the data needed for text insertion (from CompletionItem) and the
+ * structured details panel data (types, required, description) that Monaco's
+ * built-in suggest widget can't render.
+ */
+export interface EnrichedSuggestionItem {
+  /** Display label shown in the suggestion list */
+  label: string;
+  /** Text to insert when accepted */
+  insertText: string;
+  /** Whether insertText is a snippet (contains $1, $2 placeholders) */
+  insertTextRules?: number;
+  /** Monaco completion item kind (for fallback icon mapping) */
+  kind: monaco.languages.CompletionItemKind;
+  /** Replacement range */
+  range: monaco.IRange;
+  /** Text used for filtering (defaults to label if not set) */
+  filterText?: string;
+  /** Text used for sorting */
+  sortText?: string;
+  /** Additional edits to apply alongside the main insertion (e.g., removing @ trigger) */
+  additionalTextEdits?: monaco.languages.CompletionItem['additionalTextEdits'];
+  /** Whether this item should be pre-selected */
+  preselect?: boolean;
+  /** Optional command to execute after acceptance (e.g., create connector) */
+  command?: monaco.languages.Command;
+
+  // ── Enriched metadata (NOT available in standard CompletionItem) ──
+
+  /** Type names for badge rendering, e.g. ['string', 'array'] */
+  types: string[];
+  /** Whether the parameter is required. null = unknown/not applicable */
+  required: boolean | null;
+  /** Human-readable description */
+  description: string;
+  /** Default value as displayable string */
+  defaultValue?: string;
+  /** Usage example */
+  example?: string;
+  /** Suggestion category for icon and context label */
+  category: SuggestionCategory;
+  /** Context label shown above the item name in details panel, e.g. "Elasticsearch.search Parameter" */
+  contextLabel?: string;
+}
+
+/** Payload emitted by the completion provider to the custom suggest widget. */
+export interface SuggestionsPayload {
+  items: EnrichedSuggestionItem[];
+  anchorPosition: { lineNumber: number; column: number };
+  triggerKind: 'auto' | 'manual';
+}

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/types.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/types.ts
@@ -68,6 +68,8 @@ export interface EnrichedSuggestionItem {
 
 /** Payload emitted by the completion provider to the custom suggest widget. */
 export interface SuggestionsPayload {
+  /** URI of the Monaco model the suggestions belong to — subscribers filter on this. */
+  modelUri: string;
   items: EnrichedSuggestionItem[];
   anchorPosition: { lineNumber: number; column: number };
   triggerKind: 'auto' | 'manual';

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/use_custom_suggest_widget.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/use_custom_suggest_widget.ts
@@ -62,6 +62,18 @@ export const useCustomSuggestWidget = (
   }, []);
 
   // ── Show / Hide ──
+  // hideWidget must be defined before showWidget (showWidget calls it)
+
+  const hideWidget = useCallback(() => {
+    if (!ctxKeyRef.current) return;
+
+    isVisibleRef.current = false;
+    anchorPositionRef.current = null;
+    filterTextRef.current = '';
+    ctxKeyRef.current.set(false);
+    clearSuggestions();
+    render();
+  }, [render]);
 
   const showWidget = useCallback(
     (payload: SuggestionsPayload) => {
@@ -74,15 +86,12 @@ export const useCustomSuggestWidget = (
 
       // If widget is already visible on the same line, just update items
       // without resetting position/filter — prevents blinking on re-trigger
-      const alreadyVisible = isVisibleRef.current;
       const sameLine =
-        alreadyVisible &&
+        isVisibleRef.current &&
         anchorPositionRef.current?.lineNumber === payload.anchorPosition.lineNumber;
 
       if (sameLine) {
-        // Update items but keep current filterText and selection
         itemsRef.current = payload.items;
-        // Re-check filter still matches
         const filtered = getFilteredItems(payload.items, filterTextRef.current);
         if (filtered.length === 0) {
           hideWidget();
@@ -123,17 +132,6 @@ export const useCustomSuggestWidget = (
     },
     [editor, render, hideWidget]
   );
-
-  const hideWidget = useCallback(() => {
-    if (!ctxKeyRef.current) return;
-
-    isVisibleRef.current = false;
-    anchorPositionRef.current = null;
-    filterTextRef.current = '';
-    ctxKeyRef.current.set(false);
-    clearSuggestions();
-    render();
-  }, [render]);
 
   // ── Accept suggestion ──
 

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/use_custom_suggest_widget.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/use_custom_suggest_widget.ts
@@ -10,6 +10,7 @@
 import { EuiProvider, useEuiTheme } from '@elastic/eui';
 import React, { useCallback, useEffect, useRef } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
+import { i18n } from '@kbn/i18n';
 import { monaco } from '@kbn/monaco';
 
 import { clearSuggestions, subscribeSuggestions } from './enriched_suggestion_store';
@@ -71,22 +72,31 @@ export const useCustomSuggestWidget = (
   }, []);
 
   // ── Hide ──
+  //
+  // preserve=true soft-hides: visibility goes false but anchor/items/filter are
+  // kept so subsequent edits (typically a backspace into a matching prefix) can
+  // re-show the widget without requiring a fresh trigger.
+  const hideWidget = useCallback(
+    (opts?: { preserve?: boolean }) => {
+      if (!ctxKeyRef.current) return;
 
-  const hideWidget = useCallback(() => {
-    if (!ctxKeyRef.current) return;
+      isVisibleRef.current = false;
+      ctxKeyRef.current.set(false);
+      render();
 
-    isVisibleRef.current = false;
-    anchorPositionRef.current = null;
-    filterTextRef.current = '';
-    ctxKeyRef.current.set(false);
-    clearSuggestions();
-    render();
+      (
+        editorRef.current as { setAriaOptions?: (opts: Record<string, unknown>) => void }
+      )?.setAriaOptions?.({ activeDescendant: undefined });
 
-    // Clear aria active descendant (setAriaOptions is available on internal editor API)
-    (
-      editorRef.current as { setAriaOptions?: (opts: Record<string, unknown>) => void }
-    )?.setAriaOptions?.({ activeDescendant: undefined });
-  }, [render]);
+      if (!opts?.preserve) {
+        anchorPositionRef.current = null;
+        filterTextRef.current = '';
+        itemsRef.current = [];
+        clearSuggestions();
+      }
+    },
+    [render]
+  );
 
   // ── Show ──
 
@@ -267,116 +277,142 @@ export const useCustomSuggestWidget = (
     ctxKeyRef.current = ctxKey;
 
     // ── Keybindings ──
-    // Use addCommand for Enter/Tab (these conflict with the `type` command path).
-    // addCommand with a context string doesn't add `editorId` scoping, making it
-    // simpler and more reliable than addAction for keys that go through the `type` path.
+    // All keybindings go through addAction so they return IDisposable and are
+    // cleaned up on unmount. The `precondition` gates on the context key so
+    // default Monaco handlers (Enter/Tab type, Escape exit-edit-mode) stay
+    // active when the widget is hidden.
+    const addKeyAction = (
+      id: string,
+      label: string,
+      keybindings: number[],
+      run: () => void
+    ): void => {
+      disposablesRef.current.push(
+        editor.addAction({ id, label, precondition: CONTEXT_KEY, keybindings, run })
+      );
+    };
 
-    const enterCmdId = editor.addCommand(
-      monaco.KeyCode.Enter,
-      () => acceptSuggestion(),
-      CONTEXT_KEY
+    addKeyAction(
+      'customSuggest.accept',
+      i18n.translate('workflows.yamlEditor.suggest.accept', {
+        defaultMessage: 'Accept suggestion',
+      }),
+      [monaco.KeyCode.Enter],
+      () => acceptSuggestion()
     );
-    if (enterCmdId) disposablesRef.current.push({ dispose: () => {} });
-
-    const tabCmdId = editor.addCommand(monaco.KeyCode.Tab, () => acceptSuggestion(), CONTEXT_KEY);
-    if (tabCmdId) disposablesRef.current.push({ dispose: () => {} });
-
-    const escapeCmdId = editor.addCommand(monaco.KeyCode.Escape, () => hideWidget(), CONTEXT_KEY);
-    if (escapeCmdId) disposablesRef.current.push({ dispose: () => {} });
-
-    // Use addAction for arrow keys (these don't conflict with the `type` command)
+    addKeyAction(
+      'customSuggest.acceptTab',
+      i18n.translate('workflows.yamlEditor.suggest.acceptTab', {
+        defaultMessage: 'Accept suggestion (Tab)',
+      }),
+      [monaco.KeyCode.Tab],
+      () => acceptSuggestion()
+    );
+    // Escape is handled via onKeyDown rather than addAction: the shared CodeEditor
+    // wrapper listens on onKeyDown and exits edit mode on ESC. Our addAction fires
+    // through a separate pipeline, so the wrapper runs first and stopPropagation
+    // prevents our handler from firing. Intercepting in onKeyDown lets us
+    // preventDefault + stopPropagation before the wrapper decides to exit edit mode.
     disposablesRef.current.push(
-      editor.addAction({
-        id: 'customSuggest.selectPrevious',
-        label: 'Custom Suggest: Select Previous',
-        precondition: CONTEXT_KEY,
-        keybindings: [monaco.KeyCode.UpArrow],
-        run: () => {
-          selectedIndexRef.current = Math.max(0, selectedIndexRef.current - 1);
-          render();
-        },
+      editor.onKeyDown((e) => {
+        if (e.keyCode !== monaco.KeyCode.Escape) return;
+        if (!isVisibleRef.current && !anchorPositionRef.current) return;
+        e.preventDefault();
+        e.stopPropagation();
+        hideWidget();
       })
     );
-
-    disposablesRef.current.push(
-      editor.addAction({
-        id: 'customSuggest.selectNext',
-        label: 'Custom Suggest: Select Next',
-        precondition: CONTEXT_KEY,
-        keybindings: [monaco.KeyCode.DownArrow],
-        run: () => {
-          const filtered = getFilteredItems(itemsRef.current, filterTextRef.current);
-          selectedIndexRef.current = Math.min(filtered.length - 1, selectedIndexRef.current + 1);
-          render();
-        },
-      })
+    addKeyAction(
+      'customSuggest.selectPrevious',
+      i18n.translate('workflows.yamlEditor.suggest.selectPrevious', {
+        defaultMessage: 'Select previous suggestion',
+      }),
+      [monaco.KeyCode.UpArrow],
+      () => {
+        selectedIndexRef.current = Math.max(0, selectedIndexRef.current - 1);
+        render();
+      }
     );
-
-    disposablesRef.current.push(
-      editor.addAction({
-        id: 'customSuggest.pageUp',
-        label: 'Custom Suggest: Page Up',
-        precondition: CONTEXT_KEY,
-        keybindings: [monaco.KeyCode.PageUp],
-        run: () => {
-          selectedIndexRef.current = Math.max(0, selectedIndexRef.current - 8);
-          render();
-        },
-      })
+    addKeyAction(
+      'customSuggest.selectNext',
+      i18n.translate('workflows.yamlEditor.suggest.selectNext', {
+        defaultMessage: 'Select next suggestion',
+      }),
+      [monaco.KeyCode.DownArrow],
+      () => {
+        const filtered = getFilteredItems(itemsRef.current, filterTextRef.current);
+        selectedIndexRef.current = Math.min(filtered.length - 1, selectedIndexRef.current + 1);
+        render();
+      }
     );
-
-    disposablesRef.current.push(
-      editor.addAction({
-        id: 'customSuggest.pageDown',
-        label: 'Custom Suggest: Page Down',
-        precondition: CONTEXT_KEY,
-        keybindings: [monaco.KeyCode.PageDown],
-        run: () => {
-          const filtered = getFilteredItems(itemsRef.current, filterTextRef.current);
-          selectedIndexRef.current = Math.min(filtered.length - 1, selectedIndexRef.current + 8);
-          render();
-        },
-      })
+    addKeyAction(
+      'customSuggest.pageUp',
+      i18n.translate('workflows.yamlEditor.suggest.pageUp', {
+        defaultMessage: 'Page up in suggestions',
+      }),
+      [monaco.KeyCode.PageUp],
+      () => {
+        selectedIndexRef.current = Math.max(0, selectedIndexRef.current - 8);
+        render();
+      }
     );
-
-    // NOTE: No addKeybindingRules with command:null — they shadow the addCommand handlers
+    addKeyAction(
+      'customSuggest.pageDown',
+      i18n.translate('workflows.yamlEditor.suggest.pageDown', {
+        defaultMessage: 'Page down in suggestions',
+      }),
+      [monaco.KeyCode.PageDown],
+      () => {
+        const filtered = getFilteredItems(itemsRef.current, filterTextRef.current);
+        selectedIndexRef.current = Math.min(filtered.length - 1, selectedIndexRef.current + 8);
+        render();
+      }
+    );
 
     // ── Filter text tracking via onDidChangeModelContent ──
+    //
+    // Derive filter text from the live anchor→cursor range rather than diffing
+    // change events: one source of truth, and it keeps working across paste,
+    // IME composition, and programmatic edits. While the anchor is set we also
+    // process changes when the widget is soft-hidden, so typing into a new
+    // matching prefix (e.g. backspacing after a typo) reopens the widget.
 
     disposablesRef.current.push(
-      editor.onDidChangeModelContent((e) => {
-        if (!isVisibleRef.current || isAcceptingRef.current) return;
+      editor.onDidChangeModelContent(() => {
+        if (isAcceptingRef.current) return;
+        const anchor = anchorPositionRef.current;
+        if (!anchor) return;
 
-        for (const change of e.changes) {
-          if (change.text.length > 0 && change.rangeLength === 0) {
-            filterTextRef.current += change.text;
-          } else if (change.text.length === 0 && change.rangeLength > 0) {
-            filterTextRef.current = filterTextRef.current.slice(
-              0,
-              Math.max(0, filterTextRef.current.length - change.rangeLength)
-            );
-          } else if (change.text.length > 0 && change.rangeLength > 0) {
-            filterTextRef.current = filterTextRef.current.slice(
-              0,
-              Math.max(0, filterTextRef.current.length - change.rangeLength)
-            );
-            filterTextRef.current += change.text;
-          }
+        const pos = editor.getPosition();
+        const model = editor.getModel();
+        if (!pos || !model || pos.lineNumber !== anchor.lineNumber) {
+          hideWidget();
+          return;
+        }
+        if (pos.column < anchor.column) {
+          hideWidget();
+          return;
         }
 
+        filterTextRef.current = model.getValueInRange({
+          startLineNumber: anchor.lineNumber,
+          startColumn: anchor.column,
+          endLineNumber: pos.lineNumber,
+          endColumn: pos.column,
+        });
         selectedIndexRef.current = 0;
 
         const filtered = getFilteredItems(itemsRef.current, filterTextRef.current);
         if (filtered.length === 0) {
-          hideWidget();
+          // Soft hide — keep anchor/items so further editing can restore.
+          hideWidget({ preserve: true });
           return;
         }
 
-        if (filterTextRef.current.length === 0 && e.changes.some((c) => c.rangeLength > 0)) {
-          hideWidget();
-          return;
+        if (!isVisibleRef.current) {
+          isVisibleRef.current = true;
+          ctxKeyRef.current?.set(true);
         }
-
         render();
       })
     );
@@ -385,11 +421,8 @@ export const useCustomSuggestWidget = (
 
     disposablesRef.current.push(
       editor.onDidChangeCursorPosition((e) => {
-        if (!isVisibleRef.current) return;
-        if (
-          anchorPositionRef.current &&
-          e.position.lineNumber !== anchorPositionRef.current.lineNumber
-        ) {
+        if (!anchorPositionRef.current) return;
+        if (e.position.lineNumber !== anchorPositionRef.current.lineNumber) {
           hideWidget();
         }
       })
@@ -399,7 +432,7 @@ export const useCustomSuggestWidget = (
 
     disposablesRef.current.push(
       editor.onMouseDown(() => {
-        if (isVisibleRef.current) {
+        if (isVisibleRef.current || anchorPositionRef.current) {
           hideWidget();
         }
       })
@@ -416,8 +449,13 @@ export const useCustomSuggestWidget = (
     );
 
     // ── Subscribe to enriched suggestions from the completion provider ──
-
+    //
+    // The emitter is a module-level singleton that may receive payloads from
+    // other workflow editor instances; filter by modelUri so each editor only
+    // reacts to its own suggestions.
+    const ownModelUri = editor.getModel()?.uri.toString();
     const unsubscribe = subscribeSuggestions((payload) => {
+      if (ownModelUri && payload.modelUri !== ownModelUri) return;
       showWidget(payload);
     });
 

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/use_custom_suggest_widget.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/use_custom_suggest_widget.ts
@@ -18,6 +18,15 @@ import { getFilteredItems } from './suggest_list_panel';
 import { type SuggestWidgetHandle, SuggestWidgetRoot } from './suggest_widget_root';
 import type { EnrichedSuggestionItem, SuggestionsPayload } from './types';
 
+const CONTEXT_KEY = 'customSuggestWidgetVisible';
+
+/**
+ * Strip snippet placeholders for plain-text insertion.
+ * ${1:default} → default, $1 → '', $0 → ''
+ */
+const stripSnippetPlaceholders = (text: string): string =>
+  text.replace(/\$\{\d+:([^}]*)\}/g, '$1').replace(/\$\d+/g, '');
+
 /**
  * Hook that manages the custom suggest widget lifecycle.
  *
@@ -31,12 +40,10 @@ export const useCustomSuggestWidget = (
   editor: monaco.editor.IStandaloneCodeEditor | null,
   isEditorMounted: boolean
 ): void => {
-  // Inherit color mode from the parent app's EUI context
   const { colorMode } = useEuiTheme();
   const colorModeRef = useRef(colorMode);
   colorModeRef.current = colorMode;
 
-  // Mutable state refs (not React state — we render imperatively via root.render)
   const widgetRef = useRef<SuggestContentWidget | null>(null);
   const rootRef = useRef<Root | null>(null);
   const handleRef = useRef<SuggestWidgetHandle | null>(null);
@@ -49,8 +56,10 @@ export const useCustomSuggestWidget = (
   const anchorPositionRef = useRef<{ lineNumber: number; column: number } | null>(null);
   const isVisibleRef = useRef(false);
   const isAcceptingRef = useRef(false);
+  const editorRef = useRef(editor);
+  editorRef.current = editor;
 
-  // ── Update widget state via imperative handle (no root.render() per keystroke) ──
+  // ── Update widget state via imperative handle ──
 
   const render = useCallback(() => {
     handleRef.current?.update({
@@ -61,8 +70,7 @@ export const useCustomSuggestWidget = (
     });
   }, []);
 
-  // ── Show / Hide ──
-  // hideWidget must be defined before showWidget (showWidget calls it)
+  // ── Hide ──
 
   const hideWidget = useCallback(() => {
     if (!ctxKeyRef.current) return;
@@ -73,19 +81,22 @@ export const useCustomSuggestWidget = (
     ctxKeyRef.current.set(false);
     clearSuggestions();
     render();
+
+    // Clear aria active descendant
+    editorRef.current?.setAriaOptions?.({ activeDescendant: undefined } as never);
   }, [render]);
+
+  // ── Show ──
 
   const showWidget = useCallback(
     (payload: SuggestionsPayload) => {
       if (!editor || !widgetRef.current || !ctxKeyRef.current) return;
       if (payload.items.length === 0) {
-        // Provider returned empty — hide if visible
         if (isVisibleRef.current) hideWidget();
         return;
       }
 
-      // If widget is already visible on the same line, just update items
-      // without resetting position/filter — prevents blinking on re-trigger
+      // If already visible on same line, update items without reset (prevents blink)
       const sameLine =
         isVisibleRef.current &&
         anchorPositionRef.current?.lineNumber === payload.anchorPosition.lineNumber;
@@ -101,23 +112,21 @@ export const useCustomSuggestWidget = (
         return;
       }
 
-      // Fresh show — new line or first trigger
+      // Fresh show
       itemsRef.current = payload.items;
       selectedIndexRef.current = 0;
       anchorPositionRef.current = payload.anchorPosition;
 
-      // Compute initial filterText: the user may have typed characters between
-      // the async provider trigger and this callback.
+      // Compute initial filterText from anchor to current cursor (async gap)
       const pos = editor.getPosition();
       const model = editor.getModel();
       if (pos && model && pos.lineNumber === payload.anchorPosition.lineNumber) {
-        const typed = model.getValueInRange({
+        filterTextRef.current = model.getValueInRange({
           startLineNumber: pos.lineNumber,
           startColumn: payload.anchorPosition.column,
           endLineNumber: pos.lineNumber,
           endColumn: pos.column,
         });
-        filterTextRef.current = typed;
       } else {
         filterTextRef.current = '';
       }
@@ -147,19 +156,54 @@ export const useCustomSuggestWidget = (
     const pos = editor.getPosition();
     if (!pos) return;
 
-    const startCol = anchorPositionRef.current?.column ?? pos.column - filterTextRef.current.length;
-    const range = new monaco.Range(pos.lineNumber, startCol, pos.lineNumber, pos.column);
-
-    // Suppress onDidChangeModelContent handler during acceptance
     isAcceptingRef.current = true;
     hideWidget();
 
-    // Strip snippet placeholders ($1, $2, ${1:default}, $0) for plain text insertion.
-    // Kibana's Monaco build doesn't include the snippetController contribution,
-    // so editor.action.insertSnippet is not available.
-    const plainText = item.insertText.replace(/\$\{\d+(?::([^}]*))?\}|\$\d+/g, '$1');
+    // Use the completion item's range for correct replacement.
+    // The range specifies what text to replace (e.g., the word being typed).
+    // Adjust endColumn to current cursor to account for typed characters.
+    const itemRange = item.range;
+    const range = new monaco.Range(
+      itemRange.startLineNumber,
+      itemRange.startColumn,
+      pos.lineNumber,
+      pos.column
+    );
 
-    editor.executeEdits('custom-suggest', [{ range, text: plainText, forceMoveMarkers: true }]);
+    // Try snippetController2 for snippet insertions (it IS loaded in Kibana,
+    // unlike the editor.action.insertSnippet action which requires a separate contribution)
+    const isSnippet =
+      item.insertTextRules !== undefined &&
+      // eslint-disable-next-line no-bitwise
+      (item.insertTextRules & monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet) !== 0;
+
+    const snippetController = editor.getContribution('snippetController2') as {
+      insert?: (
+        template: string,
+        opts?: {
+          overwriteBefore?: number;
+          overwriteAfter?: number;
+          undoStopBefore?: boolean;
+          undoStopAfter?: boolean;
+          adjustWhitespace?: boolean;
+        }
+      ) => void;
+    } | null;
+
+    if (isSnippet && snippetController?.insert) {
+      const overwriteBefore = pos.column - itemRange.startColumn;
+      snippetController.insert(item.insertText, {
+        overwriteBefore,
+        overwriteAfter: 0,
+        undoStopBefore: true,
+        undoStopAfter: true,
+        adjustWhitespace: true,
+      });
+    } else {
+      // Plain text — strip any snippet placeholders just in case
+      const plainText = isSnippet ? stripSnippetPlaceholders(item.insertText) : item.insertText;
+      editor.executeEdits('custom-suggest', [{ range, text: plainText, forceMoveMarkers: true }]);
+    }
 
     // Apply additional text edits (e.g., removing @ trigger character)
     if (item.additionalTextEdits?.length) {
@@ -190,8 +234,7 @@ export const useCustomSuggestWidget = (
     const widget = new SuggestContentWidget(editor);
     widgetRef.current = widget;
 
-    // Create React root on the inner node — render once with EuiProvider + SuggestWidgetRoot.
-    // Subsequent updates go through the imperative handle (no root.render per keystroke).
+    // Create React root — EuiProvider is created once, updates go through handle
     const root = createRoot(widget.getInnerNode());
     rootRef.current = root;
 
@@ -217,17 +260,34 @@ export const useCustomSuggestWidget = (
       )
     );
 
-    // Create context key for conditional keybindings
-    const ctxKey = editor.createContextKey('customSuggestWidgetVisible', false);
+    // Context key for conditional keybindings
+    const ctxKey = editor.createContextKey(CONTEXT_KEY, false);
     ctxKeyRef.current = ctxKey;
 
-    // ── Register keybindings via addAction (precondition-gated) ──
+    // ── Keybindings ──
+    // Use addCommand for Enter/Tab (these conflict with the `type` command path).
+    // addCommand with a context string doesn't add `editorId` scoping, making it
+    // simpler and more reliable than addAction for keys that go through the `type` path.
 
+    const enterCmdId = editor.addCommand(
+      monaco.KeyCode.Enter,
+      () => acceptSuggestion(),
+      CONTEXT_KEY
+    );
+    if (enterCmdId) disposablesRef.current.push({ dispose: () => {} });
+
+    const tabCmdId = editor.addCommand(monaco.KeyCode.Tab, () => acceptSuggestion(), CONTEXT_KEY);
+    if (tabCmdId) disposablesRef.current.push({ dispose: () => {} });
+
+    const escapeCmdId = editor.addCommand(monaco.KeyCode.Escape, () => hideWidget(), CONTEXT_KEY);
+    if (escapeCmdId) disposablesRef.current.push({ dispose: () => {} });
+
+    // Use addAction for arrow keys (these don't conflict with the `type` command)
     disposablesRef.current.push(
       editor.addAction({
         id: 'customSuggest.selectPrevious',
         label: 'Custom Suggest: Select Previous',
-        precondition: 'customSuggestWidgetVisible',
+        precondition: CONTEXT_KEY,
         keybindings: [monaco.KeyCode.UpArrow],
         run: () => {
           selectedIndexRef.current = Math.max(0, selectedIndexRef.current - 1);
@@ -240,7 +300,7 @@ export const useCustomSuggestWidget = (
       editor.addAction({
         id: 'customSuggest.selectNext',
         label: 'Custom Suggest: Select Next',
-        precondition: 'customSuggestWidgetVisible',
+        precondition: CONTEXT_KEY,
         keybindings: [monaco.KeyCode.DownArrow],
         run: () => {
           const filtered = getFilteredItems(itemsRef.current, filterTextRef.current);
@@ -252,33 +312,9 @@ export const useCustomSuggestWidget = (
 
     disposablesRef.current.push(
       editor.addAction({
-        id: 'customSuggest.accept',
-        label: 'Custom Suggest: Accept',
-        precondition: 'customSuggestWidgetVisible',
-        keybindings: [monaco.KeyCode.Enter, monaco.KeyCode.Tab],
-        run: () => {
-          acceptSuggestion();
-        },
-      })
-    );
-
-    disposablesRef.current.push(
-      editor.addAction({
-        id: 'customSuggest.dismiss',
-        label: 'Custom Suggest: Dismiss',
-        precondition: 'customSuggestWidgetVisible',
-        keybindings: [monaco.KeyCode.Escape],
-        run: () => {
-          hideWidget();
-        },
-      })
-    );
-
-    disposablesRef.current.push(
-      editor.addAction({
         id: 'customSuggest.pageUp',
         label: 'Custom Suggest: Page Up',
-        precondition: 'customSuggestWidgetVisible',
+        precondition: CONTEXT_KEY,
         keybindings: [monaco.KeyCode.PageUp],
         run: () => {
           selectedIndexRef.current = Math.max(0, selectedIndexRef.current - 8);
@@ -291,7 +327,7 @@ export const useCustomSuggestWidget = (
       editor.addAction({
         id: 'customSuggest.pageDown',
         label: 'Custom Suggest: Page Down',
-        precondition: 'customSuggestWidgetVisible',
+        precondition: CONTEXT_KEY,
         keybindings: [monaco.KeyCode.PageDown],
         run: () => {
           const filtered = getFilteredItems(itemsRef.current, filterTextRef.current);
@@ -301,27 +337,7 @@ export const useCustomSuggestWidget = (
       })
     );
 
-    // ── Suppress built-in suggest keybindings when our widget is visible ──
-
-    disposablesRef.current.push(
-      monaco.editor.addKeybindingRules([
-        {
-          keybinding: monaco.KeyCode.Enter,
-          command: null,
-          when: 'customSuggestWidgetVisible && !suggestWidgetVisible',
-        },
-        {
-          keybinding: monaco.KeyCode.Tab,
-          command: null,
-          when: 'customSuggestWidgetVisible && !suggestWidgetVisible',
-        },
-        {
-          keybinding: monaco.KeyCode.Escape,
-          command: null,
-          when: 'customSuggestWidgetVisible && !suggestWidgetVisible',
-        },
-      ])
-    );
+    // NOTE: No addKeybindingRules with command:null — they shadow the addCommand handlers
 
     // ── Filter text tracking via onDidChangeModelContent ──
 
@@ -331,16 +347,13 @@ export const useCustomSuggestWidget = (
 
         for (const change of e.changes) {
           if (change.text.length > 0 && change.rangeLength === 0) {
-            // Insertion
             filterTextRef.current += change.text;
           } else if (change.text.length === 0 && change.rangeLength > 0) {
-            // Deletion
             filterTextRef.current = filterTextRef.current.slice(
               0,
               Math.max(0, filterTextRef.current.length - change.rangeLength)
             );
           } else if (change.text.length > 0 && change.rangeLength > 0) {
-            // Replacement
             filterTextRef.current = filterTextRef.current.slice(
               0,
               Math.max(0, filterTextRef.current.length - change.rangeLength)
@@ -351,14 +364,12 @@ export const useCustomSuggestWidget = (
 
         selectedIndexRef.current = 0;
 
-        // Check if there are still matching items
         const filtered = getFilteredItems(itemsRef.current, filterTextRef.current);
         if (filtered.length === 0) {
           hideWidget();
           return;
         }
 
-        // Dismiss if filter emptied from backspace
         if (filterTextRef.current.length === 0 && e.changes.some((c) => c.rangeLength > 0)) {
           hideWidget();
           return;
@@ -382,7 +393,7 @@ export const useCustomSuggestWidget = (
       })
     );
 
-    // ── Dismiss on mouse click in editor ──
+    // ── Dismiss on mouse click in editor (but not on widget) ──
 
     disposablesRef.current.push(
       editor.onMouseDown(() => {

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/use_custom_suggest_widget.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/use_custom_suggest_widget.ts
@@ -7,16 +7,15 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { EuiProvider, useEuiTheme } from '@elastic/eui';
-import React, { useCallback, useEffect, useRef } from 'react';
-import { createRoot, type Root } from 'react-dom/client';
-import { i18n } from '@kbn/i18n';
+import { useEuiTheme } from '@elastic/eui';
+import { useCallback, useEffect, useRef } from 'react';
 import { monaco } from '@kbn/monaco';
 
+import { planAcceptRange, toMonacoEdits } from './accept_range';
 import { clearSuggestions, subscribeSuggestions } from './enriched_suggestion_store';
-import { SuggestContentWidget } from './suggest_content_widget';
+import { type MountedSuggestWidget, mountSuggestWidget } from './mount_widget_react';
+import { registerKeybindings } from './register_keybindings';
 import { getFilteredItems } from './suggest_list_panel';
-import { type SuggestWidgetHandle, SuggestWidgetRoot } from './suggest_widget_root';
 import type { EnrichedSuggestionItem, SuggestionsPayload } from './types';
 
 const CONTEXT_KEY = 'customSuggestWidgetVisible';
@@ -31,9 +30,11 @@ const stripSnippetPlaceholders = (text: string): string =>
 /**
  * Hook that manages the custom suggest widget lifecycle.
  *
- * Creates an IContentWidget, registers context keys and keybindings,
- * subscribes to the enriched suggestion store, and renders a React
- * component into the widget's DOM node.
+ * Orchestrates three separated concerns:
+ *  - `mountSuggestWidget` creates the IContentWidget + React root.
+ *  - `registerKeybindings` wires Enter/Tab/Arrow/PgUp/PgDn/Escape.
+ *  - `planAcceptRange` folds additionalTextEdits into the main edit so
+ *    accepting after an `@` trigger cleans up the trigger character.
  *
  * Only used in the workflow YAML editor — other Monaco consumers are unaffected.
  */
@@ -45,9 +46,7 @@ export const useCustomSuggestWidget = (
   const colorModeRef = useRef(colorMode);
   colorModeRef.current = colorMode;
 
-  const widgetRef = useRef<SuggestContentWidget | null>(null);
-  const rootRef = useRef<Root | null>(null);
-  const handleRef = useRef<SuggestWidgetHandle | null>(null);
+  const mountedRef = useRef<MountedSuggestWidget | null>(null);
   const ctxKeyRef = useRef<monaco.editor.IContextKey<boolean> | null>(null);
   const disposablesRef = useRef<monaco.IDisposable[]>([]);
 
@@ -60,10 +59,8 @@ export const useCustomSuggestWidget = (
   const editorRef = useRef(editor);
   editorRef.current = editor;
 
-  // ── Update widget state via imperative handle ──
-
   const render = useCallback(() => {
-    handleRef.current?.update({
+    mountedRef.current?.getHandle()?.update({
       items: itemsRef.current,
       filterText: filterTextRef.current,
       selectedIndex: selectedIndexRef.current,
@@ -71,8 +68,6 @@ export const useCustomSuggestWidget = (
     });
   }, []);
 
-  // ── Hide ──
-  //
   // preserve=true soft-hides: visibility goes false but anchor/items/filter are
   // kept so subsequent edits (typically a backspace into a matching prefix) can
   // re-show the widget without requiring a fresh trigger.
@@ -98,11 +93,9 @@ export const useCustomSuggestWidget = (
     [render]
   );
 
-  // ── Show ──
-
   const showWidget = useCallback(
     (payload: SuggestionsPayload) => {
-      if (!editor || !widgetRef.current || !ctxKeyRef.current) return;
+      if (!editor || !mountedRef.current || !ctxKeyRef.current) return;
       if (payload.items.length === 0) {
         if (isVisibleRef.current) hideWidget();
         return;
@@ -124,7 +117,6 @@ export const useCustomSuggestWidget = (
         return;
       }
 
-      // Fresh show
       itemsRef.current = payload.items;
       selectedIndexRef.current = 0;
       anchorPositionRef.current = payload.anchorPosition;
@@ -148,13 +140,11 @@ export const useCustomSuggestWidget = (
 
       isVisibleRef.current = true;
       ctxKeyRef.current.set(true);
-      widgetRef.current.setAnchorPosition(payload.anchorPosition);
+      mountedRef.current.widget.setAnchorPosition(payload.anchorPosition);
       render();
     },
     [editor, render, hideWidget]
   );
-
-  // ── Accept suggestion ──
 
   const acceptSuggestion = useCallback(() => {
     if (!editor) return;
@@ -171,41 +161,8 @@ export const useCustomSuggestWidget = (
     isAcceptingRef.current = true;
     hideWidget();
 
-    // Main replacement range: from the item's startColumn through the current cursor.
-    const itemRange = item.range;
-    const mainRange = new monaco.Range(
-      itemRange.startLineNumber,
-      itemRange.startColumn,
-      pos.lineNumber,
-      pos.column
-    );
-
-    // Fold same-line adjacent additionalTextEdits (e.g., removing the @ trigger)
-    // into the main range so the insertion is one coherent transaction. Applying
-    // them as a second executeEdits breaks because the second call's coordinates
-    // don't compose with the first — leaving stray trigger chars like "@workflow".
-    let unionRange = mainRange;
-    const nonAdjacentEdits: Array<{ range: monaco.IRange; text: string }> = [];
-    for (const edit of item.additionalTextEdits ?? []) {
-      const r = monaco.Range.lift(edit.range);
-      const text = edit.text ?? '';
-      const adjacent =
-        r.startLineNumber === mainRange.startLineNumber &&
-        r.endLineNumber === mainRange.endLineNumber &&
-        text === '' &&
-        r.endColumn >= unionRange.startColumn &&
-        r.startColumn <= unionRange.endColumn;
-      if (adjacent) {
-        unionRange = new monaco.Range(
-          unionRange.startLineNumber,
-          Math.min(unionRange.startColumn, r.startColumn),
-          unionRange.endLineNumber,
-          Math.max(unionRange.endColumn, r.endColumn)
-        );
-      } else {
-        nonAdjacentEdits.push({ range: r, text });
-      }
-    }
+    const plan = planAcceptRange(item.range, pos, item.additionalTextEdits);
+    const { mainRange: unionRange, nonAdjacent } = toMonacoEdits(plan, monaco);
 
     const isSnippet =
       item.insertTextRules !== undefined &&
@@ -242,10 +199,10 @@ export const useCustomSuggestWidget = (
       ]);
     }
 
-    if (nonAdjacentEdits.length) {
+    if (nonAdjacent.length) {
       editor.executeEdits(
         'custom-suggest-additional',
-        nonAdjacentEdits.map((e) => ({ range: e.range, text: e.text, forceMoveMarkers: true }))
+        nonAdjacent.map((e) => ({ range: e.range, text: e.text, forceMoveMarkers: true }))
       );
     }
 
@@ -258,146 +215,59 @@ export const useCustomSuggestWidget = (
     editor.focus();
   }, [editor, hideWidget]);
 
-  // ── Setup effect ──
-
   useEffect(() => {
     if (!editor || !isEditorMounted) return;
 
-    // Create the IContentWidget
-    const widget = new SuggestContentWidget(editor);
-    widgetRef.current = widget;
+    const mounted = mountSuggestWidget(editor, {
+      colorMode: colorModeRef.current === 'DARK' ? 'dark' : 'light',
+      onSelect: (index: number) => {
+        selectedIndexRef.current = index;
+        render();
+      },
+      onAccept: (index: number) => {
+        selectedIndexRef.current = index;
+        acceptSuggestion();
+      },
+    });
+    mountedRef.current = mounted;
 
-    // Create React root — EuiProvider is created once, updates go through handle
-    const root = createRoot(widget.getInnerNode());
-    rootRef.current = root;
-
-    const refCallback = (handle: SuggestWidgetHandle | null) => {
-      handleRef.current = handle;
-    };
-
-    root.render(
-      React.createElement(
-        EuiProvider,
-        { colorMode: colorModeRef.current === 'DARK' ? 'dark' : 'light' },
-        React.createElement(SuggestWidgetRoot, {
-          ref: refCallback,
-          onSelect: (index: number) => {
-            selectedIndexRef.current = index;
-            render();
-          },
-          onAccept: (index: number) => {
-            selectedIndexRef.current = index;
-            acceptSuggestion();
-          },
-        })
-      )
-    );
-
-    // Context key for conditional keybindings
     const ctxKey = editor.createContextKey(CONTEXT_KEY, false);
     ctxKeyRef.current = ctxKey;
 
-    // ── Keybindings ──
-    // All keybindings go through addAction so they return IDisposable and are
-    // cleaned up on unmount. The `precondition` gates on the context key so
-    // default Monaco handlers (Enter/Tab type, Escape exit-edit-mode) stay
-    // active when the widget is hidden.
-    const addKeyAction = (
-      id: string,
-      label: string,
-      keybindings: number[],
-      run: () => void
-    ): void => {
-      disposablesRef.current.push(
-        editor.addAction({ id, label, precondition: CONTEXT_KEY, keybindings, run })
-      );
-    };
-
-    addKeyAction(
-      'customSuggest.accept',
-      i18n.translate('workflows.yamlEditor.suggest.accept', {
-        defaultMessage: 'Accept suggestion',
-      }),
-      [monaco.KeyCode.Enter],
-      () => acceptSuggestion()
-    );
-    addKeyAction(
-      'customSuggest.acceptTab',
-      i18n.translate('workflows.yamlEditor.suggest.acceptTab', {
-        defaultMessage: 'Accept suggestion (Tab)',
-      }),
-      [monaco.KeyCode.Tab],
-      () => acceptSuggestion()
-    );
-    // Escape is handled via onKeyDown rather than addAction: the shared CodeEditor
-    // wrapper listens on onKeyDown and exits edit mode on ESC. Our addAction fires
-    // through a separate pipeline, so the wrapper runs first and stopPropagation
-    // prevents our handler from firing. Intercepting in onKeyDown lets us
-    // preventDefault + stopPropagation before the wrapper decides to exit edit mode.
     disposablesRef.current.push(
-      editor.onKeyDown((e) => {
-        if (e.keyCode !== monaco.KeyCode.Escape) return;
-        if (!isVisibleRef.current && !anchorPositionRef.current) return;
-        e.preventDefault();
-        e.stopPropagation();
-        hideWidget();
+      ...registerKeybindings(editor, CONTEXT_KEY, {
+        accept: acceptSuggestion,
+        selectPrevious: () => {
+          selectedIndexRef.current = Math.max(0, selectedIndexRef.current - 1);
+          render();
+        },
+        selectNext: () => {
+          const filtered = getFilteredItems(itemsRef.current, filterTextRef.current);
+          selectedIndexRef.current = Math.min(filtered.length - 1, selectedIndexRef.current + 1);
+          render();
+        },
+        pageUp: () => {
+          selectedIndexRef.current = Math.max(0, selectedIndexRef.current - 8);
+          render();
+        },
+        pageDown: () => {
+          const filtered = getFilteredItems(itemsRef.current, filterTextRef.current);
+          selectedIndexRef.current = Math.min(filtered.length - 1, selectedIndexRef.current + 8);
+          render();
+        },
+        onEscape: () => {
+          if (!isVisibleRef.current && !anchorPositionRef.current) return false;
+          hideWidget();
+          return true;
+        },
       })
     );
-    addKeyAction(
-      'customSuggest.selectPrevious',
-      i18n.translate('workflows.yamlEditor.suggest.selectPrevious', {
-        defaultMessage: 'Select previous suggestion',
-      }),
-      [monaco.KeyCode.UpArrow],
-      () => {
-        selectedIndexRef.current = Math.max(0, selectedIndexRef.current - 1);
-        render();
-      }
-    );
-    addKeyAction(
-      'customSuggest.selectNext',
-      i18n.translate('workflows.yamlEditor.suggest.selectNext', {
-        defaultMessage: 'Select next suggestion',
-      }),
-      [monaco.KeyCode.DownArrow],
-      () => {
-        const filtered = getFilteredItems(itemsRef.current, filterTextRef.current);
-        selectedIndexRef.current = Math.min(filtered.length - 1, selectedIndexRef.current + 1);
-        render();
-      }
-    );
-    addKeyAction(
-      'customSuggest.pageUp',
-      i18n.translate('workflows.yamlEditor.suggest.pageUp', {
-        defaultMessage: 'Page up in suggestions',
-      }),
-      [monaco.KeyCode.PageUp],
-      () => {
-        selectedIndexRef.current = Math.max(0, selectedIndexRef.current - 8);
-        render();
-      }
-    );
-    addKeyAction(
-      'customSuggest.pageDown',
-      i18n.translate('workflows.yamlEditor.suggest.pageDown', {
-        defaultMessage: 'Page down in suggestions',
-      }),
-      [monaco.KeyCode.PageDown],
-      () => {
-        const filtered = getFilteredItems(itemsRef.current, filterTextRef.current);
-        selectedIndexRef.current = Math.min(filtered.length - 1, selectedIndexRef.current + 8);
-        render();
-      }
-    );
 
-    // ── Filter text tracking via onDidChangeModelContent ──
-    //
-    // Derive filter text from the live anchor→cursor range rather than diffing
-    // change events: one source of truth, and it keeps working across paste,
-    // IME composition, and programmatic edits. While the anchor is set we also
-    // process changes when the widget is soft-hidden, so typing into a new
-    // matching prefix (e.g. backspacing after a typo) reopens the widget.
-
+    // Filter text tracking. Derive from the live anchor→cursor range rather
+    // than diffing change events: one source of truth, and keeps working across
+    // paste, IME composition, and programmatic edits. While the anchor is set
+    // we also process changes when the widget is soft-hidden, so typing into a
+    // new matching prefix (e.g. backspacing after a typo) reopens the widget.
     disposablesRef.current.push(
       editor.onDidChangeModelContent(() => {
         if (isAcceptingRef.current) return;
@@ -425,7 +295,6 @@ export const useCustomSuggestWidget = (
 
         const filtered = getFilteredItems(itemsRef.current, filterTextRef.current);
         if (filtered.length === 0) {
-          // Soft hide — keep anchor/items so further editing can restore.
           hideWidget({ preserve: true });
           return;
         }
@@ -438,8 +307,6 @@ export const useCustomSuggestWidget = (
       })
     );
 
-    // ── Dismiss on cursor moving to a different line ──
-
     disposablesRef.current.push(
       editor.onDidChangeCursorPosition((e) => {
         if (!anchorPositionRef.current) return;
@@ -449,8 +316,6 @@ export const useCustomSuggestWidget = (
       })
     );
 
-    // ── Dismiss on mouse click in editor (but not on widget) ──
-
     disposablesRef.current.push(
       editor.onMouseDown(() => {
         if (isVisibleRef.current || anchorPositionRef.current) {
@@ -459,18 +324,15 @@ export const useCustomSuggestWidget = (
       })
     );
 
-    // ── Reposition on scroll ──
-
     disposablesRef.current.push(
       editor.onDidScrollChange(() => {
-        if (isVisibleRef.current && widgetRef.current) {
-          editor.layoutContentWidget(widgetRef.current);
+        if (isVisibleRef.current && mountedRef.current) {
+          editor.layoutContentWidget(mountedRef.current.widget);
         }
       })
     );
 
-    // ── Subscribe to enriched suggestions from the completion provider ──
-    //
+    // Subscribe to enriched suggestions from the completion provider.
     // The emitter is a module-level singleton that may receive payloads from
     // other workflow editor instances; filter by modelUri so each editor only
     // reacts to its own suggestions.
@@ -480,18 +342,14 @@ export const useCustomSuggestWidget = (
       showWidget(payload);
     });
 
-    // ── Cleanup ──
-
     return () => {
       unsubscribe();
       for (const d of disposablesRef.current) {
         d.dispose();
       }
       disposablesRef.current = [];
-      root.unmount();
-      rootRef.current = null;
-      widget.dispose();
-      widgetRef.current = null;
+      mounted.dispose();
+      mountedRef.current = null;
       ctxKeyRef.current = null;
     };
   }, [editor, isEditorMounted, render, showWidget, hideWidget, acceptSuggestion]);

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/use_custom_suggest_widget.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/use_custom_suggest_widget.ts
@@ -66,15 +66,39 @@ export const useCustomSuggestWidget = (
   const showWidget = useCallback(
     (payload: SuggestionsPayload) => {
       if (!editor || !widgetRef.current || !ctxKeyRef.current) return;
-      if (payload.items.length === 0) return;
+      if (payload.items.length === 0) {
+        // Provider returned empty — hide if visible
+        if (isVisibleRef.current) hideWidget();
+        return;
+      }
 
+      // If widget is already visible on the same line, just update items
+      // without resetting position/filter — prevents blinking on re-trigger
+      const alreadyVisible = isVisibleRef.current;
+      const sameLine =
+        alreadyVisible &&
+        anchorPositionRef.current?.lineNumber === payload.anchorPosition.lineNumber;
+
+      if (sameLine) {
+        // Update items but keep current filterText and selection
+        itemsRef.current = payload.items;
+        // Re-check filter still matches
+        const filtered = getFilteredItems(payload.items, filterTextRef.current);
+        if (filtered.length === 0) {
+          hideWidget();
+          return;
+        }
+        render();
+        return;
+      }
+
+      // Fresh show — new line or first trigger
       itemsRef.current = payload.items;
       selectedIndexRef.current = 0;
       anchorPositionRef.current = payload.anchorPosition;
 
       // Compute initial filterText: the user may have typed characters between
-      // the async provider trigger and this callback. Read the text from the
-      // anchor column to the current cursor to capture what was typed.
+      // the async provider trigger and this callback.
       const pos = editor.getPosition();
       const model = editor.getModel();
       if (pos && model && pos.lineNumber === payload.anchorPosition.lineNumber) {
@@ -89,7 +113,6 @@ export const useCustomSuggestWidget = (
         filterTextRef.current = '';
       }
 
-      // Check if any items match the initial filter — if not, don't show
       const filtered = getFilteredItems(payload.items, filterTextRef.current);
       if (filtered.length === 0) return;
 
@@ -98,7 +121,7 @@ export const useCustomSuggestWidget = (
       widgetRef.current.setAnchorPosition(payload.anchorPosition);
       render();
     },
-    [editor, render]
+    [editor, render, hideWidget]
   );
 
   const hideWidget = useCallback(() => {
@@ -133,23 +156,12 @@ export const useCustomSuggestWidget = (
     isAcceptingRef.current = true;
     hideWidget();
 
-    // Determine if we should use snippet insertion
-    const isSnippet =
-      item.insertTextRules !== undefined &&
-      // eslint-disable-next-line no-bitwise
-      (item.insertTextRules & monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet) !== 0;
+    // Strip snippet placeholders ($1, $2, ${1:default}, $0) for plain text insertion.
+    // Kibana's Monaco build doesn't include the snippetController contribution,
+    // so editor.action.insertSnippet is not available.
+    const plainText = item.insertText.replace(/\$\{\d+(?::([^}]*))?\}|\$\d+/g, '$1');
 
-    if (isSnippet) {
-      // For snippets, use Monaco's built-in snippet insertion
-      editor.executeEdits('custom-suggest', [{ range, text: '', forceMoveMarkers: true }]);
-      editor.trigger('custom-suggest', 'editor.action.insertSnippet', {
-        snippet: item.insertText,
-      });
-    } else {
-      editor.executeEdits('custom-suggest', [
-        { range, text: item.insertText, forceMoveMarkers: true },
-      ]);
-    }
+    editor.executeEdits('custom-suggest', [{ range, text: plainText, forceMoveMarkers: true }]);
 
     // Apply additional text edits (e.g., removing @ trigger character)
     if (item.additionalTextEdits?.length) {

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/use_custom_suggest_widget.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/use_custom_suggest_widget.ts
@@ -1,0 +1,387 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { EuiProvider } from '@elastic/eui';
+import React, { useCallback, useEffect, useRef } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { monaco } from '@kbn/monaco';
+
+import { clearSuggestions, subscribeSuggestions } from './enriched_suggestion_store';
+import { SuggestContentWidget } from './suggest_content_widget';
+import { getFilteredItems } from './suggest_list_panel';
+import { SuggestWidgetComponent } from './suggest_widget_component';
+import type { EnrichedSuggestionItem, SuggestionsPayload } from './types';
+
+/**
+ * Hook that manages the custom suggest widget lifecycle.
+ *
+ * Creates an IContentWidget, registers context keys and keybindings,
+ * subscribes to the enriched suggestion store, and renders a React
+ * component into the widget's DOM node.
+ *
+ * Only used in the workflow YAML editor — other Monaco consumers are unaffected.
+ */
+export const useCustomSuggestWidget = (
+  editor: monaco.editor.IStandaloneCodeEditor | null,
+  isEditorMounted: boolean
+): void => {
+  // Mutable state refs (not React state — we render imperatively via root.render)
+  const widgetRef = useRef<SuggestContentWidget | null>(null);
+  const rootRef = useRef<Root | null>(null);
+  const ctxKeyRef = useRef<monaco.editor.IContextKey<boolean> | null>(null);
+  const disposablesRef = useRef<monaco.IDisposable[]>([]);
+
+  const itemsRef = useRef<EnrichedSuggestionItem[]>([]);
+  const filterTextRef = useRef('');
+  const selectedIndexRef = useRef(0);
+  const anchorPositionRef = useRef<{ lineNumber: number; column: number } | null>(null);
+  const isVisibleRef = useRef(false);
+  const isAcceptingRef = useRef(false);
+
+  // ── Render the React component into the widget DOM ──
+
+  const render = useCallback(() => {
+    const root = rootRef.current;
+    if (!root) return;
+
+    root.render(
+      React.createElement(
+        EuiProvider,
+        { colorMode: 'dark' },
+        React.createElement(SuggestWidgetComponent, {
+          items: itemsRef.current,
+          filterText: filterTextRef.current,
+          selectedIndex: selectedIndexRef.current,
+          isVisible: isVisibleRef.current,
+          onSelect: (index: number) => {
+            selectedIndexRef.current = index;
+            render();
+          },
+          onAccept: (index: number) => {
+            selectedIndexRef.current = index;
+            acceptSuggestion();
+          },
+        })
+      )
+    );
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps -- intentionally stable
+
+  // ── Show / Hide ──
+
+  const showWidget = useCallback(
+    (payload: SuggestionsPayload) => {
+      if (!editor || !widgetRef.current || !ctxKeyRef.current) return;
+      if (payload.items.length === 0) return;
+
+      itemsRef.current = payload.items;
+      filterTextRef.current = '';
+      selectedIndexRef.current = 0;
+      anchorPositionRef.current = payload.anchorPosition;
+      isVisibleRef.current = true;
+
+      ctxKeyRef.current.set(true);
+      widgetRef.current.setAnchorPosition(payload.anchorPosition);
+      render();
+    },
+    [editor, render]
+  );
+
+  const hideWidget = useCallback(() => {
+    if (!ctxKeyRef.current) return;
+
+    isVisibleRef.current = false;
+    anchorPositionRef.current = null;
+    filterTextRef.current = '';
+    ctxKeyRef.current.set(false);
+    clearSuggestions();
+    render();
+  }, [render]);
+
+  // ── Accept suggestion ──
+
+  const acceptSuggestion = useCallback(() => {
+    if (!editor) return;
+
+    const filtered = getFilteredItems(itemsRef.current, filterTextRef.current);
+    const idx = Math.max(0, Math.min(selectedIndexRef.current, filtered.length - 1));
+    const entry = filtered[idx];
+    if (!entry) return;
+
+    const { item } = entry;
+    const pos = editor.getPosition();
+    if (!pos) return;
+
+    const startCol = anchorPositionRef.current?.column ?? pos.column - filterTextRef.current.length;
+    const range = new monaco.Range(pos.lineNumber, startCol, pos.lineNumber, pos.column);
+
+    // Suppress onDidChangeModelContent handler during acceptance
+    isAcceptingRef.current = true;
+    hideWidget();
+
+    // Determine if we should use snippet insertion
+    const isSnippet =
+      item.insertTextRules !== undefined &&
+      // eslint-disable-next-line no-bitwise
+      (item.insertTextRules & monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet) !== 0;
+
+    if (isSnippet) {
+      // For snippets, use Monaco's built-in snippet insertion
+      editor.executeEdits('custom-suggest', [{ range, text: '', forceMoveMarkers: true }]);
+      editor.trigger('custom-suggest', 'editor.action.insertSnippet', {
+        snippet: item.insertText,
+      });
+    } else {
+      editor.executeEdits('custom-suggest', [
+        { range, text: item.insertText, forceMoveMarkers: true },
+      ]);
+    }
+
+    // Apply additional text edits (e.g., removing @ trigger character)
+    if (item.additionalTextEdits?.length) {
+      const edits = item.additionalTextEdits.map((edit) => ({
+        range: monaco.Range.lift(edit.range),
+        text: edit.text,
+        forceMoveMarkers: true,
+      }));
+      editor.executeEdits('custom-suggest-additional', edits);
+    }
+
+    // Execute post-accept command if present (e.g., create connector)
+    if (item.command) {
+      const args = item.command.arguments?.[0];
+      editor.trigger('custom-suggest', item.command.id, args);
+    }
+
+    isAcceptingRef.current = false;
+    editor.focus();
+  }, [editor, hideWidget]);
+
+  // ── Setup effect ──
+
+  useEffect(() => {
+    if (!editor || !isEditorMounted) return;
+
+    // Create the IContentWidget
+    const widget = new SuggestContentWidget(editor);
+    widgetRef.current = widget;
+
+    // Create React root on the inner node
+    const root = createRoot(widget.getInnerNode());
+    rootRef.current = root;
+
+    // Create context key for conditional keybindings
+    const ctxKey = editor.createContextKey('customSuggestWidgetVisible', false);
+    ctxKeyRef.current = ctxKey;
+
+    // ── Register keybindings via addAction (precondition-gated) ──
+
+    disposablesRef.current.push(
+      editor.addAction({
+        id: 'customSuggest.selectPrevious',
+        label: 'Custom Suggest: Select Previous',
+        precondition: 'customSuggestWidgetVisible',
+        keybindings: [monaco.KeyCode.UpArrow],
+        run: () => {
+          selectedIndexRef.current = Math.max(0, selectedIndexRef.current - 1);
+          render();
+        },
+      })
+    );
+
+    disposablesRef.current.push(
+      editor.addAction({
+        id: 'customSuggest.selectNext',
+        label: 'Custom Suggest: Select Next',
+        precondition: 'customSuggestWidgetVisible',
+        keybindings: [monaco.KeyCode.DownArrow],
+        run: () => {
+          const filtered = getFilteredItems(itemsRef.current, filterTextRef.current);
+          selectedIndexRef.current = Math.min(filtered.length - 1, selectedIndexRef.current + 1);
+          render();
+        },
+      })
+    );
+
+    disposablesRef.current.push(
+      editor.addAction({
+        id: 'customSuggest.accept',
+        label: 'Custom Suggest: Accept',
+        precondition: 'customSuggestWidgetVisible',
+        keybindings: [monaco.KeyCode.Enter, monaco.KeyCode.Tab],
+        run: () => {
+          acceptSuggestion();
+        },
+      })
+    );
+
+    disposablesRef.current.push(
+      editor.addAction({
+        id: 'customSuggest.dismiss',
+        label: 'Custom Suggest: Dismiss',
+        precondition: 'customSuggestWidgetVisible',
+        keybindings: [monaco.KeyCode.Escape],
+        run: () => {
+          hideWidget();
+        },
+      })
+    );
+
+    disposablesRef.current.push(
+      editor.addAction({
+        id: 'customSuggest.pageUp',
+        label: 'Custom Suggest: Page Up',
+        precondition: 'customSuggestWidgetVisible',
+        keybindings: [monaco.KeyCode.PageUp],
+        run: () => {
+          selectedIndexRef.current = Math.max(0, selectedIndexRef.current - 8);
+          render();
+        },
+      })
+    );
+
+    disposablesRef.current.push(
+      editor.addAction({
+        id: 'customSuggest.pageDown',
+        label: 'Custom Suggest: Page Down',
+        precondition: 'customSuggestWidgetVisible',
+        keybindings: [monaco.KeyCode.PageDown],
+        run: () => {
+          const filtered = getFilteredItems(itemsRef.current, filterTextRef.current);
+          selectedIndexRef.current = Math.min(filtered.length - 1, selectedIndexRef.current + 8);
+          render();
+        },
+      })
+    );
+
+    // ── Suppress built-in suggest keybindings when our widget is visible ──
+
+    disposablesRef.current.push(
+      monaco.editor.addKeybindingRules([
+        {
+          keybinding: monaco.KeyCode.Enter,
+          command: null,
+          when: 'customSuggestWidgetVisible && !suggestWidgetVisible',
+        },
+        {
+          keybinding: monaco.KeyCode.Tab,
+          command: null,
+          when: 'customSuggestWidgetVisible && !suggestWidgetVisible',
+        },
+        {
+          keybinding: monaco.KeyCode.Escape,
+          command: null,
+          when: 'customSuggestWidgetVisible && !suggestWidgetVisible',
+        },
+      ])
+    );
+
+    // ── Filter text tracking via onDidChangeModelContent ──
+
+    disposablesRef.current.push(
+      editor.onDidChangeModelContent((e) => {
+        if (!isVisibleRef.current || isAcceptingRef.current) return;
+
+        for (const change of e.changes) {
+          if (change.text.length > 0 && change.rangeLength === 0) {
+            // Insertion
+            filterTextRef.current += change.text;
+          } else if (change.text.length === 0 && change.rangeLength > 0) {
+            // Deletion
+            filterTextRef.current = filterTextRef.current.slice(
+              0,
+              Math.max(0, filterTextRef.current.length - change.rangeLength)
+            );
+          } else if (change.text.length > 0 && change.rangeLength > 0) {
+            // Replacement
+            filterTextRef.current = filterTextRef.current.slice(
+              0,
+              Math.max(0, filterTextRef.current.length - change.rangeLength)
+            );
+            filterTextRef.current += change.text;
+          }
+        }
+
+        selectedIndexRef.current = 0;
+
+        // Check if there are still matching items
+        const filtered = getFilteredItems(itemsRef.current, filterTextRef.current);
+        if (filtered.length === 0) {
+          hideWidget();
+          return;
+        }
+
+        // Dismiss if filter emptied from backspace
+        if (filterTextRef.current.length === 0 && e.changes.some((c) => c.rangeLength > 0)) {
+          hideWidget();
+          return;
+        }
+
+        render();
+      })
+    );
+
+    // ── Dismiss on cursor moving to a different line ──
+
+    disposablesRef.current.push(
+      editor.onDidChangeCursorPosition((e) => {
+        if (!isVisibleRef.current) return;
+        if (
+          anchorPositionRef.current &&
+          e.position.lineNumber !== anchorPositionRef.current.lineNumber
+        ) {
+          hideWidget();
+        }
+      })
+    );
+
+    // ── Dismiss on mouse click in editor ──
+
+    disposablesRef.current.push(
+      editor.onMouseDown(() => {
+        if (isVisibleRef.current) {
+          hideWidget();
+        }
+      })
+    );
+
+    // ── Reposition on scroll ──
+
+    disposablesRef.current.push(
+      editor.onDidScrollChange(() => {
+        if (isVisibleRef.current && widgetRef.current) {
+          editor.layoutContentWidget(widgetRef.current);
+        }
+      })
+    );
+
+    // ── Subscribe to enriched suggestions from the completion provider ──
+
+    const unsubscribe = subscribeSuggestions((payload) => {
+      showWidget(payload);
+    });
+
+    // Initial render (hidden)
+    render();
+
+    // ── Cleanup ──
+
+    return () => {
+      unsubscribe();
+      for (const d of disposablesRef.current) {
+        d.dispose();
+      }
+      disposablesRef.current = [];
+      root.unmount();
+      rootRef.current = null;
+      widget.dispose();
+      widgetRef.current = null;
+      ctxKeyRef.current = null;
+    };
+  }, [editor, isEditorMounted, render, showWidget, hideWidget, acceptSuggestion]);
+};

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/use_custom_suggest_widget.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/use_custom_suggest_widget.ts
@@ -171,24 +171,49 @@ export const useCustomSuggestWidget = (
     isAcceptingRef.current = true;
     hideWidget();
 
-    // Use the completion item's range for correct replacement.
-    // The range specifies what text to replace (e.g., the word being typed).
-    // Adjust endColumn to current cursor to account for typed characters.
+    // Main replacement range: from the item's startColumn through the current cursor.
     const itemRange = item.range;
-    const range = new monaco.Range(
+    const mainRange = new monaco.Range(
       itemRange.startLineNumber,
       itemRange.startColumn,
       pos.lineNumber,
       pos.column
     );
 
-    // Try snippetController2 for snippet insertions (it IS loaded in Kibana,
-    // unlike the editor.action.insertSnippet action which requires a separate contribution)
+    // Fold same-line adjacent additionalTextEdits (e.g., removing the @ trigger)
+    // into the main range so the insertion is one coherent transaction. Applying
+    // them as a second executeEdits breaks because the second call's coordinates
+    // don't compose with the first — leaving stray trigger chars like "@workflow".
+    let unionRange = mainRange;
+    const nonAdjacentEdits: Array<{ range: monaco.IRange; text: string }> = [];
+    for (const edit of item.additionalTextEdits ?? []) {
+      const r = monaco.Range.lift(edit.range);
+      const text = edit.text ?? '';
+      const adjacent =
+        r.startLineNumber === mainRange.startLineNumber &&
+        r.endLineNumber === mainRange.endLineNumber &&
+        text === '' &&
+        r.endColumn >= unionRange.startColumn &&
+        r.startColumn <= unionRange.endColumn;
+      if (adjacent) {
+        unionRange = new monaco.Range(
+          unionRange.startLineNumber,
+          Math.min(unionRange.startColumn, r.startColumn),
+          unionRange.endLineNumber,
+          Math.max(unionRange.endColumn, r.endColumn)
+        );
+      } else {
+        nonAdjacentEdits.push({ range: r, text });
+      }
+    }
+
     const isSnippet =
       item.insertTextRules !== undefined &&
       // eslint-disable-next-line no-bitwise
       (item.insertTextRules & monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet) !== 0;
 
+    // snippetController2 is loaded by Kibana's Monaco build; editor.action.insertSnippet
+    // needs a separate contribution and isn't reliably available here.
     const snippetController = editor.getContribution('snippetController2') as {
       insert?: (
         template: string,
@@ -203,31 +228,27 @@ export const useCustomSuggestWidget = (
     } | null;
 
     if (isSnippet && snippetController?.insert) {
-      const overwriteBefore = pos.column - itemRange.startColumn;
       snippetController.insert(item.insertText, {
-        overwriteBefore,
-        overwriteAfter: 0,
+        overwriteBefore: pos.column - unionRange.startColumn,
+        overwriteAfter: Math.max(0, unionRange.endColumn - pos.column),
         undoStopBefore: true,
         undoStopAfter: true,
         adjustWhitespace: true,
       });
     } else {
-      // Plain text — strip any snippet placeholders just in case
       const plainText = isSnippet ? stripSnippetPlaceholders(item.insertText) : item.insertText;
-      editor.executeEdits('custom-suggest', [{ range, text: plainText, forceMoveMarkers: true }]);
+      editor.executeEdits('custom-suggest', [
+        { range: unionRange, text: plainText, forceMoveMarkers: true },
+      ]);
     }
 
-    // Apply additional text edits (e.g., removing @ trigger character)
-    if (item.additionalTextEdits?.length) {
-      const edits = item.additionalTextEdits.map((edit) => ({
-        range: monaco.Range.lift(edit.range),
-        text: edit.text,
-        forceMoveMarkers: true,
-      }));
-      editor.executeEdits('custom-suggest-additional', edits);
+    if (nonAdjacentEdits.length) {
+      editor.executeEdits(
+        'custom-suggest-additional',
+        nonAdjacentEdits.map((e) => ({ range: e.range, text: e.text, forceMoveMarkers: true }))
+      );
     }
 
-    // Execute post-accept command if present (e.g., create connector)
     if (item.command) {
       const args = item.command.arguments?.[0];
       editor.trigger('custom-suggest', item.command.id, args);

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/use_custom_suggest_widget.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/use_custom_suggest_widget.ts
@@ -82,8 +82,10 @@ export const useCustomSuggestWidget = (
     clearSuggestions();
     render();
 
-    // Clear aria active descendant
-    editorRef.current?.setAriaOptions?.({ activeDescendant: undefined } as never);
+    // Clear aria active descendant (setAriaOptions is available on internal editor API)
+    (
+      editorRef.current as { setAriaOptions?: (opts: Record<string, unknown>) => void }
+    )?.setAriaOptions?.({ activeDescendant: undefined });
   }, [render]);
 
   // ── Show ──

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/use_custom_suggest_widget.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/use_custom_suggest_widget.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { EuiProvider } from '@elastic/eui';
+import { EuiProvider, useEuiTheme } from '@elastic/eui';
 import React, { useCallback, useEffect, useRef } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { monaco } from '@kbn/monaco';
@@ -15,7 +15,7 @@ import { monaco } from '@kbn/monaco';
 import { clearSuggestions, subscribeSuggestions } from './enriched_suggestion_store';
 import { SuggestContentWidget } from './suggest_content_widget';
 import { getFilteredItems } from './suggest_list_panel';
-import { SuggestWidgetComponent } from './suggest_widget_component';
+import { type SuggestWidgetHandle, SuggestWidgetRoot } from './suggest_widget_root';
 import type { EnrichedSuggestionItem, SuggestionsPayload } from './types';
 
 /**
@@ -31,9 +31,15 @@ export const useCustomSuggestWidget = (
   editor: monaco.editor.IStandaloneCodeEditor | null,
   isEditorMounted: boolean
 ): void => {
+  // Inherit color mode from the parent app's EUI context
+  const { colorMode } = useEuiTheme();
+  const colorModeRef = useRef(colorMode);
+  colorModeRef.current = colorMode;
+
   // Mutable state refs (not React state — we render imperatively via root.render)
   const widgetRef = useRef<SuggestContentWidget | null>(null);
   const rootRef = useRef<Root | null>(null);
+  const handleRef = useRef<SuggestWidgetHandle | null>(null);
   const ctxKeyRef = useRef<monaco.editor.IContextKey<boolean> | null>(null);
   const disposablesRef = useRef<monaco.IDisposable[]>([]);
 
@@ -44,33 +50,16 @@ export const useCustomSuggestWidget = (
   const isVisibleRef = useRef(false);
   const isAcceptingRef = useRef(false);
 
-  // ── Render the React component into the widget DOM ──
+  // ── Update widget state via imperative handle (no root.render() per keystroke) ──
 
   const render = useCallback(() => {
-    const root = rootRef.current;
-    if (!root) return;
-
-    root.render(
-      React.createElement(
-        EuiProvider,
-        { colorMode: 'dark' },
-        React.createElement(SuggestWidgetComponent, {
-          items: itemsRef.current,
-          filterText: filterTextRef.current,
-          selectedIndex: selectedIndexRef.current,
-          isVisible: isVisibleRef.current,
-          onSelect: (index: number) => {
-            selectedIndexRef.current = index;
-            render();
-          },
-          onAccept: (index: number) => {
-            selectedIndexRef.current = index;
-            acceptSuggestion();
-          },
-        })
-      )
-    );
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps -- intentionally stable
+    handleRef.current?.update({
+      items: itemsRef.current,
+      filterText: filterTextRef.current,
+      selectedIndex: selectedIndexRef.current,
+      isVisible: isVisibleRef.current,
+    });
+  }, []);
 
   // ── Show / Hide ──
 
@@ -171,9 +160,32 @@ export const useCustomSuggestWidget = (
     const widget = new SuggestContentWidget(editor);
     widgetRef.current = widget;
 
-    // Create React root on the inner node
+    // Create React root on the inner node — render once with EuiProvider + SuggestWidgetRoot.
+    // Subsequent updates go through the imperative handle (no root.render per keystroke).
     const root = createRoot(widget.getInnerNode());
     rootRef.current = root;
+
+    const refCallback = (handle: SuggestWidgetHandle | null) => {
+      handleRef.current = handle;
+    };
+
+    root.render(
+      React.createElement(
+        EuiProvider,
+        { colorMode: colorModeRef.current === 'DARK' ? 'dark' : 'light' },
+        React.createElement(SuggestWidgetRoot, {
+          ref: refCallback,
+          onSelect: (index: number) => {
+            selectedIndexRef.current = index;
+            render();
+          },
+          onAccept: (index: number) => {
+            selectedIndexRef.current = index;
+            acceptSuggestion();
+          },
+        })
+      )
+    );
 
     // Create context key for conditional keybindings
     const ctxKey = editor.createContextKey('customSuggestWidgetVisible', false);
@@ -365,9 +377,6 @@ export const useCustomSuggestWidget = (
     const unsubscribe = subscribeSuggestions((payload) => {
       showWidget(payload);
     });
-
-    // Initial render (hidden)
-    render();
 
     // ── Cleanup ──
 

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/use_custom_suggest_widget.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/custom_suggest_widget/use_custom_suggest_widget.ts
@@ -69,11 +69,31 @@ export const useCustomSuggestWidget = (
       if (payload.items.length === 0) return;
 
       itemsRef.current = payload.items;
-      filterTextRef.current = '';
       selectedIndexRef.current = 0;
       anchorPositionRef.current = payload.anchorPosition;
-      isVisibleRef.current = true;
 
+      // Compute initial filterText: the user may have typed characters between
+      // the async provider trigger and this callback. Read the text from the
+      // anchor column to the current cursor to capture what was typed.
+      const pos = editor.getPosition();
+      const model = editor.getModel();
+      if (pos && model && pos.lineNumber === payload.anchorPosition.lineNumber) {
+        const typed = model.getValueInRange({
+          startLineNumber: pos.lineNumber,
+          startColumn: payload.anchorPosition.column,
+          endLineNumber: pos.lineNumber,
+          endColumn: pos.column,
+        });
+        filterTextRef.current = typed;
+      } else {
+        filterTextRef.current = '';
+      }
+
+      // Check if any items match the initial filter — if not, don't show
+      const filtered = getFilteredItems(payload.items, filterTextRef.current);
+      if (filtered.length === 0) return;
+
+      isVisibleRef.current = true;
       ctxKeyRef.current.set(true);
       widgetRef.current.setAnchorPosition(payload.anchorPosition);
       render();

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/styles/get_monaco_workflow_overrides_styles.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/styles/get_monaco_workflow_overrides_styles.test.ts
@@ -60,14 +60,19 @@ describe('getMonacoWorkflowOverridesStyles', () => {
     expect(stylesString).toContain('hidden');
   });
 
-  it('should apply shadow and border-radius to suggestion widget', () => {
+  it('should hide the built-in suggest widget only inside the workflow suggest host', () => {
     const euiThemeContext = createMockEuiThemeContext();
     const styles = getMonacoWorkflowOverridesStyles(euiThemeContext);
 
     const stylesString = styles.styles;
-    expect(stylesString).toContain('.monaco-editor .suggest-widget');
-    expect(stylesString).toContain('border-radius');
-    expect(stylesString).toContain('6px');
+    // Rule must be scoped so other Monaco editors on the page keep their
+    // built-in suggest UI.
+    expect(stylesString).toMatch(
+      /\.workflow-custom-suggest-host \.suggest-widget\s*{[^}]*display:\s*none/
+    );
+    expect(stylesString).not.toMatch(
+      /^[^{]*\.monaco-editor \.suggest-widget\s*{[^}]*display:\s*none/m
+    );
   });
 
   it('should style hover widget with proper selectors', () => {

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/styles/get_monaco_workflow_overrides_styles.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/styles/get_monaco_workflow_overrides_styles.ts
@@ -107,11 +107,9 @@ export const getMonacoWorkflowOverridesStyles = (euiThemeContext: UseEuiTheme) =
       max-height: 120px;
     }
 
+    /* Hide built-in suggest widget — custom suggest widget handles display */
     .monaco-editor .suggest-widget {
-      border-radius: 6px !important;
-      ${euiShadow(euiThemeContext, 'm')}
-      border-width: 0 !important;
-      overflow: hidden !important; // so border-radius is applied correctly
+      display: none !important;
     }
 
     .monaco-editor .suggest-details > .monaco-scrollable-element > .body > .header > .codicon-close,

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/styles/get_monaco_workflow_overrides_styles.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/styles/get_monaco_workflow_overrides_styles.ts
@@ -107,8 +107,10 @@ export const getMonacoWorkflowOverridesStyles = (euiThemeContext: UseEuiTheme) =
       max-height: 120px;
     }
 
-    /* Hide built-in suggest widget — custom suggest widget handles display */
-    .monaco-editor .suggest-widget {
+    /* Hide built-in suggest widget inside the workflow editor's overflow container
+       — our custom IContentWidget handles display for this editor. Scoped so other
+       Monaco editors on the page keep their built-in suggest UI. */
+    .workflow-custom-suggest-host .suggest-widget {
       display: none !important;
     }
 

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/workflow_yaml_editor.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/workflow_yaml_editor.tsx
@@ -75,6 +75,7 @@ import { useKibana } from '../../../hooks/use_kibana';
 import { UnsavedChangesPrompt, YamlEditor } from '../../../shared/ui';
 import { triggerSchemas } from '../../../trigger_schemas';
 import { interceptMonacoYamlProvider } from '../lib/autocomplete/intercept_monaco_yaml_provider';
+import { useCustomSuggestWidget } from '../lib/custom_suggest_widget';
 import type { ExecutionContext } from '../lib/execution_context/build_execution_context';
 import { buildExecutionContext } from '../lib/execution_context/build_execution_context';
 import { useLazyStepExecutionFetcher } from '../lib/execution_context/use_lazy_step_execution_fetcher';
@@ -471,6 +472,9 @@ export const WorkflowYAMLEditor = ({
   }, []);
 
   useFocusedStepDecoration(editorRef.current);
+
+  // Custom suggest widget (replaces Monaco's built-in suggest widget)
+  useCustomSuggestWidget(editorRef.current, isEditorMounted);
 
   // Decorations
   useTriggerTypeDecorations({

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/workflow_yaml_editor.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/workflow_yaml_editor.tsx
@@ -139,6 +139,7 @@ const editorOptions: monaco.editor.IStandaloneEditorConstructionOptions = {
     showSnippets: true,
     filterGraceful: true, // Better filtering
     localityBonus: true, // Prioritize matches near cursor
+    showStatusBar: false, // Suppress "No suggestions" when custom widget handles display
   },
   wordBasedSuggestions: false,
   hover: {


### PR DESCRIPTION
Closes https://github.com/elastic/security-team/issues/16870

> [!NOTE]
> **POC — not for merge.** Exploring what a custom Monaco suggest widget can offer for the workflow YAML editor. Design counterpart: [#14411](https://github.com/elastic/security-team/issues/14411).

## Demo

[![Watch demo](https://pub-6b50802d113345dea50c783e8280b53e.r2.dev/artifacts/20260417/8muz3s79-demo-thumb.webp)](https://pub-6b50802d113345dea50c783e8280b53e.r2.dev/artifacts/20260417/lg7nw0rk-demo263872.webm)

> [Watch video](https://pub-6b50802d113345dea50c783e8280b53e.r2.dev/artifacts/20260417/lg7nw0rk-demo263872.webm) — typing `@` inside a `{{ }}` template: widget opens, arrow-key navigation through variables, filter by first letter, Enter to accept.

### Variable completion (grouped list + details panel)

![variables](https://pub-6b50802d113345dea50c783e8280b53e.r2.dev/artifacts/20260417/j93cdhjr-pr263872-hero.webp)

The left panel shows the grouped suggestion list with a category icon, label, and kind pill per entry. The right panel shows the selected entry's type, object shape (`KEYS`), and a description sourced from the Zod `.describe()` metadata on the workflow context schemas.

### Match highlighting while filtering

![filter](https://pub-6b50802d113345dea50c783e8280b53e.r2.dev/artifacts/20260417/8ch6432m-pr263872-filter-cropped.webp)

Typing narrows the list and underlines the matched characters (Monaco-style fuzzy scoring ported for parity).

### Nested variable completion

![nested](https://pub-6b50802d113345dea50c783e8280b53e.r2.dev/artifacts/20260417/ykng24zh-pr263872-nested-cropped.webp)

Typing `.` after a variable walks into the object's shape — here `@event.rule.` shows the rule's properties (`id`, `name`, `tags`, `consumer`, `producer`, `ruleTypeId`) with per-property types. Works for arbitrary depth where the Zod schema has nested shapes.

### Step type completion

![step types](https://pub-6b50802d113345dea50c783e8280b53e.r2.dev/artifacts/20260417/3opkgy7y-pr263872-step-type-cropped.webp)

Triggering after `type:` on a step lists every registered connector and built-in control flow step, each with its own glyph (loop, branch, fork, clock, …) resolved via `HardcodedIcons`. The details panel shows the step category and a one-line description.

### Step parameter completion

![parameters](https://pub-6b50802d113345dea50c783e8280b53e.r2.dev/artifacts/20260417/h5cky36b-pr263872-params-cropped.webp)

Inside a step's `with:` block the widget offers the parameters declared in the step's Zod schema — here `elasticsearch.search` surfaces `aggregations`, `collapse`, `explain`, `from`, `highlight`, `track_total_hits`, and so on, with descriptions lifted from the schema.

## Summary

Replaces Monaco's built-in suggest widget with a custom \`IContentWidget\` for **all completion triggers** in the workflow YAML editor (\`@\`, \`.\`, space, KQL/Liquid characters, and manual invoke). The built-in widget renders a flat, unstyled list; this POC explores grouping, icons, inline descriptions, and a details panel so users can discover what's available without leaving the editor.

### Scope clarification

The widget handles every trigger the workflow completion provider emits for — not only \`@\`. Inside the workflow editor, Monaco's built-in suggest UI is replaced for YAML keys, step parameters, template variables, Liquid filters, and KQL tokens alike. The suppression is scoped to the workflow editor's own overflow container (\`.workflow-custom-suggest-host\`), so other Monaco editors on the page keep their built-in suggest UI.

### What's included
- Custom \`IContentWidget\` wired into the enriched-suggestion store for the workflow YAML editor.
- Scoped CSS: built-in suggest widget suppressed only inside the workflow editor's overflow root.
- Grouping + icons per category (event, inputs, steps, secrets, connectors, etc.).
- Details panel with description and example value per entry.
- Monaco-style fuzzy scoring and match highlighting ported for parity.
- Keybindings via \`addAction\` (disposable): \`Cmd/Ctrl+I\` to trigger, \`Enter\`/\`Tab\` to accept, \`Esc\` to dismiss (via \`onKeyDown\` to win over the shared CodeEditor wrapper), arrow keys / PgUp / PgDn for navigation.
- Per-editor routing: store payloads carry \`modelUri\` so multiple workflow editor instances don't cross-fire.
- Backspace recovery: after a no-match soft-hide, backspacing into a matching prefix re-shows the widget without requiring a new trigger.
- i18n: user-facing strings and action labels are wrapped in \`i18n.translate\`.
- Standalone HTML sandbox (\`poc/workflow_suggest_widget.html\`) for iterating on the UI outside Kibana.

### Out of scope for this POC
- Context-aware filtering by cursor position — current step / available outputs not narrowed.
- Production polish: full a11y audit (ARIA \`activedescendant\` wiring), unit tests for the fuzzy scorer, responsive width behavior on narrow viewports, \`poc/*.html\` cleanup.

## Test plan
- [ ] Open the workflow YAML editor, type \`@\` inside \`{{ }}\`, verify the custom widget appears and the built-in is suppressed.
- [ ] Confirm the built-in suggest widget still works in a non-workflow Monaco editor (e.g., Dev Console) while the workflow editor is mounted.
- [ ] Arrow keys navigate entries; \`Enter\` / \`Tab\` accepts; \`Esc\` dismisses.
- [ ] Fuzzy filtering narrows the list; typing a non-matching prefix soft-hides the widget; backspacing re-shows it.
- [ ] Light and dark themes render correctly.