### PR TITLE
[Security Solution] enable find action to old Security Solution alert flyout

### DIFF
--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/json_code_editor/json_code_editor.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/json_code_editor/json_code_editor.tsx
@@ -15,6 +15,7 @@ export interface JsonCodeEditorProps {
   width?: string | number;
   height?: string | number;
   hasLineNumbers?: boolean;
+  enableFindAction?: boolean;
 }
 
 // Required for usage in React.lazy
@@ -24,6 +25,7 @@ export default function JsonCodeEditor({
   width,
   height,
   hasLineNumbers,
+  enableFindAction,
 }: JsonCodeEditorProps) {
   const jsonValue = JSON.stringify(json, null, 2);
 
@@ -35,6 +37,7 @@ export default function JsonCodeEditor({
       hasLineNumbers={hasLineNumbers}
       onEditorDidMount={() => void 0}
       hideCopyButton={true}
+      enableFindAction={enableFindAction}
     />
   );
 }

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/shared/components/json_tab.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/shared/components/json_tab.tsx
@@ -98,7 +98,12 @@ export const JsonTab = memo(
           </EuiFlexGroup>
         </EuiFlexItem>
         <EuiFlexItem>
-          <JsonCodeEditor json={value} height={editorHeight} hasLineNumbers={true} />
+          <JsonCodeEditor
+            json={value}
+            height={editorHeight}
+            hasLineNumbers={true}
+            enableFindAction={true}
+          />
         </EuiFlexItem>
       </EuiFlexGroup>
     );


### PR DESCRIPTION
## Summary

This PR enables the search functionality in the json tab that we use in the Security Solution old expandable flyout. This way the experience is now identical to the document flyout in Discover.

| Before  | After |
| ------------- | ------------- |
| <img width="641" height="957" alt="Screenshot 2026-04-16 at 2 14 09 PM" src="https://github.com/user-attachments/assets/98a879ca-44bb-4a86-8048-f660529fcbd5" /> | <img width="642" height="959" alt="Screenshot 2026-04-16 at 2 20 52 PM" src="https://github.com/user-attachments/assets/16031d14-222d-4bb4-8354-b9c3a049000e" /> |

### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


<!--ONMERGE {"backportTargets":["8.19","9.2","9.3","9.4"]} ONMERGE-->