### PR TITLE
[Entity Store][Scout] Resume history_snapshot.spec.ts after flakiness fixes

### DIFF
--- a/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/history_snapshot.spec.ts
+++ b/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/history_snapshot.spec.ts
@@ -21,8 +21,7 @@ import {
   normalizeKeywordList,
 } from '../fixtures/helpers';
 
-// Failing: See https://github.com/elastic/kibana/issues/256862
-apiTest.describe.skip('Entity Store History Snapshot', { tag: ENTITY_STORE_TAGS }, () => {
+apiTest.describe('Entity Store History Snapshot', { tag: ENTITY_STORE_TAGS }, () => {
   let defaultHeaders: Record<string, string>;
   let internalHeaders: Record<string, string>;
 


### PR DESCRIPTION
## Summary

The reasons for history snapshot test's flakiness were removed by <https://github.com/elastic/kibana/pull/263337> and <https://github.com/elastic/kibana/pull/263746>. Both PRs have been backported to `9.4` branches as well, as should be this PR.

Closes <https://github.com/elastic/kibana/issues/256862> - hopefully for good 😅 

### Checklist

- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->