### PR TITLE
[9.4] [markdown embeddable] fix unsaved changes when settings not provided (#263564)

### DIFF
--- a/src/platform/plugins/shared/dashboard_markdown/public/components/markdown_editor.test.tsx
+++ b/src/platform/plugins/shared/dashboard_markdown/public/components/markdown_editor.test.tsx
@@ -27,7 +27,9 @@ const contentLength = testedContent.length;
 const renderMarkdownEditor = (overrideProps?: Partial<MarkdownEditorProps>) => {
   const isEditing$ = new BehaviorSubject(true);
   const isPreview$ = new BehaviorSubject(false);
-  const settings$ = new BehaviorSubject(undefined) as MarkdownEditorProps['settings$'];
+  const settings$ = new BehaviorSubject({
+    open_links_in_new_tab: true,
+  }) as MarkdownEditorProps['settings$'];
   return render(
     <>
       <MarkdownEditorPreviewSwitch

--- a/src/platform/plugins/shared/dashboard_markdown/public/components/markdown_editor.tsx
+++ b/src/platform/plugins/shared/dashboard_markdown/public/components/markdown_editor.tsx
@@ -19,7 +19,7 @@ import type { BehaviorSubject } from 'rxjs';
 import { SHORT_CONTAINER_QUERY, FOOTER_HELP_TEXT, MarkdownFooter } from './markdown_footer';
 import { MarkdownRenderer } from './markdown_renderer';
 import { MarkdownEditorSettingsPopover } from './markdown_editor_settings_popover';
-import type { MarkdownSettingsState } from '../../server/schemas';
+import type { MarkdownSettingsState } from '../../server/embeddable/schemas';
 
 interface EuiMarkdownEditorRef {
   textarea: HTMLTextAreaElement;

--- a/src/platform/plugins/shared/dashboard_markdown/public/components/markdown_editor_settings_popover.tsx
+++ b/src/platform/plugins/shared/dashboard_markdown/public/components/markdown_editor_settings_popover.tsx
@@ -10,7 +10,7 @@
 import { EuiButtonIcon, EuiPopover, EuiSwitch, EuiToolTip } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React, { useCallback, useState } from 'react';
-import type { MarkdownSettingsState } from '../../server/schemas';
+import type { MarkdownSettingsState } from '../../server/embeddable/schemas';
 
 interface Props {
   settings: MarkdownSettingsState;

--- a/src/platform/plugins/shared/dashboard_markdown/public/create_markdown_action.tsx
+++ b/src/platform/plugins/shared/dashboard_markdown/public/create_markdown_action.tsx
@@ -34,6 +34,9 @@ export const createMarkdownAction = (): ActionDefinition<EmbeddableApiContext> =
         panelType: MARKDOWN_EMBEDDABLE_TYPE,
         serializedState: {
           content: '',
+          settings: {
+            open_links_in_new_tab: true,
+          },
         },
       },
       { displaySuccessMessage: true }

--- a/src/platform/plugins/shared/dashboard_markdown/public/markdown_client/markdown_client.ts
+++ b/src/platform/plugins/shared/dashboard_markdown/public/markdown_client/markdown_client.ts
@@ -11,7 +11,11 @@ import { buildPath } from '@kbn/core-http-browser';
 import { SavedObjectNotFound } from '@kbn/kibana-utils-plugin/public';
 import type { DeleteResult } from '@kbn/content-management-plugin/common';
 
-import type { MarkdownSearchRequestQuery, MarkdownSearchResponseBody } from '../../server/api';
+import type {
+  MarkdownSearchRequestQuery,
+  MarkdownSearchResponseBody,
+  MarkdownUpdateRequestBody,
+} from '../../server/api';
 import {
   MARKDOWN_API_PATH,
   MARKDOWN_API_VERSION,
@@ -23,10 +27,10 @@ import type {
   MarkdownUpdateResponseBody,
 } from '../../server';
 import { coreServices } from '../services/kibana_services';
-import type { MarkdownAttributes } from '../../server/markdown_saved_object';
+import type { MarkdownCreateRequestBody } from '../../server';
 
 export const markdownClient = {
-  create: async (markdownState: MarkdownAttributes) => {
+  create: async (markdownState: MarkdownCreateRequestBody) => {
     return coreServices.http.post<MarkdownCreateResponseBody>(MARKDOWN_API_PATH, {
       version: MARKDOWN_API_VERSION,
       body: JSON.stringify(markdownState),
@@ -38,7 +42,7 @@ export const markdownClient = {
     });
   },
   get: async (id: string): Promise<MarkdownReadResponseBody> => {
-    const result = await coreServices.http
+    return await coreServices.http
       .get<MarkdownReadResponseBody>(buildPath(`${MARKDOWN_API_PATH}/{id}`, { id }), {
         version: MARKDOWN_API_VERSION,
       })
@@ -49,7 +53,6 @@ export const markdownClient = {
         const message = (e.body as { message?: string })?.message ?? e.message;
         throw new Error(message);
       });
-    return result;
   },
   search: async (searchQuery: MarkdownSearchRequestQuery) => {
     const { query, ...params } = searchQuery;
@@ -61,7 +64,7 @@ export const markdownClient = {
       },
     });
   },
-  update: async (id: string, markdownState: MarkdownAttributes) => {
+  update: async (id: string, markdownState: MarkdownUpdateRequestBody) => {
     const updateResponse = await coreServices.http.put<MarkdownUpdateResponseBody>(
       buildPath(`${MARKDOWN_API_PATH}/{id}`, { id }),
       {

--- a/src/platform/plugins/shared/dashboard_markdown/public/markdown_embeddable.test.tsx
+++ b/src/platform/plugins/shared/dashboard_markdown/public/markdown_embeddable.test.tsx
@@ -11,35 +11,51 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { act } from 'react-dom/test-utils';
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, firstValueFrom, of } from 'rxjs';
 import type { ViewMode } from '@kbn/presentation-publishing';
 import { markdownEmbeddableFactory } from './markdown_embeddable';
 import type { MarkdownEditorApi } from './types';
+import type { MarkdownEmbeddableState } from '../server/embeddable/schemas';
+import { markdownEmbeddableSchema } from '../server/embeddable/schemas';
 
 jest.mock('./markdown_client/markdown_client', () => {
   return {
     markdownClient: {
+      get: jest.fn(() => {
+        return Promise.resolve({
+          data: {
+            title: 'Markdown from library',
+            description: 'some description',
+            content: 'Loaded **markdown** content.',
+            settings: {
+              open_links_in_new_tab: true,
+            },
+          },
+        });
+      }),
       create: jest.fn().mockResolvedValue({ id: 'markdown-id-123' }),
       update: jest.fn().mockResolvedValue({ id: 'markdown-id-123' }),
     },
   };
 });
 
-jest.mock('./markdown_client/load_from_library', () => {
-  return {
-    loadFromLibrary: jest.fn((savedObjectId) => {
-      return Promise.resolve({
-        title: 'Markdown from library',
-        description: 'some description',
-        content: 'Loaded **markdown** content.',
-      });
-    }),
-  };
-});
+const defaultByValueState = {
+  content: '[click here](https://example.com)',
+  settings: {
+    open_links_in_new_tab: true,
+  },
+};
 
 const renderEmbeddable = async (
-  overrideParams?: Partial<Parameters<(typeof markdownEmbeddableFactory)['buildEmbeddable']>[0]>
+  initialState?: MarkdownEmbeddableState,
+  lastSavedState?: MarkdownEmbeddableState
 ) => {
+  function getInitialState() {
+    return initialState ?? defaultByValueState;
+  }
+  function getLastSavedState() {
+    return lastSavedState ?? getInitialState();
+  }
   const parentApiStub = {
     replacePanel: jest.fn(),
     children$: new BehaviorSubject([]),
@@ -47,15 +63,15 @@ const renderEmbeddable = async (
     setFocusedPanelId: jest.fn(),
     addNewPanel: jest.fn(),
     viewMode$: new BehaviorSubject<ViewMode>('view'),
+    lastSavedStateForChild$: () => of(getLastSavedState()),
+    getLastSavedStateForChild: getLastSavedState,
   };
 
   const factory = markdownEmbeddableFactory;
 
   const embeddable = await factory.buildEmbeddable({
     initializeDrilldownsManager: jest.fn(),
-    initialState: {
-      content: '[click here](https://example.com)',
-    },
+    initialState: getInitialState(),
     parentApi: parentApiStub,
     finalizeApi: (api) =>
       ({
@@ -64,7 +80,6 @@ const renderEmbeddable = async (
         parentApi: parentApiStub,
       } as unknown as MarkdownEditorApi),
     uuid: 'test-uuid',
-    ...overrideParams,
   });
 
   await act(async () => render(<embeddable.Component />));
@@ -81,15 +96,8 @@ describe('MarkdownEmbeddable', () => {
   });
 
   it('renders markdown content as HTML', async () => {
-    await renderEmbeddable({
-      initialState: { content: '# Heading' },
-    });
+    await renderEmbeddable({ ...defaultByValueState, content: '# Heading' });
     expect(screen.getByRole('heading', { name: 'Heading' })).toBeInTheDocument();
-  });
-
-  it('uses default empty content when no initial content provided', async () => {
-    await renderEmbeddable({ initialState: { content: '' } });
-    expect(screen.getByTestId('markdownRenderer')).toHaveTextContent(/^$/);
   });
 
   it('renders links with target="_blank"', async () => {
@@ -100,25 +108,19 @@ describe('MarkdownEmbeddable', () => {
   });
 
   it('resolves document relative links against current URL', async () => {
-    await renderEmbeddable({
-      initialState: { content: '[go to discover](discover)' },
-    });
+    await renderEmbeddable({ ...defaultByValueState, content: '[go to discover](discover)' });
     const link = screen.getByRole('link', { name: /go to discover/i });
     expect(link).toHaveAttribute('href', '/discover');
   });
 
   it('does not modify absolute links during relative resolution', async () => {
-    await renderEmbeddable({
-      initialState: { content: '[elastic](https://elastic.co)' },
-    });
+    await renderEmbeddable({ ...defaultByValueState, content: '[elastic](https://elastic.co)' });
     const link = screen.getByRole('link', { name: /elastic/i });
     expect(link).toHaveAttribute('href', 'https://elastic.co');
   });
 
   it('shows renderer in view mode, shows editor in edit mode', async () => {
-    const { embeddable } = await renderEmbeddable({
-      initialState: { content: 'HELLO' },
-    });
+    const { embeddable } = await renderEmbeddable({ ...defaultByValueState, content: 'HELLO' });
 
     expect(screen.getByTestId('markdownRenderer')).toBeInTheDocument();
     expect(screen.queryByLabelText(/Dashboard markdown editor/i)).not.toBeInTheDocument();
@@ -135,7 +137,8 @@ describe('MarkdownEmbeddable', () => {
   describe('Discard button behavior', () => {
     it('removes panel when Discard clicked for new panel', async () => {
       const { embeddable, parentApi } = await renderEmbeddable({
-        initialState: { content: 'HELLO' },
+        ...defaultByValueState,
+        content: 'HELLO',
       });
 
       await act(async () => {
@@ -148,7 +151,8 @@ describe('MarkdownEmbeddable', () => {
 
     it('does not remove panel if not new panel when Discard clicked', async () => {
       const { embeddable, parentApi } = await renderEmbeddable({
-        initialState: { content: 'HELLO' },
+        ...defaultByValueState,
+        content: 'HELLO',
       });
       await act(async () => {
         await embeddable.api.onEdit({ isNewPanel: false });
@@ -160,9 +164,7 @@ describe('MarkdownEmbeddable', () => {
   });
 
   it('saves content when Apply clicked', async () => {
-    const { embeddable } = await renderEmbeddable({
-      initialState: { content: 'HELLO' },
-    });
+    const { embeddable } = await renderEmbeddable({ ...defaultByValueState, content: 'HELLO' });
 
     await act(async () => {
       await embeddable.api.onEdit({ isNewPanel: true });
@@ -200,9 +202,7 @@ describe('MarkdownEmbeddable', () => {
   });
 
   it('loads content from library when by reference', async () => {
-    const { embeddable } = await renderEmbeddable({
-      initialState: { ref_id: '123' },
-    });
+    const { embeddable } = await renderEmbeddable({ ref_id: '123' });
 
     expect(embeddable.api.defaultTitle$?.value).toBe('Markdown from library');
     expect(embeddable.api.defaultDescription$?.value).toBe('some description');
@@ -210,23 +210,23 @@ describe('MarkdownEmbeddable', () => {
 
   it('can link to library when by value', async () => {
     const { embeddable } = await renderEmbeddable({
-      initialState: { content: 'by value markdown' },
+      ...defaultByValueState,
+      content: 'by value markdown',
     });
 
     expect(await embeddable.api.canLinkToLibrary()).toBe(true);
   });
 
   it('can unlink from library when by reference', async () => {
-    const { embeddable } = await renderEmbeddable({
-      initialState: { ref_id: '123' },
-    });
+    const { embeddable } = await renderEmbeddable({ ref_id: '123' });
 
     expect(await embeddable.api.canUnlinkFromLibrary()).toBe(true);
   });
 
   it('saves to library', async () => {
     const { embeddable } = await renderEmbeddable({
-      initialState: { content: 'by value markdown' },
+      ...defaultByValueState,
+      content: 'by value markdown',
     });
 
     const newId = await embeddable.api.saveToLibrary('My Markdown Title');
@@ -234,19 +234,15 @@ describe('MarkdownEmbeddable', () => {
   });
 
   it('gets serialized state by value', async () => {
-    const { embeddable } = await renderEmbeddable({
-      initialState: { content: 'by value markdown' },
-    });
+    const { embeddable } = await renderEmbeddable();
 
-    expect(embeddable.api.getSerializedStateByValue()).toEqual({
-      content: 'by value markdown',
-      settings: { open_links_in_new_tab: true },
-    });
+    expect(embeddable.api.getSerializedStateByValue()).toEqual(defaultByValueState);
   });
 
   it('gets serialized state by reference', async () => {
     const { embeddable } = await renderEmbeddable({
-      initialState: { content: 'by value markdown' },
+      ...defaultByValueState,
+      content: 'by value markdown',
     });
 
     expect(embeddable.api.getSerializedStateByReference('new-id')).toEqual({
@@ -256,12 +252,10 @@ describe('MarkdownEmbeddable', () => {
 
   it('unlinks from library', async () => {
     const { embeddable } = await renderEmbeddable({
-      initialState: {
-        ref_id: '123',
-        title: 'Some title',
-        description: 'some description',
-        hide_title: true,
-      },
+      ref_id: '123',
+      title: 'Some title',
+      description: 'some description',
+      hide_title: true,
     });
 
     expect(embeddable.api.getSerializedStateByValue()).toEqual({
@@ -276,10 +270,8 @@ describe('MarkdownEmbeddable', () => {
   describe('open links in new tab setting', () => {
     it('renders links with target="_self" when open_links_in_new_tab is false', async () => {
       await renderEmbeddable({
-        initialState: {
-          content: '[click here](https://example.com)',
-          settings: { open_links_in_new_tab: false },
-        },
+        content: '[click here](https://example.com)',
+        settings: { open_links_in_new_tab: false },
       });
       const link = screen.getByRole('link', { name: /click here/i });
       expect(link).toHaveAttribute('target', '_self');
@@ -287,10 +279,8 @@ describe('MarkdownEmbeddable', () => {
 
     it('toggles link target via the settings popover in edit mode', async () => {
       const { embeddable } = await renderEmbeddable({
-        initialState: {
-          content: '[click here](https://example.com)',
-          settings: { open_links_in_new_tab: true },
-        },
+        content: '[click here](https://example.com)',
+        settings: { open_links_in_new_tab: true },
       });
 
       // Verify initial state: links open in new tab
@@ -312,6 +302,38 @@ describe('MarkdownEmbeddable', () => {
 
       // Links should now open in the same tab
       expect(screen.getByRole('link', { name: /click here/i })).toHaveAttribute('target', '_self');
+    });
+  });
+
+  describe('unsaved chnages', () => {
+    it('should have unsaved changes when content has changed', async () => {
+      const lastSavedState = markdownEmbeddableSchema.validate({
+        content: 'hello',
+      });
+      const initialState = markdownEmbeddableSchema.validate({
+        content: 'goodbye',
+      });
+      const { embeddable } = await renderEmbeddable(initialState, lastSavedState);
+      const hasUnsavedChanges = await firstValueFrom(embeddable.api.hasUnsavedChanges$);
+      expect(hasUnsavedChanges).toBe(true);
+    });
+
+    it('should not have unsaved changes for by value state when there are no changes', async () => {
+      const initialState = markdownEmbeddableSchema.validate({
+        content: 'hello',
+      });
+      const { embeddable } = await renderEmbeddable(initialState);
+      const hasUnsavedChanges = await firstValueFrom(embeddable.api.hasUnsavedChanges$);
+      expect(hasUnsavedChanges).toBe(false);
+    });
+
+    it('should not have unsaved changes for by reference state when there are no changes', async () => {
+      const initialState = markdownEmbeddableSchema.validate({
+        ref_id: '1234',
+      });
+      const { embeddable } = await renderEmbeddable(initialState);
+      const hasUnsavedChanges = await firstValueFrom(embeddable.api.hasUnsavedChanges$);
+      expect(hasUnsavedChanges).toBe(false);
     });
   });
 });

--- a/src/platform/plugins/shared/dashboard_markdown/public/markdown_embeddable.tsx
+++ b/src/platform/plugins/shared/dashboard_markdown/public/markdown_embeddable.tsx
@@ -34,11 +34,9 @@ import { resolveRelativeLinksPlugin } from './plugins/resolve_relative_links';
 import { MarkdownEditor } from './components/markdown_editor';
 import { MarkdownEditorPreviewSwitch } from './components/markdown_editor_preview_switch';
 import { MarkdownRenderer } from './components/markdown_renderer';
-import { loadFromLibrary } from './markdown_client/load_from_library';
 import { checkForDuplicateTitle } from './markdown_client/duplicate_title_check';
 import { markdownClient } from './markdown_client/markdown_client';
-import type { MarkdownAttributes } from '../server/markdown_saved_object';
-import type { MarkdownSettingsState } from '../server/schemas';
+import type { MarkdownSettingsState } from '../server/embeddable/schemas';
 
 const flexCss = css({
   display: 'flex',
@@ -54,33 +52,27 @@ export const markdownEmbeddableFactory: EmbeddableFactory<
     const libraryId = (initialState as MarkdownByReferenceState).ref_id;
     const isByReference = libraryId !== undefined;
     const initialLibraryState = isByReference
-      ? await loadFromLibrary(libraryId)
-      : ({
-          title: '',
-          description: '',
-          content: '',
-        } as MarkdownAttributes);
+      ? (await markdownClient.get(libraryId)).data
+      : undefined;
 
     const titleManager = initializeTitleManager(initialState);
     const content$ = new BehaviorSubject<string>(
-      isByReference ? initialLibraryState.content : (initialState as MarkdownByValueState).content
+      initialLibraryState
+        ? initialLibraryState.content
+        : (initialState as MarkdownByValueState).content
     );
-    const defaultTitle$ = new BehaviorSubject<string | undefined>(
-      isByReference ? initialLibraryState.title : undefined
-    );
+    const defaultTitle$ = new BehaviorSubject<string | undefined>(initialLibraryState?.title);
     const defaultDescription$ = new BehaviorSubject<string | undefined>(
-      isByReference ? initialLibraryState.description : undefined
+      initialLibraryState?.description
     );
     const isEditing$ = new BehaviorSubject<boolean>(false);
     const isNewPanel$ = new BehaviorSubject<boolean>(false);
     const isPreview$ = new BehaviorSubject<boolean>(false);
 
     const settings$ = new BehaviorSubject<MarkdownSettingsState>(
-      (isByReference
+      initialLibraryState
         ? initialLibraryState.settings
-        : (initialState as MarkdownByValueState).settings) ?? {
-        open_links_in_new_tab: true,
-      }
+        : (initialState as MarkdownByValueState).settings
     );
 
     const overrideHoverActions$ = new BehaviorSubject<boolean>(false);
@@ -133,11 +125,7 @@ export const markdownEmbeddableFactory: EmbeddableFactory<
         // by reference 'content' or 'settings' since they are saved on apply.
         if (!isByReference) {
           content$.next((initialState as MarkdownByValueState).content);
-          settings$.next(
-            (initialState as MarkdownByValueState).settings ?? {
-              open_links_in_new_tab: true,
-            }
-          );
+          settings$.next((initialState as MarkdownByValueState).settings);
         }
       },
     });
@@ -264,9 +252,12 @@ export const markdownEmbeddableFactory: EmbeddableFactory<
                 if (libraryId) {
                   await markdownClient.update(libraryId, {
                     content: value,
-                    title: titleManager.api.title$.getValue() ?? initialLibraryState.title,
+                    title:
+                      titleManager.api.title$.getValue() ??
+                      initialLibraryState?.title ??
+                      'new markdown',
                     description:
-                      titleManager.api.description$.getValue() ?? initialLibraryState.description,
+                      titleManager.api.description$.getValue() ?? initialLibraryState?.description,
                     settings: settings$.getValue(),
                   });
                 }

--- a/src/platform/plugins/shared/dashboard_markdown/server/api/create/schemas.ts
+++ b/src/platform/plugins/shared/dashboard_markdown/server/api/create/schemas.ts
@@ -9,12 +9,12 @@
 
 import { schema } from '@kbn/config-schema';
 import { asCodeMetaSchema } from '@kbn/as-code-shared-schemas';
-import { markdownAttributesSchema } from '../../markdown_saved_object/schema/v1';
+import { markdownLibraryItemSchema } from '../schema';
 
-export const createRequestBodySchema = markdownAttributesSchema;
+export const createRequestBodySchema = markdownLibraryItemSchema;
 
 export const createResponseBodySchema = schema.object({
   id: schema.string(),
-  data: markdownAttributesSchema,
+  data: markdownLibraryItemSchema,
   meta: asCodeMetaSchema,
 });

--- a/src/platform/plugins/shared/dashboard_markdown/server/api/get_cru_response_body.ts
+++ b/src/platform/plugins/shared/dashboard_markdown/server/api/get_cru_response_body.ts
@@ -10,6 +10,7 @@
 import type { SavedObject, SavedObjectsUpdateResponse } from '@kbn/core/server';
 import { getMeta } from '@kbn/as-code-shared-schemas';
 import type { MarkdownAttributes } from '../markdown_saved_object';
+import { markdownLibraryItemSchema } from './schema';
 
 // CRU is Create, Read, Update
 export function getMarkdownCRUResponseBody(
@@ -17,7 +18,9 @@ export function getMarkdownCRUResponseBody(
 ) {
   return {
     id: savedObject.id,
-    data: savedObject.attributes as MarkdownAttributes,
+    // Route does not apply defaults to response
+    // Instead, call validate to ensure defaults are applied to response
+    data: markdownLibraryItemSchema.validate(savedObject.attributes),
     meta: getMeta(savedObject),
   };
 }

--- a/src/platform/plugins/shared/dashboard_markdown/server/api/read/schemas.ts
+++ b/src/platform/plugins/shared/dashboard_markdown/server/api/read/schemas.ts
@@ -9,10 +9,10 @@
 
 import { schema } from '@kbn/config-schema';
 import { asCodeMetaSchema } from '@kbn/as-code-shared-schemas';
-import { markdownAttributesSchema } from '../../markdown_saved_object/schema/v1';
+import { markdownLibraryItemSchema } from '../schema';
 
 export const readResponseBodySchema = schema.object({
   id: schema.string(),
-  data: markdownAttributesSchema,
+  data: markdownLibraryItemSchema,
   meta: asCodeMetaSchema,
 });

--- a/src/platform/plugins/shared/dashboard_markdown/server/api/schema.ts
+++ b/src/platform/plugins/shared/dashboard_markdown/server/api/schema.ts
@@ -7,10 +7,11 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { MarkdownAttributes } from '../../server/markdown_saved_object';
-import { markdownClient } from './markdown_client';
+import { schema } from '@kbn/config-schema';
+import { markdownAttributesSchema } from '../markdown_saved_object';
+import { markdownByValueStateSchema } from '../embeddable/schemas';
 
-export async function loadFromLibrary(libraryId: string): Promise<MarkdownAttributes> {
-  const { data } = await markdownClient.get(libraryId);
-  return data as MarkdownAttributes;
-}
+export const markdownLibraryItemSchema = schema.object({
+  ...markdownAttributesSchema.getPropSchemas(),
+  ...markdownByValueStateSchema.getPropSchemas(),
+});

--- a/src/platform/plugins/shared/dashboard_markdown/server/api/update/schemas.ts
+++ b/src/platform/plugins/shared/dashboard_markdown/server/api/update/schemas.ts
@@ -9,12 +9,12 @@
 
 import { schema } from '@kbn/config-schema';
 import { asCodeMetaSchema } from '@kbn/as-code-shared-schemas';
-import { markdownAttributesSchema } from '../../markdown_saved_object/schema/v1';
+import { markdownLibraryItemSchema } from '../schema';
 
-export const updateRequestBodySchema = markdownAttributesSchema;
+export const updateRequestBodySchema = markdownLibraryItemSchema;
 
 export const updateResponseBodySchema = schema.object({
   id: schema.string(),
-  data: markdownAttributesSchema,
+  data: markdownLibraryItemSchema,
   meta: asCodeMetaSchema,
 });

--- a/src/platform/plugins/shared/dashboard_markdown/server/embeddable/schemas.ts
+++ b/src/platform/plugins/shared/dashboard_markdown/server/embeddable/schemas.ts
@@ -12,26 +12,19 @@ import { schema } from '@kbn/config-schema';
 import { serializedTitlesSchema } from '@kbn/presentation-publishing-schemas';
 import { BY_REF_SCHEMA_META, BY_VALUE_SCHEMA_META } from '@kbn/presentation-publishing-schemas';
 
-// Markdown by-value state schema (contains content)
-const markdownByValueStateSchema = schema.object({
-  content: schema.string({
-    defaultValue: '',
+export const markdownByValueStateSchema = schema.object({
+  content: schema.string(),
+  settings: schema.object({
+    open_links_in_new_tab: schema.boolean({ defaultValue: true }),
   }),
-  settings: schema.maybe(
-    schema.object({
-      open_links_in_new_tab: schema.boolean({ defaultValue: true }),
-    })
-  ),
 });
 
-// Markdown by-reference state schema (contains savedObjectId)
 const markdownByReferenceStateSchema = schema.object({
   ref_id: schema.string({
     meta: { description: 'The unique identifier of the markdown library item.' },
   }),
 });
 
-// Markdown by-value embeddable schema (by-value state + titles)
 export const markdownByValueEmbeddableSchema = schema.allOf(
   [markdownByValueStateSchema, serializedTitlesSchema],
   {
@@ -39,7 +32,6 @@ export const markdownByValueEmbeddableSchema = schema.allOf(
   }
 );
 
-// Markdown by-reference embeddable schema (by-reference state + titles)
 const markdownByReferenceEmbeddableSchema = schema.allOf(
   [markdownByReferenceStateSchema, serializedTitlesSchema],
   {
@@ -47,11 +39,9 @@ const markdownByReferenceEmbeddableSchema = schema.allOf(
   }
 );
 
-// Complete markdown embeddable schema (union of by-value and by-reference embeddables)
 export const markdownEmbeddableSchema = schema.oneOf(
   [markdownByValueEmbeddableSchema, markdownByReferenceEmbeddableSchema],
   {
-    defaultValue: { content: '', settings: { open_links_in_new_tab: true } },
     meta: {
       description: 'Markdown panel config',
     },

--- a/src/platform/plugins/shared/dashboard_markdown/server/index.ts
+++ b/src/platform/plugins/shared/dashboard_markdown/server/index.ts
@@ -14,7 +14,7 @@ export {
   type MarkdownByValueState,
   markdownEmbeddableSchema,
   type MarkdownEmbeddableState,
-} from './schemas';
+} from './embeddable/schemas';
 
 export type {
   MarkdownCreateRequestBody,

--- a/src/platform/plugins/shared/dashboard_markdown/server/plugin.ts
+++ b/src/platform/plugins/shared/dashboard_markdown/server/plugin.ts
@@ -11,7 +11,7 @@ import type { CoreSetup, CoreStart, Plugin } from '@kbn/core/server';
 
 import { registerRoutes } from './api/register_routes';
 import { MARKDOWN_EMBEDDABLE_TYPE, MARKDOWN_SAVED_OBJECT_TYPE } from '../common/constants';
-import { markdownEmbeddableSchema } from './schemas';
+import { markdownEmbeddableSchema } from './embeddable/schemas';
 import type { MarkdownAttributes } from './markdown_saved_object';
 import { markdownSavedObjectType } from './markdown_saved_object';
 import { MarkdownStorage } from './content_management';


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[markdown embeddable] fix unsaved changes when settings not provided (#263564)](https://github.com/elastic/kibana/pull/263564)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Nathan Reese","email":"reese.nathan@elastic.co"},"sourceCommit":{"committedDate":"2026-04-16T20:22:33Z","message":"[markdown embeddable] fix unsaved changes when settings not provided (#263564)\n\nCloses https://github.com/elastic/kibana/issues/263127\n\nUnsaved changes regression caused by\nhttps://github.com/elastic/kibana/pull/260782.\nhttps://github.com/elastic/kibana/pull/260782 add `settings` to markdown\nschema as optional. MarkdownEmbeddable populated settings when not\nprovided. Unsaved changes occurred when settings where not provided in\npanel config (MarkdownEmbeddable provided defaults resulting in unsaved\nchanges).\n\nThis PR resolves the regression by making `settings` required in the\nschema, thus populating settings at the REST API level.\n\n### test instructions\n* create dashboard in dev tools console\n    ```\n    POST kbn:/api/dashboards\n    {\n      \"title\": \"issue_263127 dashboard\",\n      \"panels\": [\n        {\n          \"grid\": { \"x\": 0, \"y\": 0, \"w\": 24, \"h\": 15 },\n          \"type\": \"markdown\",\n          \"config\": {\n            \"content\": \"## Web logs overview\"\n          }\n        }\n      ]\n    }\n    ```\n* Open dashboard in edit mode and verify there are no unsaved changes\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"b65a0c2d94197f68c677ebf062f5a57c8c7ce98c","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Presentation","release_note:skip","backport:version","Project:Dashboards API","v9.4.0","v9.5.0"],"title":"[markdown embeddable] fix unsaved changes when settings not provided","number":263564,"url":"https://github.com/elastic/kibana/pull/263564","mergeCommit":{"message":"[markdown embeddable] fix unsaved changes when settings not provided (#263564)\n\nCloses https://github.com/elastic/kibana/issues/263127\n\nUnsaved changes regression caused by\nhttps://github.com/elastic/kibana/pull/260782.\nhttps://github.com/elastic/kibana/pull/260782 add `settings` to markdown\nschema as optional. MarkdownEmbeddable populated settings when not\nprovided. Unsaved changes occurred when settings where not provided in\npanel config (MarkdownEmbeddable provided defaults resulting in unsaved\nchanges).\n\nThis PR resolves the regression by making `settings` required in the\nschema, thus populating settings at the REST API level.\n\n### test instructions\n* create dashboard in dev tools console\n    ```\n    POST kbn:/api/dashboards\n    {\n      \"title\": \"issue_263127 dashboard\",\n      \"panels\": [\n        {\n          \"grid\": { \"x\": 0, \"y\": 0, \"w\": 24, \"h\": 15 },\n          \"type\": \"markdown\",\n          \"config\": {\n            \"content\": \"## Web logs overview\"\n          }\n        }\n      ]\n    }\n    ```\n* Open dashboard in edit mode and verify there are no unsaved changes\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"b65a0c2d94197f68c677ebf062f5a57c8c7ce98c"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/263564","number":263564,"mergeCommit":{"message":"[markdown embeddable] fix unsaved changes when settings not provided (#263564)\n\nCloses https://github.com/elastic/kibana/issues/263127\n\nUnsaved changes regression caused by\nhttps://github.com/elastic/kibana/pull/260782.\nhttps://github.com/elastic/kibana/pull/260782 add `settings` to markdown\nschema as optional. MarkdownEmbeddable populated settings when not\nprovided. Unsaved changes occurred when settings where not provided in\npanel config (MarkdownEmbeddable provided defaults resulting in unsaved\nchanges).\n\nThis PR resolves the regression by making `settings` required in the\nschema, thus populating settings at the REST API level.\n\n### test instructions\n* create dashboard in dev tools console\n    ```\n    POST kbn:/api/dashboards\n    {\n      \"title\": \"issue_263127 dashboard\",\n      \"panels\": [\n        {\n          \"grid\": { \"x\": 0, \"y\": 0, \"w\": 24, \"h\": 15 },\n          \"type\": \"markdown\",\n          \"config\": {\n            \"content\": \"## Web logs overview\"\n          }\n        }\n      ]\n    }\n    ```\n* Open dashboard in edit mode and verify there are no unsaved changes\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"b65a0c2d94197f68c677ebf062f5a57c8c7ce98c"}}]}] BACKPORT-->