### PR TITLE
[Platform] improve Scout script to allow keeping existing ES data

### DIFF
--- a/src/platform/packages/shared/kbn-scout/README.md
+++ b/src/platform/packages/shared/kbn-scout/README.md
@@ -400,7 +400,7 @@ Scout uses Playwright's [projects concept](https://playwright.dev/docs/test-proj
 
 ```json
 {
-  "serverless": true
+  "serverless": true,
   "projectType": "es",
   "isCloud": true,
   "cloudHostName": "elastic_cloud_hostname_qa_staging_prod",
@@ -426,6 +426,7 @@ node scripts/scout start-server --arch <arch> --domain <domain>
 
 - **`--arch`**: `stateful` or `serverless`.
 - **`--domain`**: e.g. `classic`, `search`, `observability_complete`, `security_complete`. Use `node scripts/scout start-server --help` for the full list.
+- **`--preserveEsData`**: Reuse existing serverless ES object store data on startup instead of cleaning it (useful when restarting after crashes).
 
 This command is useful for manual testing or running tests via an IDE.
 

--- a/src/platform/packages/shared/kbn-scout/src/playwright/runner/flags.test.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/runner/flags.test.ts
@@ -8,6 +8,7 @@
  */
 
 import { FlagsReader } from '@kbn/dev-cli-runner';
+import { ScoutTestTarget } from '@kbn/scout-info';
 import * as testFilesUtils from '../../common/utils';
 import * as configValidator from './config_validator';
 import { parseTestFlags } from './flags';
@@ -38,6 +39,7 @@ describe('parseTestFlags', () => {
       domain: 'classic',
       headed: false,
       logToFile: false,
+      preserveEsData: false,
       serverConfigSet: 'default',
     });
 
@@ -54,6 +56,7 @@ describe('parseTestFlags', () => {
       arch: 'stateful',
       domain: 'classic',
       logToFile: false,
+      preserveEsData: false,
       headed: false,
       serverConfigSet: 'default',
     });
@@ -69,6 +72,7 @@ describe('parseTestFlags', () => {
       arch: true,
       domain: 'classic',
       logToFile: false,
+      preserveEsData: false,
       headed: false,
       serverConfigSet: 'default',
     });
@@ -82,6 +86,7 @@ describe('parseTestFlags', () => {
       arch: 'stateful',
       domain: true,
       logToFile: false,
+      preserveEsData: false,
       headed: false,
       serverConfigSet: 'default',
     });
@@ -95,6 +100,7 @@ describe('parseTestFlags', () => {
       arch: 'stateful',
       domain: 'classic',
       logToFile: false,
+      preserveEsData: false,
       headed: false,
       serverConfigSet: 'default',
     });
@@ -110,6 +116,7 @@ describe('parseTestFlags', () => {
       arch: 'bad_arch',
       domain: 'classic',
       logToFile: false,
+      preserveEsData: false,
       headed: false,
       serverConfigSet: 'default',
     });
@@ -125,6 +132,7 @@ describe('parseTestFlags', () => {
       arch: 'stateful',
       domain: 'rainbow-barfing-unicorns',
       logToFile: false,
+      preserveEsData: false,
       headed: false,
       serverConfigSet: 'default',
     });
@@ -141,6 +149,7 @@ describe('parseTestFlags', () => {
       domain: 'observability_complete',
       config: '/path/to/config',
       logToFile: false,
+      preserveEsData: false,
       headed: false,
       serverConfigSet: 'default',
     });
@@ -154,12 +163,9 @@ describe('parseTestFlags', () => {
       repeatEach: undefined,
       installDir: undefined,
       logsDir: undefined,
+      preserveEsData: false,
       serverConfigSet: 'default',
-      testTarget: {
-        arch: 'serverless',
-        domain: 'observability_complete',
-        location: 'local',
-      },
+      testTarget: new ScoutTestTarget('local', 'serverless', 'observability_complete'),
     });
   });
 
@@ -170,6 +176,7 @@ describe('parseTestFlags', () => {
       domain: 'classic',
       config: '/path/to/config',
       logToFile: false,
+      preserveEsData: false,
       headed: true,
       esFrom: 'snapshot',
       serverConfigSet: 'default',
@@ -184,12 +191,9 @@ describe('parseTestFlags', () => {
       repeatEach: undefined,
       installDir: undefined,
       logsDir: undefined,
+      preserveEsData: false,
       serverConfigSet: 'default',
-      testTarget: {
-        arch: 'stateful',
-        domain: 'classic',
-        location: 'local',
-      },
+      testTarget: new ScoutTestTarget('local', 'stateful', 'classic'),
     });
   });
 
@@ -200,6 +204,7 @@ describe('parseTestFlags', () => {
       domain: 'security_ease',
       config: '/path/to/config',
       logToFile: false,
+      preserveEsData: false,
       headed: false,
       serverConfigSet: 'default',
     });
@@ -213,12 +218,9 @@ describe('parseTestFlags', () => {
       repeatEach: undefined,
       installDir: undefined,
       logsDir: undefined,
+      preserveEsData: false,
       serverConfigSet: 'default',
-      testTarget: {
-        arch: 'serverless',
-        domain: 'security_ease',
-        location: 'cloud',
-      },
+      testTarget: new ScoutTestTarget('cloud', 'serverless', 'security_ease'),
     });
   });
 
@@ -229,6 +231,7 @@ describe('parseTestFlags', () => {
       domain: 'classic',
       config: '/path/to/config',
       logToFile: false,
+      preserveEsData: false,
       headed: true,
       esFrom: 'snapshot',
       serverConfigSet: 'default',
@@ -243,12 +246,9 @@ describe('parseTestFlags', () => {
       repeatEach: undefined,
       installDir: undefined,
       logsDir: undefined,
+      preserveEsData: false,
       serverConfigSet: 'default',
-      testTarget: {
-        arch: 'stateful',
-        domain: 'classic',
-        location: 'cloud',
-      },
+      testTarget: new ScoutTestTarget('cloud', 'stateful', 'classic'),
     });
   });
 
@@ -259,6 +259,7 @@ describe('parseTestFlags', () => {
       domain: 'classic',
       config: '/path/to/config',
       logToFile: false,
+      preserveEsData: false,
       headed: false,
       repeatEach: '5',
       serverConfigSet: 'default',
@@ -273,12 +274,9 @@ describe('parseTestFlags', () => {
       repeatEach: 5,
       installDir: undefined,
       logsDir: undefined,
+      preserveEsData: false,
       serverConfigSet: 'default',
-      testTarget: {
-        arch: 'stateful',
-        domain: 'classic',
-        location: 'local',
-      },
+      testTarget: new ScoutTestTarget('local', 'stateful', 'classic'),
     });
   });
 
@@ -289,6 +287,7 @@ describe('parseTestFlags', () => {
       domain: 'classic',
       config: '/path/to/config',
       logToFile: false,
+      preserveEsData: false,
       headed: false,
       repeatEach: 'abc',
       serverConfigSet: 'default',
@@ -306,6 +305,7 @@ describe('parseTestFlags', () => {
       domain: 'classic',
       config: '/path/to/config',
       logToFile: false,
+      preserveEsData: false,
       headed: false,
       repeatEach: '0',
       serverConfigSet: 'default',
@@ -323,6 +323,7 @@ describe('parseTestFlags', () => {
       domain: 'classic',
       config: '/path/to/config',
       logToFile: false,
+      preserveEsData: false,
       headed: false,
       repeatEach: '2.5',
       serverConfigSet: 'default',
@@ -356,6 +357,7 @@ describe('parseTestFlags', () => {
         domain: 'classic',
         testFiles: testFile,
         logToFile: false,
+        preserveEsData: false,
         headed: false,
         serverConfigSet: 'default',
       });
@@ -370,13 +372,10 @@ describe('parseTestFlags', () => {
         repeatEach: undefined,
         installDir: undefined,
         logsDir: undefined,
+        preserveEsData: false,
         serverConfigSet: 'default',
         testFiles: [testFile],
-        testTarget: {
-          arch: 'stateful',
-          domain: 'classic',
-          location: 'local',
-        },
+        testTarget: new ScoutTestTarget('local', 'stateful', 'classic'),
       });
     });
 
@@ -400,6 +399,7 @@ describe('parseTestFlags', () => {
         domain: 'classic',
         testFiles: testFilesString,
         logToFile: false,
+        preserveEsData: false,
         headed: false,
         serverConfigSet: 'default',
       });
@@ -414,13 +414,10 @@ describe('parseTestFlags', () => {
         repeatEach: undefined,
         installDir: undefined,
         logsDir: undefined,
+        preserveEsData: false,
         serverConfigSet: 'default',
         testFiles,
-        testTarget: {
-          arch: 'stateful',
-          domain: 'classic',
-          location: 'local',
-        },
+        testTarget: new ScoutTestTarget('local', 'stateful', 'classic'),
       });
     });
 
@@ -441,6 +438,7 @@ describe('parseTestFlags', () => {
         domain: 'classic',
         testFiles: testFile,
         logToFile: false,
+        preserveEsData: false,
         headed: false,
         serverConfigSet: 'default',
       });
@@ -468,6 +466,7 @@ describe('parseTestFlags', () => {
         domain: 'classic',
         testFiles: testFile,
         logToFile: false,
+        preserveEsData: false,
         headed: false,
         serverConfigSet: 'default',
       });
@@ -492,6 +491,7 @@ describe('parseTestFlags', () => {
         domain: 'classic',
         testFiles: testFile,
         logToFile: false,
+        preserveEsData: false,
         headed: false,
         serverConfigSet: 'default',
       });
@@ -506,6 +506,7 @@ describe('parseTestFlags', () => {
         domain: 'classic',
         config: '/path/to/config',
         logToFile: false,
+        preserveEsData: false,
         headed: false,
         serverConfigSet: 'default',
       });

--- a/src/platform/packages/shared/kbn-scout/src/servers/flags.test.ts
+++ b/src/platform/packages/shared/kbn-scout/src/servers/flags.test.ts
@@ -17,6 +17,7 @@ describe('parseServerFlags', () => {
       arch: 'agentic',
       domain: 'security_complete',
       logToFile: false,
+      preserveEsData: false,
       headed: false,
     });
 
@@ -32,6 +33,7 @@ describe('parseServerFlags', () => {
       domain: 'observability_complete',
       headed: false,
       logToFile: false,
+      preserveEsData: false,
       serverConfigSet: 'default',
     });
     const result = parseServerFlags(flags);
@@ -40,6 +42,7 @@ describe('parseServerFlags', () => {
       esFrom: undefined,
       installDir: undefined,
       logsDir: undefined,
+      preserveEsData: false,
       serverConfigSet: 'default',
       testTarget: {
         arch: 'serverless',
@@ -56,6 +59,7 @@ describe('parseServerFlags', () => {
       domain: 'observability_complete',
       esFrom: 'snapshot',
       logToFile: false,
+      preserveEsData: false,
       serverConfigSet: 'default',
     });
     const result = parseServerFlags(flags);
@@ -64,6 +68,7 @@ describe('parseServerFlags', () => {
       esFrom: 'snapshot',
       installDir: undefined,
       logsDir: undefined,
+      preserveEsData: false,
       serverConfigSet: 'default',
       testTarget: {
         arch: 'stateful',
@@ -79,6 +84,7 @@ describe('parseServerFlags', () => {
       arch: 'stateful',
       domain: 'classic',
       logToFile: false,
+      preserveEsData: false,
       serverConfigSet: 'uiam_local',
     });
     const result = parseServerFlags(flags);
@@ -87,11 +93,37 @@ describe('parseServerFlags', () => {
       esFrom: undefined,
       installDir: undefined,
       logsDir: undefined,
+      preserveEsData: false,
       serverConfigSet: 'uiam_local',
       testTarget: {
         arch: 'stateful',
         domain: 'classic',
         location: 'cloud',
+      },
+    });
+  });
+
+  it(`should parse preserveEsData flag`, () => {
+    const flags = new FlagsReader({
+      location: 'local',
+      arch: 'serverless',
+      domain: 'security_complete',
+      logToFile: false,
+      preserveEsData: true,
+      serverConfigSet: 'default',
+    });
+    const result = parseServerFlags(flags);
+
+    expect(result).toEqual({
+      esFrom: undefined,
+      installDir: undefined,
+      logsDir: undefined,
+      preserveEsData: true,
+      serverConfigSet: 'default',
+      testTarget: {
+        arch: 'serverless',
+        domain: 'security_complete',
+        location: 'local',
       },
     });
   });

--- a/src/platform/packages/shared/kbn-scout/src/servers/flags.ts
+++ b/src/platform/packages/shared/kbn-scout/src/servers/flags.ts
@@ -33,7 +33,7 @@ const supportedLocations: ScoutTargetLocation[] = ScoutTargetLocationSchema.opti
 
 export const SERVER_FLAG_OPTIONS: FlagOptions = {
   string: ['location', 'arch', 'domain', 'serverConfigSet', 'esFrom', 'kibanaInstallDir'],
-  boolean: ['logToFile'],
+  boolean: ['logToFile', 'preserveEsData'],
   default: { location: 'local', serverConfigSet: 'default' },
   help: `
     --location          Where is the test target located (one of: ${supportedLocations.join(
@@ -45,6 +45,7 @@ export const SERVER_FLAG_OPTIONS: FlagOptions = {
     --esFrom            Build Elasticsearch from source or run snapshot or serverless. [default: $TEST_ES_FROM or "snapshot"]
     --kibanaInstallDir  Run Kibana from existing install directory instead of from source
     --logToFile         Write the log output from Kibana/ES to files instead of to stdout
+    --preserveEsData    Reuse existing serverless ES object store data instead of cleaning it on startup
   `,
 };
 
@@ -71,6 +72,7 @@ export function parseServerFlags(flags: FlagsReader) {
   const serverConfigSet = flags.requiredString('serverConfigSet');
   const esFrom = flags.enum('esFrom', ['source', 'snapshot', 'serverless']);
   const installDir = flags.string('kibanaInstallDir');
+  const preserveEsData = flags.boolean('preserveEsData');
   const logsDir = flags.boolean('logToFile')
     ? resolve(REPO_ROOT, 'data/ftr_servers_logs', uuidV4())
     : undefined;
@@ -79,6 +81,7 @@ export function parseServerFlags(flags: FlagsReader) {
     testTarget,
     serverConfigSet,
     esFrom,
+    preserveEsData,
     installDir,
     logsDir,
   };

--- a/src/platform/packages/shared/kbn-scout/src/servers/run_elasticsearch.ts
+++ b/src/platform/packages/shared/kbn-scout/src/servers/run_elasticsearch.ts
@@ -21,6 +21,7 @@ interface RunElasticsearchOptions {
   log: ToolingLog;
   esFrom?: string;
   esServerlessImage?: string;
+  preserveEsData?: boolean;
   config: Config;
   onEarlyExit?: (msg: string) => void;
   logsDir?: string;
@@ -83,6 +84,7 @@ export async function runElasticsearch(
     name: name ?? 'scout',
     logsDir,
     config,
+    preserveEsData: options.preserveEsData,
   });
 
   // Start linked cluster for Cross Project Search after origin is ready
@@ -93,7 +95,7 @@ export async function runElasticsearch(
       dataPath: `stateless-cluster-${name ?? 'scout'}`,
       ...config.esServerlessOptions,
       port: config.port,
-      clean: true,
+      clean: !options.preserveEsData,
       background: true,
       files: config.files,
       ssl: config.ssl,
@@ -115,12 +117,14 @@ async function startEsNode({
   config,
   onEarlyExit,
   logsDir,
+  preserveEsData,
 }: {
   log: ToolingLog;
   name: string;
   config: EsConfig & { transportPort?: number };
   onEarlyExit?: (msg: string) => void;
   logsDir?: string;
+  preserveEsData?: boolean;
 }) {
   const cluster = createTestEsCluster({
     clusterName: `cluster-${name}`,
@@ -144,6 +148,7 @@ async function startEsNode({
     transportPort: config.transportPort,
     onEarlyExit,
     serverless: config.serverless,
+    clean: config.serverless ? !preserveEsData : undefined,
     files: config.files,
     secureFiles: config.secureFiles,
   });

--- a/src/platform/packages/shared/kbn-scout/src/servers/start_servers.ts
+++ b/src/platform/packages/shared/kbn-scout/src/servers/start_servers.ts
@@ -40,6 +40,7 @@ export async function startServers(log: ToolingLog, options: StartServerOptions)
       config,
       log,
       esFrom: options.esFrom,
+      preserveEsData: options.preserveEsData,
       logsDir: options.logsDir,
     });
 

--- a/src/platform/packages/shared/kbn-test-es-server/src/test_es_cluster.ts
+++ b/src/platform/packages/shared/kbn-test-es-server/src/test_es_cluster.ts
@@ -170,6 +170,12 @@ export interface CreateTestEsClusterOptions {
    */
   serverless?: boolean;
   /**
+   * Clean existing serverless object store data before startup.
+   *
+   * Defaults to `true` for backwards compatibility.
+   */
+  clean?: boolean;
+  /**
    * Files to mount inside ES containers
    */
   files?: string[];
@@ -218,6 +224,7 @@ export function createTestEsCluster<
     onEarlyExit,
     files,
     secureFiles,
+    clean = true,
   } = options;
 
   const clusterName = `${CI_PARALLEL_PROCESS_PREFIX}${customClusterName}`;
@@ -315,7 +322,7 @@ export function createTestEsCluster<
           dataPath: `stateless-${clusterName}`,
           ...esServerlessOptions,
           port,
-          clean: true,
+          clean,
           background: true,
           files,
           ssl,


### PR DESCRIPTION
## Summary

This small PR improves the flexibility of the Scout script to allow not destroying all data in ES instances.

Today for example when we run the following command to spin up a Serverless CPS environment (see [this document](https://docs.google.com/document/d/16c6H8EVyyAUwp7QDm-77__RHz_hSJ2_wE40_as7WIqE/edit?pli=1&tab=t.0)):
```
node scripts/scout start-server --arch serverless \
  --domain security_complete --serverConfigSet cps_local
```
It always starts completely fresh. This is pretty annoying when we have to do this right after a crash, which tends to happen pretty often when switching branches and all...

The PR adds a new `--preserveEsData` option, to allow re-spinning up the environment without destroying any ES data:
```
node scripts/scout start-server --arch serverless \
  --domain security_complete --serverConfigSet cps_local \
  --preserveEsData
```

I tested locally and it all works great!

### Checklist

- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->