### PR TITLE
[Security Solution][Discover] show callout and badge for remote documents in alert/event/attacks flyouts header

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/components/header_title.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/components/header_title.test.tsx
@@ -18,6 +18,7 @@ import {
   HEADER_ASSIGNEES_BLOCK_TEST_ID,
   HEADER_BADGE_TEST_ID,
 } from '../constants/test_ids';
+import { REMOTE_DOCUMENT_BADGE_TEST_ID } from '../../../flyout_v2/document/components/remote_document_badge';
 
 jest.mock('../hooks/use_header_data', () => ({
   useHeaderData: jest.fn(),
@@ -55,6 +56,11 @@ jest.mock('../../../flyout_v2/shared/components/notes', () => ({
   ),
 }));
 
+jest.mock('../../../flyout_v2/document/components/remote_document_badge', () => ({
+  ...jest.requireActual('../../../flyout_v2/document/components/remote_document_badge'),
+  RemoteDocumentBadge: () => <div data-test-subj="remoteDocumentBadge" />,
+}));
+
 jest.mock('../../../flyout_v2/shared/components/alert_header_block', () => ({
   AlertHeaderBlock: ({
     children,
@@ -76,7 +82,10 @@ describe('HeaderTitle', () => {
       timestamp: '2024-10-10T10:00:00.000Z',
       alertsCount: 3,
     });
-    mockedUseAttackDetailsContext.mockReturnValue({ attackId: 'attack-1' });
+    mockedUseAttackDetailsContext.mockReturnValue({
+      attackId: 'attack-1',
+      searchHit: { _index: '.alerts-security.alerts-default', _id: 'attack-1' },
+    });
     mockedUseNavigateToAttackDetailsLeftPanel.mockReturnValue(jest.fn());
   });
 
@@ -84,7 +93,7 @@ describe('HeaderTitle', () => {
     jest.clearAllMocks();
   });
 
-  it('renders the attack badge', () => {
+  it('renders the attack badge for a local document', () => {
     render(
       <TestProviders>
         <HeaderTitle />
@@ -92,6 +101,26 @@ describe('HeaderTitle', () => {
     );
 
     expect(screen.getByTestId(HEADER_BADGE_TEST_ID)).toHaveTextContent('Attack');
+    expect(screen.queryByTestId(REMOTE_DOCUMENT_BADGE_TEST_ID)).not.toBeInTheDocument();
+  });
+
+  it('renders the remote document badge instead of the attack badge for a remote document', () => {
+    mockedUseAttackDetailsContext.mockReturnValue({
+      attackId: 'attack-1',
+      searchHit: {
+        _index: 'remote-cluster:.alerts-security.alerts-default',
+        _id: 'attack-1',
+      },
+    });
+
+    render(
+      <TestProviders>
+        <HeaderTitle />
+      </TestProviders>
+    );
+
+    expect(screen.getByTestId(REMOTE_DOCUMENT_BADGE_TEST_ID)).toBeInTheDocument();
+    expect(screen.queryByTestId(HEADER_BADGE_TEST_ID)).not.toBeInTheDocument();
   });
 
   it('renders the formatted timestamp when present', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/components/header_title.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/components/header_title.tsx
@@ -5,9 +5,10 @@
  * 2.0.
  */
 
-import React, { memo } from 'react';
+import React, { memo, useMemo } from 'react';
 import { EuiBadge, EuiFlexGroup, EuiFlexItem, EuiSpacer } from '@elastic/eui';
-
+import { buildDataTableRecord, getFieldValue, type EsHitRecord } from '@kbn/discover-utils';
+import { isCCSRemoteIndexName } from '@kbn/es-query';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
 import { flyoutHeaderBlockStyles } from '../../../flyout_v2/document/constants/styles';
@@ -26,6 +27,7 @@ import {
 import { useHeaderData } from '../hooks/use_header_data';
 import { useAttackDetailsContext } from '../context';
 import { useNavigateToAttackDetailsLeftPanel } from '../hooks/use_navigate_to_attack_details_left_panel';
+import { RemoteDocumentBadge } from '../../../flyout_v2/document/components/remote_document_badge';
 
 const ATTACK_HEADER_BADGE = i18n.translate(
   'xpack.securitySolution.attackDetailsFlyout.header.badge.attackLabel',
@@ -39,8 +41,13 @@ const ATTACK_HEADER_BADGE = i18n.translate(
  */
 export const HeaderTitle = memo(() => {
   const { title, timestamp, alertsCount } = useHeaderData();
-  const { attackId } = useAttackDetailsContext();
+  const { attackId, searchHit } = useAttackDetailsContext();
   const openNotesTab = useNavigateToAttackDetailsLeftPanel({ tab: 'notes' });
+  const hit = useMemo(() => buildDataTableRecord(searchHit as EsHitRecord), [searchHit]);
+  const isRemoteDocument = useMemo(
+    () => isCCSRemoteIndexName(hit.raw._index ?? (getFieldValue(hit, '_index') as string) ?? ''),
+    [hit]
+  );
 
   return (
     <>
@@ -51,15 +58,21 @@ export const HeaderTitle = memo(() => {
         </>
       )}
       <FlyoutTitle data-test-subj={HEADER_TITLE_TEST_ID} title={title} iconType={'bolt'} />
-      <EuiSpacer size="s" />
-      <EuiBadge
-        aria-label={ATTACK_HEADER_BADGE}
-        color="hollow"
-        data-test-subj={HEADER_BADGE_TEST_ID}
-        tabIndex={0}
-      >
-        {ATTACK_HEADER_BADGE}
-      </EuiBadge>
+      {isRemoteDocument ? (
+        <RemoteDocumentBadge hit={hit} />
+      ) : (
+        <>
+          <EuiSpacer size="s" />
+          <EuiBadge
+            aria-label={ATTACK_HEADER_BADGE}
+            color="hollow"
+            data-test-subj={HEADER_BADGE_TEST_ID}
+            tabIndex={0}
+          >
+            {ATTACK_HEADER_BADGE}
+          </EuiBadge>
+        </>
+      )}
       <EuiSpacer size="m" />
       <EuiFlexGroup direction="row" gutterSize="s" responsive={false} wrap>
         <EuiFlexItem css={flyoutHeaderBlockStyles}>

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/index.test.tsx
@@ -8,6 +8,7 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
+import { EVENT_KIND } from '@kbn/rule-data-utils';
 import { ATTACK_PREVIEW_BANNER, AttackDetailsPreviewPanel, AttackDetailsRightPanel } from '.';
 import { AttackDetailsPreviewPanelKey, AttackDetailsRightPanelKey } from './constants/panel_keys';
 import { useAttackDetailsContext } from './context';
@@ -138,6 +139,31 @@ describe('AttackDetailsPanel', () => {
       },
     });
     expect(openRightPanel).not.toHaveBeenCalled();
+  });
+
+  it('shows the remote document callout when searchHit._index is a CCS remote index', () => {
+    jest.mocked(useAttackDetailsContext).mockReturnValue({
+      attackId: 'attack-1',
+      indexName: 'remote-cluster:.alerts-security.alerts-default',
+      attack: null,
+      scopeId: 'scope',
+      isPreviewMode: false,
+      getFieldsData: jest.fn(),
+      browserFields: {},
+      dataFormattedForFieldBrowser: [],
+      searchHit: {
+        _id: 'attack-1',
+        _index: 'remote-cluster:.alerts-security.alerts-default',
+        _source: { [EVENT_KIND]: 'signal' },
+      },
+      refetch: jest.fn(),
+    } as unknown as ReturnType<typeof useAttackDetailsContext>);
+
+    const { getByText } = render(<AttackDetailsRightPanel />);
+
+    expect(
+      getByText('This alert originates from a remote cluster. Some features may not be available.')
+    ).toBeInTheDocument();
   });
 
   it('uses default preview banner', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/index.tsx
@@ -4,8 +4,10 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import React, { memo, useCallback } from 'react';
+import React, { memo, useCallback, useMemo } from 'react';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
+import type { EsHitRecord } from '@kbn/discover-utils';
+import { buildDataTableRecord } from '@kbn/discover-utils';
 import type { AttackDetailsProps } from './types';
 import { FlyoutNavigation } from '../shared/components/flyout_navigation';
 
@@ -20,6 +22,7 @@ import { useTabs } from './hooks/use_tabs';
 import { useNavigateToAttackDetailsLeftPanel } from './hooks/use_navigate_to_attack_details_left_panel';
 import { useAttackDetailsContext } from './context';
 import { PanelHeader } from './header';
+import { RemoteDocumentCallout } from '../../flyout_v2/document/components/remote_document_callout';
 
 export type AttackDetailsPanelPaths = 'overview' | 'table' | 'json';
 export { ATTACK_PREVIEW_BANNER } from './context';
@@ -30,7 +33,9 @@ export { ATTACK_PREVIEW_BANNER } from './context';
 export const AttackDetailsRightPanel: React.FC<Partial<AttackDetailsProps>> = memo(({ path }) => {
   const { storage } = useKibana().services;
   const { openRightPanel } = useExpandableFlyoutApi();
-  const { attackId, indexName } = useAttackDetailsContext();
+  const { attackId, indexName, searchHit } = useAttackDetailsContext();
+  const hit = useMemo(() => buildDataTableRecord(searchHit as EsHitRecord), [searchHit]);
+
   const expandDetails = useNavigateToAttackDetailsLeftPanel();
 
   const { tabsDisplayed, selectedTabId } = useTabs({ path });
@@ -54,6 +59,7 @@ export const AttackDetailsRightPanel: React.FC<Partial<AttackDetailsProps>> = me
 
   return (
     <>
+      <RemoteDocumentCallout hit={hit} />
       <FlyoutNavigation flyoutIsExpandable={true} expandDetails={expandDetails} />
       <PanelHeader
         selectedTabId={selectedTabId}

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/alert_header_title.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/alert_header_title.tsx
@@ -28,6 +28,7 @@ import { Status } from '../../../../flyout_v2/document/components/status';
 import type { CellActionRenderer } from '../../../../flyout_v2/shared/components/cell_actions';
 import { getEmptyTagValue } from '../../../../common/components/empty_value';
 import { CellActions } from '../../shared/components/cell_actions';
+import { RemoteDocumentBadge } from '../../../../flyout_v2/document/components/remote_document_badge';
 
 /**
  * Alert details flyout right section header
@@ -88,6 +89,7 @@ export const AlertHeaderTitle = memo(() => {
         <EuiSpacer size="xs" />
       </Timestamp>
       <Title hit={hit} hideLink={isRulePreview || !canReadRules} />
+      <RemoteDocumentBadge hit={hit} />
       <EuiSpacer size="m" />
       <EuiFlexGroup
         direction="row"

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/event_header_title.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/event_header_title.tsx
@@ -14,6 +14,7 @@ import { DocumentSeverity } from '../../../../flyout_v2/document/components/seve
 import { FlyoutTitle } from '../../../../flyout_v2/shared/components/flyout_title';
 import { getDocumentTitle } from '../../../../flyout_v2/document/utils/get_header_title';
 import { EVENT_TITLE_TEST_ID } from '../../../../flyout_v2/document/components/test_ids';
+import { RemoteDocumentBadge } from '../../../../flyout_v2/document/components/remote_document_badge';
 
 /**
  * Event details flyout right section header
@@ -32,6 +33,7 @@ export const EventHeaderTitle = memo(() => {
         <EuiSpacer size="xs" />
       </Timestamp>
       <FlyoutTitle title={title} iconType={'analyzeEvent'} data-test-subj={EVENT_TITLE_TEST_ID} />
+      <RemoteDocumentBadge hit={hit} />
     </>
   );
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/header.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/header.test.tsx
@@ -11,6 +11,10 @@ import { renderWithI18n as render } from '@kbn/test-jest-helpers';
 import { PanelHeader } from './header';
 import { allThreeTabs } from './hooks/use_tabs';
 import { useBasicDataFromDetailsData } from '../shared/hooks/use_basic_data_from_details_data';
+import { useDocumentDetailsContext } from '../shared/context';
+
+const REMOTE_CALLOUT_TEXT =
+  'This event originates from a remote cluster. Some features may not be available.';
 
 jest.mock('../shared/context', () => ({
   useDocumentDetailsContext: jest.fn().mockImplementation(() => {
@@ -35,6 +39,7 @@ jest.mock('./components/event_header_title', () => ({
 }));
 
 const mockUseBasicDataFromDetailsData = useBasicDataFromDetailsData as jest.Mock;
+const mockUseDocumentDetailsContext = useDocumentDetailsContext as jest.Mock;
 
 describe('PanelHeader', () => {
   beforeEach(() => {
@@ -65,5 +70,26 @@ describe('PanelHeader', () => {
     );
     expect(queryByTestId('alert-header')).toBeInTheDocument();
     expect(queryByTestId('event-header')).not.toBeInTheDocument();
+  });
+
+  it('should not render the remote document callout for a local document', () => {
+    mockUseBasicDataFromDetailsData.mockReturnValue({ isAlert: false });
+    const { queryByText } = render(
+      <PanelHeader selectedTabId={'overview'} setSelectedTabId={jest.fn()} tabs={allThreeTabs} />
+    );
+    expect(queryByText(REMOTE_CALLOUT_TEXT)).not.toBeInTheDocument();
+  });
+
+  it('should render the remote document callout for a remote document', () => {
+    mockUseBasicDataFromDetailsData.mockReturnValue({ isAlert: false });
+    const { mockSearchHit } = jest.requireActual('../shared/mocks/mock_search_hit');
+    mockUseDocumentDetailsContext.mockReturnValueOnce({
+      dataFormattedForFieldBrowser: [],
+      searchHit: { ...mockSearchHit, _index: 'remote-cluster:.alerts-security.alerts-default' },
+    });
+    const { getByText } = render(
+      <PanelHeader selectedTabId={'overview'} setSelectedTabId={jest.fn()} tabs={allThreeTabs} />
+    );
+    expect(getByText(REMOTE_CALLOUT_TEXT)).toBeInTheDocument();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/header.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/header.tsx
@@ -8,7 +8,8 @@
 import type { EuiFlyoutHeader } from '@elastic/eui';
 import { EuiSpacer, EuiTab } from '@elastic/eui';
 import type { FC } from 'react';
-import React, { memo } from 'react';
+import React, { memo, useMemo } from 'react';
+import { buildDataTableRecord, type EsHitRecord } from '@kbn/discover-utils';
 import type { RightPanelPaths } from '.';
 import type { RightPanelTabType } from './tabs';
 import { FlyoutHeader } from '../../shared/components/flyout_header';
@@ -17,6 +18,7 @@ import { AlertHeaderTitle } from './components/alert_header_title';
 import { EventHeaderTitle } from './components/event_header_title';
 import { useDocumentDetailsContext } from '../shared/context';
 import { useBasicDataFromDetailsData } from '../shared/hooks/use_basic_data_from_details_data';
+import { RemoteDocumentCallout } from '../../../flyout_v2/document/components/remote_document_callout';
 
 export interface PanelHeaderProps extends React.ComponentProps<typeof EuiFlyoutHeader> {
   /**
@@ -36,8 +38,10 @@ export interface PanelHeaderProps extends React.ComponentProps<typeof EuiFlyoutH
 
 export const PanelHeader: FC<PanelHeaderProps> = memo(
   ({ selectedTabId, setSelectedTabId, tabs, ...flyoutHeaderProps }) => {
-    const { dataFormattedForFieldBrowser } = useDocumentDetailsContext();
+    const { dataFormattedForFieldBrowser, searchHit } = useDocumentDetailsContext();
     const { isAlert } = useBasicDataFromDetailsData(dataFormattedForFieldBrowser);
+    const hit = useMemo(() => buildDataTableRecord(searchHit as EsHitRecord), [searchHit]);
+
     const onSelectedTabChanged = (id: RightPanelPaths) => setSelectedTabId(id);
 
     const renderTabs = tabs.map((tab, index) =>
@@ -63,11 +67,14 @@ export const PanelHeader: FC<PanelHeaderProps> = memo(
     );
 
     return (
-      <FlyoutHeader {...flyoutHeaderProps}>
-        {isAlert ? <AlertHeaderTitle /> : <EventHeaderTitle />}
-        <EuiSpacer size="m" />
-        <FlyoutHeaderTabs>{renderTabs}</FlyoutHeaderTabs>
-      </FlyoutHeader>
+      <>
+        <RemoteDocumentCallout hit={hit} />
+        <FlyoutHeader {...flyoutHeaderProps}>
+          {isAlert ? <AlertHeaderTitle /> : <EventHeaderTitle />}
+          <EuiSpacer size="m" />
+          <FlyoutHeaderTabs>{renderTabs}</FlyoutHeaderTabs>
+        </FlyoutHeader>
+      </>
     );
   }
 );

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/remote_document_badge.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/remote_document_badge.test.tsx
@@ -1,0 +1,168 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
+import { render } from '@testing-library/react';
+import type { DataTableRecord } from '@kbn/discover-utils';
+import {
+  ATTACK_DISCOVERY_AD_HOC_RULE_TYPE_ID,
+  ATTACK_DISCOVERY_SCHEDULES_ALERT_TYPE_ID,
+} from '@kbn/elastic-assistant-common';
+import { ALERT_RULE_TYPE_ID } from '@kbn/rule-data-utils';
+import { REMOTE_DOCUMENT_BADGE_TEST_ID, RemoteDocumentBadge } from './remote_document_badge';
+
+let mockCloud: unknown;
+jest.mock('../../../common/lib/kibana', () => ({
+  useKibana: () => ({
+    services: {
+      cloud: mockCloud,
+    },
+  }),
+}));
+
+const makeHit = (raw: DataTableRecord['raw'], flattened: DataTableRecord['flattened'] = {}) =>
+  ({ id: '1', raw, flattened, isAnchor: false } as DataTableRecord);
+
+const renderBadge = (props: React.ComponentProps<typeof RemoteDocumentBadge>) =>
+  render(
+    <IntlProvider locale="en">
+      <RemoteDocumentBadge {...props} />
+    </IntlProvider>
+  );
+
+describe('<RemoteDocumentBadge />', () => {
+  beforeEach(() => {
+    mockCloud = { isServerlessEnabled: false };
+  });
+
+  it('renders nothing for a local document', () => {
+    const { container } = renderBadge({
+      hit: makeHit({ _index: '.alerts-security.alerts-default' }),
+    });
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  describe('CCS (on-prem remote cluster)', () => {
+    it('renders "Remote alert" badge for a remote alert via raw._index', () => {
+      const { getByTestId, getByText } = renderBadge({
+        hit: makeHit(
+          { _index: 'remote-cluster:.alerts-security.alerts-default' },
+          { 'event.kind': 'signal' }
+        ),
+      });
+
+      expect(getByTestId(REMOTE_DOCUMENT_BADGE_TEST_ID)).toBeInTheDocument();
+      expect(getByText('Remote alert')).toBeInTheDocument();
+    });
+
+    it('renders "Remote event" badge for a remote event via raw._index', () => {
+      const { getByTestId, getByText } = renderBadge({
+        hit: makeHit({ _index: 'remote-cluster:logs-system-default' }, { 'event.kind': 'event' }),
+      });
+
+      expect(getByTestId(REMOTE_DOCUMENT_BADGE_TEST_ID)).toBeInTheDocument();
+      expect(getByText('Remote event')).toBeInTheDocument();
+    });
+
+    it('renders "Remote attack" badge for a remote scheduled attack discovery alert', () => {
+      const { getByTestId, getByText } = renderBadge({
+        hit: makeHit(
+          { _index: 'remote-cluster:.alerts-security.alerts-default' },
+          {
+            'event.kind': 'signal',
+            [ALERT_RULE_TYPE_ID]: ATTACK_DISCOVERY_SCHEDULES_ALERT_TYPE_ID,
+          }
+        ),
+      });
+
+      expect(getByTestId(REMOTE_DOCUMENT_BADGE_TEST_ID)).toBeInTheDocument();
+      expect(getByText('Remote attack')).toBeInTheDocument();
+    });
+
+    it('renders "Remote attack" badge for a remote ad-hoc attack discovery alert', () => {
+      const { getByTestId, getByText } = renderBadge({
+        hit: makeHit(
+          { _index: 'remote-cluster:.alerts-security.alerts-default' },
+          {
+            'event.kind': 'signal',
+            [ALERT_RULE_TYPE_ID]: ATTACK_DISCOVERY_AD_HOC_RULE_TYPE_ID,
+          }
+        ),
+      });
+
+      expect(getByTestId(REMOTE_DOCUMENT_BADGE_TEST_ID)).toBeInTheDocument();
+      expect(getByText('Remote attack')).toBeInTheDocument();
+    });
+
+    it('renders the badge for a remote document via flattened _index (raw absent)', () => {
+      const { getByTestId } = renderBadge({
+        hit: makeHit({}, { _index: 'remote-cluster:logs-system-default', 'event.kind': 'event' }),
+      });
+
+      expect(getByTestId(REMOTE_DOCUMENT_BADGE_TEST_ID)).toBeInTheDocument();
+    });
+  });
+
+  describe('CPS (serverless linked project)', () => {
+    beforeEach(() => {
+      mockCloud = { isServerlessEnabled: true };
+    });
+
+    it('renders "Linked project alert" badge for a remote alert', () => {
+      const { getByTestId, getByText } = renderBadge({
+        hit: makeHit(
+          { _index: 'remote-cluster:.alerts-security.alerts-default' },
+          { 'event.kind': 'signal' }
+        ),
+      });
+
+      expect(getByTestId(REMOTE_DOCUMENT_BADGE_TEST_ID)).toBeInTheDocument();
+      expect(getByText('Linked project alert')).toBeInTheDocument();
+    });
+
+    it('renders "Linked project event" badge for a remote event', () => {
+      const { getByTestId, getByText } = renderBadge({
+        hit: makeHit({ _index: 'remote-cluster:logs-system-default' }, { 'event.kind': 'event' }),
+      });
+
+      expect(getByTestId(REMOTE_DOCUMENT_BADGE_TEST_ID)).toBeInTheDocument();
+      expect(getByText('Linked project event')).toBeInTheDocument();
+    });
+
+    it('renders "Linked project attack" badge for a remote scheduled attack discovery alert', () => {
+      const { getByTestId, getByText } = renderBadge({
+        hit: makeHit(
+          { _index: 'remote-cluster:.alerts-security.alerts-default' },
+          {
+            'event.kind': 'signal',
+            [ALERT_RULE_TYPE_ID]: ATTACK_DISCOVERY_SCHEDULES_ALERT_TYPE_ID,
+          }
+        ),
+      });
+
+      expect(getByTestId(REMOTE_DOCUMENT_BADGE_TEST_ID)).toBeInTheDocument();
+      expect(getByText('Linked project attack')).toBeInTheDocument();
+    });
+
+    it('renders "Linked project attack" badge for a remote ad-hoc attack discovery alert', () => {
+      const { getByTestId, getByText } = renderBadge({
+        hit: makeHit(
+          { _index: 'remote-cluster:.alerts-security.alerts-default' },
+          {
+            'event.kind': 'signal',
+            [ALERT_RULE_TYPE_ID]: ATTACK_DISCOVERY_AD_HOC_RULE_TYPE_ID,
+          }
+        ),
+      });
+
+      expect(getByTestId(REMOTE_DOCUMENT_BADGE_TEST_ID)).toBeInTheDocument();
+      expect(getByText('Linked project attack')).toBeInTheDocument();
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/remote_document_badge.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/remote_document_badge.tsx
@@ -1,0 +1,115 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FC } from 'react';
+import React, { useMemo } from 'react';
+import { EuiBadge, EuiSpacer } from '@elastic/eui';
+import type { DataTableRecord } from '@kbn/discover-utils';
+import { getFieldValue } from '@kbn/discover-utils';
+import { isCCSRemoteIndexName } from '@kbn/es-query';
+import { i18n } from '@kbn/i18n';
+import { ALERT_RULE_TYPE_ID, EVENT_KIND } from '@kbn/rule-data-utils';
+import {
+  ATTACK_DISCOVERY_AD_HOC_RULE_TYPE_ID,
+  ATTACK_DISCOVERY_SCHEDULES_ALERT_TYPE_ID,
+} from '@kbn/elastic-assistant-common';
+import { EventKind } from '../constants/event_kinds';
+import { useKibana } from '../../../common/lib/kibana';
+
+export const REMOTE_DOCUMENT_BADGE_TEST_ID = 'remoteDocumentBadge';
+
+const ATTACK_DISCOVERY_RULE_TYPES = new Set<string>([
+  ATTACK_DISCOVERY_SCHEDULES_ALERT_TYPE_ID,
+  ATTACK_DISCOVERY_AD_HOC_RULE_TYPE_ID,
+]);
+
+const REMOTE_ATTACK_BADGE_LABEL = i18n.translate(
+  'xpack.securitySolution.flyout.document.components.remoteDocumentBadge.remoteAttackLabel',
+  { defaultMessage: 'Remote attack' }
+);
+
+const REMOTE_ALERT_BADGE_LABEL = i18n.translate(
+  'xpack.securitySolution.flyout.document.components.remoteDocumentBadge.remoteAlertLabel',
+  { defaultMessage: 'Remote alert' }
+);
+
+const REMOTE_EVENT_BADGE_LABEL = i18n.translate(
+  'xpack.securitySolution.flyout.document.components.remoteDocumentBadge.remoteEventLabel',
+  { defaultMessage: 'Remote event' }
+);
+
+const LINKED_PROJECT_ATTACK_BADGE_LABEL = i18n.translate(
+  'xpack.securitySolution.flyout.document.components.remoteDocumentBadge.linkedProjectAttackLabel',
+  { defaultMessage: 'Linked project attack' }
+);
+
+const LINKED_PROJECT_ALERT_BADGE_LABEL = i18n.translate(
+  'xpack.securitySolution.flyout.document.components.remoteDocumentBadge.linkedProjectAlertLabel',
+  { defaultMessage: 'Linked project alert' }
+);
+
+const LINKED_PROJECT_EVENT_BADGE_LABEL = i18n.translate(
+  'xpack.securitySolution.flyout.document.components.remoteDocumentBadge.linkedProjectEventLabel',
+  { defaultMessage: 'Linked project event' }
+);
+
+export interface RemoteDocumentBadgeProps {
+  /**
+   * The document record used to determine whether it originates from a remote cluster
+   * and whether it is an alert or an event.
+   */
+  hit: DataTableRecord;
+}
+
+/**
+ * Renders a badge when the document originates from a remote (CCS) cluster, otherwise null.
+ * Displays "Remote alert" for signals and "Remote event" for all other document kinds.
+ */
+export const RemoteDocumentBadge: FC<RemoteDocumentBadgeProps> = ({ hit }) => {
+  const { services } = useKibana();
+  const isServerless = services.cloud?.isServerlessEnabled ?? false;
+  const index = useMemo(
+    () => hit.raw._index ?? (getFieldValue(hit, '_index') as string) ?? '',
+    [hit]
+  );
+  const isAlert = useMemo(
+    () => (getFieldValue(hit, EVENT_KIND) as string) === EventKind.signal,
+    [hit]
+  );
+  const isAttack = useMemo(
+    () =>
+      isAlert && ATTACK_DISCOVERY_RULE_TYPES.has(getFieldValue(hit, ALERT_RULE_TYPE_ID) as string),
+    [hit, isAlert]
+  );
+
+  if (!isCCSRemoteIndexName(index)) {
+    return null;
+  }
+
+  const label = isServerless
+    ? isAttack
+      ? LINKED_PROJECT_ATTACK_BADGE_LABEL
+      : isAlert
+      ? LINKED_PROJECT_ALERT_BADGE_LABEL
+      : LINKED_PROJECT_EVENT_BADGE_LABEL
+    : isAttack
+    ? REMOTE_ATTACK_BADGE_LABEL
+    : isAlert
+    ? REMOTE_ALERT_BADGE_LABEL
+    : REMOTE_EVENT_BADGE_LABEL;
+
+  return (
+    <>
+      <EuiSpacer size="xs" />
+      <EuiBadge color="hollow" data-test-subj={REMOTE_DOCUMENT_BADGE_TEST_ID}>
+        {label}
+      </EuiBadge>
+    </>
+  );
+};
+
+RemoteDocumentBadge.displayName = 'RemoteDocumentBadge';

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/remote_document_callout.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/remote_document_callout.test.tsx
@@ -1,0 +1,209 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
+import { render } from '@testing-library/react';
+import type { DataTableRecord } from '@kbn/discover-utils';
+import {
+  ATTACK_DISCOVERY_AD_HOC_RULE_TYPE_ID,
+  ATTACK_DISCOVERY_SCHEDULES_ALERT_TYPE_ID,
+} from '@kbn/elastic-assistant-common';
+import { ALERT_RULE_TYPE_ID } from '@kbn/rule-data-utils';
+import { RemoteDocumentCallout } from './remote_document_callout';
+
+let mockCloud: unknown;
+jest.mock('../../../common/lib/kibana', () => ({
+  useKibana: () => ({
+    services: {
+      cloud: mockCloud,
+    },
+  }),
+}));
+
+const REMOTE_ATTACK_TEXT =
+  'This attack originates from a remote cluster. Some features may not be available.';
+const REMOTE_ALERT_TEXT =
+  'This alert originates from a remote cluster. Some features may not be available.';
+const REMOTE_EVENT_TEXT =
+  'This event originates from a remote cluster. Some features may not be available.';
+
+const LINKED_PROJECT_ATTACK_TEXT =
+  'This attack originates from a linked project. Some features may not be available.';
+const LINKED_PROJECT_ALERT_TEXT =
+  'This alert originates from a linked project. Some features may not be available.';
+const LINKED_PROJECT_EVENT_TEXT =
+  'This event originates from a linked project. Some features may not be available.';
+
+const makeHit = (raw: DataTableRecord['raw'], flattened: DataTableRecord['flattened'] = {}) =>
+  ({ id: '1', raw, flattened, isAnchor: false } as DataTableRecord);
+
+const renderCallout = (props: React.ComponentProps<typeof RemoteDocumentCallout>) =>
+  render(
+    <IntlProvider locale="en">
+      <RemoteDocumentCallout {...props} />
+    </IntlProvider>
+  );
+
+describe('<RemoteDocumentCallout />', () => {
+  beforeEach(() => {
+    mockCloud = { isServerlessEnabled: false };
+  });
+
+  it('renders nothing for a local document', () => {
+    const { container } = renderCallout({
+      hit: makeHit({ _index: '.alerts-security.alerts-default' }),
+    });
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('does not render children for a local document', () => {
+    const { queryByText } = renderCallout({
+      hit: makeHit({ _index: 'local-index' }),
+      children: <span>{'child content'}</span>,
+    });
+
+    expect(queryByText('child content')).not.toBeInTheDocument();
+  });
+
+  describe('CCS (on-prem remote cluster)', () => {
+    it('renders the alert callout for a remote alert via raw._index', () => {
+      const { getByText } = renderCallout({
+        hit: makeHit(
+          { _index: 'remote-cluster:.alerts-security.alerts-default' },
+          { 'event.kind': 'signal' }
+        ),
+      });
+
+      expect(getByText(REMOTE_ALERT_TEXT)).toBeInTheDocument();
+    });
+
+    it('renders the event callout for a remote event', () => {
+      const { getByText } = renderCallout({
+        hit: makeHit({ _index: 'remote-cluster:logs-system-default' }, { 'event.kind': 'event' }),
+      });
+
+      expect(getByText(REMOTE_EVENT_TEXT)).toBeInTheDocument();
+    });
+
+    it('renders the attack callout for a remote scheduled attack discovery alert', () => {
+      const { getByText } = renderCallout({
+        hit: makeHit(
+          { _index: 'remote-cluster:.alerts-security.alerts-default' },
+          {
+            'event.kind': 'signal',
+            [ALERT_RULE_TYPE_ID]: ATTACK_DISCOVERY_SCHEDULES_ALERT_TYPE_ID,
+          }
+        ),
+      });
+
+      expect(getByText(REMOTE_ATTACK_TEXT)).toBeInTheDocument();
+    });
+
+    it('renders the attack callout for a remote ad-hoc attack discovery alert', () => {
+      const { getByText } = renderCallout({
+        hit: makeHit(
+          { _index: 'remote-cluster:.alerts-security.alerts-default' },
+          {
+            'event.kind': 'signal',
+            [ALERT_RULE_TYPE_ID]: ATTACK_DISCOVERY_AD_HOC_RULE_TYPE_ID,
+          }
+        ),
+      });
+
+      expect(getByText(REMOTE_ATTACK_TEXT)).toBeInTheDocument();
+    });
+
+    it('renders the callout for a remote document via flattened _index (raw absent)', () => {
+      const { getByText } = renderCallout({
+        hit: makeHit({}, { _index: 'remote-cluster:logs-system-default', 'event.kind': 'event' }),
+      });
+
+      expect(getByText(REMOTE_EVENT_TEXT)).toBeInTheDocument();
+    });
+
+    it('renders children after the callout for a remote document', () => {
+      const { getByText } = renderCallout({
+        hit: makeHit(
+          { _index: 'remote-cluster:.alerts-security.alerts-default' },
+          { 'event.kind': 'signal' }
+        ),
+        children: <span>{'child content'}</span>,
+      });
+
+      expect(getByText(REMOTE_ALERT_TEXT)).toBeInTheDocument();
+      expect(getByText('child content')).toBeInTheDocument();
+    });
+  });
+
+  describe('CPS (serverless linked project)', () => {
+    beforeEach(() => {
+      mockCloud = { isServerlessEnabled: true };
+    });
+
+    it('renders the linked project alert callout for a remote alert', () => {
+      const { getByText } = renderCallout({
+        hit: makeHit(
+          { _index: 'remote-cluster:.alerts-security.alerts-default' },
+          { 'event.kind': 'signal' }
+        ),
+      });
+
+      expect(getByText(LINKED_PROJECT_ALERT_TEXT)).toBeInTheDocument();
+    });
+
+    it('renders the linked project event callout for a remote event', () => {
+      const { getByText } = renderCallout({
+        hit: makeHit({ _index: 'remote-cluster:logs-system-default' }, { 'event.kind': 'event' }),
+      });
+
+      expect(getByText(LINKED_PROJECT_EVENT_TEXT)).toBeInTheDocument();
+    });
+
+    it('renders the linked project attack callout for a remote scheduled attack discovery alert', () => {
+      const { getByText } = renderCallout({
+        hit: makeHit(
+          { _index: 'remote-cluster:.alerts-security.alerts-default' },
+          {
+            'event.kind': 'signal',
+            [ALERT_RULE_TYPE_ID]: ATTACK_DISCOVERY_SCHEDULES_ALERT_TYPE_ID,
+          }
+        ),
+      });
+
+      expect(getByText(LINKED_PROJECT_ATTACK_TEXT)).toBeInTheDocument();
+    });
+
+    it('renders the linked project attack callout for a remote ad-hoc attack discovery alert', () => {
+      const { getByText } = renderCallout({
+        hit: makeHit(
+          { _index: 'remote-cluster:.alerts-security.alerts-default' },
+          {
+            'event.kind': 'signal',
+            [ALERT_RULE_TYPE_ID]: ATTACK_DISCOVERY_AD_HOC_RULE_TYPE_ID,
+          }
+        ),
+      });
+
+      expect(getByText(LINKED_PROJECT_ATTACK_TEXT)).toBeInTheDocument();
+    });
+
+    it('renders children after the callout for a remote document', () => {
+      const { getByText } = renderCallout({
+        hit: makeHit(
+          { _index: 'remote-cluster:.alerts-security.alerts-default' },
+          { 'event.kind': 'signal' }
+        ),
+        children: <span>{'child content'}</span>,
+      });
+
+      expect(getByText(LINKED_PROJECT_ALERT_TEXT)).toBeInTheDocument();
+      expect(getByText('child content')).toBeInTheDocument();
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/remote_document_callout.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/remote_document_callout.tsx
@@ -1,0 +1,134 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FC, ReactNode } from 'react';
+import React, { useMemo } from 'react';
+import type { EuiCallOutProps } from '@elastic/eui';
+import { EuiCallOut } from '@elastic/eui';
+import type { DataTableRecord } from '@kbn/discover-utils';
+import { getFieldValue } from '@kbn/discover-utils';
+import { isCCSRemoteIndexName } from '@kbn/es-query';
+import { i18n } from '@kbn/i18n';
+import { ALERT_RULE_TYPE_ID, EVENT_KIND } from '@kbn/rule-data-utils';
+import {
+  ATTACK_DISCOVERY_AD_HOC_RULE_TYPE_ID,
+  ATTACK_DISCOVERY_SCHEDULES_ALERT_TYPE_ID,
+} from '@kbn/elastic-assistant-common';
+import { EventKind } from '../constants/event_kinds';
+import { useKibana } from '../../../common/lib/kibana';
+
+const ATTACK_DISCOVERY_RULE_TYPES = new Set<string>([
+  ATTACK_DISCOVERY_SCHEDULES_ALERT_TYPE_ID,
+  ATTACK_DISCOVERY_AD_HOC_RULE_TYPE_ID,
+]);
+
+const REMOTE_ATTACK_CALLOUT = i18n.translate(
+  'xpack.securitySolution.flyout.document.components.remoteDocumentCallout.remoteAttackMessage',
+  {
+    defaultMessage:
+      'This attack originates from a remote cluster. Some features may not be available.',
+  }
+);
+
+const REMOTE_ALERT_CALLOUT = i18n.translate(
+  'xpack.securitySolution.flyout.document.components.remoteDocumentCallout.remoteAlertMessage',
+  {
+    defaultMessage:
+      'This alert originates from a remote cluster. Some features may not be available.',
+  }
+);
+
+const REMOTE_EVENT_CALLOUT = i18n.translate(
+  'xpack.securitySolution.flyout.document.components.remoteDocumentCallout.remoteEventMessage',
+  {
+    defaultMessage:
+      'This event originates from a remote cluster. Some features may not be available.',
+  }
+);
+
+const LINKED_PROJECT_ATTACK_CALLOUT = i18n.translate(
+  'xpack.securitySolution.flyout.document.components.remoteDocumentCallout.linkedProjectAttackMessage',
+  {
+    defaultMessage:
+      'This attack originates from a linked project. Some features may not be available.',
+  }
+);
+
+const LINKED_PROJECT_ALERT_CALLOUT = i18n.translate(
+  'xpack.securitySolution.flyout.document.components.remoteDocumentCallout.linkedProjectAlertMessage',
+  {
+    defaultMessage:
+      'This alert originates from a linked project. Some features may not be available.',
+  }
+);
+
+const LINKED_PROJECT_EVENT_CALLOUT = i18n.translate(
+  'xpack.securitySolution.flyout.document.components.remoteDocumentCallout.linkedProjectEventMessage',
+  {
+    defaultMessage:
+      'This event originates from a linked project. Some features may not be available.',
+  }
+);
+
+export interface RemoteDocumentCalloutProps extends Pick<EuiCallOutProps, 'css'> {
+  /**
+   * The document record used to determine whether it originates from a remote cluster.
+   */
+  hit: DataTableRecord;
+  /**
+   * Optional content rendered after the callout, only when the callout is shown.
+   * Use this to inject a spacer when the callout is rendered inside a padded body area.
+   */
+  children?: ReactNode;
+}
+
+/**
+ * Renders a callout when the document originates from a remote (CCS) cluster, otherwise null.
+ * Any children are rendered after the callout and are suppressed when the document is local.
+ */
+export const RemoteDocumentCallout: FC<RemoteDocumentCalloutProps> = ({ hit, children }) => {
+  const { services } = useKibana();
+  const isServerless = services.cloud?.isServerlessEnabled ?? false;
+  const index = useMemo(
+    () => hit.raw._index ?? (getFieldValue(hit, '_index') as string) ?? '',
+    [hit]
+  );
+  const isAlert = useMemo(
+    () => (getFieldValue(hit, EVENT_KIND) as string) === EventKind.signal,
+    [hit]
+  );
+  const isAttack = useMemo(
+    () =>
+      isAlert && ATTACK_DISCOVERY_RULE_TYPES.has(getFieldValue(hit, ALERT_RULE_TYPE_ID) as string),
+    [hit, isAlert]
+  );
+
+  if (!isCCSRemoteIndexName(index)) {
+    return null;
+  }
+
+  const message = isServerless
+    ? isAttack
+      ? LINKED_PROJECT_ATTACK_CALLOUT
+      : isAlert
+      ? LINKED_PROJECT_ALERT_CALLOUT
+      : LINKED_PROJECT_EVENT_CALLOUT
+    : isAttack
+    ? REMOTE_ATTACK_CALLOUT
+    : isAlert
+    ? REMOTE_ALERT_CALLOUT
+    : REMOTE_EVENT_CALLOUT;
+
+  return (
+    <>
+      <EuiCallOut announceOnMount size="s" title={message} />
+      {children}
+    </>
+  );
+};
+
+RemoteDocumentCallout.displayName = 'RemoteDocumentCallout';

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/header.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/header.test.tsx
@@ -10,6 +10,7 @@ import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
 import { render } from '@testing-library/react';
 import type { DataTableRecord } from '@kbn/discover-utils';
 import { Header } from './header';
+import { REMOTE_DOCUMENT_BADGE_TEST_ID } from './components/remote_document_badge';
 import { ALERT_SUMMARY_PANEL_TEST_ID } from '../shared/components/test_ids';
 
 jest.mock('../../common/lib/kibana', () => ({
@@ -104,6 +105,18 @@ const alertHitNoRiskScore = createMockHit({
 const eventHit = createMockHit({
   'event.kind': 'event',
   'kibana.alert.risk_score': 21,
+});
+
+const remoteAlertHit = createMockHit({
+  'event.kind': 'signal',
+  'kibana.alert.rule.name': 'Test Rule',
+  'kibana.alert.rule.uuid': 'test-rule-id',
+  _index: 'remote-cluster:index-name',
+});
+
+const remoteEventHit = createMockHit({
+  'event.kind': 'event',
+  _index: 'remote-cluster:index-name',
 });
 
 const defaultHeaderProps: Pick<Parameters<typeof Header>[0], 'onAlertUpdated' | 'onShowNotes'> = {
@@ -202,5 +215,23 @@ describe('<DocumentHeader />', () => {
     const { queryByTestId } = renderHeader({ hit: eventHit });
 
     expect(queryByTestId(ALERT_SUMMARY_PANEL_TEST_ID)).not.toBeInTheDocument();
+  });
+
+  it('should not render the remote badge for local documents', () => {
+    const { queryByTestId } = renderHeader({ hit: alertHit });
+
+    expect(queryByTestId(REMOTE_DOCUMENT_BADGE_TEST_ID)).not.toBeInTheDocument();
+  });
+
+  it('should render "Remote alert" badge for remote alerts', () => {
+    const { getByTestId } = renderHeader({ hit: remoteAlertHit });
+
+    expect(getByTestId(REMOTE_DOCUMENT_BADGE_TEST_ID)).toHaveTextContent('Remote alert');
+  });
+
+  it('should render "Remote event" badge for remote non-alert documents', () => {
+    const { getByTestId } = renderHeader({ hit: remoteEventHit });
+
+    expect(getByTestId(REMOTE_DOCUMENT_BADGE_TEST_ID)).toHaveTextContent('Remote event');
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/header.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/header.tsx
@@ -24,6 +24,7 @@ import { ALERT_SUMMARY_PANEL_TEST_ID } from '../shared/components/test_ids';
 import type { CellActionRenderer } from '../shared/components/cell_actions';
 import { noopCellActionRenderer } from '../shared/components/cell_actions';
 import { useUserPrivileges } from '../../common/components/user_privileges';
+import { RemoteDocumentBadge } from './components/remote_document_badge';
 
 export interface HeaderProps {
   /**
@@ -60,12 +61,13 @@ export const Header: FC<HeaderProps> = memo(
     return (
       <>
         <DocumentSeverity hit={hit}>
-          <EuiSpacer size="m" />
+          <EuiSpacer size="s" />
         </DocumentSeverity>
         <Timestamp hit={hit}>
           <EuiSpacer size="xs" />
         </Timestamp>
         <Title hit={hit} hideLink={!canReadRules} />
+        <RemoteDocumentBadge hit={hit} />
         {isAlert && (
           <>
             <EuiSpacer size="m" />

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/index.test.tsx
@@ -38,11 +38,11 @@ jest.mock('../notes', () => ({
   NotesDetails: () => <div data-test-subj="mock-notes-details" />,
 }));
 
-const createAlertHit = (): DataTableRecord =>
+const createAlertHit = (extra: DataTableRecord['flattened'] = {}): DataTableRecord =>
   ({
     id: '1',
     raw: {},
-    flattened: { 'event.kind': 'signal' },
+    flattened: { 'event.kind': 'signal', ...extra },
     isAnchor: false,
   } as DataTableRecord);
 
@@ -149,5 +149,74 @@ describe('<DocumentFlyout />', () => {
     );
 
     expect(getByTestId('mock-header')).toHaveAttribute('data-has-on-assignees-updated', 'true');
+  });
+
+  describe('remote document callout', () => {
+    it('shows the callout for remote alerts', () => {
+      (useAlertsPrivileges as jest.Mock).mockReturnValue({ hasAlertsRead: true, loading: false });
+
+      const { getByText } = render(
+        <TestProviders>
+          <DocumentFlyout
+            hit={createAlertHit({ _index: 'remote-cluster:.alerts-security.alerts-default' })}
+            renderCellActions={jest.fn()}
+            onAlertUpdated={jest.fn()}
+          />
+        </TestProviders>
+      );
+
+      expect(
+        getByText(
+          'This alert originates from a remote cluster. Some features may not be available.'
+        )
+      ).toBeInTheDocument();
+    });
+
+    it('shows the callout for remote non-alert documents', () => {
+      (useAlertsPrivileges as jest.Mock).mockReturnValue({ hasAlertsRead: true, loading: false });
+
+      const remoteEventHit: DataTableRecord = {
+        id: '1',
+        raw: {},
+        flattened: { 'event.kind': 'event', _index: 'remote-cluster:logs-system-default' },
+        isAnchor: false,
+      } as DataTableRecord;
+
+      const { getByText } = render(
+        <TestProviders>
+          <DocumentFlyout
+            hit={remoteEventHit}
+            renderCellActions={jest.fn()}
+            onAlertUpdated={jest.fn()}
+          />
+        </TestProviders>
+      );
+
+      expect(
+        getByText(
+          'This event originates from a remote cluster. Some features may not be available.'
+        )
+      ).toBeInTheDocument();
+    });
+
+    it('does not show the callout for local documents', () => {
+      (useAlertsPrivileges as jest.Mock).mockReturnValue({ hasAlertsRead: true, loading: false });
+
+      const { queryByText } = render(
+        <TestProviders>
+          <DocumentFlyout
+            hit={createAlertHit({ _index: '.alerts-security.alerts-default' })}
+            renderCellActions={jest.fn()}
+            onAlertUpdated={jest.fn()}
+          />
+        </TestProviders>
+      );
+
+      expect(
+        queryByText(
+          'This alert originates from a remote cluster. Some features may not be available.'
+        )
+      ).not.toBeInTheDocument();
+    });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/index.tsx
@@ -27,6 +27,7 @@ import { useKibana } from '../../common/lib/kibana';
 import { flyoutProviders } from '../shared/components/flyout_provider';
 import { useIsInSecurityApp } from '../../common/hooks/is_in_security_app';
 import { alertFlyoutHistoryKey } from './constants/flyout_history';
+import { RemoteDocumentCallout } from './components/remote_document_callout';
 
 export interface DocumentFlyoutProps {
   /**
@@ -58,7 +59,6 @@ export const DocumentFlyout = memo(
     );
     const isSecurityApp = useIsInSecurityApp();
     const historyKey = isSecurityApp ? alertFlyoutHistoryKey : DOC_VIEWER_FLYOUT_HISTORY_KEY;
-
     const { hasAlertsRead, loading } = useAlertsPrivileges();
     const missingAlertsPrivilege = !loading && !hasAlertsRead && isAlert;
 
@@ -87,6 +87,7 @@ export const DocumentFlyout = memo(
 
     return (
       <>
+        <RemoteDocumentCallout hit={hit} />
         <EuiFlyoutHeader>
           <Header
             hit={hit}

--- a/x-pack/solutions/security/plugins/security_solution/public/one_discover/alert_flyout_header_component/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/one_discover/alert_flyout_header_component/index.test.tsx
@@ -270,6 +270,35 @@ describe('AlertFlyoutHeader', () => {
     });
   });
 
+  it('shows a callout when _index is a remote (CCS) index', async () => {
+    const hit = {
+      id: '1',
+      raw: { _id: '1', _index: 'remote-cluster:.alerts-security.alerts-default' },
+      flattened: {},
+    } as unknown as DataTableRecord;
+    const store = createStore(() => ({}));
+    const history = createMemoryHistory({ initialEntries: ['/discover'] });
+
+    render(
+      <Router history={history}>
+        <AlertFlyoutHeader
+          hit={hit}
+          servicesPromise={Promise.resolve(servicesMock)}
+          storePromise={Promise.resolve(store as never)}
+          onAlertUpdated={jest.fn()}
+        />
+      </Router>
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          'This event originates from a remote cluster. Some features may not be available.'
+        )
+      ).toBeInTheDocument();
+    });
+  });
+
   it('does not show the callout when both _id and _index are present in hit.raw', async () => {
     const hit = {
       id: '1',

--- a/x-pack/solutions/security/plugins/security_solution/public/one_discover/alert_flyout_header_component/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/one_discover/alert_flyout_header_component/index.tsx
@@ -12,6 +12,7 @@ import { useHistory } from 'react-router-dom';
 import { i18n } from '@kbn/i18n';
 import { DOC_VIEWER_FLYOUT_HISTORY_KEY } from '@kbn/unified-doc-viewer';
 import { defaultToolsFlyoutProperties } from '../../flyout_v2/shared/hooks/use_default_flyout_properties';
+import { RemoteDocumentCallout } from '../../flyout_v2/document/components/remote_document_callout';
 import type { SecurityAppStore } from '../../common/store/types';
 import type { StartServices } from '../../types';
 import { Header } from '../../flyout_v2/document/header';
@@ -104,20 +105,32 @@ export const AlertFlyoutHeader = ({
   }, [servicesPromise, storePromise]);
 
   const isMissingMetadata = !hit.raw._id || !hit.raw._index;
+
   const metadataCallout = isMissingMetadata ? (
     <>
       <EuiCallOut announceOnMount size="s" title={MISSING_METADATA_CALLOUT} />
       <EuiSpacer size="s" />
     </>
   ) : null;
+  const remoteDocumentCallout = (
+    <RemoteDocumentCallout hit={hit}>
+      <EuiSpacer size="s" />
+    </RemoteDocumentCallout>
+  );
 
   if (!services || !store) {
-    return metadataCallout;
+    return (
+      <>
+        {metadataCallout}
+        {remoteDocumentCallout}
+      </>
+    );
   }
 
   return (
     <>
       {metadataCallout}
+      {remoteDocumentCallout}
       {flyoutProviders({
         services,
         store,


### PR DESCRIPTION
> [!NOTE]
> I had intended to do way more changes than just the header callout and badge, but the amount of changes were too big, so I'm splitting CPS flyout support into 3 main PRs

## Summary

This PR adds a callout and a badge in the header to the alerts/events/attacks flyout for remote documents.

> [!TIP]
> The callout and the badge will show only in a Serverless environment, with CPS enabled.

### Code changes

In Security Solution
- 2 new components to display the callout and the badge
- changes to the old flyout for attacks, alerts and events
- changes to the new flyout for alerts and events

In Discover
- changes to the header for the alert and event flyout

> [!WARNING]
> The changes in Discover aren't visible yet. We don't want to enable the enhance profile until all CPS-related flyout changes are in place. To test them, you can replace `(isAlert && !isRemoteDocument) || isEvent` with `isAlert || isEvent` [here](https://github.com/elastic/kibana/blob/main/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/security_profile_providers.tsx#L45)

### UI changes

For alerts old flyout

| Local | remote |
| ------------- | ------------- |
| <img width="640" height="287" alt="Screenshot 2026-04-16 at 5 54 47 PM" src="https://github.com/user-attachments/assets/279728e2-bbd2-46c9-aba2-bbf7e309aabf" /> | <img width="639" height="349" alt="Screenshot 2026-04-16 at 6 13 09 PM" src="https://github.com/user-attachments/assets/58f87aac-b0db-4cd1-90fd-3f5e50d3602a" /> |

For alerts new flyout

| Local | remote |
| ------------- | ------------- |
| <img width="424" height="262" alt="Screenshot 2026-04-16 at 5 54 31 PM" src="https://github.com/user-attachments/assets/eafea206-5b37-41be-b2b6-643503a86bae" /> | <img width="424" height="340" alt="Screenshot 2026-04-16 at 5 55 08 PM" src="https://github.com/user-attachments/assets/aa1433f3-4df7-409f-ace1-64a4cea1e128" /> |

For events old flyout

| Local | remote |
| ------------- | ------------- |
| <img width="643" height="177" alt="Screenshot 2026-04-16 at 8 02 32 PM" src="https://github.com/user-attachments/assets/96a4993d-d5c7-44d4-8a5d-baface892d22" /> | <img width="640" height="222" alt="Screenshot 2026-04-16 at 6 13 37 PM" src="https://github.com/user-attachments/assets/48c88eb2-8575-4945-997d-a09ab6a95942" /> |

For events new flyout

| Local | remote |
| ------------- | ------------- |
| <img width="377" height="74" alt="Screenshot 2026-04-16 at 5 56 57 PM" src="https://github.com/user-attachments/assets/15cb6fa2-9feb-43cb-96f3-6021817d92cc" /> | <img width="382" height="158" alt="Screenshot 2026-04-16 at 5 56 39 PM" src="https://github.com/user-attachments/assets/520d9bfb-b892-4046-83bc-6a296469502d" /> |

## How to test

Refer to [this guide](https://docs.google.com/document/d/16c6H8EVyyAUwp7QDm-77__RHz_hSJ2_wE40_as7WIqE/edit?pli=1&tab=t.0) for local Serverless CPS setup

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->