### PR TITLE
[Security Solution] disable/hide part of the attack/alert/event flyout for remote documents

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attacks_group_take_action_items.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attacks_group_take_action_items.test.tsx
@@ -69,12 +69,13 @@ const mockUseAttackRunWorkflowContextMenuItems =
   >;
 const mockAttack = getMockAttackDiscoveryAlerts()[0];
 
-function renderAttack(attack: AttackDiscoveryAlert) {
+function renderAttack(attack: AttackDiscoveryAlert, isRemoteDocument = false) {
   return render(
     <TestProviders>
       <AttacksGroupTakeActionItems
         attack={attack}
         telemetrySource="attacks_page_group_take_action"
+        isRemoteDocument={isRemoteDocument}
       />
     </TestProviders>
   );
@@ -294,10 +295,29 @@ describe('AttacksGroupTakeActionItems', () => {
             attack={mockAttack}
             showAiAssistantAction={false}
             telemetrySource="attacks_page_group_take_action"
+            isRemoteDocument={false}
           />
         </TestProviders>
       );
       expect(queryByText('View in AI Assistant')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('when isRemoteDocument is true', () => {
+    it('renders only the Investigate in Timeline action', () => {
+      const { queryByText } = renderAttack(mockAttack, true);
+
+      expect(queryByText('Investigate in timeline')).toBeInTheDocument();
+    });
+
+    it('hides all other actions', () => {
+      const { queryByText } = renderAttack(mockAttack, true);
+
+      expect(queryByText('Mark as acknowledged')).not.toBeInTheDocument();
+      expect(queryByText('View in AI Assistant')).not.toBeInTheDocument();
+      expect(queryByText('Assign alert')).not.toBeInTheDocument();
+      expect(queryByText('Apply alert tags')).not.toBeInTheDocument();
+      expect(queryByText('Run workflow')).not.toBeInTheDocument();
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attacks_group_take_action_items.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attacks_group_take_action_items.tsx
@@ -8,9 +8,9 @@
 import type { EuiContextMenuPanelDescriptor } from '@elastic/eui';
 import { EuiContextMenu } from '@elastic/eui';
 import {
+  type AttackDiscoveryAlert,
   getAttackDiscoveryMarkdown,
   getOriginalAlertIds,
-  type AttackDiscoveryAlert,
 } from '@kbn/elastic-assistant-common';
 import React, { useCallback, useMemo } from 'react';
 import { i18n } from '@kbn/i18n';
@@ -41,6 +41,11 @@ interface AttacksGroupTakeActionItemsProps {
   size?: 's' | 'm';
   /** Telemetry source for action events (e.g. flyout vs table) */
   telemetrySource: AttacksActionTelemetrySource;
+  /**
+   * When true, only the "Investigate in Timeline" action is shown.
+   * Use this for remote/CCS attacks where mutations are not possible.
+   */
+  isRemoteDocument: boolean;
 }
 
 const ADD_TO_DATASET = i18n.translate(
@@ -55,6 +60,7 @@ export function AttacksGroupTakeActionItems({
   showAiAssistantAction = true,
   size,
   telemetrySource,
+  isRemoteDocument,
 }: AttacksGroupTakeActionItemsProps) {
   const {
     services: { evals },
@@ -203,18 +209,21 @@ export function AttacksGroupTakeActionItems({
   const defaultPanel: EuiContextMenuPanelDescriptor = useMemo(
     () => ({
       id: 0,
-      items: [
-        ...casesItems,
-        ...workflowItems,
-        ...tagsItems,
-        ...assignItems,
-        ...runWorkflowItems,
-        ...(showAiAssistantAction ? viewInAiAssistantItems : []),
-        ...datasetItems,
-        ...investigateInTimelineItems,
-      ],
+      items: isRemoteDocument
+        ? [...investigateInTimelineItems]
+        : [
+            ...casesItems,
+            ...workflowItems,
+            ...tagsItems,
+            ...assignItems,
+            ...runWorkflowItems,
+            ...(showAiAssistantAction ? viewInAiAssistantItems : []),
+            ...datasetItems,
+            ...investigateInTimelineItems,
+          ],
     }),
     [
+      isRemoteDocument,
       runWorkflowItems,
       workflowItems,
       assignItems,
@@ -228,8 +237,11 @@ export function AttacksGroupTakeActionItems({
   );
 
   const panels: EuiContextMenuPanelDescriptor[] = useMemo(
-    () => [defaultPanel, ...runWorkflowPanels, ...workflowPanels, ...assignPanels, ...tagsPanels],
-    [runWorkflowPanels, workflowPanels, assignPanels, defaultPanel, tagsPanels]
+    () =>
+      isRemoteDocument
+        ? [defaultPanel]
+        : [defaultPanel, ...runWorkflowPanels, ...workflowPanels, ...assignPanels, ...tagsPanels],
+    [isRemoteDocument, runWorkflowPanels, workflowPanels, assignPanels, defaultPanel, tagsPanels]
   );
 
   return <EuiContextMenu size={size} initialPanelId={defaultPanel.id} panels={panels} />;

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/table_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/table_section.tsx
@@ -8,10 +8,11 @@
 import React, { useCallback, useMemo, useState } from 'react';
 import { EuiFlexGroup, EuiFlexItem, EuiSpacer } from '@elastic/eui';
 import type { Filter } from '@kbn/es-query';
+import { isCCSRemoteIndexName } from '@kbn/es-query';
 import { TableId } from '@kbn/securitysolution-data-table';
 import type { DataView } from '@kbn/data-views-plugin/common';
-import { isGroupingBucket } from '@kbn/grouping/src';
 import type { GroupingSort, ParsedGroupingAggregation, RawBucket } from '@kbn/grouping/src';
+import { isGroupingBucket } from '@kbn/grouping/src';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 
 import { AttackDetailsRightPanelKey } from '../../../../flyout/attack_details/constants/panel_keys';
@@ -42,7 +43,7 @@ import { AlertsTab } from './attack_details/alerts_tab';
 import { EmptyResultsPrompt } from './empty_results_prompt';
 import { dsl } from '../utils/dsl';
 import { groupingOptions, groupingSettings } from './grouping_settings/grouping_configs';
-import { buildConnectorIdFilter, buildAttacksOnlyFilter } from './filtering_configs';
+import { buildAttacksOnlyFilter, buildConnectorIdFilter } from './filtering_configs';
 import type { GroupTakeActionItems } from '../../alerts_table/types';
 import { AttacksGroupTakeActionItems } from './attacks_group_take_action_items';
 import { useGroupStats } from './grouping_settings/use_group_stats';
@@ -259,6 +260,7 @@ export const TableSection = React.memo(
             attack={attack}
             closePopover={props.closePopover}
             telemetrySource="attacks_page_group_take_action"
+            isRemoteDocument={isCCSRemoteIndexName(attack.index ?? '')}
           />
         );
       },

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/components/assignees.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/components/assignees.test.tsx
@@ -238,4 +238,15 @@ describe('Assignees', () => {
 
     expect(screen.getByTestId('attack-details-flyout-header-assignees-empty')).toBeInTheDocument();
   });
+
+  it('disables the add button for a remote/CCS index', () => {
+    mockUseAttackDetailsContext.mockReturnValue({
+      ...defaultContext,
+      indexName: 'remote-cluster:.alerts-security.alerts-default',
+    });
+
+    renderAssignees();
+
+    expect(screen.getByTestId(HEADER_ASSIGNEES_ADD_BUTTON_TEST_ID)).toBeDisabled();
+  });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/components/assignees.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/components/assignees.tsx
@@ -18,6 +18,7 @@ import {
   EuiToolTip,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
+import { isCCSRemoteIndexName } from '@kbn/es-query';
 import { getEmptyTagValue } from '../../../common/components/empty_value';
 import { UsersAvatarsPanel } from '../../../common/components/user_profiles/users_avatars_panel';
 import { useBulkGetUserProfiles } from '../../../common/components/user_profiles/use_bulk_get_user_profiles';
@@ -56,7 +57,8 @@ AssigneesButton.displayName = 'AssigneesButton';
  * + useAttackAssigneesContextMenuItems, with EuiPopover + EuiContextMenu.
  */
 export const Assignees = memo(() => {
-  const { attackId, refetch } = useAttackDetailsContext();
+  const { attackId, indexName, refetch } = useAttackDetailsContext();
+  const isRemoteDocument = useMemo(() => isCCSRemoteIndexName(indexName), [indexName]);
   const { alertIds, assignees } = useHeaderData();
   const invalidateFindAttackDiscoveries = useInvalidateFindAttackDiscoveries();
   const { hasIndexWrite, hasAttackIndexWrite, loading: privilegesLoading } = useAttacksPrivileges();
@@ -98,9 +100,13 @@ export const Assignees = memo(() => {
 
   const button = useMemo(
     () => (
-      <AssigneesButton onClick={togglePopover} isDisabled={false} toolTipMessage={toolTipMessage} />
+      <AssigneesButton
+        onClick={togglePopover}
+        isDisabled={isRemoteDocument}
+        toolTipMessage={toolTipMessage}
+      />
     ),
-    [togglePopover, toolTipMessage]
+    [togglePopover, toolTipMessage, isRemoteDocument]
   );
 
   if (!hasPermission) {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/components/status.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/components/status.test.tsx
@@ -20,8 +20,16 @@ jest.mock('../../../common/hooks/use_space_id', () => ({
 }));
 
 jest.mock('./status_popover_button', () => ({
-  StatusPopoverButton: ({ enrichedFieldInfo }: { enrichedFieldInfo: unknown }) => (
-    <div data-test-subj="status-popover">{JSON.stringify(enrichedFieldInfo)}</div>
+  StatusPopoverButton: ({
+    enrichedFieldInfo,
+    disabled,
+  }: {
+    enrichedFieldInfo: unknown;
+    disabled?: boolean;
+  }) => (
+    <div data-test-subj="status-popover" data-disabled={String(disabled ?? false)}>
+      {JSON.stringify(enrichedFieldInfo)}
+    </div>
   ),
 }));
 
@@ -41,6 +49,7 @@ describe('<Status />', () => {
   test('renders empty tag when status data is not available', () => {
     (useAttackDetailsContext as jest.Mock).mockReturnValue({
       attackId: 'attack-id',
+      indexName: '.alerts-security.alerts-default',
       browserFields: {},
       dataFormattedForFieldBrowser: [],
     });
@@ -58,6 +67,7 @@ describe('<Status />', () => {
   test('renders empty tag in preview mode', () => {
     (useAttackDetailsContext as jest.Mock).mockReturnValue({
       attackId: 'attack-id',
+      indexName: '.alerts-security.alerts-default',
       browserFields: {},
       dataFormattedForFieldBrowser: [{}],
       isPreview: true,
@@ -76,6 +86,7 @@ describe('<Status />', () => {
     // Ensure the memo finds the correct item (field + category).
     (useAttackDetailsContext as jest.Mock).mockReturnValue({
       attackId: 'attack-id',
+      indexName: '.alerts-security.alerts-default',
       browserFields: {},
       dataFormattedForFieldBrowser: [{ field: 'kibana.alert.workflow_status', category: 'kibana' }],
     });
@@ -114,6 +125,7 @@ describe('<Status />', () => {
   test('renders empty tag when getEnrichedFieldInfo returns no values array', () => {
     (useAttackDetailsContext as jest.Mock).mockReturnValue({
       attackId: 'attack-id',
+      indexName: '.alerts-security.alerts-default',
       browserFields: {},
       dataFormattedForFieldBrowser: [{ field: 'kibana.alert.workflow_status', category: 'kibana' }],
     });
@@ -133,5 +145,51 @@ describe('<Status />', () => {
 
     expect(screen.getByTestId('empty-tag')).toBeInTheDocument();
     expect(screen.queryByTestId('status-popover')).not.toBeInTheDocument();
+  });
+
+  test('passes disabled=false to StatusPopoverButton for a local index', () => {
+    (useAttackDetailsContext as jest.Mock).mockReturnValue({
+      attackId: 'attack-id',
+      indexName: '.alerts-security.alerts-default',
+      browserFields: {},
+      dataFormattedForFieldBrowser: [{ field: 'kibana.alert.workflow_status', category: 'kibana' }],
+    });
+
+    (getEnrichedFieldInfo as jest.Mock).mockReturnValue({
+      data: { field: 'kibana.alert.workflow_status', type: 'string' },
+      eventId: 'attack-id',
+      values: ['open'],
+    });
+
+    render(
+      <TestProviders>
+        <Status />
+      </TestProviders>
+    );
+
+    expect(screen.getByTestId('status-popover')).toHaveAttribute('data-disabled', 'false');
+  });
+
+  test('passes disabled=true to StatusPopoverButton for a remote/CCS index', () => {
+    (useAttackDetailsContext as jest.Mock).mockReturnValue({
+      attackId: 'attack-id',
+      indexName: 'remote-cluster:.alerts-security.alerts-default',
+      browserFields: {},
+      dataFormattedForFieldBrowser: [{ field: 'kibana.alert.workflow_status', category: 'kibana' }],
+    });
+
+    (getEnrichedFieldInfo as jest.Mock).mockReturnValue({
+      data: { field: 'kibana.alert.workflow_status', type: 'string' },
+      eventId: 'attack-id',
+      values: ['open'],
+    });
+
+    render(
+      <TestProviders>
+        <Status />
+      </TestProviders>
+    );
+
+    expect(screen.getByTestId('status-popover')).toHaveAttribute('data-disabled', 'true');
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/components/status.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/components/status.tsx
@@ -8,6 +8,7 @@
 import React, { memo, useMemo } from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { find } from 'lodash/fp';
+import { isCCSRemoteIndexName } from '@kbn/es-query';
 import { useSpaceId } from '../../../common/hooks/use_space_id';
 import { SIGNAL_STATUS_FIELD_NAME } from '../../../timelines/components/timeline/body/renderers/constants';
 import { getEnrichedFieldInfo } from '../../document_details/right/utils/enriched_field_info';
@@ -30,8 +31,10 @@ function hasData(fieldInfo?: EnrichedFieldInfo): fieldInfo is EnrichedFieldInfoW
 }
 
 export const Status = memo(() => {
-  const { attackId, browserFields, dataFormattedForFieldBrowser } = useAttackDetailsContext();
+  const { attackId, indexName, browserFields, dataFormattedForFieldBrowser } =
+    useAttackDetailsContext();
   const currentSpaceId = useSpaceId();
+  const isRemoteDocument = useMemo(() => isCCSRemoteIndexName(indexName), [indexName]);
   const statusData = useMemo(() => {
     const item = find(
       { field: SIGNAL_STATUS_FIELD_NAME, category: 'kibana' },
@@ -63,7 +66,7 @@ export const Status = memo(() => {
       {!statusData || !hasData(statusData) ? (
         getEmptyTagValue()
       ) : (
-        <StatusPopoverButton enrichedFieldInfo={statusData} />
+        <StatusPopoverButton enrichedFieldInfo={statusData} disabled={isRemoteDocument} />
       )}
     </AlertHeaderBlock>
   );

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/components/status_popover_button.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/components/status_popover_button.test.tsx
@@ -94,7 +94,7 @@ describe('StatusPopoverButton (attack details)', () => {
   test('it passes the correct telemetry source', () => {
     render(
       <TestProviders>
-        <StatusPopoverButton enrichedFieldInfo={enrichedFieldInfo} />
+        <StatusPopoverButton enrichedFieldInfo={enrichedFieldInfo} disabled={false} />
       </TestProviders>
     );
 
@@ -108,7 +108,7 @@ describe('StatusPopoverButton (attack details)', () => {
   test('it renders the current status', () => {
     render(
       <TestProviders>
-        <StatusPopoverButton enrichedFieldInfo={enrichedFieldInfo} />
+        <StatusPopoverButton enrichedFieldInfo={enrichedFieldInfo} disabled={false} />
       </TestProviders>
     );
 
@@ -120,7 +120,7 @@ describe('StatusPopoverButton (attack details)', () => {
 
     render(
       <TestProviders>
-        <StatusPopoverButton enrichedFieldInfo={enrichedFieldInfo} />
+        <StatusPopoverButton enrichedFieldInfo={enrichedFieldInfo} disabled={false} />
       </TestProviders>
     );
 
@@ -137,7 +137,7 @@ describe('StatusPopoverButton (attack details)', () => {
 
     render(
       <TestProviders>
-        <StatusPopoverButton enrichedFieldInfo={enrichedFieldInfo} />
+        <StatusPopoverButton enrichedFieldInfo={enrichedFieldInfo} disabled={false} />
       </TestProviders>
     );
 
@@ -147,5 +147,40 @@ describe('StatusPopoverButton (attack details)', () => {
     await user.click(screen.getByText('Mark as acknowledged'));
 
     expect(mockCloseFlyout).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not open the popover when disabled=true', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <TestProviders>
+        <StatusPopoverButton enrichedFieldInfo={enrichedFieldInfo} disabled={true} />
+      </TestProviders>
+    );
+
+    await user.click(screen.getByText('open'));
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(screen.queryByText('Change attack status')).not.toBeInTheDocument();
+  });
+
+  test('does not open the popover when there are no action items', async () => {
+    (useAttackWorkflowStatusContextMenuItems as jest.Mock).mockImplementation(() => ({
+      items: [],
+      panels: [],
+    }));
+
+    const user = userEvent.setup();
+
+    render(
+      <TestProviders>
+        <StatusPopoverButton enrichedFieldInfo={enrichedFieldInfo} disabled={false} />
+      </TestProviders>
+    );
+
+    await user.click(screen.getByText('open'));
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(screen.queryByText('Change attack status')).not.toBeInTheDocument();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/components/status_popover_button.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/components/status_popover_button.tsx
@@ -30,113 +30,127 @@ interface StatusPopoverButtonProps {
    * Information used to
    */
   enrichedFieldInfo: EnrichedFieldInfoWithValues;
+  /**
+   * When true, suppresses the status-change popover regardless of user permissions.
+   * Use this when status mutations are not possible (e.g. remote/CCS documents).
+   */
+  disabled: boolean;
 }
 
 /**
  * Renders a button and its popover + modal to display the status of an attack and allows the user to change it.
  * It is used in the header of the attack details flyout.
  */
-export const StatusPopoverButton = memo(({ enrichedFieldInfo }: StatusPopoverButtonProps) => {
-  const { attackId } = useAttackDetailsContext();
-  const { alertIds } = useHeaderData();
-  const currentSpaceId = useSpaceId();
-  const { closeFlyout } = useExpandableFlyoutApi();
-  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
-  const togglePopover = useCallback(() => setIsPopoverOpen(!isPopoverOpen), [isPopoverOpen]);
-  const closePopover = useCallback(() => setIsPopoverOpen(false), []);
+export const StatusPopoverButton = memo(
+  ({ enrichedFieldInfo, disabled }: StatusPopoverButtonProps) => {
+    const { attackId } = useAttackDetailsContext();
+    const { alertIds } = useHeaderData();
+    const currentSpaceId = useSpaceId();
+    const { closeFlyout } = useExpandableFlyoutApi();
+    const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+    const togglePopover = useCallback(() => setIsPopoverOpen(!isPopoverOpen), [isPopoverOpen]);
+    const closePopover = useCallback(() => setIsPopoverOpen(false), []);
 
-  const getGlobalQuerySelector = useMemo(() => inputsSelectors.globalQuery(), []);
+    const getGlobalQuerySelector = useMemo(() => inputsSelectors.globalQuery(), []);
 
-  const globalQueries = useDeepEqualSelector(getGlobalQuerySelector);
+    const globalQueries = useDeepEqualSelector(getGlobalQuerySelector);
 
-  // refetch alerts after status change
-  const refetchGlobalQuery = useCallback(() => {
-    globalQueries.forEach((q) => q.refetch && (q.refetch as inputsModel.Refetch)());
-  }, [globalQueries]);
+    // refetch alerts after status change
+    const refetchGlobalQuery = useCallback(() => {
+      globalQueries.forEach((q) => q.refetch && (q.refetch as inputsModel.Refetch)());
+    }, [globalQueries]);
 
-  // force attacks to be refetched automatically after status change
-  const invalidateFindAttackDiscoveries = useInvalidateFindAttackDiscoveries();
+    // force attacks to be refetched automatically after status change
+    const invalidateFindAttackDiscoveries = useInvalidateFindAttackDiscoveries();
 
-  const currentWorkflowStatus = useMemo(
-    () => enrichedFieldInfo.values[0] as AlertWorkflowStatus,
-    [enrichedFieldInfo.values]
-  );
-  const onWorkflowStatusChange = useCallback(() => {
-    invalidateFindAttackDiscoveries();
-    refetchGlobalQuery();
-    closeFlyout();
-  }, [closeFlyout, invalidateFindAttackDiscoveries, refetchGlobalQuery]);
+    const currentWorkflowStatus = useMemo(
+      () => enrichedFieldInfo.values[0] as AlertWorkflowStatus,
+      [enrichedFieldInfo.values]
+    );
+    const onWorkflowStatusChange = useCallback(() => {
+      invalidateFindAttackDiscoveries();
+      refetchGlobalQuery();
+      closeFlyout();
+    }, [closeFlyout, invalidateFindAttackDiscoveries, refetchGlobalQuery]);
 
-  const { items, panels } = useAttackWorkflowStatusContextMenuItems({
-    attacksWithWorkflowStatus: [
-      {
-        attackId,
-        relatedAlertIds: alertIds,
-        workflowStatus: currentWorkflowStatus,
-      },
-    ],
-    closePopover: togglePopover,
-    onSuccess: onWorkflowStatusChange,
-    telemetrySource: 'attacks_page_flyout_header',
-  });
+    const { items, panels } = useAttackWorkflowStatusContextMenuItems({
+      attacksWithWorkflowStatus: [
+        {
+          attackId,
+          relatedAlertIds: alertIds,
+          workflowStatus: currentWorkflowStatus,
+        },
+      ],
+      closePopover: togglePopover,
+      onSuccess: onWorkflowStatusChange,
+      telemetrySource: 'attacks_page_flyout_header',
+    });
 
-  const button = useMemo(
-    () => (
-      <FormattedFieldValue
-        contextId={`${currentSpaceId}-attack-details-flyout-status-popover-button`}
-        eventId={attackId}
-        value={enrichedFieldInfo.values[0]}
-        fieldName={enrichedFieldInfo.data.field}
-        linkValue={enrichedFieldInfo.linkValue}
-        fieldType={enrichedFieldInfo.data.type}
-        fieldFormat={getFieldFormat(enrichedFieldInfo.data)}
-        truncate={false}
-        isButton={true}
-        onClick={true ? togglePopover : undefined}
-        onClickAriaLabel={CLICK_TO_CHANGE_ALERT_STATUS}
-      />
-    ),
-    [
-      currentSpaceId,
-      attackId,
-      enrichedFieldInfo.values,
-      enrichedFieldInfo.data,
-      enrichedFieldInfo.linkValue,
-      togglePopover,
-    ]
-  );
+    const statusPopoverVisible = useMemo(() => items.length > 0 && !disabled, [items, disabled]);
 
-  return (
-    <>
-      <EuiPopover
-        button={button}
-        isOpen={isPopoverOpen}
-        closePopover={closePopover}
-        panelPaddingSize="none"
-        data-test-subj={STATUS_POPOVER_TEST_ID}
-      >
-        <EuiPopoverTitle paddingSize="m">
-          {i18n.translate(
-            'xpack.securitySolution.attackDetailsFlyout.header.popover.changeAttackStatus',
-            {
-              defaultMessage: 'Change attack status',
-            }
-          )}
-        </EuiPopoverTitle>
-        <EuiContextMenu
-          panels={[
-            {
-              id: 0,
-              items,
-            },
-            ...panels,
-          ]}
-          initialPanelId={0}
-          data-test-subj={STATUS_POPOVER_BUTTON_TEST_ID}
+    const button = useMemo(
+      () => (
+        <FormattedFieldValue
+          contextId={`${currentSpaceId}-attack-details-flyout-status-popover-button`}
+          eventId={attackId}
+          value={enrichedFieldInfo.values[0]}
+          fieldName={enrichedFieldInfo.data.field}
+          linkValue={enrichedFieldInfo.linkValue}
+          fieldType={enrichedFieldInfo.data.type}
+          fieldFormat={getFieldFormat(enrichedFieldInfo.data)}
+          truncate={false}
+          isButton={statusPopoverVisible}
+          onClick={statusPopoverVisible ? togglePopover : undefined}
+          onClickAriaLabel={CLICK_TO_CHANGE_ALERT_STATUS}
         />
-      </EuiPopover>
-    </>
-  );
-});
+      ),
+      [
+        currentSpaceId,
+        attackId,
+        enrichedFieldInfo.values,
+        enrichedFieldInfo.data,
+        enrichedFieldInfo.linkValue,
+        togglePopover,
+        statusPopoverVisible,
+      ]
+    );
+
+    if (!statusPopoverVisible) {
+      return button;
+    }
+
+    return (
+      <>
+        <EuiPopover
+          button={button}
+          isOpen={isPopoverOpen}
+          closePopover={closePopover}
+          panelPaddingSize="none"
+          data-test-subj={STATUS_POPOVER_TEST_ID}
+        >
+          <EuiPopoverTitle paddingSize="m">
+            {i18n.translate(
+              'xpack.securitySolution.attackDetailsFlyout.header.popover.changeAttackStatus',
+              {
+                defaultMessage: 'Change attack status',
+              }
+            )}
+          </EuiPopoverTitle>
+          <EuiContextMenu
+            panels={[
+              {
+                id: 0,
+                items,
+              },
+              ...panels,
+            ]}
+            initialPanelId={0}
+            data-test-subj={STATUS_POPOVER_BUTTON_TEST_ID}
+          />
+        </EuiPopover>
+      </>
+    );
+  }
+);
 
 StatusPopoverButton.displayName = 'StatusPopoverButton';

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/footer.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/footer.tsx
@@ -6,6 +6,7 @@
  */
 
 import React, { useCallback, useMemo, useState } from 'react';
+import { isCCSRemoteIndexName } from '@kbn/es-query';
 import {
   EuiButton,
   EuiFlexGroup,
@@ -29,7 +30,8 @@ export { FLYOUT_FOOTER_TEST_ID };
  * Bottom section of the flyout that contains the take action button
  */
 export const PanelFooter = () => {
-  const { attack, refetch } = useAttackDetailsContext();
+  const { attack, indexName, refetch } = useAttackDetailsContext();
+  const isRemoteDocument = useMemo(() => isCCSRemoteIndexName(indexName), [indexName]);
 
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
 
@@ -90,6 +92,7 @@ export const PanelFooter = () => {
                 size="s"
                 telemetrySource="attacks_page_flyout_take_action"
                 showAiAssistantAction={false}
+                isRemoteDocument={isRemoteDocument}
               />
             </EuiPopover>
           </EuiFlexItem>

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/left/tabs/notes_tab.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/left/tabs/notes_tab.tsx
@@ -7,6 +7,8 @@
 
 import React, { memo, useMemo } from 'react';
 import { buildDataTableRecord, type EsHitRecord } from '@kbn/discover-utils';
+import { EuiSpacer } from '@elastic/eui';
+import { NotesRemoteCallout } from '../../../../flyout_v2/notes/components/notes_remote_callout';
 import { NotesDetailsContent } from '../../../../flyout_v2/notes/components/notes_details_content';
 import { useTimelineConfig } from '../../../../flyout_v2/notes/hooks/use_timeline_config';
 import { useAttackDetailsContext } from '../../context';
@@ -22,7 +24,14 @@ export const NotesTab = memo(() => {
   const isTimelineFlyout = useWhichFlyout() === Flyouts.timeline;
   const timelineConfig = useTimelineConfig(attackId, isTimelineFlyout);
 
-  return <NotesDetailsContent hit={hit} timelineConfig={timelineConfig} hideTimelineIcon={false} />;
+  return (
+    <>
+      <NotesRemoteCallout hit={hit}>
+        <EuiSpacer size="m" />
+      </NotesRemoteCallout>
+      <NotesDetailsContent hit={hit} timelineConfig={timelineConfig} hideTimelineIcon={false} />
+    </>
+  );
 });
 
 NotesTab.displayName = 'NotesTab';

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/index.test.tsx
@@ -1,0 +1,250 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react';
+import type { LeftPanelTabType } from './tabs';
+import { LeftPanel } from '.';
+import { DocumentDetailsContext } from '../shared/context';
+import { mockContextValue } from '../shared/mocks/mock_context';
+import { useUserPrivileges } from '../../../common/components/user_privileges';
+import { TestProvider } from '@kbn/expandable-flyout/src/test/provider';
+import { DocumentEventTypes } from '../../../common/lib/telemetry/types';
+
+const mockOpenLeftPanel = jest.fn();
+jest.mock('@kbn/expandable-flyout', () => ({
+  useExpandableFlyoutApi: () => ({ openLeftPanel: mockOpenLeftPanel }),
+}));
+
+jest.mock('../../../common/components/user_privileges');
+
+const mockReportEvent = jest.fn();
+jest.mock('../../../common/lib/kibana', () => ({
+  useKibana: () => ({ services: { telemetry: { reportEvent: mockReportEvent } } }),
+}));
+
+jest.mock('./header', () => ({
+  PanelHeader: ({
+    tabs,
+    selectedTabId,
+    setSelectedTabId,
+  }: {
+    tabs: LeftPanelTabType[];
+    selectedTabId: string;
+    setSelectedTabId: (id: string) => void;
+  }) => (
+    <div
+      data-test-subj="mockPanelHeader"
+      data-tab-ids={tabs.map((t) => t.id).join(',')}
+      data-selected-tab={selectedTabId}
+    >
+      {tabs.map((tab) => (
+        <button
+          key={tab.id}
+          type="button"
+          data-test-subj={`tab-${tab.id}`}
+          onClick={() => setSelectedTabId(tab.id)}
+        >
+          {tab.id}
+        </button>
+      ))}
+    </div>
+  ),
+}));
+
+jest.mock('./content', () => ({
+  PanelContent: () => <div data-test-subj="mockPanelContent" />,
+}));
+
+const mockUseUserPrivileges = useUserPrivileges as jest.Mock;
+
+const nonAlertGetFieldsData = (field: string) => (field === 'event.kind' ? 'event' : undefined);
+
+type RenderProps = Parameters<typeof LeftPanel>[0] & { contextOverrides?: Record<string, unknown> };
+
+const renderLeftPanel = ({ contextOverrides = {}, ...props }: RenderProps = {}) =>
+  render(
+    <TestProvider>
+      <DocumentDetailsContext.Provider value={{ ...mockContextValue, ...contextOverrides }}>
+        <LeftPanel {...props} />
+      </DocumentDetailsContext.Provider>
+    </TestProvider>
+  );
+
+const getTabIds = (container: HTMLElement): string[] => {
+  const raw = container
+    .querySelector('[data-test-subj="mockPanelHeader"]')!
+    .getAttribute('data-tab-ids')!;
+  return raw.split(',');
+};
+
+const getSelectedTabId = (container: HTMLElement): string =>
+  container.querySelector('[data-test-subj="mockPanelHeader"]')!.getAttribute('data-selected-tab')!;
+
+describe('<LeftPanel />', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseUserPrivileges.mockReturnValue({ notesPrivileges: { read: false } });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Tab composition — alert document
+  // ---------------------------------------------------------------------------
+  describe('tab composition for alert documents', () => {
+    it('should show visualize, insights, investigation and response tabs for a local alert', () => {
+      const tabIds = getTabIds(renderLeftPanel().container);
+
+      expect(tabIds).toEqual(['visualize', 'insights', 'investigation', 'response']);
+    });
+
+    it('should show visualize and insights tabs only for a remote alert (no investigation, no response)', () => {
+      const tabIds = getTabIds(
+        renderLeftPanel({ contextOverrides: { indexName: 'remote-cluster:index-name' } }).container
+      );
+
+      expect(tabIds).toEqual(['visualize', 'insights']);
+    });
+
+    it('should include the notes tab for a local alert when the user can read notes', () => {
+      mockUseUserPrivileges.mockReturnValue({ notesPrivileges: { read: true } });
+
+      const tabIds = getTabIds(renderLeftPanel().container);
+
+      expect(tabIds).toContain('notes');
+    });
+
+    it('should include the notes tab for a remote alert when the user can read notes', () => {
+      mockUseUserPrivileges.mockReturnValue({ notesPrivileges: { read: true } });
+
+      const tabIds = getTabIds(
+        renderLeftPanel({ contextOverrides: { indexName: 'remote-cluster:index-name' } }).container
+      );
+
+      expect(tabIds).toContain('notes');
+      expect(tabIds).not.toContain('investigation');
+      expect(tabIds).not.toContain('response');
+    });
+
+    it('should not include the notes tab when the user cannot read notes', () => {
+      mockUseUserPrivileges.mockReturnValue({ notesPrivileges: { read: false } });
+
+      const tabIds = getTabIds(renderLeftPanel().container);
+
+      expect(tabIds).not.toContain('notes');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Tab composition — non-alert document
+  // ---------------------------------------------------------------------------
+  describe('tab composition for non-alert documents', () => {
+    it('should show visualize and insights tabs only', () => {
+      const tabIds = getTabIds(
+        renderLeftPanel({ contextOverrides: { getFieldsData: nonAlertGetFieldsData } }).container
+      );
+
+      expect(tabIds).toEqual(['visualize', 'insights']);
+    });
+
+    it('should include the notes tab when the user can read notes', () => {
+      mockUseUserPrivileges.mockReturnValue({ notesPrivileges: { read: true } });
+
+      const tabIds = getTabIds(
+        renderLeftPanel({ contextOverrides: { getFieldsData: nonAlertGetFieldsData } }).container
+      );
+
+      expect(tabIds).toContain('notes');
+      expect(tabIds).not.toContain('response');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Rule preview mode
+  // ---------------------------------------------------------------------------
+  describe('rule preview mode', () => {
+    it('should not show the visualize tab in rule preview', () => {
+      const tabIds = getTabIds(
+        renderLeftPanel({ contextOverrides: { isRulePreview: true } }).container
+      );
+
+      expect(tabIds).not.toContain('visualize');
+    });
+
+    it('should not show the notes tab in rule preview even when the user can read notes', () => {
+      mockUseUserPrivileges.mockReturnValue({ notesPrivileges: { read: true } });
+
+      const tabIds = getTabIds(
+        renderLeftPanel({ contextOverrides: { isRulePreview: true } }).container
+      );
+
+      expect(tabIds).not.toContain('notes');
+    });
+
+    it('should show insights, investigation and response tabs in rule preview for an alert', () => {
+      const tabIds = getTabIds(
+        renderLeftPanel({ contextOverrides: { isRulePreview: true } }).container
+      );
+
+      expect(tabIds).toEqual(['insights', 'investigation', 'response']);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Selected tab
+  // ---------------------------------------------------------------------------
+  describe('selected tab', () => {
+    it('should default to the first tab when no path is provided', () => {
+      const selectedTabId = getSelectedTabId(renderLeftPanel().container);
+
+      expect(selectedTabId).toBe('visualize');
+    });
+
+    it('should select the tab matching path.tab', () => {
+      const selectedTabId = getSelectedTabId(
+        renderLeftPanel({ path: { tab: 'response' } }).container
+      );
+
+      expect(selectedTabId).toBe('response');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Tab click — openLeftPanel + telemetry
+  // ---------------------------------------------------------------------------
+  describe('tab click interactions', () => {
+    it('should call openLeftPanel with the correct params when a tab is clicked', () => {
+      const { getByTestId } = renderLeftPanel();
+
+      fireEvent.click(getByTestId('tab-response'));
+
+      expect(mockOpenLeftPanel).toHaveBeenCalledWith({
+        id: 'document-details-left',
+        path: { tab: 'response' },
+        params: {
+          id: mockContextValue.eventId,
+          indexName: mockContextValue.indexName,
+          scopeId: mockContextValue.scopeId,
+        },
+      });
+    });
+
+    it('should report a telemetry event when a tab is clicked', () => {
+      const { getByTestId } = renderLeftPanel();
+
+      fireEvent.click(getByTestId('tab-response'));
+
+      expect(mockReportEvent).toHaveBeenCalledWith(
+        DocumentEventTypes.DetailsFlyoutTabClicked,
+        expect.objectContaining({
+          location: mockContextValue.scopeId,
+          panel: 'left',
+          tabId: 'response',
+        })
+      );
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/index.tsx
@@ -9,6 +9,7 @@ import type { FC } from 'react';
 import React, { memo, useMemo } from 'react';
 
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
+import { isCCSRemoteIndexName } from '@kbn/es-query';
 import { useUserPrivileges } from '../../../common/components/user_privileges';
 import { DocumentDetailsLeftPanelKey } from '../shared/constants/panel_keys';
 import { useKibana } from '../../../common/lib/kibana';
@@ -38,19 +39,26 @@ export const LeftPanel: FC<Partial<DocumentDetailsProps>> = memo(({ path }) => {
     notesPrivileges: { read: canSeeNotes },
   } = useUserPrivileges();
 
+  const isRemoteDocument = isCCSRemoteIndexName(indexName);
+
   const tabsDisplayed = useMemo(() => {
     const tabList =
       eventKind === EventKind.signal
-        ? [tabs.insightsTab, tabs.investigationTab, tabs.responseTab]
+        ? [
+            tabs.insightsTab,
+            ...(isRemoteDocument ? [] : [tabs.investigationTab]),
+            ...(isRemoteDocument ? [] : [tabs.responseTab]),
+          ]
         : [tabs.insightsTab];
     if (canSeeNotes && !isRulePreview) {
       tabList.push(tabs.notesTab);
     }
+
     if (!isRulePreview) {
       return [tabs.visualizeTab, ...tabList];
     }
     return tabList;
-  }, [eventKind, isRulePreview, canSeeNotes]);
+  }, [eventKind, isRemoteDocument, isRulePreview, canSeeNotes]);
 
   const selectedTabId = useMemo(() => {
     const defaultTab = tabsDisplayed[0].id;

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/tabs/notes_tab.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/tabs/notes_tab.tsx
@@ -8,7 +8,8 @@
 import React, { memo, useMemo } from 'react';
 import { buildDataTableRecord, type EsHitRecord } from '@kbn/discover-utils';
 import { useSelector } from 'react-redux';
-import { EuiPanel } from '@elastic/eui';
+import { EuiPanel, EuiSpacer } from '@elastic/eui';
+import { NotesRemoteCallout } from '../../../../flyout_v2/notes/components/notes_remote_callout';
 import type { State } from '../../../../common/store';
 import { timelineSelectors } from '../../../../timelines/store';
 import { TimelineId } from '../../../../../common/types';
@@ -31,6 +32,9 @@ export const NotesTab = memo(() => {
 
   return (
     <EuiPanel hasBorder={false} hasShadow={false}>
+      <NotesRemoteCallout hit={hit}>
+        <EuiSpacer size="m" />
+      </NotesRemoteCallout>
       <NotesDetailsContent hit={hit} timelineConfig={timelineConfig} hideTimelineIcon={false} />
     </EuiPanel>
   );

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/about_section.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/about_section.test.tsx
@@ -14,8 +14,10 @@ import {
   EVENT_RENDERER_TEST_ID,
   MITRE_ATTACK_TITLE_TEST_ID,
   REASON_TITLE_TEST_ID,
+  RULE_SUMMARY_BUTTON_TEST_ID,
 } from '../../../../flyout_v2/document/components/test_ids';
 import { useExpandSection } from '../../../../flyout_v2/shared/hooks/use_expand_section';
+import { useUserPrivileges } from '../../../../common/components/user_privileges';
 import { DocumentDetailsContext } from '../../shared/context';
 import { mockContextValue } from '../../shared/mocks/mock_context';
 import { AboutSection } from './about_section';
@@ -31,10 +33,12 @@ jest.mock('../../../../common/components/link_to');
 jest.mock('../../../../flyout_v2/shared/hooks/use_expand_section', () => ({
   useExpandSection: jest.fn(),
 }));
+jest.mock('../../../../common/components/user_privileges');
 
 const renderAboutSection = (searchHit = mockSearchHit) => {
   const contextValue = {
     ...mockContextValue,
+    indexName: searchHit._index,
     searchHit,
   };
   return render(
@@ -111,6 +115,47 @@ describe('<AboutSection />', () => {
 
     await act(async () => {
       expect(getByText('Event renderer')).toBeInTheDocument();
+    });
+  });
+
+  describe('rule summary button', () => {
+    beforeEach(() => {
+      (useUserPrivileges as jest.Mock).mockReturnValue({
+        rulesPrivileges: { rules: { read: true } },
+      });
+    });
+
+    it('should disable the rule summary button for a remote alert', async () => {
+      const remoteAlertSearchHit = {
+        ...mockSearchHit,
+        _index: 'remote-cluster:.alerts-security.alerts-default',
+        fields: {
+          ...mockSearchHit.fields,
+          'event.kind': [EventKind.signal],
+        },
+      };
+
+      const { getByTestId } = renderAboutSection(remoteAlertSearchHit);
+
+      await act(async () => {
+        expect(getByTestId(RULE_SUMMARY_BUTTON_TEST_ID)).toHaveAttribute('disabled');
+      });
+    });
+
+    it('should enable the rule summary button for a local alert', async () => {
+      const localAlertSearchHit = {
+        ...mockSearchHit,
+        fields: {
+          ...mockSearchHit.fields,
+          'event.kind': [EventKind.signal],
+        },
+      };
+
+      const { getByTestId } = renderAboutSection(localAlertSearchHit);
+
+      await act(async () => {
+        expect(getByTestId(RULE_SUMMARY_BUTTON_TEST_ID)).not.toHaveAttribute('disabled');
+      });
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/about_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/about_section.tsx
@@ -13,6 +13,7 @@ import {
   type EsHitRecord,
   getFieldValue,
 } from '@kbn/discover-utils';
+import { isCCSRemoteIndexName } from '@kbn/es-query';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { FLYOUT_STORAGE_KEYS } from '../../../../flyout_v2/document/constants/local_storage';
 import { ExpandableSection } from '../../../../flyout_v2/shared/components/expandable_section';
@@ -70,6 +71,8 @@ export const AboutSection = memo(() => {
     [searchHit]
   );
 
+  const isRemoteDocument = useMemo(() => isCCSRemoteIndexName(indexName), [indexName]);
+
   const eventKind = useMemo(() => getFieldValue(hit, 'event.kind') as string, [hit]);
   const eventKindInECS = eventKind && isEcsAllowedValue('event.kind', eventKind);
 
@@ -79,8 +82,11 @@ export const AboutSection = memo(() => {
     defaultValue: true,
   });
 
-  const ruleSummaryDisabled =
-    isEmpty(ruleName) || isEmpty(ruleId) || isRulePreview || !canReadRules;
+  const ruleSummaryDisabled = useMemo(
+    () =>
+      isEmpty(ruleName) || isEmpty(ruleId) || isRulePreview || !canReadRules || isRemoteDocument,
+    [canReadRules, isRemoteDocument, isRulePreview, ruleId, ruleName]
+  );
 
   const openRulePreview = useCallback(() => {
     openPreviewPanel({

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/investigation_section.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/investigation_section.test.tsx
@@ -178,6 +178,18 @@ describe('<InvestigationSection />', () => {
     });
   });
 
+  it('should not render investigation guide when document is a remote alert', async () => {
+    const { queryByTestId } = renderInvestigationSection({
+      ...panelContextValue,
+      indexName: 'remote-cluster:index-name',
+      searchHit: { ...panelContextValue.searchHit, _index: 'remote-cluster:index-name' },
+    });
+
+    await act(async () => {
+      expect(queryByTestId(INVESTIGATION_GUIDE_TEST_ID)).not.toBeInTheDocument();
+    });
+  });
+
   it('should not render investigation guide when document is not signal', async () => {
     const mockGetFieldsData = (field: string) => {
       switch (field) {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/investigation_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/investigation_section.tsx
@@ -8,6 +8,7 @@
 import React, { memo, useMemo } from 'react';
 import { EuiSpacer } from '@elastic/eui';
 import { buildDataTableRecord, type DataTableRecord, type EsHitRecord } from '@kbn/discover-utils';
+import { isCCSRemoteIndexName } from '@kbn/es-query';
 import { cellActionRenderer } from '../../../../flyout_v2/shared/components/cell_actions';
 import { FLYOUT_STORAGE_KEYS } from '../../../../flyout_v2/document/constants/local_storage';
 import { useExpandSection } from '../../../../flyout_v2/shared/hooks/use_expand_section';
@@ -32,15 +33,23 @@ const KEY = 'investigation';
  * For generic events (event.kind is event), it shows only highlighted fields.
  */
 export const InvestigationSection = memo(() => {
-  const { getFieldsData, investigationFields, isRulePreview, scopeId, searchHit } =
+  const { getFieldsData, investigationFields, isRulePreview, scopeId, searchHit, indexName } =
     useDocumentDetailsContext();
-  const eventKind = getField(getFieldsData('event.kind'));
-  const ancestorIndex = getField(getFieldsData('signal.ancestors.index')) ?? '';
+  const isAlert = useMemo(
+    () => getField(getFieldsData('event.kind')) === EventKind.signal,
+    [getFieldsData]
+  );
+  const ancestorIndex = useMemo(
+    () => getField(getFieldsData('signal.ancestors.index')) ?? '',
+    [getFieldsData]
+  );
 
   const hit: DataTableRecord = useMemo(
     () => buildDataTableRecord(searchHit as EsHitRecord),
     [searchHit]
   );
+
+  const isRemoteDocument = useMemo(() => isCCSRemoteIndexName(indexName), [indexName]);
 
   const expanded = useExpandSection({
     storageKey: FLYOUT_STORAGE_KEYS.OVERVIEW_TAB_EXPANDED_SECTIONS,
@@ -61,7 +70,7 @@ export const InvestigationSection = memo(() => {
       gutterSize="none"
       data-test-subj={INVESTIGATION_SECTION_TEST_ID}
     >
-      {eventKind === EventKind.signal && (
+      {isAlert && !isRemoteDocument && (
         <>
           <InvestigationGuide
             isAvailable={!isRulePreview}
@@ -78,6 +87,7 @@ export const InvestigationSection = memo(() => {
         renderCellActions={cellActionRenderer}
         showPreview={true}
         ancestorsIndexName={ancestorIndex}
+        hideEditButton={isRemoteDocument}
       />
     </ExpandableSection>
   );

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/response_section.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/response_section.test.tsx
@@ -131,6 +131,25 @@ describe('<ResponseSection />', () => {
     expect(container).toBeEmptyDOMElement();
   });
 
+  it('should render empty component if document is a remote alert', () => {
+    const { container } = render(
+      <IntlProvider locale="en">
+        <TestProvider>
+          <DocumentDetailsContext.Provider
+            value={{
+              ...mockContextValue,
+              indexName: 'remote-cluster:index-name',
+              searchHit: { ...mockContextValue.searchHit, _index: 'remote-cluster:index-name' },
+            }}
+          >
+            <ResponseSection />
+          </DocumentDetailsContext.Provider>
+        </TestProvider>
+      </IntlProvider>
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
   it('should render if isPreviewMode is true', () => {
     const { getByTestId } = render(
       <IntlProvider locale="en">

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/response_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/response_section.tsx
@@ -9,6 +9,7 @@ import React, { memo, useMemo } from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { EuiCallOut } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
+import { isCCSRemoteIndexName } from '@kbn/es-query';
 import { FLYOUT_STORAGE_KEYS } from '../../../../flyout_v2/document/constants/local_storage';
 import { useExpandSection } from '../../../../flyout_v2/shared/hooks/use_expand_section';
 import { ResponseButton } from './response_button';
@@ -24,14 +25,19 @@ const KEY = 'response';
  * Most bottom section of the overview tab. It contains a summary of the response tab.
  */
 export const ResponseSection = memo(() => {
-  const { isRulePreview, getFieldsData } = useDocumentDetailsContext();
+  const { isRulePreview, getFieldsData, indexName } = useDocumentDetailsContext();
+
+  const isRemoteDocument = useMemo(() => isCCSRemoteIndexName(indexName), [indexName]);
 
   const expanded = useExpandSection({
     storageKey: FLYOUT_STORAGE_KEYS.OVERVIEW_TAB_EXPANDED_SECTIONS,
     title: KEY,
     defaultValue: false,
   });
-  const eventKind = getField(getFieldsData('event.kind'));
+  const isAlert = useMemo(
+    () => getField(getFieldsData('event.kind')) === EventKind.signal,
+    [getFieldsData]
+  );
 
   const content = useMemo(() => {
     if (isRulePreview) {
@@ -62,7 +68,7 @@ export const ResponseSection = memo(() => {
     return <ResponseButton />;
   }, [isRulePreview]);
 
-  if (eventKind !== EventKind.signal) {
+  if (!isAlert || isRemoteDocument) {
     return null;
   }
 

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/components/take_action_dropdown.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/components/take_action_dropdown.test.tsx
@@ -564,4 +564,75 @@ describe('take action dropdown', () => {
       );
     });
   });
+
+  describe('remote document', () => {
+    let remoteProps: TakeActionDropdownProps;
+
+    beforeEach(() => {
+      // Timeline read privilege is required so investigateInTimelineActionItems is non-empty,
+      // which allows the dropdown to render for remote documents (only that item is shown).
+      (useUserPrivileges as jest.Mock).mockReturnValue({
+        ...getUserPrivilegesMockDefaultValue(),
+        timelinePrivileges: { read: true },
+      });
+
+      remoteProps = {
+        ...defaultProps,
+        dataAsNestedObject: {
+          ...getDetectionAlertMock(),
+          _index: 'remote-cluster:.alerts-security.alerts-default',
+        },
+        searchHit: {
+          _id: 'test-id',
+          _index: 'remote-cluster:.alerts-security.alerts-default',
+        } as SearchHit,
+      };
+    });
+
+    it('should render only "Investigate in timeline" for a remote alert', async () => {
+      const wrapper = mount(
+        <TestProviders>
+          <TakeActionDropdown {...remoteProps} />
+        </TestProviders>
+      );
+      wrapper
+        .find(`button[data-test-subj="${FLYOUT_FOOTER_DROPDOWN_BUTTON_TEST_ID}"]`)
+        .simulate('click');
+
+      await waitFor(() => {
+        expect(
+          wrapper.find('[data-test-subj="investigate-in-timeline-action-item"]').exists()
+        ).toBeTruthy();
+        expect(wrapper.find('[data-test-subj="add-to-existing-case-action"]').exists()).toBeFalsy();
+        expect(wrapper.find('[data-test-subj="acknowledged-alert-status"]').exists()).toBeFalsy();
+        expect(
+          wrapper.find('[data-test-subj="alert-tags-context-menu-item"]').exists()
+        ).toBeFalsy();
+        expect(
+          wrapper.find('[data-test-subj="alert-assignees-context-menu-item"]').exists()
+        ).toBeFalsy();
+      });
+    });
+
+    it('should render the full menu for a local alert', async () => {
+      const wrapper = mount(
+        <TestProviders>
+          <TakeActionDropdown {...defaultProps} />
+        </TestProviders>
+      );
+      wrapper
+        .find(`button[data-test-subj="${FLYOUT_FOOTER_DROPDOWN_BUTTON_TEST_ID}"]`)
+        .simulate('click');
+
+      await waitFor(() => {
+        expect(
+          wrapper.find('[data-test-subj="investigate-in-timeline-action-item"]').exists()
+        ).toBeTruthy();
+        expect(
+          wrapper.find('[data-test-subj="add-to-existing-case-action"]').exists()
+        ).toBeTruthy();
+        expect(wrapper.find('[data-test-subj="acknowledged-alert-status"]').exists()).toBeTruthy();
+      });
+    });
+  });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/components/take_action_dropdown.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/components/take_action_dropdown.tsx
@@ -12,6 +12,9 @@ import type { EcsSecurityExtension as Ecs } from '@kbn/securitysolution-ecs';
 import type { TimelineEventsDetailsItem } from '@kbn/timelines-plugin/common';
 import { i18n } from '@kbn/i18n';
 import { getOr } from 'lodash/fp';
+import { buildDataTableRecord, getFieldValue } from '@kbn/discover-utils';
+import type { EsHitRecord } from '@kbn/discover-utils';
+import { isCCSRemoteIndexName } from '@kbn/es-query';
 import type { SearchHit } from '../../../../../common/search_strategy';
 import { useRunAlertWorkflowPanel } from '../../../../detections/components/alerts_table/timeline_actions/use_run_alert_workflow_panel';
 import { useRunDocumentWorkflowPanel } from '../../../../detections/components/alerts_table/timeline_actions/use_run_document_workflow_panel';
@@ -163,6 +166,16 @@ export const TakeActionDropdown = memo(
           {} as AlertSummaryData
         ),
       [dataFormattedForFieldBrowser]
+    );
+
+    const hit = useMemo(
+      () => buildDataTableRecord(searchHit as unknown as EsHitRecord),
+      [searchHit]
+    );
+
+    const isRemoteDocument = useMemo(
+      () => isCCSRemoteIndexName(hit.raw._index ?? (getFieldValue(hit, '_index') as string) ?? ''),
+      [hit]
     );
 
     const isEvent = alertSummaryData.eventKind === 'event';
@@ -352,19 +365,23 @@ export const TakeActionDropdown = memo(
 
     // items to render in the dropdown
     const items: AlertTableContextMenuItem[] = useMemo(
-      () => [
-        ...addToCaseActionItems,
-        ...alertsActionItems,
-        ...(isAlert ? alertWorkflowMenuItem : documentWorkflowMenuItem),
-        ...hostIsolationActionItems,
-        ...endpointResponseActionsConsoleItems,
-        ...(osqueryAvailable ? [osqueryActionItem] : []),
-        ...investigateInTimelineActionItems,
-      ],
+      () =>
+        isRemoteDocument
+          ? [...investigateInTimelineActionItems]
+          : [
+              ...addToCaseActionItems,
+              ...alertsActionItems,
+              ...(isAlert ? alertWorkflowMenuItem : documentWorkflowMenuItem),
+              ...hostIsolationActionItems,
+              ...endpointResponseActionsConsoleItems,
+              ...(osqueryAvailable ? [osqueryActionItem] : []),
+              ...investigateInTimelineActionItems,
+            ],
       [
         addToCaseActionItems,
         alertsActionItems,
         isAlert,
+        isRemoteDocument,
         alertWorkflowMenuItem,
         documentWorkflowMenuItem,
         hostIsolationActionItems,
@@ -377,14 +394,11 @@ export const TakeActionDropdown = memo(
 
     // panels rendered in the context menu
     const panels = [
-      {
-        id: 0,
-        items,
-      },
-      ...alertTagsPanels,
-      ...(isAlert ? runAlertWorkflowPanel : runDocumentWorkflowPanel),
-      ...alertAssigneesPanels,
-      ...statusActionPanels,
+      { id: 0, items },
+      ...(!isRemoteDocument ? alertTagsPanels : []),
+      ...(!isRemoteDocument ? (isAlert ? runAlertWorkflowPanel : runDocumentWorkflowPanel) : []),
+      ...(!isRemoteDocument ? alertAssigneesPanels : []),
+      ...(!isRemoteDocument ? statusActionPanels : []),
     ];
 
     const takeActionButton = useMemo(

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/assignees.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/assignees.test.tsx
@@ -82,10 +82,13 @@ const mockUserProfiles = [
   { uid: 'user-id-3', enabled: true, user: { username: 'user3', full_name: 'User 3' }, data: {} },
 ];
 
-const createMockHit = (assignedUserIds: string[] = ['user-id-1']): DataTableRecord => {
+const createMockHit = (
+  assignedUserIds: string[] = ['user-id-1'],
+  raw: DataTableRecord['raw'] = { _id: 'event-1' }
+): DataTableRecord => {
   return {
     id: 'event-1',
-    raw: { _id: 'event-1' },
+    raw,
     flattened: {
       'event.kind': 'signal',
       'kibana.alert.workflow_assignee_ids': assignedUserIds,
@@ -93,6 +96,11 @@ const createMockHit = (assignedUserIds: string[] = ['user-id-1']): DataTableReco
     isAnchor: false,
   } as DataTableRecord;
 };
+
+const remoteAlertHit = createMockHit(['user-id-1'], {
+  _id: 'event-1',
+  _index: 'remote-cluster:.alerts-security.alerts-default',
+});
 
 const renderAssignees = (
   props: Partial<Parameters<typeof Assignees>[0]> = {},
@@ -173,6 +181,12 @@ describe('<Assignees />', () => {
       expect(getByTestId(USER_AVATAR_ITEM_TEST_ID('user3'))).toBeInTheDocument();
     });
     expect(queryByTestId(USER_AVATAR_ITEM_TEST_ID('user1'))).toBeInTheDocument();
+  });
+
+  it('disables the add-assignees button for a remote alert', () => {
+    const { getByTestId } = renderAssignees({ hit: remoteAlertHit });
+
+    expect(getByTestId(ASSIGNEES_ADD_BUTTON_TEST_ID)).toBeDisabled();
   });
 
   it('renders the empty state when assignees are hidden', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/assignees.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/assignees.tsx
@@ -17,6 +17,7 @@ import {
   useGeneratedHtmlId,
 } from '@elastic/eui';
 import { type DataTableRecord, getFieldValue } from '@kbn/discover-utils';
+import { isCCSRemoteIndexName } from '@kbn/es-query';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
 import { ALERT_WORKFLOW_ASSIGNEE_IDS } from '@kbn/rule-data-utils';
@@ -76,6 +77,10 @@ export interface AssigneesProps {
  */
 export const Assignees = memo(({ hit, onAlertUpdated, showAssignees = true }: AssigneesProps) => {
   const eventId = useMemo(() => hit.raw._id ?? '', [hit]);
+  const isRemoteDocument = useMemo(
+    () => isCCSRemoteIndexName(hit.raw._index ?? (getFieldValue(hit, '_index') as string) ?? ''),
+    [hit]
+  );
   const initialAssignedUserIds = useMemo(() => {
     const value = getFieldValue(hit, ALERT_WORKFLOW_ASSIGNEE_IDS) as string[] | string | null;
 
@@ -132,7 +137,10 @@ export const Assignees = memo(({ hit, onAlertUpdated, showAssignees = true }: As
     [eventId, onAlertUpdated, setAlertAssignees]
   );
 
-  const isUpdateDisabled = !eventId || !hasAlertsUpdate || !isPlatinumPlus;
+  const isUpdateDisabled = useMemo(
+    () => !eventId || !hasAlertsUpdate || !isPlatinumPlus || isRemoteDocument,
+    [eventId, hasAlertsUpdate, isPlatinumPlus, isRemoteDocument]
+  );
 
   const updateAssigneesPopover = useMemo(
     () => (

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/investigation_section.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/investigation_section.test.tsx
@@ -75,6 +75,11 @@ const nonSignalMockHit = createMockHit({
   'event.kind': 'event',
 });
 
+const remoteAlertMockHit = createMockHit({
+  'event.kind': 'signal',
+  _index: 'remote-cluster:index-name',
+});
+
 const mockRenderCellActions = jest.fn(({ children }: { children: React.ReactNode }) => (
   <>{children}</>
 ));
@@ -180,6 +185,25 @@ describe('InvestigationSection', () => {
           <Router history={history}>
             <InvestigationSection
               hit={nonSignalMockHit}
+              renderCellActions={mockRenderCellActions}
+            />
+          </Router>
+        </Provider>
+      </IntlProvider>
+    );
+
+    expect(queryByTestId('investigationGuideMock')).not.toBeInTheDocument();
+  });
+
+  it('does not render investigation guide for a remote alert', () => {
+    mockUseExpandSection.mockReturnValue(true);
+
+    const { queryByTestId } = render(
+      <IntlProvider locale="en">
+        <Provider store={store}>
+          <Router history={history}>
+            <InvestigationSection
+              hit={remoteAlertMockHit}
               renderCellActions={mockRenderCellActions}
             />
           </Router>

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/investigation_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/investigation_section.tsx
@@ -9,6 +9,7 @@ import React, { memo, useCallback, useMemo } from 'react';
 import { i18n } from '@kbn/i18n';
 import type { DataTableRecord } from '@kbn/discover-utils';
 import { getFieldValue } from '@kbn/discover-utils';
+import { isCCSRemoteIndexName } from '@kbn/es-query';
 import { EVENT_KIND } from '@kbn/rule-data-utils';
 import { useHistory } from 'react-router-dom';
 import { useStore } from 'react-redux';
@@ -69,6 +70,10 @@ export const InvestigationSection = memo(
       () => (getFieldValue(hit, EVENT_KIND) as string) === EventKind.signal,
       [hit]
     );
+    const isRemoteDocument = useMemo(
+      () => isCCSRemoteIndexName(hit.raw._index ?? (getFieldValue(hit, '_index') as string) ?? ''),
+      [hit]
+    );
     const ruleId = useMemo(
       () =>
         (getFieldValue(hit, EVENT_KIND) as string) === EventKind.signal
@@ -117,7 +122,7 @@ export const InvestigationSection = memo(
         sectionId={LOCAL_STORAGE_SECTION_KEY}
         title={INVESTIGATION_SECTION_TITLE}
       >
-        {isAlert ? (
+        {isAlert && !isRemoteDocument ? (
           <InvestigationGuide
             hit={hit}
             isAvailable={true}
@@ -129,6 +134,7 @@ export const InvestigationSection = memo(
           investigationFields={investigationFields}
           ancestorsIndexName={ancestorsIndexName}
           renderCellActions={renderCellActions}
+          hideEditButton={isRemoteDocument}
         />
       </ExpandableSection>
     );

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/status.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/status.test.tsx
@@ -17,25 +17,31 @@ jest.mock('./status_popover_button', () => ({
     eventId,
     contextId,
     onStatusUpdated,
+    disabled,
   }: {
     eventId: string;
     contextId: string;
     onStatusUpdated?: () => void;
+    disabled?: boolean;
   }) => (
     <button
       data-test-subj="mockStatusPopoverButton"
       data-event-id={eventId}
       data-context-id={contextId}
+      data-disabled={String(disabled ?? false)}
       onClick={onStatusUpdated}
       type="button"
     />
   ),
 }));
 
-const createMockHit = (flattened: DataTableRecord['flattened']): DataTableRecord =>
+const createMockHit = (
+  flattened: DataTableRecord['flattened'],
+  raw: DataTableRecord['raw'] = { _id: 'es-alert-1' }
+): DataTableRecord =>
   ({
     id: 'alert-1',
-    raw: { _id: 'es-alert-1' },
+    raw,
     flattened,
     isAnchor: false,
   } as DataTableRecord);
@@ -43,6 +49,11 @@ const createMockHit = (flattened: DataTableRecord['flattened']): DataTableRecord
 const alertHit = createMockHit({
   'kibana.alert.workflow_status': 'open',
 });
+
+const remoteAlertHit = createMockHit(
+  { 'kibana.alert.workflow_status': 'open' },
+  { _id: 'es-alert-1', _index: 'remote-cluster:.alerts-security.alerts-default' }
+);
 
 const renderComponent = (props: Partial<Parameters<typeof Status>[0]> = {}) =>
   render(
@@ -99,5 +110,17 @@ describe('<Status />', () => {
 
     expect(queryByTestId('mockStatusPopoverButton')).not.toBeInTheDocument();
     expect(container).toHaveTextContent('Status—');
+  });
+
+  it('passes disabled=false to the status button for a local alert', () => {
+    const { getByTestId } = renderComponent({ hit: alertHit });
+
+    expect(getByTestId('mockStatusPopoverButton')).toHaveAttribute('data-disabled', 'false');
+  });
+
+  it('passes disabled=true to the status button for a remote alert', () => {
+    const { getByTestId } = renderComponent({ hit: remoteAlertHit });
+
+    expect(getByTestId('mockStatusPopoverButton')).toHaveAttribute('data-disabled', 'true');
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/status.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/status.tsx
@@ -8,6 +8,7 @@
 import React, { memo, useMemo } from 'react';
 import type { DataTableRecord } from '@kbn/discover-utils';
 import { getFieldValue } from '@kbn/discover-utils';
+import { isCCSRemoteIndexName } from '@kbn/es-query';
 import { ALERT_WORKFLOW_STATUS } from '@kbn/rule-data-utils';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { AlertHeaderBlock } from '../../shared/components/alert_header_block';
@@ -48,6 +49,10 @@ interface StatusProps {
 export const Status = memo(
   ({ hit, renderCellActions = noopCellActionRenderer, onAlertUpdated }: StatusProps) => {
     const eventId = hit.raw._id as string;
+    const isRemoteDocument = useMemo(
+      () => isCCSRemoteIndexName(hit.raw._index ?? (getFieldValue(hit, '_index') as string) ?? ''),
+      [hit]
+    );
     const statusFieldInfo = useMemo<StatusPopoverButtonFieldInfo | null>(() => {
       const workflowStatus = getFieldValue(hit, ALERT_WORKFLOW_STATUS);
       const statusValue = Array.isArray(workflowStatus)
@@ -88,6 +93,7 @@ export const Status = memo(
                   enrichedFieldInfo={statusFieldInfo}
                   scopeId=""
                   onStatusUpdated={onAlertUpdated}
+                  disabled={isRemoteDocument}
                 />
               ),
             })}

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/status_popover_button.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/status_popover_button.test.tsx
@@ -48,6 +48,7 @@ const props = {
   },
   scopeId: 'alerts-page',
   handleOnEventClosed: jest.fn(),
+  disabled: false,
 };
 
 type AlertsPriveleges = Partial<ReturnType<typeof useAlertsPrivileges>>;
@@ -89,6 +90,19 @@ describe('StatusPopoverButton', () => {
     expect(container.querySelector('.euiBadge__icon')).not.toBeNull();
     getByText('Mark as acknowledged');
     getByText('Mark as closed');
+  });
+
+  test('does not open the popover when disabled, even with write privileges', () => {
+    (useAlertsPrivileges as jest.Mock<AlertsPriveleges>).mockReturnValue(writePriveleges);
+    const { getByText, queryByRole } = render(
+      <TestProviders>
+        <StatusPopoverButton {...props} disabled={true} />
+      </TestProviders>
+    );
+
+    getByText('open').click();
+
+    expect(queryByRole('dialog')).not.toBeInTheDocument();
   });
 
   test('Status should be text when user does not have write priveleges', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/status_popover_button.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/status_popover_button.tsx
@@ -47,6 +47,11 @@ interface StatusPopoverButtonProps {
    * Optional callback to refresh the hosting flyout after a status mutation.
    */
   onStatusUpdated?: () => void;
+  /**
+   * When true, suppresses the status-change popover regardless of user permissions.
+   * Use this when status mutations are not possible (e.g. remote/CCS documents).
+   */
+  disabled: boolean;
 }
 
 const getFieldFormat = (field?: { format?: string | SerializedFieldFormat }) =>
@@ -63,6 +68,7 @@ export const StatusPopoverButton = memo(
     enrichedFieldInfo,
     scopeId,
     onStatusUpdated,
+    disabled,
   }: StatusPopoverButtonProps) => {
     const popoverTitleId = useGeneratedHtmlId();
 
@@ -83,9 +89,13 @@ export const StatusPopoverButton = memo(
       [actionItems, actionItemsPanels]
     );
 
-    // statusPopoverVisible includes the logic for the visibility of the popover in
-    // case actionItems is an empty array ( ex, when user has read access ).
-    const statusPopoverVisible = useMemo(() => actionItems.length > 0, [actionItems]);
+    // statusPopoverVisible controls popover availability: requires both write-capable
+    // action items (i.e. user has update permissions) and the component not being disabled
+    // (e.g. remote/CCS documents where status mutations are not possible).
+    const statusPopoverVisible = useMemo(
+      () => actionItems.length > 0 && !disabled,
+      [actionItems, disabled]
+    );
 
     const button = useMemo(
       () => (

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/take_action_button.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/take_action_button.test.tsx
@@ -67,13 +67,25 @@ const mockUseAlertsActions = useAlertsActions as jest.Mock;
 const mockUseAlertAssigneesActions = useAlertAssigneesActions as jest.Mock;
 const mockUseAlertTagsActions = useAlertTagsActions as jest.Mock;
 
-const createMockHit = (flattened: Record<string, unknown> = {}): DataTableRecord =>
+const createMockHit = (
+  flattened: Record<string, unknown> = {},
+  index: string = 'test-index'
+): DataTableRecord =>
   ({
     id: 'test-id',
-    raw: { _id: 'test-id', _index: 'test-index' },
+    raw: { _id: 'test-id', _index: index },
     flattened,
     isAnchor: false,
   } as DataTableRecord);
+
+const remoteAlertHit = createMockHit(
+  { 'event.kind': 'signal' },
+  'remote-cluster:.alerts-security.alerts-default'
+);
+const remoteEventHit = createMockHit(
+  { 'event.kind': 'event' },
+  'remote-cluster:.alerts-security.alerts-default'
+);
 const mockUseInvestigateInTimeline = useInvestigateInTimeline as jest.Mock;
 const mockUseIsInSecurityApp = useIsInSecurityApp as jest.Mock;
 const mockEcsData: Ecs = { _id: 'test-id', _index: 'test-index' };
@@ -375,6 +387,98 @@ describe('<TakeActionButton />', () => {
       expect(queryByText('Apply alert tags')).not.toBeInTheDocument();
       expect(getByText('Add note')).toBeInTheDocument();
       expect(queryByText('Run workflow')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('remote document', () => {
+    const timelineItem = { name: 'Investigate in timeline', onClick: jest.fn() };
+    const caseItem = { name: 'Add to case', onClick: jest.fn() };
+    const statusItem = { name: 'Mark as acknowledged', onClick: jest.fn() };
+    const assigneeItem = { name: 'Assign alert', onClick: jest.fn() };
+    const tagsItem = { name: 'Apply alert tags', onClick: jest.fn() };
+    const workflowItem = { name: 'Run workflow', onClick: jest.fn() };
+
+    beforeEach(() => {
+      mockUseAddToCaseActions.mockReturnValue({ addToCaseActionItems: [caseItem] });
+      mockUseAlertsActions.mockReturnValue({ actionItems: [statusItem], panels: [] });
+      mockUseAlertAssigneesActions.mockReturnValue({
+        alertAssigneesItems: [assigneeItem],
+        alertAssigneesPanels: [],
+      });
+      mockUseAlertTagsActions.mockReturnValue({
+        alertTagsItems: [tagsItem],
+        alertTagsPanels: [],
+      });
+      mockUseInvestigateInTimeline.mockReturnValue({
+        investigateInTimelineActionItems: [timelineItem],
+      });
+      mockUseRunAlertWorkflowPanel.mockReturnValue({
+        runWorkflowMenuItem: [workflowItem],
+        runAlertWorkflowPanel: [],
+      });
+      mockUseIsInSecurityApp.mockReturnValue(true);
+    });
+
+    it('should show only Investigate in Timeline for a remote alert', () => {
+      const { getByTestId, getByText, queryByText } = renderTakeActionButton({
+        ...defaultProps,
+        hit: remoteAlertHit,
+      });
+
+      fireEvent.click(getByTestId(FLYOUT_FOOTER_DROPDOWN_BUTTON_TEST_ID));
+
+      expect(getByText('Investigate in timeline')).toBeInTheDocument();
+      expect(queryByText('Add to case')).not.toBeInTheDocument();
+      expect(queryByText('Mark as acknowledged')).not.toBeInTheDocument();
+      expect(queryByText('Assign alert')).not.toBeInTheDocument();
+      expect(queryByText('Apply alert tags')).not.toBeInTheDocument();
+      expect(queryByText('Run workflow')).not.toBeInTheDocument();
+      expect(queryByText('Add note')).not.toBeInTheDocument();
+    });
+
+    it('should show only Investigate in Timeline for a remote event', () => {
+      const { getByTestId, getByText, queryByText } = renderTakeActionButton({
+        ...defaultProps,
+        hit: remoteEventHit,
+      });
+
+      fireEvent.click(getByTestId(FLYOUT_FOOTER_DROPDOWN_BUTTON_TEST_ID));
+
+      expect(getByText('Investigate in timeline')).toBeInTheDocument();
+      expect(queryByText('Add to case')).not.toBeInTheDocument();
+      expect(queryByText('Add note')).not.toBeInTheDocument();
+      expect(queryByText('Run workflow')).not.toBeInTheDocument();
+    });
+
+    it('should show no items for a remote document when not in Security app', () => {
+      mockUseIsInSecurityApp.mockReturnValue(false);
+      const { getByTestId, queryByText } = renderTakeActionButton({
+        ...defaultProps,
+        hit: remoteAlertHit,
+      });
+
+      fireEvent.click(getByTestId(FLYOUT_FOOTER_DROPDOWN_BUTTON_TEST_ID));
+
+      expect(queryByText('Investigate in timeline')).not.toBeInTheDocument();
+      expect(queryByText('Explore in Alerts')).not.toBeInTheDocument();
+    });
+
+    it('should show the full menu for a local alert (regression guard)', () => {
+      const localAlertHit = createMockHit({ 'event.kind': 'signal' });
+      const { getByTestId, getByText, queryByText } = renderTakeActionButton({
+        ...defaultProps,
+        hit: localAlertHit,
+      });
+
+      fireEvent.click(getByTestId(FLYOUT_FOOTER_DROPDOWN_BUTTON_TEST_ID));
+
+      expect(getByText('Add to case')).toBeInTheDocument();
+      expect(getByText('Mark as acknowledged')).toBeInTheDocument();
+      expect(getByText('Assign alert')).toBeInTheDocument();
+      expect(getByText('Apply alert tags')).toBeInTheDocument();
+      expect(getByText('Run workflow')).toBeInTheDocument();
+      expect(getByText('Investigate in timeline')).toBeInTheDocument();
+      expect(queryByText('Add note')).not.toBeInTheDocument();
     });
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/take_action_button.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/take_action_button.tsx
@@ -17,6 +17,7 @@ import {
 import { i18n } from '@kbn/i18n';
 import type { DataTableRecord } from '@kbn/discover-utils';
 import { getFieldValue } from '@kbn/discover-utils';
+import { isCCSRemoteIndexName } from '@kbn/es-query';
 import { ALERT_WORKFLOW_STATUS, EVENT_KIND } from '@kbn/rule-data-utils';
 import type { EcsSecurityExtension as Ecs } from '@kbn/securitysolution-ecs';
 import { EventKind } from '../constants/event_kinds';
@@ -105,6 +106,10 @@ export const TakeActionButton = memo(
     const isInSecurityApp = useIsInSecurityApp();
 
     const documentId = hit.raw._id as string;
+    const isRemoteDocument = useMemo(
+      () => isCCSRemoteIndexName(hit.raw._index ?? (getFieldValue(hit, '_index') as string) ?? ''),
+      [hit]
+    );
     const isAlert = useMemo(
       () => (getFieldValue(hit, EVENT_KIND) as string) === EventKind.signal,
       [hit]
@@ -210,16 +215,19 @@ export const TakeActionButton = memo(
     }, [closePopoverHandler, hit, isAlert, services.application]);
 
     const items = useMemo(
-      () => [
-        ...addToCaseActionItems,
-        ...(isAlert ? statusActionItems : []),
-        ...(isAlert ? alertTagsItems : []),
-        ...(isAlert ? alertAssigneesItems : []),
-        ...(isAlert ? runWorkflowMenuItem : documentWorkflowMenuItem),
-        ...(isAlert ? [] : noteItems),
-        ...(isInSecurityApp ? investigateInTimelineActionItems : []),
-        ...(!isInSecurityApp ? exploreActionItems : []),
-      ],
+      () =>
+        isRemoteDocument
+          ? [...(isInSecurityApp ? investigateInTimelineActionItems : [])]
+          : [
+              ...addToCaseActionItems,
+              ...(isAlert ? statusActionItems : []),
+              ...(isAlert ? alertTagsItems : []),
+              ...(isAlert ? alertAssigneesItems : []),
+              ...(isAlert ? runWorkflowMenuItem : documentWorkflowMenuItem),
+              ...(isAlert ? [] : noteItems),
+              ...(isInSecurityApp ? investigateInTimelineActionItems : []),
+              ...(!isInSecurityApp ? exploreActionItems : []),
+            ],
       [
         addToCaseActionItems,
         alertAssigneesItems,
@@ -229,6 +237,7 @@ export const TakeActionButton = memo(
         investigateInTimelineActionItems,
         isAlert,
         isInSecurityApp,
+        isRemoteDocument,
         noteItems,
         runWorkflowMenuItem,
         statusActionItems,
@@ -238,15 +247,16 @@ export const TakeActionButton = memo(
     const panels = useMemo(
       () => [
         { id: 0, items },
-        ...(isAlert ? statusActionPanels : []),
-        ...(isAlert ? alertAssigneesPanels : []),
-        ...(isAlert ? alertTagsPanels : []),
-        ...(isAlert ? runAlertWorkflowPanel : runDocumentWorkflowPanel),
+        ...(!isRemoteDocument && isAlert ? statusActionPanels : []),
+        ...(!isRemoteDocument && isAlert ? alertAssigneesPanels : []),
+        ...(!isRemoteDocument && isAlert ? alertTagsPanels : []),
+        ...(!isRemoteDocument ? (isAlert ? runAlertWorkflowPanel : runDocumentWorkflowPanel) : []),
       ],
       [
         alertAssigneesPanels,
         alertTagsPanels,
         isAlert,
+        isRemoteDocument,
         items,
         runAlertWorkflowPanel,
         runDocumentWorkflowPanel,

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/title.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/title.test.tsx
@@ -83,6 +83,17 @@ const externalAlertHit = createMockHit({
   'event.kind': 'alert',
 });
 
+const remoteAlertHit: DataTableRecord = {
+  id: '1',
+  raw: { _index: 'remote-cluster:.alerts-security.alerts-default' },
+  flattened: {
+    'event.kind': 'signal',
+    'kibana.alert.rule.name': 'Test Rule Name',
+    'kibana.alert.rule.uuid': 'rule-uuid-123',
+  },
+  isAnchor: false,
+} as DataTableRecord;
+
 const renderTitle = (props: Parameters<typeof Title>[0]) =>
   render(
     <IntlProvider locale="en">
@@ -141,6 +152,13 @@ describe('<Title />', () => {
 
   it('should render as plain text when the alert has no rule id', () => {
     const { queryByTestId, getByTestId } = renderTitle({ hit: alertHitWithoutRuleId });
+
+    expect(queryByTestId(TITLE_LINK_TEST_ID)).not.toBeInTheDocument();
+    expect(getByTestId(TITLE_TEST_ID)).toHaveAttribute('data-is-link', 'false');
+  });
+
+  it('should render as plain text for a remote alert even when a rule id is present', () => {
+    const { queryByTestId, getByTestId } = renderTitle({ hit: remoteAlertHit });
 
     expect(queryByTestId(TITLE_LINK_TEST_ID)).not.toBeInTheDocument();
     expect(getByTestId(TITLE_TEST_ID)).toHaveAttribute('data-is-link', 'false');

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/title.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/title.tsx
@@ -10,6 +10,7 @@ import React, { memo, useMemo } from 'react';
 import { EuiLink } from '@elastic/eui';
 import type { DataTableRecord } from '@kbn/discover-utils';
 import { getFieldValue } from '@kbn/discover-utils';
+import { isCCSRemoteIndexName } from '@kbn/es-query';
 import { ALERT_RULE_UUID, EVENT_KIND } from '@kbn/rule-data-utils';
 import { SecurityPageName } from '@kbn/deeplinks-security';
 import { EventKind } from '../constants/event_kinds';
@@ -46,19 +47,24 @@ export const Title: FC<TitleProps> = memo(({ hit, hideLink = false }) => {
   const title = useMemo(() => getDocumentTitle(hit), [hit]);
   const iconType = isAlert ? 'warning' : 'analyzeEvent';
 
+  const isRemoteDocument = useMemo(
+    () => isCCSRemoteIndexName(hit.raw._index ?? (getFieldValue(hit, '_index') as string) ?? ''),
+    [hit]
+  );
+
   const ruleId = useMemo(
     () => (getFieldValue(hit, ALERT_RULE_UUID) as string | null) ?? null,
     [hit]
   );
 
   const titleHref = useMemo(() => {
-    if (hideLink || !ruleId) return undefined;
+    if (hideLink || isRemoteDocument || !ruleId) return undefined;
     const path = getRuleDetailsUrl(ruleId);
     return services.application.getUrlForApp('securitySolutionUI', {
       deepLinkId: SecurityPageName.rules,
       path,
     });
-  }, [hideLink, ruleId, services.application]);
+  }, [hideLink, isRemoteDocument, ruleId, services.application]);
 
   if (titleHref) {
     return (

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/notes/components/notes_remote_callout.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/notes/components/notes_remote_callout.test.tsx
@@ -1,0 +1,176 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
+import { render } from '@testing-library/react';
+import type { DataTableRecord } from '@kbn/discover-utils';
+import {
+  ATTACK_DISCOVERY_AD_HOC_RULE_TYPE_ID,
+  ATTACK_DISCOVERY_SCHEDULES_ALERT_TYPE_ID,
+} from '@kbn/elastic-assistant-common';
+import { ALERT_RULE_TYPE_ID } from '@kbn/rule-data-utils';
+import {
+  LINKED_PROJECT_ATTACK_NOTES_MESSAGE,
+  LINKED_PROJECT_EVENT_NOTES_MESSAGE,
+  LINKED_PROJECT_NOTES_MESSAGE,
+  NotesRemoteCallout,
+  REMOTE_CLUSTER_ATTACK_NOTES_MESSAGE,
+  REMOTE_CLUSTER_EVENT_NOTES_MESSAGE,
+  REMOTE_CLUSTER_NOTES_MESSAGE,
+} from './notes_remote_callout';
+
+let mockCloud: unknown;
+jest.mock('../../../common/lib/kibana', () => ({
+  useKibana: () => ({
+    services: {
+      cloud: mockCloud,
+    },
+  }),
+}));
+
+const makeHit = (index: string, flattened: DataTableRecord['flattened'] = {}): DataTableRecord =>
+  ({
+    id: '1',
+    raw: { _index: index },
+    flattened: { _index: index, ...flattened },
+    isAnchor: false,
+  } as DataTableRecord);
+
+const renderCallout = (hit: DataTableRecord) =>
+  render(
+    <IntlProvider locale="en">
+      <NotesRemoteCallout hit={hit} />
+    </IntlProvider>
+  );
+
+describe('<NotesRemoteCallout />', () => {
+  beforeEach(() => {
+    mockCloud = undefined;
+  });
+
+  it('renders nothing for a local document', () => {
+    const { container } = renderCallout(
+      makeHit('.alerts-security.alerts-default', { 'event.kind': 'signal' })
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('does not render children for a local document', () => {
+    const { queryByText } = render(
+      <IntlProvider locale="en">
+        <NotesRemoteCallout hit={makeHit('.alerts-security.alerts-default')}>
+          <span>{'child content'}</span>
+        </NotesRemoteCallout>
+      </IntlProvider>
+    );
+
+    expect(queryByText('child content')).not.toBeInTheDocument();
+  });
+
+  it('renders children after the callout for a remote document', () => {
+    const { getByText } = render(
+      <IntlProvider locale="en">
+        <NotesRemoteCallout
+          hit={makeHit('remote-cluster:.alerts-security.alerts-default', {
+            'event.kind': 'signal',
+          })}
+        >
+          <span>{'child content'}</span>
+        </NotesRemoteCallout>
+      </IntlProvider>
+    );
+
+    expect(getByText(REMOTE_CLUSTER_NOTES_MESSAGE)).toBeInTheDocument();
+    expect(getByText('child content')).toBeInTheDocument();
+  });
+
+  describe('CCS (on-prem remote cluster)', () => {
+    it('renders the alert message for a remote alert', () => {
+      const { getByText } = renderCallout(
+        makeHit('remote-cluster:.alerts-security.alerts-default', { 'event.kind': 'signal' })
+      );
+
+      expect(getByText(REMOTE_CLUSTER_NOTES_MESSAGE)).toBeInTheDocument();
+    });
+
+    it('renders the event message for a remote event', () => {
+      const { getByText } = renderCallout(
+        makeHit('remote-cluster:logs-system-default', { 'event.kind': 'event' })
+      );
+
+      expect(getByText(REMOTE_CLUSTER_EVENT_NOTES_MESSAGE)).toBeInTheDocument();
+    });
+
+    it('renders the attack message for a remote scheduled attack discovery alert', () => {
+      const { getByText } = renderCallout(
+        makeHit('remote-cluster:.alerts-security.alerts-default', {
+          'event.kind': 'signal',
+          [ALERT_RULE_TYPE_ID]: ATTACK_DISCOVERY_SCHEDULES_ALERT_TYPE_ID,
+        })
+      );
+
+      expect(getByText(REMOTE_CLUSTER_ATTACK_NOTES_MESSAGE)).toBeInTheDocument();
+    });
+
+    it('renders the attack message for a remote ad-hoc attack discovery alert', () => {
+      const { getByText } = renderCallout(
+        makeHit('remote-cluster:.alerts-security.alerts-default', {
+          'event.kind': 'signal',
+          [ALERT_RULE_TYPE_ID]: ATTACK_DISCOVERY_AD_HOC_RULE_TYPE_ID,
+        })
+      );
+
+      expect(getByText(REMOTE_CLUSTER_ATTACK_NOTES_MESSAGE)).toBeInTheDocument();
+    });
+  });
+
+  describe('CPS (serverless linked project)', () => {
+    beforeEach(() => {
+      mockCloud = { isServerlessEnabled: true };
+    });
+
+    it('renders the alert message for a remote alert', () => {
+      const { getByText } = renderCallout(
+        makeHit('remote-cluster:.alerts-security.alerts-default', { 'event.kind': 'signal' })
+      );
+
+      expect(getByText(LINKED_PROJECT_NOTES_MESSAGE)).toBeInTheDocument();
+    });
+
+    it('renders the event message for a remote event', () => {
+      const { getByText } = renderCallout(
+        makeHit('remote-cluster:logs-system-default', { 'event.kind': 'event' })
+      );
+
+      expect(getByText(LINKED_PROJECT_EVENT_NOTES_MESSAGE)).toBeInTheDocument();
+    });
+
+    it('renders the attack message for a remote scheduled attack discovery alert', () => {
+      const { getByText } = renderCallout(
+        makeHit('remote-cluster:.alerts-security.alerts-default', {
+          'event.kind': 'signal',
+          [ALERT_RULE_TYPE_ID]: ATTACK_DISCOVERY_SCHEDULES_ALERT_TYPE_ID,
+        })
+      );
+
+      expect(getByText(LINKED_PROJECT_ATTACK_NOTES_MESSAGE)).toBeInTheDocument();
+    });
+
+    it('renders the attack message for a remote ad-hoc attack discovery alert', () => {
+      const { getByText } = renderCallout(
+        makeHit('remote-cluster:.alerts-security.alerts-default', {
+          'event.kind': 'signal',
+          [ALERT_RULE_TYPE_ID]: ATTACK_DISCOVERY_AD_HOC_RULE_TYPE_ID,
+        })
+      );
+
+      expect(getByText(LINKED_PROJECT_ATTACK_NOTES_MESSAGE)).toBeInTheDocument();
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/notes/components/notes_remote_callout.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/notes/components/notes_remote_callout.tsx
@@ -1,0 +1,135 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FC, ReactNode } from 'react';
+import React, { useMemo } from 'react';
+import { EuiCallOut } from '@elastic/eui';
+import type { DataTableRecord } from '@kbn/discover-utils';
+import { getFieldValue } from '@kbn/discover-utils';
+import { isCCSRemoteIndexName } from '@kbn/es-query';
+import { i18n } from '@kbn/i18n';
+import { ALERT_RULE_TYPE_ID, EVENT_KIND } from '@kbn/rule-data-utils';
+import {
+  ATTACK_DISCOVERY_AD_HOC_RULE_TYPE_ID,
+  ATTACK_DISCOVERY_SCHEDULES_ALERT_TYPE_ID,
+} from '@kbn/elastic-assistant-common';
+import { useKibana } from '../../../common/lib/kibana';
+import { EventKind } from '../../document/constants/event_kinds';
+
+const ATTACK_DISCOVERY_RULE_TYPES = new Set<string>([
+  ATTACK_DISCOVERY_SCHEDULES_ALERT_TYPE_ID,
+  ATTACK_DISCOVERY_AD_HOC_RULE_TYPE_ID,
+]);
+
+export const REMOTE_CLUSTER_NOTES_MESSAGE = i18n.translate(
+  'xpack.securitySolution.flyout.notes.remoteClusterNotesMessage',
+  {
+    defaultMessage:
+      'Notes for this alert are only available in the local cluster. You can view and add notes locally only.',
+  }
+);
+
+export const LINKED_PROJECT_NOTES_MESSAGE = i18n.translate(
+  'xpack.securitySolution.flyout.notes.linkedProjectNotesMessage',
+  {
+    defaultMessage:
+      'Notes for this alert are only available in this project. You can view and add notes locally only.',
+  }
+);
+
+export const REMOTE_CLUSTER_EVENT_NOTES_MESSAGE = i18n.translate(
+  'xpack.securitySolution.flyout.notes.remoteClusterEventNotesMessage',
+  {
+    defaultMessage:
+      'Notes for this event are only available in the local cluster. You can view and add notes locally only.',
+  }
+);
+
+export const LINKED_PROJECT_EVENT_NOTES_MESSAGE = i18n.translate(
+  'xpack.securitySolution.flyout.notes.linkedProjectEventNotesMessage',
+  {
+    defaultMessage:
+      'Notes for this event are only available in this project. You can view and add notes locally only.',
+  }
+);
+
+export const REMOTE_CLUSTER_ATTACK_NOTES_MESSAGE = i18n.translate(
+  'xpack.securitySolution.flyout.notes.remoteClusterAttackNotesMessage',
+  {
+    defaultMessage:
+      'Notes for this attack are only available in the local cluster. You can view and add notes locally only.',
+  }
+);
+
+export const LINKED_PROJECT_ATTACK_NOTES_MESSAGE = i18n.translate(
+  'xpack.securitySolution.flyout.notes.linkedProjectAttackNotesMessage',
+  {
+    defaultMessage:
+      'Notes for this attack are only available in this project. You can view and add notes locally only.',
+  }
+);
+
+export interface NotesRemoteCalloutProps {
+  /**
+   * The document record used to determine whether it originates from a remote cluster/project
+   * and whether it is an alert or an event.
+   */
+  hit: DataTableRecord;
+  /**
+   * Optional content rendered after the callout, only when the callout is shown.
+   * Use this to inject a spacer when the callout is rendered inside a padded body area.
+   */
+  children?: ReactNode;
+}
+
+/**
+ * Renders an informational callout when the document originates from a remote (CCS/CPS) index,
+ * otherwise null. Shows alert- or event-specific wording, and adapts to serverless (CPS) vs
+ * on-prem (CCS) deployments.
+ */
+export const NotesRemoteCallout: FC<NotesRemoteCalloutProps> = ({ children, hit }) => {
+  const { services } = useKibana();
+  const isServerless = services.cloud?.isServerlessEnabled ?? false;
+  const index = useMemo(
+    () => hit.raw._index ?? (getFieldValue(hit, '_index') as string) ?? '',
+    [hit]
+  );
+  const isAlert = useMemo(
+    () => (getFieldValue(hit, EVENT_KIND) as string) === EventKind.signal,
+    [hit]
+  );
+  const isAttack = useMemo(
+    () =>
+      isAlert && ATTACK_DISCOVERY_RULE_TYPES.has(getFieldValue(hit, ALERT_RULE_TYPE_ID) as string),
+    [hit, isAlert]
+  );
+
+  if (!isCCSRemoteIndexName(index)) {
+    return null;
+  }
+
+  const message = isServerless
+    ? isAttack
+      ? LINKED_PROJECT_ATTACK_NOTES_MESSAGE
+      : isAlert
+      ? LINKED_PROJECT_NOTES_MESSAGE
+      : LINKED_PROJECT_EVENT_NOTES_MESSAGE
+    : isAttack
+    ? REMOTE_CLUSTER_ATTACK_NOTES_MESSAGE
+    : isAlert
+    ? REMOTE_CLUSTER_NOTES_MESSAGE
+    : REMOTE_CLUSTER_EVENT_NOTES_MESSAGE;
+
+  return (
+    <>
+      <EuiCallOut announceOnMount size="s" title={message} />
+      {children}
+    </>
+  );
+};
+
+NotesRemoteCallout.displayName = 'NotesRemoteCallout';

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/notes/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/notes/index.test.tsx
@@ -24,6 +24,10 @@ import { ReqStatus } from '../../notes';
 import { useTimelineConfig } from './hooks/use_timeline_config';
 import { useIsInSecurityApp } from '../../common/hooks/is_in_security_app';
 
+jest.mock('./components/notes_remote_callout', () => ({
+  NotesRemoteCallout: () => null,
+}));
+
 jest.mock('./hooks/use_timeline_config');
 jest.mock('../../common/hooks/is_in_security_app');
 const useIsInSecurityAppMock = useIsInSecurityApp as jest.Mock;

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/notes/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/notes/index.tsx
@@ -22,9 +22,16 @@ import {
   NO_NOTES,
   NotesDetailsContent,
 } from './components/notes_details_content';
+import { NotesRemoteCallout } from './components/notes_remote_callout';
 import { NOTES_DETAILS_TEST_ID } from './test_ids';
 
 export { FETCH_NOTES_ERROR, NO_NOTES };
+export {
+  LINKED_PROJECT_EVENT_NOTES_MESSAGE,
+  LINKED_PROJECT_NOTES_MESSAGE,
+  REMOTE_CLUSTER_EVENT_NOTES_MESSAGE,
+  REMOTE_CLUSTER_NOTES_MESSAGE,
+} from './components/notes_remote_callout';
 
 const TITLE = i18n.translate('xpack.securitySolution.flyout.notes.title', {
   defaultMessage: 'Notes',
@@ -54,6 +61,7 @@ export const NotesDetails = memo(({ hit }: NotesDetailsProps) => {
 
   return (
     <>
+      <NotesRemoteCallout hit={hit} />
       <EuiFlyoutHeader
         hasBorder
         css={css`


### PR DESCRIPTION
> [!NOTE]
> I had intended to do way more changes than just the header callout and badge, but the amount of changes were too big, so I'm splitting CPS flyout support into 3 main PRs

## Summary

This PR disables and hides a bunch of pieces of the alerts, events and attacks flyouts for remote documents.

> [!TIP]
> The changes should only impact remote documents (in Serverless with CPS enabled). No changes to local documents (in Serverless and ECH).

### Code changes

In Security Solution for remote attacks:
- hide all actions except `Investigate in Timeline` from the flyout footer
- disable assignees and status changes in the flyout header

In Security Solution for remote alerts in new and old flyouts:
- disable title link
- disable assignees and status changes in the flyout header
- hide all actions except `Investigate in Timeline` from the flyout footer
- hide Investigation guide overview and tab
- hide Response section and tab

In Security Solution for remote events in new and old flyouts:
- hide all actions except `Investigate in Timeline` from the flyout footer

> [!WARNING]
> The changes in Discover aren't visible yet. We don't want to enable the enhance profile until all CPS-related flyout changes are in place. To test them, you can replace `(isAlert && !isRemoteDocument) || isEvent` with `isAlert || isEvent` [here](https://github.com/elastic/kibana/blob/main/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/security_profile_providers.tsx#L45)

### UI changes

### Alerts

For old flyout

| Local | remote |
| ------------- | ------------- |
| <img width="1538" height="1395" alt="Screenshot 2026-04-16 at 8 36 42 PM" src="https://github.com/user-attachments/assets/4df56eeb-c860-4db1-b944-354611a275f8" /> | <img width="1541" height="1397" alt="Screenshot 2026-04-16 at 8 36 57 PM" src="https://github.com/user-attachments/assets/42cbf7e3-9190-4e29-a188-2fd1905f2766" /> |

For new flyout

| Local | remote |
| ------------- | ------------- |
| <img width="429" height="1396" alt="Screenshot 2026-04-16 at 8 36 00 PM" src="https://github.com/user-attachments/assets/ec73dcda-5ef0-406a-b08c-cba7159162b3" /> | <img width="433" height="1397" alt="Screenshot 2026-04-16 at 8 36 16 PM" src="https://github.com/user-attachments/assets/2ca88af3-a727-4d8c-923c-28f47b5cdf53" /> |

### Events

For old flyout

| Local | remote |
| ------------- | ------------- |
| <img width="1318" height="1396" alt="Screenshot 2026-04-16 at 8 37 56 PM" src="https://github.com/user-attachments/assets/6d140e74-de7e-461c-a494-b69da2a15d37" /> | <img width="1319" height="1396" alt="Screenshot 2026-04-16 at 8 38 08 PM" src="https://github.com/user-attachments/assets/0f9c2bb0-c763-4414-ba5d-ed7516250654" /> |

For new flyout

| Local | remote |
| ------------- | ------------- |
| <img width="385" height="1392" alt="Screenshot 2026-04-16 at 8 37 31 PM" src="https://github.com/user-attachments/assets/0fdf358f-3d39-481a-a97e-d1f0d88bf71a" /> | <img width="387" height="1395" alt="Screenshot 2026-04-16 at 8 37 43 PM" src="https://github.com/user-attachments/assets/fcbe316a-9e65-43d7-a787-fdceeb2b19ff" /> |

### Attack

For old flyout

| Local | remote |
| ------------- | ------------- |
| <img width="1317" height="1393" alt="Screenshot 2026-04-16 at 9 09 37 PM" src="https://github.com/user-attachments/assets/0494544d-1b48-42d9-bde7-86faff833794" /> | <img width="1317" height="1398" alt="Screenshot 2026-04-16 at 9 30 33 PM" src="https://github.com/user-attachments/assets/02eb519b-ef96-44a9-9360-7ce219e4d57f" /> |

## How to test

Refer to [this guide](https://docs.google.com/document/d/16c6H8EVyyAUwp7QDm-77__RHz_hSJ2_wE40_as7WIqE/edit?pli=1&tab=t.0) for local Serverless CPS setup

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->