### PR TITLE
[8.19] [Security Solution] enable find action to old Security Solution alert flyout (#263875)

### DIFF
--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/json_code_editor/json_code_editor.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/json_code_editor/json_code_editor.tsx
@@ -15,6 +15,7 @@ export interface JsonCodeEditorProps {
   width?: string | number;
   height?: string | number;
   hasLineNumbers?: boolean;
+  enableFindAction?: boolean;
 }
 
 // Required for usage in React.lazy
@@ -24,6 +25,7 @@ export default function JsonCodeEditor({
   width,
   height,
   hasLineNumbers,
+  enableFindAction,
 }: JsonCodeEditorProps) {
   const jsonValue = JSON.stringify(json, null, 2);
 
@@ -35,6 +37,7 @@ export default function JsonCodeEditor({
       hasLineNumbers={hasLineNumbers}
       onEditorDidMount={() => void 0}
       hideCopyButton={true}
+      enableFindAction={enableFindAction}
     />
   );
 }

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/tabs/json_tab.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/tabs/json_tab.tsx
@@ -84,6 +84,7 @@ export const JsonTab = memo(() => {
           json={searchHit as unknown as Record<string, unknown>}
           height={editorHeight}
           hasLineNumbers={true}
+          enableFindAction={true}
         />
       </EuiFlexItem>
     </EuiFlexGroup>


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Security Solution] enable find action to old Security Solution alert flyout (#263875)](https://github.com/elastic/kibana/pull/263875)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Philippe Oberti","email":"philippe.oberti@elastic.co"},"sourceCommit":{"committedDate":"2026-04-16T23:00:12Z","message":"[Security Solution] enable find action to old Security Solution alert flyout (#263875)\n\n## Summary\n\nThis PR enables the search functionality in the json tab that we use in\nthe Security Solution old expandable flyout. This way the experience is\nnow identical to the document flyout in Discover.\n\n| Before  | After |\n| ------------- | ------------- |\n| <img width=\"641\" height=\"957\" alt=\"Screenshot 2026-04-16 at 2 14\n09 PM\"\nsrc=\"https://github.com/user-attachments/assets/98a879ca-44bb-4a86-8048-f660529fcbd5\"\n/> | <img width=\"642\" height=\"959\" alt=\"Screenshot 2026-04-16 at 2 20\n52 PM\"\nsrc=\"https://github.com/user-attachments/assets/16031d14-222d-4bb4-8354-b9c3a049000e\"\n/> |\n\n### Checklist\n\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"f2ae372cf0e72fb9d48dc3ae1f90bb04034dc370","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:enhancement","Team:Threat Hunting:Investigations","backport:all-open","v9.4.0","v9.5.0","v9.3.4","v9.2.9"],"title":"[Security Solution] enable find action to old Security Solution alert flyout","number":263875,"url":"https://github.com/elastic/kibana/pull/263875","mergeCommit":{"message":"[Security Solution] enable find action to old Security Solution alert flyout (#263875)\n\n## Summary\n\nThis PR enables the search functionality in the json tab that we use in\nthe Security Solution old expandable flyout. This way the experience is\nnow identical to the document flyout in Discover.\n\n| Before  | After |\n| ------------- | ------------- |\n| <img width=\"641\" height=\"957\" alt=\"Screenshot 2026-04-16 at 2 14\n09 PM\"\nsrc=\"https://github.com/user-attachments/assets/98a879ca-44bb-4a86-8048-f660529fcbd5\"\n/> | <img width=\"642\" height=\"959\" alt=\"Screenshot 2026-04-16 at 2 20\n52 PM\"\nsrc=\"https://github.com/user-attachments/assets/16031d14-222d-4bb4-8354-b9c3a049000e\"\n/> |\n\n### Checklist\n\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"f2ae372cf0e72fb9d48dc3ae1f90bb04034dc370"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/263936","number":263936,"state":"MERGED","mergeCommit":{"sha":"425029eae68d03e8752f2d42c5e7734020e22a80","message":"[9.4] [Security Solution] enable find action to old Security Solution alert flyout (#263875) (#263936)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.4`:\n- [[Security Solution] enable find action to old Security Solution alert\nflyout (#263875)](https://github.com/elastic/kibana/pull/263875)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Philippe Oberti <philippe.oberti@elastic.co>"}},{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/263875","number":263875,"mergeCommit":{"message":"[Security Solution] enable find action to old Security Solution alert flyout (#263875)\n\n## Summary\n\nThis PR enables the search functionality in the json tab that we use in\nthe Security Solution old expandable flyout. This way the experience is\nnow identical to the document flyout in Discover.\n\n| Before  | After |\n| ------------- | ------------- |\n| <img width=\"641\" height=\"957\" alt=\"Screenshot 2026-04-16 at 2 14\n09 PM\"\nsrc=\"https://github.com/user-attachments/assets/98a879ca-44bb-4a86-8048-f660529fcbd5\"\n/> | <img width=\"642\" height=\"959\" alt=\"Screenshot 2026-04-16 at 2 20\n52 PM\"\nsrc=\"https://github.com/user-attachments/assets/16031d14-222d-4bb4-8354-b9c3a049000e\"\n/> |\n\n### Checklist\n\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"f2ae372cf0e72fb9d48dc3ae1f90bb04034dc370"}},{"branch":"9.3","label":"v9.3.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/263935","number":263935,"state":"MERGED","mergeCommit":{"sha":"f5c6e7955f7a9552315a02b4d2a916505e8115ea","message":"[9.3] [Security Solution] enable find action to old Security Solution alert flyout (#263875) (#263935)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.3`:\n- [[Security Solution] enable find action to old Security Solution alert\nflyout (#263875)](https://github.com/elastic/kibana/pull/263875)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Philippe Oberti <philippe.oberti@elastic.co>"}},{"branch":"9.2","label":"v9.2.9","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/263934","number":263934,"state":"MERGED","mergeCommit":{"sha":"28c2e1b38616915f08b54f3bb99fb8cd4e4ba9b3","message":"[9.2] [Security Solution] enable find action to old Security Solution alert flyout (#263875) (#263934)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.2`:\n- [[Security Solution] enable find action to old Security Solution alert\nflyout (#263875)](https://github.com/elastic/kibana/pull/263875)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Philippe Oberti <philippe.oberti@elastic.co>"}}]}] BACKPORT-->