### PR TITLE
[Security Solution] disable more action row action in alerts table and Timeline for remote documents

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/header_actions/actions.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/header_actions/actions.test.tsx
@@ -13,7 +13,14 @@ import { licenseService } from '../../hooks/use_license';
 import type { ActionsComponentProps } from './actions';
 import { Actions } from './actions';
 import { useIsAnalyzerEnabled } from '../../../detections/hooks/use_is_analyzer_enabled';
+import { AlertContextMenu } from '../../../detections/components/alerts_table/timeline_actions/alert_context_menu';
 
+jest.mock(
+  '../../../detections/components/alerts_table/timeline_actions/alert_context_menu',
+  () => ({
+    AlertContextMenu: jest.fn(() => null),
+  })
+);
 jest.mock('../../hooks/use_selector');
 jest.mock('../../../detections/hooks/use_is_analyzer_enabled');
 jest.mock('../../hooks/use_license', () => {
@@ -202,6 +209,46 @@ describe('Actions', () => {
   });
 
   describe('alert context menu', () => {
+    describe('more actions button', () => {
+      beforeEach(() => {
+        jest.mocked(AlertContextMenu).mockClear();
+      });
+
+      it('should not be disabled when document is local', () => {
+        render(
+          <TestProviders>
+            <Actions {...defaultProps} />
+          </TestProviders>
+        );
+
+        expect(jest.mocked(AlertContextMenu)).toHaveBeenCalledWith(
+          expect.objectContaining({ disabled: false }),
+          expect.anything()
+        );
+      });
+
+      it('should be disabled when document is remote', () => {
+        const props = {
+          ...defaultProps,
+          ecsData: {
+            ...mockTimelineData[0].ecs,
+            _index: 'remote_cluster:.ds-logs-endpoint.events.process-default',
+          },
+        };
+
+        render(
+          <TestProviders>
+            <Actions {...props} />
+          </TestProviders>
+        );
+
+        expect(jest.mocked(AlertContextMenu)).toHaveBeenCalledWith(
+          expect.objectContaining({ disabled: true }),
+          expect.anything()
+        );
+      });
+    });
+
     describe('analyzer icon', () => {
       it('should render', () => {
         (useIsAnalyzerEnabled as jest.Mock).mockReturnValue(true);

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/header_actions/actions.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/header_actions/actions.tsx
@@ -9,6 +9,7 @@ import React, { useCallback, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { EuiButtonIcon, EuiToolTip } from '@elastic/eui';
 import styled from 'styled-components';
+import { isCCSRemoteIndexName } from '@kbn/es-query';
 import {
   makeSelectDocumentNotesBySavedObjectId,
   makeSelectNotesByDocumentId,
@@ -174,6 +175,11 @@ const ActionsComponent: React.FC<ActionsComponentProps> = ({
     [isEnterprisePlus, sessionViewConfig]
   );
 
+  const isRemoteDocument = useMemo(
+    () => isCCSRemoteIndexName(ecsData._index ?? ''),
+    [ecsData._index]
+  );
+
   return (
     <ActionsContainer data-test-subj="actions-container">
       <>
@@ -232,7 +238,7 @@ const ActionsComponent: React.FC<ActionsComponentProps> = ({
           key="alert-context-menu"
           ecsRowData={ecsData}
           scopeId={timelineId}
-          disabled={false}
+          disabled={isRemoteDocument}
           onRuleChange={onRuleChange}
           refetch={refetch}
         />

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attacks_group_take_action_items.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attacks_group_take_action_items.test.tsx
@@ -69,12 +69,13 @@ const mockUseAttackRunWorkflowContextMenuItems =
   >;
 const mockAttack = getMockAttackDiscoveryAlerts()[0];
 
-function renderAttack(attack: AttackDiscoveryAlert) {
+function renderAttack(attack: AttackDiscoveryAlert, isRemoteDocument = false) {
   return render(
     <TestProviders>
       <AttacksGroupTakeActionItems
         attack={attack}
         telemetrySource="attacks_page_group_take_action"
+        isRemoteDocument={isRemoteDocument}
       />
     </TestProviders>
   );
@@ -294,10 +295,29 @@ describe('AttacksGroupTakeActionItems', () => {
             attack={mockAttack}
             showAiAssistantAction={false}
             telemetrySource="attacks_page_group_take_action"
+            isRemoteDocument={false}
           />
         </TestProviders>
       );
       expect(queryByText('View in AI Assistant')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('when isRemoteDocument is true', () => {
+    it('renders only the Investigate in Timeline action', () => {
+      const { queryByText } = renderAttack(mockAttack, true);
+
+      expect(queryByText('Investigate in timeline')).toBeInTheDocument();
+    });
+
+    it('hides all other actions', () => {
+      const { queryByText } = renderAttack(mockAttack, true);
+
+      expect(queryByText('Mark as acknowledged')).not.toBeInTheDocument();
+      expect(queryByText('View in AI Assistant')).not.toBeInTheDocument();
+      expect(queryByText('Assign alert')).not.toBeInTheDocument();
+      expect(queryByText('Apply alert tags')).not.toBeInTheDocument();
+      expect(queryByText('Run workflow')).not.toBeInTheDocument();
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attacks_group_take_action_items.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attacks_group_take_action_items.tsx
@@ -8,9 +8,9 @@
 import type { EuiContextMenuPanelDescriptor } from '@elastic/eui';
 import { EuiContextMenu } from '@elastic/eui';
 import {
+  type AttackDiscoveryAlert,
   getAttackDiscoveryMarkdown,
   getOriginalAlertIds,
-  type AttackDiscoveryAlert,
 } from '@kbn/elastic-assistant-common';
 import React, { useCallback, useMemo } from 'react';
 import { i18n } from '@kbn/i18n';
@@ -41,6 +41,11 @@ interface AttacksGroupTakeActionItemsProps {
   size?: 's' | 'm';
   /** Telemetry source for action events (e.g. flyout vs table) */
   telemetrySource: AttacksActionTelemetrySource;
+  /**
+   * When true, only the "Investigate in Timeline" action is shown.
+   * Use this for remote/CCS attacks where mutations are not possible.
+   */
+  isRemoteDocument: boolean;
 }
 
 const ADD_TO_DATASET = i18n.translate(
@@ -55,6 +60,7 @@ export function AttacksGroupTakeActionItems({
   showAiAssistantAction = true,
   size,
   telemetrySource,
+  isRemoteDocument,
 }: AttacksGroupTakeActionItemsProps) {
   const {
     services: { evals },
@@ -203,18 +209,21 @@ export function AttacksGroupTakeActionItems({
   const defaultPanel: EuiContextMenuPanelDescriptor = useMemo(
     () => ({
       id: 0,
-      items: [
-        ...casesItems,
-        ...workflowItems,
-        ...tagsItems,
-        ...assignItems,
-        ...runWorkflowItems,
-        ...(showAiAssistantAction ? viewInAiAssistantItems : []),
-        ...datasetItems,
-        ...investigateInTimelineItems,
-      ],
+      items: isRemoteDocument
+        ? [...investigateInTimelineItems]
+        : [
+            ...casesItems,
+            ...workflowItems,
+            ...tagsItems,
+            ...assignItems,
+            ...runWorkflowItems,
+            ...(showAiAssistantAction ? viewInAiAssistantItems : []),
+            ...datasetItems,
+            ...investigateInTimelineItems,
+          ],
     }),
     [
+      isRemoteDocument,
       runWorkflowItems,
       workflowItems,
       assignItems,
@@ -228,8 +237,11 @@ export function AttacksGroupTakeActionItems({
   );
 
   const panels: EuiContextMenuPanelDescriptor[] = useMemo(
-    () => [defaultPanel, ...runWorkflowPanels, ...workflowPanels, ...assignPanels, ...tagsPanels],
-    [runWorkflowPanels, workflowPanels, assignPanels, defaultPanel, tagsPanels]
+    () =>
+      isRemoteDocument
+        ? [defaultPanel]
+        : [defaultPanel, ...runWorkflowPanels, ...workflowPanels, ...assignPanels, ...tagsPanels],
+    [isRemoteDocument, runWorkflowPanels, workflowPanels, assignPanels, defaultPanel, tagsPanels]
   );
 
   return <EuiContextMenu size={size} initialPanelId={defaultPanel.id} panels={panels} />;

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/table_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/table_section.tsx
@@ -8,10 +8,11 @@
 import React, { useCallback, useMemo, useState } from 'react';
 import { EuiFlexGroup, EuiFlexItem, EuiSpacer } from '@elastic/eui';
 import type { Filter } from '@kbn/es-query';
+import { isCCSRemoteIndexName } from '@kbn/es-query';
 import { TableId } from '@kbn/securitysolution-data-table';
 import type { DataView } from '@kbn/data-views-plugin/common';
-import { isGroupingBucket } from '@kbn/grouping/src';
 import type { GroupingSort, ParsedGroupingAggregation, RawBucket } from '@kbn/grouping/src';
+import { isGroupingBucket } from '@kbn/grouping/src';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 
 import { AttackDetailsRightPanelKey } from '../../../../flyout/attack_details/constants/panel_keys';
@@ -42,7 +43,7 @@ import { AlertsTab } from './attack_details/alerts_tab';
 import { EmptyResultsPrompt } from './empty_results_prompt';
 import { dsl } from '../utils/dsl';
 import { groupingOptions, groupingSettings } from './grouping_settings/grouping_configs';
-import { buildConnectorIdFilter, buildAttacksOnlyFilter } from './filtering_configs';
+import { buildAttacksOnlyFilter, buildConnectorIdFilter } from './filtering_configs';
 import type { GroupTakeActionItems } from '../../alerts_table/types';
 import { AttacksGroupTakeActionItems } from './attacks_group_take_action_items';
 import { useGroupStats } from './grouping_settings/use_group_stats';
@@ -259,6 +260,7 @@ export const TableSection = React.memo(
             attack={attack}
             closePopover={props.closePopover}
             telemetrySource="attacks_page_group_take_action"
+            isRemoteDocument={isCCSRemoteIndexName(attack.index ?? '')}
           />
         );
       },

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/footer.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/footer.tsx
@@ -6,6 +6,7 @@
  */
 
 import React, { useCallback, useMemo, useState } from 'react';
+import { isCCSRemoteIndexName } from '@kbn/es-query';
 import {
   EuiButton,
   EuiFlexGroup,
@@ -29,7 +30,8 @@ export { FLYOUT_FOOTER_TEST_ID };
  * Bottom section of the flyout that contains the take action button
  */
 export const PanelFooter = () => {
-  const { attack, refetch } = useAttackDetailsContext();
+  const { attack, indexName, refetch } = useAttackDetailsContext();
+  const isRemoteDocument = useMemo(() => isCCSRemoteIndexName(indexName), [indexName]);
 
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
 
@@ -90,6 +92,7 @@ export const PanelFooter = () => {
                 size="s"
                 telemetrySource="attacks_page_flyout_take_action"
                 showAiAssistantAction={false}
+                isRemoteDocument={isRemoteDocument}
               />
             </EuiPopover>
           </EuiFlexItem>


### PR DESCRIPTION
> [!NOTE]
> I had intended to do way more changes than just the header callout and badge, but the amount of changes were too big, so I'm splitting CPS flyout support into 3 main PRs

## Summary

This PR disables the more action row action icon in the Alerts table and in Timeline for remote documents.

> [!TIP]
> The changes should only impact remote documents (in Serverless with CPS enabled). No changes to local documents (in Serverless and ECH).

### Code changes

The more action icon is disabled from Timeline. Timeline will show remote documents.

THe more action icon is also disabled from all the instances of the alerts table in Security Solution. [This other change](https://github.com/elastic/kibana/pull/263572) should ensure that we never have remote alerts in those tables in the first place, but this is a second safety barrier. If they do show up (with a code change), actions won't be enabled.

### UI changes

Alerts table

| Before | After |
| ------------- | ------------- |
| <img width="1064" height="610" alt="Screenshot 2026-04-16 at 11 13 11 PM" src="https://github.com/user-attachments/assets/d72a16d3-975e-4511-b3b2-e57030bae9be" /> | <img width="1059" height="617" alt="Screenshot 2026-04-16 at 11 14 17 PM" src="https://github.com/user-attachments/assets/1614e593-6f0a-49ad-a12b-dde11d47c4a8" /> |

Timeline

| Before | After |
| ------------- | ------------- |
| <img width="1065" height="757" alt="Screenshot 2026-04-16 at 11 13 49 PM" src="https://github.com/user-attachments/assets/6db18660-1f6f-49cd-969e-a5561cf8ba3f" /> | <img width="1059" height="779" alt="Screenshot 2026-04-16 at 11 14 46 PM" src="https://github.com/user-attachments/assets/f244dd68-a034-4801-bc93-9f2baf2ceda3" /> |

## How to test

Refer to [this guide](https://docs.google.com/document/d/16c6H8EVyyAUwp7QDm-77__RHz_hSJ2_wE40_as7WIqE/edit?pli=1&tab=t.0) for local Serverless CPS setup

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->