### PR TITLE
[Cases] Re-enable setCustomField and createCaseFromTemplate workflow steps. Improve setCategory.

### DIFF
--- a/x-pack/platform/plugins/shared/cases/common/utils/owner.ts
+++ b/x-pack/platform/plugins/shared/cases/common/utils/owner.ts
@@ -9,8 +9,8 @@ import { AlertConsumers } from '@kbn/rule-data-utils';
 import { OWNER_INFO } from '../constants';
 import type { ServerlessProjectType, Owner } from '../constants/types';
 
-export const isValidOwner = (owner: string): owner is keyof typeof OWNER_INFO =>
-  Object.keys(OWNER_INFO).includes(owner);
+export const isValidOwner = (owner: string | undefined): owner is keyof typeof OWNER_INFO =>
+  !!owner && Object.keys(OWNER_INFO).includes(owner);
 
 export const getCaseOwnerByAppId = (currentAppId?: string) =>
   Object.values(OWNER_INFO).find((info) => info.appId === currentAppId)?.id;

--- a/x-pack/platform/plugins/shared/cases/common/workflows/steps/create_case_from_template.ts
+++ b/x-pack/platform/plugins/shared/cases/common/workflows/steps/create_case_from_template.ts
@@ -8,7 +8,7 @@
 import { z } from '@kbn/zod/v4';
 import { StepCategory } from '@kbn/workflows';
 import type { CommonStepDefinition } from '@kbn/workflows-extensions/common';
-import { UpdateCaseRequest as UpdateCaseRequestSchema } from '../../bundled-types.gen';
+import { Owner, UpdateCaseRequest as UpdateCaseRequestSchema } from '../../bundled-types.gen';
 import { CasesStepBaseConfigSchema, CasesStepSingleCaseOutputSchema } from './shared';
 import * as i18n from '../translations';
 
@@ -20,6 +20,7 @@ const OverwritesSchema = UpdateCaseRequestSchema.shape.cases.element.omit({
 });
 
 const InputSchema = z.object({
+  owner: Owner,
   case_template_id: z.string().min(1, 'case_template_id is required'),
   overwrites: OverwritesSchema.optional(),
 });
@@ -51,6 +52,7 @@ export const createCaseFromTemplateStepCommonDefinition: CommonStepDefinition<
 - name: create_case_from_template
   type: ${CreateCaseFromTemplateStepTypeId}
   with:
+    owner: securitySolution
     case_template_id: "triage_template"
 \`\`\``,
       `## Create case from template with overwrites
@@ -58,6 +60,7 @@ export const createCaseFromTemplateStepCommonDefinition: CommonStepDefinition<
 - name: create_case_from_template_with_overwrites
   type: ${CreateCaseFromTemplateStepTypeId}
   with:
+    owner: securitySolution
     case_template_id: "triage_template"
     overwrites:
       title: "Template based case title"

--- a/x-pack/platform/plugins/shared/cases/common/workflows/steps/set_category.ts
+++ b/x-pack/platform/plugins/shared/cases/common/workflows/steps/set_category.ts
@@ -8,7 +8,7 @@
 import type { z } from '@kbn/zod/v4';
 import { StepCategory } from '@kbn/workflows';
 import type { CommonStepDefinition } from '@kbn/workflows-extensions/common';
-import { CaseCategory } from '../../bundled-types.gen';
+import { CaseCategory, Owner } from '../../bundled-types.gen';
 import * as i18n from '../translations';
 import {
   CasesStepBaseConfigSchema,
@@ -20,6 +20,7 @@ export const SetCategoryStepTypeId = 'cases.setCategory';
 
 const InputSchema = CasesStepCaseIdVersionSchema.extend({
   category: CaseCategory.min(1, 'category is required'),
+  owner: Owner.optional(),
 });
 
 const OutputSchema = CasesStepSingleCaseOutputSchema;

--- a/x-pack/platform/plugins/shared/cases/common/workflows/steps/set_custom_field.test.ts
+++ b/x-pack/platform/plugins/shared/cases/common/workflows/steps/set_custom_field.test.ts
@@ -55,6 +55,17 @@ describe('set_custom_field common step definition', () => {
     expect(
       InputSchema.safeParse({
         case_id: caseIdFixture,
+        owner: 'securitySolution',
+        value: 'new value',
+      }).success
+    ).toBe(false);
+  });
+
+  it('rejects invalid input with missing owner', () => {
+    expect(
+      InputSchema.safeParse({
+        case_id: caseIdFixture,
+        field_name: 'cf_text',
         value: 'new value',
       }).success
     ).toBe(false);

--- a/x-pack/platform/plugins/shared/cases/common/workflows/steps/set_custom_field.ts
+++ b/x-pack/platform/plugins/shared/cases/common/workflows/steps/set_custom_field.ts
@@ -8,6 +8,7 @@
 import { z } from '@kbn/zod/v4';
 import { StepCategory } from '@kbn/workflows';
 import type { CommonStepDefinition } from '@kbn/workflows-extensions/common';
+import { Owner } from '../../bundled-types.gen';
 import {
   CasesStepBaseConfigSchema,
   CasesStepCaseIdVersionSchema,
@@ -18,6 +19,7 @@ import * as i18n from '../translations';
 export const SetCustomFieldStepTypeId = 'cases.setCustomField';
 
 export const InputSchema = CasesStepCaseIdVersionSchema.extend({
+  owner: Owner,
   field_name: z.string().min(1, 'field_name is required'),
   value: z.union([z.string().min(1), z.boolean(), z.number().int(), z.null()]),
 });
@@ -46,6 +48,7 @@ export const setCustomFieldStepCommonDefinition: CommonStepDefinition<
   type: ${SetCustomFieldStepTypeId}
   with:
     case_id: "abc-123-def-456"
+    owner: "securitySolution"
     field_name: "priority_reason"
     value: "investigate immediately"
 \`\`\``,
@@ -55,6 +58,7 @@ export const setCustomFieldStepCommonDefinition: CommonStepDefinition<
   type: ${SetCustomFieldStepTypeId}
   with:
     case_id: "abc-123-def-456"
+    owner: "securitySolution"
     field_name: "is_automated"
     value: true
 \`\`\``,

--- a/x-pack/platform/plugins/shared/cases/common/workflows/steps/test_fixtures.ts
+++ b/x-pack/platform/plugins/shared/cases/common/workflows/steps/test_fixtures.ts
@@ -136,24 +136,28 @@ export const updateCasesInputWithVersionFixture = {
 
 export const setCustomFieldTextInputFixture = {
   case_id: caseIdFixture,
+  owner: 'securitySolution',
   field_name: 'cf_text',
   value: 'new value',
 };
 
 export const setCustomFieldToggleInputFixture = {
   case_id: caseIdFixture,
+  owner: 'securitySolution',
   field_name: 'cf_toggle',
   value: true,
 };
 
 export const setCustomFieldNumberInputFixture = {
   case_id: caseIdFixture,
+  owner: 'securitySolution',
   field_name: 'cf_number',
   value: 42,
 };
 
 export const setCustomFieldNullInputFixture = {
   case_id: caseIdFixture,
+  owner: 'securitySolution',
   field_name: 'cf_optional',
   value: null,
 };

--- a/x-pack/platform/plugins/shared/cases/common/workflows/translations.ts
+++ b/x-pack/platform/plugins/shared/cases/common/workflows/translations.ts
@@ -448,7 +448,8 @@ export const ADD_CATEGORY_STEP_DESCRIPTION = i18n.translate(
 export const ADD_CATEGORY_STEP_DOCUMENTATION_DETAILS = i18n.translate(
   'xpack.cases.workflowSteps.addCategory.documentation.details',
   {
-    defaultMessage: 'This step sets the category on an existing case.',
+    defaultMessage:
+      'This step sets the category on an existing case. Provide an `owner` property to get auto-completed categories.',
   }
 );
 
@@ -575,6 +576,18 @@ export const DELETE_OBSERVABLE_STEP_DOCUMENTATION_DETAILS = i18n.translate(
       'This step deletes the specified observable from the case. The step echoes back the case_id and observable_id that were removed.',
   }
 );
+
+export const CATEGORY_CAN_BE_USED_MESSAGE = (category: string) =>
+  i18n.translate('xpack.cases.workflowSteps.shared.categoryCanBeUsedMessage', {
+    defaultMessage: 'Category "{category}" can be set on the case.',
+    values: { category },
+  });
+
+export const CATEGORY_NOT_FOUND_MESSAGE = (category: string) =>
+  i18n.translate('xpack.cases.workflowSteps.shared.categoryNotFoundMessage', {
+    defaultMessage: 'Category "{category}" was not found.',
+    values: { category },
+  });
 
 export const GET_CASES_STEP_LABEL = i18n.translate('xpack.cases.workflowSteps.getCases.label', {
   defaultMessage: 'Cases - Get cases',

--- a/x-pack/platform/plugins/shared/cases/public/workflows/create_case_from_template.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/workflows/create_case_from_template.test.tsx
@@ -176,6 +176,43 @@ describe('createCreateCaseFromTemplateStepDefinition', () => {
     });
   });
 
+  it('finds a template beyond the first 15 when the search query is non-empty', async () => {
+    const manyTemplates = [
+      ...Array.from({ length: 15 }, (_, index) => ({
+        key: `tmpl_${index}`,
+        name: `Plain ${index}`,
+        description: '',
+        caseFields: { title: `T ${index}` },
+      })),
+      {
+        key: 'only_uniquetail',
+        name: 'Only uniquetail template',
+        description: 'Last',
+        caseFields: { title: 'X' },
+      },
+    ];
+
+    const { templateSelection } = setup([
+      {
+        owner: 'securitySolution',
+        templates: manyTemplates,
+      },
+    ] as CasesConfigurationUI[]);
+
+    const searchResults = await templateSelection!.search(
+      'uniquetail',
+      createSelectionContext('securitySolution')
+    );
+
+    expect(searchResults).toEqual([
+      {
+        value: 'only_uniquetail',
+        label: 'Only uniquetail template',
+        description: 'Last',
+      },
+    ]);
+  });
+
   it('returns no options when input owner is invalid', async () => {
     const { templateSelection } = setup();
 

--- a/x-pack/platform/plugins/shared/cases/public/workflows/create_case_from_template.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/workflows/create_case_from_template.test.tsx
@@ -5,8 +5,10 @@
  * 2.0.
  */
 
+import type { SelectionOption } from '@kbn/workflows';
 import { createCreateCaseFromTemplateStepDefinition } from './create_case_from_template';
 import { getCaseConfigure } from '../containers/configure/api';
+import type { Owner } from '../../common/bundled-types.gen';
 import type { CasesConfigurationUI } from '../../common/ui';
 
 jest.mock('../containers/configure/api', () => ({
@@ -16,10 +18,50 @@ jest.mock('../containers/configure/api', () => ({
 describe('createCreateCaseFromTemplateStepDefinition', () => {
   const getCaseConfigureMock = jest.mocked(getCaseConfigure);
 
-  const setup = () => {
+  const createSelectionContext = (owner?: Owner | string) => ({
+    stepType: 'cases.createCaseFromTemplate' as const,
+    scope: 'input' as const,
+    propertyKey: 'case_template_id',
+    values: {
+      input: owner === undefined ? {} : { owner },
+    },
+  });
+
+  const defaultCasesConfigure: CasesConfigurationUI[] = [
+    {
+      owner: 'securitySolution',
+      templates: [
+        {
+          key: 'triage_template',
+          name: 'Triage template',
+          description: 'Default triage template',
+          caseFields: { title: 'Template title' },
+        },
+        {
+          key: 'investigation_template',
+          name: 'Investigation template',
+          description: 'Investigation defaults',
+          caseFields: { title: 'Investigation title' },
+        },
+      ],
+    },
+    {
+      owner: 'observability',
+      templates: [
+        {
+          key: 'observability_template',
+          name: 'Observability template',
+          description: 'Observability defaults',
+          caseFields: { title: 'Observability title' },
+        },
+      ],
+    },
+  ] as unknown as CasesConfigurationUI[];
+
+  const setup = (casesConfigure: CasesConfigurationUI[] = defaultCasesConfigure) => {
     interface SelectionHandler {
-      search: (input: string, context: unknown) => Promise<unknown>;
-      resolve: (value: string, context: unknown) => Promise<unknown>;
+      search: (input: string, context: unknown) => Promise<SelectionOption<string>[]>;
+      resolve: (value: string, context: unknown) => Promise<SelectionOption | null>;
       getDetails: (
         value: string,
         context: unknown,
@@ -27,38 +69,9 @@ describe('createCreateCaseFromTemplateStepDefinition', () => {
       ) => Promise<{ message: string }>;
     }
 
-    getCaseConfigureMock.mockResolvedValue([
-      {
-        owner: 'securitySolution',
-        templates: [
-          {
-            key: 'triage_template',
-            name: 'Triage template',
-            description: 'Default triage template',
-            caseFields: { title: 'Template title' },
-          },
-          {
-            key: 'investigation_template',
-            name: 'Investigation template',
-            description: 'Investigation defaults',
-            caseFields: { title: 'Investigation title' },
-          },
-        ],
-      },
-      {
-        owner: 'observability',
-        templates: [
-          {
-            key: 'observability_template',
-            name: 'Observability template',
-            description: 'Should not be shown for workflow owner',
-            caseFields: { title: 'Observability title' },
-          },
-        ],
-      },
-    ] as CasesConfigurationUI[]);
+    getCaseConfigureMock.mockResolvedValue(casesConfigure);
 
-    const definition = createCreateCaseFromTemplateStepDefinition();
+    const definition = createCreateCaseFromTemplateStepDefinition;
     const inputHandlers = (definition.editorHandlers?.input ?? {}) as Record<
       string,
       { selection?: SelectionHandler }
@@ -81,16 +94,14 @@ describe('createCreateCaseFromTemplateStepDefinition', () => {
   it('searches and resolves template options using case configuration API', async () => {
     const { templateSelection } = setup();
 
-    const searchResults = await templateSelection!.search('triage', {
-      stepType: 'cases.createCaseFromTemplate',
-      scope: 'input',
-      propertyKey: 'case_template_id',
-    });
-    const resolved = await templateSelection!.resolve('triage_template', {
-      stepType: 'cases.createCaseFromTemplate',
-      scope: 'input',
-      propertyKey: 'case_template_id',
-    });
+    const searchResults = await templateSelection!.search(
+      'template',
+      createSelectionContext('securitySolution')
+    );
+    const resolved = await templateSelection!.resolve(
+      'triage_template',
+      createSelectionContext('securitySolution')
+    );
 
     expect(getCaseConfigureMock).toHaveBeenCalledTimes(2);
     expect(searchResults).toEqual([
@@ -98,6 +109,11 @@ describe('createCreateCaseFromTemplateStepDefinition', () => {
         value: 'triage_template',
         label: 'Triage template',
         description: 'Default triage template',
+      },
+      {
+        value: 'investigation_template',
+        label: 'Investigation template',
+        description: 'Investigation defaults',
       },
     ]);
     expect(resolved).toEqual({
@@ -107,28 +123,129 @@ describe('createCreateCaseFromTemplateStepDefinition', () => {
     });
   });
 
-  it('returns no options for empty search query', async () => {
+  it('returns all templates for the owner when the search query is empty', async () => {
     const { templateSelection } = setup();
 
     await expect(
-      templateSelection!.search('   ', {
-        stepType: 'cases.createCaseFromTemplate',
-        scope: 'input',
-        propertyKey: 'case_template_id',
-      })
+      templateSelection!.search('   ', createSelectionContext('securitySolution'))
+    ).resolves.toEqual([
+      {
+        value: 'triage_template',
+        label: 'Triage template',
+        description: 'Default triage template',
+      },
+      {
+        value: 'investigation_template',
+        label: 'Investigation template',
+        description: 'Investigation defaults',
+      },
+    ]);
+    expect(getCaseConfigureMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns at most 15 templates when the search query is empty', async () => {
+    const manyTemplates = Array.from({ length: 16 }, (_, index) => ({
+      key: `template_${index}`,
+      name: `Template ${index}`,
+      description: `Description ${index}`,
+      caseFields: { title: `Title ${index}` },
+    }));
+
+    const { templateSelection } = setup([
+      {
+        owner: 'securitySolution',
+        templates: manyTemplates,
+      },
+    ] as CasesConfigurationUI[]);
+
+    const searchResults = await templateSelection!.search(
+      '',
+      createSelectionContext('securitySolution')
+    );
+
+    expect(searchResults).toHaveLength(15);
+    expect(searchResults[0]).toEqual({
+      value: 'template_0',
+      label: 'Template 0',
+      description: 'Description 0',
+    });
+    expect(searchResults[14]).toEqual({
+      value: 'template_14',
+      label: 'Template 14',
+      description: 'Description 14',
+    });
+  });
+
+  it('returns no options when input owner is invalid', async () => {
+    const { templateSelection } = setup();
+
+    await expect(
+      templateSelection!.search('triage', createSelectionContext('notAValidOwner'))
+    ).resolves.toEqual([]);
+    expect(getCaseConfigureMock).not.toHaveBeenCalled();
+  });
+
+  it('returns no options when input owner is empty', async () => {
+    const { templateSelection } = setup();
+
+    await expect(templateSelection!.search('triage', createSelectionContext(''))).resolves.toEqual(
+      []
+    );
+    await expect(templateSelection!.search('triage', createSelectionContext())).resolves.toEqual(
+      []
+    );
+    expect(getCaseConfigureMock).not.toHaveBeenCalled();
+  });
+
+  it('does not return observability templates when input owner is security', async () => {
+    const { templateSelection } = setup();
+
+    await expect(
+      templateSelection!.search('observability', createSelectionContext('securitySolution'))
     ).resolves.toEqual([]);
   });
 
-  it('filters templates by workflow owner', async () => {
+  it('returns security templates when input owner is securitySolution', async () => {
     const { templateSelection } = setup();
 
-    await expect(
-      templateSelection!.search('observability', {
-        stepType: 'cases.createCaseFromTemplate',
-        scope: 'input',
-        propertyKey: 'case_template_id',
-      })
-    ).resolves.toEqual([]);
+    const searchResults = await templateSelection!.search(
+      'investigation',
+      createSelectionContext('securitySolution')
+    );
+
+    expect(searchResults).toEqual([
+      {
+        value: 'investigation_template',
+        label: 'Investigation template',
+        description: 'Investigation defaults',
+      },
+    ]);
+  });
+
+  it('returns observability templates when input owner is observability', async () => {
+    const { templateSelection } = setup();
+
+    const searchResults = await templateSelection!.search(
+      'observability',
+      createSelectionContext('observability')
+    );
+    const resolved = await templateSelection!.resolve(
+      'observability_template',
+      createSelectionContext('observability')
+    );
+
+    expect(searchResults).toEqual([
+      {
+        value: 'observability_template',
+        label: 'Observability template',
+        description: 'Observability defaults',
+      },
+    ]);
+    expect(resolved).toEqual({
+      value: 'observability_template',
+      label: 'Observability template',
+      description: 'Observability defaults',
+    });
   });
 
   it('returns details message for resolved and unresolved template values', async () => {
@@ -155,11 +272,7 @@ describe('createCreateCaseFromTemplateStepDefinition', () => {
     getCaseConfigureMock.mockRejectedValueOnce(error);
 
     await expect(
-      templateSelection!.search('triage', {
-        stepType: 'cases.createCaseFromTemplate',
-        scope: 'input',
-        propertyKey: 'case_template_id',
-      })
+      templateSelection!.search('triage', createSelectionContext('securitySolution'))
     ).rejects.toThrow(error.message);
   });
 

--- a/x-pack/platform/plugins/shared/cases/public/workflows/create_case_from_template.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/workflows/create_case_from_template.tsx
@@ -5,15 +5,13 @@
  * 2.0.
  */
 
-import type { SelectionOption } from '@kbn/workflows/types/latest';
 import { getCaseConfigure } from '../containers/configure/api';
 import { createCaseFromTemplateStepCommonDefinition } from '../../common/workflows/steps/create_case_from_template';
 import * as i18n from '../../common/workflows/translations';
+import { collectSelectionSearchOptions } from './selection_search';
 import { createPublicCaseStepDefinition } from './shared';
 import { isValidOwner } from '../../common/utils/owner';
 import type { Owner } from '../../common/bundled-types.gen';
-
-const MAX_TEMPLATES_FOR_SELECTION = 15;
 
 const getTemplatesForWorkflowOwner = async (owner: Owner) => {
   const configurations = (await getCaseConfigure({})) ?? [];
@@ -38,26 +36,20 @@ export const createCreateCaseFromTemplateStepDefinition = createPublicCaseStepDe
             const query = input.trim().toLowerCase();
             const templates = await getTemplatesForWorkflowOwner(owner);
 
-            const options: SelectionOption<string>[] = [];
-            const templateLimit = Math.min(templates.length, MAX_TEMPLATES_FOR_SELECTION);
             const queryIsEmpty = query.length === 0;
 
-            for (let i = 0; i < templateLimit; i++) {
-              const template = templates[i];
-              if (
-                queryIsEmpty ||
+            return collectSelectionSearchOptions({
+              items: templates,
+              hasEmptyQuery: queryIsEmpty,
+              matchesQuery: (template) =>
                 template.key.toLowerCase().includes(query) ||
-                template.name.toLowerCase().includes(query)
-              ) {
-                options.push({
-                  value: template.key,
-                  label: template.name,
-                  description: template.description,
-                });
-              }
-            }
-
-            return options;
+                template.name.toLowerCase().includes(query),
+              toOption: (template) => ({
+                value: template.key,
+                label: template.name,
+                description: template.description,
+              }),
+            });
           },
           resolve: async (value, ctx) => {
             const owner = ctx.values.input.owner;

--- a/x-pack/platform/plugins/shared/cases/public/workflows/create_case_from_template.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/workflows/create_case_from_template.tsx
@@ -10,71 +10,85 @@ import { getCaseConfigure } from '../containers/configure/api';
 import { createCaseFromTemplateStepCommonDefinition } from '../../common/workflows/steps/create_case_from_template';
 import * as i18n from '../../common/workflows/translations';
 import { createPublicCaseStepDefinition } from './shared';
+import { isValidOwner } from '../../common/utils/owner';
+import type { Owner } from '../../common/bundled-types.gen';
 
-const WORKFLOW_CASE_OWNER = 'securitySolution';
+const MAX_TEMPLATES_FOR_SELECTION = 15;
 
-const getTemplatesForWorkflowOwner = async () => {
+const getTemplatesForWorkflowOwner = async (owner: Owner) => {
   const configurations = (await getCaseConfigure({})) ?? [];
   return configurations
-    .filter((configuration) => configuration.owner === WORKFLOW_CASE_OWNER)
+    .filter((configuration) => configuration.owner === owner)
     .flatMap((configuration) => configuration.templates ?? []);
 };
 
-export const createCreateCaseFromTemplateStepDefinition = () =>
-  createPublicCaseStepDefinition({
-    ...createCaseFromTemplateStepCommonDefinition,
-    editorHandlers: {
-      input: {
-        case_template_id: {
-          selection: {
-            search: async (input) => {
-              const templates = await getTemplatesForWorkflowOwner();
-              const query = input.trim().toLowerCase();
+export const createCreateCaseFromTemplateStepDefinition = createPublicCaseStepDefinition({
+  ...createCaseFromTemplateStepCommonDefinition,
+  editorHandlers: {
+    input: {
+      case_template_id: {
+        selection: {
+          dependsOnValues: ['input.owner'],
+          search: async (input, ctx) => {
+            const owner = ctx.values.input.owner;
+            if (!isValidOwner(owner)) {
+              return [];
+            }
 
-              if (query.length === 0) {
-                return [];
+            const query = input.trim().toLowerCase();
+            const templates = await getTemplatesForWorkflowOwner(owner);
+
+            const options: SelectionOption<string>[] = [];
+            const templateLimit = Math.min(templates.length, MAX_TEMPLATES_FOR_SELECTION);
+            const queryIsEmpty = query.length === 0;
+
+            for (let i = 0; i < templateLimit; i++) {
+              const template = templates[i];
+              if (
+                queryIsEmpty ||
+                template.key.toLowerCase().includes(query) ||
+                template.name.toLowerCase().includes(query)
+              ) {
+                options.push({
+                  value: template.key,
+                  label: template.name,
+                  description: template.description,
+                });
               }
+            }
 
-              return templates.reduce<SelectionOption<string>[]>((acc, template) => {
-                if (
-                  template.key.toLowerCase().includes(query) ||
-                  template.name.toLowerCase().includes(query)
-                ) {
-                  acc.push({
-                    value: template.key,
-                    label: template.name,
-                    description: template.description,
-                  });
-                }
-                return acc;
-              }, []);
-            },
-            resolve: async (value) => {
-              const templates = await getTemplatesForWorkflowOwner();
-              const template = templates.find((currentTemplate) => currentTemplate.key === value);
-              if (!template) {
-                return null;
-              }
+            return options;
+          },
+          resolve: async (value, ctx) => {
+            const owner = ctx.values.input.owner;
+            if (!owner) {
+              return null;
+            }
+            const templates = await getTemplatesForWorkflowOwner(owner);
+            const template = templates.find((currentTemplate) => currentTemplate.key === value);
+            if (!template) {
+              return null;
+            }
 
+            return {
+              value: template.key,
+              label: template.name,
+              description: template.description,
+            };
+          },
+          getDetails: async (value, _context, option) => {
+            if (option) {
               return {
-                value: template.key,
-                label: template.name,
-                description: template.description,
+                message: i18n.TEMPLATE_CAN_BE_USED_MESSAGE(option.value),
               };
-            },
-            getDetails: async (value, _context, option) => {
-              if (option) {
-                return {
-                  message: i18n.TEMPLATE_CAN_BE_USED_MESSAGE(option.value),
-                };
-              }
+            }
 
-              return {
-                message: i18n.TEMPLATE_NOT_FOUND_MESSAGE(value),
-              };
-            },
+            return {
+              message: i18n.TEMPLATE_NOT_FOUND_MESSAGE(value),
+            };
           },
         },
       },
     },
-  });
+  },
+});

--- a/x-pack/platform/plugins/shared/cases/public/workflows/index.ts
+++ b/x-pack/platform/plugins/shared/cases/public/workflows/index.ts
@@ -35,10 +35,9 @@ export function registerCasesSteps(
     import('./simple_steps').then((m) => m.updateCasesStepDefinition)
   );
 
-  // TODO: enable once https://github.com/elastic/security-team/issues/15982 has been resolved
-  // workflowsExtensions.registerStepDefinition(() =>
-  //   import('./set_custom_field').then((m) => m.setCustomFieldStepDefinition)
-  // );
+  workflowsExtensions.registerStepDefinition(() =>
+    import('./set_custom_field').then((m) => m.setCustomFieldStepDefinition)
+  );
 
   workflowsExtensions.registerStepDefinition(() =>
     import('./simple_steps').then((m) => m.findCasesStepDefinition)
@@ -120,6 +119,7 @@ export function registerCasesSteps(
     import('./simple_steps').then((m) => m.getCasesStepDefinition)
   );
 
-  // Leaving this in for now. We need to get support for reflective value lookup first.
-  // workflowsExtensions.registerStepDefinition(createCreateCaseFromTemplateStepDefinition());
+  workflowsExtensions.registerStepDefinition(() =>
+    import('./create_case_from_template').then((m) => m.createCreateCaseFromTemplateStepDefinition)
+  );
 }

--- a/x-pack/platform/plugins/shared/cases/public/workflows/index.ts
+++ b/x-pack/platform/plugins/shared/cases/public/workflows/index.ts
@@ -96,7 +96,7 @@ export function registerCasesSteps(
   );
 
   workflowsExtensions.registerStepDefinition(() =>
-    import('./simple_steps').then((m) => m.setCategoryStepDefinition)
+    import('./set_category').then((m) => m.setCategoryStepDefinition)
   );
 
   workflowsExtensions.registerStepDefinition(() =>

--- a/x-pack/platform/plugins/shared/cases/public/workflows/selection_search.test.ts
+++ b/x-pack/platform/plugins/shared/cases/public/workflows/selection_search.test.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  collectSelectionSearchOptions,
+  SELECTION_SEARCH_MAX_BROWSE_RESULTS,
+} from './selection_search';
+
+describe('collectSelectionSearchOptions', () => {
+  it('caps how many source rows are scanned when browsing (empty query)', () => {
+    const items = Array.from({ length: 20 }, (_, i) => `item_${i}`);
+    const options = collectSelectionSearchOptions({
+      items,
+      hasEmptyQuery: true,
+      matchesQuery: () => true,
+      toOption: (v) => ({ value: v, label: v }),
+    });
+    expect(options).toHaveLength(SELECTION_SEARCH_MAX_BROWSE_RESULTS);
+    expect(options[0]).toEqual({ value: 'item_0', label: 'item_0' });
+    expect(options[14]).toEqual({ value: 'item_14', label: 'item_14' });
+  });
+
+  it('scans all source rows when filtering (non-empty query)', () => {
+    const items = ['a', 'b', 'match_tail'];
+    const options = collectSelectionSearchOptions({
+      items,
+      hasEmptyQuery: false,
+      matchesQuery: (v) => v.includes('tail'),
+      toOption: (v) => ({ value: v, label: v }),
+    });
+    expect(options).toEqual([{ value: 'match_tail', label: 'match_tail' }]);
+  });
+
+  it('when browsing, includes every item in the scan range without using matchesQuery', () => {
+    const items = Array.from({ length: 20 }, (_, i) => `item_${i}`);
+    const options = collectSelectionSearchOptions({
+      items,
+      hasEmptyQuery: true,
+      matchesQuery: () => false,
+      toOption: (v) => ({ value: v, label: v }),
+    });
+    expect(options).toHaveLength(SELECTION_SEARCH_MAX_BROWSE_RESULTS);
+  });
+});

--- a/x-pack/platform/plugins/shared/cases/public/workflows/selection_search.ts
+++ b/x-pack/platform/plugins/shared/cases/public/workflows/selection_search.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { SelectionOption } from '@kbn/workflows/types/latest';
+
+/** Maximum number of source rows scanned in browse mode (empty query) for selection search. */
+export const SELECTION_SEARCH_MAX_BROWSE_RESULTS = 15;
+
+export interface CollectSelectionSearchOptionsParams<TItem> {
+  readonly items: readonly TItem[];
+  /** True when the trimmed search string is empty (browse mode). */
+  hasEmptyQuery: boolean;
+  /**
+   * Return true if `item` matches the non-empty search text.
+   * When `hasEmptyQuery` is true, the implementation short-circuits and does not invoke this.
+   */
+  matchesQuery: (item: TItem) => boolean;
+  toOption: (item: TItem) => SelectionOption<string>;
+}
+
+/**
+ * Builds completion options for workflow selection `search` handlers.
+ *
+ * An item is included when `hasEmptyQuery` **or** `matchesQuery(item)`.
+ *
+ * When `hasEmptyQuery` is true (browse), only the first {@link SELECTION_SEARCH_MAX_BROWSE_RESULTS}
+ * **sources** are scanned; each is included. When `hasEmptyQuery` is false (filter), **all**
+ * sources are scanned so matches are not missed past that browse cap.
+ */
+export const collectSelectionSearchOptions = <TItem>({
+  items,
+  hasEmptyQuery,
+  matchesQuery,
+  toOption,
+}: CollectSelectionSearchOptionsParams<TItem>): SelectionOption<string>[] => {
+  const limit = hasEmptyQuery
+    ? Math.min(items.length, SELECTION_SEARCH_MAX_BROWSE_RESULTS)
+    : items.length;
+  const options: SelectionOption<string>[] = [];
+
+  for (let i = 0; i < limit; i++) {
+    const item = items[i];
+    if (hasEmptyQuery || matchesQuery(item)) {
+      options.push(toOption(item));
+    }
+  }
+
+  return options;
+};

--- a/x-pack/platform/plugins/shared/cases/public/workflows/set_category.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/workflows/set_category.test.tsx
@@ -1,0 +1,190 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { SelectionOption } from '@kbn/workflows';
+import { setCategoryStepDefinition } from './set_category';
+import { getCategories } from '../containers/api';
+
+jest.mock('../containers/api', () => ({
+  getCategories: jest.fn(),
+}));
+
+describe('setCategoryStepDefinition', () => {
+  const getCategoriesMock = jest.mocked(getCategories);
+
+  const createSelectionContext = (owner?: string) => ({
+    stepType: 'cases.setCategory' as const,
+    scope: 'input' as const,
+    propertyKey: 'category',
+    values: {
+      input: owner === undefined ? {} : { owner },
+    },
+  });
+
+  const defaultCategories = ['Malware', 'Phishing', 'Ransomware', 'Data Breach'];
+
+  const setup = (categories: string[] = defaultCategories) => {
+    interface SelectionHandler {
+      search: (input: string, context: unknown) => Promise<SelectionOption<string>[]>;
+      resolve: (value: string, context: unknown) => Promise<SelectionOption | null>;
+      getDetails: (
+        value: string,
+        context: unknown,
+        option: unknown
+      ) => Promise<{ message: string }>;
+    }
+
+    getCategoriesMock.mockResolvedValue(categories);
+
+    const definition = setCategoryStepDefinition;
+    const inputHandlers = (definition.editorHandlers?.input ?? {}) as Record<
+      string,
+      { selection?: SelectionHandler }
+    >;
+
+    return {
+      definition,
+      categorySelection: inputHandlers.category?.selection,
+    };
+  };
+
+  it('returns a public step definition with expected metadata', () => {
+    const { definition } = setup();
+
+    expect(definition.id).toBe('cases.setCategory');
+    expect(definition.category).toBe('kibana.cases');
+    expect(definition.documentation?.examples?.length).toBeGreaterThan(0);
+  });
+
+  it('searches all categories when query is empty', async () => {
+    const { categorySelection } = setup();
+
+    const results = await categorySelection!.search('   ', createSelectionContext('securitySolution'));
+
+    expect(results).toEqual([
+      { value: 'Malware', label: 'Malware' },
+      { value: 'Phishing', label: 'Phishing' },
+      { value: 'Ransomware', label: 'Ransomware' },
+      { value: 'Data Breach', label: 'Data Breach' },
+    ]);
+    expect(getCategoriesMock).toHaveBeenCalledWith({ owner: ['securitySolution'] });
+  });
+
+  it('filters categories by query text', async () => {
+    const { categorySelection } = setup();
+
+    const results = await categorySelection!.search('ware', createSelectionContext('securitySolution'));
+
+    expect(results).toEqual([
+      { value: 'Malware', label: 'Malware' },
+      { value: 'Ransomware', label: 'Ransomware' },
+    ]);
+  });
+
+  it('resolves a specific category value', async () => {
+    const { categorySelection } = setup();
+
+    const resolved = await categorySelection!.resolve(
+      'Phishing',
+      createSelectionContext('securitySolution')
+    );
+
+    expect(resolved).toEqual({ value: 'Phishing', label: 'Phishing' });
+  });
+
+  it('returns null when resolving a category not in the list', async () => {
+    const { categorySelection } = setup();
+
+    const resolved = await categorySelection!.resolve(
+      'Unknown',
+      createSelectionContext('securitySolution')
+    );
+
+    expect(resolved).toBeNull();
+  });
+
+  it('returns at most 15 categories', async () => {
+    const manyCategories = Array.from({ length: 16 }, (_, i) => `Category ${i}`);
+    const { categorySelection } = setup(manyCategories);
+
+    const results = await categorySelection!.search('', createSelectionContext('securitySolution'));
+
+    expect(results).toHaveLength(15);
+  });
+
+  it('fetches all categories when owner is not provided', async () => {
+    const { categorySelection } = setup();
+
+    await categorySelection!.search('', createSelectionContext());
+
+    expect(getCategoriesMock).toHaveBeenCalledWith({ owner: [] });
+  });
+
+  it('fetches all categories when owner is invalid', async () => {
+    const { categorySelection } = setup();
+
+    await categorySelection!.search('', createSelectionContext('notAValidOwner'));
+
+    expect(getCategoriesMock).toHaveBeenCalledWith({ owner: [] });
+  });
+
+  it('fetches all categories when owner is empty string', async () => {
+    const { categorySelection } = setup();
+
+    await categorySelection!.search('', createSelectionContext(''));
+
+    expect(getCategoriesMock).toHaveBeenCalledWith({ owner: [] });
+  });
+
+  it('uses owner filter when a valid owner is provided', async () => {
+    const { categorySelection } = setup();
+
+    await categorySelection!.search('', createSelectionContext('observability'));
+
+    expect(getCategoriesMock).toHaveBeenCalledWith({ owner: ['observability'] });
+  });
+
+  it('returns details message for a resolved category', async () => {
+    const { categorySelection } = setup();
+
+    const details = await categorySelection!.getDetails(
+      'Malware',
+      createSelectionContext(),
+      { value: 'Malware', label: 'Malware' }
+    );
+
+    expect(details.message).toContain('Malware');
+    expect(details.message).toContain('can be set');
+  });
+
+  it('returns not-found message when category option is null', async () => {
+    const { categorySelection } = setup();
+
+    const details = await categorySelection!.getDetails(
+      'UnknownCategory',
+      createSelectionContext(),
+      null
+    );
+
+    expect(details.message).toContain('UnknownCategory');
+    expect(details.message).toContain('not found');
+  });
+
+  it('propagates API errors from getCategories', async () => {
+    const error = new Error('categories fetch failed');
+    const { categorySelection } = setup();
+    getCategoriesMock.mockRejectedValueOnce(error);
+
+    await expect(
+      categorySelection!.search('Malware', createSelectionContext('securitySolution'))
+    ).rejects.toThrow(error.message);
+  });
+
+  afterEach(() => {
+    getCategoriesMock.mockReset();
+  });
+});

--- a/x-pack/platform/plugins/shared/cases/public/workflows/set_category.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/workflows/set_category.test.tsx
@@ -63,7 +63,10 @@ describe('setCategoryStepDefinition', () => {
   it('searches all categories when query is empty', async () => {
     const { categorySelection } = setup();
 
-    const results = await categorySelection!.search('   ', createSelectionContext('securitySolution'));
+    const results = await categorySelection!.search(
+      '   ',
+      createSelectionContext('securitySolution')
+    );
 
     expect(results).toEqual([
       { value: 'Malware', label: 'Malware' },
@@ -77,7 +80,10 @@ describe('setCategoryStepDefinition', () => {
   it('filters categories by query text', async () => {
     const { categorySelection } = setup();
 
-    const results = await categorySelection!.search('ware', createSelectionContext('securitySolution'));
+    const results = await categorySelection!.search(
+      'ware',
+      createSelectionContext('securitySolution')
+    );
 
     expect(results).toEqual([
       { value: 'Malware', label: 'Malware' },
@@ -116,28 +122,61 @@ describe('setCategoryStepDefinition', () => {
     expect(results).toHaveLength(15);
   });
 
-  it('fetches all categories when owner is not provided', async () => {
+  it('does not fetch categories when owner is not provided', async () => {
     const { categorySelection } = setup();
 
-    await categorySelection!.search('', createSelectionContext());
+    const results = await categorySelection!.search('', createSelectionContext());
 
-    expect(getCategoriesMock).toHaveBeenCalledWith({ owner: [] });
+    expect(results).toEqual([]);
+    expect(getCategoriesMock).not.toHaveBeenCalled();
   });
 
-  it('fetches all categories when owner is invalid', async () => {
+  it('does not fetch categories when owner is invalid', async () => {
     const { categorySelection } = setup();
 
-    await categorySelection!.search('', createSelectionContext('notAValidOwner'));
+    const results = await categorySelection!.search('', createSelectionContext('notAValidOwner'));
 
-    expect(getCategoriesMock).toHaveBeenCalledWith({ owner: [] });
+    expect(results).toEqual([]);
+    expect(getCategoriesMock).not.toHaveBeenCalled();
   });
 
-  it('fetches all categories when owner is empty string', async () => {
+  it('does not fetch categories when owner is empty string', async () => {
     const { categorySelection } = setup();
 
-    await categorySelection!.search('', createSelectionContext(''));
+    const results = await categorySelection!.search('', createSelectionContext(''));
 
-    expect(getCategoriesMock).toHaveBeenCalledWith({ owner: [] });
+    expect(results).toEqual([]);
+    expect(getCategoriesMock).not.toHaveBeenCalled();
+  });
+
+  it('returns a freeform category option when owner is missing and search text is non-empty', async () => {
+    const { categorySelection } = setup();
+
+    const results = await categorySelection!.search('Custom Category', createSelectionContext());
+
+    expect(results).toEqual([{ value: 'Custom Category', label: 'Custom Category' }]);
+    expect(getCategoriesMock).not.toHaveBeenCalled();
+  });
+
+  it('resolves any category value when owner is missing', async () => {
+    const { categorySelection } = setup();
+
+    const resolved = await categorySelection!.resolve('Unknown', createSelectionContext());
+
+    expect(resolved).toEqual({ value: 'Unknown', label: 'Unknown' });
+    expect(getCategoriesMock).not.toHaveBeenCalled();
+  });
+
+  it('resolves any category value when owner is invalid', async () => {
+    const { categorySelection } = setup();
+
+    const resolved = await categorySelection!.resolve(
+      'NotInApi',
+      createSelectionContext('notAValidOwner')
+    );
+
+    expect(resolved).toEqual({ value: 'NotInApi', label: 'NotInApi' });
+    expect(getCategoriesMock).not.toHaveBeenCalled();
   });
 
   it('uses owner filter when a valid owner is provided', async () => {
@@ -151,11 +190,10 @@ describe('setCategoryStepDefinition', () => {
   it('returns details message for a resolved category', async () => {
     const { categorySelection } = setup();
 
-    const details = await categorySelection!.getDetails(
-      'Malware',
-      createSelectionContext(),
-      { value: 'Malware', label: 'Malware' }
-    );
+    const details = await categorySelection!.getDetails('Malware', createSelectionContext(), {
+      value: 'Malware',
+      label: 'Malware',
+    });
 
     expect(details.message).toContain('Malware');
     expect(details.message).toContain('can be set');

--- a/x-pack/platform/plugins/shared/cases/public/workflows/set_category.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/workflows/set_category.test.tsx
@@ -113,13 +113,28 @@ describe('setCategoryStepDefinition', () => {
     expect(resolved).toBeNull();
   });
 
-  it('returns at most 15 categories', async () => {
+  it('returns at most 15 categories when the search query is empty', async () => {
     const manyCategories = Array.from({ length: 16 }, (_, i) => `Category ${i}`);
     const { categorySelection } = setup(manyCategories);
 
     const results = await categorySelection!.search('', createSelectionContext('securitySolution'));
 
     expect(results).toHaveLength(15);
+  });
+
+  it('finds a category after index 14 when the search query is non-empty', async () => {
+    const manyCategories = [
+      ...Array.from({ length: 15 }, (_, i) => `Unrelated ${i}`),
+      'OnlyUniqueTailMatch',
+    ];
+    const { categorySelection } = setup(manyCategories);
+
+    const results = await categorySelection!.search(
+      'uniquetail',
+      createSelectionContext('securitySolution')
+    );
+
+    expect(results).toEqual([{ value: 'OnlyUniqueTailMatch', label: 'OnlyUniqueTailMatch' }]);
   });
 
   it('does not fetch categories when owner is not provided', async () => {

--- a/x-pack/platform/plugins/shared/cases/public/workflows/set_category.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/workflows/set_category.tsx
@@ -1,0 +1,68 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { SelectionOption } from '@kbn/workflows/types/latest';
+import { getCategories } from '../containers/api';
+import { setCategoryStepCommonDefinition } from '../../common/workflows/steps/set_category';
+import * as i18n from '../../common/workflows/translations';
+import { createPublicCaseStepDefinition } from './shared';
+import { isValidOwner } from '../../common/utils/owner';
+
+const MAX_CATEGORIES_FOR_SELECTION = 15;
+
+export const setCategoryStepDefinition = createPublicCaseStepDefinition({
+  ...setCategoryStepCommonDefinition,
+  editorHandlers: {
+    input: {
+      category: {
+        selection: {
+          dependsOnValues: ['input.owner'],
+          search: async (input, ctx) => {
+            const owner = ctx.values.input.owner;
+            if (!isValidOwner(owner)) {
+              return [];
+            }
+            const query = input.trim().toLowerCase();
+            const categories = await getCategories({ owner: [owner] });
+
+            const options: SelectionOption<string>[] = [];
+            const categoryLimit = Math.min(categories.length, MAX_CATEGORIES_FOR_SELECTION);
+            const queryIsEmpty = query.length === 0;
+
+            for (let i = 0; i < categoryLimit; i++) {
+              const category = categories[i];
+              if (queryIsEmpty || category.toLowerCase().includes(query)) {
+                options.push({ value: category, label: category });
+              }
+            }
+
+            return options;
+          },
+          resolve: async (value, ctx) => {
+            const owner = ctx.values.input.owner;
+            const ownerFilter = isValidOwner(owner) ? [owner] : [];
+            const categories = await getCategories({ owner: ownerFilter });
+            const found = categories.find((cat) => cat === value);
+
+            if (!found) {
+              return null;
+            }
+
+            return { value: found, label: found };
+          },
+          getDetails: async (value, _context, option) => {
+            if (option) {
+              return { message: i18n.CATEGORY_CAN_BE_USED_MESSAGE(option.value) };
+            }
+
+            return { message: i18n.CATEGORY_NOT_FOUND_MESSAGE(value) };
+          },
+        },
+      },
+    },
+  },
+});

--- a/x-pack/platform/plugins/shared/cases/public/workflows/set_category.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/workflows/set_category.tsx
@@ -5,14 +5,12 @@
  * 2.0.
  */
 
-import type { SelectionOption } from '@kbn/workflows/types/latest';
 import { getCategories } from '../containers/api';
 import { setCategoryStepCommonDefinition } from '../../common/workflows/steps/set_category';
 import * as i18n from '../../common/workflows/translations';
+import { collectSelectionSearchOptions } from './selection_search';
 import { createPublicCaseStepDefinition } from './shared';
 import { isValidOwner } from '../../common/utils/owner';
-
-const MAX_CATEGORIES_FOR_SELECTION = 15;
 
 export const setCategoryStepDefinition = createPublicCaseStepDefinition({
   ...setCategoryStepCommonDefinition,
@@ -30,18 +28,14 @@ export const setCategoryStepDefinition = createPublicCaseStepDefinition({
             const query = input.trim().toLowerCase();
             const categories = await getCategories({ owner: [owner] });
 
-            const options: SelectionOption<string>[] = [];
-            const categoryLimit = Math.min(categories.length, MAX_CATEGORIES_FOR_SELECTION);
             const queryIsEmpty = query.length === 0;
 
-            for (let i = 0; i < categoryLimit; i++) {
-              const category = categories[i];
-              if (queryIsEmpty || category.toLowerCase().includes(query)) {
-                options.push({ value: category, label: category });
-              }
-            }
-
-            return options;
+            return collectSelectionSearchOptions({
+              items: categories,
+              hasEmptyQuery: queryIsEmpty,
+              matchesQuery: (category) => category.toLowerCase().includes(query),
+              toOption: (category) => ({ value: category, label: category }),
+            });
           },
           resolve: async (value, ctx) => {
             const owner = ctx.values.input.owner;

--- a/x-pack/platform/plugins/shared/cases/public/workflows/set_category.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/workflows/set_category.tsx
@@ -23,8 +23,9 @@ export const setCategoryStepDefinition = createPublicCaseStepDefinition({
           dependsOnValues: ['input.owner'],
           search: async (input, ctx) => {
             const owner = ctx.values.input.owner;
+            // If no owner is specified, keep the input, no need to verify categories
             if (!isValidOwner(owner)) {
-              return [];
+              return input.length ? [{ value: input, label: input }] : [];
             }
             const query = input.trim().toLowerCase();
             const categories = await getCategories({ owner: [owner] });
@@ -44,8 +45,11 @@ export const setCategoryStepDefinition = createPublicCaseStepDefinition({
           },
           resolve: async (value, ctx) => {
             const owner = ctx.values.input.owner;
-            const ownerFilter = isValidOwner(owner) ? [owner] : [];
-            const categories = await getCategories({ owner: ownerFilter });
+            // If no owner was specified, just accept the value. We do not need to verify categories.
+            if (!isValidOwner(owner)) {
+              return { value, label: value };
+            }
+            const categories = await getCategories({ owner: [owner] });
             const found = categories.find((cat) => cat === value);
 
             if (!found) {

--- a/x-pack/platform/plugins/shared/cases/public/workflows/set_custom_field.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/workflows/set_custom_field.test.tsx
@@ -175,6 +175,45 @@ describe('setCustomFieldStepDefinition', () => {
     });
   });
 
+  it('finds a custom field beyond the first 15 when the search query is non-empty', async () => {
+    const manyCustomFields = [
+      ...Array.from({ length: 15 }, (_, index) => ({
+        key: `no_match_${index}`,
+        label: `Plain ${index}`,
+        type: 'text' as const,
+        required: false,
+        defaultValue: null,
+      })),
+      {
+        key: 'only_uniquetail_field',
+        label: 'Only uniquetail field',
+        type: 'text' as const,
+        required: false,
+        defaultValue: null,
+      },
+    ];
+
+    const { fieldNameSelection } = setup([
+      {
+        owner: 'securitySolution',
+        customFields: manyCustomFields,
+      },
+    ] as CasesConfigurationUI[]);
+
+    const searchResults = await fieldNameSelection!.search(
+      'uniquetail',
+      createSelectionContext('securitySolution')
+    );
+
+    expect(searchResults).toEqual([
+      {
+        value: 'only_uniquetail_field',
+        label: 'Only uniquetail field',
+        description: 'text',
+      },
+    ]);
+  });
+
   it('returns no options when input owner is invalid', async () => {
     const { fieldNameSelection } = setup();
 

--- a/x-pack/platform/plugins/shared/cases/public/workflows/set_custom_field.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/workflows/set_custom_field.test.tsx
@@ -5,21 +5,66 @@
  * 2.0.
  */
 
+import type { SelectionOption } from '@kbn/workflows';
 import { setCustomFieldStepDefinition } from './set_custom_field';
 import { getCaseConfigure } from '../containers/configure/api';
+import type { Owner } from '../../common/bundled-types.gen';
 import type { CasesConfigurationUI } from '../../common/ui';
 
 jest.mock('../containers/configure/api', () => ({
   getCaseConfigure: jest.fn(),
 }));
 
-describe('createSetCustomFieldStepDefinition', () => {
+describe('setCustomFieldStepDefinition', () => {
   const getCaseConfigureMock = jest.mocked(getCaseConfigure);
 
-  const setup = () => {
+  const createSelectionContext = (owner?: Owner | string) => ({
+    stepType: 'cases.setCustomField' as const,
+    scope: 'input' as const,
+    propertyKey: 'field_name',
+    values: {
+      input: owner === undefined ? {} : { owner },
+    },
+  });
+
+  const defaultCasesConfigure: CasesConfigurationUI[] = [
+    {
+      owner: 'securitySolution',
+      customFields: [
+        {
+          key: 'priority_reason',
+          label: 'Priority reason',
+          type: 'text',
+          required: false,
+          defaultValue: null,
+        },
+        {
+          key: 'is_automated',
+          label: 'Is automated',
+          type: 'toggle',
+          required: false,
+          defaultValue: false,
+        },
+      ],
+    },
+    {
+      owner: 'observability',
+      customFields: [
+        {
+          key: 'service_name',
+          label: 'Service name',
+          type: 'text',
+          required: false,
+          defaultValue: null,
+        },
+      ],
+    },
+  ] as unknown as CasesConfigurationUI[];
+
+  const setup = (casesConfigure: CasesConfigurationUI[] = defaultCasesConfigure) => {
     interface SelectionHandler {
-      search: (input: string, context: unknown) => Promise<unknown>;
-      resolve: (value: string, context: unknown) => Promise<unknown>;
+      search: (input: string, context: unknown) => Promise<SelectionOption<string>[]>;
+      resolve: (value: string, context: unknown) => Promise<SelectionOption | null>;
       getDetails: (
         value: string,
         context: unknown,
@@ -27,39 +72,7 @@ describe('createSetCustomFieldStepDefinition', () => {
       ) => Promise<{ message: string }>;
     }
 
-    getCaseConfigureMock.mockResolvedValue([
-      {
-        owner: 'securitySolution',
-        customFields: [
-          {
-            key: 'priority_reason',
-            label: 'Priority reason',
-            type: 'text',
-            required: false,
-            defaultValue: null,
-          },
-          {
-            key: 'is_automated',
-            label: 'Is automated',
-            type: 'toggle',
-            required: false,
-            defaultValue: false,
-          },
-        ],
-      },
-      {
-        owner: 'observability',
-        customFields: [
-          {
-            key: 'service_name',
-            label: 'Service name',
-            type: 'text',
-            required: false,
-            defaultValue: null,
-          },
-        ],
-      },
-    ] as CasesConfigurationUI[]);
+    getCaseConfigureMock.mockResolvedValue(casesConfigure);
 
     const definition = setCustomFieldStepDefinition;
     const inputHandlers = (definition.editorHandlers?.input ?? {}) as Record<
@@ -84,16 +97,14 @@ describe('createSetCustomFieldStepDefinition', () => {
   it('searches and resolves custom field options using case configuration API', async () => {
     const { fieldNameSelection } = setup();
 
-    const searchResults = await fieldNameSelection!.search('priority', {
-      stepType: 'cases.setCustomField',
-      scope: 'input',
-      propertyKey: 'field_name',
-    });
-    const resolved = await fieldNameSelection!.resolve('priority_reason', {
-      stepType: 'cases.setCustomField',
-      scope: 'input',
-      propertyKey: 'field_name',
-    });
+    const searchResults = await fieldNameSelection!.search(
+      'priority',
+      createSelectionContext('securitySolution')
+    );
+    const resolved = await fieldNameSelection!.resolve(
+      'priority_reason',
+      createSelectionContext('securitySolution')
+    );
 
     expect(getCaseConfigureMock).toHaveBeenCalledTimes(2);
     expect(searchResults).toEqual([
@@ -110,15 +121,11 @@ describe('createSetCustomFieldStepDefinition', () => {
     });
   });
 
-  it('returns all owner fields for empty search query', async () => {
+  it('returns all custom fields for the owner when the search query is empty', async () => {
     const { fieldNameSelection } = setup();
 
     await expect(
-      fieldNameSelection!.search('   ', {
-        stepType: 'cases.setCustomField',
-        scope: 'input',
-        propertyKey: 'field_name',
-      })
+      fieldNameSelection!.search('   ', createSelectionContext('securitySolution'))
     ).resolves.toEqual([
       {
         value: 'priority_reason',
@@ -131,18 +138,113 @@ describe('createSetCustomFieldStepDefinition', () => {
         description: 'toggle',
       },
     ]);
+    expect(getCaseConfigureMock).toHaveBeenCalledTimes(1);
   });
 
-  it('filters custom fields by workflow owner', async () => {
+  it('returns at most 15 custom fields when the search query is empty', async () => {
+    const manyCustomFields = Array.from({ length: 16 }, (_, index) => ({
+      key: `cf_${index}`,
+      label: `Field ${index}`,
+      type: 'text' as const,
+      required: false,
+      defaultValue: null,
+    }));
+
+    const { fieldNameSelection } = setup([
+      {
+        owner: 'securitySolution',
+        customFields: manyCustomFields,
+      },
+    ] as CasesConfigurationUI[]);
+
+    const searchResults = await fieldNameSelection!.search(
+      '',
+      createSelectionContext('securitySolution')
+    );
+
+    expect(searchResults).toHaveLength(15);
+    expect(searchResults[0]).toEqual({
+      value: 'cf_0',
+      label: 'Field 0',
+      description: 'text',
+    });
+    expect(searchResults[14]).toEqual({
+      value: 'cf_14',
+      label: 'Field 14',
+      description: 'text',
+    });
+  });
+
+  it('returns no options when input owner is invalid', async () => {
     const { fieldNameSelection } = setup();
 
     await expect(
-      fieldNameSelection!.search('service', {
-        stepType: 'cases.setCustomField',
-        scope: 'input',
-        propertyKey: 'field_name',
-      })
+      fieldNameSelection!.search('priority', createSelectionContext('notAValidOwner'))
     ).resolves.toEqual([]);
+    expect(getCaseConfigureMock).not.toHaveBeenCalled();
+  });
+
+  it('returns no options when input owner is empty', async () => {
+    const { fieldNameSelection } = setup();
+
+    await expect(
+      fieldNameSelection!.search('priority', createSelectionContext(''))
+    ).resolves.toEqual([]);
+    await expect(fieldNameSelection!.search('priority', createSelectionContext())).resolves.toEqual(
+      []
+    );
+    expect(getCaseConfigureMock).not.toHaveBeenCalled();
+  });
+
+  it('does not return observability custom fields when input owner is security', async () => {
+    const { fieldNameSelection } = setup();
+
+    await expect(
+      fieldNameSelection!.search('service', createSelectionContext('securitySolution'))
+    ).resolves.toEqual([]);
+  });
+
+  it('returns security custom fields when input owner is securitySolution', async () => {
+    const { fieldNameSelection } = setup();
+
+    const searchResults = await fieldNameSelection!.search(
+      'automated',
+      createSelectionContext('securitySolution')
+    );
+
+    expect(searchResults).toEqual([
+      {
+        value: 'is_automated',
+        label: 'Is automated',
+        description: 'toggle',
+      },
+    ]);
+  });
+
+  it('returns observability custom fields when input owner is observability', async () => {
+    const { fieldNameSelection } = setup();
+
+    const searchResults = await fieldNameSelection!.search(
+      'service',
+      createSelectionContext('observability')
+    );
+    const resolved = await fieldNameSelection!.resolve(
+      'service_name',
+      createSelectionContext('observability')
+    );
+
+    expect(searchResults).toEqual([
+      {
+        value: 'service_name',
+        label: 'Service name',
+        description: 'text',
+      },
+    ]);
+    expect(resolved).toEqual({
+      value: 'service_name',
+      label: 'Service name',
+      description: 'text',
+    });
   });
 
   it('returns details message for resolved and unresolved custom field values', async () => {
@@ -169,15 +271,11 @@ describe('createSetCustomFieldStepDefinition', () => {
     getCaseConfigureMock.mockRejectedValueOnce(error);
 
     await expect(
-      fieldNameSelection!.search('priority', {
-        stepType: 'cases.setCustomField',
-        scope: 'input',
-        propertyKey: 'field_name',
-      })
+      fieldNameSelection!.search('priority', createSelectionContext('securitySolution'))
     ).rejects.toThrow(error.message);
   });
 
-  beforeEach(() => {
+  afterEach(() => {
     getCaseConfigureMock.mockReset();
   });
 });

--- a/x-pack/platform/plugins/shared/cases/public/workflows/set_custom_field.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/workflows/set_custom_field.tsx
@@ -11,6 +11,7 @@ import { setCustomFieldStepCommonDefinition } from '../../common/workflows/steps
 import type { Owner } from '../../common/bundled-types.gen';
 import type { CasesConfigurationUICustomField } from '../../common/ui';
 import * as i18n from '../../common/workflows/translations';
+import { collectSelectionSearchOptions } from './selection_search';
 import { createPublicCaseStepDefinition } from './shared';
 import { isValidOwner } from '../../common/utils/owner';
 
@@ -21,8 +22,6 @@ const toSelectionOption = (
   label: customField.label,
   description: customField.type,
 });
-
-const MAX_CUSTOM_FIELDS_FOR_SELECTION = 15;
 
 const getCustomFieldsForWorkflowOwner = async (owner: Owner) => {
   const configurations = (await getCaseConfigure({})) ?? [];
@@ -48,21 +47,18 @@ export const setCustomFieldStepDefinition = createPublicCaseStepDefinition({
             const query = input.trim().toLowerCase();
             const customFields = await getCustomFieldsForWorkflowOwner(owner);
 
-            const options: SelectionOption<string>[] = [];
-            const fieldLimit = Math.min(customFields.length, MAX_CUSTOM_FIELDS_FOR_SELECTION);
             const queryIsEmpty = query.length === 0;
 
-            for (let i = 0; i < fieldLimit; i++) {
-              const customField = customFields[i];
-              const fieldKey = customField.key.toLowerCase();
-              const fieldLabel = customField.label.toLowerCase();
-
-              if (queryIsEmpty || fieldKey.includes(query) || fieldLabel.includes(query)) {
-                options.push(toSelectionOption(customField));
-              }
-            }
-
-            return options;
+            return collectSelectionSearchOptions({
+              items: customFields,
+              hasEmptyQuery: queryIsEmpty,
+              matchesQuery: (customField) => {
+                const fieldKey = customField.key.toLowerCase();
+                const fieldLabel = customField.label.toLowerCase();
+                return fieldKey.includes(query) || fieldLabel.includes(query);
+              },
+              toOption: (customField) => toSelectionOption(customField),
+            });
           },
           resolve: async (value, ctx) => {
             const owner = ctx.values.input.owner;

--- a/x-pack/platform/plugins/shared/cases/public/workflows/set_custom_field.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/workflows/set_custom_field.tsx
@@ -8,11 +8,11 @@
 import type { SelectionOption } from '@kbn/workflows/types/latest';
 import { getCaseConfigure } from '../containers/configure/api';
 import { setCustomFieldStepCommonDefinition } from '../../common/workflows/steps/set_custom_field';
+import type { Owner } from '../../common/bundled-types.gen';
 import type { CasesConfigurationUICustomField } from '../../common/ui';
 import * as i18n from '../../common/workflows/translations';
 import { createPublicCaseStepDefinition } from './shared';
-
-const WORKFLOW_CASE_OWNER = 'securitySolution';
+import { isValidOwner } from '../../common/utils/owner';
 
 const toSelectionOption = (
   customField: CasesConfigurationUICustomField
@@ -22,11 +22,13 @@ const toSelectionOption = (
   description: customField.type,
 });
 
-const getCustomFieldsForWorkflowOwner = async () => {
+const MAX_CUSTOM_FIELDS_FOR_SELECTION = 15;
+
+const getCustomFieldsForWorkflowOwner = async (owner: Owner) => {
   const configurations = (await getCaseConfigure({})) ?? [];
 
   return configurations
-    .filter((configuration) => configuration.owner === WORKFLOW_CASE_OWNER)
+    .filter((configuration) => configuration.owner === owner)
     .flatMap((configuration) => configuration.customFields ?? []);
 };
 
@@ -36,23 +38,39 @@ export const setCustomFieldStepDefinition = createPublicCaseStepDefinition({
     input: {
       field_name: {
         selection: {
-          search: async (input) => {
-            const customFields = await getCustomFieldsForWorkflowOwner();
-            const query = input.trim().toLowerCase();
+          dependsOnValues: ['input.owner'],
+          search: async (input, ctx) => {
+            const owner = ctx.values.input.owner;
+            if (!isValidOwner(owner)) {
+              return [];
+            }
 
-            return customFields.reduce<SelectionOption<string>[]>((acc, customField) => {
+            const query = input.trim().toLowerCase();
+            const customFields = await getCustomFieldsForWorkflowOwner(owner);
+
+            const options: SelectionOption<string>[] = [];
+            const fieldLimit = Math.min(customFields.length, MAX_CUSTOM_FIELDS_FOR_SELECTION);
+            const queryIsEmpty = query.length === 0;
+
+            for (let i = 0; i < fieldLimit; i++) {
+              const customField = customFields[i];
               const fieldKey = customField.key.toLowerCase();
               const fieldLabel = customField.label.toLowerCase();
 
-              if (!query || fieldKey.includes(query) || fieldLabel.includes(query)) {
-                acc.push(toSelectionOption(customField));
+              if (queryIsEmpty || fieldKey.includes(query) || fieldLabel.includes(query)) {
+                options.push(toSelectionOption(customField));
               }
+            }
 
-              return acc;
-            }, []);
+            return options;
           },
-          resolve: async (value) => {
-            const customFields = await getCustomFieldsForWorkflowOwner();
+          resolve: async (value, ctx) => {
+            const owner = ctx.values.input.owner;
+            if (!isValidOwner(owner)) {
+              return null;
+            }
+
+            const customFields = await getCustomFieldsForWorkflowOwner(owner);
             const customField = customFields.find((currentField) => currentField.key === value);
 
             if (!customField) {

--- a/x-pack/platform/plugins/shared/cases/public/workflows/simple_steps.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/workflows/simple_steps.test.tsx
@@ -21,7 +21,6 @@ import {
   getAllAttachmentsStepDefinition,
   getCasesByAlertIdStepDefinition,
   getCasesStepDefinition,
-  setCategoryStepDefinition,
   setDescriptionStepDefinition,
   setSeverityStepDefinition,
   setStatusStepDefinition,
@@ -29,6 +28,7 @@ import {
   unassignCaseStepDefinition,
   updateObservableStepDefinition,
 } from './simple_steps';
+import { setCategoryStepDefinition } from './set_category';
 
 describe('new cases public step definitions', () => {
   const steps = [

--- a/x-pack/platform/plugins/shared/cases/public/workflows/simple_steps.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/workflows/simple_steps.tsx
@@ -20,7 +20,6 @@ import { getAllAttachmentsStepCommonDefinition } from '../../common/workflows/st
 import { getCaseStepCommonDefinition } from '../../common/workflows/steps/get_case';
 import { getCasesByAlertIdStepCommonDefinition } from '../../common/workflows/steps/get_cases_by_alert_id';
 import { getCasesStepCommonDefinition } from '../../common/workflows/steps/get_cases';
-import { setCategoryStepCommonDefinition } from '../../common/workflows/steps/set_category';
 import { setDescriptionStepCommonDefinition } from '../../common/workflows/steps/set_description';
 import { setSeverityStepCommonDefinition } from '../../common/workflows/steps/set_severity';
 import { setStatusStepCommonDefinition } from '../../common/workflows/steps/set_status';
@@ -73,10 +72,6 @@ export const findSimilarCasesStepDefinition = createPublicCaseStepDefinition({
 
 export const getCaseStepDefinition = createPublicCaseStepDefinition({
   ...getCaseStepCommonDefinition,
-});
-
-export const setCategoryStepDefinition = createPublicCaseStepDefinition({
-  ...setCategoryStepCommonDefinition,
 });
 
 export const setDescriptionStepDefinition = createPublicCaseStepDefinition({

--- a/x-pack/platform/plugins/shared/cases/server/workflows/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/workflows/index.ts
@@ -11,7 +11,7 @@ import type { CasesClient } from '../client';
 
 import { getCaseStepDefinition } from './steps/get_case';
 import { createCaseStepDefinition } from './steps/create_case';
-// import { createCaseFromTemplateStepDefinition } from './steps/create_case_from_template';
+import { createCaseFromTemplateStepDefinition } from './steps/create_case_from_template';
 import { updateCaseStepDefinition } from './steps/update_case';
 import { updateCasesStepDefinition } from './steps/update_cases';
 import { addCommentStepDefinition } from './steps/add_comment';
@@ -27,6 +27,7 @@ import { getCasesByAlertIdStepDefinition } from './steps/get_cases_by_alert_id';
 import { getAllAttachmentsStepDefinition } from './steps/get_all_attachments';
 import { updateObservableStepDefinition } from './steps/update_observable';
 import { deleteObservableStepDefinition } from './steps/delete_observable';
+import { setCustomFieldStepDefinition } from './steps/set_custom_field';
 import { getCasesStepDefinition } from './steps/get_cases';
 import {
   assignCaseStepDefinition,
@@ -48,9 +49,8 @@ export function registerCaseWorkflowSteps(
 
   workflowsExtensions.registerStepDefinition(getCaseStepDefinition(getCasesClient));
   workflowsExtensions.registerStepDefinition(createCaseStepDefinition(getCasesClient));
-  // TODO: enable once https://github.com/elastic/security-team/issues/15982 has been resolved
-  // workflowsExtensions.registerStepDefinition(createCaseFromTemplateStepDefinition(getCasesClient));
-  // workflowsExtensions.registerStepDefinition(setCustomFieldStepDefinition(getCasesClient));
+  workflowsExtensions.registerStepDefinition(createCaseFromTemplateStepDefinition(getCasesClient));
+  workflowsExtensions.registerStepDefinition(setCustomFieldStepDefinition(getCasesClient));
   workflowsExtensions.registerStepDefinition(updateCaseStepDefinition(getCasesClient));
   workflowsExtensions.registerStepDefinition(updateCasesStepDefinition(getCasesClient));
   workflowsExtensions.registerStepDefinition(addCommentStepDefinition(getCasesClient));

--- a/x-pack/platform/plugins/shared/cases/server/workflows/steps/create_case_from_template.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/workflows/steps/create_case_from_template.test.ts
@@ -22,6 +22,7 @@ describe('createCaseFromTemplateStepDefinition', () => {
     expect(typeof definition.handler).toBe('function');
     expect(
       definition.inputSchema.safeParse({
+        owner: 'securitySolution',
         case_template_id: 'triage_template',
       }).success
     ).toBe(true);

--- a/x-pack/platform/plugins/shared/cases/server/workflows/steps/set_custom_field.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/workflows/steps/set_custom_field.test.ts
@@ -16,6 +16,7 @@ const createContext = (input: unknown, config: Record<string, unknown> = {}) =>
 describe('setCustomFieldStepDefinition', () => {
   const input = {
     case_id: 'case-1',
+    owner: 'securitySolution',
     field_name: 'first_key',
     value: 'updated value',
   };


### PR DESCRIPTION
## Summary

Fixes: https://github.com/elastic/security-team/issues/16397

The workflows team has fixed the issue where we would not get access to the user's input. This allows us to re-enable the `cases.setCustomField` and `cases.createCaseFromTemplate` workflow steps. This PR also updates `cases.setCategory` with a similar autocompletion helper. However, the validation for that one is not necessary.

Sadly we cannot provide autocompletion for `assignees` and `tags` just yet since the autocompletion does not work for arrays.

### Testing

Set up a custom field and a case template in your preferred solution and set them up with this workflow. The template and the custom field should be autocompleted as long as `owner` is specified.

```yaml
name: New workflow
enabled: false
description: This is a new workflow
triggers:
  - type: manual

steps:
  - name: create
    type: cases.createCaseFromTemplate
    with:
      owner: securitySolution
      case_template_id:
      overwrites:
        description: Test
  - name: set_custom_field
    type: cases.setCustomField
    with:
      case_id: "${{steps.create.output.case.id}}"
      owner: securitySolution
      field_name:
      value: 2
  - name: set_cat
    type: cases.setCategory
    with:
      case_id: "${{steps.create.output.case.id}}"
      category: test
```

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->