### PR TITLE
[synthetics/ftr] cache package install + share private location

### DIFF
--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/create_monitor_public_api_private_location.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/create_monitor_public_api_private_location.ts
@@ -31,7 +31,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
     before(async () => {
       await kibanaServer.savedObjects.cleanStandardList();
       editorUser = await samlAuth.createM2mApiKeyWithRoleScope('editor');
-      privateLocation = await privateLocationTestService.addTestPrivateLocation();
+      privateLocation = await privateLocationTestService.getSharedPrivateLocation();
     });
 
     after(async () => {

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/enable_default_alerting.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/enable_default_alerting.ts
@@ -47,7 +47,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
       await kibanaServer.savedObjects.cleanStandardList();
       _httpMonitorJson = getFixtureJson('http_monitor');
       editorUser = await samlAuth.createM2mApiKeyWithRoleScope('editor');
-      await privateLocationTestService.installSyntheticsPackage();
+      privateLocation = await privateLocationTestService.getSharedPrivateLocation();
       await alerting.createIndexConnector({
         roleAuthc: editorUser,
         name: TEST_INDEX_CONNECTOR_NAME,
@@ -59,7 +59,6 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
       await kibanaServer.savedObjects.clean({
         types: ['synthetics-monitor-multi-space'],
       });
-      privateLocation = await privateLocationTestService.addTestPrivateLocation();
       httpMonitorJson = {
         ..._httpMonitorJson,
         locations: [privateLocation],

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/get_monitor.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/get_monitor.ts
@@ -58,9 +58,8 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
       await retry.try(async () => {
         await kibanaServer.savedObjects.cleanStandardList();
       });
-      await privateLocationTestService.installSyntheticsPackage();
       editorUser = await samlAuth.createM2mApiKeyWithRoleScope('editor');
-      privateLocation = await privateLocationTestService.addTestPrivateLocation();
+      privateLocation = await privateLocationTestService.getSharedPrivateLocation();
       await supertest
         .put(SYNTHETICS_API_URLS.SYNTHETICS_ENABLEMENT)
         .set(editorUser.apiKeyHeader)

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/index.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/index.ts
@@ -6,9 +6,20 @@
  */
 
 import type { DeploymentAgnosticFtrProviderContext } from '../../ftr_provider_context';
+import { PrivateLocationTestService } from '../../services/synthetics_private_location';
 
-export default function ({ loadTestFile }: DeploymentAgnosticFtrProviderContext) {
+export default function ({ getService, loadTestFile }: DeploymentAgnosticFtrProviderContext) {
   describe('SyntheticsAPITests', () => {
+    before(async () => {
+      // Install the synthetics Fleet package once for the whole suite.
+      // Individual files that still call `installSyntheticsPackage()` in
+      // their own `before` hooks are no-ops after this (the service caches
+      // the resolved version); we keep those calls for now so tests remain
+      // runnable in isolation via --grep.
+      const privateLocationService = new PrivateLocationTestService(getService);
+      await privateLocationService.installSyntheticsPackage();
+    });
+
     loadTestFile(require.resolve('./legacy_and_multispace_monitor_api'));
     loadTestFile(require.resolve('./create_monitor_private_location'));
     loadTestFile(require.resolve('./create_monitor_project_private_location'));

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/reset_monitor_bulk.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/reset_monitor_bulk.ts
@@ -82,11 +82,9 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
 
     before(async () => {
       await kibanaServer.savedObjects.cleanStandardList();
-      await testPrivateLocations.installSyntheticsPackage();
-      const testPolicyName = 'Fleet test server policy' + Date.now();
-      const apiResponse = await testPrivateLocations.addFleetPolicy(testPolicyName);
-      testPolicyId = apiResponse.body.item.id;
-      privateLocations = await testPrivateLocations.setTestLocations([testPolicyId]);
+      const sharedLocation = await testPrivateLocations.getSharedPrivateLocation();
+      testPolicyId = sharedLocation.id;
+      privateLocations = [sharedLocation];
       editorUser = await samlAuth.createM2mApiKeyWithRoleScope('editor');
 
       _httpMonitorJson = getFixtureJson('http_monitor');

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/services/synthetics_private_location.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/services/synthetics_private_location.ts
@@ -8,12 +8,24 @@ import { v4 as uuidv4 } from 'uuid';
 import type { RetryService } from '@kbn/ftr-common-functional-services';
 import { X_ELASTIC_INTERNAL_ORIGIN_REQUEST } from '@kbn/core-http-common';
 import { privateLocationSavedObjectName } from '@kbn/synthetics-plugin/common/saved_objects/private_locations';
-import type { SyntheticsPrivateLocations } from '@kbn/synthetics-plugin/common/runtime_types';
+import type {
+  PrivateLocation,
+  SyntheticsPrivateLocations,
+} from '@kbn/synthetics-plugin/common/runtime_types';
 import type { KibanaSupertestProvider } from '@kbn/ftr-common-functional-services';
 import type { PackagePolicy } from '@kbn/fleet-plugin/common';
 import type { DeploymentAgnosticFtrProviderContext } from '../ftr_provider_context';
 
 export const DEFAULT_SYNTHETICS_VERSION = '1.5.0';
+
+// Module-level caches shared across test files in the same FTR run.
+// FTR spins up a single Kibana/ES stack per config, so these reflect the
+// live Kibana state for the whole test run. Callers that mutate the
+// synthetics package install or the shared private location MUST invalidate
+// the corresponding cache (see `resetInstalledVersionCache` /
+// `resetSharedPrivateLocation`) so later files don't pick up stale state.
+let cachedInstalledVersion: string | null = null;
+let cachedSharedPrivateLocation: PrivateLocation | null = null;
 
 export class PrivateLocationTestService {
   private supertestWithAuth: ReturnType<typeof KibanaSupertestProvider>;
@@ -33,7 +45,21 @@ export class PrivateLocationTestService {
     return res.body?.item?.version ?? DEFAULT_SYNTHETICS_VERSION;
   }
 
+  /**
+   * Installs (or reinstalls) the synthetics Fleet package.
+   *
+   * Idempotent across test files within a single FTR run: if the package is
+   * already installed at the resolved version, subsequent calls short-circuit.
+   * Tests that need to force a reinstall (e.g. to pin a specific prior
+   * version) should pass `{ version }`; the cache is updated to match.
+   */
   async installSyntheticsPackage({ version }: { version?: string } = {}) {
+    const resolvedVersion = version ?? (await this.fetchSyntheticsPackageVersion());
+
+    if (cachedInstalledVersion === resolvedVersion) {
+      return;
+    }
+
     await this.retry.try(async () => {
       await this.supertestWithAuth
         .post('/api/fleet/setup')
@@ -41,7 +67,7 @@ export class PrivateLocationTestService {
         .send()
         .expect(200);
     });
-    const resolvedVersion = version ?? (await this.fetchSyntheticsPackageVersion());
+
     await this.retry.try(async () => {
       await this.supertestWithAuth
         .delete(`/api/fleet/epm/packages/synthetics`)
@@ -60,6 +86,50 @@ export class PrivateLocationTestService {
         );
       }
     });
+
+    cachedInstalledVersion = resolvedVersion;
+  }
+
+  /**
+   * Force the next `installSyntheticsPackage()` call to reinstall regardless
+   * of what's cached. Use only when a test has modified the install out of
+   * band in a way the cache can't detect.
+   */
+  resetInstalledVersionCache() {
+    cachedInstalledVersion = null;
+  }
+
+  /**
+   * Returns a private location in the `default` space that is shared across
+   * test files. The first call creates the Fleet agent policy and the
+   * private-location saved object; subsequent calls in the same FTR run
+   * reuse them, saving the per-file `addFleetPolicy` + `setTestLocations`
+   * round-trips.
+   *
+   * Only use this helper in tests that treat the private location as
+   * read-only (attaching monitors to it). Tests that delete or mutate the
+   * location itself must call `addTestPrivateLocation()` to get an isolated
+   * one, or call `resetSharedPrivateLocation()` in their teardown.
+   */
+  async getSharedPrivateLocation(): Promise<PrivateLocation> {
+    if (cachedSharedPrivateLocation) {
+      return cachedSharedPrivateLocation;
+    }
+    await this.installSyntheticsPackage();
+    const apiResponse = await this.addFleetPolicy('synthetics-shared-private-location');
+    const testPolicyId = apiResponse.body.item.id;
+    const [location] = await this.setTestLocations([testPolicyId]);
+    cachedSharedPrivateLocation = location;
+    return location;
+  }
+
+  /**
+   * Invalidate the shared-private-location cache. Callers should invoke this
+   * when they knowingly delete or mutate the shared location so that later
+   * tests recreate it.
+   */
+  resetSharedPrivateLocation() {
+    cachedSharedPrivateLocation = null;
   }
 
   async addTestPrivateLocation(spaceId = 'default') {


### PR DESCRIPTION
## Summary

Reduces the runtime of `oblt.synthetics.serverless.config.ts` (the deployment-agnostic synthetics API integration tests) by cutting redundant Fleet package installs and Fleet agent-policy / private-location creations. No tests are moved — this is purely a fixture-caching change.

Scout migration of this same config is ongoing under #263963; this PR is the FTR-side optimisation split out from that work so each change is reviewable on its own.

## Why

`oblt.synthetics.serverless.config.ts` has been sitting on the `test-group-too-long:Functional Tests` Buildkite annotation for weeks (~27–28 min, flagged in 9/20 recent on-merge builds). Breakdown of a recent job log:

| Phase | Wall-clock |
|---|---|
| Pre-mocha bootstrap (agent + ES/Kibana boot + SO migration) | ~5.8 min |
| Mocha tests (31 files) | ~21.1 min |

Of the mocha runtime, ~50% is fixture overhead:
- **22 of 31 files** call `installSyntheticsPackage()` in their `before` hook. Each call is 3 Fleet round-trips (`POST /fleet/setup`, `DELETE synthetics package`, `POST synthetics package` with `force: true`) plus a version verification — realistically **8–15s on a warm stack**, so ~3–4 min across the suite just repeating identical work.
- Many files also create a fresh Fleet agent policy + private-location saved object per file even when the tests only need *any* location to attach monitors to.

## Changes

### `services/synthetics_private_location.ts`

- **`installSyntheticsPackage()` is now idempotent**. A module-level `cachedInstalledVersion` is checked up front: if the resolved target version matches, the call short-circuits. Tests that intentionally reinstall at a different version (e.g. `create_monitor_private_location` pinning a lower version) still trigger a real install and update the cache.
- New **`getSharedPrivateLocation()`**: memoises one default-space private location across test files. Only intended for tests that treat the location as read-only (attaching monitors to it). Tests that mutate or delete the location should keep calling `addTestPrivateLocation()` or invoke `resetSharedPrivateLocation()` in their teardown.
- Added `resetInstalledVersionCache()` / `resetSharedPrivateLocation()` escape hatches.

### `apis/synthetics/index.ts`

Adds a top-level `before` hook that calls `installSyntheticsPackage()` once. Files that still call it in their own `before` hooks become no-ops after the first, and remain runnable in isolation via `--grep`.

### 4 FTR specs refactored to use `getSharedPrivateLocation()`

- `get_monitor.ts`
- `create_monitor_public_api_private_location.ts`
- `enable_default_alerting.ts` — `beforeEach` `addTestPrivateLocation` → `before` with shared (the `beforeEach` only cleaned monitor SOs, not the location, so the recreate-per-test pattern wasn't load-bearing).
- `reset_monitor_bulk.ts` — the test uses the location's `id` as the fleet policy id in assertions, which matches how `setTestLocations` constructs the location.

## Expected impact

Conservatively:

| Change | Estimated savings |
|---|---:|
| Idempotent `installSyntheticsPackage` (21 redundant calls × ~10s) | ~3–4 min |
| Shared private location in 4 refactored files (~1–2s × 4) | ~0.5 min |

Enough to take this config below the 27-minute warning threshold on most builds, without moving any tests. Additional savings will come as more files adopt `getSharedPrivateLocation()` and as files migrate to Scout.

## Test plan

- [ ] Full run of the config:
  ```
  node scripts/functional_tests --config \
    x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.synthetics.serverless.config.ts
  ```
- [ ] CI confirms the config still passes and ideally drops off the `test-group-too-long` annotation.
- [ ] Any follow-up Scout migration PRs rebase cleanly on top of this.

Related: Scout migration in #263963.

Made with [Cursor](https://cursor.com)