### PR TITLE
[affected-packages] skip downstream test expansion for scout test-only changes

### DIFF
--- a/.buildkite/pipeline-utils/affected-packages/module_lookup.test.ts
+++ b/.buildkite/pipeline-utils/affected-packages/module_lookup.test.ts
@@ -547,6 +547,90 @@ describe('module_lookup', () => {
     });
   });
 
+  describe('getAffectedModulesGit – scout test-only changes skip downstream', () => {
+    function addScoutTestFile(
+      root: string,
+      moduleRelDir: string,
+      scoutDir: string,
+      fileName: string
+    ): void {
+      const dir = path.join(root, moduleRelDir, 'test', scoutDir);
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(path.join(dir, fileName), `// test ${fileName}\n`);
+    }
+
+    it('does not expand downstream when only test/scout/ files change', () => {
+      addScoutTestFile(tmpDir, 'packages/core', 'scout', 'core.spec.ts');
+      commitAll(tmpDir, 'add scout test in core');
+
+      const affected = getAffectedModulesGit({ mergeBase: baseCommit, includeDownstream: true });
+      expect(affected).toEqual(new Set(['@kbn/core']));
+    });
+
+    it('does not expand downstream when only test/scout_custom_flag/ files change', () => {
+      addScoutTestFile(tmpDir, 'packages/core', 'scout_custom_flag', 'core.spec.ts');
+      commitAll(tmpDir, 'add scout_custom_flag test in core');
+
+      const affected = getAffectedModulesGit({ mergeBase: baseCommit, includeDownstream: true });
+      expect(affected).toEqual(new Set(['@kbn/core']));
+    });
+
+    it('expands downstream when module has both code and test/scout changes', () => {
+      modifyFile(tmpDir, 'packages/core/src/index.ts', 'export const v2 = true;\n');
+      addScoutTestFile(tmpDir, 'packages/core', 'scout', 'core.spec.ts');
+      commitAll(tmpDir, 'code + scout test in core');
+
+      const affected = getAffectedModulesGit({ mergeBase: baseCommit, includeDownstream: true });
+      expect(affected).toEqual(
+        new Set(['@kbn/core', '@kbn/utils', '@kbn/my-plugin', '@kbn/analytics'])
+      );
+    });
+
+    it('handles mixed: code change in A + test-only in B', () => {
+      modifyFile(tmpDir, 'packages/core/src/index.ts', 'export const v2 = true;\n');
+      addScoutTestFile(tmpDir, 'packages/logging', 'scout', 'logging.spec.ts');
+      commitAll(tmpDir, 'code in core, test in logging');
+
+      const affected = getAffectedModulesGit({ mergeBase: baseCommit, includeDownstream: true });
+      // core expands downstream; logging does not (test-only)
+      expect(affected).toContain('@kbn/core');
+      expect(affected).toContain('@kbn/utils');
+      expect(affected).toContain('@kbn/my-plugin');
+      expect(affected).toContain('@kbn/analytics');
+      expect(affected).toContain('@kbn/logging');
+      expect(affected.size).toBe(5);
+    });
+
+    it('test-only changes in multiple modules: no downstream for any', () => {
+      addScoutTestFile(tmpDir, 'packages/core', 'scout', 'core.spec.ts');
+      addScoutTestFile(tmpDir, 'packages/logging', 'scout', 'logging.spec.ts');
+      commitAll(tmpDir, 'test-only in core and logging');
+
+      const affected = getAffectedModulesGit({ mergeBase: baseCommit, includeDownstream: true });
+      expect(affected).toEqual(new Set(['@kbn/core', '@kbn/logging']));
+    });
+
+    it('returns test-only modules without downstream when includeDownstream is false', () => {
+      addScoutTestFile(tmpDir, 'packages/core', 'scout', 'core.spec.ts');
+      commitAll(tmpDir, 'add scout test in core');
+
+      const affected = getAffectedModulesGit({ mergeBase: baseCommit, includeDownstream: false });
+      expect(affected).toEqual(new Set(['@kbn/core']));
+    });
+
+    it('non-scout test paths still trigger downstream', () => {
+      const dir = path.join(tmpDir, 'packages', 'core', 'test', 'unit');
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(path.join(dir, 'core.test.ts'), '// unit test\n');
+      commitAll(tmpDir, 'add non-scout test in core');
+
+      const affected = getAffectedModulesGit({ mergeBase: baseCommit, includeDownstream: true });
+      expect(affected).toEqual(
+        new Set(['@kbn/core', '@kbn/utils', '@kbn/my-plugin', '@kbn/analytics'])
+      );
+    });
+  });
+
   describe('getAffectedModulesGit – ignorePatterns', () => {
     it('excludes files matching a single glob pattern', () => {
       addFileInModule(tmpDir, 'packages/core', 'feature.ts');

--- a/.buildkite/pipeline-utils/affected-packages/strategy_git.ts
+++ b/.buildkite/pipeline-utils/affected-packages/strategy_git.ts
@@ -15,6 +15,8 @@ import { filterIgnoredFiles } from './utils';
 
 const isCI = !!process.env.CI?.match(/^(1|true)$/i);
 
+const SCOUT_TEST_MARKER = '/test/scout';
+
 export function getAffectedModulesGit({
   mergeBase,
   includeDownstream,
@@ -32,19 +34,47 @@ export function getAffectedModulesGit({
 
   const changedFiles = filterIgnoredFiles(allChangedFiles, ignorePatterns);
 
-  const directlyAffected = new Set<string>();
+  const codeChangedModules = new Set<string>();
+  const scoutTestOnlyModules = new Set<string>();
+
+  // Pass 1: process non-scout files to populate codeChangedModules
+  const deferredScoutFiles: string[] = [];
+
   for (const file of changedFiles) {
+    if (file.includes(SCOUT_TEST_MARKER)) {
+      deferredScoutFiles.push(file);
+      continue;
+    }
     const moduleId = findModuleForPath(file);
     if (moduleId) {
-      directlyAffected.add(moduleId);
+      codeChangedModules.add(moduleId);
     }
   }
 
-  if (ignoreUncategorizedChanges) {
-    directlyAffected.delete(UNCATEGORIZED_MODULE_ID);
+  // Pass 2: scout-test files — skip findModuleForPath when module is already code-changed
+  for (const file of deferredScoutFiles) {
+    const moduleId = findModuleForPath(file);
+    if (!moduleId || codeChangedModules.has(moduleId)) continue;
+    scoutTestOnlyModules.add(moduleId);
   }
 
-  return includeDownstream ? getDownstreamDependents(directlyAffected) : directlyAffected;
+  if (ignoreUncategorizedChanges) {
+    codeChangedModules.delete(UNCATEGORIZED_MODULE_ID);
+    scoutTestOnlyModules.delete(UNCATEGORIZED_MODULE_ID);
+  }
+
+  if (!includeDownstream) {
+    for (const id of scoutTestOnlyModules) {
+      codeChangedModules.add(id);
+    }
+    return codeChangedModules;
+  }
+
+  const expanded = getDownstreamDependents(codeChangedModules);
+  for (const id of scoutTestOnlyModules) {
+    expanded.add(id);
+  }
+  return expanded;
 }
 
 /** Paths changed from `git merge-base mergeBase HEAD` to `commit` (plus local untracked when not CI). */


### PR DESCRIPTION
## Summary

When all changed files in a module are under `test/scout*`, that module's tests still run but its downstream dependents are not triggered. This avoids running unrelated tests when only test files were modified — test files are never imported by dependent modules.

### How it works: 

The affected module resolution in `strategy_git.ts` now uses a two-pass approach:

1. Non-scout files are processed first, building a `codeChangedModules` set.
2. Scout test files are processed second, building a `scoutTestOnlyModules` set (skipping modules already known to have code changes).
3. Only `codeChangedModules` triggers downstream dependency expansion. `scoutTestOnlyModules` is added to the final result directly, without pulling in dependents.

If a module has **both** code and test changes, it is treated as a **code change** and downstream expansion applies as before.


