### PR TITLE
[9.4] [One Workflow] Fix custom property selection cache (#263304)

### DIFF
--- a/examples/workflows_extensions_example/public/step_types/external_step.ts
+++ b/examples/workflows_extensions_example/public/step_types/external_step.ts
@@ -22,6 +22,7 @@ export const getExternalStepDefinition = (deps: { externalService: IExampleExter
       config: {
         'proxy.id': {
           selection: {
+            dependsOnValues: ['config.proxy.ssl'],
             search: async (input, context) => {
               const proxies = await deps.externalService.getProxies();
               const inputTrimmed = input.trim();

--- a/src/platform/packages/shared/kbn-workflows/types/v1.ts
+++ b/src/platform/packages/shared/kbn-workflows/types/v1.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { JsonValue } from '@kbn/utility-types';
+import type { JsonValue, RecursivePartial } from '@kbn/utility-types';
 import { z } from '@kbn/zod/v4';
 import type { SerializedError, WorkflowYaml } from '../spec/schema';
 import { WorkflowSchema } from '../spec/schema';
@@ -522,11 +522,17 @@ export interface StepPropertyHandler<
   connectorIdSelection?: ConnectorIdSelectionHandler;
 }
 
+type DependsOnValuePath = `config.${string}` | `input.${string}`;
 export interface PropertySelectionHandler<
   T = unknown,
   TConfig extends Record<string, unknown> = Record<string, unknown>,
   TInput extends Record<string, unknown> = Record<string, unknown>
 > {
+  /**
+   * Dot paths (e.g. `config.proxy.ssl`, `input.owner`) whose values are passed in `context.values`
+   * and included in the selection cache key. If omitted or empty, `context.values` is `{ config: {}, input: {} }`.
+   */
+  dependsOnValues?: DependsOnValuePath[];
   /**
    * Search for options matching the input query.
    * Used by autocomplete dropdowns when the user types.
@@ -593,9 +599,9 @@ export interface StepSelectionValues<
   TInput extends Record<string, unknown> = Record<string, unknown>
 > {
   /** Root-level step properties (everything outside the `with` block). */
-  config: TConfig;
+  config: RecursivePartial<TConfig>;
   /** Properties nested under the `with` block. */
-  input: TInput;
+  input: RecursivePartial<TInput>;
 }
 
 export interface SelectionContext<
@@ -608,7 +614,7 @@ export interface SelectionContext<
   scope: 'config' | 'input';
   /** The property key (e.g., "agent_id") */
   propertyKey: string;
-  /** Sibling values of the current step, keyed by scope. */
+  /** Sibling values of the current step, keyed by scope (only paths listed in `dependsOnValues` are populated). */
   values: StepSelectionValues<TConfig, TInput>;
 }
 

--- a/src/platform/plugins/shared/workflows_extensions/dev_docs/STEPS.md
+++ b/src/platform/plugins/shared/workflows_extensions/dev_docs/STEPS.md
@@ -441,14 +441,15 @@ interface SelectionContext {
   scope: 'config' | 'input';
   /** The property key (e.g., "agent-id") */
   propertyKey: string;
-  /** Sibling values of the current step, keyed by scope. */
+  /** Sibling values of the current step, keyed by scope (see `dependsOnValues` below). */
   values: StepSelectionValues;
 }
 ```
 
-`context.values` gives handlers access to the current step's other property values.
-For example, if the YAML step has `with: { owner: securitySolution }`, the handler
-can read `context.values.input.owner`. Missing properties are `undefined`.
+**`dependsOnValues` (optional on `selection`):** Declare dot paths such as `config.proxy.ssl` or `input.owner` when your handlers need other fields from the step definition. The editor then passes only those paths in `context.values` (and uses them for cache keys). If omitted, `context.values` is `{ config: {}, input: {} }` and handlers should not rely on sibling fields unless you list them here.
+
+`context.values` gives handlers access to the requested sibling property values.
+For example, if you set `dependsOnValues: ['input.owner']` and the YAML step has `with: { owner: securitySolution }`, the handler can read `context.values.input.owner`. Missing properties are `undefined`.
 
 #### Example Implementation
 
@@ -457,13 +458,28 @@ For a complete working example, see the `external_step` implementation in `examp
 - Common definition: `examples/workflows_extensions_example/common/step_types/external_step.ts`
 - Public definition with `editorHandlers`: `examples/workflows_extensions_example/public/step_types/external_step.ts`
 
-#### Performance Considerations
+#### Performance considerations: editor caching
 
-The selection interface includes built-in caching for resolved entities to optimize performance:
+The workflows YAML editor uses two in-memory layers to reduce duplicate work while typing. **Search result lists** are keyed by step type, property scope, property key, and a fingerprint of **`context.values`** (from `dependsOnValues`, or empty when none are declared). The list is reused until replaced (no time-based expiry). **Custom-property validation** additionally keeps a **~30s TTL** cache of the combined **`resolve` + `getDetails`** outcome per logical field (step instance id, step type, scope, property key, scalar value, and the same `context.values` fingerprint). That way, changing unrelated YAML elsewhere does not re-run handlers for unchanged fields, and stale “not found” states do not linger forever.
 
-- Resolved entities are cached for 30 seconds to avoid redundant API calls
-- The `resolve` function is only called when needed (on load, paste, or when validation is triggered), and if the value is valid against the schema.
-- The `search` function is called lazily when the user triggers autocomplete
+**`search`**
+
+- After `search` returns, its options are stored under the search cache key above so the same completion list and per-option metadata can be reused.
+- If you use **`dependsOnValues`**, only those sibling fields are included in `context.values` and in the cache key—so unrelated edits elsewhere in the step do not force a new search for cache purposes.
+
+**`resolve`**
+
+- When validation needs to turn a stored value into a `SelectionOption`, it first looks up that value in the **cached search options list** for the same step type, scope, property key, and `context.values` fingerprint (if the user recently opened completions, the option may already be there).
+- **`resolve` runs only when** there is no matching option in that list. It is not invoked on every keystroke across the whole workflow when unrelated content changes, thanks to the keying described above.
+
+**`getDetails`**
+
+- During validation, **`getDetails` is covered by the validation-outcome cache** together with `resolve`: when semantic inputs are unchanged within the TTL, neither runs again—including when `resolve` previously returned `null`.
+- Implement **`getDetails` without extra network calls** when `option` is present: use `option.label`, `option.value`, and `context` to build messages and links. Reserve API calls for the **`option === null`** path (e.g. explaining that a pasted id could not be resolved). That keeps hover and error text responsive and avoids redundant fetches.
+
+**Validation pass (`workflows_management`)**
+
+- On each YAML edit, the editor re-runs validation for custom properties. The validation-outcome cache stores the **`resolve` + `getDetails`** result per field as described above. While those inputs are unchanged (e.g. you edit a different step), **`resolve` and `getDetails` are not called again** for that property—including when `resolve` previously returned `null`.
 
 ### Step 4: Register in Plugin Setup
 

--- a/src/platform/plugins/shared/workflows_management/moon.yml
+++ b/src/platform/plugins/shared/workflows_management/moon.yml
@@ -96,6 +96,7 @@ dependsOn:
   - '@kbn/logging'
   - '@kbn/core-saved-objects-api-server'
   - '@kbn/management-settings-ids'
+  - '@kbn/std'
 tags:
   - plugin
   - prod

--- a/src/platform/plugins/shared/workflows_management/public/entities/workflows/store/workflow_detail/utils/build_workflow_lookup.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/entities/workflows/store/workflow_detail/utils/build_workflow_lookup.test.ts
@@ -604,58 +604,106 @@ describe('buildStepSelectionValues', () => {
     return Object.values(steps)[0];
   }
 
-  it('should split config and input from step properties', () => {
+  it('should return empty when valuePaths is undefined', () => {
     const step = getStep(`
 steps:
   - name: s1
     type: my.step
-    connector-id: abc
-    with:
-      owner: securitySolution
-      message: hello
 `);
     const values = buildStepSelectionValues(step);
-    expect(values.config).toEqual({ 'connector-id': 'abc' });
-    expect(values.input).toEqual({ owner: 'securitySolution', message: 'hello' });
+    expect(values).toEqual({ config: {}, input: {} });
   });
 
-  it('should handle nested with paths', () => {
+  it('should include only properties matching valuePaths', () => {
     const step = getStep(`
 steps:
   - name: s1
     type: my.step
-    with:
-      inputs:
-        field1: value1
-        field2: value2
+    proxy:
+      id: p1
+      ssl: true
+    other: ignored
 `);
-    const values = buildStepSelectionValues(step);
-    expect(values.config).toEqual({});
-    expect(values.input).toEqual({ inputs: { field1: 'value1', field2: 'value2' } });
+    const values = buildStepSelectionValues(step, ['config.proxy.ssl', 'config.other']);
+    expect(values).toEqual({
+      config: { other: 'ignored', proxy: { ssl: true } },
+      input: {},
+    });
   });
 
-  it('should handle array values under with', () => {
+  it('should include an input path when requested', () => {
     const step = getStep(`
 steps:
   - name: s1
     type: my.step
     with:
-      field1:
-        - value1
-        - value2
+      owner: a
+      message: hi
 `);
-    const values = buildStepSelectionValues(step);
-    expect(values.input).toEqual({ field1: ['value1', 'value2'] });
+    const values = buildStepSelectionValues(step, ['input.owner']);
+    expect(values).toEqual({
+      config: {},
+      input: { owner: 'a' },
+    });
   });
 
-  it('should return empty objects when step has no custom properties', () => {
+  it('should return empty when valuePaths match nothing', () => {
     const step = getStep(`
 steps:
   - name: s1
     type: my.step
+    foo: 1
 `);
-    const values = buildStepSelectionValues(step);
-    expect(values.config).toEqual({});
-    expect(values.input).toEqual({});
+    const values = buildStepSelectionValues(step, ['config.bar']);
+    expect(values).toEqual({ config: {}, input: {} });
+  });
+
+  it('should not assign onto Object.prototype when path segments include "__proto__"', () => {
+    const probe = '__wmBuildWorkflowLookupProtoProbe';
+    delete (Object.prototype as Record<string, unknown>)[probe];
+    const step = getStep(`
+steps:
+  - name: s1
+    type: my.step
+    __proto__:
+      ${probe}: polluted
+`);
+    buildStepSelectionValues(step, [`config.__proto__.${probe}`]);
+    expect(Object.hasOwn(Object.prototype, probe)).toBe(false);
+    expect((Object.prototype as Record<string, unknown>)[probe]).toBeUndefined();
+  });
+
+  it('should not assign onto Object.prototype when path segments include "constructor"', () => {
+    const probe = '__wmBuildWorkflowLookupProtoProbe';
+    delete (Object.prototype as Record<string, unknown>)[probe];
+    const step = getStep(`
+steps:
+  - name: s1
+    type: my.step
+    constructor:
+      ${probe}: polluted
+`);
+    const values = buildStepSelectionValues(step, [`config.constructor.${probe}`]);
+    expect((Object.prototype as Record<string, unknown>)[probe]).toBeUndefined();
+    expect(({} as Record<string, unknown>)[probe]).toBeUndefined();
+    expect(values.config.constructor).toBeDefined();
+    expect((values.config.constructor as any)[probe]).toBe('polluted');
+  });
+
+  it('should not assign onto Object.prototype when path segments include "prototype"', () => {
+    const probe = '__wmBuildWorkflowLookupProtoProbe';
+    delete (Object.prototype as Record<string, unknown>)[probe];
+    const step = getStep(`
+steps:
+  - name: s1
+    type: my.step
+    prototype:
+      ${probe}: polluted
+`);
+    const values = buildStepSelectionValues(step, [`config.prototype.${probe}`]);
+    expect((Object.prototype as Record<string, unknown>)[probe]).toBeUndefined();
+    expect(({} as Record<string, unknown>)[probe]).toBeUndefined();
+    expect(values.config.prototype).toBeDefined();
+    expect((values.config.prototype as Record<string, unknown>)[probe]).toBe('polluted');
   });
 });

--- a/src/platform/plugins/shared/workflows_management/public/entities/workflows/store/workflow_detail/utils/build_workflow_lookup.ts
+++ b/src/platform/plugins/shared/workflows_management/public/entities/workflows/store/workflow_detail/utils/build_workflow_lookup.ts
@@ -11,6 +11,7 @@
 
 import type { LineCounter } from 'yaml';
 import YAML from 'yaml';
+import type { RecursivePartial } from '@kbn/utility-types';
 import { isBuiltInStepProperty, type StepSelectionValues } from '@kbn/workflows';
 import { isRecord } from '../../../../../../common/lib/type_guards';
 
@@ -222,12 +223,14 @@ function visitStepProps(node: any, stack: string[] = []): Record<string, StepPro
   return result;
 }
 
+// Path segments come from YAML keys; use null-prototype objects so keys like "__proto__"
+// cannot resolve inherited accessors or pollute Object.prototype when nesting.
 function setNested(obj: Record<string, unknown>, segments: string[], value: unknown): void {
   let current = obj;
   for (let i = 0; i < segments.length - 1; i++) {
     const seg = segments[i];
     if (!isRecord(current[seg])) {
-      current[seg] = {};
+      current[seg] = Object.create(null) as Record<string, unknown>;
     }
     current = current[seg] as Record<string, unknown>;
   }
@@ -235,22 +238,53 @@ function setNested(obj: Record<string, unknown>, segments: string[], value: unkn
 }
 
 /**
+ * Whether a leaf dotted path (e.g. `config.proxy.ssl`) should be included for the given
+ * `valuePaths` (from `dependsOnValues`). Matches exact paths, ancestors, or descendants.
+ */
+function leafPathMatchesValuePaths(dottedLeafKey: string, valuePaths: readonly string[]): boolean {
+  return valuePaths.some(
+    (vp) =>
+      dottedLeafKey === vp ||
+      dottedLeafKey.startsWith(`${vp}.`) ||
+      vp.startsWith(`${dottedLeafKey}.`)
+  );
+}
+
+/**
  * Builds structured config/input values from a step's scalar leaf properties.
  * Properties under the `with` block are placed in `input`; all others in `config`.
+ *
+ * When `valuePaths` is provided (e.g. from `selection.dependsOnValues`), only properties
+ * whose dotted `config.*` / `input.*` path matches are included — single pass over `propInfos`.
  */
-export function buildStepSelectionValues(step: StepInfo): StepSelectionValues {
-  const config: Record<string, unknown> = {};
-  const input: Record<string, unknown> = {};
+export function buildStepSelectionValues(
+  step: StepInfo,
+  valuePaths?: readonly string[]
+): StepSelectionValues {
+  // Same null-prototype initialization as setNested (see comment there) — required to avoid prototype pollution.
+  const config = Object.create(null) as RecursivePartial<Record<string, unknown>>;
+  const input = Object.create(null) as RecursivePartial<Record<string, unknown>>;
+
+  const pathsToMatch = valuePaths && valuePaths.length > 0 ? valuePaths : undefined;
+  if (!pathsToMatch) {
+    return { config, input };
+  }
 
   for (const propInfo of Object.values(step.propInfos)) {
     const rootKey = propInfo.path[0];
     if (rootKey === 'with') {
       const inputPath = propInfo.path.slice(1);
       if (inputPath.length > 0) {
-        setNested(input, inputPath, getValueFromValueNode(propInfo.valueNode));
+        const dottedKey = `input.${inputPath.join('.')}`;
+        if (leafPathMatchesValuePaths(dottedKey, pathsToMatch)) {
+          setNested(input, inputPath, getValueFromValueNode(propInfo.valueNode));
+        }
       }
     } else if (typeof rootKey !== 'string' || !isBuiltInStepProperty(rootKey)) {
-      setNested(config, propInfo.path, getValueFromValueNode(propInfo.valueNode));
+      const dottedKey = `config.${propInfo.path.join('.')}`;
+      if (leafPathMatchesValuePaths(dottedKey, pathsToMatch)) {
+        setNested(config, propInfo.path, getValueFromValueNode(propInfo.valueNode));
+      }
     }
   }
 

--- a/src/platform/plugins/shared/workflows_management/public/features/validate_workflow_yaml/lib/collect_all_custom_property_items.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/validate_workflow_yaml/lib/collect_all_custom_property_items.test.ts
@@ -174,4 +174,72 @@ steps:
       key: 'message',
     });
   });
+
+  it('should use empty context.values when selection has no dependsOnValues', () => {
+    const yaml = `
+name: test-workflow
+steps:
+  - name: run-agent
+    type: run-agent
+    extra: x
+`;
+    const { workflowLookup, yamlLineCounter } = performComputation(yaml.trim());
+    const selectionHandler = {
+      search: jest.fn(),
+      resolve: jest.fn(),
+      getDetails: jest.fn(),
+    };
+    const getPropertyHandler = jest.fn(
+      (stepType: string, scope: 'config' | 'input', key: string) => {
+        if (stepType === 'run-agent' && scope === 'config' && key === 'extra') {
+          return { selection: selectionHandler };
+        }
+        return null;
+      }
+    );
+    const customPropertyItems = collectAllCustomPropertyItems(
+      workflowLookup!,
+      yamlLineCounter!,
+      getPropertyHandler
+    );
+    expect(customPropertyItems[0].context.values).toEqual({ config: {}, input: {} });
+  });
+
+  it('should pass filtered context.values when dependsOnValues is set', () => {
+    const yaml = `
+name: test-workflow
+steps:
+  - name: run-agent
+    type: run-agent
+    proxy:
+      id: p1
+      ssl: true
+    other: ignored
+`;
+    const { workflowLookup, yamlLineCounter } = performComputation(yaml.trim());
+    const selectionHandler = {
+      dependsOnValues: ['config.proxy.ssl', 'config.other'] as any,
+      search: jest.fn(),
+      resolve: jest.fn(),
+      getDetails: jest.fn(),
+    };
+    const getPropertyHandler = jest.fn(
+      (stepType: string, scope: 'config' | 'input', key: string) => {
+        if (stepType === 'run-agent' && scope === 'config' && key === 'proxy.id') {
+          return { selection: selectionHandler };
+        }
+        return null;
+      }
+    );
+    const customPropertyItems = collectAllCustomPropertyItems(
+      workflowLookup!,
+      yamlLineCounter!,
+      getPropertyHandler
+    );
+    expect(customPropertyItems).toHaveLength(1);
+    expect(customPropertyItems[0].context.values).toEqual({
+      config: { other: 'ignored', proxy: { ssl: true } },
+      input: {},
+    });
+  });
 });

--- a/src/platform/plugins/shared/workflows_management/public/features/validate_workflow_yaml/lib/collect_all_custom_property_items.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/validate_workflow_yaml/lib/collect_all_custom_property_items.ts
@@ -13,7 +13,6 @@ import {
   isBuiltInStepType,
   type SelectionContext,
   type StepPropertyHandler,
-  type StepSelectionValues,
 } from '@kbn/workflows';
 import type { WorkflowLookup } from '../../../entities/workflows/store';
 import {
@@ -37,7 +36,6 @@ export function collectAllCustomPropertyItems(
   for (const step of steps) {
     // Only collect custom properties for non-built-in step types
     if (!isBuiltInStepType(step.stepType)) {
-      let stepSelectionValues: StepSelectionValues | undefined;
       for (const [propKey, prop] of Object.entries(step.propInfos)) {
         if (
           prop.keyNode.range &&
@@ -50,20 +48,20 @@ export function collectAllCustomPropertyItems(
           const key = scope === 'config' ? propKey : propKey.split('.').slice(1).join('.');
           const propertyHandler = getPropertyHandler(step.stepType, scope, key);
           if (propertyHandler && propertyHandler.selection) {
+            const selection = propertyHandler.selection;
             const [startOffset, endOffset] = prop.valueNode.range;
             const startPos = lineCounter.linePos(startOffset);
             const endPos = lineCounter.linePos(endOffset);
-            if (!stepSelectionValues) {
-              stepSelectionValues = buildStepSelectionValues(step);
-            }
+            const contextValues = buildStepSelectionValues(step, selection.dependsOnValues);
             const context: SelectionContext = {
               stepType: step.stepType,
               scope,
               propertyKey: key,
-              values: stepSelectionValues,
+              values: contextValues,
             };
             customPropertyItems.push({
               id: `${step.stepId}-${key}-${startPos.line}-${startPos.col}-${endPos.line}-${endPos.col}`,
+              stepId: step.stepId,
               startLineNumber: startPos.line,
               startColumn: startPos.col,
               endLineNumber: endPos.line,

--- a/src/platform/plugins/shared/workflows_management/public/features/validate_workflow_yaml/lib/validate_custom_properties.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/validate_workflow_yaml/lib/validate_custom_properties.test.ts
@@ -11,14 +11,12 @@ import type { StepSelectionValues } from '@kbn/workflows';
 import { getSchemaAtPath } from '@kbn/workflows/common/utils/zod/get_schema_at_path';
 import { z } from '@kbn/zod/v4';
 
-import { validateCustomProperties } from './validate_custom_properties';
-import { stepSchemas } from '../../../../common/step_schemas';
 import {
-  getCachedOption,
-  getCachedSearchOption,
-  getCacheKeyForValue,
-  setCachedOption,
-} from '../../../shared/lib/custom_property_selection_cache';
+  clearCustomPropertyValidationOutcomeCache,
+  validateCustomProperties,
+} from './validate_custom_properties';
+import { stepSchemas } from '../../../../common/step_schemas';
+import * as customPropertySelectionCache from '../../../shared/lib/custom_property_selection_cache';
 import type { CustomPropertyItem } from '../model/types';
 
 // Mock the dependencies
@@ -32,13 +30,15 @@ jest.mock('@kbn/workflows/common/utils/zod/get_schema_at_path', () => ({
   getSchemaAtPath: jest.fn(),
 }));
 
-jest.mock('../../../shared/lib/custom_property_selection_cache', () => ({
-  clearCache: jest.fn(),
-  getCachedOption: jest.fn(),
-  getCachedSearchOption: jest.fn(),
-  getCacheKeyForValue: jest.fn(),
-  setCachedOption: jest.fn(),
-}));
+jest.mock('../../../shared/lib/custom_property_selection_cache', () => {
+  const actual = jest.requireActual<
+    typeof import('../../../shared/lib/custom_property_selection_cache')
+  >('../../../shared/lib/custom_property_selection_cache');
+  return {
+    ...actual,
+    getCachedSearchOption: jest.fn(actual.getCachedSearchOption),
+  };
+});
 
 const EMPTY_VALUES: StepSelectionValues = { config: {}, input: {} };
 
@@ -46,25 +46,19 @@ const mockGetAllConnectorsMapCache = stepSchemas.getAllConnectorsMapCache as jes
   typeof stepSchemas.getAllConnectorsMapCache
 >;
 const mockGetSchemaAtPath = getSchemaAtPath as jest.MockedFunction<typeof getSchemaAtPath>;
-const mockGetCachedOption = getCachedOption as jest.MockedFunction<typeof getCachedOption>;
-const mockGetCachedSearchOption = getCachedSearchOption as jest.MockedFunction<
-  typeof getCachedSearchOption
->;
-const mockGetCacheKeyForValue = getCacheKeyForValue as jest.MockedFunction<
-  typeof getCacheKeyForValue
->;
-const mockSetCachedOption = setCachedOption as jest.MockedFunction<typeof setCachedOption>;
+const mockGetCachedSearchOption =
+  customPropertySelectionCache.getCachedSearchOption as jest.MockedFunction<
+    typeof customPropertySelectionCache.getCachedSearchOption
+  >;
 
 describe('validateCustomProperties', () => {
   beforeEach(() => {
+    clearCustomPropertyValidationOutcomeCache();
     jest.clearAllMocks();
-    // Default mock implementations
-    mockGetCachedOption.mockReturnValue(null);
-    mockGetCachedSearchOption.mockReturnValue(null);
-    mockGetCacheKeyForValue.mockImplementation(
-      (stepType, scope, propertyKey, value) =>
-        `${stepType}:${scope}:${propertyKey}:${String(value)}`
-    );
+    const actual = jest.requireActual<
+      typeof import('../../../shared/lib/custom_property_selection_cache')
+    >('../../../shared/lib/custom_property_selection_cache');
+    mockGetCachedSearchOption.mockImplementation(actual.getCachedSearchOption);
   });
 
   it('should return error when resolve returns null and getDetails returns error message', async () => {
@@ -87,6 +81,7 @@ describe('validateCustomProperties', () => {
     const customPropertyItems: CustomPropertyItem[] = [
       {
         id: '1',
+        stepId: 'step-1',
         startLineNumber: 1,
         startColumn: 1,
         endLineNumber: 1,
@@ -161,6 +156,7 @@ describe('validateCustomProperties', () => {
     const customPropertyItems: CustomPropertyItem[] = [
       {
         id: '2',
+        stepId: 'step-2',
         startLineNumber: 1,
         startColumn: 1,
         endLineNumber: 1,
@@ -209,10 +205,9 @@ describe('validateCustomProperties', () => {
       afterMessage: null,
       hoverMessage: 'Valid',
     });
-    expect(mockSetCachedOption).toHaveBeenCalledWith('2:input:2:2', resolvedOption);
   });
 
-  it('should use cached option when available', async () => {
+  it('should use cached search option when available (resolve skipped)', async () => {
     const cachedOption = {
       value: '3',
       label: 'Cached Option',
@@ -226,7 +221,7 @@ describe('validateCustomProperties', () => {
       }),
     };
 
-    mockGetCachedOption.mockReturnValue(cachedOption);
+    mockGetCachedSearchOption.mockReturnValue(cachedOption);
 
     const mockConnector = {
       type: '3',
@@ -238,6 +233,7 @@ describe('validateCustomProperties', () => {
     const customPropertyItems: CustomPropertyItem[] = [
       {
         id: '3',
+        stepId: 'step-3',
         startLineNumber: 1,
         startColumn: 1,
         endLineNumber: 1,
@@ -282,76 +278,6 @@ describe('validateCustomProperties', () => {
     });
   });
 
-  it('should use cached search option when available', async () => {
-    const cachedSearchOption = {
-      value: '4',
-      label: 'Search Option',
-      description: 'Search Description',
-    };
-    const selectionHandler = {
-      search: jest.fn(),
-      resolve: jest.fn(),
-      getDetails: jest.fn().mockResolvedValue({
-        message: 'Valid',
-      }),
-    };
-
-    mockGetCachedSearchOption.mockReturnValue(cachedSearchOption);
-
-    const mockConnector = {
-      type: '4',
-      paramsSchema: z.object({ '4': z.string() }),
-    };
-    mockGetAllConnectorsMapCache.mockReturnValue(new Map([['4', mockConnector as any]]));
-    mockGetSchemaAtPath.mockReturnValue({ schema: z.string(), scopedToPath: '4' });
-
-    const customPropertyItems: CustomPropertyItem[] = [
-      {
-        id: '4',
-        startLineNumber: 1,
-        startColumn: 1,
-        endLineNumber: 1,
-        endColumn: 1,
-        yamlPath: ['4'],
-        key: '4',
-        selectionHandler,
-        context: {
-          stepType: '4',
-          scope: 'input',
-          propertyKey: '4',
-          values: EMPTY_VALUES,
-        },
-        propertyValue: '4',
-        propertyKey: '4',
-        stepType: '4',
-        scope: 'input',
-        type: 'custom-property',
-      },
-    ];
-
-    const validationResults = await validateCustomProperties(customPropertyItems);
-
-    expect(selectionHandler.resolve).not.toHaveBeenCalled();
-    expect(selectionHandler.getDetails).toHaveBeenCalledWith(
-      '4',
-      {
-        stepType: '4',
-        scope: 'input',
-        propertyKey: '4',
-        values: EMPTY_VALUES,
-      },
-      cachedSearchOption
-    );
-    expect(validationResults).toHaveLength(1);
-    expect(validationResults[0]).toMatchObject({
-      id: '4',
-      severity: null,
-      message: null,
-      beforeMessage: '✓ Search Option',
-      afterMessage: null,
-    });
-  });
-
   it('should skip validation when schema validation fails', async () => {
     const selectionHandler = {
       search: jest.fn(),
@@ -369,6 +295,7 @@ describe('validateCustomProperties', () => {
     const customPropertyItems: CustomPropertyItem[] = [
       {
         id: '5',
+        stepId: 'step-5',
         startLineNumber: 1,
         startColumn: 1,
         endLineNumber: 1,
@@ -414,6 +341,7 @@ describe('validateCustomProperties', () => {
     const customPropertyItems: CustomPropertyItem[] = [
       {
         id: '6a',
+        stepId: 'step-6a',
         startLineNumber: 1,
         startColumn: 1,
         endLineNumber: 1,
@@ -454,6 +382,7 @@ describe('validateCustomProperties', () => {
     const customPropertyItems: CustomPropertyItem[] = [
       {
         id: '6',
+        stepId: 'step-6',
         startLineNumber: 1,
         startColumn: 1,
         endLineNumber: 1,
@@ -524,6 +453,7 @@ describe('validateCustomProperties', () => {
     const customPropertyItems: CustomPropertyItem[] = [
       {
         id: '1',
+        stepId: 'multi-step-a',
         startLineNumber: 1,
         startColumn: 1,
         endLineNumber: 1,
@@ -545,6 +475,7 @@ describe('validateCustomProperties', () => {
       },
       {
         id: '2',
+        stepId: 'multi-step-b',
         startLineNumber: 1,
         startColumn: 1,
         endLineNumber: 1,
@@ -583,5 +514,51 @@ describe('validateCustomProperties', () => {
       afterMessage: null,
       hoverMessage: 'Valid',
     });
+  });
+
+  it('should skip resolve and getDetails on a second validation when semantic inputs are unchanged', async () => {
+    const selectionHandler = {
+      search: jest.fn(),
+      resolve: jest.fn().mockResolvedValue(null),
+      getDetails: jest.fn().mockResolvedValue({
+        message: 'Unresolved',
+      }),
+    };
+
+    const mockConnector = {
+      type: 'cache-test',
+      configSchema: z.object({ field: z.string() }),
+    };
+    mockGetAllConnectorsMapCache.mockReturnValue(new Map([['cache-test', mockConnector as any]]));
+    mockGetSchemaAtPath.mockReturnValue({ schema: z.string(), scopedToPath: 'field' });
+
+    const item: CustomPropertyItem = {
+      id: 'cache-test-item',
+      stepId: 'cache-step',
+      startLineNumber: 2,
+      startColumn: 1,
+      endLineNumber: 2,
+      endColumn: 5,
+      yamlPath: ['field'],
+      key: 'field',
+      selectionHandler,
+      context: {
+        stepType: 'cache-test',
+        scope: 'config',
+        propertyKey: 'field',
+        values: EMPTY_VALUES,
+      },
+      propertyValue: 'missing-id',
+      propertyKey: 'field',
+      stepType: 'cache-test',
+      scope: 'config',
+      type: 'custom-property',
+    };
+
+    await validateCustomProperties([item]);
+    await validateCustomProperties([item]);
+
+    expect(selectionHandler.resolve).toHaveBeenCalledTimes(1);
+    expect(selectionHandler.getDetails).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/platform/plugins/shared/workflows_management/public/features/validate_workflow_yaml/lib/validate_custom_properties.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/validate_workflow_yaml/lib/validate_custom_properties.ts
@@ -7,18 +7,72 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import type { SelectionDetails, SelectionOption } from '@kbn/workflows';
 import { getSchemaAtPath } from '@kbn/workflows/common/utils/zod/get_schema_at_path';
 import type { z } from '@kbn/zod/v4';
 import { isTemplateReference } from './is_template_reference';
 import { stepSchemas } from '../../../../common/step_schemas';
 import {
-  clearCache,
-  getCachedOption,
+  getCachedCustomPropertyValidationOutcome,
   getCachedSearchOption,
-  getCacheKeyForValue,
-  setCachedOption,
+  getCustomPropertyValidationOutcomeCacheKey,
+  setCachedCustomPropertyValidationOutcome,
 } from '../../../shared/lib/custom_property_selection_cache';
 import type { CustomPropertyItem, CustomPropertyValidationResult } from '../model/types';
+
+export { clearCustomPropertyValidationOutcomeCache } from '../../../shared/lib/custom_property_selection_cache';
+
+function buildValidationResult(
+  customPropertyItem: CustomPropertyItem,
+  resolvedOption: SelectionOption | null,
+  details: SelectionDetails
+): CustomPropertyValidationResult {
+  const hasError =
+    !resolvedOption &&
+    customPropertyItem.propertyValue !== null &&
+    customPropertyItem.propertyValue !== undefined;
+
+  const hoverParts: string[] = [];
+  if (details.message) {
+    hoverParts.push(details.message);
+  }
+  if (details.links && details.links.length > 0) {
+    hoverParts.push(details.links.map((link) => `[${link.text}](${link.path})`).join(' | '));
+  }
+  const hoverMessage = hoverParts.length > 0 ? hoverParts.join('\n\n') : null;
+
+  const beforeMessage = resolvedOption ? `✓ ${resolvedOption.label}` : undefined;
+
+  if (hasError) {
+    return {
+      id: customPropertyItem.id,
+      severity: 'error' as const,
+      message: details.message,
+      beforeMessage,
+      afterMessage: null,
+      hoverMessage,
+      startLineNumber: customPropertyItem.startLineNumber,
+      startColumn: customPropertyItem.startColumn,
+      endLineNumber: customPropertyItem.endLineNumber,
+      endColumn: customPropertyItem.endColumn,
+      owner: 'custom-property-validation' as const,
+    };
+  }
+
+  return {
+    id: customPropertyItem.id,
+    severity: null,
+    message: null,
+    beforeMessage,
+    afterMessage: null,
+    hoverMessage,
+    startLineNumber: customPropertyItem.startLineNumber,
+    startColumn: customPropertyItem.startColumn,
+    endLineNumber: customPropertyItem.endLineNumber,
+    endColumn: customPropertyItem.endColumn,
+    owner: 'custom-property-validation' as const,
+  };
+}
 
 function getPropertySchema(
   stepType: string,
@@ -60,7 +114,6 @@ function shouldValidateProperty(item: CustomPropertyItem): boolean {
 export async function validateCustomProperties(
   customPropertyItems: CustomPropertyItem[]
 ): Promise<CustomPropertyValidationResult[]> {
-  clearCache();
   const validationResultsPromises: Promise<CustomPropertyValidationResult>[] = [];
   for (const customPropertyItem of customPropertyItems) {
     if (shouldValidateProperty(customPropertyItem)) {
@@ -69,66 +122,33 @@ export async function validateCustomProperties(
 
       validationResultsPromises.push(
         (async (): Promise<CustomPropertyValidationResult> => {
-          const cacheKey = getCacheKeyForValue(stepType, scope, propertyKey, propertyValue);
-
-          let resolvedOption = getCachedOption(cacheKey);
-          if (!resolvedOption) {
-            resolvedOption = getCachedSearchOption(stepType, scope, propertyKey, propertyValue);
+          const outcomeKey = getCustomPropertyValidationOutcomeCacheKey(customPropertyItem);
+          const cachedOutcome = getCachedCustomPropertyValidationOutcome(outcomeKey);
+          if (cachedOutcome) {
+            return buildValidationResult(
+              customPropertyItem,
+              cachedOutcome.resolvedOption,
+              cachedOutcome.details
+            );
           }
+
+          let resolvedOption = getCachedSearchOption(
+            stepType,
+            scope,
+            propertyKey,
+            propertyValue,
+            context.values
+          );
           if (!resolvedOption && propertyValue !== null && propertyValue !== undefined) {
             resolvedOption = await selectionHandler.resolve(propertyValue, context);
-            if (resolvedOption) {
-              setCachedOption(cacheKey, resolvedOption);
-            }
           }
 
           const input = String(propertyValue);
           const details = await selectionHandler.getDetails(input, context, resolvedOption);
 
-          const hasError = !resolvedOption && propertyValue !== null && propertyValue !== undefined;
+          setCachedCustomPropertyValidationOutcome(outcomeKey, resolvedOption, details);
 
-          const hoverParts: string[] = [];
-          if (details.message) {
-            hoverParts.push(details.message);
-          }
-          if (details.links && details.links.length > 0) {
-            hoverParts.push(
-              details.links.map((link) => `[${link.text}](${link.path})`).join(' | ')
-            );
-          }
-          const hoverMessage = hoverParts.length > 0 ? hoverParts.join('\n\n') : null;
-
-          const beforeMessage = resolvedOption ? `✓ ${resolvedOption.label}` : undefined;
-
-          if (hasError) {
-            return {
-              id: customPropertyItem.id,
-              severity: 'error' as const,
-              message: details.message,
-              beforeMessage,
-              afterMessage: null,
-              hoverMessage,
-              startLineNumber: customPropertyItem.startLineNumber,
-              startColumn: customPropertyItem.startColumn,
-              endLineNumber: customPropertyItem.endLineNumber,
-              endColumn: customPropertyItem.endColumn,
-              owner: 'custom-property-validation' as const,
-            };
-          }
-
-          return {
-            id: customPropertyItem.id,
-            severity: null,
-            message: null,
-            beforeMessage,
-            afterMessage: null,
-            hoverMessage,
-            startLineNumber: customPropertyItem.startLineNumber,
-            startColumn: customPropertyItem.startColumn,
-            endLineNumber: customPropertyItem.endLineNumber,
-            endColumn: customPropertyItem.endColumn,
-            owner: 'custom-property-validation' as const,
-          };
+          return buildValidationResult(customPropertyItem, resolvedOption, details);
         })()
       );
     }

--- a/src/platform/plugins/shared/workflows_management/public/features/validate_workflow_yaml/model/types.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/validate_workflow_yaml/model/types.ts
@@ -31,6 +31,8 @@ export interface VariableItem extends BaseItem {
 
 export interface CustomPropertyItem extends BaseItem {
   type: 'custom-property';
+  /** Stable step instance id from the workflow lookup (used for validation-outcome caching). */
+  stepId: string;
   scope: 'config' | 'input';
   stepType: string;
   propertyKey: string;

--- a/src/platform/plugins/shared/workflows_management/public/shared/lib/custom_property_selection_cache.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/shared/lib/custom_property_selection_cache.test.ts
@@ -7,15 +7,16 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { SelectionOption } from '@kbn/workflows/types/v1';
+import type { SelectionDetails, SelectionOption } from '@kbn/workflows/types/v1';
 import {
   cacheSearchOptions,
   clearCache,
-  getCachedOption,
+  getCachedCustomPropertyValidationOutcome,
   getCachedSearchOption,
-  getCacheKeyForValue,
-  setCachedOption,
+  getCustomPropertyValidationOutcomeCacheKey,
+  setCachedCustomPropertyValidationOutcome,
 } from './custom_property_selection_cache';
+import type { CustomPropertyItem } from '../../features/validate_workflow_yaml/model/types';
 
 describe('custom_property_selection_cache', () => {
   const mockOption1: SelectionOption = {
@@ -36,6 +37,8 @@ describe('custom_property_selection_cache', () => {
     label: 'Development Proxy',
   };
 
+  const mockDetails: SelectionDetails = { message: 'ok' };
+
   beforeEach(() => {
     jest.useFakeTimers();
     jest.setSystemTime(new Date('2024-01-01T00:00:00.000Z'));
@@ -48,98 +51,86 @@ describe('custom_property_selection_cache', () => {
     jest.clearAllMocks();
   });
 
-  describe('getCacheKeyForValue', () => {
-    it('should generate cache key with string value', () => {
-      const key = getCacheKeyForValue('step.type', 'config', 'proxy.id', 'proxy-1');
-      expect(key).toBe('step.type:config:proxy.id:proxy-1');
+  function makeItem(overrides: Partial<CustomPropertyItem> = {}): CustomPropertyItem {
+    return {
+      id: 'item-1',
+      stepId: 'step-a',
+      startLineNumber: 1,
+      startColumn: 1,
+      endLineNumber: 1,
+      endColumn: 1,
+      yamlPath: ['x'],
+      key: 'x',
+      selectionHandler: {} as CustomPropertyItem['selectionHandler'],
+      context: {
+        stepType: 'step.type',
+        scope: 'config',
+        propertyKey: 'proxy.id',
+        values: { config: {}, input: {} },
+      },
+      propertyValue: 'proxy-1',
+      propertyKey: 'proxy.id',
+      stepType: 'step.type',
+      scope: 'config',
+      type: 'custom-property',
+      ...overrides,
+    };
+  }
+
+  describe('getCustomPropertyValidationOutcomeCacheKey', () => {
+    it('should include step id, context fields, and serialized value', () => {
+      const item = makeItem({
+        stepId: 's1',
+        propertyValue: 'v',
+        context: {
+          stepType: 't',
+          scope: 'input',
+          propertyKey: 'k',
+          values: { config: { a: 1 }, input: {} },
+        },
+      });
+      const key = getCustomPropertyValidationOutcomeCacheKey(item);
+      expect(key).toContain('s1');
+      expect(key).toContain('t');
+      expect(key).toContain('input');
+      expect(key).toContain('k');
+      expect(key).toContain(JSON.stringify({ config: { a: 1 }, input: {} }));
+      expect(key).toContain('"v"');
     });
 
-    it('should generate cache key with number value', () => {
-      const key = getCacheKeyForValue('step.type', 'input', 'port', 8080);
-      expect(key).toBe('step.type:input:port:8080');
-    });
-
-    it('should generate cache key with null value', () => {
-      const key = getCacheKeyForValue('step.type', 'config', 'proxy.id', null);
-      expect(key).toBe('step.type:config:proxy.id:null');
-    });
-
-    it('should generate cache key with undefined value', () => {
-      const key = getCacheKeyForValue('step.type', 'config', 'proxy.id', undefined);
-      expect(key).toBe('step.type:config:proxy.id:undefined');
-    });
-
-    it('should generate different keys for different scopes', () => {
-      const configKey = getCacheKeyForValue('step.type', 'config', 'proxy.id', 'proxy-1');
-      const inputKey = getCacheKeyForValue('step.type', 'input', 'proxy.id', 'proxy-1');
-      expect(configKey).not.toBe(inputKey);
-    });
-
-    it('should generate different keys for different property keys', () => {
-      const key1 = getCacheKeyForValue('step.type', 'config', 'proxy.id', 'proxy-1');
-      const key2 = getCacheKeyForValue('step.type', 'config', 'agent.id', 'proxy-1');
-      expect(key1).not.toBe(key2);
+    it('should produce different keys for different property values', () => {
+      const a = getCustomPropertyValidationOutcomeCacheKey(makeItem({ propertyValue: 'a' }));
+      const b = getCustomPropertyValidationOutcomeCacheKey(makeItem({ propertyValue: 'b' }));
+      expect(a).not.toBe(b);
     });
   });
 
-  describe('setCachedOption and getCachedOption', () => {
-    it('should store and retrieve cached option', () => {
-      const key = getCacheKeyForValue('step.type', 'config', 'proxy.id', 'proxy-1');
-      setCachedOption(key, mockOption1);
-
-      const cached = getCachedOption(key);
-      expect(cached).toEqual(mockOption1);
+  describe('getCachedCustomPropertyValidationOutcome and setCachedCustomPropertyValidationOutcome', () => {
+    it('should store and retrieve validation outcome', () => {
+      const key = 'k1';
+      setCachedCustomPropertyValidationOutcome(key, mockOption1, mockDetails);
+      expect(getCachedCustomPropertyValidationOutcome(key)).toEqual({
+        resolvedOption: mockOption1,
+        details: mockDetails,
+      });
     });
 
-    it('should return null for non-existent cache key', () => {
-      const key = getCacheKeyForValue('step.type', 'config', 'proxy.id', 'non-existent');
-      const cached = getCachedOption(key);
-      expect(cached).toBeNull();
+    it('should return null for missing key', () => {
+      expect(getCachedCustomPropertyValidationOutcome('missing')).toBeNull();
     });
 
-    it('should return null for expired cache entry', () => {
-      const key = getCacheKeyForValue('step.type', 'config', 'proxy.id', 'proxy-1');
-      setCachedOption(key, mockOption1);
-
+    it('should expire after TTL', () => {
+      const key = 'k-exp';
+      setCachedCustomPropertyValidationOutcome(key, null, mockDetails);
       jest.advanceTimersByTime(30 * 1000 + 1);
-
-      const cached = getCachedOption(key);
-      expect(cached).toBeNull();
+      expect(getCachedCustomPropertyValidationOutcome(key)).toBeNull();
     });
 
-    it('should return cached option within TTL', () => {
-      const key = getCacheKeyForValue('step.type', 'config', 'proxy.id', 'proxy-1');
-      setCachedOption(key, mockOption1);
-
+    it('should return outcome within TTL', () => {
+      const key = 'k-ok';
+      setCachedCustomPropertyValidationOutcome(key, mockOption1, mockDetails);
       jest.advanceTimersByTime(30 * 1000 - 1);
-
-      const cached = getCachedOption(key);
-      expect(cached).toEqual(mockOption1);
-    });
-
-    it('should update existing cache entry', () => {
-      const key = getCacheKeyForValue('step.type', 'config', 'proxy.id', 'proxy-1');
-      setCachedOption(key, mockOption1);
-
-      const updatedOption: SelectionOption = {
-        ...mockOption1,
-        label: 'Updated Proxy',
-      };
-      setCachedOption(key, updatedOption);
-
-      const cached = getCachedOption(key);
-      expect(cached).toEqual(updatedOption);
-    });
-
-    it('should handle multiple cache entries independently', () => {
-      const key1 = getCacheKeyForValue('step.type', 'config', 'proxy.id', 'proxy-1');
-      const key2 = getCacheKeyForValue('step.type', 'config', 'proxy.id', 'proxy-2');
-
-      setCachedOption(key1, mockOption1);
-      setCachedOption(key2, mockOption2);
-
-      expect(getCachedOption(key1)).toEqual(mockOption1);
-      expect(getCachedOption(key2)).toEqual(mockOption2);
+      expect(getCachedCustomPropertyValidationOutcome(key)?.resolvedOption).toEqual(mockOption1);
     });
   });
 
@@ -155,15 +146,6 @@ describe('custom_property_selection_cache', () => {
       expect(cached1).toEqual(mockOption1);
       expect(cached2).toEqual(mockOption2);
       expect(cached3).toEqual(mockOption3);
-    });
-
-    it('should cache individual options via setCachedOption', () => {
-      const options = [mockOption1];
-      cacheSearchOptions('step.type', 'config', 'proxy.id', options);
-
-      const key = getCacheKeyForValue('step.type', 'config', 'proxy.id', 'proxy-1');
-      const cached = getCachedOption(key);
-      expect(cached).toEqual(mockOption1);
     });
 
     it('should handle empty options array', () => {
@@ -204,6 +186,23 @@ describe('custom_property_selection_cache', () => {
 
       expect(cached1).toEqual(mockOption1);
       expect(cached2).toEqual(mockOption2);
+    });
+
+    it('should scope search cache by context values', () => {
+      const valuesA = { config: { x: 1 }, input: {} };
+      const valuesB = { config: { x: 2 }, input: {} };
+      cacheSearchOptions('step.type', 'config', 'proxy.id', [mockOption1], valuesA);
+      cacheSearchOptions('step.type', 'config', 'proxy.id', [mockOption2], valuesB);
+
+      expect(getCachedSearchOption('step.type', 'config', 'proxy.id', 'proxy-1', valuesA)).toEqual(
+        mockOption1
+      );
+      expect(getCachedSearchOption('step.type', 'config', 'proxy.id', 'proxy-2', valuesB)).toEqual(
+        mockOption2
+      );
+      expect(
+        getCachedSearchOption('step.type', 'config', 'proxy.id', 'proxy-1', valuesB)
+      ).toBeNull();
     });
   });
 
@@ -267,36 +266,13 @@ describe('custom_property_selection_cache', () => {
   });
 
   describe('cache expiration', () => {
-    it('should expire individual cached options after TTL', () => {
-      const key = getCacheKeyForValue('step.type', 'config', 'proxy.id', 'proxy-1');
-      setCachedOption(key, mockOption1);
-
-      jest.advanceTimersByTime(30 * 1000 + 1);
-
-      const cached = getCachedOption(key);
-      expect(cached).toBeNull();
-    });
-
-    it('should not expire search cache entries (they persist)', () => {
+    it('should not expire search cache entries by time (list persists until replaced)', () => {
       cacheSearchOptions('step.type', 'config', 'proxy.id', [mockOption1]);
 
       jest.advanceTimersByTime(30 * 1000 + 1);
 
       const cached = getCachedSearchOption('step.type', 'config', 'proxy.id', 'proxy-1');
       expect(cached).toEqual(mockOption1);
-    });
-
-    it('should expire individual options cached via cacheSearchOptions after TTL', () => {
-      cacheSearchOptions('step.type', 'config', 'proxy.id', [mockOption1]);
-
-      const key = getCacheKeyForValue('step.type', 'config', 'proxy.id', 'proxy-1');
-      jest.advanceTimersByTime(30 * 1000 + 1);
-
-      const cachedViaKey = getCachedOption(key);
-      expect(cachedViaKey).toBeNull();
-
-      const cachedViaSearch = getCachedSearchOption('step.type', 'config', 'proxy.id', 'proxy-1');
-      expect(cachedViaSearch).toEqual(mockOption1);
     });
   });
 
@@ -337,29 +313,25 @@ describe('custom_property_selection_cache', () => {
       expect(cached).toEqual(optionWithObject);
     });
 
-    it('should handle very long cache keys', () => {
+    it('should handle very long option values in search cache', () => {
       const longValue = 'a'.repeat(1000);
-      const key = getCacheKeyForValue('step.type', 'config', 'proxy.id', longValue);
       const option: SelectionOption = {
         value: longValue,
         label: 'Long Value Option',
       };
-
-      setCachedOption(key, option);
-      const cached = getCachedOption(key);
+      cacheSearchOptions('step.type', 'config', 'proxy.id', [option]);
+      const cached = getCachedSearchOption('step.type', 'config', 'proxy.id', longValue);
       expect(cached).toEqual(option);
     });
 
-    it('should handle special characters in cache keys', () => {
+    it('should handle special characters in values for search cache', () => {
       const specialValue = 'proxy:id:with:colons';
-      const key = getCacheKeyForValue('step.type', 'config', 'proxy.id', specialValue);
       const option: SelectionOption = {
         value: specialValue,
         label: 'Special Chars Option',
       };
-
-      setCachedOption(key, option);
-      const cached = getCachedOption(key);
+      cacheSearchOptions('step.type', 'config', 'proxy.id', [option]);
+      const cached = getCachedSearchOption('step.type', 'config', 'proxy.id', specialValue);
       expect(cached).toEqual(option);
     });
   });

--- a/src/platform/plugins/shared/workflows_management/public/shared/lib/custom_property_selection_cache.ts
+++ b/src/platform/plugins/shared/workflows_management/public/shared/lib/custom_property_selection_cache.ts
@@ -7,58 +7,69 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { SelectionOption } from '@kbn/workflows/types/v1';
+import { safeJsonStringify } from '@kbn/std';
+import type {
+  SelectionDetails,
+  SelectionOption,
+  StepSelectionValues,
+} from '@kbn/workflows/types/v1';
+import type { CustomPropertyItem } from '../../features/validate_workflow_yaml/model/types';
 
-const resolvedEntityCache = new Map<string, { option: SelectionOption; timestamp: number }>();
 const searchOptionsCache = new Map<string, SelectionOption[]>();
+
+const validationOutcomeCache = new Map<
+  string,
+  { timestamp: number; resolvedOption: SelectionOption | null; details: SelectionDetails }
+>();
+
 // The cache purpose is to reduce the number of server requests during heavy UI editing.
 // However, long TTL has a bad impact on UX, showing stale data should be avoided.
 const CACHE_TTL_MS = 30 * 1000; // 30 seconds
 
-function getCacheKey(stepType: string, scope: string, propertyKey: string, value: unknown): string {
-  return `${stepType}:${scope}:${propertyKey}:${String(value)}`;
+function getFingerprintFromValues(values?: StepSelectionValues): string | undefined {
+  if (!values) {
+    return undefined;
+  }
+  const hasConfig = Object.keys(values.config).length > 0;
+  const hasInput = Object.keys(values.input).length > 0;
+  if (!hasConfig && !hasInput) {
+    return undefined;
+  }
+  return safeJsonStringify(values);
 }
 
-function getSearchCacheKey(stepType: string, scope: string, propertyKey: string): string {
+function getSearchCacheKey(
+  stepType: string,
+  scope: string,
+  propertyKey: string,
+  values?: StepSelectionValues
+): string {
+  const fingerprint = getFingerprintFromValues(values);
+  if (fingerprint) {
+    return `${stepType}:${scope}:${propertyKey}:search:${fingerprint}`;
+  }
   return `${stepType}:${scope}:${propertyKey}:search`;
-}
-
-export function getCachedOption(key: string): SelectionOption | null {
-  const cached = resolvedEntityCache.get(key);
-  if (cached && Date.now() - cached.timestamp < CACHE_TTL_MS) {
-    return cached.option;
-  }
-  if (cached) {
-    resolvedEntityCache.delete(key);
-  }
-  return null;
-}
-
-export function setCachedOption(key: string, option: SelectionOption): void {
-  resolvedEntityCache.set(key, { option, timestamp: Date.now() });
 }
 
 export function cacheSearchOptions(
   stepType: string,
   scope: string,
   propertyKey: string,
-  options: SelectionOption[]
+  options: SelectionOption[],
+  values?: StepSelectionValues
 ): void {
-  const cacheKey = getSearchCacheKey(stepType, scope, propertyKey);
+  const cacheKey = getSearchCacheKey(stepType, scope, propertyKey, values);
   searchOptionsCache.set(cacheKey, options);
-  for (const option of options) {
-    const valueKey = getCacheKey(stepType, scope, propertyKey, option.value);
-    setCachedOption(valueKey, option);
-  }
 }
 
 export function getCachedSearchOption(
   stepType: string,
   scope: string,
   propertyKey: string,
-  value: unknown
+  value: unknown,
+  values?: StepSelectionValues
 ): SelectionOption | null {
-  const cacheKey = getSearchCacheKey(stepType, scope, propertyKey);
+  const cacheKey = getSearchCacheKey(stepType, scope, propertyKey, values);
   const cachedOptions = searchOptionsCache.get(cacheKey);
   if (cachedOptions) {
     const matchingOption = cachedOptions.find(
@@ -71,16 +82,44 @@ export function getCachedSearchOption(
   return null;
 }
 
-export function getCacheKeyForValue(
-  stepType: string,
-  scope: string,
-  propertyKey: string,
-  value: unknown
-): string {
-  return getCacheKey(stepType, scope, propertyKey, value);
+function stableSerializePropertyValue(value: unknown): string {
+  return safeJsonStringify(value) ?? String(value);
+}
+
+export function getCustomPropertyValidationOutcomeCacheKey(item: CustomPropertyItem): string {
+  const { stepType, scope, propertyKey, values } = item.context;
+  const fp = getFingerprintFromValues(values) ?? '';
+  const valueKey = stableSerializePropertyValue(item.propertyValue);
+  return `${item.stepId}\0${stepType}\0${scope}\0${propertyKey}\0${fp}\0${valueKey}`;
+}
+
+export function getCachedCustomPropertyValidationOutcome(
+  key: string
+): { resolvedOption: SelectionOption | null; details: SelectionDetails } | null {
+  const cached = validationOutcomeCache.get(key);
+  if (!cached) {
+    return null;
+  }
+  if (Date.now() - cached.timestamp > CACHE_TTL_MS) {
+    validationOutcomeCache.delete(key);
+    return null;
+  }
+  return { resolvedOption: cached.resolvedOption, details: cached.details };
+}
+
+export function setCachedCustomPropertyValidationOutcome(
+  key: string,
+  resolvedOption: SelectionOption | null,
+  details: SelectionDetails
+): void {
+  validationOutcomeCache.set(key, { timestamp: Date.now(), resolvedOption, details });
+}
+
+export function clearCustomPropertyValidationOutcomeCache(): void {
+  validationOutcomeCache.clear();
 }
 
 export function clearCache(): void {
-  resolvedEntityCache.clear();
   searchOptionsCache.clear();
+  validationOutcomeCache.clear();
 }

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/suggestions/custom_property/get_custom_property_suggestions.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/suggestions/custom_property/get_custom_property_suggestions.ts
@@ -11,9 +11,12 @@ import { monaco } from '@kbn/monaco';
 import {
   isBuiltInStepProperty,
   isBuiltInStepType,
+  type PropertySelectionHandler,
   type SelectionContext,
   type StepPropertyHandler,
+  type StepSelectionValues,
 } from '@kbn/workflows';
+import type { StepInfo } from '../../../../../../entities/workflows/store/workflow_detail/utils/build_workflow_lookup';
 import {
   buildStepSelectionValues,
   getValueFromValueNode,
@@ -64,11 +67,10 @@ export async function getCustomPropertySuggestions(
     return [];
   }
 
-  const propertyHandler = getPropertyHandler(
-    focusedStepInfo.stepType,
-    isInConfig ? 'config' : 'input',
-    composedKey
-  );
+  const scope = isInConfig ? 'config' : 'input';
+  const { stepType } = focusedStepInfo;
+
+  const propertyHandler = getPropertyHandler(stepType, scope, composedKey);
   if (!propertyHandler || !propertyHandler.selection?.search) {
     return [];
   }
@@ -85,15 +87,13 @@ export async function getCustomPropertySuggestions(
   };
 
   const input = sanitizeSearchInput(currentValue);
-  const context: SelectionContext = {
-    stepType: focusedStepInfo.stepType,
-    scope: isInConfig ? 'config' : 'input',
-    propertyKey: composedKey,
-    values: buildStepSelectionValues(focusedStepInfo),
-  };
-  const options = await propertyHandler.selection.search(input, context);
+  const selection = propertyHandler.selection;
+  const values = getContextValues(selection, focusedStepInfo);
 
-  cacheSearchOptions(focusedStepInfo.stepType, context.scope, composedKey, options);
+  const context: SelectionContext = { stepType, scope, propertyKey: composedKey, values };
+  const options = await selection.search(input, context);
+
+  cacheSearchOptions(focusedStepInfo.stepType, context.scope, composedKey, options, values);
 
   return options.map(
     (option): monaco.languages.CompletionItem => ({
@@ -115,4 +115,14 @@ function sanitizeSearchInput(input: unknown): string {
   }
   const strInput = String(input);
   return strInput.trim().replace(/^['"]|['"]$/g, '');
+}
+
+function getContextValues(
+  selection: PropertySelectionHandler,
+  focusedStepInfo: StepInfo
+): StepSelectionValues {
+  if (!selection.dependsOnValues || selection.dependsOnValues.length === 0) {
+    return { config: {}, input: {} };
+  }
+  return buildStepSelectionValues(focusedStepInfo, selection.dependsOnValues);
 }

--- a/src/platform/plugins/shared/workflows_management/tsconfig.json
+++ b/src/platform/plugins/shared/workflows_management/tsconfig.json
@@ -96,7 +96,8 @@
     "@kbn/management-settings-ids",
     "@kbn/use-observable",
     "@kbn/cloud-plugin",
-    "@kbn/std"
+    "@kbn/std",
+    "@kbn/kbn-client"
   ],
   "exclude": ["target/**/*"]
 }

--- a/src/platform/plugins/shared/workflows_management/tsconfig.json
+++ b/src/platform/plugins/shared/workflows_management/tsconfig.json
@@ -96,7 +96,7 @@
     "@kbn/management-settings-ids",
     "@kbn/use-observable",
     "@kbn/cloud-plugin",
-    "@kbn/kbn-client"
+    "@kbn/std"
   ],
   "exclude": ["target/**/*"]
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[One Workflow] Fix custom property selection cache (#263304)](https://github.com/elastic/kibana/pull/263304)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Sergi Massaneda","email":"sergi.massaneda@elastic.co"},"sourceCommit":{"committedDate":"2026-04-16T17:49:57Z","message":"[One Workflow] Fix custom property selection cache (#263304)\n\n## Summary\n\nFixes **custom property selection caching** in the Workflows YAML editor\nby making sibling values **explicit** and by **keying caches** on those\nvalues plus stable step identity. Introduces a **~30s validation-outcome\ncache** so repeated validation does not re-run **`resolve`** /\n**`getDetails`** when nothing semantically relevant changed.\n\nPreviously, validation cleared the per-value cache on every pass and the\nresolved-option cache did not align with how search results were\nkeyed—so caching was largely ineffective. This change wires\n**`dependsOnValues`** into **`context.values`**, search cache keys, and\nvalidation-outcome keys so lists and validation stay correct when\nsibling fields matter.\n\n## What changed\n\n### `dependsOnValues` on `selection` (in _editorHandlers_)\n\n- New optional field on **`PropertySelectionHandler`**:\n**`dependsOnValues?: string[]`** — dot paths such as `config.proxy.ssl`\nor `input.owner`.\n- **`context.values`** is now populated **only** for paths listed in\n`dependsOnValues`. If omitted or empty, **`context.values` is `{ config:\n{}, input: {} }`** (handlers must not assume siblings unless declared).\n- **`StepSelectionValues`** uses **`RecursivePartial`** for `config` /\n`input` to match partial trees built from dotted paths.\n\nexample:\n\n```ts\n    editorHandlers: {\n      config: {\n        'proxy.id': {\n          selection: {\n            dependsOnValues: ['config.proxy.ssl'],\n            search: async (input, context) => {\n              const sslOnly = context.values.config.proxy?.ssl === true;\n              // do API search using input and sslOnly filter\n```\n\n### `buildStepSelectionValues`\n\n- Takes optional **`valuePaths`** (from `dependsOnValues`) and includes\nonly matching **config** / **input** leaves (with ancestor/descendant\npath matching).\n\n### Search + validation caches\n\n- **Search list cache** (`cacheSearchOptions` /\n`getCachedSearchOption`): keyed by step type, scope, property key, and a\n**fingerprint of `context.values`** when non-empty — so unrelated edits\ndo not invalidate completion lists when dependencies are declared\ncorrectly.\n- **Validation outcome cache**: stores the combined result of\n**`resolve` + `getDetails`** (including **`resolvedOption === null`**)\nper logical field, keyed by **`stepId`**, step type, scope, property\nkey, **`context.values` fingerprint**, and serialized property value —\n**30s TTL**. Removes **`clearCache()` on every\n`validateCustomProperties` run** so this cache can actually help across\nvalidation passes.\n- **`CustomPropertyItem`** gains stable **`stepId`** for validation\nkeying.\n\n### Docs & example\n\n- **`STEPS.md`**: documents `dependsOnValues`, editor caching behavior\n(search vs validation), and implementation guidance for\n**`getDetails`**.\n- **Example** `external_step`: `dependsOnValues: ['config.proxy.ssl']`\nfor `config.proxy.id` selection.\n\n## Files (high level)\n\n| Area | Files |\n|------|--------|\n| Types | `kbn-workflows/types/v1.ts` |\n| Lookup / values | `build_workflow_lookup.ts` (+ tests) |\n| Collection / types | `collect_all_custom_property_items.ts`,\n`model/types.ts` (+ tests) |\n| Validation | `validate_custom_properties.ts` (+ tests) |\n| Caching | `custom_property_selection_cache.ts` (+ tests) |\n| Autocomplete | `get_custom_property_suggestions.ts` |\n| Docs / example | `STEPS.md`, `external_step.ts` |\n\n## How to test\n\n- [x] Unit tests updated/added in the files above\n(`build_workflow_lookup`, `collect_all_custom_property_items`,\n`validate_custom_properties`, `custom_property_selection_cache`).\n- [x] Manual: custom step with **`dependsOnValues`** — confirm\nsearch/validation respect sibling values and do not spam\n**`resolve`**/**`getDetails`** when editing unrelated YAML.\n\n## Release note\n\nUser-visible: **more reliable caching** for workflow step property\nselection and validation in the YAML editor; extension authors should\nset **`dependsOnValues`** when **`search` / `resolve` / `getDetails`**\ndepend on other step fields.","sha":"b68db048962cf49f363c1ae6ae1cf32a9009d536","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:skip","backport:version","Team:One Workflow","v9.4.0","v9.5.0"],"title":"[One Workflow] Fix custom property selection cache","number":263304,"url":"https://github.com/elastic/kibana/pull/263304","mergeCommit":{"message":"[One Workflow] Fix custom property selection cache (#263304)\n\n## Summary\n\nFixes **custom property selection caching** in the Workflows YAML editor\nby making sibling values **explicit** and by **keying caches** on those\nvalues plus stable step identity. Introduces a **~30s validation-outcome\ncache** so repeated validation does not re-run **`resolve`** /\n**`getDetails`** when nothing semantically relevant changed.\n\nPreviously, validation cleared the per-value cache on every pass and the\nresolved-option cache did not align with how search results were\nkeyed—so caching was largely ineffective. This change wires\n**`dependsOnValues`** into **`context.values`**, search cache keys, and\nvalidation-outcome keys so lists and validation stay correct when\nsibling fields matter.\n\n## What changed\n\n### `dependsOnValues` on `selection` (in _editorHandlers_)\n\n- New optional field on **`PropertySelectionHandler`**:\n**`dependsOnValues?: string[]`** — dot paths such as `config.proxy.ssl`\nor `input.owner`.\n- **`context.values`** is now populated **only** for paths listed in\n`dependsOnValues`. If omitted or empty, **`context.values` is `{ config:\n{}, input: {} }`** (handlers must not assume siblings unless declared).\n- **`StepSelectionValues`** uses **`RecursivePartial`** for `config` /\n`input` to match partial trees built from dotted paths.\n\nexample:\n\n```ts\n    editorHandlers: {\n      config: {\n        'proxy.id': {\n          selection: {\n            dependsOnValues: ['config.proxy.ssl'],\n            search: async (input, context) => {\n              const sslOnly = context.values.config.proxy?.ssl === true;\n              // do API search using input and sslOnly filter\n```\n\n### `buildStepSelectionValues`\n\n- Takes optional **`valuePaths`** (from `dependsOnValues`) and includes\nonly matching **config** / **input** leaves (with ancestor/descendant\npath matching).\n\n### Search + validation caches\n\n- **Search list cache** (`cacheSearchOptions` /\n`getCachedSearchOption`): keyed by step type, scope, property key, and a\n**fingerprint of `context.values`** when non-empty — so unrelated edits\ndo not invalidate completion lists when dependencies are declared\ncorrectly.\n- **Validation outcome cache**: stores the combined result of\n**`resolve` + `getDetails`** (including **`resolvedOption === null`**)\nper logical field, keyed by **`stepId`**, step type, scope, property\nkey, **`context.values` fingerprint**, and serialized property value —\n**30s TTL**. Removes **`clearCache()` on every\n`validateCustomProperties` run** so this cache can actually help across\nvalidation passes.\n- **`CustomPropertyItem`** gains stable **`stepId`** for validation\nkeying.\n\n### Docs & example\n\n- **`STEPS.md`**: documents `dependsOnValues`, editor caching behavior\n(search vs validation), and implementation guidance for\n**`getDetails`**.\n- **Example** `external_step`: `dependsOnValues: ['config.proxy.ssl']`\nfor `config.proxy.id` selection.\n\n## Files (high level)\n\n| Area | Files |\n|------|--------|\n| Types | `kbn-workflows/types/v1.ts` |\n| Lookup / values | `build_workflow_lookup.ts` (+ tests) |\n| Collection / types | `collect_all_custom_property_items.ts`,\n`model/types.ts` (+ tests) |\n| Validation | `validate_custom_properties.ts` (+ tests) |\n| Caching | `custom_property_selection_cache.ts` (+ tests) |\n| Autocomplete | `get_custom_property_suggestions.ts` |\n| Docs / example | `STEPS.md`, `external_step.ts` |\n\n## How to test\n\n- [x] Unit tests updated/added in the files above\n(`build_workflow_lookup`, `collect_all_custom_property_items`,\n`validate_custom_properties`, `custom_property_selection_cache`).\n- [x] Manual: custom step with **`dependsOnValues`** — confirm\nsearch/validation respect sibling values and do not spam\n**`resolve`**/**`getDetails`** when editing unrelated YAML.\n\n## Release note\n\nUser-visible: **more reliable caching** for workflow step property\nselection and validation in the YAML editor; extension authors should\nset **`dependsOnValues`** when **`search` / `resolve` / `getDetails`**\ndepend on other step fields.","sha":"b68db048962cf49f363c1ae6ae1cf32a9009d536"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/263304","number":263304,"mergeCommit":{"message":"[One Workflow] Fix custom property selection cache (#263304)\n\n## Summary\n\nFixes **custom property selection caching** in the Workflows YAML editor\nby making sibling values **explicit** and by **keying caches** on those\nvalues plus stable step identity. Introduces a **~30s validation-outcome\ncache** so repeated validation does not re-run **`resolve`** /\n**`getDetails`** when nothing semantically relevant changed.\n\nPreviously, validation cleared the per-value cache on every pass and the\nresolved-option cache did not align with how search results were\nkeyed—so caching was largely ineffective. This change wires\n**`dependsOnValues`** into **`context.values`**, search cache keys, and\nvalidation-outcome keys so lists and validation stay correct when\nsibling fields matter.\n\n## What changed\n\n### `dependsOnValues` on `selection` (in _editorHandlers_)\n\n- New optional field on **`PropertySelectionHandler`**:\n**`dependsOnValues?: string[]`** — dot paths such as `config.proxy.ssl`\nor `input.owner`.\n- **`context.values`** is now populated **only** for paths listed in\n`dependsOnValues`. If omitted or empty, **`context.values` is `{ config:\n{}, input: {} }`** (handlers must not assume siblings unless declared).\n- **`StepSelectionValues`** uses **`RecursivePartial`** for `config` /\n`input` to match partial trees built from dotted paths.\n\nexample:\n\n```ts\n    editorHandlers: {\n      config: {\n        'proxy.id': {\n          selection: {\n            dependsOnValues: ['config.proxy.ssl'],\n            search: async (input, context) => {\n              const sslOnly = context.values.config.proxy?.ssl === true;\n              // do API search using input and sslOnly filter\n```\n\n### `buildStepSelectionValues`\n\n- Takes optional **`valuePaths`** (from `dependsOnValues`) and includes\nonly matching **config** / **input** leaves (with ancestor/descendant\npath matching).\n\n### Search + validation caches\n\n- **Search list cache** (`cacheSearchOptions` /\n`getCachedSearchOption`): keyed by step type, scope, property key, and a\n**fingerprint of `context.values`** when non-empty — so unrelated edits\ndo not invalidate completion lists when dependencies are declared\ncorrectly.\n- **Validation outcome cache**: stores the combined result of\n**`resolve` + `getDetails`** (including **`resolvedOption === null`**)\nper logical field, keyed by **`stepId`**, step type, scope, property\nkey, **`context.values` fingerprint**, and serialized property value —\n**30s TTL**. Removes **`clearCache()` on every\n`validateCustomProperties` run** so this cache can actually help across\nvalidation passes.\n- **`CustomPropertyItem`** gains stable **`stepId`** for validation\nkeying.\n\n### Docs & example\n\n- **`STEPS.md`**: documents `dependsOnValues`, editor caching behavior\n(search vs validation), and implementation guidance for\n**`getDetails`**.\n- **Example** `external_step`: `dependsOnValues: ['config.proxy.ssl']`\nfor `config.proxy.id` selection.\n\n## Files (high level)\n\n| Area | Files |\n|------|--------|\n| Types | `kbn-workflows/types/v1.ts` |\n| Lookup / values | `build_workflow_lookup.ts` (+ tests) |\n| Collection / types | `collect_all_custom_property_items.ts`,\n`model/types.ts` (+ tests) |\n| Validation | `validate_custom_properties.ts` (+ tests) |\n| Caching | `custom_property_selection_cache.ts` (+ tests) |\n| Autocomplete | `get_custom_property_suggestions.ts` |\n| Docs / example | `STEPS.md`, `external_step.ts` |\n\n## How to test\n\n- [x] Unit tests updated/added in the files above\n(`build_workflow_lookup`, `collect_all_custom_property_items`,\n`validate_custom_properties`, `custom_property_selection_cache`).\n- [x] Manual: custom step with **`dependsOnValues`** — confirm\nsearch/validation respect sibling values and do not spam\n**`resolve`**/**`getDetails`** when editing unrelated YAML.\n\n## Release note\n\nUser-visible: **more reliable caching** for workflow step property\nselection and validation in the YAML editor; extension authors should\nset **`dependsOnValues`** when **`search` / `resolve` / `getDetails`**\ndepend on other step fields.","sha":"b68db048962cf49f363c1ae6ae1cf32a9009d536"}}]}] BACKPORT-->