### PR TITLE
[APM] Reenable cypress navigation test

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/ftr_e2e/cypress/e2e/navigation.cy.ts
+++ b/x-pack/solutions/observability/plugins/apm/ftr_e2e/cypress/e2e/navigation.cy.ts
@@ -23,8 +23,7 @@ const serviceOverview = url.format({
   },
 });
 
-// Failing: See https://github.com/elastic/kibana/issues/262820
-describe.skip('When navigating between pages', () => {
+describe('When navigating between pages', () => {
   before(() => {
     synthtrace.index(
       opbeans({


### PR DESCRIPTION
## Summary

Closes #262820

As described in #262892, cypress tests were running into issues caused by the modal announcing AI Agent now being on by default. This lead to the test in this PR being skipped because every cypress run was failing as a result. 

But, #262892 itself fixed the issue so that the test doesn't fail anymore. This PR simply re-enables the test now that it fixed

No need to backport to 9.4 as the test was only skipped in main after it was branched off
