### PR TITLE
[skip ech] privileges_viewer_role.spec.ts

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/privileges_viewer_role.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/privileges_viewer_role.spec.ts
@@ -6,12 +6,12 @@
  */
 
 import { expect } from '@kbn/scout/ui';
-import { tags } from '@kbn/scout';
 
 import { test } from '../fixtures';
 
 // This role behaves like Fleet -> None, Integrations -> Read
-test.describe('When the user has Viewer built-in role', { tag: tags.stateful.classic }, () => {
+// TODO: skipped for running on ECH - needs investigation: https://github.com/elastic/kibana/issues/262268
+test.describe('When the user has Viewer built-in role', { tag: '@local-stateful-classic' }, () => {
   test('Fleet is accessible but user cannot perform any write actions on agent tabs', async ({
     browserAuth,
     pageObjects,


### PR DESCRIPTION
## Summary

Skipping fleet ui test from ECH runs due to regular failures

See https://github.com/elastic/kibana/issues/262268



