### PR TITLE
[Entity Analytics][Leads generation] Removing the explicit threat hunting id from the agent id

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/threat_hunting/top_threat_hunting_leads/use_lead_attachment.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/threat_hunting/top_threat_hunting_leads/use_lead_attachment.ts
@@ -6,6 +6,8 @@
  */
 
 import { useCallback } from 'react';
+import { useUiSetting } from '@kbn/kibana-react-plugin/public';
+import { AGENT_BUILDER_EXPERIMENTAL_FEATURES_SETTING_ID } from '@kbn/management-settings-ids';
 import { THREAT_HUNTING_AGENT_ID } from '../../../../../common/constants';
 import { useKibana } from '../../../../common/lib/kibana';
 import { LEAD_ATTACHMENT_PROMPT } from '../../../../agent_builder/components/prompts';
@@ -48,6 +50,11 @@ const buildLeadPrompt = (lead: HuntingLead): string => {
 
 export const useLeadAttachment = () => {
   const { agentBuilder } = useKibana().services;
+  const skillsEnabled = useUiSetting<boolean>(
+    AGENT_BUILDER_EXPERIMENTAL_FEATURES_SETTING_ID,
+    false
+  );
+  const agentId = skillsEnabled ? undefined : THREAT_HUNTING_AGENT_ID;
 
   const openWithLead = useCallback(
     (lead: HuntingLead) => {
@@ -60,10 +67,10 @@ export const useLeadAttachment = () => {
         newConversation: true,
         initialMessage: buildLeadPrompt(lead),
         sessionTag: 'security',
-        agentId: THREAT_HUNTING_AGENT_ID,
+        agentId,
       });
     },
-    [agentBuilder]
+    [agentBuilder, agentId]
   );
 
   return openWithLead;


### PR DESCRIPTION
## Summary

This PR fixes the bug mentioned at : https://github.com/elastic/kibana/issues/263019


Testing Steps : 

- Enable the following in kibana.dev.yml:
```
feature_flags.overrides:
   aiAssistant.aiAgents.enabled: true
 uiSettings.overrides:
   agentBuilder:experimentalFeatures: true
 xpack.securitySolution.enableExperimental:
   - leadGenerationEnabled
   - entityAnalyticsNewHomePageEnabled
 ```
- Navigate to Security > Entity Analytics.
- Generate or view existing threat hunting leads.
- Click on a lead card or Hunt with AI. You should be able to use the chat and send the message to the Agent builder.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

