### PR TITLE
[Synthetics] Fix package version resolution to use registry latestVersion

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/test/scout/api/services/synthetics_private_location_api_service.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/test/scout/api/services/synthetics_private_location_api_service.ts
@@ -49,6 +49,7 @@ export interface SyntheticsPrivateLocationApi {
 interface FleetPackageItem {
   status?: string;
   version?: string;
+  latestVersion?: string;
   installationInfo?: { version?: string };
 }
 
@@ -68,7 +69,15 @@ export function createSyntheticsPrivateLocationApi(
 
   const fetchSyntheticsPackageVersion = async (): Promise<string> => {
     const { data } = await fleetApi.integration.getPackage('synthetics');
-    return data?.item?.version ?? DEFAULT_SYNTHETICS_VERSION;
+    // When a package is installed, Fleet's GET epm/packages/{name} returns the
+    // *installed* version in `item.version` and exposes the registry's latest in
+    // `item.latestVersion`. Prefer `latestVersion` so no-arg callers of
+    // `installSyntheticsPackage()` always target the registry's latest and
+    // perform a real upgrade even when an older version is already installed
+    // (e.g. the "handles auto upgrading policies" test installs an old version
+    // first, then expects a subsequent no-arg install to upgrade it).
+    const item = data?.item as FleetPackageItem | undefined;
+    return item?.latestVersion ?? item?.version ?? DEFAULT_SYNTHETICS_VERSION;
   };
 
   // The synthetics Fleet package install is a *global* operation: every Scout

--- a/x-pack/solutions/observability/plugins/synthetics/test/scout/api/tests/create_monitor_private_location.spec.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/test/scout/api/tests/create_monitor_private_location.spec.ts
@@ -5,50 +5,156 @@
  * 2.0.
  */
 
+import semver from 'semver';
+import { v4 as uuidv4 } from 'uuid';
+import type { PackagePolicy } from '@kbn/fleet-plugin/common';
 import { expect } from '@kbn/scout-oblt/api';
-import { apiTest } from '../fixtures';
+import type { ApiClientFixture } from '@kbn/scout-oblt';
+import type { ScoutPrivateLocation } from '../services/synthetics_private_location_api_service';
+import { apiTest, mergeSyntheticsApiHeaders, SYNTHETICS_MONITOR_SO_TYPES } from '../fixtures';
+import { addMonitor, deleteMonitors } from '../fixtures/monitors';
+import { getPackagePolicyForMonitor } from '../fixtures/fleet';
+import { tryForTime } from '../fixtures/retry';
+import { httpMonitorFixture } from '../fixtures/data/http_monitor';
 
 /**
- * Ported from FTR `apis/synthetics/create_monitor_private_location.ts`, which
- * was itself `describe.skip` — failing per
+ * Ported from FTR `apis/synthetics/create_monitor_private_location.ts` (the
+ * deployment-agnostic suite), which was `describe.skip` per
  * https://github.com/elastic/kibana/issues/258046.
  *
- * Kept skipped: most cases assert the *full* generated Fleet package-policy via
- * the FTR `comparePolicies` / `getTestSyntheticsPolicy` sample-data helpers
- * (legacy `${monitorId}-${locationId}-${spaceId}` policy-id format). Un-skip
- * once #258046 is resolved and that sample-data comparison is ported to Scout.
+ * Only the `handles auto upgrading policies` case is ported here and active: it
+ * asserts the monitor's Fleet *package-policy version* before/after a package
+ * upgrade and does **not** depend on the `comparePolicies` /
+ * `getTestSyntheticsPolicy` sample-data helpers that block the rest of the FTR
+ * suite. The Scout `${monitorId}-${locationId}` package-policy id format is
+ * already handled by `getPackagePolicyForMonitor`.
  *
- * Original `it` titles (preserved for inventory):
- *   - adds a test fleet policy
- *   - add a test private location
- *   - does not add a monitor if there is an error in creating integration
- *   - adds a monitor in private location
- *   - added an integration for previously added monitor
- *   - edits a monitor with additional private location
- *   - added an integration for second location in edit monitor
- *   - deletes integration for a removed location from monitor
- *   - deletes integration for a deleted monitor
- *   - handles spaces
- *   - handles is_tls_enabled true
- *   - handles is_tls_enabled false
- *   - handles auto upgrading policies
- *   - returns bad request if payload is invalid for HTTP monitor
- *   - returns bad request if monitor type is invalid
- *   - can create valid monitors without all defaults
- *   - can disable retries
- *   - can enable retries with max attempts
- *   - can enable retries
- *   - cannot create a invalid monitor without a monitor type
- *   - omits unknown keys
- *   - preserves the passed namespace when preserve_namespace is passed
- *   - sets namespace to custom namespace when set
+ * Still pending (blocked by #258046 — they assert the full generated package
+ * policy via the sample-data comparison, not yet ported to Scout):
+ *   - adds a monitor in private location / added an integration for it
+ *   - edits a monitor with additional private location (+ second-location policy)
+ *   - deletes integration for a removed location / a deleted monitor
+ *   - handles spaces / is_tls_enabled true|false
+ *   - returns bad request (invalid payload / invalid monitor type)
+ *   - can create valid monitors without all defaults / retries variants
+ *   - omits unknown keys / namespace preservation cases
+ *
+ * The synthetics Scout API config runs serially (`workers: 1`,
+ * `fullyParallel: false`), so this test can safely downgrade the *global*
+ * synthetics Fleet package and restore it without racing sibling specs.
  */
-apiTest.describe.skip(
+// Forcing a package downgrade + upgrade and waiting out Fleet's policy
+// auto-upgrade sweep can take a few minutes; the default 60s per-test timeout
+// is not enough.
+const TEST_TIMEOUT = 5 * 60 * 1000;
+
+apiTest.describe(
   'PrivateLocationCreateMonitor',
   { tag: ['@local-stateful-classic', '@local-serverless-observability_complete'] },
   () => {
-    apiTest('pending Scout port (blocked by #258046) — see file header', async ({ apiClient }) => {
-      expect(Boolean(apiClient)).toBe(true);
+    const LOWER_VERSION = '1.1.1';
+
+    let editorHeaders: Record<string, string>;
+    let adminHeaders: Record<string, string>;
+    let testPolicyId: string;
+    let privateLocation: ScoutPrivateLocation;
+
+    apiTest.beforeAll(async ({ requestAuth, apiServices, kbnClient }) => {
+      const { apiKeyHeader: editorKey } = await requestAuth.getApiKey('editor');
+      editorHeaders = mergeSyntheticsApiHeaders(editorKey);
+      const { apiKeyHeader: adminKey } = await requestAuth.getApiKey('admin');
+      adminHeaders = mergeSyntheticsApiHeaders(adminKey);
+
+      await kbnClient.savedObjects.clean({ types: SYNTHETICS_MONITOR_SO_TYPES });
+      await apiServices.syntheticsPrivateLocations.installSyntheticsPackage();
+      const { id: policyId } = await apiServices.syntheticsPrivateLocations.addFleetPolicy(
+        `Fleet test server policy ${Date.now()}`
+      );
+      testPolicyId = policyId;
+      [privateLocation] = await apiServices.syntheticsPrivateLocations.setTestLocations([
+        testPolicyId,
+      ]);
     });
+
+    apiTest.afterAll(async ({ apiServices, kbnClient }) => {
+      await kbnClient.savedObjects.clean({ types: SYNTHETICS_MONITOR_SO_TYPES });
+      await apiServices.syntheticsPrivateLocations.cleanUpPrivateLocationsAndPolicies();
+      // Safety net: ensure the global package is back at the latest version even
+      // if the test body's own restore did not run.
+      await apiServices.syntheticsPrivateLocations.installSyntheticsPackage();
+    });
+
+    const getPolicy = (
+      apiClient: ApiClientFixture,
+      monitorId: string,
+      locationId: string
+    ): Promise<PackagePolicy | undefined> =>
+      getPackagePolicyForMonitor(apiClient, adminHeaders, monitorId, locationId);
+
+    apiTest(
+      'handles auto upgrading policies',
+      async ({ apiClient, apiServices }) => {
+        apiTest.setTimeout(TEST_TIMEOUT);
+        // The package-registry-verify-and-promote pipeline may run against a
+        // registry that doesn't publish old versions — skip gracefully (mirrors
+        // the FTR `this.skip()` on a 404) rather than failing the install loop.
+        const pkgCheck = await apiClient.get(`api/fleet/epm/packages/synthetics/${LOWER_VERSION}`, {
+          headers: adminHeaders,
+          responseType: 'json',
+        });
+        apiTest.skip(
+          pkgCheck.statusCode === 404,
+          `synthetics ${LOWER_VERSION} not available in package registry`
+        );
+
+        // Force the global synthetics package down to an older version so the
+        // monitor's package policy is created at that version.
+        await apiServices.syntheticsPrivateLocations.installSyntheticsPackage({
+          version: LOWER_VERSION,
+        });
+
+        let monitorId = '';
+        try {
+          const res = await addMonitor(apiClient, editorHeaders, {
+            ...httpMonitorFixture,
+            locations: [privateLocation],
+            name: `Test monitor ${uuidv4()}`,
+            namespace: 'default',
+          });
+          monitorId = (res.body as { id: string }).id;
+
+          await tryForTime(30_000, async () => {
+            const policy = await getPolicy(apiClient, monitorId, testPolicyId);
+            expect(policy?.package?.version).toBe(LOWER_VERSION);
+          });
+
+          // Reinstall the package at the latest version, then trigger Fleet
+          // setup. `installSyntheticsPackage` runs `POST /api/fleet/setup`
+          // *before* the install, so the managed-policy upgrade sweep
+          // (`setupUpgradeManagedPackagePolicies`) sees the old version and is a
+          // no-op. An explicit setup *after* the upgrade detects the now-outdated
+          // policy and schedules its upgrade — without it the test passively
+          // waits on a ~5-minute scheduled task that never fires within 120s
+          // (see PR #264487, which fixed the same flake in the FTR suite).
+          await apiServices.syntheticsPrivateLocations.installSyntheticsPackage();
+          await apiServices.fleet.internal.setup();
+
+          await tryForTime(120_000, async () => {
+            const upgraded = await getPolicy(apiClient, monitorId, testPolicyId);
+            const upgradedVersion = upgraded?.package?.version;
+            expect(
+              Boolean(upgradedVersion && semver.gt(upgradedVersion, LOWER_VERSION))
+            ).toBe(true);
+          });
+        } finally {
+          if (monitorId) {
+            await deleteMonitors(apiClient, editorHeaders, [monitorId], { spaceId: 'default' });
+          }
+          // Restore the latest package version — subsequent specs in this worker
+          // assume the package is at the latest version.
+          await apiServices.syntheticsPrivateLocations.installSyntheticsPackage();
+        }
+      }
+    );
   }
 );

--- a/x-pack/solutions/observability/plugins/synthetics/test/scout/api/tests/create_monitor_private_location.spec.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/test/scout/api/tests/create_monitor_private_location.spec.ts
@@ -91,70 +91,65 @@ apiTest.describe(
     ): Promise<PackagePolicy | undefined> =>
       getPackagePolicyForMonitor(apiClient, adminHeaders, monitorId, locationId);
 
-    apiTest(
-      'handles auto upgrading policies',
-      async ({ apiClient, apiServices }) => {
-        apiTest.setTimeout(TEST_TIMEOUT);
-        // The package-registry-verify-and-promote pipeline may run against a
-        // registry that doesn't publish old versions — skip gracefully (mirrors
-        // the FTR `this.skip()` on a 404) rather than failing the install loop.
-        const pkgCheck = await apiClient.get(`api/fleet/epm/packages/synthetics/${LOWER_VERSION}`, {
-          headers: adminHeaders,
-          responseType: 'json',
+    apiTest('handles auto upgrading policies', async ({ apiClient, apiServices }) => {
+      apiTest.setTimeout(TEST_TIMEOUT);
+      // The package-registry-verify-and-promote pipeline may run against a
+      // registry that doesn't publish old versions — skip gracefully (mirrors
+      // the FTR `this.skip()` on a 404) rather than failing the install loop.
+      const pkgCheck = await apiClient.get(`api/fleet/epm/packages/synthetics/${LOWER_VERSION}`, {
+        headers: adminHeaders,
+        responseType: 'json',
+      });
+      apiTest.skip(
+        pkgCheck.statusCode === 404,
+        `synthetics ${LOWER_VERSION} not available in package registry`
+      );
+
+      // Force the global synthetics package down to an older version so the
+      // monitor's package policy is created at that version.
+      await apiServices.syntheticsPrivateLocations.installSyntheticsPackage({
+        version: LOWER_VERSION,
+      });
+
+      let monitorId = '';
+      try {
+        const res = await addMonitor(apiClient, editorHeaders, {
+          ...httpMonitorFixture,
+          locations: [privateLocation],
+          name: `Test monitor ${uuidv4()}`,
+          namespace: 'default',
         });
-        apiTest.skip(
-          pkgCheck.statusCode === 404,
-          `synthetics ${LOWER_VERSION} not available in package registry`
-        );
+        monitorId = (res.body as { id: string }).id;
 
-        // Force the global synthetics package down to an older version so the
-        // monitor's package policy is created at that version.
-        await apiServices.syntheticsPrivateLocations.installSyntheticsPackage({
-          version: LOWER_VERSION,
+        await tryForTime(30_000, async () => {
+          const policy = await getPolicy(apiClient, monitorId, testPolicyId);
+          expect(policy?.package?.version).toBe(LOWER_VERSION);
         });
 
-        let monitorId = '';
-        try {
-          const res = await addMonitor(apiClient, editorHeaders, {
-            ...httpMonitorFixture,
-            locations: [privateLocation],
-            name: `Test monitor ${uuidv4()}`,
-            namespace: 'default',
-          });
-          monitorId = (res.body as { id: string }).id;
+        // Reinstall the package at the latest version, then trigger Fleet
+        // setup. `installSyntheticsPackage` runs `POST /api/fleet/setup`
+        // *before* the install, so the managed-policy upgrade sweep
+        // (`setupUpgradeManagedPackagePolicies`) sees the old version and is a
+        // no-op. An explicit setup *after* the upgrade detects the now-outdated
+        // policy and schedules its upgrade — without it the test passively
+        // waits on a ~5-minute scheduled task that never fires within 120s
+        // (see PR #264487, which fixed the same flake in the FTR suite).
+        await apiServices.syntheticsPrivateLocations.installSyntheticsPackage();
+        await apiServices.fleet.internal.setup();
 
-          await tryForTime(30_000, async () => {
-            const policy = await getPolicy(apiClient, monitorId, testPolicyId);
-            expect(policy?.package?.version).toBe(LOWER_VERSION);
-          });
-
-          // Reinstall the package at the latest version, then trigger Fleet
-          // setup. `installSyntheticsPackage` runs `POST /api/fleet/setup`
-          // *before* the install, so the managed-policy upgrade sweep
-          // (`setupUpgradeManagedPackagePolicies`) sees the old version and is a
-          // no-op. An explicit setup *after* the upgrade detects the now-outdated
-          // policy and schedules its upgrade — without it the test passively
-          // waits on a ~5-minute scheduled task that never fires within 120s
-          // (see PR #264487, which fixed the same flake in the FTR suite).
-          await apiServices.syntheticsPrivateLocations.installSyntheticsPackage();
-          await apiServices.fleet.internal.setup();
-
-          await tryForTime(120_000, async () => {
-            const upgraded = await getPolicy(apiClient, monitorId, testPolicyId);
-            const upgradedVersion = upgraded?.package?.version;
-            expect(
-              Boolean(upgradedVersion && semver.gt(upgradedVersion, LOWER_VERSION))
-            ).toBe(true);
-          });
-        } finally {
-          if (monitorId) {
-            await deleteMonitors(apiClient, editorHeaders, [monitorId], { spaceId: 'default' });
-          }
-          // Restore the latest package version — subsequent specs in this worker
-          // assume the package is at the latest version.
-          await apiServices.syntheticsPrivateLocations.installSyntheticsPackage();
+        await tryForTime(120_000, async () => {
+          const upgraded = await getPolicy(apiClient, monitorId, testPolicyId);
+          const upgradedVersion = upgraded?.package?.version;
+          expect(Boolean(upgradedVersion && semver.gt(upgradedVersion, LOWER_VERSION))).toBe(true);
+        });
+      } finally {
+        if (monitorId) {
+          await deleteMonitors(apiClient, editorHeaders, [monitorId], { spaceId: 'default' });
         }
+        // Restore the latest package version — subsequent specs in this worker
+        // assume the package is at the latest version.
+        await apiServices.syntheticsPrivateLocations.installSyntheticsPackage();
       }
-    );
+    });
   }
 );

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/services/synthetics_private_location.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/services/synthetics_private_location.ts
@@ -30,7 +30,17 @@ export class PrivateLocationTestService {
     const res = await this.supertestWithAuth
       .get('/api/fleet/epm/packages/synthetics')
       .set('kbn-xsrf', 'true');
-    return res.body?.item?.version ?? DEFAULT_SYNTHETICS_VERSION;
+    // When a package is installed, Fleet's GET /api/fleet/epm/packages/{name}
+    // returns the *installed* version in `item.version` and exposes the
+    // registry's latest version in `item.latestVersion`. We always want the
+    // latest available version from the registry so that callers of
+    // `installSyntheticsPackage()` (without an explicit version) perform a
+    // real upgrade even when an older version happens to be installed — for
+    // example by the "handles auto upgrading policies" test which first
+    // installs an old version and then expects a subsequent no-arg install
+    // to upgrade it.
+    const item = res.body?.item;
+    return item?.latestVersion ?? item?.version ?? DEFAULT_SYNTHETICS_VERSION;
   }
 
   async installSyntheticsPackage({ version }: { version?: string } = {}) {
@@ -52,8 +62,13 @@ export class PrivateLocationTestService {
         .send({ force: true })
         .expect(200);
       // Verify the version actually took effect — background Fleet tasks
-      // (e.g. deferred upgradePackageInstallVersion) can race and overwrite it
-      const installedVersion = await this.fetchSyntheticsPackageVersion();
+      // (e.g. deferred upgradePackageInstallVersion) can race and overwrite it.
+      // Read the installed version directly (not via fetchSyntheticsPackageVersion,
+      // which returns the registry's latest) to detect such races.
+      const infoRes = await this.supertestWithAuth
+        .get('/api/fleet/epm/packages/synthetics')
+        .set('kbn-xsrf', 'true');
+      const installedVersion = infoRes.body?.item?.version;
       if (installedVersion !== resolvedVersion) {
         throw new Error(
           `Package version mismatch after install: expected ${resolvedVersion} but got ${installedVersion}`


### PR DESCRIPTION
## Summary

Towards #258046. The `handles auto upgrading policies` test installs the synthetics package at an old version, creates a monitor, then calls `installSyntheticsPackage()` with no arguments expecting an upgrade to the registry's latest version.

### Root cause

`fetchSyntheticsPackageVersion()` read `item.version`. Fleet's `GET /api/fleet/epm/packages/{name}` returns the **installed** version in `item.version` when a package is installed and exposes the registry's latest in `item.latestVersion`. With an old version installed, the helper resolved the target version to that same old version, so the no-arg "upgrade" was a no-op and the test's retry timed out (`Expected x.y.z to be greater than x.y.z`).

### Fix

`fetchSyntheticsPackageVersion()` now prefers `item.latestVersion` (fallback to `item.version`, then `DEFAULT_SYNTHETICS_VERSION`) so no-arg callers always target the registry's latest version.

### Note: relocated to Scout

This fix originally targeted the deployment-agnostic FTR `PrivateLocationTestService`. That suite has since been migrated to Scout and retired (#272287), so the change has been **relocated** to the Scout service `synthetics_private_location_api_service.ts`, where the same bug exists. The post-install verification half of the original fix is already present in the Scout service via `isInstalledAt` (which reads the installed version directly), so only the `fetchSyntheticsPackageVersion` change is needed here.

The "handles auto upgrading policies" assertion now lives in the Scout `create_monitor_private_location.spec.ts`, which is currently `describe.skip` pending both #258046 and a separate `comparePolicies` sample-data port. This PR fixes the package-version resolution; un-skipping that spec is follow-up work.

## Test plan

- [ ] CI green.
- [ ] Follow-up: port `comparePolicies` sample data to Scout and un-skip `create_monitor_private_location.spec.ts` to validate end-to-end and close #258046.
