### PR TITLE
[Entity Store] Remove logExtractionParams from install route and drop unused filter param'

### DIFF
--- a/x-pack/solutions/security/plugins/entity_store/server/domain/asset_manager/asset_manager_client.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/asset_manager/asset_manager_client.ts
@@ -35,7 +35,7 @@ import {
   HistorySnapshotState,
   LogExtractionConfig,
 } from '../saved_objects';
-import type { HistorySnapshotBodyParams, LogExtractionInstallParams } from '../../routes/constants';
+import type { HistorySnapshotBodyParams } from '../../routes/constants';
 import {
   ENGINE_STATUS,
   ENTITY_STORE_CLUSTER_PRIVILEGES,
@@ -116,11 +116,10 @@ export class AssetManagerClient {
   public async init(
     request: KibanaRequest,
     entityTypes: EntityType[],
-    logsExtractionParams?: LogExtractionInstallParams,
     historySnapshotParams?: HistorySnapshotBodyParams
   ) {
     try {
-      const logsExtraction = LogExtractionConfig.parse(logsExtractionParams ?? {});
+      const logsExtraction = LogExtractionConfig.parse({});
       const historySnapshot = HistorySnapshotState.parse(historySnapshotParams ?? {});
 
       // Phase 1: Install shared ES assets and run independent setup tasks.

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/logs_extraction_client.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/logs_extraction_client.test.ts
@@ -897,7 +897,6 @@ describe('LogsExtractionClient', () => {
 
     it('should update multiple fields at once', async () => {
       const result = await client.updateConfig({
-        filter: 'agent.type:filebeat',
         additionalIndexPatterns: ['custom-logs-*'],
         lookbackPeriod: '6h',
         delay: '30s',
@@ -906,7 +905,6 @@ describe('LogsExtractionClient', () => {
         fieldHistoryLength: 5,
       });
 
-      expect(result.filter).toBe('agent.type:filebeat');
       expect(result.additionalIndexPatterns).toEqual(['custom-logs-*']);
       expect(result.lookbackPeriod).toBe('6h');
       expect(result.delay).toBe('30s');

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/saved_objects/global_state/constants.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/saved_objects/global_state/constants.ts
@@ -20,7 +20,6 @@ export const LOG_EXTRACTION_TIMEOUT_DEFAULT = '25s';
 
 export type LogExtractionConfig = z.infer<typeof LogExtractionConfig>;
 export const LogExtractionConfig = z.object({
-  filter: z.string().default(''),
   additionalIndexPatterns: z.array(z.string()).default([]),
   fieldHistoryLength: z.number().int().default(10),
   lookbackPeriod: z

--- a/x-pack/solutions/security/plugins/entity_store/server/routes/apis/install/index.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/routes/apis/install/index.ts
@@ -36,13 +36,10 @@ export function registerInstall(router: EntityStorePluginRouter) {
       wrapMiddlewares(async (ctx, req, res): Promise<IKibanaResponse> => {
         const entityStoreCtx = await ctx.entityStore;
         const { logger, assetManagerClient: assetManager } = entityStoreCtx;
-        const { entityTypes, logExtraction, historySnapshot } = req.body;
+        const { entityTypes, historySnapshot } = req.body;
         logger.debug('Install api called');
 
-        const privileges = await assetManager.getPrivileges(
-          req,
-          logExtraction?.additionalIndexPatterns
-        );
+        const privileges = await assetManager.getPrivileges(req);
         if (!privileges.hasAllRequested) {
           return res.forbidden({
             body: {
@@ -59,7 +56,7 @@ export function registerInstall(router: EntityStorePluginRouter) {
           return res.ok({ body: { ok: true } });
         }
 
-        await assetManager.init(req, toInstall, logExtraction, historySnapshot);
+        await assetManager.init(req, toInstall, historySnapshot);
 
         return res.created({ body: { ok: true } });
       })

--- a/x-pack/solutions/security/plugins/entity_store/server/routes/apis/install/validator.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/routes/apis/install/validator.ts
@@ -9,13 +9,11 @@ import { z } from '@kbn/zod/v4';
 import { EntityType, ALL_ENTITY_TYPES } from '../../../../common/domain/definitions/entity_schema';
 import { HistorySnapshotBodyParams } from '../../constants';
 import { parseDurationToMs } from '../../../infra/time';
-import { LogExtractionInstallSchema } from '../utils/log_extraction_validator';
 
 const MIN_HISTORY_SNAPSHOT_FREQUENCY_MS = 60 * 60 * 1000; // 1h
 
 export const BodySchema = z.object({
   entityTypes: z.array(EntityType).optional().default(ALL_ENTITY_TYPES),
-  logExtraction: LogExtractionInstallSchema,
   historySnapshot: HistorySnapshotBodyParams.optional().superRefine(validateHistorySnapshotParams),
 });
 

--- a/x-pack/solutions/security/plugins/entity_store/server/routes/apis/status.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/routes/apis/status.ts
@@ -53,13 +53,12 @@ function toPublicEngine(
   logsExtractionConfig: LogExtractionConfig
 ): StatusEngine {
   const { versionState, logExtractionState, ...rest } = engine;
-  const { delay, timeout, frequency, lookbackPeriod, fieldHistoryLength, filter, maxLogsPerPage } =
+  const { delay, timeout, frequency, lookbackPeriod, fieldHistoryLength, maxLogsPerPage } =
     logsExtractionConfig;
 
   return {
     ...rest,
     // TODO: Remove the legacy fields once we stop supporting V1.
-    filter,
     delay,
     timeout,
     frequency,

--- a/x-pack/solutions/security/plugins/entity_store/server/routes/apis/utils/log_extraction_validator.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/routes/apis/utils/log_extraction_validator.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { z } from '@kbn/zod/v4';
-import { LogExtractionInstallSchema, validateKql } from './log_extraction_validator';
+import { LogExtractionInstallSchema } from './log_extraction_validator';
 
 const TestSchema = z.object({ logExtraction: LogExtractionInstallSchema });
 
@@ -61,102 +61,3 @@ describe('LogExtractionInstallParams additionalIndexPatterns', () => {
   });
 });
 
-describe('validateKql', () => {
-  describe('valid KQL syntax', () => {
-    it('returns isValid true for field:value', () => {
-      expect(validateKql('foo:bar').isValid).toBe(true);
-      expect(validateKql('response:200').isValid).toBe(true);
-    });
-
-    it('returns isValid true for quoted value', () => {
-      expect(validateKql('foo:"bar baz"').isValid).toBe(true);
-    });
-
-    it('returns isValid true for AND/OR expressions', () => {
-      expect(validateKql('foo:bar and baz:qux').isValid).toBe(true);
-      expect(validateKql('foo:bar or baz:qux').isValid).toBe(true);
-      expect(validateKql('response:200 and nestedField:{ childOfNested: foo }').isValid).toBe(true);
-    });
-
-    it('returns isValid true for parenthesized and nested field', () => {
-      expect(validateKql('foo:(bar or baz)').isValid).toBe(true);
-      expect(validateKql('nestedField:{ childOfNested: value }').isValid).toBe(true);
-    });
-
-    it('returns isValid true for empty or whitespace-only string', () => {
-      expect(validateKql('').isValid).toBe(true);
-      expect(validateKql('   ').isValid).toBe(true);
-      expect(validateKql('\t').isValid).toBe(true);
-    });
-  });
-
-  describe('invalid KQL syntax', () => {
-    it('returns isValid false when field query is missing a value', () => {
-      const result = validateKql('response:');
-      expect(result.isValid).toBe(false);
-      expect(result.errorMsg).toBeDefined();
-      expect(result.errorMsg!.length).toBeGreaterThan(0);
-    });
-
-    it('returns isValid false when OR query is missing right side', () => {
-      const result = validateKql('response:200 or ');
-      expect(result.isValid).toBe(false);
-      expect(result.errorMsg).toBeDefined();
-      expect(result.errorMsg!.length).toBeGreaterThan(0);
-    });
-
-    it('returns isValid false when NOT query is missing sub-query', () => {
-      const result = validateKql('response:200 and not ');
-      expect(result.isValid).toBe(false);
-      expect(result.errorMsg).toBeDefined();
-      expect(result.errorMsg!.length).toBeGreaterThan(0);
-    });
-
-    it('returns isValid false for unbalanced quotes', () => {
-      const result = validateKql('foo:"ba ');
-      expect(result.isValid).toBe(false);
-      expect(result.errorMsg).toBeDefined();
-      expect(result.errorMsg!.length).toBeGreaterThan(0);
-    });
-
-    it('returns isValid false for expression without field (no colon)', () => {
-      const resultBar = validateKql('foo and bar');
-      expect(resultBar.isValid).toBe(false);
-      expect(resultBar.errorMsg).toBe('Field-based KQL is required');
-      const resultFoo = validateKql('foo');
-      expect(resultFoo.isValid).toBe(false);
-      expect(resultFoo.errorMsg).toBe('Field-based KQL is required');
-    });
-
-    it('returns isValid false for trailing "and" or "or"', () => {
-      const resultAnd = validateKql('foo:bar and ');
-      expect(resultAnd.isValid).toBe(false);
-      expect(resultAnd.errorMsg).toBeDefined();
-      expect(resultAnd.errorMsg!.length).toBeGreaterThan(0);
-      const resultOr = validateKql('foo:bar or ');
-      expect(resultOr.isValid).toBe(false);
-      expect(resultOr.errorMsg).toBeDefined();
-      expect(resultOr.errorMsg!.length).toBeGreaterThan(0);
-    });
-
-    it('returns isValid false for invalid range (missing value)', () => {
-      const result = validateKql('foo > ');
-      expect(result.isValid).toBe(false);
-      expect(result.errorMsg).toBeDefined();
-      expect(result.errorMsg!.length).toBeGreaterThan(0);
-    });
-
-    it('returns isValid false for invalid range (missing field)', () => {
-      const result = validateKql('< 1000');
-      expect(result.isValid).toBe(false);
-      expect(result.errorMsg).toBeDefined();
-      expect(result.errorMsg!.length).toBeGreaterThan(0);
-    });
-
-    it('returns isValid false for range without colon (field-based KQL required)', () => {
-      const result = validateKql('bytes > 1000');
-      expect(result.isValid).toBe(false);
-      expect(result.errorMsg).toBe('Field-based KQL is required');
-    });
-  });
-});

--- a/x-pack/solutions/security/plugins/entity_store/server/routes/apis/utils/log_extraction_validator.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/routes/apis/utils/log_extraction_validator.test.ts
@@ -60,4 +60,3 @@ describe('LogExtractionInstallParams additionalIndexPatterns', () => {
     }
   });
 });
-

--- a/x-pack/solutions/security/plugins/entity_store/server/routes/apis/utils/log_extraction_validator.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/routes/apis/utils/log_extraction_validator.ts
@@ -7,7 +7,6 @@
 
 import { z } from '@kbn/zod/v4';
 import { validateDataView } from '@kbn/data-view-validation';
-import { fromKueryExpression } from '@kbn/es-query';
 import type { LogExtractionBodyParams } from '../../constants';
 import { LogExtractionInstallParams, LogExtractionUpdateParams } from '../../constants';
 import { parseDurationToMs } from '../../../infra/time';
@@ -17,42 +16,6 @@ import {
 } from '../../../domain/saved_objects';
 
 const MIN_FREQUENCY_MS = 30 * 1000;
-
-export function validateKql(kql: string): { isValid: boolean; errorMsg?: string } {
-  try {
-    if (!kql || kql.trim() === '') {
-      return { isValid: true };
-    }
-
-    fromKueryExpression(kql);
-
-    if (/(\s+)(and|or)\s*$/i.test(kql)) {
-      throw new Error('Incomplete KQL expression');
-    }
-
-    if (!kql.includes(':')) {
-      throw new Error('Field-based KQL is required');
-    }
-
-    return { isValid: true };
-  } catch (error) {
-    return { isValid: false, errorMsg: error.message };
-  }
-}
-
-function validateFilter(data: LogExtractionBodyParams, ctx: z.RefinementCtx): void {
-  if (data.filter === undefined) {
-    return;
-  }
-  const { isValid, errorMsg } = validateKql(data.filter);
-  if (!isValid) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      path: ['filter'],
-      message: errorMsg,
-    });
-  }
-}
 
 function validateFrequencyParam(data: LogExtractionBodyParams, ctx: z.RefinementCtx): void {
   if (data.frequency === undefined) {
@@ -134,7 +97,6 @@ export function validateLogExtractionParams(
 ): void {
   if (!data) return;
 
-  validateFilter(data, ctx);
   validateFrequencyParam(data, ctx);
   validateAdditionalIndexPatterns(data, ctx);
   validateDelayVsLookbackPeriod(data, ctx);

--- a/x-pack/solutions/security/plugins/entity_store/server/routes/constants.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/routes/constants.ts
@@ -21,7 +21,6 @@ export type LogExtractionInstallParams = z.infer<typeof LogExtractionInstallPara
 // timeout: intentionally excluded from LogExtractionBodyParams
 // TODO: add timeout once we have a way to set it as a task override param
 export const LogExtractionInstallParams = LogExtractionConfig.pick({
-  filter: true,
   fieldHistoryLength: true,
   additionalIndexPatterns: true,
   lookbackPeriod: true,
@@ -34,7 +33,6 @@ export const LogExtractionInstallParams = LogExtractionConfig.pick({
 export type LogExtractionUpdateParams = z.infer<typeof LogExtractionUpdateParams>;
 
 export const LogExtractionUpdateParams = z.object({
-  filter: z.string().optional(),
   fieldHistoryLength: z.number().int().optional(),
   additionalIndexPatterns: z.array(z.string()).optional(),
   lookbackPeriod: z

--- a/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/entity_extraction_paginated.spec.ts
+++ b/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/entity_extraction_paginated.spec.ts
@@ -45,13 +45,17 @@ apiTest.describe(
       const response = await apiClient.post(ENTITY_STORE_ROUTES.public.INSTALL, {
         headers: defaultHeaders,
         responseType: 'json',
-        body: {
-          logExtraction: {
-            docsLimit: 5,
-          },
-        },
+        body: {},
       });
       expect(response.statusCode).toBe(201);
+
+      // Set docsLimit via update (logExtraction removed from install)
+      const update = await apiClient.put(ENTITY_STORE_ROUTES.public.UPDATE, {
+        headers: defaultHeaders,
+        responseType: 'json',
+        body: { logExtraction: { docsLimit: 5 } },
+      });
+      expect(update.statusCode).toBe(200);
 
       await esArchiver.loadIfNeeded(
         'x-pack/solutions/security/plugins/entity_store/test/scout/api/es_archives/updates'

--- a/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/install_privileges.spec.ts
+++ b/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/install_privileges.spec.ts
@@ -62,12 +62,9 @@ apiTest.describe('Entity Store install - privilege checks', { tag: ENTITY_STORE_
     };
   };
 
-  const getRoleWithAllPrivileges = () => buildRoleDescriptor();
   const getRoleWithoutTargetIndexPrivileges = () => buildRoleDescriptor({ withTargetIndex: false });
   const getRoleWithoutSavedObjectCreate = () =>
     buildRoleDescriptor({ withSavedObjectCreate: false });
-
-  let additionalIndicesToCleanup: string[] = [];
 
   apiTest.beforeEach(async ({ kbnClient }) => {
     await kbnClient.uiSettings.update({
@@ -82,39 +79,9 @@ apiTest.describe('Entity Store install - privilege checks', { tag: ENTITY_STORE_
         headers: { ...credentials.cookieHeader, ...PUBLIC_HEADERS },
         body: {},
       }),
-      ...additionalIndicesToCleanup.map((index) =>
-        esClient.indices.delete({ index, ignore_unavailable: true })
-      ),
     ]);
-    additionalIndicesToCleanup = [];
     await clearEntityStoreIndices(esClient);
   });
-
-  apiTest(
-    'Should fail when user lacks permissions for source index patterns',
-    async ({ apiClient, esClient, requestAuth }) => {
-      const restrictedIndex = 'restricted-test-logs';
-      additionalIndicesToCleanup = [restrictedIndex];
-
-      await esClient.indices.create({ index: restrictedIndex });
-
-      const { apiKeyHeader } = await requestAuth.getApiKeyForCustomRole(getRoleWithAllPrivileges());
-
-      const response = await apiClient.post(ENTITY_STORE_ROUTES.public.INSTALL, {
-        headers: { ...PUBLIC_HEADERS, ...apiKeyHeader },
-        responseType: 'json',
-        body: { logExtraction: { additionalIndexPatterns: [restrictedIndex] } },
-      });
-
-      expect(response.statusCode).toBe(403);
-      expect(response.body.attributes).toMatchObject({
-        missing_elasticsearch_privileges: {
-          cluster: [],
-          index: [{ index: restrictedIndex, privileges: ENTITY_STORE_SOURCE_INDICES_PRIVILEGES }],
-        },
-      });
-    }
-  );
 
   apiTest(
     'Should fail when user lacks permissions for target index patterns',

--- a/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/install_update.spec.ts
+++ b/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/install_update.spec.ts
@@ -170,16 +170,12 @@ apiTest.describe('Entity Store install / update API tests', { tag: ENTITY_STORE_
         body: {},
       });
 
-      // Set initial params via update (logExtraction removed from install)
-      await apiClient.put(ENTITY_STORE_ROUTES.public.UPDATE, {
-        headers: defaultHeaders,
       const initialUpdate = await apiClient.put(ENTITY_STORE_ROUTES.public.UPDATE, {
         headers: defaultHeaders,
         responseType: 'json',
         body: { logExtraction: { delay: '2m', frequency: '1m' } },
       });
       expect(initialUpdate.statusCode).toBe(200);
-        body: { logExtraction: { delay: '2m', frequency: '1m' } },
       });
 
       const update = await apiClient.put(ENTITY_STORE_ROUTES.public.UPDATE, {

--- a/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/install_update.spec.ts
+++ b/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/install_update.spec.ts
@@ -173,7 +173,12 @@ apiTest.describe('Entity Store install / update API tests', { tag: ENTITY_STORE_
       // Set initial params via update (logExtraction removed from install)
       await apiClient.put(ENTITY_STORE_ROUTES.public.UPDATE, {
         headers: defaultHeaders,
+      const initialUpdate = await apiClient.put(ENTITY_STORE_ROUTES.public.UPDATE, {
+        headers: defaultHeaders,
         responseType: 'json',
+        body: { logExtraction: { delay: '2m', frequency: '1m' } },
+      });
+      expect(initialUpdate.statusCode).toBe(200);
         body: { logExtraction: { delay: '2m', frequency: '1m' } },
       });
 

--- a/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/install_update.spec.ts
+++ b/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/install_update.spec.ts
@@ -130,7 +130,7 @@ apiTest.describe('Entity Store install / update API tests', { tag: ENTITY_STORE_
       await apiClient.post(ENTITY_STORE_ROUTES.public.INSTALL, {
         headers: defaultHeaders,
         responseType: 'json',
-        body: { logExtraction: { delay: '2m' } },
+        body: {},
       });
 
       const update = await apiClient.put(ENTITY_STORE_ROUTES.public.UPDATE, {
@@ -165,6 +165,13 @@ apiTest.describe('Entity Store install / update API tests', { tag: ENTITY_STORE_
       });
 
       await apiClient.post(ENTITY_STORE_ROUTES.public.INSTALL, {
+        headers: defaultHeaders,
+        responseType: 'json',
+        body: {},
+      });
+
+      // Set initial params via update (logExtraction removed from install)
+      await apiClient.put(ENTITY_STORE_ROUTES.public.UPDATE, {
         headers: defaultHeaders,
         responseType: 'json',
         body: { logExtraction: { delay: '2m', frequency: '1m' } },

--- a/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/install_update.spec.ts
+++ b/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/install_update.spec.ts
@@ -176,7 +176,6 @@ apiTest.describe('Entity Store install / update API tests', { tag: ENTITY_STORE_
         body: { logExtraction: { delay: '2m', frequency: '1m' } },
       });
       expect(initialUpdate.statusCode).toBe(200);
-      });
 
       const update = await apiClient.put(ENTITY_STORE_ROUTES.public.UPDATE, {
         headers: defaultHeaders,

--- a/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/logs_extraction_broken_mapping.spec.ts
+++ b/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/logs_extraction_broken_mapping.spec.ts
@@ -292,6 +292,13 @@ apiTest.describe('Entity Store logs extraction broken mapping', { tag: ENTITY_ST
       [FF_ENABLE_ENTITY_STORE_V2]: true,
     });
 
+    // Ensure clean state in case a prior test left the store installed
+    await apiClient.post(ENTITY_STORE_ROUTES.public.UNINSTALL, {
+      headers: defaultHeaders,
+      responseType: 'json',
+      body: {},
+    });
+
     const installResponse = await apiClient.post(ENTITY_STORE_ROUTES.public.INSTALL, {
       headers: defaultHeaders,
       responseType: 'json',


### PR DESCRIPTION
## Summary

This PR:
- removes `logExtractionParams` from install route
- removes unused `filter` parameter from `logExtractionParams` altogether

Originally towards <https://github.com/elastic/kibana/issues/262229>

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

