### PR TITLE
[9.4] [Entity Analytics] Resolution group design adjustments (#262544)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_details_flyout/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_details_flyout/index.tsx
@@ -99,9 +99,11 @@ export const getFieldsTableTab = ({ document, tableStorageKey }: FieldsTableProp
 export const getResolutionGroupTab = ({
   entityId,
   entityType,
+  scopeId,
 }: {
   entityId: string;
   entityType: EntityStoreEntityType;
+  scopeId: string;
 }) => ({
   id: EntityDetailsLeftPanelTab.RESOLUTION_GROUP,
   'data-test-subj': RESOLUTION_GROUP_TAB_TEST_ID,
@@ -111,5 +113,5 @@ export const getResolutionGroupTab = ({
       defaultMessage="Resolution group"
     />
   ),
-  content: <ResolutionGroupTab entityId={entityId} entityType={entityType} />,
+  content: <ResolutionGroupTab entityId={entityId} entityType={entityType} scopeId={scopeId} />,
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution/add_entities_section.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution/add_entities_section.test.tsx
@@ -10,9 +10,11 @@ import { render, fireEvent, waitFor } from '@testing-library/react';
 import { TestProviders } from '../../../common/mock';
 import { AddEntitiesSection } from './add_entities_section';
 import {
+  ADD_ENTITIES_ACCORDION_TEST_ID,
   ADD_ENTITIES_SECTION_TEST_ID,
   ADD_ENTITIES_SEARCH_TEST_ID,
   ADD_ENTITIES_TABLE_TEST_ID,
+  ADD_ENTITIES_SHOWING_TEST_ID,
 } from './test_ids';
 import { useSearchEntities } from './hooks/use_search_entities';
 
@@ -21,8 +23,19 @@ jest.mock('./hooks/use_search_entities');
 const mockUseSearchEntities = useSearchEntities as jest.Mock;
 
 const mockRecords = [
-  { 'entity.name': 'bob', 'entity.id': 'bob-id', 'entity.source': 'logs-azure' },
-  { 'entity.name': 'charlie', 'entity.id': 'charlie-id', 'entity.source': 'logs-okta' },
+  {
+    'entity.name': 'bob',
+    'entity.id': 'bob-id',
+    'entity.source': 'logs-azure',
+    'entity.lifecycle.last_seen': '2026-04-09T10:00:00.000Z',
+    'entity.risk.calculated_score_norm': 85.5,
+  },
+  {
+    'entity.name': 'charlie',
+    'entity.id': 'charlie-id',
+    'entity.source': 'logs-okta',
+    'entity.lifecycle.last_seen': '2026-04-08T15:30:00.000Z',
+  },
 ];
 
 describe('AddEntitiesSection', () => {
@@ -30,6 +43,7 @@ describe('AddEntitiesSection', () => {
     entityType: 'user' as const,
     excludeEntityIds: ['alice-id'],
     onAddEntity: jest.fn(),
+    onEntityNameClick: jest.fn(),
   };
 
   beforeEach(() => {
@@ -40,35 +54,72 @@ describe('AddEntitiesSection', () => {
     });
   });
 
-  it('renders search input and results table', () => {
+  it('renders collapsed accordion by default', () => {
     const { getByTestId } = render(
       <TestProviders>
         <AddEntitiesSection {...defaultProps} />
       </TestProviders>
     );
 
+    expect(getByTestId(ADD_ENTITIES_ACCORDION_TEST_ID)).toBeInTheDocument();
+    const accordionButton = getByTestId(ADD_ENTITIES_ACCORDION_TEST_ID).querySelector('button');
+    expect(accordionButton).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('renders search input and table when expanded', () => {
+    const { getByTestId } = render(
+      <TestProviders>
+        <AddEntitiesSection {...defaultProps} />
+      </TestProviders>
+    );
+
+    // Click to expand
+    fireEvent.click(getByTestId(ADD_ENTITIES_ACCORDION_TEST_ID).querySelector('button')!);
+
     expect(getByTestId(ADD_ENTITIES_SECTION_TEST_ID)).toBeInTheDocument();
     expect(getByTestId(ADD_ENTITIES_SEARCH_TEST_ID)).toBeInTheDocument();
     expect(getByTestId(ADD_ENTITIES_TABLE_TEST_ID)).toBeInTheDocument();
   });
 
-  it('renders entity rows', () => {
-    const { getByText } = render(
+  it('renders entity rows with all columns when expanded', () => {
+    const { getByTestId, getByText } = render(
       <TestProviders>
         <AddEntitiesSection {...defaultProps} />
       </TestProviders>
     );
+
+    fireEvent.click(getByTestId(ADD_ENTITIES_ACCORDION_TEST_ID).querySelector('button')!);
 
     expect(getByText('bob')).toBeInTheDocument();
     expect(getByText('charlie')).toBeInTheDocument();
+    // Column headers
+    expect(getByText('Actions')).toBeInTheDocument();
+    expect(getByText('Last seen')).toBeInTheDocument();
+    expect(getByText('Data source')).toBeInTheDocument();
   });
 
-  it('calls onAddEntity when add button is clicked', () => {
-    const { getAllByLabelText } = render(
+  it('shows "Showing X-Y of N entities" text', () => {
+    const { getByTestId } = render(
       <TestProviders>
         <AddEntitiesSection {...defaultProps} />
       </TestProviders>
     );
+
+    fireEvent.click(getByTestId(ADD_ENTITIES_ACCORDION_TEST_ID).querySelector('button')!);
+
+    expect(getByTestId(ADD_ENTITIES_SHOWING_TEST_ID)).toHaveTextContent(
+      'Showing 1-2 of 2 entities'
+    );
+  });
+
+  it('calls onAddEntity when add button is clicked', () => {
+    const { getByTestId, getAllByLabelText } = render(
+      <TestProviders>
+        <AddEntitiesSection {...defaultProps} />
+      </TestProviders>
+    );
+
+    fireEvent.click(getByTestId(ADD_ENTITIES_ACCORDION_TEST_ID).querySelector('button')!);
 
     const addButtons = getAllByLabelText(/add to resolution group/i);
     fireEvent.click(addButtons[0]);
@@ -76,18 +127,34 @@ describe('AddEntitiesSection', () => {
     expect(defaultProps.onAddEntity).toHaveBeenCalledWith(mockRecords[0]);
   });
 
-  it('debounces search input', async () => {
-    jest.useFakeTimers();
-    const { getByRole } = render(
+  it('calls onEntityNameClick when expand button is clicked', () => {
+    const { getByTestId, getAllByLabelText } = render(
       <TestProviders>
         <AddEntitiesSection {...defaultProps} />
       </TestProviders>
     );
 
+    fireEvent.click(getByTestId(ADD_ENTITIES_ACCORDION_TEST_ID).querySelector('button')!);
+
+    const expandButtons = getAllByLabelText(/open entity details/i);
+    fireEvent.click(expandButtons[0]);
+
+    expect(defaultProps.onEntityNameClick).toHaveBeenCalledWith(mockRecords[0]);
+  });
+
+  it('debounces search input', async () => {
+    jest.useFakeTimers();
+    const { getByTestId, getByRole } = render(
+      <TestProviders>
+        <AddEntitiesSection {...defaultProps} />
+      </TestProviders>
+    );
+
+    fireEvent.click(getByTestId(ADD_ENTITIES_ACCORDION_TEST_ID).querySelector('button')!);
+
     const searchInput = getByRole('searchbox');
     fireEvent.change(searchInput, { target: { value: 'test' } });
 
-    // Before debounce fires, searchQuery should still be empty
     expect(mockUseSearchEntities).toHaveBeenLastCalledWith(
       expect.objectContaining({ searchQuery: '' })
     );
@@ -109,12 +176,15 @@ describe('AddEntitiesSection', () => {
       isLoading: false,
     });
 
-    const { getByText } = render(
+    const { getByTestId, getByText, queryByText } = render(
       <TestProviders>
         <AddEntitiesSection {...defaultProps} />
       </TestProviders>
     );
 
+    fireEvent.click(getByTestId(ADD_ENTITIES_ACCORDION_TEST_ID).querySelector('button')!);
+
     expect(getByText(/no items found/i)).toBeInTheDocument();
+    expect(queryByText(/Showing/)).not.toBeInTheDocument();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution/add_entities_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution/add_entities_section.tsx
@@ -6,46 +6,59 @@
  */
 
 import React, { useState, useCallback, useMemo, useEffect, useRef } from 'react';
+import { FormattedMessage } from '@kbn/i18n-react';
 import {
+  EuiAccordion,
   EuiBasicTable,
   EuiButtonIcon,
   EuiFieldSearch,
+  EuiFlexGroup,
+  EuiFlexItem,
   EuiSpacer,
   EuiText,
-  EuiTitle,
 } from '@elastic/eui';
 import type { EuiBasicTableColumn, CriteriaWithPagination } from '@elastic/eui';
 import type { EntityType } from '@kbn/entity-store/public';
+import { FormattedRelativePreferenceDate } from '../../../common/components/formatted_date';
 import { useSearchEntities } from './hooks/use_search_entities';
 import {
   getEntityName,
   getEntityId,
   getEntitySource,
   getEntityRiskScore,
+  getEntityLastSeen,
   truncatedCellCss,
 } from './helpers';
 import {
   ADD_ENTITIES_TITLE,
   SEARCH_ENTITIES_PLACEHOLDER,
   ADD_ENTITY_BUTTON,
+  EXPAND_ENTITY_BUTTON,
   ENTITY_NAME_COLUMN,
   ENTITY_ID_COLUMN,
   SOURCE_COLUMN,
+  LAST_SEEN_COLUMN,
   RISK_SCORE_COLUMN,
+  ACTIONS_COLUMN,
 } from './translations';
 import {
   ADD_ENTITIES_SECTION_TEST_ID,
   ADD_ENTITIES_SEARCH_TEST_ID,
   ADD_ENTITIES_TABLE_TEST_ID,
+  ADD_ENTITIES_ACCORDION_TEST_ID,
+  ADD_ENTITIES_SHOWING_TEST_ID,
 } from './test_ids';
+import { RiskScoreCell } from '../home/entities_table/risk_score_cell';
 
-const PAGE_SIZE = 10;
+const DEFAULT_PAGE_SIZE = 10;
+const PAGE_SIZE_OPTIONS = [10, 25, 50];
 const SEARCH_DEBOUNCE_MS = 300;
 
 interface AddEntitiesSectionProps {
   entityType: EntityType;
   excludeEntityIds: string[];
   onAddEntity: (entity: Record<string, unknown>) => void;
+  onEntityNameClick?: (entity: Record<string, unknown>) => void;
   addingEntityId?: string;
   disabled?: boolean;
 }
@@ -55,11 +68,13 @@ export const AddEntitiesSection: React.FC<AddEntitiesSectionProps> = ({
   excludeEntityIds,
   disabled,
   onAddEntity,
+  onEntityNameClick,
   addingEntityId,
 }) => {
   const [searchInput, setSearchInput] = useState('');
   const [debouncedQuery, setDebouncedQuery] = useState('');
   const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE);
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout>>();
 
   useEffect(() => {
@@ -75,7 +90,7 @@ export const AddEntitiesSection: React.FC<AddEntitiesSectionProps> = ({
     excludeEntityIds,
     searchQuery: debouncedQuery,
     page,
-    perPage: PAGE_SIZE,
+    perPage: pageSize,
   });
 
   const records = data?.records ?? [];
@@ -88,6 +103,7 @@ export const AddEntitiesSection: React.FC<AddEntitiesSectionProps> = ({
   const handlePageChange = useCallback(
     ({ page: paginationPage }: CriteriaWithPagination<Record<string, unknown>>) => {
       setPage(paginationPage.index + 1);
+      setPageSize(paginationPage.size);
     },
     []
   );
@@ -95,9 +111,39 @@ export const AddEntitiesSection: React.FC<AddEntitiesSectionProps> = ({
   const columns: Array<EuiBasicTableColumn<Record<string, unknown>>> = useMemo(
     () => [
       {
+        name: ACTIONS_COLUMN,
+        width: '80px',
+        render: (entity: Record<string, unknown>) => {
+          const entityId = getEntityId(entity);
+          const isThisEntityAdding = addingEntityId === entityId;
+          return (
+            <EuiFlexGroup gutterSize="none" alignItems="center" responsive={false}>
+              <EuiFlexItem grow={false}>
+                <EuiButtonIcon
+                  iconType="expand"
+                  color="primary"
+                  aria-label={EXPAND_ENTITY_BUTTON}
+                  onClick={() => onEntityNameClick?.(entity)}
+                />
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiButtonIcon
+                  iconType="plus"
+                  color="primary"
+                  aria-label={ADD_ENTITY_BUTTON}
+                  onClick={() => onAddEntity(entity)}
+                  disabled={disabled || !!addingEntityId}
+                  isLoading={isThisEntityAdding}
+                />
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          );
+        },
+      },
+      {
         name: ENTITY_NAME_COLUMN,
         render: (entity: Record<string, unknown>) => (
-          <EuiText size="s" css={truncatedCellCss}>
+          <EuiText size="xs" css={truncatedCellCss}>
             {getEntityName(entity)}
           </EuiText>
         ),
@@ -105,7 +151,7 @@ export const AddEntitiesSection: React.FC<AddEntitiesSectionProps> = ({
       {
         name: ENTITY_ID_COLUMN,
         render: (entity: Record<string, unknown>) => (
-          <EuiText size="s" css={truncatedCellCss} title={getEntityId(entity)}>
+          <EuiText size="xs" css={truncatedCellCss} title={getEntityId(entity)}>
             {getEntityId(entity)}
           </EuiText>
         ),
@@ -113,75 +159,97 @@ export const AddEntitiesSection: React.FC<AddEntitiesSectionProps> = ({
       {
         name: SOURCE_COLUMN,
         render: (entity: Record<string, unknown>) => (
-          <EuiText size="s" css={truncatedCellCss} title={getEntitySource(entity)}>
+          <EuiText size="xs" css={truncatedCellCss} title={getEntitySource(entity)}>
             {getEntitySource(entity)}
           </EuiText>
         ),
+      },
+      {
+        name: LAST_SEEN_COLUMN,
+        render: (entity: Record<string, unknown>) => {
+          const lastSeen = getEntityLastSeen(entity);
+          return (
+            <EuiText size="xs" css={truncatedCellCss}>
+              {lastSeen ? <FormattedRelativePreferenceDate value={lastSeen} /> : '-'}
+            </EuiText>
+          );
+        },
       },
       {
         name: RISK_SCORE_COLUMN,
         width: '100px',
         render: (entity: Record<string, unknown>) => {
           const score = getEntityRiskScore(entity);
-          return <EuiText size="s">{score != null ? Math.round(score) : '-'}</EuiText>;
-        },
-      },
-      {
-        name: '',
-        width: '60px',
-        render: (entity: Record<string, unknown>) => {
-          const entityId = getEntityId(entity);
-          const isThisEntityAdding = addingEntityId === entityId;
-          return (
-            <EuiButtonIcon
-              iconType="plusInCircle"
-              color="primary"
-              aria-label={ADD_ENTITY_BUTTON}
-              onClick={() => onAddEntity(entity)}
-              disabled={disabled || !!addingEntityId}
-              isLoading={isThisEntityAdding}
-            />
-          );
+          return <RiskScoreCell riskScore={score} />;
         },
       },
     ],
-    [onAddEntity, addingEntityId, disabled]
+    [onAddEntity, onEntityNameClick, addingEntityId, disabled]
   );
 
   const pagination = useMemo(
     () => ({
       pageIndex: page - 1,
-      pageSize: PAGE_SIZE,
+      pageSize,
       totalItemCount: total,
-      showPerPageOptions: false,
+      showPerPageOptions: true,
+      pageSizeOptions: PAGE_SIZE_OPTIONS,
     }),
-    [page, total]
+    [page, pageSize, total]
   );
 
+  const from = total > 0 ? (page - 1) * pageSize + 1 : 0;
+  const to = Math.min(page * pageSize, total);
+
   return (
-    <div data-test-subj={ADD_ENTITIES_SECTION_TEST_ID}>
-      <EuiTitle size="xs">
-        <h3>{ADD_ENTITIES_TITLE}</h3>
-      </EuiTitle>
-      <EuiSpacer size="m" />
-      <EuiFieldSearch
-        data-test-subj={ADD_ENTITIES_SEARCH_TEST_ID}
-        placeholder={SEARCH_ENTITIES_PLACEHOLDER}
-        value={searchInput}
-        onChange={(e) => handleSearchChange(e.target.value)}
-        isClearable
-        fullWidth
-      />
-      <EuiSpacer size="s" />
-      <EuiBasicTable
-        data-test-subj={ADD_ENTITIES_TABLE_TEST_ID}
-        items={records}
-        columns={columns}
-        loading={isLoading}
-        pagination={pagination}
-        onChange={handlePageChange}
-        compressed
-      />
-    </div>
+    <EuiAccordion
+      id="addEntitiesToResolutionGroup"
+      buttonContent={ADD_ENTITIES_TITLE}
+      initialIsOpen={false}
+      data-test-subj={ADD_ENTITIES_ACCORDION_TEST_ID}
+    >
+      <div data-test-subj={ADD_ENTITIES_SECTION_TEST_ID}>
+        <EuiSpacer size="m" />
+        <EuiFieldSearch
+          data-test-subj={ADD_ENTITIES_SEARCH_TEST_ID}
+          placeholder={SEARCH_ENTITIES_PLACEHOLDER}
+          value={searchInput}
+          onChange={(e) => handleSearchChange(e.target.value)}
+          isClearable
+          fullWidth
+        />
+        <EuiSpacer size="m" />
+        {total > 0 && (
+          <>
+            <EuiText size="xs" data-test-subj={ADD_ENTITIES_SHOWING_TEST_ID}>
+              <FormattedMessage
+                id="xpack.securitySolution.entityResolution.showingEntities"
+                defaultMessage="Showing {range} of {total} entities"
+                values={{
+                  range: (
+                    <strong>
+                      {from}
+                      {'-'}
+                      {to}
+                    </strong>
+                  ),
+                  total: <strong>{total.toLocaleString()}</strong>,
+                }}
+              />
+            </EuiText>
+            <EuiSpacer size="s" />
+          </>
+        )}
+        <EuiBasicTable
+          data-test-subj={ADD_ENTITIES_TABLE_TEST_ID}
+          items={records}
+          columns={columns}
+          loading={isLoading}
+          pagination={pagination}
+          onChange={handlePageChange}
+          compressed
+        />
+      </div>
+    </EuiAccordion>
   );
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution/helpers.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution/helpers.ts
@@ -47,7 +47,6 @@ export const getEntityRiskScore = (entity: Record<string, unknown>): number | un
 /** Row data type for the resolution group table. Defined here to avoid ESLint false positives. */
 export interface TableEntityRow {
   entity: Record<string, unknown>;
-  isSummary: boolean;
 }
 
 export const truncatedCellCss = css`
@@ -56,6 +55,11 @@ export const truncatedCellCss = css`
   text-overflow: ellipsis;
   white-space: nowrap;
 `;
+
+export const getEntityLastSeen = (entity: Record<string, unknown>): string | undefined => {
+  const value = getEntityField(entity, 'entity.lifecycle.last_seen');
+  return typeof value === 'string' ? value : undefined;
+};
 
 export const getResolutionRiskScore = (entity: Record<string, unknown>): number | undefined => {
   const score = getEntityField(

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution/hooks/use_link_entities.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution/hooks/use_link_entities.ts
@@ -11,7 +11,11 @@ import { ENTITY_STORE_ROUTES } from '@kbn/entity-store/public';
 import { API_VERSIONS } from '../../../../../common/entity_analytics/constants';
 import { useKibana } from '../../../../common/lib/kibana/kibana_react';
 import { useAppToasts } from '../../../../common/hooks/use_app_toasts';
-import { ENTITY_RESOLVED_TOAST, RESOLUTION_ERROR_TITLE } from '../translations';
+import {
+  ENTITY_RESOLVED_TOAST,
+  ENTITY_RESOLVED_TOAST_TEXT,
+  RESOLUTION_ERROR_TITLE,
+} from '../translations';
 import { RESOLUTION_GROUP_QUERY_KEY } from './use_resolution_group';
 
 interface LinkEntitiesParams {
@@ -25,7 +29,11 @@ interface LinkEntitiesResponse {
   target_id: string;
 }
 
-export const useLinkEntities = () => {
+interface UseLinkEntitiesOptions {
+  successToast?: string | { title: string; text: string };
+}
+
+export const useLinkEntities = (options?: UseLinkEntitiesOptions) => {
   const { http } = useKibana().services;
   const queryClient = useQueryClient();
   const { addSuccess, addError } = useAppToasts();
@@ -39,7 +47,9 @@ export const useLinkEntities = () => {
       }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [RESOLUTION_GROUP_QUERY_KEY] });
-      addSuccess(ENTITY_RESOLVED_TOAST);
+      addSuccess(
+        options?.successToast ?? { title: ENTITY_RESOLVED_TOAST, text: ENTITY_RESOLVED_TOAST_TEXT }
+      );
     },
     onError: (error) => {
       addError(error, { title: RESOLUTION_ERROR_TITLE });

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution/hooks/use_unlink_entities.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution/hooks/use_unlink_entities.ts
@@ -11,7 +11,11 @@ import { ENTITY_STORE_ROUTES } from '@kbn/entity-store/public';
 import { API_VERSIONS } from '../../../../../common/entity_analytics/constants';
 import { useKibana } from '../../../../common/lib/kibana/kibana_react';
 import { useAppToasts } from '../../../../common/hooks/use_app_toasts';
-import { ENTITY_REMOVED_TOAST, RESOLUTION_ERROR_TITLE } from '../translations';
+import {
+  ENTITY_REMOVED_TOAST,
+  ENTITY_REMOVED_TOAST_TEXT,
+  RESOLUTION_ERROR_TITLE,
+} from '../translations';
 import { RESOLUTION_GROUP_QUERY_KEY } from './use_resolution_group';
 
 interface UnlinkEntitiesParams {
@@ -37,7 +41,7 @@ export const useUnlinkEntities = () => {
       }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [RESOLUTION_GROUP_QUERY_KEY] });
-      addSuccess(ENTITY_REMOVED_TOAST);
+      addSuccess({ title: ENTITY_REMOVED_TOAST, text: ENTITY_REMOVED_TOAST_TEXT });
     },
     onError: (error) => {
       addError(error, { title: RESOLUTION_ERROR_TITLE });

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution/resolution_group_tab.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution/resolution_group_tab.test.tsx
@@ -64,7 +64,7 @@ describe('ResolutionGroupTab', () => {
 
     const { getByTestId, getAllByText, getByText } = render(
       <TestProviders>
-        <ResolutionGroupTab entityId="alice-id" entityType="user" />
+        <ResolutionGroupTab entityId="alice-id" entityType="user" scopeId="test-scope" />
       </TestProviders>
     );
 
@@ -81,7 +81,7 @@ describe('ResolutionGroupTab', () => {
 
     const { getAllByLabelText } = render(
       <TestProviders>
-        <ResolutionGroupTab entityId="alice-id" entityType="user" />
+        <ResolutionGroupTab entityId="alice-id" entityType="user" scopeId="test-scope" />
       </TestProviders>
     );
 
@@ -109,7 +109,7 @@ describe('ResolutionGroupTab', () => {
 
     const { getAllByLabelText, findByTestId } = render(
       <TestProviders>
-        <ResolutionGroupTab entityId="alice-id" entityType="user" />
+        <ResolutionGroupTab entityId="alice-id" entityType="user" scopeId="test-scope" />
       </TestProviders>
     );
 
@@ -131,7 +131,7 @@ describe('ResolutionGroupTab', () => {
 
     const { getAllByLabelText } = render(
       <TestProviders>
-        <ResolutionGroupTab entityId="alice-id" entityType="user" />
+        <ResolutionGroupTab entityId="alice-id" entityType="user" scopeId="test-scope" />
       </TestProviders>
     );
 
@@ -149,7 +149,7 @@ describe('ResolutionGroupTab', () => {
 
     const { getAllByLabelText } = render(
       <TestProviders>
-        <ResolutionGroupTab entityId="alice-id" entityType="user" />
+        <ResolutionGroupTab entityId="alice-id" entityType="user" scopeId="test-scope" />
       </TestProviders>
     );
 
@@ -175,7 +175,7 @@ describe('ResolutionGroupTab', () => {
 
     const { getAllByLabelText, findByRole } = render(
       <TestProviders>
-        <ResolutionGroupTab entityId="alice-id" entityType="user" />
+        <ResolutionGroupTab entityId="alice-id" entityType="user" scopeId="test-scope" />
       </TestProviders>
     );
 

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution/resolution_group_tab.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution/resolution_group_tab.tsx
@@ -6,9 +6,15 @@
  */
 
 import React, { useState, useCallback, useMemo } from 'react';
-import { EuiSpacer, EuiTitle } from '@elastic/eui';
+import { EuiBadge, EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiText, EuiTitle } from '@elastic/eui';
+import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import type { EntityType } from '@kbn/entity-store/public';
 import { API_VERSIONS } from '../../../../common/entity_analytics/constants';
+import {
+  EntityPanelKeyByType,
+  EntityPanelParamByType,
+} from '../../../flyout/entity_details/shared/constants';
+import type { EntityType as SecurityEntityType } from '../../../../common/entity_analytics/types';
 import { useKibana } from '../../../common/lib/kibana/kibana_react';
 import { useAppToasts } from '../../../common/hooks/use_app_toasts';
 import { useResolutionGroup, RESOLUTION_GROUP_ROUTE } from './hooks/use_resolution_group';
@@ -18,24 +24,41 @@ import { useUnlinkEntities } from './hooks/use_unlink_entities';
 import { ResolutionGroupTable } from './resolution_group_table';
 import { AddEntitiesSection } from './add_entities_section';
 import { ConfirmResolutionModal } from './confirm_resolution_modal';
-import { getEntityId } from './helpers';
+import { getEntityId, getEntityName, getResolutionRiskScore } from './helpers';
 import {
   RESOLUTION_GROUP_LINK_TITLE,
   RESOLUTION_ERROR_TITLE,
   ENTITY_HAS_ALIASES_ERROR,
+  GROUP_RISK_SCORE_LABEL,
+  RISK_SCORE_NOT_AVAILABLE,
+  RESOLUTION_GROUP_CREATED_TOAST,
+  RESOLUTION_GROUP_CREATED_TOAST_TEXT,
 } from './translations';
 import { RESOLUTION_GROUP_TAB_CONTENT_TEST_ID } from './test_ids';
+import { RiskScoreCell } from '../home/entities_table/risk_score_cell';
 
 interface ResolutionGroupTabProps {
   entityId: string;
   entityType: EntityType;
+  scopeId: string;
 }
 
-export const ResolutionGroupTab: React.FC<ResolutionGroupTabProps> = ({ entityId, entityType }) => {
+export const ResolutionGroupTab: React.FC<ResolutionGroupTabProps> = ({
+  entityId,
+  entityType,
+  scopeId,
+}) => {
   const { http } = useKibana().services;
   const { addError } = useAppToasts();
+  const { openFlyout } = useExpandableFlyoutApi();
   const { data: group, isLoading, isFetching, isError } = useResolutionGroup(entityId);
   const linkEntities = useLinkEntities();
+  const createGroup = useLinkEntities({
+    successToast: {
+      title: RESOLUTION_GROUP_CREATED_TOAST,
+      text: RESOLUTION_GROUP_CREATED_TOAST_TEXT,
+    },
+  });
   const unlinkEntities = useUnlinkEntities();
 
   const [modalState, setModalState] = useState<{
@@ -47,6 +70,7 @@ export const ResolutionGroupTab: React.FC<ResolutionGroupTabProps> = ({ entityId
 
   const targetEntityId = group?.target ? getEntityId(group.target) : undefined;
   const hasGroup = group && group.group_size > 1;
+  const resolutionRiskScore = hasGroup ? getResolutionRiskScore(group.target) : undefined;
 
   const excludeEntityIds = useMemo(() => {
     if (!group) return [entityId];
@@ -56,6 +80,30 @@ export const ResolutionGroupTab: React.FC<ResolutionGroupTabProps> = ({ entityId
     }
     return ids;
   }, [group, entityId]);
+
+  const handleEntityNameClick = useCallback(
+    (entity: Record<string, unknown>) => {
+      const clickedEntityId = getEntityId(entity);
+      const clickedEntityName = getEntityName(entity);
+      const panelKey = EntityPanelKeyByType[entityType as SecurityEntityType];
+      const panelParam = EntityPanelParamByType[entityType as SecurityEntityType];
+
+      if (!panelKey || !panelParam) return;
+
+      openFlyout({
+        right: {
+          id: panelKey,
+          params: {
+            [panelParam]: clickedEntityName,
+            entityId: clickedEntityId,
+            contextID: scopeId,
+            scopeId,
+          },
+        },
+      });
+    },
+    [openFlyout, entityType, scopeId]
+  );
 
   const handleRemoveEntity = useCallback(
     (removeEntityId: string) => {
@@ -108,7 +156,7 @@ export const ResolutionGroupTab: React.FC<ResolutionGroupTabProps> = ({ entityId
 
   const handleConfirmResolution = useCallback(
     (targetId: string, aliasId: string) => {
-      linkEntities.mutate(
+      createGroup.mutate(
         { target_id: targetId, entity_ids: [aliasId] },
         {
           onSuccess: () => {
@@ -117,7 +165,7 @@ export const ResolutionGroupTab: React.FC<ResolutionGroupTabProps> = ({ entityId
         }
       );
     },
-    [linkEntities]
+    [createGroup]
   );
 
   const handleCancelModal = useCallback(() => {
@@ -131,9 +179,31 @@ export const ResolutionGroupTab: React.FC<ResolutionGroupTabProps> = ({ entityId
   return (
     <>
       <div data-test-subj={RESOLUTION_GROUP_TAB_CONTENT_TEST_ID}>
-        <EuiTitle size="xs">
-          <h3>{RESOLUTION_GROUP_LINK_TITLE}</h3>
-        </EuiTitle>
+        <EuiFlexGroup alignItems="center" justifyContent="spaceBetween" responsive={false}>
+          <EuiFlexItem grow={false}>
+            <EuiTitle size="xs">
+              <h3>{RESOLUTION_GROUP_LINK_TITLE}</h3>
+            </EuiTitle>
+          </EuiFlexItem>
+          {hasGroup && (
+            <EuiFlexItem grow={false}>
+              <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
+                <EuiFlexItem grow={false}>
+                  <EuiText size="xs">{GROUP_RISK_SCORE_LABEL}</EuiText>
+                </EuiFlexItem>
+                <EuiFlexItem grow={false}>
+                  {resolutionRiskScore != null ? (
+                    <RiskScoreCell riskScore={resolutionRiskScore} />
+                  ) : (
+                    <EuiBadge>
+                      <EuiText size="xs">{RISK_SCORE_NOT_AVAILABLE}</EuiText>
+                    </EuiBadge>
+                  )}
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            </EuiFlexItem>
+          )}
+        </EuiFlexGroup>
         <EuiSpacer size="m" />
         <ResolutionGroupTable
           group={group ?? null}
@@ -143,12 +213,15 @@ export const ResolutionGroupTab: React.FC<ResolutionGroupTabProps> = ({ entityId
           onRemoveEntity={handleRemoveEntity}
           targetEntityId={targetEntityId}
           removingEntityId={removingEntityId}
+          onEntityNameClick={handleEntityNameClick}
+          currentEntityId={entityId}
         />
         <EuiSpacer size="l" />
         <AddEntitiesSection
           entityType={entityType}
           excludeEntityIds={excludeEntityIds}
           onAddEntity={handleAddEntity}
+          onEntityNameClick={handleEntityNameClick}
           addingEntityId={addingEntityId}
           disabled={!groupQueryReady}
         />
@@ -159,7 +232,7 @@ export const ResolutionGroupTab: React.FC<ResolutionGroupTabProps> = ({ entityId
           newEntity={modalState.newEntity}
           onConfirm={handleConfirmResolution}
           onCancel={handleCancelModal}
-          isLoading={linkEntities.isLoading}
+          isLoading={createGroup.isLoading}
         />
       )}
     </>

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution/resolution_group_table.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution/resolution_group_table.test.tsx
@@ -33,16 +33,26 @@ const mockGroup: ResolutionGroup = {
 
 describe('ResolutionGroupTable', () => {
   it('renders table with target and alias rows', () => {
-    const { getByTestId, getByText, getAllByText } = render(
+    const { getByTestId, getByText } = render(
       <TestProviders>
         <ResolutionGroupTable group={mockGroup} isLoading={false} targetEntityId="alice-id" />
       </TestProviders>
     );
 
     expect(getByTestId(RESOLUTION_GROUP_TABLE_TEST_ID)).toBeInTheDocument();
-    // 'alice' appears in both entity row and summary row, so use getAllByText
-    expect(getAllByText('alice').length).toBeGreaterThanOrEqual(1);
+    expect(getByText('alice')).toBeInTheDocument();
     expect(getByText('alice-azure')).toBeInTheDocument();
+  });
+
+  it('shows target entity icon next to target entity name', () => {
+    const { container } = render(
+      <TestProviders>
+        <ResolutionGroupTable group={mockGroup} isLoading={false} targetEntityId="alice-id" />
+      </TestProviders>
+    );
+
+    const aggregateIcon = container.querySelector('[data-euiicon-type="aggregate"]');
+    expect(aggregateIcon).toBeInTheDocument();
   });
 
   it('shows empty state when group is null', () => {
@@ -65,26 +75,34 @@ describe('ResolutionGroupTable', () => {
     expect(container.querySelector('[role="progressbar"]')).toBeInTheDocument();
   });
 
-  it('shows remove buttons when showActions is true', () => {
+  it('shows actions as leading column with expand and delete buttons', () => {
     const onRemove = jest.fn();
-    const { getAllByLabelText } = render(
+    const onExpand = jest.fn();
+    const { getAllByLabelText, container } = render(
       <TestProviders>
         <ResolutionGroupTable
           group={mockGroup}
           isLoading={false}
           showActions
           onRemoveEntity={onRemove}
+          onEntityNameClick={onExpand}
           targetEntityId="alice-id"
+          currentEntityId="alice-id"
         />
       </TestProviders>
     );
 
+    const expandButtons = getAllByLabelText(/open entity details/i);
     const removeButtons = getAllByLabelText(/remove from resolution group/i);
-    // 2 entity rows + 1 summary row (summary renders null for actions, but we get buttons for the 2 entity rows)
-    expect(removeButtons.length).toBeGreaterThanOrEqual(2);
+    expect(expandButtons).toHaveLength(2);
+    expect(removeButtons).toHaveLength(2);
+
+    // Actions column should be first — check first header cell
+    const headers = container.querySelectorAll('th');
+    expect(headers[0]?.textContent).toContain('Actions');
   });
 
-  it('calls onRemoveEntity when remove button clicked on alias', () => {
+  it('calls onRemoveEntity when delete button clicked on alias', () => {
     const onRemove = jest.fn();
     const { getAllByLabelText } = render(
       <TestProviders>
@@ -99,10 +117,89 @@ describe('ResolutionGroupTable', () => {
     );
 
     const removeButtons = getAllByLabelText(/remove from resolution group/i);
-    // The second button is for the alias row (first is target, which is disabled)
     const aliasButton = removeButtons.find((btn) => !btn.hasAttribute('disabled'));
     expect(aliasButton).toBeDefined();
     fireEvent.click(aliasButton!);
     expect(onRemove).toHaveBeenCalledWith('alice-azure-id');
+  });
+
+  it('disables expand button for current entity', () => {
+    const onExpand = jest.fn();
+    const { getAllByLabelText } = render(
+      <TestProviders>
+        <ResolutionGroupTable
+          group={mockGroup}
+          isLoading={false}
+          showActions
+          onEntityNameClick={onExpand}
+          targetEntityId="alice-id"
+          currentEntityId="alice-id"
+        />
+      </TestProviders>
+    );
+
+    const expandButtons = getAllByLabelText(/open entity details/i);
+    const currentEntityButton = expandButtons[0];
+    expect(currentEntityButton).toBeDisabled();
+  });
+
+  it('does not render name links when showActions is true', () => {
+    const onExpand = jest.fn();
+    const { getByText } = render(
+      <TestProviders>
+        <ResolutionGroupTable
+          group={mockGroup}
+          isLoading={false}
+          showActions
+          onEntityNameClick={onExpand}
+          targetEntityId="alice-id"
+        />
+      </TestProviders>
+    );
+
+    const aliceName = getByText('alice');
+    expect(aliceName.closest('a')).toBeNull();
+  });
+
+  it('renders entity names as links when onEntityNameClick provided without showActions', () => {
+    const onClick = jest.fn();
+    const { getByText } = render(
+      <TestProviders>
+        <ResolutionGroupTable
+          group={mockGroup}
+          isLoading={false}
+          targetEntityId="alice-id"
+          onEntityNameClick={onClick}
+        />
+      </TestProviders>
+    );
+
+    const aliceLink = getByText('alice');
+    fireEvent.click(aliceLink);
+    expect(onClick).toHaveBeenCalledWith(mockGroup.target);
+  });
+
+  it('renders risk scores as badges', () => {
+    const { container } = render(
+      <TestProviders>
+        <ResolutionGroupTable group={mockGroup} isLoading={false} targetEntityId="alice-id" />
+      </TestProviders>
+    );
+
+    const badges = container.querySelectorAll('.euiBadge');
+    expect(badges.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('shows column headers with correct names', () => {
+    const { getByText } = render(
+      <TestProviders>
+        <ResolutionGroupTable group={mockGroup} isLoading={false} targetEntityId="alice-id" />
+      </TestProviders>
+    );
+
+    expect(getByText('Entity name')).toBeInTheDocument();
+    expect(getByText('Entity ID')).toBeInTheDocument();
+    expect(getByText('Data source')).toBeInTheDocument();
+    expect(getByText('Risk score')).toBeInTheDocument();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution/resolution_group_table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution/resolution_group_table.tsx
@@ -5,27 +5,25 @@
  * 2.0.
  */
 
-import React, { useMemo, useCallback } from 'react';
+import React, { useMemo } from 'react';
 import {
   EuiBasicTable,
   EuiButtonIcon,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiIconTip,
+  EuiIcon,
+  EuiLink,
   EuiText,
   EuiToolTip,
   EuiLoadingSpinner,
-  useEuiTheme,
 } from '@elastic/eui';
 import type { EuiBasicTableColumn } from '@elastic/eui';
-import { css } from '@emotion/react';
 import type { ResolutionGroup } from './hooks/use_resolution_group';
 import {
   getEntityName,
   getEntityId,
   getEntitySource,
   getEntityRiskScore,
-  getResolutionRiskScore,
   truncatedCellCss,
   type TableEntityRow,
 } from './helpers';
@@ -35,6 +33,7 @@ import {
   SOURCE_COLUMN,
   RISK_SCORE_COLUMN,
   ACTIONS_COLUMN,
+  EXPAND_ENTITY_BUTTON,
   REMOVE_ENTITY_BUTTON,
   TARGET_ENTITY_TOOLTIP,
   CANNOT_REMOVE_TARGET_TOOLTIP,
@@ -42,6 +41,7 @@ import {
   RESOLUTION_FETCH_ERROR,
 } from './translations';
 import { RESOLUTION_GROUP_TABLE_TEST_ID, RESOLUTION_EMPTY_STATE_TEST_ID } from './test_ids';
+import { RiskScoreCell } from '../home/entities_table/risk_score_cell';
 
 export interface ResolutionGroupTableProps {
   group: ResolutionGroup | null;
@@ -51,6 +51,8 @@ export interface ResolutionGroupTableProps {
   onRemoveEntity?: (entityId: string) => void;
   targetEntityId?: string;
   removingEntityId?: string;
+  onEntityNameClick?: (entity: Record<string, unknown>) => void;
+  currentEntityId?: string;
 }
 
 export const ResolutionGroupTable: React.FC<ResolutionGroupTableProps> = ({
@@ -61,31 +63,90 @@ export const ResolutionGroupTable: React.FC<ResolutionGroupTableProps> = ({
   onRemoveEntity,
   targetEntityId,
   removingEntityId,
+  onEntityNameClick,
+  currentEntityId,
 }) => {
-  const { euiTheme } = useEuiTheme();
   const hasGroup = group && group.group_size > 1;
 
   const items: TableEntityRow[] = useMemo(() => {
     if (!hasGroup) return [];
 
-    const entityRows: TableEntityRow[] = [
-      { entity: group.target, isSummary: false },
-      ...group.aliases.map((alias) => ({ entity: alias, isSummary: false })),
-    ];
-
-    // Add summary footer row
-    entityRows.push({ entity: group.target, isSummary: true });
-
-    return entityRows;
+    return [{ entity: group.target }, ...group.aliases.map((alias) => ({ entity: alias }))];
   }, [group, hasGroup]);
 
   const columns: Array<EuiBasicTableColumn<TableEntityRow>> = useMemo(() => {
-    const cols: Array<EuiBasicTableColumn<TableEntityRow>> = [
+    const cols: Array<EuiBasicTableColumn<TableEntityRow>> = [];
+
+    if (showActions) {
+      cols.push({
+        name: ACTIONS_COLUMN,
+        width: '80px',
+        render: ({ entity }: TableEntityRow) => {
+          const entityId = getEntityId(entity);
+          const isTarget = entityId === targetEntityId;
+          const isCurrentEntity = currentEntityId === entityId;
+          const isThisEntityRemoving = removingEntityId === entityId;
+
+          const expandButton = (
+            <EuiButtonIcon
+              iconType="expand"
+              color={isCurrentEntity ? 'text' : 'primary'}
+              aria-label={EXPAND_ENTITY_BUTTON}
+              disabled={isCurrentEntity}
+              onClick={() => onEntityNameClick?.(entity)}
+            />
+          );
+
+          const removeButton = (
+            <EuiButtonIcon
+              iconType="cross"
+              color="primary"
+              aria-label={REMOVE_ENTITY_BUTTON}
+              disabled={isTarget || !!removingEntityId}
+              onClick={() => onRemoveEntity?.(entityId)}
+              isLoading={isThisEntityRemoving}
+            />
+          );
+
+          return (
+            <EuiFlexGroup gutterSize="none" alignItems="center" responsive={false}>
+              <EuiFlexItem grow={false}>{expandButton}</EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                {isTarget ? (
+                  <EuiToolTip content={CANNOT_REMOVE_TARGET_TOOLTIP}>{removeButton}</EuiToolTip>
+                ) : (
+                  removeButton
+                )}
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          );
+        },
+      });
+    }
+
+    cols.push(
       {
         name: ENTITY_NAME_COLUMN,
-        render: ({ entity, isSummary }: TableEntityRow) => {
+        render: ({ entity }: TableEntityRow) => {
           const name = getEntityName(entity);
-          if (isSummary) {
+          const entityId = getEntityId(entity);
+          const isTarget = entityId === targetEntityId;
+          const isCurrentEntity = currentEntityId === entityId;
+
+          const nameContent =
+            onEntityNameClick && !isCurrentEntity && !showActions ? (
+              <EuiText size="xs" css={truncatedCellCss}>
+                <EuiLink onClick={() => onEntityNameClick(entity)} title={name}>
+                  {name}
+                </EuiLink>
+              </EuiText>
+            ) : (
+              <EuiText size="xs" css={truncatedCellCss}>
+                {name}
+              </EuiText>
+            );
+
+          if (isTarget) {
             return (
               <EuiFlexGroup
                 gutterSize="xs"
@@ -94,29 +155,25 @@ export const ResolutionGroupTable: React.FC<ResolutionGroupTableProps> = ({
                 css={truncatedCellCss}
               >
                 <EuiFlexItem grow={false} css={truncatedCellCss}>
-                  <EuiText size="s" css={truncatedCellCss}>
-                    <strong>{name}</strong>
-                  </EuiText>
+                  {nameContent}
                 </EuiFlexItem>
                 <EuiFlexItem grow={false}>
-                  <EuiIconTip content={TARGET_ENTITY_TOOLTIP} type="info" />
+                  <EuiToolTip content={TARGET_ENTITY_TOOLTIP}>
+                    <EuiIcon type="aggregate" size="s" aria-hidden={true} />
+                  </EuiToolTip>
                 </EuiFlexItem>
               </EuiFlexGroup>
             );
           }
-          return (
-            <EuiText size="s" css={truncatedCellCss}>
-              {name}
-            </EuiText>
-          );
+
+          return nameContent;
         },
       },
       {
         name: ENTITY_ID_COLUMN,
-        render: ({ entity, isSummary }: TableEntityRow) => {
-          if (isSummary) return null;
+        render: ({ entity }: TableEntityRow) => {
           return (
-            <EuiText size="s" css={truncatedCellCss} title={getEntityId(entity)}>
+            <EuiText size="xs" css={truncatedCellCss} title={getEntityId(entity)}>
               {getEntityId(entity)}
             </EuiText>
           );
@@ -124,10 +181,9 @@ export const ResolutionGroupTable: React.FC<ResolutionGroupTableProps> = ({
       },
       {
         name: SOURCE_COLUMN,
-        render: ({ entity, isSummary }: TableEntityRow) => {
-          if (isSummary) return null;
+        render: ({ entity }: TableEntityRow) => {
           return (
-            <EuiText size="s" css={truncatedCellCss} title={getEntitySource(entity)}>
+            <EuiText size="xs" css={truncatedCellCss} title={getEntitySource(entity)}>
               {getEntitySource(entity)}
             </EuiText>
           );
@@ -136,67 +192,22 @@ export const ResolutionGroupTable: React.FC<ResolutionGroupTableProps> = ({
       {
         name: RISK_SCORE_COLUMN,
         width: '100px',
-        render: ({ entity, isSummary }: TableEntityRow) => {
-          if (isSummary) {
-            const resolutionScore = getResolutionRiskScore(entity);
-            return (
-              <EuiText size="s">
-                <strong>{resolutionScore != null ? Math.round(resolutionScore) : '-'}</strong>
-              </EuiText>
-            );
-          }
+        render: ({ entity }: TableEntityRow) => {
           const score = getEntityRiskScore(entity);
-          return <EuiText size="s">{score != null ? Math.round(score) : '-'}</EuiText>;
+          return <RiskScoreCell riskScore={score} />;
         },
-      },
-    ];
-
-    if (showActions) {
-      cols.push({
-        name: ACTIONS_COLUMN,
-        width: '60px',
-        render: ({ entity, isSummary }: TableEntityRow) => {
-          if (isSummary) return null;
-          const entityId = getEntityId(entity);
-          const isTarget = entityId === targetEntityId;
-          const isThisEntityRemoving = removingEntityId === entityId;
-          const button = (
-            <EuiButtonIcon
-              iconType="cross"
-              color="danger"
-              aria-label={REMOVE_ENTITY_BUTTON}
-              disabled={isTarget || !!removingEntityId}
-              onClick={() => onRemoveEntity?.(entityId)}
-              isLoading={isThisEntityRemoving}
-            />
-          );
-          if (isTarget) {
-            return <EuiToolTip content={CANNOT_REMOVE_TARGET_TOOLTIP}>{button}</EuiToolTip>;
-          }
-          return button;
-        },
-      });
-    }
+      }
+    );
 
     return cols;
-  }, [showActions, targetEntityId, onRemoveEntity, removingEntityId]);
-
-  const getRowProps = useCallback(
-    (item: TableEntityRow) => {
-      if (item.isSummary) {
-        return {
-          css: css`
-            & > td {
-              border-bottom: none;
-              ${!showActions ? `background-color: ${euiTheme.colors.backgroundBaseSubdued};` : ''}
-            }
-          `,
-        };
-      }
-      return {};
-    },
-    [showActions, euiTheme]
-  );
+  }, [
+    showActions,
+    targetEntityId,
+    onRemoveEntity,
+    removingEntityId,
+    onEntityNameClick,
+    currentEntityId,
+  ]);
 
   if (isLoading) {
     return <EuiLoadingSpinner size="m" />;
@@ -204,17 +215,28 @@ export const ResolutionGroupTable: React.FC<ResolutionGroupTableProps> = ({
 
   if (isError) {
     return (
-      <EuiText size="s" color="danger">
+      <EuiText size="xs" color="danger">
         {RESOLUTION_FETCH_ERROR}
       </EuiText>
     );
   }
 
   if (!hasGroup) {
+    const emptyColumns: Array<EuiBasicTableColumn<TableEntityRow>> = [
+      { name: ENTITY_NAME_COLUMN, render: () => null },
+      { name: ENTITY_ID_COLUMN, render: () => null },
+      { name: SOURCE_COLUMN, render: () => null },
+      { name: RISK_SCORE_COLUMN, width: '100px', render: () => null },
+    ];
+
     return (
-      <EuiText size="s" color="subdued" data-test-subj={RESOLUTION_EMPTY_STATE_TEST_ID}>
-        {RESOLUTION_EMPTY_STATE}
-      </EuiText>
+      <EuiBasicTable
+        data-test-subj={RESOLUTION_EMPTY_STATE_TEST_ID}
+        items={[]}
+        columns={emptyColumns}
+        noItemsMessage={RESOLUTION_EMPTY_STATE}
+        compressed
+      />
     );
   }
 
@@ -223,7 +245,6 @@ export const ResolutionGroupTable: React.FC<ResolutionGroupTableProps> = ({
       data-test-subj={RESOLUTION_GROUP_TABLE_TEST_ID}
       items={items}
       columns={columns}
-      rowProps={getRowProps}
       compressed
     />
   );

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution/resolution_section.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution/resolution_section.test.tsx
@@ -8,17 +8,23 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import { TestProviders } from '../../../common/mock';
+import { EntityType } from '../../../../common/entity_analytics/types';
 import { ResolutionSection } from './resolution_section';
 import { RESOLUTION_SECTION_TEST_ID, RESOLUTION_EMPTY_STATE_TEST_ID } from './test_ids';
 import { useResolutionGroup } from './hooks/use_resolution_group';
 
 jest.mock('./hooks/use_resolution_group');
+jest.mock('@kbn/expandable-flyout', () => ({
+  useExpandableFlyoutApi: () => ({ openFlyout: jest.fn() }),
+}));
 
 const mockUseResolutionGroup = useResolutionGroup as jest.Mock;
 
 describe('ResolutionSection', () => {
   const defaultProps = {
     entityId: 'alice-id',
+    entityType: EntityType.user,
+    scopeId: 'test-scope',
     openDetailsPanel: jest.fn(),
   };
 
@@ -34,14 +40,14 @@ describe('ResolutionSection', () => {
       isLoading: false,
     });
 
-    const { getByTestId, getAllByText } = render(
+    const { getByTestId, getByText } = render(
       <TestProviders>
         <ResolutionSection {...defaultProps} />
       </TestProviders>
     );
 
     expect(getByTestId(RESOLUTION_SECTION_TEST_ID)).toBeInTheDocument();
-    expect(getAllByText('alice').length).toBeGreaterThanOrEqual(1);
+    expect(getByText('alice')).toBeInTheDocument();
   });
 
   it('shows loading spinner while loading', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution/resolution_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution/resolution_section.tsx
@@ -7,9 +7,15 @@
 
 import React, { useCallback } from 'react';
 import { EuiAccordion, EuiSpacer, EuiTitle } from '@elastic/eui';
+import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
+import type { EntityType } from '../../../../common/entity_analytics/types';
 import { ExpandablePanel } from '../../../flyout_v2/shared/components/expandable_panel';
 import { EntityDetailsLeftPanelTab } from '../../../flyout/entity_details/shared/components/left_panel/left_panel_header';
 import type { EntityDetailsPath } from '../../../flyout/entity_details/shared/components/left_panel/left_panel_header';
+import {
+  EntityPanelKeyByType,
+  EntityPanelParamByType,
+} from '../../../flyout/entity_details/shared/constants';
 import { useResolutionGroup } from './hooks/use_resolution_group';
 import { ResolutionGroupTable } from './resolution_group_table';
 import {
@@ -18,15 +24,19 @@ import {
   RESOLUTION_GROUP_LINK_TOOLTIP,
 } from './translations';
 import { RESOLUTION_SECTION_TEST_ID } from './test_ids';
-import { getEntityId } from './helpers';
+import { getEntityId, getEntityName } from './helpers';
 
 interface ResolutionSectionProps {
   entityId: string;
+  entityType: EntityType;
+  scopeId: string;
   openDetailsPanel: (path: EntityDetailsPath) => void;
 }
 
 export const ResolutionSection: React.FC<ResolutionSectionProps> = ({
   entityId,
+  entityType,
+  scopeId,
   openDetailsPanel,
 }) => {
   const {
@@ -38,9 +48,35 @@ export const ResolutionSection: React.FC<ResolutionSectionProps> = ({
     enabled: !!entityId,
   });
 
+  const { openFlyout } = useExpandableFlyoutApi();
+
   const handleOpenResolutionTab = useCallback(() => {
     openDetailsPanel({ tab: EntityDetailsLeftPanelTab.RESOLUTION_GROUP });
   }, [openDetailsPanel]);
+
+  const handleEntityNameClick = useCallback(
+    (entity: Record<string, unknown>) => {
+      const clickedEntityId = getEntityId(entity);
+      const clickedEntityName = getEntityName(entity);
+      const panelKey = EntityPanelKeyByType[entityType];
+      const panelParam = EntityPanelParamByType[entityType];
+
+      if (!panelKey || !panelParam) return;
+
+      openFlyout({
+        right: {
+          id: panelKey,
+          params: {
+            [panelParam]: clickedEntityName,
+            entityId: clickedEntityId,
+            contextID: scopeId,
+            scopeId,
+          },
+        },
+      });
+    },
+    [openFlyout, entityType, scopeId]
+  );
 
   const targetEntityId = group?.target ? getEntityId(group.target) : undefined;
 
@@ -72,6 +108,8 @@ export const ResolutionSection: React.FC<ResolutionSectionProps> = ({
           isLoading={isLoading || isFetching}
           isError={isError}
           targetEntityId={targetEntityId}
+          onEntityNameClick={handleEntityNameClick}
+          currentEntityId={entityId}
         />
       </ExpandablePanel>
     </EuiAccordion>

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution/test_ids.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution/test_ids.ts
@@ -14,5 +14,7 @@ export const RESOLUTION_GROUP_TAB_CONTENT_TEST_ID = `${PREFIX}ResolutionGroupTab
 export const ADD_ENTITIES_SECTION_TEST_ID = `${PREFIX}AddEntitiesSection` as const;
 export const ADD_ENTITIES_SEARCH_TEST_ID = `${PREFIX}AddEntitiesSearch` as const;
 export const ADD_ENTITIES_TABLE_TEST_ID = `${PREFIX}AddEntitiesTable` as const;
+export const ADD_ENTITIES_ACCORDION_TEST_ID = `${PREFIX}AddEntitiesAccordion` as const;
+export const ADD_ENTITIES_SHOWING_TEST_ID = `${PREFIX}AddEntitiesShowing` as const;
 export const CONFIRM_RESOLUTION_MODAL_TEST_ID = `${PREFIX}ConfirmResolutionModal` as const;
 export const RESOLUTION_EMPTY_STATE_TEST_ID = `${PREFIX}ResolutionEmptyState` as const;

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution/translations.ts
@@ -24,7 +24,7 @@ export const RESOLUTION_GROUP_LINK_TOOLTIP = i18n.translate(
 
 export const RESOLUTION_EMPTY_STATE = i18n.translate(
   'xpack.securitySolution.entityResolution.emptyState',
-  { defaultMessage: 'No entity resolution' }
+  { defaultMessage: 'No resolved entities' }
 );
 
 export const ENTITY_NAME_COLUMN = i18n.translate(
@@ -39,7 +39,7 @@ export const ENTITY_ID_COLUMN = i18n.translate(
 
 export const SOURCE_COLUMN = i18n.translate(
   'xpack.securitySolution.entityResolution.columns.source',
-  { defaultMessage: 'Source' }
+  { defaultMessage: 'Data source' }
 );
 
 export const RISK_SCORE_COLUMN = i18n.translate(
@@ -50,6 +50,16 @@ export const RISK_SCORE_COLUMN = i18n.translate(
 export const ACTIONS_COLUMN = i18n.translate(
   'xpack.securitySolution.entityResolution.columns.actions',
   { defaultMessage: 'Actions' }
+);
+
+export const GROUP_RISK_SCORE_LABEL = i18n.translate(
+  'xpack.securitySolution.entityResolution.groupRiskScore',
+  { defaultMessage: 'Group risk score:' }
+);
+
+export const EXPAND_ENTITY_BUTTON = i18n.translate(
+  'xpack.securitySolution.entityResolution.expandEntity',
+  { defaultMessage: 'Open entity details' }
 );
 
 export const REMOVE_ENTITY_BUTTON = i18n.translate(
@@ -84,12 +94,32 @@ export const ADD_ENTITY_BUTTON = i18n.translate(
 
 export const ENTITY_RESOLVED_TOAST = i18n.translate(
   'xpack.securitySolution.entityResolution.entityResolved',
-  { defaultMessage: 'Entity resolved' }
+  { defaultMessage: 'Entity was resolved' }
+);
+
+export const ENTITY_RESOLVED_TOAST_TEXT = i18n.translate(
+  'xpack.securitySolution.entityResolution.entityResolvedText',
+  { defaultMessage: 'Resolution group risk score will be recalculated within 1 hour.' }
+);
+
+export const RESOLUTION_GROUP_CREATED_TOAST = i18n.translate(
+  'xpack.securitySolution.entityResolution.groupCreated',
+  { defaultMessage: 'Resolution group was created' }
+);
+
+export const RESOLUTION_GROUP_CREATED_TOAST_TEXT = i18n.translate(
+  'xpack.securitySolution.entityResolution.groupCreatedText',
+  { defaultMessage: 'Resolution group risk score will be calculated within 1 hour.' }
 );
 
 export const ENTITY_REMOVED_TOAST = i18n.translate(
   'xpack.securitySolution.entityResolution.entityRemoved',
-  { defaultMessage: 'Entity removed from resolution group' }
+  { defaultMessage: 'Entity was removed from the resolution group' }
+);
+
+export const ENTITY_REMOVED_TOAST_TEXT = i18n.translate(
+  'xpack.securitySolution.entityResolution.entityRemovedText',
+  { defaultMessage: 'Resolution group risk score will be recalculated within 1 hour.' }
 );
 
 export const CONFIRM_MODAL_TITLE = i18n.translate(
@@ -115,6 +145,16 @@ export const RESOLUTION_ERROR_TITLE = i18n.translate(
 export const RESOLUTION_FETCH_ERROR = i18n.translate(
   'xpack.securitySolution.entityResolution.fetchError',
   { defaultMessage: 'Unable to load resolution group' }
+);
+
+export const RISK_SCORE_NOT_AVAILABLE = i18n.translate(
+  'xpack.securitySolution.entityResolution.riskScoreNotAvailable',
+  { defaultMessage: 'N/A' }
+);
+
+export const LAST_SEEN_COLUMN = i18n.translate(
+  'xpack.securitySolution.entityResolution.columns.lastSeen',
+  { defaultMessage: 'Last seen' }
 );
 
 export const ENTITY_HAS_ALIASES_ERROR = i18n.translate(

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/entities_data_table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/entities_data_table.tsx
@@ -31,6 +31,7 @@ import { type DataTableRecord } from '@kbn/discover-utils/types';
 import {
   EuiFlexGroup,
   EuiFlexItem,
+  EuiIconTip,
   type EuiDataGridCellValueElementProps,
   type EuiDataGridStyle,
   EuiProgress,
@@ -71,6 +72,7 @@ import type { EntityURLStateResult } from './hooks/use_entity_url_state';
 import {
   ENTITY_ANALYTICS_TABLE_ID,
   ENTITY_FIELDS,
+  ENTITY_GROUPING_OPTIONS,
   DEFAULT_VISIBLE_ROWS_PER_PAGE,
   MAX_ENTITIES_TO_LOAD,
   TEST_SUBJ_DATA_GRID,
@@ -99,6 +101,11 @@ const ROW_TYPE_LABEL = i18n.translate(
 const INSPECT_TITLE = i18n.translate(
   'xpack.securitySolution.entityAnalytics.entitiesTable.inspectTitle',
   { defaultMessage: 'Entity analytics table' }
+);
+
+const TARGET_ENTITY_TOOLTIP = i18n.translate(
+  'xpack.securitySolution.entityAnalytics.entitiesTable.targetEntityTooltip',
+  { defaultMessage: 'Primary entity in the resolution group' }
 );
 
 const COLUMN_HEADERS: Record<string, string> = {
@@ -155,12 +162,14 @@ export interface EntitiesDataTableProps {
   state: EntityURLStateResult;
   height?: number;
   groupSelectorComponent?: JSX.Element;
+  selectedGroup?: string;
 }
 
 export const EntitiesDataTable = ({
   state,
   height,
   groupSelectorComponent,
+  selectedGroup,
 }: EntitiesDataTableProps) => {
   const {
     pageSize,
@@ -396,7 +405,45 @@ export const EntitiesDataTable = ({
       ])
     );
 
+    const isResolutionGroup = selectedGroup === ENTITY_GROUPING_OPTIONS.RESOLUTION;
+
     const specificRenderers: CustomCellRenderer = {
+      ...(isResolutionGroup
+        ? {
+            [ENTITY_FIELDS.ENTITY_NAME]: ({
+              row,
+              dataView: dv,
+              fieldFormats: ff,
+            }: DataGridCellValueElementProps) => {
+              const value = row.flattened[ENTITY_FIELDS.ENTITY_NAME];
+              if (value === null || value === undefined) {
+                return getEmptyTagValue();
+              }
+              const resolvedTo = row.flattened[ENTITY_FIELDS.RESOLVED_TO];
+              const isTarget = resolvedTo === null || resolvedTo === undefined;
+              const field = dv.fields.getByName(ENTITY_FIELDS.ENTITY_NAME);
+              const formattedValue = formatFieldValue(value, row.raw, ff, dv, field, 'text');
+
+              if (isTarget) {
+                return (
+                  <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
+                    <EuiFlexItem grow={false}>{formattedValue}</EuiFlexItem>
+                    <EuiFlexItem grow={false}>
+                      <EuiIconTip
+                        content={TARGET_ENTITY_TOOLTIP}
+                        type="aggregate"
+                        size="s"
+                        data-test-subj="target-entity-icon"
+                      />
+                    </EuiFlexItem>
+                  </EuiFlexGroup>
+                );
+              }
+
+              return <>{formattedValue}</>;
+            },
+          }
+        : {}),
       [ENTITY_FIELDS.ENTITY_TYPE]: ({ row }: DataGridCellValueElementProps) => {
         const value = row.flattened[ENTITY_FIELDS.ENTITY_TYPE] as string | undefined;
         if (value == null) return getEmptyTagValue();
@@ -426,7 +473,7 @@ export const EntitiesDataTable = ({
       ...nullSafeRenderers,
       ...specificRenderers,
     };
-  }, [rows, currentColumns]);
+  }, [rows, currentColumns, selectedGroup]);
 
   const leadingControlColumns = useLeadingControlColumns({
     canUseTimeline,

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/entities_table_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/entities_table_section.tsx
@@ -211,6 +211,7 @@ const GroupContent = ({
       state={state}
       currentGroupFilters={currentGroupFilters}
       parentGroupFilters={parentGroupFilters}
+      selectedGroup={selectedGroup}
     />
   );
 };
@@ -275,12 +276,14 @@ interface DataTableWithLocalPaginationProps {
   state: EntityURLStateResult;
   currentGroupFilters: Filter[];
   parentGroupFilters?: string;
+  selectedGroup?: string;
 }
 
 const DataTableWithLocalPagination = ({
   state,
   currentGroupFilters,
   parentGroupFilters,
+  selectedGroup,
 }: DataTableWithLocalPaginationProps) => {
   const [tablePageIndex, setTablePageIndex] = useState(0);
   const [tablePageSize, setTablePageSize] = useState(10);
@@ -308,5 +311,5 @@ const DataTableWithLocalPagination = ({
     onChangeItemsPerPage: setTablePageSize,
   };
 
-  return <EntitiesDataTable state={newState} />;
+  return <EntitiesDataTable state={newState} selectedGroup={selectedGroup} />;
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/grouping/entity_group_renderer.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/grouping/entity_group_renderer.test.tsx
@@ -82,6 +82,37 @@ describe('createGroupPanelRenderer', () => {
       expect(getByText('bernicehuel')).toBeInTheDocument();
     });
 
+    it('renders entity id subtitle when metadata has target name', () => {
+      const metadata: TargetMetadataMap = new Map([
+        ['user:james@example.com', { name: 'james-hue', type: EntityType.user, riskScore: null }],
+      ]);
+      const bucket = createMockBucket({
+        key: 'user:james@example.com',
+        key_as_string: 'user:james@example.com',
+      });
+      const renderer = createGroupPanelRenderer(metadata);
+      const element = renderer(ENTITY_GROUPING_OPTIONS.RESOLUTION, bucket);
+
+      const { getByText } = render(<>{element}</>);
+
+      expect(getByText('james-hue')).toBeInTheDocument();
+      expect(getByText('Entity ID: user:james@example.com')).toBeInTheDocument();
+    });
+
+    it('does not render entity id subtitle when falling back to entity id as name', () => {
+      const bucket = createMockBucket({
+        key: 'fallback-entity-id',
+        key_as_string: 'fallback-entity-id',
+      });
+      const renderer = createGroupPanelRenderer(emptyMetadata);
+      const element = renderer(ENTITY_GROUPING_OPTIONS.RESOLUTION, bucket);
+
+      const { getByText, queryByText } = render(<>{element}</>);
+
+      expect(getByText('fallback-entity-id')).toBeInTheDocument();
+      expect(queryByText(/Entity ID:/)).not.toBeInTheDocument();
+    });
+
     it('falls back to bucket key when metadata is not available', () => {
       const bucket = createMockBucket({
         key: 'fallback-entity-id',
@@ -215,7 +246,7 @@ describe('createGroupStatsRenderer', () => {
       expect(screen.getByText('65.50')).toBeInTheDocument();
     });
 
-    it('risk score badge shows en-dash when both metadata and bucket score are null', () => {
+    it('risk score badge shows N/A when both metadata and bucket score are null', () => {
       const metadata: TargetMetadataMap = new Map([
         ['target-id', { name: 'test', type: EntityType.user, riskScore: null }],
       ]);
@@ -225,7 +256,7 @@ describe('createGroupStatsRenderer', () => {
 
       render(<TestProviders>{stats[1].component}</TestProviders>);
 
-      expect(screen.getByText('—')).toBeInTheDocument();
+      expect(screen.getByText('N/A')).toBeInTheDocument();
     });
 
     it('risk score stat is present even when no metadata or bucket score exists', () => {
@@ -237,17 +268,17 @@ describe('createGroupStatsRenderer', () => {
 
       render(<TestProviders>{stats[1].component}</TestProviders>);
 
-      expect(screen.getByText('—')).toBeInTheDocument();
+      expect(screen.getByText('N/A')).toBeInTheDocument();
     });
 
-    it('updates risk score from en-dash to actual value when metadata arrives after grouping data', () => {
+    it('updates risk score from N/A to actual value when metadata arrives after grouping data', () => {
       const bucket = createMockBucket({ key: 'target-id', doc_count: 3 });
 
-      // Phase 1: no metadata — shows en-dash
+      // Phase 1: no metadata — shows N/A
       const rendererBefore = createGroupStatsRenderer(emptyMetadata);
       const statsBefore = rendererBefore(ENTITY_GROUPING_OPTIONS.RESOLUTION, bucket);
       const { rerender } = render(<TestProviders>{statsBefore[1].component}</TestProviders>);
-      expect(screen.getByText('—')).toBeInTheDocument();
+      expect(screen.getByText('N/A')).toBeInTheDocument();
 
       // Phase 2: metadata arrived — shows actual risk score
       const metadata: TargetMetadataMap = new Map([

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/grouping/entity_group_renderer.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/grouping/entity_group_renderer.tsx
@@ -25,7 +25,7 @@ import {
   EntityPanelParamByType,
 } from '../../../../../flyout/entity_details/shared/constants';
 import { ENTITY_ANALYTICS_TABLE_ID } from '../../constants';
-import { getEmptyValue } from '../../../../../common/components/empty_value';
+import { RISK_SCORE_NOT_AVAILABLE } from '../../../entity_resolution/translations';
 import { getRiskLevel } from '../../../../../../common/entity_analytics/risk_engine';
 import { formatRiskScore } from '../../../../common/utils';
 import { getRiskScoreColors } from '../risk_score_cell';
@@ -91,7 +91,7 @@ const ResolutionGroupPanel = ({
     <EuiFlexGroup alignItems="center" gutterSize="s">
       {canOpenFlyout && (
         <EuiFlexItem grow={false}>
-          <EuiToolTip content={openEntityFlyoutLabel}>
+          <EuiToolTip content={openEntityFlyoutLabel} disableScreenReaderOutput>
             <EuiButtonIcon
               aria-label={openEntityFlyoutLabel}
               iconType="expand"
@@ -103,6 +103,14 @@ const ResolutionGroupPanel = ({
       )}
       <EuiFlexItem grow={false}>
         <EuiText size="s">{displayName}</EuiText>
+        {targetEntityName && (
+          <EuiText size="xs" color="subdued">
+            {i18n.translate('xpack.securitySolution.entityAnalytics.entitiesTable.group.entityId', {
+              defaultMessage: 'Entity ID: {entityId}',
+              values: { entityId },
+            })}
+          </EuiText>
+        )}
       </EuiFlexItem>
     </EuiFlexGroup>
   );
@@ -145,8 +153,8 @@ const GroupRiskScoreBadge = ({ riskScore }: { riskScore: number | null | undefin
 
   if (riskScore == null) {
     return (
-      <EuiBadge css={badgeCss} color="hollow">
-        {getEmptyValue()}
+      <EuiBadge css={badgeCss}>
+        <EuiText size="xs">{RISK_SCORE_NOT_AVAILABLE}</EuiText>
       </EuiBadge>
     );
   }

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/risk_score_cell.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/risk_score_cell.tsx
@@ -69,7 +69,7 @@ export const RiskScoreCell: React.FC<{ riskScore?: number }> = ({ riskScore }) =
         css={css`
           font-weight: ${euiTheme.font.weight.semiBold};
         `}
-        size="s"
+        size="xs"
         color={colors.text}
       >
         {formatRiskScore(riskScore)}

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_details_left/hooks.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_details_left/hooks.ts
@@ -94,7 +94,13 @@ export const useTabs = ({
 
     const resolutionTab =
       entityStoreEntityId && hasEntityResolutionLicense
-        ? [getResolutionGroupTab({ entityId: entityStoreEntityId, entityType: EntityType.host })]
+        ? [
+            getResolutionGroupTab({
+              entityId: entityStoreEntityId,
+              entityType: EntityType.host,
+              scopeId,
+            }),
+          ]
         : [];
 
     return [...riskScoreTab, ...insightsTab, ...graphViewTab, ...resolutionTab];

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/content.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/content.tsx
@@ -94,7 +94,12 @@ export const HostPanelContent = ({
         )}
       {entityStoreEntityId && !isPreviewMode && hasEntityResolutionLicense && (
         <>
-          <ResolutionSection entityId={entityStoreEntityId} openDetailsPanel={openDetailsPanel} />
+          <ResolutionSection
+            entityId={entityStoreEntityId}
+            entityType={EntityType.host}
+            scopeId={scopeId}
+            openDetailsPanel={openDetailsPanel}
+          />
           <EuiHorizontalRule />
         </>
       )}

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/service_details_left/tabs.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/service_details_left/tabs.tsx
@@ -38,7 +38,13 @@ export const useTabs = (
 
     const resolutionTab =
       entityStoreEntityId && hasEntityResolutionLicense
-        ? [getResolutionGroupTab({ entityId: entityStoreEntityId, entityType: EntityType.service })]
+        ? [
+            getResolutionGroupTab({
+              entityId: entityStoreEntityId,
+              entityType: EntityType.service,
+              scopeId,
+            }),
+          ]
         : [];
 
     return [...riskTab, ...graphTab, ...resolutionTab];

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/service_right/content.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/service_right/content.tsx
@@ -72,7 +72,12 @@ export const ServicePanelContent = ({
       )}
       {entityStoreEntityId && hasEntityResolutionLicense && (
         <>
-          <ResolutionSection entityId={entityStoreEntityId} openDetailsPanel={openDetailsPanel} />
+          <ResolutionSection
+            entityId={entityStoreEntityId}
+            entityType={EntityType.service}
+            scopeId={scopeId}
+            openDetailsPanel={openDetailsPanel}
+          />
           <EuiHorizontalRule />
         </>
       )}

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_details_left/tabs.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_details_left/tabs.tsx
@@ -83,7 +83,11 @@ export const useTabs = (
       tabs.push(getGraphViewTab({ entityId: entityStoreEntityId, scopeId }));
       if (hasEntityResolutionLicense) {
         tabs.push(
-          getResolutionGroupTab({ entityId: entityStoreEntityId, entityType: EntityType.user })
+          getResolutionGroupTab({
+            entityId: entityStoreEntityId,
+            entityType: EntityType.user,
+            scopeId,
+          })
         );
       }
     }

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/content.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/content.tsx
@@ -97,7 +97,12 @@ export const UserPanelContent = ({
         )}
       {entityStoreEntityId && !isPreviewMode && hasEntityResolutionLicense && (
         <>
-          <ResolutionSection entityId={entityStoreEntityId} openDetailsPanel={openDetailsPanel} />
+          <ResolutionSection
+            entityId={entityStoreEntityId}
+            entityType={EntityType.user}
+            scopeId={scopeId}
+            openDetailsPanel={openDetailsPanel}
+          />
           <EuiHorizontalRule />
         </>
       )}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Entity Analytics] Resolution group design adjustments (#262544)](https://github.com/elastic/kibana/pull/262544)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Maxim Kholod","email":"maxim.kholod@elastic.co"},"sourceCommit":{"committedDate":"2026-04-15T13:35:00Z","message":"[Entity Analytics] Resolution group design adjustments (#262544)\n\n## Summary\n\nAlign the entity resolution UX with the finalised [Figma design\nhandover](https://www.figma.com/design/ccUbKmELpHVGJeiz3kLXzw/-9.3-9.4--Entity-Analytics-Portfolio?node-id=13406-613024&t=qea1exrWY6OgWv4j-0).\nThis PR covers design adjustments across the resolution group table\n(right panel), resolution group tab (left panel), add entities section,\nentities data grid grouping, and toast messages.\n\nImplements: #260235\n\n### Screencast\n\n**Data grid and existing group flow**\n\n\nhttps://github.com/user-attachments/assets/323fb4a9-d40a-44d6-ab91-74206af11e37\n\n**New group flow**\n\n\nhttps://github.com/user-attachments/assets/92b97826-8802-48de-9a52-90a845b623fe\n\n### Changes\n\n**Resolution group table (both panels)**\n- Redesign table: remove summary row, rename columns (Entity ID, Data\nsource), add target entity icon, use xs text size, RiskScoreCell badges\nfor risk scores\n- Actions as leading column in left panel (expand + delete icons)\n- Entity name links in right panel (open type-specific flyout), plain\ntext in left panel\n- Empty state shows table with column headers and \"No resolved entities\"\nmessage\n- Remove custom row border overrides\n\n**Resolution group tab (left panel)**\n- Show group risk score badge in header (from entity store), always\nvisible with N/A badge fallback\n- Pass entityType and scopeId props to ResolutionSection\n\n**Add entities section**\n- Collapsible accordion (hidden by default)\n- Actions as first column (expand + add icons, `plus` not\n`plusInCircle`)\n- New Last seen column with relative timestamps\n- \"Showing **1-10** of **N** entities\" counter with bold range/total\n- Rows per page selector (10, 25, 50)\n- Text size xs and RiskScoreCell badges for consistency\n\n**Entities data grid grouping**\n- N/A default badge for missing risk score in resolution group header\n- Primary entity ID subtitle in group header\n- Rename \"Entity id\" → \"Entity ID\" everywhere\n\n**Toast messages**\n- \"Resolution group was created\" + risk score calculation note (new\ngroup)\n- \"Entity was resolved\" + risk score recalculation note (add to existing\ngroup)\n- \"Entity was removed from the resolution group\" + risk score\nrecalculation note (unlink)\n\n### Follow-up issues\n- #262327 — Add \"Add to Timeline\" action to resolution group table\n- #262533 — Redesign \"Create resolution group\" confirmation modal\n- #262536 — Allow removing target entity with primary reassignment\n- #262540 — Dissolve group confirmation modal\n\n### Checklist\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nLow risk — all changes are UI-only in entity resolution components. No\nAPI or data model changes.\n\n- [x] Visual regressions in resolution tables — mitigated by unit tests\ncovering all column rendering, empty states, and actions","sha":"fa6aaf1dd94b32c572651c1cf3b0f572ece9a163","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","Team:Cloud Security","backport:version","v9.4.0","v9.5.0"],"title":"[Entity Analytics] Resolution group design adjustments","number":262544,"url":"https://github.com/elastic/kibana/pull/262544","mergeCommit":{"message":"[Entity Analytics] Resolution group design adjustments (#262544)\n\n## Summary\n\nAlign the entity resolution UX with the finalised [Figma design\nhandover](https://www.figma.com/design/ccUbKmELpHVGJeiz3kLXzw/-9.3-9.4--Entity-Analytics-Portfolio?node-id=13406-613024&t=qea1exrWY6OgWv4j-0).\nThis PR covers design adjustments across the resolution group table\n(right panel), resolution group tab (left panel), add entities section,\nentities data grid grouping, and toast messages.\n\nImplements: #260235\n\n### Screencast\n\n**Data grid and existing group flow**\n\n\nhttps://github.com/user-attachments/assets/323fb4a9-d40a-44d6-ab91-74206af11e37\n\n**New group flow**\n\n\nhttps://github.com/user-attachments/assets/92b97826-8802-48de-9a52-90a845b623fe\n\n### Changes\n\n**Resolution group table (both panels)**\n- Redesign table: remove summary row, rename columns (Entity ID, Data\nsource), add target entity icon, use xs text size, RiskScoreCell badges\nfor risk scores\n- Actions as leading column in left panel (expand + delete icons)\n- Entity name links in right panel (open type-specific flyout), plain\ntext in left panel\n- Empty state shows table with column headers and \"No resolved entities\"\nmessage\n- Remove custom row border overrides\n\n**Resolution group tab (left panel)**\n- Show group risk score badge in header (from entity store), always\nvisible with N/A badge fallback\n- Pass entityType and scopeId props to ResolutionSection\n\n**Add entities section**\n- Collapsible accordion (hidden by default)\n- Actions as first column (expand + add icons, `plus` not\n`plusInCircle`)\n- New Last seen column with relative timestamps\n- \"Showing **1-10** of **N** entities\" counter with bold range/total\n- Rows per page selector (10, 25, 50)\n- Text size xs and RiskScoreCell badges for consistency\n\n**Entities data grid grouping**\n- N/A default badge for missing risk score in resolution group header\n- Primary entity ID subtitle in group header\n- Rename \"Entity id\" → \"Entity ID\" everywhere\n\n**Toast messages**\n- \"Resolution group was created\" + risk score calculation note (new\ngroup)\n- \"Entity was resolved\" + risk score recalculation note (add to existing\ngroup)\n- \"Entity was removed from the resolution group\" + risk score\nrecalculation note (unlink)\n\n### Follow-up issues\n- #262327 — Add \"Add to Timeline\" action to resolution group table\n- #262533 — Redesign \"Create resolution group\" confirmation modal\n- #262536 — Allow removing target entity with primary reassignment\n- #262540 — Dissolve group confirmation modal\n\n### Checklist\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nLow risk — all changes are UI-only in entity resolution components. No\nAPI or data model changes.\n\n- [x] Visual regressions in resolution tables — mitigated by unit tests\ncovering all column rendering, empty states, and actions","sha":"fa6aaf1dd94b32c572651c1cf3b0f572ece9a163"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/262544","number":262544,"mergeCommit":{"message":"[Entity Analytics] Resolution group design adjustments (#262544)\n\n## Summary\n\nAlign the entity resolution UX with the finalised [Figma design\nhandover](https://www.figma.com/design/ccUbKmELpHVGJeiz3kLXzw/-9.3-9.4--Entity-Analytics-Portfolio?node-id=13406-613024&t=qea1exrWY6OgWv4j-0).\nThis PR covers design adjustments across the resolution group table\n(right panel), resolution group tab (left panel), add entities section,\nentities data grid grouping, and toast messages.\n\nImplements: #260235\n\n### Screencast\n\n**Data grid and existing group flow**\n\n\nhttps://github.com/user-attachments/assets/323fb4a9-d40a-44d6-ab91-74206af11e37\n\n**New group flow**\n\n\nhttps://github.com/user-attachments/assets/92b97826-8802-48de-9a52-90a845b623fe\n\n### Changes\n\n**Resolution group table (both panels)**\n- Redesign table: remove summary row, rename columns (Entity ID, Data\nsource), add target entity icon, use xs text size, RiskScoreCell badges\nfor risk scores\n- Actions as leading column in left panel (expand + delete icons)\n- Entity name links in right panel (open type-specific flyout), plain\ntext in left panel\n- Empty state shows table with column headers and \"No resolved entities\"\nmessage\n- Remove custom row border overrides\n\n**Resolution group tab (left panel)**\n- Show group risk score badge in header (from entity store), always\nvisible with N/A badge fallback\n- Pass entityType and scopeId props to ResolutionSection\n\n**Add entities section**\n- Collapsible accordion (hidden by default)\n- Actions as first column (expand + add icons, `plus` not\n`plusInCircle`)\n- New Last seen column with relative timestamps\n- \"Showing **1-10** of **N** entities\" counter with bold range/total\n- Rows per page selector (10, 25, 50)\n- Text size xs and RiskScoreCell badges for consistency\n\n**Entities data grid grouping**\n- N/A default badge for missing risk score in resolution group header\n- Primary entity ID subtitle in group header\n- Rename \"Entity id\" → \"Entity ID\" everywhere\n\n**Toast messages**\n- \"Resolution group was created\" + risk score calculation note (new\ngroup)\n- \"Entity was resolved\" + risk score recalculation note (add to existing\ngroup)\n- \"Entity was removed from the resolution group\" + risk score\nrecalculation note (unlink)\n\n### Follow-up issues\n- #262327 — Add \"Add to Timeline\" action to resolution group table\n- #262533 — Redesign \"Create resolution group\" confirmation modal\n- #262536 — Allow removing target entity with primary reassignment\n- #262540 — Dissolve group confirmation modal\n\n### Checklist\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nLow risk — all changes are UI-only in entity resolution components. No\nAPI or data model changes.\n\n- [x] Visual regressions in resolution tables — mitigated by unit tests\ncovering all column rendering, empty states, and actions","sha":"fa6aaf1dd94b32c572651c1cf3b0f572ece9a163"}}]}] BACKPORT-->