### PR TITLE
[Entity Analytics] Fix CSV upload test to stop automated-resolution maintainer

### DIFF
--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/entity_resolution/trial_license_complete_tier/resolution_csv_upload.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/entity_resolution/trial_license_complete_tier/resolution_csv_upload.ts
@@ -12,6 +12,7 @@ import { ENTITY_STORE_ROUTES, API_VERSIONS } from '@kbn/entity-store/common';
 import { ENTITY_RESOLUTION_CSV_UPLOAD_URL } from '@kbn/security-solution-plugin/common/entity_analytics/entity_store/constants';
 import type { FtrProviderContext } from '../../../../ftr_provider_context';
 import { EntityStoreUtils } from '../../utils';
+import { entityMaintainerRouteHelpersFactory } from '../../utils/entity_maintainers';
 
 const TEST_PREFIX = 'csv-test:';
 
@@ -49,6 +50,7 @@ export default ({ getService }: FtrProviderContext) => {
   const log = getService('log');
   const retry = getService('retry');
   const entityStoreUtils = EntityStoreUtils(getService);
+  const maintainerRoutes = entityMaintainerRouteHelpersFactory(supertest);
 
   const uploadCsv = (csvContent: string) =>
     supertest
@@ -116,11 +118,18 @@ export default ({ getService }: FtrProviderContext) => {
 
   describe('@ess @serverless @skipInServerlessMKI Entity Resolution CSV Upload', () => {
     before(async () => {
-      // Use enableEntityStoreV2 (without maintainer init) to prevent the
-      // automated resolution maintainer from racing with CSV upload tests.
-      // The maintainer would link entities sharing the same user.email,
-      // interfering with the test's own resolution assertions.
       await entityStoreUtils.enableEntityStoreV2();
+
+      // Stop the automated resolution maintainer to prevent it from racing
+      // with CSV upload tests. The maintainer would link entities sharing
+      // the same user.email, interfering with the test's own assertions.
+      try {
+        await maintainerRoutes.stopMaintainer('automated-resolution');
+      } catch (e) {
+        // Maintainer may not be initialized yet (pre-#263732); safe to ignore.
+        log.debug(`Could not stop automated-resolution maintainer: ${e.message}`);
+      }
+
       await cleanEntities();
       await seedEntities();
       await waitForEntities();


### PR DESCRIPTION
## Summary

Fixes the FTR test `should link matching entities to a target` in `resolution_csv_upload.ts` that is consistently failing after PR #263732 (init on install).

PR #263732 moved entity maintainers initialization into the Entity Store install flow. The CSV upload test previously relied on `enableEntityStoreV2()` (without maintainer init) to prevent the `automated-resolution` maintainer from racing with test assertions. With the new behavior, maintainers are initialized during install regardless, so the test now explicitly stops the `automated-resolution` maintainer in the `before` hook.

The `stopMaintainer` call is wrapped in a try/catch for backward compatibility — on builds where #263732 hasn't merged yet, the maintainer task may not exist and the stop call is safely ignored.

Related: #263732, #263728

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Low risk — test-only change. Adds a `stopMaintainer` call in the test `before` hook with a try/catch fallback, so it's a no-op when the maintainer doesn't exist.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)