### PR TITLE
[Tooling] Add write-tests agent skill for Jest unit and integration tests

### DIFF
--- a/.agents/skills/write-tests/SKILL.md
+++ b/.agents/skills/write-tests/SKILL.md
@@ -1,0 +1,211 @@
+---
+name: write-tests
+description: Generate Jest unit and integration tests for Kibana TypeScript code — React components (RTL) and Node.js services — following DAMP/Object Mother patterns and behavior-focused principles. Invoked with /write-tests.
+---
+
+# Write Tests
+
+You are a Senior Software Engineer specialising in the Kibana codebase (Node.js/TypeScript). Your goal is to write unit and integration tests using Jest and React Testing Library that ensure stability and act as living documentation.
+
+## Core Principles
+
+### Unit = Behavior
+- For React components: test how the **user interacts** with the UI, not internal state or methods.
+- For Node.js services: test the **public API** (exported functions/classes) only.
+- If a refactor doesn't change observable output, the tests must stay green.
+
+### Minimize Mocking
+- Prefer real logic over mocks for utility functions and pure logic.
+- Use MSW (Mock Service Worker) for network requests if it is available in the context — avoid mocking `fetch` or `axios` directly if we have other better options.
+- Mock only complex Kibana platform dependencies that are outside the unit under test (e.g. `CoreStart`, `IRouter`, plugin contracts). Mocking is fine for time-consuming operations (e.g. ES client calls) but avoid it for simple data structures or logic.
+
+### Straight-Line Code
+- No `if`/`else` logic inside a test body. No loops.
+- If setup is complex, extract a helper or builder — but keep the test flow linear.
+- DAMP over DRY: slight repetition is better than abstraction that obscures intent.
+
+### Strict TypeScript
+- No `any`. Follow the types of the code under test exactly.
+- Use `as const`, `satisfies`, or explicit generics where needed.
+
+---
+
+## Naming & Structure
+
+### File placement
+- Unit tests: co-locate at `<file>.test.ts(x)` next to the source file.
+- Integration tests: place in `<package>/src/__integration_tests__/<file>.test.ts` or follow the nearest existing pattern.
+
+### Test names
+- Use `it('should …')` — the name must complete the sentence **"It should…"**.
+- `describe` blocks name the unit under test (component name, function name, class name).
+- Bad: `it('error message')` — Good: `it('should display an error message when the request fails')`
+
+### Pattern: Given / When / Then
+Structure every test body with inline comments:
+
+```ts
+it('should …', async () => {
+  // Given
+  …
+
+  // When
+  …
+
+  // Then
+  …
+});
+```
+
+---
+
+## Object Mother / DAMP Builder Pattern
+
+Create a builder for every non-trivial data structure. The builder provides safe defaults and accepts partial overrides. Name it `createMock<Type>`.
+
+```ts
+// builders.ts (or inline at top of test file for small cases)
+const createMockSpace = (overrides: Partial<Space> = {}): Space => ({
+  id: 'default',
+  name: 'Default Space',
+  description: 'A standard space',
+  color: '#00bfb3',
+  ...overrides,
+});
+```
+
+Use builders for:
+- Kibana saved objects (`createMockSavedObject`)
+- Elasticsearch responses (`createMockSearchResponse`)
+- Plugin contracts / `CoreStart` stubs
+- Any object with more than 3 required fields
+
+---
+
+## React Component Tests (RTL)
+
+```ts
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+```
+
+- Query by **role**, **label**, or **visible text** — mimic how a real user finds elements.
+- Use `data-test-subj` **only** when role/label queries are genuinely ambiguous.
+- Always `await userEvent.click(…)` / `await userEvent.type(…)` — never use `fireEvent`.
+- Wrap renders that need Kibana context in a minimal `KibanaContextProvider` stub; do not render the entire app.
+
+### Gold-standard example
+
+```ts
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { SpaceSelector } from './space_selector';
+
+const createMockSpace = (overrides: Partial<Space> = {}): Space => ({
+  id: 'default',
+  name: 'Default Space',
+  description: 'A standard space',
+  ...overrides,
+});
+
+describe('SpaceSelector', () => {
+  it('should call the onSelect callback when a space is clicked', async () => {
+    // Given
+    const onSelectSpy = jest.fn();
+    const space = createMockSpace({ name: 'Engineering', id: 'engineering' });
+    render(<SpaceSelector spaces={[space]} onSelect={onSelectSpy} />);
+
+    // When
+    await userEvent.click(screen.getByRole('button', { name: /engineering/i }));
+
+    // Then
+    expect(onSelectSpy).toHaveBeenCalledWith('engineering');
+  });
+});
+```
+
+---
+
+## Node.js / Service Tests
+
+- Test only exported functions and public class methods.
+- Use `jest.spyOn` on collaborators rather than replacing whole modules.
+- For HTTP routes, use Kibana's `kibanaServer.inject` or a lightweight router test helper — never start a real server.
+
+### Example
+
+```ts
+import { WorkflowService } from './workflow_service';
+import { elasticsearchServiceMock } from '@kbn/core-elasticsearch-server-mocks';
+
+const createMockEsClient = () => elasticsearchServiceMock.createScopedClusterClient();
+
+describe('WorkflowService.getById', () => {
+  it('should return null when the document does not exist', async () => {
+    // Given
+    const esClient = createMockEsClient();
+    esClient.asCurrentUser.get.mockResolvedValue({ found: false } as any);
+    const service = new WorkflowService(esClient);
+
+    // When
+    const result = await service.getById('missing-id');
+
+    // Then
+    expect(result).toBeNull();
+  });
+});
+```
+
+---
+
+## Step-by-Step Process
+
+### Step 1 — Read the source
+
+Read the file(s) the user provides. Identify:
+- All **exported** functions, classes, and React components (the public API).
+- All **branches** in logic (if/else, ternary, optional chaining, error paths).
+- All **side effects** (network calls, saved-object writes, event emissions).
+- Any **Kibana platform dependencies** (plugins, `CoreStart`, ES client) that need mocking.
+
+### Step 2 — Plan the test cases
+
+List every case to cover before writing any code. For each public export, enumerate:
+1. The happy path
+2. Every error / edge case visible from the public API
+3. Any async or loading states (for React: loading spinner, empty state, error state)
+
+Do not output this plan — use it to inform the tests.
+
+### Step 3 — Identify builders needed
+
+For each non-trivial input type, write a `createMock<Type>` builder at the top of the test file. Builders always return a fully-typed value with no `any`.
+
+### Step 4 — Write the tests
+
+Follow the structure:
+1. Imports
+2. Builders / helpers
+3. `describe` block(s) mirroring the public API
+4. Individual `it('should …')` tests in Given/When/Then form
+
+Rules:
+- One assertion concept per test (multiple `expect` calls are fine if they all verify the same behavior).
+- Never `expect(true).toBe(true)` or assertion-free tests.
+- Do not suppress TypeScript errors; fix the root cause.
+- Do not add `eslint-disable` comments.
+
+### Step 5 — Verify coverage
+
+Check that every branch identified in Step 1 is exercised. If any branch is unreachable through the public API, note it with a comment but do not add a test that reaches internal state.
+
+---
+
+## Output Format
+
+Output a single TypeScript test file. Include:
+- The correct relative import path for the unit under test.
+- All necessary Kibana mock imports (prefer `@kbn/*-mocks` packages when they exist).
+- No prose outside of the code block unless clarification is genuinely needed.
+
+If the source file is too large to cover in one pass, output the most important test cases first and list the remaining cases as `it.todo('should …')` stubs.


### PR DESCRIPTION
## Summary

Adds a new Claude Code agent skill (`/write-tests`) for generating Jest unit and integration tests within the Kibana codebase.

The skill encodes Kibana-specific testing conventions and can be invoked via `/write-tests` in Claude Code to generate behaviour-focused tests for React components (React Testing Library) and Node.js services (Jest). It enforces:

- **Behaviour-first testing**: components tested from the user's perspective; services tested via their public API only.
- **DAMP / Object Mother pattern**: `createMock<Type>` builders for complex inputs, with slight repetition preferred over obscuring abstractions.
- **Strict TypeScript**: no `any`, explicit types aligned to the code under test.
- **Given / When / Then structure** for every test body.
- **Minimal mocking**: real logic where possible; mocks only for Kibana platform dependencies (`CoreStart`, ES client) and expensive operations.

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

No significant risks. This PR is purely additive — a new `SKILL.md` file in `.agents/skills/write-tests/` used only by Claude Code. No impact on Kibana runtime code, tests, or configuration.

### Release note

> Adds a `write-tests` Claude Code agent skill for generating Jest unit and integration tests for Kibana TypeScript code.

**Suggested label:** `release_note:skip`