### PR TITLE
[One Workflow] HTTP connector accepts JSON body values - Phase 2 (UI)

### DIFF
--- a/src/platform/plugins/shared/workflows_management/common/stack_connectors_schema/http.ts
+++ b/src/platform/plugins/shared/workflows_management/common/stack_connectors_schema/http.ts
@@ -12,7 +12,7 @@
  * and will be deprecated once connectors will expose their schemas
  */
 
-import { HttpMethodSchema } from '@kbn/connector-schemas/http/schemas/v1';
+import { HttpMethodSchema, HttpRequestBodySchema } from '@kbn/connector-schemas/http/schemas/v1';
 import { z } from '@kbn/zod/v4';
 
 // HTTP connector parameter schema
@@ -25,10 +25,9 @@ export const HttpParamsSchema = z.object({
     ),
   path: z.string().optional().describe('The path appended to the base URL.'),
   method: HttpMethodSchema.describe('The HTTP method to use for the request.'),
-  body: z
-    .string()
-    .optional()
-    .describe('The body of the request. Can be a raw string, a JSON object, or a JSON array.'),
+  body: HttpRequestBodySchema.optional().describe(
+    'The body of the request. Can be a raw string, a JSON object, or a JSON array.'
+  ),
   query: z.record(z.string(), z.string()).optional(),
   headers: z.record(z.string(), z.string()).optional(),
   fetcher: z


### PR DESCRIPTION
## Summary

UI-side follow-up of https://github.com/elastic/kibana/pull/263544

### 1. Request body: objects and arrays (not only strings)

- **Schema** (`@kbn/connector-schemas/http`): `params.body` may be a string, a JSON object (`Record<string, unknown>`), or a JSON array, via `HttpRequestBodySchema`.

### Screenshots

Before

<img width="660" height="342" alt="Captura de pantalla 2026-04-15 a les 17 56 43" src="https://github.com/user-attachments/assets/90e43970-395f-48e0-a065-b9c51d935227" />

After

<img width="660" height="342" alt="Captura de pantalla 2026-04-15 a les 17 55 22" src="https://github.com/user-attachments/assets/77f34743-7e6f-458d-a593-7ac2f257b77f" />


<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->