### PR TITLE
[Infra] Remove dead constant from shared constants file

### DIFF
--- a/src/core/server/integration_tests/ci_checks/saved_objects/check_registered_types.test.ts
+++ b/src/core/server/integration_tests/ci_checks/saved_objects/check_registered_types.test.ts
@@ -814,7 +814,7 @@ describe('checking migration metadata changes on all registered SO types', () =>
         "infrastructure-ui-source|mappings: e1b10e5bec060a176469a5e9a4f80c94e23abcd7",
         "infrastructure-ui-source|schemas: da39a3ee5e6b4b0d3255bfef95601890afd80709",
         "infrastructure-ui-source|7.16.2: 4be5e4f58ef2424cf27809a4ac53214c958fda09",
-        "infrastructure-ui-source|7.13.0: c4fb38da02b6901c06ac3b6356b0fd06aeda2940",
+        "infrastructure-ui-source|7.13.0: 024f7c871de336cb3757b95e2244fd3cb43559eb",
         "infrastructure-ui-source|7.9.0: 214a790607e1034dba6625bd5e2674c22f5a51db",
         "========================================================================",
         "ingest-agent-policies|global: c3b43ce09de4bc7883a7ef73aec64d7d679b28d2",

--- a/x-pack/solutions/observability/plugins/infra/common/constants.ts
+++ b/x-pack/solutions/observability/plugins/infra/common/constants.ts
@@ -18,7 +18,6 @@ export {
 export const DEFAULT_SCHEMA: DataSchemaFormat = 'semconv';
 
 export const METRICS_INDEX_PATTERN = 'metrics-*,metricbeat-*';
-export const LOGS_INDEX_PATTERN = 'logs-*,filebeat-*,kibana_sample_data_logs*';
 export const METRICS_APP = 'metrics';
 export const LOGS_APP = 'logs';
 

--- a/x-pack/solutions/observability/plugins/infra/server/lib/sources/migrations/7_13_0_convert_log_alias_to_log_indices.ts
+++ b/x-pack/solutions/observability/plugins/infra/server/lib/sources/migrations/7_13_0_convert_log_alias_to_log_indices.ts
@@ -7,11 +7,12 @@
 
 import type { SavedObjectMigrationFn } from '@kbn/core/server';
 import type { InfraSourceConfiguration } from '../../../../common/source_configuration/source_configuration';
-import { LOGS_INDEX_PATTERN } from '../../../../common/constants';
 
 type SevenTwelveZeroSourceConfig = Omit<InfraSourceConfiguration, 'logIndices'> & {
   logAlias: string;
 };
+
+const LOGS_INDEX_PATTERN = 'logs-*,filebeat-*,kibana_sample_data_logs*';
 
 export const convertLogAliasToLogIndices: SavedObjectMigrationFn<
   SevenTwelveZeroSourceConfig,


### PR DESCRIPTION
## Summary

While the folks from obs-presentation were updating the default log patterns, they brought out attention to a constant in the infra plugin referring to logs index patterns. After some investigation on what this constant was, we realised it's a 5yrs old artifact that must have been used at some point but that is now dead code. Log patterns were migrated a couple years ago to become a Kibana advanced settings so a hardcoded pattern like that no longer applies anywhere.

The only reference left for the constant was a saved object migration for version 7.13 that is also 5yrs old at this point. To avoid further confusions in regards to the shared constant, we decided to inline the value in the migration file as it was in order to preserver the migration file behaviour while removing it from shared constants as it is no longer really being shared anywhere.



