### PR TITLE
[OTel Tracing] Check that span is recording before adding labels

### DIFF
--- a/src/platform/packages/shared/kbn-apm-utils/src/add_labels.test.ts
+++ b/src/platform/packages/shared/kbn-apm-utils/src/add_labels.test.ts
@@ -32,6 +32,7 @@ jest.mock('@opentelemetry/api', () => ({
 
 interface MockSpan {
   setAttributes: jest.Mock<void, [Record<string, AttributeValue>]>;
+  isRecording: jest.Mock<boolean>;
 }
 
 interface MockApm {
@@ -46,6 +47,7 @@ const getActiveSpanMock = trace.getActiveSpan as jest.MockedFunction<typeof trac
 
 const createMockSpan = (): MockSpan => ({
   setAttributes: jest.fn(),
+  isRecording: jest.fn().mockReturnValue(true),
 });
 
 const getTransactionAddLabelsMock = (): jest.Mock<void, [Labels, boolean?]> => {
@@ -94,6 +96,21 @@ describe('add_labels', () => {
         'kibana.count': 3,
         'kibana.enabled': true,
       });
+    });
+
+    it('does not call setAttributes on active OTel span if the span is ended', () => {
+      const span = createMockSpan();
+      span.isRecording.mockReturnValue(false);
+
+      getActiveSpanMock.mockReturnValue(span as never);
+
+      addSpanLabels({
+        foo: 'bar',
+        count: 3,
+        enabled: true,
+      });
+
+      expect(span.setAttributes).not.toHaveBeenCalled();
     });
 
     it('filters out null and undefined label values before OTel write', () => {
@@ -180,6 +197,21 @@ describe('add_labels', () => {
         'kibana.count': 3,
         'kibana.enabled': true,
       });
+    });
+
+    it('does not call setAttributes on active OTel span if the span is ended', () => {
+      const span = createMockSpan();
+      span.isRecording.mockReturnValue(false);
+
+      getActiveSpanMock.mockReturnValue(span as never);
+
+      addTransactionLabels({
+        foo: 'bar',
+        count: 3,
+        enabled: true,
+      });
+
+      expect(span.setAttributes).not.toHaveBeenCalled();
     });
 
     it('forwards isString option to apm.currentTransaction.addLabels', () => {

--- a/src/platform/packages/shared/kbn-apm-utils/src/add_labels.ts
+++ b/src/platform/packages/shared/kbn-apm-utils/src/add_labels.ts
@@ -27,10 +27,16 @@ export const prefixKeys = (labels: Labels, prefix: string): Record<string, Attri
 
 export const addSpanLabels = (labels: Labels, opts?: AddLabelsOptions): void => {
   apm.addLabels(labels, opts?.isString);
-  trace.getActiveSpan()?.setAttributes(opts?.otelAttributes ?? prefixKeys(labels, 'kibana.'));
+  const span = trace.getActiveSpan();
+  if (span && span.isRecording()) {
+    span.setAttributes(opts?.otelAttributes ?? prefixKeys(labels, 'kibana.'));
+  }
 };
 
 export const addTransactionLabels = (labels: Labels, opts?: AddLabelsOptions): void => {
   apm.currentTransaction?.addLabels(labels, opts?.isString);
-  trace.getActiveSpan()?.setAttributes(opts?.otelAttributes ?? prefixKeys(labels, 'kibana.'));
+  const span = trace.getActiveSpan();
+  if (span && span.isRecording()) {
+    span.setAttributes(opts?.otelAttributes ?? prefixKeys(labels, 'kibana.'));
+  }
 };


### PR DESCRIPTION
## Summary

Fixing the bug below by checking if the span is still active before calling `setAttributes`.

```
[2026-04-17T16:57:47.693+02:00][WARN ][telemetry] Cannot execute the operation on ended Span {traceId: ee6c0e64e5fdfa3e7b0572e1afedc262, spanId: c8ee7fa414a84eb4} Error: Operation attempted on ended Span {traceId: ee6c0e64e5fdfa3e7b0572e1afedc262, spanId: c8ee7fa414a84eb4}
    at SpanImpl._isSpanEnded (/Users/afharo/Developer/elastic/kibana/node_modules/@opentelemetry/sdk-trace-base/src/Span.ts:381:21)
    at SpanImpl.setAttribute (/Users/afharo/Developer/elastic/kibana/node_modules/@opentelemetry/sdk-trace-base/src/Span.ts:142:31)
    at SpanImpl.setAttributes (/Users/afharo/Developer/elastic/kibana/node_modules/@opentelemetry/sdk-trace-base/src/Span.ts:176:12)
    at addSpanLabels (add_labels.ts:30:26)
    at FeatureFlagsService.evaluateFlag (feature_flags_service.ts:218:18)
    at processTicksAndRejections (node:internal/process/task_queues:105:5)
    at getFeatureFlag (feature_flags.ts:97:23)
    at feature_flags.ts:79:33
    at async Promise.all (index 1)
    at fetchLensFeatureFlags (feature_flags.ts:77:5)
    at plugin.tsx:135:23
```


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.





