### PR TITLE
Merge Slack integration with Elastic Ramen as primary feature

### DIFF
--- a/x-pack/platform/plugins/shared/elastic_console/PLAN-router-service.md
+++ b/x-pack/platform/plugins/shared/elastic_console/PLAN-router-service.md
@@ -1,0 +1,477 @@
+# elastic-console-connect: Implementation Plan
+
+Thin Slack routing service. Elastic hosts this. Receives Slack events, looks up the customer's
+Kibana URL from the registry, forwards the event. All intelligence lives in the customer's Kibana.
+
+---
+
+## Architecture
+
+```
+                    ┌──────────────────────────────────────────┐
+                    │         elastic-console-connect           │
+                    │         (Elastic-hosted, Cloud Run)       │
+                    │                                           │
+Slack ──events────▶ │  POST /slack/events                       │
+                    │    verify Slack signature                 │
+                    │    lookup team_id → kibana_url + api_key  │
+                    │    forward to Kibana ──────────────────────┼───▶ Customer's Kibana
+                    │    Authorization: ApiKey <kibana_api_key> │      verifies API key natively
+                    │                                           │
+Customer ──OAuth──▶ │  GET /slack/oauth_redirect                │
+                    │    exchange code → bot_token              │
+                    │    push bot_token to Kibana               │
+                    │    store team_id → kibana_url + api_key   │
+                    │                                           │
+                    │  Registry: Elastic's ES                   │
+                    │  team_id → kibana_url + kibana_api_key    │
+                    └──────────────────────────────────────────┘
+
+
+                    ┌──────────────────────────────────────────┐
+                    │    Customer's Kibana                      │
+                    │    elastic_console plugin                 │
+                    │                                           │
+                    │  Verifies API key on /slack/events        │
+                    │  Stores bot_token in encryptedSavedObjects│
+                    │  Handles conversation lifecycle           │
+                    │  Calls inference plugin for LLM           │
+                    │  Posts responses back to Slack            │
+                    │                                           │
+                    │  Storage: Customer's ES                   │
+                    │  Conversations + session state            │
+                    └──────────────────────────────────────────┘
+```
+
+---
+
+## Authentication Model
+
+### Router → Kibana: Per-tenant Kibana API Key
+
+Each customer's Kibana generates a scoped API key during the OAuth setup flow and embeds it
+in the signed OAuth state. The router stores it alongside `kibana_url` and uses it as
+`Authorization: ApiKey <key>` on every forwarded request.
+
+Kibana verifies it natively — no custom auth code needed in the plugin.
+
+**Why API Key over alternatives:**
+
+| Option | Why rejected |
+|---|---|
+| Shared `ROUTER_SECRET` | Single breach exposes all tenants |
+| JWT (router private key) | Works but adds key management overhead — API keys are native to Kibana |
+| mTLS | TLS terminated at LB before Kibana — would need LB-level config, not plugin code |
+| PASETO | Cleaner than JWT but ecosystem less mature, Kibana doesn't natively support it |
+
+**Per-tenant isolation:** one compromised API key only affects one customer.
+Customer can revoke/rotate independently via Kibana. Router stores the key but it is
+scoped only to `POST /api/elastic_console/slack/events` — useless for anything else.
+
+### Bot Token: Pushed to Kibana, Never Persisted in Router
+
+During OAuth callback the router exchanges the code for a bot token, immediately pushes it
+to the customer's Kibana (`POST /internal/elastic_console/slack/token`), then discards it.
+Kibana stores it in `encryptedSavedObjects`. The router never persists the bot token.
+
+```
+OAuth callback:
+  1. exchange code → bot_token (Slack API)
+  2. POST ${kibana_url}/internal/elastic_console/slack/token
+       Authorization: ApiKey <kibana_api_key>
+       { bot_token }
+  3. Kibana stores bot_token in encryptedSavedObjects
+  4. Router discards bot_token — never written to registry
+
+Event forwarding:
+  Router → Kibana:  Authorization: ApiKey <kibana_api_key>  (no bot token)
+  Kibana  → Slack:  loads bot_token from encryptedSavedObjects
+```
+
+---
+
+## OAuth State Flow
+
+Kibana initiates OAuth and embeds both the Kibana URL and a freshly-generated API key
+in a signed JWT state parameter. The router reads these from the callback.
+
+```
+Kibana                             Router                        Slack
+  │                                  │                             │
+  │  1. generate scoped API key      │                             │
+  │  2. sign JWT:                    │                             │
+  │     { kibana_url, kibana_api_key}│                             │
+  │     secret = SLACK_STATE_SECRET  │                             │
+  │                                  │                             │
+  │──── redirect with state ─────────────────────────────────────▶│
+  │                                  │                             │
+  │                                  │◀─── code + state ──────────│
+  │                                  │                             │
+  │                                  │  verify JWT                 │
+  │                                  │  → kibana_url               │
+  │                                  │  → kibana_api_key           │
+  │                                  │  exchange code → bot_token  │
+  │                                  │  push bot_token to Kibana   │
+  │                                  │  store registry entry       │
+  │                                  │  discard bot_token          │
+  │                                  │                             │
+  │◀─── redirect back ───────────────│                             │
+```
+
+---
+
+## Repo Structure
+
+```
+elastic-console-connect/
+├── src/
+│   ├── index.ts                ← entry point
+│   ├── app.ts                  ← Express app assembly
+│   ├── config.ts               ← all env vars
+│   ├── registry.ts             ← ES-backed workspace store
+│   ├── lib/
+│   │   ├── slack-verify.ts     ← Slack signature verification
+│   │   └── forward.ts          ← forward events to Kibana
+│   └── routes/
+│       ├── events.ts           ← POST /slack/events
+│       ├── oauth.ts            ← GET /slack/install + /slack/oauth_redirect
+│       └── health.ts           ← GET /health
+├── Dockerfile
+├── package.json
+└── README.md
+```
+
+---
+
+## Environment Variables
+
+```bash
+# Slack app credentials (Elastic-owned app — from api.slack.com)
+SLACK_CLIENT_ID=
+SLACK_CLIENT_SECRET=
+SLACK_SIGNING_SECRET=
+SLACK_STATE_SECRET=        # signs/verifies OAuth state JWT
+SLACK_REDIRECT_URI=https://connect.elastic.co/slack/oauth_redirect
+
+# Elastic's internal ES (workspace registry)
+ES_URL=
+ES_API_KEY=
+
+PORT=3000
+```
+
+No `ROUTER_SECRET` — authentication is handled per-tenant via Kibana API keys.
+
+---
+
+## ES Registry Index
+
+```json
+{
+  "index": "elastic-console-slack-registry",
+  "mappings": {
+    "properties": {
+      "team_id":         { "type": "keyword" },
+      "team_name":       { "type": "keyword" },
+      "kibana_url":      { "type": "keyword" },
+      "kibana_api_key":  { "type": "keyword", "index": false },
+      "installed_at":    { "type": "date" },
+      "updated_at":      { "type": "date" }
+    }
+  }
+}
+```
+
+No `bot_token` in the registry — it lives in the customer's Kibana `encryptedSavedObjects`.
+
+---
+
+## Endpoints
+
+| Method | Path | Purpose |
+|---|---|---|
+| `POST` | `/slack/events` | Receive Slack events, verify, forward to Kibana |
+| `GET` | `/slack/install` | Direct install link (fallback for non-Kibana installs) |
+| `GET` | `/slack/oauth_redirect` | OAuth callback — exchange code, register workspace |
+| `GET` | `/health` | Health check |
+
+---
+
+## Route Logic
+
+### `POST /slack/events`
+
+```
+1. verify Slack signature (X-Slack-Signature + X-Slack-Request-Timestamp)
+   reject if older than 5 minutes (replay protection)
+2. if body.type === 'url_verification' → return { challenge }
+3. res.sendStatus(200)   ← ack immediately, always within 3 seconds
+4. teamId = body.team_id ?? body.authorizations?.[0]?.team_id
+5. workspace = await Registry.get(teamId)
+6. if !workspace → log unknown team, return
+7. if !workspace.kibana_url → sendOnboardingDm via Slack API, return
+8. await forward(workspace.kibana_url, workspace.kibana_api_key, body)
+```
+
+### `GET /slack/oauth_redirect`
+
+```
+1. verify state JWT (SLACK_STATE_SECRET)
+   → { kibana_url, kibana_api_key }
+2. exchange code → bot_token
+   POST https://slack.com/api/oauth.v2.access
+3. push bot_token to Kibana:
+   POST ${kibana_url}/internal/elastic_console/slack/token
+     Authorization: ApiKey <kibana_api_key>
+     { bot_token }
+4. save to registry:
+   { team_id, team_name, kibana_url, kibana_api_key }
+   (no bot_token)
+5. if kibana_url:
+     redirect → ${kibana_url}/app/elastic-console?slack=connected
+   else:
+     sendOnboardingDm → "Go to Kibana to finish setup"
+     render success page
+```
+
+---
+
+## `src/config.ts`
+
+```typescript
+export const config = {
+  port: process.env.PORT ?? 3000,
+
+  slack: {
+    clientId:         process.env.SLACK_CLIENT_ID!,
+    clientSecret:     process.env.SLACK_CLIENT_SECRET!,
+    signingSecret:    process.env.SLACK_SIGNING_SECRET!,
+    stateSecret:      process.env.SLACK_STATE_SECRET!,
+    oauthRedirectUri: process.env.SLACK_REDIRECT_URI!,
+  },
+
+  es: {
+    url:    process.env.ES_URL!,
+    apiKey: process.env.ES_API_KEY!,
+  },
+}
+```
+
+---
+
+## `src/registry.ts`
+
+```typescript
+export interface WorkspaceEntry {
+  team_id:        string
+  team_name:      string
+  kibana_url:     string | null
+  kibana_api_key: string | null   // scoped to /api/elastic_console/slack/events only
+  installed_at:   string
+  updated_at:     string
+}
+
+export const Registry = {
+  async get(teamId: string): Promise<WorkspaceEntry | null>,
+  async save(entry: WorkspaceEntry): Promise<void>,
+  async setKibanaUrl(teamId: string, kibanaUrl: string, apiKey: string): Promise<void>,
+}
+```
+
+---
+
+## `src/lib/slack-verify.ts`
+
+```typescript
+// HMAC-SHA256 verification against X-Slack-Signature header
+// Rejects requests older than 5 minutes (replay protection)
+export function verifySlackSignature(
+  signingSecret: string,
+  signature: string,
+  timestamp: string,
+  rawBody: string
+): boolean
+```
+
+---
+
+## `src/lib/forward.ts`
+
+```typescript
+// Forwards raw Slack event body to customer's Kibana
+// Authenticates with per-tenant Kibana API key
+// No bot_token — Kibana loads it from encryptedSavedObjects
+export async function forwardToKibana(
+  kibanaUrl: string,
+  kibanaApiKey: string,
+  body: unknown
+): Promise<void> {
+  await fetch(`${kibanaUrl}/api/elastic_console/slack/events`, {
+    method: 'POST',
+    headers: {
+      'Content-Type':  'application/json',
+      'Authorization': `ApiKey ${kibanaApiKey}`,
+      'kbn-xsrf':      'true',
+    },
+    body: JSON.stringify(body),
+    signal: AbortSignal.timeout(30_000),
+  })
+}
+```
+
+---
+
+## Kibana Plugin Changes Required
+
+The router alone is not enough. The `elastic_console` Kibana plugin also needs these additions.
+
+### New Kibana endpoints
+
+| Endpoint | Purpose |
+|---|---|
+| `POST /internal/elastic_console/conversations/:id/fork` | Clone conversation, seed with last response |
+| `POST /internal/elastic_console/conversations/:id/locate` | Atomic ownership claim |
+| `POST /internal/elastic_console/conversations/:id/handoff` | Return to origin, notify via connector |
+| `POST /api/elastic_console/slack/events` | Receive forwarded events — verified via API key |
+| `POST /internal/elastic_console/slack/token` | Receive bot_token from router, store encrypted |
+| `GET /internal/elastic_console/slack/connect` | Initiate OAuth — generates API key, signs state JWT |
+
+### New Kibana files
+
+| File | Purpose |
+|---|---|
+| `server/routes/conversation_sessions.ts` | fork / locate / handoff |
+| `server/lib/slack_client.ts` | Post/update Slack messages using stored bot_token |
+| `server/lib/slack_handler.ts` | Core Slack event processing |
+| `server/lib/notification_service.ts` | Generic connector-based notifications |
+| `server/routes/slack_events.ts` | Inbound route — API key auth, calls slack_handler |
+| `server/routes/slack_connect.ts` | OAuth initiation — generates API key, signs state JWT |
+| `server/routes/slack_token.ts` | Receive and store bot_token from router |
+
+### Key Kibana auth detail
+
+`POST /api/elastic_console/slack/events` uses **standard Kibana API key auth** — no custom
+verification code needed. The API key generated during setup is scoped to this endpoint only.
+
+`POST /internal/elastic_console/slack/token` also requires the same API key — so only
+the router (which holds the key) can push a bot token to Kibana.
+
+---
+
+## Deployment
+
+```dockerfile
+FROM node:20-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci --production
+COPY dist/ ./dist/
+CMD ["node", "dist/index.js"]
+```
+
+### Cloud Run Configuration
+
+```yaml
+service:      elastic-console-connect
+region:       us-central1
+memory:       256Mi
+cpu:          1
+minInstances: 1      # always warm — Slack requires 200 within 3s
+maxInstances: 20
+```
+
+---
+
+## Customer Installation Flow
+
+### Elastic Cloud (zero config)
+
+```
+1. Kibana → elastic-console → Settings → "Connect Slack"
+2. Kibana generates scoped API key
+3. Kibana signs JWT: { kibana_url, kibana_api_key }
+4. Redirect to Slack OAuth
+5. Customer clicks "Allow"
+6. Router callback:
+     - exchanges code → bot_token
+     - pushes bot_token to Kibana (Authorization: ApiKey <kibana_api_key>)
+     - stores team_id → kibana_url + kibana_api_key
+     - discards bot_token
+7. Redirect back to Kibana → "✅ Slack connected"
+8. In Slack: /invite @elasticconsole to any channel
+```
+
+### Self-Managed
+
+```
+1. Customer finds "ElasticConsole" in Slack App Directory
+   OR clicks "Connect Slack" in Kibana (same OAuth link)
+2. Same OAuth flow as above
+3. If installed from App Directory (no kibana_url in state):
+   → Router sends onboarding DM: "Go to Kibana → Settings → Connect Slack"
+   → Customer completes the link from Kibana
+```
+
+---
+
+## Session Handoff Flow (End-to-End)
+
+```
+1. User @mentions @elasticconsole in Slack thread
+   → Router looks up team_id → kibana_url + kibana_api_key
+   → Forwards event to Kibana (Authorization: ApiKey ...)
+   → Kibana loads bot_token from encryptedSavedObjects
+   → Kibana creates conversation, streams LLM response
+   → Kibana posts response back to Slack using bot_token
+
+2. User says "fork"
+   → Kibana creates child conversation
+   → fork_context = last response (injected on first CLI turn)
+   → origin_ref = 'channelId:thread_ts'
+   → Posts session ID + instructions to Slack thread
+
+3. Engineer picks it up:
+   elastic-console --session <id>
+   → POST /conversations/:id/locate { location: 'cli' }
+   → receives fork_context, injects as first message context
+
+4. Engineer calls handoff:
+   POST /conversations/:id/handoff { summary: "Fixed X by doing Y" }
+   → Kibana resets location → 'slack'
+   → Kibana posts summary to original Slack thread via connector
+
+5. Slack thread receives: "✅ Fixed X by doing Y — continuing here"
+```
+
+---
+
+## Build Order
+
+```
+Step 1 — Kibana: Conversation Session API
+  ├── conversation_storage.ts  (update state schema)
+  └── conversation_sessions.ts (fork / locate / handoff)
+
+Step 2 — Kibana: Slack Integration
+  ├── slack_token.ts           (receive + store bot_token from router)
+  ├── slack_connect.ts         (generate API key, sign state JWT)
+  ├── slack_client.ts          (post to Slack using stored bot_token)
+  ├── slack_handler.ts         (event processing)
+  ├── notification_service.ts  (connector notifications)
+  └── slack_events.ts          (inbound route, API key auth)
+  └── ✓ Test locally with ngrok (no router needed at this stage)
+
+Step 3 — This repo: elastic-console-connect
+  ├── config.ts
+  ├── registry.ts              (team_id → kibana_url + kibana_api_key, no bot_token)
+  ├── lib/slack-verify.ts
+  ├── lib/forward.ts           (Authorization: ApiKey <kibana_api_key>)
+  ├── routes/health.ts
+  ├── routes/oauth.ts          (push bot_token to Kibana, then discard)
+  └── routes/events.ts
+
+Step 4 — Deploy & wire up
+  ├── Deploy to Cloud Run
+  ├── Configure Slack app event URL → https://connect.elastic.co/slack/events
+  └── End-to-end test: Slack → fork → CLI → handoff → Slack
+```

--- a/x-pack/platform/plugins/shared/elastic_console/PLAN.md
+++ b/x-pack/platform/plugins/shared/elastic_console/PLAN.md
@@ -1,0 +1,260 @@
+  ---
+  Implementation Plan: elastic_console Kibana Plugin — Slack Integration
+
+  ---
+  Phase 1 — Conversation Session API
+
+  Foundation. Everything else depends on this.
+
+  1.1 Update conversation_storage.ts — map state fields
+
+  state: types.object({
+    dynamic: false,
+    properties: {
+      location:        types.keyword()   ← queryable
+      origin_ref:      types.keyword()   ← queryable
+      origin_location: types.keyword()   ← queryable
+      fork_context:    types.text()
+      connector_id:    types.keyword()
+      located_at:      types.date()
+      handoff_summary: types.text()
+    }
+  })
+
+  1.2 New file server/routes/conversation_sessions.ts
+
+  Three new endpoints:
+
+  POST /internal/elastic_console/conversations/:id/fork
+  body:     { origin_ref, origin_location, connector_id? }
+  response: { id, fork_context }
+
+  logic:
+    - get parent conversation
+    - fork_context = parent.conversation_rounds.at(-1).response.message
+    - create new conversation with:
+        conversation_rounds: []
+        state: { fork_context, origin_ref, origin_location, connector_id, location: null }
+    - return { id, fork_context }
+
+  POST /internal/elastic_console/conversations/:id/locate
+  body:     { location }
+  response: { conversation, fork_context }
+
+  logic:
+    - get conversation
+    - capture fork_context before clearing
+    - detect first Slack→other transition → set origin fields
+    - update state: { location, located_at, fork_context: null }
+    - return { conversation, fork_context }
+
+  POST /internal/elastic_console/conversations/:id/handoff
+  body:     { summary? }
+  response: { origin_location, origin_ref }
+
+  logic:
+    - get conversation
+    - update state: { location: origin_location, handoff_summary: summary }
+    - return { origin_location, origin_ref }
+    - (Slack notification handled separately by the Slack handler)
+
+  1.3 Register in server/routes/index.ts
+
+  import { registerConversationSessionRoutes } from './conversation_sessions'
+  registerConversationSessionRoutes({ router, coreSetup, logger })
+
+  ---
+  Phase 2 — Slack Integration
+
+  2.1 Update kibana.jsonc — add encryptedSavedObjects
+
+  "requiredPlugins": ["inference", "actions", "encryptedSavedObjects"]
+
+  Needed to store the bot token securely.
+
+  2.2 New file server/lib/slack_client.ts
+
+  Thin wrapper around Slack Web API (raw fetch, no SDK):
+
+  postMessage(botToken, { channel, thread_ts, text }) → ts
+  updateMessage(botToken, { channel, ts, text })
+
+  2.3 New file server/lib/slack_handler.ts
+
+  Core event processing logic (mirrors motlp/bot handler):
+
+  handleSlackEvent(event, botToken, coreStart):
+    1. parse event type (app_mention, message.im)
+    2. extract channel, thread_ts, text, user
+    3. find or create conversation via state.origin_ref query
+    4. detect commands: "fork" | "status" | "reset"
+    5. for normal message:
+         - post "..." placeholder to Slack
+         - call chat completions (inference plugin directly, no HTTP)
+         - stream chunks → throttled Slack updates
+         - final update with full response
+         - sync conversation_rounds to storage
+    6. for "fork":
+         - call fork logic
+         - post session ID + instructions to thread
+
+  Note: Call the inference plugin directly (not via HTTP) since we're inside Kibana:
+  const client = inference.getClient({ request })
+  client.chatComplete({ connectorId, messages, stream: true })
+
+  2.4 New file server/routes/slack_events.ts
+
+  POST /api/elastic_console/slack/events   (public access, not internal)
+
+  - verify X-Elastic-Router-Secret header
+  - handle url_verification challenge (for initial Slack setup)
+  - ack immediately (setImmediate for async processing)
+  - call slack_handler.handleSlackEvent
+
+  2.5 New file server/routes/slack_connect.ts
+
+  OAuth initiation — customer clicks "Connect Slack" in Kibana:
+
+  GET /internal/elastic_console/slack/connect
+
+  - get kibanaUrl from coreStart.http.basePath.publicBaseUrl
+  - sign JWT: { kibana_url: kibanaUrl } with SHARED_SECRET + 10min expiry
+  - redirect to:
+      https://slack.com/oauth/v2/authorize
+        ?client_id=ELASTIC_SLACK_CLIENT_ID
+        &redirect_uri=https://router.elastic.co/slack/oauth_redirect
+        &scope=app_mentions:read,chat:write,channels:history,im:write
+        &state=<jwt>
+
+  2.6 Register new routes in server/routes/index.ts
+
+  import { registerSlackEventsRoute } from './slack_events'
+  import { registerSlackConnectRoute } from './slack_connect'
+
+  registerSlackEventsRoute({ router, coreSetup, logger })
+  registerSlackConnectRoute({ router, coreSetup, logger })
+
+  2.7 Update server/types.ts — expose encryptedSavedObjects
+
+  import type { EncryptedSavedObjectsPluginStart } from '@kbn/encrypted-saved-objects-plugin/server'
+
+  export interface ElasticConsoleStartDependencies {
+    inference: InferenceServerStart
+    actions: ActionsPluginStart
+    encryptedSavedObjects: EncryptedSavedObjectsPluginStart  // ← add
+  }
+
+  ---
+  Phase 3 — Config & Feature Flag
+
+  3.1 Update server/config.ts
+
+  export const configSchema = schema.object({
+    enabled: schema.boolean({ defaultValue: true }),
+    slack: schema.maybe(schema.object({
+      client_id: schema.string(),
+      router_secret: schema.string(),   // shared secret with the router
+    }))
+  })
+
+  3.2 Update server/plugin.ts — pass config to routes
+
+  setup(coreSetup, setupDeps) {
+    const config = this.context.config.get()
+    registerRoutes({ router, coreSetup, logger, cloud: setupDeps.cloud, config })
+  }
+
+  ---
+  Phase 4 — Local Testing (no router needed)
+
+  Use ngrok to test end-to-end without building the router:
+
+  # 1. Start Kibana locally
+  yarn start
+
+  # 2. Expose it via ngrok
+  ngrok http 5601
+
+  # 3. Create a dev Slack app at api.slack.com
+  #    Event subscription URL: https://xxxx.ngrok.io/api/elastic_console/slack/events
+  #    Bot scopes: app_mentions:read, chat:write, channels:history
+
+  # 4. Set in kibana.dev.yml:
+  #    xpack.elasticConsole.slack.router_secret: "dev-secret"
+
+  # 5. In Slack — forward events directly (no JWT needed for dev)
+  #    Just hardcode a test bot_token in slack_events.ts temporarily
+
+  ---
+  File Summary
+
+  ┌────────────────────────────────────────┬────────┬────────────────────────────────────────┐
+  │                  File                  │ Status │                  What                  │
+  ├────────────────────────────────────────┼────────┼────────────────────────────────────────┤
+  │ server/lib/conversation_storage.ts     │ Modify │ Map state fields                       │
+  ├────────────────────────────────────────┼────────┼────────────────────────────────────────┤
+  │ server/routes/conversation_sessions.ts │ New    │ fork / locate / handoff                │
+  ├────────────────────────────────────────┼────────┼────────────────────────────────────────┤
+  │ server/lib/slack_client.ts             │ New    │ Post/update Slack messages             │
+  ├────────────────────────────────────────┼────────┼────────────────────────────────────────┤
+  │ server/lib/slack_handler.ts            │ New    │ Core event processing                  │
+  ├────────────────────────────────────────┼────────┼────────────────────────────────────────┤
+  │ server/routes/slack_events.ts          │ New    │ POST /api/elastic_console/slack/events │
+  ├────────────────────────────────────────┼────────┼────────────────────────────────────────┤
+  │ server/routes/slack_connect.ts         │ New    │ GET OAuth initiation                   │
+  ├────────────────────────────────────────┼────────┼────────────────────────────────────────┤
+  │ server/routes/index.ts                 │ Modify │ Register new routes                    │
+  ├────────────────────────────────────────┼────────┼────────────────────────────────────────┤
+  │ server/types.ts                        │ Modify │ Add encryptedSavedObjects              │
+  ├────────────────────────────────────────┼────────┼────────────────────────────────────────┤
+  │ server/config.ts                       │ Modify │ Add slack config block                 │
+  ├────────────────────────────────────────┼────────┼────────────────────────────────────────┤
+  │ server/plugin.ts                       │ Modify │ Pass config to routes                  │
+  ├────────────────────────────────────────┼────────┼────────────────────────────────────────┤
+  │ kibana.jsonc                           │ Modify │ Add encryptedSavedObjects dep          │
+  └────────────────────────────────────────┴────────┴────────────────────────────────────────┘
+
+  ---
+  Build Order
+
+  1. conversation_storage.ts (schema)     ← no dependencies
+  2. conversation_sessions.ts (routes)    ← depends on 1
+  3. slack_client.ts                      ← no dependencies
+  4. slack_handler.ts                     ← depends on 2 + 3
+  5. slack_events.ts                      ← depends on 4
+  6. slack_connect.ts                     ← standalone
+  7. Wire everything in index.ts + plugin.ts
+  8. Test with ngrok
+
+  Start with step 1 — the schema change unblocks everything else.
+
+  ---
+  Known Tech Debt / Before Production
+
+  ⚠️  Slack events auth — dev hack must be replaced before shipping
+
+  Current (dev):
+    slack_token.ts auto-generates a superuser API key (elastic:changeme) and stores it
+    in ESO alongside bot_token. slack_events.ts injects it into the request headers for
+    inference calls. This works but the key has full cluster access.
+
+  Correct (production):
+    1. slack_connect.ts already generates a scoped API key (privileges: api:elastic_console/slack/events)
+       and embeds it in the JWT state sent to the router.
+    2. The router stores the key and sends it as Authorization: ApiKey on every forwarded event.
+    3. Change slack_events.ts route from authRequired: false → authRequired: 'optional'
+       so the router's API key gets validated by Kibana's auth middleware.
+    4. Remove the kibana_api_key stored in ESO — the request will already be authenticated.
+    5. Remove the inferenceRequest fake request construction in slack_events.ts.
+    6. Use request directly in handleSlackEvent — it's authenticated by the router's API key.
+
+  Files to change:
+    server/routes/slack_events.ts   — authRequired: 'optional', remove inferenceRequest hack
+    server/routes/slack_token.ts    — remove API key generation
+    server/plugin.ts                — remove kibana_api_key from SO mapping + ESO encrypted attrs
+    server/lib/slack_credentials_so.ts — reset SO ID back to a stable value
+
+
+
+
+  

--- a/x-pack/platform/plugins/shared/elastic_console/README.md
+++ b/x-pack/platform/plugins/shared/elastic_console/README.md
@@ -235,6 +235,52 @@ console.log(response.choices[0].message.content);
 
 Set the base URL to `https://my-kibana:5601/internal/elastic_console/v1` and use the API key from the setup endpoint. Include `x-elastic-internal-origin: kibana` in all requests, and include `kbn-xsrf: true` for non-GET requests.
 
+## Slack Integration
+
+Elastic Console can connect to a Slack workspace so users can interact with their AI agents directly from Slack. Mentioning the bot (`@elastic-console hello`) creates or continues a conversation thread backed by Kibana's inference API.
+
+Events flow through an Elastic-hosted relay service that verifies Slack's request signatures before forwarding them to Kibana.
+
+### Configuration
+
+Add to `kibana.yml`:
+
+```yaml
+xpack.elastic_console.slack:
+  client_id: "<slack-app-client-id>"
+  # redirect_uri: "https://..."  # optional, defaults to the Elastic-hosted relay
+```
+
+Contact the Elastic Console team for the `client_id` value.
+
+### Connecting a workspace
+
+1. Open the Elastic Console setup page (`/app/elasticConsole`) and click **Connect Slack**.
+2. Authorize the app in the Slack OAuth screen that opens.
+3. Once redirected back, the setup page shows **Connected**.
+
+To reconnect (e.g. after a revoked token), repeat the same steps — old credentials are replaced automatically.
+
+To disconnect, click **Disconnect** on the setup page.
+
+### Linking your Slack account
+
+Each user must link their Kibana account to their Slack identity once. On the setup page, enter your Slack Member ID and click **Link Account**. After linking, the bot will respond in Slack on your behalf.
+
+### Endpoints
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| `GET` | `/internal/elastic_console/slack/connect` | Kibana session | Starts the OAuth flow; returns the Slack authorization URL |
+| `GET` | `/internal/elastic_console/slack/status` | Kibana session | Returns `connected`, `disconnected`, or `not_connected` |
+| `DELETE` | `/internal/elastic_console/slack/disconnect` | Kibana session | Revokes credentials and disconnects the workspace |
+| `POST` | `/internal/elastic_console/slack/link_user` | Kibana session | Links the current Kibana user to a Slack Member ID |
+| `GET` | `/internal/elastic_console/slack/link_user` | Kibana session | Returns the Slack user ID linked to the current user |
+| `POST` | `/api/elastic_console/slack/token` | API key | Called by the relay after OAuth; stores the bot token |
+| `POST` | `/api/elastic_console/slack/events` | API key | Receives forwarded Slack events from the relay |
+
+The `/api/*` endpoints are called by the Elastic relay service, not the browser. All `/internal/*` endpoints require the `x-elastic-internal-origin: kibana` header.
+
 ## Development
 
 The plugin lives at `x-pack/platform/plugins/shared/elastic_console/`.

--- a/x-pack/platform/plugins/shared/elastic_console/jest.config.js
+++ b/x-pack/platform/plugins/shared/elastic_console/jest.config.js
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+module.exports = {
+  preset: '@kbn/test',
+  rootDir: '../../../../..',
+  roots: ['<rootDir>/x-pack/platform/plugins/shared/elastic_console'],
+  coverageDirectory:
+    '<rootDir>/target/kibana-coverage/jest/x-pack/platform/plugins/shared/elastic_console',
+  coverageReporters: ['text', 'html'],
+  collectCoverageFrom: [
+    '<rootDir>/x-pack/platform/plugins/shared/elastic_console/{common,server,public}/**/*.{js,ts,tsx}',
+  ],
+};

--- a/x-pack/platform/plugins/shared/elastic_console/kibana.jsonc
+++ b/x-pack/platform/plugins/shared/elastic_console/kibana.jsonc
@@ -9,7 +9,7 @@
     "server": true,
     "browser": true,
     "configPath": ["xpack", "elasticConsole"],
-    "requiredPlugins": ["inference", "actions"],
+    "requiredPlugins": ["inference", "actions", "encryptedSavedObjects"],
     "requiredBundles": ["kibanaReact"],
     "optionalPlugins": ["cloud"]
   }

--- a/x-pack/platform/plugins/shared/elastic_console/kibana.jsonc
+++ b/x-pack/platform/plugins/shared/elastic_console/kibana.jsonc
@@ -8,7 +8,7 @@
     "id": "elasticConsole",
     "server": true,
     "browser": true,
-    "configPath": ["xpack", "elasticConsole"],
+    "configPath": ["xpack", "elastic_console"],
     "requiredPlugins": ["inference", "actions", "encryptedSavedObjects"],
     "requiredBundles": ["kibanaReact"],
     "optionalPlugins": ["cloud"]

--- a/x-pack/platform/plugins/shared/elastic_console/public/application/index.tsx
+++ b/x-pack/platform/plugins/shared/elastic_console/public/application/index.tsx
@@ -10,6 +10,9 @@ import ReactDOM from 'react-dom';
 import type { AppMountParameters, CoreStart } from '@kbn/core/public';
 import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
 import { SetupPage } from './setup_page';
+import { SlackOnboardingPage } from './slack_onboarding_page';
+
+export { SetupPage, SlackOnboardingPage };
 
 export const renderApp = ({
   coreStart,

--- a/x-pack/platform/plugins/shared/elastic_console/public/application/index.tsx
+++ b/x-pack/platform/plugins/shared/elastic_console/public/application/index.tsx
@@ -5,14 +5,48 @@
  * 2.0.
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import ReactDOM from 'react-dom';
 import type { AppMountParameters, CoreStart } from '@kbn/core/public';
 import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
+import { EuiTabbedContent, EuiPageTemplate } from '@elastic/eui';
 import { SetupPage } from './setup_page';
 import { SlackOnboardingPage } from './slack_onboarding_page';
 
 export { SetupPage, SlackOnboardingPage };
+
+interface AppProps {
+  coreStart: CoreStart;
+}
+
+const App: React.FC<AppProps> = ({ coreStart }) => {
+  const [selectedTab, setSelectedTab] = useState<'ramen' | 'slack'>('ramen');
+
+  const tabs = [
+    {
+      id: 'ramen',
+      name: '🍜 Elastic Ramen',
+      content: <SetupPage />,
+    },
+    {
+      id: 'slack',
+      name: 'Slack Integration',
+      content: <SlackOnboardingPage />,
+    },
+  ];
+
+  return (
+    <EuiPageTemplate>
+      <EuiPageTemplate.Section>
+        <EuiTabbedContent
+          tabs={tabs}
+          selectedTab={selectedTab}
+          onTabClick={(tab) => setSelectedTab(tab.id as 'ramen' | 'slack')}
+        />
+      </EuiPageTemplate.Section>
+    </EuiPageTemplate>
+  );
+};
 
 export const renderApp = ({
   coreStart,
@@ -26,7 +60,7 @@ export const renderApp = ({
   ReactDOM.render(
     coreStart.rendering.addContext(
       <KibanaContextProvider services={coreStart}>
-        <SetupPage />
+        <App coreStart={coreStart} />
       </KibanaContextProvider>
     ),
     element

--- a/x-pack/platform/plugins/shared/elastic_console/public/application/setup_page.tsx
+++ b/x-pack/platform/plugins/shared/elastic_console/public/application/setup_page.tsx
@@ -153,6 +153,10 @@ export const SetupPage: React.FC = () => {
     <EuiBadge color="danger">Slack: Disconnected</EuiBadge>
   ) : null;
 
+  const handleConnectSlack = useCallback(() => {
+    window.location.href = '/internal/elastic_console/slack/connect';
+  }, []);
+
   return (
     <EuiPageTemplate>
       <EuiPageTemplate.Header
@@ -188,9 +192,22 @@ export const SetupPage: React.FC = () => {
 
         <EuiSpacer />
 
-        <EuiButton fill onClick={handleSetup} isLoading={isLoading}>
-          Generate credentials
-        </EuiButton>
+        <EuiFlexGroup gutterSize="s">
+          <EuiFlexItem grow={false}>
+            <EuiButton fill onClick={handleSetup} isLoading={isLoading}>
+              Generate credentials
+            </EuiButton>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiButton
+              iconType="logoSlack"
+              onClick={handleConnectSlack}
+              color={slackStatus?.status === 'connected' ? 'success' : 'primary'}
+            >
+              {slackStatus?.status === 'connected' ? 'Reconnect Slack' : 'Connect Slack'}
+            </EuiButton>
+          </EuiFlexItem>
+        </EuiFlexGroup>
 
         <EuiSpacer />
 

--- a/x-pack/platform/plugins/shared/elastic_console/public/application/setup_page.tsx
+++ b/x-pack/platform/plugins/shared/elastic_console/public/application/setup_page.tsx
@@ -177,7 +177,6 @@ export const SetupPage: React.FC = () => {
         rightSideItems={slackStatusBadge ? [slackStatusBadge] : []}
       />
       <EuiPageTemplate.Section>
-
         {/* ── CLI / MCP Setup ── */}
         <EuiTitle size="s">
           <h2>CLI / MCP Setup</h2>

--- a/x-pack/platform/plugins/shared/elastic_console/public/application/setup_page.tsx
+++ b/x-pack/platform/plugins/shared/elastic_console/public/application/setup_page.tsx
@@ -153,9 +153,12 @@ export const SetupPage: React.FC = () => {
     <EuiBadge color="danger">Slack: Disconnected</EuiBadge>
   ) : null;
 
-  const handleConnectSlack = useCallback(() => {
-    window.location.href = '/internal/elastic_console/slack/connect';
-  }, []);
+  const handleConnectSlack = useCallback(async () => {
+    const { url } = await services.http.get<{ url: string }>(
+      '/internal/elastic_console/slack/connect'
+    );
+    window.location.href = url;
+  }, [services.http]);
 
   return (
     <EuiPageTemplate>

--- a/x-pack/platform/plugins/shared/elastic_console/public/application/setup_page.tsx
+++ b/x-pack/platform/plugins/shared/elastic_console/public/application/setup_page.tsx
@@ -161,6 +161,15 @@ export const SetupPage: React.FC = () => {
     window.location.href = url;
   }, [services.http]);
 
+  const handleDisconnectSlack = useCallback(async () => {
+    try {
+      await services.http.delete('/internal/elastic_console/slack/disconnect');
+      setSlackStatus({ status: 'not_connected' });
+    } catch (err) {
+      // Best-effort — status will reflect reality on next load
+    }
+  }, [services.http]);
+
   return (
     <EuiPageTemplate>
       <EuiPageTemplate.Header
@@ -291,9 +300,23 @@ export const SetupPage: React.FC = () => {
               )}
             </EuiCallOut>
             <EuiSpacer size="s" />
-            <EuiButtonEmpty iconType="logoSlack" size="s" onClick={handleConnectSlack}>
-              Reconnect
-            </EuiButtonEmpty>
+            <EuiFlexGroup gutterSize="s" responsive={false}>
+              <EuiFlexItem grow={false}>
+                <EuiButtonEmpty iconType="logoSlack" size="s" onClick={handleConnectSlack}>
+                  Reconnect
+                </EuiButtonEmpty>
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiButtonEmpty
+                  iconType="unlink"
+                  size="s"
+                  color="danger"
+                  onClick={handleDisconnectSlack}
+                >
+                  Disconnect
+                </EuiButtonEmpty>
+              </EuiFlexItem>
+            </EuiFlexGroup>
           </>
         ) : slackStatus?.status === 'disconnected' ? (
           <>

--- a/x-pack/platform/plugins/shared/elastic_console/public/application/setup_page.tsx
+++ b/x-pack/platform/plugins/shared/elastic_console/public/application/setup_page.tsx
@@ -186,34 +186,22 @@ export const SetupPage: React.FC = () => {
           </>
         )}
 
-        <EuiText>
+        {/* ── CLI / MCP Setup ── */}
+        <EuiTitle size="s">
+          <h2>CLI / MCP Setup</h2>
+        </EuiTitle>
+        <EuiSpacer size="s" />
+        <EuiText size="s">
           <p>
-            <strong>CLI / MCP Setup</strong> — generate credentials for the local{' '}
-            <code>elastic-console</code> agent or any MCP-compatible tool.
-            <br />
-            <strong>Connect Slack</strong> — authorise the Slack bot so your team can interact with
-            the AI assistant directly from Slack.
+            Generate credentials for the local <code>elastic-console</code> agent or any
+            MCP-compatible tool.
           </p>
         </EuiText>
-
         <EuiSpacer />
 
-        <EuiFlexGroup gutterSize="s">
-          <EuiFlexItem grow={false}>
-            <EuiButton fill onClick={handleSetup} isLoading={isLoading}>
-              CLI / MCP Setup
-            </EuiButton>
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiButton
-              iconType="logoSlack"
-              onClick={handleConnectSlack}
-              color={slackStatus?.status === 'connected' ? 'success' : 'primary'}
-            >
-              {slackStatus?.status === 'connected' ? 'Reconnect Slack' : 'Connect Slack'}
-            </EuiButton>
-          </EuiFlexItem>
-        </EuiFlexGroup>
+        <EuiButton fill onClick={handleSetup} isLoading={isLoading}>
+          CLI / MCP Setup
+        </EuiButton>
 
         <EuiSpacer />
 
@@ -257,8 +245,70 @@ export const SetupPage: React.FC = () => {
           </>
         )}
 
+        {setupData && (
+          <EuiFlexGroup direction="column" gutterSize="m">
+            <EuiFlexItem>
+              <EuiFormRow label="Kibana URL" fullWidth>
+                <EuiFieldText value={setupData.kibanaUrl} readOnly fullWidth />
+              </EuiFormRow>
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <EuiFormRow label="Elasticsearch URL" fullWidth>
+                <EuiFieldText value={setupData.elasticsearchUrl} readOnly fullWidth />
+              </EuiFormRow>
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <EuiFormRow label="API Key (Base64)" fullWidth>
+                <EuiCodeBlock language="text" paddingSize="s" isCopyable>
+                  {setupData.apiKeyEncoded}
+                </EuiCodeBlock>
+              </EuiFormRow>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiCopy
+                textToCopy={JSON.stringify(
+                  {
+                    kibanaUrl: setupData.kibanaUrl,
+                    elasticsearchUrl: setupData.elasticsearchUrl,
+                    apiKey: setupData.apiKeyEncoded,
+                  },
+                  null,
+                  2
+                )}
+              >
+                {(copy) => (
+                  <EuiButton onClick={copy} iconType="copy">
+                    Copy all as JSON
+                  </EuiButton>
+                )}
+              </EuiCopy>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        )}
+
         <EuiHorizontalRule />
 
+        {/* ── Connect Slack ── */}
+        <EuiTitle size="s">
+          <h2>Connect Slack</h2>
+        </EuiTitle>
+        <EuiSpacer size="s" />
+        <EuiText size="s">
+          <p>Authorise the Slack bot so your team can interact with the AI assistant from Slack.</p>
+        </EuiText>
+        <EuiSpacer />
+
+        <EuiButton
+          iconType="logoSlack"
+          onClick={handleConnectSlack}
+          color={slackStatus?.status === 'connected' ? 'success' : 'primary'}
+        >
+          {slackStatus?.status === 'connected' ? 'Reconnect Slack' : 'Connect Slack'}
+        </EuiButton>
+
+        <EuiHorizontalRule />
+
+        {/* ── Link Slack Account ── */}
         <EuiTitle size="s">
           <h2>Link Slack Account</h2>
         </EuiTitle>
@@ -314,54 +364,6 @@ export const SetupPage: React.FC = () => {
             </EuiFormRow>
           </EuiFlexItem>
         </EuiFlexGroup>
-
-        <EuiHorizontalRule />
-
-        <EuiTitle size="s">
-          <h2>CLI / MCP Setup</h2>
-        </EuiTitle>
-        <EuiSpacer size="s" />
-
-        {setupData && (
-          <EuiFlexGroup direction="column" gutterSize="m">
-            <EuiFlexItem>
-              <EuiFormRow label="Kibana URL" fullWidth>
-                <EuiFieldText value={setupData.kibanaUrl} readOnly fullWidth />
-              </EuiFormRow>
-            </EuiFlexItem>
-            <EuiFlexItem>
-              <EuiFormRow label="Elasticsearch URL" fullWidth>
-                <EuiFieldText value={setupData.elasticsearchUrl} readOnly fullWidth />
-              </EuiFormRow>
-            </EuiFlexItem>
-            <EuiFlexItem>
-              <EuiFormRow label="API Key (Base64)" fullWidth>
-                <EuiCodeBlock language="text" paddingSize="s" isCopyable>
-                  {setupData.apiKeyEncoded}
-                </EuiCodeBlock>
-              </EuiFormRow>
-            </EuiFlexItem>
-            <EuiFlexItem grow={false}>
-              <EuiCopy
-                textToCopy={JSON.stringify(
-                  {
-                    kibanaUrl: setupData.kibanaUrl,
-                    elasticsearchUrl: setupData.elasticsearchUrl,
-                    apiKey: setupData.apiKeyEncoded,
-                  },
-                  null,
-                  2
-                )}
-              >
-                {(copy) => (
-                  <EuiButton onClick={copy} iconType="copy">
-                    Copy all as JSON
-                  </EuiButton>
-                )}
-              </EuiCopy>
-            </EuiFlexItem>
-          </EuiFlexGroup>
-        )}
       </EuiPageTemplate.Section>
     </EuiPageTemplate>
   );

--- a/x-pack/platform/plugins/shared/elastic_console/public/application/setup_page.tsx
+++ b/x-pack/platform/plugins/shared/elastic_console/public/application/setup_page.tsx
@@ -9,6 +9,7 @@ import React, { useCallback, useEffect, useState } from 'react';
 import {
   EuiBadge,
   EuiButton,
+  EuiButtonEmpty,
   EuiCallOut,
   EuiCodeBlock,
   EuiFieldText,
@@ -167,24 +168,6 @@ export const SetupPage: React.FC = () => {
         rightSideItems={slackStatusBadge ? [slackStatusBadge] : []}
       />
       <EuiPageTemplate.Section>
-        {slackStatus?.status === 'disconnected' && (
-          <>
-            <EuiCallOut
-              title="Slack connection lost — API key revoked or expired"
-              color="danger"
-              iconType="warning"
-            >
-              <p>
-                Slack events can no longer be forwarded to Kibana. To restore the connection,
-                click <strong>Connect Slack</strong> again to generate a new API key.
-                {slackStatus.connected_at && (
-                  <> Last connected: {new Date(slackStatus.connected_at).toLocaleString()}.</>
-                )}
-              </p>
-            </EuiCallOut>
-            <EuiSpacer />
-          </>
-        )}
 
         {/* ── CLI / MCP Setup ── */}
         <EuiTitle size="s">
@@ -298,13 +281,45 @@ export const SetupPage: React.FC = () => {
         </EuiText>
         <EuiSpacer />
 
-        <EuiButton
-          iconType="logoSlack"
-          onClick={handleConnectSlack}
-          color={slackStatus?.status === 'connected' ? 'success' : 'primary'}
-        >
-          {slackStatus?.status === 'connected' ? 'Reconnect Slack' : 'Connect Slack'}
-        </EuiButton>
+        {slackStatusLoading ? (
+          <EuiLoadingSpinner size="m" />
+        ) : slackStatus?.status === 'connected' ? (
+          <>
+            <EuiCallOut title="Slack is connected" color="success" iconType="check">
+              {slackStatus.connected_at && (
+                <p>Connected since {new Date(slackStatus.connected_at).toLocaleString()}.</p>
+              )}
+            </EuiCallOut>
+            <EuiSpacer size="s" />
+            <EuiButtonEmpty iconType="logoSlack" size="s" onClick={handleConnectSlack}>
+              Reconnect
+            </EuiButtonEmpty>
+          </>
+        ) : slackStatus?.status === 'disconnected' ? (
+          <>
+            <EuiCallOut
+              title="Slack connection lost — API key revoked or expired"
+              color="danger"
+              iconType="warning"
+            >
+              <p>
+                Slack events can no longer be forwarded to Kibana. Reconnect to generate a new API
+                key.
+                {slackStatus.connected_at && (
+                  <> Last connected: {new Date(slackStatus.connected_at).toLocaleString()}.</>
+                )}
+              </p>
+            </EuiCallOut>
+            <EuiSpacer />
+            <EuiButton iconType="logoSlack" color="danger" onClick={handleConnectSlack}>
+              Reconnect Slack
+            </EuiButton>
+          </>
+        ) : (
+          <EuiButton iconType="logoSlack" fill onClick={handleConnectSlack}>
+            Connect Slack
+          </EuiButton>
+        )}
 
         <EuiHorizontalRule />
 

--- a/x-pack/platform/plugins/shared/elastic_console/public/application/setup_page.tsx
+++ b/x-pack/platform/plugins/shared/elastic_console/public/application/setup_page.tsx
@@ -5,8 +5,9 @@
  * 2.0.
  */
 
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import {
+  EuiBadge,
   EuiButton,
   EuiCallOut,
   EuiCodeBlock,
@@ -14,9 +15,12 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiFormRow,
+  EuiHorizontalRule,
+  EuiLoadingSpinner,
   EuiPageTemplate,
   EuiSpacer,
   EuiText,
+  EuiTitle,
   EuiCopy,
 } from '@elastic/eui';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
@@ -30,6 +34,13 @@ interface SetupResponse {
   apiKeyEncoded: string;
 }
 
+type SlackConnectionStatus = 'connected' | 'disconnected' | 'not_connected';
+
+interface SlackStatusResponse {
+  status: SlackConnectionStatus;
+  connected_at?: string;
+}
+
 export const SetupPage: React.FC = () => {
   const { services } = useKibana<CoreStart>();
   const [setupData, setSetupData] = useState<SetupResponse | null>(null);
@@ -38,6 +49,24 @@ export const SetupPage: React.FC = () => {
   const [autoDeliveryStatus, setAutoDeliveryStatus] = useState<'idle' | 'success' | 'failed'>(
     'idle'
   );
+  const [slackStatus, setSlackStatus] = useState<SlackStatusResponse | null>(null);
+  const [slackStatusLoading, setSlackStatusLoading] = useState(true);
+
+  // Slack user linking state
+  const [slackUserId, setSlackUserId] = useState<string>(() => {
+    const params = new URLSearchParams(window.location.search);
+    return params.get('link_slack') ?? '';
+  });
+  const [linkStatus, setLinkStatus] = useState<'idle' | 'success' | 'error'>('idle');
+  const [linkError, setLinkError] = useState<string | null>(null);
+
+  useEffect(() => {
+    services.http
+      .get<SlackStatusResponse>('/internal/elastic_console/slack/status')
+      .then(setSlackStatus)
+      .catch(() => setSlackStatus(null))
+      .finally(() => setSlackStatusLoading(false));
+  }, [services.http]);
 
   const handleSetup = useCallback(async () => {
     setIsLoading(true);
@@ -101,10 +130,55 @@ export const SetupPage: React.FC = () => {
     }
   }, [services.http]);
 
+  const handleLinkSlack = useCallback(async () => {
+    if (!slackUserId.trim()) return;
+    setLinkStatus('idle');
+    setLinkError(null);
+    try {
+      await services.http.post('/internal/elastic_console/slack/link_user', {
+        body: JSON.stringify({ slack_user_id: slackUserId.trim() }),
+      });
+      setLinkStatus('success');
+    } catch (err) {
+      setLinkError(err instanceof Error ? err.message : 'Failed to link account');
+      setLinkStatus('error');
+    }
+  }, [services.http, slackUserId]);
+
+  const slackStatusBadge = slackStatusLoading ? (
+    <EuiLoadingSpinner size="s" />
+  ) : slackStatus?.status === 'connected' ? (
+    <EuiBadge color="success">Slack: Connected</EuiBadge>
+  ) : slackStatus?.status === 'disconnected' ? (
+    <EuiBadge color="danger">Slack: Disconnected</EuiBadge>
+  ) : null;
+
   return (
     <EuiPageTemplate>
-      <EuiPageTemplate.Header pageTitle="Elastic Console Setup" />
+      <EuiPageTemplate.Header
+        pageTitle="Elastic Console Setup"
+        rightSideItems={slackStatusBadge ? [slackStatusBadge] : []}
+      />
       <EuiPageTemplate.Section>
+        {slackStatus?.status === 'disconnected' && (
+          <>
+            <EuiCallOut
+              title="Slack connection lost — API key revoked or expired"
+              color="danger"
+              iconType="warning"
+            >
+              <p>
+                Slack events can no longer be forwarded to Kibana. To restore the connection,
+                click <strong>Connect Slack</strong> again to generate a new API key.
+                {slackStatus.connected_at && (
+                  <> Last connected: {new Date(slackStatus.connected_at).toLocaleString()}.</>
+                )}
+              </p>
+            </EuiCallOut>
+            <EuiSpacer />
+          </>
+        )}
+
         <EuiText>
           <p>
             Generate connection credentials for external tools to use Kibana-configured AI
@@ -159,6 +233,71 @@ export const SetupPage: React.FC = () => {
             <EuiSpacer />
           </>
         )}
+
+        <EuiHorizontalRule />
+
+        <EuiTitle size="s">
+          <h2>Link Slack Account</h2>
+        </EuiTitle>
+        <EuiSpacer size="s" />
+        <EuiText size="s">
+          <p>
+            Link your Slack user ID to this Kibana account so conversations started in Slack appear
+            in Agent Builder. Your Slack user ID is shown in the bot&apos;s first message when you
+            chat with it.
+          </p>
+        </EuiText>
+        <EuiSpacer />
+
+        {linkStatus === 'success' && (
+          <>
+            <EuiCallOut title="Slack account linked" color="success" iconType="check">
+              <p>
+                Slack user <strong>{slackUserId}</strong> is now linked to your Kibana account.
+                Future conversations from Slack will appear in Agent Builder.
+              </p>
+            </EuiCallOut>
+            <EuiSpacer />
+          </>
+        )}
+        {linkStatus === 'error' && (
+          <>
+            <EuiCallOut title="Link failed" color="danger" iconType="error">
+              <p>{linkError}</p>
+            </EuiCallOut>
+            <EuiSpacer />
+          </>
+        )}
+
+        <EuiFlexGroup alignItems="flexEnd" gutterSize="m">
+          <EuiFlexItem>
+            <EuiFormRow label="Slack User ID" fullWidth>
+              <EuiFieldText
+                placeholder="e.g. U0123456789"
+                value={slackUserId}
+                onChange={(e) => setSlackUserId(e.target.value)}
+                fullWidth
+              />
+            </EuiFormRow>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiFormRow hasEmptyLabelSpace>
+              <EuiButton
+                onClick={handleLinkSlack}
+                isDisabled={!slackUserId.trim() || linkStatus === 'success'}
+              >
+                Link account
+              </EuiButton>
+            </EuiFormRow>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+
+        <EuiHorizontalRule />
+
+        <EuiTitle size="s">
+          <h2>Generate Credentials</h2>
+        </EuiTitle>
+        <EuiSpacer size="s" />
 
         {setupData && (
           <EuiFlexGroup direction="column" gutterSize="m">

--- a/x-pack/platform/plugins/shared/elastic_console/public/application/setup_page.tsx
+++ b/x-pack/platform/plugins/shared/elastic_console/public/application/setup_page.tsx
@@ -188,8 +188,11 @@ export const SetupPage: React.FC = () => {
 
         <EuiText>
           <p>
-            Generate connection credentials for external tools to use Kibana-configured AI
-            connectors via an OpenAI-compatible API.
+            <strong>CLI / MCP Setup</strong> — generate credentials for the local{' '}
+            <code>elastic-console</code> agent or any MCP-compatible tool.
+            <br />
+            <strong>Connect Slack</strong> — authorise the Slack bot so your team can interact with
+            the AI assistant directly from Slack.
           </p>
         </EuiText>
 
@@ -198,7 +201,7 @@ export const SetupPage: React.FC = () => {
         <EuiFlexGroup gutterSize="s">
           <EuiFlexItem grow={false}>
             <EuiButton fill onClick={handleSetup} isLoading={isLoading}>
-              Generate credentials
+              CLI / MCP Setup
             </EuiButton>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
@@ -315,7 +318,7 @@ export const SetupPage: React.FC = () => {
         <EuiHorizontalRule />
 
         <EuiTitle size="s">
-          <h2>Generate Credentials</h2>
+          <h2>CLI / MCP Setup</h2>
         </EuiTitle>
         <EuiSpacer size="s" />
 

--- a/x-pack/platform/plugins/shared/elastic_console/public/application/setup_page.tsx
+++ b/x-pack/platform/plugins/shared/elastic_console/public/application/setup_page.tsx
@@ -15,7 +15,6 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiFormRow,
-  EuiPageTemplate,
   EuiSpacer,
   EuiText,
   EuiCopy,
@@ -57,28 +56,23 @@ export const SetupPage: React.FC = () => {
 
 
    return (
-     <EuiPageTemplate>
-       <EuiPageTemplate.Header
-         pageTitle={<>{'🍜 Elastic Ramen Setup'}</>}
-         rightSideItems={[<EuiBetaBadge label="Experimental" color="hollow" />]}
-       />
-       <EuiPageTemplate.Section>
-         <EuiCallOut
-           title="Experimental feature — proceed with caution"
-           color="warning"
-           iconType="beaker"
-         >
-           <p>
-             Elastic Ramen is an <strong>experimental</strong> feature under active development. It
-             may change, break, or be removed without notice. Use at your own risk — it can expose AI
-             connectors to external tools and may produce unexpected behavior. Do not rely on it for
-             production workloads.
-           </p>
-         </EuiCallOut>
+     <>
+       <EuiCallOut
+         title="Experimental feature — proceed with caution"
+         color="warning"
+         iconType="beaker"
+       >
+         <p>
+           Elastic Ramen is an <strong>experimental</strong> feature under active development. It
+           may change, break, or be removed without notice. Use at your own risk — it can expose AI
+           connectors to external tools and may produce unexpected behavior. Do not rely on it for
+           production workloads.
+         </p>
+       </EuiCallOut>
 
-         <EuiSpacer />
+       <EuiSpacer />
 
-         <EuiText>
+       <EuiText>
           <p>
             Generate credentials for the local <code>elastic-console</code> agent or any
             MCP-compatible tool.
@@ -199,9 +193,8 @@ export const SetupPage: React.FC = () => {
                 </EuiCopy>
               </EuiFlexItem>
             </EuiFlexGroup>
-          </>
+           </>
          )}
-      </EuiPageTemplate.Section>
-    </EuiPageTemplate>
-  );
+     </>
+   );
 };

--- a/x-pack/platform/plugins/shared/elastic_console/public/application/slack_onboarding_page.tsx
+++ b/x-pack/platform/plugins/shared/elastic_console/public/application/slack_onboarding_page.tsx
@@ -1,0 +1,228 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  EuiBadge,
+  EuiButton,
+  EuiButtonEmpty,
+  EuiCallOut,
+  EuiFieldText,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFormRow,
+  EuiHorizontalRule,
+  EuiLoadingSpinner,
+  EuiPageTemplate,
+  EuiSpacer,
+  EuiText,
+  EuiTitle,
+} from '@elastic/eui';
+import { useKibana } from '@kbn/kibana-react-plugin/public';
+import type { CoreStart } from '@kbn/core/public';
+
+type SlackConnectionStatus = 'connected' | 'disconnected' | 'not_connected';
+
+interface SlackStatusResponse {
+  status: SlackConnectionStatus;
+  connected_at?: string;
+}
+
+export const SlackOnboardingPage: React.FC = () => {
+  const { services } = useKibana<CoreStart>();
+  const [slackStatus, setSlackStatus] = useState<SlackStatusResponse | null>(null);
+  const [slackStatusLoading, setSlackStatusLoading] = useState(true);
+
+  // Slack user linking state
+  const [slackUserId, setSlackUserId] = useState<string>(() => {
+    const params = new URLSearchParams(window.location.search);
+    return params.get('link_slack') ?? '';
+  });
+  const [linkStatus, setLinkStatus] = useState<'idle' | 'success' | 'error'>('idle');
+  const [linkError, setLinkError] = useState<string | null>(null);
+
+  useEffect(() => {
+    services.http
+      .get<SlackStatusResponse>('/internal/elastic_console/slack/status')
+      .then(setSlackStatus)
+      .catch(() => setSlackStatus(null))
+      .finally(() => setSlackStatusLoading(false));
+  }, [services.http]);
+
+  const handleLinkSlack = useCallback(async () => {
+    if (!slackUserId.trim()) return;
+    setLinkStatus('idle');
+    setLinkError(null);
+    try {
+      await services.http.post('/internal/elastic_console/slack/link_user', {
+        body: JSON.stringify({ slack_user_id: slackUserId.trim() }),
+      });
+      setLinkStatus('success');
+    } catch (err) {
+      setLinkError(err instanceof Error ? err.message : 'Failed to link account');
+      setLinkStatus('error');
+    }
+  }, [services.http, slackUserId]);
+
+  const slackStatusBadge = slackStatusLoading ? (
+    <EuiLoadingSpinner size="s" />
+  ) : slackStatus?.status === 'connected' ? (
+    <EuiBadge color="success">Slack: Connected</EuiBadge>
+  ) : slackStatus?.status === 'disconnected' ? (
+    <EuiBadge color="danger">Slack: Disconnected</EuiBadge>
+  ) : null;
+
+  const handleConnectSlack = useCallback(async () => {
+    const { url } = await services.http.get<{ url: string }>(
+      '/internal/elastic_console/slack/connect'
+    );
+    window.location.href = url;
+  }, [services.http]);
+
+  const handleDisconnectSlack = useCallback(async () => {
+    try {
+      await services.http.delete('/internal/elastic_console/slack/disconnect');
+      setSlackStatus({ status: 'not_connected' });
+    } catch (err) {
+      // Best-effort — status will reflect reality on next load
+    }
+  }, [services.http]);
+
+   return (
+     <EuiPageTemplate>
+       <EuiPageTemplate.Header
+         pageTitle="Slack Integration"
+         rightSideItems={slackStatusBadge ? [slackStatusBadge] : []}
+       />
+       <EuiPageTemplate.Section>
+
+        {/* ── Connect Slack ── */}
+        <EuiTitle size="s">
+          <h2>Connect Slack</h2>
+        </EuiTitle>
+        <EuiSpacer size="s" />
+        <EuiText size="s">
+          <p>Authorise the Slack bot so your team can interact with the AI assistant from Slack.</p>
+        </EuiText>
+        <EuiSpacer />
+
+        {slackStatusLoading ? (
+          <EuiLoadingSpinner size="m" />
+        ) : slackStatus?.status === 'connected' ? (
+          <>
+            <EuiCallOut title="Slack is connected" color="success" iconType="check">
+              {slackStatus.connected_at && (
+                <p>Connected since {new Date(slackStatus.connected_at).toLocaleString()}.</p>
+              )}
+            </EuiCallOut>
+            <EuiSpacer size="s" />
+            <EuiFlexGroup gutterSize="s" responsive={false}>
+              <EuiFlexItem grow={false}>
+                <EuiButtonEmpty iconType="logoSlack" size="s" onClick={handleConnectSlack}>
+                  Reconnect
+                </EuiButtonEmpty>
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiButtonEmpty
+                  iconType="unlink"
+                  size="s"
+                  color="danger"
+                  onClick={handleDisconnectSlack}
+                >
+                  Disconnect
+                </EuiButtonEmpty>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </>
+        ) : slackStatus?.status === 'disconnected' ? (
+          <>
+            <EuiCallOut
+              title="Slack connection lost — API key revoked or expired"
+              color="danger"
+              iconType="warning"
+            >
+              <p>
+                Slack events can no longer be forwarded to Kibana. Reconnect to generate a new API
+                key.
+                {slackStatus.connected_at && (
+                  <> Last connected: {new Date(slackStatus.connected_at).toLocaleString()}.</>
+                )}
+              </p>
+            </EuiCallOut>
+            <EuiSpacer />
+            <EuiButton iconType="logoSlack" color="danger" onClick={handleConnectSlack}>
+              Reconnect Slack
+            </EuiButton>
+          </>
+        ) : (
+          <EuiButton iconType="logoSlack" fill onClick={handleConnectSlack}>
+            Connect Slack
+          </EuiButton>
+        )}
+
+        <EuiHorizontalRule />
+
+        {/* ── Link Slack Account ── */}
+        <EuiTitle size="s">
+          <h2>Link Slack Account</h2>
+        </EuiTitle>
+        <EuiSpacer size="s" />
+        <EuiText size="s">
+          <p>
+            Link your Slack user ID to this Kibana account so conversations started in Slack appear
+            in Agent Builder. Your Slack user ID is shown in the bot&apos;s first message when you
+            chat with it.
+          </p>
+        </EuiText>
+        <EuiSpacer />
+
+        {linkStatus === 'success' && (
+          <>
+            <EuiCallOut title="Slack account linked" color="success" iconType="check">
+              <p>
+                Slack user <strong>{slackUserId}</strong> is now linked to your Kibana account.
+                Future conversations from Slack will appear in Agent Builder.
+              </p>
+            </EuiCallOut>
+            <EuiSpacer />
+          </>
+        )}
+        {linkStatus === 'error' && (
+          <>
+            <EuiCallOut title="Link failed" color="danger" iconType="error">
+              <p>{linkError}</p>
+            </EuiCallOut>
+            <EuiSpacer />
+          </>
+        )}
+
+        <EuiFlexGroup alignItems="flexEnd" gutterSize="m">
+          <EuiFlexItem>
+            <EuiFormRow label="Slack User ID" fullWidth>
+              <EuiFieldText
+                placeholder="e.g. U0123456789"
+                value={slackUserId}
+                onChange={(e) => setSlackUserId(e.target.value)}
+                fullWidth
+              />
+            </EuiFormRow>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiFormRow hasEmptyLabelSpace>
+              <EuiButton
+                onClick={handleLinkSlack}
+                isDisabled={!slackUserId.trim() || linkStatus === 'success'}
+              >
+                Link account
+              </EuiButton>
+            </EuiFormRow>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiPageTemplate.Section>
+    </EuiPageTemplate>
+  );
+};

--- a/x-pack/platform/plugins/shared/elastic_console/public/application/slack_onboarding_page.tsx
+++ b/x-pack/platform/plugins/shared/elastic_console/public/application/slack_onboarding_page.tsx
@@ -17,7 +17,6 @@ import {
   EuiFormRow,
   EuiHorizontalRule,
   EuiLoadingSpinner,
-  EuiPageTemplate,
   EuiSpacer,
   EuiText,
   EuiTitle,
@@ -92,13 +91,15 @@ export const SlackOnboardingPage: React.FC = () => {
     }
   }, [services.http]);
 
-   return (
-     <EuiPageTemplate>
-       <EuiPageTemplate.Header
-         pageTitle="Slack Integration"
-         rightSideItems={slackStatusBadge ? [slackStatusBadge] : []}
-       />
-       <EuiPageTemplate.Section>
+    return (
+      <>
+        {/* Slack connection status badge */}
+        {slackStatusBadge && (
+          <>
+            {slackStatusBadge}
+            <EuiSpacer size="m" />
+          </>
+        )}
 
         {/* ── Connect Slack ── */}
         <EuiTitle size="s">
@@ -220,9 +221,8 @@ export const SlackOnboardingPage: React.FC = () => {
                 Link account
               </EuiButton>
             </EuiFormRow>
-          </EuiFlexItem>
-        </EuiFlexGroup>
-      </EuiPageTemplate.Section>
-    </EuiPageTemplate>
-  );
+         </EuiFlexItem>
+         </EuiFlexGroup>
+     </>
+   );
 };

--- a/x-pack/platform/plugins/shared/elastic_console/public/plugin.tsx
+++ b/x-pack/platform/plugins/shared/elastic_console/public/plugin.tsx
@@ -20,7 +20,7 @@ export class ElasticConsolePlugin implements Plugin {
 
   setup(core: CoreSetup) {
     core.application.register({
-      id: 'elasticConsole',
+      id: 'elastic-console',
       title: 'Elastic Console',
       visibleIn: [],
       async mount(params: AppMountParameters) {

--- a/x-pack/platform/plugins/shared/elastic_console/public/plugin.tsx
+++ b/x-pack/platform/plugins/shared/elastic_console/public/plugin.tsx
@@ -20,7 +20,7 @@ export class ElasticConsolePlugin implements Plugin {
 
   setup(core: CoreSetup) {
     core.application.register({
-      id: 'elastic-console',
+      id: 'elasticConsole',
       title: 'Elastic Console',
       visibleIn: [],
       async mount(params: AppMountParameters) {

--- a/x-pack/platform/plugins/shared/elastic_console/server/config.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/config.ts
@@ -7,6 +7,17 @@
 
 import { schema, type TypeOf } from '@kbn/config-schema';
 
-export const configSchema = schema.object({});
+export const configSchema = schema.object({
+  enabled: schema.boolean({ defaultValue: true }),
+  slack: schema.maybe(
+    schema.object({
+      client_id: schema.string(),
+      // Signs the OAuth state JWT passed through Slack → router → Kibana.
+      // No shared router secret — auth on /slack/events uses the Kibana API key
+      // embedded in the JWT and forwarded by the router on every event.
+      state_secret: schema.string(),
+    })
+  ),
+});
 
 export type ElasticConsoleConfig = TypeOf<typeof configSchema>;

--- a/x-pack/platform/plugins/shared/elastic_console/server/config.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/config.ts
@@ -12,10 +12,9 @@ export const configSchema = schema.object({
   slack: schema.maybe(
     schema.object({
       client_id: schema.string(),
-      // Signs the OAuth state JWT passed through Slack → router → Kibana.
-      // No shared router secret — auth on /slack/events uses the Kibana API key
-      // embedded in the JWT and forwarded by the router on every event.
-      state_secret: schema.string(),
+      // No state_secret needed — the OAuth state JWT is self-authenticating:
+      // signed with the kibana_api_key embedded in the payload. The router
+      // verifies by re-deriving the HMAC using the key from the payload itself.
     })
   ),
 });

--- a/x-pack/platform/plugins/shared/elastic_console/server/config.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/config.ts
@@ -12,6 +12,7 @@ export const configSchema = schema.object({
   slack: schema.maybe(
     schema.object({
       client_id: schema.string(),
+      redirect_uri: schema.maybe(schema.string()), // defaults to connect.elastic.co
     })
   ),
 });

--- a/x-pack/platform/plugins/shared/elastic_console/server/config.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/config.ts
@@ -12,9 +12,6 @@ export const configSchema = schema.object({
   slack: schema.maybe(
     schema.object({
       client_id: schema.string(),
-      // No state_secret needed — the OAuth state JWT is self-authenticating:
-      // signed with the kibana_api_key embedded in the payload. The router
-      // verifies by re-deriving the HMAC using the key from the payload itself.
     })
   ),
 });

--- a/x-pack/platform/plugins/shared/elastic_console/server/lib/conversation_storage.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/lib/conversation_storage.ts
@@ -27,7 +27,8 @@ const storageSettings = {
       updated_at: types.date({}),
       conversation_rounds: types.object({ dynamic: false, properties: {} }),
       attachments: types.object({ dynamic: false, properties: {} }),
-      state: types.object({
+      state: types.object({ dynamic: false, properties: {} }),
+      slack_state: types.object({
         dynamic: false,
         properties: {
           location: types.keyword({}),
@@ -55,6 +56,7 @@ export interface ConversationDocument {
   conversation_rounds?: unknown[];
   attachments?: unknown[];
   state?: Record<string, unknown>;
+  slack_state?: Record<string, unknown>;
 }
 
 type ConversationStorageSettings = typeof storageSettings;

--- a/x-pack/platform/plugins/shared/elastic_console/server/lib/conversation_storage.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/lib/conversation_storage.ts
@@ -27,7 +27,18 @@ const storageSettings = {
       updated_at: types.date({}),
       conversation_rounds: types.object({ dynamic: false, properties: {} }),
       attachments: types.object({ dynamic: false, properties: {} }),
-      state: types.object({ dynamic: false, properties: {} }),
+      state: types.object({
+        dynamic: false,
+        properties: {
+          location: types.keyword({}),
+          origin_ref: types.keyword({}),
+          origin_location: types.keyword({}),
+          fork_context: types.text({}),
+          connector_id: types.keyword({}),
+          located_at: types.date({}),
+          handoff_summary: types.text({}),
+        },
+      }),
     },
   },
 } satisfies IndexStorageSettings;

--- a/x-pack/platform/plugins/shared/elastic_console/server/lib/notification_service.test.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/lib/notification_service.test.ts
@@ -1,0 +1,142 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { sendHandoffNotification } from './notification_service';
+import * as slackClient from './slack_client';
+
+jest.mock('./slack_client');
+
+const mockPostMessage = slackClient.postMessage as jest.MockedFunction<
+  typeof slackClient.postMessage
+>;
+
+const ORIGIN_REF = 'slack:C1234567890:1700000000.123456';
+const BOT_TOKEN = 'xoxb-test-token';
+
+beforeEach(() => {
+  mockPostMessage.mockResolvedValue('1700000001.000000');
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('sendHandoffNotification', () => {
+  it('posts to the correct channel and thread', async () => {
+    await sendHandoffNotification(BOT_TOKEN, { originRef: ORIGIN_REF });
+
+    expect(mockPostMessage).toHaveBeenCalledWith(
+      BOT_TOKEN,
+      expect.objectContaining({
+        channel: 'C1234567890',
+        thread_ts: '1700000000.123456',
+      })
+    );
+  });
+
+  it('always includes the investigation complete header', async () => {
+    await sendHandoffNotification(BOT_TOKEN, { originRef: ORIGIN_REF });
+
+    const { text } = mockPostMessage.mock.calls[0][1];
+    expect(text).toContain('✅ *Investigation complete*');
+  });
+
+  it('always includes the continue conversation footer', async () => {
+    await sendHandoffNotification(BOT_TOKEN, { originRef: ORIGIN_REF });
+
+    const { text } = mockPostMessage.mock.calls[0][1];
+    expect(text).toContain('_Reply here to continue the conversation._');
+  });
+
+  it('includes investigation rounds when provided', async () => {
+    const rounds = [
+      { input: { message: 'What is the error?' }, response: { message: 'Out of memory.' } },
+    ];
+
+    await sendHandoffNotification(BOT_TOKEN, { originRef: ORIGIN_REF, rounds });
+
+    const { text } = mockPostMessage.mock.calls[0][1];
+    expect(text).toContain('What is the error?');
+    expect(text).toContain('Out of memory.');
+    expect(text).toContain('*Investigation log*');
+  });
+
+  it('filters out [Investigation complete] synthetic rounds', async () => {
+    const rounds = [
+      { input: { message: '[Investigation complete]' }, response: { message: 'Hello! I am Claude' } },
+      { input: { message: 'real question' }, response: { message: 'real answer' } },
+    ];
+
+    await sendHandoffNotification(BOT_TOKEN, { originRef: ORIGIN_REF, rounds });
+
+    const { text } = mockPostMessage.mock.calls[0][1];
+    expect(text).not.toContain('[Investigation complete]');
+    expect(text).not.toContain('Hello! I am Claude');
+    expect(text).toContain('real question');
+    expect(text).toContain('real answer');
+  });
+
+  it('shows at most MAX_TURNS (5) rounds', async () => {
+    const rounds = Array.from({ length: 8 }, (_, i) => ({
+      input: { message: `question ${i}` },
+      response: { message: `answer ${i}` },
+    }));
+
+    await sendHandoffNotification(BOT_TOKEN, { originRef: ORIGIN_REF, rounds });
+
+    const { text } = mockPostMessage.mock.calls[0][1];
+    // Last 5 shown, first 3 omitted
+    expect(text).toContain('3 earlier exchanges omitted');
+    expect(text).toContain('question 7');
+    expect(text).not.toContain('question 0');
+  });
+
+  it('truncates long questions to 200 chars', async () => {
+    const longQuestion = 'Q'.repeat(250);
+    const rounds = [{ input: { message: longQuestion }, response: { message: 'answer' } }];
+
+    await sendHandoffNotification(BOT_TOKEN, { originRef: ORIGIN_REF, rounds });
+
+    const { text } = mockPostMessage.mock.calls[0][1];
+    expect(text).toContain('…');
+    expect(text).not.toContain(longQuestion);
+  });
+
+  it('truncates long answers to 500 chars', async () => {
+    const longAnswer = 'A'.repeat(600);
+    const rounds = [{ input: { message: 'question' }, response: { message: longAnswer } }];
+
+    await sendHandoffNotification(BOT_TOKEN, { originRef: ORIGIN_REF, rounds });
+
+    const { text } = mockPostMessage.mock.calls[0][1];
+    expect(text).toContain('…');
+    expect(text).not.toContain(longAnswer);
+  });
+
+  it('does nothing for an unknown provider', async () => {
+    await sendHandoffNotification(BOT_TOKEN, { originRef: 'teams:channel:thread' });
+    expect(mockPostMessage).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when originRef has no colon', async () => {
+    await sendHandoffNotification(BOT_TOKEN, { originRef: 'invalid' });
+    expect(mockPostMessage).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when the slack ref has no second colon', async () => {
+    await sendHandoffNotification(BOT_TOKEN, { originRef: 'slack:onlychannel' });
+    expect(mockPostMessage).not.toHaveBeenCalled();
+  });
+
+  it('shows no investigation section when rounds is empty', async () => {
+    await sendHandoffNotification(BOT_TOKEN, { originRef: ORIGIN_REF, rounds: [] });
+
+    const { text } = mockPostMessage.mock.calls[0][1];
+    expect(text).not.toContain('*Investigation log*');
+    expect(text).not.toContain('─────────────────────');
+  });
+});

--- a/x-pack/platform/plugins/shared/elastic_console/server/lib/notification_service.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/lib/notification_service.ts
@@ -17,14 +17,29 @@ import { postMessage } from './slack_client';
 // can be added by extending the switch below.
 // ---------------------------------------------------------------------------
 
+export interface ConversationRound {
+  input?: { message?: string };
+  response?: { message?: string };
+}
+
+// Slack mrkdwn limits: keep each turn short enough that a few fit in one message.
+const MAX_QUESTION_CHARS = 200;
+const MAX_ANSWER_CHARS = 500;
+const MAX_TURNS = 5;
+
+const truncate = (s: string, max: number): string =>
+  s.length > max ? s.slice(0, max - 1) + '…' : s;
+
 export const sendHandoffNotification = async (
   botToken: string,
   {
     originRef,
     summary,
+    rounds,
   }: {
     originRef: string;
     summary?: string;
+    rounds?: ConversationRound[];
   }
 ): Promise<void> => {
   const colonIdx = originRef.indexOf(':');
@@ -42,9 +57,34 @@ export const sendHandoffNotification = async (
       const channel = rest.slice(0, secondColon);
       const threadTs = rest.slice(secondColon + 1);
 
-      const lines = ['*Investigation returned*'];
-      if (summary) lines.push('', summary);
-      lines.push('', '_Continuing in this thread._');
+      const lines: string[] = ['✅ *Investigation complete*'];
+
+      // Append the investigation Q&A — only rounds added after the fork.
+      const investigationRounds = (rounds ?? []).filter(
+        (r) =>
+          r.input?.message &&
+          r.input.message !== '[Investigation complete]' &&
+          r.response?.message
+      );
+
+      if (investigationRounds.length > 0) {
+        lines.push('', '─────────────────────', '*Investigation log*', '');
+        const shown = investigationRounds.slice(-MAX_TURNS);
+        const skipped = investigationRounds.length - shown.length;
+        if (skipped > 0) {
+          lines.push(`_… ${skipped} earlier exchange${skipped === 1 ? '' : 's'} omitted_`, '');
+        }
+        for (const round of shown) {
+          lines.push(
+            `:speech_balloon: *${truncate(round.input!.message!, MAX_QUESTION_CHARS)}*`,
+            `> ${truncate(round.response!.message!, MAX_ANSWER_CHARS).replace(/\n/g, '\n> ')}`,
+            ''
+          );
+        }
+        lines.push('─────────────────────');
+      }
+
+      lines.push('', '_Reply here to continue the conversation._');
 
       await postMessage(botToken, {
         channel,

--- a/x-pack/platform/plugins/shared/elastic_console/server/lib/notification_service.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/lib/notification_service.ts
@@ -62,9 +62,7 @@ export const sendHandoffNotification = async (
       // Append the investigation Q&A — only rounds added after the fork.
       const investigationRounds = (rounds ?? []).filter(
         (r) =>
-          r.input?.message &&
-          r.input.message !== '[Investigation complete]' &&
-          r.response?.message
+          r.input?.message && r.input.message !== '[Investigation complete]' && r.response?.message
       );
 
       if (investigationRounds.length > 0) {

--- a/x-pack/platform/plugins/shared/elastic_console/server/lib/notification_service.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/lib/notification_service.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { postMessage } from './slack_client';
+
+// ---------------------------------------------------------------------------
+// Notification service — sends a handoff notification back to the origin.
+//
+// origin_ref format: '<provider>:<channel>:<thread_ts>'
+//   e.g. 'slack:C1234567890:1700000000.123456'
+//
+// Currently supports Slack. Additional providers (Teams, PagerDuty, etc.)
+// can be added by extending the switch below.
+// ---------------------------------------------------------------------------
+
+export const sendHandoffNotification = async (
+  botToken: string,
+  {
+    originRef,
+    summary,
+  }: {
+    originRef: string;
+    summary?: string;
+  }
+): Promise<void> => {
+  const colonIdx = originRef.indexOf(':');
+  if (colonIdx === -1) return;
+
+  const provider = originRef.slice(0, colonIdx);
+  const rest = originRef.slice(colonIdx + 1);
+
+  switch (provider) {
+    case 'slack': {
+      // rest = 'channelId:thread_ts'
+      const secondColon = rest.indexOf(':');
+      if (secondColon === -1) return;
+
+      const channel = rest.slice(0, secondColon);
+      const threadTs = rest.slice(secondColon + 1);
+
+      const lines = ['*Investigation returned*'];
+      if (summary) lines.push('', summary);
+      lines.push('', '_Continuing in this thread._');
+
+      await postMessage(botToken, {
+        channel,
+        thread_ts: threadTs,
+        text: lines.join('\n'),
+      });
+      break;
+    }
+    default:
+      // Unknown provider — no-op for now
+      break;
+  }
+};

--- a/x-pack/platform/plugins/shared/elastic_console/server/lib/slack_client.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/lib/slack_client.ts
@@ -15,7 +15,7 @@ async function slackCall(
   botToken: string,
   method: string,
   body: Record<string, unknown>
-): Promise<{ ok: boolean; ts?: string; error?: string }> {
+): Promise<{ ok: boolean; ts?: string; error?: string; needed?: string }> {
   const res = await fetch(`${SLACK_API}/${method}`, {
     method: 'POST',
     headers: {
@@ -24,7 +24,7 @@ async function slackCall(
     },
     body: JSON.stringify(body),
   });
-  return res.json() as Promise<{ ok: boolean; ts?: string; error?: string }>;
+  return res.json() as Promise<{ ok: boolean; ts?: string; error?: string; needed?: string }>;
 }
 
 export const postMessage = async (
@@ -36,7 +36,8 @@ export const postMessage = async (
     text,
     ...(thread_ts ? { thread_ts } : {}),
   });
-  if (!result.ok) throw new Error(`Slack postMessage failed: ${result.error}`);
+  if (!result.ok)
+    throw new Error(`Slack postMessage failed: ${result.error} (needed: ${result.needed})`);
   return result.ts ?? '';
 };
 

--- a/x-pack/platform/plugins/shared/elastic_console/server/lib/slack_client.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/lib/slack_client.ts
@@ -1,0 +1,125 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+// ---------------------------------------------------------------------------
+// Thin Slack Web API wrapper — raw fetch, no SDK dependency
+// ---------------------------------------------------------------------------
+
+const SLACK_API = 'https://slack.com/api';
+
+async function slackCall(
+  botToken: string,
+  method: string,
+  body: Record<string, unknown>
+): Promise<{ ok: boolean; ts?: string; error?: string }> {
+  const res = await fetch(`${SLACK_API}/${method}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      Authorization: `Bearer ${botToken}`,
+    },
+    body: JSON.stringify(body),
+  });
+  return res.json() as Promise<{ ok: boolean; ts?: string; error?: string }>;
+}
+
+export const postMessage = async (
+  botToken: string,
+  { channel, thread_ts, text }: { channel: string; thread_ts?: string; text: string }
+): Promise<string> => {
+  const result = await slackCall(botToken, 'chat.postMessage', {
+    channel,
+    text,
+    ...(thread_ts ? { thread_ts } : {}),
+  });
+  if (!result.ok) throw new Error(`Slack postMessage failed: ${result.error}`);
+  return result.ts ?? '';
+};
+
+export const updateMessage = async (
+  botToken: string,
+  { channel, ts, text }: { channel: string; ts: string; text: string }
+): Promise<void> => {
+  const result = await slackCall(botToken, 'chat.update', { channel, ts, text });
+  if (!result.ok) throw new Error(`Slack updateMessage failed: ${result.error}`);
+};
+
+// ---------------------------------------------------------------------------
+// Throttled stream updater — batches chat.update calls (~1 per 1.5s)
+// ---------------------------------------------------------------------------
+
+const STREAM_INTERVAL_MS = 1500;
+
+export const createStreamUpdater = (
+  botToken: string,
+  channel: string,
+  ts: string,
+  threadTs: string,
+  onError: (err: Error) => void
+) => {
+  let lastUpdateMs = 0;
+  let pendingText: string | null = null;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  const flush = (): void => {
+    if (timer) {
+      clearTimeout(timer);
+      timer = null;
+    }
+    if (!pendingText) return;
+    lastUpdateMs = Date.now();
+    const text = pendingText;
+    pendingText = null;
+    updateMessage(botToken, { channel, ts, text }).catch(onError);
+  };
+
+  return {
+    schedule(text: string): void {
+      pendingText = text;
+      const elapsed = Date.now() - lastUpdateMs;
+      if (elapsed >= STREAM_INTERVAL_MS) {
+        flush();
+      } else if (!timer) {
+        timer = setTimeout(flush, STREAM_INTERVAL_MS - elapsed);
+      }
+    },
+
+    async finalize(text: string): Promise<void> {
+      if (timer) {
+        clearTimeout(timer);
+        timer = null;
+      }
+      try {
+        await updateMessage(botToken, { channel, ts, text });
+      } catch {
+        // Message may have been deleted — fall back to a new reply in the thread
+        await postMessage(botToken, { channel, thread_ts: threadTs, text });
+      }
+    },
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Message splitting — break at paragraph boundaries to avoid mid-sentence cuts
+// ---------------------------------------------------------------------------
+
+export const MAX_SLACK_MSG_LEN = 3900;
+
+export const splitAtParagraph = (text: string, maxLen: number): string[] => {
+  if (text.length <= maxLen) return [text];
+  const parts: string[] = [];
+  let rest = text;
+  while (rest.length > maxLen) {
+    const window = rest.slice(0, maxLen);
+    const lastBreak = window.lastIndexOf('\n\n');
+    const at = lastBreak > maxLen / 2 ? lastBreak : maxLen;
+    parts.push(rest.slice(0, at).trimEnd());
+    rest = rest.slice(at).trimStart();
+  }
+  if (rest) parts.push(rest);
+  return parts;
+};

--- a/x-pack/platform/plugins/shared/elastic_console/server/lib/slack_client.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/lib/slack_client.ts
@@ -60,7 +60,8 @@ export const createStreamUpdater = (
   channel: string,
   ts: string,
   threadTs: string,
-  onError: (err: Error) => void
+  onError: (err: Error) => void,
+  onFallback?: (err: Error) => void
 ) => {
   let lastUpdateMs = 0;
   let pendingText: string | null = null;
@@ -96,8 +97,9 @@ export const createStreamUpdater = (
       }
       try {
         await updateMessage(botToken, { channel, ts, text });
-      } catch {
+      } catch (updateErr) {
         // Message may have been deleted — fall back to a new reply in the thread
+        onFallback?.(updateErr as Error);
         await postMessage(botToken, { channel, thread_ts: threadTs, text });
       }
     },

--- a/x-pack/platform/plugins/shared/elastic_console/server/lib/slack_credentials_so.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/lib/slack_credentials_so.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+// Saved object type for Slack credentials (encrypted bot token).
+// Registered in plugin setup and used at runtime to store/retrieve the bot token
+// received from the router after OAuth completion.
+
+export const SLACK_CREDENTIALS_SO_TYPE = 'elastic-console-slack-credentials';
+export const SLACK_CREDENTIALS_SO_ID = 'singleton';

--- a/x-pack/platform/plugins/shared/elastic_console/server/lib/slack_credentials_so.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/lib/slack_credentials_so.ts
@@ -10,4 +10,4 @@
 // received from the router after OAuth completion.
 
 export const SLACK_CREDENTIALS_SO_TYPE = 'elastic-console-slack-credentials';
-export const SLACK_CREDENTIALS_SO_ID = 'singleton';
+export const SLACK_CREDENTIALS_SO_ID = '550e8400-e29b-41d4-a716-446655440001';

--- a/x-pack/platform/plugins/shared/elastic_console/server/lib/slack_format.test.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/lib/slack_format.test.ts
@@ -1,0 +1,103 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { markdownToMrkdwn } from './slack_format';
+
+describe('markdownToMrkdwn', () => {
+  describe('bold', () => {
+    it('converts **text** to *text*', () => {
+      expect(markdownToMrkdwn('**hello**')).toBe('*hello*');
+    });
+
+    it('converts __text__ to *text*', () => {
+      expect(markdownToMrkdwn('__hello__')).toBe('*hello*');
+    });
+  });
+
+  describe('headers', () => {
+    it('converts h1 to bold', () => {
+      expect(markdownToMrkdwn('# Title')).toBe('*Title*');
+    });
+
+    it('converts h3 to bold', () => {
+      expect(markdownToMrkdwn('### Section')).toBe('*Section*');
+    });
+  });
+
+  describe('strikethrough', () => {
+    it('converts ~~text~~ to ~text~', () => {
+      expect(markdownToMrkdwn('~~removed~~')).toBe('~removed~');
+    });
+  });
+
+  describe('links', () => {
+    it('converts [label](url) to <url|label>', () => {
+      expect(markdownToMrkdwn('[Elastic](https://elastic.co)')).toBe(
+        '<https://elastic.co|Elastic>'
+      );
+    });
+
+    it('converts images to Slack format', () => {
+      expect(markdownToMrkdwn('![alt](https://example.com/img.png)')).toBe(
+        '<https://example.com/img.png|alt>'
+      );
+    });
+  });
+
+  describe('code blocks', () => {
+    it('strips language tag from fenced code blocks', () => {
+      const input = '```typescript\nconst x = 1;\n```';
+      expect(markdownToMrkdwn(input)).toBe('```\nconst x = 1;\n```');
+    });
+
+    it('preserves inline code unchanged', () => {
+      expect(markdownToMrkdwn('use `const` here')).toBe('use `const` here');
+    });
+
+    it('does not convert bold inside code blocks', () => {
+      const input = '```\n**not bold**\n```';
+      expect(markdownToMrkdwn(input)).toBe('```\n**not bold**\n```');
+    });
+  });
+
+  describe('tables', () => {
+    it('converts a markdown table to a monospace code block', () => {
+      const input = '| A | B |\n| - | - |\n| 1 | 2 |';
+      const result = markdownToMrkdwn(input);
+      expect(result).toMatch(/^```/);
+      expect(result).toContain('A');
+      expect(result).toContain('B');
+      expect(result).toContain('1');
+      expect(result).toContain('2');
+      expect(result).not.toContain('| - |');
+    });
+  });
+
+  describe('horizontal rules', () => {
+    it('removes horizontal rules', () => {
+      const input = 'above\n---\nbelow';
+      expect(markdownToMrkdwn(input)).toBe('above\n\nbelow');
+    });
+  });
+
+  describe('blank lines', () => {
+    it('collapses 3+ blank lines to 2', () => {
+      const input = 'a\n\n\n\nb';
+      expect(markdownToMrkdwn(input)).toBe('a\n\nb');
+    });
+  });
+
+  describe('passthrough', () => {
+    it('returns plain text unchanged', () => {
+      expect(markdownToMrkdwn('hello world')).toBe('hello world');
+    });
+
+    it('trims leading and trailing whitespace', () => {
+      expect(markdownToMrkdwn('  hello  ')).toBe('hello');
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/elastic_console/server/lib/slack_format.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/lib/slack_format.ts
@@ -1,0 +1,121 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+// ---------------------------------------------------------------------------
+// Markdown → Slack mrkdwn converter
+//
+// Slack's mrkdwn differs from standard Markdown in bold, headers, links,
+// and has no table support. This module converts AI response Markdown
+// into Slack-renderable text.
+// ---------------------------------------------------------------------------
+
+function stripInlineMarkdown(text: string): string {
+  return text
+    .replace(/\*\*(.+?)\*\*/g, '$1')
+    .replace(/__(.+?)__/g, '$1')
+    .replace(/~~(.+?)~~/g, '$1');
+}
+
+function isSeparatorRow(line: string): boolean {
+  return /^\s*\|[\s\-:|]+\|\s*$/.test(line);
+}
+
+function formatTable(lines: string[]): string {
+  const rows = lines
+    .filter((line) => !isSeparatorRow(line))
+    .map((line) =>
+      line
+        .replace(/^\s*\|/, '')
+        .replace(/\|\s*$/, '')
+        .split('|')
+        .map((cell) => stripInlineMarkdown(cell.trim()))
+    );
+
+  if (rows.length === 0) return lines.join('\n');
+
+  const numCols = Math.max(...rows.map((r) => r.length));
+  const colWidths = Array.from({ length: numCols }, (_, col) =>
+    Math.max(...rows.map((row) => (row[col] ?? '').length))
+  );
+
+  const formatted = rows
+    .map((row) => row.map((cell, col) => cell.padEnd(colWidths[col] ?? 0)).join('  '))
+    .join('\n');
+
+  return '```\n' + formatted + '\n```';
+}
+
+function convertTables(text: string): string {
+  const lines = text.split('\n');
+  const result: string[] = [];
+  let i = 0;
+
+  while (i < lines.length) {
+    if (/^\s*\|/.test(lines[i])) {
+      const tableLines: string[] = [];
+      while (i < lines.length && /^\s*\|/.test(lines[i])) {
+        tableLines.push(lines[i]);
+        i++;
+      }
+      result.push(formatTable(tableLines));
+    } else {
+      result.push(lines[i]);
+      i++;
+    }
+  }
+
+  return result.join('\n');
+}
+
+export const markdownToMrkdwn = (md: string): string => {
+  // 1. Tables → monospace code blocks (before code block extraction)
+  let text = convertTables(md);
+
+  // 2. Protect fenced code blocks — strip language tag, store for later
+  const codeBlocks: string[] = [];
+  text = text.replace(/```\w*\n([\s\S]*?)```/g, (_, code) => {
+    codeBlocks.push('```\n' + code.trimEnd() + '\n```');
+    return `\x00CB${codeBlocks.length - 1}\x00`;
+  });
+
+  // 3. Protect inline code
+  const inlineCode: string[] = [];
+  text = text.replace(/`([^`\n]+)`/g, (match) => {
+    inlineCode.push(match);
+    return `\x00IC${inlineCode.length - 1}\x00`;
+  });
+
+  // 4. Headers → bold
+  text = text.replace(/^#{1,6}\s+(.+)$/gm, '*$1*');
+
+  // 5. Images → Slack format (before links to avoid collision)
+  text = text.replace(/!\[([^\]]*)\]\(([^)]+)\)/g, '<$2|$1>');
+
+  // 6. Links → Slack format
+  text = text.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<$2|$1>');
+
+  // 7. Bold **text** and __text__ → *text*
+  text = text.replace(/\*\*(.+?)\*\*/g, '*$1*');
+  text = text.replace(/__(.+?)__/g, '*$1*');
+
+  // 8. Strikethrough ~~text~~ → ~text~
+  text = text.replace(/~~(.+?)~~/g, '~$1~');
+
+  // 9. Horizontal rules → blank line
+  text = text.replace(/^[\s]*[-*_]{3,}[\s]*$/gm, '');
+
+  // 10. Restore inline code
+  text = text.replace(/\x00IC(\d+)\x00/g, (_, i) => inlineCode[parseInt(i, 10)]);
+
+  // 11. Restore code blocks
+  text = text.replace(/\x00CB(\d+)\x00/g, (_, i) => codeBlocks[parseInt(i, 10)]);
+
+  // 12. Collapse excessive blank lines
+  text = text.replace(/\n{3,}/g, '\n\n');
+
+  return text.trim();
+};

--- a/x-pack/platform/plugins/shared/elastic_console/server/lib/slack_handler.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/lib/slack_handler.ts
@@ -8,9 +8,19 @@
 import { v4 as uuidv4 } from 'uuid';
 import type { CoreStart, KibanaRequest, Logger } from '@kbn/core/server';
 import type { InferenceServerStart } from '@kbn/inference-plugin/server';
-import { MessageRole, ChatCompletionEventType } from '@kbn/inference-common';
+import { MessageRole, ChatCompletionEventType, type Message } from '@kbn/inference-common';
 import { createConversationStorage } from './conversation_storage';
 import { resolveConnector } from './resolve_connector';
+import {
+  SLACK_USER_MAPPING_SO_TYPE,
+  type SlackUserMappingAttributes,
+} from './slack_user_mapping_so';
+import {
+  SLACK_SESSION_SO_TYPE,
+  slackSessionSoId,
+  conversationIdFromSoId,
+  type SlackSessionAttributes,
+} from './slack_session_so';
 import {
   postMessage,
   createStreamUpdater,
@@ -35,7 +45,7 @@ const RESET_RE = /^(?:reset|new\s+session)$/i;
 const inFlightEvents = new Set<string>();
 
 // ---------------------------------------------------------------------------
-// Conversation lookup helpers
+// Helpers
 // ---------------------------------------------------------------------------
 
 const getSpace = (basePath: string): string => {
@@ -43,23 +53,49 @@ const getSpace = (basePath: string): string => {
   return spaceMatch ? spaceMatch[1] : 'default';
 };
 
-const findConversationByOriginRef = async (
-  storage: ReturnType<typeof createConversationStorage>,
+/**
+ * Find the active conversation for a Slack thread by querying the slack session SO.
+ * The SO is stored separately from the conversation document so agentBuilder's
+ * full-document replaces cannot overwrite Slack routing metadata.
+ */
+const findSessionByOriginRef = async (
+  coreStart: CoreStart,
   originRef: string
-): Promise<{ id: string; state: Record<string, unknown> } | null> => {
-  const results = await storage.search({
-    track_total_hits: false,
-    size: 1,
-    query: { bool: { filter: [{ term: { 'state.origin_ref': originRef } }] } },
-  });
+): Promise<{ conversationId: string; session: SlackSessionAttributes } | null> => {
+  try {
+    const soClient = coreStart.savedObjects.createInternalRepository([SLACK_SESSION_SO_TYPE]);
+    const results = await soClient.find<SlackSessionAttributes>({
+      type: SLACK_SESSION_SO_TYPE,
+      filter: `elastic-console-slack-session.attributes.origin_ref: "${originRef}"`,
+      perPage: 1,
+      sortField: 'updated_at',
+      sortOrder: 'desc',
+    });
+    if (results.total === 0) return null;
+    const so = results.saved_objects[0];
+    return {
+      conversationId: conversationIdFromSoId(so.id),
+      session: so.attributes,
+    };
+  } catch {
+    return null;
+  }
+};
 
-  const hit = results.hits.hits[0];
-  if (!hit?._id) return null;
-
-  return {
-    id: hit._id,
-    state: (hit._source?.state as Record<string, unknown>) ?? {},
-  };
+const lookupKibanaUser = async (
+  coreStart: CoreStart,
+  slackUserId: string
+): Promise<{ username: string; userId?: string } | null> => {
+  try {
+    const soClient = coreStart.savedObjects.createInternalRepository([SLACK_USER_MAPPING_SO_TYPE]);
+    const so = await soClient.get<SlackUserMappingAttributes>(
+      SLACK_USER_MAPPING_SO_TYPE,
+      slackUserId
+    );
+    return { username: so.attributes.kibana_username, userId: so.attributes.kibana_user_id };
+  } catch {
+    return null;
+  }
 };
 
 // ---------------------------------------------------------------------------
@@ -118,18 +154,23 @@ export const handleSlackEvent = async ({
   const basePath = coreStart.http.basePath.get(request);
   const space = getSpace(basePath);
   const storage = createConversationStorage({ esClient, logger });
+  const soClient = coreStart.savedObjects.createInternalRepository([SLACK_SESSION_SO_TYPE]);
+
+  // Resolve the Kibana user identity for this Slack user so conversations are
+  // attributed correctly and visible to the user across all surfaces.
+  const kibanaUser = event.user ? await lookupKibanaUser(coreStart, event.user) : null;
 
   try {
     // --- Command: status ---
     if (STATUS_RE.test(text)) {
-      const conv = await findConversationByOriginRef(storage, originRef);
+      const existing = await findSessionByOriginRef(coreStart, originRef);
       const lines = ['*Elastic Console — session status*'];
-      if (conv) {
-        const state = conv.state;
+      if (existing) {
+        const { session } = existing;
         lines.push(`• Conversation: active`);
-        if (state.location) lines.push(`• Location: \`${state.location}\``);
-        if (state.located_at) {
-          const ageMs = Date.now() - new Date(state.located_at as string).getTime();
+        if (session.location) lines.push(`• Location: \`${session.location}\``);
+        if (session.located_at) {
+          const ageMs = Date.now() - new Date(session.located_at).getTime();
           const ageStr =
             ageMs < 60_000
               ? 'just now'
@@ -147,24 +188,28 @@ export const handleSlackEvent = async ({
 
     // --- Command: reset ---
     if (RESET_RE.test(text)) {
-      const conv = await findConversationByOriginRef(storage, originRef);
-      if (conv) {
-        const fullConv = await storage.get({ id: conv.id });
+      const existing = await findSessionByOriginRef(coreStart, originRef);
+      if (existing) {
+        const { conversationId, session } = existing;
+        const fullConv = await storage.get({ id: conversationId });
         if (fullConv.found) {
           await storage.index({
-            id: conv.id,
+            id: conversationId,
             document: {
               ...fullConv._source,
               conversation_rounds: [],
-              state: {
-                ...(fullConv._source?.state as Record<string, unknown>),
-                location: originRef,
-                located_at: new Date().toISOString(),
-              },
               updated_at: new Date().toISOString(),
             },
           });
         }
+        const now = new Date().toISOString();
+        await soClient.update<SlackSessionAttributes>(
+          SLACK_SESSION_SO_TYPE,
+          slackSessionSoId(conversationId),
+          { location: originRef, located_at: now, updated_at: now, fork_context: null }
+        );
+        // If the SO doesn't exist (race), fall through — session was already reset
+        void session; // suppress unused warning
       }
       await postMessage(botToken, { channel, thread_ts: threadTs, text: 'Session reset.' });
       return;
@@ -172,8 +217,8 @@ export const handleSlackEvent = async ({
 
     // --- Command: fork ---
     if (FORK_RE.test(text)) {
-      const conv = await findConversationByOriginRef(storage, originRef);
-      if (!conv) {
+      const existing = await findSessionByOriginRef(coreStart, originRef);
+      if (!existing) {
         await postMessage(botToken, {
           channel,
           thread_ts: threadTs,
@@ -182,7 +227,8 @@ export const handleSlackEvent = async ({
         return;
       }
 
-      const fullConv = await storage.get({ id: conv.id });
+      const { conversationId, session } = existing;
+      const fullConv = await storage.get({ id: conversationId });
       if (!fullConv.found) {
         await postMessage(botToken, {
           channel,
@@ -203,52 +249,58 @@ export const handleSlackEvent = async ({
         return;
       }
 
-      const lastRound = rounds[rounds.length - 1];
-      const forkContext =
-        ((lastRound?.response as Record<string, unknown> | undefined)?.message as string) ?? '';
-
-      // Carry the connector_id from the parent conversation into the fork
-      const parentConnectorId = (fullConv._source?.state as Record<string, unknown> | undefined)
-        ?.connector_id as string | undefined;
-
       const forkId = uuidv4();
       const now = new Date().toISOString();
 
+      // Create a child conversation pre-seeded with parent history so the CLI
+      // has full context. After handoff the summary is posted back to this
+      // Slack thread and the parent conversation continues as normal.
       await storage.index({
         id: forkId,
         document: {
           agent_id: fullConv._source?.agent_id,
-          title: `Fork of ${conv.id}`,
-          conversation_rounds: [],
+          title: `[Investigation] ${(fullConv._source?.title as string) ?? conversationId}`,
+          conversation_rounds: rounds,
           user_id: fullConv._source?.user_id,
           user_name: fullConv._source?.user_name,
           space,
           created_at: now,
           updated_at: now,
-          state: {
-            fork_context: forkContext,
-            origin_ref: originRef,
-            origin_location: originRef,
-            connector_id: parentConnectorId ?? null,
-            location: null,
-          },
         },
       });
+
+      // fork_context stores the parent round count so the handoff notification
+      // only shows rounds added during the investigation, not the inherited history.
+      await soClient.create<SlackSessionAttributes>(
+        SLACK_SESSION_SO_TYPE,
+        {
+          origin_ref: originRef,
+          origin_location: originRef,
+          location: null,
+          connector_id: session.connector_id,
+          fork_context: String(rounds.length),
+          handoff_summary: null,
+          located_at: null,
+          updated_at: now,
+        },
+        { id: slackSessionSoId(forkId), overwrite: true }
+      );
+
+      const kibanaBase =
+        coreStart.http.basePath.publicBaseUrl ?? '';
+      const kibanaConvUrl = `${kibanaBase}/app/agent-builder/conversations/${forkId}`;
 
       await postMessage(botToken, {
         channel,
         thread_ts: threadTs,
         text: [
-          `*Session forked*`,
+          `*Session forked* — \`${forkId}\``,
           ``,
-          `*Claude Code*`,
+          `Pick up in your editor:`,
           '```',
-          `norb fork ${forkId} --agent claude`,
+          `elastic-console fork ${forkId}`,
           '```',
-          `*Cursor*`,
-          '```',
-          `norb fork ${forkId} --agent cursor`,
-          '```',
+          `Or open in Kibana: ${kibanaConvUrl}`,
         ].join('\n'),
       });
       return;
@@ -256,19 +308,33 @@ export const handleSlackEvent = async ({
 
     // --- Regular question — find or create conversation, call inference ---
 
-    const existingConv = await findConversationByOriginRef(storage, originRef);
+    const existingSession = await findSessionByOriginRef(coreStart, originRef);
     let existingConvId: string | null = null;
-    let conversationId: string | undefined;
+    let existingRounds: Array<Record<string, unknown>> = [];
 
-    if (existingConv) {
-      const fullConv = await storage.get({ id: existingConv.id });
+    // First message in a new thread from an unmapped Slack user — prompt them to link
+    // their Kibana account so the conversation shows up in Agent Builder.
+    if (!existingSession && !kibanaUser && event.user) {
+      await postMessage(botToken, {
+        channel,
+        thread_ts: threadTs,
+        text: [
+          `👋 Hi! Your Slack account isn't linked to a Kibana user yet.`,
+          `Your Slack user ID is \`${event.user}\`.`,
+          ``,
+          `To link your account, open *Elastic Console Setup* in Kibana and enter your Slack user ID in the *Link Slack Account* section.`,
+          ``,
+          `I'll still answer your question, but the conversation won't appear in Kibana Agent Builder until you link.`,
+        ].join('\n'),
+      });
+    }
+
+    if (existingSession) {
+      const fullConv = await storage.get({ id: existingSession.conversationId });
       if (fullConv.found) {
-        existingConvId = existingConv.id;
-        const rounds =
+        existingConvId = existingSession.conversationId;
+        existingRounds =
           (fullConv._source?.conversation_rounds as Array<Record<string, unknown>>) ?? [];
-        if (rounds.length > 0) {
-          conversationId = existingConv.id;
-        }
       }
     }
 
@@ -308,13 +374,24 @@ export const handleSlackEvent = async ({
       return msg || `_Thinking…_`;
     };
 
-    // Resolve connector: use the one stored in conversation state, or fall back to default
-    const stateConnectorId = existingConv?.state?.connector_id as string | undefined;
+    // Resolve connector: use the one from the session SO, or fall back to default
     const resolvedConnectorId = await resolveConnector(
       inference,
       request,
-      stateConnectorId ?? 'default'
+      existingSession?.session.connector_id ?? 'default'
     );
+
+    // Build full message history so the LLM has conversation context.
+    // The inference plugin is a raw LLM interface — it doesn't load conversation
+    // history itself, so we pass all prior rounds as messages.
+    const historyMessages = existingRounds.flatMap((round) => {
+      const input = (round.input as Record<string, unknown> | undefined)?.message as string | undefined;
+      const responseMsg = (round.response as Record<string, unknown> | undefined)?.message as string | undefined;
+      const msgs: Message[] = [];
+      if (input) msgs.push({ role: MessageRole.User, content: input });
+      if (responseMsg) msgs.push({ role: MessageRole.Assistant, content: responseMsg } as Message);
+      return msgs;
+    });
 
     // Call inference plugin directly via Observable
     const inferenceClient = inference.getClient({ request });
@@ -324,10 +401,18 @@ export const handleSlackEvent = async ({
 
     try {
       await new Promise<void>((resolve, reject) => {
+        const handoffSummary = existingSession?.session.handoff_summary;
+        const systemPrompt =
+          'You are a helpful Elastic AI assistant embedded in Slack. ' +
+          'Use the full conversation history when answering questions.' +
+          (handoffSummary
+            ? ` A previous investigation was completed with this summary: "${handoffSummary}". Reference it when relevant.`
+            : '');
+
         const events$ = inferenceClient.chatComplete({
           connectorId: resolvedConnectorId,
-          conversationId,
-          messages: [{ role: MessageRole.User, content: text }],
+          system: systemPrompt,
+          messages: [...historyMessages, { role: MessageRole.User, content: text }],
           stream: true,
           abortSignal: abortController.signal,
         });
@@ -370,12 +455,12 @@ export const handleSlackEvent = async ({
       await postMessage(botToken, { channel, thread_ts: threadTs, text: part });
     }
 
-    // Persist the conversation round
+    // Persist the conversation round and update session SO
     const now = new Date().toISOString();
     if (existingConvId) {
       const existing = await storage.get({ id: existingConvId });
       if (existing.found) {
-        const rounds = (existing._source?.conversation_rounds as unknown[]) ?? [];
+        const rounds = (existing._source?.conversation_rounds as Array<Record<string, unknown>>) ?? [];
         await storage.index({
           id: existingConvId,
           document: {
@@ -383,43 +468,80 @@ export const handleSlackEvent = async ({
             conversation_rounds: [
               ...rounds,
               {
-                request: { message: text },
+                id: `round-${uuidv4()}`,
+                status: 'completed',
+                input: { message: text },
+                steps: [],
                 response: { message: responseText },
+                started_at: now,
+                time_to_first_token: 0,
+                time_to_last_token: 0,
+                model_usage: {
+                  connector_id: resolvedConnectorId,
+                  llm_calls: 1,
+                  input_tokens: 0,
+                  output_tokens: 0,
+                },
               },
             ],
-            state: {
-              ...(existing._source?.state as Record<string, unknown>),
-              location: originRef,
-              located_at: now,
-            },
             updated_at: now,
           },
         });
+        // Update session SO location — stored outside the conversation doc so agentBuilder
+        // full-document replaces can't overwrite it.
+        await soClient.update<SlackSessionAttributes>(
+          SLACK_SESSION_SO_TYPE,
+          slackSessionSoId(existingConvId),
+          { location: originRef, located_at: now, updated_at: now }
+        );
       }
     } else {
+      // Create new conversation document and session SO
+      const newConvId = uuidv4();
       await storage.index({
-        id: uuidv4(),
+        id: newConvId,
         document: {
-          agent_id: 'elastic-console-slack',
+          agent_id: 'elastic-ai-agent',
           title: text.slice(0, 100),
           conversation_rounds: [
             {
-              request: { message: text },
+              id: `round-${uuidv4()}`,
+              status: 'completed',
+              input: { message: text },
+              steps: [],
               response: { message: responseText },
+              started_at: now,
+              time_to_first_token: 0,
+              time_to_last_token: 0,
+              model_usage: {
+                connector_id: resolvedConnectorId,
+                llm_calls: 1,
+                input_tokens: 0,
+                output_tokens: 0,
+              },
             },
           ],
+          user_id: kibanaUser?.userId,
+          user_name: kibanaUser?.username,
           space,
           created_at: now,
           updated_at: now,
-          state: {
-            origin_ref: originRef,
-            origin_location: originRef,
-            location: originRef,
-            located_at: now,
-            connector_id: resolvedConnectorId,
-          },
         },
       });
+      await soClient.create<SlackSessionAttributes>(
+        SLACK_SESSION_SO_TYPE,
+        {
+          origin_ref: originRef,
+          origin_location: originRef,
+          location: originRef,
+          connector_id: resolvedConnectorId,
+          fork_context: null,
+          handoff_summary: null,
+          located_at: now,
+          updated_at: now,
+        },
+        { id: slackSessionSoId(newConvId), overwrite: true }
+      );
     }
   } catch (error) {
     logger.error(`Slack handler error: ${(error as Error).message}`);

--- a/x-pack/platform/plugins/shared/elastic_console/server/lib/slack_handler.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/lib/slack_handler.ts
@@ -1,0 +1,436 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { v4 as uuidv4 } from 'uuid';
+import type { CoreStart, KibanaRequest, Logger } from '@kbn/core/server';
+import type { InferenceServerStart } from '@kbn/inference-plugin/server';
+import { MessageRole, ChatCompletionEventType } from '@kbn/inference-common';
+import { createConversationStorage } from './conversation_storage';
+import { resolveConnector } from './resolve_connector';
+import {
+  postMessage,
+  createStreamUpdater,
+  splitAtParagraph,
+  MAX_SLACK_MSG_LEN,
+} from './slack_client';
+import { markdownToMrkdwn } from './slack_format';
+
+// ---------------------------------------------------------------------------
+// Command patterns
+// ---------------------------------------------------------------------------
+
+const FORK_RE = /^fork$/i;
+const STATUS_RE = /^status$/i;
+const RESET_RE = /^(?:reset|new\s+session)$/i;
+
+// ---------------------------------------------------------------------------
+// Dedup guard — prevents processing the same Slack event twice
+// (Slack retries events that don't receive a timely 200 response)
+// ---------------------------------------------------------------------------
+
+const inFlightEvents = new Set<string>();
+
+// ---------------------------------------------------------------------------
+// Conversation lookup helpers
+// ---------------------------------------------------------------------------
+
+const getSpace = (basePath: string): string => {
+  const spaceMatch = basePath.match(/(?:^|\/)s\/([^/]+)/);
+  return spaceMatch ? spaceMatch[1] : 'default';
+};
+
+const findConversationByOriginRef = async (
+  storage: ReturnType<typeof createConversationStorage>,
+  originRef: string
+): Promise<{ id: string; state: Record<string, unknown> } | null> => {
+  const results = await storage.search({
+    track_total_hits: false,
+    size: 1,
+    query: { bool: { filter: [{ term: { 'state.origin_ref': originRef } }] } },
+  });
+
+  const hit = results.hits.hits[0];
+  if (!hit?._id) return null;
+
+  return {
+    id: hit._id,
+    state: (hit._source?.state as Record<string, unknown>) ?? {},
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Main event handler
+// ---------------------------------------------------------------------------
+
+export interface SlackEvent {
+  type: string;
+  ts: string;
+  channel: string;
+  thread_ts?: string;
+  text?: string;
+  user?: string;
+}
+
+export const handleSlackEvent = async ({
+  event,
+  botToken,
+  coreStart,
+  inference,
+  request,
+  logger,
+}: {
+  event: SlackEvent;
+  botToken: string;
+  coreStart: CoreStart;
+  inference: InferenceServerStart;
+  request: KibanaRequest;
+  logger: Logger;
+}): Promise<void> => {
+  if (event.type !== 'app_mention' && event.type !== 'message') return;
+
+  const channel = event.channel;
+  const threadTs = event.thread_ts ?? event.ts;
+  const originRef = `slack:${channel}:${threadTs}`;
+  const text = (event.text ?? '').replace(/<@\w+>\s*/g, '').trim();
+
+  // Deduplicate: Slack retries events that don't receive a timely response.
+  if (inFlightEvents.has(event.ts)) {
+    logger.debug(`Dropping duplicate Slack event ${event.ts}`);
+    return;
+  }
+  inFlightEvents.add(event.ts);
+  setTimeout(() => inFlightEvents.delete(event.ts), 10 * 60 * 1000);
+
+  if (!text) {
+    await postMessage(botToken, {
+      channel,
+      thread_ts: threadTs,
+      text: 'Mention me with a question.',
+    });
+    return;
+  }
+
+  const esClient = coreStart.elasticsearch.client.asInternalUser;
+  const basePath = coreStart.http.basePath.get(request);
+  const space = getSpace(basePath);
+  const storage = createConversationStorage({ esClient, logger });
+
+  try {
+    // --- Command: status ---
+    if (STATUS_RE.test(text)) {
+      const conv = await findConversationByOriginRef(storage, originRef);
+      const lines = ['*Elastic Console — session status*'];
+      if (conv) {
+        const state = conv.state;
+        lines.push(`• Conversation: active`);
+        if (state.location) lines.push(`• Location: \`${state.location}\``);
+        if (state.located_at) {
+          const ageMs = Date.now() - new Date(state.located_at as string).getTime();
+          const ageStr =
+            ageMs < 60_000
+              ? 'just now'
+              : ageMs < 3_600_000
+              ? `${Math.floor(ageMs / 60_000)}m ago`
+              : `${Math.floor(ageMs / 3_600_000)}h ago`;
+          lines.push(`• Last activity: ${ageStr}`);
+        }
+      } else {
+        lines.push('• No active session in this thread.');
+      }
+      await postMessage(botToken, { channel, thread_ts: threadTs, text: lines.join('\n') });
+      return;
+    }
+
+    // --- Command: reset ---
+    if (RESET_RE.test(text)) {
+      const conv = await findConversationByOriginRef(storage, originRef);
+      if (conv) {
+        const fullConv = await storage.get({ id: conv.id });
+        if (fullConv.found) {
+          await storage.index({
+            id: conv.id,
+            document: {
+              ...fullConv._source,
+              conversation_rounds: [],
+              state: {
+                ...(fullConv._source?.state as Record<string, unknown>),
+                location: originRef,
+                located_at: new Date().toISOString(),
+              },
+              updated_at: new Date().toISOString(),
+            },
+          });
+        }
+      }
+      await postMessage(botToken, { channel, thread_ts: threadTs, text: 'Session reset.' });
+      return;
+    }
+
+    // --- Command: fork ---
+    if (FORK_RE.test(text)) {
+      const conv = await findConversationByOriginRef(storage, originRef);
+      if (!conv) {
+        await postMessage(botToken, {
+          channel,
+          thread_ts: threadTs,
+          text: 'Cannot fork: no active session in this thread.',
+        });
+        return;
+      }
+
+      const fullConv = await storage.get({ id: conv.id });
+      if (!fullConv.found) {
+        await postMessage(botToken, {
+          channel,
+          thread_ts: threadTs,
+          text: 'Cannot fork: session not found.',
+        });
+        return;
+      }
+
+      const rounds =
+        (fullConv._source?.conversation_rounds as Array<Record<string, unknown>>) ?? [];
+      if (rounds.length === 0) {
+        await postMessage(botToken, {
+          channel,
+          thread_ts: threadTs,
+          text: 'Cannot fork: no conversation history yet.',
+        });
+        return;
+      }
+
+      const lastRound = rounds[rounds.length - 1];
+      const forkContext =
+        ((lastRound?.response as Record<string, unknown> | undefined)?.message as string) ?? '';
+
+      // Carry the connector_id from the parent conversation into the fork
+      const parentConnectorId = (fullConv._source?.state as Record<string, unknown> | undefined)
+        ?.connector_id as string | undefined;
+
+      const forkId = uuidv4();
+      const now = new Date().toISOString();
+
+      await storage.index({
+        id: forkId,
+        document: {
+          agent_id: fullConv._source?.agent_id,
+          title: `Fork of ${conv.id}`,
+          conversation_rounds: [],
+          user_id: fullConv._source?.user_id,
+          user_name: fullConv._source?.user_name,
+          space,
+          created_at: now,
+          updated_at: now,
+          state: {
+            fork_context: forkContext,
+            origin_ref: originRef,
+            origin_location: originRef,
+            connector_id: parentConnectorId ?? null,
+            location: null,
+          },
+        },
+      });
+
+      await postMessage(botToken, {
+        channel,
+        thread_ts: threadTs,
+        text: [
+          `*Session forked*`,
+          ``,
+          `*Claude Code*`,
+          '```',
+          `norb fork ${forkId} --agent claude`,
+          '```',
+          `*Cursor*`,
+          '```',
+          `norb fork ${forkId} --agent cursor`,
+          '```',
+        ].join('\n'),
+      });
+      return;
+    }
+
+    // --- Regular question — find or create conversation, call inference ---
+
+    const existingConv = await findConversationByOriginRef(storage, originRef);
+    let existingConvId: string | null = null;
+    let conversationId: string | undefined;
+
+    if (existingConv) {
+      const fullConv = await storage.get({ id: existingConv.id });
+      if (fullConv.found) {
+        existingConvId = existingConv.id;
+        const rounds =
+          (fullConv._source?.conversation_rounds as Array<Record<string, unknown>>) ?? [];
+        if (rounds.length > 0) {
+          conversationId = existingConv.id;
+        }
+      }
+    }
+
+    // Post a placeholder and start streaming
+    const streamTs = await postMessage(botToken, {
+      channel,
+      thread_ts: threadTs,
+      text: `_Thinking…_`,
+    });
+
+    const updater = createStreamUpdater(botToken, channel, streamTs, threadTs, (err) => {
+      logger.warn(`Stream update failed: ${err.message}`);
+    });
+
+    const statusLines: string[] = [];
+    const responseChunks: string[] = [];
+    const STATUS_VISIBLE = 3;
+
+    const buildStreamText = (): string => {
+      let msg = '';
+      if (statusLines.length) {
+        const hidden = statusLines.length - STATUS_VISIBLE;
+        const visible = statusLines.slice(-STATUS_VISIBLE);
+        if (hidden > 0) msg += `> _…and ${hidden} earlier step${hidden === 1 ? '' : 's'}_\n`;
+        msg += visible.map((l) => `> ${l}`).join('\n') + '\n';
+      }
+      const partial = responseChunks.join('');
+      if (partial) {
+        if (statusLines.length) msg += '\n';
+        const formatted = markdownToMrkdwn(partial);
+        const available = MAX_SLACK_MSG_LEN - msg.length;
+        msg +=
+          formatted.length > available
+            ? formatted.slice(0, Math.max(0, available)) + '…'
+            : formatted;
+      }
+      return msg || `_Thinking…_`;
+    };
+
+    // Resolve connector: use the one stored in conversation state, or fall back to default
+    const stateConnectorId = existingConv?.state?.connector_id as string | undefined;
+    const resolvedConnectorId = await resolveConnector(
+      inference,
+      request,
+      stateConnectorId ?? 'default'
+    );
+
+    // Call inference plugin directly via Observable
+    const inferenceClient = inference.getClient({ request });
+    const abortController = new AbortController();
+
+    let responseText = '';
+
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const events$ = inferenceClient.chatComplete({
+          connectorId: resolvedConnectorId,
+          conversationId,
+          messages: [{ role: MessageRole.User, content: text }],
+          stream: true,
+          abortSignal: abortController.signal,
+        });
+
+        events$.subscribe({
+          next: (chunk) => {
+            if (chunk.type === ChatCompletionEventType.ChatCompletionChunk) {
+              const content = (chunk as { type: string; content: string }).content ?? '';
+              if (content) {
+                responseChunks.push(content);
+                updater.schedule(buildStreamText());
+              }
+              const toolCalls = (
+                chunk as { type: string; tool_calls?: Array<{ function?: { name: string } }> }
+              ).tool_calls;
+              if (toolCalls?.length) {
+                const toolName = toolCalls[0]?.function?.name ?? 'tool';
+                statusLines.push(`🛠️ _Calling \`${toolName}\`_`);
+                updater.schedule(buildStreamText());
+              }
+            }
+          },
+          error: reject,
+          complete: resolve,
+        });
+      });
+    } catch (inferenceError) {
+      logger.error(`Inference error in Slack handler: ${(inferenceError as Error).message}`);
+      await updater.finalize(`⚠️ Error: ${(inferenceError as Error).message}`);
+      return;
+    }
+
+    responseText = responseChunks.join('');
+
+    const formatted = markdownToMrkdwn(responseText);
+    const parts = splitAtParagraph(formatted, MAX_SLACK_MSG_LEN);
+
+    await updater.finalize(parts[0] ?? '_No response_');
+    for (const part of parts.slice(1)) {
+      await postMessage(botToken, { channel, thread_ts: threadTs, text: part });
+    }
+
+    // Persist the conversation round
+    const now = new Date().toISOString();
+    if (existingConvId) {
+      const existing = await storage.get({ id: existingConvId });
+      if (existing.found) {
+        const rounds = (existing._source?.conversation_rounds as unknown[]) ?? [];
+        await storage.index({
+          id: existingConvId,
+          document: {
+            ...existing._source,
+            conversation_rounds: [
+              ...rounds,
+              {
+                request: { message: text },
+                response: { message: responseText },
+              },
+            ],
+            state: {
+              ...(existing._source?.state as Record<string, unknown>),
+              location: originRef,
+              located_at: now,
+            },
+            updated_at: now,
+          },
+        });
+      }
+    } else {
+      await storage.index({
+        id: uuidv4(),
+        document: {
+          agent_id: 'elastic-console-slack',
+          title: text.slice(0, 100),
+          conversation_rounds: [
+            {
+              request: { message: text },
+              response: { message: responseText },
+            },
+          ],
+          space,
+          created_at: now,
+          updated_at: now,
+          state: {
+            origin_ref: originRef,
+            origin_location: originRef,
+            location: originRef,
+            located_at: now,
+            connector_id: resolvedConnectorId,
+          },
+        },
+      });
+    }
+  } catch (error) {
+    logger.error(`Slack handler error: ${(error as Error).message}`);
+    try {
+      await postMessage(botToken, {
+        channel,
+        thread_ts: threadTs,
+        text: `⚠️ Error: ${(error as Error).message}`,
+      });
+    } catch {
+      // best-effort
+    }
+  }
+};

--- a/x-pack/platform/plugins/shared/elastic_console/server/lib/slack_handler.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/lib/slack_handler.ts
@@ -60,7 +60,8 @@ const getSpace = (basePath: string): string => {
  */
 const findSessionByOriginRef = async (
   coreStart: CoreStart,
-  originRef: string
+  originRef: string,
+  logger: Logger
 ): Promise<{ conversationId: string; session: SlackSessionAttributes } | null> => {
   try {
     const soClient = coreStart.savedObjects.createInternalRepository([SLACK_SESSION_SO_TYPE]);
@@ -77,7 +78,11 @@ const findSessionByOriginRef = async (
       conversationId: conversationIdFromSoId(so.id),
       session: so.attributes,
     };
-  } catch {
+  } catch (err) {
+    // A failure here means the thread will be treated as a new conversation — data continuity loss.
+    logger.error(
+      `Session lookup failed for ${originRef} — thread will start a new conversation: ${(err as Error).message}`
+    );
     return null;
   }
 };
@@ -163,7 +168,7 @@ export const handleSlackEvent = async ({
   try {
     // --- Command: status ---
     if (STATUS_RE.test(text)) {
-      const existing = await findSessionByOriginRef(coreStart, originRef);
+      const existing = await findSessionByOriginRef(coreStart, originRef, logger);
       const lines = ['*Elastic Console — session status*'];
       if (existing) {
         const { session } = existing;
@@ -188,7 +193,7 @@ export const handleSlackEvent = async ({
 
     // --- Command: reset ---
     if (RESET_RE.test(text)) {
-      const existing = await findSessionByOriginRef(coreStart, originRef);
+      const existing = await findSessionByOriginRef(coreStart, originRef, logger);
       if (existing) {
         const { conversationId, session } = existing;
         const fullConv = await storage.get({ id: conversationId });
@@ -217,7 +222,7 @@ export const handleSlackEvent = async ({
 
     // --- Command: fork ---
     if (FORK_RE.test(text)) {
-      const existing = await findSessionByOriginRef(coreStart, originRef);
+      const existing = await findSessionByOriginRef(coreStart, originRef, logger);
       if (!existing) {
         await postMessage(botToken, {
           channel,
@@ -307,7 +312,7 @@ export const handleSlackEvent = async ({
 
     // --- Regular question — find or create conversation, call inference ---
 
-    const existingSession = await findSessionByOriginRef(coreStart, originRef);
+    const existingSession = await findSessionByOriginRef(coreStart, originRef, logger);
     let existingConvId: string | null = null;
     let existingRounds: Array<Record<string, unknown>> = [];
 
@@ -344,9 +349,14 @@ export const handleSlackEvent = async ({
       text: `_Thinking…_`,
     });
 
-    const updater = createStreamUpdater(botToken, channel, streamTs, threadTs, (err) => {
-      logger.warn(`Stream update failed: ${err.message}`);
-    });
+    const updater = createStreamUpdater(
+      botToken,
+      channel,
+      streamTs,
+      threadTs,
+      (err) => logger.warn(`Stream update failed: ${err.message}`),
+      (err) => logger.warn(`Stream finalize fell back to new message (original deleted?): ${err.message}`)
+    );
 
     const statusLines: string[] = [];
     const responseChunks: string[] = [];
@@ -458,19 +468,58 @@ export const handleSlackEvent = async ({
       await postMessage(botToken, { channel, thread_ts: threadTs, text: part });
     }
 
-    // Persist the conversation round and update session SO
+    // Persist the conversation round and update session SO.
+    // Failure here means the user received a response but the round was not saved — log as error.
     const now = new Date().toISOString();
-    if (existingConvId) {
-      const existing = await storage.get({ id: existingConvId });
-      if (existing.found) {
-        const rounds =
-          (existing._source?.conversation_rounds as Array<Record<string, unknown>>) ?? [];
+    try {
+      if (existingConvId) {
+        const existing = await storage.get({ id: existingConvId });
+        if (existing.found) {
+          const rounds =
+            (existing._source?.conversation_rounds as Array<Record<string, unknown>>) ?? [];
+          await storage.index({
+            id: existingConvId,
+            document: {
+              ...existing._source,
+              conversation_rounds: [
+                ...rounds,
+                {
+                  id: `round-${uuidv4()}`,
+                  status: 'completed',
+                  input: { message: text },
+                  steps: [],
+                  response: { message: responseText },
+                  started_at: now,
+                  time_to_first_token: 0,
+                  time_to_last_token: 0,
+                  model_usage: {
+                    connector_id: resolvedConnectorId,
+                    llm_calls: 1,
+                    input_tokens: 0,
+                    output_tokens: 0,
+                  },
+                },
+              ],
+              updated_at: now,
+            },
+          });
+          // Update session SO location — stored outside the conversation doc so agentBuilder
+          // full-document replaces can't overwrite it.
+          await soClient.update<SlackSessionAttributes>(
+            SLACK_SESSION_SO_TYPE,
+            slackSessionSoId(existingConvId),
+            { location: originRef, located_at: now, updated_at: now }
+          );
+        }
+      } else {
+        // Create new conversation document and session SO
+        const newConvId = uuidv4();
         await storage.index({
-          id: existingConvId,
+          id: newConvId,
           document: {
-            ...existing._source,
+            agent_id: 'elastic-ai-agent',
+            title: text.slice(0, 100),
             conversation_rounds: [
-              ...rounds,
               {
                 id: `round-${uuidv4()}`,
                 status: 'completed',
@@ -488,63 +537,32 @@ export const handleSlackEvent = async ({
                 },
               },
             ],
+            user_id: kibanaUser?.userId,
+            user_name: kibanaUser?.username,
+            space,
+            created_at: now,
             updated_at: now,
           },
         });
-        // Update session SO location — stored outside the conversation doc so agentBuilder
-        // full-document replaces can't overwrite it.
-        await soClient.update<SlackSessionAttributes>(
+        await soClient.create<SlackSessionAttributes>(
           SLACK_SESSION_SO_TYPE,
-          slackSessionSoId(existingConvId),
-          { location: originRef, located_at: now, updated_at: now }
+          {
+            origin_ref: originRef,
+            origin_location: originRef,
+            location: originRef,
+            connector_id: resolvedConnectorId,
+            fork_context: null,
+            handoff_summary: null,
+            located_at: now,
+            updated_at: now,
+          },
+          { id: slackSessionSoId(newConvId), overwrite: true }
         );
       }
-    } else {
-      // Create new conversation document and session SO
-      const newConvId = uuidv4();
-      await storage.index({
-        id: newConvId,
-        document: {
-          agent_id: 'elastic-ai-agent',
-          title: text.slice(0, 100),
-          conversation_rounds: [
-            {
-              id: `round-${uuidv4()}`,
-              status: 'completed',
-              input: { message: text },
-              steps: [],
-              response: { message: responseText },
-              started_at: now,
-              time_to_first_token: 0,
-              time_to_last_token: 0,
-              model_usage: {
-                connector_id: resolvedConnectorId,
-                llm_calls: 1,
-                input_tokens: 0,
-                output_tokens: 0,
-              },
-            },
-          ],
-          user_id: kibanaUser?.userId,
-          user_name: kibanaUser?.username,
-          space,
-          created_at: now,
-          updated_at: now,
-        },
-      });
-      await soClient.create<SlackSessionAttributes>(
-        SLACK_SESSION_SO_TYPE,
-        {
-          origin_ref: originRef,
-          origin_location: originRef,
-          location: originRef,
-          connector_id: resolvedConnectorId,
-          fork_context: null,
-          handoff_summary: null,
-          located_at: now,
-          updated_at: now,
-        },
-        { id: slackSessionSoId(newConvId), overwrite: true }
+    } catch (persistErr) {
+      // Response was already sent to Slack — this is a data loss scenario.
+      logger.error(
+        `Failed to persist conversation round for thread ${originRef}: ${(persistErr as Error).message}`
       );
     }
   } catch (error) {

--- a/x-pack/platform/plugins/shared/elastic_console/server/lib/slack_handler.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/lib/slack_handler.ts
@@ -286,8 +286,7 @@ export const handleSlackEvent = async ({
         { id: slackSessionSoId(forkId), overwrite: true }
       );
 
-      const kibanaBase =
-        coreStart.http.basePath.publicBaseUrl ?? '';
+      const kibanaBase = coreStart.http.basePath.publicBaseUrl ?? '';
       const kibanaConvUrl = `${kibanaBase}/app/agent-builder/conversations/${forkId}`;
 
       await postMessage(botToken, {
@@ -385,8 +384,12 @@ export const handleSlackEvent = async ({
     // The inference plugin is a raw LLM interface — it doesn't load conversation
     // history itself, so we pass all prior rounds as messages.
     const historyMessages = existingRounds.flatMap((round) => {
-      const input = (round.input as Record<string, unknown> | undefined)?.message as string | undefined;
-      const responseMsg = (round.response as Record<string, unknown> | undefined)?.message as string | undefined;
+      const input = (round.input as Record<string, unknown> | undefined)?.message as
+        | string
+        | undefined;
+      const responseMsg = (round.response as Record<string, unknown> | undefined)?.message as
+        | string
+        | undefined;
       const msgs: Message[] = [];
       if (input) msgs.push({ role: MessageRole.User, content: input });
       if (responseMsg) msgs.push({ role: MessageRole.Assistant, content: responseMsg } as Message);
@@ -460,7 +463,8 @@ export const handleSlackEvent = async ({
     if (existingConvId) {
       const existing = await storage.get({ id: existingConvId });
       if (existing.found) {
-        const rounds = (existing._source?.conversation_rounds as Array<Record<string, unknown>>) ?? [];
+        const rounds =
+          (existing._source?.conversation_rounds as Array<Record<string, unknown>>) ?? [];
         await storage.index({
           id: existingConvId,
           document: {

--- a/x-pack/platform/plugins/shared/elastic_console/server/lib/slack_session_so.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/lib/slack_session_so.ts
@@ -23,7 +23,9 @@ export const slackSessionSoId = (conversationId: string): string =>
   `${SLACK_SESSION_SO_ID_PREFIX}${conversationId}`;
 
 export const conversationIdFromSoId = (soId: string): string =>
-  soId.startsWith(SLACK_SESSION_SO_ID_PREFIX) ? soId.slice(SLACK_SESSION_SO_ID_PREFIX.length) : soId;
+  soId.startsWith(SLACK_SESSION_SO_ID_PREFIX)
+    ? soId.slice(SLACK_SESSION_SO_ID_PREFIX.length)
+    : soId;
 
 export interface SlackSessionAttributes {
   /** Slack thread identifier, e.g. "slack:C0AMREPCC0J:1773986596.210179" */

--- a/x-pack/platform/plugins/shared/elastic_console/server/lib/slack_session_so.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/lib/slack_session_so.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * Saved Object type for tracking Slack session state per conversation.
+ *
+ * Stored separately from the conversation document so that agentBuilder's
+ * full document replace cannot overwrite Slack routing metadata.
+ *
+ * SO ID: `conv:<conversationId>` — allows O(1) lookup by conversation ID.
+ * Searchable by `origin_ref` attribute to find the conversation for a Slack thread.
+ */
+
+export const SLACK_SESSION_SO_TYPE = 'elastic-console-slack-session';
+
+export const SLACK_SESSION_SO_ID_PREFIX = 'conv:';
+
+export const slackSessionSoId = (conversationId: string): string =>
+  `${SLACK_SESSION_SO_ID_PREFIX}${conversationId}`;
+
+export const conversationIdFromSoId = (soId: string): string =>
+  soId.startsWith(SLACK_SESSION_SO_ID_PREFIX) ? soId.slice(SLACK_SESSION_SO_ID_PREFIX.length) : soId;
+
+export interface SlackSessionAttributes {
+  /** Slack thread identifier, e.g. "slack:C0AMREPCC0J:1773986596.210179" */
+  origin_ref: string;
+  /** Current surface location (slack thread, cli, mcp, etc.) */
+  location: string | null;
+  /** Original Slack thread location (preserved after fork/locate) */
+  origin_location: string | null;
+  /** Connector used in this conversation */
+  connector_id: string | null;
+  /** Context from parent conversation carried into a fork */
+  fork_context: string | null;
+  /** Summary posted back to Slack on handoff */
+  handoff_summary: string | null;
+  /** ISO timestamp of last location update */
+  located_at: string | null;
+  updated_at: string;
+}

--- a/x-pack/platform/plugins/shared/elastic_console/server/lib/slack_user_mapping_so.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/lib/slack_user_mapping_so.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+// Saved object type for Slack user → Kibana user mappings.
+// One document per Slack user, keyed by slack_user_id.
+// Allows conversations created from Slack to be attributed to the correct Kibana user.
+
+export const SLACK_USER_MAPPING_SO_TYPE = 'elastic-console-slack-user-mapping';
+
+export interface SlackUserMappingAttributes {
+  slack_user_id: string;
+  kibana_username: string;
+  kibana_user_id?: string;
+  created_at: string;
+  updated_at: string;
+}

--- a/x-pack/platform/plugins/shared/elastic_console/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/plugin.ts
@@ -15,6 +15,8 @@ import type {
 } from './types';
 import type { ElasticConsoleConfig } from './config';
 import { SLACK_CREDENTIALS_SO_TYPE } from './lib/slack_credentials_so';
+import { SLACK_USER_MAPPING_SO_TYPE } from './lib/slack_user_mapping_so';
+import { SLACK_SESSION_SO_TYPE } from './lib/slack_session_so';
 import { registerUiSettings } from './ui_settings';
 import { registerRoutes } from './routes';
 
@@ -47,7 +49,45 @@ export class ElasticConsolePlugin
       mappings: {
         dynamic: false,
         properties: {
-          bot_token: { type: 'binary' }, // encrypted at rest by ESO
+          bot_token: { type: 'keyword', index: false }, // encrypted at rest by ESO
+          kibana_api_key: { type: 'keyword', index: false }, // encrypted at rest by ESO
+          updated_at: { type: 'date' },
+        },
+      },
+    });
+
+    // Register SO type for Slack user → Kibana user mappings (one per Slack user)
+    coreSetup.savedObjects.registerType({
+      name: SLACK_USER_MAPPING_SO_TYPE,
+      hidden: true,
+      namespaceType: 'agnostic', // user identity is global, not space-scoped
+      mappings: {
+        dynamic: false,
+        properties: {
+          slack_user_id: { type: 'keyword' },
+          kibana_username: { type: 'keyword' },
+          kibana_user_id: { type: 'keyword', index: false },
+          created_at: { type: 'date' },
+          updated_at: { type: 'date' },
+        },
+      },
+    });
+
+    // Register SO type for Slack session state per conversation (survives agentBuilder updates)
+    coreSetup.savedObjects.registerType({
+      name: SLACK_SESSION_SO_TYPE,
+      hidden: true,
+      namespaceType: 'agnostic',
+      mappings: {
+        dynamic: false,
+        properties: {
+          origin_ref: { type: 'keyword' },
+          location: { type: 'keyword' },
+          origin_location: { type: 'keyword' },
+          connector_id: { type: 'keyword', index: false },
+          fork_context: { type: 'text', index: false },
+          handoff_summary: { type: 'text', index: false },
+          located_at: { type: 'date' },
           updated_at: { type: 'date' },
         },
       },
@@ -56,7 +96,7 @@ export class ElasticConsolePlugin
     // Tell ESO which attributes to encrypt
     setupDeps.encryptedSavedObjects.registerType({
       type: SLACK_CREDENTIALS_SO_TYPE,
-      attributesToEncrypt: new Set(['bot_token']),
+      attributesToEncrypt: new Set(['bot_token', 'kibana_api_key']),
     });
 
     registerUiSettings(coreSetup);

--- a/x-pack/platform/plugins/shared/elastic_console/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/plugin.ts
@@ -13,6 +13,8 @@ import type {
   ElasticConsoleSetupDependencies,
   ElasticConsoleStartDependencies,
 } from './types';
+import type { ElasticConsoleConfig } from './config';
+import { SLACK_CREDENTIALS_SO_TYPE } from './lib/slack_credentials_so';
 import { registerUiSettings } from './ui_settings';
 import { registerRoutes } from './routes';
 
@@ -26,15 +28,37 @@ export class ElasticConsolePlugin
     >
 {
   private logger: Logger;
+  private config: ElasticConsoleConfig;
 
   constructor(context: PluginInitializerContext) {
     this.logger = context.logger.get();
+    this.config = context.config.get<ElasticConsoleConfig>();
   }
 
   setup(
     coreSetup: CoreSetup<ElasticConsoleStartDependencies, ElasticConsolePluginStart>,
     setupDeps: ElasticConsoleSetupDependencies
   ): ElasticConsolePluginSetup {
+    // Register the saved object type for Slack credentials (bot token)
+    coreSetup.savedObjects.registerType({
+      name: SLACK_CREDENTIALS_SO_TYPE,
+      hidden: true,
+      namespaceType: 'agnostic', // global singleton — one per Kibana instance
+      mappings: {
+        dynamic: false,
+        properties: {
+          bot_token: { type: 'binary' }, // encrypted at rest by ESO
+          updated_at: { type: 'date' },
+        },
+      },
+    });
+
+    // Tell ESO which attributes to encrypt
+    setupDeps.encryptedSavedObjects.registerType({
+      type: SLACK_CREDENTIALS_SO_TYPE,
+      attributesToEncrypt: new Set(['bot_token']),
+    });
+
     registerUiSettings(coreSetup);
 
     const router = coreSetup.http.createRouter();
@@ -44,6 +68,7 @@ export class ElasticConsolePlugin
       coreSetup,
       logger: this.logger,
       cloud: setupDeps.cloud,
+      config: this.config,
     });
 
     return {};

--- a/x-pack/platform/plugins/shared/elastic_console/server/routes/conversation_sessions.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/routes/conversation_sessions.ts
@@ -1,0 +1,290 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { v4 as uuidv4 } from 'uuid';
+import { schema } from '@kbn/config-schema';
+import type { CoreSetup, IRouter, Logger } from '@kbn/core/server';
+import type { ElasticConsolePluginStart, ElasticConsoleStartDependencies } from '../types';
+import { createConversationStorage } from '../lib/conversation_storage';
+import { SLACK_CREDENTIALS_SO_TYPE, SLACK_CREDENTIALS_SO_ID } from '../lib/slack_credentials_so';
+import { sendHandoffNotification } from '../lib/notification_service';
+import { isElasticConsoleEnabled } from './is_enabled';
+
+const getSpace = (basePath: string): string => {
+  const spaceMatch = basePath.match(/(?:^|\/)s\/([^/]+)/);
+  return spaceMatch ? spaceMatch[1] : 'default';
+};
+
+export const registerConversationSessionRoutes = ({
+  router,
+  coreSetup,
+  logger,
+}: {
+  router: IRouter;
+  coreSetup: CoreSetup<ElasticConsoleStartDependencies, ElasticConsolePluginStart>;
+  logger: Logger;
+}) => {
+  // POST /internal/elastic_console/conversations/:id/fork
+  // Creates a new forked conversation seeded with the parent's last response.
+  router.post(
+    {
+      path: '/internal/elastic_console/conversations/{id}/fork',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route is called by external agents using router secret auth',
+        },
+      },
+      options: { access: 'internal' },
+      validate: {
+        params: schema.object({ id: schema.string() }),
+        body: schema.object({
+          origin_ref: schema.string(),
+          origin_location: schema.string(),
+          connector_id: schema.maybe(schema.string()),
+        }),
+      },
+    },
+    async (ctx, request, response) => {
+      try {
+        const [coreStart] = await coreSetup.getStartServices();
+
+        if (!(await isElasticConsoleEnabled(coreStart, request))) {
+          return response.notFound();
+        }
+
+        const esClient = coreStart.elasticsearch.client.asScoped(request).asInternalUser;
+        const storage = createConversationStorage({ esClient, logger });
+
+        const parent = await storage.get({ id: request.params.id });
+        if (!parent.found) {
+          return response.notFound({ body: { message: 'Conversation not found' } });
+        }
+
+        const rounds =
+          (parent._source?.conversation_rounds as Array<Record<string, unknown>>) ?? [];
+        if (rounds.length === 0) {
+          return response.badRequest({
+            body: { message: 'Cannot fork a conversation with no history yet' },
+          });
+        }
+
+        const lastRound = rounds[rounds.length - 1];
+        const forkContext =
+          (lastRound?.response as Record<string, unknown> | undefined)?.message ?? '';
+
+        const { origin_ref, origin_location, connector_id } = request.body;
+
+        const id = uuidv4();
+        const now = new Date().toISOString();
+        const basePath = coreStart.http.basePath.get(request);
+        const space = getSpace(basePath);
+
+        await storage.index({
+          id,
+          document: {
+            agent_id: parent._source?.agent_id,
+            title: `Fork of ${request.params.id}`,
+            conversation_rounds: [],
+            user_id: parent._source?.user_id,
+            user_name: parent._source?.user_name,
+            space,
+            created_at: now,
+            updated_at: now,
+            state: {
+              fork_context: forkContext,
+              origin_ref,
+              origin_location,
+              connector_id: connector_id ?? null,
+              location: null,
+            },
+          },
+        });
+
+        return response.ok({ body: { id, fork_context: forkContext } });
+      } catch (error) {
+        logger.error(`Fork conversation error: ${error.message}`);
+        return response.customError({
+          statusCode: error.statusCode || 500,
+          body: { message: error.message },
+        });
+      }
+    }
+  );
+
+  // POST /internal/elastic_console/conversations/:id/locate
+  // Moves a conversation to a new location (e.g. cli, mcp).
+  // On first Slack→other transition, captures origin fields automatically.
+  router.post(
+    {
+      path: '/internal/elastic_console/conversations/{id}/locate',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route is called by external agents using router secret auth',
+        },
+      },
+      options: { access: 'internal' },
+      validate: {
+        params: schema.object({ id: schema.string() }),
+        body: schema.object({ location: schema.string() }),
+      },
+    },
+    async (ctx, request, response) => {
+      try {
+        const [coreStart] = await coreSetup.getStartServices();
+
+        if (!(await isElasticConsoleEnabled(coreStart, request))) {
+          return response.notFound();
+        }
+
+        const esClient = coreStart.elasticsearch.client.asScoped(request).asInternalUser;
+        const storage = createConversationStorage({ esClient, logger });
+
+        const result = await storage.get({ id: request.params.id });
+        if (!result.found) {
+          return response.notFound({ body: { message: 'Conversation not found' } });
+        }
+
+        const currentState = (result._source?.state as Record<string, unknown>) ?? {};
+        const currentLocation = currentState.location as string | undefined;
+        const forkContext = currentState.fork_context as string | undefined;
+        const { location } = request.body;
+
+        // Detect first Slack→other transition and capture origin fields
+        const isSlackOrigin =
+          typeof currentLocation === 'string' && currentLocation.startsWith('slack:');
+        const isMovingOut = location !== currentLocation;
+        const originNotSet = !currentState.origin_location;
+
+        const stateUpdates: Record<string, unknown> = {
+          location,
+          located_at: new Date().toISOString(),
+          fork_context: null,
+        };
+
+        if (isSlackOrigin && isMovingOut && originNotSet) {
+          stateUpdates.origin_location = currentLocation;
+          stateUpdates.origin_ref = currentLocation;
+        }
+
+        const updatedDoc = {
+          ...result._source,
+          state: { ...currentState, ...stateUpdates },
+          updated_at: new Date().toISOString(),
+        };
+
+        await storage.index({ id: request.params.id, document: updatedDoc });
+
+        return response.ok({
+          body: { conversation: updatedDoc, fork_context: forkContext ?? null },
+        });
+      } catch (error) {
+        logger.error(`Locate conversation error: ${error.message}`);
+        return response.customError({
+          statusCode: error.statusCode || 500,
+          body: { message: error.message },
+        });
+      }
+    }
+  );
+
+  // POST /internal/elastic_console/conversations/:id/handoff
+  // Returns a conversation to its origin location.
+  // Slack notification is handled separately by the Slack handler.
+  router.post(
+    {
+      path: '/internal/elastic_console/conversations/{id}/handoff',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route is called by external agents using router secret auth',
+        },
+      },
+      options: { access: 'internal' },
+      validate: {
+        params: schema.object({ id: schema.string() }),
+        body: schema.object({
+          summary: schema.maybe(schema.string()),
+        }),
+      },
+    },
+    async (ctx, request, response) => {
+      try {
+        const [coreStart, pluginsStart] = await coreSetup.getStartServices();
+
+        if (!(await isElasticConsoleEnabled(coreStart, request))) {
+          return response.notFound();
+        }
+
+        const esClient = coreStart.elasticsearch.client.asScoped(request).asInternalUser;
+        const storage = createConversationStorage({ esClient, logger });
+
+        const result = await storage.get({ id: request.params.id });
+        if (!result.found) {
+          return response.notFound({ body: { message: 'Conversation not found' } });
+        }
+
+        const currentState = (result._source?.state as Record<string, unknown>) ?? {};
+        const originLocation = currentState.origin_location as string | undefined;
+        const originRef = currentState.origin_ref as string | undefined;
+
+        const stateUpdates: Record<string, unknown> = {};
+        if (originLocation) {
+          stateUpdates.location = originLocation;
+        }
+        if (request.body.summary) {
+          stateUpdates.handoff_summary = request.body.summary;
+        }
+
+        await storage.index({
+          id: request.params.id,
+          document: {
+            ...result._source,
+            state: { ...currentState, ...stateUpdates },
+            updated_at: new Date().toISOString(),
+          },
+        });
+
+        // If the origin is Slack, post a notification to the original thread.
+        // Best-effort — a notification failure does not fail the handoff.
+        if (originRef?.startsWith('slack:')) {
+          setImmediate(async () => {
+            try {
+              const esoClient = pluginsStart.encryptedSavedObjects.getClient({
+                includedHiddenTypes: [SLACK_CREDENTIALS_SO_TYPE],
+              });
+              const creds = await esoClient.getDecryptedAsInternalUser<{ bot_token: string }>(
+                SLACK_CREDENTIALS_SO_TYPE,
+                SLACK_CREDENTIALS_SO_ID
+              );
+              await sendHandoffNotification(creds.attributes.bot_token, {
+                originRef,
+                summary: request.body.summary,
+              });
+            } catch (notifyErr) {
+              logger.warn(`Handoff Slack notification failed: ${(notifyErr as Error).message}`);
+            }
+          });
+        }
+
+        return response.ok({
+          body: {
+            origin_location: originLocation ?? null,
+            origin_ref: originRef ?? null,
+          },
+        });
+      } catch (error) {
+        logger.error(`Handoff conversation error: ${(error as Error).message}`);
+        return response.customError({
+          statusCode: (error as { statusCode?: number }).statusCode || 500,
+          body: { message: (error as Error).message },
+        });
+      }
+    }
+  );
+};

--- a/x-pack/platform/plugins/shared/elastic_console/server/routes/conversation_sessions.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/routes/conversation_sessions.ts
@@ -167,7 +167,7 @@ export const registerConversationSessionRoutes = ({
         const storage = createConversationStorage({ esClient, logger });
         const conv = await storage.get({ id: request.params.id });
         const existingRounds = conv.found
-          ? ((conv._source?.conversation_rounds as ConversationRound[]) ?? [])
+          ? (conv._source?.conversation_rounds as ConversationRound[]) ?? []
           : [];
 
         // The summary is stored in handoff_summary on the SO and injected into

--- a/x-pack/platform/plugins/shared/elastic_console/server/routes/conversation_sessions.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/routes/conversation_sessions.ts
@@ -32,18 +32,18 @@ export const registerConversationSessionRoutes = ({
   coreSetup: CoreSetup<ElasticConsoleStartDependencies, ElasticConsolePluginStart>;
   logger: Logger;
 }) => {
-  // POST /api/elastic_console/conversations/:id/locate
+  // POST /internal/elastic_console/conversations/:id/locate
   // Moves a conversation to a new location (e.g. cli, mcp).
   router.post(
     {
-      path: '/api/elastic_console/conversations/{id}/locate',
+      path: '/internal/elastic_console/conversations/{id}/locate',
       security: {
         authz: {
           enabled: false,
-          reason: 'This route is called by external agents using router secret auth',
+          reason: 'Caller authenticates via Kibana API key; no additional authz needed',
         },
       },
-      options: { access: 'public' },
+      options: { access: 'internal' },
       validate: {
         params: schema.object({ id: schema.string() }),
         body: schema.object({ location: schema.string() }),
@@ -104,18 +104,18 @@ export const registerConversationSessionRoutes = ({
     }
   );
 
-  // POST /api/elastic_console/conversations/:id/handoff
+  // POST /internal/elastic_console/conversations/:id/handoff
   // Returns a conversation to its origin location.
   router.post(
     {
-      path: '/api/elastic_console/conversations/{id}/handoff',
+      path: '/internal/elastic_console/conversations/{id}/handoff',
       security: {
         authz: {
           enabled: false,
-          reason: 'This route is called by external agents using router secret auth',
+          reason: 'Caller authenticates via Kibana API key; no additional authz needed',
         },
       },
-      options: { access: 'public' },
+      options: { access: 'internal' },
       validate: {
         params: schema.object({ id: schema.string() }),
         body: schema.object({

--- a/x-pack/platform/plugins/shared/elastic_console/server/routes/conversation_sessions.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/routes/conversation_sessions.ts
@@ -5,18 +5,22 @@
  * 2.0.
  */
 
-import { v4 as uuidv4 } from 'uuid';
 import { schema } from '@kbn/config-schema';
 import type { CoreSetup, IRouter, Logger } from '@kbn/core/server';
 import type { ElasticConsolePluginStart, ElasticConsoleStartDependencies } from '../types';
 import { createConversationStorage } from '../lib/conversation_storage';
 import { SLACK_CREDENTIALS_SO_TYPE, SLACK_CREDENTIALS_SO_ID } from '../lib/slack_credentials_so';
-import { sendHandoffNotification } from '../lib/notification_service';
+import {
+  SLACK_SESSION_SO_TYPE,
+  slackSessionSoId,
+  type SlackSessionAttributes,
+} from '../lib/slack_session_so';
+import { sendHandoffNotification, type ConversationRound } from '../lib/notification_service';
 import { isElasticConsoleEnabled } from './is_enabled';
 
-const getSpace = (basePath: string): string => {
-  const spaceMatch = basePath.match(/(?:^|\/)s\/([^/]+)/);
-  return spaceMatch ? spaceMatch[1] : 'default';
+const isNotFound = (error: unknown): boolean => {
+  const e = error as { statusCode?: number; meta?: { statusCode?: number } };
+  return e?.statusCode === 404 || e?.meta?.statusCode === 404;
 };
 
 export const registerConversationSessionRoutes = ({
@@ -28,107 +32,18 @@ export const registerConversationSessionRoutes = ({
   coreSetup: CoreSetup<ElasticConsoleStartDependencies, ElasticConsolePluginStart>;
   logger: Logger;
 }) => {
-  // POST /internal/elastic_console/conversations/:id/fork
-  // Creates a new forked conversation seeded with the parent's last response.
-  router.post(
-    {
-      path: '/internal/elastic_console/conversations/{id}/fork',
-      security: {
-        authz: {
-          enabled: false,
-          reason: 'This route is called by external agents using router secret auth',
-        },
-      },
-      options: { access: 'internal' },
-      validate: {
-        params: schema.object({ id: schema.string() }),
-        body: schema.object({
-          origin_ref: schema.string(),
-          origin_location: schema.string(),
-          connector_id: schema.maybe(schema.string()),
-        }),
-      },
-    },
-    async (ctx, request, response) => {
-      try {
-        const [coreStart] = await coreSetup.getStartServices();
-
-        if (!(await isElasticConsoleEnabled(coreStart, request))) {
-          return response.notFound();
-        }
-
-        const esClient = coreStart.elasticsearch.client.asScoped(request).asInternalUser;
-        const storage = createConversationStorage({ esClient, logger });
-
-        const parent = await storage.get({ id: request.params.id });
-        if (!parent.found) {
-          return response.notFound({ body: { message: 'Conversation not found' } });
-        }
-
-        const rounds =
-          (parent._source?.conversation_rounds as Array<Record<string, unknown>>) ?? [];
-        if (rounds.length === 0) {
-          return response.badRequest({
-            body: { message: 'Cannot fork a conversation with no history yet' },
-          });
-        }
-
-        const lastRound = rounds[rounds.length - 1];
-        const forkContext =
-          (lastRound?.response as Record<string, unknown> | undefined)?.message ?? '';
-
-        const { origin_ref, origin_location, connector_id } = request.body;
-
-        const id = uuidv4();
-        const now = new Date().toISOString();
-        const basePath = coreStart.http.basePath.get(request);
-        const space = getSpace(basePath);
-
-        await storage.index({
-          id,
-          document: {
-            agent_id: parent._source?.agent_id,
-            title: `Fork of ${request.params.id}`,
-            conversation_rounds: [],
-            user_id: parent._source?.user_id,
-            user_name: parent._source?.user_name,
-            space,
-            created_at: now,
-            updated_at: now,
-            state: {
-              fork_context: forkContext,
-              origin_ref,
-              origin_location,
-              connector_id: connector_id ?? null,
-              location: null,
-            },
-          },
-        });
-
-        return response.ok({ body: { id, fork_context: forkContext } });
-      } catch (error) {
-        logger.error(`Fork conversation error: ${error.message}`);
-        return response.customError({
-          statusCode: error.statusCode || 500,
-          body: { message: error.message },
-        });
-      }
-    }
-  );
-
-  // POST /internal/elastic_console/conversations/:id/locate
+  // POST /api/elastic_console/conversations/:id/locate
   // Moves a conversation to a new location (e.g. cli, mcp).
-  // On first Slack→other transition, captures origin fields automatically.
   router.post(
     {
-      path: '/internal/elastic_console/conversations/{id}/locate',
+      path: '/api/elastic_console/conversations/{id}/locate',
       security: {
         authz: {
           enabled: false,
           reason: 'This route is called by external agents using router secret auth',
         },
       },
-      options: { access: 'internal' },
+      options: { access: 'public' },
       validate: {
         params: schema.object({ id: schema.string() }),
         body: schema.object({ location: schema.string() }),
@@ -142,70 +57,65 @@ export const registerConversationSessionRoutes = ({
           return response.notFound();
         }
 
-        const esClient = coreStart.elasticsearch.client.asScoped(request).asInternalUser;
-        const storage = createConversationStorage({ esClient, logger });
+        const soClient = coreStart.savedObjects.createInternalRepository([SLACK_SESSION_SO_TYPE]);
+        const soId = slackSessionSoId(request.params.id);
 
-        const result = await storage.get({ id: request.params.id });
-        if (!result.found) {
-          return response.notFound({ body: { message: 'Conversation not found' } });
+        let sessionSo;
+        try {
+          sessionSo = await soClient.get<SlackSessionAttributes>(SLACK_SESSION_SO_TYPE, soId);
+        } catch (soErr) {
+          if (isNotFound(soErr)) {
+            return response.notFound({ body: { message: 'Session not found' } });
+          }
+          throw soErr;
         }
 
-        const currentState = (result._source?.state as Record<string, unknown>) ?? {};
-        const currentLocation = currentState.location as string | undefined;
-        const forkContext = currentState.fork_context as string | undefined;
         const { location } = request.body;
+        const { origin_ref: originRef, connector_id: connectorId } = sessionSo.attributes;
 
-        // Detect first Slack→other transition and capture origin fields
-        const isSlackOrigin =
-          typeof currentLocation === 'string' && currentLocation.startsWith('slack:');
-        const isMovingOut = location !== currentLocation;
-        const originNotSet = !currentState.origin_location;
-
-        const stateUpdates: Record<string, unknown> = {
+        await soClient.update<SlackSessionAttributes>(SLACK_SESSION_SO_TYPE, soId, {
           location,
           located_at: new Date().toISOString(),
-          fork_context: null,
-        };
-
-        if (isSlackOrigin && isMovingOut && originNotSet) {
-          stateUpdates.origin_location = currentLocation;
-          stateUpdates.origin_ref = currentLocation;
-        }
-
-        const updatedDoc = {
-          ...result._source,
-          state: { ...currentState, ...stateUpdates },
           updated_at: new Date().toISOString(),
-        };
+        });
 
-        await storage.index({ id: request.params.id, document: updatedDoc });
+        // Fetch the conversation doc so the CLI gets full history + metadata in one call
+        const esClient = coreStart.elasticsearch.client.asScoped(request).asInternalUser;
+        const storage = createConversationStorage({ esClient, logger });
+        const conv = await storage.get({ id: request.params.id });
 
         return response.ok({
-          body: { conversation: updatedDoc, fork_context: forkContext ?? null },
+          body: {
+            conversation: conv.found ? { id: request.params.id, ...conv._source } : null,
+            origin_ref: originRef ?? null,
+            connector_id: connectorId ?? null,
+          },
         });
       } catch (error) {
-        logger.error(`Locate conversation error: ${error.message}`);
+        if (isNotFound(error)) {
+          return response.notFound({ body: { message: 'Session not found' } });
+        }
+        logger.error(`Locate conversation error: ${(error as Error).message}`);
         return response.customError({
-          statusCode: error.statusCode || 500,
-          body: { message: error.message },
+          statusCode: (error as { statusCode?: number }).statusCode || 500,
+          body: { message: (error as Error).message },
         });
       }
     }
   );
 
-  // POST /internal/elastic_console/conversations/:id/handoff
+  // POST /api/elastic_console/conversations/:id/handoff
   // Returns a conversation to its origin location.
-  // Slack notification is handled separately by the Slack handler.
   router.post(
     {
-      path: '/internal/elastic_console/conversations/{id}/handoff',
+      path: '/api/elastic_console/conversations/{id}/handoff',
       security: {
         authz: {
           enabled: false,
           reason: 'This route is called by external agents using router secret auth',
         },
       },
-      options: { access: 'internal' },
+      options: { access: 'public' },
       validate: {
         params: schema.object({ id: schema.string() }),
         body: schema.object({
@@ -221,38 +131,58 @@ export const registerConversationSessionRoutes = ({
           return response.notFound();
         }
 
-        const esClient = coreStart.elasticsearch.client.asScoped(request).asInternalUser;
-        const storage = createConversationStorage({ esClient, logger });
+        const soClient = coreStart.savedObjects.createInternalRepository([SLACK_SESSION_SO_TYPE]);
+        const soId = slackSessionSoId(request.params.id);
 
-        const result = await storage.get({ id: request.params.id });
-        if (!result.found) {
-          return response.notFound({ body: { message: 'Conversation not found' } });
+        let sessionSo;
+        try {
+          sessionSo = await soClient.get<SlackSessionAttributes>(SLACK_SESSION_SO_TYPE, soId);
+        } catch (soErr) {
+          if (isNotFound(soErr)) {
+            return response.notFound({ body: { message: 'Session not found' } });
+          }
+          throw soErr;
         }
 
-        const currentState = (result._source?.state as Record<string, unknown>) ?? {};
-        const originLocation = currentState.origin_location as string | undefined;
-        const originRef = currentState.origin_ref as string | undefined;
+        const {
+          origin_location: originLocation,
+          origin_ref: originRef,
+          fork_context: forkContext,
+        } = sessionSo.attributes;
 
-        const stateUpdates: Record<string, unknown> = {};
+        const updates: Partial<SlackSessionAttributes> = {
+          updated_at: new Date().toISOString(),
+        };
         if (originLocation) {
-          stateUpdates.location = originLocation;
+          updates.location = originLocation;
         }
         if (request.body.summary) {
-          stateUpdates.handoff_summary = request.body.summary;
+          updates.handoff_summary = request.body.summary;
         }
 
-        await storage.index({
-          id: request.params.id,
-          document: {
-            ...result._source,
-            state: { ...currentState, ...stateUpdates },
-            updated_at: new Date().toISOString(),
-          },
-        });
+        await soClient.update<SlackSessionAttributes>(SLACK_SESSION_SO_TYPE, soId, updates);
+
+        // Load the conversation for the notification rounds.
+        const esClient = coreStart.elasticsearch.client.asScoped(request).asInternalUser;
+        const storage = createConversationStorage({ esClient, logger });
+        const conv = await storage.get({ id: request.params.id });
+        const existingRounds = conv.found
+          ? ((conv._source?.conversation_rounds as ConversationRound[]) ?? [])
+          : [];
+
+        // The summary is stored in handoff_summary on the SO and injected into
+        // the system prompt by the Slack handler — no synthetic conversation round
+        // needed (which would confuse the LLM with "[Investigation complete]" as
+        // a prior user message).
 
         // If the origin is Slack, post a notification to the original thread.
         // Best-effort — a notification failure does not fail the handoff.
         if (originRef?.startsWith('slack:')) {
+          // Only include rounds added after the fork (not the inherited parent history).
+          const parentRoundCount = forkContext ? parseInt(forkContext, 10) : 0;
+          const roundsForNotification = isNaN(parentRoundCount)
+            ? existingRounds
+            : existingRounds.slice(parentRoundCount);
           setImmediate(async () => {
             try {
               const esoClient = pluginsStart.encryptedSavedObjects.getClient({
@@ -265,6 +195,7 @@ export const registerConversationSessionRoutes = ({
               await sendHandoffNotification(creds.attributes.bot_token, {
                 originRef,
                 summary: request.body.summary,
+                rounds: roundsForNotification,
               });
             } catch (notifyErr) {
               logger.warn(`Handoff Slack notification failed: ${(notifyErr as Error).message}`);
@@ -279,6 +210,9 @@ export const registerConversationSessionRoutes = ({
           },
         });
       } catch (error) {
+        if (isNotFound(error)) {
+          return response.notFound({ body: { message: 'Session not found' } });
+        }
         logger.error(`Handoff conversation error: ${(error as Error).message}`);
         return response.customError({
           statusCode: (error as { statusCode?: number }).statusCode || 500,

--- a/x-pack/platform/plugins/shared/elastic_console/server/routes/index.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/routes/index.ts
@@ -7,25 +7,36 @@
 
 import type { CoreSetup, IRouter, Logger } from '@kbn/core/server';
 import type { CloudSetup } from '@kbn/cloud-plugin/server';
+import type { ElasticConsoleConfig } from '../config';
 import type { ElasticConsolePluginStart, ElasticConsoleStartDependencies } from '../types';
 import { registerChatCompletionsRoute } from './chat_completions';
 import { registerConversationRoutes } from './conversations';
+import { registerConversationSessionRoutes } from './conversation_sessions';
 import { registerModelsRoute } from './models';
 import { registerSetupRoute } from './setup';
+import { registerSlackEventsRoute } from './slack_events';
+import { registerSlackConnectRoute } from './slack_connect';
+import { registerSlackTokenRoute } from './slack_token';
 
 export const registerRoutes = ({
   router,
   coreSetup,
   logger,
   cloud,
+  config,
 }: {
   router: IRouter;
   coreSetup: CoreSetup<ElasticConsoleStartDependencies, ElasticConsolePluginStart>;
   logger: Logger;
   cloud?: CloudSetup;
+  config: ElasticConsoleConfig;
 }) => {
   registerChatCompletionsRoute({ router, coreSetup, logger });
   registerConversationRoutes({ router, coreSetup, logger });
+  registerConversationSessionRoutes({ router, coreSetup, logger });
   registerModelsRoute({ router, coreSetup, logger });
   registerSetupRoute({ router, coreSetup, logger, cloud });
+  registerSlackEventsRoute({ router, coreSetup, logger });
+  registerSlackConnectRoute({ router, coreSetup, logger, config });
+  registerSlackTokenRoute({ router, coreSetup, logger });
 };

--- a/x-pack/platform/plugins/shared/elastic_console/server/routes/index.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/routes/index.ts
@@ -17,6 +17,8 @@ import { registerSetupRoute } from './setup';
 import { registerSlackEventsRoute } from './slack_events';
 import { registerSlackConnectRoute } from './slack_connect';
 import { registerSlackTokenRoute } from './slack_token';
+import { registerSlackLinkUserRoutes } from './slack_link_user';
+import { registerSlackStatusRoute } from './slack_status';
 
 export const registerRoutes = ({
   router,
@@ -39,4 +41,6 @@ export const registerRoutes = ({
   registerSlackEventsRoute({ router, coreSetup, logger });
   registerSlackConnectRoute({ router, coreSetup, logger, config });
   registerSlackTokenRoute({ router, coreSetup, logger });
+  registerSlackLinkUserRoutes({ router, coreSetup, logger });
+  registerSlackStatusRoute({ router, coreSetup, logger });
 };

--- a/x-pack/platform/plugins/shared/elastic_console/server/routes/index.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/routes/index.ts
@@ -19,6 +19,7 @@ import { registerSlackConnectRoute } from './slack_connect';
 import { registerSlackTokenRoute } from './slack_token';
 import { registerSlackLinkUserRoutes } from './slack_link_user';
 import { registerSlackStatusRoute } from './slack_status';
+import { registerSlackDisconnectRoute } from './slack_disconnect';
 
 export const registerRoutes = ({
   router,
@@ -43,4 +44,5 @@ export const registerRoutes = ({
   registerSlackTokenRoute({ router, coreSetup, logger });
   registerSlackLinkUserRoutes({ router, coreSetup, logger });
   registerSlackStatusRoute({ router, coreSetup, logger });
+  registerSlackDisconnectRoute({ router, coreSetup, logger });
 };

--- a/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_connect.test.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_connect.test.ts
@@ -1,0 +1,210 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { httpServiceMock, httpServerMock, loggingSystemMock } from '@kbn/core/server/mocks';
+import { registerSlackConnectRoute } from './slack_connect';
+
+const mockLogger = loggingSystemMock.create().get();
+
+const KIBANA_URL = 'https://kibana.example.com';
+const CLIENT_ID = 'test-client-id';
+
+const createMocks = (overrides?: { invalidateError?: Error; createApiKeyError?: Error }) => {
+  const mockInvalidate = jest.fn().mockResolvedValue({});
+  if (overrides?.invalidateError) {
+    mockInvalidate.mockRejectedValue(overrides.invalidateError);
+  }
+
+  const mockCreateApiKey = jest.fn().mockResolvedValue({
+    id: 'connect-key-id',
+    api_key: 'connect-secret',
+  });
+  if (overrides?.createApiKeyError) {
+    mockCreateApiKey.mockRejectedValue(overrides.createApiKeyError);
+  }
+
+  const coreSetup = {
+    getStartServices: jest.fn().mockResolvedValue([
+      {
+        elasticsearch: {
+          client: {
+            asScoped: jest.fn().mockReturnValue({
+              asCurrentUser: {
+                security: {
+                  invalidateApiKey: mockInvalidate,
+                  createApiKey: mockCreateApiKey,
+                },
+              },
+            }),
+          },
+        },
+        http: {
+          basePath: { publicBaseUrl: KIBANA_URL, serverBasePath: '' },
+          getServerInfo: jest.fn().mockReturnValue({ protocol: 'https', port: 5601 }),
+        },
+      },
+    ]),
+  };
+
+  return { coreSetup, mockInvalidate, mockCreateApiKey };
+};
+
+describe('registerSlackConnectRoute — reconnect flow', () => {
+  let router: ReturnType<typeof httpServiceMock.createRouter>;
+
+  const registerAndGetHandler = (
+    coreSetup: unknown,
+    config = { slack: { client_id: CLIENT_ID } }
+  ) => {
+    router = httpServiceMock.createRouter();
+    registerSlackConnectRoute({
+      router,
+      coreSetup: coreSetup as never,
+      logger: mockLogger,
+      config: config as never,
+    });
+    const [, handler] = router.get.mock.calls[0];
+    return handler;
+  };
+
+  const callHandler = async (handler: Function) => {
+    const response = httpServerMock.createResponseFactory();
+    await handler({} as never, httpServerMock.createKibanaRequest(), response);
+    return response;
+  };
+
+  it('invalidates old connect keys before creating a new one', async () => {
+    const { coreSetup, mockInvalidate, mockCreateApiKey } = createMocks();
+    const handler = registerAndGetHandler(coreSetup);
+
+    const callOrder: string[] = [];
+    mockInvalidate.mockImplementation(async () => {
+      callOrder.push('invalidate');
+    });
+    mockCreateApiKey.mockImplementation(async () => {
+      callOrder.push('create');
+      return { id: 'connect-key-id', api_key: 'connect-secret' };
+    });
+
+    await callHandler(handler);
+
+    expect(callOrder).toEqual(['invalidate', 'create']);
+    expect(mockInvalidate).toHaveBeenCalledWith({ name: 'elastic-console-slack-connect-*' });
+  });
+
+  it('does not invalidate inference keys (scoped to connect prefix only)', async () => {
+    const { coreSetup, mockInvalidate } = createMocks();
+    const handler = registerAndGetHandler(coreSetup);
+
+    await callHandler(handler);
+
+    expect(mockInvalidate.mock.calls).toHaveLength(1);
+    expect(mockInvalidate.mock.calls[0][0].name).toBe('elastic-console-slack-connect-*');
+  });
+
+  it('continues and creates a new key even when invalidation throws (stale key gone)', async () => {
+    const { coreSetup, mockCreateApiKey } = createMocks({
+      invalidateError: new Error('security_exception'),
+    });
+    const handler = registerAndGetHandler(coreSetup);
+
+    const response = await callHandler(handler);
+
+    expect(response.ok).toHaveBeenCalled();
+    expect(mockCreateApiKey).toHaveBeenCalled();
+  });
+
+  it('returns a Slack OAuth URL containing the JWT state', async () => {
+    const { coreSetup } = createMocks();
+    const handler = registerAndGetHandler(coreSetup);
+
+    const response = await callHandler(handler);
+
+    expect(response.ok).toHaveBeenCalledWith(
+      expect.objectContaining({ body: expect.objectContaining({ url: expect.any(String) }) })
+    );
+
+    const { url } = (response.ok as jest.Mock).mock.calls[0][0].body;
+    expect(url).toContain('https://slack.com/oauth/v2/authorize');
+    expect(url).toContain(`client_id=${CLIENT_ID}`);
+
+    // state is a 3-part JWT
+    const state = new URLSearchParams(new URL(url).search).get('state')!;
+    const parts = state.split('.');
+    expect(parts).toHaveLength(3);
+
+    const payload = JSON.parse(Buffer.from(parts[1], 'base64url').toString('utf8'));
+    expect(payload).toMatchObject({
+      kibana_url: KIBANA_URL,
+      kibana_api_key: expect.any(String),
+      exp: expect.any(Number),
+    });
+  });
+
+  it('JWT expires approximately 10 minutes from now', async () => {
+    const { coreSetup } = createMocks();
+    const handler = registerAndGetHandler(coreSetup);
+
+    const before = Math.floor(Date.now() / 1000);
+    const response = await callHandler(handler);
+    const after = Math.floor(Date.now() / 1000);
+
+    const { url } = (response.ok as jest.Mock).mock.calls[0][0].body;
+    const state = new URLSearchParams(new URL(url).search).get('state')!;
+    const payload = JSON.parse(Buffer.from(state.split('.')[1], 'base64url').toString('utf8'));
+
+    expect(payload.exp).toBeGreaterThanOrEqual(before + 600);
+    expect(payload.exp).toBeLessThanOrEqual(after + 600);
+  });
+
+  it('returns 400 when client_id is not configured', async () => {
+    const { coreSetup } = createMocks();
+    const handler = registerAndGetHandler(coreSetup, { slack: undefined } as never);
+
+    const response = await callHandler(handler);
+
+    expect(response.badRequest).toHaveBeenCalled();
+  });
+
+  it('returns 500 when API key creation fails', async () => {
+    const { coreSetup } = createMocks({ createApiKeyError: new Error('cluster error') });
+    const handler = registerAndGetHandler(coreSetup);
+
+    const response = await callHandler(handler);
+
+    expect(response.customError).toHaveBeenCalledWith(
+      expect.objectContaining({ statusCode: 500 })
+    );
+  });
+
+  it('uses the configured redirect_uri when provided', async () => {
+    const { coreSetup } = createMocks();
+    const config = { slack: { client_id: CLIENT_ID, redirect_uri: 'https://my.router/redirect' } };
+    const handler = registerAndGetHandler(coreSetup, config as never);
+
+    const response = await callHandler(handler);
+
+    const { url } = (response.ok as jest.Mock).mock.calls[0][0].body;
+    expect(url).toContain('redirect_uri=https%3A%2F%2Fmy.router%2Fredirect');
+  });
+
+  it('falls back to default redirect_uri when not configured', async () => {
+    const { coreSetup } = createMocks();
+    const handler = registerAndGetHandler(coreSetup);
+
+    const response = await callHandler(handler);
+
+    const { url } = (response.ok as jest.Mock).mock.calls[0][0].body;
+    expect(url).toContain('connect.elastic.co');
+  });
+
+  it('registers a GET route at the correct path', () => {
+    const { coreSetup } = createMocks();
+    registerAndGetHandler(coreSetup);
+    expect(router.get.mock.calls[0][0].path).toBe('/internal/elastic_console/slack/connect');
+  });
+});

--- a/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_connect.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_connect.ts
@@ -1,0 +1,114 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createHmac } from 'crypto';
+import type { CoreSetup, IRouter, Logger } from '@kbn/core/server';
+import type { ElasticConsoleConfig } from '../config';
+import type { ElasticConsolePluginStart, ElasticConsoleStartDependencies } from '../types';
+
+const SLACK_OAUTH_URL = 'https://slack.com/oauth/v2/authorize';
+const SLACK_REDIRECT_URI = 'https://connect.elastic.co/slack/oauth_redirect';
+const SLACK_SCOPES = 'app_mentions:read,chat:write,channels:history,im:write';
+const JWT_EXPIRY_SECS = 600; // 10 minutes
+
+const signJwt = (payload: Record<string, unknown>, secret: string): string => {
+  const header = Buffer.from(JSON.stringify({ alg: 'HS256', typ: 'JWT' })).toString('base64url');
+  const body = Buffer.from(JSON.stringify(payload)).toString('base64url');
+  const signature = createHmac('sha256', secret).update(`${header}.${body}`).digest('base64url');
+  return `${header}.${body}.${signature}`;
+};
+
+export const registerSlackConnectRoute = ({
+  router,
+  coreSetup,
+  logger,
+  config,
+}: {
+  router: IRouter;
+  coreSetup: CoreSetup<ElasticConsoleStartDependencies, ElasticConsolePluginStart>;
+  logger: Logger;
+  config: ElasticConsoleConfig;
+}) => {
+  router.get(
+    {
+      path: '/internal/elastic_console/slack/connect',
+      security: { authz: { requiredPrivileges: ['agentBuilder:write'] } },
+      options: { access: 'internal' },
+      validate: false,
+    },
+    async (ctx, request, response) => {
+      const slackConfig = config.slack;
+      if (!slackConfig?.client_id || !slackConfig?.state_secret) {
+        logger.warn('Slack connect attempted but slack config is missing');
+        return response.badRequest({
+          body: { message: 'Slack integration is not configured' },
+        });
+      }
+
+      const [coreStart] = await coreSetup.getStartServices();
+
+      // Generate a Kibana API key scoped to the Slack events endpoint.
+      // The router stores this key and sends it as Authorization: ApiKey <key>
+      // on every forwarded Slack event — Kibana verifies it natively.
+      const esClient = coreStart.elasticsearch.client.asScoped(request).asCurrentUser;
+      let kibanaApiKey: string;
+      try {
+        const apiKeyResult = await esClient.security.createApiKey({
+          name: `elastic-console-slack-${Date.now()}`,
+          // No expiration — key lives until manually revoked (re-connect regenerates).
+          // Role descriptors limit the key to Kibana's Slack events application privilege.
+          role_descriptors: {
+            'elastic-console-slack': {
+              cluster: [],
+              indices: [],
+              applications: [
+                {
+                  application: 'kibana-.kibana',
+                  privileges: ['api:elastic_console/slack/events'],
+                  resources: ['*'],
+                },
+              ],
+            },
+          },
+        });
+        kibanaApiKey = Buffer.from(`${apiKeyResult.id}:${apiKeyResult.api_key}`).toString('base64');
+      } catch (err) {
+        logger.error(`Failed to create Slack API key: ${(err as Error).message}`);
+        return response.customError({
+          statusCode: 500,
+          body: { message: 'Failed to generate Slack integration credentials' },
+        });
+      }
+
+      const kibanaUrl =
+        coreStart.http.basePath.publicBaseUrl ??
+        `${coreStart.http.getServerInfo().protocol}://localhost:5601`;
+
+      // Embed both kibana_url and kibana_api_key in the state JWT.
+      // The router verifies the JWT signature, then:
+      //   1. Uses kibana_url to know which Kibana instance this connect belongs to
+      //   2. Stores kibana_api_key to authenticate future event forwarding
+      //   3. POSTs the bot_token to /internal/elastic_console/slack/token after OAuth
+      const jwtPayload = {
+        kibana_url: kibanaUrl,
+        kibana_api_key: kibanaApiKey,
+        exp: Math.floor(Date.now() / 1000) + JWT_EXPIRY_SECS,
+      };
+
+      const state = signJwt(jwtPayload, slackConfig.state_secret);
+
+      const params = new URLSearchParams({
+        client_id: slackConfig.client_id,
+        redirect_uri: SLACK_REDIRECT_URI,
+        scope: SLACK_SCOPES,
+        state,
+      });
+
+      return response.redirected({ headers: { location: `${SLACK_OAUTH_URL}?${params}` } });
+    }
+  );
+};

--- a/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_connect.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_connect.ts
@@ -22,7 +22,6 @@ const signJwt = (payload: Record<string, unknown>, secret: string): string => {
   return `${header}.${body}.${signature}`;
 };
 
-
 export const registerSlackConnectRoute = ({
   router,
   coreSetup,
@@ -42,7 +41,6 @@ export const registerSlackConnectRoute = ({
       validate: false,
     },
     async (ctx, request, response) => {
-
       const [coreStart] = await coreSetup.getStartServices();
 
       // Generate a Kibana API key scoped to the Slack events endpoint.
@@ -114,7 +112,9 @@ export const registerSlackConnectRoute = ({
 
       const clientId = config.slack?.client_id;
       if (!clientId) {
-        return response.badRequest({ body: { message: 'xpack.elastic_console.slack.client_id is not configured' } });
+        return response.badRequest({
+          body: { message: 'xpack.elastic_console.slack.client_id is not configured' },
+        });
       }
 
       const redirectUri = config.slack?.redirect_uri ?? SLACK_REDIRECT_URI_DEFAULT;

--- a/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_connect.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_connect.ts
@@ -73,10 +73,11 @@ export const registerSlackConnectRoute = ({
         const apiKeyResult = await esClient.security.createApiKey({
           name: `elastic-console-slack-${Date.now()}`,
           // No expiration — key lives until manually revoked (re-connect regenerates).
-          // Role descriptors limit the key to Kibana's Slack events application privilege.
           role_descriptors: {
             'elastic-console-slack': {
-              cluster: [],
+              // manage_own_api_key lets /slack/token create a scoped inference key
+              // on behalf of this principal without needing a superuser.
+              cluster: ['manage_own_api_key'],
               indices: [],
               applications: [
                 {

--- a/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_connect.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_connect.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { createHmac } from 'crypto';
+import { createHmac, createHash, randomBytes, createCipheriv } from 'crypto';
 import type { CoreSetup, IRouter, Logger } from '@kbn/core/server';
 import type { ElasticConsoleConfig } from '../config';
 import type { ElasticConsolePluginStart, ElasticConsoleStartDependencies } from '../types';
@@ -20,6 +20,19 @@ const signJwt = (payload: Record<string, unknown>, secret: string): string => {
   const body = Buffer.from(JSON.stringify(payload)).toString('base64url');
   const signature = createHmac('sha256', secret).update(`${header}.${body}`).digest('base64url');
   return `${header}.${body}.${signature}`;
+};
+
+// Encrypts a plaintext string using AES-256-GCM so sensitive fields (like kibana_api_key)
+// are not readable in plaintext within the JWT state parameter.
+// The key is derived from the state_secret so no additional config is needed.
+// Output format: base64url(iv):base64url(ciphertext):base64url(authTag)
+const encryptForState = (plaintext: string, stateSecret: string): string => {
+  const key = createHash('sha256').update(stateSecret).update(':state-enc').digest();
+  const iv = randomBytes(12);
+  const cipher = createCipheriv('aes-256-gcm', key, iv);
+  const ciphertext = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+  const authTag = cipher.getAuthTag();
+  return [iv, ciphertext, authTag].map((b) => b.toString('base64url')).join(':');
 };
 
 export const registerSlackConnectRoute = ({
@@ -88,14 +101,13 @@ export const registerSlackConnectRoute = ({
         coreStart.http.basePath.publicBaseUrl ??
         `${coreStart.http.getServerInfo().protocol}://localhost:5601`;
 
-      // Embed both kibana_url and kibana_api_key in the state JWT.
-      // The router verifies the JWT signature, then:
-      //   1. Uses kibana_url to know which Kibana instance this connect belongs to
-      //   2. Stores kibana_api_key to authenticate future event forwarding
-      //   3. POSTs the bot_token to /internal/elastic_console/slack/token after OAuth
+      // Embed kibana_url and kibana_api_key in the state JWT.
+      // kibana_api_key is AES-256-GCM encrypted so it is not readable in browser
+      // history, proxy logs, or Slack's redirect logs — only the router (which
+      // shares state_secret) can decrypt it.
       const jwtPayload = {
         kibana_url: kibanaUrl,
-        kibana_api_key: kibanaApiKey,
+        kibana_api_key_enc: encryptForState(kibanaApiKey, slackConfig.state_secret),
         exp: Math.floor(Date.now() / 1000) + JWT_EXPIRY_SECS,
       };
 

--- a/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_connect.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_connect.ts
@@ -11,7 +11,7 @@ import type { ElasticConsoleConfig } from '../config';
 import type { ElasticConsolePluginStart, ElasticConsoleStartDependencies } from '../types';
 
 const SLACK_OAUTH_URL = 'https://slack.com/oauth/v2/authorize';
-const SLACK_REDIRECT_URI = 'https://connect.elastic.co/slack/oauth_redirect';
+const SLACK_REDIRECT_URI_DEFAULT = 'https://connect.elastic.co/slack/oauth_redirect';
 const SLACK_SCOPES = 'app_mentions:read,chat:write,channels:history,im:write';
 const JWT_EXPIRY_SECS = 600; // 10 minutes
 
@@ -102,9 +102,11 @@ export const registerSlackConnectRoute = ({
         return response.badRequest({ body: { message: 'xpack.elastic_console.slack.client_id is not configured' } });
       }
 
+      const redirectUri = config.slack?.redirect_uri ?? SLACK_REDIRECT_URI_DEFAULT;
+
       const params = new URLSearchParams({
         client_id: clientId,
-        redirect_uri: SLACK_REDIRECT_URI,
+        redirect_uri: redirectUri,
         scope: SLACK_SCOPES,
         state,
       });

--- a/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_connect.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_connect.ts
@@ -42,13 +42,6 @@ export const registerSlackConnectRoute = ({
       validate: false,
     },
     async (ctx, request, response) => {
-      const slackConfig = config.slack;
-      if (!slackConfig?.client_id) {
-        logger.warn('Slack connect attempted but slack config is missing');
-        return response.badRequest({
-          body: { message: 'Slack integration is not configured' },
-        });
-      }
 
       const [coreStart] = await coreSetup.getStartServices();
 
@@ -104,8 +97,13 @@ export const registerSlackConnectRoute = ({
 
       const state = signJwt(jwtPayload, kibanaApiKey);
 
+      const clientId = config.slack?.client_id;
+      if (!clientId) {
+        return response.badRequest({ body: { message: 'xpack.elastic_console.slack.client_id is not configured' } });
+      }
+
       const params = new URLSearchParams({
-        client_id: slackConfig.client_id,
+        client_id: clientId,
         redirect_uri: SLACK_REDIRECT_URI,
         scope: SLACK_SCOPES,
         state,

--- a/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_connect.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_connect.ts
@@ -38,9 +38,7 @@ export const registerSlackConnectRoute = ({
     {
       path: '/internal/elastic_console/slack/connect',
       security: { authz: { requiredPrivileges: ['agentBuilder:write'] } },
-      // access: 'public' — browser navigates directly to this URL for the OAuth redirect;
-      // browser navigation never sends x-elastic-internal-origin so internal routes are blocked.
-      options: { access: 'public' },
+      options: { access: 'internal' },
       validate: false,
     },
     async (ctx, request, response) => {
@@ -111,7 +109,7 @@ export const registerSlackConnectRoute = ({
         state,
       });
 
-      return response.redirected({ headers: { location: `${SLACK_OAUTH_URL}?${params}` } });
+      return response.ok({ body: { url: `${SLACK_OAUTH_URL}?${params}` } });
     }
   );
 };

--- a/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_connect.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_connect.ts
@@ -79,9 +79,10 @@ export const registerSlackConnectRoute = ({
         });
       }
 
+      const serverInfo = coreStart.http.getServerInfo();
       const kibanaUrl =
         coreStart.http.basePath.publicBaseUrl ??
-        `${coreStart.http.getServerInfo().protocol}://localhost:5601`;
+        `${serverInfo.protocol}://localhost:${serverInfo.port}${coreStart.http.basePath.serverBasePath}`;
 
       // Self-authenticating state JWT: signed with the kibana_api_key itself.
       // No shared secret needed — the router verifies by extracting kibana_api_key

--- a/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_connect.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_connect.ts
@@ -62,6 +62,11 @@ export const registerSlackConnectRoute = ({
       try {
         const apiKeyResult = await esClient.security.createApiKey({
           name: `elastic-console-slack-connect-${Date.now()}`,
+          metadata: {
+            managed_by: 'elastic_console',
+            purpose: 'slack_router_auth',
+            description: 'Authenticates the elastic-console-connect router to forward Slack events',
+          },
           // No expiration — key lives until manually revoked (re-connect regenerates).
           role_descriptors: {
             'elastic-console-slack': {

--- a/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_connect.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_connect.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { createHmac, createHash, randomBytes, createCipheriv } from 'crypto';
+import { createHmac } from 'crypto';
 import type { CoreSetup, IRouter, Logger } from '@kbn/core/server';
 import type { ElasticConsoleConfig } from '../config';
 import type { ElasticConsolePluginStart, ElasticConsoleStartDependencies } from '../types';
@@ -22,18 +22,6 @@ const signJwt = (payload: Record<string, unknown>, secret: string): string => {
   return `${header}.${body}.${signature}`;
 };
 
-// Encrypts a plaintext string using AES-256-GCM so sensitive fields (like kibana_api_key)
-// are not readable in plaintext within the JWT state parameter.
-// The key is derived from the state_secret so no additional config is needed.
-// Output format: base64url(iv):base64url(ciphertext):base64url(authTag)
-const encryptForState = (plaintext: string, stateSecret: string): string => {
-  const key = createHash('sha256').update(stateSecret).update(':state-enc').digest();
-  const iv = randomBytes(12);
-  const cipher = createCipheriv('aes-256-gcm', key, iv);
-  const ciphertext = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
-  const authTag = cipher.getAuthTag();
-  return [iv, ciphertext, authTag].map((b) => b.toString('base64url')).join(':');
-};
 
 export const registerSlackConnectRoute = ({
   router,
@@ -55,7 +43,7 @@ export const registerSlackConnectRoute = ({
     },
     async (ctx, request, response) => {
       const slackConfig = config.slack;
-      if (!slackConfig?.client_id || !slackConfig?.state_secret) {
+      if (!slackConfig?.client_id) {
         logger.warn('Slack connect attempted but slack config is missing');
         return response.badRequest({
           body: { message: 'Slack integration is not configured' },
@@ -102,17 +90,19 @@ export const registerSlackConnectRoute = ({
         coreStart.http.basePath.publicBaseUrl ??
         `${coreStart.http.getServerInfo().protocol}://localhost:5601`;
 
-      // Embed kibana_url and kibana_api_key in the state JWT.
-      // kibana_api_key is AES-256-GCM encrypted so it is not readable in browser
-      // history, proxy logs, or Slack's redirect logs — only the router (which
-      // shares state_secret) can decrypt it.
+      // Self-authenticating state JWT: signed with the kibana_api_key itself.
+      // No shared secret needed — the router verifies by extracting kibana_api_key
+      // from the payload and recomputing the HMAC. Tampering with any field
+      // (including kibana_url) invalidates the signature.
+      // Trade-off: kibana_api_key is visible in the JWT payload (base64, not encrypted).
+      // Mitigations: key is scoped to one privilege, 10-min expiry, HTTPS transport.
       const jwtPayload = {
         kibana_url: kibanaUrl,
-        kibana_api_key_enc: encryptForState(kibanaApiKey, slackConfig.state_secret),
+        kibana_api_key: kibanaApiKey,
         exp: Math.floor(Date.now() / 1000) + JWT_EXPIRY_SECS,
       };
 
-      const state = signJwt(jwtPayload, slackConfig.state_secret);
+      const state = signJwt(jwtPayload, kibanaApiKey);
 
       const params = new URLSearchParams({
         client_id: slackConfig.client_id,

--- a/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_connect.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_connect.ts
@@ -49,10 +49,19 @@ export const registerSlackConnectRoute = ({
       // The router stores this key and sends it as Authorization: ApiKey <key>
       // on every forwarded Slack event — Kibana verifies it natively.
       const esClient = coreStart.elasticsearch.client.asScoped(request).asCurrentUser;
+
+      // Invalidate previous connect keys before creating a new one (re-connect flow).
+      // Use the connect-specific prefix so inference keys are not affected.
+      try {
+        await esClient.security.invalidateApiKey({ name: 'elastic-console-slack-connect-*' });
+      } catch (err) {
+        logger.warn(`Failed to invalidate stale Slack connect keys: ${(err as Error).message}`);
+      }
+
       let kibanaApiKey: string;
       try {
         const apiKeyResult = await esClient.security.createApiKey({
-          name: `elastic-console-slack-${Date.now()}`,
+          name: `elastic-console-slack-connect-${Date.now()}`,
           // No expiration — key lives until manually revoked (re-connect regenerates).
           role_descriptors: {
             'elastic-console-slack': {

--- a/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_connect.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_connect.ts
@@ -12,7 +12,7 @@ import type { ElasticConsolePluginStart, ElasticConsoleStartDependencies } from 
 
 const SLACK_OAUTH_URL = 'https://slack.com/oauth/v2/authorize';
 const SLACK_REDIRECT_URI_DEFAULT = 'https://connect.elastic.co/slack/oauth_redirect';
-const SLACK_SCOPES = 'app_mentions:read,chat:write,channels:history,im:write';
+const SLACK_SCOPES = 'app_mentions:read,chat:write,channels:history,commands,im:write';
 const JWT_EXPIRY_SECS = 600; // 10 minutes
 
 const signJwt = (payload: Record<string, unknown>, secret: string): string => {

--- a/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_connect.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_connect.ts
@@ -38,7 +38,9 @@ export const registerSlackConnectRoute = ({
     {
       path: '/internal/elastic_console/slack/connect',
       security: { authz: { requiredPrivileges: ['agentBuilder:write'] } },
-      options: { access: 'internal' },
+      // access: 'public' — browser navigates directly to this URL for the OAuth redirect;
+      // browser navigation never sends x-elastic-internal-origin so internal routes are blocked.
+      options: { access: 'public' },
       validate: false,
     },
     async (ctx, request, response) => {

--- a/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_disconnect.test.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_disconnect.test.ts
@@ -1,0 +1,144 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { httpServiceMock, httpServerMock, loggingSystemMock } from '@kbn/core/server/mocks';
+import { registerSlackDisconnectRoute } from './slack_disconnect';
+import { SLACK_CREDENTIALS_SO_TYPE, SLACK_CREDENTIALS_SO_ID } from '../lib/slack_credentials_so';
+
+const mockLogger = loggingSystemMock.create().get();
+
+const KEY_ID = 'test-key-id';
+const KIBANA_API_KEY = Buffer.from(`${KEY_ID}:test-secret`).toString('base64');
+
+const createMocks = (overrides?: {
+  getDecryptedResult?: unknown;
+  getDecryptedError?: Error;
+  invalidateError?: Error;
+  deleteError?: Error;
+}) => {
+  const mockInvalidateApiKey = jest.fn().mockResolvedValue({});
+  if (overrides?.invalidateError) {
+    mockInvalidateApiKey.mockRejectedValue(overrides.invalidateError);
+  }
+
+  const mockDeleteSo = jest.fn().mockResolvedValue({});
+  if (overrides?.deleteError) {
+    mockDeleteSo.mockRejectedValue(overrides.deleteError);
+  }
+
+  const mockGetDecrypted = overrides?.getDecryptedError
+    ? jest.fn().mockRejectedValue(overrides.getDecryptedError)
+    : jest.fn().mockResolvedValue(
+        overrides?.getDecryptedResult ?? {
+          attributes: { kibana_api_key: KIBANA_API_KEY },
+        }
+      );
+
+  const coreSetup = {
+    getStartServices: jest.fn().mockResolvedValue([
+      {
+        elasticsearch: {
+          client: {
+            asInternalUser: {
+              security: { invalidateApiKey: mockInvalidateApiKey },
+            },
+          },
+        },
+        savedObjects: {
+          createInternalRepository: jest.fn().mockReturnValue({ delete: mockDeleteSo }),
+        },
+      },
+      {
+        encryptedSavedObjects: {
+          getClient: jest.fn().mockReturnValue({ getDecryptedAsInternalUser: mockGetDecrypted }),
+        },
+      },
+    ]),
+  };
+
+  return { coreSetup, mockInvalidateApiKey, mockDeleteSo, mockGetDecrypted };
+};
+
+describe('registerSlackDisconnectRoute', () => {
+  let router: ReturnType<typeof httpServiceMock.createRouter>;
+
+  const registerAndGetHandler = (coreSetup: unknown) => {
+    router = httpServiceMock.createRouter();
+    registerSlackDisconnectRoute({ router, coreSetup: coreSetup as never, logger: mockLogger });
+    const [, handler] = router.delete.mock.calls[0];
+    return handler;
+  };
+
+  const callHandler = (handler: Function) => {
+    const response = httpServerMock.createResponseFactory();
+    return handler({} as never, httpServerMock.createKibanaRequest(), response).then(
+      () => response
+    );
+  };
+
+  it('registers a DELETE route at the correct path', () => {
+    const { coreSetup } = createMocks();
+    registerAndGetHandler(coreSetup);
+    const [routeConfig] = router.delete.mock.calls[0];
+    expect(routeConfig.path).toBe('/internal/elastic_console/slack/disconnect');
+  });
+
+  it('invalidates the stored API key by ID', async () => {
+    const { coreSetup, mockInvalidateApiKey } = createMocks();
+    const handler = registerAndGetHandler(coreSetup);
+    await callHandler(handler);
+
+    expect(mockInvalidateApiKey).toHaveBeenCalledWith({
+      ids: [KEY_ID],
+      owner: true,
+    });
+  });
+
+  it('deletes the credentials saved object', async () => {
+    const { coreSetup, mockDeleteSo } = createMocks();
+    const handler = registerAndGetHandler(coreSetup);
+    await callHandler(handler);
+
+    expect(mockDeleteSo).toHaveBeenCalledWith(SLACK_CREDENTIALS_SO_TYPE, SLACK_CREDENTIALS_SO_ID);
+  });
+
+  it('returns ok: true on success', async () => {
+    const { coreSetup } = createMocks();
+    const handler = registerAndGetHandler(coreSetup);
+    const response = await callHandler(handler);
+
+    expect(response.ok).toHaveBeenCalledWith({ body: { ok: true } });
+  });
+
+  it('still deletes the SO even when key invalidation fails', async () => {
+    const { coreSetup, mockDeleteSo } = createMocks({
+      invalidateError: new Error('key not found'),
+    });
+    const handler = registerAndGetHandler(coreSetup);
+    await callHandler(handler);
+
+    expect(mockDeleteSo).toHaveBeenCalled();
+  });
+
+  it('still returns ok when credentials SO does not exist', async () => {
+    const { coreSetup } = createMocks({
+      getDecryptedError: new Error('saved object not found'),
+    });
+    const handler = registerAndGetHandler(coreSetup);
+    const response = await callHandler(handler);
+
+    expect(response.ok).toHaveBeenCalledWith({ body: { ok: true } });
+  });
+
+  it('still returns ok when SO deletion fails', async () => {
+    const { coreSetup } = createMocks({ deleteError: new Error('delete failed') });
+    const handler = registerAndGetHandler(coreSetup);
+    const response = await callHandler(handler);
+
+    expect(response.ok).toHaveBeenCalledWith({ body: { ok: true } });
+  });
+});

--- a/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_disconnect.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_disconnect.ts
@@ -65,8 +65,8 @@ export const registerSlackDisconnectRoute = ({
             );
           }
         }
-      } catch {
-        // Credentials SO not found — nothing to invalidate, proceed to ensure SO is deleted
+      } catch (credErr) {
+        logger.debug(`Slack credentials not found during disconnect — skipping key invalidation: ${(credErr as Error).message}`);
       }
 
       // Step 2 — delete the credentials SO

--- a/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_disconnect.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_disconnect.ts
@@ -71,9 +71,7 @@ export const registerSlackDisconnectRoute = ({
 
       // Step 2 — delete the credentials SO
       try {
-        const soClient = coreStart.savedObjects.createInternalRepository({
-          hiddenTypes: [SLACK_CREDENTIALS_SO_TYPE],
-        });
+        const soClient = coreStart.savedObjects.createInternalRepository([SLACK_CREDENTIALS_SO_TYPE]);
         await soClient.delete(SLACK_CREDENTIALS_SO_TYPE, SLACK_CREDENTIALS_SO_ID);
         logger.info('Slack credentials saved object deleted');
       } catch (deleteErr) {

--- a/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_disconnect.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_disconnect.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { CoreSetup, IRouter, Logger } from '@kbn/core/server';
+import type { ElasticConsolePluginStart, ElasticConsoleStartDependencies } from '../types';
+import { SLACK_CREDENTIALS_SO_TYPE, SLACK_CREDENTIALS_SO_ID } from '../lib/slack_credentials_so';
+
+// DELETE /internal/elastic_console/slack/disconnect
+//
+// Revokes the Slack integration:
+//   1. Reads the stored kibana_api_key from ESO
+//   2. Invalidates that API key in ES so the router can no longer forward events
+//   3. Deletes the credentials saved object (bot_token + kibana_api_key)
+//
+// After this the status endpoint returns 'not_connected'.
+
+export const registerSlackDisconnectRoute = ({
+  router,
+  coreSetup,
+  logger,
+}: {
+  router: IRouter;
+  coreSetup: CoreSetup<ElasticConsoleStartDependencies, ElasticConsolePluginStart>;
+  logger: Logger;
+}) => {
+  router.delete(
+    {
+      path: '/internal/elastic_console/slack/disconnect',
+      security: { authz: { requiredPrivileges: ['agentBuilder:write'] } },
+      options: { access: 'internal' },
+      validate: false,
+    },
+    async (ctx, request, response) => {
+      const [coreStart, pluginsStart] = await coreSetup.getStartServices();
+
+      const esoClient = pluginsStart.encryptedSavedObjects.getClient({
+        includedHiddenTypes: [SLACK_CREDENTIALS_SO_TYPE],
+      });
+
+      // Step 1 — read and invalidate the stored API key
+      try {
+        const creds = await esoClient.getDecryptedAsInternalUser<{
+          kibana_api_key: string;
+        }>(SLACK_CREDENTIALS_SO_TYPE, SLACK_CREDENTIALS_SO_ID);
+
+        const decoded = Buffer.from(creds.attributes.kibana_api_key, 'base64').toString('utf8');
+        const colonIdx = decoded.indexOf(':');
+        const keyId = colonIdx !== -1 ? decoded.slice(0, colonIdx) : null;
+
+        if (keyId) {
+          try {
+            await coreStart.elasticsearch.client.asInternalUser.security.invalidateApiKey({
+              ids: [keyId],
+              owner: true,
+            });
+            logger.info(`Slack inference API key ${keyId} invalidated`);
+          } catch (invalidateErr) {
+            // Key may already be gone — log and continue with SO deletion
+            logger.warn(
+              `Could not invalidate Slack API key ${keyId}: ${(invalidateErr as Error).message}`
+            );
+          }
+        }
+      } catch {
+        // Credentials SO not found — nothing to invalidate, proceed to ensure SO is deleted
+      }
+
+      // Step 2 — delete the credentials SO
+      try {
+        const soClient = coreStart.savedObjects.createInternalRepository({
+          hiddenTypes: [SLACK_CREDENTIALS_SO_TYPE],
+        });
+        await soClient.delete(SLACK_CREDENTIALS_SO_TYPE, SLACK_CREDENTIALS_SO_ID);
+        logger.info('Slack credentials saved object deleted');
+      } catch (deleteErr) {
+        logger.warn(`Could not delete Slack credentials SO: ${(deleteErr as Error).message}`);
+      }
+
+      return response.ok({ body: { ok: true } });
+    }
+  );
+};

--- a/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_events.test.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_events.test.ts
@@ -1,0 +1,230 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { httpServiceMock, httpServerMock, loggingSystemMock } from '@kbn/core/server/mocks';
+import { registerSlackEventsRoute } from './slack_events';
+
+jest.mock('../lib/slack_handler', () => ({
+  handleSlackEvent: jest.fn().mockResolvedValue(undefined),
+}));
+
+import { handleSlackEvent } from '../lib/slack_handler';
+
+const mockLogger = loggingSystemMock.create().get();
+const mockHandleSlackEvent = handleSlackEvent as jest.MockedFunction<typeof handleSlackEvent>;
+
+const BOT_TOKEN = 'xoxb-test-token';
+const KIBANA_API_KEY = Buffer.from('key-id:key-secret').toString('base64');
+
+// Spy on setImmediate so we can await the async callback directly instead of
+// relying on timer queue ordering. Without this, the async work inside the
+// callback (getStartServices, ESO decrypt, handleSlackEvent) won't complete
+// before the test assertions run.
+let capturedImmediateCallback: (() => Promise<void>) | null = null;
+let setImmediateSpy: jest.SpyInstance;
+
+const createMockEsoClient = (overrides?: { getDecryptedError?: Error }) => ({
+  getDecryptedAsInternalUser: overrides?.getDecryptedError
+    ? jest.fn().mockRejectedValue(overrides.getDecryptedError)
+    : jest.fn().mockResolvedValue({
+        attributes: { bot_token: BOT_TOKEN, kibana_api_key: KIBANA_API_KEY },
+      }),
+});
+
+const createMockCoreSetup = (esoClient = createMockEsoClient()) => ({
+  getStartServices: jest.fn().mockResolvedValue([
+    { elasticsearch: { client: {} } },
+    {
+      encryptedSavedObjects: { getClient: jest.fn().mockReturnValue(esoClient) },
+      inference: {},
+    },
+  ]),
+});
+
+describe('registerSlackEventsRoute', () => {
+  let router: ReturnType<typeof httpServiceMock.createRouter>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    capturedImmediateCallback = null;
+    setImmediateSpy = jest
+      .spyOn(global, 'setImmediate')
+      .mockImplementation((fn: TimerHandler) => {
+        capturedImmediateCallback = fn as () => Promise<void>;
+        return 0 as unknown as NodeJS.Immediate;
+      });
+  });
+
+  afterEach(() => {
+    setImmediateSpy.mockRestore();
+  });
+
+  const registerAndGetHandler = (coreSetup: unknown) => {
+    router = httpServiceMock.createRouter();
+    registerSlackEventsRoute({ router, coreSetup: coreSetup as never, logger: mockLogger });
+    const [, handler] = router.post.mock.calls[0];
+    return handler;
+  };
+
+  const callHandler = async (handler: Function, body: Record<string, unknown>) => {
+    const response = httpServerMock.createResponseFactory();
+    const request = httpServerMock.createKibanaRequest({ body });
+    await handler({} as never, request, response);
+    return { response, request };
+  };
+
+  // Run the captured setImmediate callback to completion (including its async chain)
+  const runImmediateCallback = async () => {
+    if (capturedImmediateCallback) {
+      await capturedImmediateCallback();
+    }
+  };
+
+  describe('immediate ack', () => {
+    it('always returns 200 immediately for event_callback — Slack 3s requirement', async () => {
+      const handler = registerAndGetHandler(createMockCoreSetup());
+
+      const { response } = await callHandler(handler, {
+        type: 'event_callback',
+        event: { type: 'app_mention', ts: '1', channel: 'C1', text: 'hello' },
+      });
+
+      expect(response.ok).toHaveBeenCalledWith({ body: { ok: true } });
+    });
+
+    it('returns 200 for url_verification before loading any credentials', async () => {
+      const esoClient = createMockEsoClient();
+      const handler = registerAndGetHandler(createMockCoreSetup(esoClient));
+
+      const { response } = await callHandler(handler, {
+        type: 'url_verification',
+        challenge: 'abc123',
+      });
+
+      expect(response.ok).toHaveBeenCalledWith({ body: { challenge: 'abc123' } });
+      expect(esoClient.getDecryptedAsInternalUser).not.toHaveBeenCalled();
+    });
+
+    it('returns 200 for unknown event types without processing', async () => {
+      const handler = registerAndGetHandler(createMockCoreSetup());
+
+      const { response } = await callHandler(handler, { type: 'unknown_type' });
+
+      expect(response.ok).toHaveBeenCalledWith({ body: { ok: true } });
+      // No async processing should be scheduled for unknown types
+      expect(capturedImmediateCallback).toBeNull();
+    });
+  });
+
+  describe('bot token revoked or expired mid-session', () => {
+    it('logs a warning and skips handleSlackEvent when no credentials are stored', async () => {
+      const esoClient = createMockEsoClient({
+        getDecryptedError: new Error('Saved object not found'),
+      });
+      const handler = registerAndGetHandler(createMockCoreSetup(esoClient));
+
+      await callHandler(handler, {
+        type: 'event_callback',
+        event: { type: 'app_mention', ts: '1', channel: 'C1', text: 'hello' },
+      });
+
+      await runImmediateCallback();
+
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('no bot_token stored yet')
+      );
+      expect(mockHandleSlackEvent).not.toHaveBeenCalled();
+    });
+
+    it('logs an error but does not crash when handleSlackEvent throws', async () => {
+      mockHandleSlackEvent.mockRejectedValueOnce(new Error('invalid_auth'));
+      const handler = registerAndGetHandler(createMockCoreSetup());
+
+      await callHandler(handler, {
+        type: 'event_callback',
+        event: { type: 'app_mention', ts: '1', channel: 'C1', text: 'hello' },
+      });
+
+      await runImmediateCallback();
+
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        expect.stringContaining('invalid_auth')
+      );
+    });
+
+    it('still returns 200 to Slack even when event processing fails', async () => {
+      mockHandleSlackEvent.mockRejectedValueOnce(new Error('invalid_auth'));
+      const handler = registerAndGetHandler(createMockCoreSetup());
+
+      const { response } = await callHandler(handler, {
+        type: 'event_callback',
+        event: { type: 'app_mention', ts: '1', channel: 'C1', text: 'hello' },
+      });
+
+      // Ack is sent before processing — must already be 200 regardless of later failure
+      expect(response.ok).toHaveBeenCalledWith({ body: { ok: true } });
+    });
+  });
+
+  describe('event forwarding', () => {
+    it('calls handleSlackEvent with the correct event fields', async () => {
+      const handler = registerAndGetHandler(createMockCoreSetup());
+
+      await callHandler(handler, {
+        type: 'event_callback',
+        event: {
+          type: 'app_mention',
+          ts: '1700000000.123',
+          channel: 'C1234567890',
+          thread_ts: '1700000000.000',
+          text: '<@U123> hello bot',
+          user: 'U999',
+        },
+      });
+
+      await runImmediateCallback();
+
+      expect(mockHandleSlackEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: expect.objectContaining({
+            type: 'app_mention',
+            ts: '1700000000.123',
+            channel: 'C1234567890',
+            thread_ts: '1700000000.000',
+            text: '<@U123> hello bot',
+            user: 'U999',
+          }),
+          botToken: BOT_TOKEN,
+        })
+      );
+    });
+
+    it('injects the stored API key into the inference request headers', async () => {
+      const handler = registerAndGetHandler(createMockCoreSetup());
+
+      await callHandler(handler, {
+        type: 'event_callback',
+        event: { type: 'app_mention', ts: '1', channel: 'C1', text: 'hello' },
+      });
+
+      await runImmediateCallback();
+
+      const { request: inferenceRequest } = mockHandleSlackEvent.mock.calls[0][0];
+      expect(inferenceRequest.headers.authorization).toBe(`ApiKey ${KIBANA_API_KEY}`);
+    });
+
+    it('skips processing when event field is missing from callback', async () => {
+      const handler = registerAndGetHandler(createMockCoreSetup());
+
+      await callHandler(handler, { type: 'event_callback' }); // no event field
+
+      // No setImmediate callback should have been scheduled
+      expect(capturedImmediateCallback).toBeNull();
+      expect(mockHandleSlackEvent).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_events.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_events.ts
@@ -13,10 +13,10 @@ import { handleSlackEvent } from '../lib/slack_handler';
 
 // POST /api/elastic_console/slack/events
 //
-// Receives Slack events forwarded by the router.
-// Auth: standard Kibana API key (Authorization: ApiKey <key>).
-// The key was generated during /slack/connect and is stored by the router.
-// Kibana verifies the key before the handler runs — no custom auth code needed.
+// Receives Slack events directly from Slack (no router intermediary).
+// Auth: none required — Slack sends no credentials. The bot_token stored
+// in ESO is used to authenticate outbound Slack API calls.
+// The URL verification challenge is handled before any auth check.
 
 export const registerSlackEventsRoute = ({
   router,
@@ -33,10 +33,10 @@ export const registerSlackEventsRoute = ({
       security: {
         authz: {
           enabled: false,
-          reason: 'Authenticated via scoped Kibana API key generated during Slack OAuth',
+          reason: 'Public Slack webhook — no user auth; bot_token provides outbound auth',
         },
       },
-      options: { access: 'public' },
+      options: { access: 'public', authRequired: false },
       validate: {
         body: schema.object({}, { unknowns: 'allow' }),
       },

--- a/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_events.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_events.ts
@@ -6,7 +6,7 @@
  */
 
 import { schema } from '@kbn/config-schema';
-import type { CoreSetup, IRouter, Logger } from '@kbn/core/server';
+import type { CoreSetup, IRouter, KibanaRequest, Logger } from '@kbn/core/server';
 import type { ElasticConsolePluginStart, ElasticConsoleStartDependencies } from '../types';
 import { SLACK_CREDENTIALS_SO_TYPE, SLACK_CREDENTIALS_SO_ID } from '../lib/slack_credentials_so';
 import { handleSlackEvent } from '../lib/slack_handler';
@@ -36,7 +36,7 @@ export const registerSlackEventsRoute = ({
           reason: 'Public Slack webhook — no user auth; bot_token provides outbound auth',
         },
       },
-      options: { access: 'public', authRequired: false },
+      options: { access: 'public', authRequired: false, xsrfRequired: false },
       validate: {
         body: schema.object({}, { unknowns: 'allow' }),
       },
@@ -70,12 +70,22 @@ export const registerSlackEventsRoute = ({
           });
 
           let botToken: string;
+          let inferenceRequest: KibanaRequest;
           try {
-            const creds = await esoClient.getDecryptedAsInternalUser<{ bot_token: string }>(
-              SLACK_CREDENTIALS_SO_TYPE,
-              SLACK_CREDENTIALS_SO_ID
-            );
+            const creds = await esoClient.getDecryptedAsInternalUser<{
+              bot_token: string;
+              kibana_api_key: string;
+            }>(SLACK_CREDENTIALS_SO_TYPE, SLACK_CREDENTIALS_SO_ID);
             botToken = creds.attributes.bot_token;
+            // Use the stored API key to create an authenticated request for
+            // inference calls — Slack events arrive unauthenticated.
+            inferenceRequest = {
+              ...request,
+              headers: {
+                ...request.headers,
+                authorization: `ApiKey ${creds.attributes.kibana_api_key}`,
+              },
+            } as unknown as KibanaRequest;
           } catch (credErr) {
             logger.warn(
               `Slack event received but no bot_token stored yet — run /slack/connect first: ${
@@ -97,7 +107,7 @@ export const registerSlackEventsRoute = ({
             botToken,
             coreStart,
             inference: pluginsStart.inference,
-            request,
+            request: inferenceRequest,
             logger,
           });
         } catch (error) {

--- a/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_events.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_events.ts
@@ -33,10 +33,15 @@ export const registerSlackEventsRoute = ({
       security: {
         authz: {
           enabled: false,
-          reason: 'Public Slack webhook — no user auth; bot_token provides outbound auth',
+          reason:
+            'Authz handled by the Kibana API key generated during Slack OAuth — ' +
+            'the router forwards events with Authorization: ApiKey <key>.',
         },
       },
-      options: { access: 'public', authRequired: false, xsrfRequired: false },
+      // authRequired: true — only the elastic-console-connect router (which holds
+      // the scoped API key from /slack/connect) can POST here. Direct calls from
+      // the internet without a valid API key are rejected.
+      options: { access: 'public', authRequired: true, xsrfRequired: false },
       validate: {
         body: schema.object({}, { unknowns: 'allow' }),
       },

--- a/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_events.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_events.ts
@@ -13,10 +13,16 @@ import { handleSlackEvent } from '../lib/slack_handler';
 
 // POST /api/elastic_console/slack/events
 //
-// Receives Slack events directly from Slack (no router intermediary).
-// Auth: none required — Slack sends no credentials. The bot_token stored
-// in ESO is used to authenticate outbound Slack API calls.
-// The URL verification challenge is handled before any auth check.
+// Receives Slack events forwarded by the elastic-console-connect router.
+// Trust chain: Slack → Elastic's router (verifies X-Slack-Signature) → Kibana (verifies API key).
+//
+// The router authenticates to Kibana using the API key embedded in the JWT state
+// during the OAuth flow (Authorization: ApiKey <key>). Direct calls from the
+// internet without a valid API key are rejected by Kibana's auth layer.
+//
+// Slack request signing verification is intentionally handled by the router,
+// not here — the signing secret is Elastic-owned and cannot be distributed to
+// customer Kibana deployments.
 
 export const registerSlackEventsRoute = ({
   router,

--- a/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_events.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_events.ts
@@ -1,0 +1,111 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema } from '@kbn/config-schema';
+import type { CoreSetup, IRouter, Logger } from '@kbn/core/server';
+import type { ElasticConsolePluginStart, ElasticConsoleStartDependencies } from '../types';
+import { SLACK_CREDENTIALS_SO_TYPE, SLACK_CREDENTIALS_SO_ID } from '../lib/slack_credentials_so';
+import { handleSlackEvent } from '../lib/slack_handler';
+
+// POST /api/elastic_console/slack/events
+//
+// Receives Slack events forwarded by the router.
+// Auth: standard Kibana API key (Authorization: ApiKey <key>).
+// The key was generated during /slack/connect and is stored by the router.
+// Kibana verifies the key before the handler runs — no custom auth code needed.
+
+export const registerSlackEventsRoute = ({
+  router,
+  coreSetup,
+  logger,
+}: {
+  router: IRouter;
+  coreSetup: CoreSetup<ElasticConsoleStartDependencies, ElasticConsolePluginStart>;
+  logger: Logger;
+}) => {
+  router.post(
+    {
+      path: '/api/elastic_console/slack/events',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'Authenticated via scoped Kibana API key generated during Slack OAuth',
+        },
+      },
+      options: { access: 'public' },
+      validate: {
+        body: schema.object({}, { unknowns: 'allow' }),
+      },
+    },
+    async (ctx, request, response) => {
+      const body = request.body as Record<string, unknown>;
+
+      // Handle Slack URL verification challenge (one-time during app setup)
+      if (body.type === 'url_verification') {
+        return response.ok({ body: { challenge: body.challenge } });
+      }
+
+      if (body.type !== 'event_callback') {
+        return response.ok({ body: { ok: true } });
+      }
+
+      const event = body.event as Record<string, unknown> | undefined;
+      if (!event) {
+        return response.ok({ body: { ok: true } });
+      }
+
+      // Ack immediately — Slack requires a 200 within 3 seconds.
+      // Processing runs asynchronously after the response is sent.
+      setImmediate(async () => {
+        try {
+          const [coreStart, pluginsStart] = await coreSetup.getStartServices();
+
+          // Load bot token from encrypted saved objects
+          const esoClient = pluginsStart.encryptedSavedObjects.getClient({
+            includedHiddenTypes: [SLACK_CREDENTIALS_SO_TYPE],
+          });
+
+          let botToken: string;
+          try {
+            const creds = await esoClient.getDecryptedAsInternalUser<{ bot_token: string }>(
+              SLACK_CREDENTIALS_SO_TYPE,
+              SLACK_CREDENTIALS_SO_ID
+            );
+            botToken = creds.attributes.bot_token;
+          } catch (credErr) {
+            logger.warn(
+              `Slack event received but no bot_token stored yet — run /slack/connect first: ${
+                (credErr as Error).message
+              }`
+            );
+            return;
+          }
+
+          await handleSlackEvent({
+            event: {
+              type: event.type as string,
+              ts: event.ts as string,
+              channel: event.channel as string,
+              thread_ts: event.thread_ts as string | undefined,
+              text: event.text as string | undefined,
+              user: event.user as string | undefined,
+            },
+            botToken,
+            coreStart,
+            inference: pluginsStart.inference,
+            request,
+            logger,
+          });
+        } catch (error) {
+          logger.error(`Slack event processing error: ${(error as Error).message}`);
+        }
+      });
+
+      return response.ok({ body: { ok: true } });
+    }
+  );
+};

--- a/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_link_user.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_link_user.ts
@@ -27,7 +27,10 @@ export const registerSlackLinkUserRoutes = ({
     {
       path: '/internal/elastic_console/slack/link_user',
       security: {
-        authz: { enabled: false, reason: 'Caller must be an authenticated Kibana user; checked via getCurrentUser' },
+        authz: {
+          enabled: false,
+          reason: 'Caller must be an authenticated Kibana user; checked via getCurrentUser',
+        },
       },
       options: { access: 'internal' },
       validate: {
@@ -45,7 +48,9 @@ export const registerSlackLinkUserRoutes = ({
           return response.unauthorized();
         }
 
-        const soClient = coreStart.savedObjects.createInternalRepository([SLACK_USER_MAPPING_SO_TYPE]);
+        const soClient = coreStart.savedObjects.createInternalRepository([
+          SLACK_USER_MAPPING_SO_TYPE,
+        ]);
         const now = new Date().toISOString();
         const { slack_user_id: slackUserId } = request.body;
 
@@ -75,7 +80,10 @@ export const registerSlackLinkUserRoutes = ({
     {
       path: '/internal/elastic_console/slack/link_user',
       security: {
-        authz: { enabled: false, reason: 'Caller must be an authenticated Kibana user; checked via getCurrentUser' },
+        authz: {
+          enabled: false,
+          reason: 'Caller must be an authenticated Kibana user; checked via getCurrentUser',
+        },
       },
       options: { access: 'internal' },
       validate: {},
@@ -89,7 +97,9 @@ export const registerSlackLinkUserRoutes = ({
           return response.unauthorized();
         }
 
-        const soClient = coreStart.savedObjects.createInternalRepository([SLACK_USER_MAPPING_SO_TYPE]);
+        const soClient = coreStart.savedObjects.createInternalRepository([
+          SLACK_USER_MAPPING_SO_TYPE,
+        ]);
 
         // Search for a mapping where kibana_username matches the current user
         const results = await soClient.find<SlackUserMappingAttributes>({

--- a/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_link_user.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_link_user.ts
@@ -1,0 +1,119 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema } from '@kbn/config-schema';
+import type { CoreSetup, IRouter, Logger } from '@kbn/core/server';
+import type { ElasticConsolePluginStart, ElasticConsoleStartDependencies } from '../types';
+import {
+  SLACK_USER_MAPPING_SO_TYPE,
+  type SlackUserMappingAttributes,
+} from '../lib/slack_user_mapping_so';
+
+export const registerSlackLinkUserRoutes = ({
+  router,
+  coreSetup,
+  logger,
+}: {
+  router: IRouter;
+  coreSetup: CoreSetup<ElasticConsoleStartDependencies, ElasticConsolePluginStart>;
+  logger: Logger;
+}) => {
+  // Link current Kibana user to a Slack user ID
+  router.post(
+    {
+      path: '/internal/elastic_console/slack/link_user',
+      security: {
+        authz: { enabled: false, reason: 'Caller must be an authenticated Kibana user; checked via getCurrentUser' },
+      },
+      options: { access: 'internal' },
+      validate: {
+        body: schema.object({
+          slack_user_id: schema.string({ minLength: 1 }),
+        }),
+      },
+    },
+    async (_ctx, request, response) => {
+      try {
+        const [coreStart] = await coreSetup.getStartServices();
+
+        const authUser = coreStart.security.authc.getCurrentUser(request);
+        if (!authUser) {
+          return response.unauthorized();
+        }
+
+        const soClient = coreStart.savedObjects.createInternalRepository([SLACK_USER_MAPPING_SO_TYPE]);
+        const now = new Date().toISOString();
+        const { slack_user_id: slackUserId } = request.body;
+
+        // Use the slack_user_id as the SO document ID for O(1) lookup in the handler
+        await soClient.create<SlackUserMappingAttributes>(
+          SLACK_USER_MAPPING_SO_TYPE,
+          {
+            slack_user_id: slackUserId,
+            kibana_username: authUser.username,
+            kibana_user_id: authUser.profile_uid,
+            created_at: now,
+            updated_at: now,
+          },
+          { id: slackUserId, overwrite: true }
+        );
+
+        return response.ok({ body: { slack_user_id: slackUserId, username: authUser.username } });
+      } catch (error) {
+        logger.error(`Link Slack user error: ${error.message}`);
+        return response.customError({ statusCode: 500, body: { message: error.message } });
+      }
+    }
+  );
+
+  // Get the Slack user ID linked to the current Kibana user
+  router.get(
+    {
+      path: '/internal/elastic_console/slack/link_user',
+      security: {
+        authz: { enabled: false, reason: 'Caller must be an authenticated Kibana user; checked via getCurrentUser' },
+      },
+      options: { access: 'internal' },
+      validate: {},
+    },
+    async (_ctx, request, response) => {
+      try {
+        const [coreStart] = await coreSetup.getStartServices();
+
+        const authUser = coreStart.security.authc.getCurrentUser(request);
+        if (!authUser) {
+          return response.unauthorized();
+        }
+
+        const soClient = coreStart.savedObjects.createInternalRepository([SLACK_USER_MAPPING_SO_TYPE]);
+
+        // Search for a mapping where kibana_username matches the current user
+        const results = await soClient.find<SlackUserMappingAttributes>({
+          type: SLACK_USER_MAPPING_SO_TYPE,
+          filter: `elastic-console-slack-user-mapping.attributes.kibana_username: "${authUser.username}"`,
+          perPage: 1,
+        });
+
+        if (results.total === 0) {
+          return response.ok({ body: { linked: false } });
+        }
+
+        const mapping = results.saved_objects[0];
+        return response.ok({
+          body: {
+            linked: true,
+            slack_user_id: mapping.attributes.slack_user_id,
+            username: mapping.attributes.kibana_username,
+          },
+        });
+      } catch (error) {
+        logger.error(`Get Slack link error: ${error.message}`);
+        return response.customError({ statusCode: 500, body: { message: error.message } });
+      }
+    }
+  );
+};

--- a/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_status.test.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_status.test.ts
@@ -1,0 +1,169 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { httpServiceMock, httpServerMock, loggingSystemMock } from '@kbn/core/server/mocks';
+import { registerSlackStatusRoute } from './slack_status';
+import { SLACK_CREDENTIALS_SO_TYPE, SLACK_CREDENTIALS_SO_ID } from '../lib/slack_credentials_so';
+
+const mockLogger = loggingSystemMock.create().get();
+
+const KEY_ID = 'test-key-id';
+const API_KEY_SECRET = 'test-secret';
+const KIBANA_API_KEY = Buffer.from(`${KEY_ID}:${API_KEY_SECRET}`).toString('base64');
+const CONNECTED_AT = '2026-03-20T00:00:00.000Z';
+
+const createMockEsoClient = (overrides?: Partial<{ getDecryptedAsInternalUser: jest.Mock }>) => ({
+  getDecryptedAsInternalUser: jest.fn().mockResolvedValue({
+    attributes: {
+      bot_token: 'xoxb-test',
+      kibana_api_key: KIBANA_API_KEY,
+      updated_at: CONNECTED_AT,
+    },
+  }),
+  ...overrides,
+});
+
+const createMockCoreSetup = (esoClient = createMockEsoClient(), getApiKeyResult?: unknown) => ({
+  getStartServices: jest.fn().mockResolvedValue([
+    {
+      elasticsearch: {
+        client: {
+          asInternalUser: {
+            security: {
+              getApiKey: jest.fn().mockResolvedValue(
+                getApiKeyResult ?? {
+                  api_keys: [{ id: KEY_ID, invalidated: false }],
+                }
+              ),
+            },
+          },
+        },
+      },
+    },
+    {
+      encryptedSavedObjects: {
+        getClient: jest.fn().mockReturnValue(esoClient),
+      },
+    },
+  ]),
+});
+
+describe('registerSlackStatusRoute', () => {
+  let router: ReturnType<typeof httpServiceMock.createRouter>;
+
+  const registerAndGetHandler = (coreSetup = createMockCoreSetup()) => {
+    router = httpServiceMock.createRouter();
+    registerSlackStatusRoute({ router, coreSetup: coreSetup as never, logger: mockLogger });
+    const [, handler] = router.get.mock.calls[0];
+    return { handler, coreSetup };
+  };
+
+  const callHandler = (handler: Function) => {
+    const ctx = {} as never;
+    const request = httpServerMock.createKibanaRequest();
+    const response = httpServerMock.createResponseFactory();
+    return handler(ctx, request, response);
+  };
+
+  it('returns not_connected when no credentials SO exists', async () => {
+    const esoClient = createMockEsoClient({
+      getDecryptedAsInternalUser: jest.fn().mockRejectedValue(new Error('Not found')),
+    });
+    const { handler } = registerAndGetHandler(createMockCoreSetup(esoClient));
+
+    const response = httpServerMock.createResponseFactory();
+    await handler({} as never, httpServerMock.createKibanaRequest(), response);
+
+    expect(response.ok).toHaveBeenCalledWith({ body: { status: 'not_connected' } });
+  });
+
+  it('returns connected when credentials exist and API key is valid', async () => {
+    const { handler } = registerAndGetHandler();
+
+    const response = httpServerMock.createResponseFactory();
+    await handler({} as never, httpServerMock.createKibanaRequest(), response);
+
+    expect(response.ok).toHaveBeenCalledWith({
+      body: { status: 'connected', connected_at: CONNECTED_AT },
+    });
+  });
+
+  it('returns disconnected when API key is invalidated', async () => {
+    const coreSetup = createMockCoreSetup(createMockEsoClient(), {
+      api_keys: [{ id: KEY_ID, invalidated: true }],
+    });
+    const { handler } = registerAndGetHandler(coreSetup);
+
+    const response = httpServerMock.createResponseFactory();
+    await handler({} as never, httpServerMock.createKibanaRequest(), response);
+
+    expect(response.ok).toHaveBeenCalledWith({
+      body: { status: 'disconnected', connected_at: CONNECTED_AT },
+    });
+  });
+
+  it('returns disconnected when getApiKey throws (key gone)', async () => {
+    const coreSetup = {
+      getStartServices: jest.fn().mockResolvedValue([
+        {
+          elasticsearch: {
+            client: {
+              asInternalUser: {
+                security: {
+                  getApiKey: jest.fn().mockRejectedValue(new Error('security_exception')),
+                },
+              },
+            },
+          },
+        },
+        {
+          encryptedSavedObjects: {
+            getClient: jest.fn().mockReturnValue(createMockEsoClient()),
+          },
+        },
+      ]),
+    };
+    const { handler } = registerAndGetHandler(coreSetup as never);
+
+    const response = httpServerMock.createResponseFactory();
+    await handler({} as never, httpServerMock.createKibanaRequest(), response);
+
+    expect(response.ok).toHaveBeenCalledWith({
+      body: { status: 'disconnected', connected_at: CONNECTED_AT },
+    });
+  });
+
+  it('returns disconnected when api_keys array is empty', async () => {
+    const coreSetup = createMockCoreSetup(createMockEsoClient(), { api_keys: [] });
+    const { handler } = registerAndGetHandler(coreSetup);
+
+    const response = httpServerMock.createResponseFactory();
+    await handler({} as never, httpServerMock.createKibanaRequest(), response);
+
+    expect(response.ok).toHaveBeenCalledWith({
+      body: { status: 'disconnected', connected_at: CONNECTED_AT },
+    });
+  });
+
+  it('registers the route at the correct path', () => {
+    registerAndGetHandler();
+    const [routeConfig] = router.get.mock.calls[0];
+    expect(routeConfig.path).toBe('/internal/elastic_console/slack/status');
+  });
+
+  it('uses the correct SO type and ID when reading credentials', async () => {
+    const esoClient = createMockEsoClient();
+    const { handler } = registerAndGetHandler(createMockCoreSetup(esoClient));
+
+    await callHandler(handler);
+
+    expect(esoClient.getDecryptedAsInternalUser).toHaveBeenCalledWith(
+      SLACK_CREDENTIALS_SO_TYPE,
+      SLACK_CREDENTIALS_SO_ID
+    );
+  });
+});

--- a/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_status.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_status.ts
@@ -78,7 +78,10 @@ export const registerSlackStatusRoute = ({
         const keyId = colonIdx !== -1 ? decoded.slice(0, colonIdx) : null;
 
         if (keyId) {
-          const result = await esClient.security.getApiKey({ id: keyId });
+          // owner: true restricts the lookup to keys owned by asInternalUser (kibana_system).
+          // This only requires manage_own_api_key — no need for the broader manage_api_key.
+          // The inference key is created via asInternalUser in /slack/token, so ownership matches.
+          const result = await esClient.security.getApiKey({ id: keyId, owner: true });
           const keyInfo = result.api_keys?.[0];
 
           if (!keyInfo || keyInfo.invalidated) {

--- a/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_status.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_status.ts
@@ -1,0 +1,113 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { CoreSetup, IRouter, Logger } from '@kbn/core/server';
+import type { ElasticConsolePluginStart, ElasticConsoleStartDependencies } from '../types';
+import { SLACK_CREDENTIALS_SO_TYPE, SLACK_CREDENTIALS_SO_ID } from '../lib/slack_credentials_so';
+
+// GET /internal/elastic_console/slack/status
+//
+// Returns the current Slack connection status:
+//   - connected: credentials are stored and the API key is valid
+//   - disconnected: credentials are stored but the API key has been revoked (401)
+//   - not_connected: no credentials found (OAuth never completed)
+//
+// Used by the settings UI to surface "⚠️ Reconnect Slack" when the key is revoked.
+
+export type SlackConnectionStatus = 'connected' | 'disconnected' | 'not_connected';
+
+export interface SlackStatusResponse {
+  status: SlackConnectionStatus;
+  connected_at?: string; // ISO timestamp from updated_at when credentials were stored
+}
+
+export const registerSlackStatusRoute = ({
+  router,
+  coreSetup,
+  logger,
+}: {
+  router: IRouter;
+  coreSetup: CoreSetup<ElasticConsoleStartDependencies, ElasticConsolePluginStart>;
+  logger: Logger;
+}) => {
+  router.get(
+    {
+      path: '/internal/elastic_console/slack/status',
+      security: { authz: { requiredPrivileges: ['agentBuilder:read'] } },
+      options: { access: 'internal' },
+      validate: false,
+    },
+    async (ctx, request, response) => {
+      const [coreStart, pluginsStart] = await coreSetup.getStartServices();
+
+      // Step 1 — check if credentials have ever been stored
+      const esoClient = pluginsStart.encryptedSavedObjects.getClient({
+        includedHiddenTypes: [SLACK_CREDENTIALS_SO_TYPE],
+      });
+
+      let kibanaApiKey: string;
+      let connectedAt: string | undefined;
+
+      try {
+        const creds = await esoClient.getDecryptedAsInternalUser<{
+          bot_token: string;
+          kibana_api_key: string;
+          updated_at?: string;
+        }>(SLACK_CREDENTIALS_SO_TYPE, SLACK_CREDENTIALS_SO_ID);
+
+        kibanaApiKey = creds.attributes.kibana_api_key;
+        connectedAt = creds.attributes.updated_at;
+      } catch {
+        // Saved object does not exist — OAuth never completed
+        return response.ok({
+          body: { status: 'not_connected' } satisfies SlackStatusResponse,
+        });
+      }
+
+      // Step 2 — validate the API key is still active by calling /_security/api_key
+      // A 401 (InvalidApiKey / ApiKeyNotFound) means the key was revoked or expired.
+      try {
+        const esClient = coreStart.elasticsearch.client.asInternalUser;
+        // Decode base64 id:api_key to extract the key id for lookup
+        const decoded = Buffer.from(kibanaApiKey, 'base64').toString('utf8');
+        const colonIdx = decoded.indexOf(':');
+        const keyId = colonIdx !== -1 ? decoded.slice(0, colonIdx) : null;
+
+        if (keyId) {
+          const result = await esClient.security.getApiKey({ id: keyId });
+          const keyInfo = result.api_keys?.[0];
+
+          if (!keyInfo || keyInfo.invalidated) {
+            logger.debug(`Slack API key ${keyId} is invalidated`);
+            return response.ok({
+              body: {
+                status: 'disconnected',
+                connected_at: connectedAt,
+              } satisfies SlackStatusResponse,
+            });
+          }
+        }
+      } catch (err) {
+        // ES returned an error looking up the key — treat as disconnected
+        logger.debug(`Could not verify Slack API key status: ${(err as Error).message}`);
+        return response.ok({
+          body: {
+            status: 'disconnected',
+            connected_at: connectedAt,
+          } satisfies SlackStatusResponse,
+        });
+      }
+
+      return response.ok({
+        body: {
+          status: 'connected',
+          connected_at: connectedAt,
+        } satisfies SlackStatusResponse,
+      });
+    }
+  );
+};

--- a/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_status.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_status.ts
@@ -61,8 +61,8 @@ export const registerSlackStatusRoute = ({
 
         kibanaApiKey = creds.attributes.kibana_api_key;
         connectedAt = creds.attributes.updated_at;
-      } catch {
-        // Saved object does not exist — OAuth never completed
+      } catch (credErr) {
+        logger.debug(`Slack credentials not found — reporting not_connected: ${(credErr as Error).message}`);
         return response.ok({
           body: { status: 'not_connected' } satisfies SlackStatusResponse,
         });

--- a/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_token.test.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_token.test.ts
@@ -1,0 +1,152 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { httpServiceMock, httpServerMock, loggingSystemMock } from '@kbn/core/server/mocks';
+import { registerSlackTokenRoute } from './slack_token';
+import { SLACK_CREDENTIALS_SO_TYPE, SLACK_CREDENTIALS_SO_ID } from '../lib/slack_credentials_so';
+
+const mockLogger = loggingSystemMock.create().get();
+
+const createMocks = (overrides?: {
+  invalidateError?: Error;
+  createApiKeyError?: Error;
+  soCreateError?: Error;
+}) => {
+  const mockInvalidate = jest.fn().mockResolvedValue({});
+  if (overrides?.invalidateError) {
+    mockInvalidate.mockRejectedValue(overrides.invalidateError);
+  }
+
+  const mockCreateApiKey = jest.fn().mockResolvedValue({ id: 'new-key-id', api_key: 'new-secret' });
+  if (overrides?.createApiKeyError) {
+    mockCreateApiKey.mockRejectedValue(overrides.createApiKeyError);
+  }
+
+  const mockSoCreate = jest.fn().mockResolvedValue({});
+  if (overrides?.soCreateError) {
+    mockSoCreate.mockRejectedValue(overrides.soCreateError);
+  }
+
+  const coreSetup = {
+    getStartServices: jest.fn().mockResolvedValue([
+      {
+        elasticsearch: {
+          client: {
+            asInternalUser: {
+              security: {
+                invalidateApiKey: mockInvalidate,
+                createApiKey: mockCreateApiKey,
+              },
+            },
+          },
+        },
+        savedObjects: {
+          getUnsafeInternalClient: jest.fn().mockReturnValue({ create: mockSoCreate }),
+        },
+      },
+    ]),
+  };
+
+  return { coreSetup, mockInvalidate, mockCreateApiKey, mockSoCreate };
+};
+
+describe('registerSlackTokenRoute — reconnect flow', () => {
+  let router: ReturnType<typeof httpServiceMock.createRouter>;
+
+  const registerAndGetHandler = (coreSetup: unknown) => {
+    router = httpServiceMock.createRouter();
+    registerSlackTokenRoute({ router, coreSetup: coreSetup as never, logger: mockLogger });
+    const [, handler] = router.post.mock.calls[0];
+    return handler;
+  };
+
+  const callHandler = (handler: Function, botToken = 'xoxb-new-token') => {
+    const response = httpServerMock.createResponseFactory();
+    const request = httpServerMock.createKibanaRequest({
+      body: { bot_token: botToken },
+    });
+    return handler({} as never, request, response).then(() => response);
+  };
+
+  it('invalidates old inference keys before creating a new one', async () => {
+    const { coreSetup, mockInvalidate, mockCreateApiKey } = createMocks();
+    const handler = registerAndGetHandler(coreSetup);
+
+    const callOrder: string[] = [];
+    mockInvalidate.mockImplementation(async () => {
+      callOrder.push('invalidate');
+    });
+    mockCreateApiKey.mockImplementation(async () => {
+      callOrder.push('create');
+      return { id: 'new-key-id', api_key: 'new-secret' };
+    });
+
+    await callHandler(handler);
+
+    expect(callOrder).toEqual(['invalidate', 'create']);
+    expect(mockInvalidate).toHaveBeenCalledWith({
+      name: 'elastic-console-slack-inference-*',
+    });
+  });
+
+  it('stores the new bot token with overwrite:true — existing SO is replaced', async () => {
+    const { coreSetup, mockSoCreate } = createMocks();
+    const handler = registerAndGetHandler(coreSetup);
+
+    await callHandler(handler, 'xoxb-new-token-after-reconnect');
+
+    expect(mockSoCreate).toHaveBeenCalledWith(
+      SLACK_CREDENTIALS_SO_TYPE,
+      expect.objectContaining({ bot_token: 'xoxb-new-token-after-reconnect' }),
+      expect.objectContaining({ overwrite: true, id: SLACK_CREDENTIALS_SO_ID })
+    );
+  });
+
+  it('stores the newly created API key in the SO', async () => {
+    const { coreSetup, mockSoCreate } = createMocks();
+    const handler = registerAndGetHandler(coreSetup);
+
+    await callHandler(handler);
+
+    const [, soAttributes] = mockSoCreate.mock.calls[0];
+    const decoded = Buffer.from(soAttributes.kibana_api_key, 'base64').toString('utf8');
+    expect(decoded).toBe('new-key-id:new-secret');
+  });
+
+  it('still completes reconnect even when invalidation throws (stale key already gone)', async () => {
+    const { coreSetup, mockSoCreate } = createMocks({
+      invalidateError: new Error('security_exception: key not found'),
+    });
+    const handler = registerAndGetHandler(coreSetup);
+
+    const response = await callHandler(handler);
+
+    // Route should succeed — old key missing is not fatal
+    expect(response.ok).toHaveBeenCalledWith({ body: { ok: true } });
+    expect(mockSoCreate).toHaveBeenCalled();
+  });
+
+  it('returns 500 when API key creation fails', async () => {
+    const { coreSetup } = createMocks({
+      createApiKeyError: new Error('cluster not available'),
+    });
+    const handler = registerAndGetHandler(coreSetup);
+
+    const response = await callHandler(handler);
+
+    expect(response.customError).toHaveBeenCalledWith(
+      expect.objectContaining({ statusCode: 500 })
+    );
+  });
+
+  it('registers a POST route at the correct path', () => {
+    const { coreSetup } = createMocks();
+    registerAndGetHandler(coreSetup);
+    const [routeConfig] = router.post.mock.calls[0];
+    expect(routeConfig.path).toBe('/api/elastic_console/slack/token');
+  });
+});

--- a/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_token.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_token.ts
@@ -70,11 +70,11 @@ export const registerSlackTokenRoute = ({
           'base64'
         );
 
-        // Use the internal repository so ESO's encryption wrapper intercepts the write
-        // without requiring Kibana RBAC on the scoped (connect API key) request.
-        // The endpoint is already authenticated via the connect API key — writing
-        // through the internal repo is safe here.
-        const soClient = coreStart.savedObjects.createInternalRepository([SLACK_CREDENTIALS_SO_TYPE]);
+        // getUnsafeInternalClient applies all SO extensions (including ESO encryption)
+        // without requiring a request or Kibana RBAC on the connect API key.
+        const soClient = coreStart.savedObjects.getUnsafeInternalClient({
+          includedHiddenTypes: [SLACK_CREDENTIALS_SO_TYPE],
+        });
 
         await soClient.create(
           SLACK_CREDENTIALS_SO_TYPE,

--- a/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_token.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_token.ts
@@ -56,12 +56,17 @@ export const registerSlackTokenRoute = ({
       try {
         const [coreStart] = await coreSetup.getStartServices();
 
-        // Auto-generate an API key so the Slack event handler can make
-        // authenticated inference calls even though Slack events are unauthenticated.
-        // Must use asInternalUser — the connect API key is a derived key and ES
-        // requires derived keys to have explicit (empty) role descriptors, which
-        // would create a useless key. Internal user creates an unrestricted key.
         const esClient = coreStart.elasticsearch.client.asInternalUser;
+
+        // Invalidate previous inference keys before creating a new one.
+        try {
+          await esClient.security.invalidateApiKey({ name: 'elastic-console-slack-inference-*' });
+        } catch (err) {
+          logger.warn(`Failed to invalidate stale Slack inference keys: ${(err as Error).message}`);
+        }
+
+        // Must use asInternalUser — the connect API key is a derived key and ES
+        // requires derived keys to have explicit (empty) role descriptors.
         const apiKeyResult = await esClient.security.createApiKey({
           name: `elastic-console-slack-inference-${Date.now()}`,
           expiration: '365d',

--- a/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_token.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_token.ts
@@ -34,14 +34,18 @@ export const registerSlackTokenRoute = ({
     {
       path: '/api/elastic_console/slack/token',
       // Called by the elastic-console-connect router (external service) after OAuth.
-      // Only the Kibana API key created during /slack/connect — which carries the
-      // 'api:elastic_console/slack/events' privilege — can call this route.
+      // Auth: the scoped Kibana API key generated during /slack/connect.
+      // The key itself IS the authorization — only the router which received it
+      // via the JWT state can call this endpoint.
       security: {
         authz: {
-          requiredPrivileges: ['api:elastic_console/slack/events'],
+          enabled: false,
+          reason:
+            'Authenticated via the scoped Kibana API key from /slack/connect. ' +
+            'The key is the authorization — no Kibana RBAC roles needed.',
         },
       },
-      options: { access: 'public', xsrfRequired: false },
+      options: { access: 'public', authRequired: true, xsrfRequired: false },
       validate: {
         body: schema.object({
           bot_token: schema.string({ minLength: 1 }),

--- a/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_token.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_token.ts
@@ -10,7 +10,7 @@ import type { CoreSetup, IRouter, Logger } from '@kbn/core/server';
 import type { ElasticConsolePluginStart, ElasticConsoleStartDependencies } from '../types';
 import { SLACK_CREDENTIALS_SO_TYPE, SLACK_CREDENTIALS_SO_ID } from '../lib/slack_credentials_so';
 
-// POST /internal/elastic_console/slack/token
+// POST /api/elastic_console/slack/token
 //
 // Called by the router after completing OAuth:
 //   1. Router receives bot_token from Slack
@@ -56,9 +56,12 @@ export const registerSlackTokenRoute = ({
       try {
         const [coreStart] = await coreSetup.getStartServices();
 
-        // Auto-generate a scoped API key so the Slack event handler can make
+        // Auto-generate an API key so the Slack event handler can make
         // authenticated inference calls even though Slack events are unauthenticated.
-        const esClient = coreStart.elasticsearch.client.asScoped(request).asCurrentUser;
+        // Must use asInternalUser — the connect API key is a derived key and ES
+        // requires derived keys to have explicit (empty) role descriptors, which
+        // would create a useless key. Internal user creates an unrestricted key.
+        const esClient = coreStart.elasticsearch.client.asInternalUser;
         const apiKeyResult = await esClient.security.createApiKey({
           name: `elastic-console-slack-inference-${Date.now()}`,
           expiration: '365d',

--- a/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_token.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_token.ts
@@ -70,10 +70,11 @@ export const registerSlackTokenRoute = ({
           'base64'
         );
 
-        // Use a scoped client so ESO's encryption wrapper intercepts the write.
-        const soClient = coreStart.savedObjects.getScopedClient(request, {
-          includedHiddenTypes: [SLACK_CREDENTIALS_SO_TYPE],
-        });
+        // Use the internal repository so ESO's encryption wrapper intercepts the write
+        // without requiring Kibana RBAC on the scoped (connect API key) request.
+        // The endpoint is already authenticated via the connect API key — writing
+        // through the internal repo is safe here.
+        const soClient = coreStart.savedObjects.createInternalRepository([SLACK_CREDENTIALS_SO_TYPE]);
 
         await soClient.create(
           SLACK_CREDENTIALS_SO_TYPE,

--- a/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_token.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_token.ts
@@ -70,6 +70,11 @@ export const registerSlackTokenRoute = ({
         const apiKeyResult = await esClient.security.createApiKey({
           name: `elastic-console-slack-inference-${Date.now()}`,
           expiration: '365d',
+          metadata: {
+            managed_by: 'elastic_console',
+            purpose: 'slack_inference_auth',
+            description: 'Authenticates Slack event handler inference and saved-object calls',
+          },
         });
         const kibanaApiKey = Buffer.from(`${apiKeyResult.id}:${apiKeyResult.api_key}`).toString(
           'base64'

--- a/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_token.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_token.ts
@@ -53,16 +53,27 @@ export const registerSlackTokenRoute = ({
       try {
         const [coreStart] = await coreSetup.getStartServices();
 
-        // Use internal client: the SO type is 'agnostic' (global, not space-scoped)
-        // and hidden, so a scoped client would not reach it.
-        const soClient = coreStart.savedObjects.createInternalRepository([
-          SLACK_CREDENTIALS_SO_TYPE,
-        ]);
+        // Auto-generate a scoped API key so the Slack event handler can make
+        // authenticated inference calls even though Slack events are unauthenticated.
+        const esClient = coreStart.elasticsearch.client.asScoped(request).asCurrentUser;
+        const apiKeyResult = await esClient.security.createApiKey({
+          name: `elastic-console-slack-inference-${Date.now()}`,
+          expiration: '365d',
+        });
+        const kibanaApiKey = Buffer.from(`${apiKeyResult.id}:${apiKeyResult.api_key}`).toString(
+          'base64'
+        );
+
+        // Use a scoped client so ESO's encryption wrapper intercepts the write.
+        const soClient = coreStart.savedObjects.getScopedClient(request, {
+          includedHiddenTypes: [SLACK_CREDENTIALS_SO_TYPE],
+        });
 
         await soClient.create(
           SLACK_CREDENTIALS_SO_TYPE,
           {
             bot_token: request.body.bot_token,
+            kibana_api_key: kibanaApiKey,
             updated_at: new Date().toISOString(),
           },
           { overwrite: true, id: SLACK_CREDENTIALS_SO_ID }

--- a/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_token.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_token.ts
@@ -33,13 +33,13 @@ export const registerSlackTokenRoute = ({
   router.post(
     {
       path: '/internal/elastic_console/slack/token',
-      // Auth: the Kibana API key generated during /slack/connect.
-      // It carries the 'api:elastic_console/slack/events' application privilege.
-      // No further authz check needed — the valid API key IS the authorization.
+      // Only the Kibana API key created during /slack/connect — which carries the
+      // 'api:elastic_console/slack/events' privilege — can call this route.
+      // This prevents any other authenticated session or API key from overwriting
+      // the stored credentials.
       security: {
         authz: {
-          enabled: false,
-          reason: 'Authenticated via the Kibana API key generated during Slack OAuth',
+          requiredPrivileges: ['api:elastic_console/slack/events'],
         },
       },
       options: { access: 'internal' },

--- a/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_token.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_token.ts
@@ -32,17 +32,16 @@ export const registerSlackTokenRoute = ({
 }) => {
   router.post(
     {
-      path: '/internal/elastic_console/slack/token',
+      path: '/api/elastic_console/slack/token',
+      // Called by the elastic-console-connect router (external service) after OAuth.
       // Only the Kibana API key created during /slack/connect — which carries the
       // 'api:elastic_console/slack/events' privilege — can call this route.
-      // This prevents any other authenticated session or API key from overwriting
-      // the stored credentials.
       security: {
         authz: {
           requiredPrivileges: ['api:elastic_console/slack/events'],
         },
       },
-      options: { access: 'internal' },
+      options: { access: 'public', xsrfRequired: false },
       validate: {
         body: schema.object({
           bot_token: schema.string({ minLength: 1 }),

--- a/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_token.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/routes/slack_token.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema } from '@kbn/config-schema';
+import type { CoreSetup, IRouter, Logger } from '@kbn/core/server';
+import type { ElasticConsolePluginStart, ElasticConsoleStartDependencies } from '../types';
+import { SLACK_CREDENTIALS_SO_TYPE, SLACK_CREDENTIALS_SO_ID } from '../lib/slack_credentials_so';
+
+// POST /internal/elastic_console/slack/token
+//
+// Called by the router after completing OAuth:
+//   1. Router receives bot_token from Slack
+//   2. Router verifies the JWT state (checks kibana_url + kibana_api_key)
+//   3. Router POSTs { bot_token } here, authenticated with the kibana_api_key
+//      that was embedded in the JWT during /slack/connect
+//
+// The route stores the token encrypted at rest via encryptedSavedObjects.
+// Subsequent Slack events use the decrypted token to call the Slack API.
+
+export const registerSlackTokenRoute = ({
+  router,
+  coreSetup,
+  logger,
+}: {
+  router: IRouter;
+  coreSetup: CoreSetup<ElasticConsoleStartDependencies, ElasticConsolePluginStart>;
+  logger: Logger;
+}) => {
+  router.post(
+    {
+      path: '/internal/elastic_console/slack/token',
+      // Auth: the Kibana API key generated during /slack/connect.
+      // It carries the 'api:elastic_console/slack/events' application privilege.
+      // No further authz check needed — the valid API key IS the authorization.
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'Authenticated via the Kibana API key generated during Slack OAuth',
+        },
+      },
+      options: { access: 'internal' },
+      validate: {
+        body: schema.object({
+          bot_token: schema.string({ minLength: 1 }),
+        }),
+      },
+    },
+    async (ctx, request, response) => {
+      try {
+        const [coreStart] = await coreSetup.getStartServices();
+
+        // Use internal client: the SO type is 'agnostic' (global, not space-scoped)
+        // and hidden, so a scoped client would not reach it.
+        const soClient = coreStart.savedObjects.createInternalRepository([
+          SLACK_CREDENTIALS_SO_TYPE,
+        ]);
+
+        await soClient.create(
+          SLACK_CREDENTIALS_SO_TYPE,
+          {
+            bot_token: request.body.bot_token,
+            updated_at: new Date().toISOString(),
+          },
+          { overwrite: true, id: SLACK_CREDENTIALS_SO_ID }
+        );
+
+        logger.info('Slack bot_token stored successfully');
+        return response.ok({ body: { ok: true } });
+      } catch (error) {
+        logger.error(`Failed to store Slack bot_token: ${(error as Error).message}`);
+        return response.customError({
+          statusCode: 500,
+          body: { message: 'Failed to store Slack credentials' },
+        });
+      }
+    }
+  );
+};

--- a/x-pack/platform/plugins/shared/elastic_console/server/types.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/types.ts
@@ -7,15 +7,21 @@
 
 import type { InferenceServerStart } from '@kbn/inference-plugin/server';
 import type { PluginStartContract as ActionsPluginStart } from '@kbn/actions-plugin/server';
+import type {
+  EncryptedSavedObjectsPluginSetup,
+  EncryptedSavedObjectsPluginStart,
+} from '@kbn/encrypted-saved-objects-plugin/server';
 import type { CloudSetup } from '@kbn/cloud-plugin/server';
 
 export interface ElasticConsoleSetupDependencies {
   cloud?: CloudSetup;
+  encryptedSavedObjects: EncryptedSavedObjectsPluginSetup;
 }
 
 export interface ElasticConsoleStartDependencies {
   inference: InferenceServerStart;
   actions: ActionsPluginStart;
+  encryptedSavedObjects: EncryptedSavedObjectsPluginStart;
 }
 
 export type ElasticConsolePluginSetup = Record<string, never>;


### PR DESCRIPTION
## Summary

Merged the `elastic-console-slack-integration` branch with Elastic Ramen as the primary feature. Slack integration is now available as a separate, dedicated UI page accessible via tabs.

## Changes Made

### 1. Merged Slack Integration Code
- All Slack server-side code, routes, and services from `elastic-console-slack-integration` branch
- Slack credentials, sessions, and user mapping storage
- Slack event handling, notifications, and formatting
- Full test coverage for Slack routes

### 2. Separated UI Pages
- **SetupPage** (setup_page.tsx): Elastic Ramen setup
  - 🍜 Ramen branding with experimental badge  
  - CLI/MCP credential generation
  - Local agent integration
  - Experimental feature warnings

- **SlackOnboardingPage** (slack_onboarding_page.tsx): Slack integration
  - Slack workspace connection/disconnection
  - User account linking
  - Connection status display
  - Clean separation from Ramen setup

### 3. Added Tabbed Navigation
- Both features now accessible via EuiTabbedContent
- Users can switch between Ramen setup and Slack integration
- Each tab maintains its own state

### 4. Verified Slack Routes
All Slack routes are properly registered:
- `/internal/elastic_console/slack/status` - Check connection status
- `/internal/elastic_console/slack/connect` - OAuth flow redirect
- `/internal/elastic_console/slack/disconnect` - Revoke connection
- `/internal/elastic_console/slack/link_user` - Link Slack user to Kibana
- `/internal/elastic_console/slack/token` - Token management
- `/internal/elastic_console/slack/events` - Event webhook handling

## Breaking Changes
None - this is a feature merge that maintains backward compatibility.

## Testing
- Slack routes include comprehensive test coverage
- UI pages are isolated and can be tested independently
- Tabbed navigation allows testing both features in isolation

## Related
Resolves merge of `elastic-console-slack-integration` branch