### PR TITLE
[Observability Onboarding] Use locator handler for AI Agent modal to avoid click-interception race     

### DIFF
--- a/x-pack/solutions/observability/plugins/observability_onboarding/e2e/playwright/stateful/pom/pages/onboarding_home.page.ts
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/e2e/playwright/stateful/pom/pages/onboarding_home.page.ts
@@ -81,11 +81,12 @@ export class OnboardingHomePage {
   }
 
   public async maybeClickIntroducingAIAgentModalContinueBtn() {
-    try {
-      await this.introducingAIAgentModalContinueBtn.waitFor({ state: 'visible', timeout: 5000 });
-      await this.introducingAIAgentModalContinueBtn.click();
-    } catch {
-      // Modal didn't appear within timeout — continue normally
-    }
+    await this.page.addLocatorHandler(
+      this.introducingAIAgentModalContinueBtn,
+      async (btn) => {
+        await btn.click();
+      },
+      { times: 1 }
+    );
   }
 }


### PR DESCRIPTION
## Summary                                                                                  
                                         
  Replaces the fixed-timeout `waitFor` + silent `catch` in `maybeClickIntroducingAIAgentModalContinueBtn` with Playwright's `page.addLocatorHandler`.   
                                                                                                
  ## Why                                                                                        
                                         
  The AI Agent announcement modal mounts asynchronously and can appear after  the existing 5s `waitFor` window expires. When that happened, the silent catch let the test proceed, and the modal then mounted and blocked the next click with the `euiOverlayMask` producing long retry storms against `observabilityOnboardingUseCaseCard-kubernetes`                                          
                                                                                                
  ## Validation                                                                               
                                                                                                
https://github.com/elastic/ensemble/actions/runs/24570409527            