### PR TITLE
[Entity Analytics] Fix V1 risk engine routes called when entityAnalyticsEntityStoreV2 is enabled

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/api.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/api.ts
@@ -141,8 +141,9 @@ export const useEntityAnalyticsRoutes = () => {
   const isEntityAnalyticsEntityStoreV2Enabled = useIsExperimentalFeatureEnabled(
     'entityAnalyticsEntityStoreV2'
   );
-  const isMaintainerRiskScoreV2Enabled =
-    isEntityStoreV2UiSettingEnabled && isEntityAnalyticsEntityStoreV2Enabled;
+  // When entityAnalyticsEntityStoreV2 is enabled, the V1 risk_engine:risk_scoring task type is
+  // removed from Task Manager entirely. Always use entity maintainers regardless of the uiSetting.
+  const isMaintainerRiskScoreV2Enabled = isEntityAnalyticsEntityStoreV2Enabled;
 
   return useMemo(() => {
     const fetchEntityMaintainers = (ids?: string[]) =>

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_engine/routes/utils.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_engine/routes/utils.ts
@@ -12,7 +12,6 @@ import type {
   HttpResponsePayload,
   ResponseError,
 } from '@kbn/core/server';
-import { FF_ENABLE_ENTITY_STORE_V2 } from '@kbn/entity-store/common';
 import { buildSiemResponse } from '@kbn/lists-plugin/server/routes';
 import type { SecuritySolutionRequestHandlerContext } from '../../../../types';
 import { ENTITY_ANALYTICS_V2_MODE_API_ERROR } from './translations';
@@ -31,15 +30,8 @@ export const withEntityStoreV2Disabled = <P, Q, B, T extends HttpResponsePayload
     response: KibanaResponseFactory
   ): Promise<IKibanaResponse<T>> => {
     if (isRiskScoringMaintainerEnabled) {
-      const core = await context.core;
-      const isEntityStoreV2ModeEnabled = await core.uiSettings.client.get<boolean>(
-        FF_ENABLE_ENTITY_STORE_V2
-      );
-
-      if (!isEntityStoreV2ModeEnabled) {
-        return handler(context, request, response);
-      }
-
+      // When the V2 experimental flag is enabled, the V1 risk_engine:risk_scoring task type is
+      // unregistered entirely. Block V1 routes unconditionally — the uiSetting is irrelevant here.
       const siemResponse = buildSiemResponse(response);
       return siemResponse.error({
         statusCode: 400,


### PR DESCRIPTION
## Summary

- When `entityAnalyticsEntityStoreV2` is enabled, the V1 `risk_engine:risk_scoring` task type is unregistered from Task Manager. The client was routing to entity maintainers only when **both** the experimental flag AND `entityStoreEnableV2` uiSetting were `true`. Spaces where the uiSetting was never explicitly saved used the `false` fallback, causing the client to call dead V1 routes.
- On 9.4 BC2, this produced a 400 "This API is not available when Entity Store V2 is enabled" — because the server read the registered default of `true` while the client read the fallback `false`, creating a client/server mismatch.
- Locally (main branch registered default = `false`), this produced a 500 "Unsupported task type `risk_engine:risk_scoring`".

**Fix:**
- `api.ts`: `isMaintainerRiskScoreV2Enabled` now depends only on the experimental flag — entity maintainers are always used when `entityAnalyticsEntityStoreV2` is on, regardless of the uiSetting.
- `utils.ts`: Remove the `entityStoreEnableV2` loophole in `withEntityStoreV2Disabled` that previously allowed V1 routes through when the uiSetting was `false`. V1 routes are unconditionally blocked when the experimental flag is on.

Fixes https://github.com/elastic/kibana/issues/263958

## Test plan

- [ ] With `entityAnalyticsEntityStoreV2` enabled and `entityStoreEnableV2` NOT explicitly saved (or set to `false`), toggling Entity Analytics on should call entity maintainers routes (not V1 risk engine routes)
- [ ] With both flags enabled, toggle on/off works end-to-end
- [ ] With `entityAnalyticsEntityStoreV2` disabled, V1 risk engine routes still work normally
- [ ] Existing unit tests pass: `use_toggle_entity_analytics.test.ts` (25 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
