### PR TITLE
[Content List] Column layout props, sticky actions, and title click handlers

### DIFF
--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-docs/src/core_extended_features.stories.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-docs/src/core_extended_features.stories.tsx
@@ -31,8 +31,27 @@ import {
 // Storybook Meta
 // =============================================================================
 
-const meta: Meta = {
+interface ExtendedStoryArgs {
+  scrollableInline: boolean;
+  responsiveBreakpoint: boolean;
+}
+
+const meta: Meta<ExtendedStoryArgs> = {
   title: 'Content List/Core Features + Extended',
+  argTypes: {
+    scrollableInline: {
+      control: 'boolean',
+      description: 'Enable horizontal scrolling when columns exceed container width.',
+    },
+    responsiveBreakpoint: {
+      control: 'boolean',
+      description: 'Collapse the table into responsive cards on narrow viewports.',
+    },
+  },
+  args: {
+    scrollableInline: true,
+    responsiveBreakpoint: false,
+  },
   decorators: [
     (Story) => (
       <div style={{ padding: '20px', maxWidth: '1200px' }}>
@@ -68,7 +87,10 @@ const { Filters } = ContentListToolbar;
  * - [x] Created By filter — include/exclude by user (PR 10)
  * - [x] Content editor — "View details" row action via `item.onInspect` (PR 12)
  */
-const CoreTagsStarredFeaturesWrapper = () => {
+const CoreTagsStarredFeaturesWrapper = ({
+  scrollableInline = true,
+  responsiveBreakpoint = false,
+}: ExtendedStoryArgs) => {
   const { onInspect, flyout } = useInspectFlyout();
 
   const labels = useMemo(
@@ -158,11 +180,22 @@ const CoreTagsStarredFeaturesWrapper = () => {
             <Filters.Sort />
           </Filters>
         </ContentListToolbar>
-        <ContentListTable title="dashboards table">{tableChildren}</ContentListTable>
+        <ContentListTable title="dashboards table" {...{ scrollableInline, responsiveBreakpoint }}>
+          {tableChildren}
+        </ContentListTable>
         <ContentListFooter />
       </ContentListProvider>
     ),
-    [labels, dataSource, features, itemConfig, favoritesClient, tableChildren]
+    [
+      labels,
+      dataSource,
+      features,
+      itemConfig,
+      favoritesClient,
+      tableChildren,
+      scrollableInline,
+      responsiveBreakpoint,
+    ]
   );
 
   return (
@@ -202,7 +235,12 @@ const CoreTagsStarredFeaturesWrapper = () => {
           </ContentListToolbar>
         </EuiFlexItem>
         <EuiFlexItem>
-          <ContentListTable title="dashboards table">{tableChildren}</ContentListTable>
+          <ContentListTable
+            title="dashboards table"
+            {...{ scrollableInline, responsiveBreakpoint }}
+          >
+            {tableChildren}
+          </ContentListTable>
         </EuiFlexItem>
         <EuiFlexItem>
           <ContentListFooter />
@@ -232,7 +270,9 @@ const CoreTagsStarredFeaturesWrapper = () => {
  * "Starred" filter to narrow the list. Use the "Created by" filter to filter by
  * user, or type `createdBy:email` in the search bar. Hold Cmd/Ctrl to exclude.
  */
-export const CoreTagsStarredFeatures: StoryObj = {
+type Story = StoryObj<ExtendedStoryArgs>;
+
+export const CoreTagsStarredFeatures: Story = {
   name: 'Core Features + Extended',
-  render: () => <CoreTagsStarredFeaturesWrapper />,
+  render: (args) => <CoreTagsStarredFeaturesWrapper {...args} />,
 };

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-docs/src/core_features.stories.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-docs/src/core_features.stories.tsx
@@ -21,8 +21,27 @@ import { createStoryFindItems, StateDiagnosticPanel } from './stories_helpers';
 // Storybook Meta
 // =============================================================================
 
-const meta: Meta = {
+interface CoreFeaturesStoryArgs {
+  scrollableInline: boolean;
+  responsiveBreakpoint: boolean;
+}
+
+const meta: Meta<CoreFeaturesStoryArgs> = {
   title: 'Content List/Core Features',
+  argTypes: {
+    scrollableInline: {
+      control: 'boolean',
+      description: 'Enable horizontal scrolling when columns exceed container width.',
+    },
+    responsiveBreakpoint: {
+      control: 'boolean',
+      description: 'Collapse the table into responsive cards on narrow viewports.',
+    },
+  },
+  args: {
+    scrollableInline: true,
+    responsiveBreakpoint: false,
+  },
   decorators: [
     (Story) => (
       <div style={{ padding: '20px', maxWidth: '1200px' }}>
@@ -57,7 +76,10 @@ const { Column, Action } = ContentListTable;
  * - [x] Search (PR 4)
  * - [x] Selection + bulk bar (PR 7)
  */
-const CoreFeaturesWrapper = () => {
+const CoreFeaturesWrapper = ({
+  scrollableInline = true,
+  responsiveBreakpoint = false,
+}: CoreFeaturesStoryArgs) => {
   const labels = useMemo(
     () => ({
       entity: 'dashboard',
@@ -125,11 +147,16 @@ const CoreFeaturesWrapper = () => {
         item={itemConfig}
       >
         <ContentListToolbar />
-        <ContentListTable title="dashboards table">{tableChildren}</ContentListTable>
+        <ContentListTable
+          title="dashboards table"
+          {...{ scrollableInline, responsiveBreakpoint }}
+        >
+          {tableChildren}
+        </ContentListTable>
         <ContentListFooter />
       </ContentListProvider>
     ),
-    [labels, dataSource, features, itemConfig, tableChildren]
+    [labels, dataSource, features, itemConfig, tableChildren, scrollableInline, responsiveBreakpoint]
   );
 
   return (
@@ -151,7 +178,12 @@ const CoreFeaturesWrapper = () => {
           <ContentListToolbar />
         </EuiFlexItem>
         <EuiFlexItem>
-          <ContentListTable title="dashboards table">{tableChildren}</ContentListTable>
+          <ContentListTable
+            title="dashboards table"
+            {...{ scrollableInline, responsiveBreakpoint }}
+          >
+            {tableChildren}
+          </ContentListTable>
         </EuiFlexItem>
         <EuiFlexItem>
           <ContentListFooter />
@@ -178,7 +210,9 @@ const CoreFeaturesWrapper = () => {
  * composable `ContentListToolbar`, `ContentListTable`, and
  * `ContentListFooter` children that read from the provider via context.
  */
-export const CoreFeatures: StoryObj = {
+type Story = StoryObj<CoreFeaturesStoryArgs>;
+
+export const CoreFeatures: Story = {
   name: 'Core Features',
-  render: () => <CoreFeaturesWrapper />,
+  render: (args) => <CoreFeaturesWrapper {...args} />,
 };

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-docs/src/core_features.stories.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-docs/src/core_features.stories.tsx
@@ -147,16 +147,21 @@ const CoreFeaturesWrapper = ({
         item={itemConfig}
       >
         <ContentListToolbar />
-        <ContentListTable
-          title="dashboards table"
-          {...{ scrollableInline, responsiveBreakpoint }}
-        >
+        <ContentListTable title="dashboards table" {...{ scrollableInline, responsiveBreakpoint }}>
           {tableChildren}
         </ContentListTable>
         <ContentListFooter />
       </ContentListProvider>
     ),
-    [labels, dataSource, features, itemConfig, tableChildren, scrollableInline, responsiveBreakpoint]
+    [
+      labels,
+      dataSource,
+      features,
+      itemConfig,
+      tableChildren,
+      scrollableInline,
+      responsiveBreakpoint,
+    ]
   );
 
   return (

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-docs/src/core_tags_features.stories.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-docs/src/core_tags_features.stories.tsx
@@ -27,8 +27,27 @@ import {
 // Storybook Meta
 // =============================================================================
 
-const meta: Meta = {
+interface TagsStoryArgs {
+  scrollableInline: boolean;
+  responsiveBreakpoint: boolean;
+}
+
+const meta: Meta<TagsStoryArgs> = {
   title: 'Content List/Core Features + Tags',
+  argTypes: {
+    scrollableInline: {
+      control: 'boolean',
+      description: 'Enable horizontal scrolling when columns exceed container width.',
+    },
+    responsiveBreakpoint: {
+      control: 'boolean',
+      description: 'Collapse the table into responsive cards on narrow viewports.',
+    },
+  },
+  args: {
+    scrollableInline: true,
+    responsiveBreakpoint: false,
+  },
   decorators: [
     (Story) => (
       <div style={{ padding: '20px', maxWidth: '1200px' }}>
@@ -59,7 +78,10 @@ const { Filters } = ContentListToolbar;
  * - [x] Tag badges in Name column — click to filter (PR 9)
  * - [x] Search bar ↔ filter sync — `tag:name` parsed to `filters.tag` (PR 9)
  */
-const TagsFeaturesWrapper = () => {
+const TagsFeaturesWrapper = ({
+  scrollableInline = true,
+  responsiveBreakpoint = false,
+}: TagsStoryArgs) => {
   const labels = useMemo(
     () => ({
       entity: 'map',
@@ -134,11 +156,21 @@ const TagsFeaturesWrapper = () => {
             <Filters.Sort />
           </Filters>
         </ContentListToolbar>
-        <ContentListTable title="maps table">{tableChildren}</ContentListTable>
+        <ContentListTable title="maps table" {...{ scrollableInline, responsiveBreakpoint }}>
+          {tableChildren}
+        </ContentListTable>
         <ContentListFooter />
       </ContentListProvider>
     ),
-    [labels, dataSource, features, itemConfig, tableChildren]
+    [
+      labels,
+      dataSource,
+      features,
+      itemConfig,
+      tableChildren,
+      scrollableInline,
+      responsiveBreakpoint,
+    ]
   );
 
   return (
@@ -173,7 +205,9 @@ const TagsFeaturesWrapper = () => {
           </ContentListToolbar>
         </EuiFlexItem>
         <EuiFlexItem>
-          <ContentListTable title="maps table">{tableChildren}</ContentListTable>
+          <ContentListTable title="maps table" {...{ scrollableInline, responsiveBreakpoint }}>
+            {tableChildren}
+          </ContentListTable>
         </EuiFlexItem>
         <EuiFlexItem>
           <ContentListFooter />
@@ -201,7 +235,9 @@ const TagsFeaturesWrapper = () => {
  * Cmd (Mac) or Ctrl (Windows/Linux) while clicking to exclude instead.
  * Type `tag:Production` directly in the search bar to see query sync.
  */
-export const TagsFeatures: StoryObj = {
+type Story = StoryObj<TagsStoryArgs>;
+
+export const TagsFeatures: Story = {
   name: 'Core Features + Tags',
-  render: () => <TagsFeaturesWrapper />,
+  render: (args) => <TagsFeaturesWrapper {...args} />,
 };

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/README.md
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/README.md
@@ -36,7 +36,7 @@ const { Column } = ContentListTable;
 
 Column sizing props (`width`, `minWidth`, `maxWidth`, `truncateText`) map to `EuiBasicTable` column layout props. Prefer `em` units for text columns, set `minWidth` so headers remain readable, and set `maxWidth` so user content cannot stretch the table too far. `Column.Actions` is sticky by default for tables with horizontal overflow.
 
-`Column.Name` uses the provider-level `item.getHref` link by default. Passing `onClick` makes the title use that click handler instead of `getHref`; set `useHref` to preserve native link affordances such as Cmd/Ctrl-click while handling plain clicks with `onClick`.
+`Column.Name` uses the provider-level `item.getHref` link by default. Passing `onClick` makes the title use that click handler instead of `getHref`; set `shouldUseHref` to preserve native link affordances such as Cmd/Ctrl-click while handling plain clicks with `onClick`.
 
 ### Available column presets
 

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/README.md
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/README.md
@@ -21,14 +21,22 @@ Use the `Column` compound component to declare columns as children. Order in JSX
 const { Column } = ContentListTable;
 
 <ContentListTable title="Dashboards">
-  <Column.Name width="40%" />
+  <Column.Name width="32em" minWidth="24em" maxWidth="64em" truncateText={false} />
   <Column
     id="status"
     name="Status"
+    width="12em"
+    minWidth="10em"
+    maxWidth="16em"
+    truncateText
     render={(item) => <EuiBadge>{item.status}</EuiBadge>}
   />
 </ContentListTable>
 ```
+
+Column sizing props (`width`, `minWidth`, `maxWidth`, `truncateText`) map to `EuiBasicTable` column layout props. Prefer `em` units for text columns, set `minWidth` so headers remain readable, and set `maxWidth` so user content cannot stretch the table too far. `Column.Actions` is sticky by default for tables with horizontal overflow.
+
+`Column.Name` uses the provider-level `item.getHref` link by default. Passing `onClick` makes the title use that click handler instead of `getHref`; set `useHref` to preserve native link affordances such as Cmd/Ctrl-click while handling plain clicks with `onClick`.
 
 ### Available column presets
 

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/actions/actions_builder.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/actions/actions_builder.test.tsx
@@ -192,16 +192,33 @@ describe('actions column builder', () => {
 
     describe('custom configuration', () => {
       it('applies custom width', () => {
-        const props: ActionsColumnProps = { width: '150px' };
+        const props: ActionsColumnProps = {
+          width: '5em',
+          minWidth: '5em',
+          maxWidth: '5em',
+        };
         const result = buildActionsColumn(props, defaultContext);
 
-        expect(result).toMatchObject({ width: '150px' });
+        expect(result).toMatchObject({ width: '5em', minWidth: '5em', maxWidth: '5em' });
       });
 
-      it('does not include width when not specified', () => {
+      it('computes a default width from the action count when not specified', () => {
         const result = buildActionsColumn({}, defaultContext);
 
-        expect(result).not.toHaveProperty('width');
+        // 2 actions × 28px + 8px padding = 64px.
+        expect(result).toMatchObject({ width: '64px', minWidth: '64px' });
+      });
+
+      it('sticks the actions column by default', () => {
+        const result = buildActionsColumn({}, defaultContext);
+
+        expect(result).toMatchObject({ sticky: true });
+      });
+
+      it('allows sticky behavior to be disabled', () => {
+        const result = buildActionsColumn({ sticky: false }, defaultContext);
+
+        expect(result).toMatchObject({ sticky: false });
       });
 
       it('applies custom column title', () => {

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/actions/actions_builder.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/actions/actions_builder.tsx
@@ -142,9 +142,11 @@ export const buildActionsColumn = (
     return undefined;
   }
 
-  // Each `EuiButtonIcon` in EUI's expanded actions cell is 24px wide with 4px
-  // inline gap. Add 8px for cell padding so adjacent columns with long content
-  // do not squeeze the actions column.
+  // Each `EuiButtonIcon` (xs) is `euiTheme.size.l` (24px) wide with a 4px
+  // inline gap — matching `euiButtonSizeMap`'s `xs.height`. `euiButtonSizeMap`
+  // requires a live EUI theme context so we derive the constant here instead.
+  // Add 8px for cell padding so adjacent columns with long content do not
+  // squeeze the actions column.
   const defaultWidth = `${actions.length * 28 + 8}px`;
 
   return {

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/actions/actions_builder.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/actions/actions_builder.tsx
@@ -14,6 +14,7 @@ import type { ContentListItem } from '@kbn/content-list-provider';
 import type { ParsedPart } from '@kbn/content-list-assembly';
 import type { ColumnBuilderContext } from '../types';
 import { column } from '../part';
+import { getColumnLayoutProps, type ColumnLayoutProps } from '../layout';
 import { action, type ActionOutput, type ActionBuilderContext } from '../../action';
 
 /** Default i18n-translated column title for the actions column. */
@@ -28,11 +29,16 @@ const DEFAULT_ACTIONS_COLUMN_TITLE = i18n.translate(
  * These are the declarative attributes consumers pass in JSX. The actions builder
  * reads them directly from the parsed attributes.
  */
-export interface ActionsColumnProps {
-  /** Column width (CSS value like `'100px'`). */
-  width?: string;
+export interface ActionsColumnProps
+  extends Pick<ColumnLayoutProps, 'width' | 'minWidth' | 'maxWidth'> {
   /** Custom column title. Defaults to `'Actions'`. */
   columnTitle?: string;
+  /**
+   * Whether to stick the actions column to the right side during horizontal scroll.
+   *
+   * @default true
+   */
+  sticky?: boolean;
   /**
    * Action children.
    *
@@ -113,7 +119,7 @@ export const buildActionsColumn = (
   attributes: ActionsColumnProps,
   context: ColumnBuilderContext
 ): EuiBasicTableColumn<ContentListItem> | undefined => {
-  const { children, width, columnTitle } = attributes;
+  const { children, width, minWidth, maxWidth, columnTitle, sticky = true } = attributes;
 
   // Parse action children from the Column.Actions element.
   const actionParts = children !== undefined ? action.parseChildren(children) : [];
@@ -136,10 +142,20 @@ export const buildActionsColumn = (
     return undefined;
   }
 
+  // Each `EuiButtonIcon` in EUI's expanded actions cell is 24px wide with 4px
+  // inline gap. Add 8px for cell padding so adjacent columns with long content
+  // do not squeeze the actions column.
+  const defaultWidth = `${actions.length * 28 + 8}px`;
+
   return {
     name: columnTitle ?? DEFAULT_ACTIONS_COLUMN_TITLE,
     actions,
-    ...(width && { width }),
+    ...getColumnLayoutProps({
+      width: width ?? defaultWidth,
+      minWidth: minWidth ?? width ?? defaultWidth,
+      maxWidth,
+    }),
+    sticky,
     'data-test-subj': 'content-list-table-column-actions',
   };
 };

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/created_by/created_by_builder.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/created_by/created_by_builder.test.tsx
@@ -110,15 +110,24 @@ describe('created by column builder', () => {
     expect(result).toBeUndefined();
   });
 
-  it('uses custom title and width when provided', () => {
+  it('uses custom title and layout props when provided', () => {
     const result = buildCreatedByColumn(
-      { columnTitle: 'Owner', width: '72px' } satisfies CreatedByColumnProps,
+      {
+        columnTitle: 'Owner',
+        width: '8em',
+        minWidth: '8em',
+        maxWidth: '12em',
+        truncateText: true,
+      } satisfies CreatedByColumnProps,
       defaultContext
     );
 
     expect(result).toMatchObject({
       name: 'Owner',
-      width: '72px',
+      width: '8em',
+      minWidth: '8em',
+      maxWidth: '12em',
+      truncateText: true,
     });
   });
 

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/created_by/created_by_builder.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/created_by/created_by_builder.tsx
@@ -13,6 +13,7 @@ import type { ContentListItem } from '@kbn/content-list-provider';
 import { i18n } from '@kbn/i18n';
 import type { ColumnBuilderContext } from '../types';
 import { column } from '../part';
+import { getColumnLayoutProps, type ColumnLayoutProps } from '../layout';
 import { CreatedByCell } from './created_by_cell';
 
 const DEFAULT_COLUMN_TITLE = i18n.translate(
@@ -23,9 +24,7 @@ const DEFAULT_COLUMN_TITLE = i18n.translate(
 /**
  * Props for the `Column.CreatedBy` preset component.
  */
-export interface CreatedByColumnProps {
-  /** Column width (CSS value). */
-  width?: string;
+export interface CreatedByColumnProps extends ColumnLayoutProps {
   /** Override column header text. Defaults to "Created by". */
   columnTitle?: string;
 }
@@ -44,13 +43,13 @@ export const buildCreatedByColumn = (
     return undefined;
   }
 
-  const { width, columnTitle } = attributes;
+  const { columnTitle, ...layoutProps } = attributes;
 
   return {
+    ...getColumnLayoutProps(layoutProps),
     field: 'createdBy',
     name: columnTitle ?? DEFAULT_COLUMN_TITLE,
     sortable: false,
-    ...(width && { width }),
     'data-test-subj': 'content-list-table-column-createdBy',
     render: (value: string | undefined, record: ContentListItem) => {
       return <CreatedByCell createdBy={value} managed={!!record.managed} />;

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/layout.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/layout.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { EuiTableFieldDataColumnType } from '@elastic/eui';
+
+export type ColumnLayoutProps = Pick<
+  EuiTableFieldDataColumnType<object>,
+  'width' | 'minWidth' | 'maxWidth' | 'truncateText'
+>;
+
+export const getColumnLayoutProps = ({
+  width,
+  minWidth,
+  maxWidth,
+  truncateText,
+}: ColumnLayoutProps): ColumnLayoutProps => ({
+  ...(width && { width }),
+  ...(minWidth && { minWidth }),
+  ...(maxWidth && { maxWidth }),
+  ...(truncateText !== undefined && { truncateText }),
+});

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/name/cell_title.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/name/cell_title.test.tsx
@@ -163,6 +163,33 @@ describe('NameCellTitle', () => {
     expect(handleClick).not.toHaveBeenCalled();
   });
 
+  it('invokes `onClick` on modifier-key click when `shouldUseHref` is true but `getHref` returns undefined', () => {
+    // Regression: the early-return guard must check whether `href` resolved to a
+    // value, not just whether `shouldUseHref` was set. When `getHref` is absent
+    // or returns `undefined`, modifier-key clicks must still call `onClick`.
+    const Wrapper = createWrapper({});
+    const item = createItem({ title: 'No-Href Clickable Item' });
+    const handleClick = jest.fn();
+
+    render(
+      <Wrapper>
+        <NameCellTitle item={item} onClick={handleClick} shouldUseHref />
+      </Wrapper>
+    );
+
+    const link = screen.getByTestId('content-list-table-item-link');
+    const clickEvent = new MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+      metaKey: true,
+    });
+
+    fireEvent(link, clickEvent);
+
+    expect(link).not.toHaveAttribute('href');
+    expect(handleClick).toHaveBeenCalledWith(item);
+  });
+
   it('renders as plain text when `shouldUseHref` is false and `onClick` is omitted', () => {
     const Wrapper = createWrapper({ getHref: (item) => `/view/${item.id}` });
 

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/name/cell_title.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/name/cell_title.test.tsx
@@ -117,14 +117,14 @@ describe('NameCellTitle', () => {
     expect(handleClick).toHaveBeenCalledWith(item);
   });
 
-  it('uses `getHref` with `onClick` when `useHref` is true', () => {
+  it('uses `getHref` with `onClick` when `shouldUseHref` is true', () => {
     const Wrapper = createWrapper({ getHref: (item) => `/view/${item.id}` });
     const item = createItem({ title: 'Linked Clickable Item' });
     const handleClick = jest.fn();
 
     render(
       <Wrapper>
-        <NameCellTitle item={item} onClick={handleClick} useHref />
+        <NameCellTitle item={item} onClick={handleClick} shouldUseHref />
       </Wrapper>
     );
 
@@ -138,14 +138,14 @@ describe('NameCellTitle', () => {
     expect(handleClick).toHaveBeenCalledWith(item);
   });
 
-  it('allows modified clicks to use `getHref` when `useHref` is true', () => {
+  it('allows modified clicks to use `getHref` when `shouldUseHref` is true', () => {
     const Wrapper = createWrapper({ getHref: (item) => `/view/${item.id}` });
     const item = createItem({ title: 'Linked Clickable Item' });
     const handleClick = jest.fn();
 
     render(
       <Wrapper>
-        <NameCellTitle item={item} onClick={handleClick} useHref />
+        <NameCellTitle item={item} onClick={handleClick} shouldUseHref />
       </Wrapper>
     );
 
@@ -163,12 +163,12 @@ describe('NameCellTitle', () => {
     expect(handleClick).not.toHaveBeenCalled();
   });
 
-  it('renders as plain text when `useHref` is false and `onClick` is omitted', () => {
+  it('renders as plain text when `shouldUseHref` is false and `onClick` is omitted', () => {
     const Wrapper = createWrapper({ getHref: (item) => `/view/${item.id}` });
 
     render(
       <Wrapper>
-        <NameCellTitle item={createItem({ title: 'Plain Item' })} useHref={false} />
+        <NameCellTitle item={createItem({ title: 'Plain Item' })} shouldUseHref={false} />
       </Wrapper>
     );
 

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/name/cell_title.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/name/cell_title.test.tsx
@@ -8,7 +8,7 @@
  */
 
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import {
   ContentListProvider,
   type FindItemsResult,
@@ -80,6 +80,99 @@ describe('NameCellTitle', () => {
     );
 
     expect(screen.getByText('No Link Item')).toBeInTheDocument();
+    expect(screen.queryByTestId('content-list-table-item-link')).not.toBeInTheDocument();
+  });
+
+  it('renders as a link and calls `onClick` when provided without `getHref`', () => {
+    const Wrapper = createWrapper();
+    const item = createItem({ title: 'Clickable Item' });
+    const handleClick = jest.fn();
+
+    render(
+      <Wrapper>
+        <NameCellTitle item={item} onClick={handleClick} />
+      </Wrapper>
+    );
+
+    fireEvent.click(screen.getByTestId('content-list-table-item-link'));
+
+    expect(handleClick).toHaveBeenCalledWith(item);
+  });
+
+  it('ignores `getHref` by default when `onClick` is provided', () => {
+    const Wrapper = createWrapper({ getHref: (item) => `/view/${item.id}` });
+    const item = createItem({ title: 'Linked Clickable Item' });
+    const handleClick = jest.fn();
+
+    render(
+      <Wrapper>
+        <NameCellTitle item={item} onClick={handleClick} />
+      </Wrapper>
+    );
+
+    const link = screen.getByTestId('content-list-table-item-link');
+    fireEvent.click(link);
+
+    expect(link).not.toHaveAttribute('href');
+    expect(handleClick).toHaveBeenCalledWith(item);
+  });
+
+  it('uses `getHref` with `onClick` when `useHref` is true', () => {
+    const Wrapper = createWrapper({ getHref: (item) => `/view/${item.id}` });
+    const item = createItem({ title: 'Linked Clickable Item' });
+    const handleClick = jest.fn();
+
+    render(
+      <Wrapper>
+        <NameCellTitle item={item} onClick={handleClick} useHref />
+      </Wrapper>
+    );
+
+    const link = screen.getByTestId('content-list-table-item-link');
+    const clickEvent = new MouseEvent('click', { bubbles: true, cancelable: true });
+
+    fireEvent(link, clickEvent);
+
+    expect(link).toHaveAttribute('href', '/view/1');
+    expect(clickEvent.defaultPrevented).toBe(true);
+    expect(handleClick).toHaveBeenCalledWith(item);
+  });
+
+  it('allows modified clicks to use `getHref` when `useHref` is true', () => {
+    const Wrapper = createWrapper({ getHref: (item) => `/view/${item.id}` });
+    const item = createItem({ title: 'Linked Clickable Item' });
+    const handleClick = jest.fn();
+
+    render(
+      <Wrapper>
+        <NameCellTitle item={item} onClick={handleClick} useHref />
+      </Wrapper>
+    );
+
+    const link = screen.getByTestId('content-list-table-item-link');
+    const clickEvent = new MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+      metaKey: true,
+    });
+
+    fireEvent(link, clickEvent);
+
+    expect(link).toHaveAttribute('href', '/view/1');
+    expect(clickEvent.defaultPrevented).toBe(false);
+    expect(handleClick).not.toHaveBeenCalled();
+  });
+
+  it('renders as plain text when `useHref` is false and `onClick` is omitted', () => {
+    const Wrapper = createWrapper({ getHref: (item) => `/view/${item.id}` });
+
+    render(
+      <Wrapper>
+        <NameCellTitle item={createItem({ title: 'Plain Item' })} useHref={false} />
+      </Wrapper>
+    );
+
+    expect(screen.getByText('Plain Item')).toBeInTheDocument();
     expect(screen.queryByTestId('content-list-table-item-link')).not.toBeInTheDocument();
   });
 });

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/name/cell_title.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/name/cell_title.tsx
@@ -19,10 +19,10 @@ export interface NameCellTitleProps {
    * Whether to use the provider-level `item.getHref` for the title link.
    * Defaults to `true` unless `onClick` is provided.
    */
-  useHref?: boolean;
+  shouldUseHref?: boolean;
   /**
    * Optional click handler for the title. When provided, the provider-level
-   * `item.getHref` is ignored unless `useHref` is explicitly `true`.
+   * `item.getHref` is ignored unless `shouldUseHref` is explicitly `true`.
    */
   onClick?: (item: ContentListItem) => void;
 }
@@ -30,12 +30,12 @@ export interface NameCellTitleProps {
 const isPlainPrimaryClick = (event: React.MouseEvent<HTMLAnchorElement>) =>
   event.button === 0 && !event.metaKey && !event.ctrlKey && !event.shiftKey && !event.altKey;
 
-export const NameCellTitle = ({ item, useHref, onClick }: NameCellTitleProps) => {
+export const NameCellTitle = ({ item, shouldUseHref, onClick }: NameCellTitleProps) => {
   const { title } = item;
   const { item: itemConfig } = useContentListConfig();
 
-  const shouldUseHref = useHref ?? !onClick;
-  const href = shouldUseHref ? itemConfig?.getHref?.(item) : undefined;
+  const useHref = shouldUseHref ?? !onClick;
+  const href = useHref ? itemConfig?.getHref?.(item) : undefined;
 
   if (!href && !onClick) {
     return (
@@ -47,7 +47,7 @@ export const NameCellTitle = ({ item, useHref, onClick }: NameCellTitleProps) =>
 
   const handleClick = onClick
     ? (event: React.MouseEvent<HTMLAnchorElement>) => {
-        if (href && !isPlainPrimaryClick(event)) {
+        if (useHref && !isPlainPrimaryClick(event)) {
           return;
         }
         event.preventDefault();
@@ -57,7 +57,7 @@ export const NameCellTitle = ({ item, useHref, onClick }: NameCellTitleProps) =>
 
   return (
     <EuiText size="s">
-      {/* eslint-disable-next-line @elastic/eui/href-or-on-click -- Intentional when `useHref` preserves native link affordances while `onClick` handles plain clicks. */}
+      {/* eslint-disable-next-line @elastic/eui/href-or-on-click -- Intentional when `shouldUseHref` preserves native link affordances while `onClick` handles plain clicks. */}
       <EuiLink href={href} onClick={handleClick} data-test-subj="content-list-table-item-link">
         {title}
       </EuiLink>

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/name/cell_title.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/name/cell_title.tsx
@@ -47,7 +47,7 @@ export const NameCellTitle = ({ item, shouldUseHref, onClick }: NameCellTitlePro
 
   const handleClick = onClick
     ? (event: React.MouseEvent<HTMLAnchorElement>) => {
-        if (useHref && !isPlainPrimaryClick(event)) {
+        if (href && !isPlainPrimaryClick(event)) {
           return;
         }
         event.preventDefault();

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/name/cell_title.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/name/cell_title.tsx
@@ -15,16 +15,29 @@ import { useContentListConfig } from '@kbn/content-list-provider';
 
 export interface NameCellTitleProps {
   item: ContentListItem;
+  /**
+   * Whether to use the provider-level `item.getHref` for the title link.
+   * Defaults to `true` unless `onClick` is provided.
+   */
+  useHref?: boolean;
+  /**
+   * Optional click handler for the title. When provided, the provider-level
+   * `item.getHref` is ignored unless `useHref` is explicitly `true`.
+   */
+  onClick?: (item: ContentListItem) => void;
 }
 
-export const NameCellTitle = ({ item }: NameCellTitleProps) => {
+const isPlainPrimaryClick = (event: React.MouseEvent<HTMLAnchorElement>) =>
+  event.button === 0 && !event.metaKey && !event.ctrlKey && !event.shiftKey && !event.altKey;
+
+export const NameCellTitle = ({ item, useHref, onClick }: NameCellTitleProps) => {
   const { title } = item;
   const { item: itemConfig } = useContentListConfig();
 
-  const href = itemConfig?.getHref?.(item);
+  const shouldUseHref = useHref ?? !onClick;
+  const href = shouldUseHref ? itemConfig?.getHref?.(item) : undefined;
 
-  // If not clickable, render as plain text.
-  if (!href) {
+  if (!href && !onClick) {
     return (
       <EuiText size="s">
         <span>{title}</span>
@@ -32,9 +45,20 @@ export const NameCellTitle = ({ item }: NameCellTitleProps) => {
     );
   }
 
+  const handleClick = onClick
+    ? (event: React.MouseEvent<HTMLAnchorElement>) => {
+        if (href && !isPlainPrimaryClick(event)) {
+          return;
+        }
+        event.preventDefault();
+        onClick(item);
+      }
+    : undefined;
+
   return (
     <EuiText size="s">
-      <EuiLink href={href} data-test-subj="content-list-table-item-link">
+      {/* eslint-disable-next-line @elastic/eui/href-or-on-click -- Intentional when `useHref` preserves native link affordances while `onClick` handles plain clicks. */}
+      <EuiLink href={href} onClick={handleClick} data-test-subj="content-list-table-item-link">
         {title}
       </EuiLink>
     </EuiText>

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/name/name_builder.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/name/name_builder.test.tsx
@@ -116,13 +116,13 @@ describe('name column builder', () => {
 
     it('passes title click handlers through to the rendered name cell', () => {
       const handleClick = jest.fn();
-      const props: NameColumnProps = { onClick: handleClick, useHref: true };
+      const props: NameColumnProps = { onClick: handleClick, shouldUseHref: true };
       const result = buildNameColumn(props, defaultContext) as NameColumn;
 
       const item = { id: '1', title: 'Test' };
       const rendered = result.render?.('Test', item) as React.ReactElement;
 
-      expect(rendered.props).toMatchObject({ onClick: handleClick, useHref: true });
+      expect(rendered.props).toMatchObject({ onClick: handleClick, shouldUseHref: true });
     });
   });
 

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/name/name_builder.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/name/name_builder.test.tsx
@@ -51,11 +51,21 @@ describe('name column builder', () => {
       expect(result).toMatchObject({ name: 'Dashboard Name' });
     });
 
-    it('applies custom width', () => {
-      const props: NameColumnProps = { width: '50%' };
+    it('applies custom layout props', () => {
+      const props: NameColumnProps = {
+        width: '32em',
+        minWidth: '24em',
+        maxWidth: '64em',
+        truncateText: { lines: 4 },
+      };
       const result = buildNameColumn(props, defaultContext);
 
-      expect(result).toMatchObject({ width: '50%' });
+      expect(result).toMatchObject({
+        width: '32em',
+        minWidth: '24em',
+        maxWidth: '64em',
+        truncateText: { lines: 4 },
+      });
     });
 
     it('does not include width when not specified', () => {
@@ -102,6 +112,17 @@ describe('name column builder', () => {
       const item = { id: '1', title: 'Test' };
       result.render?.('Test', item);
       expect(customRender).toHaveBeenCalledWith(item);
+    });
+
+    it('passes title click handlers through to the rendered name cell', () => {
+      const handleClick = jest.fn();
+      const props: NameColumnProps = { onClick: handleClick, useHref: true };
+      const result = buildNameColumn(props, defaultContext) as NameColumn;
+
+      const item = { id: '1', title: 'Test' };
+      const rendered = result.render?.('Test', item) as React.ReactElement;
+
+      expect(rendered.props).toMatchObject({ onClick: handleClick, useHref: true });
     });
   });
 

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/name/name_builder.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/name/name_builder.tsx
@@ -66,14 +66,14 @@ export interface NameColumnProps extends ColumnLayoutProps {
   /**
    * Optional click handler for the title.
    * When provided, the provider-level `item.getHref` is ignored unless
-   * `useHref` is explicitly `true`.
+   * `shouldUseHref` is explicitly `true`.
    */
   onClick?: (item: ContentListItem) => void;
   /**
    * Whether to use the provider-level `item.getHref` for the title link.
    * Defaults to `true` unless `onClick` is provided.
    */
-  useHref?: boolean;
+  shouldUseHref?: boolean;
   /**
    * Optional click handler for tag badges.
    * Called with the tag and a boolean indicating whether a modifier key
@@ -107,7 +107,7 @@ export const buildNameColumn = (
     showTags = context.supports?.tags ?? false,
     showStarred = false,
     onClick,
-    useHref,
+    shouldUseHref,
     onTagClick,
     render: customRender,
   } = attributes;
@@ -130,7 +130,7 @@ export const buildNameColumn = (
 
       return (
         <NameCell
-          {...{ item, showDescription, showTags, showStarred, onClick, useHref, onTagClick }}
+          {...{ item, showDescription, showTags, showStarred, onClick, shouldUseHref, onTagClick }}
         />
       );
     },

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/name/name_builder.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/name/name_builder.tsx
@@ -14,6 +14,7 @@ import { i18n } from '@kbn/i18n';
 import type { ContentListItem } from '@kbn/content-list-provider';
 import type { ColumnBuilderContext } from '../types';
 import { column } from '../part';
+import { getColumnLayoutProps, type ColumnLayoutProps } from '../layout';
 import { NameCell, type NameCellProps } from './name_cell';
 
 /** Default i18n-translated column title for the name column. */
@@ -28,9 +29,7 @@ const DEFAULT_NAME_COLUMN_TITLE = i18n.translate(
  * These are the declarative attributes consumers pass in JSX. The name builder
  * reads them directly from the parsed attributes.
  */
-export interface NameColumnProps {
-  /** Column width (CSS value like `'200px'` or `'40%'`). */
-  width?: string;
+export interface NameColumnProps extends ColumnLayoutProps {
   /** Custom column title. Defaults to `'Name'`. */
   columnTitle?: string;
   /**
@@ -65,6 +64,17 @@ export interface NameColumnProps {
    */
   showStarred?: boolean;
   /**
+   * Optional click handler for the title.
+   * When provided, the provider-level `item.getHref` is ignored unless
+   * `useHref` is explicitly `true`.
+   */
+  onClick?: (item: ContentListItem) => void;
+  /**
+   * Whether to use the provider-level `item.getHref` for the title link.
+   * Defaults to `true` unless `onClick` is provided.
+   */
+  useHref?: boolean;
+  /**
    * Optional click handler for tag badges.
    * Called with the tag and a boolean indicating whether a modifier key
    * (Cmd on Mac, Ctrl on Windows/Linux) was held during the click.
@@ -89,10 +99,15 @@ export const buildNameColumn = (
   const {
     columnTitle,
     width,
+    minWidth,
+    maxWidth,
+    truncateText,
     sortable: sortableProp,
     showDescription = true,
     showTags = context.supports?.tags ?? false,
     showStarred = false,
+    onClick,
+    useHref,
     onTagClick,
     render: customRender,
   } = attributes;
@@ -106,14 +121,18 @@ export const buildNameColumn = (
     field: 'title',
     name: columnTitle ?? DEFAULT_NAME_COLUMN_TITLE,
     sortable,
-    ...(width && { width }),
+    ...getColumnLayoutProps({ width, minWidth, maxWidth, truncateText }),
     'data-test-subj': 'content-list-table-column-name',
     render: (title: string, item: ContentListItem) => {
       if (customRender) {
         return customRender(item);
       }
 
-      return <NameCell {...{ item, showDescription, showTags, showStarred, onTagClick }} />;
+      return (
+        <NameCell
+          {...{ item, showDescription, showTags, showStarred, onClick, useHref, onTagClick }}
+        />
+      );
     },
   };
 };

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/name/name_cell.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/name/name_cell.tsx
@@ -42,6 +42,17 @@ export interface NameCellProps {
    */
   showStarred?: boolean;
   /**
+   * Optional click handler for the title.
+   * When provided, the provider-level `item.getHref` is ignored unless
+   * `useHref` is explicitly `true`.
+   */
+  onClick?: (item: ContentListItem) => void;
+  /**
+   * Whether to use the provider-level `item.getHref` for the title link.
+   * Defaults to `true` unless `onClick` is provided.
+   */
+  useHref?: boolean;
+  /**
    * Optional click handler for tag badges.
    * When omitted, the built-in handler in {@link NameCellTags} toggles
    * include/exclude filters via `useContentListFilters`.
@@ -68,6 +79,8 @@ export const NameCell = memo(
     showDescription = true,
     showTags = false,
     showStarred = false,
+    onClick,
+    useHref,
     onTagClick,
   }: NameCellProps) => {
     const { tags: tagIds } = item;
@@ -97,7 +110,7 @@ export const NameCell = memo(
     return (
       <div>
         <div css={showStarred ? titleRowCss : undefined}>
-          <Title item={item} />
+          <Title {...{ item, onClick, useHref }} />
           {showStarred && <StarButton id={item.id} wrapperCss={inlineStarCss} />}
         </div>
         {showDescription && <Description item={item} />}

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/name/name_cell.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/name/name_cell.tsx
@@ -44,14 +44,14 @@ export interface NameCellProps {
   /**
    * Optional click handler for the title.
    * When provided, the provider-level `item.getHref` is ignored unless
-   * `useHref` is explicitly `true`.
+   * `shouldUseHref` is explicitly `true`.
    */
   onClick?: (item: ContentListItem) => void;
   /**
    * Whether to use the provider-level `item.getHref` for the title link.
    * Defaults to `true` unless `onClick` is provided.
    */
-  useHref?: boolean;
+  shouldUseHref?: boolean;
   /**
    * Optional click handler for tag badges.
    * When omitted, the built-in handler in {@link NameCellTags} toggles
@@ -80,7 +80,7 @@ export const NameCell = memo(
     showTags = false,
     showStarred = false,
     onClick,
-    useHref,
+    shouldUseHref,
     onTagClick,
   }: NameCellProps) => {
     const { tags: tagIds } = item;
@@ -110,7 +110,7 @@ export const NameCell = memo(
     return (
       <div>
         <div css={showStarred ? titleRowCss : undefined}>
-          <Title {...{ item, onClick, useHref }} />
+          <Title {...{ item, onClick, shouldUseHref }} />
           {showStarred && <StarButton id={item.id} wrapperCss={inlineStarCss} />}
         </div>
         {showDescription && <Description item={item} />}

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/part.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/part.ts
@@ -17,6 +17,7 @@ import type { UpdatedAtColumnProps } from './updated_at/updated_at_builder';
 import type { ActionsColumnProps } from './actions/actions_builder';
 import type { StarredColumnProps } from './starred/starred_builder';
 import type { CreatedByColumnProps } from './created_by/created_by_builder';
+import { getColumnLayoutProps, type ColumnLayoutProps } from './layout';
 
 /**
  * Props for the `Column` component (custom columns).
@@ -25,13 +26,11 @@ import type { CreatedByColumnProps } from './created_by/created_by_builder';
  * `render` function. Pre-built columns (like `Column.Name`) have
  * dedicated preset components with their own props interfaces.
  */
-export interface ColumnProps {
+export interface ColumnProps extends ColumnLayoutProps {
   /** Unique identifier for the column. */
   id: string;
   /** Display name for the column header. */
   name: ReactNode;
-  /** Column width (CSS value like `'200px'` or `'40%'`). */
-  width?: string;
   /** Whether the column is sortable. */
   sortable?: boolean;
   /**
@@ -94,7 +93,18 @@ export const column = table.definePart<
  * Custom columns are identified by `props.id` rather than a preset name.
  */
 const resolveCustomColumn = (
-  { id, name, width, sortable, field, render, 'data-test-subj': dataTestSubj }: ColumnProps,
+  {
+    id,
+    name,
+    width,
+    minWidth,
+    maxWidth,
+    truncateText,
+    sortable,
+    field,
+    render,
+    'data-test-subj': dataTestSubj,
+  }: ColumnProps,
   { supports }: ColumnBuilderContext
 ): EuiBasicTableColumn<ContentListItem> => {
   const fieldId = field ?? id;
@@ -104,7 +114,7 @@ const resolveCustomColumn = (
     name,
     field: fieldId,
     sortable: supportsSorting ? sortable : false,
-    ...(width && { width }),
+    ...getColumnLayoutProps({ width, minWidth, maxWidth, truncateText }),
     render: (_value: unknown, record: ContentListItem) => render(record),
     'data-test-subj': dataTestSubj ?? `content-list-table-column-${id}`,
   };

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/starred/starred_builder.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/starred/starred_builder.test.tsx
@@ -110,13 +110,13 @@ describe('starred column builder', () => {
     });
   });
 
-  it('uses a custom width when provided', () => {
+  it('uses custom layout props when provided', () => {
     const result = buildStarredColumn(
-      { width: '64px' } satisfies StarredColumnProps,
+      { width: '64px', minWidth: '64px', maxWidth: '64px' } satisfies StarredColumnProps,
       defaultContext
     );
 
-    expect(result).toMatchObject({ width: '64px' });
+    expect(result).toMatchObject({ width: '64px', minWidth: '64px', maxWidth: '64px' });
   });
 
   it('renders the starred header and cell', () => {

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/starred/starred_builder.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/starred/starred_builder.tsx
@@ -14,6 +14,7 @@ import type { ContentListItem } from '@kbn/content-list-provider';
 import { useContentListFilters, getIncludeExcludeFlag } from '@kbn/content-list-provider';
 import type { ColumnBuilderContext } from '../types';
 import { column } from '../part';
+import { getColumnLayoutProps, type ColumnLayoutProps } from '../layout';
 import { StarredCell } from './starred_cell';
 
 const DEFAULT_WIDTH = '40px';
@@ -35,7 +36,8 @@ const StarredColumnHeader = () => {
 /**
  * Props for the `Column.Starred` preset component.
  */
-export interface StarredColumnProps {
+export interface StarredColumnProps
+  extends Pick<ColumnLayoutProps, 'width' | 'minWidth' | 'maxWidth'> {
   /** Column width (CSS value). Defaults to `'40px'`. */
   width?: string;
 }
@@ -55,14 +57,14 @@ export const buildStarredColumn = (
     return undefined;
   }
 
-  const { width = DEFAULT_WIDTH } = attributes;
+  const { width = DEFAULT_WIDTH, minWidth, maxWidth } = attributes;
 
   return {
     field: 'id',
     name: <StarredColumnHeader />,
     align: 'center' as const,
     sortable: false,
-    width,
+    ...getColumnLayoutProps({ width, minWidth, maxWidth }),
     'data-test-subj': 'content-list-table-column-starred',
     render: (_value: string, item: ContentListItem) => {
       return <StarredCell id={item.id} />;

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/updated_at/updated_at_builder.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/updated_at/updated_at_builder.test.tsx
@@ -53,11 +53,21 @@ describe('updated at column builder', () => {
       expect(result).toMatchObject({ name: 'Modified' });
     });
 
-    it('applies custom width', () => {
-      const props: UpdatedAtColumnProps = { width: '150px' };
+    it('applies custom layout props', () => {
+      const props: UpdatedAtColumnProps = {
+        width: '12em',
+        minWidth: '12em',
+        maxWidth: '14em',
+        truncateText: false,
+      };
       const result = buildUpdatedAtColumn(props, defaultContext);
 
-      expect(result).toMatchObject({ width: '150px' });
+      expect(result).toMatchObject({
+        width: '12em',
+        minWidth: '12em',
+        maxWidth: '14em',
+        truncateText: false,
+      });
     });
 
     it('does not include width when not specified', () => {

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/updated_at/updated_at_builder.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/updated_at/updated_at_builder.tsx
@@ -13,6 +13,7 @@ import { i18n } from '@kbn/i18n';
 import type { ContentListItem } from '@kbn/content-list-provider';
 import type { ColumnBuilderContext } from '../types';
 import { column } from '../part';
+import { getColumnLayoutProps, type ColumnLayoutProps } from '../layout';
 import { UpdatedAtCell } from './updated_at_cell';
 
 /** Default i18n-translated column title for the updated at column. */
@@ -27,9 +28,7 @@ const DEFAULT_UPDATED_AT_COLUMN_TITLE = i18n.translate(
  * These are the declarative attributes consumers pass in JSX. The builder
  * reads them directly from the parsed attributes.
  */
-export interface UpdatedAtColumnProps {
-  /** Column width (CSS value like `'150px'` or `'20%'`). */
-  width?: string;
+export interface UpdatedAtColumnProps extends ColumnLayoutProps {
   /** Custom column title. Defaults to `'Last updated'`. */
   columnTitle?: string;
   /**
@@ -51,7 +50,14 @@ export const buildUpdatedAtColumn = (
   attributes: UpdatedAtColumnProps,
   context: ColumnBuilderContext
 ): EuiBasicTableColumn<ContentListItem> => {
-  const { columnTitle, width, sortable: sortableProp } = attributes;
+  const {
+    columnTitle,
+    width,
+    minWidth,
+    maxWidth,
+    truncateText,
+    sortable: sortableProp,
+  } = attributes;
 
   const supportsSorting = context.supports?.sorting ?? true;
 
@@ -62,7 +68,7 @@ export const buildUpdatedAtColumn = (
     field: 'updatedAt',
     name: columnTitle ?? DEFAULT_UPDATED_AT_COLUMN_TITLE,
     sortable,
-    ...(width && { width }),
+    ...getColumnLayoutProps({ width, minWidth, maxWidth, truncateText }),
     'data-test-subj': 'content-list-table-column-updatedAt',
     render: (_value: Date | undefined, item: ContentListItem) => {
       return <UpdatedAtCell updatedAt={item.updatedAt} />;

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/content_list_table.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/content_list_table.tsx
@@ -10,6 +10,7 @@
 import React, { useMemo } from 'react';
 import type { ReactNode } from 'react';
 import { EuiBasicTable, useEuiTheme } from '@elastic/eui';
+import type { EuiBreakpointSize } from '@elastic/eui';
 import { cssFavoriteHoverWithinEuiTableRow } from '@kbn/content-management-favorites-public';
 import {
   useContentListConfig,
@@ -39,6 +40,23 @@ export interface ContentListTableProps {
   tableLayout?: 'fixed' | 'auto';
   /** Compressed table style. */
   compressed?: boolean;
+  /**
+   * Whether to enable horizontal scrolling when columns exceed the container width.
+   * Required for sticky columns (e.g. `Column.Actions` with `sticky: true`).
+   *
+   * @default true
+   */
+  scrollableInline?: boolean;
+  /**
+   * Named breakpoint below which the table collapses into responsive cards.
+   * Set to `false` to always render as a table, or `true` to always render cards.
+   *
+   * Content List defaults to `false` because the card layout does not support
+   * selection checkboxes, tag badges, star buttons, or action columns.
+   *
+   * @default false
+   */
+  responsiveBreakpoint?: EuiBreakpointSize | boolean;
   /**
    * Custom empty state component.
    * If not provided, uses default empty state.
@@ -121,6 +139,8 @@ const ContentListTableComponent = ({
   title,
   tableLayout = 'auto',
   compressed = false,
+  scrollableInline = true,
+  responsiveBreakpoint = false,
   emptyState: customEmptyState,
   children,
   filter,
@@ -162,6 +182,8 @@ const ContentListTableComponent = ({
         onChange={onChange}
         sorting={sorting}
         selection={selection}
+        scrollableInline={scrollableInline}
+        responsiveBreakpoint={responsiveBreakpoint}
         tableLayout={tableLayout}
         data-test-subj={dataTestSubj}
       />

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/hooks/use_columns.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/hooks/use_columns.test.tsx
@@ -129,7 +129,15 @@ describe('useColumns', () => {
 
   describe('preset columns', () => {
     it('resolves a `Column.Name` preset child', () => {
-      const children = <NameColumn columnTitle="Dashboard Name" width="50%" />;
+      const children = (
+        <NameColumn
+          columnTitle="Dashboard Name"
+          width="32em"
+          minWidth="24em"
+          maxWidth="64em"
+          truncateText={{ lines: 4 }}
+        />
+      );
 
       const { result } = renderHook(() => useColumns(children), {
         wrapper: createWrapper(),
@@ -139,7 +147,10 @@ describe('useColumns', () => {
       expect(result.current[0]).toMatchObject({
         field: 'title',
         name: 'Dashboard Name',
-        width: '50%',
+        width: '32em',
+        minWidth: '24em',
+        maxWidth: '64em',
+        truncateText: { lines: 4 },
         sortable: true,
       });
     });
@@ -158,7 +169,17 @@ describe('useColumns', () => {
   describe('custom columns', () => {
     it('resolves a custom `Column` child', () => {
       const render = jest.fn(() => <span>custom</span>);
-      const children = <Column id="status" name="Status" width="20%" render={render} />;
+      const children = (
+        <Column
+          id="status"
+          name="Status"
+          width="12em"
+          minWidth="10em"
+          maxWidth="16em"
+          truncateText
+          render={render}
+        />
+      );
 
       const { result } = renderHook(() => useColumns(children), {
         wrapper: createWrapper(),
@@ -168,7 +189,10 @@ describe('useColumns', () => {
       expect(result.current[0]).toMatchObject({
         field: 'status',
         name: 'Status',
-        width: '20%',
+        width: '12em',
+        minWidth: '10em',
+        maxWidth: '16em',
+        truncateText: true,
       });
     });
 


### PR DESCRIPTION
## Summary

Standardizes column sizing across all Content List table presets and adds click handling to `Column.Name`.

- Introduces `ColumnLayoutProps` (`width`, `minWidth`, `maxWidth`, `truncateText`) shared by all column presets and the generic `Column` component, replacing the per-preset `width?: string` prop.
- Actions column auto-computes a default width from action count and is sticky by default for horizontal-scrolling tables.
- Adds `scrollableInline` and `responsiveBreakpoint` as props on `ContentListTable` with opinionated defaults (`true` and `false` respectively) to support sticky columns. Consumers can override if needed.
- Adds `onClick` and `useHref` props to `Column.Name`, threaded through `NameCell` → `NameCellTitle`. When both `href` and `onClick` are present, modifier clicks follow the href while plain clicks call `onClick`.
- Deduplicates `NameCellTitle` render branches from four to two.
- Adds Storybook controls for `scrollableInline` and `responsiveBreakpoint` to the Core Features story.

### Changes

All changes are scoped to `@kbn/content-list-table` and `@kbn/content-list-docs`.

| Area | What changed |
|------|-------------|
| **`layout.ts`** (new) | `ColumnLayoutProps` type and `getColumnLayoutProps` helper — standardizes `width`/`minWidth`/`maxWidth`/`truncateText` across columns. |
| **`part.ts`** | Generic `Column` component extends `ColumnLayoutProps`. |
| **Name** | `NameColumnProps` extends `ColumnLayoutProps`, adds `onClick`/`useHref`. `NameCell` and `NameCellTitle` thread these through. `NameCellTitle` collapsed from 4 render branches to 2. |
| **Actions** | Extends layout props, auto-computes default width from action count, sticky by default. |
| **UpdatedAt, Starred, CreatedBy** | Extend `ColumnLayoutProps` (or the relevant subset for non-text columns). |
| **Table** | New `scrollableInline` (default `true`) and `responsiveBreakpoint` (default `false`) props on `ContentListTable`, passed through to `EuiBasicTable`. Defaults enable horizontal scrolling and disable mobile card layout, which is required for sticky columns and does not support Content List features like selection, tags, and stars. |
| **Storybook** | Core Features story adds `scrollableInline` and `responsiveBreakpoint` as Storybook controls. |
| **Tests** | All builders, `cell_title`, and `use_columns` tests updated. |
| **README** | Updated code examples and documentation for layout props and `onClick`/`useHref`. |

## Test plan

- [ ] `@kbn/content-list-table` unit tests pass (155/155).
- [ ] Verify sticky actions column with horizontal overflow in Storybook.
- [ ] Verify `Column.Name` `onClick` fires on plain click, modifier clicks follow `href`.
- [ ] Toggle `scrollableInline` off in Storybook controls — table should no longer scroll horizontally.
- [ ] Toggle `responsiveBreakpoint` on in Storybook controls — table should collapse to cards on narrow viewports.