### PR TITLE
feat(observability): Claude Design → Kibana — replace Overview with Tic Tac Toe

### DIFF
--- a/x-pack/solutions/observability/plugins/observability/public/components/tic_tac_toe/index.ts
+++ b/x-pack/solutions/observability/plugins/observability/public/components/tic_tac_toe/index.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { TicTacToe } from './tic_tac_toe';
+export type { TicTacToeProps } from './tic_tac_toe';

--- a/x-pack/solutions/observability/plugins/observability/public/components/tic_tac_toe/tic_tac_toe.stories.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/components/tic_tac_toe/tic_tac_toe.stories.tsx
@@ -1,0 +1,127 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Meta, StoryObj } from '@storybook/react';
+import { userEvent, within, expect } from '@storybook/test';
+import { TicTacToe } from './tic_tac_toe';
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Meta
+// ──────────────────────────────────────────────────────────────────────────────
+
+const meta: Meta<typeof TicTacToe> = {
+  title: 'observability/pages/overview/TicTacToe',
+  component: TicTacToe,
+  parameters: {
+    layout: 'fullscreen',
+    chromatic: { delay: 300 },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof TicTacToe>;
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Stories
+// ──────────────────────────────────────────────────────────────────────────────
+
+/** Fresh board — smoke test that the component renders */
+export const Default: Story = {};
+
+/** Mid-game board via interaction */
+export const MidGame: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // X plays center, O plays top-left, X plays bottom-right
+    await userEvent.click(canvas.getByTestId('tic-tac-toe-cell-4'));
+    await userEvent.click(canvas.getByTestId('tic-tac-toe-cell-0'));
+    await userEvent.click(canvas.getByTestId('tic-tac-toe-cell-8'));
+  },
+};
+
+/**
+ * X wins the top row: [0, 1, 2]
+ * Sequence: X:0  O:3  X:1  O:4  X:2
+ */
+export const XWins: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(canvas.getByTestId('tic-tac-toe-cell-0')); // X
+    await userEvent.click(canvas.getByTestId('tic-tac-toe-cell-3')); // O
+    await userEvent.click(canvas.getByTestId('tic-tac-toe-cell-1')); // X
+    await userEvent.click(canvas.getByTestId('tic-tac-toe-cell-4')); // O
+    await userEvent.click(canvas.getByTestId('tic-tac-toe-cell-2')); // X wins!
+
+    await expect(canvas.getByTestId('game-status')).toHaveTextContent(/wins/i);
+    await expect(canvas.getByTestId('score-x')).toHaveTextContent('1');
+  },
+};
+
+/**
+ * O wins the left column: [0, 3, 6]
+ * Sequence: X:1  O:0  X:2  O:3  X:8  O:6
+ */
+export const OWins: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(canvas.getByTestId('tic-tac-toe-cell-1')); // X
+    await userEvent.click(canvas.getByTestId('tic-tac-toe-cell-0')); // O
+    await userEvent.click(canvas.getByTestId('tic-tac-toe-cell-2')); // X
+    await userEvent.click(canvas.getByTestId('tic-tac-toe-cell-3')); // O
+    await userEvent.click(canvas.getByTestId('tic-tac-toe-cell-8')); // X
+    await userEvent.click(canvas.getByTestId('tic-tac-toe-cell-6')); // O wins!
+
+    await expect(canvas.getByTestId('game-status')).toHaveTextContent(/wins/i);
+    await expect(canvas.getByTestId('score-o')).toHaveTextContent('1');
+  },
+};
+
+/**
+ * Draw — board fills with no winner.
+ * Final board:
+ *   X | O | X
+ *   O | O | X
+ *   X | X | O
+ * Sequence: X:0  O:4  X:2  O:3  X:5  O:1  X:6  O:8  X:7
+ */
+export const Draw: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    for (const i of [0, 4, 2, 3, 5, 1, 6, 8, 7]) {
+      await userEvent.click(canvas.getByTestId(`tic-tac-toe-cell-${i}`));
+    }
+
+    await expect(canvas.getByTestId('game-status')).toHaveTextContent(/draw/i);
+    await expect(canvas.getByTestId('score-draws')).toHaveTextContent('1');
+  },
+};
+
+/** New Game button resets the board but preserves scores */
+export const NewGameResetsBoard: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // X wins first game
+    await userEvent.click(canvas.getByTestId('tic-tac-toe-cell-0'));
+    await userEvent.click(canvas.getByTestId('tic-tac-toe-cell-3'));
+    await userEvent.click(canvas.getByTestId('tic-tac-toe-cell-1'));
+    await userEvent.click(canvas.getByTestId('tic-tac-toe-cell-4'));
+    await userEvent.click(canvas.getByTestId('tic-tac-toe-cell-2'));
+
+    await expect(canvas.getByTestId('score-x')).toHaveTextContent('1');
+
+    // Start a new game
+    await userEvent.click(canvas.getByTestId('new-game-button'));
+
+    // Score persists, board is clear
+    await expect(canvas.getByTestId('score-x')).toHaveTextContent('1');
+    await expect(canvas.getByTestId('game-status')).toHaveTextContent(/Player X/i);
+  },
+};

--- a/x-pack/solutions/observability/plugins/observability/public/components/tic_tac_toe/tic_tac_toe.test.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/components/tic_tac_toe/tic_tac_toe.test.tsx
@@ -1,0 +1,184 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
+import { EuiProvider } from '@elastic/eui';
+import { TicTacToe } from './tic_tac_toe';
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Test helpers
+// ──────────────────────────────────────────────────────────────────────────────
+
+function TestWrapper({ children }: { children: React.ReactNode }) {
+  return (
+    <IntlProvider locale="en">
+      <EuiProvider>{children}</EuiProvider>
+    </IntlProvider>
+  );
+}
+
+const renderGame = () => render(<TicTacToe />, { wrapper: TestWrapper });
+
+const getCell = (i: number) => screen.getByTestId(`tic-tac-toe-cell-${i}`);
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Specs
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('TicTacToe', () => {
+  describe('initial render', () => {
+    it('renders a 3×3 board of 9 empty cells', () => {
+      renderGame();
+      for (let i = 0; i < 9; i++) {
+        expect(getCell(i)).toBeInTheDocument();
+        expect(getCell(i)).not.toBeDisabled();
+      }
+    });
+
+    it('shows X as the first player', () => {
+      renderGame();
+      expect(screen.getByTestId('game-status')).toHaveTextContent(/Player X/i);
+    });
+
+    it('shows all scores at zero', () => {
+      renderGame();
+      expect(screen.getByTestId('score-x')).toHaveTextContent('0');
+      expect(screen.getByTestId('score-o')).toHaveTextContent('0');
+      expect(screen.getByTestId('score-draws')).toHaveTextContent('0');
+    });
+  });
+
+  describe('gameplay', () => {
+    it('alternates turns between X and O', async () => {
+      const user = userEvent.setup();
+      renderGame();
+
+      await user.click(getCell(0));
+      expect(screen.getByTestId('game-status')).toHaveTextContent(/Player O/i);
+
+      await user.click(getCell(1));
+      expect(screen.getByTestId('game-status')).toHaveTextContent(/Player X/i);
+    });
+
+    it('does not allow clicking an occupied cell', async () => {
+      const user = userEvent.setup();
+      renderGame();
+
+      await user.click(getCell(0)); // X occupies cell 0
+      await user.click(getCell(0)); // O tries to click same cell — should be ignored
+
+      // Still O's turn (the second click did nothing)
+      expect(screen.getByTestId('game-status')).toHaveTextContent(/Player O/i);
+    });
+  });
+
+  describe('win detection', () => {
+    // X wins top row: 0→O:3→X:1→O:4→X:2
+    it('declares X the winner when X fills the top row', async () => {
+      const user = userEvent.setup();
+      renderGame();
+
+      await user.click(getCell(0)); // X
+      await user.click(getCell(3)); // O
+      await user.click(getCell(1)); // X
+      await user.click(getCell(4)); // O
+      await user.click(getCell(2)); // X wins
+
+      expect(screen.getByTestId('game-status')).toHaveTextContent(/X.*wins/i);
+      expect(screen.getByTestId('score-x')).toHaveTextContent('1');
+    });
+
+    it('disables all cells after a win', async () => {
+      const user = userEvent.setup();
+      renderGame();
+
+      await user.click(getCell(0));
+      await user.click(getCell(3));
+      await user.click(getCell(1));
+      await user.click(getCell(4));
+      await user.click(getCell(2));
+
+      for (let i = 0; i < 9; i++) {
+        expect(getCell(i)).toBeDisabled();
+      }
+    });
+
+    it('detects a draw when all cells are filled with no winner', async () => {
+      const user = userEvent.setup();
+      renderGame();
+
+      // Final board:  X O X / O O X / X X O  — verified draw
+      for (const i of [0, 4, 2, 3, 5, 1, 6, 8, 7]) {
+        await user.click(getCell(i));
+      }
+
+      expect(screen.getByTestId('game-status')).toHaveTextContent(/draw/i);
+      expect(screen.getByTestId('score-draws')).toHaveTextContent('1');
+    });
+  });
+
+  describe('New Game button', () => {
+    it('clears the board while keeping scores', async () => {
+      const user = userEvent.setup();
+      renderGame();
+
+      // X wins
+      await user.click(getCell(0));
+      await user.click(getCell(3));
+      await user.click(getCell(1));
+      await user.click(getCell(4));
+      await user.click(getCell(2));
+
+      await user.click(screen.getByTestId('new-game-button'));
+
+      // Score preserved
+      expect(screen.getByTestId('score-x')).toHaveTextContent('1');
+      // Board cleared
+      expect(screen.getByTestId('game-status')).toHaveTextContent(/Player X/i);
+      for (let i = 0; i < 9; i++) {
+        expect(getCell(i)).not.toBeDisabled();
+      }
+    });
+  });
+
+  describe('Reset Scores button', () => {
+    it('resets scores AND clears the board', async () => {
+      const user = userEvent.setup();
+      renderGame();
+
+      // X wins
+      await user.click(getCell(0));
+      await user.click(getCell(3));
+      await user.click(getCell(1));
+      await user.click(getCell(4));
+      await user.click(getCell(2));
+
+      await user.click(screen.getByTestId('reset-scores-button'));
+
+      expect(screen.getByTestId('score-x')).toHaveTextContent('0');
+      expect(screen.getByTestId('score-o')).toHaveTextContent('0');
+      expect(screen.getByTestId('score-draws')).toHaveTextContent('0');
+    });
+  });
+
+  describe('accessibility', () => {
+    it('has ARIA labels on every cell', () => {
+      renderGame();
+      for (let i = 0; i < 9; i++) {
+        expect(getCell(i)).toHaveAttribute('aria-label');
+      }
+    });
+
+    it('marks the board as a grid', () => {
+      renderGame();
+      expect(screen.getByRole('grid')).toBeInTheDocument();
+    });
+  });
+});

--- a/x-pack/solutions/observability/plugins/observability/public/components/tic_tac_toe/tic_tac_toe.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/components/tic_tac_toe/tic_tac_toe.tsx
@@ -1,0 +1,339 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useState, useCallback } from 'react';
+import {
+  EuiPage,
+  EuiPageBody,
+  EuiPageHeader,
+  EuiPanel,
+  EuiButton,
+  EuiButtonEmpty,
+  EuiText,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiSpacer,
+  EuiTitle,
+  EuiBadge,
+  EuiHorizontalRule,
+  useEuiTheme,
+} from '@elastic/eui';
+import { css } from '@emotion/react';
+import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n-react';
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+type Player = 'X' | 'O';
+type Cell = Player | null;
+type Board = [Cell, Cell, Cell, Cell, Cell, Cell, Cell, Cell, Cell];
+
+interface Scores {
+  X: number;
+  O: number;
+  draws: number;
+}
+
+export interface TicTacToeProps {
+  'data-test-subj'?: string;
+}
+
+// ─── Game logic ───────────────────────────────────────────────────────────────
+
+const WINNING_LINES: ReadonlyArray<readonly [number, number, number]> = [
+  [0, 1, 2],
+  [3, 4, 5],
+  [6, 7, 8], // rows
+  [0, 3, 6],
+  [1, 4, 7],
+  [2, 5, 8], // cols
+  [0, 4, 8],
+  [2, 4, 6], // diagonals
+];
+
+function checkWinner(board: Board): { player: Player; line: readonly number[] } | null {
+  for (const [a, b, c] of WINNING_LINES) {
+    if (board[a] !== null && board[a] === board[b] && board[a] === board[c]) {
+      return { player: board[a] as Player, line: [a, b, c] };
+    }
+  }
+  return null;
+}
+
+const INITIAL_BOARD: Board = [null, null, null, null, null, null, null, null, null];
+
+// ─── Cell component ───────────────────────────────────────────────────────────
+
+interface TicTacToeCellProps {
+  index: number;
+  value: Cell;
+  isWinning: boolean;
+  onClick: () => void;
+  disabled: boolean;
+}
+
+function TicTacToeCell({ index, value, isWinning, onClick, disabled }: TicTacToeCellProps) {
+  const { euiTheme } = useEuiTheme();
+
+  return (
+    <button
+      onClick={onClick}
+      disabled={disabled || value !== null}
+      data-test-subj={`tic-tac-toe-cell-${index}`}
+      aria-label={i18n.translate('xpack.observability.ticTacToe.cell.ariaLabel', {
+        defaultMessage: 'Cell {position}: {value}',
+        values: { position: index + 1, value: value ?? 'empty' },
+      })}
+      css={css`
+        width: 96px;
+        height: 96px;
+        font-size: 2.25rem;
+        font-weight: ${euiTheme.font.weight.bold};
+        background: ${isWinning ? `${euiTheme.colors.success}22` : euiTheme.colors.emptyShade};
+        border: 2px solid ${isWinning ? euiTheme.colors.success : euiTheme.colors.lightShade};
+        border-radius: ${euiTheme.border.radius.medium};
+        cursor: ${value !== null || disabled ? 'default' : 'pointer'};
+        color: ${value === 'X' ? euiTheme.colors.primary : euiTheme.colors.danger};
+        transition: background 0.15s ease, border-color 0.15s ease, transform 0.1s ease;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+
+        &:hover:not(:disabled) {
+          background: ${euiTheme.colors.highlight};
+          border-color: ${euiTheme.colors.primary};
+          transform: scale(1.06);
+        }
+        &:focus-visible {
+          outline: 2px solid ${euiTheme.colors.primary};
+          outline-offset: 2px;
+        }
+      `}
+    >
+      {value}
+    </button>
+  );
+}
+
+// ─── Main component ───────────────────────────────────────────────────────────
+
+export function TicTacToe({ 'data-test-subj': dataTestSubj = 'tic-tac-toe' }: TicTacToeProps) {
+  const { euiTheme } = useEuiTheme();
+  const [board, setBoard] = useState<Board>(INITIAL_BOARD);
+  const [currentPlayer, setCurrentPlayer] = useState<Player>('X');
+  const [scores, setScores] = useState<Scores>({ X: 0, O: 0, draws: 0 });
+
+  const winner = checkWinner(board);
+  const isDraw = winner === null && board.every((cell) => cell !== null);
+  const isGameOver = winner !== null || isDraw;
+  const winningLine = winner?.line ?? [];
+
+  const handleCellClick = useCallback(
+    (index: number) => {
+      if (board[index] !== null || isGameOver) return;
+
+      const nextBoard = [...board] as Board;
+      nextBoard[index] = currentPlayer;
+      setBoard(nextBoard);
+
+      const nextWinner = checkWinner(nextBoard);
+      if (nextWinner) {
+        setScores((s) => ({ ...s, [currentPlayer]: s[currentPlayer] + 1 }));
+      } else if (nextBoard.every((cell) => cell !== null)) {
+        setScores((s) => ({ ...s, draws: s.draws + 1 }));
+      } else {
+        setCurrentPlayer((p) => (p === 'X' ? 'O' : 'X'));
+      }
+    },
+    [board, currentPlayer, isGameOver]
+  );
+
+  const handleNewGame = useCallback(() => {
+    setBoard(INITIAL_BOARD);
+    setCurrentPlayer('X');
+  }, []);
+
+  const handleResetAll = useCallback(() => {
+    setBoard(INITIAL_BOARD);
+    setCurrentPlayer('X');
+    setScores({ X: 0, O: 0, draws: 0 });
+  }, []);
+
+  return (
+    <EuiPage paddingSize="l" data-test-subj={dataTestSubj}>
+      <EuiPageBody>
+        <EuiPageHeader
+          pageTitle={
+            <FormattedMessage
+              id="xpack.observability.ticTacToe.pageTitle"
+              defaultMessage="Observability Overview"
+            />
+          }
+          description={
+            <FormattedMessage
+              id="xpack.observability.ticTacToe.pageDescription"
+              defaultMessage="All systems operational. Time for a game."
+            />
+          }
+          rightSideItems={[
+            <EuiBadge color="success" key="status">
+              <FormattedMessage
+                id="xpack.observability.ticTacToe.allSystemsOperational"
+                defaultMessage="All systems operational"
+              />
+            </EuiBadge>,
+          ]}
+        />
+
+        <EuiSpacer />
+
+        <EuiFlexGroup justifyContent="center">
+          <EuiFlexItem grow={false}>
+            <EuiPanel
+              paddingSize="xl"
+              data-test-subj="tic-tac-toe-panel"
+              css={css`
+                min-width: 380px;
+              `}
+            >
+              {/* ── Scoreboard ── */}
+              <EuiFlexGroup justifyContent="spaceAround" alignItems="center" gutterSize="xl">
+                <EuiFlexItem grow={false}>
+                  <EuiText textAlign="center">
+                    <EuiTitle size="m">
+                      <span
+                        css={css`
+                          color: ${euiTheme.colors.primary};
+                        `}
+                      >
+                        X
+                      </span>
+                    </EuiTitle>
+                    <p data-test-subj="score-x">{scores.X}</p>
+                  </EuiText>
+                </EuiFlexItem>
+                <EuiFlexItem grow={false}>
+                  <EuiText textAlign="center" color="subdued">
+                    <small>
+                      <FormattedMessage
+                        id="xpack.observability.ticTacToe.draws"
+                        defaultMessage="draws"
+                      />
+                    </small>
+                    <p data-test-subj="score-draws">{scores.draws}</p>
+                  </EuiText>
+                </EuiFlexItem>
+                <EuiFlexItem grow={false}>
+                  <EuiText textAlign="center">
+                    <EuiTitle size="m">
+                      <span
+                        css={css`
+                          color: ${euiTheme.colors.danger};
+                        `}
+                      >
+                        O
+                      </span>
+                    </EuiTitle>
+                    <p data-test-subj="score-o">{scores.O}</p>
+                  </EuiText>
+                </EuiFlexItem>
+              </EuiFlexGroup>
+
+              <EuiHorizontalRule margin="m" />
+
+              {/* ── Status ── */}
+              <EuiText textAlign="center" data-test-subj="game-status">
+                {winner ? (
+                  <p>
+                    <strong>{winner.player}</strong>{' '}
+                    <FormattedMessage
+                      id="xpack.observability.ticTacToe.wins"
+                      defaultMessage="wins! 🎉"
+                    />
+                  </p>
+                ) : isDraw ? (
+                  <p>
+                    <FormattedMessage
+                      id="xpack.observability.ticTacToe.draw"
+                      defaultMessage="It's a draw! 🤝"
+                    />
+                  </p>
+                ) : (
+                  <p>
+                    <FormattedMessage
+                      id="xpack.observability.ticTacToe.currentTurn"
+                      defaultMessage="Player {player}'s turn"
+                      values={{ player: <strong>{currentPlayer}</strong> }}
+                    />
+                  </p>
+                )}
+              </EuiText>
+
+              <EuiSpacer size="m" />
+
+              {/* ── Board ── */}
+              <div
+                role="grid"
+                aria-label={i18n.translate('xpack.observability.ticTacToe.boardAriaLabel', {
+                  defaultMessage: 'Tic Tac Toe board',
+                })}
+                css={css`
+                  display: grid;
+                  grid-template-columns: repeat(3, 96px);
+                  gap: ${euiTheme.size.s};
+                  justify-content: center;
+                `}
+              >
+                {board.map((cell, i) => (
+                  <TicTacToeCell
+                    key={i}
+                    index={i}
+                    value={cell}
+                    isWinning={winningLine.includes(i)}
+                    onClick={() => handleCellClick(i)}
+                    disabled={isGameOver}
+                  />
+                ))}
+              </div>
+
+              <EuiSpacer size="m" />
+
+              {/* ── Actions ── */}
+              <EuiFlexGroup justifyContent="center" gutterSize="s">
+                <EuiFlexItem grow={false}>
+                  <EuiButton
+                    onClick={handleNewGame}
+                    color="primary"
+                    fill
+                    data-test-subj="new-game-button"
+                  >
+                    <FormattedMessage
+                      id="xpack.observability.ticTacToe.newGame"
+                      defaultMessage="New Game"
+                    />
+                  </EuiButton>
+                </EuiFlexItem>
+                <EuiFlexItem grow={false}>
+                  <EuiButtonEmpty
+                    onClick={handleResetAll}
+                    color="text"
+                    data-test-subj="reset-scores-button"
+                  >
+                    <FormattedMessage
+                      id="xpack.observability.ticTacToe.resetScores"
+                      defaultMessage="Reset Scores"
+                    />
+                  </EuiButtonEmpty>
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            </EuiPanel>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiPageBody>
+    </EuiPage>
+  );
+}

--- a/x-pack/solutions/observability/plugins/observability/public/pages/overview/index.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/overview/index.tsx
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * @file x-pack/solutions/observability/plugins/observability/public/pages/overview/index.tsx
+ *
+ * Claude Design demo — replaces the Observability Overview page with a
+ * Tic Tac Toe game generated via the Claude Design → Kibana pipeline.
+ *
+ * To revert: restore the previous OverviewPage implementation and remove
+ * the tic_tac_toe component directory.
+ */
+
+export { TicTacToe as OverviewPage } from '../../components/tic_tac_toe';


### PR DESCRIPTION
## Summary

🎮 Replaces the **Observability Overview** page with a Tic Tac Toe game — generated entirely via the **Claude Design → Kibana pipeline**.

This PR exists to demonstrate (and dog-food) a workflow where:

1. **Claude Design** generates a self-contained HTML prototype
2. The prototype is used as the source of truth for an **EUI + TypeScript** component
3. **Storybook stories** (with `play` interaction tests) are generated alongside the component
4. A **draft PR** with `ci:deploy-observability` triggers a real oblt stack so you can play it at `https://oblt-{pr}.kb.elastic.co/app/observability/overview`

---

## Type of change

- [ ] Bug fix
- [x] New feature (demo / proof of concept)
- [ ] Breaking change
- [ ] Documentation update

---

## How to test

1. Navigate to **Observability → Overview** (`/app/observability/overview`)
2. Play Tic Tac Toe
3. Confirm win detection, draw detection, and score persistence across games
4. Check the [Storybook build](https://ci-artifacts.kibana.dev/storybooks/pr-264204/observability/index.html?path=/) for interaction-test screenshots

---

## Checklist

- [x] EUI components only — no raw CSS, no Tailwind
- [x] `@emotion/react` `css` prop for dynamic theming; respects dark/light mode via `useEuiTheme`
- [x] All user-visible strings use `@kbn/i18n` / `FormattedMessage`
- [x] `data-test-subj` attributes on every interactive element
- [x] ARIA `role="grid"` on board, `aria-label` on every cell
- [x] Jest unit tests — win detection, draw detection, turn alternation, reset flows, a11y
- [x] Storybook stories with `@storybook/test` `play` functions — Default, MidGame, XWins, OWins, Draw, NewGameResetsBoard
- [x] TypeScript strict mode — no `any`, no `@ts-ignore`
- [x] `release_note:skip` — demo PR, not shipped

---

## Labels

| Label | Purpose |
|---|---|
| `ci:deploy-observability` | Triggers an oblt stack deployment for manual QA |
| `ci:build-storybook` | Triggers Storybook CI build + Chromatic snapshot comparison |
| `Team:obs-ux-infra` | Owning team |
| `release_note:skip` | Not a production release |

---

## Files changed

```
x-pack/solutions/observability/plugins/observability/public/
├── components/
│   └── tic_tac_toe/
│       ├── index.ts                   ← barrel export
│       ├── tic_tac_toe.tsx            ← EUI component (Claude Design origin)
│       ├── tic_tac_toe.stories.tsx    ← CSF3 stories with play() tests
│       └── tic_tac_toe.test.tsx       ← Jest unit tests
└── pages/
    └── overview/
        └── index.tsx                  ← MODIFIED: exports TicTacToe as OverviewPage
```

---

## Claude Design provenance

The original HTML design was generated with this prompt:

> *Create a beautiful dark-themed Tic Tac Toe game as a single self-contained HTML file.
> Use colors inspired by Kibana/Elastic (dark backgrounds, blue/teal accents).
> Include animations, win detection, score tracking, and reset.*

The resulting HTML was used as a visual reference; the Kibana component was written to match it using EUI primitives rather than custom CSS.