### PR TITLE
[Triggers Actions UI] Replace Bootstrap `hidden` class with scoped Emotion style in rule snooze scheduler; add canary tests

### DIFF
--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rules_list/components/rule_snooze/scheduler.test.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rules_list/components/rule_snooze/scheduler.test.tsx
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { renderWithI18n } from '@kbn/test-jest-helpers';
+import { RuleSnoozeScheduler, hiddenCalendarClassName } from './scheduler';
+
+jest.mock('@elastic/eui', () => {
+  const actual = jest.requireActual('@elastic/eui');
+  const ReactMock = jest.requireActual('react');
+
+  return {
+    ...actual,
+    EuiDatePicker: ({ calendarClassName }: { calendarClassName?: string }) =>
+      ReactMock.createElement('div', {
+        'data-test-subj': 'mockEuiDatePicker',
+        'data-calendar-class-name': calendarClassName,
+      }),
+  };
+});
+
+jest.mock('@kbn/kibana-react-plugin/public', () => ({
+  useUiSetting: jest.fn(() => 'UTC'),
+}));
+
+describe('RuleSnoozeScheduler', () => {
+  test('uses an owned class instead of the legacy Bootstrap hidden class', () => {
+    expect(hiddenCalendarClassName).not.toBe('hidden');
+
+    const { container } = renderWithI18n(
+      <RuleSnoozeScheduler
+        onClose={jest.fn()}
+        onSaveSchedule={jest.fn()}
+        onCancelSchedules={jest.fn()}
+        initialSchedule={null}
+        isLoading={false}
+        hasTitle={false}
+      />
+    );
+
+    const datePickerCalendarClassNames = Array.from(
+      container.querySelectorAll('[data-test-subj="mockEuiDatePicker"]')
+    ).map((datePicker) => datePicker.getAttribute('data-calendar-class-name'));
+
+    expect(datePickerCalendarClassNames).toEqual([
+      hiddenCalendarClassName,
+      hiddenCalendarClassName,
+      null,
+    ]);
+    expect(container.querySelector('.hidden')).toBeNull();
+  });
+});

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rules_list/components/rule_snooze/scheduler.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rules_list/components/rule_snooze/scheduler.tsx
@@ -52,7 +52,9 @@ const TIMEZONE_OPTIONS = UI_TIMEZONE_OPTIONS.map((n) => ({ label: n })) ?? [{ la
 
 const useDefaultTimzezone = () => {
   const kibanaTz: string = useUiSetting('dateFormat:tz');
-  if (!kibanaTz || kibanaTz === 'Browser') return moment.tz?.guess() ?? 'UTC';
+  if (!kibanaTz || kibanaTz === 'Browser') {
+    return moment.tz?.guess() ?? 'UTC';
+  }
   return kibanaTz;
 };
 
@@ -63,6 +65,14 @@ const ruleSnoozeSchedulerPseudoFocusCss = css`
     outline: none;
   }
 `;
+
+export const hiddenCalendarClassName = 'RuleSnoozeScheduler__hiddenCalendar';
+
+const ruleSnoozeSchedulerHiddenCalendarCss = css({
+  [`.${hiddenCalendarClassName}`]: {
+    display: 'none !important',
+  },
+});
 
 export const RuleSnoozeScheduler: React.FunctionComponent<ComponentOpts> = ({
   onClose,
@@ -86,7 +96,7 @@ export const RuleSnoozeScheduler: React.FunctionComponent<ComponentOpts> = ({
         <EuiPopoverTitle>
           <EuiFlexGroup alignItems="center" justifyContent="flexStart" gutterSize="s">
             <EuiFlexItem grow={false}>
-              <EuiIcon type="chevronSingleLeft" />
+              <EuiIcon type="chevronSingleLeft" aria-hidden={true} />
             </EuiFlexItem>
             <EuiFlexItem>
               <EuiLink color="text" style={{ fontWeight: 'bold' }} onClick={onClose}>
@@ -239,13 +249,17 @@ const RuleSnoozeSchedulerPanel: React.FunctionComponent<PanelOpts> = ({
 
       if (applyToEndDate && newDateAfterStart) {
         selectEndDT(date);
-      } else selectStartDT(date, !isStartDateTimeChange);
+      } else {
+        selectStartDT(date, !isStartDateTimeChange);
+      }
     },
     [selectingEndDate, selectingEndTime, startDT, endDT, selectEndDT, selectStartDT]
   );
 
   const onClickSaveSchedule = useCallback(() => {
-    if (!startDT || !endDT) return;
+    if (!startDT || !endDT) {
+      return;
+    }
 
     const tzid = selectedTimezone[0].label ?? defaultTz;
     // Convert the dtstart from Kibana timezone to the selected timezone
@@ -294,7 +308,7 @@ const RuleSnoozeSchedulerPanel: React.FunctionComponent<PanelOpts> = ({
   }, [initialSchedule, onCancelSchedules, bulkSnoozeSchedule]);
 
   return (
-    <>
+    <div css={ruleSnoozeSchedulerHiddenCalendarCss}>
       <EuiFlexGroup
         gutterSize="xs"
         alignItems="center"
@@ -305,7 +319,7 @@ const RuleSnoozeSchedulerPanel: React.FunctionComponent<PanelOpts> = ({
           <EuiDatePickerRange
             startDateControl={
               <EuiDatePicker
-                calendarClassName="hidden"
+                calendarClassName={hiddenCalendarClassName}
                 preventOpenOnFocus
                 showTimeSelect
                 onFocus={onFocusStart}
@@ -317,7 +331,7 @@ const RuleSnoozeSchedulerPanel: React.FunctionComponent<PanelOpts> = ({
             }
             endDateControl={
               <EuiDatePicker
-                calendarClassName="hidden"
+                calendarClassName={hiddenCalendarClassName}
                 preventOpenOnFocus
                 showTimeSelect
                 className={selectingEndDate && !endDT ? 'RuleSnoozeScheduler__pseudofocus' : ''}
@@ -428,6 +442,6 @@ const RuleSnoozeSchedulerPanel: React.FunctionComponent<PanelOpts> = ({
           </EuiPopoverFooter>
         </>
       )}
-    </>
+    </div>
   );
 };

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rule_snooze_scheduler_legacy_theme.spec.ts
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rule_snooze_scheduler_legacy_theme.spec.ts
@@ -53,11 +53,7 @@ test.describe(
         return;
       }
 
-      try {
-        await apiServices.alerting.rules.delete(indexThresholdRuleId);
-      } catch {
-        // Continue cleanup even if rule deletion fails
-      }
+      await apiServices.alerting.rules.delete(indexThresholdRuleId);
     });
 
     test('keeps the scheduler stable without legacy theme CSS', async ({

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rule_snooze_scheduler_legacy_theme.spec.ts
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/test/scout/ui/tests/rule_snooze_scheduler_legacy_theme.spec.ts
@@ -1,0 +1,147 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { tags } from '@kbn/scout';
+import type { Locator, ScoutPage } from '@kbn/scout';
+import { expect } from '@kbn/scout/ui';
+import { test } from '../fixtures';
+
+const TEST_RUN_ID = Date.now();
+const INDEX_THRESHOLD_RULE_NAME = `Scout Rule Snooze Scheduler ${TEST_RUN_ID}`;
+const INDEX_THRESHOLD_RULE_TYPE_ID = '.index-threshold';
+
+test.describe(
+  'Rule snooze scheduler legacy theme independence',
+  { tag: tags.stateful.classic },
+  () => {
+    let indexThresholdRuleId: string;
+
+    test.beforeAll(async ({ apiServices }) => {
+      const indexThresholdRuleResponse = await apiServices.alerting.rules.create({
+        name: INDEX_THRESHOLD_RULE_NAME,
+        ruleTypeId: INDEX_THRESHOLD_RULE_TYPE_ID,
+        consumer: 'alerts',
+        enabled: false,
+        schedule: { interval: '1m' },
+        actions: [],
+        params: {
+          aggType: 'count',
+          termSize: 5,
+          thresholdComparator: '>',
+          timeWindowSize: 5,
+          timeWindowUnit: 'm',
+          groupBy: 'all',
+          threshold: [1000],
+          index: ['.kibana'],
+          timeField: '@timestamp',
+        },
+      });
+
+      indexThresholdRuleId = indexThresholdRuleResponse.data.id;
+    });
+
+    test.beforeEach(async ({ browserAuth }) => {
+      await browserAuth.loginAsAdmin();
+    });
+
+    test.afterAll(async ({ apiServices }) => {
+      if (!indexThresholdRuleId) {
+        return;
+      }
+
+      try {
+        await apiServices.alerting.rules.delete(indexThresholdRuleId);
+      } catch {
+        // Continue cleanup even if rule deletion fails
+      }
+    });
+
+    test('keeps the scheduler stable without legacy theme CSS', async ({
+      pageObjects,
+      page,
+    }, testInfo) => {
+      await pageObjects.ruleDetailsPage.gotoById(indexThresholdRuleId);
+      await expect(pageObjects.ruleDetailsPage.ruleName).toHaveText(INDEX_THRESHOLD_RULE_NAME);
+
+      await page.testSubj.locator('rulesListNotifyBadge-unsnoozed').click();
+      await page.testSubj.locator('ruleAddSchedule').click();
+
+      await expectNoLegacyThemeDependency({
+        page,
+        target: page.testSubj.locator('ruleSnoozeScheduler'),
+        testInfo,
+        name: 'rule-snooze-scheduler',
+      });
+    });
+  }
+);
+
+// TODO: This test can be removed when
+// https://github.com/elastic/kibana/issues/258482 is resolved.
+const LEGACY_THEME_LINK_SELECTOR =
+  'link[href*="legacy_light_theme.min.css"], link[href*="legacy_dark_theme.min.css"]';
+
+const expectNoLegacyThemeDependency = async ({
+  page,
+  target,
+  testInfo,
+  name,
+}: {
+  page: ScoutPage;
+  target: Locator;
+  testInfo: {
+    attach: (name: string, options: { body: Buffer; contentType: string }) => Promise<void>;
+  };
+  name: string;
+}) => {
+  await expect(target).toBeVisible();
+  await expect(page.testSubj.locator('scheduler-saveSchedule')).toBeEnabled();
+
+  const beforeBox = await expectVisibleBox(target);
+  const beforeScreenshot = await target.screenshot();
+
+  await page.evaluate(async (selector) => {
+    document.querySelectorAll<HTMLLinkElement>(selector).forEach((link) => link.remove());
+    await document.fonts.ready;
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+  }, LEGACY_THEME_LINK_SELECTOR);
+
+  await expect(target).toBeVisible();
+  await expect(page.testSubj.locator('scheduler-saveSchedule')).toBeEnabled();
+
+  const afterBox = await expectVisibleBox(target);
+  const afterScreenshot = await target.screenshot();
+
+  await testInfo.attach(`${name}-with-legacy-theme`, {
+    body: beforeScreenshot,
+    contentType: 'image/png',
+  });
+  await testInfo.attach(`${name}-without-legacy-theme`, {
+    body: afterScreenshot,
+    contentType: 'image/png',
+  });
+
+  expect(getBoxDimensionDelta(afterBox.width, beforeBox.width)).toBeLessThanOrEqual(0.01);
+  expect(getBoxDimensionDelta(afterBox.height, beforeBox.height)).toBeLessThanOrEqual(0.01);
+};
+
+const expectVisibleBox = async (target: Locator) => {
+  const box = await target.boundingBox();
+  if (box === null) {
+    throw new Error('Expected target to have a visible bounding box');
+  }
+  expect(box.width).toBeGreaterThan(0);
+  expect(box.height).toBeGreaterThan(0);
+  return box;
+};
+
+const getBoxDimensionDelta = (after: number, before: number) => {
+  if (before === 0) {
+    return after === 0 ? 0 : Infinity;
+  }
+  return Math.abs(after - before) / before;
+};


### PR DESCRIPTION
## Summary

Removes the Bootstrap-era `hidden` class from the rule snooze scheduler's `EuiDatePicker` components and replaces it with a component-scoped Emotion style. Adds both a Jest unit test and a Scout UI canary test to guard against regression.

### Changes

- **`scheduler.tsx`**: Replace `calendarClassName="hidden"` with a component-owned class (`RuleSnoozeScheduler__hiddenCalendar`) and a scoped Emotion `css({...})` style on a wrapper `<div>`. The `<div>` approach avoids `<Global>` and its repeated serialization on every re-render. Also fixes pre-existing lint violations (`curly` brace style, `aria-hidden` on decorative icon).
- **`scheduler.test.tsx`** (new): Jest unit test using `renderWithI18n` that asserts the exported `hiddenCalendarClassName` is not `"hidden"` and that no `.hidden` class element appears in the rendered DOM.
- **`rule_snooze_scheduler_legacy_theme.spec.ts`** (new): Scout UI canary test that creates an index-threshold rule, navigates to the snooze scheduler, screenshots the component, removes the legacy theme `<link>` elements, then asserts bounding-box dimensions stay within 1% tolerance. Before/after screenshots are attached to the test report.

## Test plan

- [ ] Jest unit tests pass (`scheduler.test.tsx`).
- [ ] Scout UI canary test passes (`rule_snooze_scheduler_legacy_theme.spec.ts`).
- [ ] Rule snooze scheduler renders and functions correctly with `hidden` replaced by scoped Emotion style.
- [ ] Canary test attaches before/after screenshots and verifies no layout shift when legacy theme CSS is removed.