### PR TITLE
[UII] Fix integration card row height calculation

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/components/package_list_grid/grid.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/components/package_list_grid/grid.tsx
@@ -61,7 +61,7 @@ export const GridColumn = ({
     rowMeasurementCache?.current?.clearAll();
     windowScrollerRef.current?.updatePosition();
     listRef.current?.recomputeRowHeights(0);
-  }, [list.length, columnCount, isLoading]);
+  }, [list, columnCount, isLoading]);
 
   // Use to work on small screen when categories are loaded
   useEffect(() => {

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/components/package_list_grid/grid.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/components/package_list_grid/grid.tsx
@@ -56,11 +56,11 @@ export const GridColumn = ({
     })
   );
 
-  // Reset the row measurement cache when the list changes
+  // Reset the row measurement cache, update position, and recompute row height when the list changes
   useEffect(() => {
     rowMeasurementCache?.current?.clearAll();
-
     windowScrollerRef.current?.updatePosition();
+    listRef.current?.recomputeRowHeights(0);
   }, [list.length, columnCount, isLoading]);
 
   // Use to work on small screen when categories are loaded

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/components/side_bar.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/components/side_bar.tsx
@@ -113,7 +113,6 @@ export const Sidebar: React.FC<SidebarProps> = ({
     <StickySidebar>
       {CreateIntegrationCardButton && !isLoadingCreatedIntegrations && (
         <>
-          <EuiSpacer size="s" />
           {hasCreatedIntegrations ? (
             <EuiLink
               color="text"

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/index.tsx
@@ -9,8 +9,6 @@ import React, { useCallback, useMemo } from 'react';
 import { EuiFlexItem, EuiFlexGroup, EuiSpacer, useEuiTheme } from '@elastic/eui';
 import { useLocation, useHistory } from 'react-router-dom';
 
-import { css } from '@emotion/react';
-
 import { useBreadcrumbs, useStartServices } from '../../../../hooks';
 import { NoEprCallout } from '../../components/no_epr_callout';
 import { categoryExists } from '../home';
@@ -125,13 +123,7 @@ export const BrowseIntegrationsPage: React.FC<{ prereleaseIntegrationsEnabled: b
         onManageIntegrationsClick={onManageIntegrationsClick}
       />
       <EuiFlexItem grow={5}>
-        <EuiFlexGroup
-          direction="column"
-          gutterSize="none"
-          css={css`
-            padding: 16px 8px;
-          `}
-        >
+        <EuiFlexGroup direction="column" gutterSize="none">
           {!isManageIntegrationsView && (
             <SearchAndFiltersBar
               categories={mainCategories}


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/259200.

This PR re-computes card row height when list of card changes. I changed dependency array back to `list` because `list.length` does not capture all list changes, for example the row heights were not being recomputed when sorting is changed from `A-Z` to `Z-A` (the same condensing issue appears prior to these changes).

PR also removes some unnecessary padding around the sidebar and card list, so that margins are even around the page and between elements.

### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->