### PR TITLE
[AI Assistant] Extend default chat experience to Agent for classic spaces

### DIFF
--- a/src/platform/plugins/shared/ai_assistant_management/selection/server/plugin.test.ts
+++ b/src/platform/plugins/shared/ai_assistant_management/selection/server/plugin.test.ts
@@ -135,7 +135,8 @@ describe('plugin', () => {
         { solution: 'es', expected: AIChatExperience.Agent },
         { solution: 'oblt', expected: AIChatExperience.Agent },
         { solution: 'security', expected: AIChatExperience.Agent },
-        { solution: 'classic', expected: AIChatExperience.Classic },
+        { solution: 'classic', expected: AIChatExperience.Agent },
+        { solution: 'workplaceai', expected: AIChatExperience.Classic },
       ])(
         'should return $expected when active space solution is "$solution"',
         async ({ solution, expected }) => {

--- a/src/platform/plugins/shared/ai_assistant_management/selection/server/plugin.ts
+++ b/src/platform/plugins/shared/ai_assistant_management/selection/server/plugin.ts
@@ -82,8 +82,9 @@ export class AIAssistantManagementSelectionPlugin
 
     // Register chat experience setting for both stateful and serverless (except workplaceai)
     if (serverlessProjectType !== 'workplaceai') {
-      // Agent is the default chat experience for Elasticsearch, Security, and
-      // Observability spaces. Other space solutions use Classic unless overridden in config.
+      // Agent is the default chat experience for Elasticsearch, Security, Observability,
+      // and Kibana Classic solution spaces. Other non-null space solutions (for example
+      // future or specialized views) use Classic unless overridden in config.
       core.uiSettings.register({
         [PREFERRED_CHAT_EXPERIENCE_SETTING_KEY]: {
           ...chatExperienceSetting,
@@ -96,7 +97,12 @@ export class AIAssistantManagementSelectionPlugin
                   request
                 );
                 const solution = activeSpace?.solution;
-                if (solution === 'es' || solution === 'security' || solution === 'oblt') {
+                if (
+                  solution === 'es' ||
+                  solution === 'security' ||
+                  solution === 'oblt' ||
+                  solution === 'classic'
+                ) {
                   return AIChatExperience.Agent;
                 }
                 if (solution != null) {

--- a/src/platform/plugins/shared/ai_assistant_management/selection/server/src/settings/chat_experience_setting.ts
+++ b/src/platform/plugins/shared/ai_assistant_management/selection/server/src/settings/chat_experience_setting.ts
@@ -23,7 +23,7 @@ export const chatExperienceSetting: Omit<UiSettingsParams<AIChatExperience>, 'va
   ),
   schema: schema.oneOf(
     [schema.literal(AIChatExperience.Classic), schema.literal(AIChatExperience.Agent)],
-    { defaultValue: AIChatExperience.Classic }
+    { defaultValue: AIChatExperience.Agent }
   ),
   options: [AIChatExperience.Classic, AIChatExperience.Agent],
   type: 'select' as const,

--- a/x-pack/platform/plugins/private/gen_ai_settings/public/components/gen_ai_settings_app.test.tsx
+++ b/x-pack/platform/plugins/private/gen_ai_settings/public/components/gen_ai_settings_app.test.tsx
@@ -428,8 +428,10 @@ describe('GenAiSettingsApp', () => {
 
       renderComponent();
 
-      // Documentation section should not be visible in Classic mode
-      expect(screen.queryByTestId('documentationSection')).not.toBeInTheDocument();
+      // Settings fields load asynchronously; until then `currentChatExperience` falls back to Agent.
+      await waitFor(() => {
+        expect(screen.queryByTestId('documentationSection')).not.toBeInTheDocument();
+      });
     });
 
     it('shows Documentation section when chat experience is Agent', async () => {

--- a/x-pack/platform/plugins/private/gen_ai_settings/public/components/gen_ai_settings_app.tsx
+++ b/x-pack/platform/plugins/private/gen_ai_settings/public/components/gen_ai_settings_app.tsx
@@ -67,7 +67,7 @@ export const GenAiSettingsApp: React.FC<GenAiSettingsAppProps> = ({ setBreadcrum
     unsavedChanges[AI_CHAT_EXPERIENCE_TYPE]?.unsavedValue ??
     chatExperienceField?.savedValue ??
     chatExperienceField?.defaultValue ??
-    AIChatExperience.Classic;
+    AIChatExperience.Agent;
   const isAgentExperience = currentChatExperience === AIChatExperience.Agent;
   const hasAgentBuilderPrivileges = application.capabilities.agentBuilder?.manageAgents === true;
 
@@ -117,13 +117,13 @@ export const GenAiSettingsApp: React.FC<GenAiSettingsAppProps> = ({ setBreadcrum
     )
       ? (unsavedChanges[AI_CHAT_EXPERIENCE_TYPE]?.unsavedValue as AIChatExperience)
       : undefined;
-    const normalizedSavedChatExperience = savedChatExperience ?? AIChatExperience.Classic;
+    const normalizedSavedChatExperience = savedChatExperience ?? AIChatExperience.Agent;
 
     // Telemetry should compare the effective "before" and "after" values.
     // - "before" should include the default if there is no saved value.
     // - "after" should reflect the unsaved change, or fall back to "before" if unchanged.
     const telemetryBeforeChatExperience =
-      savedChatExperience ?? defaultChatExperience ?? AIChatExperience.Classic;
+      savedChatExperience ?? defaultChatExperience ?? AIChatExperience.Agent;
     const telemetryAfterChatExperience = unsavedChatExperience ?? telemetryBeforeChatExperience;
     const shouldTrackOptInConfirmed =
       telemetryBeforeChatExperience !== AIChatExperience.Agent &&

--- a/x-pack/platform/plugins/shared/agent_builder/public/components/announcement/agent_builder_announcement_modal_controller.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/components/announcement/agent_builder_announcement_modal_controller.test.tsx
@@ -12,8 +12,9 @@ import { BehaviorSubject, of } from 'rxjs';
 import { EuiProvider } from '@elastic/eui';
 import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
 import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
-import { HIDE_ANNOUNCEMENTS_ID } from '@kbn/management-settings-ids';
+import { AI_CHAT_EXPERIENCE_TYPE, HIDE_ANNOUNCEMENTS_ID } from '@kbn/management-settings-ids';
 import { AGENT_BUILDER_EVENT_TYPES } from '@kbn/agent-builder-common/telemetry';
+import { AIChatExperience } from '@kbn/ai-assistant-common';
 import type { Capabilities } from '@kbn/core/public';
 
 import { AgentBuilderAnnouncementModalController } from './agent_builder_announcement_modal_controller';
@@ -37,6 +38,7 @@ function buildServices({
   userProfileEnabled = true,
   agentBuilderSeenJson,
   chatExperienceCapabilities = capabilitiesAllowRevert,
+  chatExperience = AIChatExperience.Agent,
 }: {
   hideAnnouncements?: boolean;
   announcementSeenInProfile?: boolean;
@@ -45,6 +47,7 @@ function buildServices({
   /** Overrides the JSON stored in user profile for per-space dismissal (default derives from announcementSeenInProfile). */
   agentBuilderSeenJson?: string;
   chatExperienceCapabilities?: Capabilities;
+  chatExperience?: AIChatExperience;
 } = {}) {
   const space$ = new BehaviorSubject({ id: spaceId, name: spaceId });
   const reportEvent = jest.fn();
@@ -70,7 +73,9 @@ function buildServices({
     settings: {
       client: {
         get: jest.fn(),
-        get$: jest.fn(),
+        get$: jest.fn((key: string) =>
+          key === AI_CHAT_EXPERIENCE_TYPE ? of(chatExperience) : of(undefined)
+        ),
         set: jest.fn(),
       },
       globalClient: {
@@ -152,6 +157,17 @@ describe('AgentBuilderAnnouncementModalController', () => {
 
   it('does not render the modal when user profiles are disabled', async () => {
     const { services } = buildServices({ userProfileEnabled: false });
+    renderController(services);
+
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId('agentBuilderAnnouncementContinueButton')
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it('does not render the modal when the chat experience is set to classic', async () => {
+    const { services } = buildServices({ chatExperience: AIChatExperience.Classic });
     renderController(services);
 
     await waitFor(() => {

--- a/x-pack/platform/plugins/shared/agent_builder/public/components/announcement/agent_builder_announcement_modal_controller.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/components/announcement/agent_builder_announcement_modal_controller.tsx
@@ -10,9 +10,9 @@ import useObservable from 'react-use/lib/useObservable';
 import { EMPTY } from 'rxjs';
 import type { AnalyticsServiceStart, ApplicationStart, IUiSettingsClient } from '@kbn/core/public';
 import type { UserProfileServiceStart } from '@kbn/core-user-profile-browser';
-import { canUserChangeSpaceChatExperience } from '@kbn/ai-assistant-common';
+import { AIChatExperience, canUserChangeSpaceChatExperience } from '@kbn/ai-assistant-common';
 import { useGlobalUiSetting, useKibana } from '@kbn/kibana-react-plugin/public';
-import { HIDE_ANNOUNCEMENTS_ID } from '@kbn/management-settings-ids';
+import { AI_CHAT_EXPERIENCE_TYPE, HIDE_ANNOUNCEMENTS_ID } from '@kbn/management-settings-ids';
 import { AgentBuilderAnnouncementModal } from '@kbn/agent-builder-browser';
 import { AGENT_BUILDER_EVENT_TYPES } from '@kbn/agent-builder-common/telemetry';
 import type { SpacesPluginStart } from '@kbn/spaces-plugin/public';
@@ -34,6 +34,12 @@ export function AgentBuilderAnnouncementModalController() {
   const spacesService = services.spaces;
   const activeSpace$ = useMemo(() => spacesService?.getActiveSpace$() ?? EMPTY, [spacesService]);
   const space = useObservable(activeSpace$);
+  const chatExperience = useObservable(
+    useMemo(
+      () => services.settings.client.get$<AIChatExperience>(AI_CHAT_EXPERIENCE_TYPE),
+      [services.settings.client]
+    )
+  );
   const { isSeen, isReady, markSeen } = useAgentBuilderAnnouncementModalSeenState(
     services.userProfile,
     space?.id
@@ -42,6 +48,7 @@ export function AgentBuilderAnnouncementModalController() {
 
   if (!space) return null;
   if (hideAnnouncements || isDismissed || navigator.webdriver) return null;
+  if (chatExperience === AIChatExperience.Classic) return null;
   if (!isReady) return null;
   if (isSeen) return null;
 


### PR DESCRIPTION
## Summary

Extends the Agent chat experience default to cover the `classic` Kibana space solution, which was previously falling through to Classic. Also changes the global `defaultValue` fallback in the UI setting schema and client-side fallback constants from `Classic` to `Agent`, so new spaces or spaces where settings haven't loaded yet also get the Agent experience.

Additionally fixes a test in `GenAiSettingsApp` that was relying on synchronous settings load — it now uses `waitFor` to handle the async load before asserting.

Part of: https://github.com/elastic/kibana/issues/264152

**Before fix**

https://github.com/user-attachments/assets/01c380f7-44a3-46d8-a60b-2a62f4fc3d78

**After fix**

https://github.com/user-attachments/assets/7c2db1f1-a773-4ee1-b45a-a7bec59e697a


### Checklist

- [ ] Any text added follows EUI's writing guidelines, uses sentence case text and includes i18n support
- [ ] Documentation was added for features that require explanation or tutorials
- [x] Unit or functional tests were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the docker list
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] Flaky Test Runner was used on any tests changed
- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the guidelines
- [ ] Review the backport guidelines and apply applicable `backport:*` labels.

### Identify risks

- **Behaviour change for users in classic spaces** (medium): Users in a `classic` solution space who had not explicitly set a chat experience preference will now default to Agent instead of Classic. This is intentional, but users who preferred Classic will need to manually switch. Mitigation: the setting remains user-configurable; no data is lost.
- **Global fallback change** (low): Changing the schema `defaultValue` from `Classic` to `Agent` means any space with no explicit setting (including future solution types) now defaults to Agent. This is the desired direction, and the `workplaceai` serverless project type is explicitly excluded.
- No data loss, no breaking API changes, no performance concerns.

### Release note

> The AI chat experience now defaults to Agent for classic Kibana spaces and for spaces where no preference has been set, instead of Classic.

**Suggested label:** `release_note:enhancement`

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->