### PR TITLE
[Agent Builder] Persist announcement modal dismissal globally per user

### DIFF
--- a/src/platform/packages/shared/kbn-user-profile-components/src/types.ts
+++ b/src/platform/packages/shared/kbn-user-profile-components/src/types.ts
@@ -39,8 +39,12 @@ export interface UserSettingsData {
   contrastMode?: ContrastModeValue;
   solutionNavOptOut?: boolean;
   /**
-   * Stringified JSON map of space id → whether the Agent Builder announcement modal was dismissed
-   * for that space (`true` = dismissed). Used for per-user, per-space dismissal.
+   * Whether the Agent Builder announcement modal was dismissed for the current user (all spaces).
+   */
+  agentBuilderAnnouncementModalSeen?: boolean;
+  /**
+   * Legacy: stringified JSON map of space id → dismissed (`true`). Superseded by
+   * `agentBuilderAnnouncementModalSeen`; read for backward compatibility.
    */
   agentBuilderAnnouncementModalSeenBySpaceJson?: string;
 }

--- a/x-pack/platform/plugins/shared/agent_builder/public/components/announcement/agent_builder_announcement_modal_controller.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/components/announcement/agent_builder_announcement_modal_controller.test.tsx
@@ -44,7 +44,7 @@ function buildServices({
   announcementSeenInProfile?: boolean;
   spaceId?: string;
   userProfileEnabled?: boolean;
-  /** Overrides the JSON stored in user profile for per-space dismissal (default derives from announcementSeenInProfile). */
+  /** Overrides legacy per-space JSON in user profile (when set, takes precedence over announcementSeenInProfile). */
   agentBuilderSeenJson?: string;
   chatExperienceCapabilities?: Capabilities;
   chatExperience?: AIChatExperience;
@@ -53,17 +53,18 @@ function buildServices({
   const reportEvent = jest.fn();
   const navigateToApp = jest.fn();
   const partialUpdate = jest.fn().mockResolvedValue(undefined);
-  const seenJson =
-    agentBuilderSeenJson ??
-    (announcementSeenInProfile ? JSON.stringify({ [spaceId]: true }) : JSON.stringify({}));
+  const userSettings =
+    agentBuilderSeenJson !== undefined
+      ? { agentBuilderAnnouncementModalSeenBySpaceJson: agentBuilderSeenJson }
+      : announcementSeenInProfile
+      ? { agentBuilderAnnouncementModalSeen: true as const }
+      : { agentBuilderAnnouncementModalSeenBySpaceJson: JSON.stringify({}) };
 
   const userProfile = {
     getEnabled$: () => of(userProfileEnabled),
     getCurrent: jest.fn().mockResolvedValue({
       data: {
-        userSettings: {
-          agentBuilderAnnouncementModalSeenBySpaceJson: seenJson,
-        },
+        userSettings,
       },
     }),
     partialUpdate,
@@ -186,7 +187,7 @@ describe('AgentBuilderAnnouncementModalController', () => {
     });
   });
 
-  it('shows the modal after switching to a space where the announcement was not dismissed', async () => {
+  it('does not show the modal again after switching space when dismissal was recorded for another space (legacy profile)', async () => {
     const spaceA = 'space-a';
     const spaceB = 'space-b';
     const { services, space$ } = buildServices({
@@ -206,7 +207,9 @@ describe('AgentBuilderAnnouncementModalController', () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByTestId('agentBuilderAnnouncementContinueButton')).toBeInTheDocument();
+      expect(
+        screen.queryByTestId('agentBuilderAnnouncementContinueButton')
+      ).not.toBeInTheDocument();
     });
   });
 
@@ -224,7 +227,7 @@ describe('AgentBuilderAnnouncementModalController', () => {
     await waitFor(() => {
       expect(partialUpdate).toHaveBeenCalledWith({
         userSettings: {
-          agentBuilderAnnouncementModalSeenBySpaceJson: JSON.stringify({ [SPACE_ID]: true }),
+          agentBuilderAnnouncementModalSeen: true,
         },
       });
     });
@@ -247,7 +250,11 @@ describe('AgentBuilderAnnouncementModalController', () => {
     await user.click(screen.getByTestId('agentBuilderAnnouncementRevertButton'));
 
     await waitFor(() => {
-      expect(partialUpdate).toHaveBeenCalled();
+      expect(partialUpdate).toHaveBeenCalledWith({
+        userSettings: {
+          agentBuilderAnnouncementModalSeen: true,
+        },
+      });
     });
     expect(reportEvent).toHaveBeenCalledWith(AGENT_BUILDER_EVENT_TYPES.OptOut, {
       source: 'agent_builder_nav_control',

--- a/x-pack/platform/plugins/shared/agent_builder/public/components/announcement/agent_builder_announcement_modal_controller.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/components/announcement/agent_builder_announcement_modal_controller.tsx
@@ -41,8 +41,7 @@ export function AgentBuilderAnnouncementModalController() {
     )
   );
   const { isSeen, isReady, markSeen } = useAgentBuilderAnnouncementModalSeenState(
-    services.userProfile,
-    space?.id
+    services.userProfile
   );
   const [isDismissed, setIsDismissed] = useState(false);
 

--- a/x-pack/platform/plugins/shared/agent_builder/public/components/announcement/use_agent_builder_announcement_modal_seen.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/components/announcement/use_agent_builder_announcement_modal_seen.ts
@@ -24,13 +24,16 @@ function parseSeenMap(json: string | undefined): Record<string, boolean> {
   return {};
 }
 
+function legacyMapHasAnyDismissed(map: Record<string, boolean>): boolean {
+  return Object.values(map).some((v) => v === true);
+}
+
 /**
- * Returns whether the announcement was dismissed for this space in the current user's profile.
+ * Returns whether the announcement was dismissed for the current user (all spaces).
  * When user profiles are disabled, returns true so the modal is not shown (dismissal cannot persist).
  */
-export async function getAnnouncementModalSeenForSpace(
-  userProfile: UserProfileServiceStart,
-  spaceId: string
+export async function getAnnouncementModalSeen(
+  userProfile: UserProfileServiceStart
 ): Promise<boolean> {
   const enabled = await firstValueFrom(userProfile.getEnabled$().pipe(take(1)));
   if (!enabled) {
@@ -38,23 +41,28 @@ export async function getAnnouncementModalSeenForSpace(
   }
   try {
     const profile = await userProfile.getCurrent<{
-      userSettings?: { agentBuilderAnnouncementModalSeenBySpaceJson?: string };
+      userSettings?: {
+        agentBuilderAnnouncementModalSeen?: boolean;
+        agentBuilderAnnouncementModalSeenBySpaceJson?: string;
+      };
     }>({ dataPath: 'userSettings' });
-    const raw = profile?.data?.userSettings?.agentBuilderAnnouncementModalSeenBySpaceJson;
-    const map = parseSeenMap(raw);
-    return map[spaceId] === true;
+    const settings = profile?.data?.userSettings;
+    if (settings?.agentBuilderAnnouncementModalSeen === true) {
+      return true;
+    }
+    const map = parseSeenMap(settings?.agentBuilderAnnouncementModalSeenBySpaceJson);
+    return legacyMapHasAnyDismissed(map);
   } catch {
     return true;
   }
 }
 
 /**
- * Persists dismissal for the current space in user profile data.
+ * Persists global dismissal in user profile data.
  * No-ops when user profiles are disabled.
  */
-export async function setAnnouncementModalSeenForSpace(
-  userProfile: UserProfileServiceStart,
-  spaceId: string
+export async function setAnnouncementModalSeen(
+  userProfile: UserProfileServiceStart
 ): Promise<void> {
   const enabled = await firstValueFrom(userProfile.getEnabled$().pipe(take(1)));
   if (!enabled) {
@@ -62,15 +70,18 @@ export async function setAnnouncementModalSeenForSpace(
   }
   try {
     const profile = await userProfile.getCurrent<{
-      userSettings?: { agentBuilderAnnouncementModalSeenBySpaceJson?: string };
+      userSettings?: {
+        agentBuilderAnnouncementModalSeen?: boolean;
+        agentBuilderAnnouncementModalSeenBySpaceJson?: string;
+      };
     }>({ dataPath: 'userSettings' });
     const existing = profile?.data?.userSettings ?? {};
-    const map = parseSeenMap(existing.agentBuilderAnnouncementModalSeenBySpaceJson);
-    map[spaceId] = true;
+    const { agentBuilderAnnouncementModalSeenBySpaceJson, ...rest } = existing;
+    void agentBuilderAnnouncementModalSeenBySpaceJson;
     await userProfile.partialUpdate({
       userSettings: {
-        ...existing,
-        agentBuilderAnnouncementModalSeenBySpaceJson: JSON.stringify(map),
+        ...rest,
+        agentBuilderAnnouncementModalSeen: true,
       },
     });
   } catch {
@@ -85,21 +96,16 @@ export interface UseAgentBuilderAnnouncementModalSeenStateResult {
 }
 
 export function useAgentBuilderAnnouncementModalSeenState(
-  userProfile: UserProfileServiceStart,
-  spaceId: string | undefined
+  userProfile: UserProfileServiceStart
 ): UseAgentBuilderAnnouncementModalSeenStateResult {
   const [isSeen, setIsSeen] = useState(false);
   const [isReady, setIsReady] = useState(false);
 
   useEffect(() => {
-    if (!spaceId) {
-      setIsReady(false);
-      return;
-    }
     setIsReady(false);
     let cancelled = false;
     void (async () => {
-      const seen = await getAnnouncementModalSeenForSpace(userProfile, spaceId);
+      const seen = await getAnnouncementModalSeen(userProfile);
       if (!cancelled) {
         setIsSeen(seen);
         setIsReady(true);
@@ -108,15 +114,12 @@ export function useAgentBuilderAnnouncementModalSeenState(
     return () => {
       cancelled = true;
     };
-  }, [userProfile, spaceId]);
+  }, [userProfile]);
 
   const markSeen = useCallback(async () => {
-    if (!spaceId) {
-      return;
-    }
-    await setAnnouncementModalSeenForSpace(userProfile, spaceId);
+    await setAnnouncementModalSeen(userProfile);
     setIsSeen(true);
-  }, [userProfile, spaceId]);
+  }, [userProfile]);
 
   return { isSeen, isReady, markSeen };
 }

--- a/x-pack/platform/plugins/shared/security/server/routes/user_profile/update.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/user_profile/update.test.ts
@@ -83,6 +83,7 @@ describe('Update profile routes', () => {
           userSettings: {
             darkMode: 'dark',
             contrastMode: 'high',
+            agentBuilderAnnouncementModalSeen: true,
             agentBuilderAnnouncementModalSeenBySpaceJson: '{}',
           },
         })
@@ -91,6 +92,7 @@ describe('Update profile routes', () => {
         userSettings: {
           darkMode: 'dark',
           contrastMode: 'high',
+          agentBuilderAnnouncementModalSeen: true,
           agentBuilderAnnouncementModalSeenBySpaceJson: '{}',
         },
       });
@@ -358,6 +360,34 @@ describe('Update profile routes', () => {
       expect(userProfileService.update).toHaveBeenCalledWith('u_some_id', {
         userSettings: {
           agentBuilderAnnouncementModalSeenBySpaceJson: '{}',
+        },
+      });
+    });
+
+    it('allows Elastic Cloud users to update agentBuilderAnnouncementModalSeen.', async () => {
+      session.get.mockResolvedValue({
+        error: null,
+        value: sessionMock.createValue({ userProfileId: 'u_some_id' }),
+      });
+      authc.getCurrentUser.mockReturnValue(mockAuthenticatedUser({ elastic_cloud_user: true }));
+
+      await expect(
+        routeHandler(
+          getMockContext(),
+          httpServerMock.createKibanaRequest({
+            body: {
+              userSettings: {
+                agentBuilderAnnouncementModalSeen: true,
+              },
+            },
+          }),
+          kibanaResponseFactory
+        )
+      ).resolves.toEqual(expect.objectContaining({ status: 200, payload: undefined }));
+
+      expect(userProfileService.update).toHaveBeenCalledWith('u_some_id', {
+        userSettings: {
+          agentBuilderAnnouncementModalSeen: true,
         },
       });
     });

--- a/x-pack/platform/plugins/shared/security/server/routes/user_profile/update.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/user_profile/update.ts
@@ -19,6 +19,7 @@ import { createLicensedRouteHandler } from '../licensed_route_handler';
 const ALLOWED_KEYS_UPDATE_CLOUD = [
   'userSettings.darkMode',
   'userSettings.contrastMode',
+  'userSettings.agentBuilderAnnouncementModalSeen',
   'userSettings.agentBuilderAnnouncementModalSeenBySpaceJson',
 ];
 
@@ -50,6 +51,7 @@ const userProfileUpdateSchema = schema.object({
       contrastMode: schema.maybe(
         schema.oneOf([schema.literal('system'), schema.literal('standard'), schema.literal('high')])
       ),
+      agentBuilderAnnouncementModalSeen: schema.maybe(schema.boolean()),
       agentBuilderAnnouncementModalSeenBySpaceJson: schema.maybe(
         schema.string({ maxLength: MAX_AGENT_BUILDER_ANNOUNCEMENT_SPACE_JSON_CHARS })
       ),


### PR DESCRIPTION
## Summary

The Agent Builder announcement modal used to persist dismissal in a **per-space** JSON map on the user profile. After dismissing in one space, switching to another space could show the modal again.

This change stores a global boolean (`agentBuilderAnnouncementModalSeen`) on the user profile so dismissal applies **across all spaces**. It still treats the legacy `agentBuilderAnnouncementModalSeenBySpaceJson` map as "seen" if any entry was true, and on dismiss sets the new flag and **drops** the legacy field from updates. The Security user profile update route allowlist is extended so Elastic Cloud can accept the new key.

This modal (there are two different versions of the same modal depending on access level) is now shown only once per user instead of once per user per space.

**Before fix**

https://github.com/user-attachments/assets/18cb878a-fea7-43b5-8681-cb174f0f6a8c


**After fix**

https://github.com/user-attachments/assets/23095a45-8f5a-49c4-ad80-016c9c2b1186



Part of: https://github.com/elastic/kibana/issues/264152 (1. Modal re-appears on every space switch)

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

- **Persisted user profile data (low):** Adds/uses `userSettings.agentBuilderAnnouncementModalSeen` and stops writing the legacy per-space JSON on dismiss. Existing users with only legacy data remain "seen" via the legacy map until they dismiss again, which then migrates to the global flag. No destructive migration of unrelated profile data.
- **User workflows (low / positive):** Reduces repeated modal prompts when changing spaces; intended behavior improvement.
- **Regressions (low):** Covered by updated unit tests for the modal controller and Security `user_profile` update route; legacy + global read paths are exercised.
- **Performance (negligible):** One boolean vs a small JSON map; no meaningful impact.
- **Hard-to-test scenarios (low):** Real Elastic Cloud profile updates depend on deployment configuration; allowlist change aligns with existing patterns and is covered at the route test level.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)

### Release note

> The Agent Builder announcement modal stays dismissed after you switch spaces, instead of appearing again in each space.

**Suggested label:** `release_note:enhancement`

Made with [Cursor](https://cursor.com)

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->