### PR TITLE
[Security Solution] Update rule's last run on early exit due to error

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/create_security_rule_type_wrapper.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/create_security_rule_type_wrapper.ts
@@ -263,6 +263,9 @@ export const createSecurityRuleTypeWrapper: CreateSecurityRuleTypeWrapper =
                 ruleExecutionLogger.error(`Check for indices to search failed.\nError: ${exc}`);
               }
 
+              // Closing the logger due to early exit
+              await ruleExecutionLogger.close();
+
               return { state: result.state };
             }
           }

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/query/create_query_alert_type.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/query/create_query_alert_type.test.ts
@@ -17,6 +17,7 @@ import { getQueryRuleParams } from '../../rule_schema/mocks';
 import { licensingMock } from '@kbn/licensing-plugin/server/mocks';
 import { QUERY_RULE_TYPE_ID } from '@kbn/securitysolution-rules';
 import { docLinksServiceMock } from '@kbn/core/server/mocks';
+import { SavedObjectsErrorHelpers } from '@kbn/core/server';
 import { IndexPatternsFetcher } from '@kbn/data-views-plugin/server';
 import { hasTimestampFields } from '../utils/utils';
 import { createMockEndpointAppContextService } from '../../../../endpoint/mocks';
@@ -291,5 +292,47 @@ describe('Custom Query Alerts', () => {
     expect(mockedStatusLogger.warn).toHaveBeenCalledWith(
       "The rule's max alerts per run setting (10000) is greater than the Kibana alerting limit (1000). The rule will only write a maximum of 1000 alerts per rule run."
     );
+  });
+
+  describe('when exiting early due to an error resolving the input index', () => {
+    const dataViewId = 'missing-data-view-id';
+
+    const registerAndRun = async () => {
+      const queryAlertType = securityRuleTypeWrapper(
+        createQueryAlertType({
+          id: QUERY_RULE_TYPE_ID,
+          name: 'Custom Query Rule',
+        })
+      );
+
+      alerting.registerType(queryAlertType);
+
+      await executor({ params: getQueryRuleParams({ dataViewId }) });
+    };
+
+    it('closes the rule execution logger when the data view is not found, so the last run object is updated', async () => {
+      services.savedObjectsClient.get.mockRejectedValueOnce(
+        SavedObjectsErrorHelpers.createGenericNotFoundError('index-pattern', dataViewId)
+      );
+
+      await registerAndRun();
+
+      expect(mockedStatusLogger.error).toHaveBeenCalledWith(
+        expect.stringContaining('Data view is not found.'),
+        expect.objectContaining({ userError: true })
+      );
+      expect(mockedStatusLogger.close).toHaveBeenCalledTimes(1);
+    });
+
+    it('closes the rule execution logger when resolving the input index fails unexpectedly, so the last run object is updated', async () => {
+      services.savedObjectsClient.get.mockRejectedValueOnce(new Error('Unexpected failure'));
+
+      await registerAndRun();
+
+      expect(mockedStatusLogger.error).toHaveBeenCalledWith(
+        expect.stringContaining('Check for indices to search failed.')
+      );
+      expect(mockedStatusLogger.close).toHaveBeenCalledTimes(1);
+    });
   });
 });


### PR DESCRIPTION
## Summary

Follow-up fix for https://github.com/elastic/kibana/pull/257203 where an early-exit path was missed when migrating security rule execution logging.

- Closes the rule execution logger when the rule exits early because `getInputIndex` fails (data view not found or unexpected error), so the rule's last run object gets updated for that execution.

## Details

In [`create_security_rule_type_wrapper.ts`](x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/create_security_rule_type_wrapper.ts) the executor returns early when resolving the input index (data view / index pattern) throws. Before this change, `ruleExecutionLogger.close()` was not called on that branch, which meant `setRuleLastRun` was never invoked and the rule's last run object was left stale for the execution.

## Test plan

- [ ] Unit tests in `create_query_alert_type.test.ts` cover both early-exit branches (data view not found, generic error resolving the input index) and assert that `ruleExecutionLogger.close()` is invoked.
- [ ] Manual: configure a rule with a `dataViewId` that does not exist, run the rule, and verify its last run shows the error instead of remaining stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->