### PR TITLE
[CI] Remove dead Archive Kibana Distribution block

### DIFF
--- a/.buildkite/scripts/build_kibana.sh
+++ b/.buildkite/scripts/build_kibana.sh
@@ -26,11 +26,5 @@ is_pr_with_label "ci:build-cdn-assets" || BUILD_ARGS+=("--skip-cdn-assets")
 echo "> node scripts/build" "${BUILD_ARGS[@]}"
 node scripts/build "${BUILD_ARGS[@]}"
 
-# Ensure docker cleanup finished before archiving
+# Ensure docker cleanup finished before build artifacts are uploaded
 wait $cleanup_pid || true
-
-echo "--- Archive Kibana Distribution"
-version="$(jq -r '.version' package.json)"
-linuxBuild="$KIBANA_DIR/target/kibana-$version-SNAPSHOT-linux-x86_64.tar.gz"
-mkdir -p "$KIBANA_BUILD_LOCATION"
-tar -xzf "$linuxBuild" -C "$KIBANA_BUILD_LOCATION" --strip=1


### PR DESCRIPTION
## Summary

Remove the unused "Archive Kibana Distribution" block from `build_kibana.sh`.

This block extracted the build into `KIBANA_BUILD_LOCATION` on the build agent, but no subsequent CI step runs on that same agent — test steps download the artifact independently via `download_build_artifacts.sh`. The local extraction was dead code.

Also reverts the gzip compression level change (6→1), which is superseded by #264794 switching to zstd.

## Test plan

- CI Build Kibana Distribution step completes successfully
- FTR / Scout tests still pass (they consume the build via `download_build_artifacts.sh`, unaffected by this change)