### PR TITLE
Fix CODEOWNERS: move actionable-obs-team service entries after appex-qa

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1769,6 +1769,10 @@ x-pack/platform/plugins/shared/streams/server/routes/internal/sig_events @elasti
 /x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/incident_management/ @elastic/actionable-obs-team
 /x-pack/solutions/observability/test/functional/page_objects/alert_controls.ts @elastic/actionable-obs-team
 /x-pack/platform/test/serverless/functional/page_objects/svl_custom_roles_page.ts @elastic/actionable-obs-team
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/services/alerting_api.ts @elastic/actionable-obs-team @elastic/appex-qa
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/services/slo_api.ts @elastic/actionable-obs-team @elastic/appex-qa
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/services/synthetics_params_api.ts @elastic/actionable-obs-team @elastic/appex-qa
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/services/synthetics_private_location.ts @elastic/actionable-obs-team @elastic/appex-qa
 
 
 # Elastic Stack Monitoring
@@ -2110,10 +2114,6 @@ x-pack/platform/plugins/shared/ml/server/models/data_recognizer/modules/security
 /x-pack/solutions/observability/test/api_integration_deployment_agnostic/ftr_provider_context.d.ts @elastic/appex-qa
 /x-pack/platform/test/api_integration_deployment_agnostic/*configs/ @elastic/appex-qa
 /x-pack/solutions/observability/test/api_integration_deployment_agnostic/services/ @elastic/appex-qa
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/services/alerting_api.ts @elastic/appex-qa @elastic/actionable-obs-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/services/slo_api.ts @elastic/appex-qa @elastic/actionable-obs-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/services/synthetics_params_api.ts @elastic/appex-qa @elastic/actionable-obs-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/services/synthetics_private_location.ts @elastic/appex-qa @elastic/actionable-obs-team
 /x-pack/platform/test/api_integration_deployment_agnostic/README.md @elastic/appex-qa
 /x-pack/platform/test/api_integration_deployment_agnostic/services/ @elastic/appex-qa
 /x-pack/platform/test/api_integration_deployment_agnostic/ftr_provider_context.d.ts @elastic/appex-qa

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1762,11 +1762,6 @@ x-pack/platform/plugins/shared/streams/server/routes/internal/sig_events @elasti
 /x-pack/solutions/observability/plugins/infra/public/alerting @elastic/actionable-obs-team
 /x-pack/solutions/observability/plugins/infra/server/lib/alerting @elastic/actionable-obs-team
 /x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/alerting/ @elastic/actionable-obs-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/services @elastic/actionable-obs-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/services/alerting_api.ts @elastic/actionable-obs-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/services/slo_api.ts @elastic/actionable-obs-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/services/synthetics_params_api.ts @elastic/actionable-obs-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/services/synthetics_private_location.ts @elastic/actionable-obs-team
 /x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/ @elastic/actionable-obs-team
 /x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.synthetics.index.ts @elastic/actionable-obs-team
 /x-pack/solutions/observability/test/ensemble @elastic/obs-ux-management-team
@@ -2115,6 +2110,10 @@ x-pack/platform/plugins/shared/ml/server/models/data_recognizer/modules/security
 /x-pack/solutions/observability/test/api_integration_deployment_agnostic/ftr_provider_context.d.ts @elastic/appex-qa
 /x-pack/platform/test/api_integration_deployment_agnostic/*configs/ @elastic/appex-qa
 /x-pack/solutions/observability/test/api_integration_deployment_agnostic/services/ @elastic/appex-qa
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/services/alerting_api.ts @elastic/appex-qa @elastic/actionable-obs-team
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/services/slo_api.ts @elastic/appex-qa @elastic/actionable-obs-team
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/services/synthetics_params_api.ts @elastic/appex-qa @elastic/actionable-obs-team
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/services/synthetics_private_location.ts @elastic/appex-qa @elastic/actionable-obs-team
 /x-pack/platform/test/api_integration_deployment_agnostic/README.md @elastic/appex-qa
 /x-pack/platform/test/api_integration_deployment_agnostic/services/ @elastic/appex-qa
 /x-pack/platform/test/api_integration_deployment_agnostic/ftr_provider_context.d.ts @elastic/appex-qa


### PR DESCRIPTION
## Summary

Fixes CODEOWNERS precedence issue where `@elastic/actionable-obs-team` entries for test service files were being overridden by a later `@elastic/appex-qa` wildcard rule on the `services/` directory.

In GitHub CODEOWNERS, the **last matching pattern wins**. The `@elastic/appex-qa` rule:

```
/x-pack/solutions/observability/test/api_integration_deployment_agnostic/services/ @elastic/appex-qa
```

was overriding the more specific `@elastic/actionable-obs-team` entries that appeared earlier, causing PRs touching these service files to incorrectly request review from only `@elastic/appex-qa`.

**Fix:** Added specific file entries **after** the broad `@elastic/appex-qa` directory rule with **shared ownership** — both `@elastic/appex-qa` and `@elastic/actionable-obs-team` are listed as co-owners so both teams get review requests.

### Files affected

- `alerting_api.ts`
- `slo_api.ts`
- `synthetics_params_api.ts`
- `synthetics_private_location.ts`

Made with Cursor