### PR TITLE
[9.4] [One Workflow] Deprecate direct AI connector step types in favor of ai.prompt (#263694)

### DIFF
--- a/src/platform/packages/shared/kbn-workflows/spec/deprecated_step_metadata.test.ts
+++ b/src/platform/packages/shared/kbn-workflows/spec/deprecated_step_metadata.test.ts
@@ -1,0 +1,118 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import {
+  DEPRECATED_STEP_METADATA,
+  DEPRECATED_STEP_PREFIX_METADATA,
+  getDeprecatedStepMessage,
+  getStepDeprecationInfo,
+  isDeprecatedStepType,
+} from './deprecated_step_metadata';
+
+describe('deprecated_step_metadata', () => {
+  describe('getStepDeprecationInfo', () => {
+    it('returns deprecation info for exact-match step types', () => {
+      const info = getStepDeprecationInfo('kibana.createCase');
+      expect(info).toEqual({ replacementStepType: 'cases.createCase' });
+    });
+
+    it('returns undefined for non-deprecated step types', () => {
+      expect(getStepDeprecationInfo('cases.createCase')).toBeUndefined();
+    });
+
+    it('returns deprecation info for prefix-matched step types', () => {
+      expect(getStepDeprecationInfo('inference.completion')).toEqual({
+        replacementStepType: 'ai.prompt',
+      });
+      expect(getStepDeprecationInfo('bedrock.invokeAI')).toEqual({
+        replacementStepType: 'ai.prompt',
+      });
+      expect(getStepDeprecationInfo('gen-ai.run')).toEqual({
+        replacementStepType: 'ai.prompt',
+      });
+      expect(getStepDeprecationInfo('gemini.invokeStream')).toEqual({
+        replacementStepType: 'ai.prompt',
+      });
+    });
+
+    it('does not match prefixes without the trailing dot', () => {
+      // 'inference' alone should not match the 'inference.' prefix
+      expect(getStepDeprecationInfo('inference')).toBeUndefined();
+      expect(getStepDeprecationInfo('bedrock')).toBeUndefined();
+    });
+
+    it('prioritizes exact match over prefix match', () => {
+      // Verify all exact-match entries are still returned correctly
+      for (const [stepType, info] of Object.entries(DEPRECATED_STEP_METADATA)) {
+        expect(getStepDeprecationInfo(stepType)).toEqual(info);
+      }
+    });
+
+    it('does not deprecate unrelated step types', () => {
+      expect(getStepDeprecationInfo('http')).toBeUndefined();
+      expect(getStepDeprecationInfo('ai.prompt')).toBeUndefined();
+      expect(getStepDeprecationInfo('elasticsearch.search')).toBeUndefined();
+    });
+  });
+
+  describe('isDeprecatedStepType', () => {
+    it('returns true for exact-match deprecated step types', () => {
+      expect(isDeprecatedStepType('kibana.createCase')).toBe(true);
+    });
+
+    it('returns true for prefix-matched deprecated step types', () => {
+      expect(isDeprecatedStepType('inference.completion')).toBe(true);
+      expect(isDeprecatedStepType('gen-ai.invokeAI')).toBe(true);
+    });
+
+    it('returns false for non-deprecated step types', () => {
+      expect(isDeprecatedStepType('ai.prompt')).toBe(false);
+      expect(isDeprecatedStepType('http')).toBe(false);
+    });
+  });
+
+  describe('getDeprecatedStepMessage', () => {
+    it('formats message with replacement step type', () => {
+      const message = getDeprecatedStepMessage('inference.completion', {
+        replacementStepType: 'ai.prompt',
+      });
+      expect(message).toBe(
+        'Step type "inference.completion" is deprecated. Use "ai.prompt" instead.'
+      );
+    });
+
+    it('uses custom message when provided', () => {
+      const message = getDeprecatedStepMessage('old.step', {
+        message: 'Custom deprecation notice.',
+      });
+      expect(message).toBe('Custom deprecation notice.');
+    });
+
+    it('falls back to generic message when no replacement', () => {
+      const message = getDeprecatedStepMessage('old.step', {});
+      expect(message).toBe('Step type "old.step" is deprecated.');
+    });
+  });
+
+  describe('DEPRECATED_STEP_PREFIX_METADATA', () => {
+    it('includes all AI connector prefixes', () => {
+      const prefixes = DEPRECATED_STEP_PREFIX_METADATA.map((entry) => entry.prefix);
+      expect(prefixes).toContain('inference.');
+      expect(prefixes).toContain('bedrock.');
+      expect(prefixes).toContain('gen-ai.');
+      expect(prefixes).toContain('gemini.');
+    });
+
+    it('all prefix entries suggest ai.prompt as replacement', () => {
+      for (const entry of DEPRECATED_STEP_PREFIX_METADATA) {
+        expect(entry.deprecation.replacementStepType).toBe('ai.prompt');
+      }
+    });
+  });
+});

--- a/src/platform/packages/shared/kbn-workflows/spec/deprecated_step_metadata.ts
+++ b/src/platform/packages/shared/kbn-workflows/spec/deprecated_step_metadata.ts
@@ -12,6 +12,12 @@ export interface StepDeprecationInfo {
   message?: string;
 }
 
+export interface StepPrefixDeprecationInfo {
+  /** Prefix to match against step type (e.g., 'inference.' matches 'inference.completion') */
+  prefix: string;
+  deprecation: StepDeprecationInfo;
+}
+
 export const DEPRECATED_STEP_METADATA: Record<string, StepDeprecationInfo> = {
   'kibana.createCase': {
     replacementStepType: 'cases.createCase',
@@ -39,8 +45,33 @@ export const DEPRECATED_STEP_METADATA: Record<string, StepDeprecationInfo> = {
   },
 };
 
+/**
+ * Prefix-based deprecation for step types. Any step type starting with one of these
+ * prefixes is treated as deprecated. This avoids enumerating every sub-action when an
+ * entire connector family is superseded by a purpose-built step.
+ */
+export const DEPRECATED_STEP_PREFIX_METADATA: StepPrefixDeprecationInfo[] = [
+  { prefix: 'inference.', deprecation: { replacementStepType: 'ai.prompt' } },
+  { prefix: 'bedrock.', deprecation: { replacementStepType: 'ai.prompt' } },
+  { prefix: 'gen-ai.', deprecation: { replacementStepType: 'ai.prompt' } },
+  { prefix: 'gemini.', deprecation: { replacementStepType: 'ai.prompt' } },
+];
+
+export function getStepPrefixDeprecationInfo(stepType: string): StepDeprecationInfo | undefined {
+  for (const { prefix, deprecation } of DEPRECATED_STEP_PREFIX_METADATA) {
+    if (stepType.startsWith(prefix)) {
+      return deprecation;
+    }
+  }
+  return undefined;
+}
+
 export function getStepDeprecationInfo(stepType: string): StepDeprecationInfo | undefined {
-  return DEPRECATED_STEP_METADATA[stepType];
+  const exact = DEPRECATED_STEP_METADATA[stepType];
+  if (exact) {
+    return exact;
+  }
+  return getStepPrefixDeprecationInfo(stepType);
 }
 
 export function isDeprecatedStepType(stepType: string): boolean {

--- a/src/platform/plugins/shared/workflows_management/common/schema.ts
+++ b/src/platform/plugins/shared/workflows_management/common/schema.ts
@@ -20,6 +20,7 @@ import {
   generateYamlSchemaFromConnectors,
   getElasticsearchConnectors,
   getKibanaConnectors,
+  getStepPrefixDeprecationInfo,
   SystemConnectorsMap,
 } from '@kbn/workflows';
 import { z } from '@kbn/zod/v4';
@@ -363,6 +364,11 @@ export function getDeprecatedStepMetadataMap(): Readonly<Record<string, StepDepr
   for (const connector of getAllConnectorsInternal()) {
     if (connector.deprecation) {
       deprecatedStepMetadata[connector.type] = connector.deprecation;
+    } else {
+      const prefixMatch = getStepPrefixDeprecationInfo(connector.type);
+      if (prefixMatch) {
+        deprecatedStepMetadata[connector.type] = prefixMatch;
+      }
     }
   }
 
@@ -375,7 +381,7 @@ export function getDeprecatedStepMetadataMap(): Readonly<Record<string, StepDepr
 }
 
 export function getDeprecatedStepMetadata(stepType: string): StepDeprecationInfo | undefined {
-  return getDeprecatedStepMetadataMap()[stepType];
+  return getDeprecatedStepMetadataMap()[stepType] ?? getStepPrefixDeprecationInfo(stepType);
 }
 
 export function isDeprecatedStepType(stepType: string): boolean {

--- a/src/platform/plugins/shared/workflows_management/public/features/actions_menu_popover/lib/get_action_options.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/actions_menu_popover/lib/get_action_options.test.ts
@@ -13,7 +13,7 @@ import type { WorkflowsExtensionsPublicPluginStart } from '@kbn/workflows-extens
 import { workflowsExtensionsMock } from '@kbn/workflows-extensions/public/mocks';
 import { z } from '@kbn/zod/v4';
 import { flattenOptions, getActionOptions } from './get_action_options';
-import { getAllConnectors, getDeprecatedStepMetadataMap } from '../../../../common/schema';
+import { getAllConnectors, isDeprecatedStepType } from '../../../../common/schema';
 import { getStepIconType } from '../../../shared/ui/step_icons/get_step_icon_type';
 import { triggerSchemas } from '../../../trigger_schemas';
 import type { ActionOptionData } from '../types';
@@ -21,7 +21,7 @@ import { isActionGroup, isActionOption } from '../types';
 
 jest.mock('../../../../common/schema', () => ({
   getAllConnectors: jest.fn(),
-  getDeprecatedStepMetadataMap: jest.fn(() => ({})),
+  isDeprecatedStepType: jest.fn(() => false),
 }));
 jest.mock('../../../trigger_schemas', () => ({
   triggerSchemas: { getTriggerDefinitions: jest.fn(() => []) },
@@ -60,7 +60,7 @@ describe('getActionOptions', () => {
     mockWorkflowsExtensions = workflowsExtensionsMock.createStart();
 
     (getAllConnectors as jest.Mock).mockReturnValue([]);
-    (getDeprecatedStepMetadataMap as jest.Mock).mockReturnValue({});
+    (isDeprecatedStepType as jest.Mock).mockReturnValue(false);
     (isDynamicConnector as jest.MockedFunction<typeof isDynamicConnector>).mockImplementation(
       () => false
     );
@@ -346,9 +346,9 @@ describe('getActionOptions', () => {
     };
 
     (getAllConnectors as jest.Mock).mockReturnValue([mockConnector]);
-    (getDeprecatedStepMetadataMap as jest.Mock).mockReturnValue({
-      'kibana.createCase': { replacementStepType: 'cases.createCase' },
-    });
+    (isDeprecatedStepType as jest.Mock).mockImplementation(
+      (stepType: string) => stepType === 'kibana.createCase'
+    );
     mockWorkflowsExtensions.getStepDefinition.mockReturnValue(undefined);
 
     const result = getActionOptions(mockEuiTheme, mockWorkflowsExtensions);

--- a/src/platform/plugins/shared/workflows_management/public/features/actions_menu_popover/lib/get_action_options.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/actions_menu_popover/lib/get_action_options.ts
@@ -12,7 +12,7 @@ import { AssistantIcon } from '@kbn/ai-assistant-icon';
 import { i18n } from '@kbn/i18n';
 import { getBuiltInStepDefinition, isDynamicConnector, StepCategory } from '@kbn/workflows';
 import type { WorkflowsExtensionsPublicPluginStart } from '@kbn/workflows-extensions/public';
-import { getAllConnectors, getDeprecatedStepMetadataMap } from '../../../../common/schema';
+import { getAllConnectors, isDeprecatedStepType } from '../../../../common/schema';
 import { getStepIconType } from '../../../shared/ui/step_icons/get_step_icon_type';
 import { triggerSchemas } from '../../../trigger_schemas';
 import type { ActionConnectorGroup, ActionGroup, ActionOptionData } from '../types';
@@ -23,7 +23,6 @@ export function getActionOptions(
   workflowsExtensions: WorkflowsExtensionsPublicPluginStart
 ): ActionOptionData[] {
   const connectors = getAllConnectors();
-  const deprecatedStepMetadata = getDeprecatedStepMetadataMap();
   const builtInTriggerOptions: ActionOptionData[] = [
     {
       id: 'manual',
@@ -267,7 +266,7 @@ export function getActionOptions(
   const baseTypeInstancesCount: Record<string, number> = {};
 
   for (const connector of connectors) {
-    if (!deprecatedStepMetadata[connector.type]) {
+    if (!isDeprecatedStepType(connector.type)) {
       const customStepDefinition = workflowsExtensions.getStepDefinition(connector.type);
       if (customStepDefinition) {
         const group = stepGroups[customStepDefinition.category];

--- a/src/platform/plugins/shared/workflows_management/public/features/validate_workflow_yaml/lib/validate_deprecated_step_types.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/validate_workflow_yaml/lib/validate_deprecated_step_types.test.ts
@@ -66,6 +66,26 @@ describe('validateDeprecatedStepTypes', () => {
     ]);
   });
 
+  it('returns a warning for prefix-matched deprecated step types (AI connectors)', () => {
+    const aiStep = createStepInfo({
+      stepId: 'ai_call',
+      stepType: 'inference.completion',
+      propInfos: {
+        type: createPropInfo(['type'], 'inference.completion', [10, 20, 20]),
+      },
+    });
+
+    const results = validateDeprecatedStepTypes(createWorkflowLookup([aiStep]), mockLineCounter);
+
+    expect(results).toEqual([
+      expect.objectContaining({
+        owner: 'deprecated-step-validation',
+        severity: 'warning',
+        message: 'Step type "inference.completion" is deprecated. Use "ai.prompt" instead.',
+      }),
+    ]);
+  });
+
   it('returns no warnings for non-deprecated step types', () => {
     const currentStep = createStepInfo({
       stepId: 'create_case',

--- a/src/platform/plugins/shared/workflows_management/public/features/validate_workflow_yaml/lib/validate_deprecated_step_types.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/validate_workflow_yaml/lib/validate_deprecated_step_types.ts
@@ -9,7 +9,7 @@
 
 import type { LineCounter } from 'yaml';
 import { getDeprecatedStepMessage } from '@kbn/workflows';
-import { getDeprecatedStepMetadataMap } from '../../../../common/schema';
+import { getDeprecatedStepMetadata } from '../../../../common/schema';
 import type { WorkflowLookup } from '../../../entities/workflows/store/workflow_detail/utils/build_workflow_lookup';
 import type { YamlValidationResult } from '../model/types';
 
@@ -18,10 +18,9 @@ export function validateDeprecatedStepTypes(
   lineCounter: LineCounter
 ): YamlValidationResult[] {
   const results: YamlValidationResult[] = [];
-  const deprecatedStepMetadata = getDeprecatedStepMetadataMap();
 
   for (const step of Object.values(workflowLookup.steps)) {
-    const deprecation = deprecatedStepMetadata[step.stepType];
+    const deprecation = getDeprecatedStepMetadata(step.stepType);
     const typeProp = step.propInfos.type;
 
     if (deprecation && typeProp?.valueNode.range) {

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/get_completion_item_provider.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/get_completion_item_provider.test.ts
@@ -16,7 +16,8 @@ import {
   clearAllYamlProviders,
   interceptMonacoYamlProvider,
 } from './intercept_monaco_yaml_provider';
-import { getDeprecatedStepMetadataMap } from '../../../../../common/schema';
+
+import { isDeprecatedStepType } from '../../../../../common/schema';
 
 // Mock dependencies
 jest.mock('./suggestions/get_suggestions', () => ({
@@ -33,7 +34,7 @@ jest.mock('./context/build_autocomplete_context', () => ({
 }));
 
 jest.mock('../../../../../common/schema', () => ({
-  getDeprecatedStepMetadataMap: jest.fn(() => ({})),
+  isDeprecatedStepType: jest.fn(() => false),
 }));
 
 describe('getCompletionItemProvider', () => {
@@ -63,7 +64,7 @@ describe('getCompletionItemProvider', () => {
     } as monaco.languages.CompletionContext;
 
     getState = jest.fn(() => ({} as any));
-    (getDeprecatedStepMetadataMap as jest.Mock).mockReturnValue({});
+    (isDeprecatedStepType as jest.Mock).mockReturnValue(false);
   });
 
   afterEach(() => {
@@ -170,10 +171,10 @@ describe('getCompletionItemProvider', () => {
         }),
       };
 
-      (getDeprecatedStepMetadataMap as jest.Mock).mockReturnValue({
-        'kibana.createCase': { replacementStepType: 'cases.createCase' },
-        'kibana.createCaseDefaultSpace': { replacementStepType: 'kibana.createCase' },
-      });
+      const deprecatedStepTypes = new Set(['kibana.createCase', 'kibana.createCaseDefaultSpace']);
+      (isDeprecatedStepType as jest.Mock).mockImplementation((stepType: string) =>
+        deprecatedStepTypes.has(stepType)
+      );
       monaco.languages.registerCompletionItemProvider(YAML_LANG_ID, yamlProvider);
 
       const provider = getCompletionItemProvider(getState);

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/get_completion_item_provider.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/get_completion_item_provider.ts
@@ -8,13 +8,12 @@
  */
 
 import { monaco } from '@kbn/monaco';
-import type { StepDeprecationInfo } from '@kbn/workflows';
 import { buildAutocompleteContext } from './context/build_autocomplete_context';
 import { getAllYamlProviders } from './intercept_monaco_yaml_provider';
 import { getSuggestions, isInsideLoopBody } from './suggestions/get_suggestions';
 import { isInWorkflowOutputWithBlock } from './suggestions/workflow/get_workflow_outputs_suggestions';
 import type { WorkflowKqlCompletionServices } from './suggestions/workflow_kql_completion_services';
-import { getDeprecatedStepMetadataMap } from '../../../../../common/schema';
+import { isDeprecatedStepType } from '../../../../../common/schema';
 import type { WorkflowDetailState } from '../../../../entities/workflows/store';
 
 // Unique identifier for the workflow completion provider
@@ -64,15 +63,14 @@ function getDeduplicationKey(suggestion: monaco.languages.CompletionItem): strin
  */
 function mapSuggestions(
   map: Map<string, monaco.languages.CompletionItem>,
-  suggestions: monaco.languages.CompletionItem[],
-  deprecatedStepMetadata: Readonly<Record<string, StepDeprecationInfo>>
+  suggestions: monaco.languages.CompletionItem[]
 ): void {
   for (const suggestion of suggestions) {
     const key = getDeduplicationKey(suggestion);
 
     // Skip deprecated step types - they still work for backward compatibility
     // but we don't want to suggest them to users
-    if (!deprecatedStepMetadata[key]) {
+    if (!isDeprecatedStepType(key)) {
       const existing = map.get(key);
 
       if (existing) {
@@ -121,7 +119,6 @@ export function getCompletionItemProvider(
 
       // Incremental deduplication accumulator
       const deduplicatedMap = new Map<string, monaco.languages.CompletionItem>();
-      const deprecatedStepMetadata = getDeprecatedStepMetadataMap();
 
       // Inside workflow.output's with: block, show only declared output field names so the user
       // doesn't get generic YAML/JSON Schema keys; skip the YAML provider in that case.
@@ -150,7 +147,7 @@ export function getCompletionItemProvider(
               );
               if (result) {
                 // Deduplicate across YAML providers only (snippet beats plain)
-                mapSuggestions(deduplicatedMap, result.suggestions || [], deprecatedStepMetadata);
+                mapSuggestions(deduplicatedMap, result.suggestions || []);
                 if (result.incomplete) {
                   isIncomplete = true;
                 }
@@ -173,7 +170,7 @@ export function getCompletionItemProvider(
       // Workflow suggestions always win over YAML duplicates.
       for (const suggestion of workflowSuggestions) {
         const key = getDeduplicationKey(suggestion);
-        if (!deprecatedStepMetadata[key]) {
+        if (!isDeprecatedStepType(key)) {
           deduplicatedMap.set(key, suggestion);
         }
       }

--- a/src/platform/plugins/shared/workflows_management/server/agent_builder/tools/get_step_definitions_tool.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/agent_builder/tools/get_step_definitions_tool.test.ts
@@ -18,6 +18,7 @@ jest.mock('../../../common/schema', () => ({
   getAllConnectors: (...args: unknown[]) => mockGetAllConnectors(...args),
   addDynamicConnectorsToCache: (...args: unknown[]) => mockAddDynamicConnectorsToCache(...args),
   getCachedAllConnectorsMap: () => null,
+  getDeprecatedStepMetadata: () => undefined,
 }));
 
 const invokeHandler = async (tool: BuiltinToolDefinition, input: unknown, context: unknown) =>

--- a/src/platform/plugins/shared/workflows_management/server/agent_builder/tools/get_step_definitions_tool.ts
+++ b/src/platform/plugins/shared/workflows_management/server/agent_builder/tools/get_step_definitions_tool.ts
@@ -31,6 +31,7 @@ import {
   addDynamicConnectorsToCache,
   getAllConnectors,
   getCachedAllConnectorsMap,
+  getDeprecatedStepMetadata,
 } from '../../../common/schema';
 import type { WorkflowsManagementApi } from '../../api/workflows_management_api';
 import type { AgentBuilderPluginSetupContract } from '../../types';
@@ -117,7 +118,8 @@ export function formatConnectorStep(connector: ConnectorContractUnion): StepDefi
     ? buildStepParamsSummary(connector.configSchema)
     : undefined;
   const outputSummary = buildOutputSummary(connector.outputSchema);
-  const deprecationMetadata = formatDeprecationMetadata(connector.type, connector.deprecation);
+  const deprecation = connector.deprecation ?? getDeprecatedStepMetadata(connector.type);
+  const deprecationMetadata = formatDeprecationMetadata(connector.type, deprecation);
 
   return {
     id: connector.type,

--- a/src/platform/plugins/shared/workflows_management/server/agent_builder/tools/get_step_definitions_tool_output_size.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/agent_builder/tools/get_step_definitions_tool_output_size.test.ts
@@ -17,6 +17,7 @@ jest.mock('../../../common/schema', () => ({
   },
   addDynamicConnectorsToCache: jest.fn(),
   getCachedAllConnectorsMap: () => null,
+  getDeprecatedStepMetadata: () => undefined,
 }));
 
 const MAX_CHARS_PER_STEP = 5000;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[One Workflow] Deprecate direct AI connector step types in favor of ai.prompt (#263694)](https://github.com/elastic/kibana/pull/263694)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Kirill Chernakov","email":"yakiryous@gmail.com"},"sourceCommit":{"committedDate":"2026-04-16T12:48:51Z","message":"[One Workflow] Deprecate direct AI connector step types in favor of ai.prompt (#263694)\n\n## Summary\n\nExtends the workflow step deprecation mechanism to support\n**prefix-based matching** and deprecates all direct AI connector step\ntypes (`inference.*`, `bedrock.*`, `gen-ai.*`, `gemini.*`) in favor of\nthe purpose-built `ai.prompt` step.\n\n- Users were confused by the availability of raw AI connector steps\nalongside the purpose-built `ai.*` steps ([Slack\nthread](https://elastic.slack.com/archives/C08U04SUN49/p1776097440515239))\n- Deprecated steps are hidden from autocomplete, the Add Action menu,\nand AI agent discovery\n- Existing workflows using these step types continue to work — they just\nshow a deprecation warning in the editor\n\n### Changes\n\n- Added `DEPRECATED_STEP_PREFIX_METADATA` to `@kbn/workflows` for\nprefix-based deprecation matching\n- Updated `getDeprecatedStepMetadata()` to check prefix matches after\nexact matches\n- Migrated all deprecation consumers from direct map access\n(`deprecatedMap[key]`) to function calls\n(`getDeprecatedStepMetadata(key)`)\n- Updated the agent builder tool to detect prefix deprecation on dynamic\nconnector steps\n\n### Screenshots\n\n**Editor deprecation warnings** — `inference.completion` and\n`bedrock.invokeAI` now show deprecation squiggles and hover tooltip:\n\n| Before (main) | After |\n|---|---|\n|\n![before](https://pub-6b50802d113345dea50c783e8280b53e.r2.dev/artifacts/20260416/s5rfd0ru-before_editor_nohover.webp)\n|\n![after](https://pub-6b50802d113345dea50c783e8280b53e.r2.dev/artifacts/20260416/lfqf2d0v-after_editor_nohover.webp)\n|\n\n**Deprecation hover tooltip** — hovering on a deprecated AI connector\nstep shows the replacement suggestion:\n\n![deprecation\nhover](https://pub-6b50802d113345dea50c783e8280b53e.r2.dev/artifacts/20260416/e93t9gse-after_editor_hover.webp)\n\n**Autocomplete** — typing `inference` shows \"No suggestions\" (all\n`inference.*` steps are filtered):\n\n![autocomplete no\nsuggestions](https://pub-6b50802d113345dea50c783e8280b53e.r2.dev/artifacts/20260416/ldyuw3yh-test_autocomplete_inference.webp)\n\n**Add Action menu** — searching for \"inference\" or \"bedrock\" returns no\noptions:\n\n![actions menu\ninference](https://pub-6b50802d113345dea50c783e8280b53e.r2.dev/artifacts/20260416/e1nwunw0-test_actions_menu_inference.webp)\n\n**`ai.prompt` not affected** — searching \"ai\" in the actions menu still\nshows AI Prompt, AI Classify, AI Summarize:\n\n![actions menu\nai](https://pub-6b50802d113345dea50c783e8280b53e.r2.dev/artifacts/20260416/e1jpox1j-test_actions_menu_ai.webp)\n\n**Exact-match deprecation still works** — `kibana.createCase` still\nshows deprecation warning (existing behavior preserved):\n\n![kibana cases\ndeprecation](https://pub-6b50802d113345dea50c783e8280b53e.r2.dev/artifacts/20260416/mnn2rrwx-test_kibana_cases_clean.webp)\n\nCloses elastic/security-team#16816\n\n## Test plan\n\n- [x] Verify `inference.*`, `bedrock.*`, `gen-ai.*`, `gemini.*` steps no\nlonger appear in autocomplete suggestions\n- [x] Verify these steps no longer appear in the Add Action menu\n- [x] Verify existing workflows using these steps show a deprecation\nwarning in the editor\n- [x] Verify `ai.prompt` step is not affected by the deprecation\n- [x] Verify `kibana.*` Cases steps still show exact-match deprecation\nwarnings\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\n---------\n\nCo-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>","sha":"9af9077847193ab7e10cef384a9aa099e9b1ce22","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:deprecation","backport missing","backport:version","Team:One Workflow","v9.4.0","v9.5.0"],"title":"[One Workflow] Deprecate direct AI connector step types in favor of ai.prompt","number":263694,"url":"https://github.com/elastic/kibana/pull/263694","mergeCommit":{"message":"[One Workflow] Deprecate direct AI connector step types in favor of ai.prompt (#263694)\n\n## Summary\n\nExtends the workflow step deprecation mechanism to support\n**prefix-based matching** and deprecates all direct AI connector step\ntypes (`inference.*`, `bedrock.*`, `gen-ai.*`, `gemini.*`) in favor of\nthe purpose-built `ai.prompt` step.\n\n- Users were confused by the availability of raw AI connector steps\nalongside the purpose-built `ai.*` steps ([Slack\nthread](https://elastic.slack.com/archives/C08U04SUN49/p1776097440515239))\n- Deprecated steps are hidden from autocomplete, the Add Action menu,\nand AI agent discovery\n- Existing workflows using these step types continue to work — they just\nshow a deprecation warning in the editor\n\n### Changes\n\n- Added `DEPRECATED_STEP_PREFIX_METADATA` to `@kbn/workflows` for\nprefix-based deprecation matching\n- Updated `getDeprecatedStepMetadata()` to check prefix matches after\nexact matches\n- Migrated all deprecation consumers from direct map access\n(`deprecatedMap[key]`) to function calls\n(`getDeprecatedStepMetadata(key)`)\n- Updated the agent builder tool to detect prefix deprecation on dynamic\nconnector steps\n\n### Screenshots\n\n**Editor deprecation warnings** — `inference.completion` and\n`bedrock.invokeAI` now show deprecation squiggles and hover tooltip:\n\n| Before (main) | After |\n|---|---|\n|\n![before](https://pub-6b50802d113345dea50c783e8280b53e.r2.dev/artifacts/20260416/s5rfd0ru-before_editor_nohover.webp)\n|\n![after](https://pub-6b50802d113345dea50c783e8280b53e.r2.dev/artifacts/20260416/lfqf2d0v-after_editor_nohover.webp)\n|\n\n**Deprecation hover tooltip** — hovering on a deprecated AI connector\nstep shows the replacement suggestion:\n\n![deprecation\nhover](https://pub-6b50802d113345dea50c783e8280b53e.r2.dev/artifacts/20260416/e93t9gse-after_editor_hover.webp)\n\n**Autocomplete** — typing `inference` shows \"No suggestions\" (all\n`inference.*` steps are filtered):\n\n![autocomplete no\nsuggestions](https://pub-6b50802d113345dea50c783e8280b53e.r2.dev/artifacts/20260416/ldyuw3yh-test_autocomplete_inference.webp)\n\n**Add Action menu** — searching for \"inference\" or \"bedrock\" returns no\noptions:\n\n![actions menu\ninference](https://pub-6b50802d113345dea50c783e8280b53e.r2.dev/artifacts/20260416/e1nwunw0-test_actions_menu_inference.webp)\n\n**`ai.prompt` not affected** — searching \"ai\" in the actions menu still\nshows AI Prompt, AI Classify, AI Summarize:\n\n![actions menu\nai](https://pub-6b50802d113345dea50c783e8280b53e.r2.dev/artifacts/20260416/e1jpox1j-test_actions_menu_ai.webp)\n\n**Exact-match deprecation still works** — `kibana.createCase` still\nshows deprecation warning (existing behavior preserved):\n\n![kibana cases\ndeprecation](https://pub-6b50802d113345dea50c783e8280b53e.r2.dev/artifacts/20260416/mnn2rrwx-test_kibana_cases_clean.webp)\n\nCloses elastic/security-team#16816\n\n## Test plan\n\n- [x] Verify `inference.*`, `bedrock.*`, `gen-ai.*`, `gemini.*` steps no\nlonger appear in autocomplete suggestions\n- [x] Verify these steps no longer appear in the Add Action menu\n- [x] Verify existing workflows using these steps show a deprecation\nwarning in the editor\n- [x] Verify `ai.prompt` step is not affected by the deprecation\n- [x] Verify `kibana.*` Cases steps still show exact-match deprecation\nwarnings\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\n---------\n\nCo-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>","sha":"9af9077847193ab7e10cef384a9aa099e9b1ce22"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/263694","number":263694,"mergeCommit":{"message":"[One Workflow] Deprecate direct AI connector step types in favor of ai.prompt (#263694)\n\n## Summary\n\nExtends the workflow step deprecation mechanism to support\n**prefix-based matching** and deprecates all direct AI connector step\ntypes (`inference.*`, `bedrock.*`, `gen-ai.*`, `gemini.*`) in favor of\nthe purpose-built `ai.prompt` step.\n\n- Users were confused by the availability of raw AI connector steps\nalongside the purpose-built `ai.*` steps ([Slack\nthread](https://elastic.slack.com/archives/C08U04SUN49/p1776097440515239))\n- Deprecated steps are hidden from autocomplete, the Add Action menu,\nand AI agent discovery\n- Existing workflows using these step types continue to work — they just\nshow a deprecation warning in the editor\n\n### Changes\n\n- Added `DEPRECATED_STEP_PREFIX_METADATA` to `@kbn/workflows` for\nprefix-based deprecation matching\n- Updated `getDeprecatedStepMetadata()` to check prefix matches after\nexact matches\n- Migrated all deprecation consumers from direct map access\n(`deprecatedMap[key]`) to function calls\n(`getDeprecatedStepMetadata(key)`)\n- Updated the agent builder tool to detect prefix deprecation on dynamic\nconnector steps\n\n### Screenshots\n\n**Editor deprecation warnings** — `inference.completion` and\n`bedrock.invokeAI` now show deprecation squiggles and hover tooltip:\n\n| Before (main) | After |\n|---|---|\n|\n![before](https://pub-6b50802d113345dea50c783e8280b53e.r2.dev/artifacts/20260416/s5rfd0ru-before_editor_nohover.webp)\n|\n![after](https://pub-6b50802d113345dea50c783e8280b53e.r2.dev/artifacts/20260416/lfqf2d0v-after_editor_nohover.webp)\n|\n\n**Deprecation hover tooltip** — hovering on a deprecated AI connector\nstep shows the replacement suggestion:\n\n![deprecation\nhover](https://pub-6b50802d113345dea50c783e8280b53e.r2.dev/artifacts/20260416/e93t9gse-after_editor_hover.webp)\n\n**Autocomplete** — typing `inference` shows \"No suggestions\" (all\n`inference.*` steps are filtered):\n\n![autocomplete no\nsuggestions](https://pub-6b50802d113345dea50c783e8280b53e.r2.dev/artifacts/20260416/ldyuw3yh-test_autocomplete_inference.webp)\n\n**Add Action menu** — searching for \"inference\" or \"bedrock\" returns no\noptions:\n\n![actions menu\ninference](https://pub-6b50802d113345dea50c783e8280b53e.r2.dev/artifacts/20260416/e1nwunw0-test_actions_menu_inference.webp)\n\n**`ai.prompt` not affected** — searching \"ai\" in the actions menu still\nshows AI Prompt, AI Classify, AI Summarize:\n\n![actions menu\nai](https://pub-6b50802d113345dea50c783e8280b53e.r2.dev/artifacts/20260416/e1jpox1j-test_actions_menu_ai.webp)\n\n**Exact-match deprecation still works** — `kibana.createCase` still\nshows deprecation warning (existing behavior preserved):\n\n![kibana cases\ndeprecation](https://pub-6b50802d113345dea50c783e8280b53e.r2.dev/artifacts/20260416/mnn2rrwx-test_kibana_cases_clean.webp)\n\nCloses elastic/security-team#16816\n\n## Test plan\n\n- [x] Verify `inference.*`, `bedrock.*`, `gen-ai.*`, `gemini.*` steps no\nlonger appear in autocomplete suggestions\n- [x] Verify these steps no longer appear in the Add Action menu\n- [x] Verify existing workflows using these steps show a deprecation\nwarning in the editor\n- [x] Verify `ai.prompt` step is not affected by the deprecation\n- [x] Verify `kibana.*` Cases steps still show exact-match deprecation\nwarnings\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\n---------\n\nCo-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>","sha":"9af9077847193ab7e10cef384a9aa099e9b1ce22"}}]}] BACKPORT-->