### PR TITLE
[Scout] Split best practices into general, UI, and API guides

### DIFF
--- a/.agents/skills/scout-best-practices-reviewer/SKILL.md
+++ b/.agents/skills/scout-best-practices-reviewer/SKILL.md
@@ -20,12 +20,16 @@ Important: Do not post GitHub comments unless explicitly stated.
    - API Tests: Use `apiTest` (usually in `**/test/scout/api/**`).
 2. Neighboring Scout code in the same plugin/solution (existing specs + `test/scout/**/fixtures/**`) to spot reuse opportunities and avoid duplicating helpers.
 3. Removed/previous tests (if this is a migration) to verify behavior parity.
-4. Scout docs (open only what you need):
-   - Best practices: `docs/extend/scout/best-practices.md`
+4. Scout docs (open only what you need — best practices are split by test type so you can skip the irrelevant half):
+   - **General best practices** (always relevant): `docs/extend/scout/best-practices.md`
+   - **UI-only best practices** (open when reviewing UI tests): `docs/extend/scout/ui-best-practices.md`
+   - **API-only best practices** (open when reviewing API tests): `docs/extend/scout/api-best-practices.md`
    - Core concepts & fixtures: `docs/extend/scout/core-concepts.md`, `docs/extend/scout/fixtures.md`
    - Reuse surfaces: `docs/extend/scout/page-objects.md`, `docs/extend/scout/api-services.md`
    - Type-specific guides: `docs/extend/scout/write-ui-tests.md`, `docs/extend/scout/write-api-tests.md`
    - As needed: `docs/extend/scout/api-auth.md`, `docs/extend/scout/browser-auth.md`, `docs/extend/scout/parallelism.md`, `docs/extend/scout/deployment-tags.md`, `docs/extend/scout/a11y-checks.md`, `docs/extend/scout/debugging.md`, `docs/extend/scout/run-tests.md`
+
+   **Rule of thumb:** always read the general best practices, then open **only** the UI-specific file for UI reviews or the API-specific file for API reviews. If a PR mixes UI and API specs, open both.
 
 ## Scope (be comprehensive)
 
@@ -34,17 +38,25 @@ Important: Do not post GitHub comments unless explicitly stated.
   - available fixtures (`docs/extend/scout/fixtures.md` + local `test/scout/**/fixtures`)
   - existing page objects, API services, and fixtures (in `@kbn/scout`, solution Scout packages, and plugin-local `test/scout/**`) before suggesting brand-new helpers
 
-### Quick checklist (details live in `docs/extend/scout/best-practices.md`)
+### Quick checklist
 
-- **Reuse-first**: prefer existing `pageObjects`, fixtures, and `apiServices`; if adding helpers/page objects, place them in the right scope (plugin vs solution vs `@kbn/scout`) and register via fixtures.
-- **Fixture boundaries**: `apiClient` for the endpoint under test; `apiServices`/`kbnClient` for setup/teardown only; correct auth + common headers.
-- **Correctness**: guardrail assertions before dereferencing response fields; validate contract + side effects; stable error assertions.
-- **UI scope**: UI tests should focus on user interactions and rendering; avoid “data correctness” assertions (for example exact API response shapes or exact table cell values) unless the UI behavior depends on them. Prefer Scout API tests (or unit/integration) for data correctness coverage.
-- **Isolation**: parallel-safe data and resilient cleanup in hooks; no reliance on file ordering or shared mutable state.
-- **RBAC / realism**: minimal permissions (avoid `admin` unless required); space-aware behavior covered or explicitly out of scope.
-- **Flake traps**: avoid `waitForTimeout()` and time-based assertions/retries; rely on auto-waiting + explicit readiness signals. Some locators are restricted by `@kbn/eslint/scout_no_locators` (e.g. `globalLoadingIndicator`).
-- **Cost**: avoid repeating expensive setup; consider a global setup hook for shared one-time operations.
-- **Tags / environment**: validate deployment tags and avoid assumptions that only hold in specific environments.
+Checklist items are tagged with the document they're detailed in:
+
+- **[general]** → `docs/extend/scout/best-practices.md` (applies to both UI and API tests)
+- **[ui]** → `docs/extend/scout/ui-best-practices.md`
+- **[api]** → `docs/extend/scout/api-best-practices.md`
+
+Open only the docs relevant to the test type(s) under review.
+
+- **[general]** **Reuse-first**: prefer existing `pageObjects`, fixtures, and `apiServices`; if adding helpers/page objects, place them in the right scope (plugin vs solution vs `@kbn/scout`) and register via fixtures.
+- **[api]** **Fixture boundaries**: `apiClient` for the endpoint under test; `apiServices`/`kbnClient` for setup/teardown only; correct auth + common headers.
+- **[api]** **Correctness**: guardrail assertions before dereferencing response fields; validate contract + side effects; stable error assertions.
+- **[ui]** **UI scope**: UI tests should focus on user interactions and rendering; avoid “data correctness” assertions (for example exact API response shapes or exact table cell values) unless the UI behavior depends on them. Prefer Scout API tests (or unit/integration) for data correctness coverage.
+- **[general]** **Isolation**: parallel-safe data and resilient cleanup in hooks; no reliance on file ordering or shared mutable state.
+- **[general]** **RBAC / realism**: minimal permissions (avoid `admin` unless required); space-aware behavior covered or explicitly out of scope.
+- **[ui]** **Flake traps**: avoid `waitForTimeout()` and time-based assertions/retries; rely on auto-waiting + explicit readiness signals. Some locators are restricted by `@kbn/eslint/scout_no_locators` (e.g. `globalLoadingIndicator`).
+- **[general]** **Cost**: avoid repeating expensive setup; consider a global setup hook for shared one-time operations.
+- **[general]** **Tags / environment**: validate deployment tags and avoid assumptions that only hold in specific environments.
 
 ### Files to skip
 

--- a/.macroscope/scout-review.md
+++ b/.macroscope/scout-review.md
@@ -42,13 +42,19 @@ This review is experimental. Share your feedback in the #appex-qa channel.
 All detailed findings must go in **inline GitHub PR comments** on the specific line where each issue occurs. For each inline comment:
 
 - Start with the severity emoji (🔴 Blocker, 🟡 Major, 🔵 Minor, or ⚪ Nit)
-- State the rule violated (use the section heading from `docs/extend/scout/best-practices.md`)
+- State the rule violated (use the section heading from the matching best-practices document: `docs/extend/scout/best-practices.md`, `docs/extend/scout/ui-best-practices.md`, or `docs/extend/scout/api-best-practices.md`)
 - Explain the issue in 1–2 sentences
 - Suggest a concrete fix
 
-### Link to specific sections of the Best Practices document when possible
+### Link to specific sections of the Best Practices documents when possible
 
-Where applicable, link to a specific section of the [Best Practices for Scout Tests](https://www.elastic.co/docs/extend/kibana/scout/best-practices) document so developers can learn more. A section-scoped link looks like this: `https://www.elastic.co/docs/extend/kibana/scout/best-practices#avoid-conditional-logic-in-page-objects`. You can infer the `#anchor` from the `docs/extend/scout/best-practices.md` file (e.g., `[avoid-conditional-logic-in-page-objects]`).
+Scout best practices are split across three pages; pick the one that matches the rule you’re citing:
+
+- General: `docs/extend/scout/best-practices.md` → `https://www.elastic.co/docs/extend/kibana/scout/best-practices`
+- UI tests: `docs/extend/scout/ui-best-practices.md` → `https://www.elastic.co/docs/extend/kibana/scout/ui-best-practices`
+- API tests: `docs/extend/scout/api-best-practices.md` → `https://www.elastic.co/docs/extend/kibana/scout/api-best-practices`
+
+A section-scoped link looks like this: `https://www.elastic.co/docs/extend/kibana/scout/ui-best-practices#avoid-conditional-logic-in-page-objects`. You can infer the `#anchor` from the explicit heading id in the corresponding markdown file (e.g., `[avoid-conditional-logic-in-page-objects]`).
 
 ### Updates to the PR
 

--- a/.macroscope/scout-review.md
+++ b/.macroscope/scout-review.md
@@ -21,7 +21,10 @@ Only review files that are:
 
 Skip all other changed files entirely. If no matching files were changed in this PR, conclude with no comments.
 
-Do NOT post flaky test runner nudges. A separate agent handles this.
+IMPORTANT:
+
+- Do NOT review backport PRs (these usually merge changes into branches that aren't `main`)
+- Do NOT post flaky test runner nudges. A separate agent handles this.
 
 ## Review instructions
 

--- a/docs/extend/scout.md
+++ b/docs/extend/scout.md
@@ -9,7 +9,7 @@ Scout is Kibana’s **modern UI and API test framework** built on [Playwright](h
 ## Start here [scout-start-here]
 
 - [Getting started](./scout/getting-started.md)
-- [Best practices](./scout/best-practices.md)
+- [Best practices](./scout/best-practices.md) (see also [UI test best practices](./scout/ui-best-practices.md) and [API test best practices](./scout/api-best-practices.md))
 - [UI testing](./scout/ui-testing.md)
 - [API testing](./scout/api-testing.md)
 

--- a/docs/extend/scout/api-best-practices.md
+++ b/docs/extend/scout/api-best-practices.md
@@ -1,0 +1,104 @@
+---
+navigation_title: Best practices
+---
+
+# Best practices for Scout API tests [scout-api-best-practices]
+
+Best practices specific to Scout **API tests**.
+
+:::::{tip}
+For guidance that applies to both UI and API tests, see the [general Scout best practices](./best-practices.md). Scout is built on Playwright, so the official [Playwright Best Practices](https://playwright.dev/docs/best-practices) also apply.
+:::::
+
+## Validate endpoints with `apiClient` [validate-endpoints-with-apiclient-for-readable-and-scoped-tests]
+
+Use the right fixture for the right purpose:
+
+| Fixture                       | Use for                                                                          |
+| ----------------------------- | -------------------------------------------------------------------------------- |
+| `apiClient`                   | The endpoint under test (with scoped credentials from [API auth](./api-auth.md)) |
+| `apiServices`                 | Setup/teardown and side effects                                                  |
+| `kbnClient`, `esClient`, etc. | Lower-level setup when `apiServices` doesn’t have a suitable helper              |
+
+Prefer tests that read like “call endpoint X as role Y, assert outcome”.
+
+:::::{dropdown} Example
+
+```ts
+import { expect } from '@kbn/scout/api';
+
+apiTest.beforeAll(async ({ requestAuth, apiServices }) => {
+  await apiServices.myFeature.createTestData();
+  viewerCredentials = await requestAuth.getApiKeyForViewer();
+});
+
+apiTest('returns data for viewer', async ({ apiClient }) => {
+  const response = await apiClient.get('api/my-feature/data', {
+    headers: { ...COMMON_HEADERS, ...viewerCredentials.apiKeyHeader },
+  });
+
+  expect(response).toHaveStatusCode(200);
+  expect(response.body.items).toHaveLength(3);
+});
+```
+
+:::::
+
+This pattern validates both endpoint behavior and the [permission model](./best-practices.md#test-with-minimal-permissions-avoid-admin-when-possible).
+
+## Choose the right auth pattern [choose-the-right-auth-pattern]
+
+Scout supports two authentication methods for API tests. Choose based on endpoint type:
+
+| Endpoint type                | Auth method          | Fixture                        |
+| ---------------------------- | -------------------- | ------------------------------ |
+| Public APIs (`api/*`)        | API key              | `requestAuth` + `apiKeyHeader` |
+| Internal APIs (`internal/*`) | Cookie-based session | `samlAuth` + `cookieHeader`    |
+
+See [API authentication](./api-auth.md) for details and examples.
+
+## Validate the response body (not just status) [dont-just-verify-the-status-code-validate-the-response-body]
+
+Status code assertions are necessary but not sufficient. Also validate shape and key fields.
+
+:::::{dropdown} Examples
+❌ **Don’t:** assert only the status code:
+
+```ts
+apiTest('returns autocomplete definitions', async ({ apiClient }) => {
+  const response = await apiClient.get('api/console/api_server', {
+    headers: { ...COMMON_HEADERS, ...viewerCredentials.apiKeyHeader },
+  });
+
+  expect(response).toHaveStatusCode(200);
+});
+```
+
+✔️ **Do:** validate shape and key fields too:
+
+```ts
+apiTest('returns autocomplete definitions', async ({ apiClient }) => {
+  const response = await apiClient.get('api/console/api_server', {
+    headers: { ...COMMON_HEADERS, ...viewerCredentials.apiKeyHeader },
+  });
+
+  expect(response).toHaveStatusCode(200);
+  expect(response.body).toMatchObject({
+    es: {
+      endpoints: expect.any(Object),
+      globals: expect.any(Object),
+      name: 'es',
+    },
+  });
+});
+```
+
+:::::
+
+## Related guides
+
+- [General best practices](./best-practices.md) — apply to both UI and API tests
+- [Write API tests](./write-api-tests.md)
+- [API authentication](./api-auth.md)
+- [API services](./api-services.md)
+- [Parallelism notes for API tests](./parallelism.md#api-tests-and-parallelism)

--- a/docs/extend/scout/api-services.md
+++ b/docs/extend/scout/api-services.md
@@ -162,7 +162,7 @@ export const test = baseTest.extend<{}, { apiServices: MyFeatureApiServices }>({
 
 ::::::::::{step} Use it for setup/teardown
 
-Use the helper for **setup/teardown** (and keep the endpoint under test in `apiClient` for readable, scoped tests). See [best practices](./best-practices.md#api-tests).
+Use the helper for **setup/teardown** (and keep the endpoint under test in `apiClient` for readable, scoped tests). See [API test best practices](./api-best-practices.md).
 
 :::::::{note}
 In parallel UI suites (`spaceTest`), use `scoutSpace.id` when calling methods that need space scoping: `await apiServices.myFeature.enable(scoutSpace.id)`.

--- a/docs/extend/scout/api-testing.md
+++ b/docs/extend/scout/api-testing.md
@@ -7,4 +7,5 @@ navigation_title: API testing
 Use these pages when writing Scout API integration tests:
 
 - [Write Scout API tests](./write-api-tests.md)
+- [API test best practices](./api-best-practices.md)
 - [Authentication in Scout API tests](./api-auth.md)

--- a/docs/extend/scout/best-practices.md
+++ b/docs/extend/scout/best-practices.md
@@ -2,21 +2,11 @@
 navigation_title: Best practices
 ---
 
-# Best practices for Scout tests [scout-best-practices]
+# General Scout best practices [scout-best-practices]
 
-This guide covers best practices for writing Scout UI and API tests that are reliable, maintainable, and fast.
+For test-type-specific guidance, see [UI test best practices](./ui-best-practices.md) and [API test best practices](./api-best-practices.md).
 
-Scout is built on Playwright, so the official [Playwright Best Practices](https://playwright.dev/docs/best-practices) apply.
-
-:::::{tip}
-**New to Scout?** Start with our [Scout introduction page](../scout.md).
-:::::
-
-## UI & API tests [ui-and-api-tests]
-
-Best practices that apply to both UI and API tests.
-
-### Design tests with a cloud-first mindset [design-tests-with-a-cloud-first-mindset]
+## Design tests with a cloud-first mindset [design-tests-with-a-cloud-first-mindset]
 
 Scout is deployment-agnostic: write once, run locally and on Elastic Cloud.
 
@@ -24,7 +14,7 @@ Scout is deployment-agnostic: write once, run locally and on Elastic Cloud.
 - Within a test, avoid relying on configuration, data, or behavior specific to a single deployment. Test logic should produce the same result locally and on Cloud.
 - Run your tests against a real Elastic Cloud project before merging to catch environment-specific surprises early. See [Run tests on Elastic Cloud](./run-tests.md#scout-run-tests-cloud) for setup instructions.
 
-### Keep tests close to the code they test [keep-tests-close-to-source-code]
+## Keep tests close to the code they test [keep-tests-close-to-source-code]
 
 A test should live in the plugin or package that owns the code it exercises. When writing or reviewing a test, confirm that the scenarios logically belong to the plugin they were added to:
 
@@ -33,26 +23,26 @@ A test should live in the plugin or package that owns the code it exercises. Whe
 
 This also keeps Scout's selective testing effective: it runs only the tests for modules affected by a PR, so a test placed in the wrong plugin won't be triggered by changes to the code it actually covers. The full suite still runs post-merge on `kibana-on-merge`.
 
-### Prefer runtime feature flags [prefer-runtime-feature-flags]
+## Prefer runtime feature flags [prefer-runtime-feature-flags]
 
 When a feature is gated behind a flag, enable it at runtime with `apiServices.core.settings()` rather than creating a custom server config. Runtime flags work locally and on Cloud, don’t require a server restart, and avoid the CI cost of a dedicated server instance.
 
 For the full guide (including when a custom server config is unavoidable), see [Feature flags](./feature-flags.md).
 
-### Run tests multiple times to catch flakiness [use-the-flaky-test-runner-to-catch-flaky-tests-early]
+## Run tests multiple times to catch flakiness [use-the-flaky-test-runner-to-catch-flaky-tests-early]
 
 When you add new tests, fix flakes, or make significant changes, run the same tests multiple times to catch flakiness early. A good starting point is **20–50 runs**.
 
 Prefer doing this locally first (faster feedback), and use the Flaky Test Runner in CI when needed. See [Debug flaky tests](./debugging.md#scout-debugging-flaky-tests) for guidance.
 
-### Keep test suites independent [keep-test-suites-independent]
+## Keep test suites independent [keep-test-suites-independent]
 
 - Keep **one top-level suite** per file (`test.describe`).
 - Avoid nested `describe` blocks. Use `test.step` for structure inside a test.
 - Don’t rely on test file execution order (it’s [not guaranteed](https://playwright.dev/docs/test-parallel#control-test-order)).
 - Don’t assume a previous test in the suite already set up the data you need (if that test fails or is skipped, the test will break with a misleading error).
 
-### Write descriptive test names [write-descriptive-test-names]
+## Write descriptive test names [write-descriptive-test-names]
 
 Test names should read like a sentence describing expected behavior. Clear names make failures self-explanatory and test suites scannable.
 
@@ -89,7 +79,7 @@ test('returns 403 when missing read privilege', async ({ apiClient }) => {
 
 :::::
 
-### Organize test suites by role and user flow [organize-test-suites-by-role-and-user-flow]
+## Organize test suites by role and user flow [organize-test-suites-by-role-and-user-flow]
 
 Prefer “one role + one flow per file” and keep spec files small (roughly 4–5 short tests or 2–3 longer ones). The test runner balances work at the spec-file level, so oversized files become bottlenecks during [parallel execution](./parallelism.md). Put shared login/navigation in `beforeEach`.
 
@@ -109,7 +99,7 @@ test('can see dashboard', async ({ page }) => {
 
 :::::
 
-### Use a global setup hook for one-time setup [move-repeated-one-time-setup-operations-to-a-global-setup-hook]
+## Use a global setup hook for one-time setup [move-repeated-one-time-setup-operations-to-a-global-setup-hook]
 
 If many files share the same “one-time” work (archives, API calls, settings), move it to a [global setup hook](./global-setup-hook.md).
 
@@ -128,7 +118,7 @@ globalSetupHook('Load shared test data (if needed)', async ({ esArchiver, log })
 Global setup hooks have **no corresponding teardown**. Keep operations that require cleanup (such as `kbnClient.importExport.load()`) in `beforeAll`/`afterAll` hooks so saved objects are properly removed after tests run. See [Global setup hook: When to use](./global-setup-hook.md#when-to-use) for guidance.
 ::::::
 
-### Only load archives your tests actually use [only-load-archives-your-tests-actually-use]
+## Only load archives your tests actually use [only-load-archives-your-tests-actually-use]
 
 It’s common for test suites to load Elasticsearch or Kibana archives that are barely used (or not used at all). Unused archives slow down setup, waste resources, and make it harder to understand what a test actually depends on. Check if your tests ingest the data they actually need.
 
@@ -162,7 +152,7 @@ test.beforeAll(async ({ esArchiver }) => {
 
 :::::
 
-### Keep cleanup in hooks [put-cleanup-code-in-hooks-not-in-the-test-body]
+## Keep cleanup in hooks [put-cleanup-code-in-hooks-not-in-the-test-body]
 
 Cleanup in the test body doesn’t run after a failure. Prefer `afterEach` / `afterAll`. **Don’t duplicate** the same teardown in the test body when a hook already runs it; duplication invites unnecessary `try/catch` and drift between paths.
 
@@ -191,7 +181,7 @@ test.afterEach(async ({ esClient, log }) => {
 
 :::::
 
-### Don’t use `try/catch` in tests [dont-use-try-catch-in-tests]
+## Don’t use `try/catch` in tests [dont-use-try-catch-in-tests]
 
 Tests should be clean and declarative. If a helper might return an expected error (for example, 404 during cleanup), the helper should handle it internally, for example by accepting an `ignoreErrors` option or treating a 404 during deletion as a success.
 
@@ -218,7 +208,7 @@ test.afterAll(async ({ apiServices }) => {
 
 :::::
 
-### Use constants for shared test values [use-constants-for-shared-test-values]
+## Use constants for shared test values [use-constants-for-shared-test-values]
 
 If a value is reused across suites (archive paths, fixed time ranges, endpoints, common headers), extract it into a shared `constants.ts` file. This reduces duplication and typos, and makes updates safer.
 
@@ -246,7 +236,7 @@ export const COMMON_HEADERS = {
 
 :::::
 
-### Test with minimal permissions [test-with-minimal-permissions-avoid-admin-when-possible]
+## Test with minimal permissions [test-with-minimal-permissions-avoid-admin-when-possible]
 
 Avoid `admin` unless there’s no alternative. Minimal permissions catch real permission bugs and keep tests realistic. Also test the forbidden path: verify that an under-privileged role receives `403` for endpoints it shouldn’t access.
 
@@ -296,7 +286,7 @@ await browserAuth.loginAsPlatformEngineer();
 For setup details, see [Reuse role helpers](./browser-auth.md#scout-browser-auth-extend).
 :::::
 
-### Contribute to Scout when possible [contribute-to-scout-when-possible]
+## Contribute to Scout when possible [contribute-to-scout-when-possible]
 
 If you build a helper that will benefit other tests, consider upstreaming it:
 
@@ -308,490 +298,4 @@ For the full guidance, see [Scout](../scout.md#contribute-to-scout-when-possible
 
 :::::{tip} Keep Scout packages package and plugin-agnostic
 When you move a helper into `@kbn/scout` or a solution Scout package, **don't import types from plugins or plugin-scoped packages**. Scout packages are intentionally slim, shared infrastructure — adding a dependency on a specific plugin's types pulls that plugin into every consumer and breaks the sharing model.
-:::::
-
----
-
-## UI tests [ui-tests]
-
-Best practices specific to UI tests.
-
-### Prefer parallel runs [run-tests-in-parallel-whenever-possible]
-
-Default to [parallel UI suites](./parallelism.md) when possible. Parallel workers share the same Kibana/ES deployment, but run in isolated Spaces.
-
-| Mode           | When to use                                                                                                               |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------- |
-| **Parallel**   | UI tests (most suites), suites that share pre-ingested data (often using the [global setup hook](./global-setup-hook.md)) |
-| **Sequential** | API tests, suites that require a “clean” Elasticsearch state                                                              |
-
-### Test behavior, not data correctness [focus-ui-tests-on-behavior-not-data-correctness]
-
-UI tests should answer “does this feature work for the user?” Verify that components render, respond to interaction, and navigate correctly. Leave exact data validation (computed values, aggregation results, edge cases) to API or unit tests, which are faster and less brittle.
-
-| What you’re testing                                                         | Recommended layer  |
-| --------------------------------------------------------------------------- | ------------------ |
-| User flows, navigation, rendering                                           | Scout UI test      |
-| Data correctness, API contracts, edge cases                                 | Scout API test     |
-| Isolated component logic (loading/error states, tooltips, field validation) | RTL/Jest unit test |
-
-:::::{dropdown} Examples
-❌ **Don’t:** verify computed values that belong in an API test:
-
-```ts
-await expect(page.testSubj.locator('row-0-col-count')).toHaveText('1,024');
-await expect(page.testSubj.locator('row-0-col-avg')).toHaveText('42.7');
-```
-
-✔️ **Do:** verify that the UI renders and responds to interaction:
-
-```ts
-await expect(page.testSubj.locator('datasetQualityTable-loaded')).toBeVisible();
-await page.testSubj.click('tableSortByLastActivity');
-await expect(page.testSubj.locator('row-0-col-dataset')).not.toHaveText('');
-```
-
-:::::
-
-### Use `test.step` for multi-step flows [use-teststep-for-multi-step-flows]
-
-Use `test.step()` to structure a multi-step flow while keeping one browser context (faster, clearer reporting). Group closely related actions into a single step when it keeps the report readable without hiding intent.
-
-:::::{dropdown} Example
-
-```ts
-test('navigates through pages', async ({ pageObjects }) => {
-  await test.step('go to Dashboards', async () => {
-    await pageObjects.navigation.clickDashboards();
-  });
-
-  await test.step('go to Overview', async () => {
-    await pageObjects.navigation.clickOverview();
-  });
-});
-```
-
-:::::
-
-### Prefer realistic in-app navigation for user flows [prefer-realistic-in-app-navigation]
-
-When a test asserts **user flow** (not just “land on a page”), prefer navigation the way a user would: follow links and buttons, and use browser history (`page.goBack()`) instead of direct URL jumps where it matters for the scenario. Reserve `page.goto` / deep links for cheap setup when the test is not about navigation.
-
-### Prefer APIs for setup and teardown [prefer-kibana-apis-over-ui-for-setup-and-teardown]
-
-Setup/teardown using UI is slow and brittle. Prefer Kibana APIs and fixtures.
-
-:::::{dropdown} Examples
-❌ **Don’t:** create test data through the UI:
-
-```ts
-test.beforeEach(async ({ page, browserAuth }) => {
-  await browserAuth.loginAsAdmin();
-  await page.testSubj.click('createDataViewButton');
-  await page.testSubj.fill('indexPatternInput', 'logs-*');
-  await page.testSubj.click('saveDataViewButton');
-});
-```
-
-✔️ **Do:** use API fixtures:
-
-```ts
-test.beforeEach(async ({ uiSettings, kbnClient }) => {
-  await uiSettings.setDefaultTime({ from: startTime, to: endTime });
-  await kbnClient.importExport.load(DATA_VIEW_ARCHIVE_PATH);
-});
-```
-
-:::::
-
-### Use Playwright auto-waiting [leverage-playwright-auto-waiting]
-
-Playwright actions and [web-first assertions](https://playwright.dev/docs/best-practices#use-web-first-assertions) already wait/retry. Don’t add redundant waits, and never use `page.waitForTimeout()` as it’s a hard sleep with no readiness signal and a common source of flakiness.
-
-:::::{dropdown} Examples
-❌ **Don’t:** add unnecessary waits before actions or assertions:
-
-```ts
-await page.testSubj.waitForSelector('myButton', { state: 'visible' });
-await page.testSubj.click('myButton');
-await page.testSubj.locator('successToast').waitFor();
-await expect(page.testSubj.locator('successToast')).toBeVisible();
-```
-
-✔️ **Do:** let Playwright handle waiting automatically:
-
-```ts
-await page.testSubj.click('myButton');
-await expect(page.testSubj.locator('successToast')).toBeVisible();
-```
-
-:::::
-
-### Wait for UI updates after actions [wait-for-ui-updates-when-the-next-action-requires-it]
-
-When an action triggers async UI work (navigation, saving, loading data), wait for the resulting state before your next step. This ensures the UI is ready and prevents flaky interactions with elements that haven’t rendered yet.
-
-:::::{dropdown} Example
-
-```ts
-await page.gotoApp('sample/page/here');
-await page.testSubj.waitForSelector('mainContent', { state: 'visible' });
-```
-
-:::::
-
-### Don't use manual retry loops [dont-use-manual-retry-loops]
-
-If an action fails, don't wrap it in a retry loop. Playwright already waits for actionability; repeated failures usually point to an app issue (unstable DOM, non-unique selectors, re-render bugs). Fix the component or make your waiting/locators explicit and stable.
-
-:::::{dropdown} Examples
-❌ **Don't:** retry actions in a loop:
-
-```ts
-for (let i = 0; i < 3; i++) {
-  try {
-    await page.testSubj.click('submitButton');
-    break;
-  } catch {
-    await page.waitForTimeout(1000);
-  }
-}
-```
-
-✔️ **Do:** fix the root cause (for example, wait for a readiness signal):
-
-```ts
-await expect(page.testSubj.locator('formReady')).toBeVisible();
-await page.testSubj.click('submitButton');
-```
-
-:::::
-
-### Locate UI elements reliably [locate-ui-elements-reliably]
-
-Prefer stable `data-test-subj` attributes accessed using `page.testSubj`. If `data-test-subj` is missing, prefer adding one to source code. If that’s not possible, use `getByRole` **inside a scoped container**.
-
-:::::{dropdown} Examples
-❌ **Don’t:** use raw CSS selectors or unscoped text matchers (searching the entire page for text is unreliable when duplicates exist):
-
-```ts
-await page.click('[data-test-subj="myButton"]');
-await page.getByText('Delete').click();
-```
-
-❌ **Don’t:** select elements by index ([flagged by Playwright’s recommended ESLint rules](https://playwright.dev/docs/best-practices)), as they break on non-clean environments where tests run without server restart and extra data may exist:
-
-```ts
-await page.testSubj.locator('tableRow').nth(0).click();
-```
-
-✔️ **Do:** use `page.testSubj` or scoped `getByRole`:
-
-```ts
-await page.testSubj.click('myButton');
-await page.testSubj.locator('confirmDeleteModal').getByRole('button', { name: 'Delete' }).click();
-```
-
-:::::
-
-### Avoid unnecessary timeout overrides [use-scouts-default-timeouts]
-
-Scout configures Playwright timeouts ([source](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-scout/src/playwright/config/create_config.ts)). Prefer defaults.
-
-- Don’t override suite-level timeouts/retries with `test.describe.configure()` unless you have a strong reason.
-- If you increase a timeout for one operation, keep it well below the test timeout and **add a short code comment** explaining why (slow first load, CI variance, known heavy view, etc.).
-- After raising timeouts for flakiness, **re-run the flaky test runner** (or many local repeats) to confirm the new value is necessary.
-- Keep in mind that an assertion timeout that exceeds the test timeout is ignored.
-- Time spent in hooks (`beforeEach`, `afterEach`) counts toward the test timeout. If setup is slow, the test itself may time out even though its assertions are fast.
-
-:::::{dropdown} Example
-
-```ts
-await expect(editor).toBeVisible(); // will use the default timeout
-
-// justified: report generation can be slow
-await expect(downloadBtn).toBeEnabled({ timeout: 30_000 });
-```
-
-:::::
-
-### Wait for complex UI to finish rendering [wait-for-complex-components-to-fully-render]
-
-Tables/maps/visualizations can appear before data is rendered. Prefer waiting on a component-specific **“loaded” signal** rather than global indicators like the Kibana chrome spinner (our data shows they are unreliable for confirming that a particular component has finished rendering).
-
-**Do not rely on helpers that only wait for a global “loading” indicator to disappear.** Each view should have an explicit readiness wait (or removal of such helpers in favor of those waits).
-
-:::::{dropdown} Example
-In source code, use a dynamic `data-test-subj`:
-
-```tsx
-<EuiBasicTable
-  data-test-subj={`myTable-${isLoading ? 'loading' : 'loaded'}`}
-  loading={isLoading}
-  items={items}
-  columns={columns}
-/>
-```
-
-In tests, wait for the loaded state:
-
-```ts
-await expect(page.testSubj.locator('myTable-loaded')).toBeVisible();
-```
-
-For Kibana Maps, `data-render-complete="true"` is often the right “ready” signal.
-:::::
-
-### Use existing page objects to interact with the Kibana UI [use-existing-page-objects-to-interact-with-the-kibana-ui]
-
-Prefer existing page objects (and their methods) over rebuilding EUI interactions in test files.
-
-- Prefer **`readonly` locator fields** assigned in the constructor for stable selectors, and **methods** for parameterized locators, multi-step actions, or flows. Thin getter-only methods for every field add noise; match the patterns used by built-in page objects (for example `DashboardApp`).
-
-:::::{dropdown} Example
-
-```ts
-await pageObjects.datePicker.setAbsoluteRange({
-  from: 'Sep 19, 2015 @ 06:31:44.000',
-  to: 'Sep 23, 2015 @ 18:31:44.000',
-});
-```
-
-:::::
-
-### Keep mocks and non-UI setup out of page objects [keep-mocks-out-of-page-objects]
-
-Page objects should focus on real UI interaction. Put HTTP mocks, interceptors, and similar setup in dedicated fixtures (for example `fixtures/mocks.ts`) so tests and reviewers can find them in one place.
-
-### Abstract common operations in page object methods [abstract-common-operations-in-page-object-methods]
-
-Create methods for repeated flows (and make them [wait for readiness](#wait-for-ui-updates-when-the-next-action-requires-it)).
-
-:::::{dropdown} Example
-
-```ts
-async openNewDashboard() {
-  await this.page.testSubj.click('newItemButton');
-  await this.page.testSubj.waitForSelector('emptyDashboardWidget', { state: 'visible' });
-}
-```
-
-:::::
-
-### Avoid conditional logic in page objects and tests [avoid-conditional-logic-in-page-objects]
-
-Playwright creates a fresh browser context for each test, so there is no cached state to work around. Both page object methods and test code should be explicit about the action they perform, not defensive about the current state. Conditional flows (like "if modal is open, close it first") hide bugs, waste time, and make failures harder to understand.
-
-:::::{dropdown} Examples
-❌ **Don’t:** add conditional logic to handle unknown state:
-
-```ts
-async switchToEditMode() {
-  const isViewMode = await this.page.testSubj.locator('dashboardViewMode').isVisible();
-  if (isViewMode) {
-    await this.page.testSubj.click('dashboardEditMode');
-  }
-}
-```
-
-✔️ **Do:** make the action explicit, since the caller knows the expected state:
-
-```ts
-async openEditMode() {
-  await this.page.testSubj.click('dashboardEditMode');
-  await this.page.testSubj.waitForSelector('dashboardIsEditing', { state: 'visible' });
-}
-```
-
-:::::
-
-### Keep assertions explicit in tests, not hidden in page objects [keep-assertions-explicit-in-tests-not-hidden-in-page-objects]
-
-Prefer explicit `expect()` in the test file so reviewers can see intent and failure modes. Also prefer `expect()` over manual boolean checks, as Playwright’s error output includes the locator, call log, and a clear message, which `if`/`throw` patterns lose.
-
-**In page objects, avoid `expect()`.** Use `waitForSelector` / visibility waits to synchronize after navigation or actions (for example wait for a header to be visible). Assertions belong in specs.
-
-:::::{dropdown} Examples
-❌ **Don’t:** hide assertions inside page objects:
-
-```ts
-// inside page object
-async createIndexAndVerify(name: string) {
-  await this.page.testSubj.click('saveButton');
-  await expect(this.page.testSubj.locator('indicesTable')).toContainText(name);
-}
-```
-
-✔️ **Do:** keep assertions in the test file:
-
-```ts
-await pageObjects.indexManagement.clickCreateIndexSaveButton();
-await expect(page.testSubj.locator('indicesTable')).toContainText(testIndexName);
-```
-
-:::::
-
-### Use `expect.soft` for independent checks [use-expect-soft-for-independent-checks]
-
-When a test verifies multiple independent items (KPI tiles, chart counts, table columns), use `expect.soft()` so the test continues checking everything instead of stopping at the first failure. Playwright still fails the test at the end if any soft assertion failed.
-
-:::::{dropdown} Example
-
-```ts
-test('Overview tab shows all KPI values', async ({ pageObjects }) => {
-  await pageObjects.nodeDetails.clickOverviewTab();
-  await expect.soft(pageObjects.nodeDetails.getKPI('cpuUsage')).toHaveText('50.0%');
-  await expect.soft(pageObjects.nodeDetails.getKPI('memoryUsage')).toHaveText('35.0%');
-  await expect.soft(pageObjects.nodeDetails.getKPI('diskUsage')).toHaveText('80.0%');
-});
-```
-
-:::::
-
-### Use EUI wrappers as class fields in page objects [use-eui-wrappers-as-class-fields-in-page-objects]
-
-If you must interact with EUI internals, use wrappers from Scout to keep that complexity out of tests.
-
-:::::{dropdown} Example
-
-```ts
-import { EuiComboBoxWrapper, ScoutPage } from '@kbn/scout';
-
-export class StreamsAppPage {
-  public readonly fieldComboBox: EuiComboBoxWrapper;
-
-  constructor(private readonly page: ScoutPage) {
-    this.fieldComboBox = new EuiComboBoxWrapper(this.page, 'fieldSelectorComboBox');
-  }
-
-  async selectField(value: string) {
-    await this.fieldComboBox.selectSingleOption(value);
-  }
-}
-```
-
-:::::
-
-### Add accessibility checks at key UI checkpoints [add-a11y-checks]
-
-Scout supports automated accessibility (a11y) scanning via `page.checkA11y`. Add checks at high-value points in your UI tests (landing pages, modals, flyouts, wizard steps) rather than on every interaction.
-
-:::::{dropdown} Example
-
-```ts
-const { violations } = await page.checkA11y({ include: ['[data-test-subj="myPanel"]'] });
-expect(violations).toHaveLength(0);
-```
-
-:::::
-
-For the full guide (scoping, exclusions, handling pre-existing violations), see [Accessibility testing](./a11y-checks.md).
-
-### Skip onboarding with `addInitScript` [skip-onboarding-flows-with-addinitscript]
-
-If a page has onboarding/getting-started state, set `localStorage` before navigation.
-
-:::::{dropdown} Example
-
-```ts
-test.beforeEach(async ({ page, browserAuth, pageObjects }) => {
-  await browserAuth.loginAsViewer();
-  await page.addInitScript(() => {
-    window.localStorage.setItem('gettingStartedVisited', 'true');
-  });
-  await pageObjects.homepage.goto();
-});
-```
-
-:::::
-
----
-
-## API tests [api-tests]
-
-Best practices specific to API tests.
-
-### Validate endpoints with `apiClient` [validate-endpoints-with-apiclient-for-readable-and-scoped-tests]
-
-Use the right fixture for the right purpose:
-
-| Fixture                       | Use for                                                                          |
-| ----------------------------- | -------------------------------------------------------------------------------- |
-| `apiClient`                   | The endpoint under test (with scoped credentials from [API auth](./api-auth.md)) |
-| `apiServices`                 | Setup/teardown and side effects                                                  |
-| `kbnClient`, `esClient`, etc. | Lower-level setup when `apiServices` doesn’t have a suitable helper              |
-
-Prefer tests that read like “call endpoint X as role Y, assert outcome”.
-
-:::::{dropdown} Example
-
-```ts
-import { expect } from '@kbn/scout/api';
-
-apiTest.beforeAll(async ({ requestAuth, apiServices }) => {
-  await apiServices.myFeature.createTestData();
-  viewerCredentials = await requestAuth.getApiKeyForViewer();
-});
-
-apiTest('returns data for viewer', async ({ apiClient }) => {
-  const response = await apiClient.get('api/my-feature/data', {
-    headers: { ...COMMON_HEADERS, ...viewerCredentials.apiKeyHeader },
-  });
-
-  expect(response).toHaveStatusCode(200);
-  expect(response.body.items).toHaveLength(3);
-});
-```
-
-:::::
-
-This pattern validates both endpoint behavior and the [permission model](#test-with-minimal-permissions-avoid-admin-when-possible).
-
-### Choose the right auth pattern [choose-the-right-auth-pattern]
-
-Scout supports two authentication methods for API tests. Choose based on endpoint type:
-
-| Endpoint type                | Auth method          | Fixture                        |
-| ---------------------------- | -------------------- | ------------------------------ |
-| Public APIs (`api/*`)        | API key              | `requestAuth` + `apiKeyHeader` |
-| Internal APIs (`internal/*`) | Cookie-based session | `samlAuth` + `cookieHeader`    |
-
-See [API authentication](./api-auth.md) for details and examples.
-
-### Validate the response body (not just status) [dont-just-verify-the-status-code-validate-the-response-body]
-
-Status code assertions are necessary but not sufficient. Also validate shape and key fields.
-
-:::::{dropdown} Examples
-❌ **Don’t:** assert only the status code:
-
-```ts
-apiTest('returns autocomplete definitions', async ({ apiClient }) => {
-  const response = await apiClient.get('api/console/api_server', {
-    headers: { ...COMMON_HEADERS, ...viewerCredentials.apiKeyHeader },
-  });
-
-  expect(response).toHaveStatusCode(200);
-});
-```
-
-✔️ **Do:** validate shape and key fields too:
-
-```ts
-apiTest('returns autocomplete definitions', async ({ apiClient }) => {
-  const response = await apiClient.get('api/console/api_server', {
-    headers: { ...COMMON_HEADERS, ...viewerCredentials.apiKeyHeader },
-  });
-
-  expect(response).toHaveStatusCode(200);
-  expect(response.body).toMatchObject({
-    es: {
-      endpoints: expect.any(Object),
-      globals: expect.any(Object),
-      name: 'es',
-    },
-  });
-});
-```
-
 :::::

--- a/docs/extend/scout/best-practices.md
+++ b/docs/extend/scout/best-practices.md
@@ -268,24 +268,6 @@ await browserAuth.loginWithCustomRole('logs_analyst', {
 
 :::::
 
-:::::{dropdown} Tip: extend browserAuth for repeated roles
-If the same custom role appears in many specs, extract it into a `browserAuth` fixture extension instead of repeating the role descriptor everywhere. Tests then read like intent:
-
-```ts
-// in your plugin's fixtures/index.ts
-await use({
-  ...browserAuth,
-  loginAsPlatformEngineer: () =>
-    browserAuth.loginWithCustomRole('platform_engineer', roleDescriptor),
-});
-
-// in specs
-await browserAuth.loginAsPlatformEngineer();
-```
-
-For setup details, see [Reuse role helpers](./browser-auth.md#scout-browser-auth-extend).
-:::::
-
 ## Contribute to Scout when possible [contribute-to-scout-when-possible]
 
 If you build a helper that will benefit other tests, consider upstreaming it:

--- a/docs/extend/scout/best-practices.md
+++ b/docs/extend/scout/best-practices.md
@@ -42,6 +42,28 @@ Prefer doing this locally first (faster feedback), and use the Flaky Test Runner
 - Don’t rely on test file execution order (it’s [not guaranteed](https://playwright.dev/docs/test-parallel#control-test-order)).
 - Don’t assume a previous test in the suite already set up the data you need (if that test fails or is skipped, the test will break with a misleading error).
 
+## Use `test.step` for multi-step flows [use-teststep-for-multi-step-flows]
+
+Use `test.step()` (or `apiTest.step()` in API tests) to structure a multi-step flow within a single test. It keeps the test in one context (faster, clearer reporting) and produces labelled entries in the test report that make failures easier to diagnose. Group closely related actions into a single step when it keeps the report readable without hiding intent.
+
+:::::{dropdown} Example
+
+```ts
+test('navigates through pages', async ({ pageObjects }) => {
+  await test.step('go to Dashboards', async () => {
+    await pageObjects.navigation.clickDashboards();
+  });
+
+  await test.step('go to Overview', async () => {
+    await pageObjects.navigation.clickOverview();
+  });
+});
+```
+
+The same pattern works in API tests with `apiTest.step()`.
+
+:::::
+
 ## Write descriptive test names [write-descriptive-test-names]
 
 Test names should read like a sentence describing expected behavior. Clear names make failures self-explanatory and test suites scannable.
@@ -203,6 +225,56 @@ test.afterAll(async ({ apiServices }) => {
 ```ts
 test.afterAll(async ({ apiServices }) => {
   await apiServices.cases.cleanup.deleteAllCases();
+});
+```
+
+Inside the helper, handle the expected error — either by treating 404 as success, or by accepting an `ignoreErrors` option:
+
+```ts
+async function deleteCase(caseId: string, { ignoreErrors = false } = {}) {
+  const response = await apiClient.delete(`api/cases/${caseId}`, {
+    headers: { ...COMMON_HEADERS, ...adminCredentials.apiKeyHeader },
+  });
+
+  // already gone — nothing to do
+  if (response.status === 404) return;
+  if (!ignoreErrors && response.status >= 400) {
+    throw new Error(`Failed to delete case ${caseId}: ${response.status}`);
+  }
+}
+```
+
+:::::
+
+## Use `expect.soft` for independent checks [use-expect-soft-for-independent-checks]
+
+When a test verifies multiple independent items (KPI tiles, chart counts, table columns, several response fields), you can optionally use `expect.soft()` so the test continues checking everything instead of stopping at the first failure (to facilitate troubleshooting). Playwright still fails the test at the end if any soft assertion failed.
+
+:::::{dropdown} Examples
+
+UI test:
+
+```ts
+test('Overview tab shows all KPI values', async ({ pageObjects }) => {
+  await pageObjects.nodeDetails.clickOverviewTab();
+  await expect.soft(pageObjects.nodeDetails.getKPI('cpuUsage')).toHaveText('50.0%');
+  await expect.soft(pageObjects.nodeDetails.getKPI('memoryUsage')).toHaveText('35.0%');
+  await expect.soft(pageObjects.nodeDetails.getKPI('diskUsage')).toHaveText('80.0%');
+});
+```
+
+API test:
+
+```ts
+apiTest('returns expected summary fields', async ({ apiClient }) => {
+  const response = await apiClient.get('api/my-feature/summary', {
+    headers: { ...COMMON_HEADERS, ...viewerCredentials.apiKeyHeader },
+  });
+
+  expect(response).toHaveStatusCode(200);
+  expect.soft(response.body.total).toBe(42);
+  expect.soft(response.body.active).toBe(10);
+  expect.soft(response.body.archived).toBe(32);
 });
 ```
 

--- a/docs/extend/scout/page-objects.md
+++ b/docs/extend/scout/page-objects.md
@@ -10,7 +10,7 @@ Page objects wrap UI interactions (navigation, clicking, filling forms) so tests
 Keep page objects focused on **UI interactions**. Don’t hide API setup/teardown inside page objects—use [API services](./api-services.md) or [fixtures](./fixtures.md) instead.
 ::::::
 
-For practical tips, see the page object guidelines in [UI test best practices](./best-practices.md#use-existing-page-objects-to-interact-with-the-kibana-ui).
+For practical tips, see the page object guidelines in [UI test best practices](./ui-best-practices.md#use-existing-page-objects-to-interact-with-the-kibana-ui).
 
 ## Usage [scout-page-objects-usage]
 

--- a/docs/extend/scout/ui-best-practices.md
+++ b/docs/extend/scout/ui-best-practices.md
@@ -47,26 +47,6 @@ await expect(page.testSubj.locator('row-0-col-dataset')).not.toHaveText('');
 
 :::::
 
-## Use `test.step` for multi-step flows [use-teststep-for-multi-step-flows]
-
-Use `test.step()` to structure a multi-step flow while keeping one browser context (faster, clearer reporting). Group closely related actions into a single step when it keeps the report readable without hiding intent.
-
-:::::{dropdown} Example
-
-```ts
-test('navigates through pages', async ({ pageObjects }) => {
-  await test.step('go to Dashboards', async () => {
-    await pageObjects.navigation.clickDashboards();
-  });
-
-  await test.step('go to Overview', async () => {
-    await pageObjects.navigation.clickOverview();
-  });
-});
-```
-
-:::::
-
 ## Prefer realistic in-app navigation for user flows [prefer-realistic-in-app-navigation]
 
 When a test asserts **user flow** (not just “land on a page”), prefer navigation the way a user would: follow links and buttons, and use browser history (`page.goBack()`) instead of direct URL jumps where it matters for the scenario. Reserve `page.goto` / deep links for cheap setup when the test is not about navigation.
@@ -321,23 +301,6 @@ async createIndexAndVerify(name: string) {
 ```ts
 await pageObjects.indexManagement.clickCreateIndexSaveButton();
 await expect(page.testSubj.locator('indicesTable')).toContainText(testIndexName);
-```
-
-:::::
-
-## Use `expect.soft` for independent checks [use-expect-soft-for-independent-checks]
-
-When a test verifies multiple independent items (KPI tiles, chart counts, table columns), use `expect.soft()` so the test continues checking everything instead of stopping at the first failure. Playwright still fails the test at the end if any soft assertion failed.
-
-:::::{dropdown} Example
-
-```ts
-test('Overview tab shows all KPI values', async ({ pageObjects }) => {
-  await pageObjects.nodeDetails.clickOverviewTab();
-  await expect.soft(pageObjects.nodeDetails.getKPI('cpuUsage')).toHaveText('50.0%');
-  await expect.soft(pageObjects.nodeDetails.getKPI('memoryUsage')).toHaveText('35.0%');
-  await expect.soft(pageObjects.nodeDetails.getKPI('diskUsage')).toHaveText('80.0%');
-});
 ```
 
 :::::

--- a/docs/extend/scout/ui-best-practices.md
+++ b/docs/extend/scout/ui-best-practices.md
@@ -399,6 +399,27 @@ test.beforeEach(async ({ page, browserAuth, pageObjects }) => {
 
 :::::
 
+## Extend `browserAuth` for repeated roles [extend-browserauth-for-repeated-roles]
+
+If the same custom role appears in many specs, extract it into a `browserAuth` fixture extension instead of repeating the role descriptor everywhere. Tests then read like intent.
+
+:::::{dropdown} Example
+
+```ts
+// in your plugin's fixtures/index.ts
+await use({
+  ...browserAuth,
+  loginAsPlatformEngineer: () =>
+    browserAuth.loginWithCustomRole('platform_engineer', roleDescriptor),
+});
+
+// in specs
+await browserAuth.loginAsPlatformEngineer();
+```
+
+For setup details, see [Reuse role helpers](./browser-auth.md#scout-browser-auth-extend).
+:::::
+
 ## Related guides
 
 - [General best practices](./best-practices.md) — apply to both UI and API tests

--- a/docs/extend/scout/ui-best-practices.md
+++ b/docs/extend/scout/ui-best-practices.md
@@ -1,0 +1,409 @@
+---
+navigation_title: Best practices
+---
+
+# Best practices for Scout UI tests [scout-ui-best-practices]
+
+Best practices specific to Scout **UI tests**.
+
+:::::{tip}
+For guidance that applies to both UI and API tests, see the [general Scout best practices](./best-practices.md). Scout is built on Playwright, so the official [Playwright Best Practices](https://playwright.dev/docs/best-practices) also apply.
+:::::
+
+## Prefer parallel runs [run-tests-in-parallel-whenever-possible]
+
+Default to [parallel UI suites](./parallelism.md) when possible. Parallel workers share the same Kibana/ES deployment, but run in isolated Spaces.
+
+| Mode           | When to use                                                                                                               |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| **Parallel**   | UI tests (most suites), suites that share pre-ingested data (often using the [global setup hook](./global-setup-hook.md)) |
+| **Sequential** | API tests, suites that require a “clean” Elasticsearch state                                                              |
+
+## Test behavior, not data correctness [focus-ui-tests-on-behavior-not-data-correctness]
+
+UI tests should answer “does this feature work for the user?” Verify that components render, respond to interaction, and navigate correctly. Leave exact data validation (computed values, aggregation results, edge cases) to API or unit tests, which are faster and less brittle.
+
+| What you’re testing                                                         | Recommended layer  |
+| --------------------------------------------------------------------------- | ------------------ |
+| User flows, navigation, rendering                                           | Scout UI test      |
+| Data correctness, API contracts, edge cases                                 | Scout API test     |
+| Isolated component logic (loading/error states, tooltips, field validation) | RTL/Jest unit test |
+
+:::::{dropdown} Examples
+❌ **Don’t:** verify computed values that belong in an API test:
+
+```ts
+await expect(page.testSubj.locator('row-0-col-count')).toHaveText('1,024');
+await expect(page.testSubj.locator('row-0-col-avg')).toHaveText('42.7');
+```
+
+✔️ **Do:** verify that the UI renders and responds to interaction:
+
+```ts
+await expect(page.testSubj.locator('datasetQualityTable-loaded')).toBeVisible();
+await page.testSubj.click('tableSortByLastActivity');
+await expect(page.testSubj.locator('row-0-col-dataset')).not.toHaveText('');
+```
+
+:::::
+
+## Use `test.step` for multi-step flows [use-teststep-for-multi-step-flows]
+
+Use `test.step()` to structure a multi-step flow while keeping one browser context (faster, clearer reporting). Group closely related actions into a single step when it keeps the report readable without hiding intent.
+
+:::::{dropdown} Example
+
+```ts
+test('navigates through pages', async ({ pageObjects }) => {
+  await test.step('go to Dashboards', async () => {
+    await pageObjects.navigation.clickDashboards();
+  });
+
+  await test.step('go to Overview', async () => {
+    await pageObjects.navigation.clickOverview();
+  });
+});
+```
+
+:::::
+
+## Prefer realistic in-app navigation for user flows [prefer-realistic-in-app-navigation]
+
+When a test asserts **user flow** (not just “land on a page”), prefer navigation the way a user would: follow links and buttons, and use browser history (`page.goBack()`) instead of direct URL jumps where it matters for the scenario. Reserve `page.goto` / deep links for cheap setup when the test is not about navigation.
+
+## Prefer APIs for setup and teardown [prefer-kibana-apis-over-ui-for-setup-and-teardown]
+
+Setup/teardown using UI is slow and brittle. Prefer Kibana APIs and fixtures.
+
+:::::{dropdown} Examples
+❌ **Don’t:** create test data through the UI:
+
+```ts
+test.beforeEach(async ({ page, browserAuth }) => {
+  await browserAuth.loginAsAdmin();
+  await page.testSubj.click('createDataViewButton');
+  await page.testSubj.fill('indexPatternInput', 'logs-*');
+  await page.testSubj.click('saveDataViewButton');
+});
+```
+
+✔️ **Do:** use API fixtures:
+
+```ts
+test.beforeEach(async ({ uiSettings, kbnClient }) => {
+  await uiSettings.setDefaultTime({ from: startTime, to: endTime });
+  await kbnClient.importExport.load(DATA_VIEW_ARCHIVE_PATH);
+});
+```
+
+:::::
+
+## Use Playwright auto-waiting [leverage-playwright-auto-waiting]
+
+Playwright actions and [web-first assertions](https://playwright.dev/docs/best-practices#use-web-first-assertions) already wait/retry. Don’t add redundant waits, and never use `page.waitForTimeout()` as it’s a hard sleep with no readiness signal and a common source of flakiness.
+
+:::::{dropdown} Examples
+❌ **Don’t:** add unnecessary waits before actions or assertions:
+
+```ts
+await page.testSubj.waitForSelector('myButton', { state: 'visible' });
+await page.testSubj.click('myButton');
+await page.testSubj.locator('successToast').waitFor();
+await expect(page.testSubj.locator('successToast')).toBeVisible();
+```
+
+✔️ **Do:** let Playwright handle waiting automatically:
+
+```ts
+await page.testSubj.click('myButton');
+await expect(page.testSubj.locator('successToast')).toBeVisible();
+```
+
+:::::
+
+## Wait for UI updates after actions [wait-for-ui-updates-when-the-next-action-requires-it]
+
+When an action triggers async UI work (navigation, saving, loading data), wait for the resulting state before your next step. This ensures the UI is ready and prevents flaky interactions with elements that haven’t rendered yet.
+
+:::::{dropdown} Example
+
+```ts
+await page.gotoApp('sample/page/here');
+await page.testSubj.waitForSelector('mainContent', { state: 'visible' });
+```
+
+:::::
+
+## Don't use manual retry loops [dont-use-manual-retry-loops]
+
+If an action fails, don't wrap it in a retry loop. Playwright already waits for actionability; repeated failures usually point to an app issue (unstable DOM, non-unique selectors, re-render bugs). Fix the component or make your waiting/locators explicit and stable.
+
+:::::{dropdown} Examples
+❌ **Don't:** retry actions in a loop:
+
+```ts
+for (let i = 0; i < 3; i++) {
+  try {
+    await page.testSubj.click('submitButton');
+    break;
+  } catch {
+    await page.waitForTimeout(1000);
+  }
+}
+```
+
+✔️ **Do:** fix the root cause (for example, wait for a readiness signal):
+
+```ts
+await expect(page.testSubj.locator('formReady')).toBeVisible();
+await page.testSubj.click('submitButton');
+```
+
+:::::
+
+## Locate UI elements reliably [locate-ui-elements-reliably]
+
+Prefer stable `data-test-subj` attributes accessed using `page.testSubj`. If `data-test-subj` is missing, prefer adding one to source code. If that’s not possible, use `getByRole` **inside a scoped container**.
+
+:::::{dropdown} Examples
+❌ **Don’t:** use raw CSS selectors or unscoped text matchers (searching the entire page for text is unreliable when duplicates exist):
+
+```ts
+await page.click('[data-test-subj="myButton"]');
+await page.getByText('Delete').click();
+```
+
+❌ **Don’t:** select elements by index ([flagged by Playwright’s recommended ESLint rules](https://playwright.dev/docs/best-practices)), as they break on non-clean environments where tests run without server restart and extra data may exist:
+
+```ts
+await page.testSubj.locator('tableRow').nth(0).click();
+```
+
+✔️ **Do:** use `page.testSubj` or scoped `getByRole`:
+
+```ts
+await page.testSubj.click('myButton');
+await page.testSubj.locator('confirmDeleteModal').getByRole('button', { name: 'Delete' }).click();
+```
+
+:::::
+
+## Avoid unnecessary timeout overrides [use-scouts-default-timeouts]
+
+Scout configures Playwright timeouts ([source](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-scout/src/playwright/config/create_config.ts)). Prefer defaults.
+
+- Don’t override suite-level timeouts/retries with `test.describe.configure()` unless you have a strong reason.
+- If you increase a timeout for one operation, keep it well below the test timeout and **add a short code comment** explaining why (slow first load, CI variance, known heavy view, etc.).
+- After raising timeouts for flakiness, **re-run the flaky test runner** (or many local repeats) to confirm the new value is necessary.
+- Keep in mind that an assertion timeout that exceeds the test timeout is ignored.
+- Time spent in hooks (`beforeEach`, `afterEach`) counts toward the test timeout. If setup is slow, the test itself may time out even though its assertions are fast.
+
+:::::{dropdown} Example
+
+```ts
+await expect(editor).toBeVisible(); // will use the default timeout
+
+// justified: report generation can be slow
+await expect(downloadBtn).toBeEnabled({ timeout: 30_000 });
+```
+
+:::::
+
+## Wait for complex UI to finish rendering [wait-for-complex-components-to-fully-render]
+
+Tables/maps/visualizations can appear before data is rendered. Prefer waiting on a component-specific **“loaded” signal** rather than global indicators like the Kibana chrome spinner (our data shows they are unreliable for confirming that a particular component has finished rendering).
+
+**Do not rely on helpers that only wait for a global “loading” indicator to disappear.** Each view should have an explicit readiness wait (or removal of such helpers in favor of those waits).
+
+:::::{dropdown} Example
+In source code, use a dynamic `data-test-subj`:
+
+```tsx
+<EuiBasicTable
+  data-test-subj={`myTable-${isLoading ? 'loading' : 'loaded'}`}
+  loading={isLoading}
+  items={items}
+  columns={columns}
+/>
+```
+
+In tests, wait for the loaded state:
+
+```ts
+await expect(page.testSubj.locator('myTable-loaded')).toBeVisible();
+```
+
+For Kibana Maps, `data-render-complete="true"` is often the right “ready” signal.
+:::::
+
+## Use existing page objects to interact with the Kibana UI [use-existing-page-objects-to-interact-with-the-kibana-ui]
+
+Prefer existing page objects (and their methods) over rebuilding EUI interactions in test files.
+
+- Prefer **`readonly` locator fields** assigned in the constructor for stable selectors, and **methods** for parameterized locators, multi-step actions, or flows. Thin getter-only methods for every field add noise; match the patterns used by built-in page objects (for example `DashboardApp`).
+
+:::::{dropdown} Example
+
+```ts
+await pageObjects.datePicker.setAbsoluteRange({
+  from: 'Sep 19, 2015 @ 06:31:44.000',
+  to: 'Sep 23, 2015 @ 18:31:44.000',
+});
+```
+
+:::::
+
+## Keep mocks and non-UI setup out of page objects [keep-mocks-out-of-page-objects]
+
+Page objects should focus on real UI interaction. Put HTTP mocks, interceptors, and similar setup in dedicated fixtures (for example `fixtures/mocks.ts`) so tests and reviewers can find them in one place.
+
+## Abstract common operations in page object methods [abstract-common-operations-in-page-object-methods]
+
+Create methods for repeated flows (and make them [wait for readiness](#wait-for-ui-updates-when-the-next-action-requires-it)).
+
+:::::{dropdown} Example
+
+```ts
+async openNewDashboard() {
+  await this.page.testSubj.click('newItemButton');
+  await this.page.testSubj.waitForSelector('emptyDashboardWidget', { state: 'visible' });
+}
+```
+
+:::::
+
+## Avoid conditional logic in page objects and tests [avoid-conditional-logic-in-page-objects]
+
+Playwright creates a fresh browser context for each test, so there is no cached state to work around. Both page object methods and test code should be explicit about the action they perform, not defensive about the current state. Conditional flows (like "if modal is open, close it first") hide bugs, waste time, and make failures harder to understand.
+
+:::::{dropdown} Examples
+❌ **Don’t:** add conditional logic to handle unknown state:
+
+```ts
+async switchToEditMode() {
+  const isViewMode = await this.page.testSubj.locator('dashboardViewMode').isVisible();
+  if (isViewMode) {
+    await this.page.testSubj.click('dashboardEditMode');
+  }
+}
+```
+
+✔️ **Do:** make the action explicit, since the caller knows the expected state:
+
+```ts
+async openEditMode() {
+  await this.page.testSubj.click('dashboardEditMode');
+  await this.page.testSubj.waitForSelector('dashboardIsEditing', { state: 'visible' });
+}
+```
+
+:::::
+
+## Keep assertions explicit in tests, not hidden in page objects [keep-assertions-explicit-in-tests-not-hidden-in-page-objects]
+
+Prefer explicit `expect()` in the test file so reviewers can see intent and failure modes. Also prefer `expect()` over manual boolean checks, as Playwright’s error output includes the locator, call log, and a clear message, which `if`/`throw` patterns lose.
+
+**In page objects, avoid `expect()`.** Use `waitForSelector` / visibility waits to synchronize after navigation or actions (for example wait for a header to be visible). Assertions belong in specs.
+
+:::::{dropdown} Examples
+❌ **Don’t:** hide assertions inside page objects:
+
+```ts
+// inside page object
+async createIndexAndVerify(name: string) {
+  await this.page.testSubj.click('saveButton');
+  await expect(this.page.testSubj.locator('indicesTable')).toContainText(name);
+}
+```
+
+✔️ **Do:** keep assertions in the test file:
+
+```ts
+await pageObjects.indexManagement.clickCreateIndexSaveButton();
+await expect(page.testSubj.locator('indicesTable')).toContainText(testIndexName);
+```
+
+:::::
+
+## Use `expect.soft` for independent checks [use-expect-soft-for-independent-checks]
+
+When a test verifies multiple independent items (KPI tiles, chart counts, table columns), use `expect.soft()` so the test continues checking everything instead of stopping at the first failure. Playwright still fails the test at the end if any soft assertion failed.
+
+:::::{dropdown} Example
+
+```ts
+test('Overview tab shows all KPI values', async ({ pageObjects }) => {
+  await pageObjects.nodeDetails.clickOverviewTab();
+  await expect.soft(pageObjects.nodeDetails.getKPI('cpuUsage')).toHaveText('50.0%');
+  await expect.soft(pageObjects.nodeDetails.getKPI('memoryUsage')).toHaveText('35.0%');
+  await expect.soft(pageObjects.nodeDetails.getKPI('diskUsage')).toHaveText('80.0%');
+});
+```
+
+:::::
+
+## Use EUI wrappers as class fields in page objects [use-eui-wrappers-as-class-fields-in-page-objects]
+
+If you must interact with EUI internals, use wrappers from Scout to keep that complexity out of tests.
+
+:::::{dropdown} Example
+
+```ts
+import { EuiComboBoxWrapper, ScoutPage } from '@kbn/scout';
+
+export class StreamsAppPage {
+  public readonly fieldComboBox: EuiComboBoxWrapper;
+
+  constructor(private readonly page: ScoutPage) {
+    this.fieldComboBox = new EuiComboBoxWrapper(this.page, 'fieldSelectorComboBox');
+  }
+
+  async selectField(value: string) {
+    await this.fieldComboBox.selectSingleOption(value);
+  }
+}
+```
+
+:::::
+
+## Add accessibility checks at key UI checkpoints [add-a11y-checks]
+
+Scout supports automated accessibility (a11y) scanning via `page.checkA11y`. Add checks at high-value points in your UI tests (landing pages, modals, flyouts, wizard steps) rather than on every interaction.
+
+:::::{dropdown} Example
+
+```ts
+const { violations } = await page.checkA11y({ include: ['[data-test-subj="myPanel"]'] });
+expect(violations).toHaveLength(0);
+```
+
+:::::
+
+For the full guide (scoping, exclusions, handling pre-existing violations), see [Accessibility testing](./a11y-checks.md).
+
+## Skip onboarding with `addInitScript` [skip-onboarding-flows-with-addinitscript]
+
+If a page has onboarding/getting-started state, set `localStorage` before navigation.
+
+:::::{dropdown} Example
+
+```ts
+test.beforeEach(async ({ page, browserAuth, pageObjects }) => {
+  await browserAuth.loginAsViewer();
+  await page.addInitScript(() => {
+    window.localStorage.setItem('gettingStartedVisited', 'true');
+  });
+  await pageObjects.homepage.goto();
+});
+```
+
+:::::
+
+## Related guides
+
+- [General best practices](./best-practices.md) — apply to both UI and API tests
+- [Write UI tests](./write-ui-tests.md)
+- [Browser authentication](./browser-auth.md)
+- [Page objects](./page-objects.md)
+- [Accessibility (a11y) checks](./a11y-checks.md)
+- [Parallelism](./parallelism.md)

--- a/docs/extend/scout/ui-testing.md
+++ b/docs/extend/scout/ui-testing.md
@@ -7,5 +7,6 @@ navigation_title: UI testing
 Use these pages when writing and maintaining Scout UI tests:
 
 - [Write Scout UI tests](./write-ui-tests.md)
+- [UI test best practices](./ui-best-practices.md)
 - [Browser authentication](./browser-auth.md)
 - [Accessibility (a11y) checks](./a11y-checks.md)

--- a/docs/extend/scout/write-api-tests.md
+++ b/docs/extend/scout/write-api-tests.md
@@ -17,7 +17,7 @@ Scout API tests validate HTTP endpoints with realistic scoped credentials.
 3. **Call the endpoint under test** with `apiClient` + the scoped headers
 4. **Assert** status + response body, and verify side effects when needed
 
-See [best practices for API tests](./best-practices.md#api-tests).
+See [API test best practices](./api-best-practices.md).
 
 Example test ([Console](https://github.com/elastic/kibana/blob/main/src/platform/plugins/shared/console/test/scout/api/tests/spec_definitions.spec.ts)).
 
@@ -66,7 +66,7 @@ API tests live under `<plugin-root>/test/scout/api/tests` and must end with `.sp
 ## Next steps [api-tests-next]
 
 - [API authentication](./api-auth.md)
-- [Best practices](./best-practices.md)
+- [API test best practices](./api-best-practices.md)
 - [Fixtures](./fixtures.md)
 - [Run tests](./run-tests.md) and [Debugging](./debugging.md)
 - [Parallelism notes](./parallelism.md#api-tests-and-parallelism)

--- a/docs/extend/scout/write-ui-tests.md
+++ b/docs/extend/scout/write-ui-tests.md
@@ -58,7 +58,7 @@ Spec files must end with `.spec.ts`.
 
 - [Browser authentication](./browser-auth.md)
 - [Deployment tags](./deployment-tags.md)
-- [Best practices](./best-practices.md)
+- [UI test best practices](./ui-best-practices.md)
 - [Page objects](./page-objects.md)
 - [Fixtures](./fixtures.md)
 - [Accessibility (a11y) checks](./a11y-checks.md)

--- a/docs/extend/toc.yml
+++ b/docs/extend/toc.yml
@@ -74,11 +74,13 @@ toc:
       - file: scout/ui-testing.md
         children:
           - file: scout/write-ui-tests.md
+          - file: scout/ui-best-practices.md
           - file: scout/browser-auth.md
           - file: scout/a11y-checks.md
       - file: scout/api-testing.md
         children:
           - file: scout/write-api-tests.md
+          - file: scout/api-best-practices.md
           - file: scout/api-auth.md
   - file: external-plugin-development.md
     children:


### PR DESCRIPTION
Our Scout best practices doc has grown into a very big document referenced by the [scout-best-practices-reviewer](https://github.com/elastic/kibana/tree/main/.agents/skills/scout-best-practices-reviewer) skill and the [Scout Test Review](https://github.com/elastic/kibana/blob/main/.macroscope/scout-review.md) Macroscope Check Run Agent. 

Problem: when an agent reviews an API test PR, it still has to **load the whole file** and scan through UI-only advice (and vice versa), which wastes context for no real benefit.

### Solution

This splits it into three focused pages:

- `best-practices.md`: general rules that apply to both test types (naming, tags, cleanup, permissions, etc.)
- `ui-best-practices.md`: **UI-only** (locators, waits, page objects, a11y, etc.)
- `api-best-practices.md`: **API-only** (`apiClient` usage, auth patterns, response body checks)

The UI and API pages now live under the **UI testing** and **API testing** sections, right where readers look for them.

I also updated the `scout-best-practices-reviewer` skill and the Macroscope config so they know about all three files and open only the one that matches the test type under review. All existing section anchors are preserved, so deep links from other docs keep working.