### PR TITLE
Unskip data preview test

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_processing/processing_simulation_preview.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_processing/processing_simulation_preview.spec.ts
@@ -14,8 +14,7 @@ import { generateLogsData } from '../../../fixtures/generators';
 // lowercase, trim, convert, etc.) is covered by API tests in
 // test/scout/api/tests/processing_simulate.spec.ts
 // These UI tests focus on preview table behavior, auto-update, and UI-specific features
-// Failing: See https://github.com/elastic/kibana/issues/260710
-test.describe.skip(
+test.describe(
   'Stream data processing - simulation preview',
   { tag: [...tags.stateful.classic, ...tags.serverless.observability.complete] },
   () => {


### PR DESCRIPTION
## Summary
This PR unskips `Stream data processing - simulation preview` tests after https://github.com/elastic/kibana/pull/261373 has been merged.

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->