### PR TITLE
Bulk install prebuilt rules POC

### DIFF
--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/bulk_create_rules.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/bulk_create_rules.test.ts
@@ -248,7 +248,7 @@ describe('bulkCreateRules', () => {
         category: 'test',
         producer: 'alerts',
         solution: 'stack',
-        validate: { params: { validate: (p: unknown) => p } },
+        validate: { params: { validate: (params) => params } },
         validLegacyConsumers: [],
       }));
 

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/bulk_create_rules.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/bulk_create_rules.test.ts
@@ -1,0 +1,360 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  savedObjectsClientMock,
+  loggingSystemMock,
+  savedObjectsRepositoryMock,
+  uiSettingsServiceMock,
+  coreFeatureFlagsMock,
+} from '@kbn/core/server/mocks';
+import { taskManagerMock } from '@kbn/task-manager-plugin/server/mocks';
+import { encryptedSavedObjectsMock } from '@kbn/encrypted-saved-objects-plugin/server/mocks';
+import { actionsAuthorizationMock } from '@kbn/actions-plugin/server/mocks';
+import { auditLoggerMock } from '@kbn/security-plugin/server/audit/mocks';
+import type { ActionsAuthorization, ActionsClient } from '@kbn/actions-plugin/server';
+import { createMockConnector } from '@kbn/actions-plugin/server/application/connector/mocks';
+import { ruleTypeRegistryMock } from '../../../../rule_type_registry.mock';
+import { alertingAuthorizationMock } from '../../../../authorization/alerting_authorization.mock';
+import type { AlertingAuthorization } from '../../../../authorization/alerting_authorization';
+import { RULE_SAVED_OBJECT_TYPE } from '../../../../saved_objects';
+import { ConnectorAdapterRegistry } from '../../../../connector_adapters/connector_adapter_registry';
+import { backfillClientMock } from '../../../../backfill_client/backfill_client.mock';
+import { getBeforeSetup, setGlobalDate } from '../../../../rules_client/tests/lib';
+import type { ConstructorOptions } from '../../../../rules_client/rules_client';
+import { RulesClient } from '../../../../rules_client/rules_client';
+import { ENABLED_RULE_REJECTION_MESSAGE } from './bulk_create_rules';
+
+jest.mock('@kbn/core-saved-objects-utils-server', () => {
+  const actual = jest.requireActual('@kbn/core-saved-objects-utils-server');
+  let id = 0;
+  return {
+    ...actual,
+    SavedObjectsUtils: {
+      generateId: () => `mock-id-${++id}`,
+    },
+  };
+});
+
+const taskManager = taskManagerMock.createStart();
+const ruleTypeRegistry = ruleTypeRegistryMock.create();
+const unsecuredSavedObjectsClient = savedObjectsClientMock.create();
+const encryptedSavedObjects = encryptedSavedObjectsMock.createClient();
+const authorization = alertingAuthorizationMock.create();
+const actionsAuthorization = actionsAuthorizationMock.create();
+const auditLogger = auditLoggerMock.create();
+const internalSavedObjectsRepository = savedObjectsRepositoryMock.create();
+
+const rulesClientParams: jest.Mocked<ConstructorOptions> = {
+  taskManager,
+  ruleTypeRegistry,
+  unsecuredSavedObjectsClient,
+  authorization: authorization as unknown as AlertingAuthorization,
+  actionsAuthorization: actionsAuthorization as unknown as ActionsAuthorization,
+  spaceId: 'default',
+  namespace: 'default',
+  getUserName: jest.fn(),
+  createAPIKey: jest.fn(),
+  logger: loggingSystemMock.create().get(),
+  internalSavedObjectsRepository,
+  encryptedSavedObjectsClient: encryptedSavedObjects,
+  getActionsClient: jest.fn(),
+  getEventLogClient: jest.fn(),
+  kibanaVersion: 'v8.0.0',
+  auditLogger,
+  maxScheduledPerMinute: 10000,
+  minimumScheduleInterval: { value: '1m', enforce: false },
+  isAuthenticationTypeAPIKey: jest.fn(),
+  getAuthenticationAPIKey: jest.fn(),
+  getAlertIndicesAlias: jest.fn(),
+  alertsService: null,
+  backfillClient: backfillClientMock.create(),
+  connectorAdapterRegistry: new ConnectorAdapterRegistry(),
+  isSystemAction: jest.fn(),
+  uiSettings: uiSettingsServiceMock.createStartContract(),
+  featureFlags: coreFeatureFlagsMock.createStart(),
+  isServerless: false,
+};
+
+setGlobalDate();
+
+const baseDisabledRuleData = (overrides: Record<string, unknown> = {}) => ({
+  enabled: false,
+  name: 'test rule',
+  tags: ['t1'],
+  alertTypeId: '123',
+  consumer: 'bar',
+  schedule: { interval: '1m' },
+  throttle: null,
+  notifyWhen: null,
+  params: { foo: true },
+  actions: [],
+  ...overrides,
+});
+
+const mockBulkCreateResponse = (rules: Array<{ id: string; name: string }>) => {
+  unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue({
+    saved_objects: rules.map((r) => ({
+      id: r.id,
+      type: RULE_SAVED_OBJECT_TYPE,
+      attributes: {
+        alertTypeId: '123',
+        name: r.name,
+        enabled: false,
+        consumer: 'bar',
+        schedule: { interval: '1m' },
+        params: { foo: true },
+        actions: [],
+        createdBy: 'elastic',
+        updatedBy: 'elastic',
+        createdAt: '2019-02-12T21:01:22.479Z',
+        updatedAt: '2019-02-12T21:01:22.479Z',
+        snoozeSchedule: [],
+        muteAll: false,
+        mutedInstanceIds: [],
+        executionStatus: { status: 'pending', lastExecutionDate: '2019-02-12T21:01:22.479Z' },
+        revision: 0,
+        running: false,
+        apiKey: null,
+        apiKeyOwner: null,
+        apiKeyCreatedByUser: null,
+      },
+      references: [],
+    })) as never,
+  });
+};
+
+describe('bulkCreateRules', () => {
+  let rulesClient: RulesClient;
+  let actionsClient: jest.Mocked<ActionsClient>;
+
+  beforeEach(async () => {
+    getBeforeSetup(rulesClientParams, taskManager, ruleTypeRegistry);
+    (auditLogger.log as jest.Mock).mockClear();
+    rulesClient = new RulesClient(rulesClientParams);
+    actionsClient = (await rulesClientParams.getActionsClient()) as jest.Mocked<ActionsClient>;
+    actionsClient.getBulk.mockResolvedValue([
+      createMockConnector({ id: '1', actionTypeId: 'test', name: 'a' }),
+    ]);
+    actionsClient.listTypes.mockResolvedValue([]);
+    actionsClient.isSystemAction.mockReturnValue(false);
+    rulesClientParams.getActionsClient.mockResolvedValue(actionsClient);
+    rulesClientParams.createAPIKey.mockResolvedValue({ apiKeysEnabled: false });
+    rulesClientParams.isAuthenticationTypeAPIKey.mockReturnValue(false);
+  });
+
+  test('returns empty result when given an empty rules array', async () => {
+    const result = await rulesClient.bulkCreateRules({ rules: [] });
+    expect(result).toEqual({ rules: [], errors: [], total: 0 });
+    expect(unsecuredSavedObjectsClient.bulkCreate).not.toHaveBeenCalled();
+  });
+
+  test('persists all disabled rules in a single bulkCreate call', async () => {
+    mockBulkCreateResponse([
+      { id: 'mock-id-1', name: 'r1' },
+      { id: 'mock-id-2', name: 'r2' },
+    ]);
+
+    const result = await rulesClient.bulkCreateRules({
+      rules: [
+        { data: baseDisabledRuleData({ name: 'r1' }) },
+        { data: baseDisabledRuleData({ name: 'r2' }) },
+      ],
+    });
+
+    expect(unsecuredSavedObjectsClient.bulkCreate).toHaveBeenCalledTimes(1);
+    expect(unsecuredSavedObjectsClient.bulkCreate.mock.calls[0][0]).toHaveLength(2);
+    expect(result.total).toBe(2);
+    expect(result.errors).toEqual([]);
+    expect(result.rules).toHaveLength(2);
+  });
+
+  test('never calls task manager or generates API keys', async () => {
+    mockBulkCreateResponse([{ id: 'mock-id-1', name: 'r1' }]);
+
+    await rulesClient.bulkCreateRules({
+      rules: [{ data: baseDisabledRuleData({ name: 'r1' }) }],
+    });
+
+    expect(taskManager.bulkSchedule).not.toHaveBeenCalled();
+    expect(taskManager.schedule).not.toHaveBeenCalled();
+    expect(rulesClientParams.createAPIKey).not.toHaveBeenCalled();
+    expect(rulesClientParams.getAuthenticationAPIKey).not.toHaveBeenCalled();
+  });
+
+  test('rejects every enabled rule with a per-rule error and skips them from bulkCreate', async () => {
+    mockBulkCreateResponse([{ id: 'mock-id-1', name: 'd1' }]);
+
+    const result = await rulesClient.bulkCreateRules({
+      rules: [
+        { data: baseDisabledRuleData({ name: 'enabled-1', enabled: true }) },
+        { data: baseDisabledRuleData({ name: 'd1' }) },
+        {
+          data: baseDisabledRuleData({ name: 'enabled-2', enabled: true }),
+          options: { id: 'caller-id' },
+        },
+      ],
+    });
+
+    expect(result.total).toBe(3);
+    expect(result.errors).toHaveLength(2);
+    expect(result.errors[0]).toEqual({
+      message: ENABLED_RULE_REJECTION_MESSAGE,
+      rule: { id: 'n/a', name: 'enabled-1' },
+    });
+    expect(result.errors[1]).toEqual({
+      message: ENABLED_RULE_REJECTION_MESSAGE,
+      rule: { id: 'caller-id', name: 'enabled-2' },
+    });
+    expect(result.rules).toHaveLength(1);
+    expect(unsecuredSavedObjectsClient.bulkCreate.mock.calls[0][0]).toHaveLength(1);
+  });
+
+  test('returns no rules but every input as an error when all rules are enabled', async () => {
+    const result = await rulesClient.bulkCreateRules({
+      rules: [
+        { data: baseDisabledRuleData({ name: 'e1', enabled: true }) },
+        { data: baseDisabledRuleData({ name: 'e2', enabled: true }) },
+      ],
+    });
+
+    expect(result.total).toBe(2);
+    expect(result.errors).toHaveLength(2);
+    expect(result.rules).toHaveLength(0);
+    expect(unsecuredSavedObjectsClient.bulkCreate).not.toHaveBeenCalled();
+    expect(taskManager.bulkSchedule).not.toHaveBeenCalled();
+  });
+
+  test('per-rule prepare failure is isolated and remaining rules persist', async () => {
+    ruleTypeRegistry.get
+      .mockImplementationOnce(() => {
+        throw new Error('rule type not found');
+      })
+      .mockImplementation(() => ({
+        id: '123',
+        name: 'Test',
+        actionGroups: [{ id: 'default', name: 'Default' }],
+        recoveryActionGroup: { id: 'recovered', name: 'Recovered' },
+        defaultActionGroupId: 'default',
+        minimumLicenseRequired: 'basic',
+        isExportable: true,
+        async executor() {
+          return { state: {} };
+        },
+        category: 'test',
+        producer: 'alerts',
+        solution: 'stack',
+        validate: { params: { validate: (p: unknown) => p } },
+        validLegacyConsumers: [],
+      }));
+
+    mockBulkCreateResponse([{ id: 'mock-id-2', name: 'good' }]);
+
+    const result = await rulesClient.bulkCreateRules({
+      rules: [
+        { data: baseDisabledRuleData({ name: 'bad', alertTypeId: 'unknown' }) },
+        { data: baseDisabledRuleData({ name: 'good' }) },
+      ],
+    });
+
+    expect(result.total).toBe(2);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].rule.name).toBe('bad');
+    expect(result.rules).toHaveLength(1);
+    expect(unsecuredSavedObjectsClient.bulkCreate.mock.calls[0][0]).toHaveLength(1);
+  });
+
+  test('partial SO bulkCreate failure populates errors and returns successful rules', async () => {
+    unsecuredSavedObjectsClient.bulkCreate.mockImplementation(async (objects) => {
+      const [first, second] = objects as Array<{ id: string }>;
+      return {
+        saved_objects: [
+          {
+            id: first.id,
+            type: RULE_SAVED_OBJECT_TYPE,
+            attributes: {
+              alertTypeId: '123',
+              name: 'r1',
+              enabled: false,
+              consumer: 'bar',
+              schedule: { interval: '1m' },
+              params: { foo: true },
+              actions: [],
+              createdBy: 'elastic',
+              updatedBy: 'elastic',
+              createdAt: '2019-02-12T21:01:22.479Z',
+              updatedAt: '2019-02-12T21:01:22.479Z',
+              snoozeSchedule: [],
+              muteAll: false,
+              mutedInstanceIds: [],
+              executionStatus: {
+                status: 'pending',
+                lastExecutionDate: '2019-02-12T21:01:22.479Z',
+              },
+              revision: 0,
+              running: false,
+              apiKey: null,
+              apiKeyOwner: null,
+              apiKeyCreatedByUser: null,
+            },
+            references: [],
+          },
+          {
+            id: second.id,
+            type: RULE_SAVED_OBJECT_TYPE,
+            error: { error: 'Conflict', message: 'duplicate', statusCode: 409 },
+          },
+        ],
+      } as never;
+    });
+
+    const result = await rulesClient.bulkCreateRules({
+      rules: [
+        { data: baseDisabledRuleData({ name: 'r1' }) },
+        { data: baseDisabledRuleData({ name: 'r2' }) },
+      ],
+    });
+
+    const submittedIds = (
+      unsecuredSavedObjectsClient.bulkCreate.mock.calls[0][0] as Array<{ id: string }>
+    ).map((o) => o.id);
+
+    expect(result.total).toBe(2);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].rule.id).toBe(submittedIds[1]);
+    expect(result.errors[0].status).toBe(409);
+    expect(result.rules).toHaveLength(1);
+  });
+
+  test('whole-batch SO bulkCreate throw propagates', async () => {
+    unsecuredSavedObjectsClient.bulkCreate.mockRejectedValue(new Error('boom'));
+
+    await expect(
+      rulesClient.bulkCreateRules({
+        rules: [{ data: baseDisabledRuleData({ name: 'r1' }) }],
+      })
+    ).rejects.toThrow('boom');
+  });
+
+  test('persisted SO has no apiKey, no scheduledTaskId, and no lastEnabledAt', async () => {
+    mockBulkCreateResponse([{ id: 'mock-id-1', name: 'r1' }]);
+
+    await rulesClient.bulkCreateRules({
+      rules: [{ data: baseDisabledRuleData({ name: 'r1' }) }],
+    });
+
+    const submitted = unsecuredSavedObjectsClient.bulkCreate.mock.calls[0][0] as Array<{
+      attributes: Record<string, unknown>;
+    }>;
+    expect(submitted[0].attributes.apiKey).toBeNull();
+    expect(submitted[0].attributes.apiKeyOwner).toBeNull();
+    expect(submitted[0].attributes.apiKeyCreatedByUser).toBeNull();
+    expect(submitted[0].attributes.scheduledTaskId).toBeUndefined();
+    expect(submitted[0].attributes.lastEnabledAt).toBeUndefined();
+    expect(submitted[0].attributes.enabled).toBe(false);
+  });
+});

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/bulk_create_rules.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/bulk_create_rules.ts
@@ -39,11 +39,7 @@ import {
 import { ruleDomainSchema } from '../../schemas';
 import { createRuleDataSchema } from '../create/schemas';
 import { bulkCreateRulesSo } from '../../../../data/rule';
-import type {
-  BulkCreateRulesParams,
-  BulkCreateRulesResult,
-  BulkCreateRulesItem,
-} from './types';
+import type { BulkCreateRulesParams, BulkCreateRulesResult, BulkCreateRulesItem } from './types';
 
 export const ENABLED_RULE_REJECTION_MESSAGE =
   'bulkCreateRules only supports disabled rules; use bulkEnableRules to enable rules after creation';
@@ -158,9 +154,9 @@ export async function bulkCreateRules<Params extends RuleParams = never>(
         `Error validating bulk created rule domain object for id: ${so.id}, ${e}`
       );
     }
-    rules.push(transformRuleDomainToRule<Params>(ruleDomain, { isPublic: true }) as SanitizedRule<
-      Params
-    >);
+    rules.push(
+      transformRuleDomainToRule<Params>(ruleDomain, { isPublic: true }) as SanitizedRule<Params>
+    );
   });
 
   return { rules, errors, total };

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/bulk_create_rules.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/bulk_create_rules.ts
@@ -1,0 +1,337 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import Semver from 'semver';
+import Boom from '@hapi/boom';
+import { withSpan } from '@kbn/apm-utils';
+import type { SavedObjectReference, SavedObjectsBulkCreateObject } from '@kbn/core/server';
+import { SavedObjectsUtils } from '@kbn/core/server';
+import { validateAndAuthorizeSystemActions } from '../../../../lib/validate_authorize_system_actions';
+import { RULE_SAVED_OBJECT_TYPE } from '../../../../saved_objects';
+import { parseDuration } from '../../../../../common';
+import { WriteOperations, AlertingAuthorizationEntity } from '../../../../authorization';
+import {
+  validateRuleTypeParams,
+  getRuleNotifyWhenType,
+  getDefaultMonitoringRuleDomainProperties,
+  getRuleExecutionStatusPending,
+} from '../../../../lib';
+import {
+  extractReferences,
+  validateActions,
+  addGeneratedActionValues,
+  updateMeta,
+} from '../../../../rules_client/lib';
+import { apiKeyAsRuleDomainProperties } from '../../../../rules_client/common';
+import { ruleAuditEvent, RuleAuditAction } from '../../../../rules_client/common/audit_events';
+import type { RulesClientContext, BulkOperationError } from '../../../../rules_client/types';
+import type { RuleDomain, RuleParams } from '../../types';
+import type { RawRule, SanitizedRule } from '../../../../types';
+import {
+  transformRuleAttributesToRuleDomain,
+  transformRuleDomainToRuleAttributes,
+  transformRuleDomainToRule,
+} from '../../transforms';
+import { ruleDomainSchema } from '../../schemas';
+import { createRuleDataSchema } from '../create/schemas';
+import { bulkCreateRulesSo } from '../../../../data/rule';
+import type {
+  BulkCreateRulesParams,
+  BulkCreateRulesResult,
+  BulkCreateRulesItem,
+} from './types';
+
+export const ENABLED_RULE_REJECTION_MESSAGE =
+  'bulkCreateRules only supports disabled rules; use bulkEnableRules to enable rules after creation';
+
+interface PreparedRule {
+  ruleId: string;
+  rawRule: RawRule;
+  references: SavedObjectReference[];
+}
+
+export async function bulkCreateRules<Params extends RuleParams = never>(
+  context: RulesClientContext,
+  params: BulkCreateRulesParams<Params>
+): Promise<BulkCreateRulesResult<Params>> {
+  const { rules: inputs } = params;
+  const total = inputs.length;
+  const errors: BulkOperationError[] = [];
+
+  if (total === 0) {
+    return { rules: [], errors, total };
+  }
+
+  const username = await context.getUserName();
+  const actionsClient = await context.getActionsClient();
+
+  // Reject every input that asks for an enabled rule. Callers must follow up
+  // with bulkEnableRules to schedule a task and issue an API key.
+  const indexesToPrepare: number[] = [];
+  inputs.forEach((input, index) => {
+    if (input.data.enabled) {
+      errors.push({
+        message: ENABLED_RULE_REJECTION_MESSAGE,
+        rule: {
+          id: input.options?.id ?? 'n/a',
+          name: input.data.name,
+        },
+      });
+      return;
+    }
+    indexesToPrepare.push(index);
+  });
+
+  // Phase 1: per-rule prepare with isolated try/catch.
+  const prepareResults = await Promise.all(
+    indexesToPrepare.map((index) =>
+      prepareRule<Params>({
+        context,
+        actionsClient,
+        username,
+        input: inputs[index],
+        errors,
+      })
+    )
+  );
+
+  const preparedRules = prepareResults.filter((r): r is PreparedRule => r !== null);
+
+  if (preparedRules.length === 0) {
+    return { rules: [], errors, total };
+  }
+
+  const bulkCreateAttributes: Array<SavedObjectsBulkCreateObject<RawRule>> = preparedRules.map(
+    (prepared) => ({
+      type: RULE_SAVED_OBJECT_TYPE,
+      id: prepared.ruleId,
+      attributes: prepared.rawRule,
+      references: prepared.references,
+    })
+  );
+
+  // Phase 2: persist all rule SOs in one bulkCreate call.
+  const bulkCreateResult = await withSpan(
+    { name: 'unsecuredSavedObjectsClient.bulkCreate', type: 'rules' },
+    () =>
+      bulkCreateRulesSo({
+        savedObjectsClient: context.unsecuredSavedObjectsClient,
+        bulkCreateRuleAttributes: bulkCreateAttributes,
+      })
+  );
+
+  // Walk per-row results, separating successes and failures.
+  const rules: Array<SanitizedRule<Params>> = [];
+  bulkCreateResult.saved_objects.forEach((so, idx) => {
+    const prepared = preparedRules[idx];
+    if (so.error) {
+      errors.push({
+        message: so.error.message ?? 'n/a',
+        status: so.error.statusCode,
+        rule: {
+          id: prepared.ruleId,
+          name: prepared.rawRule.name ?? 'n/a',
+        },
+      });
+      return;
+    }
+
+    const ruleType = context.ruleTypeRegistry.get(so.attributes.alertTypeId);
+    const ruleDomain = transformRuleAttributesToRuleDomain<Params>(
+      so.attributes,
+      {
+        id: so.id,
+        logger: context.logger,
+        ruleType,
+        references: so.references,
+      },
+      (connectorId: string) => actionsClient.isSystemAction(connectorId)
+    );
+    try {
+      ruleDomainSchema.validate(ruleDomain);
+    } catch (e) {
+      context.logger.warn(
+        `Error validating bulk created rule domain object for id: ${so.id}, ${e}`
+      );
+    }
+    rules.push(transformRuleDomainToRule<Params>(ruleDomain, { isPublic: true }) as SanitizedRule<
+      Params
+    >);
+  });
+
+  return { rules, errors, total };
+}
+
+interface PrepareRuleParams<Params extends RuleParams> {
+  context: RulesClientContext;
+  actionsClient: Awaited<ReturnType<RulesClientContext['getActionsClient']>>;
+  username: string | null;
+  input: BulkCreateRulesItem<Params>;
+  errors: BulkOperationError[];
+}
+
+async function prepareRule<Params extends RuleParams>({
+  context,
+  actionsClient,
+  username,
+  input,
+  errors,
+}: PrepareRuleParams<Params>): Promise<PreparedRule | null> {
+  const { data: initialData, options, allowMissingConnectorSecrets } = input;
+  const id = options?.id || SavedObjectsUtils.generateId();
+
+  try {
+    const { actions: genAction, systemActions: genSystemActions } = await addGeneratedActionValues(
+      initialData.actions,
+      initialData.systemActions,
+      context
+    );
+    const data = {
+      ...initialData,
+      actions: genAction,
+      systemActions: genSystemActions,
+    };
+
+    try {
+      createRuleDataSchema.validate(data);
+    } catch (error) {
+      throw Boom.badRequest(`Error validating create data - ${error.message}`);
+    }
+
+    // Throws 400 if rule type unregistered.
+    context.ruleTypeRegistry.get(data.alertTypeId);
+
+    try {
+      await withSpan({ name: 'authorization.ensureAuthorized', type: 'rules' }, async () =>
+        context.authorization.ensureAuthorized({
+          ruleTypeId: data.alertTypeId,
+          consumer: data.consumer,
+          operation: WriteOperations.Create,
+          entity: AlertingAuthorizationEntity.Rule,
+        })
+      );
+    } catch (error) {
+      context.auditLogger?.log(
+        ruleAuditEvent({
+          action: RuleAuditAction.CREATE,
+          savedObject: { type: RULE_SAVED_OBJECT_TYPE, id, name: data.name },
+          error,
+        })
+      );
+      throw error;
+    }
+
+    context.ruleTypeRegistry.ensureRuleTypeEnabled(data.alertTypeId);
+    const ruleType = context.ruleTypeRegistry.get(data.alertTypeId);
+    const validatedRuleTypeParams = validateRuleTypeParams(data.params, ruleType.validate.params);
+
+    await withSpan({ name: 'validateActions', type: 'rules' }, () =>
+      validateActions(context, ruleType, data, allowMissingConnectorSecrets)
+    );
+
+    await withSpan({ name: 'validateAndAuthorizeSystemActions', type: 'rules' }, () =>
+      validateAndAuthorizeSystemActions({
+        actionsClient,
+        actionsAuthorization: context.actionsAuthorization,
+        connectorAdapterRegistry: context.connectorAdapterRegistry,
+        systemActions: data.systemActions ?? [],
+        rule: { consumer: data.consumer, producer: ruleType.producer },
+      })
+    );
+
+    const intervalInMs = parseDuration(data.schedule.interval);
+    if (
+      intervalInMs < context.minimumScheduleIntervalInMs &&
+      context.minimumScheduleInterval.enforce
+    ) {
+      throw Boom.badRequest(
+        `Error creating rule: the interval is less than the allowed minimum interval of ${context.minimumScheduleInterval.value}`
+      );
+    }
+    if (
+      intervalInMs < context.minimumScheduleIntervalInMs &&
+      !context.minimumScheduleInterval.enforce
+    ) {
+      context.logger.warn(
+        `Rule schedule interval (${data.schedule.interval}) for "${ruleType.id}" rule type with ID "${id}" is less than the minimum value (${context.minimumScheduleInterval.value}). Running rules at this interval may impact alerting performance. Set "xpack.alerting.rules.minimumScheduleInterval.enforce" to true to prevent creation of these rules.`
+      );
+    }
+
+    const allActions = [...data.actions, ...(data.systemActions ?? [])];
+    const artifacts = data.artifacts ?? {};
+    const {
+      references,
+      params: updatedParams,
+      actions: actionsWithRefs,
+      artifacts: artifactsWithRefs,
+    } = await withSpan({ name: 'extractReferences', type: 'rules' }, () =>
+      extractReferences(context, ruleType, allActions, validatedRuleTypeParams, artifacts)
+    );
+
+    const createTime = Date.now();
+    const lastRunTimestamp = new Date();
+    const legacyId = Semver.lt(context.kibanaVersion, '8.0.0') ? id : null;
+    const notifyWhen = getRuleNotifyWhenType(data.notifyWhen ?? null, data.throttle ?? null);
+    const throttle = data.throttle ?? null;
+    const { systemActions, actions: _actions, ...restData } = data;
+
+    // Disabled rules never get an API key (matches createRule behaviour).
+    const apiKeyProps = apiKeyAsRuleDomainProperties(null, username, false);
+
+    const ruleAttributes = transformRuleDomainToRuleAttributes({
+      actionsWithRefs,
+      artifactsWithRefs,
+      rule: {
+        ...restData,
+        ...apiKeyProps,
+        id,
+        createdBy: username,
+        updatedBy: username,
+        createdAt: new Date(createTime),
+        updatedAt: new Date(createTime),
+        snoozeSchedule: [],
+        muteAll: false,
+        mutedInstanceIds: [],
+        notifyWhen,
+        throttle,
+        executionStatus: getRuleExecutionStatusPending(lastRunTimestamp.toISOString()),
+        monitoring: getDefaultMonitoringRuleDomainProperties(lastRunTimestamp.toISOString()),
+        revision: 0,
+        running: false,
+      } as unknown as RuleDomain<Params>,
+      params: {
+        legacyId,
+        paramsWithRefs: updatedParams,
+      },
+    });
+
+    // Per-rule audit event matches createRuleSavedObject behaviour.
+    context.auditLogger?.log(
+      ruleAuditEvent({
+        action: RuleAuditAction.CREATE,
+        outcome: 'unknown',
+        savedObject: { type: RULE_SAVED_OBJECT_TYPE, id, name: ruleAttributes.name },
+      })
+    );
+
+    return {
+      ruleId: id,
+      rawRule: updateMeta(context, ruleAttributes),
+      references,
+    };
+  } catch (error) {
+    errors.push({
+      message: error.message,
+      status: error.output?.statusCode,
+      rule: {
+        id,
+        name: input.data.name ?? 'n/a',
+      },
+    });
+    return null;
+  }
+}

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/index.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/index.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export type {
+  BulkCreateRulesParams,
+  BulkCreateRulesResult,
+  BulkCreateRulesItem,
+} from './types';
+export { bulkCreateRules } from './bulk_create_rules';

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/index.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/index.ts
@@ -5,9 +5,5 @@
  * 2.0.
  */
 
-export type {
-  BulkCreateRulesParams,
-  BulkCreateRulesResult,
-  BulkCreateRulesItem,
-} from './types';
+export type { BulkCreateRulesParams, BulkCreateRulesResult, BulkCreateRulesItem } from './types';
 export { bulkCreateRules } from './bulk_create_rules';

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/types.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_create/types.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { SanitizedRule } from '../../../../types';
+import type { RuleParams } from '../../types';
+import type { CreateRuleData } from '../create/types';
+import type { CreateRuleOptions } from '../create/create_rule';
+import type { BulkOperationError } from '../../../../rules_client/types';
+
+export interface BulkCreateRulesItem<Params extends RuleParams = never> {
+  data: CreateRuleData<Params>;
+  options?: CreateRuleOptions;
+  allowMissingConnectorSecrets?: boolean;
+}
+
+export interface BulkCreateRulesParams<Params extends RuleParams = never> {
+  rules: Array<BulkCreateRulesItem<Params>>;
+}
+
+export interface BulkCreateRulesResult<Params extends RuleParams = never> {
+  rules: Array<SanitizedRule<Params>>;
+  errors: BulkOperationError[];
+  total: number;
+}

--- a/x-pack/platform/plugins/shared/alerting/server/index.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/index.ts
@@ -39,6 +39,11 @@ export { RULE_SAVED_OBJECT_TYPE, API_KEY_PENDING_INVALIDATION_TYPE } from './sav
 export { RuleNotifyWhen } from '../common';
 export type { AlertingServerSetup, AlertingServerStart } from './plugin';
 export type { FindResult, BulkEditOperation, BulkOperationError } from './rules_client';
+export type {
+  BulkCreateRulesItem,
+  BulkCreateRulesParams,
+  BulkCreateRulesResult,
+} from './application/rule/methods/bulk_create';
 export type { Rule } from './application/rule/types';
 export type { PublicAlert as Alert } from './alert';
 export { parseDuration, isRuleSnoozed } from './lib';

--- a/x-pack/platform/plugins/shared/alerting/server/rules_client.mock.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/rules_client.mock.ts
@@ -52,6 +52,7 @@ const createRulesClientMock = () => {
     bulkGetRules: jest.fn(),
     bulkEdit: jest.fn(),
     bulkEditRuleParamsWithReadAuth: jest.fn(),
+    bulkCreateRules: jest.fn().mockResolvedValue({ rules: [], errors: [], total: 0 }),
     bulkDeleteRules: jest.fn(),
     bulkEnableRules: jest.fn(),
     bulkDisableRules: jest.fn(),

--- a/x-pack/platform/plugins/shared/alerting/server/rules_client/rules_client.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/rules_client/rules_client.ts
@@ -60,6 +60,8 @@ import type { BulkEditRuleParamsOptions } from '../application/rule/methods/bulk
 import { bulkEditRuleParamsWithReadAuth } from '../application/rule/methods/bulk_edit_params/bulk_edit_rule_params';
 import type { BulkEnableRulesParams } from '../application/rule/methods/bulk_enable';
 import { bulkEnableRules } from '../application/rule/methods/bulk_enable';
+import type { BulkCreateRulesParams } from '../application/rule/methods/bulk_create';
+import { bulkCreateRules } from '../application/rule/methods/bulk_create';
 import { enableRule } from '../application/rule/methods/enable_rule/enable_rule';
 import { updateRuleApiKey } from '../application/rule/methods/update_api_key/update_rule_api_key';
 import { disableRule } from '../application/rule/methods/disable/disable_rule';
@@ -200,6 +202,9 @@ export class RulesClient {
 
   public bulkGetRules = <Params extends RuleTypeParams = never>(params: BulkGetRulesParams) =>
     bulkGetRules<Params>(this.context, params);
+  public bulkCreateRules = <Params extends RuleTypeParams = never>(
+    params: BulkCreateRulesParams<Params>
+  ) => bulkCreateRules<Params>(this.context, params);
   public bulkDeleteRules = (options: BulkDeleteRulesRequestBody) =>
     bulkDeleteRules(this.context, options);
   public bulkEdit = <Params extends RuleTypeParams>(options: BulkEditOptions<Params>) =>

--- a/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
@@ -23,6 +23,19 @@ export const allowedExperimentalValues = Object.freeze({
   previewTelemetryUrlEnabled: false,
 
   /**
+   * When enabled, prebuilt rule installation (POST .../prebuilt_rules/installation/_perform)
+   * and rule import (POST .../rules/_import) use the new alerting `rulesClient.bulkCreateRules`
+   * path (one `savedObjectsClient.bulkCreate` per chunk) instead of the per-rule create loop.
+   *
+   * For rules whose payload requests `enabled: true`, the bulk-create call is followed by a
+   * single `rulesClient.bulkEnableRules` call (alerting `bulkCreateRules` is disabled-only).
+   * Imports of existing rules with `overwrite=true` continue to use the per-rule update path.
+   *
+   * Default off; opt in via `xpack.securitySolution.enableExperimental: ['bulkCreateRulesEnabled']`.
+   */
+  bulkCreateRulesEnabled: false,
+
+  /**
    * Enables extended rule execution logging to Event Log. When this setting is enabled:
    * - Rules write their console error, info, debug, and trace messages to Event Log,
    *   in addition to other events they log there (status changes and execution metrics).

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/api/perform_rule_installation/perform_rule_installation_handler.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/api/perform_rule_installation/perform_rule_installation_handler.ts
@@ -20,7 +20,6 @@ import { buildSiemResponse } from '../../../routes/utils';
 import { aggregatePrebuiltRuleErrors } from '../../logic/aggregate_prebuilt_rule_errors';
 import { ensureLatestRulesPackageInstalled } from '../../logic/integrations/ensure_latest_rules_package_installed';
 import { createPrebuiltRuleAssetsClient } from '../../logic/rule_assets/prebuilt_rule_assets_client';
-import { createPrebuiltRules } from '../../logic/rule_objects/create_prebuilt_rules';
 import { createPrebuiltRuleObjectsClient } from '../../logic/rule_objects/prebuilt_rule_objects_client';
 import { performTimelinesInstallation } from '../../logic/perform_timelines_installation';
 import type { RuleSignatureId, RuleVersion } from '../../../../../../common/api/detection_engine';
@@ -115,17 +114,15 @@ export const performRuleInstallationHandler = async (
       const rulesToInstall = ruleInstallQueue.splice(0, BATCH_SIZE);
       const ruleAssets = await ruleAssetsClient.fetchAssetsByVersion(rulesToInstall);
 
-      const { results, errors } = await createPrebuiltRules(
-        detectionRulesClient,
-        ruleAssets,
-        logger
+      const { results, errors } = await detectionRulesClient.bulkCreatePrebuiltRules({
+        rules: ruleAssets,
+      });
+      logger.debug(
+        `performRuleInstallation: installing batch of prebuilt rules - done. Rules created: ${results.length}. Rules failed to create: ${errors.length}`
       );
-
-      const batchInstalledRules = results.map(({ result: rule }) =>
-        pick(rule, ['id', 'rule_id', 'version'])
+      installedRules.push(
+        ...results.map(({ result: rule }) => pick(rule, ['id', 'rule_id', 'version']))
       );
-
-      installedRules.push(...batchInstalledRules);
       ruleErrors.push(...errors);
     }
 

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/api/perform_rule_installation/perform_rule_installation_handler.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/api/perform_rule_installation/perform_rule_installation_handler.ts
@@ -20,6 +20,7 @@ import { buildSiemResponse } from '../../../routes/utils';
 import { aggregatePrebuiltRuleErrors } from '../../logic/aggregate_prebuilt_rule_errors';
 import { ensureLatestRulesPackageInstalled } from '../../logic/integrations/ensure_latest_rules_package_installed';
 import { createPrebuiltRuleAssetsClient } from '../../logic/rule_assets/prebuilt_rule_assets_client';
+import { createPrebuiltRules } from '../../logic/rule_objects/create_prebuilt_rules';
 import { createPrebuiltRuleObjectsClient } from '../../logic/rule_objects/prebuilt_rule_objects_client';
 import { performTimelinesInstallation } from '../../logic/perform_timelines_installation';
 import type { RuleSignatureId, RuleVersion } from '../../../../../../common/api/detection_engine';
@@ -42,6 +43,7 @@ export const performRuleInstallationHandler = async (
     const ruleObjectsClient = createPrebuiltRuleObjectsClient(rulesClient);
     const exceptionsListClient = ctx.securitySolution.getExceptionListClient();
     const mlAuthz = ctx.securitySolution.getMlAuthz();
+    const { experimentalFeatures } = ctx.securitySolution.getConfig();
 
     const { mode } = request.body;
 
@@ -114,9 +116,10 @@ export const performRuleInstallationHandler = async (
       const rulesToInstall = ruleInstallQueue.splice(0, BATCH_SIZE);
       const ruleAssets = await ruleAssetsClient.fetchAssetsByVersion(rulesToInstall);
 
-      const { results, errors } = await detectionRulesClient.bulkCreatePrebuiltRules({
-        rules: ruleAssets,
-      });
+      const { results, errors } = experimentalFeatures.bulkCreateRulesEnabled
+        ? await detectionRulesClient.bulkCreatePrebuiltRules({ rules: ruleAssets })
+        : await createPrebuiltRules(detectionRulesClient, ruleAssets, logger);
+
       logger.debug(
         `performRuleInstallation: installing batch of prebuilt rules - done. Rules created: ${results.length}. Rules failed to create: ${errors.length}`
       );

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/import_rules/route.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/import_rules/route.ts
@@ -195,6 +195,7 @@ export const importRulesRoute = (
             allowMissingConnectorSecrets: !!actionConnectors.length,
             ruleSourceImporter,
             detectionRulesClient,
+            bulkCreate: config.experimentalFeatures.bulkCreateRulesEnabled,
           });
 
           const parseErrors = parsedRuleErrors.map((error) =>

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/__mocks__/detection_rules_client.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/__mocks__/detection_rules_client.ts
@@ -13,6 +13,7 @@ const createDetectionRulesClientMock = () => {
   const mocked: DetectionRulesClientMock = {
     createCustomRule: jest.fn(),
     createPrebuiltRule: jest.fn(),
+    bulkCreatePrebuiltRules: jest.fn().mockResolvedValue({ results: [], errors: [] }),
     updateRule: jest.fn(),
     patchRule: jest.fn(),
     deleteRule: jest.fn(),

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/__mocks__/detection_rules_client.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/__mocks__/detection_rules_client.ts
@@ -22,6 +22,7 @@ const createDetectionRulesClientMock = () => {
     revertPrebuiltRule: jest.fn(),
     importRule: jest.fn(),
     importRules: jest.fn(),
+    bulkImportRules: jest.fn().mockResolvedValue([]),
     getRuleCustomizationStatus: jest.fn(),
   };
   return mocked;

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/detection_rules_client.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/detection_rules_client.ts
@@ -19,6 +19,7 @@ import type { ProductFeaturesService } from '../../../../product_features_servic
 import { createPrebuiltRuleAssetsClient } from '../../../prebuilt_rules/logic/rule_assets/prebuilt_rule_assets_client';
 import type { RuleImportErrorObject } from '../import/errors';
 import type {
+  BulkCreatePrebuiltRulesArgs,
   BulkDeleteRulesArgs,
   BulkDeleteRulesReturn,
   CreateCustomRuleArgs,
@@ -33,6 +34,7 @@ import type {
   UpgradePrebuiltRuleArgs,
 } from './detection_rules_client_interface';
 import { createRule } from './methods/create_rule';
+import { bulkCreateRules } from './methods/bulk_create_rules';
 import { bulkDeleteRules } from './methods/bulk_delete_rules';
 import { deleteRule } from './methods/delete_rule';
 import { importRule } from './methods/import_rule';
@@ -111,6 +113,20 @@ export const createDetectionRulesClient = ({
             immutable: true,
           },
           mlAuthz,
+        });
+      });
+    },
+
+    async bulkCreatePrebuiltRules({ rules }: BulkCreatePrebuiltRulesArgs) {
+      return withSecuritySpan('DetectionRulesClient.bulkCreatePrebuiltRules', async () => {
+        return bulkCreateRules({
+          actionsClient,
+          rulesClient,
+          mlAuthz,
+          rules: rules.map((asset) => ({
+            rule: { ...asset, immutable: true },
+            source: asset,
+          })),
         });
       });
     },

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/detection_rules_client.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/detection_rules_client.ts
@@ -36,6 +36,7 @@ import type {
 import { createRule } from './methods/create_rule';
 import { bulkCreateRules } from './methods/bulk_create_rules';
 import { bulkDeleteRules } from './methods/bulk_delete_rules';
+import { bulkImportRules } from './methods/bulk_import_rules';
 import { deleteRule } from './methods/delete_rule';
 import { importRule } from './methods/import_rule';
 import { importRules } from './methods/import_rules';
@@ -214,6 +215,21 @@ export const createDetectionRulesClient = ({
         return importRules({
           ...args,
           detectionRulesClient: this,
+          savedObjectsClient,
+        });
+      });
+    },
+
+    async bulkImportRules(
+      args: ImportRulesArgs
+    ): Promise<Array<RuleResponse | RuleImportErrorObject>> {
+      return withSecuritySpan('DetectionRulesClient.bulkImportRules', async () => {
+        return bulkImportRules({
+          ...args,
+          actionsClient,
+          rulesClient,
+          detectionRulesClient: this,
+          mlAuthz,
           savedObjectsClient,
         });
       });

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/detection_rules_client_interface.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/detection_rules_client_interface.ts
@@ -20,11 +20,15 @@ import type { RuleImportErrorObject } from '../import/errors';
 import type { PrebuiltRuleAsset } from '../../../prebuilt_rules';
 import type { PrebuiltRulesCustomizationStatus } from '../../../../../../common/detection_engine/prebuilt_rules/prebuilt_rule_customization_status';
 import type { RuleAlertType } from '../../../rule_schema';
+import type { BulkCreateRulesResult } from './methods/bulk_create_rules';
 
 export interface IDetectionRulesClient {
   getRuleCustomizationStatus: () => PrebuiltRulesCustomizationStatus;
   createCustomRule: (args: CreateCustomRuleArgs) => Promise<RuleResponse>;
   createPrebuiltRule: (args: CreatePrebuiltRuleArgs) => Promise<RuleResponse>;
+  bulkCreatePrebuiltRules: (
+    args: BulkCreatePrebuiltRulesArgs
+  ) => Promise<BulkCreateRulesResult<PrebuiltRuleAsset>>;
   updateRule: (args: UpdateRuleArgs) => Promise<RuleResponse>;
   patchRule: (args: PatchRuleArgs) => Promise<RuleResponse>;
   deleteRule: (args: DeleteRuleArgs) => Promise<void>;
@@ -41,6 +45,10 @@ export interface CreateCustomRuleArgs {
 
 export interface CreatePrebuiltRuleArgs {
   params: RuleCreateProps;
+}
+
+export interface BulkCreatePrebuiltRulesArgs {
+  rules: PrebuiltRuleAsset[];
 }
 
 export interface UpdateRuleArgs {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/detection_rules_client_interface.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/detection_rules_client_interface.ts
@@ -37,6 +37,7 @@ export interface IDetectionRulesClient {
   revertPrebuiltRule: (args: RevertPrebuiltRuleArgs) => Promise<RuleResponse>;
   importRule: (args: ImportRuleArgs) => Promise<RuleResponse>;
   importRules: (args: ImportRulesArgs) => Promise<Array<RuleResponse | RuleImportErrorObject>>;
+  bulkImportRules: (args: ImportRulesArgs) => Promise<Array<RuleResponse | RuleImportErrorObject>>;
 }
 
 export interface CreateCustomRuleArgs {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/methods/bulk_create_rules.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/methods/bulk_create_rules.ts
@@ -1,0 +1,140 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { v4 as uuidv4 } from 'uuid';
+import type { ActionsClient } from '@kbn/actions-plugin/server';
+import type { BulkCreateRulesItem, RulesClient } from '@kbn/alerting-plugin/server';
+import { ruleTypeMappings } from '@kbn/securitysolution-rules';
+import { SERVER_APP_ID } from '../../../../../../../common';
+import type {
+  RuleCreateProps,
+  RuleResponse,
+} from '../../../../../../../common/api/detection_engine/model/rule_schema';
+import type { MlAuthz } from '../../../../../machine_learning/authz';
+import type { RuleParams } from '../../../../rule_schema';
+import { convertAlertingRuleToRuleResponse } from '../converters/convert_alerting_rule_to_rule_response';
+import { convertRuleResponseToAlertingRule } from '../converters/convert_rule_response_to_alerting_rule';
+import { applyRuleDefaults } from '../mergers/apply_rule_defaults';
+import { validateMlAuth } from '../utils';
+
+export interface BulkCreateRuleItem<TSource = unknown> {
+  rule: RuleCreateProps & { immutable: boolean };
+  allowMissingConnectorSecrets?: boolean;
+  /**
+   * Caller-provided value preserved verbatim and returned alongside the
+   * resulting `RuleResponse` (or per-rule error). Lets wrappers like
+   * `bulkCreatePrebuiltRules` re-pair outputs with their original input
+   * payload (e.g. a `PrebuiltRuleAsset`) without having to re-key by
+   * `rule_id` afterwards.
+   */
+  source: TSource;
+}
+
+export interface BulkCreateRulesResult<TSource = unknown> {
+  results: Array<{ item: TSource; result: RuleResponse }>;
+  errors: Array<{ item: TSource; error: Error & { statusCode?: number } }>;
+}
+
+interface BulkCreateRulesOptions<TSource> {
+  actionsClient: ActionsClient;
+  rulesClient: RulesClient;
+  mlAuthz: MlAuthz;
+  rules: Array<BulkCreateRuleItem<TSource>>;
+}
+
+/**
+ * Bulk-creates detection rules through a single alerting `bulkCreateRules`
+ * round-trip instead of issuing one Elasticsearch write per rule.
+ *
+ * Per-rule failures (ML auth, alerting validation, SO row errors) are
+ * isolated and returned via `errors` so callers can keep the partial
+ * successes from `results`.
+ *
+ * Note: the alerting bulk create method only accepts disabled rules. Callers
+ * should follow up with `bulkEnableRules` if rules need to be enabled.
+ */
+export const bulkCreateRules = async <TSource>({
+  actionsClient,
+  rulesClient,
+  mlAuthz,
+  rules: items,
+}: BulkCreateRulesOptions<TSource>): Promise<BulkCreateRulesResult<TSource>> => {
+  const results: BulkCreateRulesResult<TSource>['results'] = [];
+  const errors: BulkCreateRulesResult<TSource>['errors'] = [];
+
+  if (items.length === 0) {
+    return { results, errors };
+  }
+
+  // Pre-assign a SO id per input so we can map alerting's per-rule
+  // results/errors (keyed by rule.id) back to the original input source.
+  const idToSource = new Map<string, TSource>();
+  const bulkInputs: Array<BulkCreateRulesItem<RuleParams>> = [];
+
+  for (const item of items) {
+    try {
+      await validateMlAuth(mlAuthz, item.rule.type);
+
+      const ruleWithDefaults = applyRuleDefaults(item.rule);
+      const id = uuidv4();
+      idToSource.set(id, item.source);
+
+      bulkInputs.push({
+        data: {
+          ...convertRuleResponseToAlertingRule(ruleWithDefaults, actionsClient),
+          alertTypeId: ruleTypeMappings[item.rule.type],
+          consumer: SERVER_APP_ID,
+          // The alerting bulk create rejects enabled rules; force-disable here
+          // so the wrapper has a consistent contract with the underlying method.
+          enabled: false,
+        },
+        options: { id },
+        allowMissingConnectorSecrets: item.allowMissingConnectorSecrets,
+      });
+    } catch (error) {
+      errors.push({ item: item.source, error: toError(error) });
+    }
+  }
+
+  if (bulkInputs.length === 0) {
+    return { results, errors };
+  }
+
+  const bulkResult = await rulesClient.bulkCreateRules<RuleParams>({
+    rules: bulkInputs,
+  });
+
+  for (const rule of bulkResult.rules) {
+    if (idToSource.has(rule.id)) {
+      const item = idToSource.get(rule.id) as TSource;
+      try {
+        results.push({ item, result: convertAlertingRuleToRuleResponse(rule) });
+      } catch (error) {
+        errors.push({ item, error: toError(error) });
+      }
+    }
+  }
+
+  for (const failure of bulkResult.errors) {
+    if (idToSource.has(failure.rule.id)) {
+      const item = idToSource.get(failure.rule.id) as TSource;
+      const error = Object.assign(new Error(failure.message ?? 'Failed to create rule'), {
+        statusCode: failure.status,
+      });
+      errors.push({ item, error });
+    }
+  }
+
+  return { results, errors };
+};
+
+const toError = (err: unknown): Error & { statusCode?: number } => {
+  if (err instanceof Error) {
+    return err;
+  }
+  return new Error(typeof err === 'string' ? err : JSON.stringify(err));
+};

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/methods/bulk_import_rules.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/methods/bulk_import_rules.test.ts
@@ -1,0 +1,360 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { rulesClientMock } from '@kbn/alerting-plugin/server/mocks';
+import { actionsClientMock } from '@kbn/actions-plugin/server/actions_client/actions_client.mock';
+import { savedObjectsClientMock } from '@kbn/core/server/mocks';
+
+import { buildMlAuthz } from '../../../../../machine_learning/__mocks__/authz';
+import { getImportRulesSchemaMock } from '../../../../../../../common/api/detection_engine/rule_management/mocks';
+import { getRulesSchemaMock } from '../../../../../../../common/api/detection_engine/model/rule_schema/mocks';
+import { ruleSourceImporterMock } from '../../import/rule_source_importer/rule_source_importer.mock';
+import { findRules } from '../../search/find_rules';
+import { checkRuleExceptionReferences } from '../../import/check_rule_exception_references';
+import { createRuleImportErrorObject } from '../../import/errors';
+import { convertAlertingRuleToRuleResponse } from '../converters/convert_alerting_rule_to_rule_response';
+import { convertRuleResponseToAlertingRule } from '../converters/convert_rule_response_to_alerting_rule';
+import { applyRuleDefaults } from '../mergers/apply_rule_defaults';
+import { detectionRulesClientMock } from '../__mocks__/detection_rules_client';
+import { bulkImportRules } from './bulk_import_rules';
+
+jest.mock('../../search/find_rules');
+jest.mock('../../import/check_rule_exception_references');
+jest.mock('../../import/gather_referenced_exceptions', () => ({
+  getReferencedExceptionLists: jest.fn().mockResolvedValue([]),
+}));
+jest.mock('../converters/convert_alerting_rule_to_rule_response');
+jest.mock('../converters/convert_rule_response_to_alerting_rule');
+jest.mock('../mergers/apply_rule_defaults');
+
+const mockFindRulesEmpty = () => {
+  (findRules as jest.Mock).mockResolvedValue({ data: [], total: 0, page: 1, perPage: 0 });
+};
+
+describe('bulkImportRules', () => {
+  let rulesClient: ReturnType<typeof rulesClientMock.create>;
+  let actionsClient: ReturnType<typeof actionsClientMock.create>;
+  let savedObjectsClient: ReturnType<typeof savedObjectsClientMock.create>;
+  let detectionRulesClient: ReturnType<typeof detectionRulesClientMock.create>;
+  let mockRuleSourceImporter: ReturnType<typeof ruleSourceImporterMock.create>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    rulesClient = rulesClientMock.create();
+    actionsClient = actionsClientMock.create();
+    savedObjectsClient = savedObjectsClientMock.create();
+    detectionRulesClient = detectionRulesClientMock.create();
+    mockRuleSourceImporter = ruleSourceImporterMock.create();
+
+    mockRuleSourceImporter.calculateRuleSource.mockReturnValue({
+      ruleSource: { type: 'internal' },
+      immutable: false,
+    });
+    mockRuleSourceImporter.isPrebuiltRule.mockReturnValue(false);
+
+    (checkRuleExceptionReferences as jest.Mock).mockReturnValue([[], []]);
+    (applyRuleDefaults as jest.Mock).mockImplementation((rule) => rule);
+    (convertRuleResponseToAlertingRule as jest.Mock).mockImplementation((rule) => ({
+      name: rule.name,
+      tags: rule.tags ?? [],
+      params: { ruleId: rule.rule_id },
+      schedule: { interval: '5m' },
+      actions: [],
+      systemActions: [],
+    }));
+    // Default: identity-ish converter that surfaces rule_id from the alerting
+    // rule's params so we can re-pair without depending on the real converter.
+    (convertAlertingRuleToRuleResponse as jest.Mock).mockImplementation((rule) => ({
+      ...getRulesSchemaMock(),
+      id: rule.id,
+      rule_id: rule.params?.ruleId ?? rule.rule_id ?? 'mock-rule-id',
+      enabled: rule.enabled ?? false,
+    }));
+    mockFindRulesEmpty();
+
+    rulesClient.bulkCreateRules.mockResolvedValue({ rules: [], errors: [], total: 0 });
+    rulesClient.bulkEnableRules.mockResolvedValue({
+      rules: [],
+      errors: [],
+      total: 0,
+      taskIdsFailedToBeEnabled: [],
+    });
+  });
+
+  const callBulkImport = (overrides: Record<string, unknown> = {}) => {
+    return bulkImportRules({
+      actionsClient,
+      rulesClient,
+      detectionRulesClient,
+      mlAuthz: buildMlAuthz(),
+      savedObjectsClient,
+      rules: [getImportRulesSchemaMock()],
+      overwriteRules: false,
+      ruleSourceImporter: mockRuleSourceImporter,
+      allowMissingConnectorSecrets: false,
+      ...overrides,
+    });
+  };
+
+  it('returns an empty result for an empty input', async () => {
+    const result = await bulkImportRules({
+      actionsClient,
+      rulesClient,
+      detectionRulesClient,
+      mlAuthz: buildMlAuthz(),
+      savedObjectsClient,
+      rules: [],
+      overwriteRules: false,
+      ruleSourceImporter: mockRuleSourceImporter,
+    });
+
+    expect(result).toEqual([]);
+    expect(rulesClient.bulkCreateRules).not.toHaveBeenCalled();
+    expect(rulesClient.bulkEnableRules).not.toHaveBeenCalled();
+  });
+
+  it('issues a single bulkCreateRules call for new disabled rules and skips bulkEnableRules', async () => {
+    rulesClient.bulkCreateRules.mockImplementation(async ({ rules: bulkInputs }) => ({
+      rules: bulkInputs.map(
+        (input) =>
+          ({
+            id: input.options!.id,
+            params: { ruleId: 'r-1' },
+            enabled: false,
+          } as never)
+      ),
+      errors: [],
+      total: bulkInputs.length,
+    }));
+
+    const result = await callBulkImport({
+      rules: [getImportRulesSchemaMock({ rule_id: 'r-1', enabled: false })],
+    });
+
+    expect(rulesClient.bulkCreateRules).toHaveBeenCalledTimes(1);
+    expect(rulesClient.bulkCreateRules).toHaveBeenCalledWith(
+      expect.objectContaining({
+        rules: expect.arrayContaining([
+          expect.objectContaining({
+            data: expect.objectContaining({ enabled: false }),
+            options: expect.objectContaining({ id: expect.any(String) }),
+          }),
+        ]),
+      })
+    );
+    expect(rulesClient.bulkEnableRules).not.toHaveBeenCalled();
+    expect(result).toHaveLength(1);
+  });
+
+  it('force-disables enabled imports and follows up with bulkEnableRules for those ids', async () => {
+    const enabledImport = getImportRulesSchemaMock({ rule_id: 'r-enabled', enabled: true });
+    const disabledImport = getImportRulesSchemaMock({ rule_id: 'r-disabled', enabled: false });
+
+    let capturedIds: string[] = [];
+    rulesClient.bulkCreateRules.mockImplementation(async ({ rules: bulkInputs }) => {
+      capturedIds = bulkInputs.map((input) => input.options!.id!);
+      return {
+        rules: bulkInputs.map(
+          (input, idx) =>
+            ({
+              id: input.options!.id,
+              params: { ruleId: idx === 0 ? 'r-enabled' : 'r-disabled' },
+              enabled: false,
+            } as never)
+        ),
+        errors: [],
+        total: bulkInputs.length,
+      };
+    });
+
+    await callBulkImport({ rules: [enabledImport, disabledImport] });
+
+    expect(rulesClient.bulkCreateRules).toHaveBeenCalledTimes(1);
+    const sentRules = rulesClient.bulkCreateRules.mock.calls[0][0].rules;
+    expect(sentRules.every((r) => r.data.enabled === false)).toBe(true);
+
+    expect(rulesClient.bulkEnableRules).toHaveBeenCalledTimes(1);
+    expect(rulesClient.bulkEnableRules).toHaveBeenCalledWith({ ids: [capturedIds[0]] });
+  });
+
+  it('returns conflict errors for existing rule_ids when overwriteRules is false', async () => {
+    (findRules as jest.Mock).mockResolvedValueOnce({
+      total: 1,
+      page: 1,
+      perPage: 1,
+      data: [{ id: 'existing-so', params: { ruleId: 'r-1' } } as never],
+    });
+
+    const result = await callBulkImport({
+      rules: [getImportRulesSchemaMock({ rule_id: 'r-1' })],
+    });
+
+    expect(rulesClient.bulkCreateRules).not.toHaveBeenCalled();
+    expect(result).toEqual([
+      expect.objectContaining({
+        error: expect.objectContaining({ type: 'conflict', ruleId: 'r-1' }),
+      }),
+    ]);
+  });
+
+  it('routes existing rules through detectionRulesClient.importRule when overwriteRules is true', async () => {
+    (findRules as jest.Mock).mockResolvedValueOnce({
+      total: 1,
+      page: 1,
+      perPage: 1,
+      data: [{ id: 'existing-so', params: { ruleId: 'r-1' } } as never],
+    });
+    detectionRulesClient.importRule.mockResolvedValueOnce(getRulesSchemaMock());
+
+    const result = await callBulkImport({
+      rules: [getImportRulesSchemaMock({ rule_id: 'r-1' })],
+      overwriteRules: true,
+    });
+
+    expect(detectionRulesClient.importRule).toHaveBeenCalledTimes(1);
+    expect(rulesClient.bulkCreateRules).not.toHaveBeenCalled();
+    expect(result).toHaveLength(1);
+  });
+
+  it('attributes per-row bulkCreate failures to the originating rule_id', async () => {
+    let capturedSoId = '';
+    rulesClient.bulkCreateRules.mockImplementation(async ({ rules: bulkInputs }) => {
+      capturedSoId = bulkInputs[0].options!.id!;
+      return {
+        rules: [],
+        errors: [
+          {
+            message: 'version conflict',
+            status: 409,
+            rule: { id: capturedSoId, name: bulkInputs[0].data.name },
+          },
+        ],
+        total: 1,
+      };
+    });
+
+    const result = await callBulkImport({
+      rules: [getImportRulesSchemaMock({ rule_id: 'r-conflict' })],
+    });
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        error: expect.objectContaining({ ruleId: 'r-conflict', message: 'version conflict' }),
+      }),
+    ]);
+  });
+
+  it('reports bulkEnableRules errors per-rule without unwinding the create', async () => {
+    rulesClient.bulkCreateRules.mockImplementation(async ({ rules: bulkInputs }) => ({
+      rules: bulkInputs.map(
+        (input) =>
+          ({
+            id: input.options!.id,
+            params: { ruleId: 'r-enabled' },
+            enabled: false,
+          } as never)
+      ),
+      errors: [],
+      total: bulkInputs.length,
+    }));
+    rulesClient.bulkEnableRules.mockImplementation(async ({ ids }) => ({
+      rules: [],
+      errors: [
+        {
+          message: 'enable failed',
+          rule: { id: ids![0], name: 'mock' },
+        },
+      ],
+      total: 1,
+      taskIdsFailedToBeEnabled: [],
+    }));
+
+    const result = await callBulkImport({
+      rules: [getImportRulesSchemaMock({ rule_id: 'r-enabled', enabled: true })],
+    });
+
+    expect(result).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ rule_id: 'r-enabled' }),
+        expect.objectContaining({
+          error: expect.objectContaining({
+            ruleId: 'r-enabled',
+            message: expect.stringContaining('Rule was created but failed to enable'),
+          }),
+        }),
+      ])
+    );
+  });
+
+  it('emits an exception-list error alongside the successful create', async () => {
+    (checkRuleExceptionReferences as jest.Mock)
+      .mockReset()
+      .mockReturnValue([
+        [createRuleImportErrorObject({ ruleId: 'r-with-exception', message: 'list missing' })],
+        [],
+      ]);
+    rulesClient.bulkCreateRules.mockImplementation(async ({ rules: bulkInputs }) => ({
+      rules: bulkInputs.map(
+        (input) =>
+          ({
+            id: input.options!.id,
+            params: { ruleId: 'r-with-exception' },
+            enabled: false,
+          } as never)
+      ),
+      errors: [],
+      total: bulkInputs.length,
+    }));
+
+    const result = await callBulkImport({
+      rules: [getImportRulesSchemaMock({ rule_id: 'r-with-exception' })],
+    });
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        error: expect.objectContaining({ message: 'list missing' }),
+      }),
+      expect.objectContaining({ rule_id: 'r-with-exception' }),
+    ]);
+  });
+
+  it('builds the bulk-lookup KQL filter on params.ruleId and escapes special characters', async () => {
+    await callBulkImport({
+      rules: [
+        getImportRulesSchemaMock({ rule_id: 'simple-id' }),
+        getImportRulesSchemaMock({ rule_id: 'has"quote' }),
+        getImportRulesSchemaMock({ rule_id: 'has\\backslash' }),
+      ],
+    });
+
+    expect(findRules).toHaveBeenCalledTimes(1);
+    const callArgs = (findRules as jest.Mock).mock.calls[0][0];
+    expect(callArgs.filter).toBe(
+      'alert.attributes.params.ruleId: ("simple-id" OR "has\\"quote" OR "has\\\\backslash")'
+    );
+    expect(callArgs.perPage).toBe(3);
+  });
+
+  it('surfaces a ruleToImportHasVersion failure as a per-rule fatal error without writing', async () => {
+    mockRuleSourceImporter.isPrebuiltRule.mockReturnValue(true);
+
+    const result = await callBulkImport({
+      rules: [getImportRulesSchemaMock({ rule_id: 'r-no-version', version: undefined })],
+    });
+
+    expect(rulesClient.bulkCreateRules).not.toHaveBeenCalled();
+    expect(result).toEqual([
+      expect.objectContaining({
+        error: expect.objectContaining({
+          ruleId: 'r-no-version',
+          message: expect.stringContaining('Prebuilt rules must specify a "version"'),
+        }),
+      }),
+    ]);
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/methods/bulk_import_rules.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/methods/bulk_import_rules.ts
@@ -1,0 +1,493 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+import { v4 as uuidv4 } from 'uuid';
+import type { SavedObjectsClientContract } from '@kbn/core/server';
+import type { ActionsClient } from '@kbn/actions-plugin/server';
+import type {
+  BulkCreateRulesItem,
+  BulkCreateRulesResult,
+  RulesClient,
+} from '@kbn/alerting-plugin/server';
+import { ruleTypeMappings } from '@kbn/securitysolution-rules';
+
+import { SERVER_APP_ID } from '../../../../../../../common';
+import type { RuleResponse, RuleToImport } from '../../../../../../../common/api/detection_engine';
+import { ruleToImportHasVersion } from '../../../../../../../common/api/detection_engine/rule_management';
+import type { MlAuthz } from '../../../../../machine_learning/authz';
+import type { RuleParams } from '../../../../rule_schema';
+import { findRules } from '../../search/find_rules';
+import {
+  type RuleImportErrorObject,
+  createRuleImportErrorObject,
+  isRuleImportError,
+} from '../../import/errors';
+import { checkRuleExceptionReferences } from '../../import/check_rule_exception_references';
+import { getReferencedExceptionLists } from '../../import/gather_referenced_exceptions';
+import type { IRuleSourceImporter } from '../../import/rule_source_importer';
+import { convertAlertingRuleToRuleResponse } from '../converters/convert_alerting_rule_to_rule_response';
+import { convertRuleResponseToAlertingRule } from '../converters/convert_rule_response_to_alerting_rule';
+import { applyRuleDefaults } from '../mergers/apply_rule_defaults';
+import { validateMlAuth } from '../utils';
+import type { IDetectionRulesClient } from '../detection_rules_client_interface';
+
+interface BulkImportRulesOptions {
+  actionsClient: ActionsClient;
+  rulesClient: RulesClient;
+  detectionRulesClient: IDetectionRulesClient;
+  mlAuthz: MlAuthz;
+  savedObjectsClient: SavedObjectsClientContract;
+  rules: RuleToImport[];
+  overwriteRules: boolean;
+  ruleSourceImporter: IRuleSourceImporter;
+  allowMissingConnectorSecrets?: boolean;
+}
+
+interface PreparedItem {
+  rule: RuleToImport & { exceptions_list: RuleToImport['exceptions_list'] };
+  immutable: boolean;
+  ruleSource: ReturnType<IRuleSourceImporter['calculateRuleSource']>['ruleSource'];
+  nonFatalErrors: RuleImportErrorObject[];
+}
+
+interface ClassifiedItems {
+  overwriteItems: PreparedItem[];
+  newItems: PreparedItem[];
+  conflictErrors: RuleImportErrorObject[];
+}
+
+/**
+ * Bulk variant of `methods/import_rules.ts`.
+ *
+ * Trades N per-rule SO writes for a single `rulesClient.bulkCreateRules` round-trip
+ * for the new-rule case, with one optional follow-up `rulesClient.bulkEnableRules`
+ * for any imports the user wanted enabled.
+ *
+ * Conflict detection (rule_id already exists) is also bulked: a single `findRules`
+ * call per chunk classifies inputs into existing-vs-new before the create.
+ *
+ * Overwrite of existing rules (`overwriteRules: true` + rule already present) still
+ * goes through the per-rule update path (`detectionRulesClient.importRule`), since
+ * the alerting plugin does not expose a `bulkUpdateRules` primitive.
+ */
+export const bulkImportRules = async ({
+  actionsClient,
+  rulesClient,
+  detectionRulesClient,
+  mlAuthz,
+  savedObjectsClient,
+  rules,
+  overwriteRules,
+  ruleSourceImporter,
+  allowMissingConnectorSecrets,
+}: BulkImportRulesOptions): Promise<Array<RuleResponse | RuleImportErrorObject>> => {
+  if (rules.length === 0) {
+    return [];
+  }
+
+  const existingLists = await getReferencedExceptionLists({ rules, savedObjectsClient });
+  await ruleSourceImporter.setup(rules);
+
+  const { preparedItems, fatalErrors } = await prepareItems({
+    rules,
+    existingLists,
+    ruleSourceImporter,
+    mlAuthz,
+  });
+
+  if (preparedItems.length === 0) {
+    return fatalErrors;
+  }
+
+  const ruleIds = preparedItems.map((item) => item.rule.rule_id);
+  const existingByRuleId = await findExistingRulesByRuleId(rulesClient, ruleIds);
+  const { overwriteItems, newItems, conflictErrors } = classifyItems(
+    preparedItems,
+    existingByRuleId,
+    overwriteRules
+  );
+
+  const overwriteResults = await runOverwrites({
+    overwriteItems,
+    detectionRulesClient,
+    overwriteRules,
+    allowMissingConnectorSecrets,
+  });
+
+  const { results: newResults, fatalErrors: newFatalErrors } = await runBulkCreate({
+    newItems,
+    actionsClient,
+    rulesClient,
+    allowMissingConnectorSecrets,
+  });
+
+  return [
+    ...fatalErrors,
+    ...newFatalErrors,
+    ...conflictErrors,
+    ...overwriteResults.flat(),
+    ...newResults,
+  ];
+};
+
+const prepareItems = async ({
+  rules,
+  existingLists,
+  ruleSourceImporter,
+  mlAuthz,
+}: {
+  rules: RuleToImport[];
+  existingLists: Awaited<ReturnType<typeof getReferencedExceptionLists>>;
+  ruleSourceImporter: IRuleSourceImporter;
+  mlAuthz: MlAuthz;
+}): Promise<{ preparedItems: PreparedItem[]; fatalErrors: RuleImportErrorObject[] }> => {
+  const preparedItems: PreparedItem[] = [];
+  const fatalErrors: RuleImportErrorObject[] = [];
+
+  for (const rule of rules) {
+    const result = await prepareSingleItem({ rule, existingLists, ruleSourceImporter, mlAuthz });
+    if ('item' in result) {
+      preparedItems.push(result.item);
+    } else {
+      fatalErrors.push(result.error);
+    }
+  }
+
+  return { preparedItems, fatalErrors };
+};
+
+const prepareSingleItem = async ({
+  rule,
+  existingLists,
+  ruleSourceImporter,
+  mlAuthz,
+}: {
+  rule: RuleToImport;
+  existingLists: Awaited<ReturnType<typeof getReferencedExceptionLists>>;
+  ruleSourceImporter: IRuleSourceImporter;
+  mlAuthz: MlAuthz;
+}): Promise<{ item: PreparedItem } | { error: RuleImportErrorObject }> => {
+  try {
+    if (!ruleSourceImporter.isPrebuiltRule(rule)) {
+      rule.version = rule.version ?? 1;
+    }
+
+    if (!ruleToImportHasVersion(rule)) {
+      return { error: missingVersionError(rule.rule_id) };
+    }
+
+    await validateMlAuth(mlAuthz, rule.type);
+
+    const [exceptionErrors, exceptions] = checkRuleExceptionReferences({ rule, existingLists });
+    const { immutable, ruleSource } = ruleSourceImporter.calculateRuleSource(rule);
+
+    return {
+      item: {
+        rule: { ...rule, exceptions_list: [...exceptions] },
+        immutable,
+        ruleSource,
+        nonFatalErrors: exceptionErrors,
+      },
+    };
+  } catch (err) {
+    return { error: toImportError(err, rule.rule_id) };
+  }
+};
+
+const classifyItems = (
+  preparedItems: PreparedItem[],
+  existingByRuleId: Map<string, RuleResponse>,
+  overwriteRules: boolean
+): ClassifiedItems => {
+  const overwriteItems: PreparedItem[] = [];
+  const newItems: PreparedItem[] = [];
+  const conflictErrors: RuleImportErrorObject[] = [];
+
+  for (const item of preparedItems) {
+    const existing = existingByRuleId.get(item.rule.rule_id);
+    if (!existing) {
+      newItems.push(item);
+    } else if (overwriteRules) {
+      overwriteItems.push(item);
+    } else {
+      conflictErrors.push(
+        createRuleImportErrorObject({
+          ruleId: existing.rule_id,
+          type: 'conflict',
+          message: 'Rule with this rule_id already exists',
+        })
+      );
+    }
+  }
+
+  return { overwriteItems, newItems, conflictErrors };
+};
+
+/**
+ * Per-rule update fallback for the overwrite path. No `bulkUpdateRules` primitive
+ * exists on the alerting side yet, so this stays at single-rule granularity.
+ */
+const runOverwrites = async ({
+  overwriteItems,
+  detectionRulesClient,
+  overwriteRules,
+  allowMissingConnectorSecrets,
+}: {
+  overwriteItems: PreparedItem[];
+  detectionRulesClient: IDetectionRulesClient;
+  overwriteRules: boolean;
+  allowMissingConnectorSecrets?: boolean;
+}): Promise<Array<Array<RuleResponse | RuleImportErrorObject>>> => {
+  return Promise.all(
+    overwriteItems.map(async (item) => {
+      try {
+        const importedRule = await detectionRulesClient.importRule({
+          ruleToImport: item.rule,
+          overrideFields: { rule_source: item.ruleSource, immutable: item.immutable },
+          overwriteRules,
+          allowMissingConnectorSecrets,
+        });
+        return [...item.nonFatalErrors, importedRule];
+      } catch (err) {
+        return [...item.nonFatalErrors, toImportError(err, item.rule.rule_id)];
+      }
+    })
+  );
+};
+
+interface BulkInputContext {
+  bulkInputs: Array<BulkCreateRulesItem<RuleParams>>;
+  idToItem: Map<string, PreparedItem>;
+  ruleIdToWantedEnabled: Map<string, boolean>;
+  fatalErrors: RuleImportErrorObject[];
+}
+
+const buildBulkInputs = ({
+  newItems,
+  actionsClient,
+  allowMissingConnectorSecrets,
+}: {
+  newItems: PreparedItem[];
+  actionsClient: ActionsClient;
+  allowMissingConnectorSecrets?: boolean;
+}): BulkInputContext => {
+  const bulkInputs: Array<BulkCreateRulesItem<RuleParams>> = [];
+  const idToItem = new Map<string, PreparedItem>();
+  const ruleIdToWantedEnabled = new Map<string, boolean>();
+  const fatalErrors: RuleImportErrorObject[] = [];
+
+  for (const item of newItems) {
+    try {
+      const ruleWithDefaults = applyRuleDefaults({
+        ...item.rule,
+        immutable: item.immutable,
+      });
+      const id = uuidv4();
+      idToItem.set(id, item);
+      ruleIdToWantedEnabled.set(id, item.rule.enabled === true);
+
+      bulkInputs.push({
+        data: {
+          ...convertRuleResponseToAlertingRule(ruleWithDefaults, actionsClient),
+          alertTypeId: ruleTypeMappings[item.rule.type],
+          consumer: SERVER_APP_ID,
+          // The alerting bulk create rejects enabled rules; force-disable here
+          // and re-enable below via bulkEnableRules for the ones the user wanted.
+          enabled: false,
+        },
+        options: { id },
+        allowMissingConnectorSecrets,
+      });
+    } catch (err) {
+      fatalErrors.push(toImportError(err, item.rule.rule_id));
+    }
+  }
+
+  return { bulkInputs, idToItem, ruleIdToWantedEnabled, fatalErrors };
+};
+
+/**
+ * Phase 3b/3c: one bulk create for all new rules, then one optional bulk enable
+ * for the subset whose import payload requested `enabled: true`.
+ */
+const runBulkCreate = async ({
+  newItems,
+  actionsClient,
+  rulesClient,
+  allowMissingConnectorSecrets,
+}: {
+  newItems: PreparedItem[];
+  actionsClient: ActionsClient;
+  rulesClient: RulesClient;
+  allowMissingConnectorSecrets?: boolean;
+}): Promise<{
+  results: Array<RuleResponse | RuleImportErrorObject>;
+  fatalErrors: RuleImportErrorObject[];
+}> => {
+  const { bulkInputs, idToItem, ruleIdToWantedEnabled, fatalErrors } = buildBulkInputs({
+    newItems,
+    actionsClient,
+    allowMissingConnectorSecrets,
+  });
+
+  if (bulkInputs.length === 0) {
+    return { results: [], fatalErrors };
+  }
+
+  const bulkResult = await rulesClient.bulkCreateRules<RuleParams>({ rules: bulkInputs });
+  const { results, successfullyCreatedIds } = collectBulkCreateResults({
+    bulkResult,
+    idToItem,
+    ruleIdToWantedEnabled,
+  });
+
+  if (successfullyCreatedIds.length > 0) {
+    const enableErrors = await runBulkEnable({
+      rulesClient,
+      ids: successfullyCreatedIds,
+      idToItem,
+    });
+    results.push(...enableErrors);
+  }
+
+  return { results, fatalErrors };
+};
+
+const collectBulkCreateResults = ({
+  bulkResult,
+  idToItem,
+  ruleIdToWantedEnabled,
+}: {
+  bulkResult: BulkCreateRulesResult<RuleParams>;
+  idToItem: Map<string, PreparedItem>;
+  ruleIdToWantedEnabled: Map<string, boolean>;
+}): {
+  results: Array<RuleResponse | RuleImportErrorObject>;
+  successfullyCreatedIds: string[];
+} => {
+  const results: Array<RuleResponse | RuleImportErrorObject> = [];
+  const successfullyCreatedIds: string[] = [];
+
+  for (const created of bulkResult.rules) {
+    const item = idToItem.get(created.id);
+    if (item) {
+      try {
+        const ruleResponse = convertAlertingRuleToRuleResponse(created);
+        results.push(...item.nonFatalErrors, ruleResponse);
+        if (ruleIdToWantedEnabled.get(created.id)) {
+          successfullyCreatedIds.push(created.id);
+        }
+      } catch (err) {
+        results.push(...item.nonFatalErrors, toImportError(err, item.rule.rule_id));
+      }
+    }
+  }
+
+  for (const failure of bulkResult.errors) {
+    const item = idToItem.get(failure.rule.id);
+    if (item) {
+      results.push(
+        ...item.nonFatalErrors,
+        createRuleImportErrorObject({
+          ruleId: item.rule.rule_id,
+          message: failure.message ?? 'Failed to create rule',
+        })
+      );
+    }
+  }
+
+  return { results, successfullyCreatedIds };
+};
+
+const runBulkEnable = async ({
+  rulesClient,
+  ids,
+  idToItem,
+}: {
+  rulesClient: RulesClient;
+  ids: string[];
+  idToItem: Map<string, PreparedItem>;
+}): Promise<RuleImportErrorObject[]> => {
+  const enableResult = await rulesClient.bulkEnableRules({ ids });
+  const errors: RuleImportErrorObject[] = [];
+
+  for (const enableError of enableResult.errors) {
+    const item = idToItem.get(enableError.rule.id);
+    if (item) {
+      errors.push(
+        createRuleImportErrorObject({
+          ruleId: item.rule.rule_id,
+          message: `Rule was created but failed to enable: ${enableError.message}`,
+        })
+      );
+    }
+  }
+
+  return errors;
+};
+
+const findExistingRulesByRuleId = async (
+  rulesClient: RulesClient,
+  ruleIds: string[]
+): Promise<Map<string, RuleResponse>> => {
+  if (ruleIds.length === 0) {
+    return new Map();
+  }
+
+  // KQL escape for double-quoted literals: rule_id is a free-form RuleSignatureId,
+  // not guaranteed to be a UUID, so backslashes and quotes must be escaped.
+  const escape = (id: string) => id.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+  const filter = `alert.attributes.params.ruleId: (${ruleIds
+    .map((id) => `"${escape(id)}"`)
+    .join(' OR ')})`;
+
+  const findResult = await findRules({
+    rulesClient,
+    filter,
+    page: 1,
+    perPage: ruleIds.length,
+    fields: undefined,
+    sortField: undefined,
+    sortOrder: undefined,
+  });
+
+  const map = new Map<string, RuleResponse>();
+  for (const rule of findResult.data) {
+    try {
+      const response = convertAlertingRuleToRuleResponse(rule);
+      map.set(response.rule_id, response);
+    } catch {
+      // If a stored rule fails to convert we simply omit it from the lookup;
+      // the import will then attempt to create a rule with that rule_id and
+      // surface any conflict via the SO bulkCreate response.
+    }
+  }
+  return map;
+};
+
+const missingVersionError = (ruleId: string): RuleImportErrorObject =>
+  createRuleImportErrorObject({
+    message: i18n.translate(
+      'xpack.securitySolution.detectionEngine.rules.cannotImportPrebuiltRuleWithoutVersion',
+      {
+        defaultMessage:
+          'Prebuilt rules must specify a "version" to be imported. [rule_id: {ruleId}]',
+        values: { ruleId },
+      }
+    ),
+    ruleId,
+  });
+
+const toImportError = (err: unknown, ruleId: string): RuleImportErrorObject => {
+  if (isRuleImportError(err)) {
+    return err;
+  }
+  const message =
+    err instanceof Error ? err.message : typeof err === 'string' ? err : 'unknown error';
+  return createRuleImportErrorObject({ ruleId, message });
+};

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/import/import_rules.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/import/import_rules.ts
@@ -18,6 +18,7 @@ import { isRuleConflictError, isRuleImportError } from './errors';
  * @param overwriteRules {boolean} - whether to overwrite existing rules
  * with imported rules if their rule_id matches
  * @param detectionRulesClient {object}
+ * @param bulkCreate {boolean} - uses bulk create functionality where available.
  * @returns {Promise} an array of error and success messages from import
  */
 export const importRules = async ({
@@ -26,12 +27,14 @@ export const importRules = async ({
   detectionRulesClient,
   ruleSourceImporter,
   allowMissingConnectorSecrets,
+  bulkCreate = false,
 }: {
   ruleChunks: RuleToImport[][];
   overwriteRules: boolean;
   detectionRulesClient: IDetectionRulesClient;
   ruleSourceImporter: IRuleSourceImporter;
   allowMissingConnectorSecrets?: boolean;
+  bulkCreate?: boolean;
 }): Promise<ImportRuleResponse[]> => {
   const response: ImportRuleResponse[] = [];
 
@@ -40,12 +43,19 @@ export const importRules = async ({
   }
 
   for (const rules of ruleChunks) {
-    const importedRulesResponse = await detectionRulesClient.importRules({
-      allowMissingConnectorSecrets,
-      overwriteRules,
-      ruleSourceImporter,
-      rules,
-    });
+    const importedRulesResponse = bulkCreate
+      ? await detectionRulesClient.bulkImportRules({
+          allowMissingConnectorSecrets,
+          overwriteRules,
+          ruleSourceImporter,
+          rules,
+        })
+      : await detectionRulesClient.importRules({
+          allowMissingConnectorSecrets,
+          overwriteRules,
+          ruleSourceImporter,
+          rules,
+        });
 
     const importResponses = importedRulesResponse.map((rule) => {
       if (isRuleImportError(rule)) {


### PR DESCRIPTION
## Summary

Potential LLM-based solution to bulk installing prebuilt rules via new **`rulesClient.bulkCreateRules()`** method.

- https://github.com/elastic/kibana/issues/253742

Works locally but needs closer inspection. Does not support `enabled` rules by design to keep things simple to avoid scheduling and api key generation (which are not used by rule installation flow, only by creating single rule manually).

Speeds up rule installation significantly, depending on `BATCH_SIZE` (100  ~ 4x faster, 50 ~ 2x faster, 25 ~ same speed). Though I did notice slightly **higher memory usage**.

<img width="1661" height="583" alt="image" src="https://github.com/user-attachments/assets/0d8b889d-182a-4239-a65e-90b22105b634" />



### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks



