### PR TITLE
[Sig Events] Rename KIs search tool

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/tools/constants.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/tools/constants.ts
@@ -38,8 +38,16 @@ export const platformCoreTools = {
   executeConnectorSubAction: platformCoreTool('execute_connector_sub_action'),
 } as const;
 
+/**
+ * Sig Events tools should try to follow this naming convention when possible:
+ * {namespace}.sig_events.{feature}_{entity}_{action}
+ *
+ * - {feature} refers to a high-level scope within Sig Events, for example KIs.
+ * - {entity} is a more granular entity withing the {feature} scope, for example Feature KI or Query KI.
+ * - {action} the action to perform on the entity
+ */
 export const platformStreamsSigEventsTools = {
-  searchKnowledgeIndicators: `${internalNamespaces.platformStreams}.sig_events.search_kis`,
+  searchKnowledgeIndicators: `${internalNamespaces.platformStreams}.sig_events.ki_search`,
   createFeatureKnowledgeIndicator: `${internalNamespaces.platformStreams}.sig_events.ki_feature_create`,
   createQueryKnowledgeIndicator: `${internalNamespaces.platformStreams}.sig_events.ki_query_create`,
 } as const;

--- a/x-pack/platform/plugins/shared/streams/server/agent_builder/skills/knowledge_indicators_management/skill.md.text
+++ b/x-pack/platform/plugins/shared/streams/server/agent_builder/skills/knowledge_indicators_management/skill.md.text
@@ -15,7 +15,7 @@ KI types:
 <available_tools>
 You have 3 tools for KI management:
 
-- `search_kis`
+- `ki_search`
   When to use:
   - Always use this first before creating any KI.
   - Use to discover existing similar KIs and avoid duplicates.
@@ -32,7 +32,7 @@ You have 3 tools for KI management:
 
 <required_workflow>
 Follow this workflow every time:
-1. Search first with `search_kis`.
+1. Search first with `ki_search`.
 2. Compare results for similar intent, similar behavior pattern, or similar query purpose.
 3. If a similar KI exists, present it and avoid creating a duplicate.
 4. If no similar KI exists, output a formatted KI proposal in chat.
@@ -50,7 +50,7 @@ Be proactive when conversations surface reusable knowledge:
 - If the conversation yields a descriptive behavioral pattern (without a concrete query), suggest saving it as a Feature KI.
 
 Required proactive flow:
-1. Run `search_kis` to check for similar KIs first.
+1. Run `ki_search` to check for similar KIs first.
 2. If no close match exists, output a formatted KI proposal in chat.
 3. Call the relevant create tool so the built-in confirmation prompt is shown.
 
@@ -61,7 +61,7 @@ Suggested proactive phrasing:
 
 <tool_examples>
 Example: search first for existing KIs
-Tool: `search_kis`
+Tool: `ki_search`
 Parameters:
 - stream_names: list of stream names to scope search (optional; omit for all accessible streams)
 - search_text: natural-language intent to find similar KIs

--- a/x-pack/platform/plugins/shared/streams/server/agent_builder/skills/streams_management_skill.test.ts
+++ b/x-pack/platform/plugins/shared/streams/server/agent_builder/skills/streams_management_skill.test.ts
@@ -39,7 +39,7 @@ describe('streamsManagementSkill', () => {
   it('does not include sig events tools in getRegistryTools', async () => {
     const toolIds = await streamsManagementSkill.getRegistryTools!();
     expect(toolIds.every((id: string) => !id.includes('sig_events'))).toBe(true);
-    expect(toolIds.every((id: string) => !id.includes('search_kis'))).toBe(true);
+    expect(toolIds.every((id: string) => !id.includes('ki_search'))).toBe(true);
   });
 
   describe('skill content references all registered tool IDs in <tool_selection>', () => {

--- a/x-pack/platform/plugins/shared/streams/server/agent_builder/tools/register_tools.ts
+++ b/x-pack/platform/plugins/shared/streams/server/agent_builder/tools/register_tools.ts
@@ -105,7 +105,7 @@ export function registerAgentBuilderTools({
     createSearchKnowledgeIndicatorsTool({
       getScopedClients,
       server,
-      logger: logger.get('search_kis_tool'),
+      logger: logger.get('ki_search_tool'),
     }),
     createFeatureKnowledgeIndicatorTool({
       getScopedClients,

--- a/x-pack/platform/plugins/shared/streams/server/agent_builder/tools/search_knowledge_indicators/handler.ts
+++ b/x-pack/platform/plugins/shared/streams/server/agent_builder/tools/search_knowledge_indicators/handler.ts
@@ -32,9 +32,9 @@ export async function searchKnowledgeIndicatorsToolHandler({
     params,
     onFeatureFetchError: (streamName, error) => {
       const errorMessage =
-        error instanceof Error ? error.stack ?? error.message : String(error ?? 'Unknown error');
+        error instanceof Error ? error.stack || error.message : String(error ?? 'Unknown error');
       logger.warn(
-        `search_kis: failed to fetch features for stream "${streamName}": ${errorMessage}`
+        `ki_search: failed to fetch features for stream "${streamName}": ${errorMessage}`
       );
     },
     getStreamNames: async () => {

--- a/x-pack/platform/plugins/shared/streams/server/agent_builder/tools/search_knowledge_indicators/tool.test.ts
+++ b/x-pack/platform/plugins/shared/streams/server/agent_builder/tools/search_knowledge_indicators/tool.test.ts
@@ -20,7 +20,7 @@ jest.mock('../../../routes/utils/assert_significant_events_access', () => ({
   assertSignificantEventsAccess: jest.fn(),
 }));
 
-describe('search_kis tool', () => {
+describe('ki_search tool', () => {
   const logger = loggingSystemMock.createLogger();
   const server = {} as unknown as StreamsServer;
   const request = {} as unknown as KibanaRequest;
@@ -35,7 +35,7 @@ describe('search_kis tool', () => {
     });
 
     expect(tool.id).toBe(STREAMS_SEARCH_KNOWLEDGE_INDICATORS_TOOL_ID);
-    expect(tool.id).toBe('platform.streams.sig_events.search_kis');
+    expect(tool.id).toBe('platform.streams.sig_events.ki_search');
   });
 
   it('availability returns available when access check succeeds', async () => {

--- a/x-pack/platform/plugins/shared/streams/server/agent_builder/tools/search_knowledge_indicators/tool.ts
+++ b/x-pack/platform/plugins/shared/streams/server/agent_builder/tools/search_knowledge_indicators/tool.ts
@@ -138,7 +138,7 @@ export function createSearchKnowledgeIndicatorsTool({
         };
       } catch (error) {
         const message = error instanceof Error ? error.message : 'Unknown error';
-        logger.error(`Error running search_kis: ${message}`);
+        logger.error(`Error running ki_search: ${message}`);
         if (error instanceof Error) {
           logger.debug(error.stack ?? error.message);
         } else {

--- a/x-pack/platform/plugins/shared/streams/test/scout/api/tests/sig_events/search_knowledge_indicators_tool.spec.ts
+++ b/x-pack/platform/plugins/shared/streams/test/scout/api/tests/sig_events/search_knowledge_indicators_tool.spec.ts
@@ -38,11 +38,11 @@ import {
 } from '../../../../../server/lib/streams/assets/fields';
 import { getQueryLinkUuid } from '../../../../../server/lib/streams/assets/query/query_client';
 
-const TOOL_ID = 'platform.streams.sig_events.search_kis';
+const TOOL_ID = 'platform.streams.sig_events.ki_search';
 
 // Failing, see https://github.com/elastic/kibana/issues/262787
 apiTest.describe.skip(
-  'search_kis tool',
+  'ki_search tool',
   { tag: [...tags.stateful.classic, ...tags.serverless.observability.complete] },
   () => {
     const rootStream = 'logs.otel';

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/skills/rca/skill.md.text
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/skills/rca/skill.md.text
@@ -45,23 +45,23 @@ patterns learned from previous investigations.
 
 ## Mandatory First Step
 
-**If `search_kis` is in your tool list, your FIRST tool call MUST be
-`search_kis`. Do not call `get_logs`, `execute_esql`, or any other
+**If `ki_search` is in your tool list, your FIRST tool call MUST be
+`ki_search`. Do not call `get_logs`, `execute_esql`, or any other
 tool before it.**
 
 **Tool identity:** Your tool list may show a **longer registry id** (e.g. containing
-`platform.streams` and ending in `search_kis`). That is the same tool as
-`search_kis` in these instructions.
+`platform.streams` and ending in `ki_search`). That is the same tool as
+`ki_search` in these instructions.
 
 Knowledge Indicators (KIs) are curated, stream-specific signals — operator-written detection
 queries and automatically extracted behavioral patterns. They encode what "bad" looks like for
 this stream and are faster and more targeted than raw log search.
 
-**If `search_kis` errors** (timeout, permission, internal error): retry **once**.
+**If `ki_search` errors** (timeout, permission, internal error): retry **once**.
 If it still fails, tell the user and **proceed to Track B** — do not block the investigation.
 
 Only fall back to Track B (log funnel) if:
-- `search_kis` is NOT in your tool list, OR
+- `ki_search` is NOT in your tool list, OR
 - it **failed** after one retry (see above), OR
 - it returned no KIs for the target stream after two attempts, OR
 - every KI-derived hypothesis was explicitly refuted by live query data
@@ -88,7 +88,7 @@ hypotheses in Step A-3.
 ### Step A-1: Identify Target Stream and Time Window
 
 **Stream:** Use the service or stream name from Step A-0 as `stream_names`. If the user
-did not name a specific stream, call `search_kis` with no `stream_names`
+did not name a specific stream, call `ki_search` with no `stream_names`
 to discover which streams have KIs, present the list, and ask the user to confirm.
 
 **Time window:** Pin a single investigation window from the user's description.
@@ -290,7 +290,7 @@ them for future investigations.
 
 ## Track B: Log Funnel Investigation (Fallback Only)
 
-Enter this track if `search_kis` is not in your tool list, **failed after one retry**,
+Enter this track if `ki_search` is not in your tool list, **failed after one retry**,
 returned no KIs after two attempts, or all KI-derived hypotheses were explicitly refuted.
 
 ### Phase 1: Initial Peek
@@ -375,7 +375,7 @@ User: "The payment service has been throwing database errors since 2pm."
 
 **A-1**: stream = "payment", window = 14:00 → now.
 
-**A-2 (targeted)**: search_kis(stream_names=["payment"], search_text="database errors", limit=20)
+**A-2 (targeted)**: ki_search(stream_names=["payment"], search_text="database errors", limit=20)
 → Returns 4 KIs (features first, then queries — read all before forming hypotheses):
   - Feature KI F1: type="error_logs", confidence=93, description="FATAL: connection pool exhausted — all 100 slots occupied", filter={"field":"service.name","eq":"payment"}, status="active"
   - Feature KI F2: type="log_patterns", confidence=61, description="Slow query warnings from PostgreSQL", filter={"field":"service.name","eq":"payment"}, status="stale"


### PR DESCRIPTION
Follow up after [this discussion](https://github.com/elastic/kibana/pull/263736#discussion_r3094521548).

This change renames the KIs search tool to follow the agreed convention.

I've tested how AI Agent in Kibana behaves when a tool get renamed. Seems like it picks up the change without any issues.