### PR TITLE
Revert "Serverless artifacts build - enforce devenv recreation (#262557)

### DIFF
--- a/.buildkite/scripts/steps/artifacts/docker_image.sh
+++ b/.buildkite/scripts/steps/artifacts/docker_image.sh
@@ -215,8 +215,6 @@ steps:
         REMOTE_SERVICE_CONFIG: https://raw.githubusercontent.com/elastic/serverless-gitops/main/gen/gpctl/kibana/dev.yaml
         GPCTL_PROMOTE_DRY_RUN: ${DRY_RUN:-false}
         CHANGE_WINDOW_OVERRIDE: true
-        DEVCTL_CREATE_DIRECT: true
-        DEVCTL_VERSION: 0.7.1
 EOF
 
 else


### PR DESCRIPTION
This reverts commit 4405d6294315b9c71bcfcfa7a5e212ab7209581e.

## Summary

The adjustments from #262557 were a temporary measure to unblock devenv promotion. Things have since been fixed and the new devctl version should handle our case correctly now, so the temporary fix can be reverted.