### PR TITLE
[Agent Builder] use `searchInferenceEndpoints` to resolve default connector

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/constants.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/constants.ts
@@ -8,7 +8,7 @@
 export const AGENT_BUILDER_PARENT_INFERENCE_FEATURE_ID = 'agent_builder_parent';
 export const AGENT_BUILDER_INFERENCE_FEATURE_ID = 'agent_builder';
 export const AGENT_BUILDER_RECOMMENDED_ENDPOINTS = [
-  '.anthropic-claude-4.6-opus-chat_completion',
   '.anthropic-claude-4.6-sonnet-chat_completion',
+  '.anthropic-claude-4.6-opus-chat_completion',
   '.openai-gpt-5.2-chat_completion',
 ];

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/constants.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/constants.ts
@@ -10,10 +10,5 @@ export const AGENT_BUILDER_INFERENCE_FEATURE_ID = 'agent_builder';
 export const AGENT_BUILDER_RECOMMENDED_ENDPOINTS = [
   '.anthropic-claude-4.6-opus-chat_completion',
   '.anthropic-claude-4.6-sonnet-chat_completion',
-  '.anthropic-claude-4.5-sonnet-chat_completion',
-  '.anthropic-claude-4.5-opus-chat_completion',
-  '.google-gemini-3.0-flash-chat_completion',
-  '.google-gemini-3.1-pro-chat_completion',
   '.openai-gpt-5.2-chat_completion',
-  '.openai-gpt-oss-20b-chat_completion',
 ];

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/constants.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/constants.ts
@@ -10,6 +10,8 @@ export const AGENT_BUILDER_INFERENCE_FEATURE_ID = 'agent_builder';
 export const AGENT_BUILDER_RECOMMENDED_ENDPOINTS = [
   '.anthropic-claude-4.6-opus-chat_completion',
   '.anthropic-claude-4.6-sonnet-chat_completion',
+  '.anthropic-claude-4.5-sonnet-chat_completion',
+  '.anthropic-claude-4.5-opus-chat_completion',
   '.google-gemini-3.0-flash-chat_completion',
   '.google-gemini-3.1-pro-chat_completion',
   '.openai-gpt-5.2-chat_completion',

--- a/x-pack/platform/plugins/shared/agent_builder/kibana.jsonc
+++ b/x-pack/platform/plugins/shared/agent_builder/kibana.jsonc
@@ -33,6 +33,7 @@
       "triggersActionsUi",
       "esUiShared",
       "workflowsExtensions",
+      "searchInferenceEndpoints"
     ],
     "requiredBundles": [
       "kibanaReact",
@@ -44,7 +45,6 @@
       "licenseManagement",
       "security",
       "workflowsManagement",
-      "searchInferenceEndpoints",
       "usageCollection",
       "usageApi",
       "home",

--- a/x-pack/platform/plugins/shared/agent_builder/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/plugin.ts
@@ -263,7 +263,13 @@ export class AgentBuilderPlugin
 
   start(
     coreStart: CoreStart,
-    { inference, spaces, actions, taskManager }: AgentBuilderStartDependencies
+    {
+      inference,
+      spaces,
+      actions,
+      taskManager,
+      searchInferenceEndpoints,
+    }: AgentBuilderStartDependencies
   ): AgentBuilderPluginStart {
     const { elasticsearch, security, uiSettings, savedObjects, dataStreams, featureFlags } =
       coreStart;
@@ -281,6 +287,7 @@ export class AgentBuilderPlugin
       taskManager,
       trackingService: this.trackingService,
       analyticsService: this.analyticsService,
+      searchInferenceEndpoints,
     });
 
     const { tools, agents, skills, runnerFactory, execution, plugins, conversations } =
@@ -296,6 +303,7 @@ export class AgentBuilderPlugin
       uiSettings,
       savedObjects,
       trackingService: this.trackingService,
+      searchInferenceEndpoints,
     });
 
     // Schedule SML crawler tasks for all registered types

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/create_services.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/create_services.ts
@@ -105,6 +105,7 @@ export class ServiceManager {
     securityPlugin,
     trackingService,
     analyticsService,
+    searchInferenceEndpoints,
   }: ServicesStartDeps): InternalStartServices {
     if (!this.services) {
       throw new Error('#startServices called before #setupServices');
@@ -182,6 +183,7 @@ export class ServiceManager {
       trackingService,
       analyticsService,
       hooks,
+      searchInferenceEndpoints,
     });
     runner = runnerFactory.getRunner();
 
@@ -210,6 +212,7 @@ export class ServiceManager {
       trackingService,
       analyticsService,
       meteringService: this.services.metering,
+      searchInferenceEndpoints,
     });
 
     const execution = createAgentExecutionService({
@@ -227,6 +230,7 @@ export class ServiceManager {
       trackingService,
       analyticsService,
       meteringService: this.services.metering,
+      searchInferenceEndpoints,
     });
 
     const consumption = this.services.consumption.start({ elasticsearch, spaces });

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/execution_runner.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/execution_runner.ts
@@ -22,6 +22,7 @@ import {
 } from '@kbn/agent-builder-common';
 import { getConnectorProvider } from '@kbn/inference-common';
 import type { SpacesPluginStart } from '@kbn/spaces-plugin/server';
+import type { SearchInferenceEndpointsPluginStart } from '@kbn/search-inference-endpoints/server';
 import type { ConversationService, ConversationClient } from '../conversation';
 import type { AgentsServiceStart } from '../agents';
 import {
@@ -60,6 +61,7 @@ export interface AgentExecutionDeps {
   meteringService: MeteringService;
   trackingService?: TrackingService;
   analyticsService?: AnalyticsService;
+  searchInferenceEndpoints: SearchInferenceEndpointsPluginStart;
 }
 
 /**

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/execution_service.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/execution_service.test.ts
@@ -88,6 +88,7 @@ describe('AgentExecutionService', () => {
     uiSettings,
     savedObjects,
     meteringService,
+    searchInferenceEndpoints: {} as any,
   });
 
   beforeEach(() => {

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/runner/model_provider.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/runner/model_provider.ts
@@ -15,6 +15,7 @@ import type {
   ModelCallInfo,
 } from '@kbn/agent-builder-server/runner';
 import type { InferenceServerStart } from '@kbn/inference-plugin/server';
+import type { SearchInferenceEndpointsPluginStart } from '@kbn/search-inference-endpoints/server';
 import { getConnectorProvider, getConnectorModel } from '@kbn/inference-common';
 import type { InferenceCompleteCallbackHandler } from '@kbn/inference-common/src/chat_complete';
 import type { TrackingService } from '../../../telemetry';
@@ -28,6 +29,7 @@ export interface CreateModelProviderOpts {
   trackingService?: TrackingService;
   uiSettings: UiSettingsServiceStart;
   savedObjects: SavedObjectsServiceStart;
+  searchInferenceEndpoints: SearchInferenceEndpointsPluginStart;
 }
 
 export type CreateModelProviderFactoryFn = (
@@ -58,6 +60,7 @@ export const createModelProvider = ({
   trackingService,
   uiSettings,
   savedObjects,
+  searchInferenceEndpoints,
 }: CreateModelProviderOpts): ModelProvider => {
   const getDefaultConnectorId = async () => {
     const resolvedConnectorId = await resolveSelectedConnectorId({
@@ -66,6 +69,7 @@ export const createModelProvider = ({
       request,
       connectorId: defaultConnectorId,
       inference,
+      searchInferenceEndpoints,
     });
     if (!resolvedConnectorId) {
       throw new Error('No connector available');

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/runner/runner_factory.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/runner/runner_factory.ts
@@ -29,6 +29,7 @@ export class RunnerFactoryImpl implements RunnerFactory {
       uiSettings,
       hooks,
       savedObjects,
+      searchInferenceEndpoints,
       ...otherDeps
     } = this.deps;
     return {
@@ -43,6 +44,7 @@ export class RunnerFactoryImpl implements RunnerFactory {
         trackingService,
         uiSettings,
         savedObjects,
+        searchInferenceEndpoints,
       }),
     };
   }

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/runner/types.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/runner/types.ts
@@ -11,6 +11,7 @@ import type { SecurityServiceStart } from '@kbn/core-security-server';
 import type { UiSettingsServiceStart } from '@kbn/core-ui-settings-server';
 import type { SavedObjectsServiceStart } from '@kbn/core-saved-objects-server';
 import type { InferenceServerStart } from '@kbn/inference-plugin/server';
+import type { SearchInferenceEndpointsPluginStart } from '@kbn/search-inference-endpoints/server';
 import type { SpacesPluginStart } from '@kbn/spaces-plugin/server';
 import type { PluginStartContract as ActionsPluginStart } from '@kbn/actions-plugin/server';
 import type { Runner, HooksServiceStart } from '@kbn/agent-builder-server';
@@ -41,6 +42,7 @@ export interface RunnerFactoryDeps {
   trackingService?: TrackingService;
   analyticsService?: AnalyticsService;
   hooks: HooksServiceStart;
+  searchInferenceEndpoints: SearchInferenceEndpointsPluginStart;
 }
 
 export interface RunnerFactory {

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/utils/resolve_services.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/utils/resolve_services.ts
@@ -10,6 +10,7 @@ import type { KibanaRequest } from '@kbn/core-http-server';
 import type { UiSettingsServiceStart } from '@kbn/core-ui-settings-server';
 import type { SavedObjectsServiceStart } from '@kbn/core-saved-objects-server';
 import type { InferenceServerStart } from '@kbn/inference-plugin/server';
+import type { SearchInferenceEndpointsPluginStart } from '@kbn/search-inference-endpoints/server';
 import { MODEL_TELEMETRY_METADATA } from '../../../telemetry';
 import type { ConversationService } from '../../conversation';
 import type { AgentsServiceStart } from '../../agents';
@@ -25,6 +26,7 @@ export const resolveServices = async ({
   agentService,
   uiSettings,
   savedObjects,
+  searchInferenceEndpoints,
 }: {
   agentId: string;
   connectorId?: string;
@@ -35,6 +37,7 @@ export const resolveServices = async ({
   agentService: AgentsServiceStart;
   uiSettings: UiSettingsServiceStart;
   savedObjects: SavedObjectsServiceStart;
+  searchInferenceEndpoints: SearchInferenceEndpointsPluginStart;
 }) => {
   const selectedConnectorId = await resolveSelectedConnectorId({
     request,
@@ -42,6 +45,7 @@ export const resolveServices = async ({
     uiSettings,
     savedObjects,
     inference,
+    searchInferenceEndpoints,
   });
 
   if (!selectedConnectorId) {

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/types.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/types.ts
@@ -12,6 +12,7 @@ import type { SavedObjectsServiceStart } from '@kbn/core-saved-objects-server';
 import type { SecurityServiceStart } from '@kbn/core-security-server';
 import type { FeatureFlagsStart } from '@kbn/core-feature-flags-server';
 import type { InferenceServerStart } from '@kbn/inference-plugin/server';
+import type { SearchInferenceEndpointsPluginStart } from '@kbn/search-inference-endpoints/server';
 import type { DataStreamsStart } from '@kbn/core-data-streams-server';
 import type { TaskManagerStartContract } from '@kbn/task-manager-plugin/server';
 import type { WorkflowsServerPluginSetup } from '@kbn/workflows-management-plugin/server';
@@ -91,4 +92,5 @@ export interface ServicesStartDeps {
   securityPlugin?: SecurityPluginStart;
   trackingService?: TrackingService;
   analyticsService?: AnalyticsService;
+  searchInferenceEndpoints: SearchInferenceEndpointsPluginStart;
 }

--- a/x-pack/platform/plugins/shared/agent_builder/server/types.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/types.ts
@@ -14,7 +14,10 @@ import type { FeaturesPluginSetup } from '@kbn/features-plugin/server';
 import type { LicensingPluginStart } from '@kbn/licensing-plugin/server';
 import type { CloudStart, CloudSetup } from '@kbn/cloud-plugin/server';
 import type { UsageApiSetup, UsageApiStart } from '@kbn/usage-api-plugin/server';
-import type { SearchInferenceEndpointsPluginSetup } from '@kbn/search-inference-endpoints/server';
+import type {
+  SearchInferenceEndpointsPluginSetup,
+  SearchInferenceEndpointsPluginStart,
+} from '@kbn/search-inference-endpoints/server';
 import type {
   TaskManagerSetupContract,
   TaskManagerStartContract,
@@ -55,7 +58,7 @@ export interface AgentBuilderSetupDependencies {
   taskManager: TaskManagerSetupContract;
   actions: ActionsPluginSetup;
   home: HomeServerPluginSetup;
-  searchInferenceEndpoints?: SearchInferenceEndpointsPluginSetup;
+  searchInferenceEndpoints: SearchInferenceEndpointsPluginSetup;
 }
 
 export interface AgentBuilderStartDependencies {
@@ -67,6 +70,7 @@ export interface AgentBuilderStartDependencies {
   actions: ActionsPluginStart;
   taskManager: TaskManagerStartContract;
   security?: SecurityPluginStart;
+  searchInferenceEndpoints: SearchInferenceEndpointsPluginStart;
 }
 
 export interface AttachmentsSetup {

--- a/x-pack/platform/plugins/shared/agent_builder/server/utils/resolve_selected_connector_id.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/utils/resolve_selected_connector_id.test.ts
@@ -6,8 +6,11 @@
  */
 
 import { resolveSelectedConnectorId } from './resolve_selected_connector_id';
-import { type InferenceConnector, InferenceConnectorType } from '@kbn/inference-common';
-import { PREFERRED_DEFAULT_CONNECTOR_ID } from '../../common/constants';
+import {
+  type InferenceConnector,
+  defaultInferenceEndpoints,
+  InferenceConnectorType,
+} from '@kbn/inference-common';
 import { uiSettingsServiceMock } from '@kbn/core-ui-settings-server-mocks';
 import { savedObjectsServiceMock } from '@kbn/core-saved-objects-server-mocks';
 import { httpServerMock } from '@kbn/core-http-server-mocks';
@@ -18,7 +21,27 @@ import {
   GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR_DEFAULT_ONLY,
 } from '@kbn/management-settings-ids';
 
-const searchInferenceEndpoints = {} as SearchInferenceEndpointsPluginStart;
+const createSearchInferenceEndpointsMock = (
+  overrides: Partial<{
+    endpoints: InferenceConnector[];
+    soEntryFound: boolean;
+    error: Error;
+  }> = {}
+) => {
+  const mock: SearchInferenceEndpointsPluginStart = {
+    features: {} as any,
+    endpoints: {
+      getForFeature: overrides.error
+        ? jest.fn().mockRejectedValue(overrides.error)
+        : jest.fn().mockResolvedValue({
+            endpoints: overrides.endpoints ?? [],
+            warnings: [],
+            soEntryFound: overrides.soEntryFound ?? false,
+          }),
+    },
+  };
+  return mock;
+};
 
 const setupCoreMocks = (values: Record<string, any>) => {
   const savedObjects = savedObjectsServiceMock.createStartContract();
@@ -34,255 +57,268 @@ const setupCoreMocks = (values: Record<string, any>) => {
   return { savedObjects, uiSettings, request };
 };
 
-describe('resolveSelectedConnectorId', () => {
-  it('throws when defaultOnly=true and explicit connectorId does not match default', async () => {
-    const { savedObjects, uiSettings, request } = setupCoreMocks({
-      [GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR]: 'default-id',
-      [GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR_DEFAULT_ONLY]: true,
-    });
-    const inference = inferenceMock.createStartContract();
+const noDefaultSettings = {
+  [GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR]: 'NO_DEFAULT_CONNECTOR',
+  [GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR_DEFAULT_ONLY]: false,
+};
 
-    await expect(
-      resolveSelectedConnectorId({
+describe('resolveSelectedConnectorId', () => {
+  describe('ui settings checks', () => {
+    it('throws when defaultOnly=true and explicit connectorId does not match default', async () => {
+      const { savedObjects, uiSettings, request } = setupCoreMocks({
+        [GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR]: 'default-id',
+        [GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR_DEFAULT_ONLY]: true,
+      });
+      const inference = inferenceMock.createStartContract();
+      const searchInferenceEndpoints = createSearchInferenceEndpointsMock();
+
+      await expect(
+        resolveSelectedConnectorId({
+          uiSettings,
+          savedObjects,
+          request,
+          connectorId: 'explicit-id',
+          inference,
+          searchInferenceEndpoints,
+        })
+      ).rejects.toThrow(
+        'Connector ID [explicit-id] does not match the configured default connector ID [default-id].'
+      );
+    });
+
+    it('returns default connector when defaultOnly=true and explicit connectorId matches default', async () => {
+      const { savedObjects, uiSettings, request } = setupCoreMocks({
+        [GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR]: 'default-id',
+        [GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR_DEFAULT_ONLY]: true,
+      });
+      const inference = inferenceMock.createStartContract();
+      const searchInferenceEndpoints = createSearchInferenceEndpointsMock();
+
+      const result = await resolveSelectedConnectorId({
+        uiSettings,
+        savedObjects,
+        request,
+        connectorId: 'default-id',
+        inference,
+        searchInferenceEndpoints,
+      });
+
+      expect(result).toBe('default-id');
+    });
+
+    it('returns explicit connectorId when provided and defaultOnly=false', async () => {
+      const { savedObjects, uiSettings, request } = setupCoreMocks({
+        [GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR]: 'default-id',
+        [GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR_DEFAULT_ONLY]: false,
+      });
+      const inference = inferenceMock.createStartContract();
+      const searchInferenceEndpoints = createSearchInferenceEndpointsMock();
+
+      const result = await resolveSelectedConnectorId({
         uiSettings,
         savedObjects,
         request,
         connectorId: 'explicit-id',
         inference,
         searchInferenceEndpoints,
-      })
-    ).rejects.toThrow(
-      'Connector ID [explicit-id] does not match the configured default connector ID [default-id].'
-    );
-    expect(inference.getDefaultConnector).not.toHaveBeenCalled();
-    expect(inference.getConnectorList).not.toHaveBeenCalled();
+      });
+
+      expect(result).toBe('explicit-id');
+    });
+
+    it('returns default connector setting when no explicit connectorId and defaultOnly=false', async () => {
+      const { savedObjects, uiSettings, request } = setupCoreMocks({
+        [GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR]: 'default-id',
+        [GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR_DEFAULT_ONLY]: false,
+      });
+      const inference = inferenceMock.createStartContract();
+      const searchInferenceEndpoints = createSearchInferenceEndpointsMock();
+
+      const result = await resolveSelectedConnectorId({
+        uiSettings,
+        savedObjects,
+        request,
+        inference,
+        searchInferenceEndpoints,
+      });
+
+      expect(result).toBe('default-id');
+    });
   });
 
-  it('returns default connector when defaultOnly=true and explicit connectorId matches default', async () => {
-    const { savedObjects, uiSettings, request } = setupCoreMocks({
-      [GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR]: 'default-id',
-      [GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR_DEFAULT_ONLY]: true,
-    });
-    const inference = inferenceMock.createStartContract();
+  describe('feature endpoint fallback', () => {
+    it('returns the first feature endpoint when available', async () => {
+      const { savedObjects, uiSettings, request } = setupCoreMocks(noDefaultSettings);
+      const inference = inferenceMock.createStartContract();
+      const searchInferenceEndpoints = createSearchInferenceEndpointsMock({
+        endpoints: [
+          { connectorId: 'recommended-1' } as InferenceConnector,
+          { connectorId: 'recommended-2' } as InferenceConnector,
+        ],
+      });
 
-    const result = await resolveSelectedConnectorId({
-      uiSettings,
-      savedObjects,
-      request,
-      connectorId: 'default-id',
-      inference,
-      searchInferenceEndpoints,
+      const result = await resolveSelectedConnectorId({
+        uiSettings,
+        savedObjects,
+        request,
+        inference,
+        searchInferenceEndpoints,
+      });
+
+      expect(result).toBe('recommended-1');
+      expect(inference.getConnectorList).not.toHaveBeenCalled();
     });
 
-    expect(result).toBe('default-id');
-    expect(inference.getDefaultConnector).not.toHaveBeenCalled();
-    expect(inference.getConnectorList).not.toHaveBeenCalled();
+    it('returns the first SO-configured endpoint when soEntryFound is true', async () => {
+      const { savedObjects, uiSettings, request } = setupCoreMocks(noDefaultSettings);
+      const inference = inferenceMock.createStartContract();
+      const searchInferenceEndpoints = createSearchInferenceEndpointsMock({
+        soEntryFound: true,
+        endpoints: [{ connectorId: 'admin-configured' } as InferenceConnector],
+      });
+
+      const result = await resolveSelectedConnectorId({
+        uiSettings,
+        savedObjects,
+        request,
+        inference,
+        searchInferenceEndpoints,
+      });
+
+      expect(result).toBe('admin-configured');
+      expect(inference.getConnectorList).not.toHaveBeenCalled();
+    });
   });
 
-  it('returns explicit connectorId when provided and defaultOnly=false', async () => {
-    const { savedObjects, uiSettings, request } = setupCoreMocks({
-      [GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR]: 'default-id',
-      [GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR_DEFAULT_ONLY]: false,
-    });
-    const inference = inferenceMock.createStartContract();
+  describe('connector list fallback', () => {
+    it('prefers KIBANA_DEFAULT_CHAT_COMPLETION from connector list', async () => {
+      const { savedObjects, uiSettings, request } = setupCoreMocks(noDefaultSettings);
+      const inference = inferenceMock.createStartContract();
+      const searchInferenceEndpoints = createSearchInferenceEndpointsMock();
+      const kibanaDefault = defaultInferenceEndpoints.KIBANA_DEFAULT_CHAT_COMPLETION;
 
-    const result = await resolveSelectedConnectorId({
-      uiSettings,
-      savedObjects,
-      request,
-      connectorId: 'explicit-id',
-      inference,
-      searchInferenceEndpoints,
-    });
+      (inference.getConnectorList as jest.Mock).mockResolvedValue([
+        { connectorId: 'other-id' } as InferenceConnector,
+        { connectorId: kibanaDefault } as InferenceConnector,
+      ]);
 
-    expect(result).toBe('explicit-id');
-    expect(inference.getDefaultConnector).not.toHaveBeenCalled();
-    expect(inference.getConnectorList).not.toHaveBeenCalled();
-  });
+      const result = await resolveSelectedConnectorId({
+        uiSettings,
+        savedObjects,
+        request,
+        inference,
+        searchInferenceEndpoints,
+      });
 
-  it('returns default connector when provided and defaultOnly=false', async () => {
-    const { savedObjects, uiSettings, request } = setupCoreMocks({
-      [GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR]: 'default-id',
-      [GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR_DEFAULT_ONLY]: false,
-    });
-    const inference = inferenceMock.createStartContract();
-
-    const result = await resolveSelectedConnectorId({
-      uiSettings,
-      savedObjects,
-      request,
-      inference,
-      searchInferenceEndpoints,
+      expect(result).toBe(kibanaDefault);
     });
 
-    expect(result).toBe('default-id');
-    expect(inference.getDefaultConnector).not.toHaveBeenCalled();
-    expect(inference.getConnectorList).not.toHaveBeenCalled();
-  });
+    it('prefers Inference connector type when KIBANA_DEFAULT_CHAT_COMPLETION is not available', async () => {
+      const { savedObjects, uiSettings, request } = setupCoreMocks(noDefaultSettings);
+      const inference = inferenceMock.createStartContract();
+      const searchInferenceEndpoints = createSearchInferenceEndpointsMock();
 
-  it('falls back to inference default when no valid default setting exists', async () => {
-    const { savedObjects, uiSettings, request } = setupCoreMocks({
-      [GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR]: 'NO_DEFAULT_CONNECTOR',
-      [GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR_DEFAULT_ONLY]: false,
-    });
-    const inference = inferenceMock.createStartContract();
-    (inference.getDefaultConnector as jest.Mock).mockResolvedValue({
-      connectorId: 'inference-default-id',
-    });
+      (inference.getConnectorList as jest.Mock).mockResolvedValue([
+        { connectorId: 'openai-id', type: InferenceConnectorType.OpenAI } as InferenceConnector,
+        {
+          connectorId: 'inference-id',
+          type: InferenceConnectorType.Inference,
+        } as InferenceConnector,
+        { connectorId: 'gemini-id', type: InferenceConnectorType.Gemini } as InferenceConnector,
+      ]);
 
-    const result = await resolveSelectedConnectorId({
-      uiSettings,
-      savedObjects,
-      request,
-      inference,
-      searchInferenceEndpoints,
-    });
+      const result = await resolveSelectedConnectorId({
+        uiSettings,
+        savedObjects,
+        request,
+        inference,
+        searchInferenceEndpoints,
+      });
 
-    expect(result).toBe('inference-default-id');
-    expect(inference.getDefaultConnector).toHaveBeenCalledTimes(1);
-    expect(inference.getConnectorList).not.toHaveBeenCalled();
-  });
-
-  it('prefers first recommended connector over inference when falling back to connector list', async () => {
-    const { savedObjects, uiSettings, request } = setupCoreMocks({
-      [GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR]: 'NO_DEFAULT_CONNECTOR',
-      [GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR_DEFAULT_ONLY]: false,
-    });
-    const inference = inferenceMock.createStartContract();
-    (inference.getDefaultConnector as jest.Mock).mockRejectedValue(new Error('no default'));
-    (inference.getConnectorList as jest.Mock).mockResolvedValue([
-      { connectorId: 'inference-id', type: InferenceConnectorType.Inference } as InferenceConnector,
-      {
-        connectorId: 'Google-Gemini-2-5-Pro',
-        type: InferenceConnectorType.Gemini,
-      } as InferenceConnector,
-    ]);
-
-    const result = await resolveSelectedConnectorId({
-      uiSettings,
-      savedObjects,
-      request,
-      inference,
-      searchInferenceEndpoints,
+      expect(result).toBe('inference-id');
     });
 
-    expect(result).toBe('Google-Gemini-2-5-Pro');
-  });
+    it('prefers OpenAI connector type when neither default nor Inference are available', async () => {
+      const { savedObjects, uiSettings, request } = setupCoreMocks(noDefaultSettings);
+      const inference = inferenceMock.createStartContract();
+      const searchInferenceEndpoints = createSearchInferenceEndpointsMock();
 
-  it('prefers Anthropic-Claude-Sonnet-4-5 when available in connector list', async () => {
-    const { savedObjects, uiSettings, request } = setupCoreMocks({
-      [GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR]: 'NO_DEFAULT_CONNECTOR',
-      [GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR_DEFAULT_ONLY]: false,
-    });
-    const inference = inferenceMock.createStartContract();
-    (inference.getDefaultConnector as jest.Mock).mockRejectedValue(new Error('no default'));
-    (inference.getConnectorList as jest.Mock).mockResolvedValue([
-      { connectorId: 'inference-id', type: InferenceConnectorType.Inference } as InferenceConnector,
-      {
-        connectorId: PREFERRED_DEFAULT_CONNECTOR_ID,
-        type: InferenceConnectorType.Inference,
-      } as InferenceConnector,
-      { connectorId: 'openai-id', type: InferenceConnectorType.OpenAI } as InferenceConnector,
-    ]);
+      (inference.getConnectorList as jest.Mock).mockResolvedValue([
+        { connectorId: 'gemini-id', type: InferenceConnectorType.Gemini } as InferenceConnector,
+        { connectorId: 'openai-id', type: InferenceConnectorType.OpenAI } as InferenceConnector,
+      ]);
 
-    const result = await resolveSelectedConnectorId({
-      uiSettings,
-      savedObjects,
-      request,
-      inference,
-      searchInferenceEndpoints,
+      const result = await resolveSelectedConnectorId({
+        uiSettings,
+        savedObjects,
+        request,
+        inference,
+        searchInferenceEndpoints,
+      });
+
+      expect(result).toBe('openai-id');
     });
 
-    expect(result).toBe(PREFERRED_DEFAULT_CONNECTOR_ID);
-  });
+    it('falls back to first connector when no preferred types are available', async () => {
+      const { savedObjects, uiSettings, request } = setupCoreMocks(noDefaultSettings);
+      const inference = inferenceMock.createStartContract();
+      const searchInferenceEndpoints = createSearchInferenceEndpointsMock();
 
-  it('selects Inference connector over OpenAI when falling back to connector list', async () => {
-    const { savedObjects, uiSettings, request } = setupCoreMocks({
-      [GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR]: 'NO_DEFAULT_CONNECTOR',
-      [GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR_DEFAULT_ONLY]: false,
-    });
-    const inference = inferenceMock.createStartContract();
-    (inference.getDefaultConnector as jest.Mock).mockRejectedValue(new Error('no default'));
-    (inference.getConnectorList as jest.Mock).mockResolvedValue([
-      { connectorId: 'openai-id', type: InferenceConnectorType.OpenAI } as InferenceConnector,
-      { connectorId: 'inference-id', type: InferenceConnectorType.Inference } as InferenceConnector,
-      { connectorId: 'first-id', type: InferenceConnectorType.Gemini } as InferenceConnector,
-    ]);
+      (inference.getConnectorList as jest.Mock).mockResolvedValue([
+        { connectorId: 'gemini-id', type: InferenceConnectorType.Gemini } as InferenceConnector,
+        { connectorId: 'bedrock-id', type: InferenceConnectorType.Bedrock } as InferenceConnector,
+      ]);
 
-    const result = await resolveSelectedConnectorId({
-      uiSettings,
-      savedObjects,
-      request,
-      inference,
-      searchInferenceEndpoints,
+      const result = await resolveSelectedConnectorId({
+        uiSettings,
+        savedObjects,
+        request,
+        inference,
+        searchInferenceEndpoints,
+      });
+
+      expect(result).toBe('gemini-id');
     });
 
-    expect(result).toBe('inference-id');
-  });
+    it('returns undefined when no connectors are available', async () => {
+      const { savedObjects, uiSettings, request } = setupCoreMocks(noDefaultSettings);
+      const inference = inferenceMock.createStartContract();
+      const searchInferenceEndpoints = createSearchInferenceEndpointsMock();
 
-  it('selects OpenAI connector when Inference is not available', async () => {
-    const { savedObjects, uiSettings, request } = setupCoreMocks({
-      [GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR]: 'NO_DEFAULT_CONNECTOR',
-      [GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR_DEFAULT_ONLY]: false,
-    });
-    const inference = inferenceMock.createStartContract();
-    (inference.getDefaultConnector as jest.Mock).mockRejectedValue(new Error('no default'));
-    (inference.getConnectorList as jest.Mock).mockResolvedValue([
-      { connectorId: 'openai-id', type: InferenceConnectorType.OpenAI } as InferenceConnector,
-      { connectorId: 'first-id', type: InferenceConnectorType.Gemini } as InferenceConnector,
-    ]);
+      (inference.getConnectorList as jest.Mock).mockResolvedValue([]);
 
-    const result = await resolveSelectedConnectorId({
-      uiSettings,
-      savedObjects,
-      request,
-      inference,
-      searchInferenceEndpoints,
+      const result = await resolveSelectedConnectorId({
+        uiSettings,
+        savedObjects,
+        request,
+        inference,
+        searchInferenceEndpoints,
+      });
+
+      expect(result).toBeUndefined();
     });
 
-    expect(result).toBe('openai-id');
-  });
+    it('falls back to connector list when getForFeature throws', async () => {
+      const { savedObjects, uiSettings, request } = setupCoreMocks(noDefaultSettings);
+      const inference = inferenceMock.createStartContract();
+      const searchInferenceEndpoints = createSearchInferenceEndpointsMock({
+        error: new Error('feature resolution failed'),
+      });
+      const kibanaDefault = defaultInferenceEndpoints.KIBANA_DEFAULT_CHAT_COMPLETION;
 
-  it('selects first connector when neither Inference nor OpenAI are available', async () => {
-    const { savedObjects, uiSettings, request } = setupCoreMocks({
-      [GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR]: 'NO_DEFAULT_CONNECTOR',
-      [GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR_DEFAULT_ONLY]: false,
+      (inference.getConnectorList as jest.Mock).mockResolvedValue([
+        { connectorId: kibanaDefault } as InferenceConnector,
+      ]);
+
+      const result = await resolveSelectedConnectorId({
+        uiSettings,
+        savedObjects,
+        request,
+        inference,
+        searchInferenceEndpoints,
+      });
+
+      expect(result).toBe(kibanaDefault);
     });
-    const inference = inferenceMock.createStartContract();
-    (inference.getDefaultConnector as jest.Mock).mockRejectedValue(new Error('no default'));
-    (inference.getConnectorList as jest.Mock).mockResolvedValue([
-      { connectorId: 'first-id', type: InferenceConnectorType.Gemini } as InferenceConnector,
-      { connectorId: 'second-id', type: InferenceConnectorType.Bedrock } as InferenceConnector,
-    ]);
-
-    const result = await resolveSelectedConnectorId({
-      uiSettings,
-      savedObjects,
-      request,
-      inference,
-      searchInferenceEndpoints,
-    });
-
-    expect(result).toBe('first-id');
-  });
-
-  it('returns undefined when no default and no connectors are available', async () => {
-    const { savedObjects, uiSettings, request } = setupCoreMocks({
-      [GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR]: 'NO_DEFAULT_CONNECTOR',
-      [GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR_DEFAULT_ONLY]: false,
-    });
-    const inference = inferenceMock.createStartContract();
-    (inference.getDefaultConnector as jest.Mock).mockRejectedValue(new Error('no default'));
-    (inference.getConnectorList as jest.Mock).mockResolvedValue([]);
-
-    const result = await resolveSelectedConnectorId({
-      uiSettings,
-      savedObjects,
-      request,
-      inference,
-      searchInferenceEndpoints,
-    });
-
-    expect(result).toBeUndefined();
   });
 });

--- a/x-pack/platform/plugins/shared/agent_builder/server/utils/resolve_selected_connector_id.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/utils/resolve_selected_connector_id.test.ts
@@ -12,10 +12,13 @@ import { uiSettingsServiceMock } from '@kbn/core-ui-settings-server-mocks';
 import { savedObjectsServiceMock } from '@kbn/core-saved-objects-server-mocks';
 import { httpServerMock } from '@kbn/core-http-server-mocks';
 import { inferenceMock } from '@kbn/inference-plugin/server/mocks';
+import type { SearchInferenceEndpointsPluginStart } from '@kbn/search-inference-endpoints/server';
 import {
   GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR,
   GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR_DEFAULT_ONLY,
 } from '@kbn/management-settings-ids';
+
+const searchInferenceEndpoints = {} as SearchInferenceEndpointsPluginStart;
 
 const setupCoreMocks = (values: Record<string, any>) => {
   const savedObjects = savedObjectsServiceMock.createStartContract();
@@ -46,6 +49,7 @@ describe('resolveSelectedConnectorId', () => {
         request,
         connectorId: 'explicit-id',
         inference,
+        searchInferenceEndpoints,
       })
     ).rejects.toThrow(
       'Connector ID [explicit-id] does not match the configured default connector ID [default-id].'
@@ -67,6 +71,7 @@ describe('resolveSelectedConnectorId', () => {
       request,
       connectorId: 'default-id',
       inference,
+      searchInferenceEndpoints,
     });
 
     expect(result).toBe('default-id');
@@ -87,6 +92,7 @@ describe('resolveSelectedConnectorId', () => {
       request,
       connectorId: 'explicit-id',
       inference,
+      searchInferenceEndpoints,
     });
 
     expect(result).toBe('explicit-id');
@@ -106,6 +112,7 @@ describe('resolveSelectedConnectorId', () => {
       savedObjects,
       request,
       inference,
+      searchInferenceEndpoints,
     });
 
     expect(result).toBe('default-id');
@@ -128,6 +135,7 @@ describe('resolveSelectedConnectorId', () => {
       savedObjects,
       request,
       inference,
+      searchInferenceEndpoints,
     });
 
     expect(result).toBe('inference-default-id');
@@ -155,6 +163,7 @@ describe('resolveSelectedConnectorId', () => {
       savedObjects,
       request,
       inference,
+      searchInferenceEndpoints,
     });
 
     expect(result).toBe('Google-Gemini-2-5-Pro');
@@ -181,6 +190,7 @@ describe('resolveSelectedConnectorId', () => {
       savedObjects,
       request,
       inference,
+      searchInferenceEndpoints,
     });
 
     expect(result).toBe(PREFERRED_DEFAULT_CONNECTOR_ID);
@@ -204,6 +214,7 @@ describe('resolveSelectedConnectorId', () => {
       savedObjects,
       request,
       inference,
+      searchInferenceEndpoints,
     });
 
     expect(result).toBe('inference-id');
@@ -226,6 +237,7 @@ describe('resolveSelectedConnectorId', () => {
       savedObjects,
       request,
       inference,
+      searchInferenceEndpoints,
     });
 
     expect(result).toBe('openai-id');
@@ -248,6 +260,7 @@ describe('resolveSelectedConnectorId', () => {
       savedObjects,
       request,
       inference,
+      searchInferenceEndpoints,
     });
 
     expect(result).toBe('first-id');
@@ -267,6 +280,7 @@ describe('resolveSelectedConnectorId', () => {
       savedObjects,
       request,
       inference,
+      searchInferenceEndpoints,
     });
 
     expect(result).toBeUndefined();

--- a/x-pack/platform/plugins/shared/agent_builder/server/utils/resolve_selected_connector_id.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/utils/resolve_selected_connector_id.ts
@@ -9,6 +9,7 @@ import type { KibanaRequest } from '@kbn/core-http-server';
 import type { UiSettingsServiceStart } from '@kbn/core-ui-settings-server';
 import type { SavedObjectsServiceStart } from '@kbn/core-saved-objects-server';
 import type { InferenceServerStart } from '@kbn/inference-plugin/server';
+import type { SearchInferenceEndpointsPluginStart } from '@kbn/search-inference-endpoints/server';
 import type { InferenceConnector } from '@kbn/inference-common';
 import { InferenceConnectorType } from '@kbn/inference-common';
 import {
@@ -80,12 +81,14 @@ export const resolveSelectedConnectorId = async ({
   request,
   connectorId,
   inference,
+  searchInferenceEndpoints,
 }: {
   uiSettings: UiSettingsServiceStart;
   savedObjects: SavedObjectsServiceStart;
   request: KibanaRequest;
   connectorId?: string;
   inference: InferenceServerStart;
+  searchInferenceEndpoints: SearchInferenceEndpointsPluginStart;
 }): Promise<string | undefined> => {
   const soClient = savedObjects.getScopedClient(request);
   const uiSettingsClient = uiSettings.asScopedToClient(soClient);

--- a/x-pack/platform/plugins/shared/agent_builder/server/utils/resolve_selected_connector_id.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/utils/resolve_selected_connector_id.ts
@@ -10,68 +10,69 @@ import type { UiSettingsServiceStart } from '@kbn/core-ui-settings-server';
 import type { SavedObjectsServiceStart } from '@kbn/core-saved-objects-server';
 import type { InferenceServerStart } from '@kbn/inference-plugin/server';
 import type { SearchInferenceEndpointsPluginStart } from '@kbn/search-inference-endpoints/server';
+import { defaultInferenceEndpoints, InferenceConnectorType } from '@kbn/inference-common';
 import type { InferenceConnector } from '@kbn/inference-common';
-import { InferenceConnectorType } from '@kbn/inference-common';
 import {
   GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR,
   GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR_DEFAULT_ONLY,
 } from '@kbn/management-settings-ids';
-import { PREFERRED_DEFAULT_CONNECTOR_ID } from '../../common/constants';
-import { getFirstRecommendedConnectorId } from '../../common/recommended_connectors';
+import { AGENT_BUILDER_INFERENCE_FEATURE_ID } from '@kbn/agent-builder-common/constants';
 
 // TODO: Import from gen-ai-settings-plugin (package) once available
 const NO_DEFAULT_CONNECTOR = 'NO_DEFAULT_CONNECTOR';
 
-const selectDefaultConnector = ({ connectors }: { connectors: InferenceConnector[] }) => {
-  const recommendedId = getFirstRecommendedConnectorId(connectors.map((c) => c.connectorId));
-  if (recommendedId) {
-    const recommendedConnector = connectors.find((c) => c.connectorId === recommendedId);
-    if (recommendedConnector) return recommendedConnector;
-  }
-
-  const preferredConnector = connectors.find(
-    (connector) => connector.connectorId === PREFERRED_DEFAULT_CONNECTOR_ID
-  );
-  if (preferredConnector) return preferredConnector;
-
-  const inferenceConnector = connectors.find(
-    (connector) => connector.type === InferenceConnectorType.Inference
-  );
-  if (inferenceConnector) return inferenceConnector;
-
-  const openAIConnector = connectors.find(
-    (connector) => connector.type === InferenceConnectorType.OpenAI
-  );
-  if (openAIConnector) return openAIConnector;
-
-  return connectors[0];
-};
-
-const tryGetInferenceDefault = async (
-  inference: InferenceServerStart,
-  request: KibanaRequest
-): Promise<string | undefined> => {
-  try {
-    const defaultConnector = await inference.getDefaultConnector(request);
+const selectFallbackConnector = (connectors: InferenceConnector[]): string => {
+  const defaultId = defaultInferenceEndpoints.KIBANA_DEFAULT_CHAT_COMPLETION;
+  const defaultConnector = connectors.find((c) => c.connectorId === defaultId);
+  if (defaultConnector) {
     return defaultConnector.connectorId;
-  } catch {
-    return undefined;
   }
+
+  const inferenceConnector = connectors.find((c) => c.type === InferenceConnectorType.Inference);
+  if (inferenceConnector) {
+    return inferenceConnector.connectorId;
+  }
+
+  const openAIConnector = connectors.find((c) => c.type === InferenceConnectorType.OpenAI);
+  if (openAIConnector) {
+    return openAIConnector.connectorId;
+  }
+
+  return connectors[0].connectorId;
 };
 
-const tryGetFallbackConnector = async (
-  inference: InferenceServerStart,
-  request: KibanaRequest
-): Promise<string | undefined> => {
+const tryResolveFallbackConnector = async ({
+  searchInferenceEndpoints,
+  inference,
+  request,
+}: {
+  searchInferenceEndpoints: SearchInferenceEndpointsPluginStart;
+  inference: InferenceServerStart;
+  request: KibanaRequest;
+}): Promise<string | undefined> => {
+  // First, try feature-registered endpoints (admin SO overrides or recommended endpoints)
+  try {
+    const { endpoints } = await searchInferenceEndpoints.endpoints.getForFeature(
+      AGENT_BUILDER_INFERENCE_FEATURE_ID,
+      request
+    );
+    if (endpoints.length > 0) {
+      return endpoints[0].connectorId;
+    }
+  } catch {
+    // Ignore errors — fall through to connector list fallback
+  }
+
+  // Fall back to the full connector list, preferring the platform default
   try {
     const connectors = await inference.getConnectorList(request);
     if (connectors.length > 0) {
-      const fallbackConnector = selectDefaultConnector({ connectors });
-      return fallbackConnector.connectorId;
+      return selectFallbackConnector(connectors);
     }
   } catch {
     // Ignore errors
   }
+
   return undefined;
 };
 
@@ -109,11 +110,12 @@ export const resolveSelectedConnectorId = async ({
     }
     return defaultConnectorSetting;
   }
-  if (connectorId) return connectorId;
-  if (hasValidDefaultConnector) return defaultConnectorSetting;
+  if (connectorId) {
+    return connectorId;
+  }
+  if (hasValidDefaultConnector) {
+    return defaultConnectorSetting;
+  }
 
-  return (
-    (await tryGetInferenceDefault(inference, request)) ||
-    (await tryGetFallbackConnector(inference, request))
-  );
+  return tryResolveFallbackConnector({ searchInferenceEndpoints, inference, request });
 };


### PR DESCRIPTION
## Summary

Change our server-side default connector logic to use `searchInferenceEndpoints.endpoints.getForFeature` (and fallback to previous behavior) 

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->