### PR TITLE
fix: [Platform:Management:Fleet] Flyout missing title from announcement

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/components/agent_activity_flyout/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/components/agent_activity_flyout/index.tsx
@@ -18,6 +18,7 @@ import {
   EuiPanel,
   EuiButtonEmpty,
   EuiFlyoutFooter,
+  useGeneratedHtmlId,
 } from '@elastic/eui';
 import styled from 'styled-components';
 
@@ -123,6 +124,8 @@ export const AgentActivityFlyout: React.FunctionComponent<{
     setNActions(defaultNActions);
   };
 
+  const flyoutTitleId = useGeneratedHtmlId();
+
   return (
     <>
       <EuiFlyout
@@ -134,13 +137,14 @@ export const AgentActivityFlyout: React.FunctionComponent<{
         }}
         paddingSize="none"
         maxWidth={MAX_FLYOUT_WIDTH}
+        aria-labelledby={flyoutTitleId}
       >
-        <EuiFlyoutHeader aria-labelledby="FleetAgentActivityFlyoutTitle">
+        <EuiFlyoutHeader>
           <EuiPanel borderRadius="none" hasShadow={false} hasBorder={true}>
             <EuiFlexGroup direction="column" gutterSize="m">
               <EuiFlexItem>
                 <EuiTitle size="l">
-                  <h1>
+                  <h1 id={flyoutTitleId}>
                     <FormattedMessage
                       id="xpack.fleet.agentActivityFlyout.title"
                       defaultMessage="Agent activity"


### PR DESCRIPTION
Closes: #264347

**What**
Fixes an issue in Fleet (Management) where an announcement flyout could render without a title, resulting in an incomplete/blank flyout header.

**Why**
Announcements should always present a clear title for accessibility and user clarity. Missing titles make the flyout confusing and can lead to inconsistent UI/UX.

**How**
Ensures the flyout title is always set when opening/rendering the announcement flyout (using the announcement metadata / fallback title when needed), so the header consistently displays a valid title.

<!--ONMERGE {"backportTargets":["9.3","9.4"]} ONMERGE-->