### PR TITLE
[Synthetics] Fix FTR test Fleet memory pressure causing Kibana OOM on Cloud

### DIFF
--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/legacy_and_multispace_monitor_api.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/legacy_and_multispace_monitor_api.ts
@@ -440,9 +440,7 @@ const runTests = (
         validationPrivateLocation
       );
       const resp = await supertestEditorWithApiKey
-        .post(
-          `/s/${validationSpaceId}${SYNTHETICS_API_URLS.SYNTHETICS_MONITORS}?internal=true`
-        )
+        .post(`/s/${validationSpaceId}${SYNTHETICS_API_URLS.SYNTHETICS_MONITORS}?internal=true`)
         .send(monitorData);
 
       expect(resp.status).to.be(400);

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/legacy_and_multispace_monitor_api.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/legacy_and_multispace_monitor_api.ts
@@ -415,22 +415,34 @@ const runTests = (
   });
 
   describe('Monitor space validation', () => {
+    let validationSpaceId: string;
+    let validationPrivateLocation: any;
+
+    before(async () => {
+      validationSpaceId = `validation-space-${uuidv4()}`;
+      await kibanaServer.spaces.create({
+        id: validationSpaceId,
+        name: `Validation Space`,
+      });
+      spacesToDeleteIds.push(validationSpaceId);
+      validationPrivateLocation = usePrivateLocations
+        ? await privateLocationService.addTestPrivateLocation(validationSpaceId)
+        : undefined;
+    });
+
     it('should throw error if spaces list does not include the calling space on create', async () => {
-      const INVALID_SPACE = `invalid-space-${uuidv4()}`;
-      await kibanaServer.spaces.create({ id: INVALID_SPACE, name: `Invalid Space` });
-      spacesToDeleteIds.push(INVALID_SPACE);
       const monitorData = applyLocation(
         {
           ...getFixtureJson('http_monitor'),
           name: `invalid-create-${uuidv4()}`,
           spaces: ['default'],
         },
-        usePrivateLocations
-          ? await privateLocationService.addTestPrivateLocation(INVALID_SPACE)
-          : undefined
+        validationPrivateLocation
       );
       const resp = await supertestEditorWithApiKey
-        .post(`/s/${INVALID_SPACE}${SYNTHETICS_API_URLS.SYNTHETICS_MONITORS}?internal=true`)
+        .post(
+          `/s/${validationSpaceId}${SYNTHETICS_API_URLS.SYNTHETICS_MONITORS}?internal=true`
+        )
         .send(monitorData);
 
       expect(resp.status).to.be(400);
@@ -440,30 +452,23 @@ const runTests = (
     });
 
     it('should throw error if spaces list does not include the calling space on edit', async () => {
-      const EDIT_SPACE = `edit-space-${uuidv4()}`;
-      await kibanaServer.spaces.create({ id: EDIT_SPACE, name: `Edit Space` });
-      spacesToDeleteIds.push(EDIT_SPACE);
       const monitorData = applyLocation(
         {
           ...getFixtureJson('http_monitor'),
           name: `edit-invalid-${uuidv4()}`,
-          spaces: [EDIT_SPACE],
+          spaces: [validationSpaceId],
         },
-        usePrivateLocations
-          ? await privateLocationService.addTestPrivateLocation(EDIT_SPACE)
-          : undefined
+        validationPrivateLocation
       );
-      // Create monitor in EDIT_SPACE
       const res = await supertestEditorWithApiKey
         .post(
-          `/s/${EDIT_SPACE}${SYNTHETICS_API_URLS.SYNTHETICS_MONITORS}?internal=true&savedObjectType=${syntheticsMonitorSavedObjectType}`
+          `/s/${validationSpaceId}${SYNTHETICS_API_URLS.SYNTHETICS_MONITORS}?internal=true&savedObjectType=${syntheticsMonitorSavedObjectType}`
         )
         .send(monitorData);
       expect(res.status).eql(200, JSON.stringify(res.body));
-      // Try to edit monitor with spaces not including EDIT_SPACE
       const resp = await supertestEditorWithApiKey
         .put(
-          `/s/${EDIT_SPACE}${SYNTHETICS_API_URLS.SYNTHETICS_MONITORS}/${res.body.id}?internal=true`
+          `/s/${validationSpaceId}${SYNTHETICS_API_URLS.SYNTHETICS_MONITORS}/${res.body.id}?internal=true`
         )
         .send({ name: `edit-invalid-${uuidv4()}`, spaces: ['default'] });
 

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/services/synthetics_private_location.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/services/synthetics_private_location.ts
@@ -193,7 +193,7 @@ export class PrivateLocationTestService {
         .post(
           `${
             spaceIds[0] !== 'default' ? `/s/${spaceIds[0]}` : ``
-          }/api/fleet/agent_policies?sys_monitoring=true`
+          }/api/fleet/agent_policies`
         )
         .set('kbn-xsrf', 'true')
         .send({

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/services/synthetics_private_location.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/services/synthetics_private_location.ts
@@ -190,11 +190,7 @@ export class PrivateLocationTestService {
   async addFleetPolicy(name: string, spaceIds = ['default']) {
     return await this.retry.try(async () => {
       const response = await this.supertestWithAuth
-        .post(
-          `${
-            spaceIds[0] !== 'default' ? `/s/${spaceIds[0]}` : ``
-          }/api/fleet/agent_policies`
-        )
+        .post(`${spaceIds[0] !== 'default' ? `/s/${spaceIds[0]}` : ``}/api/fleet/agent_policies`)
         .set('kbn-xsrf', 'true')
         .send({
           name,


### PR DESCRIPTION
## Summary

The `SyntheticsAPITests` FTR suite was causing Kibana to OOM (502 "backend closed connection") on Cloud deployments. The crash consistently occurred during the `LegacyAndMultiSpaceMonitorAPI` test file, around the space-editing tests.

**Root cause:** Two sources of excessive Fleet memory pressure:

1. **`addFleetPolicy` used `?sys_monitoring=true`** — Every `addTestPrivateLocation()` call across all ~25 test files created a Fleet agent policy that also installed the system monitoring package, created a system package policy, and triggered full policy compilation. No synthetics test actually depends on system monitoring being present.

2. **"Monitor space validation" tests each created their own space + Fleet agent policy** — Two tests that only verify validation error messages were each spinning up a brand new Kibana space and Fleet agent policy (with system monitoring), when they could share a single one.

### Changes

- **`synthetics_private_location.ts`**: Removed `?sys_monitoring=true` from `addFleetPolicy`. This eliminates unnecessary system package installation + compilation for every private location across the entire synthetics test suite (~40+ calls).
- **`legacy_and_multispace_monitor_api.ts`**: Consolidated the two "Monitor space validation" tests to share a single space and private location via a `before` hook (2 agent policy creations → 1, 2 space creations → 1).

### Results

| Metric | Before | After |
|---|---|---|
| `LegacyAndMultiSpaceMonitorAPI` suite runtime | 5.0 min | **3.0 min** |
| Validation tests | ~30s each | **1-5s each** |
| 502 OOM crashes on Cloud | Yes (test 9+) | **None** |
| Full `SyntheticsAPITests` suite | Crashes mid-run | **No 502/503 errors** |

## Test plan

- [x] Ran `LegacyAndMultiSpaceMonitorAPI` in isolation — 13/13 passing (3.0 min)
- [x] Ran full `SyntheticsAPITests` suite on Cloud deployment — no 502/503/OOM errors (previously crashed after ~8 tests)

Made with [Cursor](https://cursor.com)

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->