### PR TITLE
[Alerting v2] Bound dispatcher last-notified query by longest configured throttle interval

### DIFF
--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/queries.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/queries.test.ts
@@ -205,8 +205,10 @@ describe('getAlertEpisodeSuppressionsQuery', () => {
 });
 
 describe('getLastNotifiedTimestampsQuery', () => {
+  const SINCE = new Date('2026-01-22T00:00:00.000Z');
+
   it('builds a query for a single notification group', () => {
-    const req = getLastNotifiedTimestampsQuery(['group-1']);
+    const req = getLastNotifiedTimestampsQuery(['group-1'], SINCE);
 
     expect(req.query).toContain('notification_group_id IN ("group-1")');
     expect(req.query).toContain('.alert-actions');
@@ -214,32 +216,48 @@ describe('getLastNotifiedTimestampsQuery', () => {
   });
 
   it('builds a query for multiple notification groups', () => {
-    const req = getLastNotifiedTimestampsQuery(['group-1', 'group-2']);
+    const req = getLastNotifiedTimestampsQuery(['group-1', 'group-2'], SINCE);
 
     expect(req.query).toContain('notification_group_id IN ("group-1", "group-2")');
   });
 
   it('filters for notified action type', () => {
-    const req = getLastNotifiedTimestampsQuery(['group-1']);
+    const req = getLastNotifiedTimestampsQuery(['group-1'], SINCE);
 
     expect(req.query).toContain('action_type == "notified"');
   });
 
   it('keeps the expected output columns', () => {
-    const req = getLastNotifiedTimestampsQuery(['group-1']);
+    const req = getLastNotifiedTimestampsQuery(['group-1'], SINCE);
 
     expect(req.query).toContain('KEEP notification_group_id, last_notified, episode_status');
   });
 
   it('aggregates episode_status using LAST by timestamp', () => {
-    const req = getLastNotifiedTimestampsQuery(['group-1']);
+    const req = getLastNotifiedTimestampsQuery(['group-1'], SINCE);
 
     expect(req.query).toContain('episode_status = LAST(episode_status, @timestamp)');
   });
 
   it('groups by notification_group_id', () => {
-    const req = getLastNotifiedTimestampsQuery(['group-1']);
+    const req = getLastNotifiedTimestampsQuery(['group-1'], SINCE);
 
     expect(req.query).toContain('BY notification_group_id');
+  });
+
+  it('bounds the scan by the given `since` timestamp', () => {
+    const req = getLastNotifiedTimestampsQuery(['group-1'], SINCE);
+
+    expect(req.query).toContain(`@timestamp >= "${SINCE.toISOString()}"::DATETIME`);
+  });
+
+  it('applies the timestamp bound before the notification group filter', () => {
+    const req = getLastNotifiedTimestampsQuery(['group-1'], SINCE);
+
+    const timestampBoundIndex = req.query.indexOf(`@timestamp >= "${SINCE.toISOString()}"`);
+    const notifiedFilterIndex = req.query.indexOf('action_type == "notified"');
+
+    expect(timestampBoundIndex).toBeGreaterThanOrEqual(0);
+    expect(notifiedFilterIndex).toBeGreaterThan(timestampBoundIndex);
   });
 });

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/queries.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/queries.ts
@@ -89,13 +89,23 @@ export const getAlertEpisodeSuppressionsQuery = (alertEpisodes: AlertEpisode[]):
       | KEEP rule_id, group_hash, episode_id, should_suppress, last_ack_action, last_deactivate_action, last_snooze_action`.toRequest();
 };
 
+/**
+ * Builds the ES|QL query that returns the most recent `notified` action per notification group.
+ *
+ * The `since` bound caps how far back the query scans. The throttling step derives this bound
+ * from the longest `policy.throttle.interval` currently configured, so the query cost stays
+ * proportional to the active throttle windows rather than the full retention of the actions
+ * data stream.
+ */
 export const getLastNotifiedTimestampsQuery = (
-  notificationGroupIds: NotificationGroupId[]
+  notificationGroupIds: NotificationGroupId[],
+  since: Date
 ): EsqlRequest => {
   const values = notificationGroupIds.map((id) => esql.str(id));
   const whereClause = esql.exp`action_type == "notified" AND notification_group_id IN (${values})`;
 
   return esql`FROM ${ALERT_ACTIONS_DATA_STREAM}
+    | WHERE @timestamp >= ${since.toISOString()}::datetime
     | WHERE ${whereClause}
     | STATS last_notified = MAX(@timestamp), episode_status = LAST(episode_status, @timestamp) BY notification_group_id
     | KEEP notification_group_id, last_notified, episode_status

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/steps/apply_throttling_step.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/steps/apply_throttling_step.test.ts
@@ -591,8 +591,7 @@ describe('ApplyThrottlingStep', () => {
 
     await step.execute(buildState({ groups: [group], policies, startedAt }));
 
-    const expectedLookbackMs =
-      7 * 24 * 60 * 60 * 1000 * LAST_NOTIFIED_LOOKBACK_SAFETY_FACTOR;
+    const expectedLookbackMs = 7 * 24 * 60 * 60 * 1000 * LAST_NOTIFIED_LOOKBACK_SAFETY_FACTOR;
     const expectedSince = new Date(startedAt.getTime() - expectedLookbackMs).toISOString();
 
     expect(mockEsClient.esql.query).toHaveBeenCalledTimes(1);

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/steps/apply_throttling_step.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/steps/apply_throttling_step.test.ts
@@ -5,13 +5,29 @@
  * 2.0.
  */
 
-import { applyThrottling } from './apply_throttling_step';
+import {
+  applyThrottling,
+  ApplyThrottlingStep,
+  computeLastNotifiedLookbackMs,
+  LAST_NOTIFIED_LOOKBACK_CEILING_MS,
+  LAST_NOTIFIED_LOOKBACK_FLOOR_MS,
+  LAST_NOTIFIED_LOOKBACK_SAFETY_FACTOR,
+} from './apply_throttling_step';
+import { createQueryService } from '../../services/query_service/query_service.mock';
+import { createLoggerService } from '../../services/logger_service/logger_service.mock';
+import { createLastNotifiedTimestampsResponse } from '../fixtures/dispatcher';
 import {
   createAlertEpisode,
+  createDispatcherPipelineState,
   createNotificationGroup,
   createNotificationPolicy,
 } from '../fixtures/test_utils';
-import type { NotificationGroupId, LastNotifiedInfo } from '../types';
+import type {
+  NotificationGroupId,
+  LastNotifiedInfo,
+  NotificationPolicy,
+  NotificationPolicyId,
+} from '../types';
 
 const NOW = new Date('2026-01-22T10:00:00.000Z');
 
@@ -459,5 +475,155 @@ describe('applyThrottling', () => {
       expect(dispatch).toHaveLength(0);
       expect(throttled).toHaveLength(0);
     });
+  });
+});
+
+describe('computeLastNotifiedLookbackMs', () => {
+  const buildPolicies = (
+    intervals: Array<string | undefined>
+  ): Map<NotificationPolicyId, NotificationPolicy> => {
+    const entries = intervals.map((interval, idx) => {
+      const id = `p${idx}`;
+      const policy = createNotificationPolicy({
+        id,
+        throttle: interval === undefined ? undefined : { interval },
+      });
+      return [id, policy] as const;
+    });
+    return new Map(entries);
+  };
+
+  it('returns the floor when there are no policies', () => {
+    expect(computeLastNotifiedLookbackMs(new Map())).toBe(LAST_NOTIFIED_LOOKBACK_FLOOR_MS);
+  });
+
+  it('returns the floor when no policy has a throttle interval', () => {
+    const policies = buildPolicies([undefined, undefined]);
+    expect(computeLastNotifiedLookbackMs(policies)).toBe(LAST_NOTIFIED_LOOKBACK_FLOOR_MS);
+  });
+
+  it('returns the floor when the longest interval is below it', () => {
+    const policies = buildPolicies(['5m', '30m']);
+    expect(computeLastNotifiedLookbackMs(policies)).toBe(LAST_NOTIFIED_LOOKBACK_FLOOR_MS);
+  });
+
+  it('derives the lookback from the longest configured interval with safety factor', () => {
+    const policies = buildPolicies(['1h', '7d', '2h']);
+    const sevenDaysMs = 7 * 24 * 60 * 60 * 1000;
+    expect(computeLastNotifiedLookbackMs(policies)).toBe(
+      sevenDaysMs * LAST_NOTIFIED_LOOKBACK_SAFETY_FACTOR
+    );
+  });
+
+  it('clamps to the ceiling when the longest interval exceeds it', () => {
+    const policies = buildPolicies(['52w']);
+    const { loggerService, mockLogger } = createLoggerService();
+
+    const result = computeLastNotifiedLookbackMs(policies, loggerService);
+
+    expect(result).toBe(LAST_NOTIFIED_LOOKBACK_CEILING_MS);
+    expect(mockLogger.warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not warn when the lookback fits within the ceiling', () => {
+    const policies = buildPolicies(['7d']);
+    const { loggerService, mockLogger } = createLoggerService();
+
+    computeLastNotifiedLookbackMs(policies, loggerService);
+
+    expect(mockLogger.warn).not.toHaveBeenCalled();
+  });
+
+  it('skips policies with malformed interval strings without throwing', () => {
+    const policies = buildPolicies(['not-a-duration', '7d', '10y']);
+    const sevenDaysMs = 7 * 24 * 60 * 60 * 1000;
+    expect(computeLastNotifiedLookbackMs(policies)).toBe(
+      sevenDaysMs * LAST_NOTIFIED_LOOKBACK_SAFETY_FACTOR
+    );
+  });
+
+  it('returns the floor when every policy has an invalid interval', () => {
+    const policies = buildPolicies(['invalid', '10y']);
+    expect(computeLastNotifiedLookbackMs(policies)).toBe(LAST_NOTIFIED_LOOKBACK_FLOOR_MS);
+  });
+});
+
+describe('ApplyThrottlingStep', () => {
+  const buildState = (overrides: {
+    groups?: ReturnType<typeof createNotificationGroup>[];
+    policies?: Map<NotificationPolicyId, NotificationPolicy>;
+    startedAt?: Date;
+  }) =>
+    createDispatcherPipelineState({
+      groups: overrides.groups,
+      policies: overrides.policies,
+      input: {
+        startedAt: overrides.startedAt ?? new Date('2026-01-22T08:00:00.000Z'),
+        previousStartedAt: new Date('2026-01-22T07:30:00.000Z'),
+      },
+    });
+
+  it('returns early without querying when there are no groups', async () => {
+    const { queryService, mockEsClient } = createQueryService();
+    const { loggerService } = createLoggerService();
+    const step = new ApplyThrottlingStep(queryService, loggerService);
+
+    const result = await step.execute(buildState({ groups: [] }));
+
+    expect(mockEsClient.esql.query).not.toHaveBeenCalled();
+    expect(result.type).toBe('continue');
+    if (result.type !== 'continue') return;
+    expect(result.data).toEqual({ dispatch: [], throttled: [] });
+  });
+
+  it('bounds the last-notified query by startedAt minus the derived lookback', async () => {
+    const { queryService, mockEsClient } = createQueryService();
+    const { loggerService } = createLoggerService();
+    const step = new ApplyThrottlingStep(queryService, loggerService);
+
+    mockEsClient.esql.query.mockResolvedValueOnce(createLastNotifiedTimestampsResponse());
+
+    const startedAt = new Date('2026-01-22T08:00:00.000Z');
+    const policies = new Map<NotificationPolicyId, NotificationPolicy>([
+      ['p1', createNotificationPolicy({ id: 'p1', throttle: { interval: '7d' } })],
+    ]);
+    const group = createNotificationGroup({ id: 'g1', policyId: 'p1' });
+
+    await step.execute(buildState({ groups: [group], policies, startedAt }));
+
+    const expectedLookbackMs =
+      7 * 24 * 60 * 60 * 1000 * LAST_NOTIFIED_LOOKBACK_SAFETY_FACTOR;
+    const expectedSince = new Date(startedAt.getTime() - expectedLookbackMs).toISOString();
+
+    expect(mockEsClient.esql.query).toHaveBeenCalledTimes(1);
+    const [[{ query }]] = mockEsClient.esql.query.mock.calls as unknown as Array<
+      [{ query: string }]
+    >;
+    expect(query).toContain(`@timestamp >= "${expectedSince}"::DATETIME`);
+  });
+
+  it('uses the floor lookback when no policy has a throttle interval', async () => {
+    const { queryService, mockEsClient } = createQueryService();
+    const { loggerService } = createLoggerService();
+    const step = new ApplyThrottlingStep(queryService, loggerService);
+
+    mockEsClient.esql.query.mockResolvedValueOnce(createLastNotifiedTimestampsResponse());
+
+    const startedAt = new Date('2026-01-22T08:00:00.000Z');
+    const policies = new Map<NotificationPolicyId, NotificationPolicy>([
+      ['p1', createNotificationPolicy({ id: 'p1' })],
+    ]);
+    const group = createNotificationGroup({ id: 'g1', policyId: 'p1' });
+
+    await step.execute(buildState({ groups: [group], policies, startedAt }));
+
+    const expectedSince = new Date(
+      startedAt.getTime() - LAST_NOTIFIED_LOOKBACK_FLOOR_MS
+    ).toISOString();
+
+    const [[{ query }]] = mockEsClient.esql.query.mock.calls as unknown as Array<
+      [{ query: string }]
+    >;
+    expect(query).toContain(`@timestamp >= "${expectedSince}"::DATETIME`);
   });
 });

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/steps/apply_throttling_step.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/steps/apply_throttling_step.ts
@@ -23,7 +23,77 @@ import type {
   NotificationGroup,
   NotificationGroupId,
   NotificationPolicy,
+  NotificationPolicyId,
 } from '../types';
+
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Minimum lookback for the last-notified query. Covers the `on_status_change` strategy
+ * (which has no interval) when an episode has been stable for a while: a spurious
+ * re-notification at this cadence is acceptable and acts as a "still active" signal.
+ */
+export const LAST_NOTIFIED_LOOKBACK_FLOOR_MS = ONE_DAY_MS;
+
+/**
+ * Hard cap on the lookback, protecting against pathological policy configurations
+ * (e.g. a multi-year throttle interval) that would otherwise re-expand the query
+ * toward a full data-stream scan.
+ */
+export const LAST_NOTIFIED_LOOKBACK_CEILING_MS = 90 * ONE_DAY_MS;
+
+/**
+ * Headroom on top of the longest configured throttle interval. A record at exactly
+ * the interval boundary is no longer "within interval", but the factor gives us a
+ * safety margin against clock skew and pipeline latency.
+ */
+export const LAST_NOTIFIED_LOOKBACK_SAFETY_FACTOR = 1.2;
+
+/**
+ * Derives the lookback window for `getLastNotifiedTimestampsQuery` from the currently
+ * enabled notification policies. Throttling decisions only need history within the
+ * longest configured throttle interval; anything older cannot change the outcome.
+ *
+ * Policies with malformed interval strings are skipped (not fatal) so a single bad
+ * policy cannot break throttling for the rest.
+ */
+export function computeLastNotifiedLookbackMs(
+  policies: ReadonlyMap<NotificationPolicyId, NotificationPolicy>,
+  logger?: LoggerServiceContract
+): number {
+  let maxIntervalMs = 0;
+
+  for (const policy of policies.values()) {
+    const interval = policy.throttle?.interval;
+    if (!interval) continue;
+    try {
+      const ms = parseDurationToMs(interval);
+      if (ms > maxIntervalMs) maxIntervalMs = ms;
+    } catch {
+      // Intentionally swallow: invalid interval strings are handled defensively here
+      // so throttling for other policies keeps working.
+    }
+  }
+
+  const desiredMs = maxIntervalMs * LAST_NOTIFIED_LOOKBACK_SAFETY_FACTOR;
+  const clampedMs = Math.min(
+    LAST_NOTIFIED_LOOKBACK_CEILING_MS,
+    Math.max(LAST_NOTIFIED_LOOKBACK_FLOOR_MS, desiredMs)
+  );
+
+  if (desiredMs > LAST_NOTIFIED_LOOKBACK_CEILING_MS) {
+    logger?.warn({
+      message: () =>
+        `Notification policy throttle interval (~${Math.round(
+          maxIntervalMs / ONE_DAY_MS
+        )}d) exceeds the maximum supported last-notified lookback (${Math.round(
+          LAST_NOTIFIED_LOOKBACK_CEILING_MS / ONE_DAY_MS
+        )}d); clamping. Throttling for policies with longer intervals may allow spurious re-notification.`,
+    });
+  }
+
+  return clampedMs;
+}
 
 @injectable()
 export class ApplyThrottlingStep implements DispatcherStep {
@@ -41,7 +111,13 @@ export class ApplyThrottlingStep implements DispatcherStep {
       return { type: 'continue', data: { dispatch: [], throttled: [] } };
     }
 
-    const lastNotifiedMap = await this.fetchLastNotifiedTimestamps(groups.map((g) => g.id));
+    const lookbackMs = computeLastNotifiedLookbackMs(policies, this.logger);
+    const since = new Date(input.startedAt.getTime() - lookbackMs);
+
+    const lastNotifiedMap = await this.fetchLastNotifiedTimestamps(
+      groups.map((g) => g.id),
+      since
+    );
 
     const { dispatch, throttled } = applyThrottling(
       groups,
@@ -59,10 +135,11 @@ export class ApplyThrottlingStep implements DispatcherStep {
   }
 
   private async fetchLastNotifiedTimestamps(
-    notificationGroupIds: NotificationGroupId[]
+    notificationGroupIds: NotificationGroupId[],
+    since: Date
   ): Promise<Map<NotificationGroupId, LastNotifiedInfo>> {
     const records = await this.queryService.executeQueryRows<LastNotifiedRecord>({
-      query: getLastNotifiedTimestampsQuery(notificationGroupIds).query,
+      query: getLastNotifiedTimestampsQuery(notificationGroupIds, since).query,
     });
 
     return new Map<NotificationGroupId, LastNotifiedInfo>(


### PR DESCRIPTION
## Summary

The dispatcher's `getLastNotifiedTimestampsQuery` — run every 5 seconds by the throttling step — has no lower bound on `@timestamp`. As `.alert-actions` grows, the query scans more data every cycle, so its cost grows unbounded with retention.

This PR bounds the query by a lookback window derived from the currently enabled notification policies. The lookback is the longest configured `throttle.interval × 1.2`, clamped between a 1-day floor and a 90-day ceiling. If a policy configures an interval that would exceed the ceiling, we clamp and log a warning.

Partially addresses internal tracking: elastic/rna-program#380.

## Why this is safe

The query's only consumer is `shouldDispatch` in `ApplyThrottlingStep`. It uses:
1. `lastRecord.lastNotified` compared against `policy.throttle.interval` via `isWithinInterval`.
2. `lastRecord.episodeStatus` compared against the current episode status.

A `notified` record older than the longest configured throttle interval **cannot change either decision** — `isWithinInterval` returns `false` for anything past the interval window. So bounding the scan to "longest policy interval × 1.2" produces identical throttling output for every policy with a configured interval.

### Why there's a 1-day floor (`on_status_change` case)

Policies with `groupingMode: 'per_episode'` default to the `on_status_change` strategy, which has **no interval** — it only re-notifies when the status transitions. For these policies, throttling relies entirely on finding the most recent `notified` record to compare its `episode_status` against the current status.

If the lookback were computed purely from configured intervals, a policy with no intervals would give `lookback = 0`. The query would return no record for stable episodes, `shouldDispatch` would see no `lastRecord`, and the dispatcher would re-fire the notification every 5 seconds — catastrophic spam.

The 1-day floor caps that failure mode: a stable episode gets at most one spurious re-dispatch per day, which is functionally a "still active" heartbeat. Query cost stays bounded at 24h of scan regardless.

Concrete example: a Kubernetes pod enters `CrashLoopBackOff` at `t=0` and stays there for 5 days. With the 1-day floor, the user gets 5 notifications total (initial + one per day), each query scans 24h of `.alert-actions`. Without the floor, they'd get one notification per dispatcher cycle — every 5 seconds, for 5 days.

## What changed

- `queries.ts` — `getLastNotifiedTimestampsQuery` takes a new `since: Date` argument and adds `WHERE @timestamp >= ${since}::datetime` as the first filter clause.
- `apply_throttling_step.ts` — new exported helper `computeLastNotifiedLookbackMs(policies, logger?)` derives the lookback from enabled policies with floor/ceiling/safety-factor semantics. The step computes `since = input.startedAt - lookbackMs` and threads it through `fetchLastNotifiedTimestamps`.
- Malformed `throttle.interval` strings on a single policy are skipped (not thrown) so one bad policy cannot break throttling for the rest.
- Clamp-to-ceiling emits a `logger.warn` so operators can detect misconfiguration.

## Risk and rollback

- Scoped to one step and its query builder. No pipeline, DI, or type changes outside this step.
- Revert is a one-line parameter removal and a test revert.
- `getAlertEpisodeSuppressionsQuery` is intentionally unchanged — it holds long-lived state markers (snoozes, acks) where time-bounding would be a real regression, and needs a separate design.

## How to test

Unit tests exercise:
- `getLastNotifiedTimestampsQuery` with the `since` bound present and ordered before the group filter.
- `computeLastNotifiedLookbackMs` across floor, ceiling (with warn), max-interval derivation, safety factor, invalid-interval skip, and empty-policies cases.
- `ApplyThrottlingStep.execute` asserting the rendered ES|QL query contains `@timestamp >= "<iso>"::DATETIME` for the expected `since` value, and that no query is fired when there are no groups.

```
node scripts/jest --config x-pack/platform/plugins/shared/alerting_v2/jest.config.js --testPathPattern="dispatcher/"
```

All 179 existing dispatcher unit tests (15 suites) continue to pass.

Made with [Cursor](https://cursor.com)