### PR TITLE
[Macroscope] Handle shared fixtures in Flaky Test Runner nudge

### DIFF
--- a/.macroscope/flaky-test-runner-nudge.md
+++ b/.macroscope/flaky-test-runner-nudge.md
@@ -30,9 +30,9 @@ If nothing matches, stop.
 
 ## Step 2: Does the change introduce non-determinism?
 
-The required CI pass already catches deterministic failures. The flaky test runner only adds signal when the *same* change could fail *non-deterministically* — i.e., when a single pass isn't a reliable signal. Ask one question:
+The required CI pass already catches deterministic failures. The flaky test runner only adds signal when the _same_ change could fail _non-deterministically_ — i.e., when a single pass isn't a reliable signal. Ask one question:
 
-> *Does this change introduce a new source of non-determinism that one CI pass wouldn't reliably catch?*
+> _Does this change introduce a new source of non-determinism that one CI pass wouldn't reliably catch?_
 
 If no, skip — regardless of how many test files are touched.
 
@@ -43,14 +43,13 @@ If no, skip — regardless of how many test files are touched.
 - **New or changed waits/timing:** `waitFor`, `expect.toPass`, `retry`, polling intervals, `setTimeout`, increased/decreased timeouts, new `await` on async operations whose ordering matters.
 - **New fixtures/hooks with timing components:** index creation, data ingestion waits, server startup, role/space provisioning, `beforeEach`/`afterEach` that mutate shared state.
 - **New async interactions:** new API calls, new ES queries, new network requests, new WebSocket/SSE subscriptions in tests.
-- **Parallelism or ordering changes:** `test.describe.parallel`, worker count, `fullyParallel`, changes to test sharding/grouping in configs.
-- **New selectors tied to dynamic content:** text matchers on i18n strings, selectors depending on animations, virtualized lists, or async-rendered content.
+- **New tags** added to the test suite
 
 **Skip (deterministic — one pass is sufficient):**
 
 - Renames (identifiers, tool IDs, symbols) applied uniformly across the diff.
 - File moves / directory reorganizations (e.g., for CODEOWNERS), even with mechanical import path updates.
-- Pure assertion *value* changes where the value is deterministic (`expect(x).toBe(1)` → `expect(x).toBe(2)` to match a code change).
+- Pure assertion _value_ changes where the value is deterministic (`expect(x).toBe(1)` → `expect(x).toBe(2)` to match a code change).
 - Snapshot updates.
 - Type-only changes, comments, formatting, import reorders.
 - Mechanical refactors preserving semantics (extracting a helper, splitting a file).

--- a/.macroscope/flaky-test-runner-nudge.md
+++ b/.macroscope/flaky-test-runner-nudge.md
@@ -93,6 +93,8 @@ Post one comment on the PR with a single `/flaky` command. Include tokens only f
 
 **Recommended before merge**: run the flaky test runner against this PR to catch flakiness early.
 
+<!-- optional: one-sentence rationale, see "Rationale line" below -->
+
 Trigger a run with the [Flaky Test Runner UI](https://ci-stats.kibana.dev/trigger_flaky_test_runner) or post this comment on the PR:
 
 ```
@@ -101,6 +103,26 @@ Trigger a run with the [Flaky Test Runner UI](https://ci-stats.kibana.dev/trigge
 
 This check is experimental. Share your feedback in the #appex-qa channel.
 ````
+
+### Rationale line
+
+Include a one-sentence rationale immediately below the recommendation line whenever the mapping from changed files → config(s) is not self-evident. Keep it to a single sentence; do not list every file.
+
+**Include a rationale when any of these hold:**
+
+- More than one config is listed.
+- The changed file is a shared fixture and the comment picks a canonical leaf.
+- The non-determinism signal is subtle (e.g., a new timing-sensitive fixture shared across many specs, an `unskip`, a parallelism/config change).
+- The changed file lives outside a `test/**` path (prod code that a specific config exercises).
+
+**Skip the rationale when** a single changed spec file maps to a single obvious config under the same directory — the path already tells the story.
+
+Rationale examples (pick the shape that fits):
+
+- `Covers the new Scout spec at <path> added in this PR.`
+- `<path> is a shared fixture loaded by <base config>; this leaf is the canonical vanilla config exercising the same runtime path.`
+- `<path> is referenced by both configs below via loadTestFile.`
+- `This PR unskips a previously-flaky test in <config>, so re-running it 30× validates stability.`
 
 Examples:
 

--- a/.macroscope/flaky-test-runner-nudge.md
+++ b/.macroscope/flaky-test-runner-nudge.md
@@ -15,8 +15,11 @@ Decide whether this PR needs a Flaky Test Runner nudge. If not, post nothing.
 
 **Important:**
 
-- Never post the flaky test runner comment more than once on the same PR.
 - Do not run this check on backport PRs.
+- The check may run multiple times as the PR author pushes new commits. What must never happen is a **duplicate** comment — same runner types and same config list as one already posted. Before posting, read the existing flaky-nudge comments on the PR:
+  - If the new changes resolve to a set of `(runner type, config path)` tokens that is a **subset of, or equal to**, what any prior comment already covers → post nothing.
+  - If the new changes add **new tokens** not previously covered (a new config, or a runner type — Scout or FTR — that wasn't covered before), post a new comment that lists **only the newly-added tokens**, and briefly note it's a follow-up covering additions since the previous comment.
+  - Never re-list tokens that a prior comment already covered.
 
 ## Step 1: Are any in-scope files changed?
 
@@ -25,11 +28,37 @@ Decide whether this PR needs a Flaky Test Runner nudge. If not, post nothing.
 
 If nothing matches, stop.
 
-## Step 2: Do the changes affect stability?
+## Step 2: Does the change introduce non-determinism?
 
-**Nudge if:** test logic, assertions, selectors, fixtures, page objects, test config files, hooks, timeouts, waits, API calls, new/updated/unskipped tests.
+The required CI pass already catches deterministic failures. The flaky test runner only adds signal when the *same* change could fail *non-deterministically* — i.e., when a single pass isn't a reliable signal. Ask one question:
 
-**Skip if:** comments only, pure formatting, import reorder, trivial copy changes.
+> *Does this change introduce a new source of non-determinism that one CI pass wouldn't reliably catch?*
+
+If no, skip — regardless of how many test files are touched.
+
+**Nudge (new non-determinism introduced):**
+
+- **New tests** (`test(...)`, `it(...)`, new `describe` blocks) — unknown stability.
+- **Unskipped tests** (`test.skip` → `test`, `.only` removed on a previously-skipped suite) — often skipped originally because they were flaky.
+- **New or changed waits/timing:** `waitFor`, `expect.toPass`, `retry`, polling intervals, `setTimeout`, increased/decreased timeouts, new `await` on async operations whose ordering matters.
+- **New fixtures/hooks with timing components:** index creation, data ingestion waits, server startup, role/space provisioning, `beforeEach`/`afterEach` that mutate shared state.
+- **New async interactions:** new API calls, new ES queries, new network requests, new WebSocket/SSE subscriptions in tests.
+- **Parallelism or ordering changes:** `test.describe.parallel`, worker count, `fullyParallel`, changes to test sharding/grouping in configs.
+- **New selectors tied to dynamic content:** text matchers on i18n strings, selectors depending on animations, virtualized lists, or async-rendered content.
+
+**Skip (deterministic — one pass is sufficient):**
+
+- Renames (identifiers, tool IDs, symbols) applied uniformly across the diff.
+- File moves / directory reorganizations (e.g., for CODEOWNERS), even with mechanical import path updates.
+- Pure assertion *value* changes where the value is deterministic (`expect(x).toBe(1)` → `expect(x).toBe(2)` to match a code change).
+- Snapshot updates.
+- Type-only changes, comments, formatting, import reorders.
+- Mechanical refactors preserving semantics (extracting a helper, splitting a file).
+- Config field renames / ownership tags / metadata that don't affect runtime behavior (tags, descriptions, CODEOWNERS annotations).
+
+### Sanity check before nudging
+
+If you can describe the change as "rename X to Y", "move A to B", or "update expected value from X to Y", and nothing else is going on, **skip**. A 30-run matrix cannot reveal anything a single run wouldn't.
 
 Evaluate Scout and FTR independently. Only nudge the side(s) that qualify.
 

--- a/.macroscope/flaky-test-runner-nudge.md
+++ b/.macroscope/flaky-test-runner-nudge.md
@@ -45,6 +45,16 @@ Example: `x-pack/platform/plugins/shared/streams_app/test/scout/ui/playwright.co
 
 If multiple changed files resolve to the same config, include it only once.
 
+### Shared fixtures
+
+A **shared fixture** is a non-test file (XML, JSON archive, ES/Kibana snapshot, role definition, etc.) that is not referenced by `testFiles` / `loadTestFile`, is pulled in only by `*.base.ts` configs (typically via `require.resolve` or `import`), and is consumed identically by every leaf config that extends the base (e.g. loaded once at server startup).
+
+When the changed file is a shared fixture:
+
+1. Pick **one** canonical leaf config that extends the base — prefer the plainest "vanilla" config for the affected area (no feature flags, no extra server args). For example, for a change to `@kbn/security-api-integration-helpers/saml/idp_metadata_mock_idp.xml`, prefer `x-pack/platform/test/api_integration_deployment_agnostic/configs/stateful/platform.stateful.config.ts` over siblings that layer on feature flags or solution-specific services.
+2. In the comment body, list 2–3 other leaf configs that inherit the same fixture and tell the author they can run those manually via the [Flaky Test Runner UI](https://ci-stats.kibana.dev/trigger_flaky_test_runner) for broader coverage.
+3. Do **not** add a second leaf just to "cover both base configs" when the bases exercise the same runtime path through the fixture. One run of the canonical leaf validates the shared code path; a second leaf doubles CI cost without adding signal.
+
 ## Output
 
 Post one comment on the PR with a single `/flaky` command. Include tokens only for runner types that qualify. All configs — any number, any mix of Scout and FTR — go space-separated on the same line. Format:

--- a/.macroscope/scout-review.md
+++ b/.macroscope/scout-review.md
@@ -45,19 +45,36 @@ This review is experimental. Share your feedback in the #appex-qa channel.
 All detailed findings must go in **inline GitHub PR comments** on the specific line where each issue occurs. For each inline comment:
 
 - Start with the severity emoji (🔴 Blocker, 🟡 Major, 🔵 Minor, or ⚪ Nit)
-- State the rule violated (use the section heading from the matching best-practices document: `docs/extend/scout/best-practices.md`, `docs/extend/scout/ui-best-practices.md`, or `docs/extend/scout/api-best-practices.md`)
+- State the rule violated as a **Markdown link** whose text is the section heading from the matching best-practices document and whose URL is the section-scoped URL (see routing below). The link is required, not optional.
 - Explain the issue in 1–2 sentences
 - Suggest a concrete fix
 
-### Link to specific sections of the Best Practices documents when possible
+### Pick the right best-practices document (required)
 
-Scout best practices are split across three pages; pick the one that matches the rule you’re citing:
+Scout best practices live in three files. Don't guess from keywords — read the actual headings to find the matching section:
 
-- General: `docs/extend/scout/best-practices.md` → `https://www.elastic.co/docs/extend/kibana/scout/best-practices`
 - UI tests: `docs/extend/scout/ui-best-practices.md` → `https://www.elastic.co/docs/extend/kibana/scout/ui-best-practices`
 - API tests: `docs/extend/scout/api-best-practices.md` → `https://www.elastic.co/docs/extend/kibana/scout/api-best-practices`
+- General (applies to both UI and API): `docs/extend/scout/best-practices.md` → `https://www.elastic.co/docs/extend/kibana/scout/best-practices`
 
-A section-scoped link looks like this: `https://www.elastic.co/docs/extend/kibana/scout/ui-best-practices#avoid-conditional-logic-in-page-objects`. You can infer the `#anchor` from the explicit heading id in the corresponding markdown file (e.g., `[avoid-conditional-logic-in-page-objects]`).
+**Selection rule:**
+
+1. Start from the file being reviewed. If it lives under `test/scout*/ui/**` (or is a UI page object / fixture), check `ui-best-practices.md` first. If it lives under `test/scout*/api/**` (or is an API service / client fixture), check `api-best-practices.md` first.
+2. Scan that doc's headings for one that matches the rule you're about to cite. If found, use it.
+3. Otherwise, scan the general `best-practices.md`. Use it only when the rule genuinely applies to both UI and API tests (test naming, suite independence, hooks, cleanup, etc.).
+4. When a section with the same intent exists in both the specific doc and the general doc, prefer the specific one.
+
+### Always include the section anchor
+
+Every finding must link to a **section-scoped URL**, not the doc root. Infer the `#anchor` from the explicit heading id in the markdown source (e.g., the heading `## Use Playwright auto-waiting [leverage-playwright-auto-waiting]` yields `#leverage-playwright-auto-waiting`). Only fall back to the doc root URL if the rule genuinely has no matching section (rare — re-read the doc first).
+
+Format the citation as a Markdown link using the section heading text as the link label:
+
+```
+🔵 [Use Playwright auto-waiting](https://www.elastic.co/docs/extend/kibana/scout/ui-best-practices#leverage-playwright-auto-waiting)
+```
+
+Do **not** use bare parenthetical labels like `(best practices)` or `(ui best practices)` — the citation must be a real link that takes the reader to the specific section. If you cannot identify a specific section, state the rule in plain text rather than linking to the wrong document.
 
 ### Updates to the PR
 


### PR DESCRIPTION
The flaky test runner nudger was flagging a second, somewhat arbitrary config when a PR touched a shared fixture (e.g. the mock-IDP SAML metadata XML in #257459), under the rationale of "covering both base configs". In practice both bases run the same login path, so the extra config doubled CI cost without adding signal.

This PR adds a short "Shared fixtures" rule to `.macroscope/flaky-test-runner-nudge.md` to provide guidance on how to handle this edge case.