### PR TITLE
[Security Solution] Review batch sizes for improvement to rules installation memory usage.

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/api/perform_rule_installation/perform_rule_installation_handler.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/api/perform_rule_installation/perform_rule_installation_handler.ts
@@ -99,7 +99,7 @@ export const performRuleInstallationHandler = async (
       ruleInstallQueue.push(...(await excludeLicenseRestrictedRules(allInstallableRules, mlAuthz)));
     }
 
-    const BATCH_SIZE = 100;
+    const BATCH_SIZE = 20;
     while (ruleInstallQueue.length > 0) {
       const rulesToInstall = ruleInstallQueue.splice(0, BATCH_SIZE);
       const ruleAssets = await ruleAssetsClient.fetchAssetsByVersion(rulesToInstall);


### PR DESCRIPTION
## Summary

This PR reduces prebuilt rule installation `BATCH_SIZE` to `20` (down from `100`).

When testing locally, this creates a minor improvement of ~ 5MB avg in terms of peak memory usage during rule installation without **affecting installation performance** (the speed at which rules are installed is the same). 

Possibly due to GC being able to clear `rulesToInstall` and `ruleAsssets` earlier per batch in this `while` loop:

```ts
    const BATCH_SIZE = 20;
    while (ruleInstallQueue.length > 0) {
      const rulesToInstall = ruleInstallQueue.splice(0, BATCH_SIZE);
      const ruleAssets = await ruleAssetsClient.fetchAssetsByVersion(rulesToInstall);

      // This call below runs a promise pool with max 20 concurrent changes 
      // so it doesnt make sense for `ruleAssets` array to be greater than this number 
      // as the memory allocated to it will just hang around while waiting for each batch to complete
      const { results, errors } = await createPrebuiltRules(detectionRulesClient, ruleAssets ....
```

While 5MB in the context of 1200MB is perhaps a rounding error. The change here is relatively low risk.

#### Test Results: Main vs Batch Size 20 - Prebuilt Rule Installation

<img width="1632" height="583" alt="main vs batch-size-20" src="https://github.com/user-attachments/assets/e78cd7f5-f8c9-433e-a054-a18fe5747a39" />

- Raw Data: [main-vs-batch-size-20.zip](https://github.com/user-attachments/files/26902379/main-vs-batch-size-20.zip)

## Risks

### Installation timeout

The main risk when reducing batch sizes for prebuilt rule installation is that we go over the timeout duration defined by load balancers in ECH and serverless deployments (~2 minutes depending on setup).

This aspect has been tested in 3 batches, all of which confirm that there is no noticeable increase in installation duration.

## Testing steps

1. Login
2. Security > Detection Rules (SIEM)
3. Add Elastic Rules
4. Install All
5. Check the time it takes to install rules (should not exceed the time it takes under `main`)
6. Check that all rules are installed correctly.

<details><summary>

## 👉  Detailed Test Results


</summary>

# Main vs batch-size-20 — heapUsed (memory profile CSV)


##  Test Method

- Source: `kibana-memory-profile-*.csv` in `.vscode/mem-stats` (column `heap_used`, bytes).
- **Trim:** exclude the **first 100** and **last 100** samples (rows) per run; all metrics use only the middle window (400 samples per run here; 500 ms interval → ~3.3 minutes analyzed per capture).
- Per run: **peak** `heap_used` (max in window), **average** `heap_used` (mean in window), **avg of top 20** — mean of the **20 highest** `heap_used` values in the window (high-water pressure).

## Test conditions (local)

- Kibana in **`--dev`** mode.
- **`NODE_OPTIONS="--max_old_space_size=1400"`** — `1400` in folder names is this limit (MiB), not measured heap.

## Datasets (folder names)

| Dataset | Run folders |
| --- | --- |
| **main** | `main-1400-round1`, `main-1400-round2`, `main-1400-round3` |
| **batch-size-20** | `batch-size-20-1400-round1`, `batch-size-20-1400-round2`, `batch-size-20-1400-round3` |

## Per-run results (MiB)

### main

| Run folder | Peak | Average | Avg of top 20 |
| --- | ---: | ---: | ---: |
| `main-1400-round1` | 1235.7 | 1123.1 | 1214.7 |
| `main-1400-round2` | 1257.1 | 1104.5 | 1219.3 |
| `main-1400-round3` | 1242.6 | 1122.9 | 1218.2 |

### batch-size-20

| Run folder | Peak | Average | Avg of top 20 |
| --- | ---: | ---: | ---: |
| `batch-size-20-1400-round1` | 1224.9 | 1129.3 | 1211.3 |
| `batch-size-20-1400-round2` | 1248.0 | 1132.4 | 1217.6 |
| `batch-size-20-1400-round3` | 1219.2 | 1126.4 | 1208.1 |

## Cross-run means (3 runs)

| Metric | main | batch-size-20 | Δ (batch − main) |
| --- | ---: | ---: | ---: |
| Mean of per-run **peak** | ~1245.3 MiB | ~1230.9 MiB | **−14.4 MiB** |
| Mean of per-run **average** | ~1116.7 MiB | ~1129.2 MiB | **+12.5 MiB** |
| Mean of per-run **avg of top 20** | ~1217.7 MiB | ~1212.0 MiB | **−5.7 MiB** |

## Which is more memory efficient?

**Mixed.** 

**batch-size-20** wins on **peak** and on **avg of top 20** (lower spikes / high-water band). **main** wins on **full-window average** (slightly lower typical heap over the middle segment).


</details>
