### PR TITLE
[Streams] Unskip MKI Tech Preview badge test

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_processing/create_steps.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_processing/create_steps.spec.ts
@@ -13,10 +13,9 @@ import { generateLogsData } from '../../../fixtures/generators';
 // Note: Processor creation, conditional steps, and nested steps API correctness is covered by
 // API tests in x-pack/platform/plugins/shared/streams/test/scout/api/tests/processing_persistence.spec.ts
 // These UI tests focus on the user experience: validation, button states, cancel flows, and duplication
-// TODO: consistently fails on MKI - needs investigation: https://github.com/elastic/kibana/issues/258589
 test.describe(
   'Stream data processing - creating steps',
-  { tag: [...tags.stateful.classic, '@local-serverless-observability_complete'] },
+  { tag: [...tags.stateful.classic, ...tags.serverless.observability.complete] },
   () => {
     test.beforeAll(async ({ logsSynthtraceEsClient }) => {
       await generateLogsData(logsSynthtraceEsClient)({ index: 'logs-generic-default' });


### PR DESCRIPTION
closes: #258589

## Summary

Re-enables the Streams UI test `should not show Technical Preview badge when AI suggestions are unavailable` on serverless observability (MKI). The test was skipped in #263984 while it was failing deterministically on the MKI.
 The underlying bug was fixed by #263843 after this test was skipped


## Root cause

**Root cause of the original failure (fixed):**
Before #263843, `useLoadConnectors` in `@kbn/inference-connectors` had a client-side fallback that called `fetchConnectorById` against `GET /internal/inference/connectors/{id}` whenever `soEntryFound === false` and `defaultConnectorId` was truthy. The test's `page.route` mock only covered `**/internal/search_inference_endpoints/connectors*`, so the fallback slipped past the mock and returned the project's EIS connector. The Technical Preview badge (and the "Elastic Managed LLM is the new default" callout) then rendered, and the assertion failed.

This was MKI-only because the fallback is gated on `defaultConnectorId` being truthy, which requires the `GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR` uiSetting to be configured. Serverless observability CI projects preconfigure that setting to an EIS inference endpoint; local stateful / ECH environments do not, so the fallback short-circuited there.

**How #263843 fixed it:**
Removed the client-side fallback entirely. Default-connector merging now happens server-side in `mergeConnectors` (`x-pack/platform/plugins/shared/search_inference_endpoints/server/lib/merge_connectors.ts`). After the fix, `useLoadConnectors` makes exactly one HTTP call to the endpoint the test already mocks.
