### PR TITLE
[Agent Builder] `ai.agent` fix `schema` used with `store-conversation`

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/langchain/graph_events.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/langchain/graph_events.ts
@@ -128,7 +128,7 @@ export const createMessageEvent = (
     type: ChatEventType.messageComplete,
     data: {
       message_id: messageId,
-      message_content: typeof content === 'string' ? content : '',
+      message_content: typeof content === 'string' ? content : JSON.stringify(content),
       ...(typeof content === 'object' ? { structured_output: content } : {}),
     },
   };

--- a/x-pack/platform/plugins/shared/agent_builder/common/step_types/run_agent_step.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/common/step_types/run_agent_step.ts
@@ -8,7 +8,7 @@
 import { z } from '@kbn/zod/v4';
 import type { CommonStepDefinition } from '@kbn/workflows-extensions/common';
 import { StepCategory } from '@kbn/workflows';
-import { JsonModelShapeSchema } from '@kbn/workflows/spec/schema/common/json_model_shape_schema';
+import { JsonModelSchema } from '@kbn/workflows/spec/schema/common/json_model_schema';
 import { i18n } from '@kbn/i18n';
 import {
   CONNECTOR_OR_INFERENCE_ID_CONFLICT_MESSAGE_WORKFLOW,
@@ -27,8 +27,7 @@ export const InputSchema = z.object({
   /**
    * output schema for the run agent step, if provided agent will return structured output
    */
-  // TODO: replace with proper JsonSchema7 zod schema when https://github.com/elastic/kibana/pull/244223 is merged and released
-  schema: JsonModelShapeSchema.optional().describe('The schema for the output of the agent.'),
+  schema: JsonModelSchema.optional().describe('The schema for the output of the agent.'),
   /**
    * The user input message to send to the agent.
    */


### PR DESCRIPTION
## Summary

Fix https://github.com/elastic/search-team/issues/14046

- Persist the structured output as text so that it's used as the text response for persisted conversation
- Migrate to the new json schema shape (https://github.com/elastic/kibana/pull/244223) because I forgot to do so sooner


https://github.com/user-attachments/assets/8f56a1bb-e622-4913-b85b-b215c2cd33d3



<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->