### PR TITLE
[Streams] Remove duplicate viewer-privileges test from `edit_steps.spec.ts`

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_processing/edit_steps.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_processing/edit_steps.spec.ts
@@ -122,17 +122,5 @@ test.describe(
       // Verify processor still exists
       expect(await pageObjects.streams.getProcessorsListItems()).toHaveLength(1);
     });
-
-    test('should handle insufficient privileges gracefully', async ({
-      browserAuth,
-      pageObjects,
-    }) => {
-      // Login as user with limited privileges
-      await browserAuth.loginAsViewer();
-      await pageObjects.streams.gotoProcessingTab('logs-generic-default');
-
-      // Edit button should be disabled or show tooltip
-      await expect(await pageObjects.streams.getProcessorEditButton(0)).toBeDisabled();
-    });
   }
 );


### PR DESCRIPTION
closes: #261178

## Summary

Deletes `should handle insufficient privileges gracefully` from `edit_steps.spec.ts`. It fails consistently on MKI `cloud-serverless-observability_complete` and is a duplicate of `permissions_viewer.spec.ts:53` (same `toBeDisabled()` assertion on the viewer edit button), which passes on the same target.

## Why it fails on MKI

The test logs in as admin, navigates to the processing tab, then swaps to a viewer session and re-navigates to the same URL. On MKI the UI state machine doesn't re-hydrate with viewer privilege, the edit button stays `enabled` across all retries. `permissions_viewer.spec.ts` avoids this by logging in as viewer **before** the first navigation.

## Why delete instead of fix

Permission handling is already owned by `permissions_*.spec.ts` (per the file-level comment in `edit_steps.spec.ts`). Rewriting the flow here would just duplicate existing passing coverage.
