### PR TITLE
[SecuritySolution] transfer navigation and feature ownership to Platform Delivery and Success team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1282,7 +1282,7 @@ x-pack/solutions/security/packages/data-table @elastic/security-threat-hunting-i
 x-pack/solutions/security/packages/distribution-bar @elastic/contextual-security-apps
 x-pack/solutions/security/packages/ecs-data-quality-dashboard @elastic/security-threat-hunting-investigations
 x-pack/solutions/security/packages/expandable-flyout @elastic/security-threat-hunting-investigations
-x-pack/solutions/security/packages/features @elastic/security-threat-hunting-investigations
+x-pack/solutions/security/packages/features @elastic/security-pds-deployment
 x-pack/solutions/security/packages/index-adapter @elastic/security-threat-hunting
 x-pack/solutions/security/packages/kbn-cloud-security-posture/common @elastic/contextual-security-apps
 x-pack/solutions/security/packages/kbn-cloud-security-posture/graph @elastic/contextual-security-apps
@@ -1306,9 +1306,9 @@ x-pack/solutions/security/packages/kbn-securitysolution-list-utils @elastic/secu
 x-pack/solutions/security/packages/kbn-securitysolution-lists-common @elastic/security-detection-engine
 x-pack/solutions/security/packages/kbn-securitysolution-t-grid @elastic/security-detection-engine
 x-pack/solutions/security/packages/kbn-securitysolution-utils @elastic/security-detection-engine @elastic/security-detection-rule-management
-x-pack/solutions/security/packages/navigation @elastic/security-threat-hunting-investigations
+x-pack/solutions/security/packages/navigation @elastic/security-pds-deployment
 x-pack/solutions/security/packages/security-ai-prompts @elastic/security-generative-ai
-x-pack/solutions/security/packages/side-nav @elastic/security-threat-hunting-investigations
+x-pack/solutions/security/packages/side-nav @elastic/security-pds-deployment
 x-pack/solutions/security/packages/siem-readiness @elastic/contextual-security-apps
 x-pack/solutions/security/packages/storybook/config @elastic/security-threat-hunting-investigations
 x-pack/solutions/security/packages/test-api-clients @elastic/security-detection-rule-management
@@ -2686,6 +2686,7 @@ x-pack/solutions/security/test/security_solution_api_integration/test_suites/sou
 # Security Solution sub teams
 
 ## Security Solution sub teams - security-engineering-productivity
+
 ## NOTE: It's important to keep this above other teams' sections because test automation doesn't process
 ## the CODEOWNERS file correctly. See https://github.com/elastic/kibana/issues/173307#issuecomment-1855858929
 /x-pack/solutions/security/test/security_solution_cypress/.cursor/rules/flaky_test_doctor.mdc @elastic/security-engineering-productivity
@@ -2699,6 +2700,11 @@ x-pack/solutions/security/test/security_solution_api_integration/test_suites/sou
 /x-pack/solutions/security/test/security_solution_cypress/es_archives @elastic/security-engineering-productivity
 /x-pack/solutions/security/plugins/security_solution/scripts/run_cypress @elastic/security-engineering-productivity
 /x-pack/solutions/security/plugins/security_solution/test/scout @elastic/security-engineering-productivity
+
+## Security Solution sub teams - Platform Delivery And Success
+
+/x-pack/solutions/security/plugins/security_solution/public/app/links @elastic/security-pds-deployment
+/x-pack/solutions/security/plugins/security_solution/public/common/components/navigation @elastic/security-pds-deployment
 
 ## Security Solution sub teams - Cloud Security Posture
 
@@ -2740,7 +2746,6 @@ x-pack/solutions/security/test/serverless/functional/configs/config.context_awar
 
 /x-pack/solutions/security/plugins/security_solution/public/app/actions @elastic/security-threat-hunting-investigations
 /x-pack/solutions/security/plugins/security_solution/public/app/home/template_wrapper/timeline @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution/public/app/links @elastic/security-threat-hunting-investigations
 /x-pack/solutions/security/plugins/security_solution/public/common/components/accessibility @elastic/security-threat-hunting-investigations
 /x-pack/solutions/security/plugins/security_solution/public/common/components/alert_count_by_status @elastic/security-threat-hunting-investigations
 /x-pack/solutions/security/plugins/security_solution/public/common/components/charts @elastic/security-threat-hunting-investigations
@@ -2762,7 +2767,6 @@ x-pack/solutions/security/test/serverless/functional/configs/config.context_awar
 /x-pack/solutions/security/plugins/security_solution/public/common/components/last_event_time @elastic/security-threat-hunting-investigations
 /x-pack/solutions/security/plugins/security_solution/public/common/components/links @elastic/security-threat-hunting-investigations
 /x-pack/solutions/security/plugins/security_solution/public/common/components/markdown_editor @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution/public/common/components/navigation @elastic/security-threat-hunting-investigations
 /x-pack/solutions/security/plugins/security_solution/public/common/components/news_feed @elastic/security-threat-hunting-investigations
 /x-pack/solutions/security/plugins/security_solution/public/common/components/overview_description_list @elastic/security-threat-hunting-investigations
 /x-pack/solutions/security/plugins/security_solution/public/common/components/page @elastic/security-threat-hunting-investigations

--- a/x-pack/solutions/security/packages/features/kibana.jsonc
+++ b/x-pack/solutions/security/packages/features/kibana.jsonc
@@ -2,7 +2,7 @@
   "type": "shared-common",
   "id": "@kbn/security-solution-features",
   "owner": [
-    "@elastic/security-threat-hunting-investigations"
+    "@elastic/security-pds-deployment"
   ],
   "group": "security",
   "visibility": "private"

--- a/x-pack/solutions/security/packages/features/moon.yml
+++ b/x-pack/solutions/security/packages/features/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/security-solution-features'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/security-threat-hunting-investigations'
+  defaultOwner: '@elastic/security-pds-deployment'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/security-solution-features'
   description: Moon project for @kbn/security-solution-features
   channel: ''
-  owner: '@elastic/security-threat-hunting-investigations'
+  owner: '@elastic/security-pds-deployment'
   sourceRoot: x-pack/solutions/security/packages/features
 dependsOn:
   - '@kbn/features-plugin'

--- a/x-pack/solutions/security/packages/navigation/kibana.jsonc
+++ b/x-pack/solutions/security/packages/navigation/kibana.jsonc
@@ -2,7 +2,7 @@
   "type": "shared-common",
   "id": "@kbn/security-solution-navigation",
   "owner": [
-    "@elastic/security-threat-hunting-investigations"
+    "@elastic/security-pds-deployment"
   ],
   "group": "security",
   "visibility": "private"

--- a/x-pack/solutions/security/packages/navigation/moon.yml
+++ b/x-pack/solutions/security/packages/navigation/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/security-solution-navigation'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/security-threat-hunting-investigations'
+  defaultOwner: '@elastic/security-pds-deployment'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/security-solution-navigation'
   description: Moon project for @kbn/security-solution-navigation
   channel: ''
-  owner: '@elastic/security-threat-hunting-investigations'
+  owner: '@elastic/security-pds-deployment'
   sourceRoot: x-pack/solutions/security/packages/navigation
 dependsOn:
   - '@kbn/i18n'

--- a/x-pack/solutions/security/packages/side-nav/kibana.jsonc
+++ b/x-pack/solutions/security/packages/side-nav/kibana.jsonc
@@ -2,7 +2,7 @@
   "type": "shared-common",
   "id": "@kbn/security-solution-side-nav",
   "owner": [
-    "@elastic/security-threat-hunting-investigations"
+    "@elastic/security-pds-deployment"
   ],
   "group": "security",
   "visibility": "private"

--- a/x-pack/solutions/security/packages/side-nav/moon.yml
+++ b/x-pack/solutions/security/packages/side-nav/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/security-solution-side-nav'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/security-threat-hunting-investigations'
+  defaultOwner: '@elastic/security-pds-deployment'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/security-solution-side-nav'
   description: Moon project for @kbn/security-solution-side-nav
   channel: ''
-  owner: '@elastic/security-threat-hunting-investigations'
+  owner: '@elastic/security-pds-deployment'
   sourceRoot: x-pack/solutions/security/packages/side-nav
 dependsOn:
   - '@kbn/i18n'


### PR DESCRIPTION
## Summary

Transfer ownership of the navigation and sidebar logic from the @elastic/security-threat-hunting-investigations team to @elastic/security-pds-deployment team.

### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
