### PR TITLE
[Discover] turn on Security document flyout enhanced profile

### DIFF
--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/security_profile_providers.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/security_profile_providers.tsx
@@ -29,7 +29,6 @@ export const createSecurityDocumentProfileProviders = (
   const baseProvider = createSecurityDocumentProfileProvider(providerServices);
   const enhancedProvider = extendProfileProvider(baseProvider, {
     profileId: SECURITY_PROFILE_ID.enhanced_document,
-    isExperimental: true,
     profile: {
       getDocViewer: (prev) => (params) => {
         const prevDocViewer = prev(params);


### PR DESCRIPTION
## Summary

This PR turns on the enhanced profile feature flag by removing the `isExperimental` property. That way the new Security Solution flyout experience will show up for the Security Solution navigation.

### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->