### PR TITLE
[Agent Builder] Fix - Adjust agent edit flyout spacing

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/overview/agent_overview.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/overview/agent_overview.tsx
@@ -189,7 +189,6 @@ export const AgentOverview: React.FC = () => {
           <EditDetailsFlyout
             agent={agent}
             onClose={() => setIsEditFlyoutOpen(false)}
-            isExperimentalFeaturesEnabled={isExperimentalFeaturesEnabled}
             canChangeVisibility={canChangeVisibility}
             showWorkflowSection={showWorkflowSection}
           />

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/overview/edit_details_flyout/access_section.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/overview/edit_details_flyout/access_section.tsx
@@ -115,11 +115,11 @@ export const AccessSection: React.FC<AccessSectionProps> = ({ canChangeVisibilit
       <EuiTitle size="xs">
         <h3>{flyoutLabels.accessTitle}</h3>
       </EuiTitle>
-      <EuiSpacer size="xs" />
-      <EuiText size="xs" color="subdued">
+      <EuiSpacer size="s" />
+      <EuiText size="s" color="subdued" component="p">
         {flyoutLabels.accessDescription}
       </EuiText>
-      <EuiSpacer size="m" />
+      <EuiSpacer size="l" />
       <EuiFormRow
         label={flyoutLabels.visibilityLabel}
         helpText={!canChangeVisibility ? flyoutLabels.visibilityDisabledReason : undefined}

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/overview/edit_details_flyout/custom_instructions_section.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/overview/edit_details_flyout/custom_instructions_section.tsx
@@ -21,11 +21,11 @@ export const CustomInstructionsSection: React.FC = () => {
       <EuiTitle size="xs">
         <h3>{flyoutLabels.instructionsTitle}</h3>
       </EuiTitle>
-      <EuiSpacer size="xs" />
-      <EuiText size="xs" color="subdued">
+      <EuiSpacer size="s" />
+      <EuiText size="s" color="subdued" component="p">
         {flyoutLabels.instructionsDescription}
       </EuiText>
-      <EuiSpacer size="s" />
+      <EuiSpacer size="l" />
 
       <Controller
         name="configuration.instructions"

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/overview/edit_details_flyout/customization_section.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/overview/edit_details_flyout/customization_section.tsx
@@ -37,11 +37,11 @@ export const CustomizationSection: React.FC<CustomizationSectionProps> = ({
       <EuiTitle size="xs">
         <h3>{flyoutLabels.customizationTitle}</h3>
       </EuiTitle>
-      <EuiSpacer size="xs" />
-      <EuiText size="xs" color="subdued">
+      <EuiSpacer size="s" />
+      <EuiText size="s" color="subdued" component="p">
         {flyoutLabels.customizationDescription}
       </EuiText>
-      <EuiSpacer size="m" />
+      <EuiSpacer size="l" />
 
       <EuiPanel hasBorder paddingSize="l">
         <EuiFlexGroup alignItems="center" justifyContent="spaceBetween" responsive={false}>

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/overview/edit_details_flyout/identification_section.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/overview/edit_details_flyout/identification_section.tsx
@@ -33,11 +33,11 @@ export const IdentificationSection: React.FC = () => {
       <EuiTitle size="xs">
         <h3>{flyoutLabels.identificationTitle}</h3>
       </EuiTitle>
-      <EuiSpacer size="xs" />
-      <EuiText size="xs" color="subdued">
+      <EuiSpacer size="s" />
+      <EuiText size="s" color="subdued" component="p">
         {flyoutLabels.identificationDescription}
       </EuiText>
-      <EuiSpacer size="m" />
+      <EuiSpacer size="l" />
 
       <EuiFormRow
         label={flyoutLabels.nameLabel}

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/overview/edit_details_flyout/index.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/overview/edit_details_flyout/index.tsx
@@ -48,7 +48,6 @@ const { editDetails: flyoutLabels } = labels.agentOverview;
 interface EditDetailsFlyoutProps {
   agent: AgentDefinition;
   onClose: () => void;
-  isExperimentalFeaturesEnabled: boolean;
   canChangeVisibility: boolean;
   showWorkflowSection: boolean;
 }
@@ -56,7 +55,6 @@ interface EditDetailsFlyoutProps {
 export const EditDetailsFlyout: React.FC<EditDetailsFlyoutProps> = ({
   agent,
   onClose,
-  isExperimentalFeaturesEnabled,
   canChangeVisibility,
   showWorkflowSection,
 }) => {
@@ -158,16 +156,16 @@ export const EditDetailsFlyout: React.FC<EditDetailsFlyoutProps> = ({
           <div css={contentPadding}>
             <IdentificationSection />
 
-            <EuiHorizontalRule margin="l" />
+            <EuiHorizontalRule margin="xl" />
             <AccessSection canChangeVisibility={canChangeVisibility} />
 
-            <EuiHorizontalRule margin="l" />
+            <EuiHorizontalRule margin="xl" />
             <CustomizationSection showWorkflowSection={showWorkflowSection} />
 
-            <EuiHorizontalRule margin="l" />
+            <EuiHorizontalRule margin="xl" />
             <CustomInstructionsSection />
 
-            <EuiHorizontalRule margin="l" />
+            <EuiHorizontalRule margin="xl" />
             <TagsSection />
           </div>
         </EuiFlyoutBody>

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/overview/edit_details_flyout/tags_section.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/overview/edit_details_flyout/tags_section.tsx
@@ -23,13 +23,13 @@ export const TagsSection: React.FC = () => {
       <EuiTitle size="xs">
         <h3>{flyoutLabels.tagsTitle}</h3>
       </EuiTitle>
-      <EuiSpacer size="xs" />
-      <EuiText size="xs" color="subdued">
+      <EuiSpacer size="s" />
+      <EuiText size="s" color="subdued" component="p">
         {flyoutLabels.tagsDescription}
       </EuiText>
-      <EuiSpacer size="s" />
+      <EuiSpacer size="l" />
 
-      <EuiFormRow label={flyoutLabels.tagsLabel} fullWidth>
+      <EuiFormRow aria-label={flyoutLabels.tagsLabel} fullWidth>
         <Controller
           name="labels"
           control={control}


### PR DESCRIPTION
## Summary

- Minor adjustments to agent edit flyout spacing
- Removes visible label from tag input as it is redundant with the section header
- Removes unused component prop

<img width="960" height="1200" alt="image" src="https://github.com/user-attachments/assets/31f4be63-b43a-40e6-8bc4-f88b100b75d8" />

<img width="957" height="555" alt="image" src="https://github.com/user-attachments/assets/75fb37e3-6266-47bd-8760-75bb581ed726" />



### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...





<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->