### PR TITLE
[Security Solution] update Threat Hunting Investigations to Threat Hunting codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -500,7 +500,7 @@ src/platform/packages/shared/kbn-calculate-auto @elastic/actionable-obs-team
 src/platform/packages/shared/kbn-calculate-width-from-char-count @elastic/kibana-visualizations
 src/platform/packages/shared/kbn-cases-components @elastic/kibana-cases
 src/platform/packages/shared/kbn-cbor @elastic/kibana-operations
-src/platform/packages/shared/kbn-cell-actions @elastic/security-threat-hunting-investigations
+src/platform/packages/shared/kbn-cell-actions @elastic/security-threat-hunting
 src/platform/packages/shared/kbn-chart-icons @elastic/kibana-visualizations
 src/platform/packages/shared/kbn-charts-theme @elastic/kibana-visualizations
 src/platform/packages/shared/kbn-cleanup-before-exit @elastic/observability-ui
@@ -638,7 +638,7 @@ src/platform/packages/shared/kbn-search-errors @elastic/kibana-data-discovery
 src/platform/packages/shared/kbn-search-response-warnings @elastic/kibana-data-discovery
 src/platform/packages/shared/kbn-search-types @elastic/kibana-data-discovery
 src/platform/packages/shared/kbn-security-hardening @elastic/kibana-security
-src/platform/packages/shared/kbn-securitysolution-ecs @elastic/security-threat-hunting-investigations
+src/platform/packages/shared/kbn-securitysolution-ecs @elastic/security-threat-hunting
 src/platform/packages/shared/kbn-securitysolution-es-utils @elastic/security-detection-engine
 src/platform/packages/shared/kbn-securitysolution-io-ts-types @elastic/security-detection-engine
 src/platform/packages/shared/kbn-securitysolution-io-ts-utils @elastic/security-detection-engine
@@ -681,7 +681,7 @@ src/platform/packages/shared/kbn-typed-react-router-config @elastic/obs-presenta
 src/platform/packages/shared/kbn-ui-actions-browser @elastic/appex-sharedux
 src/platform/packages/shared/kbn-ui-theme @elastic/kibana-operations
 src/platform/packages/shared/kbn-unified-chart-section-viewer @elastic/obs-exploration-team
-src/platform/packages/shared/kbn-unified-data-table @elastic/kibana-data-discovery @elastic/security-threat-hunting-investigations
+src/platform/packages/shared/kbn-unified-data-table @elastic/kibana-data-discovery @elastic/security-threat-hunting
 src/platform/packages/shared/kbn-unified-doc-viewer @elastic/kibana-data-discovery
 src/platform/packages/shared/kbn-unified-field-list @elastic/kibana-data-discovery
 src/platform/packages/shared/kbn-unified-histogram @elastic/kibana-data-discovery
@@ -1277,12 +1277,12 @@ x-pack/solutions/search/plugins/search_synonyms @elastic/search-kibana
 x-pack/solutions/search/plugins/serverless_search @elastic/search-kibana
 x-pack/solutions/search/test @elastic/search-kibana
 x-pack/solutions/security/packages/ai-security-labs-content @elastic/security-generative-ai
-x-pack/solutions/security/packages/connectors @elastic/security-threat-hunting-investigations
+x-pack/solutions/security/packages/connectors @elastic/security-threat-hunting
 x-pack/solutions/security/packages/data-stream-adapter @elastic/security-threat-hunting
-x-pack/solutions/security/packages/data-table @elastic/security-threat-hunting-investigations
+x-pack/solutions/security/packages/data-table @elastic/security-threat-hunting
 x-pack/solutions/security/packages/distribution-bar @elastic/contextual-security-apps
-x-pack/solutions/security/packages/ecs-data-quality-dashboard @elastic/security-threat-hunting-investigations
-x-pack/solutions/security/packages/expandable-flyout @elastic/security-threat-hunting-investigations
+x-pack/solutions/security/packages/ecs-data-quality-dashboard @elastic/security-threat-hunting
+x-pack/solutions/security/packages/expandable-flyout @elastic/security-threat-hunting
 x-pack/solutions/security/packages/features @elastic/security-pds-deployment
 x-pack/solutions/security/packages/index-adapter @elastic/security-threat-hunting
 x-pack/solutions/security/packages/kbn-cloud-security-posture/common @elastic/contextual-security-apps
@@ -1311,12 +1311,12 @@ x-pack/solutions/security/packages/navigation @elastic/security-pds-deployment
 x-pack/solutions/security/packages/security-ai-prompts @elastic/security-generative-ai
 x-pack/solutions/security/packages/side-nav @elastic/security-pds-deployment
 x-pack/solutions/security/packages/siem-readiness @elastic/contextual-security-apps
-x-pack/solutions/security/packages/storybook/config @elastic/security-threat-hunting-investigations
+x-pack/solutions/security/packages/storybook/config @elastic/security-threat-hunting
 x-pack/solutions/security/packages/test-api-clients @elastic/security-detection-rule-management
-x-pack/solutions/security/packages/upselling @elastic/security-threat-hunting-investigations
+x-pack/solutions/security/packages/upselling @elastic/security-threat-hunting
 x-pack/solutions/security/plugins/cloud_defend @elastic/kibana-cloud-security-posture
 x-pack/solutions/security/plugins/cloud_security_posture @elastic/contextual-security-apps
-x-pack/solutions/security/plugins/ecs_data_quality_dashboard @elastic/security-threat-hunting-investigations
+x-pack/solutions/security/plugins/ecs_data_quality_dashboard @elastic/security-threat-hunting
 x-pack/solutions/security/plugins/elastic_assistant @elastic/security-generative-ai
 x-pack/solutions/security/plugins/elastic_assistant_shared_state @elastic/security-generative-ai
 x-pack/solutions/security/plugins/entity_store @elastic/core-analysis
@@ -1326,7 +1326,7 @@ x-pack/solutions/security/plugins/security_solution @elastic/security-solution
 x-pack/solutions/security/plugins/security_solution_ess @elastic/security-solution
 x-pack/solutions/security/plugins/security_solution_serverless @elastic/security-solution
 x-pack/solutions/security/plugins/session_view @elastic/contextual-security-apps
-x-pack/solutions/security/plugins/timelines @elastic/security-threat-hunting-investigations
+x-pack/solutions/security/plugins/timelines @elastic/security-threat-hunting
 x-pack/solutions/security/test
 x-pack/solutions/security/test/plugin_functional/plugins/resolver_test @elastic/security-solution
 x-pack/solutions/security/test/security_solution_api_integration @elastic/security-detection-engine
@@ -1451,7 +1451,7 @@ x-pack/platform/test/serverless/api_integration/test_suites/platform_security @e
 /src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/observability_root_profile @elastic/obs-exploration-team
 /src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/traces_data_source_profile @elastic/obs-exploration-team
 /src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/traces_document_profile @elastic/obs-exploration-team
-/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security @elastic/kibana-data-discovery @elastic/security-threat-hunting-investigations
+/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security @elastic/kibana-data-discovery @elastic/security-threat-hunting
 
 # Platform Docs
 /x-pack/solutions/security/test/serverless/functional/test_suites/screenshot_creation/index.ts @elastic/platform-docs
@@ -2643,11 +2643,11 @@ x-pack/platform/test/functional/page_objects/search_profiler_page.ts @elastic/se
 /x-pack/solutions/security/plugins/security_solution/docs/openapi/serverless/security_solution_detections_api_* @elastic/security-detection-rule-management
 /x-pack/solutions/security/plugins/security_solution/docs/openapi/serverless/security_solution_endpoint_management_api_* @elastic/security-defend-workflows
 /x-pack/solutions/security/plugins/security_solution/docs/openapi/serverless/security_solution_entity_analytics_api_* @elastic/security-entity-analytics
-/x-pack/solutions/security/plugins/security_solution/docs/openapi/serverless/security_solution_timeline_api_* @elastic/security-threat-hunting-investigations
+/x-pack/solutions/security/plugins/security_solution/docs/openapi/serverless/security_solution_timeline_api_* @elastic/security-threat-hunting
 /x-pack/solutions/security/plugins/security_solution/docs/openapi/ess/security_solution_detections_api_* @elastic/security-detection-rule-management
 /x-pack/solutions/security/plugins/security_solution/docs/openapi/ess/security_solution_endpoint_management_api_* @elastic/security-defend-workflows
 /x-pack/solutions/security/plugins/security_solution/docs/openapi/ess/security_solution_entity_analytics_api_* @elastic/security-entity-analytics
-/x-pack/solutions/security/plugins/security_solution/docs/openapi/ess/security_solution_timeline_api_* @elastic/security-threat-hunting-investigations
+/x-pack/solutions/security/plugins/security_solution/docs/openapi/ess/security_solution_timeline_api_* @elastic/security-threat-hunting
 
 # Security Solution Offering plugins
 # TODO: assign sub directories to sub teams
@@ -2678,7 +2678,7 @@ x-pack/platform/test/functional/page_objects/search_profiler_page.ts @elastic/se
 /x-pack/solutions/security/test/security_solution_cypress/cypress/objects @elastic/security-detection-engine @elastic/security-detection-rule-management @elastic/security-threat-hunting
 /x-pack/solutions/security/test/security_solution_cypress/cypress/screens/common @elastic/security-detection-engine @elastic/security-detection-rule-management @elastic/security-threat-hunting
 /x-pack/solutions/security/test/security_solution_cypress/cypress/support @elastic/security-detection-engine @elastic/security-detection-rule-management @elastic/security-threat-hunting
-/x-pack/solutions/security/test/security_solution_cypress/cypress/urls @elastic/security-threat-hunting-investigations @elastic/security-detection-engine
+/x-pack/solutions/security/test/security_solution_cypress/cypress/urls @elastic/security-threat-hunting @elastic/security-detection-engine
 
 /x-pack/solutions/security/plugins/security_solution/common/test @elastic/security-detection-engine @elastic/security-detection-rule-management @elastic/security-threat-hunting
 
@@ -2740,116 +2740,112 @@ x-pack/solutions/security/plugins/entity_store @elastic/core-analysis
 
 ## Security Solution sub teams - Threat Hunting
 
-/x-pack/solutions/security/test/security_solution_cypress/cypress/fixtures/siem_migrations @elastic/security-threat-hunting
+/x-pack/solutions/security/plugins/security_solution/common/api/tags @elastic/security-threat-hunting
+/x-pack/solutions/security/plugins/security_solution/common/api/timeline @elastic/security-threat-hunting
+/x-pack/solutions/security/plugins/security_solution/common/endpoint/schema/resolver.ts @elastic/security-threat-hunting
+/x-pack/solutions/security/plugins/security_solution/common/search_strategy/timeline @elastic/security-threat-hunting
 /x-pack/solutions/security/plugins/security_solution/common/siem_migrations @elastic/security-threat-hunting
-/x-pack/solutions/security/plugins/security_solution/public/common/components/control_columns @elastic/security-threat-hunting
-/x-pack/solutions/security/plugins/security_solution/public/siem_migrations @elastic/security-threat-hunting
-/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations @elastic/security-threat-hunting
+/x-pack/solutions/security/plugins/security_solution/common/timelines @elastic/security-threat-hunting
+/x-pack/solutions/security/plugins/security_solution/common/types/header_actions @elastic/security-threat-hunting
+/x-pack/solutions/security/plugins/security_solution/common/types/timeline @elastic/security-threat-hunting
 
-x-pack/solutions/security/test/security_solution_api_integration/test_suites/siem_migrations @elastic/security-threat-hunting
+/x-pack/solutions/security/plugins/security_solution/public/app/actions @elastic/security-threat-hunting
+/x-pack/solutions/security/plugins/security_solution/public/app/home/template_wrapper/timeline @elastic/security-threat-hunting
+/x-pack/solutions/security/plugins/security_solution/public/app/links @elastic/security-threat-hunting
+/x-pack/solutions/security/plugins/security_solution/public/common/components/accessibility @elastic/security-threat-hunting
+/x-pack/solutions/security/plugins/security_solution/public/common/components/alert_count_by_status @elastic/security-threat-hunting
+/x-pack/solutions/security/plugins/security_solution/public/common/components/charts @elastic/security-threat-hunting
+/x-pack/solutions/security/plugins/security_solution/public/common/components/control_columns @elastic/security-threat-hunting
+/x-pack/solutions/security/plugins/security_solution/public/common/components/drag_and_drop @elastic/security-threat-hunting
+/x-pack/solutions/security/plugins/security_solution/public/common/components/draggables @elastic/security-threat-hunting
+/x-pack/solutions/security/plugins/security_solution/public/common/components/empty_page @elastic/security-threat-hunting
+/x-pack/solutions/security/plugins/security_solution/public/common/components/empty_prompt @elastic/security-threat-hunting
+/x-pack/solutions/security/plugins/security_solution/public/common/components/event_details @elastic/security-threat-hunting
+/x-pack/solutions/security/plugins/security_solution/public/common/components/events_tab @elastic/security-threat-hunting
+/x-pack/solutions/security/plugins/security_solution/public/common/components/events_viewer @elastic/security-threat-hunting
+/x-pack/solutions/security/plugins/security_solution/public/common/components/exit_full_screen @elastic/security-threat-hunting
+/x-pack/solutions/security/plugins/security_solution/public/common/components/first_last_seen/first_last_seen.tsx @elastic/security-threat-hunting
+/x-pack/solutions/security/plugins/security_solution/public/common/components/formatted_date/index.tsx @elastic/security-threat-hunting
+/x-pack/solutions/security/plugins/security_solution/public/common/components/formatted_number/index.tsx @elastic/security-threat-hunting
+/x-pack/solutions/security/plugins/security_solution/public/common/components/header_actions @elastic/security-threat-hunting
+/x-pack/solutions/security/plugins/security_solution/public/common/components/header_page @elastic/security-threat-hunting
+/x-pack/solutions/security/plugins/security_solution/public/common/components/header_section @elastic/security-threat-hunting
+/x-pack/solutions/security/plugins/security_solution/public/common/components/inspect @elastic/security-threat-hunting
+/x-pack/solutions/security/plugins/security_solution/public/common/components/last_event_time @elastic/security-threat-hunting
+/x-pack/solutions/security/plugins/security_solution/public/common/components/links @elastic/security-threat-hunting
+/x-pack/solutions/security/plugins/security_solution/public/common/components/markdown_editor @elastic/security-threat-hunting
+/x-pack/solutions/security/plugins/security_solution/public/common/components/navigation @elastic/security-threat-hunting
+/x-pack/solutions/security/plugins/security_solution/public/common/components/news_feed @elastic/security-threat-hunting
+/x-pack/solutions/security/plugins/security_solution/public/common/components/overview_description_list @elastic/security-threat-hunting
+/x-pack/solutions/security/plugins/security_solution/public/common/components/page @elastic/security-threat-hunting
+/x-pack/solutions/security/plugins/security_solution/public/common/components/sidebar_header @elastic/security-threat-hunting
+/x-pack/solutions/security/plugins/security_solution/public/common/components/tables @elastic/security-threat-hunting
+/x-pack/solutions/security/plugins/security_solution/public/common/components/top_n @elastic/security-threat-hunting
+/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions @elastic/security-threat-hunting
+/x-pack/solutions/security/plugins/security_solution/public/common/containers/unified_alerts @elastic/security-threat-hunting
+/x-pack/solutions/security/plugins/security_solution/public/common/hooks/use_resolve_conflict.tsx @elastic/security-threat-hunting
+/x-pack/solutions/security/plugins/security_solution/public/common/hooks/use_create_data_view.ts @elastic/security-threat-hunting
+/x-pack/solutions/security/plugins/security_solution/public/common/lib/cell_actions @elastic/security-threat-hunting
+/x-pack/solutions/security/plugins/security_solution/public/common/lib/clipboard @elastic/security-threat-hunting
+/x-pack/solutions/security/plugins/security_solution/public/common/mock/mock_timeline_control_columns.tsx @elastic/security-threat-hunting
+/x-pack/solutions/security/plugins/security_solution/public/dashboards @elastic/security-threat-hunting
+/x-pack/solutions/security/plugins/security_solution/public/data_view_manager @elastic/security-threat-hunting
+/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary @elastic/security-threat-hunting
+/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts @elastic/security-threat-hunting
+/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis @elastic/security-threat-hunting
+/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table @elastic/security-threat-hunting
+/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks @elastic/security-threat-hunting
+/x-pack/solutions/security/plugins/security_solution/public/detections/components/callouts @elastic/security-threat-hunting
+/x-pack/solutions/security/plugins/security_solution/public/detections/components/rules @elastic/security-threat-hunting
+/x-pack/solutions/security/plugins/security_solution/public/detections/components/user_info @elastic/security-threat-hunting
+/x-pack/solutions/security/plugins/security_solution/public/detections/containers/detection_engine/alerts @elastic/security-threat-hunting
+/x-pack/solutions/security/plugins/security_solution/public/detections/configurations/security_solution_detections @elastic/security-threat-hunting
+/x-pack/solutions/security/plugins/security_solution/public/detections/hooks @elastic/security-threat-hunting
+/x-pack/solutions/security/plugins/security_solution/public/detections/pages @elastic/security-threat-hunting
+/x-pack/solutions/security/plugins/security_solution/public/detections/utils @elastic/security-threat-hunting
+/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details @elastic/security-threat-hunting
+/x-pack/solutions/security/plugins/security_solution/public/flyout/network_details @elastic/security-threat-hunting
+/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details @elastic/security-threat-hunting
+/x-pack/solutions/security/plugins/security_solution/public/flyout/shared @elastic/security-threat-hunting
+/x-pack/solutions/security/plugins/security_solution/public/flyout/rule_details @elastic/security-threat-hunting
+/x-pack/solutions/security/plugins/security_solution/public/flyout_v2 @elastic/security-threat-hunting
+/x-pack/solutions/security/plugins/security_solution/public/notes @elastic/security-threat-hunting
+/x-pack/solutions/security/plugins/security_solution/public/one_discover @elastic/security-threat-hunting
+/x-pack/solutions/security/plugins/security_solution/public/overview @elastic/security-threat-hunting
+/x-pack/solutions/security/plugins/security_solution/public/resolver @elastic/security-threat-hunting
+/x-pack/solutions/security/plugins/security_solution/public/siem_migrations @elastic/security-threat-hunting
+/x-pack/solutions/security/plugins/security_solution/public/sourcerer @elastic/security-threat-hunting
+/x-pack/solutions/security/plugins/security_solution/public/threat_intelligence @elastic/security-threat-hunting
+/x-pack/solutions/security/plugins/security_solution/public/timelines @elastic/security-threat-hunting
+
+/x-pack/solutions/security/plugins/security_solution_serverless/public/components/dashboards_landing_callout @elastic/security-threat-hunting
+/x-pack/solutions/security/plugins/security_solution_serverless/public/upselling/pages/threat_intelligence_paywall.tsx @elastic/security-threat-hunting
+
+/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations @elastic/security-threat-hunting
+/x-pack/solutions/security/plugins/security_solution/server/lib/timeline @elastic/security-threat-hunting
+
+/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/explore/cases @elastic/security-threat-hunting
+/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/explore/filters @elastic/security-threat-hunting
+/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/explore/inspect @elastic/security-threat-hunting
+/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/explore/navigation @elastic/security-threat-hunting
+/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/explore/overview @elastic/security-threat-hunting
+/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/explore/pagination @elastic/security-threat-hunting
+/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/explore/urls @elastic/security-threat-hunting
+/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/investigations @elastic/security-threat-hunting
+/x-pack/solutions/security/test/security_solution_cypress/cypress/fixtures/siem_migrations @elastic/security-threat-hunting
+/x-pack/solutions/security/test/security_solution_cypress/cypress/screens/expandable_flyout  @elastic/security-threat-hunting
+/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/expandable_flyout  @elastic/security-threat-hunting
+
+/x-pack/platform/test/fixtures/es_archives/auditbeat/overview @elastic/security-threat-hunting
+
+/x-pack/solutions/security/test/security_solution_api_integration/test_suites/investigation @elastic/security-threat-hunting
+/x-pack/solutions/security/test/security_solution_api_integration/test_suites/siem_migrations @elastic/security-threat-hunting
 
 /x-pack/solutions/security/test/serverless/functional/test_suites/ftr/discover @elastic/security-threat-hunting
-x-pack/solutions/security/test/serverless/functional/configs/config.context_awareness.ts @elastic/security-threat-hunting
+/x-pack/solutions/security/test/serverless/functional/configs/config.context_awareness.ts @elastic/security-threat-hunting
 /x-pack/solutions/security/plugins/security_solution/common/endpoint/schema/resolver.ts @elastic/security-threat-hunting
 
-## Security Solution Threat Hunting areas - Threat Hunting Investigations
-
-/x-pack/solutions/security/plugins/security_solution/common/api/tags @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution/common/api/timeline @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution/common/search_strategy/timeline @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution/common/timelines @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution/common/types/header_actions @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution/common/types/timeline @elastic/security-threat-hunting-investigations
-
-/x-pack/solutions/security/plugins/security_solution/public/app/actions @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution/public/app/home/template_wrapper/timeline @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution/public/common/components/accessibility @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution/public/common/components/alert_count_by_status @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution/public/common/components/charts @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution/public/common/components/drag_and_drop @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution/public/common/components/draggables @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution/public/common/components/empty_page @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution/public/common/components/empty_prompt @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution/public/common/components/event_details @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution/public/common/components/events_tab @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution/public/common/components/events_viewer @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution/public/common/components/exit_full_screen @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution/public/common/components/first_last_seen/first_last_seen.tsx @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution/public/common/components/formatted_date/index.tsx @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution/public/common/components/formatted_number/index.tsx @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution/public/common/components/header_actions @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution/public/common/components/header_page @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution/public/common/components/header_section @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution/public/common/components/inspect @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution/public/common/components/last_event_time @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution/public/common/components/links @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution/public/common/components/markdown_editor @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution/public/common/components/news_feed @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution/public/common/components/overview_description_list @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution/public/common/components/page @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution/public/common/components/sidebar_header @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution/public/common/components/tables @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution/public/common/components/top_n @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution/public/common/containers/unified_alerts @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution/public/common/hooks/use_resolve_conflict.tsx @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution/public/common/hooks/use_create_data_view.ts @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution/public/common/lib/cell_actions @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution/public/common/lib/clipboard @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution/public/common/mock/mock_timeline_control_columns.tsx @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution/public/dashboards @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution/public/data_view_manager @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution/public/detections/components/callouts @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution/public/detections/components/rules @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution/public/detections/components/user_info @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution/public/detections/containers/detection_engine/alerts @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution/public/detections/configurations/security_solution_detections @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution/public/detections/hooks @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution/public/detections/pages @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution/public/detections/utils @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution/public/flyout/network_details @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution/public/flyout/shared @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution/public/flyout/rule_details @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution/public/flyout_v2 @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution/public/notes @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution/public/one_discover @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution/public/overview @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution/public/resolver @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution/public/sourcerer @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution/public/threat_intelligence @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution/public/timelines @elastic/security-threat-hunting-investigations
-
-/x-pack/solutions/security/plugins/security_solution_serverless/public/components/dashboards_landing_callout @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution_serverless/public/upselling/pages/threat_intelligence_paywall.tsx @elastic/security-threat-hunting-investigations
-
-/x-pack/solutions/security/plugins/security_solution/server/lib/timeline @elastic/security-threat-hunting-investigations
-
-/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/explore/cases @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/explore/filters @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/explore/inspect @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/explore/navigation @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/explore/overview @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/explore/pagination @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/explore/urls @elastic/security-threat-hunting-investigations
-
-/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/investigations @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/test/security_solution_cypress/cypress/screens/expandable_flyout  @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/expandable_flyout  @elastic/security-threat-hunting-investigations
-
-/x-pack/platform/test/fixtures/es_archives/auditbeat/overview @elastic/security-threat-hunting-investigations
-
-/x-pack/solutions/security/test/security_solution_api_integration/test_suites/investigation @elastic/security-threat-hunting-investigations
-
-/x-pack/solutions/security/test/serverless/functional/configs/config.context_awareness.ts @elastic/security-threat-hunting-investigations
-
-/x-pack/solutions/security/packages/test-api-clients/supertest/timelines.gen.ts @elastic/security-threat-hunting-investigations
+/x-pack/solutions/security/packages/test-api-clients/supertest/timelines.gen.ts @elastic/security-threat-hunting
 
 ## Security Solution Threat Hunting areas - Kibana Cases
 
@@ -2989,7 +2985,7 @@ x-pack/platform/plugins/shared/actions/server/lib/token_tracking @elastic/securi
 /x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_preview @elastic/security-detection-engine
 /x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/signals @elastic/security-detection-engine
 /x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/signals_migration @elastic/security-detection-engine
-/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/unified_alerts @elastic/security-detection-engine @elastic/security-threat-hunting-investigations
+/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/unified_alerts @elastic/security-detection-engine @elastic/security-threat-hunting
 /x-pack/solutions/security/plugins/security_solution/common/cti @elastic/security-detection-engine
 /x-pack/solutions/security/plugins/security_solution/common/field_maps @elastic/security-detection-engine
 /x-pack/solutions/security/test/fixtures/es_archives/entity/risks @elastic/security-detection-engine
@@ -3012,12 +3008,12 @@ x-pack/platform/plugins/shared/actions/server/lib/token_tracking @elastic/securi
 /x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types @elastic/security-detection-engine
 /x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/routes/index @elastic/security-detection-engine
 /x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/routes/signals @elastic/security-detection-engine
-/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/routes/unified_alerts @elastic/security-detection-engine @elastic/security-threat-hunting-investigations
+/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/routes/unified_alerts @elastic/security-detection-engine @elastic/security-threat-hunting
 
 /x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine @elastic/security-detection-engine
 
 /x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/detection_engine @elastic/security-detection-engine
-/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/detection_engine/unified_alerts @elastic/security-detection-engine @elastic/security-threat-hunting-investigations
+/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/detection_engine/unified_alerts @elastic/security-detection-engine @elastic/security-threat-hunting
 /x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/utils/rules/rule_gaps.ts @elastic/security-detection-engine
 /x-pack/solutions/security/test/security_solution_api_integration/test_suites/lists_and_exception_lists @elastic/security-detection-engine
 /x-pack/solutions/security/test/fixtures/es_archives/asset_criticality @elastic/security-detection-engine

--- a/src/platform/packages/shared/kbn-cell-actions/kibana.jsonc
+++ b/src/platform/packages/shared/kbn-cell-actions/kibana.jsonc
@@ -2,7 +2,7 @@
   "type": "shared-common",
   "id": "@kbn/cell-actions",
   "owner": [
-    "@elastic/security-threat-hunting-investigations"
+    "@elastic/security-threat-hunting"
   ],
   "group": "platform",
   "visibility": "shared"

--- a/src/platform/packages/shared/kbn-cell-actions/moon.yml
+++ b/src/platform/packages/shared/kbn-cell-actions/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/cell-actions'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/security-threat-hunting-investigations'
+  defaultOwner: '@elastic/security-threat-hunting'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/cell-actions'
   description: Moon project for @kbn/cell-actions
   channel: ''
-  owner: '@elastic/security-threat-hunting-investigations'
+  owner: '@elastic/security-threat-hunting'
   sourceRoot: src/platform/packages/shared/kbn-cell-actions
 dependsOn:
   - '@kbn/i18n'

--- a/src/platform/packages/shared/kbn-securitysolution-ecs/kibana.jsonc
+++ b/src/platform/packages/shared/kbn-securitysolution-ecs/kibana.jsonc
@@ -2,7 +2,7 @@
   "type": "shared-common",
   "id": "@kbn/securitysolution-ecs",
   "owner": [
-    "@elastic/security-threat-hunting-investigations"
+    "@elastic/security-threat-hunting"
   ],
   "group": "platform",
   "visibility": "shared"

--- a/src/platform/packages/shared/kbn-securitysolution-ecs/moon.yml
+++ b/src/platform/packages/shared/kbn-securitysolution-ecs/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/securitysolution-ecs'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/security-threat-hunting-investigations'
+  defaultOwner: '@elastic/security-threat-hunting'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/securitysolution-ecs'
   description: Moon project for @kbn/securitysolution-ecs
   channel: ''
-  owner: '@elastic/security-threat-hunting-investigations'
+  owner: '@elastic/security-threat-hunting'
   sourceRoot: src/platform/packages/shared/kbn-securitysolution-ecs
 tags:
   - shared-common

--- a/src/platform/packages/shared/kbn-unified-data-table/kibana.jsonc
+++ b/src/platform/packages/shared/kbn-unified-data-table/kibana.jsonc
@@ -3,7 +3,7 @@
   "id": "@kbn/unified-data-table",
   "owner": [
     "@elastic/kibana-data-discovery",
-    "@elastic/security-threat-hunting-investigations"
+    "@elastic/security-threat-hunting"
   ],
   "group": "platform",
   "visibility": "shared",

--- a/x-pack/solutions/security/packages/connectors/kibana.jsonc
+++ b/x-pack/solutions/security/packages/connectors/kibana.jsonc
@@ -2,7 +2,7 @@
   "type": "shared-browser",
   "id": "@kbn/security-solution-connectors",
   "owner": [
-    "@elastic/security-threat-hunting-investigations"
+    "@elastic/security-threat-hunting"
   ],
   "group": "security",
   "visibility": "private"

--- a/x-pack/solutions/security/packages/connectors/moon.yml
+++ b/x-pack/solutions/security/packages/connectors/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/security-solution-connectors'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/security-threat-hunting-investigations'
+  defaultOwner: '@elastic/security-threat-hunting'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/security-solution-connectors'
   description: Moon project for @kbn/security-solution-connectors
   channel: ''
-  owner: '@elastic/security-threat-hunting-investigations'
+  owner: '@elastic/security-threat-hunting'
   sourceRoot: x-pack/solutions/security/packages/connectors
 dependsOn:
   - '@kbn/i18n'

--- a/x-pack/solutions/security/packages/data-table/kibana.jsonc
+++ b/x-pack/solutions/security/packages/data-table/kibana.jsonc
@@ -2,7 +2,7 @@
   "type": "shared-browser",
   "id": "@kbn/securitysolution-data-table",
   "owner": [
-    "@elastic/security-threat-hunting-investigations"
+    "@elastic/security-threat-hunting"
   ],
   "group": "security",
   "visibility": "private"

--- a/x-pack/solutions/security/packages/data-table/moon.yml
+++ b/x-pack/solutions/security/packages/data-table/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/securitysolution-data-table'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/security-threat-hunting-investigations'
+  defaultOwner: '@elastic/security-threat-hunting'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/securitysolution-data-table'
   description: Moon project for @kbn/securitysolution-data-table
   channel: ''
-  owner: '@elastic/security-threat-hunting-investigations'
+  owner: '@elastic/security-threat-hunting'
   sourceRoot: x-pack/solutions/security/packages/data-table
 dependsOn:
   - '@kbn/cell-actions'

--- a/x-pack/solutions/security/packages/ecs-data-quality-dashboard/kibana.jsonc
+++ b/x-pack/solutions/security/packages/ecs-data-quality-dashboard/kibana.jsonc
@@ -2,7 +2,7 @@
   "type": "shared-browser",
   "id": "@kbn/ecs-data-quality-dashboard",
   "owner": [
-    "@elastic/security-threat-hunting-investigations"
+    "@elastic/security-threat-hunting"
   ],
   "group": "security",
   "visibility": "private"

--- a/x-pack/solutions/security/packages/ecs-data-quality-dashboard/moon.yml
+++ b/x-pack/solutions/security/packages/ecs-data-quality-dashboard/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/ecs-data-quality-dashboard'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/security-threat-hunting-investigations'
+  defaultOwner: '@elastic/security-threat-hunting'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/ecs-data-quality-dashboard'
   description: Moon project for @kbn/ecs-data-quality-dashboard
   channel: ''
-  owner: '@elastic/security-threat-hunting-investigations'
+  owner: '@elastic/security-threat-hunting'
   sourceRoot: x-pack/solutions/security/packages/ecs-data-quality-dashboard
 dependsOn:
   - '@kbn/i18n'

--- a/x-pack/solutions/security/packages/expandable-flyout/kibana.jsonc
+++ b/x-pack/solutions/security/packages/expandable-flyout/kibana.jsonc
@@ -2,7 +2,7 @@
   "type": "shared-browser",
   "id": "@kbn/expandable-flyout",
   "owner": [
-    "@elastic/security-threat-hunting-investigations"
+    "@elastic/security-threat-hunting"
   ],
   "group": "security",
   "visibility": "private"

--- a/x-pack/solutions/security/packages/expandable-flyout/moon.yml
+++ b/x-pack/solutions/security/packages/expandable-flyout/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/expandable-flyout'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/security-threat-hunting-investigations'
+  defaultOwner: '@elastic/security-threat-hunting'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/expandable-flyout'
   description: Moon project for @kbn/expandable-flyout
   channel: ''
-  owner: '@elastic/security-threat-hunting-investigations'
+  owner: '@elastic/security-threat-hunting'
   sourceRoot: x-pack/solutions/security/packages/expandable-flyout
 dependsOn:
   - '@kbn/i18n'

--- a/x-pack/solutions/security/packages/storybook/config/kibana.jsonc
+++ b/x-pack/solutions/security/packages/storybook/config/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "shared-common",
   "id": "@kbn/security-solution-storybook-config",
-  "owner": "@elastic/security-threat-hunting-investigations",
+  "owner": "@elastic/security-threat-hunting",
   "group": "security",
   "visibility": "private"
 }

--- a/x-pack/solutions/security/packages/storybook/config/moon.yml
+++ b/x-pack/solutions/security/packages/storybook/config/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/security-solution-storybook-config'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/security-threat-hunting-investigations'
+  defaultOwner: '@elastic/security-threat-hunting'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/security-solution-storybook-config'
   description: Moon project for @kbn/security-solution-storybook-config
   channel: ''
-  owner: '@elastic/security-threat-hunting-investigations'
+  owner: '@elastic/security-threat-hunting'
   sourceRoot: x-pack/solutions/security/packages/storybook/config
 dependsOn:
   - '@kbn/storybook'

--- a/x-pack/solutions/security/packages/upselling/kibana.jsonc
+++ b/x-pack/solutions/security/packages/upselling/kibana.jsonc
@@ -2,7 +2,7 @@
   "type": "shared-browser",
   "id": "@kbn/security-solution-upselling",
   "owner": [
-    "@elastic/security-threat-hunting-investigations"
+    "@elastic/security-threat-hunting"
   ],
   "group": "security",
   "visibility": "private"

--- a/x-pack/solutions/security/packages/upselling/moon.yml
+++ b/x-pack/solutions/security/packages/upselling/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/security-solution-upselling'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/security-threat-hunting-investigations'
+  defaultOwner: '@elastic/security-threat-hunting'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/security-solution-upselling'
   description: Moon project for @kbn/security-solution-upselling
   channel: ''
-  owner: '@elastic/security-threat-hunting-investigations'
+  owner: '@elastic/security-threat-hunting'
   sourceRoot: x-pack/solutions/security/packages/upselling
 dependsOn:
   - '@kbn/i18n'

--- a/x-pack/solutions/security/plugins/ecs_data_quality_dashboard/kibana.jsonc
+++ b/x-pack/solutions/security/plugins/ecs_data_quality_dashboard/kibana.jsonc
@@ -2,7 +2,7 @@
   "type": "plugin",
   "id": "@kbn/ecs-data-quality-dashboard-plugin",
   "owner": [
-    "@elastic/security-threat-hunting-investigations"
+    "@elastic/security-threat-hunting"
   ],
   "group": "security",
   "visibility": "private",

--- a/x-pack/solutions/security/plugins/ecs_data_quality_dashboard/moon.yml
+++ b/x-pack/solutions/security/plugins/ecs_data_quality_dashboard/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/ecs-data-quality-dashboard-plugin'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/security-threat-hunting-investigations'
+  defaultOwner: '@elastic/security-threat-hunting'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/ecs-data-quality-dashboard-plugin'
   description: Moon project for @kbn/ecs-data-quality-dashboard-plugin
   channel: ''
-  owner: '@elastic/security-threat-hunting-investigations'
+  owner: '@elastic/security-threat-hunting'
   sourceRoot: x-pack/solutions/security/plugins/ecs_data_quality_dashboard
 dependsOn:
   - '@kbn/core'

--- a/x-pack/solutions/security/plugins/timelines/kibana.jsonc
+++ b/x-pack/solutions/security/plugins/timelines/kibana.jsonc
@@ -2,7 +2,7 @@
   "type": "plugin",
   "id": "@kbn/timelines-plugin",
   "owner": [
-    "@elastic/security-threat-hunting-investigations"
+    "@elastic/security-threat-hunting"
   ],
   "group": "security",
   "visibility": "private",

--- a/x-pack/solutions/security/plugins/timelines/moon.yml
+++ b/x-pack/solutions/security/plugins/timelines/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/timelines-plugin'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/security-threat-hunting-investigations'
+  defaultOwner: '@elastic/security-threat-hunting'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/timelines-plugin'
   description: Moon project for @kbn/timelines-plugin
   channel: ''
-  owner: '@elastic/security-threat-hunting-investigations'
+  owner: '@elastic/security-threat-hunting'
   sourceRoot: x-pack/solutions/security/plugins/timelines
 dependsOn:
   - '@kbn/core'


### PR DESCRIPTION
## Summary

This PR updates the codeowners file to change Threat Hunting Investigations to just Threat Hunting, now that both teams are merged into one.

### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
