### PR TITLE
[Discover] show document flyout Security enhanced profile for remote alerts/events

### DIFF
--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/security_profile_providers.test.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/security_profile_providers.test.tsx
@@ -152,22 +152,11 @@ describe('createSecurityDocumentProfileProviders', () => {
       expect(registry.add).not.toHaveBeenCalled();
     });
 
-    it('does not override renderHeader for remote (CCS) alert documents', () => {
+    it('overrides renderHeader for remote (CCS/CPS) alert documents', () => {
       const { result, prevRenderHeader } = getDocViewerResult(
         createRecord({
           'event.kind': 'signal',
-          _index: 'remote-cluster:.alerts-security.alerts-default',
-        })
-      );
-
-      expect(result.renderHeader).toBe(prevRenderHeader);
-    });
-
-    it('overrides renderHeader for remote (CCS) event documents', () => {
-      const { result, prevRenderHeader } = getDocViewerResult(
-        createRecord({
-          'event.kind': 'event',
-          _index: 'remote-cluster:logs-system-default',
+          _index: 'remote:.alerts-security.alerts-default',
         })
       );
 
@@ -175,11 +164,47 @@ describe('createSecurityDocumentProfileProviders', () => {
       expect(result.renderHeader).not.toBe(prevRenderHeader);
     });
 
-    it('adds the overview tab for remote (CCS) alert documents', () => {
+    it('overrides renderFooter for remote (CCS/CPS) alert documents', () => {
+      const { result, prevRenderFooter } = getDocViewerResult(
+        createRecord({
+          'event.kind': 'signal',
+          _index: 'remote:.alerts-security.alerts-default',
+        })
+      );
+
+      expect(result.renderFooter).toBeDefined();
+      expect(result.renderFooter).not.toBe(prevRenderFooter);
+    });
+
+    it('overrides renderHeader for remote (CCS/CPS) event documents', () => {
+      const { result, prevRenderHeader } = getDocViewerResult(
+        createRecord({
+          'event.kind': 'event',
+          _index: 'remote:logs-system-default',
+        })
+      );
+
+      expect(result.renderHeader).toBeDefined();
+      expect(result.renderHeader).not.toBe(prevRenderHeader);
+    });
+
+    it('overrides renderFooter for remote (CCS/CPS) event documents', () => {
+      const { result, prevRenderFooter } = getDocViewerResult(
+        createRecord({
+          'event.kind': 'event',
+          _index: 'remote:logs-system-default',
+        })
+      );
+
+      expect(result.renderFooter).toBeDefined();
+      expect(result.renderFooter).not.toBe(prevRenderFooter);
+    });
+
+    it('adds the overview tab for remote (CCS/CPS) alert documents', () => {
       const { result } = getDocViewerResult(
         createRecord({
           'event.kind': 'signal',
-          _index: 'remote-cluster:.alerts-security.alerts-default',
+          _index: 'remote:.alerts-security.alerts-default',
         })
       );
       const registry = { add: jest.fn() };
@@ -190,11 +215,11 @@ describe('createSecurityDocumentProfileProviders', () => {
       );
     });
 
-    it('adds the overview tab for remote (CCS) event documents', () => {
+    it('adds the overview tab for remote (CCS/CPS) event documents', () => {
       const { result } = getDocViewerResult(
         createRecord({
           'event.kind': 'event',
-          _index: 'remote-cluster:logs-system-default',
+          _index: 'remote:logs-system-default',
         })
       );
       const registry = { add: jest.fn() };

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/security_profile_providers.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/security_profile_providers.tsx
@@ -8,10 +8,7 @@
  */
 
 import React from 'react';
-import { getFieldValue } from '@kbn/discover-utils';
-import { isCCSRemoteIndexName } from '@kbn/es-query';
 import {
-  AlertEventOverviewLazy,
   EnhancedAlertEventOverviewLazy,
   EnhancedAlertFlyoutFooterLazy,
   EnhancedAlertFlyoutHeaderLazy,
@@ -35,14 +32,11 @@ export const createSecurityDocumentProfileProviders = (
         const prevDocViewer = prev(params);
         const isAlert = isAlertDocument(params.record);
         const isEvent = isEventDocument(params.record);
-        const isRemoteDocument = isCCSRemoteIndexName(
-          (getFieldValue(params.record, '_index') as string) ?? ''
-        );
 
         return {
           ...prevDocViewer,
           renderHeader:
-            (isAlert && !isRemoteDocument) || isEvent
+            isAlert || isEvent
               ? (props) => (
                   <EnhancedAlertFlyoutHeaderLazy
                     {...props}
@@ -52,8 +46,7 @@ export const createSecurityDocumentProfileProviders = (
                 )
               : prevDocViewer.renderHeader,
           docViewsRegistry: (registry) => {
-            if ((isAlert || isEvent) && !isRemoteDocument) {
-              // For local alerts or events, use the enhanced overview
+            if (isAlert || isEvent) {
               registry.add({
                 id: 'doc_view_alerts_overview',
                 title: i18n.overviewTabTitle(isAlert),
@@ -61,14 +54,6 @@ export const createSecurityDocumentProfileProviders = (
                 render: (props) => (
                   <EnhancedAlertEventOverviewLazy {...props} providerServices={providerServices} />
                 ),
-              });
-            } else if ((isAlert || isEvent) && isRemoteDocument) {
-              // For remote alerts or events use the basic overview
-              registry.add({
-                id: 'doc_view_alerts_overview',
-                title: i18n.overviewTabTitle(isAlert),
-                order: 0,
-                render: (props) => <AlertEventOverviewLazy {...props} />,
               });
             }
 


### PR DESCRIPTION
## Summary

This PR enables showing the enhanced profile instead of falling back to the base profile for the document flyout in Discover with Security solution navigatin enabled, when opening remote documents (alerts and events).

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->