### PR TITLE
[9.4] [Security Solution] ResponseOps alerts table offers a `projectRouting` prop to override default behavior (#263572)

### DIFF
--- a/src/platform/packages/shared/kbn-alerts-ui-shared/src/common/apis/search_alerts/search_alerts.test.tsx
+++ b/src/platform/packages/shared/kbn-alerts-ui-shared/src/common/apis/search_alerts/search_alerts.test.tsx
@@ -265,7 +265,23 @@ describe('searchAlerts', () => {
         },
         sort: params.sort,
       },
-      { strategy: 'privateRuleRegistryAlertsSearchStrategy' }
+      {
+        strategy: 'privateRuleRegistryAlertsSearchStrategy',
+        abortSignal: undefined,
+        projectRouting: undefined,
+      }
+    );
+  });
+
+  it('passes projectRouting in search options', async () => {
+    await searchAlerts({ ...params, projectRouting: '_alias:_origin' });
+
+    expect(mockDataPlugin.search.search).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({
+        strategy: 'privateRuleRegistryAlertsSearchStrategy',
+        projectRouting: '_alias:_origin',
+      })
     );
   });
 

--- a/src/platform/packages/shared/kbn-alerts-ui-shared/src/common/apis/search_alerts/search_alerts.ts
+++ b/src/platform/packages/shared/kbn-alerts-ui-shared/src/common/apis/search_alerts/search_alerts.ts
@@ -21,6 +21,7 @@ import type {
   RuleRegistrySearchResponse,
 } from '@kbn/alerting-types';
 import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
+import type { ProjectRouting } from '@kbn/es-query';
 import { set } from '@kbn/safer-lodash-set';
 import { catchError, filter, lastValueFrom, map, of } from 'rxjs';
 
@@ -80,6 +81,10 @@ export interface SearchAlertsParams {
    * Whether to track the score of the query
    */
   trackScores?: boolean;
+  /**
+   * CPS project routing override for the underlying search request
+   */
+  projectRouting?: ProjectRouting;
 }
 
 export interface SearchAlertsResult {
@@ -107,6 +112,7 @@ export const searchAlerts = ({
   pageSize,
   minScore,
   trackScores,
+  projectRouting,
 }: SearchAlertsParams): Promise<SearchAlertsResult> =>
   lastValueFrom(
     data.search
@@ -125,6 +131,7 @@ export const searchAlerts = ({
         {
           strategy: 'privateRuleRegistryAlertsSearchStrategy',
           abortSignal: signal,
+          projectRouting,
         }
       )
       .pipe(

--- a/src/platform/packages/shared/kbn-alerts-ui-shared/src/common/hooks/use_search_alerts_query.test.tsx
+++ b/src/platform/packages/shared/kbn-alerts-ui-shared/src/common/hooks/use_search_alerts_query.test.tsx
@@ -149,8 +149,27 @@ describe('useSearchAlertsQuery', () => {
       },
       {
         abortSignal: expect.any(AbortSignal),
+        projectRouting: undefined,
         strategy: 'privateRuleRegistryAlertsSearchStrategy',
       }
+    );
+  });
+
+  it('forwards projectRouting to search options', async () => {
+    const { result } = renderHook(
+      () => useSearchAlertsQuery({ ...params, projectRouting: '_alias:_origin' }),
+      {
+        wrapper,
+      }
+    );
+
+    await waitFor(() => expect(result.current.data).toBeDefined());
+
+    expect(mockDataPlugin.search.search).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({
+        projectRouting: '_alias:_origin',
+      })
     );
   });
 

--- a/src/platform/packages/shared/kbn-alerts-ui-shared/src/common/hooks/use_search_alerts_query.ts
+++ b/src/platform/packages/shared/kbn-alerts-ui-shared/src/common/hooks/use_search_alerts_query.ts
@@ -49,6 +49,7 @@ export const useSearchAlertsQuery = ({
     pageSize = DEFAULT_ALERTS_PAGE_SIZE,
     minScore,
     trackScores,
+    projectRouting,
   } = params;
   return useQuery({
     queryKey: queryKeyPrefix.concat(JSON.stringify(params)),
@@ -66,6 +67,7 @@ export const useSearchAlertsQuery = ({
         pageSize,
         minScore,
         trackScores,
+        projectRouting,
       }),
     refetchOnWindowFocus: false,
     context: skipAlertsQueryContext ? undefined : AlertsQueryContext,

--- a/x-pack/platform/packages/shared/response-ops/alerts-table/components/alerts_table.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerts-table/components/alerts_table.tsx
@@ -178,6 +178,7 @@ const AlertsTableContent = typedForwardRef(
       id,
       ruleTypeIds,
       consumers,
+      projectRouting,
       query,
       minScore,
       trackScores = false,
@@ -361,6 +362,7 @@ const AlertsTableContent = typedForwardRef(
     const queryParams = useAlertsTableQueryParams({
       ruleTypeIds,
       consumers,
+      projectRouting,
       fields,
       query,
       sort,

--- a/x-pack/platform/packages/shared/response-ops/alerts-table/hooks/use_alerts_table_query_params.test.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerts-table/hooks/use_alerts_table_query_params.test.ts
@@ -15,6 +15,7 @@ const mockSetPageIndex = jest.fn();
 const defaultOptions: UseAlertsTableQueryParamsOptions = {
   ruleTypeIds: ['ruleType1'],
   consumers: ['consumer1'],
+  projectRouting: undefined,
   fields: [{ field: 'field1', include_unmapped: false }],
   query: {},
   sort: [],
@@ -29,6 +30,7 @@ const defaultOptions: UseAlertsTableQueryParamsOptions = {
 const changedOptions: Partial<UseAlertsTableQueryParamsOptions> = {
   ruleTypeIds: ['ruleType1', 'ruleType2'],
   consumers: ['consumer1', 'consumer2'],
+  projectRouting: '_alias:_origin',
   fields: [
     { field: 'field1', include_unmapped: false },
     { field: 'field2', include_unmapped: true },
@@ -42,6 +44,7 @@ const changedOptions: Partial<UseAlertsTableQueryParamsOptions> = {
 const optionsTriggeringReset = [
   'ruleTypeIds',
   'consumers',
+  'projectRouting',
   'fields',
   'query',
   'sort',
@@ -101,6 +104,7 @@ describe('useAlertsTableQueryParams', () => {
       ...defaultOptions,
       ruleTypeIds: ['ruleType1'],
       consumers: ['consumer1'],
+      projectRouting: undefined,
       fields: [{ field: 'field1', include_unmapped: false }],
       query: {},
       sort: [],

--- a/x-pack/platform/packages/shared/response-ops/alerts-table/hooks/use_alerts_table_query_params.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerts-table/hooks/use_alerts_table_query_params.ts
@@ -18,6 +18,7 @@ export interface UseAlertsTableQueryParamsOptions
       AlertsTableProps,
       | 'ruleTypeIds'
       | 'consumers'
+      | 'projectRouting'
       | 'query'
       | 'sort'
       | 'runtimeMappings'
@@ -43,6 +44,7 @@ export interface UseAlertsTableQueryParamsOptions
 export const useAlertsTableQueryParams = ({
   ruleTypeIds,
   consumers,
+  projectRouting,
   fields,
   query,
   sort,
@@ -57,6 +59,7 @@ export const useAlertsTableQueryParams = ({
   const [queryParams, setQueryParams] = useState({
     ruleTypeIds,
     consumers,
+    projectRouting,
     fields,
     query,
     sort,
@@ -76,6 +79,7 @@ export const useAlertsTableQueryParams = ({
         {
           ruleTypeIds: prevQueryParams.ruleTypeIds,
           consumers: prevQueryParams.consumers,
+          projectRouting: prevQueryParams.projectRouting,
           fields: prevQueryParams.fields,
           query: prevQueryParams.query,
           sort: prevQueryParams.sort,
@@ -86,6 +90,7 @@ export const useAlertsTableQueryParams = ({
         {
           ruleTypeIds,
           consumers,
+          projectRouting,
           fields,
           query,
           sort,
@@ -105,6 +110,7 @@ export const useAlertsTableQueryParams = ({
       return {
         ruleTypeIds,
         consumers,
+        projectRouting,
         fields,
         query,
         sort,
@@ -123,6 +129,7 @@ export const useAlertsTableQueryParams = ({
     runtimeMappings,
     sort,
     consumers,
+    projectRouting,
     minScore,
     trackScores,
     pageSize,

--- a/x-pack/platform/packages/shared/response-ops/alerts-table/moon.yml
+++ b/x-pack/platform/packages/shared/response-ops/alerts-table/moon.yml
@@ -48,6 +48,7 @@ dependsOn:
   - '@kbn/field-types'
   - '@kbn/react-query'
   - '@kbn/maintenance-windows-plugin'
+  - '@kbn/es-query'
 tags:
   - shared-browser
   - package

--- a/x-pack/platform/packages/shared/response-ops/alerts-table/tsconfig.json
+++ b/x-pack/platform/packages/shared/response-ops/alerts-table/tsconfig.json
@@ -47,5 +47,6 @@
     "@kbn/field-types",
     "@kbn/react-query",
     "@kbn/maintenance-windows-plugin",
+    "@kbn/es-query",
   ]
 }

--- a/x-pack/platform/packages/shared/response-ops/alerts-table/types.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerts-table/types.ts
@@ -6,25 +6,25 @@
  */
 
 import type {
-  JSX,
   ComponentClass,
   ComponentProps,
   ComponentType,
   Dispatch,
   FC,
+  JSX,
   Key,
   MutableRefObject,
   ReactNode,
   RefAttributes,
 } from 'react';
 import type {
-  AlertConsumers,
   ALERT_CASE_IDS,
-  ALERT_STATUS,
   ALERT_MAINTENANCE_WINDOW_IDS,
+  ALERT_STATUS,
+  AlertConsumers,
 } from '@kbn/rule-data-utils';
 import type { HttpStart } from '@kbn/core-http-browser';
-import type { EsQuerySnapshot, LegacyField } from '@kbn/alerting-types';
+import type { Alert, BrowserFields, EsQuerySnapshot, LegacyField } from '@kbn/alerting-types';
 import type {
   EuiDataGridColumn,
   EuiDataGridColumnCellAction,
@@ -39,11 +39,9 @@ import type {
   MappingRuntimeFields,
   QueryDslQueryContainer,
 } from '@elastic/elasticsearch/lib/api/types';
-import type { BrowserFields } from '@kbn/alerting-types';
 import type { SetRequired } from 'type-fest';
 import type { MaintenanceWindow } from '@kbn/maintenance-windows-plugin/common';
 import type { FieldFormatsStart } from '@kbn/field-formats-plugin/public';
-import type { Alert } from '@kbn/alerting-types';
 import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
 import type { FieldBrowserOptions } from '@kbn/response-ops-alerts-fields-browser';
 import type { MutedAlerts } from '@kbn/response-ops-alerts-apis/types';
@@ -52,6 +50,7 @@ import type { LicensingPluginStart } from '@kbn/licensing-plugin/public';
 import type { ApplicationStart } from '@kbn/core-application-browser';
 import type { SettingsStart } from '@kbn/core-ui-settings-browser';
 import type { IStorageWrapper } from '@kbn/kibana-utils-plugin/public';
+import type { ProjectRouting } from '@kbn/es-query';
 import type { EuiDataGridCellValueElementProps } from '@elastic/eui/src/components/datagrid/data_grid_types';
 import type { EuiContextMenuPanelId } from '@elastic/eui/src/components/context_menu/context_menu';
 import type { AlertFormatter } from '@kbn/alerts-ui-shared/src/common/types';
@@ -561,6 +560,10 @@ export interface PublicAlertsDataGridProps
   minScore?: number;
   trackScores?: boolean;
   consumers?: string[];
+  /**
+   * Value to override the server side search
+   */
+  projectRouting?: ProjectRouting;
   /**
    * If true, shows a button in the table toolbar to inspect the search alerts request
    */

--- a/x-pack/platform/plugins/shared/rule_registry/server/search_strategy/search_strategy.test.ts
+++ b/x-pack/platform/plugins/shared/rule_registry/server/search_strategy/search_strategy.test.ts
@@ -292,6 +292,9 @@ describe('ruleRegistrySearchStrategyProvider()', () => {
 
     expect(data.search.searchAsInternalUser.search).toHaveBeenCalled();
     expect(searchStrategySearch).not.toHaveBeenCalled();
+    expect((data.search.searchAsInternalUser.search as jest.Mock).mock.calls[0][1]).toEqual(
+      options
+    );
   });
 
   it('should use scoped user when requesting siem alerts as RBAC is not applied', async () => {
@@ -314,6 +317,36 @@ describe('ruleRegistrySearchStrategyProvider()', () => {
 
     expect(data.search.searchAsInternalUser.search as jest.Mock).not.toHaveBeenCalled();
     expect(searchStrategySearch).toHaveBeenCalled();
+    expect(searchStrategySearch.mock.calls[0][1]).toEqual(options);
+  });
+
+  it('forwards provided project routing for siem requests', async () => {
+    const request: RuleRegistrySearchRequest = {
+      ruleTypeIds: ['siem.esqlRule'],
+    };
+    const options = {
+      projectRouting: '_alias:*',
+    };
+    const deps = {
+      request: {},
+    };
+
+    getAuthorizedRuleTypesMock.mockResolvedValue([]);
+    getAlertIndicesAliasMock.mockReturnValue(['security-siem']);
+
+    const strategy = ruleRegistrySearchStrategyProvider(data, alerting, logger, security, spaces);
+
+    await lastValueFrom(
+      strategy.search(request, options, deps as unknown as SearchStrategyDependencies)
+    );
+
+    expect(searchStrategySearch).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({
+        projectRouting: '_alias:*',
+      }),
+      deps
+    );
   });
 
   it('should support pagination', async () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/index.tsx
@@ -23,6 +23,7 @@ import type { SetOptional } from 'type-fest';
 import { noop } from 'lodash';
 import type { Alert } from '@kbn/alerting-types';
 import { AlertsTable as ResponseOpsAlertsTable } from '@kbn/response-ops-alerts-table';
+import { PROJECT_ROUTING } from '@kbn/cps-utils';
 import { PageScope } from '../../../data_view_manager/constants';
 import { useDataView } from '../../../data_view_manager/hooks/use_data_view';
 import { useAlertsContext } from './alerts_context';
@@ -467,6 +468,7 @@ const AlertsTableComponent: FC<Omit<AlertTableProps, 'services' | 'isMutedAlerts
               id={id ?? `detection-engine-alert-table-${tableType}-${tableView}`}
               ruleTypeIds={SECURITY_SOLUTION_RULE_TYPE_IDS}
               consumers={ALERT_TABLE_CONSUMERS}
+              projectRouting={PROJECT_ROUTING.ORIGIN}
               query={finalBoolQuery}
               sort={sort}
               casesConfiguration={casesConfiguration}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Security Solution] ResponseOps alerts table offers a `projectRouting` prop to override default behavior (#263572)](https://github.com/elastic/kibana/pull/263572)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Philippe Oberti","email":"philippe.oberti@elastic.co"},"sourceCommit":{"committedDate":"2026-04-20T17:37:56Z","message":"[Security Solution] ResponseOps alerts table offers a `projectRouting` prop to override default behavior (#263572)\n\n## Summary\n\nThis PR adds a new `projectRouting` property to the ResponseOps alerts\ntable, so we can override the default behavior. In Security we indeed\nneed to never show remote alerts, completely ignoring the state of the\nCPS on the page.\n\n### Code changes\n\n- add a new `projectRouting` prop to the ResponseOps alerts table.\n- we ensure that if the prop isn't passed, the default behavior is not\nchanged\n- when passed, the prop overrides the default behavior\n- the alerts table within the Alerts page passes `'_alias:_origin'` to\nthe ResponseOps alerts table\n\n### If no `projectRouting` is passed we show remote alerts (CPS picker\nis enabled and multi-project is selected)\n\n<img width=\"1082\" height=\"858\" alt=\"Screenshot 2026-04-15 at 12 42\n19 PM\"\nsrc=\"https://github.com/user-attachments/assets/3baa6d75-793c-4cb1-8787-b32ecb849c62\"\n/>\n\n### If we pass `'_alias:_origin'` then we force not fetching remote\nalerts\n\n<img width=\"1079\" height=\"880\" alt=\"Screenshot 2026-04-15 at 12 43\n49 PM\"\nsrc=\"https://github.com/user-attachments/assets/89001e80-fe9b-4927-973c-5bac9621adba\"\n/>\n\n## How to test\n\nYou can follow this guide\nhttps://docs.google.com/document/d/16c6H8EVyyAUwp7QDm-77__RHz_hSJ2_wE40_as7WIqE/edit?pli=1&tab=t.0\nto generate a full local Serverless CPS environment with events and\nalerts in both the origin and the linked projects\n\nIn\n[plugin.tsx](https://github.com/elastic/kibana/tree/main/x-pack/solutions/security/plugins/security_solution/public/plugin.tsx)\nyou can replace\n```typescript\nplugins.cps?.cpsManager?.registerAppAccess(APP_UI_ID, (location: string) =>\n      /security\\/dashboards\\/[^?]+/.test(location)\n        ? ProjectRoutingAccess.EDITABLE\n        : ProjectRoutingAccess.DISABLED\n    );\n```\nwith \n```typescript\nplugins.cps?.cpsManager?.registerAppAccess(APP_UI_ID, () => ProjectRoutingAccess.EDITABLE);\n```\nto make sure that the CPS picker will be enabled on every page.\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\nPR developed with Cursor + gpt-5.3-codex","sha":"42c2045625b731e341a4a125e14ae55956d7d64e","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Threat Hunting:Investigations","backport:version","v9.4.0","v9.5.0"],"title":"[Security Solution] ResponseOps alerts table offers a `projectRouting` prop to override default behavior","number":263572,"url":"https://github.com/elastic/kibana/pull/263572","mergeCommit":{"message":"[Security Solution] ResponseOps alerts table offers a `projectRouting` prop to override default behavior (#263572)\n\n## Summary\n\nThis PR adds a new `projectRouting` property to the ResponseOps alerts\ntable, so we can override the default behavior. In Security we indeed\nneed to never show remote alerts, completely ignoring the state of the\nCPS on the page.\n\n### Code changes\n\n- add a new `projectRouting` prop to the ResponseOps alerts table.\n- we ensure that if the prop isn't passed, the default behavior is not\nchanged\n- when passed, the prop overrides the default behavior\n- the alerts table within the Alerts page passes `'_alias:_origin'` to\nthe ResponseOps alerts table\n\n### If no `projectRouting` is passed we show remote alerts (CPS picker\nis enabled and multi-project is selected)\n\n<img width=\"1082\" height=\"858\" alt=\"Screenshot 2026-04-15 at 12 42\n19 PM\"\nsrc=\"https://github.com/user-attachments/assets/3baa6d75-793c-4cb1-8787-b32ecb849c62\"\n/>\n\n### If we pass `'_alias:_origin'` then we force not fetching remote\nalerts\n\n<img width=\"1079\" height=\"880\" alt=\"Screenshot 2026-04-15 at 12 43\n49 PM\"\nsrc=\"https://github.com/user-attachments/assets/89001e80-fe9b-4927-973c-5bac9621adba\"\n/>\n\n## How to test\n\nYou can follow this guide\nhttps://docs.google.com/document/d/16c6H8EVyyAUwp7QDm-77__RHz_hSJ2_wE40_as7WIqE/edit?pli=1&tab=t.0\nto generate a full local Serverless CPS environment with events and\nalerts in both the origin and the linked projects\n\nIn\n[plugin.tsx](https://github.com/elastic/kibana/tree/main/x-pack/solutions/security/plugins/security_solution/public/plugin.tsx)\nyou can replace\n```typescript\nplugins.cps?.cpsManager?.registerAppAccess(APP_UI_ID, (location: string) =>\n      /security\\/dashboards\\/[^?]+/.test(location)\n        ? ProjectRoutingAccess.EDITABLE\n        : ProjectRoutingAccess.DISABLED\n    );\n```\nwith \n```typescript\nplugins.cps?.cpsManager?.registerAppAccess(APP_UI_ID, () => ProjectRoutingAccess.EDITABLE);\n```\nto make sure that the CPS picker will be enabled on every page.\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\nPR developed with Cursor + gpt-5.3-codex","sha":"42c2045625b731e341a4a125e14ae55956d7d64e"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/263572","number":263572,"mergeCommit":{"message":"[Security Solution] ResponseOps alerts table offers a `projectRouting` prop to override default behavior (#263572)\n\n## Summary\n\nThis PR adds a new `projectRouting` property to the ResponseOps alerts\ntable, so we can override the default behavior. In Security we indeed\nneed to never show remote alerts, completely ignoring the state of the\nCPS on the page.\n\n### Code changes\n\n- add a new `projectRouting` prop to the ResponseOps alerts table.\n- we ensure that if the prop isn't passed, the default behavior is not\nchanged\n- when passed, the prop overrides the default behavior\n- the alerts table within the Alerts page passes `'_alias:_origin'` to\nthe ResponseOps alerts table\n\n### If no `projectRouting` is passed we show remote alerts (CPS picker\nis enabled and multi-project is selected)\n\n<img width=\"1082\" height=\"858\" alt=\"Screenshot 2026-04-15 at 12 42\n19 PM\"\nsrc=\"https://github.com/user-attachments/assets/3baa6d75-793c-4cb1-8787-b32ecb849c62\"\n/>\n\n### If we pass `'_alias:_origin'` then we force not fetching remote\nalerts\n\n<img width=\"1079\" height=\"880\" alt=\"Screenshot 2026-04-15 at 12 43\n49 PM\"\nsrc=\"https://github.com/user-attachments/assets/89001e80-fe9b-4927-973c-5bac9621adba\"\n/>\n\n## How to test\n\nYou can follow this guide\nhttps://docs.google.com/document/d/16c6H8EVyyAUwp7QDm-77__RHz_hSJ2_wE40_as7WIqE/edit?pli=1&tab=t.0\nto generate a full local Serverless CPS environment with events and\nalerts in both the origin and the linked projects\n\nIn\n[plugin.tsx](https://github.com/elastic/kibana/tree/main/x-pack/solutions/security/plugins/security_solution/public/plugin.tsx)\nyou can replace\n```typescript\nplugins.cps?.cpsManager?.registerAppAccess(APP_UI_ID, (location: string) =>\n      /security\\/dashboards\\/[^?]+/.test(location)\n        ? ProjectRoutingAccess.EDITABLE\n        : ProjectRoutingAccess.DISABLED\n    );\n```\nwith \n```typescript\nplugins.cps?.cpsManager?.registerAppAccess(APP_UI_ID, () => ProjectRoutingAccess.EDITABLE);\n```\nto make sure that the CPS picker will be enabled on every page.\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\nPR developed with Cursor + gpt-5.3-codex","sha":"42c2045625b731e341a4a125e14ae55956d7d64e"}}]}] BACKPORT-->