### PR TITLE
[Osquery] Fix cypress test - advanced to osquery config issue

### DIFF
--- a/x-pack/platform/plugins/shared/osquery/cypress/e2e/all/add_integration.cy.ts
+++ b/x-pack/platform/plugins/shared/osquery/cypress/e2e/all/add_integration.cy.ts
@@ -39,8 +39,7 @@ import {
 } from '../../tasks/integrations';
 import { ServerlessRoleName } from '../../support/roles';
 
-// Failing: See https://github.com/elastic/kibana/issues/255381
-describe.skip('ALL - Add Integration', { tags: ['@ess', '@serverless'] }, () => {
+describe('ALL - Add Integration', { tags: ['@ess', '@serverless'] }, () => {
   let savedQueryId: string;
 
   before(() => {
@@ -211,11 +210,11 @@ describe.skip('ALL - Add Integration', { tags: ['@ess', '@serverless'] }, () => 
       cy.get(`[title="${policyName}"]`).click();
       closeFleetTourIfVisible();
       cy.getBySel('integrationPolicyUpgradeBtn').click();
-      cy.contains(/^Advanced$/).click();
+      cy.contains(/^Osquery config$/).click();
       cy.get('.kibanaCodeEditor', { timeout: 30000 }).should('contain', `"default--${packName}":`);
       cy.getBySel('saveIntegration').click();
       cy.get(`a[title="${integrationName}"]`).click();
-      cy.contains(/^Advanced$/).click();
+      cy.contains(/^Osquery config$/).click();
       cy.get('.kibanaCodeEditor', { timeout: 30000 }).should('contain', `"default--${packName}":`);
       cy.contains('Cancel').click();
       closeModalIfVisible();


### PR DESCRIPTION
Change introduced by merging two PR's close to each other - the bigger refactor cypress test PR had successful tests from the run prior to implementation change Pr. 