### PR TITLE
Upgrade EUI to v114.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "@elastic/elasticsearch": "9.3.4",
     "@elastic/ems-client": "8.7.0",
     "@elastic/esql": "2.0.0",
-    "@elastic/eui": "114.1.0",
+    "@elastic/eui": "114.2.0",
     "@elastic/eui-theme-borealis": "7.0.0",
     "@elastic/filesaver": "1.1.2",
     "@elastic/kibana-d3-color": "npm:@elastic/kibana-d3-color@2.0.1",

--- a/src/core/packages/i18n/browser-internal/src/i18n_eui_mapping.test.ts
+++ b/src/core/packages/i18n/browser-internal/src/i18n_eui_mapping.test.ts
@@ -14,6 +14,7 @@ import { i18n } from '@kbn/i18n';
 import i18ntokens from '@elastic/eui/i18ntokens.json';
 import { getEuiContextMapping } from './i18n_eui_mapping';
 
+const TYPE_ANNOTATIONS_REGEX = /(?<=})\s*:\s*{[\s\S]*?}(?=\s*\))/;
 /** Regexp to find {values} usage */
 const VALUES_REGEXP = /\{\w+\}/;
 type I18nTranslateCall = [
@@ -89,6 +90,8 @@ describe('@elastic/eui i18n tokens', () => {
           .replace(/\n/g, '')
           // Should trim extra spaces
           .replace(/\s{2,}/g, ' ')
+          // Should not include type annotations
+          .replace(TYPE_ANNOTATIONS_REGEX, '')
           .trim();
 
         if (!isDefFunction) {
@@ -96,8 +99,9 @@ describe('@elastic/eui i18n tokens', () => {
         } else {
           // Certain EUI defStrings are actually functions (that currently primarily handle
           // pluralization). To check EUI's pluralization against Kibana's pluralization, we
-          // need to eval the defString and then actually i18n.translate & compare the 2 outputs
-          const defFunction = eval(defString); // eslint-disable-line no-eval
+          // need to eval the defString and then actually i18n.translate & compare the 2 outputs.
+          const defStringWithoutTypeAnnotations = defString.replace(TYPE_ANNOTATIONS_REGEX, '');
+          const defFunction = eval(defStringWithoutTypeAnnotations); // eslint-disable-line no-eval
           const defFunctionArg = normalizedDefString.split('({ ')[1].split('})')[0]; // TODO: All EUI pluralization fns currently only pass 1 arg. If this changes in the future and 2 args are passed, we'll need to do some extra splitting by ','
 
           if (isPluralizationDefFunction) {

--- a/src/platform/packages/private/kbn-ui-shared-deps-npm/version_dependencies.txt
+++ b/src/platform/packages/private/kbn-ui-shared-deps-npm/version_dependencies.txt
@@ -18,7 +18,7 @@
 @elastic/esql@2.0.0
 @elastic/eui-theme-borealis@7.0.0
 @elastic/eui-theme-common@9.0.0
-@elastic/eui@114.1.0
+@elastic/eui@114.2.0
 @elastic/numeral@2.5.1
 @elastic/prismjs-esql@1.1.2
 @emotion/babel-plugin@11.13.5

--- a/yarn.lock
+++ b/yarn.lock
@@ -2408,10 +2408,10 @@
     chroma-js "^2.4.2"
     lodash "^4.17.21"
 
-"@elastic/eui@114.1.0":
-  version "114.1.0"
-  resolved "https://registry.yarnpkg.com/@elastic/eui/-/eui-114.1.0.tgz#c85fe29f092af1ccbf73c2dc5ea15fceb486852d"
-  integrity sha512-vQo87fKXKN217kLpQ46BY/sKg/AZ9dGhHsZEWfqG5iDATs5Qu9egfxaEU4+QvQn8na0YuGfOtBGj7i4jnZ4GuA==
+"@elastic/eui@114.2.0":
+  version "114.2.0"
+  resolved "https://registry.yarnpkg.com/@elastic/eui/-/eui-114.2.0.tgz#04551190586b09ed5d0de86dae3cfe2468b1178a"
+  integrity sha512-jFHflSzBdD8bEV9JaeFlB7mkV8+sh21MwMD4EsV5KVuRGYKgNUjGj1uxitMlYICFIG0qwcCa/YWvY8pUnskBoA==
   dependencies:
     "@elastic/eui-theme-common" "9.0.0"
     "@elastic/prismjs-esql" "^1.1.2"


### PR DESCRIPTION
## Dependency updates

- `@elastic/eui` - v114.1.0 ⏩ v114.2.0

---

## Changes

- Adjusted `i18n_eui_mapping.test.ts` to correctly work with type-annotated `defString`
    - I'm not exactly sure why EUI emits these as raw function strings, which are later evaluated and compared in Kibana, but it's been like that since forever, and this PR just adjusts what already exists

## Package updates

## [`v114.2.0`](https://github.com/elastic/eui/releases/v114.2.0)

- Added `addToDashboard` icon ([#9590](https://github.com/elastic/eui/pull/9590))
- Added support for document-relative links in `EuiMarkdownFormat` and `EuiMarkdownEditor` via a new `allowDocumentRelative` option in `parsingConfig.linkValidator` ([#9554](https://github.com/elastic/eui/pull/9554))
- Added `useEuiWindowEvent` hook and refactored `EuiWindowEvent` to use it internally, preventing unnecessary listener re-registration when inline arrow functions are passed as handlers ([#9536](https://github.com/elastic/eui/pull/9536))

**Bug fixes**

- Fixed a missing checked border state on `EuiCheckableCard` ([#9589](https://github.com/elastic/eui/pull/9589))
- Fixed the visual alignment of right aligned icons in `EuiFormControlButton` when `value` is not passed ([#9588](https://github.com/elastic/eui/pull/9588))

**Accessibility**

- Fixed `EuiSelectable` screen reader repeatedly announcing total results count on every option navigation instead of only when the count changes ([#9555](https://github.com/elastic/eui/pull/9555))

