### PR TITLE
[Entity Analytics] Restoring observed details queries for user and host flyouts.

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/common/api/search_strategy/hosts/details.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/search_strategy/hosts/details.ts
@@ -21,6 +21,7 @@ export const hostDetailsSchema = requestBasicOptionsSchema.extend({
   timerange,
   sort,
   factoryQueryType: z.literal(HostsQueries.details),
+  entityStoreV2: z.boolean().optional(),
 });
 
 export type HostDetailsRequestOptionsInput = z.input<typeof hostDetailsSchema>;

--- a/x-pack/solutions/security/plugins/security_solution/common/api/search_strategy/users/observed_details.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/search_strategy/users/observed_details.ts
@@ -18,6 +18,7 @@ export const observedUserDetailsSchema = requestBasicOptionsSchema.extend({
   timerange,
   inspect,
   factoryQueryType: z.literal(UsersQueries.observedDetails),
+  entityStoreV2: z.boolean().optional(),
 });
 
 export type ObservedUserDetailsRequestOptionsInput = z.input<typeof observedUserDetailsSchema>;

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/hosts/entity_store_v2_hosts_kpi_lens_shared.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/hosts/entity_store_v2_hosts_kpi_lens_shared.ts
@@ -10,9 +10,6 @@ import type { Filter } from '@kbn/es-query';
 /** Stable id for ad-hoc data view (Entity Store v2 unified latest index). */
 export const ENTITY_STORE_V2_HOSTS_KPI_LENS_AD_HOC_ID = '7f2a9c1e-4b8d-4e6f-a3c2-9d1e8f7a6b5c';
 
-export const getEntityStoreV2LatestHostsIndexTitle = (spaceId?: string) =>
-  `.entities.v2.latest.security_${spaceId ?? 'default'}`;
-
 export const getEntityStoreV2HostOnlyFilter = (): Filter => ({
   meta: {
     alias: null,

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/hosts/kpi_host_area.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/hosts/kpi_host_area.test.ts
@@ -70,7 +70,7 @@ describe('getKpiHostAreaLensAttributes', () => {
     const adHoc = attrs?.state.adHocDataViews;
     expect(adHoc).toBeDefined();
     const spec = Object.values(adHoc ?? {})[0];
-    expect(spec?.title).toBe('.entities.v2.latest.security_my_space');
+    expect(spec?.title).toBe('.entities.v2.latest.security_my_space-00001');
     const hostTypeFilter = attrs?.state.filters?.find(
       (f) => f.meta?.key === 'entity.EngineMetadata.Type'
     );

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/hosts/kpi_host_area.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/hosts/kpi_host_area.ts
@@ -5,13 +5,13 @@
  * 2.0.
  */
 
+import { getLatestEntitiesIndexName } from '@kbn/entity-store/common';
 import { UNIQUE_COUNT } from '../../translations';
 import type { LensAttributes, GetLensAttributes } from '../../types';
 
 import {
   ENTITY_STORE_V2_HOSTS_KPI_LENS_AD_HOC_ID,
   getEntityStoreV2HostOnlyFilter,
-  getEntityStoreV2LatestHostsIndexTitle,
 } from './entity_store_v2_hosts_kpi_lens_shared';
 
 const columnTimestamp = '5eea817b-67b7-4268-8ecb-7688d1094721';
@@ -95,7 +95,7 @@ const getLegacyKpiHostAreaLensAttributes = (): LensAttributes => {
 };
 
 const getEntityStoreV2KpiHostAreaLensAttributes = (spaceId?: string): LensAttributes => {
-  const indexTitle = getEntityStoreV2LatestHostsIndexTitle(spaceId);
+  const indexTitle = getLatestEntitiesIndexName(spaceId ?? 'default');
 
   return {
     description: '',

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/hosts/kpi_host_metric.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/hosts/kpi_host_metric.test.ts
@@ -70,7 +70,7 @@ describe('kpiHostMetricLensAttributes', () => {
     expect(attrs?.references).toEqual([]);
     expect(attrs?.state.internalReferences).toHaveLength(2);
     const spec = Object.values(attrs?.state.adHocDataViews ?? {})[0];
-    expect(spec?.title).toBe('.entities.v2.latest.security_custom_space');
+    expect(spec?.title).toBe('.entities.v2.latest.security_custom_space-00001');
     const hostTypeFilter = attrs?.state.filters?.find(
       (f) => f.meta?.key === 'entity.EngineMetadata.Type'
     );

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/hosts/kpi_host_metric.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/hosts/kpi_host_metric.ts
@@ -5,12 +5,12 @@
  * 2.0.
  */
 
+import { getLatestEntitiesIndexName } from '@kbn/entity-store/common';
 import type { ExtraOptions, LensAttributes } from '../../types';
 
 import {
   ENTITY_STORE_V2_HOSTS_KPI_LENS_AD_HOC_ID,
   getEntityStoreV2HostOnlyFilter,
-  getEntityStoreV2LatestHostsIndexTitle,
 } from './entity_store_v2_hosts_kpi_lens_shared';
 
 const layerId = '416b6fad-1923-4f6a-a2df-b223bb287e30';
@@ -67,7 +67,7 @@ const getLegacyKpiHostMetricLensAttributes = (): LensAttributes => {
 };
 
 const getEntityStoreV2KpiHostMetricLensAttributes = (spaceId?: string): LensAttributes => {
-  const indexTitle = getEntityStoreV2LatestHostsIndexTitle(spaceId);
+  const indexTitle = getLatestEntitiesIndexName(spaceId ?? 'default');
 
   return {
     description: '',

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/users/entity_store_v2_users_kpi_lens_shared.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/users/entity_store_v2_users_kpi_lens_shared.ts
@@ -10,9 +10,6 @@ import type { Filter } from '@kbn/es-query';
 /** Stable id for users KPI ad-hoc data view (Entity Store v2 unified latest index). */
 export const ENTITY_STORE_V2_USERS_KPI_LENS_AD_HOC_ID = 'b8e3f2a1-6c4d-5e7f-8a9b-0c1d2e3f4a5b';
 
-export const getEntityStoreV2LatestUsersIndexTitle = (spaceId?: string) =>
-  `.entities.v2.latest.security_${spaceId ?? 'default'}`;
-
 export const getEntityStoreV2UserOnlyFilter = (): Filter => ({
   meta: {
     alias: null,

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/users/kpi_total_users_area.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/users/kpi_total_users_area.test.ts
@@ -68,7 +68,7 @@ describe('getKpiTotalUsersAreaLensAttributes', () => {
     expect(attrs?.references).toEqual([]);
     expect(attrs?.state.internalReferences).toHaveLength(2);
     const spec = Object.values(attrs?.state.adHocDataViews ?? {})[0];
-    expect(spec?.title).toBe('.entities.v2.latest.security_my_space');
+    expect(spec?.title).toBe('.entities.v2.latest.security_my_space-00001');
     const userTypeFilter = attrs?.state.filters?.find(
       (f) => f.meta?.key === 'entity.EngineMetadata.Type'
     );

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/users/kpi_total_users_area.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/users/kpi_total_users_area.ts
@@ -5,12 +5,12 @@
  * 2.0.
  */
 
+import { getLatestEntitiesIndexName } from '@kbn/entity-store/common';
 import { UNIQUE_COUNT } from '../../translations';
 import type { LensAttributes, GetLensAttributes } from '../../types';
 
 import {
   ENTITY_STORE_V2_USERS_KPI_LENS_AD_HOC_ID,
-  getEntityStoreV2LatestUsersIndexTitle,
   getEntityStoreV2UserOnlyFilter,
 } from './entity_store_v2_users_kpi_lens_shared';
 
@@ -95,7 +95,7 @@ const getLegacyKpiTotalUsersAreaLensAttributes = (): LensAttributes => {
 };
 
 const getEntityStoreV2KpiTotalUsersAreaLensAttributes = (spaceId?: string): LensAttributes => {
-  const indexTitle = getEntityStoreV2LatestUsersIndexTitle(spaceId);
+  const indexTitle = getLatestEntitiesIndexName(spaceId ?? 'default');
 
   return {
     description: '',

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/users/kpi_total_users_metric.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/users/kpi_total_users_metric.test.ts
@@ -73,7 +73,7 @@ describe('kpiTotalUsersMetricLensAttributes', () => {
     expect(attrs?.references).toEqual([]);
     expect(attrs?.state.internalReferences).toHaveLength(2);
     const spec = Object.values(attrs?.state.adHocDataViews ?? {})[0];
-    expect(spec?.title).toBe('.entities.v2.latest.security_custom_space');
+    expect(spec?.title).toBe('.entities.v2.latest.security_custom_space-00001');
     const userTypeFilter = attrs?.state.filters?.find(
       (f) => f.meta?.key === 'entity.EngineMetadata.Type'
     );

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/users/kpi_total_users_metric.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/users/kpi_total_users_metric.ts
@@ -5,11 +5,11 @@
  * 2.0.
  */
 
+import { getLatestEntitiesIndexName } from '@kbn/entity-store/common';
 import type { ExtraOptions, LensAttributes } from '../../types';
 
 import {
   ENTITY_STORE_V2_USERS_KPI_LENS_AD_HOC_ID,
-  getEntityStoreV2LatestUsersIndexTitle,
   getEntityStoreV2UserOnlyFilter,
 } from './entity_store_v2_users_kpi_lens_shared';
 
@@ -67,7 +67,7 @@ const getLegacyKpiTotalUsersMetricLensAttributes = (): LensAttributes => {
 };
 
 const getEntityStoreV2KpiTotalUsersMetricLensAttributes = (spaceId?: string): LensAttributes => {
-  const indexTitle = getEntityStoreV2LatestUsersIndexTitle(spaceId);
+  const indexTitle = getLatestEntitiesIndexName(spaceId ?? 'default');
 
   return {
     description: '',

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/hosts/containers/hosts/details/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/hosts/containers/hosts/details/index.test.tsx
@@ -9,11 +9,24 @@ import { renderHook, act } from '@testing-library/react';
 import { TestProviders } from '../../../../../common/mock';
 import { ID, useHostDetails } from '.';
 import { useSearchStrategy } from '../../../../../common/containers/use_search_strategy';
+import { useUiSetting } from '../../../../../common/lib/kibana';
+import { useEntityStoreEuidApi } from '@kbn/entity-store/public';
 
 jest.mock('../../../../../common/containers/use_search_strategy', () => ({
   useSearchStrategy: jest.fn(),
 }));
+jest.mock('../../../../../common/lib/kibana', () => {
+  const actual = jest.requireActual('../../../../../common/lib/kibana');
+  return { ...actual, useUiSetting: jest.fn(() => false) };
+});
+jest.mock('@kbn/entity-store/public', () => ({
+  FF_ENABLE_ENTITY_STORE_V2: 'securitySolution:entityStoreEnableV2',
+  useEntityStoreEuidApi: jest.fn(() => undefined),
+}));
+
 const mockUseSearchStrategy = useSearchStrategy as jest.Mock;
+const mockUseUiSetting = useUiSetting as jest.Mock;
+const mockUseEntityStoreEuidApi = useEntityStoreEuidApi as jest.Mock;
 const mockSearch = jest.fn();
 
 const defaultProps = {
@@ -28,6 +41,8 @@ const defaultProps = {
 describe('useHostDetails', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUseUiSetting.mockReturnValue(false);
+    mockUseEntityStoreEuidApi.mockReturnValue(undefined);
     mockUseSearchStrategy.mockReturnValue({
       loading: false,
       result: {
@@ -59,7 +74,7 @@ describe('useHostDetails', () => {
     expect(mockSearch).not.toHaveBeenCalled();
   });
 
-  it('does not run search when hostName is missing', () => {
+  it('does not run search when hostName is empty and entity store v2 is not enabled', () => {
     const { endDate, startDate, indexNames, id, skip } = defaultProps;
     renderHook(
       () =>
@@ -69,6 +84,7 @@ describe('useHostDetails', () => {
           indexNames,
           id,
           skip,
+          hostName: '',
         }),
       {
         wrapper: TestProviders,
@@ -77,6 +93,54 @@ describe('useHostDetails', () => {
 
     expect(mockSearch).not.toHaveBeenCalled();
   });
+
+  it('does not run search when entityId is undefined and entity store v2 is enabled', () => {
+    mockUseUiSetting.mockReturnValue(true);
+    mockUseEntityStoreEuidApi.mockReturnValue({ euid: {} });
+
+    renderHook(() => useHostDetails(defaultProps), { wrapper: TestProviders });
+
+    expect(mockSearch).not.toHaveBeenCalled();
+  });
+
+  it('does not run search when entity store v2 is enabled and entity Id is specified but euidApi.euid is undefined', () => {
+    mockUseUiSetting.mockReturnValue(true);
+    mockUseEntityStoreEuidApi.mockReturnValue({ euid: undefined });
+
+    renderHook(() => useHostDetails({ ...defaultProps, entityId: 'my-macbook' }), {
+      wrapper: TestProviders,
+    });
+
+    expect(mockSearch).not.toHaveBeenCalled();
+  });
+
+  it('uses entity_id in filterQuery when entity store v2 is enabled', () => {
+    mockUseUiSetting.mockReturnValue(true);
+    mockUseEntityStoreEuidApi.mockReturnValue({ euid: {} });
+
+    renderHook(() => useHostDetails({ ...defaultProps, entityId: 'my-macbook' }), {
+      wrapper: TestProviders,
+    });
+
+    expect(mockSearch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filterQuery: JSON.stringify({ term: { entity_id: 'my-macbook' } }),
+      })
+    );
+  });
+
+  it('uses host.name in filterQuery when entity store v2 is disabled', () => {
+    mockUseEntityStoreEuidApi.mockReturnValue({ euid: {} });
+
+    renderHook(() => useHostDetails(defaultProps), { wrapper: TestProviders });
+
+    expect(mockSearch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filterQuery: JSON.stringify({ term: { 'host.name': 'my-macbook' } }),
+      })
+    );
+  });
+
   it('skip = true will cancel any running request', () => {
     const props = {
       ...defaultProps,

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/hosts/containers/hosts/details/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/hosts/containers/hosts/details/index.test.tsx
@@ -94,13 +94,29 @@ describe('useHostDetails', () => {
     expect(mockSearch).not.toHaveBeenCalled();
   });
 
-  it('does not run search when entityId is undefined and entity store v2 is enabled', () => {
+  it('does not run search when both entityId and hostName are empty and entity store v2 is enabled', () => {
+    mockUseUiSetting.mockReturnValue(true);
+    mockUseEntityStoreEuidApi.mockReturnValue({ euid: {} });
+
+    renderHook(
+      () => useHostDetails({ ...defaultProps, hostName: '', entityId: undefined }),
+      { wrapper: TestProviders }
+    );
+
+    expect(mockSearch).not.toHaveBeenCalled();
+  });
+
+  it('runs search with host.name filter when entity store v2 is enabled and entityId is undefined but hostName is provided', () => {
     mockUseUiSetting.mockReturnValue(true);
     mockUseEntityStoreEuidApi.mockReturnValue({ euid: {} });
 
     renderHook(() => useHostDetails(defaultProps), { wrapper: TestProviders });
 
-    expect(mockSearch).not.toHaveBeenCalled();
+    expect(mockSearch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filterQuery: JSON.stringify({ term: { 'host.name': 'my-macbook' } }),
+      })
+    );
   });
 
   it('does not run search when entity store v2 is enabled and entity Id is specified but euidApi.euid is undefined', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/hosts/containers/hosts/details/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/hosts/containers/hosts/details/index.test.tsx
@@ -98,10 +98,9 @@ describe('useHostDetails', () => {
     mockUseUiSetting.mockReturnValue(true);
     mockUseEntityStoreEuidApi.mockReturnValue({ euid: {} });
 
-    renderHook(
-      () => useHostDetails({ ...defaultProps, hostName: '', entityId: undefined }),
-      { wrapper: TestProviders }
-    );
+    renderHook(() => useHostDetails({ ...defaultProps, hostName: '', entityId: undefined }), {
+      wrapper: TestProviders,
+    });
 
     expect(mockSearch).not.toHaveBeenCalled();
   });

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/hosts/containers/hosts/details/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/hosts/containers/hosts/details/index.tsx
@@ -55,7 +55,7 @@ export const useHostDetails = ({
   const shouldSkip =
     skip ||
     (!entityStoreV2Enabled && isEmpty(hostName)) ||
-    (entityStoreV2Enabled && (!euidApi?.euid || isEmpty(entityId)));
+    (entityStoreV2Enabled && (!euidApi?.euid || (isEmpty(entityId) && isEmpty(hostName))));
 
   const euidFilter = useMemo(() => {
     if (shouldSkip) {
@@ -67,7 +67,12 @@ export const useHostDetails = ({
       return { term: { 'host.name': hostName } };
     } else {
       // For entity store v2, query by entity_id (runtime field)
-      return { term: { entity_id: entityId } };
+      if (entityId) {
+        return { term: { entity_id: entityId } };
+      } else if (hostName) {
+        // If entityId is not available, fall back to host.name for querying
+        return { term: { 'host.name': hostName } };
+      }
     }
   }, [entityStoreV2Enabled, shouldSkip, hostName, entityId]);
 

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/hosts/containers/hosts/details/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/hosts/containers/hosts/details/index.tsx
@@ -7,6 +7,8 @@
 
 import { useEffect, useMemo } from 'react';
 
+import { FF_ENABLE_ENTITY_STORE_V2, useEntityStoreEuidApi } from '@kbn/entity-store/public';
+import { isEmpty } from 'lodash';
 import type { inputsModel } from '../../../../../common/store';
 import type { HostItem } from '../../../../../../common/search_strategy/security_solution/hosts';
 import { HostsQueries } from '../../../../../../common/search_strategy/security_solution/hosts';
@@ -14,6 +16,7 @@ import { HostsQueries } from '../../../../../../common/search_strategy/security_
 import * as i18n from './translations';
 import type { InspectResponse } from '../../../../../types';
 import { useSearchStrategy } from '../../../../../common/containers/use_search_strategy';
+import { useUiSetting } from '../../../../../common/lib/kibana';
 
 export const ID = 'hostsDetailsQuery';
 
@@ -29,7 +32,8 @@ export interface HostDetailsArgs {
 interface UseHostDetails {
   endDate: string;
   /** When missing or empty, the host details search is not run (avoids invalid strategy requests). */
-  hostName?: string;
+  hostName: string;
+  entityId?: string;
   id?: string;
   indexNames: string[];
   skip?: boolean;
@@ -39,12 +43,33 @@ interface UseHostDetails {
 export const useHostDetails = ({
   endDate,
   hostName,
+  entityId,
   indexNames,
   id = ID,
   skip = false,
   startDate,
 }: UseHostDetails): [boolean, HostDetailsArgs, inputsModel.Refetch] => {
-  const shouldSkip = skip || hostName == null || hostName === '';
+  const entityStoreV2Enabled = useUiSetting<boolean>(FF_ENABLE_ENTITY_STORE_V2, false);
+  const euidApi = useEntityStoreEuidApi();
+
+  const shouldSkip =
+    skip ||
+    (!entityStoreV2Enabled && isEmpty(hostName)) ||
+    (entityStoreV2Enabled && (!euidApi?.euid || isEmpty(entityId)));
+
+  const euidFilter = useMemo(() => {
+    if (shouldSkip) {
+      return undefined;
+    }
+
+    if (!entityStoreV2Enabled) {
+      // For legacy entity store, query by host.name
+      return { term: { 'host.name': hostName } };
+    } else {
+      // For entity store v2, query by entity_id (runtime field)
+      return { term: { entity_id: entityId } };
+    }
+  }, [entityStoreV2Enabled, shouldSkip, hostName, entityId]);
 
   const {
     loading,
@@ -75,20 +100,22 @@ export const useHostDetails = ({
   );
 
   const hostDetailsRequest = useMemo(() => {
-    if (hostName == null || hostName === '') {
+    if (!euidFilter) {
       return null;
     }
     return {
       defaultIndex: indexNames,
       factoryQueryType: HostsQueries.details,
       hostName,
+      filterQuery: JSON.stringify(euidFilter),
+      entityStoreV2: entityStoreV2Enabled || false,
       timerange: {
         interval: '12h',
         from: startDate,
         to: endDate,
       },
     };
-  }, [endDate, hostName, indexNames, startDate]);
+  }, [endDate, entityStoreV2Enabled, euidFilter, indexNames, startDate, hostName]);
 
   useEffect(() => {
     if (!shouldSkip && hostDetailsRequest != null) {

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/hosts/pages/details/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/hosts/pages/details/index.tsx
@@ -284,8 +284,9 @@ const HostDetailsComponent: React.FC<HostDetailsProps> = ({
     endDate: to,
     startDate: from,
     hostName: detailName,
+    entityId: entityStoreV2Enabled ? entityFromStoreResult.entityRecord?.entity?.id : undefined,
     indexNames: selectedPatterns,
-    skip: selectedPatterns.length === 0 || entityStoreV2Enabled,
+    skip: selectedPatterns.length === 0,
   });
 
   const hostDetailsForOverview = entityStoreV2Enabled ? observedHost.details : hostOverview;

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/users/containers/users/observed_details/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/users/containers/users/observed_details/index.test.tsx
@@ -9,11 +9,25 @@ import { renderHook, act } from '@testing-library/react';
 import { TestProviders } from '../../../../../common/mock';
 import { useObservedUserDetails } from '.';
 import { useSearchStrategy } from '../../../../../common/containers/use_search_strategy';
+import { useUiSetting } from '../../../../../common/lib/kibana';
+import { useEntityStoreEuidApi } from '@kbn/entity-store/public';
+import { NOT_EVENT_KIND_ASSET_FILTER } from '../../../../../../common/search_strategy/security_solution/users/common';
 
 jest.mock('../../../../../common/containers/use_search_strategy', () => ({
   useSearchStrategy: jest.fn(),
 }));
+jest.mock('../../../../../common/lib/kibana', () => {
+  const actual = jest.requireActual('../../../../../common/lib/kibana');
+  return { ...actual, useUiSetting: jest.fn(() => false) };
+});
+jest.mock('@kbn/entity-store/public', () => ({
+  FF_ENABLE_ENTITY_STORE_V2: 'securitySolution:entityStoreEnableV2',
+  useEntityStoreEuidApi: jest.fn(() => undefined),
+}));
+
 const mockUseSearchStrategy = useSearchStrategy as jest.Mock;
+const mockUseUiSetting = useUiSetting as jest.Mock;
+const mockUseEntityStoreEuidApi = useEntityStoreEuidApi as jest.Mock;
 const mockSearch = jest.fn();
 
 const defaultProps = {
@@ -27,10 +41,12 @@ const defaultProps = {
 describe('useUserDetails', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUseUiSetting.mockReturnValue(false);
+    mockUseEntityStoreEuidApi.mockReturnValue(undefined);
     mockUseSearchStrategy.mockReturnValue({
       loading: false,
       result: {
-        overviewNetwork: {},
+        userDetails: {},
       },
       search: mockSearch,
       refetch: jest.fn(),
@@ -57,6 +73,77 @@ describe('useUserDetails', () => {
 
     expect(mockSearch).not.toHaveBeenCalled();
   });
+
+  it('does not run search when userName is empty and entity store v2 is not enabled', () => {
+    const { endDate, startDate, indexNames, skip } = defaultProps;
+    renderHook(
+      () =>
+        useObservedUserDetails({
+          endDate,
+          startDate,
+          indexNames,
+          skip,
+          userName: '',
+        }),
+      {
+        wrapper: TestProviders,
+      }
+    );
+
+    expect(mockSearch).not.toHaveBeenCalled();
+  });
+
+  it('does not run search when entityId is undefined and entity store v2 is enabled', () => {
+    mockUseUiSetting.mockReturnValue(true);
+    mockUseEntityStoreEuidApi.mockReturnValue({ euid: {} });
+
+    renderHook(() => useObservedUserDetails(defaultProps), { wrapper: TestProviders });
+
+    expect(mockSearch).not.toHaveBeenCalled();
+  });
+
+  it('does not run search when entity store v2 is enabled and entity Id is specified but euidApi.euid is undefined', () => {
+    mockUseUiSetting.mockReturnValue(true);
+    mockUseEntityStoreEuidApi.mockReturnValue({ euid: undefined });
+
+    renderHook(() => useObservedUserDetails({ ...defaultProps, entityId: 'myUserName' }), {
+      wrapper: TestProviders,
+    });
+
+    expect(mockSearch).not.toHaveBeenCalled();
+  });
+
+  it('uses entity_id in filterQuery when entity store v2 is enabled', () => {
+    mockUseUiSetting.mockReturnValue(true);
+    mockUseEntityStoreEuidApi.mockReturnValue({ euid: {} });
+
+    renderHook(() => useObservedUserDetails({ ...defaultProps, entityId: 'myUserName' }), {
+      wrapper: TestProviders,
+    });
+
+    expect(mockSearch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filterQuery: JSON.stringify({
+          bool: { must: [{ term: { entity_id: 'myUserName' } }, NOT_EVENT_KIND_ASSET_FILTER] },
+        }),
+      })
+    );
+  });
+
+  it('uses user.name in filterQuery when entity store v2 is disabled', () => {
+    mockUseEntityStoreEuidApi.mockReturnValue({ euid: {} });
+
+    renderHook(() => useObservedUserDetails(defaultProps), { wrapper: TestProviders });
+
+    expect(mockSearch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filterQuery: JSON.stringify({
+          bool: { must: [{ term: { 'user.name': 'myUserName' } }, NOT_EVENT_KIND_ASSET_FILTER] },
+        }),
+      })
+    );
+  });
+
   it('skip = true will cancel any running request', () => {
     const props = {
       ...defaultProps,

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/users/containers/users/observed_details/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/users/containers/users/observed_details/index.test.tsx
@@ -93,13 +93,31 @@ describe('useUserDetails', () => {
     expect(mockSearch).not.toHaveBeenCalled();
   });
 
-  it('does not run search when entityId is undefined and entity store v2 is enabled', () => {
+  it('does not run search when both entityId and userName are empty and entity store v2 is enabled', () => {
+    mockUseUiSetting.mockReturnValue(true);
+    mockUseEntityStoreEuidApi.mockReturnValue({ euid: {} });
+
+    renderHook(
+      () => useObservedUserDetails({ ...defaultProps, userName: '', entityId: undefined }),
+      { wrapper: TestProviders }
+    );
+
+    expect(mockSearch).not.toHaveBeenCalled();
+  });
+
+  it('runs search with user.name filter when entity store v2 is enabled and entityId is undefined but userName is provided', () => {
     mockUseUiSetting.mockReturnValue(true);
     mockUseEntityStoreEuidApi.mockReturnValue({ euid: {} });
 
     renderHook(() => useObservedUserDetails(defaultProps), { wrapper: TestProviders });
 
-    expect(mockSearch).not.toHaveBeenCalled();
+    expect(mockSearch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filterQuery: JSON.stringify({
+          bool: { must: [{ term: { 'user.name': 'myUserName' } }, NOT_EVENT_KIND_ASSET_FILTER] },
+        }),
+      })
+    );
   });
 
   it('does not run search when entity store v2 is enabled and entity Id is specified but euidApi.euid is undefined', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/users/containers/users/observed_details/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/users/containers/users/observed_details/index.tsx
@@ -6,6 +6,8 @@
  */
 
 import { useEffect, useMemo } from 'react';
+import { FF_ENABLE_ENTITY_STORE_V2, useEntityStoreEuidApi } from '@kbn/entity-store/public';
+import { isEmpty } from 'lodash';
 import type { inputsModel } from '../../../../../common/store';
 import * as i18n from './translations';
 import type { InspectResponse } from '../../../../../types';
@@ -13,6 +15,7 @@ import { UsersQueries } from '../../../../../../common/search_strategy/security_
 import type { UserItem } from '../../../../../../common/search_strategy/security_solution/users/common';
 import { NOT_EVENT_KIND_ASSET_FILTER } from '../../../../../../common/search_strategy/security_solution/users/common';
 import { useSearchStrategy } from '../../../../../common/containers/use_search_strategy';
+import { useUiSetting } from '../../../../../common/lib/kibana';
 
 export const OBSERVED_USER_QUERY_ID = 'observedUsersDetailsQuery';
 
@@ -28,6 +31,7 @@ export interface UserDetailsArgs {
 interface UseUserDetails {
   endDate: string;
   userName: string;
+  entityId?: string;
   id?: string;
   indexNames: string[];
   skip?: boolean;
@@ -37,11 +41,34 @@ interface UseUserDetails {
 export const useObservedUserDetails = ({
   endDate,
   userName,
+  entityId,
   indexNames,
   id = OBSERVED_USER_QUERY_ID,
   skip = false,
   startDate,
 }: UseUserDetails): [boolean, UserDetailsArgs] => {
+  const entityStoreV2Enabled = useUiSetting<boolean>(FF_ENABLE_ENTITY_STORE_V2, false);
+  const euidApi = useEntityStoreEuidApi();
+
+  const shouldSkip =
+    skip ||
+    (!entityStoreV2Enabled && isEmpty(userName)) ||
+    (entityStoreV2Enabled && (!euidApi?.euid || isEmpty(entityId)));
+
+  const euidFilter = useMemo(() => {
+    if (shouldSkip) {
+      return undefined;
+    }
+
+    if (!entityStoreV2Enabled) {
+      // For legacy entity store, query by user.name
+      return { term: { 'user.name': userName } };
+    } else {
+      // For entity store v2, query by entity_id (runtime field)
+      return { term: { entity_id: entityId } };
+    }
+  }, [entityStoreV2Enabled, shouldSkip, userName, entityId]);
+
   const {
     loading,
     result: response,
@@ -54,7 +81,7 @@ export const useObservedUserDetails = ({
       userDetails: {},
     },
     errorMessage: i18n.FAIL_USER_DETAILS,
-    abort: skip,
+    abort: shouldSkip,
   });
 
   const userDetailsResponse = useMemo(
@@ -69,26 +96,33 @@ export const useObservedUserDetails = ({
     [endDate, id, inspect, refetch, response.userDetails, startDate]
   );
 
-  const userDetailsRequest = useMemo(
-    () => ({
+  const userDetailsRequest = useMemo(() => {
+    if (!euidFilter) {
+      return null;
+    }
+    return {
       defaultIndex: indexNames,
       factoryQueryType: UsersQueries.observedDetails,
       userName,
+      filterQuery: JSON.stringify(
+        euidFilter
+          ? { bool: { must: [euidFilter, NOT_EVENT_KIND_ASSET_FILTER] } }
+          : NOT_EVENT_KIND_ASSET_FILTER
+      ),
+      entityStoreV2: entityStoreV2Enabled || false,
       timerange: {
         interval: '12h',
         from: startDate,
         to: endDate,
       },
-      filterQuery: NOT_EVENT_KIND_ASSET_FILTER,
-    }),
-    [endDate, indexNames, startDate, userName]
-  );
+    };
+  }, [endDate, entityStoreV2Enabled, euidFilter, indexNames, startDate, userName]);
 
   useEffect(() => {
-    if (!skip) {
+    if (!shouldSkip && userDetailsRequest != null) {
       search(userDetailsRequest);
     }
-  }, [userDetailsRequest, search, skip]);
+  }, [userDetailsRequest, search, shouldSkip]);
 
   return [loading, userDetailsResponse];
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/users/containers/users/observed_details/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/users/containers/users/observed_details/index.tsx
@@ -53,7 +53,7 @@ export const useObservedUserDetails = ({
   const shouldSkip =
     skip ||
     (!entityStoreV2Enabled && isEmpty(userName)) ||
-    (entityStoreV2Enabled && (!euidApi?.euid || isEmpty(entityId)));
+    (entityStoreV2Enabled && (!euidApi?.euid || (isEmpty(entityId) && isEmpty(userName))));
 
   const euidFilter = useMemo(() => {
     if (shouldSkip) {
@@ -65,7 +65,12 @@ export const useObservedUserDetails = ({
       return { term: { 'user.name': userName } };
     } else {
       // For entity store v2, query by entity_id (runtime field)
-      return { term: { entity_id: entityId } };
+      if (entityId) {
+        return { term: { entity_id: entityId } };
+      } else if (userName) {
+        // If entityId is not available, fall back to user.name for querying
+        return { term: { 'user.name': userName } };
+      }
     }
   }, [entityStoreV2Enabled, shouldSkip, userName, entityId]);
 

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/users/pages/details/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/users/pages/details/index.tsx
@@ -284,8 +284,9 @@ const UsersDetailsComponent: React.FC<UsersDetailsProps> = ({
     endDate: to,
     startDate: from,
     userName: detailName,
+    entityId: entityStoreV2Enabled ? entityFromStoreResult?.entityRecord?.entity?.id : undefined,
     indexNames: selectedPatterns,
-    skip: selectedPatterns.length === 0 || entityStoreV2Enabled,
+    skip: selectedPatterns.length === 0,
   });
 
   const userDetailsForOverview = entityStoreV2Enabled ? observedUser.details : userOverview;

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/host_entity_overview.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/host_entity_overview.tsx
@@ -169,10 +169,10 @@ export const HostEntityOverview: React.FC<HostEntityOverviewProps> = ({
 
   const [isHostDetailsLoading, { hostDetails }] = useHostDetails({
     hostName,
+    entityId: entityStoreV2Enabled ? storeHostEntityId : undefined,
     indexNames: selectedPatterns,
     startDate: from,
     endDate: to,
-    skip: entityStoreV2Enabled,
   });
 
   const hostRiskData = useMemo(() => {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/user_entity_overview.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/user_entity_overview.tsx
@@ -148,6 +148,7 @@ export const UserEntityOverview: React.FC<UserEntityOverviewProps> = ({
 
   const [isUserDetailsLoading, { userDetails }] = useObservedUserDetails({
     userName,
+    entityId: entityStoreV2Enabled ? entityRecord?.entity?.id : undefined,
     endDate: to,
     indexNames: selectedPatterns,
     startDate: from,

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/hooks/use_observed_host.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/hooks/use_observed_host.ts
@@ -6,6 +6,7 @@
  */
 
 import { useMemo } from 'react';
+import deepmerge from 'deepmerge';
 import { useSelector } from 'react-redux';
 import { useDeepEqualSelector } from '../../../../common/hooks/use_selector';
 import { inputsSelectors, sourcererSelectors } from '../../../../common/store';
@@ -57,7 +58,6 @@ export const useObservedHost = (
     ? experimentalSecurityDefaultIndexPatterns
     : oldSecurityDefaultPatterns;
 
-  // Same as useObservedUser: use entity-store observed fields only when a store record exists.
   const useEntityStoreObservedData = Boolean(
     entityFromStore?.entityRecord ?? entityFromStore?.entity
   );
@@ -67,19 +67,18 @@ export const useObservedHost = (
       endDate: to,
       startDate: from,
       hostName,
+      entityId: useEntityStoreObservedData ? entityFromStore?.entityRecord?.entity?.id : undefined,
       indexNames: securityDefaultPatterns,
       id: HOST_PANEL_RISK_SCORE_QUERY_ID,
-      skip: isInitializing || useEntityStoreObservedData,
+      skip: isInitializing,
     });
 
   useQueryInspector({
     deleteQuery,
-    inspect: useEntityStoreObservedData ? entityFromStore?.inspect : inspectObservedHost,
-    loading: useEntityStoreObservedData ? entityFromStore?.isLoading ?? false : isLoading,
+    inspect: inspectObservedHost,
+    loading: isLoading,
     queryId: HOST_PANEL_OBSERVED_HOST_QUERY_ID,
-    refetch: useEntityStoreObservedData
-      ? entityFromStore?.refetch ?? (() => {})
-      : refetchHostDetails,
+    refetch: refetchHostDetails,
     setQuery,
   });
 
@@ -104,8 +103,9 @@ export const useObservedHost = (
   return useMemo((): ObservedHostResult => {
     if (useEntityStoreObservedData && entityFromStore) {
       return {
-        details: (entityFromStore.entity ?? {}) as HostItem,
-        isLoading: entityFromStore.isLoading,
+        // merge with entity store record
+        details: deepmerge(hostDetails, entityFromStore.entityRecord ?? {}),
+        isLoading: isLoading || entityFromStore.isLoading,
         firstSeen: {
           date: entityFromStore.firstSeen ?? undefined,
           isLoading: entityFromStore.isLoading,
@@ -116,8 +116,8 @@ export const useObservedHost = (
         },
         entityRecord: entityFromStore.entityRecord ?? null,
         refetchEntityStore: entityFromStore.refetch,
-        observedDetailsInspect: undefined,
-        refetchObservedDetails: undefined,
+        observedDetailsInspect: inspectObservedHost,
+        refetchObservedDetails: refetchHostDetails,
       };
     }
     return {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/shared/hooks/use_entity_from_store.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/shared/hooks/use_entity_from_store.ts
@@ -251,7 +251,8 @@ export function useEntityFromStore(
   const entityField = record?.entity;
 
   const firstSeen = entityField?.lifecycle?.first_seen ?? null;
-  const lastSeen = entityField?.lifecycle?.last_activity ?? null;
+  const lastSeen =
+    entityField?.lifecycle?.last_activity ?? entityField?.lifecycle?.last_seen ?? null;
 
   const mappedDetails = useMemo((): HostItem | UserItem | null => {
     if (!record) {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/hooks/use_observed_user.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/hooks/use_observed_user.ts
@@ -7,6 +7,7 @@
 
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
+import deepmerge from 'deepmerge';
 import { useDeepEqualSelector } from '../../../../common/hooks/use_selector';
 import { inputsSelectors, sourcererSelectors, type inputsModel } from '../../../../common/store';
 import { useObservedUserDetails } from '../../../../explore/users/containers/users/observed_details';
@@ -65,19 +66,18 @@ export const useObservedUser = (
       endDate: to,
       startDate: from,
       userName,
+      entityId: useEntityStoreObservedData ? entityFromStore?.entityRecord?.entity?.id : undefined,
       indexNames: securityDefaultPatterns,
       id: USER_PANEL_RISK_SCORE_QUERY_ID,
-      skip: isInitializing || useEntityStoreObservedData,
+      skip: isInitializing,
     });
 
   useQueryInspector({
     deleteQuery,
-    inspect: useEntityStoreObservedData ? entityFromStore?.inspect : inspectObservedUser,
-    loading: useEntityStoreObservedData ? entityFromStore?.isLoading ?? false : isLoading,
+    inspect: inspectObservedUser,
+    loading: isLoading,
     queryId: USER_PANEL_OBSERVED_USER_QUERY_ID,
-    refetch: useEntityStoreObservedData
-      ? entityFromStore?.refetch ?? (() => {})
-      : refetchUserDetails,
+    refetch: refetchUserDetails,
     setQuery,
   });
 
@@ -102,8 +102,9 @@ export const useObservedUser = (
   return useMemo((): ObservedUserResult => {
     if (useEntityStoreObservedData && entityFromStore) {
       return {
-        details: (entityFromStore.entity ?? {}) as UserItem,
-        isLoading: entityFromStore.isLoading,
+        // merge with entity store record
+        details: deepmerge(userDetails, entityFromStore.entityRecord ?? {}),
+        isLoading: isLoading || entityFromStore.isLoading,
         firstSeen: {
           date: entityFromStore.firstSeen ?? undefined,
           isLoading: entityFromStore.isLoading,
@@ -114,8 +115,8 @@ export const useObservedUser = (
         },
         entityRecord: entityFromStore.entityRecord ?? null,
         refetchEntityStore: entityFromStore.refetch,
-        observedDetailsInspect: undefined,
-        refetchObservedDetails: undefined,
+        observedDetailsInspect: inspectObservedUser,
+        refetchObservedDetails: refetchUserDetails,
       };
     }
     return {

--- a/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/details/__mocks__/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/details/__mocks__/index.ts
@@ -511,7 +511,23 @@ export const formattedSearchStrategyResponse = {
           query: {
             bool: {
               filter: [
-                { term: { 'host.name': 'bastion00.siem.estc.dev' } },
+                {
+                  bool: {
+                    must: [],
+                    filter: [
+                      { match_all: {} },
+                      {
+                        match_phrase: {
+                          'host.name': {
+                            query: 'bastion00.siem.estc.dev',
+                          },
+                        },
+                      },
+                    ],
+                    should: [],
+                    must_not: [],
+                  },
+                },
                 {
                   range: {
                     '@timestamp': {
@@ -799,8 +815,22 @@ export const expectedDsl = {
     bool: {
       filter: [
         {
-          term: {
-            'host.name': 'bastion00.siem.estc.dev',
+          bool: {
+            filter: [
+              {
+                match_all: {},
+              },
+              {
+                match_phrase: {
+                  'host.name': {
+                    query: 'bastion00.siem.estc.dev',
+                  },
+                },
+              },
+            ],
+            must: [],
+            must_not: [],
+            should: [],
           },
         },
         {

--- a/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/details/__snapshots__/query.host_details.dsl.test.ts.snap
+++ b/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/details/__snapshots__/query.host_details.dsl.test.ts.snap
@@ -1,0 +1,24 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`buildHostDetailsQuery includes host.name filter when filterQuery is undefined 1`] = `
+Object {
+  "bool": Object {
+    "filter": Array [
+      Object {
+        "term": Object {
+          "host.name": "bastion00.siem.estc.dev",
+        },
+      },
+      Object {
+        "range": Object {
+          "@timestamp": Object {
+            "format": "strict_date_optional_time",
+            "gte": "2020-09-02T15:17:13.678Z",
+            "lte": "2020-09-03T15:17:13.678Z",
+          },
+        },
+      },
+    ],
+  },
+}
+`;

--- a/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/details/query.host_details.dsl.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/details/query.host_details.dsl.test.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { euid } from '@kbn/entity-store/common/euid_helpers';
 import { buildHostDetailsQuery } from './query.host_details.dsl';
 import { mockOptions, expectedDsl } from './__mocks__';
 
@@ -12,5 +13,31 @@ import { mockOptions, expectedDsl } from './__mocks__';
 describe('buildHostDetailsQuery', () => {
   test('build query from options correctly', () => {
     expect(buildHostDetailsQuery(mockOptions)).toEqual(expectedDsl);
+  });
+
+  test('includes host.name filter when filterQuery is undefined', () => {
+    const result = buildHostDetailsQuery({ ...mockOptions, filterQuery: undefined });
+
+    expect(result.query).toMatchSnapshot();
+  });
+
+  test('uses filterQuery when defined', () => {
+    const filterQuery = JSON.stringify({ term: { entity_id: 'some-entity-id' } });
+    const result = buildHostDetailsQuery({ ...mockOptions, filterQuery });
+
+    const filters = (result.query as { bool: { filter: unknown[] } }).bool.filter;
+    expect(filters).toContainEqual({ term: { entity_id: 'some-entity-id' } });
+    expect(filters).not.toContainEqual({ term: { 'host.name': mockOptions.hostName } });
+  });
+
+  test('includes EUID runtime mapping and documents filter when entityStoreV2 is enabled', () => {
+    const result = buildHostDetailsQuery({ ...mockOptions, entityStoreV2: true });
+
+    expect(result.runtime_mappings).toEqual({
+      entity_id: euid.painless.getEuidRuntimeMapping('host'),
+    });
+
+    const filters = (result.query as { bool: { filter: unknown[] } }).bool.filter;
+    expect(filters[0]).toEqual(euid.dsl.getEuidDocumentsContainsIdFilter('host'));
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/details/query.host_details.dsl.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/details/query.host_details.dsl.test.ts
@@ -21,6 +21,13 @@ describe('buildHostDetailsQuery', () => {
     expect(result.query).toMatchSnapshot();
   });
 
+  test('includes host.name filter when filterQuery is an empty object', () => {
+    const result = buildHostDetailsQuery({ ...mockOptions, filterQuery: {} });
+
+    const filters = (result.query as { bool: { filter: unknown[] } }).bool.filter;
+    expect(filters).toContainEqual({ term: { 'host.name': mockOptions.hostName } });
+  });
+
   test('uses filterQuery when defined', () => {
     const filterQuery = JSON.stringify({ term: { entity_id: 'some-entity-id' } });
     const result = buildHostDetailsQuery({ ...mockOptions, filterQuery });

--- a/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/details/query.host_details.dsl.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/details/query.host_details.dsl.ts
@@ -8,6 +8,7 @@
 import type { ISearchRequestParams } from '@kbn/search-types';
 import { cloudFieldsMap, hostFieldsMap } from '@kbn/securitysolution-ecs';
 import { euid } from '@kbn/entity-store/common/euid_helpers';
+import { isEmpty } from 'lodash';
 import type { HostDetailsRequestOptions } from '../../../../../../common/search_strategy/security_solution';
 import { createQueryFilterClauses, reduceFields } from '../../../../../utils/build_query';
 import { HOST_DETAILS_FIELDS, buildFieldsTermAggregation } from './helpers';
@@ -27,7 +28,7 @@ export const buildHostDetailsQuery = ({
   });
 
   // When no filter query is defined, we default to using the host name
-  const hostNameFilter = !filterQuery ? { term: { 'host.name': hostName } } : undefined;
+  const hostNameFilter = isEmpty(filterQuery) ? { term: { 'host.name': hostName } } : undefined;
 
   const filter = [
     ...(entityStoreV2 ? [euid.dsl.getEuidDocumentsContainsIdFilter('host')] : []),

--- a/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/details/query.host_details.dsl.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/details/query.host_details.dsl.ts
@@ -7,22 +7,32 @@
 
 import type { ISearchRequestParams } from '@kbn/search-types';
 import { cloudFieldsMap, hostFieldsMap } from '@kbn/securitysolution-ecs';
+import { euid } from '@kbn/entity-store/common/euid_helpers';
 import type { HostDetailsRequestOptions } from '../../../../../../common/search_strategy/security_solution';
-import { reduceFields } from '../../../../../utils/build_query/reduce_fields';
+import { createQueryFilterClauses, reduceFields } from '../../../../../utils/build_query';
 import { HOST_DETAILS_FIELDS, buildFieldsTermAggregation } from './helpers';
 
+const EUID_RUNTIME_FIELD = 'entity_id';
+
 export const buildHostDetailsQuery = ({
-  hostName,
   defaultIndex,
+  hostName,
   timerange: { from, to },
+  filterQuery,
+  entityStoreV2,
 }: HostDetailsRequestOptions): ISearchRequestParams => {
   const esFields = reduceFields(HOST_DETAILS_FIELDS, {
     ...hostFieldsMap,
     ...cloudFieldsMap,
   });
 
+  // When no filter query is defined, we default to using the host name
+  const hostNameFilter = !filterQuery ? { term: { 'host.name': hostName } } : undefined;
+
   const filter = [
-    { term: { 'host.name': hostName } },
+    ...(entityStoreV2 ? [euid.dsl.getEuidDocumentsContainsIdFilter('host')] : []),
+    ...(hostNameFilter ? [hostNameFilter] : []),
+    ...createQueryFilterClauses(filterQuery),
     {
       range: {
         '@timestamp': {
@@ -39,6 +49,9 @@ export const buildHostDetailsQuery = ({
     index: defaultIndex,
     ignore_unavailable: true,
     track_total_hits: false,
+    ...(entityStoreV2
+      ? { runtime_mappings: { [EUID_RUNTIME_FIELD]: euid.painless.getEuidRuntimeMapping('host') } }
+      : {}),
     aggregations: {
       ...buildFieldsTermAggregation(esFields.filter((field) => !['@timestamp'].includes(field))),
       endpoint_id: {

--- a/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/users/observed_details/__snapshots__/index.test.ts.snap
+++ b/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/users/observed_details/__snapshots__/index.test.ts.snap
@@ -133,11 +133,6 @@ Object {
           }
         },
         {
-          \\"term\\": {
-            \\"user.name\\": \\"bastion00.siem.estc.dev\\"
-          }
-        },
-        {
           \\"range\\": {
             \\"@timestamp\\": {
               \\"format\\": \\"strict_date_optional_time\\",

--- a/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/users/observed_details/__snapshots__/query.observed_user_details.dsl.test.ts.snap
+++ b/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/users/observed_details/__snapshots__/query.observed_user_details.dsl.test.ts.snap
@@ -129,11 +129,6 @@ Object {
           },
         },
         Object {
-          "term": Object {
-            "user.name": "bastion00.siem.estc.dev",
-          },
-        },
-        Object {
           "range": Object {
             "@timestamp": Object {
               "format": "strict_date_optional_time",
@@ -147,5 +142,28 @@ Object {
   },
   "size": 0,
   "track_total_hits": false,
+}
+`;
+
+exports[`buildUserDetailsQuery includes user.name filter when filterQuery is undefined 1`] = `
+Object {
+  "bool": Object {
+    "filter": Array [
+      Object {
+        "term": Object {
+          "user.name": "bastion00.siem.estc.dev",
+        },
+      },
+      Object {
+        "range": Object {
+          "@timestamp": Object {
+            "format": "strict_date_optional_time",
+            "gte": "2020-09-02T15:17:13.678Z",
+            "lte": "2020-09-03T15:17:13.678Z",
+          },
+        },
+      },
+    ],
+  },
 }
 `;

--- a/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/users/observed_details/query.observed_user_details.dsl.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/users/observed_details/query.observed_user_details.dsl.test.ts
@@ -20,6 +20,13 @@ describe('buildUserDetailsQuery', () => {
     expect(result.query).toMatchSnapshot();
   });
 
+  test('includes user.name filter when filterQuery is an empty object', () => {
+    const result = buildObservedUserDetailsQuery({ ...mockOptions, filterQuery: {} });
+
+    const filters = (result.query as { bool: { filter: unknown[] } }).bool.filter;
+    expect(filters).toContainEqual({ term: { 'user.name': mockOptions.userName } });
+  });
+
   test('uses filterQuery when defined', () => {
     const filterQuery = JSON.stringify({ term: { entity_id: 'some-entity-id' } });
     const result = buildObservedUserDetailsQuery({ ...mockOptions, filterQuery });

--- a/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/users/observed_details/query.observed_user_details.dsl.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/users/observed_details/query.observed_user_details.dsl.test.ts
@@ -5,11 +5,38 @@
  * 2.0.
  */
 
+import { euid } from '@kbn/entity-store/common/euid_helpers';
 import { buildObservedUserDetailsQuery } from './query.observed_user_details.dsl';
 import { mockOptions } from './__mocks__';
 
 describe('buildUserDetailsQuery', () => {
   test('build query from options correctly', () => {
     expect(buildObservedUserDetailsQuery(mockOptions)).toMatchSnapshot();
+  });
+
+  test('includes user.name filter when filterQuery is undefined', () => {
+    const result = buildObservedUserDetailsQuery({ ...mockOptions, filterQuery: undefined });
+
+    expect(result.query).toMatchSnapshot();
+  });
+
+  test('uses filterQuery when defined', () => {
+    const filterQuery = JSON.stringify({ term: { entity_id: 'some-entity-id' } });
+    const result = buildObservedUserDetailsQuery({ ...mockOptions, filterQuery });
+
+    const filters = (result.query as { bool: { filter: unknown[] } }).bool.filter;
+    expect(filters).toContainEqual({ term: { entity_id: 'some-entity-id' } });
+    expect(filters).not.toContainEqual({ term: { 'user.name': mockOptions.userName } });
+  });
+
+  test('includes EUID runtime mapping and documents filter when entityStoreV2 is enabled', () => {
+    const result = buildObservedUserDetailsQuery({ ...mockOptions, entityStoreV2: true });
+
+    expect(result.runtime_mappings).toEqual({
+      entity_id: euid.painless.getEuidRuntimeMapping('user'),
+    });
+
+    const filters = (result.query as { bool: { filter: unknown[] } }).bool.filter;
+    expect(filters[0]).toEqual(euid.dsl.getEuidDocumentsContainsIdFilter('user'));
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/users/observed_details/query.observed_user_details.dsl.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/users/observed_details/query.observed_user_details.dsl.ts
@@ -7,20 +7,28 @@
 
 import type { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
 import type { ISearchRequestParams } from '@kbn/search-types';
+import { euid } from '@kbn/entity-store/common/euid_helpers';
 import type { ObservedUserDetailsRequestOptions } from '../../../../../../common/api/search_strategy';
 import { createQueryFilterClauses } from '../../../../../utils/build_query';
 import { buildFieldsTermAggregation } from '../../hosts/details/helpers';
 import { USER_FIELDS } from './helpers';
 
+const EUID_RUNTIME_FIELD = 'entity_id';
+
 export const buildObservedUserDetailsQuery = ({
-  userName,
   defaultIndex,
+  userName,
   timerange: { from, to },
   filterQuery,
+  entityStoreV2,
 }: ObservedUserDetailsRequestOptions): ISearchRequestParams => {
+  // When no filter query is defined, we default to using the user name
+  const userNameFilter = !filterQuery ? { term: { 'user.name': userName } } : undefined;
+
   const filter: QueryDslQueryContainer[] = [
+    ...(entityStoreV2 ? [euid.dsl.getEuidDocumentsContainsIdFilter('user')] : []),
+    ...(userNameFilter ? [userNameFilter] : []),
     ...createQueryFilterClauses(filterQuery),
-    { term: { 'user.name': userName } },
     {
       range: {
         '@timestamp': {
@@ -37,6 +45,9 @@ export const buildObservedUserDetailsQuery = ({
     index: defaultIndex,
     ignore_unavailable: true,
     track_total_hits: false,
+    ...(entityStoreV2
+      ? { runtime_mappings: { [EUID_RUNTIME_FIELD]: euid.painless.getEuidRuntimeMapping('user') } }
+      : {}),
     aggregations: {
       ...buildFieldsTermAggregation(USER_FIELDS),
     },

--- a/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/users/observed_details/query.observed_user_details.dsl.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/users/observed_details/query.observed_user_details.dsl.ts
@@ -8,6 +8,7 @@
 import type { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
 import type { ISearchRequestParams } from '@kbn/search-types';
 import { euid } from '@kbn/entity-store/common/euid_helpers';
+import { isEmpty } from 'lodash';
 import type { ObservedUserDetailsRequestOptions } from '../../../../../../common/api/search_strategy';
 import { createQueryFilterClauses } from '../../../../../utils/build_query';
 import { buildFieldsTermAggregation } from '../../hosts/details/helpers';
@@ -23,7 +24,7 @@ export const buildObservedUserDetailsQuery = ({
   entityStoreV2,
 }: ObservedUserDetailsRequestOptions): ISearchRequestParams => {
   // When no filter query is defined, we default to using the user name
-  const userNameFilter = !filterQuery ? { term: { 'user.name': userName } } : undefined;
+  const userNameFilter = isEmpty(filterQuery) ? { term: { 'user.name': userName } } : undefined;
 
   const filter: QueryDslQueryContainer[] = [
     ...(entityStoreV2 ? [euid.dsl.getEuidDocumentsContainsIdFilter('user')] : []),


### PR DESCRIPTION
## Summary

We were skipping the observed details query for users and hosts when we have an entity record from the entity store, but those queries aggregate for additional information that may not be stored in the entity store. This PR unskips those queries and updates the query to query by entity.id using a runtime field when the entity store V2 is enabled.

This PR also addresses an issue on the Explore page which was using the old version of the entity store V2 index 

## To Verify (main bug)

1. Start ES and Kibana with all the V2 entity store feature flags
2. Add data using `yarn start org-data --integrations cloud_asset,system,azure`. Pick a medium sized org, default productivity suite, no detection rules
3. Navigate to the entity analytics homepage and wait a little bit. You should see entities show up after a short wait.
4. Open a host entity that has a `cloud_asset_inventory.asset_inventory` data source. You should see cloud fields populated on the host flyout under the observed section
5. Add some more organization data using `yarn start org-data`
6. Find a user entity that includes host information (easiest way is to perform this query in DevTools)

```
GET .entities.v2.latest.security_default-00001/_search
{
    "query": {
        "bool": {
            "filter": [
              {
                "match_phrase": {
                  "entity.EngineMetadata.Type": "user"
                }
              },
              {
                "exists": {
                  "field": "host"
                }
              }
            ]
        }
    }
}
```

7. Open that user entity flyout. You should see host fields populated under the observed section.


Host flyout before:
<img width="1138" height="1033" alt="Screenshot 2026-04-21 at 11 23 12 AM" src="https://github.com/user-attachments/assets/b68324c7-80bc-41a0-96fc-d0bd436f9e61" />

Host flyout after:
<img width="1145" height="1055" alt="Screenshot 2026-04-21 at 11 16 05 AM" src="https://github.com/user-attachments/assets/0716f614-bcd5-4164-bfd6-b5d31be5cefa" />

User flyout before:
<img width="1139" height="1046" alt="Screenshot 2026-04-21 at 11 22 52 AM" src="https://github.com/user-attachments/assets/19389dbf-bfcd-4d67-a621-a5e7c4d60c80" />

User flyout after:

<img width="1146" height="1044" alt="Screenshot 2026-04-21 at 11 14 19 AM" src="https://github.com/user-attachments/assets/4667e9cf-82b4-4e4e-b198-a7247e6ecd3e" />

## To Verify (side bug)

1. Navigate to the user and host explore pages and verify the top left visualization loads correctly with no errors.
Explore page before:
<img width="628" height="560" alt="Screenshot 2026-04-21 at 11 46 51 AM" src="https://github.com/user-attachments/assets/d45836fd-93d2-457c-9872-2bf3344c5ff2" />

Explore page after:
<img width="832" height="527" alt="Screenshot 2026-04-21 at 11 45 05 AM" src="https://github.com/user-attachments/assets/94aa9120-19ed-4bce-8e58-b9943ea7fa56" />


<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->