### PR TITLE
[TEST] Use PR published `@elastic/charts` package.

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "@aws-sdk/client-bedrock-runtime": "3.994.0",
     "@aws-sdk/client-kendra": "3.994.0",
     "@aws-sdk/credential-provider-node": "3.972.10",
+    "@elastic/charts": "https://ech-e2e-ci--pr-2824-xumftqsp.web.app/packages/elastic-charts-v71.5.0-pr-2824.tgz",
     "@elastic/elasticsearch/@elastic/transport": "9.3.5",
     "@storybook/react-docgen-typescript-plugin": "1.0.6--canary.9.cd77847.0",
     "@types/react": "18.2.79",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2281,10 +2281,9 @@
   dependencies:
     object-hash "^1.3.0"
 
-"@elastic/charts@71.5.0":
+"@elastic/charts@71.5.0", "@elastic/charts@https://ech-e2e-ci--pr-2824-xumftqsp.web.app/packages/elastic-charts-v71.5.0-pr-2824.tgz":
   version "71.5.0"
-  resolved "https://registry.yarnpkg.com/@elastic/charts/-/charts-71.5.0.tgz#b1e195f42f4c0611cda8bd26a57a23a516ef667b"
-  integrity sha512-0T6BVc8Rklldf3GJSpkMFX411dL48nxZ0E6KhwAdDf7E4vLFm4z672Azjkq60LzTBxE7BfHDhoamiPnNxXJEQg==
+  resolved "https://ech-e2e-ci--pr-2824-xumftqsp.web.app/packages/elastic-charts-v71.5.0-pr-2824.tgz#3f1c070f9eb795e7ab3e20aa4fd95a903301bc6d"
   dependencies:
     "@popperjs/core" "^2.11.8"
     "@reduxjs/toolkit" "1.9.7"


### PR DESCRIPTION
The PR demonstrate the use of an elastic-charts repo PR published `@elastic/charts` package from https://github.com/elastic/elastic-charts/pull/2824 to demonstrate the process that how to test an upstream elastic-charts repo change before PR merge or a release.

For testing the test elastic-charts PR [adds](https://github.com/elastic/elastic-charts/pull/2824/changes/e10534dcd2a1074329f5ad1c1f472ae3c5da759a) a border to Metric chart title


<img width="462" height="272" alt="image" src="https://github.com/user-attachments/assets/8659437d-cd96-44d1-85fa-cfcae00d0c08" />


Which Lens correctly showed
<img width="367" height="349" alt="image" src="https://github.com/user-attachments/assets/b049dbbe-7938-4b65-8fe8-4d35cbb8bda4" />


https://github.com/user-attachments/assets/a3e7d869-b923-4ad4-a63a-6b08bb2dc93f


