### PR TITLE
[DOCS] Adds 216376 to the 8.19 Kibana release notes

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -766,6 +766,7 @@ Alerting::
 * Allows users to delete a snooze schedule from a rule using schedule ID ({kibana-pull}213247[#213247]).
 * Allows users to create a snooze schedule for rules using the schedule API ({kibana-pull}210584[#210584]).
 * Implements functionality to add observables, procedures, and custom fields to alerts for {hive} ({kibana-pull}207255[#207255]).
+* Updates the `context.link` variable to use the new Discover URL formatting in all {es} query rule types ({kibana-pull}216376[#216376]).
 Dashboards and Visualizations::
 * Updates time-based charts to use the multi-layer time axis by default, providing a better time window context and improved label positioning. ({kibana-pull}210579[#210579]).
 * Adds a **Point visibility** option to Area and Line charts in **Lens** ({kibana-pull}222187[#222187]).

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -779,6 +779,7 @@ Data ingestion and Fleet::
 * Reuses shared integration policies when duplicating agent policies ({kibana-pull}217872[#217872]).
 * Adds support for collapsible sections in integration overview pages ({kibana-pull}223916[#223916]).
 * Updates the `context.link` variable to use the new Discover URL formatting in all {es} query rule types ({kibana-pull}216376[#216376]).
+Discover::
 * Expands the {esql} editor to fit the query size automatically when loading **Discover** ({kibana-pull}225509[#225509]).
 * Hides the "Selected only" toggle in **Discover**'s pages that don't support filtering by value ({kibana-pull}220624[#220624]).
 * Adds a **Copy value** button to field value cells in the Document viewer ({kibana-pull}218817[#218817]).

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -779,7 +779,6 @@ Dashboards and Visualizations::
 Data ingestion and Fleet::
 * Reuses shared integration policies when duplicating agent policies ({kibana-pull}217872[#217872]).
 * Adds support for collapsible sections in integration overview pages ({kibana-pull}223916[#223916]).
-* Updates the `context.link` variable to use the new Discover URL formatting in all {es} query rule types ({kibana-pull}216376[#216376]).
 Discover::
 * Expands the {esql} editor to fit the query size automatically when loading **Discover** ({kibana-pull}225509[#225509]).
 * Hides the "Selected only" toggle in **Discover**'s pages that don't support filtering by value ({kibana-pull}220624[#220624]).

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -778,7 +778,7 @@ Dashboards and Visualizations::
 Data ingestion and Fleet::
 * Reuses shared integration policies when duplicating agent policies ({kibana-pull}217872[#217872]).
 * Adds support for collapsible sections in integration overview pages ({kibana-pull}223916[#223916]).
-Discover::
+* Updates the `context.link` variable to use the new Discover URL formatting in all {es} query rule types ({kibana-pull}216376[#216376]).
 * Expands the {esql} editor to fit the query size automatically when loading **Discover** ({kibana-pull}225509[#225509]).
 * Hides the "Selected only" toggle in **Discover**'s pages that don't support filtering by value ({kibana-pull}220624[#220624]).
 * Adds a **Copy value** button to field value cells in the Document viewer ({kibana-pull}218817[#218817]).


### PR DESCRIPTION
## Summary

Contributes to https://github.com/elastic/docs-content-internal/issues/1101 by adding https://github.com/elastic/kibana/pull/216376 to the 8.19 Kibana release notes. 