### PR TITLE
Add leading slash to the Kibana management directories in the Streams plugin

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1734,14 +1734,14 @@ x-pack/solutions/observability/plugins/observability/server/lib/esql_extensions 
 /x-pack/platform/plugins/shared/streams/test/scout/api/tests/streams @elastic/obs-onboarding-team
 
 # Streams - Data retention overrides (owned by Kibana Management)
-x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle @elastic/kibana-management
-x-pack/platform/plugins/shared/streams/server/lib/streams/failure_store @elastic/kibana-management
-x-pack/platform/plugins/shared/streams/server/routes/internal/streams/failure_store @elastic/kibana-management
-x-pack/platform/plugins/shared/streams/server/routes/internal/streams/lifecycle @elastic/kibana-management
-x-pack/platform/plugins/shared/streams/server/lib/streams/lifecycle/ilm_policies.ts @elastic/kibana-management
-x-pack/platform/plugins/shared/streams/server/lib/streams/lifecycle/ilm_policies.test.ts @elastic/kibana-management
-x-pack/platform/plugins/shared/streams/server/lib/streams/lifecycle/ilm_phases.ts @elastic/kibana-management
-x-pack/platform/plugins/shared/streams/server/lib/streams/lifecycle/ilm_phases.test.ts @elastic/kibana-management
+/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_lifecycle @elastic/kibana-management
+/x-pack/platform/plugins/shared/streams/server/lib/streams/failure_store @elastic/kibana-management
+/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/failure_store @elastic/kibana-management
+/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/lifecycle @elastic/kibana-management
+/x-pack/platform/plugins/shared/streams/server/lib/streams/lifecycle/ilm_policies.ts @elastic/kibana-management
+/x-pack/platform/plugins/shared/streams/server/lib/streams/lifecycle/ilm_policies.test.ts @elastic/kibana-management
+/x-pack/platform/plugins/shared/streams/server/lib/streams/lifecycle/ilm_phases.ts @elastic/kibana-management
+/x-pack/platform/plugins/shared/streams/server/lib/streams/lifecycle/ilm_phases.test.ts @elastic/kibana-management
 
 # Streams — sig events overrides (obs-sig-events-team owns these subtrees)
 x-pack/platform/plugins/shared/streams_app/public/components/sig_events @elastic/obs-sig-events-team


### PR DESCRIPTION
## Summary

In https://github.com/elastic/kibana/pull/263100/ we change the ownership of this files but we are not being properly assigned as a owners by Github in recent PRs. Adding leading slash just in case that's the cause.