### PR TITLE
[Obs AI] add evaluations for adHigh-cpu scenario

### DIFF
--- a/x-pack/solutions/observability/packages/kbn-evals-suite-observability-ai/README.md
+++ b/x-pack/solutions/observability/packages/kbn-evals-suite-observability-ai/README.md
@@ -9,10 +9,10 @@ This package is separate from [`@kbn/evals-suite-obs-ai-assistant`](../kbn-evals
 
 ## Evaluations
 
-| Directory | Client | Description |
-|---|---|---|
-| `evals/ai_insights/` | `AiInsightClient` | Correctness of LLM-generated insight summaries for alerts and APM errors |
-| `evals/observability_agent/` | `AgentBuilderClient` | Observability Agent chat behavior |
+| Directory                    | Client               | Description                                                              |
+| ---------------------------- | -------------------- | ------------------------------------------------------------------------ |
+| `evals/ai_insights/`         | `AiInsightClient`    | Correctness of LLM-generated insight summaries for alerts and APM errors |
+| `evals/observability_agent/` | `AgentBuilderClient` | Observability Agent chat behavior                                        |
 
 ## Prerequisites
 
@@ -22,6 +22,7 @@ AI Insights evaluations replay observability data from GCS snapshot repositories
 
 - `obs-ai-datasets/otel-demo/payment-service-failures` — payment service invalid token errors
 - `obs-ai-datasets/otel-demo/payment-unreachable` — payment service unreachable from checkout (via the `paymentUnreachable` feature flag in the OTel demo)
+- `obs-ai-datasets/otel-demo/ad-high-cpu` — high CPU in the ad service (OpenTelemetry Demo `adHighCpu` feature flag)
 
 Set `GCS_CREDENTIALS` before starting Scout. This must contain the full JSON service account credential string (not a file path):
 
@@ -154,21 +155,21 @@ node scripts/evals stop --service edot
 
 ### CLI Options
 
-| Flag | Description |
-|---|---|
-| `--suite` | Suite ID (`observability-ai`) |
-| `--judge` | Connector ID for the LLM judge (required) |
-| `--project` | Connector/model project to evaluate against |
-| `--repetitions` | Number of times to repeat each example |
+| Flag             | Description                                                                            |
+| ---------------- | -------------------------------------------------------------------------------------- |
+| `--suite`        | Suite ID (`observability-ai`)                                                          |
+| `--judge`        | Connector ID for the LLM judge (required)                                              |
+| `--project`      | Connector/model project to evaluate against                                            |
+| `--repetitions`  | Number of times to repeat each example                                                 |
 | `--trace-es-url` | Elasticsearch cluster for trace storage (e.g., `https://user:pass@trace-cluster:9200`) |
-| `--dry-run` | Preview without executing |
+| `--dry-run`      | Preview without executing                                                              |
 
 ## Collected Metrics
 
-| Metric | Description |
-|---|---|
+| Metric                       | Description                                                             |
+| ---------------------------- | ----------------------------------------------------------------------- |
 | **Quantitative Correctness** | Factuality, Relevance, and Sequence Accuracy scores from LLM-as-a-judge |
-| **Input Tokens** | Number of input tokens consumed per evaluation (trace-based) |
-| **Output Tokens** | Number of output tokens generated per evaluation (trace-based) |
-| **Cached Tokens** | Number of cached tokens used per evaluation (trace-based) |
-| **Latency** | Duration of the `ChatComplete` span (trace-based) |
+| **Input Tokens**             | Number of input tokens consumed per evaluation (trace-based)            |
+| **Output Tokens**            | Number of output tokens generated per evaluation (trace-based)          |
+| **Cached Tokens**            | Number of cached tokens used per evaluation (trace-based)               |
+| **Latency**                  | Duration of the `ChatComplete` span (trace-based)                       |

--- a/x-pack/solutions/observability/packages/kbn-evals-suite-observability-ai/evals/agent/ad_high_cpu.spec.ts
+++ b/x-pack/solutions/observability/packages/kbn-evals-suite-observability-ai/evals/agent/ad_high_cpu.spec.ts
@@ -62,30 +62,18 @@ evaluate.describe(
               },
               output: {
                 criteria: [
-                  // Root cause identification
                   'Identifies the `ad` service as the primary source of latency, supported by evidence (e.g., elevated CPU usage, slow spans, or runtime metrics), rather than attributing the issue to unrelated services',
-                  // Causal reasoning
                   'Explains the causal chain from user symptom (slow product pages) → ad-related requests → degradation in the `ad` service (e.g., CPU-bound processing)',
-                  // Signal usage
                   'Uses concrete observability signals (e.g., service metrics, trace latency, runtime/host CPU) to support conclusions, not speculation alone',
-                  // Correct problem framing
                   'Frames the issue as compute/resource saturation within the `ad` service, not as a downstream outage, network issue, or error-driven failure',
-                  // Symptom vs root cause distinction
                   'Correctly treats increased latency in upstream services (e.g., frontend, recommendation) as symptoms of the `ad` service slowdown when supported by traces or topology',
-                  // Isolation of outlier
-                  'Demonstrates that other services are relatively healthy or not the primary bottleneck when compared to the `ad` service',
-                  // Avoids incorrect attribution
                   'Does not attribute the issue to unrelated domains (e.g., checkout, payment, cart) without supporting evidence',
-                  // Actionable next steps
-                  'Suggests relevant follow-ups for CPU-bound services (e.g., scaling, profiling, checking feature flags or load patterns, reviewing resource limits), not only generic advice',
                 ],
                 expectedTools: [
                   'observability.get_services',
-                  'observability.get_service_topology',
-                  'observability.get_trace_metrics',
-                  'observability.get_runtime_metrics',
-                  'observability.get_hosts',
                   'observability.get_traces',
+                  'observability.get_runtime_metrics',
+                  'observability.get_service_topology',
                 ],
               },
               metadata: {

--- a/x-pack/solutions/observability/packages/kbn-evals-suite-observability-ai/evals/agent/ad_high_cpu.spec.ts
+++ b/x-pack/solutions/observability/packages/kbn-evals-suite-observability-ai/evals/agent/ad_high_cpu.spec.ts
@@ -42,11 +42,12 @@ evaluate.describe(
         dataset: {
           name: 'ad-high-cpu investigation',
           description:
-            'Evaluates whether the agent correctly investigates storefront slowness driven by high CPU load in the OpenTelemetry Demo ad service (adHighCpu feature flag)',
+            'Evaluates whether the agent correctly investigates shop slowness driven by high CPU load in the OpenTelemetry Demo ad service when the `adHighCpu` feature flag is enabled (CPU burn runs at the start of each GetAds request)',
           examples: [
             {
               input: {
-                question: 'The shop is slow when people look at ads and suggested items. Why?',
+                question:
+                  'Product pages are intermittently slow when loading ads and recommendations. There are no obvious errors reported. Investigate and determine what is causing the latency.',
                 attachments: [
                   {
                     type: 'screen_context',
@@ -61,13 +62,30 @@ evaluate.describe(
               },
               output: {
                 criteria: [
-                  'Identifies the ad service (or Java ad workload) as the primary source of the slowdown, high CPU load, CPU-intensive behavior, or resource contention in that service, rather than blaming unrelated services without evidence',
+                  // Root cause identification
+                  'Identifies the `ad` service as the primary source of latency, supported by evidence (e.g., elevated CPU usage, slow spans, or runtime metrics), rather than attributing the issue to unrelated services',
+                  // Causal reasoning
+                  'Explains the causal chain from user symptom (slow product pages) → ad-related requests → degradation in the `ad` service (e.g., CPU-bound processing)',
+                  // Signal usage
+                  'Uses concrete observability signals (e.g., service metrics, trace latency, runtime/host CPU) to support conclusions, not speculation alone',
+                  // Correct problem framing
+                  'Frames the issue as compute/resource saturation within the `ad` service, not as a downstream outage, network issue, or error-driven failure',
+                  // Symptom vs root cause distinction
+                  'Correctly treats increased latency in upstream services (e.g., frontend, recommendation) as symptoms of the `ad` service slowdown when supported by traces or topology',
+                  // Isolation of outlier
+                  'Demonstrates that other services are relatively healthy or not the primary bottleneck when compared to the `ad` service',
+                  // Avoids incorrect attribution
+                  'Does not attribute the issue to unrelated domains (e.g., checkout, payment, cart) without supporting evidence',
+                  // Actionable next steps
+                  'Suggests relevant follow-ups for CPU-bound services (e.g., scaling, profiling, checking feature flags or load patterns, reviewing resource limits), not only generic advice',
                 ],
                 expectedTools: [
                   'observability.get_services',
+                  'observability.get_service_topology',
                   'observability.get_trace_metrics',
                   'observability.get_runtime_metrics',
                   'observability.get_hosts',
+                  'observability.get_traces',
                 ],
               },
               metadata: {

--- a/x-pack/solutions/observability/packages/kbn-evals-suite-observability-ai/evals/agent/ad_high_cpu.spec.ts
+++ b/x-pack/solutions/observability/packages/kbn-evals-suite-observability-ai/evals/agent/ad_high_cpu.spec.ts
@@ -63,9 +63,9 @@ evaluate.describe(
               output: {
                 criteria: [
                   'Identifies the `ad` service as the primary source of latency, supported by evidence (e.g., elevated CPU usage, slow spans, or runtime metrics), rather than attributing the issue to unrelated services',
-                  'Explains the causal chain from user symptom (slow product pages) → ad-related requests → degradation in the `ad` service (e.g., CPU-bound processing)',
+                  'Explains the causal chain from user symptom (slow product pages)',
                   'Uses concrete observability signals (e.g., service metrics, trace latency, runtime/host CPU) to support conclusions, not speculation alone',
-                  'Frames the issue as compute/resource saturation within the `ad` service, not as a downstream outage, network issue, or error-driven failure',
+                  'Frames the issue as compute/resource saturation within the `ad` service',
                   'Correctly treats increased latency in upstream services (e.g., frontend, recommendation) as symptoms of the `ad` service slowdown when supported by traces or topology',
                   'Does not attribute the issue to unrelated domains (e.g., checkout, payment, cart) without supporting evidence',
                 ],

--- a/x-pack/solutions/observability/packages/kbn-evals-suite-observability-ai/evals/agent/ad_high_cpu.spec.ts
+++ b/x-pack/solutions/observability/packages/kbn-evals-suite-observability-ai/evals/agent/ad_high_cpu.spec.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { tags } from '@kbn/scout';
+import type { LoadResult } from '@kbn/es-snapshot-loader';
+import {
+  replayObservabilityDataStreams,
+  cleanObservabilityDataStreams,
+} from '../../src/data_generators/replay';
+import { GCS_BUCKET } from '../../src/scenarios/constants';
+import { evaluate } from './evaluate';
+
+const AD_SERVICE_HIGH_CPU_GCS = {
+  bucket: GCS_BUCKET,
+  basePath: 'otel-demo/ad-high-cpu',
+};
+
+const SNAPSHOT_NAME = 'ad-high-cpu';
+
+evaluate.describe(
+  'Ad High CPU Investigation',
+  { tag: tags.serverless.observability.complete },
+  () => {
+    let replayResult: LoadResult;
+
+    evaluate.beforeAll(async ({ esClient, log }) => {
+      log.info('Replaying ad-high-cpu scenario data');
+      replayResult = await replayObservabilityDataStreams(
+        esClient,
+        log,
+        SNAPSHOT_NAME,
+        AD_SERVICE_HIGH_CPU_GCS
+      );
+    });
+
+    evaluate('investigates ad service high CPU scenario', async ({ evaluateDataset }) => {
+      await evaluateDataset({
+        dataset: {
+          name: 'ad-high-cpu investigation',
+          description:
+            'Evaluates whether the agent correctly investigates storefront slowness driven by high CPU load in the OpenTelemetry Demo ad service (adHighCpu feature flag)',
+          examples: [
+            {
+              input: {
+                question: 'The shop is slow when people look at ads and suggested items. Why?',
+                attachments: [
+                  {
+                    type: 'screen_context',
+                    data: {
+                      app: 'observability-overview',
+                      url: 'http://localhost:5601/app/observability/overview',
+                      time_range: { from: 'now-15m', to: 'now' },
+                    },
+                    hidden: true,
+                  },
+                ],
+              },
+              output: {
+                criteria: [
+                  'Identifies the ad service (or Java ad workload) as the primary source of the slowdown, high CPU load, CPU-intensive behavior, or resource contention in that service, rather than blaming unrelated services without evidence',
+                ],
+                expectedTools: [
+                  'observability.get_services',
+                  'observability.get_trace_metrics',
+                  'observability.get_runtime_metrics',
+                  'observability.get_hosts',
+                ],
+              },
+              metadata: {
+                expectedSkill: 'investigation',
+              },
+            },
+          ],
+        },
+      });
+    });
+
+    evaluate.afterAll(async ({ esClient, log }) => {
+      log.debug('Cleaning up');
+      await cleanObservabilityDataStreams(esClient, replayResult, log);
+    });
+  }
+);


### PR DESCRIPTION
Closes https://github.com/elastic/obs-ai-team/issues/553

## Summary

Adds an AB evaluation for the OpenTelemetry Demo “ad high CPU” scenario (adHighCpu)

The spec replays scenario data from GCS (otel-demo/ad-high-cpu), check agaist the `investigation` skill 


