### PR TITLE
[Cases] Feature extract utility

### DIFF
--- a/x-pack/platform/plugins/shared/cases/common/utils/template_fields.test.ts
+++ b/x-pack/platform/plugins/shared/cases/common/utils/template_fields.test.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getFieldCamelKey, getFieldSnakeKey } from './template_fields';
+
+describe('template field key utils', () => {
+  describe('getFieldSnakeKey', () => {
+    it('combines name and type with _as_', () => {
+      expect(getFieldSnakeKey('risk_score', 'keyword')).toBe('risk_score_as_keyword');
+    });
+
+    it('handles single-word name and type', () => {
+      expect(getFieldSnakeKey('severity', 'text')).toBe('severity_as_text');
+    });
+
+    it('handles multi-segment names', () => {
+      expect(getFieldSnakeKey('my_custom_field', 'number')).toBe('my_custom_field_as_number');
+    });
+  });
+
+  describe('getFieldCamelKey', () => {
+    it('returns the camelCase version of the snake key', () => {
+      expect(getFieldCamelKey('risk_score', 'keyword')).toBe('riskScoreAsKeyword');
+    });
+
+    it('handles single-word name and type', () => {
+      expect(getFieldCamelKey('severity', 'text')).toBe('severityAsText');
+    });
+
+    it('handles multi-segment names', () => {
+      expect(getFieldCamelKey('my_custom_field', 'number')).toBe('myCustomFieldAsNumber');
+    });
+
+    it('is consistent with camelCase applied to getFieldSnakeKey output', () => {
+      const name = 'some_field';
+      const type = 'date';
+      const snakeKey = getFieldSnakeKey(name, type);
+      expect(getFieldCamelKey(name, type)).toBe(
+        snakeKey.replace(/_([a-z])/g, (_, c) => c.toUpperCase())
+      );
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/cases/common/utils/template_fields.ts
+++ b/x-pack/platform/plugins/shared/cases/common/utils/template_fields.ts
@@ -5,6 +5,9 @@
  * 2.0.
  */
 
-export * from './connectors_api';
-export * from './capabilities';
-export * from './template_fields';
+import { camelCase } from 'lodash';
+
+export const getFieldSnakeKey = (name: string, type: string): string => `${name}_as_${type}`;
+
+export const getFieldCamelKey = (name: string, type: string): string =>
+  camelCase(getFieldSnakeKey(name, type));

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/components/template_fields.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/components/template_fields.tsx
@@ -7,7 +7,6 @@
 
 import type { FC } from 'react';
 import React, { useMemo } from 'react';
-import { camelCase } from 'lodash';
 import { EuiFlexGroup, EuiFlexItem, EuiButton } from '@elastic/eui';
 import type { z } from '@kbn/zod/v4';
 import { FormProvider, useForm } from '@kbn/es-ui-shared-plugin/static/forms/hook_form_lib';
@@ -16,6 +15,7 @@ import { CASE_EXTENDED_FIELDS } from '../../../../common/constants';
 import type { ParsedTemplateDefinitionSchema } from '../../../../common/types/domain/template/latest';
 import { useGetTemplate } from '../../templates_v2/hooks/use_get_template';
 import { FieldsRenderer } from '../../templates_v2/field_types/field_renderer';
+import { getFieldCamelKey, getFieldSnakeKey } from '../../../../common/utils';
 import type { OnUpdateFields } from '../types';
 import { SAVE } from '../../../common/translations';
 
@@ -39,8 +39,9 @@ const TemplateFieldsForm: FC<{
   const initialDefaultValues = useMemo(() => {
     const defaults: Record<string, Record<string, unknown>> = { [CASE_EXTENDED_FIELDS]: {} };
     for (const field of parsedTemplate.fields) {
-      const fieldKey = `${field.name}_as_${field.type}`;
-      defaults[CASE_EXTENDED_FIELDS][fieldKey] = extendedFields[camelCase(fieldKey)] ?? '';
+      const fieldKey = getFieldSnakeKey(field.name, field.type);
+      defaults[CASE_EXTENDED_FIELDS][fieldKey] =
+        extendedFields[getFieldCamelKey(field.name, field.type)] ?? '';
     }
     return defaults;
   }, [parsedTemplate.fields, extendedFields]);

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/use_change_applied_template.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/use_change_applied_template.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import { camelCase } from 'lodash';
 import { useMutation } from '@kbn/react-query';
 import type { z } from '@kbn/zod/v4';
 import { CASE_EXTENDED_FIELDS } from '../../../common/constants';
@@ -15,6 +14,7 @@ import { patchCase } from '../../containers/api';
 import { casesMutationsKeys } from '../../containers/constants';
 import { useCasesToast } from '../../common/use_cases_toast';
 import type { ServerError } from '../../types';
+import { getFieldCamelKey, getFieldSnakeKey } from '../../../common/utils';
 import { getYamlDefaultAsString } from '../templates_v2/utils';
 import { useRefreshCaseViewPage } from './use_on_refresh_case_view_page';
 import * as i18n from './translations';
@@ -33,8 +33,8 @@ export const computeNewExtendedFields = (
 ): Record<string, string> => {
   const result: Record<string, string> = {};
   for (const field of newTemplateFields) {
-    const snakeKey = `${field.name}_as_${field.type}`;
-    const camelKey = camelCase(snakeKey);
+    const snakeKey = getFieldSnakeKey(field.name, field.type);
+    const camelKey = getFieldCamelKey(field.name, field.type);
     const existingValue = currentExtendedFields[camelKey];
     if (existingValue !== undefined && existingValue !== '') {
       result[snakeKey] = String(existingValue);

--- a/x-pack/platform/plugins/shared/cases/public/components/create/use_template_form_sync.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/create/use_template_form_sync.ts
@@ -10,6 +10,7 @@ import { useFormContext, useFormData } from '@kbn/es-ui-shared-plugin/static/for
 import type { ParsedTemplate } from '../../../common/types/domain/template/v1';
 import { CASE_EXTENDED_FIELDS } from '../../../common/constants';
 import { useGetTemplate } from '../templates_v2/hooks/use_get_template';
+import { getFieldSnakeKey } from '../../../common/utils';
 import { getYamlDefaultAsString } from '../templates_v2/utils';
 
 interface UseTemplateFormSyncReturn {
@@ -71,7 +72,7 @@ export const useTemplateFormSync = (): UseTemplateFormSyncReturn => {
     const newAppliedFields: string[] = [];
     if (template.definition.fields) {
       for (const field of template.definition.fields) {
-        const fieldPath = `${CASE_EXTENDED_FIELDS}.${field.name}_as_${field.type}`;
+        const fieldPath = `${CASE_EXTENDED_FIELDS}.${getFieldSnakeKey(field.name, field.type)}`;
         const defaultValue = getYamlDefaultAsString(field.metadata?.default);
         setFieldValue(fieldPath, defaultValue);
         newAppliedFields.push(fieldPath);

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/checkbox_group.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/checkbox_group.tsx
@@ -14,6 +14,7 @@ import {
 } from '@kbn/es-ui-shared-plugin/static/forms/hook_form_lib';
 import { EuiCheckboxGroup, EuiFormRow } from '@elastic/eui';
 import { CASE_EXTENDED_FIELDS } from '../../../../../common/constants';
+import { getFieldSnakeKey } from '../../../../../common/utils';
 import type {
   CheckboxGroupFieldSchema,
   ConditionRenderProps,
@@ -90,7 +91,11 @@ export const CheckboxGroup: React.FC<CheckboxGroupProps> = ({
   );
 
   return (
-    <UseField key={name} path={`${CASE_EXTENDED_FIELDS}.${name}_as_${type}`} config={config}>
+    <UseField
+      key={name}
+      path={`${CASE_EXTENDED_FIELDS}.${getFieldSnakeKey(name, type)}`}
+      config={config}
+    >
       {renderField}
     </UseField>
   );

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/date_picker.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/date_picker.tsx
@@ -16,6 +16,7 @@ import { fieldValidators } from '@kbn/es-ui-shared-plugin/static/forms/helpers';
 import React from 'react';
 import { EuiDatePicker, EuiFormRow } from '@elastic/eui';
 import { CASE_EXTENDED_FIELDS } from '../../../../../common/constants';
+import { getFieldSnakeKey } from '../../../../../common/utils';
 import {
   type DatePickerFieldSchema,
   type ConditionRenderProps,
@@ -55,7 +56,7 @@ export const DatePicker: React.FC<DatePickerProps> = ({
   return (
     <UseField
       key={name}
-      path={`${CASE_EXTENDED_FIELDS}.${name}_as_${type}`}
+      path={`${CASE_EXTENDED_FIELDS}.${getFieldSnakeKey(name, type)}`}
       serializer={serializer}
       config={{ validations }}
     >

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/input_number.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/input_number.tsx
@@ -11,6 +11,7 @@ import { UseField } from '@kbn/es-ui-shared-plugin/static/forms/hook_form_lib';
 import { NumericField } from '@kbn/es-ui-shared-plugin/static/forms/components';
 import { fieldValidators } from '@kbn/es-ui-shared-plugin/static/forms/helpers';
 import { CASE_EXTENDED_FIELDS } from '../../../../../common/constants';
+import { getFieldSnakeKey } from '../../../../../common/utils';
 import type {
   InputNumberFieldSchema,
   ConditionRenderProps,
@@ -53,7 +54,7 @@ export const InputNumber = ({ label, name, type, isRequired, min, max }: InputNu
   return (
     <UseField
       key={name}
-      path={`${CASE_EXTENDED_FIELDS}.${name}_as_${type}`}
+      path={`${CASE_EXTENDED_FIELDS}.${getFieldSnakeKey(name, type)}`}
       component={NumericField}
       config={{ validations }}
       componentProps={{

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/input_text.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/input_text.tsx
@@ -11,6 +11,7 @@ import React from 'react';
 import { TextField } from '@kbn/es-ui-shared-plugin/static/forms/components';
 import { fieldValidators } from '@kbn/es-ui-shared-plugin/static/forms/helpers';
 import { CASE_EXTENDED_FIELDS } from '../../../../../common/constants';
+import { getFieldSnakeKey } from '../../../../../common/utils';
 import type {
   InputTextFieldSchema,
   ConditionRenderProps,
@@ -81,7 +82,7 @@ export const InputText = ({
   return (
     <UseField
       key={name}
-      path={`${CASE_EXTENDED_FIELDS}.${name}_as_${type}`}
+      path={`${CASE_EXTENDED_FIELDS}.${getFieldSnakeKey(name, type)}`}
       component={TextField}
       config={{ validations }}
       componentProps={{

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/radio_group.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/radio_group.tsx
@@ -14,6 +14,7 @@ import {
 } from '@kbn/es-ui-shared-plugin/static/forms/hook_form_lib';
 import { EuiFormRow, EuiRadioGroup } from '@elastic/eui';
 import { CASE_EXTENDED_FIELDS } from '../../../../../common/constants';
+import { getFieldSnakeKey } from '../../../../../common/utils';
 import type {
   RadioGroupFieldSchema,
   ConditionRenderProps,
@@ -98,7 +99,11 @@ export const RadioGroup: React.FC<RadioGroupProps> = ({
   );
 
   return (
-    <UseField key={name} path={`${CASE_EXTENDED_FIELDS}.${name}_as_${type}`} config={config}>
+    <UseField
+      key={name}
+      path={`${CASE_EXTENDED_FIELDS}.${getFieldSnakeKey(name, type)}`}
+      config={config}
+    >
       {(field: FieldHook<string>) => (
         <RadioGroupField
           field={field}

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/select_basic.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/select_basic.tsx
@@ -12,6 +12,7 @@ import { UseField } from '@kbn/es-ui-shared-plugin/static/forms/hook_form_lib';
 import { SelectField } from '@kbn/es-ui-shared-plugin/static/forms/components';
 import { fieldValidators } from '@kbn/es-ui-shared-plugin/static/forms/helpers';
 import { CASE_EXTENDED_FIELDS } from '../../../../../common/constants';
+import { getFieldSnakeKey } from '../../../../../common/utils';
 import type {
   SelectBasicFieldSchema,
   ConditionRenderProps,
@@ -32,7 +33,7 @@ export const SelectBasic = ({ label, metadata, name, type, isRequired }: SelectB
   return (
     <UseField
       key={name}
-      path={`${CASE_EXTENDED_FIELDS}.${name}_as_${type}`}
+      path={`${CASE_EXTENDED_FIELDS}.${getFieldSnakeKey(name, type)}`}
       component={SelectField}
       config={{ validations }}
       componentProps={{

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/textarea.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/textarea.tsx
@@ -11,6 +11,7 @@ import { UseField } from '@kbn/es-ui-shared-plugin/static/forms/hook_form_lib';
 import { TextAreaField } from '@kbn/es-ui-shared-plugin/static/forms/components';
 import { fieldValidators } from '@kbn/es-ui-shared-plugin/static/forms/helpers';
 import { CASE_EXTENDED_FIELDS } from '../../../../../common/constants';
+import { getFieldSnakeKey } from '../../../../../common/utils';
 import type {
   TextareaFieldSchema,
   ConditionRenderProps,
@@ -81,7 +82,7 @@ export const Textarea = ({
   return (
     <UseField
       key={name}
-      path={`${CASE_EXTENDED_FIELDS}.${name}_as_${type}`}
+      path={`${CASE_EXTENDED_FIELDS}.${getFieldSnakeKey(name, type)}`}
       component={TextAreaField}
       config={{ validations }}
       componentProps={{

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/user_picker/user_picker.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/user_picker/user_picker.tsx
@@ -15,6 +15,7 @@ import {
 } from '@kbn/es-ui-shared-plugin/static/forms/hook_form_lib';
 import type { UserProfileWithAvatar } from '@kbn/user-profile-components';
 import { CASE_EXTENDED_FIELDS } from '../../../../../../common/constants';
+import { getFieldSnakeKey } from '../../../../../../common/utils';
 import type {
   UserPickerFieldSchema,
   ConditionRenderProps,
@@ -106,7 +107,11 @@ export const UserPicker: React.FC<UserPickerProps> = ({
   );
 
   return (
-    <UseField key={name} path={`${CASE_EXTENDED_FIELDS}.${name}_as_${type}`} config={fieldConfig}>
+    <UseField
+      key={name}
+      path={`${CASE_EXTENDED_FIELDS}.${getFieldSnakeKey(name, type)}`}
+      config={fieldConfig}
+    >
       {renderField}
     </UseField>
   );

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/field_renderer.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/field_renderer.tsx
@@ -19,6 +19,7 @@ import { CASE_EXTENDED_FIELDS } from '../../../../common/constants';
 import { controlRegistry } from './field_types_registry';
 import { evaluateCondition } from './evaluate_conditions';
 import { useYamlFormSync } from './hooks/use_yaml_form_sync';
+import { getFieldSnakeKey } from '../../../../common/utils';
 import { getYamlDefaultAsString } from '../utils';
 
 type ParsedTemplateDefinition = z.infer<typeof ParsedTemplateDefinitionSchema>;
@@ -43,7 +44,10 @@ export const FieldsRenderer: FC<{
   );
 
   const allFieldPaths = useMemo(
-    () => parsedTemplate.fields.map((f) => `${CASE_EXTENDED_FIELDS}.${f.name}_as_${f.type}`),
+    () =>
+      parsedTemplate.fields.map(
+        (f) => `${CASE_EXTENDED_FIELDS}.${getFieldSnakeKey(f.name, f.type)}`
+      ),
     [parsedTemplate.fields]
   );
 
@@ -53,7 +57,7 @@ export const FieldsRenderer: FC<{
     const extendedFields =
       (formData as Record<string, Record<string, unknown>>)?.[CASE_EXTENDED_FIELDS] ?? {};
     return Object.fromEntries(
-      parsedTemplate.fields.map((f) => [f.name, extendedFields[`${f.name}_as_${f.type}`]])
+      parsedTemplate.fields.map((f) => [f.name, extendedFields[getFieldSnakeKey(f.name, f.type)]])
     );
   }, [formData, parsedTemplate.fields]);
 
@@ -141,7 +145,7 @@ export const TemplateFieldRenderer: FC<TemplateFieldRendererProps> = ({
     };
     for (const field of stableFields) {
       const yamlDefault = getYamlDefaultAsString(field.metadata?.default);
-      const fieldKey = `${field.name}_as_${field.type}`;
+      const fieldKey = getFieldSnakeKey(field.name, field.type);
       defaults[CASE_EXTENDED_FIELDS][fieldKey] = yamlDefault;
     }
     return defaults;

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/hooks/use_yaml_form_sync.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/hooks/use_yaml_form_sync.ts
@@ -9,6 +9,7 @@ import { useEffect, useRef } from 'react';
 import moment from 'moment-timezone';
 import type { FormHook } from '@kbn/es-ui-shared-plugin/static/forms/hook_form_lib';
 import { CASE_EXTENDED_FIELDS } from '../../../../../common/constants';
+import { getFieldSnakeKey } from '../../../../../common/utils';
 import { getYamlDefaultAsString } from '../../utils';
 
 export interface FieldInfo {
@@ -35,7 +36,7 @@ export const useYamlToFormSync = (
     for (const field of parsedFields) {
       const yamlDefault = getYamlDefaultAsString(field.metadata?.default);
       const lastSynced = lastSyncedYamlDefaultRef.current[field.name];
-      const fieldPath = `${CASE_EXTENDED_FIELDS}.${field.name}_as_${field.type}`;
+      const fieldPath = `${CASE_EXTENDED_FIELDS}.${getFieldSnakeKey(field.name, field.type)}`;
 
       if (lastSynced === undefined || lastSynced !== yamlDefault) {
         fieldsToSync.push({ path: fieldPath, name: field.name, yamlDefault });
@@ -85,7 +86,7 @@ export const useFormToYamlSync = (
       if (!extendedFields) return;
 
       for (const field of parsedFields) {
-        const fieldKey = `${field.name}_as_${field.type}`;
+        const fieldKey = getFieldSnakeKey(field.name, field.type);
         const rawValue = extendedFields[fieldKey];
         const currentFormValue = serializeFormValue(rawValue);
         const currentYamlValue = yamlDefaultsRef.current[field.name] ?? '';


### PR DESCRIPTION
## Summary

Extracts the repeated `${name}_as_${type}` / `camelCase(${name}_as_${type})` key-construction pattern into two shared
   utilities — `getFieldSnakeKey` and `getFieldCamelKey` — and moves them to `common/utils` so they are available to
  both the frontend and the server. All 13 call sites across form controls, hooks, and renderers are updated to use the
   helpers.

  ## Motivation

  The key format used to address template extended fields (`fieldName_as_fieldType`) was inlined as a template literal
  in over a dozen places across the Cases plugin. Any future change to the format would require a surgical
  find-and-replace across the entire plugin. Moving the helpers to `common` also unblocks upcoming server-side PRs that
   need to construct or validate the same keys.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



