### PR TITLE
[Presentation Publishing] Fix embeddable filter actions popover not closing after opening edit flyout

### DIFF
--- a/src/platform/plugins/shared/dashboard/public/dashboard_actions/filters_notification_popover.test.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_actions/filters_notification_popover.test.tsx
@@ -145,4 +145,53 @@ describe('filters notification popover', () => {
       expect(mockedEditPanelAction.execute).toHaveBeenCalled();
     });
   });
+
+  it('closes the popover after executing the edit action', async () => {
+    updateViewMode('edit');
+    updateFilters([getMockPhraseFilter('ay', 'oh')]);
+    await renderAndOpenPopover();
+    expect(await screen.findByTestId('filtersNotificationModal__filterItems')).toBeInTheDocument();
+
+    await userEvent.click(await screen.findByTestId('filtersNotificationModal__editButton'));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('filtersNotificationModal__filterItems')).not.toBeInTheDocument();
+    });
+  });
+
+  it('if supported, locks hover actions when opening the popover', async () => {
+    const lockHoverActions = jest.fn();
+    api = { ...api, lockHoverActions, hasLockedHoverActions$: new BehaviorSubject(false) };
+
+    await renderAndOpenPopover();
+
+    expect(lockHoverActions).toHaveBeenCalledWith(true);
+  });
+
+  it('if supported, unlocks hover actions when closing the popover via the toggle button', async () => {
+    const hasLockedHoverActions$ = new BehaviorSubject(false);
+    const lockHoverActions = jest.fn().mockImplementation((lock: boolean) => {
+      hasLockedHoverActions$.next(lock);
+    });
+    api = { ...api, lockHoverActions, hasLockedHoverActions$ };
+
+    await renderAndOpenPopover();
+    await userEvent.click(screen.getByTestId(`embeddablePanelNotification-${api.uuid}`));
+
+    expect(lockHoverActions).toHaveBeenCalledWith(false);
+  });
+
+  it('if supported, unlocks hover actions after executing the edit action', async () => {
+    const lockHoverActions = jest.fn();
+    api = { ...api, lockHoverActions, hasLockedHoverActions$: new BehaviorSubject(false) };
+    updateViewMode('edit');
+    updateFilters([getMockPhraseFilter('ay', 'oh')]);
+    await renderAndOpenPopover();
+
+    await userEvent.click(await screen.findByTestId('filtersNotificationModal__editButton'));
+
+    await waitFor(() => {
+      expect(lockHoverActions).toHaveBeenCalledWith(false);
+    });
+  });
 });

--- a/src/platform/plugins/shared/dashboard/public/dashboard_actions/filters_notification_popover.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_actions/filters_notification_popover.tsx
@@ -47,6 +47,13 @@ export function FiltersNotificationPopover({ api }: { api: FiltersNotificationAc
   const displayName = dashboardFilterNotificationActionStrings.getDisplayName();
   const canEditUnifiedSearch = api.canEditUnifiedSearch?.() ?? true;
 
+  const closePopover = useCallback(() => {
+    setIsPopoverOpen(false);
+    if (apiCanLockHoverActions(api)) {
+      api.lockHoverActions(false);
+    }
+  }, [api]);
+
   const executeEditAction = useCallback(async () => {
     try {
       const action = await uiActionsService.getAction(ACTION_EDIT_PANEL);
@@ -54,11 +61,12 @@ export function FiltersNotificationPopover({ api }: { api: FiltersNotificationAc
         embeddable: api,
         trigger: triggers[ON_OPEN_PANEL_MENU],
       } as EmbeddableApiContext & ActionExecutionMeta);
+      closePopover();
     } catch (error) {
       // eslint-disable-next-line no-console
       console.warn('Unable to execute edit action, Error: ', error.message);
     }
-  }, [api]);
+  }, [api, closePopover]);
 
   const { queryString, queryLanguage } = useMemo(() => {
     const query = api.query$?.value;
@@ -103,12 +111,7 @@ export function FiltersNotificationPopover({ api }: { api: FiltersNotificationAc
         />
       }
       isOpen={isPopoverOpen}
-      closePopover={() => {
-        setIsPopoverOpen(false);
-        if (apiCanLockHoverActions(api)) {
-          api.lockHoverActions(false);
-        }
-      }}
+      closePopover={closePopover}
       anchorPosition="upCenter"
       aria-label={displayName}
     >


### PR DESCRIPTION
## Summary

While reviewing #261195 I noticed an issue with how the edit filters quick actions popover is handled. More specifically, the problem was the filters popover would remain open after clicking the "Edit filters" button which brings up the edit flyout. This caused the popover to be rendered on top of the flyout, obstructing the editing UI. While on push flyouts the issue is not that bad as the popover will hide when clicking somewhere else the case is worse for overlay flyouts. In this latter case, because the flyout renders on top of the existing page, the click outside listener for the popover wouldn't trigger so it would remain open for as long as the edit flyout is also open making the bug much more annoying.


https://github.com/user-attachments/assets/cfbd123c-dbae-4520-85b5-0175484444f0

To fix the issue, this PR:

- Extracts the `closePopover` logic in `FiltersNotificationPopover` into a named `useCallback`, replacing the previously inline arrow function passed to `EuiPopover.closePopover`.
- Calls `closePopover()` at the end of `executeEditAction` so the popover dismisses automatically after the user clicks "Edit filters" and the action executes successfully. Previously, the popover stayed open after the action ran.

This is how the interaction looks like now that triggering the edit action also closes the popover as well


https://github.com/user-attachments/assets/b1c2b341-e68f-4ad9-a14e-976b5aaeb37c


## Test plan

- [ ] Open a dashboard with a panel that has filters or a query applied. (Any that partially publishes Unified Search capabilities)
- [ ] In view mode, click the filter notification badge — verify the popover opens and shows filters/query, and no edit button is visible.
- [ ] Switch to edit mode, click the filter notification badge — verify the edit button is visible.
- [ ] Click "Edit filters" — verify the popover closes immediately after the action executes.
- [ ] Run unit tests: `node scripts/jest src/platform/plugins/shared/dashboard/public/dashboard_actions/filters_notification_popover.test.tsx`

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [X] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [X] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [X] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


## Release note

Fixes an issue where the edit filters quick action popover in embeddables would remain open after the edit flyout is displayed, obstructing the panel edit UI
