### PR TITLE
[Agent Builder] Allow removing auto included tools if elastic capabilities flag is false

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/tools/agent_tools.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/tools/agent_tools.tsx
@@ -92,8 +92,6 @@ const ActiveToolsList: React.FC<{
                 <EuiBadge color="hollow">
                   {labels.agentTools.elasticCapabilitiesReadOnlyBadge}
                 </EuiBadge>
-              ) : isBuiltIn ? (
-                <EuiBadge color="hollow">{labels.agentTools.readOnlyBadge}</EuiBadge>
               ) : undefined
             }
             canEditAgent={canEditAgent}


### PR DESCRIPTION
## Summary

- Users should be able to remove all tools from their agent configuration if the elastic capabilities flag is false. 

Before

https://github.com/user-attachments/assets/f5cb1abc-16cc-4dd8-abad-465a2c906ba4


After

https://github.com/user-attachments/assets/5f370d5e-7390-4832-b437-704ff764dd64







<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->