### PR TITLE
[Scout Test Review] Format improvements using collapsible sections + important checks list

### DIFF
--- a/.macroscope/scout-review.md
+++ b/.macroscope/scout-review.md
@@ -25,27 +25,21 @@ Skip everything else, including internal `kbn-scout` framework implementation. I
 
 Follow `.agents/skills/scout-best-practices-reviewer/SKILL.md` for the checklist, reuse rules, and migration parity. Ignore any output formatting in that file — use the format below. Use `browse_code` to explore as needed.
 
-On PR updates, review only the new changes and stay high-signal — not nitpicky. If a `## Scout Test Review` summary comment already exists on the PR, edit it in place instead of posting a new one.
+On PR updates, review only the new changes and stay high-signal — not nitpicky.
 
 ## Non-negotiable UI test checks
 
 These rules must be verified on every applicable UI test file. Do not skip them:
 
-- [Test behavior, not data correctness](docs/extend/scout/ui-best-practices.md): if a test case is validating data, the test belongs in a different layer (component test or API test, see details in the best practices document).
+- **Test behavior, not data correctness (UI)**: if a test case is validating data (exact computed values, API response shape, edge-case data), the test belongs in a different layer. Recommend the target layer explicitly in the inline comment — "move to a Scout API test" or "move to an RTL/Jest unit test" — and suggest what the UI test should assert instead.
 
 ## Output
 
-Post detailed findings as **inline PR comments** on the offending line. Optionally post one **summary comment** with a `## Scout Test Review` header and a brief severity breakdown, ending with this footer, verbatim:
+### Inline comments (primary output)
 
-`markdown
-<sup>Share feedback on this review in the [#appex-qa](https://elastic.slack.com/archives/C04HT4P1YS3) channel.</sup>
-`
+Post detailed findings as inline PR comments on the offending line. Each inline comment must use a collapsible section to keep the PR readable. Structure:
 
-### Inline comment format
-
-Each inline comment must use a collapsible section to keep the PR readable. Structure:
-
-```markdown
+​```markdown
 <severity emoji> **[<rule name>](<link to best-practices section>)**
 
 <1–2 sentence high-level overview of the issue and the fix.>
@@ -56,7 +50,7 @@ Each inline comment must use a collapsible section to keep the PR readable. Stru
 <Full explanation, concrete fix, code blocks, before and after examples, or anything else that would overwhelm the inline view.>
 
 </details>
-```
+​```
 
 - **Severity emoji:** 🔴 Blocker, 🟡 Major, 🔵 Minor, ⚪ Nit
 - State the rule violated as a **Markdown link** whose text is the section heading from the matching best-practices document and whose URL is the section-scoped URL (see routing below). The link is required, not optional.
@@ -75,17 +69,75 @@ Scout best practices live in three files. Don't guess from keywords — read the
 
 **Selection rule:**
 
-1. Start from the file being reviewed. If it lives under `test/scout*/ui/**` (or is a UI page object / fixture), check `ui-best-practices.md` first. If it lives under `test/scout*/api/**` (or is an API service / client fixture), check `api-best-practices.md` first.
+1. Start from the file being reviewed. If it lives under `test/scout*/ui/**` (or is a UI page object / fixture), check `ui-best-practices.md` first. If it lives under `test/scout*/api/**` (or is an API service / client fixture), check `api-best-practices.md` first. For `kbn-scout*/**` files, route by what the file is (page object → UI, API service → API, shared fixture → whichever the rule targets), not by path.
 2. Scan that doc's headings for one that matches the rule you're about to cite. If found, use it.
 3. Otherwise, scan the general `best-practices.md`. Use it only when the rule genuinely applies to both UI and API tests (test naming, suite independence, hooks, cleanup, etc.).
 4. When a section with the same intent exists in both the specific doc and the general doc, prefer the specific one.
 
-Always include the section anchor
+### Always include the section anchor
+
+Every finding must link to a **section-scoped URL**, not the doc root. Infer the `#anchor` from the explicit heading id in the markdown source (e.g., the heading `## Use Playwright auto-waiting [leverage-playwright-auto-waiting]` yields `#leverage-playwright-auto-waiting`). Only fall back to the doc root URL if the rule genuinely has no matching section (rare — re-read the doc first).
 
 Format the citation as a Markdown link using the section heading text as the link label:
 
-```
+​`
 🔵 [Use Playwright auto-waiting](https://www.elastic.co/docs/extend/kibana/scout/ui-best-practices#leverage-playwright-auto-waiting)
-```
+​`
 
 Do **not** use bare parenthetical labels like `(best practices)` or `(ui best practices)` — the citation must be a real link that takes the reader to the specific section. If you cannot identify a specific section, state the rule in plain text rather than linking to the wrong document.
+
+### Summary comment (one per PR)
+
+Post one summary comment per PR with a `## Scout Test Review` header. On re-runs, edit it in place — never post a second one.
+
+The summary has three parts:
+
+**1. Current status (always present)**
+
+One line stating what was found on the latest review. Examples:
+
+- `Found 2 issues (1 🟡 Major, 1 🔵 Minor). See inline comments for details.`
+- `Found 1 issue (1 🔴 Blocker). See inline comments for details.`
+- `No issues found. ✅`
+- `Skipped — no Scout test files changed.`
+
+**2. Review log (append-only)**
+
+A running list under a `### Review log` subheading, one entry per review pass. Each entry: a commit SHA (preferred) or timestamp, then a one-line note on what changed since the previous pass. Examples:
+
+- `- abc1234 — Initial review. 2 issues found.`
+- `- def5678 — 1 issue resolved, 1 remaining. New assertion in dataset_quality.spec.ts looks good.`
+- `- 9ab0123 — All issues resolved. ✅`
+
+Log entries should be factual and diff-focused — what changed, what's new, what's gone. Skip praise and general commentary. If a re-run happens but no in-scope files changed in the new commit, don't append a log entry.
+
+**3. Footer (always present, verbatim)**
+
+​`markdown
+<sup>This review is experimental. Share your feedback in the [#appex-qa](https://elastic.slack.com/archives/C04HT4P1YS3) channel.</sup>
+​`
+
+**Summary comment template:**
+
+​```markdown
+
+## Scout Test Review
+
+<current status line>
+
+### Review log
+
+- <sha> — <one-line note>
+- <sha> — <one-line note>
+
+<footer>
+​```
+
+### Re-run behavior
+
+On each re-run:
+
+1. **Update the status line** to reflect the current state of the PR, not a cumulative total. If the developer fixed an issue, it's no longer in the count.
+2. **Append one new entry to the review log.** Do not rewrite or remove old entries — the log is a trail, not a snapshot.
+3. **Do not duplicate inline comments** on lines you've already commented on, unless the code on that line has changed. If a previous inline comment's issue has been resolved, leave the comment as-is (GitHub will mark it outdated automatically).
+4. **If the log grows past ~5 entries**, collapse older entries into a `<details>` block at the bottom of the log so the recent activity stays visible.

--- a/.macroscope/scout-review.md
+++ b/.macroscope/scout-review.md
@@ -12,42 +12,58 @@ conclusion: neutral
 
 Review this PR for compliance with Kibana Scout test best practices.
 
-**Scope**: Focus on **Scout test behavior and best practices** — things that affect test reliability, coverage, and maintainability. Do NOT flag general code quality issues (unused imports/exports, naming conventions, code style) unless they directly impact test behavior. The goal is actionable feedback on tests, not code correctness nitpicks.
+## Scope
 
-Only review files that are:
+Review only **Scout test code and the building blocks tests consume**:
 
-1. **Scout test code**: files under `**/test/scout*/**` paths (spec files, fixtures, page objects, API services, constants, global setup hooks).
-2. **Scout packages**: files under `**/kbn-scout*/**`, but only page objects, API services, fixtures, and test utilities that tests consume. Skip internal framework implementation files.
+- Files under `**/test/scout*/**`: specs, fixtures, page objects, API services, constants, global setup hooks.
+- Files under `**/kbn-scout*/**`: only page objects, API services, fixtures, and test utilities.
 
-Skip all other changed files entirely. If no matching files were changed in this PR, conclude with no comments.
-
-IMPORTANT:
-
-- Do NOT review backport PRs (these usually merge changes into branches that aren't `main`)
-- Do NOT post flaky test runner nudges. A separate agent handles this.
+Skip everything else, including internal `kbn-scout` framework implementation. If no matching files changed, conclude with no comments. Do not post flaky test runner nudges — a separate agent handles that.
 
 ## Review instructions
 
-Follow the skill at `.agents/skills/scout-best-practices-reviewer/SKILL.md` for scope, checklist, reuse rules, and migration parity. You can use the `browse_code` tool to explore the codebase. Use the output instructions below to format the review:
+Follow `.agents/skills/scout-best-practices-reviewer/SKILL.md` for the checklist, reuse rules, and migration parity. Ignore any output formatting in that file — use the format below. Use `browse_code` to explore as needed.
+
+On PR updates, review only the new changes and stay high-signal — not nitpicky. If a `## Scout Test Review` summary comment already exists on the PR, edit it in place instead of posting a new one.
+
+## Non-negotiable UI test checks
+
+These rules must be verified on every applicable UI test file. Do not skip them:
+
+- [Test behavior, not data correctness](docs/extend/scout/ui-best-practices.md): if a test case is validating data, the test belongs in a different layer (component test or API test, see details in the best practices document).
 
 ## Output
 
-Post a **brief summary comment** — a few lines with count, severity, and optionally a one-liner per finding. Keep it scannable; detailed explanations and fixes go in inline comments.
+Post detailed findings as **inline PR comments** on the offending line. Optionally post one **summary comment** with a `## Scout Test Review` header and a brief severity breakdown, ending with this footer, verbatim:
 
+`markdown
+<sup>Share feedback on this review in the [#appex-qa](https://elastic.slack.com/archives/C04HT4P1YS3) channel.</sup>
+`
+
+### Inline comment format
+
+Each inline comment must use a collapsible section to keep the PR readable. Structure:
+
+```markdown
+<severity emoji> **[<rule name>](<link to best-practices section>)**
+
+<1–2 sentence high-level overview of the issue and the fix.>
+
+<details>
+<summary>See details</summary>
+
+<Full explanation, concrete fix, code blocks, before and after examples, or anything else that would overwhelm the inline view.>
+
+</details>
 ```
-## Scout Test Review
 
-Found 2 issues (1 major, 1 minor). See inline comments for details.
-
-This review is experimental. Share your feedback in the #appex-qa channel.
-```
-
-All detailed findings must go in **inline GitHub PR comments** on the specific line where each issue occurs. For each inline comment:
-
-- Start with the severity emoji (🔴 Blocker, 🟡 Major, 🔵 Minor, or ⚪ Nit)
+- **Severity emoji:** 🔴 Blocker, 🟡 Major, 🔵 Minor, ⚪ Nit
 - State the rule violated as a **Markdown link** whose text is the section heading from the matching best-practices document and whose URL is the section-scoped URL (see routing below). The link is required, not optional.
-- Explain the issue in 1–2 sentences
-- Suggest a concrete fix
+- **Overview:** plain prose, no code. A developer skimming the PR should grasp what's wrong and whether to act on it without expanding.
+- **Details:** everything else — reasoning, code snippets, suggested diffs, links to related rules.
+
+If the finding genuinely fits in one line (e.g. a nit about a typo'd constant name), you can skip the `<details>` block. Use judgment — the goal is a scannable PR, not rigid formatting.
 
 ### Pick the right best-practices document (required)
 
@@ -64,9 +80,7 @@ Scout best practices live in three files. Don't guess from keywords — read the
 3. Otherwise, scan the general `best-practices.md`. Use it only when the rule genuinely applies to both UI and API tests (test naming, suite independence, hooks, cleanup, etc.).
 4. When a section with the same intent exists in both the specific doc and the general doc, prefer the specific one.
 
-### Always include the section anchor
-
-Every finding must link to a **section-scoped URL**, not the doc root. Infer the `#anchor` from the explicit heading id in the markdown source (e.g., the heading `## Use Playwright auto-waiting [leverage-playwright-auto-waiting]` yields `#leverage-playwright-auto-waiting`). Only fall back to the doc root URL if the rule genuinely has no matching section (rare — re-read the doc first).
+Always include the section anchor
 
 Format the citation as a Markdown link using the section heading text as the link label:
 
@@ -75,7 +89,3 @@ Format the citation as a Markdown link using the section heading text as the lin
 ```
 
 Do **not** use bare parenthetical labels like `(best practices)` or `(ui best practices)` — the citation must be a real link that takes the reader to the specific section. If you cannot identify a specific section, state the rule in plain text rather than linking to the wrong document.
-
-### Updates to the PR
-
-When a developer updates the PR, review the newer code blocks and suggest improvements while keeping the review high-signal and focused — avoid being overly nitpicky.

--- a/.macroscope/scout-review.md
+++ b/.macroscope/scout-review.md
@@ -17,7 +17,7 @@ Review this PR for compliance with Kibana Scout test best practices.
 Review only **Scout test code and the building blocks tests consume**:
 
 - Files under `**/test/scout*/**`: specs, fixtures, page objects, API services, constants, global setup hooks.
-- Files under `**/kbn-scout*/**`: only page objects, API services, fixtures, and test utilities.
+- Files under `**/kbn-scout*/**`: only specs, page objects, API services, fixtures, and test utilities.
 
 Skip everything else, including internal `kbn-scout` framework implementation. If no matching files changed, conclude with no comments. Do not post flaky test runner nudges — a separate agent handles that.
 
@@ -47,19 +47,19 @@ Post detailed findings as inline PR comments on the offending line. Each inline 
 <details>
 <summary>See details</summary>
 
-<Full explanation, concrete fix, code blocks, before and after examples, or anything else that would overwhelm the inline view.>
+<Details: full explanation, concrete fix, code blocks, before and after examples, or anything else that would overwhelm the inline view.>
 
 </details>
 ​```
 
 - **Severity emoji:** 🔴 Blocker, 🟡 Major, 🔵 Minor, ⚪ Nit
-- State the rule violated as a **Markdown link** whose text is the section heading from the matching best-practices document and whose URL is the section-scoped URL (see routing below). The link is required, not optional.
+- State the rule violated as a **Markdown link** whose text is the section heading from the matching best practices document and whose URL is the section-scoped URL (see routing below). The link is required, not optional.
 - **Overview:** plain prose, no code. A developer skimming the PR should grasp what's wrong and whether to act on it without expanding.
 - **Details:** everything else — reasoning, code snippets, suggested diffs, links to related rules.
 
 If the finding genuinely fits in one line (e.g. a nit about a typo'd constant name), you can skip the `<details>` block. Use judgment — the goal is a scannable PR, not rigid formatting.
 
-### Pick the right best-practices document (required)
+### Consult the relevant best practices documents (required)
 
 Scout best practices live in three files. Don't guess from keywords — read the actual headings to find the matching section:
 
@@ -67,12 +67,7 @@ Scout best practices live in three files. Don't guess from keywords — read the
 - API tests: `docs/extend/scout/api-best-practices.md` → `https://www.elastic.co/docs/extend/kibana/scout/api-best-practices`
 - General (applies to both UI and API): `docs/extend/scout/best-practices.md` → `https://www.elastic.co/docs/extend/kibana/scout/best-practices`
 
-**Selection rule:**
-
-1. Start from the file being reviewed. If it lives under `test/scout*/ui/**` (or is a UI page object / fixture), check `ui-best-practices.md` first. If it lives under `test/scout*/api/**` (or is an API service / client fixture), check `api-best-practices.md` first. For `kbn-scout*/**` files, route by what the file is (page object → UI, API service → API, shared fixture → whichever the rule targets), not by path.
-2. Scan that doc's headings for one that matches the rule you're about to cite. If found, use it.
-3. Otherwise, scan the general `best-practices.md`. Use it only when the rule genuinely applies to both UI and API tests (test naming, suite independence, hooks, cleanup, etc.).
-4. When a section with the same intent exists in both the specific doc and the general doc, prefer the specific one.
+When a section with the same intent exists in both the specific doc and the general doc, prefer the specific one.
 
 ### Always include the section anchor
 
@@ -80,9 +75,9 @@ Every finding must link to a **section-scoped URL**, not the doc root. Infer the
 
 Format the citation as a Markdown link using the section heading text as the link label:
 
-​`
+``​`
 🔵 [Use Playwright auto-waiting](https://www.elastic.co/docs/extend/kibana/scout/ui-best-practices#leverage-playwright-auto-waiting)
-​`
+​```
 
 Do **not** use bare parenthetical labels like `(best practices)` or `(ui best practices)` — the citation must be a real link that takes the reader to the specific section. If you cannot identify a specific section, state the rule in plain text rather than linking to the wrong document.
 


### PR DESCRIPTION
This PR updates our Macroscope-powered Scout Test Review agent:

- The `## Scout Test Review` comment is posted once and updated on subsequent pushes (instead of posting one per commit)
- Collapsible inline comments for code blocks + further details (so the PR stays scannable).
- Non-negotiable checks section: the agent must check these rules always on. At this time, we only add [Test behavior, not data correctness](https://www.elastic.co/docs/extend/kibana/scout/ui-best-practices#focus-ui-tests-on-behavior-not-data-correctness).
