### PR TITLE
[Observability:Onboarding] Fix kubernetes otel ensemble test timing issue

### DIFF
--- a/x-pack/solutions/observability/plugins/observability_onboarding/e2e/playwright/stateful/kubernetes_otel.spec.ts
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/e2e/playwright/stateful/kubernetes_otel.spec.ts
@@ -96,8 +96,9 @@ test('Otel Kubernetes', async ({
   await page.evaluate('window.dispatchEvent(new Event("blur"))');
 
   /**
-   * Additional buffer to ensure data has propagated
-   * to dashboards and Discover before navigating.
+   * Wait for the data to be ingested into the cluster.
+   * 5 minutes is generous and should be more then enough
+   * for the data to propagate everywhere.
    */
   await page.waitForTimeout(5 * 60000);
 
@@ -108,6 +109,12 @@ test('Otel Kubernetes', async ({
    * once both logs and metrics have arrived.
    */
   await otelKubernetesFlowPage.assertDataReceivedIndicator();
+
+  /**
+   * Additional buffer to ensure data has propagated
+   * to dashboards and Discover before navigating.
+   */
+  await page.waitForTimeout(2 * 60000);
 
   /**
    * Wired streams only reroutes logs (to logs.otel); metrics and traces are

--- a/x-pack/solutions/observability/plugins/observability_onboarding/e2e/playwright/stateful/kubernetes_otel.spec.ts
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/e2e/playwright/stateful/kubernetes_otel.spec.ts
@@ -96,18 +96,18 @@ test('Otel Kubernetes', async ({
   await page.evaluate('window.dispatchEvent(new Event("blur"))');
 
   /**
+   * Additional buffer to ensure data has propagated
+   * to dashboards and Discover before navigating.
+   */
+  await page.waitForTimeout(5 * 60000);
+
+  /**
    * Wait for the data received indicator to appear.
    * The flow now uses DataIngestStatus which polls for data
    * after the blur event and shows "We are monitoring your cluster"
    * once both logs and metrics have arrived.
    */
   await otelKubernetesFlowPage.assertDataReceivedIndicator();
-
-  /**
-   * Additional buffer to ensure data has propagated
-   * to dashboards and Discover before navigating.
-   */
-  await page.waitForTimeout(2 * 60000);
 
   /**
    * Wired streams only reroutes logs (to logs.otel); metrics and traces are


### PR DESCRIPTION
## Summary
This PR adds an extra wait step to the kubernetes otel ensemble workflow in order to allow time for data to be shipped from kubernetes.