### PR TITLE
Force all plugins to be enabled on SO registration test

### DIFF
--- a/src/core/server/integration_tests/saved_objects/registration/type_registrations.test.ts
+++ b/src/core/server/integration_tests/saved_objects/registration/type_registrations.test.ts
@@ -196,6 +196,9 @@ const previouslyRegisteredTypes = [
   'gap_auto_fill_scheduler',
   'trial-companion-nba-milestone',
   'streams-significant-events-settings',
+  'alerting_notification_policy',
+  'alerting_api_key_pending_invalidation',
+  'alerting_rule',
 ].sort();
 
 describe('SO type registrations', () => {
@@ -210,7 +213,21 @@ describe('SO type registrations', () => {
   });
 
   it('does not remove types from registrations without updating excludeOnUpgradeQuery', async () => {
-    root = createRoot({}, { oss: false });
+    root = createRoot(
+      {
+        plugins: {
+          forceEnableAllPlugins: true,
+        },
+        node: {
+          roles: ['ui'],
+        },
+      },
+      {
+        oss: false,
+        // running in 'dev' mode prevents cloud-experiments plugin to fail due to missing config
+        dev: true,
+      }
+    );
     await root.preboot();
     const setup = await root.setup();
     const currentlyRegisteredTypes = setup.savedObjects


### PR DESCRIPTION
We were missing some SO types in this test because we weren't forcing all plugins to be enabled. This caused the `REMOVED_TYPES` constant to be outdated. This pr fixes that and adds some SO that are in a disabled plugin