### PR TITLE
[9.4] [Synthetics FTR] Reduce Fleet churn by making installSyntheticsPackage idempotent (#264281)

### DIFF
--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/clean_up_extra_package_policies.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/clean_up_extra_package_policies.ts
@@ -10,7 +10,10 @@ import expect from '@kbn/expect';
 import { syntheticsMonitorSavedObjectType } from '@kbn/synthetics-plugin/common/types/saved_objects';
 import type { DeploymentAgnosticFtrProviderContext } from '../../ftr_provider_context';
 import { getFixtureJson } from './helpers/get_fixture_json';
-import { PrivateLocationTestService } from '../../services/synthetics_private_location';
+import {
+  PrivateLocationTestService,
+  cleanSyntheticsTestData,
+} from '../../services/synthetics_private_location';
 import { SyntheticsMonitorTestService } from '../../services/synthetics_monitor';
 
 export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
@@ -30,7 +33,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
     const testPrivateLocations = new PrivateLocationTestService(getService);
 
     before(async () => {
-      await kibanaServer.savedObjects.cleanStandardList();
+      await cleanSyntheticsTestData(kibanaServer);
       await testPrivateLocations.installSyntheticsPackage();
       editorUser = await samlAuth.createM2mApiKeyWithRoleScope('editor');
 

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/create_monitor.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/create_monitor.ts
@@ -20,7 +20,10 @@ import {
 import type { DeploymentAgnosticFtrProviderContext } from '../../ftr_provider_context';
 import { getFixtureJson } from './helpers/get_fixture_json';
 import { SyntheticsMonitorTestService } from '../../services/synthetics_monitor';
-import { PrivateLocationTestService } from '../../services/synthetics_private_location';
+import {
+  PrivateLocationTestService,
+  cleanSyntheticsTestData,
+} from '../../services/synthetics_private_location';
 
 export const addMonitorAPIHelper = async (
   supertestAPI: any,
@@ -103,7 +106,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
 
     before(async () => {
       _httpMonitorJson = getFixtureJson('http_monitor');
-      await kibanaServer.savedObjects.cleanStandardList();
+      await cleanSyntheticsTestData(kibanaServer);
       editorRoleAuthc = await samlAuth.createM2mApiKeyWithRoleScope('editor');
     });
 

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/create_monitor_private_location.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/create_monitor_private_location.ts
@@ -24,7 +24,10 @@ import rawExpect from 'expect';
 import type { DeploymentAgnosticFtrProviderContext } from '../../ftr_provider_context';
 import { getFixtureJson } from './helpers/get_fixture_json';
 import { comparePolicies, getTestSyntheticsPolicy } from './sample_data/test_policy';
-import { PrivateLocationTestService } from '../../services/synthetics_private_location';
+import {
+  PrivateLocationTestService,
+  cleanSyntheticsTestData,
+} from '../../services/synthetics_private_location';
 import { addMonitorAPIHelper, keyToOmitList, omitMonitorKeys } from './create_monitor';
 import { SyntheticsMonitorTestService } from '../../services/synthetics_monitor';
 
@@ -86,7 +89,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
     };
 
     before(async () => {
-      await kibanaServer.savedObjects.cleanStandardList();
+      await cleanSyntheticsTestData(kibanaServer);
       await testPrivateLocations.installSyntheticsPackage();
       editorUser = await samlAuth.createM2mApiKeyWithRoleScope('editor');
 
@@ -497,7 +500,10 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
         this.skip();
       }
 
-      await testPrivateLocations.installSyntheticsPackage({ version: lowerVersion });
+      await testPrivateLocations.installSyntheticsPackage({
+        version: lowerVersion,
+        force: true,
+      });
       let monitorId = '';
       const privateLocation = await testPrivateLocations.addTestPrivateLocation();
 
@@ -529,7 +535,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
 
         expect(packagePolicy.package.version).eql(lowerVersion);
 
-        await testPrivateLocations.installSyntheticsPackage();
+        await testPrivateLocations.installSyntheticsPackage({ force: true });
 
         await retry.tryForTime(120 * 1000, async () => {
           const policyResponseAfterUpgrade = await supertestWithAuth.get(
@@ -551,7 +557,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
         }
         // Restore the package to the latest version — this MUST succeed
         // or subsequent tests will run against the wrong version
-        await testPrivateLocations.installSyntheticsPackage();
+        await testPrivateLocations.installSyntheticsPackage({ force: true });
       }
     });
 

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/create_monitor_project.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/create_monitor_project.ts
@@ -24,7 +24,10 @@ import {
 } from '@kbn/synthetics-plugin/common/constants/monitor_defaults';
 import type { DeploymentAgnosticFtrProviderContext } from '../../ftr_provider_context';
 import { getFixtureJson } from './helpers/get_fixture_json';
-import { PrivateLocationTestService } from '../../services/synthetics_private_location';
+import {
+  PrivateLocationTestService,
+  cleanSyntheticsTestData,
+} from '../../services/synthetics_private_location';
 import { SyntheticsMonitorTestService } from '../../services/synthetics_monitor';
 import { LOCAL_PUBLIC_LOCATION } from './helpers/location';
 
@@ -81,7 +84,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
     };
 
     before(async () => {
-      await kibanaServer.savedObjects.cleanStandardList();
+      await cleanSyntheticsTestData(kibanaServer);
       editorUser = await samlAuth.createM2mApiKeyWithRoleScope('editor');
       await supertest
         .put(SYNTHETICS_API_URLS.SYNTHETICS_ENABLEMENT)

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/create_monitor_project_multi_space.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/create_monitor_project_multi_space.ts
@@ -14,7 +14,10 @@ import {
 import { SYNTHETICS_API_URLS } from '@kbn/synthetics-plugin/common/constants';
 import type { DeploymentAgnosticFtrProviderContext } from '../../ftr_provider_context';
 import { getFixtureJson } from './helpers/get_fixture_json';
-import { PrivateLocationTestService } from '../../services/synthetics_private_location';
+import {
+  PrivateLocationTestService,
+  cleanSyntheticsTestData,
+} from '../../services/synthetics_private_location';
 
 export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
   describe('CreateProjectMonitorsMultiSpace', function () {
@@ -27,7 +30,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
     let editorUser: RoleCredentials;
 
     before(async () => {
-      await kibanaServer.savedObjects.cleanStandardList();
+      await cleanSyntheticsTestData(kibanaServer);
       editorUser = await samlAuth.createM2mApiKeyWithRoleScope('editor');
       await supertest
         .put(SYNTHETICS_API_URLS.SYNTHETICS_ENABLEMENT)

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/create_monitor_project_private_location.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/create_monitor_project_private_location.ts
@@ -25,7 +25,10 @@ import {
 } from './sample_data/test_project_monitor_policy';
 import type { DeploymentAgnosticFtrProviderContext } from '../../ftr_provider_context';
 import { getFixtureJson } from './helpers/get_fixture_json';
-import { PrivateLocationTestService } from '../../services/synthetics_private_location';
+import {
+  PrivateLocationTestService,
+  cleanSyntheticsTestData,
+} from '../../services/synthetics_private_location';
 import { SyntheticsMonitorTestService } from '../../services/synthetics_monitor';
 import { comparePolicies } from './sample_data/test_policy';
 
@@ -60,7 +63,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
     };
 
     before(async () => {
-      await kibanaServer.savedObjects.cleanStandardList();
+      await cleanSyntheticsTestData(kibanaServer);
       editorUser = await samlAuth.createM2mApiKeyWithRoleScope('editor');
       viewerUser = await samlAuth.createM2mApiKeyWithRoleScope('viewer');
 
@@ -87,7 +90,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
     });
 
     after(async () => {
-      await kibanaServer.savedObjects.cleanStandardList();
+      await cleanSyntheticsTestData(kibanaServer);
     });
 
     beforeEach(async () => {

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/create_monitor_public_api.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/create_monitor_public_api.ts
@@ -10,6 +10,7 @@ import type { RoleCredentials } from '@kbn/ftr-common-functional-services';
 import { DEFAULT_FIELDS } from '@kbn/synthetics-plugin/common/constants/monitor_defaults';
 import type { DeploymentAgnosticFtrProviderContext } from '../../ftr_provider_context';
 import { addMonitorAPIHelper, omitMonitorKeys } from './create_monitor';
+import { cleanSyntheticsTestData } from '../../services/synthetics_private_location';
 import { LOCAL_PUBLIC_LOCATION } from './helpers/location';
 
 export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
@@ -25,12 +26,12 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
     }
 
     before(async () => {
-      await kibanaServer.savedObjects.cleanStandardList();
+      await cleanSyntheticsTestData(kibanaServer);
       editorUser = await samlAuth.createM2mApiKeyWithRoleScope('editor');
     });
 
     after(async () => {
-      await kibanaServer.savedObjects.cleanStandardList();
+      await cleanSyntheticsTestData(kibanaServer);
     });
 
     describe('HTTP Monitor', () => {

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/create_monitor_public_api_private_location.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/create_monitor_public_api_private_location.ts
@@ -13,7 +13,10 @@ import { DEFAULT_FIELDS } from '@kbn/synthetics-plugin/common/constants/monitor_
 import { LOCATION_REQUIRED_ERROR } from '@kbn/synthetics-plugin/server/routes/monitor_cruds/monitor_validation';
 import type { DeploymentAgnosticFtrProviderContext } from '../../ftr_provider_context';
 import { addMonitorAPIHelper, omitMonitorKeys } from './create_monitor';
-import { PrivateLocationTestService } from '../../services/synthetics_private_location';
+import {
+  PrivateLocationTestService,
+  cleanSyntheticsTestData,
+} from '../../services/synthetics_private_location';
 
 export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
   describe('AddNewMonitorsPublicAPI - Private locations', function () {
@@ -29,13 +32,13 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
     }
 
     before(async () => {
-      await kibanaServer.savedObjects.cleanStandardList();
+      await cleanSyntheticsTestData(kibanaServer);
       editorUser = await samlAuth.createM2mApiKeyWithRoleScope('editor');
       privateLocation = await privateLocationTestService.addTestPrivateLocation();
     });
 
     after(async () => {
-      await kibanaServer.savedObjects.cleanStandardList();
+      await cleanSyntheticsTestData(kibanaServer);
     });
 
     it('should return error for empty monitor', async function () {

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/delete_monitor.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/delete_monitor.ts
@@ -15,7 +15,10 @@ import { SYNTHETICS_API_URLS } from '@kbn/synthetics-plugin/common/constants';
 import expect from '@kbn/expect';
 import type { DeploymentAgnosticFtrProviderContext } from '../../ftr_provider_context';
 import { getFixtureJson } from './helpers/get_fixture_json';
-import { PrivateLocationTestService } from '../../services/synthetics_private_location';
+import {
+  PrivateLocationTestService,
+  cleanSyntheticsTestData,
+} from '../../services/synthetics_private_location';
 import { SyntheticsMonitorTestService } from '../../services/synthetics_monitor';
 
 export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
@@ -61,7 +64,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
     };
 
     before(async () => {
-      await kibanaServer.savedObjects.cleanStandardList();
+      await cleanSyntheticsTestData(kibanaServer);
       await testPrivateLocations.installSyntheticsPackage();
       const testPolicyName = 'Fleet test server policy' + Date.now();
       const apiResponse = await testPrivateLocations.addFleetPolicy(testPolicyName);

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/edit_monitor.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/edit_monitor.ts
@@ -20,6 +20,7 @@ import type { DeploymentAgnosticFtrProviderContext } from '../../ftr_provider_co
 import { getFixtureJson } from './helpers/get_fixture_json';
 import { omitResponseTimestamps, omitEmptyValues } from './helpers/monitor';
 import { SyntheticsMonitorTestService } from '../../services/synthetics_monitor';
+import { cleanSyntheticsTestData } from '../../services/synthetics_private_location';
 import { LOCAL_PUBLIC_LOCATION } from './helpers/location';
 
 export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
@@ -71,7 +72,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
     };
 
     before(async () => {
-      await kibanaServer.savedObjects.cleanStandardList();
+      await cleanSyntheticsTestData(kibanaServer);
       await supertestWithAuth.post('/api/fleet/setup').set('kbn-xsrf', 'true').send().expect(200);
       editorUser = await samlAuth.createM2mApiKeyWithRoleScope('editor');
       await supertest
@@ -84,7 +85,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
     });
 
     after(async () => {
-      await kibanaServer.savedObjects.cleanStandardList();
+      await cleanSyntheticsTestData(kibanaServer);
     });
 
     it('edits the monitor', async () => {

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/edit_monitor_private_location.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/edit_monitor_private_location.ts
@@ -20,7 +20,10 @@ import expect from '@kbn/expect';
 import type { DeploymentAgnosticFtrProviderContext } from '../../ftr_provider_context';
 import { getFixtureJson } from './helpers/get_fixture_json';
 import { omitResponseTimestamps, omitEmptyValues } from './helpers/monitor';
-import { PrivateLocationTestService } from '../../services/synthetics_private_location';
+import {
+  PrivateLocationTestService,
+  cleanSyntheticsTestData,
+} from '../../services/synthetics_private_location';
 import { SyntheticsMonitorTestService } from '../../services/synthetics_monitor';
 
 export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
@@ -76,7 +79,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
     };
 
     before(async () => {
-      await kibanaServer.savedObjects.cleanStandardList();
+      await cleanSyntheticsTestData(kibanaServer);
       await supertestWithAuth.post('/api/fleet/setup').set('kbn-xsrf', 'true').send().expect(200);
       editorUser = await samlAuth.createM2mApiKeyWithRoleScope('editor');
       await supertest
@@ -93,7 +96,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
     });
 
     after(async () => {
-      await kibanaServer.savedObjects.cleanStandardList();
+      await cleanSyntheticsTestData(kibanaServer);
     });
 
     beforeEach(() => {

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/edit_monitor_public_api.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/edit_monitor_public_api.ts
@@ -13,7 +13,10 @@ import { DEFAULT_FIELDS } from '@kbn/synthetics-plugin/common/constants/monitor_
 import { SYNTHETICS_API_URLS } from '@kbn/synthetics-plugin/common/constants';
 import type { DeploymentAgnosticFtrProviderContext } from '../../ftr_provider_context';
 import { addMonitorAPIHelper, omitMonitorKeys } from './create_monitor';
-import { PrivateLocationTestService } from '../../services/synthetics_private_location';
+import {
+  PrivateLocationTestService,
+  cleanSyntheticsTestData,
+} from '../../services/synthetics_private_location';
 import { LOCAL_PUBLIC_LOCATION } from './helpers/location';
 
 export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
@@ -69,13 +72,13 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
     }
 
     before(async () => {
-      await kibanaServer.savedObjects.cleanStandardList();
+      await cleanSyntheticsTestData(kibanaServer);
       editorUser = await samlAuth.createM2mApiKeyWithRoleScope('editor');
       await testPrivateLocations.installSyntheticsPackage();
     });
 
     after(async () => {
-      await kibanaServer.savedObjects.cleanStandardList();
+      await cleanSyntheticsTestData(kibanaServer);
     });
     let monitorId = 'test-id';
 

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/edit_monitor_public_api_private_location.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/edit_monitor_public_api_private_location.ts
@@ -16,7 +16,10 @@ import type { PrivateLocation } from '@kbn/synthetics-plugin/common/runtime_type
 import { LOCATION_REQUIRED_ERROR } from '@kbn/synthetics-plugin/server/routes/monitor_cruds/monitor_validation';
 import type { DeploymentAgnosticFtrProviderContext } from '../../ftr_provider_context';
 import { addMonitorAPIHelper, omitMonitorKeys } from './create_monitor';
-import { PrivateLocationTestService } from '../../services/synthetics_private_location';
+import {
+  PrivateLocationTestService,
+  cleanSyntheticsTestData,
+} from '../../services/synthetics_private_location';
 
 export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
   describe('EditMonitorsPublicAPI - Private Location', function () {
@@ -72,7 +75,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
     }
 
     before(async () => {
-      await kibanaServer.savedObjects.cleanStandardList();
+      await cleanSyntheticsTestData(kibanaServer);
       editorUser = await samlAuth.createM2mApiKeyWithRoleScope('editor');
       await testPrivateLocations.installSyntheticsPackage();
       privateLocation1 = await testPrivateLocations.addTestPrivateLocation();
@@ -80,7 +83,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
     });
 
     after(async () => {
-      await kibanaServer.savedObjects.cleanStandardList();
+      await cleanSyntheticsTestData(kibanaServer);
     });
     let monitorId = 'test-id';
 

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/edit_private_location.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/edit_private_location.ts
@@ -14,7 +14,10 @@ import type { PackagePolicy } from '@kbn/fleet-plugin/common';
 import { v4 as uuidv4 } from 'uuid';
 import type { DeploymentAgnosticFtrProviderContext } from '../../ftr_provider_context';
 import { getFixtureJson } from './helpers/get_fixture_json';
-import { PrivateLocationTestService } from '../../services/synthetics_private_location';
+import {
+  PrivateLocationTestService,
+  cleanSyntheticsTestData,
+} from '../../services/synthetics_private_location';
 import { addMonitorAPIHelper, omitMonitorKeys } from './create_monitor';
 import type { SupertestWithRoleScopeType } from '../../services';
 
@@ -43,7 +46,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
         withInternalHeaders: true,
       });
 
-      await kibanaServer.savedObjects.cleanStandardList();
+      await cleanSyntheticsTestData(kibanaServer);
       await testPrivateLocations.installSyntheticsPackage();
       editorUser = await samlAuth.createM2mApiKeyWithRoleScope('editor');
 
@@ -53,7 +56,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
     after(async () => {
       await supertestEditorWithApiKey.destroy();
       await samlAuth.invalidateM2mApiKeyWithRoleScope(editorUser);
-      await kibanaServer.savedObjects.cleanStandardList();
+      await cleanSyntheticsTestData(kibanaServer);
     });
 
     it('adds a test fleet policy', async () => {

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/enable_default_alerting.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/enable_default_alerting.ts
@@ -15,7 +15,10 @@ import { DYNAMIC_SETTINGS_DEFAULTS } from '@kbn/synthetics-plugin/common/constan
 import type { DeploymentAgnosticFtrProviderContext } from '../../ftr_provider_context';
 import { getFixtureJson } from './helpers/get_fixture_json';
 import { addMonitorAPIHelper, omitMonitorKeys } from './create_monitor';
-import { PrivateLocationTestService } from '../../services/synthetics_private_location';
+import {
+  PrivateLocationTestService,
+  cleanSyntheticsTestData,
+} from '../../services/synthetics_private_location';
 
 const TEST_INDEX_CONNECTOR_NAME = 'synthetics-default-alerting-test';
 
@@ -39,12 +42,12 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
     };
 
     after(async () => {
-      await kibanaServer.savedObjects.cleanStandardList();
+      await cleanSyntheticsTestData(kibanaServer);
       await alerting.deleteAllActionConnectors({ roleAuthc: editorUser });
     });
 
     before(async () => {
-      await kibanaServer.savedObjects.cleanStandardList();
+      await cleanSyntheticsTestData(kibanaServer);
       _httpMonitorJson = getFixtureJson('http_monitor');
       editorUser = await samlAuth.createM2mApiKeyWithRoleScope('editor');
       await privateLocationTestService.installSyntheticsPackage();

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/get_monitor.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/get_monitor.ts
@@ -21,7 +21,10 @@ import { secretKeys } from '@kbn/synthetics-plugin/common/constants/monitor_mana
 import { SyntheticsMonitorTestService } from '../../services/synthetics_monitor';
 import { omitMonitorKeys } from './create_monitor';
 import type { DeploymentAgnosticFtrProviderContext } from '../../ftr_provider_context';
-import { PrivateLocationTestService } from '../../services/synthetics_private_location';
+import {
+  PrivateLocationTestService,
+  cleanSyntheticsTestData,
+} from '../../services/synthetics_private_location';
 import { getFixtureJson } from './helpers/get_fixture_json';
 
 export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
@@ -56,7 +59,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
 
     before(async () => {
       await retry.try(async () => {
-        await kibanaServer.savedObjects.cleanStandardList();
+        await cleanSyntheticsTestData(kibanaServer);
       });
       await privateLocationTestService.installSyntheticsPackage();
       editorUser = await samlAuth.createM2mApiKeyWithRoleScope('editor');

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/get_private_location_monitors.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/get_private_location_monitors.ts
@@ -12,7 +12,10 @@ import expect from '@kbn/expect';
 import rawExpect from 'expect';
 import type { DeploymentAgnosticFtrProviderContext } from '../../ftr_provider_context';
 import { getFixtureJson } from './helpers/get_fixture_json';
-import { PrivateLocationTestService } from '../../services/synthetics_private_location';
+import {
+  PrivateLocationTestService,
+  cleanSyntheticsTestData,
+} from '../../services/synthetics_private_location';
 import { addMonitorAPIHelper, omitMonitorKeys } from './create_monitor';
 import type { SupertestWithRoleScopeType } from '../../services';
 
@@ -37,7 +40,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
         withInternalHeaders: true,
       });
 
-      await kibanaServer.savedObjects.cleanStandardList();
+      await cleanSyntheticsTestData(kibanaServer);
       await testPrivateLocations.installSyntheticsPackage();
       editorUser = await samlAuth.createM2mApiKeyWithRoleScope('editor');
     });
@@ -45,7 +48,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
     after(async () => {
       await supertestEditorWithApiKey.destroy();
       await samlAuth.invalidateM2mApiKeyWithRoleScope(editorUser);
-      await kibanaServer.savedObjects.cleanStandardList();
+      await cleanSyntheticsTestData(kibanaServer);
     });
 
     it('adds a test fleet policy', async () => {

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/index.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/index.ts
@@ -8,7 +8,7 @@
 import type { DeploymentAgnosticFtrProviderContext } from '../../ftr_provider_context';
 import { PrivateLocationTestService } from '../../services/synthetics_private_location';
 
-export default function ({ loadTestFile }: DeploymentAgnosticFtrProviderContext) {
+export default function ({ loadTestFile, getService }: DeploymentAgnosticFtrProviderContext) {
   describe('SyntheticsAPITests', function () {
     // temporarily skipping for cloud runs until stability fix is in place
     this.tags(['skipCloud']);

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/index.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/index.ts
@@ -6,11 +6,22 @@
  */
 
 import type { DeploymentAgnosticFtrProviderContext } from '../../ftr_provider_context';
+import { PrivateLocationTestService } from '../../services/synthetics_private_location';
 
 export default function ({ loadTestFile }: DeploymentAgnosticFtrProviderContext) {
   describe('SyntheticsAPITests', function () {
     // temporarily skipping for cloud runs until stability fix is in place
     this.tags(['skipCloud']);
+    // Run Fleet setup + synthetics package install exactly once for the whole
+    // suite. The underlying helper is idempotent, so every per-describe
+    // `installSyntheticsPackage()` call inside a child test file becomes a
+    // cheap GET. This removes ~24 redundant uninstall/reinstall cycles per
+    // CI run, which were the primary source of 502 / "backend closed
+    // connection" flakes against Fleet.
+    before(async () => {
+      const privateLocationService = new PrivateLocationTestService(getService);
+      await privateLocationService.installSyntheticsPackage();
+    });
 
     loadTestFile(require.resolve('./legacy_and_multispace_monitor_api'));
     loadTestFile(require.resolve('./create_monitor_private_location'));

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/inspect_monitor.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/inspect_monitor.ts
@@ -13,7 +13,10 @@ import expect from '@kbn/expect';
 import type { DeploymentAgnosticFtrProviderContext } from '../../ftr_provider_context';
 import { getFixtureJson } from './helpers/get_fixture_json';
 import { SyntheticsMonitorTestService } from '../../services/synthetics_monitor';
-import { PrivateLocationTestService } from '../../services/synthetics_private_location';
+import {
+  PrivateLocationTestService,
+  cleanSyntheticsTestData,
+} from '../../services/synthetics_private_location';
 
 export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
   describe('inspectSyntheticsMonitor', function () {
@@ -35,7 +38,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
     };
 
     before(async () => {
-      await kibanaServer.savedObjects.cleanStandardList();
+      await cleanSyntheticsTestData(kibanaServer);
       await kibanaServer.savedObjects.clean({ types: ['synthetics-param'] });
       editorUser = await samlAuth.createM2mApiKeyWithRoleScope('editor');
       adminUser = await samlAuth.createM2mApiKeyWithRoleScope('admin');

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/legacy_and_multispace_monitor_api.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/legacy_and_multispace_monitor_api.ts
@@ -14,7 +14,10 @@ import {
 } from '@kbn/synthetics-plugin/common/types/saved_objects';
 import type { DeploymentAgnosticFtrProviderContext } from '../../ftr_provider_context';
 import { getFixtureJson } from './helpers/get_fixture_json';
-import { PrivateLocationTestService } from '../../services/synthetics_private_location';
+import {
+  PrivateLocationTestService,
+  cleanSyntheticsTestData,
+} from '../../services/synthetics_private_location';
 import type { SupertestWithRoleScopeType } from '../../services';
 
 const runTests = (
@@ -74,7 +77,7 @@ const runTests = (
   };
 
   before(async () => {
-    await kibanaServer.savedObjects.cleanStandardList();
+    await cleanSyntheticsTestData(kibanaServer);
     supertestEditorWithApiKey = await roleScopedSupertest.getSupertestWithRoleScope('editor', {
       withInternalHeaders: true,
     });
@@ -87,7 +90,7 @@ const runTests = (
 
   after(async () => {
     await supertestEditorWithApiKey.destroy();
-    await kibanaServer.savedObjects.cleanStandardList();
+    await cleanSyntheticsTestData(kibanaServer);
     await Promise.all(spacesToDeleteIds.map((id) => kibanaServer.spaces.delete(id)));
   });
 

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/migrate_legacy_policies.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/migrate_legacy_policies.ts
@@ -13,7 +13,10 @@ import type { PrivateLocation, HTTPFields } from '@kbn/synthetics-plugin/common/
 import type { DeploymentAgnosticFtrProviderContext } from '../../ftr_provider_context';
 import type { SupertestWithRoleScopeType } from '../../services';
 import { getFixtureJson } from './helpers/get_fixture_json';
-import { PrivateLocationTestService } from '../../services/synthetics_private_location';
+import {
+  PrivateLocationTestService,
+  cleanSyntheticsTestData,
+} from '../../services/synthetics_private_location';
 import { SyntheticsMonitorTestService } from '../../services/synthetics_monitor';
 
 /**
@@ -134,7 +137,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
         withInternalHeaders: true,
       });
 
-      await kibanaServer.savedObjects.cleanStandardList();
+      await cleanSyntheticsTestData(kibanaServer);
       await testPrivateLocations.installSyntheticsPackage();
       editorUser = await samlAuth.createM2mApiKeyWithRoleScope('editor');
 
@@ -158,7 +161,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
 
     after(async () => {
       await supertestAdmin.destroy();
-      await kibanaServer.savedObjects.cleanStandardList();
+      await cleanSyntheticsTestData(kibanaServer);
     });
 
     describe('Migration on monitor edit', () => {

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/reset_monitor.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/reset_monitor.ts
@@ -17,7 +17,10 @@ import type { PackagePolicy } from '@kbn/fleet-plugin/common';
 import expect from '@kbn/expect';
 import type { DeploymentAgnosticFtrProviderContext } from '../../ftr_provider_context';
 import { getFixtureJson } from './helpers/get_fixture_json';
-import { PrivateLocationTestService } from '../../services/synthetics_private_location';
+import {
+  PrivateLocationTestService,
+  cleanSyntheticsTestData,
+} from '../../services/synthetics_private_location';
 import { SyntheticsMonitorTestService } from '../../services/synthetics_monitor';
 
 export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
@@ -85,7 +88,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
     };
 
     before(async () => {
-      await kibanaServer.savedObjects.cleanStandardList();
+      await cleanSyntheticsTestData(kibanaServer);
       await testPrivateLocations.installSyntheticsPackage();
       const testPolicyName = 'Fleet test server policy' + Date.now();
       const apiResponse = await testPrivateLocations.addFleetPolicy(testPolicyName);
@@ -97,7 +100,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
     });
 
     after(async () => {
-      await kibanaServer.savedObjects.cleanStandardList();
+      await cleanSyntheticsTestData(kibanaServer);
     });
 
     beforeEach(() => {

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/reset_monitor_bulk.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/reset_monitor_bulk.ts
@@ -17,7 +17,10 @@ import type { PackagePolicy } from '@kbn/fleet-plugin/common';
 import expect from '@kbn/expect';
 import type { DeploymentAgnosticFtrProviderContext } from '../../ftr_provider_context';
 import { getFixtureJson } from './helpers/get_fixture_json';
-import { PrivateLocationTestService } from '../../services/synthetics_private_location';
+import {
+  PrivateLocationTestService,
+  cleanSyntheticsTestData,
+} from '../../services/synthetics_private_location';
 import { SyntheticsMonitorTestService } from '../../services/synthetics_monitor';
 
 export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
@@ -81,7 +84,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
     };
 
     before(async () => {
-      await kibanaServer.savedObjects.cleanStandardList();
+      await cleanSyntheticsTestData(kibanaServer);
       await testPrivateLocations.installSyntheticsPackage();
       const testPolicyName = 'Fleet test server policy' + Date.now();
       const apiResponse = await testPrivateLocations.addFleetPolicy(testPolicyName);
@@ -93,7 +96,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
     });
 
     after(async () => {
-      await kibanaServer.savedObjects.cleanStandardList();
+      await cleanSyntheticsTestData(kibanaServer);
     });
 
     beforeEach(() => {

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/sync_global_params.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/sync_global_params.ts
@@ -19,7 +19,10 @@ import expect from '@kbn/expect';
 import { syntheticsParamType } from '@kbn/synthetics-plugin/common/types/saved_objects';
 import type { DeploymentAgnosticFtrProviderContext } from '../../ftr_provider_context';
 import { getFixtureJson } from './helpers/get_fixture_json';
-import { PrivateLocationTestService } from '../../services/synthetics_private_location';
+import {
+  PrivateLocationTestService,
+  cleanSyntheticsTestData,
+} from '../../services/synthetics_private_location';
 import { comparePolicies, getTestSyntheticsPolicy } from './sample_data/test_policy';
 import { addMonitorAPIHelper, omitMonitorKeys } from './create_monitor';
 
@@ -64,7 +67,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
     };
 
     before(async () => {
-      await kServer.savedObjects.cleanStandardList();
+      await cleanSyntheticsTestData(kServer);
       await testPrivateLocations.installSyntheticsPackage();
 
       _browserMonitorJson = getFixtureJson('browser_monitor');

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/sync_global_params_for_filtered_monitors.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/sync_global_params_for_filtered_monitors.ts
@@ -13,7 +13,10 @@ import { SYNTHETICS_API_URLS } from '@kbn/synthetics-plugin/common/constants';
 import { syntheticsParamType } from '@kbn/synthetics-plugin/common/types/saved_objects';
 import type { DeploymentAgnosticFtrProviderContext } from '../../ftr_provider_context';
 import { getFixtureJson } from './helpers/get_fixture_json';
-import { PrivateLocationTestService } from '../../services/synthetics_private_location';
+import {
+  PrivateLocationTestService,
+  cleanSyntheticsTestData,
+} from '../../services/synthetics_private_location';
 import { SyntheticsMonitorTestService } from '../../services/synthetics_monitor';
 
 export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
@@ -48,7 +51,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
     };
 
     before(async () => {
-      await kibanaServer.savedObjects.cleanStandardList();
+      await cleanSyntheticsTestData(kibanaServer);
       await testPrivateLocations.installSyntheticsPackage();
       editorUser = await samlAuth.createM2mApiKeyWithRoleScope('editor');
       await kibanaServer.savedObjects.clean({ types: [syntheticsParamType] });
@@ -64,7 +67,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
     });
 
     after(async () => {
-      await kibanaServer.savedObjects.cleanStandardList();
+      await cleanSyntheticsTestData(kibanaServer);
       await kibanaServer.savedObjects.clean({ types: [syntheticsParamType] });
     });
 

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/test_now_monitor.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/test_now_monitor.ts
@@ -12,6 +12,7 @@ import expect from '@kbn/expect';
 import type { DeploymentAgnosticFtrProviderContext } from '../../ftr_provider_context';
 import { getFixtureJson } from './helpers/get_fixture_json';
 import { SyntheticsMonitorTestService } from '../../services/synthetics_monitor';
+import { cleanSyntheticsTestData } from '../../services/synthetics_private_location';
 
 export const LOCAL_LOCATION = {
   id: 'dev',
@@ -37,7 +38,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
     let editorUser: RoleCredentials;
 
     before(async () => {
-      await kibanaServer.savedObjects.cleanStandardList();
+      await cleanSyntheticsTestData(kibanaServer);
       editorUser = await samlAuth.createM2mApiKeyWithRoleScope('editor');
       await supertest
         .put(SYNTHETICS_API_URLS.SYNTHETICS_ENABLEMENT)

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/services/synthetics_private_location.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/services/synthetics_private_location.ts
@@ -11,9 +11,80 @@ import { privateLocationSavedObjectName } from '@kbn/synthetics-plugin/common/sa
 import type { SyntheticsPrivateLocations } from '@kbn/synthetics-plugin/common/runtime_types';
 import type { KibanaSupertestProvider } from '@kbn/ftr-common-functional-services';
 import type { PackagePolicy } from '@kbn/fleet-plugin/common';
+import type { KbnClient } from '@kbn/kbn-client';
 import type { DeploymentAgnosticFtrProviderContext } from '../ftr_provider_context';
 
 export const DEFAULT_SYNTHETICS_VERSION = '1.5.0';
+
+/**
+ * Saved-object types that synthetics tests actually create and therefore need
+ * cleaning between suites. This is an explicit allow-list, *not* a subset of
+ * the shared `STANDARD_LIST_TYPES`, because the shared list wipes several
+ * types whose presence is required for the synthetics Fleet package to stay
+ * functional across suites:
+ *
+ *   - `epm-packages` / `epm-packages-assets`: Fleet's record of the installed
+ *     synthetics package. Wiping these forces `installSyntheticsPackage()` to
+ *     do a full DELETE+POST reinstall on every suite (the primary source of
+ *     502 / "backend closed connection" Fleet flakes in CI).
+ *   - Kibana asset types (`dashboard`, `index-pattern`, `visualization`,
+ *     `search`, `lens`, `map`, etc.): these are installed *by* the synthetics
+ *     Fleet package, referenced from `epm-packages.installed_kibana`.
+ *     Wiping them while preserving `epm-packages` leaves dangling references
+ *     that break subsequent tests which resolve package assets in new spaces.
+ *
+ * Keep this list narrow: only SO types the tests themselves create.
+ */
+const SYNTHETICS_TEST_SO_TYPES = [
+  // Synthetics test artifacts
+  'synthetics-monitor',
+  'synthetics-monitor-multi-space',
+  'synthetics-privates-locations',
+  'synthetics-private-location',
+  'synthetics-param',
+  'uptime-dynamic-settings',
+  // Fleet agent / package policies created to back private locations
+  'ingest-agent-policies',
+  'fleet-agent-policies',
+  'ingest-package-policies',
+  'fleet-package-policies',
+  // Alerting artifacts created by enable_default_alerting & related suites
+  'alert',
+  'action',
+];
+
+/**
+ * Drop-in replacement for `kibanaServer.savedObjects.cleanStandardList()` for
+ * synthetics suites. Wipes only the SO types the tests themselves create,
+ * leaving the synthetics Fleet package installation (and the Kibana/ES
+ * assets it owns) intact so `installSyntheticsPackage()` can short-circuit
+ * across suites.
+ */
+export async function cleanSyntheticsTestData(
+  kibanaServer: KbnClient,
+  options?: { space?: string }
+) {
+  await kibanaServer.savedObjects.clean({
+    types: SYNTHETICS_TEST_SO_TYPES,
+    space: options?.space,
+  });
+}
+
+// Module-level caches shared across every PrivateLocationTestService instance
+// in a single FTR run. Combined with `cleanSyntheticsTestData` (which leaves
+// the `epm-packages` SO intact), these let the ~25 suite-level `before` hooks
+// that call `installSyntheticsPackage()` short-circuit after the first real
+// install, avoiding the Fleet churn that produced 502 flakes in downstream
+// tests.
+let fleetSetupDone = false;
+let installedVersionCache: string | null = null;
+
+/** Reset the module-level cache. Exposed for tests that intentionally mutate
+ *  deployment state (e.g. the synthetics auto-upgrade test). */
+export function resetInstallSyntheticsPackageCache() {
+  fleetSetupDone = false;
+  installedVersionCache = null;
+}
 
 export class PrivateLocationTestService {
   private supertestWithAuth: ReturnType<typeof KibanaSupertestProvider>;
@@ -33,15 +104,62 @@ export class PrivateLocationTestService {
     return res.body?.item?.version ?? DEFAULT_SYNTHETICS_VERSION;
   }
 
-  async installSyntheticsPackage({ version }: { version?: string } = {}) {
-    await this.retry.try(async () => {
-      await this.supertestWithAuth
-        .post('/api/fleet/setup')
-        .set('kbn-xsrf', 'true')
-        .send()
-        .expect(200);
-    });
-    const resolvedVersion = version ?? (await this.fetchSyntheticsPackageVersion());
+  /** Returns the Fleet-reported { version, status } for the synthetics
+   *  package, or `null` if Fleet hasn't observed it at all. */
+  async getInstalledSyntheticsPackage(): Promise<{ version: string; status: string } | null> {
+    const res = await this.supertestWithAuth
+      .get('/api/fleet/epm/packages/synthetics')
+      .set('kbn-xsrf', 'true');
+    const item = res.body?.item;
+    if (!item?.version) {
+      return null;
+    }
+    return { version: item.version, status: item.status ?? 'unknown' };
+  }
+
+  /**
+   * Ensures the synthetics Fleet package is installed at the requested version.
+   *
+   * This method is idempotent across all FTR suites in a single run:
+   * - `POST /api/fleet/setup` only runs the first time any suite calls it.
+   * - If the package is already installed at the requested version, it
+   *   returns without issuing `DELETE` + `POST`.
+   *
+   * Historically every one of the ~25 Synthetics `describe` `before` hooks
+   * performed a full uninstall + reinstall cycle, which saturated Fleet and
+   * produced 502 / "backend closed connection" flakes in downstream tests.
+   * Callers that genuinely need a clean reinstall (the auto-upgrade test)
+   * should pass `{ force: true }`.
+   */
+  async installSyntheticsPackage({
+    version,
+    force = false,
+  }: { version?: string; force?: boolean } = {}) {
+    if (!fleetSetupDone) {
+      await this.retry.try(async () => {
+        await this.supertestWithAuth
+          .post('/api/fleet/setup')
+          .set('kbn-xsrf', 'true')
+          .send()
+          .expect(200);
+      });
+      fleetSetupDone = true;
+    }
+
+    const installed = await this.getInstalledSyntheticsPackage();
+    const resolvedVersion =
+      version ?? installed?.version ?? installedVersionCache ?? DEFAULT_SYNTHETICS_VERSION;
+
+    const alreadyInstalled =
+      !force &&
+      installed?.status === 'installed' &&
+      installed?.version === resolvedVersion &&
+      installedVersionCache === resolvedVersion;
+
+    if (alreadyInstalled) {
+      return;
+    }
+
     await this.retry.try(async () => {
       await this.supertestWithAuth
         .delete(`/api/fleet/epm/packages/synthetics`)
@@ -53,12 +171,13 @@ export class PrivateLocationTestService {
         .expect(200);
       // Verify the version actually took effect — background Fleet tasks
       // (e.g. deferred upgradePackageInstallVersion) can race and overwrite it
-      const installedVersion = await this.fetchSyntheticsPackageVersion();
-      if (installedVersion !== resolvedVersion) {
+      const after = await this.getInstalledSyntheticsPackage();
+      if (after?.version !== resolvedVersion) {
         throw new Error(
-          `Package version mismatch after install: expected ${resolvedVersion} but got ${installedVersion}`
+          `Package version mismatch after install: expected ${resolvedVersion} but got ${after?.version}`
         );
       }
+      installedVersionCache = resolvedVersion;
     });
   }
 

--- a/x-pack/solutions/observability/test/moon.yml
+++ b/x-pack/solutions/observability/test/moon.yml
@@ -90,6 +90,7 @@ dependsOn:
   - '@kbn/observability-agent-builder-plugin'
   - '@kbn/maintenance-windows-plugin'
   - '@kbn/product-doc-common'
+  - '@kbn/kbn-client'
 tags:
   - test-helper
   - package

--- a/x-pack/solutions/observability/test/tsconfig.json
+++ b/x-pack/solutions/observability/test/tsconfig.json
@@ -95,6 +95,7 @@
     "@kbn/aiops-log-rate-analysis",
     "@kbn/observability-agent-builder-plugin",
     "@kbn/maintenance-windows-plugin",
-    "@kbn/product-doc-common"
+    "@kbn/product-doc-common",
+    "@kbn/kbn-client"
   ]
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Synthetics FTR] Reduce Fleet churn by making installSyntheticsPackage idempotent (#264281)](https://github.com/elastic/kibana/pull/264281)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Shahzad","email":"shahzad31comp@gmail.com"},"sourceCommit":{"committedDate":"2026-04-20T07:06:13Z","message":"[Synthetics FTR] Reduce Fleet churn by making installSyntheticsPackage idempotent (#264281)\n\n## Summary\n\nReduces the Fleet work the synthetics deployment-agnostic FTR suite does\nper CI run from ~25 full package install cycles down to **1**. The\nexcessive churn was the primary source of 502 / \"backend closed\nconnection\" flakes in downstream tests (Buildkite [build\n1032](https://buildkite.com/elastic/appex-qa-stateful-kibana-ftr-tests/builds/1032/steps/canvas?sid=019da341-0cae-45f9-bca0-cda97e93857e)).\n\n### Changes\n\n1. **`installSyntheticsPackage()` is now idempotent**\n(`synthetics_private_location.ts`).\n- `POST /api/fleet/setup` runs once per FTR run (not once per\n`describe`).\n- The DELETE+POST reinstall cycle is skipped when Fleet already reports\nthe package installed at the requested version.\n- A module-level cache (`fleetSetupDone`, `installedVersionCache`)\nenforces the short-circuit across suites.\n- An exported `resetInstallSyntheticsPackageCache()` is provided for the\none test that legitimately mutates deployment state (auto-upgrade).\n\n2. **New `cleanSyntheticsTestData()` helper** replaces\n`kibanaServer.savedObjects.cleanStandardList()` in every synthetics\ndeployment-agnostic suite.\n- The shared `STANDARD_LIST_TYPES` wipes `epm-packages` /\n`epm-packages-assets` (Fleet's install record) plus the Kibana assets\nthe synthetics package itself installs — which invalidated the\nidempotency cache between suites and would otherwise force every\n`before` hook back into a full reinstall.\n- The new helper is an **explicit allow-list** of the SO types\nsynthetics tests actually create (`synthetics-monitor*`,\n`synthetics-private-location*`, `synthetics-param`,\n`uptime-dynamic-settings`, Fleet policies, `alert`/`action`). Kibana\nassets owned by the synthetics Fleet package stay intact → no\ndangling-reference failures.\n   - No change to shared kbn-kbn-client code.\n\n### Local validation\n\nRan a representative subset twice (`EnableDefaultAlerting |\ninspectSyntheticsMonitor | CleanUpExtraPackagePolicies |\nGetPrivateLocationMonitors | EditPrivateLocationAPI`) against a\nlocally-started ES + Kibana via FTR, using a\n`SYNTHETICS_LEGACY_INSTALL=1` env toggle (removed before commit) to\ncompare side-by-side:\n\n| mode | `/api/fleet/setup` calls | full install cycles | tests | wall\ntime |\n| --- | ---: | ---: | --- | --- |\n| legacy (pre-PR behavior) | 6 | 6 | **33 passing** | 1.7 min |\n| idempotent (this PR) | **1** | **1** | **33 passing** | **1.0 min** |\n\nSame test result, ~6× less Fleet churn, and faster too.\n\n### Out of scope\n\nThe transient retry helper that was briefly drafted here was removed at\nthe reviewer's request — it would have suppressed the symptom rather\nthan addressed the root cause.\n\n## Test plan\n\n- [x] Local FTR subset passes with and without the PR behavior (see\ntable above).\n- [ ] Full `oblt.stateful.config.ts` run on CI.\n- [ ] Watch `appex-qa-stateful-kibana-ftr-tests` next run for reduction\nin 502s across non-synthetics suites.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"983d3317046ca9ec24403307036fad9f0c458012","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","backport:version","author:actionable-obs","v9.5.0"],"title":"[Synthetics FTR] Reduce Fleet churn by making installSyntheticsPackage idempotent","number":264281,"url":"https://github.com/elastic/kibana/pull/264281","mergeCommit":{"message":"[Synthetics FTR] Reduce Fleet churn by making installSyntheticsPackage idempotent (#264281)\n\n## Summary\n\nReduces the Fleet work the synthetics deployment-agnostic FTR suite does\nper CI run from ~25 full package install cycles down to **1**. The\nexcessive churn was the primary source of 502 / \"backend closed\nconnection\" flakes in downstream tests (Buildkite [build\n1032](https://buildkite.com/elastic/appex-qa-stateful-kibana-ftr-tests/builds/1032/steps/canvas?sid=019da341-0cae-45f9-bca0-cda97e93857e)).\n\n### Changes\n\n1. **`installSyntheticsPackage()` is now idempotent**\n(`synthetics_private_location.ts`).\n- `POST /api/fleet/setup` runs once per FTR run (not once per\n`describe`).\n- The DELETE+POST reinstall cycle is skipped when Fleet already reports\nthe package installed at the requested version.\n- A module-level cache (`fleetSetupDone`, `installedVersionCache`)\nenforces the short-circuit across suites.\n- An exported `resetInstallSyntheticsPackageCache()` is provided for the\none test that legitimately mutates deployment state (auto-upgrade).\n\n2. **New `cleanSyntheticsTestData()` helper** replaces\n`kibanaServer.savedObjects.cleanStandardList()` in every synthetics\ndeployment-agnostic suite.\n- The shared `STANDARD_LIST_TYPES` wipes `epm-packages` /\n`epm-packages-assets` (Fleet's install record) plus the Kibana assets\nthe synthetics package itself installs — which invalidated the\nidempotency cache between suites and would otherwise force every\n`before` hook back into a full reinstall.\n- The new helper is an **explicit allow-list** of the SO types\nsynthetics tests actually create (`synthetics-monitor*`,\n`synthetics-private-location*`, `synthetics-param`,\n`uptime-dynamic-settings`, Fleet policies, `alert`/`action`). Kibana\nassets owned by the synthetics Fleet package stay intact → no\ndangling-reference failures.\n   - No change to shared kbn-kbn-client code.\n\n### Local validation\n\nRan a representative subset twice (`EnableDefaultAlerting |\ninspectSyntheticsMonitor | CleanUpExtraPackagePolicies |\nGetPrivateLocationMonitors | EditPrivateLocationAPI`) against a\nlocally-started ES + Kibana via FTR, using a\n`SYNTHETICS_LEGACY_INSTALL=1` env toggle (removed before commit) to\ncompare side-by-side:\n\n| mode | `/api/fleet/setup` calls | full install cycles | tests | wall\ntime |\n| --- | ---: | ---: | --- | --- |\n| legacy (pre-PR behavior) | 6 | 6 | **33 passing** | 1.7 min |\n| idempotent (this PR) | **1** | **1** | **33 passing** | **1.0 min** |\n\nSame test result, ~6× less Fleet churn, and faster too.\n\n### Out of scope\n\nThe transient retry helper that was briefly drafted here was removed at\nthe reviewer's request — it would have suppressed the symptom rather\nthan addressed the root cause.\n\n## Test plan\n\n- [x] Local FTR subset passes with and without the PR behavior (see\ntable above).\n- [ ] Full `oblt.stateful.config.ts` run on CI.\n- [ ] Watch `appex-qa-stateful-kibana-ftr-tests` next run for reduction\nin 502s across non-synthetics suites.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"983d3317046ca9ec24403307036fad9f0c458012"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/264281","number":264281,"mergeCommit":{"message":"[Synthetics FTR] Reduce Fleet churn by making installSyntheticsPackage idempotent (#264281)\n\n## Summary\n\nReduces the Fleet work the synthetics deployment-agnostic FTR suite does\nper CI run from ~25 full package install cycles down to **1**. The\nexcessive churn was the primary source of 502 / \"backend closed\nconnection\" flakes in downstream tests (Buildkite [build\n1032](https://buildkite.com/elastic/appex-qa-stateful-kibana-ftr-tests/builds/1032/steps/canvas?sid=019da341-0cae-45f9-bca0-cda97e93857e)).\n\n### Changes\n\n1. **`installSyntheticsPackage()` is now idempotent**\n(`synthetics_private_location.ts`).\n- `POST /api/fleet/setup` runs once per FTR run (not once per\n`describe`).\n- The DELETE+POST reinstall cycle is skipped when Fleet already reports\nthe package installed at the requested version.\n- A module-level cache (`fleetSetupDone`, `installedVersionCache`)\nenforces the short-circuit across suites.\n- An exported `resetInstallSyntheticsPackageCache()` is provided for the\none test that legitimately mutates deployment state (auto-upgrade).\n\n2. **New `cleanSyntheticsTestData()` helper** replaces\n`kibanaServer.savedObjects.cleanStandardList()` in every synthetics\ndeployment-agnostic suite.\n- The shared `STANDARD_LIST_TYPES` wipes `epm-packages` /\n`epm-packages-assets` (Fleet's install record) plus the Kibana assets\nthe synthetics package itself installs — which invalidated the\nidempotency cache between suites and would otherwise force every\n`before` hook back into a full reinstall.\n- The new helper is an **explicit allow-list** of the SO types\nsynthetics tests actually create (`synthetics-monitor*`,\n`synthetics-private-location*`, `synthetics-param`,\n`uptime-dynamic-settings`, Fleet policies, `alert`/`action`). Kibana\nassets owned by the synthetics Fleet package stay intact → no\ndangling-reference failures.\n   - No change to shared kbn-kbn-client code.\n\n### Local validation\n\nRan a representative subset twice (`EnableDefaultAlerting |\ninspectSyntheticsMonitor | CleanUpExtraPackagePolicies |\nGetPrivateLocationMonitors | EditPrivateLocationAPI`) against a\nlocally-started ES + Kibana via FTR, using a\n`SYNTHETICS_LEGACY_INSTALL=1` env toggle (removed before commit) to\ncompare side-by-side:\n\n| mode | `/api/fleet/setup` calls | full install cycles | tests | wall\ntime |\n| --- | ---: | ---: | --- | --- |\n| legacy (pre-PR behavior) | 6 | 6 | **33 passing** | 1.7 min |\n| idempotent (this PR) | **1** | **1** | **33 passing** | **1.0 min** |\n\nSame test result, ~6× less Fleet churn, and faster too.\n\n### Out of scope\n\nThe transient retry helper that was briefly drafted here was removed at\nthe reviewer's request — it would have suppressed the symptom rather\nthan addressed the root cause.\n\n## Test plan\n\n- [x] Local FTR subset passes with and without the PR behavior (see\ntable above).\n- [ ] Full `oblt.stateful.config.ts` run on CI.\n- [ ] Watch `appex-qa-stateful-kibana-ftr-tests` next run for reduction\nin 502s across non-synthetics suites.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"983d3317046ca9ec24403307036fad9f0c458012"}}]}] BACKPORT-->