### PR TITLE
[9.4] [EDR Workflows] Adapt endpoint exception privileges on alert pages (#263808)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/exceptions/hooks/use_endpoint_exceptions_capability/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/exceptions/hooks/use_endpoint_exceptions_capability/index.tsx
@@ -6,11 +6,24 @@
  */
 
 import { useMemo } from 'react';
+import { useGetEndpointExceptionsPerPolicyOptIn } from '../../../management/hooks/artifacts/use_endpoint_per_policy_opt_in';
 import { useHasSecurityCapability } from '../../../helper_hooks';
 
+/**
+ * Determine if user has capability to view or crud Endpoint Exceptions, taking into account both global artifact permissions and per-policy opt-in status.
+ *
+ * Before per-policy EE opt-in, user needs both Endpoint Exceptions ALL and Global Artifact Management ALL to CRUD.
+ *
+ * After per-policy EE opt-in, user needs only Endpoint Exceptions ALL to CRUD, as the exceptions can be created as per-policy.
+ *
+ * @param capability 'showEndpointExceptions' | 'crudEndpointExceptions'
+ */
 export const useEndpointExceptionsCapability = (
   capability: 'showEndpointExceptions' | 'crudEndpointExceptions'
 ): boolean => {
+  const { data: isPerPolicyOptIn } = useGetEndpointExceptionsPerPolicyOptIn({
+    enabled: capability === 'crudEndpointExceptions',
+  });
   const canWriteGlobalArtifacts = useHasSecurityCapability('writeGlobalArtifacts');
   const hasCapability = useHasSecurityCapability(capability);
 
@@ -19,6 +32,8 @@ export const useEndpointExceptionsCapability = (
       return hasCapability;
     }
 
-    return hasCapability && canWriteGlobalArtifacts;
-  }, [canWriteGlobalArtifacts, capability, hasCapability]);
+    const areEndpointExceptionsPerPolicy = isPerPolicyOptIn?.status === true;
+
+    return hasCapability && (canWriteGlobalArtifacts || areEndpointExceptionsPerPolicy);
+  }, [canWriteGlobalArtifacts, capability, hasCapability, isPerPolicyOptIn]);
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/exceptions/hooks/use_endpoint_exceptions_capability/use_endpoint_exceptions_capability.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/exceptions/hooks/use_endpoint_exceptions_capability/use_endpoint_exceptions_capability.test.tsx
@@ -8,10 +8,13 @@
 import { useHasSecurityCapability as _useHasSecurityCapability } from '../../../helper_hooks';
 import { renderHook as reactRenderHook } from '@testing-library/react';
 import { useEndpointExceptionsCapability } from '.';
+import { useGetEndpointExceptionsPerPolicyOptIn as _useGetEndpointExceptionsPerPolicyOptIn } from '../../../management/hooks/artifacts/use_endpoint_per_policy_opt_in';
 
 jest.mock('../../../helper_hooks');
+jest.mock('../../../management/hooks/artifacts/use_endpoint_per_policy_opt_in');
 
 const useHasSecurityCapabilityMock = _useHasSecurityCapability as jest.Mock;
+const useGetEndpointExceptionsPerPolicyOptIn = _useGetEndpointExceptionsPerPolicyOptIn as jest.Mock;
 
 describe('useEndpointExceptionsCapability()', () => {
   let capabilities: Record<string, boolean>;
@@ -30,6 +33,10 @@ describe('useEndpointExceptionsCapability()', () => {
     useHasSecurityCapabilityMock.mockImplementation((capability) =>
       Boolean(capabilities[capability])
     );
+
+    useGetEndpointExceptionsPerPolicyOptIn.mockReturnValue({ data: { status: false } });
+
+    jest.clearAllMocks();
   });
 
   it(`should return 'true' if capability 'crudEndpointExceptions' allowed`, () => {
@@ -38,12 +45,18 @@ describe('useEndpointExceptionsCapability()', () => {
   });
 
   it(`should return 'false' if capability 'crudEndpointExceptions' is not allowed`, () => {
+    capabilities.writeGlobalArtifacts = true;
     capabilities.crudEndpointExceptions = false;
     expect(renderHook('crudEndpointExceptions').result.current).toBe(false);
   });
 
-  it(`should return 'false' if capability 'crudEndpointExceptions' is allowed, but user is not allowed to manage global artifacts`, () => {
+  it(`should return 'false' if capability 'crudEndpointExceptions' is allowed, but user is not allowed to manage global artifacts and not opted in to per-policy EE`, () => {
     expect(renderHook('crudEndpointExceptions').result.current).toBe(false);
+  });
+
+  it(`should return 'true' if capability 'crudEndpointExceptions' is allowed, and user has opted in to per-policy EE, even without global artifact privilege`, () => {
+    useGetEndpointExceptionsPerPolicyOptIn.mockReturnValue({ data: { status: true } });
+    expect(renderHook('crudEndpointExceptions').result.current).toBe(true);
   });
 
   it(`should return 'true' if capabilities 'crudEndpointExceptions' and manage global artifacts is allowed`, () => {
@@ -51,7 +64,17 @@ describe('useEndpointExceptionsCapability()', () => {
     expect(renderHook('crudEndpointExceptions').result.current).toBe(true);
   });
 
+  it('should call the opt-in API when checking write privilege', () => {
+    renderHook('crudEndpointExceptions');
+    expect(useGetEndpointExceptionsPerPolicyOptIn).toBeCalledWith({ enabled: true });
+  });
+
   it(`should return 'true' if capability 'showEndpointExceptions' is allowed and manage global artifact is not allowed`, () => {
     expect(renderHook('showEndpointExceptions').result.current).toBe(true);
+  });
+
+  it('should not call the opt-in API when checking read privilege', () => {
+    renderHook('showEndpointExceptions');
+    expect(useGetEndpointExceptionsPerPolicyOptIn).toBeCalledWith({ enabled: false });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/management/hooks/artifacts/use_endpoint_per_policy_opt_in.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/hooks/artifacts/use_endpoint_per_policy_opt_in.test.ts
@@ -11,43 +11,89 @@ import {
 } from '../../../common/mock/endpoint';
 import { waitFor } from '@testing-library/dom';
 import { useGetEndpointExceptionsPerPolicyOptIn } from './use_endpoint_per_policy_opt_in';
-import { ENDPOINT_EXCEPTIONS_PER_POLICY_OPT_IN_ROUTE } from '../../../../common/endpoint/constants';
+import { endpointExceptionsPerPolicyOptInAllHttpMocks } from '../../mocks/endpoint_per_policy_opt_in_http_mocks';
 
 describe('useGetEndpointExceptionsPerPolicyOptIn()', () => {
   let testContext: AppContextTestRender;
+  let getOptInHttpMock: ReturnType<
+    typeof endpointExceptionsPerPolicyOptInAllHttpMocks
+  >['responseProvider']['optInGet'];
 
   beforeEach(() => {
     testContext = createAppRootMockRenderer();
-    testContext.coreStart.http.get.mockResolvedValue({ isOptedIn: false });
+    getOptInHttpMock = endpointExceptionsPerPolicyOptInAllHttpMocks(testContext.coreStart.http)
+      .responseProvider.optInGet;
   });
 
   afterEach(() => {
     jest.clearAllMocks();
   });
 
-  it('should call the API when the experimental feature is enabled', async () => {
-    testContext.setExperimentalFlag({ endpointExceptionsMovedUnderManagement: true });
+  describe('when feature flag is disabled', () => {
+    beforeEach(() => {
+      testContext.setExperimentalFlag({ endpointExceptionsMovedUnderManagement: false });
+    });
 
-    const { result } = testContext.renderHook(() => useGetEndpointExceptionsPerPolicyOptIn());
+    it('should not call the API when no params are passed', () => {
+      const { result } = testContext.renderHook(() => useGetEndpointExceptionsPerPolicyOptIn());
 
-    await waitFor(() => {
-      expect(result.current.data).toEqual({ isOptedIn: false });
-      expect(testContext.coreStart.http.get).toHaveBeenCalledWith(
-        ENDPOINT_EXCEPTIONS_PER_POLICY_OPT_IN_ROUTE,
-        { version: '1' }
+      expect(result.current.data).toBeUndefined();
+      expect(getOptInHttpMock).not.toHaveBeenCalled();
+    });
+
+    it('should not call the API even when enabled is true', () => {
+      const { result } = testContext.renderHook(() =>
+        useGetEndpointExceptionsPerPolicyOptIn({ enabled: true })
       );
+
+      expect(result.current.data).toBeUndefined();
+      expect(getOptInHttpMock).not.toHaveBeenCalled();
     });
   });
 
-  it('should not call the API when the experimental feature is disabled', () => {
-    testContext.setExperimentalFlag({ endpointExceptionsMovedUnderManagement: false });
+  describe('when feature flag is enabled', () => {
+    beforeEach(() => {
+      testContext.setExperimentalFlag({ endpointExceptionsMovedUnderManagement: true });
+    });
 
-    const { result } = testContext.renderHook(() => useGetEndpointExceptionsPerPolicyOptIn());
+    it('should call the API when no params are passed', async () => {
+      const { result } = testContext.renderHook(() => useGetEndpointExceptionsPerPolicyOptIn());
 
-    expect(result.current.data).toBeUndefined();
-    expect(testContext.coreStart.http.get).not.toHaveBeenCalledWith(
-      ENDPOINT_EXCEPTIONS_PER_POLICY_OPT_IN_ROUTE,
-      expect.anything()
-    );
+      await waitFor(() => {
+        expect(result.current.data).toEqual({ status: false });
+        expect(getOptInHttpMock).toHaveBeenCalled();
+      });
+    });
+
+    it('should call the API when empty object is passed', async () => {
+      const { result } = testContext.renderHook(() => useGetEndpointExceptionsPerPolicyOptIn({}));
+
+      await waitFor(() => {
+        expect(result.current.data).toEqual({ status: false });
+        expect(getOptInHttpMock).toHaveBeenCalled();
+      });
+    });
+
+    it('should call the API when enabled is true', async () => {
+      const { result } = testContext.renderHook(() =>
+        useGetEndpointExceptionsPerPolicyOptIn({ enabled: true })
+      );
+
+      await waitFor(() => {
+        expect(result.current.data).toEqual({ status: false });
+        expect(getOptInHttpMock).toHaveBeenCalled();
+      });
+    });
+
+    it('should not call the API when enabled is false', async () => {
+      const { result } = testContext.renderHook(() =>
+        useGetEndpointExceptionsPerPolicyOptIn({ enabled: false })
+      );
+
+      await waitFor(() => {
+        expect(result.current.data).toBeUndefined();
+        expect(getOptInHttpMock).not.toHaveBeenCalled();
+      });
+    });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/management/hooks/artifacts/use_endpoint_per_policy_opt_in.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/hooks/artifacts/use_endpoint_per_policy_opt_in.ts
@@ -21,7 +21,9 @@ export const useSendEndpointExceptionsPerPolicyOptIn = () => {
   });
 };
 
-export const useGetEndpointExceptionsPerPolicyOptIn = (): UseQueryResult<
+export const useGetEndpointExceptionsPerPolicyOptIn = ({
+  enabled = true,
+}: { enabled?: boolean } = {}): UseQueryResult<
   GetEndpointExceptionsPerPolicyOptInResponse,
   Error
 > => {
@@ -32,7 +34,7 @@ export const useGetEndpointExceptionsPerPolicyOptIn = (): UseQueryResult<
 
   return useQuery<GetEndpointExceptionsPerPolicyOptInResponse, Error>({
     queryKey: ['endpointExceptionsPerPolicyOptIn'],
-    enabled: isEndpointExceptionsMovedUnderManagementFFEnabled,
+    enabled: isEndpointExceptionsMovedUnderManagementFFEnabled && enabled,
     queryFn: async () =>
       http.get<GetEndpointExceptionsPerPolicyOptInResponse>(
         ENDPOINT_EXCEPTIONS_PER_POLICY_OPT_IN_ROUTE,

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/endpoint_exceptions/view/endpoint_exceptions.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/endpoint_exceptions/view/endpoint_exceptions.test.tsx
@@ -16,15 +16,20 @@ import { getEndpointAuthzInitialStateMock } from '../../../../../common/endpoint
 import { exceptionsListAllHttpMocks } from '../../../mocks';
 import { endpointExceptionsPerPolicyOptInAllHttpMocks } from '../../../mocks/endpoint_per_policy_opt_in_http_mocks';
 import userEvent from '@testing-library/user-event';
+import { useEndpointExceptionsCapability } from '../../../../exceptions/hooks/use_endpoint_exceptions_capability';
 
 jest.mock('../../../../common/components/user_privileges');
 const mockUserPrivileges = useUserPrivileges as jest.Mock;
+
+jest.mock('../../../../exceptions/hooks/use_endpoint_exceptions_capability');
+const mockUseEndpointExceptionsCapability = useEndpointExceptionsCapability as jest.Mock;
 
 describe('When on the endpoint exceptions page', () => {
   let render: () => ReturnType<AppContextTestRender['render']>;
   let renderResult: ReturnType<typeof render>;
   let history: AppContextTestRender['history'];
   let mockedContext: AppContextTestRender;
+  let mockCanCreateEndpointExceptions: boolean;
 
   beforeEach(() => {
     mockedContext = createAppRootMockRenderer();
@@ -36,10 +41,19 @@ describe('When on the endpoint exceptions page', () => {
     act(() => {
       history.push(ENDPOINT_EXCEPTIONS_PATH);
     });
+
+    mockCanCreateEndpointExceptions = true;
+    mockUseEndpointExceptionsCapability.mockImplementation((capability: string) => {
+      if (capability === 'crudEndpointExceptions') {
+        return mockCanCreateEndpointExceptions;
+      }
+
+      return true;
+    });
   });
 
   afterEach(() => {
-    mockUserPrivileges.mockReset();
+    jest.clearAllMocks();
   });
 
   describe('And no data exists', () => {
@@ -58,10 +72,11 @@ describe('When on the endpoint exceptions page', () => {
       beforeEach(() => {
         mockUserPrivileges.mockReturnValue({
           endpointPrivileges: getEndpointAuthzInitialStateMock({
-            canWriteEndpointExceptions: true,
             canWriteAdminData: false,
+            canWriteEndpointExceptions: true,
           }),
         });
+        mockCanCreateEndpointExceptions = true;
       });
 
       it('should enable adding entries', async () => {
@@ -75,14 +90,16 @@ describe('When on the endpoint exceptions page', () => {
       });
     });
 
-    describe('READ privilege', () => {
+    describe('READ privilege - or ALL privilege without global write before per-policy opt-in', () => {
       beforeEach(() => {
         mockUserPrivileges.mockReturnValue({
           endpointPrivileges: getEndpointAuthzInitialStateMock({
-            canWriteEndpointExceptions: false,
             canWriteAdminData: false,
+            canWriteEndpointExceptions: true,
           }),
         });
+
+        mockCanCreateEndpointExceptions = false;
       });
 
       it('should disable adding entries', async () => {
@@ -129,10 +146,10 @@ describe('When on the endpoint exceptions page', () => {
 
       mockUserPrivileges.mockReturnValue({
         endpointPrivileges: getEndpointAuthzInitialStateMock({
-          canWriteEndpointExceptions: true,
           canWriteAdminData: true,
         }),
       });
+      mockCanCreateEndpointExceptions = true;
     });
 
     describe('when there are no exceptions', () => {
@@ -327,10 +344,10 @@ describe('When on the endpoint exceptions page', () => {
           beforeEach(() => {
             mockUserPrivileges.mockReturnValue({
               endpointPrivileges: getEndpointAuthzInitialStateMock({
-                canWriteEndpointExceptions: true,
                 canWriteAdminData: true,
               }),
             });
+            mockCanCreateEndpointExceptions = true;
           });
 
           it('should show the update details button', async () => {
@@ -359,10 +376,10 @@ describe('When on the endpoint exceptions page', () => {
           beforeEach(() => {
             mockUserPrivileges.mockReturnValue({
               endpointPrivileges: getEndpointAuthzInitialStateMock({
-                canWriteEndpointExceptions: true,
                 canWriteAdminData: false,
               }),
             });
+            mockCanCreateEndpointExceptions = true;
           });
 
           it('should show "Contact your admin" instead of the update details button', async () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/endpoint_exceptions/view/endpoint_exceptions.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/endpoint_exceptions/view/endpoint_exceptions.tsx
@@ -8,6 +8,7 @@
 import React, { memo } from 'react';
 
 import { useUserPrivileges } from '../../../../common/components/user_privileges';
+import { useEndpointExceptionsCapability } from '../../../../exceptions/hooks/use_endpoint_exceptions_capability';
 import { useHttp } from '../../../../common/lib/kibana';
 import { ArtifactListPage } from '../../../components/artifact_list_page';
 import { EndpointExceptionsForm } from './components/endpoint_exceptions_form';
@@ -17,7 +18,10 @@ import { ENDPOINT_EXCEPTIONS_PAGE_LABELS } from '../translations';
 import { usePerPolicyOptIn } from '../hooks/use_per_policy_opt_in';
 
 export const EndpointExceptions = memo(() => {
-  const { canWriteEndpointExceptions } = useUserPrivileges().endpointPrivileges;
+  const { canWriteEndpointExceptions: hasWritePrivilege } = useUserPrivileges().endpointPrivileges;
+
+  const canCreateEndpointExceptions = useEndpointExceptionsCapability('crudEndpointExceptions');
+
   const http = useHttp();
   const endpointExceptionsApiClient = EndpointExceptionsApiClient.getInstance(http);
 
@@ -34,9 +38,12 @@ export const EndpointExceptions = memo(() => {
         data-test-subj="endpointExceptionsListPage"
         searchableFields={ENDPOINT_EXCEPTIONS_SEARCHABLE_FIELDS}
         flyoutSize="l"
-        allowCardCreateAction={canWriteEndpointExceptions}
-        allowCardEditAction={canWriteEndpointExceptions}
-        allowCardDeleteAction={canWriteEndpointExceptions}
+        // hide Create button before opt-in w/o global privilege, show after opt-in w/o global privilege
+        allowCardCreateAction={canCreateEndpointExceptions}
+        // allow showing these before opt-in w/o global privilege, so they will be greyed based on
+        // all existing artifacts being global, therefore showing user the 'needs additional priv' hint
+        allowCardEditAction={hasWritePrivilege}
+        allowCardDeleteAction={hasWritePrivilege}
         callout={perPolicyOptInCallout}
         additionalActions={
           perPolicyOptInActionMenuItem ? [perPolicyOptInActionMenuItem] : undefined


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[EDR Workflows] Adapt endpoint exception privileges on alert pages (#263808)](https://github.com/elastic/kibana/pull/263808)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Gergő Ábrahám","email":"gergo.abraham@elastic.co"},"sourceCommit":{"committedDate":"2026-04-21T09:54:20Z","message":"[EDR Workflows] Adapt endpoint exception privileges on alert pages (#263808)\n\n## Summary\n\nThis PR fixes some privilege inconsistencies around Endpoint exceptions\nand their per-policy opt-in mechanism.\n\n### Before opting in - on the new Endpoint Exceptions page\n- [x] Create button is hidden, import button is disabled for users\nwithout Global artifact management privilege\n- [x] 3 dots card action button is disabled and shows the hint that\nglobal artifact privilege is needed\n\n\nhttps://github.com/user-attachments/assets/db4b49c2-15c6-48db-bd83-2a280a58d18e\n\n### After opting in - on Alerts page\n- [x] User is able to create an Endpoint exception from an alert without\nGlobal artifact privilege\n\n\nhttps://github.com/user-attachments/assets/44e8da53-5f97-423c-a1cb-e8c5617f2527\n\n## Testing\n- start up ESS+Kibana without any FF (so an empty endpoint exception\nlist is created)\n\n- enable the following FF afterwards, to ensure that you use an\n'upgraded environment' without opting in to per-policy Endpoint\nexceptions\n  ```\n  xpack.securitySolution.enableExperimental:\n  - endpointExceptionsMovedUnderManagement\n  ```\n- for opt-in: go to Manage / Artifacts / Endpoint exceptions, and follow\nthe opt-in steps (https://github.com/elastic/kibana/pull/259598)\n\nYou can also delete the opt-in status in Dev Console with a\nsystem_indices_superuser:\n```\nDELETE .kibana_security_solution/_doc/security:reference-data:ENDPOINT-EXCEPTIONS-PER-POLICY-OPT-IN-STATUS\n```\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"b96b67c5a2fce4699a696fd59f28a653305716fd","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Defend Workflows","backport:version","v9.4.0","v9.5.0"],"title":"[EDR Workflows] Adapt endpoint exception privileges on alert pages","number":263808,"url":"https://github.com/elastic/kibana/pull/263808","mergeCommit":{"message":"[EDR Workflows] Adapt endpoint exception privileges on alert pages (#263808)\n\n## Summary\n\nThis PR fixes some privilege inconsistencies around Endpoint exceptions\nand their per-policy opt-in mechanism.\n\n### Before opting in - on the new Endpoint Exceptions page\n- [x] Create button is hidden, import button is disabled for users\nwithout Global artifact management privilege\n- [x] 3 dots card action button is disabled and shows the hint that\nglobal artifact privilege is needed\n\n\nhttps://github.com/user-attachments/assets/db4b49c2-15c6-48db-bd83-2a280a58d18e\n\n### After opting in - on Alerts page\n- [x] User is able to create an Endpoint exception from an alert without\nGlobal artifact privilege\n\n\nhttps://github.com/user-attachments/assets/44e8da53-5f97-423c-a1cb-e8c5617f2527\n\n## Testing\n- start up ESS+Kibana without any FF (so an empty endpoint exception\nlist is created)\n\n- enable the following FF afterwards, to ensure that you use an\n'upgraded environment' without opting in to per-policy Endpoint\nexceptions\n  ```\n  xpack.securitySolution.enableExperimental:\n  - endpointExceptionsMovedUnderManagement\n  ```\n- for opt-in: go to Manage / Artifacts / Endpoint exceptions, and follow\nthe opt-in steps (https://github.com/elastic/kibana/pull/259598)\n\nYou can also delete the opt-in status in Dev Console with a\nsystem_indices_superuser:\n```\nDELETE .kibana_security_solution/_doc/security:reference-data:ENDPOINT-EXCEPTIONS-PER-POLICY-OPT-IN-STATUS\n```\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"b96b67c5a2fce4699a696fd59f28a653305716fd"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/263808","number":263808,"mergeCommit":{"message":"[EDR Workflows] Adapt endpoint exception privileges on alert pages (#263808)\n\n## Summary\n\nThis PR fixes some privilege inconsistencies around Endpoint exceptions\nand their per-policy opt-in mechanism.\n\n### Before opting in - on the new Endpoint Exceptions page\n- [x] Create button is hidden, import button is disabled for users\nwithout Global artifact management privilege\n- [x] 3 dots card action button is disabled and shows the hint that\nglobal artifact privilege is needed\n\n\nhttps://github.com/user-attachments/assets/db4b49c2-15c6-48db-bd83-2a280a58d18e\n\n### After opting in - on Alerts page\n- [x] User is able to create an Endpoint exception from an alert without\nGlobal artifact privilege\n\n\nhttps://github.com/user-attachments/assets/44e8da53-5f97-423c-a1cb-e8c5617f2527\n\n## Testing\n- start up ESS+Kibana without any FF (so an empty endpoint exception\nlist is created)\n\n- enable the following FF afterwards, to ensure that you use an\n'upgraded environment' without opting in to per-policy Endpoint\nexceptions\n  ```\n  xpack.securitySolution.enableExperimental:\n  - endpointExceptionsMovedUnderManagement\n  ```\n- for opt-in: go to Manage / Artifacts / Endpoint exceptions, and follow\nthe opt-in steps (https://github.com/elastic/kibana/pull/259598)\n\nYou can also delete the opt-in status in Dev Console with a\nsystem_indices_superuser:\n```\nDELETE .kibana_security_solution/_doc/security:reference-data:ENDPOINT-EXCEPTIONS-PER-POLICY-OPT-IN-STATUS\n```\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"b96b67c5a2fce4699a696fd59f28a653305716fd"}}]}] BACKPORT-->