### PR TITLE
[@kbn/scout] Document gotoApp params and hash options in page objects guide

### DIFF
--- a/docs/extend/scout/page-objects.md
+++ b/docs/extend/scout/page-objects.md
@@ -56,6 +56,16 @@ export class NewPage {
 }
 ```
 
+`gotoApp` accepts an optional second argument with `params` (query string) and `hash` (URL hash):
+
+```ts
+// Navigate to '/app/myPlugin?_g=(time:(from:now-15m,to:now))'
+await this.page.gotoApp('myPlugin', { params: { _g: '(time:(from:now-15m,to:now))' } });
+
+// Navigate to '/app/dashboards#/view/abc-123'
+await this.page.gotoApp('dashboards', { hash: '/view/abc-123' });
+```
+
 :::::::::
 
 :::::::::{step} Register a plugin page object


### PR DESCRIPTION
## Summary

Documents the optional `params` (query string) and `hash` arguments for `gotoApp` in the Scout page objects guide ([context](https://github.com/elastic/kibana/pull/254635#discussion_r2845388428)).

## Changes

- Added usage examples for `gotoApp` with `params` and `hash` options in the page object creation step