### PR TITLE
[Entity Analytics][Watchlists] Clean up entity store and watchlist index on watchlist deletion

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/entity_sources/entity_sources_service.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/entity_sources/entity_sources_service.ts
@@ -164,9 +164,14 @@ export const createEntitySourcesService = ({
 
   /**
    * Removes entities from orphaned sources (sources that no longer exist but
-   * still have entities in the watchlist index). Skips CSV and active sources.
+   * still have entities in the watchlist index). Skips active sources and any
+   * explicitly ignored source IDs (defaults to skipping MANUAL_SOURCE_ID).
    */
-  const cleanupOrphanedEntities = async (meta: WatchlistMeta, activeSourceIds: string[] = []) => {
+  const cleanupOrphanedEntities = async (
+    meta: WatchlistMeta,
+    activeSourceIds: string[] = [],
+    ignoredSourceIds: string[] = [MANUAL_SOURCE_ID]
+  ) => {
     const aggResponse = await esClient.search({
       index: meta.index,
       size: 0,
@@ -176,7 +181,7 @@ export const createEntitySourcesService = ({
       },
     });
 
-    const excludedIds = new Set([MANUAL_SOURCE_ID, ...activeSourceIds]);
+    const excludedIds = new Set([...ignoredSourceIds, ...activeSourceIds]);
     const orphanedSourceIds: string[] = (
       (aggResponse.aggregations?.source_ids as { buckets: Array<{ key: string }> })?.buckets ?? []
     )
@@ -285,5 +290,16 @@ export const createEntitySourcesService = ({
     );
   };
 
-  return { syncWatchlist, syncAllWatchlists };
+  const deleteWatchlistEntities = async (watchlistId: string) => {
+    const watchlist = await watchlistClient.get(watchlistId);
+    const meta: WatchlistMeta = {
+      name: watchlist.name,
+      id: watchlist.id || watchlistId,
+      index: getIndexForWatchlist(namespace),
+    };
+    // Pass empty ignoredSourceIds so all sources — including manual — are treated as orphaned.
+    await cleanupOrphanedEntities(meta, [], []);
+  };
+
+  return { syncWatchlist, syncAllWatchlists, deleteWatchlistEntities };
 };

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/management/routes/delete.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/management/routes/delete.ts
@@ -15,6 +15,7 @@ import { withMinimumLicense } from '../../../utils/with_minimum_license';
 import { GetWatchlistRequestParams as WatchlistIdParams } from '../../../../../../common/api/entity_analytics/watchlists/management/get.gen';
 import { WatchlistConfigClient } from '../watchlist_config';
 import { getRequestSavedObjectClient } from '../../shared/utils';
+import { createEntitySourcesService } from '../../entity_sources/entity_sources_service';
 
 interface DeleteWatchlistResponse {
   deleted: true;
@@ -50,10 +51,25 @@ export const deleteWatchlistRoute = (
             const secSol = await context.securitySolution;
             const core = await context.core;
 
+            const namespace = secSol.getSpaceId();
+            const soClient = getRequestSavedObjectClient(core);
+            const esClient = core.elasticsearch.client.asCurrentUser;
+
+            const entitySourcesService = createEntitySourcesService({
+              namespace,
+              soClient,
+              esClient,
+              logger,
+            });
+
+            // Clean up entities from the watchlist index and entity store before
+            // removing the saved objects, so we can still resolve the watchlist name.
+            await entitySourcesService.deleteWatchlistEntities(request.params.id);
+
             const watchlistClient = new WatchlistConfigClient({
-              namespace: secSol.getSpaceId(),
-              soClient: getRequestSavedObjectClient(core),
-              esClient: core.elasticsearch.client.asCurrentUser,
+              namespace,
+              soClient,
+              esClient,
               logger,
             });
             await watchlistClient.delete(request.params.id);


### PR DESCRIPTION
## Summary

When a watchlist was deleted, entities in the watchlist index and their watchlist membership in the entity store (`entity.attributes.watchlists`) were not immediately removed — cleanup only happened asynchronously during the next periodic sync cycle. This PR hooks the existing orphan cleanup logic into the delete API so the store reflects the correct state immediately upon deletion. To support cleaning up manually assigned entities (which were previously excluded from orphan cleanup by design), `cleanupOrphanedEntities` now takes an optional `ignoredSourceIds` parameter (defaults to `[MANUAL_SOURCE_ID]`, so all existing sync call sites are unaffected) and the delete path passes an empty array.

## How to test

1. Seed your ES instance with store data using the script and steps from [here](https://github.com/elastic/kibana/pull/263058#issue-2953433017).

2. Create a watchlist and assign some entities to it (either via the assign API or CSV upload):
```
POST kbn:/api/entity_analytics/watchlists
{
  "name": "Delete Test Watchlist",
  "riskModifier": 1.5
}
```

3. Confirm entities exist in both places:
```
GET .entity_analytics.watchlists.default/_search
{
  "query": { "term": { "watchlist.id": "<your-watchlist-id>" } }
}
```
```
POST _query?format=txt
{
  "query": "FROM .entities.v2.latest.security_default* | WHERE ARRAY_CONTAINS(entity.attributes.watchlists, \"<your-watchlist-id>\") | KEEP entity.id, entity.attributes.watchlists"
}
```

4. Delete the watchlist:
```
DELETE kbn:/api/entity_analytics/watchlists/<your-watchlist-id>
```

5. Re-run the queries from step 3 and verify both return no results — without waiting for the sync task to run.

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->