### PR TITLE
[Entity Resolution] Clarify CSV upload result for already-linked entities

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution_file_uploader/components/result_step.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution_file_uploader/components/result_step.tsx
@@ -23,6 +23,7 @@ export const EntityResolutionResultStep: React.FC<ResultStepProps> = React.memo(
         <>
           <EuiSpacer size="m" />
           <EuiCallOut
+            announceOnMount
             title={
               <FormattedMessage
                 defaultMessage="Upload failed"
@@ -53,6 +54,7 @@ export const EntityResolutionResultStep: React.FC<ResultStepProps> = React.memo(
         <EuiSpacer size="m" />
         {allSuccessful && (
           <EuiCallOut
+            announceOnMount
             title={
               <FormattedMessage
                 defaultMessage="All {total} {total, plural, one {row} other {rows}} processed successfully"
@@ -69,6 +71,7 @@ export const EntityResolutionResultStep: React.FC<ResultStepProps> = React.memo(
 
         {partialSuccess && (
           <EuiCallOut
+            announceOnMount
             title={
               <FormattedMessage
                 defaultMessage="Partial upload: {successful} of {total} {total, plural, one {row} other {rows}} successful"
@@ -85,6 +88,7 @@ export const EntityResolutionResultStep: React.FC<ResultStepProps> = React.memo(
 
         {allFailed && (
           <EuiCallOut
+            announceOnMount
             title={
               <FormattedMessage
                 defaultMessage="Upload completed with no successful links"
@@ -114,37 +118,53 @@ export const EntityResolutionResultStep: React.FC<ResultStepProps> = React.memo(
 
 EntityResolutionResultStep.displayName = 'EntityResolutionResultStep';
 
-const ResultStats: React.FC<{ result: ResolutionCsvUploadResponse }> = ({ result }) => (
-  <EuiText size="s">
-    <ul>
-      <li>
-        <FormattedMessage
-          defaultMessage="{count} {count, plural, one {row} other {rows}} linked successfully"
-          id="xpack.securitySolution.entityAnalytics.entityResolutionUpload.successCount"
-          values={{ count: result.successful }}
-        />
-      </li>
-      {result.unmatched > 0 && (
-        <li>
-          <FormattedMessage
-            defaultMessage="{count} {count, plural, one {row} other {rows}} had no matching entities"
-            id="xpack.securitySolution.entityAnalytics.entityResolutionUpload.unmatchedCount"
-            values={{ count: result.unmatched }}
-          />
-        </li>
-      )}
-      {result.failed > 0 && (
-        <li>
-          <FormattedMessage
-            defaultMessage="{count} {count, plural, one {row} other {rows}} failed"
-            id="xpack.securitySolution.entityAnalytics.entityResolutionUpload.failedCount"
-            values={{ count: result.failed }}
-          />
-        </li>
-      )}
-    </ul>
-  </EuiText>
-);
+const ResultStats: React.FC<{ result: ResolutionCsvUploadResponse }> = ({ result }) => {
+  const totalSkipped = result.items.reduce((sum, item) => sum + item.skippedEntities, 0);
+  const totalLinked = result.items.reduce((sum, item) => sum + item.linkedEntities, 0);
+
+  return (
+    <EuiText size="s">
+      <ul>
+        {totalLinked > 0 && (
+          <li>
+            <FormattedMessage
+              defaultMessage="{count} {count, plural, one {entity} other {entities}} linked successfully"
+              id="xpack.securitySolution.entityAnalytics.entityResolutionUpload.successCount"
+              values={{ count: totalLinked }}
+            />
+          </li>
+        )}
+        {totalSkipped > 0 && (
+          <li>
+            <FormattedMessage
+              defaultMessage="{count} already linked {count, plural, one {entity} other {entities}} ignored"
+              id="xpack.securitySolution.entityAnalytics.entityResolutionUpload.skippedCount"
+              values={{ count: totalSkipped }}
+            />
+          </li>
+        )}
+        {result.unmatched > 0 && (
+          <li>
+            <FormattedMessage
+              defaultMessage="{count} {count, plural, one {row} other {rows}} had no matching entities"
+              id="xpack.securitySolution.entityAnalytics.entityResolutionUpload.unmatchedCount"
+              values={{ count: result.unmatched }}
+            />
+          </li>
+        )}
+        {result.failed > 0 && (
+          <li>
+            <FormattedMessage
+              defaultMessage="{count} {count, plural, one {row} other {rows}} failed"
+              id="xpack.securitySolution.entityAnalytics.entityResolutionUpload.failedCount"
+              values={{ count: result.failed }}
+            />
+          </li>
+        )}
+      </ul>
+    </EuiText>
+  );
+};
 
 const ResultDetails: React.FC<{ result: ResolutionCsvUploadResponse }> = ({ result }) => {
   const problemRows = result.items


### PR DESCRIPTION
## Summary

Improves the CSV upload result message to make idempotent behavior clear. Previously, re-importing a CSV showed "X rows linked successfully" even when all entities were already linked — which was misleading. Now the result shows separate counts:

- "X entities linked successfully" (only when new links were created)
- "X already linked entities ignored" (when entities were already resolved)

This addresses QA feedback from https://github.com/elastic/security-team/issues/16287#issuecomment-4287824314.

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Low risk — UI-only wording change in CSV upload result summary. No backend or API changes.