### PR TITLE
[codeowners] Enforce specific file ownerships within .buildkite/*

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3336,12 +3336,15 @@ x-pack/solutions/observability/plugins/synthetics/server/saved_objects/synthetic
 /src/cli_keystore/ @elastic/kibana-operations
 /.github/workflows/ @elastic/kibana-operations
 /.buildkite/ @elastic/kibana-operations
+/moon.yml @elastic/kibana-operations
+/.coderabbit.yml @elastic/kibana-operations
+
+# Buildkite specific owners overrides
+/.buildkite/scripts/steps/security/third_party_packages.txt @elastic/kibana-security
 
 # Evals (Buildkite + scripts)
 /.buildkite/pipelines/evals/ @elastic/obs-ai-team @elastic/security-generative-ai
 /.buildkite/scripts/steps/evals/ @elastic/obs-ai-team @elastic/security-generative-ai
-/.coderabbit.yml @elastic/kibana-operations
-/moon.yml @elastic/kibana-operations
 
 ####
 ## These rules are always last so they take ultimate priority over everything else

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1885,9 +1885,6 @@ x-pack/platform/plugins/shared/streams/test/scout/api/tests/sig_events @elastic/
 /x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests @elastic/obs-sig-events-team @elastic/obs-onboarding-team
 /x-pack/performance/configs/streams_* @elastic/obs-sig-events-team @elastic/obs-onboarding-team
 /x-pack/performance/journeys_e2e/streams_* @elastic/obs-sig-events-team @elastic/obs-onboarding-team
-/.buildkite/pipelines/performance/streams_weekly.yml @elastic/obs-sig-events-team @elastic/obs-onboarding-team
-/.buildkite/pipeline-resource-definitions/kibana-streams-performance-weekly.yml @elastic/obs-sig-events-team @elastic/obs-onboarding-team
-
 
 # Alerting alerting_v2
 /x-pack/platform/test/api_integration_deployment_agnostic/apis/alerting_v2 @elastic/rna-project-team
@@ -1983,13 +1980,6 @@ x-pack/platform/plugins/shared/ml/server/models/data_recognizer/modules/security
 /x-pack/platform/test/functional/services/transform @elastic/kibana-management
 /x-pack/platform/test/functional_basic/apps/transform/ @elastic/kibana-management
 
-/.buildkite/scripts/steps/esql_generate_function_metadata.sh @elastic/kibana-esql
-/.buildkite/pipelines/esql_grammar_sync.yml @elastic/kibana-esql
-/.buildkite/scripts/steps/code_generation/security_solution_codegen.sh @elastic/security-detection-rule-management
-/.buildkite/scripts/steps/code_generation/cases_codegen.sh @elastic/kibana-cases
-/.buildkite/scripts/steps/security @elastic/kibana-security
-/.buildkite/scripts/steps/entity_store_performance @elastic/contextual-security
-/.buildkite/scripts/steps/test/scout/ @elastic/appex-qa @elastic/kibana-operations
 /kbn_pm/ @elastic/kibana-operations
 /x-pack/dev-tools @elastic/kibana-operations
 /catalog-info.yaml @elastic/kibana-operations @elastic/kibana-tech-leads
@@ -1999,7 +1989,6 @@ x-pack/platform/plugins/shared/ml/server/models/data_recognizer/modules/security
 /src/platform/packages/shared/kbn-lazy-object @elastic/kibana-operations @elastic/observability-ui
 
 # QA - AppEx QA
-.buildkite/scout_ci_config.yml @elastic/appex-qa
 /docs/extend/scout.md @elastic/appex-qa
 /docs/extend/scout/** @elastic/appex-qa
 /x-pack/platform/test/index.d.ts @elastic/appex-qa
@@ -3276,9 +3265,6 @@ x-pack/solutions/observability/plugins/synthetics/server/saved_objects/synthetic
 x-pack/solutions/observability/plugins/synthetics/server/saved_objects/synthetics_param.ts @elastic/actionable-obs-team @elastic/kibana-security
 
 # OpenTelemetry semantic conventions Buildkite pipeline and scripts
-/.buildkite/pipeline-resource-definitions/kibana-otel-semconv-sync.yml @elastic/obs-onboarding-team
-/.buildkite/pipelines/otel_semconv_sync.yml @elastic/obs-onboarding-team
-/.buildkite/scripts/steps/otel_semconv_sync.sh @elastic/obs-onboarding-team
 /scripts/generate_otel_semconv.js @elastic/obs-onboarding-team
 
 # Specialised GitHub workflows for the Observability robots
@@ -3339,8 +3325,20 @@ x-pack/solutions/observability/plugins/synthetics/server/saved_objects/synthetic
 /moon.yml @elastic/kibana-operations
 /.coderabbit.yml @elastic/kibana-operations
 
-# Buildkite specific owners overrides
-/.buildkite/scripts/steps/security/third_party_packages.txt @elastic/kibana-security
+# Buildkite overrides, and ownership shares
+/.buildkite/pipelines/performance/streams_weekly.yml @elastic/obs-sig-events-team @elastic/obs-onboarding-team
+/.buildkite/pipeline-resource-definitions/kibana-otel-semconv-sync.yml @elastic/obs-onboarding-team
+/.buildkite/pipeline-resource-definitions/kibana-streams-performance-weekly.yml @elastic/obs-sig-events-team @elastic/obs-onboarding-team
+/.buildkite/pipelines/otel_semconv_sync.yml @elastic/obs-onboarding-team
+/.buildkite/scripts/steps/otel_semconv_sync.sh @elastic/obs-onboarding-team
+/.buildkite/scripts/steps/esql_generate_function_metadata.sh @elastic/kibana-esql
+/.buildkite/pipelines/esql_grammar_sync.yml @elastic/kibana-esql
+/.buildkite/scripts/steps/code_generation/security_solution_codegen.sh @elastic/security-detection-rule-management
+/.buildkite/scripts/steps/code_generation/cases_codegen.sh @elastic/kibana-cases
+/.buildkite/scripts/steps/security @elastic/kibana-security
+/.buildkite/scripts/steps/entity_store_performance @elastic/contextual-security
+/.buildkite/scripts/steps/test/scout/ @elastic/appex-qa @elastic/kibana-operations
+/.buildkite/scout_ci_config.yml @elastic/appex-qa
 
 # Evals (Buildkite + scripts)
 /.buildkite/pipelines/evals/ @elastic/obs-ai-team @elastic/security-generative-ai


### PR DESCRIPTION
## Summary
In https://github.com/elastic/kibana/pull/256594 a block of @elastic/kibana-operations ownerships were moved towards the bottom of the file. This caused a `/.buildkite/` statement to override any specialized ownerships within the folder back to Operations. 

This PR moves these overrides blocks from across the file to below the operations block, so specific file ownerships can be preserved.