### PR TITLE
[Streams] Add CODEOWNERS overrides for sig events features and queries

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1747,6 +1747,8 @@ x-pack/platform/plugins/shared/streams/server/lib/streams/lifecycle/ilm_phases.t
 x-pack/platform/plugins/shared/streams_app/public/components/sig_events @elastic/obs-sig-events-team
 x-pack/platform/plugins/shared/streams_app/public/hooks/sig_events @elastic/obs-sig-events-team
 x-pack/platform/plugins/shared/streams/server/lib/sig_events @elastic/obs-sig-events-team
+x-pack/platform/plugins/shared/streams/server/lib/streams/feature @elastic/obs-sig-events-team
+x-pack/platform/plugins/shared/streams/server/lib/tasks/task_definitions/features_identification @elastic/obs-sig-events-team
 x-pack/platform/plugins/shared/streams/server/routes/sig_events @elastic/obs-sig-events-team
 x-pack/platform/plugins/shared/streams/server/routes/internal/sig_events @elastic/obs-sig-events-team
 x-pack/platform/plugins/shared/streams/test/scout/api/tests/sig_events @elastic/obs-sig-events-team

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1744,9 +1744,18 @@ x-pack/platform/plugins/shared/streams/server/lib/streams/lifecycle/ilm_phases.t
 x-pack/platform/plugins/shared/streams/server/lib/streams/lifecycle/ilm_phases.test.ts @elastic/kibana-management
 
 # Streams — sig events overrides (obs-sig-events-team owns these subtrees)
+# schemas
+x-pack/platform/packages/shared/kbn-streams-schema/src/api/features @elastic/obs-sig-events-team
+x-pack/platform/packages/shared/kbn-streams-schema/src/api/significant_events @elastic/obs-sig-events-team
+x-pack/platform/packages/shared/kbn-streams-schema/src/feature.ts @elastic/obs-sig-events-team
+x-pack/platform/packages/shared/kbn-streams-schema/src/inference_feature_ids.ts @elastic/obs-sig-events-team
+x-pack/platform/packages/shared/kbn-streams-schema/src/queries @elastic/obs-sig-events-team
+# app
 x-pack/platform/plugins/shared/streams_app/public/components/sig_events @elastic/obs-sig-events-team
 x-pack/platform/plugins/shared/streams_app/public/hooks/sig_events @elastic/obs-sig-events-team
+# server
 x-pack/platform/plugins/shared/streams/server/lib/sig_events @elastic/obs-sig-events-team
+x-pack/platform/plugins/shared/streams/server/lib/streams/assets/query @elastic/obs-sig-events-team
 x-pack/platform/plugins/shared/streams/server/lib/streams/feature @elastic/obs-sig-events-team
 x-pack/platform/plugins/shared/streams/server/lib/tasks/task_definitions/features_identification @elastic/obs-sig-events-team
 x-pack/platform/plugins/shared/streams/server/routes/sig_events @elastic/obs-sig-events-team


### PR DESCRIPTION
## Summary

Adds CODEOWNERS overrides so `@elastic/obs-sig-events-team` is sole owner for sig events subtrees:

**Schemas** (`kbn-streams-schema/src/`):
- `api/features/`
- `api/significant_events/`
- `feature.ts`
- `inference_feature_ids.ts`
- `queries/`

**Server** (`streams/server/`):
- `lib/streams/assets/query/`
- `lib/streams/feature/`
- `lib/tasks/task_definitions/features_identification/`

These paths were previously covered by the general `streams` rule (both onboarding + sig-events). Now matches the pattern of existing `sig_events/` overrides.