### PR TITLE
Batch large terms queries for lead gen

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/lead_generation/observation_modules/behavioral_analysis_module.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/lead_generation/observation_modules/behavioral_analysis_module.test.ts
@@ -8,6 +8,7 @@
 import { elasticsearchClientMock } from '@kbn/core-elasticsearch-client-server-mocks';
 import { loggingSystemMock } from '@kbn/core/server/mocks';
 import { createBehavioralAnalysisModule } from './behavioral_analysis_module';
+import { DEFAULT_MAX_TERMS_QUERY_COUNT } from '../../utils/elasticsearch_terms_limits';
 import type { LeadEntity } from '../types';
 
 const createEntity = (type: string, name: string, email?: string): LeadEntity => ({
@@ -330,5 +331,63 @@ describe('BehavioralAnalysisModule', () => {
     expect(logger.warn).toHaveBeenCalledWith(
       expect.stringContaining('Failed to fetch alert summaries')
     );
+  });
+
+  describe('large entity volumes (P90+ scale)', () => {
+    it('batches the terms query so a single type never exceeds the ES max_terms_count limit', async () => {
+      const totalEntities = DEFAULT_MAX_TERMS_QUERY_COUNT + 5000;
+      const entities: LeadEntity[] = Array.from({ length: totalEntities }, (_, i) =>
+        createEntity('user', `user-${i}`)
+      );
+
+      esClient.search.mockImplementation((params) => {
+        const query = (params as Record<string, unknown>).query as {
+          bool: { filter: Array<Record<string, unknown>> };
+        };
+        const termsFilter = query.bool.filter.find(
+          (f) => (f.terms as Record<string, unknown> | undefined)?.['user.name']
+        ) as { terms: Record<string, string[]> };
+        const chunk = termsFilter.terms['user.name'];
+
+        // Echo back a bucket for the first name in this chunk only, so we can
+        // prove that every chunk was actually queried and merged (not just the last one).
+        return Promise.resolve(
+          createAlertAggResponse([
+            {
+              key: chunk[0],
+              docCount: 12,
+              severities: { high: 12 },
+              rules: ['Rule A'],
+              maxRiskScore: 80,
+            },
+          ]) as never
+        );
+      });
+
+      const module = createBehavioralAnalysisModule({ esClient, logger, alertsIndexPattern });
+      const observations = await module.collect(entities);
+
+      // ceil(70535 / 65535) = 2 queries for the single 'user' type
+      expect(esClient.search).toHaveBeenCalledTimes(2);
+
+      for (const [params] of esClient.search.mock.calls) {
+        const query = (params as Record<string, unknown>).query as {
+          bool: { filter: Array<Record<string, unknown>> };
+        };
+        const termsFilter = query.bool.filter.find(
+          (f) => (f.terms as Record<string, unknown> | undefined)?.['user.name']
+        ) as { terms: Record<string, string[]> };
+        expect(termsFilter.terms['user.name'].length).toBeLessThanOrEqual(
+          DEFAULT_MAX_TERMS_QUERY_COUNT
+        );
+      }
+
+      // The entity that triggered the first chunk and the entity that triggered the
+      // second chunk both need observations, proving results from every batch made it back.
+      expect(observations.some((o) => o.entityId === 'user:user-0')).toBe(true);
+      expect(
+        observations.some((o) => o.entityId === `user:user-${DEFAULT_MAX_TERMS_QUERY_COUNT}`)
+      ).toBe(true);
+    });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/lead_generation/observation_modules/behavioral_analysis_module/data_access.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/lead_generation/observation_modules/behavioral_analysis_module/data_access.ts
@@ -7,6 +7,7 @@
 
 import type { ElasticsearchClient, Logger } from '@kbn/core/server';
 import type { LeadEntity } from '../../types';
+import { DEFAULT_MAX_TERMS_QUERY_COUNT } from '../../../utils/elasticsearch_terms_limits';
 import { parseAlertBuckets } from '../types';
 import { ALERT_ENTITY_TYPES, ALERT_LOOKBACK, MODULE_ID, type AlertSummary } from './config';
 
@@ -77,43 +78,42 @@ export const fetchAlertSummariesForEntities = async (
     }
   }
 
-  const entityTerms: Array<Record<string, unknown>> = Object.entries(namesByType)
-    .filter(([, names]) => names.length > 0)
-    .map(([type, names]) => ({ terms: { [`${type}.name`]: names } }));
-  if (entityTerms.length === 0) return result;
+  if (Object.keys(namesByType).length === 0) return result;
 
   try {
-    const response = await esClient.search({
-      index: alertsIndexPattern,
-      size: 0,
-      ignore_unavailable: true,
-      allow_no_indices: true,
-      query: {
-        bool: {
-          filter: [
-            { bool: { should: entityTerms, minimum_should_match: 1 } },
-            { terms: { 'kibana.alert.workflow_status': ['open', 'acknowledged'] } },
-            { range: { '@timestamp': { gte: ALERT_LOOKBACK, lte: 'now' } } },
-          ],
-          must_not: [{ exists: { field: 'kibana.alert.building_block_type' } }],
-        },
-      },
-      aggs: Object.fromEntries(
-        Object.keys(namesByType).map((type) => [
-          `by_${type}`,
-          {
-            terms: {
-              field: `${type}.name`,
-              size: Math.min(namesByType[type].length, ENTITY_BUCKET_LIMIT),
-            },
-            aggs: alertSubAggs(),
-          },
-        ])
-      ),
-    });
-
     for (const type of Object.keys(namesByType)) {
-      parseEntityBuckets(response.aggregations?.[`by_${type}`], type, result);
+      const names = namesByType[type];
+      for (let offset = 0; offset < names.length; offset += DEFAULT_MAX_TERMS_QUERY_COUNT) {
+        const chunk = names.slice(offset, offset + DEFAULT_MAX_TERMS_QUERY_COUNT);
+
+        const response = await esClient.search({
+          index: alertsIndexPattern,
+          size: 0,
+          ignore_unavailable: true,
+          allow_no_indices: true,
+          query: {
+            bool: {
+              filter: [
+                { terms: { [`${type}.name`]: chunk } },
+                { terms: { 'kibana.alert.workflow_status': ['open', 'acknowledged'] } },
+                { range: { '@timestamp': { gte: ALERT_LOOKBACK, lte: 'now' } } },
+              ],
+              must_not: [{ exists: { field: 'kibana.alert.building_block_type' } }],
+            },
+          },
+          aggs: {
+            [`by_${type}`]: {
+              terms: {
+                field: `${type}.name`,
+                size: Math.min(chunk.length, ENTITY_BUCKET_LIMIT),
+              },
+              aggs: alertSubAggs(),
+            },
+          },
+        });
+
+        parseEntityBuckets(response.aggregations?.[`by_${type}`], type, result);
+      }
     }
   } catch (error) {
     logger.warn(`[${MODULE_ID}] Failed to fetch alert summaries: ${error}`);

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/lead_generation/observation_modules/temporal_state_module.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/lead_generation/observation_modules/temporal_state_module.test.ts
@@ -10,6 +10,7 @@ import { loggingSystemMock } from '@kbn/core/server/mocks';
 import { createTemporalStateModule } from './temporal_state_module';
 import type { LeadEntity } from '../types';
 import { PRIVILEGED_USER_WATCHLIST_ID } from './utils';
+import { DEFAULT_MAX_TERMS_QUERY_COUNT } from '../../utils/elasticsearch_terms_limits';
 
 const createPrivilegedEntity = (type: string, name: string): LeadEntity => ({
   record: {
@@ -162,5 +163,49 @@ describe('TemporalStateModule', () => {
     expect(logger.warn).toHaveBeenCalledWith(
       expect.stringContaining('Failed to query privilege history')
     );
+  });
+
+  describe('large entity volumes (P90+ scale)', () => {
+    it('batches the terms query so a single type never exceeds the ES max_terms_count limit', async () => {
+      const totalEntities = DEFAULT_MAX_TERMS_QUERY_COUNT + 3000;
+      const entities: LeadEntity[] = Array.from({ length: totalEntities }, (_, i) =>
+        createPrivilegedEntity('user', `user-${i}`)
+      );
+
+      esClient.search.mockImplementation((params) => {
+        const query = (params as Record<string, unknown>).query as {
+          bool: { filter: Array<Record<string, unknown>> };
+        };
+        const termsFilter = query.bool.filter[0] as { terms: Record<string, string[]> };
+        const chunk = termsFilter.terms['user.name'];
+
+        // Report the first name in this chunk as an escalation, proving every
+        // chunk was queried and merged (not just the last one).
+        return Promise.resolve(
+          mockSnapshotResponse([{ key: chunk[0], wasPrivileged: false }]) as never
+        );
+      });
+
+      const module = createTemporalStateModule({ esClient, logger, spaceId });
+      const observations = await module.collect(entities);
+
+      // ceil(68535 / 65535) = 2 queries for the single 'user' type
+      expect(esClient.search).toHaveBeenCalledTimes(2);
+
+      for (const [params] of esClient.search.mock.calls) {
+        const query = (params as Record<string, unknown>).query as {
+          bool: { filter: Array<Record<string, unknown>> };
+        };
+        const termsFilter = query.bool.filter[0] as { terms: Record<string, string[]> };
+        expect(termsFilter.terms['user.name'].length).toBeLessThanOrEqual(
+          DEFAULT_MAX_TERMS_QUERY_COUNT
+        );
+      }
+
+      expect(observations.some((o) => o.entityId === 'user:user-0')).toBe(true);
+      expect(
+        observations.some((o) => o.entityId === `user:user-${DEFAULT_MAX_TERMS_QUERY_COUNT}`)
+      ).toBe(true);
+    });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/lead_generation/observation_modules/temporal_state_module.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/lead_generation/observation_modules/temporal_state_module.ts
@@ -8,6 +8,7 @@
 import type { ElasticsearchClient, Logger } from '@kbn/core/server';
 import { getHistorySnapshotIndexPattern } from '@kbn/entity-store/server';
 import type { LeadEntity, Observation, ObservationModule, ObservationSeverity } from '../types';
+import { DEFAULT_MAX_TERMS_QUERY_COUNT } from '../../utils/elasticsearch_terms_limits';
 import {
   PRIVILEGED_USER_WATCHLIST_ID,
   makeObservation,
@@ -86,48 +87,52 @@ const fetchPrivilegeEscalations = async (
       const historyPattern = getHistorySnapshotIndexPattern(spaceId);
 
       try {
-        const response = await esClient.search({
-          index: historyPattern,
-          size: 0,
-          ignore_unavailable: true,
-          allow_no_indices: true,
-          query: {
-            bool: { filter: [{ terms: { [`${entityType}.name`]: names } }] },
-          },
-          aggs: {
-            by_entity: {
-              terms: { field: `${entityType}.name`, size: names.length },
-              aggs: {
-                oldest_snapshot: {
-                  top_hits: {
-                    size: 1,
-                    sort: [{ '@timestamp': { order: 'asc' } }],
-                    _source: ['entity.attributes.watchlists'],
+        for (let offset = 0; offset < names.length; offset += DEFAULT_MAX_TERMS_QUERY_COUNT) {
+          const nameChunk = names.slice(offset, offset + DEFAULT_MAX_TERMS_QUERY_COUNT);
+
+          const response = await esClient.search({
+            index: historyPattern,
+            size: 0,
+            ignore_unavailable: true,
+            allow_no_indices: true,
+            query: {
+              bool: { filter: [{ terms: { [`${entityType}.name`]: nameChunk } }] },
+            },
+            aggs: {
+              by_entity: {
+                terms: { field: `${entityType}.name`, size: nameChunk.length },
+                aggs: {
+                  oldest_snapshot: {
+                    top_hits: {
+                      size: 1,
+                      sort: [{ '@timestamp': { order: 'asc' } }],
+                      _source: ['entity.attributes.watchlists'],
+                    },
                   },
                 },
               },
             },
-          },
-        });
+          });
 
-        const buckets = ((response.aggregations?.by_entity as Record<string, unknown>)?.buckets ??
-          []) as Array<{
-          key: string;
-          oldest_snapshot: { hits: { hits: Array<{ _source: Record<string, unknown> }> } };
-        }>;
+          const buckets = ((response.aggregations?.by_entity as Record<string, unknown>)?.buckets ??
+            []) as Array<{
+            key: string;
+            oldest_snapshot: { hits: { hits: Array<{ _source: Record<string, unknown> }> } };
+          }>;
 
-        for (const bucket of buckets) {
-          const hit = bucket.oldest_snapshot.hits.hits[0];
-          if (hit) {
-            const entityField = hit._source?.entity as Record<string, unknown> | undefined;
-            const attrs = entityField?.attributes as { watchlists?: string[] } | undefined;
-            const watchlists = Array.isArray(attrs?.watchlists) ? attrs.watchlists : [];
-            const wasPrivileged = watchlists.some(
-              (w) => typeof w === 'string' && w.startsWith(PRIVILEGED_USER_WATCHLIST_ID)
-            );
+          for (const bucket of buckets) {
+            const hit = bucket.oldest_snapshot.hits.hits[0];
+            if (hit) {
+              const entityField = hit._source?.entity as Record<string, unknown> | undefined;
+              const attrs = entityField?.attributes as { watchlists?: string[] } | undefined;
+              const watchlists = Array.isArray(attrs?.watchlists) ? attrs.watchlists : [];
+              const wasPrivileged = watchlists.some(
+                (w) => typeof w === 'string' && w.startsWith(PRIVILEGED_USER_WATCHLIST_ID)
+              );
 
-            if (!wasPrivileged) {
-              escalated.add(`${entityType}:${bucket.key}`);
+              if (!wasPrivileged) {
+                escalated.add(`${entityType}:${bucket.key}`);
+              }
             }
           }
         }

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/risk_score_data_client.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/risk_score_data_client.test.ts
@@ -21,6 +21,7 @@ import { createDataStream } from '../utils/create_datastream';
 
 import * as transforms from '../utils/transforms';
 import { createOrUpdateIndex } from '../utils/create_or_update_index';
+import { DEFAULT_MAX_TERMS_QUERY_COUNT } from '../utils/elasticsearch_terms_limits';
 
 jest.mock('@kbn/alerting-plugin/server', () => ({
   createOrUpdateComponentTemplate: jest.fn(),
@@ -149,6 +150,99 @@ describe('RiskScoreDataClient', () => {
           dynamic: 'false',
         })
       );
+    });
+  });
+
+  describe('getDailyAverageRiskScoreNormSeries', () => {
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('returns an empty map without querying ES when entityNames is empty', async () => {
+      const result = await riskScoreDataClient.getDailyAverageRiskScoreNormSeries({
+        entityType: 'host',
+        entityNames: [],
+      });
+
+      expect(result.size).toBe(0);
+      expect(esClient.search).not.toHaveBeenCalled();
+    });
+
+    it('parses daily average scores per entity, dropping null buckets', async () => {
+      esClient.search.mockResolvedValueOnce({
+        aggregations: {
+          by_entity: {
+            buckets: [
+              {
+                key: 'server-1',
+                scores_over_time: {
+                  buckets: [
+                    { avg_score: { value: 42 } },
+                    { avg_score: { value: null } },
+                    { avg_score: { value: 55 } },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      } as never);
+
+      const result = await riskScoreDataClient.getDailyAverageRiskScoreNormSeries({
+        entityType: 'host',
+        entityNames: ['server-1'],
+      });
+
+      expect(esClient.search).toHaveBeenCalledTimes(1);
+      expect(result.get('host:server-1')).toEqual([42, 55]);
+    });
+
+    it('batches the terms query so a single request never exceeds the ES max_terms_count limit', async () => {
+      const totalEntities = DEFAULT_MAX_TERMS_QUERY_COUNT + 2000;
+      const entityNames = Array.from({ length: totalEntities }, (_, i) => `host-${i}`);
+
+      esClient.search.mockImplementation((params) => {
+        const query = (params as Record<string, unknown>).query as {
+          bool: { filter: Array<Record<string, unknown>> };
+        };
+        const termsFilter = query.bool.filter[0] as { terms: Record<string, string[]> };
+        const chunk = termsFilter.terms['host.name'];
+
+        return Promise.resolve({
+          aggregations: {
+            by_entity: {
+              buckets: [
+                {
+                  key: chunk[0],
+                  scores_over_time: { buckets: [{ avg_score: { value: 10 } }] },
+                },
+              ],
+            },
+          },
+        } as never);
+      });
+
+      const result = await riskScoreDataClient.getDailyAverageRiskScoreNormSeries({
+        entityType: 'host',
+        entityNames,
+      });
+
+      // ceil(67535 / 65535) = 2 queries
+      expect(esClient.search).toHaveBeenCalledTimes(2);
+
+      for (const [params] of esClient.search.mock.calls) {
+        const query = (params as Record<string, unknown>).query as {
+          bool: { filter: Array<Record<string, unknown>> };
+        };
+        const termsFilter = query.bool.filter[0] as { terms: Record<string, string[]> };
+        expect(termsFilter.terms['host.name'].length).toBeLessThanOrEqual(
+          DEFAULT_MAX_TERMS_QUERY_COUNT
+        );
+      }
+
+      // Results from the first chunk and the second chunk both need to survive the merge.
+      expect(result.has('host:host-0')).toBe(true);
+      expect(result.has(`host:host-${DEFAULT_MAX_TERMS_QUERY_COUNT}`)).toBe(true);
     });
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/risk_score_data_client.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/risk_score_data_client.ts
@@ -49,6 +49,7 @@ import {
   createEventIngestedPipeline,
   getIngestPipelineName,
 } from '../utils/event_ingested_pipeline';
+import { DEFAULT_MAX_TERMS_QUERY_COUNT } from '../utils/elasticsearch_terms_limits';
 
 interface RiskScoringDataClientOpts {
   logger: Logger;
@@ -110,45 +111,49 @@ export class RiskScoreDataClient {
     const { esClient, namespace } = this.options;
     const index = getRiskScoreTimeSeriesIndex(namespace);
 
-    const response = await esClient.search({
-      index,
-      size: 0,
-      ignore_unavailable: true,
-      allow_no_indices: true,
-      query: {
-        bool: {
-          filter: [
-            { terms: { [`${entityType}.name`]: [...entityNames] } },
-            { range: { '@timestamp': range } },
-          ],
+    for (let offset = 0; offset < entityNames.length; offset += DEFAULT_MAX_TERMS_QUERY_COUNT) {
+      const batch = entityNames.slice(offset, offset + DEFAULT_MAX_TERMS_QUERY_COUNT);
+
+      const response = await esClient.search({
+        index,
+        size: 0,
+        ignore_unavailable: true,
+        allow_no_indices: true,
+        query: {
+          bool: {
+            filter: [
+              { terms: { [`${entityType}.name`]: [...batch] } },
+              { range: { '@timestamp': range } },
+            ],
+          },
         },
-      },
-      aggs: {
-        by_entity: {
-          terms: { field: `${entityType}.name`, size: entityNames.length },
-          aggs: {
-            scores_over_time: {
-              date_histogram: { field: '@timestamp', calendar_interval: 'day' },
-              aggs: {
-                avg_score: { avg: { field: `${entityType}.risk.calculated_score_norm` } },
+        aggs: {
+          by_entity: {
+            terms: { field: `${entityType}.name`, size: batch.length },
+            aggs: {
+              scores_over_time: {
+                date_histogram: { field: '@timestamp', calendar_interval: 'day' },
+                aggs: {
+                  avg_score: { avg: { field: `${entityType}.risk.calculated_score_norm` } },
+                },
               },
             },
           },
         },
-      },
-    });
+      });
 
-    const buckets = ((response.aggregations?.by_entity as Record<string, unknown>)?.buckets ??
-      []) as Array<{
-      key: string;
-      scores_over_time: { buckets: Array<{ avg_score: { value: number | null } }> };
-    }>;
+      const buckets = ((response.aggregations?.by_entity as Record<string, unknown>)?.buckets ??
+        []) as Array<{
+        key: string;
+        scores_over_time: { buckets: Array<{ avg_score: { value: number | null } }> };
+      }>;
 
-    for (const bucket of buckets) {
-      const scores = bucket.scores_over_time.buckets
-        .map((b) => b.avg_score.value)
-        .filter((v): v is number => v != null);
-      result.set(`${entityType}:${bucket.key}`, scores);
+      for (const bucket of buckets) {
+        const scores = bucket.scores_over_time.buckets
+          .map((b) => b.avg_score.value)
+          .filter((v): v is number => v != null);
+        result.set(`${entityType}:${bucket.key}`, scores);
+      }
     }
 
     return result;

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/utils/elasticsearch_terms_limits.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/utils/elasticsearch_terms_limits.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * Maximum number of terms allowed in a single `terms` query before Elasticsearch
+ * rejects the request. Defaults to `index.max_terms_count` (65536) minus one so we
+ * stay within the default cluster limit without requiring index setting changes.
+ *
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-terms-query.html
+ */
+export const DEFAULT_MAX_TERMS_QUERY_COUNT = 65535;


### PR DESCRIPTION
## Summary

Lead generation observation modules built Elasticsearch terms queries that included every candidate entity identifier in a single clause. At large entity volumes (for example on the order of tens of thousands of IDs), that list can exceed Elasticsearch's default limit on how many terms a single terms query may contain. Elasticsearch then rejects the query, so risk history, alert summaries, and related steps fail and lead generation cannot complete.

## What changed

The same logical queries are now issued in batches: entity identifiers are split into chunks that stay under that per-query limit. Each batch runs as its own search with the same filters and aggregations as before. Results from all batches are combined in memory into the same structures the code already used (maps and sets keyed by entity), so behavior stays the same except that requests no longer hit the limit.


## How this fixes the problem
By keeping each terms clause within Elasticsearch's allowed size, searches succeed at high entity counts. Processing still covers the full candidate set; it simply uses multiple round trips when the list is larger than a single clause allows.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.