### PR TITLE
[9.3] [Search] Fix: prevent hidden provider fields from being sent in request payload (#264462)

### DIFF
--- a/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/src/components/inference_flyout_wrapper.tsx
+++ b/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/src/components/inference_flyout_wrapper.tsx
@@ -27,6 +27,7 @@ import * as LABELS from '../translations';
 import type { InferenceEndpoint } from '../types/types';
 import { InferenceServiceFormFields } from './inference_service_form_fields';
 import { useInferenceEndpointMutation } from '../hooks/use_inference_endpoint_mutation';
+import { INTERNAL_OVERRIDE_FIELDS } from '../constants';
 
 const MIN_ALLOCATIONS = 0;
 const DEFAULT_NUM_THREADS = 1;
@@ -84,12 +85,17 @@ export const formSerializer = (formData: InferenceEndpoint) => {
       ...restProviderConfig
     } = providerConfig || {};
 
+    // Get hidden fields for the current provider and remove them from the config
+    const provider = formData.config?.provider;
+    const hiddenFields = INTERNAL_OVERRIDE_FIELDS[provider]?.hidden ?? [];
+    const filteredProviderConfig = omit(restProviderConfig, hiddenFields);
+
     return {
       ...formData,
       config: {
         ...formData.config,
         providerConfig: {
-          ...restProviderConfig,
+          ...filteredProviderConfig,
           ...(maxAllocations
             ? {
                 adaptive_allocations: {

--- a/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/src/constants.tsx
+++ b/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/src/constants.tsx
@@ -96,4 +96,7 @@ export const INTERNAL_OVERRIDE_FIELDS: InternalOverrideFieldsType = {
     ],
     serverlessOnly: true,
   },
+  [ServiceProviderKeys.mistral]: {
+    hidden: ['max_input_tokens'],
+  },
 };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Search] Fix: prevent hidden provider fields from being sent in request payload (#264462)](https://github.com/elastic/kibana/pull/264462)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Brittany","email":"seialkali@gmail.com"},"sourceCommit":{"committedDate":"2026-04-21T09:27:25Z","message":"[Search] Fix: prevent hidden provider fields from being sent in request payload (#264462)\n\n## Summary\n\nFields hidden via `INTERNAL_OVERRIDE_FIELDS` were still being written\ninto the form state as null during task type selection, causing them to\nbe included in the API request. This has been fixed by skipping any\nfield not present in the filtered schema during form state sync.\n\nThis PR also hides `max_input_tokens` for the Mistral provider, which\ndoes not support this configuration and was rejecting requests that\nincluded it.\n\n<img width=\"700\" alt=\"Screenshot 2026-04-20 at 16 42 26\"\nsrc=\"https://github.com/user-attachments/assets/d60b3686-9ab2-4c13-84a9-2a4f37a75943\"\n/>\n\n### Testing\n\n- Start Kibana and navigate to the `External Inference` page\n- Click `Add endpoint` and select `Mistral` as the service.\n- Fill in a valid API key and model ID (`mistral-medium-latest`).\n- Confirm that `Maximum Input Tokens` field does not appear in the `More\noptions` accordion section.\n- Select `chat_completion` under `Task type`\n- Submit the form and confirm that the endpoint is created successfully.\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] ~Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~\n- [ ]\n~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials~\n- [ ] ~[Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios~\n- [ ] ~If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~\n- [ ] ~This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.~\n- [ ] ~[Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed~\n- [ ] ~The PR description includes the appropriate Release Notes\nsection, and the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)~\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"96445f93357dee7d3aa8de213f824948fe3ebb1c","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Search","backport:version","v9.4.0","v9.5.0","v9.3.4","v9.2.9"],"title":"[Search] Fix: prevent hidden provider fields from being sent in request payload","number":264462,"url":"https://github.com/elastic/kibana/pull/264462","mergeCommit":{"message":"[Search] Fix: prevent hidden provider fields from being sent in request payload (#264462)\n\n## Summary\n\nFields hidden via `INTERNAL_OVERRIDE_FIELDS` were still being written\ninto the form state as null during task type selection, causing them to\nbe included in the API request. This has been fixed by skipping any\nfield not present in the filtered schema during form state sync.\n\nThis PR also hides `max_input_tokens` for the Mistral provider, which\ndoes not support this configuration and was rejecting requests that\nincluded it.\n\n<img width=\"700\" alt=\"Screenshot 2026-04-20 at 16 42 26\"\nsrc=\"https://github.com/user-attachments/assets/d60b3686-9ab2-4c13-84a9-2a4f37a75943\"\n/>\n\n### Testing\n\n- Start Kibana and navigate to the `External Inference` page\n- Click `Add endpoint` and select `Mistral` as the service.\n- Fill in a valid API key and model ID (`mistral-medium-latest`).\n- Confirm that `Maximum Input Tokens` field does not appear in the `More\noptions` accordion section.\n- Select `chat_completion` under `Task type`\n- Submit the form and confirm that the endpoint is created successfully.\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] ~Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~\n- [ ]\n~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials~\n- [ ] ~[Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios~\n- [ ] ~If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~\n- [ ] ~This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.~\n- [ ] ~[Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed~\n- [ ] ~The PR description includes the appropriate Release Notes\nsection, and the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)~\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"96445f93357dee7d3aa8de213f824948fe3ebb1c"}},"sourceBranch":"main","suggestedTargetBranches":["9.3","9.2"],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/264618","number":264618,"state":"OPEN"},{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/264462","number":264462,"mergeCommit":{"message":"[Search] Fix: prevent hidden provider fields from being sent in request payload (#264462)\n\n## Summary\n\nFields hidden via `INTERNAL_OVERRIDE_FIELDS` were still being written\ninto the form state as null during task type selection, causing them to\nbe included in the API request. This has been fixed by skipping any\nfield not present in the filtered schema during form state sync.\n\nThis PR also hides `max_input_tokens` for the Mistral provider, which\ndoes not support this configuration and was rejecting requests that\nincluded it.\n\n<img width=\"700\" alt=\"Screenshot 2026-04-20 at 16 42 26\"\nsrc=\"https://github.com/user-attachments/assets/d60b3686-9ab2-4c13-84a9-2a4f37a75943\"\n/>\n\n### Testing\n\n- Start Kibana and navigate to the `External Inference` page\n- Click `Add endpoint` and select `Mistral` as the service.\n- Fill in a valid API key and model ID (`mistral-medium-latest`).\n- Confirm that `Maximum Input Tokens` field does not appear in the `More\noptions` accordion section.\n- Select `chat_completion` under `Task type`\n- Submit the form and confirm that the endpoint is created successfully.\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] ~Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~\n- [ ]\n~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials~\n- [ ] ~[Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios~\n- [ ] ~If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~\n- [ ] ~This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.~\n- [ ] ~[Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed~\n- [ ] ~The PR description includes the appropriate Release Notes\nsection, and the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)~\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"96445f93357dee7d3aa8de213f824948fe3ebb1c"}},{"branch":"9.3","label":"v9.3.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.2","label":"v9.2.9","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->