### PR TITLE
Saved objects tags client improvements - cache-aligned client

### DIFF
--- a/src/platform/plugins/shared/saved_objects_tagging_oss/public/api.mock.ts
+++ b/src/platform/plugins/shared/saved_objects_tagging_oss/public/api.mock.ts
@@ -31,7 +31,10 @@ const createCacheMock = () => {
   const mock: jest.Mocked<ITagsCache> = {
     getState: jest.fn(),
     getState$: jest.fn(),
+    isInitialized: jest.fn(),
   };
+
+  mock.isInitialized.mockReturnValue(false);
 
   return mock;
 };

--- a/src/platform/plugins/shared/saved_objects_tagging_oss/public/api.ts
+++ b/src/platform/plugins/shared/saved_objects_tagging_oss/public/api.ts
@@ -50,6 +50,12 @@ export interface ITagsCache {
    * Return an observable that will emit everytime the cache's state mutates.
    */
   getState$(params?: { waitForInitialization?: boolean }): Observable<Tag[]>;
+
+  /**
+   * True after the cache has completed its initial load (`initialize`), including
+   * when that load produced an empty tag list.
+   */
+  isInitialized(): boolean;
 }
 
 /**

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/moon.yml
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/moon.yml
@@ -33,6 +33,7 @@ dependsOn:
   - '@kbn/core-notifications-browser'
   - '@kbn/react-kibana-mount'
   - '@kbn/core-lifecycle-browser'
+  - '@kbn/core-http-browser'
 tags:
   - plugin
   - prod

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/public/components/connected/tag_list.test.tsx
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/public/components/connected/tag_list.test.tsx
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { TagsCache } from '../../services/tags/tags_cache';
+import { createTagReference, createTag } from '../../../common/test_utils';
+import { getConnectedTagListComponent } from './tag_list';
+
+describe('getConnectedTagListComponent', () => {
+  it('renders tag badges after the cache finishes initializing', async () => {
+    const tagsCache = new TagsCache({
+      refreshHandler: () => [createTag({ id: 'tag-1', name: 'Tag One' })],
+    });
+    const TagList = getConnectedTagListComponent({ cache: tagsCache });
+
+    const { unmount } = render(<TagList object={{ references: [createTagReference('tag-1')] }} />);
+
+    expect(screen.queryByText('Tag One')).not.toBeInTheDocument();
+
+    await act(async () => {
+      await tagsCache.initialize();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Tag One')).toBeInTheDocument();
+    });
+
+    unmount();
+    tagsCache.stop();
+  });
+});

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/public/components/connected/tag_list.tsx
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/public/components/connected/tag_list.tsx
@@ -45,7 +45,9 @@ export const getConnectedTagListComponent = ({
   cache,
 }: GetConnectedTagListOptions): FC<TagListComponentProps> => {
   return (props: TagListComponentProps) => {
-    const tags = useObservable(cache.getState$(), cache.getState());
+    // `cache` is fixed for the lifetime of the component returned by getConnectedTagListComponent
+    const tagsState$ = useMemo(() => cache.getState$({ waitForInitialization: true }), []);
+    const tags = useObservable(tagsState$, cache.getState());
     return <SavedObjectTagList {...props} tags={tags} />;
   };
 };

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/public/components/connected/tag_list.tsx
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/public/components/connected/tag_list.tsx
@@ -44,9 +44,9 @@ interface GetConnectedTagListOptions {
 export const getConnectedTagListComponent = ({
   cache,
 }: GetConnectedTagListOptions): FC<TagListComponentProps> => {
+  const tagsState$ = cache.getState$({ waitForInitialization: true });
+
   return (props: TagListComponentProps) => {
-    // `cache` is fixed for the lifetime of the component returned by getConnectedTagListComponent
-    const tagsState$ = useMemo(() => cache.getState$({ waitForInitialization: true }), []);
     const tags = useObservable(tagsState$, cache.getState());
     return <SavedObjectTagList {...props} tags={tags} />;
   };

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/public/plugin.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/public/plugin.ts
@@ -70,10 +70,16 @@ export class SavedObjectTaggingPlugin
 
   public start({ http, application, analytics, ...startServices }: CoreStart) {
     this.tagCache = new TagsCache({
-      refreshHandler: () => this.tagClient!.getAll({ asSystemRequest: true }),
+      refreshHandler: () => this.tagClient!.fetchAllFromNetwork({ asSystemRequest: true }),
       refreshInterval: this.config.cacheRefreshInterval,
     });
-    this.tagClient = new TagsClient({ analytics, http, changeListener: this.tagCache });
+
+    this.tagClient = new TagsClient({
+      analytics,
+      http,
+      cache: this.tagCache,
+    });
+
     this.assignmentService = new TagAssignmentService({ http });
 
     // do not fetch tags on anonymous page

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/public/services/tags/tags_cache.mock.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/public/services/tags/tags_cache.mock.ts
@@ -15,17 +15,19 @@ const createTagsCacheMock = () => {
   const mock: TagsCacheMock = {
     getState: jest.fn(),
     getState$: jest.fn(),
+    isInitialized: jest.fn(),
     initialize: jest.fn(),
     stop: jest.fn(),
 
-    onDelete: jest.fn(),
-    onCreate: jest.fn(),
-    onUpdate: jest.fn(),
-    onGetAll: jest.fn(),
+    onDidDelete: jest.fn(),
+    onDidCreate: jest.fn(),
+    onDidUpdate: jest.fn(),
+    onDidGetAll: jest.fn(),
   };
 
   mock.getState.mockReturnValue([]);
   mock.getState$.mockReturnValue(of([]));
+  mock.isInitialized.mockReturnValue(false);
   mock.initialize.mockResolvedValue(undefined);
 
   return mock;

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/public/services/tags/tags_cache.test.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/public/services/tags/tags_cache.test.ts
@@ -47,6 +47,19 @@ describe('TagsCache', () => {
     await tagsCache.initialize();
   });
 
+  describe('#isInitialized', () => {
+    it('is false before `initialize` completes', () => {
+      const cache = new TagsCache({ refreshHandler });
+      expect(cache.isInitialized()).toBe(false);
+    });
+
+    it('is true after `initialize` completes', async () => {
+      const cache = new TagsCache({ refreshHandler });
+      await cache.initialize();
+      expect(cache.isInitialized()).toBe(true);
+    });
+  });
+
   describe('#getState$', () => {
     describe('when `waitForInitialization` is `true`', () => {
       it('does not emit before `initialize` completes', async () => {
@@ -80,24 +93,24 @@ describe('TagsCache', () => {
     });
   });
 
-  describe('#onDelete', () => {
+  describe('#onDidDelete', () => {
     it('removes the deleted tag from the cache', async () => {
-      tagsCache.onDelete('tag-1');
+      tagsCache.onDidDelete('tag-1');
 
       expect(tagsCache.getState().map((tag) => tag.id)).toEqual(['tag-2', 'tag-3']);
     });
 
     it('does nothing if the specified id is not in the cache', async () => {
-      tagsCache.onDelete('tag-4');
+      tagsCache.onDidDelete('tag-4');
 
       expect(tagsCache.getState().map((tag) => tag.id)).toEqual(['tag-1', 'tag-2', 'tag-3']);
     });
   });
 
-  describe('#onCreate', () => {
+  describe('#onDidCreate', () => {
     it('adds the new tag to the cache', async () => {
       const newTag = createTag({ id: 'new-tag' });
-      tagsCache.onCreate(newTag);
+      tagsCache.onDidCreate(newTag);
 
       expect(tagsCache.getState().map((tag) => tag.id)).toEqual([
         'tag-1',
@@ -109,7 +122,7 @@ describe('TagsCache', () => {
 
     it('replace the entry from the cache if already existing', async () => {
       const newTag = createTag({ id: 'tag-2', name: 'new-tag' });
-      tagsCache.onCreate(newTag);
+      tagsCache.onDidCreate(newTag);
 
       const cacheState = tagsCache.getState();
       expect(cacheState.map((tag) => tag.id)).toEqual(['tag-1', 'tag-3', 'tag-2']);
@@ -117,10 +130,10 @@ describe('TagsCache', () => {
     });
   });
 
-  describe('#onUpdate', () => {
+  describe('#onDidUpdate', () => {
     it('replace the entry from the cache', async () => {
       const updatedAttributes = createAttributes({ name: 'updated-name' });
-      tagsCache.onUpdate('tag-2', updatedAttributes);
+      tagsCache.onDidUpdate('tag-2', updatedAttributes);
 
       const cacheState = tagsCache.getState();
       expect(cacheState.map((tag) => tag.id)).toEqual(['tag-1', 'tag-2', 'tag-3']);
@@ -132,11 +145,11 @@ describe('TagsCache', () => {
     });
   });
 
-  describe('#onGetAll', () => {
+  describe('#onDidGetAll', () => {
     it('refreshes the cache with the new list', () => {
       const newTags = createTags(['tag-1', 'tag-4', 'tag-5']);
 
-      tagsCache.onGetAll(newTags);
+      tagsCache.onDidGetAll(newTags);
 
       expect(tagsCache.getState()).toEqual(newTags);
     });

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/public/services/tags/tags_cache.test.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/public/services/tags/tags_cache.test.ts
@@ -47,6 +47,39 @@ describe('TagsCache', () => {
     await tagsCache.initialize();
   });
 
+  describe('#getState$', () => {
+    describe('when `waitForInitialization` is `true`', () => {
+      it('does not emit before `initialize` completes', async () => {
+        const cache = new TagsCache({ refreshHandler });
+        const emissions: Tag[][] = [];
+        const subscription = cache.getState$({ waitForInitialization: true }).subscribe((tags) => {
+          emissions.push([...tags]);
+        });
+
+        expect(emissions).toEqual([]);
+
+        await cache.initialize();
+
+        expect(emissions.length).toBe(1);
+        expect(emissions[0].map((tag) => tag.id)).toEqual(['tag-1', 'tag-2', 'tag-3']);
+        subscription.unsubscribe();
+      });
+    });
+
+    describe('when `waitForInitialization` is not used', () => {
+      it('emits synchronously with the initial empty cache state', () => {
+        const cache = new TagsCache({ refreshHandler });
+        const emissions: Tag[][] = [];
+        const subscription = cache.getState$().subscribe((tags) => {
+          emissions.push([...tags]);
+        });
+
+        expect(emissions).toEqual([[]]);
+        subscription.unsubscribe();
+      });
+    });
+  });
+
   describe('#onDelete', () => {
     it('removes the deleted tag from the cache', async () => {
       tagsCache.onDelete('tag-1');

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/public/services/tags/tags_cache.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/public/services/tags/tags_cache.ts
@@ -14,10 +14,10 @@ import type { Tag, TagAttributes } from '../../../common/types';
 export type { ITagsCache };
 
 export interface ITagsChangeListener {
-  onDelete: (id: string) => void;
-  onCreate: (tag: Tag) => void;
-  onUpdate: (id: string, attributes: TagAttributes) => void;
-  onGetAll: (tags: Tag[]) => void;
+  onDidDelete: (id: string) => void;
+  onDidCreate: (tag: Tag) => void;
+  onDidUpdate: (id: string, attributes: TagAttributes) => void;
+  onDidGetAll: (tags: Tag[]) => void;
 }
 
 export type CacheRefreshHandler = () => Tag[] | Promise<Tag[]>;
@@ -86,15 +86,19 @@ export class TagsCache implements ITagsCache, ITagsChangeListener {
       : this.public$;
   }
 
-  public onDelete(id: string) {
+  public isInitialized(): boolean {
+    return this.isInitialized$.getValue();
+  }
+
+  public onDidDelete(id: string) {
     this.internal$.next(this.internal$.value.filter((tag) => tag.id !== id));
   }
 
-  public onCreate(tag: Tag) {
+  public onDidCreate(tag: Tag) {
     this.internal$.next([...this.internal$.value.filter((f) => f.id !== tag.id), tag]);
   }
 
-  public onUpdate(id: string, attributes: TagAttributes) {
+  public onDidUpdate(id: string, attributes: TagAttributes) {
     this.internal$.next(
       this.internal$.value.map((tag) => {
         if (tag.id === id) {
@@ -108,7 +112,7 @@ export class TagsCache implements ITagsCache, ITagsChangeListener {
     );
   }
 
-  public onGetAll(tags: Tag[]) {
+  public onDidGetAll(tags: Tag[]) {
     this.internal$.next(tags);
   }
 

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/public/services/tags/tags_client.test.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/public/services/tags/tags_client.test.ts
@@ -6,25 +6,29 @@
  */
 
 import { httpServiceMock } from '@kbn/core/public/mocks';
+import type { ITagsCache } from '@kbn/saved-objects-tagging-oss-plugin/public';
 import type { Tag } from '../../../common/types';
 import { createTag, createTagAttributes } from '../../../common/test_utils';
+import type { ITagsChangeListener } from './tags_cache';
 import { tagsCacheMock } from './tags_cache.mock';
 import { TagsClient, type FindTagsOptions } from './tags_client';
 import { coreMock } from '@kbn/core/public/mocks';
 
+type TagsClientCache = ITagsCache & ITagsChangeListener;
+
 describe('TagsClient', () => {
   let tagsClient: TagsClient;
-  let changeListener: ReturnType<typeof tagsCacheMock.create>;
+  let cache: ReturnType<typeof tagsCacheMock.create>;
   let http: ReturnType<typeof httpServiceMock.createSetupContract>;
 
   beforeEach(() => {
     http = httpServiceMock.createSetupContract();
-    changeListener = tagsCacheMock.create();
+    cache = tagsCacheMock.create();
     const { analytics } = coreMock.createStart();
     tagsClient = new TagsClient({
       analytics,
       http,
-      changeListener,
+      cache: cache as unknown as TagsClientCache,
     });
   });
 
@@ -56,14 +60,14 @@ describe('TagsClient', () => {
 
       await expect(tagsClient.create(createTagAttributes())).rejects.toThrowError(error);
     });
-    it('notifies its changeListener if the http call succeed', async () => {
+    it('notifies its cache if the http call succeed', async () => {
       await tagsClient.create(createTagAttributes());
 
-      expect(changeListener.onCreate).toHaveBeenCalledTimes(1);
-      expect(changeListener.onCreate).toHaveBeenCalledWith(expectedTag);
+      expect(cache.onDidCreate).toHaveBeenCalledTimes(1);
+      expect(cache.onDidCreate).toHaveBeenCalledWith(expectedTag);
     });
-    it('ignores potential errors when calling `changeListener.onCreate`', async () => {
-      changeListener.onCreate.mockImplementation(() => {
+    it('ignores potential errors when calling `cache.onDidCreate`', async () => {
+      cache.onDidCreate.mockImplementation(() => {
         throw new Error('error in onCreate');
       });
 
@@ -100,15 +104,15 @@ describe('TagsClient', () => {
 
       await expect(tagsClient.update(tagId, createTagAttributes())).rejects.toThrowError(error);
     });
-    it('notifies its changeListener if the http call succeed', async () => {
+    it('notifies its cache if the http call succeed', async () => {
       await tagsClient.update(tagId, createTagAttributes());
 
       const { id, ...attributes } = expectedTag;
-      expect(changeListener.onUpdate).toHaveBeenCalledTimes(1);
-      expect(changeListener.onUpdate).toHaveBeenCalledWith(id, attributes);
+      expect(cache.onDidUpdate).toHaveBeenCalledTimes(1);
+      expect(cache.onDidUpdate).toHaveBeenCalledWith(id, attributes);
     });
-    it('ignores potential errors when calling `changeListener.onUpdate`', async () => {
-      changeListener.onUpdate.mockImplementation(() => {
+    it('ignores potential errors when calling `cache.onDidUpdate`', async () => {
+      cache.onDidUpdate.mockImplementation(() => {
         throw new Error('error in onUpdate');
       });
 
@@ -181,18 +185,128 @@ describe('TagsClient', () => {
 
       await expect(tagsClient.getAll()).rejects.toThrowError(error);
     });
-    it('notifies its changeListener if the http call succeed', async () => {
+    it('notifies its cache if the http call succeed', async () => {
       await tagsClient.getAll();
 
-      expect(changeListener.onGetAll).toHaveBeenCalledTimes(1);
-      expect(changeListener.onGetAll).toHaveBeenCalledWith(expectedTags);
+      expect(cache.onDidGetAll).toHaveBeenCalledTimes(1);
+      expect(cache.onDidGetAll).toHaveBeenCalledWith(expectedTags);
     });
-    it('ignores potential errors when calling `changeListener.onDelete`', async () => {
-      changeListener.onGetAll.mockImplementation(() => {
+    it('ignores potential errors when calling `cache.onDidGetAll`', async () => {
+      cache.onDidGetAll.mockImplementation(() => {
         throw new Error('error in onCreate');
       });
 
       await expect(tagsClient.getAll()).resolves.toBeDefined();
+    });
+  });
+
+  describe('#fetchAllFromNetwork', () => {
+    let expectedTags: Tag[];
+
+    beforeEach(() => {
+      expectedTags = [
+        createTag({ id: 'tag-1' }),
+        createTag({ id: 'tag-2' }),
+        createTag({ id: 'tag-3' }),
+      ];
+      http.get.mockResolvedValue({ tags: expectedTags });
+    });
+
+    it('calls the tags list API and notifies the cache', async () => {
+      const tags = await tagsClient.fetchAllFromNetwork({ asSystemRequest: true });
+
+      expect(http.get).toHaveBeenCalledTimes(1);
+      expect(http.get).toHaveBeenCalledWith('/api/saved_objects_tagging/tags', {
+        asSystemRequest: true,
+      });
+      expect(cache.onDidGetAll).toHaveBeenCalledTimes(1);
+      expect(cache.onDidGetAll).toHaveBeenCalledWith(expectedTags);
+      expect(tags).toEqual(expectedTags);
+    });
+  });
+
+  describe('read-through cache', () => {
+    let cacheAndListener: ReturnType<typeof tagsCacheMock.create>;
+
+    beforeEach(() => {
+      cacheAndListener = tagsCacheMock.create();
+      const { analytics } = coreMock.createStart();
+      tagsClient = new TagsClient({
+        analytics,
+        http,
+        cache: cacheAndListener as unknown as TagsClientCache,
+      });
+    });
+
+    describe('#get', () => {
+      it('returns from cache without http when the tag id is present', async () => {
+        const tag = createTag({ id: 'cached-id' });
+        cacheAndListener.getState.mockReturnValue([tag]);
+        const result = await tagsClient.get('cached-id');
+        expect(result).toBe(tag);
+        expect(http.get).not.toHaveBeenCalled();
+      });
+
+      it('fetches via http and notifies onDidCreate when id is not in cache', async () => {
+        cacheAndListener.getState.mockReturnValue([]);
+        const expectedTag = createTag({ id: 'remote-id' });
+        http.get.mockResolvedValue({ tag: expectedTag });
+        const result = await tagsClient.get('remote-id');
+        expect(http.get).toHaveBeenCalledWith('/api/saved_objects_tagging/tags/remote-id');
+        expect(cacheAndListener.onDidCreate).toHaveBeenCalledWith(expectedTag);
+        expect(result).toEqual(expectedTag);
+      });
+    });
+
+    describe('#getAll', () => {
+      it('returns a shallow copy of cache state without http when initialized', async () => {
+        const tags = [createTag({ id: 'a' })];
+        cacheAndListener.isInitialized.mockReturnValue(true);
+        cacheAndListener.getState.mockReturnValue(tags);
+        const result = await tagsClient.getAll();
+        expect(result).toEqual(tags);
+        expect(result).not.toBe(tags);
+        expect(http.get).not.toHaveBeenCalled();
+      });
+
+      it('fetches from network when cache is not initialized', async () => {
+        cacheAndListener.isInitialized.mockReturnValue(false);
+        const expectedFromNetwork = [createTag({ id: 'n1' })];
+        http.get.mockResolvedValue({ tags: expectedFromNetwork });
+        const result = await tagsClient.getAll();
+        expect(http.get).toHaveBeenCalledTimes(1);
+        expect(cacheAndListener.onDidGetAll).toHaveBeenCalledWith(expectedFromNetwork);
+        expect(result).toEqual(expectedFromNetwork);
+      });
+    });
+
+    describe('#findByName', () => {
+      it('returns from cache for exact match when initialized', async () => {
+        const tag = createTag({ id: 'i1', name: 'Security Solution' });
+        cacheAndListener.isInitialized.mockReturnValue(true);
+        cacheAndListener.getState.mockReturnValue([tag]);
+        const result = await tagsClient.findByName('security solution', { exact: true });
+        expect(result).toBe(tag);
+        expect(http.get).not.toHaveBeenCalled();
+      });
+
+      it('calls find and merges results on exact miss when initialized', async () => {
+        cacheAndListener.isInitialized.mockReturnValue(true);
+        cacheAndListener.getState.mockReturnValue([]);
+        const fromNetwork = {
+          ...createTag({ id: 'n1', name: 'Foo' }),
+          relationCount: 2,
+        };
+        http.get.mockResolvedValue({ tags: [fromNetwork], total: 1 });
+        const result = await tagsClient.findByName('Foo', { exact: true });
+        expect(http.get).toHaveBeenCalledWith('/internal/saved_objects_tagging/tags/_find', {
+          query: { page: 1, perPage: 10000, search: 'Foo' },
+        });
+        expect(cacheAndListener.onDidCreate).toHaveBeenCalledWith(
+          expect.objectContaining({ id: 'n1', name: 'Foo' })
+        );
+        expect(result).toMatchObject({ id: 'n1', name: 'Foo' });
+      });
     });
   });
 
@@ -215,14 +329,14 @@ describe('TagsClient', () => {
 
       await expect(tagsClient.delete(tagId)).rejects.toThrowError(error);
     });
-    it('notifies its changeListener if the http call succeed', async () => {
+    it('notifies its cache if the http call succeed', async () => {
       await tagsClient.delete(tagId);
 
-      expect(changeListener.onDelete).toHaveBeenCalledTimes(1);
-      expect(changeListener.onDelete).toHaveBeenCalledWith(tagId);
+      expect(cache.onDidDelete).toHaveBeenCalledTimes(1);
+      expect(cache.onDidDelete).toHaveBeenCalledWith(tagId);
     });
-    it('ignores potential errors when calling `changeListener.onDelete`', async () => {
-      changeListener.onDelete.mockImplementation(() => {
+    it('ignores potential errors when calling `cache.onDidDelete`', async () => {
+      cache.onDidDelete.mockImplementation(() => {
         throw new Error('error in onCreate');
       });
 
@@ -293,15 +407,15 @@ describe('TagsClient', () => {
 
         await expect(tagsClient.bulkDelete(tagIds)).rejects.toThrowError(error);
       });
-      it('notifies its changeListener if the http call succeed', async () => {
+      it('notifies its cache if the http call succeed', async () => {
         await tagsClient.bulkDelete(tagIds);
 
-        expect(changeListener.onDelete).toHaveBeenCalledTimes(2);
-        expect(changeListener.onDelete).toHaveBeenCalledWith(tagIds[0]);
-        expect(changeListener.onDelete).toHaveBeenCalledWith(tagIds[1]);
+        expect(cache.onDidDelete).toHaveBeenCalledTimes(2);
+        expect(cache.onDidDelete).toHaveBeenCalledWith(tagIds[0]);
+        expect(cache.onDidDelete).toHaveBeenCalledWith(tagIds[1]);
       });
-      it('ignores potential errors when calling `changeListener.onDelete`', async () => {
-        changeListener.onDelete.mockImplementation(() => {
+      it('ignores potential errors when calling `cache.onDidDelete`', async () => {
+        cache.onDidDelete.mockImplementation(() => {
           throw new Error('error in onCreate');
         });
 

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/public/services/tags/tags_client.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/public/services/tags/tags_client.ts
@@ -5,8 +5,10 @@
  * 2.0.
  */
 
+import { buildPath } from '@kbn/core-http-browser';
 import type { HttpSetup, AnalyticsServiceStart } from '@kbn/core/public';
 import { reportPerformanceMetricEvent } from '@kbn/ebt-tools';
+import type { ITagsCache } from '@kbn/saved-objects-tagging-oss-plugin/public';
 import type {
   Tag,
   TagAttributes,
@@ -26,7 +28,8 @@ const UPDATE_TAG_EVENT = 'updateTag';
 export interface TagsClientOptions {
   analytics: AnalyticsServiceStart;
   http: HttpSetup;
-  changeListener?: ITagsChangeListener;
+  /** When set, read APIs consult this cache before calling the network. */
+  cache?: ITagsCache & ITagsChangeListener;
 }
 
 export interface FindTagsOptions {
@@ -56,12 +59,12 @@ export interface ITagInternalClient extends ITagsClient {
 export class TagsClient implements ITagInternalClient {
   private readonly analytics: AnalyticsServiceStart;
   private readonly http: HttpSetup;
-  private readonly changeListener?: ITagsChangeListener;
+  private readonly cache?: ITagsCache & ITagsChangeListener;
 
-  constructor({ analytics, http, changeListener }: TagsClientOptions) {
+  constructor({ analytics, http, cache }: TagsClientOptions) {
     this.analytics = analytics;
     this.http = http;
-    this.changeListener = changeListener;
+    this.cache = cache;
   }
 
   // public APIs from ITagsClient
@@ -78,8 +81,8 @@ export class TagsClient implements ITagInternalClient {
     });
 
     trapErrors(() => {
-      if (this.changeListener) {
-        this.changeListener.onCreate(tag);
+      if (this.cache) {
+        this.cache.onDidCreate(tag);
       }
     });
 
@@ -88,9 +91,12 @@ export class TagsClient implements ITagInternalClient {
 
   public async update(id: string, attributes: TagAttributes) {
     const startTime = window.performance.now();
-    const { tag } = await this.http.post<{ tag: Tag }>(`/api/saved_objects_tagging/tags/${id}`, {
-      body: JSON.stringify(attributes),
-    });
+    const { tag } = await this.http.post<{ tag: Tag }>(
+      buildPath('/api/saved_objects_tagging/tags/{id}', { id }),
+      {
+        body: JSON.stringify(attributes),
+      }
+    );
     const duration = window.performance.now() - startTime;
     reportPerformanceMetricEvent(this.analytics, {
       eventName: UPDATE_TAG_EVENT,
@@ -98,9 +104,9 @@ export class TagsClient implements ITagInternalClient {
     });
 
     trapErrors(() => {
-      if (this.changeListener) {
+      if (this.cache) {
         const { id: newId, ...newAttributes } = tag;
-        this.changeListener.onUpdate(newId, newAttributes);
+        this.cache.onDidUpdate(newId, newAttributes);
       }
     });
 
@@ -108,11 +114,29 @@ export class TagsClient implements ITagInternalClient {
   }
 
   public async get(id: string) {
-    const { tag } = await this.http.get<{ tag: Tag }>(`/api/saved_objects_tagging/tags/${id}`);
+    const cached = (this.cache?.getState() ?? []).find((t) => t.id === id);
+    if (cached) {
+      return cached;
+    }
+
+    const { tag } = await this.http.get<{ tag: Tag }>(
+      buildPath('/api/saved_objects_tagging/tags/{id}', { id })
+    );
+
+    trapErrors(() => {
+      if (this.cache) {
+        this.cache.onDidCreate(tag);
+      }
+    });
+
     return tag;
   }
 
-  public async getAll({ asSystemRequest }: GetAllTagsOptions = {}) {
+  /**
+   * Loads all tags from the server, updates the change listener / cache, and returns the list.
+   * Used by {@link TagsCache} refresh so periodic reloads always hit the network.
+   */
+  public async fetchAllFromNetwork({ asSystemRequest }: GetAllTagsOptions = {}): Promise<Tag[]> {
     const startTime = window.performance.now();
     const fetchOptions = { asSystemRequest };
     const { tags } = await this.http.get<{ tags: Tag[] }>(
@@ -126,17 +150,24 @@ export class TagsClient implements ITagInternalClient {
     });
 
     trapErrors(() => {
-      if (this.changeListener) {
-        this.changeListener.onGetAll(tags);
+      if (this.cache) {
+        this.cache.onDidGetAll(tags);
       }
     });
 
     return tags;
   }
 
+  public async getAll(options: GetAllTagsOptions = {}) {
+    if (this.cache?.isInitialized()) {
+      return [...this.cache.getState()];
+    }
+    return this.fetchAllFromNetwork(options);
+  }
+
   public async delete(id: string) {
     const startTime = window.performance.now();
-    await this.http.delete<{}>(`/api/saved_objects_tagging/tags/${id}`);
+    await this.http.delete<{}>(buildPath('/api/saved_objects_tagging/tags/{id}', { id }));
     const duration = window.performance.now() - startTime;
     reportPerformanceMetricEvent(this.analytics, {
       eventName: DELETE_TAG_EVENT,
@@ -144,8 +175,8 @@ export class TagsClient implements ITagInternalClient {
     });
 
     trapErrors(() => {
-      if (this.changeListener) {
-        this.changeListener.onDelete(id);
+      if (this.cache) {
+        this.cache.onDidDelete(id);
       }
     });
   }
@@ -174,12 +205,36 @@ export class TagsClient implements ITagInternalClient {
   }
 
   public async findByName(name: string, { exact }: { exact?: boolean } = { exact: false }) {
+    if (exact && this.cache?.isInitialized()) {
+      const cached = this.cache
+        .getState()
+        .find((t) => t.name.toLocaleLowerCase() === name.toLocaleLowerCase());
+      if (cached) {
+        return cached;
+      }
+    }
+
     const { tags = [] } = await this.find({ page: 1, perPage: 10000, search: name });
+
+    if (tags.length > 0) {
+      this.mergeFindResultsIntoCache(tags);
+    }
+
     if (exact) {
-      const tag = tags.find((t) => t.name.toLocaleLowerCase() === name.toLocaleLowerCase());
-      return tag ?? null;
+      return tags.find((t) => t.name.toLocaleLowerCase() === name.toLocaleLowerCase()) ?? null;
     }
     return tags.length > 0 ? tags[0] : null;
+  }
+
+  private mergeFindResultsIntoCache(tags: TagWithRelations[]) {
+    for (const t of tags) {
+      const { relationCount: _relationCount, ...plain } = t;
+      trapErrors(() => {
+        if (this.cache) {
+          this.cache.onDidCreate(plain as Tag);
+        }
+      });
+    }
   }
 
   public async bulkDelete(tagIds: string[]) {
@@ -196,9 +251,9 @@ export class TagsClient implements ITagInternalClient {
     });
 
     trapErrors(() => {
-      if (this.changeListener) {
+      if (this.cache) {
         tagIds.forEach((tagId) => {
-          this.changeListener!.onDelete(tagId);
+          this.cache!.onDidDelete(tagId);
         });
       }
     });

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/tsconfig.json
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/tsconfig.json
@@ -20,7 +20,8 @@
     "@kbn/ebt-tools",
     "@kbn/core-notifications-browser",
     "@kbn/react-kibana-mount",
-    "@kbn/core-lifecycle-browser"
+    "@kbn/core-lifecycle-browser",
+    "@kbn/core-http-browser"
   ],
   "exclude": [
     "target/**/*",

--- a/x-pack/solutions/security/plugins/security_solution/public/common/containers/tags/__mocks__/api.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/containers/tags/__mocks__/api.ts
@@ -11,11 +11,9 @@ export const MOCK_TAG_NAME = 'test tag';
 export const DEFAULT_TAGS_RESPONSE = [
   {
     id: MOCK_TAG_ID,
-    attributes: {
-      name: MOCK_TAG_NAME,
-      description: 'test tag description',
-      color: '#2c7b82',
-    },
+    name: MOCK_TAG_NAME,
+    description: 'test tag description',
+    color: '#2c7b82',
   },
 ];
 

--- a/x-pack/solutions/security/plugins/security_solution/public/common/containers/tags/api.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/containers/tags/api.ts
@@ -20,7 +20,7 @@ export const getTagsByName = async ({
   savedObjectsTaggingClient,
   tagName,
 }: {
-  savedObjectsTaggingClient?: ITagsClient;
+  savedObjectsTaggingClient: ITagsClient | undefined;
   tagName: string;
 }): Promise<TagResponse[] | null> => {
   const tag = await savedObjectsTaggingClient?.findByName(tagName, { exact: true });

--- a/x-pack/solutions/security/plugins/security_solution/public/common/containers/tags/api.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/containers/tags/api.ts
@@ -4,14 +4,11 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-
-import type { HttpSetup } from '@kbn/core/public';
 import type {
   ITagsClient,
   TagAttributes,
   Tag as TagResponse,
 } from '@kbn/saved-objects-tagging-oss-plugin/common';
-import { INTERNAL_TAGS_URL } from '../../../../common/constants';
 
 export interface Tag {
   id: string;
@@ -19,15 +16,17 @@ export interface Tag {
   attributes: TagAttributes;
 }
 
-export const getTagsByName = (
-  { http, tagName }: { http: HttpSetup; tagName: string },
-  abortSignal?: AbortSignal
-): Promise<Tag[]> =>
-  http.get(INTERNAL_TAGS_URL, {
-    version: '1',
-    query: { name: tagName },
-    signal: abortSignal,
-  });
+export const getTagsByName = async ({
+  savedObjectsTaggingClient,
+  tagName,
+}: {
+  savedObjectsTaggingClient?: ITagsClient;
+  tagName: string;
+}): Promise<TagResponse[] | null> => {
+  const tag = await savedObjectsTaggingClient?.findByName(tagName, { exact: true });
+
+  return tag ? [tag] : [];
+};
 
 // Dashboard listing needs savedObjectsTaggingClient to work correctly with cache.
 // https://github.com/elastic/kibana/issues/160723#issuecomment-1641904984

--- a/x-pack/solutions/security/plugins/security_solution/public/dashboards/containers/use_fetch_security_tags.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/dashboards/containers/use_fetch_security_tags.test.ts
@@ -7,11 +7,7 @@
 
 import type { HttpStart } from '@kbn/core/public';
 import { waitFor, renderHook } from '@testing-library/react';
-import {
-  INTERNAL_TAGS_URL,
-  SECURITY_TAG_DESCRIPTION,
-  SECURITY_TAG_NAME,
-} from '../../../common/constants';
+import { SECURITY_TAG_DESCRIPTION, SECURITY_TAG_NAME } from '../../../common/constants';
 import { useKibana } from '../../common/lib/kibana';
 import { useFetchSecurityTags } from './use_fetch_security_tags';
 import { DEFAULT_TAGS_RESPONSE } from '../../common/containers/tags/__mocks__/api';
@@ -26,13 +22,14 @@ jest.mock('../../../common/utils/get_ramdom_color', () => ({
 const mockGet = jest.fn();
 const mockAbortSignal = {} as unknown as AbortSignal;
 const mockCreateTag = jest.fn();
+const mockFindByName = jest.fn();
 const renderUseCreateSecurityDashboardLink = () => renderHook(() => useFetchSecurityTags(), {});
 
 describe('useFetchSecurityTags', () => {
   beforeAll(() => {
     useKibana().services.http = { get: mockGet } as unknown as HttpStart;
     useKibana().services.savedObjectsTagging = {
-      client: { create: mockCreateTag } as unknown as ITagsClient,
+      client: { create: mockCreateTag, findByName: mockFindByName } as unknown as ITagsClient,
     } as unknown as SavedObjectsTaggingApi;
     global.AbortController = jest.fn().mockReturnValue({
       abort: jest.fn(),
@@ -50,18 +47,12 @@ describe('useFetchSecurityTags', () => {
     renderUseCreateSecurityDashboardLink();
 
     await waitFor(() => {
-      expect(mockGet).toHaveBeenCalledWith(
-        INTERNAL_TAGS_URL,
-        expect.objectContaining({
-          query: { name: SECURITY_TAG_NAME },
-          signal: mockAbortSignal,
-        })
-      );
+      expect(mockFindByName).toHaveBeenCalledWith(SECURITY_TAG_NAME, { exact: true });
     });
   });
 
   test('should create a Security Solution tag if no Security Solution tags were found', async () => {
-    mockGet.mockResolvedValue([]);
+    mockFindByName.mockResolvedValue(null);
 
     renderUseCreateSecurityDashboardLink();
 
@@ -75,13 +66,13 @@ describe('useFetchSecurityTags', () => {
   });
 
   test('should return Security Solution tags', async () => {
-    mockGet.mockResolvedValue(DEFAULT_TAGS_RESPONSE);
+    mockFindByName.mockResolvedValue(DEFAULT_TAGS_RESPONSE[0]);
 
     const expected = DEFAULT_TAGS_RESPONSE.map((tag) => ({
-      id: tag.id,
       type: 'tag',
-      ...tag.attributes,
+      ...tag,
     }));
+
     const { result } = renderUseCreateSecurityDashboardLink();
 
     await waitFor(() => {

--- a/x-pack/solutions/security/plugins/security_solution/public/dashboards/containers/use_fetch_security_tags.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/dashboards/containers/use_fetch_security_tags.ts
@@ -13,7 +13,7 @@ import { SECURITY_TAG_DESCRIPTION, SECURITY_TAG_NAME } from '../../../common/con
 import { getRandomColor } from '../../../common/utils/get_ramdom_color';
 
 export const useFetchSecurityTags = () => {
-  const { http, savedObjectsTagging } = useKibana().services;
+  const { savedObjectsTagging } = useKibana().services;
   const tagCreated = useRef(false);
 
   const {
@@ -21,11 +21,14 @@ export const useFetchSecurityTags = () => {
     isLoading: isLoadingTags,
     error: errorFetchTags,
   } = useFetch(REQUEST_NAMES.SECURITY_TAGS, getTagsByName, {
-    initialParameters: { http, tagName: SECURITY_TAG_NAME },
+    initialParameters: {
+      savedObjectsTaggingClient: savedObjectsTagging?.client,
+      tagName: SECURITY_TAG_NAME,
+    },
   });
 
   const {
-    fetch: fetchCreateTag,
+    fetch: createTagHandler,
     data: tag,
     isLoading: isLoadingCreateTags,
     error: errorCreateTag,
@@ -41,7 +44,7 @@ export const useFetchSecurityTags = () => {
       !tagCreated.current
     ) {
       tagCreated.current = true;
-      fetchCreateTag({
+      createTagHandler({
         savedObjectsTaggingClient: savedObjectsTagging.client,
         tag: {
           name: SECURITY_TAG_NAME,
@@ -50,11 +53,11 @@ export const useFetchSecurityTags = () => {
         },
       });
     }
-  }, [errorFetchTags, fetchCreateTag, savedObjectsTagging, isLoadingTags, tags]);
+  }, [errorFetchTags, createTagHandler, savedObjectsTagging, isLoadingTags, tags]);
 
   const tagsResult = useMemo(() => {
     if (tags?.length) {
-      return tags.map((t) => ({ id: t.id, type: 'tag', managed: t.managed, ...t.attributes }));
+      return tags.map((t) => ({ type: 'tag', ...t }));
     }
     return tag ? [{ type: 'tag', ...tag }] : undefined;
   }, [tags, tag]);

--- a/x-pack/solutions/security/plugins/security_solution/public/overview/containers/overview_cti_links/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/overview/containers/overview_cti_links/index.test.tsx
@@ -1,0 +1,78 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { HttpStart } from '@kbn/core/public';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { ITagsClient } from '@kbn/saved-objects-tagging-oss-plugin/common';
+import type { SavedObjectsTaggingApi } from '@kbn/saved-objects-tagging-oss-plugin/public';
+import { INTERNAL_DASHBOARDS_URL } from '../../../../common/constants';
+import { useKibana } from '../../../common/lib/kibana';
+import { CTI_TAG_NAME, useCtiDashboardLinks } from '.';
+
+jest.mock('../../../common/lib/kibana');
+jest.mock('../../../common/lib/apm/use_track_http_request', () => ({
+  useTrackHttpRequest: jest.fn(() => ({
+    startTracking: jest.fn(() => ({ endTracking: jest.fn() })),
+  })),
+}));
+jest.mock('../../../common/components/link_to', () => ({
+  useGetSecuritySolutionUrl: jest.fn(() =>
+    jest.fn(({ path }: { path: string }) => `/security/dashboards/${path}`)
+  ),
+}));
+
+const mockHttpPost = jest.fn();
+const mockAbortSignal = {} as unknown as AbortSignal;
+const mockFindByName = jest.fn();
+
+const renderUseCtiDashboardLinks = (tiDataSources = [{ dataset: 'a', name: 'TI', count: 1 }]) =>
+  renderHook(() => useCtiDashboardLinks({ tiDataSources }), {});
+
+describe('useCtiDashboardLinks', () => {
+  beforeAll(() => {
+    useKibana().services.http = {
+      post: mockHttpPost,
+    } as unknown as HttpStart;
+    useKibana().services.savedObjectsTagging = {
+      client: { findByName: mockFindByName } as unknown as ITagsClient,
+    } as unknown as SavedObjectsTaggingApi;
+    global.AbortController = jest.fn().mockReturnValue({
+      abort: jest.fn(),
+      signal: mockAbortSignal,
+    });
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('should resolve CTI tag via savedObjectsTagging.client findByName', async () => {
+    mockFindByName.mockResolvedValue(null);
+    mockHttpPost.mockResolvedValue([]);
+
+    renderUseCtiDashboardLinks();
+
+    await waitFor(() => {
+      expect(mockFindByName).toHaveBeenCalledWith(CTI_TAG_NAME, { exact: true });
+    });
+  });
+
+  test('should fetch dashboards by tag ids after tags resolve', async () => {
+    mockFindByName.mockResolvedValue({ id: 'cti-tag-id', managed: false, attributes: {} });
+    mockHttpPost.mockResolvedValue([]);
+
+    renderUseCtiDashboardLinks();
+
+    await waitFor(() => {
+      expect(mockHttpPost).toHaveBeenCalledWith(INTERNAL_DASHBOARDS_URL, {
+        version: '1',
+        body: JSON.stringify({ tagIds: ['cti-tag-id'] }),
+        signal: mockAbortSignal,
+      });
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/overview/containers/overview_cti_links/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/overview/containers/overview_cti_links/index.tsx
@@ -13,17 +13,20 @@ import { useFetch, REQUEST_NAMES } from '../../../common/hooks/use_fetch';
 import { SecurityPageName } from '../../../../common/constants';
 import { useGetSecuritySolutionUrl } from '../../../common/components/link_to';
 
-const CTI_TAG_NAME = 'threat intel';
+export const CTI_TAG_NAME = 'threat intel';
 
 const useCtiInstalledDashboards = () => {
-  const { http } = useKibana().services;
+  const { http, savedObjectsTagging } = useKibana().services;
 
   const {
     data: ctiTags,
     isLoading: isLoadingTags,
     error: errorTags,
   } = useFetch(REQUEST_NAMES.CTI_TAGS, getTagsByName, {
-    initialParameters: { http, tagName: CTI_TAG_NAME },
+    initialParameters: {
+      savedObjectsTaggingClient: savedObjectsTagging?.client,
+      tagName: CTI_TAG_NAME,
+    },
   });
 
   const {


### PR DESCRIPTION
## Summary

This changeset improves how the **browser Tags API client** cooperates with **`TagsCache`** so reads are cache-aware, refreshes always reconcile from the server, and listing UIs (e.g. dashboard Tags column) do not depend on the empty “pre-initialize” cache emission. It also tightens the **`ITagsCache` / cache listener** contract with explicit initialization and **`onDid*`** listener names.

Related context: [elastic/kibana#207418](https://github.com/elastic/kibana/issues/207418) (dashboard list tags not shown on first load until interaction).

---

## Saved Objects Tagging client (`TagsClient`)

**Read-through behavior (when `cache` is wired in plugin start)**

- **`getAll`**: If the cache reports **`isInitialized()`**, returns a **shallow copy** of `cache.getState()` and **does not** call the tags list HTTP API or emit the GET_ALL performance metric. If the cache has not finished its first load, delegates to **`fetchAllFromNetwork`** (same as today’s cold start).
- **`get`**: Resolves from **`(cache.getState() ?? [])`** by id first; on miss, loads by id from the API and notifies the cache via **`onDidCreate`**.
- **`findByName`**: For **`exact: true`** and an initialized cache, scans in-memory tags first (same case rules as before). On miss, uses the existing **`find`** HTTP path, then **merges** each result into the cache via **`onDidGetAll`** / **`onDidCreate`** (after stripping `relationCount` from `TagWithRelations`) so other UI subscribers stay in sync.
- **`fetchAllFromNetwork`**: Dedicated path used only for **network-backed** full list loads: HTTP GET `/api/saved_objects_tagging/tags`, analytics (`getAllTag`), and **`onDidGetAll(tags)`**. This is what **must** run on schedule / initial refresh so we never “refresh” by returning only the in-memory cache.

**Plugin wiring**

- `TagsClient` is constructed with a single **`cache`** reference (`ITagsCache & ITagsChangeListener`) instead of a separate change-listener handle.
- **`TagsCache` `refreshHandler`** now calls **`tagClient.fetchAllFromNetwork({ asSystemRequest: true })`**, **not** `getAll`, so periodic / initial refresh cannot short-circuit on the cache-first `getAll` path.

**HTTP hardening**

- Tag URLs that embed ids use **`buildPath`** from `@kbn/core-http-browser` for safe path encoding (aligned with lint expectations).

---

## `ITagsCache` and `TagsCache` listener API

- **`ITagsCache`** (OSS) now includes **`isInitialized(): boolean`** so callers can distinguish “first load not done yet” from “loaded and legitimately empty” (cannot rely on `getState().length === 0` alone).
- **`ITagsChangeListener`** / **`TagsCache`** use explicit event-style names: **`onDidCreate`**, **`onDidUpdate`**, **`onDidDelete`**, **`onDidGetAll`** (replacing `onCreate` / `onUpdate` / `onDelete` / `onGetAll`).
- **`TagsClient`** notifies the cache only through these **`onDid*`** methods.

---

## UI: connected `TagList`

- Subscribes to **`cache.getState$({ waitForInitialization: true })`** (with a stable observable via `useMemo`) so the first emission is not the empty `BehaviorSubject` seed **before** the first successful refresh—matching the pattern already used in **`parseSearchQuery`** for tag-aware search.

---

## Tests

- **`tags_client`**: `fetchAllFromNetwork`, cache-first **`get` / `getAll` / `findByName`**, hit/miss and listener expectations; `TagsClientCache` typing for tests.
- **`tags_cache`**: **`isInitialized`** before/after **`initialize`**; describe blocks for **`onDid*`**.
- **`tag_list`**: connected component behavior after cache initialization.
- OSS **`api.mock`** / **`tags_cache.mock`**: **`isInitialized`** and **`onDid*`** mocks.

---

## Downstream impact

- Callers that use **`ITagsClient`** only (e.g. Security **`findByName`** / tag helpers) automatically benefit from cache-first reads and cache updates on network misses, as long as they use the same plugin-supplied client instance wired to **`TagsCache`**.
- **`ITagsCache`** is a **public** type; any external mock of **`ITagsCache`** must implement **`isInitialized`**.

---

## How to verify

- Unit: `node scripts/jest x-pack/platform/plugins/shared/saved_objects_tagging/public/services/tags/tags_client.test.ts x-pack/platform/plugins/shared/saved_objects_tagging/public/services/tags/tags_cache.test.ts x-pack/platform/plugins/shared/saved_objects_tagging/public/components/connected/tag_list.test.tsx`
- Manual: cold start → Dashboards list → Tags column should show managed tags without needing extra clicks once the cache has initialized (e.g. reported issue in https://github.com/elastic/kibana/issues/207418 should be resolved).


<!--ONMERGE {"backportTargets":["8.19","9.3","9.4"]} ONMERGE-->