### PR TITLE
fix(entity-analytics): use host.name/user.name in Timeline filter instead of EUID identity field value

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/footer.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/footer.test.tsx
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { HostPanelFooter } from './footer';
+import { TestProviders } from '../../../common/mock';
+
+// Capture the kqlQuery passed to TakeAction so we can assert its value
+jest.mock('../shared/components/take_action', () => ({
+  TakeAction: ({ kqlQuery, isDisabled }: { kqlQuery: string; isDisabled?: boolean }) => (
+    <div
+      data-test-subj="take-action"
+      data-kql-query={kqlQuery}
+      data-disabled={String(!!isDisabled)}
+    />
+  ),
+}));
+
+describe('HostPanelFooter', () => {
+  it('builds the timeline KQL using host.name when identityFields contains host.name', () => {
+    const { getByTestId } = render(
+      <HostPanelFooter hostName="test-host" identityFields={{ 'host.name': 'test-host' }} />,
+      { wrapper: TestProviders }
+    );
+    expect(getByTestId('take-action').getAttribute('data-kql-query')).toBe(
+      'host.name: "test-host"'
+    );
+  });
+
+  it('builds the timeline KQL using hostName prop when identityFields only has host.id (entity store v2 scenario)', () => {
+    // Entity store v2: host is identified by host.id (higher EUID rank), so identityFields = { 'host.id': 'some-uuid' }
+    // The footer must NOT fall back to using the host.id value as host.name
+    const { getByTestId } = render(
+      <HostPanelFooter hostName="real-hostname" identityFields={{ 'host.id': 'some-uuid-1234' }} />,
+      { wrapper: TestProviders }
+    );
+    const kqlQuery = getByTestId('take-action').getAttribute('data-kql-query');
+    expect(kqlQuery).toBe('host.name: "real-hostname"');
+    expect(kqlQuery).not.toContain('some-uuid-1234');
+  });
+
+  it('disables the Take Action button when hostName is empty and identityFields has no host.name', () => {
+    const { getByTestId } = render(
+      <HostPanelFooter hostName="" identityFields={{ 'host.id': 'some-uuid-1234' }} />,
+      { wrapper: TestProviders }
+    );
+    expect(getByTestId('take-action').getAttribute('data-disabled')).toBe('true');
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/footer.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/footer.tsx
@@ -13,16 +13,23 @@ import type { IdentityFields } from '../../document_details/shared/utils';
 import type { EntityStoreRecord } from '../shared/hooks/use_entity_from_store';
 
 export const HostPanelFooter = ({
+  hostName: hostNameProp,
   identityFields,
   entity,
 }: {
+  /**
+   * The human-readable host name to use in the timeline KQL filter (e.g. from `entity.name` / `host.name`).
+   * Takes priority over values derived from `identityFields`, which may contain only identity-field IDs
+   * (e.g. `host.id`) when Entity Store v2 identifies entities by `host.id` rather than `host.name`.
+   */
+  hostName?: string;
   identityFields: IdentityFields;
   /** When entity store v2 is enabled: entity record from the store. */
   entity?: EntityStoreRecord;
 }) => {
   const hostName = useMemo(
-    () => identityFields[EntityIdentifierFields.hostName] || Object.values(identityFields)[0] || '',
-    [identityFields]
+    () => hostNameProp || identityFields[EntityIdentifierFields.hostName] || '',
+    [hostNameProp, identityFields]
   );
 
   return (

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/index.tsx
@@ -342,7 +342,11 @@ export const HostPanel = ({
         />
       )}
       {!isPreviewMode && assetInventoryEnabled && (
-        <HostPanelFooter identityFields={documentEntityIdentifiers} entity={entityFromStore} />
+        <HostPanelFooter
+          hostName={hostName}
+          identityFields={documentEntityIdentifiers}
+          entity={entityFromStore}
+        />
       )}
     </>
   );

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/footer.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/footer.tsx
@@ -12,16 +12,23 @@ import type { IdentityFields } from '../../document_details/shared/utils';
 import type { EntityStoreRecord } from '../shared/hooks/use_entity_from_store';
 
 export const UserPanelFooter = ({
+  userName: userNameProp,
   identityFields,
   entity,
 }: {
+  /**
+   * The human-readable user name to use in the timeline KQL filter (e.g. from `entity.name` / `user.name`).
+   * Takes priority over values derived from `identityFields`, which may contain only identity-field IDs
+   * (e.g. `user.id`, `user.email`) when Entity Store v2 identifies entities by non-name fields.
+   */
+  userName?: string;
   identityFields: IdentityFields;
   /** When entity store v2 is enabled: entity record from the store. */
   entity?: EntityStoreRecord;
 }) => {
   const userName = useMemo(
-    () => identityFields['user.name'] || Object.values(identityFields)[0] || '',
-    [identityFields]
+    () => userNameProp || identityFields['user.name'] || '',
+    [userNameProp, identityFields]
   );
 
   return (

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/index.tsx
@@ -335,7 +335,11 @@ export const UserPanel = ({
         )}
       </FlyoutBody>
       {!isPreviewMode && assetInventoryEnabled && (
-        <UserPanelFooter identityFields={documentEntityIdentifiers} entity={entityFromStore} />
+        <UserPanelFooter
+          userName={userName}
+          identityFields={documentEntityIdentifiers}
+          entity={entityFromStore}
+        />
       )}
       {isPreviewMode && (
         <UserPreviewPanelFooter


### PR DESCRIPTION
## Summary

Fixes #263755

When **Entity Store v2** is enabled, the EUID (Entity Unique IDentifier) ranking may resolve a host using `host.id` (higher EUID priority) rather than `host.name`. This caused `HostPanelFooter` and `UserPanelFooter` to fall back to `Object.values(identityFields)[0]`, producing a KQL timeline filter of `host.name: "<host-id-value>"` — which matched no data in Timeline.

The same bug existed symmetrically in `UserPanelFooter` with `user.id`/`user.email` taking precedence over `user.name`.

### Root cause

`HostPanelFooter` derived the `host.name` used in the KQL filter from `identityFields`:

```ts
// Before — falls back to first identity field value (e.g. host.id) when host.name is absent
const hostName = useMemo(
  () => identityFields[EntityIdentifierFields.hostName] || Object.values(identityFields)[0] || '',
  [identityFields]
);
```

With Entity Store v2, `getEntityIdentifiersFromDocument` only returns the _highest-ranked_ EUID field (`host.id`), so `identityFields['host.name']` was `undefined` and the fallback was the `host.id` value.

### Fix

Added an explicit `hostName` / `userName` prop to the footer components that takes priority over the `identityFields`-derived value. The parent `HostPanel` and `UserPanel` already receive the correct human-readable name via their own props and now forward it:

```ts
// After
const hostName = useMemo(
  () => hostNameProp || identityFields[EntityIdentifierFields.hostName] || '',
  [hostNameProp, identityFields]
);
```

## Testing

- Unit test added for `HostPanelFooter` covering:
  - Correct KQL when `hostName` prop matches `identityFields['host.name']`
  - Correct KQL (`host.name: "webserver-01"`) when only `host.id` is present in `identityFields` (Entity Store v2 scenario)
  - `isDisabled` state when `hostName` is empty

### Manual verification steps

1. Enable feature flags: `entityAnalyticsNewHomePageEnabled`, `entityAnalyticsWatchlistEnabled`, `securitySolution:entityStoreEnableV2`, `entityAnalyticsEntityStoreV2`
2. Index a document with both `host.name` and `host.id` fields
3. Wait for the Entity Store transform to create the host entity record
4. Open **Security → Entity Analytics**, find the host in the Entities table
5. Open the host flyout → **Take action → Investigate in Timeline**
6. Verify the timeline filter reads `host.name: "<hostname>"` ✅ (previously it would read `host.name: "<host-id-value>"` ❌)

Made with [Cursor](https://cursor.com)