### PR TITLE
[Kibana Core] Fix CODEOWNER exclusions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2268,11 +2268,11 @@ x-pack/platform/test/plugin_api_integration/test_suites/platform/ @elastic/kiban
 #CC# /x-pack/plugins/global_search_providers/ @elastic/kibana-core
 
 # Exclude OAS error baseline file from @elastic/kibana-core ownership
-!/src/platform/packages/private/kbn-validate-oas/oas_error_baseline.json
+/src/platform/packages/private/kbn-validate-oas/oas_error_baseline.json
 # Exclude usage collection schemas from @elastic/kibana-core ownership
-!/src/platform/plugins/private/kibana_usage_collection/server/collectors/application_usage/schema.ts
-!/src/platform/plugins/private/kibana_usage_collection/server/collectors/management/schema.ts
-!/src/platform/plugins/private/kibana_usage_collection/server/collectors/management/types.ts
+/src/platform/plugins/private/kibana_usage_collection/server/collectors/application_usage/schema.ts
+/src/platform/plugins/private/kibana_usage_collection/server/collectors/management/schema.ts
+/src/platform/plugins/private/kibana_usage_collection/server/collectors/management/types.ts
 
 # Kibana Telemetry
 /.telemetryrc.json @elastic/kibana-core


### PR DESCRIPTION
## Summary

The syntax with `!` does not work. It should be an explicit line without a codeowner instead of negating the line.


Proof that we're getting pinged for those paths: https://github.com/elastic/kibana/pull/264387/changes