### PR TITLE
Add new badge to Entity analytics on side nav

### DIFF
--- a/x-pack/solutions/security/packages/navigation/src/navigation_tree/entity_analytics_navigation_tree.ts
+++ b/x-pack/solutions/security/packages/navigation/src/navigation_tree/entity_analytics_navigation_tree.ts
@@ -19,6 +19,7 @@ export const createEntityAnalyticsNavigationTree = (
       id: SecurityPageName.entityAnalyticsHomePage,
       icon: 'chartBarVerticalStack',
       link: securityLink(SecurityPageName.entityAnalyticsHomePage),
+      badgeType: 'new',
     };
   } else {
     return {


### PR DESCRIPTION
## Summary

Adding the `new` badge to the side nav for Entity analytics as per Iryna's request (https://elastic.slack.com/archives/C09U0KU22RY/p1776770584193449)

## How to verify
1. Open a space with the Security view
2. Click _More_ on the side navigation
3. Verify the New badge is visible next to Entity analytics
4. Click on _Entity analytics_ to navigate to the page
5. Navigate away to any other page
6. Click _More_ again and verify the New badge is no longer visible

<img width="1366" height="829" alt="Screenshot 2026-04-21 at 10 49 29 AM" src="https://github.com/user-attachments/assets/e4a98b37-5563-469c-9e70-e89c1ba8e062" />

https://github.com/user-attachments/assets/2767b222-6691-478d-9e39-7503542b71a9

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->