### PR TITLE
[Data views as code] Add new API schemas

### DIFF
--- a/src/platform/packages/shared/as-code/data-views-schema/index.ts
+++ b/src/platform/packages/shared/as-code/data-views-schema/index.ts
@@ -10,19 +10,23 @@
 export {
   AS_CODE_DATA_VIEW_REFERENCE_TYPE,
   AS_CODE_DATA_VIEW_SPEC_TYPE,
-  AS_CODE_ESQL_DATA_SOURCE_TYPE,
-} from './src/constants';
+} from './src/adhoc/constants';
+export { AS_CODE_ESQL_DATA_SOURCE_TYPE } from './src/constants';
 export {
   dataViewReferenceSchema,
   dataViewSchema,
   dataViewSpecSchema,
-} from './src/schema_data_view';
+} from './src/adhoc/data_views';
+export { runtimeFieldSchema } from './src/adhoc/runtime_fields';
+export { storedDataViewSchema } from './src/stored/data_views';
+export { storedRuntimeFieldSchema } from './src/stored/runtime_fields';
 export { esqlDataSourceSchema } from './src/schema_esql_data_source';
-export { runtimeFieldSchema } from './src/schema_runtime_field';
 export type {
   AsCodeDataView,
   AsCodeDataViewReference,
   AsCodeDataViewSpec,
   AsCodeEsqlDataSource,
   AsCodeRuntimeField,
+  AsCodeStoredDataView,
+  AsCodeStoredRuntimeField,
 } from './src/types';

--- a/src/platform/packages/shared/as-code/data-views-schema/src/adhoc/constants.ts
+++ b/src/platform/packages/shared/as-code/data-views-schema/src/adhoc/constants.ts
@@ -7,5 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-/** `type` discriminator for as-code `data_source`: ES|QL query. */
-export const AS_CODE_ESQL_DATA_SOURCE_TYPE = 'esql' as const;
+/** `type` discriminator for as-code `data_source`: saved Kibana data view id. */
+export const AS_CODE_DATA_VIEW_REFERENCE_TYPE = 'data_view_reference' as const;
+
+/** `type` discriminator for as-code `data_source`: inline DataViewSpec-shaped fields. */
+export const AS_CODE_DATA_VIEW_SPEC_TYPE = 'data_view_spec' as const;

--- a/src/platform/packages/shared/as-code/data-views-schema/src/adhoc/data_views.ts
+++ b/src/platform/packages/shared/as-code/data-views-schema/src/adhoc/data_views.ts
@@ -9,7 +9,8 @@
 
 import { schema } from '@kbn/config-schema';
 import { AS_CODE_DATA_VIEW_REFERENCE_TYPE, AS_CODE_DATA_VIEW_SPEC_TYPE } from './constants';
-import { runtimeFieldSchema } from './schema_runtime_field';
+import { commonDataViewSpecSchema } from '../common/data_views';
+import { runtimeFieldSchema } from './runtime_fields';
 
 export const dataViewReferenceSchema = schema.object(
   {
@@ -24,23 +25,9 @@ export const dataViewReferenceSchema = schema.object(
   { meta: { id: 'kbn-data-view-reference-schema', title: 'Data view reference' } }
 );
 
-export const dataViewSpecSchema = schema.object(
+export const dataViewSpecSchema = commonDataViewSpecSchema.extends(
   {
     type: schema.literal(AS_CODE_DATA_VIEW_SPEC_TYPE),
-    index_pattern: schema.string({
-      meta: {
-        description:
-          'The index pattern (Elasticsearch index expression) to use as the data source. Example: "my-index-*".',
-      },
-    }),
-    time_field: schema.maybe(
-      schema.string({
-        meta: {
-          description:
-            'The name of the time field in the index. Used for time-based filtering. Example: "@timestamp".',
-        },
-      })
-    ),
     runtime_fields: schema.maybe(schema.arrayOf(runtimeFieldSchema, { maxSize: 100 })),
   },
   { meta: { id: 'kbn-data-view-spec-schema', title: 'Data view inline spec' } }

--- a/src/platform/packages/shared/as-code/data-views-schema/src/adhoc/runtime_fields.test.ts
+++ b/src/platform/packages/shared/as-code/data-views-schema/src/adhoc/runtime_fields.test.ts
@@ -11,11 +11,8 @@ import {
   PRIMITIVE_RUNTIME_FIELD_TYPES,
   RUNTIME_FIELD_COMPOSITE_TYPE,
 } from '@kbn/data-views-plugin/common';
-import type {
-  compositeRuntimeFieldSchema,
-  primitiveRuntimeFieldSchema,
-} from './schema_runtime_field';
-import { runtimeFieldSchema } from './schema_runtime_field';
+import type { compositeRuntimeFieldSchema, primitiveRuntimeFieldSchema } from './runtime_fields';
+import { runtimeFieldSchema } from './runtime_fields';
 import type { TypeOf } from '@kbn/config-schema';
 
 const buildPrimitiveRuntimeField = (
@@ -36,7 +33,7 @@ const buildCompositeRuntimeField = (
   };
 };
 
-describe('schema_runtime_fields', () => {
+describe('runtime_fields', () => {
   describe('given an invalid type', () => {
     it('should throw an error', () => {
       // Given

--- a/src/platform/packages/shared/as-code/data-views-schema/src/adhoc/runtime_fields.ts
+++ b/src/platform/packages/shared/as-code/data-views-schema/src/adhoc/runtime_fields.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { schema } from '@kbn/config-schema';
+import {
+  commonFieldSchema,
+  commonRuntimeFieldSchema,
+  compositeSubfieldSchema,
+  RUNTIME_FIELD_COMPOSITE_TYPE,
+} from '../common/runtime_fields';
+
+export const primitiveRuntimeFieldSchema = schema.object({
+  ...commonFieldSchema,
+  ...commonRuntimeFieldSchema,
+});
+
+export const compositeRuntimeFieldSchema = schema.object({
+  type: schema.literal(RUNTIME_FIELD_COMPOSITE_TYPE),
+  fields: schema.arrayOf(compositeSubfieldSchema, { maxSize: 100 }),
+  ...commonRuntimeFieldSchema,
+});
+
+export const runtimeFieldSchema = schema.discriminatedUnion('type', [
+  primitiveRuntimeFieldSchema,
+  compositeRuntimeFieldSchema,
+]);

--- a/src/platform/packages/shared/as-code/data-views-schema/src/common/data_views.ts
+++ b/src/platform/packages/shared/as-code/data-views-schema/src/common/data_views.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { schema } from '@kbn/config-schema';
+
+export const commonDataViewSpecSchema = schema.object({
+  index_pattern: schema.string({
+    meta: {
+      description:
+        'The index pattern (Elasticsearch index expression) to use as the data source. Example: "my-index-*".',
+    },
+  }),
+  time_field: schema.maybe(
+    schema.string({
+      meta: {
+        description:
+          'The name of the time field in the index. Used for time-based filtering. Example: "@timestamp".',
+      },
+    })
+  ),
+});

--- a/src/platform/packages/shared/as-code/data-views-schema/src/common/runtime_fields.ts
+++ b/src/platform/packages/shared/as-code/data-views-schema/src/common/runtime_fields.ts
@@ -14,7 +14,7 @@ import type {
   RuntimeFieldCompositeType,
 } from '@kbn/data-views-plugin/common';
 
-const PRIMITIVE_RUNTIME_FIELD_TYPES: PrimitiveRuntimeFieldTypes = [
+export const PRIMITIVE_RUNTIME_FIELD_TYPES: PrimitiveRuntimeFieldTypes = [
   'keyword',
   'long',
   'double',
@@ -24,14 +24,14 @@ const PRIMITIVE_RUNTIME_FIELD_TYPES: PrimitiveRuntimeFieldTypes = [
   'geo_point',
 ];
 
-const RUNTIME_FIELD_COMPOSITE_TYPE: RuntimeFieldCompositeType = 'composite';
+export const RUNTIME_FIELD_COMPOSITE_TYPE: RuntimeFieldCompositeType = 'composite';
 
 const MAX_NAME_LENGTH = 1000;
 
 /**
  * Both composite and primitive runtime fields share the same base - name and script.
  */
-const commonRuntimeFieldSchema = {
+export const commonRuntimeFieldSchema = {
   /**
    * The name of the runtime field.
    * Example: 'my_runtime_field'
@@ -65,7 +65,7 @@ const commonRuntimeFieldSchema = {
 /**
  * The field definition is applicable for both top level fields in a primitive runtime field and subfields in a composite runtime field.
  */
-const commonFieldSchema = {
+export const commonFieldSchema = {
   /**
    * The type of the runtime field (e.g., 'keyword', 'long', 'date').
    * Example: 'keyword'
@@ -126,41 +126,18 @@ const commonFieldSchema = {
   ),
 };
 
-export const primitiveRuntimeFieldSchema = schema.object(
-  {
-    ...commonFieldSchema,
-    ...commonRuntimeFieldSchema,
-  },
-  { meta: { id: 'kbn-runtime-field-schema', title: 'Runtime field' } }
-);
-
-export const compositeRuntimeFieldSchema = schema.object(
-  {
-    type: schema.literal(RUNTIME_FIELD_COMPOSITE_TYPE),
-    fields: schema.arrayOf(
-      schema.object({
-        /**
-         * The name of the subfield.
-         * If the name is "field" and this subname is "name" the full name of the subfield will be "field.name".
-         */
-        name: schema.string({
-          minLength: 1,
-          maxLength: MAX_NAME_LENGTH,
-          meta: {
-            description:
-              'The name of the runtime subfield, it gets appended to the parent field name. Example: "parent_name.my_runtime_subfield".',
-          },
-        }),
-        ...commonFieldSchema,
-      }),
-      { maxSize: 100 }
-    ),
-    ...commonRuntimeFieldSchema,
-  },
-  { meta: { id: 'kbn-composite-runtime-field-schema', title: 'Composite runtime field' } }
-);
-
-export const runtimeFieldSchema = schema.discriminatedUnion('type', [
-  primitiveRuntimeFieldSchema,
-  compositeRuntimeFieldSchema,
-]);
+export const compositeSubfieldSchema = schema.object({
+  /**
+   * The name of the subfield.
+   * If the name is "field" and this subname is "name" the full name of the subfield will be "field.name".
+   */
+  name: schema.string({
+    minLength: 1,
+    maxLength: MAX_NAME_LENGTH,
+    meta: {
+      description:
+        'The name of the runtime subfield, it gets appended to the parent field name. Example: "parent_name.my_runtime_subfield".',
+    },
+  }),
+  ...commonFieldSchema,
+});

--- a/src/platform/packages/shared/as-code/data-views-schema/src/stored/data_views.ts
+++ b/src/platform/packages/shared/as-code/data-views-schema/src/stored/data_views.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { schema } from '@kbn/config-schema';
+import { commonDataViewSpecSchema } from '../common/data_views';
+import { storedRuntimeFieldSchema } from './runtime_fields';
+
+export const storedDataViewSchema = commonDataViewSpecSchema.extends(
+  {
+    id: schema.maybe(
+      schema.string({
+        meta: {
+          description:
+            'Kibana provides a unique identifier for each data view, or you can create your own.',
+        },
+      })
+    ),
+    name: schema.maybe(
+      schema.string({
+        meta: {
+          description: 'The name of the data view. Example: "Sample data view".',
+        },
+      })
+    ),
+    allow_hidden_indices: schema.maybe(
+      schema.boolean({
+        meta: {
+          description: 'Allow hidden and system indices.',
+        },
+      })
+    ),
+    runtime_fields: schema.maybe(schema.arrayOf(storedRuntimeFieldSchema, { maxSize: 100 })),
+  },
+  {
+    meta: { id: 'storedDataViewSchema' },
+  }
+);

--- a/src/platform/packages/shared/as-code/data-views-schema/src/stored/runtime_fields.ts
+++ b/src/platform/packages/shared/as-code/data-views-schema/src/stored/runtime_fields.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { schema } from '@kbn/config-schema';
+import {
+  commonFieldSchema,
+  commonRuntimeFieldSchema,
+  compositeSubfieldSchema,
+  RUNTIME_FIELD_COMPOSITE_TYPE,
+} from '../common/runtime_fields';
+
+const commonStoredRuntimeFieldSchema = {
+  popularity: schema.maybe(schema.number({ min: 0 })),
+};
+
+const primitiveStoredRuntimeFieldSchema = schema.object({
+  ...commonStoredRuntimeFieldSchema,
+  ...commonFieldSchema,
+  ...commonRuntimeFieldSchema,
+});
+
+const compositeStoredRuntimeFieldSchema = schema.object({
+  ...commonStoredRuntimeFieldSchema,
+  type: schema.literal(RUNTIME_FIELD_COMPOSITE_TYPE),
+  fields: schema.arrayOf(compositeSubfieldSchema.extends(commonStoredRuntimeFieldSchema), {
+    maxSize: 100,
+  }),
+  ...commonRuntimeFieldSchema,
+});
+
+export const storedRuntimeFieldSchema = schema.discriminatedUnion('type', [
+  primitiveStoredRuntimeFieldSchema,
+  compositeStoredRuntimeFieldSchema,
+]);

--- a/src/platform/packages/shared/as-code/data-views-schema/src/types.ts
+++ b/src/platform/packages/shared/as-code/data-views-schema/src/types.ts
@@ -7,16 +7,21 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 import type { TypeOf } from '@kbn/config-schema';
+import type { runtimeFieldSchema } from './adhoc/runtime_fields';
 import type {
   dataViewReferenceSchema,
   dataViewSchema,
   dataViewSpecSchema,
-} from './schema_data_view';
+} from './adhoc/data_views';
+import type { storedDataViewSchema } from './stored/data_views';
+import type { storedRuntimeFieldSchema } from './stored/runtime_fields';
 import type { esqlDataSourceSchema } from './schema_esql_data_source';
-import type { runtimeFieldSchema } from './schema_runtime_field';
 
 export type AsCodeRuntimeField = TypeOf<typeof runtimeFieldSchema>;
 export type AsCodeDataViewReference = TypeOf<typeof dataViewReferenceSchema>;
 export type AsCodeDataViewSpec = TypeOf<typeof dataViewSpecSchema>;
 export type AsCodeDataView = TypeOf<typeof dataViewSchema>;
 export type AsCodeEsqlDataSource = TypeOf<typeof esqlDataSourceSchema>;
+
+export type AsCodeStoredDataView = TypeOf<typeof storedDataViewSchema>;
+export type AsCodeStoredRuntimeField = TypeOf<typeof storedRuntimeFieldSchema>;


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/262225

To add the data views APIs we need new schemas that include more fields.
- Data views += id, name and allow_hidden_indices
- Runtime fields += Popularity

Ideally we want to reuse the existing schemas we created for the first part of the as code work, for that we can also add this ones in the `as-code/data-views-schema` package, so basically I'm going with something like:

```
as-code/data-views-schema
|__ common                   (shared schemas for both adhoc and stored schemas)
|       |__ data_views.ts
|       |__ runtime_fields.ts
|__ adhoc                   (specific implementation of the existing adhoc schemas)
|        |__ constsants.ts
|        |__ data_views.ts
|        |__ runtime_fields.ts
|__ stored                  (specific implementation of the new stored schemas)
         |__ data_views.ts
         |__ runtime_fields.ts
```


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



