### PR TITLE
[Security Solution] Discard preview scores for entities outside the store

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/routes/calculate_scores_v2.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/routes/calculate_scores_v2.test.ts
@@ -1,0 +1,134 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ElasticsearchClient, Logger, SavedObjectsClientContract } from '@kbn/core/server';
+import type { EntityUpdateClient } from '@kbn/entity-store/server';
+import { calculateScoresWithESQLV2 } from './calculate_scores_v2';
+import { fetchEntitiesByIds } from '../maintainer/utils/fetch_entities_by_ids';
+import { applyScoreModifiersFromEntities } from '../modifiers/apply_modifiers_from_entities';
+import { fetchWatchlistConfigs } from '../maintainer/utils/fetch_watchlist_configs';
+
+jest.mock('../maintainer/utils/fetch_entities_by_ids');
+jest.mock('../modifiers/apply_modifiers_from_entities');
+jest.mock('../maintainer/utils/fetch_watchlist_configs');
+
+describe('calculateScoresWithESQLV2', () => {
+  const esClient = {
+    search: jest.fn(),
+    esql: {
+      query: jest.fn(),
+    },
+  } as unknown as jest.Mocked<ElasticsearchClient>;
+  const logger = {} as Logger;
+  const crudClient = {} as EntityUpdateClient;
+  const soClient = {} as SavedObjectsClientContract;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+
+    (fetchWatchlistConfigs as jest.Mock).mockResolvedValue(new Map());
+    (esClient.search as jest.Mock).mockResolvedValue({
+      aggregations: {
+        by_entity_id: {
+          buckets: [{ key: { entity_id: 'host:known' } }, { key: { entity_id: 'host:missing' } }],
+          after_key: undefined,
+        },
+      },
+    });
+    (esClient.esql.query as jest.Mock).mockResolvedValue({
+      values: [
+        [
+          1,
+          50,
+          JSON.stringify({
+            id: 'alert-known',
+            index: '.alerts-security.alerts-default',
+            risk_score: '50',
+            contribution: '12',
+            time: '2026-04-21T00:00:00.000Z',
+            rule_name: 'Known alert',
+          }),
+          'host:known',
+        ],
+        [
+          1,
+          40,
+          JSON.stringify({
+            id: 'alert-missing',
+            index: '.alerts-security.alerts-default',
+            risk_score: '40',
+            contribution: '8',
+            time: '2026-04-21T00:00:00.000Z',
+            rule_name: 'Missing alert',
+          }),
+          'host:missing',
+        ],
+      ],
+    });
+    (fetchEntitiesByIds as jest.Mock).mockResolvedValue(
+      new Map([
+        [
+          'host:known',
+          {
+            entity: {
+              id: 'host:known',
+            },
+          },
+        ],
+      ])
+    );
+    (applyScoreModifiersFromEntities as jest.Mock).mockImplementation(({ page }) =>
+      page.scores.map((score: { entity_id: string }) => ({
+        id_field: 'entity.id',
+        id_value: score.entity_id,
+      }))
+    );
+  });
+
+  it('discards preview scores for entities missing from the entity store', async () => {
+    const response = await calculateScoresWithESQLV2({
+      afterKeys: {},
+      identifierType: 'host',
+      index: 'test-index',
+      pageSize: 100,
+      range: { start: 'now-15d', end: 'now' },
+      runtimeMappings: {},
+      filter: undefined,
+      weights: [],
+      alertSampleSizePerShard: 100,
+      excludeAlertStatuses: ['closed'],
+      excludeAlertTags: [],
+      filters: [],
+      esClient,
+      logger,
+      crudClient,
+      soClient,
+      namespace: 'default',
+    });
+
+    expect(applyScoreModifiersFromEntities).toHaveBeenCalledWith(
+      expect.objectContaining({
+        page: expect.objectContaining({
+          scores: [expect.objectContaining({ entity_id: 'host:known' })],
+        }),
+      })
+    );
+    expect(response).toEqual({
+      after_keys: {
+        host: {},
+      },
+      scores: {
+        host: [
+          {
+            id_field: 'entity.id',
+            id_value: 'host:known',
+          },
+        ],
+      },
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/routes/calculate_scores_v2.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/routes/calculate_scores_v2.test.ts
@@ -7,6 +7,7 @@
 
 import type { ElasticsearchClient, Logger, SavedObjectsClientContract } from '@kbn/core/server';
 import type { EntityUpdateClient } from '@kbn/entity-store/server';
+import { EntityType } from '../../../../../common/entity_analytics/types';
 import { calculateScoresWithESQLV2 } from './calculate_scores_v2';
 import { fetchEntitiesByIds } from '../maintainer/utils/fetch_entities_by_ids';
 import { applyScoreModifiersFromEntities } from '../modifiers/apply_modifiers_from_entities';
@@ -92,7 +93,7 @@ describe('calculateScoresWithESQLV2', () => {
   it('discards preview scores for entities missing from the entity store', async () => {
     const response = await calculateScoresWithESQLV2({
       afterKeys: {},
-      identifierType: 'host',
+      identifierType: EntityType.host,
       index: 'test-index',
       pageSize: 100,
       range: { start: 'now-15d', end: 'now' },

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/routes/calculate_scores_v2.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/routes/calculate_scores_v2.ts
@@ -137,8 +137,10 @@ export const calculateScoresWithESQLV2 = async ({
         entityIds,
         logger,
         errorContext:
-          'Error fetching entities for preview modifier application. Scoring will proceed without modifiers',
+          'Error fetching entities for preview modifier application. Scores for entities missing from the store will be discarded',
       });
+      const knownEntityIds = new Set(entities.keys());
+      const inStoreBaseScores = baseScores.filter((score) => knownEntityIds.has(score.entity_id));
 
       const scores = applyScoreModifiersFromEntities({
         now,
@@ -146,7 +148,7 @@ export const calculateScoresWithESQLV2 = async ({
         scoreType: 'base',
         weights,
         page: {
-          scores: baseScores,
+          scores: inStoreBaseScores,
           identifierField: 'entity.id',
         },
         entities,

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/routes/calculate_scores_v2.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/routes/calculate_scores_v2.ts
@@ -137,7 +137,7 @@ export const calculateScoresWithESQLV2 = async ({
         entityIds,
         logger,
         errorContext:
-          'Error fetching entities for preview modifier application. Scores for entities missing from the store will be discarded',
+          'Error fetching entities for preview scoring. Scores for entities that cannot be resolved from the store will be discarded',
       });
       const knownEntityIds = new Set(entities.keys());
       const inStoreBaseScores = baseScores.filter((score) => knownEntityIds.has(score.entity_id));


### PR DESCRIPTION
## Summary
- keep the risk score preview v2 API aligned with maintainer behavior by dropping alert-derived entity IDs that are not present in Entity Store
- add a focused regression test around `calculateScoresWithESQLV2()` so preview parity is covered without refactoring the pipeline
- clarify the preview scoring warning message so it covers unresolved Entity Store lookups as well as truly missing entities

## Known caveat
- preview still paginates on alert-derived entity IDs first and filters against Entity Store afterward, so a response can contain fewer than the requested `page_size` for a given entity type, including zero results, if many scored entities are absent from or cannot be resolved from Entity Store
- this is acceptable for the current management UI because it only renders the top 5 preview rows per entity type and the backend default page size remains 1000



<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->