### PR TITLE
[SLO] Fix APM embeddable ids

### DIFF
--- a/x-pack/solutions/observability/plugins/slo/public/components/alert_details/components/custom_panels/apm/apm_alert_details.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/components/alert_details/components/custom_panels/apm/apm_alert_details.tsx
@@ -28,7 +28,7 @@ export function APMLatencyAlertDetails({
       <APMEmbeddableRoot
         slo={slo}
         dataTimeRange={dataTimeRange}
-        embeddableId={'APM_ALERTING_LATENCY_CHART_EMBEDDABLE'}
+        embeddableId={'apm_alerting_latency_chart'}
         alert={alert}
         rule={rule}
       />
@@ -37,7 +37,7 @@ export function APMLatencyAlertDetails({
           <APMEmbeddableRoot
             slo={slo}
             dataTimeRange={dataTimeRange}
-            embeddableId={'APM_ALERTING_THROUGHPUT_CHART_EMBEDDABLE'}
+            embeddableId={'apm_alerting_throughput_chart'}
             alert={alert}
             rule={rule}
           />
@@ -46,7 +46,7 @@ export function APMLatencyAlertDetails({
           <APMEmbeddableRoot
             slo={slo}
             dataTimeRange={dataTimeRange}
-            embeddableId={'APM_ALERTING_FAILED_TRANSACTIONS_CHART_EMBEDDABLE'}
+            embeddableId={'apm_alerting_failed_transactions_chart'}
             alert={alert}
             rule={rule}
           />
@@ -67,7 +67,7 @@ export function APMAvailabilityAlertDetails({
       <APMEmbeddableRoot
         slo={slo}
         dataTimeRange={dataTimeRange}
-        embeddableId={'APM_ALERTING_FAILED_TRANSACTIONS_CHART_EMBEDDABLE'}
+        embeddableId={'apm_alerting_failed_transactions_chart'}
         alert={alert}
         rule={rule}
       />
@@ -76,7 +76,7 @@ export function APMAvailabilityAlertDetails({
           <APMEmbeddableRoot
             slo={slo}
             dataTimeRange={dataTimeRange}
-            embeddableId={'APM_ALERTING_THROUGHPUT_CHART_EMBEDDABLE'}
+            embeddableId={'apm_alerting_throughput_chart'}
             alert={alert}
             rule={rule}
           />
@@ -85,7 +85,7 @@ export function APMAvailabilityAlertDetails({
           <APMEmbeddableRoot
             slo={slo}
             dataTimeRange={dataTimeRange}
-            embeddableId={'APM_ALERTING_LATENCY_CHART_EMBEDDABLE'}
+            embeddableId={'apm_alerting_latency_chart'}
             alert={alert}
             rule={rule}
           />

--- a/x-pack/solutions/observability/plugins/slo/public/components/alert_details/components/custom_panels/apm/embeddable_root.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/components/alert_details/components/custom_panels/apm/embeddable_root.tsx
@@ -18,11 +18,9 @@ import { apmTransactionDurationIndicatorSchema } from '@kbn/slo-schema';
 import type { BurnRateAlert, BurnRateRule, TimeRange } from '../../../types';
 
 type EmbeddableId =
-  | 'APM_THROUGHPUT_CHART_EMBEDDABLE'
-  | 'APM_LATENCY_CHART_EMBEDDABLE'
-  | 'APM_ALERTING_FAILED_TRANSACTIONS_CHART_EMBEDDABLE'
-  | 'APM_ALERTING_LATENCY_CHART_EMBEDDABLE'
-  | 'APM_ALERTING_THROUGHPUT_CHART_EMBEDDABLE';
+  | 'apm_alerting_failed_transactions_chart'
+  | 'apm_alerting_latency_chart'
+  | 'apm_alerting_throughput_chart';
 
 export type APMTransactionDurationSLOResponse = GetSLOResponse & {
   indicator: APMTransactionDurationIndicator;


### PR DESCRIPTION
## Summary

Closes #264008

As part of the dashboards as code effort, #254079 introduced a change by which embeddable ids were changed. While most usages were properly updated, a couple of hardcoded string references in the SLO plugin were left unchanged. This is leading to issues where the APM embeddables in the alert details page are failing to be displayed because the code is unable to find the appropiate embeddable factory when searching by it's old id.

In order to prevent issues like this in the future, I plan to do a follow up PR providing a proper fix to this issue in a way that allows the SLO plugin to consume the embeddable id constants defined in APM instead of having to relay on redefining the strings values in both plugins, which can lead to inconsistencies as this one. But, given the timing with the 9.4 BC I've decided to go first for this quick-and-easy approach of just changing the strings in the SLO plugin as well. While this is not ideal code-wise it will allow us to have a low-risk fix in time to be backported to 9.4 so we don't ship this view in a broken state.

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->