### PR TITLE
[Scout Test Review] Do not post extra issue comments, drop severity

### DIFF
--- a/.macroscope/scout-review.md
+++ b/.macroscope/scout-review.md
@@ -40,7 +40,7 @@ These rules must be verified on every applicable UI test file. Do not skip them:
 Post detailed findings as inline PR comments on the offending line. Each inline comment must use a collapsible section to keep the PR readable. Structure:
 
 ​```markdown
-<severity emoji> **[<rule name>](<link to best-practices section>)**
+**[<rule name>](<link to best-practices section>)**
 
 <1–2 sentence high-level overview of the issue and the fix.>
 
@@ -52,8 +52,7 @@ Post detailed findings as inline PR comments on the offending line. Each inline 
 </details>
 ​```
 
-- **Severity emoji:** 🟡 Major, 🔵 Minor, ⚪ Nit (blocking issues reported by the reviewer skill should be treated as "major")
-- State the rule violated as a **Markdown link** whose text is the section heading from the matching best practices document and whose URL is the section-scoped URL (see routing below). The link is required, not optional.
+- **Rule link (optional).** If a best-practices section genuinely matches, state the rule as a **Markdown link** whose text is the section heading and whose URL is the section-scoped URL (see routing below). If no section matches, or if a match would feel forced or contrived (e.g. making the heading fit a finding it doesn't really describe), **omit the rule link line entirely** and start the comment with the overview prose. Do not invent a match, do not reuse a vaguely-related section, and do not fall back to a doc-root link. A finding without a rule link is fine when the overview alone is self-explanatory.
 - **Overview:** plain prose, no code. A developer skimming the PR should grasp what's wrong and whether to act on it without expanding.
 - **Details:** everything else — reasoning, code snippets, suggested diffs, links to related rules.
 
@@ -69,53 +68,43 @@ Scout best practices live in three files. Don't guess from keywords — read the
 
 When a section with the same intent exists in both the specific doc and the general doc, prefer the specific one.
 
-### Always include the section anchor
+### Always include the section anchor (when you link)
 
-Every finding must link to a **section-scoped URL**, not the doc root. Infer the `#anchor` from the explicit heading id in the markdown source (e.g., the heading `## Use Playwright auto-waiting [leverage-playwright-auto-waiting]` yields `#leverage-playwright-auto-waiting`). Only fall back to the doc root URL if the rule genuinely has no matching section (rare — re-read the doc first).
+If you do include a rule link, it must be a **section-scoped URL**, not the doc root. Infer the `#anchor` from the explicit heading id in the markdown source (e.g., the heading `## Use Playwright auto-waiting [leverage-playwright-auto-waiting]` yields `#leverage-playwright-auto-waiting`).
 
 Format the citation as a Markdown link using the section heading text as the link label:
 
 ``​`
-🔵 [Use Playwright auto-waiting](https://www.elastic.co/docs/extend/kibana/scout/ui-best-practices#leverage-playwright-auto-waiting)
+[Use Playwright auto-waiting](https://www.elastic.co/docs/extend/kibana/scout/ui-best-practices#leverage-playwright-auto-waiting)
 ​```
 
-Do **not** use bare parenthetical labels like `(best practices)` or `(ui best practices)` — the citation must be a real link that takes the reader to the specific section. If you cannot identify a specific section, state the rule in plain text rather than linking to the wrong document.
+Do **not** use bare parenthetical labels like `(best practices)` or `(ui best practices)`, do **not** link to the doc root, and do **not** force-fit a loosely-related section just to have a link. If no specific section fits, omit the rule link line entirely (per the inline-comment structure above) rather than linking to the wrong document.
 
-### Summary comment (one per PR)
+### Review body (compact, one line + footer)
 
-Post one summary comment per PR with a `## Scout Test Review` header. On re-runs, edit it in place — never post a second one.
+The summary lives in the **PR review body** — not in a separate top-level issue comment. Do **not** post an additional issue comment summarizing the review; the review body is the only summary surface.
 
-The summary has two parts:
+Keep the review body compact: a single bolded label line stating the current status, followed by the footer. No heading (`##`), no review log, no severity breakdown, no per-commit history.
 
-**1. Current status (always present)**
-
-One line stating what was found on the latest review. Examples:
-
-- `Found 2 issues (1 🟡 Major, 1 🔵 Minor). See inline comments for details.`
-- `Found 1 issue (1 🟡 Major). See inline comments for details.`
-- `No issues found ✅`
-- `All issues resolved ✅`
-
-**2. Footer (always present, verbatim)**
-
-​`markdown
-<sup>Share feedback in the [#appex-qa](https://elastic.slack.com/archives/C04HT4P1YS3) channel.</sup>
-​`
-
-**Summary comment template:**
+**Review body template (use verbatim):**
 
 ​```markdown
+**Scout Test Review**: <current status>
 
-## Scout Test Review
-
-<current status line>
-
-<footer>
+<sup>Share feedback in the [#appex-qa](https://elastic.slack.com/archives/C04HT4P1YS3) channel.</sup>
 ​```
+
+**Current status** is one short clause. Examples:
+
+- `found 3 issues. See inline comments for details.`
+- `found 1 issue. See inline comments for details.`
+
+Do not add finding counts by severity, per-commit review logs, experimental disclaimers, or any other text to the review body.
 
 ### Re-run behavior
 
 On each re-run:
 
-1. **Update the status line** to reflect the current state of the PR. If the developer fixed an issue, it's no longer in the count. If the developer fixed all issues, "All issues resolved ✅"
-2. **Do not duplicate inline comments** on lines you've already commented on, unless the code on that line has changed (update the existing comment).
+1. **Update the status**: if an inline comment was addressed in a recent commit, update and resolve the comment.
+2. **Do not post an additional top-level issue comment** for re-runs — even to acknowledge new commits or say "no new issues found". Silence on re-runs with nothing new to add is the correct behavior.
+3. **Do not duplicate inline comments** on lines you've already commented on, unless the code on that line has changed (update the existing comment).


### PR DESCRIPTION
This PR updates the Scout Test Review custom instructions to not post extra issue comments on the PR (usually with the "## Scout Test Review" heading. This reduces the overall PR noise / keeps our review compact.