### PR TITLE
[Storage Index Adapter] Fix index template creation on Serverless

### DIFF
--- a/config/serverless.oblt.yml
+++ b/config/serverless.oblt.yml
@@ -109,6 +109,3 @@ xpack.ml.compatibleModuleType: 'observability'
 
 # Disable the embedded Dev Console
 console.ui.embeddedEnabled: false
-
-# TODO: Remove this before merging
-xpack.evals.enabled: true

--- a/config/serverless.oblt.yml
+++ b/config/serverless.oblt.yml
@@ -110,5 +110,5 @@ xpack.ml.compatibleModuleType: 'observability'
 # Disable the embedded Dev Console
 console.ui.embeddedEnabled: false
 
-# TODO: Remove this once before merging
+# TODO: Remove this before merging
 xpack.evals.enabled: true

--- a/config/serverless.oblt.yml
+++ b/config/serverless.oblt.yml
@@ -109,3 +109,5 @@ xpack.ml.compatibleModuleType: 'observability'
 
 # Disable the embedded Dev Console
 console.ui.embeddedEnabled: false
+
+xpack.evals.enabled: true

--- a/config/serverless.oblt.yml
+++ b/config/serverless.oblt.yml
@@ -110,4 +110,5 @@ xpack.ml.compatibleModuleType: 'observability'
 # Disable the embedded Dev Console
 console.ui.embeddedEnabled: false
 
+# TODO: Remove this once before merging
 xpack.evals.enabled: true

--- a/src/platform/packages/shared/kbn-storage-adapter/src/index_adapter/index.test.ts
+++ b/src/platform/packages/shared/kbn-storage-adapter/src/index_adapter/index.test.ts
@@ -8,6 +8,8 @@
  */
 
 import type { ElasticsearchClient, Logger } from '@kbn/core/server';
+import type { TransportResult } from '@elastic/elasticsearch';
+import { errors } from '@elastic/elasticsearch';
 import type { StorageTransportOptions } from '../..';
 import { StorageIndexAdapter, type StorageSettings } from '../..';
 
@@ -184,7 +186,39 @@ describe('StorageIndexAdapter - transport options forwarding', () => {
     );
   });
 
-  it('omits index template settings on serverless', async () => {
+  it('omits index template settings when isServerless option is true', async () => {
+    const adapter = new StorageIndexAdapter(esClient, loggerMock, storageSettings, {
+      isServerless: true,
+    });
+    const client = adapter.getClient();
+
+    await client.index({ id: 'doc1', document: { foo: 'bar' } });
+
+    expect(esClient.indices.putIndexTemplate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        template: expect.not.objectContaining({ settings: expect.anything() }),
+      })
+    );
+  });
+
+  it('includes index template settings when isServerless option is false', async () => {
+    const adapter = new StorageIndexAdapter(esClient, loggerMock, storageSettings, {
+      isServerless: false,
+    });
+    const client = adapter.getClient();
+
+    await client.index({ id: 'doc1', document: { foo: 'bar' } });
+
+    expect(esClient.indices.putIndexTemplate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        template: expect.objectContaining({
+          settings: expect.objectContaining({ auto_expand_replicas: '0-1' }),
+        }),
+      })
+    );
+  });
+
+  it('omits settings when info() reports serverless and isServerless is not provided', async () => {
     (esClient.info as jest.Mock).mockResolvedValue({
       version: { build_flavor: 'serverless' },
     });
@@ -202,10 +236,74 @@ describe('StorageIndexAdapter - transport options forwarding', () => {
     );
   });
 
-  it('caches the serverless detection across writes', async () => {
-    (esClient.info as jest.Mock).mockResolvedValue({
-      version: { build_flavor: 'serverless' },
+  it('does not call info() when isServerless option is provided', async () => {
+    const adapter = new StorageIndexAdapter(esClient, loggerMock, storageSettings, {
+      isServerless: true,
     });
+    const client = adapter.getClient();
+
+    await client.index({ id: 'doc1', document: { foo: 'bar' } });
+
+    expect(esClient.info).not.toHaveBeenCalled();
+  });
+
+  it('retries without settings when both info() and isServerless are unavailable', async () => {
+    (esClient.info as jest.Mock).mockRejectedValue(new Error('forbidden'));
+
+    const serverlessError = new errors.ResponseError({
+      statusCode: 400,
+      headers: {},
+      warnings: [],
+      meta: {} as any,
+      body: {
+        error: {
+          type: 'illegal_argument_exception',
+          reason:
+            'Settings [index.auto_expand_replicas,index.number_of_shards] are not available when running in serverless mode',
+        },
+      },
+    } as TransportResult);
+    (esClient.indices.putIndexTemplate as jest.Mock).mockRejectedValueOnce(serverlessError);
+
+    const adapter = new StorageIndexAdapter(esClient, loggerMock, storageSettings);
+    const client = adapter.getClient();
+
+    await client.index({ id: 'doc1', document: { foo: 'bar' } });
+
+    expect(esClient.indices.putIndexTemplate).toHaveBeenCalledTimes(2);
+    expect(esClient.indices.putIndexTemplate).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        template: expect.objectContaining({
+          settings: expect.objectContaining({ auto_expand_replicas: '0-1' }),
+        }),
+      })
+    );
+    expect(esClient.indices.putIndexTemplate).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        template: expect.not.objectContaining({ settings: expect.anything() }),
+      })
+    );
+  });
+
+  it('skips settings on subsequent writes after reactive serverless detection', async () => {
+    (esClient.info as jest.Mock).mockRejectedValue(new Error('forbidden'));
+
+    const serverlessError = new errors.ResponseError({
+      statusCode: 400,
+      headers: {},
+      warnings: [],
+      meta: {} as any,
+      body: {
+        error: {
+          type: 'illegal_argument_exception',
+          reason:
+            'Settings [index.auto_expand_replicas,index.number_of_shards] are not available when running in serverless mode',
+        },
+      },
+    } as TransportResult);
+    (esClient.indices.putIndexTemplate as jest.Mock).mockRejectedValueOnce(serverlessError);
 
     const adapter = new StorageIndexAdapter(esClient, loggerMock, storageSettings);
     const client = adapter.getClient();
@@ -213,21 +311,11 @@ describe('StorageIndexAdapter - transport options forwarding', () => {
     await client.index({ id: 'doc1', document: { foo: 'bar' } });
     await client.index({ id: 'doc2', document: { foo: 'baz' } });
 
-    expect(esClient.info).toHaveBeenCalledTimes(1);
-    expect(esClient.indices.putIndexTemplate).toHaveBeenCalledTimes(2);
-  });
-
-  it('includes index template settings on non-serverless', async () => {
-    const adapter = new StorageIndexAdapter(esClient, loggerMock, storageSettings);
-    const client = adapter.getClient();
-
-    await client.index({ id: 'doc1', document: { foo: 'bar' } });
-
-    expect(esClient.indices.putIndexTemplate).toHaveBeenCalledWith(
+    expect(esClient.indices.putIndexTemplate).toHaveBeenCalledTimes(3);
+    expect(esClient.indices.putIndexTemplate).toHaveBeenNthCalledWith(
+      3,
       expect.objectContaining({
-        template: expect.objectContaining({
-          settings: expect.objectContaining({ auto_expand_replicas: '0-1' }),
-        }),
+        template: expect.not.objectContaining({ settings: expect.anything() }),
       })
     );
   });

--- a/src/platform/packages/shared/kbn-storage-adapter/src/index_adapter/index.test.ts
+++ b/src/platform/packages/shared/kbn-storage-adapter/src/index_adapter/index.test.ts
@@ -8,6 +8,8 @@
  */
 
 import type { ElasticsearchClient, Logger } from '@kbn/core/server';
+import type { TransportResult } from '@elastic/elasticsearch';
+import { errors } from '@elastic/elasticsearch';
 import type { StorageTransportOptions } from '../..';
 import { StorageIndexAdapter, type StorageSettings } from '../..';
 
@@ -177,6 +179,75 @@ describe('StorageIndexAdapter - transport options forwarding', () => {
             number_of_shards: 1,
           }),
         }),
+      })
+    );
+  });
+
+  it('retries index template without settings on serverless ES', async () => {
+    const serverlessError = new errors.ResponseError({
+      statusCode: 400,
+      headers: {},
+      warnings: [],
+      meta: {} as any,
+      body: {
+        error: {
+          type: 'illegal_argument_exception',
+          reason:
+            'Settings [index.auto_expand_replicas,index.number_of_shards] are not available when running in serverless mode',
+        },
+      },
+    } as TransportResult);
+    (esClient.indices.putIndexTemplate as jest.Mock).mockRejectedValueOnce(serverlessError);
+
+    const adapter = new StorageIndexAdapter(esClient, loggerMock, storageSettings);
+    const client = adapter.getClient();
+
+    await client.index({ id: 'doc1', document: { foo: 'bar' } });
+
+    expect(esClient.indices.putIndexTemplate).toHaveBeenCalledTimes(2);
+    expect(esClient.indices.putIndexTemplate).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        template: expect.objectContaining({
+          settings: expect.objectContaining({ auto_expand_replicas: '0-1' }),
+        }),
+      })
+    );
+    expect(esClient.indices.putIndexTemplate).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        template: expect.not.objectContaining({ settings: expect.anything() }),
+      })
+    );
+  });
+
+  it('skips settings on subsequent writes after serverless detection', async () => {
+    const serverlessError = new errors.ResponseError({
+      statusCode: 400,
+      headers: {},
+      warnings: [],
+      meta: {} as any,
+      body: {
+        error: {
+          type: 'illegal_argument_exception',
+          reason:
+            'Settings [index.auto_expand_replicas,index.number_of_shards] are not available when running in serverless mode',
+        },
+      },
+    } as TransportResult);
+    (esClient.indices.putIndexTemplate as jest.Mock).mockRejectedValueOnce(serverlessError);
+
+    const adapter = new StorageIndexAdapter(esClient, loggerMock, storageSettings);
+    const client = adapter.getClient();
+
+    await client.index({ id: 'doc1', document: { foo: 'bar' } });
+    await client.index({ id: 'doc2', document: { foo: 'baz' } });
+
+    expect(esClient.indices.putIndexTemplate).toHaveBeenCalledTimes(3);
+    expect(esClient.indices.putIndexTemplate).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({
+        template: expect.not.objectContaining({ settings: expect.anything() }),
       })
     );
   });

--- a/src/platform/packages/shared/kbn-storage-adapter/src/index_adapter/index.test.ts
+++ b/src/platform/packages/shared/kbn-storage-adapter/src/index_adapter/index.test.ts
@@ -183,7 +183,7 @@ describe('StorageIndexAdapter - transport options forwarding', () => {
     );
   });
 
-  it('retries index template without settings on serverless ES', async () => {
+  it('retries index template without settings on serverless', async () => {
     const serverlessError = new errors.ResponseError({
       statusCode: 400,
       headers: {},

--- a/src/platform/packages/shared/kbn-storage-adapter/src/index_adapter/index.test.ts
+++ b/src/platform/packages/shared/kbn-storage-adapter/src/index_adapter/index.test.ts
@@ -8,8 +8,6 @@
  */
 
 import type { ElasticsearchClient, Logger } from '@kbn/core/server';
-import type { TransportResult } from '@elastic/elasticsearch';
-import { errors } from '@elastic/elasticsearch';
 import type { StorageTransportOptions } from '../..';
 import { StorageIndexAdapter, type StorageSettings } from '../..';
 
@@ -35,6 +33,9 @@ const storageSettings = {
 
 const createMockEsClient = () => {
   const client = {
+    info: jest.fn().mockResolvedValue({
+      version: { build_flavor: 'default' },
+    }),
     search: jest.fn().mockResolvedValue({
       hits: { hits: [{ _id: 'doc1', _index: 'test_index', _source: { foo: 'bar' } }] },
     }),
@@ -183,59 +184,28 @@ describe('StorageIndexAdapter - transport options forwarding', () => {
     );
   });
 
-  it('retries index template without settings on serverless', async () => {
-    const serverlessError = new errors.ResponseError({
-      statusCode: 400,
-      headers: {},
-      warnings: [],
-      meta: {} as any,
-      body: {
-        error: {
-          type: 'illegal_argument_exception',
-          reason:
-            'Settings [index.auto_expand_replicas,index.number_of_shards] are not available when running in serverless mode',
-        },
-      },
-    } as TransportResult);
-    (esClient.indices.putIndexTemplate as jest.Mock).mockRejectedValueOnce(serverlessError);
+  it('omits index template settings on serverless', async () => {
+    (esClient.info as jest.Mock).mockResolvedValue({
+      version: { build_flavor: 'serverless' },
+    });
 
     const adapter = new StorageIndexAdapter(esClient, loggerMock, storageSettings);
     const client = adapter.getClient();
 
     await client.index({ id: 'doc1', document: { foo: 'bar' } });
 
-    expect(esClient.indices.putIndexTemplate).toHaveBeenCalledTimes(2);
-    expect(esClient.indices.putIndexTemplate).toHaveBeenNthCalledWith(
-      1,
-      expect.objectContaining({
-        template: expect.objectContaining({
-          settings: expect.objectContaining({ auto_expand_replicas: '0-1' }),
-        }),
-      })
-    );
-    expect(esClient.indices.putIndexTemplate).toHaveBeenNthCalledWith(
-      2,
+    expect(esClient.info).toHaveBeenCalledTimes(1);
+    expect(esClient.indices.putIndexTemplate).toHaveBeenCalledWith(
       expect.objectContaining({
         template: expect.not.objectContaining({ settings: expect.anything() }),
       })
     );
   });
 
-  it('skips settings on subsequent writes after serverless detection', async () => {
-    const serverlessError = new errors.ResponseError({
-      statusCode: 400,
-      headers: {},
-      warnings: [],
-      meta: {} as any,
-      body: {
-        error: {
-          type: 'illegal_argument_exception',
-          reason:
-            'Settings [index.auto_expand_replicas,index.number_of_shards] are not available when running in serverless mode',
-        },
-      },
-    } as TransportResult);
-    (esClient.indices.putIndexTemplate as jest.Mock).mockRejectedValueOnce(serverlessError);
+  it('caches the serverless detection across writes', async () => {
+    (esClient.info as jest.Mock).mockResolvedValue({
+      version: { build_flavor: 'serverless' },
+    });
 
     const adapter = new StorageIndexAdapter(esClient, loggerMock, storageSettings);
     const client = adapter.getClient();
@@ -243,11 +213,21 @@ describe('StorageIndexAdapter - transport options forwarding', () => {
     await client.index({ id: 'doc1', document: { foo: 'bar' } });
     await client.index({ id: 'doc2', document: { foo: 'baz' } });
 
-    expect(esClient.indices.putIndexTemplate).toHaveBeenCalledTimes(3);
-    expect(esClient.indices.putIndexTemplate).toHaveBeenNthCalledWith(
-      3,
+    expect(esClient.info).toHaveBeenCalledTimes(1);
+    expect(esClient.indices.putIndexTemplate).toHaveBeenCalledTimes(2);
+  });
+
+  it('includes index template settings on non-serverless', async () => {
+    const adapter = new StorageIndexAdapter(esClient, loggerMock, storageSettings);
+    const client = adapter.getClient();
+
+    await client.index({ id: 'doc1', document: { foo: 'bar' } });
+
+    expect(esClient.indices.putIndexTemplate).toHaveBeenCalledWith(
       expect.objectContaining({
-        template: expect.not.objectContaining({ settings: expect.anything() }),
+        template: expect.objectContaining({
+          settings: expect.objectContaining({ auto_expand_replicas: '0-1' }),
+        }),
       })
     );
   });

--- a/src/platform/packages/shared/kbn-storage-adapter/src/index_adapter/index.ts
+++ b/src/platform/packages/shared/kbn-storage-adapter/src/index_adapter/index.ts
@@ -84,14 +84,6 @@ function isNotFoundError(error: Error): error is errors.ResponseError & { status
   return isResponseError(error) && error.statusCode === 404;
 }
 
-function isServerlessSettingsError(error: unknown): boolean {
-  if (!isResponseError(error as Error)) {
-    return false;
-  }
-  const reason: string = (error as errors.ResponseError).body?.error?.reason ?? '';
-  return reason.includes('not available when running in serverless mode');
-}
-
 /*
  * When calling into Elasticsearch, the stack trace is lost.
  * If we create an error before calling, and append it to
@@ -151,7 +143,7 @@ export class StorageIndexAdapter<
 
   private readonly logger: Logger;
   private updateMappingsPromise: Promise<void> | undefined;
-  private isServerless: boolean | undefined;
+  private serverlessCheck: Promise<boolean> | undefined;
 
   constructor(
     private readonly esClient: ElasticsearchClient,
@@ -160,6 +152,16 @@ export class StorageIndexAdapter<
     private readonly options: StorageIndexAdapterOptions<TApplicationType> = {}
   ) {
     this.logger = logger.get('storage').get(this.storage.name);
+  }
+
+  private detectServerless(): Promise<boolean> {
+    if (!this.serverlessCheck) {
+      this.serverlessCheck = this.esClient
+        .info()
+        .then((info) => info.version.build_flavor === 'serverless')
+        .catch(() => false);
+    }
+    return this.serverlessCheck;
   }
 
   private getSearchIndexPattern(): string {
@@ -172,60 +174,34 @@ export class StorageIndexAdapter<
 
   private async createOrUpdateIndexTemplate(): Promise<void> {
     const version = getSchemaVersion(this.storage);
+    const isServerless = await this.detectServerless();
 
-    const mappings: IndicesPutIndexTemplateIndexTemplateMapping['mappings'] = {
-      _meta: { version },
-      dynamic: 'strict',
-      properties: {
-        ...mapValues(this.storage.schema.properties, toElasticsearchMappingProperty),
+    const template: IndicesPutIndexTemplateIndexTemplateMapping = {
+      ...(isServerless ? {} : { settings: StorageIndexAdapter.INDEX_SETTINGS }),
+      mappings: {
+        _meta: { version },
+        dynamic: 'strict',
+        properties: {
+          ...mapValues(this.storage.schema.properties, toElasticsearchMappingProperty),
+        },
+      },
+      aliases: {
+        [getAliasName(this.storage.name)]: {
+          is_write_index: true,
+        },
       },
     };
 
-    const aliases: IndicesPutIndexTemplateIndexTemplateMapping['aliases'] = {
-      [getAliasName(this.storage.name)]: {
-        is_write_index: true,
-      },
-    };
-
-    const baseRequest = {
-      name: getIndexTemplateName(this.storage.name),
-      create: false as const,
-      allow_auto_create: false as const,
-      index_patterns: getIndexPattern(this.storage.name),
-      _meta: { version },
-    };
-
-    const putTemplate = (includeSettings: boolean) =>
-      wrapEsCall(
-        this.esClient.indices.putIndexTemplate({
-          ...baseRequest,
-          template: {
-            ...(includeSettings ? { settings: StorageIndexAdapter.INDEX_SETTINGS } : {}),
-            mappings,
-            aliases,
-          },
-        })
-      ).catch(catchConflictError);
-
-    if (this.isServerless) {
-      await putTemplate(false);
-      return;
-    }
-
-    try {
-      await putTemplate(true);
-      this.isServerless = false;
-    } catch (error) {
-      if (isServerlessSettingsError(error)) {
-        this.isServerless = true;
-        this.logger.debug(
-          'Index settings are unavailable (serverless ES); retrying template without settings'
-        );
-        await putTemplate(false);
-      } else {
-        throw error;
-      }
-    }
+    await wrapEsCall(
+      this.esClient.indices.putIndexTemplate({
+        name: getIndexTemplateName(this.storage.name),
+        create: false,
+        allow_auto_create: false,
+        index_patterns: getIndexPattern(this.storage.name),
+        _meta: { version },
+        template,
+      })
+    ).catch(catchConflictError);
   }
 
   private async getExistingIndexTemplate(): Promise<IndicesIndexTemplate | undefined> {

--- a/src/platform/packages/shared/kbn-storage-adapter/src/index_adapter/index.ts
+++ b/src/platform/packages/shared/kbn-storage-adapter/src/index_adapter/index.ts
@@ -84,6 +84,14 @@ function isNotFoundError(error: Error): error is errors.ResponseError & { status
   return isResponseError(error) && error.statusCode === 404;
 }
 
+function isServerlessSettingsError(error: unknown): boolean {
+  if (!isResponseError(error as Error)) {
+    return false;
+  }
+  const reason: string = (error as errors.ResponseError).body?.error?.reason ?? '';
+  return reason.includes('not available when running in serverless mode');
+}
+
 /*
  * When calling into Elasticsearch, the stack trace is lost.
  * If we create an error before calling, and append it to
@@ -136,8 +144,14 @@ export class StorageIndexAdapter<
   TStorageSettings extends IndexStorageSettings,
   TApplicationType extends Partial<StorageDocumentOf<TStorageSettings>>
 > {
+  private static readonly INDEX_SETTINGS = {
+    auto_expand_replicas: '0-1',
+    number_of_shards: 1,
+  } as const;
+
   private readonly logger: Logger;
   private updateMappingsPromise: Promise<void> | undefined;
+  private isServerless: boolean | undefined;
 
   constructor(
     private readonly esClient: ElasticsearchClient,
@@ -159,39 +173,59 @@ export class StorageIndexAdapter<
   private async createOrUpdateIndexTemplate(): Promise<void> {
     const version = getSchemaVersion(this.storage);
 
-    const template: IndicesPutIndexTemplateIndexTemplateMapping = {
-      settings: {
-        auto_expand_replicas: '0-1',
-        number_of_shards: 1,
-      },
-      mappings: {
-        _meta: {
-          version,
-        },
-        dynamic: 'strict',
-        properties: {
-          ...mapValues(this.storage.schema.properties, toElasticsearchMappingProperty),
-        },
-      },
-      aliases: {
-        [getAliasName(this.storage.name)]: {
-          is_write_index: true,
-        },
+    const mappings: IndicesPutIndexTemplateIndexTemplateMapping['mappings'] = {
+      _meta: { version },
+      dynamic: 'strict',
+      properties: {
+        ...mapValues(this.storage.schema.properties, toElasticsearchMappingProperty),
       },
     };
 
-    await wrapEsCall(
-      this.esClient.indices.putIndexTemplate({
-        name: getIndexTemplateName(this.storage.name),
-        create: false,
-        allow_auto_create: false,
-        index_patterns: getIndexPattern(this.storage.name),
-        _meta: {
-          version,
-        },
-        template,
-      })
-    ).catch(catchConflictError);
+    const aliases: IndicesPutIndexTemplateIndexTemplateMapping['aliases'] = {
+      [getAliasName(this.storage.name)]: {
+        is_write_index: true,
+      },
+    };
+
+    const baseRequest = {
+      name: getIndexTemplateName(this.storage.name),
+      create: false as const,
+      allow_auto_create: false as const,
+      index_patterns: getIndexPattern(this.storage.name),
+      _meta: { version },
+    };
+
+    const putTemplate = (includeSettings: boolean) =>
+      wrapEsCall(
+        this.esClient.indices.putIndexTemplate({
+          ...baseRequest,
+          template: {
+            ...(includeSettings ? { settings: StorageIndexAdapter.INDEX_SETTINGS } : {}),
+            mappings,
+            aliases,
+          },
+        })
+      ).catch(catchConflictError);
+
+    if (this.isServerless) {
+      await putTemplate(false);
+      return;
+    }
+
+    try {
+      await putTemplate(true);
+      this.isServerless = false;
+    } catch (error) {
+      if (isServerlessSettingsError(error)) {
+        this.isServerless = true;
+        this.logger.debug(
+          'Index settings are unavailable (serverless ES); retrying template without settings'
+        );
+        await putTemplate(false);
+      } else {
+        throw error;
+      }
+    }
   }
 
   private async getExistingIndexTemplate(): Promise<IndicesIndexTemplate | undefined> {

--- a/src/platform/packages/shared/kbn-storage-adapter/src/index_adapter/index.ts
+++ b/src/platform/packages/shared/kbn-storage-adapter/src/index_adapter/index.ts
@@ -84,6 +84,14 @@ function isNotFoundError(error: Error): error is errors.ResponseError & { status
   return isResponseError(error) && error.statusCode === 404;
 }
 
+function isServerlessSettingsError(error: unknown): boolean {
+  if (!isResponseError(error as Error)) {
+    return false;
+  }
+  const reason: string = (error as errors.ResponseError).body?.error?.reason ?? '';
+  return reason.includes('not available when running in serverless mode');
+}
+
 /*
  * When calling into Elasticsearch, the stack trace is lost.
  * If we create an error before calling, and append it to
@@ -111,6 +119,18 @@ export interface StorageIndexAdapterOptions<TApplicationType> {
    * This should be used as rarely as possible - in most cases, new properties should be added as optional.
    */
   migrateSource?: (document: Record<string, unknown>) => TApplicationType;
+  /**
+   * When true, index settings (e.g. `number_of_shards`, `auto_expand_replicas`)
+   * are omitted from index templates because Serverless ES does not support them
+   * on user-visible indices.
+   *
+   * Detection is three-tiered:
+   * 1. Explicit - this option is used when provided.
+   * 2. Proactive - `esClient.info()` is called to check `build_flavor`.
+   * 3. Reactive - if both above are unavailable, the adapter catches
+   *    the `illegal_argument_exception` on the first write and retries.
+   */
+  isServerless?: boolean;
 }
 
 /**
@@ -143,7 +163,8 @@ export class StorageIndexAdapter<
 
   private readonly logger: Logger;
   private updateMappingsPromise: Promise<void> | undefined;
-  private serverlessCheck: Promise<boolean> | undefined;
+  private serverlessCheck: Promise<boolean | undefined> | undefined;
+  private isServerless: boolean | undefined;
 
   constructor(
     private readonly esClient: ElasticsearchClient,
@@ -152,14 +173,26 @@ export class StorageIndexAdapter<
     private readonly options: StorageIndexAdapterOptions<TApplicationType> = {}
   ) {
     this.logger = logger.get('storage').get(this.storage.name);
+    this.isServerless = options.isServerless;
   }
 
-  private detectServerless(): Promise<boolean> {
+  /**
+   * Probes the ES cluster via `info()` to determine if we're running
+   * against Serverless ES. The result is cached for the lifetime of
+   * this adapter instance. Returns `undefined` when the check cannot
+   * be performed (e.g. missing method on a mock client, or
+   * insufficient privileges).
+   */
+  private detectServerless(): Promise<boolean | undefined> {
     if (!this.serverlessCheck) {
-      this.serverlessCheck = this.esClient
-        .info()
-        .then((info) => info.version.build_flavor === 'serverless')
-        .catch(() => false);
+      this.serverlessCheck = (async () => {
+        try {
+          const info = await this.esClient.info();
+          return info.version.build_flavor === 'serverless';
+        } catch {
+          return undefined;
+        }
+      })();
     }
     return this.serverlessCheck;
   }
@@ -174,34 +207,57 @@ export class StorageIndexAdapter<
 
   private async createOrUpdateIndexTemplate(): Promise<void> {
     const version = getSchemaVersion(this.storage);
-    const isServerless = await this.detectServerless();
 
-    const template: IndicesPutIndexTemplateIndexTemplateMapping = {
-      ...(isServerless ? {} : { settings: StorageIndexAdapter.INDEX_SETTINGS }),
-      mappings: {
-        _meta: { version },
-        dynamic: 'strict',
-        properties: {
-          ...mapValues(this.storage.schema.properties, toElasticsearchMappingProperty),
-        },
-      },
-      aliases: {
-        [getAliasName(this.storage.name)]: {
-          is_write_index: true,
-        },
+    const mappings: IndicesPutIndexTemplateIndexTemplateMapping['mappings'] = {
+      _meta: { version },
+      dynamic: 'strict',
+      properties: {
+        ...mapValues(this.storage.schema.properties, toElasticsearchMappingProperty),
       },
     };
 
-    await wrapEsCall(
-      this.esClient.indices.putIndexTemplate({
-        name: getIndexTemplateName(this.storage.name),
-        create: false,
-        allow_auto_create: false,
-        index_patterns: getIndexPattern(this.storage.name),
-        _meta: { version },
-        template,
-      })
-    ).catch(catchConflictError);
+    const aliases: IndicesPutIndexTemplateIndexTemplateMapping['aliases'] = {
+      [getAliasName(this.storage.name)]: {
+        is_write_index: true,
+      },
+    };
+
+    const putTemplate = (includeSettings: boolean) =>
+      wrapEsCall(
+        this.esClient.indices.putIndexTemplate({
+          name: getIndexTemplateName(this.storage.name),
+          create: false,
+          allow_auto_create: false,
+          index_patterns: getIndexPattern(this.storage.name),
+          _meta: { version },
+          template: {
+            ...(includeSettings ? { settings: StorageIndexAdapter.INDEX_SETTINGS } : {}),
+            mappings,
+            aliases,
+          },
+        })
+      ).catch(catchConflictError);
+
+    const serverless = this.isServerless ?? (await this.detectServerless());
+    if (serverless !== undefined) {
+      await putTemplate(!serverless);
+      return;
+    }
+
+    try {
+      await putTemplate(true);
+      this.isServerless = false;
+    } catch (error) {
+      if (isServerlessSettingsError(error)) {
+        this.isServerless = true;
+        this.logger.debug(
+          'Index settings are unavailable (serverless ES); retrying template without settings'
+        );
+        await putTemplate(false);
+      } else {
+        throw error;
+      }
+    }
   }
 
   private async getExistingIndexTemplate(): Promise<IndicesIndexTemplate | undefined> {

--- a/x-pack/platform/plugins/shared/evals/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/evals/server/plugin.ts
@@ -35,11 +35,13 @@ export class EvalsPlugin
 {
   private readonly logger: Logger;
   private readonly config: EvalsConfig;
+  private readonly isServerless: boolean;
   private datasetService?: DatasetService;
 
   constructor(context: PluginInitializerContext<EvalsConfig>) {
     this.logger = context.logger.get();
     this.config = context.config.get();
+    this.isServerless = context.env.packageInfo.buildFlavor === 'serverless';
   }
 
   setup(
@@ -52,7 +54,7 @@ export class EvalsPlugin
     }
 
     this.logger.info('Setting up Evals plugin');
-    this.datasetService = new DatasetService(this.logger);
+    this.datasetService = new DatasetService(this.logger, this.isServerless);
 
     coreSetup.savedObjects.registerType(evalsRemoteKibanaConfigSavedObjectType);
     encryptedSavedObjects.registerType({

--- a/x-pack/platform/plugins/shared/evals/server/storage/dataset_service.ts
+++ b/x-pack/platform/plugins/shared/evals/server/storage/dataset_service.ts
@@ -19,7 +19,7 @@ import {
 } from './examples_storage';
 
 export class DatasetService {
-  constructor(private readonly logger: Logger) {}
+  constructor(private readonly logger: Logger, private readonly isServerless: boolean) {}
 
   getClient(esClient: ElasticsearchClient): DatasetClient {
     const datasetsStorageAdapter = this.createDatasetsStorageAdapter(esClient);
@@ -35,7 +35,8 @@ export class DatasetService {
     return new StorageIndexAdapter<typeof datasetsStorageSettings, DatasetStorageProperties>(
       esClient,
       this.logger,
-      datasetsStorageSettings
+      datasetsStorageSettings,
+      { isServerless: this.isServerless }
     );
   }
 
@@ -45,6 +46,8 @@ export class DatasetService {
     return new StorageIndexAdapter<
       typeof datasetExamplesStorageSettings,
       DatasetExampleStorageProperties
-    >(esClient, this.logger, datasetExamplesStorageSettings);
+    >(esClient, this.logger, datasetExamplesStorageSettings, {
+      isServerless: this.isServerless,
+    });
   }
 }


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/264845

## Summary

Fixes index template creation on Serverless for indices `kibana-evaluation-datasets`, `kibana-evaluation-dataset-examples`).

PR #263096 added `auto_expand_replicas` and `number_of_shards` to index templates in `StorageIndexAdapter`. Serverless ES rejects these settings on non-system indices with an `illegal_argument_exception`, while hidden indices (e.g.: used by Streams) are unaffected because Kibana manages them as system indices.

### Dataset upsert error for Kibana evaluation runs

<img width="1247" height="473" alt="image" src="https://github.com/user-attachments/assets/10e75668-7a1d-462e-9594-37fbee0f08e3" />

### Error in logs:
```
Failed to upsert evaluation dataset: ResponseError: illegal_argument_exception
	Root causes:
		illegal_argument_exception: Settings [index.auto_expand_replicas,index.number_of_shards] are not available when running in serverless mode
```

## Fix

The changes were introduced in three tiers to detect serverless environments for index template settings:

- Explicit detection - Introduced a new `isServerless` option in `StorageIndexAdapterOptions`. When provided, the adapter skips or includes settings without any extra calls.
- Proactive - if `isServerless` is not provided, the adapter calls `esClient.info()` on the first write and checks `version.build_flavor`. The result is cached for the adapter's lifetime.
- Reactive - if both above are unavailable (e.g.: `info()` fails due to insufficient privileges), the adapter catches the `illegal_argument_exception` on the first write, retries without settings, and caches the result.

The Evals plugin passes `isServerless` explicitly because the evals route handler creates `StorageIndexAdapter` with `esClient.asCurrentUser`, which is scoped to the caller's API key. This API key may lack the monitor cluster privilege needed for `esClient.info()`, making tier 2 unreliable. There `buildFlavor` is passed from the plugin context.

## Test Plan

- [x] Deploy the fix to a serverless project from this PR
- [x] Create a config file (e.g.: `config.testcluster.json`) and add the serverless project URL as the dataset target
- [x] Run evals with `node scripts/evals start --suite significant-events --project eis-anthropic-claude-4-6-sonnet --judge eis-google-gemini-3-1-pro --export-profile local --datasets-profile testcluster`

### With this fix, the dataset upsert works as expected
<img width="1531" height="877" alt="image" src="https://github.com/user-attachments/assets/84c2a5cd-138b-457e-85d3-bd87bff4867c" />

<img width="1710" height="556" alt="image" src="https://github.com/user-attachments/assets/bbfeb03a-405f-4551-8326-e12b0192d332" />

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


