### PR TITLE
[Entity Analytics] Fix accesses maintainer CloudTrail event filter to include SendSSHPublicKey

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/accesses/integrations/aws_cloudtrail/build_composite_agg.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/accesses/integrations/aws_cloudtrail/build_composite_agg.test.ts
@@ -13,9 +13,11 @@ describe('AWS CloudTrail buildCompositeAggQuery', () => {
     expect(query.query.bool.filter).toContainEqual({ term: { 'event.module': 'aws' } });
   });
 
-  it('filters for StartSession action', () => {
+  it('filters for StartSession and SendSSHPublicKey actions', () => {
     const query = buildCompositeAggQuery();
-    expect(query.query.bool.filter).toContainEqual({ term: { 'event.action': 'StartSession' } });
+    expect(query.query.bool.filter).toContainEqual({
+      terms: { 'event.action': ['StartSession', 'SendSSHPublicKey'] },
+    });
   });
 
   it('does not filter on logon_type or event.provider', () => {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/accesses/integrations/aws_cloudtrail/build_composite_agg.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/accesses/integrations/aws_cloudtrail/build_composite_agg.ts
@@ -12,6 +12,9 @@ export { buildBucketUserFilter } from '../shared_query_utils';
 
 export const buildCompositeAggQuery = (afterKey?: CompositeAfterKey) =>
   buildCompositeAggQueryBase(
-    [{ term: { 'event.module': 'aws' } }, { term: { 'event.action': 'StartSession' } }],
+    [
+      { term: { 'event.module': 'aws' } },
+      { terms: { 'event.action': ['StartSession', 'SendSSHPublicKey'] } },
+    ],
     afterKey
   );

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/accesses/integrations/aws_cloudtrail/build_esql_query.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/accesses/integrations/aws_cloudtrail/build_esql_query.test.ts
@@ -13,10 +13,11 @@ describe('AWS CloudTrail buildEsqlQuery', () => {
     expect(buildEsqlQuery('production')).toContain('FROM logs-aws.cloudtrail-production');
   });
 
-  it('filters for AWS module and StartSession action', () => {
+  it('filters for AWS module and StartSession or SendSSHPublicKey actions', () => {
     const query = buildEsqlQuery('default');
     expect(query).toContain('event.module == "aws"');
-    expect(query).toContain('event.action == "StartSession"');
+    expect(query).toContain('"StartSession"');
+    expect(query).toContain('"SendSSHPublicKey"');
   });
 
   it('does not filter on event.provider or logon_type', () => {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/accesses/integrations/aws_cloudtrail/build_esql_query.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/accesses/integrations/aws_cloudtrail/build_esql_query.ts
@@ -12,6 +12,6 @@ export function buildEsqlQuery(namespace: string): string {
   return buildAccessEsqlQuery(
     getIndexPattern(namespace),
     `event.module == "aws"
-    AND event.action == "StartSession"`
+    AND event.action IN ("StartSession", "SendSSHPublicKey")`
   );
 }


### PR DESCRIPTION
## Summary

- The `accesses_frequently`/`accesses_infrequently` maintainer for AWS CloudTrail was filtering on `event.action == "StartSession"` (SSM Session Manager), which produced no results because those events don't exist in the environment
- Broadens the filter to `event.action IN ("StartSession", "SendSSHPublicKey")` to also capture EC2 Instance Connect events, which are the actual host-access events present in CloudTrail data

## Test plan

- [ ] All existing unit tests pass (`node scripts/jest .../accesses --no-coverage`)
- [ ] Verify `accesses_frequently`/`accesses_infrequently` relationships appear on user entities after the maintainer runs with CloudTrail data containing `SendSSHPublicKey` events

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->