### PR TITLE
[Entity Analytics] Add missing OpenAPI descriptions and examples to p…

### DIFF
--- a/src/platform/packages/private/kbn-validate-oas/src/oas_error_baseline.json
+++ b/src/platform/packages/private/kbn-validate-oas/src/oas_error_baseline.json
@@ -1,4 +1,4 @@
 {
-  "./oas_docs/output/kibana.yaml": 748,
-  "./oas_docs/output/kibana.serverless.yaml": 656
+  "./oas_docs/output/kibana.yaml": 731,
+  "./oas_docs/output/kibana.serverless.yaml": 639
 }

--- a/x-pack/solutions/security/packages/test-api-clients/supertest/entity_analytics.gen.ts
+++ b/x-pack/solutions/security/packages/test-api-clients/supertest/entity_analytics.gen.ts
@@ -234,6 +234,9 @@ If a record already exists for the specified entity, that record is overwritten 
       .set(X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'kibana')
       .send(props.body as object);
   },
+  /**
+   * Creates a new privileged user to be monitored by the Privilege Monitoring Engine.
+   */
   createPrivMonUser(props: CreatePrivMonUserProps, kibanaSpace: string = 'default') {
     return supertest
       .post(getRouteUrlForSpace('/api/entity_analytics/monitoring/users', kibanaSpace))
@@ -242,6 +245,9 @@ If a record already exists for the specified entity, that record is overwritten 
       .set(X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'kibana')
       .send(props.body as object);
   },
+  /**
+   * Creates a new entity analytics watchlist with an optional set of entity sources. Watchlists apply a risk score modifier to matched entities.
+   */
   createWatchlist(props: CreateWatchlistProps, kibanaSpace: string = 'default') {
     return supertest
       .post(getRouteUrlForSpace('/api/entity_analytics/watchlists', kibanaSpace))
@@ -316,6 +322,9 @@ If a record already exists for the specified entity, that record is overwritten 
       .set(ELASTIC_HTTP_VERSION_HEADER, '2023-10-31')
       .set(X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'kibana');
   },
+  /**
+   * Deletes the Privilege Monitoring Engine and optionally removes all associated privileged user data.
+   */
   deleteMonitoringEngine(props: DeleteMonitoringEngineProps, kibanaSpace: string = 'default') {
     return supertest
       .delete(getRouteUrlForSpace('/api/entity_analytics/monitoring/engine/delete', kibanaSpace))
@@ -324,6 +333,9 @@ If a record already exists for the specified entity, that record is overwritten 
       .set(X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'kibana')
       .query(props.query);
   },
+  /**
+   * Removes a privileged user from monitoring by their document ID.
+   */
   deletePrivMonUser(props: DeletePrivMonUserProps, kibanaSpace: string = 'default') {
     return supertest
       .delete(
@@ -386,6 +398,9 @@ The entity will be immediately deleted from the latest index.  It will remain av
       .set(X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'kibana')
       .send(props.body as object);
   },
+  /**
+   * Disables the Privilege Monitoring Engine, stopping all monitoring activity without removing data.
+   */
   disableMonitoringEngine(kibanaSpace: string = 'default') {
     return supertest
       .post(getRouteUrlForSpace('/api/entity_analytics/monitoring/engine/disable', kibanaSpace))
@@ -498,6 +513,9 @@ The entity will be immediately deleted from the latest index.  It will remain av
       .set(X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'kibana')
       .query(props.query);
   },
+  /**
+   * Returns the installation and ML module setup status of the privileged access detection package, along with the state of each associated ML job.
+   */
   getPrivilegedAccessDetectionPackageStatus(kibanaSpace: string = 'default') {
     return supertest
       .get(
@@ -520,6 +538,9 @@ The entity will be immediately deleted from the latest index.  It will remain av
       .set(ELASTIC_HTTP_VERSION_HEADER, '1')
       .set(X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'kibana');
   },
+  /**
+   * Retrieves the details of an entity analytics watchlist by its unique identifier.
+   */
   getWatchlist(props: GetWatchlistProps, kibanaSpace: string = 'default') {
     return supertest
       .get(
@@ -574,6 +595,9 @@ The entity will be immediately deleted from the latest index.  It will remain av
       .set(X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'kibana')
       .send(props.body as object);
   },
+  /**
+   * Initializes the Privilege Monitoring Engine, setting up the required resources and starting the engine.
+   */
   initMonitoringEngine(kibanaSpace: string = 'default') {
     return supertest
       .post(getRouteUrlForSpace('/api/entity_analytics/monitoring/engine/init', kibanaSpace))
@@ -591,6 +615,9 @@ The entity will be immediately deleted from the latest index.  It will remain av
       .set(ELASTIC_HTTP_VERSION_HEADER, '1')
       .set(X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'kibana');
   },
+  /**
+   * Installs the privileged access detection integration package and sets up the associated ML modules required for the Entity Analytics privileged user monitoring experience.
+   */
   installPrivilegedAccessDetectionPackage(kibanaSpace: string = 'default') {
     return supertest
       .post(
@@ -647,6 +674,9 @@ Each row will match up to 10,000 entities.
       .set(X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'kibana')
       .query(props.query);
   },
+  /**
+   * Returns a list of all privileged users currently being monitored. Supports optional KQL filtering.
+   */
   listPrivMonUsers(props: ListPrivMonUsersProps, kibanaSpace: string = 'default') {
     return supertest
       .get(getRouteUrlForSpace('/api/entity_analytics/monitoring/users/list', kibanaSpace))
@@ -674,6 +704,9 @@ Each row will match up to 10,000 entities.
       .set(X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'kibana')
       .query(props.query);
   },
+  /**
+   * Returns a list of all entity analytics watchlists.
+   */
   listWatchlists(kibanaSpace: string = 'default') {
     return supertest
       .get(getRouteUrlForSpace('/api/entity_analytics/watchlists/list', kibanaSpace))
@@ -692,6 +725,9 @@ Each row will match up to 10,000 entities.
       .set(X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'kibana')
       .send(props.body as object);
   },
+  /**
+   * Bulk upserts privileged users by uploading a CSV file. Returns per-row errors and aggregate upload statistics.
+   */
   privmonBulkUploadUsersCsv(kibanaSpace: string = 'default') {
     return supertest
       .post(getRouteUrlForSpace('/api/entity_analytics/monitoring/users/_csv', kibanaSpace))
@@ -699,6 +735,9 @@ Each row will match up to 10,000 entities.
       .set(ELASTIC_HTTP_VERSION_HEADER, '2023-10-31')
       .set(X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'kibana');
   },
+  /**
+   * Returns the current health status of the Privilege Monitoring Engine, including engine status, error details, and user count statistics.
+   */
   privMonHealth(kibanaSpace: string = 'default') {
     return supertest
       .get(getRouteUrlForSpace('/api/entity_analytics/monitoring/privileges/health', kibanaSpace))
@@ -739,6 +778,9 @@ Each row will match up to 10,000 entities.
       .set(ELASTIC_HTTP_VERSION_HEADER, '1')
       .set(X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'kibana');
   },
+  /**
+   * Schedules the Privilege Monitoring Engine to run as soon as possible, triggering an immediate monitoring cycle.
+   */
   scheduleMonitoringEngine(kibanaSpace: string = 'default') {
     return supertest
       .post(
@@ -861,6 +903,9 @@ remain on the watchlist.
       .set(X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'kibana')
       .send(props.body as object);
   },
+  /**
+   * Updates the details of an existing monitored privileged user by their document ID.
+   */
   updatePrivMonUser(props: UpdatePrivMonUserProps, kibanaSpace: string = 'default') {
     return supertest
       .put(
@@ -874,6 +919,9 @@ remain on the watchlist.
       .set(X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'kibana')
       .send(props.body as object);
   },
+  /**
+   * Updates the name, description, risk modifier, or managed status of an existing entity analytics watchlist.
+   */
   updateWatchlist(props: UpdateWatchlistProps, kibanaSpace: string = 'default') {
     return supertest
       .put(

--- a/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/monitoring/engine/delete.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/monitoring/engine/delete.schema.yaml
@@ -10,6 +10,7 @@ paths:
       x-codegen-enabled: true
       operationId: DeleteMonitoringEngine
       summary: Delete the Privilege Monitoring Engine
+      description: Deletes the Privilege Monitoring Engine and optionally removes all associated privileged user data.
       parameters:
         - in: query
           name: data
@@ -31,3 +32,8 @@ paths:
                     type: boolean
                 required:
                   - deleted
+              examples:
+                DeleteMonitoringEngineResponse:
+                  summary: Engine deleted successfully
+                  value:
+                    deleted: true

--- a/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/monitoring/engine/disable.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/monitoring/engine/disable.schema.yaml
@@ -10,6 +10,7 @@ paths:
       x-codegen-enabled: true
       operationId: DisableMonitoringEngine
       summary: Disable the Privilege Monitoring Engine
+      description: Disables the Privilege Monitoring Engine, stopping all monitoring activity without removing data.
 
       responses:
         "200":
@@ -18,3 +19,8 @@ paths:
             application/json:
               schema:
                 $ref: "../common.schema.yaml#/components/schemas/MonitoringEngineDescriptor"
+              examples:
+                DisableMonitoringEngineResponse:
+                  summary: Engine disabled successfully
+                  value:
+                    status: disabled

--- a/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/monitoring/engine/init.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/monitoring/engine/init.schema.yaml
@@ -10,6 +10,7 @@ paths:
       x-codegen-enabled: true
       operationId: InitMonitoringEngine
       summary: Initialize the Privilege Monitoring Engine
+      description: Initializes the Privilege Monitoring Engine, setting up the required resources and starting the engine.
 
       responses:
         "200":
@@ -18,6 +19,11 @@ paths:
             application/json:
               schema:
                 $ref: "../common.schema.yaml#/components/schemas/MonitoringEngineDescriptor"
+              examples:
+                InitMonitoringEngineResponse:
+                  summary: Engine initialized successfully
+                  value:
+                    status: started
         "500":
           description: Internal Server Error
           content:

--- a/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/monitoring/engine/schedule_now.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/monitoring/engine/schedule_now.schema.yaml
@@ -10,6 +10,7 @@ paths:
       x-codegen-enabled: true
       operationId: ScheduleMonitoringEngine
       summary: Schedule the Privilege Monitoring Engine
+      description: Schedules the Privilege Monitoring Engine to run as soon as possible, triggering an immediate monitoring cycle.
 
       responses:
         "200":
@@ -22,6 +23,11 @@ paths:
                   success:
                     type: boolean
                     description: Indicates the scheduling was successful
+              examples:
+                ScheduleMonitoringEngineResponse:
+                  summary: Engine scheduled successfully
+                  value:
+                    success: true
         "409":
           description: Conflict - Monitoring engine is already running
           content:

--- a/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/monitoring/health.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/monitoring/health.schema.yaml
@@ -10,6 +10,7 @@ paths:
       x-codegen-enabled: true
       operationId: PrivMonHealth
       summary: Health check on Privilege Monitoring
+      description: Returns the current health status of the Privilege Monitoring Engine, including engine status, error details, and user count statistics.
 
       responses:
         "200":
@@ -44,3 +45,11 @@ paths:
 
                 required:
                   - status
+              examples:
+                PrivMonHealthResponse:
+                  summary: Healthy privilege monitoring engine
+                  value:
+                    status: started
+                    users:
+                      current_count: 42
+                      max_allowed: 1000

--- a/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/monitoring/privileged_access_detection/install.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/monitoring/privileged_access_detection/install.schema.yaml
@@ -9,6 +9,7 @@ paths:
       x-codegen-enabled: true
       operationId: InstallPrivilegedAccessDetectionPackage
       summary: Installs the privileged access detection package for the Entity Analytics privileged user monitoring experience
+      description: Installs the privileged access detection integration package and sets up the associated ML modules required for the Entity Analytics privileged user monitoring experience.
 
       responses:
         "200":
@@ -22,3 +23,8 @@ paths:
                 properties:
                   message:
                     type: string
+              examples:
+                InstallPrivilegedAccessDetectionPackageResponse:
+                  summary: Package installed successfully
+                  value:
+                    message: Privileged access detection package installed successfully

--- a/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/monitoring/privileged_access_detection/status.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/monitoring/privileged_access_detection/status.schema.yaml
@@ -9,6 +9,7 @@ paths:
       x-codegen-enabled: true
       operationId: GetPrivilegedAccessDetectionPackageStatus
       summary: Gets the status of the privileged access detection package for the Entity Analytics privileged user monitoring experience
+      description: Returns the installation and ML module setup status of the privileged access detection package, along with the state of each associated ML job.
 
       responses:
         "200":
@@ -43,3 +44,16 @@ paths:
                         state:
                           type: string
                           enum: [closing, closed, opened, failed, opening]
+              examples:
+                GetPrivilegedAccessDetectionPackageStatusResponse:
+                  summary: Package fully installed and running
+                  value:
+                    package_installation_status: complete
+                    ml_module_setup_status: complete
+                    jobs:
+                      - job_id: pad-high-risk-login
+                        description: Detects high-risk login patterns
+                        state: opened
+                      - job_id: pad-privilege-escalation
+                        description: Detects privilege escalation events
+                        state: opened

--- a/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/monitoring/users/create.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/monitoring/users/create.schema.yaml
@@ -10,12 +10,24 @@ paths:
       x-codegen-enabled: true
       operationId: CreatePrivMonUser
       summary: Create a new monitored user
+      description: Creates a new privileged user to be monitored by the Privilege Monitoring Engine.
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: "./common.schema.yaml#/components/schemas/UserName"
+            examples:
+              CreatePrivMonUserRequest:
+                summary: Create a monitored user
+                value:
+                  user:
+                    name: john.doe
+                  entity_analytics_monitoring:
+                    labels:
+                      - field: department
+                        value: IT
+                        source: api
 
       responses:
         "200":
@@ -24,3 +36,19 @@ paths:
             application/json:
               schema:
                 $ref: "./common.schema.yaml#/components/schemas/MonitoredUserDoc"
+              examples:
+                CreatePrivMonUserResponse:
+                  summary: Created monitored user
+                  value:
+                    id: user-abc-123
+                    user:
+                      name: john.doe
+                      is_privileged: true
+                    entity_analytics_monitoring:
+                      labels:
+                        - field: department
+                          value: IT
+                          source: api
+                    "@timestamp": "2026-01-28T12:00:00.000Z"
+                    event:
+                      ingested: "2026-01-28T12:00:00.000Z"

--- a/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/monitoring/users/delete.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/monitoring/users/delete.schema.yaml
@@ -10,6 +10,7 @@ paths:
       x-codegen-enabled: true
       operationId: DeletePrivMonUser
       summary: Delete a monitored user
+      description: Removes a privileged user from monitoring by their document ID.
       parameters:
         - name: id
           in: path
@@ -32,3 +33,9 @@ paths:
                   message:
                     type: string
                     description: A message providing additional information about the deletion status
+              examples:
+                DeletePrivMonUserResponse:
+                  summary: User deleted successfully
+                  value:
+                    acknowledged: true
+                    message: User deleted successfully

--- a/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/monitoring/users/list.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/monitoring/users/list.schema.yaml
@@ -10,6 +10,7 @@ paths:
       x-codegen-enabled: true
       operationId: ListPrivMonUsers
       summary: List all monitored users
+      description: Returns a list of all privileged users currently being monitored. Supports optional KQL filtering.
       parameters:
         - name: kql
           in: query
@@ -26,3 +27,31 @@ paths:
                 type: array
                 items:
                   $ref: "./common.schema.yaml#/components/schemas/MonitoredUserDoc"
+              examples:
+                ListPrivMonUsersResponse:
+                  summary: List of monitored users
+                  value:
+                    - id: user-abc-123
+                      user:
+                        name: john.doe
+                        is_privileged: true
+                      entity_analytics_monitoring:
+                        labels:
+                          - field: department
+                            value: IT
+                            source: api
+                      "@timestamp": "2026-01-28T12:00:00.000Z"
+                      event:
+                        ingested: "2026-01-28T12:00:00.000Z"
+                    - id: user-def-456
+                      user:
+                        name: jane.smith
+                        is_privileged: true
+                      entity_analytics_monitoring:
+                        labels:
+                          - field: department
+                            value: Security
+                            source: csv
+                      "@timestamp": "2026-01-15T09:00:00.000Z"
+                      event:
+                        ingested: "2026-01-15T09:00:00.000Z"

--- a/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/monitoring/users/update.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/monitoring/users/update.schema.yaml
@@ -10,6 +10,7 @@ paths:
       x-codegen-enabled: true
       operationId: UpdatePrivMonUser
       summary: Update a monitored user
+      description: Updates the details of an existing monitored privileged user by their document ID.
       parameters:
         - name: id
           in: path
@@ -22,6 +23,18 @@ paths:
           application/json:
             schema:
               $ref: "./common.schema.yaml#/components/schemas/MonitoredUserUpdateDoc"
+            examples:
+              UpdatePrivMonUserRequest:
+                summary: Update a monitored user
+                value:
+                  user:
+                    name: john.doe
+                    is_privileged: true
+                  entity_analytics_monitoring:
+                    labels:
+                      - field: department
+                        value: Security
+                        source: api
 
       responses:
         "200":
@@ -30,3 +43,19 @@ paths:
             application/json:
               schema:
                 $ref: "./common.schema.yaml#/components/schemas/MonitoredUserDoc"
+              examples:
+                UpdatePrivMonUserResponse:
+                  summary: Updated monitored user
+                  value:
+                    id: user-abc-123
+                    user:
+                      name: john.doe
+                      is_privileged: true
+                    entity_analytics_monitoring:
+                      labels:
+                        - field: department
+                          value: Security
+                          source: api
+                    "@timestamp": "2026-01-28T12:00:00.000Z"
+                    event:
+                      ingested: "2026-01-28T12:00:00.000Z"

--- a/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/monitoring/users/upload_csv.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/monitoring/users/upload_csv.schema.yaml
@@ -10,6 +10,7 @@ paths:
       x-codegen-enabled: true
       operationId: PrivmonBulkUploadUsersCSV
       summary: Upsert multiple monitored users via CSV upload
+      description: Bulk upserts privileged users by uploading a CSV file. Returns per-row errors and aggregate upload statistics.
       requestBody:
         content:
           multipart/form-data:

--- a/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/risk_engine/engine_cleanup_route.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/risk_engine/engine_cleanup_route.schema.yaml
@@ -21,6 +21,11 @@ paths:
                 properties:
                   cleanup_successful:
                     type: boolean
+              examples:
+                CleanUpRiskEngineResponse:
+                  summary: Successful cleanup response
+                  value:
+                    cleanup_successful: true
         '400':
           description: Task manager is unavailable
           content:

--- a/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/risk_engine/engine_configure_saved_object_route.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/risk_engine/engine_configure_saved_object_route.schema.yaml
@@ -51,6 +51,23 @@ paths:
                     required:
                       - entity_types
                       - filter
+            examples:
+              ConfigureRiskEngineSavedObjectRequest:
+                summary: Configure the risk engine saved object
+                value:
+                  exclude_alert_statuses:
+                    - closed
+                  range:
+                    start: now-30d
+                    end: now
+                  exclude_alert_tags:
+                    - low-priority
+                  enable_reset_to_zero: false
+                  filters:
+                    - entity_types:
+                        - host
+                        - user
+                      filter: 'host.name: *'
       responses:
         "200":
           description: Successful response
@@ -61,6 +78,11 @@ paths:
                 properties:
                   risk_engine_saved_object_configured:
                     type: boolean
+              examples:
+                ConfigureRiskEngineSavedObjectResponse:
+                  summary: Successful configuration response
+                  value:
+                    risk_engine_saved_object_configured: true
         "400":
           description: Task manager is unavailable
           content:

--- a/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/risk_engine/engine_schedule_now_route.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/risk_engine/engine_schedule_now_route.schema.yaml
@@ -31,6 +31,11 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RiskEngineScheduleNowResponse'
+              examples:
+                ScheduleRiskEngineNowResponse:
+                  summary: Successful schedule response
+                  value:
+                    success: true
         '400':
           description: Task manager is unavailable
           content:

--- a/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/watchlists/management/create.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/watchlists/management/create.schema.yaml
@@ -13,6 +13,7 @@ paths:
       x-state: Technical Preview
       operationId: CreateWatchlist
       summary: Create a new watchlist
+      description: Creates a new entity analytics watchlist with an optional set of entity sources. Watchlists apply a risk score modifier to matched entities.
       requestBody:
         required: true
         content:

--- a/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/watchlists/management/get.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/watchlists/management/get.schema.yaml
@@ -14,6 +14,7 @@ paths:
       x-state: Technical Preview
       operationId: GetWatchlist
       summary: Get a watchlist by ID
+      description: Retrieves the details of an entity analytics watchlist by its unique identifier.
       parameters:
         - name: id
           in: path

--- a/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/watchlists/management/list.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/watchlists/management/list.schema.yaml
@@ -14,6 +14,7 @@ paths:
       x-state: Technical Preview
       operationId: ListWatchlists
       summary: List all watchlists
+      description: Returns a list of all entity analytics watchlists.
       responses:
         "200":
           description: List of watchlists

--- a/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/watchlists/management/update.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/watchlists/management/update.schema.yaml
@@ -13,6 +13,7 @@ paths:
       x-state: Technical Preview
       operationId: UpdateWatchlist
       summary: Update an existing watchlist
+      description: Updates the name, description, risk modifier, or managed status of an existing entity analytics watchlist.
       parameters:
         - name: id
           in: path

--- a/x-pack/solutions/security/plugins/security_solution/common/api/quickstart_client.gen.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/quickstart_client.gen.ts
@@ -878,6 +878,9 @@ If a record already exists for the specified entity, that record is overwritten 
       })
       .catch(catchAxiosErrorFormatAndThrow);
   }
+  /**
+   * Creates a new privileged user to be monitored by the Privilege Monitoring Engine.
+   */
   async createPrivMonUser(props: CreatePrivMonUserProps) {
     this.log.info(`${new Date().toISOString()} Calling API CreatePrivMonUser`);
     return this.kbnClient
@@ -1047,6 +1050,9 @@ For detailed information on Kibana actions and alerting, and additional API call
       })
       .catch(catchAxiosErrorFormatAndThrow);
   }
+  /**
+   * Creates a new entity analytics watchlist with an optional set of entity sources. Watchlists apply a risk score modifier to matched entities.
+   */
   async createWatchlist(props: CreateWatchlistProps) {
     this.log.info(`${new Date().toISOString()} Calling API CreateWatchlist`);
     return this.kbnClient
@@ -1160,6 +1166,9 @@ For detailed information on Kibana actions and alerting, and additional API call
       })
       .catch(catchAxiosErrorFormatAndThrow);
   }
+  /**
+   * Deletes the Privilege Monitoring Engine and optionally removes all associated privileged user data.
+   */
   async deleteMonitoringEngine(props: DeleteMonitoringEngineProps) {
     this.log.info(`${new Date().toISOString()} Calling API DeleteMonitoringEngine`);
     return this.kbnClient
@@ -1195,6 +1204,9 @@ Requires the **Timeline and Notes** write privilege (`notes_write`).
       })
       .catch(catchAxiosErrorFormatAndThrow);
   }
+  /**
+   * Removes a privileged user from monitoring by their document ID.
+   */
   async deletePrivMonUser(props: DeletePrivMonUserProps) {
     this.log.info(`${new Date().toISOString()} Calling API DeletePrivMonUser`);
     return this.kbnClient
@@ -1312,6 +1324,9 @@ The entity will be immediately deleted from the latest index.  It will remain av
       })
       .catch(catchAxiosErrorFormatAndThrow);
   }
+  /**
+   * Disables the Privilege Monitoring Engine, stopping all monitoring activity without removing data.
+   */
   async disableMonitoringEngine() {
     this.log.info(`${new Date().toISOString()} Calling API DisableMonitoringEngine`);
     return this.kbnClient
@@ -2022,6 +2037,9 @@ Requires the **Timeline and Notes** read privilege (`notes_read`).
       })
       .catch(catchAxiosErrorFormatAndThrow);
   }
+  /**
+   * Returns the installation and ML module setup status of the privileged access detection package, along with the state of each associated ML job.
+   */
   async getPrivilegedAccessDetectionPackageStatus() {
     this.log.info(
       `${new Date().toISOString()} Calling API GetPrivilegedAccessDetectionPackageStatus`
@@ -2269,6 +2287,9 @@ Requires the **Timeline and Notes** read privilege (`notes_read`).
       })
       .catch(catchAxiosErrorFormatAndThrow);
   }
+  /**
+   * Retrieves the details of an entity analytics watchlist by its unique identifier.
+   */
   async getWatchlist(props: GetWatchlistProps) {
     this.log.info(`${new Date().toISOString()} Calling API GetWatchlist`);
     return this.kbnClient
@@ -2390,6 +2411,9 @@ Requires the **Timeline and Notes** read privilege (`notes_read`).
       })
       .catch(catchAxiosErrorFormatAndThrow);
   }
+  /**
+   * Initializes the Privilege Monitoring Engine, setting up the required resources and starting the engine.
+   */
   async initMonitoringEngine() {
     this.log.info(`${new Date().toISOString()} Calling API InitMonitoringEngine`);
     return this.kbnClient
@@ -2494,6 +2518,9 @@ providing you with the most current and effective threat detection capabilities.
       })
       .catch(catchAxiosErrorFormatAndThrow);
   }
+  /**
+   * Installs the privileged access detection integration package and sets up the associated ML modules required for the Entity Analytics privileged user monitoring experience.
+   */
   async installPrivilegedAccessDetectionPackage() {
     this.log.info(
       `${new Date().toISOString()} Calling API InstallPrivilegedAccessDetectionPackage`
@@ -2575,6 +2602,9 @@ Each row will match up to 10,000 entities.
       })
       .catch(catchAxiosErrorFormatAndThrow);
   }
+  /**
+   * Returns a list of all privileged users currently being monitored. Supports optional KQL filtering.
+   */
   async listPrivMonUsers(props: ListPrivMonUsersProps) {
     this.log.info(`${new Date().toISOString()} Calling API ListPrivMonUsers`);
     return this.kbnClient
@@ -2606,6 +2636,9 @@ Each row will match up to 10,000 entities.
       })
       .catch(catchAxiosErrorFormatAndThrow);
   }
+  /**
+   * Returns a list of all entity analytics watchlists.
+   */
   async listWatchlists() {
     this.log.info(`${new Date().toISOString()} Calling API ListWatchlists`);
     return this.kbnClient
@@ -2767,6 +2800,9 @@ Requires the **Timeline and Notes** write privilege (`notes_write`).
       })
       .catch(catchAxiosErrorFormatAndThrow);
   }
+  /**
+   * Bulk upserts privileged users by uploading a CSV file. Returns per-row errors and aggregate upload statistics.
+   */
   async privmonBulkUploadUsersCsv(props: PrivmonBulkUploadUsersCSVProps) {
     this.log.info(`${new Date().toISOString()} Calling API PrivmonBulkUploadUsersCSV`);
     return this.kbnClient
@@ -2780,6 +2816,9 @@ Requires the **Timeline and Notes** write privilege (`notes_write`).
       })
       .catch(catchAxiosErrorFormatAndThrow);
   }
+  /**
+   * Returns the current health status of the Privilege Monitoring Engine, including engine status, error details, and user count statistics.
+   */
   async privMonHealth() {
     this.log.info(`${new Date().toISOString()} Calling API PrivMonHealth`);
     return this.kbnClient
@@ -3028,6 +3067,9 @@ The difference between the `id` and `rule_id` is that the `id` is a unique rule 
       })
       .catch(catchAxiosErrorFormatAndThrow);
   }
+  /**
+   * Schedules the Privilege Monitoring Engine to run as soon as possible, triggering an immediate monitoring cycle.
+   */
   async scheduleMonitoringEngine() {
     this.log.info(`${new Date().toISOString()} Calling API ScheduleMonitoringEngine`);
     return this.kbnClient
@@ -3404,6 +3446,9 @@ remain on the watchlist.
       })
       .catch(catchAxiosErrorFormatAndThrow);
   }
+  /**
+   * Updates the details of an existing monitored privileged user by their document ID.
+   */
   async updatePrivMonUser(props: UpdatePrivMonUserProps) {
     this.log.info(`${new Date().toISOString()} Calling API UpdatePrivMonUser`);
     return this.kbnClient
@@ -3491,6 +3536,9 @@ The difference between the `id` and `rule_id` is that the `id` is a unique rule 
       })
       .catch(catchAxiosErrorFormatAndThrow);
   }
+  /**
+   * Updates the name, description, risk modifier, or managed status of an existing entity analytics watchlist.
+   */
   async updateWatchlist(props: UpdateWatchlistProps) {
     this.log.info(`${new Date().toISOString()} Calling API UpdateWatchlist`);
     return this.kbnClient

--- a/x-pack/solutions/security/plugins/security_solution/docs/openapi/ess/security_solution_entity_analytics_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/docs/openapi/ess/security_solution_entity_analytics_api_2023_10_31.bundled.schema.yaml
@@ -308,6 +308,9 @@ paths:
         - Security Entity Analytics API
   /api/entity_analytics/monitoring/engine/delete:
     delete:
+      description: >-
+        Deletes the Privilege Monitoring Engine and optionally removes all
+        associated privileged user data.
       operationId: DeleteMonitoringEngine
       parameters:
         - description: Whether to delete all the privileged user data
@@ -321,6 +324,11 @@ paths:
         '200':
           content:
             application/json:
+              examples:
+                DeleteMonitoringEngineResponse:
+                  summary: Engine deleted successfully
+                  value:
+                    deleted: true
               schema:
                 type: object
                 properties:
@@ -334,11 +342,19 @@ paths:
         - Security Entity Analytics API
   /api/entity_analytics/monitoring/engine/disable:
     post:
+      description: >-
+        Disables the Privilege Monitoring Engine, stopping all monitoring
+        activity without removing data.
       operationId: DisableMonitoringEngine
       responses:
         '200':
           content:
             application/json:
+              examples:
+                DisableMonitoringEngineResponse:
+                  summary: Engine disabled successfully
+                  value:
+                    status: disabled
               schema:
                 $ref: '#/components/schemas/MonitoringEngineDescriptor'
           description: Successful response
@@ -347,11 +363,19 @@ paths:
         - Security Entity Analytics API
   /api/entity_analytics/monitoring/engine/init:
     post:
+      description: >-
+        Initializes the Privilege Monitoring Engine, setting up the required
+        resources and starting the engine.
       operationId: InitMonitoringEngine
       responses:
         '200':
           content:
             application/json:
+              examples:
+                InitMonitoringEngineResponse:
+                  summary: Engine initialized successfully
+                  value:
+                    status: started
               schema:
                 $ref: '#/components/schemas/MonitoringEngineDescriptor'
           description: Successful response
@@ -366,11 +390,19 @@ paths:
         - Security Entity Analytics API
   /api/entity_analytics/monitoring/engine/schedule_now:
     post:
+      description: >-
+        Schedules the Privilege Monitoring Engine to run as soon as possible,
+        triggering an immediate monitoring cycle.
       operationId: ScheduleMonitoringEngine
       responses:
         '200':
           content:
             application/json:
+              examples:
+                ScheduleMonitoringEngineResponse:
+                  summary: Engine scheduled successfully
+                  value:
+                    success: true
               schema:
                 type: object
                 properties:
@@ -393,11 +425,22 @@ paths:
         - Security Entity Analytics API
   /api/entity_analytics/monitoring/privileges/health:
     get:
+      description: >-
+        Returns the current health status of the Privilege Monitoring Engine,
+        including engine status, error details, and user count statistics.
       operationId: PrivMonHealth
       responses:
         '200':
           content:
             application/json:
+              examples:
+                PrivMonHealthResponse:
+                  summary: Healthy privilege monitoring engine
+                  value:
+                    status: started
+                    users:
+                      current_count: 42
+                      max_allowed: 1000
               schema:
                 type: object
                 properties:
@@ -456,10 +499,24 @@ paths:
         - Security Entity Analytics API
   /api/entity_analytics/monitoring/users:
     post:
+      description: >-
+        Creates a new privileged user to be monitored by the Privilege
+        Monitoring Engine.
       operationId: CreatePrivMonUser
       requestBody:
         content:
           application/json:
+            examples:
+              CreatePrivMonUserRequest:
+                summary: Create a monitored user
+                value:
+                  entity_analytics_monitoring:
+                    labels:
+                      - field: department
+                        source: api
+                        value: IT
+                  user:
+                    name: john.doe
             schema:
               $ref: '#/components/schemas/UserName'
         required: true
@@ -467,6 +524,22 @@ paths:
         '200':
           content:
             application/json:
+              examples:
+                CreatePrivMonUserResponse:
+                  summary: Created monitored user
+                  value:
+                    '@timestamp': '2026-01-28T12:00:00.000Z'
+                    entity_analytics_monitoring:
+                      labels:
+                        - field: department
+                          source: api
+                          value: IT
+                    event:
+                      ingested: '2026-01-28T12:00:00.000Z'
+                    id: user-abc-123
+                    user:
+                      is_privileged: true
+                      name: john.doe
               schema:
                 $ref: '#/components/schemas/MonitoredUserDoc'
           description: User created successfully
@@ -475,6 +548,9 @@ paths:
         - Security Entity Analytics API
   /api/entity_analytics/monitoring/users/_csv:
     post:
+      description: >-
+        Bulk upserts privileged users by uploading a CSV file. Returns per-row
+        errors and aggregate upload statistics.
       operationId: PrivmonBulkUploadUsersCSV
       requestBody:
         content:
@@ -522,6 +598,7 @@ paths:
         - Security Entity Analytics API
   /api/entity_analytics/monitoring/users/{id}:
     delete:
+      description: Removes a privileged user from monitoring by their document ID.
       operationId: DeletePrivMonUser
       parameters:
         - in: path
@@ -533,6 +610,12 @@ paths:
         '200':
           content:
             application/json:
+              examples:
+                DeletePrivMonUserResponse:
+                  summary: User deleted successfully
+                  value:
+                    acknowledged: true
+                    message: User deleted successfully
               schema:
                 type: object
                 properties:
@@ -551,6 +634,9 @@ paths:
       tags:
         - Security Entity Analytics API
     put:
+      description: >-
+        Updates the details of an existing monitored privileged user by their
+        document ID.
       operationId: UpdatePrivMonUser
       parameters:
         - in: path
@@ -561,6 +647,18 @@ paths:
       requestBody:
         content:
           application/json:
+            examples:
+              UpdatePrivMonUserRequest:
+                summary: Update a monitored user
+                value:
+                  entity_analytics_monitoring:
+                    labels:
+                      - field: department
+                        source: api
+                        value: Security
+                  user:
+                    is_privileged: true
+                    name: john.doe
             schema:
               $ref: '#/components/schemas/MonitoredUserUpdateDoc'
         required: true
@@ -568,6 +666,22 @@ paths:
         '200':
           content:
             application/json:
+              examples:
+                UpdatePrivMonUserResponse:
+                  summary: Updated monitored user
+                  value:
+                    '@timestamp': '2026-01-28T12:00:00.000Z'
+                    entity_analytics_monitoring:
+                      labels:
+                        - field: department
+                          source: api
+                          value: Security
+                    event:
+                      ingested: '2026-01-28T12:00:00.000Z'
+                    id: user-abc-123
+                    user:
+                      is_privileged: true
+                      name: john.doe
               schema:
                 $ref: '#/components/schemas/MonitoredUserDoc'
           description: User updated successfully
@@ -576,6 +690,9 @@ paths:
         - Security Entity Analytics API
   /api/entity_analytics/monitoring/users/list:
     get:
+      description: >-
+        Returns a list of all privileged users currently being monitored.
+        Supports optional KQL filtering.
       operationId: ListPrivMonUsers
       parameters:
         - description: KQL query to filter the list of monitored users
@@ -588,6 +705,34 @@ paths:
         '200':
           content:
             application/json:
+              examples:
+                ListPrivMonUsersResponse:
+                  summary: List of monitored users
+                  value:
+                    - '@timestamp': '2026-01-28T12:00:00.000Z'
+                      entity_analytics_monitoring:
+                        labels:
+                          - field: department
+                            source: api
+                            value: IT
+                      event:
+                        ingested: '2026-01-28T12:00:00.000Z'
+                      id: user-abc-123
+                      user:
+                        is_privileged: true
+                        name: john.doe
+                    - '@timestamp': '2026-01-15T09:00:00.000Z'
+                      entity_analytics_monitoring:
+                        labels:
+                          - field: department
+                            source: csv
+                            value: Security
+                      event:
+                        ingested: '2026-01-15T09:00:00.000Z'
+                      id: user-def-456
+                      user:
+                        is_privileged: true
+                        name: jane.smith
               schema:
                 items:
                   $ref: '#/components/schemas/MonitoredUserDoc'
@@ -598,11 +743,20 @@ paths:
         - Security Entity Analytics API
   /api/entity_analytics/privileged_user_monitoring/pad/install:
     post:
+      description: >-
+        Installs the privileged access detection integration package and sets up
+        the associated ML modules required for the Entity Analytics privileged
+        user monitoring experience.
       operationId: InstallPrivilegedAccessDetectionPackage
       responses:
         '200':
           content:
             application/json:
+              examples:
+                InstallPrivilegedAccessDetectionPackageResponse:
+                  summary: Package installed successfully
+                  value:
+                    message: Privileged access detection package installed successfully
               schema:
                 type: object
                 properties:
@@ -618,11 +772,28 @@ paths:
         - Security Entity Analytics API
   /api/entity_analytics/privileged_user_monitoring/pad/status:
     get:
+      description: >-
+        Returns the installation and ML module setup status of the privileged
+        access detection package, along with the state of each associated ML
+        job.
       operationId: GetPrivilegedAccessDetectionPackageStatus
       responses:
         '200':
           content:
             application/json:
+              examples:
+                GetPrivilegedAccessDetectionPackageStatusResponse:
+                  summary: Package fully installed and running
+                  value:
+                    jobs:
+                      - description: Detects high-risk login patterns
+                        job_id: pad-high-risk-login
+                        state: opened
+                      - description: Detects privilege escalation events
+                        job_id: pad-privilege-escalation
+                        state: opened
+                    ml_module_setup_status: complete
+                    package_installation_status: complete
               schema:
                 type: object
                 properties:
@@ -668,6 +839,9 @@ paths:
         - Security Entity Analytics API
   /api/entity_analytics/watchlists:
     post:
+      description: >-
+        Creates a new entity analytics watchlist with an optional set of entity
+        sources. Watchlists apply a risk score modifier to matched entities.
       operationId: CreateWatchlist
       requestBody:
         content:
@@ -786,6 +960,9 @@ paths:
       x-state: Technical Preview
   /api/entity_analytics/watchlists/{id}:
     get:
+      description: >-
+        Retrieves the details of an entity analytics watchlist by its unique
+        identifier.
       operationId: GetWatchlist
       parameters:
         - description: Unique ID of the watchlist
@@ -817,6 +994,9 @@ paths:
         - Security Entity Analytics API
       x-state: Technical Preview
     put:
+      description: >-
+        Updates the name, description, risk modifier, or managed status of an
+        existing entity analytics watchlist.
       operationId: UpdateWatchlist
       parameters:
         - description: The ID of the watchlist to update
@@ -1177,6 +1357,7 @@ paths:
       x-state: Technical Preview; added in 9.4.0
   /api/entity_analytics/watchlists/list:
     get:
+      description: Returns a list of all entity analytics watchlists.
       operationId: ListWatchlists
       responses:
         '200':
@@ -2112,6 +2293,11 @@ paths:
         '200':
           content:
             application/json:
+              examples:
+                CleanUpRiskEngineResponse:
+                  summary: Successful cleanup response
+                  value:
+                    cleanup_successful: true
               schema:
                 type: object
                 properties:
@@ -2140,6 +2326,23 @@ paths:
       requestBody:
         content:
           application/json:
+            examples:
+              ConfigureRiskEngineSavedObjectRequest:
+                summary: Configure the risk engine saved object
+                value:
+                  enable_reset_to_zero: false
+                  exclude_alert_statuses:
+                    - closed
+                  exclude_alert_tags:
+                    - low-priority
+                  filters:
+                    - entity_types:
+                        - host
+                        - user
+                      filter: 'host.name: *'
+                  range:
+                    end: now
+                    start: now-30d
             schema:
               type: object
               properties:
@@ -2184,6 +2387,11 @@ paths:
         '200':
           content:
             application/json:
+              examples:
+                ConfigureRiskEngineSavedObjectResponse:
+                  summary: Successful configuration response
+                  value:
+                    risk_engine_saved_object_configured: true
               schema:
                 type: object
                 properties:
@@ -2220,6 +2428,11 @@ paths:
         '200':
           content:
             application/json:
+              examples:
+                ScheduleRiskEngineNowResponse:
+                  summary: Successful schedule response
+                  value:
+                    success: true
               schema:
                 $ref: '#/components/schemas/RiskEngineScheduleNowResponse'
           description: Successful response

--- a/x-pack/solutions/security/plugins/security_solution/docs/openapi/serverless/security_solution_entity_analytics_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/docs/openapi/serverless/security_solution_entity_analytics_api_2023_10_31.bundled.schema.yaml
@@ -308,6 +308,9 @@ paths:
         - Security Entity Analytics API
   /api/entity_analytics/monitoring/engine/delete:
     delete:
+      description: >-
+        Deletes the Privilege Monitoring Engine and optionally removes all
+        associated privileged user data.
       operationId: DeleteMonitoringEngine
       parameters:
         - description: Whether to delete all the privileged user data
@@ -321,6 +324,11 @@ paths:
         '200':
           content:
             application/json:
+              examples:
+                DeleteMonitoringEngineResponse:
+                  summary: Engine deleted successfully
+                  value:
+                    deleted: true
               schema:
                 type: object
                 properties:
@@ -334,11 +342,19 @@ paths:
         - Security Entity Analytics API
   /api/entity_analytics/monitoring/engine/disable:
     post:
+      description: >-
+        Disables the Privilege Monitoring Engine, stopping all monitoring
+        activity without removing data.
       operationId: DisableMonitoringEngine
       responses:
         '200':
           content:
             application/json:
+              examples:
+                DisableMonitoringEngineResponse:
+                  summary: Engine disabled successfully
+                  value:
+                    status: disabled
               schema:
                 $ref: '#/components/schemas/MonitoringEngineDescriptor'
           description: Successful response
@@ -347,11 +363,19 @@ paths:
         - Security Entity Analytics API
   /api/entity_analytics/monitoring/engine/init:
     post:
+      description: >-
+        Initializes the Privilege Monitoring Engine, setting up the required
+        resources and starting the engine.
       operationId: InitMonitoringEngine
       responses:
         '200':
           content:
             application/json:
+              examples:
+                InitMonitoringEngineResponse:
+                  summary: Engine initialized successfully
+                  value:
+                    status: started
               schema:
                 $ref: '#/components/schemas/MonitoringEngineDescriptor'
           description: Successful response
@@ -366,11 +390,19 @@ paths:
         - Security Entity Analytics API
   /api/entity_analytics/monitoring/engine/schedule_now:
     post:
+      description: >-
+        Schedules the Privilege Monitoring Engine to run as soon as possible,
+        triggering an immediate monitoring cycle.
       operationId: ScheduleMonitoringEngine
       responses:
         '200':
           content:
             application/json:
+              examples:
+                ScheduleMonitoringEngineResponse:
+                  summary: Engine scheduled successfully
+                  value:
+                    success: true
               schema:
                 type: object
                 properties:
@@ -393,11 +425,22 @@ paths:
         - Security Entity Analytics API
   /api/entity_analytics/monitoring/privileges/health:
     get:
+      description: >-
+        Returns the current health status of the Privilege Monitoring Engine,
+        including engine status, error details, and user count statistics.
       operationId: PrivMonHealth
       responses:
         '200':
           content:
             application/json:
+              examples:
+                PrivMonHealthResponse:
+                  summary: Healthy privilege monitoring engine
+                  value:
+                    status: started
+                    users:
+                      current_count: 42
+                      max_allowed: 1000
               schema:
                 type: object
                 properties:
@@ -456,10 +499,24 @@ paths:
         - Security Entity Analytics API
   /api/entity_analytics/monitoring/users:
     post:
+      description: >-
+        Creates a new privileged user to be monitored by the Privilege
+        Monitoring Engine.
       operationId: CreatePrivMonUser
       requestBody:
         content:
           application/json:
+            examples:
+              CreatePrivMonUserRequest:
+                summary: Create a monitored user
+                value:
+                  entity_analytics_monitoring:
+                    labels:
+                      - field: department
+                        source: api
+                        value: IT
+                  user:
+                    name: john.doe
             schema:
               $ref: '#/components/schemas/UserName'
         required: true
@@ -467,6 +524,22 @@ paths:
         '200':
           content:
             application/json:
+              examples:
+                CreatePrivMonUserResponse:
+                  summary: Created monitored user
+                  value:
+                    '@timestamp': '2026-01-28T12:00:00.000Z'
+                    entity_analytics_monitoring:
+                      labels:
+                        - field: department
+                          source: api
+                          value: IT
+                    event:
+                      ingested: '2026-01-28T12:00:00.000Z'
+                    id: user-abc-123
+                    user:
+                      is_privileged: true
+                      name: john.doe
               schema:
                 $ref: '#/components/schemas/MonitoredUserDoc'
           description: User created successfully
@@ -475,6 +548,9 @@ paths:
         - Security Entity Analytics API
   /api/entity_analytics/monitoring/users/_csv:
     post:
+      description: >-
+        Bulk upserts privileged users by uploading a CSV file. Returns per-row
+        errors and aggregate upload statistics.
       operationId: PrivmonBulkUploadUsersCSV
       requestBody:
         content:
@@ -522,6 +598,7 @@ paths:
         - Security Entity Analytics API
   /api/entity_analytics/monitoring/users/{id}:
     delete:
+      description: Removes a privileged user from monitoring by their document ID.
       operationId: DeletePrivMonUser
       parameters:
         - in: path
@@ -533,6 +610,12 @@ paths:
         '200':
           content:
             application/json:
+              examples:
+                DeletePrivMonUserResponse:
+                  summary: User deleted successfully
+                  value:
+                    acknowledged: true
+                    message: User deleted successfully
               schema:
                 type: object
                 properties:
@@ -551,6 +634,9 @@ paths:
       tags:
         - Security Entity Analytics API
     put:
+      description: >-
+        Updates the details of an existing monitored privileged user by their
+        document ID.
       operationId: UpdatePrivMonUser
       parameters:
         - in: path
@@ -561,6 +647,18 @@ paths:
       requestBody:
         content:
           application/json:
+            examples:
+              UpdatePrivMonUserRequest:
+                summary: Update a monitored user
+                value:
+                  entity_analytics_monitoring:
+                    labels:
+                      - field: department
+                        source: api
+                        value: Security
+                  user:
+                    is_privileged: true
+                    name: john.doe
             schema:
               $ref: '#/components/schemas/MonitoredUserUpdateDoc'
         required: true
@@ -568,6 +666,22 @@ paths:
         '200':
           content:
             application/json:
+              examples:
+                UpdatePrivMonUserResponse:
+                  summary: Updated monitored user
+                  value:
+                    '@timestamp': '2026-01-28T12:00:00.000Z'
+                    entity_analytics_monitoring:
+                      labels:
+                        - field: department
+                          source: api
+                          value: Security
+                    event:
+                      ingested: '2026-01-28T12:00:00.000Z'
+                    id: user-abc-123
+                    user:
+                      is_privileged: true
+                      name: john.doe
               schema:
                 $ref: '#/components/schemas/MonitoredUserDoc'
           description: User updated successfully
@@ -576,6 +690,9 @@ paths:
         - Security Entity Analytics API
   /api/entity_analytics/monitoring/users/list:
     get:
+      description: >-
+        Returns a list of all privileged users currently being monitored.
+        Supports optional KQL filtering.
       operationId: ListPrivMonUsers
       parameters:
         - description: KQL query to filter the list of monitored users
@@ -588,6 +705,34 @@ paths:
         '200':
           content:
             application/json:
+              examples:
+                ListPrivMonUsersResponse:
+                  summary: List of monitored users
+                  value:
+                    - '@timestamp': '2026-01-28T12:00:00.000Z'
+                      entity_analytics_monitoring:
+                        labels:
+                          - field: department
+                            source: api
+                            value: IT
+                      event:
+                        ingested: '2026-01-28T12:00:00.000Z'
+                      id: user-abc-123
+                      user:
+                        is_privileged: true
+                        name: john.doe
+                    - '@timestamp': '2026-01-15T09:00:00.000Z'
+                      entity_analytics_monitoring:
+                        labels:
+                          - field: department
+                            source: csv
+                            value: Security
+                      event:
+                        ingested: '2026-01-15T09:00:00.000Z'
+                      id: user-def-456
+                      user:
+                        is_privileged: true
+                        name: jane.smith
               schema:
                 items:
                   $ref: '#/components/schemas/MonitoredUserDoc'
@@ -598,11 +743,20 @@ paths:
         - Security Entity Analytics API
   /api/entity_analytics/privileged_user_monitoring/pad/install:
     post:
+      description: >-
+        Installs the privileged access detection integration package and sets up
+        the associated ML modules required for the Entity Analytics privileged
+        user monitoring experience.
       operationId: InstallPrivilegedAccessDetectionPackage
       responses:
         '200':
           content:
             application/json:
+              examples:
+                InstallPrivilegedAccessDetectionPackageResponse:
+                  summary: Package installed successfully
+                  value:
+                    message: Privileged access detection package installed successfully
               schema:
                 type: object
                 properties:
@@ -618,11 +772,28 @@ paths:
         - Security Entity Analytics API
   /api/entity_analytics/privileged_user_monitoring/pad/status:
     get:
+      description: >-
+        Returns the installation and ML module setup status of the privileged
+        access detection package, along with the state of each associated ML
+        job.
       operationId: GetPrivilegedAccessDetectionPackageStatus
       responses:
         '200':
           content:
             application/json:
+              examples:
+                GetPrivilegedAccessDetectionPackageStatusResponse:
+                  summary: Package fully installed and running
+                  value:
+                    jobs:
+                      - description: Detects high-risk login patterns
+                        job_id: pad-high-risk-login
+                        state: opened
+                      - description: Detects privilege escalation events
+                        job_id: pad-privilege-escalation
+                        state: opened
+                    ml_module_setup_status: complete
+                    package_installation_status: complete
               schema:
                 type: object
                 properties:
@@ -668,6 +839,9 @@ paths:
         - Security Entity Analytics API
   /api/entity_analytics/watchlists:
     post:
+      description: >-
+        Creates a new entity analytics watchlist with an optional set of entity
+        sources. Watchlists apply a risk score modifier to matched entities.
       operationId: CreateWatchlist
       requestBody:
         content:
@@ -786,6 +960,9 @@ paths:
       x-state: Technical Preview
   /api/entity_analytics/watchlists/{id}:
     get:
+      description: >-
+        Retrieves the details of an entity analytics watchlist by its unique
+        identifier.
       operationId: GetWatchlist
       parameters:
         - description: Unique ID of the watchlist
@@ -817,6 +994,9 @@ paths:
         - Security Entity Analytics API
       x-state: Technical Preview
     put:
+      description: >-
+        Updates the name, description, risk modifier, or managed status of an
+        existing entity analytics watchlist.
       operationId: UpdateWatchlist
       parameters:
         - description: The ID of the watchlist to update
@@ -1177,6 +1357,7 @@ paths:
       x-state: Technical Preview; added in 9.4.0
   /api/entity_analytics/watchlists/list:
     get:
+      description: Returns a list of all entity analytics watchlists.
       operationId: ListWatchlists
       responses:
         '200':
@@ -2112,6 +2293,11 @@ paths:
         '200':
           content:
             application/json:
+              examples:
+                CleanUpRiskEngineResponse:
+                  summary: Successful cleanup response
+                  value:
+                    cleanup_successful: true
               schema:
                 type: object
                 properties:
@@ -2140,6 +2326,23 @@ paths:
       requestBody:
         content:
           application/json:
+            examples:
+              ConfigureRiskEngineSavedObjectRequest:
+                summary: Configure the risk engine saved object
+                value:
+                  enable_reset_to_zero: false
+                  exclude_alert_statuses:
+                    - closed
+                  exclude_alert_tags:
+                    - low-priority
+                  filters:
+                    - entity_types:
+                        - host
+                        - user
+                      filter: 'host.name: *'
+                  range:
+                    end: now
+                    start: now-30d
             schema:
               type: object
               properties:
@@ -2184,6 +2387,11 @@ paths:
         '200':
           content:
             application/json:
+              examples:
+                ConfigureRiskEngineSavedObjectResponse:
+                  summary: Successful configuration response
+                  value:
+                    risk_engine_saved_object_configured: true
               schema:
                 type: object
                 properties:
@@ -2220,6 +2428,11 @@ paths:
         '200':
           content:
             application/json:
+              examples:
+                ScheduleRiskEngineNowResponse:
+                  summary: Successful schedule response
+                  value:
+                    success: true
               schema:
                 $ref: '#/components/schemas/RiskEngineScheduleNowResponse'
           description: Successful response


### PR DESCRIPTION
### Summary

Closes: https://github.com/elastic/security-team/issues/16463

Adds operation-level descriptions and request/response examples to 19 OpenAPI schema files across the entity analytics public API surface to improve documentation quality and developer experience.

- **risk_engine:** add response examples to CleanUpRiskEngine, ScheduleRiskEngineNow; add request + response examples to ConfigureRiskEngineSavedObject
- **monitoring/engine:** add descriptions and response examples to InitMonitoringEngine, DisableMonitoringEngine, DeleteMonitoringEngine, ScheduleMonitoringEngine
- **monitoring/health:** add description and response example to PrivMonHealth
- **monitoring/users:** add descriptions, request examples, and response examples to CreatePrivMonUser, DeletePrivMonUser, UpdatePrivMonUser, ListPrivMonUsers; add description to PrivmonBulkUploadUsersCSV
- **monitoring/privileged_access_detection:** add descriptions and response examples to InstallPrivilegedAccessDetectionPackage and GetPrivilegedAccessDetectionPackageStatus
- **watchlists:** add descriptions to CreateWatchlist, GetWatchlist, UpdateWatchlist, ListWatchlists


## Checklist

### `/api/risk_score/*`
- [x] `CleanUpRiskEngine` — response example
- [x] `ConfigureRiskEngineSavedObject` — request example, response example
- [x] `ScheduleRiskEngineNow` — response example

### `/api/entity_analytics/monitoring/*`
- [x] `InitMonitoringEngine` — description, response example
- [x] `DisableMonitoringEngine` — description, response example
- [x] `DeleteMonitoringEngine` — description, response example
- [x] `ScheduleMonitoringEngine` — description, response example
- [x] `PrivMonHealth` — description, response example
- [x] `CreatePrivMonUser` — description, request example, response example
- [x] `DeletePrivMonUser` — description, response example
- [x] `UpdatePrivMonUser` — description, request example, response example
- [x] `ListPrivMonUsers` — description, response example
- [x] `PrivmonBulkUploadUsersCSV` — description

### `/api/entity_analytics/privileged_user_monitoring/*`
- [x] `InstallPrivilegedAccessDetectionPackage` — description, response example
- [x] `GetPrivilegedAccessDetectionPackageStatus` — description, response example

### `/api/entity_analytics/watchlists/*`
- [x] `CreateWatchlist` — description
- [x] `GetWatchlist` — description
- [x] `UpdateWatchlist` — description
- [x] `ListWatchlists` — description


<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->