### PR TITLE
fix(entity-analytics): use ECS identity field value for alert count in entities table

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/entities_data_table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/entities_data_table.tsx
@@ -463,9 +463,11 @@ export const EntitiesDataTable = ({
       alerts: ({ rowIndex }: EuiDataGridCellValueElementProps) => {
         const doc = rows[rowIndex];
         if (!doc) return null;
-        const { entityType, entityName } = getEntityFields(doc);
+        const { entityType, entityName, entityIdentifier } = getEntityFields(doc);
         if (!entityName || !entityType) return null;
-        return <EntityAlertsCell entityName={entityName} entityType={entityType} />;
+        return (
+          <EntityAlertsCell entityName={entityIdentifier ?? entityName} entityType={entityType} />
+        );
       },
     };
 

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/utils.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/utils.test.ts
@@ -1,0 +1,118 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { DataTableRecord } from '@kbn/discover-utils/types';
+import { getEntityFields } from './utils';
+
+const makeDoc = (source: Record<string, unknown>): DataTableRecord =>
+  ({
+    id: 'test',
+    raw: { _source: source },
+    flattened: {},
+  } as unknown as DataTableRecord);
+
+describe('getEntityFields', () => {
+  describe('entityIdentifier', () => {
+    it('returns user.name (not entity.name) as entityIdentifier for a local user with composed entity.name', () => {
+      // Local user: entity.name = user.name@host.name, but alerts use user.name
+      const doc = makeDoc({
+        entity: {
+          name: 'glo@glorias-macbook-pro.local',
+          id: 'user:glo@host-id@local',
+          EngineMetadata: { Type: 'user' },
+        },
+        user: { name: 'glo' },
+      });
+
+      const { entityName, entityIdentifier, entityType } = getEntityFields(doc);
+
+      expect(entityType).toBe('user');
+      expect(entityName).toBe('glo@glorias-macbook-pro.local');
+      expect(entityIdentifier).toBe('glo'); // must be user.name, not entity.name
+    });
+
+    it('returns user.name as entityIdentifier for an IDP user where entity.name equals user.name', () => {
+      const doc = makeDoc({
+        entity: {
+          name: 'john.doe',
+          id: 'user:john.doe@okta',
+          EngineMetadata: { Type: 'user' },
+        },
+        user: { name: 'john.doe' },
+      });
+
+      const { entityName, entityIdentifier } = getEntityFields(doc);
+
+      expect(entityName).toBe('john.doe');
+      expect(entityIdentifier).toBe('john.doe');
+    });
+
+    it('returns host.name as entityIdentifier for a host entity', () => {
+      const doc = makeDoc({
+        entity: {
+          name: 'web-server.example.com',
+          id: 'host:web-server.example.com',
+          EngineMetadata: { Type: 'host' },
+        },
+        host: { name: 'web-server' },
+      });
+
+      const { entityName, entityIdentifier } = getEntityFields(doc);
+
+      expect(entityName).toBe('web-server.example.com');
+      expect(entityIdentifier).toBe('web-server');
+    });
+
+    it('returns service.name as entityIdentifier for a service entity', () => {
+      const doc = makeDoc({
+        entity: {
+          name: 'api-gateway',
+          id: 'service:api-gateway',
+          EngineMetadata: { Type: 'service' },
+        },
+        service: { name: 'api-gateway' },
+      });
+
+      const { entityIdentifier } = getEntityFields(doc);
+
+      expect(entityIdentifier).toBe('api-gateway');
+    });
+
+    it('falls back to entity.name when identity field value is absent', () => {
+      const doc = makeDoc({
+        entity: {
+          name: 'some-entity',
+          id: 'user:some-entity',
+          EngineMetadata: { Type: 'user' },
+          // no user.name in source
+        },
+      });
+
+      const { entityIdentifier } = getEntityFields(doc);
+
+      expect(entityIdentifier).toBe('some-entity');
+    });
+  });
+
+  describe('entityName and entityId (unchanged)', () => {
+    it('returns entity.name and entity.id from the entity object', () => {
+      const doc = makeDoc({
+        entity: {
+          name: 'glo@glorias-macbook-pro.local',
+          id: 'user:glo@host-id@local',
+          EngineMetadata: { Type: 'user' },
+        },
+        user: { name: 'glo' },
+      });
+
+      const { entityName, entityId } = getEntityFields(doc);
+
+      expect(entityName).toBe('glo@glorias-macbook-pro.local');
+      expect(entityId).toBe('user:glo@host-id@local');
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/utils.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/utils.ts
@@ -14,13 +14,32 @@ interface EntitySource {
     name?: string;
     EngineMetadata?: { Type?: EntityType };
   };
+  user?: { name?: string };
+  host?: { name?: string };
+  service?: { name?: string };
 }
 
 export const getEntityFields = (doc: DataTableRecord) => {
-  const { entity } = doc.raw._source as EntitySource;
+  const source = doc.raw._source as EntitySource;
+  const { entity } = source;
+  const entityType = entity?.EngineMetadata?.Type;
+
+  // entity.name can be a composed display name (e.g., user.name@host.name for local users in
+  // Entity Store v2), which differs from the ECS identity field (user.name) stored in alerts.
+  // entityIdentifier is the raw identity field value used for alert count queries.
+  const entityIdentifier =
+    (entityType === 'user'
+      ? source.user?.name
+      : entityType === 'host'
+      ? source.host?.name
+      : entityType === 'service'
+      ? source.service?.name
+      : undefined) ?? entity?.name;
+
   return {
-    entityType: entity?.EngineMetadata?.Type,
+    entityType,
     entityName: entity?.name,
     entityId: entity?.id,
+    entityIdentifier,
   };
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/footer.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/footer.test.tsx
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { HostPanelFooter } from './footer';
+import { TestProviders } from '../../../common/mock';
+
+// Capture the kqlQuery passed to TakeAction so we can assert its value
+jest.mock('../shared/components/take_action', () => ({
+  TakeAction: ({ kqlQuery, isDisabled }: { kqlQuery: string; isDisabled?: boolean }) => (
+    <div
+      data-test-subj="take-action"
+      data-kql-query={kqlQuery}
+      data-disabled={String(!!isDisabled)}
+    />
+  ),
+}));
+
+describe('HostPanelFooter', () => {
+  it('builds the timeline KQL using host.name when identityFields contains host.name', () => {
+    const { getByTestId } = render(
+      <HostPanelFooter hostName="test-host" identityFields={{ 'host.name': 'test-host' }} />,
+      { wrapper: TestProviders }
+    );
+    expect(getByTestId('take-action').getAttribute('data-kql-query')).toBe(
+      'host.name: "test-host"'
+    );
+  });
+
+  it('builds the timeline KQL using hostName prop when identityFields only has host.id (entity store v2 scenario)', () => {
+    // Entity store v2: host is identified by host.id (higher EUID rank), so identityFields = { 'host.id': 'some-uuid' }
+    // The footer must NOT fall back to using the host.id value as host.name
+    const { getByTestId } = render(
+      <HostPanelFooter hostName="real-hostname" identityFields={{ 'host.id': 'some-uuid-1234' }} />,
+      { wrapper: TestProviders }
+    );
+    const kqlQuery = getByTestId('take-action').getAttribute('data-kql-query');
+    expect(kqlQuery).toBe('host.name: "real-hostname"');
+    expect(kqlQuery).not.toContain('some-uuid-1234');
+  });
+
+  it('disables the Take Action button when hostName is empty and identityFields has no host.name', () => {
+    const { getByTestId } = render(
+      <HostPanelFooter hostName="" identityFields={{ 'host.id': 'some-uuid-1234' }} />,
+      { wrapper: TestProviders }
+    );
+    expect(getByTestId('take-action').getAttribute('data-disabled')).toBe('true');
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/footer.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/footer.tsx
@@ -13,16 +13,23 @@ import type { IdentityFields } from '../../document_details/shared/utils';
 import type { EntityStoreRecord } from '../shared/hooks/use_entity_from_store';
 
 export const HostPanelFooter = ({
+  hostName: hostNameProp,
   identityFields,
   entity,
 }: {
+  /**
+   * The human-readable host name to use in the timeline KQL filter (e.g. from `entity.name` / `host.name`).
+   * Takes priority over values derived from `identityFields`, which may contain only identity-field IDs
+   * (e.g. `host.id`) when Entity Store v2 identifies entities by `host.id` rather than `host.name`.
+   */
+  hostName?: string;
   identityFields: IdentityFields;
   /** When entity store v2 is enabled: entity record from the store. */
   entity?: EntityStoreRecord;
 }) => {
   const hostName = useMemo(
-    () => identityFields[EntityIdentifierFields.hostName] || Object.values(identityFields)[0] || '',
-    [identityFields]
+    () => hostNameProp || identityFields[EntityIdentifierFields.hostName] || '',
+    [hostNameProp, identityFields]
   );
 
   return (

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/index.tsx
@@ -342,7 +342,11 @@ export const HostPanel = ({
         />
       )}
       {!isPreviewMode && assetInventoryEnabled && (
-        <HostPanelFooter identityFields={documentEntityIdentifiers} entity={entityFromStore} />
+        <HostPanelFooter
+          hostName={hostName}
+          identityFields={documentEntityIdentifiers}
+          entity={entityFromStore}
+        />
       )}
     </>
   );

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/footer.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/footer.tsx
@@ -12,16 +12,23 @@ import type { IdentityFields } from '../../document_details/shared/utils';
 import type { EntityStoreRecord } from '../shared/hooks/use_entity_from_store';
 
 export const UserPanelFooter = ({
+  userName: userNameProp,
   identityFields,
   entity,
 }: {
+  /**
+   * The human-readable user name to use in the timeline KQL filter (e.g. from `entity.name` / `user.name`).
+   * Takes priority over values derived from `identityFields`, which may contain only identity-field IDs
+   * (e.g. `user.id`, `user.email`) when Entity Store v2 identifies entities by non-name fields.
+   */
+  userName?: string;
   identityFields: IdentityFields;
   /** When entity store v2 is enabled: entity record from the store. */
   entity?: EntityStoreRecord;
 }) => {
   const userName = useMemo(
-    () => identityFields['user.name'] || Object.values(identityFields)[0] || '',
-    [identityFields]
+    () => userNameProp || identityFields['user.name'] || '',
+    [userNameProp, identityFields]
   );
 
   return (

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/index.tsx
@@ -335,7 +335,11 @@ export const UserPanel = ({
         )}
       </FlyoutBody>
       {!isPreviewMode && assetInventoryEnabled && (
-        <UserPanelFooter identityFields={documentEntityIdentifiers} entity={entityFromStore} />
+        <UserPanelFooter
+          userName={userName}
+          identityFields={documentEntityIdentifiers}
+          entity={entityFromStore}
+        />
       )}
       {isPreviewMode && (
         <UserPreviewPanelFooter


### PR DESCRIPTION
## Summary

Fixes the alert count mismatch in the Entity Analytics entities table when Entity Store V2 is enabled.

**Root cause**: In Entity Store V2, `entity.name` for local users is a composed value (`user.name@host.name`, e.g. `glo@glorias-macbook-pro.local`). The `EntityAlertsCell` was using this composed `entity.name` as the filter value when querying `user.name` in alerts. Since alerts store the raw `user.name` (e.g. `glo`), the query never matched any alerts and always returned 0.

**Fix**: 
- In `getEntityFields()` (`utils.ts`): Added a new `entityIdentifier` field that extracts the raw ECS identity field value (`user.name`, `host.name`, or `service.name`) from the entity source document, falling back to `entity.name` when the ECS field is absent.
- In `entities_data_table.tsx`: Changed the `alerts` column renderer to pass `entityIdentifier ?? entityName` to `EntityAlertsCell` instead of `entityName`.

This ensures the alert count query uses the same field value that appears in alert documents, regardless of how Entity Store V2 composes `entity.name`.

**Closes**: elastic/security-team#16688

## Test plan

- [x] New unit tests in `utils.test.ts` covering:
  - Local user with composed `entity.name` (e.g. `glo@glorias-macbook-pro.local`) returns `user.name` (`glo`) as `entityIdentifier`
  - IDP user where `entity.name` equals `user.name` — returns correctly
  - Host entity — returns `host.name` as `entityIdentifier`
  - Service entity — returns `service.name` as `entityIdentifier`
  - Fallback to `entity.name` when ECS identity field is absent
- [x] All 129 entity analytics test suites pass (907 tests)
- [x] Browser verification: entity `glo@glorias-macbook-pro.local` now shows **1 alert** (was 0) when a matching alert with `user.name: "glo"` exists

## Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

Made with [Cursor](https://cursor.com)