### PR TITLE
[DO NOT MERGE] Flaky test runner: detection_rule_status duration debug (run 2)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/create_security_rule_type_wrapper.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/create_security_rule_type_wrapper.ts
@@ -472,6 +472,14 @@ export const createSecurityRuleTypeWrapper: CreateSecurityRuleTypeWrapper =
             );
             const suppressedAlertsCount = result.suppressedAlertsCount ?? 0;
 
+            // DEBUG: raw timing arrays prior to sum+round, for flake investigation.
+            logger.info(
+              `[debug] ruleType=${rule.ruleTypeId} ` +
+                `searchAfterTimes=${JSON.stringify(result.searchAfterTimes)} ` +
+                `bulkCreateTimes=${JSON.stringify(result.bulkCreateTimes)} ` +
+                `enrichmentTimes=${JSON.stringify(result.enrichmentTimes)}`
+            );
+
             ruleExecutionLogger.logMetrics({
               total_search_duration_ms:
                 result.searchAfterTimes.length > 0

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/create_security_rule_type_wrapper.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/create_security_rule_type_wrapper.ts
@@ -472,7 +472,7 @@ export const createSecurityRuleTypeWrapper: CreateSecurityRuleTypeWrapper =
             );
             const suppressedAlertsCount = result.suppressedAlertsCount ?? 0;
 
-            // DEBUG: raw timing arrays prior to sum+round, for flake investigation.
+            // DEBUG: raw timing arrays prior to sum+round, for flake investigation. (run 2)
             logger.info(
               `[debug] ruleType=${rule.ruleTypeId} ` +
                 `searchAfterTimes=${JSON.stringify(result.searchAfterTimes)} ` +

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/telemetry/trial_license_complete_tier/configs/ess.config.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/telemetry/trial_license_complete_tier/configs/ess.config.ts
@@ -18,5 +18,11 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
     junit: {
       reportName: 'Detection Engine - Telemetry Integration Tests - ESS Env - Trial License',
     },
+    // DEBUG: disable CI log capture so our debug logger.info lines stream to
+    // the Buildkite console instead of being buffered and only dumped on test
+    // failure.
+    mochaReporter: {
+      captureLogOutput: false,
+    },
   };
 }

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/telemetry/trial_license_complete_tier/configs/serverless.config.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/telemetry/trial_license_complete_tier/configs/serverless.config.ts
@@ -5,9 +5,10 @@
  * 2.0.
  */
 
+import type { FtrConfigProviderContext } from '@kbn/test';
 import { createTestConfig } from '../../../../../config/serverless/config.base';
 
-export default createTestConfig({
+const baseConfig = createTestConfig({
   testFiles: [require.resolve('..')],
   junit: {
     reportName: 'Detection Engine - Telemetry Integration Tests - Serverless Env - Complete Tier',
@@ -16,3 +17,16 @@ export default createTestConfig({
     `--xpack.securitySolution.enableExperimental=${JSON.stringify(['previewTelemetryUrlEnabled'])}`,
   ],
 });
+
+export default async (context: FtrConfigProviderContext) => {
+  const config = await baseConfig(context);
+  return {
+    ...config,
+    // DEBUG: disable CI log capture so our debug logger.info lines stream to
+    // the Buildkite console instead of being buffered and only dumped on test
+    // failure.
+    mochaReporter: {
+      captureLogOutput: false,
+    },
+  };
+};

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/telemetry/trial_license_complete_tier/index.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/telemetry/trial_license_complete_tier/index.ts
@@ -8,17 +8,17 @@ import type { FtrProviderContext } from '../../../../ftr_provider_context';
 
 export default ({ loadTestFile }: FtrProviderContext): void => {
   describe('Detections Response -  Detection rule type telemetry', function () {
-    loadTestFile(require.resolve('./usage_collector/all_types'));
-    loadTestFile(require.resolve('./usage_collector/detection_rules'));
-    loadTestFile(require.resolve('./usage_collector/exceptions_metrics'));
-    loadTestFile(require.resolve('./usage_collector/value_list_metrics'));
+    // loadTestFile(require.resolve('./usage_collector/all_types'));
+    // loadTestFile(require.resolve('./usage_collector/detection_rules'));
+    // loadTestFile(require.resolve('./usage_collector/exceptions_metrics'));
+    // loadTestFile(require.resolve('./usage_collector/value_list_metrics'));
     loadTestFile(require.resolve('./usage_collector/detection_rule_status'));
-    loadTestFile(require.resolve('./usage_collector/detection_rule_upgrade_status'));
-    loadTestFile(require.resolve('./usage_collector/detection_rule_customization_status'));
-    loadTestFile(require.resolve('./usage_collector/detection_rules_legacy_action'));
+    // loadTestFile(require.resolve('./usage_collector/detection_rule_upgrade_status'));
+    // loadTestFile(require.resolve('./usage_collector/detection_rule_customization_status'));
+    // loadTestFile(require.resolve('./usage_collector/detection_rules_legacy_action'));
 
-    loadTestFile(require.resolve('./task_based/all_types'));
-    loadTestFile(require.resolve('./task_based/detection_rules'));
-    loadTestFile(require.resolve('./task_based/security_lists'));
+    // loadTestFile(require.resolve('./task_based/all_types'));
+    // loadTestFile(require.resolve('./task_based/detection_rules'));
+    // loadTestFile(require.resolve('./task_based/security_lists'));
   });
 };

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/telemetry/trial_license_complete_tier/usage_collector/detection_rule_status.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/telemetry/trial_license_complete_tier/usage_collector/detection_rule_status.ts
@@ -8,7 +8,10 @@
 import expect from '@kbn/expect';
 import expect_ from 'expect';
 import type { MlJobUsageMetric } from '@kbn/security-solution-plugin/server/usage/detections/ml_jobs/types';
-import type { RulesTypeUsage } from '@kbn/security-solution-plugin/server/usage/detections/rules/types';
+import type {
+  RulesTypeUsage,
+  SingleEventMetric,
+} from '@kbn/security-solution-plugin/server/usage/detections/rules/types';
 import type { DetectionMetrics } from '@kbn/security-solution-plugin/server/usage/detections/types';
 import type {
   ThreatMatchRuleCreateProps,
@@ -45,6 +48,66 @@ export default ({ getService }: FtrProviderContext) => {
   const log = getService('log');
   const retry = getService('retry');
   const es = getService('es');
+
+  // DEBUG: dumps raw execution-metrics docs for a given rule category along with
+  // the index/search/enrichment duration slices from the stats payload, so we
+  // can see whether each field was stored as 0, as a small rounded int, or was
+  // never written.
+  const dumpExecutionMetrics = async (
+    ruleCategory: string,
+    statsMetrics: SingleEventMetric | undefined
+  ): Promise<void> => {
+    try {
+      const result = await es.search({
+        index: '.kibana-event-log-*',
+        size: 20,
+        query: {
+          bool: {
+            filter: [
+              { term: { 'event.action': 'execution-metrics' } },
+              { term: { 'rule.category': ruleCategory } },
+            ],
+          },
+        },
+        sort: [{ '@timestamp': { order: 'asc' } }],
+        _source: ['@timestamp', 'kibana.alert.rule.execution.metrics', 'rule.category'],
+      });
+      const hits = (result.hits.hits ?? []).map((h) => h._source);
+      log.info(
+        `[debug] ${ruleCategory} execution-metrics docs (${hits.length}): ${JSON.stringify(
+          hits,
+          null,
+          2
+        )}`
+      );
+      log.info(
+        `[debug] ${ruleCategory} stats durations: ${JSON.stringify({
+          index_duration: statsMetrics?.index_duration,
+          search_duration: statsMetrics?.search_duration,
+          enrichment_duration: statsMetrics?.enrichment_duration,
+        })}`
+      );
+    } catch (e) {
+      log.warning(`[debug] dumpExecutionMetrics failed for ${ruleCategory}: ${e}`);
+    }
+  };
+
+  // DEBUG: logs the stats slice again at the start of a failing-style it block,
+  // so that the attribution is unambiguous in mocha's output (the before-all
+  // dump is visually attached to the first it in the describe, which can be a
+  // different test than the one that fails).
+  const logStatsForIt = (
+    ruleCategory: string,
+    statsMetrics: SingleEventMetric | undefined
+  ): void => {
+    log.info(
+      `[debug] it(${ruleCategory}) durations: ${JSON.stringify({
+        index_duration: statsMetrics?.index_duration,
+        search_duration: statsMetrics?.search_duration,
+        enrichment_duration: statsMetrics?.enrichment_duration,
+      })}`
+    );
+  };
 
   describe('@ess @serverless Detection rule status telemetry', () => {
     before(async () => {
@@ -85,6 +148,10 @@ export default ({ getService }: FtrProviderContext) => {
             1
           );
         });
+        await dumpExecutionMetrics(
+          'siem.queryRule',
+          stats?.detection_rules.detection_rule_status.custom_rules.query
+        );
       });
 
       it('should have an empty "ml_jobs"', () => {
@@ -177,6 +244,10 @@ export default ({ getService }: FtrProviderContext) => {
       });
 
       it('@skipInServerlessMKI should have non zero values for "index_duration"', () => {
+        logStatsForIt(
+          'siem.queryRule',
+          stats?.detection_rules.detection_rule_status.custom_rules.query
+        );
         expect(
           stats?.detection_rules.detection_rule_status.custom_rules.query.index_duration.max
         ).to.be.above(1);
@@ -272,6 +343,10 @@ export default ({ getService }: FtrProviderContext) => {
             1
           );
         });
+        await dumpExecutionMetrics(
+          'siem.eqlRule',
+          stats?.detection_rules.detection_rule_status.custom_rules.eql
+        );
       });
 
       it('should have an empty "ml_jobs"', () => {
@@ -363,6 +438,10 @@ export default ({ getService }: FtrProviderContext) => {
       });
 
       it('should have non zero values for "index_duration"', () => {
+        logStatsForIt(
+          'siem.eqlRule',
+          stats?.detection_rules.detection_rule_status.custom_rules.eql
+        );
         expect(
           stats?.detection_rules.detection_rule_status.custom_rules.eql.index_duration.max
         ).to.be.above(1);
@@ -464,6 +543,10 @@ export default ({ getService }: FtrProviderContext) => {
             1
           );
         });
+        await dumpExecutionMetrics(
+          'siem.thresholdRule',
+          stats?.detection_rules.detection_rule_status.custom_rules.threshold
+        );
       });
 
       it('should have an empty "ml_jobs"', () => {
@@ -557,6 +640,10 @@ export default ({ getService }: FtrProviderContext) => {
       });
 
       it('should have non zero values for "index_duration"', () => {
+        logStatsForIt(
+          'siem.thresholdRule',
+          stats?.detection_rules.detection_rule_status.custom_rules.threshold
+        );
         expect(
           stats?.detection_rules.detection_rule_status.custom_rules.threshold.index_duration.max
         ).to.be.above(1);
@@ -672,6 +759,10 @@ export default ({ getService }: FtrProviderContext) => {
             1
           );
         });
+        await dumpExecutionMetrics(
+          'siem.indicatorRule',
+          stats?.detection_rules.detection_rule_status.custom_rules.threat_match
+        );
       });
 
       it('should have an empty "ml_jobs"', () => {
@@ -767,6 +858,10 @@ export default ({ getService }: FtrProviderContext) => {
       });
 
       it('should have non zero values for "index_duration"', () => {
+        logStatsForIt(
+          'siem.indicatorRule',
+          stats?.detection_rules.detection_rule_status.custom_rules.threat_match
+        );
         expect(
           stats?.detection_rules.detection_rule_status.custom_rules.threat_match.index_duration.max
         ).to.be.above(1);


### PR DESCRIPTION
## Summary

Second parallel throwaway PR for the [Kibana Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner). Do not merge.

Same debug-instrumented code as the companion PR; trivial comment tweak so this has a distinct tip commit for an independent flaky-runner batch.

## Flaky Test Runner
- `x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/telemetry/trial_license_complete_tier/configs/ess.config.ts`
- `x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/telemetry/trial_license_complete_tier/configs/serverless.config.ts`