### PR TITLE
[ci] Use zstd for moon artifacts

### DIFF
--- a/.buildkite/scripts/bootstrap.sh
+++ b/.buildkite/scripts/bootstrap.sh
@@ -24,11 +24,13 @@ if [[ "$(pwd)" != *"/local-ssd/"* && "$(pwd)" != "/dev/shm"* ]]; then
     mv ~/.kibana/.yarn-local-mirror ./
   fi
   # Check if there's a cache artifact uploaded from a previous step
-  if (buildkite-agent artifact download --step "store_cache" "moon-cache.tar.zst" ~/); then
-    echo "Found moon-cache.tar.zst artifact, extracting to ./.moon/cache"
-    mkdir -p ./.moon/cache
-    echo "Extracting moon-cache.tar.zst to ./.moon/cache"
-    tar -xf ~/moon-cache.tar.zst -I zstd -C ./
+  if [[ -z "${KBN_BOOTSTRAP_NO_PREBUILT:-}" ]]; then
+    if (buildkite-agent artifact download --step "store_cache" "moon-cache.tar.zst" ~/); then
+      echo "Found moon-cache.tar.zst artifact, extracting to ./.moon/cache"
+      mkdir -p ./.moon/cache
+      echo "Extracting moon-cache.tar.zst to ./.moon/cache"
+      tar -xf ~/moon-cache.tar.zst -I zstd -C ./
+    fi
   fi
 fi
 

--- a/.buildkite/scripts/bootstrap.sh
+++ b/.buildkite/scripts/bootstrap.sh
@@ -24,11 +24,11 @@ if [[ "$(pwd)" != *"/local-ssd/"* && "$(pwd)" != "/dev/shm"* ]]; then
     mv ~/.kibana/.yarn-local-mirror ./
   fi
   # Check if there's a cache artifact uploaded from a previous step
-  if (buildkite-agent artifact download --step "store_cache" "moon-cache.tar.gz" ~/); then
-    echo "Found moon-cache.tar.gz artifact, extracting to ./.moon/cache"
+  if (buildkite-agent artifact download --step "store_cache" "moon-cache.tar.zst" ~/); then
+    echo "Found moon-cache.tar.zst artifact, extracting to ./.moon/cache"
     mkdir -p ./.moon/cache
-    echo "Extracting moon-cache.tar.gz to ./.moon/cache"
-    tar -xzf ~/moon-cache.tar.gz -C ./
+    echo "Extracting moon-cache.tar.zst to ./.moon/cache"
+    tar -xf ~/moon-cache.tar.zst -I zstd -C ./
   fi
 fi
 

--- a/.buildkite/scripts/steps/store_cache.sh
+++ b/.buildkite/scripts/steps/store_cache.sh
@@ -12,8 +12,8 @@ if [[ ! -d .moon/cache ]]; then
   echo "No moon cache directory found, skipping archive"
   exit 0
 else
-  tar -czf ~/moon-cache.tar.gz .moon/cache || echo "Failed to archive moon cache"
+  tar -cf ~/moon-cache.tar.zst -I 'zstd -19 -T0' .moon/cache || echo "Failed to archive moon cache"
   cd ~/
-  buildkite-agent artifact upload moon-cache.tar.gz || echo "Failed to upload moon cache"
-  echo "Moon cache archived as moon-cache.tar.gz"
+  buildkite-agent artifact upload moon-cache.tar.zst || echo "Failed to upload moon cache"
+  echo "Moon cache archived as moon-cache.tar.zst"
 fi


### PR DESCRIPTION
Use zstd for the moon cache, and skips downloading the archive on steps that don't need it.

<!--ONMERGE {"backportTargets":["8.19","9.2","9.3","9.4"]} ONMERGE-->