### PR TITLE
[9.4] [Security solution][Attacks] Change "take action items" order to match alerts page items (#262739)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/bulk_action_items/use_bulk_attack_case_items.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/bulk_action_items/use_bulk_attack_case_items.test.tsx
@@ -122,7 +122,7 @@ describe('useBulkAttackCaseItems', () => {
       }
     );
 
-    await result.current.items[0]?.onClick?.(
+    await result.current.items[1]?.onClick?.(
       [
         {
           _id: 'attack-1',
@@ -166,7 +166,7 @@ describe('useBulkAttackCaseItems', () => {
       }
     );
 
-    await result.current.items[0]?.onClick?.(
+    await result.current.items[1]?.onClick?.(
       [
         {
           _id: 'attack-1',
@@ -195,7 +195,7 @@ describe('useBulkAttackCaseItems', () => {
       }
     );
 
-    await result.current.items[1]?.onClick?.(
+    await result.current.items[0]?.onClick?.(
       [
         {
           _id: 'attack-1',
@@ -239,7 +239,7 @@ describe('useBulkAttackCaseItems', () => {
       }
     );
 
-    await result.current.items[1]?.onClick?.(
+    await result.current.items[0]?.onClick?.(
       [
         {
           _id: 'attack-1',

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/bulk_action_items/use_bulk_attack_case_items.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/bulk_action_items/use_bulk_attack_case_items.tsx
@@ -121,15 +121,6 @@ export const useBulkAttackCaseItems = ({
       canCreateAndReadCases
         ? [
             {
-              name: ADD_TO_NEW_CASE,
-              label: ADD_TO_NEW_CASE,
-              key: 'attack-add-to-new-case',
-              'data-test-subj': 'attack-add-to-new-case',
-              disableOnQuery: true,
-              disable: isAddToNewCaseDisabled,
-              onClick: onAddToNewCaseClick,
-            },
-            {
               name: ADD_TO_EXISTING_CASE,
               label: ADD_TO_EXISTING_CASE,
               key: 'attack-add-to-existing-case',
@@ -137,6 +128,15 @@ export const useBulkAttackCaseItems = ({
               disableOnQuery: true,
               disable: isAddToExistingCaseDisabled,
               onClick: onAddToExistingCaseClick,
+            },
+            {
+              name: ADD_TO_NEW_CASE,
+              label: ADD_TO_NEW_CASE,
+              key: 'attack-add-to-new-case',
+              'data-test-subj': 'attack-add-to-new-case',
+              disableOnQuery: true,
+              disable: isAddToNewCaseDisabled,
+              onClick: onAddToNewCaseClick,
             },
           ]
         : [],


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Security solution][Attacks] Change "take action items" order to match alerts page items (#262739)](https://github.com/elastic/kibana/pull/262739)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Nicholas Peretti","email":"nicholas.peretti@elastic.co"},"sourceCommit":{"committedDate":"2026-04-15T17:40:02Z","message":"[Security solution][Attacks] Change \"take action items\" order to match alerts page items (#262739)\n\n## Summary\n\nAddresses #262266 \n\nThis PR changes the order of the action items in the new attack\ndiscovery page to match the order of similar items in the alerts page.\n\n### Before\n\n|alerts|attacks|\n|---|---|\n| <img width=\"272\" height=\"530\" alt=\"Screenshot 2026-04-13 at 11 30 16\"\nsrc=\"https://github.com/user-attachments/assets/dcc82349-1331-4a37-b23f-3855cfdc9c61\"\n/> | <img width=\"274\" height=\"462\" alt=\"Screenshot 2026-04-13 at 11 41\n37\"\nsrc=\"https://github.com/user-attachments/assets/f922c46c-057f-40a8-be5b-0d5a4d7ac584\"\n/> |\n\n### After\n\n|alerts|attacks|\n|---|---|\n| <img width=\"272\" height=\"530\" alt=\"Screenshot 2026-04-13 at 11 30 16\"\nsrc=\"https://github.com/user-attachments/assets/dcc82349-1331-4a37-b23f-3855cfdc9c61\"\n/> | <img width=\"285\" height=\"485\" alt=\"Screenshot 2026-04-13 at 11 30\n29\"\nsrc=\"https://github.com/user-attachments/assets/e701fdfc-3735-47e5-985d-655a2f07cb8e\"\n/> |","sha":"4d854ce2115327b84a2c43b2ad461c859f989686","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","Team:Threat Hunting","Team: SecuritySolution","Team:Threat Hunting:Investigations","v9.4.0","v9.5.0"],"title":"[Security solution][Attacks] Change \"take action items\" order to match alerts page items","number":262739,"url":"https://github.com/elastic/kibana/pull/262739","mergeCommit":{"message":"[Security solution][Attacks] Change \"take action items\" order to match alerts page items (#262739)\n\n## Summary\n\nAddresses #262266 \n\nThis PR changes the order of the action items in the new attack\ndiscovery page to match the order of similar items in the alerts page.\n\n### Before\n\n|alerts|attacks|\n|---|---|\n| <img width=\"272\" height=\"530\" alt=\"Screenshot 2026-04-13 at 11 30 16\"\nsrc=\"https://github.com/user-attachments/assets/dcc82349-1331-4a37-b23f-3855cfdc9c61\"\n/> | <img width=\"274\" height=\"462\" alt=\"Screenshot 2026-04-13 at 11 41\n37\"\nsrc=\"https://github.com/user-attachments/assets/f922c46c-057f-40a8-be5b-0d5a4d7ac584\"\n/> |\n\n### After\n\n|alerts|attacks|\n|---|---|\n| <img width=\"272\" height=\"530\" alt=\"Screenshot 2026-04-13 at 11 30 16\"\nsrc=\"https://github.com/user-attachments/assets/dcc82349-1331-4a37-b23f-3855cfdc9c61\"\n/> | <img width=\"285\" height=\"485\" alt=\"Screenshot 2026-04-13 at 11 30\n29\"\nsrc=\"https://github.com/user-attachments/assets/e701fdfc-3735-47e5-985d-655a2f07cb8e\"\n/> |","sha":"4d854ce2115327b84a2c43b2ad461c859f989686"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/262739","number":262739,"mergeCommit":{"message":"[Security solution][Attacks] Change \"take action items\" order to match alerts page items (#262739)\n\n## Summary\n\nAddresses #262266 \n\nThis PR changes the order of the action items in the new attack\ndiscovery page to match the order of similar items in the alerts page.\n\n### Before\n\n|alerts|attacks|\n|---|---|\n| <img width=\"272\" height=\"530\" alt=\"Screenshot 2026-04-13 at 11 30 16\"\nsrc=\"https://github.com/user-attachments/assets/dcc82349-1331-4a37-b23f-3855cfdc9c61\"\n/> | <img width=\"274\" height=\"462\" alt=\"Screenshot 2026-04-13 at 11 41\n37\"\nsrc=\"https://github.com/user-attachments/assets/f922c46c-057f-40a8-be5b-0d5a4d7ac584\"\n/> |\n\n### After\n\n|alerts|attacks|\n|---|---|\n| <img width=\"272\" height=\"530\" alt=\"Screenshot 2026-04-13 at 11 30 16\"\nsrc=\"https://github.com/user-attachments/assets/dcc82349-1331-4a37-b23f-3855cfdc9c61\"\n/> | <img width=\"285\" height=\"485\" alt=\"Screenshot 2026-04-13 at 11 30\n29\"\nsrc=\"https://github.com/user-attachments/assets/e701fdfc-3735-47e5-985d-655a2f07cb8e\"\n/> |","sha":"4d854ce2115327b84a2c43b2ad461c859f989686"}}]}] BACKPORT-->