### PR TITLE
[9.4] [Security solution][Attacks] Move "ask AI assistant" to its own button in attack's flyout (#262759)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attack_details/attack_ai_assistant_button.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attack_details/attack_ai_assistant_button.test.tsx
@@ -16,18 +16,9 @@ import { TestProviders } from '../../../../../common/mock/test_providers';
 import type { AttackDiscoveryAlert } from '@kbn/elastic-assistant-common';
 import { useAgentBuilderAvailability } from '../../../../../agent_builder/hooks/use_agent_builder_availability';
 import { useAttackDiscoveryAttachment } from '../../../../../attack_discovery/pages/results/use_attack_discovery_attachment';
+import { useViewInAiAssistant } from '../../../../../attack_discovery/pages/results/attack_discovery_panel/view_in_ai_assistant/use_view_in_ai_assistant';
 import { NewAgentBuilderAttachment } from '../../../../../agent_builder/components/new_agent_builder_attachment';
 import type { AgentBuilderAddToChatTelemetry } from '../../../../../agent_builder/hooks/use_report_add_to_chat';
-
-// Mock child components
-jest.mock(
-  '../../../../../attack_discovery/pages/results/attack_discovery_panel/view_in_ai_assistant',
-  () => ({
-    ViewInAiAssistant: jest.fn(() => (
-      <div data-test-subj="viewInAiAssistant">{'ViewInAiAssistant'}</div>
-    )),
-  })
-);
 
 jest.mock('../../../../../agent_builder/components/new_agent_builder_attachment', () => ({
   NewAgentBuilderAttachment: jest.fn(() => (
@@ -35,7 +26,6 @@ jest.mock('../../../../../agent_builder/components/new_agent_builder_attachment'
   )),
 }));
 
-// Mock hooks
 jest.mock('../../../../../agent_builder/hooks/use_agent_builder_availability', () => ({
   useAgentBuilderAvailability: jest.fn(),
 }));
@@ -43,6 +33,13 @@ jest.mock('../../../../../agent_builder/hooks/use_agent_builder_availability', (
 jest.mock('../../../../../attack_discovery/pages/results/use_attack_discovery_attachment', () => ({
   useAttackDiscoveryAttachment: jest.fn(),
 }));
+
+jest.mock(
+  '../../../../../attack_discovery/pages/results/attack_discovery_panel/view_in_ai_assistant/use_view_in_ai_assistant',
+  () => ({
+    useViewInAiAssistant: jest.fn(),
+  })
+);
 
 describe('AttackAiAssistantButton', () => {
   const mockAttack = {
@@ -65,8 +62,14 @@ describe('AttackAiAssistantButton', () => {
       </TestProviders>
     );
 
+  const mockShowAssistantOverlay = jest.fn();
+
   beforeEach(() => {
     jest.clearAllMocks();
+    (useViewInAiAssistant as jest.Mock).mockReturnValue({
+      disabled: false,
+      showAssistantOverlay: mockShowAssistantOverlay,
+    });
   });
 
   it('renders NewAgentBuilderAttachment when isAgentChatExperienceEnabled is true', () => {
@@ -90,7 +93,7 @@ describe('AttackAiAssistantButton', () => {
     );
   });
 
-  it('renders ViewInAiAssistant when isAgentChatExperienceEnabled is false', () => {
+  it('renders AiButton when isAgentChatExperienceEnabled is false', () => {
     (useAgentBuilderAvailability as jest.Mock).mockReturnValue({
       isAgentChatExperienceEnabled: false,
     });
@@ -100,5 +103,21 @@ describe('AttackAiAssistantButton', () => {
 
     expect(screen.getByTestId(VIEW_IN_AI_ASSISTANT_TEST_ID)).toBeInTheDocument();
     expect(screen.queryByTestId(NEW_AGENT_BUILDER_ATTACHMENT_TEST_ID)).not.toBeInTheDocument();
+    expect(screen.getByText('View in AI Assistant')).toBeInTheDocument();
+  });
+
+  it('disables the AiButton when useViewInAiAssistant returns disabled', () => {
+    (useAgentBuilderAvailability as jest.Mock).mockReturnValue({
+      isAgentChatExperienceEnabled: false,
+    });
+    (useAttackDiscoveryAttachment as jest.Mock).mockReturnValue(jest.fn());
+    (useViewInAiAssistant as jest.Mock).mockReturnValue({
+      disabled: true,
+      showAssistantOverlay: mockShowAssistantOverlay,
+    });
+
+    renderComponent();
+
+    expect(screen.getByTestId(VIEW_IN_AI_ASSISTANT_TEST_ID)).toBeDisabled();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attack_details/attack_ai_assistant_button.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attack_details/attack_ai_assistant_button.tsx
@@ -7,7 +7,9 @@
 
 import React from 'react';
 import type { AttackDiscoveryAlert } from '@kbn/elastic-assistant-common';
-import { ViewInAiAssistant } from '../../../../../attack_discovery/pages/results/attack_discovery_panel/view_in_ai_assistant';
+import { AiButton } from '@kbn/shared-ux-ai-components';
+import { useViewInAiAssistant } from '../../../../../attack_discovery/pages/results/attack_discovery_panel/view_in_ai_assistant/use_view_in_ai_assistant';
+import { VIEW_IN_AI_ASSISTANT } from '../../../../../attack_discovery/pages/results/attack_discovery_panel/view_in_ai_assistant/translations';
 import { useAgentBuilderAvailability } from '../../../../../agent_builder/hooks/use_agent_builder_availability';
 import { NewAgentBuilderAttachment } from '../../../../../agent_builder/components/new_agent_builder_attachment';
 import type { AgentBuilderAddToChatTelemetry } from '../../../../../agent_builder/hooks/use_report_add_to_chat';
@@ -25,12 +27,16 @@ interface Props {
 
 /**
  * Renders a button to view the attack in the AI Assistant.
- * It conditionally renders either `NewAgentBuilderAttachment` or `ViewInAiAssistant`
+ * It conditionally renders either `NewAgentBuilderAttachment` or an `AiButton`
  * based on the agent builder availability.
  */
 export const AttackAiAssistantButton = React.memo<Props>(({ attack, pathway }) => {
   const { isAgentChatExperienceEnabled } = useAgentBuilderAvailability();
   const openAgentBuilderFlyout = useAttackDiscoveryAttachment(attack, attack.replacements);
+  const { disabled, showAssistantOverlay } = useViewInAiAssistant({
+    attackDiscovery: attack,
+    replacements: attack.replacements,
+  });
 
   if (isAgentChatExperienceEnabled) {
     return (
@@ -44,6 +50,16 @@ export const AttackAiAssistantButton = React.memo<Props>(({ attack, pathway }) =
     );
   }
 
-  return <ViewInAiAssistant attackDiscovery={attack} replacements={attack.replacements} />;
+  return (
+    <AiButton
+      variant="empty"
+      iconType="aiAssistantLogo"
+      data-test-subj="viewInAiAssistant"
+      isDisabled={disabled}
+      onClick={showAssistantOverlay}
+    >
+      {VIEW_IN_AI_ASSISTANT}
+    </AiButton>
+  );
 });
 AttackAiAssistantButton.displayName = 'AttackAiAssistantButton';

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attacks_group_take_action_items.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attacks_group_take_action_items.test.tsx
@@ -286,5 +286,18 @@ describe('AttacksGroupTakeActionItems', () => {
       const { queryByText } = renderAttack(mockAttack);
       expect(queryByText('View in AI Assistant')).not.toBeInTheDocument();
     });
+
+    it('should not render the action item when showAiAssistantAction is false', () => {
+      const { queryByText } = render(
+        <TestProviders>
+          <AttacksGroupTakeActionItems
+            attack={mockAttack}
+            showAiAssistantAction={false}
+            telemetrySource="attacks_page_group_take_action"
+          />
+        </TestProviders>
+      );
+      expect(queryByText('View in AI Assistant')).not.toBeInTheDocument();
+    });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attacks_group_take_action_items.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attacks_group_take_action_items.tsx
@@ -33,6 +33,8 @@ interface AttacksGroupTakeActionItemsProps {
   closePopover?: () => void;
   /** Optional callback to run after an action is successfully taken */
   onActionSuccess?: () => void;
+  /** Whether to include the AI assistant action in the menu (default true) */
+  showAiAssistantAction?: boolean;
   /** Optional size for the context menu for flyout */
   size?: 's' | 'm';
   /** Telemetry source for action events (e.g. flyout vs table) */
@@ -43,6 +45,7 @@ export function AttacksGroupTakeActionItems({
   attack,
   closePopover,
   onActionSuccess,
+  showAiAssistantAction = true,
   size,
   telemetrySource,
 }: AttacksGroupTakeActionItemsProps) {
@@ -147,13 +150,13 @@ export function AttacksGroupTakeActionItems({
     () => ({
       id: 0,
       items: [
-        ...workflowItems,
-        ...runWorkflowItems,
-        ...assignItems,
-        ...tagsItems,
-        ...investigateInTimelineItems,
         ...casesItems,
-        ...viewInAiAssistantItems,
+        ...workflowItems,
+        ...tagsItems,
+        ...assignItems,
+        ...runWorkflowItems,
+        ...(showAiAssistantAction ? viewInAiAssistantItems : []),
+        ...investigateInTimelineItems,
       ],
     }),
     [
@@ -163,6 +166,7 @@ export function AttacksGroupTakeActionItems({
       tagsItems,
       investigateInTimelineItems,
       casesItems,
+      showAiAssistantAction,
       viewInAiAssistantItems,
     ]
   );

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/footer.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/footer.test.tsx
@@ -16,6 +16,15 @@ import {
   FLYOUT_FOOTER_TAKE_ACTION_BUTTON_TEST_ID,
 } from './constants/test_ids';
 
+jest.mock(
+  '../../detections/components/attacks/table/attack_details/attack_ai_assistant_button',
+  () => ({
+    AttackAiAssistantButton: () => (
+      <div data-test-subj="attackAiAssistantButton">{'AttackAiAssistantButton'}</div>
+    ),
+  })
+);
+
 const defaultSearchHit = {
   _id: 'attack-1',
   _source: {},
@@ -69,17 +78,29 @@ describe('PanelFooter', () => {
     expect(screen.getByRole('button', { name: 'Take action' })).toBeInTheDocument();
   });
 
-  it('does not render the Take Action button when attack is null', () => {
+  it('does not render the footer when attack is null', () => {
     renderFooter({ attack: null });
 
-    expect(screen.getByTestId(FLYOUT_FOOTER_TEST_ID)).toBeInTheDocument();
+    expect(screen.queryByTestId(FLYOUT_FOOTER_TEST_ID)).not.toBeInTheDocument();
     expect(screen.queryByTestId(FLYOUT_FOOTER_TAKE_ACTION_BUTTON_TEST_ID)).not.toBeInTheDocument();
   });
 
-  it('does not render the Take Action button when attackId is empty and attack is null', () => {
+  it('does not render the footer when attackId is empty and attack is null', () => {
     renderFooter({ attackId: '', attack: null });
 
-    expect(screen.getByTestId(FLYOUT_FOOTER_TEST_ID)).toBeInTheDocument();
+    expect(screen.queryByTestId(FLYOUT_FOOTER_TEST_ID)).not.toBeInTheDocument();
     expect(screen.queryByTestId(FLYOUT_FOOTER_TAKE_ACTION_BUTTON_TEST_ID)).not.toBeInTheDocument();
+  });
+
+  it('renders the AI assistant button when attack is present', () => {
+    renderFooter();
+
+    expect(screen.getByTestId('attackAiAssistantButton')).toBeInTheDocument();
+  });
+
+  it('does not render the AI assistant button when attack is null', () => {
+    renderFooter({ attack: null });
+
+    expect(screen.queryByTestId('attackAiAssistantButton')).not.toBeInTheDocument();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/footer.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/footer.tsx
@@ -16,6 +16,7 @@ import {
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { AttacksGroupTakeActionItems } from '../../detections/components/attacks/table/attacks_group_take_action_items';
+import { AttackAiAssistantButton } from '../../detections/components/attacks/table/attack_details/attack_ai_assistant_button';
 import {
   FLYOUT_FOOTER_TAKE_ACTION_BUTTON_TEST_ID,
   FLYOUT_FOOTER_TEST_ID,
@@ -63,30 +64,34 @@ export const PanelFooter = () => {
     [togglePopover]
   );
 
+  if (!attack) return null;
+
   return (
     <EuiFlyoutFooter data-test-subj={FLYOUT_FOOTER_TEST_ID}>
       <EuiPanel color="transparent">
         <EuiFlexGroup justifyContent="flexEnd" alignItems="center">
           <EuiFlexItem grow={false}>
-            {attack ? (
-              <EuiPopover
-                id="AttackDetailsTakeActionPanel"
-                button={takeActionButton}
-                isOpen={isPopoverOpen}
+            <AttackAiAssistantButton attack={attack} pathway="attacks_page_flyout_take_action" />
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiPopover
+              id="AttackDetailsTakeActionPanel"
+              button={takeActionButton}
+              isOpen={isPopoverOpen}
+              closePopover={closePopover}
+              panelPaddingSize="none"
+              anchorPosition="downLeft"
+              repositionOnScroll
+            >
+              <AttacksGroupTakeActionItems
+                attack={attack}
+                onActionSuccess={onActionSuccess}
                 closePopover={closePopover}
-                panelPaddingSize="none"
-                anchorPosition="downLeft"
-                repositionOnScroll
-              >
-                <AttacksGroupTakeActionItems
-                  attack={attack}
-                  onActionSuccess={onActionSuccess}
-                  closePopover={closePopover}
-                  size="s"
-                  telemetrySource="attacks_page_flyout_take_action"
-                />
-              </EuiPopover>
-            ) : null}
+                size="s"
+                telemetrySource="attacks_page_flyout_take_action"
+                showAiAssistantAction={false}
+              />
+            </EuiPopover>
           </EuiFlexItem>
         </EuiFlexGroup>
       </EuiPanel>


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Security solution][Attacks] Move "ask AI assistant" to its own button in attack's flyout (#262759)](https://github.com/elastic/kibana/pull/262759)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Nicholas Peretti","email":"nicholas.peretti@elastic.co"},"sourceCommit":{"committedDate":"2026-04-16T19:35:46Z","message":"[Security solution][Attacks] Move \"ask AI assistant\" to its own button in attack's flyout (#262759)\n\n## Summary\n\nCloses #262332 \n\nMoves the \"Ask AI Assistant\" action from the \"Take action\" dropdown menu\nto its own dedicated button in the attack details flyout footer, making\nit more discoverable and accessible.\n\n## Flyout footer\n\n|Before|After|\n|---|---|\n|<img width=\"336\" height=\"425\" alt=\"Screenshot 2026-04-13 at 13 06 25\"\nsrc=\"https://github.com/user-attachments/assets/c7a4d176-f7dc-4bb1-a1a3-0b1e32df54e5\"\n/>|<img width=\"342\" height=\"388\" alt=\"Screenshot 2026-04-13 at 13 05 10\"\nsrc=\"https://github.com/user-attachments/assets/e90838dd-8252-4474-b00d-79c121e63388\"\n/>|\n\nTo stay consistent with the latest looks and feel, the\n`AttackAiAssistantButton` has been update with the `AiButton`.\n\n\n|Before|After|\n|---|---|\n|<img width=\"552\" height=\"546\" alt=\"Screenshot 2026-04-13 at 13 06 10\"\nsrc=\"https://github.com/user-attachments/assets/8920496c-c148-4c5a-8b32-a0d0a9aa01e6\"\n/>|<img width=\"558\" height=\"563\" alt=\"Screenshot 2026-04-13 at 13 05 34\"\nsrc=\"https://github.com/user-attachments/assets/58904515-c089-49c9-b3c1-4f481e43a1d2\"\n/>|\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"75aeff55f7306ffc0008ea32a794e4308b2fa3ad","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","Team:Threat Hunting","Team: SecuritySolution","Team:Threat Hunting:Investigations","v9.4.0","v9.5.0"],"title":"[Security solution][Attacks] Move \"ask AI assistant\" to its own button in attack's flyout","number":262759,"url":"https://github.com/elastic/kibana/pull/262759","mergeCommit":{"message":"[Security solution][Attacks] Move \"ask AI assistant\" to its own button in attack's flyout (#262759)\n\n## Summary\n\nCloses #262332 \n\nMoves the \"Ask AI Assistant\" action from the \"Take action\" dropdown menu\nto its own dedicated button in the attack details flyout footer, making\nit more discoverable and accessible.\n\n## Flyout footer\n\n|Before|After|\n|---|---|\n|<img width=\"336\" height=\"425\" alt=\"Screenshot 2026-04-13 at 13 06 25\"\nsrc=\"https://github.com/user-attachments/assets/c7a4d176-f7dc-4bb1-a1a3-0b1e32df54e5\"\n/>|<img width=\"342\" height=\"388\" alt=\"Screenshot 2026-04-13 at 13 05 10\"\nsrc=\"https://github.com/user-attachments/assets/e90838dd-8252-4474-b00d-79c121e63388\"\n/>|\n\nTo stay consistent with the latest looks and feel, the\n`AttackAiAssistantButton` has been update with the `AiButton`.\n\n\n|Before|After|\n|---|---|\n|<img width=\"552\" height=\"546\" alt=\"Screenshot 2026-04-13 at 13 06 10\"\nsrc=\"https://github.com/user-attachments/assets/8920496c-c148-4c5a-8b32-a0d0a9aa01e6\"\n/>|<img width=\"558\" height=\"563\" alt=\"Screenshot 2026-04-13 at 13 05 34\"\nsrc=\"https://github.com/user-attachments/assets/58904515-c089-49c9-b3c1-4f481e43a1d2\"\n/>|\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"75aeff55f7306ffc0008ea32a794e4308b2fa3ad"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/262759","number":262759,"mergeCommit":{"message":"[Security solution][Attacks] Move \"ask AI assistant\" to its own button in attack's flyout (#262759)\n\n## Summary\n\nCloses #262332 \n\nMoves the \"Ask AI Assistant\" action from the \"Take action\" dropdown menu\nto its own dedicated button in the attack details flyout footer, making\nit more discoverable and accessible.\n\n## Flyout footer\n\n|Before|After|\n|---|---|\n|<img width=\"336\" height=\"425\" alt=\"Screenshot 2026-04-13 at 13 06 25\"\nsrc=\"https://github.com/user-attachments/assets/c7a4d176-f7dc-4bb1-a1a3-0b1e32df54e5\"\n/>|<img width=\"342\" height=\"388\" alt=\"Screenshot 2026-04-13 at 13 05 10\"\nsrc=\"https://github.com/user-attachments/assets/e90838dd-8252-4474-b00d-79c121e63388\"\n/>|\n\nTo stay consistent with the latest looks and feel, the\n`AttackAiAssistantButton` has been update with the `AiButton`.\n\n\n|Before|After|\n|---|---|\n|<img width=\"552\" height=\"546\" alt=\"Screenshot 2026-04-13 at 13 06 10\"\nsrc=\"https://github.com/user-attachments/assets/8920496c-c148-4c5a-8b32-a0d0a9aa01e6\"\n/>|<img width=\"558\" height=\"563\" alt=\"Screenshot 2026-04-13 at 13 05 34\"\nsrc=\"https://github.com/user-attachments/assets/58904515-c089-49c9-b3c1-4f481e43a1d2\"\n/>|\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"75aeff55f7306ffc0008ea32a794e4308b2fa3ad"}}]}] BACKPORT-->