### PR TITLE
[sigevents][ki] Include rare patterns in `log_patterns` feature

### DIFF
--- a/x-pack/platform/packages/shared/kbn-evals-suite-significant-events/evals/ki_query_generation/get_computed_ki_features_from_docs.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-significant-events/evals/ki_query_generation/get_computed_ki_features_from_docs.ts
@@ -6,13 +6,13 @@
  */
 
 import type { Feature } from '@kbn/streams-schema';
+import { selectLogPatternsForLlm } from '@kbn/streams-ai/src/features/computed/log_patterns';
 import { CANONICAL_LAST_SEEN } from '../../src/data_generators/canonical_ki_features';
 
 const ERROR_KEYWORDS = ['error', 'exception', 'fatal', 'fail', 'panic', 'timeout', 'traceback'];
 const MAX_FIELD_VALUE_SAMPLES = 5;
 const MAX_SAMPLE_DOCS = 5;
 const MAX_ERROR_SAMPLES = 5;
-const MAX_PATTERNS = 5;
 
 /**
  * Recursively flattens a nested ES document into dot-delimited field names.
@@ -159,19 +159,19 @@ const buildLogPatterns = (
     }
   }
 
-  const patterns = [...patternGroups.values()]
+  const sorted = [...patternGroups.values()]
     .sort((a, b) => b.count - a.count)
-    .slice(0, MAX_PATTERNS)
     .map(({ count, sample }) => ({
       count,
-      field: 'body.text',
-      regex: '.*',
       sample,
+      field: 'body.text',
       pattern: sample
         .slice(0, 80)
         .replace(/[0-9a-f]{8,}/gi, '*')
         .replace(/\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}/g, '*'),
     }));
+
+  const patterns = selectLogPatternsForLlm(sorted);
 
   return {
     id: 'log_patterns',

--- a/x-pack/platform/packages/shared/kbn-streams-ai/src/features/computed/log_patterns.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-ai/src/features/computed/log_patterns.ts
@@ -8,13 +8,12 @@
 import { getLogPatterns } from '@kbn/ai-tools';
 import { LOG_PATTERNS_FEATURE_TYPE } from '@kbn/streams-schema';
 import { createTracedEsClient } from '@kbn/traced-es-client';
-import { uniqBy } from 'lodash';
 import type { ComputedFeatureGenerator } from './types';
 
 const LOG_MESSAGE_FIELDS = ['message', 'body.text'];
 
-const MAX_PATTERNS = 10;
 const MAX_COMMON_PATTERNS = 4;
+const MAX_RARE_PATTERNS = 6;
 const MAX_SAMPLE_LENGTH = 500;
 
 const truncateSample = (sample: string) =>
@@ -29,10 +28,10 @@ export interface LogPatternEntry {
 
 export function selectLogPatternsForLlm(patterns: LogPatternEntry[]): LogPatternEntry[] {
   const common = patterns.slice(0, MAX_COMMON_PATTERNS);
-  const rare = patterns.slice(-(MAX_PATTERNS - MAX_COMMON_PATTERNS));
-  const selected = uniqBy([...common, ...rare], (p) => p.sample);
+  const rareStart = Math.max(MAX_COMMON_PATTERNS, patterns.length - MAX_RARE_PATTERNS);
+  const rare = patterns.slice(rareStart);
 
-  return selected.map(({ field, pattern, count, sample }) => ({
+  return [...common, ...rare].map(({ field, pattern, count, sample }) => ({
     pattern,
     count,
     sample: truncateSample(sample),

--- a/x-pack/platform/packages/shared/kbn-streams-ai/src/features/computed/log_patterns.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-ai/src/features/computed/log_patterns.ts
@@ -8,10 +8,37 @@
 import { getLogPatterns } from '@kbn/ai-tools';
 import { LOG_PATTERNS_FEATURE_TYPE } from '@kbn/streams-schema';
 import { createTracedEsClient } from '@kbn/traced-es-client';
+import { uniqBy } from 'lodash';
 import type { ComputedFeatureGenerator } from './types';
 
 const LOG_MESSAGE_FIELDS = ['message', 'body.text'];
-const MAX_PATTERNS = 5;
+
+const MAX_PATTERNS = 10;
+const MAX_COMMON_PATTERNS = 4;
+const MAX_SAMPLE_LENGTH = 500;
+
+const truncateSample = (sample: string) =>
+  sample.length > MAX_SAMPLE_LENGTH ? `${sample.slice(0, MAX_SAMPLE_LENGTH)}…` : sample;
+
+export interface LogPatternEntry {
+  field: string;
+  pattern: string;
+  count: number;
+  sample: string;
+}
+
+export function selectLogPatternsForLlm(patterns: LogPatternEntry[]): LogPatternEntry[] {
+  const common = patterns.slice(0, MAX_COMMON_PATTERNS);
+  const rare = patterns.slice(-(MAX_PATTERNS - MAX_COMMON_PATTERNS));
+  const selected = uniqBy([...common, ...rare], (p) => p.sample);
+
+  return selected.map(({ field, pattern, count, sample }) => ({
+    pattern,
+    count,
+    sample: truncateSample(sample),
+    field,
+  }));
+}
 
 export const logPatternsGenerator: ComputedFeatureGenerator = {
   type: LOG_PATTERNS_FEATURE_TYPE,
@@ -19,8 +46,8 @@ export const logPatternsGenerator: ComputedFeatureGenerator = {
   description: 'Log message patterns identified through categorization analysis',
 
   llmInstructions: `Contains log message patterns identified by analyzing the log messages in the stream.
-Use the \`properties.patterns\` array to see common log patterns, their frequency, and sample messages.
-Each pattern includes: field (source field name), pattern (with placeholders), regex, count (frequency), and sample (example message).
+Use the \`properties.patterns\` array to see both common and rare log patterns. The array contains the top common patterns (highest \`count\`) and the rarest patterns (lowest \`count\`) — rare patterns are often the most interesting for anomaly or error detection.
+Each pattern includes: field (source field name), pattern (normalized message with placeholders), count (frequency), and sample (a real example message, possibly truncated).
 This is useful for understanding the types of logs in the stream and identifying anomalies or trends.`,
 
   generate: async ({ stream, start, end, esClient, logger }) => {
@@ -38,14 +65,6 @@ This is useful for understanding the types of logs in the stream and identifying
       fields: LOG_MESSAGE_FIELDS,
     });
 
-    return {
-      patterns: patterns.slice(0, MAX_PATTERNS).map(({ field, pattern, regex, count, sample }) => ({
-        pattern,
-        regex,
-        count,
-        sample,
-        field,
-      })),
-    };
+    return { patterns: selectLogPatternsForLlm(patterns) };
   },
 };


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/258872

## Summary

The `log_patterns` computed KI was always dropping rare patterns via sort + `slice(0, 5)`, wasting the expensive rare-patterns aggregation.

- Split the pattern budget between common and rare patterns.
- Bumped `MAX_PATTERNS` from 5 to 10. Log patterns are an information-dense feature we ship to the LLM so it's worth spending a bit more budget here.
- Dropped `regex` from the LLM payload. It's derived from `pattern` (same tokens joined with `.+?`) so it carries no extra signal, and it was the single largest field per entry. Nothing reads it downstream.
- Capped `sample` at 500 chars as a pathological-input safety net.
- Extracted `selectLogPatternsForLlm` so the evals harness shares the exact production logic.

