### PR TITLE
[Entity Analytics] Homepage UI fixes

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/anomalies_panel.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/anomalies_panel.test.tsx
@@ -10,6 +10,13 @@ import { render, screen } from '@testing-library/react';
 import { EntityAnalyticsRecentAnomalies } from './anomalies_panel';
 import { TestProviders } from '../../../common/mock';
 
+const MOCK_ML_HREF = '/app/ml/explorer';
+
+jest.mock('@kbn/ml-plugin/public', () => ({
+  ...jest.requireActual('@kbn/ml-plugin/public'),
+  useMlHref: () => MOCK_ML_HREF,
+}));
+
 describe('AnomaliesPanel', () => {
   it('should render the panel', () => {
     render(
@@ -20,5 +27,17 @@ describe('AnomaliesPanel', () => {
 
     expect(screen.getByTestId('recent-anomalies-panel')).toBeInTheDocument();
     expect(screen.getByText('Recent anomalies')).toBeInTheDocument();
+  });
+
+  it('should render the Open in Anomaly Explorer button with a link', () => {
+    render(
+      <TestProviders>
+        <EntityAnalyticsRecentAnomalies />
+      </TestProviders>
+    );
+
+    const link = screen.getByRole('link', { name: 'Open in Anomaly Explorer' });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', MOCK_ML_HREF);
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/anomalies_panel.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/anomalies_panel.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { EuiButton, EuiFlexGroup, EuiFlexItem, EuiLink, EuiSpacer, EuiTitle } from '@elastic/eui';
+import { EuiButtonEmpty, EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiTitle } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { ML_PAGES, useMlHref } from '@kbn/ml-plugin/public';
 import { RecentAnomaliesChart } from '../recent_anomalies/recent_anomalies_chart';
@@ -50,14 +50,17 @@ export const EntityAnalyticsRecentAnomalies: React.FC<{ watchlistId?: string }> 
           </EuiTitle>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiButton color={'primary'} fill={false} iconType={'anomalySwimLane'}>
-            <EuiLink href={anomalyExplorerUrl} external={false} target="_blank">
-              <FormattedMessage
-                id="xpack.securitySolution.entityAnalytics.homePage.recentAnomalies.viewAllInAnomalyExplorer"
-                defaultMessage="View all in Anomaly Explorer"
-              />
-            </EuiLink>
-          </EuiButton>
+          <EuiButtonEmpty
+            color={'primary'}
+            iconType={'popout'}
+            href={anomalyExplorerUrl}
+            target="_blank"
+          >
+            <FormattedMessage
+              id="xpack.securitySolution.entityAnalytics.homePage.recentAnomalies.viewAllInAnomalyExplorer"
+              defaultMessage="Open in Anomaly Explorer"
+            />
+          </EuiButtonEmpty>
         </EuiFlexItem>
       </EuiFlexGroup>
       <EuiSpacer size={'m'} />

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/entities_data_table.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/entities_data_table.test.tsx
@@ -14,7 +14,6 @@ import { useFetchGridData } from './hooks/use_fetch_grid_data';
 import { useInvestigateInTimeline } from '../../../../common/hooks/timeline/use_investigate_in_timeline';
 import { useUserPrivileges } from '../../../../common/components/user_privileges';
 import { useGlobalTime } from '../../../../common/containers/use_global_time';
-import { useAgentBuilderAvailability } from '../../../../agent_builder/hooks/use_agent_builder_availability';
 import { useKibana } from '../../../../common/lib/kibana';
 import type { EntityURLStateResult } from './hooks/use_entity_url_state';
 import type { DataView } from '@kbn/data-views-plugin/common';
@@ -28,7 +27,6 @@ const mockUseFetchGridData = jest.mocked(useFetchGridData);
 const mockUseInvestigateInTimeline = jest.mocked(useInvestigateInTimeline);
 const mockUseUserPrivileges = jest.mocked(useUserPrivileges);
 const mockUseGlobalTime = jest.mocked(useGlobalTime);
-const mockUseAgentBuilderAvailability = jest.mocked(useAgentBuilderAvailability);
 const mockUseKibana = jest.mocked(useKibana);
 
 jest.mock('@kbn/unified-data-table', () => {
@@ -49,7 +47,6 @@ jest.mock('@kbn/expandable-flyout', () => ({
 jest.mock('../../../../common/hooks/timeline/use_investigate_in_timeline');
 jest.mock('../../../../common/components/user_privileges');
 jest.mock('../../../../common/containers/use_global_time');
-jest.mock('../../../../agent_builder/hooks/use_agent_builder_availability');
 jest.mock('./hooks/use_fetch_grid_data');
 jest.mock('./hooks/use_styles', () => ({
   useStyles: () => ({
@@ -159,13 +156,6 @@ describe('EntitiesDataTable', () => {
       isInitializing: false,
       from: 'now-15m',
       to: 'now',
-    });
-
-    mockUseAgentBuilderAvailability.mockReturnValue({
-      isAgentBuilderEnabled: false,
-      hasAgentBuilderPrivilege: false,
-      isAgentChatExperienceEnabled: false,
-      hasValidAgentBuilderLicense: false,
     });
 
     mockUseKibana.mockReturnValue({

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/hooks/use_leading_control_columns.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/hooks/use_leading_control_columns.test.tsx
@@ -8,31 +8,11 @@
 import { renderHook } from '@testing-library/react';
 import { useLeadingControlColumns } from './use_leading_control_columns';
 
-const mockOpenChat = jest.fn();
-const mockUseAgentBuilderAvailability = jest.fn().mockReturnValue({ isAgentBuilderEnabled: false });
-const mockUseKibana = jest.fn().mockReturnValue({
-  services: { agentBuilder: undefined },
-});
-
-jest.mock('../../../../../agent_builder/hooks/use_agent_builder_availability', () => ({
-  useAgentBuilderAvailability: (...args: unknown[]) => mockUseAgentBuilderAvailability(...args),
-}));
-
-jest.mock('../../../../../common/lib/kibana/use_kibana', () => ({
-  useKibana: (...args: unknown[]) => mockUseKibana(...args),
-}));
-
 describe('useLeadingControlColumns', () => {
   const defaultArgs = {
     canUseTimeline: false,
     investigateInTimeline: jest.fn(),
   };
-
-  beforeEach(() => {
-    jest.clearAllMocks();
-    mockUseAgentBuilderAvailability.mockReturnValue({ isAgentBuilderEnabled: false });
-    mockUseKibana.mockReturnValue({ services: { agentBuilder: undefined } });
-  });
 
   it('returns no timeline action when canUseTimeline is false', () => {
     const { result } = renderHook(() => useLeadingControlColumns(defaultArgs));
@@ -44,30 +24,5 @@ describe('useLeadingControlColumns', () => {
       useLeadingControlColumns({ ...defaultArgs, canUseTimeline: true })
     );
     expect(result.current.find((c) => c.id === 'entity-analytics-timeline-action')).toBeDefined();
-  });
-
-  it('returns no AI action when isAgentBuilderEnabled is false', () => {
-    const { result } = renderHook(() => useLeadingControlColumns(defaultArgs));
-    expect(result.current.find((c) => c.id === 'entity-analytics-ai-action')).toBeUndefined();
-  });
-
-  it('returns AI action when isAgentBuilderEnabled is true and agentBuilder has openChat', () => {
-    mockUseAgentBuilderAvailability.mockReturnValue({ isAgentBuilderEnabled: true });
-    mockUseKibana.mockReturnValue({
-      services: { agentBuilder: { openChat: mockOpenChat } },
-    });
-
-    const { result } = renderHook(() => useLeadingControlColumns(defaultArgs));
-    expect(result.current.find((c) => c.id === 'entity-analytics-ai-action')).toBeDefined();
-  });
-
-  it('returns no AI action when agentBuilder is undefined even if enabled', () => {
-    mockUseAgentBuilderAvailability.mockReturnValue({ isAgentBuilderEnabled: true });
-    mockUseKibana.mockReturnValue({
-      services: { agentBuilder: undefined },
-    });
-
-    const { result } = renderHook(() => useLeadingControlColumns(defaultArgs));
-    expect(result.current.find((c) => c.id === 'entity-analytics-ai-action')).toBeUndefined();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/hooks/use_leading_control_columns.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/hooks/use_leading_control_columns.tsx
@@ -11,9 +11,6 @@ import type { RowControlColumn } from '@kbn/discover-utils';
 import type { EntityType } from '../../../../../../common/entity_analytics/types';
 import { EntityTypeToIdentifierField } from '../../../../../../common/entity_analytics/types';
 import { createDataProviders } from '../../../../../app/actions/add_to_timeline/data_provider';
-import { SecurityAgentBuilderAttachments } from '../../../../../../common/constants';
-import { useAgentBuilderAvailability } from '../../../../../agent_builder/hooks/use_agent_builder_availability';
-import { useKibana } from '../../../../../common/lib/kibana/use_kibana';
 import { getEntityFields } from '../utils';
 import { ENTITY_ANALYTICS_TABLE_ID } from '../constants';
 
@@ -41,9 +38,6 @@ export const useLeadingControlColumns = ({
   canUseTimeline,
   investigateInTimeline,
 }: UseLeadingControlColumnsArgs): RowControlColumn[] => {
-  const { isAgentBuilderEnabled } = useAgentBuilderAvailability();
-  const { agentBuilder } = useKibana().services;
-
   return useMemo(() => {
     const columns: RowControlColumn[] = [];
 
@@ -77,55 +71,6 @@ export const useLeadingControlColumns = ({
       });
     }
 
-    if (isAgentBuilderEnabled && agentBuilder?.openChat) {
-      columns.push({
-        id: 'entity-analytics-ai-action',
-        render: (Control, { record }) => {
-          const { entityType, entityName } = getEntityFields(record);
-          if (!entityName || !entityType) {
-            return <Control iconType="sparkles" label="" disabled onClick={undefined} />;
-          }
-
-          return (
-            <Control
-              iconType="sparkles"
-              label={i18n.translate(
-                'xpack.securitySolution.entityAnalytics.entitiesTable.addToChat',
-                { defaultMessage: 'Add to chat' }
-              )}
-              color="text"
-              onClick={() => {
-                agentBuilder.openChat({
-                  autoSendInitialMessage: false,
-                  newConversation: true,
-                  initialMessage: i18n.translate(
-                    'xpack.securitySolution.entityAnalytics.entitiesTable.aiInvestigationPrompt',
-                    {
-                      defaultMessage:
-                        'Investigate this entity and provide relevant context about its risk and activity.',
-                    }
-                  ),
-                  attachments: [
-                    {
-                      id: `${SecurityAgentBuilderAttachments.entity}-${Date.now()}`,
-                      type: SecurityAgentBuilderAttachments.entity,
-                      data: {
-                        identifierType: entityType,
-                        identifier: entityName,
-                        attachmentLabel: `${entityType}: ${entityName}`,
-                      },
-                    },
-                  ],
-                  sessionTag: 'security',
-                });
-              }}
-              data-test-subj="entity-analytics-home-ai-action-icon"
-            />
-          );
-        },
-      });
-    }
-
     return columns;
-  }, [canUseTimeline, investigateInTimeline, isAgentBuilderEnabled, agentBuilder]);
+  }, [canUseTimeline, investigateInTimeline]);
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/pages/entity_analytics_home_page.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/pages/entity_analytics_home_page.test.tsx
@@ -14,6 +14,13 @@ import { useSourcererDataView } from '../../sourcerer/containers';
 import { useIsExperimentalFeatureEnabled } from '../../common/hooks/use_experimental_features';
 import { useDataView } from '../../data_view_manager/hooks/use_data_view';
 
+jest.mock('../../common/components/link_to', () => ({
+  useGetSecuritySolutionUrl:
+    () =>
+    ({ deepLinkId, path = '' }: { deepLinkId: string; path?: string }) =>
+      `/app/security/${deepLinkId}${path}`,
+}));
+
 jest.mock('../../sourcerer/containers', () => ({
   useSourcererDataView: jest.fn(() => ({
     indicesExist: true,
@@ -135,7 +142,7 @@ describe('EntityAnalyticsHomePage', () => {
       { wrapper: TestProviders }
     );
 
-    expect(screen.getByText('Entity Analytics')).toBeInTheDocument();
+    expect(screen.getByText('Entity analytics')).toBeInTheDocument();
   });
 
   it('renders the KQL search bar', () => {
@@ -198,6 +205,17 @@ describe('EntityAnalyticsHomePage', () => {
     );
 
     expect(screen.getByTestId('entityAnalyticsHomePageLoader')).toBeInTheDocument();
+  });
+
+  it('renders the watchlists settings button', () => {
+    render(
+      <MemoryRouter>
+        <EntityAnalyticsHomePage />
+      </MemoryRouter>,
+      { wrapper: TestProviders }
+    );
+
+    expect(screen.getByRole('link', { name: 'Watchlists settings' })).toBeInTheDocument();
   });
 
   it('renders empty prompt when indices do not exist', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/pages/entity_analytics_home_page.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/pages/entity_analytics_home_page.tsx
@@ -14,7 +14,9 @@ import {
   EuiPanel,
   EuiTitle,
   useIsWithinBreakpoints,
+  EuiButtonIcon,
 } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { SecurityPageName } from '../../app/types';
 import { SecuritySolutionPageWrapper } from '../../common/components/page_wrapper';
@@ -46,6 +48,8 @@ import {
   type URLQuery,
 } from '../components/home/entities_table';
 import { DynamicRiskLevelPanel } from '../components/home/dynamic_risk_level_panel';
+import { useGetSecuritySolutionUrl } from '../../common/components/link_to';
+import { TabId } from './entity_analytics_management_page';
 import { TopThreatHuntingLeads } from '../components/threat_hunting/top_threat_hunting_leads';
 import { ThreatHuntingLeadsFlyout } from '../components/threat_hunting/top_threat_hunting_leads/threat_hunting_leads_flyout';
 import { useHuntingLeads } from '../components/threat_hunting/top_threat_hunting_leads/use_hunting_leads';
@@ -105,6 +109,7 @@ export const EntityAnalyticsHomePage = () => {
 
   const location = useLocation();
   const history = useHistory();
+  const getSecuritySolutionUrl = useGetSecuritySolutionUrl();
 
   const selectedWatchlistId = useMemo(() => {
     const params = new URLSearchParams(location.search);
@@ -187,10 +192,29 @@ export const EntityAnalyticsHomePage = () => {
             />
           }
           rightSideItems={[
-            <WatchlistFilter
-              selectedId={selectedWatchlistId ?? ''}
-              onChangeSelectedId={setSelectedWatchlist}
-            />,
+            <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
+              <EuiFlexItem grow={false}>
+                <WatchlistFilter
+                  selectedId={selectedWatchlistId ?? ''}
+                  onChangeSelectedId={setSelectedWatchlist}
+                />
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiButtonIcon
+                  display="base"
+                  iconType="gear"
+                  size="m"
+                  aria-label={i18n.translate(
+                    'xpack.securitySolution.entityAnalytics.homePage.watchlistsSettingsButtonAriaLabel',
+                    { defaultMessage: 'Watchlists settings' }
+                  )}
+                  href={getSecuritySolutionUrl({
+                    deepLinkId: SecurityPageName.entityAnalyticsManagement,
+                    path: `/${TabId.Watchlists}`,
+                  })}
+                />
+              </EuiFlexItem>
+            </EuiFlexGroup>,
           ]}
         />
 

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/pages/entity_analytics_home_page.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/pages/entity_analytics_home_page.tsx
@@ -183,7 +183,7 @@ export const EntityAnalyticsHomePage = () => {
           title={
             <FormattedMessage
               id="xpack.securitySolution.entityAnalytics.homePage.pageTitle"
-              defaultMessage="Entity Analytics"
+              defaultMessage="Entity analytics"
             />
           }
           rightSideItems={[

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/entity_analytics/entity_analytics_home/entity_analytics_home_page.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/entity_analytics/entity_analytics_home/entity_analytics_home_page.cy.ts
@@ -56,7 +56,7 @@ describe(
 
     it('renders page as expected', () => {
       cy.get(PAGE_TITLE).should('exist');
-      cy.get('h1').contains('Entity Analytics').should('be.visible');
+      cy.get('h1').contains('Entity analytics').should('be.visible');
     });
 
     it('renders KQL search bar', () => {

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/screens/entity_analytics/entity_analytics_home.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/screens/entity_analytics/entity_analytics_home.ts
@@ -19,7 +19,6 @@ export const DATAGRID_SORTING_SELECTOR = '[data-test-subj="dataGridColumnSorting
 export const EXPAND_ROW_BUTTON = '[data-test-subj="docTableExpandToggleColumn"]';
 
 export const TIMELINE_ACTION = '[data-test-subj="entity-analytics-home-timeline-icon"]';
-export const AI_ACTION = '[data-test-subj="entity-analytics-home-ai-action-icon"]';
 
 export const FIELDS_SELECTOR_BUTTON = '[data-test-subj="entityAnalyticsFieldsSelectorOpenButton"]';
 export const FIELDS_SELECTOR_MODAL = '[data-test-subj="entityAnalyticsFieldsSelectorModal"]';


### PR DESCRIPTION
## Summary

Couple UI updates to the Entity Analytics home page:
- Update title to be sentence case (https://github.com/elastic/security-team/issues/16873)
- Updated style and text of Anomaly Explorer button (https://github.com/elastic/security-team/issues/16874)
- Added watchlist settings button (https://github.com/elastic/security-team/issues/16875)
- Removed agent builder action button from Entities table (https://github.com/elastic/security-team/issues/16957)


| Before    | After |
| -------- | ------- |
| <img width="1910" height="787" alt="Screenshot 2026-04-21 at 3 06 23 PM" src="https://github.com/user-attachments/assets/61cff1d2-43ab-476b-8548-f9cd97e09123" /> | <img width="1911" height="790" alt="Screenshot 2026-04-21 at 2 58 48 PM" src="https://github.com/user-attachments/assets/8a3819f0-88ba-46ef-b729-a5f350780f36" /> |
| <img width="1611" height="578" alt="Screenshot 2026-04-21 at 3 06 29 PM" src="https://github.com/user-attachments/assets/9c3a403b-e57a-41f5-800f-b1b645b70275" /> | <img width="1613" height="581" alt="Screenshot 2026-04-21 at 2 59 00 PM" src="https://github.com/user-attachments/assets/392121c1-49e6-4587-b97e-17fda2b5e4a3" /> |




<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->