### PR TITLE
[Agent Builder] Add telemetry counters for connector SML indexing failures

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/plugin.ts
@@ -227,6 +227,7 @@ export class AgentBuilderPlugin
       serviceManager: this.serviceManager,
       logger: this.logger.get('connector-lifecycle'),
       getStartServices: coreSetup.getStartServices,
+      usageCounter: this.usageCounter,
     });
 
     setupDeps.actions.registerConnectorLifecycleListener({

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/connector_lifecycle/connector_lifecycle_handler.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/connector_lifecycle/connector_lifecycle_handler.test.ts
@@ -8,6 +8,7 @@
 import { loggingSystemMock } from '@kbn/core/server/mocks';
 import { AttachmentType } from '@kbn/agent-builder-common/attachments';
 import { AGENT_BUILDER_EXPERIMENTAL_FEATURES_SETTING_ID } from '@kbn/management-settings-ids';
+import type { UsageCounter } from '@kbn/usage-collection-plugin/server';
 import { createConnectorLifecycleHandler } from './connector_lifecycle_handler';
 
 const createMockUiSettingsClient = (experimentalFeaturesEnabled = true) => ({
@@ -45,6 +46,9 @@ const createMockGetStartServices = () =>
     { spaces: { spacesService: { getSpaceId: jest.fn().mockReturnValue('default') } } },
     {},
   ]);
+
+const createMockUsageCounter = (): jest.Mocked<UsageCounter> =>
+  ({ incrementCounter: jest.fn() } as unknown as jest.Mocked<UsageCounter>);
 
 const createBaseParams = (overrides = {}) => ({
   connectorId: 'connector-abc',
@@ -129,6 +133,37 @@ describe('createConnectorLifecycleHandler', () => {
       );
     });
 
+    it('increments sml_index_failure counter when SML indexing fails', async () => {
+      const sml = createMockSmlService();
+      sml.indexAttachment.mockRejectedValue(new Error('SML error'));
+      const usageCounter = createMockUsageCounter();
+      const handler = createConnectorLifecycleHandler({
+        serviceManager: createMockServiceManager(createMockUiSettingsClient(), sml) as any,
+        logger,
+        getStartServices: createMockGetStartServices(),
+        usageCounter,
+      });
+
+      await handler.onPostCreate(createBaseParams() as any);
+
+      expect(usageCounter.incrementCounter).toHaveBeenCalledWith(
+        expect.objectContaining({ counterName: 'agent_builder_sml_index_failure' })
+      );
+    });
+
+    it('does not throw when usageCounter is undefined and SML indexing fails', async () => {
+      const sml = createMockSmlService();
+      sml.indexAttachment.mockRejectedValue(new Error('SML error'));
+      const handler = createConnectorLifecycleHandler({
+        serviceManager: createMockServiceManager(createMockUiSettingsClient(), sml) as any,
+        logger,
+        getStartServices: createMockGetStartServices(),
+        usageCounter: undefined,
+      });
+
+      await expect(handler.onPostCreate(createBaseParams() as any)).resolves.toBeUndefined();
+    });
+
     it('returns early when services are not started', async () => {
       const handler = createConnectorLifecycleHandler({
         serviceManager: { internalStart: undefined } as any,
@@ -180,6 +215,39 @@ describe('createConnectorLifecycleHandler', () => {
       expect(logger.warn).toHaveBeenCalledWith(
         expect.stringContaining('failed to remove connector')
       );
+    });
+
+    it('increments sml_delete_failure counter when SML delete fails', async () => {
+      const sml = createMockSmlService();
+      sml.indexAttachment.mockRejectedValue(new Error('SML delete error'));
+      const usageCounter = createMockUsageCounter();
+      const handler = createConnectorLifecycleHandler({
+        serviceManager: createMockServiceManager(createMockUiSettingsClient(), sml) as any,
+        logger,
+        getStartServices: createMockGetStartServices(),
+        usageCounter,
+      });
+
+      await handler.onPostDelete(createBaseParams({ connectorType: '.test' }) as any);
+
+      expect(usageCounter.incrementCounter).toHaveBeenCalledWith(
+        expect.objectContaining({ counterName: 'agent_builder_sml_delete_failure' })
+      );
+    });
+
+    it('does not throw when usageCounter is undefined and SML delete fails', async () => {
+      const sml = createMockSmlService();
+      sml.indexAttachment.mockRejectedValue(new Error('SML delete error'));
+      const handler = createConnectorLifecycleHandler({
+        serviceManager: createMockServiceManager(createMockUiSettingsClient(), sml) as any,
+        logger,
+        getStartServices: createMockGetStartServices(),
+        usageCounter: undefined,
+      });
+
+      await expect(
+        handler.onPostDelete(createBaseParams({ connectorType: '.test' }) as any)
+      ).resolves.toBeUndefined();
     });
 
     it('returns early when services are not started', async () => {

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/connector_lifecycle/connector_lifecycle_handler.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/connector_lifecycle/connector_lifecycle_handler.ts
@@ -14,16 +14,19 @@ import type {
 } from '@kbn/actions-plugin/server';
 import type { CoreStart } from '@kbn/core/server';
 import type { SpacesPluginStart } from '@kbn/spaces-plugin/server';
+import type { UsageCounter } from '@kbn/usage-collection-plugin/server';
 import type { ServiceManager } from '..';
+import { trackSmlDeleteFailure, trackSmlIndexFailure } from '../../telemetry/usage_counters';
 
 interface ConnectorLifecycleHandlerDeps {
   serviceManager: ServiceManager;
   logger: Logger;
   getStartServices: () => Promise<[CoreStart, { spaces?: SpacesPluginStart }, unknown]>;
+  usageCounter?: UsageCounter;
 }
 
 export function createConnectorLifecycleHandler(deps: ConnectorLifecycleHandlerDeps) {
-  const { serviceManager, logger, getStartServices } = deps;
+  const { serviceManager, logger, getStartServices, usageCounter } = deps;
 
   return {
     async onPostCreate(params: ConnectorLifecyclePostCreateParams): Promise<void> {
@@ -78,6 +81,7 @@ export function createConnectorLifecycleHandler(deps: ConnectorLifecycleHandlerD
                 (smlError as Error).message
               }`
             );
+            trackSmlIndexFailure(usageCounter);
           }
         }
       } catch (error) {
@@ -127,6 +131,7 @@ export function createConnectorLifecycleHandler(deps: ConnectorLifecycleHandlerD
                 (smlError as Error).message
               }`
             );
+            trackSmlDeleteFailure(usageCounter);
           }
         }
       } catch (error) {

--- a/x-pack/platform/plugins/shared/agent_builder/server/telemetry/index.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/telemetry/index.ts
@@ -14,6 +14,8 @@ export {
   trackLLMUsage,
   trackConversationRound,
   trackQueryToResultTime,
+  trackSmlIndexFailure,
+  trackSmlDeleteFailure,
   AGENTBUILDER_USAGE_DOMAIN,
 } from './usage_counters';
 export { registerTelemetryCollector, type AgentBuilderTelemetry } from './telemetry_collector';

--- a/x-pack/platform/plugins/shared/agent_builder/server/telemetry/usage_counters.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/telemetry/usage_counters.test.ts
@@ -12,6 +12,8 @@ import {
   trackLLMUsage,
   trackConversationRound,
   trackQueryToResultTime,
+  trackSmlIndexFailure,
+  trackSmlDeleteFailure,
   AGENTBUILDER_USAGE_DOMAIN,
 } from './usage_counters';
 
@@ -307,6 +309,54 @@ describe('usage_counters', () => {
           incrementBy: 1,
         });
       }
+    });
+  });
+
+  describe('trackSmlIndexFailure', () => {
+    let mockUsageCounter: jest.Mocked<UsageCounter>;
+
+    beforeEach(() => {
+      mockUsageCounter = {
+        incrementCounter: jest.fn(),
+      } as unknown as jest.Mocked<UsageCounter>;
+    });
+
+    it('does nothing when usageCounter is undefined', () => {
+      expect(() => trackSmlIndexFailure(undefined)).not.toThrow();
+    });
+
+    it('increments the sml_index_failure counter', () => {
+      trackSmlIndexFailure(mockUsageCounter);
+
+      expect(mockUsageCounter.incrementCounter).toHaveBeenCalledWith({
+        counterName: 'agent_builder_sml_index_failure',
+        counterType: 'count',
+        incrementBy: 1,
+      });
+    });
+  });
+
+  describe('trackSmlDeleteFailure', () => {
+    let mockUsageCounter: jest.Mocked<UsageCounter>;
+
+    beforeEach(() => {
+      mockUsageCounter = {
+        incrementCounter: jest.fn(),
+      } as unknown as jest.Mocked<UsageCounter>;
+    });
+
+    it('does nothing when usageCounter is undefined', () => {
+      expect(() => trackSmlDeleteFailure(undefined)).not.toThrow();
+    });
+
+    it('increments the sml_delete_failure counter', () => {
+      trackSmlDeleteFailure(mockUsageCounter);
+
+      expect(mockUsageCounter.incrementCounter).toHaveBeenCalledWith({
+        counterName: 'agent_builder_sml_delete_failure',
+        counterType: 'count',
+        incrementBy: 1,
+      });
     });
   });
 });

--- a/x-pack/platform/plugins/shared/agent_builder/server/telemetry/usage_counters.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/telemetry/usage_counters.ts
@@ -132,3 +132,31 @@ export function trackQueryToResultTime(
     incrementBy: 1,
   });
 }
+
+/**
+ * Helper to track SML index failures when a connector fails to be indexed
+ * @param usageCounter - Usage counter instance
+ */
+export function trackSmlIndexFailure(usageCounter: UsageCounter | undefined): void {
+  if (!usageCounter) return;
+
+  usageCounter.incrementCounter({
+    counterName: `${AGENTBUILDER_USAGE_DOMAIN}_sml_index_failure`,
+    counterType: 'count',
+    incrementBy: 1,
+  });
+}
+
+/**
+ * Helper to track SML delete failures when a connector fails to be removed from the index
+ * @param usageCounter - Usage counter instance
+ */
+export function trackSmlDeleteFailure(usageCounter: UsageCounter | undefined): void {
+  if (!usageCounter) return;
+
+  usageCounter.incrementCounter({
+    counterName: `${AGENTBUILDER_USAGE_DOMAIN}_sml_delete_failure`,
+    counterType: 'count',
+    incrementBy: 1,
+  });
+}

--- a/x-pack/platform/test/agent_builder_api_integration/apis/connector_lifecycle.ts
+++ b/x-pack/platform/test/agent_builder_api_integration/apis/connector_lifecycle.ts
@@ -1,0 +1,145 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+import { smlElasticsearchIndexMappings, smlIndexName } from '@kbn/agent-builder-plugin/server';
+import type { AgentBuilderApiFtrProviderContext } from '../../agent_builder/services/api';
+import { createLlmProxy, type LlmProxy } from '../utils/llm_proxy';
+import {
+  createLlmProxyActionConnector,
+  deleteActionConnector,
+} from '../utils/llm_proxy/llm_proxy_action_connector';
+
+export default function ({ getService }: AgentBuilderApiFtrProviderContext) {
+  const es = getService('es');
+  const log = getService('log');
+
+  describe('Connector lifecycle → SML indexing', function () {
+    this.tags(['skipServerless']);
+
+    let llmProxy: LlmProxy;
+
+    before(async () => {
+      const exists = await es.indices.exists({ index: smlIndexName });
+      if (!exists) {
+        await es.indices.create({
+          index: smlIndexName,
+          mappings: smlElasticsearchIndexMappings,
+        });
+      }
+
+      llmProxy = await createLlmProxy(log);
+    });
+
+    after(async () => {
+      llmProxy.close();
+    });
+
+    it('indexes the connector into SML when a connector is created', async () => {
+      let connectorId: string | undefined;
+
+      try {
+        connectorId = await createLlmProxyActionConnector(getService, {
+          port: llmProxy.getPort(),
+        });
+
+        // The SML indexing is async but happens synchronously within the lifecycle hook.
+        // Retry search to account for ES indexing latency.
+        let hit: unknown;
+        for (let attempt = 0; attempt < 10; attempt++) {
+          const result = await es.search({
+            index: smlIndexName,
+            query: { term: { origin_id: connectorId } },
+          });
+          if (result.hits.hits.length > 0) {
+            hit = result.hits.hits[0];
+            break;
+          }
+          await new Promise((resolve) => setTimeout(resolve, 500));
+        }
+
+        expect(hit).to.be.ok();
+        const source = (hit as any)._source;
+        expect(source.origin_id).to.be(connectorId);
+        expect(source.type).to.be('connector');
+      } finally {
+        if (connectorId) {
+          await deleteActionConnector(getService, { actionId: connectorId });
+
+          // Allow time for the SML delete to propagate
+          await new Promise((resolve) => setTimeout(resolve, 1000));
+
+          // Verify the connector was removed from SML
+          try {
+            await es.deleteByQuery({
+              index: smlIndexName,
+              query: { term: { origin_id: connectorId } },
+              refresh: true,
+            });
+          } catch {
+            // ignore cleanup failures
+          }
+        }
+      }
+    });
+
+    it('removes the connector from SML when a connector is deleted', async () => {
+      let connectorId: string | undefined;
+
+      try {
+        connectorId = await createLlmProxyActionConnector(getService, {
+          port: llmProxy.getPort(),
+        });
+
+        const createdConnectorId = connectorId;
+
+        // Wait for create indexing
+        for (let attempt = 0; attempt < 10; attempt++) {
+          const result = await es.search({
+            index: smlIndexName,
+            query: { term: { origin_id: createdConnectorId } },
+          });
+          if (result.hits.hits.length > 0) break;
+          await new Promise((resolve) => setTimeout(resolve, 500));
+        }
+
+        // Now delete the connector and verify removal
+        await deleteActionConnector(getService, { actionId: createdConnectorId });
+        connectorId = undefined;
+
+        // The delete is also async-ish; retry to confirm removal
+        let removed = false;
+        for (let attempt = 0; attempt < 10; attempt++) {
+          const result = await es.search({
+            index: smlIndexName,
+            query: { term: { origin_id: createdConnectorId } },
+          });
+          if (result.hits.hits.length === 0) {
+            removed = true;
+            break;
+          }
+          await new Promise((resolve) => setTimeout(resolve, 500));
+        }
+
+        expect(removed).to.be(true);
+      } finally {
+        if (connectorId) {
+          await deleteActionConnector(getService, { actionId: connectorId });
+          try {
+            await es.deleteByQuery({
+              index: smlIndexName,
+              query: { term: { origin_id: connectorId } },
+              refresh: true,
+            });
+          } catch {
+            // ignore cleanup failures
+          }
+        }
+      }
+    });
+  });
+}

--- a/x-pack/platform/test/agent_builder_api_integration/apis/index.ts
+++ b/x-pack/platform/test/agent_builder_api_integration/apis/index.ts
@@ -26,5 +26,6 @@ export default function ({ loadTestFile }: FtrProviderContext) {
     loadTestFile(require.resolve('./skills/skills_validation.ts'));
     loadTestFile(require.resolve('./plugins'));
     loadTestFile(require.resolve('./sml'));
+    loadTestFile(require.resolve('./connector_lifecycle'));
   });
 }


### PR DESCRIPTION
## Summary

When the connector lifecycle handler fails to index or remove a connector from the Semantic Memory Layer (SML), the error is caught and logged as a warning. This PR adds telemetry usage counters so the failure rate is observable without parsing logs.

- Adds `agent_builder_sml_index_failure` counter incremented whenever `onPostCreate` fails to index a connector into SML
- Adds `agent_builder_sml_delete_failure` counter incremented whenever `onPostDelete` fails to remove a connector from SML
- Wires the `usageCounter` through `createConnectorLifecycleHandler` deps (optional, guarded against `undefined`)
- Adds an API integration test verifying the end-to-end wiring: connector create → SML indexed, connector delete → SML removed

## Test plan

- [x] Unit tests: `connector_lifecycle_handler.test.ts` — 13 tests all passing
- [x] Unit tests: `usage_counters.test.ts` — 28 tests all passing
- [x] Type check: `agent_builder` plugin tsconfig — clean
- [x] Lint: no errors
- [ ] API integration tests: `connector_lifecycle.ts` — validates end-to-end SML indexing via connector lifecycle (runs in CI)

## Notes

- Tasks 2 (retry/reconciliation evaluation) and 3 (add `list()` enumeration) from the linked issue are left for follow-up once failure rates are observable
- The `usageCounter` is optional throughout — if `usageCollection` plugin is unavailable, telemetry is silently skipped (existing behavior preserved)

Refs: https://github.com/elastic/search-team/issues/13495