### PR TITLE
Alert rule ES|QL: BASE/CONDITION highlights, Discover flyout, context menu

### DIFF
--- a/src/platform/packages/private/kbn-esql-editor/src/alert_rule_query_context_menu.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/alert_rule_query_context_menu.tsx
@@ -1,0 +1,243 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  EuiContextMenuItem,
+  EuiContextMenuPanel,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiHorizontalRule,
+  EuiOutsideClickDetector,
+  EuiPanel,
+  EuiText,
+  useEuiTheme,
+} from '@elastic/eui';
+import { css } from '@emotion/react';
+import { i18n } from '@kbn/i18n';
+import type { monaco } from '@kbn/monaco';
+import type { RefObject } from 'react';
+import {
+  getAlertRuleSplitMenuShortcutLabels,
+  runCopyBase,
+  runCopyCondition,
+  runResetToAutomaticSplit,
+  runSetAsRuleCondition,
+  type AlertRuleSplitContextMenuCallbacks,
+} from './alert_rule_split_context_menu';
+import { getAlertRuleCopySegments } from './split_esql_base_condition';
+
+export interface AlertRuleQueryContextMenuProps {
+  active: boolean;
+  editorRef: RefObject<monaco.editor.IStandaloneCodeEditor | undefined>;
+  callbacks: AlertRuleSplitContextMenuCallbacks;
+}
+
+/**
+ * Right-click menu with only alert-rule actions. Monaco’s built-in context menu is disabled
+ * (`contextmenu: false`); this listener uses capture to replace it while `active` is true.
+ */
+export function AlertRuleQueryContextMenu({
+  active,
+  editorRef,
+  callbacks,
+}: AlertRuleQueryContextMenuProps) {
+  const { euiTheme } = useEuiTheme();
+  const [coords, setCoords] = useState<{ x: number; y: number } | null>(null);
+  const listenerRef = useRef<{
+    node: HTMLElement;
+    handler: (ev: MouseEvent) => void;
+  } | null>(null);
+
+  const close = useCallback(() => setCoords(null), []);
+
+  useEffect(() => {
+    if (!active) {
+      setCoords(null);
+      return;
+    }
+
+    let cancelled = false;
+
+    const attach = () => {
+      if (cancelled) {
+        return;
+      }
+      const editor = editorRef.current;
+      const node = editor?.getDomNode() ?? null;
+      if (!node) {
+        if (!cancelled) {
+          requestAnimationFrame(attach);
+        }
+        return;
+      }
+
+      const handler = (ev: MouseEvent) => {
+        ev.preventDefault();
+        ev.stopPropagation();
+        setCoords({ x: ev.clientX, y: ev.clientY });
+      };
+
+      node.addEventListener('contextmenu', handler, true);
+      listenerRef.current = { node, handler };
+    };
+
+    attach();
+
+    return () => {
+      cancelled = true;
+      const cur = listenerRef.current;
+      if (cur) {
+        cur.node.removeEventListener('contextmenu', cur.handler, true);
+        listenerRef.current = null;
+      }
+    };
+  }, [active, editorRef]);
+
+  useEffect(() => {
+    if (!coords) {
+      return;
+    }
+    const onKeyDown = (ev: KeyboardEvent) => {
+      if (ev.key === 'Escape') {
+        close();
+      }
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [coords, close]);
+
+  if (!active || !coords) {
+    return null;
+  }
+
+  const editor = editorRef.current;
+  const model = editor?.getModel();
+  const query = model?.getValue() ?? '';
+  const override = callbacks.getConditionRangeOverride?.() ?? null;
+  const { baseText, conditionText } = getAlertRuleCopySegments(query, override);
+
+  const setAsRuleConditionLabel = i18n.translate(
+    'esqlEditor.alertRuleContextMenu.setAsRuleCondition',
+    {
+      defaultMessage: 'Set as rule condition',
+    }
+  );
+  const resetToAutomaticSplitLabel = i18n.translate(
+    'esqlEditor.alertRuleContextMenu.resetToAutomaticSplit',
+    {
+      defaultMessage: 'Reset to automatic split',
+    }
+  );
+  const copyBaseLabel = i18n.translate('esqlEditor.alertRuleContextMenu.copyBase', {
+    defaultMessage: 'Copy BASE',
+  });
+  const copyConditionLabel = i18n.translate('esqlEditor.alertRuleContextMenu.copyCondition', {
+    defaultMessage: 'Copy CONDITION',
+  });
+
+  const shortcuts = getAlertRuleSplitMenuShortcutLabels();
+
+  const menuItemWithShortcut = (label: string, shortcut: string) => (
+    <EuiFlexGroup
+      gutterSize="s"
+      alignItems="center"
+      justifyContent="spaceBetween"
+      responsive={false}
+      css={css`
+        width: 100%;
+        min-width: 0;
+      `}
+    >
+      <EuiFlexItem grow={false}>{label}</EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiText
+          size="s"
+          color="subdued"
+          css={css`
+            white-space: nowrap;
+            font-variant-numeric: tabular-nums;
+          `}
+        >
+          {shortcut}
+        </EuiText>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+
+  return (
+    <EuiOutsideClickDetector onOutsideClick={close}>
+      <div
+        role="presentation"
+        data-test-subj="esqlAlertRuleQueryContextMenu"
+        css={css`
+          position: fixed;
+          left: ${coords.x}px;
+          top: ${coords.y}px;
+          z-index: ${euiTheme.levels.flyout};
+          min-width: 280px;
+        `}
+        onMouseDown={(e) => e.stopPropagation()}
+      >
+        <EuiPanel paddingSize="none" hasShadow borderRadius="m">
+          <EuiContextMenuPanel size="s">
+            <EuiContextMenuItem
+              data-test-subj="esqlAlertRuleQueryContextMenu-setCondition"
+              onClick={() => {
+                const ed = editorRef.current;
+                if (ed) {
+                  runSetAsRuleCondition(ed, callbacks);
+                }
+                close();
+              }}
+            >
+              {menuItemWithShortcut(setAsRuleConditionLabel, shortcuts.setAsRuleCondition)}
+            </EuiContextMenuItem>
+            <EuiHorizontalRule margin="none" />
+            <EuiContextMenuItem
+              data-test-subj="esqlAlertRuleQueryContextMenu-resetAutomaticSplit"
+              onClick={() => {
+                runResetToAutomaticSplit(callbacks);
+                close();
+              }}
+            >
+              {resetToAutomaticSplitLabel}
+            </EuiContextMenuItem>
+            <EuiContextMenuItem
+              data-test-subj="esqlAlertRuleQueryContextMenu-copyBase"
+              disabled={!baseText}
+              onClick={() => {
+                const ed = editorRef.current;
+                if (ed) {
+                  runCopyBase(ed, callbacks);
+                }
+                close();
+              }}
+            >
+              {copyBaseLabel}
+            </EuiContextMenuItem>
+            <EuiContextMenuItem
+              data-test-subj="esqlAlertRuleQueryContextMenu-copyCondition"
+              disabled={!conditionText}
+              onClick={() => {
+                const ed = editorRef.current;
+                if (ed) {
+                  runCopyCondition(ed, callbacks);
+                }
+                close();
+              }}
+            >
+              {copyConditionLabel}
+            </EuiContextMenuItem>
+          </EuiContextMenuPanel>
+        </EuiPanel>
+      </div>
+    </EuiOutsideClickDetector>
+  );
+}

--- a/src/platform/packages/private/kbn-esql-editor/src/alert_rule_query_region_labels.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/alert_rule_query_region_labels.tsx
@@ -1,0 +1,145 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { useEuiTheme } from '@elastic/eui';
+import { css } from '@emotion/react';
+import { i18n } from '@kbn/i18n';
+import type { monaco } from '@kbn/monaco';
+import React, { useCallback, useEffect, useState } from 'react';
+import type { RefObject } from 'react';
+
+export interface AlertRuleRegionLabelMeta {
+  baseStartLine: number;
+  baseEndLine: number;
+  conditionStartLine: number;
+  conditionEndLine: number;
+  hasCondition: boolean;
+  /** When false, the BASE label is hidden (e.g. entire query highlighted as CONDITION). */
+  hasBase?: boolean;
+}
+
+function getBlockCenterTopPx(
+  editor: monaco.editor.IStandaloneCodeEditor,
+  startLine: number,
+  endLine: number
+): number | undefined {
+  const topStart = editor.getScrolledVisiblePosition({ lineNumber: startLine, column: 1 });
+  const topEnd = editor.getScrolledVisiblePosition({ lineNumber: endLine, column: 1 });
+  if (!topStart || !topEnd) {
+    return undefined;
+  }
+  const blockTop = Math.min(topStart.top, topEnd.top);
+  const blockBottom = Math.max(topStart.top + topStart.height, topEnd.top + topEnd.height);
+  return (blockTop + blockBottom) / 2;
+}
+
+export function AlertRuleQueryRegionLabels({
+  active,
+  editorRef,
+  meta,
+}: {
+  active: boolean;
+  editorRef: RefObject<monaco.editor.IStandaloneCodeEditor | undefined>;
+  meta: AlertRuleRegionLabelMeta | null;
+}) {
+  const { euiTheme } = useEuiTheme();
+  const [baseTop, setBaseTop] = useState<number | undefined>(undefined);
+  const [conditionTop, setConditionTop] = useState<number | undefined>(undefined);
+
+  const updatePositions = useCallback(() => {
+    const editor = editorRef.current;
+    if (!active || !meta || !editor) {
+      setBaseTop(undefined);
+      setConditionTop(undefined);
+      return;
+    }
+
+    const baseCenter = getBlockCenterTopPx(editor, meta.baseStartLine, meta.baseEndLine);
+    setBaseTop(baseCenter);
+
+    if (meta.hasCondition) {
+      const condCenter = getBlockCenterTopPx(
+        editor,
+        meta.conditionStartLine,
+        meta.conditionEndLine
+      );
+      setConditionTop(condCenter);
+    } else {
+      setConditionTop(undefined);
+    }
+  }, [active, editorRef, meta]);
+
+  useEffect(() => {
+    updatePositions();
+  }, [updatePositions]);
+
+  useEffect(() => {
+    const editor = editorRef.current;
+    if (!active || !meta || !editor) {
+      return;
+    }
+
+    const d1 = editor.onDidScrollChange(() => updatePositions());
+    const d2 = editor.onDidLayoutChange(() => updatePositions());
+    const d3 = editor.onDidContentSizeChange(() => updatePositions());
+
+    return () => {
+      d1.dispose();
+      d2.dispose();
+      d3.dispose();
+    };
+  }, [active, editorRef, meta, updatePositions]);
+
+  if (!active || !meta) {
+    return null;
+  }
+
+  const baseLabel = i18n.translate('esqlEditor.alertRuleHighlight.baseLabel', {
+    defaultMessage: 'BASE',
+  });
+  const conditionLabel = i18n.translate('esqlEditor.alertRuleHighlight.conditionLabel', {
+    defaultMessage: 'CONDITION',
+  });
+
+  const labelCss = (color: string) => css`
+    position: absolute;
+    right: ${euiTheme.size.s};
+    transform: translateY(-50%);
+    pointer-events: none;
+    z-index: 2;
+    font-size: 8pt;
+    line-height: 1;
+    font-weight: ${euiTheme.font.weight.bold};
+    letter-spacing: 0.04em;
+    color: ${color};
+  `;
+
+  return (
+    <>
+      {meta.hasBase !== false && baseTop !== undefined && (
+        <div
+          css={labelCss(euiTheme.colors.primaryText)}
+          style={{ top: baseTop }}
+          data-test-subj="esqlAlertRuleHighlightBaseLabel"
+        >
+          {baseLabel}
+        </div>
+      )}
+      {meta.hasCondition && conditionTop !== undefined && (
+        <div
+          css={labelCss(euiTheme.colors.accentText)}
+          style={{ top: conditionTop }}
+          data-test-subj="esqlAlertRuleHighlightConditionLabel"
+        >
+          {conditionLabel}
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/platform/packages/private/kbn-esql-editor/src/alert_rule_split_context_menu.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/alert_rule_split_context_menu.ts
@@ -1,0 +1,131 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { copyToClipboard } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { monaco } from '@kbn/monaco';
+import { isMac } from '@kbn/shared-ux-utility';
+import {
+  getAlertRuleCopySegments,
+  type AlertRuleConditionRangeOverride,
+} from './split_esql_base_condition';
+
+/**
+ * Keyboard shortcuts (only active while these actions are registered — alert-rule context).
+ * Avoids existing ES|QL chords: Ctrl/Cmd+Enter, +K, +I, +/ and Chrome’s Ctrl/Cmd+Shift+B (bookmark bar).
+ *
+ * - **Set as rule condition:** `Ctrl+Alt+C` (Win/Linux) or `⌘⌥C` (macOS) — **C**ondition
+ */
+const KEY_SET_CONDITION =
+  // eslint-disable-next-line no-bitwise
+  monaco.KeyMod.CtrlCmd | monaco.KeyMod.Alt | monaco.KeyCode.KeyC;
+
+/** Label for the context menu, aligned with `KEY_SET_CONDITION`. */
+export function getAlertRuleSplitMenuShortcutLabels(): {
+  setAsRuleCondition: string;
+} {
+  if (isMac) {
+    return { setAsRuleCondition: '⌘⌥C' };
+  }
+  return { setAsRuleCondition: 'Ctrl+Alt+C' };
+}
+
+export interface AlertRuleSplitContextMenuCallbacks {
+  setConditionRangeOverride: (range: AlertRuleConditionRangeOverride | null) => void;
+  /** Current override from the host (Discover / form state). */
+  getConditionRangeOverride?: () => AlertRuleConditionRangeOverride | null;
+}
+
+function getSelectionOffsets(editor: monaco.editor.IStandaloneCodeEditor): {
+  start: number;
+  end: number;
+} | null {
+  const model = editor.getModel();
+  const sel = editor.getSelection();
+  if (!model || !sel || sel.isEmpty()) {
+    return null;
+  }
+  const o1 = model.getOffsetAt(sel.getStartPosition());
+  const o2 = model.getOffsetAt(sel.getEndPosition());
+  const start = Math.min(o1, o2);
+  const end = Math.max(o1, o2);
+  if (end === start) {
+    return null;
+  }
+  return { start, end };
+}
+
+/** Runs the same logic as the context menu / keybinding for “Set as rule condition”. */
+export function runSetAsRuleCondition(
+  editor: monaco.editor.IStandaloneCodeEditor,
+  callbacks: AlertRuleSplitContextMenuCallbacks
+): void {
+  const range = getSelectionOffsets(editor);
+  if (!range) {
+    return;
+  }
+  callbacks.setConditionRangeOverride({ start: range.start, end: range.end });
+}
+
+/** Clears manual split and restores automatic detection (first top-level `| WHERE …`). */
+export function runResetToAutomaticSplit(callbacks: AlertRuleSplitContextMenuCallbacks): void {
+  callbacks.setConditionRangeOverride(null);
+}
+
+export function runCopyBase(
+  editor: monaco.editor.IStandaloneCodeEditor,
+  callbacks: AlertRuleSplitContextMenuCallbacks
+): void {
+  const model = editor.getModel();
+  if (!model) {
+    return;
+  }
+  const query = model.getValue();
+  const override = callbacks.getConditionRangeOverride?.() ?? null;
+  const { baseText } = getAlertRuleCopySegments(query, override);
+  if (baseText) {
+    copyToClipboard(baseText);
+  }
+}
+
+export function runCopyCondition(
+  editor: monaco.editor.IStandaloneCodeEditor,
+  callbacks: AlertRuleSplitContextMenuCallbacks
+): void {
+  const model = editor.getModel();
+  if (!model) {
+    return;
+  }
+  const query = model.getValue();
+  const override = callbacks.getConditionRangeOverride?.() ?? null;
+  const { conditionText } = getAlertRuleCopySegments(query, override);
+  if (conditionText) {
+    copyToClipboard(conditionText);
+  }
+}
+
+/**
+ * Registers keybindings only (no Monaco context menu — the flyout uses `AlertRuleQueryContextMenu`).
+ * Dispose when alert-rule highlight mode ends.
+ */
+export function registerAlertRuleSplitEditorActions(
+  editor: monaco.editor.IStandaloneCodeEditor,
+  callbacks: AlertRuleSplitContextMenuCallbacks
+): monaco.IDisposable {
+  return editor.addAction({
+    id: 'esql.alertRule.setAsRuleCondition',
+    label: i18n.translate('esqlEditor.alertRuleContextMenu.setAsRuleCondition', {
+      defaultMessage: 'Set as rule condition',
+    }),
+    keybindings: [KEY_SET_CONDITION],
+    run: (ed) => {
+      runSetAsRuleCondition(ed, callbacks);
+    },
+  });
+}

--- a/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
@@ -86,6 +86,10 @@ import { useEsqlCallbacks } from './hooks/use_esql_callbacks';
 import { useMemoizedCaches } from './hooks/use_memoized_caches';
 import { useQueryActions } from './hooks/use_query_actions';
 import { useQueryValidation } from './hooks/use_query_validation';
+import { AlertRuleQueryRegionLabels } from './alert_rule_query_region_labels';
+import { AlertRuleQueryContextMenu } from './alert_rule_query_context_menu';
+import { registerAlertRuleSplitEditorActions } from './alert_rule_split_context_menu';
+import { useAlertRuleContextHighlight } from './hooks/use_alert_rule_context_highlight';
 import { useEditorConfig } from './hooks/use_editor_config';
 import { useTimePickerPopover } from './hooks/use_time_picker_popover';
 import { useDataSourceBrowser } from './resource_browser/use_data_source_browser';
@@ -120,6 +124,9 @@ const ESQLEditorInternal = function ESQLEditor({
   hideQuickSearch,
   queryStats,
   enableResourceBrowser = false,
+  highlightQueryForAlertRuleContext = false,
+  alertRuleConditionRangeOverride = null,
+  onAlertRuleConditionRangeOverrideChange,
 }: ESQLEditorPropsInternal) {
   const popoverRef = useRef<HTMLDivElement>(null);
   const editorModel = useRef<monaco.editor.ITextModel>();
@@ -576,6 +583,49 @@ const ESQLEditorInternal = function ESQLEditor({
     onOpenQueryInNewTab
   );
 
+  const { alertRuleContextHighlightStyle, regionMeta } = useAlertRuleContextHighlight({
+    active: highlightQueryForAlertRuleContext,
+    editorModel,
+    queryText: code,
+    conditionRangeOverride: alertRuleConditionRangeOverride ?? null,
+  });
+
+  const onAlertRuleRangeOverrideChangeRef = useRef(onAlertRuleConditionRangeOverrideChange);
+  onAlertRuleRangeOverrideChangeRef.current = onAlertRuleConditionRangeOverrideChange;
+
+  const alertRuleConditionRangeOverrideRef = useRef(alertRuleConditionRangeOverride);
+  alertRuleConditionRangeOverrideRef.current = alertRuleConditionRangeOverride ?? null;
+
+  useEffect(() => {
+    if (
+      !highlightQueryForAlertRuleContext ||
+      typeof onAlertRuleConditionRangeOverrideChange !== 'function'
+    ) {
+      return;
+    }
+    let cancelled = false;
+    let menuDisposable: { dispose: () => void } | undefined;
+    const tryAttach = () => {
+      const editor = editorRef.current;
+      if (!editor) {
+        requestAnimationFrame(tryAttach);
+        return;
+      }
+      if (cancelled) {
+        return;
+      }
+      menuDisposable = registerAlertRuleSplitEditorActions(editor, {
+        setConditionRangeOverride: (range) => onAlertRuleRangeOverrideChangeRef.current?.(range),
+        getConditionRangeOverride: () => alertRuleConditionRangeOverrideRef.current ?? null,
+      });
+    };
+    tryAttach();
+    return () => {
+      cancelled = true;
+      menuDisposable?.dispose();
+    };
+  }, [highlightQueryForAlertRuleContext]);
+
   const {
     esqlDepsByModelUri,
     suggestionProvider,
@@ -607,6 +657,7 @@ const ESQLEditorInternal = function ESQLEditor({
         styles={css`
           ${lookupIndexBadgeStyle}
           ${sourcesBadgeStyle}
+          ${alertRuleContextHighlightStyle}
         `}
       />
       {Boolean(editorIsInline) && !hideRunQueryButton ? (
@@ -663,6 +714,24 @@ const ESQLEditorInternal = function ESQLEditor({
             `}
           >
             <div css={styles.editorContainer}>
+              <AlertRuleQueryRegionLabels
+                active={highlightQueryForAlertRuleContext}
+                editorRef={editorRef}
+                meta={regionMeta}
+              />
+              {highlightQueryForAlertRuleContext &&
+                typeof onAlertRuleConditionRangeOverrideChange === 'function' && (
+                  <AlertRuleQueryContextMenu
+                    active
+                    editorRef={editorRef}
+                    callbacks={{
+                      setConditionRangeOverride: (range) =>
+                        onAlertRuleConditionRangeOverrideChange?.(range),
+                      getConditionRangeOverride: () =>
+                        alertRuleConditionRangeOverrideRef.current ?? null,
+                    }}
+                  />
+                )}
               <CodeEditor
                 htmlId={htmlId}
                 aria-label={i18n.translate('esqlEditor.ariaLabel', {

--- a/src/platform/packages/private/kbn-esql-editor/src/helpers.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/helpers.ts
@@ -305,8 +305,10 @@ export const getEditorOverwrites = (theme: UseEuiTheme<{}>) => {
     .hover-row.status-bar {
       display: none;
     }
+    // Breathing room between digits and the line-decoration column (e.g. alert-rule BASE/CONDITION bars)
     .margin-view-overlays .line-numbers {
       color: ${theme.euiTheme.colors.textDisabled};
+      padding-right: ${theme.euiTheme.size.s};
     }
     .current-line ~ .line-numbers {
       color: ${theme.euiTheme.colors.textSubdued};

--- a/src/platform/packages/private/kbn-esql-editor/src/hooks/use_alert_rule_context_highlight.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/hooks/use_alert_rule_context_highlight.ts
@@ -1,0 +1,278 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { useEuiTheme } from '@elastic/eui';
+import { css } from '@emotion/react';
+import { monaco } from '@kbn/monaco';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import type React from 'react';
+import type { AlertRuleRegionLabelMeta } from '../alert_rule_query_region_labels';
+import { getRangeFromOffsets } from '../resource_browser/utils';
+import {
+  getAlertRuleSplitPlan,
+  type AlertRuleConditionRangeOverride,
+  type AlertRuleSplitPlan,
+} from '../split_esql_base_condition';
+
+/** Region fill — primary-tinted band for BASE. */
+const BASE_CLASS = 'esqlEditorAlertRuleBaseHighlight';
+/** Line-decorations gutter — primary strong border. */
+const BASE_GUTTER_CLASS = 'esqlEditorAlertRuleBaseGutter';
+/** Region fill — accent-tinted band for CONDITION. */
+const CONDITION_CLASS = 'esqlEditorAlertRuleConditionHighlight';
+/** Line-decorations gutter — accent strong border. */
+const CONDITION_GUTTER_CLASS = 'esqlEditorAlertRuleConditionGutter';
+
+/** Lower than 50% so `backgroundBaseInteractiveSelect` on selected text stays distinct on both tints. */
+const REGION_TINT_RATIO = 0.36;
+
+function pushBaseDecorations(
+  model: monaco.editor.ITextModel,
+  newDecorations: monaco.editor.IModelDeltaDecoration[],
+  startOffset: number,
+  endOffset: number
+) {
+  if (startOffset >= endOffset) {
+    return;
+  }
+  const r = getRangeFromOffsets(model, startOffset, endOffset);
+  newDecorations.push({
+    range: new monaco.Range(
+      r.startLineNumber,
+      r.startColumn,
+      r.endLineNumber,
+      r.endColumn
+    ),
+    options: {
+      className: BASE_CLASS,
+      linesDecorationsClassName: BASE_GUTTER_CLASS,
+      isWholeLine: true,
+      stickiness: monaco.editor.TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges,
+    },
+  });
+}
+
+function pushConditionDecorations(
+  model: monaco.editor.ITextModel,
+  newDecorations: monaco.editor.IModelDeltaDecoration[],
+  startOffset: number,
+  endOffset: number
+) {
+  if (startOffset >= endOffset) {
+    return;
+  }
+  const r = getRangeFromOffsets(model, startOffset, endOffset);
+  newDecorations.push({
+    range: new monaco.Range(
+      r.startLineNumber,
+      r.startColumn,
+      r.endLineNumber,
+      r.endColumn
+    ),
+    options: {
+      className: CONDITION_CLASS,
+      linesDecorationsClassName: CONDITION_GUTTER_CLASS,
+      isWholeLine: true,
+      stickiness: monaco.editor.TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges,
+    },
+  });
+}
+
+function setRegionMetaForPlan(
+  model: monaco.editor.ITextModel,
+  plan: AlertRuleSplitPlan,
+  len: number,
+  lineCount: number
+): AlertRuleRegionLabelMeta {
+  if (plan.kind === 'all-base') {
+    return {
+      baseStartLine: 1,
+      baseEndLine: lineCount,
+      conditionStartLine: lineCount,
+      conditionEndLine: lineCount,
+      hasCondition: false,
+      hasBase: true,
+    };
+  }
+  if (plan.kind === 'all-condition') {
+    return {
+      baseStartLine: 1,
+      baseEndLine: 1,
+      conditionStartLine: 1,
+      conditionEndLine: lineCount,
+      hasCondition: true,
+      hasBase: false,
+    };
+  }
+  if (plan.kind === 'split') {
+    const baseRange = getRangeFromOffsets(model, 0, plan.conditionStartOffset);
+    const condRange = getRangeFromOffsets(model, plan.conditionStartOffset, len);
+    return {
+      baseStartLine: baseRange.startLineNumber,
+      baseEndLine: baseRange.endLineNumber,
+      conditionStartLine: condRange.startLineNumber,
+      conditionEndLine: condRange.endLineNumber,
+      hasCondition: true,
+      hasBase: true,
+    };
+  }
+  // range
+  const { conditionStart: cs, conditionEnd: ce } = plan;
+  const condRange = getRangeFromOffsets(model, cs, ce);
+  let baseStartLine = 1;
+  let baseEndLine = 1;
+  if (cs > 0) {
+    const leadBase = getRangeFromOffsets(model, 0, cs);
+    baseStartLine = leadBase.startLineNumber;
+    baseEndLine = leadBase.endLineNumber;
+  } else if (ce < len) {
+    const trailBase = getRangeFromOffsets(model, ce, len);
+    baseStartLine = trailBase.startLineNumber;
+    baseEndLine = trailBase.endLineNumber;
+  }
+  return {
+    baseStartLine,
+    baseEndLine,
+    conditionStartLine: condRange.startLineNumber,
+    conditionEndLine: condRange.endLineNumber,
+    hasCondition: true,
+    hasBase: cs > 0 || ce < len,
+  };
+}
+
+export function useAlertRuleContextHighlight({
+  active,
+  editorModel,
+  queryText,
+  conditionRangeOverride,
+}: {
+  active: boolean;
+  editorModel: React.MutableRefObject<monaco.editor.ITextModel | undefined>;
+  /** Bumps the effect when the editor value changes so highlights apply after mount. */
+  queryText: string;
+  /**
+   * When non-null, this character range is CONDITION; `null` uses automatic `| WHERE` detection.
+   */
+  conditionRangeOverride: AlertRuleConditionRangeOverride | null;
+}) {
+  const { euiTheme } = useEuiTheme();
+  const decorationIdsRef = useRef<string[]>([]);
+  const [regionMeta, setRegionMeta] = useState<AlertRuleRegionLabelMeta | null>(null);
+
+  const alertRuleContextHighlightStyle = useMemo(
+    () => css`
+      .${BASE_CLASS} {
+        background-color: color-mix(
+          in srgb,
+          ${euiTheme.colors.backgroundLightPrimary} ${REGION_TINT_RATIO * 100}%,
+          transparent
+        ) !important;
+      }
+      .${CONDITION_CLASS} {
+        background-color: color-mix(
+          in srgb,
+          ${euiTheme.colors.backgroundLightAccent} ${REGION_TINT_RATIO * 100}%,
+          transparent
+        ) !important;
+      }
+      /* Neutral interactive fill so selection reads clearly on both primary- and accent-tinted lines */
+      .ESQLEditor .monaco-editor .view-overlays .selected-text {
+        background-color: ${euiTheme.colors.backgroundBaseInteractiveSelect} !important;
+      }
+      /* Renders in Monaco’s line-decorations column (between line numbers and text). */
+      .${BASE_GUTTER_CLASS} {
+        box-sizing: border-box;
+        width: 100% !important;
+        height: 100% !important;
+        border-left: ${euiTheme.size.xs} solid ${euiTheme.colors.borderStrongPrimary};
+      }
+      .${CONDITION_GUTTER_CLASS} {
+        box-sizing: border-box;
+        width: 100% !important;
+        height: 100% !important;
+        border-left: ${euiTheme.size.xs} solid ${euiTheme.colors.borderStrongAccent};
+      }
+    `,
+    [euiTheme]
+  );
+
+  useEffect(() => {
+    const model = editorModel.current;
+    if (!active) {
+      if (model) {
+        decorationIdsRef.current = model.deltaDecorations(decorationIdsRef.current, []);
+      }
+      setRegionMeta(null);
+      return;
+    }
+    if (!model) {
+      return;
+    }
+
+    const applyHighlight = () => {
+      const fullText = model.getValue();
+      const len = fullText.length;
+      const plan = getAlertRuleSplitPlan(fullText, conditionRangeOverride);
+
+      const newDecorations: monaco.editor.IModelDeltaDecoration[] = [];
+
+      const lineCount = model.getLineCount();
+      const endColumn = model.getLineMaxColumn(lineCount);
+      const fullRange = new monaco.Range(1, 1, lineCount, endColumn);
+
+      if (plan.kind === 'all-base') {
+        newDecorations.push({
+          range: fullRange,
+          options: {
+            className: BASE_CLASS,
+            linesDecorationsClassName: BASE_GUTTER_CLASS,
+            isWholeLine: true,
+            stickiness: monaco.editor.TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges,
+          },
+        });
+        setRegionMeta(setRegionMetaForPlan(model, plan, len, lineCount));
+      } else if (plan.kind === 'all-condition') {
+        newDecorations.push({
+          range: fullRange,
+          options: {
+            className: CONDITION_CLASS,
+            linesDecorationsClassName: CONDITION_GUTTER_CLASS,
+            isWholeLine: true,
+            stickiness: monaco.editor.TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges,
+          },
+        });
+        setRegionMeta(setRegionMetaForPlan(model, plan, len, lineCount));
+      } else if (plan.kind === 'range') {
+        const { conditionStart: cs, conditionEnd: ce } = plan;
+        pushBaseDecorations(model, newDecorations, 0, cs);
+        pushConditionDecorations(model, newDecorations, cs, ce);
+        pushBaseDecorations(model, newDecorations, ce, len);
+        setRegionMeta(setRegionMetaForPlan(model, plan, len, lineCount));
+      } else {
+        const splitOffset = plan.conditionStartOffset;
+        pushBaseDecorations(model, newDecorations, 0, splitOffset);
+        pushConditionDecorations(model, newDecorations, splitOffset, len);
+        setRegionMeta(setRegionMetaForPlan(model, plan, len, lineCount));
+      }
+
+      decorationIdsRef.current = model.deltaDecorations(decorationIdsRef.current, newDecorations);
+    };
+
+    applyHighlight();
+    const disposable = model.onDidChangeContent(() => applyHighlight());
+
+    return () => {
+      disposable.dispose();
+      decorationIdsRef.current = model.deltaDecorations(decorationIdsRef.current, []);
+      setRegionMeta(null);
+    };
+  }, [active, editorModel, queryText, conditionRangeOverride]);
+
+  return { alertRuleContextHighlightStyle, regionMeta };
+}

--- a/src/platform/packages/private/kbn-esql-editor/src/hooks/use_editor_config.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/hooks/use_editor_config.ts
@@ -154,6 +154,11 @@ export const useEditorConfig = ({
 
   const codeEditorOptions: CodeEditorProps['options'] = useMemo(
     () => ({
+      /**
+       * Disabled so Monaco’s default context menu never shows. Alert-rule mode uses a custom EUI menu
+       * (`alert_rule_query_context_menu.tsx`) with capture-phase `contextmenu` on the editor DOM.
+       */
+      contextmenu: false,
       hover: {
         above: false,
       },

--- a/src/platform/packages/private/kbn-esql-editor/src/split_esql_base_condition.test.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/split_esql_base_condition.test.ts
@@ -1,0 +1,115 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import {
+  findEsqlConditionStartOffset,
+  getActiveConditionInterval,
+  getAlertRuleCopySegments,
+  getAlertRuleSplitPlan,
+} from './split_esql_base_condition';
+
+describe('getAlertRuleSplitPlan', () => {
+  it('uses automatic | WHERE when override is null', () => {
+    const q = 'FROM a | WHERE x > 1';
+    const plan = getAlertRuleSplitPlan(q, null);
+    expect(plan.kind).toBe('split');
+    if (plan.kind === 'split') {
+      expect(q.slice(plan.conditionStartOffset)).toMatch(/^\|\s*WHERE/i);
+    }
+  });
+
+  it('returns range when override selects a substring', () => {
+    const q = 'FROM a | STATS b = COUNT(*) | WHERE c > 1';
+    const plan = getAlertRuleSplitPlan(q, { start: 5, end: 12 });
+    expect(plan.kind).toBe('range');
+    if (plan.kind === 'range') {
+      expect(plan.conditionStart).toBe(5);
+      expect(plan.conditionEnd).toBe(12);
+    }
+  });
+
+  it('returns all-condition when override spans full query', () => {
+    const q = 'FROM a';
+    expect(getAlertRuleSplitPlan(q, { start: 0, end: q.length }).kind).toBe('all-condition');
+  });
+
+  it('normalizes reversed start/end on override', () => {
+    const q = '0123456789';
+    const plan = getAlertRuleSplitPlan(q, { start: 7, end: 3 });
+    expect(plan.kind).toBe('range');
+    if (plan.kind === 'range') {
+      expect(plan.conditionStart).toBe(3);
+      expect(plan.conditionEnd).toBe(7);
+    }
+  });
+});
+
+describe('getActiveConditionInterval', () => {
+  it('returns [| WHERE …, EOF) for automatic split', () => {
+    const q = 'FROM a\n| WHERE x > 1';
+    const iv = getActiveConditionInterval(q, null);
+    expect(iv).not.toBeNull();
+    expect(q.slice(iv!.start, iv!.end)).toMatch(/^\|\s*WHERE[\s\S]*/i);
+  });
+
+  it('returns null for all-base (no WHERE)', () => {
+    expect(getActiveConditionInterval('FROM a | STATS c = COUNT(*)', null)).toBeNull();
+  });
+
+  it('returns manual range when override is set', () => {
+    const q = '0123456789';
+    const iv = getActiveConditionInterval(q, { start: 2, end: 5 });
+    expect(iv).toEqual({ start: 2, end: 5 });
+  });
+});
+
+describe('getAlertRuleCopySegments', () => {
+  it('splits automatic | WHERE into base and condition text', () => {
+    const q = 'FROM a | WHERE x > 1';
+    const { baseText, conditionText } = getAlertRuleCopySegments(q, null);
+    expect(baseText).toBe('FROM a ');
+    expect(conditionText).toBe('| WHERE x > 1');
+  });
+
+  it('concatenates prefix and suffix for range plan base text', () => {
+    const q = '0123456789';
+    const { baseText, conditionText } = getAlertRuleCopySegments(q, { start: 3, end: 7 });
+    expect(baseText).toBe('012789');
+    expect(conditionText).toBe('3456');
+  });
+
+  it('returns full query as base when there is no condition', () => {
+    const q = 'FROM a | STATS c = COUNT(*)';
+    const { baseText, conditionText } = getAlertRuleCopySegments(q, null);
+    expect(baseText).toBe(q);
+    expect(conditionText).toBe('');
+  });
+});
+
+describe('findEsqlConditionStartOffset', () => {
+  it('returns the index of | before WHERE for a typical query', () => {
+    const q = `FROM kibana_sample_data_flights
+| STATS count = COUNT(*) BY DestCityName
+| WHERE DestCityName == "Barcelona"`;
+    const idx = findEsqlConditionStartOffset(q);
+    expect(idx).not.toBeNull();
+    expect(q.slice(idx!, idx! + 20)).toMatch(/^\|\s*WHERE/i);
+  });
+
+  it('returns null when there is no WHERE pipeline stage', () => {
+    expect(findEsqlConditionStartOffset('FROM foo | STATS c = COUNT(*)')).toBeNull();
+  });
+
+  it('is case-insensitive on WHERE', () => {
+    const q = 'FROM a | where x > 1';
+    const idx = findEsqlConditionStartOffset(q);
+    expect(idx).not.toBeNull();
+    expect(q.slice(idx!)).toMatch(/^\|\s*where/i);
+  });
+});

--- a/src/platform/packages/private/kbn-esql-editor/src/split_esql_base_condition.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/split_esql_base_condition.ts
@@ -1,0 +1,126 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+/**
+ * Returns the 0-based character index in `query` where the alert "condition"
+ * segment begins: the leading `|` of the first top-level `| WHERE …` pipeline stage.
+ * If no such clause exists, returns `null` (entire query is treated as base only).
+ *
+ * Users can move text across the boundary by editing the query (e.g. adding or
+ * removing `| WHERE`); highlights update on every change.
+ */
+export function findEsqlConditionStartOffset(query: string): number | null {
+  const re = /\|\s*WHERE\b/i;
+  const match = re.exec(query);
+  if (!match) {
+    return null;
+  }
+  return match.index;
+}
+
+/** Manual CONDITION region from the editor selection (0-based offsets into `query`). */
+export type AlertRuleConditionRangeOverride = { start: number; end: number };
+
+export type AlertRuleSplitPlan =
+  | { kind: 'all-base' }
+  | { kind: 'all-condition' }
+  | { kind: 'split'; conditionStartOffset: number }
+  | { kind: 'range'; conditionStart: number; conditionEnd: number };
+
+function getAutomaticSplitPlan(query: string): AlertRuleSplitPlan {
+  const auto = findEsqlConditionStartOffset(query);
+  if (auto === null) {
+    return { kind: 'all-base' };
+  }
+  return { kind: 'split', conditionStartOffset: auto };
+}
+
+/**
+ * Resolves how to highlight BASE vs CONDITION for the alert-rule editor overlay.
+ *
+ * @param query — full ES|QL text
+ * @param override — `null` uses automatic detection (first top-level `| WHERE …`);
+ *   otherwise the selected character range is highlighted as CONDITION (BASE before / after).
+ */
+export function getAlertRuleSplitPlan(
+  query: string,
+  override: AlertRuleConditionRangeOverride | null
+): AlertRuleSplitPlan {
+  const len = query.length;
+  if (override !== null) {
+    let start = Math.max(0, Math.min(override.start, len));
+    let end = Math.max(0, Math.min(override.end, len));
+    if (end < start) {
+      const t = start;
+      start = end;
+      end = t;
+    }
+    if (end === start) {
+      return getAutomaticSplitPlan(query);
+    }
+    if (start === 0 && end === len) {
+      return { kind: 'all-condition' };
+    }
+    return { kind: 'range', conditionStart: start, conditionEnd: end };
+  }
+
+  return getAutomaticSplitPlan(query);
+}
+
+/**
+ * Returns the active CONDITION character interval `[start, end)` for the current plan, or `null`
+ * when there is no condition segment (`all-base`).
+ */
+export function getActiveConditionInterval(
+  query: string,
+  override: AlertRuleConditionRangeOverride | null
+): { start: number; end: number } | null {
+  const plan = getAlertRuleSplitPlan(query, override);
+  const len = query.length;
+  if (plan.kind === 'split') {
+    return { start: plan.conditionStartOffset, end: len };
+  }
+  if (plan.kind === 'range') {
+    return { start: plan.conditionStart, end: plan.conditionEnd };
+  }
+  if (plan.kind === 'all-condition') {
+    return { start: 0, end: len };
+  }
+  return null;
+}
+
+/**
+ * Text segments for BASE vs CONDITION for the current split plan (clipboard, previews).
+ * For `range` plans, BASE is the non-condition prefix and suffix concatenated (no separator).
+ */
+export function getAlertRuleCopySegments(
+  query: string,
+  override: AlertRuleConditionRangeOverride | null
+): { baseText: string; conditionText: string } {
+  const plan = getAlertRuleSplitPlan(query, override);
+  const len = query.length;
+  if (plan.kind === 'all-base') {
+    return { baseText: query, conditionText: '' };
+  }
+  if (plan.kind === 'all-condition') {
+    return { baseText: '', conditionText: query };
+  }
+  if (plan.kind === 'split') {
+    const c0 = plan.conditionStartOffset;
+    return {
+      baseText: query.slice(0, c0),
+      conditionText: query.slice(c0, len),
+    };
+  }
+  const { conditionStart: cs, conditionEnd: ce } = plan;
+  return {
+    baseText: query.slice(0, cs) + query.slice(ce, len),
+    conditionText: query.slice(cs, ce),
+  };
+}

--- a/src/platform/packages/private/kbn-esql-editor/src/types.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/types.ts
@@ -90,6 +90,22 @@ export interface ESQLEditorProps {
   enableResourceBrowser?: boolean;
   /** Stats about the last request made */
   queryStats?: ESQLQueryStats;
+  /**
+   * When true, applies a subtle background highlight to the full query in the editor.
+   * Intended for contexts where the query is referenced by another surface (e.g. creating an alert rule from Discover).
+   */
+  highlightQueryForAlertRuleContext?: boolean;
+  /**
+   * When {@link highlightQueryForAlertRuleContext} is active, optional character range (0-based offsets)
+   * highlighted as CONDITION. `null` uses automatic detection (first `| WHERE`). Set via context menu in Discover.
+   */
+  alertRuleConditionRangeOverride?: { start: number; end: number } | null;
+  /**
+   * Updates {@link alertRuleConditionRangeOverride} from the editor context menu (for example “Set as rule condition” or “Reset to automatic split”).
+   */
+  onAlertRuleConditionRangeOverrideChange?: (
+    range: { start: number; end: number } | null
+  ) => void;
 }
 
 interface ESQLVariableService {

--- a/src/platform/plugins/shared/discover/public/application/main/components/top_nav/app_menu_actions/create_esql_rule_flyout.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/top_nav/app_menu_actions/create_esql_rule_flyout.tsx
@@ -28,12 +28,15 @@ export function CreateESQLRuleFlyout({
   getState,
   subscribe,
   onClose,
+  onFlyoutPresenceChange,
 }: {
   services: DiscoverServices;
   tabId: string;
   getState: () => DiscoverInternalState;
   subscribe: (listener: () => void) => () => void;
   onClose: () => void;
+  /** Notifies when this flyout is mounted (Discover editor highlight) or unmounted. */
+  onFlyoutPresenceChange?: (openForTabId: string | null) => void;
 }) {
   const getQuery = useCallback(() => getEsqlQuery(getState, tabId), [getState, tabId]);
 
@@ -76,6 +79,14 @@ export function CreateESQLRuleFlyout({
       appChangeSubscription.unsubscribe();
     };
   }, [history, core.application.currentAppId$]);
+
+  useEffect(() => {
+    if (query === null) {
+      return;
+    }
+    onFlyoutPresenceChange?.(tabId);
+    return () => onFlyoutPresenceChange?.(null);
+  }, [onFlyoutPresenceChange, tabId, query]);
 
   if (query === null) {
     return null;

--- a/src/platform/plugins/shared/discover/public/application/main/components/top_nav/app_menu_actions/get_alerts.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/top_nav/app_menu_actions/get_alerts.tsx
@@ -129,6 +129,7 @@ export const getAlertsAppMenuItem = ({
   getState,
   subscribe,
   showCreateRuleV2,
+  onEsqlRuleV2FlyoutOpenChange,
 }: {
   discoverParams: AppMenuDiscoverParams;
   services: DiscoverServices;
@@ -136,6 +137,8 @@ export const getAlertsAppMenuItem = ({
   getState: () => DiscoverInternalState;
   subscribe: (listener: () => void) => () => void;
   showCreateRuleV2?: boolean;
+  /** Fired when the ES|QL rule v2 flyout opens (`tabId`) or closes (`null`). Used for Discover editor emphasis and optional prettify on open. */
+  onEsqlRuleV2FlyoutOpenChange?: (tabId: string | null) => void | Promise<void>;
 }): DiscoverAppMenuItemType => {
   const { dataView, isEsqlMode } = discoverParams;
   const timeField = getTimeField(dataView);
@@ -163,6 +166,7 @@ export const getAlertsAppMenuItem = ({
             getState={getState}
             subscribe={subscribe}
             onClose={onFinishAction}
+            onFlyoutPresenceChange={onEsqlRuleV2FlyoutOpenChange}
           />
         );
       },

--- a/src/platform/plugins/shared/discover/public/application/main/components/top_nav/discover_topnav.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/top_nav/discover_topnav.tsx
@@ -163,6 +163,22 @@ export const DiscoverTopNav = ({
     (state) => state.persistedDiscoverSession
   );
   const isEsqlMode = useIsEsqlMode();
+  const esqlRuleV2FlyoutOpenForTabId = useInternalStateSelector(
+    (state) => state.esqlRuleV2FlyoutOpenForTabId
+  );
+  const highlightQueryForAlertRuleContext =
+    isEsqlMode &&
+    esqlRuleV2FlyoutOpenForTabId !== null &&
+    esqlRuleV2FlyoutOpenForTabId === currentTabId;
+  const esqlAlertRuleConditionRangeOverride = useInternalStateSelector(
+    (state) => state.esqlAlertRuleConditionRangeOverride
+  );
+  const onAlertRuleConditionRangeOverrideChange = useCallback(
+    (range: { start: number; end: number } | null) => {
+      dispatch(internalStateActions.setEsqlAlertRuleConditionRangeOverride(range));
+    },
+    [dispatch]
+  );
   const showDatePicker = useMemo(() => {
     // always show the timepicker for ES|QL mode
     return (
@@ -496,6 +512,9 @@ export const DiscoverTopNav = ({
         }
         esqlQueryStats={esqlQueryStats}
         onOpenQueryInNewTab={onOpenQueryInNewTab}
+        highlightQueryForAlertRuleContext={highlightQueryForAlertRuleContext}
+        alertRuleConditionRangeOverride={esqlAlertRuleConditionRangeOverride}
+        onAlertRuleConditionRangeOverrideChange={onAlertRuleConditionRangeOverrideChange}
       />
       {isESQLToDataViewTransitionModalVisible && (
         <ESQLToDataViewTransitionModal onClose={onESQLToDataViewTransitionModalClose} />

--- a/src/platform/plugins/shared/discover/public/application/main/components/top_nav/use_top_nav_links.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/top_nav/use_top_nav_links.tsx
@@ -11,7 +11,8 @@ import { useCallback, useMemo } from 'react';
 import { i18n } from '@kbn/i18n';
 import type { DataView } from '@kbn/data-views-plugin/public';
 import { METRIC_TYPE } from '@kbn/analytics';
-import { ENABLE_ESQL, getInitialESQLQuery } from '@kbn/esql-utils';
+import { ENABLE_ESQL, getInitialESQLQuery, prettifyQuery } from '@kbn/esql-utils';
+import { isOfAggregateQueryType } from '@kbn/es-query';
 import type { AppMenuConfig } from '@kbn/core-chrome-app-menu-components';
 import type { DiscoverAppMenuItemType } from '@kbn/discover-utils';
 import { AppMenuRegistry, dismissFlyouts, DiscoverFlyouts } from '@kbn/discover-utils';
@@ -38,6 +39,7 @@ import {
 import { useProfileAccessor } from '../../../../context_awareness';
 import {
   internalStateActions,
+  selectTab,
   selectTabSavedSearchByValueAttributes,
   useCurrentDataView,
   useCurrentTabAction,
@@ -134,6 +136,34 @@ export const useTopNavLinks = ({
   const canCreateESQLRule = !!services.capabilities.alertingVTwo;
   const showCreateRuleV2 = isEsqlMode && canCreateESQLRule;
 
+  const onEsqlRuleV2FlyoutOpenChange = useCallback(
+    async (openForTabId: string | null) => {
+      if (openForTabId) {
+        try {
+          const state = getState();
+          const tab = selectTab(state, openForTabId);
+          const q = tab?.appState.query;
+          if (q && isOfAggregateQueryType(q)) {
+            const raw = q.esql;
+            const pretty = prettifyQuery(raw);
+            if (pretty !== raw) {
+              await dispatch(
+                internalStateActions.updateESQLQuery({
+                  tabId: openForTabId,
+                  queryOrUpdater: pretty,
+                })
+              );
+            }
+          }
+        } catch {
+          // Unparseable or invalid query — open the flyout without mutating the editor text.
+        }
+      }
+      dispatch(internalStateActions.setEsqlRuleV2FlyoutOpenForTabId(openForTabId));
+    },
+    [dispatch, getState]
+  );
+
   const appMenuItems: DiscoverAppMenuItemType[] = useMemo(() => {
     const items: DiscoverAppMenuItemType[] = [];
 
@@ -150,6 +180,7 @@ export const useTopNavLinks = ({
         getState,
         subscribe,
         showCreateRuleV2,
+        onEsqlRuleV2FlyoutOpenChange,
       });
       items.push(alertsAppMenuItem);
     }
@@ -237,6 +268,7 @@ export const useTopNavLinks = ({
     totalHitsState,
     intl,
     showCreateRuleV2,
+    onEsqlRuleV2FlyoutOpenChange,
   ]);
 
   const transitionFromDataViewToESQL = useCurrentTabAction(

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/internal_state.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/internal_state.ts
@@ -78,6 +78,8 @@ const initialState: DiscoverInternalState = {
   defaultProfileEsqlQuery: undefined,
   savedDataViews: [],
   isESQLToDataViewTransitionModalVisible: false,
+  esqlRuleV2FlyoutOpenForTabId: null,
+  esqlAlertRuleConditionRangeOverride: null,
   tabsBarVisibility: TabsBarVisibility.default,
   tabs: {
     areInitializing: false,
@@ -222,6 +224,23 @@ export const internalStateSlice = createSlice({
 
     setTabsBarVisibility: (state, action: PayloadAction<TabsBarVisibility>) => {
       state.tabsBarVisibility = action.payload;
+    },
+
+    setEsqlRuleV2FlyoutOpenForTabId: (
+      state,
+      action: PayloadAction<DiscoverInternalState['esqlRuleV2FlyoutOpenForTabId']>
+    ) => {
+      state.esqlRuleV2FlyoutOpenForTabId = action.payload;
+      if (action.payload === null) {
+        state.esqlAlertRuleConditionRangeOverride = null;
+      }
+    },
+
+    setEsqlAlertRuleConditionRangeOverride: (
+      state,
+      action: PayloadAction<DiscoverInternalState['esqlAlertRuleConditionRangeOverride']>
+    ) => {
+      state.esqlAlertRuleConditionRangeOverride = action.payload;
     },
 
     markNonActiveTabsForRefetch: (state) => {
@@ -661,8 +680,9 @@ const createMiddleware = (options: InternalStateDependencies) => {
 
   startListening({
     actionCreator: discardFlyoutsOnTabChange,
-    effect: () => {
+    effect: (_action, listenerApi) => {
       dismissFlyouts([DiscoverFlyouts.lensEdit, DiscoverFlyouts.metricInsights]);
+      listenerApi.dispatch(internalStateSlice.actions.setEsqlRuleV2FlyoutOpenForTabId(null));
     },
   });
 

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/types.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/types.ts
@@ -240,6 +240,16 @@ export interface DiscoverInternalState {
   defaultProfileAdHocDataViewIds: string[];
   defaultProfileEsqlQuery: DefaultEsqlQueryConfig | undefined;
   isESQLToDataViewTransitionModalVisible: boolean;
+  /**
+   * When set, the Discover ES|QL editor may emphasize the query (e.g. while the ES|QL rule v2 flyout is open).
+   * Cleared when the flyout closes or the user switches tabs.
+   */
+  esqlRuleV2FlyoutOpenForTabId: string | null;
+  /**
+   * Optional character range (0-based offsets into the query) highlighted as CONDITION while the rule flyout is open.
+   * `null` uses automatic `| WHERE` detection. Set from the editor context menu.
+   */
+  esqlAlertRuleConditionRangeOverride: { start: number; end: number } | null;
   tabsBarVisibility: TabsBarVisibility;
   tabs: {
     areInitializing: boolean;

--- a/src/platform/plugins/shared/unified_search/public/query_string_input/query_bar_top_row.tsx
+++ b/src/platform/plugins/shared/unified_search/public/query_string_input/query_bar_top_row.tsx
@@ -251,6 +251,12 @@ export interface QueryBarTopRowProps<QT extends Query | AggregateQuery = Query> 
    * Optional ES|QL prop - Enable data source browser in ESQL editor
    */
   enableResourceBrowser?: ESQLEditorProps['enableResourceBrowser'];
+  /**
+   * Optional ES|QL prop — emphasize the query when a related flow is open (e.g. alert rule from Discover).
+   */
+  highlightQueryForAlertRuleContext?: ESQLEditorProps['highlightQueryForAlertRuleContext'];
+  alertRuleConditionRangeOverride?: ESQLEditorProps['alertRuleConditionRangeOverride'];
+  onAlertRuleConditionRangeOverrideChange?: ESQLEditorProps['onAlertRuleConditionRangeOverrideChange'];
   useBackgroundSearchButton?: boolean;
   /**
    * Opt-in to the new DateRangePicker. The new picker is shown only when both
@@ -1213,6 +1219,9 @@ export const QueryBarTopRow = React.memo(
             onOpenQueryInNewTab={props.onOpenQueryInNewTab}
             queryStats={props.esqlQueryStats}
             enableResourceBrowser={props.enableResourceBrowser}
+            highlightQueryForAlertRuleContext={props.highlightQueryForAlertRuleContext}
+            alertRuleConditionRangeOverride={props.alertRuleConditionRangeOverride}
+            onAlertRuleConditionRangeOverrideChange={props.onAlertRuleConditionRangeOverrideChange}
           />
         )
       );

--- a/src/platform/plugins/shared/unified_search/public/search_bar/create_search_bar.tsx
+++ b/src/platform/plugins/shared/unified_search/public/search_bar/create_search_bar.tsx
@@ -308,6 +308,9 @@ export function createSearchBar({
             useBackgroundSearchButton={props.useBackgroundSearchButton}
             esqlQueryStats={props.esqlQueryStats}
             enableResourceBrowser={props.enableResourceBrowser}
+            highlightQueryForAlertRuleContext={props.highlightQueryForAlertRuleContext}
+            alertRuleConditionRangeOverride={props.alertRuleConditionRangeOverride}
+            onAlertRuleConditionRangeOverrideChange={props.onAlertRuleConditionRangeOverrideChange}
             enableDateRangePicker={props.enableDateRangePicker}
           />
         </core.i18n.Context>

--- a/src/platform/plugins/shared/unified_search/public/search_bar/search_bar.tsx
+++ b/src/platform/plugins/shared/unified_search/public/search_bar/search_bar.tsx
@@ -176,6 +176,11 @@ export interface SearchBarOwnProps<QT extends AggregateQuery | Query = Query> {
    * Enable data source browser suggestion in ES|QL editor.
    */
   enableResourceBrowser?: boolean;
+  /** When true, emphasize the ES|QL query in the editor (e.g. while an alert-rule flyout is open). */
+  highlightQueryForAlertRuleContext?: boolean;
+  /** Discover alert-rule flow: manual CONDITION character range (0-based offsets). */
+  alertRuleConditionRangeOverride?: { start: number; end: number } | null;
+  onAlertRuleConditionRangeOverrideChange?: (range: { start: number; end: number } | null) => void;
 }
 
 export type SearchBarProps<QT extends Query | AggregateQuery = Query> = SearchBarOwnProps<QT> &
@@ -808,6 +813,11 @@ export class SearchBarUI<QT extends (Query | AggregateQuery) | Query = Query> ex
           useBackgroundSearchButton={this.props.useBackgroundSearchButton}
           enableDateRangePicker={this.props.enableDateRangePicker}
           enableResourceBrowser={this.props.enableResourceBrowser}
+          highlightQueryForAlertRuleContext={this.props.highlightQueryForAlertRuleContext}
+          alertRuleConditionRangeOverride={this.props.alertRuleConditionRangeOverride}
+          onAlertRuleConditionRangeOverrideChange={
+            this.props.onAlertRuleConditionRangeOverrideChange
+          }
         />
       </div>
     );

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/dynamic_rule_form_flyout.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/dynamic_rule_form_flyout.tsx
@@ -6,9 +6,12 @@
  */
 
 import React, { useMemo } from 'react';
+import { EuiCallOut } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 import { QueryClient, QueryClientProvider } from '@kbn/react-query';
 import { RuleFormFlyout } from './rule_form_flyout';
 import { DynamicRuleForm } from '../form/dynamic_rule_form';
+import { EsqlQuerySplitLegend } from '../form/fields/esql_query_split_legend';
 import { useCreateRule } from '../form/hooks/use_create_rule';
 import type { FormValues } from '../form/types';
 import type { RuleFormServices } from '../form/contexts';
@@ -50,13 +53,31 @@ const DynamicRuleFormFlyoutInner = ({
   };
 
   return (
-    <RuleFormFlyout push={push} onClose={onClose} isLoading={isLoading}>
+    <RuleFormFlyout
+      push={push}
+      onClose={onClose}
+      isLoading={isLoading}
+      bodyBanner={
+        <EuiCallOut
+          color="accent"
+          iconType="popper"
+          size="s"
+          title={i18n.translate('xpack.alertingV2.ruleForm.esqlQuerySplitCalloutTitle', {
+            defaultMessage: 'Alerting v2: Create alert rules from Discover',
+          })}
+          data-test-subj="alertingV2EsqlQuerySplitCallout"
+        >
+          <EsqlQuerySplitLegend />
+        </EuiCallOut>
+      }
+    >
       <DynamicRuleForm
         onSubmit={handleSubmit}
         isSubmitting={isLoading}
         query={query}
         services={services}
         layout="flyout"
+        omitEsqlQuerySplitLegend
       />
     </RuleFormFlyout>
   );

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/rule_form_flyout.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/rule_form_flyout.tsx
@@ -27,6 +27,11 @@ export interface RuleFormFlyoutProps {
   onClose?: () => void;
   isLoading?: boolean;
   children: React.ReactNode;
+  /**
+   * Renders in `EuiFlyoutBody`’s banner region: flush under the header divider, full width,
+   * outside the body’s padded scroll content (intended for `EuiCallOut`).
+   */
+  bodyBanner?: React.ReactNode;
 }
 
 /**
@@ -47,6 +52,7 @@ export const RuleFormFlyout = ({
   onClose,
   isLoading = false,
   children,
+  bodyBanner,
 }: RuleFormFlyoutProps) => {
   const clickedRef = useRef(false);
 
@@ -74,6 +80,7 @@ export const RuleFormFlyout = ({
       aria-labelledby={FLYOUT_TITLE_ID}
       size="l"
       maxWidth={600}
+      paddingSize="m"
     >
       <div
         style={{ display: 'contents' }}
@@ -86,16 +93,16 @@ export const RuleFormFlyout = ({
         onFocusCapture={onFocusCapture}
       >
         <EuiFlyoutHeader hasBorder>
-          <EuiTitle size="m" id={FLYOUT_TITLE_ID}>
-            <h2>
+          <EuiTitle size="s" id={FLYOUT_TITLE_ID}>
+            <h3>
               <FormattedMessage
                 id="xpack.alertingV2.ruleForm.flyoutTitle"
                 defaultMessage="Create Alert Rule"
               />
-            </h2>
+            </h3>
           </EuiTitle>
         </EuiFlyoutHeader>
-        <EuiFlyoutBody>{children}</EuiFlyoutBody>
+        <EuiFlyoutBody banner={bodyBanner}>{children}</EuiFlyoutBody>
         <EuiFlyoutFooter>
           <EuiFlexGroup justifyContent="spaceBetween">
             <EuiFlexItem grow={false}>

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/dynamic_rule_form.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/dynamic_rule_form.tsx
@@ -38,6 +38,10 @@ export interface DynamicRuleFormProps {
   includeSubmission?: boolean;
   submitLabel?: React.ReactNode;
   cancelLabel?: React.ReactNode;
+  /**
+   * When true, the ES|QL BASE/CONDITION legend is omitted from Rule evaluation (e.g. rendered in the DynamicRuleFormFlyout header callout).
+   */
+  omitEsqlQuerySplitLegend?: boolean;
 }
 
 /**
@@ -65,6 +69,7 @@ export const DynamicRuleForm = ({
   onCancel,
   submitLabel,
   cancelLabel,
+  omitEsqlQuerySplitLegend = false,
 }: DynamicRuleFormProps) => {
   // Get default form values derived from the query
   const formValues = useFormDefaults({ query });
@@ -97,6 +102,7 @@ export const DynamicRuleForm = ({
         onSubmit={onSubmit}
         onSuccess={onSuccess}
         includeQueryEditor={false}
+        omitEsqlQuerySplitLegend={omitEsqlQuerySplitLegend}
         includeYaml={includeYaml}
         isDisabled={isDisabled}
         isSubmitting={isSubmitting}

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/field_groups/condition_field_group.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/field_groups/condition_field_group.test.tsx
@@ -1,0 +1,104 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { createFormWrapper, createMockServices } from '../../test_utils';
+import { ConditionFieldGroup } from './condition_field_group';
+import * as useQueryColumnsModule from '../hooks/use_query_columns';
+import * as useDataFieldsModule from '../hooks/use_data_fields';
+
+jest.mock('../hooks/use_query_columns');
+jest.mock('../hooks/use_data_fields');
+jest.mock('../fields/evaluation_query_field', () => ({
+  EvaluationQueryField: () => <div data-test-subj="mockEvaluationQueryField" />,
+}));
+
+describe('ConditionFieldGroup', () => {
+  const mockServices = createMockServices();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.mocked(useQueryColumnsModule.useQueryColumns).mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: null,
+      isError: false,
+      isSuccess: true,
+      isFetching: false,
+      status: 'success',
+      fetchStatus: 'idle',
+    } as ReturnType<typeof useQueryColumnsModule.useQueryColumns>);
+    jest.mocked(useDataFieldsModule.useDataFields).mockReturnValue({
+      data: {},
+      isLoading: false,
+    } as ReturnType<typeof useDataFieldsModule.useDataFields>);
+  });
+
+  it('renders the ES|QL split legend when includeBase is false (Discover)', () => {
+    const Wrapper = createFormWrapper(
+      { evaluation: { query: { base: 'FROM x | STATS c = COUNT() BY y | WHERE c > 1' } } },
+      mockServices
+    );
+
+    render(
+      <Wrapper>
+        <ConditionFieldGroup includeBase={false} />
+      </Wrapper>
+    );
+
+    expect(screen.getByTestId('alertingV2EsqlQuerySplitLegend')).toBeInTheDocument();
+    expect(screen.getByText('BASE')).toBeInTheDocument();
+    expect(screen.getByText('CONDITION')).toBeInTheDocument();
+    expect(screen.queryByText('Base query')).not.toBeInTheDocument();
+  });
+
+  it('does not render the ES|QL split legend when omitEsqlQuerySplitLegend is true', () => {
+    const Wrapper = createFormWrapper(
+      { evaluation: { query: { base: 'FROM x | STATS c = COUNT() BY y | WHERE c > 1' } } },
+      mockServices
+    );
+
+    render(
+      <Wrapper>
+        <ConditionFieldGroup includeBase={false} omitEsqlQuerySplitLegend />
+      </Wrapper>
+    );
+
+    expect(screen.queryByTestId('alertingV2EsqlQuerySplitLegend')).not.toBeInTheDocument();
+  });
+
+  it('does not render a Rule evaluation accordion in flyout when legend is omitted (plain group)', () => {
+    const Wrapper = createFormWrapper(
+      { evaluation: { query: { base: 'FROM x | STATS c = COUNT() BY y | WHERE c > 1' } } },
+      mockServices,
+      { layout: 'flyout' }
+    );
+
+    render(
+      <Wrapper>
+        <ConditionFieldGroup includeBase={false} omitEsqlQuerySplitLegend />
+      </Wrapper>
+    );
+
+    expect(screen.queryByRole('button', { name: 'Rule evaluation' })).not.toBeInTheDocument();
+    expect(screen.getByText('Group Fields')).toBeInTheDocument();
+  });
+
+  it('renders the evaluation query field when includeBase is true', () => {
+    const Wrapper = createFormWrapper({}, mockServices);
+
+    render(
+      <Wrapper>
+        <ConditionFieldGroup includeBase={true} />
+      </Wrapper>
+    );
+
+    expect(screen.queryByTestId('alertingV2EsqlQuerySplitLegend')).not.toBeInTheDocument();
+    expect(screen.getByTestId('mockEvaluationQueryField')).toBeInTheDocument();
+  });
+});

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/field_groups/condition_field_group.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/field_groups/condition_field_group.tsx
@@ -7,11 +7,10 @@
 
 import React from 'react';
 import { i18n } from '@kbn/i18n';
-import { EuiSpacer, EuiFormRow, EuiCodeBlock } from '@elastic/eui';
-import { useFormContext, useWatch } from 'react-hook-form';
-import type { FormValues } from '../types';
+import { EuiSpacer } from '@elastic/eui';
 import { FieldGroup } from './field_group';
 import { EvaluationQueryField } from '../fields/evaluation_query_field';
+import { EsqlQuerySplitLegend } from '../fields/esql_query_split_legend';
 import { GroupFieldSelect } from '../fields/group_field_select';
 import { TimeFieldSelect } from '../fields/time_field_select';
 
@@ -19,52 +18,46 @@ interface ConditionFieldGroupProps {
   /**
    * Whether to include the editable base query field.
    * When true, shows an editable ES|QL editor for the base query.
-   * When false, shows the base query as read-only (if available).
+   * When false, shows the ES|QL split legend (unless omitted — e.g. legend is in a flyout callout).
    */
   includeBase?: boolean;
+  /**
+   * When true, do not render {@link EsqlQuerySplitLegend} (shown elsewhere, e.g. `EuiCallOut` under the flyout header).
+   */
+  omitEsqlQuerySplitLegend?: boolean;
 }
 
 /**
  * Condition field group for configuring alert trigger conditions.
  *
  * This component displays:
- * - An editable ES|QL query editor (when includeBase is true) OR a read-only view of the base query
+ * - An editable ES|QL query editor (when includeBase is true), or
+ * - A legend linking Discover’s BASE / CONDITION highlights to rule semantics (when includeBase is false and not omitted).
  *
- * The full ES|QL query defines what data is being evaluated, including any
- * trigger condition (e.g. a trailing WHERE clause).
+ * The full ES|QL query is edited in Discover when includeBase is false; the form does not duplicate it.
  */
-export const ConditionFieldGroup = ({ includeBase = false }: ConditionFieldGroupProps) => {
-  const { control } = useFormContext<FormValues>();
-
-  // Read the base query from form state (initialized via useFormDefaults)
-  const baseQuery = useWatch({ control, name: 'evaluation.query.base' });
+export const ConditionFieldGroup = ({
+  includeBase = false,
+  omitEsqlQuerySplitLegend = false,
+}: ConditionFieldGroupProps) => {
+  const showInlineLegend = !includeBase && !omitEsqlQuerySplitLegend;
 
   return (
     <FieldGroup
       title={i18n.translate('xpack.alertingV2.ruleForm.condition', {
         defaultMessage: 'Rule evaluation',
       })}
+      flyoutDisplay={omitEsqlQuerySplitLegend ? 'plain' : 'accordion'}
     >
       {includeBase ? (
-        // Editable base query
         <>
           <EvaluationQueryField />
           <EuiSpacer size="m" />
         </>
       ) : (
-        // Read-only base query (only show if there's a query to display)
-        baseQuery && (
+        showInlineLegend && (
           <>
-            <EuiFormRow
-              label={i18n.translate('xpack.alertingV2.ruleForm.baseQueryLabel', {
-                defaultMessage: 'Base query',
-              })}
-              fullWidth
-            >
-              <EuiCodeBlock language="esql" fontSize="m" paddingSize="m" isCopyable>
-                {baseQuery}
-              </EuiCodeBlock>
-            </EuiFormRow>
+            <EsqlQuerySplitLegend />
             <EuiSpacer size="m" />
           </>
         )

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/field_groups/field_group.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/field_groups/field_group.test.tsx
@@ -133,6 +133,17 @@ describe('FieldGroup', () => {
       expect(screen.getByRole('button', { name: 'Test Section' })).toBeInTheDocument();
     });
 
+    it('renders children without an accordion when flyoutDisplay is plain', () => {
+      renderFieldGroup(
+        <FieldGroup title="Test Section" flyoutDisplay="plain">
+          <div>Plain child</div>
+        </FieldGroup>
+      );
+
+      expect(screen.queryByRole('button', { name: 'Test Section' })).not.toBeInTheDocument();
+      expect(screen.getByText('Plain child')).toBeInTheDocument();
+    });
+
     it('renders children when initially open (static variant)', () => {
       renderFieldGroup(
         <FieldGroup title="Test Section">

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/field_groups/field_group.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/field_groups/field_group.tsx
@@ -23,6 +23,11 @@ import { useRuleFormMeta } from '../contexts';
 interface BaseFieldGroupProps {
   title: string;
   children: React.ReactNode;
+  /**
+   * Flyout layout only. When `plain`, skips the accordion and renders `children` directly
+   * (no section title), keeping the same trailing spacer and divider as other flyout groups.
+   */
+  flyoutDisplay?: 'accordion' | 'plain';
 }
 
 type StaticFieldGroupProps = BaseFieldGroupProps & {
@@ -61,7 +66,7 @@ const isUncontrolledFieldGroup = (
 };
 
 export const FieldGroup = (props: FieldGroupProps) => {
-  const { title, children } = props;
+  const { title, children, flyoutDisplay = 'accordion' } = props;
   const { layout } = useRuleFormMeta();
   const id = useGeneratedHtmlId({ prefix: 'fieldGroup' });
   const isControlled = isControlledFieldGroup(props);
@@ -84,6 +89,16 @@ export const FieldGroup = (props: FieldGroupProps) => {
       setUncontrolledIsOpen((prev) => !prev);
     }
   }, [isControlled, isUncontrolled, props]);
+
+  if (layout === 'flyout' && flyoutDisplay === 'plain') {
+    return (
+      <>
+        {children}
+        <EuiSpacer size="m" />
+        <EuiHorizontalRule margin="xs" />
+      </>
+    );
+  }
 
   if (layout === 'flyout') {
     const accordionProps = isControlled

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/esql_query_split_legend.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/esql_query_split_legend.tsx
@@ -1,0 +1,112 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiText, useEuiTheme } from '@elastic/eui';
+import { css } from '@emotion/react';
+import { i18n } from '@kbn/i18n';
+
+/**
+ * Explains how the ES|QL query is split into BASE vs CONDITION for Alerting V2,
+ * with legend colors aligned to the Discover editor (primary for BASE, accent for CONDITION).
+ */
+export function EsqlQuerySplitLegend() {
+  const { euiTheme } = useEuiTheme();
+
+  const titleStyle = (color: string) => css`
+    font-size: 8pt;
+    line-height: 1.2;
+    font-weight: ${euiTheme.font.weight.bold};
+    letter-spacing: 0.04em;
+    color: ${color};
+  `;
+
+  const LegendRow = ({
+    borderColor,
+    fillColor,
+    titleColor,
+    title,
+    description,
+  }: {
+    borderColor: string;
+    fillColor: string;
+    titleColor: string;
+    title: string;
+    description: string;
+  }) => (
+    <EuiFlexGroup gutterSize="s" alignItems="flexStart" responsive={false}>
+      <EuiFlexItem grow={false}>
+        <div
+          aria-hidden
+          css={css`
+            width: ${euiTheme.size.s};
+            min-height: ${euiTheme.size.xl};
+            border-radius: ${euiTheme.border.radius.small};
+            border-left: ${euiTheme.border.width.thick} solid ${borderColor};
+            background-color: ${fillColor};
+            flex-shrink: 0;
+          `}
+        />
+      </EuiFlexItem>
+      <EuiFlexItem>
+        <EuiText size="xs" color="default">
+          <span css={titleStyle(titleColor)}>{title}</span>
+          {' — '}
+          {description}
+        </EuiText>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+
+  return (
+    <div data-test-subj="alertingV2EsqlQuerySplitLegend">
+      <EuiText size="xs" color="default">
+        <p>
+          {i18n.translate('xpack.alertingV2.ruleForm.esqlLegendIntro', {
+            defaultMessage:
+              'Build and refine your alerting rule directly in Discover. Your query is automatically split into:',
+          })}
+        </p>
+      </EuiText>
+      <EuiSpacer size="s" />
+      <LegendRow
+        borderColor={euiTheme.colors.borderStrongPrimary}
+        fillColor={euiTheme.colors.backgroundLightPrimary}
+        titleColor={euiTheme.colors.primaryText}
+        title={i18n.translate('xpack.alertingV2.ruleForm.esqlLegendBaseTitle', {
+          defaultMessage: 'BASE',
+        })}
+        description={i18n.translate('xpack.alertingV2.ruleForm.esqlLegendBaseDescription', {
+          defaultMessage:
+            'Defines groups and values (everything before the alert WHERE clause), so you can view what exists',
+        })}
+      />
+      <EuiSpacer size="xs" />
+      <LegendRow
+        borderColor={euiTheme.colors.borderStrongAccent}
+        fillColor={euiTheme.colors.backgroundLightAccent}
+        titleColor={euiTheme.colors.accentText}
+        title={i18n.translate('xpack.alertingV2.ruleForm.esqlLegendConditionTitle', {
+          defaultMessage: 'CONDITION',
+        })}
+        description={i18n.translate('xpack.alertingV2.ruleForm.esqlLegendConditionDescription', {
+          defaultMessage:
+            'The alert filter (usually the last WHERE clause). It controls when the rule runs for each group.',
+        })}
+      />
+      <EuiSpacer size="s" />
+      <EuiText size="xs" color="default">
+        <p>
+          {i18n.translate('xpack.alertingV2.ruleForm.esqlLegendFooter', {
+            defaultMessage:
+              "A smart initial split is applied, but you're always in control. If needed, adjust CONDITION directly in the editor using right click actions.",
+          })}
+        </p>
+      </EuiText>
+    </div>
+  );
+}

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/gui_rule_form.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/gui_rule_form.test.tsx
@@ -13,8 +13,12 @@ import { RULE_FORM_ID } from './constants';
 
 // Mock field groups to avoid complex dependencies
 jest.mock('./field_groups/condition_field_group', () => ({
-  ConditionFieldGroup: (props: { includeBase?: boolean }) => (
-    <div data-test-subj="mockConditionFieldGroup" data-include-base={String(props.includeBase)}>
+  ConditionFieldGroup: (props: { includeBase?: boolean; omitEsqlQuerySplitLegend?: boolean }) => (
+    <div
+      data-test-subj="mockConditionFieldGroup"
+      data-include-base={String(props.includeBase)}
+      data-omit-esql-legend={String(props.omitEsqlQuerySplitLegend)}
+    >
       Condition Field Group
     </div>
   ),
@@ -121,6 +125,24 @@ describe('GuiRuleForm', () => {
 
       const conditionGroup = screen.getByTestId('mockConditionFieldGroup');
       expect(conditionGroup).toHaveAttribute('data-include-base', 'true');
+    });
+
+    it('passes omitEsqlQuerySplitLegend to ConditionFieldGroup', () => {
+      render(<GuiRuleForm {...defaultProps} includeQueryEditor={false} omitEsqlQuerySplitLegend />, {
+        wrapper: createFormWrapper(),
+      });
+
+      const conditionGroup = screen.getByTestId('mockConditionFieldGroup');
+      expect(conditionGroup).toHaveAttribute('data-omit-esql-legend', 'true');
+    });
+
+    it('defaults omitEsqlQuerySplitLegend to false', () => {
+      render(<GuiRuleForm {...defaultProps} />, { wrapper: createFormWrapper() });
+
+      expect(screen.getByTestId('mockConditionFieldGroup')).toHaveAttribute(
+        'data-omit-esql-legend',
+        'false'
+      );
     });
   });
 

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/gui_rule_form.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/gui_rule_form.tsx
@@ -21,6 +21,10 @@ export interface GuiRuleFormProps {
   onSubmit: (values: FormValues) => void;
   /** Whether to include the ES|QL query editor (default: true) */
   includeQueryEditor?: boolean;
+  /**
+   * When true, the ES|QL BASE/CONDITION legend is not rendered in Rule evaluation (e.g. it is shown in a flyout `EuiCallOut` instead).
+   */
+  omitEsqlQuerySplitLegend?: boolean;
 }
 
 /**
@@ -35,14 +39,21 @@ export interface GuiRuleFormProps {
  *
  * Requires a FormProvider context with FormValues type to be present in the component tree.
  */
-export const GuiRuleForm = ({ onSubmit, includeQueryEditor = true }: GuiRuleFormProps) => {
+export const GuiRuleForm = ({
+  onSubmit,
+  includeQueryEditor = true,
+  omitEsqlQuerySplitLegend = false,
+}: GuiRuleFormProps) => {
   const { handleSubmit } = useFormContext<FormValues>();
 
   return (
     <EuiForm id={RULE_FORM_ID} component="form" onSubmit={handleSubmit(onSubmit)}>
       <RuleDetailsFieldGroup />
       <EuiSpacer size="m" />
-      <ConditionFieldGroup includeBase={includeQueryEditor} />
+      <ConditionFieldGroup
+        includeBase={includeQueryEditor}
+        omitEsqlQuerySplitLegend={omitEsqlQuerySplitLegend}
+      />
       <EuiSpacer size="m" />
       <RuleExecutionFieldGroup />
       <EuiSpacer size="m" />

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/rule_form.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/rule_form.test.tsx
@@ -45,13 +45,16 @@ jest.mock('./gui_rule_form', () => ({
   GuiRuleForm: ({
     onSubmit,
     includeQueryEditor,
+    omitEsqlQuerySplitLegend,
   }: {
     onSubmit: () => void;
     includeQueryEditor?: boolean;
+    omitEsqlQuerySplitLegend?: boolean;
   }) => (
     <form
       id="ruleV2Form"
       data-test-subj="mockGuiRuleForm"
+      data-omit-esql-legend={String(omitEsqlQuerySplitLegend)}
       onSubmit={(e) => {
         e.preventDefault();
         onSubmit();
@@ -124,6 +127,20 @@ describe('RuleForm', () => {
       render(<RuleForm {...defaultProps} />, { wrapper: createFormWrapper() });
 
       expect(screen.getByText('Query Editor')).toBeInTheDocument();
+    });
+
+    it('passes omitEsqlQuerySplitLegend to GuiRuleForm', () => {
+      render(<RuleForm {...defaultProps} omitEsqlQuerySplitLegend />, {
+        wrapper: createFormWrapper(),
+      });
+
+      expect(screen.getByTestId('mockGuiRuleForm')).toHaveAttribute('data-omit-esql-legend', 'true');
+    });
+
+    it('defaults omitEsqlQuerySplitLegend to false on GuiRuleForm', () => {
+      render(<RuleForm {...defaultProps} />, { wrapper: createFormWrapper() });
+
+      expect(screen.getByTestId('mockGuiRuleForm')).toHaveAttribute('data-omit-esql-legend', 'false');
     });
   });
 

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/rule_form.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/rule_form.tsx
@@ -43,6 +43,10 @@ export interface RuleFormProps {
   onCancel?: () => void;
   /** Whether to include the ES|QL query editor (default: true) */
   includeQueryEditor?: boolean;
+  /**
+   * When true, the ES|QL BASE/CONDITION legend is not rendered in Rule evaluation (e.g. shown in a flyout `EuiCallOut` instead).
+   */
+  omitEsqlQuerySplitLegend?: boolean;
   /** Whether to include YAML editor toggle (default: false) */
   includeYaml?: boolean;
   isDisabled?: boolean;
@@ -68,6 +72,7 @@ const RuleFormContent = ({
   onSubmit: externalOnSubmit,
   onSuccess,
   includeQueryEditor = true,
+  omitEsqlQuerySplitLegend = false,
   includeYaml = false,
   isDisabled = false,
   isSubmitting: externalIsSubmitting = false,
@@ -170,7 +175,11 @@ const RuleFormContent = ({
           isSubmitting={isSubmitting}
         />
       ) : (
-        <GuiRuleForm onSubmit={onSubmit} includeQueryEditor={includeQueryEditor} />
+        <GuiRuleForm
+          onSubmit={onSubmit}
+          includeQueryEditor={includeQueryEditor}
+          omitEsqlQuerySplitLegend={omitEsqlQuerySplitLegend}
+        />
       )}
 
       {includeSubmission && (


### PR DESCRIPTION
## Summary
Draft PR from fork `joana-cps/kibana` — work in progress on alert-rule ES|QL integration.

### ES|QL editor (Discover alert flow)
- Visual split between **BASE** (primary) and **CONDITION** (accent), gutter labels, and margin spacing.
- Custom context menu: set selection as rule condition, reset to automatic split, copy BASE / copy CONDITION.
- Split plan helpers, copy segments, and unit tests.

### Alerting v2 flyout
- Callout title and ES|QL split legend copy; flyout layout refinements.

### Wiring
- Discover, unified search, and Redux state pass override where needed.

---
*Draft — opened to preserve progress.*

Made with [Cursor](https://cursor.com)