### PR TITLE
Fix OAS path parameters to always set `required: true`

### DIFF
--- a/src/platform/packages/shared/kbn-router-to-openapispec/src/oas_converter/kbn_config_schema/lib.test.ts
+++ b/src/platform/packages/shared/kbn-router-to-openapispec/src/oas_converter/kbn_config_schema/lib.test.ts
@@ -217,7 +217,7 @@ describe('convertPathParameters', () => {
         {
           in: 'path',
           name: 'a',
-          required: false,
+          required: true,
           schema: {
             type: 'string',
           },

--- a/src/platform/packages/shared/kbn-router-to-openapispec/src/oas_converter/kbn_config_schema/lib.ts
+++ b/src/platform/packages/shared/kbn-router-to-openapispec/src/oas_converter/kbn_config_schema/lib.ts
@@ -138,7 +138,7 @@ const convertObjectMembersToParameterObjects = (
     return {
       name: schemaKey,
       in: isPathParameter ? 'path' : 'query',
-      required: isPathParameter ? !paramSchema.optional : isSubSchemaRequired,
+      required: isPathParameter || isSubSchemaRequired,
       schema: finalSchema,
       description,
     };


### PR DESCRIPTION
## Summary

Changes `convertObjectMembersToParameterObjects` in `kbn-router-to-openapispec` to unconditionally set `required: true` for path parameters, instead of deriving it from the schema's optionality. The OpenAPI 3.0 spec requires all path parameters to be required, regardless of whether the route defines them as optional internally.

Fixes https://github.com/elastic/kibana/issues/264568
Relates to https://github.com/elastic/kibana/issues/256462

<details>
<summary>How to test this</summary>

Capture the OAS snapshot and verify no path parameters have `required: false`:
  ```
  node scripts/capture_oas_snapshot --no-serverless
  ```
  Inspect `oas_docs/bundle.json` for the `POST /api/actions/connector/{id}` and `POST /api/alerting/rule/{id}` parameters. Both should now show `"required": true`.

</details>

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
  - N/A, no UI text changes
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
  - N/A, no user-facing feature changes
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
  - Existing test updated to reflect corrected behavior; all 224 tests pass
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
  - N/A, no config changes
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
  - OAS spec accuracy fix only, no runtime behavior change
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
  - N/A, deterministic unit test update only
- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

This PR carries low risk, OAS spec accuracy fix only with no runtime code changes.

| Risk | Severity | Likelihood | Mitigation |
|------|----------|------------|------------|
| Path parameters on optional `{id?}` routes now show `required: true` in the OAS spec | Low | Already happening | Correct behavior per OpenAPI 3.0. The route still accepts requests without `{id}` at runtime. |

No runtime code changes. No config changes. No breaking API changes.

### Release note

N/A, OAS generator fix, no user-facing changes.

Co-Validated by: Claude Opus 4.6