### PR TITLE
unskip failing home interstitial test - increase timeout to wait for load animation to finish

### DIFF
--- a/src/platform/test/functional/page_objects/home_page.ts
+++ b/src/platform/test/functional/page_objects/home_page.ts
@@ -71,7 +71,10 @@ export class HomePageObject extends FtrService {
     const animSpeedExtraSlow = 500;
     await new Promise((resolve) => setTimeout(resolve, animSpeedExtraSlow));
     return this.retry.try(async () => {
-      return await this.testSubjects.isDisplayed('homeWelcomeInterstitial', animSpeedExtraSlow * 4);
+      return await this.testSubjects.isDisplayed(
+        'homeWelcomeInterstitial',
+        animSpeedExtraSlow * 16
+      );
     });
   }
 


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/229498

This change addresses test runs that fail because the page has not fully loaded. These test runs created PNG artifacts such as:

- <img width="1200" height="661" alt="image" src="https://github.com/user-attachments/assets/3e299194-b41b-4787-a51d-7380e91c3517" />
- <img width="1200" height="661" alt="image" src="https://github.com/user-attachments/assets/11fb8a13-690f-4a3b-aecf-e5adc2e7cbda" />



A "partially greyed out" welcome is the signature of a fade-in animation caught mid-transition — exactly what the page object's own comment warns about:

```
// This element inherits style...with an animation duration set to $euiAnimSpeedExtraSlow
// hence we setup a delay so the interstitial has enough time to fade in
```

Test command:
```
node scripts/functional_tests --bail --kibana-install-dir ../kibana-build-xpack --config=src/platform/test/functional/apps/home/config.ts 
```

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- ~~[ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~~
- ~~[ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~~
- ~~[ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios~~
- ~~[ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~~
- ~~[ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.~~
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- ~~[ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)~~
- ~~[ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.~~
