### PR TITLE
[9.2] [UII] Increase schema array limits (#264552)

### DIFF
--- a/oas_docs/bundle.json
+++ b/oas_docs/bundle.json
@@ -10297,7 +10297,7 @@
                               ],
                               "type": "object"
                             },
-                            "maxItems": 10,
+                            "maxItems": 100,
                             "type": "array"
                           },
                           "has_fleet_server": {
@@ -11344,7 +11344,7 @@
                       ],
                       "type": "object"
                     },
-                    "maxItems": 10,
+                    "maxItems": 100,
                     "type": "array"
                   },
                   "has_fleet_server": {
@@ -11672,7 +11672,7 @@
                             ],
                             "type": "object"
                           },
-                          "maxItems": 10,
+                          "maxItems": 100,
                           "type": "array"
                         },
                         "has_fleet_server": {
@@ -12748,7 +12748,7 @@
                               ],
                               "type": "object"
                             },
-                            "maxItems": 10,
+                            "maxItems": 100,
                             "type": "array"
                           },
                           "has_fleet_server": {
@@ -14077,7 +14077,7 @@
                             ],
                             "type": "object"
                           },
-                          "maxItems": 10,
+                          "maxItems": 100,
                           "type": "array"
                         },
                         "has_fleet_server": {
@@ -15124,7 +15124,7 @@
                       ],
                       "type": "object"
                     },
-                    "maxItems": 10,
+                    "maxItems": 100,
                     "type": "array"
                   },
                   "has_fleet_server": {
@@ -15452,7 +15452,7 @@
                             ],
                             "type": "object"
                           },
-                          "maxItems": 10,
+                          "maxItems": 100,
                           "type": "array"
                         },
                         "has_fleet_server": {
@@ -16623,7 +16623,7 @@
                             ],
                             "type": "object"
                           },
-                          "maxItems": 10,
+                          "maxItems": 100,
                           "type": "array"
                         },
                         "has_fleet_server": {
@@ -25286,7 +25286,7 @@
                             "items": {
                               "type": "string"
                             },
-                            "maxItems": 10,
+                            "maxItems": 100,
                             "type": "array"
                           },
                           "conditions": {
@@ -25347,7 +25347,7 @@
                                   ],
                                   "type": "object"
                                 },
-                                "maxItems": 10,
+                                "maxItems": 100,
                                 "type": "array"
                               },
                               "fields": {
@@ -25363,7 +25363,7 @@
                                   ],
                                   "type": "object"
                                 },
-                                "maxItems": 10,
+                                "maxItems": 100,
                                 "type": "array"
                               }
                             },
@@ -25403,7 +25403,7 @@
                               ],
                               "type": "object"
                             },
-                            "maxItems": 10,
+                            "maxItems": 100,
                             "type": "array"
                           },
                           "id": {
@@ -25749,7 +25749,7 @@
                               "additionalProperties": {},
                               "type": "object"
                             },
-                            "maxItems": 100,
+                            "maxItems": 1000,
                             "type": "array"
                           },
                           "readme": {
@@ -26971,7 +26971,7 @@
                               ],
                               "type": "object"
                             },
-                            "maxItems": 10,
+                            "maxItems": 100,
                             "type": "array"
                           },
                           "name": {
@@ -27488,14 +27488,14 @@
                                 "items": {
                                   "type": "string"
                                 },
-                                "maxItems": 100,
+                                "maxItems": 1000,
                                 "type": "array"
                               },
                               "asset_types": {
                                 "items": {
                                   "type": "string"
                                 },
-                                "maxItems": 10,
+                                "maxItems": 100,
                                 "type": "array"
                               },
                               "text": {
@@ -27518,7 +27518,7 @@
                           "items": {
                             "type": "string"
                           },
-                          "maxItems": 10,
+                          "maxItems": 100,
                           "type": "array"
                         },
                         "conditions": {
@@ -27579,7 +27579,7 @@
                                 ],
                                 "type": "object"
                               },
-                              "maxItems": 10,
+                              "maxItems": 100,
                               "type": "array"
                             },
                             "fields": {
@@ -27595,7 +27595,7 @@
                                 ],
                                 "type": "object"
                               },
-                              "maxItems": 10,
+                              "maxItems": 100,
                               "type": "array"
                             }
                           },
@@ -27639,7 +27639,7 @@
                             ],
                             "type": "object"
                           },
-                          "maxItems": 10,
+                          "maxItems": 100,
                           "type": "array"
                         },
                         "installationInfo": {
@@ -27991,7 +27991,7 @@
                             "additionalProperties": {},
                             "type": "object"
                           },
-                          "maxItems": 100,
+                          "maxItems": 1000,
                           "type": "array"
                         },
                         "readme": {
@@ -28033,7 +28033,7 @@
                             ],
                             "type": "object"
                           },
-                          "maxItems": 10,
+                          "maxItems": 100,
                           "type": "array"
                         },
                         "signature_path": {
@@ -28476,14 +28476,14 @@
                                 "items": {
                                   "type": "string"
                                 },
-                                "maxItems": 100,
+                                "maxItems": 1000,
                                 "type": "array"
                               },
                               "asset_types": {
                                 "items": {
                                   "type": "string"
                                 },
-                                "maxItems": 10,
+                                "maxItems": 100,
                                 "type": "array"
                               },
                               "text": {
@@ -28506,7 +28506,7 @@
                           "items": {
                             "type": "string"
                           },
-                          "maxItems": 10,
+                          "maxItems": 100,
                           "type": "array"
                         },
                         "conditions": {
@@ -28567,7 +28567,7 @@
                                 ],
                                 "type": "object"
                               },
-                              "maxItems": 10,
+                              "maxItems": 100,
                               "type": "array"
                             },
                             "fields": {
@@ -28583,7 +28583,7 @@
                                 ],
                                 "type": "object"
                               },
-                              "maxItems": 10,
+                              "maxItems": 100,
                               "type": "array"
                             }
                           },
@@ -28627,7 +28627,7 @@
                             ],
                             "type": "object"
                           },
-                          "maxItems": 10,
+                          "maxItems": 100,
                           "type": "array"
                         },
                         "installationInfo": {
@@ -28979,7 +28979,7 @@
                             "additionalProperties": {},
                             "type": "object"
                           },
-                          "maxItems": 100,
+                          "maxItems": 1000,
                           "type": "array"
                         },
                         "readme": {
@@ -29021,7 +29021,7 @@
                             ],
                             "type": "object"
                           },
-                          "maxItems": 10,
+                          "maxItems": 100,
                           "type": "array"
                         },
                         "signature_path": {

--- a/x-pack/platform/plugins/shared/fleet/server/types/models/agent_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/types/models/agent_policy.ts
@@ -154,7 +154,7 @@ export const AgentPolicyBaseSchema = {
           description:
             'User defined data tags that are added to all of the inputs. The values can be strings or numbers.',
         },
-        maxSize: 10,
+        maxSize: 100,
       }
     )
   ),

--- a/x-pack/platform/plugins/shared/fleet/server/types/models/preconfiguration.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/types/models/preconfiguration.ts
@@ -164,7 +164,7 @@ export const PreconfiguredFleetProxiesSchema = schema.arrayOf(
     certificate: schema.maybe(schema.string()),
     certificate_key: schema.maybe(schema.string()),
   }),
-  { defaultValue: [], maxSize: 10 }
+  { defaultValue: [], maxSize: 100 }
 );
 
 export const PreconfiguredAgentPoliciesSchema = schema.arrayOf(
@@ -249,7 +249,7 @@ export const PreconfiguredSpaceSettingsSchema = schema.arrayOf(
             }
           },
         }),
-        { maxSize: 10 }
+        { maxSize: 100 }
       )
     ),
   }),

--- a/x-pack/platform/plugins/shared/fleet/server/types/rest_spec/epm.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/types/rest_spec/epm.ts
@@ -151,7 +151,7 @@ export const PackageInfoSchema = schema
     version: schema.string(),
     description: schema.maybe(schema.string()),
     title: schema.string(),
-    icons: schema.maybe(schema.arrayOf(PackageIconSchema, { maxSize: 10 })),
+    icons: schema.maybe(schema.arrayOf(PackageIconSchema, { maxSize: 100 })),
     conditions: schema.maybe(
       schema.object({
         kibana: schema.maybe(schema.object({ version: schema.maybe(schema.string()) })),
@@ -181,9 +181,9 @@ export const PackageInfoSchema = schema
       schema.arrayOf(schema.recordOf(schema.string(), schema.any()), { maxSize: 1000 })
     ),
     policy_templates: schema.maybe(
-      schema.arrayOf(schema.recordOf(schema.string(), schema.any()), { maxSize: 100 })
+      schema.arrayOf(schema.recordOf(schema.string(), schema.any()), { maxSize: 1000 })
     ),
-    categories: schema.maybe(schema.arrayOf(schema.string(), { maxSize: 10 })),
+    categories: schema.maybe(schema.arrayOf(schema.string(), { maxSize: 100 })),
     owner: schema.maybe(
       schema.object({
         github: schema.maybe(schema.string()),
@@ -211,10 +211,10 @@ export const PackageInfoSchema = schema
     discovery: schema.maybe(
       schema.object({
         fields: schema.maybe(
-          schema.arrayOf(schema.object({ name: schema.string() }), { maxSize: 10 })
+          schema.arrayOf(schema.object({ name: schema.string() }), { maxSize: 100 })
         ),
         datasets: schema.maybe(
-          schema.arrayOf(schema.object({ name: schema.string() }), { maxSize: 10 })
+          schema.arrayOf(schema.object({ name: schema.string() }), { maxSize: 100 })
         ),
       })
     ),
@@ -239,7 +239,7 @@ export const InstalledPackageSchema = schema.object({
   status: schema.string(),
   title: schema.maybe(schema.string()),
   description: schema.maybe(schema.string()),
-  icons: schema.maybe(schema.arrayOf(PackageIconSchema, { maxSize: 10 })),
+  icons: schema.maybe(schema.arrayOf(PackageIconSchema, { maxSize: 100 })),
   dataStreams: schema.arrayOf(
     schema.object({
       name: schema.string(),
@@ -318,7 +318,7 @@ export const GetPackageInfoSchema = PackageInfoSchema.extends({
   licensePath: schema.maybe(schema.string()),
   keepPoliciesUpToDate: schema.maybe(schema.boolean()),
   license: schema.maybe(schema.string()),
-  screenshots: schema.maybe(schema.arrayOf(PackageIconSchema, { maxSize: 10 })),
+  screenshots: schema.maybe(schema.arrayOf(PackageIconSchema, { maxSize: 100 })),
   elasticsearch: schema.maybe(schema.recordOf(schema.string(), schema.any())),
   agent: schema.maybe(
     schema.object({
@@ -333,8 +333,8 @@ export const GetPackageInfoSchema = PackageInfoSchema.extends({
     schema.arrayOf(
       schema.object({
         text: schema.string(),
-        asset_types: schema.maybe(schema.arrayOf(schema.string(), { maxSize: 10 })),
-        asset_ids: schema.maybe(schema.arrayOf(schema.string(), { maxSize: 100 })),
+        asset_types: schema.maybe(schema.arrayOf(schema.string(), { maxSize: 100 })),
+        asset_ids: schema.maybe(schema.arrayOf(schema.string(), { maxSize: 1000 })),
       }),
       { maxSize: 1000 }
     )


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[UII] Increase schema array limits (#264552)](https://github.com/elastic/kibana/pull/264552)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jen Huang","email":"its.jenetic@gmail.com"},"sourceCommit":{"committedDate":"2026-04-21T23:57:54Z","message":"[UII] Increase schema array limits (#264552)\n\n## Summary\n\nResolves https://github.com/elastic/kibana/issues/259713\n\nhttps://github.com/elastic/kibana/pull/247093 introduced limits to Fleet\narray schemas. I found that this stopped Kafka integration from loading\nentirely locally due to the low limit added for package screenshots:\n\n<img width=\"2968\" height=\"752\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/afaecec2-9952-42e6-aa0b-1c373104a2e2\"\n/>\n.\n\nWhile investigating I found that\nhttps://github.com/elastic/kibana/issues/259713 was already filed for\nother issues with the new limits.\n  \nThis PR increases limits for risk areas, mostly EPM schemas to allow\ncomplete passthrough of package info, and policy schemas as some\npackages are very large and contain many streams/other config (AWS).\n\n### Checklist\n\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"bfb34e1ebfc0f2c30149344cc5e14773e1dac049","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Fleet","backport:version","v9.4.0","v9.1.11","v9.5.0","v9.3.4","v9.2.9"],"title":"[UII] Increase schema array limits","number":264552,"url":"https://github.com/elastic/kibana/pull/264552","mergeCommit":{"message":"[UII] Increase schema array limits (#264552)\n\n## Summary\n\nResolves https://github.com/elastic/kibana/issues/259713\n\nhttps://github.com/elastic/kibana/pull/247093 introduced limits to Fleet\narray schemas. I found that this stopped Kafka integration from loading\nentirely locally due to the low limit added for package screenshots:\n\n<img width=\"2968\" height=\"752\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/afaecec2-9952-42e6-aa0b-1c373104a2e2\"\n/>\n.\n\nWhile investigating I found that\nhttps://github.com/elastic/kibana/issues/259713 was already filed for\nother issues with the new limits.\n  \nThis PR increases limits for risk areas, mostly EPM schemas to allow\ncomplete passthrough of package info, and policy schemas as some\npackages are very large and contain many streams/other config (AWS).\n\n### Checklist\n\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"bfb34e1ebfc0f2c30149344cc5e14773e1dac049"}},"sourceBranch":"main","suggestedTargetBranches":["9.1","9.3","9.2"],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/264869","number":264869,"state":"OPEN"},{"branch":"9.1","label":"v9.1.11","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/264552","number":264552,"mergeCommit":{"message":"[UII] Increase schema array limits (#264552)\n\n## Summary\n\nResolves https://github.com/elastic/kibana/issues/259713\n\nhttps://github.com/elastic/kibana/pull/247093 introduced limits to Fleet\narray schemas. I found that this stopped Kafka integration from loading\nentirely locally due to the low limit added for package screenshots:\n\n<img width=\"2968\" height=\"752\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/afaecec2-9952-42e6-aa0b-1c373104a2e2\"\n/>\n.\n\nWhile investigating I found that\nhttps://github.com/elastic/kibana/issues/259713 was already filed for\nother issues with the new limits.\n  \nThis PR increases limits for risk areas, mostly EPM schemas to allow\ncomplete passthrough of package info, and policy schemas as some\npackages are very large and contain many streams/other config (AWS).\n\n### Checklist\n\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"bfb34e1ebfc0f2c30149344cc5e14773e1dac049"}},{"branch":"9.3","label":"v9.3.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.2","label":"v9.2.9","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->