### PR TITLE
[9.1] [UII] Increase schema array limits (#264552)

### DIFF
--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -14975,7 +14975,7 @@ paths:
                             required:
                               - name
                               - value
-                          maxItems: 10
+                          maxItems: 100
                           type: array
                         has_fleet_server:
                           type: boolean
@@ -15218,7 +15218,7 @@ paths:
                                                   - enabled
                                                   - data_stream
                                                   - compiled_stream
-                                              maxItems: 100
+                                              maxItems: 1000
                                               type: array
                                             type:
                                               type: string
@@ -15399,7 +15399,7 @@ paths:
                                           type: string
                                       required:
                                         - id
-                                    maxItems: 100
+                                    maxItems: 1000
                                     type: array
                                   spaceIds:
                                     items:
@@ -15681,7 +15681,7 @@ paths:
                     required:
                       - name
                       - value
-                  maxItems: 10
+                  maxItems: 100
                   type: array
                 has_fleet_server:
                   type: boolean
@@ -15909,7 +15909,7 @@ paths:
                           required:
                             - name
                             - value
-                        maxItems: 10
+                        maxItems: 100
                         type: array
                       has_fleet_server:
                         type: boolean
@@ -16152,7 +16152,7 @@ paths:
                                                 - enabled
                                                 - data_stream
                                                 - compiled_stream
-                                            maxItems: 100
+                                            maxItems: 1000
                                             type: array
                                           type:
                                             type: string
@@ -16333,7 +16333,7 @@ paths:
                                         type: string
                                     required:
                                       - id
-                                  maxItems: 100
+                                  maxItems: 1000
                                   type: array
                                 spaceIds:
                                   items:
@@ -16634,7 +16634,7 @@ paths:
                             required:
                               - name
                               - value
-                          maxItems: 10
+                          maxItems: 100
                           type: array
                         has_fleet_server:
                           type: boolean
@@ -16877,7 +16877,7 @@ paths:
                                                   - enabled
                                                   - data_stream
                                                   - compiled_stream
-                                              maxItems: 100
+                                              maxItems: 1000
                                               type: array
                                             type:
                                               type: string
@@ -17058,7 +17058,7 @@ paths:
                                           type: string
                                       required:
                                         - id
-                                    maxItems: 100
+                                    maxItems: 1000
                                     type: array
                                   spaceIds:
                                     items:
@@ -17338,7 +17338,7 @@ paths:
                           required:
                             - name
                             - value
-                        maxItems: 10
+                        maxItems: 100
                         type: array
                       has_fleet_server:
                         type: boolean
@@ -17581,7 +17581,7 @@ paths:
                                                 - enabled
                                                 - data_stream
                                                 - compiled_stream
-                                            maxItems: 100
+                                            maxItems: 1000
                                             type: array
                                           type:
                                             type: string
@@ -17762,7 +17762,7 @@ paths:
                                         type: string
                                     required:
                                       - id
-                                  maxItems: 100
+                                  maxItems: 1000
                                   type: array
                                 spaceIds:
                                   items:
@@ -18043,7 +18043,7 @@ paths:
                     required:
                       - name
                       - value
-                  maxItems: 10
+                  maxItems: 100
                   type: array
                 has_fleet_server:
                   type: boolean
@@ -18271,7 +18271,7 @@ paths:
                           required:
                             - name
                             - value
-                        maxItems: 10
+                        maxItems: 100
                         type: array
                       has_fleet_server:
                         type: boolean
@@ -18514,7 +18514,7 @@ paths:
                                                 - enabled
                                                 - data_stream
                                                 - compiled_stream
-                                            maxItems: 100
+                                            maxItems: 1000
                                             type: array
                                           type:
                                             type: string
@@ -18695,7 +18695,7 @@ paths:
                                         type: string
                                     required:
                                       - id
-                                  maxItems: 100
+                                  maxItems: 1000
                                   type: array
                                 spaceIds:
                                   items:
@@ -19057,7 +19057,7 @@ paths:
                           required:
                             - name
                             - value
-                        maxItems: 10
+                        maxItems: 100
                         type: array
                       has_fleet_server:
                         type: boolean
@@ -19300,7 +19300,7 @@ paths:
                                                 - enabled
                                                 - data_stream
                                                 - compiled_stream
-                                            maxItems: 100
+                                            maxItems: 1000
                                             type: array
                                           type:
                                             type: string
@@ -19481,7 +19481,7 @@ paths:
                                         type: string
                                     required:
                                       - id
-                                  maxItems: 100
+                                  maxItems: 1000
                                   type: array
                                 spaceIds:
                                   items:
@@ -24258,7 +24258,7 @@ paths:
                         categories:
                           items:
                             type: string
-                          maxItems: 10
+                          maxItems: 100
                           type: array
                         conditions:
                           additionalProperties: true
@@ -24302,7 +24302,7 @@ paths:
                                     type: string
                                 required:
                                   - name
-                              maxItems: 10
+                              maxItems: 100
                               type: array
                         download:
                           type: string
@@ -24327,7 +24327,7 @@ paths:
                                 type: string
                             required:
                               - src
-                          maxItems: 10
+                          maxItems: 100
                           type: array
                         id:
                           type: string
@@ -24564,7 +24564,7 @@ paths:
                           items:
                             additionalProperties: {}
                             type: object
-                          maxItems: 100
+                          maxItems: 1000
                           type: array
                         readme:
                           type: string
@@ -25434,12 +25434,12 @@ paths:
                             asset_ids:
                               items:
                                 type: string
-                              maxItems: 100
+                              maxItems: 1000
                               type: array
                             asset_types:
                               items:
                                 type: string
-                              maxItems: 10
+                              maxItems: 100
                               type: array
                             text:
                               type: string
@@ -25453,7 +25453,7 @@ paths:
                       categories:
                         items:
                           type: string
-                        maxItems: 10
+                        maxItems: 100
                         type: array
                       conditions:
                         additionalProperties: true
@@ -25497,7 +25497,7 @@ paths:
                                   type: string
                               required:
                                 - name
-                            maxItems: 10
+                            maxItems: 100
                             type: array
                       download:
                         type: string
@@ -25525,7 +25525,7 @@ paths:
                               type: string
                           required:
                             - src
-                        maxItems: 10
+                        maxItems: 100
                         type: array
                       installationInfo:
                         additionalProperties: true
@@ -25766,7 +25766,7 @@ paths:
                         items:
                           additionalProperties: {}
                           type: object
-                        maxItems: 100
+                        maxItems: 1000
                         type: array
                       readme:
                         type: string
@@ -25795,7 +25795,7 @@ paths:
                               type: string
                           required:
                             - src
-                        maxItems: 10
+                        maxItems: 100
                         type: array
                       signature_path:
                         type: string
@@ -26083,12 +26083,12 @@ paths:
                             asset_ids:
                               items:
                                 type: string
-                              maxItems: 100
+                              maxItems: 1000
                               type: array
                             asset_types:
                               items:
                                 type: string
-                              maxItems: 10
+                              maxItems: 100
                               type: array
                             text:
                               type: string
@@ -26102,7 +26102,7 @@ paths:
                       categories:
                         items:
                           type: string
-                        maxItems: 10
+                        maxItems: 100
                         type: array
                       conditions:
                         additionalProperties: true
@@ -26146,7 +26146,7 @@ paths:
                                   type: string
                               required:
                                 - name
-                            maxItems: 10
+                            maxItems: 100
                             type: array
                       download:
                         type: string
@@ -26174,7 +26174,7 @@ paths:
                               type: string
                           required:
                             - src
-                        maxItems: 10
+                        maxItems: 100
                         type: array
                       installationInfo:
                         additionalProperties: true
@@ -26415,7 +26415,7 @@ paths:
                         items:
                           additionalProperties: {}
                           type: object
-                        maxItems: 100
+                        maxItems: 1000
                         type: array
                       readme:
                         type: string
@@ -26444,7 +26444,7 @@ paths:
                               type: string
                           required:
                             - src
-                        maxItems: 10
+                        maxItems: 100
                         type: array
                       signature_path:
                         type: string
@@ -26990,7 +26990,7 @@ paths:
                                 type: string
                             required:
                               - src
-                          maxItems: 10
+                          maxItems: 100
                           type: array
                         name:
                           type: string
@@ -33227,7 +33227,7 @@ paths:
                                         - enabled
                                         - data_stream
                                         - compiled_stream
-                                    maxItems: 100
+                                    maxItems: 1000
                                     type: array
                                   type:
                                     type: string
@@ -33408,7 +33408,7 @@ paths:
                                 type: string
                             required:
                               - id
-                          maxItems: 100
+                          maxItems: 1000
                           type: array
                         spaceIds:
                           items:
@@ -33663,7 +33663,7 @@ paths:
                                 - enabled
                                 - data_stream
                                 - compiled_stream
-                            maxItems: 100
+                            maxItems: 1000
                             type: array
                           type:
                             type: string
@@ -34117,7 +34117,7 @@ paths:
                                       - enabled
                                       - data_stream
                                       - compiled_stream
-                                  maxItems: 100
+                                  maxItems: 1000
                                   type: array
                                 type:
                                   type: string
@@ -34298,7 +34298,7 @@ paths:
                               type: string
                           required:
                             - id
-                        maxItems: 100
+                        maxItems: 1000
                         type: array
                       spaceIds:
                         items:
@@ -34602,7 +34602,7 @@ paths:
                                         - enabled
                                         - data_stream
                                         - compiled_stream
-                                    maxItems: 100
+                                    maxItems: 1000
                                     type: array
                                   type:
                                     type: string
@@ -34783,7 +34783,7 @@ paths:
                                 type: string
                             required:
                               - id
-                          maxItems: 100
+                          maxItems: 1000
                           type: array
                         spaceIds:
                           items:
@@ -35117,7 +35117,7 @@ paths:
                                       - enabled
                                       - data_stream
                                       - compiled_stream
-                                  maxItems: 100
+                                  maxItems: 1000
                                   type: array
                                 type:
                                   type: string
@@ -35298,7 +35298,7 @@ paths:
                               type: string
                           required:
                             - id
-                        maxItems: 100
+                        maxItems: 1000
                         type: array
                       spaceIds:
                         items:
@@ -35555,7 +35555,7 @@ paths:
                                 - enabled
                                 - data_stream
                                 - compiled_stream
-                            maxItems: 100
+                            maxItems: 1000
                             type: array
                           type:
                             type: string
@@ -35576,7 +35576,7 @@ paths:
                         required:
                           - type
                           - enabled
-                      maxItems: 100
+                      maxItems: 1000
                       type: array
                     is_managed:
                       type: boolean
@@ -36006,7 +36006,7 @@ paths:
                                       - enabled
                                       - data_stream
                                       - compiled_stream
-                                  maxItems: 100
+                                  maxItems: 1000
                                   type: array
                                 type:
                                   type: string
@@ -36187,7 +36187,7 @@ paths:
                               type: string
                           required:
                             - id
-                        maxItems: 100
+                        maxItems: 1000
                         type: array
                       spaceIds:
                         items:
@@ -36809,7 +36809,7 @@ paths:
                                               - enabled
                                               - data_stream
                                               - compiled_stream
-                                          maxItems: 100
+                                          maxItems: 1000
                                           type: array
                                         type:
                                           type: string
@@ -36990,7 +36990,7 @@ paths:
                                       type: string
                                   required:
                                     - id
-                                maxItems: 100
+                                maxItems: 1000
                                 type: array
                               spaceIds:
                                 items:
@@ -37214,7 +37214,7 @@ paths:
                                           - enabled
                                           - data_stream
                                           - compiled_stream
-                                      maxItems: 100
+                                      maxItems: 1000
                                       type: array
                                     type:
                                       type: string
@@ -37326,7 +37326,7 @@ paths:
                                       type: string
                                   required:
                                     - id
-                                maxItems: 100
+                                maxItems: 1000
                                 type: array
                               supports_agentless:
                                 default: false

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -17235,7 +17235,7 @@ paths:
                             required:
                               - name
                               - value
-                          maxItems: 10
+                          maxItems: 100
                           type: array
                         has_fleet_server:
                           type: boolean
@@ -17927,7 +17927,7 @@ paths:
                     required:
                       - name
                       - value
-                  maxItems: 10
+                  maxItems: 100
                   type: array
                 has_fleet_server:
                   type: boolean
@@ -18155,7 +18155,7 @@ paths:
                           required:
                             - name
                             - value
-                        maxItems: 10
+                        maxItems: 100
                         type: array
                       has_fleet_server:
                         type: boolean
@@ -18866,7 +18866,7 @@ paths:
                             required:
                               - name
                               - value
-                          maxItems: 10
+                          maxItems: 100
                           type: array
                         has_fleet_server:
                           type: boolean
@@ -19556,7 +19556,7 @@ paths:
                           required:
                             - name
                             - value
-                        maxItems: 10
+                        maxItems: 100
                         type: array
                       has_fleet_server:
                         type: boolean
@@ -20247,7 +20247,7 @@ paths:
                     required:
                       - name
                       - value
-                  maxItems: 10
+                  maxItems: 100
                   type: array
                 has_fleet_server:
                   type: boolean
@@ -20475,7 +20475,7 @@ paths:
                           required:
                             - name
                             - value
-                        maxItems: 10
+                        maxItems: 100
                         type: array
                       has_fleet_server:
                         type: boolean
@@ -21246,7 +21246,7 @@ paths:
                           required:
                             - name
                             - value
-                        maxItems: 10
+                        maxItems: 100
                         type: array
                       has_fleet_server:
                         type: boolean
@@ -26433,7 +26433,7 @@ paths:
                         categories:
                           items:
                             type: string
-                          maxItems: 10
+                          maxItems: 100
                           type: array
                         conditions:
                           additionalProperties: true
@@ -26477,7 +26477,7 @@ paths:
                                     type: string
                                 required:
                                   - name
-                              maxItems: 10
+                              maxItems: 100
                               type: array
                         download:
                           type: string
@@ -26502,7 +26502,7 @@ paths:
                                 type: string
                             required:
                               - src
-                          maxItems: 10
+                          maxItems: 100
                           type: array
                         id:
                           type: string
@@ -26738,7 +26738,7 @@ paths:
                           items:
                             additionalProperties: {}
                             type: object
-                          maxItems: 100
+                          maxItems: 1000
                           type: array
                         readme:
                           type: string
@@ -27608,12 +27608,12 @@ paths:
                             asset_ids:
                               items:
                                 type: string
-                              maxItems: 100
+                              maxItems: 1000
                               type: array
                             asset_types:
                               items:
                                 type: string
-                              maxItems: 10
+                              maxItems: 100
                               type: array
                             text:
                               type: string
@@ -27627,7 +27627,7 @@ paths:
                       categories:
                         items:
                           type: string
-                        maxItems: 10
+                        maxItems: 100
                         type: array
                       conditions:
                         additionalProperties: true
@@ -27671,7 +27671,7 @@ paths:
                                   type: string
                               required:
                                 - name
-                            maxItems: 10
+                            maxItems: 100
                             type: array
                       download:
                         type: string
@@ -27699,7 +27699,7 @@ paths:
                               type: string
                           required:
                             - src
-                        maxItems: 10
+                        maxItems: 100
                         type: array
                       installationInfo:
                         additionalProperties: true
@@ -27939,7 +27939,7 @@ paths:
                         items:
                           additionalProperties: {}
                           type: object
-                        maxItems: 100
+                        maxItems: 1000
                         type: array
                       readme:
                         type: string
@@ -27968,7 +27968,7 @@ paths:
                               type: string
                           required:
                             - src
-                        maxItems: 10
+                        maxItems: 100
                         type: array
                       signature_path:
                         type: string
@@ -28256,12 +28256,12 @@ paths:
                             asset_ids:
                               items:
                                 type: string
-                              maxItems: 100
+                              maxItems: 1000
                               type: array
                             asset_types:
                               items:
                                 type: string
-                              maxItems: 10
+                              maxItems: 100
                               type: array
                             text:
                               type: string
@@ -28275,7 +28275,7 @@ paths:
                       categories:
                         items:
                           type: string
-                        maxItems: 10
+                        maxItems: 100
                         type: array
                       conditions:
                         additionalProperties: true
@@ -28319,7 +28319,7 @@ paths:
                                   type: string
                               required:
                                 - name
-                            maxItems: 10
+                            maxItems: 100
                             type: array
                       download:
                         type: string
@@ -28347,7 +28347,7 @@ paths:
                               type: string
                           required:
                             - src
-                        maxItems: 10
+                        maxItems: 100
                         type: array
                       installationInfo:
                         additionalProperties: true
@@ -28587,7 +28587,7 @@ paths:
                         items:
                           additionalProperties: {}
                           type: object
-                        maxItems: 100
+                        maxItems: 1000
                         type: array
                       readme:
                         type: string
@@ -28616,7 +28616,7 @@ paths:
                               type: string
                           required:
                             - src
-                        maxItems: 10
+                        maxItems: 100
                         type: array
                       signature_path:
                         type: string
@@ -29162,7 +29162,7 @@ paths:
                                 type: string
                             required:
                               - src
-                          maxItems: 10
+                          maxItems: 100
                           type: array
                         name:
                           type: string

--- a/x-pack/platform/plugins/shared/fleet/server/types/models/agent_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/types/models/agent_policy.ts
@@ -154,7 +154,7 @@ export const AgentPolicyBaseSchema = {
           description:
             'User defined data tags that are added to all of the inputs. The values can be strings or numbers.',
         },
-        maxSize: 10,
+        maxSize: 100,
       }
     )
   ),

--- a/x-pack/platform/plugins/shared/fleet/server/types/models/preconfiguration.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/types/models/preconfiguration.ts
@@ -164,7 +164,7 @@ export const PreconfiguredFleetProxiesSchema = schema.arrayOf(
     certificate: schema.maybe(schema.string()),
     certificate_key: schema.maybe(schema.string()),
   }),
-  { defaultValue: [], maxSize: 10 }
+  { defaultValue: [], maxSize: 100 }
 );
 
 export const PreconfiguredAgentPoliciesSchema = schema.arrayOf(
@@ -249,7 +249,7 @@ export const PreconfiguredSpaceSettingsSchema = schema.arrayOf(
             }
           },
         }),
-        { maxSize: 10 }
+        { maxSize: 100 }
       )
     ),
   }),

--- a/x-pack/platform/plugins/shared/fleet/server/types/rest_spec/epm.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/types/rest_spec/epm.ts
@@ -147,7 +147,7 @@ export const PackageInfoSchema = schema
     version: schema.string(),
     description: schema.maybe(schema.string()),
     title: schema.string(),
-    icons: schema.maybe(schema.arrayOf(PackageIconSchema, { maxSize: 10 })),
+    icons: schema.maybe(schema.arrayOf(PackageIconSchema, { maxSize: 100 })),
     conditions: schema.maybe(
       schema.object({
         kibana: schema.maybe(schema.object({ version: schema.maybe(schema.string()) })),
@@ -177,9 +177,9 @@ export const PackageInfoSchema = schema
       schema.arrayOf(schema.recordOf(schema.string(), schema.any()), { maxSize: 1000 })
     ),
     policy_templates: schema.maybe(
-      schema.arrayOf(schema.recordOf(schema.string(), schema.any()), { maxSize: 100 })
+      schema.arrayOf(schema.recordOf(schema.string(), schema.any()), { maxSize: 1000 })
     ),
-    categories: schema.maybe(schema.arrayOf(schema.string(), { maxSize: 10 })),
+    categories: schema.maybe(schema.arrayOf(schema.string(), { maxSize: 100 })),
     owner: schema.maybe(
       schema.object({
         github: schema.maybe(schema.string()),
@@ -207,7 +207,7 @@ export const PackageInfoSchema = schema
     discovery: schema.maybe(
       schema.object({
         fields: schema.maybe(
-          schema.arrayOf(schema.object({ name: schema.string() }), { maxSize: 10 })
+          schema.arrayOf(schema.object({ name: schema.string() }), { maxSize: 100 })
         ),
       })
     ),
@@ -232,7 +232,7 @@ export const InstalledPackageSchema = schema.object({
   status: schema.string(),
   title: schema.maybe(schema.string()),
   description: schema.maybe(schema.string()),
-  icons: schema.maybe(schema.arrayOf(PackageIconSchema, { maxSize: 10 })),
+  icons: schema.maybe(schema.arrayOf(PackageIconSchema, { maxSize: 100 })),
   dataStreams: schema.arrayOf(
     schema.object({
       name: schema.string(),
@@ -310,7 +310,7 @@ export const GetPackageInfoSchema = PackageInfoSchema.extends({
   licensePath: schema.maybe(schema.string()),
   keepPoliciesUpToDate: schema.maybe(schema.boolean()),
   license: schema.maybe(schema.string()),
-  screenshots: schema.maybe(schema.arrayOf(PackageIconSchema, { maxSize: 10 })),
+  screenshots: schema.maybe(schema.arrayOf(PackageIconSchema, { maxSize: 100 })),
   elasticsearch: schema.maybe(schema.recordOf(schema.string(), schema.any())),
   agent: schema.maybe(
     schema.object({
@@ -325,8 +325,8 @@ export const GetPackageInfoSchema = PackageInfoSchema.extends({
     schema.arrayOf(
       schema.object({
         text: schema.string(),
-        asset_types: schema.maybe(schema.arrayOf(schema.string(), { maxSize: 10 })),
-        asset_ids: schema.maybe(schema.arrayOf(schema.string(), { maxSize: 100 })),
+        asset_types: schema.maybe(schema.arrayOf(schema.string(), { maxSize: 100 })),
+        asset_ids: schema.maybe(schema.arrayOf(schema.string(), { maxSize: 1000 })),
       }),
       { maxSize: 1000 }
     )


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[UII] Increase schema array limits (#264552)](https://github.com/elastic/kibana/pull/264552)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jen Huang","email":"its.jenetic@gmail.com"},"sourceCommit":{"committedDate":"2026-04-21T23:57:54Z","message":"[UII] Increase schema array limits (#264552)\n\n## Summary\n\nResolves https://github.com/elastic/kibana/issues/259713\n\nhttps://github.com/elastic/kibana/pull/247093 introduced limits to Fleet\narray schemas. I found that this stopped Kafka integration from loading\nentirely locally due to the low limit added for package screenshots:\n\n<img width=\"2968\" height=\"752\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/afaecec2-9952-42e6-aa0b-1c373104a2e2\"\n/>\n.\n\nWhile investigating I found that\nhttps://github.com/elastic/kibana/issues/259713 was already filed for\nother issues with the new limits.\n  \nThis PR increases limits for risk areas, mostly EPM schemas to allow\ncomplete passthrough of package info, and policy schemas as some\npackages are very large and contain many streams/other config (AWS).\n\n### Checklist\n\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"bfb34e1ebfc0f2c30149344cc5e14773e1dac049","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Fleet","backport:version","v9.4.0","v9.1.11","v9.5.0","v9.3.4","v9.2.9"],"title":"[UII] Increase schema array limits","number":264552,"url":"https://github.com/elastic/kibana/pull/264552","mergeCommit":{"message":"[UII] Increase schema array limits (#264552)\n\n## Summary\n\nResolves https://github.com/elastic/kibana/issues/259713\n\nhttps://github.com/elastic/kibana/pull/247093 introduced limits to Fleet\narray schemas. I found that this stopped Kafka integration from loading\nentirely locally due to the low limit added for package screenshots:\n\n<img width=\"2968\" height=\"752\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/afaecec2-9952-42e6-aa0b-1c373104a2e2\"\n/>\n.\n\nWhile investigating I found that\nhttps://github.com/elastic/kibana/issues/259713 was already filed for\nother issues with the new limits.\n  \nThis PR increases limits for risk areas, mostly EPM schemas to allow\ncomplete passthrough of package info, and policy schemas as some\npackages are very large and contain many streams/other config (AWS).\n\n### Checklist\n\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"bfb34e1ebfc0f2c30149344cc5e14773e1dac049"}},"sourceBranch":"main","suggestedTargetBranches":["9.1","9.3","9.2"],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/264869","number":264869,"state":"OPEN"},{"branch":"9.1","label":"v9.1.11","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/264552","number":264552,"mergeCommit":{"message":"[UII] Increase schema array limits (#264552)\n\n## Summary\n\nResolves https://github.com/elastic/kibana/issues/259713\n\nhttps://github.com/elastic/kibana/pull/247093 introduced limits to Fleet\narray schemas. I found that this stopped Kafka integration from loading\nentirely locally due to the low limit added for package screenshots:\n\n<img width=\"2968\" height=\"752\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/afaecec2-9952-42e6-aa0b-1c373104a2e2\"\n/>\n.\n\nWhile investigating I found that\nhttps://github.com/elastic/kibana/issues/259713 was already filed for\nother issues with the new limits.\n  \nThis PR increases limits for risk areas, mostly EPM schemas to allow\ncomplete passthrough of package info, and policy schemas as some\npackages are very large and contain many streams/other config (AWS).\n\n### Checklist\n\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"bfb34e1ebfc0f2c30149344cc5e14773e1dac049"}},{"branch":"9.3","label":"v9.3.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.2","label":"v9.2.9","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->