### PR TITLE
[Security Solution] fix wrong LineClamp usage in alert flyout

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/alert_description.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/alert_description.tsx
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { css } from '@emotion/react';
 import { EuiButtonEmpty, EuiFlexGroup, EuiFlexItem, EuiTitle } from '@elastic/eui';
 import { type DataTableRecord, getFieldValue } from '@kbn/discover-utils';
 import { i18n } from '@kbn/i18n';
@@ -13,7 +14,6 @@ import { EVENT_KIND } from '@kbn/rule-data-utils';
 import type { FC } from 'react';
 import React, { useMemo } from 'react';
 import { EventKind } from '../constants/event_kinds';
-import { LineClamp } from '../../../common/components/line_clamp';
 import {
   ALERT_DESCRIPTION_DETAILS_TEST_ID,
   ALERT_DESCRIPTION_TITLE_TEST_ID,
@@ -123,7 +123,17 @@ export const AlertDescription: FC<AlertDescriptionProps> = ({
         </EuiTitle>
       </EuiFlexItem>
       <EuiFlexItem data-test-subj={ALERT_DESCRIPTION_DETAILS_TEST_ID}>
-        <LineClamp>{isAlert ? alertRuleDescription : '-'}</LineClamp>
+        <p
+          css={css`
+            word-break: break-word;
+            display: -webkit-box;
+            -webkit-line-clamp: 3;
+            -webkit-box-orient: vertical;
+            overflow: hidden;
+          `}
+        >
+          {isAlert ? alertRuleDescription : '-'}
+        </p>
       </EuiFlexItem>
     </EuiFlexGroup>
   );


### PR DESCRIPTION
## Summary

This PR fixes a small UI issue introduced by this previous [PR](https://github.com/elastic/kibana/pull/254101). We were having issues with rendering in the new flyout, and decided then to use the existing `LineClamp` component that seemed to fix the issue.

The issue ended up being something else that we fixed in another PR [here](https://github.com/elastic/kibana/pull/255943/changes#diff-dfa06a73abbdd72198cf7dbfae8493e9296b4f3d464a3abb864b284026b23d8b).

The usage of the `LineClamp` component actually introduced an annoying `Read more` button for long rule description. This was not caught during PR review as most rule description are short.

### Unwanted UI - showing the `Read more` button

<img width="430" height="449" alt="Screenshot 2026-04-21 at 8 47 26 PM" src="https://github.com/user-attachments/assets/125d8a4b-90be-40de-972f-40897c432c0c" />

<img width="435" height="620" alt="Screenshot 2026-04-21 at 8 47 17 PM" src="https://github.com/user-attachments/assets/f8776d50-d8cd-441f-983e-031766ef3b38" />

### Fix, using the previous code we've been using on the flyout of years

<img width="424" height="379" alt="Screenshot 2026-04-21 at 8 59 38 PM" src="https://github.com/user-attachments/assets/f649a9e7-ac05-445a-acf8-4511f76052c2" />

### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->