### PR TITLE
[9.2] [CVE-2026-35213] Bump @hapi/hapi to 21.4.8 to fix ReDoS in @hapi/content (#264077)

### DIFF
--- a/package.json
+++ b/package.json
@@ -165,7 +165,7 @@
     "@hapi/boom": "10.0.1",
     "@hapi/cookie": "12.0.1",
     "@hapi/h2o2": "10.0.4",
-    "@hapi/hapi": "21.4.3",
+    "@hapi/hapi": "21.4.8",
     "@hapi/hoek": "11.0.7",
     "@hapi/inert": "7.1.0",
     "@hapi/wreck": "18.1.0",

--- a/packages/kbn-cli-dev-mode/src/base_path_proxy/http1.ts
+++ b/packages/kbn-cli-dev-mode/src/base_path_proxy/http1.ts
@@ -168,7 +168,11 @@ export class Http1BasePathProxyServer implements BasePathProxyServer {
               pathname: `${this.httpConfig.basePath}/${request.params.kbnPath}`,
               query: request.query,
             }),
-            headers: request.headers,
+            headers: Object.fromEntries(
+              Object.entries(request.headers).flatMap(([k, v]) =>
+                v === undefined ? [] : [[k, Array.isArray(v) ? v.join(', ') : v]]
+              )
+            ),
           }),
         },
       },

--- a/src/core/packages/execution-context/server-internal/src/execution_context_container.ts
+++ b/src/core/packages/execution-context/server-internal/src/execution_context_container.ts
@@ -15,10 +15,10 @@ import type { IExecutionContextContainer } from '@kbn/core-execution-context-ser
 export const BAGGAGE_HEADER = 'x-kbn-context';
 
 export function getParentContextFrom(
-  headers: Record<string, string>
+  headers: Record<string, string | string[] | undefined>
 ): KibanaExecutionContext | undefined {
   const header = headers[BAGGAGE_HEADER];
-  return parseHeader(header);
+  return parseHeader(Array.isArray(header) ? header[0] : header);
 }
 
 function parseHeader(header?: string): KibanaExecutionContext | undefined {

--- a/src/core/packages/execution-context/server-internal/src/execution_context_service.ts
+++ b/src/core/packages/execution-context/server-internal/src/execution_context_service.ts
@@ -23,7 +23,9 @@ import { ExecutionContextContainer, getParentContextFrom } from './execution_con
  * @internal
  */
 export interface IExecutionContext {
-  getParentContextFrom(headers: Record<string, string>): KibanaExecutionContext | undefined;
+  getParentContextFrom(
+    headers: Record<string, string | string[] | undefined>
+  ): KibanaExecutionContext | undefined;
 
   setRequestId(requestId: string): void;
 

--- a/src/core/packages/http/router-server-internal/src/request.ts
+++ b/src/core/packages/http/router-server-internal/src/request.ts
@@ -176,7 +176,9 @@ export class CoreKibanaRequest<
     this.injectHostInfo(request);
 
     this.url = request.url ?? new URL('https://fake-request/url');
-    this.headers = isRealReq ? deepFreeze({ ...request.headers }) : request.headers;
+    this.headers = isRealReq
+      ? (deepFreeze({ ...request.headers }) as unknown as Headers)
+      : (request.headers as unknown as Headers);
     this.isSystemRequest = this.headers['kbn-system-request'] === 'true';
     this.isFakeRequest = !isRealReq;
     // set to false if elasticInternalOrigin is explicitly set to false

--- a/src/core/packages/http/router-server-internal/src/router.test.ts
+++ b/src/core/packages/http/router-server-internal/src/router.test.ts
@@ -157,8 +157,8 @@ describe('Router', () => {
       const [{ handler }] = router.getRoutes();
       await handler(
         createRequestMock({
-          params: { foo: 1 },
-          query: { foo: 1 },
+          params: { foo: '1' },
+          query: { foo: '1' },
           payload: { foo: 1 },
         }),
         mockResponseToolkit
@@ -293,8 +293,8 @@ describe('Router', () => {
     for (let i = 0; i < 10; i++) {
       await handler(
         createRequestMock({
-          params: { foo: 1 },
-          query: { foo: 1 },
+          params: { foo: '1' },
+          query: { foo: '1' },
           payload: { foo: 1 },
         }),
         mockResponseToolkit

--- a/src/core/packages/http/server-internal/src/logging/get_response_log.ts
+++ b/src/core/packages/http/server-internal/src/logging/get_response_log.ts
@@ -26,7 +26,7 @@ const FORBIDDEN_HEADERS = [
 ];
 const REDACTED_HEADER_TEXT = '[REDACTED]';
 
-type HapiHeaders = Record<string, string | string[]>;
+type HapiHeaders = Record<string, string | string[] | undefined>;
 
 // We are excluding sensitive headers by default, until we have a log filtering mechanism.
 function redactSensitiveHeaders(key: string, value: string | string[]): string | string[] {
@@ -35,13 +35,13 @@ function redactSensitiveHeaders(key: string, value: string | string[]): string |
 
 // Shallow clone the headers so they are not mutated if filtered by a RewriteAppender.
 function cloneAndFilterHeaders(headers?: HapiHeaders) {
-  const result = {} as HapiHeaders;
+  const result = {} as Record<string, string | string[]>;
   if (headers) {
     for (const key of Object.keys(headers)) {
-      result[key] = redactSensitiveHeaders(
-        key,
-        Array.isArray(headers[key]) ? [...headers[key]] : headers[key]
-      );
+      const value = headers[key];
+      if (value !== undefined) {
+        result[key] = redactSensitiveHeaders(key, Array.isArray(value) ? [...value] : value);
+      }
     }
   }
   return result;
@@ -108,7 +108,9 @@ export function getEcsResponseLog(request: Request, log: Logger) {
       query,
     },
     user_agent: {
-      original: request.headers['user-agent'],
+      original: Array.isArray(request.headers['user-agent'])
+        ? request.headers['user-agent'][0]
+        : request.headers['user-agent'],
     },
     trace: traceId ? { id: traceId } : undefined,
   };

--- a/src/platform/packages/private/kbn-hapi-mocks/src/request.ts
+++ b/src/platform/packages/private/kbn-hapi-mocks/src/request.ts
@@ -21,7 +21,7 @@ export const createRequestMock = (customization: DeepPartial<Request> = {}): Req
   );
   if (customization.query) {
     Object.entries(customization.query).forEach(([key, value]) => {
-      url.searchParams.set(key, value);
+      url.searchParams.set(key, Array.isArray(value) ? value.join(',') : String(value ?? ''));
     });
   }
 

--- a/src/platform/packages/shared/kbn-server-http-tools/src/get_request_id.ts
+++ b/src/platform/packages/shared/kbn-server-http-tools/src/get_request_id.ts
@@ -15,9 +15,10 @@ export function getRequestId(
   { allowFromAnyIp, ipAllowlist }: { allowFromAnyIp: boolean; ipAllowlist: string[] }
 ): string {
   const remoteAddress = request.raw.req.socket?.remoteAddress;
+  const opaqueId = request.headers['x-opaque-id'];
   return allowFromAnyIp ||
     // socket may be undefined in integration tests that connect via the http listener directly
     (remoteAddress && ipAllowlist.includes(remoteAddress))
-    ? request.headers['x-opaque-id'] ?? uuidv4()
+    ? (Array.isArray(opaqueId) ? opaqueId[0] : opaqueId) ?? uuidv4()
     : uuidv4();
 }

--- a/x-pack/solutions/security/plugins/security_solution/scripts/endpoint/api_emulator/emulator_plugins/crowdstrike/routes/host_actions_route.ts
+++ b/x-pack/solutions/security/plugins/security_solution/scripts/endpoint/api_emulator/emulator_plugins/crowdstrike/routes/host_actions_route.ts
@@ -43,6 +43,7 @@ const hostActionsInvalidAgentIdError = async () => {
 
 const hostActionsHandler: ExternalEdrServerEmulatorRouteHandlerMethod<
   {},
+  {},
   CrowdstrikeHostActionsParams
 > = async () => {
   return {

--- a/x-pack/solutions/security/plugins/security_solution/scripts/endpoint/api_emulator/external_edr_server_emulator.types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/scripts/endpoint/api_emulator/external_edr_server_emulator.types.ts
@@ -29,7 +29,7 @@ export interface ExternalEdrServerEmulatorCoreServices {
 
 export type ExternalEdrServerEmulatorRouteHandlerMethod<
   TParams extends HapiTypes.Request['params'] = any,
-  TQuery extends HapiTypes.Request['query'] = any,
+  TQuery extends object = any,
   TPayload extends HapiTypes.Request['payload'] = any,
   TPre extends HapiTypes.Request['pre'] = { services: ExternalEdrServerEmulatorCoreServices }
 > = EmulatorServerRouteHandlerMethod<TParams, TQuery, TPayload, TPre>;

--- a/x-pack/solutions/security/plugins/security_solution/scripts/endpoint/api_emulator/lib/emulator_server.types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/scripts/endpoint/api_emulator/lib/emulator_server.types.ts
@@ -42,10 +42,10 @@ export interface EmulatorServerPlugin<TServices extends Record<string, any> = an
 
 export interface EmulatorServerRequest<
   TParams extends HapiTypes.Request['params'] = any,
-  TQuery extends HapiTypes.Request['query'] = any,
+  TQuery extends object = any,
   TPayload extends HapiTypes.Request['payload'] = any,
   TPre extends HapiTypes.Request['pre'] = any
-> extends HapiTypes.Request {
+> extends Omit<HapiTypes.Request, 'query'> {
   params: TParams;
   query: TQuery;
   payload: TPayload;
@@ -54,7 +54,7 @@ export interface EmulatorServerRequest<
 
 export type EmulatorServerRouteHandlerMethod<
   TParams extends HapiTypes.Request['params'] = any,
-  TQuery extends HapiTypes.Request['query'] = any,
+  TQuery extends object = any,
   TPayload extends HapiTypes.Request['payload'] = any,
   TPre extends HapiTypes.Request['pre'] = any
 > = (
@@ -65,7 +65,7 @@ export type EmulatorServerRouteHandlerMethod<
 
 export interface EmulatorServerRouteDefinition<
   TParams extends HapiTypes.Request['params'] = any,
-  TQuery extends HapiTypes.Request['query'] = any,
+  TQuery extends object = any,
   TPayload extends HapiTypes.Request['payload'] = any,
   TPre extends HapiTypes.Request['pre'] = any
 > extends Omit<HapiTypes.ServerRoute, 'handler'> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3316,19 +3316,6 @@
     "@hapi/validate" "^2.0.1"
     "@hapi/wreck" "^18.0.1"
 
-"@hapi/statehood@^8.2.1":
-  version "8.2.1"
-  resolved "https://registry.yarnpkg.com/@hapi/statehood/-/statehood-8.2.1.tgz#4435f11f78873f07aa7422a95386ae9802a914e1"
-  integrity sha512-xf72TG/QINW26jUu+uL5H+crE1o8GplIgfPWwPZhnAGJzetIVAQEQYvzq+C0aEVHg5/lMMtQ+L9UryuSa5Yjkg==
-  dependencies:
-    "@hapi/boom" "^10.0.1"
-    "@hapi/bounce" "^3.0.1"
-    "@hapi/bourne" "^3.0.0"
-    "@hapi/cryptiles" "^6.0.1"
-    "@hapi/hoek" "^11.0.2"
-    "@hapi/iron" "^7.0.1"
-    "@hapi/validate" "^2.0.1"
-
 "@hapi/hapi@21.4.8", "@hapi/hapi@^21.1.0":
   version "21.4.8"
   resolved "https://registry.yarnpkg.com/@hapi/hapi/-/hapi-21.4.8.tgz#3f92f9999dd344f754411d752054c569202cb5b7"
@@ -3452,10 +3439,10 @@
     "@hapi/bounce" "^3.0.1"
     "@hapi/hoek" "^11.0.2"
 
-"@hapi/statehood@^8.2.0":
-  version "8.2.0"
-  resolved "https://registry.yarnpkg.com/@hapi/statehood/-/statehood-8.2.0.tgz#f9e9367ad1a02a975dc6b24dad728af19962da0f"
-  integrity sha512-63JlCVIrsmuunWsyc3OeuFO+gH6v56swLCl7OM1w09l/exQKPUxSUDF2Slkuw8k91nIzr0A2/aPvjLOWf9ksrg==
+"@hapi/statehood@^8.2.1":
+  version "8.2.1"
+  resolved "https://registry.yarnpkg.com/@hapi/statehood/-/statehood-8.2.1.tgz#4435f11f78873f07aa7422a95386ae9802a914e1"
+  integrity sha512-xf72TG/QINW26jUu+uL5H+crE1o8GplIgfPWwPZhnAGJzetIVAQEQYvzq+C0aEVHg5/lMMtQ+L9UryuSa5Yjkg==
   dependencies:
     "@hapi/boom" "^10.0.1"
     "@hapi/bounce" "^3.0.1"
@@ -3479,7 +3466,7 @@
     "@hapi/wreck" "^18.1.0"
 
 "@hapi/teamwork@^6.0.0", "@hapi/teamwork@^6.0.1":
-  version "6.0.1"
+  version "6.0.0"
   resolved "https://registry.yarnpkg.com/@hapi/teamwork/-/teamwork-6.0.0.tgz#b3a173cf811ba59fc6ee22318a1b51f4561f06e0"
   integrity sha512-05HumSy3LWfXpmJ9cr6HzwhAavrHkJ1ZRCmNE2qJMihdM5YcWreWPfyN0yKT2ZjCM92au3ZkuodjBxOibxM67A==
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3465,12 +3465,7 @@
     "@hapi/pez" "^6.1.1"
     "@hapi/wreck" "^18.1.0"
 
-"@hapi/teamwork@^6.0.0":
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/@hapi/teamwork/-/teamwork-6.0.0.tgz#b3a173cf811ba59fc6ee22318a1b51f4561f06e0"
-  integrity sha512-05HumSy3LWfXpmJ9cr6HzwhAavrHkJ1ZRCmNE2qJMihdM5YcWreWPfyN0yKT2ZjCM92au3ZkuodjBxOibxM67A==
-
-"@hapi/teamwork@^6.0.1":
+"@hapi/teamwork@^6.0.0", "@hapi/teamwork@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/@hapi/teamwork/-/teamwork-6.0.1.tgz#2f6496170f47abd8446930447f64e64ba1d57d3f"
   integrity sha512-52OXRslUfYwXAOG8k58f2h2ngXYQGP0x5RPOo+eWA/FtyLgHjGMrE3+e9LSXP/0q2YfHAK5wj9aA9DTy1K+kyQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3272,10 +3272,10 @@
     "@hapi/podium" "^5.0.0"
     "@hapi/validate" "^2.0.1"
 
-"@hapi/content@^6.0.0":
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/@hapi/content/-/content-6.0.0.tgz#2427af3bac8a2f743512fce2a70cbdc365af29df"
-  integrity sha512-CEhs7j+H0iQffKfe5Htdak5LBOz/Qc8TRh51cF+BFv0qnuph3Em4pjGVzJMkI2gfTDdlJKWJISGWS1rK34POGA==
+"@hapi/content@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@hapi/content/-/content-6.0.1.tgz#b0afe7523c9f754726852204dd2d32ec1578cb64"
+  integrity sha512-lQ2vOoFMNYxwKVnKf+3Pi3PfoviM4EJYlT9JbrBPfEc0xKMiVDqqXF8UTE1S1oKhHQliWSP5t6zTKNlmaXBGcQ==
   dependencies:
     "@hapi/boom" "^10.0.0"
 
@@ -3316,10 +3316,23 @@
     "@hapi/validate" "^2.0.1"
     "@hapi/wreck" "^18.0.1"
 
-"@hapi/hapi@21.4.3", "@hapi/hapi@^21.1.0":
-  version "21.4.3"
-  resolved "https://registry.yarnpkg.com/@hapi/hapi/-/hapi-21.4.3.tgz#e829eef35659d7618831f4431382229107a71d07"
-  integrity sha512-Q7g0ZY4gxU69wabFKH75qR0AFOdiOECj6vGqTHBSO5Lrwe6TwD8r9LkYQIbvtG8N423VDpdVsiZP8MnBwmD6Hw==
+"@hapi/statehood@^8.2.1":
+  version "8.2.1"
+  resolved "https://registry.yarnpkg.com/@hapi/statehood/-/statehood-8.2.1.tgz#4435f11f78873f07aa7422a95386ae9802a914e1"
+  integrity sha512-xf72TG/QINW26jUu+uL5H+crE1o8GplIgfPWwPZhnAGJzetIVAQEQYvzq+C0aEVHg5/lMMtQ+L9UryuSa5Yjkg==
+  dependencies:
+    "@hapi/boom" "^10.0.1"
+    "@hapi/bounce" "^3.0.1"
+    "@hapi/bourne" "^3.0.0"
+    "@hapi/cryptiles" "^6.0.1"
+    "@hapi/hoek" "^11.0.2"
+    "@hapi/iron" "^7.0.1"
+    "@hapi/validate" "^2.0.1"
+
+"@hapi/hapi@21.4.8", "@hapi/hapi@^21.1.0":
+  version "21.4.8"
+  resolved "https://registry.yarnpkg.com/@hapi/hapi/-/hapi-21.4.8.tgz#3f92f9999dd344f754411d752054c569202cb5b7"
+  integrity sha512-l93IrEG4iQyM+yKdngWmkPtajkJGM81yfinmSFmiaNHG+r1fgsWaewwcE1hhsFnqPrVZpU8Y3PiVJMb6uT+01Q==
   dependencies:
     "@hapi/accept" "^6.0.3"
     "@hapi/ammo" "^6.0.1"
@@ -3334,9 +3347,9 @@
     "@hapi/podium" "^5.0.2"
     "@hapi/shot" "^6.0.2"
     "@hapi/somever" "^4.1.1"
-    "@hapi/statehood" "^8.2.0"
-    "@hapi/subtext" "^8.1.1"
-    "@hapi/teamwork" "^6.0.0"
+    "@hapi/statehood" "^8.2.1"
+    "@hapi/subtext" "^8.1.2"
+    "@hapi/teamwork" "^6.0.1"
     "@hapi/topo" "^6.0.2"
     "@hapi/validate" "^2.0.1"
 
@@ -3398,15 +3411,15 @@
     "@hapi/hoek" "^11.0.2"
     "@hapi/vise" "^5.0.1"
 
-"@hapi/pez@^6.1.0":
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/@hapi/pez/-/pez-6.1.0.tgz#64d9f95580fc7d8f1d13437ee4a8676709954fda"
-  integrity sha512-+FE3sFPYuXCpuVeHQ/Qag1b45clR2o54QoonE/gKHv9gukxQ8oJJZPR7o3/ydDTK6racnCJXxOyT1T93FCJMIg==
+"@hapi/pez@^6.1.1":
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/@hapi/pez/-/pez-6.1.1.tgz#d99a4f62291b1c008179bb534791b8dfc59f7f8d"
+  integrity sha512-yg2OS1tC0S1sHXvhUtWsfRn6lrKl9jKtRhZ+EI0woOW/gqX5vM2PZ1459ypCvCYDRLJ9nIyueeEH5MJV1ZDqIg==
   dependencies:
     "@hapi/b64" "^6.0.1"
     "@hapi/boom" "^10.0.1"
-    "@hapi/content" "^6.0.0"
-    "@hapi/hoek" "^11.0.2"
+    "@hapi/content" "^6.0.1"
+    "@hapi/hoek" "^11.0.7"
     "@hapi/nigel" "^5.0.1"
 
 "@hapi/pinpoint@^2.0.1":
@@ -3452,21 +3465,21 @@
     "@hapi/iron" "^7.0.1"
     "@hapi/validate" "^2.0.1"
 
-"@hapi/subtext@^8.1.1":
-  version "8.1.1"
-  resolved "https://registry.yarnpkg.com/@hapi/subtext/-/subtext-8.1.1.tgz#48b93ab9196f7bf5902060ec92459fc354acba6e"
-  integrity sha512-ex1Y2s/KuJktS8Ww0k6XJ5ysSKrzNym4i5pDVuCwlSgHHviHUsT1JNzE6FYhNU9TTHSNdyfue/t2m89bpkX9Jw==
+"@hapi/subtext@^8.1.2":
+  version "8.1.2"
+  resolved "https://registry.yarnpkg.com/@hapi/subtext/-/subtext-8.1.2.tgz#f625391fed73c76f156f020169d4c30f485a89d9"
+  integrity sha512-2x71YJHmFpCjhIhfiNZdKp63nh3xRPp7RrwH7JoO9R4Sd0DRzzRU/VfX2fMmUR7jcoS5qNET1WyGIaqKpMu/ng==
   dependencies:
     "@hapi/boom" "^10.0.1"
     "@hapi/bourne" "^3.0.0"
-    "@hapi/content" "^6.0.0"
+    "@hapi/content" "^6.0.1"
     "@hapi/file" "^3.0.0"
-    "@hapi/hoek" "^11.0.2"
-    "@hapi/pez" "^6.1.0"
-    "@hapi/wreck" "^18.0.1"
+    "@hapi/hoek" "^11.0.7"
+    "@hapi/pez" "^6.1.1"
+    "@hapi/wreck" "^18.1.0"
 
-"@hapi/teamwork@^6.0.0":
-  version "6.0.0"
+"@hapi/teamwork@^6.0.0", "@hapi/teamwork@^6.0.1":
+  version "6.0.1"
   resolved "https://registry.yarnpkg.com/@hapi/teamwork/-/teamwork-6.0.0.tgz#b3a173cf811ba59fc6ee22318a1b51f4561f06e0"
   integrity sha512-05HumSy3LWfXpmJ9cr6HzwhAavrHkJ1ZRCmNE2qJMihdM5YcWreWPfyN0yKT2ZjCM92au3ZkuodjBxOibxM67A==
 
@@ -3504,7 +3517,7 @@
   dependencies:
     "@hapi/hoek" "^11.0.2"
 
-"@hapi/wreck@18.1.0", "@hapi/wreck@^18.0.1":
+"@hapi/wreck@18.1.0", "@hapi/wreck@^18.0.1", "@hapi/wreck@^18.1.0":
   version "18.1.0"
   resolved "https://registry.yarnpkg.com/@hapi/wreck/-/wreck-18.1.0.tgz#68e631fc7568ebefc6252d5b86cb804466c8dbe6"
   integrity sha512-0z6ZRCmFEfV/MQqkQomJ7sl/hyxvcZM7LtuVqN3vdAO4vM9eBbowl0kaqQj9EJJQab+3Uuh1GxbGIBFy4NfJ4w==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3465,10 +3465,15 @@
     "@hapi/pez" "^6.1.1"
     "@hapi/wreck" "^18.1.0"
 
-"@hapi/teamwork@^6.0.0", "@hapi/teamwork@^6.0.1":
+"@hapi/teamwork@^6.0.0":
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/@hapi/teamwork/-/teamwork-6.0.0.tgz#b3a173cf811ba59fc6ee22318a1b51f4561f06e0"
   integrity sha512-05HumSy3LWfXpmJ9cr6HzwhAavrHkJ1ZRCmNE2qJMihdM5YcWreWPfyN0yKT2ZjCM92au3ZkuodjBxOibxM67A==
+
+"@hapi/teamwork@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@hapi/teamwork/-/teamwork-6.0.1.tgz#2f6496170f47abd8446930447f64e64ba1d57d3f"
+  integrity sha512-52OXRslUfYwXAOG8k58f2h2ngXYQGP0x5RPOo+eWA/FtyLgHjGMrE3+e9LSXP/0q2YfHAK5wj9aA9DTy1K+kyQ==
 
 "@hapi/tlds@^1.1.1":
   version "1.1.2"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
- [[CVE-2026-35213] Bump @hapi/hapi to 21.4.8 to fix ReDoS in @hapi/content (#264077)](https://github.com/elastic/kibana/pull/264077)

## Summary

Fixes CVE-2026-35213 — a Regular Expression Denial of Service (ReDoS) vulnerability in `@hapi/content@6.0.0`, a transitive dependency of `@hapi/hapi`.

Upgrades `@hapi/hapi` from `21.4.3` to `21.4.8`, which cascades into patching the full vulnerable dependency chain:

| Package | Before | After | Role |
|---|---|---|---|
| `@hapi/hapi` | `21.4.3` | `21.4.8` | Direct dependency (HTTP server) |
| `@hapi/subtext` | `8.1.1` | `8.1.2` | Request body parsing |
| `@hapi/pez` | `6.1.0` | `6.1.1` | Multipart form parsing |
| `@hapi/content` | `6.0.0` | `6.0.1` | **Vulnerable package — contains the fix** |

**Tracking issue:** elastic/security#9673

Made with [Cursor](https://cursor.com)

(cherry picked from commit bbc2c334ec65264f49f4c8fce6e816a5d64845ed)