### PR TITLE
[Lens] Fix `Open in Discover` drilldowns for time based visualizations do not carry over the KQL query and DSL filters from the dashboard

### DIFF
--- a/x-pack/platform/plugins/shared/lens/public/trigger_actions/open_in_discover_helpers.ts
+++ b/x-pack/platform/plugins/shared/lens/public/trigger_actions/open_in_discover_helpers.ts
@@ -63,15 +63,17 @@ async function getDiscoverLocationParams({
     throw new Error('Underlying data is not ready');
   }
   const dataView = await dataViews.get(args.dataViewSpec.id!);
-  // we don't want to pass the DSL filters when navigating from an ES|SQL embeddable
+  // `filtersToApply` is what we pass to Discover as `filters` in the locator params: merged drilldown
+  // + Lens underlying-data filters (`args.filters`) when the panel is not text-based. For text-based
+  // (ES|QL) panels it stays `[]` so we do not attach the same constraints as Kibana DSL filter pills.
   let filtersToApply = embeddable.isTextBasedLanguage()
     ? []
     : [...(filters || []), ...args.filters];
   let timeRangeToApply = args.timeRange;
   // if the target data view is time based, attempt to split out a time range from the provided filters
-  if (dataView.isTimeBased() && dataView.timeFieldName === timeFieldName) {
+  if (timeFieldName && dataView.isTimeBased() && dataView.timeFieldName === timeFieldName) {
     const { extractTimeRange } = await import('@kbn/es-query');
-    const { restOfFilters, timeRange } = extractTimeRange(filters || [], timeFieldName);
+    const { restOfFilters, timeRange } = extractTimeRange(filtersToApply, timeFieldName);
     filtersToApply = restOfFilters;
     if (timeRange) {
       timeRangeToApply = timeRange;


### PR DESCRIPTION
## Summary

Fix https://github.com/elastic/kibana/issues/264758

Use all filters (`filtersToApply`) instead of only drilldown filters (`filters`) for time based visualizations.

## Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.