### PR TITLE
[9.4] [Agent Builder] Skills and Plugins telemetry (#264380)

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/telemetry/agent_builder_events.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/telemetry/agent_builder_events.ts
@@ -21,6 +21,8 @@ export const AGENT_BUILDER_EVENT_TYPES = {
   SkillCreated: `${TELEMETRY_PREFIX}_skill_created`,
   SkillUpdated: `${TELEMETRY_PREFIX}_skill_updated`,
   SkillDeleted: `${TELEMETRY_PREFIX}_skill_deleted`,
+  SkillInvoked: `${TELEMETRY_PREFIX}_skill_invoked`,
+  PluginImported: `${TELEMETRY_PREFIX}_plugin_imported`,
   RoundComplete: `${TELEMETRY_PREFIX}_round_complete`,
   RoundError: `${TELEMETRY_PREFIX}_round_error`,
   ToolCallSuccess: `${TELEMETRY_PREFIX}_tool_call_success`,
@@ -102,22 +104,94 @@ export interface ReportToolCreatedParams {
   tool_type: string;
 }
 
+/** Origin of a skill: `custom` for user-created via the public API, `plugin` for plugin-bundled. */
+export type SkillCreationOrigin = 'custom' | 'plugin';
+
+/** Origin of a skill at invocation time: `builtin`, `custom` (user-created), or `plugin` (plugin-installed). */
+export type SkillInvocationOrigin = 'builtin' | 'custom' | 'plugin';
+
+/**
+ * Solution area a skill belongs to. Built-in skills are classified by their `basePath`.
+ * Custom (user-created) skills are reported as `custom`. Plugin-backed skills are
+ * reported as `plugin`. `unknown` is reserved for built-ins whose `basePath` does not
+ * match any known prefix.
+ */
+export type SkillSolutionArea =
+  | 'security'
+  | 'observability'
+  | 'search'
+  | 'platform'
+  | 'custom'
+  | 'plugin'
+  | 'unknown';
+
 /** Telemetry params reported when a user-created skill is created. */
 export interface ReportSkillCreatedParams {
-  /** Identifier of the created skill. */
+  /**
+   * Identifier of the created skill, normalized for privacy. Custom skills are
+   * reported as `custom-<sha256_prefix>`; plugin-bundled creates as
+   * `plugin-<plugin_id_hash>-<sha256_prefix>`.
+   */
   skill_id: string;
+  /** Optional origin (`custom` for direct API creates, `plugin` for plugin-bundled creates). */
+  origin?: SkillCreationOrigin;
 }
 
 /** Telemetry params reported when a user-created skill is updated. */
 export interface ReportSkillUpdatedParams {
-  /** Identifier of the updated skill. */
+  /**
+   * Identifier of the updated skill, normalized for privacy. Custom skills are
+   * reported as `custom-<sha256_prefix>`; plugin-bundled updates as
+   * `plugin-<plugin_id_hash>-<sha256_prefix>`.
+   */
   skill_id: string;
+  /** Optional origin (`custom` for direct API updates, `plugin` for plugin-bundled updates). */
+  origin?: SkillCreationOrigin;
 }
 
 /** Telemetry params reported when a user-created skill is deleted. */
 export interface ReportSkillDeletedParams {
-  /** Identifier of the deleted skill. */
+  /**
+   * Identifier of the deleted skill, normalized for privacy. Custom skills are
+   * reported as `custom-<sha256_prefix>`; plugin-bundled deletes as
+   * `plugin-<plugin_id_hash>-<sha256_prefix>`.
+   */
   skill_id: string;
+  /** Optional origin (`custom` for direct API deletes, `plugin` for plugin-bundled deletes). */
+  origin?: SkillCreationOrigin;
+}
+
+/** Telemetry params reported when a skill is invoked (loaded into the active tool set). */
+export interface ReportSkillInvokedParams {
+  /**
+   * ID of the invoked skill. Built-in skills keep their ID; custom skills are reported as
+   * `custom-<sha256_prefix>`; plugin-backed skills as `plugin-<plugin_id_hash>-<sha256_prefix>`.
+   */
+  skill_id: string;
+  /** Where this skill came from. */
+  origin: SkillInvocationOrigin;
+  /** Solution area derived from the skill's `basePath` (built-ins) or origin. */
+  solution_area: SkillSolutionArea;
+  /** Normalized plugin ID. Present when `origin === 'plugin'`. */
+  plugin_id?: string;
+  /** Normalized agent ID running this skill, when known. */
+  agent_id?: string;
+  /** Conversation ID, when known. */
+  conversation_id?: string;
+  /** Agent execution ID, when known. */
+  execution_id?: string;
+  /** Number of tools dynamically registered by this skill load. */
+  tool_count: number;
+}
+
+/** Telemetry params reported when a custom plugin is imported (URL or upload). */
+export interface ReportPluginImportedParams {
+  /** Normalized plugin ID. */
+  plugin_id: string;
+  /** Where the plugin came from. */
+  source_type: 'url' | 'upload';
+  /** Number of persisted skills bundled with the plugin. */
+  skill_count: number;
 }
 
 export interface ReportToolCallSuccessParams {
@@ -158,6 +232,10 @@ export interface AgentBuilderTelemetryEventsMap {
   [AGENT_BUILDER_EVENT_TYPES.SkillUpdated]: ReportSkillUpdatedParams;
   /** Fired when a user-created skill is deleted. */
   [AGENT_BUILDER_EVENT_TYPES.SkillDeleted]: ReportSkillDeletedParams;
+  /** Fired when a skill is invoked (its tools are dynamically registered for the agent). */
+  [AGENT_BUILDER_EVENT_TYPES.SkillInvoked]: ReportSkillInvokedParams;
+  /** Fired when a custom plugin is imported. */
+  [AGENT_BUILDER_EVENT_TYPES.PluginImported]: ReportPluginImportedParams;
   [AGENT_BUILDER_EVENT_TYPES.RoundComplete]: ReportRoundCompleteParams;
   [AGENT_BUILDER_EVENT_TYPES.RoundError]: ReportRoundErrorParams;
   [AGENT_BUILDER_EVENT_TYPES.ToolCallSuccess]: ReportToolCallSuccessParams;
@@ -174,6 +252,8 @@ export type AgentBuilderTelemetryEvent =
   | EventTypeOpts<ReportSkillCreatedParams>
   | EventTypeOpts<ReportSkillUpdatedParams>
   | EventTypeOpts<ReportSkillDeletedParams>
+  | EventTypeOpts<ReportSkillInvokedParams>
+  | EventTypeOpts<ReportPluginImportedParams>
   | EventTypeOpts<ReportRoundCompleteParams>
   | EventTypeOpts<ReportRoundErrorParams>
   | EventTypeOpts<ReportToolCallSuccessParams>
@@ -189,6 +269,8 @@ export type AgentBuilderEventTypes =
   | typeof AGENT_BUILDER_EVENT_TYPES.SkillCreated
   | typeof AGENT_BUILDER_EVENT_TYPES.SkillUpdated
   | typeof AGENT_BUILDER_EVENT_TYPES.SkillDeleted
+  | typeof AGENT_BUILDER_EVENT_TYPES.SkillInvoked
+  | typeof AGENT_BUILDER_EVENT_TYPES.PluginImported
   | typeof AGENT_BUILDER_EVENT_TYPES.RoundComplete
   | typeof AGENT_BUILDER_EVENT_TYPES.RoundError
   | typeof AGENT_BUILDER_EVENT_TYPES.ToolCallSuccess
@@ -343,8 +425,16 @@ const SKILL_CREATED_EVENT: AgentBuilderTelemetryEvent = {
       type: 'keyword',
       _meta: {
         description:
-          'ID of the created skill (normalized: built-in skills keep ID, custom skills become "custom-<sha256_prefix>")',
+          'ID of the created skill (normalized: custom skills become "custom-<sha256_prefix>", plugin-bundled creates become "plugin-<plugin_id_hash>-<sha256_prefix>")',
         optional: false,
+      },
+    },
+    origin: {
+      type: 'keyword',
+      _meta: {
+        description:
+          'Origin of the created skill (custom for direct API creates, plugin for plugin-bundled creates)',
+        optional: true,
       },
     },
   },
@@ -357,8 +447,16 @@ const SKILL_UPDATED_EVENT: AgentBuilderTelemetryEvent = {
       type: 'keyword',
       _meta: {
         description:
-          'ID of the updated skill (normalized: built-in skills keep ID, custom skills become "custom-<sha256_prefix>")',
+          'ID of the updated skill (normalized: custom skills become "custom-<sha256_prefix>", plugin-bundled updates become "plugin-<plugin_id_hash>-<sha256_prefix>")',
         optional: false,
+      },
+    },
+    origin: {
+      type: 'keyword',
+      _meta: {
+        description:
+          'Origin of the updated skill (custom for direct API updates, plugin for plugin-bundled updates)',
+        optional: true,
       },
     },
   },
@@ -371,7 +469,107 @@ const SKILL_DELETED_EVENT: AgentBuilderTelemetryEvent = {
       type: 'keyword',
       _meta: {
         description:
-          'ID of the deleted skill (normalized: built-in skills keep ID, custom skills become "custom-<sha256_prefix>")',
+          'ID of the deleted skill (normalized: custom skills become "custom-<sha256_prefix>", plugin-bundled deletes become "plugin-<plugin_id_hash>-<sha256_prefix>")',
+        optional: false,
+      },
+    },
+    origin: {
+      type: 'keyword',
+      _meta: {
+        description:
+          'Origin of the deleted skill (custom for direct API deletes, plugin for plugin-bundled deletes)',
+        optional: true,
+      },
+    },
+  },
+};
+
+const SKILL_INVOKED_EVENT: AgentBuilderTelemetryEvent = {
+  eventType: AGENT_BUILDER_EVENT_TYPES.SkillInvoked,
+  schema: {
+    skill_id: {
+      type: 'keyword',
+      _meta: {
+        description:
+          'ID of the invoked skill (normalized: built-in skills keep ID, custom skills become "custom-<sha256_prefix>", plugin-backed skills become "plugin-<plugin_id_hash>-<sha256_prefix>")',
+        optional: false,
+      },
+    },
+    origin: {
+      type: 'keyword',
+      _meta: {
+        description: 'Origin of the invoked skill (builtin|custom|plugin)',
+        optional: false,
+      },
+    },
+    solution_area: {
+      type: 'keyword',
+      _meta: {
+        description:
+          'Solution area the skill belongs to (security|observability|search|platform|custom|plugin|unknown)',
+        optional: false,
+      },
+    },
+    plugin_id: {
+      type: 'keyword',
+      _meta: {
+        description: 'Normalized plugin ID, present when origin is "plugin"',
+        optional: true,
+      },
+    },
+    agent_id: {
+      type: 'keyword',
+      _meta: {
+        description:
+          'ID of the agent invoking the skill (normalized: built-in agents keep ID, custom agents become "custom-<sha256_prefix>")',
+        optional: true,
+      },
+    },
+    conversation_id: {
+      type: 'keyword',
+      _meta: {
+        description: 'Conversation ID',
+        optional: true,
+      },
+    },
+    execution_id: {
+      type: 'keyword',
+      _meta: {
+        description: 'Agent execution ID',
+        optional: true,
+      },
+    },
+    tool_count: {
+      type: 'integer',
+      _meta: {
+        description: 'Number of tools dynamically registered by this skill load',
+        optional: false,
+      },
+    },
+  },
+};
+
+const PLUGIN_IMPORTED_EVENT: AgentBuilderTelemetryEvent = {
+  eventType: AGENT_BUILDER_EVENT_TYPES.PluginImported,
+  schema: {
+    plugin_id: {
+      type: 'keyword',
+      _meta: {
+        description: 'Normalized plugin ID (custom-<sha256_prefix>)',
+        optional: false,
+      },
+    },
+    source_type: {
+      type: 'keyword',
+      _meta: {
+        description: 'Where the plugin came from (url|upload)',
+        optional: false,
+      },
+    },
+    skill_count: {
+      type: 'integer',
+      _meta: {
+        description: 'Number of persisted skills bundled with the plugin',
         optional: false,
       },
     },
@@ -764,6 +962,8 @@ export const agentBuilderServerEbtEvents: Array<EventTypeOpts<Record<string, unk
   SKILL_CREATED_EVENT,
   SKILL_UPDATED_EVENT,
   SKILL_DELETED_EVENT,
+  SKILL_INVOKED_EVENT,
+  PLUGIN_IMPORTED_EVENT,
   ROUND_COMPLETE_EVENT,
   ROUND_ERROR_EVENT,
   TOOL_CALL_SUCCESS_EVENT,

--- a/x-pack/platform/plugins/shared/agent_builder/server/hooks/skills/load_skill_tools_after_read.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/hooks/skills/load_skill_tools_after_read.test.ts
@@ -17,8 +17,15 @@ import type { InternalSkillDefinition } from '@kbn/agent-builder-server/skills';
 import { ToolManagerToolType } from '@kbn/agent-builder-server/runner';
 import type { SkillBoundedTool } from '@kbn/agent-builder-server/skills';
 import { ToolType } from '@kbn/agent-builder-common';
+import type { AnalyticsService } from '../../telemetry';
 import { createToolHandlerContextMock, type ToolHandlerContextMock } from '../../test_utils/runner';
-import { loadSkillToolsAfterRead } from './load_skill_tools_after_read';
+import { createLoadSkillToolsAfterRead } from './load_skill_tools_after_read';
+
+const createAnalyticsServiceMock = (): jest.Mocked<
+  Pick<AnalyticsService, 'reportSkillInvoked'>
+> => ({
+  reportSkillInvoked: jest.fn(),
+});
 
 const createSkillFileEntry = (
   overrides: Partial<{ path: string; skillId: string }> = {}
@@ -89,8 +96,9 @@ const createHookContext = ({
   toolHandlerContext,
 });
 
-describe('loadSkillToolsAfterRead', () => {
+describe('createLoadSkillToolsAfterRead', () => {
   let toolHandlerContext: ToolHandlerContextMock;
+  const loadSkillToolsAfterRead = createLoadSkillToolsAfterRead();
 
   beforeEach(() => {
     toolHandlerContext = createToolHandlerContextMock();
@@ -329,6 +337,138 @@ describe('loadSkillToolsAfterRead', () => {
       const context = createHookContext({ toolHandlerContext });
 
       await expect(loadSkillToolsAfterRead(context)).resolves.not.toThrow();
+      expect(toolHandlerContext.toolManager.addTools).toHaveBeenCalled();
+    });
+  });
+
+  describe('telemetry', () => {
+    let analyticsService: jest.Mocked<Pick<AnalyticsService, 'reportSkillInvoked'>>;
+    let loadSkillToolsAfterReadWithTelemetry: ReturnType<typeof createLoadSkillToolsAfterRead>;
+
+    beforeEach(() => {
+      analyticsService = createAnalyticsServiceMock();
+      loadSkillToolsAfterReadWithTelemetry = createLoadSkillToolsAfterRead({
+        analyticsService: analyticsService as unknown as AnalyticsService,
+      });
+    });
+
+    it('reports SkillInvoked with classification and the agent context from the run stack', async () => {
+      const skill = createMockSkill({
+        id: 'security-skill',
+        readonly: true,
+        basePath: 'skills/security/foo',
+        getInlineTools: jest.fn().mockReturnValue([]),
+        getRegistryTools: jest.fn().mockReturnValue([]),
+      });
+
+      toolHandlerContext.filestore.read.mockResolvedValue(
+        createSkillFileEntry({ skillId: 'security-skill' })
+      );
+      toolHandlerContext.skills.get.mockResolvedValue(skill);
+      toolHandlerContext.runContext = {
+        runId: 'run-1',
+        stack: [
+          { type: 'agent', agentId: 'my_agent', conversationId: 'conv-1', executionId: 'exec-1' },
+          { type: 'tool', toolId: 'some-tool' },
+        ],
+      };
+
+      const context = createHookContext({ toolHandlerContext });
+
+      await loadSkillToolsAfterReadWithTelemetry(context);
+
+      expect(analyticsService.reportSkillInvoked).toHaveBeenCalledWith({
+        skillId: 'security-skill',
+        origin: 'builtin',
+        solutionArea: 'security',
+        pluginId: undefined,
+        agentId: 'my_agent',
+        conversationId: 'conv-1',
+        executionId: 'exec-1',
+        toolCount: 0,
+      });
+    });
+
+    it('passes the actual tool count (inline + registry) to reportSkillInvoked', async () => {
+      const inlineTool = { id: 'inline-1', type: ToolType.builtin } as SkillBoundedTool;
+      const convertedInline = { id: 'inline-1-converted' } as any;
+      const registryTool = { id: 'registry-1' } as any;
+
+      const skill = createMockSkill({
+        getInlineTools: jest.fn().mockReturnValue([inlineTool]),
+        getRegistryTools: jest.fn().mockReturnValue(['registry-1']),
+      });
+
+      toolHandlerContext.filestore.read.mockResolvedValue(createSkillFileEntry());
+      toolHandlerContext.skills.get.mockResolvedValue(skill);
+      toolHandlerContext.skills.convertSkillTool.mockReturnValue(convertedInline);
+      toolHandlerContext.toolProvider.list.mockResolvedValue([registryTool]);
+
+      const context = createHookContext({ toolHandlerContext });
+
+      await loadSkillToolsAfterReadWithTelemetry(context);
+
+      expect(analyticsService.reportSkillInvoked).toHaveBeenCalledWith(
+        expect.objectContaining({ toolCount: 2 })
+      );
+    });
+
+    it('passes pluginId for plugin-backed skills', async () => {
+      const skill = createMockSkill({
+        id: 'my-plugin-skill',
+        readonly: false,
+        plugin_id: 'plugin-uuid-1',
+        basePath: '/skills/my-plugin',
+      });
+
+      toolHandlerContext.filestore.read.mockResolvedValue(
+        createSkillFileEntry({ skillId: 'my-plugin-skill' })
+      );
+      toolHandlerContext.skills.get.mockResolvedValue(skill);
+
+      const context = createHookContext({ toolHandlerContext });
+
+      await loadSkillToolsAfterReadWithTelemetry(context);
+
+      expect(analyticsService.reportSkillInvoked).toHaveBeenCalledWith(
+        expect.objectContaining({
+          skillId: 'my-plugin-skill',
+          origin: 'plugin',
+          solutionArea: 'plugin',
+          pluginId: 'plugin-uuid-1',
+        })
+      );
+    });
+
+    it('does not report telemetry when no analytics service is provided', async () => {
+      const skill = createMockSkill();
+
+      toolHandlerContext.filestore.read.mockResolvedValue(createSkillFileEntry());
+      toolHandlerContext.skills.get.mockResolvedValue(skill);
+
+      const context = createHookContext({ toolHandlerContext });
+
+      await loadSkillToolsAfterRead(context);
+
+      expect(analyticsService.reportSkillInvoked).not.toHaveBeenCalled();
+    });
+
+    it('does not throw and warns when reportSkillInvoked throws', async () => {
+      const skill = createMockSkill();
+
+      toolHandlerContext.filestore.read.mockResolvedValue(createSkillFileEntry());
+      toolHandlerContext.skills.get.mockResolvedValue(skill);
+      analyticsService.reportSkillInvoked.mockImplementation(() => {
+        throw new Error('boom');
+      });
+
+      const context = createHookContext({ toolHandlerContext });
+
+      await expect(loadSkillToolsAfterReadWithTelemetry(context)).resolves.not.toThrow();
+      expect(toolHandlerContext.logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to report SkillInvoked telemetry')
+      );
+      // Tools were still added even though telemetry failed.
       expect(toolHandlerContext.toolManager.addTools).toHaveBeenCalled();
     });
   });

--- a/x-pack/platform/plugins/shared/agent_builder/server/hooks/skills/load_skill_tools_after_read.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/hooks/skills/load_skill_tools_after_read.ts
@@ -7,43 +7,52 @@
 
 import type { AfterToolCallHookContext, ToolProvider } from '@kbn/agent-builder-server';
 import { filestoreTools } from '@kbn/agent-builder-common/tools';
-import type { SkillsService, ToolManager } from '@kbn/agent-builder-server/runner';
+import { getAgentFromRunContext } from '@kbn/agent-builder-server';
+import type { RunContext, SkillsService, ToolManager } from '@kbn/agent-builder-server/runner';
 import { ToolManagerToolType } from '@kbn/agent-builder-server/runner';
 import type { KibanaRequest } from '@kbn/core/server';
 import type { Logger } from '@kbn/logging';
 import { pickTools } from '../../services/execution/run_agent/utils/select_tools';
 import { isSkillFileEntry } from '../../services/execution/runner/store/volumes/skills/utils';
+import type { AnalyticsService } from '../../telemetry';
+import { classifySkill } from '../../telemetry/utils';
 
 const MAX_SKILL_REGISTRY_TOOLS = 25;
 
-export const loadSkillToolsAfterRead = async (context: AfterToolCallHookContext): Promise<void> => {
-  if (context.toolId !== filestoreTools.read) {
-    return;
-  }
+export const createLoadSkillToolsAfterRead = ({
+  analyticsService,
+}: { analyticsService?: AnalyticsService } = {}) => {
+  return async (context: AfterToolCallHookContext): Promise<void> => {
+    if (context.toolId !== filestoreTools.read) {
+      return;
+    }
 
-  const { filestore, skills, toolProvider, toolManager, request, logger } =
-    context.toolHandlerContext;
+    const { filestore, skills, toolProvider, toolManager, request, logger, runContext } =
+      context.toolHandlerContext;
 
-  const path = context.toolParams.path as string | undefined;
-  if (!path) {
-    return;
-  }
+    const path = context.toolParams.path as string | undefined;
+    if (!path) {
+      return;
+    }
 
-  const entry = await filestore.read(path);
-  if (!entry || !isSkillFileEntry(entry)) {
-    return;
-  }
+    const entry = await filestore.read(path);
+    if (!entry || !isSkillFileEntry(entry)) {
+      return;
+    }
 
-  const { skill_id: skillId } = entry.metadata;
+    const { skill_id: skillId } = entry.metadata;
 
-  await loadSkillTools({
-    skillsService: skills,
-    skillId,
-    toolProvider,
-    request,
-    toolManager,
-    logger,
-  });
+    await loadSkillTools({
+      skillsService: skills,
+      skillId,
+      toolProvider,
+      request,
+      toolManager,
+      logger,
+      runContext,
+      analyticsService,
+    });
+  };
 };
 
 const loadSkillTools = async ({
@@ -53,6 +62,8 @@ const loadSkillTools = async ({
   request,
   toolManager,
   logger,
+  runContext,
+  analyticsService,
 }: {
   skillsService: SkillsService;
   skillId: string;
@@ -60,6 +71,8 @@ const loadSkillTools = async ({
   request: KibanaRequest;
   toolManager: ToolManager;
   logger: Logger;
+  runContext: RunContext;
+  analyticsService?: AnalyticsService;
 }): Promise<void> => {
   const skill = await skillsService.get(skillId);
   if (!skill) {
@@ -91,4 +104,25 @@ const loadSkillTools = async ({
       dynamic: true,
     }
   );
+
+  if (!analyticsService) {
+    return;
+  }
+
+  try {
+    const agentContext = getAgentFromRunContext(runContext);
+    const { origin, solution_area: solutionArea } = classifySkill(skill);
+    analyticsService.reportSkillInvoked({
+      skillId: skill.id,
+      origin,
+      solutionArea,
+      pluginId: skill.plugin_id,
+      agentId: agentContext?.agentId,
+      conversationId: agentContext?.conversationId,
+      executionId: agentContext?.executionId,
+      toolCount: inlineExecutableTools.length + registryExecutableTools.length,
+    });
+  } catch (e) {
+    logger.warn(`Failed to report SkillInvoked telemetry: ${e}`);
+  }
 };

--- a/x-pack/platform/plugins/shared/agent_builder/server/hooks/skills/register_skill_tools_loader_hook.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/hooks/skills/register_skill_tools_loader_hook.ts
@@ -7,19 +7,28 @@
 
 import { HookLifecycle, HookExecutionMode } from '@kbn/agent-builder-server';
 import type { InternalSetupServices } from '../../services';
-import { loadSkillToolsAfterRead } from './load_skill_tools_after_read';
+import type { AnalyticsService } from '../../telemetry';
+import { createLoadSkillToolsAfterRead } from './load_skill_tools_after_read';
+
+export interface RegisterSkillToolsLoaderHookDeps {
+  analyticsService?: AnalyticsService;
+}
 
 /**
  * Registers a blocking afterToolCall hook that dynamically loads a skill's
- * tools into the tool manager when the agent reads a skill file.
+ * tools into the tool manager when the agent reads a skill file. Also emits
+ * a `SkillInvoked` EBT event when telemetry is available.
  */
-export const registerSkillToolsLoaderHook = (serviceSetups: InternalSetupServices): void => {
+export const registerSkillToolsLoaderHook = (
+  serviceSetups: InternalSetupServices,
+  deps: RegisterSkillToolsLoaderHookDeps = {}
+): void => {
   serviceSetups.hooks.register({
     id: 'skill-tools-loader',
     hooks: {
       [HookLifecycle.afterToolCall]: {
         mode: HookExecutionMode.blocking,
-        handler: loadSkillToolsAfterRead,
+        handler: createLoadSkillToolsAfterRead({ analyticsService: deps.analyticsService }),
       },
     },
   });

--- a/x-pack/platform/plugins/shared/agent_builder/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/plugin.ts
@@ -195,7 +195,7 @@ export class AgentBuilderPlugin
       getInternalServices,
     });
 
-    registerSkillToolsLoaderHook(serviceSetups);
+    registerSkillToolsLoaderHook(serviceSetups, { analyticsService: this.analyticsService });
 
     const smlTools = createSmlTools({
       getSmlService: () => {

--- a/x-pack/platform/plugins/shared/agent_builder/server/routes/skills.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/routes/skills.ts
@@ -205,7 +205,7 @@ export function registerSkillsRoutes({
         const { skills: skillService, auditLogService } = getInternalServices();
         const registry = await skillService.getRegistry({ request });
         const skill = await registry.create(createRequest);
-        analyticsService?.reportSkillCreated({ skillId: skill.id });
+        analyticsService?.reportSkillCreated({ skillId: skill.id, origin: 'custom' });
         auditLogService.logSkillCreated(request, { skillId: skill.id });
         const publicSkill = await internalToPublicDefinition(skill);
         return response.ok<CreateSkillResponse>({
@@ -280,7 +280,7 @@ export function registerSkillsRoutes({
         const update: UpdateSkillPayload = parseResult.data;
         const registry = await skillService.getRegistry({ request });
         const skill = await registry.update(skillId, update);
-        analyticsService?.reportSkillUpdated({ skillId: skill.id });
+        analyticsService?.reportSkillUpdated({ skillId: skill.id, origin: 'custom' });
         auditLogService.logSkillUpdated(request, { skillId: skill.id });
         const publicSkill = await internalToPublicDefinition(skill);
         return response.ok<UpdateSkillResponse>({
@@ -376,7 +376,7 @@ export function registerSkillsRoutes({
         try {
           const success = await registry.delete(skillId);
           if (success) {
-            analyticsService?.reportSkillDeleted({ skillId });
+            analyticsService?.reportSkillDeleted({ skillId, origin: 'custom' });
             auditLogService.logSkillDeleted(request, { skillId });
           } else {
             auditLogService.logSkillDeleted(request, {

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/create_services.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/create_services.ts
@@ -163,6 +163,7 @@ export class ServiceManager {
       elasticsearch,
       spaces,
       config: this.config,
+      analyticsService,
     });
 
     const runnerFactory = new RunnerFactoryImpl({

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/plugins/plugin_service.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/plugins/plugin_service.test.ts
@@ -420,9 +420,7 @@ describe('PluginsService', () => {
       it('reports PluginImported with sourceType "url" when installing from a URL', async () => {
         mockParsePluginFromUrl.mockResolvedValue(archiveWithSkills);
         mockClient.findByName.mockResolvedValue(undefined);
-        mockClient.create.mockResolvedValue(
-          createMockPersistedPlugin({ id: 'created-plugin-id' })
-        );
+        mockClient.create.mockResolvedValue(createMockPersistedPlugin({ id: 'created-plugin-id' }));
         mockSkillClient.bulkCreate.mockResolvedValue([]);
 
         await start.installPlugin({
@@ -440,9 +438,7 @@ describe('PluginsService', () => {
       it('reports PluginImported with sourceType "file" when installing from a file', async () => {
         mockParsePluginFromFile.mockResolvedValue(archiveWithSkills);
         mockClient.findByName.mockResolvedValue(undefined);
-        mockClient.create.mockResolvedValue(
-          createMockPersistedPlugin({ id: 'created-plugin-id' })
-        );
+        mockClient.create.mockResolvedValue(createMockPersistedPlugin({ id: 'created-plugin-id' }));
         mockSkillClient.bulkCreate.mockResolvedValue([]);
 
         await start.installPlugin({

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/plugins/plugin_service.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/plugins/plugin_service.test.ts
@@ -11,6 +11,7 @@ import type { KibanaRequest } from '@kbn/core/server';
 import { createPluginsService, type PluginsServiceStart } from './plugin_service';
 import type { PluginClient, PersistedPluginDefinition } from './client';
 import type { SkillClient } from '../skills/persisted/client';
+import type { AnalyticsService } from '../../telemetry';
 
 const mockRandomUUID = jest.fn().mockReturnValue('test-plugin-uuid');
 jest.mock('crypto', () => ({
@@ -96,6 +97,7 @@ describe('PluginsService', () => {
   let start: PluginsServiceStart;
   let mockClient: jest.Mocked<PluginClient>;
   let mockSkillClient: jest.Mocked<SkillClient>;
+  let mockAnalyticsService: jest.Mocked<Pick<AnalyticsService, 'reportPluginImported'>>;
   const mockRequest = {} as KibanaRequest;
 
   beforeEach(() => {
@@ -123,6 +125,10 @@ describe('PluginsService', () => {
       deleteByPluginId: jest.fn(),
     };
 
+    mockAnalyticsService = {
+      reportPluginImported: jest.fn(),
+    };
+
     mockCreateClient.mockReturnValue(mockClient);
     mockCreateSkillClient.mockReturnValue(mockSkillClient);
 
@@ -144,6 +150,7 @@ describe('PluginsService', () => {
         githubBaseUrl: 'https://github.com',
         topSnippets: { numSnippets: 2, numWords: 750 },
       },
+      analyticsService: mockAnalyticsService as unknown as AnalyticsService,
     });
   });
 
@@ -163,7 +170,11 @@ describe('PluginsService', () => {
       skills: [
         {
           dirName: 'pdf-processor',
-          meta: { name: 'PDF Processor', description: 'Processes PDFs' },
+          meta: {
+            name: 'PDF Processor',
+            description: 'Processes PDFs',
+            allowedTools: ['tool-1', 'tool-2'],
+          },
           content: 'Skill instructions for PDF.',
           referencedFiles: [{ relativePath: 'schema.json', content: '{}' }],
         },
@@ -210,7 +221,7 @@ describe('PluginsService', () => {
             referenced_content: [
               { name: 'schema.json', relativePath: 'schema.json', content: '{}' },
             ],
-            tool_ids: [],
+            tool_ids: ['tool-1', 'tool-2'],
             plugin_id: 'test-plugin-uuid',
           },
           {
@@ -402,6 +413,64 @@ describe('PluginsService', () => {
         );
 
         expect(result).toBe(persistedPlugin);
+      });
+    });
+
+    describe('telemetry', () => {
+      it('reports PluginImported with sourceType "url" when installing from a URL', async () => {
+        mockParsePluginFromUrl.mockResolvedValue(archiveWithSkills);
+        mockClient.findByName.mockResolvedValue(undefined);
+        mockClient.create.mockResolvedValue(
+          createMockPersistedPlugin({ id: 'created-plugin-id' })
+        );
+        mockSkillClient.bulkCreate.mockResolvedValue([]);
+
+        await start.installPlugin({
+          request: mockRequest,
+          source: { type: 'url', url: 'https://example.com/plugin.zip' },
+        });
+
+        expect(mockAnalyticsService.reportPluginImported).toHaveBeenCalledWith({
+          pluginId: 'created-plugin-id',
+          sourceType: 'url',
+          skillCount: 2,
+        });
+      });
+
+      it('reports PluginImported with sourceType "file" when installing from a file', async () => {
+        mockParsePluginFromFile.mockResolvedValue(archiveWithSkills);
+        mockClient.findByName.mockResolvedValue(undefined);
+        mockClient.create.mockResolvedValue(
+          createMockPersistedPlugin({ id: 'created-plugin-id' })
+        );
+        mockSkillClient.bulkCreate.mockResolvedValue([]);
+
+        await start.installPlugin({
+          request: mockRequest,
+          source: { type: 'file', filePath: '/tmp/plugin.zip' },
+        });
+
+        expect(mockAnalyticsService.reportPluginImported).toHaveBeenCalledWith({
+          pluginId: 'created-plugin-id',
+          sourceType: 'file',
+          skillCount: 2,
+        });
+      });
+
+      it('does not report PluginImported when install fails (existing plugin)', async () => {
+        mockParsePluginFromUrl.mockResolvedValue(archiveWithSkills);
+        mockClient.findByName.mockResolvedValue(
+          createMockPersistedPlugin({ id: 'existing-id', version: '0.9.0' })
+        );
+
+        await expect(
+          start.installPlugin({
+            request: mockRequest,
+            source: { type: 'url', url: 'https://example.com/plugin.zip' },
+          })
+        ).rejects.toThrow(/already installed/);
+
+        expect(mockAnalyticsService.reportPluginImported).not.toHaveBeenCalled();
       });
     });
   });

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/plugins/plugin_service.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/plugins/plugin_service.ts
@@ -14,6 +14,7 @@ import type { SpacesPluginStart } from '@kbn/spaces-plugin/server';
 import { isAllowedBuiltinPlugin } from '@kbn/agent-builder-server/allow_lists';
 import type { BuiltInPluginDefinition } from '@kbn/agent-builder-server/plugins';
 import type { AgentBuilderConfig } from '../../config';
+import type { AnalyticsService } from '../../telemetry';
 import { getCurrentSpaceId } from '../../utils/spaces';
 import type { PluginClient, PersistedPluginDefinition } from './client';
 import { createClient, parsedArchiveToCreateRequest } from './client';
@@ -59,6 +60,7 @@ export interface PluginsServiceStartDeps {
   elasticsearch: ElasticsearchServiceStart;
   spaces?: SpacesPluginStart;
   config: AgentBuilderConfig;
+  analyticsService?: AnalyticsService;
 }
 
 export const createPluginsService = (): PluginsService => {
@@ -169,6 +171,7 @@ class PluginsServiceImpl implements PluginsService {
     const createRequests = parsedArchive.skills.map((skill) =>
       toSkillCreateRequest({ skill, pluginName, pluginId })
     );
+
     await skillClient.bulkCreate(createRequests);
 
     const skillIds = createRequests.map((req) => req.id);
@@ -181,7 +184,16 @@ class PluginsServiceImpl implements PluginsService {
       id: pluginId,
     });
 
-    return pluginClient.create(createRequest);
+    const created = await pluginClient.create(createRequest);
+
+    const { analyticsService } = this.getStartDeps();
+    analyticsService?.reportPluginImported({
+      pluginId: created.id,
+      sourceType: source.type,
+      skillCount: createRequests.length,
+    });
+
+    return created;
   }
 
   private async deletePlugin({
@@ -230,7 +242,7 @@ const toSkillCreateRequest = ({
       relativePath: file.relativePath,
       content: file.content,
     })),
-    tool_ids: [],
+    tool_ids: skill.meta.allowedTools ?? [],
     plugin_id: pluginId,
   };
 };

--- a/x-pack/platform/plugins/shared/agent_builder/server/telemetry/agent_builder_telemetry.md
+++ b/x-pack/platform/plugins/shared/agent_builder/server/telemetry/agent_builder_telemetry.md
@@ -154,6 +154,167 @@ only over conversations created in the last day.
   - What it is: Error counts grouped by normalized error type/code.
   - How we count: Usage counters prefixed with `agent_builder_error_by_type_`.
 
+## EBT (Event-Based Telemetry) events
+
+The Agent Builder emits server-side EBT events via `AnalyticsService`. All IDs that could
+contain user-generated content are normalized before reporting (SHA-256 prefix hashing) to
+protect privacy. Built-in identifiers are kept as-is.
+
+### `agent_builder_agent_created`
+
+Fired when a custom agent is created.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `agent_id` | keyword | yes | Normalized agent ID. |
+| `tool_ids` | keyword[] | yes | Deduplicated, normalized tool IDs included in the agent's tool selection. |
+
+### `agent_builder_agent_updated`
+
+Fired when a custom agent is updated.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `agent_id` | keyword | yes | Normalized agent ID. |
+| `tool_ids` | keyword[] | yes | Deduplicated, normalized tool IDs after the update. |
+
+### `agent_builder_tool_created`
+
+Fired when a custom tool is created.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `tool_id` | keyword | yes | Normalized tool ID. |
+| `tool_type` | keyword | yes | Tool type (e.g. `esql`, `index_search`, `workflow`). |
+
+### `agent_builder_round_complete`
+
+Fired at the end of each successful conversation round.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `agent_id` | keyword | yes | Normalized agent ID. |
+| `attachments` | keyword[] | no | Attachment types (e.g. `file`, `screenshot`), if any. |
+| `conversation_id` | keyword | no | Conversation ID. |
+| `execution_id` | keyword | no | Agent execution ID. |
+| `input_tokens` | integer | yes | Input tokens consumed in this round. |
+| `llm_calls` | integer | yes | Number of LLM calls made during the round. |
+| `message_length` | integer | yes | Character length of the user's input message. |
+| `model` | keyword | no | LLM model identifier. |
+| `model_provider` | keyword | no | LLM provider identifier. |
+| `output_tokens` | integer | yes | Output tokens produced in this round. |
+| `round_id` | keyword | yes | Unique round identifier. |
+| `round_status` | keyword | yes | Final status of the round. |
+| `response_length` | integer | yes | Character length of the assistant's response. |
+| `round_number` | integer | yes | 1-based round index within the conversation. |
+| `started_at` | keyword | yes | ISO timestamp when the round started. |
+| `time_to_first_token` | integer | yes | Milliseconds to first token. |
+| `time_to_last_token` | integer | yes | Milliseconds to last token (end-to-end latency). |
+| `tool_calls` | integer | yes | Total number of tool-call steps in this round. |
+| `tool_call_errors` | integer | yes | Number of tool calls where all results were errors. |
+| `tools_invoked` | keyword[] | yes | Normalized tool IDs invoked (may contain duplicates for per-tool counts). |
+
+### `agent_builder_round_error`
+
+Fired when a round fails with an unrecoverable error.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `agent_id` | keyword | yes | Normalized agent ID. |
+| `conversation_id` | keyword | no | Conversation ID. |
+| `execution_id` | keyword | no | Agent execution ID. |
+| `round_id` | keyword | no | Round ID, if available. |
+| `model_provider` | keyword | no | LLM provider identifier. |
+| `error_type` | keyword | yes | Sanitized/normalized error type or code. |
+| `error_message` | keyword | yes | Error message (truncated to 500 chars). |
+
+### `agent_builder_tool_call_success`
+
+Fired after a tool call completes successfully.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `tool_id` | keyword | yes | Normalized tool ID. |
+| `tool_call_id` | keyword | yes | Unique tool call identifier. |
+| `source` | keyword | yes | Origin of the tool call (e.g. `default_agent`, `custom_agent`, `mcp`). |
+| `agent_id` | keyword | no | Normalized agent ID. |
+| `conversation_id` | keyword | no | Conversation ID. |
+| `execution_id` | keyword | no | Agent execution ID. |
+| `model` | keyword | no | LLM model that requested the tool call. |
+| `result_types` | keyword[] | yes | Types of result entries returned by the tool. |
+| `duration_ms` | integer | yes | Tool execution time in milliseconds. |
+
+### `agent_builder_tool_call_error`
+
+Fired when a tool call fails.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `tool_id` | keyword | yes | Normalized tool ID. |
+| `tool_call_id` | keyword | yes | Unique tool call identifier. |
+| `source` | keyword | yes | Origin of the tool call. |
+| `agent_id` | keyword | no | Normalized agent ID. |
+| `conversation_id` | keyword | no | Conversation ID. |
+| `execution_id` | keyword | no | Agent execution ID. |
+| `model` | keyword | no | LLM model that requested the tool call. |
+| `error_type` | keyword | yes | Sanitized/normalized error type or code. |
+| `error_message` | keyword | yes | Error message (truncated to 500 chars). |
+| `duration_ms` | integer | yes | Tool execution time in milliseconds. |
+
+### Skill CRUD events
+
+These three events share the same schema. They fire on skill create/update/delete via the
+public API or during plugin import.
+
+| Event type | Constant |
+|------------|----------|
+| `agent_builder_skill_created` | `AGENT_BUILDER_EVENT_TYPES.SkillCreated` |
+| `agent_builder_skill_updated` | `AGENT_BUILDER_EVENT_TYPES.SkillUpdated` |
+| `agent_builder_skill_deleted` | `AGENT_BUILDER_EVENT_TYPES.SkillDeleted` |
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `skill_id` | keyword | yes | Normalized skill ID. Custom → `custom-<hash>`, plugin-bundled → `plugin-<plugin_hash>-<skill_hash>`. |
+| `origin` | keyword | no | `custom` (direct API) or `plugin` (plugin-bundled). |
+
+### `agent_builder_skill_invoked`
+
+Fired when the agent reads a skill file and its tools are dynamically loaded into the tool
+manager (`loadSkillToolsAfterRead` hook).
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `skill_id` | keyword | yes | Normalized skill ID. Built-ins keep original ID; custom → `custom-<hash>`; plugin → `plugin-<plugin_hash>-<skill_hash>`. |
+| `origin` | keyword | yes | `builtin`, `custom`, or `plugin`. |
+| `solution_area` | keyword | yes | `security`, `observability`, `search`, `platform`, `custom`, `plugin`, or `unknown`. Derived from `basePath` for built-ins. |
+| `plugin_id` | keyword | no | Normalized plugin ID (`custom-<hash>`). Present when `origin` is `plugin`. |
+| `agent_id` | keyword | no | Normalized agent ID from the run context. |
+| `conversation_id` | keyword | no | Conversation ID. |
+| `execution_id` | keyword | no | Agent execution ID. |
+| `tool_count` | integer | yes | Number of tools (inline + registry) registered by this skill load. |
+
+### `agent_builder_plugin_imported`
+
+Fired after a successful plugin install (URL or file upload).
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `plugin_id` | keyword | yes | Normalized plugin ID (`custom-<hash>`). Falls back to `unknown` if empty. |
+| `source_type` | keyword | yes | `url` or `upload`. |
+| `skill_count` | integer | yes | Number of skills bundled with the imported plugin. |
+
+### ID normalization scheme
+
+| Entity | Built-in | Custom | Plugin-backed |
+|--------|----------|--------|---------------|
+| Agent ID | original ID | `custom-<sha256[0:16]>` | — |
+| Tool ID | original ID | `custom-<sha256[0:16]>` | — |
+| Skill ID | original ID (readonly) | `custom-<sha256[0:16]>` | `plugin-<plugin_sha256[0:16]>-<skill_sha256[0:16]>` |
+| Plugin ID | — | — | `custom-<sha256[0:16]>` |
+
+All hashes use SHA-256 truncated to the first 16 hex characters. Implementation is in
+`telemetry/utils.ts`.
+
 ## Usage counters
 
 All usage counters are stored under the domain `agent_builder` using the Usage Counters

--- a/x-pack/platform/plugins/shared/agent_builder/server/telemetry/analytics_service.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/telemetry/analytics_service.test.ts
@@ -240,6 +240,179 @@ describe('AnalyticsService', () => {
     });
   });
 
+  describe.each([
+    { method: 'reportSkillCreated' as const, eventType: AGENT_BUILDER_EVENT_TYPES.SkillCreated },
+    { method: 'reportSkillUpdated' as const, eventType: AGENT_BUILDER_EVENT_TYPES.SkillUpdated },
+    { method: 'reportSkillDeleted' as const, eventType: AGENT_BUILDER_EVENT_TYPES.SkillDeleted },
+  ])('$method', ({ method, eventType }) => {
+    it('normalizes the skill_id and passes origin for custom skills', () => {
+      service[method]({ skillId: 'custom-skill-1', origin: 'custom' });
+
+      expect(analytics.reportEvent).toHaveBeenCalledWith(eventType, {
+        skill_id: 'custom-a1c01b755b74d7bd',
+        origin: 'custom',
+      });
+    });
+
+    it('uses a composite `plugin-<hash>-<hash>` id when a pluginId is provided', () => {
+      service[method]({ skillId: 'plugin-skill', origin: 'plugin', pluginId: 'plugin-uuid-1' });
+
+      expect(analytics.reportEvent).toHaveBeenCalledWith(eventType, {
+        skill_id: 'plugin-f3a4ba6782682a47-eabadf06389e747c',
+        origin: 'plugin',
+      });
+    });
+
+    it('does not throw when reporting throws', () => {
+      analytics.reportEvent.mockImplementation(() => {
+        throw new Error('boom');
+      });
+
+      expect(() => service[method]({ skillId: 'custom-skill-1' })).not.toThrow();
+      expect(logger.debug).toHaveBeenCalled();
+    });
+  });
+
+  describe('reportSkillInvoked', () => {
+    it('reports the SkillInvoked event for a built-in skill (keeps original skill_id, normalizes agent_id)', () => {
+      service.reportSkillInvoked({
+        skillId: 'builtin-skill-1',
+        origin: 'builtin',
+        solutionArea: 'platform',
+        agentId: agentBuilderDefaultAgentId,
+        conversationId: 'conv-1',
+        executionId: 'exec-1',
+        toolCount: 3,
+      });
+
+      expect(analytics.reportEvent).toHaveBeenCalledWith(AGENT_BUILDER_EVENT_TYPES.SkillInvoked, {
+        skill_id: 'builtin-skill-1',
+        origin: 'builtin',
+        solution_area: 'platform',
+        plugin_id: undefined,
+        agent_id: agentBuilderDefaultAgentId,
+        conversation_id: 'conv-1',
+        execution_id: 'exec-1',
+        tool_count: 3,
+      });
+    });
+
+    it('reports the SkillInvoked event for a plugin-backed skill (composite skill_id, hashed plugin_id)', () => {
+      service.reportSkillInvoked({
+        skillId: 'plugin-skill',
+        origin: 'plugin',
+        solutionArea: 'plugin',
+        pluginId: 'plugin-uuid-1',
+        agentId: 'my_custom_agent',
+        toolCount: 0,
+      });
+
+      expect(analytics.reportEvent).toHaveBeenCalledWith(AGENT_BUILDER_EVENT_TYPES.SkillInvoked, {
+        skill_id: 'plugin-f3a4ba6782682a47-eabadf06389e747c',
+        origin: 'plugin',
+        solution_area: 'plugin',
+        plugin_id: 'plugin-f3a4ba6782682a47',
+        agent_id: 'custom-da3031a511e7fadf',
+        conversation_id: undefined,
+        execution_id: undefined,
+        tool_count: 0,
+      });
+    });
+
+    it('reports the SkillInvoked event for a custom skill (hashed skill_id, undefined plugin/agent)', () => {
+      service.reportSkillInvoked({
+        skillId: 'custom-skill-1',
+        origin: 'custom',
+        solutionArea: 'custom',
+        toolCount: 1,
+      });
+
+      expect(analytics.reportEvent).toHaveBeenCalledWith(AGENT_BUILDER_EVENT_TYPES.SkillInvoked, {
+        skill_id: 'custom-a1c01b755b74d7bd',
+        origin: 'custom',
+        solution_area: 'custom',
+        plugin_id: undefined,
+        agent_id: undefined,
+        conversation_id: undefined,
+        execution_id: undefined,
+        tool_count: 1,
+      });
+    });
+
+    it('does not throw when reporting throws', () => {
+      analytics.reportEvent.mockImplementation(() => {
+        throw new Error('boom');
+      });
+
+      expect(() =>
+        service.reportSkillInvoked({
+          skillId: 'custom-skill-1',
+          origin: 'custom',
+          solutionArea: 'custom',
+          toolCount: 0,
+        })
+      ).not.toThrow();
+      expect(logger.debug).toHaveBeenCalled();
+    });
+  });
+
+  describe('reportPluginImported', () => {
+    it('reports source_type `url` when sourceType is "url" and hashes the plugin id', () => {
+      service.reportPluginImported({
+        pluginId: 'plugin-uuid-1',
+        sourceType: 'url',
+        skillCount: 2,
+      });
+
+      expect(analytics.reportEvent).toHaveBeenCalledWith(AGENT_BUILDER_EVENT_TYPES.PluginImported, {
+        plugin_id: 'plugin-f3a4ba6782682a47',
+        source_type: 'url',
+        skill_count: 2,
+      });
+    });
+
+    it('reports source_type `upload` when sourceType is "file"', () => {
+      service.reportPluginImported({
+        pluginId: 'plugin-uuid-1',
+        sourceType: 'file',
+        skillCount: 0,
+      });
+
+      expect(analytics.reportEvent).toHaveBeenCalledWith(
+        AGENT_BUILDER_EVENT_TYPES.PluginImported,
+        expect.objectContaining({ source_type: 'upload' })
+      );
+    });
+
+    it('reports plugin_id as `unknown` when the input plugin id is empty', () => {
+      service.reportPluginImported({
+        pluginId: '',
+        sourceType: 'url',
+        skillCount: 0,
+      });
+
+      expect(analytics.reportEvent).toHaveBeenCalledWith(
+        AGENT_BUILDER_EVENT_TYPES.PluginImported,
+        expect.objectContaining({ plugin_id: 'unknown' })
+      );
+    });
+
+    it('does not throw when reporting throws', () => {
+      analytics.reportEvent.mockImplementation(() => {
+        throw new Error('boom');
+      });
+
+      expect(() =>
+        service.reportPluginImported({
+          pluginId: 'plugin-uuid-1',
+          sourceType: 'url',
+          skillCount: 1,
+        })
+      ).not.toThrow();
+      expect(logger.debug).toHaveBeenCalled();
+    });
+  });
+
   describe('reportRoundError', () => {
     const defaultArgs = {
       agentId: agentBuilderDefaultAgentId,

--- a/x-pack/platform/plugins/shared/agent_builder/server/telemetry/analytics_service.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/telemetry/analytics_service.ts
@@ -19,18 +19,28 @@ import {
 import type {
   ReportAgentCreatedParams,
   ReportAgentUpdatedParams,
+  ReportPluginImportedParams,
   ReportRoundCompleteParams,
   ReportRoundErrorParams,
   ReportSkillCreatedParams,
   ReportSkillDeletedParams,
+  ReportSkillInvokedParams,
   ReportSkillUpdatedParams,
   ReportToolCallErrorParams,
   ReportToolCallSuccessParams,
   ReportToolCreatedParams,
+  SkillCreationOrigin,
+  SkillInvocationOrigin,
+  SkillSolutionArea,
 } from '@kbn/agent-builder-common/telemetry/agent_builder_events';
 import type { ModelProvider } from '@kbn/inference-common';
 import { normalizeErrorType, sanitizeForCounterName } from './error_utils';
-import { normalizeAgentIdForTelemetry, normalizeToolIdForTelemetry } from './utils';
+import {
+  normalizeAgentIdForTelemetry,
+  normalizePluginIdForTelemetry,
+  normalizeSkillIdForTelemetry,
+  normalizeToolIdForTelemetry,
+} from './utils';
 
 /**
  * Server-side analytics wrapper for Agent Builder telemetry.
@@ -108,33 +118,135 @@ export class AnalyticsService {
     }
   }
 
-  reportSkillCreated({ skillId }: { skillId: string }): void {
+  reportSkillCreated({
+    skillId,
+    origin,
+    pluginId,
+  }: {
+    skillId: string;
+    origin?: SkillCreationOrigin;
+    pluginId?: string;
+  }): void {
     try {
       this.analytics.reportEvent<ReportSkillCreatedParams>(AGENT_BUILDER_EVENT_TYPES.SkillCreated, {
-        skill_id: skillId,
+        skill_id: normalizeSkillIdForTelemetry({
+          id: skillId,
+          readonly: false,
+          plugin_id: pluginId,
+        }),
+        origin,
       });
     } catch (error) {
       this.logger.debug('Failed to report SkillCreated telemetry event', { error });
     }
   }
 
-  reportSkillUpdated({ skillId }: { skillId: string }): void {
+  reportSkillUpdated({
+    skillId,
+    origin,
+    pluginId,
+  }: {
+    skillId: string;
+    origin?: SkillCreationOrigin;
+    pluginId?: string;
+  }): void {
     try {
       this.analytics.reportEvent<ReportSkillUpdatedParams>(AGENT_BUILDER_EVENT_TYPES.SkillUpdated, {
-        skill_id: skillId,
+        skill_id: normalizeSkillIdForTelemetry({
+          id: skillId,
+          readonly: false,
+          plugin_id: pluginId,
+        }),
+        origin,
       });
     } catch (error) {
       this.logger.debug('Failed to report SkillUpdated telemetry event', { error });
     }
   }
 
-  reportSkillDeleted({ skillId }: { skillId: string }): void {
+  reportSkillDeleted({
+    skillId,
+    origin,
+    pluginId,
+  }: {
+    skillId: string;
+    origin?: SkillCreationOrigin;
+    pluginId?: string;
+  }): void {
     try {
       this.analytics.reportEvent<ReportSkillDeletedParams>(AGENT_BUILDER_EVENT_TYPES.SkillDeleted, {
-        skill_id: skillId,
+        skill_id: normalizeSkillIdForTelemetry({
+          id: skillId,
+          readonly: false,
+          plugin_id: pluginId,
+        }),
+        origin,
       });
     } catch (error) {
       this.logger.debug('Failed to report SkillDeleted telemetry event', { error });
+    }
+  }
+
+  reportSkillInvoked({
+    skillId,
+    origin,
+    solutionArea,
+    pluginId,
+    agentId,
+    conversationId,
+    executionId,
+    toolCount,
+  }: {
+    skillId: string;
+    origin: SkillInvocationOrigin;
+    solutionArea: SkillSolutionArea;
+    pluginId?: string;
+    agentId?: string;
+    conversationId?: string;
+    executionId?: string;
+    toolCount: number;
+  }): void {
+    try {
+      this.analytics.reportEvent<ReportSkillInvokedParams>(AGENT_BUILDER_EVENT_TYPES.SkillInvoked, {
+        skill_id: normalizeSkillIdForTelemetry({
+          id: skillId,
+          readonly: origin === 'builtin',
+          plugin_id: pluginId,
+        }),
+        origin,
+        solution_area: solutionArea,
+        plugin_id: normalizePluginIdForTelemetry(pluginId),
+        agent_id: normalizeAgentIdForTelemetry(agentId),
+        conversation_id: conversationId,
+        execution_id: executionId,
+        tool_count: toolCount,
+      });
+    } catch (error) {
+      this.logger.debug('Failed to report SkillInvoked telemetry event', { error });
+    }
+  }
+
+  reportPluginImported({
+    pluginId,
+    sourceType,
+    skillCount,
+  }: {
+    pluginId: string;
+    sourceType: 'url' | 'file';
+    skillCount: number;
+  }): void {
+    try {
+      const normalizedPluginId = normalizePluginIdForTelemetry(pluginId);
+      this.analytics.reportEvent<ReportPluginImportedParams>(
+        AGENT_BUILDER_EVENT_TYPES.PluginImported,
+        {
+          plugin_id: normalizedPluginId ?? 'unknown',
+          source_type: sourceType === 'url' ? 'url' : 'upload',
+          skill_count: skillCount,
+        }
+      );
+    } catch (error) {
+      this.logger.debug('Failed to report PluginImported telemetry event', { error });
     }
   }
 

--- a/x-pack/platform/plugins/shared/agent_builder/server/telemetry/utils.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/telemetry/utils.test.ts
@@ -1,0 +1,120 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  classifySkill,
+  normalizePluginIdForTelemetry,
+  normalizeSkillIdForTelemetry,
+} from './utils';
+
+describe('normalizePluginIdForTelemetry', () => {
+  it('returns undefined when no plugin id is provided', () => {
+    expect(normalizePluginIdForTelemetry()).toBeUndefined();
+    expect(normalizePluginIdForTelemetry(undefined)).toBeUndefined();
+    expect(normalizePluginIdForTelemetry('')).toBeUndefined();
+  });
+
+  it('returns a stable hashed label for plugin ids', () => {
+    expect(normalizePluginIdForTelemetry('plugin-uuid-1')).toBe('plugin-f3a4ba6782682a47');
+  });
+
+  it('returns the same hash for the same input across calls', () => {
+    const a = normalizePluginIdForTelemetry('plugin-uuid-1');
+    const b = normalizePluginIdForTelemetry('plugin-uuid-1');
+    expect(a).toBe(b);
+  });
+});
+
+describe('normalizeSkillIdForTelemetry', () => {
+  it('returns the original id for read-only (built-in) skills', () => {
+    expect(normalizeSkillIdForTelemetry({ id: 'builtin-skill-1', readonly: true })).toBe(
+      'builtin-skill-1'
+    );
+  });
+
+  it('hashes plugin-backed skill ids as `<plugin-hash>-<skill-hash>`', () => {
+    expect(
+      normalizeSkillIdForTelemetry({
+        id: 'plugin-skill',
+        readonly: false,
+        plugin_id: 'plugin-uuid-1',
+      })
+    ).toBe('plugin-f3a4ba6782682a47-eabadf06389e747c');
+  });
+
+  it('hashes plain custom skill ids as `custom-<hash>`', () => {
+    expect(normalizeSkillIdForTelemetry({ id: 'custom-skill-1', readonly: false })).toBe(
+      'custom-a1c01b755b74d7bd'
+    );
+  });
+
+  it('returns the original id when readonly even if a plugin_id is also set (readonly takes precedence)', () => {
+    expect(
+      normalizeSkillIdForTelemetry({
+        id: 'builtin-skill-1',
+        readonly: true,
+        plugin_id: 'plugin-uuid-1',
+      })
+    ).toBe('builtin-skill-1');
+  });
+});
+
+describe('classifySkill', () => {
+  it('classifies plugin-backed skills as plugin/plugin', () => {
+    expect(
+      classifySkill({ readonly: false, plugin_id: 'plugin-uuid-1', basePath: '/skills/anything' })
+    ).toEqual({ origin: 'plugin', solution_area: 'plugin' });
+  });
+
+  it('classifies non-readonly, non-plugin skills as custom/custom', () => {
+    expect(classifySkill({ readonly: false, basePath: '/skills/anything' })).toEqual({
+      origin: 'custom',
+      solution_area: 'custom',
+    });
+  });
+
+  it('classifies readonly skills as builtin and derives the solution_area from basePath', () => {
+    expect(classifySkill({ readonly: true, basePath: 'skills/security/foo' })).toEqual({
+      origin: 'builtin',
+      solution_area: 'security',
+    });
+    expect(classifySkill({ readonly: true, basePath: 'skills/observability/bar' })).toEqual({
+      origin: 'builtin',
+      solution_area: 'observability',
+    });
+    expect(classifySkill({ readonly: true, basePath: 'skills/search/baz' })).toEqual({
+      origin: 'builtin',
+      solution_area: 'search',
+    });
+    expect(classifySkill({ readonly: true, basePath: 'skills/platform/qux' })).toEqual({
+      origin: 'builtin',
+      solution_area: 'platform',
+    });
+  });
+
+  it('normalizes leading slashes in basePath when classifying built-in skills', () => {
+    expect(classifySkill({ readonly: true, basePath: '/skills/security/foo' })).toEqual({
+      origin: 'builtin',
+      solution_area: 'security',
+    });
+    expect(classifySkill({ readonly: true, basePath: '///skills/platform/qux' })).toEqual({
+      origin: 'builtin',
+      solution_area: 'platform',
+    });
+  });
+
+  it('returns `unknown` for built-in skills whose basePath does not match a known prefix', () => {
+    expect(classifySkill({ readonly: true, basePath: 'skills/something-else/foo' })).toEqual({
+      origin: 'builtin',
+      solution_area: 'unknown',
+    });
+    expect(classifySkill({ readonly: true, basePath: '' })).toEqual({
+      origin: 'builtin',
+      solution_area: 'unknown',
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/agent_builder/server/telemetry/utils.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/telemetry/utils.ts
@@ -7,10 +7,15 @@
 
 import { agentBuilderDefaultAgentId } from '@kbn/agent-builder-common';
 import { isInternalTool } from '@kbn/agent-builder-common/tools';
+import type {
+  SkillInvocationOrigin,
+  SkillSolutionArea,
+} from '@kbn/agent-builder-common/telemetry/agent_builder_events';
 import {
   AGENT_BUILDER_BUILTIN_AGENTS,
   AGENT_BUILDER_BUILTIN_TOOLS,
 } from '@kbn/agent-builder-server/allow_lists';
+import type { InternalSkillDefinition } from '@kbn/agent-builder-server/skills';
 import { createHash } from 'crypto';
 
 const BUILTIN_AGENT_IDS = new Set([agentBuilderDefaultAgentId, ...AGENT_BUILDER_BUILTIN_AGENTS]);
@@ -18,6 +23,7 @@ const BUILTIN_TOOL_IDS = new Set(AGENT_BUILDER_BUILTIN_TOOLS);
 
 const CUSTOM = 'custom';
 const CUSTOM_HASH_PREFIX = `${CUSTOM}-`;
+const PLUGIN_HASH_PREFIX = 'plugin-';
 const CUSTOM_HASH_HEX_LENGTH = 16;
 
 function sha256Hex(value: string): string {
@@ -26,6 +32,10 @@ function sha256Hex(value: string): string {
 
 function toCustomHashedId(value: string): string {
   return `${CUSTOM_HASH_PREFIX}${sha256Hex(value).slice(0, CUSTOM_HASH_HEX_LENGTH)}`;
+}
+
+function toPluginHashedId(value: string): string {
+  return `${PLUGIN_HASH_PREFIX}${sha256Hex(value).slice(0, CUSTOM_HASH_HEX_LENGTH)}`;
 }
 
 /**
@@ -49,4 +59,81 @@ export function normalizeToolIdForTelemetry(toolId: string): string {
   return (BUILTIN_TOOL_IDS as Set<string>).has(toolId) || isInternalTool(toolId)
     ? toolId
     : toCustomHashedId(toolId);
+}
+
+/**
+ * Normalizes plugin IDs for telemetry to protect user privacy.
+ * All plugin IDs (typically randomUUIDs) are reported as a stable hashed label
+ * ("custom-<sha256_prefix>"). Mirrors the agent/tool normalization scheme.
+ */
+export function normalizePluginIdForTelemetry(pluginId?: string): string | undefined {
+  if (!pluginId) {
+    return undefined;
+  }
+  return toPluginHashedId(pluginId);
+}
+
+/**
+ * Normalizes a skill ID for telemetry. Built-in (read-only) skills keep their ID
+ * since they map to a known set of identifiers. Custom skills are hashed.
+ * Plugin-backed skills get a `plugin-<plugin_id_hash>-<sha256_prefix>` label so
+ * downstream analysis can attribute invocations to a specific plugin without
+ * exposing user-chosen IDs.
+ */
+export function normalizeSkillIdForTelemetry(skill: {
+  id: string;
+  readonly: boolean;
+  plugin_id?: string;
+}): string {
+  if (skill.readonly) {
+    return skill.id;
+  }
+  if (skill.plugin_id) {
+    const pluginHash = toPluginHashedId(skill.plugin_id);
+    const skillHash = sha256Hex(skill.id).slice(0, CUSTOM_HASH_HEX_LENGTH);
+    return `${pluginHash}-${skillHash}`;
+  }
+  return toCustomHashedId(skill.id);
+}
+
+/**
+ * Classifies a skill into an `origin` and `solution_area` for telemetry.
+ *
+ * - `origin`: `plugin` if the skill was installed from a plugin, `builtin` if
+ *   it's a read-only built-in skill, otherwise `custom`.
+ * - `solution_area`: derived from `basePath` for built-ins
+ *   (`skills/security/...` → `security`, `skills/observability/...` →
+ *   `observability`, `skills/search/...` → `search`, `skills/platform/...` →
+ *   `platform`); literal `custom` for user-created; `plugin` for plugin-backed.
+ */
+export function classifySkill(
+  skill: Pick<InternalSkillDefinition, 'readonly' | 'plugin_id' | 'basePath'>
+): {
+  origin: SkillInvocationOrigin;
+  solution_area: SkillSolutionArea;
+} {
+  if (skill.plugin_id) {
+    return { origin: 'plugin', solution_area: 'plugin' };
+  }
+  if (!skill.readonly) {
+    return { origin: 'custom', solution_area: 'custom' };
+  }
+  return { origin: 'builtin', solution_area: solutionAreaFromBasePath(skill.basePath) };
+}
+
+function solutionAreaFromBasePath(basePath: string): SkillSolutionArea {
+  const normalized = basePath.replace(/^\/+/, '');
+  if (normalized.startsWith('skills/security')) {
+    return 'security';
+  }
+  if (normalized.startsWith('skills/observability')) {
+    return 'observability';
+  }
+  if (normalized.startsWith('skills/search')) {
+    return 'search';
+  }
+  if (normalized.startsWith('skills/platform')) {
+    return 'platform';
+  }
+  return 'unknown';
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Agent Builder] Skills and Plugins telemetry (#264380)](https://github.com/elastic/kibana/pull/264380)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Pablo Machado","email":"pablo.nevesmachado@elastic.co"},"sourceCommit":{"committedDate":"2026-04-21T16:22:57Z","message":"[Agent Builder] Skills and Plugins telemetry (#264380)\n\nresolves https://github.com/elastic/search-team/issues/13653\n\n## Summary\n\nAdds two new EBT telemetry events (`SkillInvoked`, `PluginImported`) and\nenriches the existing skill CRUD events (`SkillCreated`, `SkillUpdated`,\n`SkillDeleted`) with an `origin` field and privacy-safe plugin-aware ID\nnormalization. This gives us visibility into how skills and plugins are\nactually used in production — which solution areas are invoked, how many\ntools each skill loads, and whether skills come from built-in sources,\nuser-created custom definitions, or plugin bundles.\n\n### Telemetry events reference\n\n#### `agent_builder_skill_created` / `agent_builder_skill_updated` /\n`agent_builder_skill_deleted`\n\nFired on skill CRUD via the public API or plugin import.\n\n| Property | Type | Required | Description |\n|----------|------|----------|-------------|\n| `skill_id` | `keyword` | yes | Normalized skill ID (`custom-<hash>` or\n`plugin-<plugin_hash>-<skill_hash>`) |\n| `origin` | `keyword` | no | `custom` (direct API) or `plugin`\n(plugin-bundled) |\n\n#### `agent_builder_skill_invoked` *(new)*\n\nFired when the agent reads a skill file and its tools are dynamically\nloaded.\n\n| Property | Type | Required | Description |\n|----------|------|----------|-------------|\n| `skill_id` | `keyword` | yes | Normalized skill ID (built-ins keep\noriginal ID; custom → `custom-<hash>`; plugin →\n`plugin-<plugin_hash>-<skill_hash>`) |\n| `origin` | `keyword` | yes | `builtin`, `custom`, or `plugin` |\n| `solution_area` | `keyword` | yes | `security`, `observability`,\n`search`, `platform`, `custom`, `plugin`, or `unknown` |\n| `plugin_id` | `keyword` | no | Normalized plugin ID (`custom-<hash>`),\npresent when `origin` is `plugin` |\n| `agent_id` | `keyword` | no | Normalized agent ID from the run context\n|\n| `conversation_id` | `keyword` | no | Conversation ID |\n| `execution_id` | `keyword` | no | Agent execution ID |\n| `tool_count` | `integer` | yes | Number of tools (inline + registry)\nregistered by this skill load |\n\n#### `agent_builder_plugin_imported` *(new)*\n\nFired after a successful plugin install (URL or file upload).\n\n| Property | Type | Required | Description |\n|----------|------|----------|-------------|\n| `plugin_id` | `keyword` | yes | Normalized plugin ID (`custom-<hash>`)\n|\n| `source_type` | `keyword` | yes | `url` or `upload` |\n| `skill_count` | `integer` | yes | Number of skills bundled with the\nplugin |\n\n### How to test\n\n1. Start Kibana with Agent Builder enabled.\n2. Create, update, and delete a custom skill — verify\n`SkillCreated`/`SkillUpdated`/`SkillDeleted` EBT events fire with\n`origin: 'custom'` and a hashed `skill_id`.\n3. Install a plugin from a URL or file upload — verify a\n`PluginImported` event fires with the hashed `plugin_id`, correct\n`source_type`, and `skill_count`.\n4. Trigger a skill invocation (e.g. an agent reading a skill file) —\nverify a `SkillInvoked` event fires with the correct `origin`,\n`solution_area`, `tool_count`, and agent context fields.\n5. Query the `ebt-kibana-server` telemetry index and ensure the data is\nthere\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"a0d1fea4725530d98f6fb61e45f50eb3c78072af","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:version","v9.4.0","Team:agent-builder","feature:agent-builder","v9.5.0"],"title":"[Agent Builder] Skills and Plugins telemetry","number":264380,"url":"https://github.com/elastic/kibana/pull/264380","mergeCommit":{"message":"[Agent Builder] Skills and Plugins telemetry (#264380)\n\nresolves https://github.com/elastic/search-team/issues/13653\n\n## Summary\n\nAdds two new EBT telemetry events (`SkillInvoked`, `PluginImported`) and\nenriches the existing skill CRUD events (`SkillCreated`, `SkillUpdated`,\n`SkillDeleted`) with an `origin` field and privacy-safe plugin-aware ID\nnormalization. This gives us visibility into how skills and plugins are\nactually used in production — which solution areas are invoked, how many\ntools each skill loads, and whether skills come from built-in sources,\nuser-created custom definitions, or plugin bundles.\n\n### Telemetry events reference\n\n#### `agent_builder_skill_created` / `agent_builder_skill_updated` /\n`agent_builder_skill_deleted`\n\nFired on skill CRUD via the public API or plugin import.\n\n| Property | Type | Required | Description |\n|----------|------|----------|-------------|\n| `skill_id` | `keyword` | yes | Normalized skill ID (`custom-<hash>` or\n`plugin-<plugin_hash>-<skill_hash>`) |\n| `origin` | `keyword` | no | `custom` (direct API) or `plugin`\n(plugin-bundled) |\n\n#### `agent_builder_skill_invoked` *(new)*\n\nFired when the agent reads a skill file and its tools are dynamically\nloaded.\n\n| Property | Type | Required | Description |\n|----------|------|----------|-------------|\n| `skill_id` | `keyword` | yes | Normalized skill ID (built-ins keep\noriginal ID; custom → `custom-<hash>`; plugin →\n`plugin-<plugin_hash>-<skill_hash>`) |\n| `origin` | `keyword` | yes | `builtin`, `custom`, or `plugin` |\n| `solution_area` | `keyword` | yes | `security`, `observability`,\n`search`, `platform`, `custom`, `plugin`, or `unknown` |\n| `plugin_id` | `keyword` | no | Normalized plugin ID (`custom-<hash>`),\npresent when `origin` is `plugin` |\n| `agent_id` | `keyword` | no | Normalized agent ID from the run context\n|\n| `conversation_id` | `keyword` | no | Conversation ID |\n| `execution_id` | `keyword` | no | Agent execution ID |\n| `tool_count` | `integer` | yes | Number of tools (inline + registry)\nregistered by this skill load |\n\n#### `agent_builder_plugin_imported` *(new)*\n\nFired after a successful plugin install (URL or file upload).\n\n| Property | Type | Required | Description |\n|----------|------|----------|-------------|\n| `plugin_id` | `keyword` | yes | Normalized plugin ID (`custom-<hash>`)\n|\n| `source_type` | `keyword` | yes | `url` or `upload` |\n| `skill_count` | `integer` | yes | Number of skills bundled with the\nplugin |\n\n### How to test\n\n1. Start Kibana with Agent Builder enabled.\n2. Create, update, and delete a custom skill — verify\n`SkillCreated`/`SkillUpdated`/`SkillDeleted` EBT events fire with\n`origin: 'custom'` and a hashed `skill_id`.\n3. Install a plugin from a URL or file upload — verify a\n`PluginImported` event fires with the hashed `plugin_id`, correct\n`source_type`, and `skill_count`.\n4. Trigger a skill invocation (e.g. an agent reading a skill file) —\nverify a `SkillInvoked` event fires with the correct `origin`,\n`solution_area`, `tool_count`, and agent context fields.\n5. Query the `ebt-kibana-server` telemetry index and ensure the data is\nthere\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"a0d1fea4725530d98f6fb61e45f50eb3c78072af"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/264380","number":264380,"mergeCommit":{"message":"[Agent Builder] Skills and Plugins telemetry (#264380)\n\nresolves https://github.com/elastic/search-team/issues/13653\n\n## Summary\n\nAdds two new EBT telemetry events (`SkillInvoked`, `PluginImported`) and\nenriches the existing skill CRUD events (`SkillCreated`, `SkillUpdated`,\n`SkillDeleted`) with an `origin` field and privacy-safe plugin-aware ID\nnormalization. This gives us visibility into how skills and plugins are\nactually used in production — which solution areas are invoked, how many\ntools each skill loads, and whether skills come from built-in sources,\nuser-created custom definitions, or plugin bundles.\n\n### Telemetry events reference\n\n#### `agent_builder_skill_created` / `agent_builder_skill_updated` /\n`agent_builder_skill_deleted`\n\nFired on skill CRUD via the public API or plugin import.\n\n| Property | Type | Required | Description |\n|----------|------|----------|-------------|\n| `skill_id` | `keyword` | yes | Normalized skill ID (`custom-<hash>` or\n`plugin-<plugin_hash>-<skill_hash>`) |\n| `origin` | `keyword` | no | `custom` (direct API) or `plugin`\n(plugin-bundled) |\n\n#### `agent_builder_skill_invoked` *(new)*\n\nFired when the agent reads a skill file and its tools are dynamically\nloaded.\n\n| Property | Type | Required | Description |\n|----------|------|----------|-------------|\n| `skill_id` | `keyword` | yes | Normalized skill ID (built-ins keep\noriginal ID; custom → `custom-<hash>`; plugin →\n`plugin-<plugin_hash>-<skill_hash>`) |\n| `origin` | `keyword` | yes | `builtin`, `custom`, or `plugin` |\n| `solution_area` | `keyword` | yes | `security`, `observability`,\n`search`, `platform`, `custom`, `plugin`, or `unknown` |\n| `plugin_id` | `keyword` | no | Normalized plugin ID (`custom-<hash>`),\npresent when `origin` is `plugin` |\n| `agent_id` | `keyword` | no | Normalized agent ID from the run context\n|\n| `conversation_id` | `keyword` | no | Conversation ID |\n| `execution_id` | `keyword` | no | Agent execution ID |\n| `tool_count` | `integer` | yes | Number of tools (inline + registry)\nregistered by this skill load |\n\n#### `agent_builder_plugin_imported` *(new)*\n\nFired after a successful plugin install (URL or file upload).\n\n| Property | Type | Required | Description |\n|----------|------|----------|-------------|\n| `plugin_id` | `keyword` | yes | Normalized plugin ID (`custom-<hash>`)\n|\n| `source_type` | `keyword` | yes | `url` or `upload` |\n| `skill_count` | `integer` | yes | Number of skills bundled with the\nplugin |\n\n### How to test\n\n1. Start Kibana with Agent Builder enabled.\n2. Create, update, and delete a custom skill — verify\n`SkillCreated`/`SkillUpdated`/`SkillDeleted` EBT events fire with\n`origin: 'custom'` and a hashed `skill_id`.\n3. Install a plugin from a URL or file upload — verify a\n`PluginImported` event fires with the hashed `plugin_id`, correct\n`source_type`, and `skill_count`.\n4. Trigger a skill invocation (e.g. an agent reading a skill file) —\nverify a `SkillInvoked` event fires with the correct `origin`,\n`solution_area`, `tool_count`, and agent context fields.\n5. Query the `ebt-kibana-server` telemetry index and ensure the data is\nthere\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"a0d1fea4725530d98f6fb61e45f50eb3c78072af"}}]}] BACKPORT-->