### PR TITLE
[CI] Update limits.yml for securitySolution

### DIFF
--- a/packages/kbn-optimizer/limits.yml
+++ b/packages/kbn-optimizer/limits.yml
@@ -162,7 +162,7 @@ pageLoadAssetSize:
   searchQueryRules: 6689
   searchSynonyms: 6371
   security: 79627
-  securitySolution: 157027
+  securitySolution: 160000
   securitySolutionEss: 38689
   securitySolutionServerless: 52082
   serverless: 7412


### PR DESCRIPTION
## Summary
Parallel changes to the same plugin has breached the package limits. 
```
page load bundle size for securitySolution plugin is greater than the limit of 157027. The current value is 157044.
```

This PR fixes it out of band with some headroom to 160k