### PR TITLE
[Saved Objects] Fix scroll_count test 502 on ECH by reducing import batch size

### DIFF
--- a/src/platform/plugins/shared/saved_objects_management/test/scout/api/tests/scroll_count_large.spec.ts
+++ b/src/platform/plugins/shared/saved_objects_management/test/scout/api/tests/scroll_count_large.spec.ts
@@ -43,11 +43,12 @@ apiTest.describe('scroll_count - more than 10k objects', { tag: tags.deploymentA
     apiTest.setTimeout(IMPORT_TIMEOUT);
     adminCredentials = await requestAuth.getApiKey('admin');
 
-    for (const [start, end] of [
-      [1, 6000],
-      [6001, 12000],
-    ]) {
-      const ndjson = generateVisualizationNdjson(start, end);
+    const BATCH_SIZE = 1_000;
+    const TOTAL_OBJECTS = 12_000;
+
+    for (let batchStart = 1; batchStart <= TOTAL_OBJECTS; batchStart += BATCH_SIZE) {
+      const batchEnd = batchStart + BATCH_SIZE - 1;
+      const ndjson = generateVisualizationNdjson(batchStart, batchEnd);
       const formData = new FormData();
       formData.append('file', ndjson, 'export.ndjson');
 


### PR DESCRIPTION
## Summary

Fixes #262663

The `scroll_count - more than 10k objects` test was failing on ECH (Elastic Cloud Hosted) with a 502 during `beforeAll` setup, while passing on Serverless.

The failure was **not** in the `scroll_count` route itself, but in the test setup step that imports 12,000 visualizations to populate the dataset. The setup used 2 batches of 6,000 objects each via `POST /api/saved_objects/_import`.

On ECH, traffic flows through HAProxy which enforces a client-side timeout (typically 60 s). Importing 6,000 objects in a single call requires streaming and parsing a ~1 MB NDJSON multipart payload, multiple bulk-index calls to Elasticsearch, and building a response with `successResults` containing one entry per object (~600 KB JSON). If Kibana takes longer than the HAProxy timeout, the proxy closes the connection and returns 502.

**Fix:** Reduce the import batch size from 6,000 to 1,000 objects per call (12 batches total instead of 2). Each batch is ~165 KB request / ~100 KB response, well within ECH proxy limits and timeout. The total number of objects imported (12,000) and the test assertion remain unchanged.

## Test plan

- [x] Existing test `returns the correct count for each included types` validates the fix end-to-end (still asserts `{ visualization: 12000 }`)
- [ ] Verify the test passes on `cloud-stateful-classic` (ECH) in CI

Made with [Cursor](https://cursor.com)