### PR TITLE
[Security Solution] Hide migration callout on SIEM migration routes

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/common/lib/integrations/hooks/use_create_auto_import_card.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/lib/integrations/hooks/use_create_auto_import_card.tsx
@@ -5,12 +5,11 @@
  * 2.0.
  */
 
-import React, { useCallback } from 'react';
+import { useCallback } from 'react';
 import { useNavigation } from '@kbn/security-solution-navigation';
 import AssistantIconSVG from '@kbn/ai-assistant-icon/svg/assistant.svg';
 import { i18n } from '@kbn/i18n';
 import type { IntegrationCardItem } from '@kbn/fleet-plugin/public';
-import { EuiBadge } from '@elastic/eui';
 import { useIntegrationContext } from './integration_context';
 import {
   CARD_DESCRIPTION_LINE_CLAMP,
@@ -29,9 +28,6 @@ const DESCRIPTION = i18n.translate(
       'AI-driven process to build the integration step-by-step, or upload a pre-made .zip package integration.',
   }
 );
-const BADGE = i18n.translate('xpack.securitySolution.integrations.createAutoImportCard.badge', {
-  defaultMessage: 'New',
-});
 
 const navigation = { appId: 'integrations', path: 'create' };
 const ID = 'placeholder:auto_import';
@@ -45,7 +41,6 @@ export const useCreateAutoImportCard = () => {
       id: ID,
       title: TITLE,
       name: TITLE,
-      titleBadge: <EuiBadge color="warning">{BADGE}</EuiBadge>,
       titleLineClamp: CARD_TITLE_LINE_CLAMP,
       descriptionLineClamp: CARD_DESCRIPTION_LINE_CLAMP,
       maxCardHeight: MAX_CARD_HEIGHT_IN_PX,

--- a/x-pack/solutions/security/plugins/security_solution/public/onboarding/components/onboarding_body/cards/common/integrations/callouts/integration_card_top_callout.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/onboarding/components/onboarding_body/cards/common/integrations/callouts/integration_card_top_callout.test.tsx
@@ -11,6 +11,7 @@ import { of } from 'rxjs';
 import { IntegrationCardTopCallout } from './integration_card_top_callout';
 import { useOnboardingService } from '../../../../../hooks/use_onboarding_service';
 import { IntegrationTabId } from '../../../../../../../common/lib/integrations/types';
+import { useShowMigrationCallout } from './migrations_callout';
 
 jest.mock('../../../../../hooks/use_onboarding_service', () => ({
   useOnboardingService: jest.fn(),
@@ -20,12 +21,14 @@ jest.mock('./agentless_available_callout');
 jest.mock('./active_integrations_callout');
 jest.mock('./endpoint_callout');
 jest.mock('./migrations_callout', () => ({
-  MigrationsCallout: () => null,
+  MigrationsCallout: () => <div data-test-subj="migrationsCallout" />,
+  useShowMigrationCallout: jest.fn(() => true),
 }));
 
 describe('IntegrationCardTopCallout', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    (useShowMigrationCallout as jest.Mock).mockReturnValue(true);
   });
 
   test('renders EndpointCallout when endpoint tab selected and no integrations installed', async () => {
@@ -80,5 +83,22 @@ describe('IntegrationCardTopCallout', () => {
     await waitFor(() => {
       expect(getByTestId('activeIntegrationsCallout')).toBeInTheDocument();
     });
+  });
+
+  test('does not render MigrationsCallout when visibility hook returns false', () => {
+    (useOnboardingService as jest.Mock).mockReturnValue({
+      isAgentlessAvailable$: of(false),
+    });
+    (useShowMigrationCallout as jest.Mock).mockReturnValue(false);
+
+    const { queryByTestId } = render(
+      <IntegrationCardTopCallout
+        activeIntegrationsCount={0}
+        isAgentRequired={false}
+        selectedTabId={IntegrationTabId.cloud}
+      />
+    );
+
+    expect(queryByTestId('migrationsCallout')).not.toBeInTheDocument();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/onboarding/components/onboarding_body/cards/common/integrations/callouts/integration_card_top_callout.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/onboarding/components/onboarding_body/cards/common/integrations/callouts/integration_card_top_callout.tsx
@@ -14,7 +14,7 @@ import { AgentlessAvailableCallout } from './agentless_available_callout';
 import { ActiveIntegrationsCallout } from './active_integrations_callout';
 import { EndpointCallout } from './endpoint_callout';
 import { IntegrationTabId } from '../../../../../../../common/lib/integrations/types';
-import { MigrationsCallout } from './migrations_callout';
+import { MigrationsCallout, useShowMigrationCallout } from './migrations_callout';
 
 export const IntegrationCardTopCallout = React.memo<{
   activeIntegrationsCount: number;
@@ -23,6 +23,8 @@ export const IntegrationCardTopCallout = React.memo<{
 }>(({ activeIntegrationsCount, isAgentRequired, selectedTabId }) => {
   const { isAgentlessAvailable$ } = useOnboardingService();
   const isAgentlessAvailable = useObservable(isAgentlessAvailable$, undefined);
+
+  const showMigrationCallout = useShowMigrationCallout();
 
   const showActiveCallout = activeIntegrationsCount > 0 || isAgentRequired;
 
@@ -38,7 +40,7 @@ export const IntegrationCardTopCallout = React.memo<{
 
   return (
     <>
-      <MigrationsCallout />
+      {showMigrationCallout && <MigrationsCallout />}
       {showAnyLegacyCallout && <EuiSpacer size="s" />}
       {showEndpointCallout && <EndpointCallout />}
       {showAgentlessCallout && <AgentlessAvailableCallout />}

--- a/x-pack/solutions/security/plugins/security_solution/public/onboarding/components/onboarding_body/cards/common/integrations/callouts/migrations_callout.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/onboarding/components/onboarding_body/cards/common/integrations/callouts/migrations_callout.tsx
@@ -8,8 +8,10 @@ import React, { memo, useMemo, useCallback } from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { EuiPanel, EuiButton, EuiFlexItem, EuiFlexGroup } from '@elastic/eui';
 import { SecurityPageName, useNavigateTo } from '@kbn/security-solution-navigation';
+import { useLocation } from 'react-router-dom';
 import { IconAgent } from '../../../../../../../common/icons/agent';
 import { useGetSecuritySolutionUrl } from '../../../../../../../common/components/link_to';
+import { SIEM_MIGRATIONS_PATH } from '../../../../../../../../common/constants';
 
 export const MigrationsCallout = memo(() => {
   const { navigateTo } = useNavigateTo();
@@ -18,6 +20,7 @@ export const MigrationsCallout = memo(() => {
     () => getSecuritySolutionUrl({ deepLinkId: SecurityPageName.siemMigrationsManage }),
     [getSecuritySolutionUrl]
   );
+
   const onClick = useCallback(
     (e: React.SyntheticEvent) => {
       e.preventDefault();
@@ -54,5 +57,11 @@ export const MigrationsCallout = memo(() => {
     </EuiPanel>
   );
 });
+
+export const useShowMigrationCallout = () => {
+  const { pathname } = useLocation();
+
+  return !pathname.includes(SIEM_MIGRATIONS_PATH);
+};
 
 MigrationsCallout.displayName = 'MigrationsCallout';


### PR DESCRIPTION
## Summary

This PR hides the onboarding migration callout when the current route is under `siem_migrations`, so users already in migration flows do not see redundant promotion. It introduces a dedicated `useShowMigrationCallout` hook and uses it in `IntegrationCardTopCallout` to gate rendering of the migration callout. The related unit test is updated to mock and verify the new hook behavior. It also removes the stale `New` title badge from the auto-import integration card.

### Checklist

Check the PR satisfies following conditions.

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [x] Low - route matching uses `pathname.includes(SIEM_MIGRATIONS_PATH)`, which may hide the callout for any route containing that segment; mitigation: this is intentional for all SIEM migration routes and uses a shared constant to avoid string drift.

### Release note

> Fixes onboarding integrations behavior by hiding the migration callout on SIEM migration routes.

**Suggested label:** `release_note:fix`