### PR TITLE
[Automatic Import] Add checkbox to auto install integration after approval

### DIFF
--- a/x-pack/platform/plugins/shared/automatic_import/common/index.ts
+++ b/x-pack/platform/plugins/shared/automatic_import/common/index.ts
@@ -76,6 +76,7 @@ export {
   type IntegrationDownloadZipClickedPayload,
   type ApproveModalCancelClickedPayload,
   type ApproveModalApproveClickedPayload,
+  type ApproveModalApproveWithAutoInstallClickedPayload,
   type DataStreamDeleteConfirmedPayload,
   type DataStreamRefreshConfirmedPayload,
   type PipelineEditedPayload,

--- a/x-pack/platform/plugins/shared/automatic_import/common/telemetry/types.ts
+++ b/x-pack/platform/plugins/shared/automatic_import/common/telemetry/types.ts
@@ -37,6 +37,7 @@ export enum AutomaticImportTelemetryEventType {
   IntegrationDownloadZipClicked = 'automatic_import_integration_download_zip_clicked',
   ApproveModalCancelClicked = 'automatic_import_approve_modal_cancel_clicked',
   ApproveModalApproveClicked = 'automatic_import_approve_modal_approve_clicked',
+  ApproveModalApproveWithAutoInstallClicked = 'automatic_import_approve_modal_approve_with_auto_install_clicked',
 }
 
 export interface CreateIntegrationPageLoadedPayload {
@@ -134,6 +135,9 @@ export interface ApproveModalApproveClickedPayload {
   dataStreamCount: number;
 }
 
+/** User approved with "Automatically install integration after approval" checked; fires after approve API succeeds, before install. */
+export type ApproveModalApproveWithAutoInstallClickedPayload = ApproveModalApproveClickedPayload;
+
 export interface DataStreamDeleteConfirmedPayload {
   sessionId?: string;
   integrationId?: string;
@@ -190,6 +194,8 @@ export type AutomaticImportTelemetryEventPayload<T extends AutomaticImportTeleme
     ? ApproveModalCancelClickedPayload
     : T extends AutomaticImportTelemetryEventType.ApproveModalApproveClicked
     ? ApproveModalApproveClickedPayload
+    : T extends AutomaticImportTelemetryEventType.ApproveModalApproveWithAutoInstallClicked
+    ? ApproveModalApproveWithAutoInstallClickedPayload
     : T extends AutomaticImportTelemetryEventType.DataStreamDeleteConfirmed
     ? DataStreamDeleteConfirmedPayload
     : T extends AutomaticImportTelemetryEventType.DataStreamRefreshConfirmed

--- a/x-pack/platform/plugins/shared/automatic_import/public/components/integration_management/integration_management.tsx
+++ b/x-pack/platform/plugins/shared/automatic_import/public/components/integration_management/integration_management.tsx
@@ -59,6 +59,9 @@ const IntegrationManagementContents: React.FC<IntegrationManagementContentsProps
   const [isDeleteIntegrationModalVisible, setIsDeleteIntegrationModalVisible] = useState(false);
   const deleteIntegrationModalTitleId = useGeneratedHtmlId();
   const { reportCancelButtonClicked, reportDoneButtonClicked } = useTelemetry();
+  // Reanalysis updates data streams on the server but not integration form fields, so
+  // useFormIsModified stays false; allow Done so the user can leave after scheduling reanalysis.
+  const [reanalysisJustScheduled, setReanalysisJustScheduled] = useState(false);
 
   const performCancelNavigation = useCallback(() => {
     reportCancelButtonClicked({ integrationId });
@@ -99,13 +102,21 @@ const IntegrationManagementContents: React.FC<IntegrationManagementContentsProps
     submit();
   }, [integrationId, reportDoneButtonClicked, submit]);
 
+  const handleDataStreamReanalyzeSuccess = useCallback(() => {
+    setReanalysisJustScheduled(true);
+  }, []);
+
+  useEffect(() => {
+    setReanalysisJustScheduled(false);
+  }, [integrationId]);
+
   return (
     <>
       <KibanaPageTemplate restrictWidth={PAGE_RESTRICT_WIDTH}>
         <KibanaPageTemplate.Header pageTitle={i18n.PAGE_TITLE_NEW_INTEGRATION} />
         <KibanaPageTemplate.Section>
           <ConnectorSelector />
-          <ManagementContents />
+          <ManagementContents onDataStreamReanalyzeSuccess={handleDataStreamReanalyzeSuccess} />
         </KibanaPageTemplate.Section>
       </KibanaPageTemplate>
       <ButtonsFooter
@@ -113,7 +124,7 @@ const IntegrationManagementContents: React.FC<IntegrationManagementContentsProps
         isActionDisabled={
           !hasDataStreams ||
           isDeletingDataStream ||
-          (Boolean(integrationId) && !isNewlyCreated && !isFormModified)
+          (Boolean(integrationId) && !isNewlyCreated && !isFormModified && !reanalysisJustScheduled)
         }
         isCancelDisabled={isDeletingDataStream}
         onCancel={handleCancel}

--- a/x-pack/platform/plugins/shared/automatic_import/public/components/integration_management/management_contents/data_streams/data_streams.tsx
+++ b/x-pack/platform/plugins/shared/automatic_import/public/components/integration_management/management_contents/data_streams/data_streams.tsx
@@ -25,7 +25,9 @@ import { EditPipelineFlyout } from './edit_pipeline_flyout';
 import { useTelemetry } from '../../../telemetry_context';
 import { useIntegrationForm } from '../../forms/integration_form';
 
-export const DataStreams = React.memo<{ integrationId?: string }>(() => {
+export const DataStreams = React.memo<{
+  onDataStreamReanalyzeSuccess?: () => void;
+}>(({ onDataStreamReanalyzeSuccess }) => {
   const {
     isCreateDataStreamFlyoutOpen,
     openCreateDataStreamFlyout,
@@ -126,7 +128,11 @@ export const DataStreams = React.memo<{ integrationId?: string }>(() => {
       )}
 
       {hasDataStreams && integration?.dataStreams && integrationId && (
-        <DataStreamsTable integrationId={integrationId} items={integration.dataStreams} />
+        <DataStreamsTable
+          integrationId={integrationId}
+          items={integration.dataStreams}
+          onReanalyzeSuccess={onDataStreamReanalyzeSuccess}
+        />
       )}
 
       {isCreateDataStreamFlyoutOpen && (

--- a/x-pack/platform/plugins/shared/automatic_import/public/components/integration_management/management_contents/data_streams/data_streams_table/data_steams_table.tsx
+++ b/x-pack/platform/plugins/shared/automatic_import/public/components/integration_management/management_contents/data_streams/data_streams_table/data_steams_table.tsx
@@ -26,9 +26,14 @@ import { useTelemetry } from '../../../../telemetry_context';
 interface DataStreamsTableProps {
   integrationId: string;
   items: DataStreamResponse[];
+  onReanalyzeSuccess?: () => void;
 }
 
-export const DataStreamsTable = ({ integrationId, items }: DataStreamsTableProps) => {
+export const DataStreamsTable = ({
+  integrationId,
+  items,
+  onReanalyzeSuccess,
+}: DataStreamsTableProps) => {
   const { euiTheme } = useEuiTheme();
   const { deleteDataStreamMutation } = useDeleteDataStream();
   const { reanalyzeDataStreamMutation } = useReanalyzeDataStream();
@@ -89,19 +94,25 @@ export const DataStreamsTable = ({ integrationId, items }: DataStreamsTableProps
 
   const isDeleting = (item: DataStreamResponse) => item.status === 'deleting';
 
-  const handleReAnalyzeConfirm = () => {
+  const handleReAnalyzeConfirm = async () => {
     if (!formData?.connectorId || !dataStreamReanalyzeTarget) return;
 
+    const target = dataStreamReanalyzeTarget;
     reportDataStreamRefreshConfirmed({
       integrationId,
-      dataStreamId: dataStreamReanalyzeTarget.dataStreamId,
+      dataStreamId: target.dataStreamId,
     });
     setDataStreamReanalyzeTarget(null);
-    reanalyzeDataStreamMutation.mutate({
-      integrationId,
-      dataStreamId: dataStreamReanalyzeTarget.dataStreamId,
-      connectorId: formData.connectorId,
-    });
+    try {
+      await reanalyzeDataStreamMutation.mutateAsync({
+        integrationId,
+        dataStreamId: target.dataStreamId,
+        connectorId: formData.connectorId,
+      });
+      onReanalyzeSuccess?.();
+    } catch {
+      // Error toast is shown by useReanalyzeDataStream
+    }
   };
 
   const handleReanalyzeCancel = () => {

--- a/x-pack/platform/plugins/shared/automatic_import/public/components/integration_management/management_contents/data_streams/data_streams_table/data_streams_table.test.tsx
+++ b/x-pack/platform/plugins/shared/automatic_import/public/components/integration_management/management_contents/data_streams/data_streams_table/data_streams_table.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { render, screen, within } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { DataStreamsTable } from './data_steams_table';
 import type { DataStreamResponse } from '../../../../../../common';
@@ -36,8 +36,10 @@ const mockDeleteDataStreamMutation = {
 };
 
 const mockReanalyzeMutate = jest.fn();
+const mockReanalyzeMutateAsync = jest.fn().mockResolvedValue(undefined);
 const mockReanalyzeDataStreamMutation = {
   mutate: mockReanalyzeMutate,
+  mutateAsync: mockReanalyzeMutateAsync,
   isLoading: false,
   variables: undefined as
     | { dataStreamId: string; integrationId: string; connectorId: string }
@@ -345,10 +347,12 @@ describe('DataStreamsTable', () => {
       const confirmButton = screen.getByRole('button', { name: /Re-Analyze/i });
       await userEvent.click(confirmButton);
 
-      expect(mockReanalyzeMutate).toHaveBeenCalledWith({
-        integrationId: 'integration-123',
-        dataStreamId: 'ds-1',
-        connectorId: 'test-connector-id',
+      await waitFor(() => {
+        expect(mockReanalyzeMutateAsync).toHaveBeenCalledWith({
+          integrationId: 'integration-123',
+          dataStreamId: 'ds-1',
+          connectorId: 'test-connector-id',
+        });
       });
     });
 

--- a/x-pack/platform/plugins/shared/automatic_import/public/components/integration_management/management_contents/management_contents.tsx
+++ b/x-pack/platform/plugins/shared/automatic_import/public/components/integration_management/management_contents/management_contents.tsx
@@ -23,7 +23,9 @@ const useStepStyles = () => {
   };
 };
 
-export const ManagementContents = React.memo(() => {
+export const ManagementContents = React.memo<{
+  onDataStreamReanalyzeSuccess?: () => void;
+}>(({ onDataStreamReanalyzeSuccess }) => {
   const styles = useStepStyles();
 
   const steps: EuiStepsProps['steps'] = [
@@ -35,7 +37,7 @@ export const ManagementContents = React.memo(() => {
     {
       title: i18n.STEP_DEFINE_DATA_STREAMS,
       titleSize: 'xs',
-      children: <DataStreams />,
+      children: <DataStreams onDataStreamReanalyzeSuccess={onDataStreamReanalyzeSuccess} />,
     },
   ];
 

--- a/x-pack/platform/plugins/shared/automatic_import/public/services/telemetry/events.ts
+++ b/x-pack/platform/plugins/shared/automatic_import/public/services/telemetry/events.ts
@@ -214,6 +214,23 @@ export const telemetryEventsSchemas: Partial<
       },
     },
   },
+  [AutomaticImportTelemetryEventType.ApproveModalApproveWithAutoInstallClicked]: {
+    integrationId: {
+      type: 'keyword',
+      _meta: { description: 'Integration ID', optional: true },
+    },
+    version: {
+      type: 'keyword',
+      _meta: { description: 'Integration version being approved', optional: true },
+    },
+    dataStreamCount: {
+      type: 'long',
+      _meta: {
+        description: 'Total number of data streams in the integration at the time of approval',
+        optional: false,
+      },
+    },
+  },
   [AutomaticImportTelemetryEventType.DataStreamDeleteConfirmed]: {
     sessionId: {
       type: 'keyword',

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/components/manage_integration_actions.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/components/manage_integration_actions.tsx
@@ -347,6 +347,7 @@ export const ManageIntegrationActions: React.FC<{
         onEdit={onEdit}
         onFetchReviewDetails={onFetchReviewDetails}
         onApproveAndDeploy={onApproveAndDeploy}
+        onInstallToCluster={onInstallToCluster}
         DataStreamResultsFlyoutComponent={DataStreamResultsFlyoutComponent}
       />
     </>

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/components/manage_integration_actions.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/components/manage_integration_actions.tsx
@@ -42,13 +42,17 @@ export const ManageIntegrationActions: React.FC<{
   onDelete: (integrationId: string) => Promise<void>;
   DataStreamResultsFlyoutComponent?: DataStreamResultsFlyoutComponent;
   onFetchReviewDetails: (integrationId: string) => Promise<ReviewIntegrationDetails>;
-  onApproveAndDeploy: (
+  onApproveAndInstall: (
     integrationId: string,
     version: string,
-    categories: string[]
+    categories: string[],
+    autoInstallAfterApproval: boolean
   ) => Promise<void>;
   onDownloadZip?: (integrationId: string) => Promise<void>;
-  onInstallToCluster?: (integrationId: string) => Promise<void>;
+  onInstallToCluster?: (
+    integrationId: string,
+    options?: { skipSuccessToast?: boolean }
+  ) => Promise<void>;
 }> = ({
   integration,
   isPackageReady,
@@ -59,7 +63,7 @@ export const ManageIntegrationActions: React.FC<{
   onDelete,
   DataStreamResultsFlyoutComponent,
   onFetchReviewDetails,
-  onApproveAndDeploy,
+  onApproveAndInstall,
   onDownloadZip,
   onInstallToCluster,
 }) => {
@@ -346,7 +350,7 @@ export const ManageIntegrationActions: React.FC<{
         onClose={closeReviewModal}
         onEdit={onEdit}
         onFetchReviewDetails={onFetchReviewDetails}
-        onApproveAndDeploy={onApproveAndDeploy}
+        onApproveAndInstall={onApproveAndInstall}
         onInstallToCluster={onInstallToCluster}
         DataStreamResultsFlyoutComponent={DataStreamResultsFlyoutComponent}
       />

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/components/manage_integrations_table.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/components/manage_integrations_table.tsx
@@ -852,7 +852,7 @@ export const ManageIntegrationsTable: React.FC<{
                   : undefined
               }
             >
-              <span>
+              <span tabIndex={0}>
                 <EuiButton
                   size="s"
                   iconType="exportAction"

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/components/manage_integrations_table.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/components/manage_integrations_table.tsx
@@ -320,8 +320,13 @@ export const ManageIntegrationsTable: React.FC<{
     [http, notifications, automaticImport]
   );
 
-  const approveAndDeployIntegration = useCallback(
-    async (integrationId: string, version: string, categories: string[]) => {
+  const approveAndInstallIntegration = useCallback(
+    async (
+      integrationId: string,
+      version: string,
+      categories: string[],
+      autoInstallAfterApproval: boolean
+    ) => {
       try {
         await http.post(
           `/api/automatic_import/integrations/${encodeURIComponent(integrationId)}/approve`,
@@ -332,12 +337,16 @@ export const ManageIntegrationsTable: React.FC<{
         );
 
         notifications.toasts.addSuccess({
-          title: i18n.translate(
-            'xpack.fleet.epmList.manageIntegrations.actions.approveSuccessTitle',
-            {
-              defaultMessage: 'Integration approved and ready to deploy',
-            }
-          ),
+          title: autoInstallAfterApproval
+            ? i18n.translate(
+                'xpack.fleet.epmList.manageIntegrations.actions.approveSuccessWithInstallTitle',
+                {
+                  defaultMessage: 'Integration approved and installed',
+                }
+              )
+            : i18n.translate('xpack.fleet.epmList.manageIntegrations.actions.approveSuccessTitle', {
+                defaultMessage: 'Integration approved',
+              }),
         });
         onRefetch();
       } catch (error) {
@@ -356,7 +365,8 @@ export const ManageIntegrationsTable: React.FC<{
   );
 
   const installToCluster = useCallback(
-    async (integrationId: string) => {
+    async (integrationId: string, options?: { skipSuccessToast?: boolean }) => {
+      const { skipSuccessToast = false } = options ?? {};
       try {
         const zipBlob = await http.get(
           `/api/automatic_import/integrations/${encodeURIComponent(integrationId)}/download`,
@@ -378,12 +388,14 @@ export const ManageIntegrationsTable: React.FC<{
         });
 
         await queryClient.invalidateQueries({ queryKey: ['get-packages'] });
-        notifications.toasts.addSuccess({
-          title: i18n.translate(
-            'xpack.fleet.epmList.manageIntegrations.actions.installSuccessTitle',
-            { defaultMessage: 'Integration installed to cluster successfully' }
-          ),
-        });
+        if (!skipSuccessToast) {
+          notifications.toasts.addSuccess({
+            title: i18n.translate(
+              'xpack.fleet.epmList.manageIntegrations.actions.installSuccessTitle',
+              { defaultMessage: 'Integration installed to cluster successfully' }
+            ),
+          });
+        }
       } catch (error) {
         notifications.toasts.addError(error as Error, {
           title: i18n.translate(
@@ -607,7 +619,7 @@ export const ManageIntegrationsTable: React.FC<{
                   automaticImport?.components.DataStreamResultsFlyout
                 }
                 onFetchReviewDetails={fetchIntegrationReviewDetails}
-                onApproveAndDeploy={approveAndDeployIntegration}
+                onApproveAndInstall={approveAndInstallIntegration}
                 onDownloadZip={downloadZipPackage}
                 onInstallToCluster={installToCluster}
               />
@@ -634,7 +646,7 @@ export const ManageIntegrationsTable: React.FC<{
             onDelete={deleteIntegration}
             DataStreamResultsFlyoutComponent={automaticImport?.components.DataStreamResultsFlyout}
             onFetchReviewDetails={fetchIntegrationReviewDetails}
-            onApproveAndDeploy={approveAndDeployIntegration}
+            onApproveAndInstall={approveAndInstallIntegration}
             onDownloadZip={downloadZipPackage}
             onInstallToCluster={installToCluster}
           />
@@ -646,7 +658,7 @@ export const ManageIntegrationsTable: React.FC<{
       goToEditIntegration,
       deleteIntegration,
       fetchIntegrationReviewDetails,
-      approveAndDeployIntegration,
+      approveAndInstallIntegration,
       downloadZipPackage,
       installToCluster,
       installedPackageVersions,

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/components/review_approve_modal.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/components/review_approve_modal.tsx
@@ -142,12 +142,16 @@ export const ReviewApproveModal: React.FC<{
   onClose: () => void;
   onEdit: (integrationId: string) => void;
   onFetchReviewDetails: (integrationId: string) => Promise<ReviewIntegrationDetails>;
-  onApproveAndDeploy: (
+  onApproveAndInstall: (
     integrationId: string,
     version: string,
-    categories: string[]
+    categories: string[],
+    autoInstallAfterApproval: boolean
   ) => Promise<void>;
-  onInstallToCluster?: (integrationId: string) => Promise<void>;
+  onInstallToCluster?: (
+    integrationId: string,
+    options?: { skipSuccessToast?: boolean }
+  ) => Promise<void>;
   DataStreamResultsFlyoutComponent?: DataStreamResultsFlyoutComponent;
 }> = ({
   isOpen,
@@ -155,7 +159,7 @@ export const ReviewApproveModal: React.FC<{
   onClose,
   onEdit,
   onFetchReviewDetails,
-  onApproveAndDeploy,
+  onApproveAndInstall,
   onInstallToCluster,
   DataStreamResultsFlyoutComponent,
 }) => {
@@ -266,7 +270,7 @@ export const ReviewApproveModal: React.FC<{
         defaultMessage: 'Enter a valid semantic version (for example, 1.0.0).',
       });
 
-  const handleApproveAndDeploy = useCallback(async () => {
+  const handleApproveAndInstall = useCallback(async () => {
     const version = reviewVersion.trim();
     if (!semverValid(version) || version.startsWith(INVALID_VERSION)) {
       setIsVersionTouched(true);
@@ -282,7 +286,7 @@ export const ReviewApproveModal: React.FC<{
           : i18n.translate(
               'xpack.fleet.epmList.manageIntegrations.actions.reviewVersionValidationError',
               {
-                defaultMessage: 'Provide a valid version before approving and deploying.',
+                defaultMessage: 'Provide a valid version before approving and installing.',
               }
             )
       );
@@ -313,9 +317,10 @@ export const ReviewApproveModal: React.FC<{
     setIsApproving(true);
     setReviewError(null);
     try {
-      await onApproveAndDeploy(integrationId, version, categoryIds);
+      const willAutoInstall = autoInstallAfterApproval && Boolean(onInstallToCluster);
+      await onApproveAndInstall(integrationId, version, categoryIds, willAutoInstall);
       if (autoInstallAfterApproval && onInstallToCluster) {
-        await onInstallToCluster(integrationId);
+        await onInstallToCluster(integrationId, { skipSuccessToast: true });
       }
       onClose();
     } catch (error) {
@@ -323,7 +328,7 @@ export const ReviewApproveModal: React.FC<{
         error instanceof Error
           ? error.message
           : i18n.translate('xpack.fleet.epmList.manageIntegrations.actions.reviewApproveError', {
-              defaultMessage: 'Failed to approve and deploy integration.',
+              defaultMessage: 'Failed to approve and install integration.',
             })
       );
     } finally {
@@ -333,7 +338,7 @@ export const ReviewApproveModal: React.FC<{
     automaticImport,
     autoInstallAfterApproval,
     integrationId,
-    onApproveAndDeploy,
+    onApproveAndInstall,
     onClose,
     onInstallToCluster,
     reviewDetails,
@@ -543,11 +548,11 @@ export const ReviewApproveModal: React.FC<{
           />
         </EuiButtonEmpty>
         <EuiButton
-          onClick={handleApproveAndDeploy}
+          onClick={handleApproveAndInstall}
           fill
           isLoading={isApproving}
           isDisabled={isLoadingReviewDetails || !isVersionValid || !hasAtLeastOneCategory}
-          data-test-subj="manageIntegrationReviewApproveDeployButton"
+          data-test-subj="manageIntegrationReviewApproveInstallButton"
         >
           <FormattedMessage
             id="xpack.fleet.epmList.manageIntegrations.actions.reviewModalApprove"

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/components/review_approve_modal.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/components/review_approve_modal.tsx
@@ -12,6 +12,7 @@ import {
   EuiButton,
   EuiButtonEmpty,
   EuiButtonIcon,
+  EuiCheckbox,
   EuiComboBox,
   EuiEmptyPrompt,
   EuiFieldText,
@@ -29,6 +30,7 @@ import {
   EuiPopover,
   EuiSpacer,
   EuiText,
+  htmlIdGenerator,
 } from '@elastic/eui';
 import type { EuiBasicTableColumn, EuiComboBoxOptionOption } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
@@ -145,6 +147,7 @@ export const ReviewApproveModal: React.FC<{
     version: string,
     categories: string[]
   ) => Promise<void>;
+  onInstallToCluster?: (integrationId: string) => Promise<void>;
   DataStreamResultsFlyoutComponent?: DataStreamResultsFlyoutComponent;
 }> = ({
   isOpen,
@@ -153,6 +156,7 @@ export const ReviewApproveModal: React.FC<{
   onEdit,
   onFetchReviewDetails,
   onApproveAndDeploy,
+  onInstallToCluster,
   DataStreamResultsFlyoutComponent,
 }) => {
   const { automaticImport } = useStartServices();
@@ -165,6 +169,12 @@ export const ReviewApproveModal: React.FC<{
   const [selectedDataStreamForFlyout, setSelectedDataStreamForFlyout] =
     useState<ReviewDataStream | null>(null);
   const [selectedCategories, setSelectedCategories] = useState<EuiComboBoxOptionOption[]>([]);
+  const [autoInstallAfterApproval, setAutoInstallAfterApproval] = useState(true);
+
+  const autoInstallCheckboxId = useMemo(
+    () => htmlIdGenerator('manageIntegrationReviewAutoInstall')(),
+    []
+  );
 
   const { data: categoriesData } = useGetCategoriesQuery({ prerelease: false });
   const categoryOptions = useMemo<EuiComboBoxOptionOption[]>(
@@ -219,6 +229,7 @@ export const ReviewApproveModal: React.FC<{
       setReviewError(null);
       setSelectedDataStreamForFlyout(null);
       setSelectedCategories([]);
+      setAutoInstallAfterApproval(true);
       loadReviewDetails();
     }
   }, [isOpen, loadReviewDetails]);
@@ -303,6 +314,9 @@ export const ReviewApproveModal: React.FC<{
     setReviewError(null);
     try {
       await onApproveAndDeploy(integrationId, version, categoryIds);
+      if (autoInstallAfterApproval && onInstallToCluster) {
+        await onInstallToCluster(integrationId);
+      }
       onClose();
     } catch (error) {
       setReviewError(
@@ -317,9 +331,11 @@ export const ReviewApproveModal: React.FC<{
     }
   }, [
     automaticImport,
+    autoInstallAfterApproval,
     integrationId,
     onApproveAndDeploy,
     onClose,
+    onInstallToCluster,
     reviewDetails,
     reviewVersion,
     selectedCategories,
@@ -491,6 +507,20 @@ export const ReviewApproveModal: React.FC<{
                 onChange={(options) => setSelectedCategories(options)}
               />
             </EuiFormRow>
+            <EuiSpacer size="m" />
+            <EuiCheckbox
+              id={autoInstallCheckboxId}
+              data-test-subj="manageIntegrationReviewAutoInstallCheckbox"
+              label={i18n.translate(
+                'xpack.fleet.epmList.manageIntegrations.actions.reviewModalAutoInstallLabel',
+                {
+                  defaultMessage: 'Automatically install integration after approval',
+                }
+              )}
+              checked={autoInstallAfterApproval}
+              onChange={(event) => setAutoInstallAfterApproval(event.target.checked)}
+              disabled={isApproving}
+            />
           </>
         )}
         {reviewError && (

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/components/review_approve_modal.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/components/review_approve_modal.tsx
@@ -319,6 +319,16 @@ export const ReviewApproveModal: React.FC<{
     try {
       const willAutoInstall = autoInstallAfterApproval && Boolean(onInstallToCluster);
       await onApproveAndInstall(integrationId, version, categoryIds, willAutoInstall);
+      if (willAutoInstall) {
+        (automaticImport?.telemetry as AutomaticImportTelemetry)?.reportEvent(
+          'automatic_import_approve_modal_approve_with_auto_install_clicked',
+          {
+            integrationId,
+            version: reviewVersion.trim(),
+            dataStreamCount: reviewDetails?.dataStreams.length ?? 0,
+          }
+        );
+      }
       if (autoInstallAfterApproval && onInstallToCluster) {
         await onInstallToCluster(integrationId, { skipSuccessToast: true });
       }

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/page_objects/manage_integrations_table_page.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/page_objects/manage_integrations_table_page.ts
@@ -106,6 +106,10 @@ export class ManageIntegrationsTablePage {
     return this.page.testSubj.locator('manageIntegrationReviewModalCategories');
   }
 
+  getReviewModalAutoInstallCheckbox() {
+    return this.page.testSubj.locator('manageIntegrationReviewAutoInstallCheckbox');
+  }
+
   getActionsFilterButton() {
     return this.page.testSubj.locator('manageIntegrationsActionsFilterBtn');
   }

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/page_objects/manage_integrations_table_page.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/page_objects/manage_integrations_table_page.ts
@@ -90,8 +90,8 @@ export class ManageIntegrationsTablePage {
     return this.page.getByRole('dialog', { name: 'Review and approve data streams dialog' });
   }
 
-  getReviewApproveDeployButton() {
-    return this.page.testSubj.locator('manageIntegrationReviewApproveDeployButton');
+  getReviewApproveInstallButton() {
+    return this.page.testSubj.locator('manageIntegrationReviewApproveInstallButton');
   }
 
   getReviewModalCancelButton() {

--- a/x-pack/platform/plugins/shared/fleet/test/scout_automatic_import/ui/tests/manage_integrations_table.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout_automatic_import/ui/tests/manage_integrations_table.spec.ts
@@ -277,6 +277,8 @@ test.describe('Manage Integrations Table', { tag: tags.stateful.classic }, () =>
     await categoryInput.press('ArrowDown');
     await categoryInput.press('Enter');
 
+    await pageObjects.manageIntegrationsTable.getReviewModalAutoInstallCheckbox().uncheck();
+
     const approveRequest = page.waitForRequest(
       (req) =>
         req.url().includes(`/integrations/${MOCK_COMPLETED.integrationId}/approve`) &&
@@ -285,6 +287,146 @@ test.describe('Manage Integrations Table', { tag: tags.stateful.classic }, () =>
     await pageObjects.manageIntegrationsTable.getReviewApproveInstallButton().click();
     await approveRequest;
     await expect(pageObjects.manageIntegrationsTable.getReviewApproveModal()).toBeHidden();
+  });
+
+  test('Review modal auto-install checkbox: is checked by default', async ({
+    page,
+    pageObjects,
+  }) => {
+    await mockIntegrationsList(page, [MOCK_COMPLETED]);
+    await mockIntegrationDetails(page, MOCK_COMPLETED.integrationId);
+    await pageObjects.manageIntegrationsTable.navigateTo();
+    await pageObjects.manageIntegrationsTable.openActionsMenu('Completed Integration');
+    await pageObjects.manageIntegrationsTable.getReviewApproveMenuItem().click();
+    await expect(pageObjects.manageIntegrationsTable.getReviewApproveModal()).toBeVisible();
+    const checkbox = pageObjects.manageIntegrationsTable.getReviewModalAutoInstallCheckbox();
+    await expect(checkbox).toBeVisible();
+    await expect(checkbox).toBeChecked();
+  });
+
+  test('Review modal auto-install checkbox: approve with it on calls approve, download, and EPM install then closes', async ({
+    page,
+    pageObjects,
+  }) => {
+    await mockIntegrationsList(page, [MOCK_COMPLETED]);
+    await mockIntegrationDetails(page, MOCK_COMPLETED.integrationId);
+    await page.route('**/api/fleet/epm/categories**', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ items: [{ id: 'security', title: 'Security', count: 1 }] }),
+      })
+    );
+    await page.route(
+      `**/api/automatic_import/integrations/${MOCK_COMPLETED.integrationId}/approve`,
+      (route) => route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })
+    );
+    await page.route(
+      `**/api/automatic_import/integrations/${MOCK_COMPLETED.integrationId}/download*`,
+      (route) =>
+        route.fulfill({
+          status: 200,
+          headers: { 'content-type': 'application/zip' },
+          body: Buffer.from('PK'),
+        })
+    );
+    await page.route('**/api/fleet/epm/packages', (route) => {
+      if (route.request().method() === 'POST') {
+        return route.fulfill({ status: 200, contentType: 'application/json', body: '{}' });
+      }
+      return route.continue();
+    });
+
+    await pageObjects.manageIntegrationsTable.navigateTo();
+    await pageObjects.manageIntegrationsTable.openActionsMenu('Completed Integration');
+    await pageObjects.manageIntegrationsTable.getReviewApproveMenuItem().click();
+    await expect(pageObjects.manageIntegrationsTable.getReviewApproveModal()).toBeVisible();
+    await expect(
+      pageObjects.manageIntegrationsTable.getReviewModalAutoInstallCheckbox()
+    ).toBeChecked();
+
+    await pageObjects.manageIntegrationsTable.getReviewModalVersionInput().fill('1.0.0');
+    const categoryInput = pageObjects.manageIntegrationsTable
+      .getReviewModalCategoriesComboBox()
+      .locator('input');
+    await categoryInput.click();
+    await categoryInput.press('ArrowDown');
+    await categoryInput.press('Enter');
+
+    const approveRequest = page.waitForRequest(
+      (req) =>
+        req.url().includes(`/integrations/${MOCK_COMPLETED.integrationId}/approve`) &&
+        req.method() === 'POST'
+    );
+    const downloadRequest = page.waitForRequest(
+      (req) =>
+        req.url().includes(`/integrations/${MOCK_COMPLETED.integrationId}/download`) &&
+        req.url().includes('intent=install') &&
+        req.method() === 'GET'
+    );
+    const installRequest = page.waitForRequest(
+      (req) => req.url().includes('/api/fleet/epm/packages') && req.method() === 'POST'
+    );
+    await pageObjects.manageIntegrationsTable.getReviewApproveInstallButton().click();
+    await Promise.all([approveRequest, downloadRequest, installRequest]);
+    await expect(pageObjects.manageIntegrationsTable.getReviewApproveModal()).toBeHidden();
+  });
+
+  test('Review modal auto-install checkbox: when off, only the approve API runs (no install download)', async ({
+    page,
+    pageObjects,
+  }) => {
+    let installIntentDownloadCount = 0;
+    await page.route('**/api/automatic_import/integrations/**/download**', (route) => {
+      if (new URL(route.request().url()).searchParams.get('intent') === 'install') {
+        installIntentDownloadCount += 1;
+      }
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/zip',
+        body: Buffer.from('PK'),
+      });
+    });
+
+    await mockIntegrationsList(page, [MOCK_COMPLETED]);
+    await mockIntegrationDetails(page, MOCK_COMPLETED.integrationId);
+    await page.route('**/api/fleet/epm/categories**', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ items: [{ id: 'security', title: 'Security', count: 1 }] }),
+      })
+    );
+    await page.route(
+      `**/api/automatic_import/integrations/${MOCK_COMPLETED.integrationId}/approve`,
+      (route) => route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })
+    );
+
+    await pageObjects.manageIntegrationsTable.navigateTo();
+    await pageObjects.manageIntegrationsTable.openActionsMenu('Completed Integration');
+    await pageObjects.manageIntegrationsTable.getReviewApproveMenuItem().click();
+    await expect(pageObjects.manageIntegrationsTable.getReviewApproveModal()).toBeVisible();
+    await pageObjects.manageIntegrationsTable.getReviewModalVersionInput().fill('1.0.0');
+    const categoryInput = pageObjects.manageIntegrationsTable
+      .getReviewModalCategoriesComboBox()
+      .locator('input');
+    await categoryInput.click();
+    await categoryInput.press('ArrowDown');
+    await categoryInput.press('Enter');
+    await pageObjects.manageIntegrationsTable.getReviewModalAutoInstallCheckbox().uncheck();
+    await expect(
+      pageObjects.manageIntegrationsTable.getReviewModalAutoInstallCheckbox()
+    ).not.toBeChecked();
+
+    const approveRequest = page.waitForRequest(
+      (req) =>
+        req.url().includes(`/integrations/${MOCK_COMPLETED.integrationId}/approve`) &&
+        req.method() === 'POST'
+    );
+    await pageObjects.manageIntegrationsTable.getReviewApproveInstallButton().click();
+    await approveRequest;
+    await expect(pageObjects.manageIntegrationsTable.getReviewApproveModal()).toBeHidden();
+    expect(installIntentDownloadCount).toBe(0);
   });
 
   test('closing the Review & Approve modal via Cancel dismisses it', async ({
@@ -789,6 +931,7 @@ test.describe('Manage Integrations Table', { tag: tags.stateful.classic }, () =>
     await categoryInput.press('ArrowDown');
     await categoryInput.press('Enter');
 
+    await pageObjects.manageIntegrationsTable.getReviewModalAutoInstallCheckbox().uncheck();
     await pageObjects.manageIntegrationsTable.getReviewApproveInstallButton().click();
 
     const modal = pageObjects.manageIntegrationsTable.getReviewApproveModal();

--- a/x-pack/platform/plugins/shared/fleet/test/scout_automatic_import/ui/tests/manage_integrations_table.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout_automatic_import/ui/tests/manage_integrations_table.spec.ts
@@ -231,10 +231,14 @@ test.describe('Manage Integrations Table', { tag: tags.stateful.classic }, () =>
     await pageObjects.manageIntegrationsTable.getReviewApproveMenuItem().click();
     await expect(pageObjects.manageIntegrationsTable.getReviewApproveModal()).toBeVisible();
 
-    await expect(pageObjects.manageIntegrationsTable.getReviewApproveDeployButton()).toBeDisabled();
+    await expect(
+      pageObjects.manageIntegrationsTable.getReviewApproveInstallButton()
+    ).toBeDisabled();
 
     await pageObjects.manageIntegrationsTable.getReviewModalVersionInput().fill('1.0.0');
-    await expect(pageObjects.manageIntegrationsTable.getReviewApproveDeployButton()).toBeDisabled();
+    await expect(
+      pageObjects.manageIntegrationsTable.getReviewApproveInstallButton()
+    ).toBeDisabled();
 
     const categoryInput = pageObjects.manageIntegrationsTable
       .getReviewModalCategoriesComboBox()
@@ -242,7 +246,7 @@ test.describe('Manage Integrations Table', { tag: tags.stateful.classic }, () =>
     await categoryInput.click();
     await categoryInput.press('ArrowDown');
     await categoryInput.press('Enter');
-    await expect(pageObjects.manageIntegrationsTable.getReviewApproveDeployButton()).toBeEnabled();
+    await expect(pageObjects.manageIntegrationsTable.getReviewApproveInstallButton()).toBeEnabled();
   });
 
   test('Approve flow calls the approve API and closes the modal', async ({ page, pageObjects }) => {
@@ -278,7 +282,7 @@ test.describe('Manage Integrations Table', { tag: tags.stateful.classic }, () =>
         req.url().includes(`/integrations/${MOCK_COMPLETED.integrationId}/approve`) &&
         req.method() === 'POST'
     );
-    await pageObjects.manageIntegrationsTable.getReviewApproveDeployButton().click();
+    await pageObjects.manageIntegrationsTable.getReviewApproveInstallButton().click();
     await approveRequest;
     await expect(pageObjects.manageIntegrationsTable.getReviewApproveModal()).toBeHidden();
   });
@@ -648,7 +652,9 @@ test.describe('Manage Integrations Table', { tag: tags.stateful.classic }, () =>
     await expect(pageObjects.manageIntegrationsTable.getReviewApproveModal()).toBeVisible();
 
     await pageObjects.manageIntegrationsTable.getReviewModalVersionInput().fill('1.0.0');
-    await expect(pageObjects.manageIntegrationsTable.getReviewApproveDeployButton()).toBeDisabled();
+    await expect(
+      pageObjects.manageIntegrationsTable.getReviewApproveInstallButton()
+    ).toBeDisabled();
     await expect(page.getByText('Select at least one category.')).toBeVisible();
   });
 
@@ -783,7 +789,7 @@ test.describe('Manage Integrations Table', { tag: tags.stateful.classic }, () =>
     await categoryInput.press('ArrowDown');
     await categoryInput.press('Enter');
 
-    await pageObjects.manageIntegrationsTable.getReviewApproveDeployButton().click();
+    await pageObjects.manageIntegrationsTable.getReviewApproveInstallButton().click();
 
     const modal = pageObjects.manageIntegrationsTable.getReviewApproveModal();
     await expect(modal).toBeVisible();


### PR DESCRIPTION
## Summary

Improves the **Manage integrations** Review & Approve flow for automatic-import packages: optional **install on approve**, clearer success toasts, **deploy → install** naming, and minor a11y/UX fixes. Also fixes the **Edit integration** page so **Done** enables after a successful **reanalyse** when the integration form is unchanged, plus a tooltip a11y fix for bulk **Install**.

## Changes

### Review & Approve (Fleet)
- **Checkbox (default on):** “Automatically install integration after approval” — runs the same `installToCluster` path as the **Install** menu action after approve.
- **Success toasts:** Without auto-install: “Integration approved”. With auto-install: “Integration approved and installed” (and suppresses the duplicate “installed to cluster” success toast on that path).
- **Copy:** “Deploy” → “install” in this flow (prop/handler names, user strings, and `data-test-subj` for the primary Approve action).
- **a11y:** `tabIndex={0}` on the `EuiToolTip` wrapper for bulk **Install** (disabled button + tooltip pattern).

### Automatic Import – Edit integration
- **Done** was disabled when only a data stream was reanalysed (reanalysis does not mark the integration form dirty). After a **successful** reanalyse, **Done** is allowed; state resets on integration id change.
- Wires: `ManagementContents` → `DataStreams` → `DataStreamsTable` via `onReanalyzeSuccess`; reanalyse uses `mutateAsync` and invokes the parent callback only on success.

### Tests
- Scout: `getReviewApproveInstallButton` and `manageIntegrationReviewApproveInstallButton` match the new `data-test-subj`.


https://github.com/user-attachments/assets/cab5adf5-1da1-440b-a682-b956ee7c944e



## How to test

1. **Fleet → Integrations → Manage (automatic import):** Open **Review & Approve** — exercise checkbox, approve with/without auto-install, toasts, and install behavior.
2. **Automatic Import → Edit integration:** Reanalyse a data stream with no other field edits — **Done** should enable after success.
3. Run `node scripts/check_changes.ts` (and Scout for `manage_integrations_table` if you touch those tests).

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->