### PR TITLE
[Dataset quality] Fix 400 on page refresh when a text filter is active

### DIFF
--- a/x-pack/platform/plugins/shared/dataset_quality/public/services/data_streams_stats/data_streams_stats_client.ts
+++ b/x-pack/platform/plugins/shared/dataset_quality/public/services/data_streams_stats/data_streams_stats_client.ts
@@ -87,7 +87,7 @@ export class DataStreamsStatsClient implements IDataStreamsStatsClient {
     params: GetDataStreamsStatsQuery
   ): Promise<DataStreamStatServiceResponse> {
     const types =
-      'types' in params
+      'types' in params && params.types
         ? rison.encodeArray(params.types.length === 0 ? KNOWN_TYPES : params.types)
         : undefined;
     const response = await this.http

--- a/x-pack/platform/plugins/shared/dataset_quality/public/state_machines/dataset_quality_controller/src/state_machine.test.ts
+++ b/x-pack/platform/plugins/shared/dataset_quality/public/state_machines/dataset_quality_controller/src/state_machine.test.ts
@@ -292,6 +292,40 @@ describe('DatasetQualityControllerStateMachine', () => {
         actor.stop();
       });
 
+      // Regression coverage for https://github.com/elastic/kibana/issues/250827:
+      // the free-text filter (filters.query) is applied client-side only, so
+      // passing it as `datasetQuery` to the stats/degraded/failed endpoints
+      // both triggered a 400 on /stats (the route schema rejected the combo)
+      // and caused the server to treat the substring as a literal data stream
+      // name on /degraded_docs and /failed_docs, returning empty results.
+      it('should not forward filters.query to stats/degraded/failed fetches', async () => {
+        const { machine, dataStreamStatsClient } = buildStateMachine({
+          initialContext: {
+            ...DEFAULT_CONTEXT,
+            filters: {
+              ...DEFAULT_CONTEXT.filters,
+              query: 'synth',
+            },
+          },
+        });
+        const actor = createActor(machine);
+        actor.start();
+
+        await waitForState(actor, 'main.stats.datasets.loaded');
+
+        expect(dataStreamStatsClient.getDataStreamsStats).toHaveBeenCalledWith(
+          expect.not.objectContaining({ datasetQuery: expect.anything() })
+        );
+        expect(dataStreamStatsClient.getDataStreamsDegradedStats).toHaveBeenCalledWith(
+          expect.not.objectContaining({ datasetQuery: expect.anything() })
+        );
+        expect(dataStreamStatsClient.getDataStreamsFailedStats).toHaveBeenCalledWith(
+          expect.not.objectContaining({ datasetQuery: expect.anything() })
+        );
+
+        actor.stop();
+      });
+
       it('should transition datasets to loaded on success', async () => {
         const { machine } = buildStateMachine();
         const actor = createActor(machine);

--- a/x-pack/platform/plugins/shared/dataset_quality/public/state_machines/dataset_quality_controller/src/state_machine.test.ts
+++ b/x-pack/platform/plugins/shared/dataset_quality/public/state_machines/dataset_quality_controller/src/state_machine.test.ts
@@ -292,12 +292,6 @@ describe('DatasetQualityControllerStateMachine', () => {
         actor.stop();
       });
 
-      // Regression coverage for https://github.com/elastic/kibana/issues/250827:
-      // the free-text filter (filters.query) is applied client-side only, so
-      // passing it as `datasetQuery` to the stats/degraded/failed endpoints
-      // both triggered a 400 on /stats (the route schema rejected the combo)
-      // and caused the server to treat the substring as a literal data stream
-      // name on /degraded_docs and /failed_docs, returning empty results.
       it('should not forward filters.query to stats/degraded/failed fetches', async () => {
         const { machine, dataStreamStatsClient } = buildStateMachine({
           initialContext: {

--- a/x-pack/platform/plugins/shared/dataset_quality/public/state_machines/dataset_quality_controller/src/state_machine.ts
+++ b/x-pack/platform/plugins/shared/dataset_quality/public/state_machines/dataset_quality_controller/src/state_machine.ts
@@ -735,7 +735,6 @@ const createLoadDataStreamStatsActor = ({
   fromPromise(async ({ input }: { input: DatasetQualityControllerContext }) =>
     dataStreamStatsClient.getDataStreamsStats({
       types: getValidDatasetTypes(input, isDatasetQualityAllSignalsAvailable),
-      datasetQuery: input.filters.query,
     })
   );
 
@@ -771,7 +770,6 @@ const createLoadDegradedDocsActor = ({
 
     return dataStreamStatsClient.getDataStreamsDegradedStats({
       types: getValidDatasetTypes(input, isDatasetQualityAllSignalsAvailable),
-      datasetQuery: input.filters.query,
       start,
       end,
     });
@@ -786,7 +784,6 @@ const createLoadFailedDocsActor = ({
 
     return dataStreamStatsClient.getDataStreamsFailedStats({
       types: getValidDatasetTypes(input, isDatasetQualityAllSignalsAvailable),
-      datasetQuery: input.filters.query,
       start,
       end,
     });

--- a/x-pack/platform/plugins/shared/dataset_quality/server/routes/data_streams/routes.ts
+++ b/x-pack/platform/plugins/shared/dataset_quality/server/routes/data_streams/routes.ts
@@ -85,8 +85,13 @@ const datasetTypesPrivilegesRoute = createDatasetQualityServerRoute({
 const statsRoute = createDatasetQualityServerRoute({
   endpoint: 'GET /internal/dataset_quality/data_streams/stats',
   params: t.type({
+    // Each branch declares both keys so strict excess-key validation accepts
+    // requests that carry `types` and `datasetQuery` together.
     query: t.intersection([
-      t.union([t.type({ types: typesRt }), t.type({ datasetQuery: t.string })]),
+      t.union([
+        t.intersection([t.type({ types: typesRt }), t.partial({ datasetQuery: t.string })]),
+        t.intersection([t.type({ datasetQuery: t.string }), t.partial({ types: typesRt })]),
+      ]),
       t.partial({ includeCreationDate: toBooleanRt }),
     ]),
   }),

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/dataset_quality/stats.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/dataset_quality/stats.ts
@@ -261,10 +261,6 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
       });
     });
 
-    // Regression coverage for https://github.com/elastic/kibana/issues/250827:
-    // refreshing the Data Set Quality page with a text filter used to send both
-    // `types` and `datasetQuery` to /data_streams/stats, which the route schema
-    // (a t.union) incorrectly rejected as excess keys.
     describe('query schema accepts types and datasetQuery together', () => {
       let supertestDatasetQualityMonitorWithCookieCredentials: SupertestWithRoleScopeType;
       let roleAuthc: RoleCredentials;

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/dataset_quality/stats.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/dataset_quality/stats.ts
@@ -261,6 +261,41 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
       });
     });
 
+    // Regression coverage for https://github.com/elastic/kibana/issues/250827:
+    // refreshing the Data Set Quality page with a text filter used to send both
+    // `types` and `datasetQuery` to /data_streams/stats, which the route schema
+    // (a t.union) incorrectly rejected as excess keys.
+    describe('query schema accepts types and datasetQuery together', () => {
+      let supertestDatasetQualityMonitorWithCookieCredentials: SupertestWithRoleScopeType;
+      let roleAuthc: RoleCredentials;
+
+      before(async () => {
+        await saml.setCustomRole(customRoles.datasetQualityMonitorUserRole);
+        supertestDatasetQualityMonitorWithCookieCredentials =
+          await customRoleScopedSupertest.getSupertestWithCustomRoleScope({
+            useCookieHeader: true,
+            withInternalHeaders: true,
+          });
+        roleAuthc = await saml.createM2mApiKeyWithCustomRoleScope();
+      });
+
+      after(async () => {
+        await saml.invalidateM2mApiKeyWithRoleScope(roleAuthc);
+        await saml.deleteCustomRole();
+      });
+
+      it('accepts both types and datasetQuery in a single request', async () => {
+        const resp = await supertestDatasetQualityMonitorWithCookieCredentials
+          .get('/internal/dataset_quality/data_streams/stats')
+          .query({
+            types: rison.encodeArray(['logs']),
+            datasetQuery: 'synth',
+          });
+
+        expect(resp.status).to.be(200);
+      });
+    });
+
     describe('multiple dataStream types are requested', () => {
       let supertestDatasetQualityMonitorWithCookieCredentials: SupertestWithRoleScopeType;
       let roleAuthc: RoleCredentials;


### PR DESCRIPTION
closes: #250827

## Summary


Refreshing the Data Set Quality page with a value in the **Filter data sets** box (e.g. `pageState=(filters:(...,query:synth,...))`) failed with a 400 and rendered a misleading "You don't have the required privileges…" panel. The actual server response was:

```
"Failed to validate: Excess keys are not allowed: query.datasetQuery"
```

This PR fixes the underlying bug and a related latent one.

## Root cause

Two problems, both introduced/exposed by #210301 .

### Bug 1: server schema regression

`GET /internal/dataset_quality/data_streams/stats` was switched from:

```ts
t.intersection([t.type({ types }), t.partial({ datasetQuery })])
```

to:

```ts
t.intersection([
  t.union([t.type({ types }), t.type({ datasetQuery })]),
  t.partial({ includeCreationDate }),
])
```

The union was added so the new Streams lifecycle caller could send `datasetQuery` without `types`. But under Kibana's strict excess-keys validation, a request carrying both keys (as the Data Set Quality page always does when a text filter is present) is rejected by either union branch, hence the 400.

### Bug 2: client sends `datasetQuery` for a client-side-only filter

The **Filter data sets** text box is a pure client-side substring filter (`dataset.rawName.includes(query)` in `use_dataset_quality_table.tsx`). The state machine was nevertheless forwarding that free-text value as `datasetQuery` to the stats/degraded/failed endpoints. Server-side, `datasetQuery` is treated as a literal data stream name (`datasetNames = [datasetQuery]`), so typing e.g. `synth` would make the server look for a stream literally named `synth` and return an empty result, a silent bug that was invisible on `/stats` (which also 400'd) but was quietly breaking `/degraded_docs` and `/failed_docs` on any refresh with a filter applied.

## How to test
To test it, add some filter (eg. `synth` if you are using synthrace scenario), then refresh the page. Filter should persist and there should be no error this time


<!--ONMERGE {"backportTargets":["9.2","9.3"]} ONMERGE-->