### PR TITLE
[8.19][Entity Store v1] Fix OAS docs by adding missing examples and descriptions

### DIFF
--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -14827,6 +14827,13 @@ paths:
       requestBody:
         content:
           application/json:
+            examples:
+              initEntityStoreRequest:
+                summary: Initialize with default settings
+                value:
+                  entityTypes:
+                    - host
+                    - user
             schema:
               type: object
               properties:
@@ -15073,6 +15080,16 @@ paths:
       requestBody:
         content:
           application/json:
+            examples:
+              initEntityEngineRequest:
+                summary: Initialize a host engine with default settings
+                value:
+                  delay: 1m
+                  fieldHistoryLength: 10
+                  frequency: 1m
+                  indexPattern: ''
+                  lookbackPeriod: 3h
+                  timestampField: '@timestamp'
             schema:
               type: object
               properties:
@@ -15385,6 +15402,22 @@ paths:
         '200':
           content:
             application/json:
+              examples:
+                listEntitiesResponse:
+                  summary: A page of host entities
+                  value:
+                    page: 1
+                    per_page: 10
+                    records:
+                      - entity:
+                          id: web-server-01
+                          name: web-server-01
+                          type: host
+                        host:
+                          ip:
+                            - 10.0.0.1
+                          name: web-server-01
+                    total: 1
               schema:
                 type: object
                 properties:

--- a/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/entity_store/enable.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/entity_store/enable.schema.yaml
@@ -17,6 +17,13 @@ paths:
         required: true
         content:
           application/json:
+            examples:
+              initEntityStoreRequest:
+                summary: Initialize with default settings
+                value:
+                  entityTypes:
+                    - host
+                    - user
             schema:
               type: object
               properties:

--- a/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/entity_store/engine/init.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/entity_store/engine/init.schema.yaml
@@ -23,6 +23,16 @@ paths:
         required: true
         content:
           application/json:
+            examples:
+              initEntityEngineRequest:
+                summary: Initialize a host engine with default settings
+                value:
+                  fieldHistoryLength: 10
+                  indexPattern: ''
+                  timestampField: '@timestamp'
+                  lookbackPeriod: '3h'
+                  frequency: '1m'
+                  delay: '1m'
             schema:
               type: object
               properties:

--- a/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/entity_store/entities/list_entities.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/entity_store/entities/list_entities.schema.yaml
@@ -92,3 +92,19 @@ paths:
                   - page
                   - per_page
                   - total
+              examples:
+                listEntitiesResponse:
+                  summary: A page of host entities
+                  value:
+                    records:
+                      - entity:
+                          id: 'web-server-01'
+                          name: 'web-server-01'
+                          type: 'host'
+                        host:
+                          name: 'web-server-01'
+                          ip:
+                            - '10.0.0.1'
+                    page: 1
+                    per_page: 10
+                    total: 1

--- a/x-pack/solutions/security/plugins/security_solution/docs/openapi/ess/security_solution_entity_analytics_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/docs/openapi/ess/security_solution_entity_analytics_api_2023_10_31.bundled.schema.yaml
@@ -307,6 +307,13 @@ paths:
       requestBody:
         content:
           application/json:
+            examples:
+              initEntityStoreRequest:
+                summary: Initialize with default settings
+                value:
+                  entityTypes:
+                    - host
+                    - user
             schema:
               type: object
               properties:
@@ -536,6 +543,16 @@ paths:
       requestBody:
         content:
           application/json:
+            examples:
+              initEntityEngineRequest:
+                summary: Initialize a host engine with default settings
+                value:
+                  delay: 1m
+                  fieldHistoryLength: 10
+                  frequency: 1m
+                  indexPattern: ''
+                  lookbackPeriod: 3h
+                  timestampField: '@timestamp'
             schema:
               type: object
               properties:
@@ -840,6 +857,22 @@ paths:
         '200':
           content:
             application/json:
+              examples:
+                listEntitiesResponse:
+                  summary: A page of host entities
+                  value:
+                    page: 1
+                    per_page: 10
+                    records:
+                      - entity:
+                          id: web-server-01
+                          name: web-server-01
+                          type: host
+                        host:
+                          ip:
+                            - 10.0.0.1
+                          name: web-server-01
+                    total: 1
               schema:
                 type: object
                 properties:

--- a/x-pack/solutions/security/plugins/security_solution/docs/openapi/serverless/security_solution_entity_analytics_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/docs/openapi/serverless/security_solution_entity_analytics_api_2023_10_31.bundled.schema.yaml
@@ -307,6 +307,13 @@ paths:
       requestBody:
         content:
           application/json:
+            examples:
+              initEntityStoreRequest:
+                summary: Initialize with default settings
+                value:
+                  entityTypes:
+                    - host
+                    - user
             schema:
               type: object
               properties:
@@ -536,6 +543,16 @@ paths:
       requestBody:
         content:
           application/json:
+            examples:
+              initEntityEngineRequest:
+                summary: Initialize a host engine with default settings
+                value:
+                  delay: 1m
+                  fieldHistoryLength: 10
+                  frequency: 1m
+                  indexPattern: ''
+                  lookbackPeriod: 3h
+                  timestampField: '@timestamp'
             schema:
               type: object
               properties:
@@ -840,6 +857,22 @@ paths:
         '200':
           content:
             application/json:
+              examples:
+                listEntitiesResponse:
+                  summary: A page of host entities
+                  value:
+                    page: 1
+                    per_page: 10
+                    records:
+                      - entity:
+                          id: web-server-01
+                          name: web-server-01
+                          type: host
+                        host:
+                          ip:
+                            - 10.0.0.1
+                          name: web-server-01
+                    total: 1
               schema:
                 type: object
                 properties:


### PR DESCRIPTION
## Summary

Adds missing examples and descriptions, fixing OAS docs for Entity Store v1 routes
