### PR TITLE
[Discover][Traces/Logs] Fix results table hidden after switching from metrics profile

### DIFF
--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/logs_data_source_profile/accessors/get_default_app_state.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/logs_data_source_profile/accessors/get_default_app_state.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { LOG_LEVEL_FIELD } from '@kbn/discover-utils';
+import { fieldConstants } from '@kbn/discover-utils';
 import type { DataSourceProfileProvider } from '../../../../profiles';
 import type { DefaultAppStateColumn } from '../../../../types';
 
@@ -22,7 +22,7 @@ export const createGetDefaultAppState = ({
     const appState = { ...prev(params) };
 
     appState.hideTable = false;
-    appState.breakdownField = LOG_LEVEL_FIELD;
+    appState.breakdownField = fieldConstants.LOG_LEVEL_FIELD;
 
     if (defaultColumns) {
       appState.columns = [];

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/logs_data_source_profile/accessors/get_default_app_state.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/logs_data_source_profile/accessors/get_default_app_state.ts
@@ -21,6 +21,7 @@ export const createGetDefaultAppState = ({
   return (prev) => (params) => {
     const appState = { ...prev(params) };
 
+    appState.hideTable = false;
     appState.breakdownField = LOG_LEVEL_FIELD;
 
     if (defaultColumns) {

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/logs_data_source_profile/profile.test.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/logs_data_source_profile/profile.test.ts
@@ -127,6 +127,17 @@ describe('logsDataSourceProfileProvider', () => {
     ).toEqual(RESOLUTION_MISMATCH);
   });
 
+  it('should return the correct default app state', () => {
+    const getDefaultAppState = logsDataSourceProfileProvider.profile.getDefaultAppState?.(
+      () => ({}),
+      { context: RESOLUTION_MATCH.context }
+    );
+    expect(getDefaultAppState?.({ dataView: dataViewWithTimefieldMock })).toMatchObject({
+      hideTable: false,
+      breakdownField: 'log.level',
+    });
+  });
+
   const dataViewWithLogLevel = createStubIndexPattern({
     spec: {
       title: VALID_IMPLICIT_DATA_INDEX_PATTERN,

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/logs_data_source_profile/sub_profiles/integration_logs.test.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/logs_data_source_profile/sub_profiles/integration_logs.test.ts
@@ -135,8 +135,9 @@ describe('createIntegrationLogsDataSourceProfileProviders', () => {
       const getDefaultAppState = provider.profile.getDefaultAppState?.(() => ({}), {
         context: RESOLUTION_MATCH.context,
       });
-      expect(getDefaultAppState?.({ dataView: dataViewWithTimefieldMock })).toMatchObject({
+      expect(getDefaultAppState?.({ dataView: dataViewWithTimefieldMock })).toEqual({
         hideTable: false,
+        breakdownField: 'log.level',
         columns: expectedColumnsMap[provider.profileId],
       });
     });

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/logs_data_source_profile/sub_profiles/integration_logs.test.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/logs_data_source_profile/sub_profiles/integration_logs.test.ts
@@ -135,7 +135,8 @@ describe('createIntegrationLogsDataSourceProfileProviders', () => {
       const getDefaultAppState = provider.profile.getDefaultAppState?.(() => ({}), {
         context: RESOLUTION_MATCH.context,
       });
-      expect(getDefaultAppState?.({ dataView: dataViewWithTimefieldMock })).toEqual({
+      expect(getDefaultAppState?.({ dataView: dataViewWithTimefieldMock })).toMatchObject({
+        hideTable: false,
         columns: expectedColumnsMap[provider.profileId],
       });
     });

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/traces_data_source_profile/accessors/get_default_app_state.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/traces_data_source_profile/accessors/get_default_app_state.ts
@@ -22,6 +22,7 @@ export const getDefaultAppState: DataSourceProfileProvider['profile']['getDefaul
   (prev) => (params) => ({
     ...prev(params),
 
+    hideTable: false,
     columns: [
       { name: TIMESTAMP_FIELD, width: 212 },
       { name: SERVICE_NAME_FIELD },

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/traces_data_source_profile/profile.test.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/traces_data_source_profile/profile.test.ts
@@ -125,6 +125,26 @@ describe('tracesDataSourceProfileProvider', () => {
     ).toEqual(RESOLUTION_MISMATCH);
   });
 
+  it('should return the correct default app state', () => {
+    const getDefaultAppState = tracesDataSourceProfileProvider.profile.getDefaultAppState?.(
+      () => ({}),
+      { context: RESOLUTION_MATCH.context }
+    );
+    expect(getDefaultAppState?.({ dataView: {} as unknown as DataView })).toMatchObject({
+      hideTable: false,
+      columns: [
+        { name: '@timestamp', width: 212 },
+        { name: 'service.name' },
+        { name: 'transaction.name' },
+        { name: 'span.name' },
+        { name: 'transaction.duration.us' },
+        { name: 'span.duration.us' },
+        { name: 'event.outcome' },
+      ],
+      rowHeight: 1,
+    });
+  });
+
   it('should NOT match when the solutionType is NOT Observability', () => {
     expect(
       tracesDataSourceProfileProvider.resolve({


### PR DESCRIPTION
## Summary

The traces and logs profiles now explicitly declare `hideTable: false` in their `getDefaultAppState` accessors. Without this, switching from a metrics `TS …` query to a `FROM traces*` or logs query left the results table permanently hidden.

### Root cause

The metrics profile sets `hideTable: true` via `getDefaultAppState`, which gets persisted to the URL state. On profile transition, the reset logic in `default_profile_state.ts` only clears a field when the incoming profile explicitly defines it:

https://github.com/elastic/kibana/blob/47cc5fe42a3cda2f8163ce24ea26278415600ea7/src/platform/plugins/shared/discover/public/application/main/state_management/utils/default_profile_state.ts#L60-L65

The traces and logs profiles never declared `hideTable`, so `defaultState.hideTable === undefined`, the condition short-circuits, and the `true` from the metrics profile is never cleared.

### Why this wasn't caught sooner

This is a concern that's hard to catch: `hideTable` was added to the metrics profile after the traces and logs profiles were established, and there's no mechanism today to signal other profile owners when new sticky state fields are introduced. We only found out when the behavior broke.

Worth discussing with @elastic/kibana-data-discovery: should the reset logic in [`default_profile_state.ts`](https://github.com/elastic/kibana/blob/main/src/platform/plugins/shared/discover/public/application/main/state_management/utils/default_profile_state.ts) fall back to the app default (`false`) when the incoming profile does not define a field, rather than preserving whatever the previous profile set? That would make the system self-correcting and avoid this class of bug regardless of who adds new fields. We've gone with the narrow fix for now but wanted to raise it.


### Options considered
- Option A (chosen): add `hideTable: false` to the traces and logs profile accessors. The `!== undefined` guard is intentional, a profile that doesn't define a field is deliberately neutral. The traces and logs profiles are not neutral about table visibility, so they should declare it explicitly.

- Option B (discarded for now): change the shared guard in [`default_profile_state.ts`](https://github.com/elastic/kibana/blob/main/src/platform/plugins/shared/discover/public/application/main/state_management/utils/default_profile_state.ts) to fall back to `false` when the incoming profile does not define a field. This fixes the bug, but it changes the guard globally and might affect other areas.


### Test coverage
The unit tests for `default_profile_state.ts` check the reset mechanics but use mocks that already return `hideTable: false`, so they would pass regardless of this change.

An E2E was also considered but not added, it would only guard against this specific regression. The real gap is structural: when a profile introduces a new sticky state field, all other profiles need to explicitly declare a reset value in `getDefaultAppState`, with no mechanism to enforce it.



### How to test

1. Open Discover in Observability
2. Run a metrics query using the `TS` command 
3. Confirm the results table is hidden
4. Change the query to `FROM traces*` 
5. Confirm the results table is now visible
