### PR TITLE
[ResponseOps][AlertingV2] Add temporary _reset_resources route

### DIFF
--- a/x-pack/platform/plugins/shared/alerting_v2/server/resources/README.md
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/resources/README.md
@@ -19,6 +19,44 @@ If you change stored document shape, retention behavior, or ES|QL views, this fo
 
 `register_resources.ts` registers datastreams and ES|QL views, then asks `ResourceManager` to start initialization during plugin start.
 
+## Temporary reset API (pre-GA only)
+
+While alerting v2 is still pre-GA and breaking resource changes are still expected, Kibana also exposes a temporary internal endpoint that wipes and recreates these resources:
+
+- endpoint: `POST /internal/alerting/v2/_reset_resources`
+- implementation: `server/routes/reset_resources_route.ts`
+- success response: `204 No Content`
+
+What it deletes:
+
+- all documents in `.rule-events`
+- all documents in `.alert-actions`
+- the backing index templates for those two data streams
+- all alerting v2 saved objects of type `alerting_rule`, `alerting_notification_policy`, and `alerting_api_key_pending_invalidation`
+- all per-rule task manager tasks of type `alerting_v2:rule_executor`
+
+What it recreates:
+
+- `.rule-events`
+- `.alert-actions`
+- their ILM policies and index templates
+
+How to call it from Kibana Dev Tools:
+
+```http
+POST kbn:/internal/alerting/v2/_reset_resources
+```
+
+Permissions required:
+
+- The alerting v2 feature privilegs
+- The superuser role to have access to system indices
+
+Notes:
+
+- This endpoint is intentionally destructive and only meant to unblock pre-GA development when resource or saved object schema changes require a clean slate.
+- Remove this section from the README when `server/routes/reset_resources_route.ts` is removed for GA. That cleanup is tracked by `rna-program#426`.
+
 ## Design principles
 
 | Topic | Behavior |

--- a/x-pack/platform/plugins/shared/alerting_v2/server/resources/datastreams/register.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/resources/datastreams/register.ts
@@ -31,6 +31,6 @@ export function registerDatastreams({
   }
 }
 
-function getDataStreamResourceDefinitions(): ResourceDefinition[] {
+export function getDataStreamResourceDefinitions(): ResourceDefinition[] {
   return [getAlertEventsResourceDefinition(), getAlertActionsResourceDefinition()];
 }

--- a/x-pack/platform/plugins/shared/alerting_v2/server/routes/reset_resources_route.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/routes/reset_resources_route.ts
@@ -7,9 +7,9 @@
 
 /**
  * Temporary endpoint used to reset the alerting_v2 resources (data streams,
- * their backing index templates, and all plugin-owned saved objects) when
- * breaking changes require a clean slate. Added as part of
- * https://github.com/elastic/rna-program/issues/204.
+ * their backing index templates, all plugin-owned saved objects, and the
+ * per-rule task_manager tasks) when breaking changes require a clean slate.
+ * Added as part of https://github.com/elastic/rna-program/issues/204.
  *
  * Meant to be removed before GA: delete this file and its `bind(Route)` entry
  * in `server/setup/bind_routes.ts`. Nothing else references it. Removal is
@@ -18,21 +18,18 @@
 
 import type { ElasticsearchClient } from '@kbn/core/server';
 import type { RouteSecurity } from '@kbn/core-http-server';
-import { ALERTING_CASES_SAVED_OBJECT_INDEX } from '@kbn/core-saved-objects-server';
+import {
+  ALERTING_CASES_SAVED_OBJECT_INDEX,
+  TASK_MANAGER_SAVED_OBJECT_INDEX,
+} from '@kbn/core-saved-objects-server';
 import { isResponseError } from '@kbn/es-errors';
 import { inject, injectable } from 'inversify';
 
+import { ALERTING_RULE_EXECUTOR_TASK_TYPE } from '../lib/rule_executor/task_definition';
 import { ALERTING_V2_API_PRIVILEGES } from '../lib/security/privileges';
 import { EsServiceScopedToken } from '../lib/services/es_service/tokens';
 import { DatastreamInitializer } from '../lib/services/resource_service/datastream_initializer';
-import {
-  ALERT_ACTIONS_DATA_STREAM,
-  getAlertActionsResourceDefinition,
-} from '../resources/datastreams/alert_actions';
-import {
-  ALERT_EVENTS_DATA_STREAM,
-  getAlertEventsResourceDefinition,
-} from '../resources/datastreams/alert_events';
+import { getDataStreamResourceDefinitions } from '../resources/datastreams/register';
 import type { ResourceDefinition } from '../resources/datastreams/types';
 import {
   API_KEY_PENDING_INVALIDATION_TYPE,
@@ -80,16 +77,15 @@ export class ResetResourcesRoute extends BaseAlertingRoute {
   }
 
   protected async execute() {
-    const definitions: ResourceDefinition[] = [
-      getAlertEventsResourceDefinition(),
-      getAlertActionsResourceDefinition(),
-    ];
+    const definitions = getDataStreamResourceDefinitions();
 
+    const dataStreamNames = definitions.map((definition) => definition.dataStreamName).join(', ');
     const savedObjectTypes = ALERTING_V2_SAVED_OBJECT_TYPES.join(', ');
     this.ctx.logger.debug(
-      `Resetting alerting v2 resources [${ALERT_EVENTS_DATA_STREAM}, ${ALERT_ACTIONS_DATA_STREAM}, saved objects: ${savedObjectTypes}]`
+      `Resetting alerting v2 resources [data streams: ${dataStreamNames}, saved objects: ${savedObjectTypes}, task type: ${ALERTING_RULE_EXECUTOR_TASK_TYPE}]`
     );
 
+    await this.deleteAllRuleTasks();
     await this.deleteAllSavedObjects();
 
     for (const definition of definitions) {
@@ -113,6 +109,32 @@ export class ResetResourcesRoute extends BaseAlertingRoute {
       index: ALERTING_CASES_SAVED_OBJECT_INDEX,
       query: {
         terms: { type: ALERTING_V2_SAVED_OBJECT_TYPES },
+      },
+      conflicts: 'proceed',
+      refresh: true,
+      wait_for_completion: true,
+    });
+  }
+
+  /**
+   * Delete every task_manager task associated with an alerting_v2 rule.
+   *
+   * Task manager tasks are stored as `type: 'task'` saved objects in
+   * `.kibana_task_manager` with the task type under `task.taskType`. We
+   * narrow to `ALERTING_RULE_EXECUTOR_TASK_TYPE` so recurring infra tasks
+   * owned by this plugin (API key invalidation, dispatcher, usage) are left
+   * alone — only the per-rule tasks are removed.
+   */
+  private async deleteAllRuleTasks(): Promise<void> {
+    await this.esClient.deleteByQuery({
+      index: TASK_MANAGER_SAVED_OBJECT_INDEX,
+      query: {
+        bool: {
+          must: [
+            { term: { type: 'task' } },
+            { term: { 'task.taskType': ALERTING_RULE_EXECUTOR_TASK_TYPE } },
+          ],
+        },
       },
       conflicts: 'proceed',
       refresh: true,

--- a/x-pack/platform/plugins/shared/alerting_v2/server/routes/reset_resources_route.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/routes/reset_resources_route.ts
@@ -1,0 +1,153 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * Temporary endpoint used to reset the alerting_v2 resources (data streams,
+ * their backing index templates, and all plugin-owned saved objects) when
+ * breaking changes require a clean slate. Added as part of
+ * https://github.com/elastic/rna-program/issues/204.
+ *
+ * Meant to be removed before GA: delete this file and its `bind(Route)` entry
+ * in `server/setup/bind_routes.ts`. Nothing else references it. Removal is
+ * tracked by https://github.com/elastic/rna-program/issues/426.
+ */
+
+import type { ElasticsearchClient } from '@kbn/core/server';
+import type { RouteSecurity } from '@kbn/core-http-server';
+import { ALERTING_CASES_SAVED_OBJECT_INDEX } from '@kbn/core-saved-objects-server';
+import { isResponseError } from '@kbn/es-errors';
+import { inject, injectable } from 'inversify';
+
+import { ALERTING_V2_API_PRIVILEGES } from '../lib/security/privileges';
+import { EsServiceScopedToken } from '../lib/services/es_service/tokens';
+import { DatastreamInitializer } from '../lib/services/resource_service/datastream_initializer';
+import {
+  ALERT_ACTIONS_DATA_STREAM,
+  getAlertActionsResourceDefinition,
+} from '../resources/datastreams/alert_actions';
+import {
+  ALERT_EVENTS_DATA_STREAM,
+  getAlertEventsResourceDefinition,
+} from '../resources/datastreams/alert_events';
+import type { ResourceDefinition } from '../resources/datastreams/types';
+import {
+  API_KEY_PENDING_INVALIDATION_TYPE,
+  NOTIFICATION_POLICY_SAVED_OBJECT_TYPE,
+  RULE_SAVED_OBJECT_TYPE,
+} from '../saved_objects';
+import { AlertingRouteContext } from './alerting_route_context';
+import { BaseAlertingRoute } from './base_alerting_route';
+
+const RESET_RESOURCES_API_PATH = '/internal/alerting/v2/_reset_resources';
+
+// Keep in sync with `registerSavedObjects` in `server/saved_objects/index.ts`.
+const ALERTING_V2_SAVED_OBJECT_TYPES = [
+  RULE_SAVED_OBJECT_TYPE,
+  NOTIFICATION_POLICY_SAVED_OBJECT_TYPE,
+  API_KEY_PENDING_INVALIDATION_TYPE,
+];
+
+@injectable()
+export class ResetResourcesRoute extends BaseAlertingRoute {
+  static method = 'post' as const;
+  static path = RESET_RESOURCES_API_PATH;
+  static security: RouteSecurity = {
+    authz: {
+      requiredPrivileges: [
+        ALERTING_V2_API_PRIVILEGES.rules.write,
+        ALERTING_V2_API_PRIVILEGES.alerts.write,
+        ALERTING_V2_API_PRIVILEGES.notificationPolicies.write,
+      ],
+    },
+  };
+  static routeOptions = {
+    access: 'internal',
+    summary: 'Reset alerting v2 resources (temporary, pre-GA only)',
+  } as const;
+  static validate = false as const;
+
+  protected readonly routeName = 'reset alerting v2 resources';
+
+  constructor(
+    @inject(AlertingRouteContext) ctx: AlertingRouteContext,
+    @inject(EsServiceScopedToken) private readonly esClient: ElasticsearchClient
+  ) {
+    super(ctx);
+  }
+
+  protected async execute() {
+    const definitions: ResourceDefinition[] = [
+      getAlertEventsResourceDefinition(),
+      getAlertActionsResourceDefinition(),
+    ];
+
+    const savedObjectTypes = ALERTING_V2_SAVED_OBJECT_TYPES.join(', ');
+    this.ctx.logger.debug(
+      `Resetting alerting v2 resources [${ALERT_EVENTS_DATA_STREAM}, ${ALERT_ACTIONS_DATA_STREAM}, saved objects: ${savedObjectTypes}]`
+    );
+
+    await this.deleteAllSavedObjects();
+
+    for (const definition of definitions) {
+      await this.deleteDataStreamIfExists(definition.dataStreamName);
+      await this.deleteIndexTemplateIfExists(definition.dataStreamName);
+      await this.recreate(definition);
+    }
+
+    return this.ctx.response.noContent();
+  }
+
+  /**
+   * Delete every saved object registered by this plugin across all spaces.
+   *
+   * The SavedObjectsClient does not expose a "delete all of type" operation,
+   * so we fall back to a `delete_by_query` against the saved objects index
+   * (`.kibana_alerting_cases`) filtered by the three plugin-owned types.
+   */
+  private async deleteAllSavedObjects(): Promise<void> {
+    await this.esClient.deleteByQuery({
+      index: ALERTING_CASES_SAVED_OBJECT_INDEX,
+      query: {
+        terms: { type: ALERTING_V2_SAVED_OBJECT_TYPES },
+      },
+      conflicts: 'proceed',
+      refresh: true,
+      wait_for_completion: true,
+    });
+  }
+
+  private async deleteDataStreamIfExists(name: string): Promise<void> {
+    try {
+      await this.esClient.indices.deleteDataStream({ name });
+    } catch (error) {
+      if (isResponseError(error) && error.statusCode === 404) {
+        return;
+      }
+
+      throw error;
+    }
+  }
+
+  private async deleteIndexTemplateIfExists(name: string): Promise<void> {
+    try {
+      await this.esClient.indices.deleteIndexTemplate({ name });
+    } catch (error) {
+      if (isResponseError(error) && error.statusCode === 404) {
+        return;
+      }
+
+      throw error;
+    }
+  }
+
+  private async recreate(definition: ResourceDefinition): Promise<void> {
+    // Manual construction instead of DI: DatastreamInitializer is wired to
+    // the internal ES client via @inject, and we want the request-scoped one.
+    const initializer = new DatastreamInitializer(this.ctx.logger, this.esClient, definition);
+    await initializer.initialize();
+  }
+}

--- a/x-pack/platform/plugins/shared/alerting_v2/server/setup/bind_routes.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/setup/bind_routes.ts
@@ -40,6 +40,13 @@ import { MatcherValueSuggestionsRoute } from '../routes/suggestions/matcher_valu
 import { MatcherDataFieldsRoute } from '../routes/suggestions/matcher_data_fields_route';
 import { NotificationPolicyTagsRoute } from '../routes/suggestions/notification_policy_tags_route';
 
+/**
+ * TODO: https://github.com/elastic/rna-program/issues/426
+ * Remove this route and its binding before GA.
+ */
+
+import { ResetResourcesRoute } from '../routes/reset_resources_route';
+
 export function bindRoutes({ bind }: ContainerModuleLoadOptions) {
   bind(Route).toConstantValue(CreateRuleRoute);
   bind(Route).toConstantValue(UpdateRuleRoute);
@@ -73,4 +80,6 @@ export function bindRoutes({ bind }: ContainerModuleLoadOptions) {
   bind(Route).toConstantValue(MatcherValueSuggestionsRoute);
   bind(Route).toConstantValue(MatcherDataFieldsRoute);
   bind(Route).toConstantValue(NotificationPolicyTagsRoute);
+  // TODO(rna-program#426): remove this binding before GA.
+  bind(Route).toConstantValue(ResetResourcesRoute);
 }


### PR DESCRIPTION
## Summary

Adds a temporary internal endpoint `POST /internal/alerting/v2/_reset_resources` that wipes and recreates the alerting_v2 Elasticsearch resources when breaking changes require a clean slate during pre-GA development.

What it does:

- Deletes the `.rule-events` and `.alert-actions` data streams (swallowing 404s).
- Deletes their backing index templates (swallowing 404s).
- Deletes all plugin-owned saved objects (`alerting_rule`, `alerting_notification_policy`, `alerting_api_key_pending_invalidation`) via a single `delete_by_query` against `.kibana_alerting_cases`, since the Saved Objects Client does not expose a "delete all of type" operation.
- Deletes all tasks associated with the rules.
- Recreates the data streams, ILM policies, and index templates by reusing `DatastreamInitializer`.
- Returns `204 No Content` on success.

All Elasticsearch calls use the request-scoped client (`EsServiceScopedToken`) so the caller's permissions are enforced. Access is gated on the combined write privileges for rules, alerts, and notification policies.

## Temporary, pre-GA only

The endpoint is intentionally self-contained in a single file (`routes/reset_resources_route.ts`) plus a single binding entry in `setup/bind_routes.ts`. Removal before GA is two deletes with no orphaned code.

- Closes: elastic/rna-program#204
- Removal tracked by: elastic/rna-program#426

## Test plan

- Start Kibana, create a rule and a notification policy, and index some alert events/actions.
- Call `POST kbn:/internal/alerting/v2/_reset_resources` with a user having the appropriate permissions. You need to have access to modify system indices and full access to the alerting v2 data streams.
- Verify `.rule-events` and `.alert-actions` data streams and index templates are recreated and are empty.
- Verify `alerting_rule`, `alerting_notification_policy`, and `alerting_api_key_pending_invalidation` saved objects are gone.

```
GET .kibana_alerting_cases/_search
{
  "query": {
    "bool": {
      "filter": [
        {
            "terms": {
              "type": [
                "alerting_rule",
                "alerting_notification_policy",
                "alerting_api_key_pending_invalidation"
              ]
            }
        }
      ]
    }
  }
}
```

- Verify that rule-related tasks are gone.

```
GET .kibana_task_manager/_search
{
  "query": {
    "bool": {
      "filter": [
        {
            "term": {
              "task.taskType": "alerting_v2:rule_executor"
            }
        }
      ]
    }
  }
}
```

- Call the endpoint with a user missing one of the required privileges; verify a 403.

Made with [Cursor](https://cursor.com)