### PR TITLE
Update Figma connector docs to be in-line with current connector beha…

### DIFF
--- a/docs/reference/connectors-kibana/figma-action-type.md
+++ b/docs/reference/connectors-kibana/figma-action-type.md
@@ -11,7 +11,7 @@ applies_to:
 
 # Figma connector [figma-action-type]
 
-The Figma connector communicates with the Figma REST API to browse design files, inspect document structure, render nodes as images, and explore team projects. It is used as a data source for Workplace AI (for example Agent Builder).
+The Figma connector communicates with the [Figma REST API](https://developers.figma.com/docs/rest-api/) to browse design files, inspect document structure, render nodes as images, and explore team projects. It can be used with Agent Builder and Workflows.
 
 ## Create connectors in {{kib}} [define-figma-ui]
 
@@ -19,10 +19,18 @@ You can create connectors in **{{stack-manage-app}} > {{connectors-ui}}**.
 
 ### Connector configuration [figma-connector-configuration]
 
-Figma connectors use API key (header) authentication:
+Figma connectors support **API key (header)** authentication (a Figma personal access token sent in the `X-Figma-Token` header) or **OAuth 2.0 authorization code** (Figma signs the user in through {{kib}} and {{kib}} stores refreshable tokens). Select the authentication type when you create or edit the connector.
 
-X-Figma-Token
-:   A Figma personal access token. See [Get API credentials](#figma-api-credentials) for how to obtain it.
+API key (header)
+:   A Figma personal access token sent in the `X-Figma-Token` header. See [Get API credentials](#figma-api-credentials).
+
+OAuth 2.0 authorization code
+:   Uses an **OAuth app** registered in Figma. In {{kib}} you provide:
+
+    - **Client ID** and **Client Secret**: from your Figma OAuth app
+    - **Redirect URI**: register {{kib}}'s OAuth callback in your Figma OAuth app (see [Get API credentials](#figma-api-credentials))
+
+    The connector automatically uses the correct Figma OAuth endpoints and scopes (`current_user:read`, `file_content:read`, and `projects:read`).
 
 ## Test connectors [figma-action-configuration]
 
@@ -43,15 +51,15 @@ List project files
     - **projectId** (required): The Figma project ID (from **List team projects** or the project URL).
 
 Get file
-:   Get a Figma file's structure, metadata, components, and styles. The file key can be taken from any Figma file URL: `https://www.figma.com/file/FILE_KEY/...`.
+:   Get a Figma file's structure, metadata, components, and styles. The file key can be taken from any Figma file URL of the form `https://www.figma.com/:file_type/:file_key/:file_name`, where `file_type` is one of `design`, `file`, `board`, `proto`, or `slides`.
     - **fileKey** (required): The file key from the Figma file URL.
-    - **node_ids** (optional): Comma-separated node IDs to retrieve specific nodes (for example `1:2,1:3`).
-    - **depth** (optional): How deep into the document tree to traverse. `1` = pages only; `2` = pages and top-level objects. Omit or increase for the full tree. Defaults to `2`.
+    - **nodeIds** (optional): Comma-separated node IDs to retrieve specific nodes (for example `1:2,1:3`).
+    - **depth** (optional): How deep into the document tree to traverse. `1` = pages only; `2` = pages and top-level objects. Omit for the full tree.
 
 Render nodes
 :   Render Figma nodes as images. Returns temporary image URLs (valid for 30 days). Supports PNG, JPG, SVG, and PDF.
     - **fileKey** (required): The file key from the Figma file URL.
-    - **node_ids** (required): Comma-separated node IDs to render (for example `1:2,1:3`). Find node IDs in Figma URLs (`?node-id=1:2`) or from **Get file** output.
+    - **nodeIds** (required): Comma-separated node IDs to render (for example `1:2,1:3`). Find node IDs in Figma URLs (`?node-id=1:2`) or from **Get file** output.
     - **format** (optional): Image format: `png`, `jpg`, `svg`, or `pdf`. Defaults to `png`.
     - **scale** (optional): Scale factor between 0.01 and 4. Defaults to `1`.
 
@@ -66,12 +74,49 @@ Use the [Action configuration settings](/reference/configuration-reference/alert
 <a id="figma-api-credentials"></a>
 ## Get API credentials [figma-api-credentials]
 
-To use the Figma connector, you need a Figma personal access token:
+The Figma connector supports two authentication methods: **OAuth 2.0 authorization code** (recommended) and **API key (header)** using a personal access token.
+
+### OAuth 2.0 authorization code (recommended)
+
+This matches the **OAuth 2.0 authorization code** authentication type in {{kib}}. You register a Figma OAuth app, then let users authorize the connector with their own Figma account; {{kib}} handles the token exchange and refresh automatically.
+
+1. Log in to [Figma](https://www.figma.com/) and go to [figma.com/developers/apps](https://www.figma.com/developers/apps).
+2. Select **Create new app** and enter a name (for example "Kibana").
+3. Open your draft app and start the configuration flow.
+4. On the **OAuth credentials** page, copy the **Client ID** and **Client Secret**. The Client Secret is only shown once, so store it securely.
+5. On the same page, select **Add a redirect URL** and enter {{kib}}'s OAuth callback URL. Copy the pattern below and substitute your public {{kib}} hostname:
+
+    ```text
+    https://<your-kibana-host>/api/actions/connector/_oauth_callback
+    ```
+
+6. On the **OAuth scopes** page, select the following scopes:
+
+    - `current_user:read` — read your name, email, and profile image
+    - `file_content:read` — read the contents of files, such as nodes and the editor type
+    - `projects:read` — list projects and files in projects
+
+7. Complete the configuration flow and publish the app. Private apps are available immediately; public apps require Figma review.
+8. In {{kib}}, create a Figma connector and select **OAuth 2.0 authorization code** as the authentication method. Enter the **Client ID** and **Client Secret**, then authorize with your Figma account. The connector automatically configures the correct Figma OAuth endpoints and scopes.
+
+::::{note}
+Figma access tokens expire after 90 days. The connector automatically refreshes them using the stored refresh token, so no manual rotation is required as long as the refresh token remains valid.
+::::
+
+### Personal access token (API key header)
+
+Use this method if you prefer a static token tied to your own Figma account. Tokens grant access to your Figma account and files shared with you.
 
 1. Log in to [Figma](https://www.figma.com/).
-2. Open your **Account settings** (profile menu → Settings, or [Figma account settings](https://www.figma.com/settings)).
-3. Scroll to **Personal access tokens** and click **Generate new token**.
-4. Name the token (for example "Kibana Figma connector") and copy the token value.
-5. Use this value as **X-Figma-Token** in the connector configuration. The connector sends it in the `X-Figma-Token` header per the [Figma REST API](https://developers.figma.com/docs/rest-api/).
+2. Open your [account settings](https://www.figma.com/settings) and select the **Security** tab.
+3. Scroll to **Personal access tokens** and select **Generate new token**.
+4. Name the token (for example "Kibana Figma connector"), set an expiration, and select the following scopes:
+
+    - `current_user:read`
+    - `file_content:read`
+    - `projects:read`
+
+5. Select **Generate token** and copy the token value. This is your only chance to copy it, so store it securely.
+6. In {{kib}}, create a Figma connector, select **API key (header)** as the authentication method, and paste the token as the value for `X-Figma-Token`.
 
 Keep the token secret because it grants access to your Figma account and files shared with you.


### PR DESCRIPTION
## Summary

Updates `docs/reference/connectors-kibana/figma-action-type.md` so it accurately reflects the Figma connector spec at `src/platform/packages/shared/kbn-connector-specs/src/specs/figma/figma.ts`.

### What changed

- **Documented OAuth 2.0 authorization code auth.** The spec supports both `api_key_header` (personal access token) and `oauth_authorization_code` (Client ID/Secret with auto-refresh), but the docs only covered the API key. Both methods are now documented in the **Connector configuration** and **Get API credentials** sections, with OAuth listed as recommended.
- **Fixed parameter names.** Docs used `node_ids` (snake_case) for `Get file` and `Render nodes`, but the Zod schemas in the spec use `nodeIds` (camelCase).
- **Removed an incorrect default.** Docs claimed `depth` defaults to `2`, but the spec has no default — corrected to "Omit for the full tree."
- **Broadened the file URL pattern.** The spec's `FILE_PATH_PREFIXES` accepts `design`, `file`, `board`, `proto`, and `slides`; docs now mention all five instead of only `file`.
- **Updated the intro.** Replaced "data source for Workplace AI (for example Agent Builder)" with "can be used with Agent Builder and Workflows," matching `supportedFeatureIds: ['workflows', 'agentBuilder']`.
- **Rewrote the credentials section** to include:
  - An OAuth app walkthrough (register at `figma.com/developers/apps`, copy Client ID/Secret, add `https://<kibana-host>/api/actions/connector/_oauth_callback` as redirect URL, select the granular scopes `current_user:read`, `file_content:read`, `projects:read`, publish).
  - A note that Figma access tokens expire after 90 days and are auto-refreshed by the connector.
  - Updated personal access token steps — PAT generation is now under **Settings → Security**, and the three granular scopes must be selected on the token.

### Impact

Docs-only change. No code changes, no behavior changes, no tests affected.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials




<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->