### PR TITLE
[9.4] Rename isCCSRemoteIndexName method to isNonLocalIndexName (#264539)

### DIFF
--- a/src/platform/packages/shared/kbn-es-query/index.ts
+++ b/src/platform/packages/shared/kbn-es-query/index.ts
@@ -141,7 +141,7 @@ export {
   getDataViewFieldSubtypeNested,
   isDataViewFieldSubtypeMulti,
   isDataViewFieldSubtypeNested,
-  isCCSRemoteIndexName,
+  isNonLocalIndexName,
   getTimeZoneFromSettings,
 } from './src/utils';
 

--- a/src/platform/packages/shared/kbn-es-query/src/utils.test.ts
+++ b/src/platform/packages/shared/kbn-es-query/src/utils.test.ts
@@ -7,40 +7,40 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { isCCSRemoteIndexName } from './utils';
+import { isNonLocalIndexName } from './utils';
 
 describe('util tests', () => {
-  describe('isCCSRemoteIndexName', () => {
+  describe('isNonLocalIndexName', () => {
     it('should not validate empty string', () => {
-      expect(isCCSRemoteIndexName('')).toBe(false);
+      expect(isNonLocalIndexName('')).toBe(false);
     });
 
     it('should not validate date math expression', () => {
-      expect(isCCSRemoteIndexName('<logstash-{now/d-2d}>')).toBe(false);
+      expect(isNonLocalIndexName('<logstash-{now/d-2d}>')).toBe(false);
     });
 
     it('should not validate date math expression with negation', () => {
-      expect(isCCSRemoteIndexName('-<logstash-{now/d-2d}>')).toBe(false);
+      expect(isNonLocalIndexName('-<logstash-{now/d-2d}>')).toBe(false);
     });
 
     it('should not validate invalid prefix', () => {
-      expect(isCCSRemoteIndexName(':logstash-{now/d-2d}')).toBe(false);
+      expect(isNonLocalIndexName(':logstash-{now/d-2d}')).toBe(false);
     });
 
     it('should validate CCS pattern', () => {
-      expect(isCCSRemoteIndexName('*:logstash-{now/d-2d}')).toBe(true);
+      expect(isNonLocalIndexName('*:logstash-{now/d-2d}')).toBe(true);
     });
 
     it('should not validate selector with wildcard', () => {
-      expect(isCCSRemoteIndexName('my-data-stream::*')).toBe(false);
+      expect(isNonLocalIndexName('my-data-stream::*')).toBe(false);
     });
 
     it('should not validate index name with selector', () => {
-      expect(isCCSRemoteIndexName('my-data-stream::failures')).toBe(false);
+      expect(isNonLocalIndexName('my-data-stream::failures')).toBe(false);
     });
 
     it('should not validate wildcard with selector', () => {
-      expect(isCCSRemoteIndexName('-logs-*::data')).toBe(false);
+      expect(isNonLocalIndexName('-logs-*::data')).toBe(false);
     });
   });
 });

--- a/src/platform/packages/shared/kbn-es-query/src/utils.ts
+++ b/src/platform/packages/shared/kbn-es-query/src/utils.ts
@@ -38,7 +38,9 @@ export function getDataViewFieldSubtypeMulti(field: HasSubtype) {
 }
 
 /**
- * Check whether the index expression represents a remote index (CCS) or not.
+ * Check whether the index expression represents a non-local index or not. This can happen in:
+ * - CCS for a remote cluster
+ * - CPS for a linked project
  * The index name is assumed to be individual index (no commas) but can contain `-`, wildcards,
  * datemath, remote cluster name and any other syntax permissible in index expression component.
  *
@@ -46,7 +48,7 @@ export function getDataViewFieldSubtypeMulti(field: HasSubtype) {
  *
  * @param indexExpression
  */
-export function isCCSRemoteIndexName(indexExpression: string): boolean {
+export function isNonLocalIndexName(indexExpression: string): boolean {
   if (indexExpression === '' || indexExpression[0] === '<' || indexExpression.startsWith('-<')) {
     // This is date math, but even if it is not, the remote can't start with '<'.
     // Thus, whatever it is, this is definitely not a remote index.

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/components/alert_event_overview.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/components/alert_event_overview.tsx
@@ -11,7 +11,7 @@ import type { FC, PropsWithChildren } from 'react';
 import React, { useMemo, useState } from 'react';
 import { fieldConstants, getFieldValue } from '@kbn/discover-utils';
 import type { DocViewerComponent } from '@kbn/unified-doc-viewer/types';
-import { isCCSRemoteIndexName } from '@kbn/es-query';
+import { isNonLocalIndexName } from '@kbn/es-query';
 import {
   EuiAccordion,
   EuiButton,
@@ -95,7 +95,7 @@ export const AlertEventOverview: DocViewerComponent = ({ hit }) => {
     // If the url is not populated, we fall back opening Timeline, but this will not work for remote indices as
     // Timeline should not read from linked project (at least during Tech Preview)
     const index = getFieldValue(hit, '_index') as string | undefined;
-    if (isCCSRemoteIndexName(index ?? '')) return undefined;
+    if (isNonLocalIndexName(index ?? '')) return undefined;
 
     // This will only be reached for local alerts that don't have the `kibana.alert.url` or all local events.
     return getSecurityTimelineRedirectUrl({

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_logs_overview/logs_overview_degraded_fields.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_logs_overview/logs_overview_degraded_fields.tsx
@@ -31,7 +31,7 @@ import { getRouterLinkProps } from '@kbn/router-utils';
 import type { DataQualityDetailsLocatorParams } from '@kbn/deeplinks-observability';
 import { DATA_QUALITY_DETAILS_LOCATOR_ID } from '@kbn/deeplinks-observability';
 import type { BrowserUrlService } from '@kbn/share-plugin/public';
-import { isCCSRemoteIndexName } from '@kbn/es-query';
+import { isNonLocalIndexName } from '@kbn/es-query';
 import { getUnifiedDocViewerServices } from '../../plugin';
 import type { ScrollableSectionWrapperApi } from './scrollable_section_wrapper';
 import { ScrollableSectionWrapper } from './scrollable_section_wrapper';
@@ -128,7 +128,7 @@ export const LogsOverviewDegradedFields = forwardRef<
     prefix: qualityIssuesAccordionTitle,
   });
 
-  const isCCSRemoteIndex = isCCSRemoteIndexName(rawDoc._index ?? '');
+  const isCCSRemoteIndex = isNonLocalIndexName(rawDoc._index ?? '');
 
   const [tableOptions, setTableOptions] = useState<TableOptions>(DEFAULT_TABLE_OPTIONS);
 

--- a/x-pack/platform/plugins/private/monitoring/common/ccs_utils.ts
+++ b/x-pack/platform/plugins/private/monitoring/common/ccs_utils.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { isCCSRemoteIndexName } from '@kbn/es-query';
+import { isNonLocalIndexName } from '@kbn/es-query';
 import type { MonitoringConfig } from '../server/config';
 
 /**
@@ -68,7 +68,7 @@ export function prefixIndexPatternWithCcs(
  * @return {String} {@code null} if none. Otherwise the cluster prefix.
  */
 export function parseCrossClusterPrefix(indexName: string): string | null {
-  const isCcs = isCCSRemoteIndexName(indexName);
+  const isCcs = isNonLocalIndexName(indexName);
   if (!isCcs) {
     return null;
   }

--- a/x-pack/platform/plugins/private/monitoring/server/lib/alerts/fetch_ccr_read_exceptions.ts
+++ b/x-pack/platform/plugins/private/monitoring/server/lib/alerts/fetch_ccr_read_exceptions.ts
@@ -7,7 +7,7 @@
 
 import type { ElasticsearchClient } from '@kbn/core/server';
 import { get } from 'lodash';
-import { isCCSRemoteIndexName } from '@kbn/es-query';
+import { isNonLocalIndexName } from '@kbn/es-query';
 import { CCS_REMOTE_PATTERN } from '../../../common/constants';
 import type { CCRReadExceptionsStats } from '../../../common/types/alerts';
 import { getIndexPatterns, getElasticsearchDataset } from '../../../common/get_index_patterns';
@@ -172,7 +172,7 @@ export async function fetchCCRReadExceptions(
         shardId,
         leaderIndex,
         lastReadException,
-        ccs: isCCSRemoteIndexName(monitoringIndexName) ? monitoringIndexName.split(':')[0] : null,
+        ccs: isNonLocalIndexName(monitoringIndexName) ? monitoringIndexName.split(':')[0] : null,
       });
     }
   }

--- a/x-pack/platform/plugins/private/monitoring/server/lib/alerts/fetch_cluster_health.ts
+++ b/x-pack/platform/plugins/private/monitoring/server/lib/alerts/fetch_cluster_health.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 import type { ElasticsearchClient } from '@kbn/core/server';
-import { isCCSRemoteIndexName } from '@kbn/es-query';
+import { isNonLocalIndexName } from '@kbn/es-query';
 import type { AlertCluster, AlertClusterHealth } from '../../../common/types/alerts';
 import type { ElasticsearchSource } from '../../../common/types/es';
 import { createDatasetFilter } from './create_dataset_query_filter';
@@ -86,7 +86,7 @@ export async function fetchClusterHealth(
       health:
         hit._source!.cluster_state?.status || hit._source!.elasticsearch?.cluster?.stats?.status,
       clusterUuid: hit._source!.cluster_uuid || hit._source!.elasticsearch?.cluster?.id,
-      ccs: isCCSRemoteIndexName(hit._index) ? hit._index.split(':')[0] : undefined,
+      ccs: isNonLocalIndexName(hit._index) ? hit._index.split(':')[0] : undefined,
     } as AlertClusterHealth;
   });
 }

--- a/x-pack/platform/plugins/private/transform/public/app/hooks/use_index_data.ts
+++ b/x-pack/platform/plugins/private/transform/public/app/hooks/use_index_data.ts
@@ -28,7 +28,7 @@ import {
 } from '@kbn/ml-data-grid';
 import type { TimeRange as TimeRangeMs } from '@kbn/ml-date-picker';
 
-import { isCCSRemoteIndexName } from '@kbn/es-query';
+import { isNonLocalIndexName } from '@kbn/es-query';
 import {
   hasKeywordDuplicate,
   isKeywordDuplicate,
@@ -174,7 +174,7 @@ export const useIndexData = (options: UseIndexDataOptions): UseIndexDataReturnTy
       setErrorMessage(getErrorMessage(dataGridDataError));
       setStatus(INDEX_STATUS.ERROR);
     } else if (!dataGridDataIsLoading && !dataGridDataIsError && dataGridData !== undefined) {
-      const isCrossClusterSearch = isCCSRemoteIndexName(indexPattern);
+      const isCrossClusterSearch = isNonLocalIndexName(indexPattern);
       const isMissingFields = dataGridData.hits.hits.every((d) => typeof d.fields === 'undefined');
 
       const docs = dataGridData.hits.hits.map((d) => getProcessedFields(d.fields ?? {}));

--- a/x-pack/platform/plugins/shared/ml/public/application/util/index_utils.ts
+++ b/x-pack/platform/plugins/shared/ml/public/application/util/index_utils.ts
@@ -6,7 +6,7 @@
  */
 
 import type { SavedSearch, SavedSearchPublicPluginStart } from '@kbn/saved-search-plugin/public';
-import { isCCSRemoteIndexName } from '@kbn/es-query';
+import { isNonLocalIndexName } from '@kbn/es-query';
 import type { Query, Filter } from '@kbn/es-query';
 import type { DataView, DataViewField, DataViewsContract } from '@kbn/data-views-plugin/common';
 import type { SearchSourceFields } from '@kbn/data-plugin/public';
@@ -74,7 +74,7 @@ export function getQueryFromSavedSearchObject(savedSearch: SavedSearch) {
  * which means it is cross-cluster
  */
 export function isCcsIndexPattern(indexPattern: string) {
-  return isCCSRemoteIndexName(indexPattern);
+  return isNonLocalIndexName(indexPattern);
 }
 
 export function findMessageField(

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/diagnostics/summary_tab/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/diagnostics/summary_tab/index.tsx
@@ -6,8 +6,8 @@
  */
 
 import React from 'react';
-import { EuiFlexGroup, EuiCallOut, EuiDescriptionList, EuiSpacer } from '@elastic/eui';
-import { isCCSRemoteIndexName } from '@kbn/es-query';
+import { EuiCallOut, EuiDescriptionList, EuiFlexGroup, EuiSpacer } from '@elastic/eui';
+import { isNonLocalIndexName } from '@kbn/es-query';
 
 import type { APIReturnType } from '../../../../services/rest/create_call_apm_api';
 import { ApmIntegrationPackageStatus } from './apm_integration_package_status';
@@ -101,6 +101,6 @@ function PrivilegesCallout({ diagnosticsBundle }: { diagnosticsBundle: Diagnosti
 
 export function getIsCrossCluster(diagnosticsBundle?: DiagnosticsBundle) {
   return Object.values(diagnosticsBundle?.apmIndices ?? {}).some((indicies) => {
-    return isCCSRemoteIndexName(indicies);
+    return isNonLocalIndexName(indicies);
   });
 }

--- a/x-pack/solutions/observability/plugins/apm/server/routes/correlations/queries/fetch_p_values.test.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/correlations/queries/fetch_p_values.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { isCCSRemoteIndexName } from '@kbn/es-query';
+import { isNonLocalIndexName } from '@kbn/es-query';
 import { ERROR_CORRELATION_THRESHOLD } from '../../../../common/correlations/constants';
 import type { FailedTransactionsCorrelation } from '../../../../common/correlations/failed_transactions_correlations/types';
 import type {
@@ -27,8 +27,8 @@ const mockFetchFailedEventsCorrelationPValues =
   fetchFailedEventsCorrelationPValues as jest.MockedFunction<
     typeof fetchFailedEventsCorrelationPValues
   >;
-const mockIsCCSRemoteIndexName = isCCSRemoteIndexName as jest.MockedFunction<
-  typeof isCCSRemoteIndexName
+const mockisNonLocalIndexName = isNonLocalIndexName as jest.MockedFunction<
+  typeof isNonLocalIndexName
 >;
 
 describe('fetchPValues', () => {
@@ -65,7 +65,7 @@ describe('fetchPValues', () => {
 
   beforeEach(() => {
     jest.resetAllMocks();
-    mockIsCCSRemoteIndexName.mockReturnValue(false);
+    mockisNonLocalIndexName.mockReturnValue(false);
   });
 
   it('should return failed transactions correlations when pValues are below threshold', async () => {
@@ -321,7 +321,7 @@ describe('fetchPValues', () => {
       durationMax: 200,
     });
 
-    mockIsCCSRemoteIndexName.mockReturnValue(true);
+    mockisNonLocalIndexName.mockReturnValue(true);
 
     const correlation: FailedTransactionsCorrelation = {
       fieldName: 'service.version',
@@ -344,7 +344,7 @@ describe('fetchPValues', () => {
 
     expect(result.ccsWarning).toBe(true);
     expect(result.failedTransactionsCorrelations).toHaveLength(1);
-    expect(mockIsCCSRemoteIndexName).toHaveBeenCalledWith('apm-*-transaction-*');
+    expect(mockisNonLocalIndexName).toHaveBeenCalledWith('apm-*-transaction-*');
   });
 
   it('should set ccsWarning to false when there are rejected promises but index is not remote', async () => {
@@ -355,7 +355,7 @@ describe('fetchPValues', () => {
       durationMax: 200,
     });
 
-    mockIsCCSRemoteIndexName.mockReturnValue(false);
+    mockisNonLocalIndexName.mockReturnValue(false);
 
     const correlation: FailedTransactionsCorrelation = {
       fieldName: 'service.version',

--- a/x-pack/solutions/observability/plugins/apm/server/routes/correlations/queries/fetch_p_values.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/correlations/queries/fetch_p_values.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { isCCSRemoteIndexName } from '@kbn/es-query';
+import { isNonLocalIndexName } from '@kbn/es-query';
 import pLimit from 'p-limit';
 import { ERROR_CORRELATION_THRESHOLD } from '../../../../common/correlations/constants';
 import type { FailedTransactionsCorrelation } from '../../../../common/correlations/failed_transactions_correlations/types';
@@ -112,7 +112,7 @@ export const fetchPValues = async ({
 
   const index = apmEventClient.indices[eventType as keyof typeof apmEventClient.indices];
 
-  const ccsWarning = rejected.length > 0 && isCCSRemoteIndexName(index);
+  const ccsWarning = rejected.length > 0 && isNonLocalIndexName(index);
 
   return { failedTransactionsCorrelations, ccsWarning, fallbackResult };
 };

--- a/x-pack/solutions/observability/plugins/apm/server/routes/correlations/queries/fetch_significant_correlations.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/correlations/queries/fetch_significant_correlations.ts
@@ -8,7 +8,7 @@
 import { range } from 'lodash';
 
 import { termQuery } from '@kbn/observability-plugin/server';
-import { isCCSRemoteIndexName } from '@kbn/es-query';
+import { isNonLocalIndexName } from '@kbn/es-query';
 import type { LatencyCorrelation } from '../../../../common/correlations/latency_correlations/types';
 import type {
   CommonCorrelationsQueryParams,
@@ -196,7 +196,7 @@ export const fetchSignificantCorrelations = async ({
 
   const index = apmEventClient.indices[eventType as keyof typeof apmEventClient.indices];
 
-  const ccsWarning = rejected.length > 0 && isCCSRemoteIndexName(index);
+  const ccsWarning = rejected.length > 0 && isNonLocalIndexName(index);
 
   return {
     latencyCorrelations,

--- a/x-pack/solutions/observability/plugins/apm/server/routes/storage_explorer/is_cross_cluster_search.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/storage_explorer/is_cross_cluster_search.ts
@@ -5,12 +5,12 @@
  * 2.0.
  */
 
-import { isCCSRemoteIndexName } from '@kbn/es-query';
+import { isNonLocalIndexName } from '@kbn/es-query';
 import type { APMEventClient } from '../../lib/helpers/create_es_client/create_apm_event_client';
 import { getApmIndicesCombined } from './indices_stats_helpers';
 
 export function isCrossClusterSearch(apmEventClient: APMEventClient) {
   // Check if a remote cluster is set in APM indices
   const index = getApmIndicesCombined(apmEventClient);
-  return isCCSRemoteIndexName(index);
+  return isNonLocalIndexName(index);
 }

--- a/x-pack/solutions/observability/plugins/slo/server/lib/collectors/fetcher.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/lib/collectors/fetcher.ts
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { isCCSRemoteIndexName } from '@kbn/es-query';
+import { isNonLocalIndexName } from '@kbn/es-query';
 import { ALL_VALUE } from '@kbn/slo-schema';
 import type { CollectorFetchContext } from '@kbn/usage-collection-plugin/server';
 import type { StoredSLODefinition } from '../../domain/models';
@@ -63,7 +63,7 @@ export const fetcher = async (context: CollectorFetchContext) => {
         total: acc.total + 1, // deprecated in favor of definitions.total
         definitions: {
           total: acc.definitions.total + 1,
-          total_with_ccs: isCCSRemoteIndexName(so.attributes.indicator.params.index)
+          total_with_ccs: isNonLocalIndexName(so.attributes.indicator.params.index)
             ? acc.definitions.total_with_ccs + 1
             : acc.definitions.total_with_ccs,
           total_with_groups: [so.attributes.groupBy].flat().includes(ALL_VALUE)

--- a/x-pack/solutions/observability/plugins/slo/server/services/summary_search_client/summary_search_client.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/summary_search_client/summary_search_client.ts
@@ -6,7 +6,7 @@
  */
 
 import type { IScopedClusterClient, Logger } from '@kbn/core/server';
-import { isCCSRemoteIndexName } from '@kbn/es-query';
+import { isNonLocalIndexName } from '@kbn/es-query';
 import { ALL_VALUE } from '@kbn/slo-schema';
 import { assertNever } from '@kbn/std';
 import { partition } from 'lodash';
@@ -195,7 +195,7 @@ export class DefaultSummarySearchClient implements SummarySearchClient {
 }
 
 function getRemoteClusterName(index: string) {
-  if (isCCSRemoteIndexName(index)) {
+  if (isNonLocalIndexName(index)) {
     return index.substring(0, index.indexOf(':'));
   }
 }

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/logs_extraction_client.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/logs_extraction/logs_extraction_client.ts
@@ -9,7 +9,7 @@ import type { Logger } from '@kbn/logging';
 import moment from 'moment';
 import { SavedObjectsErrorHelpers, type ElasticsearchClient } from '@kbn/core/server';
 import type { DataViewsService } from '@kbn/data-views-plugin/common';
-import { isCCSRemoteIndexName } from '@kbn/es-query';
+import { isNonLocalIndexName } from '@kbn/es-query';
 import type {
   EntityType,
   ManagedEntityDefinition,
@@ -756,7 +756,7 @@ export class LogsExtractionClient {
     const remoteIndexPatterns: string[] = [];
 
     withoutAlerts.forEach((index) => {
-      if (isCCSRemoteIndexName(index)) {
+      if (isNonLocalIndexName(index)) {
         remoteIndexPatterns.push(index);
       } else {
         localIndexPatterns.push(index);

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/header_actions/actions.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/header_actions/actions.tsx
@@ -9,7 +9,7 @@ import React, { useCallback, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { EuiButtonIcon, EuiToolTip } from '@elastic/eui';
 import styled from 'styled-components';
-import { isCCSRemoteIndexName } from '@kbn/es-query';
+import { isNonLocalIndexName } from '@kbn/es-query';
 import {
   makeSelectDocumentNotesBySavedObjectId,
   makeSelectNotesByDocumentId,
@@ -176,7 +176,7 @@ const ActionsComponent: React.FC<ActionsComponentProps> = ({
   );
 
   const isRemoteDocument = useMemo(
-    () => isCCSRemoteIndexName(ecsData._index ?? ''),
+    () => isNonLocalIndexName(ecsData._index ?? ''),
     [ecsData._index]
   );
 

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/table_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/table_section.tsx
@@ -8,7 +8,7 @@
 import React, { useCallback, useMemo, useState } from 'react';
 import { EuiFlexGroup, EuiFlexItem, EuiSpacer } from '@elastic/eui';
 import type { Filter } from '@kbn/es-query';
-import { isCCSRemoteIndexName } from '@kbn/es-query';
+import { isNonLocalIndexName } from '@kbn/es-query';
 import { TableId } from '@kbn/securitysolution-data-table';
 import type { DataView } from '@kbn/data-views-plugin/common';
 import type { GroupingSort, ParsedGroupingAggregation, RawBucket } from '@kbn/grouping/src';
@@ -260,7 +260,7 @@ export const TableSection = React.memo(
             attack={attack}
             closePopover={props.closePopover}
             telemetrySource="attacks_page_group_take_action"
-            isRemoteDocument={isCCSRemoteIndexName(attack.index ?? '')}
+            isRemoteDocument={isNonLocalIndexName(attack.index ?? '')}
           />
         );
       },

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/components/assignees.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/components/assignees.tsx
@@ -18,7 +18,7 @@ import {
   EuiToolTip,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import { isCCSRemoteIndexName } from '@kbn/es-query';
+import { isNonLocalIndexName } from '@kbn/es-query';
 import { getEmptyTagValue } from '../../../common/components/empty_value';
 import { UsersAvatarsPanel } from '../../../common/components/user_profiles/users_avatars_panel';
 import { useBulkGetUserProfiles } from '../../../common/components/user_profiles/use_bulk_get_user_profiles';
@@ -58,7 +58,7 @@ AssigneesButton.displayName = 'AssigneesButton';
  */
 export const Assignees = memo(() => {
   const { attackId, indexName, refetch } = useAttackDetailsContext();
-  const isRemoteDocument = useMemo(() => isCCSRemoteIndexName(indexName), [indexName]);
+  const isRemoteDocument = useMemo(() => isNonLocalIndexName(indexName), [indexName]);
   const { alertIds, assignees } = useHeaderData();
   const invalidateFindAttackDiscoveries = useInvalidateFindAttackDiscoveries();
   const { hasIndexWrite, hasAttackIndexWrite, loading: privilegesLoading } = useAttacksPrivileges();

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/components/header_title.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/components/header_title.tsx
@@ -8,7 +8,7 @@
 import React, { memo, useMemo } from 'react';
 import { EuiBadge, EuiFlexGroup, EuiFlexItem, EuiSpacer } from '@elastic/eui';
 import { buildDataTableRecord, getFieldValue, type EsHitRecord } from '@kbn/discover-utils';
-import { isCCSRemoteIndexName } from '@kbn/es-query';
+import { isNonLocalIndexName } from '@kbn/es-query';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
 import { flyoutHeaderBlockStyles } from '../../../flyout_v2/document/constants/styles';
@@ -45,7 +45,7 @@ export const HeaderTitle = memo(() => {
   const openNotesTab = useNavigateToAttackDetailsLeftPanel({ tab: 'notes' });
   const hit = useMemo(() => buildDataTableRecord(searchHit as EsHitRecord), [searchHit]);
   const isRemoteDocument = useMemo(
-    () => isCCSRemoteIndexName(hit.raw._index ?? (getFieldValue(hit, '_index') as string) ?? ''),
+    () => isNonLocalIndexName(hit.raw._index ?? (getFieldValue(hit, '_index') as string) ?? ''),
     [hit]
   );
 

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/components/status.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/components/status.tsx
@@ -8,7 +8,7 @@
 import React, { memo, useMemo } from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { find } from 'lodash/fp';
-import { isCCSRemoteIndexName } from '@kbn/es-query';
+import { isNonLocalIndexName } from '@kbn/es-query';
 import { useSpaceId } from '../../../common/hooks/use_space_id';
 import { SIGNAL_STATUS_FIELD_NAME } from '../../../timelines/components/timeline/body/renderers/constants';
 import { getEnrichedFieldInfo } from '../../document_details/right/utils/enriched_field_info';
@@ -34,7 +34,7 @@ export const Status = memo(() => {
   const { attackId, indexName, browserFields, dataFormattedForFieldBrowser } =
     useAttackDetailsContext();
   const currentSpaceId = useSpaceId();
-  const isRemoteDocument = useMemo(() => isCCSRemoteIndexName(indexName), [indexName]);
+  const isRemoteDocument = useMemo(() => isNonLocalIndexName(indexName), [indexName]);
   const statusData = useMemo(() => {
     const item = find(
       { field: SIGNAL_STATUS_FIELD_NAME, category: 'kibana' },

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/footer.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/footer.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { useCallback, useMemo, useState } from 'react';
-import { isCCSRemoteIndexName } from '@kbn/es-query';
+import { isNonLocalIndexName } from '@kbn/es-query';
 import {
   EuiButton,
   EuiFlexGroup,
@@ -31,7 +31,7 @@ export { FLYOUT_FOOTER_TEST_ID };
  */
 export const PanelFooter = () => {
   const { attack, indexName, refetch } = useAttackDetailsContext();
-  const isRemoteDocument = useMemo(() => isCCSRemoteIndexName(indexName), [indexName]);
+  const isRemoteDocument = useMemo(() => isNonLocalIndexName(indexName), [indexName]);
 
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
 

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/index.tsx
@@ -9,7 +9,7 @@ import type { FC } from 'react';
 import React, { memo, useMemo } from 'react';
 
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
-import { isCCSRemoteIndexName } from '@kbn/es-query';
+import { isNonLocalIndexName } from '@kbn/es-query';
 import { useUserPrivileges } from '../../../common/components/user_privileges';
 import { DocumentDetailsLeftPanelKey } from '../shared/constants/panel_keys';
 import { useKibana } from '../../../common/lib/kibana';
@@ -39,7 +39,7 @@ export const LeftPanel: FC<Partial<DocumentDetailsProps>> = memo(({ path }) => {
     notesPrivileges: { read: canSeeNotes },
   } = useUserPrivileges();
 
-  const isRemoteDocument = isCCSRemoteIndexName(indexName);
+  const isRemoteDocument = isNonLocalIndexName(indexName);
 
   const tabsDisplayed = useMemo(() => {
     const tabList =

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/about_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/about_section.tsx
@@ -13,7 +13,7 @@ import {
   type EsHitRecord,
   getFieldValue,
 } from '@kbn/discover-utils';
-import { isCCSRemoteIndexName } from '@kbn/es-query';
+import { isNonLocalIndexName } from '@kbn/es-query';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { FLYOUT_STORAGE_KEYS } from '../../../../flyout_v2/document/constants/local_storage';
 import { ExpandableSection } from '../../../../flyout_v2/shared/components/expandable_section';
@@ -71,7 +71,7 @@ export const AboutSection = memo(() => {
     [searchHit]
   );
 
-  const isRemoteDocument = useMemo(() => isCCSRemoteIndexName(indexName), [indexName]);
+  const isRemoteDocument = useMemo(() => isNonLocalIndexName(indexName), [indexName]);
 
   const eventKind = useMemo(() => getFieldValue(hit, 'event.kind') as string, [hit]);
   const eventKindInECS = eventKind && isEcsAllowedValue('event.kind', eventKind);

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/investigation_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/investigation_section.tsx
@@ -8,7 +8,7 @@
 import React, { memo, useMemo } from 'react';
 import { EuiSpacer } from '@elastic/eui';
 import { buildDataTableRecord, type DataTableRecord, type EsHitRecord } from '@kbn/discover-utils';
-import { isCCSRemoteIndexName } from '@kbn/es-query';
+import { isNonLocalIndexName } from '@kbn/es-query';
 import { cellActionRenderer } from '../../../../flyout_v2/shared/components/cell_actions';
 import { FLYOUT_STORAGE_KEYS } from '../../../../flyout_v2/document/constants/local_storage';
 import { useExpandSection } from '../../../../flyout_v2/shared/hooks/use_expand_section';
@@ -49,7 +49,7 @@ export const InvestigationSection = memo(() => {
     [searchHit]
   );
 
-  const isRemoteDocument = useMemo(() => isCCSRemoteIndexName(indexName), [indexName]);
+  const isRemoteDocument = useMemo(() => isNonLocalIndexName(indexName), [indexName]);
 
   const expanded = useExpandSection({
     storageKey: FLYOUT_STORAGE_KEYS.OVERVIEW_TAB_EXPANDED_SECTIONS,

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/response_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/response_section.tsx
@@ -9,7 +9,7 @@ import React, { memo, useMemo } from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { EuiCallOut } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import { isCCSRemoteIndexName } from '@kbn/es-query';
+import { isNonLocalIndexName } from '@kbn/es-query';
 import { FLYOUT_STORAGE_KEYS } from '../../../../flyout_v2/document/constants/local_storage';
 import { useExpandSection } from '../../../../flyout_v2/shared/hooks/use_expand_section';
 import { ResponseButton } from './response_button';
@@ -27,7 +27,7 @@ const KEY = 'response';
 export const ResponseSection = memo(() => {
   const { isRulePreview, getFieldsData, indexName } = useDocumentDetailsContext();
 
-  const isRemoteDocument = useMemo(() => isCCSRemoteIndexName(indexName), [indexName]);
+  const isRemoteDocument = useMemo(() => isNonLocalIndexName(indexName), [indexName]);
 
   const expanded = useExpandSection({
     storageKey: FLYOUT_STORAGE_KEYS.OVERVIEW_TAB_EXPANDED_SECTIONS,

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/components/take_action_dropdown.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/components/take_action_dropdown.tsx
@@ -14,7 +14,7 @@ import { i18n } from '@kbn/i18n';
 import { getOr } from 'lodash/fp';
 import { buildDataTableRecord, getFieldValue } from '@kbn/discover-utils';
 import type { EsHitRecord } from '@kbn/discover-utils';
-import { isCCSRemoteIndexName } from '@kbn/es-query';
+import { isNonLocalIndexName } from '@kbn/es-query';
 import type { SearchHit } from '../../../../../common/search_strategy';
 import { useRunAlertWorkflowPanel } from '../../../../detections/components/alerts_table/timeline_actions/use_run_alert_workflow_panel';
 import { useRunDocumentWorkflowPanel } from '../../../../detections/components/alerts_table/timeline_actions/use_run_document_workflow_panel';
@@ -174,7 +174,7 @@ export const TakeActionDropdown = memo(
     );
 
     const isRemoteDocument = useMemo(
-      () => isCCSRemoteIndexName(hit.raw._index ?? (getFieldValue(hit, '_index') as string) ?? ''),
+      () => isNonLocalIndexName(hit.raw._index ?? (getFieldValue(hit, '_index') as string) ?? ''),
       [hit]
     );
 

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/assignees.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/assignees.tsx
@@ -17,7 +17,7 @@ import {
   useGeneratedHtmlId,
 } from '@elastic/eui';
 import { type DataTableRecord, getFieldValue } from '@kbn/discover-utils';
-import { isCCSRemoteIndexName } from '@kbn/es-query';
+import { isNonLocalIndexName } from '@kbn/es-query';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
 import { ALERT_WORKFLOW_ASSIGNEE_IDS } from '@kbn/rule-data-utils';
@@ -78,7 +78,7 @@ export interface AssigneesProps {
 export const Assignees = memo(({ hit, onAlertUpdated, showAssignees = true }: AssigneesProps) => {
   const eventId = useMemo(() => hit.raw._id ?? '', [hit]);
   const isRemoteDocument = useMemo(
-    () => isCCSRemoteIndexName(hit.raw._index ?? (getFieldValue(hit, '_index') as string) ?? ''),
+    () => isNonLocalIndexName(hit.raw._index ?? (getFieldValue(hit, '_index') as string) ?? ''),
     [hit]
   );
   const initialAssignedUserIds = useMemo(() => {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/investigation_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/investigation_section.tsx
@@ -9,7 +9,7 @@ import React, { memo, useCallback, useMemo } from 'react';
 import { i18n } from '@kbn/i18n';
 import type { DataTableRecord } from '@kbn/discover-utils';
 import { getFieldValue } from '@kbn/discover-utils';
-import { isCCSRemoteIndexName } from '@kbn/es-query';
+import { isNonLocalIndexName } from '@kbn/es-query';
 import { EVENT_KIND } from '@kbn/rule-data-utils';
 import { useHistory } from 'react-router-dom';
 import { useStore } from 'react-redux';
@@ -71,7 +71,7 @@ export const InvestigationSection = memo(
       [hit]
     );
     const isRemoteDocument = useMemo(
-      () => isCCSRemoteIndexName(hit.raw._index ?? (getFieldValue(hit, '_index') as string) ?? ''),
+      () => isNonLocalIndexName(hit.raw._index ?? (getFieldValue(hit, '_index') as string) ?? ''),
       [hit]
     );
     const ruleId = useMemo(

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/remote_document_badge.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/remote_document_badge.tsx
@@ -10,7 +10,7 @@ import React, { useMemo } from 'react';
 import { EuiBadge, EuiSpacer } from '@elastic/eui';
 import type { DataTableRecord } from '@kbn/discover-utils';
 import { getFieldValue } from '@kbn/discover-utils';
-import { isCCSRemoteIndexName } from '@kbn/es-query';
+import { isNonLocalIndexName } from '@kbn/es-query';
 import { i18n } from '@kbn/i18n';
 import { ALERT_RULE_TYPE_ID, EVENT_KIND } from '@kbn/rule-data-utils';
 import {
@@ -86,7 +86,7 @@ export const RemoteDocumentBadge: FC<RemoteDocumentBadgeProps> = ({ hit }) => {
     [hit, isAlert]
   );
 
-  if (!isCCSRemoteIndexName(index)) {
+  if (!isNonLocalIndexName(index)) {
     return null;
   }
 

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/remote_document_callout.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/remote_document_callout.tsx
@@ -11,7 +11,7 @@ import type { EuiCallOutProps } from '@elastic/eui';
 import { EuiCallOut } from '@elastic/eui';
 import type { DataTableRecord } from '@kbn/discover-utils';
 import { getFieldValue } from '@kbn/discover-utils';
-import { isCCSRemoteIndexName } from '@kbn/es-query';
+import { isNonLocalIndexName } from '@kbn/es-query';
 import { i18n } from '@kbn/i18n';
 import { ALERT_RULE_TYPE_ID, EVENT_KIND } from '@kbn/rule-data-utils';
 import {
@@ -107,7 +107,7 @@ export const RemoteDocumentCallout: FC<RemoteDocumentCalloutProps> = ({ hit, chi
     [hit, isAlert]
   );
 
-  if (!isCCSRemoteIndexName(index)) {
+  if (!isNonLocalIndexName(index)) {
     return null;
   }
 

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/status.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/status.tsx
@@ -8,7 +8,7 @@
 import React, { memo, useMemo } from 'react';
 import type { DataTableRecord } from '@kbn/discover-utils';
 import { getFieldValue } from '@kbn/discover-utils';
-import { isCCSRemoteIndexName } from '@kbn/es-query';
+import { isNonLocalIndexName } from '@kbn/es-query';
 import { ALERT_WORKFLOW_STATUS } from '@kbn/rule-data-utils';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { AlertHeaderBlock } from '../../shared/components/alert_header_block';
@@ -50,7 +50,7 @@ export const Status = memo(
   ({ hit, renderCellActions = noopCellActionRenderer, onAlertUpdated }: StatusProps) => {
     const eventId = hit.raw._id as string;
     const isRemoteDocument = useMemo(
-      () => isCCSRemoteIndexName(hit.raw._index ?? (getFieldValue(hit, '_index') as string) ?? ''),
+      () => isNonLocalIndexName(hit.raw._index ?? (getFieldValue(hit, '_index') as string) ?? ''),
       [hit]
     );
     const statusFieldInfo = useMemo<StatusPopoverButtonFieldInfo | null>(() => {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/take_action_button.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/take_action_button.tsx
@@ -17,7 +17,7 @@ import {
 import { i18n } from '@kbn/i18n';
 import type { DataTableRecord } from '@kbn/discover-utils';
 import { getFieldValue } from '@kbn/discover-utils';
-import { isCCSRemoteIndexName } from '@kbn/es-query';
+import { isNonLocalIndexName } from '@kbn/es-query';
 import { ALERT_WORKFLOW_STATUS, EVENT_KIND } from '@kbn/rule-data-utils';
 import type { EcsSecurityExtension as Ecs } from '@kbn/securitysolution-ecs';
 import { EventKind } from '../constants/event_kinds';
@@ -107,7 +107,7 @@ export const TakeActionButton = memo(
 
     const documentId = hit.raw._id as string;
     const isRemoteDocument = useMemo(
-      () => isCCSRemoteIndexName(hit.raw._index ?? (getFieldValue(hit, '_index') as string) ?? ''),
+      () => isNonLocalIndexName(hit.raw._index ?? (getFieldValue(hit, '_index') as string) ?? ''),
       [hit]
     );
     const isAlert = useMemo(

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/title.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/title.tsx
@@ -10,7 +10,7 @@ import React, { memo, useMemo } from 'react';
 import { EuiLink } from '@elastic/eui';
 import type { DataTableRecord } from '@kbn/discover-utils';
 import { getFieldValue } from '@kbn/discover-utils';
-import { isCCSRemoteIndexName } from '@kbn/es-query';
+import { isNonLocalIndexName } from '@kbn/es-query';
 import { ALERT_RULE_UUID, EVENT_KIND } from '@kbn/rule-data-utils';
 import { SecurityPageName } from '@kbn/deeplinks-security';
 import { EventKind } from '../constants/event_kinds';
@@ -48,7 +48,7 @@ export const Title: FC<TitleProps> = memo(({ hit, hideLink = false }) => {
   const iconType = isAlert ? 'warning' : 'analyzeEvent';
 
   const isRemoteDocument = useMemo(
-    () => isCCSRemoteIndexName(hit.raw._index ?? (getFieldValue(hit, '_index') as string) ?? ''),
+    () => isNonLocalIndexName(hit.raw._index ?? (getFieldValue(hit, '_index') as string) ?? ''),
     [hit]
   );
 

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/notes/components/notes_remote_callout.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/notes/components/notes_remote_callout.tsx
@@ -10,7 +10,7 @@ import React, { useMemo } from 'react';
 import { EuiCallOut } from '@elastic/eui';
 import type { DataTableRecord } from '@kbn/discover-utils';
 import { getFieldValue } from '@kbn/discover-utils';
-import { isCCSRemoteIndexName } from '@kbn/es-query';
+import { isNonLocalIndexName } from '@kbn/es-query';
 import { i18n } from '@kbn/i18n';
 import { ALERT_RULE_TYPE_ID, EVENT_KIND } from '@kbn/rule-data-utils';
 import {
@@ -108,7 +108,7 @@ export const NotesRemoteCallout: FC<NotesRemoteCalloutProps> = ({ children, hit 
     [hit, isAlert]
   );
 
-  if (!isCCSRemoteIndexName(index)) {
+  if (!isNonLocalIndexName(index)) {
     return null;
   }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [Rename isCCSRemoteIndexName method to isNonLocalIndexName (#264539)](https://github.com/elastic/kibana/pull/264539)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Philippe Oberti","email":"philippe.oberti@elastic.co"},"sourceCommit":{"committedDate":"2026-04-22T13:14:19Z","message":"Rename isCCSRemoteIndexName method to isNonLocalIndexName (#264539)\n\n> [!NOTE]\n> Any better suggestions for the function's name are welcomed!\n\n## Summary\n\nThis PR renames the `isCCSRemoteIndexName` that we have in the\n`kbn-es-query` package to `isNonLocalIndexName`, to make it less\nspecific to CCS. We can indeed use the same function in a Serverless CPS\nenvironment.\n\nI considered other names, like:\n- `isExternalIndexName`\n- `hasRemoteOrLinkedPrefix`\n- `isCrossScopeIndexName`\n- `isForeignIndexName`\n- `isScopedIndexName`\n- `isCCSOrCPSNonLocalIndexName`\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"9feb852893ed3fe46e758cd4d37c5144054fa7f5","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Threat Hunting:Investigations","backport:version","v9.4.0","Team:obs-presentation","v9.5.0"],"title":"Rename isCCSRemoteIndexName method to isNonLocalIndexName","number":264539,"url":"https://github.com/elastic/kibana/pull/264539","mergeCommit":{"message":"Rename isCCSRemoteIndexName method to isNonLocalIndexName (#264539)\n\n> [!NOTE]\n> Any better suggestions for the function's name are welcomed!\n\n## Summary\n\nThis PR renames the `isCCSRemoteIndexName` that we have in the\n`kbn-es-query` package to `isNonLocalIndexName`, to make it less\nspecific to CCS. We can indeed use the same function in a Serverless CPS\nenvironment.\n\nI considered other names, like:\n- `isExternalIndexName`\n- `hasRemoteOrLinkedPrefix`\n- `isCrossScopeIndexName`\n- `isForeignIndexName`\n- `isScopedIndexName`\n- `isCCSOrCPSNonLocalIndexName`\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"9feb852893ed3fe46e758cd4d37c5144054fa7f5"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/264539","number":264539,"mergeCommit":{"message":"Rename isCCSRemoteIndexName method to isNonLocalIndexName (#264539)\n\n> [!NOTE]\n> Any better suggestions for the function's name are welcomed!\n\n## Summary\n\nThis PR renames the `isCCSRemoteIndexName` that we have in the\n`kbn-es-query` package to `isNonLocalIndexName`, to make it less\nspecific to CCS. We can indeed use the same function in a Serverless CPS\nenvironment.\n\nI considered other names, like:\n- `isExternalIndexName`\n- `hasRemoteOrLinkedPrefix`\n- `isCrossScopeIndexName`\n- `isForeignIndexName`\n- `isScopedIndexName`\n- `isCCSOrCPSNonLocalIndexName`\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"9feb852893ed3fe46e758cd4d37c5144054fa7f5"}}]}] BACKPORT-->