### PR TITLE
[ES|QL] Root replacement range

### DIFF
--- a/src/platform/packages/shared/kbn-esql-language/src/language/autocomplete/autocomplete.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/language/autocomplete/autocomplete.ts
@@ -176,26 +176,16 @@ export async function suggest(
         ...recommendedQueriesSuggestionsFromStaticTemplates
       );
 
-      const sourceCommandsSuggestions = attachRootQueryReplacementRanges(
-        suggestions.filter(isSourceCommandSuggestion),
-        fullText,
-        offset
-      );
       const headerCommandsSuggestions = suggestions.filter(isHeaderCommandSuggestion);
-      const resolvedRecommendedQueriesSuggestions = attachRootQueryReplacementRanges(
-        recommendedQueriesSuggestions,
+      const rootLevelQuerySuggestions = attachRootQueryReplacementRanges(
+        [...suggestions.filter(isSourceCommandSuggestion), ...recommendedQueriesSuggestions],
         fullText,
         offset
       );
 
-      return orderingEngine.sort(
-        [
-          ...headerCommandsSuggestions,
-          ...sourceCommandsSuggestions,
-          ...resolvedRecommendedQueriesSuggestions,
-        ],
-        { command: '' }
-      );
+      return orderingEngine.sort([...headerCommandsSuggestions, ...rootLevelQuerySuggestions], {
+        command: '',
+      });
     }
 
     return suggestions.filter(

--- a/src/platform/packages/shared/kbn-esql-language/src/language/autocomplete/autocomplete.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/language/autocomplete/autocomplete.ts
@@ -36,7 +36,7 @@ import type { ColumnsMap, GetColumnMapFn } from '../shared/columns_retrieval_hel
 import { getColumnsByTypeRetriever } from '../shared/columns_retrieval_helpers';
 import { getUnmappedFieldsStrategy } from '../../commands/definitions/utils/settings';
 import { isTimeseriesSourceCommand } from '../../commands/definitions/utils/timeseries_check';
-import { attachReplacementRanges } from './utils/prefix_range';
+import { attachReplacementRanges, attachRootQueryReplacementRanges } from './utils/prefix_range';
 
 function isSourceCommandSuggestion({ label }: { label: string }) {
   const sourceCommands = esqlCommandRegistry
@@ -176,14 +176,23 @@ export async function suggest(
         ...recommendedQueriesSuggestionsFromStaticTemplates
       );
 
-      const sourceCommandsSuggestions = suggestions.filter(isSourceCommandSuggestion);
+      const sourceCommandsSuggestions = attachRootQueryReplacementRanges(
+        suggestions.filter(isSourceCommandSuggestion),
+        fullText,
+        offset
+      );
       const headerCommandsSuggestions = suggestions.filter(isHeaderCommandSuggestion);
+      const resolvedRecommendedQueriesSuggestions = attachRootQueryReplacementRanges(
+        recommendedQueriesSuggestions,
+        fullText,
+        offset
+      );
 
       return orderingEngine.sort(
         [
           ...headerCommandsSuggestions,
           ...sourceCommandsSuggestions,
-          ...recommendedQueriesSuggestions,
+          ...resolvedRecommendedQueriesSuggestions,
         ],
         { command: '' }
       );

--- a/src/platform/packages/shared/kbn-esql-language/src/language/autocomplete/utils/prefix_range.test.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/language/autocomplete/utils/prefix_range.test.ts
@@ -7,7 +7,12 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { computePrefixRange, attachReplacementRanges, type PrefixResult } from './prefix_range';
+import {
+  computePrefixRange,
+  attachReplacementRanges,
+  attachRootQueryReplacementRanges,
+  type PrefixResult,
+} from './prefix_range';
 import type { ISuggestionItem } from '../../../commands/registry/types';
 
 describe('computePrefixRange', () => {
@@ -190,5 +195,27 @@ describe('attachReplacementRanges', () => {
     const result = attachReplacementRanges('FROM a | WHERE x > ', suggestions);
 
     expect(result[0].rangeToReplace).toEqual({ start: 19, end: 19 });
+  });
+});
+
+describe('attachRootQueryReplacementRanges', () => {
+  const makeSuggestion = (text: string, rangeToReplace?: { start: number; end: number }) =>
+    ({
+      text,
+      label: text,
+      kind: 'Variable' as const,
+      sortText: text,
+      ...(rangeToReplace ? { rangeToReplace } : {}),
+    } as ISuggestionItem);
+
+  it('replaces the typed root prefix and trailing query', () => {
+    const suggestions = [makeSuggestion('FROM kibana_sample_data_logs | LIMIT 10')];
+    const result = attachRootQueryReplacementRanges(
+      suggestions,
+      'FROM kibana_sample_data_logs | STATS count = COUNT(*)',
+      2
+    );
+
+    expect(result[0].rangeToReplace).toEqual({ start: 0, end: 54 });
   });
 });

--- a/src/platform/packages/shared/kbn-esql-language/src/language/autocomplete/utils/prefix_range.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/language/autocomplete/utils/prefix_range.ts
@@ -64,6 +64,28 @@ export function computePrefixRange(query: string): PrefixResult {
 // Replacement Range Resolver
 // =============================================
 
+/** Adds a replacement range for root-level query suggestions. */
+export function attachRootQueryReplacementRanges(
+  suggestions: ISuggestionItem[],
+  fullText: string,
+  offset: number
+): ISuggestionItem[] {
+  const start = computePrefixRange(fullText.substring(0, offset)).range.start;
+  const end = fullText.length;
+
+  // If there is nothing after the cursor, do not replace anything.
+  if (start === offset && end === offset) {
+    return suggestions;
+  }
+
+  const rangeToReplace = { start, end: end + 1 };
+
+  return suggestions.map((suggestion) => ({
+    ...suggestion,
+    rangeToReplace,
+  }));
+}
+
 /** Attaches replacement ranges, resolves preserveTypedPrefix and requiresExistingColumnMatch. */
 export function attachReplacementRanges(
   innerText: string,


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/264759 

It applies whenever the cursor is positioned before an existing source command

https://github.com/user-attachments/assets/1b582d42-46c0-41cc-a91a-8b9459426ca4




Note: 
I will generalize it here https://github.com/elastic/kibana/issues/258529 along with the other follow up cases that depend on the context, but avoid mixing it with the `orignal`flow (pears vs apples)

