### PR TITLE
[9.3] [Security Solution][Detection Engine] Fix Navigation For Shared Exception Lists Flyout (#257511)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/exceptions/pages/shared_lists/shared_lists.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/exceptions/pages/shared_lists/shared_lists.test.tsx
@@ -302,4 +302,38 @@ describe('SharedLists', () => {
       expect(createButton).toHaveFocus();
     });
   });
+
+  it('returns focus to the create button when the create shared list flyout is closed', async () => {
+    (useUserPrivileges as jest.Mock).mockReturnValue({
+      ...initialUserPrivilegesState(),
+      rulesPrivileges: {
+        rules: { read: true, edit: true },
+        exceptions: { read: true, edit: true },
+      },
+    });
+
+    const wrapper = render(
+      <TestProviders>
+        <SharedLists />
+      </TestProviders>
+    );
+
+    const createButtonText = wrapper.getByText('Create shared exception list');
+    const createButton = createButtonText.closest('button')!;
+    fireEvent.click(createButton);
+
+    const createListOption = wrapper.getByTestId('manageExceptionListCreateExceptionListButton');
+    fireEvent.click(createListOption);
+
+    await waitFor(() => {
+      expect(wrapper.getByTestId('createSharedExceptionListFlyout')).toBeInTheDocument();
+    });
+
+    const closeFlyoutButton = wrapper.getByTestId('closeFlyoutButton');
+    fireEvent.click(closeFlyoutButton);
+
+    await waitFor(() => {
+      expect(createButton).toHaveFocus();
+    });
+  });
 });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Security Solution][Detection Engine] Fix Navigation For Shared Exception Lists Flyout (#257511)](https://github.com/elastic/kibana/pull/257511)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Hannah Brooks","email":"hannah.brooks@elastic.co"},"sourceCommit":{"committedDate":"2026-03-17T18:22:46Z","message":"[Security Solution][Detection Engine] Fix Navigation For Shared Exception Lists Flyout (#257511)\n\n## Summary\n\nFixes issue [#227237](https://github.com/elastic/kibana/issues/227237).\n\nWhen we would create a new exception list from the flyout and proceeded\nto close the flyout, the focus would not return to the button that\nopened the flyout.\n\nThis PR implements a solution to force focus to return back to the\nbutton. I tested without `requestAnimationFrame` and it seems that the\ncleanup that `EuiFlyout` needs to complete before we can return focus\nand `requestAnimationFrame` ensures this happens.","sha":"2210107492ff1c10b9357f7b188453e3e6768004","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:all-open","Team:Detection Engine","a11y","v9.4.0","9.4 candidate","v9.3.3","v9.2.8","v8.19.14"],"title":"[Security Solution][Detection Engine] Fix Navigation For Shared Exception Lists Flyout","number":257511,"url":"https://github.com/elastic/kibana/pull/257511","mergeCommit":{"message":"[Security Solution][Detection Engine] Fix Navigation For Shared Exception Lists Flyout (#257511)\n\n## Summary\n\nFixes issue [#227237](https://github.com/elastic/kibana/issues/227237).\n\nWhen we would create a new exception list from the flyout and proceeded\nto close the flyout, the focus would not return to the button that\nopened the flyout.\n\nThis PR implements a solution to force focus to return back to the\nbutton. I tested without `requestAnimationFrame` and it seems that the\ncleanup that `EuiFlyout` needs to complete before we can return focus\nand `requestAnimationFrame` ensures this happens.","sha":"2210107492ff1c10b9357f7b188453e3e6768004"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/257511","number":257511,"mergeCommit":{"message":"[Security Solution][Detection Engine] Fix Navigation For Shared Exception Lists Flyout (#257511)\n\n## Summary\n\nFixes issue [#227237](https://github.com/elastic/kibana/issues/227237).\n\nWhen we would create a new exception list from the flyout and proceeded\nto close the flyout, the focus would not return to the button that\nopened the flyout.\n\nThis PR implements a solution to force focus to return back to the\nbutton. I tested without `requestAnimationFrame` and it seems that the\ncleanup that `EuiFlyout` needs to complete before we can return focus\nand `requestAnimationFrame` ensures this happens.","sha":"2210107492ff1c10b9357f7b188453e3e6768004"}},{"branch":"9.3","label":"v9.3.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/258406","number":258406,"state":"MERGED","mergeCommit":{"sha":"6d3eed67ecbd19b011d817be100fa035d32649ae","message":"[9.3] [Security Solution][Detection Engine] Fix Navigation For Shared Exception Lists Flyout (#257511) (#258406)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.3`:\n- [[Security Solution][Detection Engine] Fix Navigation For Shared\nException Lists Flyout\n(#257511)](https://github.com/elastic/kibana/pull/257511)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n"}},{"branch":"9.2","label":"v9.2.8","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/258408","number":258408,"state":"MERGED","mergeCommit":{"sha":"4f1726b0052acc16c4b5bd350f5247abe57cc829","message":"[9.2] [Security Solution][Detection Engine] Fix Navigation For Shared Exception Lists Flyout (#257511) (#258408)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.2`:\n- [[Security Solution][Detection Engine] Fix Navigation For Shared\nException Lists Flyout\n(#257511)](https://github.com/elastic/kibana/pull/257511)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>"}},{"branch":"8.19","label":"v8.19.14","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/258410","number":258410,"state":"MERGED","mergeCommit":{"sha":"5672977bcf533bd3ac142074b2e14fa41d60d226","message":"[8.19] [Security Solution][Detection Engine] Fix Navigation For Shared Exception Lists Flyout (#257511) (#258410)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.19`:\n- [[Security Solution][Detection Engine] Fix Navigation For Shared\nException Lists Flyout\n(#257511)](https://github.com/elastic/kibana/pull/257511)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>"}}]}] BACKPORT-->