### PR TITLE
[ci] Update limits.yml for agentBuilder

### DIFF
--- a/packages/kbn-optimizer/limits.yml
+++ b/packages/kbn-optimizer/limits.yml
@@ -1,7 +1,7 @@
 pageLoadAssetSize:
   actions: 20000
   advancedSettings: 6196
-  agentBuilder: 45717
+  agentBuilder: 48000
   agentBuilderPlatform: 8886
   aiAssistantManagementSelection: 13590
   aiops: 15227


### PR DESCRIPTION
## Summary
Parallel changes to the same plugin has breached the package limits. 
```
page load bundle size for agentBuilder plugin is greater than the limit of 45717. The current value is 45724.
```

This PR fixes it out of band with some headroom to 48000 manually