### PR TITLE
[9.4] [Agent Builder] Redesign announcement modal with three A/B variants (#264995)

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/announcement_modal/agent_builder_announcement_modal.test.tsx
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/announcement_modal/agent_builder_announcement_modal.test.tsx
@@ -12,8 +12,10 @@ import userEvent from '@testing-library/user-event';
 import { EuiProvider } from '@elastic/eui';
 import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
 import { AgentBuilderAnnouncementModal } from './agent_builder_announcement_modal';
+import * as i18n from './translations';
 
 const defaultProps = {
+  variant: '1b' as const,
   onContinue: jest.fn(),
   onRevert: jest.fn(),
 };
@@ -57,21 +59,40 @@ describe('AgentBuilderAnnouncementModal', () => {
     expect(defaultProps.onContinue).toHaveBeenCalled();
   });
 
-  it('hides revert, omits bullets and history callout, and shows documentation link when canRevertToAssistant is false', () => {
-    renderWithEui(<AgentBuilderAnnouncementModal {...defaultProps} canRevertToAssistant={false} />);
+  it('variant 1a shows feature list and no important notes or revert', () => {
+    renderWithEui(<AgentBuilderAnnouncementModal {...defaultProps} variant="1a" />);
 
+    expect(screen.getByText(i18n.FEATURE_TAKES_ACTION_TITLE)).toBeInTheDocument();
+    expect(screen.queryByTestId('agentBuilderAnnouncementImportantNotes')).not.toBeInTheDocument();
     expect(screen.queryByTestId('agentBuilderAnnouncementRevertButton')).not.toBeInTheDocument();
-    expect(screen.queryByText('What to expect:')).not.toBeInTheDocument();
-    expect(screen.queryByText('Need your history?')).not.toBeInTheDocument();
-    expect(screen.getByTestId('agentBuilderAnnouncementLearnMoreCallout')).toBeInTheDocument();
-    const docLink = screen.getByTestId('agentBuilderAnnouncementDocumentationLink');
-    expect(docLink).toHaveAttribute(
+    expect(screen.getByTestId('agentBuilderAnnouncementModal-1a')).toBeInTheDocument();
+  });
+
+  it('variant 1b shows features, important notes with settings copy, and revert', () => {
+    renderWithEui(<AgentBuilderAnnouncementModal {...defaultProps} variant="1b" />);
+
+    expect(screen.getByText(i18n.FEATURE_TAKES_ACTION_TITLE)).toBeInTheDocument();
+    expect(screen.getByTestId('agentBuilderAnnouncementImportantNotes')).toBeInTheDocument();
+    expect(screen.getByText(i18n.NOTE_REVERT_IN_SETTINGS)).toBeInTheDocument();
+    expect(screen.getByTestId('agentBuilderAnnouncementRevertButton')).toBeInTheDocument();
+  });
+
+  it('variant 2a shows important notes with admin copy, no features, no revert', () => {
+    renderWithEui(<AgentBuilderAnnouncementModal {...defaultProps} variant="2a" />);
+
+    expect(screen.queryByText(i18n.FEATURE_TAKES_ACTION_TITLE)).not.toBeInTheDocument();
+    expect(screen.getByTestId('agentBuilderAnnouncementImportantNotes')).toBeInTheDocument();
+    expect(screen.getByText(i18n.NOTE_CONTACT_ADMIN)).toBeInTheDocument();
+    expect(screen.queryByTestId('agentBuilderAnnouncementRevertButton')).not.toBeInTheDocument();
+  });
+
+  it('release notes link points at documentation URL', () => {
+    renderWithEui(<AgentBuilderAnnouncementModal {...defaultProps} variant="1a" />);
+
+    const releaseNotes = screen.getByTestId('agentBuilderAnnouncementReleaseNotesButton');
+    expect(releaseNotes).toHaveAttribute(
       'href',
       'https://www.elastic.co/docs/explore-analyze/ai-features/elastic-agent-builder'
-    );
-    expect(screen.getByText(/Learn more in our/i)).toBeInTheDocument();
-    expect(screen.getByTestId('agentBuilderAnnouncementContinueButton')).toHaveTextContent(
-      'Got it'
     );
   });
 });

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/announcement_modal/agent_builder_announcement_modal.tsx
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/announcement_modal/agent_builder_announcement_modal.tsx
@@ -5,169 +5,111 @@
  * 2.0.
  */
 
-import React from 'react';
+import React, { type ComponentType } from 'react';
 import {
-  EuiBetaBadge,
-  EuiButton,
-  EuiButtonEmpty,
-  EuiCallOut,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiLink,
+  EuiIcon,
   EuiModal,
-  EuiModalBody,
-  EuiModalFooter,
   EuiModalHeader,
   EuiModalHeaderTitle,
-  EuiText,
-  useEuiTheme,
   useGeneratedHtmlId,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
-import { FormattedMessage } from '@kbn/i18n-react';
 import * as i18n from './translations';
+import type { AnnouncementModalVariantProps } from './variants/types';
+import { NoPriorAssistantUsage } from './variants/no_prior_assistant_usage';
+import { PriorAssistantAdminRevert } from './variants/prior_assistant_admin_revert';
+import { PriorAssistantSpaceAdminRevert } from './variants/prior_assistant_space_admin_revert';
 
-const AGENT_BUILDER_DOCUMENTATION_URL =
-  'https://www.elastic.co/docs/explore-analyze/ai-features/elastic-agent-builder';
+export type { AgentBuilderAnnouncementVariant } from './translations';
 
 export interface AgentBuilderAnnouncementModalProps {
+  variant: i18n.AgentBuilderAnnouncementVariant;
   onRevert: () => void;
   onContinue: () => void;
-  /**
-   * When false, the revert action is hidden and the body shows a short FYI plus a link to
-   * documentation (no bullets or history callout), since the user cannot change Gen AI settings.
-   */
-  canRevertToAssistant?: boolean;
 }
 
-export const AgentBuilderAnnouncementModal: React.FC<AgentBuilderAnnouncementModalProps> = ({
-  onRevert,
-  onContinue,
-  canRevertToAssistant = true,
-}) => {
-  const { euiTheme } = useEuiTheme();
-  const modalTitleId = useGeneratedHtmlId({ prefix: 'agentBuilderAnnouncementModalTitle' });
+const VARIANT_CONTENT: Record<
+  i18n.AgentBuilderAnnouncementVariant,
+  ComponentType<AnnouncementModalVariantProps>
+> = {
+  '1a': NoPriorAssistantUsage,
+  '1b': PriorAssistantSpaceAdminRevert,
+  '2a': PriorAssistantAdminRevert,
+};
 
-  const listCss = css`
-    li + li {
-      margin-top: ${euiTheme.size.base};
+const MODAL_MAX_WIDTH = 576;
+
+/** Header product icon gradient (design: blue → purple). */
+const AGENT_PRODUCT_ICON_GRADIENT_START = '#1750BA';
+const AGENT_PRODUCT_ICON_GRADIENT_END = '#6B3C9F';
+
+function AnnouncementModalHeader({ titleId }: { titleId: string }) {
+  const gradientId = useGeneratedHtmlId({ prefix: 'agentBuilderAnnouncementAgentIconGradient' });
+  const iconWrapperCss = css`
+    display: inline-flex;
+    line-height: 0;
+
+    & .euiIcon,
+    & .euiIcon [fill]:not([fill='none']) {
+      fill: url(#${gradientId}) !important;
     }
   `;
 
-  const calloutAfterBodyWrapperCss = css`
-    margin-top: 2em;
-  `;
-
   return (
-    <EuiModal aria-labelledby={modalTitleId} onClose={onContinue} css={{ maxWidth: '576px' }}>
-      <EuiModalHeader>
-        <EuiModalHeaderTitle id={modalTitleId}>
-          <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
-            <EuiFlexItem grow={false}>{i18n.MODAL_TITLE}</EuiFlexItem>
-            <EuiFlexItem grow={false}>
-              <EuiBetaBadge label={i18n.BETA_LABEL} size="m" css={{ verticalAlign: 'middle' }} />
-            </EuiFlexItem>
-          </EuiFlexGroup>
-        </EuiModalHeaderTitle>
-      </EuiModalHeader>
-
-      <EuiModalBody>
-        <EuiText size="s">
-          <p>
-            <FormattedMessage
-              id="xpack.agentBuilder.announcementModal.modalDescription"
-              defaultMessage="We've set <strong>AI Agent</strong> as the default experience for this space to provide more powerful automation across your environment."
-              values={{ strong: (chunks: React.ReactNode) => <strong>{chunks}</strong> }}
-            />
-          </p>
-
-          {canRevertToAssistant ? (
-            <>
-              <p>
-                <em>{i18n.WHAT_TO_EXPECT}</em>
-              </p>
-
-              <ul css={listCss}>
-                <li>
-                  <strong>{i18n.DUAL_EXPERIENCES_TITLE}</strong> {i18n.DUAL_EXPERIENCES_BODY}
-                </li>
-                <li>
-                  <strong>{i18n.DATA_ISOLATION_TITLE}</strong> {i18n.DATA_ISOLATION_BODY}
-                </li>
-                <li>
-                  <strong>{i18n.FEATURE_PARITY_TITLE}</strong> {i18n.FEATURE_PARITY_BODY}
-                </li>
-              </ul>
-            </>
-          ) : null}
-        </EuiText>
-
-        {canRevertToAssistant ? null : (
-          <div css={calloutAfterBodyWrapperCss}>
-            <EuiCallOut
-              announceOnMount={false}
-              title={i18n.LEARN_MORE_CALLOUT_TITLE}
-              iconType="bulb"
-              color="primary"
-              size="s"
-              data-test-subj="agentBuilderAnnouncementLearnMoreCallout"
+    <EuiModalHeader>
+      <EuiFlexGroup gutterSize="m" alignItems="center" responsive={false}>
+        <EuiFlexItem grow={false}>
+          <span css={iconWrapperCss}>
+            <svg
+              width="0"
+              height="0"
+              aria-hidden="true"
+              focusable="false"
+              style={{ position: 'absolute' }}
             >
-              <EuiText size="s">
-                <p>
-                  <FormattedMessage
-                    id="xpack.agentBuilder.announcementModal.learnMoreDescriptionDetail"
-                    defaultMessage="Learn more in our {documentationLink}."
-                    values={{
-                      documentationLink: (
-                        <EuiLink
-                          href={AGENT_BUILDER_DOCUMENTATION_URL}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          external
-                          data-test-subj="agentBuilderAnnouncementDocumentationLink"
-                        >
-                          {i18n.DOCUMENTATION_LINK_TEXT}
-                        </EuiLink>
-                      ),
-                    }}
-                  />
-                </p>
-              </EuiText>
-            </EuiCallOut>
-          </div>
-        )}
+              <defs>
+                <linearGradient
+                  id={gradientId}
+                  x1="-0.5"
+                  y1="-2.5"
+                  x2="15.5"
+                  y2="9.5"
+                  gradientUnits="userSpaceOnUse"
+                >
+                  <stop offset="16%" stopColor={AGENT_PRODUCT_ICON_GRADIENT_START} />
+                  <stop offset="83%" stopColor={AGENT_PRODUCT_ICON_GRADIENT_END} />
+                </linearGradient>
+              </defs>
+            </svg>
+            <EuiIcon type="productAgent" size="xl" aria-hidden={true} />
+          </span>
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiModalHeaderTitle id={titleId}>{i18n.MODAL_TITLE}</EuiModalHeaderTitle>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </EuiModalHeader>
+  );
+}
 
-        {canRevertToAssistant ? (
-          <div css={calloutAfterBodyWrapperCss}>
-            <EuiCallOut
-              announceOnMount={false}
-              title={i18n.NEED_HISTORY_TITLE}
-              iconType="hourglass"
-              color="primary"
-              size="s"
-            >
-              <EuiText size="s">
-                <p>{i18n.NEED_HISTORY_BODY}</p>
-              </EuiText>
-            </EuiCallOut>
-          </div>
-        ) : null}
-      </EuiModalBody>
-
-      <EuiModalFooter>
-        {canRevertToAssistant ? (
-          <EuiButtonEmpty onClick={onRevert} data-test-subj="agentBuilderAnnouncementRevertButton">
-            {i18n.REVERT_BUTTON}
-          </EuiButtonEmpty>
-        ) : null}
-        <EuiButton
-          fill
-          onClick={onContinue}
-          data-test-subj="agentBuilderAnnouncementContinueButton"
-        >
-          {canRevertToAssistant ? i18n.CONTINUE_BUTTON : i18n.CONTINUE_BUTTON_READONLY}
-        </EuiButton>
-      </EuiModalFooter>
+export const AgentBuilderAnnouncementModal: React.FC<AgentBuilderAnnouncementModalProps> = ({
+  variant,
+  onRevert,
+  onContinue,
+}) => {
+  const modalTitleId = useGeneratedHtmlId({ prefix: 'agentBuilderAnnouncementModalTitle' });
+  const VariantContent = VARIANT_CONTENT[variant];
+  return (
+    <EuiModal
+      aria-labelledby={modalTitleId}
+      onClose={onContinue}
+      css={{ maxWidth: MODAL_MAX_WIDTH }}
+      data-test-subj={`agentBuilderAnnouncementModal-${variant}`}
+    >
+      <AnnouncementModalHeader titleId={modalTitleId} />
+      <VariantContent onContinue={onContinue} onRevert={onRevert} />
     </EuiModal>
   );
 };

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/announcement_modal/announcement_ui_shared.tsx
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/announcement_modal/announcement_ui_shared.tsx
@@ -1,0 +1,99 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiButton, EuiFlexGroup, EuiFlexItem, EuiIcon, EuiText, useEuiTheme } from '@elastic/eui';
+import { css } from '@emotion/react';
+
+export const announcementModalFooterCss = css`
+  margin-top: 1em;
+`;
+import { AGENT_BUILDER_RELEASE_NOTES_URL } from './announcement_urls';
+import * as i18n from './translations';
+
+export function AnnouncementReleaseNotesButton() {
+  return (
+    <EuiButton
+      href={AGENT_BUILDER_RELEASE_NOTES_URL}
+      target="_blank"
+      rel="noopener noreferrer"
+      iconType="popout"
+      iconSide="right"
+      color="primary"
+      fill={false}
+      data-test-subj="agentBuilderAnnouncementReleaseNotesButton"
+    >
+      {i18n.RELEASE_NOTES_BUTTON}
+    </EuiButton>
+  );
+}
+
+/** Intro paragraph + three feature rows (bolt, plugs, refresh) per design. */
+export function AnnouncementFeatureBulletList() {
+  const { euiTheme } = useEuiTheme();
+
+  const iconItemCss = css`
+    padding-top: ${euiTheme.size.xxs};
+  `;
+
+  const featureListCss = css`
+    && {
+      list-style: none;
+      margin: ${euiTheme.size.base} 0 0;
+      padding: 0;
+    }
+
+    && li + li {
+      margin-top: ${euiTheme.size.base};
+    }
+  `;
+
+  return (
+    <EuiText size="s">
+      <p>{i18n.INTRO}</p>
+      <ul css={featureListCss}>
+        <li>
+          <EuiFlexGroup gutterSize="s" alignItems="flexStart" responsive={false}>
+            <EuiFlexItem grow={false} css={iconItemCss}>
+              <EuiIcon type="bolt" color={euiTheme.colors.textPrimary} aria-hidden={true} />
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <span>
+                <strong>{i18n.FEATURE_TAKES_ACTION_TITLE}</strong> {i18n.FEATURE_TAKES_ACTION_BODY}
+              </span>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </li>
+        <li>
+          <EuiFlexGroup gutterSize="s" alignItems="flexStart" responsive={false}>
+            <EuiFlexItem grow={false} css={iconItemCss}>
+              <EuiIcon type="plugs" color={euiTheme.colors.textPrimary} aria-hidden={true} />
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <span>
+                <strong>{i18n.FEATURE_CONNECTS_TOOLS_TITLE}</strong>{' '}
+                {i18n.FEATURE_CONNECTS_TOOLS_BODY}
+              </span>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </li>
+        <li>
+          <EuiFlexGroup gutterSize="s" alignItems="flexStart" responsive={false}>
+            <EuiFlexItem grow={false} css={iconItemCss}>
+              <EuiIcon type="refresh" color={euiTheme.colors.textPrimary} aria-hidden={true} />
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <span>
+                <strong>{i18n.FEATURE_ITERATES_TITLE}</strong> {i18n.FEATURE_ITERATES_BODY}
+              </span>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </li>
+      </ul>
+    </EuiText>
+  );
+}

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/announcement_modal/announcement_urls.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/announcement_modal/announcement_urls.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/** Docs link for Release notes CTA until a dedicated release-notes URL is provided. */
+export const AGENT_BUILDER_RELEASE_NOTES_URL =
+  'https://www.elastic.co/docs/explore-analyze/ai-features/elastic-agent-builder';

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/announcement_modal/translations.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/announcement_modal/translations.ts
@@ -7,90 +7,89 @@
 
 import { i18n } from '@kbn/i18n';
 
+export type AgentBuilderAnnouncementVariant = '1a' | '1b' | '2a';
+
 export const MODAL_TITLE = i18n.translate('xpack.agentBuilder.announcementModal.modalTitle', {
   defaultMessage: 'Introducing AI Agent',
 });
 
-export const BETA_LABEL = i18n.translate('xpack.agentBuilder.announcementModal.betaLabel', {
-  defaultMessage: 'Beta',
+export const INTRO = i18n.translate('xpack.agentBuilder.announcementModal.intro', {
+  defaultMessage:
+    'AI Agent can take action, not just answer. It runs queries, connects your tools, and works across your environment to complete tasks end-to-end.',
 });
 
-export const WHAT_TO_EXPECT = i18n.translate('xpack.agentBuilder.announcementModal.whatToExpect', {
-  defaultMessage: 'What to expect:',
-});
-
-export const DUAL_EXPERIENCES_TITLE = i18n.translate(
-  'xpack.agentBuilder.announcementModal.dualExperiencesTitle',
-  { defaultMessage: 'Dual Experiences:' }
+export const FEATURE_TAKES_ACTION_TITLE = i18n.translate(
+  'xpack.agentBuilder.announcementModal.featureTakesActionTitle',
+  { defaultMessage: 'Takes action' }
 );
 
-export const DUAL_EXPERIENCES_BODY = i18n.translate(
-  'xpack.agentBuilder.announcementModal.dualExperiencesBody',
+export const FEATURE_TAKES_ACTION_BODY = i18n.translate(
+  'xpack.agentBuilder.announcementModal.featureTakesActionBody',
   {
-    defaultMessage:
-      'Both AI Agent and AI Assistant are available. You are currently using the AI Agent.',
+    defaultMessage: 'by executing multi-step tasks, not just suggestions',
   }
 );
 
-export const DATA_ISOLATION_TITLE = i18n.translate(
-  'xpack.agentBuilder.announcementModal.dataIsolationTitle',
-  { defaultMessage: 'Data Isolation:' }
+export const FEATURE_CONNECTS_TOOLS_TITLE = i18n.translate(
+  'xpack.agentBuilder.announcementModal.featureConnectsToolsTitle',
+  { defaultMessage: 'Connects tools' }
 );
 
-export const DATA_ISOLATION_BODY = i18n.translate(
-  'xpack.agentBuilder.announcementModal.dataIsolationBody',
+export const FEATURE_CONNECTS_TOOLS_BODY = i18n.translate(
+  'xpack.agentBuilder.announcementModal.featureConnectsToolsBody',
   {
-    defaultMessage:
-      'AI Agent starts with a clean slate and does not currently access your previous chats, prompts, or knowledge base entries from AI Assistant.',
+    defaultMessage: 'by working across data sources and integrations',
   }
 );
 
-export const FEATURE_PARITY_TITLE = i18n.translate(
-  'xpack.agentBuilder.announcementModal.featureParityTitle',
-  { defaultMessage: 'Feature Parity:' }
+export const FEATURE_ITERATES_TITLE = i18n.translate(
+  'xpack.agentBuilder.announcementModal.featureIteratesTitle',
+  { defaultMessage: 'Iterates' }
 );
 
-export const FEATURE_PARITY_BODY = i18n.translate(
-  'xpack.agentBuilder.announcementModal.featureParityBody',
+export const FEATURE_ITERATES_BODY = i18n.translate(
+  'xpack.agentBuilder.announcementModal.featureIteratesBody',
   {
-    defaultMessage:
-      'Some legacy features, such as anonymization and chat sharing, are not yet supported in this Beta version.',
+    defaultMessage: 'by adapting mid-task based on what it finds',
   }
 );
 
-export const NEED_HISTORY_TITLE = i18n.translate(
-  'xpack.agentBuilder.announcementModal.needHistoryTitle',
-  { defaultMessage: 'Need your history?' }
+export const IMPORTANT_NOTES_TITLE = i18n.translate(
+  'xpack.agentBuilder.announcementModal.importantNotesTitle',
+  { defaultMessage: 'Important notes:' }
 );
 
-export const NEED_HISTORY_BODY = i18n.translate(
-  'xpack.agentBuilder.announcementModal.needHistoryBody',
+export const NOTE_HISTORY_UNTOUCHED = i18n.translate(
+  'xpack.agentBuilder.announcementModal.noteHistoryUntouched',
   {
-    defaultMessage:
-      'Your AI Assistant data is safe and remains fully accessible. You can opt-out of the Agent and switch back to the legacy Assistant at any time via the GenAI Settings page.',
+    defaultMessage: 'Your chat history, prompts, and data are untouched',
   }
 );
 
-export const LEARN_MORE_CALLOUT_TITLE = i18n.translate(
-  'xpack.agentBuilder.announcementModal.learnMoreCalloutTitle',
-  { defaultMessage: 'Explore Agent Builder' }
+export const NOTE_REVERT_IN_SETTINGS = i18n.translate(
+  'xpack.agentBuilder.announcementModal.noteRevertInSettings',
+  {
+    defaultMessage: 'Revert back to AI Assistant anytime in GenAI Settings',
+  }
 );
 
-export const DOCUMENTATION_LINK_TEXT = i18n.translate(
-  'xpack.agentBuilder.announcementModal.documentationLinkText',
-  { defaultMessage: 'documentation' }
+export const NOTE_CONTACT_ADMIN = i18n.translate(
+  'xpack.agentBuilder.announcementModal.noteContactAdmin',
+  {
+    defaultMessage: 'To revert to AI Assistant, please contact your administrator',
+  }
 );
 
 export const REVERT_BUTTON = i18n.translate('xpack.agentBuilder.announcementModal.revertButton', {
   defaultMessage: 'Revert to AI Assistant',
 });
 
-export const CONTINUE_BUTTON = i18n.translate(
-  'xpack.agentBuilder.announcementModal.continueButton',
-  { defaultMessage: 'Continue with AI Agent' }
+export const RELEASE_NOTES_BUTTON = i18n.translate(
+  'xpack.agentBuilder.announcementModal.releaseNotesButton',
+  { defaultMessage: 'Release notes' }
 );
 
-export const CONTINUE_BUTTON_READONLY = i18n.translate(
-  'xpack.agentBuilder.announcementModal.continueButtonReadonly',
-  { defaultMessage: 'Got it' }
+export const USE_AI_AGENT_BUTTON = i18n.translate(
+  'xpack.agentBuilder.announcementModal.useAiAgentButton',
+  { defaultMessage: 'Use AI Agent' }
 );

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/announcement_modal/variants/no_prior_assistant_usage.tsx
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/announcement_modal/variants/no_prior_assistant_usage.tsx
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiButton, EuiFlexGroup, EuiFlexItem, EuiModalBody, EuiModalFooter } from '@elastic/eui';
+import {
+  AnnouncementFeatureBulletList,
+  AnnouncementReleaseNotesButton,
+  announcementModalFooterCss,
+} from '../announcement_ui_shared';
+import * as i18n from '../translations';
+import type { AnnouncementModalVariantProps } from './types';
+
+/**
+ * Users with no prior Observability / Security AI Assistant usage in this space.
+ * Feature highlights only; no history callout.
+ */
+export function NoPriorAssistantUsage({ onContinue }: AnnouncementModalVariantProps) {
+  return (
+    <>
+      <EuiModalBody>
+        <AnnouncementFeatureBulletList />
+      </EuiModalBody>
+      <EuiModalFooter css={announcementModalFooterCss}>
+        <EuiFlexGroup justifyContent="flexEnd" alignItems="center" responsive={false}>
+          <EuiFlexItem grow={false}>
+            <EuiFlexGroup gutterSize="s" responsive={false}>
+              <AnnouncementReleaseNotesButton />
+              <EuiButton
+                fill
+                onClick={onContinue}
+                data-test-subj="agentBuilderAnnouncementContinueButton"
+              >
+                {i18n.USE_AI_AGENT_BUTTON}
+              </EuiButton>
+            </EuiFlexGroup>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiModalFooter>
+    </>
+  );
+}

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/announcement_modal/variants/prior_assistant_admin_revert.tsx
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/announcement_modal/variants/prior_assistant_admin_revert.tsx
@@ -1,0 +1,91 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import {
+  EuiButton,
+  EuiCallOut,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiModalBody,
+  EuiModalFooter,
+  EuiText,
+  useEuiTheme,
+} from '@elastic/eui';
+import { css } from '@emotion/react';
+import {
+  AnnouncementReleaseNotesButton,
+  announcementModalFooterCss,
+} from '../announcement_ui_shared';
+import * as i18n from '../translations';
+import type { AnnouncementModalVariantProps } from './types';
+
+/**
+ * Users who already used AI Assistant but need an administrator to revert chat experience.
+ */
+export function PriorAssistantAdminRevert({ onContinue }: AnnouncementModalVariantProps) {
+  const { euiTheme } = useEuiTheme();
+
+  const calloutWrapperCss = css`
+    margin-top: ${euiTheme.size.l};
+  `;
+
+  const notesListCss = css`
+    && {
+      margin: ${euiTheme.size.s} 0 0;
+      margin-left: 0;
+      margin-bottom: 0;
+      padding-left: 0;
+      list-style-position: inside;
+    }
+
+    && li + li {
+      margin-top: ${euiTheme.size.xs};
+    }
+  `;
+
+  return (
+    <>
+      <EuiModalBody>
+        <EuiText size="s">
+          <p>{i18n.INTRO}</p>
+        </EuiText>
+        <div css={calloutWrapperCss}>
+          <EuiCallOut
+            announceOnMount={false}
+            title={i18n.IMPORTANT_NOTES_TITLE}
+            iconType="bulb"
+            color="primary"
+            size="m"
+            data-test-subj="agentBuilderAnnouncementImportantNotes"
+          >
+            <ul css={notesListCss}>
+              <li>{i18n.NOTE_HISTORY_UNTOUCHED}</li>
+              <li>{i18n.NOTE_CONTACT_ADMIN}</li>
+            </ul>
+          </EuiCallOut>
+        </div>
+      </EuiModalBody>
+      <EuiModalFooter css={announcementModalFooterCss}>
+        <EuiFlexGroup justifyContent="flexEnd" alignItems="center" responsive={false}>
+          <EuiFlexItem grow={false}>
+            <EuiFlexGroup gutterSize="s" responsive={false}>
+              <AnnouncementReleaseNotesButton />
+              <EuiButton
+                fill
+                onClick={onContinue}
+                data-test-subj="agentBuilderAnnouncementContinueButton"
+              >
+                {i18n.USE_AI_AGENT_BUTTON}
+              </EuiButton>
+            </EuiFlexGroup>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiModalFooter>
+    </>
+  );
+}

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/announcement_modal/variants/prior_assistant_space_admin_revert.tsx
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/announcement_modal/variants/prior_assistant_space_admin_revert.tsx
@@ -1,0 +1,102 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import {
+  EuiButton,
+  EuiButtonEmpty,
+  EuiCallOut,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiModalBody,
+  EuiModalFooter,
+  useEuiTheme,
+} from '@elastic/eui';
+import { css } from '@emotion/react';
+import {
+  AnnouncementFeatureBulletList,
+  AnnouncementReleaseNotesButton,
+  announcementModalFooterCss,
+} from '../announcement_ui_shared';
+import * as i18n from '../translations';
+import type { AnnouncementModalVariantProps } from './types';
+
+/**
+ * Users who already used AI Assistant and can revert the space-level chat
+ * experience back to AI Assistant via GenAI Settings.
+ */
+export function PriorAssistantSpaceAdminRevert({
+  onContinue,
+  onRevert,
+}: AnnouncementModalVariantProps) {
+  const { euiTheme } = useEuiTheme();
+
+  const calloutWrapperCss = css`
+    margin-top: ${euiTheme.size.l};
+  `;
+
+  const notesListCss = css`
+    && {
+      margin: ${euiTheme.size.s} 0 0;
+      margin-left: 0;
+      margin-bottom: 0;
+      padding-left: 0;
+      list-style-position: inside;
+    }
+
+    && li + li {
+      margin-top: ${euiTheme.size.xs};
+    }
+  `;
+
+  return (
+    <>
+      <EuiModalBody>
+        <AnnouncementFeatureBulletList />
+        <div css={calloutWrapperCss}>
+          <EuiCallOut
+            announceOnMount={false}
+            title={i18n.IMPORTANT_NOTES_TITLE}
+            iconType="bulb"
+            color="primary"
+            size="m"
+            data-test-subj="agentBuilderAnnouncementImportantNotes"
+          >
+            <ul css={notesListCss}>
+              <li>{i18n.NOTE_HISTORY_UNTOUCHED}</li>
+              <li>{i18n.NOTE_REVERT_IN_SETTINGS}</li>
+            </ul>
+          </EuiCallOut>
+        </div>
+      </EuiModalBody>
+      <EuiModalFooter css={announcementModalFooterCss}>
+        <EuiFlexGroup justifyContent="spaceBetween" alignItems="center" responsive={false}>
+          <EuiFlexItem grow={false}>
+            <EuiButtonEmpty
+              onClick={onRevert}
+              data-test-subj="agentBuilderAnnouncementRevertButton"
+            >
+              {i18n.REVERT_BUTTON}
+            </EuiButtonEmpty>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiFlexGroup gutterSize="s" responsive={false}>
+              <AnnouncementReleaseNotesButton />
+              <EuiButton
+                fill
+                onClick={onContinue}
+                data-test-subj="agentBuilderAnnouncementContinueButton"
+              >
+                {i18n.USE_AI_AGENT_BUTTON}
+              </EuiButton>
+            </EuiFlexGroup>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiModalFooter>
+    </>
+  );
+}

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/announcement_modal/variants/types.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/announcement_modal/variants/types.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/** Props for variant body + footer (modal chrome lives in the parent). */
+export interface AnnouncementModalVariantProps {
+  onContinue: () => void;
+  onRevert: () => void;
+}

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/index.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/index.ts
@@ -20,4 +20,7 @@ export type { EventsServiceStartContract, BrowserChatEvent } from './events';
 export { WorkflowComboBox } from './workflow_combo_box';
 export type { WorkflowComboBoxProps, WorkflowComboBoxOption } from './workflow_combo_box';
 export { AgentBuilderAnnouncementModal } from './announcement_modal/agent_builder_announcement_modal';
-export type { AgentBuilderAnnouncementModalProps } from './announcement_modal/agent_builder_announcement_modal';
+export type {
+  AgentBuilderAnnouncementModalProps,
+  AgentBuilderAnnouncementVariant,
+} from './announcement_modal/agent_builder_announcement_modal';

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/telemetry/agent_builder_events.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/telemetry/agent_builder_events.ts
@@ -45,10 +45,16 @@ export type OptInAction =
 export interface ReportOptInActionParams {
   action: OptInAction;
   source: OptInSource;
+  /** Announcement modal design variant when the event originates from that flow. */
+  announcement_variant?: '1a' | '1b' | '2a';
+  /** Whether the user had prior Observability or Security AI Assistant conversations (current space). */
+  had_prior_ai_assistant_usage?: boolean;
 }
 
 export interface ReportOptOutParams {
   source: 'security_settings_menu' | 'stack_management' | 'agent_builder_nav_control';
+  announcement_variant?: '1a' | '1b' | '2a';
+  had_prior_ai_assistant_usage?: boolean;
 }
 
 export interface ReportAddToChatClickedParams {
@@ -295,6 +301,20 @@ const OPT_IN_EVENT: AgentBuilderTelemetryEvent = {
         optional: false,
       },
     },
+    announcement_variant: {
+      type: 'keyword',
+      _meta: {
+        description: 'Agent Builder announcement modal variant (1a|1b|2a)',
+        optional: true,
+      },
+    },
+    had_prior_ai_assistant_usage: {
+      type: 'boolean',
+      _meta: {
+        description: 'Whether the user had prior AI Assistant conversations in the current space',
+        optional: true,
+      },
+    },
   },
 };
 
@@ -307,6 +327,20 @@ const OPT_OUT_EVENT: AgentBuilderTelemetryEvent = {
         description:
           'Source of the opt-out action (security_settings_menu|stack_management|agent_builder_nav_control)',
         optional: false,
+      },
+    },
+    announcement_variant: {
+      type: 'keyword',
+      _meta: {
+        description: 'Agent Builder announcement modal variant (1a|1b|2a)',
+        optional: true,
+      },
+    },
+    had_prior_ai_assistant_usage: {
+      type: 'boolean',
+      _meta: {
+        description: 'Whether the user had prior AI Assistant conversations in the current space',
+        optional: true,
       },
     },
   },
@@ -802,7 +836,7 @@ const TOOL_CALL_SUCCESS_EVENT: AgentBuilderTelemetryEvent = {
       _meta: {
         description:
           'ID of the agent (normalized: built-in agents keep ID, custom agents become "custom-<sha256_prefix>")',
-        optional: false,
+        optional: true,
       },
     },
     conversation_id: {
@@ -879,7 +913,7 @@ const TOOL_CALL_ERROR_EVENT: AgentBuilderTelemetryEvent = {
       _meta: {
         description:
           'ID of the agent (normalized: built-in agents keep ID, custom agents become "custom-<sha256_prefix>")',
-        optional: false,
+        optional: true,
       },
     },
     conversation_id: {

--- a/x-pack/platform/plugins/shared/agent_builder/moon.yml
+++ b/x-pack/platform/plugins/shared/agent_builder/moon.yml
@@ -92,6 +92,7 @@ dependsOn:
   - '@kbn/usage-collection-plugin'
   - '@kbn/core-notifications-browser'
   - '@kbn/ai-assistant-common'
+  - '@kbn/elastic-assistant-common'
   - '@kbn/ui-theme'
   - '@kbn/ai-assistant-management-plugin'
   - '@kbn/inference-endpoint-ui-common'

--- a/x-pack/platform/plugins/shared/agent_builder/public/components/announcement/agent_builder_announcement_modal_controller.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/components/announcement/agent_builder_announcement_modal_controller.test.tsx
@@ -31,6 +31,38 @@ const capabilitiesAllowRevert: Capabilities = {
   agentBuilder: { manageAgents: true },
 };
 
+function createHttpMock({
+  observabilityConversationCount = 0,
+  securityTotal = 0,
+}: {
+  observabilityConversationCount?: number;
+  securityTotal?: number;
+} = {}) {
+  return {
+    fetch: jest.fn((path: string, options?: { method?: string }) => {
+      if (
+        path.includes('internal/observability_ai_assistant/conversations') &&
+        options?.method === 'POST'
+      ) {
+        return Promise.resolve({
+          conversations: Array(observabilityConversationCount).fill({
+            conversation: { id: 'c1', title: 't', last_updated: '' },
+          }),
+        });
+      }
+      if (path.includes('conversations/_find')) {
+        return Promise.resolve({
+          total: securityTotal,
+          page: 1,
+          perPage: 1,
+          data: [],
+        });
+      }
+      return Promise.resolve({});
+    }),
+  };
+}
+
 function buildServices({
   hideAnnouncements = false,
   announcementSeenInProfile = false,
@@ -39,6 +71,8 @@ function buildServices({
   agentBuilderSeenJson,
   chatExperienceCapabilities = capabilitiesAllowRevert,
   chatExperience = AIChatExperience.Agent,
+  observabilityConversationCount = 0,
+  securityTotal = 0,
 }: {
   hideAnnouncements?: boolean;
   announcementSeenInProfile?: boolean;
@@ -48,6 +82,8 @@ function buildServices({
   agentBuilderSeenJson?: string;
   chatExperienceCapabilities?: Capabilities;
   chatExperience?: AIChatExperience;
+  observabilityConversationCount?: number;
+  securityTotal?: number;
 } = {}) {
   const space$ = new BehaviorSubject({ id: spaceId, name: spaceId });
   const reportEvent = jest.fn();
@@ -70,6 +106,8 @@ function buildServices({
     partialUpdate,
   };
 
+  const http = createHttpMock({ observabilityConversationCount, securityTotal });
+
   const services = {
     settings: {
       client: {
@@ -90,9 +128,10 @@ function buildServices({
     analytics: { reportEvent },
     application: { navigateToApp, capabilities: chatExperienceCapabilities },
     userProfile,
+    http,
   };
 
-  return { services, reportEvent, navigateToApp, partialUpdate, userProfile, space$ };
+  return { services, reportEvent, navigateToApp, partialUpdate, userProfile, space$, http };
 }
 
 function renderController(services: ReturnType<typeof buildServices>['services']) {
@@ -185,6 +224,7 @@ describe('AgentBuilderAnnouncementModalController', () => {
     await waitFor(() => {
       expect(screen.getByTestId('agentBuilderAnnouncementContinueButton')).toBeInTheDocument();
     });
+    expect(screen.getByTestId('agentBuilderAnnouncementModal-1a')).toBeInTheDocument();
   });
 
   it('does not show the modal again after switching space when dismissal was recorded for another space (legacy profile)', async () => {
@@ -234,13 +274,17 @@ describe('AgentBuilderAnnouncementModalController', () => {
     expect(reportEvent).toHaveBeenCalledWith(AGENT_BUILDER_EVENT_TYPES.OptInAction, {
       action: 'confirmed',
       source: 'agent_builder_nav_control',
+      announcement_variant: '1a',
+      had_prior_ai_assistant_usage: false,
     });
     expect(screen.queryByTestId('agentBuilderAnnouncementContinueButton')).not.toBeInTheDocument();
   });
 
   it('calls partialUpdate, reports OptOut telemetry, navigates to GenAI settings, and hides the modal on revert', async () => {
     const user = userEvent.setup();
-    const { services, reportEvent, navigateToApp, partialUpdate } = buildServices();
+    const { services, reportEvent, navigateToApp, partialUpdate } = buildServices({
+      observabilityConversationCount: 1,
+    });
     renderController(services);
 
     await waitFor(() =>
@@ -258,17 +302,20 @@ describe('AgentBuilderAnnouncementModalController', () => {
     });
     expect(reportEvent).toHaveBeenCalledWith(AGENT_BUILDER_EVENT_TYPES.OptOut, {
       source: 'agent_builder_nav_control',
+      announcement_variant: '1b',
+      had_prior_ai_assistant_usage: true,
     });
     expect(navigateToApp).toHaveBeenCalledWith('management', { path: '/ai/genAiSettings' });
     expect(screen.queryByTestId('agentBuilderAnnouncementRevertButton')).not.toBeInTheDocument();
   });
 
-  it('does not show revert when the user cannot change space-level chat experience', async () => {
+  it('shows variant 2a when the user has prior assistant usage but cannot change chat experience', async () => {
     const { services } = buildServices({
       chatExperienceCapabilities: {
         ...capabilitiesAllowRevert,
         advancedSettings: { save: false },
       },
+      observabilityConversationCount: 1,
     });
     renderController(services);
 
@@ -276,11 +323,7 @@ describe('AgentBuilderAnnouncementModalController', () => {
       expect(screen.getByTestId('agentBuilderAnnouncementContinueButton')).toBeInTheDocument();
     });
     expect(screen.queryByTestId('agentBuilderAnnouncementRevertButton')).not.toBeInTheDocument();
-    expect(screen.queryByText('Need your history?')).not.toBeInTheDocument();
-    expect(screen.getByTestId('agentBuilderAnnouncementLearnMoreCallout')).toBeInTheDocument();
-    expect(screen.getByTestId('agentBuilderAnnouncementDocumentationLink')).toHaveAttribute(
-      'href',
-      'https://www.elastic.co/docs/explore-analyze/ai-features/elastic-agent-builder'
-    );
+    expect(screen.getByTestId('agentBuilderAnnouncementModal-2a')).toBeInTheDocument();
+    expect(screen.getByTestId('agentBuilderAnnouncementImportantNotes')).toBeInTheDocument();
   });
 });

--- a/x-pack/platform/plugins/shared/agent_builder/public/components/announcement/agent_builder_announcement_modal_controller.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/components/announcement/agent_builder_announcement_modal_controller.tsx
@@ -8,7 +8,12 @@
 import React, { useMemo, useState } from 'react';
 import useObservable from 'react-use/lib/useObservable';
 import { EMPTY } from 'rxjs';
-import type { AnalyticsServiceStart, ApplicationStart, IUiSettingsClient } from '@kbn/core/public';
+import type {
+  AnalyticsServiceStart,
+  ApplicationStart,
+  HttpStart,
+  IUiSettingsClient,
+} from '@kbn/core/public';
 import type { UserProfileServiceStart } from '@kbn/core-user-profile-browser';
 import { AIChatExperience, canUserChangeSpaceChatExperience } from '@kbn/ai-assistant-common';
 import { useGlobalUiSetting, useKibana } from '@kbn/kibana-react-plugin/public';
@@ -17,6 +22,10 @@ import { AgentBuilderAnnouncementModal } from '@kbn/agent-builder-browser';
 import { AGENT_BUILDER_EVENT_TYPES } from '@kbn/agent-builder-common/telemetry';
 import type { SpacesPluginStart } from '@kbn/spaces-plugin/public';
 import { useAgentBuilderAnnouncementModalSeenState } from './use_agent_builder_announcement_modal_seen';
+import {
+  computeAnnouncementVariant,
+  useAiAssistantPriorUsage,
+} from './use_ai_assistant_prior_usage';
 
 export function AgentBuilderAnnouncementModalController() {
   const { services } = useKibana<{
@@ -24,11 +33,20 @@ export function AgentBuilderAnnouncementModalController() {
     analytics: AnalyticsServiceStart;
     application: ApplicationStart;
     userProfile: UserProfileServiceStart;
+    http: HttpStart;
     settings: { client: IUiSettingsClient; globalClient: IUiSettingsClient };
   }>();
   const canRevertToAssistant = useMemo(
     () => canUserChangeSpaceChatExperience(services.application.capabilities),
     [services.application.capabilities]
+  );
+  const { hasUsedAiAssistant, isReady: isUsageReady } = useAiAssistantPriorUsage(
+    services.http,
+    services.application.capabilities
+  );
+  const variant = useMemo(
+    () => computeAnnouncementVariant(hasUsedAiAssistant, canRevertToAssistant),
+    [hasUsedAiAssistant, canRevertToAssistant]
   );
   const hideAnnouncements = useGlobalUiSetting<boolean>(HIDE_ANNOUNCEMENTS_ID);
   const spacesService = services.spaces;
@@ -40,25 +58,33 @@ export function AgentBuilderAnnouncementModalController() {
       [services.settings.client]
     )
   );
-  const { isSeen, isReady, markSeen } = useAgentBuilderAnnouncementModalSeenState(
-    services.userProfile
-  );
+  const {
+    isSeen,
+    isReady: isSeenStateReady,
+    markSeen,
+  } = useAgentBuilderAnnouncementModalSeenState(services.userProfile);
   const [isDismissed, setIsDismissed] = useState(false);
 
   if (!space) return null;
   if (hideAnnouncements || isDismissed || navigator.webdriver) return null;
   if (chatExperience === AIChatExperience.Classic) return null;
-  if (!isReady) return null;
+  if (!isSeenStateReady || !isUsageReady) return null;
   if (isSeen) return null;
+
+  const telemetryContext = {
+    announcement_variant: variant,
+    had_prior_ai_assistant_usage: hasUsedAiAssistant,
+  };
 
   return (
     <AgentBuilderAnnouncementModal
-      canRevertToAssistant={canRevertToAssistant}
+      variant={variant}
       onContinue={() => {
         void markSeen().catch(() => {});
         services.analytics.reportEvent(AGENT_BUILDER_EVENT_TYPES.OptInAction, {
           action: 'confirmed',
           source: 'agent_builder_nav_control',
+          ...telemetryContext,
         });
         setIsDismissed(true);
       }}
@@ -66,6 +92,7 @@ export function AgentBuilderAnnouncementModalController() {
         void markSeen().catch(() => {});
         services.analytics.reportEvent(AGENT_BUILDER_EVENT_TYPES.OptOut, {
           source: 'agent_builder_nav_control',
+          ...telemetryContext,
         });
         services.application.navigateToApp('management', { path: '/ai/genAiSettings' });
         setIsDismissed(true);

--- a/x-pack/platform/plugins/shared/agent_builder/public/components/announcement/use_ai_assistant_prior_usage.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/components/announcement/use_ai_assistant_prior_usage.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useEffect, useState } from 'react';
+import type { Capabilities, HttpStart } from '@kbn/core/public';
+import {
+  API_VERSIONS,
+  ELASTIC_AI_ASSISTANT_CONVERSATIONS_URL_FIND,
+} from '@kbn/elastic-assistant-common';
+import type { AgentBuilderAnnouncementVariant } from '@kbn/agent-builder-browser';
+
+const OBSERVABILITY_CONVERSATIONS_ROUTE = '/internal/observability_ai_assistant/conversations';
+
+interface ObservabilityConversationsResponse {
+  conversations: unknown[];
+}
+
+export function computeAnnouncementVariant(
+  hasUsedAiAssistant: boolean,
+  canRevertToAssistant: boolean
+): AgentBuilderAnnouncementVariant {
+  if (!hasUsedAiAssistant) {
+    return '1a';
+  }
+  return canRevertToAssistant ? '1b' : '2a';
+}
+
+async function checkObservabilityAssistantUsage(http: HttpStart): Promise<boolean> {
+  try {
+    const res = await http.fetch<ObservabilityConversationsResponse>(
+      OBSERVABILITY_CONVERSATIONS_ROUTE,
+      {
+        method: 'POST',
+        body: JSON.stringify({}),
+        headers: { 'Content-Type': 'application/json' },
+      }
+    );
+    return Array.isArray(res.conversations) && res.conversations.length > 0;
+  } catch {
+    return false;
+  }
+}
+
+async function checkSecurityAssistantUsage(http: HttpStart): Promise<boolean> {
+  try {
+    const res = await http.fetch<{ total: number }>(ELASTIC_AI_ASSISTANT_CONVERSATIONS_URL_FIND, {
+      method: 'GET',
+      version: API_VERSIONS.public.v1,
+      query: {
+        page: 1,
+        per_page: 1,
+        is_owner: true,
+      },
+    });
+    return typeof res.total === 'number' && res.total > 0;
+  } catch {
+    return false;
+  }
+}
+
+export interface UseAiAssistantPriorUsageResult {
+  hasUsedAiAssistant: boolean;
+  isReady: boolean;
+}
+
+export function useAiAssistantPriorUsage(
+  http: HttpStart,
+  capabilities: Capabilities
+): UseAiAssistantPriorUsageResult {
+  const [hasUsedAiAssistant, setHasUsedAiAssistant] = useState(false);
+  const [isReady, setIsReady] = useState(false);
+
+  const checkObs = capabilities.observabilityAIAssistant?.show === true;
+  const checkSec = capabilities.securitySolutionAssistant?.['ai-assistant'] === true;
+
+  useEffect(() => {
+    let cancelled = false;
+    setIsReady(false);
+
+    if (!checkObs && !checkSec) {
+      setHasUsedAiAssistant(false);
+      setIsReady(true);
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    void (async () => {
+      const results = await Promise.all([
+        checkObs ? checkObservabilityAssistantUsage(http) : Promise.resolve(false),
+        checkSec ? checkSecurityAssistantUsage(http) : Promise.resolve(false),
+      ]);
+      if (!cancelled) {
+        setHasUsedAiAssistant(results.some(Boolean));
+        setIsReady(true);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [http, checkObs, checkSec]);
+
+  return { hasUsedAiAssistant, isReady };
+}

--- a/x-pack/platform/plugins/shared/agent_builder/tsconfig.json
+++ b/x-pack/platform/plugins/shared/agent_builder/tsconfig.json
@@ -81,6 +81,7 @@
     "@kbn/usage-collection-plugin",
     "@kbn/core-notifications-browser",
     "@kbn/ai-assistant-common",
+    "@kbn/elastic-assistant-common",
     "@kbn/ui-theme",
     "@kbn/ai-assistant-management-plugin",
     "@kbn/inference-endpoint-ui-common",


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Agent Builder] Redesign announcement modal with three A/B variants (#264995)](https://github.com/elastic/kibana/pull/264995)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jon Wålstedt","email":"jon.walstedt@elastic.co"},"sourceCommit":{"committedDate":"2026-04-22T14:40:55Z","message":"[Agent Builder] Redesign announcement modal with three A/B variants (#264995)\n\n## Summary\n\n### What\nReplaces the binary `canRevertToAssistant` prop on the announcement\nmodal with a three-way variant system (`1a` / `1b` / `2a`) that reflects\neach user's prior AI Assistant usage and their permission to revert the\nspace-level chat experience.\n\n### Why\nThe updated design specifies three distinct modal layouts per user\nstate:\n\n- **1a** – user has never used AI Assistant (regardless of revert\npermission): feature highlights only, no history callout, no revert\naction.\n- **1b** – user has prior AI Assistant usage + is a space admin who can\nrevert the space-level chat experience via GenAI Settings: feature\nhighlights, \"important notes\" callout with settings copy, revert button.\n- **2a** – user has prior AI Assistant usage + lacks permission to\nrevert (must contact an admin): intro paragraph, \"important notes\"\ncallout with admin copy, no revert button.\n\n\n**1a**\n\n<img width=\"705\" height=\"437\" alt=\"Screenshot 2026-04-22 at 13 18 02\"\nsrc=\"https://github.com/user-attachments/assets/fe19d2c7-2eae-46a7-a56b-edcb90d32f50\"\n/>\n\n**1b**\n\n<img width=\"675\" height=\"565\" alt=\"Screenshot 2026-04-22 at 13 21 01\"\nsrc=\"https://github.com/user-attachments/assets/407f01c9-68f9-4d89-a271-00a81188339c\"\n/>\n\n**2a**\n\n<img width=\"721\" height=\"480\" alt=\"Screenshot 2026-04-22 at 13 23 37\"\nsrc=\"https://github.com/user-attachments/assets/156d539d-a1c7-4743-906f-9b76233a6511\"\n/>\n\n\n\n### Changes\n\n**Modal structure**\n- Extracted each variant into its own component under\n`announcement_modal/variants/`:\n  - `NoPriorAssistantUsage` (1a)\n- `PriorAssistantSpaceAdminRevert` (1b) — space admin can revert for the\nwhole space\n  - `PriorAssistantAdminRevert` (2a) — user must contact admin\n- Shared UI pieces (feature bullet list with bolt/plugs/refresh icons,\nrelease-notes button, footer CSS) live in `announcement_ui_shared.tsx`.\n- URL constant moved to `announcement_urls.ts`.\n- Modal header now includes a gradient product icon (`productAgent`) per\nthe new design.\n\n**Prior-usage detection**\n- Added `useAiAssistantPriorUsage` hook that races parallel checks\nagainst the Observability AI Assistant\n(`/internal/observability_ai_assistant/conversations`) and Security AI\nAssistant (`conversations/_find`) endpoints, gated by capabilities, to\ndetermine whether the user has any prior conversations in the current\nspace.\n- Added `computeAnnouncementVariant` pure function that derives the\nvariant from `(hasUsedAiAssistant, canRevertToAssistant)`.\n- The controller waits for both the \"seen\" state and the usage check to\nresolve before rendering, preventing a layout flash.\n\n**Telemetry**\n- Added `announcement_variant` (`1a` | `1b` | `2a`) and\n`had_prior_ai_assistant_usage` (boolean) fields to both `OptInAction`\nand `OptOut` event schemas so conversion and revert rates can be\nsegmented per variant.\n\n**Tests**\n- Updated modal unit tests to cover each variant explicitly.\n- Updated controller integration tests to wire up an HTTP mock for both\nassistant endpoints and assert the correct variant is selected and the\ncorrect telemetry context is emitted.\n\n**Other**\n- Added `@kbn/elastic-assistant-common` to `agent_builder` plugin\ntsconfig.\n\n---\n\n### Checklist\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\n- **Performance (low):** The modal now fires up to two API calls (Obs +\nSecurity conversations) on mount. Both use minimal pagination\n(`per_page=1`) and fail-safe to `false` on error, so the user experience\nis unaffected in error scenarios.\n- **Variant mis-classification (low):** A user with conversations in one\nassistant but not the other is still correctly classified as\n`hasUsedAiAssistant = true` via `results.some(Boolean)`. Users without\neither assistant capability skip the network calls entirely and\nimmediately receive variant 1a.\n- **No breaking API or data changes.** The modal change is display-only;\nno saved objects, settings, or public API surfaces are modified.\n\n### Release note\n\n> Redesigns the AI Agent announcement modal into three tailored layouts\nbased on whether the user has prior AI Assistant history and whether\nthey can revert the space-level chat experience, improving contextual\nclarity at onboarding.\n\nPart of: https://github.com/elastic/kibana/issues/264152\n\n\n**PR developed with Claude Code and Sonnet 4.6**\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"621285d27233af85ea31f0e0e2183b1599e5f41d","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:enhancement","Team:Threat Hunting","backport:version","v9.4.0","v9.5.0"],"title":"[Agent Builder] Redesign announcement modal with three A/B variants","number":264995,"url":"https://github.com/elastic/kibana/pull/264995","mergeCommit":{"message":"[Agent Builder] Redesign announcement modal with three A/B variants (#264995)\n\n## Summary\n\n### What\nReplaces the binary `canRevertToAssistant` prop on the announcement\nmodal with a three-way variant system (`1a` / `1b` / `2a`) that reflects\neach user's prior AI Assistant usage and their permission to revert the\nspace-level chat experience.\n\n### Why\nThe updated design specifies three distinct modal layouts per user\nstate:\n\n- **1a** – user has never used AI Assistant (regardless of revert\npermission): feature highlights only, no history callout, no revert\naction.\n- **1b** – user has prior AI Assistant usage + is a space admin who can\nrevert the space-level chat experience via GenAI Settings: feature\nhighlights, \"important notes\" callout with settings copy, revert button.\n- **2a** – user has prior AI Assistant usage + lacks permission to\nrevert (must contact an admin): intro paragraph, \"important notes\"\ncallout with admin copy, no revert button.\n\n\n**1a**\n\n<img width=\"705\" height=\"437\" alt=\"Screenshot 2026-04-22 at 13 18 02\"\nsrc=\"https://github.com/user-attachments/assets/fe19d2c7-2eae-46a7-a56b-edcb90d32f50\"\n/>\n\n**1b**\n\n<img width=\"675\" height=\"565\" alt=\"Screenshot 2026-04-22 at 13 21 01\"\nsrc=\"https://github.com/user-attachments/assets/407f01c9-68f9-4d89-a271-00a81188339c\"\n/>\n\n**2a**\n\n<img width=\"721\" height=\"480\" alt=\"Screenshot 2026-04-22 at 13 23 37\"\nsrc=\"https://github.com/user-attachments/assets/156d539d-a1c7-4743-906f-9b76233a6511\"\n/>\n\n\n\n### Changes\n\n**Modal structure**\n- Extracted each variant into its own component under\n`announcement_modal/variants/`:\n  - `NoPriorAssistantUsage` (1a)\n- `PriorAssistantSpaceAdminRevert` (1b) — space admin can revert for the\nwhole space\n  - `PriorAssistantAdminRevert` (2a) — user must contact admin\n- Shared UI pieces (feature bullet list with bolt/plugs/refresh icons,\nrelease-notes button, footer CSS) live in `announcement_ui_shared.tsx`.\n- URL constant moved to `announcement_urls.ts`.\n- Modal header now includes a gradient product icon (`productAgent`) per\nthe new design.\n\n**Prior-usage detection**\n- Added `useAiAssistantPriorUsage` hook that races parallel checks\nagainst the Observability AI Assistant\n(`/internal/observability_ai_assistant/conversations`) and Security AI\nAssistant (`conversations/_find`) endpoints, gated by capabilities, to\ndetermine whether the user has any prior conversations in the current\nspace.\n- Added `computeAnnouncementVariant` pure function that derives the\nvariant from `(hasUsedAiAssistant, canRevertToAssistant)`.\n- The controller waits for both the \"seen\" state and the usage check to\nresolve before rendering, preventing a layout flash.\n\n**Telemetry**\n- Added `announcement_variant` (`1a` | `1b` | `2a`) and\n`had_prior_ai_assistant_usage` (boolean) fields to both `OptInAction`\nand `OptOut` event schemas so conversion and revert rates can be\nsegmented per variant.\n\n**Tests**\n- Updated modal unit tests to cover each variant explicitly.\n- Updated controller integration tests to wire up an HTTP mock for both\nassistant endpoints and assert the correct variant is selected and the\ncorrect telemetry context is emitted.\n\n**Other**\n- Added `@kbn/elastic-assistant-common` to `agent_builder` plugin\ntsconfig.\n\n---\n\n### Checklist\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\n- **Performance (low):** The modal now fires up to two API calls (Obs +\nSecurity conversations) on mount. Both use minimal pagination\n(`per_page=1`) and fail-safe to `false` on error, so the user experience\nis unaffected in error scenarios.\n- **Variant mis-classification (low):** A user with conversations in one\nassistant but not the other is still correctly classified as\n`hasUsedAiAssistant = true` via `results.some(Boolean)`. Users without\neither assistant capability skip the network calls entirely and\nimmediately receive variant 1a.\n- **No breaking API or data changes.** The modal change is display-only;\nno saved objects, settings, or public API surfaces are modified.\n\n### Release note\n\n> Redesigns the AI Agent announcement modal into three tailored layouts\nbased on whether the user has prior AI Assistant history and whether\nthey can revert the space-level chat experience, improving contextual\nclarity at onboarding.\n\nPart of: https://github.com/elastic/kibana/issues/264152\n\n\n**PR developed with Claude Code and Sonnet 4.6**\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"621285d27233af85ea31f0e0e2183b1599e5f41d"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/264995","number":264995,"mergeCommit":{"message":"[Agent Builder] Redesign announcement modal with three A/B variants (#264995)\n\n## Summary\n\n### What\nReplaces the binary `canRevertToAssistant` prop on the announcement\nmodal with a three-way variant system (`1a` / `1b` / `2a`) that reflects\neach user's prior AI Assistant usage and their permission to revert the\nspace-level chat experience.\n\n### Why\nThe updated design specifies three distinct modal layouts per user\nstate:\n\n- **1a** – user has never used AI Assistant (regardless of revert\npermission): feature highlights only, no history callout, no revert\naction.\n- **1b** – user has prior AI Assistant usage + is a space admin who can\nrevert the space-level chat experience via GenAI Settings: feature\nhighlights, \"important notes\" callout with settings copy, revert button.\n- **2a** – user has prior AI Assistant usage + lacks permission to\nrevert (must contact an admin): intro paragraph, \"important notes\"\ncallout with admin copy, no revert button.\n\n\n**1a**\n\n<img width=\"705\" height=\"437\" alt=\"Screenshot 2026-04-22 at 13 18 02\"\nsrc=\"https://github.com/user-attachments/assets/fe19d2c7-2eae-46a7-a56b-edcb90d32f50\"\n/>\n\n**1b**\n\n<img width=\"675\" height=\"565\" alt=\"Screenshot 2026-04-22 at 13 21 01\"\nsrc=\"https://github.com/user-attachments/assets/407f01c9-68f9-4d89-a271-00a81188339c\"\n/>\n\n**2a**\n\n<img width=\"721\" height=\"480\" alt=\"Screenshot 2026-04-22 at 13 23 37\"\nsrc=\"https://github.com/user-attachments/assets/156d539d-a1c7-4743-906f-9b76233a6511\"\n/>\n\n\n\n### Changes\n\n**Modal structure**\n- Extracted each variant into its own component under\n`announcement_modal/variants/`:\n  - `NoPriorAssistantUsage` (1a)\n- `PriorAssistantSpaceAdminRevert` (1b) — space admin can revert for the\nwhole space\n  - `PriorAssistantAdminRevert` (2a) — user must contact admin\n- Shared UI pieces (feature bullet list with bolt/plugs/refresh icons,\nrelease-notes button, footer CSS) live in `announcement_ui_shared.tsx`.\n- URL constant moved to `announcement_urls.ts`.\n- Modal header now includes a gradient product icon (`productAgent`) per\nthe new design.\n\n**Prior-usage detection**\n- Added `useAiAssistantPriorUsage` hook that races parallel checks\nagainst the Observability AI Assistant\n(`/internal/observability_ai_assistant/conversations`) and Security AI\nAssistant (`conversations/_find`) endpoints, gated by capabilities, to\ndetermine whether the user has any prior conversations in the current\nspace.\n- Added `computeAnnouncementVariant` pure function that derives the\nvariant from `(hasUsedAiAssistant, canRevertToAssistant)`.\n- The controller waits for both the \"seen\" state and the usage check to\nresolve before rendering, preventing a layout flash.\n\n**Telemetry**\n- Added `announcement_variant` (`1a` | `1b` | `2a`) and\n`had_prior_ai_assistant_usage` (boolean) fields to both `OptInAction`\nand `OptOut` event schemas so conversion and revert rates can be\nsegmented per variant.\n\n**Tests**\n- Updated modal unit tests to cover each variant explicitly.\n- Updated controller integration tests to wire up an HTTP mock for both\nassistant endpoints and assert the correct variant is selected and the\ncorrect telemetry context is emitted.\n\n**Other**\n- Added `@kbn/elastic-assistant-common` to `agent_builder` plugin\ntsconfig.\n\n---\n\n### Checklist\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\n- **Performance (low):** The modal now fires up to two API calls (Obs +\nSecurity conversations) on mount. Both use minimal pagination\n(`per_page=1`) and fail-safe to `false` on error, so the user experience\nis unaffected in error scenarios.\n- **Variant mis-classification (low):** A user with conversations in one\nassistant but not the other is still correctly classified as\n`hasUsedAiAssistant = true` via `results.some(Boolean)`. Users without\neither assistant capability skip the network calls entirely and\nimmediately receive variant 1a.\n- **No breaking API or data changes.** The modal change is display-only;\nno saved objects, settings, or public API surfaces are modified.\n\n### Release note\n\n> Redesigns the AI Agent announcement modal into three tailored layouts\nbased on whether the user has prior AI Assistant history and whether\nthey can revert the space-level chat experience, improving contextual\nclarity at onboarding.\n\nPart of: https://github.com/elastic/kibana/issues/264152\n\n\n**PR developed with Claude Code and Sonnet 4.6**\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"621285d27233af85ea31f0e0e2183b1599e5f41d"}}]}] BACKPORT-->