### PR TITLE
Unskip functional_execution_context browser tests

### DIFF
--- a/x-pack/platform/test/functional_execution_context/tests/browser.ts
+++ b/x-pack/platform/test/functional_execution_context/tests/browser.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { encode as risonEncode } from '@kbn/rison';
 import type { Ecs, KibanaExecutionContext } from '@kbn/core/server';
 import type { FtrProviderContext } from '../ftr_provider_context';
 import { assertLogContains, isExecutionContextLog, readLogFile } from '../test_utils';
@@ -19,8 +20,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     'timePicker',
   ]);
 
-  // Failing: See https://github.com/elastic/kibana/issues/258554
-  describe.skip('Browser apps', () => {
+  describe('Browser apps', () => {
     let logs: Ecs[];
     let discoverSessionFirstTabId = '';
     const retry = getService('retry');
@@ -340,7 +340,9 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
                 name: 'discover',
                 id: '571aaf70-4c88-11e8-b3d7-01146121b73d',
                 description: '[Flights] Flight Log',
-                url: `/app/discover#/view/571aaf70-4c88-11e8-b3d7-01146121b73d?_tab=(tabId:'${discoverSessionFirstTabId}')`,
+                url: `/app/discover#/view/571aaf70-4c88-11e8-b3d7-01146121b73d?_tab=${risonEncode({
+                  tabId: discoverSessionFirstTabId,
+                })}`,
               },
             }),
           });


### PR DESCRIPTION
## Summary

Closes #258554.

The `dashboard app > propagates context for built-in Discover > propagates to Kibana logs` test in `x-pack/platform/test/functional_execution_context/tests/browser.ts` was skipped because it failed intermittently after #257467 added the selected `tabId` to the discover embeddable's locator URL.

Root cause: the test's expected URL was built with a hardcoded template — ``?_tab=(tabId:'${discoverSessionFirstTabId}')`` — that assumed single quotes around the tab id. The `[Flights] Flight Log` saved search is legacy (pre-tabs), so its tab id is generated as a random `uuidv4()` by the `extractTabs` backfill. Rison only quotes strings that start with a digit, so whenever the generated UUID started with a letter (`a`–`f`) the log line contained `(tabId:abc...)` without quotes and the deep-equality match in `isExecutionContextLog` failed.

Fix: build the expected `_tab=...` segment with `@kbn/rison`'s `encode` so the test matches whatever the locator produces, regardless of the UUID's first character. Unskip the outer `describe`.

The inner `describe.skip`s for TSVB/Vega/Tag Cloud/Vertical bar were already skipped for unrelated reasons and are left as-is.