### PR TITLE
[Security Solution] fix analyzer not showing child flyout in Discover

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/analyze_graph.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/analyze_graph.tsx
@@ -211,6 +211,7 @@ export const AnalyzeGraph: FC = () => {
         shouldUpdate={shouldUpdate}
         filters={filters}
         renderCellActions={cellActionRenderer}
+        useLegacyExpandableFlyout={true}
       />
     </div>
   );

--- a/x-pack/solutions/security/plugins/security_solution/public/resolver/test_utilities/simulator/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/resolver/test_utilities/simulator/index.tsx
@@ -82,6 +82,7 @@ export class Simulator {
     history,
     filters,
     shouldUpdate,
+    useLegacyExpandableFlyout = false,
   }: {
     /**
      * A (mock) data access layer that will be used to create the Resolver store.
@@ -102,6 +103,7 @@ export class Simulator {
     history: HistoryPackageHistoryInterface;
     filters: TimeFilters;
     shouldUpdate: boolean;
+    useLegacyExpandableFlyout?: boolean;
   }) {
     // create the spy middleware (for debugging tests)
     this.spyMiddleware = spyMiddlewareFactory();
@@ -151,6 +153,7 @@ export class Simulator {
         indices={indices}
         filters={filters}
         shouldUpdate={shouldUpdate}
+        useLegacyExpandableFlyout={useLegacyExpandableFlyout}
         renderCellActions={cellActionRenderer}
       />
     );

--- a/x-pack/solutions/security/plugins/security_solution/public/resolver/test_utilities/simulator/mock_resolver.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/resolver/test_utilities/simulator/mock_resolver.tsx
@@ -111,6 +111,7 @@ export const MockResolver = React.memo((props: MockResolverProps) => {
                       indices={props.indices}
                       shouldUpdate={props.shouldUpdate}
                       filters={props.filters}
+                      useLegacyExpandableFlyout={props.useLegacyExpandableFlyout}
                       renderCellActions={props.renderCellActions}
                     />
                     <DetailsPanel

--- a/x-pack/solutions/security/plugins/security_solution/public/resolver/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/resolver/types.ts
@@ -856,6 +856,10 @@ export interface ResolverProps {
    * Optional callback invoked after alert mutations in nested flyouts.
    */
   onAlertUpdated?: () => void;
+  /**
+   * Use the legacy expandable flyout behavior for resolver panels.
+   */
+  useLegacyExpandableFlyout?: boolean;
 }
 
 /**

--- a/x-pack/solutions/security/plugins/security_solution/public/resolver/view/controls/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/resolver/view/controls/index.test.tsx
@@ -100,8 +100,35 @@ describe('graph controls: when relsover is loaded with an origin node', () => {
     ).toYieldEqualTo({ showPanelButton: 1 });
   });
 
-  it('should open the analyzer details panel when clicking the view button', async () => {
+  it('should open the analyzer details panel using system flyout by default', async () => {
     (await simulator.resolve('resolver:graph-controls:show-panel-button'))?.simulate('click');
+
+    expect(mockFlyoutApi.openPreviewPanel).toHaveBeenCalledTimes(0);
+  });
+
+  it('should open the analyzer details panel in expandable flyout when legacy mode is enabled', async () => {
+    jest.clearAllMocks();
+    jest.mocked(useExpandableFlyoutApi).mockReturnValue(mockFlyoutApi);
+    const {
+      metadata: { databaseDocumentID },
+      dataAccessLayer,
+    } = noAncestorsTwoChildren();
+
+    const legacyFlyoutSimulator = new Simulator({
+      dataAccessLayer,
+      databaseDocumentID,
+      resolverComponentInstanceID: `${resolverComponentInstanceID}-legacy-flyout`,
+      history: createMemoryHistory(),
+      indices: [],
+      shouldUpdate: false,
+      filters: {},
+      useLegacyExpandableFlyout: true,
+    });
+
+    await legacyFlyoutSimulator.resolve('resolver:graph-controls:zoom-in');
+    (
+      await legacyFlyoutSimulator.resolve('resolver:graph-controls:show-panel-button')
+    )?.simulate('click');
 
     expect(mockFlyoutApi.openPreviewPanel).toHaveBeenCalledTimes(1);
   });

--- a/x-pack/solutions/security/plugins/security_solution/public/resolver/view/controls/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/resolver/view/controls/index.test.tsx
@@ -126,9 +126,9 @@ describe('graph controls: when relsover is loaded with an origin node', () => {
     });
 
     await legacyFlyoutSimulator.resolve('resolver:graph-controls:zoom-in');
-    (
-      await legacyFlyoutSimulator.resolve('resolver:graph-controls:show-panel-button')
-    )?.simulate('click');
+    (await legacyFlyoutSimulator.resolve('resolver:graph-controls:show-panel-button'))?.simulate(
+      'click'
+    );
 
     expect(mockFlyoutApi.openPreviewPanel).toHaveBeenCalledTimes(1);
   });

--- a/x-pack/solutions/security/plugins/security_solution/public/resolver/view/resolver_without_providers.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/resolver/view/resolver_without_providers.tsx
@@ -35,7 +35,6 @@ import type { State } from '../../common/store/types';
 import { DocumentDetailsAnalyzerPanelKey } from '../../flyout/document_details/shared/constants/panel_keys';
 import { flyoutProviders } from '../../flyout_v2/shared/components/flyout_provider';
 import { DocumentFlyoutWrapper } from '../../flyout_v2/document/document_flyout_wrapper';
-import { useIsExperimentalFeatureEnabled } from '../../common/hooks/use_experimental_features';
 import { useDefaultDocumentFlyoutProperties } from '../../flyout_v2/shared/hooks/use_default_flyout_properties';
 
 export const ANALYZER_PREVIEW_BANNER = {
@@ -66,11 +65,10 @@ export const ResolverWithoutProviders = React.memo(
       filters,
       renderCellActions,
       onAlertUpdated,
+      useLegacyExpandableFlyout = false,
     }: ResolverProps,
     refToForward
   ) {
-    const newFlyoutSystemEnabled = useIsExperimentalFeatureEnabled('newFlyoutSystemEnabled');
-
     const { services } = useKibana();
     const { overlays } = services;
     const store = useStore();
@@ -176,7 +174,9 @@ export const ResolverWithoutProviders = React.memo(
     );
 
     const onShowPanel = useCallback(() => {
-      if (newFlyoutSystemEnabled) {
+      const shouldUseSystemFlyout = !useLegacyExpandableFlyout;
+
+      if (shouldUseSystemFlyout) {
         overlays.openSystemFlyout(
           flyoutProviders({
             services,
@@ -209,7 +209,6 @@ export const ResolverWithoutProviders = React.memo(
     }, [
       defaultFlyoutProperties,
       history,
-      newFlyoutSystemEnabled,
       onShowEvent,
       openPreviewPanel,
       overlays,
@@ -217,6 +216,7 @@ export const ResolverWithoutProviders = React.memo(
       resolverComponentInstanceID,
       services,
       store,
+      useLegacyExpandableFlyout,
     ]);
 
     return (


### PR DESCRIPTION
## Summary

This PR fixes an issue where Analyzer was not rendering children flyouts when clicking on a node when loaded in Discover.

### Reason of the issue:

Within the Analyzer code, we were using the `newFlyoutSystemEnabled` feature flag to drive which flyout to open: the new system flyout or the legacy expandable flyout.
While this was working great in Security Solution and Discover when testing locally (during PR review), it was actually hidden by the fact that we were testing with both the `newFlyoutSystemEnabled` feature flag and the `enhanced-security-document-profile` Discover profile enabled. This recent [PR](https://github.com/elastic/kibana/pull/264488) enabled the enhanced document profile in Discover by default, but the `newFlyoutSystemEnabled` feature flag is still not enabled in Security Solution.

Hence we now have this inconsistency...

### Solution

Instead of listening to both the `newFlyoutSystemEnabled` and `enhanced-security-document-profile` profile within the Analyzer code, I decided to pass a new property called `useLegacyExpandableFlyout `. That way the Analyzer code does not have to make that decision, which is a lot cleaner...

#### Behavior

`useLegacyExpandableFlyout` is set to `false` by default. This means that by default the new system flyout will be used. This is ok because Analyzer is only used in 2 places:
- the old flyout, where we pass `useLegacyExpandableFlyout={true}`
-  new new flyout

#### UI

Before (broken in Discover)

https://github.com/user-attachments/assets/416ba348-1186-4166-9684-8e2a8cdee5bb

After (fixed)

https://github.com/user-attachments/assets/e42c211c-3f74-4e72-8155-edd6cf5f255a

Old flyout is still working as expected

<img width="1335" height="1076" alt="Screenshot 2026-04-22 at 11 38 03 AM" src="https://github.com/user-attachments/assets/9fb3250e-9bf6-454d-b8d8-77b451d04f96" />

New flyout is working in Security Solution

<img width="1335" height="1076" alt="Screenshot 2026-04-22 at 11 38 03 AM" src="https://github.com/user-attachments/assets/cabaf8bb-dad0-4211-a347-8e7c88dfabd4" />

New flyout is working in Discover

<img width="1340" height="1079" alt="Screenshot 2026-04-22 at 11 38 55 AM" src="https://github.com/user-attachments/assets/72df53fd-fba5-4f85-8ca0-85086ac71815" />

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.





<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->