### PR TITLE
[build] Support tar.zst on docker images

### DIFF
--- a/.buildkite/scripts/steps/cloud/build_and_deploy.sh
+++ b/.buildkite/scripts/steps/cloud/build_and_deploy.sh
@@ -47,7 +47,7 @@ esac
 echo "--- Download Kibana Distribution"
 
 mkdir -p ./target
-download_artifact "kibana-$VERSION-linux-x86_64.tar.gz" ./target --build "${KIBANA_BUILD_ID:-$BUILDKITE_BUILD_ID}"
+download_artifact "kibana-$VERSION-linux-x86_64.tar.zst" ./target --build "${KIBANA_BUILD_ID:-$BUILDKITE_BUILD_ID}"
 
 echo "--- Build Cloud Distribution"
 ELASTICSEARCH_MANIFEST_URL="https://storage.googleapis.com/kibana-ci-es-snapshots-daily/$(jq -r '.version' package.json)/manifest-latest-verified.json"
@@ -77,6 +77,7 @@ else
     --skip-platform-folders \
     --skip-archives \
     --skip-cdn-assets \
+    --tar-zstd \
     --docker-images \
     --docker-tag-qualifier="$GIT_COMMIT" \
     --docker-push \

--- a/.buildkite/scripts/steps/cloud/build_cloud_image.sh
+++ b/.buildkite/scripts/steps/cloud/build_cloud_image.sh
@@ -13,7 +13,7 @@ VERSION="$(jq -r '.version' package.json)-SNAPSHOT"
 echo "--- Download Kibana Distribution"
 
 mkdir -p ./target
-download_artifact "kibana-$VERSION-linux-x86_64.tar.gz" ./target --build "${KIBANA_BUILD_ID:-$BUILDKITE_BUILD_ID}"
+download_artifact "kibana-$VERSION-linux-x86_64.tar.zst" ./target --build "${KIBANA_BUILD_ID:-$BUILDKITE_BUILD_ID}"
 
 echo "--- Build Cloud Distribution"
 
@@ -23,6 +23,7 @@ node scripts/build \
   --skip-platform-folders \
   --skip-cdn-assets \
   --skip-archives \
+  --tar-zstd \
   --docker-images \
   --docker-tag-qualifier="$GIT_COMMIT" \
   --docker-push \

--- a/.buildkite/scripts/steps/fips/build.sh
+++ b/.buildkite/scripts/steps/fips/build.sh
@@ -8,7 +8,7 @@ source .buildkite/scripts/common/util.sh
 source .buildkite/scripts/steps/artifacts/env.sh
 
 mkdir -p target
-download_artifact "kibana-$FULL_VERSION-linux-x86_64.tar.gz" ./target --build "${KIBANA_BUILD_ID:-$BUILDKITE_BUILD_ID}"
+download_artifact "kibana-$FULL_VERSION-linux-x86_64.tar.zst" ./target --build "${KIBANA_BUILD_ID:-$BUILDKITE_BUILD_ID}"
 
 echo "--- Build FIPS image"
 node scripts/build \
@@ -17,6 +17,7 @@ node scripts/build \
     --skip-platform-folders \
     --skip-cdn-assets \
     --skip-archives \
+    --tar-zstd \
     --docker-images \
     --docker-namespace="kibana-ci" \
     --docker-tag-qualifier="$BUILDKITE_COMMIT" \

--- a/.buildkite/scripts/steps/fips/build_cloud_fips_image.sh
+++ b/.buildkite/scripts/steps/fips/build_cloud_fips_image.sh
@@ -13,7 +13,7 @@ VERSION="$(jq -r '.version' package.json)-SNAPSHOT"
 echo "--- Download Kibana Distribution"
 
 mkdir -p ./target
-download_artifact "kibana-$VERSION-linux-x86_64.tar.gz" ./target --build "${KIBANA_BUILD_ID:-$BUILDKITE_BUILD_ID}"
+download_artifact "kibana-$VERSION-linux-x86_64.tar.zst" ./target --build "${KIBANA_BUILD_ID:-$BUILDKITE_BUILD_ID}"
 
 echo "--- Build Cloud FIPS Distribution"
 
@@ -23,6 +23,7 @@ node scripts/build \
   --skip-platform-folders \
   --skip-cdn-assets \
   --skip-archives \
+  --tar-zstd \
   --docker-images \
   --docker-tag-qualifier="$GIT_COMMIT" \
   --docker-push \

--- a/src/dev/build/tasks/os_packages/docker_generator/run.ts
+++ b/src/dev/build/tasks/os_packages/docker_generator/run.ts
@@ -82,7 +82,8 @@ export async function runDockerGenerator(
   if (flags.serverless) artifactVariant = '-serverless';
   if (flags.solution) artifactSolution = `-${flags.solution.artifact}`;
   const artifactPrefix = `kibana${artifactVariant}${artifactSolution}-${version}-linux`;
-  const artifactTarball = `${artifactPrefix}-${artifactArchitecture}.tar.gz`;
+  const tarExt = config.getTarZstd() ? 'tar.zst' : 'tar.gz';
+  const artifactTarball = `${artifactPrefix}-${artifactArchitecture}.${tarExt}`;
   const beatsArchitecture = flags.architecture === 'aarch64' ? 'arm64' : 'x86_64';
   const metricbeatTarball = `metricbeat${
     flags.fips ? '-fips' : ''
@@ -138,6 +139,8 @@ export async function runDockerGenerator(
     revision: config.getBuildSha(),
     publicArtifactSubdomain,
     fips: flags.fips,
+    tarZstd: config.getTarZstd(),
+    tarExt,
   };
 
   type HostArchitectureToDocker = Record<string, string>;

--- a/src/dev/build/tasks/os_packages/docker_generator/template_context.ts
+++ b/src/dev/build/tasks/os_packages/docker_generator/template_context.ts
@@ -35,4 +35,6 @@ export interface TemplateContext {
   revision: string;
   architecture?: string;
   fips?: boolean;
+  tarZstd?: boolean;
+  tarExt: string;
 }

--- a/src/dev/build/tasks/os_packages/docker_generator/templates/base/Dockerfile
+++ b/src/dev/build/tasks/os_packages/docker_generator/templates/base/Dockerfile
@@ -16,7 +16,7 @@ RUN microdnf install -y findutils tar gzip{{#tarZstd}} zstd{{/tarZstd}}
 {{/ubi}}
 {{#wolfi}}
 RUN for iter in 1 2 3 4 5; do \
-      apk --no-cache add curl{{#tarZstd}} zstd{{/tarZstd}} && break; \
+      apk --no-cache add curl gnutar{{#tarZstd}} zstd{{/tarZstd}} && break; \
       echo "apk add failed (attempt $iter/5), retrying in $((iter * 10))s..."; \
       sleep $((iter * 10)); \
       [ $iter -eq 5 ] && exit 1; \

--- a/src/dev/build/tasks/os_packages/docker_generator/templates/base/Dockerfile
+++ b/src/dev/build/tasks/os_packages/docker_generator/templates/base/Dockerfile
@@ -12,11 +12,11 @@
 FROM {{{baseImageName}}} AS builder
 
 {{#ubi}}
-RUN microdnf install -y findutils tar gzip
+RUN microdnf install -y findutils tar gzip{{#tarZstd}} zstd{{/tarZstd}}
 {{/ubi}}
 {{#wolfi}}
 RUN for iter in 1 2 3 4 5; do \
-      apk --no-cache add curl && break; \
+      apk --no-cache add curl{{#tarZstd}} zstd{{/tarZstd}} && break; \
       echo "apk add failed (attempt $iter/5), retrying in $((iter * 10))s..."; \
       sleep $((iter * 10)); \
       [ $iter -eq 5 ] && exit 1; \
@@ -32,14 +32,14 @@ RUN cd /tmp && \
   cd -
 {{/usePublicArtifact}}
 {{^usePublicArtifact}}
-COPY {{artifactTarball}} /tmp/kibana.tar.gz
+COPY {{artifactTarball}} /tmp/kibana.{{tarExt}}
 {{/usePublicArtifact}}
 
 RUN mkdir /usr/share/kibana
 WORKDIR /usr/share/kibana
 RUN tar \
   --strip-components=1 \
-  -zxf /tmp/kibana.tar.gz
+  {{#tarZstd}}-I zstd -xf{{/tarZstd}}{{^tarZstd}}-zxf{{/tarZstd}} /tmp/kibana.{{tarExt}}
 
 # Ensure that group permissions are the same as user permissions.
 # This will help when relying on GID-0 to run Kibana, rather than UID-1000.


### PR DESCRIPTION
This is only used on CI currently.  The production change after rendered will be a no-op.


Fixes an issue where docker image's were looking for the tar.gz artifacts after https://github.com/elastic/kibana/pull/264794.