### PR TITLE
[9.4] [Agent Builder] Add snapshot telemetry to skills and plugins  (#264694)

### DIFF
--- a/x-pack/platform/plugins/private/telemetry_collection_xpack/schema/xpack_platform.json
+++ b/x-pack/platform/plugins/private/telemetry_collection_xpack/schema/xpack_platform.json
@@ -357,6 +357,96 @@
             }
           }
         },
+        "skills": {
+          "properties": {
+            "total": {
+              "type": "long",
+              "_meta": {
+                "description": "Total number of persisted skills (custom + plugin-bundled)"
+              }
+            },
+            "custom": {
+              "type": "long",
+              "_meta": {
+                "description": "Number of user-created custom skills"
+              }
+            },
+            "plugin": {
+              "type": "long",
+              "_meta": {
+                "description": "Number of plugin-bundled skills"
+              }
+            }
+          }
+        },
+        "plugins": {
+          "properties": {
+            "total": {
+              "type": "long",
+              "_meta": {
+                "description": "Total number of installed plugins"
+              }
+            }
+          }
+        },
+        "skill_invocations": {
+          "properties": {
+            "total": {
+              "type": "long",
+              "_meta": {
+                "description": "Total skill invocations across all origins"
+              }
+            },
+            "by_origin": {
+              "properties": {
+                "builtin": {
+                  "type": "long",
+                  "_meta": {
+                    "description": "Skill invocations from built-in skills"
+                  }
+                },
+                "custom": {
+                  "type": "long",
+                  "_meta": {
+                    "description": "Skill invocations from user-created skills"
+                  }
+                },
+                "plugin": {
+                  "type": "long",
+                  "_meta": {
+                    "description": "Skill invocations from plugin-bundled skills"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "plugin_imports": {
+          "properties": {
+            "total": {
+              "type": "long",
+              "_meta": {
+                "description": "Total plugin imports across all source types"
+              }
+            },
+            "by_source": {
+              "properties": {
+                "url": {
+                  "type": "long",
+                  "_meta": {
+                    "description": "Plugins imported via URL"
+                  }
+                },
+                "upload": {
+                  "type": "long",
+                  "_meta": {
+                    "description": "Plugins imported via file upload"
+                  }
+                }
+              }
+            }
+          }
+        },
         "conversations": {
           "properties": {
             "total": {

--- a/x-pack/platform/plugins/shared/agent_builder/server/hooks/skills/load_skill_tools_after_read.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/hooks/skills/load_skill_tools_after_read.test.ts
@@ -17,7 +17,7 @@ import type { InternalSkillDefinition } from '@kbn/agent-builder-server/skills';
 import { ToolManagerToolType } from '@kbn/agent-builder-server/runner';
 import type { SkillBoundedTool } from '@kbn/agent-builder-server/skills';
 import { ToolType } from '@kbn/agent-builder-common';
-import type { AnalyticsService } from '../../telemetry';
+import type { AnalyticsService, TrackingService } from '../../telemetry';
 import { createToolHandlerContextMock, type ToolHandlerContextMock } from '../../test_utils/runner';
 import { createLoadSkillToolsAfterRead } from './load_skill_tools_after_read';
 
@@ -25,6 +25,12 @@ const createAnalyticsServiceMock = (): jest.Mocked<
   Pick<AnalyticsService, 'reportSkillInvoked'>
 > => ({
   reportSkillInvoked: jest.fn(),
+});
+
+const createTrackingServiceMock = (): jest.Mocked<
+  Pick<TrackingService, 'trackSkillInvocation'>
+> => ({
+  trackSkillInvocation: jest.fn(),
 });
 
 const createSkillFileEntry = (
@@ -343,12 +349,15 @@ describe('createLoadSkillToolsAfterRead', () => {
 
   describe('telemetry', () => {
     let analyticsService: jest.Mocked<Pick<AnalyticsService, 'reportSkillInvoked'>>;
+    let trackingService: jest.Mocked<Pick<TrackingService, 'trackSkillInvocation'>>;
     let loadSkillToolsAfterReadWithTelemetry: ReturnType<typeof createLoadSkillToolsAfterRead>;
 
     beforeEach(() => {
       analyticsService = createAnalyticsServiceMock();
+      trackingService = createTrackingServiceMock();
       loadSkillToolsAfterReadWithTelemetry = createLoadSkillToolsAfterRead({
         analyticsService: analyticsService as unknown as AnalyticsService,
+        trackingService: trackingService as unknown as TrackingService,
       });
     });
 
@@ -438,6 +447,52 @@ describe('createLoadSkillToolsAfterRead', () => {
           pluginId: 'plugin-uuid-1',
         })
       );
+      expect(trackingService.trackSkillInvocation).toHaveBeenCalledWith('plugin');
+    });
+
+    it('calls trackSkillInvocation with the correct origin when a skill is invoked', async () => {
+      const skill = createMockSkill({
+        id: 'security-skill',
+        readonly: true,
+        basePath: 'skills/security/foo',
+        getInlineTools: jest.fn().mockReturnValue([]),
+        getRegistryTools: jest.fn().mockReturnValue([]),
+      });
+
+      toolHandlerContext.filestore.read.mockResolvedValue(
+        createSkillFileEntry({ skillId: 'security-skill' })
+      );
+      toolHandlerContext.skills.get.mockResolvedValue(skill);
+      toolHandlerContext.runContext = {
+        runId: 'run-1',
+        stack: [
+          { type: 'agent', agentId: 'my_agent', conversationId: 'conv-1', executionId: 'exec-1' },
+        ],
+      };
+
+      const context = createHookContext({ toolHandlerContext });
+
+      await loadSkillToolsAfterReadWithTelemetry(context);
+
+      expect(trackingService.trackSkillInvocation).toHaveBeenCalledTimes(1);
+      expect(trackingService.trackSkillInvocation).toHaveBeenCalledWith('builtin');
+    });
+
+    it('does not call trackSkillInvocation when no tracking service is provided', async () => {
+      const loadSkillToolsAfterReadAnalyticsOnly = createLoadSkillToolsAfterRead({
+        analyticsService: analyticsService as unknown as AnalyticsService,
+      });
+
+      const skill = createMockSkill();
+
+      toolHandlerContext.filestore.read.mockResolvedValue(createSkillFileEntry());
+      toolHandlerContext.skills.get.mockResolvedValue(skill);
+
+      const context = createHookContext({ toolHandlerContext });
+
+      await loadSkillToolsAfterReadAnalyticsOnly(context);
+
+      expect(trackingService.trackSkillInvocation).not.toHaveBeenCalled();
     });
 
     it('does not report telemetry when no analytics service is provided', async () => {
@@ -470,6 +525,7 @@ describe('createLoadSkillToolsAfterRead', () => {
       );
       // Tools were still added even though telemetry failed.
       expect(toolHandlerContext.toolManager.addTools).toHaveBeenCalled();
+      expect(trackingService.trackSkillInvocation).not.toHaveBeenCalled();
     });
   });
 

--- a/x-pack/platform/plugins/shared/agent_builder/server/hooks/skills/load_skill_tools_after_read.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/hooks/skills/load_skill_tools_after_read.ts
@@ -14,14 +14,15 @@ import type { KibanaRequest } from '@kbn/core/server';
 import type { Logger } from '@kbn/logging';
 import { pickTools } from '../../services/execution/run_agent/utils/select_tools';
 import { isSkillFileEntry } from '../../services/execution/runner/store/volumes/skills/utils';
-import type { AnalyticsService } from '../../telemetry';
+import type { AnalyticsService, TrackingService } from '../../telemetry';
 import { classifySkill } from '../../telemetry/utils';
 
 const MAX_SKILL_REGISTRY_TOOLS = 25;
 
 export const createLoadSkillToolsAfterRead = ({
   analyticsService,
-}: { analyticsService?: AnalyticsService } = {}) => {
+  trackingService,
+}: { analyticsService?: AnalyticsService; trackingService?: TrackingService } = {}) => {
   return async (context: AfterToolCallHookContext): Promise<void> => {
     if (context.toolId !== filestoreTools.read) {
       return;
@@ -51,6 +52,7 @@ export const createLoadSkillToolsAfterRead = ({
       logger,
       runContext,
       analyticsService,
+      trackingService,
     });
   };
 };
@@ -64,6 +66,7 @@ const loadSkillTools = async ({
   logger,
   runContext,
   analyticsService,
+  trackingService,
 }: {
   skillsService: SkillsService;
   skillId: string;
@@ -73,6 +76,7 @@ const loadSkillTools = async ({
   logger: Logger;
   runContext: RunContext;
   analyticsService?: AnalyticsService;
+  trackingService?: TrackingService;
 }): Promise<void> => {
   const skill = await skillsService.get(skillId);
   if (!skill) {
@@ -105,14 +109,10 @@ const loadSkillTools = async ({
     }
   );
 
-  if (!analyticsService) {
-    return;
-  }
-
   try {
     const agentContext = getAgentFromRunContext(runContext);
     const { origin, solution_area: solutionArea } = classifySkill(skill);
-    analyticsService.reportSkillInvoked({
+    analyticsService?.reportSkillInvoked({
       skillId: skill.id,
       origin,
       solutionArea,
@@ -122,6 +122,7 @@ const loadSkillTools = async ({
       executionId: agentContext?.executionId,
       toolCount: inlineExecutableTools.length + registryExecutableTools.length,
     });
+    trackingService?.trackSkillInvocation(origin);
   } catch (e) {
     logger.warn(`Failed to report SkillInvoked telemetry: ${e}`);
   }

--- a/x-pack/platform/plugins/shared/agent_builder/server/hooks/skills/register_skill_tools_loader_hook.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/hooks/skills/register_skill_tools_loader_hook.ts
@@ -7,11 +7,12 @@
 
 import { HookLifecycle, HookExecutionMode } from '@kbn/agent-builder-server';
 import type { InternalSetupServices } from '../../services';
-import type { AnalyticsService } from '../../telemetry';
+import type { AnalyticsService, TrackingService } from '../../telemetry';
 import { createLoadSkillToolsAfterRead } from './load_skill_tools_after_read';
 
 export interface RegisterSkillToolsLoaderHookDeps {
   analyticsService?: AnalyticsService;
+  trackingService?: TrackingService;
 }
 
 /**
@@ -28,7 +29,10 @@ export const registerSkillToolsLoaderHook = (
     hooks: {
       [HookLifecycle.afterToolCall]: {
         mode: HookExecutionMode.blocking,
-        handler: createLoadSkillToolsAfterRead({ analyticsService: deps.analyticsService }),
+        handler: createLoadSkillToolsAfterRead({
+          analyticsService: deps.analyticsService,
+          trackingService: deps.trackingService,
+        }),
       },
     },
   });

--- a/x-pack/platform/plugins/shared/agent_builder/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/plugin.ts
@@ -195,7 +195,10 @@ export class AgentBuilderPlugin
       getInternalServices,
     });
 
-    registerSkillToolsLoaderHook(serviceSetups, { analyticsService: this.analyticsService });
+    registerSkillToolsLoaderHook(serviceSetups, {
+      analyticsService: this.analyticsService,
+      trackingService: this.trackingService,
+    });
 
     const smlTools = createSmlTools({
       getSmlService: () => {

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/create_services.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/create_services.ts
@@ -164,6 +164,7 @@ export class ServiceManager {
       spaces,
       config: this.config,
       analyticsService,
+      trackingService,
     });
 
     const runnerFactory = new RunnerFactoryImpl({

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/plugins/plugin_service.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/plugins/plugin_service.test.ts
@@ -11,7 +11,7 @@ import type { KibanaRequest } from '@kbn/core/server';
 import { createPluginsService, type PluginsServiceStart } from './plugin_service';
 import type { PluginClient, PersistedPluginDefinition } from './client';
 import type { SkillClient } from '../skills/persisted/client';
-import type { AnalyticsService } from '../../telemetry';
+import type { AnalyticsService, TrackingService } from '../../telemetry';
 
 const mockRandomUUID = jest.fn().mockReturnValue('test-plugin-uuid');
 jest.mock('crypto', () => ({
@@ -98,6 +98,7 @@ describe('PluginsService', () => {
   let mockClient: jest.Mocked<PluginClient>;
   let mockSkillClient: jest.Mocked<SkillClient>;
   let mockAnalyticsService: jest.Mocked<Pick<AnalyticsService, 'reportPluginImported'>>;
+  let mockTrackingService: jest.Mocked<Pick<TrackingService, 'trackPluginImport'>>;
   const mockRequest = {} as KibanaRequest;
 
   beforeEach(() => {
@@ -129,6 +130,10 @@ describe('PluginsService', () => {
       reportPluginImported: jest.fn(),
     };
 
+    mockTrackingService = {
+      trackPluginImport: jest.fn(),
+    };
+
     mockCreateClient.mockReturnValue(mockClient);
     mockCreateSkillClient.mockReturnValue(mockSkillClient);
 
@@ -151,6 +156,7 @@ describe('PluginsService', () => {
         topSnippets: { numSnippets: 2, numWords: 750 },
       },
       analyticsService: mockAnalyticsService as unknown as AnalyticsService,
+      trackingService: mockTrackingService as unknown as TrackingService,
     });
   });
 
@@ -433,6 +439,7 @@ describe('PluginsService', () => {
           sourceType: 'url',
           skillCount: 2,
         });
+        expect(mockTrackingService.trackPluginImport).toHaveBeenCalledWith('url');
       });
 
       it('reports PluginImported with sourceType "file" when installing from a file', async () => {
@@ -451,6 +458,44 @@ describe('PluginsService', () => {
           sourceType: 'file',
           skillCount: 2,
         });
+        expect(mockTrackingService.trackPluginImport).toHaveBeenCalledWith('file');
+      });
+
+      it('does not throw when trackingService is undefined', async () => {
+        const mockElasticsearch = {
+          client: {
+            asScoped: jest.fn(() => ({
+              asInternalUser: {},
+            })),
+          },
+        };
+
+        const service = createPluginsService();
+        service.setup({ skillsSetup: { registerSkill: jest.fn() } });
+        const startWithoutTracking = service.start({
+          logger: loggerMock.create(),
+          elasticsearch: mockElasticsearch as any,
+          config: {
+            enabled: true,
+            githubBaseUrl: 'https://github.com',
+            topSnippets: { numSnippets: 2, numWords: 750 },
+          },
+          analyticsService: mockAnalyticsService as unknown as AnalyticsService,
+        });
+
+        mockParsePluginFromUrl.mockResolvedValue(archiveWithSkills);
+        mockClient.findByName.mockResolvedValue(undefined);
+        mockClient.create.mockResolvedValue(
+          createMockPersistedPlugin({ id: 'created-plugin-id' })
+        );
+        mockSkillClient.bulkCreate.mockResolvedValue([]);
+
+        await expect(
+          startWithoutTracking.installPlugin({
+            request: mockRequest,
+            source: { type: 'url', url: 'https://example.com/plugin.zip' },
+          })
+        ).resolves.toBeDefined();
       });
 
       it('does not report PluginImported when install fails (existing plugin)', async () => {
@@ -467,6 +512,7 @@ describe('PluginsService', () => {
         ).rejects.toThrow(/already installed/);
 
         expect(mockAnalyticsService.reportPluginImported).not.toHaveBeenCalled();
+        expect(mockTrackingService.trackPluginImport).not.toHaveBeenCalled();
       });
     });
   });

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/plugins/plugin_service.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/plugins/plugin_service.test.ts
@@ -485,9 +485,7 @@ describe('PluginsService', () => {
 
         mockParsePluginFromUrl.mockResolvedValue(archiveWithSkills);
         mockClient.findByName.mockResolvedValue(undefined);
-        mockClient.create.mockResolvedValue(
-          createMockPersistedPlugin({ id: 'created-plugin-id' })
-        );
+        mockClient.create.mockResolvedValue(createMockPersistedPlugin({ id: 'created-plugin-id' }));
         mockSkillClient.bulkCreate.mockResolvedValue([]);
 
         await expect(

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/plugins/plugin_service.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/plugins/plugin_service.ts
@@ -14,7 +14,7 @@ import type { SpacesPluginStart } from '@kbn/spaces-plugin/server';
 import { isAllowedBuiltinPlugin } from '@kbn/agent-builder-server/allow_lists';
 import type { BuiltInPluginDefinition } from '@kbn/agent-builder-server/plugins';
 import type { AgentBuilderConfig } from '../../config';
-import type { AnalyticsService } from '../../telemetry';
+import type { AnalyticsService, TrackingService } from '../../telemetry';
 import { getCurrentSpaceId } from '../../utils/spaces';
 import type { PluginClient, PersistedPluginDefinition } from './client';
 import { createClient, parsedArchiveToCreateRequest } from './client';
@@ -61,6 +61,7 @@ export interface PluginsServiceStartDeps {
   spaces?: SpacesPluginStart;
   config: AgentBuilderConfig;
   analyticsService?: AnalyticsService;
+  trackingService?: TrackingService;
 }
 
 export const createPluginsService = (): PluginsService => {
@@ -186,12 +187,13 @@ class PluginsServiceImpl implements PluginsService {
 
     const created = await pluginClient.create(createRequest);
 
-    const { analyticsService } = this.getStartDeps();
+    const { analyticsService, trackingService } = this.getStartDeps();
     analyticsService?.reportPluginImported({
       pluginId: created.id,
       sourceType: source.type,
       skillCount: createRequests.length,
     });
+    trackingService?.trackPluginImport(source.type);
 
     return created;
   }

--- a/x-pack/platform/plugins/shared/agent_builder/server/telemetry/agent_builder_telemetry.md
+++ b/x-pack/platform/plugins/shared/agent_builder/server/telemetry/agent_builder_telemetry.md
@@ -36,6 +36,38 @@ pipeline. They include:
   - What it is: Total number of custom agents created.
   - How we count: ES `count` on the agents system index.
 
+### skills
+- `skills.total`
+  - What it is: Total number of persisted skills (custom + plugin-bundled).
+  - How we count: ES `hits.total` on the skills system index.
+- `skills.custom`
+  - What it is: Number of user-created custom skills.
+  - How we count: ES filter aggregation on skills without a `plugin_id` field.
+- `skills.plugin`
+  - What it is: Number of plugin-bundled skills.
+  - How we count: ES filter aggregation on skills with a `plugin_id` field.
+
+### plugins
+- `plugins.total`
+  - What it is: Total number of installed plugins.
+  - How we count: ES `count` on the plugins system index.
+
+### skill_invocations
+- `skill_invocations.total`
+  - What it is: Total skill invocations across all origins.
+  - How we count: Sum of per-origin usage counters (see usage counters section).
+- `skill_invocations.by_origin.builtin|custom|plugin`
+  - What it is: Skill invocations grouped by origin.
+  - How we count: Individual usage counters per origin.
+
+### plugin_imports
+- `plugin_imports.total`
+  - What it is: Total plugin imports across all source types.
+  - How we count: Sum of per-source usage counters (see usage counters section).
+- `plugin_imports.by_source.url|upload`
+  - What it is: Plugin imports grouped by source type.
+  - How we count: Individual usage counters per source type.
+
 ### conversations
 
 All-time conversation metrics (no date filter).
@@ -356,6 +388,20 @@ period configured by Kibana (defaults to several days).
 - `agent_builder_rounds_21-50`
 - `agent_builder_rounds_51+`
   - Count of conversation rounds bucketed by current round number.
+
+### Skill invocation counters
+- `agent_builder_skill_invocation_builtin`
+  - Count of skill invocations from built-in skills.
+- `agent_builder_skill_invocation_custom`
+  - Count of skill invocations from user-created skills.
+- `agent_builder_skill_invocation_plugin`
+  - Count of skill invocations from plugin-bundled skills.
+
+### Plugin import counters
+- `agent_builder_plugin_import_url`
+  - Count of plugins imported via URL.
+- `agent_builder_plugin_import_upload`
+  - Count of plugins imported via file upload.
 
 ### Query-to-result time counters
 - `agent_builder_query_to_result_time_<1s`

--- a/x-pack/platform/plugins/shared/agent_builder/server/telemetry/index.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/telemetry/index.ts
@@ -14,6 +14,8 @@ export {
   trackLLMUsage,
   trackConversationRound,
   trackQueryToResultTime,
+  trackSkillInvocation,
+  trackPluginImport,
   AGENTBUILDER_USAGE_DOMAIN,
 } from './usage_counters';
 export { registerTelemetryCollector, type AgentBuilderTelemetry } from './telemetry_collector';

--- a/x-pack/platform/plugins/shared/agent_builder/server/telemetry/query_utils.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/telemetry/query_utils.test.ts
@@ -438,6 +438,176 @@ describe('query_utils', () => {
       });
     });
 
+    describe('getSkillsMetrics', () => {
+      it('returns total, custom, and plugin counts from ES', async () => {
+        esClient.search.mockResolvedValue({
+          took: 1,
+          timed_out: false,
+          _shards: { total: 1, successful: 1, skipped: 0, failed: 0 },
+          hits: {
+            total: { value: 42, relation: 'eq' },
+            hits: [],
+          },
+          aggregations: {
+            custom: { doc_count: 30 },
+            plugin: { doc_count: 12 },
+          },
+        });
+
+        const result = await queryUtils.getSkillsMetrics();
+
+        expect(result).toEqual({
+          total: 42,
+          custom: 30,
+          plugin: 12,
+        });
+      });
+
+      it('handles hits.total as a number', async () => {
+        esClient.search.mockResolvedValue({
+          took: 1,
+          timed_out: false,
+          _shards: { total: 1, successful: 1, skipped: 0, failed: 0 },
+          hits: { total: 7, hits: [] },
+          aggregations: {
+            custom: { doc_count: 5 },
+            plugin: { doc_count: 2 },
+          },
+        });
+
+        const result = await queryUtils.getSkillsMetrics();
+
+        expect(result.total).toBe(7);
+        expect(result.custom).toBe(5);
+        expect(result.plugin).toBe(2);
+      });
+
+      it('queries the skills index with track_total_hits and filter aggs', async () => {
+        esClient.search.mockResolvedValue({
+          took: 1,
+          timed_out: false,
+          _shards: { total: 1, successful: 1, skipped: 0, failed: 0 },
+          hits: { total: { value: 0, relation: 'eq' }, hits: [] },
+          aggregations: {
+            custom: { doc_count: 0 },
+            plugin: { doc_count: 0 },
+          },
+        });
+
+        await queryUtils.getSkillsMetrics();
+
+        expect(esClient.search).toHaveBeenCalledWith({
+          index: '.chat-skills',
+          size: 0,
+          track_total_hits: true,
+          aggs: {
+            custom: {
+              filter: {
+                bool: {
+                  must_not: { exists: { field: 'plugin_id' } },
+                },
+              },
+            },
+            plugin: {
+              filter: {
+                exists: { field: 'plugin_id' },
+              },
+            },
+          },
+        });
+      });
+
+      it('defaults custom and plugin to 0 when aggregations are missing', async () => {
+        esClient.search.mockResolvedValue({
+          took: 1,
+          timed_out: false,
+          _shards: { total: 1, successful: 1, skipped: 0, failed: 0 },
+          hits: { total: { value: 0, relation: 'eq' }, hits: [] },
+          aggregations: {},
+        });
+
+        const result = await queryUtils.getSkillsMetrics();
+
+        expect(result.custom).toBe(0);
+        expect(result.plugin).toBe(0);
+      });
+
+      it('returns zeros on index_not_found_exception', async () => {
+        const error = {
+          message: 'index_not_found_exception: no such index [.chat-skills]',
+        };
+        esClient.search.mockRejectedValue(error);
+
+        const result = await queryUtils.getSkillsMetrics();
+
+        expect(result).toEqual({
+          total: 0,
+          custom: 0,
+          plugin: 0,
+        });
+        expect(logger.warn).not.toHaveBeenCalled();
+      });
+
+      it('logs warning and returns zeros on other errors', async () => {
+        esClient.search.mockRejectedValue(new Error('ES error'));
+
+        const result = await queryUtils.getSkillsMetrics();
+
+        expect(result).toEqual({
+          total: 0,
+          custom: 0,
+          plugin: 0,
+        });
+        expect(logger.warn).toHaveBeenCalledWith('Failed to fetch skills metrics: ES error');
+      });
+    });
+
+    describe('getPluginsCount', () => {
+      it('returns plugins count from ES', async () => {
+        esClient.count.mockResolvedValue({
+          count: 9,
+          _shards: { total: 1, successful: 1, skipped: 0, failed: 0 },
+        });
+
+        const result = await queryUtils.getPluginsCount();
+
+        expect(result).toBe(9);
+        expect(esClient.count).toHaveBeenCalledWith({ index: '.chat-plugins' });
+      });
+
+      it('returns 0 when count is undefined', async () => {
+        esClient.count.mockResolvedValue({
+          count: undefined as any,
+          _shards: { total: 1, successful: 1, skipped: 0, failed: 0 },
+        });
+
+        const result = await queryUtils.getPluginsCount();
+
+        expect(result).toBe(0);
+      });
+
+      it('returns 0 and does not log warning for index_not_found_exception', async () => {
+        const error = {
+          message: 'index_not_found_exception: no such index [.chat-plugins]',
+        };
+        esClient.count.mockRejectedValue(error);
+
+        const result = await queryUtils.getPluginsCount();
+
+        expect(result).toBe(0);
+        expect(logger.warn).not.toHaveBeenCalled();
+      });
+
+      it('returns 0 and logs warning on other errors', async () => {
+        esClient.count.mockRejectedValue(new Error('ES error'));
+
+        const result = await queryUtils.getPluginsCount();
+
+        expect(result).toBe(0);
+        expect(logger.warn).toHaveBeenCalledWith('Failed to fetch plugins count: ES error');
+      });
+    });
+
     describe('getConversationMetrics', () => {
       const mockConversationResponse = ({
         totalHits = 100,

--- a/x-pack/platform/plugins/shared/agent_builder/server/telemetry/query_utils.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/telemetry/query_utils.ts
@@ -7,6 +7,8 @@
 
 import type { ElasticsearchClient, Logger, SavedObjectsClientContract } from '@kbn/core/server';
 import { chatSystemIndex } from '@kbn/agent-builder-server';
+import { skillIndexName } from '../services/skills/persisted/client/storage';
+import { pluginIndexName } from '../services/plugins/client/storage';
 
 export const isIndexNotFoundError = (error: unknown): boolean => {
   if (!error || typeof error !== 'object') {
@@ -194,6 +196,75 @@ export class QueryUtils {
       // Suppress warning for missing index - expected when no agents have been created yet
       if (!isIndexNotFoundError(error)) {
         this.logger.warn(`Failed to fetch custom agents count: ${error.message}`);
+      }
+      return 0;
+    }
+  }
+
+  /**
+   * Get counts of persisted skills from Elasticsearch, broken down by origin.
+   * Skills with a `plugin_id` field are plugin-bundled; the rest are custom.
+   * Built-in skills are not persisted, so we get that count separately.
+   */
+  async getSkillsMetrics(): Promise<{
+    total: number;
+    custom: number;
+    plugin: number;
+  }> {
+    try {
+      const response = await this.esClient.search({
+        index: skillIndexName,
+        size: 0,
+        track_total_hits: true,
+        aggs: {
+          custom: {
+            filter: {
+              bool: {
+                must_not: { exists: { field: 'plugin_id' } },
+              },
+            },
+          },
+          plugin: {
+            filter: {
+              exists: { field: 'plugin_id' },
+            },
+          },
+        },
+      });
+
+      const total =
+        typeof response.hits.total === 'number'
+          ? response.hits.total
+          : response.hits.total?.value || 0;
+      const customCount = (response.aggregations?.custom as { doc_count?: number })?.doc_count ?? 0;
+      const pluginCount = (response.aggregations?.plugin as { doc_count?: number })?.doc_count ?? 0;
+
+      return {
+        total,
+        custom: customCount,
+        plugin: pluginCount,
+      };
+    } catch (error) {
+      if (!isIndexNotFoundError(error)) {
+        this.logger.warn(`Failed to fetch skills metrics: ${(error as Error).message}`);
+      }
+      return { total: 0, custom: 0, plugin: 0 };
+    }
+  }
+
+  /**
+   * Get total count of installed plugins from Elasticsearch.
+   */
+  async getPluginsCount(): Promise<number> {
+    try {
+      const response = await this.esClient.count({
+        index: pluginIndexName,
+      });
+
+      return response.count || 0;
+    } catch (error) {
+      if (!isIndexNotFoundError(error)) {
+        this.logger.warn(`Failed to fetch plugins count: ${(error as Error).message}`);
       }
       return 0;
     }

--- a/x-pack/platform/plugins/shared/agent_builder/server/telemetry/telemetry_collector.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/telemetry/telemetry_collector.test.ts
@@ -17,6 +17,8 @@ jest.mock('./query_utils', () => ({
   QueryUtils: jest.fn().mockImplementation(() => ({
     getCustomToolsMetrics: jest.fn(),
     getCustomAgentsMetrics: jest.fn(),
+    getSkillsMetrics: jest.fn(),
+    getPluginsCount: jest.fn(),
     getConversationMetrics: jest.fn(),
     getCountersByPrefix: jest.fn(),
     calculatePercentilesFromBuckets: jest.fn(),
@@ -107,6 +109,33 @@ describe('telemetry_collector', () => {
       expect(registeredCollector.schema.custom_agents.total.type).toBe('long');
     });
 
+    it('defines skills schema', () => {
+      expect(registeredCollector.schema.skills).toBeDefined();
+      expect(registeredCollector.schema.skills.total.type).toBe('long');
+      expect(registeredCollector.schema.skills.custom.type).toBe('long');
+      expect(registeredCollector.schema.skills.plugin.type).toBe('long');
+    });
+
+    it('defines plugins schema', () => {
+      expect(registeredCollector.schema.plugins).toBeDefined();
+      expect(registeredCollector.schema.plugins.total.type).toBe('long');
+    });
+
+    it('defines skill_invocations schema', () => {
+      expect(registeredCollector.schema.skill_invocations).toBeDefined();
+      expect(registeredCollector.schema.skill_invocations.total.type).toBe('long');
+      expect(registeredCollector.schema.skill_invocations.by_origin.builtin.type).toBe('long');
+      expect(registeredCollector.schema.skill_invocations.by_origin.custom.type).toBe('long');
+      expect(registeredCollector.schema.skill_invocations.by_origin.plugin.type).toBe('long');
+    });
+
+    it('defines plugin_imports schema', () => {
+      expect(registeredCollector.schema.plugin_imports).toBeDefined();
+      expect(registeredCollector.schema.plugin_imports.total.type).toBe('long');
+      expect(registeredCollector.schema.plugin_imports.by_source.url.type).toBe('long');
+      expect(registeredCollector.schema.plugin_imports.by_source.upload.type).toBe('long');
+    });
+
     it('defines conversations schema with token breakdown', () => {
       expect(registeredCollector.schema.conversations).toBeDefined();
       expect(registeredCollector.schema.conversations.total.type).toBe('long');
@@ -182,6 +211,12 @@ describe('telemetry_collector', () => {
           ],
         }),
         getCustomAgentsMetrics: jest.fn().mockResolvedValue(3),
+        getSkillsMetrics: jest.fn().mockResolvedValue({
+          total: 12,
+          custom: 3,
+          plugin: 4,
+        }),
+        getPluginsCount: jest.fn().mockResolvedValue(7),
         getConversationMetrics: jest.fn().mockResolvedValue({
           total: 100,
           total_rounds: 500,
@@ -270,6 +305,23 @@ describe('telemetry_collector', () => {
               ])
             );
           }
+          if (prefix === `${AGENTBUILDER_USAGE_DOMAIN}_skill_invocation_`) {
+            return Promise.resolve(
+              new Map([
+                [`${AGENTBUILDER_USAGE_DOMAIN}_skill_invocation_builtin`, 10],
+                [`${AGENTBUILDER_USAGE_DOMAIN}_skill_invocation_custom`, 20],
+                [`${AGENTBUILDER_USAGE_DOMAIN}_skill_invocation_plugin`, 5],
+              ])
+            );
+          }
+          if (prefix === `${AGENTBUILDER_USAGE_DOMAIN}_plugin_import_`) {
+            return Promise.resolve(
+              new Map([
+                [`${AGENTBUILDER_USAGE_DOMAIN}_plugin_import_url`, 3],
+                [`${AGENTBUILDER_USAGE_DOMAIN}_plugin_import_upload`, 7],
+              ])
+            );
+          }
           if (prefix === `${AGENTBUILDER_USAGE_DOMAIN}_llm_provider_`) {
             return Promise.resolve(
               new Map([
@@ -329,6 +381,28 @@ describe('telemetry_collector', () => {
       });
 
       expect(result.custom_agents).toEqual({ total: 3 });
+
+      expect(result.skills).toEqual({
+        total: 12,
+        custom: 3,
+        plugin: 4,
+      });
+      expect(result.plugins).toEqual({ total: 7 });
+      expect(result.skill_invocations).toEqual({
+        total: 35,
+        by_origin: {
+          builtin: 10,
+          custom: 20,
+          plugin: 5,
+        },
+      });
+      expect(result.plugin_imports).toEqual({
+        total: 10,
+        by_source: {
+          url: 3,
+          upload: 7,
+        },
+      });
 
       expect(result.conversations).toEqual({
         total: 100,
@@ -435,6 +509,63 @@ describe('telemetry_collector', () => {
           { type: 'internalError', count: 7 },
         ],
       });
+
+      expect(mockQueryUtils.getSkillsMetrics).toHaveBeenCalledTimes(1);
+      expect(mockQueryUtils.getPluginsCount).toHaveBeenCalledTimes(1);
+      expect(mockQueryUtils.getCountersByPrefix).toHaveBeenCalledWith(
+        AGENTBUILDER_USAGE_DOMAIN,
+        `${AGENTBUILDER_USAGE_DOMAIN}_skill_invocation_`
+      );
+      expect(mockQueryUtils.getCountersByPrefix).toHaveBeenCalledWith(
+        AGENTBUILDER_USAGE_DOMAIN,
+        `${AGENTBUILDER_USAGE_DOMAIN}_plugin_import_`
+      );
+    });
+
+    it('maps skill_invocation and plugin_import usage counters into telemetry', async () => {
+      mockQueryUtils.getSkillsMetrics.mockResolvedValue({
+        total: 4,
+        custom: 1,
+        plugin: 1,
+      });
+      mockQueryUtils.getPluginsCount.mockResolvedValue(2);
+      mockQueryUtils.getCountersByPrefix.mockImplementation((_domain: string, prefix: string) => {
+        if (prefix === `${AGENTBUILDER_USAGE_DOMAIN}_skill_invocation_`) {
+          return Promise.resolve(
+            new Map([
+              [`${AGENTBUILDER_USAGE_DOMAIN}_skill_invocation_builtin`, 1],
+              [`${AGENTBUILDER_USAGE_DOMAIN}_skill_invocation_custom`, 2],
+              [`${AGENTBUILDER_USAGE_DOMAIN}_skill_invocation_plugin`, 3],
+            ])
+          );
+        }
+        if (prefix === `${AGENTBUILDER_USAGE_DOMAIN}_plugin_import_`) {
+          return Promise.resolve(
+            new Map([
+              [`${AGENTBUILDER_USAGE_DOMAIN}_plugin_import_url`, 4],
+              [`${AGENTBUILDER_USAGE_DOMAIN}_plugin_import_upload`, 1],
+            ])
+          );
+        }
+        return Promise.resolve(new Map());
+      });
+
+      const result: AgentBuilderTelemetry = await registeredCollector.fetch(mockContext);
+
+      expect(result.skills).toEqual({
+        total: 4,
+        custom: 1,
+        plugin: 1,
+      });
+      expect(result.plugins).toEqual({ total: 2 });
+      expect(result.skill_invocations).toEqual({
+        total: 6,
+        by_origin: { builtin: 1, custom: 2, plugin: 3 },
+      });
+      expect(result.plugin_imports).toEqual({
+        total: 5,
+        by_source: { url: 4, upload: 1 },
+      });
     });
 
     it('returns default values when fetch throws error', async () => {
@@ -457,6 +588,23 @@ describe('telemetry_collector', () => {
       expect(result).toEqual({
         custom_tools: { total: 0, by_type: [] },
         custom_agents: { total: 0 },
+        skills: { total: 0, custom: 0, plugin: 0 },
+        plugins: { total: 0 },
+        skill_invocations: {
+          total: 0,
+          by_origin: {
+            builtin: 0,
+            custom: 0,
+            plugin: 0,
+          },
+        },
+        plugin_imports: {
+          total: 0,
+          by_source: {
+            url: 0,
+            upload: 0,
+          },
+        },
         conversations: emptyConversationMetrics,
         daily: emptyConversationMetrics,
         query_to_result_time: {

--- a/x-pack/platform/plugins/shared/agent_builder/server/telemetry/telemetry_collector.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/telemetry/telemetry_collector.ts
@@ -54,6 +54,29 @@ export interface AgentBuilderTelemetry {
   custom_agents: {
     total: number;
   };
+  skills: {
+    total: number;
+    custom: number;
+    plugin: number;
+  };
+  plugins: {
+    total: number;
+  };
+  skill_invocations: {
+    total: number;
+    by_origin: {
+      builtin: number;
+      custom: number;
+      plugin: number;
+    };
+  };
+  plugin_imports: {
+    total: number;
+    by_source: {
+      url: number;
+      upload: number;
+    };
+  };
   conversations: ConversationMetrics;
   daily: ConversationMetrics;
   query_to_result_time: {
@@ -176,6 +199,84 @@ export function registerTelemetryCollector(
             type: 'long',
             _meta: {
               description: 'Total number of custom agents created by users',
+            },
+          },
+        },
+        skills: {
+          total: {
+            type: 'long',
+            _meta: {
+              description: 'Total number of persisted skills (custom + plugin-bundled)',
+            },
+          },
+          custom: {
+            type: 'long',
+            _meta: {
+              description: 'Number of user-created custom skills',
+            },
+          },
+          plugin: {
+            type: 'long',
+            _meta: {
+              description: 'Number of plugin-bundled skills',
+            },
+          },
+        },
+        plugins: {
+          total: {
+            type: 'long',
+            _meta: {
+              description: 'Total number of installed plugins',
+            },
+          },
+        },
+        skill_invocations: {
+          total: {
+            type: 'long',
+            _meta: {
+              description: 'Total skill invocations across all origins',
+            },
+          },
+          by_origin: {
+            builtin: {
+              type: 'long',
+              _meta: {
+                description: 'Skill invocations from built-in skills',
+              },
+            },
+            custom: {
+              type: 'long',
+              _meta: {
+                description: 'Skill invocations from user-created skills',
+              },
+            },
+            plugin: {
+              type: 'long',
+              _meta: {
+                description: 'Skill invocations from plugin-bundled skills',
+              },
+            },
+          },
+        },
+        plugin_imports: {
+          total: {
+            type: 'long',
+            _meta: {
+              description: 'Total plugin imports across all source types',
+            },
+          },
+          by_source: {
+            url: {
+              type: 'long',
+              _meta: {
+                description: 'Plugins imported via URL',
+              },
+            },
+            upload: {
+              type: 'long',
+              _meta: {
+                description: 'Plugins imported via file upload',
+              },
             },
           },
         },
@@ -559,6 +660,9 @@ export function registerTelemetryCollector(
 
           const customAgents = await queryUtils.getCustomAgentsMetrics();
 
+          const skillsMetrics = await queryUtils.getSkillsMetrics();
+          const pluginsCount = await queryUtils.getPluginsCount();
+
           const conversations = await queryUtils.getConversationMetrics();
 
           const dailyDateFilter = {
@@ -597,6 +701,43 @@ export function registerTelemetryCollector(
             a2a: toolCallCounters.get(`${AGENTBUILDER_USAGE_DOMAIN}_tool_call_a2a`) || 0,
           };
           const totalToolCalls = Object.values(toolCallsBySource).reduce(
+            (sum, count) => sum + count,
+            0
+          );
+
+          const skillInvocationCounters = await queryUtils.getCountersByPrefix(
+            AGENTBUILDER_USAGE_DOMAIN,
+            `${AGENTBUILDER_USAGE_DOMAIN}_skill_invocation_`
+          );
+
+          const skillInvocationsByOrigin = {
+            builtin:
+              skillInvocationCounters.get(
+                `${AGENTBUILDER_USAGE_DOMAIN}_skill_invocation_builtin`
+              ) || 0,
+            custom:
+              skillInvocationCounters.get(`${AGENTBUILDER_USAGE_DOMAIN}_skill_invocation_custom`) ||
+              0,
+            plugin:
+              skillInvocationCounters.get(`${AGENTBUILDER_USAGE_DOMAIN}_skill_invocation_plugin`) ||
+              0,
+          };
+          const totalSkillInvocations = Object.values(skillInvocationsByOrigin).reduce(
+            (sum, count) => sum + count,
+            0
+          );
+
+          const pluginImportCounters = await queryUtils.getCountersByPrefix(
+            AGENTBUILDER_USAGE_DOMAIN,
+            `${AGENTBUILDER_USAGE_DOMAIN}_plugin_import_`
+          );
+
+          const pluginImportsBySource = {
+            url: pluginImportCounters.get(`${AGENTBUILDER_USAGE_DOMAIN}_plugin_import_url`) || 0,
+            upload:
+              pluginImportCounters.get(`${AGENTBUILDER_USAGE_DOMAIN}_plugin_import_upload`) || 0,
+          };
+          const totalPluginImports = Object.values(pluginImportsBySource).reduce(
             (sum, count) => sum + count,
             0
           );
@@ -660,6 +801,16 @@ export function registerTelemetryCollector(
           const telemetry: AgentBuilderTelemetry = {
             custom_tools: customTools,
             custom_agents: { total: customAgents },
+            skills: skillsMetrics,
+            plugins: { total: pluginsCount },
+            skill_invocations: {
+              total: totalSkillInvocations,
+              by_origin: skillInvocationsByOrigin,
+            },
+            plugin_imports: {
+              total: totalPluginImports,
+              by_source: pluginImportsBySource,
+            },
             conversations,
             daily,
             query_to_result_time: queryToResultTime,
@@ -701,6 +852,23 @@ export function registerTelemetryCollector(
           return {
             custom_tools: { total: 0, by_type: [] },
             custom_agents: { total: 0 },
+            skills: { total: 0, custom: 0, plugin: 0 },
+            plugins: { total: 0 },
+            skill_invocations: {
+              total: 0,
+              by_origin: {
+                builtin: 0,
+                custom: 0,
+                plugin: 0,
+              },
+            },
+            plugin_imports: {
+              total: 0,
+              by_source: {
+                url: 0,
+                upload: 0,
+              },
+            },
             conversations: emptyConversationMetrics,
             daily: emptyConversationMetrics,
             query_to_result_time: {

--- a/x-pack/platform/plugins/shared/agent_builder/server/telemetry/tracking_service.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/telemetry/tracking_service.test.ts
@@ -483,6 +483,92 @@ describe('TrackingService', () => {
     });
   });
 
+  describe('trackSkillInvocation', () => {
+    it('increments counter for builtin origin', () => {
+      trackingService.trackSkillInvocation('builtin');
+
+      expect(mockUsageCounter.incrementCounter).toHaveBeenCalledWith({
+        counterName: `${AGENTBUILDER_USAGE_DOMAIN}_skill_invocation_builtin`,
+        counterType: 'count',
+        incrementBy: 1,
+      });
+    });
+
+    it('increments counter for custom origin', () => {
+      trackingService.trackSkillInvocation('custom');
+
+      expect(mockUsageCounter.incrementCounter).toHaveBeenCalledWith({
+        counterName: `${AGENTBUILDER_USAGE_DOMAIN}_skill_invocation_custom`,
+        counterType: 'count',
+        incrementBy: 1,
+      });
+    });
+
+    it('increments counter for plugin origin', () => {
+      trackingService.trackSkillInvocation('plugin');
+
+      expect(mockUsageCounter.incrementCounter).toHaveBeenCalledWith({
+        counterName: `${AGENTBUILDER_USAGE_DOMAIN}_skill_invocation_plugin`,
+        counterType: 'count',
+        incrementBy: 1,
+      });
+    });
+
+    it('logs debug message on success', () => {
+      trackingService.trackSkillInvocation('custom');
+
+      expect(logger.debug).toHaveBeenCalledWith('Tracked skill invocation: origin=custom');
+    });
+
+    it('logs error when incrementCounter throws', () => {
+      mockUsageCounter.incrementCounter.mockImplementation(() => {
+        throw new Error('Counter error');
+      });
+
+      trackingService.trackSkillInvocation('builtin');
+
+      expect(logger.error).toHaveBeenCalledWith('Failed to track skill invocation: Counter error');
+    });
+  });
+
+  describe('trackPluginImport', () => {
+    it('increments counter for url source', () => {
+      trackingService.trackPluginImport('url');
+
+      expect(mockUsageCounter.incrementCounter).toHaveBeenCalledWith({
+        counterName: `${AGENTBUILDER_USAGE_DOMAIN}_plugin_import_url`,
+        counterType: 'count',
+        incrementBy: 1,
+      });
+    });
+
+    it('increments counter for upload source', () => {
+      trackingService.trackPluginImport('upload');
+
+      expect(mockUsageCounter.incrementCounter).toHaveBeenCalledWith({
+        counterName: `${AGENTBUILDER_USAGE_DOMAIN}_plugin_import_upload`,
+        counterType: 'count',
+        incrementBy: 1,
+      });
+    });
+
+    it('logs debug message on success', () => {
+      trackingService.trackPluginImport('url');
+
+      expect(logger.debug).toHaveBeenCalledWith('Tracked plugin import: sourceType=url');
+    });
+
+    it('logs error when incrementCounter throws', () => {
+      mockUsageCounter.incrementCounter.mockImplementation(() => {
+        throw new Error('Counter error');
+      });
+
+      trackingService.trackPluginImport('upload');
+
+      expect(logger.error).toHaveBeenCalledWith('Failed to track plugin import: Counter error');
+    });
+  });
+
   describe('trackError', () => {
     it('increments total error counter', () => {
       const error = new Error('Test error');

--- a/x-pack/platform/plugins/shared/agent_builder/server/telemetry/tracking_service.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/telemetry/tracking_service.ts
@@ -8,7 +8,12 @@
 import type { Logger } from '@kbn/logging';
 import type { UsageCounter } from '@kbn/usage-collection-plugin/server';
 import { v4 as uuidv4 } from 'uuid';
-import { AGENTBUILDER_USAGE_DOMAIN, trackLLMUsage as trackLLMUsageCounter } from './usage_counters';
+import {
+  AGENTBUILDER_USAGE_DOMAIN,
+  trackLLMUsage as trackLLMUsageCounter,
+  trackSkillInvocation as trackSkillInvocationCounter,
+  trackPluginImport as trackPluginImportCounter,
+} from './usage_counters';
 import {
   normalizeErrorType,
   sanitizeForCounterName,
@@ -214,6 +219,33 @@ export class TrackingService {
       this.logger.error(
         `Failed to track error: ${err instanceof Error ? err.message : String(err)}`
       );
+    }
+  }
+
+  /**
+   * Track a skill invocation
+   * @param origin - Skill origin (builtin, custom, or plugin)
+   */
+  trackSkillInvocation(origin: 'builtin' | 'custom' | 'plugin'): void {
+    try {
+      trackSkillInvocationCounter(this.usageCounter, origin);
+      this.logger.debug(`Tracked skill invocation: origin=${origin}`);
+    } catch (error) {
+      this.logger.error(`Failed to track skill invocation: ${error.message}`);
+    }
+  }
+
+  /**
+   * Track a plugin import
+   * @param sourceType - The original source type from the install request
+   */
+  trackPluginImport(sourceType: string): void {
+    try {
+      const importType = sourceType === 'url' ? 'url' : 'upload';
+      trackPluginImportCounter(this.usageCounter, importType);
+      this.logger.debug(`Tracked plugin import: sourceType=${importType}`);
+    } catch (error) {
+      this.logger.error(`Failed to track plugin import: ${error.message}`);
     }
   }
 }

--- a/x-pack/platform/plugins/shared/agent_builder/server/telemetry/usage_counters.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/telemetry/usage_counters.test.ts
@@ -12,6 +12,8 @@ import {
   trackLLMUsage,
   trackConversationRound,
   trackQueryToResultTime,
+  trackSkillInvocation,
+  trackPluginImport,
   AGENTBUILDER_USAGE_DOMAIN,
 } from './usage_counters';
 
@@ -307,6 +309,84 @@ describe('usage_counters', () => {
           incrementBy: 1,
         });
       }
+    });
+  });
+
+  describe('trackSkillInvocation', () => {
+    let mockUsageCounter: jest.Mocked<UsageCounter>;
+
+    beforeEach(() => {
+      mockUsageCounter = {
+        incrementCounter: jest.fn(),
+      } as unknown as jest.Mocked<UsageCounter>;
+    });
+
+    it('does nothing when usageCounter is undefined', () => {
+      expect(() => trackSkillInvocation(undefined, 'builtin')).not.toThrow();
+    });
+
+    it('tracks skill invocation from builtin', () => {
+      trackSkillInvocation(mockUsageCounter, 'builtin');
+
+      expect(mockUsageCounter.incrementCounter).toHaveBeenCalledWith({
+        counterName: 'agent_builder_skill_invocation_builtin',
+        counterType: 'count',
+        incrementBy: 1,
+      });
+    });
+
+    it('tracks skill invocation from custom', () => {
+      trackSkillInvocation(mockUsageCounter, 'custom');
+
+      expect(mockUsageCounter.incrementCounter).toHaveBeenCalledWith({
+        counterName: 'agent_builder_skill_invocation_custom',
+        counterType: 'count',
+        incrementBy: 1,
+      });
+    });
+
+    it('tracks skill invocation from plugin', () => {
+      trackSkillInvocation(mockUsageCounter, 'plugin');
+
+      expect(mockUsageCounter.incrementCounter).toHaveBeenCalledWith({
+        counterName: 'agent_builder_skill_invocation_plugin',
+        counterType: 'count',
+        incrementBy: 1,
+      });
+    });
+  });
+
+  describe('trackPluginImport', () => {
+    let mockUsageCounter: jest.Mocked<UsageCounter>;
+
+    beforeEach(() => {
+      mockUsageCounter = {
+        incrementCounter: jest.fn(),
+      } as unknown as jest.Mocked<UsageCounter>;
+    });
+
+    it('does nothing when usageCounter is undefined', () => {
+      expect(() => trackPluginImport(undefined, 'url')).not.toThrow();
+    });
+
+    it('tracks plugin import from url', () => {
+      trackPluginImport(mockUsageCounter, 'url');
+
+      expect(mockUsageCounter.incrementCounter).toHaveBeenCalledWith({
+        counterName: 'agent_builder_plugin_import_url',
+        counterType: 'count',
+        incrementBy: 1,
+      });
+    });
+
+    it('tracks plugin import from upload', () => {
+      trackPluginImport(mockUsageCounter, 'upload');
+
+      expect(mockUsageCounter.incrementCounter).toHaveBeenCalledWith({
+        counterName: 'agent_builder_plugin_import_upload',
+        counterType: 'count',
+        incrementBy: 1,
+      });
     });
   });
 });

--- a/x-pack/platform/plugins/shared/agent_builder/server/telemetry/usage_counters.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/telemetry/usage_counters.ts
@@ -132,3 +132,35 @@ export function trackQueryToResultTime(
     incrementBy: 1,
   });
 }
+
+/**
+ * Helper to track skill invocations by origin
+ */
+export function trackSkillInvocation(
+  usageCounter: UsageCounter | undefined,
+  origin: 'builtin' | 'custom' | 'plugin'
+): void {
+  if (!usageCounter) return;
+
+  usageCounter.incrementCounter({
+    counterName: `${AGENTBUILDER_USAGE_DOMAIN}_skill_invocation_${origin}`,
+    counterType: 'count',
+    incrementBy: 1,
+  });
+}
+
+/**
+ * Helper to track plugin imports by source type
+ */
+export function trackPluginImport(
+  usageCounter: UsageCounter | undefined,
+  sourceType: 'url' | 'upload'
+): void {
+  if (!usageCounter) return;
+
+  usageCounter.incrementCounter({
+    counterName: `${AGENTBUILDER_USAGE_DOMAIN}_plugin_import_${sourceType}`,
+    counterType: 'count',
+    incrementBy: 1,
+  });
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Agent Builder] Add snapshot telemetry to skills and plugins  (#264694)](https://github.com/elastic/kibana/pull/264694)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Pablo Machado","email":"pablo.nevesmachado@elastic.co"},"sourceCommit":{"committedDate":"2026-04-22T19:04:19Z","message":"[Agent Builder] Add snapshot telemetry to skills and plugins  (#264694)\n\nRelates to https://github.com/elastic/kibana/pull/264380\naddresses https://github.com/elastic/search-team/issues/13653\n\n## Summary\n\nAdds snapshot telemetry for **skills** and **plugins** to the Agent\nBuilder telemetry collector, complementing the existing EBT (Event-Based\nTelemetry) approach from #264380. The snapshot collector can be queried\nquickly via Kibana usage stats without needing to aggregate individual\nevents.\n\n### Architecture\n\n**Three layers added:**\n\n1. **Usage counters** (`usage_counters.ts`) — New `trackSkillInvocation`\nand `trackPluginImport` helpers that increment per-origin / per-source\ncounters. These are called from `TrackingService` alongside the existing\nEBT analytics events.\n\n2. **ES queries** (`query_utils.ts`) — New `getSkillsMetrics()` queries\nthe `.chat-skills` index with filter aggregations to break down\npersisted skills into `custom` (no `plugin_id`) vs `plugin` (has\n`plugin_id`). New `getPluginsCount()` counts docs in `.chat-plugins`.\n\n3. **Telemetry collector** (`telemetry_collector.ts`) — Extends the\n`AgentBuilderTelemetry` schema with four new sections:\n   - `skills` — `total`, `custom`, `plugin`\n   - `plugins` — `total`\n   - `skill_invocations` — `total` + `by_origin` (builtin/custom/plugin)\n   - `plugin_imports` — `total` + `by_source` (url/upload)\n\n### Snapshot telemetry fields\n\nAll fields added to the `AgentBuilderTelemetry` collector schema by this\nPR:\n\n| Field | Type | Source | Description |\n|---|---|---|---|\n| `skills.total` | `long` | ES query (`.chat-skills`, `hits.total`) |\nTotal number of persisted skills (custom + plugin-bundled) |\n| `skills.custom` | `long` | ES query (filter agg: no `plugin_id`) |\nNumber of user-created custom skills |\n| `skills.plugin` | `long` | ES query (filter agg: has `plugin_id`) |\nNumber of plugin-bundled skills |\n| `plugins.total` | `long` | ES query (`.chat-plugins`, `count`) | Total\nnumber of installed plugins |\n| `skill_invocations.total` | `long` | Usage counter (sum) | Total skill\ninvocations across all origins |\n| `skill_invocations.by_origin.builtin` | `long` | Usage counter | Skill\ninvocations from built-in skills |\n| `skill_invocations.by_origin.custom` | `long` | Usage counter | Skill\ninvocations from user-created skills |\n| `skill_invocations.by_origin.plugin` | `long` | Usage counter | Skill\ninvocations from plugin-bundled skills |\n| `plugin_imports.total` | `long` | Usage counter (sum) | Total plugin\nimports across all source types |\n| `plugin_imports.by_source.url` | `long` | Usage counter | Plugins\nimported via URL |\n| `plugin_imports.by_source.upload` | `long` | Usage counter | Plugins\nimported via file upload |\n\n**Usage counter names** (incremented at runtime, read back by the\ncollector):\n\n| Counter name | Incremented by |\n|---|---|\n| `agent_builder_skill_invocation_builtin` |\n`TrackingService.trackSkillInvocation('builtin')` |\n| `agent_builder_skill_invocation_custom` |\n`TrackingService.trackSkillInvocation('custom')` |\n| `agent_builder_skill_invocation_plugin` |\n`TrackingService.trackSkillInvocation('plugin')` |\n| `agent_builder_plugin_import_url` |\n`TrackingService.trackPluginImport('url')` |\n| `agent_builder_plugin_import_upload` |\n`TrackingService.trackPluginImport('upload')` |\n\n### How to test\n\n1. Start Kibana with Agent Builder enabled and a working connector.\n2. Create a custom skill and a plugin (import via URL or file upload).\n3. Invoke a skill in a conversation.\n4. Query the telemetry collector endpoint and verify the new `skills`,\n`plugins`, `skill_invocations`, and `plugin_imports` fields are\npopulated with correct counts.\n\n### Checklist\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\n- **Low risk — additional ES queries at telemetry collection time**:\n`getSkillsMetrics` and `getPluginsCount` add two extra ES calls during\nperiodic telemetry collection. Both are `size: 0` / `count` queries on\nsmall system indices, so impact is negligible. Errors are caught and\ndefault to zero.\n- **Low risk — usage counter overhead**: The new `trackSkillInvocation`\nand `trackPluginImport` counters are lightweight in-memory increments,\nconsistent with the existing counters pattern.\n\n### Release notes\n\nSkip — internal telemetry, no user-facing changes.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"1a8b73d86e09ae9379ab6b3f18e483e38299fff4","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:version","v9.4.0","Team:agent-builder","feature:agent-builder","v9.5.0"],"title":"[Agent Builder] Add snapshot telemetry to skills and plugins ","number":264694,"url":"https://github.com/elastic/kibana/pull/264694","mergeCommit":{"message":"[Agent Builder] Add snapshot telemetry to skills and plugins  (#264694)\n\nRelates to https://github.com/elastic/kibana/pull/264380\naddresses https://github.com/elastic/search-team/issues/13653\n\n## Summary\n\nAdds snapshot telemetry for **skills** and **plugins** to the Agent\nBuilder telemetry collector, complementing the existing EBT (Event-Based\nTelemetry) approach from #264380. The snapshot collector can be queried\nquickly via Kibana usage stats without needing to aggregate individual\nevents.\n\n### Architecture\n\n**Three layers added:**\n\n1. **Usage counters** (`usage_counters.ts`) — New `trackSkillInvocation`\nand `trackPluginImport` helpers that increment per-origin / per-source\ncounters. These are called from `TrackingService` alongside the existing\nEBT analytics events.\n\n2. **ES queries** (`query_utils.ts`) — New `getSkillsMetrics()` queries\nthe `.chat-skills` index with filter aggregations to break down\npersisted skills into `custom` (no `plugin_id`) vs `plugin` (has\n`plugin_id`). New `getPluginsCount()` counts docs in `.chat-plugins`.\n\n3. **Telemetry collector** (`telemetry_collector.ts`) — Extends the\n`AgentBuilderTelemetry` schema with four new sections:\n   - `skills` — `total`, `custom`, `plugin`\n   - `plugins` — `total`\n   - `skill_invocations` — `total` + `by_origin` (builtin/custom/plugin)\n   - `plugin_imports` — `total` + `by_source` (url/upload)\n\n### Snapshot telemetry fields\n\nAll fields added to the `AgentBuilderTelemetry` collector schema by this\nPR:\n\n| Field | Type | Source | Description |\n|---|---|---|---|\n| `skills.total` | `long` | ES query (`.chat-skills`, `hits.total`) |\nTotal number of persisted skills (custom + plugin-bundled) |\n| `skills.custom` | `long` | ES query (filter agg: no `plugin_id`) |\nNumber of user-created custom skills |\n| `skills.plugin` | `long` | ES query (filter agg: has `plugin_id`) |\nNumber of plugin-bundled skills |\n| `plugins.total` | `long` | ES query (`.chat-plugins`, `count`) | Total\nnumber of installed plugins |\n| `skill_invocations.total` | `long` | Usage counter (sum) | Total skill\ninvocations across all origins |\n| `skill_invocations.by_origin.builtin` | `long` | Usage counter | Skill\ninvocations from built-in skills |\n| `skill_invocations.by_origin.custom` | `long` | Usage counter | Skill\ninvocations from user-created skills |\n| `skill_invocations.by_origin.plugin` | `long` | Usage counter | Skill\ninvocations from plugin-bundled skills |\n| `plugin_imports.total` | `long` | Usage counter (sum) | Total plugin\nimports across all source types |\n| `plugin_imports.by_source.url` | `long` | Usage counter | Plugins\nimported via URL |\n| `plugin_imports.by_source.upload` | `long` | Usage counter | Plugins\nimported via file upload |\n\n**Usage counter names** (incremented at runtime, read back by the\ncollector):\n\n| Counter name | Incremented by |\n|---|---|\n| `agent_builder_skill_invocation_builtin` |\n`TrackingService.trackSkillInvocation('builtin')` |\n| `agent_builder_skill_invocation_custom` |\n`TrackingService.trackSkillInvocation('custom')` |\n| `agent_builder_skill_invocation_plugin` |\n`TrackingService.trackSkillInvocation('plugin')` |\n| `agent_builder_plugin_import_url` |\n`TrackingService.trackPluginImport('url')` |\n| `agent_builder_plugin_import_upload` |\n`TrackingService.trackPluginImport('upload')` |\n\n### How to test\n\n1. Start Kibana with Agent Builder enabled and a working connector.\n2. Create a custom skill and a plugin (import via URL or file upload).\n3. Invoke a skill in a conversation.\n4. Query the telemetry collector endpoint and verify the new `skills`,\n`plugins`, `skill_invocations`, and `plugin_imports` fields are\npopulated with correct counts.\n\n### Checklist\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\n- **Low risk — additional ES queries at telemetry collection time**:\n`getSkillsMetrics` and `getPluginsCount` add two extra ES calls during\nperiodic telemetry collection. Both are `size: 0` / `count` queries on\nsmall system indices, so impact is negligible. Errors are caught and\ndefault to zero.\n- **Low risk — usage counter overhead**: The new `trackSkillInvocation`\nand `trackPluginImport` counters are lightweight in-memory increments,\nconsistent with the existing counters pattern.\n\n### Release notes\n\nSkip — internal telemetry, no user-facing changes.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"1a8b73d86e09ae9379ab6b3f18e483e38299fff4"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/264694","number":264694,"mergeCommit":{"message":"[Agent Builder] Add snapshot telemetry to skills and plugins  (#264694)\n\nRelates to https://github.com/elastic/kibana/pull/264380\naddresses https://github.com/elastic/search-team/issues/13653\n\n## Summary\n\nAdds snapshot telemetry for **skills** and **plugins** to the Agent\nBuilder telemetry collector, complementing the existing EBT (Event-Based\nTelemetry) approach from #264380. The snapshot collector can be queried\nquickly via Kibana usage stats without needing to aggregate individual\nevents.\n\n### Architecture\n\n**Three layers added:**\n\n1. **Usage counters** (`usage_counters.ts`) — New `trackSkillInvocation`\nand `trackPluginImport` helpers that increment per-origin / per-source\ncounters. These are called from `TrackingService` alongside the existing\nEBT analytics events.\n\n2. **ES queries** (`query_utils.ts`) — New `getSkillsMetrics()` queries\nthe `.chat-skills` index with filter aggregations to break down\npersisted skills into `custom` (no `plugin_id`) vs `plugin` (has\n`plugin_id`). New `getPluginsCount()` counts docs in `.chat-plugins`.\n\n3. **Telemetry collector** (`telemetry_collector.ts`) — Extends the\n`AgentBuilderTelemetry` schema with four new sections:\n   - `skills` — `total`, `custom`, `plugin`\n   - `plugins` — `total`\n   - `skill_invocations` — `total` + `by_origin` (builtin/custom/plugin)\n   - `plugin_imports` — `total` + `by_source` (url/upload)\n\n### Snapshot telemetry fields\n\nAll fields added to the `AgentBuilderTelemetry` collector schema by this\nPR:\n\n| Field | Type | Source | Description |\n|---|---|---|---|\n| `skills.total` | `long` | ES query (`.chat-skills`, `hits.total`) |\nTotal number of persisted skills (custom + plugin-bundled) |\n| `skills.custom` | `long` | ES query (filter agg: no `plugin_id`) |\nNumber of user-created custom skills |\n| `skills.plugin` | `long` | ES query (filter agg: has `plugin_id`) |\nNumber of plugin-bundled skills |\n| `plugins.total` | `long` | ES query (`.chat-plugins`, `count`) | Total\nnumber of installed plugins |\n| `skill_invocations.total` | `long` | Usage counter (sum) | Total skill\ninvocations across all origins |\n| `skill_invocations.by_origin.builtin` | `long` | Usage counter | Skill\ninvocations from built-in skills |\n| `skill_invocations.by_origin.custom` | `long` | Usage counter | Skill\ninvocations from user-created skills |\n| `skill_invocations.by_origin.plugin` | `long` | Usage counter | Skill\ninvocations from plugin-bundled skills |\n| `plugin_imports.total` | `long` | Usage counter (sum) | Total plugin\nimports across all source types |\n| `plugin_imports.by_source.url` | `long` | Usage counter | Plugins\nimported via URL |\n| `plugin_imports.by_source.upload` | `long` | Usage counter | Plugins\nimported via file upload |\n\n**Usage counter names** (incremented at runtime, read back by the\ncollector):\n\n| Counter name | Incremented by |\n|---|---|\n| `agent_builder_skill_invocation_builtin` |\n`TrackingService.trackSkillInvocation('builtin')` |\n| `agent_builder_skill_invocation_custom` |\n`TrackingService.trackSkillInvocation('custom')` |\n| `agent_builder_skill_invocation_plugin` |\n`TrackingService.trackSkillInvocation('plugin')` |\n| `agent_builder_plugin_import_url` |\n`TrackingService.trackPluginImport('url')` |\n| `agent_builder_plugin_import_upload` |\n`TrackingService.trackPluginImport('upload')` |\n\n### How to test\n\n1. Start Kibana with Agent Builder enabled and a working connector.\n2. Create a custom skill and a plugin (import via URL or file upload).\n3. Invoke a skill in a conversation.\n4. Query the telemetry collector endpoint and verify the new `skills`,\n`plugins`, `skill_invocations`, and `plugin_imports` fields are\npopulated with correct counts.\n\n### Checklist\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\n- **Low risk — additional ES queries at telemetry collection time**:\n`getSkillsMetrics` and `getPluginsCount` add two extra ES calls during\nperiodic telemetry collection. Both are `size: 0` / `count` queries on\nsmall system indices, so impact is negligible. Errors are caught and\ndefault to zero.\n- **Low risk — usage counter overhead**: The new `trackSkillInvocation`\nand `trackPluginImport` counters are lightweight in-memory increments,\nconsistent with the existing counters pattern.\n\n### Release notes\n\nSkip — internal telemetry, no user-facing changes.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"1a8b73d86e09ae9379ab6b3f18e483e38299fff4"}}]}] BACKPORT-->