### PR TITLE
Update anomaly bands colors to use EUI theme and integrate elastic ch…

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/recent_anomalies/anomaly_bands.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/recent_anomalies/anomaly_bands.ts
@@ -27,7 +27,7 @@ export const useAnomalyBands: () => {
   const { euiTheme } = useEuiTheme();
 
   const bandDefinitions = [
-    { start: 0, end: 3, color: '#E5F6Fa' }, // TODO, this color needs to align with the usage in ML, ongoing discussion in this ticket: https://github.com/elastic/kibana/issues/217508. Issue to track this todo: https://github.com/elastic/security-team/issues/12810
+    { start: 0, end: 3, color: euiTheme.colors.severity.unknown }, // TODO, this color needs to align with the usage in ML, ongoing discussion in this ticket: https://github.com/elastic/kibana/issues/217508. Issue to track this todo: https://github.com/elastic/security-team/issues/12810
     { start: 3, end: 25, color: euiTheme.colors.severity.neutral },
     { start: 25, end: 50, color: euiTheme.colors.severity.warning },
     { start: 50, end: 75, color: euiTheme.colors.severity.risk },

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/recent_anomalies/anomaly_bands.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/recent_anomalies/anomaly_bands.ts
@@ -27,7 +27,7 @@ export const useAnomalyBands: () => {
   const { euiTheme } = useEuiTheme();
 
   const bandDefinitions = [
-    { start: 0, end: 3, color: euiTheme.colors.severity.unknown }, 
+    { start: 0, end: 3, color: euiTheme.colors.severity.unknown },
     { start: 3, end: 25, color: euiTheme.colors.severity.neutral },
     { start: 25, end: 50, color: euiTheme.colors.severity.warning },
     { start: 50, end: 75, color: euiTheme.colors.severity.risk },

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/recent_anomalies/anomaly_bands.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/recent_anomalies/anomaly_bands.ts
@@ -27,7 +27,7 @@ export const useAnomalyBands: () => {
   const { euiTheme } = useEuiTheme();
 
   const bandDefinitions = [
-    { start: 0, end: 3, color: euiTheme.colors.severity.unknown }, // TODO, this color needs to align with the usage in ML, ongoing discussion in this ticket: https://github.com/elastic/kibana/issues/217508. Issue to track this todo: https://github.com/elastic/security-team/issues/12810
+    { start: 0, end: 3, color: euiTheme.colors.severity.unknown }, 
     { start: 3, end: 25, color: euiTheme.colors.severity.neutral },
     { start: 25, end: 50, color: euiTheme.colors.severity.warning },
     { start: 50, end: 75, color: euiTheme.colors.severity.risk },

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/recent_anomalies/anomaly_heatmap.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/recent_anomalies/anomaly_heatmap.tsx
@@ -15,6 +15,7 @@ import {
   Settings,
 } from '@elastic/charts';
 import { EuiFlexGroup, EuiFlexItem, EuiLoadingChart, EuiCallOut } from '@elastic/eui';
+import { useElasticChartsTheme } from '@kbn/charts-theme';
 import { i18n } from '@kbn/i18n';
 import React from 'react';
 import { useIntervalForHeatmap } from './anomaly_heatmap_interval';
@@ -102,6 +103,7 @@ export const AnomalyHeatmap: React.FC<AnomalyHeatmapProps> = ({
   const timeFormatter = useTimeFormatter();
   const xDomain = useXDomainFromGlobalTime();
   const styling = getAnomalyChartStyling(compressed);
+  const baseTheme = useElasticChartsTheme();
 
   return (
     <EuiFlexItem
@@ -128,6 +130,7 @@ export const AnomalyHeatmap: React.FC<AnomalyHeatmapProps> = ({
       {!isLoading && !isError && (
         <Chart>
           <Settings
+            baseTheme={baseTheme}
             theme={{ heatmap: heatmapComponentStyle }}
             noResults={noResultsComponent ?? undefined}
             xDomain={xDomain}

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/recent_anomalies/recent_anomalies_chart.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/recent_anomalies/recent_anomalies_chart.tsx
@@ -16,6 +16,7 @@ import { EntityNameList } from './entity_name_list';
 import { AnomalyHeatmap } from './anomaly_heatmap';
 import { getAnomalyChartStyling } from './anomaly_chart_styling';
 import { useQueryInspector } from '../../../common/components/page/manage_query';
+import { RecentAnomaliesHeatmapNoResults } from './recent_anomalies_heatmap_no_results';
 
 const RECENT_ANOMALIES_QUERY_ID = 'recent-anomalies-query';
 const RECENT_ANOMALIES_CONTEXT_ID = 'RecentAnomalies-table';
@@ -125,6 +126,7 @@ export const RecentAnomaliesChart: React.FC<RecentAnomaliesChartProps> = ({
           isLoading={isLoading}
           isError={isError}
           compressed
+          noResultsComponent={<RecentAnomaliesHeatmapNoResults />}
         />
       </EuiFlexGroup>
     </>

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/recent_anomalies/recent_anomalies_heatmap_no_results.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/recent_anomalies/recent_anomalies_heatmap_no_results.tsx
@@ -23,7 +23,7 @@ export const RecentAnomaliesHeatmapNoResults: React.FC = () => {
                 defaultMessage="No anomaly results match your search criteria"
               />
             </h3>
-          </EuiTitle>   
+          </EuiTitle>
         </EuiText>
       </EuiFlexItem>
       <EuiFlexItem grow={false}>

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/recent_anomalies/recent_anomalies_heatmap_no_results.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/recent_anomalies/recent_anomalies_heatmap_no_results.tsx
@@ -23,13 +23,7 @@ export const RecentAnomaliesHeatmapNoResults: React.FC = () => {
                 defaultMessage="No anomaly results match your search criteria"
               />
             </h3>
-          </EuiTitle>
-          <p>
-            <FormattedMessage
-              id="xpack.securitySolution.entityAnalytics.recentAnomalies.noResultsDescription"
-              defaultMessage={`To get started, click "ML job settings" above to configure and run anomaly detection jobs within your environment.`}
-            />
-          </p>
+          </EuiTitle>   
         </EuiText>
       </EuiFlexItem>
       <EuiFlexItem grow={false}>

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/recent_anomalies/recent_anomalies_heatmap_no_results.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/recent_anomalies/recent_anomalies_heatmap_no_results.tsx
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiFlexGroup, EuiFlexItem, EuiImage, EuiText, EuiTitle } from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n-react';
+import { i18n } from '@kbn/i18n';
+import React from 'react';
+import illustration from '../../../common/images/illustration_product_no_results_magnifying_glass.svg';
+
+export const RecentAnomaliesHeatmapNoResults: React.FC = () => {
+  return (
+    <EuiFlexGroup css={{ maxWidth: '600px' }}>
+      <EuiFlexItem>
+        <EuiText size="s">
+          <EuiTitle>
+            <h3>
+              <FormattedMessage
+                id="xpack.securitySolution.entityAnalytics.recentAnomalies.noResultsTitle"
+                defaultMessage="No anomaly results match your search criteria"
+              />
+            </h3>
+          </EuiTitle>
+          <p>
+            <FormattedMessage
+              id="xpack.securitySolution.entityAnalytics.recentAnomalies.noResultsDescription"
+              defaultMessage={`To get started, click "ML job settings" above to configure and run anomaly detection jobs within your environment.`}
+            />
+          </p>
+        </EuiText>
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiImage
+          size="200px"
+          alt={i18n.translate(
+            'xpack.securitySolution.entityAnalytics.recentAnomalies.emptyState.illustrationAlt',
+            {
+              defaultMessage: 'No results',
+            }
+          )}
+          url={illustration}
+        />
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+};


### PR DESCRIPTION
### Summary

This PR allows Anomaly Detection viz to use EUI Dark theme 

- Changed the color for the first anomaly band to use `euiTheme.colors.severity.unknown` for better alignment with ML usage.
- Imported `useElasticChartsTheme` in the `anomaly_heatmap` component and applied it to the chart settings for consistent theming.
- Added a `noResultsComponent` to the `RecentAnomaliesChart` to handle cases where no data is available.

**Demo Screenshots:** 

<img width="3456" height="1888" alt="image" src="https://github.com/user-attachments/assets/f40b6a5e-aa2d-49ae-9406-401d612fa423" />

<img width="1471" height="956" alt="Screenshot 2026-04-22 at 20 51 26" src="https://github.com/user-attachments/assets/8c80e97d-a5f2-43a4-b0b0-0caa7ff0ec2f" />






<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->