### PR TITLE
[9.4] [Fleet] Utilize new `sections` and `section` in integration form (#263552)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/common/services/package_to_package_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/package_to_package_policy.ts
@@ -112,10 +112,6 @@ export const varsReducer = (
   configObject: PackagePolicyConfigRecord,
   registryVar: RegistryVarsEntry
 ): PackagePolicyConfigRecord => {
-  // section_header vars are decorative only and hold no value
-  if (registryVar.type === 'section_header') {
-    return configObject;
-  }
   const configEntry: PackagePolicyConfigRecordEntry = {
     value: !registryVar.default && registryVar.multi ? [] : registryVar.default,
   };

--- a/x-pack/platform/plugins/shared/fleet/common/types/models/epm.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/types/models/epm.ts
@@ -272,6 +272,7 @@ export enum RegistryPolicyTemplateKeys {
   dynamic_signal_types = 'dynamic_signal_types',
   var_groups = 'var_groups',
   deprecated = 'deprecated',
+  sections = 'sections',
 }
 interface BaseTemplate {
   [RegistryPolicyTemplateKeys.name]: string;
@@ -300,6 +301,7 @@ export interface RegistryPolicyInputOnlyTemplate extends BaseTemplate {
   [RegistryPolicyTemplateKeys.required_vars]?: RegistryRequiredVars;
   [RegistryPolicyTemplateKeys.vars]?: RegistryVarsEntry[];
   [RegistryPolicyTemplateKeys.var_groups]?: RegistryVarGroup[];
+  [RegistryPolicyTemplateKeys.sections]?: RegistrySection[];
   [RegistryPolicyTemplateKeys.dynamic_signal_types]?: boolean;
 }
 
@@ -325,6 +327,7 @@ export enum RegistryInputKeys {
   migrate_from = 'migrate_from',
   dynamic_signal_types = 'dynamic_signal_types',
   show_divider = 'show_divider',
+  sections = 'sections',
 }
 
 export type RegistryInputGroup = 'logs' | 'metrics';
@@ -350,6 +353,7 @@ export interface RegistryInput {
   [RegistryInputKeys.dynamic_signal_types]?: boolean;
   /** When false, suppresses the automatic horizontal divider rendered after the input-level config section. Defaults to true. */
   [RegistryInputKeys.show_divider]?: boolean;
+  [RegistryInputKeys.sections]?: RegistrySection[];
 }
 
 export enum RegistryStreamKeys {
@@ -365,6 +369,7 @@ export enum RegistryStreamKeys {
   var_groups = 'var_groups',
   deprecated = 'deprecated',
   migrate_from = 'migrate_from',
+  sections = 'sections',
 }
 
 export interface RegistryStream {
@@ -380,6 +385,7 @@ export interface RegistryStream {
   [RegistryStreamKeys.var_groups]?: RegistryVarGroup[];
   [RegistryStreamKeys.deprecated]?: DeprecationInfo;
   [RegistryStreamKeys.migrate_from]?: string;
+  [RegistryStreamKeys.sections]?: RegistrySection[];
 }
 
 export type RegistryStreamWithDataStream = RegistryStream & { data_stream: RegistryDataStream };
@@ -554,8 +560,13 @@ export type RegistryVarType =
   | 'string'
   | 'textarea'
   | 'duration'
-  | 'url'
-  | 'section_header';
+  | 'url';
+
+export interface RegistrySection {
+  name: string;
+  title: string;
+  description?: string;
+}
 export enum RegistryVarsEntryKeys {
   name = 'name',
   title = 'title',
@@ -574,6 +585,7 @@ export enum RegistryVarsEntryKeys {
   max_duration = 'max_duration',
   url_allowed_schemes = 'url_allowed_schemes',
   deprecated = 'deprecated',
+  section = 'section',
 }
 
 // EPR types this as `[]map[string]interface{}`
@@ -601,6 +613,7 @@ export interface RegistryVarsEntry {
   [RegistryVarsEntryKeys.max_duration]?: string;
   [RegistryVarsEntryKeys.url_allowed_schemes]?: string[];
   [RegistryVarsEntryKeys.deprecated]?: DeprecationInfo;
+  [RegistryVarsEntryKeys.section]?: string;
 }
 
 // Deprecated as part of the removing public references to saved object schemas

--- a/x-pack/platform/plugins/shared/fleet/common/types/models/package_spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/types/models/package_spec.ts
@@ -9,6 +9,7 @@ import type {
   DeprecationInfo,
   RegistryElasticsearch,
   RegistryPolicyTemplate,
+  RegistrySection,
   RegistryVarsEntry,
 } from './epm';
 
@@ -63,6 +64,7 @@ export interface PackageSpecManifest {
   policy_templates?: RegistryPolicyTemplate[];
   vars?: RegistryVarsEntry[];
   var_groups?: RegistryVarGroup[];
+  sections?: RegistrySection[];
   owner: { github?: string; type?: 'elastic' | 'partner' | 'community' };
   elasticsearch?: Pick<
     RegistryElasticsearch,

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_config.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_config.test.tsx
@@ -86,6 +86,106 @@ describe('PackagePolicyInputConfig', () => {
     expect(utils.queryByText('Deprecated Var')).not.toBeInTheDocument();
   });
 
+  it('should render section titles for vars with a matching section attribute', () => {
+    const renderer = createFleetTestRendererMock();
+    const mockOnChange = jest.fn();
+
+    const utils = renderer.render(
+      <PackagePolicyInputConfig
+        hasInputStreams={false}
+        inputValidationResults={{}}
+        packagePolicyInput={{
+          enabled: true,
+          type: 'input',
+          streams: [],
+        }}
+        updatePackagePolicyInput={mockOnChange}
+        packageInputVars={[
+          {
+            name: 'ungrouped_var',
+            title: 'Ungrouped Var',
+            type: 'text',
+            show_user: true,
+          },
+          {
+            name: 'auth_var',
+            title: 'Auth Var',
+            type: 'text',
+            show_user: true,
+            section: 'auth_section',
+          },
+        ]}
+        sections={[{ name: 'auth_section', title: 'Authentication', description: 'Auth settings' }]}
+      />
+    );
+
+    expect(utils.queryByText('Ungrouped Var')).toBeInTheDocument();
+    expect(utils.queryByText('Authentication')).toBeInTheDocument();
+    expect(utils.queryByText('Auth settings')).toBeInTheDocument();
+    expect(utils.queryByText('Auth Var')).toBeInTheDocument();
+  });
+
+  it('should render vars without a section attribute as ungrouped even when sections are defined', () => {
+    const renderer = createFleetTestRendererMock();
+    const mockOnChange = jest.fn();
+
+    const utils = renderer.render(
+      <PackagePolicyInputConfig
+        hasInputStreams={false}
+        inputValidationResults={{}}
+        packagePolicyInput={{
+          enabled: true,
+          type: 'input',
+          streams: [],
+        }}
+        updatePackagePolicyInput={mockOnChange}
+        packageInputVars={[
+          {
+            name: 'ungrouped_var',
+            title: 'Ungrouped Var',
+            type: 'text',
+            show_user: true,
+          },
+        ]}
+        sections={[{ name: 'auth_section', title: 'Authentication' }]}
+      />
+    );
+
+    expect(utils.queryByText('Ungrouped Var')).toBeInTheDocument();
+    // Section header should not render if no vars reference it
+    expect(utils.queryByText('Authentication')).not.toBeInTheDocument();
+  });
+
+  it('should not render section titles when no sections prop is provided', () => {
+    const renderer = createFleetTestRendererMock();
+    const mockOnChange = jest.fn();
+
+    const utils = renderer.render(
+      <PackagePolicyInputConfig
+        hasInputStreams={false}
+        inputValidationResults={{}}
+        packagePolicyInput={{
+          enabled: true,
+          type: 'input',
+          streams: [],
+        }}
+        updatePackagePolicyInput={mockOnChange}
+        packageInputVars={[
+          {
+            name: 'auth_var',
+            title: 'Auth Var',
+            type: 'text',
+            show_user: true,
+            section: 'auth_section',
+          },
+        ]}
+      />
+    );
+
+    expect(utils.queryByText('Auth Var')).toBeInTheDocument();
+    expect(utils.queryByText('Authentication')).not.toBeInTheDocument();
+  });
+
   it('should show deprecated vars on edit page (isEditPage=true)', () => {
     const renderer = createFleetTestRendererMock();
     const mockOnChange = jest.fn();

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_config.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_config.tsx
@@ -12,6 +12,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiText,
+  EuiTitle,
   EuiSpacer,
   EuiButtonEmpty,
   useIsWithinMinBreakpoint,
@@ -21,6 +22,7 @@ import {
 import type {
   NewPackagePolicyInput,
   NewPackagePolicyInputStream,
+  RegistrySection,
   RegistryVarGroup,
   RegistryVarsEntry,
 } from '../../../../../../types';
@@ -32,6 +34,59 @@ import { useAgentless } from '../../../single_page_layout/hooks/setup_technology
 
 import { PackagePolicyInputVarField } from './package_policy_input_var_field';
 import { VarGroupSelector } from './var_group_selector';
+
+const renderVarsWithSections = (
+  vars: RegistryVarsEntry[],
+  renderVarItem: (varDef: RegistryVarsEntry) => React.ReactNode,
+  sectionDefs?: RegistrySection[]
+): React.ReactNode => {
+  if (!sectionDefs?.length) {
+    return <>{vars.map((varDef) => renderVarItem(varDef))}</>;
+  }
+
+  const sectionSet = new Set(sectionDefs.map((s) => s.name));
+  const varsBySectionName = new Map<string, RegistryVarsEntry[]>();
+  const varsWithoutSection: RegistryVarsEntry[] = [];
+
+  for (const varDef of vars) {
+    const sectionName = varDef.section;
+    if (sectionName && sectionSet.has(sectionName)) {
+      if (!varsBySectionName.has(sectionName)) {
+        varsBySectionName.set(sectionName, []);
+      }
+      varsBySectionName.get(sectionName)!.push(varDef);
+    } else {
+      varsWithoutSection.push(varDef);
+    }
+  }
+
+  return (
+    <>
+      {varsWithoutSection.map((varDef) => renderVarItem(varDef))}
+      {sectionDefs.map((section) => {
+        const sectionVars = varsBySectionName.get(section.name);
+        if (!sectionVars?.length) return null;
+        return (
+          <EuiFlexItem key={section.name}>
+            <EuiFlexGroup direction="column" gutterSize="m">
+              <EuiFlexItem>
+                <EuiTitle size="xxs">
+                  <h4>{section.title}</h4>
+                </EuiTitle>
+                {section.description && (
+                  <EuiText size="s" color="subdued">
+                    <p>{section.description}</p>
+                  </EuiText>
+                )}
+              </EuiFlexItem>
+              {sectionVars.map((varDef) => renderVarItem(varDef))}
+            </EuiFlexGroup>
+          </EuiFlexItem>
+        );
+      })}
+    </>
+  );
+};
 
 export interface StreamAdvancedVarsConfig {
   vars: RegistryVarsEntry[];
@@ -53,6 +108,7 @@ export const PackagePolicyInputConfig: React.FunctionComponent<{
   onVarGroupSelectionChange?: (groupName: string, optionName: string) => void;
   showDescriptionColumn?: boolean;
   streamAdvancedVars?: StreamAdvancedVarsConfig;
+  sections?: RegistrySection[];
 }> = memo(
   ({
     hasInputStreams,
@@ -67,6 +123,7 @@ export const PackagePolicyInputConfig: React.FunctionComponent<{
     onVarGroupSelectionChange,
     showDescriptionColumn = true,
     streamAdvancedVars,
+    sections,
   }) => {
     // Showing advanced options toggle state
     const [isShowingAdvanced, setIsShowingAdvanced] = useState<boolean>(false);
@@ -198,36 +255,38 @@ export const PackagePolicyInputConfig: React.FunctionComponent<{
         ) : null}
         <EuiFlexItem>
           <EuiFlexGroup direction="column" gutterSize="m">
-            {preGroupRequiredVars.map((varDef) => {
-              const { name: varName, type: varType } = varDef;
-
-              const value = packagePolicyInput.vars?.[varName]?.value;
-              const frozen = packagePolicyInput.vars?.[varName]?.frozen;
-
-              return (
-                <EuiFlexItem key={varName}>
-                  <PackagePolicyInputVarField
-                    varDef={varDef}
-                    value={value}
-                    frozen={frozen}
-                    onChange={(newValue: any) => {
-                      updatePackagePolicyInput({
-                        vars: {
-                          ...packagePolicyInput.vars,
-                          [varName]: {
-                            type: varType,
-                            value: newValue,
+            {renderVarsWithSections(
+              preGroupRequiredVars,
+              (varDef) => {
+                const { name: varName, type: varType } = varDef;
+                const value = packagePolicyInput.vars?.[varName]?.value;
+                const frozen = packagePolicyInput.vars?.[varName]?.frozen;
+                return (
+                  <EuiFlexItem key={varName}>
+                    <PackagePolicyInputVarField
+                      varDef={varDef}
+                      value={value}
+                      frozen={frozen}
+                      onChange={(newValue: any) => {
+                        updatePackagePolicyInput({
+                          vars: {
+                            ...packagePolicyInput.vars,
+                            [varName]: {
+                              type: varType,
+                              value: newValue,
+                            },
                           },
-                        },
-                      });
-                    }}
-                    errors={inputValidationResults.vars?.[varName]}
-                    forceShowErrors={forceShowErrors}
-                    isEditPage={isEditPage}
-                  />
-                </EuiFlexItem>
-              );
-            })}
+                        });
+                      }}
+                      errors={inputValidationResults.vars?.[varName]}
+                      forceShowErrors={forceShowErrors}
+                      isEditPage={isEditPage}
+                    />
+                  </EuiFlexItem>
+                );
+              },
+              sections
+            )}
             {varGroups?.map((varGroup) => (
               <EuiFlexItem key={varGroup.name}>
                 <VarGroupSelector
@@ -238,36 +297,38 @@ export const PackagePolicyInputConfig: React.FunctionComponent<{
                 />
               </EuiFlexItem>
             ))}
-            {postGroupRequiredVars.map((varDef) => {
-              const { name: varName, type: varType } = varDef;
-
-              const value = packagePolicyInput.vars?.[varName]?.value;
-              const frozen = packagePolicyInput.vars?.[varName]?.frozen;
-
-              return (
-                <EuiFlexItem key={varName}>
-                  <PackagePolicyInputVarField
-                    varDef={varDef}
-                    value={value}
-                    frozen={frozen}
-                    onChange={(newValue: any) => {
-                      updatePackagePolicyInput({
-                        vars: {
-                          ...packagePolicyInput.vars,
-                          [varName]: {
-                            type: varType,
-                            value: newValue,
+            {renderVarsWithSections(
+              postGroupRequiredVars,
+              (varDef) => {
+                const { name: varName, type: varType } = varDef;
+                const value = packagePolicyInput.vars?.[varName]?.value;
+                const frozen = packagePolicyInput.vars?.[varName]?.frozen;
+                return (
+                  <EuiFlexItem key={varName}>
+                    <PackagePolicyInputVarField
+                      varDef={varDef}
+                      value={value}
+                      frozen={frozen}
+                      onChange={(newValue: any) => {
+                        updatePackagePolicyInput({
+                          vars: {
+                            ...packagePolicyInput.vars,
+                            [varName]: {
+                              type: varType,
+                              value: newValue,
+                            },
                           },
-                        },
-                      });
-                    }}
-                    errors={inputValidationResults.vars?.[varName]}
-                    forceShowErrors={forceShowErrors}
-                    isEditPage={isEditPage}
-                  />
-                </EuiFlexItem>
-              );
-            })}
+                        });
+                      }}
+                      errors={inputValidationResults.vars?.[varName]}
+                      forceShowErrors={forceShowErrors}
+                      isEditPage={isEditPage}
+                    />
+                  </EuiFlexItem>
+                );
+              },
+              sections
+            )}
             {allAdvancedVars.length ? (
               <Fragment>
                 <EuiFlexItem>

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_panel.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_panel.tsx
@@ -524,6 +524,7 @@ export const PackagePolicyInputPanel: React.FunctionComponent<{
               onVarGroupSelectionChange={handleInputVarGroupSelectionChange}
               showDescriptionColumn={!isSingleInputAndStreams}
               streamAdvancedVars={consolidatedStreamAdvancedVars}
+              sections={packageInput.sections}
             />
             {hasInputStreams &&
             !shouldConsolidateAdvancedSections &&

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_var_field.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_var_field.tsx
@@ -13,7 +13,6 @@ import {
   EuiSwitch,
   EuiFieldText,
   EuiText,
-  EuiTitle,
   EuiFieldPassword,
   EuiCodeBlock,
   EuiTextArea,
@@ -111,21 +110,6 @@ export const PackagePolicyInputVarField: React.FunctionComponent<InputFieldProps
     // Hide deprecated variables on new installations
     if (!isEditPage && !!varDef.deprecated) {
       return null;
-    }
-
-    if (type === 'section_header') {
-      return (
-        <>
-          <EuiTitle size="xxs">
-            <h4>{title || name}</h4>
-          </EuiTitle>
-          {description && (
-            <EuiText size="s" color="subdued">
-              <ReactMarkdown children={description} />
-            </EuiText>
-          )}
-        </>
-      );
     }
 
     if (name === DATASET_VAR_NAME && packageType === 'input') {

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/multi_page_layout/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/multi_page_layout/index.tsx
@@ -9,6 +9,7 @@ import { useRouteMatch } from 'react-router-dom';
 import { i18n } from '@kbn/i18n';
 
 import { splitPkgKey } from '../../../../../../../common/services';
+import { isOnlyAgentlessIntegration } from '../../../../../../../common/services/agentless_policy_helper';
 
 import {
   useGetPackageInfoByKeyQuery,
@@ -17,6 +18,11 @@ import {
 } from '../../../../hooks';
 
 import type { AddToPolicyParams, CreatePackagePolicyParams } from '../types';
+
+import {
+  useAgentless,
+  isAgentlessSetupDefault,
+} from '../single_page_layout/hooks/setup_technology';
 
 import { useGetAgentPolicyOrDefault } from './hooks';
 
@@ -63,6 +69,7 @@ export const CreatePackagePolicyMultiPage: CreatePackagePolicyParams = ({
   const [onSplash, setOnSplash] = useState(true);
   const [currentStep, setCurrentStep] = useState(0);
   const [isManaged, setIsManaged] = useState(true);
+  const { isAgentlessEnabled, isAgentlessDefault } = useAgentless();
   const { getHref } = useLink();
   const [enrolledAgentIds, setEnrolledAgentIds] = useState<string[]>([]);
   const toggleIsManaged = (newIsManaged: boolean) => {
@@ -84,6 +91,17 @@ export const CreatePackagePolicyMultiPage: CreatePackagePolicyParams = ({
   } = useGetAgentPolicyOrDefault(agentPolicyId);
 
   const packageInfo = useMemo(() => packageInfoData?.item, [packageInfoData]);
+
+  // Skip the splash for agentless-only or agentless-default integrations — the
+  // "Install Elastic Agent" first step is not applicable to those flows.
+  const isAgentlessByDefault = useMemo(
+    () =>
+      isAgentlessEnabled &&
+      !!packageInfo &&
+      (isOnlyAgentlessIntegration(packageInfo, integration) ||
+        isAgentlessSetupDefault(isAgentlessDefault, packageInfo, integration)),
+    [isAgentlessEnabled, isAgentlessDefault, packageInfo, integration]
+  );
 
   const integrationInfo = useMemo(() => {
     if (!integration) return;
@@ -107,7 +125,7 @@ export const CreatePackagePolicyMultiPage: CreatePackagePolicyParams = ({
     ...(prerelease ? { prerelease: 'true' } : {}),
   });
 
-  if (onSplash || !packageInfo) {
+  if ((onSplash && !isAgentlessByDefault) || !packageInfo) {
     return (
       <AddFirstIntegrationSplashScreen
         isLoading={isPackageInfoLoading || isLoadingInitialRequest || isAgentPolicyLoading}

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/services/is_advanced_var.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/services/is_advanced_var.ts
@@ -26,11 +26,6 @@ export const isAdvancedVar = (
   varGroups?: RegistryVarGroup[],
   varGroupSelections?: VarGroupSelection
 ): boolean => {
-  // section_header vars are decorative and always render with required vars, never under "Advanced options"
-  if (varDef.type === 'section_header') {
-    return false;
-  }
-
   // If var is in a selected var_group option, treat as non-advanced (override show_user: false)
   if (
     varGroups &&

--- a/x-pack/platform/plugins/shared/fleet/public/types/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/types/index.ts
@@ -102,6 +102,7 @@ export type {
   CategorySummaryList,
   PackageInfo,
   PackageMetadata,
+  RegistrySection,
   RegistryVarsEntry,
   RegistryInput,
   RegistryStream,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Fleet] Utilize new `sections` and `section` in integration form (#263552)](https://github.com/elastic/kibana/pull/263552)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Mason Herron","email":"46727170+Supplementing@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-04-17T20:13:56Z","message":"[Fleet] Utilize new `sections` and `section` in integration form (#263552)\n\n## Summary\n\nThis PR goes along with the changes in\nhttps://github.com/elastic/integrations/pull/17495 and\nhttps://github.com/elastic/package-spec/pull/1133 and allows Kibana to\nutilize and render `sections` and `section` attributes from a package\nmanifest which allows users to declare section headers with defined\norder, and then assign variables that belong under each header. Kibana\nwill then render the variables under the headers. The headers are\nrendered as EuiTitles.\n\nWe previously added `section_headers` in\nhttps://github.com/elastic/kibana/pull/262129, but those were deemed too\nflexible and mixed UI elements with vars, this makes UI elements and\nvars more distinct and helps keep layouts more intact when users move\nitems around.\n\nYou may wonder how this differs from the existing `var_groups`, those\nrely on a EuiSelect, which then renders fields based on the selected\noption, this allows users to group items that always render, regardless\nof selected options.\n\nIf no section is passed, fields will be rendered outside of the section\nin the order in which they are added to the manifest, in the same way\nthey work before this PR.\n\nNOTE: since this work is still underway, and there arent any\nintegrations using any section_headers yet, there is no risk in making\nthis change at this time. cc @jsoriano\n\n_Additional (small) change: Removed the 'add your first integration'\nsplash screen for agentless default/preferred integrations. It doesnt\nmake a ton of sense to recommend that the user install elastic agent\nwhen the integration is agentless preferred or default. We now check and\ndont render the splash screen if so_\n\n## Testing\n\nIn order to test, simply install this test integration and view the\nlayout\n\n[custom_okta-3.14.2.zip](https://github.com/user-attachments/files/26756006/custom_okta-3.14.2.zip)\n\n\n<img width=\"1708\" height=\"1203\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/2e223f75-d9ee-4d2d-b260-2a0cfa32299a\"\n/>\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Jaime Soriano Pastor <jaime.soriano@elastic.co>","sha":"934fead655127259b3eea067943cf19e2c3dd787","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Fleet","backport:version","v9.4.0","v9.5.0"],"title":"[Fleet] Utilize new `sections` and `section` in integration form","number":263552,"url":"https://github.com/elastic/kibana/pull/263552","mergeCommit":{"message":"[Fleet] Utilize new `sections` and `section` in integration form (#263552)\n\n## Summary\n\nThis PR goes along with the changes in\nhttps://github.com/elastic/integrations/pull/17495 and\nhttps://github.com/elastic/package-spec/pull/1133 and allows Kibana to\nutilize and render `sections` and `section` attributes from a package\nmanifest which allows users to declare section headers with defined\norder, and then assign variables that belong under each header. Kibana\nwill then render the variables under the headers. The headers are\nrendered as EuiTitles.\n\nWe previously added `section_headers` in\nhttps://github.com/elastic/kibana/pull/262129, but those were deemed too\nflexible and mixed UI elements with vars, this makes UI elements and\nvars more distinct and helps keep layouts more intact when users move\nitems around.\n\nYou may wonder how this differs from the existing `var_groups`, those\nrely on a EuiSelect, which then renders fields based on the selected\noption, this allows users to group items that always render, regardless\nof selected options.\n\nIf no section is passed, fields will be rendered outside of the section\nin the order in which they are added to the manifest, in the same way\nthey work before this PR.\n\nNOTE: since this work is still underway, and there arent any\nintegrations using any section_headers yet, there is no risk in making\nthis change at this time. cc @jsoriano\n\n_Additional (small) change: Removed the 'add your first integration'\nsplash screen for agentless default/preferred integrations. It doesnt\nmake a ton of sense to recommend that the user install elastic agent\nwhen the integration is agentless preferred or default. We now check and\ndont render the splash screen if so_\n\n## Testing\n\nIn order to test, simply install this test integration and view the\nlayout\n\n[custom_okta-3.14.2.zip](https://github.com/user-attachments/files/26756006/custom_okta-3.14.2.zip)\n\n\n<img width=\"1708\" height=\"1203\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/2e223f75-d9ee-4d2d-b260-2a0cfa32299a\"\n/>\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Jaime Soriano Pastor <jaime.soriano@elastic.co>","sha":"934fead655127259b3eea067943cf19e2c3dd787"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/263552","number":263552,"mergeCommit":{"message":"[Fleet] Utilize new `sections` and `section` in integration form (#263552)\n\n## Summary\n\nThis PR goes along with the changes in\nhttps://github.com/elastic/integrations/pull/17495 and\nhttps://github.com/elastic/package-spec/pull/1133 and allows Kibana to\nutilize and render `sections` and `section` attributes from a package\nmanifest which allows users to declare section headers with defined\norder, and then assign variables that belong under each header. Kibana\nwill then render the variables under the headers. The headers are\nrendered as EuiTitles.\n\nWe previously added `section_headers` in\nhttps://github.com/elastic/kibana/pull/262129, but those were deemed too\nflexible and mixed UI elements with vars, this makes UI elements and\nvars more distinct and helps keep layouts more intact when users move\nitems around.\n\nYou may wonder how this differs from the existing `var_groups`, those\nrely on a EuiSelect, which then renders fields based on the selected\noption, this allows users to group items that always render, regardless\nof selected options.\n\nIf no section is passed, fields will be rendered outside of the section\nin the order in which they are added to the manifest, in the same way\nthey work before this PR.\n\nNOTE: since this work is still underway, and there arent any\nintegrations using any section_headers yet, there is no risk in making\nthis change at this time. cc @jsoriano\n\n_Additional (small) change: Removed the 'add your first integration'\nsplash screen for agentless default/preferred integrations. It doesnt\nmake a ton of sense to recommend that the user install elastic agent\nwhen the integration is agentless preferred or default. We now check and\ndont render the splash screen if so_\n\n## Testing\n\nIn order to test, simply install this test integration and view the\nlayout\n\n[custom_okta-3.14.2.zip](https://github.com/user-attachments/files/26756006/custom_okta-3.14.2.zip)\n\n\n<img width=\"1708\" height=\"1203\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/2e223f75-d9ee-4d2d-b260-2a0cfa32299a\"\n/>\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Jaime Soriano Pastor <jaime.soriano@elastic.co>","sha":"934fead655127259b3eea067943cf19e2c3dd787"}}]}] BACKPORT-->