### PR TITLE
[EDR Workflows] Fix saved-query dropdown race in add_integration cypress test

### DIFF
--- a/x-pack/platform/plugins/shared/osquery/cypress/e2e/all/add_integration.cy.ts
+++ b/x-pack/platform/plugins/shared/osquery/cypress/e2e/all/add_integration.cy.ts
@@ -9,7 +9,9 @@ import { LIVE_QUERY_EDITOR } from '../../screens/live_query';
 import {
   ADD_PACK_HEADER_BUTTON,
   ADD_QUERY_BUTTON,
+  FLYOUT_SAVED_QUERY_SAVE_BUTTON,
   formFieldInputSelector,
+  SAVE_PACK_BUTTON,
   SAVED_QUERY_DROPDOWN_SELECT,
   TABLE_ROWS,
 } from '../../screens/packs';
@@ -18,6 +20,7 @@ import {
   cleanupAgentPolicy,
   cleanupSavedQuery,
   loadSavedQuery,
+  savedQueryFixture,
 } from '../../tasks/api_fixtures';
 import {
   createOldOsqueryPath,
@@ -201,9 +204,14 @@ describe('ALL - Add Integration', { tags: ['@ess', '@serverless'] }, () => {
       cy.getBySel(ADD_QUERY_BUTTON).click();
       cy.getBySel('globalLoadingIndicator').should('not.exist');
       cy.getBySel(LIVE_QUERY_EDITOR).should('exist');
-      cy.getBySel(SAVED_QUERY_DROPDOWN_SELECT).click().type('{downArrow}{enter}');
-      cy.contains(/^Save$/).click();
-      cy.contains(/^Save pack$/).click();
+      // `useSavedQueries` resolves independently of LIVE_QUERY_EDITOR; wait for
+      // the fixture option to render before selecting so {enter} can't no-op on
+      // a slow MKI fetch and leave the flyout open over `save-pack-button`.
+      cy.getBySel(SAVED_QUERY_DROPDOWN_SELECT).click();
+      cy.contains('[role="option"]', savedQueryFixture.id).click();
+      cy.getBySel(FLYOUT_SAVED_QUERY_SAVE_BUTTON).click();
+      cy.getBySel(FLYOUT_SAVED_QUERY_SAVE_BUTTON).should('not.exist');
+      cy.getBySel(SAVE_PACK_BUTTON).click();
       cy.contains(`Successfully created "${packName}" pack`).click();
       cy.visit('app/fleet/policies');
       closeFleetTourIfVisible();


### PR DESCRIPTION
## Summary

Fixes a long-standing race in the `should have integration and packs copied when upgrading integration` Cypress test in `add_integration.cy.ts`.

`useSavedQueries` (the saved-query dropdown's data source) is a separate React Query GET that resolves independently of `LIVE_QUERY_EDITOR`. On slower MKI runs `cy.getBySel(SAVED_QUERY_DROPDOWN_SELECT).click().type('{downArrow}{enter}')` could fire `{enter}` before any options had rendered, leaving the flyout's required fields (Query, ID) empty. The flyout then refused to close on Save and the still-visible flyout footer covered `save-pack-button` — exactly matching the failure error: *\"this element: \<button data-test-subj=\"save-pack-button\"\>...\</button\> is being covered by another element: \<span\>Save\</span\>\"*. Passes on ESS local because that GET is near-instant; fails on MKI because remote serverless ES is slower.

## Changes

- Open the saved-query dropdown, then deterministically select the known fixture option via `cy.contains('[role=\"option\"]', savedQueryFixture.id).click()` — implicitly waits for the GET to resolve.
- Replace brittle `cy.contains(/^Save$/)` / `/^Save pack$/` with the existing `query-flyout-save-button` and `save-pack-button` test subjects (matches the conventions already in `packs_create_edit.cy.ts`).
- Assert the flyout actually unmounts before clicking the pack-form Save — turns the prior cryptic \"covered by element\" symptom into a clear \"flyout still open\" failure if the form is ever invalid again.

MKI RUN - https://buildkite.com/elastic/kibana-serverless-security-solution-quality-gate-defend-workflows/builds/4586#_

Closes https://github.com/elastic/kibana/issues/255381