### PR TITLE
[1Feedback] Make getFeedbackQuestionsForApp async

### DIFF
--- a/src/platform/packages/shared/feedback-components/src/components/feedback_container.test.tsx
+++ b/src/platform/packages/shared/feedback-components/src/components/feedback_container.test.tsx
@@ -14,7 +14,7 @@ import userEvent from '@testing-library/user-event';
 import { FeedbackContainer } from './feedback_container';
 
 const mockProps = {
-  getQuestions: jest.fn().mockReturnValue([
+  getQuestions: jest.fn().mockResolvedValue([
     {
       id: 'experience',
       type: 'experience',
@@ -37,32 +37,37 @@ describe('FeedbackContainer', () => {
     jest.clearAllMocks();
   });
 
-  it('should render container', () => {
+  it('should render container', async () => {
     renderWithI18n(<FeedbackContainer {...mockProps} />);
 
-    expect(screen.getByTestId('feedbackContainer')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByTestId('feedbackContainer')).toBeInTheDocument();
+    });
   });
 
-  it('should render header, body, and footer', () => {
+  it('should render header, body, and footer', async () => {
     renderWithI18n(<FeedbackContainer {...mockProps} />);
 
-    expect(screen.getByTestId('feedbackHeader')).toBeInTheDocument();
-    expect(screen.getByTestId('feedbackBody')).toBeInTheDocument();
-    expect(screen.getByTestId('feedbackFooter')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByTestId('feedbackHeader')).toBeInTheDocument();
+      expect(screen.getByTestId('feedbackBody')).toBeInTheDocument();
+      expect(screen.getByTestId('feedbackFooter')).toBeInTheDocument();
+    });
   });
 
-  it('should disable send button when no data is entered', () => {
+  it('should disable send button when no data is entered', async () => {
     renderWithI18n(<FeedbackContainer {...mockProps} />);
 
-    const sendButton = screen.getByTestId('feedbackFooterSendFeedbackButton');
-
-    expect(sendButton).toBeDisabled();
+    await waitFor(() => {
+      const sendButton = screen.getByTestId('feedbackFooterSendFeedbackButton');
+      expect(sendButton).toBeDisabled();
+    });
   });
 
   it('should enable send button when CSAT score is selected', async () => {
     renderWithI18n(<FeedbackContainer {...mockProps} />);
 
-    const emailConsentCheckbox = screen.getByTestId('feedbackEmailConsentCheckbox');
+    const emailConsentCheckbox = await screen.findByTestId('feedbackEmailConsentCheckbox');
     await userEvent.click(emailConsentCheckbox);
 
     const csatButtons = screen.getAllByRole('button', { name: /^\d$/ });
@@ -77,7 +82,7 @@ describe('FeedbackContainer', () => {
   it('should submit feedback with correct data', async () => {
     renderWithI18n(<FeedbackContainer {...mockProps} />);
 
-    const emailConsentCheckbox = screen.getByTestId('feedbackEmailConsentCheckbox');
+    const emailConsentCheckbox = await screen.findByTestId('feedbackEmailConsentCheckbox');
     await userEvent.click(emailConsentCheckbox);
 
     const csatButtons = screen.getAllByRole('button', { name: /^\d$/ });
@@ -103,7 +108,7 @@ describe('FeedbackContainer', () => {
   it('should show success toast and hide container on successful submit', async () => {
     renderWithI18n(<FeedbackContainer {...mockProps} />);
 
-    const emailConsentCheckbox = screen.getByTestId('feedbackEmailConsentCheckbox');
+    const emailConsentCheckbox = await screen.findByTestId('feedbackEmailConsentCheckbox');
     await userEvent.click(emailConsentCheckbox);
 
     const csatButtons = screen.getAllByRole('button', { name: /^\d$/ });
@@ -129,7 +134,7 @@ describe('FeedbackContainer', () => {
   it('should block submission and show email error when email is invalid and email consent is checked', async () => {
     renderWithI18n(<FeedbackContainer {...mockProps} />);
 
-    const emailConsentCheckbox = screen.getByTestId('feedbackEmailConsentCheckbox');
+    const emailConsentCheckbox = await screen.findByTestId('feedbackEmailConsentCheckbox');
     expect(emailConsentCheckbox).toBeChecked();
 
     const csatButtons = screen.getAllByRole('button', { name: /^\d$/ });
@@ -154,7 +159,7 @@ describe('FeedbackContainer', () => {
   it('should enable send button when email is valid and email consent is checked', async () => {
     renderWithI18n(<FeedbackContainer {...mockProps} />);
 
-    const emailConsentCheckbox = screen.getByTestId('feedbackEmailConsentCheckbox');
+    const emailConsentCheckbox = await screen.findByTestId('feedbackEmailConsentCheckbox');
     expect(emailConsentCheckbox).toBeChecked();
 
     const csatButtons = screen.getAllByRole('button', { name: /^\d$/ });
@@ -174,7 +179,7 @@ describe('FeedbackContainer', () => {
     mockProps.getCurrentUserEmail.mockResolvedValue(undefined);
     renderWithI18n(<FeedbackContainer {...mockProps} />);
 
-    const emailConsentCheckbox = screen.getByTestId('feedbackEmailConsentCheckbox');
+    const emailConsentCheckbox = await screen.findByTestId('feedbackEmailConsentCheckbox');
     expect(emailConsentCheckbox).toBeChecked();
 
     const csatButtons = screen.getAllByRole('button', { name: /^\d$/ });
@@ -196,7 +201,7 @@ describe('FeedbackContainer', () => {
   it('should enable send button when email consent is unchecked', async () => {
     renderWithI18n(<FeedbackContainer {...mockProps} />);
 
-    const emailConsentCheckbox = screen.getByTestId('feedbackEmailConsentCheckbox');
+    const emailConsentCheckbox = await screen.findByTestId('feedbackEmailConsentCheckbox');
     expect(emailConsentCheckbox).toBeChecked();
 
     const csatButtons = screen.getAllByRole('button', { name: /^\d$/ });

--- a/src/platform/packages/shared/feedback-components/src/components/feedback_container.tsx
+++ b/src/platform/packages/shared/feedback-components/src/components/feedback_container.tsx
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { EuiFlexGroup, useEuiTheme } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
@@ -15,9 +15,10 @@ import type { FeedbackFormData, FeedbackRegistryEntry } from '../types';
 import { FeedbackHeader } from './header';
 import { FeedbackBody } from './body/feedback_body';
 import { FeedbackFooter } from './footer/feedback_footer';
+import { FeedbackContainerSkeleton } from './feedback_container_skeleton';
 
 interface Props {
-  getQuestions: (appId: string) => FeedbackRegistryEntry[];
+  getQuestions: (appId: string) => Promise<FeedbackRegistryEntry[]>;
   getAppDetails: () => { title: string; id: string; url: string };
   getCurrentUserEmail: () => Promise<string | undefined>;
   sendFeedback: (data: FeedbackFormData) => Promise<void>;
@@ -42,8 +43,46 @@ export const FeedbackContainer = ({
   const [isEmailValid, setIsEmailValid] = useState(true);
   const [forceShowEmailError, setForceShowEmailError] = useState(false);
 
+  const [questions, setQuestions] = useState<FeedbackRegistryEntry[]>([]);
+  const [isLoadingQuestions, setIsLoadingQuestions] = useState(true);
+
   const { title: appTitle, id: appId, url: appUrl } = getAppDetails();
-  const questions = getQuestions(appId);
+
+  const containerCss = css`
+    padding: ${euiTheme.size.l};
+    width: 576px;
+  `;
+
+  useEffect(() => {
+    const abortController = new AbortController();
+    setIsLoadingQuestions(true);
+    getQuestions(appId)
+      .then((q) => {
+        if (!abortController.signal.aborted) {
+          setQuestions(q);
+          setIsLoadingQuestions(false);
+        }
+      })
+      .catch(() => {
+        if (!abortController.signal.aborted) {
+          setIsLoadingQuestions(false);
+          hideFeedbackContainer();
+          showToast(
+            i18n.translate('feedback.loadQuestionsFailureToast.title', {
+              defaultMessage: 'Failed to load feedback form. Please try again later.',
+            }),
+            'error'
+          );
+        }
+      });
+    return () => {
+      abortController.abort();
+    };
+  }, [getQuestions, appId, hideFeedbackContainer, showToast]);
+
+  if (isLoadingQuestions) {
+    return <FeedbackContainerSkeleton />;
+  }
 
   const isFormFilled =
     selectedCsatOptionId ||
@@ -120,11 +159,6 @@ export const FeedbackContainer = ({
       setIsSubmitting(false);
     }
   };
-
-  const containerCss = css`
-    padding: ${euiTheme.size.l};
-    width: 576px;
-  `;
 
   return (
     <EuiFlexGroup

--- a/src/platform/packages/shared/feedback-components/src/components/feedback_container.tsx
+++ b/src/platform/packages/shared/feedback-components/src/components/feedback_container.tsx
@@ -16,6 +16,7 @@ import { FeedbackHeader } from './header';
 import { FeedbackBody } from './body/feedback_body';
 import { FeedbackFooter } from './footer/feedback_footer';
 import { FeedbackContainerSkeleton } from './feedback_container_skeleton';
+import { useQuestionsForApp } from '../hooks/use_questions_for_app';
 
 interface Props {
   getQuestions: (appId: string) => Promise<FeedbackRegistryEntry[]>;
@@ -43,10 +44,9 @@ export const FeedbackContainer = ({
   const [isEmailValid, setIsEmailValid] = useState(true);
   const [forceShowEmailError, setForceShowEmailError] = useState(false);
 
-  const [questions, setQuestions] = useState<FeedbackRegistryEntry[]>([]);
-  const [isLoadingQuestions, setIsLoadingQuestions] = useState(true);
-
   const { title: appTitle, id: appId, url: appUrl } = getAppDetails();
+
+  const { questions, isLoading, error } = useQuestionsForApp({ getQuestions, appId });
 
   const containerCss = css`
     padding: ${euiTheme.size.l};
@@ -54,33 +54,18 @@ export const FeedbackContainer = ({
   `;
 
   useEffect(() => {
-    const abortController = new AbortController();
-    setIsLoadingQuestions(true);
-    getQuestions(appId)
-      .then((q) => {
-        if (!abortController.signal.aborted) {
-          setQuestions(q);
-          setIsLoadingQuestions(false);
-        }
-      })
-      .catch(() => {
-        if (!abortController.signal.aborted) {
-          setIsLoadingQuestions(false);
-          hideFeedbackContainer();
-          showToast(
-            i18n.translate('feedback.loadQuestionsFailureToast.title', {
-              defaultMessage: 'Failed to load feedback form. Please try again later.',
-            }),
-            'error'
-          );
-        }
-      });
-    return () => {
-      abortController.abort();
-    };
-  }, [getQuestions, appId, hideFeedbackContainer, showToast]);
+    if (error) {
+      hideFeedbackContainer();
+      showToast(
+        i18n.translate('feedback.loadQuestionsFailureToast.title', {
+          defaultMessage: 'Failed to load feedback form. Please try again later.',
+        }),
+        'error'
+      );
+    }
+  }, [error, hideFeedbackContainer, showToast]);
 
-  if (isLoadingQuestions) {
+  if (isLoading || error) {
     return <FeedbackContainerSkeleton />;
   }
 

--- a/src/platform/packages/shared/feedback-components/src/components/feedback_container_skeleton.tsx
+++ b/src/platform/packages/shared/feedback-components/src/components/feedback_container_skeleton.tsx
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React from 'react';
+import React, { Fragment } from 'react';
 import {
   EuiFlexGroup,
   EuiFlexItem,
@@ -42,18 +42,16 @@ export const FeedbackContainerSkeleton = () => {
         <EuiSkeletonRectangle width="100%" height={52} borderRadius="s" />
       </EuiFlexItem>
       <EuiSpacer size="m" />
-      <EuiFlexItem grow={false}>
-        <EuiSkeletonText lines={1} />
-      </EuiFlexItem>
-      <EuiFlexItem grow={false}>
-        <EuiSkeletonRectangle width="100%" height={108} borderRadius="s" />
-      </EuiFlexItem>
-      <EuiFlexItem grow={false}>
-        <EuiSkeletonText lines={1} />
-      </EuiFlexItem>
-      <EuiFlexItem grow={false}>
-        <EuiSkeletonRectangle width="100%" height={108} borderRadius="s" />
-      </EuiFlexItem>
+      {Array.from({ length: 2 }, (_, i) => (
+        <Fragment key={i}>
+          <EuiFlexItem grow={false}>
+            <EuiSkeletonText lines={1} />
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiSkeletonRectangle width="100%" height={108} borderRadius="s" />
+          </EuiFlexItem>
+        </Fragment>
+      ))}
       <EuiSpacer size="l" />
       <EuiFlexItem grow={false}>
         <EuiSkeletonRectangle width="100%" height={72} borderRadius="s" />

--- a/src/platform/packages/shared/feedback-components/src/components/feedback_container_skeleton.tsx
+++ b/src/platform/packages/shared/feedback-components/src/components/feedback_container_skeleton.tsx
@@ -1,0 +1,72 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import {
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiSkeletonText,
+  EuiSkeletonRectangle,
+  EuiSkeletonTitle,
+  useEuiTheme,
+  EuiSpacer,
+} from '@elastic/eui';
+import { css } from '@emotion/react';
+
+export const FeedbackContainerSkeleton = () => {
+  const { euiTheme } = useEuiTheme();
+
+  const containerCss = css`
+    height: 720px;
+    padding: ${euiTheme.size.l};
+    width: 576px;
+  `;
+
+  return (
+    <EuiFlexGroup
+      direction="column"
+      gutterSize="s"
+      css={containerCss}
+      data-test-subj="feedbackContainerLoading"
+    >
+      <EuiFlexItem grow={false}>
+        <EuiSkeletonTitle size="l" />
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiSkeletonRectangle width="100%" height={52} borderRadius="s" />
+      </EuiFlexItem>
+      <EuiSpacer size="m" />
+      <EuiFlexItem grow={false}>
+        <EuiSkeletonText lines={1} />
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiSkeletonRectangle width="100%" height={108} borderRadius="s" />
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiSkeletonText lines={1} />
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiSkeletonRectangle width="100%" height={108} borderRadius="s" />
+      </EuiFlexItem>
+      <EuiSpacer size="l" />
+      <EuiFlexItem grow={false}>
+        <EuiSkeletonRectangle width="100%" height={72} borderRadius="s" />
+      </EuiFlexItem>
+      <EuiSpacer size="l" />
+      <EuiFlexItem grow={false}>
+        <EuiSkeletonRectangle width="100%" height={68} borderRadius="s" />
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiFlexGroup justifyContent="flexEnd">
+          <EuiSkeletonRectangle width={112} height={40} borderRadius="s" />
+        </EuiFlexGroup>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+};

--- a/src/platform/packages/shared/feedback-components/src/components/feedback_trigger_button.test.tsx
+++ b/src/platform/packages/shared/feedback-components/src/components/feedback_trigger_button.test.tsx
@@ -22,7 +22,7 @@ const createMockProps = ({
 }: {
   isTelemetryGlobalSettingEnabled: boolean;
 }) => ({
-  getQuestions: jest.fn().mockReturnValue([]),
+  getQuestions: jest.fn().mockResolvedValue([]),
   getAppDetails: jest
     .fn()
     .mockReturnValue({ title: 'Test App', id: 'testApp', url: 'http://testapp.com' }),

--- a/src/platform/packages/shared/feedback-components/src/components/feedback_trigger_button.tsx
+++ b/src/platform/packages/shared/feedback-components/src/components/feedback_trigger_button.tsx
@@ -18,7 +18,7 @@ const LazyFeedbackContainer = lazy(() =>
 );
 
 interface Props {
-  getQuestions: (appId: string) => FeedbackRegistryEntry[];
+  getQuestions: (appId: string) => Promise<FeedbackRegistryEntry[]>;
   getAppDetails: () => { title: string; id: string; url: string };
   getCurrentUserEmail: () => Promise<string | undefined>;
   sendFeedback: (data: FeedbackFormData) => Promise<void>;

--- a/src/platform/packages/shared/feedback-components/src/components/index.ts
+++ b/src/platform/packages/shared/feedback-components/src/components/index.ts
@@ -22,4 +22,5 @@ export { FeedbackBody } from './body';
 export { SendFeedbackButton } from './footer';
 export { FeedbackFooter } from './footer';
 
+export { FeedbackContainerSkeleton } from './feedback_container_skeleton';
 export { FeedbackContainer } from './feedback_container';

--- a/src/platform/packages/shared/feedback-components/src/hooks/index.ts
+++ b/src/platform/packages/shared/feedback-components/src/hooks/index.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export { useQuestionsForApp } from './use_questions_for_app';

--- a/src/platform/packages/shared/feedback-components/src/hooks/use_questions_for_app.ts
+++ b/src/platform/packages/shared/feedback-components/src/hooks/use_questions_for_app.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { useEffect, useState } from 'react';
+import type { FeedbackRegistryEntry } from '../types';
+
+interface UseQuestionsForAppArgs {
+  getQuestions: (appId: string) => Promise<FeedbackRegistryEntry[]>;
+  appId: string;
+}
+
+interface UseQuestionsForAppResult {
+  questions: FeedbackRegistryEntry[];
+  isLoading: boolean;
+  error: Error | undefined;
+}
+
+export const useQuestionsForApp = ({
+  getQuestions,
+  appId,
+}: UseQuestionsForAppArgs): UseQuestionsForAppResult => {
+  const [questions, setQuestions] = useState<FeedbackRegistryEntry[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | undefined>();
+
+  useEffect(() => {
+    const abortController = new AbortController();
+    setIsLoading(true);
+    setError(undefined);
+    getQuestions(appId)
+      .then((q) => {
+        if (!abortController.signal.aborted) {
+          setQuestions(q);
+          setIsLoading(false);
+        }
+      })
+      .catch((err) => {
+        if (!abortController.signal.aborted) {
+          setError(err);
+          setIsLoading(false);
+        }
+      });
+    return () => {
+      abortController.abort();
+    };
+  }, [getQuestions, appId]);
+
+  return { questions, isLoading, error };
+};

--- a/x-pack/platform/packages/private/feedback-registry/src/questions/default.ts
+++ b/x-pack/platform/packages/private/feedback-registry/src/questions/default.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FeedbackRegistryEntry } from '@kbn/feedback-components';
+import { DEFAULT_EXPERIENCE_QUESTION_ID, DEFAULT_GENERAL_QUESTION_ID } from '../constants';
+
+export const questions: FeedbackRegistryEntry[] = [
+  {
+    id: DEFAULT_EXPERIENCE_QUESTION_ID,
+    order: 1,
+    placeholder: {
+      i18nId: 'xpack.feedbackRegistry.defaultExperiencePlaceholder',
+      defaultMessage: 'Describe your experience',
+    },
+    ariaLabel: {
+      i18nId: 'xpack.feedbackRegistry.defaultExperienceAriaLabel',
+      defaultMessage: 'Describe your experience',
+    },
+    question: 'Describe your experience',
+  },
+  {
+    id: DEFAULT_GENERAL_QUESTION_ID,
+    order: 2,
+    placeholder: {
+      i18nId: 'xpack.feedbackRegistry.defaultGeneralPlaceholder',
+      defaultMessage: 'Add more thoughts',
+    },
+    label: {
+      i18nId: 'xpack.feedbackRegistry.defaultGeneralLabel',
+      defaultMessage: 'Anything else you would like to share about Elastic overall?',
+    },
+    ariaLabel: {
+      i18nId: 'xpack.feedbackRegistry.defaultGeneralAriaLabel',
+      defaultMessage: 'Additional feedback about Elastic',
+    },
+    question: 'Anything else you would like to share about Elastic overall?',
+  },
+];

--- a/x-pack/platform/packages/private/feedback-registry/src/registry.ts
+++ b/x-pack/platform/packages/private/feedback-registry/src/registry.ts
@@ -6,55 +6,20 @@
  */
 
 import type { FeedbackRegistryEntry } from '@kbn/feedback-components';
-import {
-  DEFAULT_EXPERIENCE_QUESTION_ID,
-  DEFAULT_GENERAL_QUESTION_ID,
-  DEFAULT_REGISTRY_ID,
-} from './constants';
+import { DEFAULT_REGISTRY_ID } from './constants';
 import type { FeedbackRegistry } from './types';
 
 const feedbackRegistry: FeedbackRegistry = new Map([
-  [
-    DEFAULT_REGISTRY_ID,
-    [
-      {
-        id: DEFAULT_EXPERIENCE_QUESTION_ID,
-        order: 1,
-        placeholder: {
-          i18nId: 'xpack.feedbackRegistry.defaultExperiencePlaceholder',
-          defaultMessage: 'Describe your experience',
-        },
-        ariaLabel: {
-          i18nId: 'xpack.feedbackRegistry.defaultExperienceAriaLabel',
-          defaultMessage: 'Describe your experience',
-        },
-        question: 'Describe your experience',
-      },
-      {
-        id: DEFAULT_GENERAL_QUESTION_ID,
-        order: 2,
-        placeholder: {
-          i18nId: 'xpack.feedbackRegistry.defaultGeneralPlaceholder',
-          defaultMessage: 'Add more thoughts',
-        },
-        label: {
-          i18nId: 'xpack.feedbackRegistry.defaultGeneralLabel',
-          defaultMessage: 'Anything else you would like to share about Elastic overall?',
-        },
-        ariaLabel: {
-          i18nId: 'xpack.feedbackRegistry.defaultGeneralAriaLabel',
-          defaultMessage: 'Additional feedback about Elastic',
-        },
-        question: 'Anything else you would like to share about Elastic overall?',
-      },
-    ],
-  ],
+  [DEFAULT_REGISTRY_ID, () => import('./questions/default').then((m) => m.questions)],
 ]);
 
-export const getFeedbackQuestionsForApp = (appId?: string): FeedbackRegistryEntry[] => {
-  if (appId && feedbackRegistry.has(appId)) {
-    return feedbackRegistry.get(appId)?.sort((a, b) => a.order - b.order) || [];
-  }
-
-  return feedbackRegistry.get(DEFAULT_REGISTRY_ID)?.sort((a, b) => a.order - b.order) || [];
+export const getFeedbackQuestionsForApp = async (
+  appId?: string
+): Promise<FeedbackRegistryEntry[]> => {
+  const loader =
+    appId && feedbackRegistry.has(appId)
+      ? feedbackRegistry.get(appId)!
+      : feedbackRegistry.get(DEFAULT_REGISTRY_ID)!;
+  const questions = await loader();
+  return questions.sort((a, b) => a.order - b.order);
 };

--- a/x-pack/platform/packages/private/feedback-registry/src/types.ts
+++ b/x-pack/platform/packages/private/feedback-registry/src/types.ts
@@ -15,5 +15,7 @@ export type FeedbackRegistryEntryId = string;
 
 /**
  * List of feedback plugin questions for a given application.
+ * Each entry is a lazy loader that returns the questions for a specific app,
+ * ensuring only the relevant questions are loaded at runtime.
  */
-export type FeedbackRegistry = Map<FeedbackRegistryEntryId, FeedbackRegistryEntry[]>;
+export type FeedbackRegistry = Map<FeedbackRegistryEntryId, () => Promise<FeedbackRegistryEntry[]>>;

--- a/x-pack/platform/plugins/private/feedback/feedback.mdx
+++ b/x-pack/platform/plugins/private/feedback/feedback.mdx
@@ -27,18 +27,44 @@ Feedback, along with other session data, is sent using the server-side EBT `feed
 
 ## Defining application specific questions
 
-To define application-specific questions, add them to the `@kbn/feedback-registry` package.
+To define application-specific questions, add them to the `@kbn/feedback-registry` package. Each application's questions live in a separate file under `questions/`, and the registry lazily loads only the relevant set at runtime.
 
-1. Go to: `x-pack/platform/packages/private/feedback-registry/src/registry.ts`
-2. Define up to two questions.
+1. Create a new file for your application's questions at `x-pack/platform/packages/private/feedback-registry/src/questions/<your_app>.ts`. Define up to two questions:
 
 ```ts
-/**
- * The id of the application associated with this feedback entry, e.g. 'dashboard', 'discover'
- * or in case of deep links, the deep link id e.g. 'ml:dataVisualizer'.
- */
-type FeedbackRegistryEntryId = string;
+import type { FeedbackRegistryEntry } from '@kbn/feedback-components';
 
+export const questions: FeedbackRegistryEntry[] = [
+  {
+    id: 'my_app_experience',
+    order: 1,
+    placeholder: {
+      i18nId: 'xpack.feedbackRegistry.myAppExperiencePlaceholder',
+      defaultMessage: 'Describe your experience',
+    },
+    ariaLabel: {
+      i18nId: 'xpack.feedbackRegistry.myAppExperienceAriaLabel',
+      defaultMessage: 'Describe your experience',
+    },
+    question: 'Describe your experience',
+  },
+];
+```
+
+2. Register a lazy loader for your app in `x-pack/platform/packages/private/feedback-registry/src/registry.ts` by adding an entry to the `feedbackRegistry` map:
+
+```ts
+const feedbackRegistry: FeedbackRegistry = new Map([
+  [DEFAULT_REGISTRY_ID, () => import('./questions/default').then((m) => m.questions)],
+  ['myApp', () => import('./questions/my_app').then((m) => m.questions)],
+]);
+```
+
+This ensures that only your app's questions are loaded when the feedback form is opened, keeping the feedback plugin's bundle size constant regardless of how many apps register questions.
+
+The `FeedbackRegistryEntry` interface is defined as follows:
+
+```ts
 /**
  * Definition of a feedback question entry in the feedback registry.
  */
@@ -77,8 +103,6 @@ interface FeedbackRegistryEntry {
     defaultMessage: string;
   };
 }
-
-type FeedbackRegistry = Map<FeedbackRegistryEntryId, FeedbackRegistryEntry[]>;
 ```
 
 3. If you're unsure of your application ID:

--- a/x-pack/platform/plugins/private/feedback/public/plugin.tsx
+++ b/x-pack/platform/plugins/private/feedback/public/plugin.tsx
@@ -10,7 +10,6 @@ import type { CoreSetup, CoreStart, Plugin } from '@kbn/core/public';
 import type { CloudSetup, CloudStart } from '@kbn/cloud-plugin/public';
 import type { TelemetryPluginStart } from '@kbn/telemetry-plugin/public';
 import type { SpacesPluginStart } from '@kbn/spaces-plugin/public';
-import { getFeedbackQuestionsForApp } from '@kbn/feedback-registry';
 import type { FeedbackRegistryEntry } from '@kbn/feedback-components';
 import type { FeedbackFormData } from '../common';
 import { getAppDetails } from './src/utils';
@@ -61,8 +60,10 @@ export class FeedbackPlugin implements Plugin {
 
     const getAppDetailsWrapper = () => getAppDetails(core);
 
-    const getQuestions = (appId: string): FeedbackRegistryEntry[] =>
-      getFeedbackQuestionsForApp(appId);
+    const getQuestions = async (appId: string): Promise<FeedbackRegistryEntry[]> => {
+      const { getFeedbackQuestionsForApp } = await import('@kbn/feedback-registry');
+      return getFeedbackQuestionsForApp(appId);
+    };
 
     const getCurrentUserEmail = async (): Promise<string | undefined> => {
       if (!core.security) return undefined;


### PR DESCRIPTION
## Summary

This PR introduces an improvement to the way we load feedback questions. Instead of loading all questions at once, we only load relevant questions. 

This is in response to https://github.com/elastic/kibana/pull/265015 increasing feedback bundle size by almost double.

### Visuals

- Feedback form loading skeleton:
<img width="733" height="815" alt="Screenshot 2026-04-23 at 00 38 07" src="https://github.com/user-attachments/assets/ce9cc2d0-c3c4-458b-939a-83db4fa22f4c" />
