### PR TITLE
[8.19] [Security Solution] Fix flaky bulk edit alert suppression Cypress test (#261164)

### DIFF
--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/create_new_rule.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/create_new_rule.ts
@@ -937,7 +937,13 @@ export const fillAlertSuppressionFields = (fields: string[]) => {
   cy.get(ALERT_SUPPRESSION_FIELDS_COMBO_BOX).should('not.be.disabled');
   cy.get(ALERT_SUPPRESSION_FIELDS_COMBO_BOX).click();
   fields.forEach((field) => {
-    cy.get(ALERT_SUPPRESSION_FIELDS_COMBO_BOX).type(`${field}{downArrow}{enter}{esc}`);
+    cy.get(ALERT_SUPPRESSION_FIELDS_COMBO_BOX).type(`${field}{downArrow}{enter}`);
+    // Wait for the field to be selected as a pill before closing the dropdown,
+    // otherwise {esc} can race with {enter} and cancel the selection
+    cy.get(ALERT_SUPPRESSION_FIELDS_COMBO_BOX)
+      .find('[data-test-subj="euiComboBoxPill"]')
+      .should('contain.text', field);
+    cy.get(ALERT_SUPPRESSION_FIELDS_COMBO_BOX).type('{esc}');
   });
 };
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Security Solution] Fix flaky bulk edit alert suppression Cypress test (#261164)](https://github.com/elastic/kibana/pull/261164)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Maxim Palenov","email":"maxim.palenov@elastic.co"},"sourceCommit":{"committedDate":"2026-04-10T09:50:05Z","message":"[Security Solution] Fix flaky bulk edit alert suppression Cypress test (#261164)\n\n## Summary\n\nFixes flaky `bulk_edit_rules_suppression.cy.ts` — specifically the \"Set\nalert suppression\" and \"Overwrites existing alert suppression\" test.\n\nThe `fillAlertSuppressionFields` helper fired `{enter}{esc}` in a single\nCypress `type()` call. The `{esc}` could race ahead of the combo box\nprocessing the `{enter}` selection, effectively canceling it. This left\nthe field as typed text rather than a confirmed pill, causing a\nvalidation error (\"A minimum of one suppression field is required\") that\nprevented form submission — the test then timed out waiting for the\nprogress indicator that never appeared.\n\n**Fix:** Split into two `type()` calls with an assertion in between that\nwaits for the combo box pill to appear before closing the dropdown.\n\n### Failing Buildkite builds\n\n-\nhttps://buildkite.com/elastic/security-serverless-quality-gate-kibana-periodic/builds/3559?sid=019d2b95-6f36-4d03-8ff2-d54d232c7f8d\n-\nhttps://buildkite.com/elastic/security-serverless-quality-gate-kibana-periodic/builds/3564?sid=019d30b3-9a59-432a-92cf-e540c0710f81\n-\nhttps://buildkite.com/elastic/security-serverless-quality-gate-kibana-periodic/builds/3567?sid=019d3486-7d24-4373-baa8-8d080484bff7\n-\nhttps://buildkite.com/elastic/security-serverless-quality-gate-kibana-periodic/builds/3573?sid=019d3c40-d310-4b50-ba5e-98c6753ac7b7\n\n## Flaky test runner\n\n- 🟢 [100\nruns](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/11408)\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"1ff26e6698f0f72b5cab23387b9708fb40c75ade","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["test","release_note:skip","backport missing","Team:Detections and Resp","Team: SecuritySolution","Feature:Rule Management","Team:Detection Rule Management","backport:version","v9.4.0","v9.3.3","v9.2.8","v8.19.14","v9.3.4"],"title":"[Security Solution] Fix flaky bulk edit alert suppression Cypress test","number":261164,"url":"https://github.com/elastic/kibana/pull/261164","mergeCommit":{"message":"[Security Solution] Fix flaky bulk edit alert suppression Cypress test (#261164)\n\n## Summary\n\nFixes flaky `bulk_edit_rules_suppression.cy.ts` — specifically the \"Set\nalert suppression\" and \"Overwrites existing alert suppression\" test.\n\nThe `fillAlertSuppressionFields` helper fired `{enter}{esc}` in a single\nCypress `type()` call. The `{esc}` could race ahead of the combo box\nprocessing the `{enter}` selection, effectively canceling it. This left\nthe field as typed text rather than a confirmed pill, causing a\nvalidation error (\"A minimum of one suppression field is required\") that\nprevented form submission — the test then timed out waiting for the\nprogress indicator that never appeared.\n\n**Fix:** Split into two `type()` calls with an assertion in between that\nwaits for the combo box pill to appear before closing the dropdown.\n\n### Failing Buildkite builds\n\n-\nhttps://buildkite.com/elastic/security-serverless-quality-gate-kibana-periodic/builds/3559?sid=019d2b95-6f36-4d03-8ff2-d54d232c7f8d\n-\nhttps://buildkite.com/elastic/security-serverless-quality-gate-kibana-periodic/builds/3564?sid=019d30b3-9a59-432a-92cf-e540c0710f81\n-\nhttps://buildkite.com/elastic/security-serverless-quality-gate-kibana-periodic/builds/3567?sid=019d3486-7d24-4373-baa8-8d080484bff7\n-\nhttps://buildkite.com/elastic/security-serverless-quality-gate-kibana-periodic/builds/3573?sid=019d3c40-d310-4b50-ba5e-98c6753ac7b7\n\n## Flaky test runner\n\n- 🟢 [100\nruns](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/11408)\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"1ff26e6698f0f72b5cab23387b9708fb40c75ade"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/261164","number":261164,"mergeCommit":{"message":"[Security Solution] Fix flaky bulk edit alert suppression Cypress test (#261164)\n\n## Summary\n\nFixes flaky `bulk_edit_rules_suppression.cy.ts` — specifically the \"Set\nalert suppression\" and \"Overwrites existing alert suppression\" test.\n\nThe `fillAlertSuppressionFields` helper fired `{enter}{esc}` in a single\nCypress `type()` call. The `{esc}` could race ahead of the combo box\nprocessing the `{enter}` selection, effectively canceling it. This left\nthe field as typed text rather than a confirmed pill, causing a\nvalidation error (\"A minimum of one suppression field is required\") that\nprevented form submission — the test then timed out waiting for the\nprogress indicator that never appeared.\n\n**Fix:** Split into two `type()` calls with an assertion in between that\nwaits for the combo box pill to appear before closing the dropdown.\n\n### Failing Buildkite builds\n\n-\nhttps://buildkite.com/elastic/security-serverless-quality-gate-kibana-periodic/builds/3559?sid=019d2b95-6f36-4d03-8ff2-d54d232c7f8d\n-\nhttps://buildkite.com/elastic/security-serverless-quality-gate-kibana-periodic/builds/3564?sid=019d30b3-9a59-432a-92cf-e540c0710f81\n-\nhttps://buildkite.com/elastic/security-serverless-quality-gate-kibana-periodic/builds/3567?sid=019d3486-7d24-4373-baa8-8d080484bff7\n-\nhttps://buildkite.com/elastic/security-serverless-quality-gate-kibana-periodic/builds/3573?sid=019d3c40-d310-4b50-ba5e-98c6753ac7b7\n\n## Flaky test runner\n\n- 🟢 [100\nruns](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/11408)\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"1ff26e6698f0f72b5cab23387b9708fb40c75ade"}},{"branch":"9.3","label":"v9.3.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/262472","number":262472,"state":"MERGED","mergeCommit":{"sha":"1f5e24d5f38ad4ab1a4fdb993250898c25337098","message":"[9.3] [Security Solution] Fix flaky bulk edit alert suppression Cypress test (#261164) (#262472)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.3`:\n- [[Security Solution] Fix flaky bulk edit alert suppression Cypress\ntest (#261164)](https://github.com/elastic/kibana/pull/261164)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Maxim Palenov <maxim.palenov@elastic.co>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>"}},{"branch":"9.2","label":"v9.2.8","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/262471","number":262471,"state":"OPEN"},{"branch":"8.19","label":"v8.19.14","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->