### PR TITLE
[build] Apply patches

### DIFF
--- a/src/dev/build/tasks/install_dependencies_task.ts
+++ b/src/dev/build/tasks/install_dependencies_task.ts
@@ -11,6 +11,7 @@ import type { Task } from '../lib';
 import { exec } from '../lib';
 
 const YARN_EXEC = process.env.npm_execpath || 'yarn';
+const NODE_EXEC = process.execPath || 'node';
 
 export const InstallDependencies: Task = {
   description: 'Installing node_modules, including production builds of packages',
@@ -38,7 +39,7 @@ export const InstallDependencies: Task = {
 
     await exec(
       log,
-      'node',
+      NODE_EXEC,
       [
         config.resolveFromRepo('node_modules/.bin/patch-package'),
         '--error-on-fail',

--- a/src/dev/build/tasks/install_dependencies_task.ts
+++ b/src/dev/build/tasks/install_dependencies_task.ts
@@ -35,5 +35,19 @@ export const InstallDependencies: Task = {
         cwd: build.resolvePath(),
       }
     );
+
+    await exec(
+      log,
+      'node',
+      [
+        config.resolveFromRepo('node_modules/.bin/patch-package'),
+        '--error-on-fail',
+        '--patch-dir',
+        config.resolveFromRepo('patches'),
+      ],
+      {
+        cwd: build.resolvePath(),
+      }
+    );
   },
 };

--- a/src/dev/build/tasks/install_dependencies_task.ts
+++ b/src/dev/build/tasks/install_dependencies_task.ts
@@ -7,6 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { relative } from 'path';
+
 import type { Task } from '../lib';
 import { exec } from '../lib';
 
@@ -44,7 +46,7 @@ export const InstallDependencies: Task = {
         config.resolveFromRepo('node_modules/.bin/patch-package'),
         '--error-on-fail',
         '--patch-dir',
-        config.resolveFromRepo('patches'),
+        relative(build.resolvePath(), config.resolveFromRepo('patches')),
       ],
       {
         cwd: build.resolvePath(),


### PR DESCRIPTION
Follow up to https://github.com/elastic/kibana/pull/263121, which also needs to run on the build.

https://buildkite.com/elastic/kibana-artifacts-snapshot/builds/8279

```
jon@mbp % tar xzf kibana-9.4.0-SNAPSHOT-linux-x86_64.tar.gz --to-stdout kibana-9.4.0-SNAPSHOT/node_modules/zod/v4/classic/schemas.cjs | head -160 | tail -35
const checks = __importStar(require("./checks.cjs"));
const iso = __importStar(require("./iso.cjs"));
const parse = __importStar(require("./parse.cjs"));
// Maps (internalProto, key) pairs already initialized — avoids repeated prototype setup
const _protoInitMap = new WeakMap();
/**
 * Sets shared methods on the *internal* prototype layer of inst's concrete constructor
 * (once per concrete type per key). The internal prototype sits one level below the
 * user-visible `_.prototype`, keeping `Object.keys(_.prototype)` empty by default
 * and preventing V8 dictionary-mode degradation.
 *
 * Falls back to `Object.getPrototypeOf(inst)` for constructors not created with
 * `$constructor` (e.g., in tests or third-party code).
 */
function _initProto(inst, key, methods, defineProps) {
    const proto = inst._zod?.constr?.[core.$internalProto] ?? Object.getPrototypeOf(inst);
```