### PR TITLE
Add ESLint rule to warn when EuiLink has onClick without href

### DIFF
--- a/packages/kbn-eslint-config/.eslintrc.js
+++ b/packages/kbn-eslint-config/.eslintrc.js
@@ -368,6 +368,7 @@ module.exports = {
     '@kbn/eslint/no_this_in_property_initializers': 'error',
     '@kbn/eslint/no_unsafe_console': 'error',
     '@kbn/eslint/no_unsafe_hash': 'error',
+    '@kbn/eslint/eui_link_href_with_onclick': 'warn',
     '@kbn/imports/no_unresolvable_imports': 'error',
     '@kbn/imports/uniform_imports': 'error',
     '@kbn/imports/no_unused_imports': 'error',

--- a/packages/kbn-eslint-plugin-eslint/index.js
+++ b/packages/kbn-eslint-plugin-eslint/index.js
@@ -38,5 +38,6 @@ module.exports = {
     require_kbn_fs: require('./rules/require_kbn_fs'),
     require_include_in_check_a11y: require('./rules/require_include_in_check_a11y'),
     no_wrapped_error_in_logger: require('./rules/no_wrapped_error_in_logger'),
+    eui_link_href_with_onclick: require('./rules/eui_link_href_with_onclick'),
   },
 };

--- a/packages/kbn-eslint-plugin-eslint/rules/eui_link_href_with_onclick.js
+++ b/packages/kbn-eslint-plugin-eslint/rules/eui_link_href_with_onclick.js
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+/** @typedef {import("eslint").Rule.RuleModule} Rule */
+
+const ERROR_MSG =
+  '<EuiLink> with `onClick` should also have an `href` for proper link semantics and accessibility. Without `href`, the component renders as a `<button>` instead of an `<a>`.';
+
+/** @type {Rule} */
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    schema: [],
+    messages: {
+      euiLinkHrefWithOnclick: ERROR_MSG,
+    },
+  },
+  create: (context) => ({
+    JSXOpeningElement(node) {
+      if (node.name.type !== 'JSXIdentifier' || node.name.name !== 'EuiLink') {
+        return;
+      }
+
+      const hasOnClick = node.attributes.some(
+        (attr) => attr.type === 'JSXAttribute' && attr.name.name === 'onClick'
+      );
+      const hasHref = node.attributes.some(
+        (attr) => attr.type === 'JSXAttribute' && attr.name.name === 'href'
+      );
+
+      if (hasOnClick && !hasHref) {
+        context.report({
+          node,
+          messageId: 'euiLinkHrefWithOnclick',
+        });
+      }
+    },
+  }),
+};

--- a/packages/kbn-eslint-plugin-eslint/rules/eui_link_href_with_onclick.test.js
+++ b/packages/kbn-eslint-plugin-eslint/rules/eui_link_href_with_onclick.test.js
@@ -1,0 +1,76 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+const { RuleTester } = require('eslint');
+const rule = require('./eui_link_href_with_onclick');
+const dedent = require('dedent');
+
+const ruleTester = new RuleTester({
+  parser: require.resolve('@typescript-eslint/parser'),
+  parserOptions: {
+    sourceType: 'module',
+    ecmaVersion: 2018,
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
+});
+
+ruleTester.run('@kbn/eslint/eui_link_href_with_onclick', rule, {
+  valid: [
+    {
+      code: dedent`
+        <EuiLink href="/foo" onClick={handler}>Click me</EuiLink>
+      `,
+    },
+    {
+      code: dedent`
+        <EuiLink href="/foo">Click me</EuiLink>
+      `,
+    },
+    {
+      code: dedent`
+        <EuiLink>Click me</EuiLink>
+      `,
+    },
+    {
+      code: dedent`
+        <EuiButton onClick={handler}>Click me</EuiButton>
+      `,
+    },
+    {
+      code: dedent`
+        <EuiButtonEmpty onClick={handler}>Click me</EuiButtonEmpty>
+      `,
+    },
+  ],
+
+  invalid: [
+    {
+      code: dedent`
+        <EuiLink onClick={handler}>Click me</EuiLink>
+      `,
+      errors: [
+        {
+          messageId: 'euiLinkHrefWithOnclick',
+        },
+      ],
+    },
+    {
+      code: dedent`
+        <EuiLink onClick={handler} color="primary">Click me</EuiLink>
+      `,
+      errors: [
+        {
+          messageId: 'euiLinkHrefWithOnclick',
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

- Adds a new `@kbn/eslint/eui_link_href_with_onclick` rule that warns when `<EuiLink>` has `onClick` without `href`
- Without `href`, EuiLink renders as a `<button>` instead of an `<a>`, breaking link semantics and accessibility (e.g., "Open in new tab", URL preview on hover)
- Enabled as `warn` globally in `kbn-eslint-config`

BUT the main problem is that this rule directly contradicts the inherent EUILink HrefOnClick rule: https://github.com/elastic/eui/blob/main/packages/eslint-plugin/src/rules/href_or_on_click.ts


## Test plan

- [x] Unit tests pass (7 cases: 5 valid, 2 invalid)
- [x] Verify warning appears on existing `<EuiLink onClick={...}>` usages without `href`
- [ ] Verify no warning on `<EuiLink href="..." onClick={...}>` or `<EuiLink href="...">` (the other inherent eui warning still exists)