### PR TITLE
Skip ci-stats reporting when bootstrap runs with --offline

### DIFF
--- a/src/dev/kbn_pm/src/cli.mjs
+++ b/src/dev/kbn_pm/src/cli.mjs
@@ -108,7 +108,7 @@ try {
     });
   }
 
-  if (timings.length && !args.getBooleanValue('offline')) {
+  if (timings.length) {
     const reporter = await tryToGetCiStatsReporter(log);
     if (reporter) {
       await reporter.timings({ timings });

--- a/src/dev/kbn_pm/src/cli.mjs
+++ b/src/dev/kbn_pm/src/cli.mjs
@@ -108,7 +108,7 @@ try {
     });
   }
 
-  if (timings.length) {
+  if (timings.length && !args.getBooleanValue('offline')) {
     const reporter = await tryToGetCiStatsReporter(log);
     if (reporter) {
       await reporter.timings({ timings });

--- a/src/dev/kbn_pm/src/commands/bootstrap/bootstrap_command.mjs
+++ b/src/dev/kbn_pm/src/commands/bootstrap/bootstrap_command.mjs
@@ -64,6 +64,9 @@ export const command = {
   },
   async run({ args, log, time }) {
     const offline = args.getBooleanValue('offline') ?? false;
+    if (offline) {
+      process.env.CI_STATS_DISABLED = 'true';
+    }
     const validate = args.getBooleanValue('validate') ?? true;
     const quiet = args.getBooleanValue('quiet') ?? false;
     const vscodeConfig =


### PR DESCRIPTION
## Summary

- When running `yarn kbn bootstrap --offline` (e.g., on an airplane), the ci-stats reporter still attempts to POST timing telemetry to `https://ci-stats.kibana.dev`
- This affects **two** reporting paths: the `cli.mjs` timing reporter after bootstrap completes, and child processes using `@kbn/dev-cli-runner` (e.g., `update_vscode_config` which was observed taking **101 seconds** purely from ci-stats retry delays)
- With no network, each reporting call retries 5 times with 60s timeouts + exponential backoff, blocking for ~100 seconds per call
- This sets `CI_STATS_DISABLED=true` in the process environment when `--offline` is passed, disabling ci-stats for the bootstrap process and all child processes via the existing `isEnabled()` check in `CiStatsReporter`

## Test plan

- [x] Run `yarn kbn bootstrap --offline` and verify it completes without hanging at ci-stats reporting steps
- [x] Run `yarn kbn bootstrap` (without `--offline`) and verify ci-stats reporting still works as before