### PR TITLE
[CI] Skip prebuilt webpack bundles in Pick Test Group Run Order step

### DIFF
--- a/.buildkite/scripts/steps/test/pick_test_group_run_order.sh
+++ b/.buildkite/scripts/steps/test/pick_test_group_run_order.sh
@@ -2,6 +2,10 @@
 
 set -euo pipefail
 
+# This step only runs a Node.js script to compute test group ordering;
+# it never needs the dev-mode shared webpack bundles (monaco, ui-shared-deps).
+export KBN_BOOTSTRAP_NO_PREBUILT=true
+
 source .buildkite/scripts/bootstrap.sh
 
 echo '--- Pick Test Group Run Order'


### PR DESCRIPTION
## Summary

Skip building shared webpack bundles (monaco, ui-shared-deps) during the **Pick Test Group Run Order** step by setting `KBN_BOOTSTRAP_NO_PREBUILT=true`. This step only runs a Node.js script (`pick_test_group_run_order.ts`) to compute test grouping — it never loads or serves browser bundles.

Saves **~84s** off bootstrap in this step. The same pattern is already used in `common.sh` for FTR config steps.

Split from #264875.


Made with [Cursor](https://cursor.com)

<!--ONMERGE {"backportTargets":["8.19","9.3","9.4"]} ONMERGE-->