### PR TITLE
Split serverless security FTR config.group1 to reduce CI time

### DIFF
--- a/x-pack/platform/test/serverless/functional/configs/security/config.group1.ts
+++ b/x-pack/platform/test/serverless/functional/configs/security/config.group1.ts
@@ -12,18 +12,7 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
 
   return {
     ...baseTestConfig.getAll(),
-    testFiles: [
-      require.resolve('../../test_suites/home_page'),
-      require.resolve('../../test_suites/management'),
-      require.resolve('../../test_suites/dev_tools'),
-      require.resolve('../../test_suites/platform_security'),
-      require.resolve('../../test_suites/reporting'),
-      require.resolve('../../test_suites/grok_debugger'),
-      require.resolve('../../test_suites/console'),
-      require.resolve('../../test_suites/painless_lab'),
-      require.resolve('../../test_suites/spaces'),
-      require.resolve('../../test_suites/data_usage'),
-    ],
+    testFiles: [require.resolve('../../test_suites/management')],
     junit: {
       reportName: 'Serverless Security Functional Tests - Common Group 1',
     },

--- a/x-pack/platform/test/serverless/functional/configs/security/config.group18.ts
+++ b/x-pack/platform/test/serverless/functional/configs/security/config.group18.ts
@@ -12,7 +12,18 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
 
   return {
     ...baseTestConfig.getAll(),
-    testFiles: [require.resolve('../../test_suites/visualizations/group10')],
+    testFiles: [
+      require.resolve('../../test_suites/visualizations/group10'),
+      require.resolve('../../test_suites/home_page'),
+      require.resolve('../../test_suites/dev_tools'),
+      require.resolve('../../test_suites/platform_security'),
+      require.resolve('../../test_suites/reporting'),
+      require.resolve('../../test_suites/grok_debugger'),
+      require.resolve('../../test_suites/console'),
+      require.resolve('../../test_suites/painless_lab'),
+      require.resolve('../../test_suites/spaces'),
+      require.resolve('../../test_suites/data_usage'),
+    ],
     junit: {
       reportName: 'Serverless Security Functional Tests - Common Group 18',
     },


### PR DESCRIPTION
## Summary

Split `config.group1.ts` (Serverless Security Functional Tests - Common Group 1) to reduce CI feedback time by moving suites into the existing `config.group18.ts`.

### Problem

`config.group1` currently bundles **10 test suites** (128 test cases) with:

- **Median wall time: ~33 min** (P90: ~39 min)
- Test execution: ~21 min
- The `management` suite alone accounts for **67% of test time** (~14 min)

Other security groups typically have 2–3 test suites. Group 1 was significantly overloaded.

### Changes

Move the 9 lighter suites from `config.group1` into `config.group18`, which is the lightest existing group at only ~6m 35s FTR duration. This avoids creating a new CI job and its associated server startup overhead.

- **`config.group1.ts`** — now contains only the `management` suite (83 test cases, ~14 min test execution)
- **`config.group18.ts`** — gains the 9 former group1 suites: `home_page`, `dev_tools`, `platform_security`, `reporting`, `grok_debugger`, `console`, `painless_lab`, `spaces`, `data_usage` (in addition to its existing `visualizations/group10`)

No new config file or CI job is created.

### Expected Improvement

| Metric           | Before   | After (est.) | Saved      |
| ---------------- | -------- | ------------ | ---------- |
| group1 median wall time | ~33 min | ~21–25 min  | ~8–12 min |
| group1 P90 wall time    | ~39 min | ~27–30 min  | ~9–12 min |
| group18 FTR duration    | ~6.5 min | ~13.5 min  | —          |

~25–30% reduction in group1 CI feedback time, with no additional server startup cost.

## Test plan

- Verify `config.group1.ts` runs successfully with only the management suite
- Verify `config.group18.ts` runs successfully with the added suites
- Confirm both configs appear and pass in CI

Made with Cursor

<!--ONMERGE {"backportTargets":["8.19","9.2","9.3","9.4"]} ONMERGE-->