### PR TITLE
Small optimization of `getFlattenedObject`

### DIFF
--- a/src/platform/packages/shared/kbn-std/src/get_flattened_object.ts
+++ b/src/platform/packages/shared/kbn-std/src/get_flattened_object.ts
@@ -12,6 +12,26 @@ function shouldReadKeys(value: unknown): value is Record<string, any> {
 }
 
 /**
+ * Flattens a deeply nested object to a map of dot-separated
+ * paths pointing to all primitive values **and arrays**
+ * from `object`.
+ *
+ * @param prefix - The prefix to use for the path.
+ * @param object - The object to flatten.
+ * @param result - The result object to store the flattened values. Note: this object is mutated in place.
+ */
+function flatten(prefix: string, object: Record<string, unknown>, result: Record<string, unknown>) {
+  for (const [key, value] of Object.entries(object)) {
+    const path = prefix ? `${prefix}.${key}` : key;
+    if (shouldReadKeys(value)) {
+      flatten(path, value, result);
+    } else {
+      result[path] = value;
+    }
+  }
+}
+
+/**
  *  Flattens a deeply nested object to a map of dot-separated
  *  paths pointing to all primitive values **and arrays**
  *  from `rootValue`.
@@ -27,16 +47,7 @@ export function getFlattenedObject(rootValue: Record<string, any>) {
     throw new TypeError(`Root value is not flatten-able, received ${rootValue}`);
   }
 
-  const result: { [key: string]: any } = {};
-  (function flatten(prefix, object) {
-    for (const [key, value] of Object.entries(object)) {
-      const path = prefix ? `${prefix}.${key}` : key;
-      if (shouldReadKeys(value)) {
-        flatten(path, value);
-      } else {
-        result[path] = value;
-      }
-    }
-  })('', rootValue);
+  const result: Record<string, unknown> = {};
+  flatten('', rootValue, result);
   return result;
 }

--- a/src/platform/packages/shared/kbn-std/src/get_flattened_object.ts
+++ b/src/platform/packages/shared/kbn-std/src/get_flattened_object.ts
@@ -47,7 +47,7 @@ export function getFlattenedObject(rootValue: Record<string, any>) {
     throw new TypeError(`Root value is not flatten-able, received ${rootValue}`);
   }
 
-  const result: Record<string, unknown> = {};
+  const result: { [key: string]: any } = {};
   flatten('', rootValue, result);
   return result;
 }


### PR DESCRIPTION
## Summary

Just moving the function declared on every execution to a stateless function that's defined once.

It should improve memory usage (haven't validated it with actual metrics, though), and reduce stress on the GC, releasing CPU usage as well.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
  - N/A
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
  - N/A: no public-facing behavior changed.
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
  - No tests changed. The logic still validates them.
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
  - N/A
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
  - No flaky test fixed.
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
  - No need: `release_note:skip`.
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
  - Backporting to all-open branches because it's a low risk change that can bring 

### Identify risks

- [x] No risks. Just profit





<!--ONMERGE {"backportTargets":["8.19","9.2","9.3","9.4"]} ONMERGE-->