### PR TITLE
[Cases][Workflows] Make parsing more resilient

### DIFF
--- a/x-pack/platform/plugins/shared/cases/server/workflows/steps/delete_cases.ts
+++ b/x-pack/platform/plugins/shared/cases/server/workflows/steps/delete_cases.ts
@@ -10,7 +10,7 @@ import { createServerStepDefinition } from '@kbn/workflows-extensions/server';
 import { deleteCasesStepCommonDefinition } from '../../../common/workflows/steps/delete_cases';
 import type { CasesClient } from '../../client';
 import { DELETE_CASES_FAILED_MESSAGE } from './translations';
-import { getCasesClientFromStepsContext, getErrorMessage } from './utils';
+import { getCasesClientFromStepsContext, getErrorMessage, safeParseCaseForWorkflowOutput } from './utils';
 
 export const deleteCasesStepDefinition = (
   getCasesClient: (request: KibanaRequest) => Promise<CasesClient>
@@ -24,9 +24,10 @@ export const deleteCasesStepDefinition = (
         const casesClient = await getCasesClientFromStepsContext(context, getCasesClient);
         await casesClient.cases.delete(case_ids);
 
-        const output = deleteCasesStepCommonDefinition.outputSchema.parse({
-          case_ids,
-        });
+        const output = safeParseCaseForWorkflowOutput(
+          deleteCasesStepCommonDefinition.outputSchema,
+          { case_ids }
+        );
 
         return { output };
       } catch (error) {

--- a/x-pack/platform/plugins/shared/cases/server/workflows/steps/delete_cases.ts
+++ b/x-pack/platform/plugins/shared/cases/server/workflows/steps/delete_cases.ts
@@ -10,7 +10,11 @@ import { createServerStepDefinition } from '@kbn/workflows-extensions/server';
 import { deleteCasesStepCommonDefinition } from '../../../common/workflows/steps/delete_cases';
 import type { CasesClient } from '../../client';
 import { DELETE_CASES_FAILED_MESSAGE } from './translations';
-import { getCasesClientFromStepsContext, getErrorMessage, safeParseCaseForWorkflowOutput } from './utils';
+import {
+  getCasesClientFromStepsContext,
+  getErrorMessage,
+  safeParseCaseForWorkflowOutput,
+} from './utils';
 
 export const deleteCasesStepDefinition = (
   getCasesClient: (request: KibanaRequest) => Promise<CasesClient>

--- a/x-pack/platform/plugins/shared/cases/server/workflows/steps/find_cases.ts
+++ b/x-pack/platform/plugins/shared/cases/server/workflows/steps/find_cases.ts
@@ -10,7 +10,7 @@ import { createServerStepDefinition } from '@kbn/workflows-extensions/server';
 import { findCasesStepCommonDefinition } from '../../../common/workflows/steps/find_cases';
 import type { CasesFindRequestWithCustomFields } from '../../../common/types/api';
 import type { CasesClient } from '../../client';
-import { getCasesClientFromStepsContext } from './utils';
+import { getCasesClientFromStepsContext, safeParseCaseForWorkflowOutput } from './utils';
 
 export const findCasesStepDefinition = (
   getCasesClient: (request: KibanaRequest) => Promise<CasesClient>
@@ -19,8 +19,8 @@ export const findCasesStepDefinition = (
     ...findCasesStepCommonDefinition,
     handler: async (context) => {
       try {
-        const casesClient = await getCasesClientFromStepsContext(context, getCasesClient);
         const input = findCasesStepCommonDefinition.inputSchema.parse(context.input);
+        const casesClient = await getCasesClientFromStepsContext(context, getCasesClient);
 
         const findRequest: CasesFindRequestWithCustomFields = {
           ...input,
@@ -28,7 +28,10 @@ export const findCasesStepDefinition = (
           severity: input.severity as CasesFindRequestWithCustomFields['severity'],
         };
         const response = await casesClient.cases.find(findRequest);
-        const output = findCasesStepCommonDefinition.outputSchema.parse(response);
+        const output = safeParseCaseForWorkflowOutput(
+          findCasesStepCommonDefinition.outputSchema,
+          response
+        );
 
         return { output };
       } catch (error) {

--- a/x-pack/platform/plugins/shared/cases/server/workflows/steps/find_similar_cases.ts
+++ b/x-pack/platform/plugins/shared/cases/server/workflows/steps/find_similar_cases.ts
@@ -10,7 +10,7 @@ import { createServerStepDefinition } from '@kbn/workflows-extensions/server';
 import { findSimilarCasesStepCommonDefinition } from '../../../common/workflows/steps/find_similar_cases';
 import type { CasesClient } from '../../client';
 import { FIND_SIMILAR_CASES_FAILED_MESSAGE } from './translations';
-import { getCasesClientFromStepsContext } from './utils';
+import { getCasesClientFromStepsContext, safeParseCaseForWorkflowOutput } from './utils';
 
 export const findSimilarCasesStepDefinition = (
   getCasesClient: (request: KibanaRequest) => Promise<CasesClient>
@@ -27,7 +27,10 @@ export const findSimilarCasesStepDefinition = (
           perPage: input.perPage,
         });
 
-        const output = findSimilarCasesStepCommonDefinition.outputSchema.parse(similarCases);
+        const output = safeParseCaseForWorkflowOutput(
+          findSimilarCasesStepCommonDefinition.outputSchema,
+          similarCases
+        );
 
         return { output };
       } catch (_error) {

--- a/x-pack/platform/plugins/shared/cases/server/workflows/steps/get_all_attachments.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/workflows/steps/get_all_attachments.test.ts
@@ -64,15 +64,14 @@ describe('getAllAttachmentsStepDefinition', () => {
   });
 
   it('returns error when attachments.getAll throws', async () => {
-    // FAILURE SCENARIO: client throws (e.g. case not found or auth failure)
     const getAll = jest.fn().mockRejectedValue(new Error('not found'));
     const getCasesClient = jest.fn().mockResolvedValue({
       attachments: { getAll },
     } as unknown as CasesClient);
     const definition = getAllAttachmentsStepDefinition(getCasesClient);
 
-    await expect(definition.handler(createContext({ case_id: 'case-1' }))).rejects.toThrow(
-      'not found'
-    );
+    const result = await definition.handler(createContext({ case_id: 'case-1' }));
+
+    expect(result).toMatchObject({ error: expect.objectContaining({ message: 'not found' }) });
   });
 });

--- a/x-pack/platform/plugins/shared/cases/server/workflows/steps/get_all_attachments.ts
+++ b/x-pack/platform/plugins/shared/cases/server/workflows/steps/get_all_attachments.ts
@@ -9,7 +9,7 @@ import type { KibanaRequest } from '@kbn/core/server';
 import { createServerStepDefinition } from '@kbn/workflows-extensions/server';
 import { getAllAttachmentsStepCommonDefinition } from '../../../common/workflows/steps/get_all_attachments';
 import type { CasesClient } from '../../client';
-import { getCasesClientFromStepsContext } from './utils';
+import { getCasesClientFromStepsContext, safeParseCaseForWorkflowOutput } from './utils';
 
 export const getAllAttachmentsStepDefinition = (
   getCasesClient: (request: KibanaRequest) => Promise<CasesClient>
@@ -17,15 +17,20 @@ export const getAllAttachmentsStepDefinition = (
   createServerStepDefinition({
     ...getAllAttachmentsStepCommonDefinition,
     handler: async (context) => {
-      const casesClient = await getCasesClientFromStepsContext(context, getCasesClient);
-      const attachments = await casesClient.attachments.getAll({
-        caseID: context.input.case_id,
-      });
+      try {
+        const casesClient = await getCasesClientFromStepsContext(context, getCasesClient);
+        const attachments = await casesClient.attachments.getAll({
+          caseID: context.input.case_id,
+        });
 
-      const output = getAllAttachmentsStepCommonDefinition.outputSchema.parse({
-        attachments,
-      });
+        const output = safeParseCaseForWorkflowOutput(
+          getAllAttachmentsStepCommonDefinition.outputSchema,
+          { attachments }
+        );
 
-      return { output };
+        return { output };
+      } catch (error) {
+        return { error };
+      }
     },
   });

--- a/x-pack/platform/plugins/shared/cases/server/workflows/steps/get_cases.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/workflows/steps/get_cases.test.ts
@@ -71,15 +71,14 @@ describe('getCasesStepDefinition', () => {
   });
 
   it('returns error when cases.bulkGet throws', async () => {
-    // FAILURE SCENARIO: client throws (e.g. auth failure)
     const bulkGet = jest.fn().mockRejectedValue(new Error('unauthorized'));
     const getCasesClient = jest.fn().mockResolvedValue({
       cases: { bulkGet },
     } as unknown as CasesClient);
     const definition = getCasesStepDefinition(getCasesClient);
 
-    await expect(definition.handler(createContext({ case_ids: ['case-1'] }))).rejects.toThrow(
-      'unauthorized'
-    );
+    const result = await definition.handler(createContext({ case_ids: ['case-1'] }));
+
+    expect(result).toMatchObject({ error: expect.objectContaining({ message: 'unauthorized' }) });
   });
 });

--- a/x-pack/platform/plugins/shared/cases/server/workflows/steps/get_cases.ts
+++ b/x-pack/platform/plugins/shared/cases/server/workflows/steps/get_cases.ts
@@ -9,7 +9,7 @@ import type { KibanaRequest } from '@kbn/core/server';
 import { createServerStepDefinition } from '@kbn/workflows-extensions/server';
 import { getCasesStepCommonDefinition } from '../../../common/workflows/steps/get_cases';
 import type { CasesClient } from '../../client';
-import { getCasesClientFromStepsContext } from './utils';
+import { getCasesClientFromStepsContext, safeParseCaseForWorkflowOutput } from './utils';
 
 export const getCasesStepDefinition = (
   getCasesClient: (request: KibanaRequest) => Promise<CasesClient>
@@ -17,11 +17,18 @@ export const getCasesStepDefinition = (
   createServerStepDefinition({
     ...getCasesStepCommonDefinition,
     handler: async (context) => {
-      const casesClient = await getCasesClientFromStepsContext(context, getCasesClient);
-      const result = await casesClient.cases.bulkGet({ ids: context.input.case_ids });
+      try {
+        const casesClient = await getCasesClientFromStepsContext(context, getCasesClient);
+        const result = await casesClient.cases.bulkGet({ ids: context.input.case_ids });
 
-      const output = getCasesStepCommonDefinition.outputSchema.parse(result);
+        const output = safeParseCaseForWorkflowOutput(
+          getCasesStepCommonDefinition.outputSchema,
+          result
+        );
 
-      return { output };
+        return { output };
+      } catch (error) {
+        return { error };
+      }
     },
   });

--- a/x-pack/platform/plugins/shared/cases/server/workflows/steps/get_cases_by_alert_id.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/workflows/steps/get_cases_by_alert_id.test.ts
@@ -71,13 +71,14 @@ describe('getCasesByAlertIdStepDefinition', () => {
   });
 
   it('returns error when getCasesByAlertID throws', async () => {
-    // FAILURE SCENARIO: client throws (e.g. authorization failure or network error)
     const getCasesByAlertID = jest.fn().mockRejectedValue(new Error('unauthorized'));
     const getCasesClient = jest.fn().mockResolvedValue({
       cases: { getCasesByAlertID },
     } as unknown as CasesClient);
     const definition = getCasesByAlertIdStepDefinition(getCasesClient);
 
-    await expect(definition.handler(createContext({ alert_id: 'alert-1' }))).rejects.toThrow();
+    const result = await definition.handler(createContext({ alert_id: 'alert-1' }));
+
+    expect(result).toMatchObject({ error: expect.objectContaining({ message: 'unauthorized' }) });
   });
 });

--- a/x-pack/platform/plugins/shared/cases/server/workflows/steps/get_cases_by_alert_id.ts
+++ b/x-pack/platform/plugins/shared/cases/server/workflows/steps/get_cases_by_alert_id.ts
@@ -9,7 +9,7 @@ import type { KibanaRequest } from '@kbn/core/server';
 import { createServerStepDefinition } from '@kbn/workflows-extensions/server';
 import { getCasesByAlertIdStepCommonDefinition } from '../../../common/workflows/steps/get_cases_by_alert_id';
 import type { CasesClient } from '../../client';
-import { getCasesClientFromStepsContext } from './utils';
+import { getCasesClientFromStepsContext, safeParseCaseForWorkflowOutput } from './utils';
 
 export const getCasesByAlertIdStepDefinition = (
   getCasesClient: (request: KibanaRequest) => Promise<CasesClient>
@@ -17,18 +17,23 @@ export const getCasesByAlertIdStepDefinition = (
   createServerStepDefinition({
     ...getCasesByAlertIdStepCommonDefinition,
     handler: async (context) => {
-      const casesClient = await getCasesClientFromStepsContext(context, getCasesClient);
-      const relatedCases = await casesClient.cases.getCasesByAlertID({
-        alertID: context.input.alert_id,
-        options: {
-          owner: context.input.owner,
-        },
-      });
+      try {
+        const casesClient = await getCasesClientFromStepsContext(context, getCasesClient);
+        const relatedCases = await casesClient.cases.getCasesByAlertID({
+          alertID: context.input.alert_id,
+          options: {
+            owner: context.input.owner,
+          },
+        });
 
-      const output = getCasesByAlertIdStepCommonDefinition.outputSchema.parse({
-        cases: relatedCases,
-      });
+        const output = safeParseCaseForWorkflowOutput(
+          getCasesByAlertIdStepCommonDefinition.outputSchema,
+          { cases: relatedCases }
+        );
 
-      return { output };
+        return { output };
+      } catch (error) {
+        return { error };
+      }
     },
   });

--- a/x-pack/platform/plugins/shared/cases/server/workflows/steps/update_cases.ts
+++ b/x-pack/platform/plugins/shared/cases/server/workflows/steps/update_cases.ts
@@ -9,7 +9,7 @@ import type { KibanaRequest } from '@kbn/core/server';
 import { createServerStepDefinition } from '@kbn/workflows-extensions/server';
 import { updateCasesStepCommonDefinition } from '../../../common/workflows/steps/update_cases';
 import type { CasesClient } from '../../client';
-import { getCasesClientFromStepsContext, getErrorMessage, pushCase } from './utils';
+import { getCasesClientFromStepsContext, getErrorMessage, pushCase, safeParseCaseForWorkflowOutput } from './utils';
 import { UPDATE_CASES_FAILED_MESSAGE } from './translations';
 import { prepareCasePatch } from './update_case_helpers';
 
@@ -77,7 +77,7 @@ export const updateCasesStepDefinition = (
           }
         }
 
-        const output = updateCasesStepCommonDefinition.outputSchema.parse({ cases: updatedCases });
+        const output = safeParseCaseForWorkflowOutput(updateCasesStepCommonDefinition.outputSchema, { cases: updatedCases });
         return { output };
       } catch (error) {
         if (error instanceof Error && error.message.includes('could not be updated')) {

--- a/x-pack/platform/plugins/shared/cases/server/workflows/steps/update_cases.ts
+++ b/x-pack/platform/plugins/shared/cases/server/workflows/steps/update_cases.ts
@@ -9,7 +9,12 @@ import type { KibanaRequest } from '@kbn/core/server';
 import { createServerStepDefinition } from '@kbn/workflows-extensions/server';
 import { updateCasesStepCommonDefinition } from '../../../common/workflows/steps/update_cases';
 import type { CasesClient } from '../../client';
-import { getCasesClientFromStepsContext, getErrorMessage, pushCase, safeParseCaseForWorkflowOutput } from './utils';
+import {
+  getCasesClientFromStepsContext,
+  getErrorMessage,
+  pushCase,
+  safeParseCaseForWorkflowOutput,
+} from './utils';
 import { UPDATE_CASES_FAILED_MESSAGE } from './translations';
 import { prepareCasePatch } from './update_case_helpers';
 
@@ -77,7 +82,10 @@ export const updateCasesStepDefinition = (
           }
         }
 
-        const output = safeParseCaseForWorkflowOutput(updateCasesStepCommonDefinition.outputSchema, { cases: updatedCases });
+        const output = safeParseCaseForWorkflowOutput(
+          updateCasesStepCommonDefinition.outputSchema,
+          { cases: updatedCases }
+        );
         return { output };
       } catch (error) {
         if (error instanceof Error && error.message.includes('could not be updated')) {


### PR DESCRIPTION
## Summary

Some of the case workflow steps were using a strict `.parse()` on the output. Since some attachments can have almost arbitrary values, we should use `.safeParse()` in workflow steps. Output schemas provide a best-effort experience in the workflow editor and they shouldn't fail steps.

### Testing

Make sure the cases kitchen sink workflow still works (adding alerts to your env is encouraged):

<details>
<summary>Click to expand kitchen sink workflow</summary>

```yaml
version: "1"
name: "cases.kitchen_sink"
description: "Kitchen-sink workflow that exercises all Cases workflow steps."
enabled: true
tags: [ "cases", "kitchen-sink", "example" ]
triggers:
  - type: manual

inputs:
  - name: case_title
    type: string
    required: false
    default: "Kitchen sink workflow case"
    description: "Title for the case created by cases.createCase."
  - name: case_description
    type: string
    required: false
    default: "Created by the cases.kitchen_sink workflow example."
    description: "Description for the case created by cases.createCase."

steps:
  - name: create_case
    type: cases.createCase
    with:
      title: "{{ inputs.case_title }}"
      description: "{{ inputs.case_description }}"
      owner: securitySolution
      tags:
        - "kitchen-sink"
        - "workflows"
      severity: low
      settings:
        syncAlerts: false
        extractObservables: false
        

  - name: get_created_case
    type: cases.getCase
    with:
      case_id: "${{ steps.create_case.output.case.id }}"
      include_comments: false

  - name: update_created_case
    type: cases.updateCase
    with:
      case_id: "${{ steps.get_created_case.output.case.id }}"
      updates:
        title: "Updated: {{ inputs.case_title }}"
        description: "Updated by cases.updateCase in kitchen-sink workflow."
        severity: medium
        status: in-progress

  - name: add_comment_to_case
    type: cases.addComment
    with:
      case_id: "${{ steps.update_created_case.output.case.id }}"
      comment: "Kitchen-sink workflow comment added via cases.addComment."
  # - name: set_custom_field
  #   type: cases.setCustomField
  #   with:
  #     case_id: "${{steps.add_comment_to_case.output.case.id}}"
  #     field_name: cb6e9948-09ca-4ec6-8ebf-68de45f851e4
  #     value: true
  - name: find_similar
    type: cases.findSimilarCases
    with:
      case_id: "${{ steps.update_created_case.output.case.id }}"
      page: 1
      perPage: 20
  - name: find_cases
    type: cases.findCases
    with:
      owner: securitySolution
      page: 1
      perPage: 20
  - name: case_add_tags
    type: cases.addTags
    with:
      case_id: "${{ steps.update_created_case.output.case.id }}"
      tags:
        - added_afterwards
  - name: set_cat
    type: cases.setCategory
    with:
      case_id: "${{ steps.case_add_tags.output.case.id }}"
      version: "${{ steps.case_add_tags.output.case.version }}"
      category: test_cat
  - name: set_description
    type: cases.setDescription
    with:
      case_id: "${{steps.case_add_tags.output.case.id}}"
      version: "${{steps.set_cat.output.case.version}}"
      description: "setting with setDescription"
  - name: assign
    type: cases.assignCase
    with:
      case_id: "${{steps.set_description.output.case.id}}"
      version: "${{steps.set_description.output.case.version}}"
      assignees: 
        - uid: "u_mGBROF_q5bmFCATbLXAcCwKa0k8JvONAwSruelyKA5E_0"
  - name: unassign
    type: cases.unassignCase
    with:
      case_id: "${{steps.assign.output.case.id}}"
      assignees: null
  # - name: add_events
  #   type: cases.addEvents
  #   with:
  #     case_id: "${{steps.add_alert.output.case.id}}"
  #     events:
  #       - eventId: AZziMFnfH5twofAXPjsY
  #         index: .ds-logs-endpoint.events.process-default-2026.03.12-000001
  - name: add_observables
    type: cases.addObservables
    with:
      case_id: ${{ steps.create_case.output.case.id }}
      observables:
        - typeKey: observable-type-ipv4
          value: 10.0.0.1
          description: Initial observable

  - name: update_observable
    type: cases.updateObservable
    with:
      case_id: ${{ steps.create_case.output.case.id }}
      observable_id: ${{ steps.add_observables.output.case.observables[0].id }}
      value: 10.0.0.42
      description: Updated via kitchen sink
  - name: get_all_attachments
    type: cases.getAllAttachments
    with:
      case_id: ${{ steps.create_case.output.case.id }}
  - name: delete_observable
    type: cases.deleteObservable
    with:
      case_id: ${{ steps.create_case.output.case.id }}
      observable_id: ${{ steps.add_observables.output.case.observables[0].id }}
  
  - name: query_newest_alerts
    type: elasticsearch.search
    with:
      index: .alerts-security.alerts-*
      query:
        match_all: {}
      sort: "@timestamp"
      size: 10
  - name: map_alerts
    type: data.map
    with:
      fields:
        alertId: ${{ item._id }}
        index: ${{ item._index }}
    items: ${{ steps.query_newest_alerts.output.hits.hits }}
  - name: check
    type: if
    condition: 'steps.map_alerts.output.length > 0'
    steps:
      - name: add_queried_alerts
        type: cases.addAlerts
        with:
          case_id: ${{ steps.create_case.output.case.id }}
          alerts: ${{ steps.map_alerts.output }}
      - name: get_cases_by_alert_id
        type: cases.getCasesByAlertId
        with:
          alert_id: ${{ steps.map_alerts.output[0].alertId }}
          owner: securitySolution

  - name: create_another_one
    type: cases.createCase
    with:
      description: "another one"
      owner: securitySolution
      title: "The second one"
  - name: bulk_update
    type: cases.updateCases
    with:
      cases:
        - case_id: "{{steps.create_case.output.case.id}}"
          updates:
            category: bulked
        - case_id: "{{steps.create_another_one.output.case.id}}"
          updates:
            category: bulked    
```

</details>

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->