### PR TITLE
[SigEvents] Remove dead `saveQueries` parameter from onboarding task

### DIFF
--- a/x-pack/platform/plugins/shared/streams/scripts/seed_sigevents_env/steps/seed_tasks.ts
+++ b/x-pack/platform/plugins/shared/streams/scripts/seed_sigevents_env/steps/seed_tasks.ts
@@ -153,7 +153,6 @@ function buildTaskDocs(
         from: 0,
         to: 0,
         steps: ['features_identification', 'queries_generation'],
-        saveQueries: true,
       },
       {
         featuresTaskResult: { status: 'completed', features },

--- a/x-pack/platform/plugins/shared/streams/server/lib/tasks/task_definitions/onboarding.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/tasks/task_definitions/onboarding.ts
@@ -47,7 +47,6 @@ export interface OnboardingTaskParams {
   from: number;
   to: number;
   steps: OnboardingStep[];
-  saveQueries: boolean;
   connectors?: {
     features?: string;
     queries?: string;
@@ -56,9 +55,8 @@ export interface OnboardingTaskParams {
 
 export const STREAMS_ONBOARDING_TASK_TYPE = 'streams_onboarding';
 
-export function getOnboardingTaskId(streamName: string, saveQueries: boolean = true) {
-  const base = `${STREAMS_ONBOARDING_TASK_TYPE}_${streamName}`;
-  return saveQueries ? base : `${base}_no_save_queries`;
+export function getOnboardingTaskId(streamName: string) {
+  return `${STREAMS_ONBOARDING_TASK_TYPE}_${streamName}`;
 }
 
 const FEATURES_IDENTIFICATION_RECENCY_MS = 12 * 60 * 60 * 1000; // 12 hours
@@ -99,8 +97,8 @@ export function createStreamsOnboardingTask(taskContext: TaskContext) {
               }
               const { fakeRequest } = runContext;
 
-              const { streamName, from, to, steps, saveQueries, connectors, _task } = runContext
-                .taskInstance.params as TaskParams<OnboardingTaskParams>;
+              const { streamName, from, to, steps, connectors, _task } = runContext.taskInstance
+                .params as TaskParams<OnboardingTaskParams>;
 
               const { taskClient, getQueryClient, streamsClient, uiSettingsClient } =
                 await taskContext.getScopedClients({
@@ -178,12 +176,10 @@ export function createStreamsOnboardingTask(taskContext: TaskContext) {
                         return;
                       }
 
-                      if (saveQueries) {
-                        await persistQueries(streamName, queriesTaskResult.queries, {
-                          queryClient: await getQueryClient(),
-                          streamsClient,
-                        });
-                      }
+                      await persistQueries(streamName, queriesTaskResult.queries, {
+                        queryClient: await getQueryClient(),
+                        streamsClient,
+                      });
                       break;
 
                     default:
@@ -198,7 +194,6 @@ export function createStreamsOnboardingTask(taskContext: TaskContext) {
                     from,
                     to,
                     steps,
-                    saveQueries,
                     connectors,
                   },
                   { featuresTaskResult, queriesTaskResult }
@@ -274,7 +269,6 @@ export function createStreamsOnboardingTask(taskContext: TaskContext) {
                     from,
                     to,
                     steps,
-                    saveQueries,
                     connectors,
                   },
                   errorMessage

--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/onboarding/route.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/onboarding/route.ts
@@ -6,7 +6,6 @@
  */
 
 import { z } from '@kbn/zod/v4';
-import { BooleanFromString } from '@kbn/zod-helpers/v4';
 import type { OnboardingResult, TaskResult } from '@kbn/streams-schema';
 import { OnboardingStep } from '@kbn/streams-schema';
 import { STREAMS_API_PRIVILEGES } from '../../../../../common/constants';
@@ -21,7 +20,6 @@ import { handleTaskAction } from '../../../utils/task_helpers';
 import { taskActionSchema } from '../../../../lib/tasks/task_action_schema';
 
 const timestampFromString = z.string().transform((input) => new Date(input).getTime());
-const saveQueriesSchema = BooleanFromString.optional().default(true);
 
 export type OnboardingTaskResult = TaskResult<OnboardingResult>;
 
@@ -40,9 +38,6 @@ export const onboardingTaskRoute = createServerRoute({
   },
   params: z.object({
     path: z.object({ streamName: z.string() }),
-    query: z.object({
-      saveQueries: saveQueriesSchema,
-    }),
     body: taskActionSchema({
       from: timestampFromString,
       to: timestampFromString,
@@ -73,13 +68,10 @@ export const onboardingTaskRoute = createServerRoute({
 
     const {
       path: { streamName },
-      query,
       body,
     } = params;
 
-    const { saveQueries } = query;
-
-    const onboardingTaskId = getOnboardingTaskId(streamName, saveQueries);
+    const onboardingTaskId = getOnboardingTaskId(streamName);
 
     const actionParams =
       body.action === 'schedule'
@@ -93,7 +85,6 @@ export const onboardingTaskRoute = createServerRoute({
                 from: body.from,
                 to: body.to,
                 steps: body.steps,
-                saveQueries,
                 connectors: body.connectors,
               },
               request,
@@ -123,9 +114,6 @@ export const onboardingStatusRoute = createServerRoute({
   },
   params: z.object({
     path: z.object({ streamName: z.string() }),
-    query: z.object({
-      saveQueries: saveQueriesSchema,
-    }),
   }),
   handler: async ({ params, request, getScopedClients, server }): Promise<OnboardingTaskResult> => {
     const { licensing, uiSettingsClient, taskClient } = await getScopedClients({
@@ -135,9 +123,8 @@ export const onboardingStatusRoute = createServerRoute({
 
     const {
       path: { streamName },
-      query: { saveQueries },
     } = params;
-    const taskId = getOnboardingTaskId(streamName, saveQueries);
+    const taskId = getOnboardingTaskId(streamName);
 
     return taskClient.getStatus<OnboardingTaskParams, OnboardingResult>(taskId);
   },

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/stream_detail_significant_events_view/hooks/use_knowledge_indicators_task.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/stream_detail_significant_events_view/hooks/use_knowledge_indicators_task.ts
@@ -34,7 +34,7 @@ export function useKnowledgeIndicatorsTask({ streamName, onComplete, onError }: 
     },
   } = useKibana();
   const { getOnboardingTaskStatus, scheduleOnboardingTask, cancelOnboardingTask } =
-    useOnboardingApi({ saveQueries: true });
+    useOnboardingApi();
 
   const scheduleTaskMutation = useMutation({
     mutationFn: scheduleOnboardingTask,

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/stream_detail_significant_events_view/promotion_callout/promotion_callout.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/stream_detail_significant_events_view/promotion_callout/promotion_callout.tsx
@@ -43,7 +43,7 @@ export function PromotionCallout({ streamName, onReviewClick }: PromotionCallout
   const queryClient = useQueryClient();
 
   const { queries, isLoading, refetch } = usePromotableQueries(streamName);
-  const { acknowledgeOnboardingTask } = useOnboardingApi({ saveQueries: true });
+  const { acknowledgeOnboardingTask } = useOnboardingApi();
   const { promote } = useQueriesApi();
 
   const promoteMutation = useMutation<{ promoted: number }, Error>({

--- a/x-pack/platform/plugins/shared/streams_app/public/hooks/sig_events/use_promotable_queries.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/hooks/sig_events/use_promotable_queries.ts
@@ -29,7 +29,7 @@ export function usePromotableQueries(streamName: string) {
     perPage: 1_000,
   });
 
-  const { getOnboardingTaskStatus } = useOnboardingApi({ saveQueries: true });
+  const { getOnboardingTaskStatus } = useOnboardingApi();
 
   const onboardingTaskStatusResult = useQuery({
     queryKey: ['onboardingTaskStatus', streamName, 'promotableQueries'],

--- a/x-pack/platform/plugins/shared/streams_app/public/hooks/use_onboarding_api.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/hooks/use_onboarding_api.ts
@@ -11,10 +11,6 @@ import { useMemo } from 'react';
 import { useKibana } from './use_kibana';
 import { getLast24HoursTimeRange } from '../util/time_range';
 
-export interface UseOnboardingApiOptions {
-  saveQueries?: boolean;
-}
-
 export interface ScheduleOnboardingOptions {
   steps?: OnboardingStep[];
   connectors?: {
@@ -23,7 +19,7 @@ export interface ScheduleOnboardingOptions {
   };
 }
 
-export function useOnboardingApi({ saveQueries = true }: UseOnboardingApiOptions = {}) {
+export function useOnboardingApi() {
   const {
     dependencies: {
       start: {
@@ -45,7 +41,6 @@ export function useOnboardingApi({ saveQueries = true }: UseOnboardingApiOptions
             signal,
             params: {
               path: { streamName },
-              query: { saveQueries },
               body: {
                 action: 'schedule' as const,
                 from,
@@ -64,7 +59,6 @@ export function useOnboardingApi({ saveQueries = true }: UseOnboardingApiOptions
             signal,
             params: {
               path: { streamName },
-              query: { saveQueries },
             },
           }
         );
@@ -76,7 +70,6 @@ export function useOnboardingApi({ saveQueries = true }: UseOnboardingApiOptions
             signal,
             params: {
               path: { streamName },
-              query: { saveQueries },
               body: {
                 action: 'cancel' as const,
               },
@@ -91,7 +84,6 @@ export function useOnboardingApi({ saveQueries = true }: UseOnboardingApiOptions
             signal,
             params: {
               path: { streamName },
-              query: { saveQueries },
               body: {
                 action: 'acknowledge' as const,
               },
@@ -100,6 +92,6 @@ export function useOnboardingApi({ saveQueries = true }: UseOnboardingApiOptions
         );
       },
     }),
-    [saveQueries, signal, streamsRepositoryClient]
+    [signal, streamsRepositoryClient]
   );
 }


### PR DESCRIPTION
## Summary

The `saveQueries` parameter in the onboarding task flow was always `true` at every call site — no caller ever passed `false`. This removes the dead parameter and makes query persistence unconditional.

### Why `saveQueries` existed

It was introduced in [#254660](https://github.com/elastic/kibana/pull/254660) to support a "preview before commit" workflow in the Add Significant Event flyout: the flyout would run the onboarding task with `saveQueries: false` so generated queries were stored only in task state without being persisted, letting the user preview them before explicit submission.

### Why it's no longer needed

That flyout was subsequently replaced by the current promotion callout / suggested rules flow, which always persists queries immediately. Every remaining call site passes `true` (or relies on the `true` default), and no code path ever sets `saveQueries: false`:

| Caller | Value |
|--------|-------|
| `use_promotable_queries.ts` | explicit `true` |
| `promotion_callout.tsx` | explicit `true` |
| `use_knowledge_indicators_task.ts` | explicit `true` |
| `use_bulk_onboarding.ts` | no arg (default `true`) |
| `use_onboarding_status_update_queue.ts` | no arg (default `true`) |
| `seed_tasks.ts` | hardcoded `true` |

### What changed

- Removed `saveQueries` from `OnboardingTaskParams` interface and `getOnboardingTaskId`
- Removed `saveQueries` query param from both onboarding routes (`POST _task` and `GET _status`)
- Removed `UseOnboardingApiOptions` interface and `saveQueries` option from the `useOnboardingApi` hook
- Removed explicit `{ saveQueries: true }` from all client-side callers
- Removed `saveQueries: true` from seed script task params
- Removed the `if (saveQueries)` guard around `persistQueries` — queries are now always persisted