### PR TITLE
[Entity Analytics] Wire abort signal into risk score maintainer

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/maintainer/risk_score_maintainer.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/maintainer/risk_score_maintainer.ts
@@ -340,7 +340,7 @@ const executeEntityTypeRun = async ({
   const runNow = new Date().toISOString();
   const runTag = toRunTag(calculationRunId);
   const runLogger = withLogContext(logger, `[risk_score_maintainer][${entityType}][run:${runTag}]`);
-  let runStatus: 'success' | 'error' = 'success';
+  let runStatus: 'success' | 'error' | 'aborted' = 'success';
   let runErrorKind: MaintainerErrorKind | undefined;
   const runMetrics = metricsTracker.newRun();
   const runTelemetry = telemetryReporter.forRun({
@@ -352,6 +352,9 @@ const executeEntityTypeRun = async ({
   const checkAbortBetweenStages = () => {
     if (abortSignal?.aborted) {
       runLogger.info('Risk score maintainer run aborted between stages');
+      if (runStatus === 'success') {
+        runStatus = 'aborted';
+      }
       skipRemainingStages = true;
     }
   };

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/maintainer/risk_score_maintainer.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/maintainer/risk_score_maintainer.ts
@@ -122,7 +122,7 @@ export const createRiskScoreMaintainer = ({
       logger.info(`Risk score maintainer setup completed for namespace "${namespace}"`);
       return status.state;
     },
-    run: async ({ status, crudClient }) => {
+    run: async ({ status, crudClient, abortController }) => {
       const runContext = await initializeRunContext({
         getStartServices,
         namespace: status.metadata.namespace,
@@ -156,10 +156,15 @@ export const createRiskScoreMaintainer = ({
       const metricsTracker = createRunMetricsTracker();
       telemetryReporter.clearGlobalSkipReason();
       for (const entityType of runConfig.entityTypes) {
+        if (abortController.signal.aborted) {
+          logger.info('Risk score maintainer run aborted before processing entity type');
+          break;
+        }
         await executeEntityTypeRun({
           entityType,
           crudClient,
           logger,
+          abortSignal: abortController.signal,
           telemetryReporter,
           metricsTracker,
           runContext,
@@ -315,6 +320,7 @@ const executeEntityTypeRun = async ({
   entityType,
   crudClient,
   logger,
+  abortSignal,
   telemetryReporter,
   metricsTracker,
   runContext,
@@ -323,6 +329,7 @@ const executeEntityTypeRun = async ({
   entityType: EntityType;
   crudClient: Parameters<NonNullable<RiskScoreMaintainerConfig['run']>>[0]['crudClient'];
   logger: Logger;
+  abortSignal?: AbortSignal;
   telemetryReporter: TelemetryReporter;
   metricsTracker: RunMetricsTracker;
   runContext: InitializedRunContext;
@@ -341,6 +348,13 @@ const executeEntityTypeRun = async ({
     entityType,
     idBasedRiskScoringEnabled: runConfig.idBasedRiskScoringEnabled,
   });
+  let skipRemainingStages = false;
+  const checkAbortBetweenStages = () => {
+    if (abortSignal?.aborted) {
+      runLogger.info('Risk score maintainer run aborted between stages');
+      skipRemainingStages = true;
+    }
+  };
 
   runLogger.debug('starting base scoring/reset pass');
   // Stage 1: score base entity risk and update lookup docs.
@@ -362,6 +376,7 @@ const executeEntityTypeRun = async ({
       pageSize: runConfig.pageSize,
       sampleSize: runConfig.sampleSize,
       watchlistConfigs: runConfig.watchlistConfigs,
+      abortSignal,
       idBasedRiskScoringEnabled: runConfig.idBasedRiskScoringEnabled,
       writer: runConfig.writer,
     });
@@ -388,107 +403,120 @@ const executeEntityTypeRun = async ({
     throw error;
   }
 
-  if (runMetrics.lookupDocsUpserted > 0) {
-    // Refresh so stage 2 can read the latest lookup docs.
-    await runContext.esClient.indices.refresh({ index: runContext.lookupIndex });
-    runLogger.debug(`refreshed lookup index after ${runMetrics.lookupDocsUpserted} upserts`);
-  }
+  checkAbortBetweenStages();
 
-  // Stage 2: score resolution targets (group scores).
-  const resolutionStage = runTelemetry.startResolutionStage();
-  try {
-    const resolutionResult = await runResolutionScoringStep({
-      esClient: runContext.esClient,
-      crudClient,
-      logger: runLogger,
-      entityType,
-      alertsIndex: runConfig.alertsIndex,
-      lookupIndex: runContext.lookupIndex,
-      pageSize: runConfig.pageSize,
-      sampleSize: runConfig.sampleSize,
-      now: runNow,
-      calculationRunId,
-      watchlistConfigs: runConfig.watchlistConfigs,
-      idBasedRiskScoringEnabled: runConfig.idBasedRiskScoringEnabled,
-      writer: runConfig.writer,
-    });
-    metricsTracker.recordResolution(runMetrics, resolutionResult);
-    if (resolutionResult.skippedReason) {
-      resolutionStage.skipped(resolutionResult.skippedReason);
-    } else {
-      resolutionStage.success({
-        pagesProcessed: resolutionResult.pagesProcessed,
-        scoresWritten: resolutionResult.scoresWritten,
-      });
+  if (!skipRemainingStages) {
+    if (runMetrics.lookupDocsUpserted > 0) {
+      // Refresh so stage 2 can read the latest lookup docs.
+      await runContext.esClient.indices.refresh({ index: runContext.lookupIndex });
+      runLogger.debug(`refreshed lookup index after ${runMetrics.lookupDocsUpserted} upserts`);
     }
-  } catch (error) {
-    const errorMessage = telemetryReporter.getErrorMessage(error);
-    runStatus = 'error';
-    runErrorKind = 'unexpected';
-    runLogger.error(`resolution scoring failed: ${errorMessage}`);
-    resolutionStage.error({ errorKind: 'unexpected' });
-  }
 
-  // Refresh the risk score data stream so reset-to-zero can see scores written in phases 1 & 2.
-  // Without this, the ES|QL query in reset may not see the new documents and could incorrectly
-  // zero out scores that were just written in this run.
-  const { alias: riskScoreAlias } = getIndexPatternDataStream(runContext.namespace);
-  await runContext.esClient.indices.refresh({ index: riskScoreAlias });
-
-  // Stage 3: reset stale positive scores not touched in this run.
-  if (runConfig.configuration.enableResetToZero !== false) {
-    const resetStage = runTelemetry.startResetStage();
+    // Stage 2: score resolution targets (group scores).
+    const resolutionStage = runTelemetry.startResolutionStage();
     try {
-      const resetResult = await resetToZero({
+      const resolutionResult = await runResolutionScoringStep({
         esClient: runContext.esClient,
-        writer: runConfig.writer,
-        spaceId: runContext.namespace,
-        entityType,
-        logger: runLogger,
-        idBasedRiskScoringEnabled: runConfig.idBasedRiskScoringEnabled,
         crudClient,
-        watchlistConfigs: runConfig.watchlistConfigs,
-        calculationRunId,
+        logger: runLogger,
+        entityType,
+        alertsIndex: runConfig.alertsIndex,
+        lookupIndex: runContext.lookupIndex,
+        pageSize: runConfig.pageSize,
+        sampleSize: runConfig.sampleSize,
         now: runNow,
+        calculationRunId,
+        watchlistConfigs: runConfig.watchlistConfigs,
+        abortSignal,
+        idBasedRiskScoringEnabled: runConfig.idBasedRiskScoringEnabled,
+        writer: runConfig.writer,
       });
-      metricsTracker.recordResetToZero(runMetrics, resetResult);
-      if (resetResult.scoresWritten > 0) {
-        runLogger.info(`reset ${resetResult.scoresWritten} stale risk scores to zero`);
+      metricsTracker.recordResolution(runMetrics, resolutionResult);
+      if (resolutionResult.skippedReason) {
+        resolutionStage.skipped(resolutionResult.skippedReason);
       } else {
-        runLogger.debug('reset_to_zero found no stale scores');
+        resolutionStage.success({
+          pagesProcessed: resolutionResult.pagesProcessed,
+          scoresWritten: resolutionResult.scoresWritten,
+        });
       }
-      resetStage.success({
-        scoresWritten: resetResult.scoresWritten,
-        resetBatchLimitHit: resetResult.resetBatchLimitHit,
-      });
     } catch (error) {
       const errorMessage = telemetryReporter.getErrorMessage(error);
       runStatus = 'error';
       runErrorKind = 'unexpected';
-      resetStage.error({ errorKind: 'unexpected' });
-      runLogger.error(`error resetting risk scores to zero: ${errorMessage}`);
+      runLogger.error(`resolution scoring failed: ${errorMessage}`);
+      resolutionStage.error({ errorKind: 'unexpected' });
     }
-  } else {
-    runLogger.debug('reset_to_zero disabled in configuration');
-    runTelemetry.startResetStage().skipped();
   }
 
-  // Final cleanup: remove old lookup docs outside the current risk window.
-  const riskWindowStart = runConfig.configuration.range?.start ?? 'now-30d';
-  try {
-    const prunedDocs = await pruneLookupIndex({
-      esClient: runContext.esClient,
-      index: runContext.lookupIndex,
-      riskWindowStart,
-    });
-    metricsTracker.recordPrune(runMetrics, prunedDocs);
-    if (prunedDocs > 0) {
-      runLogger.debug(`pruned ${prunedDocs} stale lookup documents`);
+  checkAbortBetweenStages();
+
+  if (!skipRemainingStages) {
+    // Refresh the risk score data stream so reset-to-zero can see scores written in phases 1 & 2.
+    // Without this, the ES|QL query in reset may not see the new documents and could incorrectly
+    // zero out scores that were just written in this run.
+    const { alias: riskScoreAlias } = getIndexPatternDataStream(runContext.namespace);
+    await runContext.esClient.indices.refresh({ index: riskScoreAlias });
+
+    // Stage 3: reset stale positive scores not touched in this run.
+    if (runConfig.configuration.enableResetToZero !== false) {
+      const resetStage = runTelemetry.startResetStage();
+      try {
+        const resetResult = await resetToZero({
+          esClient: runContext.esClient,
+          writer: runConfig.writer,
+          spaceId: runContext.namespace,
+          entityType,
+          logger: runLogger,
+          idBasedRiskScoringEnabled: runConfig.idBasedRiskScoringEnabled,
+          crudClient,
+          watchlistConfigs: runConfig.watchlistConfigs,
+          calculationRunId,
+          now: runNow,
+        });
+        metricsTracker.recordResetToZero(runMetrics, resetResult);
+        if (resetResult.scoresWritten > 0) {
+          runLogger.info(`reset ${resetResult.scoresWritten} stale risk scores to zero`);
+        } else {
+          runLogger.debug('reset_to_zero found no stale scores');
+        }
+        resetStage.success({
+          scoresWritten: resetResult.scoresWritten,
+          resetBatchLimitHit: resetResult.resetBatchLimitHit,
+        });
+      } catch (error) {
+        const errorMessage = telemetryReporter.getErrorMessage(error);
+        runStatus = 'error';
+        runErrorKind = 'unexpected';
+        resetStage.error({ errorKind: 'unexpected' });
+        runLogger.error(`error resetting risk scores to zero: ${errorMessage}`);
+      }
+    } else {
+      runLogger.debug('reset_to_zero disabled in configuration');
+      runTelemetry.startResetStage().skipped();
     }
-  } catch (error) {
-    runStatus = 'error';
-    runErrorKind = 'unexpected';
-    runLogger.error(`error pruning lookup index: ${telemetryReporter.getErrorMessage(error)}`);
+  }
+
+  checkAbortBetweenStages();
+
+  if (!skipRemainingStages) {
+    // Final cleanup: remove old lookup docs outside the current risk window.
+    const riskWindowStart = runConfig.configuration.range?.start ?? 'now-30d';
+    try {
+      const prunedDocs = await pruneLookupIndex({
+        esClient: runContext.esClient,
+        index: runContext.lookupIndex,
+        riskWindowStart,
+      });
+      metricsTracker.recordPrune(runMetrics, prunedDocs);
+      if (prunedDocs > 0) {
+        runLogger.debug(`pruned ${prunedDocs} stale lookup documents`);
+      }
+    } catch (error) {
+      runStatus = 'error';
+      runErrorKind = 'unexpected';
+      runLogger.error(`error pruning lookup index: ${telemetryReporter.getErrorMessage(error)}`);
+    }
   }
 
   runTelemetry.completionSummary({

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/maintainer/steps/run_resolution_scoring_step.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/maintainer/steps/run_resolution_scoring_step.ts
@@ -26,6 +26,7 @@ interface RunResolutionScoringParams {
   sampleSize: number;
   now: string;
   calculationRunId: string;
+  abortSignal?: AbortSignal;
   watchlistConfigs: Map<string, WatchlistObject>;
   idBasedRiskScoringEnabled: boolean;
   writer: Awaited<ReturnType<RiskScoreDataClient['getWriter']>>;
@@ -42,6 +43,7 @@ export const runResolutionScoringStep = async ({
   sampleSize,
   now,
   calculationRunId,
+  abortSignal,
   watchlistConfigs,
   idBasedRiskScoringEnabled,
   writer,
@@ -65,6 +67,10 @@ export const runResolutionScoringStep = async ({
     calculationRunId,
     watchlistConfigs,
   })) {
+    if (abortSignal?.aborted) {
+      runLogger.info('Resolution scoring aborted between pages');
+      break;
+    }
     pagesProcessed += 1;
     if (pageScores.length > 0) {
       scoresWrittenResolution += await persistScoresToRiskIndex({

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/maintainer/steps/score_base_entities.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/maintainer/steps/score_base_entities.ts
@@ -38,12 +38,14 @@ interface ScoreBaseEntitiesParams {
   now: string;
   watchlistConfigs: Map<string, WatchlistObject>;
   calculationRunId: string;
+  abortSignal?: AbortSignal;
 }
 
 interface ScoreAndPersistBaseEntitiesParams extends ScoreBaseEntitiesParams {
   writer: RiskEngineDataWriter;
   idBasedRiskScoringEnabled: boolean;
   lookupIndex: string;
+  abortSignal?: AbortSignal;
 }
 
 export interface Phase1BaseScoringSummary extends StepResult {
@@ -82,11 +84,16 @@ export const calculateBaseEntityScores = async function* ({
   now,
   watchlistConfigs,
   calculationRunId,
+  abortSignal,
 }: ScoreBaseEntitiesParams): AsyncGenerator<ScoredEntityPage> {
   let afterKey: Record<string, string> | undefined;
   let previousPageUpperBound: string | undefined;
 
   do {
+    if (abortSignal?.aborted) {
+      logger.info('Base scoring aborted between pages');
+      return;
+    }
     // Per page: find this page's start/end IDs for scoring, then apply entity modifiers.
     const pageResult = await fetchNextEuidPage({
       esClient,

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/maintainer/telemetry_reporter.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/maintainer/telemetry_reporter.ts
@@ -231,7 +231,7 @@ export const createRiskScoreMaintainerTelemetryReporter = ({
         });
       },
       completionSummary: (input: {
-        runStatus: 'success' | 'error';
+        runStatus: 'success' | 'error' | 'aborted';
         runErrorKind?: MaintainerErrorKind;
         scoresWrittenBase: number;
         scoresWrittenResolution: number;


### PR DESCRIPTION
## Summary
- wire `abortController` from the entity maintainer framework into risk score maintainer execution and pass `abortSignal` downstream
- add abort checkpoints between entity types, between maintainer stages, and between pagination pages in base + resolution scoring steps
- preserve partial run completion logging and report aborted runs via existing maintainer telemetry status (`status: aborted`) without schema expansion

## Manual test steps
1. In `x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/maintainer/register_risk_score_maintainer.ts`, temporarily set `timeout` to `1m`.
2. Ensure Kibana file logging is enabled (for example appender target: `/tmp/kibana-perf.log`) and restart Kibana.
3. Seed perf data from `~/dev/security-documents-generator`:
   - `yarn start risk-score-v2 --perf --dangerous-clean --no-follow-on --space default`
4. Inspect logs and confirm abort behavior:
   - base pagination logs followed by `Base scoring aborted between pages`
   - `Risk score maintainer run aborted between stages`
   - `Risk score maintainer run aborted before processing entity type`
   - run summary log includes `"status":"aborted"` with partial metrics
5. Revert timeout back to `45m`.