### PR TITLE
[Security][Workflows] Register workflow steps synchronously using async loaders

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/plugin.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/plugin.tsx
@@ -76,6 +76,7 @@ import { defaultDeepLinks } from './app/links/default_deep_links';
 import { AIValueReportLocatorDefinition } from '../common/locators/ai_value_report/locator';
 import { registerAttachmentUiDefinitions } from './agent_builder/attachment_types';
 import { registerRuleAttachment } from './agent_builder/attachment_types/rule_attachment';
+import { registerWorkflowSteps } from './workflows/step_types';
 
 export class Plugin implements IPlugin<PluginSetup, PluginStart, SetupPlugins, StartPlugins> {
   private config: SecuritySolutionUiConfigType;
@@ -127,20 +128,8 @@ export class Plugin implements IPlugin<PluginSetup, PluginStart, SetupPlugins, S
       share.url.locators.create(new AIValueReportLocatorDefinition());
     }
 
-    // Register workflow steps
     if (workflowsExtensions) {
-      import('./workflows/step_types')
-        .then(async ({ registerWorkflowSteps }) => {
-          const [coreStart] = await core.getStartServices();
-          return registerWorkflowSteps(workflowsExtensions, coreStart);
-        })
-        .catch((error) => {
-          this.logger.error(
-            `Error registering security workflow steps: ${
-              error instanceof Error ? error.message : String(error)
-            }`
-          );
-        });
+      registerWorkflowSteps(workflowsExtensions, core);
     }
 
     // Lazily instantiate subPlugins and initialize services

--- a/x-pack/solutions/security/plugins/security_solution/public/workflows/jest.config.js
+++ b/x-pack/solutions/security/plugins/security_solution/public/workflows/jest.config.js
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+module.exports = {
+  preset: '@kbn/test',
+  rootDir: '../../../../../../..',
+  roots: ['<rootDir>/x-pack/solutions/security/plugins/security_solution/public/workflows'],
+  coverageDirectory:
+    '<rootDir>/target/kibana-coverage/jest/x-pack/solutions/security/plugins/security_solution/public/workflows',
+  coverageReporters: ['text', 'html'],
+  collectCoverageFrom: [
+    '<rootDir>/x-pack/solutions/security/plugins/security_solution/public/workflows/**/*.{ts,tsx}',
+  ],
+  moduleNameMapper: require('../../server/__mocks__/module_name_map'),
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/workflows/step_types/register_workflow_steps.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/workflows/step_types/register_workflow_steps.test.ts
@@ -41,7 +41,8 @@ describe('registerWorkflowSteps (public)', () => {
     registerWorkflowSteps(workflowsExtensions, core);
 
     expect(workflowsExtensions.registerStepDefinition).toHaveBeenCalledTimes(2);
-    expect(core.getStartServices).not.toHaveBeenCalled();
+    // getStartServices is called once eagerly to create the shared memoized promise
+    expect(core.getStartServices).toHaveBeenCalledTimes(1);
   });
 
   it('async loader returns step definitions when feature flag is enabled', async () => {
@@ -72,17 +73,18 @@ describe('registerWorkflowSteps (public)', () => {
     await expect(loader2()).resolves.toBeUndefined();
   });
 
-  it('checks the correct feature flag key and default value', async () => {
+  it('checks the feature flag exactly once even when both loaders resolve', async () => {
     const { core, coreStart } = buildCoreMock(true);
     const workflowsExtensions = createWorkflowsExtensionsMock();
 
     registerWorkflowSteps(workflowsExtensions, core);
 
-    const [loader] = workflowsExtensions.registerStepDefinition.mock.calls.map(
+    const [loader1, loader2] = workflowsExtensions.registerStepDefinition.mock.calls.map(
       ([arg]) => arg as StepLoader
     );
-    await loader();
+    await Promise.all([loader1(), loader2()]);
 
+    expect(coreStart.featureFlags.getBooleanValue).toHaveBeenCalledTimes(1);
     expect(coreStart.featureFlags.getBooleanValue).toHaveBeenCalledWith(
       REGISTER_ALERT_VALIDATION_STEPS_FEATURE_FLAG,
       REGISTER_ALERT_VALIDATION_STEP_FEATURE_FLAG_DEFAULT

--- a/x-pack/solutions/security/plugins/security_solution/public/workflows/step_types/register_workflow_steps.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/workflows/step_types/register_workflow_steps.test.ts
@@ -1,0 +1,91 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { coreMock } from '@kbn/core/public/mocks';
+import type {
+  WorkflowsExtensionsPublicPluginSetup,
+  PublicStepDefinition,
+} from '@kbn/workflows-extensions/public';
+import { registerWorkflowSteps } from './register_workflow_steps';
+import { renderAlertNarrativeStepDefinition } from './render_alert_narrative_step';
+import { buildAlertEntityGraphStepDefinition } from './build_alert_entity_graph_step';
+import {
+  REGISTER_ALERT_VALIDATION_STEPS_FEATURE_FLAG,
+  REGISTER_ALERT_VALIDATION_STEP_FEATURE_FLAG_DEFAULT,
+} from '../../../common/constants';
+
+type StepLoader = () => Promise<PublicStepDefinition | undefined>;
+
+const createWorkflowsExtensionsMock = (): jest.Mocked<WorkflowsExtensionsPublicPluginSetup> => ({
+  registerStepDefinition: jest.fn(),
+  registerTriggerDefinition: jest.fn(),
+});
+
+describe('registerWorkflowSteps (public)', () => {
+  const buildCoreMock = (featureFlagEnabled: boolean) => {
+    const core = coreMock.createSetup();
+    const coreStart = coreMock.createStart();
+    coreStart.featureFlags.getBooleanValue.mockReturnValue(featureFlagEnabled);
+    core.getStartServices.mockResolvedValue([coreStart, {}, {}]);
+    return { core, coreStart };
+  };
+
+  it('calls registerStepDefinition synchronously for both steps', () => {
+    const { core } = buildCoreMock(true);
+    const workflowsExtensions = createWorkflowsExtensionsMock();
+
+    registerWorkflowSteps(workflowsExtensions, core);
+
+    expect(workflowsExtensions.registerStepDefinition).toHaveBeenCalledTimes(2);
+    expect(core.getStartServices).not.toHaveBeenCalled();
+  });
+
+  it('async loader returns step definitions when feature flag is enabled', async () => {
+    const { core } = buildCoreMock(true);
+    const workflowsExtensions = createWorkflowsExtensionsMock();
+
+    registerWorkflowSteps(workflowsExtensions, core);
+
+    const [loader1, loader2] = workflowsExtensions.registerStepDefinition.mock.calls.map(
+      ([arg]) => arg as StepLoader
+    );
+
+    await expect(loader1()).resolves.toBe(renderAlertNarrativeStepDefinition);
+    await expect(loader2()).resolves.toBe(buildAlertEntityGraphStepDefinition);
+  });
+
+  it('async loader returns undefined when feature flag is disabled', async () => {
+    const { core } = buildCoreMock(false);
+    const workflowsExtensions = createWorkflowsExtensionsMock();
+
+    registerWorkflowSteps(workflowsExtensions, core);
+
+    const [loader1, loader2] = workflowsExtensions.registerStepDefinition.mock.calls.map(
+      ([arg]) => arg as StepLoader
+    );
+
+    await expect(loader1()).resolves.toBeUndefined();
+    await expect(loader2()).resolves.toBeUndefined();
+  });
+
+  it('checks the correct feature flag key and default value', async () => {
+    const { core, coreStart } = buildCoreMock(true);
+    const workflowsExtensions = createWorkflowsExtensionsMock();
+
+    registerWorkflowSteps(workflowsExtensions, core);
+
+    const [loader] = workflowsExtensions.registerStepDefinition.mock.calls.map(
+      ([arg]) => arg as StepLoader
+    );
+    await loader();
+
+    expect(coreStart.featureFlags.getBooleanValue).toHaveBeenCalledWith(
+      REGISTER_ALERT_VALIDATION_STEPS_FEATURE_FLAG,
+      REGISTER_ALERT_VALIDATION_STEP_FEATURE_FLAG_DEFAULT
+    );
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/workflows/step_types/register_workflow_steps.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/workflows/step_types/register_workflow_steps.ts
@@ -32,11 +32,15 @@ export const registerWorkflowSteps = (
 
   workflowsExtensions.registerStepDefinition(async () => {
     if (!(await isEnabled)) return undefined;
-    return import('./render_alert_narrative_step').then((m) => m.renderAlertNarrativeStepDefinition);
+    return import('./render_alert_narrative_step').then(
+      (m) => m.renderAlertNarrativeStepDefinition
+    );
   });
 
   workflowsExtensions.registerStepDefinition(async () => {
     if (!(await isEnabled)) return undefined;
-    return import('./build_alert_entity_graph_step').then((m) => m.buildAlertEntityGraphStepDefinition);
+    return import('./build_alert_entity_graph_step').then(
+      (m) => m.buildAlertEntityGraphStepDefinition
+    );
   });
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/workflows/step_types/register_workflow_steps.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/workflows/step_types/register_workflow_steps.ts
@@ -23,21 +23,22 @@ export const registerWorkflowSteps = (
   workflowsExtensions: WorkflowsExtensionsPublicPluginSetup,
   core: CoreSetup
 ): void => {
-  const isEnabled = async () => {
-    const [coreStart] = await core.getStartServices();
-    return coreStart.featureFlags.getBooleanValue(
-      REGISTER_ALERT_VALIDATION_STEPS_FEATURE_FLAG,
-      REGISTER_ALERT_VALIDATION_STEP_FEATURE_FLAG_DEFAULT
+  const isEnabled = core
+    .getStartServices()
+    .then(([coreStart]) =>
+      coreStart.featureFlags.getBooleanValue(
+        REGISTER_ALERT_VALIDATION_STEPS_FEATURE_FLAG,
+        REGISTER_ALERT_VALIDATION_STEP_FEATURE_FLAG_DEFAULT
+      )
     );
-  };
 
   workflowsExtensions.registerStepDefinition(async () => {
-    if (!(await isEnabled())) return undefined;
+    if (!(await isEnabled)) return undefined;
     return renderAlertNarrativeStepDefinition;
   });
 
   workflowsExtensions.registerStepDefinition(async () => {
-    if (!(await isEnabled())) return undefined;
+    if (!(await isEnabled)) return undefined;
     return buildAlertEntityGraphStepDefinition;
   });
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/workflows/step_types/register_workflow_steps.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/workflows/step_types/register_workflow_steps.ts
@@ -6,7 +6,7 @@
  */
 
 import type { WorkflowsExtensionsPublicPluginSetup } from '@kbn/workflows-extensions/public';
-import type { CoreStart } from '@kbn/core/public';
+import type { CoreSetup } from '@kbn/core/public';
 import { renderAlertNarrativeStepDefinition } from './render_alert_narrative_step';
 import { buildAlertEntityGraphStepDefinition } from './build_alert_entity_graph_step';
 import {
@@ -15,19 +15,29 @@ import {
 } from '../../../common/constants';
 
 /**
- * Registers all security workflow steps with the workflowsExtensions plugin
+ * Registers all security workflow steps with the workflowsExtensions plugin.
+ * Registration is synchronous; each step uses an async loader to perform the
+ * feature-flag check at resolution time.
  */
-export const registerWorkflowSteps = async (
+export const registerWorkflowSteps = (
   workflowsExtensions: WorkflowsExtensionsPublicPluginSetup,
-  core: CoreStart
-): Promise<void> => {
-  const registerAlertValidationStepsEnabled = await core.featureFlags.getBooleanValue(
-    REGISTER_ALERT_VALIDATION_STEPS_FEATURE_FLAG,
-    REGISTER_ALERT_VALIDATION_STEP_FEATURE_FLAG_DEFAULT
-  );
+  core: CoreSetup
+): void => {
+  const isEnabled = async () => {
+    const [coreStart] = await core.getStartServices();
+    return coreStart.featureFlags.getBooleanValue(
+      REGISTER_ALERT_VALIDATION_STEPS_FEATURE_FLAG,
+      REGISTER_ALERT_VALIDATION_STEP_FEATURE_FLAG_DEFAULT
+    );
+  };
 
-  if (registerAlertValidationStepsEnabled) {
-    workflowsExtensions.registerStepDefinition(renderAlertNarrativeStepDefinition);
-    workflowsExtensions.registerStepDefinition(buildAlertEntityGraphStepDefinition);
-  }
+  workflowsExtensions.registerStepDefinition(async () => {
+    if (!(await isEnabled())) return undefined;
+    return renderAlertNarrativeStepDefinition;
+  });
+
+  workflowsExtensions.registerStepDefinition(async () => {
+    if (!(await isEnabled())) return undefined;
+    return buildAlertEntityGraphStepDefinition;
+  });
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/workflows/step_types/register_workflow_steps.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/workflows/step_types/register_workflow_steps.ts
@@ -7,8 +7,6 @@
 
 import type { WorkflowsExtensionsPublicPluginSetup } from '@kbn/workflows-extensions/public';
 import type { CoreSetup } from '@kbn/core/public';
-import { renderAlertNarrativeStepDefinition } from './render_alert_narrative_step';
-import { buildAlertEntityGraphStepDefinition } from './build_alert_entity_graph_step';
 import {
   REGISTER_ALERT_VALIDATION_STEPS_FEATURE_FLAG,
   REGISTER_ALERT_VALIDATION_STEP_FEATURE_FLAG_DEFAULT,
@@ -34,11 +32,11 @@ export const registerWorkflowSteps = (
 
   workflowsExtensions.registerStepDefinition(async () => {
     if (!(await isEnabled)) return undefined;
-    return renderAlertNarrativeStepDefinition;
+    return import('./render_alert_narrative_step').then((m) => m.renderAlertNarrativeStepDefinition);
   });
 
   workflowsExtensions.registerStepDefinition(async () => {
     if (!(await isEnabled)) return undefined;
-    return buildAlertEntityGraphStepDefinition;
+    return import('./build_alert_entity_graph_step').then((m) => m.buildAlertEntityGraphStepDefinition);
   });
 };

--- a/x-pack/solutions/security/plugins/security_solution/server/plugin.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/plugin.ts
@@ -820,20 +820,7 @@ export class Plugin implements ISecuritySolutionPlugin {
     this.registerAgentBuilderAttachmentsAndTools(plugins, core, this.logger);
 
     if (plugins.workflowsExtensions) {
-      const workflowsExtensions = plugins.workflowsExtensions;
-      core
-        .getStartServices()
-        .then(async ([coreStart]) => {
-          await registerWorkflowSteps(workflowsExtensions, coreStart);
-        })
-        .catch((error) => {
-          this.logger.error(
-            `[RegisterAlertValidationSteps] Error registering alert validation steps: ${error.message}`,
-            {
-              error: error.stack,
-            }
-          );
-        });
+      registerWorkflowSteps(plugins.workflowsExtensions, core);
     }
 
     setupAlertsCapabilitiesSwitcher({

--- a/x-pack/solutions/security/plugins/security_solution/server/workflows/step_types/register_workflow_steps.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/workflows/step_types/register_workflow_steps.test.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { coreMock } from '@kbn/core/server/mocks';
+import type {
+  WorkflowsExtensionsServerPluginSetup,
+  ServerStepDefinition,
+} from '@kbn/workflows-extensions/server';
+import { registerWorkflowSteps } from './register_workflow_steps';
+import { renderAlertNarrativeStepDefinition } from './render_alert_narrative_step';
+import { buildAlertEntityGraphStepDefinition } from './build_alert_entity_graph_step';
+import {
+  REGISTER_ALERT_VALIDATION_STEPS_FEATURE_FLAG,
+  REGISTER_ALERT_VALIDATION_STEP_FEATURE_FLAG_DEFAULT,
+} from '../../../common/constants';
+
+type StepLoader = () => Promise<ServerStepDefinition | undefined>;
+
+const createWorkflowsExtensionsMock = (): jest.Mocked<WorkflowsExtensionsServerPluginSetup> => ({
+  registerStepDefinition: jest.fn(),
+  registerTriggerDefinition: jest.fn(),
+  registerTriggerEventHandler: jest.fn(),
+});
+
+describe('registerWorkflowSteps (server)', () => {
+  const buildCoreMock = (featureFlagEnabled: boolean) => {
+    const core = coreMock.createSetup();
+    const coreStart = coreMock.createStart();
+    coreStart.featureFlags.getBooleanValue.mockResolvedValue(featureFlagEnabled);
+    core.getStartServices.mockResolvedValue([coreStart, {}, {}]);
+    return { core, coreStart };
+  };
+
+  it('calls registerStepDefinition synchronously for both steps', () => {
+    const { core } = buildCoreMock(true);
+    const workflowsExtensions = createWorkflowsExtensionsMock();
+
+    registerWorkflowSteps(workflowsExtensions, core);
+
+    expect(workflowsExtensions.registerStepDefinition).toHaveBeenCalledTimes(2);
+    expect(core.getStartServices).not.toHaveBeenCalled();
+  });
+
+  it('async loader returns step definitions when feature flag is enabled', async () => {
+    const { core } = buildCoreMock(true);
+    const workflowsExtensions = createWorkflowsExtensionsMock();
+
+    registerWorkflowSteps(workflowsExtensions, core);
+
+    const [loader1, loader2] = workflowsExtensions.registerStepDefinition.mock.calls.map(
+      ([arg]) => arg as StepLoader
+    );
+
+    await expect(loader1()).resolves.toBe(renderAlertNarrativeStepDefinition);
+    await expect(loader2()).resolves.toBe(buildAlertEntityGraphStepDefinition);
+  });
+
+  it('async loader returns undefined when feature flag is disabled', async () => {
+    const { core } = buildCoreMock(false);
+    const workflowsExtensions = createWorkflowsExtensionsMock();
+
+    registerWorkflowSteps(workflowsExtensions, core);
+
+    const [loader1, loader2] = workflowsExtensions.registerStepDefinition.mock.calls.map(
+      ([arg]) => arg as StepLoader
+    );
+
+    await expect(loader1()).resolves.toBeUndefined();
+    await expect(loader2()).resolves.toBeUndefined();
+  });
+
+  it('checks the correct feature flag key and default value', async () => {
+    const { core, coreStart } = buildCoreMock(true);
+    const workflowsExtensions = createWorkflowsExtensionsMock();
+
+    registerWorkflowSteps(workflowsExtensions, core);
+
+    const [loader] = workflowsExtensions.registerStepDefinition.mock.calls.map(
+      ([arg]) => arg as StepLoader
+    );
+    await loader();
+
+    expect(coreStart.featureFlags.getBooleanValue).toHaveBeenCalledWith(
+      REGISTER_ALERT_VALIDATION_STEPS_FEATURE_FLAG,
+      REGISTER_ALERT_VALIDATION_STEP_FEATURE_FLAG_DEFAULT
+    );
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/server/workflows/step_types/register_workflow_steps.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/workflows/step_types/register_workflow_steps.test.ts
@@ -42,7 +42,8 @@ describe('registerWorkflowSteps (server)', () => {
     registerWorkflowSteps(workflowsExtensions, core);
 
     expect(workflowsExtensions.registerStepDefinition).toHaveBeenCalledTimes(2);
-    expect(core.getStartServices).not.toHaveBeenCalled();
+    // getStartServices is called once eagerly to create the shared memoized promise
+    expect(core.getStartServices).toHaveBeenCalledTimes(1);
   });
 
   it('async loader returns step definitions when feature flag is enabled', async () => {
@@ -73,17 +74,18 @@ describe('registerWorkflowSteps (server)', () => {
     await expect(loader2()).resolves.toBeUndefined();
   });
 
-  it('checks the correct feature flag key and default value', async () => {
+  it('checks the feature flag exactly once even when both loaders resolve', async () => {
     const { core, coreStart } = buildCoreMock(true);
     const workflowsExtensions = createWorkflowsExtensionsMock();
 
     registerWorkflowSteps(workflowsExtensions, core);
 
-    const [loader] = workflowsExtensions.registerStepDefinition.mock.calls.map(
+    const [loader1, loader2] = workflowsExtensions.registerStepDefinition.mock.calls.map(
       ([arg]) => arg as StepLoader
     );
-    await loader();
+    await Promise.all([loader1(), loader2()]);
 
+    expect(coreStart.featureFlags.getBooleanValue).toHaveBeenCalledTimes(1);
     expect(coreStart.featureFlags.getBooleanValue).toHaveBeenCalledWith(
       REGISTER_ALERT_VALIDATION_STEPS_FEATURE_FLAG,
       REGISTER_ALERT_VALIDATION_STEP_FEATURE_FLAG_DEFAULT

--- a/x-pack/solutions/security/plugins/security_solution/server/workflows/step_types/register_workflow_steps.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/workflows/step_types/register_workflow_steps.ts
@@ -23,21 +23,22 @@ export const registerWorkflowSteps = (
   workflowsExtensions: WorkflowsExtensionsServerPluginSetup,
   core: CoreSetup
 ): void => {
-  const isEnabled = async () => {
-    const [coreStart] = await core.getStartServices();
-    return coreStart.featureFlags.getBooleanValue(
-      REGISTER_ALERT_VALIDATION_STEPS_FEATURE_FLAG,
-      REGISTER_ALERT_VALIDATION_STEP_FEATURE_FLAG_DEFAULT
+  const isEnabled = core
+    .getStartServices()
+    .then(([coreStart]) =>
+      coreStart.featureFlags.getBooleanValue(
+        REGISTER_ALERT_VALIDATION_STEPS_FEATURE_FLAG,
+        REGISTER_ALERT_VALIDATION_STEP_FEATURE_FLAG_DEFAULT
+      )
     );
-  };
 
   workflowsExtensions.registerStepDefinition(async () => {
-    if (!(await isEnabled())) return undefined;
+    if (!(await isEnabled)) return undefined;
     return renderAlertNarrativeStepDefinition;
   });
 
   workflowsExtensions.registerStepDefinition(async () => {
-    if (!(await isEnabled())) return undefined;
+    if (!(await isEnabled)) return undefined;
     return buildAlertEntityGraphStepDefinition;
   });
 };

--- a/x-pack/solutions/security/plugins/security_solution/server/workflows/step_types/register_workflow_steps.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/workflows/step_types/register_workflow_steps.ts
@@ -6,7 +6,7 @@
  */
 
 import type { WorkflowsExtensionsServerPluginSetup } from '@kbn/workflows-extensions/server';
-import type { CoreStart } from '@kbn/core/server';
+import type { CoreSetup } from '@kbn/core/server';
 import { renderAlertNarrativeStepDefinition } from './render_alert_narrative_step';
 import { buildAlertEntityGraphStepDefinition } from './build_alert_entity_graph_step';
 import {
@@ -15,19 +15,29 @@ import {
 } from '../../../common/constants';
 
 /**
- * Registers all security workflow steps with the workflowsExtensions plugin
+ * Registers all security workflow steps with the workflowsExtensions plugin.
+ * Registration is synchronous; each step uses an async loader to perform the
+ * feature-flag check at resolution time.
  */
-export const registerWorkflowSteps = async (
+export const registerWorkflowSteps = (
   workflowsExtensions: WorkflowsExtensionsServerPluginSetup,
-  coreStart: CoreStart
-): Promise<void> => {
-  const registerAlertValidationStepsEnabled = await coreStart.featureFlags.getBooleanValue(
-    REGISTER_ALERT_VALIDATION_STEPS_FEATURE_FLAG,
-    REGISTER_ALERT_VALIDATION_STEP_FEATURE_FLAG_DEFAULT
-  );
+  core: CoreSetup
+): void => {
+  const isEnabled = async () => {
+    const [coreStart] = await core.getStartServices();
+    return coreStart.featureFlags.getBooleanValue(
+      REGISTER_ALERT_VALIDATION_STEPS_FEATURE_FLAG,
+      REGISTER_ALERT_VALIDATION_STEP_FEATURE_FLAG_DEFAULT
+    );
+  };
 
-  if (registerAlertValidationStepsEnabled) {
-    workflowsExtensions.registerStepDefinition(renderAlertNarrativeStepDefinition);
-    workflowsExtensions.registerStepDefinition(buildAlertEntityGraphStepDefinition);
-  }
+  workflowsExtensions.registerStepDefinition(async () => {
+    if (!(await isEnabled())) return undefined;
+    return renderAlertNarrativeStepDefinition;
+  });
+
+  workflowsExtensions.registerStepDefinition(async () => {
+    if (!(await isEnabled())) return undefined;
+    return buildAlertEntityGraphStepDefinition;
+  });
 };


### PR DESCRIPTION
## Summary

Follows up on elastic/kibana#264788 (merged by @semd) which added async-loader support to the `ServerStepRegistry` and `PublicStepRegistry`.

Previously, `registerStepDefinition` was called inside a deferred `getStartServices().then()` callback — meaning registration happened *after* the `setup()` lifecycle completed. semd flagged this as problematic in review comments on #259159 ([comment 1](https://github.com/elastic/kibana/pull/259159#discussion_r3118152108), [comment 2](https://github.com/elastic/kibana/pull/259159#discussion_r3118166290)).

This PR applies the fix on the security_solution side: `registerStepDefinition` is now called **synchronously** during `setup()`. Each step is registered with an async loader that checks the feature flag at resolution time and returns `undefined` to skip registration when the flag is disabled.

Changes on both server and public sides:
- `registerWorkflowSteps` is now a synchronous function accepting `CoreSetup` instead of `CoreStart`
- Each step is wrapped in an async loader that defers the feature-flag check to resolution time
- `plugin.ts` / `plugin.tsx` call `registerWorkflowSteps` directly in `setup()` (no deferred `.then()`)
- New unit tests for both server and public `registerWorkflowSteps`

## Test plan

- [ ] `node scripts/jest x-pack/solutions/security/plugins/security_solution/server/workflows/step_types/register_workflow_steps.test.ts`
- [ ] `node scripts/jest x-pack/solutions/security/plugins/security_solution/public/workflows/step_types/register_workflow_steps.test.ts`
- [ ] Confirm no regression in existing workflow step tests