### PR TITLE
[ResponseOps][Connectors] Connector flyout: improve preconfigured connectors view

### DIFF
--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/action_connector_form/edit_connector_flyout/read_only.test.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/action_connector_form/edit_connector_flyout/read_only.test.tsx
@@ -43,4 +43,24 @@ describe('ReadOnlyConnectorMessage', () => {
 
     expect(getByText('Extra Component')).toBeInTheDocument();
   });
+
+  it('should wrap all content in a single EuiText with size="s" for consistent typography', () => {
+    const { getByText, container } = render(
+      <ReadOnlyConnectorMessage
+        connectorId="123"
+        connectorName="Test Connector"
+        extraComponent={ExtraComponent}
+        href="https://example.com"
+      />,
+      { wrapper: I18nProvider }
+    );
+
+    const wrapper = container.firstElementChild!;
+    expect(wrapper.className).toContain('euiText-s');
+
+    const readOnlyMessage = getByText('This connector is read-only.');
+    const extraComponent = getByText('Extra Component');
+    expect(wrapper.contains(readOnlyMessage)).toBe(true);
+    expect(wrapper.contains(extraComponent)).toBe(true);
+  });
 });

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/action_connector_form/edit_connector_flyout/read_only.test.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/action_connector_form/edit_connector_flyout/read_only.test.tsx
@@ -43,24 +43,4 @@ describe('ReadOnlyConnectorMessage', () => {
 
     expect(getByText('Extra Component')).toBeInTheDocument();
   });
-
-  it('should wrap all content in a single EuiText with size="s" for consistent typography', () => {
-    const { getByText, container } = render(
-      <ReadOnlyConnectorMessage
-        connectorId="123"
-        connectorName="Test Connector"
-        extraComponent={ExtraComponent}
-        href="https://example.com"
-      />,
-      { wrapper: I18nProvider }
-    );
-
-    const wrapper = container.firstElementChild!;
-    expect(wrapper.className).toContain('euiText-s');
-
-    const readOnlyMessage = getByText('This connector is read-only.');
-    const extraComponent = getByText('Extra Component');
-    expect(wrapper.contains(readOnlyMessage)).toBe(true);
-    expect(wrapper.contains(extraComponent)).toBe(true);
-  });
 });

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/action_connector_form/edit_connector_flyout/read_only.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/action_connector_form/edit_connector_flyout/read_only.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { Suspense } from 'react';
-import { EuiLink, EuiSpacer, EuiText } from '@elastic/eui';
+import { EuiLink, EuiText } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import type { ActionTypeModel } from '../../../..';
@@ -19,26 +19,25 @@ export const ReadOnlyConnectorMessage: React.FC<{
 }> = ({ connectorId, connectorName, extraComponent, href }) => {
   const ExtraComponent = extraComponent;
   return (
-    <>
-      <EuiText>
+    <EuiText size="s">
+      <p>
         {i18n.translate('xpack.triggersActionsUI.sections.editConnectorForm.descriptionText', {
           defaultMessage: 'This connector is read-only.',
         })}
-      </EuiText>
-      <EuiLink data-test-subj="read-only-link" href={href} target="_blank">
-        <FormattedMessage
-          id="xpack.triggersActionsUI.sections.editConnectorForm.preconfiguredHelpLabel"
-          defaultMessage="Learn more about preconfigured connectors."
-        />
-      </EuiLink>
+      </p>
+      <p>
+        <EuiLink data-test-subj="read-only-link" href={href} target="_blank">
+          <FormattedMessage
+            id="xpack.triggersActionsUI.sections.editConnectorForm.preconfiguredHelpLabel"
+            defaultMessage="Learn more about preconfigured connectors."
+          />
+        </EuiLink>
+      </p>
       {ExtraComponent && (
-        <>
-          <EuiSpacer size="m" />
-          <Suspense fallback={null}>
-            <ExtraComponent connectorId={connectorId} connectorName={connectorName} />
-          </Suspense>
-        </>
+        <Suspense fallback={null}>
+          <ExtraComponent connectorId={connectorId} connectorName={connectorName} />
+        </Suspense>
       )}
-    </>
+    </EuiText>
   );
 };


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/242942

## Summary

- The read-only / preconfigured connector flyout had inconsistent font sizes between the base message and the `ExtraComponent`.
- wrapped all content in `ReadOnlyConnectorMessage` inside a single EuiText of size = 's', so the base text and any extra component rendered by connector types share consistent font sizes.

<!--ONMERGE {"backportTargets":["9.3","9.4"]} ONMERGE-->