### PR TITLE
fix(workflows): use textSubdued for YAML editor line numbers

### DIFF
--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/styles/use_workflows_monaco_theme.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/styles/use_workflows_monaco_theme.ts
@@ -41,7 +41,7 @@ export function useWorkflowsMonacoTheme() {
         'editor.hoverHighlightBackground': chroma(
           transparentize(euiTheme.colors.primary, 0.15)
         ).hex(),
-        'editorLineNumber.foreground': euiTheme.colors.textPrimary,
+        'editorLineNumber.foreground': euiTheme.colors.textSubdued,
         'editorLineNumber.activeForeground': euiTheme.colors.textSubdued,
         'editorIndentGuide.background1': euiTheme.colors.backgroundLightText,
         'editorIndentGuide.activeBackground1': euiTheme.colors.borderBaseDisabled,


### PR DESCRIPTION
Before 
<img width="80" height="189" alt="image" src="https://github.com/user-attachments/assets/d7c564a8-1b69-4738-ab67-101567ec1c6d" />


After.
<img width="403" height="253" alt="image" src="https://github.com/user-attachments/assets/6b9a6376-7365-48ae-a3a8-a6f9fda75599" />


## Summary

Line numbers in the Workflow YAML editor were rendered using `euiTheme.colors.textPrimary` (blue), which is semantically reserved for primary interactive content and links — not decorative gutter text.

This single-line change switches to `euiTheme.colors.textSubdued`, the standard EUI token for de-emphasized supporting text, making the gutter consistent with conventional editor UX (VS Code, Ace, CodeMirror all use subdued gutter colors).

**Before:** line numbers appear in primary blue  
**After:** line numbers appear in subdued gray

## Test plan

- [ ] Open Workflows in Kibana dev
- [ ] Verify YAML editor line numbers are gray (subdued), not blue
- [ ] Verify active line number remains subdued (was already correct)
- [ ] Check both light and dark EUI color modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)