### PR TITLE
Replace 'target entity' with 'primary entity' in resolution UI

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution/confirm_resolution_modal.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution/confirm_resolution_modal.tsx
@@ -84,7 +84,7 @@ export const ConfirmResolutionModal: React.FC<ConfirmResolutionModalProps> = ({
         <EuiText size="s">
           {i18n.translate('xpack.securitySolution.entityResolution.confirmModal.description', {
             defaultMessage:
-              'Both entity records will be maintained, but one will become the target entity for this resolution group.',
+              'Both entity records will be maintained, but one will become the primary entity for this resolution group.',
           })}
         </EuiText>
         <EuiSpacer size="m" />

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution/entity_resolution_tab.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution/entity_resolution_tab.tsx
@@ -27,7 +27,7 @@ export const EntityResolutionTab: React.FC = () => {
         <EuiText size="s">
           <FormattedMessage
             id="xpack.securitySolution.entityAnalytics.entityResolution.uploadDescription"
-            defaultMessage="Bulk link entities to resolution targets by importing a CSV file. Each row uses identity fields to find matching entities and links them to a target entity specified by its entity ID."
+            defaultMessage="Bulk link entities to resolution targets by importing a CSV file. Each row uses identity fields to find matching entities and links them to a primary entity specified by its entity ID."
           />
         </EuiText>
         <EuiSpacer size="s" />
@@ -46,7 +46,7 @@ const WhatIsEntityResolutionPanel: React.FC = () => {
       <EuiText size="s">
         <FormattedMessage
           id="xpack.securitySolution.entityAnalytics.entityResolution.introText"
-          defaultMessage="Use a CSV file to batch-link entity records that represent the same real-world identity. Aliases are matched by identity fields and linked to a target entity."
+          defaultMessage="Use a CSV file to batch-link entity records that represent the same real-world identity. Aliases are matched by identity fields and linked to a primary entity."
         />
       </EuiText>
       <EuiSpacer size="l" />
@@ -65,7 +65,7 @@ const WhatIsEntityResolutionPanel: React.FC = () => {
       <EuiText size="s">
         <FormattedMessage
           id="xpack.securitySolution.entityAnalytics.entityResolution.whatIsDescription"
-          defaultMessage="Entity resolution links multiple entity records that represent the same real-world identity across different data sources. For example, a user may appear as separate entities from Active Directory, Okta, and Entra ID. Resolution groups these aliases under a single target entity, providing a unified view for risk scoring, investigation, and threat detection."
+          defaultMessage="Entity resolution links multiple entity records that represent the same real-world identity across different data sources. For example, a user may appear as separate entities from Active Directory, Okta, and Entra ID. Resolution groups these aliases under a single primary entity, providing a unified view for risk scoring, investigation, and threat detection."
         />
       </EuiText>
       <EuiHorizontalRule />

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution/translations.ts
@@ -69,12 +69,12 @@ export const REMOVE_ENTITY_BUTTON = i18n.translate(
 
 export const TARGET_ENTITY_TOOLTIP = i18n.translate(
   'xpack.securitySolution.entityResolution.targetEntityTooltip',
-  { defaultMessage: 'This is the target entity for this resolution group' }
+  { defaultMessage: 'This is the primary entity for this resolution group' }
 );
 
 export const CANNOT_REMOVE_TARGET_TOOLTIP = i18n.translate(
   'xpack.securitySolution.entityResolution.cannotRemoveTarget',
-  { defaultMessage: 'The target entity cannot be removed from the resolution group' }
+  { defaultMessage: 'The primary entity cannot be removed from the resolution group' }
 );
 
 export const ADD_ENTITIES_TITLE = i18n.translate(

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution_file_uploader/components/file_picker_step.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_resolution_file_uploader/components/file_picker_step.tsx
@@ -103,7 +103,7 @@ export const EntityResolutionFilePickerStep: React.FC<FilePickerStepProps> = Rea
             </li>
             <li>
               <FormattedMessage
-                defaultMessage="{resolvedTo}: The {entityId} of the target entity"
+                defaultMessage="{resolvedTo}: The {entityId} of the primary entity"
                 id="xpack.securitySolution.entityAnalytics.entityResolutionUpload.resolvedToColumn"
                 values={{
                   resolvedTo: <b>{'resolved_to'}</b>,


### PR DESCRIPTION
## Summary

Replaces "target entity" wording with "primary entity" across all entity resolution UI text (tooltips, modals, descriptions) to align with the design language.

Fixes https://github.com/elastic/security-team/issues/16994

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

No risks — text-only changes to i18n strings with no logic or API changes.

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->