### PR TITLE
fix(monaco): use EUI backgroundLightWarning for word highlight color

### DIFF
--- a/src/platform/packages/shared/kbn-monaco/src/code_editor/theme.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/code_editor/theme.ts
@@ -8,6 +8,7 @@
  */
 
 import type { UseEuiTheme } from '@elastic/eui';
+import chroma from 'chroma-js';
 import type { monaco } from '../..';
 
 export function createTheme(
@@ -99,6 +100,8 @@ export function createTheme(
       'list.hoverBackground': euiTheme.colors.backgroundBaseSubdued,
       'list.highlightForeground': euiTheme.colors.primary,
       'editor.lineHighlightBorder': euiTheme.colors.lightestShade,
+      'editor.wordHighlightBackground': chroma(euiTheme.colors.backgroundLightWarning).hex(),
+      'editor.wordHighlightStrongBackground': chroma(euiTheme.colors.backgroundLightWarning).hex(),
       'editorHoverWidget.foreground': euiTheme.colors.darkestShade,
       'editorHoverWidget.background': euiTheme.colors.backgroundBaseSubdued,
       'diffEditor.insertedTextBackground': euiTheme.colors.borderBaseSuccess,


### PR DESCRIPTION
## Summary

Word occurrence highlights (the gray boxes shown when you click on a word in any Monaco editor) were using Monaco's built-in default gray color.

This replaces it with `euiTheme.colors.backgroundLightWarning` — a soft yellow EUI semantic token — making the highlight visually distinct and consistent with the EUI design system.

The change applies to **all `CodeEditor` instances** across Kibana (YAML editor, Dev Console, JSON inputs, ES|QL, etc.) since it targets the shared base theme in `@kbn/monaco`.

`chroma-js` is used to convert the EUI color token to hex since Monaco's theme API only accepts hex color values.

## Test plan

- [ ] Open any Monaco-based editor in Kibana (Workflows, Dev Console, ES|QL)
- [ ] Click on any word
- [ ] Verify all occurrences highlight in soft yellow instead of gray
- [ ] Verify both light and dark EUI color modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)