### PR TITLE
[One Workflow]: Use textSubdued for YAML editor line numbers

### DIFF
--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/styles/use_workflows_monaco_theme.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/styles/use_workflows_monaco_theme.ts
@@ -41,7 +41,7 @@ export function useWorkflowsMonacoTheme() {
         'editor.hoverHighlightBackground': chroma(
           transparentize(euiTheme.colors.primary, 0.15)
         ).hex(),
-        'editorLineNumber.foreground': euiTheme.colors.textPrimary,
+        'editorLineNumber.foreground': euiTheme.colors.textSubdued,
         'editorLineNumber.activeForeground': euiTheme.colors.textSubdued,
         'editorIndentGuide.background1': euiTheme.colors.backgroundLightText,
         'editorIndentGuide.activeBackground1': euiTheme.colors.borderBaseDisabled,


### PR DESCRIPTION
## Summary

Line numbers in the Workflow YAML editor were rendered using `euiTheme.colors.textPrimary` (blue), which is semantically reserved for primary interactive content — not decorative gutter text.

This changes it to `euiTheme.colors.textSubdued`, the standard EUI token for de-emphasized supporting text, making the gutter consistent with conventional editor UX and with how the active line number was already styled.

**Before:** line numbers appear in primary blue
**After:** line numbers appear in subdued gray

## Test plan

- [ ] Open Workflows YAML editor in Kibana dev
- [ ] Verify line numbers are gray (subdued), not blue
- [ ] Verify active line number remains subdued (was already correct)
- [ ] Check both light and dark EUI color modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->