### PR TITLE
[Security Solution][TEST-ONLY] isolate bulk edit suppression cy test for MKI

### DIFF
--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/cypress_ci_serverless_qa.config.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/cypress_ci_serverless_qa.config.ts
@@ -39,7 +39,8 @@ export default defineCypressConfig({
     baseUrl: 'http://localhost:5601',
     experimentalCspAllowList: ['default-src', 'script-src', 'script-src-elem'],
     experimentalMemoryManagement: true,
-    specPattern: './cypress/e2e/**/*.cy.ts',
+    specPattern:
+      './cypress/e2e/detection_response/rule_management/rule_actions/bulk_actions/bulk_edit_rules_suppression_essentials_serverless.cy.ts',
     setupNodeEvents(on, config) {
       esArchiver(on, config);
       samlAuthentication(on, config);

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/cypress_ci_serverless_qa.config.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/cypress_ci_serverless_qa.config.ts
@@ -39,8 +39,7 @@ export default defineCypressConfig({
     baseUrl: 'http://localhost:5601',
     experimentalCspAllowList: ['default-src', 'script-src', 'script-src-elem'],
     experimentalMemoryManagement: true,
-    specPattern:
-      './cypress/e2e/detection_response/rule_management/rule_actions/bulk_actions/bulk_edit_rules_suppression_essentials_serverless.cy.ts',
+    specPattern: './cypress/e2e/**/*.cy.ts',
     setupNodeEvents(on, config) {
       esArchiver(on, config);
       samlAuthentication(on, config);

--- a/x-pack/solutions/security/test/security_solution_cypress/package.json
+++ b/x-pack/solutions/security/test/security_solution_cypress/package.json
@@ -104,7 +104,7 @@
     "cypress:run:qa:serverless:rule_management:maintenance_windows": "yarn cypress:qa:serverless --spec './cypress/e2e/detection_response/rule_management/maintenance_windows/**/*.cy.ts'",
     "cypress:run:qa:serverless:rule_management:prebuilt_rules": "yarn cypress:qa:serverless --spec './cypress/e2e/detection_response/rule_management/prebuilt_rules/**/*.cy.ts'",
     "cypress:run:qa:serverless:rule_management:related_integrations": "yarn cypress:qa:serverless --spec './cypress/e2e/detection_response/rule_management/related_integrations/**/*.cy.ts'",
-    "cypress:run:qa:serverless:rule_management:rule_actions": "yarn cypress:qa:serverless --spec './cypress/e2e/detection_response/rule_management/rule_actions/**/*.cy.ts'",
+    "cypress:run:qa:serverless:rule_management:rule_actions": "yarn cypress:qa:serverless --spec './cypress/e2e/detection_response/rule_management/rule_actions/bulk_actions/bulk_edit_rules_suppression_essentials_serverless.cy.ts'",
     "cypress:run:qa:serverless:rule_management:rule_details": "yarn cypress:qa:serverless --spec './cypress/e2e/detection_response/rule_management/rule_details/**/*.cy.ts'",
     "cypress:run:qa:serverless:rule_management:rules_table": "yarn cypress:qa:serverless --spec './cypress/e2e/detection_response/rule_management/rules_table/**/*.cy.ts'"
   }


### PR DESCRIPTION
## Summary

**Do not merge.** Test-only branch to reproduce the periodic MKI flake on a single spec.

Restricts the QA/MKI cypress config `specPattern` to:
`x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/bulk_actions/bulk_edit_rules_suppression_essentials_serverless.cy.ts`

The spec has been failing in periodic MKI (Serverless) since at least Apr 9, with repeated fails on Apr 19 and 21 on the `euiComboBoxPill` selector. #261164 (merged Apr 10) passed the flaky test runner but did not fix the MKI failures.

## Test plan

- [ ] Trigger periodic MKI against this branch to confirm the flake still reproduces with only this spec running

🤖 Generated with [Claude Code](https://claude.com/claude-code)