### PR TITLE
[Security Solution] Fix flaky bulk edit alert suppression Cypress tests on MKI

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation/components/alert_suppression_edit/components/alert_suppression_edit.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation/components/alert_suppression_edit/components/alert_suppression_edit.tsx
@@ -21,6 +21,7 @@ interface AlertSuppressionEditProps {
   disabledText?: string;
   warningText?: string;
   fullWidth?: boolean;
+  isLoading?: boolean;
 }
 
 export const AlertSuppressionEdit = memo(function AlertSuppressionEdit({
@@ -30,6 +31,7 @@ export const AlertSuppressionEdit = memo(function AlertSuppressionEdit({
   disabledText,
   warningText,
   fullWidth,
+  isLoading,
 }: AlertSuppressionEditProps): JSX.Element {
   const [{ [ALERT_SUPPRESSION_FIELDS_FIELD_NAME]: suppressionFields }] = useFormData<{
     [ALERT_SUPPRESSION_FIELDS_FIELD_NAME]: string[];
@@ -44,6 +46,7 @@ export const AlertSuppressionEdit = memo(function AlertSuppressionEdit({
         labelAppend={labelAppend}
         disabled={disabled}
         fullWidth={fullWidth}
+        isLoading={isLoading}
       />
       {warningText && (
         <EuiText size="xs" color="warning" data-test-subj="alertSuppressionWarning">

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation/components/alert_suppression_edit/components/suppression_fields_selector.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation/components/alert_suppression_edit/components/suppression_fields_selector.tsx
@@ -18,6 +18,7 @@ interface SuppressionFieldsSelectorProps {
   labelAppend?: React.ReactNode;
   disabled?: boolean;
   fullWidth?: boolean;
+  isLoading?: boolean;
 }
 
 export function SuppressionFieldsSelector({
@@ -25,6 +26,7 @@ export function SuppressionFieldsSelector({
   labelAppend,
   disabled,
   fullWidth,
+  isLoading,
 }: SuppressionFieldsSelectorProps): JSX.Element {
   return (
     <EuiFormRow
@@ -42,6 +44,7 @@ export function SuppressionFieldsSelector({
             isDisabled: disabled,
             fullWidth,
             ariaLabel: i18n.ALERT_SUPPRESSION_SUPPRESS_BY_FIELD_LABEL,
+            isLoading,
           }}
         />
       </>

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation_ui/components/multi_select_fields/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation_ui/components/multi_select_fields/index.tsx
@@ -60,10 +60,10 @@ export const MultiSelectAutocompleteComponent: React.FC<MultiSelectAutocompleteP
    * options lits.
    */
   useEffect(() => {
-    if (isDisabled) {
+    if (isDisabled || isLoading) {
       comboBoxRef.current?.closeList();
     }
-  }, [isDisabled]);
+  }, [isDisabled, isLoading]);
 
   return (
     <ComboBoxField

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation_ui/components/multi_select_fields/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation_ui/components/multi_select_fields/index.tsx
@@ -19,6 +19,7 @@ interface MultiSelectAutocompleteProps {
   fullWidth?: boolean;
   dataTestSubj?: string;
   ariaLabel?: string;
+  isLoading?: boolean;
 }
 
 const FIELD_COMBO_BOX_WIDTH = 410;
@@ -32,6 +33,7 @@ export const MultiSelectAutocompleteComponent: React.FC<MultiSelectAutocompleteP
   fullWidth = false,
   dataTestSubj,
   ariaLabel,
+  isLoading,
 }: MultiSelectAutocompleteProps) => {
   const comboBoxRef = useRef<EuiComboBox<unknown>>();
   const fieldEuiFieldProps = useMemo(
@@ -42,11 +44,12 @@ export const MultiSelectAutocompleteComponent: React.FC<MultiSelectAutocompleteP
       placeholder: FIELD_PLACEHOLDER,
       onCreateOption: undefined,
       ...(fullWidth ? {} : { style: { width: `${FIELD_COMBO_BOX_WIDTH}px` } }),
-      isDisabled,
+      isDisabled: isDisabled || isLoading,
+      isLoading,
       ref: comboBoxRef,
       'aria-label': ariaLabel ?? field.label,
     }),
-    [browserFields, isDisabled, fullWidth, comboBoxRef, ariaLabel, field.label]
+    [browserFields, isDisabled, isLoading, fullWidth, comboBoxRef, ariaLabel, field.label]
   );
 
   /**

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/bulk_actions/forms/set_alert_suppression_form.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/bulk_actions/forms/set_alert_suppression_form.tsx
@@ -84,7 +84,7 @@ export const SetAlertSuppressionForm = React.memo(function SetAlertSuppressionFo
   const { uiSettings } = useKibana().services;
   const defaultPatterns = uiSettings.get<string[]>(DEFAULT_INDEX_KEY);
 
-  const [_, { indexPatterns }] = useFetchIndex(defaultPatterns, false);
+  const [isFetchingIndexFields, { indexPatterns }] = useFetchIndex(defaultPatterns, false);
   const suppressibleFields = useTermsAggregationFields(indexPatterns?.fields);
 
   const handleSubmit = async () => {
@@ -129,7 +129,11 @@ export const SetAlertSuppressionForm = React.memo(function SetAlertSuppressionFo
       </EuiFlexGroup>
       <EuiSpacer size="l" />
 
-      <AlertSuppressionEdit suppressibleFields={suppressibleFields} fullWidth />
+      <AlertSuppressionEdit
+        suppressibleFields={suppressibleFields}
+        isLoading={isFetchingIndexFields}
+        fullWidth
+      />
     </BulkEditFormWrapper>
   );
 });

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/create_new_rule.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/create_new_rule.ts
@@ -963,14 +963,16 @@ export const fillAlertSuppressionFields = (fields: string[], checkFieldsInComboB
       cy.get(COMBO_BOX_OPTION).should('contain.text', field);
     }
 
-    cy.get(ALERT_SUPPRESSION_FIELDS_COMBO_BOX).type(`${field}{downArrow}{enter}`);
-    // Wait for the field to be selected as a pill before closing the dropdown,
-    // otherwise {esc} can race with {enter} and cancel the selection
+    // Type only — do not use {downArrow}{enter}. On slow environments (MKI) the
+    // option list can rebuild mid-type when the index fetch resolves, which
+    // resets the active highlight and turns {enter} into a no-op.
+    cy.get(ALERT_SUPPRESSION_FIELDS_COMBO_BOX).type(field);
+    cy.get(COMBO_BOX_OPTION).contains(field).click();
     cy.get(ALERT_SUPPRESSION_FIELDS_COMBO_BOX)
       .find('[data-test-subj="euiComboBoxPill"]')
       .should('contain.text', field);
-    cy.get(ALERT_SUPPRESSION_FIELDS_COMBO_BOX).type('{esc}');
   });
+  cy.get(ALERT_SUPPRESSION_FIELDS_COMBO_BOX).type('{esc}');
 };
 
 export const clearAlertSuppressionFields = () => {

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/create_new_rule.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/create_new_rule.ts
@@ -966,6 +966,8 @@ export const fillAlertSuppressionFields = (fields: string[], checkFieldsInComboB
     cy.get(ALERT_SUPPRESSION_FIELDS_COMBO_BOX).type(field);
     // Using a click instead of keyboard navigation to avoid potential focus loss when page is still loading
     cy.contains(COMBO_BOX_OPTION, field).click();
+    // Wait for the field to be selected as a pill before closing the dropdown,
+    // otherwise {esc} can race with {enter} and cancel the selection
     cy.get(ALERT_SUPPRESSION_FIELDS_COMBO_BOX)
       .find('[data-test-subj="euiComboBoxPill"]')
       .should('contain.text', field);

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/create_new_rule.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/create_new_rule.ts
@@ -963,13 +963,8 @@ export const fillAlertSuppressionFields = (fields: string[], checkFieldsInComboB
       cy.get(COMBO_BOX_OPTION).should('contain.text', field);
     }
 
-    // Type only — do not use {downArrow}{enter}. On slow environments (MKI) the
-    // option list can rebuild mid-type when the index fetch resolves, which
-    // resets the active highlight and turns {enter} into a no-op.
     cy.get(ALERT_SUPPRESSION_FIELDS_COMBO_BOX).type(field);
-    // Use the contains(selector, text) overload so the yielded element is the
-    // option button, not the inner <mark> highlight — the mark is
-    // pointer-events: none and breaks cy.click().
+    // Using a click instead of keyboard navigation to avoid potential focus loss when page is still loading
     cy.contains(COMBO_BOX_OPTION, field).click();
     cy.get(ALERT_SUPPRESSION_FIELDS_COMBO_BOX)
       .find('[data-test-subj="euiComboBoxPill"]')

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/create_new_rule.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/create_new_rule.ts
@@ -967,7 +967,10 @@ export const fillAlertSuppressionFields = (fields: string[], checkFieldsInComboB
     // option list can rebuild mid-type when the index fetch resolves, which
     // resets the active highlight and turns {enter} into a no-op.
     cy.get(ALERT_SUPPRESSION_FIELDS_COMBO_BOX).type(field);
-    cy.get(COMBO_BOX_OPTION).contains(field).click();
+    // Use the contains(selector, text) overload so the yielded element is the
+    // option button, not the inner <mark> highlight — the mark is
+    // pointer-events: none and breaks cy.click().
+    cy.contains(COMBO_BOX_OPTION, field).click();
     cy.get(ALERT_SUPPRESSION_FIELDS_COMBO_BOX)
       .find('[data-test-subj="euiComboBoxPill"]')
       .should('contain.text', field);


### PR DESCRIPTION
## Summary

This PR fixes flaky Cypress test that's failing in MKI periodic pipeline. The test is testing a bulk action to add alert suppression to rules. Test fails because it tries to use to select a dropdown item, while the request that fetches the data for the dropdown is still in flight.

<img width="1920" height="1113" alt="Bulk Edit - Alert Suppression -- Rules without suppression -- Set alert suppression (failed)" src="https://github.com/user-attachments/assets/4955c446-a5d8-4fbc-bde4-209f78da1eae" />

The main fix is to disable the dropdown while loading is in progress. An additional fix is to use a click to select a dropdown item instead of doing it via keyboard. Keyboard focus can potentially switch to something else during page load.

🟢 [Ran a bunch of times](https://buildkite.com/elastic/kibana-serverless-security-solution-quality-gate-rule-management/builds?branch=refs%2Fpull%2F265262) through the MKI pipeline (where it used to fail)
🟢 [Ran](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/11874) through a normal Flaky Test Runner too.
🟢 Normal CI pipeline also lookin' nice and green.




<!--ONMERGE {"backportTargets":["8.19","9.2","9.3","9.4"]} ONMERGE-->