### PR TITLE
Update status badge labels from "Error" to "Failed" in dashboards and…

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/dashboards/components/status_badge/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/dashboards/components/status_badge/index.test.tsx
@@ -20,13 +20,13 @@ describe('StatusBadge', () => {
     expect(getByText('Installed')).toBeInTheDocument();
   });
 
-  it('renders "Error" when status is FAILED', () => {
+  it('renders "Failed" when status is FAILED', () => {
     const dashboard = getDashboardMigrationDashboardMock({
       elastic_dashboard: undefined,
       status: SiemMigrationStatus.FAILED,
     });
     const { getByText } = render(<StatusBadge dashboard={dashboard} />);
-    expect(getByText('Error')).toBeInTheDocument();
+    expect(getByText('Failed')).toBeInTheDocument();
   });
 
   it('shows tooltip with comment on failed translation', async () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/dashboards/components/status_badge/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/dashboards/components/status_badge/translations.ts
@@ -17,6 +17,6 @@ export const DASHBOARD_STATUS_INSTALLED = i18n.translate(
 export const DASHBOARD_STATUS_FAILED = i18n.translate(
   'xpack.securitySolution.siemMigrations.dashboards.status.failedLabel',
   {
-    defaultMessage: 'Error',
+    defaultMessage: 'Failed',
   }
 );

--- a/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/rules/components/status_badge/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/rules/components/status_badge/index.test.tsx
@@ -26,7 +26,7 @@ describe('StatusBadge', () => {
       status: SiemMigrationStatus.FAILED,
     });
     const { getByText } = render(<StatusBadge migrationRule={rule} />);
-    expect(getByText('Error')).toBeInTheDocument();
+    expect(getByText('Failed')).toBeInTheDocument();
   });
 
   it('shows tooltip with comment on failed translation', async () => {
@@ -44,7 +44,7 @@ describe('StatusBadge', () => {
     });
     const { getByText, findByText } = render(<StatusBadge migrationRule={rule} />);
 
-    fireEvent.mouseOver(getByText('Error'));
+    fireEvent.mouseOver(getByText('Failed'));
 
     const tooltip = await findByText(errorMessage);
     expect(tooltip).toBeInTheDocument();

--- a/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/rules/components/status_badge/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/rules/components/status_badge/translations.ts
@@ -17,6 +17,6 @@ export const RULE_STATUS_INSTALLED = i18n.translate(
 export const RULE_STATUS_FAILED = i18n.translate(
   'xpack.securitySolution.siemMigrations.rules.status.failedLabel',
   {
-    defaultMessage: 'Error',
+    defaultMessage: 'Failed',
   }
 );


### PR DESCRIPTION

## Summary

Issue and steps to reproduce:

https://github.com/elastic/kibana/issues/263730


<img width="2553" height="1229" alt="Screenshot 2026-04-23 at 12 23 11" src="https://github.com/user-attachments/assets/f9f86392-4fec-41ad-8482-642232a02fb5" />

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios



<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->