### PR TITLE
[Security Solution] Fix Attack Discovery schedule showing 'changes not saved' after successful save

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/details_flyout/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/details_flyout/index.test.tsx
@@ -26,6 +26,9 @@ jest.mock('../logic/use_update_schedule');
 jest.mock('../logic/use_get_schedule');
 jest.mock('../../../../../common/lib/kibana');
 jest.mock('../../../../../sourcerer/containers');
+jest.mock('../utils/convert_form_data', () => ({
+  convertFormDataInBaseSchedule: jest.fn().mockReturnValue({}),
+}));
 jest.mock('react-router-dom', () => ({
   matchPath: jest.fn(),
   useLocation: jest.fn().mockReturnValue({
@@ -225,6 +228,59 @@ describe('DetailsFlyout', () => {
 
       // Verify the confirmation modal is shown
       expect(screen.getByTestId('confirmationModal')).toBeInTheDocument();
+    });
+  });
+
+  describe('after a successful save', () => {
+    beforeEach(() => {
+      // Override connectors to include the connector that matches the mock schedule's connectorId
+      (useLoadConnectors as jest.Mock).mockReturnValue({
+        isLoading: false,
+        data: [
+          {
+            id: mockAttackDiscoverySchedule.params.apiConfig.connectorId,
+            name: mockAttackDiscoverySchedule.params.apiConfig.name,
+            actionTypeId: mockAttackDiscoverySchedule.params.apiConfig.actionTypeId,
+          },
+        ],
+      });
+    });
+
+    it('should clear unsaved changes so close does not prompt confirmation modal', async () => {
+      await renderComponent();
+
+      // Enter edit mode
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('edit'));
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('attackDiscoveryScheduleForm')).toBeInTheDocument();
+      });
+
+      // Simulate unsaved changes
+      act(() => {
+        fireEvent.change(screen.getByTestId('alertsRange'), { target: { value: 'changed' } });
+      });
+
+      // Save changes
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('save'));
+      });
+
+      // Wait for save to complete — form disappears when setIsEditing(false) is called
+      await waitFor(() => {
+        expect(screen.queryByTestId('attackDiscoveryScheduleForm')).not.toBeInTheDocument();
+      });
+
+      // Close the flyout
+      act(() => {
+        fireEvent.click(screen.getByTestId('euiFlyoutCloseButton'));
+      });
+
+      // Confirmation modal must NOT appear — unsaved changes flag should have been cleared on save
+      expect(screen.queryByTestId('confirmationModal')).not.toBeInTheDocument();
+      expect(defaultProps.onClose).toHaveBeenCalled();
     });
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/details_flyout/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/details_flyout/index.tsx
@@ -111,6 +111,7 @@ export const DetailsFlyout: React.FC<Props> = React.memo(({ scheduleId, onClose 
           experimentalDataView
         );
         await updateAttackDiscoverySchedule({ id: scheduleId, scheduleToUpdate });
+        setHasUnsavedChanges(false);
         setIsEditing(false);
       } catch (err) {
         // Error is handled by the mutation's onError callback, so no need to do anything here


### PR DESCRIPTION
## Summary

Fixes #247665

After successfully saving an Attack Discovery schedule, the `hasUnsavedChanges` flag was not being reset to `false`. This caused the "Discard unsaved changes?" confirmation modal to appear when the user closed the details flyout, even though the save had already succeeded.

**Root cause:** In `DetailsFlyout`, the `onUpdateSchedule` callback called `setIsEditing(false)` after a successful API response but never called `setHasUnsavedChanges(false)`.

**Fix:** Reset `hasUnsavedChanges` to `false` immediately after the schedule update succeeds, before exiting edit mode.

## Changes

- `details_flyout/index.tsx`: Add `setHasUnsavedChanges(false)` after a successful `updateAttackDiscoverySchedule` call.
- `details_flyout/index.test.tsx`: Add a TDD test that verifies closing the flyout after a successful save does not show the confirmation modal.

## Test plan

- [x] New Jest unit test added: `DetailsFlyout > after a successful save > should clear unsaved changes so close does not prompt confirmation modal`
- [x] All existing `DetailsFlyout` tests continue to pass (14/14)
- [x] `node scripts/check_changes.ts` passes (lint + pre-commit checks)

## Steps to verify manually

1. Navigate to Security → Attack Discovery
2. Open an existing schedule
3. Edit any field and click **Save**
4. After save succeeds, click the **✕** close button
5. **Expected:** Flyout closes immediately with no confirmation modal
6. **Before fix:** "Discard unsaved changes?" modal appeared even though changes were already saved

<!--ONMERGE {"backportTargets":["8.19","9.3","9.4"]} ONMERGE-->