### PR TITLE
[SigEvents] Move EMPTY_TOKENS to @kbn/streams-ai and refactor sumTokens

### DIFF
--- a/x-pack/platform/packages/shared/kbn-streams-ai/index.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-ai/index.ts
@@ -31,7 +31,7 @@ export {
   createDefaultSignificantEventsToolUsage,
   type SignificantEventsToolUsage,
 } from './src/significant_events/tools/tool_usage';
-export { sumTokens } from './src/helpers/sum_tokens';
+export { EMPTY_TOKENS, sumTokens } from './src/helpers/sum_tokens';
 export {
   identifyFeatures,
   toPreviouslyIdentifiedFeature,

--- a/x-pack/platform/packages/shared/kbn-streams-ai/src/features/identify_features.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-ai/src/features/identify_features.ts
@@ -19,7 +19,7 @@ import { withSpan } from '@kbn/apm-utils';
 import { conditionSchema, isConditionComplete, type Condition } from '@kbn/streamlang';
 import { createIdentifyFeaturesPrompt } from './prompt';
 import { formatRawDocument } from './utils/format_raw_document';
-import { EMPTY_TOKENS, sumTokens } from '../helpers/sum_tokens';
+import { sumTokens } from '../helpers/sum_tokens';
 
 export interface PreviouslyIdentifiedFeature {
   id: string;
@@ -130,7 +130,7 @@ export async function identifyFeatures({
   return {
     features,
     ignoredFeatures,
-    tokensUsed: sumTokens(EMPTY_TOKENS, response.tokens),
+    tokensUsed: sumTokens({ added: response.tokens }),
   };
 }
 

--- a/x-pack/platform/packages/shared/kbn-streams-ai/src/features/identify_features.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-ai/src/features/identify_features.ts
@@ -19,7 +19,7 @@ import { withSpan } from '@kbn/apm-utils';
 import { conditionSchema, isConditionComplete, type Condition } from '@kbn/streamlang';
 import { createIdentifyFeaturesPrompt } from './prompt';
 import { formatRawDocument } from './utils/format_raw_document';
-import { sumTokens } from '../helpers/sum_tokens';
+import { EMPTY_TOKENS, sumTokens } from '../helpers/sum_tokens';
 
 export interface PreviouslyIdentifiedFeature {
   id: string;
@@ -130,7 +130,7 @@ export async function identifyFeatures({
   return {
     features,
     ignoredFeatures,
-    tokensUsed: sumTokens({ prompt: 0, completion: 0, total: 0, cached: 0 }, response.tokens),
+    tokensUsed: sumTokens(EMPTY_TOKENS, response.tokens),
   };
 }
 

--- a/x-pack/platform/packages/shared/kbn-streams-ai/src/helpers/sum_tokens.test.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-ai/src/helpers/sum_tokens.test.ts
@@ -11,8 +11,8 @@ describe('sumTokens', () => {
   const a = { prompt: 10, completion: 20, total: 30, cached: 5 };
   const b = { prompt: 3, completion: 7, total: 10, cached: 2 };
 
-  it('sums total and added', () => {
-    expect(sumTokens({ total: a, added: b })).toEqual({
+  it('sums accumulated and added', () => {
+    expect(sumTokens({ accumulated: a, added: b })).toEqual({
       prompt: 13,
       completion: 27,
       total: 40,
@@ -20,12 +20,12 @@ describe('sumTokens', () => {
     });
   });
 
-  it('defaults total to EMPTY_TOKENS when only added is provided', () => {
+  it('defaults accumulated to EMPTY_TOKENS when only added is provided', () => {
     expect(sumTokens({ added: b })).toEqual(b);
   });
 
-  it('returns total unchanged when only total is provided', () => {
-    expect(sumTokens({ total: a })).toEqual(a);
+  it('returns accumulated unchanged when only accumulated is provided', () => {
+    expect(sumTokens({ accumulated: a })).toEqual(a);
   });
 
   it('returns EMPTY_TOKENS when neither param is provided', () => {
@@ -34,7 +34,7 @@ describe('sumTokens', () => {
 
   it('treats missing cached on added as 0', () => {
     const noCached = { prompt: 1, completion: 2, total: 3 };
-    expect(sumTokens({ total: a, added: noCached })).toEqual({
+    expect(sumTokens({ accumulated: a, added: noCached })).toEqual({
       prompt: 11,
       completion: 22,
       total: 33,
@@ -42,9 +42,9 @@ describe('sumTokens', () => {
     });
   });
 
-  it('treats missing cached on total as 0', () => {
+  it('treats missing cached on accumulated as 0', () => {
     const noCached = { prompt: 1, completion: 2, total: 3 };
-    expect(sumTokens({ total: noCached, added: b })).toEqual({
+    expect(sumTokens({ accumulated: noCached, added: b })).toEqual({
       prompt: 4,
       completion: 9,
       total: 13,

--- a/x-pack/platform/packages/shared/kbn-streams-ai/src/helpers/sum_tokens.test.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-ai/src/helpers/sum_tokens.test.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EMPTY_TOKENS, sumTokens } from './sum_tokens';
+
+describe('sumTokens', () => {
+  const a = { prompt: 10, completion: 20, total: 30, cached: 5 };
+  const b = { prompt: 3, completion: 7, total: 10, cached: 2 };
+
+  it('sums total and added', () => {
+    expect(sumTokens({ total: a, added: b })).toEqual({
+      prompt: 13,
+      completion: 27,
+      total: 40,
+      cached: 7,
+    });
+  });
+
+  it('defaults total to EMPTY_TOKENS when only added is provided', () => {
+    expect(sumTokens({ added: b })).toEqual(b);
+  });
+
+  it('returns total unchanged when only total is provided', () => {
+    expect(sumTokens({ total: a })).toEqual(a);
+  });
+
+  it('returns EMPTY_TOKENS when neither param is provided', () => {
+    expect(sumTokens({})).toEqual(EMPTY_TOKENS);
+  });
+
+  it('treats missing cached on added as 0', () => {
+    const noCached = { prompt: 1, completion: 2, total: 3 };
+    expect(sumTokens({ total: a, added: noCached })).toEqual({
+      prompt: 11,
+      completion: 22,
+      total: 33,
+      cached: 5,
+    });
+  });
+
+  it('treats missing cached on total as 0', () => {
+    const noCached = { prompt: 1, completion: 2, total: 3 };
+    expect(sumTokens({ total: noCached, added: b })).toEqual({
+      prompt: 4,
+      completion: 9,
+      total: 13,
+      cached: 2,
+    });
+  });
+});

--- a/x-pack/platform/packages/shared/kbn-streams-ai/src/helpers/sum_tokens.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-ai/src/helpers/sum_tokens.ts
@@ -15,16 +15,16 @@ export const EMPTY_TOKENS: ChatCompletionTokenCount = {
 };
 
 export function sumTokens({
-  total = EMPTY_TOKENS,
+  accumulated = EMPTY_TOKENS,
   added,
 }: {
-  total?: ChatCompletionTokenCount;
+  accumulated?: ChatCompletionTokenCount;
   added?: ChatCompletionTokenCount;
 }): ChatCompletionTokenCount {
   return {
-    completion: total.completion + (added?.completion ?? 0),
-    prompt: total.prompt + (added?.prompt ?? 0),
-    total: total.total + (added?.total ?? 0),
-    cached: (total.cached ?? 0) + (added?.cached ?? 0),
+    completion: accumulated.completion + (added?.completion ?? 0),
+    prompt: accumulated.prompt + (added?.prompt ?? 0),
+    total: accumulated.total + (added?.total ?? 0),
+    cached: (accumulated.cached ?? 0) + (added?.cached ?? 0),
   };
 }

--- a/x-pack/platform/packages/shared/kbn-streams-ai/src/helpers/sum_tokens.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-ai/src/helpers/sum_tokens.ts
@@ -14,14 +14,17 @@ export const EMPTY_TOKENS: ChatCompletionTokenCount = {
   cached: 0,
 };
 
-export function sumTokens(
-  a: ChatCompletionTokenCount,
-  b?: ChatCompletionTokenCount
-): ChatCompletionTokenCount {
+export function sumTokens({
+  total = EMPTY_TOKENS,
+  added,
+}: {
+  total?: ChatCompletionTokenCount;
+  added?: ChatCompletionTokenCount;
+}): ChatCompletionTokenCount {
   return {
-    completion: a.completion + (b?.completion ?? 0),
-    prompt: a.prompt + (b?.prompt ?? 0),
-    total: a.total + (b?.total ?? 0),
-    cached: (a.cached ?? 0) + (b?.cached ?? 0),
+    completion: total.completion + (added?.completion ?? 0),
+    prompt: total.prompt + (added?.prompt ?? 0),
+    total: total.total + (added?.total ?? 0),
+    cached: (total.cached ?? 0) + (added?.cached ?? 0),
   };
 }

--- a/x-pack/platform/packages/shared/kbn-streams-ai/src/helpers/sum_tokens.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-ai/src/helpers/sum_tokens.ts
@@ -7,6 +7,13 @@
 
 import type { ChatCompletionTokenCount } from '@kbn/inference-common';
 
+export const EMPTY_TOKENS: ChatCompletionTokenCount = {
+  prompt: 0,
+  completion: 0,
+  total: 0,
+  cached: 0,
+};
+
 export function sumTokens(
   a: ChatCompletionTokenCount,
   b?: ChatCompletionTokenCount

--- a/x-pack/platform/packages/shared/kbn-streams-ai/src/significant_events/generate_significant_events.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-ai/src/significant_events/generate_significant_events.ts
@@ -287,15 +287,7 @@ export async function generateSignificantEvents({
 
   return {
     queries,
-    tokensUsed: sumTokens(
-      {
-        prompt: 0,
-        completion: 0,
-        total: 0,
-        cached: 0,
-      },
-      response.tokens
-    ),
+    tokensUsed: sumTokens({ added: response.tokens }),
     toolUsage,
   };
 }

--- a/x-pack/platform/plugins/shared/streams/server/lib/sig_events/features/identify_inferred_features.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/sig_events/features/identify_inferred_features.ts
@@ -18,6 +18,7 @@ import {
   isFeatureWithFilter,
 } from '@kbn/streams-schema';
 import {
+  EMPTY_TOKENS,
   identifyFeatures,
   type ExcludedFeatureSummary,
   type IgnoredFeature,
@@ -27,7 +28,6 @@ import { fetchSampleDocuments } from '../../tasks/task_definitions/features_iden
 import { PromptsConfigService } from '../saved_objects/prompts_config_service';
 import type { SigEventsTuningConfig } from '../../../../common/sig_events_tuning_config';
 import { DEFAULT_SIG_EVENTS_TUNING_CONFIG } from '../../../../common/sig_events_tuning_config';
-import { EMPTY_TOKENS } from './iteration_state';
 import {
   reconcileInferredFeatures,
   toFeatureSummary,

--- a/x-pack/platform/plugins/shared/streams/server/lib/sig_events/features/index.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/sig_events/features/index.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-export { MS_PER_DAY, EMPTY_TOKENS } from './iteration_state';
+export { MS_PER_DAY } from './iteration_state';
 export { deriveSuccessCount, deriveTotalTokensUsed } from './iteration_state';
 
 export { identifyInferredFeatures, buildTelemetry } from './identify_inferred_features';

--- a/x-pack/platform/plugins/shared/streams/server/lib/sig_events/features/iteration_state.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/sig_events/features/iteration_state.ts
@@ -28,5 +28,7 @@ export function deriveSuccessCount(results: IterationResult[]): number {
 }
 
 export function deriveTotalTokensUsed(results: IterationResult[]): ChatCompletionTokenCount {
-  return results.reduce((acc, r) => sumTokens(acc, r.tokensUsed), { ...EMPTY_TOKENS });
+  return results.reduce((acc, r) => sumTokens({ total: acc, added: r.tokensUsed }), {
+    ...EMPTY_TOKENS,
+  });
 }

--- a/x-pack/platform/plugins/shared/streams/server/lib/sig_events/features/iteration_state.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/sig_events/features/iteration_state.ts
@@ -28,7 +28,7 @@ export function deriveSuccessCount(results: IterationResult[]): number {
 }
 
 export function deriveTotalTokensUsed(results: IterationResult[]): ChatCompletionTokenCount {
-  return results.reduce((acc, r) => sumTokens({ total: acc, added: r.tokensUsed }), {
+  return results.reduce((acc, r) => sumTokens({ accumulated: acc, added: r.tokensUsed }), {
     ...EMPTY_TOKENS,
   });
 }

--- a/x-pack/platform/plugins/shared/streams/server/lib/sig_events/features/iteration_state.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/sig_events/features/iteration_state.ts
@@ -7,16 +7,9 @@
 
 import type { ChatCompletionTokenCount } from '@kbn/inference-common';
 import type { Feature, IterationResult } from '@kbn/streams-schema';
-import { sumTokens } from '@kbn/streams-ai';
+import { EMPTY_TOKENS, sumTokens } from '@kbn/streams-ai';
 
 export const MS_PER_DAY = 24 * 60 * 60 * 1000;
-
-export const EMPTY_TOKENS: ChatCompletionTokenCount = {
-  prompt: 0,
-  completion: 0,
-  total: 0,
-  cached: 0,
-};
 
 export interface AccumulatedIterationState {
   discoveredFeatures: Feature[];

--- a/x-pack/platform/plugins/shared/streams/server/lib/sig_events/insights/generate_insights.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/sig_events/insights/generate_insights.ts
@@ -81,7 +81,7 @@ export async function generateInsights({
   );
 
   const tokensUsed = streamInsightsResults.reduce<ChatCompletionTokenCount>(
-    (acc, result) => sumTokens({ total: acc, added: result.tokens_used }),
+    (acc, result) => sumTokens({ accumulated: acc, added: result.tokens_used }),
     EMPTY_TOKENS
   );
 
@@ -123,7 +123,7 @@ export async function generateInsights({
 
     return {
       insights,
-      tokens_used: sumTokens({ total: tokensUsed, added: response.tokens }),
+      tokens_used: sumTokens({ accumulated: tokensUsed, added: response.tokens }),
     };
   } catch (error) {
     if (

--- a/x-pack/platform/plugins/shared/streams/server/lib/sig_events/insights/generate_insights.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/sig_events/insights/generate_insights.ts
@@ -177,7 +177,7 @@ async function generateStreamInsights({
   if (queryDataList.length === 0) {
     return {
       insights: [],
-      tokens_used: { prompt: 0, completion: 0, total: 0 },
+      tokens_used: EMPTY_TOKENS,
     };
   }
 
@@ -212,7 +212,7 @@ async function generateStreamInsights({
 
     return {
       insights,
-      tokens_used: response.tokens ?? { prompt: 0, completion: 0, total: 0 },
+      tokens_used: response.tokens ?? EMPTY_TOKENS,
     };
   } catch (error) {
     if (
@@ -224,7 +224,7 @@ async function generateStreamInsights({
       );
       return {
         insights: [],
-        tokens_used: { prompt: 0, completion: 0, total: 0 },
+        tokens_used: EMPTY_TOKENS,
       };
     }
 

--- a/x-pack/platform/plugins/shared/streams/server/lib/sig_events/insights/generate_insights.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/sig_events/insights/generate_insights.ts
@@ -11,7 +11,7 @@ import type {
   ToolCallback,
   ToolDefinition,
 } from '@kbn/inference-common';
-import { sumTokens } from '@kbn/streams-ai';
+import { EMPTY_TOKENS, sumTokens } from '@kbn/streams-ai';
 import type { ElasticsearchClient, Logger } from '@kbn/core/server';
 import type { Streams } from '@kbn/streams-schema';
 import type { GenerateInsightsResult } from '@kbn/streams-schema';
@@ -81,8 +81,8 @@ export async function generateInsights({
   );
 
   const tokensUsed = streamInsightsResults.reduce<ChatCompletionTokenCount>(
-    (acc, result) => sumTokens(acc, result.tokens_used),
-    { prompt: 0, completion: 0, total: 0 }
+    (acc, result) => sumTokens({ total: acc, added: result.tokens_used }),
+    EMPTY_TOKENS
   );
 
   // If no stream insights, return empty
@@ -123,7 +123,7 @@ export async function generateInsights({
 
     return {
       insights,
-      tokens_used: sumTokens(tokensUsed, response.tokens),
+      tokens_used: sumTokens({ total: tokensUsed, added: response.tokens }),
     };
   } catch (error) {
     if (


### PR DESCRIPTION
## Summary

Two improvements to token counting utilities in `@kbn/streams-ai`:

1. **Move `EMPTY_TOKENS`** from `features/iteration_state.ts` to `@kbn/streams-ai` (alongside `sumTokens`). It was defined locally in the features domain but is used across multiple areas. Centralising it avoids duplication.

2. **Refactor `sumTokens` to use named params**: `sumTokens({ total?, added? })` instead of positional args. `total` defaults to `EMPTY_TOKENS`, eliminating inline zero-token objects at call sites.