### PR TITLE
[Agent Builder] Dashboards in Chat: Fix ES|QL editor shown in dashboard preview

### DIFF
--- a/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/canvas_integration/dashboard_canvas_attachment.tsx
+++ b/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/canvas_integration/dashboard_canvas_attachment.tsx
@@ -26,8 +26,7 @@ export type DashboardCanvasAttachmentProps = AttachmentRenderProps<DashboardAtta
   dashboardLocator?: DashboardRendererProps['locator'];
   openSidebarConversation?: () => void;
   searchBarComponent: UnifiedSearchPublicPluginStart['ui']['SearchBar'];
-  filterManager: DataPublicPluginStart['query']['filterManager'];
-  timefilter: DataPublicPluginStart['query']['timefilter']['timefilter'];
+  data: DataPublicPluginStart;
   checkSavedDashboardExist: (dashboardId: string) => Promise<boolean>;
   canWriteDashboards: boolean;
 };

--- a/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/canvas_integration/dashboard_canvas_attachment.tsx
+++ b/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/canvas_integration/dashboard_canvas_attachment.tsx
@@ -27,6 +27,7 @@ export type DashboardCanvasAttachmentProps = AttachmentRenderProps<DashboardAtta
   openSidebarConversation?: () => void;
   searchBarComponent: UnifiedSearchPublicPluginStart['ui']['SearchBar'];
   filterManager: DataPublicPluginStart['query']['filterManager'];
+  timefilter: DataPublicPluginStart['query']['timefilter']['timefilter'];
   checkSavedDashboardExist: (dashboardId: string) => Promise<boolean>;
   canWriteDashboards: boolean;
 };

--- a/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/canvas_integration/dashboard_canvas_content.test.tsx
+++ b/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/canvas_integration/dashboard_canvas_content.test.tsx
@@ -12,7 +12,7 @@ import type { DashboardApi } from '@kbn/dashboard-plugin/public';
 import { DashboardRenderer } from '@kbn/dashboard-plugin/public';
 import type { ActionButton } from '@kbn/agent-builder-browser/attachments';
 import type { DashboardAttachment } from '@kbn/dashboard-agent-common/types';
-import type { Filter, Query } from '@kbn/es-query';
+import type { Filter, Query, TimeRange } from '@kbn/es-query';
 import { renderWithKibanaRenderContext } from '@kbn/test-jest-helpers';
 import { DashboardCanvasAttachment } from './dashboard_canvas_attachment';
 import * as dashboardAgentCommon from '@kbn/dashboard-agent-common';
@@ -90,6 +90,24 @@ describe('DashboardCanvasAttachment', () => {
     };
   };
 
+  const createMockTimefilter = () => {
+    let currentTime: TimeRange = { from: 'now-15m', to: 'now' };
+    const timeUpdate$ = new Subject<void>();
+
+    return {
+      getTime: jest.fn(() => currentTime),
+      getTimeUpdate$: jest.fn(() => timeUpdate$.asObservable()),
+      setTime: jest.fn((nextTime: TimeRange) => {
+        currentTime = nextTime;
+        timeUpdate$.next();
+      }),
+      emitTime: (nextTime: TimeRange) => {
+        currentTime = nextTime;
+        timeUpdate$.next();
+      },
+    };
+  };
+
   const mockAttachment: DashboardAttachment = {
     type: DASHBOARD_ATTACHMENT_TYPE,
     id: 'test-dashboard-id',
@@ -149,12 +167,14 @@ describe('DashboardCanvasAttachment', () => {
       DashboardCanvasAttachmentProps['checkSavedDashboardExist']
     > = jest.fn().mockResolvedValue(false);
     const mockFilterManager = createMockFilterManager();
+    const mockTimefilter = createMockTimefilter();
     const mockApi = createMockDashboardApi(mockApiOverrides);
     const openSidebarConversation = jest.fn();
 
     const props: DashboardCanvasAttachmentProps = {
       ...defaultProps,
       filterManager: mockFilterManager as any,
+      timefilter: mockTimefilter as any,
       registerActionButtons,
       updateOrigin,
       closeCanvas,
@@ -178,6 +198,7 @@ describe('DashboardCanvasAttachment', () => {
       props,
       mockApi,
       mockFilterManager,
+      mockTimefilter,
       registerActionButtons,
       updateOrigin,
       closeCanvas,
@@ -470,6 +491,25 @@ describe('DashboardCanvasAttachment', () => {
     expect(getLatestSearchBarProps()).toEqual(
       expect.objectContaining({
         filters: nextFilters,
+      })
+    );
+  });
+
+  it('updates the preview time range when timefilter emits (e.g. chart brush)', async () => {
+    const { mockApi, mockTimefilter } = await renderDashboardCanvasAttachment();
+    const nextTimeRange = { from: '2026-04-01T00:00:00Z', to: '2026-04-02T00:00:00Z' };
+    const setTimeRangeMock = mockApi.setTimeRange as jest.Mock;
+
+    setTimeRangeMock.mockClear();
+    act(() => {
+      mockTimefilter.emitTime(nextTimeRange);
+    });
+
+    expect(mockApi.setTimeRange).toHaveBeenCalledWith(nextTimeRange);
+    expect(getLatestSearchBarProps()).toEqual(
+      expect.objectContaining({
+        dateRangeFrom: nextTimeRange.from,
+        dateRangeTo: nextTimeRange.to,
       })
     );
   });
@@ -796,11 +836,13 @@ describe('DashboardCanvasAttachment', () => {
       const closeCanvas = jest.fn();
       const checkSavedDashboardExist = jest.fn().mockResolvedValue(false);
       const filterManager = createMockFilterManager();
+      const timefilter = createMockTimefilter();
 
       const { container } = renderWithKibanaRenderContext(
         <DashboardCanvasAttachment
           {...defaultProps}
           filterManager={filterManager as any}
+          timefilter={timefilter as any}
           registerActionButtons={registerActionButtons}
           updateOrigin={updateOrigin}
           closeCanvas={closeCanvas}
@@ -830,11 +872,13 @@ describe('DashboardCanvasAttachment', () => {
       const closeCanvas = jest.fn();
       const checkSavedDashboardExist = jest.fn().mockResolvedValue(false);
       const filterManager = createMockFilterManager();
+      const timefilter = createMockTimefilter();
 
       const { container } = renderWithKibanaRenderContext(
         <DashboardCanvasAttachment
           {...defaultProps}
           filterManager={filterManager as any}
+          timefilter={timefilter as any}
           registerActionButtons={registerActionButtons}
           updateOrigin={updateOrigin}
           closeCanvas={closeCanvas}

--- a/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/canvas_integration/dashboard_canvas_content.test.tsx
+++ b/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/canvas_integration/dashboard_canvas_content.test.tsx
@@ -398,7 +398,7 @@ describe('DashboardCanvasAttachment', () => {
       });
     });
 
-    expect(mockApi.setQuery).toHaveBeenCalledWith(undefined);
+    expect(mockApi.setQuery).toHaveBeenCalledWith({ query: '', language: 'kuery' });
     expect(mockApi.forceRefresh).toHaveBeenCalled();
   });
 

--- a/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/canvas_integration/dashboard_canvas_content.test.tsx
+++ b/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/canvas_integration/dashboard_canvas_content.test.tsx
@@ -8,6 +8,7 @@
 import React from 'react';
 import { render, act, waitFor } from '@testing-library/react';
 import { BehaviorSubject, Subject } from 'rxjs';
+import { dataPluginMock } from '@kbn/data-plugin/public/mocks';
 import type { DashboardApi } from '@kbn/dashboard-plugin/public';
 import { DashboardRenderer } from '@kbn/dashboard-plugin/public';
 import type { ActionButton } from '@kbn/agent-builder-browser/attachments';
@@ -108,6 +109,16 @@ describe('DashboardCanvasAttachment', () => {
     };
   };
 
+  const createMockData = (
+    filterManager: ReturnType<typeof createMockFilterManager>,
+    timefilter: ReturnType<typeof createMockTimefilter>
+  ) => {
+    const data = dataPluginMock.createStartContract();
+    Object.assign(data.query.filterManager, filterManager);
+    Object.assign(data.query.timefilter.timefilter, timefilter);
+    return data;
+  };
+
   const mockAttachment: DashboardAttachment = {
     type: DASHBOARD_ATTACHMENT_TYPE,
     id: 'test-dashboard-id',
@@ -168,13 +179,13 @@ describe('DashboardCanvasAttachment', () => {
     > = jest.fn().mockResolvedValue(false);
     const mockFilterManager = createMockFilterManager();
     const mockTimefilter = createMockTimefilter();
+    const mockData = createMockData(mockFilterManager, mockTimefilter);
     const mockApi = createMockDashboardApi(mockApiOverrides);
     const openSidebarConversation = jest.fn();
 
     const props: DashboardCanvasAttachmentProps = {
       ...defaultProps,
-      filterManager: mockFilterManager as any,
-      timefilter: mockTimefilter as any,
+      data: mockData,
       registerActionButtons,
       updateOrigin,
       closeCanvas,
@@ -386,7 +397,7 @@ describe('DashboardCanvasAttachment', () => {
         showFilterBar: true,
         showDatePicker: true,
         showQueryMenu: false,
-        useDefaultBehaviors: true,
+        useDefaultBehaviors: false,
       })
     );
   });
@@ -442,7 +453,7 @@ describe('DashboardCanvasAttachment', () => {
   });
 
   it('updates dashboard filters from the preview filter bar', async () => {
-    const { mockApi, props } = await renderDashboardCanvasAttachment();
+    const { mockApi, mockFilterManager } = await renderDashboardCanvasAttachment();
     const nextFilters = [{ meta: { key: 'host.name' } }] as Filter[];
 
     (mockApi.setFilters as jest.MockedFunction<typeof mockApi.setFilters>).mockClear();
@@ -450,7 +461,7 @@ describe('DashboardCanvasAttachment', () => {
       getLatestSearchBarProps()?.onFiltersUpdated(nextFilters);
     });
 
-    expect(props.filterManager.setFilters).toHaveBeenCalledWith(nextFilters);
+    expect(mockFilterManager.setFilters).toHaveBeenCalledWith(nextFilters);
     expect(mockApi.setFilters).toHaveBeenCalledWith(nextFilters);
     expect(mockApi.setFilters).toHaveBeenCalledTimes(1);
   });
@@ -837,12 +848,12 @@ describe('DashboardCanvasAttachment', () => {
       const checkSavedDashboardExist = jest.fn().mockResolvedValue(false);
       const filterManager = createMockFilterManager();
       const timefilter = createMockTimefilter();
+      const data = createMockData(filterManager, timefilter);
 
       const { container } = renderWithKibanaRenderContext(
         <DashboardCanvasAttachment
           {...defaultProps}
-          filterManager={filterManager as any}
-          timefilter={timefilter as any}
+          data={data}
           registerActionButtons={registerActionButtons}
           updateOrigin={updateOrigin}
           closeCanvas={closeCanvas}
@@ -873,12 +884,12 @@ describe('DashboardCanvasAttachment', () => {
       const checkSavedDashboardExist = jest.fn().mockResolvedValue(false);
       const filterManager = createMockFilterManager();
       const timefilter = createMockTimefilter();
+      const data = createMockData(filterManager, timefilter);
 
       const { container } = renderWithKibanaRenderContext(
         <DashboardCanvasAttachment
           {...defaultProps}
-          filterManager={filterManager as any}
-          timefilter={timefilter as any}
+          data={data}
           registerActionButtons={registerActionButtons}
           updateOrigin={updateOrigin}
           closeCanvas={closeCanvas}

--- a/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/canvas_integration/dashboard_canvas_content.tsx
+++ b/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/canvas_integration/dashboard_canvas_content.tsx
@@ -59,6 +59,7 @@ export const DashboardCanvasContent = ({
   dashboardLocator,
   searchBarComponent: SearchBar,
   filterManager,
+  timefilter,
   checkSavedDashboardExist,
   canWriteDashboards,
 }: AttachmentRenderProps<DashboardAttachment> & {
@@ -70,6 +71,7 @@ export const DashboardCanvasContent = ({
   openSidebarConversation?: () => void;
   searchBarComponent: UnifiedSearchPublicPluginStart['ui']['SearchBar'];
   filterManager: DataPublicPluginStart['query']['filterManager'];
+  timefilter: DataPublicPluginStart['query']['timefilter']['timefilter'];
   checkSavedDashboardExist: (dashboardId: string) => Promise<boolean>;
   canWriteDashboards: boolean;
 }) => {
@@ -112,6 +114,7 @@ export const DashboardCanvasContent = ({
     dashboardApi,
     dashboardState,
     filterManager,
+    timefilter,
   });
 
   const getCreationOptions = useCallback(

--- a/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/canvas_integration/dashboard_canvas_content.tsx
+++ b/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/canvas_integration/dashboard_canvas_content.tsx
@@ -58,8 +58,7 @@ export const DashboardCanvasContent = ({
   openSidebarConversation,
   dashboardLocator,
   searchBarComponent: SearchBar,
-  filterManager,
-  timefilter,
+  data,
   checkSavedDashboardExist,
   canWriteDashboards,
 }: AttachmentRenderProps<DashboardAttachment> & {
@@ -70,8 +69,7 @@ export const DashboardCanvasContent = ({
   dashboardLocator?: DashboardRendererProps['locator'];
   openSidebarConversation?: () => void;
   searchBarComponent: UnifiedSearchPublicPluginStart['ui']['SearchBar'];
-  filterManager: DataPublicPluginStart['query']['filterManager'];
-  timefilter: DataPublicPluginStart['query']['timefilter']['timefilter'];
+  data: DataPublicPluginStart;
   checkSavedDashboardExist: (dashboardId: string) => Promise<boolean>;
   canWriteDashboards: boolean;
 }) => {
@@ -113,8 +111,7 @@ export const DashboardCanvasContent = ({
   const { filters, query, searchBarProps, timeRange } = useDashboardPreviewUnifiedSearch({
     dashboardApi,
     dashboardState,
-    filterManager,
-    timefilter,
+    data,
   });
 
   const getCreationOptions = useCallback(

--- a/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/canvas_integration/use_dashboard_preview_unified_search.ts
+++ b/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/canvas_integration/use_dashboard_preview_unified_search.ts
@@ -22,16 +22,18 @@ interface UseDashboardPreviewUnifiedSearchParams {
   filterManager: DataPublicPluginStart['query']['filterManager'];
 }
 
-const normalizeQuery = (nextQuery: Query | undefined) => {
+const DEFAULT_EMPTY_QUERY: Query = { query: '', language: 'kuery' };
+
+const normalizeQuery = (nextQuery: Query | undefined): Query => {
   if (!nextQuery) {
-    return undefined;
+    return DEFAULT_EMPTY_QUERY;
   }
 
   if (typeof nextQuery.query !== 'string') {
     return nextQuery;
   }
 
-  return nextQuery.query.trim() === '' ? undefined : nextQuery;
+  return nextQuery.query.trim() === '' ? DEFAULT_EMPTY_QUERY : nextQuery;
 };
 
 export const useDashboardPreviewUnifiedSearch = ({
@@ -42,9 +44,7 @@ export const useDashboardPreviewUnifiedSearch = ({
   const [timeRange, setTimeRange] = useState<TimeRange>(
     dashboardState.time_range ?? DEFAULT_TIME_RANGE
   );
-  const [query, setQuery] = useState<Query | undefined>(
-    normalizeQuery(toStoredQuery(dashboardState.query))
-  );
+  const [query, setQuery] = useState<Query>(normalizeQuery(toStoredQuery(dashboardState.query)));
   const [filters, setFilters] = useState<Filter[]>(toStoredFilters(dashboardState.filters) ?? []);
   const [dataViews, setDataViews] = useState<DataView[]>([]);
 
@@ -153,6 +153,7 @@ export const useDashboardPreviewUnifiedSearch = ({
       showQueryMenu: false,
       screenTitle: dashboardState.title,
       displayStyle: 'inPage' as const,
+      disableSubscribingToGlobalDataServices: true,
     }),
     [
       dashboardApi,

--- a/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/canvas_integration/use_dashboard_preview_unified_search.ts
+++ b/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/canvas_integration/use_dashboard_preview_unified_search.ts
@@ -19,8 +19,7 @@ import { DEFAULT_TIME_RANGE } from '@kbn/dashboard-agent-common';
 interface UseDashboardPreviewUnifiedSearchParams {
   dashboardApi: DashboardApi | undefined;
   dashboardState: DashboardState;
-  filterManager: DataPublicPluginStart['query']['filterManager'];
-  timefilter: DataPublicPluginStart['query']['timefilter']['timefilter'];
+  data: DataPublicPluginStart;
 }
 
 const DEFAULT_EMPTY_QUERY: Query = { query: '', language: 'kuery' };
@@ -40,9 +39,11 @@ const normalizeQuery = (nextQuery: Query | undefined): Query => {
 export const useDashboardPreviewUnifiedSearch = ({
   dashboardApi,
   dashboardState,
-  filterManager,
-  timefilter,
+  data,
 }: UseDashboardPreviewUnifiedSearchParams) => {
+  const { filterManager } = data.query;
+  const { timefilter } = data.query.timefilter;
+
   const [timeRange, setTimeRange] = useState<TimeRange>(
     dashboardState.time_range ?? DEFAULT_TIME_RANGE
   );

--- a/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/canvas_integration/use_dashboard_preview_unified_search.ts
+++ b/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/canvas_integration/use_dashboard_preview_unified_search.ts
@@ -20,6 +20,7 @@ interface UseDashboardPreviewUnifiedSearchParams {
   dashboardApi: DashboardApi | undefined;
   dashboardState: DashboardState;
   filterManager: DataPublicPluginStart['query']['filterManager'];
+  timefilter: DataPublicPluginStart['query']['timefilter']['timefilter'];
 }
 
 const DEFAULT_EMPTY_QUERY: Query = { query: '', language: 'kuery' };
@@ -40,6 +41,7 @@ export const useDashboardPreviewUnifiedSearch = ({
   dashboardApi,
   dashboardState,
   filterManager,
+  timefilter,
 }: UseDashboardPreviewUnifiedSearchParams) => {
   const [timeRange, setTimeRange] = useState<TimeRange>(
     dashboardState.time_range ?? DEFAULT_TIME_RANGE
@@ -110,6 +112,19 @@ export const useDashboardPreviewUnifiedSearch = ({
     };
   }, [filterManager]);
 
+  useEffect(() => {
+    const timefilterSubscription = timefilter.getTimeUpdate$().subscribe(() => {
+      const nextTimeRange = timefilter.getTime();
+      setTimeRange((currentTimeRange) =>
+        isEqual(currentTimeRange, nextTimeRange) ? currentTimeRange : nextTimeRange
+      );
+    });
+
+    return () => {
+      timefilterSubscription.unsubscribe();
+    };
+  }, [timefilter]);
+
   const onRefresh = useCallback(() => {
     dashboardApi?.forceRefresh();
   }, [dashboardApi]);
@@ -141,7 +156,7 @@ export const useDashboardPreviewUnifiedSearch = ({
       onQuerySubmit,
       onFiltersUpdated,
       onRefresh,
-      useDefaultBehaviors: true,
+      useDefaultBehaviors: false,
       disableQueryLanguageSwitcher: true,
       isDisabled: !dashboardApi,
       dataTestSubj: 'dashboardCanvasSearchBar',

--- a/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/index.test.tsx
+++ b/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/index.test.tsx
@@ -9,7 +9,7 @@ import { BehaviorSubject, Subject } from 'rxjs';
 import type { DashboardApi, DashboardStart } from '@kbn/dashboard-plugin/public';
 import type { DashboardSaveEvent } from '@kbn/dashboard-plugin/public';
 import type { AgentBuilderPluginStart } from '@kbn/agent-builder-plugin/public';
-import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
+import { dataPluginMock } from '@kbn/data-plugin/public/mocks';
 import type { UnifiedSearchPublicPluginStart } from '@kbn/unified-search-plugin/public';
 import type { AttachmentUIDefinition } from '@kbn/agent-builder-browser/attachments';
 import type { DashboardAttachment } from '@kbn/dashboard-agent-common/types';
@@ -176,20 +176,7 @@ describe('registerDashboardAttachmentUiDefinition', () => {
       findDashboardsService,
     } as unknown as DashboardStart;
 
-    const data: DataPublicPluginStart = {
-      query: {
-        filterManager: {
-          setFilters: jest.fn(),
-        },
-        timefilter: {
-          timefilter: {
-            getTime: jest.fn(() => ({ from: 'now-15m', to: 'now' })),
-            getTimeUpdate$: jest.fn(() => new Subject<void>().asObservable()),
-            setTime: jest.fn(),
-          },
-        },
-      },
-    } as unknown as DataPublicPluginStart;
+    const data = dataPluginMock.createStartContract();
 
     const unifiedSearch: UnifiedSearchPublicPluginStart = {
       ui: { SearchBar: jest.fn() },
@@ -199,8 +186,7 @@ describe('registerDashboardAttachmentUiDefinition', () => {
       agentBuilder,
       addAttachment: mockAddAttachment,
       canWriteDashboards: true,
-      filterManager: data.query.filterManager,
-      timefilter: data.query.timefilter.timefilter,
+      data,
       dashboardPlugin,
       unifiedSearch,
       dashboardLocator: undefined,

--- a/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/index.test.tsx
+++ b/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/index.test.tsx
@@ -181,6 +181,13 @@ describe('registerDashboardAttachmentUiDefinition', () => {
         filterManager: {
           setFilters: jest.fn(),
         },
+        timefilter: {
+          timefilter: {
+            getTime: jest.fn(() => ({ from: 'now-15m', to: 'now' })),
+            getTimeUpdate$: jest.fn(() => new Subject<void>().asObservable()),
+            setTime: jest.fn(),
+          },
+        },
       },
     } as unknown as DataPublicPluginStart;
 
@@ -193,6 +200,7 @@ describe('registerDashboardAttachmentUiDefinition', () => {
       addAttachment: mockAddAttachment,
       canWriteDashboards: true,
       filterManager: data.query.filterManager,
+      timefilter: data.query.timefilter.timefilter,
       dashboardPlugin,
       unifiedSearch,
       dashboardLocator: undefined,

--- a/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/index.tsx
+++ b/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/index.tsx
@@ -32,6 +32,7 @@ export const registerDashboardAttachmentUiDefinition = ({
   dashboardLocator,
   unifiedSearch,
   filterManager,
+  timefilter,
   dashboardPlugin,
   canWriteDashboards,
 }: {
@@ -39,6 +40,7 @@ export const registerDashboardAttachmentUiDefinition = ({
   dashboardLocator?: DashboardRendererProps['locator'];
   unifiedSearch: UnifiedSearchPublicPluginStart;
   filterManager: DataPublicPluginStart['query']['filterManager'];
+  timefilter: DataPublicPluginStart['query']['timefilter']['timefilter'];
   dashboardPlugin: DashboardStart;
   canWriteDashboards: boolean;
 }): (() => void) => {
@@ -106,6 +108,7 @@ export const registerDashboardAttachmentUiDefinition = ({
         dashboardLocator={dashboardLocator}
         searchBarComponent={unifiedSearch.ui.SearchBar}
         filterManager={filterManager}
+        timefilter={timefilter}
         checkSavedDashboardExist={checkSavedDashboardExist}
         canWriteDashboards={canWriteDashboards}
       />

--- a/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/index.tsx
+++ b/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/index.tsx
@@ -31,16 +31,14 @@ export const registerDashboardAttachmentUiDefinition = ({
   agentBuilder,
   dashboardLocator,
   unifiedSearch,
-  filterManager,
-  timefilter,
+  data,
   dashboardPlugin,
   canWriteDashboards,
 }: {
   agentBuilder: AgentBuilderPluginStart;
   dashboardLocator?: DashboardRendererProps['locator'];
   unifiedSearch: UnifiedSearchPublicPluginStart;
-  filterManager: DataPublicPluginStart['query']['filterManager'];
-  timefilter: DataPublicPluginStart['query']['timefilter']['timefilter'];
+  data: DataPublicPluginStart;
   dashboardPlugin: DashboardStart;
   canWriteDashboards: boolean;
 }): (() => void) => {
@@ -107,8 +105,7 @@ export const registerDashboardAttachmentUiDefinition = ({
         {...callbacks}
         dashboardLocator={dashboardLocator}
         searchBarComponent={unifiedSearch.ui.SearchBar}
-        filterManager={filterManager}
-        timefilter={timefilter}
+        data={data}
         checkSavedDashboardExist={checkSavedDashboardExist}
         canWriteDashboards={canWriteDashboards}
       />

--- a/x-pack/platform/plugins/shared/dashboard_agent/public/plugin.ts
+++ b/x-pack/platform/plugins/shared/dashboard_agent/public/plugin.ts
@@ -48,6 +48,7 @@ export class DashboardAgentPlugin
         dashboardLocator: plugins.share.url.locators.get(DASHBOARD_APP_LOCATOR),
         unifiedSearch: plugins.unifiedSearch,
         filterManager: plugins.data.query.filterManager,
+        timefilter: plugins.data.query.timefilter.timefilter,
         dashboardPlugin: plugins.dashboard,
       });
     });

--- a/x-pack/platform/plugins/shared/dashboard_agent/public/plugin.ts
+++ b/x-pack/platform/plugins/shared/dashboard_agent/public/plugin.ts
@@ -47,8 +47,7 @@ export class DashboardAgentPlugin
         canWriteDashboards: core.application.capabilities.dashboard_v2?.showWriteControls === true,
         dashboardLocator: plugins.share.url.locators.get(DASHBOARD_APP_LOCATOR),
         unifiedSearch: plugins.unifiedSearch,
-        filterManager: plugins.data.query.filterManager,
-        timefilter: plugins.data.query.timefilter.timefilter,
+        data: plugins.data,
         dashboardPlugin: plugins.dashboard,
       });
     });


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/265202

The preview's `<SearchBar>` was not isolated from global data services. The
stateful `SearchBar` internally subscribes to `data.query.queryString` via `useQueryStringManager`, which overrides the `query` prop with whatever the global query is. When Discover had set an ES|QL query, that global state leaked into the dashboard preview and `QueryBarTopRow` rendered the ES|QL editor.

Fix:
  - Pass `disableSubscribingToGlobalDataServices: true` in the preview's `searchBarProps` so the bar is driven solely by the preview's local state.
  - Default the preview's initial query to `{ query: '', language: 'kuery' }` instead of `undefined`. Without a concrete query, unified search falls back to `getDefaultQuery()`, which resolves to the user's stored language preference (often `'lucene'`) - locked in place by `disableQueryLanguageSwitcher: true`. A concrete KQL default short-circuits
    that fallback.
   - Flip `useDefaultBehaviors` to `false`. With the bar isolated from the global services, the previous `true` setting was both redundant and harmful: `defaultQueryOnSubmit` writes the submitted query/time back in into the global `queryString` and `timefilter` on every update, which in our case would silently overwrite global values.
   - Add a dedicated `timefilter.getUpdate$` subscription, mirroring the existing `filterManager.getUpdates$` one. Chart brush writes to the global `timefilter` via `multi_value_click_action`, and previously reached the preview only through the SearchBar's internal `useTimefilter`. With the bar now being isolated from global services, the preview hook needs to listen directly so chart-brush time changes still propagate to `dashboardApi.setTimeRange`.
   
 Note: While with this approach, the preview's timepicker doesn't write to global state, brushing over charts still does.

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->