### PR TITLE
Add error logging to saved_objects_tagging tags endpoint

### DIFF
--- a/x-pack/platform/plugins/shared/saved_objects_tagging/server/index.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/server/index.ts
@@ -17,5 +17,5 @@ export type { IAssignmentService } from './services';
 
 export const plugin = async (initializerContext: PluginInitializerContext) => {
   const { SavedObjectTaggingPlugin } = await import('./plugin');
-  return new SavedObjectTaggingPlugin();
+  return new SavedObjectTaggingPlugin(initializerContext);
 };

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/server/plugin.test.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/server/plugin.test.ts
@@ -19,7 +19,7 @@ describe('SavedObjectTaggingPlugin', () => {
   let usageCollectionSetup: ReturnType<typeof usageCollectionPluginMock.createSetupContract>;
 
   beforeEach(() => {
-    plugin = new SavedObjectTaggingPlugin();
+    plugin = new SavedObjectTaggingPlugin(coreMock.createPluginInitializerContext());
     featuresPluginSetup = featuresPluginMock.createSetup();
     usageCollectionSetup = usageCollectionPluginMock.createSetupContract();
     // `usageCollection` 'mocked' implementation use the real `CollectorSet` implementation

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/server/plugin.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { CoreSetup, CoreStart, Plugin } from '@kbn/core/server';
+import type { CoreSetup, CoreStart, Plugin, PluginInitializerContext } from '@kbn/core/server';
 import type { FeaturesPluginSetup } from '@kbn/features-plugin/server';
 import type { UsageCollectionSetup } from '@kbn/usage-collection-plugin/server';
 import type { SecurityPluginSetup, SecurityPluginStart } from '@kbn/security-plugin/server';
@@ -36,6 +36,12 @@ interface StartDeps {
 export class SavedObjectTaggingPlugin
   implements Plugin<{}, SavedObjectTaggingStart, SetupDeps, StartDeps>
 {
+  private readonly logger;
+
+  constructor(initializerContext: PluginInitializerContext) {
+    this.logger = initializerContext.logger.get();
+  }
+
   public setup(
     { savedObjects, http, getStartServices }: CoreSetup<StartDeps, SavedObjectTaggingStart>,
     { features, usageCollection, security }: SetupDeps
@@ -43,7 +49,7 @@ export class SavedObjectTaggingPlugin
     savedObjects.registerType(tagType);
 
     const router = http.createRouter<TagsHandlerContext>();
-    registerRoutes({ router });
+    registerRoutes({ router, logger: this.logger });
 
     http.registerRouteHandlerContext<TagsHandlerContext, 'tags'>(
       'tags',

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/server/routes/index.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/server/routes/index.ts
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import type { Logger } from '@kbn/core/server';
+
 import {
   registerUpdateTagRoute,
   registerGetAllTagsRoute,
@@ -20,12 +22,18 @@ import {
 import { registerInternalFindTagsRoute, registerInternalBulkDeleteRoute } from './internal';
 import type { TagsPluginRouter } from '../types';
 
-export const registerRoutes = ({ router }: { router: TagsPluginRouter }) => {
+export const registerRoutes = ({
+  router,
+  logger,
+}: {
+  router: TagsPluginRouter;
+  logger: Logger;
+}) => {
   // tags API
   registerCreateTagRoute(router);
   registerUpdateTagRoute(router);
   registerDeleteTagRoute(router);
-  registerGetAllTagsRoute(router);
+  registerGetAllTagsRoute(router, logger);
   registerGetTagRoute(router);
   // assignment API
   registerFindAssignableObjectsRoute(router);

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/server/routes/tags/get_all_tags.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/server/routes/tags/get_all_tags.ts
@@ -5,9 +5,10 @@
  * 2.0.
  */
 
+import type { Logger } from '@kbn/core/server';
 import type { TagsPluginRouter } from '../../types';
 
-export const registerGetAllTagsRoute = (router: TagsPluginRouter) => {
+export const registerGetAllTagsRoute = (router: TagsPluginRouter, logger: Logger) => {
   router.get(
     {
       path: '/api/saved_objects_tagging/tags',
@@ -21,13 +22,22 @@ export const registerGetAllTagsRoute = (router: TagsPluginRouter) => {
       validate: {},
     },
     router.handleLegacyErrors(async (ctx, req, res) => {
-      const { tagsClient } = await ctx.tags;
-      const tags = await tagsClient.getAll();
-      return res.ok({
-        body: {
-          tags,
-        },
-      });
+      try {
+        const { tagsClient } = await ctx.tags;
+        const tags = await tagsClient.getAll();
+        return res.ok({
+          body: {
+            tags,
+          },
+        });
+      } catch (e) {
+        logger.error(
+          `GET /api/saved_objects_tagging/tags error: [${e.constructor?.name}] ${e.message} ` +
+            `(statusCode: ${e.statusCode ?? 'N/A'}, isBoom: ${!!e.isBoom}, ` +
+            `output.statusCode: ${e.output?.statusCode ?? 'N/A'})`
+        );
+        throw e;
+      }
     })
   );
 };


### PR DESCRIPTION
Part of elastic/kibana#264960

## Summary

Adds explicit error logging to the `GET /api/saved_objects_tagging/tags` route handler. We've been seeing intermittent 500s on this endpoint in production, likely caused by expired ES tokens propagating as unrecognized error types through the HTTP router. The new logger captures the error constructor name, status code, and Boom metadata to help pinpoint the root cause.