### PR TITLE
[console] lazy-load @elastic/request-converter in convert-request route

### DIFF
--- a/src/platform/plugins/shared/console/server/routes/api/console/convert_request_to_language/index.ts
+++ b/src/platform/plugins/shared/console/server/routes/api/console/convert_request_to_language/index.ts
@@ -10,7 +10,6 @@
 import type { RequestHandler } from '@kbn/core/server';
 import type { TypeOf } from '@kbn/config-schema';
 import { schema } from '@kbn/config-schema';
-import { convertRequests } from '@elastic/request-converter';
 import type { RouteDependencies } from '../../..';
 
 import { acceptedHttpVerb, nonEmptyString } from '../proxy/validation_config';
@@ -45,6 +44,11 @@ export const registerConvertRequestRoute = ({
     const { language, esHost, kibanaHost } = query;
 
     try {
+      // Lazy-loaded so that prettier (a transitive dependency of
+      // @elastic/request-converter's JavaScript exporter) doesn't sit in the
+      // server's idle heap on instances that never use this feature.
+      const { convertRequests } = await import('@elastic/request-converter');
+
       // Iterate over each request and build all the requests into a single string
       // that can be passed to the request-converter library
       let devtoolsScript = '';


### PR DESCRIPTION
## Summary

Moves the `@elastic/request-converter` import in Console's convert-request-to-language route from top-level to a dynamic `await import()` inside the request handler.

The previous top-level import ran at plugin route registration. `@elastic/request-converter`'s barrel eagerly loads its JavaScript exporter, which top-level requires `prettier` and `prettier/parser-typescript`. As a result every Kibana server kept ~5 MB of formatter state resident even though `convertRequests` is only called when a user clicks "Copy as <language>" in Console.

Closes #265276
Part of #264189

## Test plan

- [ ] Type-check passes (`node scripts/type_check --project src/platform/plugins/shared/console/tsconfig.json`)
- [ ] Console UI: open the request converter, paste a request, click "Copy as Python/JS/etc." — first click triggers the lazy load, subsequent calls reuse the cached module
- [ ] Heap snapshot of an idle server no longer shows `prettier` retained

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->