### PR TITLE
[Search] fix(search-applications): remove markup rendering from doc explorer

### DIFF
--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/applications/components/search_application/docs_explorer/field_value_cell.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/applications/components/search_application/docs_explorer/field_value_cell.tsx
@@ -7,10 +7,6 @@
 
 import React from 'react';
 
-import { css } from '@emotion/react';
-
-import { useEuiTheme, transparentize } from '@elastic/eui';
-
 import type { FieldValue } from './convert_results';
 import { isFieldValue } from './convert_results';
 
@@ -19,33 +15,14 @@ export interface FieldValueCellProps {
 }
 
 export const FieldValueCell: React.FC<FieldValueCellProps> = ({ value }) => {
-  const { euiTheme, colorMode } = useEuiTheme();
-
   if (isFieldValue(value)) {
     if (value.snippet) {
-      const [snippet] = value.snippet;
-      // https://github.com/elastic/eui/blob/c4afd758e4c42ba6b12ea58ccfd6486d5f544afb/src/components/mark/mark.styles.ts#L29-L36
-      const transparency = { DARK: 0.3, LIGHT: 0.1 };
-      return (
-        <span
-          // eslint-disable-next-line react/no-danger
-          dangerouslySetInnerHTML={{ __html: snippet }}
-          css={css`
-            & em {
-              font-style: normal;
-              font-weight: ${euiTheme.font.weight.bold};
-              background-color: ${transparentize(euiTheme.colors.primary, transparency[colorMode])};
-              color: ${euiTheme.colors.text};
-            }
-          `}
-        />
-      );
+      return <span>{JSON.stringify(value.snippet)}</span>;
     }
     return (
       <FieldValueCell value={value.raw as Exclude<FieldValueCellProps['value'], FieldValue>} />
     );
   }
-
   if (typeof value === 'string') {
     return <span>{value}</span>;
   }


### PR DESCRIPTION
## Summary

Removes field rendering from Search Applications docs explorer.

Search Applications had code in the docs explorer that would render markup if the field had a `.snippet`. Removed this entire handling as it was not needed and the entire Search Applications feature is deprecated.

### Screenshots

Before:
<img width="3358" height="1834" alt="image" src="https://github.com/user-attachments/assets/baba58b5-d194-4802-8da8-a555e17ea6e3" />

After:
<img width="1915" height="729" alt="image" src="https://github.com/user-attachments/assets/d3878b66-29ee-41be-8b5a-80089ac8fd62" />
<img width="1915" height="729" alt="image" src="https://github.com/user-attachments/assets/0cfea704-5523-4619-b26c-09bf40a5a1c4" />

### Checklist

- [ ] ~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

## Release note

Fixes Search Applications document explorer to not render markup from fields.

<!--ONMERGE {"backportTargets":["8.19","9.2","9.3","9.4"]} ONMERGE-->