### PR TITLE
Alerting v2: creation & edit flows (prototype)

### DIFF
--- a/src/platform/packages/private/kbn-esql-editor/src/custom_editor_commands.test.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/custom_editor_commands.test.ts
@@ -259,5 +259,32 @@ describe('Custom Editor Commands', () => {
 
       expect(mockOnPrettifyQuery).toHaveBeenCalledTimes(1);
     });
+
+    it('registers create ES|QL rule shortcut when callback is provided', () => {
+      const mockOnQuerySubmit = jest.fn();
+      const mockToggleVisor = jest.fn();
+      const mockOnPrettifyQuery = jest.fn();
+      const mockOnCreateEsqlRule = jest.fn();
+
+      addEditorKeyBindings(
+        mockEditor,
+        mockOnQuerySubmit,
+        mockToggleVisor,
+        mockOnPrettifyQuery,
+        mockOnCreateEsqlRule
+      );
+
+      expect(mockEditor.addCommand).toHaveBeenCalledTimes(4);
+
+      const cmdShiftACall = (mockEditor.addCommand as jest.Mock).mock.calls.find(
+        // eslint-disable-next-line no-bitwise
+        ([keyMod]) => keyMod === (monaco.KeyMod.CtrlCmd | monaco.KeyMod.Shift | monaco.KeyCode.KeyA)
+      );
+      expect(cmdShiftACall).toBeDefined();
+
+      const cmdShiftAHandler = cmdShiftACall![1];
+      cmdShiftAHandler();
+      expect(mockOnCreateEsqlRule).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/src/platform/packages/private/kbn-esql-editor/src/custom_editor_commands.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/custom_editor_commands.ts
@@ -314,7 +314,8 @@ export const addEditorKeyBindings = (
   editor: monaco.editor.IStandaloneCodeEditor,
   onQuerySubmit: (source: QuerySource) => void,
   toggleVisor: () => void,
-  onPrettifyQuery: () => void
+  onPrettifyQuery: () => void,
+  onCreateEsqlAlertingRule?: () => void
 ) => {
   // Add editor key bindings
   editor.addCommand(
@@ -336,6 +337,14 @@ export const addEditorKeyBindings = (
       onPrettifyQuery();
     }
   );
+
+  if (onCreateEsqlAlertingRule) {
+    editor.addCommand(
+      // eslint-disable-next-line no-bitwise
+      monaco.KeyMod.CtrlCmd | monaco.KeyMod.Shift | monaco.KeyCode.KeyA,
+      onCreateEsqlAlertingRule
+    );
+  }
 };
 
 export const addTabKeybindingRules = () => {

--- a/src/platform/packages/private/kbn-esql-editor/src/editor_footer/index.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/editor_footer/index.tsx
@@ -51,6 +51,7 @@ interface EditorFooterProps {
   dataErrorsControl?: DataErrorsControl;
   starredQueriesService: EsqlStarredQueriesService | null;
   queryStats?: QueryStats;
+  showCreateEsqlRuleKeyboardShortcut?: boolean;
 }
 
 const openDocumentationLabel = i18n.translate('esqlEditor.query.documentationAriaLabel', {
@@ -77,6 +78,7 @@ export const EditorFooter = memo(function EditorFooter({
   dataErrorsControl,
   starredQueriesService,
   queryStats,
+  showCreateEsqlRuleKeyboardShortcut,
 }: EditorFooterProps) {
   const kibana = useKibana<ESQLEditorDeps>();
   const { docLinks } = kibana.services;
@@ -142,7 +144,9 @@ export const EditorFooter = memo(function EditorFooter({
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <EuiFlexGroup gutterSize="xs" responsive={false} alignItems="center">
-              <KeyboardShortcuts />
+              <KeyboardShortcuts
+                showCreateEsqlRuleKeyboardShortcut={showCreateEsqlRuleKeyboardShortcut}
+              />
               <QueryWrapComponent onPrettifyQuery={onPrettifyQuery} />
               {displayDocumentationAsFlyout && (
                 <>

--- a/src/platform/packages/private/kbn-esql-editor/src/editor_footer/keyboard_shortcuts.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/editor_footer/keyboard_shortcuts.tsx
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { i18n } from '@kbn/i18n';
 import {
   useEuiTheme,
@@ -27,52 +27,77 @@ import { isMac } from '@kbn/shared-ux-utility';
 
 const COMMAND_KEY = isMac ? '⌘' : 'CTRL';
 
-const listItems = [
-  {
-    title: (
-      <>
-        <kbd>{COMMAND_KEY}</kbd> <kbd>Enter</kbd>
-      </>
-    ),
-    description: i18n.translate('esqlEditor.query.runKeyboardShortcutsLabel', {
-      defaultMessage: 'Run query',
-    }),
-  },
-  {
-    title: (
-      <>
-        <kbd>{COMMAND_KEY}</kbd> <kbd>/</kbd>
-      </>
-    ),
-    description: i18n.translate('esqlEditor.query.commentKeyboardShortcutsLabel', {
-      defaultMessage: 'Comment/uncomment line',
-    }),
-  },
-  {
-    title: (
-      <>
-        <kbd>{COMMAND_KEY}</kbd> <kbd>K</kbd>
-      </>
-    ),
-    description: i18n.translate('esqlEditor.query.openVisorKeyboardShortcutsLabel', {
-      defaultMessage: 'Open quick search',
-    }),
-  },
-  {
-    title: (
-      <>
-        <kbd>{COMMAND_KEY}</kbd> <kbd>I</kbd>
-      </>
-    ),
-    description: i18n.translate('esqlEditor.query.prettifyKeyboardShortcutsLabel', {
-      defaultMessage: 'Prettify query',
-    }),
-  },
-];
+const createListItems = (showCreateEsqlRule: boolean) => {
+  const base = [
+    {
+      title: (
+        <>
+          <kbd>{COMMAND_KEY}</kbd> <kbd>Enter</kbd>
+        </>
+      ),
+      description: i18n.translate('esqlEditor.query.runKeyboardShortcutsLabel', {
+        defaultMessage: 'Run query',
+      }),
+    },
+    {
+      title: (
+        <>
+          <kbd>{COMMAND_KEY}</kbd> <kbd>/</kbd>
+        </>
+      ),
+      description: i18n.translate('esqlEditor.query.commentKeyboardShortcutsLabel', {
+        defaultMessage: 'Comment/uncomment line',
+      }),
+    },
+    {
+      title: (
+        <>
+          <kbd>{COMMAND_KEY}</kbd> <kbd>K</kbd>
+        </>
+      ),
+      description: i18n.translate('esqlEditor.query.openVisorKeyboardShortcutsLabel', {
+        defaultMessage: 'Open quick search',
+      }),
+    },
+    {
+      title: (
+        <>
+          <kbd>{COMMAND_KEY}</kbd> <kbd>I</kbd>
+        </>
+      ),
+      description: i18n.translate('esqlEditor.query.prettifyKeyboardShortcutsLabel', {
+        defaultMessage: 'Prettify query',
+      }),
+    },
+  ];
 
-export function KeyboardShortcuts() {
+  if (showCreateEsqlRule) {
+    base.push({
+      title: (
+        <>
+          <kbd>{COMMAND_KEY}</kbd> <kbd>Shift</kbd> <kbd>A</kbd>
+        </>
+      ),
+      description: i18n.translate('esqlEditor.query.createEsqlRuleKeyboardShortcutsLabel', {
+        defaultMessage: 'Create ES|QL rule',
+      }),
+    });
+  }
+
+  return base;
+};
+
+export function KeyboardShortcuts({
+  showCreateEsqlRuleKeyboardShortcut = false,
+}: {
+  showCreateEsqlRuleKeyboardShortcut?: boolean;
+}) {
   const euiThemeContext = useEuiTheme();
   const { euiTheme } = euiThemeContext;
+  const listItems = useMemo(
+    () => createListItems(showCreateEsqlRuleKeyboardShortcut),
+    [showCreateEsqlRuleKeyboardShortcut]
+  );
 
   const [isOpen, setIsOpen] = useState(false);
 

--- a/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
@@ -120,6 +120,7 @@ const ESQLEditorInternal = function ESQLEditor({
   hideQuickSearch,
   queryStats,
   enableResourceBrowser = false,
+  onCreateEsqlAlertingRule,
 }: ESQLEditorPropsInternal) {
   const popoverRef = useRef<HTMLDivElement>(null);
   const editorModel = useRef<monaco.editor.ITextModel>();
@@ -717,7 +718,13 @@ const ESQLEditorInternal = function ESQLEditor({
                   });
 
                   // Add editor key bindings
-                  addEditorKeyBindings(editor, onQuerySubmit, onToggleVisor, onPrettifyQuery);
+                  addEditorKeyBindings(
+                    editor,
+                    onQuerySubmit,
+                    onToggleVisor,
+                    onPrettifyQuery,
+                    onCreateEsqlAlertingRule
+                  );
 
                   // Store disposables for cleanup
                   const currentEditor = editorRef.current;
@@ -851,6 +858,7 @@ const ESQLEditorInternal = function ESQLEditor({
         dataErrorsControl={dataErrorsControl}
         starredQueriesService={starredQueriesService}
         queryStats={queryStats}
+        showCreateEsqlRuleKeyboardShortcut={Boolean(onCreateEsqlAlertingRule)}
         {...editorMessages}
         onErrorClick={onErrorClick}
       />

--- a/src/platform/packages/private/kbn-esql-editor/src/types.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/types.ts
@@ -90,6 +90,11 @@ export interface ESQLEditorProps {
   enableResourceBrowser?: boolean;
   /** Stats about the last request made */
   queryStats?: ESQLQueryStats;
+  /**
+   * When set, registers a keyboard shortcut (Ctrl/Cmd+Shift+A) and lists it in keyboard shortcuts
+   * help. The host app should open the same flow as its "Create ES|QL rule" action.
+   */
+  onCreateEsqlAlertingRule?: () => void;
 }
 
 interface ESQLVariableService {

--- a/src/platform/plugins/shared/discover/common/app_locator.test.ts
+++ b/src/platform/plugins/shared/discover/common/app_locator.test.ts
@@ -55,6 +55,32 @@ describe('Discover url generator', () => {
     expect(_g).toEqual(undefined);
   });
 
+  test('includes openCreateEsqlRuleV2Flyout in location state for alerting v2 deep links', async () => {
+    const { locator } = await setup();
+    const { app, state } = await locator.getLocation({
+      query: { esql: 'ROW 1' },
+      openCreateEsqlRuleV2Flyout: true,
+    });
+
+    expect(app).toBe('discover');
+    expect(state).toEqual({ openCreateEsqlRuleV2Flyout: true });
+  });
+
+  test('includes esqlRuleV2EditRuleId in location state for Discover edit rule deep links', async () => {
+    const { locator } = await setup();
+    const { app, state } = await locator.getLocation({
+      query: { esql: 'ROW 1' },
+      openCreateEsqlRuleV2Flyout: true,
+      esqlRuleV2EditRuleId: 'rule-abc',
+    });
+
+    expect(app).toBe('discover');
+    expect(state).toEqual({
+      openCreateEsqlRuleV2Flyout: true,
+      esqlRuleV2EditRuleId: 'rule-abc',
+    });
+  });
+
   test('can create a link to a saved search in Discover', async () => {
     const { locator } = await setup();
     const { path } = await locator.getLocation({ savedSearchId });

--- a/src/platform/plugins/shared/discover/common/app_locator.ts
+++ b/src/platform/plugins/shared/discover/common/app_locator.ts
@@ -21,6 +21,16 @@ export const DISCOVER_APP_LOCATOR = 'DISCOVER_APP_LOCATOR';
 
 export interface DiscoverAppLocatorParams extends SerializableRecord {
   /**
+   * When true, after Discover loads in ES|QL mode, open the "Create ES|QL rule" (alerting v2) flyout.
+   * Use with a locator navigation `state` payload; requires an ES|QL `query` in the same params.
+   */
+  openCreateEsqlRuleV2Flyout?: boolean;
+  /**
+   * When set with `openCreateEsqlRuleV2Flyout`, opens the flyout in edit mode with this rule id
+   * pre-loaded (for example from alerting quick edit "Edit in Discover").
+   */
+  esqlRuleV2EditRuleId?: string;
+  /**
    * Optionally set saved search ID.
    */
   savedSearchId?: string;
@@ -142,6 +152,8 @@ export interface MainHistoryLocationState {
   dataViewSpec?: DataViewSpec;
   esqlControls?: ControlPanelsState<OptionsListESQLControlState>;
   isAlertResults?: boolean;
+  openCreateEsqlRuleV2Flyout?: boolean;
+  esqlRuleV2EditRuleId?: string;
 }
 
 export type DiscoverAppLocatorGetLocation =

--- a/src/platform/plugins/shared/discover/common/app_locator_get_location.ts
+++ b/src/platform/plugins/shared/discover/common/app_locator_get_location.ts
@@ -91,6 +91,8 @@ export const parseAppLocatorParams = (params: DiscoverAppLocatorParams) => {
     sampleSize,
     isAlertResults,
     esqlControls,
+    openCreateEsqlRuleV2Flyout,
+    esqlRuleV2EditRuleId,
   } = params;
 
   const appState: Partial<DiscoverAppState> = {};
@@ -122,6 +124,8 @@ export const parseAppLocatorParams = (params: DiscoverAppLocatorParams) => {
   if (dataViewSpec) state.dataViewSpec = dataViewSpec;
   if (isAlertResults) state.isAlertResults = isAlertResults;
   if (esqlControls) state.esqlControls = esqlControls;
+  if (openCreateEsqlRuleV2Flyout) state.openCreateEsqlRuleV2Flyout = true;
+  if (esqlRuleV2EditRuleId) state.esqlRuleV2EditRuleId = esqlRuleV2EditRuleId;
 
   return { appState, globalState, state };
 };

--- a/src/platform/plugins/shared/discover/public/application/main/components/single_tab_view/discover_open_esql_rule_v2_from_navigation.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/single_tab_view/discover_open_esql_rule_v2_from_navigation.tsx
@@ -1,0 +1,75 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React, { useEffect, useState } from 'react';
+import { useDiscoverServices } from '../../../../hooks/use_discover_services';
+import { CreateESQLRuleFlyout } from '../top_nav/app_menu_actions/create_esql_rule_flyout';
+import type { MainHistoryLocationState } from '../../../../../common';
+import { useIsEsqlMode } from '../../hooks/use_is_esql_mode';
+import {
+  useCurrentTabSelector,
+  useInternalStateGetState,
+  useInternalStateSubscribe,
+} from '../../state_management/redux';
+
+/**
+ * If navigation included `state: { openCreateEsqlRuleV2Flyout: true }` (e.g. from the alerting v2
+ * rules list "Create in Discover" action or quick edit "Edit in Discover"), open the v2 ES|QL rule
+ * form once the tab is in ES|QL mode. Optional `esqlRuleV2EditRuleId` pre-loads that rule in the form.
+ */
+export function DiscoverOpenEsqlRuleV2FromNavigation() {
+  const services = useDiscoverServices();
+  const getState = useInternalStateGetState();
+  const subscribe = useInternalStateSubscribe();
+  const tabId = useCurrentTabSelector((tab) => tab.id);
+  const isEsqlMode = useIsEsqlMode();
+  const [pendingOpen, setPendingOpen] = useState(false);
+  const [flyoutOpen, setFlyoutOpen] = useState(false);
+  const [esqlRuleV2EditRuleId, setEsqlRuleV2EditRuleId] = useState<string | undefined>(undefined);
+
+  useEffect(() => {
+    const history = services.getScopedHistory<MainHistoryLocationState>();
+    if (!history?.location.state?.openCreateEsqlRuleV2Flyout) {
+      return;
+    }
+    const editId = history.location.state.esqlRuleV2EditRuleId;
+    setEsqlRuleV2EditRuleId(typeof editId === 'string' ? editId : undefined);
+    const nextState: MainHistoryLocationState = { ...history.location.state };
+    delete nextState.openCreateEsqlRuleV2Flyout;
+    delete nextState.esqlRuleV2EditRuleId;
+    const hasRemainingState = Object.keys(nextState).length > 0;
+    history.replace({
+      ...history.location,
+      state: hasRemainingState ? nextState : undefined,
+    });
+    setPendingOpen(true);
+  }, [services]);
+
+  useEffect(() => {
+    if (pendingOpen && isEsqlMode) {
+      setFlyoutOpen(true);
+      setPendingOpen(false);
+    }
+  }, [pendingOpen, isEsqlMode]);
+
+  if (!flyoutOpen) {
+    return null;
+  }
+
+  return (
+    <CreateESQLRuleFlyout
+      services={services}
+      tabId={tabId}
+      getState={getState}
+      subscribe={subscribe}
+      editRuleId={esqlRuleV2EditRuleId}
+      onClose={() => setFlyoutOpen(false)}
+    />
+  );
+}

--- a/src/platform/plugins/shared/discover/public/application/main/components/single_tab_view/main_app.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/single_tab_view/main_app.tsx
@@ -16,6 +16,7 @@ import { useDiscoverServices } from '../../../../hooks/use_discover_services';
 import { useSavedSearchAliasMatchRedirect } from '../../../../hooks/saved_search_alias_match_redirect';
 import { useAdHocDataViews } from '../../hooks/use_adhoc_data_views';
 import { DiscoverAgentBuilderConfig } from './discover_agent_builder_config';
+import { DiscoverOpenEsqlRuleV2FromNavigation } from './discover_open_esql_rule_v2_from_navigation';
 
 const DiscoverLayoutMemoized = React.memo(DiscoverLayout);
 
@@ -40,6 +41,7 @@ export function DiscoverMainApp() {
   return (
     <RootDragDropProvider>
       <DiscoverAgentBuilderConfig />
+      <DiscoverOpenEsqlRuleV2FromNavigation />
       <DiscoverLayoutMemoized />
     </RootDragDropProvider>
   );

--- a/src/platform/plugins/shared/discover/public/application/main/components/top_nav/app_menu_actions/create_esql_rule_flyout.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/top_nav/app_menu_actions/create_esql_rule_flyout.tsx
@@ -28,12 +28,15 @@ export function CreateESQLRuleFlyout({
   getState,
   subscribe,
   onClose,
+  editRuleId,
 }: {
   services: DiscoverServices;
   tabId: string;
   getState: () => DiscoverInternalState;
   subscribe: (listener: () => void) => () => void;
   onClose: () => void;
+  /** When set, load and edit this alerting v2 rule in the flyout (deep link from quick edit). */
+  editRuleId?: string;
 }) {
   const getQuery = useCallback(() => getEsqlQuery(getState, tabId), [getState, tabId]);
 
@@ -81,5 +84,7 @@ export function CreateESQLRuleFlyout({
     return null;
   }
 
-  return <RuleFormFlyout query={query} onClose={onClose} />;
+  return (
+    <RuleFormFlyout query={query} onClose={onClose} ruleId={editRuleId} />
+  );
 }

--- a/src/platform/plugins/shared/discover/public/application/main/components/top_nav/discover_topnav.test.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/top_nav/discover_topnav.test.tsx
@@ -27,6 +27,20 @@ import { DiscoverToolkitTestProvider } from '../../../../__mocks__/test_provider
 import { DiscoverTopNavMenuProvider, discoverTopNavMenuContext } from './discover_topnav_menu';
 import type { AppMenuConfig } from '@kbn/core-chrome-app-menu-components';
 
+jest.mock('@kbn/alerts-ui-shared', () => ({
+  ...jest.requireActual('@kbn/alerts-ui-shared'),
+  useGetRuleTypesPermissions: jest.fn(() => ({
+    authorizedRuleTypes: [
+      {
+        id: '.es-query',
+        authorizedConsumers: {
+          discover: { all: true, read: true },
+        },
+      },
+    ],
+  })),
+}));
+
 let mockDiscoverService = createDiscoverServicesMock();
 type AggregateQueryTopNavMenuProps = ComponentProps<
   typeof mockDiscoverService.navigation.ui.AggregateQueryTopNavMenu

--- a/src/platform/plugins/shared/discover/public/application/main/components/top_nav/discover_topnav.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/top_nav/discover_topnav.tsx
@@ -12,8 +12,10 @@ import { DataViewType, type DataView, type DataViewSpec } from '@kbn/data-views-
 import {
   DiscoverFlyouts,
   dismissAllFlyoutsExceptFor,
+  dismissFlyouts,
   prepareDataViewForEditing,
 } from '@kbn/discover-utils';
+import { useGetRuleTypesPermissions, type RuleTypeWithDescription } from '@kbn/alerts-ui-shared';
 import type { ESQLEditorRestorableState } from '@kbn/esql-editor';
 import { useESQLQueryStats } from '@kbn/esql/public';
 import { type Query, type TimeRange, type AggregateQuery } from '@kbn/es-query';
@@ -40,10 +42,12 @@ import {
   useInternalStateDispatch,
   useInternalStateGetState,
   useInternalStateSelector,
+  useInternalStateSubscribe,
 } from '../../state_management/redux';
 import { DiscoverTopNavMenu } from './discover_topnav_menu';
 import { ESQLToDataViewTransitionModal } from './esql_dataview_transition';
 import { DiscoverSessionSaveModalContainer } from './save_discover_session';
+import { CreateESQLRuleFlyout } from './app_menu_actions/create_esql_rule_flyout';
 import {
   isDiscoverInspectorInTabMenu,
   useDiscoverTopNavWithInspector,
@@ -137,6 +141,7 @@ export const DiscoverTopNav = ({
 }: DiscoverTopNavProps) => {
   const dispatch = useInternalStateDispatch();
   const getState = useInternalStateGetState();
+  const subscribe = useInternalStateSubscribe();
   const currentTabId = useCurrentTabSelector((tab) => tab.id);
   const services = useDiscoverServices();
   const { dataViewEditor, navigation, dataViewFieldEditor, data } = services;
@@ -144,6 +149,7 @@ export const DiscoverTopNav = ({
   const [controlGroupApi, setControlGroupApi] = useState<ControlGroupRendererApi | undefined>();
   const [isSaveModalVisible, setIsSaveModalVisible] = useState(false);
   const [initialCopyOnSave, setInitialCopyOnSave] = useState(false);
+  const [isCreateEsqlRuleFlyoutOpen, setIsCreateEsqlRuleFlyoutOpen] = useState(false);
 
   const onSaveCbRef = useRef<(() => void) | undefined>(undefined);
 
@@ -163,6 +169,33 @@ export const DiscoverTopNav = ({
     (state) => state.persistedDiscoverSession
   );
   const isEsqlMode = useIsEsqlMode();
+  const { authorizedRuleTypes } = useGetRuleTypesPermissions({
+    http: services.http,
+    toasts: services.notifications.toasts,
+  });
+  const authorizedRuleTypeIds = useMemo(
+    () =>
+      authorizedRuleTypes
+        .filter((ruleType: RuleTypeWithDescription) =>
+          Object.values(ruleType.authorizedConsumers).some((consumer) => consumer.all)
+        )
+        .map((ruleType) => ruleType.id),
+    [authorizedRuleTypes]
+  );
+  const showCreateEsqlRuleShortcut =
+    isEsqlMode &&
+    !!services.capabilities.alertingVTwo &&
+    !!services.triggersActionsUi &&
+    authorizedRuleTypeIds.length > 0;
+
+  const onCreateEsqlAlertingRule = useCallback(() => {
+    if (!showCreateEsqlRuleShortcut) {
+      return;
+    }
+    dismissFlyouts();
+    setIsCreateEsqlRuleFlyoutOpen(true);
+  }, [showCreateEsqlRuleShortcut]);
+
   const showDatePicker = useMemo(() => {
     // always show the timepicker for ES|QL mode
     return (
@@ -496,7 +529,17 @@ export const DiscoverTopNav = ({
         }
         esqlQueryStats={esqlQueryStats}
         onOpenQueryInNewTab={onOpenQueryInNewTab}
+        onCreateEsqlAlertingRule={showCreateEsqlRuleShortcut ? onCreateEsqlAlertingRule : undefined}
       />
+      {isCreateEsqlRuleFlyoutOpen && (
+        <CreateESQLRuleFlyout
+          services={services}
+          tabId={currentTabId}
+          getState={getState}
+          subscribe={subscribe}
+          onClose={() => setIsCreateEsqlRuleFlyoutOpen(false)}
+        />
+      )}
       {isESQLToDataViewTransitionModalVisible && (
         <ESQLToDataViewTransitionModal onClose={onESQLToDataViewTransitionModalClose} />
       )}

--- a/src/platform/plugins/shared/unified_search/public/query_string_input/query_bar_top_row.tsx
+++ b/src/platform/plugins/shared/unified_search/public/query_string_input/query_bar_top_row.tsx
@@ -246,6 +246,10 @@ export interface QueryBarTopRowProps<QT extends Query | AggregateQuery = Query> 
    * Optional ES|QL prop - Callback function invoked to open the given ES|QL query in a new Discover tab
    */
   onOpenQueryInNewTab?: ESQLEditorProps['onOpenQueryInNewTab'];
+  /**
+   * Optional ES|QL prop - Registers editor shortcut to create an alerting rule from the current query
+   */
+  onCreateEsqlAlertingRule?: ESQLEditorProps['onCreateEsqlAlertingRule'];
   onESQLDocsFlyoutVisibilityChanged?: (isOpen: boolean) => void;
   /**
    * Optional ES|QL prop - Enable data source browser in ESQL editor
@@ -1211,6 +1215,7 @@ export const QueryBarTopRow = React.memo(
             }
             esqlVariables={props.esqlVariablesConfig?.esqlVariables ?? []}
             onOpenQueryInNewTab={props.onOpenQueryInNewTab}
+            onCreateEsqlAlertingRule={props.onCreateEsqlAlertingRule}
             queryStats={props.esqlQueryStats}
             enableResourceBrowser={props.enableResourceBrowser}
           />

--- a/src/platform/plugins/shared/unified_search/public/search_bar/search_bar.tsx
+++ b/src/platform/plugins/shared/unified_search/public/search_bar/search_bar.tsx
@@ -166,6 +166,7 @@ export interface SearchBarOwnProps<QT extends AggregateQuery | Query = Query> {
 
   /** Optional configurations for the lookup join index editor */
   onOpenQueryInNewTab?: QueryBarTopRowProps['onOpenQueryInNewTab'];
+  onCreateEsqlAlertingRule?: QueryBarTopRowProps['onCreateEsqlAlertingRule'];
 
   esqlEditorInitialState?: QueryBarTopRowProps['esqlEditorInitialState'];
   onEsqlEditorInitialStateChange?: QueryBarTopRowProps['onEsqlEditorInitialStateChange'];
@@ -805,6 +806,7 @@ export class SearchBarUI<QT extends (Query | AggregateQuery) | Query = Query> ex
           esqlVariablesConfig={this.props.esqlVariablesConfig}
           esqlQueryStats={this.props.esqlQueryStats}
           onOpenQueryInNewTab={this.props.onOpenQueryInNewTab}
+          onCreateEsqlAlertingRule={this.props.onCreateEsqlAlertingRule}
           useBackgroundSearchButton={this.props.useBackgroundSearchButton}
           enableDateRangePicker={this.props.enableDateRangePicker}
           enableResourceBrowser={this.props.enableResourceBrowser}

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/dynamic_rule_form_flyout.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/dynamic_rule_form_flyout.tsx
@@ -57,6 +57,7 @@ const DynamicRuleFormFlyoutInner = ({
         query={query}
         services={services}
         layout="flyout"
+        includeYaml
       />
     </RuleFormFlyout>
   );

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/rule_form_flyout.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/rule_form_flyout.tsx
@@ -27,6 +27,11 @@ export interface RuleFormFlyoutProps {
   onClose?: () => void;
   isLoading?: boolean;
   children: React.ReactNode;
+  /**
+   * `create` (default) shows "Create Alert Rule" and a create-style primary action;
+   * `edit` shows edit copy and "Save" for update flows (for example, editing from Discover).
+   */
+  variant?: 'create' | 'edit';
 }
 
 /**
@@ -47,7 +52,9 @@ export const RuleFormFlyout = ({
   onClose,
   isLoading = false,
   children,
+  variant = 'create',
 }: RuleFormFlyoutProps) => {
+  const isEdit = variant === 'edit';
   const clickedRef = useRef(false);
 
   const onFocusCapture = useCallback(
@@ -66,7 +73,7 @@ export const RuleFormFlyout = ({
     <EuiFlyout
       session="start"
       flyoutMenuProps={{
-        title: 'Create Alert Rule',
+        title: isEdit ? 'Edit Alert Rule' : 'Create Alert Rule',
         hideTitle: true,
       }}
       type={push ? 'push' : 'overlay'}
@@ -86,12 +93,19 @@ export const RuleFormFlyout = ({
         onFocusCapture={onFocusCapture}
       >
         <EuiFlyoutHeader hasBorder>
-          <EuiTitle size="m" id={FLYOUT_TITLE_ID}>
+          <EuiTitle size="s" id={FLYOUT_TITLE_ID}>
             <h2>
-              <FormattedMessage
-                id="xpack.alertingV2.ruleForm.flyoutTitle"
-                defaultMessage="Create Alert Rule"
-              />
+              {isEdit ? (
+                <FormattedMessage
+                  id="xpack.alertingV2.ruleForm.flyoutTitleEdit"
+                  defaultMessage="Edit Alert Rule"
+                />
+              ) : (
+                <FormattedMessage
+                  id="xpack.alertingV2.ruleForm.flyoutTitle"
+                  defaultMessage="Create Alert Rule"
+                />
+              )}
             </h2>
           </EuiTitle>
         </EuiFlyoutHeader>
@@ -114,10 +128,17 @@ export const RuleFormFlyout = ({
                 type="submit"
                 data-test-subj="ruleV2FlyoutSaveButton"
               >
-                <FormattedMessage
-                  id="xpack.alertingV2.ruleForm.createRuleButtonLabel"
-                  defaultMessage="Create rule"
-                />
+                {isEdit ? (
+                  <FormattedMessage
+                    id="xpack.alertingV2.ruleForm.saveRuleButtonLabel"
+                    defaultMessage="Save"
+                  />
+                ) : (
+                  <FormattedMessage
+                    id="xpack.alertingV2.ruleForm.createRuleButtonLabel"
+                    defaultMessage="Create rule"
+                  />
+                )}
               </EuiButton>
             </EuiFlexItem>
           </EuiFlexGroup>

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/standalone_rule_form_flyout.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/standalone_rule_form_flyout.tsx
@@ -57,6 +57,7 @@ const StandaloneRuleFormFlyoutInner = ({
         query={query}
         services={services}
         layout="flyout"
+        includeYaml
       />
     </RuleFormFlyout>
   );

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/components/edit_mode_toggle.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/components/edit_mode_toggle.test.tsx
@@ -17,17 +17,17 @@ describe('EditModeToggle', () => {
     jest.clearAllMocks();
   });
 
-  it('renders Form and YAML buttons', () => {
+  it('renders GUI and YAML buttons', () => {
     render(<EditModeToggle editMode="form" onChange={mockOnChange} />);
 
-    expect(screen.getByText('Form')).toBeInTheDocument();
+    expect(screen.getByText('GUI')).toBeInTheDocument();
     expect(screen.getByText('YAML')).toBeInTheDocument();
   });
 
-  it('shows Form as selected when editMode is form', () => {
+  it('shows GUI as selected when editMode is form', () => {
     render(<EditModeToggle editMode="form" onChange={mockOnChange} />);
 
-    const formButton = screen.getByText('Form').closest('button');
+    const formButton = screen.getByText('GUI').closest('button');
     expect(formButton).toHaveClass('euiButtonGroupButton-isSelected');
   });
 
@@ -46,10 +46,10 @@ describe('EditModeToggle', () => {
     expect(mockOnChange).toHaveBeenCalledWith('yaml');
   });
 
-  it('calls onChange with "form" when Form button is clicked', async () => {
+  it('calls onChange with "form" when GUI button is clicked', async () => {
     render(<EditModeToggle editMode="yaml" onChange={mockOnChange} />);
 
-    await userEvent.click(screen.getByText('Form'));
+    await userEvent.click(screen.getByText('GUI'));
 
     expect(mockOnChange).toHaveBeenCalledWith('form');
   });
@@ -57,7 +57,7 @@ describe('EditModeToggle', () => {
   it('disables buttons when disabled prop is true', () => {
     render(<EditModeToggle editMode="form" onChange={mockOnChange} disabled />);
 
-    const formButton = screen.getByText('Form').closest('button');
+    const formButton = screen.getByText('GUI').closest('button');
     const yamlButton = screen.getByText('YAML').closest('button');
 
     expect(formButton).toBeDisabled();

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/components/edit_mode_toggle.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/components/edit_mode_toggle.tsx
@@ -20,10 +20,10 @@ interface EditModeToggleProps {
 const toggleButtons = [
   {
     id: 'form',
-    label: i18n.translate('xpack.alertingV2.ruleForm.editMode.form', {
-      defaultMessage: 'Form',
+    label: i18n.translate('xpack.alertingV2.ruleForm.editMode.gui', {
+      defaultMessage: 'GUI',
     }),
-    iconType: 'productDashboard',
+    iconType: 'tableOfContents',
     'data-test-subj': 'ruleV2FormEditModeFormButton',
   },
   {

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/components/submission_buttons.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/components/submission_buttons.test.tsx
@@ -64,4 +64,14 @@ describe('SubmissionButtons', () => {
     expect(screen.queryByTestId('showRequestCreateTab')).not.toBeInTheDocument();
     expect(screen.queryByTestId('showRequestUpdateTab')).not.toBeInTheDocument();
   });
+
+  it('does not render show request when showRequestButton is false', () => {
+    render(
+      <SubmissionButtons isSubmitting={false} onCancel={jest.fn()} showRequestButton={false} />,
+      { wrapper: createFormWrapper() }
+    );
+
+    expect(screen.queryByTestId('ruleV2FormShowRequestButton')).not.toBeInTheDocument();
+    expect(screen.getByTestId('ruleV2FormSubmitButton')).toBeInTheDocument();
+  });
 });

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/components/submission_buttons.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/components/submission_buttons.tsx
@@ -28,6 +28,8 @@ export interface SubmissionButtonsProps {
   submitLabel?: React.ReactNode;
   cancelLabel?: React.ReactNode;
   ruleId?: string;
+  /** When false, hides the "Show request" action (e.g. quick edit flyout). Default: true. */
+  showRequestButton?: boolean;
 }
 
 export const SubmissionButtons = ({
@@ -36,6 +38,7 @@ export const SubmissionButtons = ({
   submitLabel,
   cancelLabel,
   ruleId,
+  showRequestButton = true,
 }: SubmissionButtonsProps) => {
   const [isShowRequestVisible, setIsShowRequestVisible] = useState(false);
 
@@ -66,29 +69,42 @@ export const SubmissionButtons = ({
           </EuiFlexItem>
         )}
         <EuiFlexItem grow={false}>
-          <EuiFlexGroup gutterSize="m">
-            <EuiFlexItem grow={false}>
-              <EuiButtonEmpty
-                onClick={onShowRequest}
-                isDisabled={isSubmitting}
-                data-test-subj="ruleV2FormShowRequestButton"
-              >
-                {SHOW_REQUEST_LABEL}
-              </EuiButtonEmpty>
-            </EuiFlexItem>
-            <EuiFlexItem grow={false}>
-              <EuiButton
-                type="submit"
-                form={RULE_FORM_ID}
-                isLoading={isSubmitting}
-                fill
-                iconType="plusInCircle"
-                data-test-subj="ruleV2FormSubmitButton"
-              >
-                {submitLabel ?? defaultSubmitLabel}
-              </EuiButton>
-            </EuiFlexItem>
-          </EuiFlexGroup>
+          {showRequestButton ? (
+            <EuiFlexGroup gutterSize="m">
+              <EuiFlexItem grow={false}>
+                <EuiButtonEmpty
+                  onClick={onShowRequest}
+                  isDisabled={isSubmitting}
+                  data-test-subj="ruleV2FormShowRequestButton"
+                >
+                  {SHOW_REQUEST_LABEL}
+                </EuiButtonEmpty>
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiButton
+                  type="submit"
+                  form={RULE_FORM_ID}
+                  isLoading={isSubmitting}
+                  fill
+                  iconType="plusInCircle"
+                  data-test-subj="ruleV2FormSubmitButton"
+                >
+                  {submitLabel ?? defaultSubmitLabel}
+                </EuiButton>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          ) : (
+            <EuiButton
+              type="submit"
+              form={RULE_FORM_ID}
+              isLoading={isSubmitting}
+              fill
+              iconType="plusInCircle"
+              data-test-subj="ruleV2FormSubmitButton"
+            >
+              {submitLabel ?? defaultSubmitLabel}
+            </EuiButton>
+          )}
         </EuiFlexItem>
       </EuiFlexGroup>
       {isShowRequestVisible && <ShowRequestModal ruleId={ruleId} onClose={onCloseShowRequest} />}

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/contexts/index.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/contexts/index.ts
@@ -12,4 +12,5 @@ export {
   type RuleFormServices,
   type RuleFormMeta,
   type RuleFormLayout,
+  type RuleFormVariant,
 } from './rule_form_context';

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/contexts/rule_form_context.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/contexts/rule_form_context.tsx
@@ -19,13 +19,22 @@ export interface RuleFormServices {
   notifications: NotificationsStart;
   application: ApplicationStart;
   lens: LensPublicStart;
+  /**
+   * Open the given ES|QL in Discover. When omitted, "Open in Discover" is not shown
+   * in the rule summary / preview header.
+   */
+  openEsqlInDiscover?: (esql: string) => void | Promise<void>;
 }
 
 export type RuleFormLayout = 'page' | 'flyout';
 
+export type RuleFormVariant = 'default' | 'quickEdit';
+
 export interface RuleFormMeta {
   /** Whether the form is rendered on a full page or inside a flyout. */
   layout: RuleFormLayout;
+  /** `quickEdit` hides kind/runbook and collapses alert conditions by default. */
+  formVariant?: RuleFormVariant;
 }
 
 interface RuleFormContextValue {

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/dynamic_rule_form.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/dynamic_rule_form.tsx
@@ -67,7 +67,7 @@ export const DynamicRuleForm = ({
   cancelLabel,
 }: DynamicRuleFormProps) => {
   // Get default form values derived from the query
-  const formValues = useFormDefaults({ query });
+  const formValues = useFormDefaults({ query, defaultSource: 'discover' });
 
   const methods = useForm<FormValues>({
     mode: 'onBlur',

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/field_groups/alert_conditions_field_group.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/field_groups/alert_conditions_field_group.tsx
@@ -28,7 +28,14 @@ import { RecoveryDelayField } from '../fields/recovery_delay_field';
  *     uses RecoveryBaseQueryOnlyField (full ES|QL editor with "not same as eval" validation)
  * - Recovery delay (recovering state transition: immediate / recoveries / duration)
  */
-export const AlertConditionsFieldGroup = () => {
+export interface AlertConditionsFieldGroupProps {
+  /** When false, alert conditions section starts collapsed (quick edit). */
+  defaultOpen?: boolean;
+}
+
+export const AlertConditionsFieldGroup = ({
+  defaultOpen = true,
+}: AlertConditionsFieldGroupProps) => {
   const { control } = useFormContext<FormValues>();
   const { data } = useRuleFormServices();
   const kind = useWatch({ control, name: 'kind' });
@@ -47,7 +54,7 @@ export const AlertConditionsFieldGroup = () => {
       title={i18n.translate('xpack.alertingV2.ruleForm.alertConditions', {
         defaultMessage: 'Alert conditions',
       })}
-      defaultOpen
+      defaultOpen={defaultOpen}
     >
       <AlertDelayField />
       <EuiSpacer size="m" />

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/field_groups/condition_field_group.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/field_groups/condition_field_group.tsx
@@ -10,7 +10,9 @@ import { i18n } from '@kbn/i18n';
 import { EuiSpacer, EuiFormRow, EuiCodeBlock } from '@elastic/eui';
 import { useFormContext, useWatch } from 'react-hook-form';
 import type { FormValues } from '../types';
+import { useRuleFormMeta } from '../contexts';
 import { FieldGroup } from './field_group';
+import { PageRuleEvaluationFieldGroup } from './page_rule_evaluation_field_group';
 import { EvaluationQueryField } from '../fields/evaluation_query_field';
 import { GroupFieldSelect } from '../fields/group_field_select';
 import { TimeFieldSelect } from '../fields/time_field_select';
@@ -22,22 +24,35 @@ interface ConditionFieldGroupProps {
    * When false, shows the base query as read-only (if available).
    */
   includeBase?: boolean;
+  /** When true, read-only block uses the "ES|QL query" label (quick edit / builder). */
+  readOnlyQueryLabelEsql?: boolean;
 }
 
 /**
  * Condition field group for configuring alert trigger conditions.
  *
- * This component displays:
- * - An editable ES|QL query editor (when includeBase is true) OR a read-only view of the base query
+ * On the **page** layout (and not `quickEdit`), this renders the split-panel
+ * “Threshold Alert” evaluation block from RnA Figma; the ES|QL query is
+ * read-only in the right column (rule summary). Flyouts and quick edit keep
+ * the previous “Rule evaluation” field group.
  *
- * The full ES|QL query defines what data is being evaluated, including any
- * trigger condition (e.g. a trailing WHERE clause).
+ * Otherwise: an ES|QL query editor (when includeBase is true) or a read-only
+ * base query, plus group and time fields.
  */
-export const ConditionFieldGroup = ({ includeBase = false }: ConditionFieldGroupProps) => {
+export const ConditionFieldGroup = ({
+  includeBase = false,
+  readOnlyQueryLabelEsql = false,
+}: ConditionFieldGroupProps) => {
   const { control } = useFormContext<FormValues>();
+  const { layout, formVariant = 'default' } = useRuleFormMeta();
+  const usePageEvaluationLayout = layout === 'page' && formVariant !== 'quickEdit';
 
   // Read the base query from form state (initialized via useFormDefaults)
   const baseQuery = useWatch({ control, name: 'evaluation.query.base' });
+
+  if (usePageEvaluationLayout) {
+    return <PageRuleEvaluationFieldGroup />;
+  }
 
   return (
     <FieldGroup
@@ -56,9 +71,15 @@ export const ConditionFieldGroup = ({ includeBase = false }: ConditionFieldGroup
         baseQuery && (
           <>
             <EuiFormRow
-              label={i18n.translate('xpack.alertingV2.ruleForm.baseQueryLabel', {
-                defaultMessage: 'Base query',
-              })}
+              label={
+                readOnlyQueryLabelEsql
+                  ? i18n.translate('xpack.alertingV2.ruleForm.esqlQueryLabel', {
+                      defaultMessage: 'ES|QL query',
+                    })
+                  : i18n.translate('xpack.alertingV2.ruleForm.baseQueryLabel', {
+                      defaultMessage: 'Base query',
+                    })
+              }
               fullWidth
             >
               <EuiCodeBlock language="esql" fontSize="m" paddingSize="m" isCopyable>

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/field_groups/page_rule_evaluation_field_group.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/field_groups/page_rule_evaluation_field_group.tsx
@@ -1,0 +1,340 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import {
+  EuiButtonEmpty,
+  EuiFieldText,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFormRow,
+  EuiHorizontalRule,
+  EuiPanel,
+  EuiSelect,
+  EuiSpacer,
+  EuiSplitPanel,
+  EuiText,
+  EuiTitle,
+  useGeneratedHtmlId,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { Controller, useFormContext } from 'react-hook-form';
+import { validateEsqlQuery } from '@kbn/alerting-v2-schemas';
+import type { FormValues } from '../types';
+import { DataSourceField } from '../fields/data_source_field';
+import { GroupFieldSelect } from '../fields/group_field_select';
+import { TimeFieldSelect } from '../fields/time_field_select';
+
+const TIME_FIELD_HELP = i18n.translate('xpack.alertingV2.ruleForm.pageEvaluation.timeFieldHelp', {
+  defaultMessage: 'Select the timestamp field to use for time-based queries',
+});
+
+const StatsPlaceholder = () => {
+  const labelId = useGeneratedHtmlId({ prefix: 'statsLabel' });
+  const aggId = useGeneratedHtmlId({ prefix: 'statsAgg' });
+  const fieldId = useGeneratedHtmlId({ prefix: 'statsField' });
+
+  return (
+    <div>
+      <EuiTitle size="xxs">
+        <h4>
+          {i18n.translate('xpack.alertingV2.ruleForm.pageEvaluation.statsSectionTitle', {
+            defaultMessage: 'STATS',
+          })}
+        </h4>
+      </EuiTitle>
+      <EuiSpacer size="xs" />
+      <EuiPanel paddingSize="s" hasBorder grow={false}>
+        <EuiFlexGroup gutterSize="s" responsive={false} wrap>
+          <EuiFlexItem grow={true} style={{ minWidth: '120px' }}>
+            <EuiFormRow
+              id={labelId}
+              label={i18n.translate('xpack.alertingV2.ruleForm.pageEvaluation.statsLabelField', {
+                defaultMessage: 'label',
+              })}
+            >
+              <EuiFieldText
+                id={labelId}
+                name={labelId}
+                placeholder="avg_cpu"
+                fullWidth
+                compressed
+              />
+            </EuiFormRow>
+          </EuiFlexItem>
+          <EuiFlexItem grow={true} style={{ minWidth: '100px' }}>
+            <EuiFormRow
+              id={aggId}
+              label={i18n.translate(
+                'xpack.alertingV2.ruleForm.pageEvaluation.statsAggregationField',
+                {
+                  defaultMessage: 'aggregation',
+                }
+              )}
+            >
+              <EuiSelect
+                id={aggId}
+                name={aggId}
+                options={[
+                  {
+                    value: 'avg',
+                    text: i18n.translate(
+                      'xpack.alertingV2.ruleForm.pageEvaluation.aggregationAverage',
+                      {
+                        defaultMessage: 'Average',
+                      }
+                    ),
+                  },
+                  {
+                    value: 'max',
+                    text: i18n.translate(
+                      'xpack.alertingV2.ruleForm.pageEvaluation.aggregationMax',
+                      {
+                        defaultMessage: 'Max',
+                      }
+                    ),
+                  },
+                ]}
+                fullWidth
+                compressed
+              />
+            </EuiFormRow>
+          </EuiFlexItem>
+          <EuiFlexItem grow={true} style={{ minWidth: '180px' }}>
+            <EuiFormRow
+              id={fieldId}
+              label={i18n.translate('xpack.alertingV2.ruleForm.pageEvaluation.statsValueField', {
+                defaultMessage: 'field',
+              })}
+            >
+              <EuiSelect
+                id={fieldId}
+                name={fieldId}
+                options={[
+                  {
+                    value: 'system.cpu',
+                    text: 'system.cpu.total.norm.pct',
+                  },
+                  {
+                    value: 'system.memory',
+                    text: 'system.memory.used.pct',
+                  },
+                ]}
+                fullWidth
+                compressed
+              />
+            </EuiFormRow>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiPanel>
+      <EuiSpacer size="s" />
+      <EuiButtonEmpty
+        type="button"
+        size="xs"
+        iconType="plusInCircle"
+        flush="both"
+        data-test-subj="ruleV2PageRuleEvaluationAddStats"
+        onClick={() => {
+          // STATS rows will be bound to form state in a follow-up
+        }}
+      >
+        {i18n.translate('xpack.alertingV2.ruleForm.pageEvaluation.addAnotherStats', {
+          defaultMessage: 'Add another stats',
+        })}
+      </EuiButtonEmpty>
+    </div>
+  );
+};
+
+const TriggerPlaceholder = () => {
+  const labelId = useGeneratedHtmlId({ prefix: 'trigLabel' });
+  const opId = useGeneratedHtmlId({ prefix: 'trigOp' });
+  const valueId = useGeneratedHtmlId({ prefix: 'trigValue' });
+
+  return (
+    <div>
+      <EuiTitle size="xxs">
+        <h4>
+          {i18n.translate('xpack.alertingV2.ruleForm.pageEvaluation.triggerSectionTitle', {
+            defaultMessage: 'Trigger condition',
+          })}
+        </h4>
+      </EuiTitle>
+      <EuiSpacer size="xs" />
+      <EuiPanel paddingSize="s" hasBorder grow={false}>
+        <EuiFlexGroup gutterSize="s" responsive={false} wrap>
+          <EuiFlexItem grow={true} style={{ minWidth: '120px' }}>
+            <EuiFormRow
+              id={labelId}
+              label={i18n.translate('xpack.alertingV2.ruleForm.pageEvaluation.triggerLabelField', {
+                defaultMessage: 'label',
+              })}
+            >
+              <EuiSelect
+                id={labelId}
+                name={labelId}
+                options={[
+                  {
+                    value: 'avg_cpu',
+                    text: 'avg_cpu',
+                  },
+                  {
+                    value: 'max_mem',
+                    text: 'max_mem',
+                  },
+                ]}
+                fullWidth
+                compressed
+              />
+            </EuiFormRow>
+          </EuiFlexItem>
+          <EuiFlexItem grow={true} style={{ minWidth: '100px' }}>
+            <EuiFormRow
+              id={opId}
+              label={i18n.translate(
+                'xpack.alertingV2.ruleForm.pageEvaluation.triggerOperatorField',
+                {
+                  defaultMessage: 'operator',
+                }
+              )}
+            >
+              <EuiSelect
+                id={opId}
+                name={opId}
+                options={[
+                  {
+                    value: 'gt',
+                    text: i18n.translate(
+                      'xpack.alertingV2.ruleForm.pageEvaluation.triggerOperatorAbove',
+                      {
+                        defaultMessage: 'is above',
+                      }
+                    ),
+                  },
+                  {
+                    value: 'lt',
+                    text: i18n.translate(
+                      'xpack.alertingV2.ruleForm.pageEvaluation.triggerOperatorBelow',
+                      {
+                        defaultMessage: 'is below',
+                      }
+                    ),
+                  },
+                ]}
+                fullWidth
+                compressed
+              />
+            </EuiFormRow>
+          </EuiFlexItem>
+          <EuiFlexItem grow={true} style={{ minWidth: '120px' }}>
+            <EuiFormRow
+              id={valueId}
+              label={i18n.translate('xpack.alertingV2.ruleForm.pageEvaluation.triggerValueField', {
+                defaultMessage: 'value',
+              })}
+            >
+              <EuiFieldText
+                id={valueId}
+                name={valueId}
+                placeholder={i18n.translate(
+                  'xpack.alertingV2.ruleForm.pageEvaluation.triggerValuePlaceholder',
+                  {
+                    defaultMessage: 'Type text',
+                  }
+                )}
+                fullWidth
+                compressed
+              />
+            </EuiFormRow>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiPanel>
+      <EuiSpacer size="s" />
+      <EuiButtonEmpty
+        type="button"
+        size="xs"
+        iconType="plusInCircle"
+        flush="both"
+        data-test-subj="ruleV2PageRuleEvaluationAddCondition"
+        onClick={() => {
+          // Trigger rows will be bound to form state in a follow-up
+        }}
+      >
+        {i18n.translate('xpack.alertingV2.ruleForm.pageEvaluation.addAnotherCondition', {
+          defaultMessage: 'Add another condition',
+        })}
+      </EuiButtonEmpty>
+    </div>
+  );
+};
+
+/**
+ * Full-page "Rule evaluation" block (EuiSplitPanel) aligned with RnA Rule Authoring Figma.
+ * The ES|QL query is shown read-only in the right column; this block keeps the builder fields only.
+ *
+ * Figma: https://www.figma.com/design/tY4wbu3wXh4XK9p4MmYRLQ/RnA---Rule-Authoring-experience?node-id=1441-15488
+ */
+export const PageRuleEvaluationFieldGroup = () => {
+  const { control } = useFormContext<FormValues>();
+  const evaluationTitle = i18n.translate('xpack.alertingV2.ruleForm.pageEvaluation.typeThreshold', {
+    defaultMessage: 'Threshold Alert',
+  });
+
+  return (
+    <>
+      <EuiSplitPanel.Outer
+        hasBorder
+        hasShadow={false}
+        data-test-subj="pageRuleEvaluationFieldGroup"
+      >
+        <EuiSplitPanel.Inner color="subdued" paddingSize="s">
+          <EuiText size="s" data-test-subj="pageRuleEvaluationTitle">
+            <p>
+              <strong>{evaluationTitle}</strong>
+            </p>
+          </EuiText>
+        </EuiSplitPanel.Inner>
+        <EuiSplitPanel.Inner paddingSize="m" color="plain">
+          <EuiFlexGroup direction="column" gutterSize="m" alignItems="stretch" responsive={false}>
+            <EuiFlexItem grow={false}>
+              <DataSourceField />
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <GroupFieldSelect />
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <TimeFieldSelect helpText={TIME_FIELD_HELP} />
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiHorizontalRule margin="xs" />
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <StatsPlaceholder />
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiHorizontalRule margin="xs" />
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <TriggerPlaceholder />
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiSplitPanel.Inner>
+      </EuiSplitPanel.Outer>
+      <Controller
+        name="evaluation.query.base"
+        control={control}
+        rules={{
+          required: i18n.translate('xpack.alertingV2.ruleForm.queryRequiredError', {
+            defaultMessage: 'ES|QL query is required.',
+          }),
+          validate: (value) => validateEsqlQuery(value) ?? true,
+        }}
+        render={() => null}
+      />
+    </>
+  );
+};

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/field_groups/rule_details_field_group.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/field_groups/rule_details_field_group.test.tsx
@@ -37,10 +37,10 @@ describe('RuleDetailsFieldGroup', () => {
     );
 
     expect(screen.getByText('Tags')).toBeInTheDocument();
-    expect(screen.getByText('optional')).toBeInTheDocument();
+    expect(screen.getAllByText('optional').length).toBeGreaterThanOrEqual(1);
   });
 
-  it('renders the add description button initially', () => {
+  it('renders the description field with optional label', () => {
     const Wrapper = createFormWrapper();
 
     render(
@@ -48,22 +48,9 @@ describe('RuleDetailsFieldGroup', () => {
         <RuleDetailsFieldGroup />
       </Wrapper>
     );
-
-    expect(screen.getByText('Add description')).toBeInTheDocument();
-  });
-
-  it('renders the description field when add description is clicked', async () => {
-    const Wrapper = createFormWrapper();
-
-    render(
-      <Wrapper>
-        <RuleDetailsFieldGroup />
-      </Wrapper>
-    );
-
-    await userEvent.click(screen.getByText('Add description'));
 
     expect(screen.getByText('Description')).toBeInTheDocument();
+    expect(screen.getByTestId('ruleDescriptionInput')).toBeInTheDocument();
   });
 
   it('does not render enabled or kind fields', () => {

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/field_groups/rule_details_field_group.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/field_groups/rule_details_field_group.tsx
@@ -14,8 +14,8 @@ export const RuleDetailsFieldGroup = () => {
   return (
     <>
       <NameField />
-      <TagsField />
       <DescriptionField />
+      <TagsField />
     </>
   );
 };

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/data_source_field.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/data_source_field.tsx
@@ -1,0 +1,127 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { EuiFormRow, EuiSelect } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { useFormContext, useWatch } from 'react-hook-form';
+import type { DataViewListItem } from '@kbn/data-views-plugin/common';
+import type { FormValues } from '../types';
+import { useRuleFormMeta, useRuleFormServices } from '../contexts';
+
+const FROM_PATTERN = /^\s*FROM\s+([^\n|]+)/i;
+
+/**
+ * Replaces the first `FROM` clause in an ES|QL string, or prepends a minimal query.
+ */
+export const replaceDataSourceInEsqlQuery = (query: string, dataSource: string): string => {
+  const source = dataSource.trim();
+  if (!source) {
+    return query;
+  }
+  if (/^\s*FROM\s+/i.test(query)) {
+    return query.replace(/^\s*FROM\s+[^\n|]+/im, `FROM ${source}`);
+  }
+  if (!query?.trim()) {
+    return `FROM ${source}\n| LIMIT 1`;
+  }
+  return `FROM ${source}\n${query}`;
+};
+
+const parseFromClause = (baseQuery: string | undefined): string => {
+  if (!baseQuery) {
+    return '';
+  }
+  return FROM_PATTERN.exec(baseQuery)?.[1]?.trim() ?? '';
+};
+
+/**
+ * Data source for page rule evaluation: `FROM` value backed by data views, updates `evaluation.query.base`.
+ */
+export const DataSourceField = () => {
+  const { dataViews } = useRuleFormServices();
+  const { layout } = useRuleFormMeta();
+  const { control, setValue } = useFormContext<FormValues>();
+  const baseQuery = useWatch({ name: 'evaluation.query.base', control });
+  const dataSourceRowId = 'ruleV2FormDataSourceField';
+  const [dataViewList, setDataViewList] = useState<DataViewListItem[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    let cancel = false;
+    dataViews
+      .getIdsWithTitle()
+      .then((list) => {
+        if (!cancel) {
+          setDataViewList(list);
+        }
+      })
+      .finally(() => {
+        if (!cancel) {
+          setIsLoading(false);
+        }
+      });
+    return () => {
+      cancel = true;
+    };
+  }, [dataViews]);
+
+  const fromClause = useMemo(() => parseFromClause(baseQuery), [baseQuery]);
+
+  const selectOptions = useMemo(() => {
+    const placeholder = {
+      value: '',
+      text: i18n.translate('xpack.alertingV2.ruleForm.pageEvaluation.dataSourcePlaceholder', {
+        defaultMessage: 'Select a data source',
+      }),
+      disabled: true,
+    };
+    const fromDataViews = dataViewList.map((item) => ({
+      value: item.title,
+      text: item.name?.trim() ? `${item.name} (${item.title})` : item.title,
+    }));
+    if (fromClause && !fromDataViews.some((o) => o.value === fromClause)) {
+      return [placeholder, { value: fromClause, text: fromClause }, ...fromDataViews];
+    }
+    return [placeholder, ...fromDataViews];
+  }, [dataViewList, fromClause]);
+
+  const onDataSourceChange = useCallback(
+    (event: React.ChangeEvent<HTMLSelectElement>) => {
+      const next = event.target.value;
+      setValue('evaluation.query.base', replaceDataSourceInEsqlQuery(baseQuery ?? '', next), {
+        shouldValidate: true,
+        shouldDirty: true,
+      });
+    },
+    [baseQuery, setValue]
+  );
+
+  return (
+    <EuiFormRow
+      id={dataSourceRowId}
+      label={i18n.translate('xpack.alertingV2.ruleForm.pageEvaluation.dataSourceLabel', {
+        defaultMessage: 'Data source',
+      })}
+      fullWidth
+    >
+      <EuiSelect
+        id={dataSourceRowId}
+        data-test-subj="ruleV2FormDataSourceSelect"
+        options={selectOptions}
+        value={fromClause}
+        onChange={onDataSourceChange}
+        isLoading={isLoading}
+        fullWidth
+        compressed={layout === 'flyout'}
+        aria-label={i18n.translate('xpack.alertingV2.ruleForm.pageEvaluation.dataSourceAriaLabel', {
+          defaultMessage: 'Select data source for the rule query',
+        })}
+      />
+    </EuiFormRow>
+  );
+};

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/description_field.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/description_field.test.tsx
@@ -12,30 +12,15 @@ import { DescriptionField } from './description_field';
 import { createFormWrapper, createMockServices } from '../../test_utils';
 
 describe('DescriptionField', () => {
-  it('renders "Add description" button when no description value exists', () => {
+  it('renders textarea with Description label and optional', () => {
     render(<DescriptionField />, { wrapper: createFormWrapper() });
-
-    expect(screen.getByTestId('addDescriptionButton')).toBeInTheDocument();
-    expect(screen.getByText('Add description')).toBeInTheDocument();
-  });
-
-  it('does not render textarea initially when no description', () => {
-    render(<DescriptionField />, { wrapper: createFormWrapper() });
-
-    expect(screen.queryByTestId('ruleDescriptionInput')).not.toBeInTheDocument();
-  });
-
-  it('shows textarea when "Add description" button is clicked', async () => {
-    const user = userEvent.setup();
-    render(<DescriptionField />, { wrapper: createFormWrapper() });
-
-    await user.click(screen.getByTestId('addDescriptionButton'));
 
     expect(screen.getByTestId('ruleDescriptionInput')).toBeInTheDocument();
     expect(screen.getByText('Description')).toBeInTheDocument();
+    expect(screen.getByText('optional')).toBeInTheDocument();
   });
 
-  it('displays textarea directly when initial description value exists', () => {
+  it('displays initial description value from form context', () => {
     const Wrapper = createFormWrapper({
       metadata: {
         name: 'Test Rule',
@@ -46,54 +31,29 @@ describe('DescriptionField', () => {
 
     render(<DescriptionField />, { wrapper: Wrapper });
 
-    expect(screen.getByTestId('ruleDescriptionInput')).toBeInTheDocument();
     expect(screen.getByTestId('ruleDescriptionInput')).toHaveValue('Initial description');
-    expect(screen.queryByTestId('addDescriptionButton')).not.toBeInTheDocument();
   });
 
-  it('displays placeholder text in textarea', async () => {
-    const user = userEvent.setup();
+  it('displays placeholder text in textarea', () => {
     render(<DescriptionField />, { wrapper: createFormWrapper() });
 
-    await user.click(screen.getByTestId('addDescriptionButton'));
-
-    expect(
-      screen.getByPlaceholderText('Add an optional description for this rule...')
-    ).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Add rule description')).toBeInTheDocument();
   });
 
   it('updates value when user types in textarea', async () => {
     const user = userEvent.setup();
     render(<DescriptionField />, { wrapper: createFormWrapper() });
-
-    await user.click(screen.getByTestId('addDescriptionButton'));
     const textarea = screen.getByTestId('ruleDescriptionInput');
     await user.type(textarea, 'My new description');
 
     expect(textarea).toHaveValue('My new description');
   });
 
-  it('renders correctly in flyout layout', async () => {
-    const user = userEvent.setup();
+  it('renders correctly in flyout layout', () => {
     render(<DescriptionField />, {
       wrapper: createFormWrapper({}, createMockServices(), { layout: 'flyout' }),
     });
 
-    await user.click(screen.getByTestId('addDescriptionButton'));
-
-    expect(screen.getByTestId('ruleDescriptionInput')).toBeInTheDocument();
-  });
-
-  it('keeps textarea visible after clearing the value', async () => {
-    const user = userEvent.setup();
-    render(<DescriptionField />, { wrapper: createFormWrapper() });
-
-    await user.click(screen.getByTestId('addDescriptionButton'));
-    const textarea = screen.getByTestId('ruleDescriptionInput');
-    await user.type(textarea, 'test');
-    await user.clear(textarea);
-
-    // Textarea should still be visible even though value is cleared
     expect(screen.getByTestId('ruleDescriptionInput')).toBeInTheDocument();
   });
 });

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/description_field.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/description_field.tsx
@@ -5,9 +5,9 @@
  * 2.0.
  */
 
-import React, { useState, useCallback, useEffect } from 'react';
+import React from 'react';
 import { i18n } from '@kbn/i18n';
-import { EuiFormRow, EuiTextArea, EuiButtonEmpty, EuiSpacer } from '@elastic/eui';
+import { EuiFormRow, EuiTextArea } from '@elastic/eui';
 import { Controller, useFormContext } from 'react-hook-form';
 import type { FormValues } from '../types';
 import { useRuleFormMeta } from '../contexts';
@@ -15,43 +15,8 @@ import { useRuleFormMeta } from '../contexts';
 const DESCRIPTION_ROW_ID = 'ruleV2FormDescriptionField';
 
 export const DescriptionField = () => {
-  const { control, watch } = useFormContext<FormValues>();
+  const { control } = useFormContext<FormValues>();
   const { layout } = useRuleFormMeta();
-  const descriptionValue = watch('metadata.description');
-
-  // Show the input if there's already a description value
-  const [isInputVisible, setIsInputVisible] = useState(() => Boolean(descriptionValue));
-
-  // Update visibility if description value changes externally (e.g., form reset)
-  useEffect(() => {
-    if (descriptionValue && !isInputVisible) {
-      setIsInputVisible(true);
-    }
-  }, [descriptionValue, isInputVisible]);
-
-  const handleAddDescription = useCallback(() => {
-    setIsInputVisible(true);
-  }, []);
-
-  if (!isInputVisible) {
-    return (
-      <>
-        <EuiSpacer size="s" />
-        <EuiButtonEmpty
-          iconType="plusInCircle"
-          onClick={handleAddDescription}
-          size="xs"
-          data-test-subj="addDescriptionButton"
-          color="text"
-        >
-          {i18n.translate('xpack.alertingV2.ruleForm.addDescriptionButton', {
-            defaultMessage: 'Add description',
-          })}
-        </EuiButtonEmpty>
-        <EuiSpacer size="s" />
-      </>
-    );
-  }
 
   return (
     <Controller
@@ -63,6 +28,9 @@ export const DescriptionField = () => {
           label={i18n.translate('xpack.alertingV2.ruleForm.descriptionLabel', {
             defaultMessage: 'Description',
           })}
+          labelAppend={i18n.translate('xpack.alertingV2.ruleForm.descriptionOptional', {
+            defaultMessage: 'optional',
+          })}
           fullWidth
           isInvalid={!!error}
           error={error?.message}
@@ -70,12 +38,12 @@ export const DescriptionField = () => {
           <EuiTextArea
             {...field}
             inputRef={ref}
-            rows={2}
+            rows={3}
             fullWidth
             isInvalid={!!error}
             compressed={layout === 'flyout'}
             placeholder={i18n.translate('xpack.alertingV2.ruleForm.descriptionPlaceholder', {
-              defaultMessage: 'Add an optional description for this rule...',
+              defaultMessage: 'Add rule description',
             })}
             data-test-subj="ruleDescriptionInput"
           />

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/kind_field.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/kind_field.test.tsx
@@ -18,10 +18,13 @@ describe('KindField', () => {
     expect(screen.getByText('Track active and recovered state over time')).toBeInTheDocument();
   });
 
-  it('renders the description text', () => {
+  it('renders an info icon with accessible description text (not inline body copy)', () => {
     render(<KindField />, { wrapper: createFormWrapper() });
 
-    expect(screen.getByText(/Enables lifecycle management/)).toBeInTheDocument();
+    expect(screen.queryByText(/Enables lifecycle management/)).not.toBeInTheDocument();
+    const info = screen.getByTestId('kindFieldDescriptionInfo');
+    expect(info).toBeInTheDocument();
+    expect(info).toHaveAttribute('aria-label', expect.stringMatching(/Enables lifecycle management/));
   });
 
   it('is checked when kind is alert (default)', () => {

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/kind_field.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/kind_field.tsx
@@ -6,12 +6,17 @@
  */
 
 import React from 'react';
-import { EuiCheckableCard, EuiText } from '@elastic/eui';
+import { EuiCheckableCard, EuiFlexGroup, EuiFlexItem, EuiIcon, EuiToolTip } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { Controller, useFormContext } from 'react-hook-form';
 import type { FormValues } from '../types';
 
 const CARD_ID = 'ruleV2KindField';
+
+const tooltipContent = i18n.translate('xpack.alertingV2.ruleForm.kindField.checkboxDescription', {
+  defaultMessage:
+    'Enables lifecycle management: the system will track state transitions across alert events for each series, manage episodes, and dispatch to notification policies. Without this, alert events are observation-only records.',
+});
 
 export const KindField = () => {
   const { control } = useFormContext<FormValues>();
@@ -28,23 +33,32 @@ export const KindField = () => {
             id={CARD_ID}
             checkableType="checkbox"
             label={
-              <strong>
-                {i18n.translate('xpack.alertingV2.ruleForm.kindField.checkboxLabel', {
-                  defaultMessage: 'Track active and recovered state over time',
-                })}
-              </strong>
+              <EuiFlexGroup alignItems="center" responsive={false} gutterSize="xs">
+                <EuiFlexItem grow={false}>
+                  <strong>
+                    {i18n.translate('xpack.alertingV2.ruleForm.kindField.checkboxLabel', {
+                      defaultMessage: 'Track active and recovered state over time',
+                    })}
+                  </strong>
+                </EuiFlexItem>
+                <EuiFlexItem grow={false}>
+                  <EuiToolTip content={tooltipContent} position="top">
+                    <EuiIcon
+                      tabIndex={0}
+                      type="info"
+                      size="s"
+                      color="subdued"
+                      data-test-subj="kindFieldDescriptionInfo"
+                      aria-label={tooltipContent}
+                    />
+                  </EuiToolTip>
+                </EuiFlexItem>
+              </EuiFlexGroup>
             }
             checked={isChecked}
             onChange={() => onChange(isChecked ? 'signal' : 'alert')}
             data-test-subj="kindField"
-          >
-            <EuiText size="s" color="subdued">
-              {i18n.translate('xpack.alertingV2.ruleForm.kindField.checkboxDescription', {
-                defaultMessage:
-                  'Enables lifecycle management: the system will track state transitions across alert events for each series, manage episodes, and dispatch to notification policies. Without this, alert events are observation-only records.',
-              })}
-            </EuiText>
-          </EuiCheckableCard>
+          />
         );
       }}
     />

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/name_field.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/name_field.test.tsx
@@ -32,7 +32,7 @@ describe('NameField', () => {
 
     const input = screen.getByTestId('ruleNameInput');
     expect(input).toBeInTheDocument();
-    expect(input).toHaveAttribute('placeholder', 'Untitled rule');
+    expect(input).toHaveAttribute('placeholder', 'Add a rule name');
   });
 
   it('displays initial value from form context', () => {

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/name_field.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/name_field.tsx
@@ -56,7 +56,7 @@ export const NameField = () => {
             isInvalid={!!error}
             compressed={layout === 'flyout'}
             placeholder={i18n.translate('xpack.alertingV2.ruleForm.namePlaceholder', {
-              defaultMessage: 'Untitled rule',
+              defaultMessage: 'Add a rule name',
             })}
             aria-label={i18n.translate('xpack.alertingV2.ruleForm.nameAriaLabel', {
               defaultMessage: 'Rule name',

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/open_in_discover_link.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/open_in_discover_link.tsx
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useCallback, useState } from 'react';
+import { EuiButtonEmpty } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { useRuleFormServices } from '../contexts';
+
+export interface OpenInDiscoverLinkProps {
+  esql: string;
+}
+
+export const OpenInDiscoverLink = ({ esql }: OpenInDiscoverLinkProps) => {
+  const { openEsqlInDiscover } = useRuleFormServices();
+  const [isNavigating, setIsNavigating] = useState(false);
+  const trimmed = esql.trim();
+  const canOpen = Boolean(openEsqlInDiscover) && Boolean(trimmed);
+
+  const onClick = useCallback(async () => {
+    if (!openEsqlInDiscover || !trimmed) {
+      return;
+    }
+    setIsNavigating(true);
+    try {
+      await openEsqlInDiscover(trimmed);
+    } finally {
+      setIsNavigating(false);
+    }
+  }, [openEsqlInDiscover, trimmed]);
+
+  if (!openEsqlInDiscover) {
+    return null;
+  }
+
+  return (
+    <EuiButtonEmpty
+      size="xs"
+      color="text"
+      iconType="discoverApp"
+      isLoading={isNavigating}
+      isDisabled={!canOpen || isNavigating}
+      onClick={onClick}
+      data-test-subj="ruleFormOpenInDiscover"
+    >
+      {i18n.translate('xpack.alertingV2.ruleForm.openInDiscover', {
+        defaultMessage: 'Open in Discover',
+      })}
+    </EuiButtonEmpty>
+  );
+};

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/query_results_grid.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/query_results_grid.tsx
@@ -69,6 +69,8 @@ export interface QueryResultsGridProps {
   timeField?: string;
   /** The lookback duration string for the chart time range (e.g. '5m', '1h') */
   lookback?: string;
+  /** Extra controls in the panel header (e.g. Open in Discover) */
+  headerActions?: React.ReactNode;
 }
 
 /**
@@ -97,6 +99,7 @@ export const QueryResultsGrid = ({
   query,
   timeField,
   lookback,
+  headerActions,
 }: QueryResultsGridProps) => {
   const [pagination, setPagination] = useState({ pageIndex: 0, pageSize: DEFAULT_PAGE_SIZE });
 
@@ -173,6 +176,7 @@ export const QueryResultsGrid = ({
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiFlexGroup gutterSize="m" alignItems="center" responsive={false}>
+            {headerActions}
             {lookback && (
               <EuiFlexItem grow={false}>
                 <EuiText size="xs" color="subdued">

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/rule_preview_panel.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/rule_preview_panel.tsx
@@ -11,6 +11,7 @@ import { i18n } from '@kbn/i18n';
 import { useFormContext, useWatch } from 'react-hook-form';
 import type { FormValues } from '../types';
 import { useRuleFormMeta } from '../contexts';
+import { RuleSummaryQueryPanel } from './rule_summary_query_panel';
 import { RuleResultsPreview } from './rule_results_preview';
 import { RecoveryResultsPreview } from './recovery_results_preview';
 
@@ -31,6 +32,8 @@ export const RulePreviewPanel = () => {
   if (layout === 'page') {
     return (
       <>
+        <RuleSummaryQueryPanel />
+        <EuiSpacer size="m" />
         <RuleResultsPreview />
         {showRecoveryPreview && (
           <>

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/rule_results_preview.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/rule_results_preview.tsx
@@ -5,10 +5,13 @@
  * 2.0.
  */
 
-import React from 'react';
+import React, { useMemo } from 'react';
 import { i18n } from '@kbn/i18n';
+import { useFormContext, useWatch } from 'react-hook-form';
+import type { FormValues } from '../types';
 import { useRulePreview } from '../hooks/use_rule_preview';
 import { QueryResultsGrid } from './query_results_grid';
+import { OpenInDiscoverLink } from './open_in_discover_link';
 
 /**
  * Rule results preview panel.
@@ -18,6 +21,8 @@ import { QueryResultsGrid } from './query_results_grid';
  * when results are available. Delegates rendering to `QueryResultsGrid`.
  */
 export const RuleResultsPreview = () => {
+  const { control } = useFormContext<FormValues>();
+  const baseQuery = useWatch({ name: 'evaluation.query.base', control });
   const {
     columns,
     rows,
@@ -33,11 +38,14 @@ export const RuleResultsPreview = () => {
     lookback,
   } = useRulePreview();
 
+  const headerActions = useMemo(() => <OpenInDiscoverLink esql={baseQuery ?? ''} />, [baseQuery]);
+
   return (
     <QueryResultsGrid
       title={i18n.translate('xpack.alertingV2.ruleForm.ruleResultsPreview.title', {
         defaultMessage: 'Rule results preview',
       })}
+      headerActions={headerActions}
       dataTestSubj="ruleResultsPreviewGrid"
       emptyBody={i18n.translate('xpack.alertingV2.ruleForm.ruleResultsPreview.emptyBody', {
         defaultMessage:

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/rule_summary_query_panel.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/rule_summary_query_panel.tsx
@@ -1,0 +1,78 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import {
+  EuiCodeBlock,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiPanel,
+  EuiSpacer,
+  EuiText,
+  EuiTitle,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { useFormContext, useWatch } from 'react-hook-form';
+import type { FormValues } from '../types';
+import { OpenInDiscoverLink } from './open_in_discover_link';
+
+/**
+ * Read-only ES|QL query for the page layout right column (Rule summary).
+ */
+export const RuleSummaryQueryPanel = () => {
+  const { control } = useFormContext<FormValues>();
+  const baseQuery = useWatch({ name: 'evaluation.query.base', control });
+
+  return (
+    <EuiPanel hasBorder hasShadow={false} paddingSize="m" data-test-subj="ruleSummaryQueryPanel">
+      <EuiTitle size="s">
+        <h2>
+          {i18n.translate('xpack.alertingV2.ruleForm.ruleSummary.title', {
+            defaultMessage: 'Rule Summary',
+          })}
+        </h2>
+      </EuiTitle>
+      <EuiSpacer size="m" />
+      <EuiFlexGroup
+        alignItems="center"
+        justifyContent="spaceBetween"
+        responsive={false}
+        gutterSize="m"
+      >
+        <EuiFlexItem grow={false}>
+          <EuiText size="s">
+            <p>
+              <strong>
+                {i18n.translate('xpack.alertingV2.ruleForm.ruleSummary.esqlHeading', {
+                  defaultMessage: 'ES|QL query',
+                })}
+              </strong>
+            </p>
+          </EuiText>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <OpenInDiscoverLink esql={baseQuery ?? ''} />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+      <EuiSpacer size="s" />
+      {baseQuery?.trim() ? (
+        <EuiCodeBlock language="esql" fontSize="m" paddingSize="m" isCopyable overflowHeight={360}>
+          {baseQuery}
+        </EuiCodeBlock>
+      ) : (
+        <EuiText size="s" color="subdued" data-test-subj="ruleSummaryQueryEmpty">
+          <p>
+            {i18n.translate('xpack.alertingV2.ruleForm.ruleSummary.emptyQuery', {
+              defaultMessage:
+                'No query yet. Set your rule evaluation query in YAML or update defaults.',
+            })}
+          </p>
+        </EuiText>
+      )}
+    </EuiPanel>
+  );
+};

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/time_field_select.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/time_field_select.tsx
@@ -28,7 +28,12 @@ const NO_TIME_FIELDS_OPTION = {
   value: '',
 };
 
-export const TimeFieldSelect = () => {
+export interface TimeFieldSelectProps {
+  /** Shown under the time field (page evaluation layout). */
+  helpText?: string;
+}
+
+export const TimeFieldSelect = ({ helpText }: TimeFieldSelectProps = {}) => {
   const { http, dataViews } = useRuleFormServices();
   const { layout } = useRuleFormMeta();
   const { control, setValue, getValues } = useFormContext<FormValues>();
@@ -88,9 +93,10 @@ export const TimeFieldSelect = () => {
             })}
             isInvalid={!!error}
             error={error?.message}
+            helpText={helpText}
             fullWidth
           >
-            {/* used eslint-disable-next-line to bypass EUI's isInvalid prop check since we're handling validation via 
+            {/* used eslint-disable-next-line to bypass EUI's isInvalid prop check since we're handling validation via
             react-hook-form to keep the scroll to error and to not disply additional error messages */}
             {/* eslint-disable-next-line @elastic/eui/consistent-is-invalid-props */}
             <EuiSelect

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/gui_rule_form.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/gui_rule_form.tsx
@@ -21,6 +21,7 @@ export interface GuiRuleFormProps {
   onSubmit: (values: FormValues) => void;
   /** Whether to include the ES|QL query editor (default: true) */
   includeQueryEditor?: boolean;
+  formVariant?: 'default' | 'quickEdit';
 }
 
 /**
@@ -35,22 +36,30 @@ export interface GuiRuleFormProps {
  *
  * Requires a FormProvider context with FormValues type to be present in the component tree.
  */
-export const GuiRuleForm = ({ onSubmit, includeQueryEditor = true }: GuiRuleFormProps) => {
+export const GuiRuleForm = ({
+  onSubmit,
+  includeQueryEditor = true,
+  formVariant = 'default',
+}: GuiRuleFormProps) => {
   const { handleSubmit } = useFormContext<FormValues>();
+  const isQuickEdit = formVariant === 'quickEdit';
 
   return (
     <EuiForm id={RULE_FORM_ID} component="form" onSubmit={handleSubmit(onSubmit)}>
       <RuleDetailsFieldGroup />
       <EuiSpacer size="m" />
-      <ConditionFieldGroup includeBase={includeQueryEditor} />
+      <ConditionFieldGroup
+        includeBase={includeQueryEditor}
+        readOnlyQueryLabelEsql={isQuickEdit && !includeQueryEditor}
+      />
       <EuiSpacer size="m" />
       <RuleExecutionFieldGroup />
       <EuiSpacer size="m" />
       <KindField />
       <EuiSpacer size="m" />
-      <AlertConditionsFieldGroup />
+      <AlertConditionsFieldGroup defaultOpen={!isQuickEdit} />
       <EuiSpacer size="m" />
-      <AttachmentRunbookFieldGroup />
+      {isQuickEdit ? null : <AttachmentRunbookFieldGroup />}
     </EuiForm>
   );
 };

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/hooks/use_form_defaults.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/hooks/use_form_defaults.ts
@@ -13,6 +13,8 @@ import { useDefaultGroupBy } from './use_default_group_by';
 interface UseFormDefaultsProps {
   /** The ES|QL query to derive defaults from */
   query: string;
+  /** Set on new rules from Discover vs in-app create flows. */
+  defaultSource?: 'discover' | 'kibana_ui';
 }
 
 /**
@@ -28,7 +30,7 @@ interface UseFormDefaultsProps {
  * Note: timeField defaults to '@timestamp' which is the most common time field.
  * TimeFieldSelect may update this if @timestamp is not available in the query results.
  */
-export const useFormDefaults = ({ query }: UseFormDefaultsProps): FormValues => {
+export const useFormDefaults = ({ query, defaultSource }: UseFormDefaultsProps): FormValues => {
   const { defaultGroupBy } = useDefaultGroupBy({ query });
 
   return useMemo(
@@ -38,6 +40,7 @@ export const useFormDefaults = ({ query }: UseFormDefaultsProps): FormValues => 
         name: '',
         enabled: true,
         description: '',
+        ...(defaultSource !== undefined ? { source: defaultSource } : {}),
       },
       timeField: '@timestamp', // Default to @timestamp; TimeFieldSelect may update if not available
       schedule: {
@@ -60,6 +63,6 @@ export const useFormDefaults = ({ query }: UseFormDefaultsProps): FormValues => 
       stateTransitionAlertDelayMode: DELAY_MODE.immediate,
       stateTransitionRecoveryDelayMode: DELAY_MODE.immediate,
     }),
-    [query, defaultGroupBy]
+    [query, defaultGroupBy, defaultSource]
   );
 };

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/index.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/index.tsx
@@ -48,10 +48,10 @@ export const RuleResultsPreview = () => (
   </Suspense>
 );
 
-export type { FormValues, StateTransitionDelayMode } from './types';
+export type { FormValues, StateTransitionDelayMode, RuleCreationSource } from './types';
 export type { DynamicRuleFormProps } from './dynamic_rule_form';
 export type { StandaloneRuleFormProps } from './standalone_rule_form';
-export type { RuleFormServices, RuleFormMeta, RuleFormLayout } from './contexts';
+export type { RuleFormServices, RuleFormMeta, RuleFormLayout, RuleFormVariant } from './contexts';
 export { RuleFormProvider, useRuleFormServices, useRuleFormMeta } from './contexts';
 export {
   deriveAlertDelayModeFromStateTransition,
@@ -62,3 +62,4 @@ export {
   mapRuleResponseToFormValues,
 } from './utils/rule_request_mappers';
 export type { RuleRequestCommon } from './utils/rule_request_mappers';
+export { useUpdateRule } from './hooks/use_update_rule';

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/rule_form.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/rule_form.test.tsx
@@ -134,8 +134,14 @@ describe('RuleForm', () => {
       expect(screen.queryByTestId('ruleV2FormEditModeToggle')).not.toBeInTheDocument();
     });
 
-    it('shows edit mode toggle when includeYaml is true', () => {
+    it('does not show edit mode toggle on page layout when includeYaml is true', () => {
       render(<RuleForm {...defaultProps} includeYaml />, { wrapper: createFormWrapper() });
+
+      expect(screen.queryByTestId('ruleV2FormEditModeToggle')).not.toBeInTheDocument();
+    });
+
+    it('shows edit mode toggle when includeYaml is true and layout is flyout', () => {
+      render(<RuleForm {...defaultProps} includeYaml layout="flyout" />, { wrapper: createFormWrapper() });
 
       expect(screen.getByTestId('ruleV2FormEditModeToggle')).toBeInTheDocument();
       expect(screen.getByTestId('ruleV2FormEditModeFormButton')).toBeInTheDocument();
@@ -145,13 +151,13 @@ describe('RuleForm', () => {
     it('shows Rule configuration heading when includeYaml is true', () => {
       render(<RuleForm {...defaultProps} includeYaml />, { wrapper: createFormWrapper() });
 
-      expect(screen.getByText('Rule configuration')).toBeInTheDocument();
+      expect(screen.getByText('Rule Configuration')).toBeInTheDocument();
     });
 
     it('does not show Rule configuration heading when includeYaml is false', () => {
       render(<RuleForm {...defaultProps} includeYaml={false} />, { wrapper: createFormWrapper() });
 
-      expect(screen.queryByText('Rule configuration')).not.toBeInTheDocument();
+      expect(screen.queryByText('Rule Configuration')).not.toBeInTheDocument();
     });
 
     it('starts in form mode by default', () => {
@@ -164,7 +170,7 @@ describe('RuleForm', () => {
     it('switches to YAML mode when YAML toggle is clicked', async () => {
       const user = userEvent.setup();
 
-      render(<RuleForm {...defaultProps} includeYaml />, { wrapper: createFormWrapper() });
+      render(<RuleForm {...defaultProps} includeYaml layout="flyout" />, { wrapper: createFormWrapper() });
 
       await user.click(screen.getByTestId('ruleV2FormEditModeYamlButton'));
 
@@ -175,7 +181,7 @@ describe('RuleForm', () => {
     it('switches back to form mode when Form toggle is clicked', async () => {
       const user = userEvent.setup();
 
-      render(<RuleForm {...defaultProps} includeYaml />, { wrapper: createFormWrapper() });
+      render(<RuleForm {...defaultProps} includeYaml layout="flyout" />, { wrapper: createFormWrapper() });
 
       // Switch to YAML
       await user.click(screen.getByTestId('ruleV2FormEditModeYamlButton'));
@@ -188,7 +194,7 @@ describe('RuleForm', () => {
     });
 
     it('disables toggle when isDisabled is true', () => {
-      render(<RuleForm {...defaultProps} includeYaml isDisabled />, {
+      render(<RuleForm {...defaultProps} includeYaml isDisabled layout="flyout" />, {
         wrapper: createFormWrapper(),
       });
 
@@ -274,7 +280,7 @@ describe('RuleForm', () => {
     it('shows submission buttons in YAML mode', async () => {
       const user = userEvent.setup();
 
-      render(<RuleForm {...defaultProps} includeSubmission includeYaml />, {
+      render(<RuleForm {...defaultProps} includeSubmission includeYaml layout="flyout" />, {
         wrapper: createFormWrapper(),
       });
 

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/rule_form.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/rule_form.tsx
@@ -54,6 +54,8 @@ export interface RuleFormProps {
   cancelLabel?: React.ReactNode;
   /** When provided, the form operates in edit mode and uses PATCH instead of POST on submission. */
   ruleId?: string;
+  /** @see StandaloneRuleForm / RuleFormProvider meta */
+  formVariant?: 'default' | 'quickEdit';
 }
 
 /**
@@ -76,12 +78,15 @@ const RuleFormContent = ({
   submitLabel,
   cancelLabel,
   ruleId,
+  formVariant = 'default',
 }: RuleFormProps) => {
   const { reset } = useFormContext<FormValues>();
   const services = useRuleFormServices();
   const { layout } = useRuleFormMeta();
   const { http, notifications } = services;
   const [editMode, setEditMode] = useState<EditMode>('form');
+  /** Full-page rule form hides the GUI/YAML switch; flyouts keep it. */
+  const showEditModeToggle = includeYaml && layout === 'flyout';
 
   // Internal submission hooks — always initialised so hooks are stable,
   // but only the appropriate one is used when no external onSubmit is provided.
@@ -137,7 +142,7 @@ const RuleFormContent = ({
       {includeYaml && (
         <EuiFlexGroup
           alignItems="center"
-          justifyContent="spaceBetween"
+          justifyContent={showEditModeToggle ? 'spaceBetween' : 'flexStart'}
           responsive={false}
           gutterSize="m"
         >
@@ -146,18 +151,20 @@ const RuleFormContent = ({
               <h3>
                 <FormattedMessage
                   id="xpack.alertingV2.ruleForm.ruleConfigurationHeading"
-                  defaultMessage="Rule configuration"
+                  defaultMessage="Rule Configuration"
                 />
               </h3>
             </EuiTitle>
           </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EditModeToggle
-              editMode={editMode}
-              onChange={handleModeChange}
-              disabled={isDisabled || isSubmitting}
-            />
-          </EuiFlexItem>
+          {showEditModeToggle ? (
+            <EuiFlexItem grow={false}>
+              <EditModeToggle
+                editMode={editMode}
+                onChange={handleModeChange}
+                disabled={isDisabled || isSubmitting}
+              />
+            </EuiFlexItem>
+          ) : null}
         </EuiFlexGroup>
       )}
       <EuiSpacer size="m" />
@@ -170,7 +177,11 @@ const RuleFormContent = ({
           isSubmitting={isSubmitting}
         />
       ) : (
-        <GuiRuleForm onSubmit={onSubmit} includeQueryEditor={includeQueryEditor} />
+        <GuiRuleForm
+          onSubmit={onSubmit}
+          includeQueryEditor={includeQueryEditor}
+          formVariant={formVariant}
+        />
       )}
 
       {includeSubmission && (
@@ -180,6 +191,7 @@ const RuleFormContent = ({
           submitLabel={submitLabel}
           cancelLabel={cancelLabel}
           ruleId={ruleId}
+          showRequestButton={formVariant !== 'quickEdit'}
         />
       )}
     </>
@@ -187,22 +199,35 @@ const RuleFormContent = ({
 
   if (layout === 'page') {
     return (
-      <EuiFlexGroup gutterSize="l" alignItems="flexStart">
+      <EuiFlexGroup gutterSize="l" alignItems="flexStart" responsive={false}>
         <EuiFlexItem grow={1} style={{ minWidth: 0 }}>
           {formContent}
         </EuiFlexItem>
-        <EuiFlexItem grow={1} style={{ minWidth: 0 }}>
-          <RulePreviewPanel />
-        </EuiFlexItem>
+        {formVariant !== 'quickEdit' ? (
+          <EuiFlexItem
+            grow={1}
+            style={{
+              minWidth: 0,
+              position: 'sticky',
+              top: 16,
+              alignSelf: 'flex-start',
+              maxHeight: 'calc(100vh - 32px)',
+              overflowY: 'auto',
+            }}
+            data-test-subj="ruleFormPagePreviewColumn"
+          >
+            <RulePreviewPanel />
+          </EuiFlexItem>
+        ) : null}
       </EuiFlexGroup>
     );
   }
 
-  // Flyout layout: form with nested flyout preview
+  // Flyout layout: form with nested flyout preview (preview omitted for quick edit)
   return (
     <>
       {formContent}
-      <RulePreviewPanel />
+      {formVariant !== 'quickEdit' ? <RulePreviewPanel /> : null}
     </>
   );
 };
@@ -221,7 +246,7 @@ const RuleFormContent = ({
  * Includes its own QueryClientProvider for react-query hooks used by field components.
  * Services and layout metadata are provided via RuleFormProvider context, eliminating prop drilling.
  */
-export const RuleForm = ({ layout = 'page', ...props }: RuleFormProps) => {
+export const RuleForm = ({ layout = 'page', formVariant = 'default', ...props }: RuleFormProps) => {
   const queryClient = useMemo(
     () =>
       new QueryClient({
@@ -235,12 +260,12 @@ export const RuleForm = ({ layout = 'page', ...props }: RuleFormProps) => {
     []
   );
 
-  const meta = useMemo(() => ({ layout }), [layout]);
+  const meta = useMemo(() => ({ layout, formVariant }), [layout, formVariant]);
 
   return (
     <QueryClientProvider client={queryClient}>
       <RuleFormProvider services={props.services} meta={meta}>
-        <RuleFormContent {...props} />
+        <RuleFormContent {...props} formVariant={formVariant} />
       </RuleFormProvider>
     </QueryClientProvider>
   );

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/standalone_rule_form.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/standalone_rule_form.tsx
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
-import React, { useMemo } from 'react';
-import { useForm, FormProvider } from 'react-hook-form';
+import React, { useEffect, useMemo } from 'react';
+import { useForm, FormProvider, useFormState, useWatch } from 'react-hook-form';
 import type { FormValues } from './types';
 import { RuleForm } from './rule_form';
 import type { RuleFormServices, RuleFormLayout } from './contexts';
@@ -43,6 +43,25 @@ export interface StandaloneRuleFormProps {
   initialValues?: Partial<FormValues>;
   /** When provided, the form operates in edit mode and uses PATCH instead of POST on submission. */
   ruleId?: string;
+  /**
+   * When true, shows a reduced set of fields (quick edit): no kind switch, no runbook, alert conditions start collapsed.
+   * Use with `includeQueryEditor` to control ES|QL edit vs read-only.
+   */
+  formVariant?: 'default' | 'quickEdit';
+  /**
+   * Whether the main ES|QL field is editable (default: true). Set false to show read-only for builder-origin rules in quick edit.
+   */
+  includeQueryEditor?: boolean;
+  /**
+   * When the form's dirty state changes (any field value differs from defaults after mount).
+   * Use for custom footers, for example to disable "Apply" until the user has edited the rule.
+   */
+  onDirtyChange?: (isDirty: boolean) => void;
+  /**
+   * When set, called with the current `metadata` object whenever it changes in the form
+   * (for example to drive header actions that depend on `metadata.source`).
+   */
+  onMetadataChange?: (metadata: FormValues['metadata']) => void;
 }
 
 /**
@@ -74,8 +93,16 @@ export const StandaloneRuleForm = ({
   cancelLabel,
   initialValues,
   ruleId,
+  formVariant = 'default',
+  includeQueryEditor = true,
+  onDirtyChange,
+  onMetadataChange,
 }: StandaloneRuleFormProps) => {
-  const queryDefaults = useFormDefaults({ query });
+  const isNew = !ruleId;
+  const queryDefaults = useFormDefaults({
+    query,
+    defaultSource: isNew ? initialValues?.metadata?.source ?? 'kibana_ui' : undefined,
+  });
 
   const defaultValues = useMemo<FormValues>(
     () => ({
@@ -119,6 +146,8 @@ export const StandaloneRuleForm = ({
 
   return (
     <FormProvider {...methods}>
+      {onDirtyChange != null ? <FormDirtySubscriber onDirtyChange={onDirtyChange} /> : null}
+      {onMetadataChange != null ? <MetadataSubscriber onMetadataChange={onMetadataChange} /> : null}
       <RuleForm
         services={services}
         layout={layout}
@@ -132,7 +161,31 @@ export const StandaloneRuleForm = ({
         submitLabel={submitLabel}
         cancelLabel={cancelLabel}
         ruleId={ruleId}
+        formVariant={formVariant}
+        includeQueryEditor={includeQueryEditor}
       />
     </FormProvider>
   );
 };
+
+function FormDirtySubscriber({ onDirtyChange }: { onDirtyChange: (isDirty: boolean) => void }) {
+  const { isDirty } = useFormState<FormValues>();
+  useEffect(() => {
+    onDirtyChange(isDirty);
+  }, [isDirty, onDirtyChange]);
+  return null;
+}
+
+function MetadataSubscriber({
+  onMetadataChange,
+}: {
+  onMetadataChange: (metadata: FormValues['metadata']) => void;
+}) {
+  const metadata = useWatch<FormValues, 'metadata'>({ name: 'metadata' });
+  useEffect(() => {
+    if (metadata) {
+      onMetadataChange(metadata);
+    }
+  }, [metadata, onMetadataChange]);
+  return null;
+}

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/types.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/types.ts
@@ -21,12 +21,16 @@ export type StateTransitionDelayMode = (typeof DELAY_MODE)[keyof typeof DELAY_MO
 /**
  * Rule metadata containing identification and categorization info.
  */
+export type RuleCreationSource = 'discover' | 'kibana_ui';
+
 export interface RuleMetadata {
   name: string;
   enabled: boolean;
   description?: string;
   owner?: string;
   tags?: string[];
+  /** Where the rule was first created; drives quick-edit ES|QL editability. */
+  source?: RuleCreationSource;
 }
 
 export interface RuleSchedule {

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/utils/rule_request_mappers.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/utils/rule_request_mappers.ts
@@ -46,6 +46,7 @@ const mapMetadata = (metadata: FormValues['metadata']) => ({
   description: metadata.description,
   owner: metadata.owner,
   tags: metadata.tags,
+  ...(metadata.source !== undefined ? { source: metadata.source } : {}),
 });
 
 const mapSchedule = (schedule: FormValues['schedule']) => ({
@@ -257,6 +258,7 @@ export const mapRuleResponseToFormValues = (rule: RuleResponse): Partial<FormVal
       enabled: rule.enabled,
       owner: rule.metadata.owner,
       tags: rule.metadata.tags,
+      ...(rule.metadata.source !== undefined ? { source: rule.metadata.source } : {}),
     },
     timeField: rule.time_field,
     schedule: {

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/index.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/index.ts
@@ -6,7 +6,7 @@
  */
 
 // Pre-composed flyouts (lazy loaded) - recommended for most use cases
-export { DynamicRuleFormFlyout, StandaloneRuleFormFlyout } from './flyout';
+export { DynamicRuleFormFlyout, StandaloneRuleFormFlyout, RuleFormFlyout } from './flyout';
 
 // Lazy components (without Suspense wrapper) - for consumers who need full control
 export {
@@ -36,6 +36,7 @@ export {
   mapFormValuesToUpdateRequest,
   mapRuleResponseToFormValues,
 } from './form';
+export { useUpdateRule } from './form';
 
 // Types
 export type {
@@ -46,6 +47,8 @@ export type {
   RuleFormServices,
   RuleFormMeta,
   RuleFormLayout,
+  RuleFormVariant,
+  RuleCreationSource,
   RuleRequestCommon,
 } from './form';
 

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/src/rule_data_schema.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/src/rule_data_schema.ts
@@ -51,6 +51,11 @@ const metadataSchema = z
       .max(100)
       .optional()
       .describe('Tags for categorization.'),
+    /** Where the rule was first created (Discover vs in-app builder). */
+    source: z
+      .enum(['discover', 'kibana_ui'])
+      .optional()
+      .describe('Creation surface: Discover or Kibana rule builder UI.'),
   })
   .strict()
   .describe('Rule metadata.');

--- a/x-pack/platform/plugins/shared/alerting_v2/kibana.jsonc
+++ b/x-pack/platform/plugins/shared/alerting_v2/kibana.jsonc
@@ -29,7 +29,7 @@
       "kibanaUtils",
       "share"
     ],
-    "optionalPlugins": ["usageCollection"],
+    "optionalPlugins": ["usageCollection", "agentBuilder"],
     "requiredBundles": ["alerting", "kibanaReact"],
     "extraPublicDirs": []
   }

--- a/x-pack/platform/plugins/shared/alerting_v2/public/application/rules_app.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/application/rules_app.tsx
@@ -8,6 +8,7 @@
 import React from 'react';
 import { Route, Routes } from '@kbn/shared-ux-router';
 import { RuleFormPage } from '../pages/rule_form_page/rule_form_page';
+import { RuleBuildersHubPage } from '../pages/rule_builders_hub_page/rule_builders_hub_page';
 import { RulesListPage } from '../pages/rules_list_page/rules_list_page';
 import { RuleDetailsRoute } from '../routes/rule_details_route';
 
@@ -17,8 +18,11 @@ export const RulesApp = () => {
       <Route path="/edit/:id">
         <RuleFormPage />
       </Route>
-      <Route path="/create">
+      <Route path="/create/form">
         <RuleFormPage />
+      </Route>
+      <Route path="/create">
+        <RuleBuildersHubPage />
       </Route>
       <Route exact path="/:ruleId">
         <RuleDetailsRoute />

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/quick_edit_rule_button.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/quick_edit_rule_button.tsx
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiButtonIcon, EuiToolTip } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import type { RuleApiResponse } from '../services/rules_api';
+
+export interface QuickEditRuleButtonProps {
+  rule: RuleApiResponse;
+  onEdit: (rule: RuleApiResponse) => void;
+}
+
+export const QuickEditRuleButton = ({ rule, onEdit }: QuickEditRuleButtonProps) => {
+  const quickEditLabel = i18n.translate('xpack.alertingV2.quickEdit', {
+    defaultMessage: 'Quick edit',
+  });
+
+  return (
+    <EuiToolTip content={quickEditLabel}>
+      <EuiButtonIcon
+        iconType="pencil"
+        color="text"
+        aria-label={quickEditLabel}
+        data-test-subj={`editRule-${rule.id}`}
+        onClick={() => onEdit(rule)}
+      />
+    </EuiToolTip>
+  );
+};

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule/flyouts/index.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule/flyouts/index.ts
@@ -7,3 +7,5 @@
 
 export { RuleSummaryFlyout } from './rule_summary_flyout';
 export type { RuleSummaryFlyoutProps } from './rule_summary_flyout';
+export { QuickEditRuleFlyout } from './quick_edit_rule_flyout';
+export type { QuickEditRuleFlyoutProps } from './quick_edit_rule_flyout';

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule/flyouts/quick_edit_rule_flyout.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule/flyouts/quick_edit_rule_flyout.tsx
@@ -1,0 +1,349 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  EuiButton,
+  EuiButtonEmpty,
+  EuiCallOut,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFlyout,
+  EuiFlyoutBody,
+  EuiFlyoutFooter,
+  EuiFlyoutHeader,
+  EuiIcon,
+  EuiLoadingSpinner,
+  EuiSpacer,
+  EuiTitle,
+  EuiToolTip,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import {
+  mapRuleResponseToFormValues,
+  RULE_FORM_ID,
+  StandaloneRuleForm,
+  useUpdateRule,
+  type FormValues,
+} from '@kbn/alerting-v2-rule-form';
+import { DISCOVER_APP_LOCATOR } from '@kbn/deeplinks-analytics';
+import { CoreStart, useService } from '@kbn/core-di-browser';
+import { PluginStart } from '@kbn/core-di';
+import type { DiscoverAppLocatorParams } from '@kbn/discover-plugin/common';
+import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
+import type { DataViewsPublicPluginStart } from '@kbn/data-views-plugin/public';
+import type { LensPublicStart } from '@kbn/lens-plugin/public';
+import { useQueryClient } from '@kbn/react-query';
+import { FormattedMessage } from '@kbn/i18n-react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useFetchRule } from '../../../hooks/use_fetch_rule';
+import { ruleKeys } from '../../../hooks/query_key_factory';
+import { useAlertingV2KibanaServices } from '../../../kibana_services';
+import { paths } from '../../../constants';
+
+const FLYOUT_TITLE_ID = 'alertingV2QuickEditRuleFlyoutTitle';
+
+/**
+ * Push flyout width matches {@link RuleSummaryFlyout} (view rule): `type="push"` and `size="s"`.
+ * `session` + `flyoutMenuProps` follow the shared rule-form flyout pattern (session rail).
+ */
+const QUICK_EDIT_FLYOUT_PROPS = {
+  session: 'start' as const,
+  flyoutMenuProps: { title: 'Quick Edit Alert Rule', hideTitle: true },
+  type: 'push' as const,
+  size: 's' as const,
+  /** Default flyout padding is l; use s for a tighter quick-edit layout. */
+  paddingSize: 's' as const,
+};
+
+export interface QuickEditRuleFlyoutProps {
+  ruleId: string;
+  onClose: () => void;
+}
+
+export const QuickEditRuleFlyout = ({ ruleId, onClose }: QuickEditRuleFlyoutProps) => {
+  const kibana = useAlertingV2KibanaServices();
+  const queryClient = useQueryClient();
+  const http = useService(CoreStart('http'));
+  const application = useService(CoreStart('application'));
+  const notifications = useService(CoreStart('notifications'));
+  const data = useService(PluginStart('data')) as DataPublicPluginStart;
+  const dataViews = useService(PluginStart('dataViews')) as DataViewsPublicPluginStart;
+  const lens = useService(PluginStart('lens')) as LensPublicStart;
+  const { data: rule, isLoading, isError, error } = useFetchRule(ruleId);
+  const { updateRule, isLoading: isSaving } = useUpdateRule({ http, notifications, ruleId });
+
+  const ruleFormServices = useMemo(
+    () => ({
+      http,
+      data,
+      dataViews,
+      notifications,
+      application,
+      lens,
+    }),
+    [http, data, dataViews, notifications, application, lens]
+  );
+
+  const [isFormDirty, setFormIsDirty] = useState(false);
+  const clickedRef = useRef(false);
+
+  useEffect(() => {
+    setFormIsDirty(false);
+  }, [ruleId]);
+  const onFocusCapture = useCallback(
+    (e: React.FocusEvent<HTMLDivElement>) => {
+      if (clickedRef.current) {
+        return;
+      }
+      const from = e.relatedTarget as HTMLElement | null;
+      if (from && !e.currentTarget.contains(from)) {
+        (e.target as HTMLElement).blur();
+        from.focus({ preventScroll: true });
+      }
+    },
+    []
+  );
+
+  const onSaveSuccess = useCallback(() => {
+    queryClient.invalidateQueries(ruleKeys.lists());
+    queryClient.invalidateQueries(ruleKeys.detail(ruleId));
+    onClose();
+  }, [queryClient, ruleId, onClose]);
+
+  const handleSubmit = useCallback(
+    (values: FormValues) => {
+      updateRule(values, {
+        onSuccess: onSaveSuccess,
+      });
+    },
+    [updateRule, onSaveSuccess]
+  );
+
+  const isDiscoverSource = rule?.metadata?.source === 'discover';
+  const includeQueryEditor = isDiscoverSource;
+
+  const openEditInDiscover = useCallback(async () => {
+    if (!kibana?.share || !rule) {
+      return;
+    }
+    const locator = kibana.share.url.locators.get<DiscoverAppLocatorParams>(DISCOVER_APP_LOCATOR);
+    if (!locator) {
+      return;
+    }
+    const esql = rule.evaluation.query.base;
+    const { app, path, state } = await locator.getLocation({
+      query: { esql },
+      openCreateEsqlRuleV2Flyout: true,
+      esqlRuleV2EditRuleId: rule.id,
+    });
+    await application.navigateToApp(app, { path, state });
+  }, [kibana, application, rule]);
+
+  const openEditInBuilder = useCallback(() => {
+    if (!rule) {
+      return;
+    }
+    application.navigateToUrl(http.basePath.prepend(paths.ruleEdit(rule.id)));
+  }, [http, application, rule]);
+
+  const quickEditInfo = i18n.translate('xpack.alertingV2.quickEditRuleFlyout.info', {
+    defaultMessage: 'Inline editing offers limited configuration options',
+  });
+
+  const configTitle = i18n.translate('xpack.alertingV2.quickEditRuleFlyout.configSection', {
+    defaultMessage: 'Rule configuration',
+  });
+
+  if (isLoading) {
+    return (
+      <EuiFlyout
+        {...QUICK_EDIT_FLYOUT_PROPS}
+        onClose={onClose}
+        data-test-subj="quickEditRuleFlyout"
+        aria-labelledby={FLYOUT_TITLE_ID}
+      >
+        <EuiFlyoutHeader hasBorder>
+          <EuiTitle size="xs" id={FLYOUT_TITLE_ID}>
+            <h2>
+              <FormattedMessage
+                id="xpack.alertingV2.quickEditRuleFlyout.title"
+                defaultMessage="Quick Edit Alert Rule"
+              />
+            </h2>
+          </EuiTitle>
+        </EuiFlyoutHeader>
+        <EuiFlyoutBody>
+          <EuiLoadingSpinner size="l" />
+        </EuiFlyoutBody>
+      </EuiFlyout>
+    );
+  }
+
+  if (isError || !rule) {
+    return (
+      <EuiFlyout
+        {...QUICK_EDIT_FLYOUT_PROPS}
+        onClose={onClose}
+        data-test-subj="quickEditRuleFlyout"
+        aria-labelledby={FLYOUT_TITLE_ID}
+      >
+        <EuiFlyoutHeader hasBorder>
+          <EuiTitle size="xs" id={FLYOUT_TITLE_ID}>
+            <h2>
+              <FormattedMessage
+                id="xpack.alertingV2.quickEditRuleFlyout.title"
+                defaultMessage="Quick Edit Alert Rule"
+              />
+            </h2>
+          </EuiTitle>
+        </EuiFlyoutHeader>
+        <EuiFlyoutBody>
+          <EuiCallOut
+            color="danger"
+            title={
+              <FormattedMessage
+                id="xpack.alertingV2.quickEditRuleFlyout.loadError"
+                defaultMessage="We couldn’t load this rule."
+              />
+            }
+          >
+            {error instanceof Error ? error.message : String(error ?? '')}
+          </EuiCallOut>
+        </EuiFlyoutBody>
+      </EuiFlyout>
+    );
+  }
+
+  const initialQuery = rule.evaluation.query.base;
+  const initialValues = mapRuleResponseToFormValues(rule);
+  const canOpenDiscover = Boolean(
+    isDiscoverSource && kibana?.share?.url?.locators?.get?.(DISCOVER_APP_LOCATOR)
+  );
+
+  return (
+    <EuiFlyout
+      {...QUICK_EDIT_FLYOUT_PROPS}
+      onClose={onClose}
+      data-test-subj="quickEditRuleFlyout"
+      aria-labelledby={FLYOUT_TITLE_ID}
+    >
+      <div
+        style={{ display: 'contents' }}
+        onPointerDown={() => {
+          clickedRef.current = true;
+        }}
+        onPointerUp={() => {
+          clickedRef.current = false;
+        }}
+        onFocusCapture={onFocusCapture}
+      >
+        <EuiFlyoutHeader hasBorder>
+          <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false} wrap={false}>
+            <EuiFlexItem grow={false}>
+              <EuiTitle size="xs" id={FLYOUT_TITLE_ID}>
+                <h2>
+                  <FormattedMessage
+                    id="xpack.alertingV2.quickEditRuleFlyout.title"
+                    defaultMessage="Quick Edit Alert Rule"
+                  />
+                </h2>
+              </EuiTitle>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiToolTip content={quickEditInfo}>
+                <EuiIcon type="info" size="m" color="text" aria-label={quickEditInfo} tabIndex={0} />
+              </EuiToolTip>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiFlyoutHeader>
+        <EuiFlyoutBody>
+          <EuiFlexGroup
+            alignItems="center"
+            justifyContent="spaceBetween"
+            gutterSize="m"
+            responsive={false}
+          >
+            <EuiTitle size="xs">
+              <h3>{configTitle}</h3>
+            </EuiTitle>
+            {isDiscoverSource ? (
+              <EuiButton
+                size="s"
+                iconType="discoverApp"
+                color="text"
+                display="base"
+                isDisabled={!canOpenDiscover}
+                onClick={openEditInDiscover}
+              >
+                <FormattedMessage
+                  id="xpack.alertingV2.quickEditRuleFlyout.editInDiscover"
+                  defaultMessage="Edit in Discover"
+                />
+              </EuiButton>
+            ) : (
+              <EuiButton
+                size="s"
+                iconType="indexOpen"
+                color="text"
+                display="base"
+                onClick={openEditInBuilder}
+              >
+                <FormattedMessage
+                  id="xpack.alertingV2.quickEditRuleFlyout.editInBuilder"
+                  defaultMessage="Edit in Builder"
+                />
+              </EuiButton>
+            )}
+          </EuiFlexGroup>
+          <EuiSpacer size="m" />
+          <StandaloneRuleForm
+            key={ruleId}
+            query={initialQuery}
+            services={ruleFormServices}
+            layout="flyout"
+            formVariant="quickEdit"
+            includeQueryEditor={includeQueryEditor}
+            includeYaml={false}
+            includeSubmission={false}
+            isSubmitting={isSaving}
+            onSubmit={handleSubmit}
+            onDirtyChange={setFormIsDirty}
+            ruleId={ruleId}
+            initialValues={initialValues}
+          />
+        </EuiFlyoutBody>
+        <EuiFlyoutFooter>
+          <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
+            <EuiFlexItem grow={false}>
+              <EuiButtonEmpty onClick={onClose} isDisabled={isSaving} data-test-subj="quickEditRuleCancel">
+                <FormattedMessage
+                  id="xpack.alertingV2.quickEditRuleFlyout.cancel"
+                  defaultMessage="Cancel"
+                />
+              </EuiButtonEmpty>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiButton
+                fill
+                type="submit"
+                form={RULE_FORM_ID}
+                isLoading={isSaving}
+                isDisabled={isSaving || !isFormDirty}
+                data-test-subj="quickEditRuleApplyButton"
+              >
+                <FormattedMessage
+                  id="xpack.alertingV2.quickEditRuleFlyout.applyAndClose"
+                  defaultMessage="Apply and close"
+                />
+              </EuiButton>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiFlyoutFooter>
+      </div>
+    </EuiFlyout>
+  );
+};

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule/flyouts/rule_summary_flyout.test.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule/flyouts/rule_summary_flyout.test.tsx
@@ -21,12 +21,21 @@ jest.mock('@kbn/core-di-browser', () => ({
   CoreStart: (key: string) => key,
 }));
 
+jest.mock('../../../pages/rules_list_page/use_rule_list_row_menu_actions', () => ({
+  useRuleListRowMenuActions: () => ({
+    canOpenEditInDiscover: true,
+    canEditWithAi: true,
+    onEditInDiscover: jest.fn(),
+    onEditInBuilder: jest.fn(),
+    onEditWithAiAgent: jest.fn(),
+    onRunRule: jest.fn(),
+    onUpdateApiKey: jest.fn(),
+  }),
+}));
+
 jest.mock('../../../pages/rules_list_page/rule_actions_menu', () => ({
-  RuleActionsMenu: ({ rule, onEdit, onClone, onDelete, onToggleEnabled }: any) => (
+  RuleActionsMenu: ({ rule, onClone, onDelete, onToggleEnabled }: any) => (
     <div data-test-subj={`ruleActionsMenu-${rule.id}`}>
-      <button data-test-subj="mockEdit" onClick={() => onEdit(rule)}>
-        Edit
-      </button>
       <button data-test-subj="mockClone" onClick={() => onClone(rule)}>
         Clone
       </button>
@@ -148,7 +157,7 @@ describe('RuleSummaryFlyout', () => {
   it('forwards action callbacks to the RuleActionsMenu with the rule', () => {
     const { props } = renderFlyout();
 
-    fireEvent.click(screen.getByTestId('mockEdit'));
+    fireEvent.click(screen.getByTestId('editRule-rule-1'));
     expect(props.onEdit).toHaveBeenCalledWith(baseRule);
 
     fireEvent.click(screen.getByTestId('mockClone'));

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule/flyouts/rule_summary_flyout.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule/flyouts/rule_summary_flyout.tsx
@@ -24,7 +24,9 @@ import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import React from 'react';
 import { paths } from '../../../constants';
+import { QuickEditRuleButton } from '../../quick_edit_rule_button';
 import { RuleActionsMenu } from '../../../pages/rules_list_page/rule_actions_menu';
+import { useRuleListRowMenuActions } from '../../../pages/rules_list_page/use_rule_list_row_menu_actions';
 import { RuleProvider } from '../../rule_details/rule_context';
 import {
   RuleHeaderDescription,
@@ -56,6 +58,16 @@ export const RuleSummaryFlyout = ({
   const { basePath } = useService(CoreStart('http'));
   const detailsHref = basePath.prepend(paths.ruleDetails(rule.id));
 
+  const {
+    canOpenEditInDiscover,
+    canEditWithAi,
+    onEditInDiscover,
+    onEditInBuilder,
+    onEditWithAiAgent,
+    onRunRule,
+    onUpdateApiKey,
+  } = useRuleListRowMenuActions();
+
   return (
     <RuleProvider rule={rule}>
       <EuiFlyout
@@ -83,9 +95,18 @@ export const RuleSummaryFlyout = ({
             alignItems="center"
           >
             <EuiFlexItem grow={false}>
+              <QuickEditRuleButton rule={rule} onEdit={onEdit} />
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
               <RuleActionsMenu
                 rule={rule}
-                onEdit={onEdit}
+                canOpenEditInDiscover={canOpenEditInDiscover}
+                canEditWithAi={canEditWithAi}
+                onEditInDiscover={onEditInDiscover}
+                onEditInBuilder={onEditInBuilder}
+                onEditWithAiAgent={onEditWithAiAgent}
+                onRunRule={onRunRule}
+                onUpdateApiKey={onUpdateApiKey}
                 onClone={onClone}
                 onDelete={onDelete}
                 onToggleEnabled={onToggleEnabled}

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_builders/rule_builder_choice_cards.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_builders/rule_builder_choice_cards.tsx
@@ -1,0 +1,119 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { css } from '@emotion/react';
+import {
+  EuiCard,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiIcon,
+  EuiSpacer,
+  EuiText,
+  EuiTitle,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+
+export interface RuleBuilderChoiceCardsProps {
+  /** App path for the threshold alert builder (rule create form) */
+  thresholdHref: string;
+  /** Alignment for “Start from a rule builder”. Rules list empty state uses center; hub uses left. */
+  sectionHeadingAlign?: 'left' | 'center';
+}
+
+/**
+ * "Start from a rule builder" — Threshold Alert and Service Latency (coming soon) cards
+ * used on the rules list empty state and the create-rule hub.
+ */
+export const RuleBuilderChoiceCards = ({
+  thresholdHref,
+  sectionHeadingAlign = 'center',
+}: RuleBuilderChoiceCardsProps) => {
+  return (
+    <>
+      <div
+        css={css`
+          text-align: ${sectionHeadingAlign};
+          width: 100%;
+        `}
+      >
+        <EuiTitle size="xxs">
+          <h3>
+            {i18n.translate('xpack.alertingV2.rulesList.empty.buildersSectionTitle', {
+              defaultMessage: 'Start from a rule builder',
+            })}
+          </h3>
+        </EuiTitle>
+      </div>
+      <EuiSpacer size="m" />
+      <EuiFlexGroup alignItems="stretch" gutterSize="m" responsive>
+        <EuiFlexItem>
+          <EuiCard
+            data-test-subj="ruleBuilderChoiceThreshold"
+            layout="horizontal"
+            hasBorder
+            paddingSize="l"
+            icon={<EuiIcon type="visBarVertical" size="m" color="text" />}
+            title={i18n.translate('xpack.alertingV2.rulesList.empty.thresholdAlertTitle', {
+              defaultMessage: 'Threshold Alert',
+            })}
+            titleElement="h3"
+            titleSize="xs"
+            description={i18n.translate(
+              'xpack.alertingV2.rulesList.empty.thresholdAlertDescription',
+              {
+                defaultMessage:
+                  'Monitor one or more metrics and alert when they cross a threshold. Multi-condition support with custom aggregations.',
+              }
+            )}
+            href={thresholdHref}
+          >
+            <EuiText size="xs" color="subdued">
+              {i18n.translate('xpack.alertingV2.rulesList.empty.thresholdReplaces', {
+                defaultMessage: 'Replaces: Custom threshold, Metric threshold',
+              })}
+            </EuiText>
+          </EuiCard>
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiCard
+            data-test-subj="ruleBuilderChoiceServiceLatency"
+            layout="horizontal"
+            hasBorder
+            paddingSize="l"
+            icon={<EuiIcon type="clock" size="m" color="subdued" />}
+            title={i18n.translate('xpack.alertingV2.rulesList.empty.serviceLatencyTitle', {
+              defaultMessage: 'Service Latency',
+            })}
+            titleElement="h3"
+            titleSize="xs"
+            description={i18n.translate(
+              'xpack.alertingV2.rulesList.empty.serviceLatencyDescription',
+              {
+                defaultMessage:
+                  "Alert when a service's response time exceeds a threshold. Pick service, transaction type, percentile, and environment.",
+              }
+            )}
+            isDisabled
+            betaBadgeProps={{
+              label: i18n.translate('xpack.alertingV2.rulesList.empty.comingSoonBadge', {
+                defaultMessage: 'COMING SOON',
+              }),
+              color: 'hollow',
+            }}
+          >
+            <EuiText size="xs" color="subdued">
+              {i18n.translate('xpack.alertingV2.rulesList.empty.serviceLatencyReplaces', {
+                defaultMessage: 'Replaces: APM latency rule',
+              })}
+            </EuiText>
+          </EuiCard>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </>
+  );
+};

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/rule_detail_page.test.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/rule_detail_page.test.tsx
@@ -109,15 +109,6 @@ describe('RuleDetailPage', () => {
     expect(screen.getByTestId('ruleConditionsSection')).toBeInTheDocument();
     expect(screen.getByTestId('ruleMetadataSection')).toBeInTheDocument();
     expect(screen.getByTestId('ruleDetailsActionsButton')).toBeInTheDocument();
-    expect(screen.getByTestId('openEditRuleFlyoutButton')).toBeInTheDocument();
-  });
-
-  it('renders edit button with correct href', () => {
-    renderPage(baseRule);
-    expect(screen.getByTestId('openEditRuleFlyoutButton')).toHaveAttribute(
-      'href',
-      '/app/management/alertingV2/rules/edit/rule-1'
-    );
   });
 
   it('opens delete confirmation from actions menu', () => {

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/rule_detail_page.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/rule_detail_page.tsx
@@ -5,10 +5,7 @@
  * 2.0.
  */
 
-import { EuiButtonEmpty, EuiPageHeader, EuiSpacer } from '@elastic/eui';
-import { i18n } from '@kbn/i18n';
-import { FormattedMessage } from '@kbn/i18n-react';
-import { CoreStart, useService } from '@kbn/core-di-browser';
+import { EuiPageHeader, EuiSpacer } from '@elastic/eui';
 import React from 'react';
 import { useHistory } from 'react-router-dom';
 import { RuleDetailsActionsMenu } from './rule_details_actions_menu';
@@ -18,12 +15,10 @@ import { DeleteConfirmationModal } from '../rule/modals/delete_confirmation_moda
 import { RuleHeaderDescription, RuleTitleWithBadges } from './rule_header_description';
 import { RuleSidebar } from './sidebar/rule_sidebar';
 import { useRule } from './rule_context';
-import { paths } from '../../constants';
 
 export const RuleDetailPage: React.FunctionComponent = () => {
   const rule = useRule();
   useBreadcrumbs('rule_details', { ruleName: rule.metadata?.name });
-  const { basePath } = useService(CoreStart('http'));
 
   const history = useHistory();
   const { mutate: deleteRule, isLoading: isDeleting } = useDeleteRule();
@@ -53,22 +48,6 @@ export const RuleDetailPage: React.FunctionComponent = () => {
             key="actions"
             showDeleteConfirmation={showDeleteConfirmationModal}
           />,
-          <EuiButtonEmpty
-            aria-label={i18n.translate(
-              'xpack.alertingV2.sections.ruleDetails.editRuleButtonLabel',
-              { defaultMessage: 'Edit Rule' }
-            )}
-            data-test-subj="openEditRuleFlyoutButton"
-            color="text"
-            iconType="pencil"
-            name="edit"
-            href={basePath.prepend(paths.ruleEdit(rule.id))}
-          >
-            <FormattedMessage
-              id="xpack.alertingV2.sections.ruleDetails.editRuleButtonLabel"
-              defaultMessage="Edit Rule"
-            />
-          </EuiButtonEmpty>,
         ]}
       />
 

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/rule_details_actions_menu.test.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/rule_details_actions_menu.test.tsx
@@ -6,21 +6,39 @@
  */
 
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { act, render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { I18nProvider } from '@kbn/i18n-react';
-import { CoreStart, useService } from '@kbn/core-di-browser';
+import { useService } from '@kbn/core-di-browser';
 import { RuleDetailsActionsMenu } from './rule_details_actions_menu';
 import { RuleProvider } from './rule_context';
 import type { RuleApiResponse } from '../../services/rules_api';
 
 const mockToggleRuleEnabled = jest.fn();
 const mockNavigateToUrl = jest.fn();
-const mockUseService = useService as jest.MockedFunction<typeof useService>;
-const mockCoreStart = CoreStart as jest.MockedFunction<typeof CoreStart>;
+const mockOnEditInDiscover = jest.fn();
+const mockOnEditInBuilder = jest.fn();
+const mockOnEditWithAi = jest.fn();
+const mockOnRun = jest.fn();
+const mockOnUpdateApiKey = jest.fn();
 
-jest.mock('@kbn/core-di-browser');
+jest.mock('@kbn/core-di-browser', () => ({
+  useService: jest.fn(),
+  CoreStart: (key: string) => key,
+}));
 jest.mock('../../hooks/use_toggle_rule_enabled', () => ({
   useToggleRuleEnabled: () => ({ mutate: mockToggleRuleEnabled }),
+}));
+
+jest.mock('../../pages/rules_list_page/use_rule_list_row_menu_actions', () => ({
+  useRuleListRowMenuActions: () => ({
+    canOpenEditInDiscover: true,
+    canEditWithAi: true,
+    onEditInDiscover: mockOnEditInDiscover,
+    onEditInBuilder: mockOnEditInBuilder,
+    onEditWithAiAgent: mockOnEditWithAi,
+    onRunRule: mockOnRun,
+    onUpdateApiKey: mockOnUpdateApiKey,
+  }),
 }));
 
 const enabledRule = {
@@ -31,6 +49,17 @@ const enabledRule = {
 } as RuleApiResponse;
 
 const disabledRule = { ...enabledRule, enabled: false } as RuleApiResponse;
+
+const mockUseService = useService as jest.MockedFunction<typeof useService>;
+
+const openActionsMenu = async () => {
+  await act(async () => {
+    fireEvent.click(screen.getByTestId('ruleActionsButton-rule-1'));
+  });
+  await waitFor(() => {
+    expect(screen.getByTestId('ruleActionsContextMenu-rule-1')).toBeInTheDocument();
+  });
+};
 
 const renderMenu = (rule: RuleApiResponse, showDeleteConfirmation = jest.fn()) =>
   render(
@@ -44,7 +73,6 @@ const renderMenu = (rule: RuleApiResponse, showDeleteConfirmation = jest.fn()) =
 describe('RuleDetailsActionsMenu', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockCoreStart.mockImplementation((key: string) => key as never);
     mockUseService.mockImplementation((service: unknown) => {
       if (service === 'application') {
         return { navigateToUrl: mockNavigateToUrl } as never;
@@ -58,58 +86,82 @@ describe('RuleDetailsActionsMenu', () => {
 
   it('renders the actions button', () => {
     renderMenu(enabledRule);
-    expect(screen.getByTestId('ruleDetailsActionsButton')).toBeInTheDocument();
+    expect(screen.getByTestId('ruleActionsButton-rule-1')).toBeInTheDocument();
   });
 
-  it('shows disable option for enabled rules', () => {
+  it('shows disable option for enabled rules', async () => {
     renderMenu(enabledRule);
-    fireEvent.click(screen.getByTestId('ruleDetailsActionsButton'));
-    expect(screen.getByTestId('ruleDetailsDisableButton')).toBeInTheDocument();
-    expect(screen.queryByTestId('ruleDetailsEnableButton')).not.toBeInTheDocument();
+    await openActionsMenu();
+    expect(screen.getByTestId('toggleEnabledRule-rule-1')).toBeInTheDocument();
   });
 
-  it('shows enable option for disabled rules', () => {
+  it('shows enable option for disabled rules', async () => {
     renderMenu(disabledRule);
-    fireEvent.click(screen.getByTestId('ruleDetailsActionsButton'));
-    expect(screen.getByTestId('ruleDetailsEnableButton')).toBeInTheDocument();
-    expect(screen.queryByTestId('ruleDetailsDisableButton')).not.toBeInTheDocument();
+    await openActionsMenu();
+    expect(screen.getByTestId('toggleEnabledRule-rule-1')).toBeInTheDocument();
   });
 
-  it('calls toggleRuleEnabled with enabled=false when disable is clicked', () => {
+  it('calls toggleRuleEnabled with enabled=false when disable is clicked', async () => {
     renderMenu(enabledRule);
-    fireEvent.click(screen.getByTestId('ruleDetailsActionsButton'));
-    fireEvent.click(screen.getByTestId('ruleDetailsDisableButton'));
+    await openActionsMenu();
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('toggleEnabledRule-rule-1'));
+    });
     expect(mockToggleRuleEnabled).toHaveBeenCalledWith({ id: 'rule-1', enabled: false });
   });
 
-  it('calls toggleRuleEnabled with enabled=true when enable is clicked', () => {
+  it('calls toggleRuleEnabled with enabled=true when enable is clicked', async () => {
     renderMenu(disabledRule);
-    fireEvent.click(screen.getByTestId('ruleDetailsActionsButton'));
-    fireEvent.click(screen.getByTestId('ruleDetailsEnableButton'));
+    await openActionsMenu();
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('toggleEnabledRule-rule-1'));
+    });
     expect(mockToggleRuleEnabled).toHaveBeenCalledWith({ id: 'rule-1', enabled: true });
   });
 
-  it('navigates to create page with cloneFrom query param when clone is clicked', () => {
+  it('navigates to create page with cloneFrom query param when clone is clicked', async () => {
     renderMenu(enabledRule);
-    fireEvent.click(screen.getByTestId('ruleDetailsActionsButton'));
-    fireEvent.click(screen.getByTestId('ruleDetailsCloneButton'));
+    await openActionsMenu();
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('cloneRule-rule-1'));
+    });
     expect(mockNavigateToUrl).toHaveBeenCalledWith(
-      '/app/management/alertingV2/rules/create?cloneFrom=rule-1'
+      '/app/management/alertingV2/rules/create/form?cloneFrom=rule-1'
     );
   });
 
-  it('calls showDeleteConfirmation when delete is clicked', () => {
+  it('calls showDeleteConfirmation when delete is clicked', async () => {
     const showDelete = jest.fn();
     renderMenu(enabledRule, showDelete);
-    fireEvent.click(screen.getByTestId('ruleDetailsActionsButton'));
-    fireEvent.click(screen.getByTestId('ruleDetailsDeleteButton'));
+    await openActionsMenu();
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('deleteRule-rule-1'));
+    });
     expect(showDelete).toHaveBeenCalledTimes(1);
   });
 
-  it('always shows clone and delete options', () => {
+  it('always shows clone and delete options', async () => {
     renderMenu(enabledRule);
-    fireEvent.click(screen.getByTestId('ruleDetailsActionsButton'));
-    expect(screen.getByTestId('ruleDetailsCloneButton')).toBeInTheDocument();
-    expect(screen.getByTestId('ruleDetailsDeleteButton')).toBeInTheDocument();
+    await openActionsMenu();
+    expect(screen.getByTestId('cloneRule-rule-1')).toBeInTheDocument();
+    expect(screen.getByTestId('deleteRule-rule-1')).toBeInTheDocument();
+  });
+
+  it('shows Edit in Discover for discover-sourced rules', async () => {
+    const discoverRule = {
+      ...enabledRule,
+      metadata: { ...enabledRule.metadata, name: 'D', source: 'discover' as const },
+    } as RuleApiResponse;
+    renderMenu(discoverRule);
+    await openActionsMenu();
+    expect(screen.getByTestId('editInDiscoverRule-rule-1')).toBeInTheDocument();
+    expect(screen.queryByTestId('editInBuilderRule-rule-1')).not.toBeInTheDocument();
+  });
+
+  it('shows Edit in Builder for non-discover rules', async () => {
+    renderMenu(enabledRule);
+    await openActionsMenu();
+    expect(screen.getByTestId('editInBuilderRule-rule-1')).toBeInTheDocument();
+    expect(screen.queryByTestId('editInDiscoverRule-rule-1')).not.toBeInTheDocument();
   });
 });

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/rule_details_actions_menu.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/rule_details_actions_menu.tsx
@@ -5,13 +5,14 @@
  * 2.0.
  */
 
-import { i18n } from '@kbn/i18n';
-import React, { useState } from 'react';
-import { EuiButtonIcon, EuiContextMenu, EuiPopover } from '@elastic/eui';
+import React, { useCallback } from 'react';
 import { CoreStart, useService } from '@kbn/core-di-browser';
 import { paths } from '../../constants';
 import { useToggleRuleEnabled } from '../../hooks/use_toggle_rule_enabled';
+import { useRuleListRowMenuActions } from '../../pages/rules_list_page/use_rule_list_row_menu_actions';
+import { RuleActionsMenu } from '../../pages/rules_list_page/rule_actions_menu';
 import { useRule } from './rule_context';
+import type { RuleApiResponse } from '../../services/rules_api';
 
 export interface RuleDetailsActionsMenuProps {
   showDeleteConfirmation: () => void;
@@ -21,99 +22,55 @@ export const RuleDetailsActionsMenu: React.FunctionComponent<RuleDetailsActionsM
   showDeleteConfirmation,
 }) => {
   const rule = useRule();
-  const [isPopoverOpen, setIsPopoverOpen] = useState<boolean>(false);
   const { navigateToUrl } = useService(CoreStart('application'));
   const { basePath } = useService(CoreStart('http'));
   const { mutate: toggleRuleEnabled } = useToggleRuleEnabled();
+  const {
+    canOpenEditInDiscover,
+    canEditWithAi,
+    onEditInDiscover,
+    onEditInBuilder,
+    onEditWithAiAgent,
+    onRunRule,
+    onUpdateApiKey,
+  } = useRuleListRowMenuActions();
 
-  const handleToggleEnable = () => {
-    setIsPopoverOpen(false);
-    toggleRuleEnabled({
-      id: rule.id,
-      enabled: !rule.enabled,
-    });
-  };
-
-  const handleClone = () => {
-    setIsPopoverOpen(false);
-    navigateToUrl(basePath.prepend(`${paths.ruleCreate}?cloneFrom=${encodeURIComponent(rule.id)}`));
-  };
-
-  const handleDelete = () => {
-    setIsPopoverOpen(false);
-    showDeleteConfirmation();
-  };
-
-  const panels = [
-    {
-      id: 0,
-      items: [
-        ...(rule.enabled
-          ? [
-              {
-                'data-test-subj': 'ruleDetailsDisableButton',
-                onClick: handleToggleEnable,
-                name: i18n.translate('xpack.alertingV2.ruleDetails.disableRuleButtonLabel', {
-                  defaultMessage: 'Disable rule',
-                }),
-              },
-            ]
-          : [
-              {
-                'data-test-subj': 'ruleDetailsEnableButton',
-                onClick: handleToggleEnable,
-                name: i18n.translate('xpack.alertingV2.ruleDetails.enableRuleButtonLabel', {
-                  defaultMessage: 'Enable rule',
-                }),
-              },
-            ]),
-        {
-          'data-test-subj': 'ruleDetailsCloneButton',
-          onClick: handleClone,
-          name: i18n.translate('xpack.alertingV2.ruleDetails.cloneRuleButtonLabel', {
-            defaultMessage: 'Clone rule',
-          }),
-        },
-        {
-          className: 'ruleDetailsActionsMenu__deleteButton',
-          'data-test-subj': 'ruleDetailsDeleteButton',
-          onClick: handleDelete,
-          name: i18n.translate('xpack.alertingV2.ruleDetails.deleteRuleButtonLabel', {
-            defaultMessage: 'Delete rule',
-          }),
-        },
-      ],
+  const onClone = useCallback(
+    (r: RuleApiResponse) => {
+      navigateToUrl(
+        basePath.prepend(`${paths.ruleCreateForm}?cloneFrom=${encodeURIComponent(r.id)}`)
+      );
     },
-  ];
+    [navigateToUrl, basePath]
+  );
+
+  const onDelete = useCallback(
+    (_rule: RuleApiResponse) => {
+      showDeleteConfirmation();
+    },
+    [showDeleteConfirmation]
+  );
+
+  const onToggleEnabled = useCallback(
+    (r: RuleApiResponse) => {
+      toggleRuleEnabled({ id: r.id, enabled: !r.enabled });
+    },
+    [toggleRuleEnabled]
+  );
 
   return (
-    <EuiPopover
-      aria-label={i18n.translate('xpack.alertingV2.ruleDetails.actionsMenuPopoverAriaLabel', {
-        defaultMessage: 'Rule actions',
-      })}
-      button={
-        <EuiButtonIcon
-          data-test-subj="ruleDetailsActionsButton"
-          iconType="boxesHorizontal"
-          color="text"
-          size="m"
-          onClick={() => setIsPopoverOpen(!isPopoverOpen)}
-          aria-label={i18n.translate('xpack.alertingV2.ruleDetails.actionsMenuAriaLabel', {
-            defaultMessage: 'Actions',
-          })}
-        />
-      }
-      isOpen={isPopoverOpen}
-      closePopover={() => setIsPopoverOpen(false)}
-      ownFocus
-      panelPaddingSize="none"
-    >
-      <EuiContextMenu
-        initialPanelId={0}
-        panels={panels}
-        className="ruleDetailsActionsMenu"
-        data-test-subj="ruleDetailsActionsMenu"
-      />
-    </EuiPopover>
+    <RuleActionsMenu
+      rule={rule}
+      canOpenEditInDiscover={canOpenEditInDiscover}
+      canEditWithAi={canEditWithAi}
+      onEditInDiscover={onEditInDiscover}
+      onEditInBuilder={onEditInBuilder}
+      onEditWithAiAgent={onEditWithAiAgent}
+      onRunRule={onRunRule}
+      onUpdateApiKey={onUpdateApiKey}
+      onClone={onClone}
+      onDelete={onDelete}
+      onToggleEnabled={onToggleEnabled}
+    />
   );
 };

--- a/x-pack/platform/plugins/shared/alerting_v2/public/constants.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/constants.ts
@@ -25,7 +25,10 @@ export {
 } from '@kbn/alerting-v2-constants';
 
 export const paths = {
+  /** Rule builder cards hub (entry from "Create rule") */
   ruleCreate: `${ALERTING_V2_RULES_BASE_PATH}/create`,
+  /** Standalone create-rule form (threshold builder and clone-to-create flows) */
+  ruleCreateForm: `${ALERTING_V2_RULES_BASE_PATH}/create/form`,
   ruleEdit: (id: string) => `${ALERTING_V2_RULES_BASE_PATH}/edit/${encodeURIComponent(id)}`,
   ruleDetails: (id: string) => `${ALERTING_V2_RULES_BASE_PATH}/${encodeURIComponent(id)}`,
   ruleList: ALERTING_V2_RULES_BASE_PATH,

--- a/x-pack/platform/plugins/shared/alerting_v2/public/create_rule_form_flyout.test.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/create_rule_form_flyout.test.tsx
@@ -42,6 +42,10 @@ jest.mock('./kibana_services', () => ({
     }),
 }));
 
+jest.mock('./edit_esql_rule_form_flyout', () => ({
+  EditEsqlRuleFormFlyout: () => <div data-test-subj="mockEditEsqlRuleFormFlyout" />,
+}));
+
 import { DynamicRuleFormFlyout } from './create_rule_form_flyout';
 
 describe('DynamicRuleFormFlyout', () => {
@@ -110,5 +114,23 @@ describe('DynamicRuleFormFlyout', () => {
     });
 
     expect(capturedFlyoutProps.push).toBe(true);
+  });
+
+  it('renders the edit flyout when ruleId is set instead of the package create flyout', async () => {
+    const mockServices = createMockServices();
+    render(
+      <DynamicRuleFormFlyout
+        query="ROW 1"
+        ruleId="rule-123"
+        onClose={jest.fn()}
+      />
+    );
+
+    resolveServices(mockServices);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('mockEditEsqlRuleFormFlyout')).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId('mockDynamicRuleFormFlyout')).not.toBeInTheDocument();
   });
 });

--- a/x-pack/platform/plugins/shared/alerting_v2/public/create_rule_form_flyout.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/create_rule_form_flyout.tsx
@@ -9,14 +9,22 @@ import React from 'react';
 import { EuiLoadingSpinner } from '@elastic/eui';
 import useAsync from 'react-use/lib/useAsync';
 import { untilPluginStartServicesReady } from './kibana_services';
+import { EditEsqlRuleFormFlyout } from './edit_esql_rule_form_flyout';
 
 export interface CreateRuleFormFlyoutProps {
   query: string;
   onClose?: () => void;
   push?: boolean;
+  /**
+   * When set, opens the flyout in edit mode with the rule loaded from the API
+   * (for example, Discover "Edit" from a Discover-origin rule).
+   */
+  ruleId?: string;
 }
 
 export const DynamicRuleFormFlyout = (props: CreateRuleFormFlyoutProps) => {
+  const { ruleId, ...createProps } = props;
+
   const { loading, value } = useAsync(() => {
     const servicesPromise = untilPluginStartServicesReady();
     const modulePromise = import('@kbn/alerting-v2-rule-form');
@@ -26,7 +34,20 @@ export const DynamicRuleFormFlyout = (props: CreateRuleFormFlyoutProps) => {
   const services = value?.[0];
   const Flyout = value?.[1]?.DynamicRuleFormFlyout;
 
-  if (loading || !services || !Flyout) return <EuiLoadingSpinner size="l" />;
+  if (loading || !services) return <EuiLoadingSpinner size="l" />;
 
-  return <Flyout {...props} services={services} />;
+  if (ruleId) {
+    return (
+      <EditEsqlRuleFormFlyout
+        services={services}
+        ruleId={ruleId}
+        onClose={createProps.onClose ?? (() => {})}
+        push={createProps.push}
+      />
+    );
+  }
+
+  if (!Flyout) return <EuiLoadingSpinner size="l" />;
+
+  return <Flyout {...createProps} services={services} />;
 };

--- a/x-pack/platform/plugins/shared/alerting_v2/public/edit_esql_rule_form_flyout.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/edit_esql_rule_form_flyout.tsx
@@ -1,0 +1,139 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiCallOut, EuiLoadingSpinner, EuiSpacer } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n-react';
+import type { RuleResponse } from '@kbn/alerting-v2-schemas';
+import { ALERTING_V2_RULE_API_PATH } from '@kbn/alerting-v2-constants';
+import {
+  mapRuleResponseToFormValues,
+  RuleFormFlyout,
+  StandaloneRuleForm,
+  useUpdateRule,
+  type FormValues,
+} from '@kbn/alerting-v2-rule-form';
+import { QueryClient, QueryClientProvider, useQuery } from '@kbn/react-query';
+import React, { useCallback, useMemo } from 'react';
+import { ruleKeys } from './hooks/query_key_factory';
+import type { AlertingV2KibanaServices } from './kibana_services';
+
+export interface EditEsqlRuleFormFlyoutProps {
+  ruleId: string;
+  onClose: () => void;
+  push?: boolean;
+  services: AlertingV2KibanaServices;
+}
+
+const EditEsqlRuleFormFlyoutInner = ({
+  ruleId,
+  onClose,
+  push = true,
+  services,
+}: EditEsqlRuleFormFlyoutProps) => {
+  // Use http from props instead of useFetchRule (useService(RulesApi)) so this flyout works
+  // when mounted from Discover, where the alerting v2 plugin DI container is not in context.
+  const { data: rule, isLoading, isError, error } = useQuery({
+    queryKey: ruleKeys.detail(ruleId),
+    queryFn: () =>
+      services.http.get<RuleResponse>(
+        `${ALERTING_V2_RULE_API_PATH}/${encodeURIComponent(ruleId)}`
+      ),
+    enabled: Boolean(ruleId),
+    onError: () => {
+      services.notifications.toasts.addDanger(
+        i18n.translate('xpack.alertingV2.editEsqlRuleFormFlyout.loadErrorToast', {
+          defaultMessage: 'Failed to load rule',
+        })
+      );
+    },
+    retry: false,
+    refetchOnWindowFocus: false,
+  });
+  const { updateRule, isLoading: isSaving } = useUpdateRule({
+    http: services.http,
+    notifications: services.notifications,
+    ruleId,
+  });
+
+  const handleSubmit = useCallback(
+    (values: FormValues) => {
+      updateRule(values, { onSuccess: onClose });
+    },
+    [updateRule, onClose]
+  );
+
+  const formBody = (() => {
+    if (isLoading) {
+      return <EuiLoadingSpinner size="l" />;
+    }
+    if (isError || !rule) {
+      return (
+        <EuiCallOut
+          color="danger"
+          title={
+            <FormattedMessage
+              id="xpack.alertingV2.editEsqlRuleFormFlyout.loadErrorTitle"
+              defaultMessage="We couldn’t load this rule."
+            />
+          }
+        >
+          {error instanceof Error ? error.message : String(error ?? '')}
+        </EuiCallOut>
+      );
+    }
+    const isDiscoverSource = rule.metadata?.source === 'discover';
+    return (
+      <StandaloneRuleForm
+        key={ruleId}
+        query={rule.evaluation.query.base}
+        initialValues={mapRuleResponseToFormValues(rule)}
+        ruleId={ruleId}
+        onSubmit={handleSubmit}
+        services={services}
+        layout="flyout"
+        includeYaml
+        includeSubmission={false}
+        isSubmitting={isSaving}
+        includeQueryEditor={isDiscoverSource}
+      />
+    );
+  })();
+
+  return (
+    <RuleFormFlyout
+      variant="edit"
+      push={push}
+      onClose={onClose}
+      isLoading={isLoading || isSaving}
+    >
+      <EuiSpacer size="s" />
+      {formBody}
+    </RuleFormFlyout>
+  );
+};
+
+export const EditEsqlRuleFormFlyout = (props: EditEsqlRuleFormFlyoutProps) => {
+  const queryClient = useMemo(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            retry: false,
+            refetchOnWindowFocus: false,
+          },
+        },
+      }),
+    []
+  );
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <EditEsqlRuleFormFlyoutInner {...props} />
+    </QueryClientProvider>
+  );
+};

--- a/x-pack/platform/plugins/shared/alerting_v2/public/index.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/index.ts
@@ -10,10 +10,12 @@ import { OnSetup, PluginSetup, PluginStart, Start } from '@kbn/core-di';
 import { CoreSetup } from '@kbn/core-di-browser';
 import { i18n } from '@kbn/i18n';
 import type { ManagementSetup } from '@kbn/management-plugin/public';
+import type { AgentBuilderPluginStart } from '@kbn/agent-builder-plugin/public';
 import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
 import type { DataViewsPublicPluginStart } from '@kbn/data-views-plugin/public';
 import type { ExpressionsStart } from '@kbn/expressions-plugin/public';
 import type { LensPublicStart } from '@kbn/lens-plugin/public';
+import type { SharePluginStart } from '@kbn/share-plugin/public';
 import type { UiActionsStart } from '@kbn/ui-actions-plugin/public';
 import {
   ALERTING_V2_SECTION_ID,
@@ -43,6 +45,13 @@ export const module = new ContainerModule(({ bind }) => {
 
     getStartServices().then(([coreStart]) => {
       const diContainer = coreStart.injection.getContainer();
+      const share = diContainer.get(PluginStart('share')) as SharePluginStart;
+      let agentBuilder: AgentBuilderPluginStart | undefined;
+      try {
+        agentBuilder = diContainer.get(PluginStart('agentBuilder')) as AgentBuilderPluginStart;
+      } catch {
+        agentBuilder = undefined;
+      }
       setKibanaServices({
         http: coreStart.http,
         notifications: coreStart.notifications,
@@ -52,6 +61,8 @@ export const module = new ContainerModule(({ bind }) => {
         lens: diContainer.get(PluginStart('lens')) as LensPublicStart,
         expressions: diContainer.get(PluginStart('expressions')) as ExpressionsStart,
         uiActions: diContainer.get(PluginStart('uiActions')) as UiActionsStart,
+        share,
+        agentBuilder,
       });
     });
 

--- a/x-pack/platform/plugins/shared/alerting_v2/public/kibana_services.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/kibana_services.test.ts
@@ -22,6 +22,7 @@ const createMockServices = (): AlertingV2KibanaServices => ({
   lens: lensPluginMock.createStartContract(),
   expressions: {} as AlertingV2KibanaServices['expressions'],
   uiActions: {} as AlertingV2KibanaServices['uiActions'],
+  share: { url: { locators: { get: jest.fn() } } } as unknown as AlertingV2KibanaServices['share'],
 });
 
 describe('kibana_services', () => {

--- a/x-pack/platform/plugins/shared/alerting_v2/public/kibana_services.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/kibana_services.ts
@@ -5,15 +5,20 @@
  * 2.0.
  */
 
+import { useSyncExternalStore } from 'react';
 import { BehaviorSubject } from 'rxjs';
 import type { RuleFormServices } from '@kbn/alerting-v2-rule-form';
+import type { AgentBuilderPluginStart } from '@kbn/agent-builder-plugin/public';
 import type { ExpressionsStart } from '@kbn/expressions-plugin/public';
+import type { SharePluginStart } from '@kbn/share-plugin/public';
 import type { UiActionsStart } from '@kbn/ui-actions-plugin/public';
 
 /** Services shared by rule UI, episodes UI, and other alerting_v2 surfaces. */
 export type AlertingV2KibanaServices = RuleFormServices & {
   expressions: ExpressionsStart;
   uiActions: UiActionsStart;
+  share: SharePluginStart;
+  agentBuilder?: AgentBuilderPluginStart;
 };
 
 const servicesReady$ = new BehaviorSubject<AlertingV2KibanaServices | undefined>(undefined);
@@ -33,3 +38,18 @@ export const untilPluginStartServicesReady = (): Promise<AlertingV2KibanaService
 export const setKibanaServices = (services: AlertingV2KibanaServices) => {
   servicesReady$.next(services);
 };
+
+/**
+ * Resolves to undefined until plugin start has registered services (rare on first paint).
+ */
+export const useAlertingV2KibanaServices = (): AlertingV2KibanaServices | undefined => {
+  return useSyncExternalStore(
+    (onChange) => {
+      const sub = servicesReady$.subscribe(() => onChange());
+      return () => sub.unsubscribe();
+    },
+    () => servicesReady$.value,
+    () => servicesReady$.value
+  );
+};
+

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/episode_details_page/episode_details_page.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/episode_details_page/episode_details_page.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { Suspense, useMemo, useState } from 'react';
+import React, { Suspense, useCallback, useMemo, useState } from 'react';
 import {
   EuiAccordion,
   EuiBadge,
@@ -52,7 +52,11 @@ import { css } from '@emotion/react';
 import { useHistory, useParams } from 'react-router-dom';
 import { KibanaPageTemplate } from '@kbn/shared-ux-page-kibana-template';
 import { useFetchRule } from '../../hooks/use_fetch_rule';
+import { useDeleteRule } from '../../hooks/use_delete_rule';
+import { useToggleRuleEnabled } from '../../hooks/use_toggle_rule_enabled';
 import { CenterJustifiedSpinner } from '../../components/center_justified_spinner';
+import { DeleteConfirmationModal } from '../../components/rule/modals/delete_confirmation_modal';
+import { RuleSummaryFlyout } from '../../components/rule/flyouts';
 import { paths } from '../../constants';
 import type { AlertEpisodesKibanaServices } from '../../episodes_kibana_services';
 import { useBreadcrumbs } from '../../hooks/use_breadcrumbs';
@@ -121,8 +125,13 @@ export function EpisodeDetailsPage() {
   const [sidebarPanel, setSidebarPanel] = useState<EpisodeDetailsSidebarPanel>('episode_details');
   const { services } = useKibana<AlertEpisodesKibanaServices>();
   const { euiTheme } = useEuiTheme();
-  const { data, notifications, http, expressions } = services;
+  const { data, notifications, http, expressions, application } = services;
   const history = useHistory();
+
+  const [isRuleSummaryFlyoutOpen, setIsRuleSummaryFlyoutOpen] = useState(false);
+  const [rulePendingDelete, setRulePendingDelete] = useState<RuleResponse | null>(null);
+  const deleteRuleMutation = useDeleteRule();
+  const toggleEnabledMutation = useToggleRuleEnabled();
 
   const {
     data: eventRows = [],
@@ -234,6 +243,18 @@ export function EpisodeDetailsPage() {
       : i18n.translate('xpack.alertingV2.episodeDetails.ruleKindAlerting', {
           defaultMessage: 'Alerting',
         });
+
+  const onConfirmDeleteRule = useCallback(() => {
+    if (!rulePendingDelete) {
+      return;
+    }
+    deleteRuleMutation.mutate(rulePendingDelete.id, {
+      onSettled: () => {
+        setRulePendingDelete(null);
+        setIsRuleSummaryFlyoutOpen(false);
+      },
+    });
+  }, [deleteRuleMutation, rulePendingDelete]);
 
   const isLoading = isLoadingEvents || (Boolean(ruleId) && isLoadingRule);
   const episodeNotFound = !isLoading && eventRows.length === 0;
@@ -455,7 +476,7 @@ export function EpisodeDetailsPage() {
                       size="xs"
                       color="text"
                       iconType="eye"
-                      href={http.basePath.prepend(paths.ruleDetails(rule.id))}
+                      onClick={() => setIsRuleSummaryFlyoutOpen(true)}
                       data-test-subj="alertingV2EpisodeDetailsViewRuleDetailsButton"
                     >
                       {i18n.translate('xpack.alertingV2.episodeDetails.viewRuleDetails', {
@@ -550,37 +571,38 @@ export function EpisodeDetailsPage() {
   );
 
   return (
-    <KibanaPageTemplate
-      paddingSize="none"
-      bottomBorder={false}
-      data-test-subj="alertingV2EpisodeDetailsPage"
-    >
-      {isLoading ? (
-        <KibanaPageTemplate.Section grow>
-          <CenterJustifiedSpinner />
-        </KibanaPageTemplate.Section>
-      ) : (
-        <>
-          <KibanaPageTemplate.Header
-            pageTitle={pageTitle}
-            description={headerDescription}
-            bottomBorder
-            rightSideItems={[
-              <AlertEpisodeActions
-                key="alertingV2EpisodeHeaderActions"
-                episodeId={episodeId}
-                groupHash={groupHash}
-                episodeAction={episodeAction}
-                groupAction={groupAction}
-                http={http}
-                openInDiscoverHref={openInDiscoverHref}
-                expressions={expressions}
-                buttonsOutlined={false}
-              />,
-            ]}
-            rightSideGroupProps={{ gutterSize: 's' }}
-          />
-          <KibanaPageTemplate.Section paddingSize="none" grow>
+    <>
+      <KibanaPageTemplate
+        paddingSize="none"
+        bottomBorder={false}
+        data-test-subj="alertingV2EpisodeDetailsPage"
+      >
+        {isLoading ? (
+          <KibanaPageTemplate.Section grow>
+            <CenterJustifiedSpinner />
+          </KibanaPageTemplate.Section>
+        ) : (
+          <>
+            <KibanaPageTemplate.Header
+              pageTitle={pageTitle}
+              description={headerDescription}
+              bottomBorder
+              rightSideItems={[
+                <AlertEpisodeActions
+                  key="alertingV2EpisodeHeaderActions"
+                  episodeId={episodeId}
+                  groupHash={groupHash}
+                  episodeAction={episodeAction}
+                  groupAction={groupAction}
+                  http={http}
+                  openInDiscoverHref={openInDiscoverHref}
+                  expressions={expressions}
+                  buttonsOutlined={false}
+                />,
+              ]}
+              rightSideGroupProps={{ gutterSize: 's' }}
+            />
+            <KibanaPageTemplate.Section paddingSize="none" grow>
             <EuiSplitPanel.Outer direction="row" hasBorder={false} hasShadow={false} grow>
               <EuiSplitPanel.Inner grow paddingSize="l">
                 <Suspense fallback={<EuiLoadingSpinner size="l" />}>
@@ -681,8 +703,35 @@ export function EpisodeDetailsPage() {
               </EuiSplitPanel.Inner>
             </EuiSplitPanel.Outer>
           </KibanaPageTemplate.Section>
-        </>
-      )}
-    </KibanaPageTemplate>
+          </>
+        )}
+      </KibanaPageTemplate>
+      {rule && isRuleSummaryFlyoutOpen ? (
+        <RuleSummaryFlyout
+          rule={rule}
+          onClose={() => setIsRuleSummaryFlyoutOpen(false)}
+          onEdit={(r) => {
+            setIsRuleSummaryFlyoutOpen(false);
+            application.navigateToUrl(http.basePath.prepend(paths.ruleEdit(r.id)));
+          }}
+          onClone={(r) => {
+            setIsRuleSummaryFlyoutOpen(false);
+            application.navigateToUrl(
+              http.basePath.prepend(`${paths.ruleCreateForm}?cloneFrom=${encodeURIComponent(r.id)}`)
+            );
+          }}
+          onDelete={(r) => setRulePendingDelete(r)}
+          onToggleEnabled={(r) => toggleEnabledMutation.mutate({ id: r.id, enabled: !r.enabled })}
+        />
+      ) : null}
+      {rulePendingDelete ? (
+        <DeleteConfirmationModal
+          ruleName={rulePendingDelete.metadata?.name ?? rulePendingDelete.id}
+          onCancel={() => setRulePendingDelete(null)}
+          onConfirm={onConfirmDeleteRule}
+          isLoading={deleteRuleMutation.isLoading}
+        />
+      ) : null}
+    </>
   );
 }

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/rule_builders_hub_page/rule_builders_hub_page.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/rule_builders_hub_page/rule_builders_hub_page.tsx
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiPageTemplate, EuiSpacer, EuiText, EuiTitle } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { useService, CoreStart } from '@kbn/core-di-browser';
+import { RuleBuilderChoiceCards } from '../../components/rule_builders/rule_builder_choice_cards';
+import { useBreadcrumbs } from '../../hooks/use_breadcrumbs';
+import { paths } from '../../constants';
+
+export const RuleBuildersHubPage = () => {
+  const { basePath } = useService(CoreStart('http'));
+  useBreadcrumbs('create');
+
+  return (
+    <EuiPageTemplate.Section
+      paddingSize="l"
+      grow
+      restrictWidth
+      data-test-subj="ruleBuildersHub"
+    >
+      <EuiTitle size="m">
+        <h1>
+          {i18n.translate('xpack.alertingV2.ruleBuildersHub.pageTitle', {
+            defaultMessage: 'New Alerting Experience',
+          })}
+        </h1>
+      </EuiTitle>
+      <EuiSpacer size="m" />
+      <EuiText size="s" color="subdued" data-test-subj="ruleBuildersHubDescription">
+        {i18n.translate('xpack.alertingV2.ruleBuildersHub.pageDescription', {
+          defaultMessage:
+            'Powerful ES|QL-driven rules and support for external alerts — consistent, high-quality alert data in a unified experience. Start from a rule builder below.',
+        })}
+      </EuiText>
+      <EuiSpacer size="l" />
+      <RuleBuilderChoiceCards
+        thresholdHref={basePath.prepend(paths.ruleCreateForm)}
+        sectionHeadingAlign="left"
+      />
+    </EuiPageTemplate.Section>
+  );
+};

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/rule_form_page/rule_form_page.test.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/rule_form_page/rule_form_page.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { I18nProvider } from '@kbn/i18n-react';
 import { QueryClient, QueryClientProvider } from '@kbn/react-query';
 import { MemoryRouter } from 'react-router-dom';
@@ -33,11 +33,26 @@ jest.mock('@kbn/alerting-v2-rule-form', () => {
 });
 
 const mockNavigateToUrl = jest.fn();
+const mockNavigateToApp = jest.fn();
+const mockGetLocation = jest.fn().mockResolvedValue({
+  app: 'discover',
+  path: '#/',
+  state: { openCreateEsqlRuleV2Flyout: true, esqlRuleV2EditRuleId: 'rule-1' },
+});
 const mockGetUrlForApp = jest.fn((appId: string, options?: { path?: string }) => {
   const path = options?.path ?? '';
   return `/app/${appId}${path}`;
 });
 const mockDocTitleChange = jest.fn();
+
+jest.mock('../rules_list_page/use_rule_list_creation_actions', () => ({
+  useRuleListCreationActions: () => ({
+    canCreateInDiscover: true,
+    canCreateWithAi: false,
+    openCreateInDiscover: jest.fn(),
+    openCreateWithAiAgent: jest.fn(),
+  }),
+}));
 
 jest.mock('../../application/breadcrumb_context', () => ({
   useSetBreadcrumbs: () => jest.fn(),
@@ -49,13 +64,26 @@ jest.mock('@kbn/core-di-browser', () => ({
       return { basePath: { prepend: (p: string) => p } };
     }
     if (token === 'application') {
-      return { navigateToUrl: mockNavigateToUrl, getUrlForApp: mockGetUrlForApp };
+      return {
+        navigateToUrl: mockNavigateToUrl,
+        navigateToApp: mockNavigateToApp,
+        getUrlForApp: mockGetUrlForApp,
+      };
     }
     if (token === 'chrome') {
       return { docTitle: { change: mockDocTitleChange } };
     }
     if (token === 'data') {
       return { search: { search: jest.fn() } };
+    }
+    if (token === 'share') {
+      return {
+        url: {
+          locators: {
+            get: () => ({ getLocation: mockGetLocation }),
+          },
+        },
+      };
     }
     return {};
   },
@@ -74,9 +102,9 @@ const createQueryClient = () =>
 const renderCreatePage = () => {
   return render(
     <QueryClientProvider client={createQueryClient()}>
-      <MemoryRouter initialEntries={['/create']}>
+      <MemoryRouter initialEntries={['/create/form']}>
         <I18nProvider>
-          <Route path="/create">
+          <Route path="/create/form">
             <RuleFormPage />
           </Route>
         </I18nProvider>
@@ -102,9 +130,9 @@ const renderEditPage = (ruleId: string = 'rule-1') => {
 const renderClonePage = (sourceRuleId: string = 'rule-1') => {
   return render(
     <QueryClientProvider client={createQueryClient()}>
-      <MemoryRouter initialEntries={[`/create?cloneFrom=${sourceRuleId}`]}>
+      <MemoryRouter initialEntries={[`/create/form?cloneFrom=${sourceRuleId}`]}>
         <I18nProvider>
-          <Route path="/create">
+          <Route path="/create/form">
             <RuleFormPage />
           </Route>
         </I18nProvider>
@@ -117,6 +145,11 @@ describe('RuleFormPage', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     capturedStandaloneProps = {};
+    mockGetLocation.mockResolvedValue({
+      app: 'discover',
+      path: '#/',
+      state: { openCreateEsqlRuleV2Flyout: true, esqlRuleV2EditRuleId: 'rule-1' },
+    });
   });
 
   describe('create mode', () => {
@@ -124,6 +157,12 @@ describe('RuleFormPage', () => {
       renderCreatePage();
 
       expect(screen.getByRole('heading', { name: 'Create rule' })).toBeInTheDocument();
+    });
+
+    it('does not show Create in Discover (edit-only action)', () => {
+      renderCreatePage();
+
+      expect(screen.queryByTestId('ruleFormPageCreateInDiscoverButton')).not.toBeInTheDocument();
     });
 
     it('renders StandaloneRuleForm', () => {
@@ -277,6 +316,94 @@ describe('RuleFormPage', () => {
       expect(screen.getByText('Edit rule')).toBeInTheDocument();
     });
 
+    it('shows Create in Discover in the header for builder-origin rules', () => {
+      mockUseFetchRule.mockReturnValue({
+        data: {
+          id: 'rule-1',
+          kind: 'alert',
+          enabled: true,
+          metadata: { name: 'Test Rule', source: 'kibana_ui' },
+          time_field: '@timestamp',
+          schedule: { every: '1m', lookback: '5m' },
+          evaluation: { query: { base: 'FROM my-index | LIMIT 1' } },
+        },
+        isLoading: false,
+        isError: false,
+        error: null,
+      });
+
+      renderEditPage();
+
+      expect(screen.getByTestId('ruleFormPageCreateInDiscoverButton')).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: 'Create in Discover' })
+      ).toBeInTheDocument();
+    });
+
+    it('shows Edit in Discover in the header for discover-origin rules', () => {
+      mockUseFetchRule.mockReturnValue({
+        data: {
+          id: 'rule-1',
+          kind: 'alert',
+          enabled: true,
+          metadata: { name: 'Test Rule', source: 'discover' },
+          time_field: '@timestamp',
+          schedule: { every: '1m', lookback: '5m' },
+          evaluation: { query: { base: 'FROM my-index | LIMIT 1' } },
+        },
+        isLoading: false,
+        isError: false,
+        error: null,
+      });
+
+      renderEditPage();
+
+      expect(screen.getByTestId('ruleFormPageEditInDiscoverButton')).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: 'Edit in Discover' })
+      ).toBeInTheDocument();
+    });
+
+    it('opens Discover with the ES|QL rule flyout in edit mode when Create in Discover is clicked', async () => {
+      mockUseFetchRule.mockReturnValue({
+        data: {
+          id: 'rule-1',
+          kind: 'alert',
+          enabled: true,
+          metadata: { name: 'Test Rule' },
+          time_field: '@timestamp',
+          schedule: { every: '1m', lookback: '5m' },
+          evaluation: { query: { base: 'FROM my-index | LIMIT 1' } },
+        },
+        isLoading: false,
+        isError: false,
+        error: null,
+      });
+
+      renderEditPage();
+
+      fireEvent.click(screen.getByTestId('ruleFormPageCreateInDiscoverButton'));
+
+      await waitFor(() => {
+        expect(mockNavigateToApp).toHaveBeenCalled();
+      });
+
+      expect(mockGetLocation).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: { esql: 'FROM my-index | LIMIT 1' },
+          openCreateEsqlRuleV2Flyout: true,
+          esqlRuleV2EditRuleId: 'rule-1',
+        })
+      );
+      expect(mockNavigateToApp).toHaveBeenCalledWith(
+        'discover',
+        expect.objectContaining({
+          path: '#/',
+          state: { openCreateEsqlRuleV2Flyout: true, esqlRuleV2EditRuleId: 'rule-1' },
+        })
+      );
+    });
+
     it('passes ruleId to StandaloneRuleForm', () => {
       mockUseFetchRule.mockReturnValue({
         data: {
@@ -427,6 +554,27 @@ describe('RuleFormPage', () => {
       renderClonePage();
 
       expect(screen.getByRole('heading', { name: 'Create rule' })).toBeInTheDocument();
+    });
+
+    it('does not show Create in Discover in clone mode', () => {
+      mockUseFetchRule.mockReturnValue({
+        data: {
+          id: 'rule-1',
+          kind: 'alert',
+          enabled: true,
+          metadata: { name: 'Source Rule' },
+          time_field: '@timestamp',
+          schedule: { every: '1m', lookback: '5m' },
+          evaluation: { query: { base: 'FROM logs-* | LIMIT 1' } },
+        },
+        isLoading: false,
+        isError: false,
+        error: null,
+      });
+
+      renderClonePage();
+
+      expect(screen.queryByTestId('ruleFormPageCreateInDiscoverButton')).not.toBeInTheDocument();
     });
 
     it('does not pass ruleId to StandaloneRuleForm (creates a new rule)', () => {

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/rule_form_page/rule_form_page.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/rule_form_page/rule_form_page.tsx
@@ -7,6 +7,7 @@
 
 import React, { useCallback, useMemo } from 'react';
 import {
+  EuiButton,
   EuiCallOut,
   EuiLoadingSpinner,
   EuiPageHeader,
@@ -21,6 +22,9 @@ import type { LensPublicStart } from '@kbn/lens-plugin/public';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { useParams, useLocation } from 'react-router-dom';
 import { useQueryClient } from '@kbn/react-query';
+import { DISCOVER_APP_LOCATOR } from '@kbn/deeplinks-analytics';
+import type { DiscoverAppLocatorParams } from '@kbn/discover-plugin/common';
+import type { SharePluginStart } from '@kbn/share-plugin/public';
 import { StandaloneRuleForm, mapRuleResponseToFormValues } from '@kbn/alerting-v2-rule-form';
 import type { FormValues } from '@kbn/alerting-v2-rule-form';
 import { i18n } from '@kbn/i18n';
@@ -28,6 +32,7 @@ import { useFetchRule } from '../../hooks/use_fetch_rule';
 import { ruleKeys } from '../../hooks/query_key_factory';
 import { useBreadcrumbs } from '../../hooks/use_breadcrumbs';
 import { paths } from '../../constants';
+import { useRuleListCreationActions } from '../rules_list_page/use_rule_list_creation_actions';
 
 const DEFAULT_QUERY = 'FROM logs-*\n| LIMIT 1';
 
@@ -136,7 +141,58 @@ const RuleFormPageContent = ({ ruleId, initialQuery, initialValues }: RuleFormPa
   const data = useService(PluginStart('data')) as DataPublicPluginStart;
   const dataViews = useService(PluginStart('dataViews')) as DataViewsPublicPluginStart;
   const lens = useService(PluginStart('lens')) as LensPublicStart;
+  const share = useService(PluginStart('share')) as SharePluginStart;
   const queryClient = useQueryClient();
+
+  const { canCreateInDiscover, openCreateInDiscover } = useRuleListCreationActions();
+
+  const openEsqlInDiscover = useCallback(
+    async (esql: string) => {
+      const locator = share?.url?.locators?.get<DiscoverAppLocatorParams>(DISCOVER_APP_LOCATOR);
+      if (!locator) {
+        return;
+      }
+      const { app, path, state } = await locator.getLocation({
+        query: { esql },
+      });
+      await application.navigateToApp(app, { path, state });
+    },
+    [application, share]
+  );
+
+  /** Create / clone: open Discover with the new-rule flyout; use form default query when set (e.g. clone). */
+  const onCreateInDiscoverFromForm = useCallback(async () => {
+    if (initialQuery === undefined || initialQuery === DEFAULT_QUERY) {
+      await openCreateInDiscover();
+      return;
+    }
+    const locator = share?.url?.locators?.get<DiscoverAppLocatorParams>(DISCOVER_APP_LOCATOR);
+    if (!locator?.getLocation) {
+      return;
+    }
+    const { app, path, state } = await locator.getLocation({
+      query: { esql: initialQuery },
+      openCreateEsqlRuleV2Flyout: true,
+    });
+    await application.navigateToApp(app, { path, state });
+  }, [application, initialQuery, openCreateInDiscover, share]);
+
+  const openContinueInDiscover = useCallback(async () => {
+    if (!ruleId) {
+      return;
+    }
+    const locator = share?.url?.locators?.get<DiscoverAppLocatorParams>(DISCOVER_APP_LOCATOR);
+    if (!locator?.getLocation) {
+      return;
+    }
+    const esql = initialQuery ?? DEFAULT_QUERY;
+    const { app, path, state } = await locator.getLocation({
+      query: { esql },
+      openCreateEsqlRuleV2Flyout: true,
+      esqlRuleV2EditRuleId: ruleId,
+    });
+    await application.navigateToApp(app, { path, state });
+  }, [application, initialQuery, ruleId, share]);
 
   useBreadcrumbs(isEditing ? 'edit' : 'create');
 
@@ -148,8 +204,9 @@ const RuleFormPageContent = ({ ruleId, initialQuery, initialValues }: RuleFormPa
       notifications,
       application,
       lens,
+      openEsqlInDiscover,
     }),
-    [http, data, dataViews, notifications, application, lens]
+    [http, data, dataViews, notifications, application, lens, openEsqlInDiscover]
   );
 
   const onSuccess = useCallback(() => {
@@ -176,9 +233,61 @@ const RuleFormPageContent = ({ ruleId, initialQuery, initialValues }: RuleFormPa
     <FormattedMessage id="xpack.alertingV2.createRule.submitLabel" defaultMessage="Create rule" />
   );
 
+  const editInDiscoverLabel = i18n.translate('xpack.alertingV2.rulesList.action.editInDiscover', {
+    defaultMessage: 'Edit in Discover',
+  });
+  const createInDiscoverLabel = i18n.translate('xpack.alertingV2.rulesList.createInDiscover', {
+    defaultMessage: 'Create in Discover',
+  });
+
+  const pageHeaderRight = useMemo(() => {
+    if (!canCreateInDiscover) {
+      return undefined;
+    }
+    if (ruleId) {
+      return [
+        <EuiButton
+          key="editInDiscover"
+          data-test-subj="ruleFormPageEditInDiscoverButton"
+          size="s"
+          color="text"
+          fill={false}
+          iconType="discoverApp"
+          onClick={() => {
+            void openContinueInDiscover();
+          }}
+        >
+          {editInDiscoverLabel}
+        </EuiButton>,
+      ];
+    }
+    return [
+      <EuiButton
+        key="createInDiscoverForm"
+        data-test-subj="ruleFormPageCreateInDiscoverButton"
+        size="s"
+        color="text"
+        fill={false}
+        iconType="discoverApp"
+        onClick={() => {
+          void onCreateInDiscoverFromForm();
+        }}
+      >
+        {createInDiscoverLabel}
+      </EuiButton>,
+    ];
+  }, [
+    canCreateInDiscover,
+    createInDiscoverLabel,
+    editInDiscoverLabel,
+    onCreateInDiscoverFromForm,
+    openContinueInDiscover,
+    ruleId,
+  ]);
+
   return (
     <>
-      <EuiPageHeader pageTitle={pageTitle} />
+      <EuiPageHeader pageTitle={pageTitle} rightSideItems={pageHeaderRight} />
       <EuiSpacer size="m" />
       <StandaloneRuleForm
         query={initialQuery ?? DEFAULT_QUERY}

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/rules_list_page/create_rule_split_button.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/rules_list_page/create_rule_split_button.tsx
@@ -1,0 +1,119 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useCallback, useMemo, useState } from 'react';
+import { EuiButton, EuiContextMenu, EuiSplitButton, useGeneratedHtmlId } from '@elastic/eui';
+import type { EuiContextMenuPanelDescriptor } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { useService, CoreStart } from '@kbn/core-di-browser';
+import { FormattedMessage } from '@kbn/i18n-react';
+import { useBoolean } from '@kbn/react-hooks';
+import { paths } from '../../constants';
+import { useRuleListCreationActions } from './use_rule_list_creation_actions';
+
+export const CreateRuleSplitButton = () => {
+  const { basePath } = useService(CoreStart('http'));
+  const application = useService(CoreStart('application'));
+  const {
+    canCreateInDiscover,
+    canCreateWithAi,
+    openCreateInDiscover,
+    openCreateWithAiAgent,
+  } = useRuleListCreationActions();
+
+  const [isOpen, { off: close, toggle }] = useBoolean(false);
+  const [menuKey, setMenuKey] = useState(0);
+  const popoverId = useGeneratedHtmlId({ prefix: 'createRuleSplit' });
+  const closeMenu = useCallback(() => {
+    close();
+    setMenuKey((k) => k + 1);
+  }, [close]);
+
+  const onCreateWithAi = useCallback(() => {
+    openCreateWithAiAgent();
+  }, [openCreateWithAiAgent]);
+
+  const panels: EuiContextMenuPanelDescriptor[] = useMemo(() => {
+    const items: EuiContextMenuPanelDescriptor[number]['items'] = [];
+    if (canCreateInDiscover) {
+      items.push({
+        'data-test-subj': 'createRuleMenuCreateInDiscover',
+        name: i18n.translate('xpack.alertingV2.rulesList.createInDiscover', {
+          defaultMessage: 'Create in Discover',
+        }),
+        icon: 'discoverApp',
+        onClick: () => {
+          void openCreateInDiscover();
+          closeMenu();
+        },
+      });
+    }
+    if (canCreateWithAi) {
+      items.push({
+        'data-test-subj': 'createRuleMenuCreateWithAiAgent',
+        name: i18n.translate('xpack.alertingV2.rulesList.createWithAiAgent', {
+          defaultMessage: 'Create with AI Agent',
+        }),
+        icon: 'productAgent',
+        onClick: () => {
+          onCreateWithAi();
+          closeMenu();
+        },
+      });
+    }
+    return [{ id: 0, items }];
+  }, [canCreateInDiscover, canCreateWithAi, closeMenu, onCreateWithAi, openCreateInDiscover]);
+
+  const hasDropdownItems = canCreateInDiscover || canCreateWithAi;
+  const createHref = basePath.prepend(paths.ruleCreate);
+  const secondaryLabel = i18n.translate('xpack.alertingV2.rulesList.createRuleSplitOptions', {
+    defaultMessage: 'More create options for rules',
+  });
+
+  const createRuleLabel = (
+    <FormattedMessage
+      id="xpack.alertingV2.rulesList.createRuleButton"
+      defaultMessage="Create rule"
+    />
+  );
+
+  if (!hasDropdownItems) {
+    return (
+      <EuiButton fill href={createHref} data-test-subj="createRuleButton" iconType="plusInCircle">
+        {createRuleLabel}
+      </EuiButton>
+    );
+  }
+
+  return (
+    <EuiSplitButton data-test-subj="createRuleSplitButton" color="primary" fill size="m">
+      <EuiSplitButton.ActionPrimary
+        data-test-subj="createRuleButton"
+        iconType="plusInCircle"
+        onClick={() => {
+          application.navigateToUrl(createHref);
+        }}
+      >
+        {createRuleLabel}
+      </EuiSplitButton.ActionPrimary>
+      <EuiSplitButton.ActionSecondary
+        data-test-subj="createRuleSplitButtonDropdown"
+        iconType="arrowDown"
+        aria-label={secondaryLabel}
+        onClick={toggle}
+        popoverProps={{
+          id: popoverId,
+          isOpen,
+          closePopover: closeMenu,
+          anchorPosition: 'downRight',
+          panelPaddingSize: 'none',
+          children: <EuiContextMenu key={menuKey} size="m" initialPanelId={0} panels={panels} />,
+        }}
+      />
+    </EuiSplitButton>
+  );
+};

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/rules_list_page/rule_actions_menu.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/rules_list_page/rule_actions_menu.tsx
@@ -5,20 +5,26 @@
  * 2.0.
  */
 
-import React, { useState } from 'react';
-import {
-  EuiButtonIcon,
-  EuiContextMenuItem,
-  EuiContextMenuPanel,
-  EuiIcon,
-  EuiPopover,
-} from '@elastic/eui';
+import React, { useCallback, useMemo, useState } from 'react';
+import { EuiButtonIcon, EuiContextMenu, EuiPopover, useGeneratedHtmlId } from '@elastic/eui';
+import type { EuiContextMenuPanelDescriptor } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import type { RuleApiResponse } from '../../services/rules_api';
 
+/**
+ * Rule overflow menu — structure, labels, and EUI icons follow:
+ * Figma: RnA Rule Authoring (node 1592:37436)
+ * https://www.figma.com/design/tY4wbu3wXh4XK9p4MmYRLQ/RnA---Rule-Authoring-experience?node-id=1592-37436
+ */
 export interface RuleActionsMenuProps {
   rule: RuleApiResponse;
-  onEdit: (rule: RuleApiResponse) => void;
+  canOpenEditInDiscover: boolean;
+  canEditWithAi: boolean;
+  onEditInDiscover: (rule: RuleApiResponse) => void | Promise<void>;
+  onEditInBuilder: (rule: RuleApiResponse) => void;
+  onEditWithAiAgent: (rule: RuleApiResponse) => void;
+  onRunRule: (rule: RuleApiResponse) => void;
+  onUpdateApiKey: (rule: RuleApiResponse) => void;
   onClone: (rule: RuleApiResponse) => void;
   onDelete: (rule: RuleApiResponse) => void;
   onToggleEnabled: (rule: RuleApiResponse) => void;
@@ -26,90 +32,212 @@ export interface RuleActionsMenuProps {
 
 export const RuleActionsMenu = ({
   rule,
-  onEdit,
+  canOpenEditInDiscover,
+  canEditWithAi,
+  onEditInDiscover,
+  onEditInBuilder,
+  onEditWithAiAgent,
+  onRunRule,
+  onUpdateApiKey,
   onClone,
   onDelete,
   onToggleEnabled,
 }: RuleActionsMenuProps) => {
   const [isOpen, setIsOpen] = useState(false);
+  const [menuKey, setMenuKey] = useState(0);
+  const popoverId = useGeneratedHtmlId({ prefix: 'ruleActionsMenu' });
 
-  const menuItems = [
-    <EuiContextMenuItem
-      key="edit"
-      icon={<EuiIcon type="pencil" size="m" aria-hidden={true} />}
-      onClick={() => {
-        setIsOpen(false);
-        onEdit(rule);
-      }}
-      data-test-subj={`editRule-${rule.id}`}
-    >
-      {i18n.translate('xpack.alertingV2.rulesList.action.edit', { defaultMessage: 'Edit' })}
-    </EuiContextMenuItem>,
-    <EuiContextMenuItem
-      key="clone"
-      icon={<EuiIcon type="copy" size="m" aria-hidden={true} />}
-      onClick={() => {
-        setIsOpen(false);
+  const closeMenu = useCallback(() => {
+    setIsOpen(false);
+    setMenuKey((k) => k + 1);
+  }, []);
+
+  const isDiscoverSource = rule.metadata?.source === 'discover';
+
+  const moreActionsLabel = i18n.translate('xpack.alertingV2.rulesList.action.moreActions', {
+    defaultMessage: 'More actions',
+  });
+
+  const menuAriaLabel = i18n.translate('xpack.alertingV2.rulesList.action.actionsMenu', {
+    defaultMessage: 'Rule actions',
+  });
+
+  const panels: EuiContextMenuPanelDescriptor[] = useMemo(() => {
+    const editInDiscoverLabel = i18n.translate('xpack.alertingV2.rulesList.action.editInDiscover', {
+      defaultMessage: 'Edit in Discover',
+    });
+    const editInBuilderLabel = i18n.translate('xpack.alertingV2.rulesList.action.editInBuilder', {
+      defaultMessage: 'Edit in Builder',
+    });
+    const editWithAiLabel = i18n.translate('xpack.alertingV2.rulesList.action.editWithAiAgent', {
+      defaultMessage: 'Edit with AI Agent',
+    });
+    const cloneLabel = i18n.translate('xpack.alertingV2.rulesList.action.clone', {
+      defaultMessage: 'Clone',
+    });
+    const runLabel = i18n.translate('xpack.alertingV2.rulesList.action.run', {
+      defaultMessage: 'Run',
+    });
+    const updateApiKeyLabel = i18n.translate('xpack.alertingV2.rulesList.action.updateApiKey', {
+      defaultMessage: 'Update API key',
+    });
+    const deleteLabel = i18n.translate('xpack.alertingV2.rulesList.action.delete', {
+      defaultMessage: 'Delete',
+    });
+    const enableLabel = i18n.translate('xpack.alertingV2.rulesList.action.enable', {
+      defaultMessage: 'Enable',
+    });
+    const disableLabel = i18n.translate('xpack.alertingV2.rulesList.action.disable', {
+      defaultMessage: 'Disable',
+    });
+    const editWithAiUnavailableTooltip = i18n.translate(
+      'xpack.alertingV2.rulesList.action.editWithAiAgentUnavailableTooltip',
+      {
+        defaultMessage: 'Agent Builder isn’t available in this deployment.',
+      }
+    );
+
+    const items: EuiContextMenuPanelDescriptor[number]['items'] = [];
+
+    if (isDiscoverSource) {
+      items.push({
+        'data-test-subj': `editInDiscoverRule-${rule.id}`,
+        name: editInDiscoverLabel,
+        icon: 'discoverApp',
+        disabled: !canOpenEditInDiscover,
+        onClick: () => {
+          if (!canOpenEditInDiscover) {
+            return;
+          }
+          void onEditInDiscover(rule);
+          closeMenu();
+        },
+      });
+    } else {
+      items.push({
+        'data-test-subj': `editInBuilderRule-${rule.id}`,
+        name: editInBuilderLabel,
+        icon: 'indexOpen',
+        onClick: () => {
+          onEditInBuilder(rule);
+          closeMenu();
+        },
+      });
+    }
+
+    items.push({
+      'data-test-subj': `editWithAiRule-${rule.id}`,
+      name: editWithAiLabel,
+      icon: 'productAgent',
+      disabled: !canEditWithAi,
+      ...(canEditWithAi
+        ? {}
+        : { toolTipContent: editWithAiUnavailableTooltip, toolTipProps: { position: 'left' } }),
+      onClick: () => {
+        if (!canEditWithAi) {
+          return;
+        }
+        onEditWithAiAgent(rule);
+        closeMenu();
+      },
+    });
+
+    items.push({
+      'data-test-subj': `cloneRule-${rule.id}`,
+      name: cloneLabel,
+      icon: 'copy',
+      onClick: () => {
         onClone(rule);
-      }}
-      data-test-subj={`cloneRule-${rule.id}`}
-    >
-      {i18n.translate('xpack.alertingV2.rulesList.action.clone', { defaultMessage: 'Clone' })}
-    </EuiContextMenuItem>,
-    <EuiContextMenuItem
-      key="toggleEnabled"
-      icon={<EuiIcon type={rule.enabled ? 'bellSlash' : 'bell'} size="m" aria-hidden={true} />}
-      onClick={() => {
-        setIsOpen(false);
+        closeMenu();
+      },
+    });
+
+    items.push({ isSeparator: true, key: 'rule-actions-sep-1', margin: 'xs', size: 'full' });
+
+    items.push({
+      'data-test-subj': `runRule-${rule.id}`,
+      name: runLabel,
+      icon: 'play',
+      onClick: () => {
+        onRunRule(rule);
+        closeMenu();
+      },
+    });
+
+    items.push({
+      'data-test-subj': `toggleEnabledRule-${rule.id}`,
+      name: rule.enabled ? disableLabel : enableLabel,
+      icon: rule.enabled ? 'crossInCircle' : 'checkCircle',
+      onClick: () => {
         onToggleEnabled(rule);
-      }}
-      data-test-subj={`toggleEnabledRule-${rule.id}`}
-    >
-      {rule.enabled
-        ? i18n.translate('xpack.alertingV2.rulesList.action.disable', {
-            defaultMessage: 'Disable',
-          })
-        : i18n.translate('xpack.alertingV2.rulesList.action.enable', {
-            defaultMessage: 'Enable',
-          })}
-    </EuiContextMenuItem>,
-    <EuiContextMenuItem
-      key="delete"
-      icon={<EuiIcon type="trash" size="m" color="danger" aria-hidden={true} />}
-      onClick={() => {
-        setIsOpen(false);
+        closeMenu();
+      },
+    });
+
+    items.push({
+      'data-test-subj': `updateApiKeyRule-${rule.id}`,
+      name: updateApiKeyLabel,
+      icon: 'key',
+      onClick: () => {
+        onUpdateApiKey(rule);
+        closeMenu();
+      },
+    });
+
+    items.push({ isSeparator: true, key: 'rule-actions-sep-2', margin: 'xs', size: 'full' });
+
+    items.push({
+      'data-test-subj': `deleteRule-${rule.id}`,
+      name: deleteLabel,
+      icon: 'trash',
+      onClick: () => {
         onDelete(rule);
-      }}
-      data-test-subj={`deleteRule-${rule.id}`}
-    >
-      {i18n.translate('xpack.alertingV2.rulesList.action.delete', {
-        defaultMessage: 'Delete',
-      })}
-    </EuiContextMenuItem>,
-  ];
+        closeMenu();
+      },
+    });
+
+    return [{ id: 0, items }];
+  }, [
+    canOpenEditInDiscover,
+    canEditWithAi,
+    closeMenu,
+    isDiscoverSource,
+    onClone,
+    onDelete,
+    onEditInBuilder,
+    onEditInDiscover,
+    onEditWithAiAgent,
+    onRunRule,
+    onToggleEnabled,
+    onUpdateApiKey,
+    rule,
+  ]);
 
   return (
     <EuiPopover
+      id={popoverId}
       button={
         <EuiButtonIcon
           iconType="boxesHorizontal"
-          aria-label={i18n.translate('xpack.alertingV2.rulesList.action.moreActions', {
-            defaultMessage: 'More actions',
-          })}
+          aria-label={moreActionsLabel}
           color="text"
           onClick={() => setIsOpen((open) => !open)}
           data-test-subj={`ruleActionsButton-${rule.id}`}
         />
       }
       isOpen={isOpen}
-      closePopover={() => setIsOpen(false)}
-      panelPaddingSize="none"
+      closePopover={closeMenu}
+      panelPaddingSize="s"
       anchorPosition="downRight"
-      aria-label={i18n.translate('xpack.alertingV2.rulesList.action.actionsMenu', {
-        defaultMessage: 'Rule actions',
-      })}
+      aria-label={menuAriaLabel}
     >
-      <EuiContextMenuPanel size="s" items={menuItems} />
+      <EuiContextMenu
+        key={menuKey}
+        data-test-subj={`ruleActionsContextMenu-${rule.id}`}
+        size="m"
+        initialPanelId={0}
+        panels={panels}
+      />
     </EuiPopover>
   );
 };

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/rules_list_page/rules_list_empty_state.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/rules_list_page/rules_list_empty_state.tsx
@@ -1,0 +1,167 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import {
+  EuiCard,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiHorizontalRule,
+  EuiIcon,
+  EuiLink,
+  EuiPanel,
+  EuiSpacer,
+  EuiText,
+  EuiTitle,
+} from '@elastic/eui';
+import { css } from '@emotion/react';
+import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n-react';
+import { useService, CoreStart } from '@kbn/core-di-browser';
+import { paths } from '../../constants';
+import { RuleBuilderChoiceCards } from '../../components/rule_builders/rule_builder_choice_cards';
+import { useRuleListCreationActions } from './use_rule_list_creation_actions';
+
+export const RulesListEmptyState = () => {
+  const { basePath } = useService(CoreStart('http'));
+  const docLinks = useService(CoreStart('docLinks'));
+  const guideHref = docLinks.links.alerting.guide;
+  const {
+    canCreateInDiscover,
+    canCreateWithAi,
+    openCreateInDiscover,
+    openCreateWithAiAgent,
+  } = useRuleListCreationActions();
+
+  const discoverCard = (
+    <EuiCard
+      data-test-subj="rulesListEmptyCreateInDiscover"
+      layout="horizontal"
+      hasBorder
+      paddingSize="l"
+      icon={<EuiIcon type="discoverApp" size="m" color="text" />}
+      title={i18n.translate('xpack.alertingV2.rulesList.empty.createInDiscoverTitle', {
+        defaultMessage: 'Create in discover',
+      })}
+      titleElement="h3"
+      titleSize="xs"
+      description={i18n.translate('xpack.alertingV2.rulesList.empty.createInDiscoverDescription', {
+        defaultMessage: 'Create as an ES|QL query with live preview. YAML editor available.',
+      })}
+      onClick={canCreateInDiscover ? () => void openCreateInDiscover() : undefined}
+      isDisabled={!canCreateInDiscover}
+    />
+  );
+
+  const aiCard = (
+    <EuiCard
+      data-test-subj="rulesListEmptyCreateWithAi"
+      layout="horizontal"
+      hasBorder
+      paddingSize="l"
+      icon={<EuiIcon type="productAgent" size="m" color="text" aria-hidden={true} />}
+      title={i18n.translate('xpack.alertingV2.rulesList.empty.createWithAiTitle', {
+        defaultMessage: 'Create with AI Agent',
+      })}
+      titleElement="h3"
+      titleSize="xs"
+      description={i18n.translate('xpack.alertingV2.rulesList.empty.createWithAiDescription', {
+        defaultMessage: 'Set up an Alerting rule with the help of the AI Agent.',
+      })}
+      onClick={canCreateWithAi ? openCreateWithAiAgent : undefined}
+      isDisabled={!canCreateWithAi}
+    />
+  );
+
+  return (
+    <EuiPanel
+      data-test-subj="rulesListEmptyState"
+      grow={false}
+      hasBorder
+      paddingSize="xl"
+      css={css`
+        max-width: 900px;
+        width: 100%;
+        flex-shrink: 0;
+        margin: 0;
+      `}
+    >
+      <EuiFlexGroup direction="column" alignItems="center" gutterSize="s">
+        <EuiTitle size="m" textAlign="center">
+          <h2>
+            {i18n.translate('xpack.alertingV2.rulesList.empty.welcomeTitle', {
+              defaultMessage: 'Welcome to the new Alerting experience',
+            })}
+          </h2>
+        </EuiTitle>
+        <EuiText textAlign="center" size="s" color="subdued">
+          {i18n.translate('xpack.alertingV2.rulesList.empty.welcomeDescription', {
+            defaultMessage:
+              'Powerful ES|QL-driven rules and support for external alerts, it delivers consistent, high-quality alert data into a unified experience.',
+          })}
+        </EuiText>
+      </EuiFlexGroup>
+      <EuiSpacer size="l" />
+      <EuiFlexGroup alignItems="stretch" gutterSize="m">
+        <EuiFlexItem>{discoverCard}</EuiFlexItem>
+        <EuiFlexItem>{aiCard}</EuiFlexItem>
+      </EuiFlexGroup>
+      <EuiSpacer size="l" />
+      <EuiFlexGroup alignItems="center" gutterSize="m" responsive={false}>
+        <EuiFlexItem>
+          <EuiHorizontalRule margin="none" />
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiText size="s" color="subdued" textAlign="center">
+            {i18n.translate('xpack.alertingV2.rulesList.empty.orSeparator', {
+              defaultMessage: 'or',
+            })}
+          </EuiText>
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiHorizontalRule margin="none" />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+      <EuiSpacer size="l" />
+      <RuleBuilderChoiceCards
+        thresholdHref={basePath.prepend(paths.ruleCreateForm)}
+      />
+      <EuiSpacer size="l" />
+      <EuiPanel
+        color="subdued"
+        grow={false}
+        borderRadius="m"
+        paddingSize="m"
+        hasShadow={false}
+        css={css`
+          text-align: center;
+        `}
+      >
+        <EuiText size="s">
+          <FormattedMessage
+            id="xpack.alertingV2.rulesList.empty.docFooter"
+            defaultMessage="Want to learn more? {docLink}"
+            values={{
+              docLink: (
+                <EuiLink
+                  data-test-subj="rulesListEmptyReadDocumentation"
+                  href={guideHref}
+                  target="_blank"
+                  external
+                >
+                  {i18n.translate('xpack.alertingV2.rulesList.empty.readDocumentation', {
+                    defaultMessage: 'Read documentation',
+                  })}
+                </EuiLink>
+              ),
+            }}
+          />
+        </EuiText>
+      </EuiPanel>
+    </EuiPanel>
+  );
+};

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/rules_list_page/rules_list_page.test.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/rules_list_page/rules_list_page.test.tsx
@@ -23,16 +23,37 @@ jest.mock('../../application/breadcrumb_context', () => ({
   useSetBreadcrumbs: () => jest.fn(),
 }));
 
+jest.mock('../../kibana_services', () => ({
+  useAlertingV2KibanaServices: () => ({
+    share: { url: { locators: { get: () => undefined } } },
+  }),
+}));
+
+const mockNavigateToApp = jest.fn().mockResolvedValue(undefined);
+
+const mockApplicationCapabilities = {
+  discover_v2: { show: true },
+  alertingVTwo: true,
+};
+
 jest.mock('@kbn/core-di-browser', () => ({
   useService: (token: unknown) => {
     if (token === 'application') {
-      return { navigateToUrl: mockNavigateToUrl, getUrlForApp: mockGetUrlForApp };
+      return {
+        navigateToUrl: mockNavigateToUrl,
+        getUrlForApp: mockGetUrlForApp,
+        navigateToApp: mockNavigateToApp,
+        capabilities: mockApplicationCapabilities,
+      };
     }
     if (token === 'chrome') {
       return { docTitle: { change: mockDocTitleChange } };
     }
     if (token === 'http') {
       return { basePath: { prepend: (p: string) => p } };
+    }
+    if (token === 'docLinks') {
+      return { links: { alerting: { guide: 'https://www.elastic.co/guide' } } };
     }
     return {};
   },
@@ -221,7 +242,7 @@ describe('RulesListPage', () => {
     expect(screen.getByText('Network error')).toBeInTheDocument();
   });
 
-  it('shows "Showing 0-0 of 0 Rules" when there are no rules', () => {
+  it('renders the designed empty state when there are no rules and no search or filters', () => {
     mockUseFetchRules.mockReturnValue({
       data: { items: [], total: 0, page: 1, perPage: 20 },
       isLoading: false,
@@ -231,8 +252,10 @@ describe('RulesListPage', () => {
 
     renderPage();
 
-    const showingLabel = screen.getByTestId('rulesListShowingLabel');
-    expect(showingLabel).toHaveTextContent('Showing 0-0 of 0 Rules');
+    expect(screen.getByTestId('rulesListEmptyState')).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'Welcome to the new Alerting experience' })
+    ).toBeInTheDocument();
   });
 
   it('shows correct "Showing" range when rules exist', () => {
@@ -771,7 +794,7 @@ describe('RulesListPage', () => {
     fireEvent.click(screen.getByTestId('cloneRule-rule-1'));
 
     expect(mockNavigateToUrl).toHaveBeenCalledWith(
-      '/app/management/alertingV2/rules/create?cloneFrom=rule-1'
+      '/app/management/alertingV2/rules/create/form?cloneFrom=rule-1'
     );
   });
 

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/rules_list_page/rules_list_page.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/rules_list_page/rules_list_page.tsx
@@ -7,7 +7,7 @@
 
 import React, { useEffect, useMemo, useState } from 'react';
 import {
-  EuiButton,
+  EuiButtonEmpty,
   EuiCallOut,
   EuiFieldSearch,
   EuiFilterGroup,
@@ -15,10 +15,12 @@ import {
   EuiFlexItem,
   EuiPageHeader,
   EuiSpacer,
+  useEuiTheme,
   type Criteria,
 } from '@elastic/eui';
-import { CoreStart, useService } from '@kbn/core-di-browser';
+import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
+import { useService, CoreStart } from '@kbn/core-di-browser';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { useDebouncedValue } from '@kbn/react-hooks';
 import type { FindRulesSortField } from '@kbn/alerting-v2-schemas';
@@ -26,7 +28,8 @@ import type { RuleApiResponse } from '../../services/rules_api';
 import { useFetchRules } from '../../hooks/use_fetch_rules';
 import { useFetchRuleTags } from '../../hooks/use_fetch_rule_tags';
 import { useBreadcrumbs } from '../../hooks/use_breadcrumbs';
-import { paths } from '../../constants';
+import { CreateRuleSplitButton } from './create_rule_split_button';
+import { RulesListEmptyState } from './rules_list_empty_state';
 import { RulesListTableContainer } from './rules_list_table_container';
 import type { RulesListTableSortField } from './rules_list_table';
 import { ModeFilterPopover } from '../../components/rule/popovers/mode_filter_popover';
@@ -47,8 +50,15 @@ const TABLE_FIELD_TO_API_SORT_FIELD = Object.fromEntries(
   Object.entries(SORT_FIELD_TO_TABLE_FIELD).map(([api, table]) => [table, api])
 ) as Partial<Record<string, FindRulesSortField>>;
 
+const emptyStateRootLayout = css`
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+`;
+
 export const RulesListPage = () => {
-  const { basePath } = useService(CoreStart('http'));
+  const { euiTheme } = useEuiTheme();
+  const docLinks = useService(CoreStart('docLinks'));
 
   useBreadcrumbs('rules_list');
 
@@ -110,27 +120,50 @@ export const RulesListPage = () => {
 
   const hasActiveFilters = Boolean(filter);
 
+  const isRichEmpty =
+    !isLoading &&
+    !isError &&
+    (data?.total ?? 0) === 0 &&
+    !debouncedSearch &&
+    !hasActiveFilters;
+
+  const emptyStateShellCss = useMemo(
+    () => css`
+      /* Centers the empty-state *section* (the bordered panel) in the viewport, without stretching it */
+      display: flex;
+      flex: 1 1 auto;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      min-height: calc(100dvh - 10rem);
+      width: 100%;
+      box-sizing: border-box;
+      padding: 0 ${euiTheme.size.m};
+    `,
+    [euiTheme.size.m]
+  );
+
   return (
-    <div>
+    <div css={isRichEmpty ? emptyStateRootLayout : undefined}>
       <EuiPageHeader
         pageTitle={
-          <FormattedMessage
-            id="xpack.alertingV2.rulesList.pageTitle"
-            defaultMessage="Alerting V2 Rules"
-          />
+          <FormattedMessage id="xpack.alertingV2.rulesList.pageTitle" defaultMessage="Rules" />
         }
         rightSideItems={[
-          <EuiButton
-            key="create-rule"
-            fill
-            href={basePath.prepend(paths.ruleCreate)}
-            data-test-subj="createRuleButton"
+          <CreateRuleSplitButton key="create-rule" />,
+          <EuiButtonEmpty
+            key="docs"
+            iconType="documentation"
+            size="m"
+            href={docLinks.links.alerting.guide}
+            target="_blank"
+            data-test-subj="rulesListDocumentation"
           >
             <FormattedMessage
-              id="xpack.alertingV2.rulesList.createRuleButton"
-              defaultMessage="Create rule"
+              id="xpack.alertingV2.rulesList.documentation"
+              defaultMessage="Documentation"
             />
-          </EuiButton>,
+          </EuiButtonEmpty>,
         ]}
       />
       <EuiSpacer size="m" />
@@ -152,7 +185,12 @@ export const RulesListPage = () => {
           <EuiSpacer />
         </>
       ) : null}
-      {!isError ? (
+      {!isError && isRichEmpty ? (
+        <div css={emptyStateShellCss} data-test-subj="rulesListEmptyStateShell">
+          <RulesListEmptyState />
+        </div>
+      ) : null}
+      {!isError && !isRichEmpty ? (
         <>
           <EuiFlexGroup gutterSize="s">
             <EuiFlexItem>

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/rules_list_page/rules_list_table.test.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/rules_list_page/rules_list_table.test.tsx
@@ -382,15 +382,9 @@ describe('RulesListTable', () => {
   });
 
   describe('row actions menu', () => {
-    it('calls onEdit when edit action is clicked', async () => {
+    it('calls onEdit when quick edit is clicked', async () => {
       const onEdit = jest.fn();
       renderTable({ onEdit });
-
-      fireEvent.click(screen.getByTestId('ruleActionsButton-rule-1'));
-
-      await waitFor(() => {
-        expect(screen.getByTestId('editRule-rule-1')).toBeInTheDocument();
-      });
 
       fireEvent.click(screen.getByTestId('editRule-rule-1'));
 

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/rules_list_page/rules_list_table.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/rules_list_page/rules_list_table.tsx
@@ -34,6 +34,7 @@ import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
 import { getIndexPatternFromESQLQuery } from '@kbn/esql-utils';
 import type { RuleApiResponse } from '../../services/rules_api';
+import { QuickEditRuleButton } from '../../components/quick_edit_rule_button';
 import { RuleActionsMenu } from './rule_actions_menu';
 
 const labelsContainerStyle = css`
@@ -97,6 +98,13 @@ export interface RulesListTableProps {
   onClone: (rule: RuleApiResponse) => void;
   onDelete: (rule: RuleApiResponse) => void;
   onToggleEnabled: (rule: RuleApiResponse) => void;
+  canOpenEditInDiscover: boolean;
+  canEditWithAi: boolean;
+  onEditInDiscover: (rule: RuleApiResponse) => void | Promise<void>;
+  onEditInBuilder: (rule: RuleApiResponse) => void;
+  onEditWithAiAgent: (rule: RuleApiResponse) => void;
+  onRunRule: (rule: RuleApiResponse) => void;
+  onUpdateApiKey: (rule: RuleApiResponse) => void;
 
   /** Pagination callback */
   onTableChange: (criteria: Criteria<RuleApiResponse>) => void;
@@ -129,6 +137,13 @@ export const RulesListTable: React.FC<RulesListTableProps> = ({
   onClone,
   onDelete,
   onToggleEnabled,
+  canOpenEditInDiscover,
+  canEditWithAi,
+  onEditInDiscover,
+  onEditInBuilder,
+  onEditWithAiAgent,
+  onRunRule,
+  onUpdateApiKey,
   onTableChange,
 }) => {
   const { euiTheme } = useEuiTheme();
@@ -352,16 +367,34 @@ export const RulesListTable: React.FC<RulesListTableProps> = ({
             defaultMessage="Actions"
           />
         ),
-        width: '6%',
+        width: '8%',
         align: 'right',
         render: (rule: RuleApiResponse) => (
-          <RuleActionsMenu
-            rule={rule}
-            onEdit={onEdit}
-            onClone={onClone}
-            onDelete={onDelete}
-            onToggleEnabled={onToggleEnabled}
-          />
+          <EuiFlexGroup
+            gutterSize="xs"
+            alignItems="center"
+            justifyContent="flexEnd"
+            responsive={false}
+          >
+            <EuiFlexItem grow={false}>
+              <QuickEditRuleButton rule={rule} onEdit={onEdit} />
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <RuleActionsMenu
+                rule={rule}
+                canOpenEditInDiscover={canOpenEditInDiscover}
+                canEditWithAi={canEditWithAi}
+                onEditInDiscover={onEditInDiscover}
+                onEditInBuilder={onEditInBuilder}
+                onEditWithAiAgent={onEditWithAiAgent}
+                onRunRule={onRunRule}
+                onUpdateApiKey={onUpdateApiKey}
+                onClone={onClone}
+                onDelete={onDelete}
+                onToggleEnabled={onToggleEnabled}
+              />
+            </EuiFlexItem>
+          </EuiFlexGroup>
         ),
       },
     ],
@@ -376,6 +409,13 @@ export const RulesListTable: React.FC<RulesListTableProps> = ({
       onClone,
       onDelete,
       onToggleEnabled,
+      canOpenEditInDiscover,
+      canEditWithAi,
+      onEditInDiscover,
+      onEditInBuilder,
+      onEditWithAiAgent,
+      onRunRule,
+      onUpdateApiKey,
     ]
   );
 

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/rules_list_page/rules_list_table_container.test.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/rules_list_page/rules_list_table_container.test.tsx
@@ -50,6 +50,32 @@ jest.mock('../../hooks/use_toggle_rule_enabled', () => ({
   useToggleRuleEnabled: () => mockUseToggleRuleEnabled(),
 }));
 
+jest.mock('./use_rule_list_row_menu_actions', () => ({
+  useRuleListRowMenuActions: () => ({
+    canOpenEditInDiscover: true,
+    canEditWithAi: true,
+    onEditInDiscover: jest.fn(),
+    onEditInBuilder: jest.fn(),
+    onEditWithAiAgent: jest.fn(),
+    onRunRule: jest.fn(),
+    onUpdateApiKey: jest.fn(),
+  }),
+}));
+
+jest.mock('../../components/rule/flyouts', () => {
+  const actual = jest.requireActual('../../components/rule/flyouts');
+  return {
+    ...actual,
+    QuickEditRuleFlyout: ({ ruleId, onClose }: { ruleId: string; onClose: () => void }) => (
+      <div data-test-subj="quickEditRuleFlyout" data-rule-id={ruleId}>
+        <button type="button" onClick={onClose}>
+          close quick
+        </button>
+      </div>
+    ),
+  };
+});
+
 const mockRules = [
   {
     id: 'rule-1',
@@ -110,20 +136,14 @@ describe('RulesListTableContainer', () => {
   });
 
   describe('navigation callbacks', () => {
-    it('navigates to edit page when edit action is clicked', async () => {
+    it('opens the quick edit flyout when quick edit is clicked', async () => {
       renderContainer();
-
-      fireEvent.click(screen.getByTestId('ruleActionsButton-rule-1'));
-
-      await waitFor(() => {
-        expect(screen.getByTestId('editRule-rule-1')).toBeInTheDocument();
-      });
 
       fireEvent.click(screen.getByTestId('editRule-rule-1'));
 
-      expect(mockNavigateToUrl).toHaveBeenCalledWith(
-        '/app/management/alertingV2/rules/edit/rule-1'
-      );
+      const flyout = screen.getByTestId('quickEditRuleFlyout');
+      expect(flyout).toBeInTheDocument();
+      expect(flyout).toHaveAttribute('data-rule-id', 'rule-1');
     });
 
     it('navigates to clone page when clone action is clicked', async () => {
@@ -138,7 +158,7 @@ describe('RulesListTableContainer', () => {
       fireEvent.click(screen.getByTestId('cloneRule-rule-1'));
 
       expect(mockNavigateToUrl).toHaveBeenCalledWith(
-        '/app/management/alertingV2/rules/create?cloneFrom=rule-1'
+        '/app/management/alertingV2/rules/create/form?cloneFrom=rule-1'
       );
     });
   });

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/rules_list_page/rules_list_table_container.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/rules_list_page/rules_list_table_container.tsx
@@ -15,9 +15,10 @@ import { useBulkDeleteRules } from '../../hooks/use_bulk_delete_rules';
 import { useBulkEnableRules, useBulkDisableRules } from '../../hooks/use_bulk_enable_disable_rules';
 import { useToggleRuleEnabled } from '../../hooks/use_toggle_rule_enabled';
 import { DeleteConfirmationModal } from '../../components/rule/modals/delete_confirmation_modal';
-import { RuleSummaryFlyout } from '../../components/rule/flyouts';
+import { QuickEditRuleFlyout, RuleSummaryFlyout } from '../../components/rule/flyouts';
 import { paths } from '../../constants';
 import { RulesListTable, type RulesListTableSortField } from './rules_list_table';
+import { useRuleListRowMenuActions } from './use_rule_list_row_menu_actions';
 
 export interface RulesListTableContainerProps {
   items: RuleApiResponse[];
@@ -52,6 +53,7 @@ export const RulesListTableContainer: React.FC<RulesListTableContainerProps> = (
 
   const [ruleToDelete, setRuleToDelete] = useState<RuleApiResponse | null>(null);
   const [expandedRuleId, setExpandedRuleId] = useState<string | null>(null);
+  const [quickEditRuleId, setQuickEditRuleId] = useState<string | null>(null);
   const [showBulkDeleteConfirm, setShowBulkDeleteConfirm] = useState(false);
 
   const expandedRule = expandedRuleId ? items.find((r) => r.id === expandedRuleId) ?? null : null;
@@ -61,6 +63,16 @@ export const RulesListTableContainer: React.FC<RulesListTableContainerProps> = (
   const bulkEnableMutation = useBulkEnableRules();
   const bulkDisableMutation = useBulkDisableRules();
   const toggleEnabledMutation = useToggleRuleEnabled();
+
+  const {
+    canOpenEditInDiscover,
+    canEditWithAi,
+    onEditInDiscover,
+    onEditInBuilder,
+    onEditWithAiAgent,
+    onRunRule,
+    onUpdateApiKey,
+  } = useRuleListRowMenuActions();
 
   const {
     isAllSelected,
@@ -140,24 +152,40 @@ export const RulesListTableContainer: React.FC<RulesListTableContainerProps> = (
         onBulkDelete={handleBulkDelete}
         onNavigateToDetails={(r) => navigateToUrl(basePath.prepend(paths.ruleDetails(r.id)))}
         onExpand={(r) => setExpandedRuleId(r.id)}
-        onEdit={(r) => navigateToUrl(basePath.prepend(paths.ruleEdit(r.id)))}
+        onEdit={(r) => {
+          setExpandedRuleId(null);
+          setQuickEditRuleId(r.id);
+        }}
         onClone={(r) =>
           navigateToUrl(
-            basePath.prepend(`${paths.ruleCreate}?cloneFrom=${encodeURIComponent(r.id)}`)
+            basePath.prepend(`${paths.ruleCreateForm}?cloneFrom=${encodeURIComponent(r.id)}`)
           )
         }
         onDelete={(r) => setRuleToDelete(r)}
         onToggleEnabled={(r) => toggleEnabledMutation.mutate({ id: r.id, enabled: !r.enabled })}
+        canOpenEditInDiscover={canOpenEditInDiscover}
+        canEditWithAi={canEditWithAi}
+        onEditInDiscover={onEditInDiscover}
+        onEditInBuilder={onEditInBuilder}
+        onEditWithAiAgent={onEditWithAiAgent}
+        onRunRule={onRunRule}
+        onUpdateApiKey={onUpdateApiKey}
         onTableChange={onTableChange}
       />
+      {quickEditRuleId ? (
+        <QuickEditRuleFlyout ruleId={quickEditRuleId} onClose={() => setQuickEditRuleId(null)} />
+      ) : null}
       {expandedRule ? (
         <RuleSummaryFlyout
           rule={expandedRule}
           onClose={() => setExpandedRuleId(null)}
-          onEdit={(r) => navigateToUrl(basePath.prepend(paths.ruleEdit(r.id)))}
+          onEdit={(r) => {
+            setExpandedRuleId(null);
+            setQuickEditRuleId(r.id);
+          }}
           onClone={(r) =>
             navigateToUrl(
-              basePath.prepend(`${paths.ruleCreate}?cloneFrom=${encodeURIComponent(r.id)}`)
+              basePath.prepend(`${paths.ruleCreateForm}?cloneFrom=${encodeURIComponent(r.id)}`)
             )
           }
           onDelete={(r) => setRuleToDelete(r)}

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/rules_list_page/use_rule_list_creation_actions.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/rules_list_page/use_rule_list_creation_actions.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useCallback, useMemo } from 'react';
+import { useService, CoreStart } from '@kbn/core-di-browser';
+import { DISCOVER_APP_LOCATOR } from '@kbn/deeplinks-analytics';
+import type { DiscoverAppLocatorParams } from '@kbn/discover-plugin/common';
+import { useAlertingV2KibanaServices } from '../../kibana_services';
+
+export const DEFAULT_ESQL_FOR_CREATE_RULE = 'FROM logs-*\n| LIMIT 1';
+
+export function useRuleListCreationActions() {
+  const application = useService(CoreStart('application'));
+  const { capabilities } = application;
+  const kibana = useAlertingV2KibanaServices();
+  const share = kibana?.share;
+  const agentBuilder = kibana?.agentBuilder;
+
+  const canCreateInDiscover = useMemo(
+    () =>
+      Boolean(share) &&
+      Boolean(capabilities.discover_v2?.show) &&
+      Boolean(capabilities.alertingVTwo) &&
+      Boolean(share?.url?.locators?.get?.(DISCOVER_APP_LOCATOR)),
+    [capabilities.alertingVTwo, capabilities.discover_v2?.show, share]
+  );
+
+  const canCreateWithAi = Boolean(agentBuilder?.openChat);
+
+  const openCreateInDiscover = useCallback(async () => {
+    if (!share) {
+      return;
+    }
+    const locator = share.url.locators.get<DiscoverAppLocatorParams>(DISCOVER_APP_LOCATOR);
+    if (!locator?.getLocation) {
+      return;
+    }
+    const { app, path, state } = await locator.getLocation({
+      query: { esql: DEFAULT_ESQL_FOR_CREATE_RULE },
+      openCreateEsqlRuleV2Flyout: true,
+    });
+    await application.navigateToApp(app, { path, state });
+  }, [application, share]);
+
+  const openCreateWithAiAgent = useCallback(() => {
+    agentBuilder?.openChat();
+  }, [agentBuilder]);
+
+  return {
+    canCreateInDiscover,
+    canCreateWithAi,
+    openCreateInDiscover,
+    openCreateWithAiAgent,
+  };
+}

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/rules_list_page/use_rule_list_row_menu_actions.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/rules_list_page/use_rule_list_row_menu_actions.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useCallback } from 'react';
+import { useService, CoreStart } from '@kbn/core-di-browser';
+import { DISCOVER_APP_LOCATOR } from '@kbn/deeplinks-analytics';
+import type { DiscoverAppLocatorParams } from '@kbn/discover-plugin/common';
+import { useAlertingV2KibanaServices } from '../../kibana_services';
+import { paths } from '../../constants';
+import type { RuleApiResponse } from '../../services/rules_api';
+import { useRuleListCreationActions } from './use_rule_list_creation_actions';
+
+/**
+ * Handlers and flags for the rules list / summary overflow menu (Edit in Discover vs Builder, AI, etc.).
+ */
+export function useRuleListRowMenuActions() {
+  const kibana = useAlertingV2KibanaServices();
+  const application = useService(CoreStart('application'));
+  const http = useService(CoreStart('http'));
+  const { canCreateInDiscover, canCreateWithAi, openCreateWithAiAgent } = useRuleListCreationActions();
+
+  const onEditInDiscover = useCallback(
+    async (rule: RuleApiResponse) => {
+      if (!kibana?.share) {
+        return;
+      }
+      const locator = kibana.share.url.locators.get<DiscoverAppLocatorParams>(DISCOVER_APP_LOCATOR);
+      if (!locator) {
+        return;
+      }
+      const esql = rule.evaluation.query.base;
+      const { app, path, state } = await locator.getLocation({
+        query: { esql },
+        openCreateEsqlRuleV2Flyout: true,
+        esqlRuleV2EditRuleId: rule.id,
+      });
+      await application.navigateToApp(app, { path, state });
+    },
+    [application, kibana?.share]
+  );
+
+  const onEditInBuilder = useCallback(
+    (rule: RuleApiResponse) => {
+      application.navigateToUrl(http.basePath.prepend(paths.ruleEdit(rule.id)));
+    },
+    [application, http]
+  );
+
+  const onEditWithAiAgent = useCallback(
+    (_rule: RuleApiResponse) => {
+      openCreateWithAiAgent();
+    },
+    [openCreateWithAiAgent]
+  );
+
+  const onRunRule = useCallback((_rule: RuleApiResponse) => {
+    // Placeholder until run-rule flow is implemented
+  }, []);
+
+  const onUpdateApiKey = useCallback((_rule: RuleApiResponse) => {
+    // Placeholder until update API key flow is implemented
+  }, []);
+
+  return {
+    canOpenEditInDiscover: canCreateInDiscover,
+    canEditWithAi: canCreateWithAi,
+    onEditInDiscover,
+    onEditInBuilder,
+    onEditWithAiAgent,
+    onRunRule,
+    onUpdateApiKey,
+  };
+}

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/rules_client/utils.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/rules_client/utils.test.ts
@@ -157,5 +157,17 @@ describe('utils', () => {
 
       expect(response.metadata.description).toBe('Round-trip desc');
     });
+
+    it('round-trips metadata.source through create → transform', () => {
+      const createData: CreateRuleData = {
+        ...baseCreateData,
+        metadata: { name: 'src-rule', source: 'discover' },
+      };
+
+      const soAttrs = transformCreateRuleBodyToRuleSoAttributes(createData, serverFields);
+      const response = transformRuleSoAttributesToRuleApiResponse('rule-src-1', soAttrs);
+
+      expect(response.metadata.source).toBe('discover');
+    });
   });
 });

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/rules_client/utils.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/rules_client/utils.ts
@@ -63,6 +63,7 @@ export function transformCreateRuleBodyToRuleSoAttributes(
       description: data.metadata.description,
       owner: data.metadata.owner,
       tags: data.metadata.tags,
+      ...(data.metadata.source !== undefined ? { source: data.metadata.source } : {}),
     },
     time_field: data.time_field,
     schedule: {
@@ -148,6 +149,7 @@ export function transformRuleSoAttributesToRuleApiResponse(
       description: attrs.metadata.description,
       owner: attrs.metadata.owner,
       tags: attrs.metadata.tags,
+      ...(attrs.metadata.source !== undefined ? { source: attrs.metadata.source } : {}),
     },
     time_field: attrs.time_field,
     schedule: {

--- a/x-pack/platform/plugins/shared/alerting_v2/server/saved_objects/schemas/rule_saved_object_attributes/v1.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/saved_objects/schemas/rule_saved_object_attributes/v1.ts
@@ -24,6 +24,9 @@ export const ruleSavedObjectAttributesSchema = schema.object({
     description: schema.maybe(schema.string()),
     owner: schema.maybe(schema.string()),
     tags: schema.maybe(schema.arrayOf(schema.string(), { minSize: 1, maxSize: 100 })),
+    source: schema.maybe(
+      schema.oneOf([schema.literal('discover'), schema.literal('kibana_ui')])
+    ),
   }),
   time_field: schema.string(),
   schedule: schema.object({

--- a/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/ui/fixtures/page_objects/rule_form_page.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/ui/fixtures/page_objects/rule_form_page.ts
@@ -17,7 +17,7 @@ export class RuleFormPage {
   }
 
   async gotoCreate() {
-    await this.page.gotoApp('management/alertingV2/rules/create');
+    await this.page.gotoApp('management/alertingV2/rules/create/form');
   }
 
   async gotoRulesList() {


### PR DESCRIPTION
## Summary
Prototype work for Alerting v2 rule creation and edit experiences: rules list empty state, builders hub, Discover integration (deep links + flyout), rule detail/form actions, quick edit, overflow menus, and related rule-form/layout updates.

## Notes
- Opened as **draft** for iteration.
- Excludes local-only paths (e.g. `packages/kbn-repo-packages`, `x-pack/plugins` if untracked in this workspace).

## Testing
- [ ] Manual smoke in Stack Management → Alerting v2
- [ ] CI / automated tests to be run when ready to undraft


Made with [Cursor](https://cursor.com)