### PR TITLE
[Discover] [PoC] Discover view mode selector

### DIFF
--- a/src/platform/plugins/shared/discover/public/components/view_mode_toggle/view_mode_toggle.test.tsx
+++ b/src/platform/plugins/shared/discover/public/components/view_mode_toggle/view_mode_toggle.test.tsx
@@ -11,13 +11,13 @@ import { VIEW_MODE } from '../../../common/constants';
 import { renderWithKibanaRenderContext } from '@kbn/test-jest-helpers';
 import React from 'react';
 import { screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import { DocumentViewModeToggle } from './view_mode_toggle';
 import { getDiscoverInternalStateMock } from '../../__mocks__/discover_state.mock';
 import { FetchStatus } from '../../application/types';
 import { DiscoverToolkitTestProvider } from '../../__mocks__/test_provider';
 import { createDiscoverServicesMock } from '../../__mocks__/services';
 import { buildDataViewMock } from '@kbn/discover-utils/src/__mocks__';
+import { EuiSuperSelectTestHarness } from '@kbn/test-eui-helpers';
 
 describe('Document view mode toggle component', () => {
   const renderComponent = async ({
@@ -68,15 +68,15 @@ describe('Document view mode toggle component', () => {
   };
 
   it('should render if SHOW_FIELD_STATISTICS is true', async () => {
+    const selector = new EuiSuperSelectTestHarness('dscViewModeToggle');
+
     await renderComponent();
 
     expect(screen.getByTestId('dscViewModeToggle')).toBeVisible();
     expect(screen.getByTestId('discoverQueryTotalHits')).toBeVisible();
-
-    expect(screen.getByTestId('dscViewModeDocumentButton')).toBeVisible();
-    expect(screen.getByTestId('dscViewModePatternAnalysisButton')).toBeVisible();
-    expect(screen.getByTestId('dscViewModeFieldStatsButton')).toBeVisible();
-    expect(screen.getByTestId('dscViewModeDocumentButton')).toHaveTextContent('Documents (10)');
+    expect(selector.getSelected()).toContain('Documents');
+    expect(screen.getByText('View')).toBeVisible();
+    expect(screen.getByTestId('discoverQueryTotalHits')).toHaveTextContent('10 results');
   });
 
   it('should not render if SHOW_FIELD_STATISTICS is false', async () => {
@@ -84,10 +84,6 @@ describe('Document view mode toggle component', () => {
 
     expect(screen.getByTestId('dscViewModeToggle')).toBeVisible();
     expect(screen.getByTestId('discoverQueryTotalHits')).toBeVisible();
-
-    expect(screen.getByTestId('dscViewModeDocumentButton')).toBeVisible();
-    expect(screen.getByTestId('dscViewModePatternAnalysisButton')).toBeVisible();
-    expect(screen.queryByTestId('dscViewModeFieldStatsButton')).not.toBeInTheDocument();
   });
 
   it('should not show document and field stats view if ES|QL', async () => {
@@ -104,59 +100,56 @@ describe('Document view mode toggle component', () => {
 
   it('should set the view mode to VIEW_MODE.DOCUMENT_LEVEL when dscViewModeDocumentButton is clicked', async () => {
     const setDiscoverViewMode = jest.fn();
-    const user = userEvent.setup();
+    const selector = new EuiSuperSelectTestHarness('dscViewModeToggle');
 
     await renderComponent({ setDiscoverViewMode });
-    await user.click(screen.getByTestId('dscViewModeDocumentButton'));
+    await selector.select('dscViewModeDocumentOption');
 
     expect(setDiscoverViewMode).toHaveBeenCalledWith(VIEW_MODE.DOCUMENT_LEVEL);
   });
 
   it('should set the view mode to VIEW_MODE.PATTERN_LEVEL when dscViewModePatternAnalysisButton is clicked', async () => {
     const setDiscoverViewMode = jest.fn();
-    const user = userEvent.setup();
+    const selector = new EuiSuperSelectTestHarness('dscViewModeToggle');
 
     await renderComponent({ setDiscoverViewMode });
-    await user.click(screen.getByTestId('dscViewModePatternAnalysisButton'));
+    await selector.select('dscViewModePatternAnalysisOption');
 
     expect(setDiscoverViewMode).toHaveBeenCalledWith(VIEW_MODE.PATTERN_LEVEL);
   });
 
   it('should set the view mode to VIEW_MODE.AGGREGATED_LEVEL when dscViewModeFieldStatsButton is clicked', async () => {
     const setDiscoverViewMode = jest.fn();
-    const user = userEvent.setup();
+    const selector = new EuiSuperSelectTestHarness('dscViewModeToggle');
 
     await renderComponent({ setDiscoverViewMode });
-    await user.click(screen.getByTestId('dscViewModeFieldStatsButton'));
+    await selector.select('dscViewModeFieldStatsOption');
 
     expect(setDiscoverViewMode).toHaveBeenCalledWith(VIEW_MODE.AGGREGATED_LEVEL);
   });
 
   it('should select the Documents tab if viewMode is VIEW_MODE.DOCUMENT_LEVEL', async () => {
+    const selector = new EuiSuperSelectTestHarness('dscViewModeToggle');
+
     await renderComponent();
 
-    expect(screen.getByTestId('dscViewModeDocumentButton')).toHaveAttribute(
-      'aria-selected',
-      'true'
-    );
+    expect(selector.getSelected()).toContain('Documents');
   });
 
   it('should select the Pattern Analysis tab if viewMode is VIEW_MODE.PATTERN_LEVEL', async () => {
+    const selector = new EuiSuperSelectTestHarness('dscViewModeToggle');
+
     await renderComponent({ viewMode: VIEW_MODE.PATTERN_LEVEL });
 
-    expect(screen.getByTestId('dscViewModePatternAnalysisButton')).toHaveAttribute(
-      'aria-selected',
-      'true'
-    );
+    expect(selector.getSelected()).toContain('Patterns');
   });
 
   it('should select the Field statistics tab if viewMode is VIEW_MODE.AGGREGATED_LEVEL', async () => {
+    const selector = new EuiSuperSelectTestHarness('dscViewModeToggle');
+
     await renderComponent({ viewMode: VIEW_MODE.AGGREGATED_LEVEL });
 
-    expect(screen.getByTestId('dscViewModeFieldStatsButton')).toHaveAttribute(
-      'aria-selected',
-      'true'
-    );
+    expect(selector.getSelected()).toContain('Field statistics');
   });
 
   it('should switch to document and hide pattern tab when there are no text fields', async () => {
@@ -170,8 +163,10 @@ describe('Document view mode toggle component', () => {
 
     expect(setDiscoverViewMode).toHaveBeenCalledWith(VIEW_MODE.DOCUMENT_LEVEL, true);
     await waitFor(() => {
-      expect(screen.queryByTestId('dscViewModePatternAnalysisButton')).not.toBeInTheDocument();
+      expect(screen.getByTestId('dscViewModeToggle')).toBeVisible();
     });
-    expect(screen.getAllByRole('tab')).toHaveLength(2);
+    const selector = new EuiSuperSelectTestHarness('dscViewModeToggle');
+    await selector.select('dscViewModeDocumentOption');
+    expect(screen.queryByTestId('dscViewModePatternAnalysisOption')).not.toBeInTheDocument();
   });
 });

--- a/src/platform/plugins/shared/discover/public/components/view_mode_toggle/view_mode_toggle.tsx
+++ b/src/platform/plugins/shared/discover/public/components/view_mode_toggle/view_mode_toggle.tsx
@@ -9,8 +9,15 @@
 
 import type { ComponentProps } from 'react';
 import React, { useMemo, useEffect, useState, type ReactElement, useCallback } from 'react';
-import { EuiFlexGroup, EuiFlexItem, EuiTab, EuiTabs, useEuiTheme } from '@elastic/eui';
-import { FormattedMessage } from '@kbn/i18n-react';
+import {
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiIcon,
+  EuiSuperSelect,
+  useEuiTheme,
+  type EuiSuperSelectOption,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 import { css } from '@emotion/react';
 import { SHOW_FIELD_STATISTICS } from '@kbn/discover-utils';
 import type { DataView } from '@kbn/data-views-plugin/common';
@@ -100,10 +107,77 @@ export const DocumentViewModeToggle = ({
   `;
 
   const tabsCss = css`
-    .euiTab__content {
-      line-height: ${euiTheme.size.xl};
-    }
+    min-width: ${euiTheme.base * 10}px;
   `;
+
+  const viewModeOptions = useMemo<Array<EuiSuperSelectOption<VIEW_MODE>>>(() => {
+    const options: Array<EuiSuperSelectOption<VIEW_MODE>> = [
+      {
+        value: VIEW_MODE.DOCUMENT_LEVEL,
+        inputDisplay: (
+          <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
+            <EuiFlexItem grow={false}>
+              <EuiIcon type="table" aria-hidden="true" />
+            </EuiFlexItem>
+            <EuiFlexItem>
+              {isEsqlMode
+                ? i18n.translate('discover.viewModes.esql.label', {
+                    defaultMessage: 'Results',
+                  })
+                : i18n.translate('discover.viewModes.document.label', {
+                    defaultMessage: 'Documents',
+                  })}
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        ),
+        'data-test-subj': 'dscViewModeDocumentOption',
+      },
+    ];
+
+    if (showPatternAnalysisTab) {
+      options.push({
+        value: VIEW_MODE.PATTERN_LEVEL,
+        inputDisplay: (
+          <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
+            <EuiFlexItem grow={false}>
+              <EuiIcon type="pattern" aria-hidden="true" />
+            </EuiFlexItem>
+            <EuiFlexItem>
+              {i18n.translate('discover.viewModes.patternAnalysis.dropdownLabel', {
+                defaultMessage: 'Patterns{patternCount}',
+                values: {
+                  patternCount: patternCount !== undefined ? ` (${patternCount})` : '',
+                },
+              })}
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        ),
+        'data-test-subj': 'dscViewModePatternAnalysisOption',
+      });
+    }
+
+    if (showFieldStatisticsTab) {
+      options.push({
+        value: VIEW_MODE.AGGREGATED_LEVEL,
+        inputDisplay: (
+          <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
+            <EuiFlexItem grow={false}>
+              <EuiIcon type="stats" aria-hidden="true" />
+            </EuiFlexItem>
+            <EuiFlexItem>
+              {i18n.translate('discover.viewModes.fieldStatistics.label', {
+                defaultMessage: 'Field statistics',
+              })}
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        ),
+        disabled: isEsqlMode,
+        'data-test-subj': 'dscViewModeFieldStatsOption',
+      });
+    }
+
+    return options;
+  }, [isEsqlMode, patternCount, showFieldStatisticsTab, showPatternAnalysisTab]);
 
   useEffect(() => {
     if (viewMode === VIEW_MODE.AGGREGATED_LEVEL && isEsqlMode) {
@@ -140,56 +214,33 @@ export const DocumentViewModeToggle = ({
             hitsTotalToDisplay={hitsTotalToDisplay}
           />
         ) : (
-          <EuiTabs size="m" css={tabsCss} data-test-subj="dscViewModeToggle" bottomBorder={false}>
-            <EuiTab
-              isSelected={viewMode === VIEW_MODE.DOCUMENT_LEVEL}
-              onClick={() => setDiscoverViewMode(VIEW_MODE.DOCUMENT_LEVEL)}
-              data-test-subj="dscViewModeDocumentButton"
-            >
-              {isEsqlMode ? (
-                <FormattedMessage id="discover.viewModes.esql.label" defaultMessage="Results" />
-              ) : (
-                <FormattedMessage
-                  id="discover.viewModes.document.label"
-                  defaultMessage="Documents"
-                />
-              )}
+          <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
+            <EuiFlexItem grow={false}>
+              <EuiSuperSelect<VIEW_MODE>
+                options={viewModeOptions}
+                valueOfSelected={viewMode}
+                onChange={setDiscoverViewMode}
+                prepend={i18n.translate('discover.viewModes.visibleLabel', {
+                  defaultMessage: 'View',
+                })}
+                compressed
+                hasDividers
+                data-test-subj="dscViewModeToggle"
+                aria-label={i18n.translate('discover.viewModes.ariaLabel', {
+                  defaultMessage: 'Select a Discover view',
+                })}
+                css={tabsCss}
+              />
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
               <HitsCounter
-                mode={HitsCounterMode.appended}
+                mode={HitsCounterMode.standalone}
                 hitCounterLabel={hitCounterLabel}
                 hitCounterPluralLabel={hitCounterPluralLabel}
                 hitsTotalToDisplay={hitsTotalToDisplay}
               />
-            </EuiTab>
-
-            {showPatternAnalysisTab ? (
-              <EuiTab
-                isSelected={viewMode === VIEW_MODE.PATTERN_LEVEL}
-                onClick={() => setDiscoverViewMode(VIEW_MODE.PATTERN_LEVEL)}
-                data-test-subj="dscViewModePatternAnalysisButton"
-              >
-                <FormattedMessage
-                  id="discover.viewModes.patternAnalysis.label"
-                  defaultMessage="Patterns {patternCount}"
-                  values={{ patternCount: patternCount !== undefined ? ` (${patternCount})` : '' }}
-                />
-              </EuiTab>
-            ) : null}
-
-            {showFieldStatisticsTab ? (
-              <EuiTab
-                disabled={isEsqlMode}
-                isSelected={viewMode === VIEW_MODE.AGGREGATED_LEVEL}
-                onClick={() => setDiscoverViewMode(VIEW_MODE.AGGREGATED_LEVEL)}
-                data-test-subj="dscViewModeFieldStatsButton"
-              >
-                <FormattedMessage
-                  id="discover.viewModes.fieldStatistics.label"
-                  defaultMessage="Field statistics"
-                />
-              </EuiTab>
-            ) : null}
-          </EuiTabs>
+            </EuiFlexItem>
+          </EuiFlexGroup>
         )}
       </EuiFlexItem>
     </EuiFlexGroup>


### PR DESCRIPTION
## Summary

WIP.

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.