### PR TITLE
[CPS] make explicit projectRouting override picker mode defaults

### DIFF
--- a/src/platform/packages/shared/kbn-cps-utils/types.ts
+++ b/src/platform/packages/shared/kbn-cps-utils/types.ts
@@ -55,6 +55,10 @@ export interface ICPSManager {
   getTotalProjectCount(): number;
   getProjectRouting$(): Observable<ProjectRouting | undefined>;
   setProjectRouting(projectRouting: ProjectRouting | undefined): void;
+  /**
+   * Returns an explicit override value when provided, regardless of picker access mode.
+   * Otherwise resolves routing based on current picker access and CPS state.
+   */
   getProjectRouting(overrideValue?: ProjectRouting): ProjectRouting | undefined;
   getDefaultProjectRouting(): ProjectRouting;
   updateDefaultProjectRouting(projectRouting?: ProjectRouting): void;

--- a/src/platform/plugins/shared/cps/public/services/cps_manager.test.ts
+++ b/src/platform/plugins/shared/cps/public/services/cps_manager.test.ts
@@ -333,11 +333,19 @@ describe('CPSManager', () => {
       expect(cpsManager.getProjectRouting()).toBe(DEFAULT_NPRE_VALUE);
     });
 
-    it('returns undefined when access is DISABLED, regardless of override', async () => {
+    it('returns override value when access is DISABLED', async () => {
       await changeAccess(ProjectRoutingAccess.DISABLED);
 
       expect(cpsManager.getProjectRouting()).toBeUndefined();
-      expect(cpsManager.getProjectRouting('_alias:_origin')).toBeUndefined();
+      expect(cpsManager.getProjectRouting('_alias:_origin')).toBe('_alias:_origin');
+    });
+
+    it('returns override value when access is READONLY', async () => {
+      await cpsManager.whenReady();
+      await changeAccess(ProjectRoutingAccess.READONLY);
+
+      expect(cpsManager.getProjectRouting()).toBe(DEFAULT_NPRE_VALUE);
+      expect(cpsManager.getProjectRouting('_alias:_origin')).toBe('_alias:_origin');
     });
 
     it('resets projectRouting$ to default when access changes to DISABLED', async () => {

--- a/src/platform/plugins/shared/cps/public/services/cps_manager.ts
+++ b/src/platform/plugins/shared/cps/public/services/cps_manager.ts
@@ -191,12 +191,16 @@ export class CPSManager implements ICPSManager {
    * Get the current project routing value
    */
   public getProjectRouting(overrideValue?: ProjectRouting) {
+    if (overrideValue !== undefined) {
+      return overrideValue;
+    }
+
     if (this.projectPickerAccess$.value === ProjectRoutingAccess.DISABLED) {
       return undefined;
     } else if (this.projectPickerAccess$.value === ProjectRoutingAccess.READONLY) {
       return this.defaultProjectRouting;
     }
-    return overrideValue ?? this.projectRouting$.value;
+    return this.projectRouting$.value;
   }
 
   /**


### PR DESCRIPTION
## Summary

In this previous [PR](https://github.com/elastic/kibana/pull/263572) I added a `projectRouting` property to the ResponseOps alerts table, to allow consumers like `security_solution` to enforce `projectRouting:origin` if they desire. The reason is we never want to show remote alerts in the alerts table in Security.

I did local testing with the picker in `EDITABLE` mode, which worked great, as can be seen in this video:

https://github.com/user-attachments/assets/4673643f-5e9a-4f67-9c3a-d8a0044c8c5b

But @michaelolo24 just pointed me this morning that with the picker in `READONLY` mode, remote alerts were still showing, which we do not want.

### Code changes

In CPS `READONLY` and `DISABLED` modes, the downstream routing resolution could override that explicit value with mode/default routing, which allowed remote alerts to reappear.

This change makes precedence explicit: when a caller provides `projectRouting`, that value always wins.
CPS mode-based behavior is used only when no explicit override is provided.

#### What changed

- Updated CPS routing resolution (getProjectRouting) to return the caller override first.
- Kept existing fallback behavior unchanged when no override is passed:
  - `DISABLED` -> undefined
  - `READONLY` -> space default routing
  - `EDITABLE` -> current/last editable routing

#### Impact

- Security’s alerts table can reliably enforce _alias:_origin in all CPS picker modes.
- More generally, programmatic overrides are now deterministic and no longer dependent on picker access state.
- Scope is intentionally minimal (single precedence point + tests) to reduce risk.

### UI confirmation

Now with the picker in `READONLY` we do not see remote alerts anymore (72 alerts only, instead of 84 like seen in the video above when `All projects` is selected):

| Local project set at Space level | All projects set at Space leve |
| ------------- | ------------- |
| <img width="1425" height="896" alt="Screenshot 2026-04-23 at 1 43 52 PM" src="https://github.com/user-attachments/assets/3bc6ccbe-f22a-44bd-a060-4075537df62c" /> | <img width="1425" height="899" alt="Screenshot 2026-04-23 at 1 43 28 PM" src="https://github.com/user-attachments/assets/64fbe3e1-3c70-4b2d-b808-20ac43f1d1d1" /> |

### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->