### PR TITLE
Add pairwise skill overlap eval for agent builder

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/kbn-evals-suite-agent-builder/evals/skill_overlap/README.md
+++ b/x-pack/platform/packages/shared/agent-builder/kbn-evals-suite-agent-builder/evals/skill_overlap/README.md
@@ -1,0 +1,35 @@
+# Skill Overlap Eval
+
+Analyses every pair of registered agent builder skills for description overlap that could cause the agent to load the wrong skill. Each pair is evaluated by an LLM judge that checks for shared trigger phrases, ambiguous user messages, missing negative guidance, and content-level domain invasion. The results are reported as risk levels (`HIGH`, `MEDIUM`, `LOW`, `NONE`) with actionable recommendations.
+
+Experimental skills (behind `agentBuilder:experimentalFeatures`) are automatically enabled during the eval so they are included in the pairwise analysis.
+
+## Running
+
+### 1. Initialise
+
+Run the interactive setup to configure connectors and local vault config:
+
+```bash
+node scripts/evals init
+```
+
+### 2. Export connectors
+
+Copy the `export` command printed by `init` and run it:
+
+```bash
+export KIBANA_TESTING_AI_CONNECTORS=<output from init>
+```
+
+### 3. Start the eval
+
+```bash
+node scripts/evals start --suite agent-builder --judge eis-anthropic-claude-4-6-sonnet --model eis-anthropic-claude-4-6-sonnet --datasets-profile none --grep "Skill Overlap"
+```
+
+`--datasets-profile none` skips dataset loading (this eval only uses the live skill catalog). `--grep "Skill Overlap"` restricts the run to this eval suite.
+
+## Single-model execution
+
+This eval analyses skill descriptions — it doesn't exercise the task model. To avoid redundant LLM calls when multiple connectors are configured, the spec skips all projects except the one matching the judge (`evaluationConnector`). Set `--model` to the same connector as `--judge`.

--- a/x-pack/platform/packages/shared/agent-builder/kbn-evals-suite-agent-builder/evals/skill_overlap/skill_overlap.spec.ts
+++ b/x-pack/platform/packages/shared/agent-builder/kbn-evals-suite-agent-builder/evals/skill_overlap/skill_overlap.spec.ts
@@ -1,0 +1,551 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { BoundInferenceClient } from '@kbn/inference-common';
+import type { EvaluationReporter, Example, ExperimentTask, RanExperiment } from '@kbn/evals';
+import { selectEvaluators } from '@kbn/evals';
+import type { HttpHandler } from '@kbn/core/public';
+import type { SomeDevLog } from '@kbn/some-dev-log';
+import { table } from 'table';
+import chalk from 'chalk';
+import { tags } from '@kbn/scout';
+import { AGENT_BUILDER_EXPERIMENTAL_FEATURES_SETTING_ID } from '@kbn/management-settings-ids';
+import { evaluate as base } from '../../src/evaluate';
+
+interface SkillSummary {
+  id: string;
+  name: string;
+  description: string;
+  tool_ids: string[];
+  readonly: boolean;
+  experimental: boolean;
+}
+
+interface SkillDefinition {
+  id: string;
+  name: string;
+  description: string;
+  content: string;
+  referenced_content?: Array<{ name: string; relativePath: string; content: string }>;
+  tool_ids: string[];
+  readonly: boolean;
+  experimental: boolean;
+}
+
+type SkillCatalog = Map<string, SkillDefinition>;
+
+async function enableExperimentalSkills(fetch: HttpHandler, log: SomeDevLog): Promise<boolean> {
+  try {
+    await fetch(`/api/kibana/settings/${AGENT_BUILDER_EXPERIMENTAL_FEATURES_SETTING_ID}`, {
+      method: 'POST',
+      body: JSON.stringify({ value: true }),
+    });
+    log.info('Enabled agentBuilder:experimentalFeatures for skill visibility');
+    return true;
+  } catch {
+    log.info('agentBuilder:experimentalFeatures is overridden in kibana.yml — skipping');
+    return false;
+  }
+}
+
+async function restoreExperimentalSkills(fetch: HttpHandler, log: SomeDevLog): Promise<void> {
+  try {
+    await fetch(`/api/kibana/settings/${AGENT_BUILDER_EXPERIMENTAL_FEATURES_SETTING_ID}`, {
+      method: 'DELETE',
+    });
+    log.info('Restored agentBuilder:experimentalFeatures to default');
+  } catch {
+    log.warning('Failed to restore agentBuilder:experimentalFeatures');
+  }
+}
+
+async function loadAllSkills(fetch: HttpHandler, log: SomeDevLog): Promise<SkillCatalog> {
+  log.info('Loading all skill definitions from the agent builder API');
+
+  const { results: summaries } = (await fetch('/api/agent_builder/skills', {
+    method: 'GET',
+    version: '2023-10-31',
+    query: { include_plugins: true },
+  })) as { results: SkillSummary[] };
+
+  log.info(`Found ${summaries.length} skills, fetching full definitions`);
+
+  const catalog: SkillCatalog = new Map();
+
+  const settled = await Promise.allSettled(
+    summaries.map(async (summary) => {
+      const skill = (await fetch(`/api/agent_builder/skills/${encodeURIComponent(summary.id)}`, {
+        method: 'GET',
+        version: '2023-10-31',
+      })) as SkillDefinition;
+      return skill;
+    })
+  );
+
+  for (const result of settled) {
+    if (result.status === 'fulfilled') {
+      catalog.set(result.value.id, result.value);
+    }
+  }
+
+  log.info(`Loaded ${catalog.size} skill definitions`);
+  return catalog;
+}
+
+function generateAllPairs(catalog: SkillCatalog): PairwiseExample[] {
+  const ids = [...catalog.keys()].sort();
+  const pairs: PairwiseExample[] = [];
+
+  for (let i = 0; i < ids.length; i++) {
+    for (let j = i + 1; j < ids.length; j++) {
+      pairs.push({
+        input: { skillIdA: ids[i], skillIdB: ids[j] },
+        output: {},
+      });
+    }
+  }
+
+  return pairs;
+}
+
+const PAIRWISE_ANALYSIS_SYSTEM = `You are a quality assurance analyst for an LLM agent's skill routing system.
+
+The agent has access to multiple "skills" — specialized instruction sets that guide it through domain-specific tasks. The agent decides which skill to load based ONLY on the skill's short "description" field. After loading, it follows the skill's full "content" instructions.
+
+Your job: analyze two skills for overlap in their descriptions that could cause the agent to load the WRONG skill for a given user request.
+
+Focus on:
+1. DESCRIPTION OVERLAP: Shared trigger phrases, keywords, or intent patterns in the descriptions that would match the same user messages
+2. AMBIGUOUS USER MESSAGES: Concrete example user messages that could reasonably activate either skill
+3. NEGATIVE GUIDANCE GAPS: Whether either skill explicitly says "Do NOT use for..." to exclude the other's domain — and whether such guidance is missing
+4. CONTENT-LEVEL DOMAIN INVASION: Whether one skill's full content claims territory that belongs to the other (e.g., listing examples or workflows from the other's domain)
+
+Return your analysis as valid JSON with this exact structure:
+{
+  "risk_level": "HIGH" | "MEDIUM" | "LOW" | "NONE",
+  "overlapping_triggers": ["trigger phrase 1", "trigger phrase 2"],
+  "ambiguous_user_messages": ["example user message 1", "example user message 2"],
+  "negative_guidance_gaps": "description of what Do-NOT-use clauses are missing, or empty string if none",
+  "overlap_description": "detailed explanation of the overlap and why it causes confusion, or why there is no overlap",
+  "recommendations": ["specific actionable fix 1", "specific actionable fix 2"]
+}
+
+Risk level definitions:
+- HIGH: User messages in the primary domain of one skill would regularly trigger the other. No negative guidance exists. This is a routing defect that must be fixed.
+- MEDIUM: Some user messages could plausibly trigger either skill. Partial negative guidance exists or overlap is limited to edge cases.
+- LOW: Overlap exists only in uncommon edge cases or is well-mitigated by clear negative guidance.
+- NONE: Descriptions are clearly distinct with no realistic routing confusion.
+
+Be rigorous. Only rate HIGH when there is genuine, frequent routing confusion — not just thematic similarity between skills in the same domain.`;
+
+function buildPairwisePrompt(skillA: SkillDefinition, skillB: SkillDefinition): string {
+  const truncate = (text: string, maxLen: number) =>
+    text.length > maxLen ? text.slice(0, maxLen) + '\n[... truncated ...]' : text;
+
+  return `## Skill A: ${skillA.name} (id: ${skillA.id})
+
+### Description (what the agent sees to decide whether to load this skill)
+${skillA.description}
+
+### Full Content (instructions loaded after selection)
+${truncate(skillA.content, 6000)}
+
+---
+
+## Skill B: ${skillB.name} (id: ${skillB.id})
+
+### Description (what the agent sees to decide whether to load this skill)
+${skillB.description}
+
+### Full Content (instructions loaded after selection)
+${truncate(skillB.content, 6000)}
+
+---
+
+Analyze these two skills for routing overlap. Return ONLY valid JSON.`;
+}
+
+interface PairwiseAnalysisOutput {
+  risk_level: string;
+  overlapping_triggers: string[];
+  ambiguous_user_messages: string[];
+  negative_guidance_gaps: string;
+  overlap_description: string;
+  recommendations: string[];
+  raw_response: string;
+  parse_error?: string;
+}
+
+type PairwiseExample = Example<
+  { skillIdA: string; skillIdB: string },
+  Record<string, never>,
+  Record<string, never>
+>;
+
+function tryParseJson<T>(raw: string): { parsed: T | null; error?: string } {
+  const jsonMatch = raw.match(/```(?:json)?\s*([\s\S]*?)```/) ?? raw.match(/(\{[\s\S]*\})/);
+  const toParse = jsonMatch?.[1]?.trim() ?? raw.trim();
+  try {
+    return { parsed: JSON.parse(toParse) as T };
+  } catch (e) {
+    return { parsed: null, error: `Failed to parse JSON: ${e}` };
+  }
+}
+
+async function callLlm(
+  inferenceClient: BoundInferenceClient,
+  system: string,
+  input: string
+): Promise<string> {
+  const response = await inferenceClient.output({
+    id: 'skill-overlap-analysis',
+    system,
+    input,
+  });
+  return response.content;
+}
+
+function createPairwiseTask({
+  skillCatalog,
+  inferenceClient,
+  log,
+}: {
+  skillCatalog: SkillCatalog;
+  inferenceClient: BoundInferenceClient;
+  log: SomeDevLog;
+}): ExperimentTask<PairwiseExample, PairwiseAnalysisOutput> {
+  return async ({ input }) => {
+    const { skillIdA, skillIdB } = input!;
+    const skillA = skillCatalog.get(skillIdA);
+    const skillB = skillCatalog.get(skillIdB);
+
+    if (!skillA || !skillB) {
+      const missing = [!skillA ? skillIdA : null, !skillB ? skillIdB : null].filter(Boolean);
+      log.warning(`Skipping pair: skills not found: ${missing.join(', ')}`);
+      return {
+        risk_level: 'UNAVAILABLE',
+        overlapping_triggers: [],
+        ambiguous_user_messages: [],
+        negative_guidance_gaps: '',
+        overlap_description: 'Skills not registered in this deployment.',
+        recommendations: [],
+        raw_response: '',
+      };
+    }
+
+    const prompt = buildPairwisePrompt(skillA, skillB);
+    const raw = await callLlm(inferenceClient, PAIRWISE_ANALYSIS_SYSTEM, prompt);
+    const { parsed, error } = tryParseJson<Omit<PairwiseAnalysisOutput, 'raw_response'>>(raw);
+
+    if (!parsed) {
+      return {
+        risk_level: 'PARSE_ERROR',
+        overlapping_triggers: [],
+        ambiguous_user_messages: [],
+        negative_guidance_gaps: '',
+        overlap_description: '',
+        recommendations: [],
+        raw_response: raw,
+        parse_error: error,
+      };
+    }
+
+    return { ...parsed, raw_response: raw };
+  };
+}
+
+/**
+ * Pairwise evaluators — these check the current state of skills in the codebase.
+ * A HIGH risk_level means the two skill descriptions have a routing defect.
+ * The eval FAILS when overlaps are found, PASSES when descriptions are clean.
+ */
+function createPairwiseEvaluators() {
+  return selectEvaluators<PairwiseExample, PairwiseAnalysisOutput>([
+    {
+      name: 'StructuredOutput',
+      kind: 'CODE',
+      evaluate: async ({ output }) => {
+        if (!output || output.risk_level === 'UNAVAILABLE') {
+          return { score: null, label: 'skipped', explanation: 'Skills not available' };
+        }
+        if (output.parse_error) {
+          return { score: 0, metadata: { error: output.parse_error } };
+        }
+
+        const validRiskLevels = ['HIGH', 'MEDIUM', 'LOW', 'NONE'];
+        const hasValidRisk = validRiskLevels.includes(output.risk_level);
+        const hasDescription =
+          typeof output.overlap_description === 'string' && output.overlap_description.length > 10;
+        const hasTriggers = Array.isArray(output.overlapping_triggers);
+        const hasRecommendations = Array.isArray(output.recommendations);
+
+        const checks = [hasValidRisk, hasDescription, hasTriggers, hasRecommendations];
+        const passed = checks.filter(Boolean).length;
+
+        return {
+          score: passed / checks.length,
+          metadata: { hasValidRisk, hasDescription, hasTriggers, hasRecommendations },
+        };
+      },
+    },
+    {
+      name: 'NoHighRiskOverlap',
+      kind: 'CODE',
+      evaluate: async ({ output, input }) => {
+        if (!output || output.risk_level === 'UNAVAILABLE') {
+          return { score: null, label: 'skipped' };
+        }
+
+        if (output.risk_level === 'HIGH') {
+          return {
+            score: 0,
+            label: 'HIGH_RISK',
+            explanation: `${input?.skillIdA} <-> ${input?.skillIdB}: ${output.overlap_description}`,
+          };
+        }
+
+        return { score: 1, label: output.risk_level };
+      },
+    },
+  ]);
+}
+
+interface SkillConflictProfile {
+  high: number;
+  medium: number;
+  low: number;
+  worst: string;
+  conflicts: Array<{ other: string; level: string }>;
+}
+
+const SEVERITY_RANK: Record<string, number> = { HIGH: 0, MEDIUM: 1, LOW: 2 };
+
+function colorRisk(level: string): string {
+  if (level === 'HIGH') return chalk.bold.red(level);
+  if (level === 'MEDIUM') return chalk.yellow(level);
+  if (level === 'LOW') return chalk.green(level);
+  return chalk.gray(level);
+}
+
+function printPairwiseReport(
+  experiment: RanExperiment,
+  skillCatalog: SkillCatalog,
+  log: SomeDevLog
+): void {
+  const runs = Object.values(experiment.runs);
+  const profiles = new Map<string, SkillConflictProfile>();
+
+  const emptyProfile = (): SkillConflictProfile => ({
+    high: 0,
+    medium: 0,
+    low: 0,
+    worst: '-',
+    conflicts: [],
+  });
+
+  for (const skillId of skillCatalog.keys()) {
+    profiles.set(skillId, emptyProfile());
+  }
+
+  for (const run of runs) {
+    const output = run.output as PairwiseAnalysisOutput;
+    const input = run.input ?? {};
+    const level = output?.risk_level;
+    if (!level || level === 'NONE' || level === 'UNAVAILABLE' || level === 'PARSE_ERROR') continue;
+
+    const skillA = input.skillIdA as string;
+    const skillB = input.skillIdB as string;
+    const key = level === 'HIGH' ? 'high' : level === 'MEDIUM' ? 'medium' : 'low';
+
+    for (const [id, other] of [
+      [skillA, skillB],
+      [skillB, skillA],
+    ] as const) {
+      if (!profiles.has(id)) {
+        profiles.set(id, emptyProfile());
+      }
+      const p = profiles.get(id)!;
+      p[key]++;
+      p.conflicts.push({ other, level });
+      if (p.worst === '-' || (SEVERITY_RANK[level] ?? 99) < (SEVERITY_RANK[p.worst] ?? 99)) {
+        p.worst = level;
+      }
+    }
+  }
+
+  const sorted = [...profiles.entries()].sort(([a], [b]) => a.localeCompare(b));
+
+  const details: string[] = [];
+
+  for (const level of ['HIGH', 'MEDIUM'] as const) {
+    const pairsAtLevel = runs.filter(
+      (r) => (r.output as PairwiseAnalysisOutput)?.risk_level === level
+    );
+    if (pairsAtLevel.length === 0) continue;
+
+    const plural = pairsAtLevel.length > 1 ? 's' : '';
+    details.push(`${colorRisk(level)} RISK DETAILS (${pairsAtLevel.length} pair${plural}):`);
+    details.push('');
+
+    for (const run of pairsAtLevel) {
+      const output = run.output as PairwiseAnalysisOutput;
+      const input = run.input ?? {};
+      const idA = String(input.skillIdA);
+      const idB = String(input.skillIdB);
+      const tagA = skillCatalog.get(idA)?.experimental ? chalk.magenta(' [exp]') : '';
+      const tagB = skillCatalog.get(idB)?.experimental ? chalk.magenta(' [exp]') : '';
+      const labelA = chalk.bold.white(idA) + tagA;
+      const labelB = chalk.bold.white(idB) + tagB;
+      details.push(`  [${colorRisk(level)}] ${labelA} ${chalk.gray('<->')} ${labelB}`);
+      if (output.overlapping_triggers?.length > 0) {
+        const triggers = output.overlapping_triggers.map((t) => chalk.cyan(`"${t}"`)).join(', ');
+        details.push(`    ${chalk.dim('Triggers:')} ${triggers}`);
+      }
+      if (output.ambiguous_user_messages?.length > 0) {
+        for (const msg of output.ambiguous_user_messages) {
+          details.push(`    ${chalk.dim('Ambiguous:')} ${chalk.italic(`"${msg}"`)}`);
+        }
+      }
+      if (output.negative_guidance_gaps) {
+        details.push(
+          `    ${chalk.dim('Missing guidance:')} ${chalk.yellow(output.negative_guidance_gaps)}`
+        );
+      }
+      if (output.recommendations?.length > 0) {
+        for (const rec of output.recommendations) {
+          details.push(`    ${chalk.dim('Fix:')} ${chalk.green(rec)}`);
+        }
+      }
+      details.push('');
+    }
+  }
+
+  const totalHigh = runs.filter(
+    (r) => (r.output as PairwiseAnalysisOutput)?.risk_level === 'HIGH'
+  ).length;
+  const totalMed = runs.filter(
+    (r) => (r.output as PairwiseAnalysisOutput)?.risk_level === 'MEDIUM'
+  ).length;
+  const totalLow = runs.filter(
+    (r) => (r.output as PairwiseAnalysisOutput)?.risk_level === 'LOW'
+  ).length;
+  const skillsWithIssues = sorted.filter(([, p]) => p.worst !== '-').length;
+
+  const formatConflicts = (conflicts: SkillConflictProfile['conflicts']): string => {
+    if (conflicts.length === 0) return chalk.gray('-');
+    const highAndMed = conflicts
+      .filter((c) => c.level === 'HIGH' || c.level === 'MEDIUM')
+      .sort((a, b) => a.other.localeCompare(b.other));
+    if (highAndMed.length === 0) {
+      return chalk.gray(`${conflicts.length} low`);
+    }
+    return highAndMed
+      .map((c) => {
+        const exp = skillCatalog.get(c.other)?.experimental ? chalk.magenta(' [exp]') : '';
+        return `${c.other}${exp} (${colorRisk(c.level)})`;
+      })
+      .join('\n');
+  };
+
+  const skillLabel = (id: string, color?: (s: string) => string) => {
+    const name = color ? color(id) : id;
+    return skillCatalog.get(id)?.experimental ? `${name} ${chalk.magenta('[exp]')}` : name;
+  };
+
+  const tableHeaders = ['Skill', 'HIGH', 'MED', 'LOW', 'Conflicts'].map((h) => chalk.bold(h));
+  const tableRows = sorted.map(([id, p]) => {
+    const color = p.worst === 'HIGH' ? chalk.red : p.worst === 'MEDIUM' ? chalk.yellow : undefined;
+    return [
+      skillLabel(id, color),
+      p.high > 0 ? chalk.bold.red(String(p.high)) : chalk.gray(String(p.high)),
+      p.medium > 0 ? chalk.yellow(String(p.medium)) : chalk.gray(String(p.medium)),
+      p.low > 0 ? chalk.green(String(p.low)) : chalk.gray(String(p.low)),
+      formatConflicts(p.conflicts),
+    ];
+  });
+  const summaryRow = [
+    chalk.bold('Total pairs'),
+    chalk.bold.red(String(totalHigh)),
+    chalk.bold.yellow(String(totalMed)),
+    chalk.bold.green(String(totalLow)),
+    `${skillsWithIssues}/${profiles.size} skills affected`,
+  ];
+
+  const summaryTable = table([tableHeaders, ...tableRows, summaryRow], {
+    columns: {
+      0: { alignment: 'left' },
+      1: { alignment: 'right' },
+      2: { alignment: 'right' },
+      3: { alignment: 'right' },
+      4: { alignment: 'left' },
+    },
+  });
+
+  if (details.length > 0) {
+    log.info(`\n${details.join('\n')}`);
+  }
+  log.info(`\n${chalk.bold.blue('═══ SKILL OVERLAP RESULTS ═══')}\n${summaryTable}`);
+}
+
+const evaluate = base.extend<
+  {},
+  {
+    skillCatalog: SkillCatalog;
+  }
+>({
+  skillCatalog: [
+    async ({ fetch, log }, use) => {
+      const wasEnabled = await enableExperimentalSkills(fetch, log);
+      const catalog = await loadAllSkills(fetch, log);
+      await use(catalog);
+      if (wasEnabled) {
+        await restoreExperimentalSkills(fetch, log);
+      }
+    },
+    { scope: 'worker' },
+  ],
+  reportModelScore: [
+    async ({}, use: (r: EvaluationReporter) => Promise<void>) => {
+      await use(async () => {});
+    },
+    { scope: 'worker' },
+  ],
+});
+
+evaluate.describe('Skill Overlap - Pairwise Analysis', { tag: tags.stateful.classic }, () => {
+  evaluate.beforeEach(async ({ evaluationConnector, connector }, testInfo) => {
+    if (connector.id !== evaluationConnector.id) {
+      testInfo.skip(true, 'Skill overlap only needs to run once (using the judge model)');
+    }
+  });
+
+  evaluate(
+    'no skill pair has high-risk description overlap',
+    async ({ executorClient, inferenceClient, skillCatalog, log }) => {
+      const pairs = generateAllPairs(skillCatalog);
+      log.info(`Generated ${pairs.length} skill pairs from ${skillCatalog.size} skills`);
+
+      const task = createPairwiseTask({ skillCatalog, inferenceClient, log });
+
+      const experiment = await executorClient.runExperiment(
+        {
+          dataset: {
+            name: 'agent-builder: skill-overlap-pairwise',
+            description:
+              'Checks every pair of registered skills for description overlap that could cause incorrect skill routing',
+            examples: pairs,
+          },
+          task,
+          concurrency: 10,
+        },
+        createPairwiseEvaluators()
+      );
+
+      printPairwiseReport(experiment, skillCatalog, log);
+    }
+  );
+});


### PR DESCRIPTION
## Summary

Adds an eval that analyses every pair of registered agent builder skills for description overlap that could cause the agent to load the wrong skill. An LLM judge checks each pair for shared trigger phrases, ambiguous user messages, missing negative guidance, and content-level domain invasion, then reports a risk level (`HIGH`, `MEDIUM`, `LOW`, `NONE`) with actionable recommendations.

The goal is to catch skill routing conflicts early — before they surface as incorrect skill selection in production — and give skill authors concrete guidance on how to disambiguate their descriptions.

## Screenshot

<img width="1778" height="1202" alt="Screenshot 2026-04-23 at 21 10 08" src="https://github.com/user-attachments/assets/e1608c44-af5f-46a3-b187-bd94843b38cb" />

## Results


<details>
<summary>OVERVIEW</summary>

```
      ╔═════════════════════════════════╤══════╤═════╤═════╤══════════════════════════════════════════╗
      ║ Skill                           │ HIGH │ MED │ LOW │ Conflicts                                ║
      ╟─────────────────────────────────┼──────┼─────┼─────┼──────────────────────────────────────────╢
      ║ alert-analysis                  │    0 │   3 │   6 │ find-security-ml-jobs (MEDIUM)           ║
      ║                                 │      │     │     │ observability.rca [exp] (MEDIUM)         ║
      ║                                 │      │     │     │ threat-hunting (MEDIUM)                  ║
      ╟─────────────────────────────────┼──────┼─────┼─────┼──────────────────────────────────────────╢
      ║ dashboard-management            │    0 │   1 │   5 │ visualization-creation (MEDIUM)          ║
      ╟─────────────────────────────────┼──────┼─────┼─────┼──────────────────────────────────────────╢
      ║ data-exploration                │    0 │   8 │  13 │ discover-data-analysis (MEDIUM)          ║
      ║                                 │      │     │     │ knowledge-indicators-management (MEDIUM) ║
      ║                                 │      │     │     │ observability.investigation (MEDIUM)     ║
      ║                                 │      │     │     │ observability.rca [exp] (MEDIUM)         ║
      ║                                 │      │     │     │ search.elasticsearch-onboarding (MEDIUM) ║
      ║                                 │      │     │     │ search.keyword-search (MEDIUM)           ║
      ║                                 │      │     │     │ streams-management (MEDIUM)              ║
      ║                                 │      │     │     │ threat-hunting (MEDIUM)                  ║
      ╟─────────────────────────────────┼──────┼─────┼─────┼──────────────────────────────────────────╢
      ║ detection-rule-edit             │    0 │   2 │   6 │ knowledge-indicators-management (MEDIUM) ║
      ║                                 │      │     │     │ threat-hunting (MEDIUM)                  ║
      ╟─────────────────────────────────┼──────┼─────┼─────┼──────────────────────────────────────────╢
      ║ discover-data-analysis          │    0 │   4 │  10 │ data-exploration (MEDIUM)                ║
      ║                                 │      │     │     │ observability.rca [exp] (MEDIUM)         ║
      ║                                 │      │     │     │ streams-management (MEDIUM)              ║
      ║                                 │      │     │     │ visualization-creation (MEDIUM)          ║
      ╟─────────────────────────────────┼──────┼─────┼─────┼──────────────────────────────────────────╢
      ║ entity-analytics                │    0 │   1 │   7 │ find-security-ml-jobs (MEDIUM)           ║
      ╟─────────────────────────────────┼──────┼─────┼─────┼──────────────────────────────────────────╢
      ║ find-security-ml-jobs           │    0 │   4 │   5 │ alert-analysis (MEDIUM)                  ║
      ║                                 │      │     │     │ entity-analytics (MEDIUM)                ║
      ║                                 │      │     │     │ observability.rca [exp] (MEDIUM)         ║
      ║                                 │      │     │     │ threat-hunting (MEDIUM)                  ║
      ╟─────────────────────────────────┼──────┼─────┼─────┼──────────────────────────────────────────╢
      ║ graph-creation                  │    0 │   2 │   6 │ observability.investigation (MEDIUM)     ║
      ║                                 │      │     │     │ observability.service-map (MEDIUM)       ║
      ╟─────────────────────────────────┼──────┼─────┼─────┼──────────────────────────────────────────╢
      ║ knowledge-indicators-management │    0 │   3 │   7 │ data-exploration (MEDIUM)                ║
      ║                                 │      │     │     │ detection-rule-edit (MEDIUM)             ║
      ║                                 │      │     │     │ observability.investigation (MEDIUM)     ║
      ╟─────────────────────────────────┼──────┼─────┼─────┼──────────────────────────────────────────╢
      ║ observability.investigation     │    1 │   4 │   7 │ data-exploration (MEDIUM)                ║
      ║                                 │      │     │     │ graph-creation (MEDIUM)                  ║
      ║                                 │      │     │     │ knowledge-indicators-management (MEDIUM) ║
      ║                                 │      │     │     │ observability.rca [exp] (HIGH)           ║
      ║                                 │      │     │     │ observability.service-map (MEDIUM)       ║
      ╟─────────────────────────────────┼──────┼─────┼─────┼──────────────────────────────────────────╢
      ║ observability.rca [exp]         │    1 │   5 │   6 │ alert-analysis (MEDIUM)                  ║
      ║                                 │      │     │     │ data-exploration (MEDIUM)                ║
      ║                                 │      │     │     │ discover-data-analysis (MEDIUM)          ║
      ║                                 │      │     │     │ find-security-ml-jobs (MEDIUM)           ║
      ║                                 │      │     │     │ observability.investigation (HIGH)       ║
      ║                                 │      │     │     │ streams-management (MEDIUM)              ║
      ╟─────────────────────────────────┼──────┼─────┼─────┼──────────────────────────────────────────╢
      ║ observability.service-map       │    0 │   2 │   4 │ graph-creation (MEDIUM)                  ║
      ║                                 │      │     │     │ observability.investigation (MEDIUM)     ║
      ╟─────────────────────────────────┼──────┼─────┼─────┼──────────────────────────────────────────╢
      ║ search.catalog-ecommerce        │    1 │   1 │   4 │ search.keyword-search (HIGH)             ║
      ║                                 │      │     │     │ search.vector-hybrid-search (MEDIUM)     ║
      ╟─────────────────────────────────┼──────┼─────┼─────┼──────────────────────────────────────────╢
      ║ search.elasticsearch-onboarding │    0 │   3 │   7 │ data-exploration (MEDIUM)                ║
      ║                                 │      │     │     │ search.rag-chatbot (MEDIUM)              ║
      ║                                 │      │     │     │ search.vector-hybrid-search (MEDIUM)     ║
      ╟─────────────────────────────────┼──────┼─────┼─────┼──────────────────────────────────────────╢
      ║ search.keyword-search           │    1 │   1 │   5 │ data-exploration (MEDIUM)                ║
      ║                                 │      │     │     │ search.catalog-ecommerce (HIGH)          ║
      ╟─────────────────────────────────┼──────┼─────┼─────┼──────────────────────────────────────────╢
      ║ search.rag-chatbot              │    0 │   3 │   4 │ search.elasticsearch-onboarding (MEDIUM) ║
      ║                                 │      │     │     │ search.use-case-library (MEDIUM)         ║
      ║                                 │      │     │     │ search.vector-hybrid-search (MEDIUM)     ║
      ╟─────────────────────────────────┼──────┼─────┼─────┼──────────────────────────────────────────╢
      ║ search.use-case-library         │    0 │   2 │   5 │ search.rag-chatbot (MEDIUM)              ║
      ║                                 │      │     │     │ search.vector-hybrid-search (MEDIUM)     ║
      ╟─────────────────────────────────┼──────┼─────┼─────┼──────────────────────────────────────────╢
      ║ search.vector-hybrid-search     │    0 │   4 │   3 │ search.catalog-ecommerce (MEDIUM)        ║
      ║                                 │      │     │     │ search.elasticsearch-onboarding (MEDIUM) ║
      ║                                 │      │     │     │ search.rag-chatbot (MEDIUM)              ║
      ║                                 │      │     │     │ search.use-case-library (MEDIUM)         ║
      ╟─────────────────────────────────┼──────┼─────┼─────┼──────────────────────────────────────────╢
      ║ streams-management              │    0 │   3 │  12 │ data-exploration (MEDIUM)                ║
      ║                                 │      │     │     │ discover-data-analysis (MEDIUM)          ║
      ║                                 │      │     │     │ observability.rca [exp] (MEDIUM)         ║
      ╟─────────────────────────────────┼──────┼─────┼─────┼──────────────────────────────────────────╢
      ║ threat-hunting                  │    0 │   4 │   8 │ alert-analysis (MEDIUM)                  ║
      ║                                 │      │     │     │ data-exploration (MEDIUM)                ║
      ║                                 │      │     │     │ detection-rule-edit (MEDIUM)             ║
      ║                                 │      │     │     │ find-security-ml-jobs (MEDIUM)           ║
      ╟─────────────────────────────────┼──────┼─────┼─────┼──────────────────────────────────────────╢
      ║ visualization-creation          │    0 │   2 │   8 │ dashboard-management (MEDIUM)            ║
      ║                                 │      │     │     │ discover-data-analysis (MEDIUM)          ║
      ╟─────────────────────────────────┼──────┼─────┼─────┼──────────────────────────────────────────╢
      ║ workflow-authoring [exp]        │    0 │   0 │   4 │ 4 low                                    ║
      ╟─────────────────────────────────┼──────┼─────┼─────┼──────────────────────────────────────────╢
      ║ Total pairs                     │    2 │  31 │  71 │ 22/22 skills affected                    ║
      ╚═════════════════════════════════╧══════╧═════╧═════╧══════════════════════════════════════════╝
```
</details>

<details>
<summary>HIGH RISK DETAILS (2 pairs) </summary>

```
        [HIGH] observability.investigation <-> observability.rca [exp]
          Triggers: "alert firing", "why is [service] failing/erroring/slow", "service health / degradation", "error rates / latency spikes", "SLO/SLA breach", "cascading failure across services", "anomalies or spikes in logs or metrics", "investigate errors in a service", "what's wrong with a service", "outage / performance regression", "trace analysis", "log patterns"
          Ambiguous: "Why is the checkout service returning 500 errors?"
          Ambiguous: "An alert fired for the payment service — what's wrong?"
          Ambiguous: "The API latency spiked, what's the root cause?"
          Ambiguous: "Our payment service is slow, can you investigate?"
          Ambiguous: "We're seeing a high error rate on the order service"
          Ambiguous: "What caused the outage at 3pm?"
          Ambiguous: "Investigate the errors in the checkout service"
          Ambiguous: "There's a latency regression in the auth service after the last deploy"
          Ambiguous: "We had an SLO breach — what happened?"
          Ambiguous: "Service X keeps timing out, what's going on?"
          Missing guidance: Skill A (investigation) excludes security/SIEM use cases but does NOT exclude RCA or 'why is X broken' questions — which are the primary domain of Skill B. Skill B (rca) excludes generic log retrieval and reporting but does NOT exclude general observability investigation questions, service health checks, or alert triage — which are the primary domain of Skill A. Neither skill tells the agent 'do not use this when the other skill is more appropriate.' The descriptions are almost entirely co-extensive for the most common observability user messages (alert fired, service slow, errors spiking), with no mutual exclusion clauses between them.
          Fix: Add a mutual exclusion clause to Skill A's description: 'Do NOT use when the user is asking WHY something failed and a root cause analysis workflow (ki_search, KI-driven hypotheses) is available — use the rca skill instead.'
          Fix: Add a mutual exclusion clause to Skill B's description: 'Do NOT use for general observability browsing, topology exploration, or simple health checks where no root cause diagnosis is needed — use the investigation skill instead.'
          Fix: Reframe Skill A as the 'exploration and monitoring' skill (what is happening, what services exist, what are current metrics) and Skill B as the 'diagnosis' skill (why is something broken), and make this distinction explicit and non-overlapping in both descriptions.
          Fix: Add concrete distinguishing examples to each description: Skill A should list 'show me the topology for checkout,' 'what is the current error rate?,' 'are there any active alerts?' as its canonical triggers; Skill B should list 'why is checkout failing?,' 'what caused the 3pm outage?,' 'root cause the latency spike' as its canonical triggers.
          Fix: Consider merging the two skills into one, since their investigation workflows are nearly identical and the split creates unavoidable routing ambiguity for the most common observability questions.

        [HIGH] search.catalog-ecommerce <-> search.keyword-search
          Triggers: "faceted search / faceted navigation", "autocomplete / typeahead", "filters", "traditional search functionality", "text matching", "products index with title, description, category, price fields", "filter by category, price range, brand"
          Ambiguous: "I want to add autocomplete to my product search"
          Ambiguous: "How do I add faceted navigation with brand and category filters?"
          Ambiguous: "I need to build a search bar for my product catalog"
          Ambiguous: "How do I filter products by price range and category in Elasticsearch?"
          Ambiguous: "I want to add typeahead suggestions to my search"
          Ambiguous: "How do I set up full-text search with filters for my products?"
          Ambiguous: "I need to search across product titles and descriptions with keyword matching"
          Ambiguous: "How do I show facet counts for brands and categories?"
          Missing guidance: Skill B (keyword-search) has no 'Do NOT use' clause excluding product catalog or e-commerce scenarios — it explicitly lists 'products' as a primary example and covers faceting, autocomplete, and price/brand filtering, which are the core triggers of Skill A. Skill A excludes 'document search without structured attributes' and redirects to keyword-search, but this exclusion is too narrow: it does not exclude the large overlap zone where both skills claim identical territory (product indexes with facets and autocomplete). Neither skill says 'Do NOT use this if the developer is building a product/e-commerce search' vs. 'Do NOT use this if the developer only needs generic document search', leaving the entire product-search domain claimed by both.
          Fix: Rewrite Skill B's description to explicitly exclude e-commerce/product catalog use cases: e.g., 'Use for general-purpose full-text search over articles, documents, or content — NOT for product catalog search with merchandising, variant attributes, or shopping-oriented relevance; use catalog-ecommerce for that.'
          Fix: Rewrite Skill A's description to lead with its differentiating features: e.g., 'Use when a developer is building a shopping or product catalog experience requiring merchandising/boosting, variant attributes, did-you-mean suggestions, or sale/inventory-aware relevance — not for general document or content search.'
          Fix: Add explicit 'Do NOT use' clauses to both descriptions: Skill A should say 'Do NOT use for general document or content search without shopping context'; Skill B should say 'Do NOT use for product catalog search with merchandising, boosting, or variant filtering — use catalog-ecommerce instead.'
          Fix: Remove 'products' as the primary example from Skill B's description and content, replacing it with a non-commerce domain (e.g., articles, knowledge base documents) to reduce content-level domain invasion.
          Fix: In Skill B's description, replace 'faceted search' with 'faceted search over non-commerce content' and remove 'autocomplete' or qualify it as 'autocomplete for document/article search' to reduce trigger overlap with Skill A.

```
</details>


<details>
<summary>MEDIUM RISK DETAILS (31 pairs)</summary>

```
        [MEDIUM] alert-analysis <-> observability.rca [exp]
          Triggers: "alert firing", "an alert fired", "investigate alerts", "alert triage", "understanding alert context"
          Ambiguous: "An alert fired — what's wrong?"
          Ambiguous: "I have a security alert firing, can you investigate?"
          Ambiguous: "Why did this alert trigger?"
          Ambiguous: "Help me understand why this alert fired on my system"
          Ambiguous: "An alert went off and I need to know the root cause"
          Missing guidance: The alert-analysis skill has no 'Do NOT use for' clause excluding observability/infrastructure alerts (e.g., SLA breaches, latency spikes, service errors). The rca skill explicitly lists 'an alert fired' as a trigger phrase without scoping it to observability/infrastructure alerts only, meaning security alerts could match it. Neither skill tells the agent to avoid the other's domain when the word 'alert' appears. The rca skill should exclude security-domain alerts (SIEM, EDR, threat detection) and the alert-analysis skill should exclude infrastructure/observability alerts.
          Fix: Add a 'Do NOT use for' clause to alert-analysis: 'Do NOT use for observability or infrastructure alerts about service latency, error rates, outages, or SLA breaches — use the rca skill for those.'
          Fix: Add a 'Do NOT use for' clause to rca: 'Do NOT use for security alerts from SIEM, EDR, or threat detection systems (e.g., alerts involving MITRE ATT&CK techniques, malware, IOCs, or suspicious user/host behavior) — use the alert-analysis skill for those.'
          Fix: Reword the rca description's alert trigger from the generic 'when they report an alert firing' to 'when they report an observability or infrastructure alert firing (e.g., APM, uptime, SLA, or metric threshold alerts)' to narrow the match surface.
          Fix: Reword the alert-analysis description to explicitly scope 'alert' to security alerts: replace 'triaging alert queues' with 'triaging security alert queues (SIEM, EDR, threat detection)' to reduce false matches on infrastructure alert messages.

        [MEDIUM] alert-analysis <-> find-security-ml-jobs
          Triggers: "suspicious behavior involving hosts or users", "lateral movement investigation", "unusual login activity", "anomalous access patterns", "security entities (hosts, users, IPs)", "investigating suspicious activity", "unexpected logins from different locations", "large downloads / data exfiltration"
          Ambiguous: "Is this user behaving suspiciously? They logged in from an unusual location."
          Ambiguous: "Investigate unusual activity for host web-server-01"
          Ambiguous: "Are there any anomalous logins related to this alert?"
          Ambiguous: "Show me suspicious behavior for user john.doe"
          Ambiguous: "I'm seeing a large data download — is this related to any alerts?"
          Ambiguous: "Investigate lateral movement on my network"
          Ambiguous: "Is there anything unusual about this host's recent activity?"
          Ambiguous: "Check if this IP is involved in any suspicious behavior"
          Missing guidance: Neither skill explicitly excludes the other's domain. The alert-analysis skill does not say 'Do NOT use for ML anomaly detection or behavioral analysis without an alert.' The find-security-ml-jobs skill does not say 'Do NOT use when starting from a specific alert ID or triaging an alert queue.' The alert-analysis skill mentions entity risk scores and behavioral context but does not redirect ML anomaly queries to find-security-ml-jobs. Conversely, find-security-ml-jobs covers anomalous behavior for the same entity types (hosts, users, IPs) that alert-analysis investigates, without clarifying it is not for alert triage. The overlap is especially pronounced when a user investigates suspicious entity behavior without referencing a specific alert.
          Fix: Add explicit negative guidance to alert-analysis description: 'Do NOT use for proactive anomaly hunting or ML-based behavioral analysis without a specific alert to investigate — use find-security-ml-jobs instead.'
          Fix: Add explicit negative guidance to find-security-ml-jobs description: 'Do NOT use when triaging or investigating a specific existing alert — use alert-analysis instead. Use this skill for proactive, ML-driven anomaly detection without a known alert as the starting point.'
          Fix: Reframe the find-security-ml-jobs description to emphasize the ML/proactive-hunting angle more distinctly, e.g., 'Use ML anomaly detection jobs to proactively hunt for unusual behavior when no specific alert has been triggered.'
          Fix: In the alert-analysis description, clarify the entry point: 'Use ONLY when starting from a specific alert ID or alert queue — not for general behavioral anomaly hunting.'
          Fix: Add a cross-reference in alert-analysis content: when behavioral anomaly context is needed without a specific alert, explicitly instruct the agent to route to find-security-ml-jobs rather than attempting to handle it inline.

        [MEDIUM] alert-analysis <-> threat-hunting
          Triggers: "investigating suspicious activity", "IOC search (IPs, domains, file hashes)", "MITRE ATT&CK technique correlation", "lateral movement investigation", "entity-based investigation (hosts, users, IPs)", "threat intelligence enrichment", "analyzing suspicious activity patterns"
          Ambiguous: "Investigate suspicious activity from IP 192.168.1.50 over the last 24 hours"
          Ambiguous: "Search for this file hash across our environment and tell me if it's malicious"
          Ambiguous: "Look into potential lateral movement from host WORKSTATION-42"
          Ambiguous: "Find all activity related to this suspicious domain name"
          Ambiguous: "Investigate this user account — I think it may be compromised"
          Ambiguous: "Check if there are any signs of C2 beaconing in our network logs"
          Ambiguous: "Analyze suspicious process executions on our endpoints this week"
          Ambiguous: "I think we have a threat actor using living-off-the-land techniques — can you investigate?"
          Missing guidance: Neither skill explicitly excludes the other's domain. alert-analysis does not say 'Do NOT use for proactive hunts without a specific alert ID' and threat-hunting does not say 'Do NOT use when you have a specific alert to triage.' The boundary between 'I have an alert' (alert-analysis) and 'I suspect a threat but have no alert yet' (threat-hunting) is not stated in either description. Both descriptions use the word 'investigating' and reference IOC lookups, MITRE ATT&CK, and entity-based exploration, with no exclusionary language to differentiate them.
          Fix: Add explicit negative guidance to alert-analysis description: append 'Do NOT use for proactive hunts without a specific alert — use threat-hunting instead.'
          Fix: Add explicit negative guidance to threat-hunting description: append 'Do NOT use when starting from a specific alert ID that needs triage — use alert-analysis instead.'
          Fix: Rewrite the alert-analysis description to emphasize the alert-first entry point: e.g., 'Use when you have a specific alert ID or alert queue to triage' rather than the broader 'investigating a specific alert'.
          Fix: Rewrite the threat-hunting description to emphasize the hypothesis-first, no-alert entry point: e.g., 'Use when no specific alert exists and you are proactively searching for threats based on a hypothesis or IOC list.'
          Fix: Add a routing decision hint to both descriptions clarifying the handoff: e.g., 'If a hunt confirms a threat, switch to alert-analysis for triage' (threat-hunting) and 'If no alert exists yet, switch to threat-hunting for proactive investigation' (alert-analysis).
          Fix: Remove or qualify the shared trigger phrase 'investigating suspicious activity' from the threat-hunting description, since alert-analysis also covers investigation — differentiate by anchoring threat-hunting to 'proactive' or 'hypothesis-driven' investigation exclusively.

        [MEDIUM] data-exploration <-> discover-data-analysis
          Triggers: "explore data", "analyze data", "query data", "Elasticsearch", "patterns and trends", "aggregation queries", "summarize data", "query results"
          Ambiguous: "Can you analyze my Elasticsearch data and find patterns?"
          Ambiguous: "Run some aggregation queries on my data and summarize the results"
          Ambiguous: "Help me explore my data and identify trends"
          Ambiguous: "Query my Elasticsearch index and show me what's interesting"
          Ambiguous: "Analyze my query results and highlight any anomalies"
          Ambiguous: "Can you summarize the data in my index?"
          Missing guidance: Skill A (data-exploration) has no 'Do NOT use for' clause excluding Kibana Discover ES|QL analysis scenarios. Skill B (discover-data-analysis) has no 'Do NOT use for' clause excluding general Elasticsearch exploration outside of Kibana Discover. Neither skill explicitly delineates where the other should be used instead. Skill A's description says nothing about being limited to non-Kibana contexts, and Skill B's description does not mention that it requires an attached query result or a Kibana Discover context — both of which are critical constraints that would help the router distinguish them.
          Fix: Update Skill B's description to explicitly mention the Kibana Discover context and attached query results requirement, e.g.: 'Analyzes ES|QL query results attached from Kibana Discover, identifying patterns, trends, and anomalies — requires an active Kibana Discover session with ES|QL mode enabled and attached query results.'
          Fix: Update Skill A's description to explicitly exclude Kibana Discover ES|QL scenarios, e.g.: 'Guides agents through exploring, querying, and summarizing data stored in Elasticsearch using available tools. Do NOT use when the user is in Kibana Discover with ES|QL query results attached — use discover-data-analysis instead.'
          Fix: Add a 'Do NOT use for' clause to Skill B's content introduction stating: 'Do NOT use this skill for general Elasticsearch exploration outside of Kibana Discover, or when no ES|QL query results attachment is present — use data-exploration instead.'
          Fix: Add a 'Do NOT use for' clause to Skill A's content introduction stating: 'Do NOT use this skill when the user is working in Kibana Discover with ES|QL mode and has attached query results — use discover-data-analysis instead.'
          Fix: Consider adding a routing hint in Skill B's description that references the attachment dependency, since the router cannot inspect attachments — this is the single most important differentiator and is currently invisible to the routing decision.

        [MEDIUM] dashboard-management <-> visualization-creation
          Triggers: "create visualization panels", "inline visualization editing", "panel creation", "create visualizations", "chart creation within a dashboard context"
          Ambiguous: "Create a bar chart showing top 10 hosts by CPU usage"
          Ambiguous: "I need a visualization of error rates over time"
          Ambiguous: "Add a new chart to my dashboard"
          Ambiguous: "Create a line chart and put it on a dashboard"
          Ambiguous: "Make me a metric panel showing total request count"
          Ambiguous: "Build me some charts for my infrastructure data"
          Missing guidance: Skill A (dashboard-management) does not explicitly exclude standalone visualization creation requests that happen to mention charts or panels without explicitly saying 'dashboard'. Skill B (visualization-creation) has a good negative clause ('The primary goal is to compose or update a dashboard. Use the dashboard-management skill for dashboard panel creation and layout'), but Skill A lacks a symmetric clause explicitly saying 'Do NOT use this skill when the user asks for a standalone chart or visualization without mentioning a dashboard.' The descriptions themselves don't contain negative guidance — only the full content does — meaning the agent must load the skill before seeing the exclusion rules, which is too late for routing decisions.
          Fix: Add explicit exclusion language to Skill A's description, e.g.: 'Compose and update Kibana dashboards involving panel creation, layout, and inline visualization editing. Do NOT use for standalone visualization creation without a dashboard context.'
          Fix: Add explicit exclusion language to Skill B's description, e.g.: 'Create standalone or reusable visualizations from grounded index and field context. Do NOT use when the goal is to compose, update, or add panels to a Kibana dashboard.'
          Fix: Rename or reword Skill A's description to de-emphasize 'panel creation' and 'visualization editing' in favor of dashboard-centric language, e.g.: 'Manage Kibana dashboard layout, structure, and composition — including adding, editing, and arranging panels within a dashboard.'
          Fix: Add a routing hint to Skill B's description that clarifies the standalone intent more strongly, e.g.: 'Create standalone, reusable visualization artifacts (charts, metrics, trends) outside of any dashboard workflow.'
          Fix: Consider adding a short disambiguation rule visible at routing time (in descriptions) such as: Skill A — 'Use when a dashboard is the end artifact'; Skill B — 'Use when a visualization attachment is the end artifact or intermediate reusable artifact.'

        [MEDIUM] data-exploration <-> observability.investigation
          Triggers: "log patterns", "querying data", "exploring data", "summarizing data", "available indices", "index", "data exploration"
          Ambiguous: "Can you show me the log patterns for the last hour?"
          Ambiguous: "What indices are available?"
          Ambiguous: "Can you query the logs and summarize what you find?"
          Ambiguous: "Show me patterns in the data"
          Ambiguous: "Can you explore the data and tell me what's in this index?"
          Ambiguous: "Summarize the data in my Elasticsearch index"
          Missing guidance: Skill A (data-exploration) has no negative guidance at all — it does not say 'Do NOT use for observability investigations, APM services, log pattern analysis, or alert diagnosis.' This is a gap because its description mentions 'querying and summarizing data stored in Elasticsearch,' which could match observability-related queries about logs and indices. Skill B explicitly excludes security/SIEM use cases but does not exclude generic Elasticsearch data exploration, meaning a user asking about 'log patterns' or 'indices' could plausibly route to either skill.
          Fix: Add a 'Do NOT use for' clause to Skill A's description, e.g.: 'Do NOT use for observability investigations, APM service health, alert diagnosis, log pattern analysis for running services, or any question about error rates, latency, or traces.'
          Fix: Narrow Skill A's description to emphasize ad-hoc or analytical data exploration (e.g., 'Guides agents through ad-hoc exploration and querying of arbitrary Elasticsearch indices for analytical or discovery purposes — not for observability or service health investigations.').
          Fix: Add a clarifying note to Skill B's description that it handles log pattern analysis specifically in the context of observability and service health, not general-purpose Elasticsearch querying.
          Fix: In Skill A's content, add a routing note: 'If the user is asking about service health, APM metrics, error rates, latency, alerts, or infrastructure issues, route to the observability.investigation skill instead.'

        [MEDIUM] data-exploration <-> knowledge-indicators-management
          Triggers: "search existing indicators", "query", "Elasticsearch", "ES|QL", "explore data", "find patterns", "summarize data"
          Ambiguous: "Can you search for existing queries related to 5xx errors in my logs?"
          Ambiguous: "I want to find patterns in my Elasticsearch data"
          Ambiguous: "Can you run a query to detect error spikes in the checkout stream?"
          Ambiguous: "Search for any existing detection logic for timeout errors"
          Ambiguous: "Help me query and summarize log data from the payment service"
          Ambiguous: "Find recurring patterns in my logs index"
          Missing guidance: Neither skill contains explicit 'Do NOT use for...' clauses. The data-exploration skill does not exclude KI management workflows, and the knowledge-indicators-management skill does not exclude general Elasticsearch data exploration. The knowledge-indicators-management skill's description uses the word 'search' which overlaps with data-exploration's querying intent. The data-exploration skill's description mentions 'querying and summarizing data' which could match requests that are actually about finding or managing Query KIs. Neither skill clarifies that it is NOT for the other's domain.
          Fix: Add a 'Do NOT use for...' clause to data-exploration's description: e.g., 'Not for managing or creating Knowledge Indicators (KIs) — use knowledge-indicators-management for that.'
          Fix: Add a 'Do NOT use for...' clause to knowledge-indicators-management's description: e.g., 'Not for ad-hoc data exploration or one-off Elasticsearch queries — use data-exploration for that.'
          Fix: Reword the knowledge-indicators-management description to emphasize the KI lifecycle (create, deduplicate, store reusable knowledge) rather than 'search', which is ambiguous: e.g., 'Create, deduplicate, and store reusable Streams Knowledge Indicators (KIs) including behavioral patterns and ES|QL detection queries.'
          Fix: Reword the data-exploration description to explicitly scope it to ad-hoc, one-off data exploration: e.g., 'Guides agents through ad-hoc exploration, querying, and summarization of raw data stored in Elasticsearch indices — not for managing reusable Knowledge Indicators.'
          Fix: In the data-exploration skill content, add a routing note: 'If the user is asking about saving, managing, or reusing detection patterns or queries as Knowledge Indicators, defer to the knowledge-indicators-management skill instead.'

        [MEDIUM] data-exploration <-> observability.rca [exp]
          Triggers: "anomalies or spikes in logs or metrics", "explore data stored in Elasticsearch", "querying data in Elasticsearch", "summarizing data", "patterns in data"
          Ambiguous: "I'm seeing a spike in errors in my Elasticsearch index, can you help me investigate?"
          Ambiguous: "Can you query the logs index and show me what's causing the high error rate?"
          Ambiguous: "I want to explore the metrics data and find anomalies from this morning"
          Ambiguous: "Show me patterns in the logs from the checkout service over the last hour"
          Ambiguous: "Can you look at the data in my Elasticsearch index and tell me what's wrong?"
          Missing guidance: The data-exploration skill has NO 'Do NOT use for' clauses at all. It does not exclude diagnostic or RCA-style queries, meaning a user asking to 'explore logs to find what's causing errors' could plausibly route to data-exploration instead of rca. The rca skill does exclude 'generic log retrieval' and 'reporting/analytics', which partially guards against pulling pure data-exploration requests into rca, but data-exploration has no reciprocal exclusion for failure-diagnosis requests that happen to involve querying Elasticsearch.
          Fix: Add a 'Do NOT use for' clause to the data-exploration skill description explicitly excluding failure diagnosis, root cause analysis, and anomaly investigation — e.g., 'Do NOT use when the user is asking why something is broken, failing, or degraded; use the rca skill for those cases.'
          Fix: Add a 'Do NOT use for' clause to the data-exploration skill content (not just description) that redirects users with diagnostic intent to the rca skill.
          Fix: Tighten the data-exploration description to emphasize neutral data access ('browsing', 'ad-hoc querying', 'reporting') rather than open-ended 'exploring patterns', which can sound diagnostic.
          Fix: In the rca skill description, add a clarifying note that it applies even when the user's phrasing is data-access-oriented (e.g., 'query logs to find errors') as long as the underlying intent is diagnosing a failure or anomaly.
          Fix: Consider adding an intent-disambiguation step: if the agent detects both data-access language and failure-diagnosis language in the same message, default to rca and note that data-exploration is available for follow-up ad-hoc queries.

        [MEDIUM] data-exploration <-> search.elasticsearch-onboarding
          Triggers: "Elasticsearch", "querying data", "exploring data", "indices", "getting started with Elasticsearch", "how do I query", "summarizing data", "setting up indices"
          Ambiguous: "How do I query my Elasticsearch index?"
          Ambiguous: "I want to explore my data in Elasticsearch"
          Ambiguous: "Can you help me get started with Elasticsearch queries?"
          Ambiguous: "How do I search through my Elasticsearch data?"
          Ambiguous: "I need help querying and summarizing data from my indices"
          Ambiguous: "Show me how to run a query against my Elasticsearch index"
          Ambiguous: "I want to understand what's in my Elasticsearch data"
          Missing guidance: The data-exploration skill has no 'Do NOT use for' clause at all — it does not exclude onboarding, tutorials, or first-time setup scenarios, meaning it could be selected for users who are new to Elasticsearch and want a guided walkthrough. The elasticsearch-onboarding skill does include some routing guidance (prefer a different skill for narrow single-pattern requests), but it does not explicitly say 'Do NOT use for exploring existing data in Elasticsearch indices' or 'Do NOT use when the user already has data and wants to query it.' Neither skill explicitly excludes the other's domain, leaving a gap for messages about querying or exploring Elasticsearch data that could plausibly match both.
          Fix: Add a 'Do NOT use for' clause to the data-exploration skill description, e.g.: 'Do NOT use for first-time onboarding, tutorials, or users who are new to Elasticsearch and need a guided walkthrough — use elasticsearch-onboarding instead.'
          Fix: Add a 'Do NOT use for' clause to the elasticsearch-onboarding skill description, e.g.: 'Do NOT use when the user already has data in Elasticsearch and simply wants to run, explore, or summarize queries against existing indices — use data-exploration instead.'
          Fix: Differentiate the data-exploration description more sharply by emphasizing it is for users who already have data in Elasticsearch and want to query or analyze it, not for users learning or setting up Elasticsearch for the first time.
          Fix: In the elasticsearch-onboarding skill content, add an explicit routing rule in the 'When to invoke this skill' table: if the user already has an Elasticsearch index and wants to explore or query existing data, prefer loading data-exploration.
          Fix: Consider adding a clarifying question or intent-detection heuristic in the agent's routing logic: if the user mentions 'my data,' 'my index,' or 'existing index,' prefer data-exploration; if they mention 'new,' 'start,' 'learn,' or 'build,' prefer elasticsearch-onboarding.

        [MEDIUM] data-exploration <-> search.keyword-search
          Triggers: "querying data in Elasticsearch", "exploring Elasticsearch indices", "filtering data in Elasticsearch", "summarizing data from Elasticsearch", "running Elasticsearch queries"
          Ambiguous: "How do I query my Elasticsearch index to find specific documents?"
          Ambiguous: "I want to filter and search through my Elasticsearch data"
          Ambiguous: "Can you help me find documents in Elasticsearch matching certain keywords?"
          Ambiguous: "How do I search for products in my Elasticsearch index?"
          Ambiguous: "I need to query my Elasticsearch data and summarize the results"
          Missing guidance: The data-exploration skill has no 'Do NOT use for' clause excluding developer-facing search implementation tasks (e.g., building search features, mapping design, autocomplete). It could absorb requests that belong to keyword-search. The keyword-search skill does have a partial exclusion ('Do not use this guide when: natural language queries return poor results...') but this only excludes semantic/vector search — it does not exclude ad-hoc data exploration or analytical querying scenarios that belong to data-exploration. Neither skill explicitly says 'Do NOT use for the other skill's domain.'
          Fix: Add a 'Do NOT use for' clause to the data-exploration description: e.g., 'Do NOT use when a developer is building a search feature, designing index mappings, or implementing autocomplete/faceted search in an application — use keyword-search instead.'
          Fix: Add a 'Do NOT use for' clause to the keyword-search description: e.g., 'Do NOT use for ad-hoc analytical querying, data summarization, or one-off exploration of existing indices — use data-exploration instead.'
          Fix: Sharpen the data-exploration description to emphasize its analytical/ad-hoc nature: e.g., 'Guides analysts through ad-hoc exploration, querying, and summarization of data already stored in Elasticsearch indices — not for building search features.'
          Fix: Sharpen the keyword-search description to emphasize its developer/build orientation: e.g., 'Guide for developers building keyword/full-text search features into an application using Elasticsearch — not for ad-hoc data exploration or analytics.'

        [MEDIUM] data-exploration <-> threat-hunting
          Triggers: "exploring data in Elasticsearch", "querying Elasticsearch indices", "summarizing data", "listing available indices", "running queries against security data"
          Ambiguous: "Can you query the logs-endpoint.events.process-* index and show me what's there?"
          Ambiguous: "I want to explore the network logs in Elasticsearch and summarize what I find"
          Ambiguous: "List the available indices and help me query one of them"
          Ambiguous: "Can you search for unusual patterns in my Elasticsearch data?"
          Ambiguous: "Help me run a query to find rare events in my security logs"
          Missing guidance: The data-exploration skill has no 'Do NOT use for' clause excluding security/threat-hunting scenarios. A user asking to explore security indices (e.g., winlogbeat-*, filebeat-*) or look for anomalies could plausibly trigger data-exploration instead of threat-hunting. The threat-hunting skill does reference 'alert-analysis' as a cross-reference but never explicitly excludes general data exploration. Neither skill warns the agent away from the other's domain.
          Fix: Add a 'Do NOT use for' clause to the data-exploration skill description, e.g.: 'Do NOT use for security investigations, threat hunting, IOC searches, anomaly detection in security telemetry, or any scenario involving suspected malicious activity — use the threat-hunting skill instead.'
          Fix: Add a 'Do NOT use for' clause to the threat-hunting skill description, e.g.: 'Do NOT use for general-purpose data exploration or non-security analytics queries — use the data-exploration skill for those.'
          Fix: Narrow the data-exploration skill description to explicitly scope it to non-security use cases, e.g.: 'Guides agents through exploring, querying, and summarizing non-security data stored in Elasticsearch using available tools. For security investigations or threat hunting, use the threat-hunting skill.'
          Fix: Add a routing note inside the data-exploration skill content (e.g., at the top under Overview) that instructs the agent: 'If the user's goal involves detecting threats, searching for IOCs, or investigating suspicious activity, stop and load the threat-hunting skill instead.'

        [MEDIUM] data-exploration <-> streams-management
          Triggers: "explore data in Elasticsearch", "query documents", "summarize data", "show me documents", "data stored in Elasticsearch", "aggregations", "patterns in data"
          Ambiguous: "Show me documents from logs.ecs.nginx"
          Ambiguous: "Can you query my Elasticsearch data and summarize what's there?"
          Ambiguous: "I want to explore the data in my logs index"
          Ambiguous: "Show me aggregations over my logs data"
          Ambiguous: "What documents are in my logs.otel stream?"
          Ambiguous: "Can you run a query and show me the results from my data?"
          Ambiguous: "I want to look at the data in logs.ecs.android"
          Missing guidance: The data-exploration skill description has no 'Do NOT use for' clause excluding streams-specific workflows (e.g., stream names like logs.ecs, logs.otel, processing pipelines, ingestion failures). The streams-management skill description explicitly covers document querying ('Inspect definitions, schema, quality, lifecycle, and documents') but does not exclude generic Elasticsearch index exploration. Neither skill tells the agent to defer to the other when the user's request involves both querying documents AND stream-specific context. The data-exploration skill content also has no guard against being used for streams-managed indices.
          Fix: Add a 'Do NOT use for' clause to the data-exploration description explicitly excluding Elastic streams (e.g., 'Do NOT use for Elastic streams — use streams-management instead when the user mentions stream names like logs.ecs, logs.otel, or any dot-notation child stream, or when the data source is a managed stream').
          Fix: Add a 'Do NOT use for' clause to the streams-management description excluding generic Elasticsearch index exploration that is not stream-managed (e.g., 'Do NOT use for general Elasticsearch index queries unrelated to Elastic streams').
          Fix: In the data-exploration skill content, add a routing guard at the top: if the user's target index matches a known stream naming pattern (logs.ecs.*, logs.otel.*, etc.), recommend switching to the streams-management skill.
          Fix: Differentiate the data-exploration description more sharply by scoping it to non-stream Elasticsearch indices (e.g., 'Guides agents through exploring, querying, and summarizing data stored in non-stream Elasticsearch indices and data views').
          Fix: In the streams-management description, make document querying intent more explicit as a streams-specific action (e.g., 'query or inspect documents within a stream') to help the router prefer it over data-exploration when a stream name is present.

        [MEDIUM] detection-rule-edit <-> knowledge-indicators-management
          Triggers: "ES|QL query", "detection query", "reusable ES|QL detection", "create a query", "detection logic"
          Ambiguous: "Create an ES|QL query to detect 5xx bursts in the checkout stream"
          Ambiguous: "Save this detection query for future use"
          Ambiguous: "Create a reusable detection rule for timeout spikes"
          Ambiguous: "Build a query that detects unusual login patterns"
          Ambiguous: "I want to create a query KI for this detection logic"
          Missing guidance: Skill A (detection-rule-edit) has no exclusion clause for Knowledge Indicator creation or ES|QL queries used outside of formal SIEM detection rules. Skill B (knowledge-indicators-management) has no exclusion clause for formal security detection rule creation, and does not distinguish between a 'Query KI' (an ES|QL snippet stored as operational knowledge) and a 'detection rule' (a formal SIEM rule object). A user asking to 'create an ES|QL detection query' could plausibly match either skill's description with no negative guidance to disambiguate.
          Fix: Add a 'Do NOT use for' clause to Skill A's description: 'Do NOT use for creating Knowledge Indicators (KIs) or saving reusable ES|QL snippets to Streams — use the knowledge-indicators-management skill for that.'
          Fix: Add a 'Do NOT use for' clause to Skill B's description: 'Do NOT use for creating or editing formal SIEM detection rules with fields like severity, MITRE ATT&CK, or schedule — use the detection-rule-edit skill for that.'
          Fix: Rename 'Query KI' terminology in Skill B's description to something less likely to match 'detection rule' triggers, e.g., 'reusable ES|QL operational query snippet' instead of 'reusable ES|QL-based detection query'.
          Fix: Add explicit domain anchors to both descriptions: Skill A should mention 'SIEM rule attachment' and Skill B should mention 'Streams significant events' as the primary context, making the routing context clearer to the agent.

        [MEDIUM] detection-rule-edit <-> threat-hunting
          Triggers: "ES|QL queries for detection", "MITRE ATT&CK techniques/TTPs", "converting hunt findings into detection rules", "suspicious activity patterns", "create a security detection rule", "detection strategies"
          Ambiguous: "I found suspicious lateral movement activity during my hunt — can you create a detection rule for it?"
          Ambiguous: "Convert my threat hunting query into a detection rule"
          Ambiguous: "Build an ES|QL rule to detect C2 beaconing based on periodic network connections"
          Ambiguous: "I want to detect rare process executions — can you help me write a query and turn it into a rule?"
          Ambiguous: "Create a detection rule for this MITRE ATT&CK technique T1059"
          Ambiguous: "Help me operationalize this hunt finding as a SIEM rule"
          Missing guidance: Neither skill explicitly excludes the other's domain. Skill B (threat-hunting) mentions 'Operationalize confirmed findings by converting hunt queries into detection rules' without redirecting to Skill A, which could cause the agent to attempt rule creation inside the threat-hunting skill. Skill A (detection-rule-edit) has no 'Do NOT use for threat hunting investigations' clause. Skill B has no 'Do NOT use for creating or editing detection rules' clause. The handoff between the two skills is implied but never enforced via negative guidance.
          Fix: Add explicit negative guidance to Skill B's description: 'Do NOT use for creating or editing detection rules — use detection-rule-edit for that.'
          Fix: Add explicit negative guidance to Skill A's description: 'Do NOT use for proactive threat hunting, IOC searches, or anomaly investigation — use threat-hunting for those.'
          Fix: In Skill B's content, replace the vague 'Operationalize confirmed findings by converting hunt queries into detection rules' with an explicit handoff instruction: 'To convert a hunt finding into a detection rule, switch to the detection-rule-edit skill.'
          Fix: Revise Skill B's description to remove the phrase 'converting hunt findings into actionable intelligence' or clarify it means case creation and documentation, not rule authoring.
          Fix: Add a routing disambiguation example to Skill A's description clarifying it handles rule creation even when the user mentions a prior hunt, e.g., 'Use this skill when the user wants to persist a detection as a rule, even if they discovered it during a hunt.'

        [MEDIUM] discover-data-analysis <-> observability.rca [exp]
          Triggers: "anomalies in logs or metrics", "spikes in data", "errors in service/logs", "analyze my data", "patterns and trends", "something is wrong"
          Ambiguous: "I'm seeing anomalies in my data, can you analyze them?"
          Ambiguous: "There are spikes in my error logs — what's going on?"
          Ambiguous: "Can you look at these query results and find any issues?"
          Ambiguous: "I see a lot of 500 errors in my data, can you investigate?"
          Ambiguous: "Analyze the trends in my logs and tell me if anything looks wrong"
          Ambiguous: "Something looks off in my metrics — can you take a look?"
          Missing guidance: Skill A (discover-data-analysis) has no 'Do NOT use for' clause excluding incident diagnosis, root cause analysis, or error investigation scenarios. A user asking to 'analyze errors' or 'find anomalies' in Kibana Discover could plausibly trigger either skill. Skill B (rca) does have a 'Do NOT use for' clause excluding generic analytics and reporting, but it does NOT exclude 'anomaly detection in query results' or 'pattern analysis in Discover,' which are core to Skill A. Neither skill explicitly excludes the other's primary domain when the user's phrasing is ambiguous (e.g., 'investigate errors in my data').
          Fix: Add a 'Do NOT use for' clause to Skill A's description explicitly excluding root cause analysis and incident diagnosis, e.g.: 'Do NOT use when the user is asking why something is broken, reporting an outage, or needs to diagnose a service failure — use the RCA skill instead.'
          Fix: Add a 'Do NOT use for' clause to Skill B's description excluding exploratory data analysis in Kibana Discover, e.g.: 'Do NOT use when the user is in Kibana Discover and wants to explore or summarize their ES|QL query results without a specific incident or failure to diagnose.'
          Fix: Refine Skill B's trigger phrase 'anomalies or spikes in logs or metrics' to require explicit failure/incident context, e.g.: 'anomalies or spikes that indicate a service failure or SLA breach,' to reduce overlap with Skill A's pattern-detection use case.
          Fix: Add context-anchoring language to Skill A's description to make the Kibana Discover context more prominent as a required condition, e.g.: 'Only use when the user is actively working in Kibana Discover with ES|QL query results attached.'

        [MEDIUM] discover-data-analysis <-> streams-management
          Triggers: "data quality", "analyze my data", "patterns and anomalies", "query results", "ES|QL", "ingestion failures", "documents"
          Ambiguous: "Can you check my data for quality issues?"
          Ambiguous: "Show me any anomalies in my logs.ecs stream"
          Ambiguous: "Analyze the documents in my stream"
          Ambiguous: "Are there any patterns in my ES|QL query results?"
          Ambiguous: "I'm seeing ingestion failures — can you analyze what's going wrong?"
          Ambiguous: "What does my data look like in logs.otel.linux?"
          Ambiguous: "Find correlations in my data"
          Missing guidance: Skill A (discover-data-analysis) has no exclusion clause saying 'Do NOT use for stream management, stream inspection, or ingestion pipeline issues.' Skill B (streams-management) has no exclusion clause saying 'Do NOT use for ad-hoc ES|QL analysis in Kibana Discover or general data pattern analysis unrelated to stream configuration.' The phrase 'data quality' appears in Skill B's description and is also a named on-demand capability in Skill A's content, with no mutual exclusion between the two. Similarly, 'documents' and 'ES|QL' appear as triggers in Skill B's description but are also core to Skill A's operation.
          Fix: Add a negative guidance clause to Skill A's description: 'Do NOT use for stream management, pipeline configuration, ingestion failure diagnosis, or stream-level data quality — use streams-management for those.'
          Fix: Add a negative guidance clause to Skill B's description: 'Do NOT use for ad-hoc ES|QL analysis of arbitrary Kibana Discover query results unrelated to stream configuration or management.'
          Fix: Rename or qualify 'data quality' in Skill B's description to be more specific, e.g. 'stream-level data quality metrics, schema violations, and degraded document counts' to distinguish it from general data analysis.
          Fix: In Skill A's on-demand section for data quality/correlation, add an explicit note: 'If the user is asking about stream health, ingestion failures, or pipeline issues, defer to the streams-management skill instead of running aggregation queries.'
          Fix: Consider adding a shared disambiguation preamble that the agent evaluates before routing: if the user mentions a stream name (e.g. logs.ecs, logs.otel) or the word 'stream', prefer streams-management; if the user is in Kibana Discover with an active ES|QL query attachment, prefer discover-data-analysis.

        [MEDIUM] discover-data-analysis <-> visualization-creation
          Triggers: "create a visualization", "show a chart", "visualize my data", "generate ES|QL query", "analyze and visualize", "show trends", "show distribution"
          Ambiguous: "Can you create a visualization of my data?"
          Ambiguous: "Show me a chart of the top 10 source IPs"
          Ambiguous: "Visualize the trends in my query results"
          Ambiguous: "Generate an ES|QL query and show me a chart"
          Ambiguous: "Show me a bar chart of response codes"
          Ambiguous: "Can you make a visualization showing CPU usage over time?"
          Missing guidance: Skill A (discover-data-analysis) has no 'Do NOT use for' clause excluding standalone visualization creation requests. Skill B (visualization-creation) has a partial exclusion ('Do not use this skill when the user first needs broad data discovery and exploration across unknown sources') but does not explicitly exclude requests that originate from Kibana Discover with an existing ES|QL query context. Neither skill explicitly says 'Do NOT use for visualization-only requests' (Skill A) or 'Do NOT use when the user is in Kibana Discover analyzing ES|QL results' (Skill B). The overlap is particularly acute because Skill A mandates calling createVisualization as a non-optional step, meaning visualization creation is embedded in its workflow — yet a user asking 'show me a chart' could plausibly route to Skill B instead.
          Fix: Add an explicit exclusion to Skill A's description: 'Do NOT use for standalone visualization creation requests outside of Kibana Discover or when no ES|QL query result attachment is present.'
          Fix: Add an explicit exclusion to Skill B's description: 'Do NOT use when the user is in Kibana Discover with an active ES|QL query result attachment and is asking to analyze or explore their data — use discover-data-analysis instead.'
          Fix: Rewrite Skill A's description to emphasize the Kibana Discover context and attached query results as the primary trigger signal, e.g., 'Analyzes ES|QL query results attached from Kibana Discover by running aggregation queries to identify patterns, trends, and anomalies. Requires an active ES|QL query result attachment.'
          Fix: Rewrite Skill B's description to explicitly scope it to standalone/reusable visualization creation outside of the Discover analysis flow, e.g., 'Creates standalone or reusable visualizations from a known index and field context, outside of the Kibana Discover data analysis workflow.'
          Fix: In Skill A's content, add a routing note clarifying that the embedded visualization step does not make this skill interchangeable with visualization-creation — it is a secondary output of the analysis, not the primary goal.

        [MEDIUM] entity-analytics <-> find-security-ml-jobs
          Triggers: "security entities (hosts, users, services, generic)", "unusual/anomalous behavior", "suspicious activities", "privileged users accessing critical assets", "access behaviors", "investigating entities"
          Ambiguous: "Are any users behaving suspiciously?"
          Ambiguous: "Which privileged users have been accessing critical assets?"
          Ambiguous: "Show me risky users with unusual access patterns"
          Ambiguous: "Is there anything suspicious about this host's behavior?"
          Ambiguous: "Which users have unusual login activity?"
          Ambiguous: "Are any entities doing something they shouldn't be?"
          Missing guidance: Skill A (entity-analytics) does not explicitly exclude anomaly/ML-based behavioral investigation, even though that is Skill B's domain. Skill B (find-security-ml-jobs) does not explicitly exclude risk-score-based entity investigation, even though that is Skill A's domain. Skill B references Skill A in its 'Related Skills' section, which helps somewhat, but neither skill has a 'Do NOT use for...' clause that redirects the agent away from the other skill when the query falls into the other's territory. Specifically, Skill A's description mentions 'access behaviors' and 'privilege attributes' which directly overlaps with Skill B's description of 'abnormal access patterns' and 'privileged users accessing critical assets'.
          Fix: Add a 'Do NOT use for...' clause to Skill A's description explicitly excluding ML-based anomaly detection: e.g., 'Do NOT use for investigating specific behavioral anomalies detected by ML jobs (e.g., unusual login times, geo-anomalies, large downloads) — use find-security-ml-jobs for those.'
          Fix: Add a 'Do NOT use for...' clause to Skill B's description explicitly excluding risk-score lookups: e.g., 'Do NOT use for looking up entity risk scores, risk levels, or asset criticality — use entity-analytics for those.'
          Fix: Replace the ambiguous phrase 'access behaviors' in Skill A's description with more specific language like 'risk-score-based access behavior signals' to differentiate it from Skill B's ML-driven behavioral analysis.
          Fix: Replace 'privileged users accessing critical assets' in Skill B's description with 'ML-detected anomalies involving privileged user access' to make the ML-specific nature explicit and reduce overlap with Skill A's 'privilege attributes' trigger.
          Fix: In Skill B's content, expand the 'Related Skills' section into a clearer disambiguation note that explains when to use entity-analytics instead, helping the agent self-correct if it loaded the wrong skill.

        [MEDIUM] find-security-ml-jobs <-> observability.rca [exp]
          Triggers: "anomalies or spikes in logs or metrics", "anomalous behavior", "unusual behavior", "suspicious activity", "unexpected behavior", "investigate anomalies"
          Ambiguous: "We're seeing anomalous login activity — can you investigate?"
          Ambiguous: "There are unusual spikes in network traffic from a host — what's going on?"
          Ambiguous: "Investigate the anomalies detected on this server"
          Ambiguous: "Why is this user behaving unusually?"
          Ambiguous: "We're seeing unexpected activity from an external IP — is something wrong?"
          Ambiguous: "There are anomalies in our metrics — can you find the root cause?"
          Ambiguous: "Something unusual is happening with our service — can you investigate?"
          Missing guidance: Skill B (rca) explicitly says 'Do NOT use for generic log retrieval or reporting' but does NOT exclude security anomaly investigation or ML-based behavioral analysis. Skill A (find-security-ml-jobs) has NO negative guidance at all — it does not say 'Do NOT use for service outages, performance degradations, or infrastructure failures,' which means service-level anomalies could incorrectly route to it. The word 'anomalies' appears prominently in both descriptions without domain scoping, creating a gap where neither skill excludes the other's territory.
          Fix: Add explicit negative guidance to Skill A's description: 'Do NOT use for service outages, application errors, performance degradations, or infrastructure reliability incidents — use the RCA skill for those.'
          Fix: Add explicit negative guidance to Skill B's description: 'Do NOT use for security threat investigation, suspicious user/host behavior, or ML-based security anomaly detection — use the find-security-ml-jobs skill for those.'
          Fix: Reword Skill A's description to front-load security-specific terminology more clearly, e.g., 'Guide to investigating security threats and suspicious entity behavior using ML anomaly detection — covers malicious login patterns, lateral movement, data exfiltration, and compromised accounts.'
          Fix: Reword Skill B's description to explicitly scope 'anomalies' to observability/reliability context, e.g., replace 'anomalies or spikes in logs or metrics' with 'anomalies or spikes in application/infrastructure logs or performance metrics (not security threat detection).'

        [MEDIUM] find-security-ml-jobs <-> threat-hunting
          Triggers: "anomalous behavior investigation", "lateral movement", "suspicious activity patterns", "unusual logins / authentication patterns", "anomaly identification", "large downloads / unusual data transfer", "suspicious domain activities"
          Ambiguous: "Investigate lateral movement on my network"
          Ambiguous: "Find anomalous login activity for users in my environment"
          Ambiguous: "Are there any suspicious authentication patterns I should know about?"
          Ambiguous: "Show me unusual network activity that could indicate a threat"
          Ambiguous: "Identify anomalies in user behavior over the last week"
          Ambiguous: "Look for suspicious external domain connections"
          Ambiguous: "Find users with unusual data download patterns"
          Missing guidance: Neither skill explicitly excludes the other's domain. 'find-security-ml-jobs' does not say 'Do NOT use for hypothesis-driven hunts or IOC searches.' 'threat-hunting' does not say 'Do NOT use for ML anomaly job queries or pre-built ML model results.' The threat-hunting skill's description explicitly lists 'anomaly identification' and 'lateral movement tracking' — both of which are also core triggers in find-security-ml-jobs. This creates a bidirectional gap: a user asking about anomalies or lateral movement has no signal in either description to prefer one skill over the other.
          Fix: Add explicit negative guidance to find-security-ml-jobs description: 'Do NOT use for hypothesis-driven threat hunts, IOC searches, or investigations that do not rely on pre-built Elastic ML anomaly detection jobs.'
          Fix: Add explicit negative guidance to threat-hunting description: 'Do NOT use when the investigation can be answered by querying pre-built Elastic Security ML anomaly detection jobs (use find-security-ml-jobs instead).'
          Fix: Reframe the find-security-ml-jobs description to emphasize the ML-job-specific mechanism: e.g., 'Use when you want to query Elastic Security pre-built ML anomaly detection jobs to surface scored anomalies for hosts, users, or services' — making the ML-job dependency the primary trigger rather than the generic investigation intent.
          Fix: Reframe the threat-hunting description to emphasize the hypothesis-driven, proactive, and IOC-search nature as the primary differentiator, and explicitly note it operates on raw security telemetry rather than ML anomaly indices.
          Fix: In the threat-hunting content, add a cross-reference: 'If the investigation involves querying Elastic ML anomaly scores rather than raw telemetry, use the find-security-ml-jobs skill instead.'

        [MEDIUM] graph-creation <-> observability.investigation
          Triggers: "service topology", "dependency visualization", "relationship visualization", "entity connections"
          Ambiguous: "Show me the service topology for the checkout service"
          Ambiguous: "Can you visualize the dependencies between my microservices?"
          Ambiguous: "Create a graph showing how my services are connected"
          Ambiguous: "Show me a topology map of my infrastructure"
          Ambiguous: "Visualize the relationships between my APM services"
          Missing guidance: Skill A (graph-creation) has no exclusion for observability/APM topology requests — it does not say 'Do NOT use for service topology visualization when observability data is available.' Skill B (investigation) mentions 'service topology' as a trigger in its description but does not say 'Do NOT use for generic graph/visualization requests unrelated to observability.' The most critical gap is in Skill A: a user asking to 'show service topology' or 'visualize service dependencies' could plausibly match Skill A's description ('transforming raw data into React Flow nodes and edges') even when the intent is observability investigation. Skill B's content even calls get_service_topology internally and could produce topology data that a user might then ask to visualize — creating a handoff ambiguity.
          Fix: Add a 'Do NOT use' clause to Skill A's description: 'Do NOT use for observability investigations, APM service health queries, or topology lookups that require fetching live service data — use the observability investigation skill for those.'
          Fix: Remove or qualify 'service topology' from Skill B's description trigger list, replacing it with 'service topology analysis' or 'service topology investigation' to signal that Skill B fetches and interprets topology data rather than rendering it as a graph attachment.
          Fix: Add a 'Do NOT use' clause to Skill B's description: 'Do NOT use when the user only wants to render or create a graph/diagram attachment from already-available relationship data without needing live observability data.'
          Fix: In Skill B's content, add a note that if the user wants to render the topology as a visual graph attachment after investigation, the graph-creation skill should be invoked as a follow-up step, clarifying the handoff boundary between the two skills.

        [MEDIUM] graph-creation <-> observability.service-map
          Triggers: "service dependencies", "service topology", "how services connect", "what calls what between services", "upstream/downstream dependencies", "visualize", "service map"
          Ambiguous: "Show me the dependencies between my services"
          Ambiguous: "Visualize the service topology for my application"
          Ambiguous: "Create a graph of how my services connect to each other"
          Ambiguous: "Map out the upstream and downstream dependencies for frontend"
          Ambiguous: "Show me a dependency graph for the checkout service"
          Ambiguous: "Draw a diagram of service-to-service calls"
          Missing guidance: Skill A (graph-creation) has a 'Do not use' clause for charts/tables/metrics and cases with no relationship data, but it does NOT explicitly exclude APM/observability service maps or direct the agent to prefer Skill B when the context is observability. Skill B does explicitly say 'Do not use for generic data graphing or generic architecture diagrams' and its content references the generic graph skill as a fallback — but Skill A's description contains no reciprocal exclusion. This asymmetry means the agent could load Skill A for observability service map requests because Skill A's description matches 'service dependency visualization' without any signal to prefer Skill B.
          Fix: Add an explicit 'Do NOT use for APM or observability service maps — use the observability.service-map skill instead' clause to Skill A's description so the agent has a clear signal to prefer Skill B when the context is observability or APM.
          Fix: Add domain-qualifying language to Skill A's description to anchor it to generic/non-observability use cases, e.g., 'Create graph attachments for generic relationship, architecture, or data topology visualization (not for APM/observability service maps).'
          Fix: Strengthen Skill B's description to include additional APM-specific keywords (e.g., 'APM', 'traces', 'observability platform') so it scores higher than Skill A when the user's message is clearly in an observability context.
          Fix: In Skill A's full content 'Do not use' section, add a bullet: 'The user is asking about live service topology in an APM or observability context — use the observability.service-map skill instead.'

        [MEDIUM] knowledge-indicators-management <-> observability.investigation
          Triggers: "log patterns", "recurring patterns", "error patterns", "detection query", "ES|QL query", "reusable detection logic", "anomaly conditions", "error signatures"
          Ambiguous: "Save this log pattern for future use"
          Ambiguous: "I keep seeing this error pattern in the checkout service, can we capture it?"
          Ambiguous: "Create a query to detect 5xx bursts in the payment stream"
          Ambiguous: "I want to save this recurring timeout pattern I found during investigation"
          Ambiguous: "Can you help me capture this detection logic for future investigations?"
          Ambiguous: "Store this ES|QL query for detecting latency spikes"
          Missing guidance: Skill B (investigation) has no 'Do NOT use for' clause covering KI management, knowledge capture, or saving/storing patterns and queries. Skill A (knowledge-indicators-management) has no 'Do NOT use for' clause at all — it does not exclude observability investigation tasks. When a user is mid-investigation and asks to 'save' or 'capture' a pattern, neither skill explicitly defers to the other. Skill A's proactive suggestions language ('recurring log patterns', 'error signatures', 'anomaly conditions', 'reusable ES|QL detection') closely mirrors the vocabulary used in Skill B's description ('log patterns', 'error rates'), creating a gap where the agent may load Skill A for an investigation request or Skill B for a KI-creation request.
          Fix: Add a 'Do NOT use for' clause to Skill A's description: 'Do NOT use for active investigation, diagnosing service health, analyzing traces, or answering observability questions — use the investigation skill for those tasks.'
          Fix: Add a 'Do NOT use for' clause to Skill B's description: 'Do NOT use for saving, creating, or managing Knowledge Indicators (KIs) — use the knowledge-indicators-management skill for that.'
          Fix: Differentiate Skill A's description language away from investigation vocabulary: replace 'search existing indicators' with 'store and retrieve reusable KI artifacts' and emphasize the save/create/manage intent rather than discovery/analysis intent.
          Fix: Add a handoff note in Skill B's content instructing the agent that when an investigation surfaces a reusable pattern or query worth saving, it should suggest switching to the knowledge-indicators-management skill rather than attempting to create KIs itself.
          Fix: Add a handoff note in Skill A's content clarifying that if the user needs to perform an active investigation first before capturing a KI, the investigation skill should be used, and KI creation should follow afterward.

        [MEDIUM] observability.investigation <-> observability.service-map
          Triggers: "service topology", "service dependencies", "upstream/downstream dependencies", "how services connect", "what calls what between services", "APM observability context"
          Ambiguous: "Show me the service topology for checkout"
          Ambiguous: "What are the upstream and downstream dependencies for payment-service?"
          Ambiguous: "Can you show me the dependencies for the frontend service?"
          Ambiguous: "Show me how services are connected in my APM"
          Ambiguous: "Visualize the service topology around checkout"
          Ambiguous: "Map out the dependencies for payment-service"
          Missing guidance: Skill A (investigation) does not exclude 'show/visualize service topology' requests — it lists 'service topology' as a trigger without distinguishing visualization requests from analytical ones. Skill B (service-map) does exclude text-only topology questions ('What calls checkout?' → text answer), but Skill A has no reciprocal exclusion saying 'Do NOT use when the user explicitly asks to visualize or show a service map.' The boundary between 'investigate topology' and 'show topology visually' is not enforced in Skill A's description.
          Fix: Add a negative guidance clause to Skill A's description: 'Do NOT use when the user explicitly asks to visualize, show, or render a service map or topology diagram — use the service-map skill instead.'
          Fix: Refine Skill A's description trigger for topology from the broad 'service topology' to 'service topology analysis' or 'topology-based diagnosis' to reduce collision with Skill B's visualization trigger.
          Fix: Add a positive clarifier to Skill B's description such as: 'Activates ONLY when the user wants a visual/rendered map — not for topology questions answered in text during an investigation.'
          Fix: In Skill A's full content, add a routing note under the topology step: 'If the user's primary intent is to see a visual service map rather than diagnose an issue, defer to the service-map skill instead of calling get_service_topology directly.'

        [MEDIUM] observability.rca [exp] <-> streams-management
          Triggers: "ingestion failures", "data quality", "stream errors", "something is wrong with stream X / data pipeline Y", "anomalies in logs or metrics", "investigate errors in a service/stream", "processing pipeline issues"
          Ambiguous: "Why is my logs.ecs.nginx stream showing errors?"
          Ambiguous: "There are ingestion failures in my stream — what's wrong?"
          Ambiguous: "My data pipeline is broken, can you help?"
          Ambiguous: "I'm seeing anomalies in stream logs.otel.linux — what happened?"
          Ambiguous: "Why are documents failing in my stream?"
          Ambiguous: "Something is wrong with stream logs.ecs.android"
          Ambiguous: "My processing pipeline is causing errors — root cause?"
          Ambiguous: "Why is data not arriving in my stream correctly?"
          Missing guidance: The RCA skill explicitly mentions 'What's wrong with stream X / data pipeline Y?' as a trigger example in its content, directly overlapping with the streams-management skill's core domain. The RCA skill's description says 'when they see anomalies or spikes in logs or metrics' which could match stream data quality issues. The streams-management skill has no 'Do NOT use for' clause excluding failure diagnosis or root cause analysis. The RCA skill's 'Do NOT use for' clause does not exclude stream-specific investigations. Neither skill explicitly defers to the other when stream names are mentioned alongside failure symptoms.
          Fix: Add a 'Do NOT use for' clause to the RCA skill description explicitly excluding Elastic stream management tasks: 'Do NOT use for: inspecting, modifying, or diagnosing Elastic stream definitions, processing pipelines, field mappings, or ingestion configuration — use the streams-management skill instead.'
          Fix: Add a 'Do NOT use for' clause to the streams-management skill description: 'Do NOT use for: general root cause analysis of application errors, service outages, latency spikes, or infrastructure failures unrelated to stream configuration.'
          Fix: Remove or qualify the 'What's wrong with stream X / data pipeline Y?' example from the RCA skill's content, or annotate it to clarify it refers to application-level data pipelines (e.g., Kafka, Flink) rather than Elastic ingest streams.
          Fix: Add a routing handoff note in the streams-management skill content: 'If the user's question is about why an application or service is failing (not about stream configuration or ingestion), defer to the RCA skill.'
          Fix: Clarify the streams-management description to distinguish 'ingestion failures' (documents failing to ingest due to mapping/processing errors) from 'service errors' (application-level failures), so the agent can distinguish stream config problems from broader system failures.

        [MEDIUM] search.catalog-ecommerce <-> search.vector-hybrid-search
          Triggers: "find similar products", "semantic search for products", "product search with meaning-based matching", "embeddings for product catalog", "hybrid search for e-commerce"
          Ambiguous: "I want to build a product search that understands what users mean, not just exact keywords"
          Ambiguous: "How do I find similar products using embeddings in Elasticsearch?"
          Ambiguous: "I want to add semantic search to my product catalog"
          Ambiguous: "Can I use kNN to improve my product recommendations?"
          Ambiguous: "I want hybrid search for my e-commerce site"
          Ambiguous: "How do I make my product search understand natural language queries?"
          Missing guidance: Skill A (catalog-ecommerce) mentions 'If they need meaning-based find similar products, combine this with the vector-hybrid-search approach' but does not explicitly say 'Do NOT use this skill for semantic/vector search.' Skill B (vector-hybrid-search) has no exclusion clause for e-commerce or product catalog contexts at all — it does not say 'Do NOT use for pure faceted/filter-based product search without semantic intent.' Neither skill explicitly guards against the overlap zone of semantic or hybrid product search, which is a realistic and common developer use case.
          Fix: Add a 'Do NOT use for' clause to Skill B's description: e.g., 'Do NOT use when the primary need is faceted navigation, product filtering by attributes, autocomplete, or merchandising — use catalog-ecommerce for those.'
          Fix: Add a 'Do NOT use for' clause to Skill A's description: e.g., 'Do NOT use when the developer primarily wants semantic/meaning-based search, embeddings, kNN, or hybrid BM25+kNN — use vector-hybrid-search for those, or combine both skills for semantic product search.'
          Fix: Add a combined-skill routing hint to both descriptions explicitly: e.g., 'For semantic or hybrid product search (meaning-based + faceted), load BOTH catalog-ecommerce AND vector-hybrid-search.' This prevents the agent from picking just one when both are needed.
          Fix: In Skill A's content Section 1 'When to Use This Guide,' the existing note about 'find similar products' should be elevated to the description field so the routing agent can act on it before loading the skill.

        [MEDIUM] search.elasticsearch-onboarding <-> search.rag-chatbot
          Triggers: "build a chatbot", "Q&A over my data", "AI assistant", "RAG pipeline", "answer questions from my docs", "getting started with RAG", "help me build a chatbot"
          Ambiguous: "I want to build a Q&A chatbot that answers questions from our docs"
          Ambiguous: "Help me get started with a RAG pipeline using LangChain"
          Ambiguous: "I'm new to Elasticsearch and want to build an AI assistant"
          Ambiguous: "How do I build a chatbot over my knowledge base?"
          Ambiguous: "I want to try building a RAG system with Elasticsearch"
          Ambiguous: "Can you walk me through setting up a Q&A system over my documents?"
          Missing guidance: Skill A (elasticsearch-onboarding) explicitly lists RAG/chatbot as a downstream skill to invoke (/rag-chatbot), but its description still claims to match messages like 'I want to build a Q&A chatbot that answers questions from our docs' as an example first message — meaning the agent could load Skill A instead of Skill B for a clearly RAG-specific request. Skill B's description does not say 'Do NOT use for general onboarding or first-time Elasticsearch users,' so a user who is both new to Elasticsearch AND wants a RAG chatbot could plausibly trigger either skill. Neither description explicitly excludes the other's primary trigger patterns.
          Fix: Remove 'I want to build a Q&A chatbot that answers questions from our docs' from Skill A's description examples, or add a qualifier like '(if they need end-to-end onboarding first)' to clarify it only applies when the user is also new/exploratory.
          Fix: Add explicit negative guidance to Skill A's description: 'Do NOT load this skill when the user's request is specifically and solely about building a RAG pipeline, chatbot, or Q&A system and they show no signs of needing general onboarding — prefer /rag-chatbot directly.'
          Fix: Add explicit negative guidance to Skill B's description: 'Do NOT use for general Elasticsearch onboarding or when the user is new to Elasticsearch and needs end-to-end setup guidance — prefer /elasticsearch-onboarding first.'
          Fix: In Skill A's description, reframe the RAG/chatbot example as a downstream case: e.g., 'If the user wants to build a RAG chatbot AND needs onboarding, load this skill; if they already know what they want and just need RAG implementation, load /rag-chatbot directly.'
          Fix: Consider adding a routing priority rule to Skill B's description stating it should be preferred over Skill A when the user's message contains explicit RAG/chatbot terminology combined with a clear implementation intent (not just exploration).

        [MEDIUM] search.elasticsearch-onboarding <-> search.vector-hybrid-search
          Triggers: "semantic search", "vector search", "hybrid search", "kNN", "embeddings", "Elasticsearch as a vector database", "build search", "getting started with vector/semantic search"
          Ambiguous: "I want to use Elasticsearch as a vector database for my AI app"
          Ambiguous: "How do I get started with semantic search in Elasticsearch?"
          Ambiguous: "I want to build hybrid search — where do I begin?"
          Ambiguous: "Help me set up kNN search from scratch"
          Ambiguous: "I'm new to Elasticsearch and want to do vector search"
          Ambiguous: "Walk me through building semantic search with Elasticsearch"
          Missing guidance: Skill B (vector-hybrid-search) has no 'Do NOT use for' clause in its description to exclude onboarding/getting-started scenarios. A user saying 'I want to get started with vector search' matches both descriptions equally — Skill A because of 'get started / onboarding / build search', and Skill B because of 'wants semantic search, hybrid search, kNN, embeddings'. Skill A's description does mention preferring Skill B for 'deep hybrid vector tuning only', but this is in the full content, not the description the agent uses for routing. Neither description explicitly says 'Do NOT load this skill if the user is in an onboarding arc' (Skill B) or 'Do NOT load this skill if the user only asks about vector/semantic search specifically' (Skill A).
          Fix: Add a 'Do NOT use for' clause to Skill B's description, e.g.: 'Do NOT load this skill as the first skill in a conversation; if the user is new, onboarding, or asking where to start — even for vector/semantic topics — load /elasticsearch-onboarding first.'
          Fix: Add a scoping qualifier to Skill B's description to restrict it to deep/implementation-phase use, e.g.: 'Use only when the user is already past initial onboarding and needs deep implementation detail on vector or hybrid search patterns.'
          Fix: Add a 'Do NOT use for' clause to Skill A's description to clarify it should not be bypassed when the user's message contains explicit vector/semantic keywords, reinforcing that it is the entry point regardless of topic specificity: 'Load this skill even when the user mentions vector search, semantic search, or kNN — if they are starting out or need guided setup.'
          Fix: Move the routing note currently buried in Skill A's full content ('Usually invoke a different skill first when the request is narrowly about one pattern only') into Skill A's description so the agent can use it at routing time, not just after loading.

        [MEDIUM] search.rag-chatbot <-> search.use-case-library
          Triggers: "chatbot", "AI assistant", "Q&A over my data", "answer questions from my data", "knowledge base", "RAG pipeline", "build a chatbot"
          Ambiguous: "I want to build a chatbot for my company's knowledge base"
          Ambiguous: "Can I use Elasticsearch to build an AI assistant?"
          Ambiguous: "What does Elasticsearch support for building Q&A systems?"
          Ambiguous: "I want to build something like ChatGPT over my docs — what can Elastic do for that?"
          Ambiguous: "What use cases does Elasticsearch support for AI-powered assistants?"
          Ambiguous: "I'm thinking about building a RAG system — is that something Elasticsearch can do?"
          Missing guidance: Skill B (use-case-library) has no 'Do NOT use' clause excluding it when the developer already knows they want to build a RAG/chatbot system and is ready to implement. Skill A (rag-chatbot) correctly excludes pure search-results use cases, but does not exclude exploratory 'what can I build?' questions that Skill B owns. Neither skill explicitly tells the agent to prefer the other when the user's message combines exploration ('what can Elastic do for chatbots?') with implementation intent ('I want to build a chatbot').
          Fix: Add a 'Do NOT use for' clause to Skill B's description: 'Do NOT use when the developer has already decided to build a chatbot or RAG system and is asking how to implement it — use rag-chatbot instead.'
          Fix: Add a 'Do NOT use for' clause to Skill A's description: 'Do NOT use when the developer is still exploring what to build or asking what Elasticsearch supports — use use-case-library instead.'
          Fix: Reword Skill B's description trigger to emphasize the exploratory/discovery intent more sharply, e.g., replace 'needs help choosing what to build' with 'is undecided about their use case and needs to explore options before committing to a direction.'
          Fix: In Skill B's Use Case #3 content, add an explicit handoff note: 'If the user confirms they want to build a chatbot or RAG system, load the rag-chatbot skill for detailed implementation guidance.' This mirrors the onboarding handoff pattern already present in both skills.

        [MEDIUM] search.rag-chatbot <-> search.vector-hybrid-search
          Triggers: "embeddings", "vector search", "kNN retrieval", "semantic search", "dense_vector", "embedding strategies", "Elasticsearch as a vector store/database", "RAG pipeline"
          Ambiguous: "I want to build a RAG system using Elasticsearch as a vector store"
          Ambiguous: "How do I set up kNN search for my chatbot?"
          Ambiguous: "I need to embed my documents and search them semantically to power a Q&A bot"
          Ambiguous: "What's the best way to use dense_vector for a question-answering system?"
          Ambiguous: "I want to use Elasticsearch with embeddings to answer questions from my docs"
          Ambiguous: "How do I do hybrid search for a retrieval-augmented generation pipeline?"
          Missing guidance: Skill A (rag-chatbot) explicitly says 'Do NOT use this guide when the developer only needs search results (not generated answers)' — this partially excludes Skill B's domain. However, Skill B (vector-hybrid-search) has NO reciprocal exclusion clause saying 'Do NOT use for RAG pipelines, chatbots, or Q&A systems where generated answers are needed.' This is the primary gap: a user asking about vector search in the context of a RAG pipeline or chatbot could plausibly trigger Skill B, which lacks any guidance to redirect to Skill A. Additionally, Skill A's content covers dense_vector mappings, embedding ingestion pipelines, and kNN retrieval — all core topics of Skill B — without explicitly deferring to Skill B for those subtopics.
          Fix: Add an explicit negative guidance clause to Skill B's description: 'Do NOT use when the developer wants a chatbot, Q&A system, or generated answers from documents — use rag-chatbot instead.'
          Fix: Add an explicit positive redirect to Skill A's description: 'For the vector search and embedding infrastructure underlying RAG, this skill covers the retrieval layer; use vector-hybrid-search only if the developer needs pure semantic/hybrid search without answer generation.'
          Fix: In Skill A's content, add a cross-reference note in the embedding/kNN sections stating: 'For deeper coverage of vector field types, hybrid BM25+kNN, and reranking outside of RAG, see the vector-hybrid-search skill.'
          Fix: Differentiate the descriptions more sharply by emphasizing the output type: Skill A's description should prominently feature 'generated answers' and 'LLM,' while Skill B's description should prominently feature 'search results' and 'relevance ranking' to make the routing boundary clear to the agent.

        [MEDIUM] search.use-case-library <-> search.vector-hybrid-search
          Triggers: "semantic search", "hybrid search", "knowledge base search", "AI-powered assistant / chatbot", "RAG pipeline", "vector search", "embeddings", "what can I build with Elasticsearch"
          Ambiguous: "I want to build a semantic search over my documents"
          Ambiguous: "How do I set up hybrid search for my knowledge base?"
          Ambiguous: "I want to build a chatbot that searches my company docs using embeddings"
          Ambiguous: "What's the best way to use Elasticsearch for RAG?"
          Ambiguous: "I need vector search for my product catalog"
          Ambiguous: "Can Elasticsearch do semantic search? What would that look like for my use case?"
          Missing guidance: Neither skill explicitly says 'Do NOT use for...' to exclude the other's domain. Skill A (use-case-library) covers semantic search, hybrid search, RAG, and vector search within its use case descriptions (Knowledge Base, AI Assistant, Recommendations), which are the primary domain of Skill B (vector-hybrid-search). Skill B does not say 'Do not use this for use case exploration or discovery.' Skill A does not say 'Do not use this for implementation-level vector/hybrid search questions.' A developer asking about semantic search or hybrid search could plausibly trigger either skill depending on how the question is phrased.
          Fix: Add a 'Do NOT use for' clause to Skill A's description: 'Do NOT use when the developer already knows their use case and is asking how to implement vector search, hybrid search, kNN, or embeddings — use search.vector-hybrid-search instead.'
          Fix: Add a 'Do NOT use for' clause to Skill B's description: 'Do NOT use when the developer is still exploring what to build or asking what Elasticsearch supports — use search.use-case-library instead.'
          Fix: In Skill A's description, replace or supplement the generic mention of 'hybrid search' and 'semantic search' in use case summaries with a forward pointer: 'For implementation details on vector/hybrid search, the agent will load search.vector-hybrid-search after use case selection.'
          Fix: Add an explicit handoff trigger in Skill A's content: once a use case involving vector/hybrid search is confirmed, explicitly instruct the agent to load search.vector-hybrid-search before proceeding to onboarding, so the routing decision is made programmatically rather than left to description matching.

```
</details>