### PR TITLE
[9.4] [Cases][Docs] - Add additional examples and cleanup to openApi (#263617)

### DIFF
--- a/src/platform/packages/private/kbn-validate-oas/src/oas_error_baseline.json
+++ b/src/platform/packages/private/kbn-validate-oas/src/oas_error_baseline.json
@@ -1,4 +1,4 @@
 {
-  "./oas_docs/output/kibana.yaml": 821,
+  "./oas_docs/output/kibana.yaml": 796,
   "./oas_docs/output/kibana.serverless.yaml": 723
 }

--- a/x-pack/platform/plugins/shared/cases/common/bundled-types.gen.ts
+++ b/x-pack/platform/plugins/shared/cases/common/bundled-types.gen.ts
@@ -691,6 +691,11 @@ export const CaseResponseProperties = lazySchema(() =>
     external_service: ExternalService,
     id: z.string(),
     /**
+      * A monotonically increasing number assigned to each case, unique per space. This value is generated asynchronously after the case is created and may not be present immediately in the response.
+
+      */
+    incremental_id: z.number().int().nullable().optional(),
+    /**
      * Observables attached to the case.
      */
     observables: z.array(CaseObservable),
@@ -1184,6 +1189,11 @@ export const CaseResponseGetCase = lazySchema(() =>
     duration: z.number().int().nullable(),
     external_service: ExternalService,
     id: z.string(),
+    /**
+      * A monotonically increasing number assigned to each case, unique per space. This value is generated asynchronously after the case is created and may not be present immediately in the response.
+
+      */
+    incremental_id: z.number().int().nullable().optional(),
     /**
      * Observables attached to the case.
      */
@@ -1720,16 +1730,21 @@ export const UserActionsFindResponseProperties = lazySchema(() =>
      */
     type: z.enum([
       'assignees',
-      'create_case',
+      'category',
       'comment',
       'connector',
+      'create_case',
+      'customFields',
+      'delete_case',
       'description',
+      'extended_fields',
+      'observables',
       'pushed',
-      'tags',
-      'title',
-      'status',
       'settings',
       'severity',
+      'status',
+      'tags',
+      'title',
     ]),
   })
 );

--- a/x-pack/platform/plugins/shared/cases/docs/openapi/bundled-types.json
+++ b/x-pack/platform/plugins/shared/cases/docs/openapi/bundled-types.json
@@ -74,6 +74,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/response_4xx"
+                },
+                "examples": {
+                  "response401": {
+                    "$ref": "#/components/examples/response_401"
+                  }
                 }
               }
             }
@@ -105,6 +110,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/response_4xx"
+                },
+                "examples": {
+                  "response401": {
+                    "$ref": "#/components/examples/response_401"
+                  }
                 }
               }
             }
@@ -174,6 +184,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/response_4xx"
+                },
+                "examples": {
+                  "response401": {
+                    "$ref": "#/components/examples/response_401"
+                  }
                 }
               }
             }
@@ -288,6 +303,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/response_4xx"
+                },
+                "examples": {
+                  "response401": {
+                    "$ref": "#/components/examples/response_401"
+                  }
                 }
               }
             }
@@ -322,21 +342,26 @@
                   "maxItems": 10000,
                   "items": {
                     "$ref": "#/components/schemas/related_case"
-                  },
-                  "example": [
-                    {
-                      "id": "06116b80-e1c3-11ec-be9b-9b1838238ee6",
-                      "title": "security_case",
-                      "description": "Investigating suspicious activity",
-                      "status": "open",
-                      "createdAt": "2020-02-19T23:06:33.798Z",
-                      "totals": {
-                        "alerts": 1,
-                        "events": 0,
-                        "userComments": 0
+                  }
+                },
+                "examples": {
+                  "getCasesByAlertResponse": {
+                    "summary": "Cases associated with a given alert.",
+                    "value": [
+                      {
+                        "id": "06116b80-e1c3-11ec-be9b-9b1838238ee6",
+                        "title": "security_case",
+                        "description": "Investigating suspicious activity",
+                        "status": "open",
+                        "createdAt": "2020-02-19T23:06:33.798Z",
+                        "totals": {
+                          "alerts": 1,
+                          "events": 0,
+                          "userComments": 0
+                        }
                       }
-                    }
-                  ]
+                    ]
+                  }
                 }
               }
             }
@@ -347,6 +372,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/response_4xx"
+                },
+                "examples": {
+                  "response401": {
+                    "$ref": "#/components/examples/response_401"
+                  }
                 }
               }
             }
@@ -510,6 +540,25 @@
                           }
                         }
                       },
+                      "observableTypes": {
+                        "type": "array",
+                        "description": "Custom observable type configuration details.",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "key": {
+                              "type": "string",
+                              "description": "The observable type key.",
+                              "example": "d312efda-ec2b-42ec-9e2c-84981795c581"
+                            },
+                            "label": {
+                              "type": "string",
+                              "description": "The observable type label.",
+                              "example": "My observable type"
+                            }
+                          }
+                        }
+                      },
                       "owner": {
                         "$ref": "#/components/schemas/owner"
                       },
@@ -573,6 +622,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/response_4xx"
+                },
+                "examples": {
+                  "response401": {
+                    "$ref": "#/components/examples/response_401"
+                  }
                 }
               }
             }
@@ -746,6 +800,25 @@
                         }
                       }
                     },
+                    "observableTypes": {
+                      "type": "array",
+                      "description": "Custom observable type configuration details.",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "key": {
+                            "type": "string",
+                            "description": "The observable type key.",
+                            "example": "d312efda-ec2b-42ec-9e2c-84981795c581"
+                          },
+                          "label": {
+                            "type": "string",
+                            "description": "The observable type label.",
+                            "example": "My observable type"
+                          }
+                        }
+                      }
+                    },
                     "owner": {
                       "$ref": "#/components/schemas/owner"
                     },
@@ -808,6 +881,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/response_4xx"
+                },
+                "examples": {
+                  "response401": {
+                    "$ref": "#/components/examples/response_401"
+                  }
                 }
               }
             }
@@ -986,6 +1064,25 @@
                         }
                       }
                     },
+                    "observableTypes": {
+                      "type": "array",
+                      "description": "Custom observable type configuration details.",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "key": {
+                            "type": "string",
+                            "description": "The observable type key.",
+                            "example": "d312efda-ec2b-42ec-9e2c-84981795c581"
+                          },
+                          "label": {
+                            "type": "string",
+                            "description": "The observable type label.",
+                            "example": "My observable type"
+                          }
+                        }
+                      }
+                    },
                     "owner": {
                       "$ref": "#/components/schemas/owner"
                     },
@@ -1048,6 +1145,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/response_4xx"
+                },
+                "examples": {
+                  "response401": {
+                    "$ref": "#/components/examples/response_401"
+                  }
                 }
               }
             }
@@ -1120,6 +1222,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/response_4xx"
+                },
+                "examples": {
+                  "response401": {
+                    "$ref": "#/components/examples/response_401"
+                  }
                 }
               }
             }
@@ -1166,6 +1273,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/response_4xx"
+                },
+                "examples": {
+                  "response401": {
+                    "$ref": "#/components/examples/response_401"
+                  }
                 }
               }
             }
@@ -1211,6 +1323,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/response_4xx"
+                },
+                "examples": {
+                  "response401": {
+                    "$ref": "#/components/examples/response_401"
+                  }
                 }
               }
             }
@@ -1257,6 +1374,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/response_4xx"
+                },
+                "examples": {
+                  "response401": {
+                    "$ref": "#/components/examples/response_401"
+                  }
                 }
               }
             }
@@ -1317,6 +1439,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/response_4xx"
+                },
+                "examples": {
+                  "response401": {
+                    "$ref": "#/components/examples/response_401"
+                  }
                 }
               }
             }
@@ -1348,11 +1475,28 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/response_4xx"
+                },
+                "examples": {
+                  "response401": {
+                    "$ref": "#/components/examples/response_401"
+                  }
                 }
               }
             }
           }
-        }
+        },
+        "x-codeSamples": [
+          {
+            "label": "curl",
+            "lang": "curl",
+            "source": "curl \\\n  --request DELETE 'https://localhost:5601/api/cases/9c235210-6834-11ea-a78c-6ffb38a34414/comments' \\\n  --header \"Authorization: $API_KEY\" \\\n  --header \"kbn-xsrf: true\"\n"
+          },
+          {
+            "label": "Console",
+            "lang": "console",
+            "source": "DELETE kbn:/api/cases/9c235210-6834-11ea-a78c-6ffb38a34414/comments\n"
+          }
+        ]
       },
       "patch": {
         "summary": "Update a case comment or alert",
@@ -1406,6 +1550,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/response_4xx"
+                },
+                "examples": {
+                  "response401": {
+                    "$ref": "#/components/examples/response_401"
+                  }
                 }
               }
             }
@@ -1457,6 +1606,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/response_4xx"
+                },
+                "examples": {
+                  "response401": {
+                    "$ref": "#/components/examples/response_401"
+                  }
                 }
               }
             }
@@ -1493,11 +1647,28 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/response_4xx"
+                },
+                "examples": {
+                  "response401": {
+                    "$ref": "#/components/examples/response_401"
+                  }
                 }
               }
             }
           }
-        }
+        },
+        "x-codeSamples": [
+          {
+            "label": "curl",
+            "lang": "curl",
+            "source": "curl \\\n  --request DELETE 'https://localhost:5601/api/cases/9c235210-6834-11ea-a78c-6ffb38a34414/comments/71ec1870-725b-11ea-a0b2-c51ea50a58e2' \\\n  --header \"Authorization: $API_KEY\" \\\n  --header \"kbn-xsrf: true\"\n"
+          },
+          {
+            "label": "Console",
+            "lang": "console",
+            "source": "DELETE kbn:/api/cases/9c235210-6834-11ea-a78c-6ffb38a34414/comments/71ec1870-725b-11ea-a0b2-c51ea50a58e2\n"
+          }
+        ]
       },
       "get": {
         "summary": "Get a case comment or alert",
@@ -1543,6 +1714,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/response_4xx"
+                },
+                "examples": {
+                  "response401": {
+                    "$ref": "#/components/examples/response_401"
+                  }
                 }
               }
             }
@@ -1575,6 +1751,12 @@
               "schema": {
                 "type": "object",
                 "nullable": true
+              },
+              "examples": {
+                "pushCaseRequest": {
+                  "summary": "Push a case to an external service. No request body is required.",
+                  "value": null
+                }
               }
             }
           }
@@ -1601,6 +1783,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/response_4xx"
+                },
+                "examples": {
+                  "response401": {
+                    "$ref": "#/components/examples/response_401"
+                  }
                 }
               }
             }
@@ -1673,6 +1860,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/response_4xx"
+                },
+                "examples": {
+                  "response401": {
+                    "$ref": "#/components/examples/response_401"
+                  }
                 }
               }
             }
@@ -1749,6 +1941,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/response_4xx"
+                },
+                "examples": {
+                  "response401": {
+                    "$ref": "#/components/examples/response_401"
+                  }
                 }
               }
             }
@@ -1778,6 +1975,14 @@
             "multipart/form-data": {
               "schema": {
                 "$ref": "#/components/schemas/add_case_file_request"
+              },
+              "examples": {
+                "addCaseFileRequest": {
+                  "summary": "Attach a plain text file named \"my_attachment\".",
+                  "value": {
+                    "filename": "my_attachment"
+                  }
+                }
               }
             }
           }
@@ -1804,11 +2009,23 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/response_4xx"
+                },
+                "examples": {
+                  "response401": {
+                    "$ref": "#/components/examples/response_401"
+                  }
                 }
               }
             }
           }
-        }
+        },
+        "x-codeSamples": [
+          {
+            "label": "curl",
+            "lang": "curl",
+            "source": "curl \\\n  --request POST 'https://localhost:5601/api/cases/9c235210-6834-11ea-a78c-6ffb38a34414/files' \\\n  --header \"Authorization: $API_KEY\" \\\n  --header \"kbn-xsrf: true\" \\\n  --form \"file=@/path/to/my_attachment.txt\" \\\n  --form \"filename=my_attachment\"\n"
+          }
+        ]
       }
     }
   },
@@ -1911,7 +2128,8 @@
         "schema": {
           "type": "integer",
           "default": 1
-        }
+        },
+        "example": 1
       },
       "page_size": {
         "in": "query",
@@ -1922,7 +2140,8 @@
           "type": "integer",
           "default": 20,
           "maximum": 100
-        }
+        },
+        "example": 20
       },
       "reporters": {
         "in": "query",
@@ -1946,7 +2165,8 @@
         "description": "An Elasticsearch simple_query_string query that filters the objects in the response.",
         "schema": {
           "type": "string"
-        }
+        },
+        "example": "Case title 1"
       },
       "searchFields": {
         "in": "query",
@@ -1975,7 +2195,8 @@
             "low",
             "medium"
           ]
-        }
+        },
+        "example": "low"
       },
       "sortField": {
         "in": "query",
@@ -2008,7 +2229,8 @@
             "desc"
           ],
           "default": "desc"
-        }
+        },
+        "example": "desc"
       },
       "status": {
         "in": "query",
@@ -2715,6 +2937,98 @@
           "username"
         ]
       },
+      "case_response_created_by_properties": {
+        "title": "Case response properties for created_by",
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string",
+            "example": null,
+            "nullable": true
+          },
+          "full_name": {
+            "type": "string",
+            "example": null,
+            "nullable": true
+          },
+          "username": {
+            "type": "string",
+            "example": "elastic",
+            "nullable": true
+          },
+          "profile_uid": {
+            "type": "string",
+            "example": "u_J41Oh6L9ki-Vo2tOogS8WRTENzhHurGtRc87NgEAlkc_0"
+          }
+        },
+        "required": [
+          "email",
+          "full_name",
+          "username"
+        ]
+      },
+      "case_response_pushed_by_properties": {
+        "title": "Case response properties for pushed_by",
+        "type": "object",
+        "nullable": true,
+        "properties": {
+          "email": {
+            "type": "string",
+            "example": null,
+            "nullable": true
+          },
+          "full_name": {
+            "type": "string",
+            "example": null,
+            "nullable": true
+          },
+          "username": {
+            "type": "string",
+            "example": "elastic",
+            "nullable": true
+          },
+          "profile_uid": {
+            "type": "string",
+            "example": "u_J41Oh6L9ki-Vo2tOogS8WRTENzhHurGtRc87NgEAlkc_0"
+          }
+        },
+        "required": [
+          "email",
+          "full_name",
+          "username"
+        ]
+      },
+      "case_response_updated_by_properties": {
+        "title": "Case response properties for updated_by",
+        "type": "object",
+        "nullable": true,
+        "properties": {
+          "email": {
+            "type": "string",
+            "example": null,
+            "nullable": true
+          },
+          "full_name": {
+            "type": "string",
+            "example": null,
+            "nullable": true
+          },
+          "username": {
+            "type": "string",
+            "example": "elastic",
+            "nullable": true
+          },
+          "profile_uid": {
+            "type": "string",
+            "example": "u_J41Oh6L9ki-Vo2tOogS8WRTENzhHurGtRc87NgEAlkc_0"
+          }
+        },
+        "required": [
+          "email",
+          "full_name",
+          "username"
+        ]
+      },
       "actions_comment_response_properties": {
         "title": "Case response properties for actions comments",
         "type": "object",
@@ -3084,98 +3398,6 @@
           }
         }
       },
-      "case_response_created_by_properties": {
-        "title": "Case response properties for created_by",
-        "type": "object",
-        "properties": {
-          "email": {
-            "type": "string",
-            "example": null,
-            "nullable": true
-          },
-          "full_name": {
-            "type": "string",
-            "example": null,
-            "nullable": true
-          },
-          "username": {
-            "type": "string",
-            "example": "elastic",
-            "nullable": true
-          },
-          "profile_uid": {
-            "type": "string",
-            "example": "u_J41Oh6L9ki-Vo2tOogS8WRTENzhHurGtRc87NgEAlkc_0"
-          }
-        },
-        "required": [
-          "email",
-          "full_name",
-          "username"
-        ]
-      },
-      "case_response_pushed_by_properties": {
-        "title": "Case response properties for pushed_by",
-        "type": "object",
-        "nullable": true,
-        "properties": {
-          "email": {
-            "type": "string",
-            "example": null,
-            "nullable": true
-          },
-          "full_name": {
-            "type": "string",
-            "example": null,
-            "nullable": true
-          },
-          "username": {
-            "type": "string",
-            "example": "elastic",
-            "nullable": true
-          },
-          "profile_uid": {
-            "type": "string",
-            "example": "u_J41Oh6L9ki-Vo2tOogS8WRTENzhHurGtRc87NgEAlkc_0"
-          }
-        },
-        "required": [
-          "email",
-          "full_name",
-          "username"
-        ]
-      },
-      "case_response_updated_by_properties": {
-        "title": "Case response properties for updated_by",
-        "type": "object",
-        "nullable": true,
-        "properties": {
-          "email": {
-            "type": "string",
-            "example": null,
-            "nullable": true
-          },
-          "full_name": {
-            "type": "string",
-            "example": null,
-            "nullable": true
-          },
-          "username": {
-            "type": "string",
-            "example": "elastic",
-            "nullable": true
-          },
-          "profile_uid": {
-            "type": "string",
-            "example": "u_J41Oh6L9ki-Vo2tOogS8WRTENzhHurGtRc87NgEAlkc_0"
-          }
-        },
-        "required": [
-          "email",
-          "full_name",
-          "username"
-        ]
-      },
       "external_service": {
         "type": "object",
         "nullable": true,
@@ -3352,10 +3574,10 @@
               "discriminator": {
                 "propertyName": "type",
                 "mapping": {
-                  "actions": "#/components/schemas/actions_comment_response_properties",
-                  "alert": "#/components/schemas/alert_comment_response_properties",
-                  "event": "#/components/schemas/event_comment_response_properties",
-                  "user": "#/components/schemas/user_comment_response_properties"
+                  "actions": "actions_comment_response_properties.yaml",
+                  "alert": "alert_comment_response_properties.yaml",
+                  "event": "event_comment_response_properties.yaml",
+                  "user": "user_comment_response_properties.yaml"
                 }
               }
             }
@@ -3388,13 +3610,13 @@
             "discriminator": {
               "propertyName": "type",
               "mapping": {
-                ".none": "#/components/schemas/connector_properties_none",
-                ".cases-webhook": "#/components/schemas/connector_properties_cases_webhook",
-                ".jira": "#/components/schemas/connector_properties_jira",
-                ".resilient": "#/components/schemas/connector_properties_resilient",
-                ".servicenow": "#/components/schemas/connector_properties_servicenow",
-                ".servicenow-sir": "#/components/schemas/connector_properties_servicenow_sir",
-                ".swimlane": "#/components/schemas/connector_properties_swimlane"
+                ".none": "connector_properties_none.yaml",
+                ".cases-webhook": "connector_properties_cases_webhook.yaml",
+                ".jira": "connector_properties_jira.yaml",
+                ".resilient": "connector_properties_resilient.yaml",
+                ".servicenow": "connector_properties_servicenow.yaml",
+                ".servicenow-sir": "connector_properties_servicenow_sir.yaml",
+                ".swimlane": "connector_properties_swimlane.yaml"
               }
             }
           },
@@ -3457,6 +3679,12 @@
           "id": {
             "type": "string",
             "example": "66b9aa00-94fa-11ea-9f74-e7e108796192"
+          },
+          "incremental_id": {
+            "type": "integer",
+            "description": "A monotonically increasing number assigned to each case, unique per space. This value is generated asynchronously after the case is created and may not be present immediately in the response.\n",
+            "nullable": true,
+            "example": 1
           },
           "observables": {
             "type": "array",
@@ -3539,6 +3767,25 @@
             "example": 401
           }
         }
+      },
+      "case_close_sync_reason": {
+        "description": "The close reason to sync to attached alerts when closing the case. Can be one of following predefined reasons: [false_positive, duplicate, true_positive, benign_positive, automated_closure, other] or a custom reason provided by the user.\n",
+        "oneOf": [
+          {
+            "type": "string",
+            "enum": [
+              "false_positive",
+              "duplicate",
+              "true_positive",
+              "benign_positive",
+              "automated_closure",
+              "other"
+            ]
+          },
+          {
+            "type": "string"
+          }
+        ]
       },
       "update_case_request": {
         "title": "Update case request",
@@ -3655,6 +3902,9 @@
                 },
                 "title": {
                   "$ref": "#/components/schemas/case_title"
+                },
+                "closeReason": {
+                  "$ref": "#/components/schemas/case_close_sync_reason"
                 },
                 "version": {
                   "description": "The current version of the case. To determine this value, use the get case or search cases (`_find`) APIs.\n",
@@ -4179,13 +4429,13 @@
             "discriminator": {
               "propertyName": "type",
               "mapping": {
-                ".none": "#/components/schemas/connector_properties_none",
-                ".cases-webhook": "#/components/schemas/connector_properties_cases_webhook",
-                ".jira": "#/components/schemas/connector_properties_jira",
-                ".resilient": "#/components/schemas/connector_properties_resilient",
-                ".servicenow": "#/components/schemas/connector_properties_servicenow",
-                ".servicenow-sir": "#/components/schemas/connector_properties_servicenow_sir",
-                ".swimlane": "#/components/schemas/connector_properties_swimlane"
+                ".none": "connector_properties_none.yaml",
+                ".cases-webhook": "connector_properties_cases_webhook.yaml",
+                ".jira": "connector_properties_jira.yaml",
+                ".resilient": "connector_properties_resilient.yaml",
+                ".servicenow": "connector_properties_servicenow.yaml",
+                ".servicenow-sir": "connector_properties_servicenow_sir.yaml",
+                ".swimlane": "connector_properties_swimlane.yaml"
               }
             }
           },
@@ -4248,6 +4498,12 @@
           "id": {
             "type": "string",
             "example": "66b9aa00-94fa-11ea-9f74-e7e108796192"
+          },
+          "incremental_id": {
+            "type": "integer",
+            "description": "A monotonically increasing number assigned to each case, unique per space. This value is generated asynchronously after the case is created and may not be present immediately in the response.\n",
+            "nullable": true,
+            "example": 1
           },
           "observables": {
             "type": "array",
@@ -4332,6 +4588,59 @@
           }
         }
       },
+      "alert_identifiers": {
+        "title": "Alert identifiers",
+        "description": "The alert identifiers. It is required only when `type` is `alert`. You can use an array of strings to add multiple alerts to a case, provided that they all relate to the same rule; `index` must also be an array with the same length or number of elements. Adding multiple alerts in this manner is recommended rather than calling the API multiple times. This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.\n",
+        "oneOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "maxItems": 1000
+          }
+        ],
+        "x-state": "Technical preview",
+        "example": "6b24c4dc44bc720cfc92797f3d61fff952f2b2627db1fb4f8cc49f4530c4ff42"
+      },
+      "alert_indices": {
+        "title": "Alert indices",
+        "description": "The alert indices. It is required only when `type` is `alert`. If you are adding multiple alerts to a case, use an array of strings; the position of each index name in the array must match the position of the corresponding alert identifier in the `alertId` array.  This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.\n",
+        "oneOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "maxItems": 1000
+          }
+        ],
+        "x-state": "Technical preview"
+      },
+      "rule": {
+        "title": "Alerting rule",
+        "description": "The rule that is associated with the alerts. It is required only when `type` is `alert`. This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.\n",
+        "type": "object",
+        "x-state": "Technical preview",
+        "properties": {
+          "id": {
+            "description": "The rule identifier.",
+            "type": "string",
+            "example": "94d80550-aaf4-11ec-985f-97e55adae8b9"
+          },
+          "name": {
+            "description": "The rule name.",
+            "type": "string",
+            "example": "security_rule"
+          }
+        }
+      },
       "add_alert_comment_request_properties": {
         "title": "Add case comment request properties for alerts",
         "required": [
@@ -4395,59 +4704,6 @@
           "type"
         ]
       },
-      "alert_identifiers": {
-        "title": "Alert identifiers",
-        "description": "The alert identifiers. It is required only when `type` is `alert`. You can use an array of strings to add multiple alerts to a case, provided that they all relate to the same rule; `index` must also be an array with the same length or number of elements. Adding multiple alerts in this manner is recommended rather than calling the API multiple times. This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.\n",
-        "oneOf": [
-          {
-            "type": "string"
-          },
-          {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "maxItems": 1000
-          }
-        ],
-        "x-state": "Technical preview",
-        "example": "6b24c4dc44bc720cfc92797f3d61fff952f2b2627db1fb4f8cc49f4530c4ff42"
-      },
-      "alert_indices": {
-        "title": "Alert indices",
-        "description": "The alert indices. It is required only when `type` is `alert`. If you are adding multiple alerts to a case, use an array of strings; the position of each index name in the array must match the position of the corresponding alert identifier in the `alertId` array.  This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.\n",
-        "oneOf": [
-          {
-            "type": "string"
-          },
-          {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "maxItems": 1000
-          }
-        ],
-        "x-state": "Technical preview"
-      },
-      "rule": {
-        "title": "Alerting rule",
-        "description": "The rule that is associated with the alerts. It is required only when `type` is `alert`. This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.\n",
-        "type": "object",
-        "x-state": "Technical preview",
-        "properties": {
-          "id": {
-            "description": "The rule identifier.",
-            "type": "string",
-            "example": "94d80550-aaf4-11ec-985f-97e55adae8b9"
-          },
-          "name": {
-            "description": "The rule name.",
-            "type": "string",
-            "example": "security_rule"
-          }
-        }
-      },
       "add_case_comment_request": {
         "title": "Add case comment request",
         "description": "The add comment to case API request body varies depending on whether you are adding an alert or a comment.",
@@ -4462,8 +4718,8 @@
         "discriminator": {
           "propertyName": "type",
           "mapping": {
-            "alert": "#/components/schemas/add_alert_comment_request_properties",
-            "user": "#/components/schemas/add_user_comment_request_properties"
+            "alert": "add_alert_comment_request_properties.yaml",
+            "user": "add_user_comment_request_properties.yaml"
           }
         }
       },
@@ -4568,8 +4824,8 @@
         "discriminator": {
           "propertyName": "type",
           "mapping": {
-            "alert": "#/components/schemas/update_alert_comment_request_properties",
-            "user": "#/components/schemas/update_user_comment_request_properties"
+            "alert": "update_alert_comment_request_properties.yaml",
+            "user": "update_user_comment_request_properties.yaml"
           }
         }
       },
@@ -5117,16 +5373,21 @@
             "description": "The type of action.",
             "enum": [
               "assignees",
-              "create_case",
+              "category",
               "comment",
               "connector",
+              "create_case",
+              "customFields",
+              "delete_case",
               "description",
+              "extended_fields",
+              "observables",
               "pushed",
-              "tags",
-              "title",
-              "status",
               "settings",
-              "severity"
+              "severity",
+              "status",
+              "tags",
+              "title"
             ],
             "example": "create_case"
           }
@@ -5244,6 +5505,14 @@
             }
           },
           "external_service": null
+        }
+      },
+      "response_401": {
+        "summary": "Authorization information is missing or invalid.",
+        "value": {
+          "error": "Unauthorized",
+          "message": "Unable to authenticate with the provided credentials.",
+          "statusCode": 401
         }
       },
       "update_case_request": {
@@ -5377,6 +5646,7 @@
           "cases": [
             {
               "id": "abed3a70-71bd-11ea-a0b2-c51ea50a58e2",
+              "incremental_id": 1,
               "version": "WzExMCwxXQ==",
               "comments": [],
               "observables": [],
@@ -5456,6 +5726,7 @@
                 "type": "text"
               }
             ],
+            "observableTypes": [],
             "owner": "cases",
             "created_at": "2024-07-01T17:07:17.767Z",
             "created_by": {
@@ -5780,6 +6051,7 @@
         "summary": "Get case response. Comments are not included; use the find case comments API. totalComment reflects the actual count.",
         "value": {
           "id": "31cdada0-02c1-11ed-85f2-4f7c222ca2fa",
+          "incremental_id": 1,
           "version": "WzM2LDFd",
           "totalComment": 1,
           "totalAlerts": 1,
@@ -5929,8 +6201,13 @@
               "created_by": {
                 "username": "elastic",
                 "email": null,
-                "full_name": null
-              }
+                "full_name": null,
+                "profile_uid": "u_mGBROF_q5bmFCATbLXAcCwKa0k8JvONAwSruelyKA5E_0"
+              },
+              "pushed_at": null,
+              "pushed_by": null,
+              "updated_at": null,
+              "updated_by": null
             }
           ],
           "observables": [],
@@ -6160,17 +6437,22 @@
           "closed_at": null,
           "closed_by": null,
           "created_at": "2022-07-29T00:59:39.444Z",
+          "assignees": [],
+          "category": null,
+          "customFields": [],
           "created_by": {
             "username": "elastic",
             "email": null,
-            "full_name": null
+            "full_name": null,
+            "profile_uid": "u_mGBROF_q5bmFCATbLXAcCwKa0k8JvONAwSruelyKA5E_0"
           },
           "status": "open",
           "updated_at": "2022-07-29T01:20:58.436Z",
           "updated_by": {
             "username": "elastic",
             "full_name": null,
-            "email": null
+            "email": null,
+            "profile_uid": "u_mGBROF_q5bmFCATbLXAcCwKa0k8JvONAwSruelyKA5E_0"
           },
           "connector": {
             "id": "09f8c0b0-0eda-11ed-bd18-65557fe66949",

--- a/x-pack/platform/plugins/shared/cases/docs/openapi/bundled-types.schema.yaml
+++ b/x-pack/platform/plugins/shared/cases/docs/openapi/bundled-types.schema.yaml
@@ -49,6 +49,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/response_4xx'
+              examples:
+                response401:
+                  $ref: '#/components/examples/response_401'
     delete:
       summary: Delete cases
       operationId: deleteCaseDefaultSpace
@@ -68,6 +71,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/response_4xx'
+              examples:
+                response401:
+                  $ref: '#/components/examples/response_401'
       x-code-samples:
         - label: curl
           lang: curl
@@ -116,6 +122,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/response_4xx'
+              examples:
+                response401:
+                  $ref: '#/components/examples/response_401'
   /api/cases/_find:
     get:
       summary: Search cases
@@ -175,6 +184,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/response_4xx'
+              examples:
+                response401:
+                  $ref: '#/components/examples/response_401'
   /api/cases/alerts/{alertId}:
     get:
       summary: Get cases for an alert
@@ -197,22 +209,28 @@ paths:
                 maxItems: 10000
                 items:
                   $ref: '#/components/schemas/related_case'
-                example:
-                  - id: 06116b80-e1c3-11ec-be9b-9b1838238ee6
-                    title: security_case
-                    description: Investigating suspicious activity
-                    status: open
-                    createdAt: '2020-02-19T23:06:33.798Z'
-                    totals:
-                      alerts: 1
-                      events: 0
-                      userComments: 0
+              examples:
+                getCasesByAlertResponse:
+                  summary: Cases associated with a given alert.
+                  value:
+                    - id: 06116b80-e1c3-11ec-be9b-9b1838238ee6
+                      title: security_case
+                      description: Investigating suspicious activity
+                      status: open
+                      createdAt: '2020-02-19T23:06:33.798Z'
+                      totals:
+                        alerts: 1
+                        events: 0
+                        userComments: 0
         '401':
           description: Authorization information is missing or invalid.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/response_4xx'
+              examples:
+                response401:
+                  $ref: '#/components/examples/response_401'
   /api/cases/configure:
     get:
       summary: Get case settings
@@ -332,6 +350,20 @@ paths:
                           target:
                             type: string
                             example: summary
+                    observableTypes:
+                      type: array
+                      description: Custom observable type configuration details.
+                      items:
+                        type: object
+                        properties:
+                          key:
+                            type: string
+                            description: The observable type key.
+                            example: d312efda-ec2b-42ec-9e2c-84981795c581
+                          label:
+                            type: string
+                            description: The observable type label.
+                            example: My observable type
                     owner:
                       $ref: '#/components/schemas/owner'
                     templates:
@@ -376,6 +408,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/response_4xx'
+              examples:
+                response401:
+                  $ref: '#/components/examples/response_401'
     post:
       summary: Add case settings
       operationId: setCaseConfigurationDefaultSpace
@@ -500,6 +535,20 @@ paths:
                         target:
                           type: string
                           example: summary
+                  observableTypes:
+                    type: array
+                    description: Custom observable type configuration details.
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          type: string
+                          description: The observable type key.
+                          example: d312efda-ec2b-42ec-9e2c-84981795c581
+                        label:
+                          type: string
+                          description: The observable type label.
+                          example: My observable type
                   owner:
                     $ref: '#/components/schemas/owner'
                   templates:
@@ -544,6 +593,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/response_4xx'
+              examples:
+                response401:
+                  $ref: '#/components/examples/response_401'
   /api/cases/configure/{configurationId}:
     patch:
       summary: Update case settings
@@ -670,6 +722,20 @@ paths:
                         target:
                           type: string
                           example: summary
+                  observableTypes:
+                    type: array
+                    description: Custom observable type configuration details.
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          type: string
+                          description: The observable type key.
+                          example: d312efda-ec2b-42ec-9e2c-84981795c581
+                        label:
+                          type: string
+                          description: The observable type label.
+                          example: My observable type
                   owner:
                     $ref: '#/components/schemas/owner'
                   templates:
@@ -714,6 +780,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/response_4xx'
+              examples:
+                response401:
+                  $ref: '#/components/examples/response_401'
   /api/cases/reporters:
     get:
       summary: Get case creators
@@ -763,6 +832,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/response_4xx'
+              examples:
+                response401:
+                  $ref: '#/components/examples/response_401'
   /api/cases/tags:
     get:
       summary: Get case tags
@@ -792,6 +864,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/response_4xx'
+              examples:
+                response401:
+                  $ref: '#/components/examples/response_401'
   /api/cases/{caseId}:
     get:
       summary: Get case information
@@ -820,6 +895,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/response_4xx'
+              examples:
+                response401:
+                  $ref: '#/components/examples/response_401'
   /api/cases/{caseId}/alerts:
     get:
       summary: Get all alerts for a case
@@ -849,6 +927,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/response_4xx'
+              examples:
+                response401:
+                  $ref: '#/components/examples/response_401'
   /api/cases/{caseId}/comments:
     post:
       summary: Add a case comment or alert
@@ -885,6 +966,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/response_4xx'
+              examples:
+                response401:
+                  $ref: '#/components/examples/response_401'
     delete:
       summary: Delete all case comments and alerts
       operationId: deleteCaseCommentsDefaultSpace
@@ -904,6 +988,21 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/response_4xx'
+              examples:
+                response401:
+                  $ref: '#/components/examples/response_401'
+      x-codeSamples:
+        - label: curl
+          lang: curl
+          source: |
+            curl \
+              --request DELETE 'https://localhost:5601/api/cases/9c235210-6834-11ea-a78c-6ffb38a34414/comments' \
+              --header "Authorization: $API_KEY" \
+              --header "kbn-xsrf: true"
+        - label: Console
+          lang: console
+          source: |
+            DELETE kbn:/api/cases/9c235210-6834-11ea-a78c-6ffb38a34414/comments
     patch:
       summary: Update a case comment or alert
       operationId: updateCaseCommentDefaultSpace
@@ -939,6 +1038,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/response_4xx'
+              examples:
+                response401:
+                  $ref: '#/components/examples/response_401'
   /api/cases/{caseId}/comments/_find:
     get:
       summary: Find case comments
@@ -968,6 +1070,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/response_4xx'
+              examples:
+                response401:
+                  $ref: '#/components/examples/response_401'
   /api/cases/{caseId}/comments/{commentId}:
     delete:
       summary: Delete a case comment or alert
@@ -989,6 +1094,21 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/response_4xx'
+              examples:
+                response401:
+                  $ref: '#/components/examples/response_401'
+      x-codeSamples:
+        - label: curl
+          lang: curl
+          source: |
+            curl \
+              --request DELETE 'https://localhost:5601/api/cases/9c235210-6834-11ea-a78c-6ffb38a34414/comments/71ec1870-725b-11ea-a0b2-c51ea50a58e2' \
+              --header "Authorization: $API_KEY" \
+              --header "kbn-xsrf: true"
+        - label: Console
+          lang: console
+          source: |
+            DELETE kbn:/api/cases/9c235210-6834-11ea-a78c-6ffb38a34414/comments/71ec1870-725b-11ea-a0b2-c51ea50a58e2
     get:
       summary: Get a case comment or alert
       operationId: getCaseCommentDefaultSpace
@@ -1017,6 +1137,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/response_4xx'
+              examples:
+                response401:
+                  $ref: '#/components/examples/response_401'
   /api/cases/{caseId}/connector/{connectorId}/_push:
     post:
       summary: Push a case to an external service
@@ -1035,6 +1158,10 @@ paths:
             schema:
               type: object
               nullable: true
+            examples:
+              pushCaseRequest:
+                summary: Push a case to an external service. No request body is required.
+                value: null
       responses:
         '200':
           description: Indicates a successful call.
@@ -1051,6 +1178,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/response_4xx'
+              examples:
+                response401:
+                  $ref: '#/components/examples/response_401'
   /api/cases/{caseId}/user_actions/_find:
     get:
       summary: Find case activity
@@ -1093,6 +1223,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/response_4xx'
+              examples:
+                response401:
+                  $ref: '#/components/examples/response_401'
   /api/cases/configure/connectors/_find:
     get:
       summary: Get case connectors
@@ -1143,6 +1276,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/response_4xx'
+              examples:
+                response401:
+                  $ref: '#/components/examples/response_401'
   /api/cases/{caseId}/files:
     post:
       summary: Attach a file to a case
@@ -1162,6 +1298,11 @@ paths:
           multipart/form-data:
             schema:
               $ref: '#/components/schemas/add_case_file_request'
+            examples:
+              addCaseFileRequest:
+                summary: Attach a plain text file named "my_attachment".
+                value:
+                  filename: my_attachment
       responses:
         '200':
           description: Indicates a successful call.
@@ -1178,6 +1319,19 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/response_4xx'
+              examples:
+                response401:
+                  $ref: '#/components/examples/response_401'
+      x-codeSamples:
+        - label: curl
+          lang: curl
+          source: |
+            curl \
+              --request POST 'https://localhost:5601/api/cases/9c235210-6834-11ea-a78c-6ffb38a34414/files' \
+              --header "Authorization: $API_KEY" \
+              --header "kbn-xsrf: true" \
+              --form "file=@/path/to/my_attachment.txt" \
+              --form "filename=my_attachment"
 components:
   parameters:
     kbn_xsrf:
@@ -1251,6 +1405,7 @@ components:
       schema:
         type: integer
         default: 1
+      example: 1
     page_size:
       in: query
       name: perPage
@@ -1260,6 +1415,7 @@ components:
         type: integer
         default: 20
         maximum: 100
+      example: 20
     reporters:
       in: query
       name: reporters
@@ -1275,6 +1431,7 @@ components:
       description: An Elasticsearch simple_query_string query that filters the objects in the response.
       schema:
         type: string
+      example: Case title 1
     searchFields:
       in: query
       name: searchFields
@@ -1294,6 +1451,7 @@ components:
           - high
           - low
           - medium
+      example: low
     sortField:
       in: query
       name: sortField
@@ -1321,6 +1479,7 @@ components:
           - asc
           - desc
         default: desc
+      example: desc
     status:
       in: query
       name: status
@@ -2408,6 +2567,12 @@ components:
         id:
           type: string
           example: 66b9aa00-94fa-11ea-9f74-e7e108796192
+        incremental_id:
+          type: integer
+          description: |
+            A monotonically increasing number assigned to each case, unique per space. This value is generated asynchronously after the case is created and may not be present immediately in the response.
+          nullable: true
+          example: 1
         observables:
           type: array
           description: Observables attached to the case.
@@ -3003,6 +3168,12 @@ components:
         id:
           type: string
           example: 66b9aa00-94fa-11ea-9f74-e7e108796192
+        incremental_id:
+          type: integer
+          description: |
+            A monotonically increasing number assigned to each case, unique per space. This value is generated asynchronously after the case is created and may not be present immediately in the response.
+          nullable: true
+          example: 1
         observables:
           type: array
           description: Observables attached to the case.
@@ -3612,16 +3783,21 @@ components:
           description: The type of action.
           enum:
             - assignees
-            - create_case
+            - category
             - comment
             - connector
+            - create_case
+            - customFields
+            - delete_case
             - description
+            - extended_fields
+            - observables
             - pushed
-            - tags
-            - title
-            - status
             - settings
             - severity
+            - status
+            - tags
+            - title
           example: create_case
     add_case_file_request:
       title: Add case file request properties
@@ -3710,6 +3886,12 @@ components:
             parent: null
             priority: High
         external_service: null
+    response_401:
+      summary: Authorization information is missing or invalid.
+      value:
+        error: Unauthorized
+        message: Unable to authenticate with the provided credentials.
+        statusCode: 401
     update_case_request:
       summary: Update the case description, tags, and connector.
       value:
@@ -3809,6 +3991,7 @@ components:
         total: 1
         cases:
           - id: abed3a70-71bd-11ea-a0b2-c51ea50a58e2
+            incremental_id: 1
             version: WzExMCwxXQ==
             comments: []
             observables: []
@@ -3870,6 +4053,7 @@ components:
               label: my-text-field
               required: false
               type: text
+          observableTypes: []
           owner: cases
           created_at: '2024-07-01T17:07:17.767Z'
           created_by:
@@ -4094,6 +4278,7 @@ components:
       summary: Get case response. Comments are not included; use the find case comments API. totalComment reflects the actual count.
       value:
         id: 31cdada0-02c1-11ed-85f2-4f7c222ca2fa
+        incremental_id: 1
         version: WzM2LDFd
         totalComment: 1
         totalAlerts: 1
@@ -4212,6 +4397,11 @@ components:
               username: elastic
               email: null
               full_name: null
+              profile_uid: u_mGBROF_q5bmFCATbLXAcCwKa0k8JvONAwSruelyKA5E_0
+            pushed_at: null
+            pushed_by: null
+            updated_at: null
+            updated_by: null
         observables: []
         totalAlerts: 0
         totalEvents: 0
@@ -4397,16 +4587,21 @@ components:
         closed_at: null
         closed_by: null
         created_at: '2022-07-29T00:59:39.444Z'
+        assignees: []
+        category: null
+        customFields: []
         created_by:
           username: elastic
           email: null
           full_name: null
+          profile_uid: u_mGBROF_q5bmFCATbLXAcCwKa0k8JvONAwSruelyKA5E_0
         status: open
         updated_at: '2022-07-29T01:20:58.436Z'
         updated_by:
           username: elastic
           full_name: null
           email: null
+          profile_uid: u_mGBROF_q5bmFCATbLXAcCwKa0k8JvONAwSruelyKA5E_0
         connector:
           id: 09f8c0b0-0eda-11ed-bd18-65557fe66949
           name: My connector

--- a/x-pack/platform/plugins/shared/cases/docs/openapi/components/examples/add_comment_response.yaml
+++ b/x-pack/platform/plugins/shared/cases/docs/openapi/components/examples/add_comment_response.yaml
@@ -11,6 +11,11 @@ value:
         username: elastic
         email: null
         full_name: null
+        profile_uid: u_mGBROF_q5bmFCATbLXAcCwKa0k8JvONAwSruelyKA5E_0
+      pushed_at: null
+      pushed_by: null
+      updated_at: null
+      updated_by: null
   observables: []
   totalAlerts: 0
   totalEvents: 0

--- a/x-pack/platform/plugins/shared/cases/docs/openapi/components/examples/find_case_response.yaml
+++ b/x-pack/platform/plugins/shared/cases/docs/openapi/components/examples/find_case_response.yaml
@@ -7,6 +7,7 @@ value:
     "cases": [
       {
         "id": "abed3a70-71bd-11ea-a0b2-c51ea50a58e2",
+        "incremental_id": 1,
         "version": "WzExMCwxXQ==",
         "comments": [],
         "observables": [],

--- a/x-pack/platform/plugins/shared/cases/docs/openapi/components/examples/get_case_configuration_response.yaml
+++ b/x-pack/platform/plugins/shared/cases/docs/openapi/components/examples/get_case_configuration_response.yaml
@@ -8,6 +8,7 @@ value:
         label: my-text-field
         required: false
         type: text
+    observableTypes: []
     owner: cases
     created_at: 2024-07-01T17:07:17.767Z
     created_by:

--- a/x-pack/platform/plugins/shared/cases/docs/openapi/components/examples/get_case_response.yaml
+++ b/x-pack/platform/plugins/shared/cases/docs/openapi/components/examples/get_case_response.yaml
@@ -2,6 +2,7 @@ summary: Get case response. Comments are not included; use the find case comment
 value: 
   {
     "id":"31cdada0-02c1-11ed-85f2-4f7c222ca2fa",
+    "incremental_id":1,
     "version":"WzM2LDFd",
     "totalComment":1,
     "totalAlerts":1,

--- a/x-pack/platform/plugins/shared/cases/docs/openapi/components/examples/push_case_response.yaml
+++ b/x-pack/platform/plugins/shared/cases/docs/openapi/components/examples/push_case_response.yaml
@@ -24,17 +24,22 @@ value:
     "closed_at": null,
     "closed_by": null,
     "created_at": "2022-07-29T00:59:39.444Z",
+    "assignees": [],
+    "category": null,
+    "customFields": [],
     "created_by": {
       "username": "elastic",
       "email": null,
-      "full_name": null
+      "full_name": null,
+      "profile_uid": "u_mGBROF_q5bmFCATbLXAcCwKa0k8JvONAwSruelyKA5E_0"
     },
     "status": "open",
     "updated_at": "2022-07-29T01:20:58.436Z",
     "updated_by": {
       "username": "elastic",
       "full_name": null,
-      "email": null
+      "email": null,
+      "profile_uid": "u_mGBROF_q5bmFCATbLXAcCwKa0k8JvONAwSruelyKA5E_0"
     },
     "connector": {
       "id": "09f8c0b0-0eda-11ed-bd18-65557fe66949",

--- a/x-pack/platform/plugins/shared/cases/docs/openapi/components/examples/response_401.yaml
+++ b/x-pack/platform/plugins/shared/cases/docs/openapi/components/examples/response_401.yaml
@@ -1,0 +1,7 @@
+summary: Authorization information is missing or invalid.
+value:
+  {
+    "error": "Unauthorized",
+    "message": "Unable to authenticate with the provided credentials.",
+    "statusCode": 401
+  }

--- a/x-pack/platform/plugins/shared/cases/docs/openapi/components/parameters/page_index.yaml
+++ b/x-pack/platform/plugins/shared/cases/docs/openapi/components/parameters/page_index.yaml
@@ -5,3 +5,4 @@ required: false
 schema:
   type: integer
   default: 1
+example: 1

--- a/x-pack/platform/plugins/shared/cases/docs/openapi/components/parameters/page_size.yaml
+++ b/x-pack/platform/plugins/shared/cases/docs/openapi/components/parameters/page_size.yaml
@@ -6,3 +6,4 @@ schema:
   type: integer
   default: 20
   maximum: 100
+example: 20

--- a/x-pack/platform/plugins/shared/cases/docs/openapi/components/parameters/search.yaml
+++ b/x-pack/platform/plugins/shared/cases/docs/openapi/components/parameters/search.yaml
@@ -3,3 +3,4 @@ name: search
 description: An Elasticsearch simple_query_string query that filters the objects in the response.
 schema:
   type: string
+example: Case title 1

--- a/x-pack/platform/plugins/shared/cases/docs/openapi/components/parameters/severity.yaml
+++ b/x-pack/platform/plugins/shared/cases/docs/openapi/components/parameters/severity.yaml
@@ -8,3 +8,4 @@ schema:
     - high
     - low
     - medium
+example: low

--- a/x-pack/platform/plugins/shared/cases/docs/openapi/components/parameters/sort_order.yaml
+++ b/x-pack/platform/plugins/shared/cases/docs/openapi/components/parameters/sort_order.yaml
@@ -6,3 +6,4 @@ schema:
   type: string
   enum: [asc, desc]
   default: desc
+example: desc

--- a/x-pack/platform/plugins/shared/cases/docs/openapi/components/schemas/case_configure_response_properties.yaml
+++ b/x-pack/platform/plugins/shared/cases/docs/openapi/components/schemas/case_configure_response_properties.yaml
@@ -44,6 +44,20 @@ mappings:
       target:
         type: string
         example: summary
+observableTypes:
+  type: array
+  description: Custom observable type configuration details.
+  items:
+    type: object
+    properties:
+      key:
+        type: string
+        description: The observable type key.
+        example: d312efda-ec2b-42ec-9e2c-84981795c581
+      label:
+        type: string
+        description: The observable type label.
+        example: My observable type
 owner:
   $ref: 'owner.yaml'
 templates:

--- a/x-pack/platform/plugins/shared/cases/docs/openapi/components/schemas/case_response_get_case.yaml
+++ b/x-pack/platform/plugins/shared/cases/docs/openapi/components/schemas/case_response_get_case.yaml
@@ -91,6 +91,14 @@ properties:
   id:
     type: string
     example: 66b9aa00-94fa-11ea-9f74-e7e108796192
+  incremental_id:
+    type: integer
+    description: >
+      A monotonically increasing number assigned to each case, unique per space.
+      This value is generated asynchronously after the case is created and may
+      not be present immediately in the response.
+    nullable: true
+    example: 1
   observables:
     type: array
     description: Observables attached to the case.

--- a/x-pack/platform/plugins/shared/cases/docs/openapi/components/schemas/case_response_properties.yaml
+++ b/x-pack/platform/plugins/shared/cases/docs/openapi/components/schemas/case_response_properties.yaml
@@ -105,6 +105,14 @@ properties:
   id:
     type: string
     example: 66b9aa00-94fa-11ea-9f74-e7e108796192
+  incremental_id:
+    type: integer
+    description: >
+      A monotonically increasing number assigned to each case, unique per space.
+      This value is generated asynchronously after the case is created and may
+      not be present immediately in the response.
+    nullable: true
+    example: 1
   observables:
     type: array
     description: Observables attached to the case.

--- a/x-pack/platform/plugins/shared/cases/docs/openapi/components/schemas/user_actions_find_response_properties.yaml
+++ b/x-pack/platform/plugins/shared/cases/docs/openapi/components/schemas/user_actions_find_response_properties.yaml
@@ -56,14 +56,19 @@ properties:
     description: The type of action.
     enum:
       - assignees
-      - create_case
+      - category
       - comment
       - connector
+      - create_case
+      - customFields
+      - delete_case
       - description
+      - extended_fields
+      - observables
       - pushed
-      - tags
-      - title
-      - status
       - settings
       - severity
+      - status
+      - tags
+      - title
     example: create_case

--- a/x-pack/platform/plugins/shared/cases/docs/openapi/paths/api@cases.yaml
+++ b/x-pack/platform/plugins/shared/cases/docs/openapi/paths/api@cases.yaml
@@ -34,6 +34,9 @@ post:
         application/json:
           schema:
             $ref: '../components/schemas/response_4xx.yaml'
+          examples:
+            response401:
+              $ref: '../components/examples/response_401.yaml'
 
 delete:
   summary: Delete cases
@@ -57,6 +60,9 @@ delete:
         application/json:
           schema:
             $ref: '../components/schemas/response_4xx.yaml'
+          examples:
+            response401:
+              $ref: '../components/examples/response_401.yaml'
   x-code-samples:
     - label: curl
       lang: curl
@@ -107,3 +113,6 @@ patch:
         application/json:
           schema:
             $ref: '../components/schemas/response_4xx.yaml'
+          examples:
+            response401:
+              $ref: '../components/examples/response_401.yaml'

--- a/x-pack/platform/plugins/shared/cases/docs/openapi/paths/api@cases@_find.yaml
+++ b/x-pack/platform/plugins/shared/cases/docs/openapi/paths/api@cases@_find.yaml
@@ -58,3 +58,6 @@ get:
         application/json:
           schema:
             $ref: '../components/schemas/response_4xx.yaml'
+          examples:
+            response401:
+              $ref: '../components/examples/response_401.yaml'

--- a/x-pack/platform/plugins/shared/cases/docs/openapi/paths/api@cases@alerts@{alertid}.yaml
+++ b/x-pack/platform/plugins/shared/cases/docs/openapi/paths/api@cases@alerts@{alertid}.yaml
@@ -21,19 +21,25 @@ get:
             maxItems: 10000
             items:
               $ref: '../components/schemas/related_case.yaml'
-            example:
-              - id: 06116b80-e1c3-11ec-be9b-9b1838238ee6
-                title: security_case
-                description: Investigating suspicious activity
-                status: open
-                createdAt: '2020-02-19T23:06:33.798Z'
-                totals:
-                  alerts: 1
-                  events: 0
-                  userComments: 0
+          examples:
+            getCasesByAlertResponse:
+              summary: Cases associated with a given alert.
+              value:
+                - id: 06116b80-e1c3-11ec-be9b-9b1838238ee6
+                  title: security_case
+                  description: Investigating suspicious activity
+                  status: open
+                  createdAt: '2020-02-19T23:06:33.798Z'
+                  totals:
+                    alerts: 1
+                    events: 0
+                    userComments: 0
     '401':
       description: Authorization information is missing or invalid.
       content:
         application/json:
           schema:
             $ref: '../components/schemas/response_4xx.yaml'
+          examples:
+            response401:
+              $ref: '../components/examples/response_401.yaml'

--- a/x-pack/platform/plugins/shared/cases/docs/openapi/paths/api@cases@configure.yaml
+++ b/x-pack/platform/plugins/shared/cases/docs/openapi/paths/api@cases@configure.yaml
@@ -30,6 +30,9 @@ get:
         application/json:
           schema:
             $ref: '../components/schemas/response_4xx.yaml'
+          examples:
+            response401:
+              $ref: '../components/examples/response_401.yaml'
 
 post:
   summary: Add case settings
@@ -71,3 +74,6 @@ post:
         application/json:
           schema:
             $ref: '../components/schemas/response_4xx.yaml'
+          examples:
+            response401:
+              $ref: '../components/examples/response_401.yaml'

--- a/x-pack/platform/plugins/shared/cases/docs/openapi/paths/api@cases@configure@connectors@_find.yaml
+++ b/x-pack/platform/plugins/shared/cases/docs/openapi/paths/api@cases@configure@connectors@_find.yaml
@@ -27,3 +27,6 @@ get:
         application/json:
           schema:
             $ref: '../components/schemas/response_4xx.yaml'
+          examples:
+            response401:
+              $ref: '../components/examples/response_401.yaml'

--- a/x-pack/platform/plugins/shared/cases/docs/openapi/paths/api@cases@configure@{configurationid}.yaml
+++ b/x-pack/platform/plugins/shared/cases/docs/openapi/paths/api@cases@configure@{configurationid}.yaml
@@ -39,3 +39,6 @@ patch:
         application/json:
           schema:
             $ref: '../components/schemas/response_4xx.yaml'
+          examples:
+            response401:
+              $ref: '../components/examples/response_401.yaml'

--- a/x-pack/platform/plugins/shared/cases/docs/openapi/paths/api@cases@reporters.yaml
+++ b/x-pack/platform/plugins/shared/cases/docs/openapi/paths/api@cases@reporters.yaml
@@ -35,3 +35,6 @@ get:
         application/json:
           schema:
             $ref: '../components/schemas/response_4xx.yaml'
+          examples:
+            response401:
+              $ref: '../components/examples/response_401.yaml'

--- a/x-pack/platform/plugins/shared/cases/docs/openapi/paths/api@cases@tags.yaml
+++ b/x-pack/platform/plugins/shared/cases/docs/openapi/paths/api@cases@tags.yaml
@@ -27,3 +27,6 @@ get:
         application/json:
           schema:
             $ref: '../components/schemas/response_4xx.yaml'
+          examples:
+            response401:
+              $ref: '../components/examples/response_401.yaml'

--- a/x-pack/platform/plugins/shared/cases/docs/openapi/paths/api@cases@{caseid}.yaml
+++ b/x-pack/platform/plugins/shared/cases/docs/openapi/paths/api@cases@{caseid}.yaml
@@ -30,3 +30,6 @@ get:
         application/json:
           schema:
             $ref: '../components/schemas/response_4xx.yaml'
+          examples:
+            response401:
+              $ref: '../components/examples/response_401.yaml'

--- a/x-pack/platform/plugins/shared/cases/docs/openapi/paths/api@cases@{caseid}@alerts.yaml
+++ b/x-pack/platform/plugins/shared/cases/docs/openapi/paths/api@cases@{caseid}@alerts.yaml
@@ -28,3 +28,6 @@ get:
         application/json:
           schema:
             $ref: '../components/schemas/response_4xx.yaml'
+          examples:
+            response401:
+              $ref: '../components/examples/response_401.yaml'

--- a/x-pack/platform/plugins/shared/cases/docs/openapi/paths/api@cases@{caseid}@comments.yaml
+++ b/x-pack/platform/plugins/shared/cases/docs/openapi/paths/api@cases@{caseid}@comments.yaml
@@ -36,6 +36,9 @@ post:
         application/json:
           schema:
             $ref: '../components/schemas/response_4xx.yaml'
+          examples:
+            response401:
+              $ref: '../components/examples/response_401.yaml'
 
 delete:
   summary: Delete all case comments and alerts
@@ -59,6 +62,21 @@ delete:
         application/json:
           schema:
             $ref: '../components/schemas/response_4xx.yaml'
+          examples:
+            response401:
+              $ref: '../components/examples/response_401.yaml'
+  x-codeSamples:
+    - label: curl
+      lang: curl
+      source: |
+        curl \
+          --request DELETE 'https://localhost:5601/api/cases/9c235210-6834-11ea-a78c-6ffb38a34414/comments' \
+          --header "Authorization: $API_KEY" \
+          --header "kbn-xsrf: true"
+    - label: Console
+      lang: console
+      source: |
+        DELETE kbn:/api/cases/9c235210-6834-11ea-a78c-6ffb38a34414/comments
 
 patch:
   summary: Update a case comment or alert
@@ -98,3 +116,6 @@ patch:
         application/json:
           schema:
             $ref: '../components/schemas/response_4xx.yaml'
+          examples:
+            response401:
+              $ref: '../components/examples/response_401.yaml'

--- a/x-pack/platform/plugins/shared/cases/docs/openapi/paths/api@cases@{caseid}@comments@_find.yaml
+++ b/x-pack/platform/plugins/shared/cases/docs/openapi/paths/api@cases@{caseid}@comments@_find.yaml
@@ -27,3 +27,6 @@ get:
         application/json:
           schema:
             $ref: '../components/schemas/response_4xx.yaml'
+          examples:
+            response401:
+              $ref: '../components/examples/response_401.yaml'

--- a/x-pack/platform/plugins/shared/cases/docs/openapi/paths/api@cases@{caseid}@comments@{commentid}.yaml
+++ b/x-pack/platform/plugins/shared/cases/docs/openapi/paths/api@cases@{caseid}@comments@{commentid}.yaml
@@ -20,6 +20,21 @@ delete:
         application/json:
           schema:
             $ref: '../components/schemas/response_4xx.yaml'
+          examples:
+            response401:
+              $ref: '../components/examples/response_401.yaml'
+  x-codeSamples:
+    - label: curl
+      lang: curl
+      source: |
+        curl \
+          --request DELETE 'https://localhost:5601/api/cases/9c235210-6834-11ea-a78c-6ffb38a34414/comments/71ec1870-725b-11ea-a0b2-c51ea50a58e2' \
+          --header "Authorization: $API_KEY" \
+          --header "kbn-xsrf: true"
+    - label: Console
+      lang: console
+      source: |
+        DELETE kbn:/api/cases/9c235210-6834-11ea-a78c-6ffb38a34414/comments/71ec1870-725b-11ea-a0b2-c51ea50a58e2
 
 get:
   summary: Get a case comment or alert
@@ -51,3 +66,6 @@ get:
         application/json:
           schema:
             $ref: '../components/schemas/response_4xx.yaml'
+          examples:
+            response401:
+              $ref: '../components/examples/response_401.yaml'

--- a/x-pack/platform/plugins/shared/cases/docs/openapi/paths/api@cases@{caseid}@connector@{connectorid}@_push.yaml
+++ b/x-pack/platform/plugins/shared/cases/docs/openapi/paths/api@cases@{caseid}@connector@{connectorid}@_push.yaml
@@ -16,6 +16,10 @@ post:
         schema:
           type: object
           nullable: true
+        examples:
+          pushCaseRequest:
+            summary: Push a case to an external service. No request body is required.
+            value: null
   responses:
     '200':
       description: Indicates a successful call.
@@ -32,3 +36,6 @@ post:
         application/json:
           schema:
             $ref: '../components/schemas/response_4xx.yaml'
+          examples:
+            response401:
+              $ref: '../components/examples/response_401.yaml'

--- a/x-pack/platform/plugins/shared/cases/docs/openapi/paths/api@cases@{caseid}@files.yaml
+++ b/x-pack/platform/plugins/shared/cases/docs/openapi/paths/api@cases@{caseid}@files.yaml
@@ -22,6 +22,11 @@ post:
       multipart/form-data:
         schema:
           $ref: '../components/schemas/add_case_file_request.yaml'
+        examples:
+          addCaseFileRequest:
+            summary: Attach a plain text file named "my_attachment".
+            value:
+              filename: my_attachment
   responses:
     '200':
       description: Indicates a successful call.
@@ -38,3 +43,16 @@ post:
         application/json:
           schema:
             $ref: '../components/schemas/response_4xx.yaml'
+          examples:
+            response401:
+              $ref: '../components/examples/response_401.yaml'
+  x-codeSamples:
+    - label: curl
+      lang: curl
+      source: |
+        curl \
+          --request POST 'https://localhost:5601/api/cases/9c235210-6834-11ea-a78c-6ffb38a34414/files' \
+          --header "Authorization: $API_KEY" \
+          --header "kbn-xsrf: true" \
+          --form "file=@/path/to/my_attachment.txt" \
+          --form "filename=my_attachment"

--- a/x-pack/platform/plugins/shared/cases/docs/openapi/paths/api@cases@{caseid}@user_actions@_find.yaml
+++ b/x-pack/platform/plugins/shared/cases/docs/openapi/paths/api@cases@{caseid}@user_actions@_find.yaml
@@ -42,3 +42,6 @@ get:
         application/json:
           schema:
             $ref: '../components/schemas/response_4xx.yaml'
+          examples:
+            response401:
+              $ref: '../components/examples/response_401.yaml'


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Cases][Docs] - Add additional examples and cleanup to openApi (#263617)](https://github.com/elastic/kibana/pull/263617)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Michael Olorunnisola","email":"michael.olorunnisola@elastic.co"},"sourceCommit":{"committedDate":"2026-04-22T16:50:30Z","message":"[Cases][Docs] - Add additional examples and cleanup to openApi (#263617)\n\n## Summary\n\nThis PR is a housekeeping pass on the public API documentation for\nKibana Cases. The docs had drifted from reality — some fields were\nmissing, some examples were wrong, some endpoints had no code samples,\nand the docs validator was throwing 22 errors. This PR makes the docs\nmatch what the API actually returns, and gets the validator to pass\ncleanly.\n\nNothing about the API itself changes. Only documentation and its\ngenerated bundles.\n\n## The four kinds of fixes\n\n### 1. Added missing \"unauthorized\" (401) examples\n\nEvery Cases endpoint was missing an example for its 401 response, which\ntripped the validator. Rather than copy-pasting the same example 16\ntimes, a shared `components/examples/response_401.yaml` was created and\nreferenced everywhere. One endpoint\n(`paths/api@cases@alerts@{alertid}.yaml`) was also using a deprecated\n`example:` format and got converted to the modern `examples:` map.\n\n### 2. Filled in missing code samples and request examples\n\nFour endpoints gained curl + Console code samples or request-body\nexamples — most notably:\n\n- **File upload** (`paths/api@cases@{caseid}@files.yaml`) — now shows\nmultipart form usage\n- **Push-to-connector**\n(`paths/api@cases@{caseid}@connector@{connectorid}@_push.yaml`) —\nclarified that no body is needed\n- **Delete comments** (both bulk and single) — added curl + Console\nsamples\n\nFive query-parameter component files also got `example:` values so the\nrendered docs aren't blank:\n\n- `page_index.yaml` → `1`\n- `page_size.yaml` → `20`\n- `sort_order.yaml` → `desc`\n- `severity.yaml` → `low`\n- `search.yaml` → `Case title 1`\n\n### 3. Schema inaccuracies — docs didn't match reality\n\nThree notable gaps between docs and actual API responses:\n\n- **`incremental_id` on cases** — added to\n`case_response_properties.yaml` and `case_response_get_case.yaml`, with\na note that it's populated asynchronously and won't appear in the\nimmediate `POST` response.\n- **User-action `type` enum was stale** — had 11 values, should have had\n16. Added `category`, `customFields`, `delete_case`, `extended_fields`,\n`observables` to `user_actions_find_response_properties.yaml`.\n- **`observableTypes` was completely missing** from the\ncase-configuration response schema — added to\n`case_configure_response_properties.yaml`.\n\n### 4. Example payloads didn't match real API output\n\nAuthor tested example files against a live Kibana and patched\ndiscrepancies:\n\n- **`add_comment_response.yaml`** — was missing `pushed_at`,\n`pushed_by`, `updated_at`, `updated_by`, and `profile_uid` on\n`created_by`.\n- **`push_case_response.yaml`** — was missing `assignees`,\n`customFields`, `category`, and `profile_uid` on\n`created_by`/`updated_by`.\n\n## Why the diff looks huge (+41,888 / −84,370)\n\nDon't be alarmed by the size. The vast majority of the churn is in three\nregenerated files:\n\n- `oas_docs/output/kibana.yaml` (+40,991 / −84,137)\n- `x-pack/platform/plugins/shared/cases/docs/openapi/bundled-types.json`\n-\n`x-pack/platform/plugins/shared/cases/docs/openapi/bundled-types.schema.yaml`\n\nThese are machine-generated bundles. A manual post-bundle fixup was\napplied to the schema YAML to convert Redocly's file-path discriminator\nmappings (`foo.yaml`) into the `#/components/schemas/foo` format that\n`kbn-openapi-bundler` requires, so that `make merge-api-docs-stateful`\ncontinues to work.\n\n## Key files to actually review\n\nThe hand-written changes (everything non-generated) are concentrated in:\n\n- `components/examples/` — new shared 401 example + updated response\nexamples\n- `components/parameters/` — added example values\n- `components/schemas/` — the three schema fixes\n- `paths/` — 16 path files got the 401 reference; a handful got new code\nsamples\n\n## Bottom line\n\nDocs-only cleanup. No runtime behavior changes, no tests to run, just\nsafer and more accurate public API documentation. Validator now passes\nwith **0 errors**.\n\n- written with Claude\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"61a520d49e389557c908761e231f74eac9d1dcaf","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","backport:version","Team:Cases","v9.4.0","v9.5.0"],"title":"[Cases][Docs] - Add additional examples and cleanup to openApi","number":263617,"url":"https://github.com/elastic/kibana/pull/263617","mergeCommit":{"message":"[Cases][Docs] - Add additional examples and cleanup to openApi (#263617)\n\n## Summary\n\nThis PR is a housekeeping pass on the public API documentation for\nKibana Cases. The docs had drifted from reality — some fields were\nmissing, some examples were wrong, some endpoints had no code samples,\nand the docs validator was throwing 22 errors. This PR makes the docs\nmatch what the API actually returns, and gets the validator to pass\ncleanly.\n\nNothing about the API itself changes. Only documentation and its\ngenerated bundles.\n\n## The four kinds of fixes\n\n### 1. Added missing \"unauthorized\" (401) examples\n\nEvery Cases endpoint was missing an example for its 401 response, which\ntripped the validator. Rather than copy-pasting the same example 16\ntimes, a shared `components/examples/response_401.yaml` was created and\nreferenced everywhere. One endpoint\n(`paths/api@cases@alerts@{alertid}.yaml`) was also using a deprecated\n`example:` format and got converted to the modern `examples:` map.\n\n### 2. Filled in missing code samples and request examples\n\nFour endpoints gained curl + Console code samples or request-body\nexamples — most notably:\n\n- **File upload** (`paths/api@cases@{caseid}@files.yaml`) — now shows\nmultipart form usage\n- **Push-to-connector**\n(`paths/api@cases@{caseid}@connector@{connectorid}@_push.yaml`) —\nclarified that no body is needed\n- **Delete comments** (both bulk and single) — added curl + Console\nsamples\n\nFive query-parameter component files also got `example:` values so the\nrendered docs aren't blank:\n\n- `page_index.yaml` → `1`\n- `page_size.yaml` → `20`\n- `sort_order.yaml` → `desc`\n- `severity.yaml` → `low`\n- `search.yaml` → `Case title 1`\n\n### 3. Schema inaccuracies — docs didn't match reality\n\nThree notable gaps between docs and actual API responses:\n\n- **`incremental_id` on cases** — added to\n`case_response_properties.yaml` and `case_response_get_case.yaml`, with\na note that it's populated asynchronously and won't appear in the\nimmediate `POST` response.\n- **User-action `type` enum was stale** — had 11 values, should have had\n16. Added `category`, `customFields`, `delete_case`, `extended_fields`,\n`observables` to `user_actions_find_response_properties.yaml`.\n- **`observableTypes` was completely missing** from the\ncase-configuration response schema — added to\n`case_configure_response_properties.yaml`.\n\n### 4. Example payloads didn't match real API output\n\nAuthor tested example files against a live Kibana and patched\ndiscrepancies:\n\n- **`add_comment_response.yaml`** — was missing `pushed_at`,\n`pushed_by`, `updated_at`, `updated_by`, and `profile_uid` on\n`created_by`.\n- **`push_case_response.yaml`** — was missing `assignees`,\n`customFields`, `category`, and `profile_uid` on\n`created_by`/`updated_by`.\n\n## Why the diff looks huge (+41,888 / −84,370)\n\nDon't be alarmed by the size. The vast majority of the churn is in three\nregenerated files:\n\n- `oas_docs/output/kibana.yaml` (+40,991 / −84,137)\n- `x-pack/platform/plugins/shared/cases/docs/openapi/bundled-types.json`\n-\n`x-pack/platform/plugins/shared/cases/docs/openapi/bundled-types.schema.yaml`\n\nThese are machine-generated bundles. A manual post-bundle fixup was\napplied to the schema YAML to convert Redocly's file-path discriminator\nmappings (`foo.yaml`) into the `#/components/schemas/foo` format that\n`kbn-openapi-bundler` requires, so that `make merge-api-docs-stateful`\ncontinues to work.\n\n## Key files to actually review\n\nThe hand-written changes (everything non-generated) are concentrated in:\n\n- `components/examples/` — new shared 401 example + updated response\nexamples\n- `components/parameters/` — added example values\n- `components/schemas/` — the three schema fixes\n- `paths/` — 16 path files got the 401 reference; a handful got new code\nsamples\n\n## Bottom line\n\nDocs-only cleanup. No runtime behavior changes, no tests to run, just\nsafer and more accurate public API documentation. Validator now passes\nwith **0 errors**.\n\n- written with Claude\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"61a520d49e389557c908761e231f74eac9d1dcaf"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/265404","number":265404,"state":"OPEN"},{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/263617","number":263617,"mergeCommit":{"message":"[Cases][Docs] - Add additional examples and cleanup to openApi (#263617)\n\n## Summary\n\nThis PR is a housekeeping pass on the public API documentation for\nKibana Cases. The docs had drifted from reality — some fields were\nmissing, some examples were wrong, some endpoints had no code samples,\nand the docs validator was throwing 22 errors. This PR makes the docs\nmatch what the API actually returns, and gets the validator to pass\ncleanly.\n\nNothing about the API itself changes. Only documentation and its\ngenerated bundles.\n\n## The four kinds of fixes\n\n### 1. Added missing \"unauthorized\" (401) examples\n\nEvery Cases endpoint was missing an example for its 401 response, which\ntripped the validator. Rather than copy-pasting the same example 16\ntimes, a shared `components/examples/response_401.yaml` was created and\nreferenced everywhere. One endpoint\n(`paths/api@cases@alerts@{alertid}.yaml`) was also using a deprecated\n`example:` format and got converted to the modern `examples:` map.\n\n### 2. Filled in missing code samples and request examples\n\nFour endpoints gained curl + Console code samples or request-body\nexamples — most notably:\n\n- **File upload** (`paths/api@cases@{caseid}@files.yaml`) — now shows\nmultipart form usage\n- **Push-to-connector**\n(`paths/api@cases@{caseid}@connector@{connectorid}@_push.yaml`) —\nclarified that no body is needed\n- **Delete comments** (both bulk and single) — added curl + Console\nsamples\n\nFive query-parameter component files also got `example:` values so the\nrendered docs aren't blank:\n\n- `page_index.yaml` → `1`\n- `page_size.yaml` → `20`\n- `sort_order.yaml` → `desc`\n- `severity.yaml` → `low`\n- `search.yaml` → `Case title 1`\n\n### 3. Schema inaccuracies — docs didn't match reality\n\nThree notable gaps between docs and actual API responses:\n\n- **`incremental_id` on cases** — added to\n`case_response_properties.yaml` and `case_response_get_case.yaml`, with\na note that it's populated asynchronously and won't appear in the\nimmediate `POST` response.\n- **User-action `type` enum was stale** — had 11 values, should have had\n16. Added `category`, `customFields`, `delete_case`, `extended_fields`,\n`observables` to `user_actions_find_response_properties.yaml`.\n- **`observableTypes` was completely missing** from the\ncase-configuration response schema — added to\n`case_configure_response_properties.yaml`.\n\n### 4. Example payloads didn't match real API output\n\nAuthor tested example files against a live Kibana and patched\ndiscrepancies:\n\n- **`add_comment_response.yaml`** — was missing `pushed_at`,\n`pushed_by`, `updated_at`, `updated_by`, and `profile_uid` on\n`created_by`.\n- **`push_case_response.yaml`** — was missing `assignees`,\n`customFields`, `category`, and `profile_uid` on\n`created_by`/`updated_by`.\n\n## Why the diff looks huge (+41,888 / −84,370)\n\nDon't be alarmed by the size. The vast majority of the churn is in three\nregenerated files:\n\n- `oas_docs/output/kibana.yaml` (+40,991 / −84,137)\n- `x-pack/platform/plugins/shared/cases/docs/openapi/bundled-types.json`\n-\n`x-pack/platform/plugins/shared/cases/docs/openapi/bundled-types.schema.yaml`\n\nThese are machine-generated bundles. A manual post-bundle fixup was\napplied to the schema YAML to convert Redocly's file-path discriminator\nmappings (`foo.yaml`) into the `#/components/schemas/foo` format that\n`kbn-openapi-bundler` requires, so that `make merge-api-docs-stateful`\ncontinues to work.\n\n## Key files to actually review\n\nThe hand-written changes (everything non-generated) are concentrated in:\n\n- `components/examples/` — new shared 401 example + updated response\nexamples\n- `components/parameters/` — added example values\n- `components/schemas/` — the three schema fixes\n- `paths/` — 16 path files got the 401 reference; a handful got new code\nsamples\n\n## Bottom line\n\nDocs-only cleanup. No runtime behavior changes, no tests to run, just\nsafer and more accurate public API documentation. Validator now passes\nwith **0 errors**.\n\n- written with Claude\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"61a520d49e389557c908761e231f74eac9d1dcaf"}}]}] BACKPORT-->