### PR TITLE
[Discover] Fix Discover failing to load legacy control groups

### DIFF
--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/tab_mapping_utils.test.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/tab_mapping_utils.test.ts
@@ -8,8 +8,10 @@
  */
 
 import { omit } from 'lodash';
+import { ESQL_CONTROL } from '@kbn/controls-constants';
 import { savedSearchMock } from '../../../../__mocks__/saved_search';
 import { createDiscoverServicesMock } from '../../../../__mocks__/services';
+import { mockControlState } from '../../../../__mocks__/esql_controls';
 import { getTabStateMock, getPersistedTabMock } from './__mocks__/internal_state.mocks';
 import {
   fromSavedObjectTabToSearchSource,
@@ -249,6 +251,37 @@ describe('tab mapping utils', () => {
           "uiState": Object {},
         }
       `);
+    });
+
+    it('should normalize legacy controlGroupJson when loading saved object tabs', () => {
+      const legacyControlsTab = getTabStateMock({
+        id: 'legacy-controls-tab',
+        label: 'Legacy controls tab',
+        initialInternalState: {
+          serializedSearchSource: { index: 'test-data-view-legacy' },
+        },
+        attributes: {
+          controlGroupState: mockControlState,
+          visContext: undefined,
+        },
+      });
+
+      const tabState = fromSavedObjectTabToTabState({
+        tab: fromTabStateToSavedObjectTab({
+          tab: legacyControlsTab,
+          services,
+          currentDataView: undefined,
+        }),
+        existingTab: tab1,
+      });
+
+      expect(tabState.attributes.controlGroupState).toEqual({
+        ...mockControlState,
+        panel1: {
+          ...mockControlState.panel1,
+          type: ESQL_CONTROL,
+        },
+      });
     });
   });
 

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/utils.test.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/utils.test.ts
@@ -11,6 +11,7 @@ import {
   createTabItem,
   extractEsqlVariables,
   getSerializedSearchSourceDataViewDetails,
+  parseControlGroupJson,
 } from './utils';
 import { type TabState } from './types';
 import { getTabStateMock } from './__mocks__/internal_state.mocks';
@@ -156,5 +157,55 @@ describe('extractEsqlVariables', () => {
         value: ['1', '2', '3'],
       },
     ]);
+  });
+
+  it('should extract variables from legacy parsed control panels', () => {
+    const panels = parseControlGroupJson(
+      JSON.stringify({
+        panel1: {
+          ...createMockESQLControlPanel('legacyVar', ESQLVariableType.VALUES, ['legacyValue']),
+          type: 'esqlControl',
+        },
+      })
+    );
+
+    expect(panels.panel1?.type).toBe(ESQL_CONTROL);
+    expect(extractEsqlVariables(panels)).toEqual([
+      {
+        key: 'legacyVar',
+        type: ESQLVariableType.VALUES,
+        value: 'legacyValue',
+      },
+    ]);
+  });
+});
+
+describe('parseControlGroupJson', () => {
+  it('should normalize legacy esqlControl panel types', () => {
+    expect(
+      parseControlGroupJson(
+        JSON.stringify({
+          panel1: {
+            type: 'esqlControl',
+            variable_name: 'legacyVar',
+          },
+          panel2: {
+            type: 'options_list_control',
+          },
+        })
+      )
+    ).toEqual({
+      panel1: {
+        type: ESQL_CONTROL,
+        variable_name: 'legacyVar',
+      },
+      panel2: {
+        type: 'options_list_control',
+      },
+    });
+  });
+
+  it('should return an empty object for invalid JSON', () => {
+    expect(parseControlGroupJson('{')).toEqual({});
   });
 });

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/utils.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/utils.ts
@@ -121,7 +121,24 @@ export const parseControlGroupJson = (
   jsonString?: string | null
 ): ControlPanelsState<OptionsListESQLControlState> => {
   try {
-    return jsonString ? JSON.parse(jsonString) : {};
+    if (!jsonString) {
+      return {};
+    }
+
+    const controlGroup = JSON.parse(jsonString) as ControlPanelsState<OptionsListESQLControlState>;
+
+    if (!isObject(controlGroup)) {
+      return {};
+    }
+
+    for (const panel of Object.values(controlGroup)) {
+      // Migrate legacy control type if necessary
+      if (panel.type === 'esqlControl') {
+        panel.type = ESQL_CONTROL;
+      }
+    }
+
+    return controlGroup;
   } catch (e) {
     return {};
   }

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/tabs_storage_manager.test.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/tabs_storage_manager.test.tsx
@@ -8,8 +8,10 @@
  */
 
 import { omit } from 'lodash';
+import { ESQL_CONTROL } from '@kbn/controls-constants';
 import type { UnifiedHistogramVisContext } from '@kbn/unified-histogram';
 import { createKbnUrlStateStorage, Storage } from '@kbn/kibana-utils-plugin/public';
+import { mockControlState } from '../../../__mocks__/esql_controls';
 import { createDiscoverServicesMock } from '../../../__mocks__/services';
 import {
   createTabsStorageManager,
@@ -283,7 +285,7 @@ describe('TabsStorageManager', () => {
     const storedSerializedSearchSource = { index: 'test-index' };
     const storedSearchSessionId = 'test-session-id';
     const legacyVisContext = { legacyVis: 'legacyValue' };
-    const legacyControlGroupState = { legacyControlGroup: 'legacyGroupValue' };
+    const legacyControlGroupState = mockControlState;
 
     const toLegacyStoredTab = (tab: TabState | RecentlyClosedTabState) => {
       const storedTab = { ...toStoredTab(tab), attributes: undefined };
@@ -319,13 +321,74 @@ describe('TabsStorageManager', () => {
     const loadedTab = loadedProps.allTabs[0];
     expect(loadedTab.attributes).toStrictEqual({
       visContext: legacyVisContext,
-      controlGroupState: legacyControlGroupState,
+      controlGroupState: {
+        ...legacyControlGroupState,
+        panel1: {
+          ...legacyControlGroupState.panel1,
+          type: ESQL_CONTROL,
+        },
+      },
       timeRestore: false,
     });
+    expect(loadedTab.esqlVariables).toStrictEqual([
+      {
+        key: 'foo',
+        type: 'values',
+        value: 'bar',
+      },
+    ]);
     expect(loadedTab.initialInternalState).toStrictEqual({
       serializedSearchSource: storedSerializedSearchSource,
       searchSessionId: storedSearchSessionId,
     });
+  });
+
+  it('should normalize legacy controlGroupState stored in attributes', async () => {
+    const {
+      tabsStorageManager,
+      urlStateStorage,
+      services: { storage },
+    } = create();
+
+    storage.set(TABS_LOCAL_STORAGE_KEY, {
+      userId: mockUserId,
+      spaceId: mockSpaceId,
+      openTabs: [
+        {
+          ...toStoredTab(mockTab1),
+          attributes: {
+            ...mockTab1.attributes,
+            controlGroupState: mockControlState,
+          },
+        },
+      ],
+      closedTabs: [],
+    });
+
+    await urlStateStorage.set(TAB_STATE_URL_KEY, {
+      tabId: mockTab1.id,
+    });
+
+    const loadedProps = tabsStorageManager.loadLocally({
+      userId: mockUserId,
+      spaceId: mockSpaceId,
+      defaultTabState: DEFAULT_TAB_STATE,
+    });
+
+    expect(loadedProps.allTabs[0]?.attributes.controlGroupState).toStrictEqual({
+      ...mockControlState,
+      panel1: {
+        ...mockControlState.panel1,
+        type: ESQL_CONTROL,
+      },
+    });
+    expect(loadedProps.allTabs[0]?.esqlVariables).toStrictEqual([
+      {
+        key: 'foo',
+        type: 'values',
+        value: 'bar',
+      },
+    ]);
   });
 
   it('should clear tabs and select a default one', () => {

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/tabs_storage_manager.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/tabs_storage_manager.ts
@@ -222,7 +222,9 @@ export const createTabsStorageManager = ({
       tabStateInStorage.globalState || defaultTabState.globalState
     );
 
-    let controlGroupState = attributes?.controlGroupState;
+    let controlGroupState = attributes?.controlGroupState
+      ? parseControlGroupJson(JSON.stringify(attributes.controlGroupState))
+      : attributes?.controlGroupState;
 
     // migration from the older format where controlGroupJson was stored in internalState
     if (internalState && 'controlGroupJson' in internalState && !attributes?.controlGroupState) {

--- a/src/platform/plugins/shared/discover/public/embeddable/utils/add_controls_from_saved_session.test.ts
+++ b/src/platform/plugins/shared/discover/public/embeddable/utils/add_controls_from_saved_session.test.ts
@@ -131,5 +131,29 @@ describe('addControlsFromSavedSession', () => {
       expect(addedPanels).not.toContain(['var1', 'var2']);
       expect(addedPanels).toEqual(['nonExistentVar']);
     });
+
+    it('should normalize legacy esqlControl panels through parseControlGroupJson', async () => {
+      await addControlsFromSavedSession(
+        mockContainer,
+        JSON.stringify({
+          panel1: {
+            type: 'esqlControl',
+            order: 0,
+            variable_name: 'nonExistentVar',
+          },
+        })
+      );
+
+      expect(mockContainer.addNewPanel).toHaveBeenCalledWith(
+        {
+          panelType: ESQL_CONTROL,
+          serializedState: {
+            variable_name: 'nonExistentVar',
+            type: ESQL_CONTROL,
+          },
+        },
+        { beside: undefined, scrollToPanel: false }
+      );
+    });
   });
 });

--- a/src/platform/plugins/shared/discover/public/embeddable/utils/add_controls_from_saved_session.ts
+++ b/src/platform/plugins/shared/discover/public/embeddable/utils/add_controls_from_saved_session.ts
@@ -8,19 +8,16 @@
  */
 import type { CanAddNewPanel } from '@kbn/presentation-publishing';
 import type { PublishesESQLVariables } from '@kbn/esql-types';
-import type { OptionsListESQLControlState } from '@kbn/controls-schemas';
-import type { ControlPanelsState } from '@kbn/control-group-renderer';
 import { ESQL_CONTROL } from '@kbn/controls-constants';
 import { omit } from 'lodash';
+import { parseControlGroupJson } from '../../application/main/state_management/redux/utils';
 
 export const addControlsFromSavedSession = async (
   container: CanAddNewPanel & Partial<PublishesESQLVariables>,
   controlGroupJson: string,
   uuid?: string | undefined
 ): Promise<void> => {
-  const controlsState = controlGroupJson.length
-    ? (JSON.parse(controlGroupJson) as ControlPanelsState<OptionsListESQLControlState>)
-    : {};
+  const controlsState = parseControlGroupJson(controlGroupJson);
   const esqlVariables$ = container.esqlVariables$;
   const esqlVariables = esqlVariables$?.getValue();
 


### PR DESCRIPTION
## Summary

This PR fixes legacy control groups within imported Discover sessions failing to load. Not sure it's the best long term fix, but should at least work as a quick fix.

Sample Discover session with legacy controls (rename to `.ndjson`): [controls.json](https://github.com/user-attachments/files/27035550/controls.json)

Fixes #265397.

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->