### PR TITLE
Split discover/embeddable FTR config to reduce CI duration

### DIFF
--- a/.buildkite/ftr_platform_stateful_configs.yml
+++ b/.buildkite/ftr_platform_stateful_configs.yml
@@ -86,6 +86,7 @@ enabled:
   - src/platform/test/functional/apps/dashboard/esql_controls/config.ts
   - src/platform/test/functional/apps/discover/ccs_compatibility/config.ts
   - src/platform/test/functional/apps/discover/embeddable/config.ts
+  - src/platform/test/functional/apps/discover/embeddable_2/config.ts
   - src/platform/test/functional/apps/discover/esql_1/config.ts
   - src/platform/test/functional/apps/discover/esql_2/config.ts
   - src/platform/test/functional/apps/discover/esql_3/config.ts

--- a/src/platform/test/functional/apps/discover/embeddable_2/config.ts
+++ b/src/platform/test/functional/apps/discover/embeddable_2/config.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { FtrConfigProviderContext } from '@kbn/test';
+
+export default async function ({ readConfigFile }: FtrConfigProviderContext) {
+  const functionalConfig = await readConfigFile(require.resolve('../../../config.base.js'));
+
+  return {
+    ...functionalConfig.getAll(),
+    testFiles: [require.resolve('.')],
+  };
+}

--- a/src/platform/test/functional/apps/discover/embeddable_2/index.ts
+++ b/src/platform/test/functional/apps/discover/embeddable_2/index.ts
@@ -13,7 +13,7 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
   const esArchiver = getService('esArchiver');
   const browser = getService('browser');
 
-  describe('discover/embeddable', function () {
+  describe('discover/embeddable_2', function () {
     before(async function () {
       await browser.setWindowSize(1300, 800);
     });
@@ -24,6 +24,10 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
       );
     });
 
-    loadTestFile(require.resolve('./_saved_search_embeddable'));
+    loadTestFile(require.resolve('../embeddable/multiple_data_views'));
+    loadTestFile(require.resolve('../embeddable/_log_stream_embeddable'));
+    loadTestFile(require.resolve('../embeddable/_esql_embeddable'));
+    loadTestFile(require.resolve('../embeddable/_new_panel_embeddable'));
+    loadTestFile(require.resolve('../embeddable/_save_session_to_dashboard'));
   });
 }


### PR DESCRIPTION
## Summary

The `discover/embeddable` FTR config has been consistently exceeding the 27-minute CI warning threshold (p75 ~30 min) on **100% of kibana-on-merge builds since Apr 16**.

This PR splits the suite into two groups to bring each under the threshold:

| Group | Tests | Estimated Duration |
|-------|-------|--------------------|
| `embeddable` | `_saved_search_embeddable` (16 tests) | ~14-20 min |
| `embeddable_2` | `multiple_data_views`, `_log_stream_embeddable`, `_esql_embeddable`, `_new_panel_embeddable`, `_save_session_to_dashboard` (18 tests) | ~16-22 min |

### What changed
- **`embeddable/index.ts`**: removed 5 `loadTestFile` calls (kept only `_saved_search_embeddable`)
- **`embeddable_2/config.ts`** (new): FTR config pointing to the same `config.base.js`
- **`embeddable_2/index.ts`** (new): loads the 5 moved test files via relative paths from `../embeddable/`
- **`ftr_platform_stateful_configs.yml`**: registered the new config

No spec files were modified -- `embeddable_2/index.ts` references them from their original location.

## Test plan

- [ ] CI passes with both `embeddable` and `embeddable_2` groups running independently
- [ ] Verify both groups land under the 27-minute threshold after a few on-merge runs


Made with [Cursor](https://cursor.com)

<!--ONMERGE {"backportTargets":["8.19","9.3","9.4"]} ONMERGE-->