### PR TITLE
[SigEvents] register kibana-url flag for env snapshot CLIs

### DIFF
--- a/x-pack/platform/packages/shared/kbn-evals-suite-significant-events/scripts/capture_env_snapshot/index.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-significant-events/scripts/capture_env_snapshot/index.ts
@@ -32,6 +32,7 @@ run(({ log, flags }) => captureEnvSnapshot({ log, flags }), {
       'es-url',
       'es-username',
       'es-password',
+      'kibana-url',
       'snapshot-name',
       'run-id',
       'logs-index',

--- a/x-pack/platform/packages/shared/kbn-evals-suite-significant-events/scripts/capture_env_snapshot/index.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-significant-events/scripts/capture_env_snapshot/index.ts
@@ -52,6 +52,7 @@ run(({ log, flags }) => captureEnvSnapshot({ log, flags }), {
       --es-url                Elasticsearch URL (default: from kibana.dev.yml)
       --es-username           ES username (default: from kibana.dev.yml)
       --es-password           ES password (default: from kibana.dev.yml)
+      --kibana-url            Kibana base URL (default: from kibana.dev.yml)
     `,
   },
 });

--- a/x-pack/platform/packages/shared/kbn-evals-suite-significant-events/scripts/restore_env_snapshot/index.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-significant-events/scripts/restore_env_snapshot/index.ts
@@ -42,6 +42,7 @@ run(({ log, flags }) => restoreEnvSnapshot({ log, flags }), {
       'es-url',
       'es-username',
       'es-password',
+      'kibana-url',
       'snapshot-name',
       'gcs-bucket',
       'gcs-base-path',

--- a/x-pack/platform/packages/shared/kbn-evals-suite-significant-events/scripts/restore_env_snapshot/index.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-significant-events/scripts/restore_env_snapshot/index.ts
@@ -69,6 +69,7 @@ run(({ log, flags }) => restoreEnvSnapshot({ log, flags }), {
       --es-url                Elasticsearch URL (default: from kibana.dev.yml)
       --es-username           ES username (default: from kibana.dev.yml)
       --es-password           ES password (default: from kibana.dev.yml)
+      --kibana-url            Kibana base URL (default: from kibana.dev.yml)
     `,
   },
 });

--- a/x-pack/platform/packages/shared/kbn-evals-suite-significant-events/scripts/restore_env_snapshot/restore_env_snapshot.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-significant-events/scripts/restore_env_snapshot/restore_env_snapshot.ts
@@ -143,7 +143,7 @@ export const restoreEnvSnapshot = async ({
   const clean = Boolean(flags.clean);
   const { snapshotName, systemIndices, alertIndices, logsIndex } = parseCommonSnapshotFlags(flags);
 
-  log.info(`Restore: ${snapshotName} | ES: ${config.esUrl}`);
+  log.info(`Restore: ${snapshotName} | ES: ${config.esUrl} | Kibana: ${config.kibanaUrl}`);
   log.info(`GCS bucket: ${gcsBucket} | Base path: ${gcsBasePath}`);
   log.info(`Data indices: ${[logsIndex, ...alertIndices].join(', ')}`);
   log.info(`System indices: ${systemIndices.join(', ')}`);


### PR DESCRIPTION
## Summary

Registers `kibana-url` in the `@kbn/dev-cli-runner` `string` flags for the SigEvents environment snapshot CLIs (`capture_sigevents_env_snapshot.js` and `restore_sigevents_env_snapshot.js`) so `--kibana-url` is parsed and passed through instead of being ignored.

### How to test

- Run `node scripts/capture_sigevents_env_snapshot.js --help` and `node scripts/restore_sigevents_env_snapshot.js --help` from `x-pack/platform/packages/shared/kbn-evals-suite-significant-events` and confirm `--kibana-url` appears in the documented flags (if your wrapper surfaces `string` flags).
- Optionally invoke either script with `--kibana-url http://localhost:5601/...` and confirm the value is no longer dropped by the flag parser.

---
🤖 Co-authored with AI assistance.
