### PR TITLE
[Infra] Keep Hosts UI time range fresh on refresh

### DIFF
--- a/x-pack/solutions/observability/plugins/infra/public/hooks/use_time_range.test.ts
+++ b/x-pack/solutions/observability/plugins/infra/public/hooks/use_time_range.test.ts
@@ -8,14 +8,22 @@
 import { renderHook } from '@testing-library/react';
 import { useTimeRange } from './use_time_range';
 import * as datemath from '../utils/datemath';
+import * as reloadRequestTimeModule from './use_reload_request_time';
 
 jest.mock('../utils/datemath');
+jest.mock('./use_reload_request_time');
 
 describe('useTimeRange', () => {
   const mockParseDateRange = datemath.parseDateRange as jest.Mock;
+  const mockUseReloadRequestTimeContext =
+    reloadRequestTimeModule.useReloadRequestTimeContext as jest.Mock;
 
   beforeEach(() => {
     Date.now = jest.fn(() => new Date(Date.UTC(2021, 0, 1, 12)).valueOf());
+    mockUseReloadRequestTimeContext.mockReturnValue({
+      reloadRequestTime: 0,
+      updateReloadRequestTime: jest.fn(),
+    });
   });
 
   afterEach(() => {
@@ -55,5 +63,39 @@ describe('useTimeRange', () => {
 
     expect(result.current.from).toBe(expectedFrom);
     expect(result.current.to).toBe(expectedTo);
+  });
+
+  it('recomputes the resolved date range when reloadRequestTime changes', () => {
+    // Simulate wall-clock advancing between the first and second parse.
+    const firstFrom = '2021-01-01T11:45:00.000Z';
+    const firstTo = '2021-01-01T12:00:00.000Z';
+    const secondFrom = '2021-01-01T11:50:00.000Z';
+    const secondTo = '2021-01-01T12:05:00.000Z';
+
+    mockParseDateRange
+      .mockReturnValueOnce({ from: firstFrom, to: firstTo })
+      .mockReturnValueOnce({ from: secondFrom, to: secondTo });
+
+    mockUseReloadRequestTimeContext.mockReturnValue({
+      reloadRequestTime: 1_000,
+      updateReloadRequestTime: jest.fn(),
+    });
+
+    const { result, rerender } = renderHook(() =>
+      useTimeRange({ rangeFrom: 'now-15m', rangeTo: 'now' })
+    );
+
+    expect(result.current).toEqual({ from: firstFrom, to: firstTo });
+
+    // Simulate refresh: reloadRequestTime advances.
+    mockUseReloadRequestTimeContext.mockReturnValue({
+      reloadRequestTime: 2_000,
+      updateReloadRequestTime: jest.fn(),
+    });
+
+    rerender();
+
+    expect(mockParseDateRange).toHaveBeenCalledTimes(2);
+    expect(result.current).toEqual({ from: secondFrom, to: secondTo });
   });
 });

--- a/x-pack/solutions/observability/plugins/infra/public/hooks/use_time_range.ts
+++ b/x-pack/solutions/observability/plugins/infra/public/hooks/use_time_range.ts
@@ -7,6 +7,7 @@
 
 import { useMemo } from 'react';
 import { parseDateRange } from '../utils/datemath';
+import { useReloadRequestTimeContext } from './use_reload_request_time';
 
 const DEFAULT_FROM_IN_MILLISECONDS = 15 * 60000;
 
@@ -20,6 +21,12 @@ const getDefaultTimestamps = () => {
 };
 
 export const useTimeRange = ({ rangeFrom, rangeTo }: { rangeFrom?: string; rangeTo?: string }) => {
+  // Relative datemath strings (e.g. `now-15m`, `now`) are resolved to absolute ISO
+  // timestamps here. Including `reloadRequestTime` as a dependency ensures the memo
+  // is re-evaluated whenever a refresh is requested, so the resolved window advances
+  // with wall-clock time and keeps downstream consumers (table, KPIs, metadata) in sync.
+  const { reloadRequestTime } = useReloadRequestTimeContext();
+
   const parsedDateRange = useMemo(() => {
     const defaults = getDefaultTimestamps();
 
@@ -33,7 +40,9 @@ export const useTimeRange = ({ rangeFrom, rangeTo }: { rangeFrom?: string; range
     });
 
     return { from, to };
-  }, [rangeFrom, rangeTo]);
+    // `reloadRequestTime` is intentionally included to re-resolve relative datemath on refresh.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [rangeFrom, rangeTo, reloadRequestTime]);
 
   return parsedDateRange;
 };

--- a/x-pack/solutions/observability/plugins/infra/public/pages/metrics/hosts/components/kpis/kpi_charts.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/pages/metrics/hosts/components/kpis/kpi_charts.tsx
@@ -65,7 +65,7 @@ export const getSubtitle = ({
 };
 
 export const KpiCharts = () => {
-  const { searchCriteria } = useUnifiedSearchContext();
+  const { searchCriteria, parsedDateRange } = useUnifiedSearchContext();
   const { reloadRequestTime } = useReloadRequestTimeContext();
   const { hostNodes, loading: hostsLoading, error } = useHostsViewContext();
   const { loading: hostCountLoading, count: hostCount } = useHostCountContext();
@@ -95,9 +95,15 @@ export const KpiCharts = () => {
 
   // prevents requests and searchCriteria state from reloading the chart
   // we want it to reload only once the table has finished loading.
-  // attributes passed to useAfterLoadedState don't need to be memoized
+  // attributes passed to useAfterLoadedState don't need to be memoized.
+  //
+  // Use the resolved absolute timestamps (parsedDateRange) instead of the raw
+  // relative strings from searchCriteria.dateRange so that Lens queries the
+  // exact same window the table was populated from. This keeps KPIs consistent
+  // with the hosts table and prevents N/A when relative ranges drift between
+  // the two after the page has been idle.
   const { afterLoadedState } = useAfterLoadedState(loading, {
-    dateRange: searchCriteria.dateRange,
+    dateRange: parsedDateRange,
     query: shouldUseSearchCriteria ? searchCriteria.query : undefined,
     filters,
     reloadRequestTime,

--- a/x-pack/solutions/observability/plugins/infra/public/pages/metrics/hosts/components/tabs/metrics/chart.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/pages/metrics/hosts/components/tabs/metrics/chart.tsx
@@ -27,7 +27,7 @@ export type ChartProps = LensConfig & {
 };
 
 export const Chart = ({ id, dataView, ...chartProps }: ChartProps) => {
-  const { searchCriteria } = useUnifiedSearchContext();
+  const { searchCriteria, parsedDateRange } = useUnifiedSearchContext();
   const { loading, error, hostNodes } = useHostsViewContext();
   const { reloadRequestTime } = useReloadRequestTimeContext();
   const { currentPage } = useHostsTableContext();
@@ -36,9 +36,15 @@ export const Chart = ({ id, dataView, ...chartProps }: ChartProps) => {
 
   // prevents searchCriteria state from reloading the chart
   // we want it to reload only once the table has finished loading.
-  // attributes passed to useAfterLoadedState don't need to be memoized
+  // attributes passed to useAfterLoadedState don't need to be memoized.
+  //
+  // Use the resolved absolute timestamps (parsedDateRange) instead of the raw
+  // relative strings from searchCriteria.dateRange so Lens queries the same
+  // window the hosts table was populated from. Otherwise, on idle pages using
+  // relative ranges (e.g. `now-15m`), the table filter (stale absolute times)
+  // and the chart window (live relative times) can diverge and return N/A.
   const { afterLoadedState } = useAfterLoadedState(loading, {
-    dateRange: searchCriteria.dateRange,
+    dateRange: parsedDateRange,
     query: shouldUseSearchCriteria ? searchCriteria.query : undefined,
     reloadRequestTime,
   });


### PR DESCRIPTION
## Summary

Closes elastic/kibana#265513

Fixes the Hosts UI showing `N/A` on KPI tiles (and a table out of sync with the charts) when a relative time range is used and the page has been idle for longer than the selected range. The in-app Refresh currently does not recover the page; only a full browser reload does.

Two compounding issues, fixed together:

1. `useTimeRange` memoized the resolved `parsedDateRange` with `[rangeFrom, rangeTo]`. For relative ranges (`now-15m`, `now`) those strings never change, so the resolved absolute window was frozen at first mount. The in-app Refresh bumped `reloadRequestTime` but did not invalidate this memo, so `useHostsView` kept querying the stale window.
2. `kpi_charts.tsx` and `tabs/metrics/chart.tsx` forwarded the raw `searchCriteria.dateRange` strings to Lens while `useHostsView` used the memoized absolute `parsedDateRange`. Lens re-resolves `now` on every render, so charts drifted forward while the table's window stayed pinned. The charts then filtered by `host.name IN (…stale table hosts…)` over the current window → `N/A` whenever those hosts had rotated out.

### Changes

- `x-pack/solutions/observability/plugins/infra/public/hooks/use_time_range.ts` — add `reloadRequestTime` (from `useReloadRequestTimeContext`) to the `useMemo` deps so the resolved window advances on refresh. Mirrors APM's `useTimeRange` (`timeRangeId` dependency).
- `x-pack/solutions/observability/plugins/infra/public/pages/metrics/hosts/components/kpis/kpi_charts.tsx` — pass the resolved `parsedDateRange` to Lens instead of the raw relative strings.
- `x-pack/solutions/observability/plugins/infra/public/pages/metrics/hosts/components/tabs/metrics/chart.tsx` — same treatment for the Metrics-tab chart.
- `x-pack/solutions/observability/plugins/infra/public/hooks/use_time_range.test.ts` — mock the new context dependency and add a regression test asserting the memo re-resolves when `reloadRequestTime` changes.

### Demo
#### Before

https://github.com/user-attachments/assets/eaa64311-09a8-4a7d-aabe-9f6bea4770b5


#### After

https://github.com/user-attachments/assets/19a14957-bf92-4b43-9ec5-204c25f34730


### How to reproduce

1. Turn auto-refresh off in the date picker.
2. Ingest a synthtrace scenario, for example: "infra_hosts_with_apm_hosts"
3. Select `Last 1 minute`.
4. Wait ~2 minutes without interacting.
5. Ingest another synthtrace scenario, for example "infra_hosts_ecs"
6. Click the in-app **Refresh** (not F5).
7. Before the fix: KPI tiles flip to `N/A` on fleets with rotating host identities; the Hosts table lists hosts from the stale window. Network tab confirms the `/api/metrics/infra/host` request still uses the stale absolute `range`, while the Lens `bsearch` uses a fresh `now-1m`/`now` window.
8. After the fix: both requests use the same fresh absolute window; the table and KPIs stay in sync.

<!--ONMERGE {"backportTargets":["8.19","9.3","9.4"]} ONMERGE-->