### PR TITLE
fix(streams): treat missing backing data stream as empty state

### DIFF
--- a/x-pack/platform/plugins/shared/streams/server/agent_builder/tools/read/get_lifecycle_stats.ts
+++ b/x-pack/platform/plugins/shared/streams/server/agent_builder/tools/read/get_lifecycle_stats.ts
@@ -11,6 +11,7 @@ import { ToolResultType } from '@kbn/agent-builder-common/tools/tool_result';
 import type { BuiltinToolDefinition } from '@kbn/agent-builder-server';
 import { Streams, isIlmLifecycle, isDslLifecycle, isInheritLifecycle } from '@kbn/streams-schema';
 import type { IngestStreamEffectiveLifecycle } from '@kbn/streams-schema';
+import { isNotFoundError } from '@kbn/es-errors';
 import dedent from 'dedent';
 import type { GetScopedClients } from '../../../routes/types';
 import {
@@ -72,7 +73,26 @@ export const createGetLifecycleStatsTool = ({
         };
       }
 
-      const dataStream = await streamsClient.getDataStream(name);
+      let dataStream;
+      try {
+        dataStream = await streamsClient.getDataStream(name);
+      } catch (err) {
+        if (isNotFoundError(err)) {
+          return {
+            results: [
+              {
+                type: ToolResultType.other,
+                data: {
+                  stream: name,
+                  message:
+                    'Stream has no backing data stream yet (no data has been onboarded). Lifecycle stats are unavailable.',
+                },
+              },
+            ],
+          };
+        }
+        throw err;
+      }
       const lifecycle = await getEffectiveLifecycle({ definition, streamsClient, dataStream });
 
       const retentionInfo = buildRetentionInfo(lifecycle);

--- a/x-pack/platform/plugins/shared/streams/server/lib/sig_events/features/identify_computed_features.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/sig_events/features/identify_computed_features.ts
@@ -9,6 +9,7 @@ import type { ElasticsearchClient } from '@kbn/core/server';
 import type { Logger } from '@kbn/logging';
 import type { Feature, Streams } from '@kbn/streams-schema';
 import { generateAllComputedFeatures } from '@kbn/streams-ai';
+import { isNotFoundError } from '@kbn/es-errors';
 import type { FeatureClient } from '../../streams/feature/feature_client';
 import { reconcileComputedFeatures } from './reconcile_features';
 
@@ -35,13 +36,28 @@ export async function identifyComputedFeatures({
   featureTtlDays,
   runId,
 }: IdentifyComputedFeaturesOptions): Promise<Feature[]> {
-  const computedFeatures = await generateAllComputedFeatures({
-    stream,
-    start,
-    end,
-    esClient,
-    logger: logger.get('computed_features'),
-  });
+  let computedFeatures;
+  try {
+    computedFeatures = await generateAllComputedFeatures({
+      stream,
+      start,
+      end,
+      esClient,
+      logger: logger.get('computed_features'),
+    });
+  } catch (err) {
+    // A stream can exist without a materialized backing data stream yet
+    // (e.g. a wired root stream before any data has been onboarded). That's
+    // a normal state, not a failure — there's simply nothing to analyze.
+    if (isNotFoundError(err)) {
+      logger.debug(
+        () =>
+          `Skipping computed features for ${streamName}: backing data stream not materialized yet`
+      );
+      return [];
+    }
+    throw err;
+  }
 
   const reconciledComputedFeatures = reconcileComputedFeatures({
     computedFeatures,

--- a/x-pack/platform/plugins/shared/streams/server/lib/tasks/task_definitions/features_identification/fetch_sample_documents.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/tasks/task_definitions/features_identification/fetch_sample_documents.ts
@@ -12,6 +12,7 @@ import type { FeatureWithFilter } from '@kbn/streams-schema';
 import { getDiverseSampleDocuments, getSampleDocuments } from '@kbn/ai-tools';
 import { conditionToQueryDsl, getConditionFields } from '@kbn/streamlang';
 import type { Condition } from '@kbn/streamlang';
+import { isNotFoundError } from '@kbn/es-errors';
 import { getEntityFilters } from './get_entity_filters';
 import { parseError } from '../../../streams/errors/parse_error';
 
@@ -19,19 +20,7 @@ const EMPTY_SAMPLE: { hits: Array<SearchHit<Record<string, unknown>>> } = { hits
 
 type SamplingStrategy = 'entity-filtered' | 'diverse' | 'random';
 
-export async function fetchSampleDocuments({
-  esClient,
-  index,
-  start,
-  end,
-  features,
-  logger,
-  size,
-  entityFilteredRatio,
-  diverseRatio,
-  maxEntityFilters,
-  diverseOffset = 0,
-}: {
+interface FetchSampleDocumentsOptions {
   esClient: ElasticsearchClient;
   index: string;
   start: number;
@@ -43,7 +32,59 @@ export async function fetchSampleDocuments({
   diverseRatio: number;
   diverseOffset?: number;
   maxEntityFilters: number;
-}) {
+}
+
+interface FetchSampleDocumentsResult {
+  documents: Array<SearchHit<Record<string, unknown>>>;
+  totalFilters: number;
+  filtersCapped: boolean;
+  hasFilteredDocuments: boolean;
+  nextOffset: number;
+}
+
+function emptyResult(diverseOffset: number): FetchSampleDocumentsResult {
+  return {
+    documents: [],
+    totalFilters: 0,
+    filtersCapped: false,
+    hasFilteredDocuments: false,
+    nextOffset: diverseOffset,
+  };
+}
+
+export async function fetchSampleDocuments(
+  options: FetchSampleDocumentsOptions
+): Promise<FetchSampleDocumentsResult> {
+  try {
+    return await fetchSampleDocumentsInner(options);
+  } catch (err) {
+    // A stream definition can exist without a materialized backing data
+    // stream yet (e.g. wired root streams before any data is onboarded).
+    // Treat that as "no documents to sample" rather than a failure.
+    if (isNotFoundError(err)) {
+      options.logger.debug(
+        () =>
+          `No sample documents for ${options.index}: backing data stream not materialized yet`
+      );
+      return emptyResult(options.diverseOffset ?? 0);
+    }
+    throw err;
+  }
+}
+
+async function fetchSampleDocumentsInner({
+  esClient,
+  index,
+  start,
+  end,
+  features,
+  logger,
+  size,
+  entityFilteredRatio,
+  diverseRatio,
+  maxEntityFilters,
+  diverseOffset = 0,
+}: FetchSampleDocumentsOptions): Promise<FetchSampleDocumentsResult> {
   if (entityFilteredRatio < 0 || diverseRatio < 0) {
     throw new Error(
       `entityFilteredRatio (${entityFilteredRatio}) and diverseRatio (${diverseRatio}) must be >= 0`

--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/lifecycle/route.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/lifecycle/route.ts
@@ -10,6 +10,7 @@ import { BooleanFromString } from '@kbn/zod-helpers/v4';
 import type { IndicesGetResponse } from '@elastic/elasticsearch/lib/api/types';
 import type { IScopedClusterClient } from '@kbn/core/server';
 import { Streams, isIlmLifecycle, type IlmPolicyWithUsage } from '@kbn/streams-schema';
+import { isNotFoundError } from '@kbn/es-errors';
 import { processAsyncInChunks } from '../../../../utils/process_async_in_chunks';
 import { STREAMS_API_PRIVILEGES } from '../../../../../common/constants';
 import { createServerRoute } from '../../../create_server_route';
@@ -82,7 +83,19 @@ const lifecycleStatsRoute = createServerRoute({
       throw new StatusError('Lifecycle stats are only available for ingest streams', 400);
     }
 
-    const dataStream = await streamsClient.getDataStream(name);
+    // A stream definition can exist without a materialized backing data
+    // stream yet (e.g. wired root streams before any data is onboarded).
+    // Return empty stats in that case rather than leaking an ES error.
+    const dataStream = await streamsClient.getDataStream(name).catch((err) => {
+      if (isNotFoundError(err)) {
+        return null;
+      }
+      throw err;
+    });
+    if (!dataStream) {
+      return { phases: [] };
+    }
+
     const lifecycle = await getEffectiveLifecycle({ definition, streamsClient, dataStream });
     if (!isIlmLifecycle(lifecycle)) {
       throw new StatusError('Lifecycle stats are only available for ILM policy', 400);

--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/management/unmanaged_assets_route.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/management/unmanaged_assets_route.ts
@@ -7,6 +7,7 @@
 
 import { Streams } from '@kbn/streams-schema';
 import { z } from '@kbn/zod/v4';
+import { isNotFoundError } from '@kbn/es-errors';
 import { SecurityError } from '../../../../lib/streams/errors/security_error';
 import { StatusError } from '../../../../lib/streams/errors/status_error';
 import { WrongStreamTypeError } from '../../../../lib/streams/errors/wrong_stream_type_error';
@@ -54,7 +55,17 @@ export const unmanagedAssetsRoute = createServerRoute({
       );
     }
 
-    const dataStream = await streamsClient.getDataStream(params.path.name);
+    // Classic streams wrap an existing data stream; if the backing data
+    // stream is missing, surface a typed 404 instead of a raw ES error.
+    const dataStream = await streamsClient.getDataStream(params.path.name).catch((err) => {
+      if (isNotFoundError(err)) {
+        throw new StatusError(
+          `Stream ${params.path.name} has no backing data stream`,
+          404
+        );
+      }
+      throw err;
+    });
 
     if (dataStream.replicated === true) {
       throw new StatusError(

--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/processing/route.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/processing/route.ts
@@ -11,6 +11,7 @@ import {
   isEnabledFailureStore,
   namedFieldDefinitionConfigSchema,
 } from '@kbn/streams-schema';
+import { isNotFoundError } from '@kbn/es-errors';
 import type { DataStreamWithFailureStore } from '@kbn/streams-schema/src/models/ingest/failure_store';
 import { z } from '@kbn/zod/v4';
 import { streamlangDSLSchema } from '@kbn/streamlang';
@@ -313,8 +314,18 @@ export const failureStoreSamplesRoute = createServerRoute({
       );
     }
 
-    // Check if failure store is enabled for this stream
-    const dataStream = await streamsClient.getDataStream(params.path.name);
+    // Check if failure store is enabled for this stream. A stream definition
+    // can exist without a materialized backing data stream yet — in that case
+    // there are no failure store samples to return.
+    const dataStream = await streamsClient.getDataStream(params.path.name).catch((err) => {
+      if (isNotFoundError(err)) {
+        return null;
+      }
+      throw err;
+    });
+    if (!dataStream) {
+      return { documents: [] };
+    }
     const effectiveFailureStore = getFailureStore({
       dataStream: dataStream as DataStreamWithFailureStore,
     });

--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/processing/simulation_handler.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/processing/simulation_handler.ts
@@ -8,6 +8,7 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 
 import { errors as esErrors } from '@elastic/elasticsearch';
+import { isNotFoundError } from '@kbn/es-errors';
 import type {
   IngestDocument,
   IngestProcessorContainer,
@@ -56,6 +57,7 @@ import {
 import { getProcessingPipelineName } from '../../../../lib/streams/ingest_pipelines/name';
 import type { StreamsClient } from '../../../../lib/streams/client';
 import { createStreamlangResolverOptions } from '../../../../lib/streams/resolvers';
+import { StatusError } from '../../../../lib/streams/errors/status_error';
 import { buildSimulationProcessorsWithConditionNoops } from './simulation_condition_noops';
 
 export interface ProcessingSimulationParams {
@@ -993,10 +995,24 @@ const getStreamIndex = async (
   indexState: IndicesIndexState;
   fieldCaps: FieldCapsResponse['fields'];
 }> => {
-  const dataStream = await streamsClient.getDataStream(streamName);
+  // A stream definition can exist without a materialized backing data
+  // stream yet. Convert that into a typed 404 so the UI can show a clear
+  // message instead of a raw ES transport error.
+  let dataStream;
+  try {
+    dataStream = await streamsClient.getDataStream(streamName);
+  } catch (err) {
+    if (isNotFoundError(err)) {
+      throw new StatusError(
+        `Stream ${streamName} has no backing data stream yet. Onboard data to this stream before running a processing simulation.`,
+        404
+      );
+    }
+    throw err;
+  }
   const lastIndexRef = dataStream.indices.at(-1);
   if (!lastIndexRef) {
-    throw new Error(`No writing index found for stream ${streamName}`);
+    throw new StatusError(`No writing index found for stream ${streamName}`, 404);
   }
 
   const [lastIndex, lastIndexFieldCaps] = await Promise.all([

--- a/x-pack/platform/plugins/shared/streams/server/routes/streams/doc_counts/get_streams_doc_counts.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/streams/doc_counts/get_streams_doc_counts.ts
@@ -6,18 +6,44 @@
  */
 
 import type {
+  IndicesGetDataStreamResponse,
   IndicesStatsIndicesStats,
   SearchRequest,
   QueryDslQueryContainer,
 } from '@elastic/elasticsearch/lib/api/types';
 import type { ElasticsearchClient } from '@kbn/core/server';
 import type { ESQLSearchResponse } from '@kbn/es-types';
+import { isNotFoundError } from '@kbn/es-errors';
 import type { StreamDocsStat } from '../../../../common';
 import {
   getDataStreamsMeteringStats,
   getLastBackingIndexByStream,
   processAsyncInChunks,
 } from './utils';
+
+/**
+ * Resolves data streams for an optional single-stream filter, treating a
+ * missing backing data stream as "no streams" rather than an error. Stream
+ * definitions can exist without a materialized data stream (e.g. wired root
+ * streams before any data is onboarded), and the rest of the plugin treats
+ * that as a normal, empty state.
+ */
+async function safeGetDataStreams(
+  esClient: ElasticsearchClient,
+  streamName?: string
+): Promise<IndicesGetDataStreamResponse['data_streams']> {
+  try {
+    const response = streamName
+      ? await esClient.indices.getDataStream({ name: streamName })
+      : await esClient.indices.getDataStream();
+    return response.data_streams;
+  } catch (err) {
+    if (isNotFoundError(err)) {
+      return [];
+    }
+    throw err;
+  }
+}
 
 /**
  * Fetches total document counts for one or all streams.
@@ -43,9 +69,7 @@ export async function getDocCountsForStreams(options: {
 }): Promise<StreamDocsStat[]> {
   const { isServerless, esClient, esClientAsSecondaryAuthUser, streamName } = options;
 
-  const { data_streams: streams } = streamName
-    ? await esClient.indices.getDataStream({ name: streamName })
-    : await esClient.indices.getDataStream();
+  const streams = await safeGetDataStreams(esClient, streamName);
   if (!streams.length) {
     return [];
   }
@@ -131,9 +155,7 @@ export async function getDegradedDocCountsForStreams(options: {
 }): Promise<StreamDocsStat[]> {
   const { esClient, streamName } = options;
 
-  const { data_streams: streams } = streamName
-    ? await esClient.indices.getDataStream({ name: streamName })
-    : await esClient.indices.getDataStream();
+  const streams = await safeGetDataStreams(esClient, streamName);
 
   if (!streams.length) {
     return [];
@@ -234,9 +256,7 @@ export async function getFailedDocCountsForStreams(options: {
 }): Promise<StreamDocsStat[]> {
   const { esClient, start, end, streamName } = options;
 
-  const { data_streams: streams } = streamName
-    ? await esClient.indices.getDataStream({ name: streamName })
-    : await esClient.indices.getDataStream();
+  const streams = await safeGetDataStreams(esClient, streamName);
 
   if (!streams.length) {
     return [];


### PR DESCRIPTION
A stream definition can exist without a materialized backing data stream (e.g. wired root streams before any data has been onboarded, or freshly-enabled `logs.ecs` / `logs.otel`). The rest of the streams plugin already treats that as a normal, empty state — see `read_stream.ts`, `wired_stream.getMatchingDataStream`, `failure_store/route_helpers.ts`, and the agent-builder `get_stream` tool. Several other call sites did not, and surfaced a raw `index_not_found_exception` from the ES transport to the caller (or, in the features identification task, to Kibana's unhandled rejection handler, which crashed the process — see #265496).

This change extends the "missing data stream is a valid empty state" invariant to the remaining server-side call sites:

- `identify_computed_features` + `fetch_sample_documents`: wrap the top-level ES work in a single `isNotFoundError` catch that returns an empty result. The features identification task now quietly produces zero features for a stream with no data yet, instead of logging an error (or, pre-#265496, crashing Kibana).

- `doc_counts/get_streams_doc_counts.ts`: extract a `safeGetDataStreams` helper that returns `[]` on 404, and use it in all three (total / degraded / failed) doc-count helpers. The UI doc-count calls for a single stream now return zero counts instead of a 500.

- `lifecycle/route.ts` (`lifecycleStatsRoute`): return empty phases when the data stream is missing instead of leaking the ES error.

- `processing/simulation_handler.ts` (`getStreamIndex`): convert missing data stream / writing index into a typed `StatusError(404)` with a user-friendly message ("Onboard data to this stream before running a processing simulation") instead of a raw ES error. Simulation genuinely needs an index, so this stays an error — just a typed one.

- `processing/route.ts` (`failureStoreSamplesRoute`): return
  `{ documents: [] }` when the data stream is missing.

- `management/unmanaged_assets_route.ts`: convert missing data stream into a typed `StatusError(404)` (classic streams by definition wrap an existing data stream, so this stays an error — just typed).

- `agent_builder/tools/read/get_lifecycle_stats.ts`: return a friendly tool result ("no data has been onboarded") when the data stream is missing, instead of the raw ES error message.

Scope: server-only. The UI affordances the reviewer mentioned (e.g. disabling onboarding buttons when no data stream exists) are left for a follow-up; they can now safely rely on these endpoints returning clean empty shapes rather than errors.
