### PR TITLE
fix(security): do not use minimal authentication during re-authenticaiton caused by expired access token

### DIFF
--- a/x-pack/platform/plugins/shared/security/common/constants.ts
+++ b/x-pack/platform/plugins/shared/security/common/constants.ts
@@ -57,6 +57,12 @@ export const NEXT_URL_QUERY_STRING_PARAMETER = 'next';
 export const SESSION_ERROR_REASON_HEADER = 'kbn-session-error-reason';
 
 /**
+ * Indicates that any authentication optimizations (e.g., minimal authentication mode) should be disabled and the full
+ * authentication information should be made available.
+ */
+export const KIBANA_AUTH_FULL_HEADER = 'kbn-auth-full';
+
+/**
  * The HTTP header that's supposed to carry the client ES authentication information when needed (e.g.,
  * UIAM shared secret).
  */

--- a/x-pack/platform/plugins/shared/security/server/authentication/authentication_service.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/authentication/authentication_service.test.ts
@@ -45,6 +45,7 @@ import type { PublicMethodsOf } from '@kbn/utility-types';
 import { AuthenticationResult } from './authentication_result';
 import { AuthenticationService } from './authentication_service';
 import type { AuthenticatedUser, SecurityLicense } from '../../common';
+import { KIBANA_AUTH_FULL_HEADER } from '../../common/constants';
 import { licenseMock } from '../../common/licensing/index.mock';
 import { mockAuthenticatedUser } from '../../common/model/authenticated_user.mock';
 import { auditServiceMock } from '../audit/mocks';
@@ -590,7 +591,7 @@ describe('AuthenticationService', () => {
         expect(reauthenticate).toHaveBeenCalledWith(mockRequest);
       });
 
-      it('filters out and recovers `Authorization` header when provider cannot handle error.', async () => {
+      it('filters out and recovers `Authorization` header and enforces full authentication when provider cannot handle error.', async () => {
         const failureReason = new errors.ResponseError(
           securityMock.createApiResponse({
             statusCode: 401,
@@ -615,12 +616,12 @@ describe('AuthenticationService', () => {
 
         expect(reauthenticate).toHaveBeenCalledTimes(1);
         expect(reauthenticate).toHaveBeenCalledWith(mockRequest);
-        expect(modifiedHeaders).toEqual({ Random: 'random' });
+        expect(modifiedHeaders).toEqual({ Random: 'random', [KIBANA_AUTH_FULL_HEADER]: 'true' });
 
         expect(mockRequest.headers).toEqual({ Authorization: 'Basic xxx', Random: 'random' });
       });
 
-      it('filters out and recovers `Authorization` header when provider can handle error.', async () => {
+      it('filters out and recovers `Authorization` header and enforces full authentication when provider can handle error.', async () => {
         const failureReason = new errors.ResponseError(
           securityMock.createApiResponse({
             statusCode: 401,
@@ -649,12 +650,12 @@ describe('AuthenticationService', () => {
 
         expect(reauthenticate).toHaveBeenCalledTimes(1);
         expect(reauthenticate).toHaveBeenCalledWith(mockRequest);
-        expect(modifiedHeaders).toEqual({ Random: 'random' });
+        expect(modifiedHeaders).toEqual({ Random: 'random', [KIBANA_AUTH_FULL_HEADER]: 'true' });
 
         expect(mockRequest.headers).toEqual({ Authorization: 'Basic xxx', Random: 'random' });
       });
 
-      it('filters out and recovers `Authorization` header when provider fails with unexpected error.', async () => {
+      it('filters out and recovers `Authorization` header and enforces full authentication when provider fails with unexpected error.', async () => {
         const failureReason = new errors.ResponseError(
           securityMock.createApiResponse({
             statusCode: 401,
@@ -681,7 +682,7 @@ describe('AuthenticationService', () => {
 
         expect(reauthenticate).toHaveBeenCalledTimes(1);
         expect(reauthenticate).toHaveBeenCalledWith(mockRequest);
-        expect(modifiedHeaders).toEqual({ Random: 'random' });
+        expect(modifiedHeaders).toEqual({ Random: 'random', [KIBANA_AUTH_FULL_HEADER]: 'true' });
 
         expect(mockRequest.headers).toEqual({ Authorization: 'Basic xxx', Random: 'random' });
       });

--- a/x-pack/platform/plugins/shared/security/server/authentication/authentication_service.ts
+++ b/x-pack/platform/plugins/shared/security/server/authentication/authentication_service.ts
@@ -37,7 +37,7 @@ import { Authenticator } from './authenticator';
 import { canRedirectRequest } from './can_redirect_request';
 import type { DeauthenticationResult } from './deauthentication_result';
 import type { AuthenticatedUser, SecurityLicense } from '../../common';
-import { NEXT_URL_QUERY_STRING_PARAMETER } from '../../common/constants';
+import { KIBANA_AUTH_FULL_HEADER, NEXT_URL_QUERY_STRING_PARAMETER } from '../../common/constants';
 import { shouldProviderUseLoginForm } from '../../common/model';
 import type { ConfigType } from '../config';
 import { getDetailedErrorMessage, getErrorStatusCode } from '../errors';
@@ -333,10 +333,12 @@ export class AuthenticationService {
         // WORKAROUND: Due to BWC reasons Core mutates headers of the original request with authentication
         // headers returned during authentication stage. We should remove these headers before re-authentication to not
         // conflict with the HTTP authentication logic. Performance impact is negligible since this is not a hot path.
+        // Additionally, we explicitly include KIBANA_AUTH_FULL_HEADER header to skip any authentication optimizations
+        // and make sure re-authentication is performed in full scope.
         (request.headers as Record<string, unknown>) = Object.fromEntries(
-          Object.entries(originalHeaders).filter(
-            ([headerName]) => headerName.toLowerCase() !== 'authorization'
-          )
+          Object.entries(originalHeaders)
+            .filter(([headerName]) => headerName.toLowerCase() !== 'authorization')
+            .concat([[KIBANA_AUTH_FULL_HEADER, 'true']])
         );
         authenticationResult = await this.authenticator.reauthenticate(request);
       } catch (err) {

--- a/x-pack/platform/plugins/shared/security/server/authentication/providers/base.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/authentication/providers/base.test.ts
@@ -12,6 +12,7 @@ import {
   mockAuthenticationProviderOptions,
   type MockAuthenticationProviderOptions,
 } from './base.mock';
+import { KIBANA_AUTH_FULL_HEADER } from '../../../common/constants';
 import { mockAuthenticatedUser } from '../../../common/model/authenticated_user.mock';
 import { sessionMock } from '../../session_management/session.mock';
 import { AuthenticationResult } from '../authentication_result';
@@ -50,8 +51,9 @@ describe('BaseAuthenticationProvider', () => {
 
   describe('getUser', () => {
     describe('minimal authentication mode', () => {
-      const createMinimalAuthcRequest = () =>
+      const createMinimalAuthcRequest = (headers?: Record<string, string>) =>
         httpServerMock.createKibanaRequest({
+          headers,
           kibanaRouteOptions: {
             xsrfRequired: true,
             access: 'internal',
@@ -138,6 +140,21 @@ describe('BaseAuthenticationProvider', () => {
         mockOptions.client.asScoped.mockReturnValue(mockScopedClusterClient);
 
         const user = await provider.getUserPublic(request, undefined, undefined);
+
+        expect(mockOptions.client.asScoped).toHaveBeenCalled();
+        expect(user.username).toBe(esUser.username);
+      });
+
+      it('falls back to Elasticsearch _authenticate when KIBANA_AUTH_FULL_HEADER HTTP header is set', async () => {
+        const session = sessionMock.createValue({ username: 'testuser' });
+        const request = createMinimalAuthcRequest({ [KIBANA_AUTH_FULL_HEADER]: 'true' });
+
+        const esUser = mockAuthenticatedUser();
+        const mockScopedClusterClient = elasticsearchServiceMock.createScopedClusterClient();
+        mockScopedClusterClient.asCurrentUser.security.authenticate.mockResponse(esUser);
+        mockOptions.client.asScoped.mockReturnValue(mockScopedClusterClient);
+
+        const user = await provider.getUserPublic(request, undefined, session);
 
         expect(mockOptions.client.asScoped).toHaveBeenCalled();
         expect(user.username).toBe(esUser.username);

--- a/x-pack/platform/plugins/shared/security/server/authentication/providers/base.ts
+++ b/x-pack/platform/plugins/shared/security/server/authentication/providers/base.ts
@@ -16,6 +16,7 @@ import { deepFreeze } from '@kbn/std';
 import type { PublicMethodsOf } from '@kbn/utility-types';
 
 import type { AuthenticatedUser } from '../../../common';
+import { KIBANA_AUTH_FULL_HEADER } from '../../../common/constants';
 import type { AuthenticationInfo } from '../../elasticsearch';
 import type { SessionValue } from '../../session_management';
 import type { UiamServicePublic } from '../../uiam';
@@ -163,10 +164,13 @@ export abstract class BaseAuthenticationProvider<TState = unknown> {
     // For "minimal" authentication, we don't need to call the `_authenticate` endpoint and can just
     // return a static user proxy. The caveat here is that we don't validate credentials, but it
     // will be done by the Elasticsearch itself.
+    // We also want to skip minimal authentication for requests that explicitly ask for the full authentication
+    // information by setting `kbn-auth-full` header to `true` (e.g., during re-authentication).
     if (
       session &&
       session.username &&
-      request.route.options.security?.authc?.enabled === 'minimal'
+      request.route.options.security?.authc?.enabled === 'minimal' &&
+      request.headers[KIBANA_AUTH_FULL_HEADER] !== 'true'
     ) {
       this.logger.debug(`Performing "minimal" authentication for request ${request.url.pathname}.`);
       return this.getMinAuthenticationUserProxy(session);

--- a/x-pack/platform/test/security_api_integration/tests/kerberos/kerberos_login.ts
+++ b/x-pack/platform/test/security_api_integration/tests/kerberos/kerberos_login.ts
@@ -598,5 +598,67 @@ export default function ({ getService }: FtrProviderContext) {
       expect(minimalResponse.body.principal).to.not.have.property('authentication_realm');
       expect(defaultResponse.body).to.have.property('authentication_realm');
     });
+
+    it('should support minimal authentication even when access token is expired', async function () {
+      this.timeout(60000);
+
+      const response = await supertest
+        .get('/security/account')
+        .set('Authorization', `Negotiate ${spnegoToken}`)
+        .expect(200);
+
+      const sessionCookie = parseCookie(response.headers['set-cookie'][0])!;
+      checkCookieIsSet(sessionCookie);
+
+      // Access token expiration is set to 15s for API integration tests.
+      // Let's wait for 20s to make sure token expires.
+      await setTimeoutAsync(20000);
+
+      // Access the minimal auth endpoint with the session cookie. The minimal route relies on
+      // Elasticsearch for credentials validation (e.g., via `_has_privileges` call), so the
+      // expired access token must be transparently refreshed via the re-authentication flow.
+      const minimalResponse = await supertest
+        .get('/authentication/fast/me')
+        .set('Cookie', sessionCookie.cookieString())
+        .expect(200);
+
+      expect(minimalResponse.body.principal.username).to.eql('tester@TEST.ELASTIC.CO');
+      expect(minimalResponse.body.principal.authentication_provider).to.eql({
+        type: 'kerberos',
+        name: 'kerberos',
+      });
+    });
+
+    it('should support minimal authentication with `kbn-auth-full` header forcing full authentication', async () => {
+      const response = await supertest
+        .get('/security/account')
+        .set('Authorization', `Negotiate ${spnegoToken}`)
+        .expect(200);
+
+      const sessionCookie = parseCookie(response.headers['set-cookie'][0])!;
+      checkCookieIsSet(sessionCookie);
+
+      // Access the minimal auth endpoint with the `kbn-auth-full` header set to `true` to force
+      // full authentication even on a route that otherwise supports the minimal authentication mode.
+      const fullAuthResponse = await supertest
+        .get('/authentication/fast/me')
+        .set('Cookie', sessionCookie.cookieString())
+        .set('kbn-auth-full', 'true')
+        .expect(200);
+
+      expect(fullAuthResponse.body.principal.username).to.eql('tester@TEST.ELASTIC.CO');
+      expect(fullAuthResponse.body.principal.authentication_provider).to.eql({
+        type: 'kerberos',
+        name: 'kerberos',
+      });
+
+      // When `kbn-auth-full` header is set, Kibana calls ES `_authenticate` API, so full user
+      // information (including `authentication_realm`) should be available.
+      expect(fullAuthResponse.body.principal).to.have.property('authentication_realm');
+      expect(fullAuthResponse.body.principal.authentication_realm).to.eql({
+        name: 'kerb1',
+        type: 'kerberos',
+      });
+    });
   });
 }

--- a/x-pack/platform/test/security_api_integration/tests/oidc/authorization_code_flow/oidc_auth.ts
+++ b/x-pack/platform/test/security_api_integration/tests/oidc/authorization_code_flow/oidc_auth.ts
@@ -807,5 +807,97 @@ export default function ({ getService }: FtrProviderContext) {
       expect(minimalResponse.body.principal).to.not.have.property('authentication_realm');
       expect(defaultResponse.body).to.have.property('authentication_realm');
     });
+
+    it('should support minimal authentication even when access token is expired', async function () {
+      this.timeout(60000);
+
+      // Initiate OIDC handshake.
+      const handshakeResponse = await supertest
+        .get('/abc/xyz/handshake?one=two three&auth_provider_hint=saml&auth_url_hash=%23%2Fworkpad')
+        .expect(302);
+
+      const handshakeCookie = parseCookie(handshakeResponse.headers['set-cookie'][0])!;
+      const stateAndNonce = getStateAndNonce(handshakeResponse.headers.location);
+
+      // Set the nonce in the mock OIDC Provider.
+      await supertest
+        .post('/api/oidc_provider/setup')
+        .set('kbn-xsrf', 'xxx')
+        .send({ nonce: stateAndNonce.nonce })
+        .expect(200);
+
+      // Complete the OIDC callback.
+      const oidcAuthenticationResponse = await supertest
+        .get(`/api/security/oidc/callback?code=code1&state=${stateAndNonce.state}`)
+        .set('Cookie', handshakeCookie.cookieString())
+        .expect(302);
+
+      const sessionCookie = parseCookie(oidcAuthenticationResponse.headers['set-cookie'][0])!;
+
+      // Access token expiration is set to 15s for API integration tests.
+      // Let's wait for 20s to make sure token expires.
+      await setTimeoutAsync(20000);
+
+      // Access the minimal auth endpoint with the session cookie. The minimal route relies on
+      // Elasticsearch for credentials validation (e.g., via `_has_privileges` call), so the
+      // expired access token must be transparently refreshed via the re-authentication flow.
+      const minimalResponse = await supertest
+        .get('/authentication/fast/me')
+        .set('Cookie', sessionCookie.cookieString())
+        .expect(200);
+
+      expect(minimalResponse.body.principal.username).to.eql('user1');
+      expect(minimalResponse.body.principal.authentication_provider).to.eql({
+        type: 'oidc',
+        name: 'oidc',
+      });
+    });
+
+    it('should support minimal authentication with `kbn-auth-full` header forcing full authentication', async () => {
+      // Initiate OIDC handshake.
+      const handshakeResponse = await supertest
+        .get('/abc/xyz/handshake?one=two three&auth_provider_hint=saml&auth_url_hash=%23%2Fworkpad')
+        .expect(302);
+
+      const handshakeCookie = parseCookie(handshakeResponse.headers['set-cookie'][0])!;
+      const stateAndNonce = getStateAndNonce(handshakeResponse.headers.location);
+
+      // Set the nonce in the mock OIDC Provider.
+      await supertest
+        .post('/api/oidc_provider/setup')
+        .set('kbn-xsrf', 'xxx')
+        .send({ nonce: stateAndNonce.nonce })
+        .expect(200);
+
+      // Complete the OIDC callback.
+      const oidcAuthenticationResponse = await supertest
+        .get(`/api/security/oidc/callback?code=code1&state=${stateAndNonce.state}`)
+        .set('Cookie', handshakeCookie.cookieString())
+        .expect(302);
+
+      const sessionCookie = parseCookie(oidcAuthenticationResponse.headers['set-cookie'][0])!;
+
+      // Access the minimal auth endpoint with the `kbn-auth-full` header set to `true` to force
+      // full authentication even on a route that otherwise supports the minimal authentication mode.
+      const fullAuthResponse = await supertest
+        .get('/authentication/fast/me')
+        .set('Cookie', sessionCookie.cookieString())
+        .set('kbn-auth-full', 'true')
+        .expect(200);
+
+      expect(fullAuthResponse.body.principal.username).to.eql('user1');
+      expect(fullAuthResponse.body.principal.authentication_provider).to.eql({
+        type: 'oidc',
+        name: 'oidc',
+      });
+
+      // When `kbn-auth-full` header is set, Kibana calls ES `_authenticate` API, so full user
+      // information (including `authentication_realm`) should be available.
+      expect(fullAuthResponse.body.principal).to.have.property('authentication_realm');
+      expect(fullAuthResponse.body.principal.authentication_realm).to.eql({
+        name: 'oidc1',
+        type: 'oidc',
+      });
+    });
   });
 }

--- a/x-pack/platform/test/security_api_integration/tests/pki/pki_auth.ts
+++ b/x-pack/platform/test/security_api_integration/tests/pki/pki_auth.ts
@@ -586,5 +586,73 @@ export default function ({ getService }: FtrProviderContext) {
       expect(minimalResponse.body.principal).to.not.have.property('authentication_realm');
       expect(defaultResponse.body).to.have.property('authentication_realm');
     });
+
+    it('should support minimal authentication even when access token is expired', async function () {
+      this.timeout(60000);
+
+      const response = await supertest
+        .get('/security/account')
+        .ca(CA_CERT)
+        .pfx(FIRST_CLIENT_CERT)
+        .expect(200);
+
+      const sessionCookie = parseCookie(response.headers['set-cookie'][0])!;
+      checkCookieIsSet(sessionCookie);
+
+      // Access token expiration is set to 15s for API integration tests.
+      // Let's wait for 20s to make sure token expires.
+      await setTimeoutAsync(20000);
+
+      // Access the minimal auth endpoint with the session cookie. The minimal route relies on
+      // Elasticsearch for credentials validation (e.g., via `_has_privileges` call), so the
+      // expired access token must be transparently refreshed via the re-authentication flow.
+      const minimalResponse = await supertest
+        .get('/authentication/fast/me')
+        .ca(CA_CERT)
+        .pfx(FIRST_CLIENT_CERT)
+        .set('Cookie', sessionCookie.cookieString())
+        .expect(200);
+
+      expect(minimalResponse.body.principal.username).to.eql('first_client');
+      expect(minimalResponse.body.principal.authentication_provider).to.eql({
+        type: 'pki',
+        name: 'pki',
+      });
+    });
+
+    it('should support minimal authentication with `kbn-auth-full` header forcing full authentication', async () => {
+      const response = await supertest
+        .get('/security/account')
+        .ca(CA_CERT)
+        .pfx(FIRST_CLIENT_CERT)
+        .expect(200);
+
+      const sessionCookie = parseCookie(response.headers['set-cookie'][0])!;
+      checkCookieIsSet(sessionCookie);
+
+      // Access the minimal auth endpoint with the `kbn-auth-full` header set to `true` to force
+      // full authentication even on a route that otherwise supports the minimal authentication mode.
+      const fullAuthResponse = await supertest
+        .get('/authentication/fast/me')
+        .ca(CA_CERT)
+        .pfx(FIRST_CLIENT_CERT)
+        .set('Cookie', sessionCookie.cookieString())
+        .set('kbn-auth-full', 'true')
+        .expect(200);
+
+      expect(fullAuthResponse.body.principal.username).to.eql('first_client');
+      expect(fullAuthResponse.body.principal.authentication_provider).to.eql({
+        type: 'pki',
+        name: 'pki',
+      });
+
+      // When `kbn-auth-full` header is set, Kibana calls ES `_authenticate` API, so full user
+      // information (including `authentication_realm`) should be available.
+      expect(fullAuthResponse.body.principal).to.have.property('authentication_realm');
+      expect(fullAuthResponse.body.principal.authentication_realm).to.eql({
+        name: 'pki1',
+        type: 'pki',
+      });
+    });
   });
 }

--- a/x-pack/platform/test/security_api_integration/tests/saml/saml_login.ts
+++ b/x-pack/platform/test/security_api_integration/tests/saml/saml_login.ts
@@ -1017,5 +1017,67 @@ export default function ({ getService }: FtrProviderContext) {
       expect(minimalResponse.body.principal).to.not.have.property('authentication_realm');
       expect(defaultResponse.body).to.have.property('authentication_realm');
     });
+
+    it('should support minimal authentication even when access token is expired', async function () {
+      this.timeout(60000);
+
+      // Authenticate via IdP initiated SAML login.
+      const samlAuthenticationResponse = await supertest
+        .post('/api/security/saml/callback')
+        .send({ SAMLResponse: await createSAMLResponse() })
+        .expect(302);
+
+      const sessionCookie = parseCookie(samlAuthenticationResponse.headers['set-cookie'][0])!;
+
+      // Access token expiration is set to 15s for API integration tests.
+      // Let's wait for 20s to make sure token expires.
+      await setTimeoutAsync(20000);
+
+      // Access the minimal auth endpoint with the session cookie. The minimal route relies on
+      // Elasticsearch for credentials validation (e.g., via `_has_privileges` call), so the
+      // expired access token must be transparently refreshed via the re-authentication flow.
+      const minimalResponse = await supertest
+        .get('/authentication/fast/me')
+        .set('Cookie', sessionCookie.cookieString())
+        .expect(200);
+
+      expect(minimalResponse.body.principal.username).to.eql('a@b.c');
+      expect(minimalResponse.body.principal.authentication_provider).to.eql({
+        type: 'saml',
+        name: 'saml',
+      });
+    });
+
+    it('should support minimal authentication with `kbn-auth-full` header forcing full authentication', async () => {
+      // Authenticate via IdP initiated SAML login.
+      const samlAuthenticationResponse = await supertest
+        .post('/api/security/saml/callback')
+        .send({ SAMLResponse: await createSAMLResponse() })
+        .expect(302);
+
+      const sessionCookie = parseCookie(samlAuthenticationResponse.headers['set-cookie'][0])!;
+
+      // Access the minimal auth endpoint with the `kbn-auth-full` header set to `true` to force
+      // full authentication even on a route that otherwise supports the minimal authentication mode.
+      const fullAuthResponse = await supertest
+        .get('/authentication/fast/me')
+        .set('Cookie', sessionCookie.cookieString())
+        .set('kbn-auth-full', 'true')
+        .expect(200);
+
+      expect(fullAuthResponse.body.principal.username).to.eql('a@b.c');
+      expect(fullAuthResponse.body.principal.authentication_provider).to.eql({
+        type: 'saml',
+        name: 'saml',
+      });
+
+      // When `kbn-auth-full` header is set, Kibana calls ES `_authenticate` API, so full user
+      // information (including `authentication_realm`) should be available.
+      expect(fullAuthResponse.body.principal).to.have.property('authentication_realm');
+      expect(fullAuthResponse.body.principal.authentication_realm).to.eql({
+        name: 'saml1',
+        type: 'saml',
+      });
+    });
   });
 }

--- a/x-pack/platform/test/security_api_integration/tests/token/login.ts
+++ b/x-pack/platform/test/security_api_integration/tests/token/login.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { setTimeout as setTimeoutAsync } from 'timers/promises';
 import { parse as parseCookie } from 'tough-cookie';
 
 import expect from '@kbn/expect';
@@ -177,6 +178,80 @@ export default function ({ getService }: FtrProviderContext) {
       // so we don't have `authentication_realm` information available.
       expect(minimalResponse.body.principal).to.not.have.property('authentication_realm');
       expect(defaultResponse.body).to.have.property('authentication_realm');
+    });
+
+    it('should support minimal authentication even when access token is expired', async function () {
+      this.timeout(60000);
+
+      const loginResponse = await supertest
+        .post('/internal/security/login')
+        .set('kbn-xsrf', 'true')
+        .send({
+          providerType: 'token',
+          providerName: 'token',
+          currentURL: '/',
+          params: { username: 'elastic', password: 'changeme' },
+        })
+        .expect(200);
+
+      const sessionCookie = extractSessionCookie(loginResponse);
+      if (!sessionCookie) {
+        throw new Error('No session cookie set');
+      }
+
+      // Access token expiration is set to 15s for API integration tests.
+      // Let's wait for 20s to make sure token expires.
+      await setTimeoutAsync(20000);
+
+      // Access the minimal auth endpoint with the session cookie. The minimal route relies on
+      // Elasticsearch for credentials validation (e.g., via `_has_privileges` call), so the
+      // expired access token must be transparently refreshed via the re-authentication flow.
+      const minimalResponse = await supertest
+        .get('/authentication/fast/me')
+        .set('Cookie', sessionCookie.cookieString())
+        .expect(200);
+
+      expect(minimalResponse.body.principal.username).to.eql('elastic');
+      expect(minimalResponse.body.principal.authentication_provider).to.eql({
+        type: 'token',
+        name: 'token',
+      });
+    });
+
+    it('should support minimal authentication with `kbn-auth-full` header forcing full authentication', async () => {
+      const loginResponse = await supertest
+        .post('/internal/security/login')
+        .set('kbn-xsrf', 'true')
+        .send({
+          providerType: 'token',
+          providerName: 'token',
+          currentURL: '/',
+          params: { username: 'elastic', password: 'changeme' },
+        })
+        .expect(200);
+
+      const sessionCookie = extractSessionCookie(loginResponse);
+      if (!sessionCookie) {
+        throw new Error('No session cookie set');
+      }
+
+      // Access the minimal auth endpoint with the `kbn-auth-full` header set to `true` to force
+      // full authentication even on a route that otherwise supports the minimal authentication mode.
+      const fullAuthResponse = await supertest
+        .get('/authentication/fast/me')
+        .set('Cookie', sessionCookie.cookieString())
+        .set('kbn-auth-full', 'true')
+        .expect(200);
+
+      expect(fullAuthResponse.body.principal.username).to.eql('elastic');
+      expect(fullAuthResponse.body.principal.authentication_provider).to.eql({
+        type: 'token',
+        name: 'token',
+      });
+
+      // When `kbn-auth-full` header is set, Kibana calls ES `_authenticate` API, so full user
+      // information (including `authentication_realm`) should be available.
+      expect(fullAuthResponse.body.principal).to.have.property('authentication_realm');
     });
   });
 }


### PR DESCRIPTION
## Summary

Fixes a bug where Kibana could incorrectly use "minimal" authentication during the **re-authentication flow** triggered by an expired access token. When a request to a route that opts into minimal authentication (e.g., the internal search endpoint) makes an Elasticsearch call with an expired access token, Core's `setUnauthorizedErrorHandler` kicks in and asks the security plugin to re-authenticate. Previously, the re-authentication path reused the same minimal-auth shortcut that returned a static user stub without actually validating or refreshing credentials - so the token was never refreshed, the ES retry used the same expired token, and the user would eventually get logged out and bounced back through the SSO handshake.

The fix introduces a new internal HTTP header, `kbn-auth-full`, that instructs the provider's `getUser` path to bypass the minimal-authentication optimization and always perform a full ES `_authenticate` call. The header is set by `AuthenticationService` before invoking `authenticator.reauthenticate(...)` and is stripped before control returns to the route handler. This guarantees the re-authentication path goes through the real token refresh logic.

### About the `kbn-auth-full` header

This is **not a user-facing header**. It's internal plumbing between the `AuthenticationService` and the provider's `getUser` method. It's also intentionally generic: during the minimal-auth adoption period we may want to use it from other places (custom debugging builds, ad-hoc diagnostics, tests) to force-disable the minimal-auth optimization on specific requests without changing the route security config. If a client sets it from the outside, the worst case is that minimal auth is bypassed for their request, no security implications, just a small performance cost.

## Tests

- Unit tests for `AuthenticationService` and `BaseAuthenticationProvider` cover the new header behavior.
- Integration tests added under `x-pack/platform/test/security_api_integration/tests/{saml,pki,kerberos,oidc,token}` for the `/authentication/fast/me` minimal-auth endpoint:
  - `should support minimal authentication even when access token is expired` - reproduces the bug scenario.
  - `should support minimal authentication with` `kbn-auth-full` `header forcing full authentication` - verifies the header forces a full ES `_authenticate` call (asserted via presence of `authentication_realm` on the principal).

## How to manually reproduce / verify

The bug is easy to reproduce locally by shortening the access token lifetime:

0. Modify `src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/default/stateful/base.config.ts` to add `xpack.security.authc.token.timeout=3s` to `serverArgs`.
1. Run Scout test server (stateful):
   ```
   node scripts/scout.js start-server --arch stateful --domain classic
   ```
2. Open Kibana (port is 5620), and load a sample data set (e.g., "Sample web logs").
3. Open an app that hits the internal search endpoint (the only non-test route currently using `authc.enabled: 'minimal'`), e.g., Discover or a dashboard, and keep interacting with it for longer than the 15s token lifetime (e.g. keep hitting `Refresh` button in Dashboard for ~30-45 seconds).
4. **Before the fix:** after the first token expiry, Kibana intermittently logs the user out and redirects through the SSO handshake because the re-authentication silently failed to refresh the token (see attached video)

https://github.com/user-attachments/assets/00806e39-43ff-47f8-a7e7-46f3c6fb253d

5. **After the fix:** the session is transparently extended and the user stays logged in across token refreshes.

__Assisted by:__ Claude Code (Opus 4.7) for integration tests and PR description

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->