### PR TITLE
[Lens] Align axis tick precision to decimal formatter in XY charts

### DIFF
--- a/src/platform/plugins/shared/chart_expressions/expression_xy/public/components/xy_chart.test.tsx
+++ b/src/platform/plugins/shared/chart_expressions/expression_xy/public/components/xy_chart.test.tsx
@@ -2009,6 +2009,78 @@ describe('XYChart component', () => {
     });
   });
 
+  describe('axis decimal precision', () => {
+    test('applies y axis maximumFractionDigits from number formatter params', () => {
+      const { data, args } = sampleArgs();
+      const yAxisFormatData: Datatable = {
+        ...data,
+        columns: data.columns.map((column) =>
+          column.id === 'a'
+            ? {
+                ...column,
+                meta: {
+                  ...column.meta,
+                  params: {
+                    id: 'number',
+                    params: {
+                      pattern: '0,0.00',
+                      decimals: 2,
+                    },
+                  },
+                },
+              }
+            : column
+        ),
+      };
+
+      const component = shallow(
+        <XYChart
+          {...defaultProps}
+          args={{
+            ...args,
+            layers: args.layers.map((layer) => ({
+              ...layer,
+              accessors: ['a'],
+              splitAccessors: undefined,
+              table: yAxisFormatData,
+            })),
+          }}
+        />
+      );
+
+      const yAxis = component
+        .find(Axis)
+        .filterWhere((axis) => axis.prop('id') !== 'x')
+        .first();
+
+      expect(yAxis.prop('maximumFractionDigits')).toEqual(2);
+    });
+
+    test('does not set maximumFractionDigits when formatter does not include decimals', () => {
+      const { args } = sampleArgs();
+      const component = shallow(
+        <XYChart
+          {...defaultProps}
+          args={{
+            ...args,
+            layers: args.layers.map((layer) => ({
+              ...layer,
+              accessors: ['a'],
+              splitAccessors: undefined,
+            })),
+          }}
+        />
+      );
+
+      const yAxis = component
+        .find(Axis)
+        .filterWhere((axis) => axis.prop('id') !== 'x')
+        .first();
+
+      expect(yAxis.prop('maximumFractionDigits')).toBeUndefined();
+    });
+  });
+
   describe('y series coloring', () => {
     const args = createArgsWithLayers();
     const layer = args.layers[0] as DataLayerConfig;
@@ -2190,7 +2262,10 @@ describe('XYChart component', () => {
   test('it should pass the formatter function to the axis', () => {
     const localConvertSpy = jest.fn((x) => x);
     const getFormatSpy = jest.fn();
-    getFormatSpy.mockReturnValue({ convert: localConvertSpy });
+    getFormatSpy.mockReturnValue({
+      convert: localConvertSpy,
+      params: jest.fn(() => ({})),
+    });
 
     const { args } = sampleArgs();
 
@@ -2986,7 +3061,10 @@ describe('XYChart component', () => {
     const args = createArgsWithLayers([timeSampleLayer]);
 
     const getCustomFormatSpy = jest.fn();
-    getCustomFormatSpy.mockReturnValue({ convert: jest.fn((x) => Boolean(x)) });
+    getCustomFormatSpy.mockReturnValue({
+      convert: jest.fn((x) => Boolean(x)),
+      params: jest.fn(() => ({})),
+    });
 
     const component = shallow(
       <XYChart {...defaultProps} formatFactory={getCustomFormatSpy} args={{ ...args }} />

--- a/src/platform/plugins/shared/chart_expressions/expression_xy/public/components/xy_chart.tsx
+++ b/src/platform/plugins/shared/chart_expressions/expression_xy/public/components/xy_chart.tsx
@@ -969,7 +969,7 @@ export function XYChart({
             )}
             {yAxesConfiguration.map((axis) => {
               const tickDecimals = axis.formatter
-                ? getDecimalsFromFormatParams(axis.formatter?.params())
+                ? getDecimalsFromFormatParams(axis.formatter.params())
                 : undefined;
 
               return (

--- a/src/platform/plugins/shared/chart_expressions/expression_xy/public/components/xy_chart.tsx
+++ b/src/platform/plugins/shared/chart_expressions/expression_xy/public/components/xy_chart.tsx
@@ -92,8 +92,8 @@ import {
   getAxesConfiguration,
   getLinesCausedPaddings,
   validateExtent,
-  getDecimalsFromFormatParams,
   getOriginalAxisPosition,
+  getDecimalsFromFormat,
 } from '../helpers';
 import { getXDomain, XyEndzones } from './x_domain';
 import { getLegendAction } from './legend_action';
@@ -363,7 +363,7 @@ export function XYChart({
     xAxisColumn?.id ? fieldFormats[dataLayers[0].layerId].xAccessors[xAxisColumn?.id] : undefined
   );
 
-  const xTickDecimals = getDecimalsFromFormatParams(xAxisFormatter.params());
+  const xTickDecimals = getDecimalsFromFormat(xAxisFormatter);
 
   // This is a safe formatter for the xAccessor that abstracts the knowledge of already formatted layers
   const safeXAccessorLabelRenderer = (value: unknown): string =>
@@ -969,7 +969,7 @@ export function XYChart({
             )}
             {yAxesConfiguration.map((axis) => {
               const tickDecimals = axis.formatter
-                ? getDecimalsFromFormatParams(axis.formatter.params())
+                ? getDecimalsFromFormat(axis.formatter)
                 : undefined;
 
               return (

--- a/src/platform/plugins/shared/chart_expressions/expression_xy/public/components/xy_chart.tsx
+++ b/src/platform/plugins/shared/chart_expressions/expression_xy/public/components/xy_chart.tsx
@@ -92,6 +92,7 @@ import {
   getAxesConfiguration,
   getLinesCausedPaddings,
   validateExtent,
+  getDecimalsFromFormatParams,
   getOriginalAxisPosition,
 } from '../helpers';
 import { getXDomain, XyEndzones } from './x_domain';
@@ -361,6 +362,8 @@ export function XYChart({
   const xAxisFormatter = formatFactory(
     xAxisColumn?.id ? fieldFormats[dataLayers[0].layerId].xAccessors[xAxisColumn?.id] : undefined
   );
+
+  const xTickDecimals = getDecimalsFromFormatParams(xAxisFormatter.params());
 
   // This is a safe formatter for the xAccessor that abstracts the knowledge of already formatted layers
   const safeXAccessorLabelRenderer = (value: unknown): string =>
@@ -951,6 +954,7 @@ export function XYChart({
                 }
                 return value;
               }}
+              maximumFractionDigits={xTickDecimals}
               style={xAxisStyle}
               showOverlappingLabels={xAxisConfig?.showOverlappingLabels}
               showDuplicatedTicks={xAxisConfig?.showDuplicates}
@@ -964,6 +968,10 @@ export function XYChart({
               />
             )}
             {yAxesConfiguration.map((axis) => {
+              const tickDecimals = axis.formatter
+                ? getDecimalsFromFormatParams(axis.formatter?.params())
+                : undefined;
+
               return (
                 <Axis
                   key={axis.groupId}
@@ -982,6 +990,7 @@ export function XYChart({
                     }
                     return value;
                   }}
+                  maximumFractionDigits={tickDecimals}
                   style={getYAxesStyle(axis)}
                   domain={getYAxisDomain(axis)}
                   showOverlappingLabels={axis.showOverlappingLabels}

--- a/src/platform/plugins/shared/chart_expressions/expression_xy/public/components/xy_chart_series_naming.test.tsx
+++ b/src/platform/plugins/shared/chart_expressions/expression_xy/public/components/xy_chart_series_naming.test.tsx
@@ -57,7 +57,8 @@ const dataWithFormats: Datatable = {
 };
 const getFormatSpy: jest.Mock = jest.fn();
 const convertSpy: jest.Mock = jest.fn((x) => x);
-getFormatSpy.mockReturnValue({ convert: convertSpy });
+const paramsSpy: jest.Mock = jest.fn(() => ({}));
+getFormatSpy.mockReturnValue({ convert: convertSpy, params: paramsSpy });
 
 const defaultProps: Omit<XYChartRenderProps, 'args'> = {
   data: dataPluginMock.createStartContract(),
@@ -97,7 +98,7 @@ describe('provides correct series naming', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     convertSpy.mockImplementation((d) => d);
-    getFormatSpy.mockReturnValue({ convert: convertSpy });
+    getFormatSpy.mockReturnValue({ convert: convertSpy, params: paramsSpy });
   });
 
   test('simplest xy chart without human-readable name', async () => {

--- a/src/platform/plugins/shared/chart_expressions/expression_xy/public/helpers/format.ts
+++ b/src/platform/plugins/shared/chart_expressions/expression_xy/public/helpers/format.ts
@@ -7,9 +7,10 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { DatatableColumn } from '@kbn/expressions-plugin/common';
 import type { ExpressionValueVisDimension } from '@kbn/chart-expressions-common';
-import { getFormatByAccessor, getColumnByAccessor } from '@kbn/chart-expressions-common';
+import { getColumnByAccessor, getFormatByAccessor } from '@kbn/chart-expressions-common';
+import type { DatatableColumn } from '@kbn/expressions-plugin/common';
+import type { FieldFormatParams } from '@kbn/field-formats-plugin/common';
 
 export const getFormat = (
   columns: DatatableColumn[],
@@ -25,4 +26,31 @@ export const getFormat = (
         }
       : undefined
   );
+};
+
+const MAX_UNWRAP_DEPTH = 3;
+
+/**
+ * Reads the original `decimals` value that Lens writes onto the format params
+ * (via `lens_format_column`), unwrapping decorator formats such as `suffix`
+ * that nest the inner numeric format under `params.params`.
+ */
+export const getDecimalsFromFormatParams = (
+  params: FieldFormatParams,
+  depth = 0
+): number | undefined => {
+  if (!params || depth > MAX_UNWRAP_DEPTH) {
+    return undefined;
+  }
+
+  if (typeof params.decimals === 'number') {
+    return params.decimals;
+  }
+
+  const nestedParams = params.params;
+  if (nestedParams && typeof nestedParams === 'object' && !Array.isArray(nestedParams)) {
+    return getDecimalsFromFormatParams(nestedParams, depth + 1);
+  }
+
+  return undefined;
 };

--- a/src/platform/plugins/shared/chart_expressions/expression_xy/public/helpers/format.ts
+++ b/src/platform/plugins/shared/chart_expressions/expression_xy/public/helpers/format.ts
@@ -10,7 +10,8 @@
 import type { ExpressionValueVisDimension } from '@kbn/chart-expressions-common';
 import { getColumnByAccessor, getFormatByAccessor } from '@kbn/chart-expressions-common';
 import type { DatatableColumn } from '@kbn/expressions-plugin/common';
-import type { FieldFormatParams } from '@kbn/field-formats-plugin/common';
+import type { FieldFormat, FieldFormatParams } from '@kbn/field-formats-plugin/common';
+import { isNumber, isUndefined } from 'lodash';
 
 export const getFormat = (
   columns: DatatableColumn[],
@@ -28,29 +29,31 @@ export const getFormat = (
   );
 };
 
-const MAX_UNWRAP_DEPTH = 3;
-
 /**
- * Reads the original `decimals` value that Lens writes onto the format params
- * (via `lens_format_column`), unwrapping decorator formats such as `suffix`
- * that nest the inner numeric format under `params.params`.
+ * Reads a single key from the field format's params, unwrapping decorator formats such as `suffix` by
+ * walking nested `params.params` until the key is found or `maxDepth` is reached.
  */
-export const getDecimalsFromFormatParams = (
-  params: FieldFormatParams,
-  depth = 0
-): number | undefined => {
-  if (!params || depth > MAX_UNWRAP_DEPTH) {
-    return undefined;
-  }
+export const getFormatParam = (format: FieldFormat, param: string, maxDepth = 3) => {
+  const getNested = (params: FieldFormatParams, depth: number) => {
+    if (depth > maxDepth) {
+      return undefined;
+    }
 
-  if (typeof params.decimals === 'number') {
-    return params.decimals;
-  }
+    if (!isUndefined(params[param])) {
+      return params[param];
+    }
 
-  const nestedParams = params.params;
-  if (nestedParams && typeof nestedParams === 'object' && !Array.isArray(nestedParams)) {
-    return getDecimalsFromFormatParams(nestedParams, depth + 1);
-  }
+    const nested = params?.params;
 
-  return undefined;
+    if (nested && typeof nested === 'object' && !Array.isArray(nested)) {
+      return getNested(nested, depth + 1);
+    }
+  };
+
+  return getNested(format.params(), 0);
+};
+
+export const getDecimalsFromFormat = (format: FieldFormat) => {
+  const value = getFormatParam(format, 'decimals');
+  return isNumber(value) ? value : undefined;
 };

--- a/x-pack/platform/plugins/shared/lens/common/expressions/impl/format_column/format_column.test.ts
+++ b/x-pack/platform/plugins/shared/lens/common/expressions/impl/format_column/format_column.test.ts
@@ -55,7 +55,7 @@ describe('format_column', () => {
     const result = await fn(datatable, { columnId: 'test', format: 'number', decimals: 5 });
     expect(result.columns[0].meta.params).toEqual({
       id: 'number',
-      params: { formatOverride: true, pattern: '0,0.00000' },
+      params: { formatOverride: true, pattern: '0,0.00000', decimals: 5 },
     });
   });
 
@@ -73,7 +73,7 @@ describe('format_column', () => {
         suffixString: 'ABC',
         id: 'number',
         formatOverride: true,
-        params: { formatOverride: true, pattern: '0,0.00000' },
+        params: { formatOverride: true, pattern: '0,0.00000', decimals: 5 },
       },
     });
   });
@@ -83,7 +83,7 @@ describe('format_column', () => {
     const result = await fn(datatable, { columnId: 'test', format: 'number', decimals: 0 });
     expect(result.columns[0].meta.params).toEqual({
       id: 'number',
-      params: { formatOverride: true, pattern: '0,0' },
+      params: { formatOverride: true, pattern: '0,0', decimals: 0 },
     });
   });
 
@@ -224,8 +224,9 @@ describe('format_column', () => {
           formatOverride: true,
           wrapperParam: 123,
           id: 'number',
-          params: { formatOverride: true, pattern: '0,0.00000' },
+          params: { formatOverride: true, pattern: '0,0.00000', decimals: 5 },
           pattern: '0,0.00000',
+          decimals: 5,
         },
       });
     });
@@ -249,9 +250,10 @@ describe('format_column', () => {
           paramsPerField: [
             {
               id: 'number',
-              params: { formatOverride: true, pattern: '0,0.00000' },
+              params: { formatOverride: true, pattern: '0,0.00000', decimals: 5 },
               formatOverride: true,
               pattern: '0,0.00000',
+              decimals: 5,
             },
           ],
         },
@@ -307,7 +309,7 @@ describe('format_column', () => {
       type: 'number',
       params: {
         id: 'number',
-        params: { pattern: '0,0.00000a', formatOverride: true },
+        params: { pattern: '0,0.00000a', formatOverride: true, decimals: 5 },
       },
     });
   });
@@ -350,6 +352,7 @@ describe('format_column', () => {
           useShortSuffix: true,
           showSuffix: true,
           includeSpaceWithSuffix: true,
+          decimals: 2,
         },
       },
     });
@@ -382,6 +385,7 @@ describe('format_column', () => {
             useShortSuffix: true,
             showSuffix: true,
             includeSpaceWithSuffix: true,
+            decimals: 2,
           },
         },
       },

--- a/x-pack/platform/plugins/shared/lens/common/expressions/impl/format_column/format_column_fn.ts
+++ b/x-pack/platform/plugins/shared/lens/common/expressions/impl/format_column/format_column_fn.ts
@@ -75,6 +75,7 @@ export const formatColumnFn: FormatColumnExpressionFunction['fn'] = (
                   suffix,
                   ...otherArgs,
                 }),
+                decimals,
               },
             };
             return withParams(col, serializedFormat as Record<string, unknown>);
@@ -105,6 +106,7 @@ export const formatColumnFn: FormatColumnExpressionFunction['fn'] = (
               suffix,
               ...otherArgs,
             }),
+            decimals,
           };
           // Some parent formatters are multi-fields and wrap the custom format into a "paramsPerField"
           // property. Here the format is passed to this property to make it work properly


### PR DESCRIPTION
## Summary

Closes #170151.
The Decimals user input was not being use to pass a meaningful value to `maximumFractionDigits`. 

**Before**

https://github.com/user-attachments/assets/f6682afe-728f-4e69-8769-25297cc4fba2

**After**

https://github.com/user-attachments/assets/9004f9ae-158f-465d-b180-6d64d671c2a2
 
Information on Decimals was used for creating the tick label format pattern, and then was no longer kept on the axis configuration. As a minimal change, I added it as an optional parameter on field formatter, so we can use it to set`maximumFractionDigits` when configuring `<Axis>`.

While the decimals information is present in the format string, passing it directly as an optional parameter avoids having to parse the format string to get that information back, which added a parsing layer that could add risks for drift. 

(Alternatively, thought of moving this to axis config instead of formatter, to make obvious that it doesn’t just influence formatting, however, as the goal is to keep this things coupled to avoid states where they diverge and lead to weird results, this feels like a good middle ground)

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Release note
> Fixes issue where the decimals setting in the number formatter was not used to generate appropriate axis ticks.