### PR TITLE
[Agent Builder] Fix graph recursion limit and cycle state carry-over

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/run_chat_agent.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/run_chat_agent.ts
@@ -410,7 +410,7 @@ const createInitializerCommand = ({
     startAt = steps.executeTool;
   }
 
-  if (lastRound?.state) {
+  if (lastRound?.state && lastRound?.status === ConversationRoundStatus.awaitingPrompt) {
     initialState.currentCycle = lastRound.state.agent.current_cycle;
     initialState.errorCount = lastRound.state.agent.error_count;
   }
@@ -422,7 +422,8 @@ const createInitializerCommand = ({
 };
 
 const getRecursionLimit = (cycleLimit: number): number => {
-  // langchain's recursionLimit is basically the number of nodes we can traverse before hitting a recursion limit error
-  // we have two steps per cycle (agent node + tool call node), and then a few other steps (prepare + answering), and some extra buffer
-  return cycleLimit * 2 + 8;
+  // langchain's recursionLimit is the number of graph nodes we can traverse before hitting a recursion limit error.
+  // Each research cycle traverses 3 nodes: checkBackgroundWork → researchAgent → executeTool.
+  // On top of that we have init, prepareToAnswer, answerAgent (with potential error retries), and finalize.
+  return cycleLimit * 3 + 10;
 };


### PR DESCRIPTION
## Summary

We noticed that the Entity Analytics skill in Agent Builder was often hitting a `GRAPH_RECURSION_LIMIT` error during multi-turn conversations. The repro is straightforward: ask the agent to show the Entity Analytics dashboard, then follow up with something like "help me analyze the 3 critical risks" — the second turn would fail with the LangGraph recursion error.

Digging in, it looks like the Entity Analytics skill surfaces this because it's one of the more tool-heavy flows (search entities → get entity per result → add dashboard attachment), but the underlying issue appears to be in the platform agent builder graph, not the skill itself.

### Fix 1: `getRecursionLimit` formula

The `getRecursionLimit` function assumed **2 graph steps per research cycle** (researchAgent + executeTool), but the graph actually traverses **3 nodes per cycle** because `checkBackgroundWork` sits between `executeTool` and `researchAgent` on every loop. This meant the LangGraph recursion limit was set to 38 (`15 * 2 + 8`) when the graph could need up to ~55 steps to complete 15 cycles plus the answer phase. In practice the graph would hit the hard limit at around 11 tool cycles instead of the intended 15.

Updated to `cycleLimit * 3 + 10`.

### Fix 2: `currentCycle` carry-over across rounds

`currentCycle` and `errorCount` were being restored from the previous round's state unconditionally. This means if round 1 used 6 cycles, round 2 would start at cycle 6 instead of 0 — shrinking the effective tool budget for every subsequent turn in a conversation. This state restoration looks like it's intended for HITL (human-in-the-loop) resume when the round is `awaitingPrompt`, so the fix gates it on that status.