### PR TITLE
[8.19] [Infra] Keep Hosts UI time range fresh on refresh (#265515)

### DIFF
--- a/x-pack/solutions/observability/plugins/infra/public/hooks/use_time_range.test.ts
+++ b/x-pack/solutions/observability/plugins/infra/public/hooks/use_time_range.test.ts
@@ -8,14 +8,22 @@
 import { renderHook } from '@testing-library/react';
 import { useTimeRange } from './use_time_range';
 import * as datemath from '../utils/datemath';
+import * as reloadRequestTimeModule from './use_reload_request_time';
 
 jest.mock('../utils/datemath');
+jest.mock('./use_reload_request_time');
 
 describe('useTimeRange', () => {
   const mockParseDateRange = datemath.parseDateRange as jest.Mock;
+  const mockUseReloadRequestTimeContext =
+    reloadRequestTimeModule.useReloadRequestTimeContext as jest.Mock;
 
   beforeEach(() => {
     Date.now = jest.fn(() => new Date(Date.UTC(2021, 0, 1, 12)).valueOf());
+    mockUseReloadRequestTimeContext.mockReturnValue({
+      reloadRequestTime: 0,
+      updateReloadRequestTime: jest.fn(),
+    });
   });
 
   afterEach(() => {
@@ -55,5 +63,39 @@ describe('useTimeRange', () => {
 
     expect(result.current.from).toBe(expectedFrom);
     expect(result.current.to).toBe(expectedTo);
+  });
+
+  it('recomputes the resolved date range when reloadRequestTime changes', () => {
+    // Simulate wall-clock advancing between the first and second parse.
+    const firstFrom = '2021-01-01T11:45:00.000Z';
+    const firstTo = '2021-01-01T12:00:00.000Z';
+    const secondFrom = '2021-01-01T11:50:00.000Z';
+    const secondTo = '2021-01-01T12:05:00.000Z';
+
+    mockParseDateRange
+      .mockReturnValueOnce({ from: firstFrom, to: firstTo })
+      .mockReturnValueOnce({ from: secondFrom, to: secondTo });
+
+    mockUseReloadRequestTimeContext.mockReturnValue({
+      reloadRequestTime: 1_000,
+      updateReloadRequestTime: jest.fn(),
+    });
+
+    const { result, rerender } = renderHook(() =>
+      useTimeRange({ rangeFrom: 'now-15m', rangeTo: 'now' })
+    );
+
+    expect(result.current).toEqual({ from: firstFrom, to: firstTo });
+
+    // Simulate refresh: reloadRequestTime advances.
+    mockUseReloadRequestTimeContext.mockReturnValue({
+      reloadRequestTime: 2_000,
+      updateReloadRequestTime: jest.fn(),
+    });
+
+    rerender();
+
+    expect(mockParseDateRange).toHaveBeenCalledTimes(2);
+    expect(result.current).toEqual({ from: secondFrom, to: secondTo });
   });
 });

--- a/x-pack/solutions/observability/plugins/infra/public/hooks/use_time_range.ts
+++ b/x-pack/solutions/observability/plugins/infra/public/hooks/use_time_range.ts
@@ -7,6 +7,7 @@
 
 import { useMemo } from 'react';
 import { parseDateRange } from '../utils/datemath';
+import { useReloadRequestTimeContext } from './use_reload_request_time';
 
 const DEFAULT_FROM_IN_MILLISECONDS = 15 * 60000;
 
@@ -20,6 +21,12 @@ const getDefaultTimestamps = () => {
 };
 
 export const useTimeRange = ({ rangeFrom, rangeTo }: { rangeFrom?: string; rangeTo?: string }) => {
+  // Relative datemath strings (e.g. `now-15m`, `now`) are resolved to absolute ISO
+  // timestamps here. Including `reloadRequestTime` as a dependency ensures the memo
+  // is re-evaluated whenever a refresh is requested, so the resolved window advances
+  // with wall-clock time and keeps downstream consumers (table, KPIs, metadata) in sync.
+  const { reloadRequestTime } = useReloadRequestTimeContext();
+
   const parsedDateRange = useMemo(() => {
     const defaults = getDefaultTimestamps();
 
@@ -33,7 +40,9 @@ export const useTimeRange = ({ rangeFrom, rangeTo }: { rangeFrom?: string; range
     });
 
     return { from, to };
-  }, [rangeFrom, rangeTo]);
+    // `reloadRequestTime` is intentionally included to re-resolve relative datemath on refresh.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [rangeFrom, rangeTo, reloadRequestTime]);
 
   return parsedDateRange;
 };

--- a/x-pack/solutions/observability/plugins/infra/public/pages/metrics/hosts/components/kpis/kpi_charts.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/pages/metrics/hosts/components/kpis/kpi_charts.tsx
@@ -16,7 +16,7 @@ import { useAfterLoadedState } from '../../hooks/use_after_loaded_state';
 import { useMetricsDataViewContext } from '../../../../../containers/metrics_source';
 
 export const KpiCharts = () => {
-  const { searchCriteria } = useUnifiedSearchContext();
+  const { searchCriteria, parsedDateRange } = useUnifiedSearchContext();
   const { reloadRequestTime } = useReloadRequestTimeContext();
   const { hostNodes, loading: hostsLoading } = useHostsViewContext();
   const { loading: hostCountLoading, count: hostCount } = useHostCountContext();
@@ -62,9 +62,15 @@ export const KpiCharts = () => {
 
   // prevents requests and searchCriteria state from reloading the chart
   // we want it to reload only once the table has finished loading.
-  // attributes passed to useAfterLoadedState don't need to be memoized
+  // attributes passed to useAfterLoadedState don't need to be memoized.
+  //
+  // Use the resolved absolute timestamps (parsedDateRange) instead of the raw
+  // relative strings from searchCriteria.dateRange so that Lens queries the
+  // exact same window the table was populated from. This keeps KPIs consistent
+  // with the hosts table and prevents N/A when relative ranges drift between
+  // the two after the page has been idle.
   const { afterLoadedState } = useAfterLoadedState(loading, {
-    dateRange: searchCriteria.dateRange,
+    dateRange: parsedDateRange,
     query: shouldUseSearchCriteria ? searchCriteria.query : undefined,
     filters,
     reloadRequestTime,

--- a/x-pack/solutions/observability/plugins/infra/public/pages/metrics/hosts/components/tabs/metrics/chart.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/pages/metrics/hosts/components/tabs/metrics/chart.tsx
@@ -24,7 +24,7 @@ export type ChartProps = LensConfig & {
 };
 
 export const Chart = ({ id, ...chartProps }: ChartProps) => {
-  const { searchCriteria } = useUnifiedSearchContext();
+  const { searchCriteria, parsedDateRange } = useUnifiedSearchContext();
   const { loading } = useHostsViewContext();
   const { reloadRequestTime } = useReloadRequestTimeContext();
   const { currentPage } = useHostsTableContext();
@@ -36,9 +36,15 @@ export const Chart = ({ id, ...chartProps }: ChartProps) => {
 
   // prevents searchCriteria state from reloading the chart
   // we want it to reload only once the table has finished loading.
-  // attributes passed to useAfterLoadedState don't need to be memoized
+  // attributes passed to useAfterLoadedState don't need to be memoized.
+  //
+  // Use the resolved absolute timestamps (parsedDateRange) instead of the raw
+  // relative strings from searchCriteria.dateRange so Lens queries the same
+  // window the hosts table was populated from. Otherwise, on idle pages using
+  // relative ranges (e.g. `now-15m`), the table filter (stale absolute times)
+  // and the chart window (live relative times) can diverge and return N/A.
   const { afterLoadedState } = useAfterLoadedState(loading, {
-    dateRange: searchCriteria.dateRange,
+    dateRange: parsedDateRange,
     query: shouldUseSearchCriteria ? searchCriteria.query : undefined,
     reloadRequestTime,
   });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Infra] Keep Hosts UI time range fresh on refresh (#265515)](https://github.com/elastic/kibana/pull/265515)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Sergi Romeu","email":"sergi.romeu@elastic.co"},"sourceCommit":{"committedDate":"2026-04-24T13:16:34Z","message":"[Infra] Keep Hosts UI time range fresh on refresh (#265515)","sha":"22c4fcab1aa091d39ea61af032ca06e8514bbb7e","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport:version","v9.4.0","Team:obs-presentation","v9.5.0","v9.3.4","v8.19.15"],"title":"[Infra] Keep Hosts UI time range fresh on refresh","number":265515,"url":"https://github.com/elastic/kibana/pull/265515","mergeCommit":{"message":"[Infra] Keep Hosts UI time range fresh on refresh (#265515)","sha":"22c4fcab1aa091d39ea61af032ca06e8514bbb7e"}},"sourceBranch":"main","suggestedTargetBranches":["9.3","8.19"],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/265547","number":265547,"state":"OPEN"},{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/265515","number":265515,"mergeCommit":{"message":"[Infra] Keep Hosts UI time range fresh on refresh (#265515)","sha":"22c4fcab1aa091d39ea61af032ca06e8514bbb7e"}},{"branch":"9.3","label":"v9.3.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.15","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->