### PR TITLE
[9.3] [ResponseOps][Connectors] Connector flyout: improve preconfigured connectors view (#265233)

### DIFF
--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/action_connector_form/edit_connector_flyout/read_only.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/action_connector_form/edit_connector_flyout/read_only.tsx
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
-import React from 'react';
-import { EuiLink, EuiSpacer, EuiText } from '@elastic/eui';
+import React, { Suspense } from 'react';
+import { EuiLink, EuiText } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import type { ActionTypeModel } from '../../../..';
@@ -19,24 +19,25 @@ export const ReadOnlyConnectorMessage: React.FC<{
 }> = ({ connectorId, connectorName, extraComponent, href }) => {
   const ExtraComponent = extraComponent;
   return (
-    <>
-      <EuiText>
+    <EuiText size="s">
+      <p>
         {i18n.translate('xpack.triggersActionsUI.sections.editConnectorForm.descriptionText', {
           defaultMessage: 'This connector is read-only.',
         })}
-      </EuiText>
-      <EuiLink data-test-subj="read-only-link" href={href} target="_blank">
-        <FormattedMessage
-          id="xpack.triggersActionsUI.sections.editConnectorForm.preconfiguredHelpLabel"
-          defaultMessage="Learn more about preconfigured connectors."
-        />
-      </EuiLink>
+      </p>
+      <p>
+        <EuiLink data-test-subj="read-only-link" href={href} target="_blank">
+          <FormattedMessage
+            id="xpack.triggersActionsUI.sections.editConnectorForm.preconfiguredHelpLabel"
+            defaultMessage="Learn more about preconfigured connectors."
+          />
+        </EuiLink>
+      </p>
       {ExtraComponent && (
-        <>
-          <EuiSpacer size="m" />
+        <Suspense fallback={null}>
           <ExtraComponent connectorId={connectorId} connectorName={connectorName} />
-        </>
+        </Suspense>
       )}
-    </>
+    </EuiText>
   );
 };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[ResponseOps][Connectors] Connector flyout: improve preconfigured connectors view (#265233)](https://github.com/elastic/kibana/pull/265233)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Georgiana-Andreea Onoleață","email":"georgiana.onoleata@elastic.co"},"sourceCommit":{"committedDate":"2026-04-24T13:44:19Z","message":"[ResponseOps][Connectors] Connector flyout: improve preconfigured connectors view (#265233)\n\nCloses https://github.com/elastic/kibana/issues/242942\n\n## Summary\n\n- The read-only / preconfigured connector flyout had inconsistent font\nsizes between the base message and the `ExtraComponent`.\n- wrapped all content in `ReadOnlyConnectorMessage` inside a single\nEuiText of size = 's', so the base text and any extra component rendered\nby connector types share consistent font sizes.","sha":"d4e039ee630158927abc1017c1c13e1efa65f289","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:skip","Team:ResponseOps","backport:version","v9.4.0","v9.5.0","v9.3.4"],"title":"[ResponseOps][Connectors] Connector flyout: improve preconfigured connectors view","number":265233,"url":"https://github.com/elastic/kibana/pull/265233","mergeCommit":{"message":"[ResponseOps][Connectors] Connector flyout: improve preconfigured connectors view (#265233)\n\nCloses https://github.com/elastic/kibana/issues/242942\n\n## Summary\n\n- The read-only / preconfigured connector flyout had inconsistent font\nsizes between the base message and the `ExtraComponent`.\n- wrapped all content in `ReadOnlyConnectorMessage` inside a single\nEuiText of size = 's', so the base text and any extra component rendered\nby connector types share consistent font sizes.","sha":"d4e039ee630158927abc1017c1c13e1efa65f289"}},"sourceBranch":"main","suggestedTargetBranches":["9.4","9.3"],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/265233","number":265233,"mergeCommit":{"message":"[ResponseOps][Connectors] Connector flyout: improve preconfigured connectors view (#265233)\n\nCloses https://github.com/elastic/kibana/issues/242942\n\n## Summary\n\n- The read-only / preconfigured connector flyout had inconsistent font\nsizes between the base message and the `ExtraComponent`.\n- wrapped all content in `ReadOnlyConnectorMessage` inside a single\nEuiText of size = 's', so the base text and any extra component rendered\nby connector types share consistent font sizes.","sha":"d4e039ee630158927abc1017c1c13e1efa65f289"}},{"branch":"9.3","label":"v9.3.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->