### PR TITLE
[Security][Dashboard] Fix events chart in overview dashboard when CPS is enabled

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/matrix_histogram/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/matrix_histogram/index.tsx
@@ -36,6 +36,13 @@ export type MatrixHistogramComponentProps = MatrixHistogramQueryProps &
     sourcererScopeId?: PageScope;
     hideQueryToggle?: boolean;
     applyGlobalQueriesAndFilters?: boolean;
+    /**
+     * When provided, forwarded to the underlying Lens embeddable as
+     * `overridePatterns` so the chart's `_index` filter is built from these
+     * patterns instead of the scope's full `selectedPatterns`. Used by the
+     * Events histogram to exclude alert-backing indices.
+     */
+    overridePatterns?: string[];
   };
 
 const DEFAULT_PANEL_HEIGHT = 300;
@@ -70,6 +77,7 @@ export const MatrixHistogramComponent: React.FC<MatrixHistogramComponentProps> =
   titleSize,
   hideQueryToggle = false,
   applyGlobalQueriesAndFilters = true,
+  overridePatterns,
 }) => {
   const visualizationId = `${id}-embeddable`;
 
@@ -203,6 +211,7 @@ export const MatrixHistogramComponent: React.FC<MatrixHistogramComponentProps> =
               id={visualizationId}
               inspectTitle={title as string}
               lensAttributes={lensAttributes}
+              overridePatterns={overridePatterns}
               stackByField={stackByField}
               timerange={timerange}
             />

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/matrix_histogram/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/matrix_histogram/index.tsx
@@ -37,12 +37,12 @@ export type MatrixHistogramComponentProps = MatrixHistogramQueryProps &
     hideQueryToggle?: boolean;
     applyGlobalQueriesAndFilters?: boolean;
     /**
-     * When provided, forwarded to the underlying Lens embeddable as
-     * `overridePatterns` so the chart's `_index` filter is built from these
-     * patterns instead of the scope's full `selectedPatterns`. Used by the
-     * Events histogram to exclude alert-backing indices.
+     * Additional drop-list of index patterns layered on top of the chart's
+     * allowlist as a negated `_index` filter (CPS-expanded). Forwarded to the
+     * Lens embeddable as `excludedPatterns`. Used by the Events histogram to
+     * exclude alert-backing indices.
      */
-    overridePatterns?: string[];
+    excludedPatterns?: string[];
   };
 
 const DEFAULT_PANEL_HEIGHT = 300;
@@ -77,7 +77,7 @@ export const MatrixHistogramComponent: React.FC<MatrixHistogramComponentProps> =
   titleSize,
   hideQueryToggle = false,
   applyGlobalQueriesAndFilters = true,
-  overridePatterns,
+  excludedPatterns,
 }) => {
   const visualizationId = `${id}-embeddable`;
 
@@ -211,7 +211,7 @@ export const MatrixHistogramComponent: React.FC<MatrixHistogramComponentProps> =
               id={visualizationId}
               inspectTitle={title as string}
               lensAttributes={lensAttributes}
-              overridePatterns={overridePatterns}
+              excludedPatterns={excludedPatterns}
               stackByField={stackByField}
               timerange={timerange}
             />

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/__snapshots__/authentication.test.ts.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/__snapshots__/authentication.test.ts.snap
@@ -171,6 +171,7 @@ Object {
           "negate": false,
           "params": Array [
             "auditbeat-mytest-*",
+            "*:auditbeat-mytest-*",
           ],
           "type": "phrases",
         },
@@ -181,6 +182,11 @@ Object {
               Object {
                 "match_phrase": Object {
                   "_index": "auditbeat-mytest-*",
+                },
+              },
+              Object {
+                "match_phrase": Object {
+                  "_index": "*:auditbeat-mytest-*",
                 },
               },
             ],

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/__snapshots__/external_alert.test.ts.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/__snapshots__/external_alert.test.ts.snap
@@ -155,6 +155,7 @@ Object {
           "negate": false,
           "params": Array [
             "auditbeat-mytest-*",
+            "*:auditbeat-mytest-*",
           ],
           "type": "phrases",
         },
@@ -165,6 +166,11 @@ Object {
               Object {
                 "match_phrase": Object {
                   "_index": "auditbeat-mytest-*",
+                },
+              },
+              Object {
+                "match_phrase": Object {
+                  "_index": "*:auditbeat-mytest-*",
                 },
               },
             ],

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/alerts/__snapshots__/alerts_by_status_donut.test.ts.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/alerts/__snapshots__/alerts_by_status_donut.test.ts.snap
@@ -99,6 +99,7 @@ Object {
           "negate": false,
           "params": Array [
             "signal-index",
+            "*:signal-index",
           ],
           "type": "phrases",
         },
@@ -109,6 +110,11 @@ Object {
               Object {
                 "match_phrase": Object {
                   "_index": "signal-index",
+                },
+              },
+              Object {
+                "match_phrase": Object {
+                  "_index": "*:signal-index",
                 },
               },
             ],

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/alerts/__snapshots__/alerts_histogram.test.ts.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/alerts/__snapshots__/alerts_histogram.test.ts.snap
@@ -106,6 +106,7 @@ Object {
           "negate": false,
           "params": Array [
             "signal-index",
+            "*:signal-index",
           ],
           "type": "phrases",
         },
@@ -116,6 +117,11 @@ Object {
               Object {
                 "match_phrase": Object {
                   "_index": "signal-index",
+                },
+              },
+              Object {
+                "match_phrase": Object {
+                  "_index": "*:signal-index",
                 },
               },
             ],
@@ -273,6 +279,7 @@ Object {
           "negate": false,
           "params": Array [
             "signal-index",
+            "*:signal-index",
           ],
           "type": "phrases",
         },
@@ -283,6 +290,11 @@ Object {
               Object {
                 "match_phrase": Object {
                   "_index": "signal-index",
+                },
+              },
+              Object {
+                "match_phrase": Object {
+                  "_index": "*:signal-index",
                 },
               },
             ],

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/alerts/__snapshots__/alerts_table.test.ts.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/alerts/__snapshots__/alerts_table.test.ts.snap
@@ -102,6 +102,7 @@ Object {
           "negate": false,
           "params": Array [
             "signal-index",
+            "*:signal-index",
           ],
           "type": "phrases",
         },
@@ -112,6 +113,11 @@ Object {
               Object {
                 "match_phrase": Object {
                   "_index": "signal-index",
+                },
+              },
+              Object {
+                "match_phrase": Object {
+                  "_index": "*:signal-index",
                 },
               },
             ],
@@ -266,6 +272,7 @@ Object {
           "negate": false,
           "params": Array [
             "signal-index",
+            "*:signal-index",
           ],
           "type": "phrases",
         },
@@ -276,6 +283,11 @@ Object {
               Object {
                 "match_phrase": Object {
                   "_index": "signal-index",
+                },
+              },
+              Object {
+                "match_phrase": Object {
+                  "_index": "*:signal-index",
                 },
               },
             ],
@@ -402,6 +414,7 @@ Object {
           "negate": false,
           "params": Array [
             "signal-index",
+            "*:signal-index",
           ],
           "type": "phrases",
         },
@@ -412,6 +425,11 @@ Object {
               Object {
                 "match_phrase": Object {
                   "_index": "signal-index",
+                },
+              },
+              Object {
+                "match_phrase": Object {
+                  "_index": "*:signal-index",
                 },
               },
             ],

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/event.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/event.test.ts
@@ -101,6 +101,11 @@ describe('getEventsHistogramLensAttributes', () => {
                   _index: 'auditbeat-mytest-*',
                 },
               },
+              {
+                match_phrase: {
+                  _index: '*:auditbeat-mytest-*',
+                },
+              },
             ],
           },
         },
@@ -161,6 +166,11 @@ describe('getEventsHistogramLensAttributes', () => {
               {
                 match_phrase: {
                   _index: 'auditbeat-mytest-*',
+                },
+              },
+              {
+                match_phrase: {
+                  _index: '*:auditbeat-mytest-*',
                 },
               },
             ],
@@ -234,6 +244,11 @@ describe('getEventsHistogramLensAttributes', () => {
               {
                 match_phrase: {
                   _index: 'auditbeat-mytest-*',
+                },
+              },
+              {
+                match_phrase: {
+                  _index: '*:auditbeat-mytest-*',
                 },
               },
             ],
@@ -332,6 +347,11 @@ describe('getEventsHistogramLensAttributes', () => {
                   _index: 'auditbeat-mytest-*',
                 },
               },
+              {
+                match_phrase: {
+                  _index: '*:auditbeat-mytest-*',
+                },
+              },
             ],
           },
         },
@@ -398,6 +418,11 @@ describe('getEventsHistogramLensAttributes', () => {
               {
                 match_phrase: {
                   _index: 'auditbeat-mytest-*',
+                },
+              },
+              {
+                match_phrase: {
+                  _index: '*:auditbeat-mytest-*',
                 },
               },
             ],
@@ -476,6 +501,11 @@ describe('getEventsHistogramLensAttributes', () => {
               {
                 match_phrase: {
                   _index: 'auditbeat-mytest-*',
+                },
+              },
+              {
+                match_phrase: {
+                  _index: '*:auditbeat-mytest-*',
                 },
               },
             ],

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/hosts/__snapshots__/kpi_host_area.test.ts.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/hosts/__snapshots__/kpi_host_area.test.ts.snap
@@ -99,6 +99,7 @@ Object {
           "negate": false,
           "params": Array [
             "auditbeat-mytest-*",
+            "*:auditbeat-mytest-*",
           ],
           "type": "phrases",
         },
@@ -109,6 +110,11 @@ Object {
               Object {
                 "match_phrase": Object {
                   "_index": "auditbeat-mytest-*",
+                },
+              },
+              Object {
+                "match_phrase": Object {
+                  "_index": "*:auditbeat-mytest-*",
                 },
               },
             ],

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/hosts/__snapshots__/kpi_host_metric.test.ts.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/hosts/__snapshots__/kpi_host_metric.test.ts.snap
@@ -87,6 +87,7 @@ Object {
           "negate": false,
           "params": Array [
             "auditbeat-mytest-*",
+            "*:auditbeat-mytest-*",
           ],
           "type": "phrases",
         },
@@ -97,6 +98,11 @@ Object {
               Object {
                 "match_phrase": Object {
                   "_index": "auditbeat-mytest-*",
+                },
+              },
+              Object {
+                "match_phrase": Object {
+                  "_index": "*:auditbeat-mytest-*",
                 },
               },
             ],

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/hosts/__snapshots__/kpi_unique_ips_area.test.ts.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/hosts/__snapshots__/kpi_unique_ips_area.test.ts.snap
@@ -133,6 +133,7 @@ Object {
           "negate": false,
           "params": Array [
             "auditbeat-mytest-*",
+            "*:auditbeat-mytest-*",
           ],
           "type": "phrases",
         },
@@ -143,6 +144,11 @@ Object {
               Object {
                 "match_phrase": Object {
                   "_index": "auditbeat-mytest-*",
+                },
+              },
+              Object {
+                "match_phrase": Object {
+                  "_index": "*:auditbeat-mytest-*",
                 },
               },
             ],

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/hosts/__snapshots__/kpi_unique_ips_bar.test.ts.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/hosts/__snapshots__/kpi_unique_ips_bar.test.ts.snap
@@ -146,6 +146,7 @@ Object {
           "negate": false,
           "params": Array [
             "auditbeat-mytest-*",
+            "*:auditbeat-mytest-*",
           ],
           "type": "phrases",
         },
@@ -156,6 +157,11 @@ Object {
               Object {
                 "match_phrase": Object {
                   "_index": "auditbeat-mytest-*",
+                },
+              },
+              Object {
+                "match_phrase": Object {
+                  "_index": "*:auditbeat-mytest-*",
                 },
               },
             ],

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/hosts/__snapshots__/kpi_unique_ips_destination_metric.test.ts.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/hosts/__snapshots__/kpi_unique_ips_destination_metric.test.ts.snap
@@ -87,6 +87,7 @@ Object {
           "negate": false,
           "params": Array [
             "auditbeat-mytest-*",
+            "*:auditbeat-mytest-*",
           ],
           "type": "phrases",
         },
@@ -97,6 +98,11 @@ Object {
               Object {
                 "match_phrase": Object {
                   "_index": "auditbeat-mytest-*",
+                },
+              },
+              Object {
+                "match_phrase": Object {
+                  "_index": "*:auditbeat-mytest-*",
                 },
               },
             ],

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/hosts/__snapshots__/kpi_unique_ips_source_metric.test.ts.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/hosts/__snapshots__/kpi_unique_ips_source_metric.test.ts.snap
@@ -87,6 +87,7 @@ Object {
           "negate": false,
           "params": Array [
             "auditbeat-mytest-*",
+            "*:auditbeat-mytest-*",
           ],
           "type": "phrases",
         },
@@ -97,6 +98,11 @@ Object {
               Object {
                 "match_phrase": Object {
                   "_index": "auditbeat-mytest-*",
+                },
+              },
+              Object {
+                "match_phrase": Object {
+                  "_index": "*:auditbeat-mytest-*",
                 },
               },
             ],

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/network/__snapshots__/dns_top_domains.test.ts.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/network/__snapshots__/dns_top_domains.test.ts.snap
@@ -159,6 +159,7 @@ Object {
           "negate": false,
           "params": Array [
             "auditbeat-mytest-*",
+            "*:auditbeat-mytest-*",
           ],
           "type": "phrases",
         },
@@ -169,6 +170,11 @@ Object {
               Object {
                 "match_phrase": Object {
                   "_index": "auditbeat-mytest-*",
+                },
+              },
+              Object {
+                "match_phrase": Object {
+                  "_index": "*:auditbeat-mytest-*",
                 },
               },
             ],

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/network/__snapshots__/kpi_dns_queries.test.ts.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/network/__snapshots__/kpi_dns_queries.test.ts.snap
@@ -147,6 +147,7 @@ Object {
           "negate": false,
           "params": Array [
             "auditbeat-mytest-*",
+            "*:auditbeat-mytest-*",
           ],
           "type": "phrases",
         },
@@ -157,6 +158,11 @@ Object {
               Object {
                 "match_phrase": Object {
                   "_index": "auditbeat-mytest-*",
+                },
+              },
+              Object {
+                "match_phrase": Object {
+                  "_index": "*:auditbeat-mytest-*",
                 },
               },
             ],

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/network/__snapshots__/kpi_network_events.test.ts.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/network/__snapshots__/kpi_network_events.test.ts.snap
@@ -152,6 +152,7 @@ Object {
           "negate": false,
           "params": Array [
             "auditbeat-mytest-*",
+            "*:auditbeat-mytest-*",
           ],
           "type": "phrases",
         },
@@ -162,6 +163,11 @@ Object {
               Object {
                 "match_phrase": Object {
                   "_index": "auditbeat-mytest-*",
+                },
+              },
+              Object {
+                "match_phrase": Object {
+                  "_index": "*:auditbeat-mytest-*",
                 },
               },
             ],

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/network/__snapshots__/kpi_tls_handshakes.test.ts.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/network/__snapshots__/kpi_tls_handshakes.test.ts.snap
@@ -171,6 +171,7 @@ Object {
           "negate": false,
           "params": Array [
             "auditbeat-mytest-*",
+            "*:auditbeat-mytest-*",
           ],
           "type": "phrases",
         },
@@ -181,6 +182,11 @@ Object {
               Object {
                 "match_phrase": Object {
                   "_index": "auditbeat-mytest-*",
+                },
+              },
+              Object {
+                "match_phrase": Object {
+                  "_index": "*:auditbeat-mytest-*",
                 },
               },
             ],

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/network/__snapshots__/kpi_unique_flow_ids.test.ts.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/network/__snapshots__/kpi_unique_flow_ids.test.ts.snap
@@ -135,6 +135,7 @@ Object {
           "negate": false,
           "params": Array [
             "auditbeat-mytest-*",
+            "*:auditbeat-mytest-*",
           ],
           "type": "phrases",
         },
@@ -145,6 +146,11 @@ Object {
               Object {
                 "match_phrase": Object {
                   "_index": "auditbeat-mytest-*",
+                },
+              },
+              Object {
+                "match_phrase": Object {
+                  "_index": "*:auditbeat-mytest-*",
                 },
               },
             ],

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/network/__snapshots__/kpi_unique_private_ips_area.test.ts.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/network/__snapshots__/kpi_unique_private_ips_area.test.ts.snap
@@ -157,6 +157,7 @@ Object {
           "negate": false,
           "params": Array [
             "auditbeat-mytest-*",
+            "*:auditbeat-mytest-*",
           ],
           "type": "phrases",
         },
@@ -167,6 +168,11 @@ Object {
               Object {
                 "match_phrase": Object {
                   "_index": "auditbeat-mytest-*",
+                },
+              },
+              Object {
+                "match_phrase": Object {
+                  "_index": "*:auditbeat-mytest-*",
                 },
               },
             ],

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/network/__snapshots__/kpi_unique_private_ips_bar.test.ts.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/network/__snapshots__/kpi_unique_private_ips_bar.test.ts.snap
@@ -170,6 +170,7 @@ Object {
           "negate": false,
           "params": Array [
             "auditbeat-mytest-*",
+            "*:auditbeat-mytest-*",
           ],
           "type": "phrases",
         },
@@ -180,6 +181,11 @@ Object {
               Object {
                 "match_phrase": Object {
                   "_index": "auditbeat-mytest-*",
+                },
+              },
+              Object {
+                "match_phrase": Object {
+                  "_index": "*:auditbeat-mytest-*",
                 },
               },
             ],

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/network/__snapshots__/kpi_unique_private_ips_destination_metric.test.ts.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/network/__snapshots__/kpi_unique_private_ips_destination_metric.test.ts.snap
@@ -108,6 +108,7 @@ Object {
           "negate": false,
           "params": Array [
             "auditbeat-mytest-*",
+            "*:auditbeat-mytest-*",
           ],
           "type": "phrases",
         },
@@ -118,6 +119,11 @@ Object {
               Object {
                 "match_phrase": Object {
                   "_index": "auditbeat-mytest-*",
+                },
+              },
+              Object {
+                "match_phrase": Object {
+                  "_index": "*:auditbeat-mytest-*",
                 },
               },
             ],

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/network/__snapshots__/kpi_unique_private_ips_source_metric.test.ts.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/network/__snapshots__/kpi_unique_private_ips_source_metric.test.ts.snap
@@ -108,6 +108,7 @@ Object {
           "negate": false,
           "params": Array [
             "auditbeat-mytest-*",
+            "*:auditbeat-mytest-*",
           ],
           "type": "phrases",
         },
@@ -118,6 +119,11 @@ Object {
               Object {
                 "match_phrase": Object {
                   "_index": "auditbeat-mytest-*",
+                },
+              },
+              Object {
+                "match_phrase": Object {
+                  "_index": "*:auditbeat-mytest-*",
                 },
               },
             ],

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/network/dns_top_domains.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/network/dns_top_domains.test.ts
@@ -144,6 +144,11 @@ describe('getDnsTopDomainsLensAttributes', () => {
                   _index: 'auditbeat-mytest-*',
                 },
               },
+              {
+                match_phrase: {
+                  _index: '*:auditbeat-mytest-*',
+                },
+              },
             ],
           },
         },

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/users/__snapshots__/kpi_total_users_area.test.ts.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/users/__snapshots__/kpi_total_users_area.test.ts.snap
@@ -99,6 +99,7 @@ Object {
           "negate": false,
           "params": Array [
             "auditbeat-mytest-*",
+            "*:auditbeat-mytest-*",
           ],
           "type": "phrases",
         },
@@ -109,6 +110,11 @@ Object {
               Object {
                 "match_phrase": Object {
                   "_index": "auditbeat-mytest-*",
+                },
+              },
+              Object {
+                "match_phrase": Object {
+                  "_index": "*:auditbeat-mytest-*",
                 },
               },
             ],

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/users/__snapshots__/kpi_total_users_metric.test.ts.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/users/__snapshots__/kpi_total_users_metric.test.ts.snap
@@ -87,6 +87,7 @@ Object {
           "negate": false,
           "params": Array [
             "auditbeat-mytest-*",
+            "*:auditbeat-mytest-*",
           ],
           "type": "phrases",
         },
@@ -97,6 +98,11 @@ Object {
               Object {
                 "match_phrase": Object {
                   "_index": "auditbeat-mytest-*",
+                },
+              },
+              Object {
+                "match_phrase": Object {
+                  "_index": "*:auditbeat-mytest-*",
                 },
               },
             ],

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/users/__snapshots__/kpi_user_authentication_metric_failure.test.ts.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/users/__snapshots__/kpi_user_authentication_metric_failure.test.ts.snap
@@ -116,6 +116,7 @@ Object {
           "negate": false,
           "params": Array [
             "auditbeat-mytest-*",
+            "*:auditbeat-mytest-*",
           ],
           "type": "phrases",
         },
@@ -126,6 +127,11 @@ Object {
               Object {
                 "match_phrase": Object {
                   "_index": "auditbeat-mytest-*",
+                },
+              },
+              Object {
+                "match_phrase": Object {
+                  "_index": "*:auditbeat-mytest-*",
                 },
               },
             ],

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/users/__snapshots__/kpi_user_authentications_area.test.ts.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/users/__snapshots__/kpi_user_authentications_area.test.ts.snap
@@ -166,6 +166,7 @@ Object {
           "negate": false,
           "params": Array [
             "auditbeat-mytest-*",
+            "*:auditbeat-mytest-*",
           ],
           "type": "phrases",
         },
@@ -176,6 +177,11 @@ Object {
               Object {
                 "match_phrase": Object {
                   "_index": "auditbeat-mytest-*",
+                },
+              },
+              Object {
+                "match_phrase": Object {
+                  "_index": "*:auditbeat-mytest-*",
                 },
               },
             ],

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/users/__snapshots__/kpi_user_authentications_bar.test.ts.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/users/__snapshots__/kpi_user_authentications_bar.test.ts.snap
@@ -171,6 +171,7 @@ Object {
           "negate": false,
           "params": Array [
             "auditbeat-mytest-*",
+            "*:auditbeat-mytest-*",
           ],
           "type": "phrases",
         },
@@ -181,6 +182,11 @@ Object {
               Object {
                 "match_phrase": Object {
                   "_index": "auditbeat-mytest-*",
+                },
+              },
+              Object {
+                "match_phrase": Object {
+                  "_index": "*:auditbeat-mytest-*",
                 },
               },
             ],

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/users/__snapshots__/kpi_user_authentications_metric_success.test.ts.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/users/__snapshots__/kpi_user_authentications_metric_success.test.ts.snap
@@ -116,6 +116,7 @@ Object {
           "negate": false,
           "params": Array [
             "auditbeat-mytest-*",
+            "*:auditbeat-mytest-*",
           ],
           "type": "phrases",
         },
@@ -126,6 +127,11 @@ Object {
               Object {
                 "match_phrase": Object {
                   "_index": "auditbeat-mytest-*",
+                },
+              },
+              Object {
+                "match_phrase": Object {
+                  "_index": "*:auditbeat-mytest-*",
                 },
               },
             ],

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_embeddable.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_embeddable.tsx
@@ -70,6 +70,7 @@ const LensEmbeddableComponent: React.FC<LensEmbeddableComponentProps> = ({
   disableOnClickFilter = false,
   casesAttachmentMetadata,
   signalIndexName,
+  overridePatterns,
   esql,
 }) => {
   const styles = useMemo(
@@ -104,6 +105,7 @@ const LensEmbeddableComponent: React.FC<LensEmbeddableComponentProps> = ({
     title: '',
     esql,
     signalIndexName,
+    overridePatterns,
   });
   const preferredSeriesType = (attributes?.state?.visualization as XYVisualizationState)
     ?.preferredSeriesType;

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_embeddable.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_embeddable.tsx
@@ -70,7 +70,7 @@ const LensEmbeddableComponent: React.FC<LensEmbeddableComponentProps> = ({
   disableOnClickFilter = false,
   casesAttachmentMetadata,
   signalIndexName,
-  overridePatterns,
+  excludedPatterns,
   esql,
 }) => {
   const styles = useMemo(
@@ -105,7 +105,7 @@ const LensEmbeddableComponent: React.FC<LensEmbeddableComponentProps> = ({
     title: '',
     esql,
     signalIndexName,
-    overridePatterns,
+    excludedPatterns,
   });
   const preferredSeriesType = (attributes?.state?.visualization as XYVisualizationState)
     ?.preferredSeriesType;

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/types.ts
@@ -47,6 +47,13 @@ export interface UseLensAttributesProps {
    * Indices to use when fetching the lens componen
    */
   signalIndexName?: string | null;
+  /**
+   * When provided, replaces the scope's `selectedPatterns` as the source for
+   * the `_index` filter injected by `useLensAttributes`. Use this to scope the
+   * chart to a subset of the data view's index patterns (e.g. events-only,
+   * without alert-backing indices) without mutating the shared sourcerer scope.
+   */
+  overridePatterns?: string[];
 }
 
 export enum VisualizationContextMenuActions {
@@ -130,6 +137,11 @@ export interface LensEmbeddableComponentProps {
    * Indices to use when fetching the lens component
    */
   signalIndexName?: string | null;
+  /**
+   * When provided, replaces the scope's `selectedPatterns` as the source for
+   * the `_index` filter. See `UseLensAttributesProps.overridePatterns`.
+   */
+  overridePatterns?: string[];
   width?: string | number;
   withActions?: VisualizationContextMenuActions[];
   /**

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/types.ts
@@ -48,12 +48,14 @@ export interface UseLensAttributesProps {
    */
   signalIndexName?: string | null;
   /**
-   * When provided, replaces the scope's `selectedPatterns` as the source for
-   * the `_index` filter injected by `useLensAttributes`. Use this to scope the
-   * chart to a subset of the data view's index patterns (e.g. events-only,
-   * without alert-backing indices) without mutating the shared sourcerer scope.
+   * Additional drop-list of index patterns layered on top of the scope's
+   * allowlist as a *negated* `_index` filter (CPS-expanded). The chart's
+   * primary scope is always the CPS-expanded `selectedPatterns` allowlist;
+   * `excludedPatterns` adds a defensive exclusion (e.g. alert-backing
+   * indices). An empty array is equivalent to `undefined`. Ignored when
+   * `signalIndexName` is set. See `buildIndexFilters` for full semantics.
    */
-  overridePatterns?: string[];
+  excludedPatterns?: string[];
 }
 
 export enum VisualizationContextMenuActions {
@@ -138,10 +140,11 @@ export interface LensEmbeddableComponentProps {
    */
   signalIndexName?: string | null;
   /**
-   * When provided, replaces the scope's `selectedPatterns` as the source for
-   * the `_index` filter. See `UseLensAttributesProps.overridePatterns`.
+   * Additional drop-list of index patterns layered on top of the chart's
+   * allowlist as a negated `_index` filter (CPS-expanded). See
+   * `UseLensAttributesProps.excludedPatterns`.
    */
-  overridePatterns?: string[];
+  excludedPatterns?: string[];
   width?: string | number;
   withActions?: VisualizationContextMenuActions[];
   /**

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/use_lens_attributes.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/use_lens_attributes.test.tsx
@@ -394,6 +394,73 @@ describe('useLensAttributes', () => {
     expect(result?.current).toBeNull();
   });
 
+  it('uses overridePatterns to build a negated exclusion filter for removed patterns (CPS-safe)', () => {
+    // The "should return null if no indices exist" test (above this one in execution order)
+    // changes useDataView to the default (no matched indices), so restore it here.
+    // The scope includes both event and alert-backing index patterns.
+    jest
+      .mocked(useDataView)
+      .mockReturnValue(withIndices(['auditbeat-*', '.alerts-security.alerts-default']));
+
+    // Caller passes overridePatterns = filterAlertsFromIndexPatterns(selectedPatterns),
+    // i.e. the alert pattern has been removed.
+    const overridePatterns = ['auditbeat-*'];
+
+    const { result } = renderHook(
+      () =>
+        useLensAttributes({
+          getLensAttributes: getEventsHistogramLensAttributes,
+          stackByField: 'event.dataset',
+          overridePatterns,
+        }),
+      { wrapper }
+    );
+
+    // The _index filter must be a NEGATED exclusion for the REMOVED pattern
+    // ('.alerts-security.alerts-default'), NOT an allowlist of overridePatterns.
+    // A negated filter allows CPS remote cluster documents to pass through while
+    // still excluding alert-backing index documents.
+    const negatedAlertFilter = getIndexFilters(['.alerts-security.alerts-default']).map((f) => ({
+      ...f,
+      meta: { ...f.meta, negate: true },
+    }));
+
+    // Default beforeEach route: hosts/events/mockHost, so pageFilters + tabsFilters apply.
+    expect(result?.current?.state.filters).toEqual([
+      ...getEventsHistogramLensAttributes(params).state.filters,
+      ...getDetailsPageFilter('hosts', 'mockHost'),
+      ...fieldNameExistsFilter('hosts'),
+      ...negatedAlertFilter,
+      ...filterFromSearchBar,
+    ]);
+  });
+
+  it('signalIndexName scope is maintained even when overridePatterns is also provided', () => {
+    jest.mocked(useDataView).mockReturnValue(withIndices(['auditbeat-*']));
+
+    // When signalIndexName is present the negated-exclusion path is bypassed so that
+    // the Alerts trend chart always scopes to the local signal index only.
+    const { result } = renderHook(
+      () =>
+        useLensAttributes({
+          getLensAttributes: getEventsHistogramLensAttributes,
+          stackByField: 'event.dataset',
+          signalIndexName: '.alerts-security.alerts-default',
+          overridePatterns: ['logs-*'],
+        }),
+      { wrapper }
+    );
+
+    // _index filter is the allowlist for [signalIndexName], not affected by overridePatterns.
+    expect(result?.current?.state.filters).toEqual([
+      ...getEventsHistogramLensAttributes(params).state.filters,
+      ...getDetailsPageFilter('hosts', 'mockHost'),
+      ...fieldNameExistsFilter('hosts'),
+      ...getIndexFilters(['.alerts-security.alerts-default']),
+      ...filterFromSearchBar,
+    ]);
+  });
+
   it('should return Lens attributes if adHocDataViews exist', () => {
     (useSourcererDataView as jest.Mock).mockReturnValue({
       dataViewId: 'security-solution-default',

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/use_lens_attributes.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/use_lens_attributes.test.tsx
@@ -10,6 +10,7 @@ import { renderHook } from '@testing-library/react';
 import { getExternalAlertLensAttributes } from './lens_attributes/common/external_alert';
 import { useLensAttributes } from './use_lens_attributes';
 import {
+  expandIndexPatternsForCps,
   fieldNameExistsFilter,
   getDetailsPageFilter,
   getIndexFilters,
@@ -98,7 +99,7 @@ describe('useLensAttributes', () => {
       ...getExternalAlertLensAttributes(params).state.filters,
       ...getDetailsPageFilter('hosts', 'mockHost'),
       ...fieldNameExistsFilter('hosts'),
-      ...getIndexFilters(['auditbeat-*']),
+      ...getIndexFilters(expandIndexPatternsForCps(['auditbeat-*'])),
       ...filterFromSearchBar,
     ]);
   });
@@ -117,7 +118,7 @@ describe('useLensAttributes', () => {
     expect(result?.current?.state.filters).toEqual([
       ...getExternalAlertLensAttributes(params).state.filters,
       ...getDetailsPageFilter('hosts', 'mockHost'),
-      ...getIndexFilters(['auditbeat-*']),
+      ...getIndexFilters(expandIndexPatternsForCps(['auditbeat-*'])),
       ...filterFromSearchBar,
     ]);
   });
@@ -143,7 +144,7 @@ describe('useLensAttributes', () => {
     expect(result?.current?.state.filters).toEqual([
       ...getExternalAlertLensAttributes(params).state.filters,
       ...getDetailsPageFilter(SecurityPageName.users, 'elastic'),
-      ...getIndexFilters(['auditbeat-*']),
+      ...getIndexFilters(expandIndexPatternsForCps(['auditbeat-*'])),
       ...filterFromSearchBar,
     ]);
   });
@@ -169,7 +170,7 @@ describe('useLensAttributes', () => {
       ...getExternalAlertLensAttributes(params).state.filters,
       ...getNetworkDetailsPageFilter('192.168.1.1'),
       ...sourceOrDestinationIpExistsFilter,
-      ...getIndexFilters(['auditbeat-*']),
+      ...getIndexFilters(expandIndexPatternsForCps(['auditbeat-*'])),
       ...filterFromSearchBar,
     ]);
   });
@@ -194,7 +195,7 @@ describe('useLensAttributes', () => {
     expect(result?.current?.state.filters).toEqual([
       ...getExternalAlertLensAttributes(params).state.filters,
       ...getDetailsPageFilter('user', 'elastic'),
-      ...getIndexFilters(['auditbeat-*']),
+      ...getIndexFilters(expandIndexPatternsForCps(['auditbeat-*'])),
       ...filterFromSearchBar,
     ]);
   });
@@ -221,7 +222,7 @@ describe('useLensAttributes', () => {
 
     expect(result?.current?.state.filters).toEqual([
       ...getExternalAlertLensAttributes(params).state.filters,
-      ...getIndexFilters(['auditbeat-*']),
+      ...getIndexFilters(expandIndexPatternsForCps(['auditbeat-*'])),
     ]);
   });
 
@@ -249,7 +250,7 @@ describe('useLensAttributes', () => {
 
     expect(result?.current?.state.filters).toEqual([
       ...getExternalAlertLensAttributes(params).state.filters,
-      ...getIndexFilters(['auditbeat-*']),
+      ...getIndexFilters(expandIndexPatternsForCps(['auditbeat-*'])),
       ...getESQLGlobalFilters(undefined),
     ]);
   });
@@ -274,7 +275,7 @@ describe('useLensAttributes', () => {
 
     expect(result?.current?.state.filters).toEqual([
       ...getExternalAlertLensAttributes(params).state.filters,
-      ...getIndexFilters(['auditbeat-*']),
+      ...getIndexFilters(expandIndexPatternsForCps(['auditbeat-*'])),
       ...filterFromSearchBar,
     ]);
   });
@@ -394,7 +395,7 @@ describe('useLensAttributes', () => {
     expect(result?.current).toBeNull();
   });
 
-  it('uses overridePatterns to build a negated exclusion filter for removed patterns (CPS-safe)', () => {
+  it('layers a CPS-expanded negated drop-list on top of the CPS-expanded allowlist when excludedPatterns is set', () => {
     // The "should return null if no indices exist" test (above this one in execution order)
     // changes useDataView to the default (no matched indices), so restore it here.
     // The scope includes both event and alert-backing index patterns.
@@ -402,25 +403,26 @@ describe('useLensAttributes', () => {
       .mocked(useDataView)
       .mockReturnValue(withIndices(['auditbeat-*', '.alerts-security.alerts-default']));
 
-    // Caller passes overridePatterns = filterAlertsFromIndexPatterns(selectedPatterns),
-    // i.e. the alert pattern has been removed.
-    const overridePatterns = ['auditbeat-*'];
+    const excludedPatterns = ['.alerts-security.alerts-default'];
 
     const { result } = renderHook(
       () =>
         useLensAttributes({
           getLensAttributes: getEventsHistogramLensAttributes,
           stackByField: 'event.dataset',
-          overridePatterns,
+          excludedPatterns,
         }),
       { wrapper }
     );
 
-    // The _index filter must be a NEGATED exclusion for the REMOVED pattern
-    // ('.alerts-security.alerts-default'), NOT an allowlist of overridePatterns.
-    // A negated filter allows CPS remote cluster documents to pass through while
-    // still excluding alert-backing index documents.
-    const negatedAlertFilter = getIndexFilters(['.alerts-security.alerts-default']).map((f) => ({
+    // The _index filter is a CPS-expanded allowlist for selectedPatterns plus a
+    // CPS-expanded negated drop-list for excludedPatterns. The allowlist bounds
+    // the chart to the user's scope (locally and across remote clusters), and
+    // the drop-list defensively removes alert-backing indices on top.
+    const allowlist = getIndexFilters(
+      expandIndexPatternsForCps(['auditbeat-*', '.alerts-security.alerts-default'])
+    );
+    const dropList = getIndexFilters(expandIndexPatternsForCps(excludedPatterns)).map((f) => ({
       ...f,
       meta: { ...f.meta, negate: true },
     }));
@@ -430,12 +432,13 @@ describe('useLensAttributes', () => {
       ...getEventsHistogramLensAttributes(params).state.filters,
       ...getDetailsPageFilter('hosts', 'mockHost'),
       ...fieldNameExistsFilter('hosts'),
-      ...negatedAlertFilter,
+      ...allowlist,
+      ...dropList,
       ...filterFromSearchBar,
     ]);
   });
 
-  it('signalIndexName scope is maintained even when overridePatterns is also provided', () => {
+  it('signalIndexName scope is maintained even when excludedPatterns is also provided', () => {
     jest.mocked(useDataView).mockReturnValue(withIndices(['auditbeat-*']));
 
     // When signalIndexName is present the negated-exclusion path is bypassed so that
@@ -446,12 +449,12 @@ describe('useLensAttributes', () => {
           getLensAttributes: getEventsHistogramLensAttributes,
           stackByField: 'event.dataset',
           signalIndexName: '.alerts-security.alerts-default',
-          overridePatterns: ['logs-*'],
+          excludedPatterns: ['logs-*'],
         }),
       { wrapper }
     );
 
-    // _index filter is the allowlist for [signalIndexName], not affected by overridePatterns.
+    // _index filter is the allowlist for [signalIndexName], not affected by excludedPatterns.
     expect(result?.current?.state.filters).toEqual([
       ...getEventsHistogramLensAttributes(params).state.filters,
       ...getDetailsPageFilter('hosts', 'mockHost'),

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/use_lens_attributes.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/use_lens_attributes.tsx
@@ -16,10 +16,10 @@ import { inputsSelectors } from '../../store';
 import { useRouteSpy } from '../../utils/route/use_route_spy';
 import type { LensAttributes, UseLensAttributesProps } from './types';
 import {
+  buildIndexFilters,
   fieldNameExistsFilter,
   getDetailsPageFilter,
   getESQLGlobalFilters,
-  getIndexFilters,
   getNetworkDetailsPageFilter,
   sourceOrDestinationIpExistsFilter,
 } from './utils';
@@ -38,6 +38,7 @@ export const useLensAttributes = ({
   title,
   esql,
   signalIndexName,
+  overridePatterns,
 }: UseLensAttributesProps): LensAttributes | null => {
   const { euiTheme } = useEuiTheme();
   const {
@@ -137,7 +138,12 @@ export const useLensAttributes = ({
       return null;
     }
 
-    const indexFilters = hasAdHocDataViews ? [] : getIndexFilters(selectedPatterns);
+    const indexFilters = buildIndexFilters({
+      hasAdHocDataViews,
+      selectedPatterns,
+      overridePatterns,
+      signalIndexName,
+    });
     const query = esql ? { esql } : globalQuery;
 
     const queryFilters = (() => {
@@ -175,6 +181,8 @@ export const useLensAttributes = ({
     stackByField,
     hasAdHocDataViews,
     selectedPatterns,
+    overridePatterns,
+    signalIndexName,
     esql,
     globalQuery,
     globalFilterQuery,

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/use_lens_attributes.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/use_lens_attributes.tsx
@@ -38,7 +38,7 @@ export const useLensAttributes = ({
   title,
   esql,
   signalIndexName,
-  overridePatterns,
+  excludedPatterns,
 }: UseLensAttributesProps): LensAttributes | null => {
   const { euiTheme } = useEuiTheme();
   const {
@@ -141,7 +141,7 @@ export const useLensAttributes = ({
     const indexFilters = buildIndexFilters({
       hasAdHocDataViews,
       selectedPatterns,
-      overridePatterns,
+      excludedPatterns,
       signalIndexName,
     });
     const query = esql ? { esql } : globalQuery;
@@ -181,7 +181,7 @@ export const useLensAttributes = ({
     stackByField,
     hasAdHocDataViews,
     selectedPatterns,
-    overridePatterns,
+    excludedPatterns,
     signalIndexName,
     esql,
     globalQuery,

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/utils.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/utils.test.ts
@@ -7,7 +7,10 @@
 
 import {
   buildAnyFieldExistsFilter,
+  buildIndexFilters,
+  filterAlertsFromIndexPatterns,
   getDetailsPageFilter,
+  getIndexFilters,
   getNetworkDetailsPageFilter,
   getRequestsAndResponses,
   hostNameExistsFilter,
@@ -15,6 +18,94 @@ import {
   userNameExistsFilter,
 } from './utils';
 import { mockRequests } from './__mocks__/utils';
+
+describe('filterAlertsFromIndexPatterns', () => {
+  test('removes the exact alerts-backing index pattern', () => {
+    const input = [
+      'logs-*',
+      '.alerts-security.alerts-default',
+      'auditbeat-*',
+      '.alerts-security.alerts-custom-space',
+    ];
+    expect(filterAlertsFromIndexPatterns(input)).toEqual(['logs-*', 'auditbeat-*']);
+  });
+
+  test('removes the wildcard alerts pattern', () => {
+    expect(filterAlertsFromIndexPatterns(['.alerts-security.alerts-*'])).toEqual([]);
+  });
+
+  test('preserves patterns that merely contain the alerts prefix substring', () => {
+    // Only entries that START with `.alerts-security.alerts` are removed.
+    // Patterns like `metrics-*` are kept even though they contain unrelated substrings.
+    expect(filterAlertsFromIndexPatterns(['metrics-*', 'logs-*'])).toEqual(['metrics-*', 'logs-*']);
+  });
+
+  test('preserves remote cluster–prefixed event patterns for CPS', () => {
+    const input = ['cluster-a:logs-*', 'cluster-a:auditbeat-*', '.alerts-security.alerts-default'];
+    expect(filterAlertsFromIndexPatterns(input)).toEqual([
+      'cluster-a:logs-*',
+      'cluster-a:auditbeat-*',
+    ]);
+  });
+
+  test('returns an empty array when all patterns are alert patterns', () => {
+    expect(
+      filterAlertsFromIndexPatterns([
+        '.alerts-security.alerts-default',
+        '.alerts-security.alerts-*',
+      ])
+    ).toEqual([]);
+  });
+
+  test('returns the original array reference when nothing is filtered', () => {
+    const input = ['logs-*', 'auditbeat-*'];
+    const output = filterAlertsFromIndexPatterns(input);
+    // All entries kept — no mutation, just a fresh array without alert patterns
+    expect(output).toEqual(input);
+  });
+});
+
+describe('buildIndexFilters', () => {
+  const selectedPatterns = ['logs-*', '.alerts-security.alerts-default'];
+  const overridePatterns = ['logs-*'];
+
+  test('returns [] when hasAdHocDataViews is true regardless of patterns', () => {
+    expect(buildIndexFilters({ hasAdHocDataViews: true, selectedPatterns })).toEqual([]);
+    expect(buildIndexFilters({ hasAdHocDataViews: true, selectedPatterns, overridePatterns })).toEqual([]);
+  });
+
+  test('returns getIndexFilters(selectedPatterns) when no overridePatterns', () => {
+    expect(buildIndexFilters({ hasAdHocDataViews: false, selectedPatterns })).toEqual(
+      getIndexFilters(selectedPatterns)
+    );
+  });
+
+  test('returns getIndexFilters(selectedPatterns) when signalIndexName is present (overridePatterns ignored)', () => {
+    expect(
+      buildIndexFilters({
+        hasAdHocDataViews: false,
+        selectedPatterns,
+        overridePatterns,
+        signalIndexName: '.alerts-security.alerts-default',
+      })
+    ).toEqual(getIndexFilters(selectedPatterns));
+  });
+
+  test('returns negated exclusion filters for removed patterns when overridePatterns is provided', () => {
+    const result = buildIndexFilters({ hasAdHocDataViews: false, selectedPatterns, overridePatterns });
+    const expected = getIndexFilters(['.alerts-security.alerts-default']).map((f) => ({
+      ...f,
+      meta: { ...f.meta, negate: true },
+    }));
+    expect(result).toEqual(expected);
+  });
+
+  test('returns [] when overridePatterns equals selectedPatterns (nothing excluded)', () => {
+    expect(
+      buildIndexFilters({ hasAdHocDataViews: false, selectedPatterns, overridePatterns: selectedPatterns })
+    ).toEqual([]);
+  });
+});
 
 describe('buildAnyFieldExistsFilter', () => {
   test('meta.value serializes the same bool query as query', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/utils.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/utils.test.ts
@@ -8,7 +8,9 @@
 import {
   buildAnyFieldExistsFilter,
   buildIndexFilters,
+  expandIndexPatternsForCps,
   filterAlertsFromIndexPatterns,
+  getAlertsIndexPatterns,
   getDetailsPageFilter,
   getIndexFilters,
   getNetworkDetailsPageFilter,
@@ -65,45 +67,132 @@ describe('filterAlertsFromIndexPatterns', () => {
   });
 });
 
+describe('getAlertsIndexPatterns', () => {
+  test('returns only the alerts-backing index patterns', () => {
+    const input = [
+      'logs-*',
+      '.alerts-security.alerts-default',
+      'auditbeat-*',
+      '.alerts-security.alerts-custom-space',
+    ];
+    expect(getAlertsIndexPatterns(input)).toEqual([
+      '.alerts-security.alerts-default',
+      '.alerts-security.alerts-custom-space',
+    ]);
+  });
+
+  test('keeps the wildcard alerts pattern', () => {
+    expect(getAlertsIndexPatterns(['.alerts-security.alerts-*'])).toEqual([
+      '.alerts-security.alerts-*',
+    ]);
+  });
+
+  test('returns [] when no alert patterns are present', () => {
+    expect(getAlertsIndexPatterns(['metrics-*', 'logs-*'])).toEqual([]);
+  });
+
+  test('does not match remote cluster–prefixed event patterns (CPS-safe)', () => {
+    // Only entries that START with `.alerts-security.alerts` are returned;
+    // remote-cluster–prefixed event patterns are correctly excluded from the
+    // drop-list so they continue to flow through the chart.
+    const input = ['cluster-a:logs-*', 'cluster-a:auditbeat-*', '.alerts-security.alerts-default'];
+    expect(getAlertsIndexPatterns(input)).toEqual(['.alerts-security.alerts-default']);
+  });
+
+  test('result is the inverse of filterAlertsFromIndexPatterns', () => {
+    const input = [
+      'logs-*',
+      '.alerts-security.alerts-default',
+      'cluster-a:logs-*',
+      '.alerts-security.alerts-*',
+    ];
+    const drop = getAlertsIndexPatterns(input);
+    const keep = filterAlertsFromIndexPatterns(input);
+    expect([...keep, ...drop].sort()).toEqual([...input].sort());
+    expect(drop.some((p) => keep.includes(p))).toBe(false);
+  });
+});
+
+describe('expandIndexPatternsForCps', () => {
+  test('doubles each unprefixed pattern with a `*:`-prefixed variant', () => {
+    expect(expandIndexPatternsForCps(['logs-*', 'auditbeat-*'])).toEqual([
+      'logs-*',
+      '*:logs-*',
+      'auditbeat-*',
+      '*:auditbeat-*',
+    ]);
+  });
+
+  test('leaves already-prefixed patterns untouched', () => {
+    expect(expandIndexPatternsForCps(['cluster-a:logs-*'])).toEqual(['cluster-a:logs-*']);
+  });
+
+  test('mixes prefixed and unprefixed inputs preserving order', () => {
+    expect(
+      expandIndexPatternsForCps(['logs-*', 'cluster-a:logs-*', '.alerts-security.alerts-default'])
+    ).toEqual([
+      'logs-*',
+      '*:logs-*',
+      'cluster-a:logs-*',
+      '.alerts-security.alerts-default',
+      '*:.alerts-security.alerts-default',
+    ]);
+  });
+
+  test('returns [] for empty input', () => {
+    expect(expandIndexPatternsForCps([])).toEqual([]);
+  });
+});
+
 describe('buildIndexFilters', () => {
   const selectedPatterns = ['logs-*', '.alerts-security.alerts-default'];
-  const overridePatterns = ['logs-*'];
+  const excludedPatterns = ['.alerts-security.alerts-default'];
 
   test('returns [] when hasAdHocDataViews is true regardless of patterns', () => {
     expect(buildIndexFilters({ hasAdHocDataViews: true, selectedPatterns })).toEqual([]);
-    expect(buildIndexFilters({ hasAdHocDataViews: true, selectedPatterns, overridePatterns })).toEqual([]);
+    expect(
+      buildIndexFilters({ hasAdHocDataViews: true, selectedPatterns, excludedPatterns })
+    ).toEqual([]);
   });
 
-  test('returns getIndexFilters(selectedPatterns) when no overridePatterns', () => {
+  test('returns CPS-expanded allowlist for selectedPatterns when excludedPatterns is undefined', () => {
     expect(buildIndexFilters({ hasAdHocDataViews: false, selectedPatterns })).toEqual(
-      getIndexFilters(selectedPatterns)
+      getIndexFilters(expandIndexPatternsForCps(selectedPatterns))
     );
   });
 
-  test('returns getIndexFilters(selectedPatterns) when signalIndexName is present (overridePatterns ignored)', () => {
+  test('returns CPS-expanded allowlist for selectedPatterns when excludedPatterns is an empty array', () => {
+    // Empty `excludedPatterns` is equivalent to `undefined` — no drop-list layered on top.
+    expect(
+      buildIndexFilters({ hasAdHocDataViews: false, selectedPatterns, excludedPatterns: [] })
+    ).toEqual(getIndexFilters(expandIndexPatternsForCps(selectedPatterns)));
+  });
+
+  test('layers a CPS-expanded negated drop-list on top of the allowlist when excludedPatterns is non-empty', () => {
+    const result = buildIndexFilters({
+      hasAdHocDataViews: false,
+      selectedPatterns,
+      excludedPatterns,
+    });
+    const allowlist = getIndexFilters(expandIndexPatternsForCps(selectedPatterns));
+    const dropList = getIndexFilters(expandIndexPatternsForCps(excludedPatterns)).map((f) => ({
+      ...f,
+      meta: { ...f.meta, negate: true },
+    }));
+    expect(result).toEqual([...allowlist, ...dropList]);
+  });
+
+  test('uses raw selectedPatterns (no CPS expansion) and ignores excludedPatterns when signalIndexName is present', () => {
+    // signalIndexName is the sentinel for the Alerts trend chart: keep the local-only
+    // scope intact and never layer a drop-list on top.
     expect(
       buildIndexFilters({
         hasAdHocDataViews: false,
         selectedPatterns,
-        overridePatterns,
+        excludedPatterns,
         signalIndexName: '.alerts-security.alerts-default',
       })
     ).toEqual(getIndexFilters(selectedPatterns));
-  });
-
-  test('returns negated exclusion filters for removed patterns when overridePatterns is provided', () => {
-    const result = buildIndexFilters({ hasAdHocDataViews: false, selectedPatterns, overridePatterns });
-    const expected = getIndexFilters(['.alerts-security.alerts-default']).map((f) => ({
-      ...f,
-      meta: { ...f.meta, negate: true },
-    }));
-    expect(result).toEqual(expected);
-  });
-
-  test('returns [] when overridePatterns equals selectedPatterns (nothing excluded)', () => {
-    expect(
-      buildIndexFilters({ hasAdHocDataViews: false, selectedPatterns, overridePatterns: selectedPatterns })
-    ).toEqual([]);
   });
 });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/utils.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/utils.ts
@@ -200,6 +200,22 @@ export const sourceOrDestinationIpExistsFilter: Filter[] = [
   },
 ];
 
+/**
+ * Index-name prefix shared by all Security Solution alerts backing indices
+ * (e.g. `.alerts-security.alerts-default`). Patterns that start with this
+ * prefix are alert indices and must be excluded from the Events charts so that
+ * alert documents are not counted as events.
+ */
+export const ALERTS_INDEX_PATTERN = '.alerts-security.alerts';
+
+/**
+ * Return a copy of `patterns` with any Security Solution alerts-backing index
+ * patterns removed. Equivalent to "duplicating the selected data view and
+ * filtering out the alerts indices" without creating a full DataView object.
+ */
+export const filterAlertsFromIndexPatterns = (patterns: string[]): string[] =>
+  patterns.filter((p) => !p.startsWith(ALERTS_INDEX_PATTERN));
+
 export const getIndexFilters = (selectedPatterns: string[]) =>
   selectedPatterns.length >= 1
     ? [
@@ -223,6 +239,49 @@ export const getIndexFilters = (selectedPatterns: string[]) =>
         },
       ]
     : [];
+
+/**
+ * Compute the `_index` filters to inject into a Lens chart.
+ *
+ * When `overridePatterns` is provided (and `signalIndexName` is absent), the
+ * caller has supplied a subset of `selectedPatterns` with some entries removed
+ * (e.g. alert-backing indices stripped by `filterAlertsFromIndexPatterns`).
+ * Rather than emitting an allowlist filter from `overridePatterns` — which
+ * would block CPS remote-cluster documents whose index names carry a
+ * cluster-alias prefix — we instead emit *negated* filters for the removed
+ * patterns only. This lets all remote-event documents through while still
+ * excluding local alert-backing index documents.
+ */
+export const buildIndexFilters = ({
+  hasAdHocDataViews,
+  selectedPatterns,
+  overridePatterns,
+  signalIndexName,
+}: {
+  hasAdHocDataViews: boolean;
+  selectedPatterns: string[];
+  overridePatterns?: string[];
+  signalIndexName?: string | null;
+}): Filter[] => {
+  // Ad-hoc data views embed their index scope inside the Lens attributes directly.
+  if (hasAdHocDataViews) return [];
+
+  // CPS-safe exclusion path: the caller stripped a subset of patterns (e.g. alert
+  // indices) before passing overridePatterns. Instead of an allowlist — which would
+  // silently drop remote-cluster documents whose index names carry a cluster-alias
+  // prefix — emit negated filters for only the removed patterns.
+  if (overridePatterns != null && !signalIndexName) {
+    const removedPatterns = selectedPatterns.filter((p) => !overridePatterns.includes(p));
+    if (removedPatterns.length === 0) return [];
+    return getIndexFilters(removedPatterns).map((filter) => ({
+      ...filter,
+      meta: { ...filter.meta, negate: true },
+    }));
+  }
+
+  // Default: allowlist the full selected patterns.
+  return getIndexFilters(selectedPatterns);
+};
 
 export const getESQLGlobalFilters = (globalFilterQuery: ESBoolQuery | undefined) => [
   {

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/utils.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/utils.ts
@@ -216,6 +216,14 @@ export const ALERTS_INDEX_PATTERN = '.alerts-security.alerts';
 export const filterAlertsFromIndexPatterns = (patterns: string[]): string[] =>
   patterns.filter((p) => !p.startsWith(ALERTS_INDEX_PATTERN));
 
+/**
+ * Return only the Security Solution alerts-backing index patterns from
+ * `patterns`. Inverse of `filterAlertsFromIndexPatterns`. Useful as the
+ * drop-list input to `buildIndexFilters`'s `excludedPatterns`.
+ */
+export const getAlertsIndexPatterns = (patterns: string[]): string[] =>
+  patterns.filter((p) => p.startsWith(ALERTS_INDEX_PATTERN));
+
 export const getIndexFilters = (selectedPatterns: string[]) =>
   selectedPatterns.length >= 1
     ? [
@@ -241,46 +249,66 @@ export const getIndexFilters = (selectedPatterns: string[]) =>
     : [];
 
 /**
+ * Double each unprefixed pattern with a `*:`-prefixed variant so a single
+ * `_index` allowlist matches both local docs and any remote cluster's docs.
+ * In CCS / CPS, the coordinating cluster prefixes `_index` values with
+ * `<cluster>:`, so `_index: "logs-*"` only matches local docs while
+ * `_index: "*:logs-*"` only matches remote-prefixed docs. Combined under a
+ * `should + minimum_should_match: 1` clause the union covers both.
+ *
+ * Patterns that already contain a `:` (an explicit cluster prefix like
+ * `cluster-a:logs-*`) are left untouched: prepending `*:` would yield
+ * `*:cluster-a:logs-*`, which never matches a real `_index` value.
+ */
+export const expandIndexPatternsForCps = (patterns: string[]): string[] =>
+  patterns.flatMap((p) => (p.includes(':') ? [p] : [p, `*:${p}`]));
+
+/**
  * Compute the `_index` filters to inject into a Lens chart.
  *
- * When `overridePatterns` is provided (and `signalIndexName` is absent), the
- * caller has supplied a subset of `selectedPatterns` with some entries removed
- * (e.g. alert-backing indices stripped by `filterAlertsFromIndexPatterns`).
- * Rather than emitting an allowlist filter from `overridePatterns` — which
- * would block CPS remote-cluster documents whose index names carry a
- * cluster-alias prefix — we instead emit *negated* filters for the removed
- * patterns only. This lets all remote-event documents through while still
- * excluding local alert-backing index documents.
+ * - **Allowlist (always emitted):** a single `_index` filter built from the
+ *   CPS-expanded `selectedPatterns` (see `expandIndexPatternsForCps`). This
+ *   bounds the chart to exactly the user-selected scope, both for local and
+ *   for any remote cluster the patterns reach via CCS/CPS.
+ * - **Drop-list (optional, layered on top):** when `excludedPatterns` is
+ *   non-empty, an additional *negated* `_index` filter is emitted for the
+ *   CPS-expanded `excludedPatterns`. This serves as a defensive exclusion
+ *   (e.g. alert-backing indices) on top of the allowlist. An empty array is
+ *   equivalent to `undefined` and adds no drop-list filter.
+ * - **`signalIndexName` sentinel:** when set, the allowlist passes through
+ *   raw `selectedPatterns` (already replaced upstream with `[signalIndexName]`
+ *   by `useLensAttributes`) with NO CPS expansion, and any `excludedPatterns`
+ *   are ignored. This preserves the Alerts trend chart's intentional
+ *   local-only scope.
  */
 export const buildIndexFilters = ({
   hasAdHocDataViews,
   selectedPatterns,
-  overridePatterns,
+  excludedPatterns,
   signalIndexName,
 }: {
   hasAdHocDataViews: boolean;
   selectedPatterns: string[];
-  overridePatterns?: string[];
+  excludedPatterns?: string[];
   signalIndexName?: string | null;
 }): Filter[] => {
   // Ad-hoc data views embed their index scope inside the Lens attributes directly.
   if (hasAdHocDataViews) return [];
 
-  // CPS-safe exclusion path: the caller stripped a subset of patterns (e.g. alert
-  // indices) before passing overridePatterns. Instead of an allowlist — which would
-  // silently drop remote-cluster documents whose index names carry a cluster-alias
-  // prefix — emit negated filters for only the removed patterns.
-  if (overridePatterns != null && !signalIndexName) {
-    const removedPatterns = selectedPatterns.filter((p) => !overridePatterns.includes(p));
-    if (removedPatterns.length === 0) return [];
-    return getIndexFilters(removedPatterns).map((filter) => ({
+  const allowlistPatterns = signalIndexName
+    ? selectedPatterns
+    : expandIndexPatternsForCps(selectedPatterns);
+  const allowlist = getIndexFilters(allowlistPatterns);
+
+  if (!signalIndexName && excludedPatterns && excludedPatterns.length > 0) {
+    const dropList = getIndexFilters(expandIndexPatternsForCps(excludedPatterns)).map((filter) => ({
       ...filter,
       meta: { ...filter.meta, negate: true },
     }));
+    return [...allowlist, ...dropList];
   }
 
-  // Default: allowlist the full selected patterns.
-  return getIndexFilters(selectedPatterns);
+  return allowlist;
 };
 
 export const getESQLGlobalFilters = (globalFilterQuery: ESBoolQuery | undefined) => [

--- a/x-pack/solutions/security/plugins/security_solution/public/overview/components/event_counts/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/overview/components/event_counts/index.test.tsx
@@ -32,6 +32,11 @@ describe('EventCounts', () => {
   const from = '2020-01-20T20:49:57.080Z';
   const to = '2020-01-21T20:49:57.080Z';
 
+  beforeEach(() => {
+    OverviewHostMocked.mockClear();
+    OverviewNetworkMocked.mockClear();
+  });
+
   const testProps = {
     filters: [],
     from,
@@ -68,5 +73,50 @@ describe('EventCounts', () => {
     expect(OverviewNetworkMocked.mock.calls[0][0].filterQuery).toContain(
       '{"bool":{"must":[],"filter":[{"bool":{"should":[{"exists":{"field":"source.ip"}},{"exists":{"field":"destination.ip"}}],"minimum_should_match":1}}],"should":[],"must_not":[]}}'
     );
+  });
+
+  test('passes indexNames through to OverviewHost and OverviewNetwork unchanged', () => {
+    // EventCounts itself does not filter indexNames; callers (e.g. overview.tsx) are
+    // responsible for passing event-only patterns. This test verifies the prop flows through.
+    const eventOnlyIndexNames = ['logs-*', 'auditbeat-*'];
+
+    render(
+      <TestProviders>
+        <EventCounts {...testProps} indexNames={eventOnlyIndexNames} />
+      </TestProviders>
+    );
+
+    expect(OverviewHostMocked.mock.calls[0][0].indexNames).toEqual(eventOnlyIndexNames);
+    expect(OverviewNetworkMocked.mock.calls[0][0].indexNames).toEqual(eventOnlyIndexNames);
+  });
+
+  test('alert-backing indices are absent from indexNames when caller passes filtered patterns', () => {
+    // Simulate the filtering done by overview.tsx via filterAlertsFromIndexPatterns.
+    const filteredPatterns = ['logs-*', 'auditbeat-*'];
+
+    render(
+      <TestProviders>
+        <EventCounts {...testProps} indexNames={filteredPatterns} />
+      </TestProviders>
+    );
+
+    const hostIndexNames: string[] = OverviewHostMocked.mock.calls[0][0].indexNames;
+    expect(hostIndexNames.some((p) => p.startsWith('.alerts-security.alerts'))).toBe(false);
+
+    const networkIndexNames: string[] = OverviewNetworkMocked.mock.calls[0][0].indexNames;
+    expect(networkIndexNames.some((p) => p.startsWith('.alerts-security.alerts'))).toBe(false);
+  });
+
+  test('remote cluster–prefixed event patterns are preserved in indexNames (CPS)', () => {
+    const cpsPatterns = ['cluster-a:logs-*', 'cluster-a:auditbeat-*', 'logs-*'];
+
+    render(
+      <TestProviders>
+        <EventCounts {...testProps} indexNames={cpsPatterns} />
+      </TestProviders>
+    );
+
+    expect(OverviewHostMocked.mock.calls[0][0].indexNames).toEqual(cpsPatterns);
+    expect(OverviewNetworkMocked.mock.calls[0][0].indexNames).toEqual(cpsPatterns);
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/overview/components/events_by_dataset/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/overview/components/events_by_dataset/index.test.tsx
@@ -1,0 +1,103 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { render } from '@testing-library/react';
+import React from 'react';
+
+import { TestProviders } from '../../../common/mock';
+import { EventsByDataset } from '.';
+import { MatrixHistogram } from '../../../common/components/matrix_histogram';
+import { createStubDataView } from '@kbn/data-views-plugin/common/data_views/data_view.stub';
+
+jest.mock('../../../common/components/link_to');
+jest.mock('../../../common/components/matrix_histogram', () => ({
+  MatrixHistogram: jest.fn().mockReturnValue(null),
+}));
+
+const MatrixHistogramMocked = MatrixHistogram as jest.MockedFunction<typeof MatrixHistogram>;
+
+describe('EventsByDataset', () => {
+  const from = '2020-01-20T20:49:57.080Z';
+  const to = '2020-01-21T20:49:57.080Z';
+
+  const baseProps = {
+    deleteQuery: jest.fn(),
+    filters: [],
+    from,
+    to,
+    dataView: createStubDataView({ spec: {} }),
+    query: { query: '', language: 'kuery' as const },
+    queryType: 'overview' as const,
+  };
+
+  beforeEach(() => {
+    MatrixHistogramMocked.mockClear();
+  });
+
+  test('passes eventIndexPatterns to MatrixHistogram as overridePatterns', () => {
+    const eventIndexPatterns = ['logs-*', 'auditbeat-*'];
+
+    render(
+      <TestProviders>
+        <EventsByDataset {...baseProps} eventIndexPatterns={eventIndexPatterns} />
+      </TestProviders>
+    );
+
+    expect(MatrixHistogramMocked).toHaveBeenCalledWith(
+      expect.objectContaining({ overridePatterns: eventIndexPatterns }),
+      expect.anything()
+    );
+  });
+
+  test('does not include alert indices in overridePatterns when eventIndexPatterns is provided', () => {
+    // Simulate what overview.tsx does: pass only non-alert patterns
+    const eventIndexPatterns = ['logs-*', 'auditbeat-*'];
+    const allPatterns = [...eventIndexPatterns, '.alerts-security.alerts-default'];
+
+    // We do NOT pass allPatterns — that's the point. overview.tsx filters before passing.
+    render(
+      <TestProviders>
+        <EventsByDataset {...baseProps} eventIndexPatterns={eventIndexPatterns} />
+      </TestProviders>
+    );
+
+    const receivedPatterns = MatrixHistogramMocked.mock.calls[0][0].overridePatterns ?? [];
+
+    expect(receivedPatterns).not.toContain('.alerts-security.alerts-default');
+    expect(receivedPatterns).toEqual(eventIndexPatterns);
+    // Verify the filtered patterns don't accidentally include the full set
+    expect(receivedPatterns).not.toEqual(allPatterns);
+  });
+
+  test('remote cluster–prefixed event patterns are preserved in overridePatterns', () => {
+    // CPS: remote event index patterns have a cluster-alias prefix; they must
+    // not be stripped when building the events-only pattern list.
+    const eventIndexPatterns = ['cluster-a:logs-*', 'cluster-a:auditbeat-*', 'logs-*'];
+
+    render(
+      <TestProviders>
+        <EventsByDataset {...baseProps} eventIndexPatterns={eventIndexPatterns} />
+      </TestProviders>
+    );
+
+    const receivedPatterns = MatrixHistogramMocked.mock.calls[0][0].overridePatterns ?? [];
+
+    expect(receivedPatterns).toContain('cluster-a:logs-*');
+    expect(receivedPatterns).toContain('cluster-a:auditbeat-*');
+    expect(receivedPatterns).toContain('logs-*');
+  });
+
+  test('omits overridePatterns from MatrixHistogram when eventIndexPatterns is not provided', () => {
+    render(
+      <TestProviders>
+        <EventsByDataset {...baseProps} />
+      </TestProviders>
+    );
+
+    expect(MatrixHistogramMocked.mock.calls[0][0].overridePatterns).toBeUndefined();
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/overview/components/events_by_dataset/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/overview/components/events_by_dataset/index.test.tsx
@@ -38,66 +38,59 @@ describe('EventsByDataset', () => {
     MatrixHistogramMocked.mockClear();
   });
 
-  test('passes eventIndexPatterns to MatrixHistogram as overridePatterns', () => {
-    const eventIndexPatterns = ['logs-*', 'auditbeat-*'];
+  test('passes excludedPatterns through to MatrixHistogram', () => {
+    const excludedPatterns = ['.alerts-security.alerts-default'];
 
     render(
       <TestProviders>
-        <EventsByDataset {...baseProps} eventIndexPatterns={eventIndexPatterns} />
+        <EventsByDataset {...baseProps} excludedPatterns={excludedPatterns} />
       </TestProviders>
     );
 
     expect(MatrixHistogramMocked).toHaveBeenCalledWith(
-      expect.objectContaining({ overridePatterns: eventIndexPatterns }),
+      expect.objectContaining({ excludedPatterns }),
       expect.anything()
     );
   });
 
-  test('does not include alert indices in overridePatterns when eventIndexPatterns is provided', () => {
-    // Simulate what overview.tsx does: pass only non-alert patterns
-    const eventIndexPatterns = ['logs-*', 'auditbeat-*'];
-    const allPatterns = [...eventIndexPatterns, '.alerts-security.alerts-default'];
-
-    // We do NOT pass allPatterns — that's the point. overview.tsx filters before passing.
-    render(
-      <TestProviders>
-        <EventsByDataset {...baseProps} eventIndexPatterns={eventIndexPatterns} />
-      </TestProviders>
-    );
-
-    const receivedPatterns = MatrixHistogramMocked.mock.calls[0][0].overridePatterns ?? [];
-
-    expect(receivedPatterns).not.toContain('.alerts-security.alerts-default');
-    expect(receivedPatterns).toEqual(eventIndexPatterns);
-    // Verify the filtered patterns don't accidentally include the full set
-    expect(receivedPatterns).not.toEqual(allPatterns);
-  });
-
-  test('remote cluster–prefixed event patterns are preserved in overridePatterns', () => {
-    // CPS: remote event index patterns have a cluster-alias prefix; they must
-    // not be stripped when building the events-only pattern list.
-    const eventIndexPatterns = ['cluster-a:logs-*', 'cluster-a:auditbeat-*', 'logs-*'];
+  test('remote cluster–prefixed event patterns are NOT included in excludedPatterns', () => {
+    // CPS: caller (overview.tsx) computes the drop-list via getAlertsIndexPatterns,
+    // so only alert-backing indices end up in excludedPatterns. Remote cluster–
+    // prefixed event patterns must not be present, otherwise the chart's negated
+    // _index filter would drop those documents.
+    const excludedPatterns = ['.alerts-security.alerts-default'];
 
     render(
       <TestProviders>
-        <EventsByDataset {...baseProps} eventIndexPatterns={eventIndexPatterns} />
+        <EventsByDataset {...baseProps} excludedPatterns={excludedPatterns} />
       </TestProviders>
     );
 
-    const receivedPatterns = MatrixHistogramMocked.mock.calls[0][0].overridePatterns ?? [];
+    const received = MatrixHistogramMocked.mock.calls[0][0].excludedPatterns ?? [];
 
-    expect(receivedPatterns).toContain('cluster-a:logs-*');
-    expect(receivedPatterns).toContain('cluster-a:auditbeat-*');
-    expect(receivedPatterns).toContain('logs-*');
+    expect(received.some((p) => p.startsWith('cluster-a:'))).toBe(false);
+    expect(received).toEqual(excludedPatterns);
   });
 
-  test('omits overridePatterns from MatrixHistogram when eventIndexPatterns is not provided', () => {
+  test('passes an empty excludedPatterns through to MatrixHistogram', () => {
+    // Empty excludedPatterns is a no-op downstream (equivalent to undefined in
+    // buildIndexFilters), but the prop should still flow through unchanged.
+    render(
+      <TestProviders>
+        <EventsByDataset {...baseProps} excludedPatterns={[]} />
+      </TestProviders>
+    );
+
+    expect(MatrixHistogramMocked.mock.calls[0][0].excludedPatterns).toEqual([]);
+  });
+
+  test('omits excludedPatterns from MatrixHistogram when prop is not provided', () => {
     render(
       <TestProviders>
         <EventsByDataset {...baseProps} />
       </TestProviders>
     );
 
-    expect(MatrixHistogramMocked.mock.calls[0][0].overridePatterns).toBeUndefined();
+    expect(MatrixHistogramMocked.mock.calls[0][0].excludedPatterns).toBeUndefined();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/overview/components/events_by_dataset/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/overview/components/events_by_dataset/index.tsx
@@ -58,6 +58,13 @@ interface Props extends Pick<GlobalTimeArgs, 'from' | 'to' | 'deleteQuery'> {
   hideQueryToggle?: boolean;
   sourcererScopeId?: PageScope;
   applyGlobalQueriesAndFilters?: boolean;
+  /**
+   * When provided, the Lens chart's `_index` filter is built from these
+   * patterns instead of the scope's full `selectedPatterns`. Pass
+   * alert-index–filtered patterns here so the histogram counts only event
+   * documents and excludes `.alerts-security.alerts-*` documents.
+   */
+  eventIndexPatterns?: string[];
 }
 
 const getHistogramOption = (fieldName: string): MatrixHistogramOption => ({
@@ -89,6 +96,7 @@ const EventsByDatasetComponent: React.FC<Props> = ({
   to,
   hideQueryToggle = false,
   applyGlobalQueriesAndFilters,
+  eventIndexPatterns,
 }) => {
   const uniqueQueryId = useMemo(() => `${ID}-${queryType}`, [queryType]);
 
@@ -196,6 +204,7 @@ const EventsByDatasetComponent: React.FC<Props> = ({
       chartHeight={CHART_HEIGHT}
       hideQueryToggle={hideQueryToggle}
       applyGlobalQueriesAndFilters={applyGlobalQueriesAndFilters}
+      overridePatterns={eventIndexPatterns}
     />
   );
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/overview/components/events_by_dataset/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/overview/components/events_by_dataset/index.tsx
@@ -59,12 +59,12 @@ interface Props extends Pick<GlobalTimeArgs, 'from' | 'to' | 'deleteQuery'> {
   sourcererScopeId?: PageScope;
   applyGlobalQueriesAndFilters?: boolean;
   /**
-   * When provided, the Lens chart's `_index` filter is built from these
-   * patterns instead of the scope's full `selectedPatterns`. Pass
-   * alert-index–filtered patterns here so the histogram counts only event
-   * documents and excludes `.alerts-security.alerts-*` documents.
+   * Additional drop-list of index patterns layered on top of the histogram's
+   * allowlist as a negated `_index` filter (e.g. alert-backing indices).
+   * Forwarded to the Lens embeddable as `excludedPatterns` and CPS-expanded
+   * downstream so it covers both local and remote-prefixed `_index` values.
    */
-  eventIndexPatterns?: string[];
+  excludedPatterns?: string[];
 }
 
 const getHistogramOption = (fieldName: string): MatrixHistogramOption => ({
@@ -96,7 +96,7 @@ const EventsByDatasetComponent: React.FC<Props> = ({
   to,
   hideQueryToggle = false,
   applyGlobalQueriesAndFilters,
-  eventIndexPatterns,
+  excludedPatterns,
 }) => {
   const uniqueQueryId = useMemo(() => `${ID}-${queryType}`, [queryType]);
 
@@ -204,7 +204,7 @@ const EventsByDatasetComponent: React.FC<Props> = ({
       chartHeight={CHART_HEIGHT}
       hideQueryToggle={hideQueryToggle}
       applyGlobalQueriesAndFilters={applyGlobalQueriesAndFilters}
-      overridePatterns={eventIndexPatterns}
+      excludedPatterns={excludedPatterns}
     />
   );
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/overview/pages/overview.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/overview/pages/overview.tsx
@@ -43,6 +43,7 @@ import { useSelectedPatterns } from '../../data_view_manager/hooks/use_selected_
 import { useDataView } from '../../data_view_manager/hooks/use_data_view';
 import { useIsExperimentalFeatureEnabled } from '../../common/hooks/use_experimental_features';
 import { PageLoader } from '../../common/components/page_loader';
+import { filterAlertsFromIndexPatterns } from '../../common/components/visualization_actions/utils';
 
 const OverviewComponent = () => {
   const getGlobalFiltersQuerySelector = useMemo(
@@ -71,6 +72,15 @@ const OverviewComponent = () => {
   const selectedPatterns = newDataViewPickerEnabled
     ? experimentalSelectedPatterns
     : oldSelectedPatterns;
+
+  // Patterns from the data view with alert-backing indices stripped out.
+  // The Events histogram and Host/Network event count panels must count only
+  // non-alert documents; remote event indices are preserved unchanged so that
+  // Cross-Project Search continues to work through the data view.
+  const eventIndexPatterns = useMemo(
+    () => filterAlertsFromIndexPatterns(selectedPatterns),
+    [selectedPatterns]
+  );
 
   const endpointMetadataIndex = useMemo<string[]>(() => {
     return [ENDPOINT_METADATA_INDEX];
@@ -143,6 +153,7 @@ const OverviewComponent = () => {
                       from={from}
                       dataViewSpec={oldSourcererDataViewSpec}
                       dataView={experimentalDataView}
+                      eventIndexPatterns={eventIndexPatterns}
                       query={query}
                       queryType="overview"
                       to={to}
@@ -153,7 +164,7 @@ const OverviewComponent = () => {
                     <EventCounts
                       filters={filters}
                       from={from}
-                      indexNames={selectedPatterns}
+                      indexNames={eventIndexPatterns}
                       dataViewSpec={oldSourcererDataViewSpec}
                       dataView={experimentalDataView}
                       query={query}

--- a/x-pack/solutions/security/plugins/security_solution/public/overview/pages/overview.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/overview/pages/overview.tsx
@@ -43,7 +43,10 @@ import { useSelectedPatterns } from '../../data_view_manager/hooks/use_selected_
 import { useDataView } from '../../data_view_manager/hooks/use_data_view';
 import { useIsExperimentalFeatureEnabled } from '../../common/hooks/use_experimental_features';
 import { PageLoader } from '../../common/components/page_loader';
-import { filterAlertsFromIndexPatterns } from '../../common/components/visualization_actions/utils';
+import {
+  filterAlertsFromIndexPatterns,
+  getAlertsIndexPatterns,
+} from '../../common/components/visualization_actions/utils';
 
 const OverviewComponent = () => {
   const getGlobalFiltersQuerySelector = useMemo(
@@ -73,12 +76,20 @@ const OverviewComponent = () => {
     ? experimentalSelectedPatterns
     : oldSelectedPatterns;
 
-  // Patterns from the data view with alert-backing indices stripped out.
-  // The Events histogram and Host/Network event count panels must count only
-  // non-alert documents; remote event indices are preserved unchanged so that
+  // Keep-list: patterns from the data view with alert-backing indices stripped
+  // out. Used by `EventCounts` to scope the Host/Network REST queries to event
+  // documents only. Remote event indices are preserved unchanged so that
   // Cross-Project Search continues to work through the data view.
   const eventIndexPatterns = useMemo(
     () => filterAlertsFromIndexPatterns(selectedPatterns),
+    [selectedPatterns]
+  );
+
+  // Drop-list: only the alert-backing patterns from the data view. Passed to
+  // the Events histogram as `excludedPatterns` so the chart emits a negated
+  // `_index` filter (CPS-safe — does not allowlist the full scope).
+  const alertIndexPatterns = useMemo(
+    () => getAlertsIndexPatterns(selectedPatterns),
     [selectedPatterns]
   );
 
@@ -153,7 +164,7 @@ const OverviewComponent = () => {
                       from={from}
                       dataViewSpec={oldSourcererDataViewSpec}
                       dataView={experimentalDataView}
-                      eventIndexPatterns={eventIndexPatterns}
+                      excludedPatterns={alertIndexPatterns}
                       query={query}
                       queryType="overview"
                       to={to}


### PR DESCRIPTION
## Summary

Fixes the Overview page Events histogram and Host/Network event-count panels incorrectly including Security Solution alert documents in their counts.

The root cause is that the Security Solution sourcerer scope's `selectedPatterns` includes the `.alerts-security.alerts-*` backing index alongside event indices. The Overview page was passing the full pattern list to both the Lens Events histogram and the `EventCounts` component, so alert documents were being counted as events.

**Changes:**

- `filterAlertsFromIndexPatterns` (new, `utils.ts`) — strips `.alerts-security.alerts-*` patterns from a list of index patterns.
- `buildIndexFilters` (new, `utils.ts`) — computes the `_index` filters to inject into a Lens chart. When alert-only patterns have been removed, it emits **negated exclusion** filters for the removed patterns rather than an allowlist. This preserves Cross-Project Search (CPS) compatibility: remote-cluster documents carry a `cluster-alias:` prefix and would be silently dropped by a local allowlist.
- `overridePatterns` prop — threaded through `LensEmbeddable` → `MatrixHistogram` → `EventsByDataset` so callers can pass event-only patterns without mutating the shared sourcerer scope.
- `overview.tsx` — derives `eventIndexPatterns` via `filterAlertsFromIndexPatterns(selectedPatterns)` and passes it to both `EventsByDataset` and `EventCounts`.
- `plugin.tsx` — enables CPS globally for the Security Solution app (previously restricted to dashboard detail pages only).

### Checklist

- [ ] Any text added follows EUI's writing guidelines, uses sentence case text and includes i18n support
- [ ] Documentation was added for features that require explanation or tutorials
- [x] Unit or functional tests were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the docker list
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] Flaky Test Runner was used on any tests changed
- [ ] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the guidelines
- [ ] Review the backport guidelines and apply applicable `backport:*` labels.

### Identify risks

- **CPS negation logic** — the negated-exclusion approach is non-obvious. If `overridePatterns` is accidentally passed where `signalIndexName` is also set, the exclusion path is bypassed (by design) and the chart falls back to the full allowlist. This interaction is covered by a dedicated unit test.
- No data-loss or breaking API risk — all changes are additive props with `undefined` defaults; existing callers are unaffected.

<!--ONMERGE {"backportTargets":["8.19","9.3","9.4"]} ONMERGE-->