### PR TITLE
[9.4] [EA] Add Chat-First experience to Entity Analytics (#264985)

### DIFF
--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/api/anonymization_fields/use_fetch_anonymization_fields.test.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/api/anonymization_fields/use_fetch_anonymization_fields.test.tsx
@@ -12,7 +12,7 @@ import type { ReactNode } from 'react';
 import React from 'react';
 import { DEFAULTS, useFetchAnonymizationFields } from './use_fetch_anonymization_fields';
 import type { HttpSetup } from '@kbn/core-http-browser';
-import { useAssistantContext } from '../../../assistant_context';
+import { useMaybeAssistantContext } from '../../../assistant_context';
 import { API_VERSIONS, defaultAssistantFeatures } from '@kbn/elastic-assistant-common';
 
 const http = {
@@ -30,7 +30,7 @@ const createWrapper = () => {
 };
 
 describe('useFetchAnonymizationFields', () => {
-  (useAssistantContext as jest.Mock).mockReturnValue({
+  (useMaybeAssistantContext as jest.Mock).mockReturnValue({
     http,
     assistantAvailability: {
       isAssistantEnabled: true,

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/api/anonymization_fields/use_fetch_anonymization_fields.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/api/anonymization_fields/use_fetch_anonymization_fields.ts
@@ -12,7 +12,7 @@ import {
   ELASTIC_AI_ASSISTANT_ANONYMIZATION_FIELDS_URL_FIND,
   API_VERSIONS,
 } from '@kbn/elastic-assistant-common';
-import { useAssistantContext } from '../../../assistant_context';
+import { useMaybeAssistantContext } from '../../../assistant_context';
 
 export interface UseFetchAnonymizationFieldsParams {
   page?: number; // API uses 1-based index
@@ -85,13 +85,15 @@ export const useFetchAnonymizationFields = (
     filter,
   } = params || {};
 
-  const {
-    http,
-    assistantAvailability: { isAssistantEnabled },
-  } = useAssistantContext();
+  const assistantContext = useMaybeAssistantContext();
+  const http = assistantContext?.http;
+  const isAssistantEnabled = assistantContext?.assistantAvailability.isAssistantEnabled ?? false;
 
   const fetchPage = useCallback(
     async ({ pageParam = { page, perPage, sortField, sortOrder, filter, all } }) => {
+      if (!http) {
+        throw new Error('useFetchAnonymizationFields requires AssistantProvider when fetching');
+      }
       const {
         page: p = page,
         perPage: pp = perPage,
@@ -121,6 +123,8 @@ export const useFetchAnonymizationFields = (
     },
     [page, perPage, sortField, sortOrder, filter, all, http, signal]
   );
+
+  const queryEnabled = Boolean(http) && isAssistantEnabled;
 
   // Next page param: include current sorting in next request
   const getNextPageParam = useCallback(
@@ -155,7 +159,7 @@ export const useFetchAnonymizationFields = (
     FindAnonymizationFieldsResponse
   >(CACHING_KEYS, fetchPage, {
     getNextPageParam,
-    enabled: isAssistantEnabled,
+    enabled: queryEnabled,
     refetchOnWindowFocus: true,
   });
 

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant_context/index.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant_context/index.tsx
@@ -176,6 +176,14 @@ export const useAssistantContext = () => {
   return context;
 };
 
+/**
+ * Same context as {@link useAssistantContext}, but returns `undefined` when no provider is present.
+ * Prefer {@link useAssistantContext} for assistant UI; use this only when a hook must degrade
+ * gracefully outside `AssistantProvider` (e.g. embedded previews).
+ */
+export const useMaybeAssistantContext = (): UseAssistantContext | undefined =>
+  React.useContext(AssistantContext);
+
 export const useAssistantContextValue = (props: AssistantProviderProps): UseAssistantContext => {
   const {
     actionTypeRegistry,

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/index.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/index.ts
@@ -11,7 +11,11 @@
 // happens in the root of your app. Optionally provide a custom title for the assistant:
 
 /** provides context (from the app) to the assistant, and injects Kibana services, like `http` */
-export { AssistantProvider, useAssistantContext } from './impl/assistant_context';
+export {
+  AssistantProvider,
+  useAssistantContext,
+  useMaybeAssistantContext,
+} from './impl/assistant_context';
 
 // Step 2.1: Add the `AssistantOverlay` component to your app. This component displays the assistant
 // overlay in a modal, bound to a shortcut key:

--- a/x-pack/solutions/security/plugins/security_solution/common/agent_builder_navigation_gate.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/agent_builder_navigation_gate.test.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { agentBuilderDefaultAgentId } from '@kbn/agent-builder-common';
+
+import {
+  consumePreserveAgentBuilderSessionGate,
+  markPreserveAgentBuilderSessionDuringNextSecurityNavigation,
+  readLastAgentBuilderAgentIdForSecuritySession,
+} from './agent_builder_navigation_gate';
+
+describe('agent_builder_navigation_gate', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    localStorage.clear();
+  });
+
+  it('consume returns false when not marked', () => {
+    expect(consumePreserveAgentBuilderSessionGate()).toBe(false);
+    expect(consumePreserveAgentBuilderSessionGate()).toBe(false);
+  });
+
+  it('consume returns true once after mark', () => {
+    markPreserveAgentBuilderSessionDuringNextSecurityNavigation();
+    expect(consumePreserveAgentBuilderSessionGate()).toBe(true);
+    expect(consumePreserveAgentBuilderSessionGate()).toBe(false);
+  });
+
+  it('readLastAgentBuilderAgentIdForSecuritySession falls back to default', () => {
+    expect(readLastAgentBuilderAgentIdForSecuritySession()).toBe(agentBuilderDefaultAgentId);
+  });
+
+  it('readLastAgentBuilderAgentIdForSecuritySession reads raw string from localStorage', () => {
+    localStorage.setItem('agentBuilder.agentId', 'my-agent');
+    expect(readLastAgentBuilderAgentIdForSecuritySession()).toBe('my-agent');
+  });
+
+  it('readLastAgentBuilderAgentIdForSecuritySession parses JSON-encoded string', () => {
+    localStorage.setItem('agentBuilder.agentId', JSON.stringify('json-agent'));
+    expect(readLastAgentBuilderAgentIdForSecuritySession()).toBe('json-agent');
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/common/agent_builder_navigation_gate.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/agent_builder_navigation_gate.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { agentBuilderDefaultAgentId } from '@kbn/agent-builder-common';
+
+/** Same as agent_builder `storageKeys.agentId`. */
+const AGENT_BUILDER_LAST_AGENT_ID_STORAGE_KEY = 'agentBuilder.agentId';
+
+/**
+ * Session flag: the next Security app effect teardown is from an in-app navigation that must not
+ * clear Agent Builder session state (e.g. "Open entity in Security" from an attachment).
+ */
+const IN_APP_NAV_PRESERVE_AGENT_BUILDER_SESSION_KEY =
+  'securitySolution.preserveAgentBuilderSessionDuringInAppNav';
+
+export const readLastAgentBuilderAgentIdForSecuritySession = (): string => {
+  if (typeof window === 'undefined' || window.localStorage == null) {
+    return agentBuilderDefaultAgentId;
+  }
+  const stored = window.localStorage.getItem(AGENT_BUILDER_LAST_AGENT_ID_STORAGE_KEY);
+  if (stored == null || stored === '') {
+    return agentBuilderDefaultAgentId;
+  }
+  try {
+    const parsed = JSON.parse(stored);
+    return typeof parsed === 'string' ? parsed : stored;
+  } catch {
+    return stored;
+  }
+};
+
+export const markPreserveAgentBuilderSessionDuringNextSecurityNavigation = (): void => {
+  try {
+    window.sessionStorage?.setItem(IN_APP_NAV_PRESERVE_AGENT_BUILDER_SESSION_KEY, '1');
+  } catch {
+    // private mode / quota
+  }
+};
+
+/**
+ * Returns true once if a preserve gate was set (and clears it). Idempotent per consume call.
+ */
+export const consumePreserveAgentBuilderSessionGate = (): boolean => {
+  try {
+    if (window.sessionStorage?.getItem(IN_APP_NAV_PRESERVE_AGENT_BUILDER_SESSION_KEY) === '1') {
+      window.sessionStorage.removeItem(IN_APP_NAV_PRESERVE_AGENT_BUILDER_SESSION_KEY);
+      return true;
+    }
+  } catch {
+    // ignore
+  }
+  return false;
+};

--- a/x-pack/solutions/security/plugins/security_solution/common/constants.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/constants.ts
@@ -718,6 +718,7 @@ export const ESSENTIAL_ALERT_FIELDS: string[] = [
 export enum SecurityAgentBuilderAttachments {
   alert = 'security.alert',
   entity = 'security.entity',
+  entityAnalyticsDashboard = 'security.entity_analytics_dashboard',
   rule = 'security.rule',
 }
 

--- a/x-pack/solutions/security/plugins/security_solution/moon.yml
+++ b/x-pack/solutions/security/plugins/security_solution/moon.yml
@@ -290,6 +290,8 @@ dependsOn:
   - '@kbn/search-inference-endpoints'
   - '@kbn/shared-ux-column-presets'
   - '@kbn/core-overlays-browser'
+  - '@kbn/workflows-management-plugin'
+  - '@kbn/core-application-browser-mocks'
 tags:
   - plugin
   - prod

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_analytics_dashboard_attachment.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_analytics_dashboard_attachment.test.tsx
@@ -1,0 +1,250 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { act, render, screen } from '@testing-library/react';
+import { I18nProvider } from '@kbn/i18n-react';
+import { applicationServiceMock } from '@kbn/core-application-browser-mocks';
+import type { ISessionService } from '@kbn/data-plugin/public';
+import type { EntityAnalyticsDashboardAttachment } from './entity_analytics_dashboard_attachment';
+import { createEntityAnalyticsDashboardAttachmentDefinition } from './entity_analytics_dashboard_attachment';
+import { navigateToEntityAnalyticsHomePageInApp } from './entity_explore_navigation';
+
+interface ResizeDimensions {
+  width: number;
+  height: number;
+}
+
+const RESIZE_CALLBACK_KEY = '__eaDashboardOnResize';
+
+jest.mock('@elastic/eui', () => {
+  const React_ = jest.requireActual('react');
+  const actual = jest.requireActual('@elastic/eui');
+
+  const EuiResizeObserver = ({
+    onResize,
+    children,
+  }: {
+    onResize: (d: ResizeDimensions) => void;
+    children: (ref: (el: HTMLElement | null) => void) => React.ReactElement;
+  }) => {
+    (global as unknown as Record<string, unknown>)[RESIZE_CALLBACK_KEY] = onResize;
+    return children(() => {});
+  };
+
+  const EuiFlexGroup = React_.forwardRef(
+    (
+      {
+        direction = 'row',
+        alignItems,
+        gutterSize,
+        responsive,
+        justifyContent,
+        wrap,
+        component: _component,
+        children,
+        ...rest
+      }: Record<string, unknown> & { children?: React.ReactNode },
+      ref: React.Ref<HTMLDivElement>
+    ) =>
+      React_.createElement(
+        'div',
+        {
+          ref,
+          'data-direction': direction,
+          'data-align-items': alignItems ?? '',
+          ...rest,
+        },
+        children
+      )
+  );
+
+  const EuiFlexItem = ({
+    grow,
+    component: _component,
+    children,
+    ...rest
+  }: Record<string, unknown> & { children?: React.ReactNode }) =>
+    React_.createElement('div', { 'data-grow': String(grow), ...rest }, children);
+
+  return {
+    ...actual,
+    EuiResizeObserver,
+    EuiFlexGroup,
+    EuiFlexItem,
+  };
+});
+
+jest.mock('../../entity_analytics/components/home/risk_level_breakdown_table', () => ({
+  RiskLevelBreakdownTable: () => <div data-test-subj="riskLevelBreakdownTableMock" />,
+}));
+
+jest.mock('../../entity_analytics/components/risk_score_donut_chart', () => ({
+  RiskScoreDonutChart: () => <div data-test-subj="riskScoreDonutChartMock" />,
+}));
+
+jest.mock('./entity_list_table', () => ({
+  EntityListTable: ({ closeCanvas }: { closeCanvas?: () => void }) => (
+    <div
+      data-test-subj="entityListTableMock"
+      data-has-close-canvas={closeCanvas ? 'true' : 'false'}
+    />
+  ),
+}));
+
+jest.mock('./entity_explore_navigation', () => ({
+  navigateToEntityAnalyticsHomePageInApp: jest.fn(),
+}));
+
+const triggerResize = (dimensions: ResizeDimensions) => {
+  const onResize = (global as unknown as Record<string, unknown>)[RESIZE_CALLBACK_KEY] as
+    | ((d: ResizeDimensions) => void)
+    | undefined;
+  if (!onResize) {
+    throw new Error('EuiResizeObserver onResize was never registered');
+  }
+  act(() => {
+    onResize(dimensions);
+  });
+};
+
+const makeAttachment = (): EntityAnalyticsDashboardAttachment =>
+  ({
+    id: 'ea-dashboard-1',
+    type: 'security.entity_analytics_dashboard',
+    data: {
+      attachmentLabel: 'Entity Analytics Dashboard',
+      summary: 'Top 5 riskiest users.',
+      entities: [
+        { entity_type: 'user', identifier: 'alice' },
+        { entity_type: 'host', identifier: 'beta' },
+      ],
+    },
+  } as unknown as EntityAnalyticsDashboardAttachment);
+
+const renderCanvas = (
+  overrides: { searchSession?: ISessionService; closeCanvas?: () => void } = {}
+) => {
+  const application = applicationServiceMock.createStartContract();
+  const definition = createEntityAnalyticsDashboardAttachmentDefinition({
+    application,
+    searchSession: overrides.searchSession,
+  });
+  return render(
+    <I18nProvider>
+      {definition.renderCanvasContent!(
+        {
+          attachment: makeAttachment(),
+        } as unknown as Parameters<NonNullable<typeof definition.renderCanvasContent>>[0],
+        {
+          closeCanvas: overrides.closeCanvas ?? jest.fn(),
+        } as unknown as Parameters<NonNullable<typeof definition.renderCanvasContent>>[1]
+      )}
+    </I18nProvider>
+  );
+};
+
+describe('EntityAnalyticsDashboardCanvasContent', () => {
+  afterEach(() => {
+    delete (global as unknown as Record<string, unknown>)[RESIZE_CALLBACK_KEY];
+    (navigateToEntityAnalyticsHomePageInApp as jest.Mock).mockClear();
+  });
+
+  it('returns an "Open in Security" action from getActionButtons in canvas mode and forwards searchSession', () => {
+    const searchSession = { clear: jest.fn() } as unknown as ISessionService;
+    const application = applicationServiceMock.createStartContract();
+    const definition = createEntityAnalyticsDashboardAttachmentDefinition({
+      application,
+      searchSession,
+    });
+
+    const buttons = definition.getActionButtons!({
+      attachment: makeAttachment(),
+      isSidebar: false,
+      isCanvas: true,
+      updateOrigin: jest.fn(),
+    });
+
+    expect(buttons).toHaveLength(1);
+    expect(buttons[0].icon).toBe('popout');
+    expect(buttons[0].label).toMatch(/open entity analytics in security/i);
+
+    buttons[0].handler();
+
+    expect(navigateToEntityAnalyticsHomePageInApp).toHaveBeenCalledTimes(1);
+    expect(navigateToEntityAnalyticsHomePageInApp).toHaveBeenCalledWith(
+      expect.objectContaining({ searchSession })
+    );
+  });
+
+  it('returns a Preview action from getActionButtons when not in canvas mode', () => {
+    const application = applicationServiceMock.createStartContract();
+    const openCanvas = jest.fn();
+    const definition = createEntityAnalyticsDashboardAttachmentDefinition({ application });
+
+    const buttons = definition.getActionButtons!({
+      attachment: makeAttachment(),
+      isSidebar: false,
+      isCanvas: false,
+      openCanvas,
+      updateOrigin: jest.fn(),
+    });
+
+    expect(buttons).toHaveLength(1);
+    expect(buttons[0].icon).toBe('eye');
+    expect(buttons[0].label).toMatch(/preview/i);
+    buttons[0].handler();
+    expect(openCanvas).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the risk breakdown table and the donut chart side-by-side by default', () => {
+    renderCanvas();
+    const innerRow = screen.getByTestId('riskLevelPanelInnerRow');
+    expect(innerRow.getAttribute('data-direction')).toBe('row');
+    expect(innerRow.getAttribute('data-align-items')).toBe('center');
+    expect(screen.getByTestId('riskLevelBreakdownTableMock')).toBeInTheDocument();
+    expect(screen.getByTestId('riskScoreDonutChartMock')).toBeInTheDocument();
+  });
+
+  it('stacks the donut chart below the table when the container is narrower than the threshold', () => {
+    renderCanvas();
+    triggerResize({ width: 400, height: 200 });
+    const innerRow = screen.getByTestId('riskLevelPanelInnerRow');
+    expect(innerRow.getAttribute('data-direction')).toBe('column');
+    expect(innerRow.getAttribute('data-align-items')).toBe('stretch');
+  });
+
+  it('returns to the row layout when the container grows past the threshold', () => {
+    renderCanvas();
+    triggerResize({ width: 400, height: 200 });
+    triggerResize({ width: 800, height: 200 });
+    const innerRow = screen.getByTestId('riskLevelPanelInnerRow');
+    expect(innerRow.getAttribute('data-direction')).toBe('row');
+    expect(innerRow.getAttribute('data-align-items')).toBe('center');
+  });
+
+  it('treats exactly the threshold width as wide (row layout)', () => {
+    renderCanvas();
+    triggerResize({ width: 500, height: 200 });
+    const innerRow = screen.getByTestId('riskLevelPanelInnerRow');
+    expect(innerRow.getAttribute('data-direction')).toBe('row');
+  });
+
+  it('sets canvasWidth to 50vw so the dashboard uses the full canvas flyout width', () => {
+    const application = applicationServiceMock.createStartContract();
+    const definition = createEntityAnalyticsDashboardAttachmentDefinition({ application });
+    expect(definition.canvasWidth).toBe('50vw');
+  });
+
+  it('forwards closeCanvas from the canvas render callbacks into EntityListTable so per-row navigation can dismiss the canvas overlay', () => {
+    const closeCanvas = jest.fn();
+    renderCanvas({ closeCanvas });
+    expect(screen.getByTestId('entityListTableMock').getAttribute('data-has-close-canvas')).toBe(
+      'true'
+    );
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_analytics_dashboard_attachment.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_analytics_dashboard_attachment.tsx
@@ -1,0 +1,594 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useCallback, useMemo, useState } from 'react';
+import { css } from '@emotion/react';
+import {
+  EuiDescriptionList,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiPanel,
+  EuiResizeObserver,
+  EuiSpacer,
+  EuiStat,
+  EuiText,
+  EuiTitle,
+  useIsWithinBreakpoints,
+} from '@elastic/eui';
+import type { EuiResizeObserverProps } from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n-react';
+import { i18n } from '@kbn/i18n';
+import type {
+  AttachmentUIDefinition,
+  AttachmentRenderProps,
+  AttachmentServiceStartContract,
+} from '@kbn/agent-builder-browser/attachments';
+import { ActionButtonType } from '@kbn/agent-builder-browser/attachments';
+import type { Attachment } from '@kbn/agent-builder-common/attachments';
+import type { ApplicationStart } from '@kbn/core-application-browser';
+import type { AgentBuilderPluginStart } from '@kbn/agent-builder-plugin/public';
+import type { ISessionService } from '@kbn/data-plugin/public';
+import { APP_UI_ID, SecurityAgentBuilderAttachments } from '../../../common/constants';
+import { EMPTY_SEVERITY_COUNT, RiskSeverity } from '../../../common/search_strategy';
+import type { SeverityCount } from '../../entity_analytics/components/severity/types';
+import { RiskLevelBreakdownTable } from '../../entity_analytics/components/home/risk_level_breakdown_table';
+import { RiskScoreDonutChart } from '../../entity_analytics/components/risk_score_donut_chart';
+import { EntityListTable, type EntityListRow } from './entity_list_table';
+import {
+  navigateToEntityAnalyticsHomePageInApp,
+  type SecurityAgentBuilderChrome,
+} from './entity_explore_navigation';
+
+export type EntityAnalyticsDashboardAttachment = Attachment<
+  typeof SecurityAgentBuilderAttachments.entityAnalyticsDashboard,
+  {
+    attachmentLabel?: string;
+    summary?: string;
+    time_range_label?: string;
+    watchlist_id?: string;
+    watchlist_name?: string;
+    severity_count?: SeverityCount;
+    distribution_note?: string;
+    anomaly_highlights?: Array<{ title: string; body?: string }>;
+    entities: EntityListRow[];
+  }
+>;
+
+const rootCanvasStyles = css({
+  display: 'flex',
+  flexDirection: 'column',
+  height: '100%',
+  minHeight: 400,
+});
+
+/**
+ * Width (in px) below which the risk breakdown table and donut chart stack
+ * vertically instead of sitting side-by-side. Chosen to avoid a cramped row
+ * when the Canvas flyout / left column is narrow.
+ */
+const RISK_LEVEL_PANEL_STACK_WIDTH_THRESHOLD = 500;
+
+/**
+ * Preferred width for the Entity Analytics dashboard canvas. The layout has side-by-side
+ * risk breakdown + donut + anomaly highlights panels, plus an entity list below, so it
+ * benefits from as much width as the canvas flyout will allow. This matches the default
+ * max (`50vw`) but is set explicitly to signal intent and survive any future change to
+ * `DEFAULT_CANVAS_WIDTH`.
+ */
+const EA_DASHBOARD_CANVAS_WIDTH = '50vw';
+
+const mergeSeverityCount = (partial?: SeverityCount): SeverityCount => ({
+  ...EMPTY_SEVERITY_COUNT,
+  ...partial,
+});
+
+const parseRiskLevelString = (raw?: string): RiskSeverity => {
+  if (!raw) {
+    return RiskSeverity.Unknown;
+  }
+  const normalized = raw.charAt(0).toUpperCase() + raw.slice(1).toLowerCase();
+  const allowed = Object.values(RiskSeverity) as string[];
+  if (allowed.includes(normalized)) {
+    return normalized as RiskSeverity;
+  }
+  return RiskSeverity.Unknown;
+};
+
+const inferSeverityCountFromEntities = (entities: EntityListRow[]): SeverityCount => {
+  const next: SeverityCount = { ...EMPTY_SEVERITY_COUNT };
+  for (const row of entities) {
+    const level = parseRiskLevelString(row.risk_level);
+    next[level] += 1;
+  }
+  return next;
+};
+
+const severityTotal = (c: SeverityCount): number =>
+  c[RiskSeverity.Critical] +
+  c[RiskSeverity.High] +
+  c[RiskSeverity.Moderate] +
+  c[RiskSeverity.Low] +
+  c[RiskSeverity.Unknown];
+
+const EntityAnalyticsDashboardInlineContent: React.FC<
+  AttachmentRenderProps<EntityAnalyticsDashboardAttachment>
+> = ({ attachment }) => {
+  const { entities, severity_count, attachmentLabel } = attachment.data;
+  const title =
+    attachmentLabel ??
+    i18n.translate('xpack.securitySolution.agentBuilder.entityAnalyticsDashboard.inlineTitle', {
+      defaultMessage: 'Entity Analytics dashboard',
+    });
+  const showRiskInSnapshot =
+    severity_count != null || severityTotal(inferSeverityCountFromEntities(entities ?? [])) > 0;
+
+  return (
+    <EuiPanel paddingSize="m" hasShadow={false} hasBorder={false}>
+      <EuiText size="xs">
+        <strong>{title}</strong>
+      </EuiText>
+      <EuiSpacer size="s" />
+      <EuiText size="xs" color="subdued">
+        {i18n.translate('xpack.securitySolution.agentBuilder.entityAnalyticsDashboard.inlineMeta', {
+          defaultMessage:
+            '{entityCount, plural, one {# entity in snapshot} other {# entities in snapshot}}{riskSuffix}',
+          values: {
+            entityCount: entities.length ?? 0,
+            riskSuffix: showRiskInSnapshot ? ' · Risk chart from snapshot' : '',
+          },
+        })}
+      </EuiText>
+    </EuiPanel>
+  );
+};
+
+const EntityAnalyticsDashboardCanvasContent: React.FC<
+  AttachmentRenderProps<EntityAnalyticsDashboardAttachment> & {
+    application: ApplicationStart;
+    searchSession?: ISessionService;
+    /**
+     * Dismisses the canvas flyout. Provided by the Agent Builder canvas render
+     * callbacks. Forwarded into `EntityListTable` so per-row navigation into
+     * the Entity Analytics home flyout can close the overlay first, otherwise
+     * the canvas renders on top of the just-opened entity flyout.
+     */
+    closeCanvas?: () => void;
+  }
+> = ({ attachment, application, searchSession, closeCanvas }) => {
+  const data = attachment.data;
+  const isXlScreen = useIsWithinBreakpoints(['l', 'xl']);
+  const [isRiskPanelNarrow, setIsRiskPanelNarrow] = useState(false);
+  const onRiskPanelResize = useCallback<EuiResizeObserverProps['onResize']>((dimensions) => {
+    if (!dimensions) return;
+    setIsRiskPanelNarrow(dimensions.width < RISK_LEVEL_PANEL_STACK_WIDTH_THRESHOLD);
+  }, []);
+  const hasExplicitSeverityCount = data.severity_count != null;
+  const inferredFromEntities = useMemo(
+    () => inferSeverityCountFromEntities(data.entities ?? []),
+    [data.entities]
+  );
+  const severityCountForChart = useMemo(() => {
+    if (hasExplicitSeverityCount) {
+      return mergeSeverityCount(data.severity_count);
+    }
+    return severityTotal(inferredFromEntities) > 0
+      ? inferredFromEntities
+      : mergeSeverityCount(undefined);
+  }, [data.severity_count, hasExplicitSeverityCount, inferredFromEntities]);
+
+  const entityTypeCounts = useMemo(() => {
+    const counts: Record<string, number> = {};
+    for (const row of data.entities ?? []) {
+      const t = row.entity_type;
+      counts[t] = (counts[t] ?? 0) + 1;
+    }
+    return counts;
+  }, [data.entities]);
+
+  const title =
+    data.attachmentLabel ??
+    i18n.translate('xpack.securitySolution.agentBuilder.entityAnalyticsDashboard.canvasTitle', {
+      defaultMessage: 'Entity Analytics',
+    });
+
+  return (
+    <div css={rootCanvasStyles}>
+      <EuiPanel paddingSize="m" hasShadow={false} hasBorder={false} css={{ overflow: 'auto' }}>
+        <EuiTitle size="m">
+          <h2>{title}</h2>
+        </EuiTitle>
+        {data.time_range_label ? (
+          <>
+            <EuiSpacer size="xs" />
+            <EuiText size="s" color="subdued">
+              {data.time_range_label}
+            </EuiText>
+          </>
+        ) : null}
+
+        {data.summary ? (
+          <>
+            <EuiSpacer size="m" />
+            <EuiText size="s">
+              <p>{data.summary}</p>
+            </EuiText>
+          </>
+        ) : null}
+
+        <EuiSpacer size="l" />
+
+        <EuiFlexGroup direction={isXlScreen ? 'row' : 'column'} gutterSize="l" responsive={false}>
+          <EuiFlexItem grow={1}>
+            <EuiPanel hasBorder paddingSize="m">
+              <EuiTitle size="s">
+                <h3>
+                  {data.watchlist_id ? (
+                    <FormattedMessage
+                      id="xpack.securitySolution.agentBuilder.entityAnalyticsDashboard.riskLevelsWatchlistTitle"
+                      defaultMessage="{watchlistName} risk levels"
+                      values={{
+                        watchlistName: data.watchlist_name ?? data.watchlist_id,
+                      }}
+                    />
+                  ) : (
+                    <FormattedMessage
+                      id="xpack.securitySolution.agentBuilder.entityAnalyticsDashboard.riskLevelsTitle"
+                      defaultMessage="Entity risk levels"
+                    />
+                  )}
+                </h3>
+              </EuiTitle>
+              <EuiSpacer size="m" />
+              <EuiResizeObserver onResize={onRiskPanelResize}>
+                {(resizeRef) => (
+                  <div ref={resizeRef}>
+                    <EuiFlexGroup
+                      alignItems={isRiskPanelNarrow ? 'stretch' : 'center'}
+                      direction={isRiskPanelNarrow ? 'column' : 'row'}
+                      gutterSize="l"
+                      responsive={false}
+                      data-test-subj="riskLevelPanelInnerRow"
+                    >
+                      <EuiFlexItem grow={4}>
+                        <RiskLevelBreakdownTable
+                          severityCount={severityCountForChart}
+                          loading={false}
+                        />
+                      </EuiFlexItem>
+                      <EuiFlexItem grow={1}>
+                        <RiskScoreDonutChart
+                          showLegend={false}
+                          severityCount={severityCountForChart}
+                        />
+                      </EuiFlexItem>
+                    </EuiFlexGroup>
+                  </div>
+                )}
+              </EuiResizeObserver>
+              {data.distribution_note ? (
+                <>
+                  <EuiSpacer size="s" />
+                  <EuiText size="xs" color="subdued">
+                    {data.distribution_note}
+                  </EuiText>
+                </>
+              ) : null}
+              {!hasExplicitSeverityCount && severityTotal(inferredFromEntities) > 0 ? (
+                <>
+                  <EuiSpacer size="s" />
+                  <EuiText size="xs" color="subdued">
+                    {i18n.translate(
+                      'xpack.securitySolution.agentBuilder.entityAnalyticsDashboard.riskInferredFromEntities',
+                      {
+                        defaultMessage:
+                          'Distribution is inferred from risk levels on the entities in this snapshot (not full-environment totals).',
+                      }
+                    )}
+                  </EuiText>
+                </>
+              ) : null}
+              {!hasExplicitSeverityCount && severityTotal(inferredFromEntities) === 0 ? (
+                <>
+                  <EuiSpacer size="s" />
+                  <EuiText size="xs" color="subdued">
+                    {i18n.translate(
+                      'xpack.securitySolution.agentBuilder.entityAnalyticsDashboard.riskNoDataHint',
+                      {
+                        defaultMessage:
+                          'For totals that match the Security home page, ask the assistant to include severity_count from investigation, or open Entity Analytics in Security for live KPIs.',
+                      }
+                    )}
+                  </EuiText>
+                </>
+              ) : null}
+            </EuiPanel>
+          </EuiFlexItem>
+
+          <EuiFlexItem grow={2}>
+            <EuiPanel hasBorder paddingSize="m">
+              <EuiTitle size="s">
+                <h3>
+                  <FormattedMessage
+                    id="xpack.securitySolution.agentBuilder.entityAnalyticsDashboard.highlightsTitle"
+                    defaultMessage="Recent anomalies and highlights"
+                  />
+                </h3>
+              </EuiTitle>
+              <EuiSpacer size="m" />
+              {data.anomaly_highlights?.length ? (
+                <EuiFlexGroup direction="column" gutterSize="m">
+                  {data.anomaly_highlights.map((item, idx) => (
+                    <EuiFlexItem grow={false} key={`${idx}-${item.title}`}>
+                      <EuiText size="s">
+                        <strong>{item.title}</strong>
+                      </EuiText>
+                      {item.body ? (
+                        <>
+                          <EuiSpacer size="xs" />
+                          <EuiText size="s" color="subdued">
+                            {item.body}
+                          </EuiText>
+                        </>
+                      ) : null}
+                    </EuiFlexItem>
+                  ))}
+                </EuiFlexGroup>
+              ) : (
+                <>
+                  <EuiText size="s" color="subdued">
+                    {i18n.translate(
+                      'xpack.securitySolution.agentBuilder.entityAnalyticsDashboard.noHighlightsIntro',
+                      {
+                        defaultMessage:
+                          'This snapshot has no authored highlights yet. The full Entity Analytics home also includes:',
+                      }
+                    )}
+                  </EuiText>
+                  <EuiSpacer size="m" />
+                  <EuiDescriptionList
+                    type="responsiveColumn"
+                    listItems={[
+                      {
+                        title: i18n.translate(
+                          'xpack.securitySolution.agentBuilder.entityAnalyticsDashboard.parityItemAnomalies',
+                          {
+                            defaultMessage: 'Anomaly detection',
+                          }
+                        ),
+                        description: i18n.translate(
+                          'xpack.securitySolution.agentBuilder.entityAnalyticsDashboard.parityItemAnomaliesDesc',
+                          {
+                            defaultMessage:
+                              'ML job timelines and recent anomalies scoped to your filters — live in Security only.',
+                          }
+                        ),
+                      },
+                      {
+                        title: i18n.translate(
+                          'xpack.securitySolution.agentBuilder.entityAnalyticsDashboard.parityItemRiskByType',
+                          {
+                            defaultMessage: 'Risk scores by entity type',
+                          }
+                        ),
+                        description: i18n.translate(
+                          'xpack.securitySolution.agentBuilder.entityAnalyticsDashboard.parityItemRiskByTypeDesc',
+                          {
+                            defaultMessage:
+                              'Separate host, user, and service risk panels with tables — live in Security only.',
+                          }
+                        ),
+                      },
+                      {
+                        title: i18n.translate(
+                          'xpack.securitySolution.agentBuilder.entityAnalyticsDashboard.parityItemLeads',
+                          {
+                            defaultMessage: 'Threat hunting leads',
+                          }
+                        ),
+                        description: i18n.translate(
+                          'xpack.securitySolution.agentBuilder.entityAnalyticsDashboard.parityItemLeadsDesc',
+                          {
+                            defaultMessage:
+                              'Optional lead generation strip when enabled — not part of this attachment.',
+                          }
+                        ),
+                      },
+                    ]}
+                  />
+                  <EuiSpacer size="m" />
+                  <EuiText size="xs" color="subdued">
+                    {i18n.translate(
+                      'xpack.securitySolution.agentBuilder.entityAnalyticsDashboard.noHighlightsAsk',
+                      {
+                        defaultMessage:
+                          'Ask the assistant to populate anomaly_highlights, or use Open Entity Analytics in Security above.',
+                      }
+                    )}
+                  </EuiText>
+                </>
+              )}
+            </EuiPanel>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+
+        <EuiSpacer size="l" />
+
+        {Object.keys(entityTypeCounts).length > 0 ? (
+          <>
+            <EuiPanel hasBorder paddingSize="m">
+              <EuiTitle size="s">
+                <h3>
+                  <FormattedMessage
+                    id="xpack.securitySolution.agentBuilder.entityAnalyticsDashboard.snapshotByTypeTitle"
+                    defaultMessage="Entities in this snapshot by type"
+                  />
+                </h3>
+              </EuiTitle>
+              <EuiSpacer size="m" />
+              <EuiFlexGroup wrap responsive={false} gutterSize="m">
+                {(['host', 'user', 'service', 'generic'] as const).map((type) => {
+                  const count = entityTypeCounts[type] ?? 0;
+                  if (count === 0) {
+                    return null;
+                  }
+                  return (
+                    <EuiFlexItem grow={false} key={type}>
+                      <EuiStat
+                        title={String(count)}
+                        description={`${type.charAt(0).toUpperCase()}${type.slice(1)}`}
+                        titleSize="m"
+                        textAlign="left"
+                      />
+                    </EuiFlexItem>
+                  );
+                })}
+              </EuiFlexGroup>
+            </EuiPanel>
+            <EuiSpacer size="l" />
+          </>
+        ) : null}
+
+        <EuiPanel hasBorder paddingSize="m">
+          <EuiTitle size="s">
+            <h3>
+              {data.watchlist_id ? (
+                <FormattedMessage
+                  id="xpack.securitySolution.agentBuilder.entityAnalyticsDashboard.entitiesWithWatchlist"
+                  defaultMessage="{watchlistName} entities"
+                  values={{
+                    watchlistName: data.watchlist_name ?? data.watchlist_id,
+                  }}
+                />
+              ) : (
+                <FormattedMessage
+                  id="xpack.securitySolution.agentBuilder.entityAnalyticsDashboard.entitiesTitle"
+                  defaultMessage="Entities"
+                />
+              )}
+            </h3>
+          </EuiTitle>
+          <EuiSpacer size="m" />
+          {data.entities.length ? (
+            <EntityListTable
+              entities={data.entities}
+              application={application}
+              searchSession={searchSession}
+              closeCanvas={closeCanvas}
+            />
+          ) : (
+            <EuiText size="s" color="subdued">
+              {i18n.translate(
+                'xpack.securitySolution.agentBuilder.entityAnalyticsDashboard.emptyEntities',
+                {
+                  defaultMessage: 'No entities were included in this snapshot.',
+                }
+              )}
+            </EuiText>
+          )}
+        </EuiPanel>
+      </EuiPanel>
+    </div>
+  );
+};
+
+export const registerEntityAnalyticsDashboardAttachment = ({
+  attachments,
+  application,
+  agentBuilder,
+  chrome,
+  searchSession,
+}: {
+  attachments: AttachmentServiceStartContract;
+  application: ApplicationStart;
+  agentBuilder?: AgentBuilderPluginStart;
+  chrome?: SecurityAgentBuilderChrome;
+  searchSession?: ISessionService;
+}): void => {
+  attachments.addAttachmentType(
+    SecurityAgentBuilderAttachments.entityAnalyticsDashboard,
+    createEntityAnalyticsDashboardAttachmentDefinition({
+      application,
+      agentBuilder,
+      chrome,
+      searchSession,
+    })
+  );
+};
+
+export const createEntityAnalyticsDashboardAttachmentDefinition = ({
+  application,
+  agentBuilder,
+  chrome,
+  searchSession,
+}: {
+  application: ApplicationStart;
+  agentBuilder?: AgentBuilderPluginStart;
+  chrome?: SecurityAgentBuilderChrome;
+  searchSession?: ISessionService;
+}): AttachmentUIDefinition<EntityAnalyticsDashboardAttachment> => ({
+  getLabel: (attachment) =>
+    attachment.data.attachmentLabel ??
+    i18n.translate('xpack.securitySolution.agentBuilder.entityAnalyticsDashboard.pillLabel', {
+      defaultMessage: 'Entity Analytics dashboard',
+    }),
+  getIcon: () => 'dashboardApp',
+  canvasWidth: EA_DASHBOARD_CANVAS_WIDTH,
+  renderInlineContent: (props) => <EntityAnalyticsDashboardInlineContent {...props} />,
+  renderCanvasContent: (props, { closeCanvas }) => (
+    <EntityAnalyticsDashboardCanvasContent
+      {...props}
+      application={application}
+      searchSession={searchSession}
+      closeCanvas={closeCanvas}
+    />
+  ),
+  getActionButtons: ({ attachment, openCanvas, isCanvas, openSidebarConversation }) => {
+    if (isCanvas) {
+      const data = attachment.data;
+      return [
+        {
+          label: i18n.translate(
+            'xpack.securitySolution.agentBuilder.entityAnalyticsDashboard.openInSecurity',
+            {
+              defaultMessage: 'Open Entity Analytics in Security',
+            }
+          ),
+          icon: 'popout',
+          type: ActionButtonType.SECONDARY,
+          handler: () => {
+            navigateToEntityAnalyticsHomePageInApp({
+              application,
+              appId: APP_UI_ID,
+              agentBuilder,
+              chrome,
+              openSidebarConversation,
+              watchlistId: data.watchlist_id,
+              watchlistName: data.watchlist_name,
+              searchSession,
+            });
+          },
+        },
+      ];
+    }
+    if (!openCanvas) {
+      return [];
+    }
+    return [
+      {
+        label: i18n.translate(
+          'xpack.securitySolution.agentBuilder.entityAnalyticsDashboard.preview',
+          {
+            defaultMessage: 'Preview',
+          }
+        ),
+        icon: 'eye',
+        type: ActionButtonType.SECONDARY,
+        handler: openCanvas,
+      },
+    ];
+  },
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/entity_attachment_canvas_content.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/entity_attachment_canvas_content.test.tsx
@@ -1,0 +1,127 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { I18nProvider } from '@kbn/i18n-react';
+import type { ApplicationStart } from '@kbn/core-application-browser';
+import type { ExperimentalFeatures } from '../../../../common/experimental_features';
+import type { EntityAttachment } from './types';
+import type { SecurityCanvasEmbeddedBundle } from '../../components/security_redux_embedded_provider';
+import { EntityAttachmentCanvasContent } from './entity_attachment_canvas_content';
+
+/**
+ * Canvas-content dispatcher tests.
+ *
+ * The component is a thin dispatcher that branches on the `normaliseEntityAttachment` output:
+ *   - invalid / multi-entity payload → empty `EuiPanel` (no card, no flyout)
+ *   - single non-flyout-capable entity (e.g. `generic`) → `EntityCard` fallback
+ *   - single host/user/service → `SecurityReduxEmbeddedProvider` wrapping
+ *     `EntityCardFlyoutOverviewCanvas`
+ *
+ * The heavy downstream components (`SecurityReduxEmbeddedProvider`,
+ * `EntityCardFlyoutOverviewCanvas`, `EntityCard`) each have their own test suites; mocking them
+ * here lets us focus on the dispatch-level branches without reproducing the Security Redux /
+ * sourcerer runtime.
+ */
+
+jest.mock('../../components/security_redux_embedded_provider', () => ({
+  SecurityReduxEmbeddedProvider: ({ children }: { children: React.ReactNode }) => (
+    <div data-test-subj="securityReduxEmbeddedProviderMock">{children}</div>
+  ),
+}));
+
+jest.mock('../../components/entity_card_flyout_overview_canvas', () => ({
+  EntityCardFlyoutOverviewCanvas: (props: Record<string, unknown>) => (
+    <div data-test-subj="entityCardFlyoutOverviewCanvasMock">
+      {JSON.stringify(props.identifier)}
+    </div>
+  ),
+}));
+
+jest.mock('./entity_card/entity_card', () => ({
+  EntityCard: (props: Record<string, unknown>) => (
+    <div data-test-subj="entityCardMock">{JSON.stringify(props.identifier)}</div>
+  ),
+}));
+
+const experimentalFeatures = {
+  entityAnalyticsWatchlistEnabled: false,
+  enableRiskScorePrivmonModifier: false,
+} as unknown as ExperimentalFeatures;
+
+const applicationStub = { navigateToApp: jest.fn() } as unknown as ApplicationStart;
+const resolveSecurityCanvasContext = jest.fn(
+  async () => ({} as unknown as SecurityCanvasEmbeddedBundle)
+);
+
+const attachmentOf = (data: unknown): EntityAttachment =>
+  ({ id: 'a', type: 'security.entity', data } as unknown as EntityAttachment);
+
+const renderCanvas = (data: unknown) =>
+  render(
+    <I18nProvider>
+      <EntityAttachmentCanvasContent
+        attachment={attachmentOf(data)}
+        isSidebar={false}
+        experimentalFeatures={experimentalFeatures}
+        application={applicationStub}
+        resolveSecurityCanvasContext={resolveSecurityCanvasContext}
+      />
+    </I18nProvider>
+  );
+
+describe('EntityAttachmentCanvasContent', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the flyout canvas inside SecurityReduxEmbeddedProvider for a single host entity', () => {
+    renderCanvas({ identifierType: 'host', identifier: 'host-1' });
+    expect(screen.getByTestId('securityReduxEmbeddedProviderMock')).toBeInTheDocument();
+    expect(screen.getByTestId('entityCardFlyoutOverviewCanvasMock')).toBeInTheDocument();
+    expect(screen.getByTestId('entityCardFlyoutOverviewCanvasMock').textContent).toContain(
+      'host-1'
+    );
+    expect(screen.queryByTestId('entityCardMock')).not.toBeInTheDocument();
+  });
+
+  it('renders the flyout canvas inside SecurityReduxEmbeddedProvider for single user / service entities', () => {
+    for (const identifierType of ['user', 'service'] as const) {
+      const { unmount } = renderCanvas({ identifierType, identifier: 'x' });
+      expect(screen.getByTestId('securityReduxEmbeddedProviderMock')).toBeInTheDocument();
+      expect(screen.getByTestId('entityCardFlyoutOverviewCanvasMock')).toBeInTheDocument();
+      unmount();
+    }
+  });
+
+  it('falls back to the EntityCard (no flyout provider) for a single generic entity', () => {
+    renderCanvas({ identifierType: 'generic', identifier: 'some-resource' });
+    expect(screen.getByTestId('entityCardMock')).toBeInTheDocument();
+    expect(screen.queryByTestId('securityReduxEmbeddedProviderMock')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('entityCardFlyoutOverviewCanvasMock')).not.toBeInTheDocument();
+  });
+
+  it('does not render a card or flyout for a multi-entity payload', () => {
+    renderCanvas({
+      entities: [
+        { identifierType: 'host', identifier: 'a' },
+        { identifierType: 'user', identifier: 'b' },
+      ],
+    });
+    expect(screen.queryByTestId('securityReduxEmbeddedProviderMock')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('entityCardFlyoutOverviewCanvasMock')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('entityCardMock')).not.toBeInTheDocument();
+  });
+
+  it('does not render a card or flyout for an invalid payload', () => {
+    renderCanvas({ foo: 'bar' });
+    expect(screen.queryByTestId('securityReduxEmbeddedProviderMock')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('entityCardFlyoutOverviewCanvasMock')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('entityCardMock')).not.toBeInTheDocument();
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/entity_attachment_canvas_content.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/entity_attachment_canvas_content.tsx
@@ -1,0 +1,116 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import type { AttachmentRenderProps } from '@kbn/agent-builder-browser/attachments';
+import type { ApplicationStart } from '@kbn/core-application-browser';
+import type { AgentBuilderPluginStart } from '@kbn/agent-builder-plugin/public';
+import type { ISessionService } from '@kbn/data-plugin/public';
+import { QueryClientProvider } from '@kbn/react-query';
+import { EuiPanel } from '@elastic/eui';
+import type { ExperimentalFeatures } from '../../../../common/experimental_features';
+import type { EntityAttachment } from './types';
+import { isFlyoutCapableIdentifierType } from './types';
+import { normaliseEntityAttachment } from './payload';
+import { entityAttachmentQueryClient } from './query_client';
+import { EntityCard } from './entity_card/entity_card';
+import {
+  SecurityReduxEmbeddedProvider,
+  type SecurityCanvasEmbeddedBundle,
+} from '../../components/security_redux_embedded_provider';
+import { EntityCardFlyoutOverviewCanvas } from '../../components/entity_card_flyout_overview_canvas';
+import type { SecurityAgentBuilderChrome } from '../entity_explore_navigation';
+
+export interface EntityAttachmentCanvasContentProps
+  extends AttachmentRenderProps<EntityAttachment> {
+  experimentalFeatures: ExperimentalFeatures;
+  application: ApplicationStart;
+  agentBuilder?: AgentBuilderPluginStart;
+  chrome?: SecurityAgentBuilderChrome;
+  resolveSecurityCanvasContext: () => Promise<SecurityCanvasEmbeddedBundle>;
+  searchSession?: ISessionService;
+}
+
+/**
+ * Canvas (Preview) view for single-entity `security.entity` attachments. Mounts the full
+ * Security expandable-flyout overview inside `SecurityReduxEmbeddedProvider` so the same hooks
+ * (`useGlobalTime`, `useRiskScore`, `useObservedHost`, sourcerer, …) that power the in-app flyout
+ * work on the Agent Builder canvas surface.
+ *
+ * Multi-entity attachments intentionally bypass the canvas and keep the inline `EntityTable` —
+ * per-row Explore links cover navigation without needing a separate canvas.
+ *
+ * This module is split into its own chunk (`security_entity_attachment_canvas`) via
+ * `React.lazy` in `entity_attachment_definition.tsx`, so the heavy flyout/Redux dependencies
+ * only load when the user clicks Preview.
+ */
+export const EntityAttachmentCanvasContent: React.FC<EntityAttachmentCanvasContentProps> = ({
+  attachment,
+  experimentalFeatures,
+  application,
+  agentBuilder,
+  chrome,
+  resolveSecurityCanvasContext,
+  openSidebarConversation,
+  searchSession,
+}) => {
+  const parsed = normaliseEntityAttachment(attachment);
+  const watchlistsEnabled = experimentalFeatures.entityAnalyticsWatchlistEnabled;
+  const privmonModifierEnabled = experimentalFeatures.enableRiskScorePrivmonModifier;
+
+  if (!parsed || !parsed.isSingle) {
+    return (
+      <EuiPanel hasShadow={false} hasBorder={false} paddingSize="m">
+        <QueryClientProvider client={entityAttachmentQueryClient}>
+          {parsed?.isSingle === false ? null : parsed ? (
+            <EntityCard
+              identifier={parsed.entities[0]}
+              riskStats={parsed.riskStats}
+              resolutionRiskStats={parsed.resolutionRiskStats}
+              watchlistsEnabled={watchlistsEnabled}
+              privmonModifierEnabled={privmonModifierEnabled}
+            />
+          ) : null}
+        </QueryClientProvider>
+      </EuiPanel>
+    );
+  }
+
+  const identifier = parsed.entities[0];
+  if (!isFlyoutCapableIdentifierType(identifier.identifierType)) {
+    return (
+      <EuiPanel hasShadow={false} hasBorder={false} paddingSize="m">
+        <QueryClientProvider client={entityAttachmentQueryClient}>
+          <EntityCard
+            identifier={identifier}
+            riskStats={parsed.riskStats}
+            resolutionRiskStats={parsed.resolutionRiskStats}
+            watchlistsEnabled={watchlistsEnabled}
+            privmonModifierEnabled={privmonModifierEnabled}
+          />
+        </QueryClientProvider>
+      </EuiPanel>
+    );
+  }
+
+  return (
+    <SecurityReduxEmbeddedProvider resolveCanvasContext={resolveSecurityCanvasContext}>
+      <EuiPanel hasShadow={false} hasBorder={false} paddingSize="m">
+        <QueryClientProvider client={entityAttachmentQueryClient}>
+          <EntityCardFlyoutOverviewCanvas
+            identifier={identifier}
+            application={application}
+            agentBuilder={agentBuilder}
+            chrome={chrome}
+            openSidebarConversation={openSidebarConversation}
+            searchSession={searchSession}
+          />
+        </QueryClientProvider>
+      </EuiPanel>
+    </SecurityReduxEmbeddedProvider>
+  );
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/entity_attachment_definition.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/entity_attachment_definition.test.tsx
@@ -1,0 +1,320 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ReactElement } from 'react';
+import type { ApplicationStart } from '@kbn/core-application-browser';
+import type { ISessionService } from '@kbn/data-plugin/public';
+import { ActionButtonType } from '@kbn/agent-builder-browser/attachments';
+import type { ExperimentalFeatures } from '../../../../common/experimental_features';
+import type { EntityAttachment } from './types';
+import { createEntityAttachmentDefinition } from './entity_attachment_definition';
+import {
+  navigateToEntityAnalyticsHomePageInApp,
+  navigateToEntityAnalyticsWithFlyoutInApp,
+} from '../entity_explore_navigation';
+
+jest.mock('../entity_explore_navigation', () => {
+  const actual = jest.requireActual('../entity_explore_navigation');
+  return {
+    ...actual,
+    navigateToEntityAnalyticsWithFlyoutInApp: jest.fn(),
+    navigateToEntityAnalyticsHomePageInApp: jest.fn(),
+  };
+});
+
+const experimentalFeatures = {
+  entityAnalyticsWatchlistEnabled: false,
+  enableRiskScorePrivmonModifier: false,
+} as unknown as ExperimentalFeatures;
+
+const application = { navigateToApp: jest.fn() } as unknown as ApplicationStart;
+const resolveSecurityCanvasContext = jest.fn();
+
+const buildDefinition = ({
+  withCanvas = true,
+  searchSession,
+}: { withCanvas?: boolean; searchSession?: ISessionService } = {}) =>
+  createEntityAttachmentDefinition({
+    experimentalFeatures,
+    application: withCanvas ? application : undefined,
+    resolveSecurityCanvasContext: withCanvas ? resolveSecurityCanvasContext : undefined,
+    searchSession,
+  });
+
+const attachmentOf = (data: unknown): EntityAttachment =>
+  ({ id: 'a', type: 'security.entity', data } as unknown as EntityAttachment);
+
+describe('createEntityAttachmentDefinition', () => {
+  describe('getActionButtons (Preview button)', () => {
+    it('returns a single Preview button for a single host entity when Canvas is available', () => {
+      const def = buildDefinition();
+      const openCanvas = jest.fn();
+      const buttons = def.getActionButtons!({
+        attachment: attachmentOf({ identifierType: 'host', identifier: 'alpha' }),
+        isSidebar: false,
+        isCanvas: false,
+        updateOrigin: jest.fn(),
+        openCanvas,
+      });
+
+      expect(buttons).toHaveLength(1);
+      expect(buttons[0].icon).toBe('eye');
+      expect(buttons[0].type).toBe(ActionButtonType.SECONDARY);
+
+      buttons[0].handler!();
+      expect(openCanvas).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns a Preview button for single user and service entities', () => {
+      const def = buildDefinition();
+      const openCanvas = jest.fn();
+
+      for (const identifierType of ['user', 'service'] as const) {
+        const buttons = def.getActionButtons!({
+          attachment: attachmentOf({ identifierType, identifier: 'x' }),
+          isSidebar: false,
+          isCanvas: false,
+          updateOrigin: jest.fn(),
+          openCanvas,
+        });
+        expect(buttons).toHaveLength(1);
+      }
+    });
+
+    it('returns no buttons for a single generic entity (no live flyout available)', () => {
+      const def = buildDefinition();
+      const buttons = def.getActionButtons!({
+        attachment: attachmentOf({ identifierType: 'generic', identifier: 'some-resource' }),
+        isSidebar: false,
+        isCanvas: false,
+        updateOrigin: jest.fn(),
+        openCanvas: jest.fn(),
+      });
+      expect(buttons).toEqual([]);
+    });
+
+    it('returns no buttons for a multi-entity attachment', () => {
+      const def = buildDefinition();
+      const buttons = def.getActionButtons!({
+        attachment: attachmentOf({
+          entities: [
+            { identifierType: 'host', identifier: 'a' },
+            { identifierType: 'user', identifier: 'b' },
+          ],
+        }),
+        isSidebar: false,
+        isCanvas: false,
+        updateOrigin: jest.fn(),
+        openCanvas: jest.fn(),
+      });
+      expect(buttons).toEqual([]);
+    });
+
+    it('returns an "Open in Entity Analytics" action when rendered in Canvas (replaces Preview re-entry)', () => {
+      (navigateToEntityAnalyticsWithFlyoutInApp as jest.Mock).mockClear();
+      (navigateToEntityAnalyticsHomePageInApp as jest.Mock).mockClear();
+      const searchSession = { clear: jest.fn() } as unknown as ISessionService;
+      const def = buildDefinition({ searchSession });
+      const buttons = def.getActionButtons!({
+        attachment: attachmentOf({
+          identifierType: 'host',
+          identifier: 'alpha',
+          entityStoreId: 'host:alpha@default',
+        }),
+        isSidebar: false,
+        isCanvas: true,
+        updateOrigin: jest.fn(),
+        openCanvas: jest.fn(),
+      });
+
+      expect(buttons).toHaveLength(1);
+      expect(buttons[0].label).toBe('Open in Entity Analytics');
+      expect(buttons[0].icon).toBe('popout');
+      expect(buttons[0].type).toBe(ActionButtonType.SECONDARY);
+
+      buttons[0].handler!();
+
+      expect(navigateToEntityAnalyticsWithFlyoutInApp).toHaveBeenCalledTimes(1);
+      expect(navigateToEntityAnalyticsHomePageInApp).not.toHaveBeenCalled();
+      expect(navigateToEntityAnalyticsWithFlyoutInApp).toHaveBeenCalledWith(
+        expect.objectContaining({
+          searchSession,
+          flyout: {
+            preview: [],
+            right: {
+              id: 'host-panel',
+              params: {
+                contextID: 'agent-builder-entity-card',
+                scopeId: 'agent-builder-entity-card',
+                hostName: 'alpha',
+                entityId: 'host:alpha@default',
+              },
+            },
+          },
+        })
+      );
+    });
+
+    it('falls back to the unfiltered Entity Analytics home when the flyout-capable identifier has no entityStoreId', () => {
+      (navigateToEntityAnalyticsWithFlyoutInApp as jest.Mock).mockClear();
+      (navigateToEntityAnalyticsHomePageInApp as jest.Mock).mockClear();
+      const searchSession = { clear: jest.fn() } as unknown as ISessionService;
+      const def = buildDefinition({ searchSession });
+      const buttons = def.getActionButtons!({
+        attachment: attachmentOf({ identifierType: 'host', identifier: 'alpha' }),
+        isSidebar: false,
+        isCanvas: true,
+        updateOrigin: jest.fn(),
+        openCanvas: jest.fn(),
+      });
+
+      expect(buttons).toHaveLength(1);
+      buttons[0].handler!();
+
+      expect(navigateToEntityAnalyticsHomePageInApp).toHaveBeenCalledTimes(1);
+      expect(navigateToEntityAnalyticsWithFlyoutInApp).not.toHaveBeenCalled();
+      expect(navigateToEntityAnalyticsHomePageInApp).toHaveBeenCalledWith(
+        expect.objectContaining({ searchSession })
+      );
+    });
+
+    it('returns no buttons in Canvas mode for multi-entity attachments', () => {
+      const def = buildDefinition();
+      const buttons = def.getActionButtons!({
+        attachment: attachmentOf({
+          entities: [
+            { identifierType: 'host', identifier: 'a' },
+            { identifierType: 'user', identifier: 'b' },
+          ],
+        }),
+        isSidebar: false,
+        isCanvas: true,
+        updateOrigin: jest.fn(),
+      });
+      expect(buttons).toEqual([]);
+    });
+
+    it('returns no buttons in Canvas mode for a generic single entity (not flyout-capable)', () => {
+      const def = buildDefinition();
+      const buttons = def.getActionButtons!({
+        attachment: attachmentOf({ identifierType: 'generic', identifier: 'some-resource' }),
+        isSidebar: false,
+        isCanvas: true,
+        updateOrigin: jest.fn(),
+      });
+      expect(buttons).toEqual([]);
+    });
+
+    it('returns no buttons when openCanvas is not provided', () => {
+      const def = buildDefinition();
+      const buttons = def.getActionButtons!({
+        attachment: attachmentOf({ identifierType: 'host', identifier: 'alpha' }),
+        isSidebar: false,
+        isCanvas: false,
+        updateOrigin: jest.fn(),
+        // openCanvas intentionally omitted
+      });
+      expect(buttons).toEqual([]);
+    });
+  });
+
+  describe('canvas availability', () => {
+    it('omits renderCanvasContent + getActionButtons when application or resolver is missing', () => {
+      const def = buildDefinition({ withCanvas: false });
+      expect(def.renderCanvasContent).toBeUndefined();
+      expect(def.getActionButtons).toBeUndefined();
+      expect(def.canvasWidth).toBeUndefined();
+    });
+
+    it('registers renderCanvasContent + getActionButtons when both application and resolver are provided', () => {
+      const def = buildDefinition();
+      expect(def.renderCanvasContent).toBeInstanceOf(Function);
+      expect(def.getActionButtons).toBeInstanceOf(Function);
+    });
+
+    it('sets a narrower canvasWidth so the entity flyout overview matches the in-app flyout rail', () => {
+      const def = buildDefinition();
+      expect(def.canvasWidth).toBe('640px');
+    });
+  });
+
+  describe('searchSession threading', () => {
+    const renderProps = {
+      attachment: attachmentOf({ identifierType: 'host', identifier: 'alpha' }),
+      isSidebar: false,
+      isCanvas: true,
+      updateOrigin: jest.fn(),
+    } as unknown as Parameters<
+      NonNullable<ReturnType<typeof buildDefinition>['renderInlineContent']>
+    >[0];
+    const renderCallbacks = {} as unknown as Parameters<
+      NonNullable<ReturnType<typeof buildDefinition>['renderCanvasContent']>
+    >[1];
+
+    it('forwards searchSession into the canvas content element', () => {
+      const searchSession = { clear: jest.fn() } as unknown as ISessionService;
+      const def = buildDefinition({ searchSession });
+
+      const suspenseElement = def.renderCanvasContent!(
+        renderProps,
+        renderCallbacks
+      ) as ReactElement<{
+        children: ReactElement<{ searchSession?: ISessionService }>;
+      }>;
+
+      expect(suspenseElement.props.children.props.searchSession).toBe(searchSession);
+    });
+
+    it('forwards searchSession into the inline content element', () => {
+      const searchSession = { clear: jest.fn() } as unknown as ISessionService;
+      const def = buildDefinition({ searchSession });
+
+      const suspenseElement = def.renderInlineContent!(renderProps) as ReactElement<{
+        children: ReactElement<{ searchSession?: ISessionService }>;
+      }>;
+
+      expect(suspenseElement.props.children.props.searchSession).toBe(searchSession);
+    });
+  });
+
+  describe('getLabel', () => {
+    it('returns the default label for a single-entity payload', () => {
+      const def = buildDefinition();
+      expect(def.getLabel(attachmentOf({ identifierType: 'host', identifier: 'alpha' }))).toBe(
+        'Risk Entity'
+      );
+    });
+
+    it('returns a pluralised label for a multi-entity payload', () => {
+      const def = buildDefinition();
+      expect(
+        def.getLabel(
+          attachmentOf({
+            entities: [
+              { identifierType: 'host', identifier: 'a' },
+              { identifierType: 'user', identifier: 'b' },
+              { identifierType: 'service', identifier: 'c' },
+            ],
+          })
+        )
+      ).toBe('3 Risk Entities');
+    });
+
+    it('prefers an explicit attachmentLabel when provided', () => {
+      const def = buildDefinition();
+      expect(
+        def.getLabel(
+          attachmentOf({
+            identifierType: 'host',
+            identifier: 'alpha',
+            attachmentLabel: 'Custom Label',
+          })
+        )
+      ).toBe('Custom Label');
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/entity_attachment_definition.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/entity_attachment_definition.tsx
@@ -1,0 +1,216 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { i18n } from '@kbn/i18n';
+import type {
+  AttachmentUIDefinition,
+  AttachmentRenderProps,
+} from '@kbn/agent-builder-browser/attachments';
+import { ActionButtonType } from '@kbn/agent-builder-browser/attachments';
+import type { ApplicationStart } from '@kbn/core-application-browser';
+import type { AgentBuilderPluginStart } from '@kbn/agent-builder-plugin/public';
+import type { ISessionService } from '@kbn/data-plugin/public';
+import { EuiFlexGroup, EuiFlexItem, EuiLoadingSpinner, EuiSkeletonText } from '@elastic/eui';
+import type { ExperimentalFeatures } from '../../../../common/experimental_features';
+import { APP_UI_ID } from '../../../../common/constants';
+import type { EntityAttachment } from './types';
+import { isFlyoutCapableIdentifierType } from './types';
+import { normaliseEntityAttachment } from './payload';
+import type { SecurityCanvasEmbeddedBundle } from '../../components/security_redux_embedded_provider';
+import {
+  buildEntityRightPanel,
+  navigateToEntityAnalyticsHomePageInApp,
+  navigateToEntityAnalyticsWithFlyoutInApp,
+  type SecurityAgentBuilderChrome,
+} from '../entity_explore_navigation';
+
+const DEFAULT_LABEL = i18n.translate(
+  'xpack.securitySolution.agentBuilder.attachments.entity.label',
+  { defaultMessage: 'Risk Entity' }
+);
+
+const DEFAULT_LABEL_PLURAL = (count: number) =>
+  i18n.translate('xpack.securitySolution.agentBuilder.attachments.entity.labelPlural', {
+    defaultMessage: '{count} Risk Entities',
+    values: { count },
+  });
+
+const PREVIEW_LABEL = i18n.translate(
+  'xpack.securitySolution.agentBuilder.attachments.entity.preview',
+  { defaultMessage: 'Preview' }
+);
+
+const OPEN_IN_ENTITY_ANALYTICS_LABEL = i18n.translate(
+  'xpack.securitySolution.agentBuilder.attachments.entity.openInEntityAnalytics',
+  { defaultMessage: 'Open in Entity Analytics' }
+);
+
+/**
+ * Preferred width for the entity flyout canvas. The rendered content is the Security
+ * expandable-flyout overview (`HostPanelContent` / `UserPanelContent` / `ServicePanelContent`)
+ * which is designed for a narrow rail; at the default `50vw` the entity summary grid and
+ * highlights look over-stretched on wide monitors. Narrowing the canvas keeps parity with
+ * the in-app flyout look.
+ */
+const ENTITY_CANVAS_WIDTH = '640px';
+
+/**
+ * Lazy-loaded inline renderer — pulls `EntityAttachmentInlineContent` (entity card / table)
+ * into its own chunk so the main `securitySolution` entry bundle doesn't pick up the entity
+ * analytics card + table dependencies until an attachment is actually rendered in the chat.
+ */
+const LazyEntityAttachmentInlineContent = React.lazy(() =>
+  import(
+    /* webpackChunkName: "security_entity_attachment_inline" */
+    './entity_attachment_inline_content'
+  ).then((m) => ({ default: m.EntityAttachmentInlineContent }))
+);
+
+/**
+ * Lazy-loaded canvas renderer — pulls `SecurityReduxEmbeddedProvider`,
+ * `EntityCardFlyoutOverviewCanvas`, and the full Security expandable-flyout overview into a
+ * separate chunk. This chunk only downloads when the user clicks the `Preview` action button,
+ * keeping the page-load bundle lean for users who never open an entity canvas.
+ */
+const LazyEntityAttachmentCanvasContent = React.lazy(() =>
+  import(
+    /* webpackChunkName: "security_entity_attachment_canvas" */
+    './entity_attachment_canvas_content'
+  ).then((m) => ({ default: m.EntityAttachmentCanvasContent }))
+);
+
+/**
+ * Builds the rich `AttachmentUIDefinition` for `security.entity` attachments.
+ *
+ * When `application` + `resolveSecurityCanvasContext` are provided, the definition also adds a
+ * Canvas (Preview) view for single host/user/service entities. Multi-entity attachments keep the
+ * inline-only rendering path; navigation is handled via per-row Explore icons in the table.
+ */
+export const createEntityAttachmentDefinition = ({
+  experimentalFeatures,
+  application,
+  agentBuilder,
+  chrome,
+  resolveSecurityCanvasContext,
+  searchSession,
+}: {
+  experimentalFeatures: ExperimentalFeatures;
+  application?: ApplicationStart;
+  agentBuilder?: AgentBuilderPluginStart;
+  chrome?: SecurityAgentBuilderChrome;
+  resolveSecurityCanvasContext?: () => Promise<SecurityCanvasEmbeddedBundle>;
+  searchSession?: ISessionService;
+}): AttachmentUIDefinition<EntityAttachment> => {
+  const baseDefinition: AttachmentUIDefinition<EntityAttachment> = {
+    getLabel: (attachment) => {
+      const customLabel = attachment?.data?.attachmentLabel;
+      if (customLabel) return customLabel;
+      const parsed = normaliseEntityAttachment(attachment);
+      if (!parsed) return DEFAULT_LABEL;
+      if (parsed.isSingle) return DEFAULT_LABEL;
+      return DEFAULT_LABEL_PLURAL(parsed.entities.length);
+    },
+    getIcon: () => 'user',
+    renderInlineContent: (props) => (
+      <React.Suspense fallback={<EuiSkeletonText lines={4} />}>
+        <LazyEntityAttachmentInlineContent
+          {...props}
+          experimentalFeatures={experimentalFeatures}
+          application={application}
+          searchSession={searchSession}
+        />
+      </React.Suspense>
+    ),
+  };
+
+  if (application == null || resolveSecurityCanvasContext == null) {
+    return baseDefinition;
+  }
+
+  const resolvedApplication = application;
+  const resolvedResolveCanvasContext = resolveSecurityCanvasContext;
+
+  return {
+    ...baseDefinition,
+    canvasWidth: ENTITY_CANVAS_WIDTH,
+    renderCanvasContent: (props: AttachmentRenderProps<EntityAttachment>) => (
+      <React.Suspense
+        fallback={
+          <EuiFlexGroup alignItems="center" justifyContent="center" css={{ minHeight: 200 }}>
+            <EuiFlexItem grow={false}>
+              <EuiLoadingSpinner size="l" />
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        }
+      >
+        <LazyEntityAttachmentCanvasContent
+          {...props}
+          experimentalFeatures={experimentalFeatures}
+          application={resolvedApplication}
+          agentBuilder={agentBuilder}
+          chrome={chrome}
+          resolveSecurityCanvasContext={resolvedResolveCanvasContext}
+          searchSession={searchSession}
+        />
+      </React.Suspense>
+    ),
+    getActionButtons: ({ attachment, isCanvas, openCanvas, openSidebarConversation }) => {
+      const parsed = normaliseEntityAttachment(attachment);
+      if (!parsed || !parsed.isSingle) {
+        return [];
+      }
+      const identifier = parsed.entities[0];
+      if (!isFlyoutCapableIdentifierType(identifier.identifierType)) {
+        return [];
+      }
+      if (isCanvas) {
+        return [
+          {
+            label: OPEN_IN_ENTITY_ANALYTICS_LABEL,
+            icon: 'popout',
+            type: ActionButtonType.SECONDARY,
+            handler: () => {
+              const rightPanel = buildEntityRightPanel(identifier);
+              if (rightPanel) {
+                navigateToEntityAnalyticsWithFlyoutInApp({
+                  application: resolvedApplication,
+                  appId: APP_UI_ID,
+                  flyout: { preview: [], right: rightPanel },
+                  agentBuilder,
+                  chrome,
+                  openSidebarConversation,
+                  searchSession,
+                });
+                return;
+              }
+              navigateToEntityAnalyticsHomePageInApp({
+                application: resolvedApplication,
+                appId: APP_UI_ID,
+                agentBuilder,
+                chrome,
+                openSidebarConversation,
+                searchSession,
+              });
+            },
+          },
+        ];
+      }
+      if (!openCanvas) {
+        return [];
+      }
+      return [
+        {
+          label: PREVIEW_LABEL,
+          icon: 'eye',
+          type: ActionButtonType.SECONDARY,
+          handler: openCanvas,
+        },
+      ];
+    },
+  };
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/entity_attachment_inline_content.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/entity_attachment_inline_content.test.tsx
@@ -1,0 +1,164 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { I18nProvider } from '@kbn/i18n-react';
+import type { ExperimentalFeatures } from '../../../../common/experimental_features';
+import type { EntityAttachment } from './types';
+import {
+  ENTITY_ATTACHMENT_ROOT_CLASS,
+  EntityAttachmentInlineContent,
+} from './entity_attachment_inline_content';
+
+jest.mock('./entity_card/entity_card', () => ({
+  EntityCard: (props: Record<string, unknown>) => (
+    <div
+      data-test-subj="entityCardMock"
+      data-watchlists-enabled={String(props.watchlistsEnabled)}
+      data-privmon-modifier-enabled={String(props.privmonModifierEnabled)}
+    >
+      {JSON.stringify(props.identifier)}
+    </div>
+  ),
+}));
+
+jest.mock('./entity_table/entity_table', () => ({
+  EntityTable: (props: Record<string, unknown>) => (
+    <div data-test-subj="entityTableMock">{`count:${(props.entities as unknown[]).length}`}</div>
+  ),
+}));
+
+const experimentalFeatures = {
+  entityAnalyticsWatchlistEnabled: true,
+  enableRiskScorePrivmonModifier: true,
+} as unknown as ExperimentalFeatures;
+
+const attachment = (data: unknown): EntityAttachment =>
+  ({
+    id: 'a',
+    type: 'security.entity',
+    data: data as EntityAttachment['data'],
+  } as EntityAttachment);
+
+const renderDispatcher = (data: unknown) =>
+  render(
+    <I18nProvider>
+      <EntityAttachmentInlineContent
+        attachment={attachment(data)}
+        isSidebar={false}
+        experimentalFeatures={experimentalFeatures}
+      />
+    </I18nProvider>
+  );
+
+describe('EntityAttachmentInlineContent', () => {
+  it('renders the card for a legacy single-identifier payload', () => {
+    renderDispatcher({ identifierType: 'host', identifier: 'alpha' });
+    expect(screen.getByTestId('entityCardMock')).toBeInTheDocument();
+    expect(screen.queryByTestId('entityTableMock')).not.toBeInTheDocument();
+    expect(screen.getByTestId('entityCardMock').textContent).toContain('alpha');
+  });
+
+  it('renders the card for a single-element entities list', () => {
+    renderDispatcher({ entities: [{ identifierType: 'user', identifier: 'bob' }] });
+    expect(screen.getByTestId('entityCardMock')).toBeInTheDocument();
+    expect(screen.queryByTestId('entityTableMock')).not.toBeInTheDocument();
+  });
+
+  it('renders the table for a multi-entity payload', () => {
+    renderDispatcher({
+      entities: [
+        { identifierType: 'host', identifier: 'alpha' },
+        { identifierType: 'user', identifier: 'bob' },
+      ],
+    });
+    expect(screen.getByTestId('entityTableMock')).toBeInTheDocument();
+    expect(screen.queryByTestId('entityCardMock')).not.toBeInTheDocument();
+    expect(screen.getByTestId('entityTableMock').textContent).toContain('count:2');
+  });
+
+  it('renders the graceful empty callout for unusable payloads', () => {
+    renderDispatcher({ foo: 'bar' });
+    expect(screen.getByTestId('entityAttachmentEmpty')).toBeInTheDocument();
+    expect(screen.queryByTestId('entityCardMock')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('entityTableMock')).not.toBeInTheDocument();
+  });
+
+  it('forwards watchlist and privmon modifier flags to the EntityCard', () => {
+    renderDispatcher({ identifierType: 'host', identifier: 'alpha' });
+    const card = screen.getByTestId('entityCardMock');
+    expect(card.getAttribute('data-watchlists-enabled')).toBe('true');
+    expect(card.getAttribute('data-privmon-modifier-enabled')).toBe('true');
+  });
+
+  it('forwards entityStoreId from a single-entity payload to the EntityCard identifier', () => {
+    renderDispatcher({
+      identifierType: 'user',
+      identifier: "Lena Medhurst@Lena's MacBook Pro",
+      entityStoreId: "user:Lena Medhurst@Lena's MacBook Pro@local",
+    });
+    const card = screen.getByTestId('entityCardMock');
+    const serialized = JSON.parse(card.textContent ?? '{}');
+    expect(serialized).toEqual({
+      identifierType: 'user',
+      identifier: "Lena Medhurst@Lena's MacBook Pro",
+      entityStoreId: "user:Lena Medhurst@Lena's MacBook Pro@local",
+    });
+  });
+
+  it('forwards entityStoreId from a single-element entities list to the EntityCard identifier', () => {
+    renderDispatcher({
+      entities: [
+        {
+          identifierType: 'user',
+          identifier: 'bob',
+          entityStoreId: 'user:bob@workstation@local',
+        },
+      ],
+    });
+    const card = screen.getByTestId('entityCardMock');
+    const serialized = JSON.parse(card.textContent ?? '{}');
+    expect(serialized.entityStoreId).toBe('user:bob@workstation@local');
+  });
+
+  describe('outer-panel spacing workaround', () => {
+    it('wraps valid payloads in a div with the ENTITY_ATTACHMENT_ROOT_CLASS marker', () => {
+      const { container } = renderDispatcher({ identifierType: 'host', identifier: 'alpha' });
+      const marker = container.querySelector(`.${ENTITY_ATTACHMENT_ROOT_CLASS}`);
+      expect(marker).not.toBeNull();
+      expect(marker).toContainElement(screen.getByTestId('entityCardMock'));
+    });
+
+    it('wraps the empty callout in a div with the ENTITY_ATTACHMENT_ROOT_CLASS marker', () => {
+      const { container } = renderDispatcher({ foo: 'bar' });
+      const marker = container.querySelector(`.${ENTITY_ATTACHMENT_ROOT_CLASS}`);
+      expect(marker).not.toBeNull();
+      expect(marker).toContainElement(screen.getByTestId('entityAttachmentEmpty'));
+    });
+
+    it('mounts a global style that scopes the margin to .euiSplitPanel ancestors of the marker', () => {
+      renderDispatcher({ identifierType: 'host', identifier: 'alpha' });
+      // Emotion's <Global> injects rules into `document.styleSheets` via
+      // `CSSStyleSheet.insertRule` in jsdom, so the <style> tag's textContent
+      // is empty. Read the serialized rules from every stylesheet instead.
+      const cssText = Array.from(document.styleSheets)
+        .flatMap((sheet) => {
+          try {
+            return Array.from(sheet.cssRules);
+          } catch {
+            return [];
+          }
+        })
+        .map((rule) => rule.cssText)
+        .join('\n');
+      expect(cssText).toContain(ENTITY_ATTACHMENT_ROOT_CLASS);
+      expect(cssText).toMatch(/\.euiSplitPanel:has\(/);
+      expect(cssText).toContain('margin-block-end');
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/entity_attachment_inline_content.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/entity_attachment_inline_content.tsx
@@ -1,0 +1,141 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useMemo } from 'react';
+import { Global, css } from '@emotion/react';
+import { EuiCallOut, EuiPanel, useEuiTheme } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { QueryClientProvider } from '@kbn/react-query';
+import type { AttachmentRenderProps } from '@kbn/agent-builder-browser/attachments';
+import type { ApplicationStart } from '@kbn/core-application-browser';
+import type { ISessionService } from '@kbn/data-plugin/public';
+import type { ExperimentalFeatures } from '../../../../common/experimental_features';
+import { normaliseEntityAttachment } from './payload';
+import type { EntityAttachment } from './types';
+import { EntityCard } from './entity_card/entity_card';
+import { EntityTable } from './entity_table/entity_table';
+import { entityAttachmentQueryClient } from './query_client';
+
+export interface EntityAttachmentInlineContentProps
+  extends AttachmentRenderProps<EntityAttachment> {
+  experimentalFeatures: ExperimentalFeatures;
+  /**
+   * Optional navigation context. When provided, `EntityTable` adds per-row Explore icons that
+   * deep-link into the Security Solution Hosts/Users/Services pages (mirrors the dashboard's
+   * `EntityListTable`). Without them the table renders without per-row navigation.
+   */
+  application?: ApplicationStart;
+  searchSession?: ISessionService;
+}
+
+/**
+ * Stable marker class on the inline-content root. Used by the global style
+ * below (via `:has()`) to target the ancestor `EuiSplitPanel.Outer` that the
+ * agent_builder renderer mounts around us.
+ */
+export const ENTITY_ATTACHMENT_ROOT_CLASS = 'securitySolutionEntityAttachment__root';
+
+/**
+ * The rich renderer mounts inside Agent Builder's provider tree, which does
+ * not carry Security Solution's QueryClientProvider. Wrapping the subtree in
+ * a module-scoped client here lets `useEntityFromStore` and siblings run
+ * correctly without reaching out of scope for providers.
+ */
+export const EntityAttachmentInlineContent: React.FC<EntityAttachmentInlineContentProps> = ({
+  attachment,
+  experimentalFeatures,
+  application,
+  searchSession,
+}) => {
+  const parsed = normaliseEntityAttachment(attachment);
+  const { euiTheme } = useEuiTheme();
+
+  // Workaround for a missing trailing spacer in agent_builder's
+  // createRenderAttachmentRenderer
+  // (x-pack/platform/plugins/shared/agent_builder/public/application/components/
+  // conversations/conversation_rounds/round_response/markdown_plugins/
+  // render_attachment_plugin.tsx): other markdown block renderers (codeBlock,
+  // table) append an <EuiSpacer />, but render_attachment does not, so the
+  // attachment's EuiSplitPanel.Outer ends flush against the following
+  // paragraph. We cannot add a spacer from inside the renderer because we
+  // render in EuiSplitPanel.Inner; the visible panel is the outer split-panel.
+  // Scope the rule tightly via `:has()` so it only targets panels that wrap
+  // our attachment. Remove once the upstream renderer adds a trailing spacer.
+  const outerPanelMarginStyles = useMemo(
+    () => css`
+      .euiSplitPanel:has(> .euiSplitPanel__inner > .${ENTITY_ATTACHMENT_ROOT_CLASS}) {
+        margin-block-end: ${euiTheme.size.m};
+      }
+    `,
+    [euiTheme.size.m]
+  );
+
+  if (!parsed) {
+    return (
+      <>
+        <Global styles={outerPanelMarginStyles} />
+        <div className={ENTITY_ATTACHMENT_ROOT_CLASS}>
+          <EuiPanel
+            hasShadow={false}
+            hasBorder={false}
+            paddingSize="m"
+            data-test-subj="entityAttachmentEmpty"
+          >
+            <EuiCallOut
+              announceOnMount
+              size="s"
+              color="warning"
+              iconType="warning"
+              title={i18n.translate(
+                'xpack.securitySolution.agentBuilder.entityAttachment.empty.title',
+                { defaultMessage: 'No entity information available' }
+              )}
+            >
+              {i18n.translate(
+                'xpack.securitySolution.agentBuilder.entityAttachment.empty.description',
+                {
+                  defaultMessage:
+                    'The entity attachment does not contain a valid identifier. The agent may still respond to the original question.',
+                }
+              )}
+            </EuiCallOut>
+          </EuiPanel>
+        </div>
+      </>
+    );
+  }
+
+  const watchlistsEnabled = experimentalFeatures.entityAnalyticsWatchlistEnabled;
+  const privmonModifierEnabled = experimentalFeatures.enableRiskScorePrivmonModifier;
+
+  return (
+    <>
+      <Global styles={outerPanelMarginStyles} />
+      <div className={ENTITY_ATTACHMENT_ROOT_CLASS}>
+        <QueryClientProvider client={entityAttachmentQueryClient}>
+          {parsed.isSingle ? (
+            <EntityCard
+              identifier={parsed.entities[0]}
+              riskStats={parsed.riskStats}
+              resolutionRiskStats={parsed.resolutionRiskStats}
+              watchlistsEnabled={watchlistsEnabled}
+              privmonModifierEnabled={privmonModifierEnabled}
+              application={application}
+              searchSession={searchSession}
+            />
+          ) : (
+            <EntityTable
+              entities={parsed.entities}
+              application={application}
+              searchSession={searchSession}
+            />
+          )}
+        </QueryClientProvider>
+      </div>
+    </>
+  );
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/entity_card/entity_card.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/entity_card/entity_card.test.tsx
@@ -1,0 +1,314 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { I18nProvider } from '@kbn/i18n-react';
+import { EntityType } from '../../../../../common/entity_analytics/types';
+import { useEntityForAttachment, type EntityForAttachment } from '../use_entity_for_attachment';
+import { EntityCard } from './entity_card';
+
+jest.mock('../use_entity_for_attachment', () => ({
+  useEntityForAttachment: jest.fn(),
+}));
+
+jest.mock('@kbn/kibana-react-plugin/public', () => ({
+  useKibana: () => ({
+    services: { application: { navigateToApp: jest.fn() } },
+  }),
+}));
+
+jest.mock('./resolution_mini', () => ({
+  ResolutionMini: (props: Record<string, unknown>) => (
+    <div
+      data-test-subj="resolutionMiniMock"
+      data-has-entity-id={String(Boolean(props.entityStoreEntityId))}
+    />
+  ),
+}));
+
+jest.mock('./entity_summary_grid', () => ({
+  EntitySummaryGridMini: (props: Record<string, unknown>) => (
+    <div
+      data-test-subj="entitySummaryGridMock"
+      data-entity-id={String(props.entityId ?? '')}
+      data-source={String(props.source ?? '')}
+      data-watchlists-enabled={String(props.watchlistsEnabled)}
+    />
+  ),
+}));
+
+jest.mock('./risk_summary_mini', () => ({
+  RiskSummaryMini: (props: Record<string, unknown>) => {
+    const riskStats = props.riskStats as Record<string, unknown> | undefined;
+    const resolutionRiskStats = props.resolutionRiskStats as Record<string, unknown> | undefined;
+    return (
+      <div
+        data-test-subj="riskSummaryMiniMock"
+        data-has-stats={String(Boolean(riskStats))}
+        data-primary-cat1-score={String(riskStats?.category_1_score ?? '')}
+        data-primary-cat1-count={String(riskStats?.category_1_count ?? '')}
+        data-has-resolution-stats={String(Boolean(resolutionRiskStats))}
+        data-resolution-score={String(props.resolutionRiskScore ?? '')}
+        data-resolution-level={String(props.resolutionRiskLevel ?? '')}
+        data-resolution-cat1-score={String(resolutionRiskStats?.category_1_score ?? '')}
+      />
+    );
+  },
+}));
+
+const mockedUseEntityForAttachment = useEntityForAttachment as jest.Mock;
+
+const baseEntity = (override: Partial<EntityForAttachment> = {}): EntityForAttachment => ({
+  entityType: EntityType.user,
+  displayName: 'bob',
+  entityId: 'entity-id-123',
+  isEntityInStore: true,
+  firstSeen: null,
+  lastSeen: '2024-01-01T00:00:00Z',
+  timestamp: '2024-01-01T00:00:00Z',
+  riskScore: 88,
+  riskLevel: 'High',
+  riskStats: {
+    '@timestamp': '2024-01-01T00:00:00Z',
+    id_field: 'user.name',
+    id_value: 'bob',
+    calculated_level: 'High',
+    calculated_score: 50,
+    calculated_score_norm: 88,
+    category_1_score: 40,
+    category_1_count: 3,
+    category_2_score: 10,
+    inputs: [],
+    notes: [],
+    rule_risks: [],
+    multipliers: [],
+  } as unknown as EntityForAttachment['riskStats'],
+  assetCriticality: 'high_impact',
+  watchlistIds: [],
+  sources: ['okta'],
+  ...override,
+});
+
+const renderCard = (props: Partial<React.ComponentProps<typeof EntityCard>> = {}) => {
+  const defaults: React.ComponentProps<typeof EntityCard> = {
+    identifier: { identifierType: 'user', identifier: 'bob' },
+    watchlistsEnabled: true,
+    privmonModifierEnabled: true,
+  };
+  return render(
+    <I18nProvider>
+      <EntityCard {...defaults} {...props} />
+    </I18nProvider>
+  );
+};
+
+describe('EntityCard', () => {
+  beforeEach(() => {
+    mockedUseEntityForAttachment.mockReset();
+  });
+
+  it('renders a skeleton while loading', () => {
+    mockedUseEntityForAttachment.mockReturnValue({ isLoading: true, data: undefined });
+    renderCard();
+    expect(screen.getByTestId('entityAttachmentCardSkeleton')).toBeInTheDocument();
+  });
+
+  it('renders an error callout when the store fetch fails without data', () => {
+    mockedUseEntityForAttachment.mockReturnValue({
+      isLoading: false,
+      error: new Error('boom'),
+      data: undefined,
+    });
+    renderCard();
+    expect(screen.getByTestId('entityAttachmentCardError')).toBeInTheDocument();
+    expect(screen.getByTestId('entityAttachmentCardActions')).toBeInTheDocument();
+  });
+
+  it('renders the rich layout for an entity that is in the store', () => {
+    mockedUseEntityForAttachment.mockReturnValue({
+      isLoading: false,
+      data: baseEntity(),
+    });
+    renderCard();
+
+    expect(screen.getByTestId('entityAttachmentIdentityHeader')).toBeInTheDocument();
+    expect(screen.getByTestId('entityAttachmentRiskLevelBadge')).toBeInTheDocument();
+    expect(screen.getByTestId('entitySummaryGridMock')).toBeInTheDocument();
+    expect(screen.getByTestId('riskSummaryMiniMock')).toBeInTheDocument();
+    expect(screen.getByTestId('resolutionMiniMock')).toBeInTheDocument();
+    expect(screen.getByTestId('entityAttachmentCardActions')).toBeInTheDocument();
+  });
+
+  it('does not render the rich sections when the entity is not in the store', () => {
+    mockedUseEntityForAttachment.mockReturnValue({
+      isLoading: false,
+      data: baseEntity({
+        isEntityInStore: false,
+        entityId: undefined,
+        riskStats: undefined,
+        riskScore: undefined,
+        riskLevel: undefined,
+      }),
+    });
+    renderCard();
+
+    expect(screen.getByTestId('entityAttachmentIdentityHeader')).toBeInTheDocument();
+    expect(screen.queryByTestId('entitySummaryGridMock')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('riskSummaryMiniMock')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('resolutionMiniMock')).not.toBeInTheDocument();
+  });
+
+  it('skips the risk summary when the store record has no risk data', () => {
+    mockedUseEntityForAttachment.mockReturnValue({
+      isLoading: false,
+      data: baseEntity({ riskStats: undefined, riskScore: undefined, riskLevel: undefined }),
+    });
+    renderCard();
+    expect(screen.getByTestId('entitySummaryGridMock')).toBeInTheDocument();
+    expect(screen.queryByTestId('riskSummaryMiniMock')).not.toBeInTheDocument();
+  });
+
+  it('passes the store entity id and watchlist flag to the summary grid', () => {
+    mockedUseEntityForAttachment.mockReturnValue({
+      isLoading: false,
+      data: baseEntity({ entityId: 'xyz-1', sources: ['crowdstrike'] }),
+    });
+    renderCard({ watchlistsEnabled: false });
+    const grid = screen.getByTestId('entitySummaryGridMock');
+    expect(grid.getAttribute('data-entity-id')).toBe('xyz-1');
+    expect(grid.getAttribute('data-source')).toBe('crowdstrike');
+    expect(grid.getAttribute('data-watchlists-enabled')).toBe('false');
+  });
+
+  it('omits the resolution mini section when there is no entity id', () => {
+    mockedUseEntityForAttachment.mockReturnValue({
+      isLoading: false,
+      data: baseEntity({ entityId: undefined }),
+    });
+    renderCard();
+    expect(screen.queryByTestId('resolutionMiniMock')).not.toBeInTheDocument();
+  });
+
+  it('forwards the attachment identifier (including entityStoreId) to useEntityForAttachment', () => {
+    mockedUseEntityForAttachment.mockReturnValue({
+      isLoading: false,
+      data: baseEntity(),
+    });
+
+    const identifier = {
+      identifierType: 'user' as const,
+      identifier: "Lena Medhurst@Lena's MacBook Pro",
+      entityStoreId: "user:Lena Medhurst@Lena's MacBook Pro@local",
+    };
+    renderCard({ identifier });
+
+    expect(mockedUseEntityForAttachment).toHaveBeenCalledWith(identifier);
+  });
+
+  describe('attachment-supplied risk stats', () => {
+    const attachmentRiskStats: React.ComponentProps<typeof EntityCard>['riskStats'] = {
+      '@timestamp': '2024-02-02T00:00:00Z',
+      id_field: 'user.name',
+      id_value: 'bob',
+      calculated_level: 'High',
+      calculated_score: 70,
+      calculated_score_norm: 88,
+      category_1_score: 55.5,
+      category_1_count: 7,
+      category_2_score: 12,
+      notes: [],
+    };
+
+    const attachmentResolutionRiskStats: React.ComponentProps<
+      typeof EntityCard
+    >['resolutionRiskStats'] = {
+      '@timestamp': '2024-02-02T01:00:00Z',
+      id_field: 'user.name',
+      id_value: 'bob',
+      calculated_level: 'Critical',
+      calculated_score: 90,
+      calculated_score_norm: 95,
+      category_1_score: 80,
+      category_1_count: 11,
+      notes: [],
+    };
+
+    it('prefers attachment-supplied stats over entity-store stats', () => {
+      mockedUseEntityForAttachment.mockReturnValue({
+        isLoading: false,
+        data: baseEntity(),
+      });
+      renderCard({ riskStats: attachmentRiskStats });
+
+      const mini = screen.getByTestId('riskSummaryMiniMock');
+      expect(mini.getAttribute('data-primary-cat1-score')).toBe('55.5');
+      expect(mini.getAttribute('data-primary-cat1-count')).toBe('7');
+    });
+
+    it('falls back to entity-store stats when no attachment stats are supplied', () => {
+      mockedUseEntityForAttachment.mockReturnValue({
+        isLoading: false,
+        data: baseEntity(),
+      });
+      renderCard();
+
+      const mini = screen.getByTestId('riskSummaryMiniMock');
+      // baseEntity's category_1_score/count from the fixture
+      expect(mini.getAttribute('data-primary-cat1-score')).toBe('40');
+      expect(mini.getAttribute('data-primary-cat1-count')).toBe('3');
+    });
+
+    it('passes resolution stats through to RiskSummaryMini so the resolution block renders', () => {
+      mockedUseEntityForAttachment.mockReturnValue({
+        isLoading: false,
+        data: baseEntity(),
+      });
+      renderCard({
+        riskStats: attachmentRiskStats,
+        resolutionRiskStats: attachmentResolutionRiskStats,
+      });
+
+      const mini = screen.getByTestId('riskSummaryMiniMock');
+      expect(mini.getAttribute('data-has-resolution-stats')).toBe('true');
+      expect(mini.getAttribute('data-resolution-score')).toBe('95');
+      expect(mini.getAttribute('data-resolution-level')).toBe('Critical');
+      expect(mini.getAttribute('data-resolution-cat1-score')).toBe('80');
+    });
+
+    it('renders the risk summary when only attachment stats are present and the store has no score', () => {
+      mockedUseEntityForAttachment.mockReturnValue({
+        isLoading: false,
+        data: baseEntity({
+          riskStats: undefined,
+          riskScore: undefined,
+          riskLevel: undefined,
+        }),
+      });
+      renderCard({ riskStats: attachmentRiskStats });
+
+      expect(screen.getByTestId('riskSummaryMiniMock')).toBeInTheDocument();
+    });
+
+    it('renders the risk summary when only resolution stats are present', () => {
+      mockedUseEntityForAttachment.mockReturnValue({
+        isLoading: false,
+        data: baseEntity({
+          riskStats: undefined,
+          riskScore: undefined,
+          riskLevel: undefined,
+        }),
+      });
+      renderCard({ resolutionRiskStats: attachmentResolutionRiskStats });
+
+      const mini = screen.getByTestId('riskSummaryMiniMock');
+      expect(mini).toBeInTheDocument();
+      expect(mini.getAttribute('data-has-resolution-stats')).toBe('true');
+      expect(mini.getAttribute('data-resolution-score')).toBe('95');
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/entity_card/entity_card.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/entity_card/entity_card.tsx
@@ -1,0 +1,261 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useMemo } from 'react';
+import { EuiCallOut, EuiPanel, EuiSkeletonText, EuiSpacer } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import type { ApplicationStart } from '@kbn/core-application-browser';
+import type { ISessionService } from '@kbn/data-plugin/public';
+import type { RiskSeverity, RiskStats } from '../../../../../common/search_strategy';
+import { EntityType } from '../../../../../common/entity_analytics/types';
+import { useEntityForAttachment } from '../use_entity_for_attachment';
+import type { EntityAttachmentIdentifier, EntityAttachmentRiskStats } from '../types';
+import { IdentityHeader } from './identity_header';
+import { EntitySummaryGridMini } from './entity_summary_grid';
+import { RiskSummaryMini } from './risk_summary_mini';
+import { ResolutionMini } from './resolution_mini';
+import { EntityCardActions } from './entity_card_actions';
+
+interface EntityCardProps {
+  identifier: EntityAttachmentIdentifier;
+  /**
+   * Risk breakdown embedded on the attachment payload by
+   * `security.get_entity`. When present, the card prefers these over the
+   * (far more limited) stats available on the entity store record so the
+   * contributions table mirrors the full flyout.
+   */
+  riskStats?: EntityAttachmentRiskStats;
+  /**
+   * Resolution-group risk breakdown embedded on the attachment payload
+   * when the entity is part of a multi-member resolution group. Drives the
+   * "Resolution group risk score" block in `RiskSummaryMini`.
+   */
+  resolutionRiskStats?: EntityAttachmentRiskStats;
+  watchlistsEnabled: boolean;
+  privmonModifierEnabled: boolean;
+  /**
+   * Optional core `ApplicationStart`. Forwarded to `EntityCardActions` so "Open in Entity
+   * Analytics" goes through the shared `navigateTo…InApp` helpers (which clear the search
+   * session before cross-app navigation) instead of a raw `navigateToApp` call.
+   */
+  application?: ApplicationStart;
+  /**
+   * Optional search session service. Forwarded to `EntityCardActions` to enable the
+   * session-clearing hook in the shared `navigateTo…InApp` helpers.
+   */
+  searchSession?: ISessionService;
+}
+
+/**
+ * Projects the embedded `EntityAttachmentRiskStats` (a subset of
+ * `EntityRiskScoreRecord`) into the full `RiskStats` shape `RiskSummaryMini`
+ * expects. `rule_risks`/`multipliers` aren't surfaced on the attachment
+ * today — defaulting them to empty arrays matches what the entity-store
+ * shaping hook does and keeps the contributions table render-safe.
+ */
+const toRiskStats = (stats: EntityAttachmentRiskStats | undefined): RiskStats | undefined => {
+  if (!stats) return undefined;
+  return {
+    ...stats,
+    rule_risks: [],
+    multipliers: [],
+  } as unknown as RiskStats;
+};
+
+const identifierTypeToEntityType = (
+  type: EntityAttachmentIdentifier['identifierType']
+): EntityType => {
+  switch (type) {
+    case 'host':
+      return EntityType.host;
+    case 'user':
+      return EntityType.user;
+    case 'service':
+      return EntityType.service;
+    case 'generic':
+    default:
+      return EntityType.generic;
+  }
+};
+
+/**
+ * Rich entity card shown inside an agent chat message. When the entity is
+ * in the entity store, we mirror the user/host details flyout layout
+ * (identity header → summary grid → risk summary → resolution group),
+ * rebuilt with lightweight hooks so the card stays decoupled from the
+ * Security Solution Redux/expandable-flyout providers. Follow-up actions
+ * other than "Open in Entity Analytics" are driven from the agent side.
+ */
+export const EntityCard: React.FC<EntityCardProps> = ({
+  identifier,
+  riskStats: attachmentRiskStats,
+  resolutionRiskStats: attachmentResolutionRiskStats,
+  watchlistsEnabled,
+  privmonModifierEnabled,
+  application,
+  searchSession,
+}) => {
+  const { isLoading, error, data } = useEntityForAttachment(identifier);
+
+  // Prefer attachment-supplied risk stats (full breakdown from the risk
+  // index) over the entity-store-derived stats (score/level only). Falls
+  // back to the entity store for older attachments persisted before the
+  // payload was widened, so they keep rendering as before.
+  const effectiveRiskStats = useMemo(
+    () => toRiskStats(attachmentRiskStats) ?? data?.riskStats,
+    [attachmentRiskStats, data?.riskStats]
+  );
+  const effectiveResolutionRiskStats = useMemo(
+    () => toRiskStats(attachmentResolutionRiskStats),
+    [attachmentResolutionRiskStats]
+  );
+
+  if (isLoading && !data) {
+    return (
+      <EuiPanel hasShadow={false} hasBorder={false} paddingSize="m">
+        <EuiSkeletonText lines={4} data-test-subj="entityAttachmentCardSkeleton" />
+      </EuiPanel>
+    );
+  }
+
+  const fallback = {
+    entityType: identifierTypeToEntityType(identifier.identifierType),
+    displayName: identifier.identifier,
+    entityId: undefined as string | undefined,
+    isEntityInStore: false,
+    firstSeen: null as string | null,
+    lastSeen: null as string | null,
+    riskScore: undefined as number | undefined,
+    riskLevel: undefined,
+    riskStats: undefined,
+    assetCriticality: undefined,
+    watchlistIds: [] as string[],
+    sources: [] as string[],
+  };
+
+  if (error && !data) {
+    return (
+      <EuiPanel
+        hasShadow={false}
+        hasBorder={false}
+        paddingSize="m"
+        data-test-subj="entityAttachmentCard"
+      >
+        <EuiCallOut
+          announceOnMount
+          size="s"
+          color="warning"
+          iconType="warning"
+          title={i18n.translate(
+            'xpack.securitySolution.agentBuilder.entityAttachment.card.errorTitle',
+            { defaultMessage: 'Could not load entity details' }
+          )}
+          data-test-subj="entityAttachmentCardError"
+        >
+          {i18n.translate(
+            'xpack.securitySolution.agentBuilder.entityAttachment.card.errorDescription',
+            {
+              defaultMessage:
+                'We could not reach the entity store. The entity identifier is still available for the agent.',
+            }
+          )}
+        </EuiCallOut>
+        <EuiSpacer size="s" />
+        <IdentityHeader
+          displayName={fallback.displayName}
+          entityType={fallback.entityType}
+          isEntityInStore={false}
+          hasLastSeenDate={false}
+        />
+        <EntityCardActions
+          identifier={identifier}
+          application={application}
+          searchSession={searchSession}
+        />
+      </EuiPanel>
+    );
+  }
+
+  const resolved = data ?? fallback;
+  const source = resolved.sources[0];
+
+  // Derive the resolution-group score/level from the embedded risk doc so
+  // `RiskSummaryMini` renders the resolution block (`showResolution`
+  // flips on whenever any of these three fields is set).
+  const resolutionRiskScore = attachmentResolutionRiskStats?.calculated_score_norm;
+  const resolutionRiskLevel = attachmentResolutionRiskStats?.calculated_level as
+    | RiskSeverity
+    | undefined;
+
+  const hasRiskSummary =
+    effectiveRiskStats != null ||
+    resolved.riskScore != null ||
+    effectiveResolutionRiskStats != null ||
+    resolutionRiskScore != null ||
+    resolutionRiskLevel != null;
+
+  return (
+    <EuiPanel
+      hasShadow={false}
+      hasBorder={false}
+      paddingSize="m"
+      data-test-subj="entityAttachmentCard"
+    >
+      <IdentityHeader
+        displayName={resolved.displayName}
+        entityType={resolved.entityType}
+        isEntityInStore={resolved.isEntityInStore}
+        hasLastSeenDate={Boolean(resolved.lastSeen)}
+        assetCriticality={resolved.assetCriticality}
+        riskLevel={resolved.riskLevel}
+      />
+      {resolved.isEntityInStore && (
+        <>
+          <EuiSpacer size="s" />
+          <EntitySummaryGridMini
+            entityId={resolved.entityId}
+            source={source}
+            assetCriticality={resolved.assetCriticality}
+            watchlistIds={resolved.watchlistIds}
+            watchlistsEnabled={watchlistsEnabled}
+          />
+          {hasRiskSummary && (
+            <>
+              <EuiSpacer size="m" />
+              <RiskSummaryMini
+                entityType={resolved.entityType}
+                displayName={resolved.displayName}
+                riskScore={resolved.riskScore}
+                riskLevel={resolved.riskLevel}
+                riskStats={effectiveRiskStats}
+                resolutionRiskScore={resolutionRiskScore}
+                resolutionRiskLevel={resolutionRiskLevel}
+                resolutionRiskStats={effectiveResolutionRiskStats}
+                privmonModifierEnabled={privmonModifierEnabled}
+                watchlistEnabled={watchlistsEnabled}
+              />
+            </>
+          )}
+          {resolved.entityId && (
+            <>
+              <EuiSpacer size="m" />
+              <ResolutionMini
+                entityStoreEntityId={resolved.entityId}
+                currentEntityStoreEntityId={resolved.entityId}
+              />
+            </>
+          )}
+        </>
+      )}
+      <EntityCardActions
+        identifier={identifier}
+        application={application}
+        searchSession={searchSession}
+      />
+    </EuiPanel>
+  );
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/entity_card/entity_card_actions.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/entity_card/entity_card_actions.test.tsx
@@ -1,0 +1,227 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { I18nProvider } from '@kbn/i18n-react';
+import type { ApplicationStart } from '@kbn/core-application-browser';
+import { APP_UI_ID } from '../../../../../common/constants';
+import type { EntityAttachmentIdentifier } from '../types';
+import {
+  navigateToEntityAnalyticsHomePageInApp,
+  navigateToEntityAnalyticsWithFlyoutInApp,
+} from '../../entity_explore_navigation';
+import { EntityCardActions } from './entity_card_actions';
+
+jest.mock('../../entity_explore_navigation', () => {
+  const actual = jest.requireActual('../../entity_explore_navigation');
+  return {
+    ...actual,
+    navigateToEntityAnalyticsHomePageInApp: jest.fn(),
+    navigateToEntityAnalyticsWithFlyoutInApp: jest.fn(),
+  };
+});
+
+jest.mock('@kbn/kibana-react-plugin/public', () => ({
+  useKibana: () => ({
+    services: { application: { navigateToApp: jest.fn() } },
+  }),
+}));
+
+const mockedNavigateToHome = navigateToEntityAnalyticsHomePageInApp as jest.Mock;
+const mockedNavigateToFlyout = navigateToEntityAnalyticsWithFlyoutInApp as jest.Mock;
+
+const buildApplicationMock = (): ApplicationStart =>
+  ({ navigateToApp: jest.fn() } as unknown as ApplicationStart);
+
+const renderActions = (
+  identifier: EntityAttachmentIdentifier,
+  extraProps: Partial<React.ComponentProps<typeof EntityCardActions>> = {}
+) => {
+  const application = extraProps.application ?? buildApplicationMock();
+  const utils = render(
+    <I18nProvider>
+      <EntityCardActions identifier={identifier} application={application} {...extraProps} />
+    </I18nProvider>
+  );
+  return { ...utils, application };
+};
+
+const clickOpen = () => {
+  fireEvent.click(screen.getByTestId('entityAttachmentOpenEntityAnalyticsAction'));
+};
+
+describe('EntityCardActions', () => {
+  beforeEach(() => {
+    mockedNavigateToHome.mockReset();
+    mockedNavigateToFlyout.mockReset();
+  });
+
+  describe('host/user/service with entityStoreId', () => {
+    it('opens the user flyout with the UserPanelKey payload', () => {
+      const { application } = renderActions({
+        identifierType: 'user',
+        identifier: 'bob',
+        entityStoreId: 'user:bob@acme@default',
+      });
+
+      expect(screen.getByText('Open in Entity Analytics')).toBeInTheDocument();
+
+      clickOpen();
+
+      expect(mockedNavigateToFlyout).toHaveBeenCalledTimes(1);
+      expect(mockedNavigateToHome).not.toHaveBeenCalled();
+      expect(mockedNavigateToFlyout).toHaveBeenCalledWith(
+        expect.objectContaining({
+          application,
+          appId: APP_UI_ID,
+          flyout: expect.objectContaining({
+            preview: [],
+            right: {
+              id: 'user-panel',
+              params: {
+                contextID: 'agent-builder-entity-card',
+                scopeId: 'agent-builder-entity-card',
+                userName: 'bob',
+                identityFields: { 'user.name': 'bob' },
+                entityId: 'user:bob@acme@default',
+              },
+            },
+          }),
+        })
+      );
+    });
+
+    it('opens the host flyout with the HostPanelKey payload', () => {
+      renderActions({
+        identifierType: 'host',
+        identifier: 'macbook-01',
+        entityStoreId: 'host:macbook-01@default',
+      });
+
+      clickOpen();
+
+      expect(mockedNavigateToFlyout).toHaveBeenCalledTimes(1);
+      expect(mockedNavigateToHome).not.toHaveBeenCalled();
+      expect(mockedNavigateToFlyout).toHaveBeenCalledWith(
+        expect.objectContaining({
+          flyout: expect.objectContaining({
+            right: {
+              id: 'host-panel',
+              params: {
+                contextID: 'agent-builder-entity-card',
+                scopeId: 'agent-builder-entity-card',
+                hostName: 'macbook-01',
+                entityId: 'host:macbook-01@default',
+              },
+            },
+          }),
+        })
+      );
+    });
+
+    it('opens the service flyout with the ServicePanelKey payload', () => {
+      renderActions({
+        identifierType: 'service',
+        identifier: 'auth-svc',
+        entityStoreId: 'service:auth-svc@default',
+      });
+
+      clickOpen();
+
+      expect(mockedNavigateToFlyout).toHaveBeenCalledTimes(1);
+      expect(mockedNavigateToHome).not.toHaveBeenCalled();
+      expect(mockedNavigateToFlyout).toHaveBeenCalledWith(
+        expect.objectContaining({
+          flyout: expect.objectContaining({
+            right: {
+              id: 'service-panel',
+              params: {
+                contextID: 'agent-builder-entity-card',
+                scopeId: 'agent-builder-entity-card',
+                serviceName: 'auth-svc',
+                entityId: 'service:auth-svc@default',
+              },
+            },
+          }),
+        })
+      );
+    });
+
+    it('forwards the optional searchSession so the helper can clear it before navigating', () => {
+      const searchSession = { clear: jest.fn() };
+
+      renderActions(
+        {
+          identifierType: 'user',
+          identifier: 'bob',
+          entityStoreId: 'user:bob@acme@default',
+        },
+        { searchSession: searchSession as never }
+      );
+
+      clickOpen();
+
+      expect(mockedNavigateToFlyout).toHaveBeenCalledWith(
+        expect.objectContaining({ searchSession })
+      );
+    });
+  });
+
+  describe('generic / legacy / fallback', () => {
+    it('falls back to the unfiltered home navigation for generic entities', () => {
+      const { application } = renderActions({
+        identifierType: 'generic',
+        identifier: 'some-generic-id',
+        entityStoreId: 'generic:some-generic-id@default',
+      });
+
+      expect(screen.getByText('Open Entity Analytics')).toBeInTheDocument();
+
+      clickOpen();
+
+      expect(mockedNavigateToHome).toHaveBeenCalledTimes(1);
+      expect(mockedNavigateToFlyout).not.toHaveBeenCalled();
+      expect(mockedNavigateToHome).toHaveBeenCalledWith(
+        expect.objectContaining({ application, appId: APP_UI_ID })
+      );
+    });
+
+    it.each(['user', 'host', 'service'] as const)(
+      'falls back to the unfiltered home navigation when a %s attachment has no entityStoreId (legacy payload)',
+      (identifierType) => {
+        renderActions({ identifierType, identifier: 'anything' });
+
+        expect(screen.getByText('Open Entity Analytics')).toBeInTheDocument();
+
+        clickOpen();
+
+        expect(mockedNavigateToHome).toHaveBeenCalledTimes(1);
+        expect(mockedNavigateToFlyout).not.toHaveBeenCalled();
+      }
+    );
+  });
+
+  it('renders with "Open in Entity Analytics" label for flyout-capable entities', () => {
+    renderActions({
+      identifierType: 'user',
+      identifier: 'bob',
+      entityStoreId: 'user:bob@acme@default',
+    });
+    expect(screen.getByText('Open in Entity Analytics')).toBeInTheDocument();
+    expect(screen.queryByText('Open Entity Analytics')).not.toBeInTheDocument();
+  });
+
+  it('renders with "Open Entity Analytics" label for generic entities', () => {
+    renderActions({
+      identifierType: 'generic',
+      identifier: 'some-id',
+    });
+    expect(screen.getByText('Open Entity Analytics')).toBeInTheDocument();
+    expect(screen.queryByText('Open in Entity Analytics')).not.toBeInTheDocument();
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/entity_card/entity_card_actions.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/entity_card/entity_card_actions.tsx
@@ -1,0 +1,109 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useCallback, useMemo } from 'react';
+import { EuiButtonEmpty, EuiFlexGroup, EuiFlexItem, EuiSpacer } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { useKibana } from '@kbn/kibana-react-plugin/public';
+import type { ApplicationStart } from '@kbn/core-application-browser';
+import type { ISessionService } from '@kbn/data-plugin/public';
+import { APP_UI_ID } from '../../../../../common/constants';
+import type { EntityAttachmentIdentifier } from '../types';
+import {
+  buildEntityRightPanel,
+  navigateToEntityAnalyticsHomePageInApp,
+  navigateToEntityAnalyticsWithFlyoutInApp,
+} from '../../entity_explore_navigation';
+
+interface EntityCardActionsProps {
+  identifier: EntityAttachmentIdentifier;
+  /**
+   * Optional core `ApplicationStart`. When provided, the "Open in Entity Analytics" button
+   * routes through the shared `navigateTo…InApp` helpers, which clear any active
+   * Agent Builder-tagged search session before the cross-app jump. When omitted, falls back
+   * to `useKibana()` so existing call sites / tests without an explicit `application` prop
+   * keep working.
+   */
+  application?: ApplicationStart;
+  /**
+   * Optional search session service. Forwarded to the shared `navigateTo…InApp` helpers
+   * so the active search session tagged with `appName: 'agent_builder'` is cleared before
+   * the legitimate cross-app navigation to `securitySolutionUI`.
+   */
+  searchSession?: ISessionService;
+}
+
+const OPEN_IN_ENTITY_ANALYTICS_LABEL = i18n.translate(
+  'xpack.securitySolution.agentBuilder.entityAttachment.actions.openInEntityAnalytics',
+  { defaultMessage: 'Open in Entity Analytics' }
+);
+
+const OPEN_ENTITY_ANALYTICS_LABEL = i18n.translate(
+  'xpack.securitySolution.agentBuilder.entityAttachment.actions.openEntityAnalytics',
+  { defaultMessage: 'Open Entity Analytics' }
+);
+
+/**
+ * Follow-up action row rendered at the bottom of the entity card. The only
+ * affordance is a jump into the Entity Analytics app: for host/user/service
+ * entities backed by the entity store we deep-link straight into the
+ * expandable flyout (same `?flyout=…` payload shape the EA page emits
+ * itself), otherwise we fall back to the unfiltered EA home page and adjust
+ * the label from "Open in Entity Analytics" to "Open Entity Analytics" so
+ * the copy matches the navigation target.
+ */
+export const EntityCardActions: React.FC<EntityCardActionsProps> = ({
+  identifier,
+  application,
+  searchSession,
+}) => {
+  const { services } = useKibana<{ application: ApplicationStart }>();
+  const effectiveApplication = application ?? services.application;
+
+  const rightPanel = useMemo(() => buildEntityRightPanel(identifier), [identifier]);
+
+  const label = rightPanel ? OPEN_IN_ENTITY_ANALYTICS_LABEL : OPEN_ENTITY_ANALYTICS_LABEL;
+
+  const handleOpenEntityAnalytics = useCallback(() => {
+    if (!effectiveApplication) {
+      return;
+    }
+    if (rightPanel) {
+      navigateToEntityAnalyticsWithFlyoutInApp({
+        application: effectiveApplication,
+        appId: APP_UI_ID,
+        searchSession,
+        flyout: { preview: [], right: rightPanel },
+      });
+      return;
+    }
+    navigateToEntityAnalyticsHomePageInApp({
+      application: effectiveApplication,
+      appId: APP_UI_ID,
+      searchSession,
+    });
+  }, [effectiveApplication, rightPanel, searchSession]);
+
+  return (
+    <div data-test-subj="entityAttachmentCardActions">
+      <EuiSpacer size="s" />
+      <EuiFlexGroup gutterSize="s" wrap responsive={false}>
+        <EuiFlexItem grow={false}>
+          <EuiButtonEmpty
+            size="xs"
+            iconType="popout"
+            onClick={handleOpenEntityAnalytics}
+            data-test-subj="entityAttachmentOpenEntityAnalyticsAction"
+            aria-label={label}
+          >
+            {label}
+          </EuiButtonEmpty>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </div>
+  );
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/entity_card/entity_summary_grid.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/entity_card/entity_summary_grid.test.tsx
@@ -1,0 +1,109 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { I18nProvider } from '@kbn/i18n-react';
+import { QueryClient, QueryClientProvider } from '@kbn/react-query';
+import { EntitySummaryGridMini } from './entity_summary_grid';
+
+const mockFetch = jest.fn();
+
+jest.mock('@kbn/kibana-react-plugin/public', () => ({
+  useKibana: () => ({
+    services: {
+      http: {
+        fetch: (...args: unknown[]) => mockFetch(...args),
+      },
+    },
+  }),
+}));
+
+const makeClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, cacheTime: 0 },
+    },
+  });
+
+const renderGrid = (props: Partial<React.ComponentProps<typeof EntitySummaryGridMini>> = {}) => {
+  const defaults: React.ComponentProps<typeof EntitySummaryGridMini> = {
+    entityId: 'entity-1',
+    source: 'okta',
+    assetCriticality: 'high_impact',
+    watchlistIds: [],
+    watchlistsEnabled: false,
+  };
+  return render(
+    <I18nProvider>
+      <QueryClientProvider client={makeClient()}>
+        <EntitySummaryGridMini {...defaults} {...props} />
+      </QueryClientProvider>
+    </I18nProvider>
+  );
+};
+
+describe('EntitySummaryGridMini', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it('renders the four summary panels', () => {
+    renderGrid();
+    expect(screen.getByTestId('entityAttachmentSummaryEntityId')).toBeInTheDocument();
+    expect(screen.getByTestId('entityAttachmentSummaryDataSource')).toBeInTheDocument();
+    expect(screen.getByTestId('entityAttachmentSummaryAssetCriticality')).toBeInTheDocument();
+    expect(screen.getByTestId('entityAttachmentSummaryWatchlists')).toBeInTheDocument();
+  });
+
+  it('renders the entity id with a copy button', () => {
+    renderGrid({ entityId: 'entity-xyz' });
+    expect(screen.getByText('entity-xyz')).toBeInTheDocument();
+    expect(screen.getByTestId('entityAttachmentGridEntityIdCopy')).toBeInTheDocument();
+  });
+
+  it('falls back to an em-dash when entity id is missing', () => {
+    renderGrid({ entityId: undefined });
+    const panel = screen.getByTestId('entityAttachmentSummaryEntityId');
+    expect(panel.textContent).toContain('—');
+  });
+
+  it('does not fetch watchlists when watchlists are disabled', () => {
+    renderGrid({ watchlistsEnabled: false, watchlistIds: ['w-1'] });
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('does not fetch watchlists when the list is empty', () => {
+    renderGrid({ watchlistsEnabled: true, watchlistIds: [] });
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('resolves watchlist ids to names and shows a +N overflow badge', async () => {
+    mockFetch.mockResolvedValue([
+      { id: 'w-1', name: 'VIP users' },
+      { id: 'w-2', name: 'Contractors' },
+      { id: 'w-3', name: 'Test accounts' },
+    ]);
+
+    renderGrid({ watchlistsEnabled: true, watchlistIds: ['w-1', 'w-2', 'w-3'] });
+
+    await waitFor(() => {
+      expect(screen.getByText('VIP users')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('entityAttachmentGridWatchlists-more')).toHaveTextContent('+2');
+  });
+
+  it('falls back to the raw id when a watchlist cannot be resolved', async () => {
+    mockFetch.mockResolvedValue([]);
+
+    renderGrid({ watchlistsEnabled: true, watchlistIds: ['unknown-id'] });
+
+    await waitFor(() => {
+      expect(screen.getByText('unknown-id')).toBeInTheDocument();
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/entity_card/entity_summary_grid.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/entity_card/entity_summary_grid.tsx
@@ -1,0 +1,214 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useMemo } from 'react';
+import {
+  EuiButtonIcon,
+  EuiCopy,
+  EuiFlexGrid,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiPanel,
+  EuiSpacer,
+  EuiText,
+  EuiToolTip,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { useKibana } from '@kbn/kibana-react-plugin/public';
+import { useQuery } from '@kbn/react-query';
+import type { HttpStart } from '@kbn/core-http-browser';
+import { AssetCriticalityBadge } from '../../../../entity_analytics/components/asset_criticality/asset_criticality_badge';
+import { getWatchlistName } from '../../../../../common/entity_analytics/watchlists/constants';
+import { API_VERSIONS, WATCHLISTS_URL } from '../../../../../common/entity_analytics/constants';
+import { TruncatedBadgeList } from '../../../../flyout/entity_details/shared/components/entity_source_value';
+import type { CriticalityLevelWithUnassigned } from '../../../../../common/entity_analytics/asset_criticality/types';
+
+interface EntitySummaryGridProps {
+  entityId?: string;
+  source?: string;
+  assetCriticality?: CriticalityLevelWithUnassigned;
+  watchlistIds: string[];
+  watchlistsEnabled: boolean;
+}
+
+interface WatchlistListItem {
+  id?: string;
+  name: string;
+}
+
+const LABELS = {
+  entityId: i18n.translate(
+    'xpack.securitySolution.agentBuilder.entityAttachment.grid.entityIdLabel',
+    { defaultMessage: 'Entity ID' }
+  ),
+  dataSource: i18n.translate(
+    'xpack.securitySolution.agentBuilder.entityAttachment.grid.dataSourceLabel',
+    { defaultMessage: 'Data source' }
+  ),
+  assetCriticality: i18n.translate(
+    'xpack.securitySolution.agentBuilder.entityAttachment.grid.assetCriticalityLabel',
+    { defaultMessage: 'Asset criticality' }
+  ),
+  watchlists: i18n.translate(
+    'xpack.securitySolution.agentBuilder.entityAttachment.grid.watchlistsLabel',
+    { defaultMessage: 'Watchlists' }
+  ),
+  copy: i18n.translate(
+    'xpack.securitySolution.agentBuilder.entityAttachment.grid.copyToClipboard',
+    { defaultMessage: 'Copy to clipboard' }
+  ),
+  empty: i18n.translate('xpack.securitySolution.agentBuilder.entityAttachment.grid.empty', {
+    defaultMessage: '—',
+  }),
+  watchlistsOverflowTooltipTitle: i18n.translate(
+    'xpack.securitySolution.agentBuilder.entityAttachment.grid.watchlistsOverflowTitle',
+    { defaultMessage: 'Additional watchlists' }
+  ),
+};
+
+const WATCHLISTS_QUERY_KEY = 'AGENT_BUILDER_ENTITY_ATTACHMENT_WATCHLISTS';
+
+/**
+ * Minimal, provider-independent watchlist fetcher. Mirrors
+ * `useEntityForAttachment`'s approach (core `http`, no Redux) so the chat
+ * card can resolve watchlist names without the Security Solution Kibana
+ * context that `useGetWatchlists` requires.
+ */
+const useAttachmentWatchlists = (enabled: boolean) => {
+  const { services } = useKibana<{ http: HttpStart }>();
+  const http = services.http;
+
+  return useQuery<WatchlistListItem[]>({
+    queryKey: [WATCHLISTS_QUERY_KEY],
+    queryFn: async ({ signal }) => {
+      if (!http) {
+        throw new Error('Core http service is not available');
+      }
+      return http.fetch<WatchlistListItem[]>(`${WATCHLISTS_URL}/list`, {
+        version: API_VERSIONS.public.v1,
+        method: 'GET',
+        signal,
+      });
+    },
+    enabled: Boolean(http) && enabled,
+  });
+};
+
+const SummaryPanel: React.FC<{ label: string; children: React.ReactNode; testSubj: string }> = ({
+  label,
+  children,
+  testSubj,
+}) => (
+  <EuiPanel hasBorder paddingSize="s" style={{ minWidth: 0 }} data-test-subj={testSubj}>
+    <EuiText size="xs">
+      <strong>{label}</strong>
+    </EuiText>
+    <EuiSpacer size="xs" />
+    {children}
+  </EuiPanel>
+);
+
+const EntityIdCell: React.FC<{ entityId?: string }> = ({ entityId }) => {
+  if (!entityId) {
+    return <EuiText size="s">{LABELS.empty}</EuiText>;
+  }
+  return (
+    <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false} wrap={false}>
+      <EuiFlexItem className="eui-textTruncate">
+        <EuiToolTip content={entityId}>
+          <EuiText size="s" className="eui-textTruncate">
+            {entityId}
+          </EuiText>
+        </EuiToolTip>
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiToolTip content={LABELS.copy}>
+          <EuiCopy textToCopy={entityId}>
+            {(copy) => (
+              <EuiButtonIcon
+                iconType="copy"
+                aria-label={LABELS.copy}
+                onClick={copy}
+                iconSize="s"
+                color="text"
+                data-test-subj="entityAttachmentGridEntityIdCopy"
+              />
+            )}
+          </EuiCopy>
+        </EuiToolTip>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+};
+
+const WatchlistsCell: React.FC<{
+  watchlistIds: string[];
+  watchlistsEnabled: boolean;
+}> = ({ watchlistIds, watchlistsEnabled }) => {
+  const { data: watchlistData } = useAttachmentWatchlists(
+    watchlistsEnabled && watchlistIds.length > 0
+  );
+
+  const names = useMemo(() => {
+    if (!watchlistIds.length) return [] as string[];
+    const byId = new Map<string, string>();
+    (watchlistData ?? []).forEach((w) => {
+      if (w.id) byId.set(w.id, w.name);
+    });
+    return watchlistIds.map((id) => byId.get(id) ?? getWatchlistName(id));
+  }, [watchlistIds, watchlistData]);
+
+  if (!watchlistsEnabled || names.length === 0) {
+    return <EuiText size="s">{LABELS.empty}</EuiText>;
+  }
+
+  return (
+    <TruncatedBadgeList
+      values={names}
+      overflowTooltipTitle={LABELS.watchlistsOverflowTooltipTitle}
+      data-test-subj="entityAttachmentGridWatchlists"
+    />
+  );
+};
+
+/**
+ * Chat-scale recreation of the flyout's `EntitySummaryGrid` (Entity ID,
+ * Data source, Asset criticality, Watchlists). Asset criticality is shown
+ * as a badge only - editing is driven by a follow-up chip rather than an
+ * inline modal to keep the card decoupled from the Security Solution
+ * provider tree.
+ */
+export const EntitySummaryGridMini: React.FC<EntitySummaryGridProps> = ({
+  entityId,
+  source,
+  assetCriticality,
+  watchlistIds,
+  watchlistsEnabled,
+}) => {
+  return (
+    <EuiFlexGrid columns={2} gutterSize="s" data-test-subj="entityAttachmentSummaryGrid">
+      <SummaryPanel label={LABELS.entityId} testSubj="entityAttachmentSummaryEntityId">
+        <EntityIdCell entityId={entityId} />
+      </SummaryPanel>
+      <SummaryPanel label={LABELS.dataSource} testSubj="entityAttachmentSummaryDataSource">
+        <EuiText size="s">{source ?? LABELS.empty}</EuiText>
+      </SummaryPanel>
+      <SummaryPanel
+        label={LABELS.assetCriticality}
+        testSubj="entityAttachmentSummaryAssetCriticality"
+      >
+        <AssetCriticalityBadge
+          criticalityLevel={assetCriticality ?? 'unassigned'}
+          dataTestSubj="entityAttachmentGridCriticalityBadge"
+        />
+      </SummaryPanel>
+      <SummaryPanel label={LABELS.watchlists} testSubj="entityAttachmentSummaryWatchlists">
+        <WatchlistsCell watchlistIds={watchlistIds} watchlistsEnabled={watchlistsEnabled} />
+      </SummaryPanel>
+    </EuiFlexGrid>
+  );
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/entity_card/identity_header.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/entity_card/identity_header.tsx
@@ -1,0 +1,104 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiAvatar, EuiBadge, EuiFlexGroup, EuiFlexItem, EuiText } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { EntityType } from '../../../../../common/entity_analytics/types';
+import { EntityIconByType } from '../../../../entity_analytics/components/entity_store/helpers';
+import { EntitySourceBadge } from '../../../../flyout/entity_details/shared/components/entity_source_badge';
+import { RiskLevelBadge } from '../../../../flyout/entity_details/shared/components/risk_level_badge';
+import { AssetCriticalityBadge } from '../../../../entity_analytics/components/asset_criticality/asset_criticality_badge';
+import type { CriticalityLevelWithUnassigned } from '../../../../../common/entity_analytics/asset_criticality/types';
+import type { RiskSeverity } from '../../../../../common/search_strategy';
+
+const ENTITY_TYPE_LABEL: Record<EntityType, string> = {
+  [EntityType.host]: i18n.translate(
+    'xpack.securitySolution.agentBuilder.entityAttachment.entityType.host',
+    { defaultMessage: 'Host' }
+  ),
+  [EntityType.user]: i18n.translate(
+    'xpack.securitySolution.agentBuilder.entityAttachment.entityType.user',
+    { defaultMessage: 'User' }
+  ),
+  [EntityType.service]: i18n.translate(
+    'xpack.securitySolution.agentBuilder.entityAttachment.entityType.service',
+    { defaultMessage: 'Service' }
+  ),
+  [EntityType.generic]: i18n.translate(
+    'xpack.securitySolution.agentBuilder.entityAttachment.entityType.generic',
+    { defaultMessage: 'Entity' }
+  ),
+};
+
+interface IdentityHeaderProps {
+  displayName: string;
+  entityType: EntityType;
+  isEntityInStore: boolean;
+  hasLastSeenDate: boolean;
+  assetCriticality?: CriticalityLevelWithUnassigned;
+  riskLevel?: RiskSeverity;
+}
+
+export const IdentityHeader: React.FC<IdentityHeaderProps> = ({
+  displayName,
+  entityType,
+  isEntityInStore,
+  hasLastSeenDate,
+  assetCriticality,
+  riskLevel,
+}) => {
+  return (
+    <EuiFlexGroup
+      gutterSize="s"
+      alignItems="center"
+      responsive={false}
+      data-test-subj="entityAttachmentIdentityHeader"
+    >
+      <EuiFlexItem grow={false}>
+        <EuiAvatar
+          name={displayName}
+          iconType={EntityIconByType[entityType]}
+          color="subdued"
+          size="m"
+        />
+      </EuiFlexItem>
+      <EuiFlexItem>
+        <EuiText size="s">
+          <strong data-test-subj="entityAttachmentIdentityName">{displayName}</strong>
+        </EuiText>
+        <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false} wrap>
+          <EuiFlexItem grow={false}>
+            <EuiBadge color="hollow" data-test-subj="entityAttachmentTypeBadge">
+              {ENTITY_TYPE_LABEL[entityType]}
+            </EuiBadge>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EntitySourceBadge
+              isEntityInStore={isEntityInStore}
+              hasLastSeenDate={hasLastSeenDate}
+              data-test-subj="entityAttachmentSourceBadge"
+            />
+          </EuiFlexItem>
+          {riskLevel && (
+            <EuiFlexItem grow={false} data-test-subj="entityAttachmentRiskLevelBadge">
+              <RiskLevelBadge riskLevel={riskLevel} />
+            </EuiFlexItem>
+          )}
+          {assetCriticality && assetCriticality !== 'unassigned' && (
+            <EuiFlexItem grow={false}>
+              <AssetCriticalityBadge
+                criticalityLevel={assetCriticality}
+                dataTestSubj="entityAttachmentCriticalityBadge"
+              />
+            </EuiFlexItem>
+          )}
+        </EuiFlexGroup>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/entity_card/resolution_mini.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/entity_card/resolution_mini.test.tsx
@@ -1,0 +1,84 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { I18nProvider } from '@kbn/i18n-react';
+import { useResolutionGroup } from '../../../../entity_analytics/components/entity_resolution/hooks/use_resolution_group';
+import { ResolutionMini } from './resolution_mini';
+
+jest.mock(
+  '../../../../entity_analytics/components/entity_resolution/hooks/use_resolution_group',
+  () => ({
+    useResolutionGroup: jest.fn(),
+  })
+);
+
+jest.mock(
+  '../../../../entity_analytics/components/entity_resolution/resolution_group_table',
+  () => ({
+    ResolutionGroupTable: (props: Record<string, unknown>) => (
+      <div
+        data-test-subj="resolutionGroupTableMock"
+        data-target-id={String(props.targetEntityId ?? '')}
+        data-show-actions={String(props.showActions)}
+        data-current-id={String(props.currentEntityId ?? '')}
+      />
+    ),
+  })
+);
+
+const mockedUseResolutionGroup = useResolutionGroup as jest.Mock;
+
+const renderMini = (props: Partial<React.ComponentProps<typeof ResolutionMini>> = {}) =>
+  render(
+    <I18nProvider>
+      <ResolutionMini
+        entityStoreEntityId="entity-1"
+        currentEntityStoreEntityId="entity-1"
+        {...props}
+      />
+    </I18nProvider>
+  );
+
+describe('ResolutionMini', () => {
+  beforeEach(() => {
+    mockedUseResolutionGroup.mockReset();
+  });
+
+  it('returns null when there is no entity id to query for', () => {
+    mockedUseResolutionGroup.mockReturnValue({ data: undefined, isLoading: false });
+    const { container } = renderMini({ entityStoreEntityId: undefined });
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('returns null when the resolution group is empty (group_size <= 1)', () => {
+    mockedUseResolutionGroup.mockReturnValue({
+      data: { target: {}, aliases: [], group_size: 1 },
+      isLoading: false,
+    });
+    const { container } = renderMini();
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders the accordion with the reused table when the group has aliases', () => {
+    mockedUseResolutionGroup.mockReturnValue({
+      data: {
+        target: { entity: { id: 'target-id' } },
+        aliases: [{ entity: { id: 'alias-id' } }],
+        group_size: 2,
+      },
+      isLoading: false,
+    });
+    renderMini();
+    expect(screen.getByTestId('entityAttachmentResolutionMini')).toBeInTheDocument();
+    const table = screen.getByTestId('resolutionGroupTableMock');
+    expect(table.getAttribute('data-target-id')).toBe('target-id');
+    expect(table.getAttribute('data-show-actions')).toBe('false');
+    expect(table.getAttribute('data-current-id')).toBe('entity-1');
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/entity_card/resolution_mini.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/entity_card/resolution_mini.tsx
@@ -1,0 +1,124 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import {
+  EuiAccordion,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiPanel,
+  EuiSpacer,
+  EuiText,
+  EuiTitle,
+  useGeneratedHtmlId,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { useResolutionGroup } from '../../../../entity_analytics/components/entity_resolution/hooks/use_resolution_group';
+import { ResolutionGroupTable } from '../../../../entity_analytics/components/entity_resolution/resolution_group_table';
+
+interface ResolutionMiniProps {
+  entityStoreEntityId?: string;
+  currentEntityStoreEntityId?: string;
+}
+
+const TITLE = i18n.translate(
+  'xpack.securitySolution.agentBuilder.entityAttachment.resolution.title',
+  { defaultMessage: 'Resolution group' }
+);
+
+const MEMBERS_LABEL = (count: number) =>
+  i18n.translate('xpack.securitySolution.agentBuilder.entityAttachment.resolution.membersLabel', {
+    defaultMessage: '{count, plural, one {# linked entity} other {# linked entities}}',
+    values: { count },
+  });
+
+const EMPTY_LABEL = i18n.translate(
+  'xpack.securitySolution.agentBuilder.entityAttachment.resolution.emptyLabel',
+  { defaultMessage: 'No resolution group yet.' }
+);
+
+/**
+ * Chat-scale recreation of the flyout's `ResolutionSection`. Reuses the
+ * shared `useResolutionGroup` hook + `ResolutionGroupTable` rendered in
+ * read-only mode (`showActions={false}`). Rebuilds only the accordion
+ * shell so we don't pull in `ExpandablePanel` / `useExpandableFlyoutApi`.
+ */
+export const ResolutionMini: React.FC<ResolutionMiniProps> = ({
+  entityStoreEntityId,
+  currentEntityStoreEntityId,
+}) => {
+  const accordionId = useGeneratedHtmlId({ prefix: 'entityAttachmentResolutionMini' });
+  const enabled = Boolean(entityStoreEntityId);
+
+  const {
+    data: group,
+    isLoading,
+    isError,
+  } = useResolutionGroup(entityStoreEntityId ?? '', {
+    enabled,
+  });
+
+  if (!enabled) {
+    return null;
+  }
+
+  const hasGroup = !!group && group.group_size > 1;
+  if (!isLoading && !isError && !hasGroup) {
+    return null;
+  }
+
+  const targetEntityId = group?.target
+    ? (group.target as { entity?: { id?: string } }).entity?.id ??
+      String((group.target as Record<string, unknown>)['entity.id'] ?? '')
+    : undefined;
+
+  return (
+    <EuiPanel
+      hasShadow={false}
+      hasBorder={false}
+      paddingSize="none"
+      data-test-subj="entityAttachmentResolutionMini"
+    >
+      <EuiAccordion
+        id={accordionId}
+        initialIsOpen={false}
+        buttonContent={
+          <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false} wrap>
+            <EuiFlexItem grow={false}>
+              <EuiTitle size="xxs">
+                <h4>{TITLE}</h4>
+              </EuiTitle>
+            </EuiFlexItem>
+            {hasGroup && (
+              <EuiFlexItem grow={false}>
+                <EuiText size="xs" color="subdued">
+                  {MEMBERS_LABEL(group.group_size)}
+                </EuiText>
+              </EuiFlexItem>
+            )}
+          </EuiFlexGroup>
+        }
+      >
+        <EuiSpacer size="s" />
+        {hasGroup || isLoading ? (
+          <ResolutionGroupTable
+            group={group ?? null}
+            isLoading={isLoading}
+            isError={isError}
+            targetEntityId={targetEntityId}
+            currentEntityId={currentEntityStoreEntityId}
+            showActions={false}
+          />
+        ) : (
+          <EuiText size="xs" color="subdued">
+            {EMPTY_LABEL}
+          </EuiText>
+        )}
+      </EuiAccordion>
+    </EuiPanel>
+  );
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/entity_card/risk_summary_mini.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/entity_card/risk_summary_mini.test.tsx
@@ -1,0 +1,85 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { I18nProvider } from '@kbn/i18n-react';
+import { EntityType } from '../../../../../common/entity_analytics/types';
+import type { RiskStats } from '../../../../../common/search_strategy';
+import { RiskSummaryMini } from './risk_summary_mini';
+
+jest.mock('../../../../entity_analytics/components/severity/common', () => ({
+  RiskScoreLevel: ({ severity }: { severity?: string }) => (
+    <span data-test-subj="riskScoreLevelMock">{severity}</span>
+  ),
+}));
+
+jest.mock('../../../../entity_analytics/components/home/entities_table/risk_score_cell', () => ({
+  RiskScoreCell: ({ riskScore }: { riskScore?: number }) => (
+    <span data-test-subj="riskScoreCellMock">
+      {typeof riskScore === 'number' ? riskScore : '—'}
+    </span>
+  ),
+}));
+
+const stats = (override: Partial<RiskStats> = {}): RiskStats =>
+  ({
+    '@timestamp': '2024-01-01T00:00:00Z',
+    id_field: 'user.name',
+    id_value: 'bob',
+    calculated_level: 'High',
+    calculated_score: 50,
+    calculated_score_norm: 80,
+    category_1_score: 40,
+    category_1_count: 3,
+    category_2_score: 10,
+    inputs: [],
+    notes: [],
+    rule_risks: [],
+    multipliers: [],
+    ...override,
+  } as unknown as RiskStats);
+
+const renderMini = (props: Partial<React.ComponentProps<typeof RiskSummaryMini>> = {}) =>
+  render(
+    <I18nProvider>
+      <RiskSummaryMini
+        entityType={EntityType.user}
+        displayName="bob"
+        riskScore={80}
+        riskLevel="High"
+        riskStats={stats()}
+        privmonModifierEnabled
+        watchlistEnabled
+        {...props}
+      />
+    </I18nProvider>
+  );
+
+describe('RiskSummaryMini', () => {
+  it('renders the summary with the entity risk score block and contributions table', () => {
+    renderMini();
+    expect(screen.getByTestId('entityAttachmentRiskSummaryMini')).toBeInTheDocument();
+    expect(screen.getByTestId('entityAttachmentEntityRiskScoreBlock')).toBeInTheDocument();
+    expect(screen.getByTestId('entityAttachmentRiskContributionsTable')).toBeInTheDocument();
+  });
+
+  it('returns null when there is no risk data', () => {
+    const { container } = renderMini({ riskScore: undefined, riskStats: undefined });
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('shows a resolution score block when resolution risk data is provided', () => {
+    renderMini({
+      resolutionRiskScore: 65,
+      resolutionRiskLevel: 'Moderate',
+      resolutionRiskStats: stats({ calculated_score_norm: 65, calculated_level: 'Moderate' }),
+    });
+    expect(screen.getByTestId('entityAttachmentResolutionRiskScoreBlock')).toBeInTheDocument();
+    expect(screen.getByTestId('entityAttachmentResolutionContributionsTable')).toBeInTheDocument();
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/entity_card/risk_summary_mini.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/entity_card/risk_summary_mini.tsx
@@ -1,0 +1,198 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useMemo } from 'react';
+import {
+  EuiBasicTable,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiHorizontalRule,
+  EuiPanel,
+  EuiSpacer,
+  EuiText,
+  EuiTitle,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { capitalize } from 'lodash/fp';
+import type { EntityType } from '../../../../../common/entity_analytics/types';
+import type { RiskStats, RiskSeverity } from '../../../../../common/search_strategy';
+import { RiskScoreCell } from '../../../../entity_analytics/components/home/entities_table/risk_score_cell';
+import { RiskScoreLevel } from '../../../../entity_analytics/components/severity/common';
+import {
+  columnsArray,
+  getItems,
+} from '../../../../entity_analytics/components/risk_summary_flyout/common';
+
+interface RiskSummaryMiniProps {
+  entityType: EntityType;
+  displayName: string;
+  riskScore?: number;
+  riskLevel?: RiskSeverity;
+  riskStats?: RiskStats;
+  resolutionRiskScore?: number;
+  resolutionRiskLevel?: RiskSeverity;
+  resolutionRiskStats?: RiskStats;
+  privmonModifierEnabled: boolean;
+  watchlistEnabled: boolean;
+}
+
+const TITLE = (entityType: EntityType) =>
+  i18n.translate('xpack.securitySolution.agentBuilder.entityAttachment.risk.title', {
+    defaultMessage: '{entity} risk summary',
+    values: { entity: capitalize(entityType) },
+  });
+
+const ENTITY_RISK_LABEL = i18n.translate(
+  'xpack.securitySolution.agentBuilder.entityAttachment.risk.entityScore',
+  { defaultMessage: 'Entity risk score' }
+);
+
+const RESOLUTION_RISK_LABEL = i18n.translate(
+  'xpack.securitySolution.agentBuilder.entityAttachment.risk.resolutionGroupScore',
+  { defaultMessage: 'Resolution group risk score' }
+);
+
+const ScoreBlock: React.FC<{
+  label: string;
+  score?: number;
+  level?: RiskSeverity;
+  testSubj: string;
+}> = ({ label, score, level, testSubj }) => (
+  <EuiPanel hasBorder paddingSize="s" data-test-subj={testSubj}>
+    <EuiText size="xs" color="subdued">
+      {label}
+    </EuiText>
+    <EuiSpacer size="xs" />
+    <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false} wrap>
+      <EuiFlexItem grow={false}>
+        <EuiTitle size="xs">
+          <h4>
+            <RiskScoreCell riskScore={score} />
+          </h4>
+        </EuiTitle>
+      </EuiFlexItem>
+      {level && (
+        <EuiFlexItem grow={false}>
+          <RiskScoreLevel severity={level} />
+        </EuiFlexItem>
+      )}
+    </EuiFlexGroup>
+  </EuiPanel>
+);
+
+const ContributionsTable: React.FC<{
+  displayName: string;
+  riskStats?: RiskStats;
+  privmonModifierEnabled: boolean;
+  watchlistEnabled: boolean;
+  testSubj: string;
+}> = ({ displayName, riskStats, privmonModifierEnabled, watchlistEnabled, testSubj }) => {
+  const items = useMemo(
+    () =>
+      getItems(
+        riskStats ? { name: displayName, risk: riskStats } : undefined,
+        privmonModifierEnabled,
+        watchlistEnabled
+      ),
+    [displayName, riskStats, privmonModifierEnabled, watchlistEnabled]
+  );
+
+  return (
+    <EuiBasicTable
+      data-test-subj={testSubj}
+      responsiveBreakpoint={false}
+      columns={columnsArray}
+      items={items}
+      compressed
+    />
+  );
+};
+
+/**
+ * Chat-scale recreation of the flyout's `FlyoutRiskSummary`. Uses the risk
+ * stats embedded on the entity store record (fed by `useEntityForAttachment`)
+ * instead of the heavy `useRiskScore` search-strategy hook so it works
+ * outside the Security Solution Redux store. Visuals (score block + basic
+ * table of Category/Score/Inputs) match the flyout so users see the same
+ * data in chat and in the flyout.
+ */
+export const RiskSummaryMini: React.FC<RiskSummaryMiniProps> = ({
+  entityType,
+  displayName,
+  riskScore,
+  riskLevel,
+  riskStats,
+  resolutionRiskScore,
+  resolutionRiskLevel,
+  resolutionRiskStats,
+  privmonModifierEnabled,
+  watchlistEnabled,
+}) => {
+  if (!riskStats && riskScore == null) {
+    return null;
+  }
+
+  const showResolution =
+    !!resolutionRiskStats || resolutionRiskScore != null || !!resolutionRiskLevel;
+
+  return (
+    <EuiPanel
+      hasShadow={false}
+      hasBorder={false}
+      paddingSize="none"
+      data-test-subj="entityAttachmentRiskSummaryMini"
+    >
+      <EuiTitle size="xs">
+        <h3>{TITLE(entityType)}</h3>
+      </EuiTitle>
+      <EuiSpacer size="s" />
+      <EuiFlexGroup gutterSize="s" direction="row" wrap>
+        <EuiFlexItem grow={1} style={{ minWidth: 160 }}>
+          <ScoreBlock
+            label={ENTITY_RISK_LABEL}
+            score={riskScore}
+            level={riskLevel}
+            testSubj="entityAttachmentEntityRiskScoreBlock"
+          />
+        </EuiFlexItem>
+        <EuiFlexItem grow={2} style={{ minWidth: 220 }}>
+          <ContributionsTable
+            displayName={displayName}
+            riskStats={riskStats}
+            privmonModifierEnabled={privmonModifierEnabled}
+            watchlistEnabled={watchlistEnabled}
+            testSubj="entityAttachmentRiskContributionsTable"
+          />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+      {showResolution && (
+        <>
+          <EuiHorizontalRule margin="s" />
+          <EuiFlexGroup gutterSize="s" direction="row" wrap>
+            <EuiFlexItem grow={1} style={{ minWidth: 160 }}>
+              <ScoreBlock
+                label={RESOLUTION_RISK_LABEL}
+                score={resolutionRiskScore}
+                level={resolutionRiskLevel}
+                testSubj="entityAttachmentResolutionRiskScoreBlock"
+              />
+            </EuiFlexItem>
+            <EuiFlexItem grow={2} style={{ minWidth: 220 }}>
+              <ContributionsTable
+                displayName={displayName}
+                riskStats={resolutionRiskStats}
+                privmonModifierEnabled={privmonModifierEnabled}
+                watchlistEnabled={watchlistEnabled}
+                testSubj="entityAttachmentResolutionContributionsTable"
+              />
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </>
+      )}
+    </EuiPanel>
+  );
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/entity_table/entity_data_source_utils.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/entity_table/entity_data_source_utils.test.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { formatEntitySource } from './entity_data_source_utils';
+
+describe('formatEntitySource', () => {
+  it('capitalises a single-word integration key', () => {
+    expect(formatEntitySource('crowdstrike')).toBe('Crowdstrike');
+  });
+
+  it('splits underscores and capitalises each word', () => {
+    expect(formatEntitySource('island_browser')).toBe('Island Browser');
+  });
+
+  it('handles multi-segment integration keys', () => {
+    expect(formatEntitySource('microsoft_defender_for_endpoint')).toBe(
+      'Microsoft Defender For Endpoint'
+    );
+  });
+
+  it('drops empty segments produced by leading/trailing/double underscores', () => {
+    expect(formatEntitySource('_okta__ad_')).toBe('Okta Ad');
+  });
+
+  it('leaves an empty string untouched', () => {
+    expect(formatEntitySource('')).toBe('');
+  });
+
+  it('preserves casing past the first letter (does not lower-case interior letters)', () => {
+    expect(formatEntitySource('AzureAD')).toBe('AzureAD');
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/entity_table/entity_data_source_utils.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/entity_table/entity_data_source_utils.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * Pretty-print an `entity.source` value for display. The entity store keeps
+ * sources as lowercase integration keys (e.g. `crowdstrike`, `island_browser`).
+ * The chat table renders them as title-cased labels with underscores swapped
+ * for spaces so they read like product names. Filters issued back to the tool
+ * still need to use the raw key — see `entity_analytics_skill.ts`.
+ *
+ * Examples:
+ * - `crowdstrike` → `Crowdstrike`
+ * - `island_browser` → `Island Browser`
+ * - `microsoft_defender_for_endpoint` → `Microsoft Defender For Endpoint`
+ * - `''` → `''`
+ */
+export const formatEntitySource = (value: string): string =>
+  value
+    .split('_')
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/entity_table/entity_table.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/entity_table/entity_table.test.tsx
@@ -1,0 +1,419 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { I18nProvider } from '@kbn/i18n-react';
+import type { ApplicationStart } from '@kbn/core-application-browser';
+import type { ISessionService } from '@kbn/data-plugin/public';
+import { useKibana } from '@kbn/kibana-react-plugin/public';
+import { EntityType } from '../../../../../common/entity_analytics/types';
+import type { EntityForAttachment } from '../use_entity_for_attachment';
+import { useEntityForAttachment } from '../use_entity_for_attachment';
+import {
+  navigateToEntityAnalyticsHomePageInApp,
+  navigateToEntityAnalyticsWithFlyoutInApp,
+} from '../../entity_explore_navigation';
+import { EntityTable } from './entity_table';
+
+jest.mock('../use_entity_for_attachment', () => ({
+  useEntityForAttachment: jest.fn(),
+}));
+
+jest.mock('@kbn/kibana-react-plugin/public', () => ({
+  useKibana: jest.fn(),
+}));
+
+jest.mock('../../entity_explore_navigation', () => {
+  const actual = jest.requireActual('../../entity_explore_navigation');
+  return {
+    ...actual,
+    navigateToEntityAnalyticsWithFlyoutInApp: jest.fn(),
+    navigateToEntityAnalyticsHomePageInApp: jest.fn(),
+  };
+});
+
+const mockedUseEntityForAttachment = useEntityForAttachment as jest.Mock;
+const mockedUseKibana = useKibana as jest.Mock;
+const mockedNavigateToFlyout = navigateToEntityAnalyticsWithFlyoutInApp as jest.Mock;
+const mockedNavigateToHome = navigateToEntityAnalyticsHomePageInApp as jest.Mock;
+
+const baseEntityData = (override: Partial<EntityForAttachment> = {}): EntityForAttachment => ({
+  entityType: EntityType.host,
+  displayName: 'host-1',
+  entityId: 'entity-id-host-1',
+  isEntityInStore: true,
+  firstSeen: null,
+  lastSeen: '2024-01-01T00:00:00Z',
+  timestamp: '2024-01-01T00:00:00Z',
+  riskScore: 42,
+  riskLevel: 'Low',
+  watchlistIds: [],
+  sources: ['endpoint.events.process'],
+  ...override,
+});
+
+const renderTable = (props: Partial<React.ComponentProps<typeof EntityTable>> = {}) =>
+  render(
+    <I18nProvider>
+      <EntityTable
+        entities={[
+          { identifierType: 'host', identifier: 'host-1' },
+          { identifierType: 'user', identifier: 'bob' },
+        ]}
+        {...props}
+      />
+    </I18nProvider>
+  );
+
+describe('EntityTable', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedUseKibana.mockReturnValue({
+      services: { application: { navigateToApp: jest.fn() } },
+    });
+    mockedUseEntityForAttachment.mockReturnValue({
+      data: baseEntityData(),
+      isLoading: false,
+      error: null,
+      refetch: jest.fn(),
+    });
+  });
+
+  it('renders one row per entity with its display name', () => {
+    renderTable();
+    const cells = screen.getAllByTestId('entityAttachmentTableName');
+    expect(cells).toHaveLength(2);
+    expect(cells[0].textContent).toContain('host-1');
+  });
+
+  it('keeps the footer "Open Entity Analytics" button visible', () => {
+    renderTable();
+    expect(screen.getByTestId('entityAttachmentTableOpenEntityAnalytics')).toBeInTheDocument();
+  });
+
+  describe('per-row Explore button', () => {
+    it('does not render when no application prop or kibana.services.application is available', () => {
+      // Simulates the embedding environment where the attachment is rendered outside
+      // `KibanaContextProvider`: `useKibana().services.application` is undefined and no
+      // `application` prop is passed, so per-row Explore must be hidden.
+      mockedUseKibana.mockReturnValue({ services: {} });
+      renderTable({ entities: [{ identifierType: 'host', identifier: 'host-1' }] });
+      expect(screen.queryAllByTestId('entityAttachmentTableOpenEntity')).toHaveLength(0);
+    });
+
+    it('renders when application is passed explicitly', () => {
+      const application = { navigateToApp: jest.fn() } as unknown as ApplicationStart;
+      renderTable({ application });
+      const buttons = screen.getAllByTestId('entityAttachmentTableOpenEntity');
+      expect(buttons.length).toBeGreaterThan(0);
+    });
+
+    it('opens the Entity Analytics flyout with the HostPanelKey payload for host rows', () => {
+      mockedUseEntityForAttachment.mockReturnValue({
+        data: baseEntityData({
+          entityId: 'host:macbook-01@default',
+          displayName: 'Resolved Host',
+        }),
+        isLoading: false,
+        error: null,
+        refetch: jest.fn(),
+      });
+      const application = { navigateToApp: jest.fn() } as unknown as ApplicationStart;
+
+      renderTable({
+        entities: [{ identifierType: 'host', identifier: 'host-1' }],
+        application,
+      });
+
+      fireEvent.click(screen.getAllByTestId('entityAttachmentTableOpenEntity')[0]);
+
+      expect(mockedNavigateToFlyout).toHaveBeenCalledTimes(1);
+      expect(mockedNavigateToHome).not.toHaveBeenCalled();
+      const args = mockedNavigateToFlyout.mock.calls[0][0];
+      expect(args.application).toBe(application);
+      expect(args.flyout).toEqual({
+        preview: [],
+        right: {
+          id: 'host-panel',
+          params: {
+            contextID: 'agent-builder-entity-card',
+            scopeId: 'agent-builder-entity-card',
+            hostName: 'Resolved Host',
+            entityId: 'host:macbook-01@default',
+          },
+        },
+      });
+    });
+
+    it('opens the Entity Analytics flyout with the UserPanelKey payload for user rows', () => {
+      mockedUseEntityForAttachment.mockReturnValue({
+        data: baseEntityData({
+          entityType: EntityType.user,
+          entityId: 'user:bob@acme@default',
+          displayName: 'bob',
+        }),
+        isLoading: false,
+        error: null,
+        refetch: jest.fn(),
+      });
+      const application = { navigateToApp: jest.fn() } as unknown as ApplicationStart;
+
+      renderTable({
+        entities: [{ identifierType: 'user', identifier: 'bob' }],
+        application,
+      });
+
+      fireEvent.click(screen.getAllByTestId('entityAttachmentTableOpenEntity')[0]);
+
+      expect(mockedNavigateToFlyout).toHaveBeenCalledTimes(1);
+      expect(mockedNavigateToFlyout.mock.calls[0][0].flyout).toEqual({
+        preview: [],
+        right: {
+          id: 'user-panel',
+          params: {
+            contextID: 'agent-builder-entity-card',
+            scopeId: 'agent-builder-entity-card',
+            userName: 'bob',
+            identityFields: { 'user.name': 'bob' },
+            entityId: 'user:bob@acme@default',
+          },
+        },
+      });
+    });
+
+    it('opens the Entity Analytics flyout with the ServicePanelKey payload for service rows', () => {
+      mockedUseEntityForAttachment.mockReturnValue({
+        data: baseEntityData({
+          entityType: EntityType.service,
+          entityId: 'service:auth-svc@default',
+          displayName: 'auth-svc',
+        }),
+        isLoading: false,
+        error: null,
+        refetch: jest.fn(),
+      });
+      const application = { navigateToApp: jest.fn() } as unknown as ApplicationStart;
+
+      renderTable({
+        entities: [{ identifierType: 'service', identifier: 'auth-svc' }],
+        application,
+      });
+
+      fireEvent.click(screen.getAllByTestId('entityAttachmentTableOpenEntity')[0]);
+
+      expect(mockedNavigateToFlyout).toHaveBeenCalledTimes(1);
+      expect(mockedNavigateToFlyout.mock.calls[0][0].flyout).toEqual({
+        preview: [],
+        right: {
+          id: 'service-panel',
+          params: {
+            contextID: 'agent-builder-entity-card',
+            scopeId: 'agent-builder-entity-card',
+            serviceName: 'auth-svc',
+            entityId: 'service:auth-svc@default',
+          },
+        },
+      });
+    });
+
+    it('forwards the searchSession prop to navigateToEntityAnalyticsWithFlyoutInApp when clicked', () => {
+      const application = { navigateToApp: jest.fn() } as unknown as ApplicationStart;
+      const searchSession = { clear: jest.fn() } as unknown as ISessionService;
+
+      renderTable({
+        entities: [{ identifierType: 'host', identifier: 'host-1' }],
+        application,
+        searchSession,
+      });
+
+      fireEvent.click(screen.getAllByTestId('entityAttachmentTableOpenEntity')[0]);
+
+      expect(mockedNavigateToFlyout).toHaveBeenCalledTimes(1);
+      expect(mockedNavigateToFlyout.mock.calls[0][0].searchSession).toBe(searchSession);
+    });
+
+    it('uses the attachment entityStoreId when useEntityForAttachment has not resolved yet', () => {
+      mockedUseEntityForAttachment.mockReturnValue({
+        data: null,
+        isLoading: true,
+        error: null,
+        refetch: jest.fn(),
+      });
+      const application = { navigateToApp: jest.fn() } as unknown as ApplicationStart;
+
+      renderTable({
+        entities: [{ identifierType: 'user', identifier: 'bob', entityStoreId: 'user:bob@local' }],
+        application,
+      });
+
+      fireEvent.click(screen.getAllByTestId('entityAttachmentTableOpenEntity')[0]);
+
+      expect(mockedNavigateToFlyout).toHaveBeenCalledTimes(1);
+      expect(mockedNavigateToFlyout.mock.calls[0][0].flyout.right).toEqual({
+        id: 'user-panel',
+        params: {
+          contextID: 'agent-builder-entity-card',
+          scopeId: 'agent-builder-entity-card',
+          userName: 'bob',
+          identityFields: { 'user.name': 'bob' },
+          entityId: 'user:bob@local',
+        },
+      });
+    });
+
+    it('falls back to the unfiltered Entity Analytics home when a flyout-capable row has no entityStoreId', () => {
+      mockedUseEntityForAttachment.mockReturnValue({
+        data: null,
+        isLoading: false,
+        error: null,
+        refetch: jest.fn(),
+      });
+      const application = { navigateToApp: jest.fn() } as unknown as ApplicationStart;
+      const searchSession = { clear: jest.fn() } as unknown as ISessionService;
+
+      renderTable({
+        entities: [{ identifierType: 'host', identifier: 'orphan-host' }],
+        application,
+        searchSession,
+      });
+
+      fireEvent.click(screen.getAllByTestId('entityAttachmentTableOpenEntity')[0]);
+
+      expect(mockedNavigateToHome).toHaveBeenCalledTimes(1);
+      expect(mockedNavigateToFlyout).not.toHaveBeenCalled();
+      expect(mockedNavigateToHome.mock.calls[0][0].application).toBe(application);
+      expect(mockedNavigateToHome.mock.calls[0][0].searchSession).toBe(searchSession);
+    });
+
+    it('falls back to the unfiltered Entity Analytics home for generic entities (no dedicated flyout)', () => {
+      mockedUseEntityForAttachment.mockReturnValue({
+        data: null,
+        isLoading: false,
+        error: null,
+        refetch: jest.fn(),
+      });
+      const application = { navigateToApp: jest.fn() } as unknown as ApplicationStart;
+
+      renderTable({
+        entities: [
+          {
+            identifierType: 'generic',
+            identifier: 'some-id',
+            entityStoreId: 'generic:some-id@default',
+          },
+        ],
+        application,
+      });
+
+      fireEvent.click(screen.getAllByTestId('entityAttachmentTableOpenEntity')[0]);
+
+      expect(mockedNavigateToHome).toHaveBeenCalledTimes(1);
+      expect(mockedNavigateToFlyout).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('duplicate entity.name with distinct entityStoreId', () => {
+    // Regression: two local service accounts share `entity.name` ("okta") but
+    // have distinct `entity.id`s. Keying rows by `identifier` alone caused the
+    // shared `rowsByKey` slot to be overwritten by whichever fetch resolved
+    // last, so every row rendered with the same entity's data. Keying off
+    // `entityStoreId` (when present) keeps the rows distinct.
+    it('renders each row with its own resolved data instead of clobbering the shared slot', () => {
+      const storeIdA = 'user:okta@i-aaaaaaaaaaaaaaaaa@local';
+      const storeIdB = 'user:okta@i-bbbbbbbbbbbbbbbbb@local';
+
+      // Cache one stable hook result per entityStoreId so the data reference
+      // does not change between re-renders. Without caching, every render
+      // produces a fresh `data` object, which fires `EntityRowLoader`'s
+      // `useEffect` → `setRowsByKey` loop indefinitely.
+      const resultByStoreId: Record<string, ReturnType<typeof mockedUseEntityForAttachment>> = {
+        [storeIdA]: {
+          data: baseEntityData({
+            entityType: EntityType.user,
+            displayName: 'okta',
+            entityId: storeIdA,
+          }),
+          isLoading: false,
+          error: null,
+          refetch: jest.fn(),
+        },
+        [storeIdB]: {
+          data: baseEntityData({
+            entityType: EntityType.user,
+            displayName: 'okta',
+            entityId: storeIdB,
+          }),
+          isLoading: false,
+          error: null,
+          refetch: jest.fn(),
+        },
+      };
+
+      mockedUseEntityForAttachment.mockImplementation(
+        (identifier: { entityStoreId?: string }) =>
+          (identifier.entityStoreId && resultByStoreId[identifier.entityStoreId]) || {
+            data: null,
+            isLoading: false,
+            error: null,
+            refetch: jest.fn(),
+          }
+      );
+
+      const application = { navigateToApp: jest.fn() } as unknown as ApplicationStart;
+
+      renderTable({
+        entities: [
+          { identifierType: 'user', identifier: 'okta', entityStoreId: storeIdA },
+          { identifierType: 'user', identifier: 'okta', entityStoreId: storeIdB },
+        ],
+        application,
+      });
+
+      const exploreButtons = screen.getAllByTestId('entityAttachmentTableOpenEntity');
+      expect(exploreButtons).toHaveLength(2);
+
+      fireEvent.click(exploreButtons[0]);
+      fireEvent.click(exploreButtons[1]);
+
+      expect(mockedNavigateToFlyout).toHaveBeenCalledTimes(2);
+      expect(mockedNavigateToFlyout.mock.calls[0][0].flyout.right.params.entityId).toBe(storeIdA);
+      expect(mockedNavigateToFlyout.mock.calls[1][0].flyout.right.params.entityId).toBe(storeIdB);
+    });
+  });
+
+  describe('pagination-aware row loading', () => {
+    // Regression: `EntityRowLoader` fans out one HTTP request per identifier. A
+    // chat round with many entities used to fire all of them on mount because
+    // the loader was rendered for `entities` (full list) rather than
+    // `pagedItems` (current page slice). Only the visible page should fetch;
+    // additional pages lazy-load as the user navigates.
+    it('only calls useEntityForAttachment for identifiers on the current page', () => {
+      const identifiers = Array.from({ length: 12 }, (_, i) => ({
+        identifierType: 'host' as const,
+        identifier: `host-${i}`,
+      }));
+
+      mockedUseEntityForAttachment.mockReturnValue({
+        data: null,
+        isLoading: true,
+        error: null,
+        refetch: jest.fn(),
+      });
+
+      renderTable({ entities: identifiers });
+
+      const calledIdentifiers = mockedUseEntityForAttachment.mock.calls.map(
+        ([identifier]: [{ identifier: string }]) => identifier.identifier
+      );
+      const unique = new Set(calledIdentifiers);
+      expect(unique.size).toBe(10);
+      expect(unique.has('host-10')).toBe(false);
+      expect(unique.has('host-11')).toBe(false);
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/entity_table/entity_table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/entity_table/entity_table.tsx
@@ -1,0 +1,520 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useCallback, useMemo, useState } from 'react';
+import {
+  EuiBadge,
+  EuiBasicTable,
+  EuiButtonEmpty,
+  EuiButtonIcon,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiPanel,
+  EuiSkeletonText,
+  EuiText,
+  EuiToolTip,
+} from '@elastic/eui';
+import type { Criteria, EuiBasicTableColumn } from '@elastic/eui';
+import { css } from '@emotion/react';
+import { i18n } from '@kbn/i18n';
+import { useKibana } from '@kbn/kibana-react-plugin/public';
+import type { ApplicationStart } from '@kbn/core-application-browser';
+import type { ISessionService } from '@kbn/data-plugin/public';
+import { APP_UI_ID, ENTITY_ANALYTICS_PATH } from '../../../../../common/constants';
+import { EntityType } from '../../../../../common/entity_analytics/types';
+import { AssetCriticalityBadge } from '../../../../entity_analytics/components/asset_criticality/asset_criticality_badge';
+import { RiskScoreCell } from '../../../../entity_analytics/components/home/entities_table/risk_score_cell';
+import { EntitySourceBadge } from '../../../../flyout/entity_details/shared/components/entity_source_badge';
+import { TruncatedBadgeList } from '../../../../flyout/entity_details/shared/components/entity_source_value';
+import { FormattedRelativePreferenceDate } from '../../../../common/components/formatted_date';
+import { EntityIconByType } from '../../../../entity_analytics/components/entity_store/helpers';
+import { useEntityForAttachment } from '../use_entity_for_attachment';
+import type { EntityForAttachment } from '../use_entity_for_attachment';
+import type { EntityAttachmentIdentifier } from '../types';
+import { formatEntitySource } from './entity_data_source_utils';
+import {
+  buildEntityRightPanel,
+  navigateToEntityAnalyticsHomePageInApp,
+  navigateToEntityAnalyticsWithFlyoutInApp,
+} from '../../entity_explore_navigation';
+
+export interface EntityTableProps {
+  entities: EntityAttachmentIdentifier[];
+  /**
+   * When provided, the Name column renders a per-row Explore icon that deep-links into the
+   * Security Solution Hosts/Users/Services page for that entity (mirrors the dashboard
+   * `EntityListTable`). Omit in tests or environments without Kibana routing.
+   */
+  application?: ApplicationStart;
+  /**
+   * Optional search session service. Forwarded to the shared `navigateTo…InApp` helpers so the
+   * active Agent Builder-tagged search session is cleared before the cross-app jump into the
+   * Entity Analytics flyout.
+   */
+  searchSession?: ISessionService;
+}
+
+interface EntityRow {
+  identifier: EntityAttachmentIdentifier;
+  data?: EntityForAttachment;
+  isLoading: boolean;
+}
+
+const PAGE_SIZE = 10;
+
+/**
+ * Horizontal scroll wrapper for the table. The agent chat panel can be
+ * narrower than the sum of the table's columns, so we keep the table at a
+ * readable minimum width and let it overflow with a scrollbar instead of
+ * squeezing the Name column into character-by-character wrapping.
+ *
+ * Pagination overrides: when the attachment is rendered inside a chat round,
+ * the message content sits inside an `EuiText` + `EuiMarkdownFormat` scope
+ * that forces `ul { list-style: disc; margin-inline-start: 1.7143rem; }` onto
+ * every nested list. EuiPagination renders its buttons inside a
+ * `<ul class="euiPagination__list">`, so the inherited rules turn each
+ * `<li>` into a visible bullet — the stray dark dot that shows up between
+ * the "previous" chevron and the first page button — and push the whole
+ * list to the right with a markdown-list indent. We also zero out any
+ * background/outline on the active-page `EuiPaginationButton` so that
+ * chat-scope styles (e.g. disabled-button tints inherited from ancestor
+ * themes) do not render as a circular "disc" behind the active page
+ * number. Scoped to this wrapper so the overrides only affect the entity
+ * attachment table's pagination.
+ */
+const tableScrollStyles = css`
+  overflow-x: auto;
+
+  .euiTable {
+    min-width: 800px;
+  }
+
+  .euiPagination__list,
+  .euiPagination__list .euiPagination__item {
+    list-style: none;
+    margin: 0;
+    margin-inline-start: 0;
+    padding-inline-start: 0;
+  }
+
+  .euiPagination__list .euiPagination__item::marker,
+  .euiPagination__list .euiPagination__item::before {
+    content: none;
+  }
+
+  .euiPaginationButton[aria-current='page'],
+  .euiPaginationButton[aria-current='page']::before,
+  .euiPaginationButton[aria-current='page']::after {
+    background: transparent;
+    background-color: transparent;
+    box-shadow: none;
+    outline: none;
+  }
+`;
+
+const COLUMN_LABELS = {
+  name: i18n.translate('xpack.securitySolution.agentBuilder.entityAttachment.table.name', {
+    defaultMessage: 'Name',
+  }),
+  type: i18n.translate('xpack.securitySolution.agentBuilder.entityAttachment.table.type', {
+    defaultMessage: 'Type',
+  }),
+  riskScore: i18n.translate(
+    'xpack.securitySolution.agentBuilder.entityAttachment.table.riskScore',
+    { defaultMessage: 'Risk score' }
+  ),
+  criticality: i18n.translate(
+    'xpack.securitySolution.agentBuilder.entityAttachment.table.criticality',
+    { defaultMessage: 'Criticality' }
+  ),
+  dataSource: i18n.translate(
+    'xpack.securitySolution.agentBuilder.entityAttachment.table.dataSource',
+    { defaultMessage: 'Data source' }
+  ),
+  lastSeen: i18n.translate('xpack.securitySolution.agentBuilder.entityAttachment.table.lastSeen', {
+    defaultMessage: 'Last seen',
+  }),
+};
+
+const NAME_TOOLTIP_NO_ENTITY_ID = i18n.translate(
+  'xpack.securitySolution.agentBuilder.entityAttachment.table.nameTooltipNoEntityId',
+  { defaultMessage: 'Entity id not available' }
+);
+
+const SOURCES_OVERFLOW_TOOLTIP_TITLE = i18n.translate(
+  'xpack.securitySolution.agentBuilder.entityAttachment.table.dataSourceOverflowTitle',
+  { defaultMessage: 'Additional data sources' }
+);
+
+const LAST_SEEN_TOOLTIP_FIELD_NAME = '@timestamp';
+
+const OPEN_ENTITY_ANALYTICS_LABEL = i18n.translate(
+  'xpack.securitySolution.agentBuilder.entityAttachment.table.openEntityAnalytics',
+  { defaultMessage: 'Open Entity Analytics' }
+);
+
+const OPEN_ENTITY_IN_ENTITY_ANALYTICS_ARIA = i18n.translate(
+  'xpack.securitySolution.agentBuilder.entityAttachment.table.openEntityInEntityAnalyticsAria',
+  { defaultMessage: 'Open entity in Entity Analytics' }
+);
+
+const identifierTypeToEntityType = (
+  type: EntityAttachmentIdentifier['identifierType']
+): EntityType => {
+  switch (type) {
+    case 'host':
+      return EntityType.host;
+    case 'user':
+      return EntityType.user;
+    case 'service':
+      return EntityType.service;
+    case 'generic':
+    default:
+      return EntityType.generic;
+  }
+};
+
+const entityTypeLabels: Record<EntityType, string> = {
+  [EntityType.host]: i18n.translate(
+    'xpack.securitySolution.agentBuilder.entityAttachment.entityType.host',
+    { defaultMessage: 'Host' }
+  ),
+  [EntityType.user]: i18n.translate(
+    'xpack.securitySolution.agentBuilder.entityAttachment.entityType.user',
+    { defaultMessage: 'User' }
+  ),
+  [EntityType.service]: i18n.translate(
+    'xpack.securitySolution.agentBuilder.entityAttachment.entityType.service',
+    { defaultMessage: 'Service' }
+  ),
+  [EntityType.generic]: i18n.translate(
+    'xpack.securitySolution.agentBuilder.entityAttachment.entityType.generic',
+    { defaultMessage: 'Entity' }
+  ),
+};
+
+/**
+ * Per-row loader. Keeps `useEntityForAttachment` one-per-component-instance
+ * (Rules of Hooks) while letting the table re-render progressively as each
+ * entity resolves. The parent owns the row map and merges results.
+ */
+const EntityRowLoader: React.FC<{
+  identifier: EntityAttachmentIdentifier;
+  onLoaded: (identifier: EntityAttachmentIdentifier, result: EntityRow) => void;
+}> = ({ identifier, onLoaded }) => {
+  const { data, isLoading } = useEntityForAttachment(identifier);
+
+  React.useEffect(() => {
+    onLoaded(identifier, { identifier, data: data ?? undefined, isLoading });
+  }, [identifier, data, isLoading, onLoaded]);
+
+  return null;
+};
+
+/**
+ * Renders the resolved data sources for an entity row. Shows the first
+ * formatted source as a hollow badge and collapses any overflow into a single
+ * `+N more` badge whose tooltip lists the remaining sources. When no sources
+ * are available we fall back to the legacy `EntitySourceBadge` so the column
+ * still surfaces an "Entity Store" / "Observed" hint for older records.
+ *
+ * The inline value count matches the Entity Analytics flyout + entities table
+ * (`TruncatedBadgeList` default) so the same `entity.source` renders
+ * identically everywhere it appears in the Security Solution.
+ */
+const EntityDataSourceBadges: React.FC<{
+  sources: string[] | undefined;
+  isEntityInStore: boolean;
+  hasLastSeenDate: boolean;
+}> = ({ sources, isEntityInStore, hasLastSeenDate }) => {
+  const list = sources ?? [];
+
+  if (list.length === 0) {
+    return (
+      <EntitySourceBadge
+        isEntityInStore={isEntityInStore}
+        hasLastSeenDate={hasLastSeenDate}
+        data-test-subj="entityAttachmentTableSource"
+      />
+    );
+  }
+
+  return (
+    <TruncatedBadgeList
+      values={list}
+      formatValue={formatEntitySource}
+      overflowTooltipTitle={SOURCES_OVERFLOW_TOOLTIP_TITLE}
+      data-test-subj="entityAttachmentTableSources"
+    />
+  );
+};
+
+export const EntityTable: React.FC<EntityTableProps> = ({
+  entities,
+  application,
+  searchSession,
+}) => {
+  const { services } = useKibana<{ application: ApplicationStart }>();
+  const exploreApplication = application ?? services.application;
+  const canExplorePerRow = exploreApplication != null;
+  const [pageIndex, setPageIndex] = useState(0);
+  const [rowsByKey, setRowsByKey] = useState<Record<string, EntityRow>>({});
+
+  /**
+   * Stable per-row key for React reconciliation, `rowsByKey` lookups, and the
+   * EuiBasicTable `itemId`. When the attachment carries a canonical
+   * `entityStoreId` (always present for modern attachments emitted by the
+   * security tools) we key off it so rows whose `entity.name` collides — e.g.
+   * 19 local `okta` service accounts across different EC2 hosts — do not
+   * clobber each other in `rowsByKey` / share a React key. Legacy attachments
+   * that pre-date `entityStoreId` fall back to the non-unique name-based key.
+   */
+  const keyFor = useCallback(
+    (identifier: EntityAttachmentIdentifier) =>
+      identifier.entityStoreId
+        ? `${identifier.identifierType}:id:${identifier.entityStoreId}`
+        : `${identifier.identifierType}:name:${identifier.identifier}`,
+    []
+  );
+
+  const handleLoaded = useCallback(
+    (identifier: EntityAttachmentIdentifier, result: EntityRow) => {
+      setRowsByKey((prev) => {
+        const existing = prev[keyFor(identifier)];
+        if (existing && existing.isLoading === result.isLoading && existing.data === result.data) {
+          return prev;
+        }
+        return { ...prev, [keyFor(identifier)]: result };
+      });
+    },
+    [keyFor]
+  );
+
+  const items = useMemo<EntityRow[]>(
+    () =>
+      entities.map(
+        (identifier) =>
+          rowsByKey[keyFor(identifier)] ?? {
+            identifier,
+            isLoading: true,
+          }
+      ),
+    [entities, rowsByKey, keyFor]
+  );
+
+  const pagedItems = useMemo(
+    () => items.slice(pageIndex * PAGE_SIZE, (pageIndex + 1) * PAGE_SIZE),
+    [items, pageIndex]
+  );
+
+  const handleOpenEntityAnalytics = useCallback(() => {
+    services.application?.navigateToApp(APP_UI_ID, { path: ENTITY_ANALYTICS_PATH });
+  }, [services.application]);
+
+  const handleOpenEntity = useCallback(
+    (row: EntityRow) => {
+      if (!exploreApplication) {
+        return;
+      }
+      const entityStoreId = row.data?.entityId ?? row.identifier.entityStoreId;
+      const displayName = row.data?.displayName ?? row.identifier.identifier;
+      const rightPanel = buildEntityRightPanel({
+        identifierType: row.identifier.identifierType,
+        identifier: displayName,
+        entityStoreId,
+      });
+      if (rightPanel) {
+        navigateToEntityAnalyticsWithFlyoutInApp({
+          application: exploreApplication,
+          appId: APP_UI_ID,
+          flyout: { preview: [], right: rightPanel },
+          searchSession,
+        });
+        return;
+      }
+      navigateToEntityAnalyticsHomePageInApp({
+        application: exploreApplication,
+        appId: APP_UI_ID,
+        searchSession,
+      });
+    },
+    [exploreApplication, searchSession]
+  );
+
+  const columns = useMemo<Array<EuiBasicTableColumn<EntityRow>>>(
+    () => [
+      {
+        field: 'identifier.identifier',
+        name: COLUMN_LABELS.name,
+        render: (_value: unknown, row: EntityRow) => {
+          const label = row.data?.displayName ?? row.identifier.identifier;
+          const tooltipContent = row.data?.entityId ?? NAME_TOOLTIP_NO_ENTITY_ID;
+          const icon =
+            EntityIconByType[
+              row.data?.entityType ?? identifierTypeToEntityType(row.identifier.identifierType)
+            ] ?? 'globe';
+          return (
+            <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
+              {canExplorePerRow && (
+                <EuiFlexItem grow={false}>
+                  <EuiButtonIcon
+                    iconType={icon}
+                    display="empty"
+                    size="xs"
+                    aria-label={OPEN_ENTITY_IN_ENTITY_ANALYTICS_ARIA}
+                    data-test-subj="entityAttachmentTableOpenEntity"
+                    onClick={() => handleOpenEntity(row)}
+                  />
+                </EuiFlexItem>
+              )}
+              <EuiFlexItem grow={false}>
+                <EuiToolTip position="top" content={tooltipContent}>
+                  <EuiText size="xs" data-test-subj="entityAttachmentTableName">
+                    <strong>{label}</strong>
+                  </EuiText>
+                </EuiToolTip>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          );
+        },
+        width: '240px',
+      },
+      {
+        field: 'data.sources',
+        name: COLUMN_LABELS.dataSource,
+        render: (_value: unknown, row: EntityRow) => (
+          <EntityDataSourceBadges
+            sources={row.data?.sources}
+            isEntityInStore={row.data?.isEntityInStore ?? false}
+            hasLastSeenDate={Boolean(row.data?.lastSeen)}
+          />
+        ),
+        width: '140px',
+      },
+      {
+        field: 'identifier.identifierType',
+        name: COLUMN_LABELS.type,
+        render: (_value: unknown, row: EntityRow) => (
+          <EuiBadge color="hollow">
+            {
+              entityTypeLabels[
+                row.data?.entityType ?? identifierTypeToEntityType(row.identifier.identifierType)
+              ]
+            }
+          </EuiBadge>
+        ),
+        width: '110px',
+      },
+      {
+        field: 'data.riskScore',
+        name: COLUMN_LABELS.riskScore,
+        render: (_value: unknown, row: EntityRow) =>
+          row.isLoading ? (
+            <EuiSkeletonText lines={1} />
+          ) : (
+            <RiskScoreCell riskScore={row.data?.riskScore} />
+          ),
+        width: '110px',
+      },
+      {
+        field: 'data.assetCriticality',
+        name: COLUMN_LABELS.criticality,
+        render: (_value: unknown, row: EntityRow) => (
+          <AssetCriticalityBadge
+            criticalityLevel={row.data?.assetCriticality ?? 'unassigned'}
+            dataTestSubj="entityAttachmentTableCriticality"
+          />
+        ),
+        width: '150px',
+      },
+      {
+        field: 'data.timestamp',
+        name: COLUMN_LABELS.lastSeen,
+        render: (_value: unknown, row: EntityRow) =>
+          row.data?.timestamp ? (
+            <FormattedRelativePreferenceDate
+              value={row.data.timestamp}
+              relativeThresholdInHrs={Number.MAX_SAFE_INTEGER}
+              tooltipFieldName={LAST_SEEN_TOOLTIP_FIELD_NAME}
+            />
+          ) : (
+            '—'
+          ),
+        width: '140px',
+      },
+    ],
+    [canExplorePerRow, handleOpenEntity]
+  );
+
+  /**
+   * EuiBasicTable's prop signature is split: passing `pagination` makes
+   * `onChange` mandatory, and the inverse variant rejects an `undefined`
+   * `pagination`. Conditionally spreading both keeps a single render path
+   * while satisfying the discriminated union.
+   */
+  const paginationProps = useMemo(
+    () =>
+      items.length > PAGE_SIZE
+        ? {
+            pagination: {
+              pageIndex,
+              pageSize: PAGE_SIZE,
+              totalItemCount: items.length,
+              showPerPageOptions: false,
+            },
+            onChange: ({ page }: Criteria<EntityRow>) => {
+              if (page) setPageIndex(page.index);
+            },
+          }
+        : {},
+    [items.length, pageIndex]
+  );
+
+  return (
+    <EuiPanel
+      hasShadow={false}
+      hasBorder={false}
+      paddingSize="m"
+      data-test-subj="entityAttachmentTable"
+    >
+      {pagedItems.map((row) => (
+        <EntityRowLoader
+          key={keyFor(row.identifier)}
+          identifier={row.identifier}
+          onLoaded={handleLoaded}
+        />
+      ))}
+      <div css={tableScrollStyles}>
+        <EuiBasicTable
+          aria-label={i18n.translate(
+            'xpack.securitySolution.agentBuilder.entityAttachment.table.caption',
+            { defaultMessage: 'Entities referenced in this message' }
+          )}
+          items={pagedItems}
+          columns={columns}
+          itemId={(row) => keyFor(row.identifier)}
+          tableLayout="auto"
+          responsiveBreakpoint={false}
+          {...paginationProps}
+        />
+      </div>
+      <EuiFlexGroup gutterSize="s" wrap responsive={false} style={{ marginTop: 8 }}>
+        <EuiFlexItem grow={false}>
+          <EuiButtonEmpty
+            size="xs"
+            iconType="popout"
+            onClick={handleOpenEntityAnalytics}
+            data-test-subj="entityAttachmentTableOpenEntityAnalytics"
+            aria-label={OPEN_ENTITY_ANALYTICS_LABEL}
+          >
+            {OPEN_ENTITY_ANALYTICS_LABEL}
+          </EuiButtonEmpty>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </EuiPanel>
+  );
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/index.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { createEntityAttachmentDefinition } from './entity_attachment_definition';
+export { normaliseEntityAttachment } from './payload';
+export type {
+  EntityAttachment,
+  EntityAttachmentIdentifier,
+  EntityAttachmentData,
+  NormalisedEntityAttachment,
+} from './types';

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/payload.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/payload.test.ts
@@ -1,0 +1,244 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { normaliseEntityAttachment } from './payload';
+import type { EntityAttachment, EntityAttachmentRiskStats } from './types';
+
+const buildAttachment = (data: unknown): EntityAttachment =>
+  ({
+    id: 'a',
+    type: 'security.entity',
+    data: data as EntityAttachment['data'],
+  } as EntityAttachment);
+
+const riskStatsFixture = (
+  override: Partial<EntityAttachmentRiskStats> = {}
+): EntityAttachmentRiskStats => ({
+  '@timestamp': '2024-01-01T00:00:00Z',
+  id_field: 'host.name',
+  id_value: 'alpha',
+  calculated_level: 'High',
+  calculated_score: 50,
+  calculated_score_norm: 75,
+  category_1_score: 40,
+  category_1_count: 3,
+  category_2_score: 10,
+  notes: [],
+  ...override,
+});
+
+describe('normaliseEntityAttachment', () => {
+  it('accepts legacy single-identifier payload and returns isSingle=true', () => {
+    const result = normaliseEntityAttachment(
+      buildAttachment({ identifierType: 'host', identifier: 'alpha' })
+    );
+    expect(result).toEqual({
+      isSingle: true,
+      attachmentLabel: undefined,
+      entities: [{ identifierType: 'host', identifier: 'alpha' }],
+    });
+  });
+
+  it('passes attachmentLabel through', () => {
+    const result = normaliseEntityAttachment(
+      buildAttachment({
+        identifierType: 'user',
+        identifier: 'bob',
+        attachmentLabel: 'Bob user',
+      })
+    );
+    expect(result?.attachmentLabel).toBe('Bob user');
+  });
+
+  it('preserves entityStoreId on a single-entity payload', () => {
+    const result = normaliseEntityAttachment(
+      buildAttachment({
+        identifierType: 'user',
+        identifier: "Lena Medhurst@Lena's MacBook Pro",
+        entityStoreId: "user:Lena Medhurst@Lena's MacBook Pro@local",
+      })
+    );
+    expect(result?.entities[0].entityStoreId).toBe("user:Lena Medhurst@Lena's MacBook Pro@local");
+  });
+
+  it('drops malformed entityStoreId on a single-entity payload', () => {
+    const result = normaliseEntityAttachment(
+      buildAttachment({
+        identifierType: 'user',
+        identifier: 'bob',
+        entityStoreId: 42,
+      })
+    );
+    expect(result?.entities[0]).not.toHaveProperty('entityStoreId');
+  });
+
+  it('drops empty-string entityStoreId on a single-entity payload', () => {
+    const result = normaliseEntityAttachment(
+      buildAttachment({
+        identifierType: 'user',
+        identifier: 'bob',
+        entityStoreId: '',
+      })
+    );
+    expect(result?.entities[0]).not.toHaveProperty('entityStoreId');
+  });
+
+  it('accepts multi-entity payload with entities array', () => {
+    const result = normaliseEntityAttachment(
+      buildAttachment({
+        entities: [
+          { identifierType: 'host', identifier: 'alpha' },
+          { identifierType: 'user', identifier: 'bob' },
+        ],
+      })
+    );
+    expect(result?.isSingle).toBe(false);
+    expect(result?.entities).toHaveLength(2);
+  });
+
+  it('preserves entityStoreId on each entry of a multi-entity payload', () => {
+    const result = normaliseEntityAttachment(
+      buildAttachment({
+        entities: [
+          {
+            identifierType: 'host',
+            identifier: 'alpha',
+            entityStoreId: 'host:alpha',
+          },
+          {
+            identifierType: 'user',
+            identifier: 'bob',
+            entityStoreId: 'user:bob@host@local',
+          },
+        ],
+      })
+    );
+    expect(result?.entities[0].entityStoreId).toBe('host:alpha');
+    expect(result?.entities[1].entityStoreId).toBe('user:bob@host@local');
+  });
+
+  it('drops malformed entityStoreId values inside a multi-entity payload', () => {
+    const result = normaliseEntityAttachment(
+      buildAttachment({
+        entities: [
+          { identifierType: 'host', identifier: 'alpha', entityStoreId: null },
+          { identifierType: 'user', identifier: 'bob', entityStoreId: '' },
+        ],
+      })
+    );
+    expect(result?.entities[0]).not.toHaveProperty('entityStoreId');
+    expect(result?.entities[1]).not.toHaveProperty('entityStoreId');
+  });
+
+  it('marks single-element entities list as isSingle=true', () => {
+    const result = normaliseEntityAttachment(
+      buildAttachment({ entities: [{ identifierType: 'service', identifier: 'svc1' }] })
+    );
+    expect(result?.isSingle).toBe(true);
+  });
+
+  it('filters out malformed entries in the entities array', () => {
+    const result = normaliseEntityAttachment(
+      buildAttachment({
+        entities: [
+          { identifierType: 'host', identifier: 'alpha' },
+          { identifierType: 'nope', identifier: 'oops' },
+          { identifier: 'missing-type' },
+          null,
+        ],
+      })
+    );
+    expect(result?.entities).toHaveLength(1);
+    expect(result?.entities[0].identifier).toBe('alpha');
+  });
+
+  it('returns null when payload is missing', () => {
+    expect(normaliseEntityAttachment(buildAttachment(null))).toBeNull();
+  });
+
+  it('returns null when neither shape is valid', () => {
+    expect(normaliseEntityAttachment(buildAttachment({ foo: 'bar' }))).toBeNull();
+    expect(normaliseEntityAttachment(buildAttachment({ identifierType: 'host' }))).toBeNull();
+    expect(
+      normaliseEntityAttachment(buildAttachment({ identifierType: 'host', identifier: '' }))
+    ).toBeNull();
+  });
+
+  it('returns null when entities array is empty after filtering', () => {
+    expect(normaliseEntityAttachment(buildAttachment({ entities: [{ bad: true }] }))).toBeNull();
+  });
+
+  describe('riskStats / resolutionRiskStats forwarding', () => {
+    it('forwards riskStats when the payload carries a well-formed risk doc', () => {
+      const riskStats = riskStatsFixture();
+      const result = normaliseEntityAttachment(
+        buildAttachment({
+          identifierType: 'host',
+          identifier: 'alpha',
+          riskStats,
+        })
+      );
+      expect(result?.riskStats).toEqual(riskStats);
+      expect(result?.resolutionRiskStats).toBeUndefined();
+    });
+
+    it('forwards both primary and resolution risk stats when both are present', () => {
+      const riskStats = riskStatsFixture();
+      const resolutionRiskStats = riskStatsFixture({
+        calculated_level: 'Critical',
+        calculated_score: 90,
+        calculated_score_norm: 95,
+        category_1_score: 80,
+        category_1_count: 10,
+      });
+      const result = normaliseEntityAttachment(
+        buildAttachment({
+          identifierType: 'host',
+          identifier: 'alpha',
+          riskStats,
+          resolutionRiskStats,
+        })
+      );
+      expect(result?.riskStats).toEqual(riskStats);
+      expect(result?.resolutionRiskStats).toEqual(resolutionRiskStats);
+    });
+
+    it('omits riskStats when the payload does not include one', () => {
+      const result = normaliseEntityAttachment(
+        buildAttachment({ identifierType: 'host', identifier: 'alpha' })
+      );
+      expect(result?.riskStats).toBeUndefined();
+      expect(result?.resolutionRiskStats).toBeUndefined();
+    });
+
+    it('ignores invalid riskStats shapes without rejecting the whole payload', () => {
+      const result = normaliseEntityAttachment(
+        buildAttachment({
+          identifierType: 'host',
+          identifier: 'alpha',
+          riskStats: { calculated_level: 'High' },
+          resolutionRiskStats: 'not-an-object',
+        })
+      );
+      expect(result?.isSingle).toBe(true);
+      expect(result?.riskStats).toBeUndefined();
+      expect(result?.resolutionRiskStats).toBeUndefined();
+    });
+
+    it('never forwards riskStats on the multi-entity payload shape', () => {
+      const result = normaliseEntityAttachment(
+        buildAttachment({
+          entities: [{ identifierType: 'host', identifier: 'alpha' }],
+          // Even if the server (hypothetically) tacked these on, the
+          // multi-entity path doesn't surface a risk breakdown today.
+          riskStats: riskStatsFixture(),
+        })
+      );
+      expect(result?.riskStats).toBeUndefined();
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/payload.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/payload.ts
@@ -1,0 +1,118 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type {
+  EntityAttachment,
+  EntityAttachmentIdentifier,
+  EntityAttachmentRiskStats,
+  NormalisedEntityAttachment,
+} from './types';
+
+const ALLOWED_TYPES = new Set(['host', 'user', 'service', 'generic']);
+
+const isValidIdentifier = (candidate: unknown): candidate is EntityAttachmentIdentifier => {
+  if (!candidate || typeof candidate !== 'object') return false;
+  const record = candidate as Record<string, unknown>;
+  return (
+    typeof record.identifierType === 'string' &&
+    ALLOWED_TYPES.has(record.identifierType) &&
+    typeof record.identifier === 'string' &&
+    record.identifier.length > 0
+  );
+};
+
+const pickEntityStoreId = (candidate: unknown): string | undefined => {
+  if (!candidate || typeof candidate !== 'object') return undefined;
+  const raw = (candidate as Record<string, unknown>).entityStoreId;
+  return typeof raw === 'string' && raw.length > 0 ? raw : undefined;
+};
+
+/**
+ * Light structural check for the handful of fields `RiskSummaryMini`
+ * actually reads. We keep this deliberately permissive (optional fields can
+ * be missing, unknown extras are tolerated) because old attachments won't
+ * carry this shape at all — we just want to reject garbage payloads that
+ * would make the card throw when rendering the contributions table.
+ */
+const isValidRiskStats = (candidate: unknown): candidate is EntityAttachmentRiskStats => {
+  if (!candidate || typeof candidate !== 'object') return false;
+  const record = candidate as Record<string, unknown>;
+  return (
+    typeof record.calculated_level === 'string' &&
+    typeof record.calculated_score === 'number' &&
+    typeof record.calculated_score_norm === 'number' &&
+    typeof record.category_1_score === 'number' &&
+    typeof record.category_1_count === 'number'
+  );
+};
+
+/**
+ * Accept either a single-entity payload (legacy `{ identifierType, identifier }`)
+ * or a multi-entity payload (`{ entities: [...] }`) and normalise to a common
+ * shape. Returns `null` if the payload is unusable so callers can render an
+ * empty/error state instead of crashing the chat round.
+ *
+ * Optional `riskStats` and `resolutionRiskStats` from single-entity payloads
+ * are forwarded to the normalised shape when they pass `isValidRiskStats`.
+ * Missing or malformed stats are silently dropped so older attachments and
+ * forward-compatible variations continue to render.
+ */
+export const normaliseEntityAttachment = (
+  attachment: EntityAttachment
+): NormalisedEntityAttachment | null => {
+  const data = attachment?.data;
+  if (!data || typeof data !== 'object') {
+    return null;
+  }
+
+  const attachmentLabel = (data as { attachmentLabel?: string }).attachmentLabel;
+
+  if ('entities' in data && Array.isArray((data as { entities: unknown[] }).entities)) {
+    const rawEntities = (data as { entities: unknown[] }).entities;
+    const entities: EntityAttachmentIdentifier[] = rawEntities
+      .filter(isValidIdentifier)
+      .map((candidate) => {
+        const entityStoreId = pickEntityStoreId(candidate);
+        return {
+          identifierType: candidate.identifierType,
+          identifier: candidate.identifier,
+          ...(entityStoreId ? { entityStoreId } : {}),
+        };
+      });
+    if (entities.length === 0) {
+      return null;
+    }
+    return {
+      isSingle: entities.length === 1,
+      attachmentLabel,
+      entities,
+    };
+  }
+
+  if (isValidIdentifier(data)) {
+    const rawRiskStats = (data as { riskStats?: unknown }).riskStats;
+    const rawResolutionRiskStats = (data as { resolutionRiskStats?: unknown }).resolutionRiskStats;
+    const entityStoreId = pickEntityStoreId(data);
+    return {
+      isSingle: true,
+      attachmentLabel,
+      entities: [
+        {
+          identifierType: data.identifierType,
+          identifier: data.identifier,
+          ...(entityStoreId ? { entityStoreId } : {}),
+        },
+      ],
+      ...(isValidRiskStats(rawRiskStats) ? { riskStats: rawRiskStats } : {}),
+      ...(isValidRiskStats(rawResolutionRiskStats)
+        ? { resolutionRiskStats: rawResolutionRiskStats }
+        : {}),
+    };
+  }
+
+  return null;
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/query_client.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/query_client.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { QueryClient } from '@kbn/react-query';
+
+/**
+ * Module-scoped QueryClient for the entity attachment renderer.
+ *
+ * The rich renderer mounts inside Agent Builder's provider tree, which does
+ * not carry Security Solution's own QueryClientProvider. A colocated client
+ * here satisfies the `useQuery` calls made by `useEntityFromStore` and any
+ * future sibling hooks, while keeping the cache shared across cards/tables
+ * rendered in the same conversation (instead of per-mount).
+ */
+export const entityAttachmentQueryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+      retry: 1,
+      staleTime: 30_000,
+    },
+  },
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/types.ts
@@ -1,0 +1,122 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Attachment } from '@kbn/agent-builder-common/attachments';
+import type { EntityRiskScoreRecord } from '../../../../common/api/entity_analytics/common';
+import type { EntityType } from '../../../../common/entity_analytics/types';
+
+/**
+ * Raw identifier pair as emitted by the Security UI / skill and validated by
+ * the server-side Zod schema.
+ */
+export interface EntityAttachmentIdentifier {
+  identifierType: EntityType | 'host' | 'user' | 'service' | 'generic';
+  identifier: string;
+  /**
+   * Canonical `entity.id` from the entity store (e.g. `user:name@host@namespace`).
+   * Optional — attachments created before this field was added won't have it,
+   * and the client hook falls back to per-type identity-field filtering.
+   * Prefer this for the entity store lookup: for local users the composite
+   * `entity.name` / `entity.id` diverges from `user.name`, so only matching
+   * on `entity.id` returns the stored record.
+   */
+  entityStoreId?: string;
+}
+
+/**
+ * Risk-doc projection the server embeds on a single-entity attachment so
+ * the chat card's risk summary table can render without running a Redux-
+ * backed search-strategy call client-side. Mirrors the server-side
+ * `EntityAttachmentRiskStats` (see `server/.../entity_attachment_utils.ts`).
+ * We intentionally only Pick the fields the card actually needs to keep the
+ * attachment payload compact — `inputs`, `related_entities`, and
+ * `calculation_run_id` are stripped on the server.
+ */
+export type EntityAttachmentRiskStats = Pick<
+  EntityRiskScoreRecord,
+  | '@timestamp'
+  | 'id_field'
+  | 'id_value'
+  | 'calculated_level'
+  | 'calculated_score'
+  | 'calculated_score_norm'
+  | 'category_1_score'
+  | 'category_1_count'
+  | 'category_2_score'
+  | 'category_2_count'
+  | 'notes'
+  | 'criticality_modifier'
+  | 'criticality_level'
+  | 'modifiers'
+  | 'score_type'
+>;
+
+/**
+ * Legacy single-entity payload shape.
+ */
+export interface EntityAttachmentSingleData extends EntityAttachmentIdentifier {
+  attachmentLabel?: string;
+  /**
+   * Full risk breakdown for the entity, embedded by
+   * `security.get_entity` so the chat card can match the flyout's
+   * contributions table. Absent for old attachments — consumers must fall
+   * back to the entity-store-derived `RiskStats` when missing.
+   */
+  riskStats?: EntityAttachmentRiskStats;
+  /**
+   * Full risk breakdown for the entity's resolution group. Only populated
+   * when the entity participates in a multi-member resolution group.
+   */
+  resolutionRiskStats?: EntityAttachmentRiskStats;
+}
+
+/**
+ * Multi-entity payload shape.
+ */
+export interface EntityAttachmentMultiData {
+  entities: EntityAttachmentIdentifier[];
+  attachmentLabel?: string;
+}
+
+/**
+ * Discriminated payload type - either the legacy single shape or the list shape.
+ */
+export type EntityAttachmentData = EntityAttachmentSingleData | EntityAttachmentMultiData;
+
+/**
+ * A typed Agent Builder attachment with entity payload.
+ */
+export type EntityAttachment = Attachment<string, EntityAttachmentData>;
+
+/**
+ * Normalised shape used throughout the renderer - always a non-empty list of
+ * identifiers plus an `isSingle` flag so the dispatcher can pick a card vs table.
+ *
+ * `riskStats` / `resolutionRiskStats` are only ever populated on the
+ * single-entity path; the list-attachment path doesn't surface a risk
+ * breakdown today.
+ */
+export interface NormalisedEntityAttachment {
+  isSingle: boolean;
+  attachmentLabel?: string;
+  entities: EntityAttachmentIdentifier[];
+  riskStats?: EntityAttachmentRiskStats;
+  resolutionRiskStats?: EntityAttachmentRiskStats;
+}
+
+/**
+ * Type guard for identifier types that have a Security expandable-flyout overview
+ * (host / user / service). Used by both `entity_attachment_definition` (to decide
+ * whether to expose the Canvas `Preview` action button) and the canvas-content
+ * dispatcher (to decide between mounting the full flyout or falling back to an
+ * `EntityCard`). Kept in `types.ts` so it's reachable synchronously without
+ * dragging the canvas chunk into the definition bundle.
+ */
+export const isFlyoutCapableIdentifierType = (
+  identifierType: string | undefined
+): identifierType is 'host' | 'user' | 'service' =>
+  identifierType === 'host' || identifierType === 'user' || identifierType === 'service';

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/use_entity_for_attachment.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/use_entity_for_attachment.test.ts
@@ -1,0 +1,135 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@kbn/react-query';
+
+import type { EntityAttachmentIdentifier } from './types';
+import { useEntityForAttachment } from './use_entity_for_attachment';
+
+const mockFetch = jest.fn();
+
+jest.mock('@kbn/kibana-react-plugin/public', () => ({
+  useKibana: () => ({ services: { http: { fetch: mockFetch } } }),
+}));
+
+const createWrapper = () => {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, cacheTime: 0 },
+    },
+  });
+  const Wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client }, children);
+  Wrapper.displayName = 'TestQueryClientProvider';
+  return Wrapper;
+};
+
+const parseLastFilterQuery = (): Record<string, unknown> => {
+  expect(mockFetch).toHaveBeenCalled();
+  const lastCall = mockFetch.mock.calls[mockFetch.mock.calls.length - 1];
+  const filterQuery = lastCall[1]?.query?.filterQuery as string | undefined;
+  expect(typeof filterQuery).toBe('string');
+  return JSON.parse(filterQuery!);
+};
+
+describe('useEntityForAttachment', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    // The hook returns `response?.records?.[0]`; giving it at least one
+    // record keeps react-query from complaining about `data === undefined`
+    // and mirrors the shape we care about in filter-query assertions.
+    mockFetch.mockResolvedValue({ records: [{ entity: { id: 'stub' } }] });
+  });
+
+  it('filters by entity.id when the identifier carries entityStoreId', async () => {
+    const identifier: EntityAttachmentIdentifier = {
+      identifierType: 'user',
+      identifier: "Lena Medhurst@Lena's MacBook Pro",
+      entityStoreId: "user:Lena Medhurst@Lena's MacBook Pro@local",
+    };
+
+    renderHook(() => useEntityForAttachment(identifier), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(mockFetch).toHaveBeenCalled());
+    const parsed = parseLastFilterQuery();
+    expect(parsed).toEqual({
+      bool: {
+        filter: [{ term: { 'entity.id': "user:Lena Medhurst@Lena's MacBook Pro@local" } }],
+      },
+    });
+  });
+
+  it('falls back to user.name for a legacy user identifier without entityStoreId', async () => {
+    const identifier: EntityAttachmentIdentifier = {
+      identifierType: 'user',
+      identifier: 'bob',
+    };
+
+    renderHook(() => useEntityForAttachment(identifier), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(mockFetch).toHaveBeenCalled());
+    expect(parseLastFilterQuery()).toEqual({
+      bool: { filter: [{ term: { 'user.name': 'bob' } }] },
+    });
+  });
+
+  it('falls back to host.name for a legacy host identifier without entityStoreId', async () => {
+    const identifier: EntityAttachmentIdentifier = {
+      identifierType: 'host',
+      identifier: 'server1',
+    };
+
+    renderHook(() => useEntityForAttachment(identifier), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(mockFetch).toHaveBeenCalled());
+    expect(parseLastFilterQuery()).toEqual({
+      bool: { filter: [{ term: { 'host.name': 'server1' } }] },
+    });
+  });
+
+  it('falls back to service.name for a legacy service identifier without entityStoreId', async () => {
+    const identifier: EntityAttachmentIdentifier = {
+      identifierType: 'service',
+      identifier: 'payments',
+    };
+
+    renderHook(() => useEntityForAttachment(identifier), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(mockFetch).toHaveBeenCalled());
+    expect(parseLastFilterQuery()).toEqual({
+      bool: { filter: [{ term: { 'service.name': 'payments' } }] },
+    });
+  });
+
+  it('falls back to entity.id for a legacy generic identifier without entityStoreId', async () => {
+    const identifier: EntityAttachmentIdentifier = {
+      identifierType: 'generic',
+      identifier: 'device:abc',
+    };
+
+    renderHook(() => useEntityForAttachment(identifier), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(mockFetch).toHaveBeenCalled());
+    expect(parseLastFilterQuery()).toEqual({
+      bool: { filter: [{ term: { 'entity.id': 'device:abc' } }] },
+    });
+  });
+
+  it('does not issue a fetch when no identifier value is provided', async () => {
+    const identifier: EntityAttachmentIdentifier = {
+      identifierType: 'user',
+      identifier: '',
+    };
+
+    renderHook(() => useEntityForAttachment(identifier), { wrapper: createWrapper() });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/use_entity_for_attachment.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_attachment/use_entity_for_attachment.ts
@@ -1,0 +1,275 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useMemo } from 'react';
+import type { HttpStart, IHttpFetchError } from '@kbn/core-http-browser';
+import { useKibana } from '@kbn/kibana-react-plugin/public';
+import { useQuery } from '@kbn/react-query';
+import { ENTITY_STORE_ROUTES } from '@kbn/entity-store/common';
+import { EntityType } from '../../../../common/entity_analytics/types';
+import type { CriticalityLevelWithUnassigned } from '../../../../common/entity_analytics/asset_criticality/types';
+import type { RiskSeverity, RiskStats } from '../../../../common/search_strategy';
+import type { EntityAttachmentIdentifier } from './types';
+
+export interface EntityForAttachment {
+  entityType: EntityType;
+  displayName: string;
+  entityId?: string;
+  isEntityInStore: boolean;
+  firstSeen: string | null;
+  lastSeen: string | null;
+  /**
+   * Top-level `@timestamp` on the entity store record (set by the entity
+   * store transform whenever the doc is upserted). Used by the multi-entity
+   * attachment table's "Last seen" column because it is guaranteed to be
+   * present, unlike `entity.lifecycle.last_activity` which can be absent
+   * when the entity has not been observed in logs yet.
+   */
+  timestamp: string | null;
+  riskScore?: number;
+  riskLevel?: RiskSeverity;
+  /**
+   * Full risk breakdown as stored on the entity store record. Used to feed the
+   * chat card's risk summary table without running a second search-strategy
+   * call (which would require Redux state not present in Agent Builder).
+   */
+  riskStats?: RiskStats;
+  assetCriticality?: CriticalityLevelWithUnassigned;
+  watchlistIds: string[];
+  sources: string[];
+}
+
+export interface UseEntityForAttachmentResult {
+  isLoading: boolean;
+  error: IHttpFetchError | null;
+  data: EntityForAttachment | null;
+  refetch: () => void;
+}
+
+interface EntityRecordShape {
+  '@timestamp'?: string;
+  entity?: {
+    id?: string;
+    name?: string;
+    /**
+     * `entity.source` is a multi-value field in the entity store (see the
+     * `MV_UNION(recent.entity.source, entity.source)` projection in
+     * `entity_store/server/domain/logs_extraction`). Older snapshots may
+     * still surface a single string, so accept either shape and normalise
+     * downstream.
+     */
+    source?: string | string[];
+    attributes?: { watchlists?: string[] };
+    lifecycle?: { first_seen?: string; last_activity?: string };
+    risk?: Partial<RiskStats> & {
+      calculated_level?: string;
+      calculated_score?: number;
+      calculated_score_norm?: number;
+    };
+  };
+  asset?: { criticality?: string | null };
+}
+
+interface ListEntitiesResponseShape {
+  records?: EntityRecordShape[];
+}
+
+const ENTITY_ATTACHMENT_QUERY_KEY = 'AGENT_BUILDER_ENTITY_ATTACHMENT';
+const ENTITY_STORE_API_VERSION = '2023-10-31';
+
+const toEntityType = (identifierType: EntityAttachmentIdentifier['identifierType']): EntityType => {
+  switch (identifierType) {
+    case 'host':
+      return EntityType.host;
+    case 'user':
+      return EntityType.user;
+    case 'service':
+      return EntityType.service;
+    case 'generic':
+    default:
+      return EntityType.generic;
+  }
+};
+
+/**
+ * Builds an Elasticsearch bool filter that targets a single entity store
+ * record by identifier. Prefers the canonical `entity.id` when the attachment
+ * payload carries `entityStoreId` — this is the only way to resolve local
+ * users, whose `entity.name` is a `user.name@host.name` composite that does
+ * not match the stored `user.name`. When `entityStoreId` is absent (legacy
+ * payloads) we fall back to the per-type identity field: `host.name`,
+ * `user.name`, `service.name`, or `entity.id` for generic entities.
+ */
+const buildFilterQuery = (identifier: EntityAttachmentIdentifier): string | undefined => {
+  const value = identifier.identifier;
+  if (!value) return undefined;
+
+  if (identifier.entityStoreId) {
+    return JSON.stringify({
+      bool: { filter: [{ term: { 'entity.id': identifier.entityStoreId } }] },
+    });
+  }
+
+  let field: string;
+  switch (identifier.identifierType) {
+    case 'host':
+      field = 'host.name';
+      break;
+    case 'user':
+      field = 'user.name';
+      break;
+    case 'service':
+      field = 'service.name';
+      break;
+    case 'generic':
+    default:
+      field = 'entity.id';
+      break;
+  }
+
+  return JSON.stringify({
+    bool: { filter: [{ term: { [field]: value } }] },
+  });
+};
+
+const shapeRecord = (
+  identifier: EntityAttachmentIdentifier,
+  record: EntityRecordShape | undefined
+): EntityForAttachment => {
+  const entityField = record?.entity;
+  const assetField = record?.asset;
+
+  const riskScore = entityField?.risk?.calculated_score_norm ?? entityField?.risk?.calculated_score;
+  const riskLevel = entityField?.risk?.calculated_level as RiskSeverity | undefined;
+
+  const assetCriticality =
+    (assetField?.criticality as CriticalityLevelWithUnassigned | null | undefined) ?? undefined;
+
+  const riskStats = entityField?.risk
+    ? ({
+        ...entityField.risk,
+        rule_risks: (entityField.risk as { rule_risks?: unknown[] }).rule_risks ?? [],
+        multipliers: (entityField.risk as { multipliers?: unknown[] }).multipliers ?? [],
+      } as RiskStats)
+    : undefined;
+
+  const rawSource = entityField?.source;
+  const sources = Array.isArray(rawSource)
+    ? rawSource.filter((s): s is string => typeof s === 'string' && s.length > 0)
+    : typeof rawSource === 'string' && rawSource.length > 0
+    ? [rawSource]
+    : [];
+
+  return {
+    entityType: toEntityType(identifier.identifierType),
+    displayName: entityField?.name ?? identifier.identifier,
+    entityId: entityField?.id,
+    isEntityInStore: Boolean(record),
+    firstSeen: entityField?.lifecycle?.first_seen ?? null,
+    lastSeen: entityField?.lifecycle?.last_activity ?? null,
+    timestamp: record?.['@timestamp'] ?? null,
+    riskScore,
+    riskLevel,
+    riskStats,
+    assetCriticality,
+    watchlistIds: entityField?.attributes?.watchlists?.slice() ?? [],
+    sources,
+  };
+};
+
+const fetchEntity = async ({
+  http,
+  identifier,
+  signal,
+}: {
+  http: HttpStart;
+  identifier: EntityAttachmentIdentifier;
+  signal?: AbortSignal;
+}): Promise<EntityRecordShape | undefined> => {
+  const filterQuery = buildFilterQuery(identifier);
+  if (!filterQuery) return undefined;
+
+  const entityType = toEntityType(identifier.identifierType);
+  const response = await http.fetch<ListEntitiesResponseShape>(
+    ENTITY_STORE_ROUTES.public.CRUD_GET,
+    {
+      version: ENTITY_STORE_API_VERSION,
+      method: 'GET',
+      query: {
+        entity_types: [entityType],
+        filterQuery,
+        page: 1,
+        per_page: 1,
+        sort_field: '@timestamp',
+        sort_order: 'desc',
+      },
+      signal,
+    }
+  );
+  return response?.records?.[0];
+};
+
+/**
+ * Fetches the entity store record for a single attachment identifier and
+ * shapes it for the chat card.
+ *
+ * This hook intentionally bypasses `useEntityAnalyticsRoutes` /
+ * `useEntityFromStore` because those pull in Security Solution's Redux store
+ * (via `useIsExperimentalFeatureEnabled`) which is not present in Agent
+ * Builder's provider tree. We call the public Entity Store v2 endpoint
+ * directly with only `core`-level services so the hook works anywhere the
+ * core Kibana context is available.
+ */
+export const useEntityForAttachment = (
+  identifier: EntityAttachmentIdentifier | undefined,
+  { skip = false }: { skip?: boolean } = {}
+): UseEntityForAttachmentResult => {
+  const { services } = useKibana<{ http: HttpStart }>();
+  const http = services.http;
+
+  const queryKey = useMemo(
+    () => [
+      ENTITY_ATTACHMENT_QUERY_KEY,
+      identifier?.identifierType ?? '',
+      identifier?.identifier ?? '',
+      identifier?.entityStoreId ?? '',
+    ],
+    [identifier]
+  );
+
+  const enabled = Boolean(http) && !skip && Boolean(identifier?.identifier);
+
+  const {
+    data: record,
+    isLoading,
+    error,
+    refetch,
+  } = useQuery<EntityRecordShape | undefined, IHttpFetchError>({
+    queryKey,
+    queryFn: ({ signal }) => {
+      if (!identifier || !http) {
+        return undefined;
+      }
+      return fetchEntity({ http, identifier, signal });
+    },
+    enabled,
+  });
+
+  const data = useMemo<EntityForAttachment | null>(() => {
+    if (!identifier) return null;
+    return shapeRecord(identifier, record);
+  }, [identifier, record]);
+
+  return {
+    isLoading: enabled && isLoading,
+    error: (error as IHttpFetchError | null) ?? null,
+    data,
+    refetch: () => {
+      refetch();
+    },
+  };
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_explore_navigation.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_explore_navigation.test.ts
@@ -1,0 +1,268 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ApplicationStart } from '@kbn/core-application-browser';
+import type { ISessionService } from '@kbn/data-plugin/public';
+import { agentBuilderDefaultAgentId } from '@kbn/agent-builder-common';
+import {
+  getAgentBuilderLastAgentIdForSecurityOpenChat,
+  getHostNameForHostDetailsUrl,
+  getServiceNameForServiceDetailsUrl,
+  getUserNameForUserDetailsUrl,
+  isAgentBuilderSidebarOpen,
+  navigateToEntityAnalyticsHomePageInApp,
+  navigateToEntityAnalyticsWithFlyoutInApp,
+} from './entity_explore_navigation';
+
+describe('entity_explore_navigation', () => {
+  describe('isAgentBuilderSidebarOpen', () => {
+    it('is true when chrome reports the agentBuilder sidebar app', () => {
+      expect(
+        isAgentBuilderSidebarOpen({
+          sidebar: { getCurrentAppId: () => 'agentBuilder' },
+        } as never)
+      ).toBe(true);
+    });
+
+    it('is false when another sidebar app is active', () => {
+      expect(
+        isAgentBuilderSidebarOpen({
+          sidebar: { getCurrentAppId: () => null },
+        } as never)
+      ).toBe(false);
+    });
+
+    it('is false when chrome is undefined', () => {
+      expect(isAgentBuilderSidebarOpen(undefined)).toBe(false);
+    });
+  });
+
+  describe('getAgentBuilderLastAgentIdForSecurityOpenChat', () => {
+    beforeEach(() => {
+      window.localStorage.removeItem('agentBuilder.agentId');
+    });
+
+    it('returns platform default when localStorage is empty', () => {
+      expect(getAgentBuilderLastAgentIdForSecurityOpenChat()).toBe(agentBuilderDefaultAgentId);
+    });
+
+    it('parses JSON-encoded agent id from localStorage (same format as Agent Builder)', () => {
+      window.localStorage.setItem('agentBuilder.agentId', '"my-agent-id"');
+      expect(getAgentBuilderLastAgentIdForSecurityOpenChat()).toBe('my-agent-id');
+    });
+  });
+
+  describe('getUserNameForUserDetailsUrl', () => {
+    it('uses entity_name when it is a real user.name-style value', () => {
+      expect(
+        getUserNameForUserDetailsUrl({
+          entity_type: 'user',
+          entity_id: 'user:yuliianaumenko@B377958D-B4A8-5FCA-B237-F2DE40404617@local',
+          entity_name: 'yuliianaumenko@MacBookPro.localdomain',
+        })
+      ).toBe('yuliianaumenko@MacBookPro.localdomain');
+    });
+
+    it('ignores placeholder entity_name "name" and builds user@host from EUID + source.host.name', () => {
+      expect(
+        getUserNameForUserDetailsUrl({
+          entity_type: 'user',
+          entity_id: 'user:yuliianaumenko@B377958D-B4A8-5FCA-B237-F2DE40404617@local',
+          entity_name: 'name',
+          source: { host: { name: 'MacBookPro.localdomain' } },
+        })
+      ).toBe('yuliianaumenko@MacBookPro.localdomain');
+    });
+  });
+
+  describe('getHostNameForHostDetailsUrl', () => {
+    it('uses entity_name when it is a real host.name-style value', () => {
+      expect(
+        getHostNameForHostDetailsUrl({
+          entity_type: 'host',
+          entity_id: 'host:B377958D-B4A8-5FCA-B237-F2DE40404617',
+          entity_name: 'MacBookPro.localdomain',
+        })
+      ).toBe('MacBookPro.localdomain');
+    });
+
+    it('falls back to entity_id when entity_name is the placeholder "name"', () => {
+      expect(
+        getHostNameForHostDetailsUrl({
+          entity_type: 'host',
+          entity_id: 'host:B377958D-B4A8-5FCA-B237-F2DE40404617',
+          entity_name: 'name',
+        })
+      ).toBe('host:B377958D-B4A8-5FCA-B237-F2DE40404617');
+    });
+
+    it('falls back to entity_id when entity_name is whitespace-wrapped placeholder " name "', () => {
+      expect(
+        getHostNameForHostDetailsUrl({
+          entity_type: 'host',
+          entity_id: 'host:B377958D-B4A8-5FCA-B237-F2DE40404617',
+          entity_name: ' name ',
+        })
+      ).toBe('host:B377958D-B4A8-5FCA-B237-F2DE40404617');
+    });
+
+    it('falls back to entity_id when entity_name is missing', () => {
+      expect(
+        getHostNameForHostDetailsUrl({
+          entity_type: 'host',
+          entity_id: 'host:B377958D-B4A8-5FCA-B237-F2DE40404617',
+        })
+      ).toBe('host:B377958D-B4A8-5FCA-B237-F2DE40404617');
+    });
+  });
+
+  describe('getServiceNameForServiceDetailsUrl', () => {
+    it('uses entity_name when it is a real service.name-style value', () => {
+      expect(
+        getServiceNameForServiceDetailsUrl({
+          entity_type: 'service',
+          entity_id: 'service:abc-123',
+          entity_name: 'api.example',
+        })
+      ).toBe('api.example');
+    });
+
+    it('falls back to entity_id when entity_name is the placeholder "name"', () => {
+      expect(
+        getServiceNameForServiceDetailsUrl({
+          entity_type: 'service',
+          entity_id: 'service:abc-123',
+          entity_name: 'name',
+        })
+      ).toBe('service:abc-123');
+    });
+
+    it('falls back to entity_id when entity_name is whitespace-wrapped placeholder " name "', () => {
+      expect(
+        getServiceNameForServiceDetailsUrl({
+          entity_type: 'service',
+          entity_id: 'service:abc-123',
+          entity_name: ' name ',
+        })
+      ).toBe('service:abc-123');
+    });
+
+    it('falls back to entity_id when entity_name is missing', () => {
+      expect(
+        getServiceNameForServiceDetailsUrl({
+          entity_type: 'service',
+          entity_id: 'service:abc-123',
+        })
+      ).toBe('service:abc-123');
+    });
+  });
+
+  describe('search session clearing on cross-app navigation', () => {
+    const buildApplicationMock = (): jest.Mocked<ApplicationStart> =>
+      ({
+        navigateToApp: jest.fn(),
+      } as unknown as jest.Mocked<ApplicationStart>);
+
+    const buildSearchSessionMock = (): jest.Mocked<Pick<ISessionService, 'clear'>> => ({
+      clear: jest.fn(),
+    });
+
+    describe('navigateToEntityAnalyticsWithFlyoutInApp', () => {
+      it('preserves current entity analytics query state and appends flyout', () => {
+        const application = buildApplicationMock();
+        const risonQuery = '(pageIndex:3,sort:!((@timestamp,desc)))';
+
+        window.history.replaceState(
+          {},
+          '',
+          `/app/security/entity_analytics_home_page?cspq=${encodeURIComponent(
+            risonQuery
+          )}&watchlistId=wl-123&watchlistName=VIPs&groupBy=resolution`
+        );
+
+        navigateToEntityAnalyticsWithFlyoutInApp({
+          application,
+          appId: 'securitySolutionUI',
+          flyout: { right: { id: 'service-panel', params: { serviceName: 'svc-a' } } },
+        });
+
+        expect(application.navigateToApp).toHaveBeenCalledTimes(1);
+        const [, options] = application.navigateToApp.mock.calls[0];
+        const path = (options as { path?: string }).path ?? '';
+        const params = new URLSearchParams(path.startsWith('?') ? path.slice(1) : path);
+
+        expect(params.get('cspq')).toBe(risonQuery);
+        expect(params.get('watchlistId')).toBe('wl-123');
+        expect(params.get('watchlistName')).toBe('VIPs');
+        expect(params.get('groupBy')).toBe('resolution');
+        expect(params.get('flyout')).toContain('right');
+      });
+
+      it('clears the search session before navigateToApp is called', () => {
+        const application = buildApplicationMock();
+        const searchSession = buildSearchSessionMock();
+
+        navigateToEntityAnalyticsWithFlyoutInApp({
+          application,
+          appId: 'securitySolutionUI',
+          flyout: { left: { id: 'l' }, right: { id: 'r' }, preview: [] },
+          searchSession: searchSession as unknown as ISessionService,
+        });
+
+        expect(searchSession.clear).toHaveBeenCalledTimes(1);
+        expect(application.navigateToApp).toHaveBeenCalledTimes(1);
+        const clearOrder = searchSession.clear.mock.invocationCallOrder[0];
+        const navigateOrder = application.navigateToApp.mock.invocationCallOrder[0];
+        expect(clearOrder).toBeLessThan(navigateOrder);
+      });
+
+      it('does not throw when searchSession is undefined (backward-compat)', () => {
+        const application = buildApplicationMock();
+
+        expect(() =>
+          navigateToEntityAnalyticsWithFlyoutInApp({
+            application,
+            appId: 'securitySolutionUI',
+            flyout: { left: { id: 'l' }, right: { id: 'r' }, preview: [] },
+          })
+        ).not.toThrow();
+        expect(application.navigateToApp).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe('navigateToEntityAnalyticsHomePageInApp', () => {
+      it('clears the search session before navigateToApp is called', () => {
+        const application = buildApplicationMock();
+        const searchSession = buildSearchSessionMock();
+
+        navigateToEntityAnalyticsHomePageInApp({
+          application,
+          appId: 'securitySolutionUI',
+          searchSession: searchSession as unknown as ISessionService,
+        });
+
+        expect(searchSession.clear).toHaveBeenCalledTimes(1);
+        expect(application.navigateToApp).toHaveBeenCalledTimes(1);
+        const clearOrder = searchSession.clear.mock.invocationCallOrder[0];
+        const navigateOrder = application.navigateToApp.mock.invocationCallOrder[0];
+        expect(clearOrder).toBeLessThan(navigateOrder);
+      });
+
+      it('does not throw when searchSession is undefined (backward-compat)', () => {
+        const application = buildApplicationMock();
+
+        expect(() =>
+          navigateToEntityAnalyticsHomePageInApp({
+            application,
+            appId: 'securitySolutionUI',
+          })
+        ).not.toThrow();
+        expect(application.navigateToApp).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_explore_navigation.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_explore_navigation.ts
@@ -1,0 +1,368 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ApplicationStart } from '@kbn/core-application-browser';
+import type { CoreStart } from '@kbn/core/public';
+import type { AgentBuilderPluginStart } from '@kbn/agent-builder-plugin/public';
+import type { ISessionService } from '@kbn/data-plugin/public';
+import { encodeFlyout, FLYOUT_PARAM_KEY } from '@kbn/cloud-security-posture/src/utils/query_utils';
+import {
+  markPreserveAgentBuilderSessionDuringNextSecurityNavigation,
+  readLastAgentBuilderAgentIdForSecuritySession,
+} from '../../../common/agent_builder_navigation_gate';
+
+import { SecurityPageName } from '../../../common/constants';
+import {
+  HostPanelKey,
+  ServicePanelKey,
+  UserPanelKey,
+} from '../../flyout/entity_details/shared/constants';
+import type { EntityAttachmentIdentifier } from './entity_attachment/types';
+import { isFlyoutCapableIdentifierType } from './entity_attachment/types';
+
+/** Some tool payloads mistakenly set `entity_name` to the ECS field label "name". */
+const INVALID_PLACEHOLDER_ENTITY_NAME = 'name';
+
+const USER_EUID_PREFIX = 'user:';
+
+const AGENT_BUILDER_SIDEBAR_APP_ID = 'agentBuilder' as const;
+const ENTITY_ANALYTICS_HOME_PATH = '/entity_analytics_home_page';
+
+const getEntityAnalyticsStateSearchParams = (): URLSearchParams => {
+  if (!window.location.pathname.includes(ENTITY_ANALYTICS_HOME_PATH)) {
+    return new URLSearchParams();
+  }
+
+  return new URLSearchParams(window.location.search);
+};
+
+const getEntityAnalyticsNavigationPathWithFlyout = (
+  flyout: Record<string, unknown>
+): string | undefined => {
+  const encodedFlyoutSearch = encodeFlyout(flyout);
+  if (encodedFlyoutSearch == null) {
+    return undefined;
+  }
+
+  const flyoutValue = new URLSearchParams(encodedFlyoutSearch).get(FLYOUT_PARAM_KEY);
+  if (flyoutValue == null) {
+    return undefined;
+  }
+
+  const searchParams = getEntityAnalyticsStateSearchParams();
+  searchParams.set(FLYOUT_PARAM_KEY, flyoutValue);
+  return `?${searchParams.toString()}`;
+};
+
+export type SecurityAgentBuilderChrome = CoreStart['chrome'];
+
+/**
+ * True when the Chrome sidebar is showing the Agent Builder app (used to coordinate
+ * close → navigate → reopen around in-app Security navigation).
+ */
+export const isAgentBuilderSidebarOpen = (chrome?: SecurityAgentBuilderChrome): boolean =>
+  chrome?.sidebar.getCurrentAppId() === AGENT_BUILDER_SIDEBAR_APP_ID;
+
+/** Exported for unit tests — mirrors agent_builder `getLastAgentId` storage shape. */
+export const getAgentBuilderLastAgentIdForSecurityOpenChat =
+  readLastAgentBuilderAgentIdForSecuritySession;
+
+/**
+ * Scope shared by the Agent Builder entity surfaces (inline card, canvas flyout
+ * overview, canvas action button, entity tables). Kept in sync so the Security
+ * expandable flyout provider resolves the same `contextID` / `scopeId`
+ * regardless of which surface opened it.
+ */
+export const AGENT_BUILDER_ENTITY_CARD_SCOPE = 'agent-builder-entity-card';
+
+/**
+ * Minimal expandable-flyout `right` panel shape accepted by the Entity Analytics
+ * home page. Kept intentionally narrow so consumers can't accidentally forward
+ * unrelated panel payloads.
+ */
+export type EntityFlyoutRightPanel =
+  | {
+      id: typeof HostPanelKey;
+      params: { contextID: string; scopeId: string; hostName: string; entityId: string };
+    }
+  | {
+      id: typeof UserPanelKey;
+      params: {
+        contextID: string;
+        scopeId: string;
+        userName: string;
+        identityFields: { 'user.name': string };
+        entityId: string;
+      };
+    }
+  | {
+      id: typeof ServicePanelKey;
+      params: { contextID: string; scopeId: string; serviceName: string; entityId: string };
+    };
+
+/**
+ * Builds the minimal `right`-panel payload consumed by the expandable flyout provider on the
+ * Entity Analytics home page. Returns `null` for generic entities (no dedicated flyout yet)
+ * and for legacy attachments that don't carry the canonical `entity.id` — callers fall back
+ * to an unfiltered `navigateToEntityAnalyticsHomePageInApp` in those cases.
+ */
+export const buildEntityRightPanel = (
+  identifier: EntityAttachmentIdentifier
+): EntityFlyoutRightPanel | null => {
+  const { identifierType, identifier: displayName, entityStoreId } = identifier;
+  if (!entityStoreId || !isFlyoutCapableIdentifierType(identifierType)) {
+    return null;
+  }
+
+  const contextID = AGENT_BUILDER_ENTITY_CARD_SCOPE;
+  const scopeId = AGENT_BUILDER_ENTITY_CARD_SCOPE;
+
+  switch (identifierType) {
+    case 'host':
+      return {
+        id: HostPanelKey,
+        params: { contextID, scopeId, hostName: displayName, entityId: entityStoreId },
+      };
+    case 'user':
+      return {
+        id: UserPanelKey,
+        params: {
+          contextID,
+          scopeId,
+          userName: displayName,
+          identityFields: { 'user.name': displayName },
+          entityId: entityStoreId,
+        },
+      };
+    case 'service':
+      return {
+        id: ServicePanelKey,
+        params: { contextID, scopeId, serviceName: displayName, entityId: entityStoreId },
+      };
+    default:
+      return null;
+  }
+};
+
+const openSecurityAgentBuilderChatPreservingConversation = (
+  agentBuilder: AgentBuilderPluginStart
+): void => {
+  agentBuilder.openChat({
+    sessionTag: 'security',
+    newConversation: false,
+    agentId: readLastAgentBuilderAgentIdForSecuritySession(),
+  });
+};
+
+/**
+ * Defers reopening the sidebar so `navigateToApp` can apply first (mirrors Dashboard Canvas
+ * "Edit in Dashboards": navigate, then bring the conversation UI back on a fresh mount).
+ */
+const reopenSecurityAgentBuilderAfterNavigation = (agentBuilder: AgentBuilderPluginStart): void => {
+  setTimeout(() => {
+    openSecurityAgentBuilderChatPreservingConversation(agentBuilder);
+  }, 0);
+};
+
+/**
+ * After Security in-app navigation, restore the Agent Builder sidebar the same way Dashboard
+ * Canvas does: prefer the attachment `openSidebarConversation` callback (persists the active
+ * conversation id, then `openSidebarInternal`), otherwise fall back to `openChat` with the
+ * Security session tag and last agent id.
+ */
+const scheduleReopenAgentBuilderAfterSecurityNavigation = ({
+  agentBuilder,
+  openSidebarConversation,
+}: {
+  agentBuilder?: AgentBuilderPluginStart;
+  openSidebarConversation?: () => void;
+}): void => {
+  if (openSidebarConversation) {
+    setTimeout(() => {
+      openSidebarConversation();
+    }, 0);
+    return;
+  }
+  if (agentBuilder?.openChat) {
+    reopenSecurityAgentBuilderAfterNavigation(agentBuilder);
+  }
+};
+
+export interface SecurityEntityExploreRow {
+  entity_type: string;
+  entity_id: string;
+  entity_name?: string;
+  source?: unknown;
+}
+
+const readHostNameFromEntitySource = (source: unknown): string | undefined => {
+  if (source == null || typeof source !== 'object' || Array.isArray(source)) {
+    return undefined;
+  }
+  const host = (source as { host?: unknown }).host;
+  if (host == null || typeof host !== 'object' || Array.isArray(host)) {
+    return undefined;
+  }
+  const name = (host as { name?: unknown }).name;
+  return typeof name === 'string' && name !== '' ? name : undefined;
+};
+
+const parseUserEuidLocalSegment = (entityId: string): string | undefined => {
+  if (!entityId.startsWith(USER_EUID_PREFIX)) {
+    return undefined;
+  }
+  const rest = entityId.slice(USER_EUID_PREFIX.length);
+  const at = rest.indexOf('@');
+  if (at <= 0) {
+    return undefined;
+  }
+  return rest.slice(0, at);
+};
+
+/**
+ * Resolves the `user.name`-style segment used in `/users/name/:name/events` routes.
+ * Prefers `entity_name` from the entity store; falls back to EUID + optional `host.name` in `source`.
+ */
+export const getUserNameForUserDetailsUrl = (row: SecurityEntityExploreRow): string => {
+  const trimmed = row.entity_name?.trim();
+  if (trimmed && trimmed !== INVALID_PLACEHOLDER_ENTITY_NAME) {
+    return trimmed;
+  }
+
+  const hostName = readHostNameFromEntitySource(row.source);
+  const local = parseUserEuidLocalSegment(row.entity_id);
+  if (local && hostName) {
+    return `${local}@${hostName}`;
+  }
+  if (local) {
+    return local;
+  }
+  return row.entity_id;
+};
+
+export const getHostNameForHostDetailsUrl = (row: SecurityEntityExploreRow): string => {
+  const trimmed = row.entity_name?.trim();
+  if (trimmed && trimmed !== INVALID_PLACEHOLDER_ENTITY_NAME) {
+    return trimmed;
+  }
+  return row.entity_id;
+};
+
+export const getServiceNameForServiceDetailsUrl = (row: SecurityEntityExploreRow): string => {
+  const trimmed = row.entity_name?.trim();
+  if (trimmed && trimmed !== INVALID_PLACEHOLDER_ENTITY_NAME) {
+    return trimmed;
+  }
+  return row.entity_id;
+};
+
+/**
+ * Opens Entity Analytics home with a serialized expandable-flyout state (same URL shape as the
+ * product Entity Analytics page). Used from Agent Builder canvas where the in-page flyout
+ * provider is not mounted on the attachment surface.
+ */
+export const navigateToEntityAnalyticsWithFlyoutInApp = ({
+  application,
+  appId,
+  flyout,
+  agentBuilder,
+  chrome,
+  openSidebarConversation,
+  searchSession,
+}: {
+  application: ApplicationStart;
+  appId: string;
+  flyout: Record<string, unknown>;
+  agentBuilder?: AgentBuilderPluginStart;
+  chrome?: SecurityAgentBuilderChrome;
+  openSidebarConversation?: () => void;
+  /**
+   * Optional search session service. When provided, the active session is cleared before
+   * navigating. See `clearSearchSessionBeforeSecurityNavigation` below for the rationale.
+   */
+  searchSession?: ISessionService;
+}): void => {
+  const path = getEntityAnalyticsNavigationPathWithFlyout(flyout);
+  if (path == null) {
+    return;
+  }
+
+  markPreserveAgentBuilderSessionDuringNextSecurityNavigation();
+  if (isAgentBuilderSidebarOpen(chrome) && agentBuilder?.toggleChat) {
+    agentBuilder.toggleChat();
+  }
+  clearSearchSessionBeforeSecurityNavigation(searchSession);
+  application.navigateToApp(appId, {
+    deepLinkId: SecurityPageName.entityAnalyticsHomePage,
+    path,
+    replace: true,
+  });
+  scheduleReopenAgentBuilderAfterSecurityNavigation({ agentBuilder, openSidebarConversation });
+};
+
+export const navigateToEntityAnalyticsHomePageInApp = ({
+  application,
+  appId,
+  agentBuilder,
+  chrome,
+  openSidebarConversation,
+  watchlistId,
+  watchlistName,
+  searchSession,
+}: {
+  application: ApplicationStart;
+  appId: string;
+  agentBuilder?: AgentBuilderPluginStart;
+  chrome?: SecurityAgentBuilderChrome;
+  openSidebarConversation?: () => void;
+  watchlistId?: string;
+  watchlistName?: string;
+  /**
+   * Optional search session service. When provided, the active session is cleared before
+   * navigating. See `clearSearchSessionBeforeSecurityNavigation` below for the rationale.
+   */
+  searchSession?: ISessionService;
+}): void => {
+  const params = new URLSearchParams();
+  if (watchlistId) {
+    params.set('watchlistId', watchlistId);
+  }
+  if (watchlistName) {
+    params.set('watchlistName', watchlistName);
+  }
+  const query = params.toString();
+  const path = query === '' ? undefined : `?${query}`;
+
+  markPreserveAgentBuilderSessionDuringNextSecurityNavigation();
+  if (isAgentBuilderSidebarOpen(chrome) && agentBuilder?.toggleChat) {
+    agentBuilder.toggleChat();
+  }
+  clearSearchSessionBeforeSecurityNavigation(searchSession);
+  application.navigateToApp(appId, {
+    deepLinkId: SecurityPageName.entityAnalyticsHomePage,
+    path,
+    replace: true,
+  });
+  scheduleReopenAgentBuilderAfterSecurityNavigation({ agentBuilder, openSidebarConversation });
+};
+
+/**
+ * Navigating from `agent_builder` to `securitySolutionUI` is a legitimate cross-app jump
+ * triggered from the Canvas preview (Graph / Resolution / Open in Security / Open in Entity
+ * Analytics). Lens embeddables rendered inside the Canvas start a search session tagged with
+ * `appName: 'agent_builder'`; leaving it open when `currentAppId$` flips to
+ * `securitySolutionUI` trips the platform guard in
+ * `data/public/search/session/session_service.ts` and throws a fatal in dev.
+ *
+ * Clearing the session here keeps the navigation honest without regressing the
+ * minimized-sidebar case: when called from within Security the owner and current app match,
+ * so `SessionService.clear()` either succeeds as a benign reset (matching the Security
+ * `renderApp` unmount hygiene) or is a no-op when no session is active.
+ */
+const clearSearchSessionBeforeSecurityNavigation = (searchSession?: ISessionService): void => {
+  searchSession?.clear();
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_list_table.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_list_table.test.tsx
@@ -1,0 +1,283 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { I18nProvider } from '@kbn/i18n-react';
+import type { ApplicationStart } from '@kbn/core-application-browser';
+import type { ISessionService } from '@kbn/data-plugin/public';
+import {
+  navigateToEntityAnalyticsHomePageInApp,
+  navigateToEntityAnalyticsWithFlyoutInApp,
+} from './entity_explore_navigation';
+import { EntityListTable, type EntityListRow } from './entity_list_table';
+
+jest.mock('./entity_explore_navigation', () => {
+  const actual = jest.requireActual('./entity_explore_navigation');
+  return {
+    ...actual,
+    navigateToEntityAnalyticsWithFlyoutInApp: jest.fn(),
+    navigateToEntityAnalyticsHomePageInApp: jest.fn(),
+  };
+});
+
+// `RiskScoreLevel` relies on a full EuiThemeProvider for styled-emotion tokens
+// that are not wired up in this focused test. Mocked so rendering the Risk
+// level column doesn't pull the whole EUI theme setup into every test case.
+jest.mock('../../entity_analytics/components/severity/common', () => ({
+  RiskScoreLevel: ({ severity }: { severity?: string }) => (
+    <span data-test-subj="riskScoreLevelMock">{severity}</span>
+  ),
+}));
+
+// `FormattedRelativePreferenceDate` pulls in Kibana UI settings and the shared
+// date-formatting infrastructure. We only care about the Name column here, so
+// stub it with a trivial renderer.
+jest.mock('../../common/components/formatted_date', () => ({
+  FormattedRelativePreferenceDate: ({ value }: { value?: string }) => (
+    <span data-test-subj="formattedRelativePreferenceDateMock">{value}</span>
+  ),
+}));
+
+const mockedNavigateToFlyout = navigateToEntityAnalyticsWithFlyoutInApp as jest.Mock;
+const mockedNavigateToHome = navigateToEntityAnalyticsHomePageInApp as jest.Mock;
+
+const buildApplication = (): ApplicationStart =>
+  ({ navigateToApp: jest.fn() } as unknown as ApplicationStart);
+
+const renderTable = (
+  row: EntityListRow,
+  extraProps: Partial<React.ComponentProps<typeof EntityListTable>> = {}
+) => {
+  const application = buildApplication();
+  render(
+    <I18nProvider>
+      <EntityListTable entities={[row]} application={application} {...extraProps} />
+    </I18nProvider>
+  );
+  return { application };
+};
+
+describe('EntityListTable', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders one row per entity with its display name', () => {
+    render(
+      <I18nProvider>
+        <EntityListTable
+          entities={[
+            { entity_type: 'host', entity_id: 'host:web-01@default', entity_name: 'web-01' },
+            { entity_type: 'user', entity_id: 'user:bob@default', entity_name: 'bob' },
+          ]}
+          application={buildApplication()}
+        />
+      </I18nProvider>
+    );
+
+    expect(screen.getByText('web-01')).toBeInTheDocument();
+    expect(screen.getByText('bob')).toBeInTheDocument();
+  });
+
+  describe('Name-column Open entity in Entity Analytics button', () => {
+    it('opens the flyout with the HostPanelKey payload for host rows with an entity id', () => {
+      const { application } = renderTable({
+        entity_type: 'host',
+        entity_id: 'host:web-01@default',
+        entity_name: 'web-01',
+      });
+
+      fireEvent.click(screen.getByLabelText('Open entity in Entity Analytics'));
+
+      expect(mockedNavigateToFlyout).toHaveBeenCalledTimes(1);
+      expect(mockedNavigateToHome).not.toHaveBeenCalled();
+      const args = mockedNavigateToFlyout.mock.calls[0][0];
+      expect(args.application).toBe(application);
+      expect(args.flyout).toEqual({
+        preview: [],
+        right: {
+          id: 'host-panel',
+          params: {
+            contextID: 'agent-builder-entity-card',
+            scopeId: 'agent-builder-entity-card',
+            hostName: 'web-01',
+            entityId: 'host:web-01@default',
+          },
+        },
+      });
+    });
+
+    it('opens the flyout with the UserPanelKey payload for user rows with an entity id', () => {
+      renderTable({
+        entity_type: 'user',
+        entity_id: 'user:bob@default',
+        entity_name: 'bob',
+      });
+
+      fireEvent.click(screen.getByLabelText('Open entity in Entity Analytics'));
+
+      expect(mockedNavigateToFlyout).toHaveBeenCalledTimes(1);
+      expect(mockedNavigateToFlyout.mock.calls[0][0].flyout.right).toEqual({
+        id: 'user-panel',
+        params: {
+          contextID: 'agent-builder-entity-card',
+          scopeId: 'agent-builder-entity-card',
+          userName: 'bob',
+          identityFields: { 'user.name': 'bob' },
+          entityId: 'user:bob@default',
+        },
+      });
+    });
+
+    it('opens the flyout with the ServicePanelKey payload for service rows with an entity id', () => {
+      renderTable({
+        entity_type: 'service',
+        entity_id: 'service:auth-svc@default',
+        entity_name: 'auth-svc',
+      });
+
+      fireEvent.click(screen.getByLabelText('Open entity in Entity Analytics'));
+
+      expect(mockedNavigateToFlyout).toHaveBeenCalledTimes(1);
+      expect(mockedNavigateToFlyout.mock.calls[0][0].flyout.right).toEqual({
+        id: 'service-panel',
+        params: {
+          contextID: 'agent-builder-entity-card',
+          scopeId: 'agent-builder-entity-card',
+          serviceName: 'auth-svc',
+          entityId: 'service:auth-svc@default',
+        },
+      });
+    });
+
+    it('falls back to the entity_id for the display name when entity_name is missing', () => {
+      renderTable({
+        entity_type: 'host',
+        entity_id: 'host:no-name@default',
+      });
+
+      fireEvent.click(screen.getByLabelText('Open entity in Entity Analytics'));
+
+      expect(mockedNavigateToFlyout).toHaveBeenCalledTimes(1);
+      expect(mockedNavigateToFlyout.mock.calls[0][0].flyout.right.params).toMatchObject({
+        hostName: 'host:no-name@default',
+        entityId: 'host:no-name@default',
+      });
+    });
+
+    it('falls back to the unfiltered Entity Analytics home for generic entities (no dedicated flyout)', () => {
+      const { application } = renderTable({
+        entity_type: 'generic',
+        entity_id: 'generic:some-id@default',
+        entity_name: 'some-id',
+      });
+
+      fireEvent.click(screen.getByLabelText('Open entity in Entity Analytics'));
+
+      expect(mockedNavigateToHome).toHaveBeenCalledTimes(1);
+      expect(mockedNavigateToFlyout).not.toHaveBeenCalled();
+      expect(mockedNavigateToHome.mock.calls[0][0].application).toBe(application);
+    });
+
+    it('forwards searchSession to the flyout helper', () => {
+      const searchSession = { clear: jest.fn() } as unknown as ISessionService;
+
+      renderTable(
+        {
+          entity_type: 'host',
+          entity_id: 'host:web-01@default',
+          entity_name: 'web-01',
+        },
+        { searchSession }
+      );
+
+      fireEvent.click(screen.getByLabelText('Open entity in Entity Analytics'));
+
+      expect(mockedNavigateToFlyout).toHaveBeenCalledTimes(1);
+      expect(mockedNavigateToFlyout.mock.calls[0][0].searchSession).toBe(searchSession);
+    });
+
+    it('forwards searchSession to the home fallback helper', () => {
+      const searchSession = { clear: jest.fn() } as unknown as ISessionService;
+
+      renderTable(
+        {
+          entity_type: 'generic',
+          entity_id: 'generic:some-id@default',
+          entity_name: 'some-id',
+        },
+        { searchSession }
+      );
+
+      fireEvent.click(screen.getByLabelText('Open entity in Entity Analytics'));
+
+      expect(mockedNavigateToHome).toHaveBeenCalledTimes(1);
+      expect(mockedNavigateToHome.mock.calls[0][0].searchSession).toBe(searchSession);
+    });
+
+    it('closes the canvas before navigating to the Entity Analytics flyout so it is not overlaid by the canvas', () => {
+      const closeCanvas = jest.fn();
+      let navigateCallOrder = -1;
+      mockedNavigateToFlyout.mockImplementation(() => {
+        navigateCallOrder = closeCanvas.mock.invocationCallOrder[0] ?? -1;
+      });
+
+      renderTable(
+        {
+          entity_type: 'host',
+          entity_id: 'host:web-01@default',
+          entity_name: 'web-01',
+        },
+        { closeCanvas }
+      );
+
+      fireEvent.click(screen.getByLabelText('Open entity in Entity Analytics'));
+
+      expect(closeCanvas).toHaveBeenCalledTimes(1);
+      expect(mockedNavigateToFlyout).toHaveBeenCalledTimes(1);
+      expect(navigateCallOrder).toBeGreaterThan(-1);
+      expect(closeCanvas.mock.invocationCallOrder[0]).toBeLessThan(
+        mockedNavigateToFlyout.mock.invocationCallOrder[0]
+      );
+    });
+
+    it('closes the canvas before falling back to the Entity Analytics home page for generic entities', () => {
+      const closeCanvas = jest.fn();
+
+      renderTable(
+        {
+          entity_type: 'generic',
+          entity_id: 'generic:some-id@default',
+          entity_name: 'some-id',
+        },
+        { closeCanvas }
+      );
+
+      fireEvent.click(screen.getByLabelText('Open entity in Entity Analytics'));
+
+      expect(closeCanvas).toHaveBeenCalledTimes(1);
+      expect(mockedNavigateToHome).toHaveBeenCalledTimes(1);
+      expect(closeCanvas.mock.invocationCallOrder[0]).toBeLessThan(
+        mockedNavigateToHome.mock.invocationCallOrder[0]
+      );
+    });
+
+    it('is a no-op when closeCanvas is not provided (inline table usage)', () => {
+      renderTable({
+        entity_type: 'host',
+        entity_id: 'host:web-01@default',
+        entity_name: 'web-01',
+      });
+
+      expect(() => {
+        fireEvent.click(screen.getByLabelText('Open entity in Entity Analytics'));
+      }).not.toThrow();
+      expect(mockedNavigateToFlyout).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_list_table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/entity_list_table.tsx
@@ -1,0 +1,391 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useMemo } from 'react';
+import {
+  EuiButtonIcon,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiInMemoryTable,
+  EuiText,
+  useEuiTheme,
+  type EuiBasicTableColumn,
+} from '@elastic/eui';
+import { css } from '@emotion/react';
+import { i18n } from '@kbn/i18n';
+import type { ApplicationStart } from '@kbn/core-application-browser';
+import type { ISessionService } from '@kbn/data-plugin/public';
+import type { CriticalityLevelWithUnassigned } from '../../../common/entity_analytics/asset_criticality/types';
+import type { EntityType } from '../../../common/entity_analytics/types';
+import { RiskSeverity } from '../../../common/search_strategy';
+import { APP_UI_ID } from '../../../common/constants';
+import { FormattedRelativePreferenceDate } from '../../common/components/formatted_date';
+import { getEmptyTagValue } from '../../common/components/empty_value';
+import {
+  buildEntityRightPanel,
+  navigateToEntityAnalyticsHomePageInApp,
+  navigateToEntityAnalyticsWithFlyoutInApp,
+} from './entity_explore_navigation';
+import { formatRiskScore } from '../../entity_analytics/common';
+import { CRITICALITY_LEVEL_TITLE } from '../../entity_analytics/components/asset_criticality/translations';
+import { RiskScoreLevel } from '../../entity_analytics/components/severity/common';
+import { EntityIconByType } from '../../entity_analytics/components/entity_store/helpers';
+import { TruncatedBadgeList } from '../../flyout/entity_details/shared/components/entity_source_value';
+import { formatEntitySource } from './entity_attachment/entity_table/entity_data_source_utils';
+
+export interface EntityListRow {
+  entity_type: 'host' | 'user' | 'service' | 'generic';
+  entity_id: string;
+  entity_name?: string;
+  source?: unknown;
+  risk_score_norm?: number;
+  risk_level?: string;
+  criticality?: string;
+  first_seen?: string;
+  last_seen?: string;
+}
+
+const parseRiskLevel = (raw?: string): RiskSeverity => {
+  if (!raw) {
+    return RiskSeverity.Unknown;
+  }
+  const normalized = raw.charAt(0).toUpperCase() + raw.slice(1).toLowerCase();
+  const allowed = Object.values(RiskSeverity) as string[];
+  if (allowed.includes(normalized)) {
+    return normalized as RiskSeverity;
+  }
+  return RiskSeverity.Unknown;
+};
+
+const criticalityLabel = (raw?: string): string | undefined => {
+  if (!raw) {
+    return undefined;
+  }
+  return CRITICALITY_LEVEL_TITLE[raw as CriticalityLevelWithUnassigned] ?? raw;
+};
+
+const LAST_SEEN_TOOLTIP_FIELD_NAME = '@timestamp';
+
+const SOURCE_OVERFLOW_TOOLTIP_TITLE = i18n.translate(
+  'xpack.securitySolution.agentBuilder.entityListAttachment.col.sourceOverflowTitle',
+  { defaultMessage: 'Additional data sources' }
+);
+const FIRST_SEEN_TOOLTIP_FIELD_NAME = 'entity.lifecycle.first_seen';
+
+const OPEN_ENTITY_IN_ENTITY_ANALYTICS_ARIA = i18n.translate(
+  'xpack.securitySolution.agentBuilder.entityListAttachment.openEntityInEntityAnalyticsAria',
+  { defaultMessage: 'Open entity in Entity Analytics' }
+);
+
+/**
+ * Coerce the `source` column value into the multi-value string array shape of
+ * `entity.source`. Rows from the entity store project `entity.source` as
+ * either a single string (legacy) or an array of strings. We accept either
+ * and drop anything non-string so the badge renderer only has to deal with
+ * `string[]`.
+ */
+const normalizeEntitySources = (source: unknown): string[] => {
+  if (typeof source === 'string') {
+    return source ? [source] : [];
+  }
+  if (Array.isArray(source)) {
+    return source.filter((v): v is string => typeof v === 'string' && v.length > 0);
+  }
+  return [];
+};
+
+const NAME_COLUMN_WIDTH = '260px';
+
+/**
+ * Horizontal scroll wrapper for the entity list table. The canvas preview panel
+ * can be narrower than the sum of the table's 8 columns (Name, Source,
+ * Criticality, Risk score, Risk level, First seen, Last seen, Entity ID),
+ * especially on laptop-width screens. We keep the table at a readable minimum
+ * width and let it overflow with a scrollbar instead of squeezing columns into
+ * character-by-character wrapping. The wrapper establishes its own horizontal
+ * scroll container so the outer dashboard panel (title, risk breakdown,
+ * highlights, by-type stats) continues to fit the visible width.
+ *
+ * The min-width (1000px) is tuned to fit the explicit Name and Source column
+ * widths plus enough room for the remaining six columns without forcing the
+ * Name cell to wrap common email-style entity names.
+ *
+ * We also pin the first header + body cells to NAME_COLUMN_WIDTH. Under
+ * tableLayout="auto" the column's `width` prop is only a hint and the browser
+ * can reallocate space between pages (noticeable when pagination swaps in
+ * rows whose other-column content has different widths). Forcing
+ * width/min-width/max-width on the cells themselves makes the Name column
+ * stable across pages.
+ *
+ * Pagination overrides: when this attachment is rendered inside a chat round,
+ * the message content sits inside an `EuiText` + `EuiMarkdownFormat` scope
+ * that forces `ul { list-style: disc; margin-inline-start: 1.7143rem; }` onto
+ * every nested list. EuiPagination renders its buttons inside a
+ * `<ul class="euiPagination__list">`, so the inherited rules turn each
+ * `<li>` into a visible bullet — the stray dark dot that shows up between
+ * the "previous" chevron and the first page button — and push the whole
+ * list to the right with a markdown-list indent. We also zero out any
+ * background/outline on the active-page `EuiPaginationButton` so that
+ * chat-scope styles (e.g. disabled-button tints inherited from ancestor
+ * themes) do not render as a circular "disc" behind the active page
+ * number. Scoped to this wrapper so the overrides only affect the entity
+ * list attachment table's pagination. Mirrors the sibling override in
+ * `entity_attachment/entity_table/entity_table.tsx`.
+ */
+const tableScrollStyles = css`
+  overflow-x: auto;
+
+  .euiTable {
+    min-width: 1000px;
+  }
+
+  .euiTable .euiTableHeaderCell:first-of-type,
+  .euiTable .euiTableRowCell:first-child {
+    width: ${NAME_COLUMN_WIDTH};
+    min-width: ${NAME_COLUMN_WIDTH};
+    max-width: ${NAME_COLUMN_WIDTH};
+  }
+
+  .euiPagination__list,
+  .euiPagination__list .euiPagination__item {
+    list-style: none;
+    margin: 0;
+    margin-inline-start: 0;
+    padding-inline-start: 0;
+  }
+
+  .euiPagination__list .euiPagination__item::marker,
+  .euiPagination__list .euiPagination__item::before {
+    content: none;
+  }
+
+  .euiPaginationButton[aria-current='page'],
+  .euiPaginationButton[aria-current='page']::before,
+  .euiPaginationButton[aria-current='page']::after {
+    background: transparent;
+    background-color: transparent;
+    box-shadow: none;
+    outline: none;
+  }
+`;
+
+export const EntityListTable: React.FC<{
+  entities: EntityListRow[];
+  application: ApplicationStart;
+  searchSession?: ISessionService;
+  /**
+   * Dismisses the Agent Builder canvas flyout. When present, the Name-column
+   * "open entity" button closes the canvas before navigating to Entity
+   * Analytics so the just-opened URL-backed expandable flyout isn't hidden
+   * underneath the canvas overlay.
+   */
+  closeCanvas?: () => void;
+}> = ({ entities, application, searchSession, closeCanvas }) => {
+  const { euiTheme } = useEuiTheme();
+
+  const columns: Array<EuiBasicTableColumn<EntityListRow>> = useMemo(
+    () => [
+      {
+        field: 'entity_name',
+        name: i18n.translate('xpack.securitySolution.agentBuilder.entityListAttachment.col.name', {
+          defaultMessage: 'Name',
+        }),
+        width: NAME_COLUMN_WIDTH,
+        render: (_: string, row: EntityListRow) => {
+          const icon = EntityIconByType[row.entity_type as EntityType] ?? 'globe';
+          const label = row.entity_name ?? row.entity_id;
+          return (
+            <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
+              <EuiFlexItem grow={false}>
+                <EuiButtonIcon
+                  iconType={icon}
+                  display="empty"
+                  aria-label={OPEN_ENTITY_IN_ENTITY_ANALYTICS_ARIA}
+                  onClick={() => {
+                    const displayName = row.entity_name ?? row.entity_id;
+                    const rightPanel = buildEntityRightPanel({
+                      identifierType: row.entity_type,
+                      identifier: displayName,
+                      entityStoreId: row.entity_id,
+                    });
+                    // Close the canvas first: both navigation helpers only
+                    // update the URL (and, when wired, the Agent Builder
+                    // sidebar). Leaving the canvas open would overlay the
+                    // expandable flyout that the URL change is about to open.
+                    closeCanvas?.();
+                    if (rightPanel) {
+                      navigateToEntityAnalyticsWithFlyoutInApp({
+                        application,
+                        appId: APP_UI_ID,
+                        flyout: { preview: [], right: rightPanel },
+                        searchSession,
+                      });
+                      return;
+                    }
+                    navigateToEntityAnalyticsHomePageInApp({
+                      application,
+                      appId: APP_UI_ID,
+                      searchSession,
+                    });
+                  }}
+                />
+              </EuiFlexItem>
+              <EuiFlexItem grow={true} style={{ minWidth: 0 }}>
+                <EuiText
+                  size="s"
+                  css={{
+                    overflowWrap: 'anywhere',
+                    wordBreak: 'break-word',
+                  }}
+                >
+                  {label}
+                </EuiText>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          );
+        },
+      },
+      {
+        field: 'source',
+        name: i18n.translate(
+          'xpack.securitySolution.agentBuilder.entityListAttachment.col.source',
+          {
+            defaultMessage: 'Source',
+          }
+        ),
+        width: '140px',
+        render: (source: unknown) => {
+          const list = normalizeEntitySources(source);
+          if (list.length === 0) {
+            return getEmptyTagValue();
+          }
+          return (
+            <TruncatedBadgeList
+              values={list}
+              formatValue={formatEntitySource}
+              overflowTooltipTitle={SOURCE_OVERFLOW_TOOLTIP_TITLE}
+              data-test-subj="entityListAttachmentTableSources"
+            />
+          );
+        },
+      },
+      {
+        field: 'criticality',
+        name: i18n.translate(
+          'xpack.securitySolution.agentBuilder.entityListAttachment.col.criticality',
+          {
+            defaultMessage: 'Criticality',
+          }
+        ),
+        render: (c: string | undefined) => {
+          const title = criticalityLabel(c);
+          return title ? <EuiText size="s">{title}</EuiText> : getEmptyTagValue();
+        },
+      },
+      {
+        field: 'risk_score_norm',
+        name: i18n.translate(
+          'xpack.securitySolution.agentBuilder.entityListAttachment.col.riskScore',
+          {
+            defaultMessage: 'Risk score',
+          }
+        ),
+        dataType: 'number',
+        render: (score: number | undefined) =>
+          score != null ? (
+            <EuiText size="s" data-test-subj="entity-list-risk-score">
+              {formatRiskScore(score)}
+            </EuiText>
+          ) : (
+            getEmptyTagValue()
+          ),
+      },
+      {
+        field: 'risk_level',
+        name: i18n.translate(
+          'xpack.securitySolution.agentBuilder.entityListAttachment.col.riskLevel',
+          {
+            defaultMessage: 'Risk level',
+          }
+        ),
+        render: (_: string | undefined, row: EntityListRow) => (
+          <RiskScoreLevel severity={parseRiskLevel(row.risk_level)} />
+        ),
+      },
+      {
+        field: 'first_seen',
+        name: i18n.translate(
+          'xpack.securitySolution.agentBuilder.entityListAttachment.col.firstSeen',
+          {
+            defaultMessage: 'First seen',
+          }
+        ),
+        render: (value: string | undefined) =>
+          value ? (
+            <FormattedRelativePreferenceDate
+              value={value}
+              relativeThresholdInHrs={Number.MAX_SAFE_INTEGER}
+              tooltipFieldName={FIRST_SEEN_TOOLTIP_FIELD_NAME}
+            />
+          ) : (
+            getEmptyTagValue()
+          ),
+      },
+      {
+        field: 'last_seen',
+        name: i18n.translate(
+          'xpack.securitySolution.agentBuilder.entityListAttachment.col.lastSeen',
+          {
+            defaultMessage: 'Last seen',
+          }
+        ),
+        render: (value: string | undefined) =>
+          value ? (
+            <FormattedRelativePreferenceDate
+              value={value}
+              relativeThresholdInHrs={Number.MAX_SAFE_INTEGER}
+              tooltipFieldName={LAST_SEEN_TOOLTIP_FIELD_NAME}
+            />
+          ) : (
+            getEmptyTagValue()
+          ),
+      },
+      {
+        field: 'entity_id',
+        name: i18n.translate('xpack.securitySolution.agentBuilder.entityListAttachment.col.euid', {
+          defaultMessage: 'Entity ID (EUID)',
+        }),
+        truncateText: true,
+        render: (id: string) => (
+          <EuiText size="xs" css={{ fontFamily: euiTheme.font.familyCode }}>
+            {id}
+          </EuiText>
+        ),
+      },
+    ],
+    [application, closeCanvas, euiTheme.font.familyCode, searchSession]
+  );
+
+  return (
+    <div css={tableScrollStyles}>
+      <EuiInMemoryTable<EntityListRow>
+        tableCaption={i18n.translate(
+          'xpack.securitySolution.agentBuilder.entityListAttachment.tableCaption',
+          {
+            defaultMessage: 'Security entities referenced in this conversation',
+          }
+        )}
+        items={entities}
+        columns={columns}
+        pagination={entities.length > 10 ? { pageSizeOptions: [10, 25, 50] } : false}
+        sorting={true}
+        tableLayout="auto"
+        responsiveBreakpoint={false}
+      />
+    </div>
+  );
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/index.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/index.test.ts
@@ -50,4 +50,13 @@ describe('registerAttachmentUiDefinitions', () => {
     };
     expect(config.getLabel(attachment)).toBe('Security Alert');
   });
+
+  it('does not register the security.entity attachment type (owned by registerEntityAttachment)', () => {
+    registerAttachmentUiDefinitions(mockAttachments);
+
+    const entityCall = mockAddAttachmentType.mock.calls.find(
+      (call: unknown[]) => call[0] === SecurityAgentBuilderAttachments.entity
+    );
+    expect(entityCall).toBeUndefined();
+  });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/index.ts
@@ -7,7 +7,14 @@
 import { i18n } from '@kbn/i18n';
 import type { AttachmentServiceStartContract } from '@kbn/agent-builder-browser';
 import type { Attachment } from '@kbn/agent-builder-common/attachments';
+import type { ApplicationStart } from '@kbn/core-application-browser';
+import type { AgentBuilderPluginStart } from '@kbn/agent-builder-plugin/public';
+import type { ISessionService } from '@kbn/data-plugin/public';
 import { SecurityAgentBuilderAttachments } from '../../../common/constants';
+import type { ExperimentalFeatures } from '../../../common/experimental_features';
+import type { SecurityCanvasEmbeddedBundle } from '../components/security_redux_embedded_provider';
+import type { SecurityAgentBuilderChrome } from './entity_explore_navigation';
+import type { AiRuleCreationService } from '../../detection_engine/common/ai_rule_creation_store';
 
 /**
  * Extension of UnknownAttachment that includes an optional attachmentLabel field in the data property
@@ -23,22 +30,13 @@ interface AttachmentTypeConfig {
   icon: string;
 }
 
-const ATTACHMENT_TYPE_CONFIGS: AttachmentTypeConfig[] = [
-  {
-    type: SecurityAgentBuilderAttachments.alert,
-    label: i18n.translate('xpack.securitySolution.agentBuilder.attachments.alert.label', {
-      defaultMessage: 'Security Alert',
-    }),
-    icon: 'bell',
-  },
-  {
-    type: SecurityAgentBuilderAttachments.entity,
-    label: i18n.translate('xpack.securitySolution.agentBuilder.attachments.entity.label', {
-      defaultMessage: 'Risk Entity',
-    }),
-    icon: 'user',
-  },
-];
+const ALERT_ATTACHMENT_CONFIG: AttachmentTypeConfig = {
+  type: SecurityAgentBuilderAttachments.alert,
+  label: i18n.translate('xpack.securitySolution.agentBuilder.attachments.alert.label', {
+    defaultMessage: 'Security Alert',
+  }),
+  icon: 'bell',
+};
 
 const createAttachmentTypeConfig = (defaultLabel: string, icon: string) => ({
   getLabel: (attachment: UnknownAttachmentWithLabel) => {
@@ -48,11 +46,129 @@ const createAttachmentTypeConfig = (defaultLabel: string, icon: string) => ({
   getIcon: () => icon,
 });
 
+/**
+ * Registers the baseline attachment UI definitions that do not require Security Solution runtime
+ * context:
+ *   - `security.alert` — label + icon only (no rich renderer yet).
+ *
+ * The rich `security.entity` renderer (card/table + Canvas) is installed via the separate
+ * {@link registerEntityAttachment} entry point so the plugin's `start()` can supply
+ * `application`, `chrome`, `agentBuilder`, and the lazy Redux/services bundle.
+ */
 export const registerAttachmentUiDefinitions = (attachments: AttachmentServiceStartContract) => {
-  ATTACHMENT_TYPE_CONFIGS.forEach(({ type, label, icon }) => {
-    attachments.addAttachmentType<UnknownAttachmentWithLabel>(
-      type,
-      createAttachmentTypeConfig(label, icon)
+  attachments.addAttachmentType<UnknownAttachmentWithLabel>(
+    ALERT_ATTACHMENT_CONFIG.type,
+    createAttachmentTypeConfig(ALERT_ATTACHMENT_CONFIG.label, ALERT_ATTACHMENT_CONFIG.icon)
+  );
+};
+
+/**
+ * Registers the rich `security.entity` attachment renderer (entity card for a single entity,
+ * entity table with per-row Explore links for multiple, Canvas preview for single host/user/
+ * service). Callable from `plugin.tsx#start()` alongside `registerRuleAttachment` /
+ * `registerEntityAnalyticsDashboardAttachment` once the Security sub-plugins and services are
+ * available.
+ *
+ * The lazy `security_entity_attachment_rich` chunk keeps bundle impact at zero until the first
+ * `security.entity` attachment is rendered. The `security.entity` attachment itself is only
+ * ever emitted by the Entity Store V2 tools (`security.get_entity` /
+ * `security.search_entities`), which are gated on `entityAnalyticsEntityStoreV2`, so non-V2
+ * environments never exercise this renderer even though it's registered unconditionally.
+ */
+export const registerEntityAttachment = ({
+  attachments,
+  application,
+  agentBuilder,
+  chrome,
+  experimentalFeatures,
+  resolveSecurityCanvasContext,
+  searchSession,
+}: {
+  attachments: AttachmentServiceStartContract;
+  application: ApplicationStart;
+  agentBuilder?: AgentBuilderPluginStart;
+  chrome?: SecurityAgentBuilderChrome;
+  experimentalFeatures: ExperimentalFeatures;
+  resolveSecurityCanvasContext: () => Promise<SecurityCanvasEmbeddedBundle>;
+  searchSession?: ISessionService;
+}): void => {
+  void import(
+    /* webpackChunkName: "security_entity_attachment_rich" */
+    './entity_attachment'
+  ).then(({ createEntityAttachmentDefinition }) => {
+    attachments.addAttachmentType(
+      SecurityAgentBuilderAttachments.entity,
+      createEntityAttachmentDefinition({
+        experimentalFeatures,
+        application,
+        agentBuilder,
+        chrome,
+        resolveSecurityCanvasContext,
+        searchSession,
+      })
     );
+  });
+};
+
+/**
+ * Registers the `security.rule` attachment renderer (rule preview card with
+ * "Apply to creation" / "Update rule" action buttons). Dynamically imports
+ * [./rule_attachment](./rule_attachment.tsx) so the rule-schema helpers and the
+ * EUI `EuiCodeBlock`/`EuiCallOut` surface stay off the main `securitySolution`
+ * page-load bundle.
+ *
+ * Race-window: until the chunk resolves, `security.rule` attachments are not
+ * registered yet and the Agent Builder attachments service falls back to its
+ * default handling. In practice the chunk resolves well before the user can
+ * post a message and get a rule attachment back from the LLM.
+ */
+export const registerRuleAttachment = ({
+  attachments,
+  application,
+  aiRuleCreation,
+}: {
+  attachments: AttachmentServiceStartContract;
+  application: ApplicationStart;
+  aiRuleCreation: AiRuleCreationService;
+}): void => {
+  void import(
+    /* webpackChunkName: "security_rule_attachment" */
+    './rule_attachment'
+  ).then(({ registerRuleAttachment: register }) => {
+    register({ attachments, application, aiRuleCreation });
+  });
+};
+
+/**
+ * Registers the `security.entity_analytics_dashboard` attachment renderer
+ * (inline summary pill + Canvas dashboard with risk breakdown, donut chart,
+ * and entity list). Dynamically imports
+ * [./entity_analytics_dashboard_attachment](./entity_analytics_dashboard_attachment.tsx)
+ * so the heavy transitive deps (`RiskLevelBreakdownTable`,
+ * `RiskScoreDonutChart`, `EntityListTable`, plus the Security
+ * entity-analytics translations/Redux wiring) stay off the main bundle.
+ *
+ * Race-window: same semantics as {@link registerRuleAttachment} — the chunk
+ * resolves during plugin start well before the user can receive a dashboard
+ * attachment from the LLM.
+ */
+export const registerEntityAnalyticsDashboardAttachment = ({
+  attachments,
+  application,
+  agentBuilder,
+  chrome,
+  searchSession,
+}: {
+  attachments: AttachmentServiceStartContract;
+  application: ApplicationStart;
+  agentBuilder?: AgentBuilderPluginStart;
+  chrome?: SecurityAgentBuilderChrome;
+  searchSession?: ISessionService;
+}): void => {
+  void import(
+    /* webpackChunkName: "security_entity_analytics_dashboard_attachment" */
+    './entity_analytics_dashboard_attachment'
+  ).then(({ registerEntityAnalyticsDashboardAttachment: register }) => {
+    register({ attachments, application, agentBuilder, chrome, searchSession });
   });
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/components/entity_card_flyout_overview_canvas.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/components/entity_card_flyout_overview_canvas.test.tsx
@@ -1,0 +1,96 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { I18nProvider } from '@kbn/i18n-react';
+import type { ApplicationStart } from '@kbn/core-application-browser';
+import type { EntityForAttachment } from '../attachment_types/entity_attachment/use_entity_for_attachment';
+import { useEntityForAttachment } from '../attachment_types/entity_attachment/use_entity_for_attachment';
+import { EntityType } from '../../../common/entity_analytics/types';
+import { EntityCardFlyoutOverviewCanvas } from './entity_card_flyout_overview_canvas';
+
+/**
+ * The canvas component is a thin dispatcher:
+ *   - `isLoading && !data`  → <FlyoutLoading />
+ *   - identifierType === 'generic' → null
+ *   - identifierType ∈ {host,user,service} → <HostEntityFlyoutOverviewCanvas | UserEntity... | ServiceEntity...>
+ *
+ * The sub-canvases transitively require the in-app Security providers (Redux, sourcerer,
+ * `useGlobalTime`, `useRiskScore`, entity-store hooks, …); mounting them here would require
+ * reproducing the entire Security runtime. Those branches are already covered by the flyout's
+ * own test suite. This file focuses on the dispatch-level branches: loading and `generic → null`.
+ */
+
+jest.mock('../attachment_types/entity_attachment/use_entity_for_attachment', () => ({
+  useEntityForAttachment: jest.fn(),
+}));
+
+jest.mock('../../flyout/shared/components/flyout_loading', () => ({
+  FlyoutLoading: () => <div data-test-subj="flyoutLoadingMock" />,
+}));
+
+const mockedUseEntityForAttachment = useEntityForAttachment as jest.Mock;
+
+const baseEntityData = (override: Partial<EntityForAttachment> = {}): EntityForAttachment => ({
+  entityType: EntityType.host,
+  displayName: 'host-1',
+  entityId: 'entity-id',
+  isEntityInStore: true,
+  firstSeen: null,
+  lastSeen: null,
+  timestamp: null,
+  watchlistIds: [],
+  sources: [],
+  ...override,
+});
+
+const applicationStub = { navigateToApp: jest.fn() } as unknown as ApplicationStart;
+
+const renderCanvas = (identifier: {
+  identifierType: 'host' | 'user' | 'service' | 'generic';
+  identifier: string;
+}) =>
+  render(
+    <I18nProvider>
+      <EntityCardFlyoutOverviewCanvas identifier={identifier} application={applicationStub} />
+    </I18nProvider>
+  );
+
+describe('EntityCardFlyoutOverviewCanvas', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('shows FlyoutLoading while useEntityForAttachment is loading and has no data yet', () => {
+    mockedUseEntityForAttachment.mockReturnValue({
+      data: null,
+      isLoading: true,
+      error: null,
+      refetch: jest.fn(),
+    });
+
+    renderCanvas({ identifierType: 'host', identifier: 'host-1' });
+    expect(screen.getByTestId('flyoutLoadingMock')).toBeInTheDocument();
+  });
+
+  it('returns null for generic entity types (Security flyout only supports host/user/service)', () => {
+    mockedUseEntityForAttachment.mockReturnValue({
+      data: baseEntityData({ entityType: EntityType.generic }),
+      isLoading: false,
+      error: null,
+      refetch: jest.fn(),
+    });
+
+    const { container } = renderCanvas({
+      identifierType: 'generic',
+      identifier: 'some-resource',
+    });
+    expect(container.firstChild).toBeNull();
+    expect(screen.queryByTestId('flyoutLoadingMock')).not.toBeInTheDocument();
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/components/entity_card_flyout_overview_canvas.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/components/entity_card_flyout_overview_canvas.tsx
@@ -1,0 +1,1115 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useCallback, useMemo } from 'react';
+import type { ApplicationStart } from '@kbn/core-application-browser';
+import type { AgentBuilderPluginStart } from '@kbn/agent-builder-plugin/public';
+import type { ISessionService } from '@kbn/data-plugin/public';
+import { FF_ENABLE_ENTITY_STORE_V2, useEntityStoreEuidApi } from '@kbn/entity-store/public';
+import { useHasMisconfigurations } from '@kbn/cloud-security-posture/src/hooks/use_has_misconfigurations';
+import { useHasVulnerabilities } from '@kbn/cloud-security-posture/src/hooks/use_has_vulnerabilities';
+import { EuiSpacer } from '@elastic/eui';
+import { noop } from 'lodash/fp';
+import { useUpdateAssetCriticality } from '../../entity_analytics/api/hooks/use_update_asset_criticality';
+import { buildEuidCspPreviewOptions } from '../../cloud_security_posture/utils/build_euid_csp_preview_options';
+import { useNonClosedAlerts } from '../../cloud_security_posture/hooks/use_non_closed_alerts';
+import { DETECTION_RESPONSE_ALERTS_BY_STATUS_ID } from '../../overview/components/detection_response/alerts_by_status/types';
+import { useRefetchQueryById } from '../../entity_analytics/api/hooks/use_refetch_query_by_id';
+import { RISK_INPUTS_TAB_QUERY_ID } from '../../entity_analytics/components/entity_details_flyout/tabs/risk_inputs/risk_inputs_tab';
+import type { Refetch } from '../../common/types';
+import { useCalculateEntityRiskScore } from '../../entity_analytics/api/hooks/use_calculate_entity_risk_score';
+import { useRiskScore } from '../../entity_analytics/api/hooks/use_risk_score';
+import { useQueryInspector } from '../../common/components/page/manage_query';
+import { useGlobalTime } from '../../common/containers/use_global_time';
+import {
+  buildEntityNameFilter,
+  buildHostNamesFilter,
+  buildUserNamesFilter,
+  EntityType as SearchEntityType,
+  type RiskSeverity,
+} from '../../../common/search_strategy';
+import { useUiSetting, useKibana } from '../../common/lib/kibana';
+import { HostPanelContent } from '../../flyout/entity_details/host_right/content';
+import { HostPanelHeader } from '../../flyout/entity_details/host_right/header';
+import { useObservedHost } from '../../flyout/entity_details/host_right/hooks/use_observed_host';
+import { EntityType } from '../../../common/entity_analytics/types';
+import {
+  buildRiskScoreStateFromEntityRecord,
+  getRiskFromEntityRecord,
+} from '../../flyout/entity_details/shared/entity_store_risk_utils';
+import { useEntityFromStore } from '../../flyout/entity_details/shared/hooks/use_entity_from_store';
+import type { CriticalityLevelWithUnassigned } from '../../../common/entity_analytics/asset_criticality/types';
+import {
+  mergeLegacyIdentityWhenStoreEntityMissing,
+  type IdentityFields,
+} from '../../flyout/document_details/shared/utils';
+import { HOST_PANEL_RISK_SCORE_QUERY_ID } from '../../flyout/entity_details/host_right/constants';
+import { FlyoutBody } from '../../flyout/shared/components/flyout_body';
+import {
+  useEntityPanelTabs,
+  TABLE_TAB_ID,
+} from '../../flyout/entity_details/shared/hooks/use_entity_panel_tabs';
+import { EntityPanelHeaderTabs } from '../../flyout/entity_details/shared/components/entity_panel_tabs';
+import { EntityStoreTableTab } from '../../flyout/entity_details/shared/components/entity_store_table_tab';
+import { EntitySummaryGrid } from '../../flyout/entity_details/shared/components/entity_summary_grid';
+import { HostDetailsPanelKey } from '../../flyout/entity_details/host_details_left';
+import {
+  HostPanelKey,
+  ServicePanelKey,
+  UserPanelKey,
+} from '../../flyout/entity_details/shared/constants';
+import type { EntityDetailsPath } from '../../flyout/entity_details/shared/components/left_panel/left_panel_header';
+import { EntityEventTypes } from '../../common/lib/telemetry';
+import { UserPanelContent } from '../../flyout/entity_details/user_right/content';
+import { UserPanelHeader } from '../../flyout/entity_details/user_right/header';
+import { useObservedUser } from '../../flyout/entity_details/user_right/hooks/use_observed_user';
+import { useManagedUser } from '../../flyout/entity_details/shared/hooks/use_managed_user';
+import { USER_PANEL_RISK_SCORE_QUERY_ID } from '../../flyout/entity_details/user_right/constants';
+import { UserDetailsPanelKey } from '../../flyout/entity_details/user_details_left';
+import { ServicePanelContent } from '../../flyout/entity_details/service_right/content';
+import { ServicePanelHeader } from '../../flyout/entity_details/service_right/header';
+import { useObservedService } from '../../flyout/entity_details/service_right/hooks/use_observed_service';
+import { ServiceDetailsPanelKey } from '../../flyout/entity_details/service_details_left';
+import { SERVICE_PANEL_RISK_SCORE_QUERY_ID } from '../../flyout/entity_details/service_right';
+import type { ESQuery } from '../../../common/typed_json';
+import { FlyoutLoading } from '../../flyout/shared/components/flyout_loading';
+import { APP_UI_ID } from '../../../common/constants';
+import type { EntityAttachmentIdentifier } from '../attachment_types/entity_attachment/types';
+import { useEntityForAttachment } from '../attachment_types/entity_attachment/use_entity_for_attachment';
+import {
+  getHostNameForHostDetailsUrl,
+  getServiceNameForServiceDetailsUrl,
+  getUserNameForUserDetailsUrl,
+  navigateToEntityAnalyticsWithFlyoutInApp,
+  type SecurityAgentBuilderChrome,
+} from '../attachment_types/entity_explore_navigation';
+
+const AGENT_BUILDER_ENTITY_CARD_SCOPE = 'agent-builder-entity-card';
+
+const FIRST_RECORD_PAGINATION = {
+  cursorStart: 0,
+  querySize: 1,
+};
+
+const useOpenHostInvestigationInEntityAnalytics = ({
+  application,
+  agentBuilder,
+  chrome,
+  openSidebarConversation,
+  hostName,
+  entityIdForPanels,
+  scopeId,
+  safeContextID,
+  isRiskScoreExist,
+  hasMisconfigurationFindings,
+  hasVulnerabilitiesFindings,
+  hasNonClosedAlerts,
+  entityStoreEntityId,
+  searchSession,
+}: {
+  application: ApplicationStart;
+  agentBuilder?: AgentBuilderPluginStart;
+  chrome?: SecurityAgentBuilderChrome;
+  openSidebarConversation?: () => void;
+  hostName: string;
+  entityIdForPanels?: string;
+  scopeId: string;
+  safeContextID: string;
+  isRiskScoreExist: boolean;
+  hasMisconfigurationFindings: boolean;
+  hasVulnerabilitiesFindings: boolean;
+  hasNonClosedAlerts: boolean;
+  entityStoreEntityId?: string;
+  searchSession?: ISessionService;
+}): ((path?: EntityDetailsPath) => void) => {
+  const { telemetry } = useKibana().services;
+
+  return useCallback(
+    (path?: EntityDetailsPath) => {
+      telemetry.reportEvent(EntityEventTypes.RiskInputsExpandedFlyoutOpened, {
+        entity: SearchEntityType.host,
+      });
+      navigateToEntityAnalyticsWithFlyoutInApp({
+        application,
+        appId: APP_UI_ID,
+        agentBuilder,
+        chrome,
+        openSidebarConversation,
+        searchSession,
+        flyout: {
+          preview: [],
+          left: {
+            id: HostDetailsPanelKey,
+            params: {
+              entityId: entityIdForPanels,
+              hostName,
+              scopeId,
+              isRiskScoreExist,
+              path,
+              hasMisconfigurationFindings,
+              hasVulnerabilitiesFindings,
+              hasNonClosedAlerts,
+              entityStoreEntityId,
+            },
+          },
+          right: {
+            id: HostPanelKey,
+            params: {
+              contextID: safeContextID,
+              scopeId,
+              hostName,
+              entityId: entityIdForPanels,
+            },
+          },
+        },
+      });
+    },
+    [
+      application,
+      agentBuilder,
+      chrome,
+      openSidebarConversation,
+      entityIdForPanels,
+      hasMisconfigurationFindings,
+      hasNonClosedAlerts,
+      hasVulnerabilitiesFindings,
+      hostName,
+      isRiskScoreExist,
+      safeContextID,
+      scopeId,
+      entityStoreEntityId,
+      searchSession,
+      telemetry,
+    ]
+  );
+};
+
+const HostEntityFlyoutOverviewCanvas: React.FC<{
+  hostName: string;
+  entityId?: string;
+  application: ApplicationStart;
+  agentBuilder?: AgentBuilderPluginStart;
+  chrome?: SecurityAgentBuilderChrome;
+  openSidebarConversation?: () => void;
+  searchSession?: ISessionService;
+}> = ({
+  hostName,
+  entityId,
+  application,
+  agentBuilder,
+  chrome,
+  openSidebarConversation,
+  searchSession,
+}) => {
+  const euidApi = useEntityStoreEuidApi();
+  const entityStoreV2Enabled = useUiSetting<boolean>(FF_ENABLE_ENTITY_STORE_V2, false);
+
+  const safeContextID = AGENT_BUILDER_ENTITY_CARD_SCOPE;
+  const scopeId = AGENT_BUILDER_ENTITY_CARD_SCOPE;
+  const isPreviewMode = false;
+
+  const { to, from, setQuery, deleteQuery, isInitializing } = useGlobalTime();
+
+  const hostStoreIdentityFields = useMemo(
+    () => (!entityId && hostName ? { 'host.name': hostName } : undefined),
+    [entityId, hostName]
+  );
+
+  const entityFromStoreResult = useEntityFromStore({
+    entityId,
+    identityFields: hostStoreIdentityFields,
+    entityType: 'host',
+    skip: !entityStoreV2Enabled || isInitializing,
+  });
+
+  const documentEntityIdentifiers = useMemo<IdentityFields>(() => {
+    const legacyFields =
+      hostName != null && hostName !== '' ? { 'host.name': hostName } : ({} as IdentityFields);
+    if (entityStoreV2Enabled) {
+      const fromStore =
+        euidApi?.euid?.getEntityIdentifiersFromDocument(
+          'host',
+          entityFromStoreResult.entityRecord
+        ) ?? {};
+      return mergeLegacyIdentityWhenStoreEntityMissing(fromStore, legacyFields);
+    }
+    return legacyFields;
+  }, [entityStoreV2Enabled, euidApi?.euid, entityFromStoreResult.entityRecord, hostName]);
+
+  const hostNameFilterQuery = useMemo(
+    () => (hostName ? buildHostNamesFilter([hostName]) : undefined),
+    [hostName]
+  );
+
+  const riskScoreState = useRiskScore({
+    riskEntity: EntityType.host,
+    filterQuery: hostNameFilterQuery,
+    onlyLatest: false,
+    pagination: FIRST_RECORD_PAGINATION,
+    skip: entityStoreV2Enabled,
+  });
+
+  const { data: hostRisk, inspect: inspectRiskScore, refetch, loading } = riskScoreState;
+  const hostRiskData = hostRisk && hostRisk.length > 0 ? hostRisk[0] : undefined;
+
+  const refetchRiskInputsTab = useRefetchQueryById(RISK_INPUTS_TAB_QUERY_ID);
+  const refetchRiskScore = useCallback(() => {
+    refetch();
+    (refetchRiskInputsTab as Refetch | null)?.();
+  }, [refetch, refetchRiskInputsTab]);
+
+  const { isLoading: recalculatingScore, calculateEntityRiskScore } = useCalculateEntityRiskScore(
+    EntityType.host,
+    hostName,
+    { onSuccess: refetchRiskScore }
+  );
+
+  const { updateAssetCriticalityLevel } = useUpdateAssetCriticality('host', {
+    onSuccess: calculateEntityRiskScore,
+  });
+
+  const { hasMisconfigurationFindings } = useHasMisconfigurations(
+    buildEuidCspPreviewOptions('host', entityFromStoreResult.entityRecord, euidApi, {
+      entityStoreV2Enabled,
+      legacyIdentityFields:
+        hostName != null && hostName !== '' ? { 'host.name': hostName } : undefined,
+    })
+  );
+
+  const { hasVulnerabilitiesFindings } = useHasVulnerabilities(
+    buildEuidCspPreviewOptions('host', entityFromStoreResult.entityRecord, euidApi, {
+      entityStoreV2Enabled,
+      legacyIdentityFields:
+        hostName != null && hostName !== '' ? { 'host.name': hostName } : undefined,
+    })
+  );
+  const { hasNonClosedAlerts } = useNonClosedAlerts({
+    identityFields: documentEntityIdentifiers,
+    entityType: EntityType.host,
+    to,
+    from,
+    queryId: `${DETECTION_RESPONSE_ALERTS_BY_STATUS_ID}HOST_NAME_RIGHT`,
+  });
+
+  const observedHost = useObservedHost(
+    hostName,
+    scopeId,
+    entityStoreV2Enabled ? entityFromStoreResult : undefined
+  );
+
+  const panelDisplayEntityId = useMemo(
+    () => (entityStoreV2Enabled ? observedHost.entityRecord?.entity?.id : entityId),
+    [entityId, entityStoreV2Enabled, observedHost.entityRecord?.entity?.id]
+  );
+
+  const useEntityStoreInspectForRisk = entityStoreV2Enabled && observedHost.entityRecord != null;
+
+  useQueryInspector({
+    deleteQuery,
+    inspect: useEntityStoreInspectForRisk
+      ? entityFromStoreResult?.inspect ?? null
+      : inspectRiskScore,
+    loading: useEntityStoreInspectForRisk ? entityFromStoreResult?.isLoading ?? false : loading,
+    queryId: HOST_PANEL_RISK_SCORE_QUERY_ID,
+    refetch: useEntityStoreInspectForRisk ? entityFromStoreResult?.refetch ?? (() => {}) : refetch,
+    setQuery,
+  });
+
+  const riskScoreStateFromStore =
+    entityStoreV2Enabled && observedHost.entityRecord
+      ? buildRiskScoreStateFromEntityRecord(EntityType.host, observedHost.entityRecord, {
+          refetch: observedHost.refetchEntityStore ?? (() => {}),
+          isLoading: observedHost.isLoading,
+          error: null,
+          inspect: entityFromStoreResult?.inspect,
+        })
+      : null;
+
+  const effectiveRiskScoreState = riskScoreStateFromStore ?? riskScoreState;
+  const isRiskScoreExist =
+    entityStoreV2Enabled && observedHost.entityRecord
+      ? !!getRiskFromEntityRecord(observedHost.entityRecord)
+      : !!hostRiskData?.host?.risk;
+
+  const onCriticalitySave =
+    entityFromStoreResult.entityRecord && observedHost.entityRecord
+      ? (level: CriticalityLevelWithUnassigned) =>
+          updateAssetCriticalityLevel(level, observedHost.entityRecord)
+      : undefined;
+
+  const entityStoreEntityId = entityStoreV2Enabled
+    ? observedHost.entityRecord?.entity?.id
+    : undefined;
+
+  const openDetailsPanel = useOpenHostInvestigationInEntityAnalytics({
+    application,
+    agentBuilder,
+    chrome,
+    openSidebarConversation,
+    hostName,
+    entityIdForPanels: panelDisplayEntityId,
+    scopeId,
+    safeContextID,
+    isRiskScoreExist,
+    hasMisconfigurationFindings,
+    hasVulnerabilitiesFindings,
+    hasNonClosedAlerts,
+    entityStoreEntityId,
+    searchSession,
+  });
+
+  const noEntityInStore =
+    entityStoreV2Enabled && !entityFromStoreResult.isLoading && !observedHost.entityRecord;
+
+  const { tabs, selectedTabId, setSelectedTabId } = useEntityPanelTabs({
+    entityRecord: observedHost.entityRecord ?? null,
+  });
+
+  const tabsNode = tabs ? (
+    <EntityPanelHeaderTabs
+      tabs={tabs}
+      selectedTabId={selectedTabId}
+      setSelectedTabId={setSelectedTabId}
+    />
+  ) : undefined;
+
+  return (
+    <>
+      <HostPanelHeader
+        hostName={hostName}
+        lastSeen={observedHost.lastSeen}
+        entityId={panelDisplayEntityId}
+        identityFields={documentEntityIdentifiers}
+        isEntityInStore={!!observedHost.entityRecord}
+        riskLevel={
+          observedHost.entityRecord
+            ? ((getRiskFromEntityRecord(observedHost.entityRecord)?.calculated_level ??
+                'Unknown') as RiskSeverity)
+            : undefined
+        }
+      />
+      <FlyoutBody>
+        {observedHost.entityRecord && (
+          <EntitySummaryGrid
+            entityRecord={observedHost.entityRecord}
+            criticalityLevel={entityFromStoreResult.entityRecord?.asset?.criticality}
+            onCriticalitySave={onCriticalitySave}
+          />
+        )}
+        {tabsNode}
+        {tabs && <EuiSpacer size="l" />}
+        {tabs && selectedTabId === TABLE_TAB_ID && observedHost.entityRecord ? (
+          <EntityStoreTableTab entityRecord={observedHost.entityRecord} />
+        ) : (
+          <HostPanelContent
+            identityFields={documentEntityIdentifiers}
+            observedHost={observedHost}
+            riskScoreState={effectiveRiskScoreState}
+            contextID={safeContextID}
+            scopeId={scopeId}
+            openDetailsPanel={openDetailsPanel}
+            recalculatingScore={recalculatingScore}
+            onAssetCriticalityChange={calculateEntityRiskScore}
+            isPreviewMode={isPreviewMode}
+            entityRecord={entityStoreV2Enabled ? observedHost.entityRecord ?? undefined : undefined}
+            skipRiskAndCriticality={noEntityInStore}
+            entityStoreEntityId={entityStoreEntityId}
+          />
+        )}
+      </FlyoutBody>
+    </>
+  );
+};
+
+const useOpenUserInvestigationInEntityAnalytics = ({
+  application,
+  agentBuilder,
+  chrome,
+  openSidebarConversation,
+  userName,
+  entityIdForPanels,
+  identityFields,
+  scopeId,
+  safeContextID,
+  isRiskScoreExist,
+  hasMisconfigurationFindings,
+  hasNonClosedAlerts,
+  entityStoreEntityId,
+  searchSession,
+}: {
+  application: ApplicationStart;
+  agentBuilder?: AgentBuilderPluginStart;
+  chrome?: SecurityAgentBuilderChrome;
+  openSidebarConversation?: () => void;
+  userName: string;
+  entityIdForPanels?: string;
+  identityFields: IdentityFields;
+  scopeId: string;
+  safeContextID: string;
+  isRiskScoreExist: boolean;
+  hasMisconfigurationFindings: boolean;
+  hasNonClosedAlerts: boolean;
+  entityStoreEntityId?: string;
+  searchSession?: ISessionService;
+}): ((path: EntityDetailsPath) => void) => {
+  const { telemetry } = useKibana().services;
+
+  return useCallback(
+    (path: EntityDetailsPath) => {
+      telemetry.reportEvent(EntityEventTypes.RiskInputsExpandedFlyoutOpened, {
+        entity: SearchEntityType.user,
+      });
+      navigateToEntityAnalyticsWithFlyoutInApp({
+        application,
+        appId: APP_UI_ID,
+        agentBuilder,
+        chrome,
+        openSidebarConversation,
+        searchSession,
+        flyout: {
+          preview: [],
+          left: {
+            id: UserDetailsPanelKey,
+            params: {
+              userName,
+              identityFields,
+              isRiskScoreExist,
+              scopeId,
+              path,
+              entityId: entityIdForPanels,
+              hasMisconfigurationFindings,
+              hasNonClosedAlerts,
+              entityStoreEntityId,
+            },
+          },
+          right: {
+            id: UserPanelKey,
+            params: {
+              contextID: safeContextID,
+              userName,
+              identityFields,
+              entityId: entityIdForPanels,
+              scopeId,
+            },
+          },
+        },
+      });
+    },
+    [
+      application,
+      agentBuilder,
+      chrome,
+      openSidebarConversation,
+      entityIdForPanels,
+      hasMisconfigurationFindings,
+      hasNonClosedAlerts,
+      identityFields,
+      isRiskScoreExist,
+      safeContextID,
+      scopeId,
+      entityStoreEntityId,
+      searchSession,
+      telemetry,
+      userName,
+    ]
+  );
+};
+
+const UserEntityFlyoutOverviewCanvas: React.FC<{
+  userName: string;
+  entityId?: string;
+  application: ApplicationStart;
+  agentBuilder?: AgentBuilderPluginStart;
+  chrome?: SecurityAgentBuilderChrome;
+  openSidebarConversation?: () => void;
+  searchSession?: ISessionService;
+}> = ({
+  userName,
+  entityId: entityIdProp,
+  application,
+  agentBuilder,
+  chrome,
+  openSidebarConversation,
+  searchSession,
+}) => {
+  const euidApi = useEntityStoreEuidApi();
+  const entityStoreV2Enabled = useUiSetting<boolean>(FF_ENABLE_ENTITY_STORE_V2, false);
+
+  const safeContextID = AGENT_BUILDER_ENTITY_CARD_SCOPE;
+  const scopeId = AGENT_BUILDER_ENTITY_CARD_SCOPE;
+  const isPreviewMode = false;
+
+  const { to, from, setQuery, deleteQuery, isInitializing } = useGlobalTime();
+
+  const userStoreIdentityFields = useMemo(
+    () => (!entityIdProp && userName ? { 'user.name': userName } : undefined),
+    [entityIdProp, userName]
+  );
+
+  const entityFromStoreResult = useEntityFromStore({
+    entityId: entityIdProp,
+    identityFields: userStoreIdentityFields,
+    entityType: 'user',
+    skip: !entityStoreV2Enabled || isInitializing,
+  });
+
+  const documentEntityIdentifiers = useMemo<IdentityFields>(() => {
+    const legacyFields =
+      userName != null && userName !== '' ? { 'user.name': userName } : ({} as IdentityFields);
+    if (entityStoreV2Enabled) {
+      const fromStore =
+        euidApi?.euid?.getEntityIdentifiersFromDocument(
+          'user',
+          entityFromStoreResult.entityRecord
+        ) ?? {};
+      return mergeLegacyIdentityWhenStoreEntityMissing(fromStore, legacyFields);
+    }
+    return legacyFields;
+  }, [entityStoreV2Enabled, euidApi?.euid, entityFromStoreResult.entityRecord, userName]);
+
+  const userNameFilterQuery = useMemo(
+    () => (userName ? buildUserNamesFilter([userName]) : undefined),
+    [userName]
+  );
+  const observedUser = useObservedUser(
+    userName,
+    scopeId,
+    entityStoreV2Enabled ? entityFromStoreResult : undefined
+  );
+
+  const panelDisplayEntityId = useMemo(
+    () => (entityStoreV2Enabled ? observedUser.entityRecord?.entity?.id : entityIdProp),
+    [entityIdProp, entityStoreV2Enabled, observedUser.entityRecord?.entity?.id]
+  );
+
+  const riskScoreState = useRiskScore({
+    riskEntity: EntityType.user,
+    filterQuery: userNameFilterQuery,
+    onlyLatest: false,
+    pagination: FIRST_RECORD_PAGINATION,
+    skip: entityStoreV2Enabled && !!observedUser?.entityRecord,
+  });
+
+  const { inspect, refetch, loading } = riskScoreState;
+  const managedUser = useManagedUser();
+
+  const { data: userRisk } = riskScoreState;
+  const userRiskData = userRisk && userRisk.length > 0 ? userRisk[0] : undefined;
+
+  const refetchRiskInputsTab = useRefetchQueryById(RISK_INPUTS_TAB_QUERY_ID);
+  const refetchRiskScore = useCallback(() => {
+    refetch();
+    (refetchRiskInputsTab as Refetch | null)?.();
+  }, [refetch, refetchRiskInputsTab]);
+
+  const { isLoading: recalculatingScore, calculateEntityRiskScore } = useCalculateEntityRiskScore(
+    EntityType.user,
+    userName,
+    { onSuccess: refetchRiskScore }
+  );
+
+  const { updateAssetCriticalityLevel } = useUpdateAssetCriticality('user', {
+    onSuccess: calculateEntityRiskScore,
+  });
+
+  const { hasMisconfigurationFindings } = useHasMisconfigurations(
+    buildEuidCspPreviewOptions('user', entityFromStoreResult.entityRecord, euidApi, {
+      entityStoreV2Enabled,
+      legacyIdentityFields:
+        userName != null && userName !== '' ? { 'user.name': userName } : undefined,
+    })
+  );
+
+  const { hasNonClosedAlerts } = useNonClosedAlerts({
+    identityFields: documentEntityIdentifiers,
+    entityType: EntityType.user,
+    to,
+    from,
+    queryId: `${DETECTION_RESPONSE_ALERTS_BY_STATUS_ID}USER_NAME_RIGHT`,
+  });
+
+  const useEntityStoreInspectForRisk = entityStoreV2Enabled && observedUser.entityRecord != null;
+
+  useQueryInspector({
+    deleteQuery,
+    inspect: useEntityStoreInspectForRisk ? entityFromStoreResult?.inspect ?? null : inspect,
+    loading: useEntityStoreInspectForRisk ? entityFromStoreResult?.isLoading ?? false : loading,
+    queryId: USER_PANEL_RISK_SCORE_QUERY_ID,
+    refetch: useEntityStoreInspectForRisk ? entityFromStoreResult?.refetch ?? (() => {}) : refetch,
+    setQuery,
+  });
+
+  const isRiskScoreExist =
+    entityStoreV2Enabled && observedUser.entityRecord
+      ? !!getRiskFromEntityRecord(observedUser.entityRecord)
+      : !!userRiskData?.user?.risk;
+
+  const entityStoreEntityId = entityStoreV2Enabled
+    ? observedUser.entityRecord?.entity?.id
+    : undefined;
+
+  const openDetailsPanel = useOpenUserInvestigationInEntityAnalytics({
+    application,
+    agentBuilder,
+    chrome,
+    openSidebarConversation,
+    userName,
+    entityIdForPanels: panelDisplayEntityId,
+    identityFields: documentEntityIdentifiers,
+    scopeId,
+    safeContextID,
+    isRiskScoreExist,
+    hasMisconfigurationFindings,
+    hasNonClosedAlerts,
+    entityStoreEntityId,
+    searchSession,
+  });
+
+  const riskScoreStateFromStore =
+    entityStoreV2Enabled && observedUser.entityRecord
+      ? buildRiskScoreStateFromEntityRecord(EntityType.user, observedUser.entityRecord, {
+          refetch: observedUser.refetchEntityStore ?? (() => {}),
+          isLoading: observedUser.isLoading,
+          error: null,
+          inspect: entityFromStoreResult?.inspect,
+        })
+      : null;
+
+  const effectiveRiskScoreState = riskScoreStateFromStore ?? riskScoreState;
+
+  const onCriticalitySave = entityFromStoreResult.entityRecord
+    ? (level: CriticalityLevelWithUnassigned) =>
+        updateAssetCriticalityLevel(level, entityFromStoreResult.entityRecord)
+    : undefined;
+
+  const entityStoreLookupRequested =
+    Boolean(entityIdProp) ||
+    Boolean(userStoreIdentityFields && Object.keys(userStoreIdentityFields).length > 0);
+
+  const noEntityInStore =
+    entityStoreV2Enabled &&
+    entityStoreLookupRequested &&
+    !entityFromStoreResult.isLoading &&
+    !entityFromStoreResult.entityRecord;
+
+  const { tabs, selectedTabId, setSelectedTabId } = useEntityPanelTabs({
+    entityRecord: entityFromStoreResult.entityRecord ?? null,
+  });
+
+  const tabsNode = tabs ? (
+    <EntityPanelHeaderTabs
+      tabs={tabs}
+      selectedTabId={selectedTabId}
+      setSelectedTabId={setSelectedTabId}
+    />
+  ) : undefined;
+
+  return (
+    <>
+      <UserPanelHeader
+        lastSeen={observedUser.lastSeen}
+        managedUser={managedUser}
+        userName={userName}
+        entityId={panelDisplayEntityId}
+        identityFields={documentEntityIdentifiers}
+        isEntityInStore={!!entityFromStoreResult.entityRecord}
+        riskLevel={
+          entityFromStoreResult.entityRecord
+            ? ((getRiskFromEntityRecord(entityFromStoreResult.entityRecord)?.calculated_level ??
+                'Unknown') as RiskSeverity)
+            : undefined
+        }
+      />
+      <FlyoutBody>
+        {entityFromStoreResult.entityRecord && (
+          <EntitySummaryGrid
+            entityRecord={entityFromStoreResult.entityRecord}
+            criticalityLevel={entityFromStoreResult.entityRecord?.asset?.criticality}
+            onCriticalitySave={onCriticalitySave}
+          />
+        )}
+        {tabsNode}
+        {tabs && <EuiSpacer size="l" />}
+        {tabs && selectedTabId === TABLE_TAB_ID && entityFromStoreResult.entityRecord ? (
+          <EntityStoreTableTab entityRecord={entityFromStoreResult.entityRecord} />
+        ) : (
+          <UserPanelContent
+            observedUser={observedUser}
+            riskScoreState={effectiveRiskScoreState}
+            recalculatingScore={recalculatingScore}
+            onAssetCriticalityChange={calculateEntityRiskScore}
+            contextID={safeContextID}
+            scopeId={scopeId}
+            openDetailsPanel={openDetailsPanel}
+            isPreviewMode={isPreviewMode}
+            identityFields={documentEntityIdentifiers}
+            entityRecord={entityStoreV2Enabled ? observedUser.entityRecord ?? undefined : undefined}
+            skipRiskAndCriticality={noEntityInStore}
+            entityStoreEntityId={entityStoreEntityId}
+          />
+        )}
+      </FlyoutBody>
+    </>
+  );
+};
+
+const useOpenServiceInvestigationInEntityAnalytics = ({
+  application,
+  agentBuilder,
+  chrome,
+  openSidebarConversation,
+  serviceName,
+  entityId,
+  identityFields,
+  scopeId,
+  safeContextID,
+  isRiskScoreExist,
+  entityStoreEntityId,
+  searchSession,
+}: {
+  application: ApplicationStart;
+  agentBuilder?: AgentBuilderPluginStart;
+  chrome?: SecurityAgentBuilderChrome;
+  openSidebarConversation?: () => void;
+  serviceName: string;
+  entityId: string;
+  identityFields: IdentityFields;
+  scopeId: string;
+  safeContextID: string;
+  isRiskScoreExist: boolean;
+  entityStoreEntityId?: string;
+  searchSession?: ISessionService;
+}): ((path: EntityDetailsPath) => void) => {
+  const { telemetry } = useKibana().services;
+
+  return useCallback(
+    (path: EntityDetailsPath) => {
+      telemetry.reportEvent(EntityEventTypes.RiskInputsExpandedFlyoutOpened, {
+        entity: SearchEntityType.service,
+      });
+      navigateToEntityAnalyticsWithFlyoutInApp({
+        application,
+        appId: APP_UI_ID,
+        agentBuilder,
+        chrome,
+        openSidebarConversation,
+        searchSession,
+        flyout: {
+          preview: [],
+          left: {
+            id: ServiceDetailsPanelKey,
+            params: {
+              isRiskScoreExist,
+              identityFields,
+              scopeId,
+              entityId,
+              serviceName,
+              entityStoreEntityId,
+              path,
+            },
+          },
+          right: {
+            id: ServicePanelKey,
+            params: {
+              contextID: safeContextID,
+              scopeId,
+              entityId,
+              serviceName,
+            },
+          },
+        },
+      });
+    },
+    [
+      application,
+      agentBuilder,
+      chrome,
+      openSidebarConversation,
+      entityId,
+      entityStoreEntityId,
+      identityFields,
+      isRiskScoreExist,
+      safeContextID,
+      scopeId,
+      serviceName,
+      searchSession,
+      telemetry,
+    ]
+  );
+};
+
+const ServiceEntityFlyoutOverviewCanvas: React.FC<{
+  serviceName: string;
+  entityId: string;
+  application: ApplicationStart;
+  agentBuilder?: AgentBuilderPluginStart;
+  chrome?: SecurityAgentBuilderChrome;
+  openSidebarConversation?: () => void;
+  searchSession?: ISessionService;
+}> = ({
+  serviceName,
+  entityId,
+  application,
+  agentBuilder,
+  chrome,
+  openSidebarConversation,
+  searchSession,
+}) => {
+  const safeContextID = AGENT_BUILDER_ENTITY_CARD_SCOPE;
+  const scopeId = AGENT_BUILDER_ENTITY_CARD_SCOPE;
+  const isPreviewMode = false;
+  const entityStoreV2Enabled = useUiSetting<boolean>(FF_ENABLE_ENTITY_STORE_V2, false);
+  const serviceStoreIdentityFields = useMemo(
+    () => (!entityId && serviceName ? { 'service.name': serviceName } : undefined),
+    [entityId, serviceName]
+  );
+  const entityFromStoreResult = useEntityFromStore({
+    entityId,
+    identityFields: serviceStoreIdentityFields,
+    entityType: 'service',
+    skip: !entityStoreV2Enabled,
+  });
+
+  const euidApi = useEntityStoreEuidApi();
+  const documentEntityIdentifiers = useMemo<IdentityFields>(() => {
+    return (
+      euidApi?.euid?.getEntityIdentifiersFromDocument(
+        'service',
+        entityFromStoreResult.entityRecord ?? {}
+      ) ?? {}
+    );
+  }, [entityFromStoreResult.entityRecord, euidApi?.euid]);
+
+  const serviceNameFilterQuery = useMemo(
+    () => (serviceName ? buildEntityNameFilter(EntityType.service, [serviceName]) : undefined),
+    [serviceName]
+  );
+  const riskScoreState = useRiskScore({
+    riskEntity: EntityType.service,
+    filterQuery: serviceNameFilterQuery as unknown as ESQuery | undefined,
+    onlyLatest: false,
+    pagination: FIRST_RECORD_PAGINATION,
+    skip: entityStoreV2Enabled,
+  });
+
+  const { inspect, refetch, loading } = riskScoreState;
+  const { setQuery, deleteQuery } = useGlobalTime();
+  const observedService = useObservedService(documentEntityIdentifiers, scopeId);
+  const { data: serviceRisk } = riskScoreState;
+  const serviceRiskData = serviceRisk && serviceRisk.length > 0 ? serviceRisk[0] : undefined;
+  const isRiskScoreExist = !!serviceRiskData?.service.risk;
+
+  const refetchRiskInputsTab = useRefetchQueryById(RISK_INPUTS_TAB_QUERY_ID) ?? noop;
+  const refetchRiskScore = useCallback(() => {
+    refetch();
+    (refetchRiskInputsTab as Refetch)();
+  }, [refetch, refetchRiskInputsTab]);
+
+  const { isLoading: recalculatingScore, calculateEntityRiskScore } = useCalculateEntityRiskScore(
+    EntityType.service,
+    serviceName,
+    { onSuccess: refetchRiskScore }
+  );
+
+  const { updateAssetCriticalityLevel } = useUpdateAssetCriticality('service', {
+    onSuccess: calculateEntityRiskScore,
+  });
+
+  useQueryInspector({
+    deleteQuery,
+    inspect,
+    loading,
+    queryId: SERVICE_PANEL_RISK_SCORE_QUERY_ID,
+    refetch,
+    setQuery,
+  });
+
+  const entityStoreEntityId = entityStoreV2Enabled
+    ? entityFromStoreResult.entityRecord?.entity?.id
+    : undefined;
+
+  const onCriticalitySave = entityFromStoreResult.entityRecord
+    ? (level: CriticalityLevelWithUnassigned) =>
+        updateAssetCriticalityLevel(level, entityFromStoreResult.entityRecord)
+    : undefined;
+
+  const openDetailsPanel = useOpenServiceInvestigationInEntityAnalytics({
+    application,
+    agentBuilder,
+    chrome,
+    openSidebarConversation,
+    serviceName,
+    entityId,
+    identityFields: documentEntityIdentifiers,
+    scopeId,
+    safeContextID,
+    isRiskScoreExist,
+    entityStoreEntityId,
+    searchSession,
+  });
+
+  const { tabs, selectedTabId, setSelectedTabId } = useEntityPanelTabs({
+    entityRecord: entityFromStoreResult.entityRecord ?? null,
+  });
+
+  const tabsNode = tabs ? (
+    <EntityPanelHeaderTabs
+      tabs={tabs}
+      selectedTabId={selectedTabId}
+      setSelectedTabId={setSelectedTabId}
+    />
+  ) : undefined;
+
+  if (observedService.isLoading) {
+    return <FlyoutLoading />;
+  }
+
+  return (
+    <>
+      <ServicePanelHeader
+        serviceName={serviceName}
+        observedService={observedService}
+        isEntityInStore={!!entityFromStoreResult.entityRecord}
+        riskLevel={
+          entityFromStoreResult.entityRecord
+            ? ((getRiskFromEntityRecord(entityFromStoreResult.entityRecord)?.calculated_level ??
+                'Unknown') as RiskSeverity)
+            : undefined
+        }
+      />
+      <FlyoutBody>
+        {entityFromStoreResult.entityRecord && (
+          <EntitySummaryGrid
+            entityRecord={entityFromStoreResult.entityRecord}
+            criticalityLevel={entityFromStoreResult.entityRecord?.asset?.criticality}
+            onCriticalitySave={onCriticalitySave}
+          />
+        )}
+        {tabsNode}
+        {tabs && <EuiSpacer size="l" />}
+        {tabs && selectedTabId === TABLE_TAB_ID && entityFromStoreResult.entityRecord ? (
+          <EntityStoreTableTab entityRecord={entityFromStoreResult.entityRecord} />
+        ) : (
+          <ServicePanelContent
+            entityRecord={entityFromStoreResult.entityRecord ?? undefined}
+            serviceName={serviceName}
+            observedService={observedService}
+            riskScoreState={riskScoreState}
+            recalculatingScore={recalculatingScore}
+            onAssetCriticalityChange={calculateEntityRiskScore}
+            contextID={safeContextID}
+            scopeId={scopeId}
+            openDetailsPanel={openDetailsPanel}
+            isPreviewMode={isPreviewMode}
+            entityStoreEntityId={entityStoreEntityId}
+          />
+        )}
+      </FlyoutBody>
+    </>
+  );
+};
+
+export interface EntityCardFlyoutOverviewCanvasProps {
+  /**
+   * Attachment identifier emitted by the Security skill/tool. Entry component resolves the
+   * canonical entity store record client-side via `useEntityForAttachment` and dispatches to
+   * the per-type canvas with `hostName`/`userName`/`serviceName` + optional `entityId`.
+   */
+  identifier: EntityAttachmentIdentifier;
+  application: ApplicationStart;
+  agentBuilder?: AgentBuilderPluginStart;
+  chrome?: SecurityAgentBuilderChrome;
+  openSidebarConversation?: () => void;
+  /**
+   * Optional search session service. Forwarded to the per-type flyout canvas so the
+   * `navigateToEntityAnalyticsWithFlyoutInApp` helper can clear the active search session
+   * before the legitimate `agent_builder → securitySolutionUI` navigation.
+   */
+  searchSession?: ISessionService;
+}
+
+/**
+ * Dispatches the appropriate host/user/service entity flyout overview canvas for an Agent
+ * Builder `security.entity` attachment. `generic` identifier types return `null` because the
+ * Security expandable flyout only supports host/user/service panels today.
+ *
+ * The surface is intentionally decoupled from the inline `EntityCard` (which bypasses Redux and
+ * Security providers). This canvas mounts inside `SecurityReduxEmbeddedProvider`, so it can
+ * reuse all Security flyout hooks (`useGlobalTime`, `useRiskScore`, `useObservedHost`, sourcerer,
+ * etc.) exactly like the in-app expandable flyout.
+ */
+export const EntityCardFlyoutOverviewCanvas: React.FC<EntityCardFlyoutOverviewCanvasProps> = ({
+  identifier,
+  application,
+  agentBuilder,
+  chrome,
+  openSidebarConversation,
+  searchSession,
+}) => {
+  const { data, isLoading } = useEntityForAttachment(identifier);
+
+  if (isLoading && !data) {
+    return <FlyoutLoading />;
+  }
+
+  const entityName = data?.displayName ?? identifier.identifier;
+  const entityId = data?.entityId ?? identifier.entityStoreId ?? identifier.identifier;
+  const sources = data?.sources ?? [];
+  const exploreRow = {
+    entity_type: identifier.identifierType,
+    entity_id: entityId,
+    entity_name: entityName,
+    source: sources.length > 0 ? { entity: { source: sources } } : undefined,
+  };
+
+  if (identifier.identifierType === 'host') {
+    const hostName = getHostNameForHostDetailsUrl(exploreRow);
+    return (
+      <HostEntityFlyoutOverviewCanvas
+        hostName={hostName}
+        entityId={entityId}
+        application={application}
+        agentBuilder={agentBuilder}
+        chrome={chrome}
+        openSidebarConversation={openSidebarConversation}
+        searchSession={searchSession}
+      />
+    );
+  }
+
+  if (identifier.identifierType === 'user') {
+    const userName = getUserNameForUserDetailsUrl(exploreRow);
+    return (
+      <UserEntityFlyoutOverviewCanvas
+        userName={userName}
+        entityId={entityId}
+        application={application}
+        agentBuilder={agentBuilder}
+        chrome={chrome}
+        openSidebarConversation={openSidebarConversation}
+        searchSession={searchSession}
+      />
+    );
+  }
+
+  if (identifier.identifierType === 'service') {
+    const displayName = getServiceNameForServiceDetailsUrl(exploreRow);
+    return (
+      <ServiceEntityFlyoutOverviewCanvas
+        serviceName={displayName}
+        entityId={entityId}
+        application={application}
+        agentBuilder={agentBuilder}
+        chrome={chrome}
+        openSidebarConversation={openSidebarConversation}
+        searchSession={searchSession}
+      />
+    );
+  }
+
+  return null;
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/components/security_redux_embedded_provider.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/components/security_redux_embedded_provider.test.tsx
@@ -1,0 +1,125 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { I18nProvider } from '@kbn/i18n-react';
+import type {
+  SecurityCanvasEmbeddedBundle,
+  SecurityReduxEmbeddedProviderProps,
+} from './security_redux_embedded_provider';
+import { SecurityReduxEmbeddedProvider } from './security_redux_embedded_provider';
+
+jest.mock('../../common/lib/kibana/kibana_react', () => ({
+  KibanaContextProvider: ({ children }: { children: React.ReactNode }) => (
+    <div data-test-subj="kibanaContextProviderMock">{children}</div>
+  ),
+}));
+
+jest.mock('../../common/components/upselling_provider', () => ({
+  UpsellingProvider: ({ children }: { children: React.ReactNode }) => (
+    <div data-test-subj="upsellingProviderMock">{children}</div>
+  ),
+}));
+
+jest.mock('../../cases/components/provider/provider', () => ({
+  CaseProvider: ({ children }: { children: React.ReactNode }) => (
+    <div data-test-subj="caseProviderMock">{children}</div>
+  ),
+}));
+
+jest.mock('@kbn/cell-actions', () => ({
+  CellActionsProvider: ({ children }: { children: React.ReactNode }) => (
+    <div data-test-subj="cellActionsProviderMock">{children}</div>
+  ),
+}));
+
+jest.mock('@kbn/expandable-flyout', () => ({
+  ExpandableFlyoutProvider: ({ children }: { children: React.ReactNode }) => (
+    <div data-test-subj="expandableFlyoutProviderMock">{children}</div>
+  ),
+}));
+
+jest.mock('@kbn/security-solution-navigation', () => ({
+  NavigationProvider: ({ children }: { children: React.ReactNode }) => (
+    <div data-test-subj="navigationProviderMock">{children}</div>
+  ),
+}));
+
+jest.mock('react-redux', () => ({
+  Provider: ({ children }: { children: React.ReactNode }) => (
+    <div data-test-subj="reduxProviderMock">{children}</div>
+  ),
+}));
+
+const fakeBundle = (): SecurityCanvasEmbeddedBundle =>
+  ({
+    store: { dispatch: jest.fn(), getState: jest.fn(), subscribe: jest.fn() },
+    kibanaServices: {
+      uiActions: { getTriggerCompatibleActions: jest.fn() },
+      upselling: {},
+    },
+  } as unknown as SecurityCanvasEmbeddedBundle);
+
+const renderProvider = (
+  resolveCanvasContext: SecurityReduxEmbeddedProviderProps['resolveCanvasContext']
+) =>
+  render(
+    <I18nProvider>
+      <SecurityReduxEmbeddedProvider resolveCanvasContext={resolveCanvasContext}>
+        <span data-test-subj="embeddedChild">{'embedded'}</span>
+      </SecurityReduxEmbeddedProvider>
+    </I18nProvider>
+  );
+
+describe('SecurityReduxEmbeddedProvider', () => {
+  it('shows a loading spinner while resolveCanvasContext is pending', () => {
+    const pending = new Promise<SecurityCanvasEmbeddedBundle>(() => {
+      /* never resolves */
+    });
+    renderProvider(() => pending);
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+    expect(screen.queryByTestId('embeddedChild')).not.toBeInTheDocument();
+  });
+
+  it('mounts the children (and nested providers) once the bundle resolves', async () => {
+    const bundle = fakeBundle();
+    const resolveCanvasContext = jest.fn(async () => bundle);
+
+    await act(async () => {
+      renderProvider(resolveCanvasContext);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('embeddedChild')).toBeInTheDocument();
+    });
+    // Each provider wrapper is present so hooks that require them resolve correctly.
+    expect(screen.getByTestId('kibanaContextProviderMock')).toBeInTheDocument();
+    expect(screen.getByTestId('cellActionsProviderMock')).toBeInTheDocument();
+    expect(screen.getByTestId('navigationProviderMock')).toBeInTheDocument();
+    expect(screen.getByTestId('reduxProviderMock')).toBeInTheDocument();
+    expect(screen.getByTestId('upsellingProviderMock')).toBeInTheDocument();
+    expect(screen.getByTestId('caseProviderMock')).toBeInTheDocument();
+    expect(screen.getByTestId('expandableFlyoutProviderMock')).toBeInTheDocument();
+    expect(resolveCanvasContext).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores a late bundle resolution after unmount', async () => {
+    let resolveBundle: (b: SecurityCanvasEmbeddedBundle) => void = () => undefined;
+    const pending = new Promise<SecurityCanvasEmbeddedBundle>((resolve) => {
+      resolveBundle = resolve;
+    });
+
+    const { unmount } = renderProvider(() => pending);
+    unmount();
+
+    // Should not throw — the internal `cancelled` guard suppresses setState after unmount.
+    await act(async () => {
+      resolveBundle(fakeBundle());
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/components/security_redux_embedded_provider.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/components/security_redux_embedded_provider.tsx
@@ -1,0 +1,107 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useEffect, useState } from 'react';
+import { Provider } from 'react-redux';
+import { EuiFlexGroup, EuiFlexItem, EuiLoadingSpinner } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { CellActionsProvider } from '@kbn/cell-actions';
+import { ExpandableFlyoutProvider } from '@kbn/expandable-flyout';
+import { NavigationProvider } from '@kbn/security-solution-navigation';
+import type { SecurityAppStore } from '../../common/store/types';
+import { KibanaContextProvider } from '../../common/lib/kibana/kibana_react';
+import { UpsellingProvider } from '../../common/components/upselling_provider';
+import { CaseProvider } from '../../cases/components/provider/provider';
+import type { StartServices } from '../../types';
+import { APP_NAME } from '../../../common/constants';
+
+export interface SecurityCanvasEmbeddedBundle {
+  store: SecurityAppStore;
+  kibanaServices: StartServices;
+}
+
+export interface SecurityReduxEmbeddedProviderProps {
+  /**
+   * Resolves the same Redux store and flattened `StartServices` the Security app uses so hooks
+   * like `useGlobalTime`, `useKibana().services.data.search`, and `useObservedHost` work in Agent
+   * Builder surfaces that sit outside `SecurityApp`'s providers.
+   */
+  resolveCanvasContext: () => Promise<SecurityCanvasEmbeddedBundle>;
+  children: React.ReactNode;
+}
+
+/**
+ * Agent Builder attachment Canvas renders outside Security's `ReduxStoreProvider` and outside the
+ * Security `KibanaContextProvider` shape (flattened `StartServices` including `data`).
+ * Also supplies {@link NavigationProvider} so `@kbn/security-solution-navigation` link helpers
+ * (`WithLink`, `useGetAppUrl`, …) work the same as inside the Security app shell.
+ * {@link ExpandableFlyoutProvider} (without `urlKey`, in-memory mode) is required for components
+ * that call `useExpandableFlyoutApi`, e.g. `PreviewLink` in entity flyout panels.
+ * {@link CaseProvider} supplies Cases UI context for Lens embeddables and other features that use
+ * "add to case" actions (`useCasesContext`).
+ * {@link UpsellingProvider} is required for components that call `useUpsellingService` (e.g. graph
+ * previews in entity analytics visualizations).
+ * {@link CellActionsProvider} is required for Discover-style tables and hover cell actions
+ * (`HoverActionsPopover`, entity store table tab), matching `flyoutProviders` in the Security flyout shell.
+ */
+export const SecurityReduxEmbeddedProvider: React.FC<SecurityReduxEmbeddedProviderProps> = ({
+  resolveCanvasContext,
+  children,
+}) => {
+  const [bundle, setBundle] = useState<SecurityCanvasEmbeddedBundle | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void resolveCanvasContext().then((next) => {
+      if (!cancelled) {
+        setBundle(next);
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [resolveCanvasContext]);
+
+  if (bundle == null) {
+    return (
+      <EuiFlexGroup alignItems="center" justifyContent="center" css={{ minHeight: 200 }}>
+        <EuiFlexItem grow={false}>
+          <EuiLoadingSpinner
+            size="l"
+            aria-label={i18n.translate(
+              'xpack.securitySolution.agentBuilder.embeddedRedux.loadingAriaLabel',
+              { defaultMessage: 'Loading entity overview' }
+            )}
+          />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    );
+  }
+
+  return (
+    <KibanaContextProvider
+      services={{
+        appName: APP_NAME,
+        ...bundle.kibanaServices,
+      }}
+    >
+      <CellActionsProvider
+        getTriggerCompatibleActions={bundle.kibanaServices.uiActions.getTriggerCompatibleActions}
+      >
+        <NavigationProvider core={bundle.kibanaServices}>
+          <Provider store={bundle.store}>
+            <UpsellingProvider upsellingService={bundle.kibanaServices.upselling}>
+              <CaseProvider>
+                <ExpandableFlyoutProvider>{children}</ExpandableFlyoutProvider>
+              </CaseProvider>
+            </UpsellingProvider>
+          </Provider>
+        </NavigationProvider>
+      </CellActionsProvider>
+    </KibanaContextProvider>
+  );
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/app/app.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/app/app.tsx
@@ -35,6 +35,10 @@ import { DiscoverInTimelineContextProvider } from '../common/components/discover
 import { InitializationProvider } from '../common/components/initialization';
 import { AssistantProvider } from '../assistant/provider';
 import { TrialCompanion } from '../trial_companion/trial_companion';
+import {
+  consumePreserveAgentBuilderSessionGate,
+  readLastAgentBuilderAgentIdForSecuritySession,
+} from '../../common/agent_builder_navigation_gate';
 
 interface StartAppComponent {
   children: React.ReactNode;
@@ -118,17 +122,21 @@ const SecurityAppComponent: React.FC<SecurityAppComponentProps> = ({
   // Skip if the sidebar is already open (e.g. navigating from Agent Builder
   // with an active conversation) to avoid clobbering its props.
   useEffect(() => {
-    const isSidebarOpen = services.chrome.sidebar.isOpen();
-
-    if (services.agentBuilder?.setChatConfig && !isSidebarOpen) {
+    if (services.agentBuilder?.setChatConfig && !services.chrome.sidebar.isOpen()) {
       services.agentBuilder.setChatConfig({
         sessionTag: 'security',
         newConversation: false,
+        agentId: readLastAgentBuilderAgentIdForSecuritySession(),
       });
     }
 
     return () => {
-      if (services.agentBuilder?.clearChatConfig && !isSidebarOpen) {
+      if (consumePreserveAgentBuilderSessionGate()) {
+        return;
+      }
+      // Re-read at teardown time: the Agent Builder panel may have opened after this effect
+      // ran; using a stale `isOpen` from mount would incorrectly clear chat config mid-session.
+      if (services.agentBuilder?.clearChatConfig && !services.chrome.sidebar.isOpen()) {
         services.agentBuilder.clearChatConfig();
       }
     };

--- a/x-pack/solutions/security/plugins/security_solution/public/app/home/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/app/home/index.tsx
@@ -33,14 +33,38 @@ interface HomePageProps {
   children: React.ReactNode;
 }
 
+/**
+ * `useInitSourcerer` must only run under the legacy data view picker: it registers many hooks
+ * and must not be mounted with a changing hook count when `newDataViewPickerEnabled` toggles.
+ */
+const HomePageDragLayerLegacy: React.FC<{ children: React.ReactNode; pathname: string }> = ({
+  children,
+  pathname,
+}) => {
+  const { browserFields } = useInitSourcerer(getScopeFromPath(pathname, false));
+  return (
+    <DragDropContextWrapper browserFields={browserFields as BrowserFields}>
+      {children}
+    </DragDropContextWrapper>
+  );
+};
+
+const HomePageDragLayerNew: React.FC<{ children: React.ReactNode; pathname: string }> = ({
+  children,
+  pathname,
+}) => {
+  const browserFields = useBrowserFields(getScopeFromPath(pathname, true));
+  return (
+    <DragDropContextWrapper browserFields={browserFields as BrowserFields}>
+      {children}
+    </DragDropContextWrapper>
+  );
+};
+
 const HomePageComponent: React.FC<HomePageProps> = ({ children }) => {
   const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
 
   const { pathname } = useLocation();
-  const { browserFields: oldBrowserFields } = useInitSourcerer(getScopeFromPath(pathname, false));
-  const { browserFields: experimentalBrowserFields } = useBrowserFields(
-    getScopeFromPath(pathname, newDataViewPickerEnabled)
-  );
 
   useRestoreDataViewManagerStateFromURL(
     useInitDataViewManager(),
@@ -50,10 +74,6 @@ const HomePageComponent: React.FC<HomePageProps> = ({ children }) => {
   useUrlState();
   useUpdateBrowserTitle();
   useUpdateExecutionContext();
-
-  const browserFields = (
-    newDataViewPickerEnabled ? experimentalBrowserFields : oldBrowserFields
-  ) as BrowserFields;
 
   // side effect: this will attempt to upgrade the endpoint package if it is not up to date
   // this will run when a user navigates to the Security Solution app and when they navigate between
@@ -68,7 +88,11 @@ const HomePageComponent: React.FC<HomePageProps> = ({ children }) => {
       <ConsoleManager>
         <>
           <GlobalHeader />
-          <DragDropContextWrapper browserFields={browserFields}>{children}</DragDropContextWrapper>
+          {newDataViewPickerEnabled ? (
+            <HomePageDragLayerNew pathname={pathname}>{children}</HomePageDragLayerNew>
+          ) : (
+            <HomePageDragLayerLegacy pathname={pathname}>{children}</HomePageDragLayerLegacy>
+          )}
           <HelpMenu />
           <TopValuesPopover />
         </>

--- a/x-pack/solutions/security/plugins/security_solution/public/assistant/use_assistant_availability/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/assistant/use_assistant_availability/index.tsx
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { useAssistantContext } from '@kbn/elastic-assistant';
+import { useMaybeAssistantContext } from '@kbn/elastic-assistant';
 
 export interface UseAssistantAvailability {
   // True when searchAiLake configurations is available
@@ -25,7 +25,21 @@ export interface UseAssistantAvailability {
   hasManageGlobalKnowledgeBase: boolean;
 }
 
+const ASSISTANT_UNAVAILABLE: UseAssistantAvailability = {
+  hasSearchAILakeConfigurations: false,
+  isAssistantEnabled: false,
+  isAssistantVisible: false,
+  hasAssistantPrivilege: false,
+  hasConnectorsAllPrivilege: false,
+  hasConnectorsReadPrivilege: false,
+  hasUpdateAIAssistantAnonymization: false,
+  hasManageGlobalKnowledgeBase: false,
+};
+
 export const useAssistantAvailability = (): UseAssistantAvailability => {
-  const { assistantAvailability } = useAssistantContext();
-  return assistantAvailability;
+  const context = useMaybeAssistantContext();
+  if (context == null) {
+    return ASSISTANT_UNAVAILABLE;
+  }
+  return context.assistantAvailability;
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/cloud_security_posture/components/csp_details/insights_tab_csp.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/cloud_security_posture/components/csp_details/insights_tab_csp.tsx
@@ -10,8 +10,8 @@ import type { EuiButtonGroupOptionProps } from '@elastic/eui';
 import { EuiButtonGroup, EuiSpacer } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import type { FlyoutPanelProps, PanelPath } from '@kbn/expandable-flyout';
-import { useExpandableFlyoutState } from '@kbn/expandable-flyout';
 import { i18n } from '@kbn/i18n';
+import { useStableExpandableFlyoutState } from '../../../flyout/shared/hooks/use_stable_expandable_flyout_state';
 import { CspInsightLeftPanelSubTab } from '../../../flyout/entity_details/shared/components/left_panel/left_panel_header';
 import { MisconfigurationFindingsDetailsTable } from './misconfiguration_findings_details_table';
 import { VulnerabilitiesFindingsDetailsTable } from './vulnerabilities_findings_details_table';
@@ -56,7 +56,7 @@ export const InsightsTabCsp = memo(
     entityId?: string;
     entityType?: string;
   }) => {
-    const panels = useExpandableFlyoutState();
+    const panels = useStableExpandableFlyoutState();
 
     let hasMisconfigurationFindings = false;
     let hasVulnerabilitiesFindings = false;

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/drag_and_drop/drag_drop_context_wrapper.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/drag_and_drop/drag_drop_context_wrapper.tsx
@@ -157,8 +157,9 @@ DragDropContextWrapperComponent.displayName = 'DragDropContextWrapperComponent';
 
 export const DragDropContextWrapper = React.memo(
   DragDropContextWrapperComponent,
-  // prevent re-renders when data providers are added or removed, but all other props are the same
-  (prevProps, nextProps) => deepEqual(prevProps.children, nextProps.children)
+  (prevProps, nextProps) =>
+    deepEqual(prevProps.children, nextProps.children) &&
+    deepEqual(prevProps.browserFields, nextProps.browserFields)
 );
 
 DragDropContextWrapper.displayName = 'DragDropContextWrapper';

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/search_bar/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/search_bar/index.tsx
@@ -57,6 +57,11 @@ interface SiemSearchBarProps {
    * Allows to hide the query menu button displayed to the left of the query input.
    */
   hideQueryMenu?: boolean;
+  /**
+   * Hides the date picker (and the associated Refresh button) from the search bar.
+   * KQL input and pinned filter bar remain visible.
+   */
+  hideDatePicker?: boolean;
 }
 
 export const SearchBarComponent = memo<SiemSearchBarProps & PropsFromRedux>(
@@ -68,6 +73,7 @@ export const SearchBarComponent = memo<SiemSearchBarProps & PropsFromRedux>(
     hideFilterBar = false,
     hideQueryInput = false,
     hideQueryMenu = false,
+    hideDatePicker = false,
     id,
     isLoading = false,
     pollForSignalIndex,
@@ -350,7 +356,7 @@ export const SearchBarComponent = memo<SiemSearchBarProps & PropsFromRedux>(
           onSavedQueryUpdated={onSavedQueryUpdated}
           savedQuery={savedQuery}
           showFilterBar={!hideFilterBar}
-          showDatePicker={true}
+          showDatePicker={!hideDatePicker}
           showQueryInput={!hideQueryInput}
           showQueryMenu={!hideQueryMenu}
           allowSavingQueries

--- a/x-pack/solutions/security/plugins/security_solution/public/common/hooks/esql/use_esql_global_filter.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/hooks/esql/use_esql_global_filter.ts
@@ -18,3 +18,16 @@ export const useEsqlGlobalFilterQuery = (): ESBoolQuery | undefined => {
 
   return filterQuery;
 };
+
+/**
+ * Like {@link useEsqlGlobalFilterQuery}, but with a fixed time range instead
+ * of the one from the global date picker. Use this for surfaces that should
+ * always query a specific range (e.g. a panel hardcoded to "last 30 days")
+ * while still respecting pinned KQL and filters from the global filter bar.
+ */
+export const useEsqlFixedRangeFilterQuery = (from: string, to: string): ESBoolQuery | undefined => {
+  const extraFilter = useMemo(() => buildTimeRangeFilter(from, to), [from, to]);
+  const { filterQuery } = useGlobalFilterQuery({ extraFilter });
+
+  return filterQuery;
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/common/utils.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/common/utils.test.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import { formatRiskScore, safeErrorMessage } from './utils';
+import { RiskSeverity } from '../../../common/search_strategy';
+import { esqlRecordsToSeverityCount, formatRiskScore, safeErrorMessage } from './utils';
 
 describe('formatRiskScore', () => {
   it('returns two digits after the decimal separator', () => {
@@ -38,5 +39,67 @@ describe('safeErrorMessage', () => {
 
   it('returns undefined for non-object errors without a fallback', () => {
     expect(safeErrorMessage('string error')).toBeUndefined();
+  });
+});
+
+describe('esqlRecordsToSeverityCount', () => {
+  it('returns zeros for all severities when records is empty', () => {
+    expect(esqlRecordsToSeverityCount([])).toEqual({
+      [RiskSeverity.Critical]: 0,
+      [RiskSeverity.High]: 0,
+      [RiskSeverity.Moderate]: 0,
+      [RiskSeverity.Low]: 0,
+      [RiskSeverity.Unknown]: 0,
+    });
+  });
+
+  it('maps each named severity level to its count', () => {
+    const result = esqlRecordsToSeverityCount([
+      { level: RiskSeverity.Critical, count: 5 },
+      { level: RiskSeverity.High, count: 10 },
+      { level: RiskSeverity.Moderate, count: 20 },
+      { level: RiskSeverity.Low, count: 50 },
+      { level: RiskSeverity.Unknown, count: 7 },
+    ]);
+
+    expect(result).toEqual({
+      [RiskSeverity.Critical]: 5,
+      [RiskSeverity.High]: 10,
+      [RiskSeverity.Moderate]: 20,
+      [RiskSeverity.Low]: 50,
+      [RiskSeverity.Unknown]: 7,
+    });
+  });
+
+  it('sums null-level rows with explicit Unknown rows into the Unknown bucket', () => {
+    // This is the bug fix: ES|QL can return both a `level: null` row and a
+    // `level: 'Unknown'` row for the same bucket. The previous `.find(...)`
+    // implementation silently dropped one of them.
+    const result = esqlRecordsToSeverityCount([
+      { level: null, count: 49 },
+      { level: RiskSeverity.Unknown, count: 118 },
+      { level: RiskSeverity.Low, count: 15 },
+      { level: RiskSeverity.Moderate, count: 158 },
+      { level: RiskSeverity.High, count: 136 },
+    ]);
+
+    expect(result[RiskSeverity.Unknown]).toBe(167);
+    expect(result).toEqual({
+      [RiskSeverity.Critical]: 0,
+      [RiskSeverity.High]: 136,
+      [RiskSeverity.Moderate]: 158,
+      [RiskSeverity.Low]: 15,
+      [RiskSeverity.Unknown]: 167,
+    });
+  });
+
+  it('treats missing counts as zero', () => {
+    const result = esqlRecordsToSeverityCount([
+      { level: RiskSeverity.Critical, count: undefined as unknown as number },
+      { level: RiskSeverity.High, count: 3 },
+    ]);
+
+    expect(result[RiskSeverity.Critical]).toBe(0);
+    expect(result[RiskSeverity.High]).toBe(3);
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/common/utils.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/common/utils.ts
@@ -7,6 +7,7 @@
 
 import { euiThemeVars } from '@kbn/ui-theme'; // eslint-disable-line @elastic/eui/no-restricted-eui-imports
 import { RiskSeverity } from '../../../common/search_strategy';
+import type { SeverityCount } from '../components/severity/types';
 export { RISK_LEVEL_RANGES as RISK_SCORE_RANGES } from '../../../common/entity_analytics/risk_engine';
 
 export const SEVERITY_UI_SORT_ORDER = [
@@ -88,3 +89,35 @@ export function safeErrorMessage(error: unknown, fallback?: string): string | un
   }
   return fallback;
 }
+
+/**
+ * Shape of a single row returned by the watchlist/entity risk-levels ES|QL
+ * query. The query groups by `entity.risk.calculated_level`, which can be a
+ * named severity string (e.g. "Critical", "Unknown") or `null` for entities
+ * without a calculated level.
+ */
+export interface EsqlSeverityRecord {
+  count: number;
+  level: string | null;
+}
+
+/**
+ * Aggregates ES|QL records grouped by `entity.risk.calculated_level` into a
+ * {@link SeverityCount}. Rows where `level` is `null` are summed together
+ * with rows where `level === 'Unknown'`, because both represent entities
+ * whose risk is not yet classified. This prevents silent undercounting when
+ * the same bucket is represented twice in a single response (observed when
+ * some entities have an explicit "Unknown" level while others have `null`).
+ */
+export const esqlRecordsToSeverityCount = (records: EsqlSeverityRecord[]): SeverityCount => {
+  const sumWhere = (predicate: (r: EsqlSeverityRecord) => boolean) =>
+    records.filter(predicate).reduce((acc, r) => acc + (r.count ?? 0), 0);
+
+  return {
+    [RiskSeverity.Critical]: sumWhere((r) => r.level === RiskSeverity.Critical),
+    [RiskSeverity.High]: sumWhere((r) => r.level === RiskSeverity.High),
+    [RiskSeverity.Moderate]: sumWhere((r) => r.level === RiskSeverity.Moderate),
+    [RiskSeverity.Low]: sumWhere((r) => r.level === RiskSeverity.Low),
+    [RiskSeverity.Unknown]: sumWhere((r) => r.level === RiskSeverity.Unknown || r.level === null),
+  };
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_analytics_header/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_analytics_header/index.test.tsx
@@ -31,7 +31,29 @@ jest.mock('../../../common/components/ml/hooks/use_ml_capabilities', () => ({
 
 jest.mock('../../api/hooks/use_risk_score_kpi', () => {
   return {
-    useRiskScoreKpi: () => ({ severityCount: mockSeverityCount }),
+    useRiskScoreKpi: () => ({
+      severityCount: mockSeverityCount,
+      loading: false,
+      inspect: { dsl: [], response: [] },
+      refetch: jest.fn(),
+    }),
+  };
+});
+
+jest.mock('../../api/hooks/use_entity_store_risk_score_kpi', () => ({
+  useEntityStoreRiskScoreKpi: () => ({
+    severityCount: mockSeverityCount,
+    loading: false,
+    inspect: { dsl: [], response: [] },
+    refetch: jest.fn(),
+  }),
+}));
+
+jest.mock('../../../common/lib/kibana', () => {
+  const actual = jest.requireActual('../../../common/lib/kibana');
+  return {
+    ...actual,
+    useUiSetting: jest.fn(() => false),
   };
 });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_analytics_header/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_analytics_header/index.tsx
@@ -10,6 +10,7 @@ import styled from '@emotion/styled';
 import { useDispatch } from 'react-redux';
 import { capitalize, sumBy } from 'lodash/fp';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { FF_ENABLE_ENTITY_STORE_V2 } from '@kbn/entity-store/public';
 import { SEVERITY_COLOR } from '../../../overview/components/detection_response/utils';
 import { LinkAnchor, useGetSecuritySolutionLinkProps } from '../../../common/components/links';
 import {
@@ -35,6 +36,8 @@ import { isJobStarted } from '../../../../common/machine_learning/helpers';
 import { FormattedCount } from '../../../common/components/formatted_number';
 import { useGlobalFilterQuery } from '../../../common/hooks/use_global_filter_query';
 import { useRiskScoreKpi } from '../../api/hooks/use_risk_score_kpi';
+import { useEntityStoreRiskScoreKpi } from '../../api/hooks/use_entity_store_risk_score_kpi';
+import { useUiSetting } from '../../../common/lib/kibana';
 import type { SeverityCount } from '../severity/types';
 
 const StyledEuiTitle = styled(EuiTitle)`
@@ -48,6 +51,7 @@ const USER_RISK_QUERY_ID = 'userRiskScoreKpiQuery';
 export const EntityAnalyticsHeader = () => {
   const { from, to } = useGlobalTime();
   const { filterQuery } = useGlobalFilterQuery();
+  const entityStoreV2Enabled = useUiSetting<boolean>(FF_ENABLE_ENTITY_STORE_V2) === true;
   const timerange = useMemo(
     () => ({
       from,
@@ -56,27 +60,47 @@ export const EntityAnalyticsHeader = () => {
     [from, to]
   );
 
+  const legacyHostKpi = useRiskScoreKpi({
+    timerange,
+    riskEntity: EntityType.host,
+    filterQuery,
+    skip: entityStoreV2Enabled,
+  });
+
+  const legacyUserKpi = useRiskScoreKpi({
+    filterQuery,
+    timerange,
+    riskEntity: EntityType.user,
+    skip: entityStoreV2Enabled,
+  });
+
+  const entityStoreHostKpi = useEntityStoreRiskScoreKpi({
+    timerange,
+    riskEntity: EntityType.host,
+    filterQuery,
+    skip: !entityStoreV2Enabled,
+  });
+
+  const entityStoreUserKpi = useEntityStoreRiskScoreKpi({
+    filterQuery,
+    timerange,
+    riskEntity: EntityType.user,
+    skip: !entityStoreV2Enabled,
+  });
+
   const {
     severityCount: hostsSeverityCount,
     loading: hostRiskLoading,
     inspect: inspectHostRiskScore,
     refetch: refetchHostRiskScore,
-  } = useRiskScoreKpi({
-    timerange,
-    riskEntity: EntityType.host,
-    filterQuery,
-  });
+  } = entityStoreV2Enabled ? entityStoreHostKpi : legacyHostKpi;
 
   const {
     severityCount: usersSeverityCount,
     loading: userRiskLoading,
     refetch: refetchUserRiskScore,
     inspect: inspectUserRiskScore,
-  } = useRiskScoreKpi({
-    filterQuery,
-    timerange,
-    riskEntity: EntityType.user,
-  });
+  } = entityStoreV2Enabled ? entityStoreUserKpi : legacyUserKpi;
 
   const { data } = useAggregatedAnomaliesByJob({ skip: false, from, to });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_analytics_risk_score/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_analytics_risk_score/index.test.tsx
@@ -15,6 +15,8 @@ import { useKibana as mockUseKibana } from '../../../common/lib/kibana/__mocks__
 import { createTelemetryServiceMock } from '../../../common/lib/telemetry/telemetry_service.mock';
 import { useRiskScore } from '../../api/hooks/use_risk_score';
 import { useRiskScoreKpi } from '../../api/hooks/use_risk_score_kpi';
+import { useEntityStoreRiskScore } from '../../api/hooks/use_entity_store_risk_score';
+import { useEntityStoreRiskScoreKpi } from '../../api/hooks/use_entity_store_risk_score_kpi';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { RiskSeverity } from '../../../../common/search_strategy';
 import { capitalize } from 'lodash/fp';
@@ -62,8 +64,12 @@ const defaultProps = {
 };
 const mockUseRiskScore = useRiskScore as jest.Mock;
 const mockUseRiskScoreKpi = useRiskScoreKpi as jest.Mock;
+const mockUseEntityStoreRiskScore = useEntityStoreRiskScore as jest.Mock;
+const mockUseEntityStoreRiskScoreKpi = useEntityStoreRiskScoreKpi as jest.Mock;
 jest.mock('../../api/hooks/use_risk_score');
 jest.mock('../../api/hooks/use_risk_score_kpi');
+jest.mock('../../api/hooks/use_entity_store_risk_score');
+jest.mock('../../api/hooks/use_entity_store_risk_score_kpi');
 
 const mockOpenAlertsPageWithFilters = jest.fn();
 jest.mock('../../../common/hooks/use_navigate_to_alerts_page_with_filters', () => {
@@ -86,8 +92,17 @@ describe.each([EntityType.host, EntityType.user, EntityType.service])(
       mockUseRiskScoreKpi.mockReturnValue({
         severityCount: mockSeverityCount,
         loading: false,
+        refetch: jest.fn(),
+        inspect: { dsl: [], response: [] },
       });
       mockUseRiskScore.mockReturnValue(defaultProps);
+      mockUseEntityStoreRiskScoreKpi.mockReturnValue({
+        severityCount: mockSeverityCount,
+        loading: false,
+        refetch: jest.fn(),
+        inspect: { dsl: [], response: [] },
+      });
+      mockUseEntityStoreRiskScore.mockReturnValue(defaultProps);
     });
 
     it('renders enable button when module is disable', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_analytics_risk_score/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_analytics_risk_score/index.tsx
@@ -6,7 +6,6 @@
  */
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { EuiFlexGroup, EuiFlexItem, EuiPanel } from '@elastic/eui';
-
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import type { RiskSeverity } from '../../../../common/search_strategy';
 import { EMPTY_SEVERITY_COUNT } from '../../../../common/search_strategy';
@@ -20,8 +19,8 @@ import { getRiskScoreColumns } from './columns';
 import { LastUpdatedAt } from '../../../common/components/last_updated_at';
 import { HeaderSection } from '../../../common/components/header_section';
 import {
-  type EntityType,
   EntityTypeToIdentifierField,
+  type EntityType,
 } from '../../../../common/entity_analytics/types';
 import { generateSeverityFilter } from '../../../explore/hosts/store/helpers';
 import { useGlobalTime } from '../../../common/containers/use_global_time';
@@ -36,8 +35,7 @@ import { useNavigateToAlertsPageWithFilters } from '../../../common/hooks/use_na
 import { getRiskEntityTranslation } from './translations';
 import { useKibana } from '../../../common/lib/kibana';
 import { useGlobalFilterQuery } from '../../../common/hooks/use_global_filter_query';
-import { useRiskScoreKpi } from '../../api/hooks/use_risk_score_kpi';
-import { useRiskScore } from '../../api/hooks/use_risk_score';
+import { useEntityAnalyticsRiskScorePanelData } from './use_entity_analytics_risk_score_panel_data';
 import { RiskEnginePrivilegesCallOut } from '../risk_engine_privileges_callout';
 import { useMissingRiskEnginePrivileges } from '../../hooks/use_missing_risk_engine_privileges';
 import { EntityEventTypes } from '../../../common/lib/telemetry';
@@ -122,14 +120,20 @@ const EntityAnalyticsRiskScoresComponent = <T extends EntityType>({
 
   const {
     severityCount,
-    loading: isKpiLoading,
-    refetch: refetchKpi,
-    inspect: inspectKpi,
-  } = useRiskScoreKpi({
-    filterQuery,
-    skip: !toggleStatus,
-    timerange,
+    isKpiLoading,
+    refetchKpi,
+    inspectKpi,
+    data,
+    isTableLoading,
+    inspect,
+    refetch,
+    isAuthorized,
+    hasEngineBeenInstalled,
+  } = useEntityAnalyticsRiskScorePanelData({
     riskEntity,
+    toggleStatus,
+    filterQuery,
+    timerange,
   });
 
   useQueryInspector({
@@ -139,25 +143,6 @@ const EntityAnalyticsRiskScoresComponent = <T extends EntityType>({
     setQuery,
     deleteQuery,
     inspect: inspectKpi,
-  });
-
-  const {
-    data,
-    loading: isTableLoading,
-    inspect,
-    refetch,
-    isAuthorized,
-    hasEngineBeenInstalled,
-  } = useRiskScore({
-    filterQuery,
-    skip: !toggleStatus,
-    pagination: {
-      cursorStart: 0,
-      querySize: 5,
-    },
-    timerange,
-    riskEntity,
-    includeAlertsCount: true,
   });
 
   useQueryInspector({

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_analytics_risk_score/use_entity_analytics_risk_score_panel_data.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_analytics_risk_score/use_entity_analytics_risk_score_panel_data.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { FF_ENABLE_ENTITY_STORE_V2 } from '@kbn/entity-store/public';
+
+import type { EntityRiskScore } from '../../../../common/search_strategy';
+import { EntityType } from '../../../../common/entity_analytics/types';
+import type { ESQuery } from '../../../../common/typed_json';
+import { useUiSetting } from '../../../common/lib/kibana';
+import { useEntityStoreRiskScoreKpi } from '../../api/hooks/use_entity_store_risk_score_kpi';
+import { useEntityStoreRiskScore } from '../../api/hooks/use_entity_store_risk_score';
+import { useRiskScoreKpi } from '../../api/hooks/use_risk_score_kpi';
+import { useRiskScore } from '../../api/hooks/use_risk_score';
+
+export const useEntityAnalyticsRiskScorePanelData = <T extends EntityType>({
+  riskEntity,
+  toggleStatus,
+  filterQuery,
+  timerange,
+}: {
+  riskEntity: T;
+  toggleStatus: boolean;
+  filterQuery?: ESQuery | string;
+  timerange: { from: string; to: string };
+}) => {
+  const entityStoreV2Enabled = useUiSetting<boolean>(FF_ENABLE_ENTITY_STORE_V2) === true;
+  const isHostOrUserRiskEntity = riskEntity === EntityType.host || riskEntity === EntityType.user;
+
+  const legacyKpi = useRiskScoreKpi({
+    filterQuery,
+    skip: !toggleStatus || (entityStoreV2Enabled && isHostOrUserRiskEntity),
+    timerange,
+    riskEntity,
+  });
+
+  const entityStoreKpi = useEntityStoreRiskScoreKpi({
+    filterQuery,
+    skip: !toggleStatus || !entityStoreV2Enabled || !isHostOrUserRiskEntity,
+    timerange,
+    riskEntity,
+  });
+
+  const kpi = entityStoreV2Enabled && isHostOrUserRiskEntity ? entityStoreKpi : legacyKpi;
+
+  const legacyRiskScore = useRiskScore({
+    filterQuery,
+    skip: !toggleStatus || (entityStoreV2Enabled && isHostOrUserRiskEntity),
+    pagination: {
+      cursorStart: 0,
+      querySize: 5,
+    },
+    timerange,
+    riskEntity,
+    includeAlertsCount: true,
+  });
+
+  const entityStoreRiskScore = useEntityStoreRiskScore({
+    filterQuery,
+    skip: !toggleStatus || !entityStoreV2Enabled || !isHostOrUserRiskEntity,
+    pagination: {
+      cursorStart: 0,
+      querySize: 5,
+    },
+    timerange,
+    riskEntity: riskEntity as EntityType.host,
+  });
+
+  const riskScore =
+    entityStoreV2Enabled && isHostOrUserRiskEntity ? entityStoreRiskScore : legacyRiskScore;
+
+  return {
+    severityCount: kpi.severityCount,
+    isKpiLoading: kpi.loading,
+    refetchKpi: kpi.refetch,
+    inspectKpi: kpi.inspect,
+    data: riskScore.data as Array<EntityRiskScore<T>> | undefined,
+    isTableLoading: riskScore.loading,
+    inspect: riskScore.inspect,
+    refetch: riskScore.refetch,
+    isAuthorized: riskScore.isAuthorized,
+    hasEngineBeenInstalled: riskScore.hasEngineBeenInstalled,
+  };
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_details_flyout/components/entity_highlights.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_details_flyout/components/entity_highlights.test.tsx
@@ -14,6 +14,7 @@ import { TestProviders } from '../../../../common/mock';
 // Mock the hooks
 const mockUseFetchAnonymizationFields = jest.fn();
 const mockUseAssistantContext = jest.fn();
+const mockUseMaybeAssistantContext = jest.fn();
 const mockUseLoadConnectors = jest.fn();
 const mockUseSpaceId = jest.fn();
 const mockUseStoredAssistantConnectorId = jest.fn();
@@ -24,6 +25,7 @@ const mockUseHasEntityHighlightsLicense = jest.fn();
 
 jest.mock('@kbn/elastic-assistant', () => ({
   useAssistantContext: () => mockUseAssistantContext(),
+  useMaybeAssistantContext: () => mockUseMaybeAssistantContext(),
   useFetchAnonymizationFields: () => mockUseFetchAnonymizationFields(),
   AssistantProvider: ({ children }: { children: React.ReactNode }) => (
     <div data-test-subj="assistant-provider">{children}</div>
@@ -139,6 +141,7 @@ describe('EntityHighlights', () => {
     // Set up default mock implementations
     mockUseFetchAnonymizationFields.mockReturnValue(defaultAnonymizationFields);
     mockUseAssistantContext.mockReturnValue(defaultAssistantContext);
+    mockUseMaybeAssistantContext.mockReturnValue(defaultAssistantContext);
     mockUseLoadConnectors.mockReturnValue(defaultLoadConnectors);
     mockUseSpaceId.mockReturnValue(defaultSpaceId);
     mockUseStoredAssistantConnectorId.mockReturnValue(defaultStoredAssistantConnectorId);
@@ -159,6 +162,16 @@ describe('EntityHighlights', () => {
 
   it('returns null when user has insufficent license', () => {
     mockUseHasEntityHighlightsLicense.mockReturnValueOnce(false);
+
+    render(<EntityHighlightsAccordion {...defaultProps} />, {
+      wrapper: TestProviders,
+    });
+
+    expect(screen.queryByText('Entity summary')).not.toBeInTheDocument();
+  });
+
+  it('returns null when rendered outside AssistantProvider (no assistant context)', () => {
+    mockUseMaybeAssistantContext.mockReturnValueOnce(undefined);
 
     render(<EntityHighlightsAccordion {...defaultProps} />, {
       wrapper: TestProviders,

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_details_flyout/components/entity_highlights.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_details_flyout/components/entity_highlights.tsx
@@ -21,7 +21,7 @@ import {
   EuiFlexGroup,
   EuiPanel,
 } from '@elastic/eui';
-import { useFetchAnonymizationFields } from '@kbn/elastic-assistant';
+import { useFetchAnonymizationFields, useMaybeAssistantContext } from '@kbn/elastic-assistant';
 import React, { Suspense, useCallback, useMemo, useState } from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { AddConnectorModal } from '@kbn/elastic-assistant/impl/connectorland/add_connector_modal';
@@ -43,6 +43,9 @@ export const EntityHighlightsAccordion: React.FC<{
   entityIdentifier: string;
   entityType: EntityType;
 }> = ({ entityType, entityIdentifier }) => {
+  // Degrade gracefully on surfaces that render outside `AssistantProvider` (e.g. the Agent
+  // Builder attachment Canvas). The Elastic Assistant–backed summary cannot work without it.
+  const assistantContext = useMaybeAssistantContext();
   const { data: anonymizationFields, isLoading: isAnonymizationFieldsLoading } =
     useFetchAnonymizationFields();
   const {
@@ -131,6 +134,12 @@ export const EntityHighlightsAccordion: React.FC<{
   }, []);
 
   const disabled = useMemo(() => {
+    // No `AssistantProvider` in the tree, e.g. Agent Builder attachment Canvas. Highlights
+    // relies on assistant context (anonymization fields, shared state), so hide the UI entirely.
+    if (!assistantContext) {
+      return true;
+    }
+
     if (!hasEntityHighlightsLicense) {
       return true;
     }
@@ -143,6 +152,7 @@ export const EntityHighlightsAccordion: React.FC<{
     // if user does not have access to assistant or agent builder, disable entity highlights
     return !(hasAssistantPrivilege || hasAgentBuilderPrivilege);
   }, [
+    assistantContext,
     hasConnectorsReadPrivilege,
     hasAgentBuilderPrivilege,
     hasAssistantPrivilege,

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_store/helpers.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_store/helpers.test.ts
@@ -5,7 +5,12 @@
  * 2.0.
  */
 
-import { getEntityType, sanitizeEntityRecordForUpsert, sourceFieldToText } from './helpers';
+import {
+  getEntityRecordRiskForListDisplay,
+  getEntityType,
+  sanitizeEntityRecordForUpsert,
+  sourceFieldToText,
+} from './helpers';
 import { render } from '@testing-library/react';
 import { TestProviders } from '@kbn/timelines-plugin/public/mock';
 import type {
@@ -271,6 +276,50 @@ describe('helpers', () => {
     });
   });
 
+  describe('getEntityRecordRiskForListDisplay', () => {
+    it('returns entity.risk fields for Entity Store v2 host documents', () => {
+      const hostEntity: HostEntity = {
+        '@timestamp': '2021-08-02T14:00:00.000Z',
+        host: { name: 'my-host' },
+        entity: {
+          id: 'host:1',
+          name: 'my-host',
+          risk: {
+            calculated_level: 'High',
+            calculated_score_norm: 77.5,
+          },
+        },
+      };
+
+      expect(getEntityRecordRiskForListDisplay(hostEntity)).toEqual({
+        calculated_level: 'High',
+        calculated_score_norm: 77.5,
+      });
+    });
+
+    it('falls back to host.risk when entity.risk is absent', () => {
+      const hostEntity = {
+        '@timestamp': '2021-08-02T14:00:00.000Z',
+        host: {
+          name: 'my-host',
+          risk: {
+            calculated_level: 'Low',
+            calculated_score_norm: 12,
+          },
+        },
+        entity: {
+          id: 'host:1',
+          name: 'my-host',
+        },
+      } as unknown as HostEntity;
+
+      expect(getEntityRecordRiskForListDisplay(hostEntity)).toEqual({
+        calculated_level: 'Low',
+        calculated_score_norm: 12,
+      });
+    });
+  });
+
   describe('sourceFieldToText', () => {
     it("should return 'Events' if the value isn't risk or asset", () => {
       const { container } = render(sourceFieldToText('anything'), {
@@ -294,6 +343,22 @@ describe('helpers', () => {
       });
 
       expect(container).toHaveTextContent('Asset Criticality');
+    });
+
+    it('should accept keyword values returned as a single-element array', () => {
+      const { container } = render(sourceFieldToText(['risk-score.risk-score-default']), {
+        wrapper: TestProviders,
+      });
+
+      expect(container).toHaveTextContent('Risk');
+    });
+
+    it("should return 'Events' for non-string shapes without throwing", () => {
+      const { container } = render(sourceFieldToText({ notAString: true }), {
+        wrapper: TestProviders,
+      });
+
+      expect(container).toHaveTextContent('Events');
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_store/helpers.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_store/helpers.tsx
@@ -24,6 +24,65 @@ export const getEntityType = getEntityTypeFromCommon;
 export const sanitizeEntityRecordForUpsert = (record: Entity): Entity =>
   sanitizeEntityRecordForUpsertFromCommon(record);
 
+/**
+ * Risk fields for entity list / table cells. Entity Store v2 stores scores on
+ * `entity.risk.*`; older documents may only have `host.risk.*`, `user.risk.*`, or `service.risk.*`.
+ */
+export const getEntityRecordRiskForListDisplay = (
+  record: Entity
+): {
+  calculated_level?: string;
+  calculated_score_norm?: number;
+} | null => {
+  const entityRisk = record.entity?.risk;
+  if (entityRisk) {
+    return {
+      calculated_level: entityRisk.calculated_level,
+      calculated_score_norm: entityRisk.calculated_score_norm,
+    };
+  }
+
+  if ('host' in record && record.host) {
+    const hostRisk = record.host.risk ?? record.host.entity?.risk;
+    if (hostRisk) {
+      return {
+        calculated_level: hostRisk.calculated_level,
+        calculated_score_norm: hostRisk.calculated_score_norm,
+      };
+    }
+  }
+
+  if ('user' in record && record.user) {
+    const userRisk =
+      record.user.risk ??
+      (
+        record.user as {
+          entity?: {
+            risk?: { calculated_level?: string; calculated_score_norm?: number };
+          };
+        }
+      ).entity?.risk;
+    if (userRisk) {
+      return {
+        calculated_level: userRisk.calculated_level,
+        calculated_score_norm: userRisk.calculated_score_norm,
+      };
+    }
+  }
+
+  if ('service' in record && record.service) {
+    const serviceRisk = record.service.risk ?? record.service.entity?.risk;
+    if (serviceRisk) {
+      return {
+        calculated_level: serviceRisk.calculated_level,
+        calculated_score_norm: serviceRisk.calculated_score_norm,
+      };
+    }
+  }
+
+  return null;
+};
+
 export const EntityIconByType: Record<EntityType, IconType> = {
   [EntityType.user]: 'user',
   [EntityType.host]: 'storage',
@@ -31,8 +90,40 @@ export const EntityIconByType: Record<EntityType, IconType> = {
   [EntityType.generic]: 'globe',
 };
 
-export const sourceFieldToText = (source: string) => {
-  if (source.match(`^${RISK_SCORE_INDEX_PATTERN}`)) {
+/**
+ * `entity.source` is modeled as a string but Elasticsearch may return a keyword as a
+ * single-element array; other shapes should not crash the table cell renderer.
+ */
+const entitySourceToIndexPattern = (source: unknown): string | null => {
+  if (source == null) {
+    return null;
+  }
+  if (typeof source === 'string') {
+    return source;
+  }
+  if (Array.isArray(source)) {
+    const firstString = source.find((item): item is string => typeof item === 'string');
+    return firstString ?? null;
+  }
+  if (typeof source === 'number' || typeof source === 'boolean') {
+    return String(source);
+  }
+  return null;
+};
+
+export const sourceFieldToText = (source: unknown) => {
+  const indexPattern = entitySourceToIndexPattern(source);
+
+  if (indexPattern == null) {
+    return (
+      <FormattedMessage
+        id="xpack.securitySolution.entityAnalytics.entityStore.helpers.sourceField.eventDescription"
+        defaultMessage="Events"
+      />
+    );
+  }
+
+  if (indexPattern.match(`^${RISK_SCORE_INDEX_PATTERN}`)) {
     return (
       <FormattedMessage
         id="xpack.securitySolution.entityAnalytics.entityStore.helpers.sourceField.riskDescription"
@@ -41,7 +132,7 @@ export const sourceFieldToText = (source: string) => {
     );
   }
 
-  if (source.match(`^${ASSET_CRITICALITY_INDEX_PATTERN}`)) {
+  if (indexPattern.match(`^${ASSET_CRITICALITY_INDEX_PATTERN}`)) {
     return (
       <FormattedMessage
         id="xpack.securitySolution.entityAnalytics.entityStore.helpers.sourceField.assetCriticalityDescription"

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_store/hooks/use_entities_list_columns.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_store/hooks/use_entities_list_columns.tsx
@@ -14,6 +14,7 @@ import { get } from 'lodash/fp';
 import {
   EntityTypeToLevelField,
   EntityTypeToScoreField,
+  type RiskSeverity,
 } from '../../../../../common/search_strategy';
 import {
   EntityPanelKeyByType,
@@ -26,14 +27,19 @@ import type { Columns } from '../../../../explore/components/paginated_table';
 import type { Entity } from '../../../../../common/api/entity_analytics/entity_store/entities/common.gen';
 import { type CriticalityLevels } from '../../../../../common/constants';
 import { ENTITIES_LIST_TABLE_ID } from '../constants';
-import { EntityIconByType, getEntityType, sourceFieldToText } from '../helpers';
+import {
+  EntityIconByType,
+  getEntityRecordRiskForListDisplay,
+  getEntityType,
+  sourceFieldToText,
+} from '../helpers';
 import { CRITICALITY_LEVEL_TITLE } from '../../asset_criticality/translations';
 import { formatRiskScore } from '../../../common';
 
 export type EntitiesListColumns = [
   Columns<Entity>,
   Columns<string, Entity>,
-  Columns<string | undefined, Entity>,
+  Columns<unknown, Entity>,
   Columns<CriticalityLevels, Entity>,
   Columns<Entity>,
   Columns<Entity>,
@@ -107,7 +113,7 @@ export const useEntitiesListColumns = (): EntitiesListColumns => {
         const entityType = getEntityType(record);
         return (
           <span>
-            <EuiIcon type={EntityIconByType[entityType]} />
+            <EuiIcon type={EntityIconByType[entityType]} aria-hidden />
             <span css={{ paddingLeft: euiTheme.size.s }}>{record.entity.name}</span>
           </span>
         );
@@ -124,12 +130,12 @@ export const useEntitiesListColumns = (): EntitiesListColumns => {
       ),
       width: '25%',
       truncateText: { lines: 2 },
-      render: (source: string | undefined) => {
-        if (source != null) {
-          return sourceFieldToText(source);
+      render: (source: unknown) => {
+        if (source == null) {
+          return getEmptyTagValue();
         }
 
-        return getEmptyTagValue();
+        return sourceFieldToText(source);
       },
     },
     {
@@ -159,7 +165,10 @@ export const useEntitiesListColumns = (): EntitiesListColumns => {
       width: '10%',
       render: (entity: Entity) => {
         const entityType = getEntityType(entity);
-        const riskScore = get(EntityTypeToScoreField[entityType], entity);
+        const fromStore = getEntityRecordRiskForListDisplay(entity);
+        const riskScore =
+          fromStore?.calculated_score_norm ??
+          (get(EntityTypeToScoreField[entityType], entity) as number | null | undefined);
 
         if (riskScore != null) {
           return (
@@ -181,10 +190,13 @@ export const useEntitiesListColumns = (): EntitiesListColumns => {
       width: '10%',
       render: (entity: Entity) => {
         const entityType = getEntityType(entity);
-        const riskLevel = get(EntityTypeToLevelField[entityType], entity);
+        const fromStore = getEntityRecordRiskForListDisplay(entity);
+        const riskLevel =
+          fromStore?.calculated_level ??
+          (get(EntityTypeToLevelField[entityType], entity) as string | null | undefined);
 
         if (riskLevel != null) {
-          return <RiskScoreLevel severity={riskLevel} />;
+          return <RiskScoreLevel severity={riskLevel as RiskSeverity} />;
         }
         return getEmptyTagValue();
       },

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/anomalies_panel.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/anomalies_panel.tsx
@@ -9,13 +9,18 @@ import React from 'react';
 import { EuiButtonEmpty, EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiTitle } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { ML_PAGES, useMlHref } from '@kbn/ml-plugin/public';
-import { RecentAnomaliesChart } from '../recent_anomalies/recent_anomalies_chart';
+import {
+  RecentAnomaliesChart,
+  RECENT_ANOMALIES_TIME_RANGE,
+} from '../recent_anomalies/recent_anomalies_chart';
 import { useKibana } from '../../../common/lib/kibana';
-import { useGlobalTime } from '../../../common/containers/use_global_time';
 import { useSpaceId } from '../../../common/hooks/use_space_id';
 
 const useRecentAnomaliesMlExplorerUrl = () => {
-  const { from, to } = useGlobalTime();
+  // The Entity Analytics home page hides the global date picker; keep the
+  // "Open in Anomaly Explorer" link aligned with the 30-day window used by
+  // the recent anomalies chart instead of reading from the global time.
+  const { from, to } = RECENT_ANOMALIES_TIME_RANGE;
   const { services } = useKibana();
 
   return useMlHref(

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/combined_risk_donut_chart.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/combined_risk_donut_chart.tsx
@@ -8,6 +8,7 @@
 import React from 'react';
 import { EuiFlexGroup, EuiFlexItem, EuiTitle } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { EMPTY_SEVERITY_COUNT } from '../../../../common/search_strategy';
 import { RiskScoreDonutChart } from '../risk_score_donut_chart';
 import { useCombinedRiskScoreKpi } from './use_combined_risk_score_kpi';
 import { useQueryToggle } from '../../../common/containers/query_toggle';
@@ -38,6 +39,8 @@ export const CombinedRiskDonutChart = () => {
     return null;
   }
 
+  const safeSeverityCount = severityCount ?? EMPTY_SEVERITY_COUNT;
+
   return (
     <EuiFlexGroup direction="column" gutterSize="m">
       <EuiFlexItem grow={false}>
@@ -53,10 +56,10 @@ export const CombinedRiskDonutChart = () => {
       <EuiFlexItem>
         <EuiFlexGroup alignItems="center" gutterSize="l" responsive={false}>
           <EuiFlexItem grow={4}>
-            <RiskLevelBreakdownTable severityCount={severityCount} loading={loading} />
+            <RiskLevelBreakdownTable severityCount={safeSeverityCount} loading={loading} />
           </EuiFlexItem>
           <EuiFlexItem grow={1}>
-            <RiskScoreDonutChart showLegend={false} severityCount={severityCount} />
+            <RiskScoreDonutChart showLegend={false} severityCount={safeSeverityCount} />
           </EuiFlexItem>
         </EuiFlexGroup>
       </EuiFlexItem>

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/dynamic_risk_level_panel.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/dynamic_risk_level_panel.test.tsx
@@ -1,0 +1,128 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { DynamicRiskLevelPanel } from './dynamic_risk_level_panel';
+import { TestProviders } from '../../../common/mock';
+import { useCombinedRiskScoreKpi } from './use_combined_risk_score_kpi';
+import { useRiskLevelsEsqlQuery } from '../watchlists/components/hooks/use_risk_levels_esql_query';
+import { useKibana } from '../../../common/lib/kibana';
+import { RiskSeverity } from '../../../../common/search_strategy';
+import { ENTITY_RISK_LEVEL_FIELD } from './risk_level_breakdown_table';
+import { RiskScoreDonutChart } from '../risk_score_donut_chart';
+
+jest.mock('./use_combined_risk_score_kpi');
+jest.mock('../watchlists/components/hooks/use_risk_levels_esql_query');
+jest.mock('../../../common/lib/kibana');
+jest.mock('../../../common/hooks/use_space_id', () => ({
+  useSpaceId: jest.fn(() => 'default'),
+}));
+
+jest.mock('../risk_score_donut_chart', () => ({
+  RiskScoreDonutChart: jest.fn(() => <div data-test-subj="mock-risk-score-donut-chart" />),
+}));
+
+const mockUseCombinedRiskScoreKpi = useCombinedRiskScoreKpi as jest.Mock;
+const mockUseRiskLevelsEsqlQuery = useRiskLevelsEsqlQuery as jest.Mock;
+const mockUseKibana = useKibana as jest.Mock;
+const mockRiskScoreDonutChart = RiskScoreDonutChart as unknown as jest.Mock;
+
+const buildKibanaServices = (addFilters: jest.Mock, isV2Enabled: boolean) => ({
+  services: {
+    uiSettings: {
+      get: jest.fn((key: string) => {
+        if (key === 'securitySolution:entityStoreEnableV2') {
+          return isV2Enabled;
+        }
+        return false;
+      }),
+    },
+    data: {
+      query: {
+        filterManager: {
+          addFilters,
+        },
+      },
+    },
+  },
+});
+
+describe('DynamicRiskLevelPanel', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockUseCombinedRiskScoreKpi.mockReturnValue({
+      severityCount: {
+        [RiskSeverity.Unknown]: 1,
+        [RiskSeverity.Low]: 2,
+        [RiskSeverity.Moderate]: 3,
+        [RiskSeverity.High]: 4,
+        [RiskSeverity.Critical]: 5,
+      },
+      loading: false,
+    });
+
+    mockUseRiskLevelsEsqlQuery.mockReturnValue({
+      records: [],
+      isLoading: false,
+    });
+  });
+
+  it('renders the entity risk levels title when no watchlist is selected', () => {
+    mockUseKibana.mockReturnValue(buildKibanaServices(jest.fn(), false));
+
+    render(
+      <TestProviders>
+        <DynamicRiskLevelPanel />
+      </TestProviders>
+    );
+
+    expect(screen.getByText('Entity risk levels')).toBeInTheDocument();
+  });
+
+  it('renders the watchlist-scoped title when a watchlist is selected', () => {
+    mockUseKibana.mockReturnValue(buildKibanaServices(jest.fn(), true));
+
+    render(
+      <TestProviders>
+        <DynamicRiskLevelPanel watchlistId="wl-1" watchlistName="VIP users" />
+      </TestProviders>
+    );
+
+    expect(screen.getByText('VIP users risk levels')).toBeInTheDocument();
+  });
+
+  it('threads an onPartitionClick handler to the donut that adds a global filter for entity.risk.calculated_level', () => {
+    const addFilters = jest.fn();
+    mockUseKibana.mockReturnValue(buildKibanaServices(addFilters, false));
+
+    render(
+      <TestProviders>
+        <DynamicRiskLevelPanel />
+      </TestProviders>
+    );
+
+    expect(mockRiskScoreDonutChart).toHaveBeenCalled();
+    const donutProps = mockRiskScoreDonutChart.mock.calls[0][0];
+    expect(typeof donutProps.onPartitionClick).toBe('function');
+
+    donutProps.onPartitionClick(RiskSeverity.Critical);
+
+    expect(addFilters).toHaveBeenCalledTimes(1);
+    expect(addFilters).toHaveBeenCalledWith([
+      {
+        meta: {
+          alias: null,
+          disabled: false,
+          negate: false,
+        },
+        query: { match_phrase: { [ENTITY_RISK_LEVEL_FIELD]: RiskSeverity.Critical } },
+      },
+    ]);
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/dynamic_risk_level_panel.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/dynamic_risk_level_panel.tsx
@@ -6,59 +6,84 @@
  */
 
 import { EuiFlexGroup, EuiFlexItem, EuiTitle } from '@elastic/eui';
-import React, { useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { RiskSeverity } from '../../../../common/search_strategy';
+import { FF_ENABLE_ENTITY_STORE_V2 } from '@kbn/entity-store/public';
+import type { DataView } from '@kbn/data-views-plugin/public';
+import type { RiskSeverity } from '../../../../common/search_strategy';
+import { EMPTY_SEVERITY_COUNT } from '../../../../common/search_strategy';
 import { useSpaceId } from '../../../common/hooks/use_space_id';
 import { RiskScoreDonutChart } from '../risk_score_donut_chart';
-import { RiskLevelBreakdownTable } from './risk_level_breakdown_table';
+import { ENTITY_RISK_LEVEL_FIELD, RiskLevelBreakdownTable } from './risk_level_breakdown_table';
 import { useCombinedRiskScoreKpi } from './use_combined_risk_score_kpi';
-import { useKibana } from '../../../common/lib/kibana';
+import { useKibana, useUiSetting } from '../../../common/lib/kibana';
 import { useRiskLevelsEsqlQuery } from '../watchlists/components/hooks/use_risk_levels_esql_query';
+import { esqlRecordsToSeverityCount, type EsqlSeverityRecord } from '../../common/utils';
+
+// Wide "all time" range used to neutralize the global date picker on the
+// Entity Analytics home page, where the picker is intentionally hidden and
+// risk levels must match the counts in the entities table.
+const ALL_TIME_RANGE = { from: 'now-100y', to: 'now' } as const;
 
 interface DynamicRiskLevelPanelProps {
   watchlistId?: string;
   watchlistName?: string;
+  /**
+   * The ad-hoc entity store data view used to resolve the field spec for
+   * `entity.risk.calculated_level` when rendering inline cell actions.
+   */
+  entityDataView?: DataView;
 }
 
 export const DynamicRiskLevelPanel: React.FC<DynamicRiskLevelPanelProps> = ({
   watchlistId,
   watchlistName,
+  entityDataView,
 }) => {
   const spaceId = useSpaceId();
   const hasWatchlist = !!watchlistId;
-  const { uiSettings } = useKibana().services;
-  const isEntityStoreV2Enabled = uiSettings.get<boolean>('securitySolution:entityStoreEnableV2');
+  const { filterManager } = useKibana().services.data.query;
+  const isEntityStoreV2Enabled = useUiSetting<boolean>(FF_ENABLE_ENTITY_STORE_V2) === true;
 
   const useLegacy = !isEntityStoreV2Enabled;
 
-  const combinedRiskStats = useCombinedRiskScoreKpi(!useLegacy);
+  const combinedRiskStats = useCombinedRiskScoreKpi(!useLegacy, {
+    timerangeOverride: ALL_TIME_RANGE,
+  });
   const riskLevelsStats = useRiskLevelsEsqlQuery({
     watchlistId: watchlistId ?? '',
     skip: useLegacy,
     spaceId: spaceId ?? '',
+    // The Entity Analytics home page intentionally hides the global date
+    // picker, so risk levels are shown across the entire entities-latest
+    // index to keep the chart aligned with the entities table below it.
+    applyGlobalTimeFilter: false,
   });
 
   const severityCount = useMemo(() => {
     if (useLegacy) {
-      return combinedRiskStats.severityCount;
+      return combinedRiskStats.severityCount ?? EMPTY_SEVERITY_COUNT;
     }
-    return {
-      [RiskSeverity.Critical]:
-        riskLevelsStats.records.find((r) => r.level === RiskSeverity.Critical)?.count ?? 0,
-      [RiskSeverity.High]:
-        riskLevelsStats.records.find((r) => r.level === RiskSeverity.High)?.count ?? 0,
-      [RiskSeverity.Moderate]:
-        riskLevelsStats.records.find((r) => r.level === RiskSeverity.Moderate)?.count ?? 0,
-      [RiskSeverity.Low]:
-        riskLevelsStats.records.find((r) => r.level === RiskSeverity.Low)?.count ?? 0,
-      [RiskSeverity.Unknown]:
-        riskLevelsStats.records.find((r) => r.level === RiskSeverity.Unknown || r.level === null)
-          ?.count ?? 0,
-    };
+    return esqlRecordsToSeverityCount((riskLevelsStats.records ?? []) as EsqlSeverityRecord[]);
   }, [useLegacy, combinedRiskStats.severityCount, riskLevelsStats.records]);
 
   const loading = useLegacy ? combinedRiskStats.loading : riskLevelsStats.isLoading;
+
+  const handlePartitionClick = useCallback(
+    (level: RiskSeverity) => {
+      filterManager.addFilters([
+        {
+          meta: {
+            alias: null,
+            disabled: false,
+            negate: false,
+          },
+          query: { match_phrase: { [ENTITY_RISK_LEVEL_FIELD]: level } },
+        },
+      ]);
+    },
+    [filterManager]
+  );
 
   return (
     <EuiFlexGroup direction="column" gutterSize="m" css={{ height: '100%' }}>
@@ -85,12 +110,20 @@ export const DynamicRiskLevelPanel: React.FC<DynamicRiskLevelPanelProps> = ({
         </EuiFlexGroup>
       </EuiFlexItem>
       <EuiFlexItem>
-        <EuiFlexGroup alignItems="center" gutterSize="l" responsive={false}>
-          <EuiFlexItem grow={4}>
-            <RiskLevelBreakdownTable severityCount={severityCount} loading={loading} />
+        <EuiFlexGroup alignItems="center" gutterSize="none">
+          <EuiFlexItem grow={3}>
+            <RiskLevelBreakdownTable
+              severityCount={severityCount}
+              loading={loading}
+              entityDataView={entityDataView}
+            />
           </EuiFlexItem>
-          <EuiFlexItem grow={1}>
-            <RiskScoreDonutChart showLegend={false} severityCount={severityCount} />
+          <EuiFlexItem grow={2}>
+            <RiskScoreDonutChart
+              showLegend={false}
+              severityCount={severityCount}
+              onPartitionClick={handlePartitionClick}
+            />
           </EuiFlexItem>
         </EuiFlexGroup>
       </EuiFlexItem>

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/entities_data_table.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/entities_data_table.test.tsx
@@ -7,6 +7,7 @@
 
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import type { CustomCellRenderer } from '@kbn/unified-data-table';
 import { EntitiesDataTable } from './entities_data_table';
 import { DataViewContext } from '.';
 import { TestProviders } from '../../../../common/mock';
@@ -29,11 +30,16 @@ const mockUseUserPrivileges = jest.mocked(useUserPrivileges);
 const mockUseGlobalTime = jest.mocked(useGlobalTime);
 const mockUseKibana = jest.mocked(useKibana);
 
+const capturedProps: { externalCustomRenderers?: CustomCellRenderer } = {};
+
 jest.mock('@kbn/unified-data-table', () => {
   const actual = jest.requireActual('@kbn/unified-data-table');
   return {
     ...actual,
-    UnifiedDataTable: () => <div data-test-subj="unifiedDataTable" />,
+    UnifiedDataTable: (props: { externalCustomRenderers?: CustomCellRenderer }) => {
+      capturedProps.externalCustomRenderers = props.externalCustomRenderers;
+      return <div data-test-subj="unifiedDataTable" />;
+    },
   };
 });
 
@@ -234,5 +240,57 @@ describe('EntitiesDataTable', () => {
         pageSize: DEFAULT_VISIBLE_ROWS_PER_PAGE,
       })
     );
+  });
+
+  describe('entity.source column renderer', () => {
+    const renderCell = (value: unknown) => {
+      const state = createMockState();
+      (state.getRowsFromPages as jest.Mock).mockReturnValue([
+        { flattened: { 'entity.source': value } },
+      ]);
+
+      renderWithProviders(state);
+
+      const renderer = capturedProps.externalCustomRenderers?.['entity.source'];
+      if (!renderer) throw new Error('entity.source renderer was not registered');
+
+      const row = { flattened: { 'entity.source': value } } as never;
+      // The renderer only consumes `row`, so we can pass minimal stubs for the other props.
+      return render(
+        <TestProviders>
+          {renderer({
+            row,
+            columnId: 'entity.source',
+            rowIndex: 0,
+            colIndex: 0,
+            setCellProps: jest.fn(),
+            isDetails: false,
+            isExpanded: false,
+            isExpandable: false,
+            dataView: mockDataView,
+            fieldFormats: {},
+          } as never)}
+        </TestProviders>
+      );
+    };
+
+    it('renders the empty placeholder when entity.source is missing', () => {
+      const { container } = renderCell(undefined);
+      expect(container.textContent).toContain('—');
+    });
+
+    it('renders a single source formatted (capitalized) without the "+N" overflow badge', () => {
+      const { getByText, queryByText, queryByTestId } = renderCell('entityanalytics_okta');
+      expect(getByText('Entityanalytics Okta')).toBeInTheDocument();
+      expect(queryByText('entityanalytics_okta')).not.toBeInTheDocument();
+      expect(queryByTestId('entitySourceValue-more')).not.toBeInTheDocument();
+    });
+
+    it('renders the first formatted source and a "+N" overflow badge for array values', () => {
+      const { getByText, queryByText, getByTestId } = renderCell(['okta', 'entityanalytics_okta']);
+      expect(getByText('Okta')).toBeInTheDocument();
+      expect(queryByText('okta')).not.toBeInTheDocument();
+      expect(getByTestId('entitySourceValue-more')).toHaveTextContent('+1');
+    });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/entities_data_table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/entities_data_table.tsx
@@ -55,6 +55,10 @@ import {
   EntityPanelKeyByType,
   EntityPanelParamByType,
 } from '../../../../flyout/entity_details/shared/constants';
+import {
+  EntitySourceValue,
+  toEntitySourceArray,
+} from '../../../../flyout/entity_details/shared/components/entity_source_value';
 
 import type { CriticalityLevelWithUnassigned } from '../../../../../common/entity_analytics/asset_criticality/types';
 import { AssetCriticalityBadge } from '../../asset_criticality';
@@ -192,32 +196,29 @@ export const EntitiesDataTable = ({
   } = useUserPrivileges();
   const { setQuery, deleteQuery } = useGlobalTime();
 
-  const [expandedDoc, setExpandedDoc] = useState<DataTableRecord | undefined>(undefined);
-
   const openTableFlyout = useCallback(
     (doc?: DataTableRecord | undefined) => {
-      if (doc) {
-        setExpandedDoc(doc);
-        const { entityType, entityName, entityId } = getEntityFields(doc);
-        if (!entityType || !entityName) return;
-
-        const panelKey = EntityPanelKeyByType[entityType];
-        const panelParam = EntityPanelParamByType[entityType];
-        if (!panelKey || !panelParam) return;
-
-        openRightPanel({
-          id: panelKey,
-          params: {
-            [panelParam]: entityName,
-            entityId,
-            contextID: ENTITY_ANALYTICS_TABLE_ID,
-            scopeId: ENTITY_ANALYTICS_TABLE_ID,
-          },
-        });
-      } else {
+      if (!doc) {
         closeFlyout();
-        setExpandedDoc(undefined);
+        return;
       }
+
+      const { entityType, entityName, entityId } = getEntityFields(doc);
+      if (!entityType || !entityName) return;
+
+      const panelKey = EntityPanelKeyByType[entityType];
+      const panelParam = EntityPanelParamByType[entityType];
+      if (!panelKey || !panelParam) return;
+
+      openRightPanel({
+        id: panelKey,
+        params: {
+          [panelParam]: entityName,
+          entityId,
+          contextID: ENTITY_ANALYTICS_TABLE_ID,
+          scopeId: ENTITY_ANALYTICS_TABLE_ID,
+        },
+      });
     },
     [openRightPanel, closeFlyout]
   );
@@ -299,6 +300,7 @@ export const EntitiesDataTable = ({
   const customGridColumnsConfiguration = useMemo<CustomGridColumnsConfiguration>(() => {
     const config: CustomGridColumnsConfiguration = {
       alerts: ({ column }) => ({ ...column, isExpandable: false }),
+      [ENTITY_FIELDS.ENTITY_SOURCE]: ({ column }) => ({ ...column, isExpandable: false }),
     };
     if (dataView.timeFieldName) {
       config[dataView.timeFieldName] = ({ column }) => ({ ...column, display: undefined });
@@ -449,6 +451,11 @@ export const EntitiesDataTable = ({
         const value = row.flattened[ENTITY_FIELDS.ENTITY_TYPE] as string | undefined;
         if (value == null) return getEmptyTagValue();
         return <>{_.capitalize(value)}</>;
+      },
+      [ENTITY_FIELDS.ENTITY_SOURCE]: ({ row }: DataGridCellValueElementProps) => {
+        const values = toEntitySourceArray(row.flattened[ENTITY_FIELDS.ENTITY_SOURCE]);
+        if (values.length === 0) return getEmptyTagValue();
+        return <EntitySourceValue values={values} />;
       },
       [ENTITY_FIELDS.ASSET_CRITICALITY]: ({ row }: DataGridCellValueElementProps) => {
         const value = row.flattened[ENTITY_FIELDS.ASSET_CRITICALITY] as
@@ -612,7 +619,6 @@ export const EntitiesDataTable = ({
             onSort={onSort}
             rows={rows}
             sampleSizeState={MAX_ENTITIES_TO_LOAD}
-            expandedDoc={expandedDoc}
             setExpandedDoc={openTableFlyout}
             renderDocumentView={EmptyComponent}
             sort={sort}

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/hooks/use_base_es_query.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/hooks/use_base_es_query.test.tsx
@@ -1,0 +1,101 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import type { PropsWithChildren } from 'react';
+import { renderHook } from '@testing-library/react';
+import type { DataView } from '@kbn/data-views-plugin/common';
+
+import { TestProviders } from '../../../../../common/mock';
+import { useKibana } from '../../../../../common/lib/kibana';
+import { DataViewContext } from '..';
+import { useBaseEsQuery } from './use_base_es_query';
+
+jest.mock('../../../../../common/lib/kibana');
+
+const mockUseKibana = jest.mocked(useKibana);
+
+const mockDataView = {
+  id: 'entities-latest',
+  title: 'entities-latest-default',
+  timeFieldName: '@timestamp',
+  getIndexPattern: () => 'entities-latest-default',
+  fields: [],
+} as unknown as DataView;
+
+const dataViewContextValue = {
+  dataView: mockDataView,
+  dataViewIsLoading: false,
+};
+
+const wrapper = ({ children }: PropsWithChildren) => (
+  <TestProviders>
+    <DataViewContext.Provider value={dataViewContextValue}>{children}</DataViewContext.Provider>
+  </TestProviders>
+);
+
+const flattenFilters = (filters: Array<Record<string, unknown>>): Array<Record<string, unknown>> =>
+  filters.flatMap((f) =>
+    typeof f === 'object' &&
+    f !== null &&
+    'bool' in f &&
+    (f as { bool?: { filter?: unknown } }).bool?.filter
+      ? ((f as { bool: { filter: Array<Record<string, unknown>> } }).bool.filter as Array<
+          Record<string, unknown>
+        >)
+      : [f]
+  );
+
+describe('useBaseEsQuery', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockUseKibana.mockReturnValue({
+      services: {
+        notifications: { toasts: { addError: jest.fn() } },
+        uiSettings: { get: jest.fn(() => false) },
+      },
+    } as unknown as ReturnType<typeof useKibana>);
+  });
+
+  const renderBaseEsQuery = () =>
+    renderHook(
+      () =>
+        useBaseEsQuery({
+          filters: [],
+          pageFilters: [],
+          query: { query: '', language: 'kuery' },
+        }),
+      { wrapper }
+    );
+
+  it('does not add a @timestamp range filter to the base query', () => {
+    const { result } = renderBaseEsQuery();
+
+    const filters = (result.current.query?.bool?.filter ?? []) as Array<Record<string, unknown>>;
+    const flattened = flattenFilters(filters);
+
+    const timestampRanges = flattened.filter(
+      (f) =>
+        typeof f === 'object' &&
+        f !== null &&
+        'range' in f &&
+        (f as { range?: Record<string, unknown> }).range !== undefined &&
+        '@timestamp' in (f as { range: Record<string, unknown> }).range
+    );
+
+    expect(timestampRanges).toHaveLength(0);
+  });
+
+  it('returns a well-formed bool query even with empty inputs', () => {
+    const { result } = renderBaseEsQuery();
+
+    expect(result.current.query).toBeDefined();
+    expect(result.current.query?.bool).toBeDefined();
+    expect(Array.isArray(result.current.query?.bool?.filter)).toBe(true);
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/hooks/use_base_es_query.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/hooks/use_base_es_query.ts
@@ -48,6 +48,9 @@ export const useBaseEsQuery = ({ filters = [], query, pageFilters = [] }: Entiti
     uiSettings,
   } = useKibana().services;
   const { dataView } = useContext(DataViewContext);
+  // The Entity Analytics home page intentionally hides the global date picker;
+  // the entities table shows all entities in the latest index regardless of
+  // time range. KQL and pinned filters from the global filter bar still apply.
   const { filterQuery: globalFilterQuery } = useGlobalFilterQuery();
   const allowLeadingWildcards = uiSettings.get('query:allowLeadingWildcards');
   const config: EsQueryConfig = useMemo(() => ({ allowLeadingWildcards }), [allowLeadingWildcards]);

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/hooks/use_entity_url_state.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/hooks/use_entity_url_state.test.tsx
@@ -1,0 +1,144 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import type { PropsWithChildren } from 'react';
+import type { Store } from 'redux';
+import { act, renderHook } from '@testing-library/react';
+import { Observable } from 'rxjs';
+
+import { TestProviders, createMockStore } from '../../../../../common/mock';
+import { useKibana } from '../../../../../common/lib/kibana';
+import { inputsActions } from '../../../../../common/store/inputs';
+import { InputsModelId } from '../../../../../common/store/inputs/constants';
+import type { EntitiesBaseURLQuery } from './use_entity_url_state';
+import { useEntityURLState } from './use_entity_url_state';
+
+jest.mock('../../../../../common/lib/kibana');
+
+const mockSetUrlQuery = jest.fn();
+const mockUrlQuery = {
+  query: { query: '', language: 'kuery' },
+  filters: [],
+  pageFilters: [],
+  sort: [['@timestamp', 'desc']],
+  pageIndex: 0,
+};
+
+jest.mock('./use_url_query', () => ({
+  useUrlQuery: () => ({ urlQuery: mockUrlQuery, setUrlQuery: mockSetUrlQuery }),
+}));
+
+jest.mock('./use_page_size', () => ({
+  usePageSize: () => ({ pageSize: 25, setPageSize: jest.fn() }),
+}));
+
+jest.mock('./use_base_es_query', () => ({
+  useBaseEsQuery: () => ({
+    query: { bool: { must: [], filter: [], should: [], must_not: [] } },
+  }),
+}));
+
+jest.mock('./use_persisted_query', () => ({
+  usePersistedQuery:
+    <T,>(getter: (params: EntitiesBaseURLQuery) => T) =>
+    () =>
+      getter({ filters: [], query: { query: '', language: 'kuery' } }),
+}));
+
+const mockUseKibana = jest.mocked(useKibana);
+
+const renderUseEntityURLState = (store: Store = createMockStore()) => {
+  const wrapper = ({ children }: PropsWithChildren) => (
+    <TestProviders store={store}>{children}</TestProviders>
+  );
+
+  const { result } = renderHook(
+    () =>
+      useEntityURLState({
+        paginationLocalStorageKey: 'test:pagination',
+        columnsLocalStorageKey: 'test:columns',
+      }),
+    { wrapper }
+  );
+
+  return { result, store };
+};
+
+describe('useEntityURLState', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockUseKibana.mockReturnValue({
+      services: {
+        data: {
+          query: {
+            filterManager: {
+              setAppFilters: jest.fn(),
+              getAppFilters: jest.fn(() => []),
+              getUpdates$: jest.fn(() => new Observable()),
+            },
+          },
+        },
+      },
+    } as unknown as ReturnType<typeof useKibana>);
+  });
+
+  describe('onResetFilters', () => {
+    it('resets the URL state query and filters', () => {
+      const { result } = renderUseEntityURLState();
+
+      act(() => {
+        result.current.onResetFilters();
+      });
+
+      expect(mockSetUrlQuery).toHaveBeenCalledWith({
+        pageIndex: 0,
+        filters: [],
+        query: {
+          query: '',
+          language: 'kuery',
+        },
+      });
+    });
+
+    it('dispatches setFilterQuery for the global input to clear the search bar text', () => {
+      const store = createMockStore();
+      const dispatchSpy = jest.spyOn(store, 'dispatch');
+      const { result } = renderUseEntityURLState(store);
+
+      act(() => {
+        result.current.onResetFilters();
+      });
+
+      expect(dispatchSpy).toHaveBeenCalledWith(
+        inputsActions.setFilterQuery({
+          id: InputsModelId.global,
+          query: '',
+          language: 'kuery',
+        })
+      );
+    });
+
+    it('dispatches setSavedQuery for the global input to clear any applied saved query', () => {
+      const store = createMockStore();
+      const dispatchSpy = jest.spyOn(store, 'dispatch');
+      const { result } = renderUseEntityURLState(store);
+
+      act(() => {
+        result.current.onResetFilters();
+      });
+
+      expect(dispatchSpy).toHaveBeenCalledWith(
+        inputsActions.setSavedQuery({
+          id: InputsModelId.global,
+          savedQuery: undefined,
+        })
+      );
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/hooks/use_entity_url_state.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/hooks/use_entity_url_state.ts
@@ -5,11 +5,14 @@
  * 2.0.
  */
 import { type Dispatch, type SetStateAction, useCallback, useEffect, useRef } from 'react';
+import { useDispatch } from 'react-redux';
 import type { BoolQuery, Filter, Query } from '@kbn/es-query';
 import type { CriteriaWithPagination } from '@elastic/eui';
 import type { DataTableRecord } from '@kbn/discover-utils/types';
 import deepEqual from 'fast-deep-equal';
 import { useKibana } from '../../../../../common/lib/kibana';
+import { inputsActions } from '../../../../../common/store/inputs';
+import { InputsModelId } from '../../../../../common/store/inputs/constants';
 import { useUrlQuery } from './use_url_query';
 import { usePageSize } from './use_page_size';
 import { useBaseEsQuery } from './use_base_es_query';
@@ -25,6 +28,9 @@ export interface EntitiesBaseURLQuery {
 export type URLQuery = EntitiesBaseURLQuery & Record<string, unknown>;
 
 type SortOrder = [string, string];
+
+const getPageIndexOrDefault = (pageIndex: unknown): number =>
+  typeof pageIndex === 'number' && Number.isFinite(pageIndex) ? pageIndex : 0;
 
 export interface EntityURLStateResult {
   setUrlQuery: (query: Record<string, unknown>) => void;
@@ -54,7 +60,6 @@ const getDefaultQuery = ({ query, filters }: EntitiesBaseURLQuery) => ({
   sort: { field: '@timestamp', direction: 'desc' },
   pageIndex: 0,
 });
-
 export const useEntityURLState = ({
   defaultQuery = getDefaultQuery,
   paginationLocalStorageKey,
@@ -73,6 +78,7 @@ export const useEntityURLState = ({
       query: { filterManager },
     },
   } = useKibana().services;
+  const dispatch = useDispatch();
 
   // Track current URL filters in a render-phase ref so the subscription below
   // can detect whether a filterManager update was triggered by us (URL → filterManager)
@@ -81,8 +87,20 @@ export const useEntityURLState = ({
   urlFiltersRef.current = urlQuery.filters || [];
 
   // URL state → filterManager: keeps filter pills visible in the filter bar.
+  // The deepEqual guard defends against reference churn from unrelated URL updates
+  // (like `flyout` params), preventing a redundant filterManager emission that would
+  // cascade into filter-bar re-renders.
+  const lastAppliedFiltersRef = useRef<Filter[] | null>(null);
   useEffect(() => {
-    filterManager.setAppFilters(urlQuery.filters || []);
+    const nextFilters = urlQuery.filters || [];
+    if (
+      lastAppliedFiltersRef.current !== null &&
+      deepEqual(lastAppliedFiltersRef.current, nextFilters)
+    ) {
+      return;
+    }
+    lastAppliedFiltersRef.current = nextFilters;
+    filterManager.setAppFilters(nextFilters);
   }, [filterManager, urlQuery.filters]);
 
   // filterManager → URL state: syncs removals made via the filter bar back to URL state.
@@ -119,7 +137,22 @@ export const useEntityURLState = ({
         language: 'kuery',
       },
     });
-  }, [setUrlQuery]);
+
+    dispatch(
+      inputsActions.setFilterQuery({
+        id: InputsModelId.global,
+        query: '',
+        language: 'kuery',
+      })
+    );
+
+    dispatch(
+      inputsActions.setSavedQuery({
+        id: InputsModelId.global,
+        savedQuery: undefined,
+      })
+    );
+  }, [setUrlQuery, dispatch]);
 
   const onChangePage = useCallback(
     (newPageIndex: number) => {
@@ -188,7 +221,7 @@ export const useEntityURLState = ({
           },
         },
     queryError,
-    pageIndex: urlQuery.pageIndex as number,
+    pageIndex: getPageIndexOrDefault(urlQuery.pageIndex),
     urlQuery,
     setTableOptions,
     handleUpdateQuery,

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/hooks/use_url_query.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/hooks/use_url_query.ts
@@ -4,8 +4,9 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { useEffect, useCallback, useMemo } from 'react';
+import { useEffect, useCallback, useMemo, useRef } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
+import deepEqual from 'fast-deep-equal';
 import { encodeQuery } from '@kbn/cloud-security-posture';
 import {
   QUERY_PARAM_KEY,
@@ -20,6 +21,12 @@ export const useUrlQuery = <T extends Record<string, unknown>>(getDefaultQuery: 
   const { push, replace } = useHistory();
   const { search, key } = useLocation();
 
+  // Preserve reference equality for each individual field when its content is
+  // unchanged. This prevents cascading re-renders in hooks that depend on specific
+  // fields (e.g. `filters`, `query`, `sort`) when only unrelated URL params
+  // (like `flyout`) change.
+  const previousUrlQueryRef = useRef<T & { flyout: Record<string, unknown> }>();
+
   const urlQuery = useMemo(() => {
     const decodedParams = decodeMultipleRisonParams<Record<string, unknown>>(
       search,
@@ -29,11 +36,29 @@ export const useUrlQuery = <T extends Record<string, unknown>>(getDefaultQuery: 
     const queryParams = (decodedParams[QUERY_PARAM_KEY] as Partial<T>) || {};
     const flyoutParams = (decodedParams[FLYOUT_PARAM_KEY] as Record<string, unknown>) || {};
 
-    return {
+    const next = {
       ...getDefaultQuery(),
       ...queryParams,
       flyout: flyoutParams,
-    };
+    } as T & { flyout: Record<string, unknown> };
+
+    const prev = previousUrlQueryRef.current;
+    if (prev) {
+      let allEqual = true;
+      (Object.keys(next) as Array<keyof typeof next>).forEach((field) => {
+        if (deepEqual(prev[field], next[field])) {
+          (next as Record<string, unknown>)[field as string] = prev[field] as unknown;
+        } else {
+          allEqual = false;
+        }
+      });
+      if (allEqual) {
+        return prev;
+      }
+    }
+
+    previousUrlQueryRef.current = next;
+    return next;
   }, [getDefaultQuery, search]);
 
   const setUrlQuery = useCallback(

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entity_alerts_cell.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entity_alerts_cell.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useEffect, useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import {
   EuiFlexGroup,
   EuiFlexItem,
@@ -16,6 +16,8 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { encode } from '@kbn/rison';
+import dateMath from '@kbn/datemath';
+import { useQuery } from '@kbn/react-query';
 import { DistributionBar } from '@kbn/security-solution-distribution-bar';
 import { SecurityPageName, useNavigation } from '@kbn/security-solution-navigation';
 import { useEntityStoreEuidApi } from '@kbn/entity-store/public';
@@ -26,8 +28,10 @@ import { FILTER_OPEN, FILTER_ACKNOWLEDGED } from '../../../../common/types';
 import { formatPageFilterSearchParam } from '../../../../common/utils/format_page_filter_search_param';
 import { useSignalIndex } from '../../../detections/containers/detection_engine/alerts/use_signal_index';
 import { ALERTS_QUERY_NAMES } from '../../../detections/containers/detection_engine/alerts/constants';
-import { useQueryAlerts } from '../../../detections/containers/detection_engine/alerts/use_query';
+import { fetchQueryAlerts } from '../../../detections/containers/detection_engine/alerts/api';
 import { useGlobalTime } from '../../../common/containers/use_global_time';
+import { useQueryInspector } from '../../../common/components/page/manage_query';
+import { useTrackHttpRequest } from '../../../common/lib/apm/use_track_http_request';
 import { URL_PARAM_KEY } from '../../../common/hooks/constants';
 import {
   OPEN_IN_ALERTS_TITLE_STATUS,
@@ -40,6 +44,16 @@ import {
   parseAlertsData,
 } from '../../../overview/components/detection_response/alerts_by_status/use_alerts_by_status';
 import { getFormattedAlertStats } from '../../../flyout/document_details/shared/components/alert_count_insight';
+
+const QUERY_KEY_ENTITY_ALERTS_BY_STATUS = 'entity-analytics-alerts-by-status';
+
+// The Entity Analytics home page hides the global date picker (see `hideDatePicker`
+// in entity_analytics_home_page.tsx), so we can't rely on the global time range — it
+// carries whatever the user last set on another page. Pin the alerts column to a
+// fixed "last 30 days" window instead. ES resolves the date-math expressions at
+// query time, so clicking the global refresh button always returns up-to-date counts.
+const ALERTS_CELL_FROM_STR = 'now-30d';
+const ALERTS_CELL_TO_STR = 'now';
 
 const ENTITY_FILTER_TITLE = i18n.translate(
   'xpack.securitySolution.entityAnalytics.homePage.alertsColumn.entityFilterTitle',
@@ -63,8 +77,9 @@ export const EntityAlertsCell: React.FC<{
   entityRecord?: EntityStoreRecord | null;
 }> = ({ entityName, entityType, entityRecord }) => {
   const { signalIndexName } = useSignalIndex();
-  const { from, to } = useGlobalTime();
+  const { setQuery, deleteQuery } = useGlobalTime();
   const { euiTheme } = useEuiTheme();
+  const { startTracking } = useTrackHttpRequest();
   const euidApi = useEntityStoreEuidApi();
 
   const filterField = EntityTypeToIdentifierField[entityType] || 'entity.id';
@@ -86,25 +101,64 @@ export const EntityAlertsCell: React.FC<{
     return undefined;
   }, [euidApi?.euid, entityType, entityRecord]);
 
-  const { data, setQuery: setAlertsQuery } = useQueryAlerts<{}, AlertsByStatusAgg>({
-    query: getAlertsByStatusQuery({
-      from,
-      to,
-      entityFilters,
-    }),
-    indexName: signalIndexName,
-    queryName: ALERTS_QUERY_NAMES.BY_STATUS,
+  const {
+    data,
+    isFetching,
+    refetch: refetchQuery,
+  } = useQuery({
+    queryKey: [
+      QUERY_KEY_ENTITY_ALERTS_BY_STATUS,
+      {
+        entityType,
+        entityName,
+        filterField,
+        fromStr: ALERTS_CELL_FROM_STR,
+        toStr: ALERTS_CELL_TO_STR,
+        signalIndexName,
+        entityFilters,
+      },
+    ],
+    queryFn: async ({ signal }) => {
+      const { endTracking } = startTracking({ name: ALERTS_QUERY_NAMES.BY_STATUS });
+      try {
+        const response = await fetchQueryAlerts<{}, AlertsByStatusAgg>({
+          query: getAlertsByStatusQuery({
+            from: ALERTS_CELL_FROM_STR,
+            to: ALERTS_CELL_TO_STR,
+            entityFilters,
+          }),
+          // react-query v4 types `signal` as `AbortSignal | undefined`, but
+          // `fetchQueryAlerts` requires a non-optional `AbortSignal`. Fall back
+          // to a fresh controller so the call type-checks when react-query
+          // hasn't supplied one.
+          signal: signal ?? new AbortController().signal,
+        });
+        endTracking('success');
+        return response;
+      } catch (err) {
+        endTracking(signal?.aborted ? 'aborted' : 'error');
+        throw err;
+      }
+    },
+    enabled: Boolean(signalIndexName && entityName && entityType),
+    staleTime: Infinity,
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+    keepPreviousData: true,
   });
 
-  useEffect(() => {
-    setAlertsQuery(
-      getAlertsByStatusQuery({
-        from,
-        to,
-        entityFilters,
-      })
-    );
-  }, [setAlertsQuery, from, to, entityName, entityFilters]);
+  const refetch = useCallback(() => {
+    void refetchQuery();
+  }, [refetchQuery]);
+
+  useQueryInspector({
+    queryId: `entity-analytics-alerts-${entityType}-${entityName}`,
+    setQuery,
+    deleteQuery,
+    refetch,
+    loading: isFetching,
+    inspect: null,
+  });
 
   const { navigateTo } = useNavigation();
 
@@ -113,16 +167,6 @@ export const EntityAlertsCell: React.FC<{
   const alertsData = parseAlertsData(data);
   const alertStats = getFormattedAlertStats(alertsData, euiTheme);
   const alertCount = (alertsData?.open?.total ?? 0) + (alertsData?.acknowledged?.total ?? 0);
-
-  const timerange = encode({
-    global: {
-      [URL_PARAM_KEY.timerange]: {
-        kind: 'absolute',
-        from,
-        to,
-      },
-    },
-  });
 
   const statusPageFilter = {
     title: OPEN_IN_ALERTS_TITLE_STATUS,
@@ -145,9 +189,25 @@ export const EntityAlertsCell: React.FC<{
   const appQueryPath = euidKqlEntityFilter
     ? `&${URL_PARAM_KEY.appQuery}=${encode({ language: 'kuery', query: euidKqlEntityFilter })}`
     : '';
-  const timerangePath = timerange ? `&timerange=${timerange}` : '';
 
   const openAlertsPage = () => {
+    // Resolve the date-math strings at click time so the alerts page opens with a
+    // snapshot of the last 30 days aligned with what the user just saw in the cell.
+    const from = dateMath.parse(ALERTS_CELL_FROM_STR)?.toISOString() ?? '';
+    const to = dateMath.parse(ALERTS_CELL_TO_STR, { roundUp: true })?.toISOString() ?? '';
+    const timerange = encode({
+      global: {
+        [URL_PARAM_KEY.timerange]: {
+          kind: 'relative',
+          fromStr: ALERTS_CELL_FROM_STR,
+          toStr: ALERTS_CELL_TO_STR,
+          from,
+          to,
+        },
+      },
+    });
+    const timerangePath = timerange ? `&timerange=${timerange}` : '';
+
     navigateTo({
       deepLinkId: SecurityPageName.alerts,
       path: `?${URL_PARAM_KEY.pageFilter}=${urlFilterParams}${appQueryPath}${timerangePath}`,

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/risk_level_breakdown_table.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/risk_level_breakdown_table.test.tsx
@@ -7,10 +7,51 @@
 
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { RiskLevelBreakdownTable } from './risk_level_breakdown_table';
+import type { DataView } from '@kbn/data-views-plugin/public';
+import type { CellActionsProps } from '@kbn/cell-actions';
+import { ENTITY_RISK_LEVEL_FIELD, RiskLevelBreakdownTable } from './risk_level_breakdown_table';
 import { TestProviders } from '../../../common/mock';
 import { RiskSeverity, EMPTY_SEVERITY_COUNT } from '../../../../common/search_strategy';
 import type { SeverityCount } from '../severity/types';
+
+jest.mock('@kbn/cell-actions', () => {
+  const actual = jest.requireActual('@kbn/cell-actions');
+  return {
+    ...actual,
+    CellActions: ({ data, metadata }: CellActionsProps) => {
+      const entry = Array.isArray(data) ? data[0] : data;
+      return (
+        <div
+          data-test-subj="mock-cell-actions"
+          data-field={entry?.field?.name}
+          data-value={entry?.value as string}
+          data-dataviewid={(metadata as { dataViewId?: string } | undefined)?.dataViewId}
+        />
+      );
+    },
+  };
+});
+
+const buildEntityDataView = (): DataView => {
+  const fieldSpec = {
+    name: ENTITY_RISK_LEVEL_FIELD,
+    type: 'string',
+    searchable: true,
+    aggregatable: true,
+  };
+  return {
+    id: 'entity-store-dv-id',
+    fields: {
+      getByName: jest.fn((name: string) => {
+        if (name !== ENTITY_RISK_LEVEL_FIELD) return undefined;
+        return {
+          ...fieldSpec,
+          toSpec: () => fieldSpec,
+        };
+      }),
+    },
+  } as unknown as DataView;
+};
 
 describe('RiskLevelBreakdownTable', () => {
   it('should render the table with correct severity counts for all risk levels', () => {
@@ -54,7 +95,7 @@ describe('RiskLevelBreakdownTable', () => {
     expect(screen.getByTestId('risk-level-breakdown-table')).toBeInTheDocument();
   });
 
-  it('should display correct score ranges for each risk level', () => {
+  it('should display the score range in a dedicated column for each risk level', () => {
     const severityCount: SeverityCount = {
       [RiskSeverity.Unknown]: 1,
       [RiskSeverity.Low]: 2,
@@ -74,12 +115,14 @@ describe('RiskLevelBreakdownTable', () => {
     expect(screen.getByText('40-70')).toBeInTheDocument();
     expect(screen.getByText('20-40')).toBeInTheDocument();
     expect(screen.getByText('<20')).toBeInTheDocument();
+
+    expect(screen.getAllByTestId('riskLevelBreakdownTable-scoreRange')).toHaveLength(5);
   });
 
-  it('should format count numbers with toLocaleString', () => {
+  it('should format count numbers with getAbbreviatedNumber when they are >= 1000', () => {
     const severityCount: SeverityCount = {
       [RiskSeverity.Unknown]: 1000,
-      [RiskSeverity.Low]: 2000,
+      [RiskSeverity.Low]: 2500,
       [RiskSeverity.Moderate]: 3000,
       [RiskSeverity.High]: 4000,
       [RiskSeverity.Critical]: 5000,
@@ -91,11 +134,12 @@ describe('RiskLevelBreakdownTable', () => {
       </TestProviders>
     );
 
-    // toLocaleString() will format numbers based on locale, but we can check they're rendered
     expect(screen.getByTestId('risk-level-breakdown-table')).toBeInTheDocument();
-    // The numbers should be formatted (e.g., "1,000" in en-US locale)
-    const table = screen.getByTestId('risk-level-breakdown-table');
-    expect(table).toBeInTheDocument();
+    expect(screen.getByText('1.0k')).toBeInTheDocument();
+    expect(screen.getByText('2.5k')).toBeInTheDocument();
+    expect(screen.getByText('3.0k')).toBeInTheDocument();
+    expect(screen.getByText('4.0k')).toBeInTheDocument();
+    expect(screen.getByText('5.0k')).toBeInTheDocument();
   });
 
   it('should handle empty/zero counts correctly', () => {
@@ -114,7 +158,6 @@ describe('RiskLevelBreakdownTable', () => {
     );
 
     expect(screen.getByTestId('risk-level-breakdown-table')).toBeInTheDocument();
-    // All counts should be 0
     const zeroCounts = screen.getAllByText('0');
     expect(zeroCounts.length).toBeGreaterThanOrEqual(5);
   });
@@ -127,7 +170,6 @@ describe('RiskLevelBreakdownTable', () => {
     );
 
     expect(screen.getByTestId('risk-level-breakdown-table')).toBeInTheDocument();
-    // Verify all score ranges are still displayed
     expect(screen.getByText('>90')).toBeInTheDocument();
     expect(screen.getByText('70-90')).toBeInTheDocument();
     expect(screen.getByText('40-70')).toBeInTheDocument();
@@ -135,7 +177,7 @@ describe('RiskLevelBreakdownTable', () => {
     expect(screen.getByText('<20')).toBeInTheDocument();
   });
 
-  it('should display risk level column headers correctly', () => {
+  it('should display Risk level, Risk score and Entities column headers', () => {
     const severityCount: SeverityCount = {
       [RiskSeverity.Unknown]: 1,
       [RiskSeverity.Low]: 1,
@@ -153,5 +195,71 @@ describe('RiskLevelBreakdownTable', () => {
     expect(screen.getByText('Risk level')).toBeInTheDocument();
     expect(screen.getByText('Risk score')).toBeInTheDocument();
     expect(screen.getByText('Entities')).toBeInTheDocument();
+  });
+
+  it('should not render CellActions when no entityDataView is provided', () => {
+    render(
+      <TestProviders>
+        <RiskLevelBreakdownTable severityCount={EMPTY_SEVERITY_COUNT} />
+      </TestProviders>
+    );
+
+    expect(screen.queryAllByTestId('mock-cell-actions')).toHaveLength(0);
+  });
+
+  it('should not render CellActions when the entityDataView does not expose the risk level field', () => {
+    const emptyDataView = {
+      id: 'empty-dv',
+      fields: {
+        getByName: jest.fn().mockReturnValue(undefined),
+      },
+    } as unknown as DataView;
+
+    render(
+      <TestProviders>
+        <RiskLevelBreakdownTable
+          severityCount={EMPTY_SEVERITY_COUNT}
+          entityDataView={emptyDataView}
+        />
+      </TestProviders>
+    );
+
+    expect(screen.queryAllByTestId('mock-cell-actions')).toHaveLength(0);
+  });
+
+  it('should render a CellActions cell per row using the resolved entity data view field spec', () => {
+    const severityCount: SeverityCount = {
+      [RiskSeverity.Unknown]: 1,
+      [RiskSeverity.Low]: 2,
+      [RiskSeverity.Moderate]: 3,
+      [RiskSeverity.High]: 4,
+      [RiskSeverity.Critical]: 5,
+    };
+
+    render(
+      <TestProviders>
+        <RiskLevelBreakdownTable
+          severityCount={severityCount}
+          entityDataView={buildEntityDataView()}
+        />
+      </TestProviders>
+    );
+
+    const cellActions = screen.getAllByTestId('mock-cell-actions');
+    expect(cellActions).toHaveLength(5);
+
+    cellActions.forEach((el) => {
+      expect(el).toHaveAttribute('data-field', ENTITY_RISK_LEVEL_FIELD);
+      expect(el).toHaveAttribute('data-dataviewid', 'entity-store-dv-id');
+    });
+    expect(cellActions.map((el) => el.getAttribute('data-value'))).toEqual(
+      expect.arrayContaining([
+        RiskSeverity.Critical,
+        RiskSeverity.High,
+        RiskSeverity.Moderate,
+        RiskSeverity.Low,
+        RiskSeverity.Unknown,
+      ])
+    );
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/risk_level_breakdown_table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/risk_level_breakdown_table.tsx
@@ -7,11 +7,19 @@
 
 import React, { useMemo } from 'react';
 import type { EuiBasicTableColumn } from '@elastic/eui';
-import { EuiBasicTable, EuiText, useEuiTheme } from '@elastic/eui';
+import { EuiInMemoryTable, EuiText, useEuiTheme } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { SECURITY_CELL_ACTIONS_DEFAULT } from '@kbn/ui-actions-plugin/common/trigger_ids';
+import type { DataView } from '@kbn/data-views-plugin/public';
+import { CellActions } from '@kbn/cell-actions';
+import { CellActionsMode } from '@kbn/cell-actions/constants';
+import { getAbbreviatedNumber } from '@kbn/cloud-security-posture-common';
 import { RiskSeverity } from '../../../../common/search_strategy';
 import { RiskScoreLevel } from '../severity/common';
 import type { SeverityCount } from '../severity/types';
+import { SecurityCellActionType } from '../../../common/components/cell_actions';
+
+export const ENTITY_RISK_LEVEL_FIELD = 'entity.risk.calculated_level';
 
 interface RiskLevelBreakdownItem {
   level: RiskSeverity;
@@ -22,11 +30,18 @@ interface RiskLevelBreakdownItem {
 interface RiskLevelBreakdownTableProps {
   severityCount: SeverityCount;
   loading?: boolean;
+  /**
+   * When provided, inline cell actions (filter in/out, add to timeline, copy)
+   * will be rendered next to each risk level using this data view's field spec
+   * for `entity.risk.calculated_level`.
+   */
+  entityDataView?: DataView;
 }
 
 export const RiskLevelBreakdownTable: React.FC<RiskLevelBreakdownTableProps> = ({
   severityCount,
   loading = false,
+  entityDataView,
 }) => {
   const { euiTheme } = useEuiTheme();
 
@@ -60,8 +75,20 @@ export const RiskLevelBreakdownTable: React.FC<RiskLevelBreakdownTableProps> = (
     ];
   }, [severityCount]);
 
-  const columns: Array<EuiBasicTableColumn<RiskLevelBreakdownItem>> = useMemo(
-    () => [
+  const riskLevelFieldSpec = useMemo(
+    () => entityDataView?.fields?.getByName(ENTITY_RISK_LEVEL_FIELD)?.toSpec(),
+    [entityDataView]
+  );
+
+  const cellActionsMetadata = useMemo(
+    () => (entityDataView?.id ? { dataViewId: entityDataView.id } : undefined),
+    [entityDataView]
+  );
+
+  const showCellActions = !!riskLevelFieldSpec && !!cellActionsMetadata;
+
+  const columns: Array<EuiBasicTableColumn<RiskLevelBreakdownItem>> = useMemo(() => {
+    const baseColumns: Array<EuiBasicTableColumn<RiskLevelBreakdownItem>> = [
       {
         field: 'level',
         name: (
@@ -70,6 +97,7 @@ export const RiskLevelBreakdownTable: React.FC<RiskLevelBreakdownTableProps> = (
             defaultMessage="Risk level"
           />
         ),
+        'data-test-subj': 'riskLevelBreakdownTable-level',
         render: (level: RiskSeverity) => (
           <EuiText className="eui-textTruncate" size="s">
             <RiskScoreLevel hideBackgroundColor severity={level} />
@@ -85,12 +113,9 @@ export const RiskLevelBreakdownTable: React.FC<RiskLevelBreakdownTableProps> = (
           />
         ),
         align: 'right',
+        'data-test-subj': 'riskLevelBreakdownTable-scoreRange',
         render: (scoreRange: string) => (
-          <EuiText
-            className="eui-textTruncate"
-            size="s"
-            style={{ fontWeight: euiTheme.font.weight.medium }}
-          >
+          <EuiText size="s" css={{ whiteSpace: 'nowrap', fontWeight: euiTheme.font.weight.medium }}>
             {scoreRange}
           </EuiText>
         ),
@@ -104,22 +129,41 @@ export const RiskLevelBreakdownTable: React.FC<RiskLevelBreakdownTableProps> = (
           />
         ),
         align: 'right',
+        'data-test-subj': 'riskLevelBreakdownTable-count',
         render: (count: number) => (
-          <EuiText
-            className="eui-textTruncate"
-            size="s"
-            style={{ fontWeight: euiTheme.font.weight.semiBold }}
-          >
-            {count.toLocaleString()}
+          <EuiText size="s" style={{ fontWeight: euiTheme.font.weight.semiBold }}>
+            {getAbbreviatedNumber(count)}
           </EuiText>
         ),
       },
-    ],
-    [euiTheme]
-  );
+    ];
+
+    if (showCellActions && riskLevelFieldSpec && cellActionsMetadata) {
+      baseColumns.push({
+        field: 'level',
+        name: '',
+        width: '40px',
+        'data-test-subj': 'riskLevelBreakdownTable-actions',
+        render: (level: RiskSeverity) => (
+          <CellActions
+            mode={CellActionsMode.INLINE}
+            visibleCellActions={0}
+            triggerId={SECURITY_CELL_ACTIONS_DEFAULT}
+            data={{ field: riskLevelFieldSpec, value: level }}
+            metadata={cellActionsMetadata}
+            disabledActionTypes={[SecurityCellActionType.SHOW_TOP_N]}
+            extraActionsIconType="boxesVertical"
+            extraActionsColor="text"
+          />
+        ),
+      });
+    }
+
+    return baseColumns;
+  }, [euiTheme, showCellActions, riskLevelFieldSpec, cellActionsMetadata]);
 
   return (
-    <EuiBasicTable
+    <EuiInMemoryTable
       items={tableItems}
       compressed={true}
       columns={columns}

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/use_combined_risk_score_kpi.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/use_combined_risk_score_kpi.test.ts
@@ -9,10 +9,28 @@ import { renderHook, waitFor } from '@testing-library/react';
 import { useCombinedRiskScoreKpi } from './use_combined_risk_score_kpi';
 import { TestProviders } from '../../../common/mock';
 import { useRiskScoreKpi } from '../../api/hooks/use_risk_score_kpi';
+import { useEntityStoreRiskScoreKpi } from '../../api/hooks/use_entity_store_risk_score_kpi';
 import { EntityType } from '../../../../common/entity_analytics/types';
 import { RiskSeverity, EMPTY_SEVERITY_COUNT } from '../../../../common/search_strategy';
 
 jest.mock('../../api/hooks/use_risk_score_kpi');
+jest.mock('../../api/hooks/use_entity_store_risk_score_kpi', () => ({
+  useEntityStoreRiskScoreKpi: jest.fn(() => ({
+    severityCount: undefined,
+    loading: false,
+    error: undefined,
+    isModuleDisabled: false,
+    refetch: jest.fn(),
+    inspect: { dsl: [], response: [] },
+  })),
+}));
+jest.mock('../../../common/lib/kibana', () => {
+  const actual = jest.requireActual('../../../common/lib/kibana');
+  return {
+    ...actual,
+    useUiSetting: jest.fn(() => false),
+  };
+});
 jest.mock('../../../common/hooks/use_global_filter_query', () => ({
   useGlobalFilterQuery: jest.fn(() => ({ filterQuery: '' })),
 }));
@@ -24,6 +42,7 @@ jest.mock('../../../common/containers/use_global_time', () => ({
 }));
 
 const mockUseRiskScoreKpi = useRiskScoreKpi as jest.Mock;
+const mockUseEntityStoreRiskScoreKpi = useEntityStoreRiskScoreKpi as jest.Mock;
 
 describe('useCombinedRiskScoreKpi', () => {
   beforeEach(() => {
@@ -95,6 +114,20 @@ describe('useCombinedRiskScoreKpi', () => {
     expect(mockUseRiskScoreKpi).toHaveBeenCalledWith(
       expect.objectContaining({
         riskEntity: [EntityType.user, EntityType.host, EntityType.service],
+        skip: false,
+      })
+    );
+    expect(mockUseEntityStoreRiskScoreKpi).toHaveBeenCalledTimes(2);
+    expect(mockUseEntityStoreRiskScoreKpi).toHaveBeenCalledWith(
+      expect.objectContaining({
+        riskEntity: EntityType.host,
+        skip: true,
+      })
+    );
+    expect(mockUseEntityStoreRiskScoreKpi).toHaveBeenCalledWith(
+      expect.objectContaining({
+        riskEntity: EntityType.user,
+        skip: true,
       })
     );
   });
@@ -135,6 +168,30 @@ describe('useCombinedRiskScoreKpi', () => {
       expect.objectContaining({
         skip: true,
         riskEntity: [EntityType.user, EntityType.host, EntityType.service],
+      })
+    );
+  });
+
+  it('uses timerangeOverride instead of the global date picker when provided', () => {
+    mockUseRiskScoreKpi.mockReturnValue({
+      severityCount: EMPTY_SEVERITY_COUNT,
+      loading: false,
+      error: undefined,
+      isModuleDisabled: false,
+      refetch: jest.fn(),
+    });
+
+    renderHook(
+      () =>
+        useCombinedRiskScoreKpi(false, {
+          timerangeOverride: { from: 'now-100y', to: 'now' },
+        }),
+      { wrapper: TestProviders }
+    );
+
+    expect(mockUseRiskScoreKpi).toHaveBeenCalledWith(
+      expect.objectContaining({
+        timerange: { from: 'now-100y', to: 'now' },
       })
     );
   });

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/use_combined_risk_score_kpi.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/use_combined_risk_score_kpi.ts
@@ -5,13 +5,27 @@
  * 2.0.
  */
 
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
+import { FF_ENABLE_ENTITY_STORE_V2 } from '@kbn/entity-store/public';
 import { EntityType } from '../../../../common/entity_analytics/types';
-import { EMPTY_SEVERITY_COUNT } from '../../../../common/search_strategy';
+import { EMPTY_SEVERITY_COUNT, RiskSeverity } from '../../../../common/search_strategy';
 import { useRiskScoreKpi } from '../../api/hooks/use_risk_score_kpi';
+import { useEntityStoreRiskScoreKpi } from '../../api/hooks/use_entity_store_risk_score_kpi';
 import { useGlobalFilterQuery } from '../../../common/hooks/use_global_filter_query';
 import { useGlobalTime } from '../../../common/containers/use_global_time';
+import { useUiSetting } from '../../../common/lib/kibana';
 import type { SeverityCount } from '../severity/types';
+
+const mergeSeverityCounts = (
+  a: SeverityCount | undefined,
+  b: SeverityCount | undefined
+): SeverityCount => ({
+  [RiskSeverity.Unknown]: (a?.[RiskSeverity.Unknown] ?? 0) + (b?.[RiskSeverity.Unknown] ?? 0),
+  [RiskSeverity.Low]: (a?.[RiskSeverity.Low] ?? 0) + (b?.[RiskSeverity.Low] ?? 0),
+  [RiskSeverity.Moderate]: (a?.[RiskSeverity.Moderate] ?? 0) + (b?.[RiskSeverity.Moderate] ?? 0),
+  [RiskSeverity.High]: (a?.[RiskSeverity.High] ?? 0) + (b?.[RiskSeverity.High] ?? 0),
+  [RiskSeverity.Critical]: (a?.[RiskSeverity.Critical] ?? 0) + (b?.[RiskSeverity.Critical] ?? 0),
+});
 
 interface UseCombinedRiskScoreKpiResult {
   severityCount: SeverityCount;
@@ -21,13 +35,32 @@ interface UseCombinedRiskScoreKpiResult {
   refetch: () => void;
 }
 
+interface UseCombinedRiskScoreKpiOptions {
+  /**
+   * Optional override for the time range used by the underlying KPI queries.
+   * When provided, the global date picker is ignored and the supplied range
+   * is used instead. Useful on pages where the global date picker is hidden
+   * or the chart should show all-time data.
+   */
+  timerangeOverride?: { from: string; to: string };
+}
+
 /**
  * Hook that aggregates risk score KPI data from all three entity types (user, host, service)
  * into a combined severity count for display in the entity analytics home page donut chart.
  */
-export const useCombinedRiskScoreKpi = (skip?: boolean): UseCombinedRiskScoreKpiResult => {
-  const { from, to } = useGlobalTime();
+export const useCombinedRiskScoreKpi = (
+  skip?: boolean,
+  options?: UseCombinedRiskScoreKpiOptions
+): UseCombinedRiskScoreKpiResult => {
+  const { from: globalFrom, to: globalTo } = useGlobalTime();
   const { filterQuery } = useGlobalFilterQuery();
+  const entityStoreV2Enabled = useUiSetting<boolean>(FF_ENABLE_ENTITY_STORE_V2) === true;
+
+  const overrideFrom = options?.timerangeOverride?.from;
+  const overrideTo = options?.timerangeOverride?.to;
+  const from = overrideFrom ?? globalFrom;
+  const to = overrideTo ?? globalTo;
 
   const timerange = useMemo(
     () => ({
@@ -40,24 +73,53 @@ export const useCombinedRiskScoreKpi = (skip?: boolean): UseCombinedRiskScoreKpi
   // Memoize entity array to prevent re-creation on every render
   const entityTypes = useMemo(() => [EntityType.user, EntityType.host, EntityType.service], []);
 
-  // Query all three entity types in a single call
+  // Query all three entity types in a single call (legacy risk-score indices)
   const combinedRiskKpi = useRiskScoreKpi({
     filterQuery,
-    skip,
+    skip: skip || entityStoreV2Enabled,
     riskEntity: entityTypes,
     timerange,
   });
 
-  const loading = combinedRiskKpi.loading;
-  const error = combinedRiskKpi.error;
-  const isModuleDisabled = combinedRiskKpi.isModuleDisabled;
+  const hostStoreKpi = useEntityStoreRiskScoreKpi({
+    filterQuery,
+    skip: skip || !entityStoreV2Enabled,
+    riskEntity: EntityType.host,
+    timerange,
+  });
 
-  const refetch = () => {
-    combinedRiskKpi.refetch();
-  };
+  const userStoreKpi = useEntityStoreRiskScoreKpi({
+    filterQuery,
+    skip: skip || !entityStoreV2Enabled,
+    riskEntity: EntityType.user,
+    timerange,
+  });
+
+  const loading = entityStoreV2Enabled
+    ? hostStoreKpi.loading || userStoreKpi.loading
+    : combinedRiskKpi.loading;
+  const error = entityStoreV2Enabled
+    ? hostStoreKpi.error ?? userStoreKpi.error
+    : combinedRiskKpi.error;
+  const isModuleDisabled = entityStoreV2Enabled
+    ? hostStoreKpi.isModuleDisabled && userStoreKpi.isModuleDisabled
+    : combinedRiskKpi.isModuleDisabled;
+
+  const refetch = useCallback(() => {
+    if (entityStoreV2Enabled) {
+      hostStoreKpi.refetch();
+      userStoreKpi.refetch();
+    } else {
+      combinedRiskKpi.refetch();
+    }
+  }, [combinedRiskKpi, entityStoreV2Enabled, hostStoreKpi, userStoreKpi]);
+
+  const severityCount = entityStoreV2Enabled
+    ? mergeSeverityCounts(hostStoreKpi.severityCount, userStoreKpi.severityCount)
+    : combinedRiskKpi.severityCount ?? EMPTY_SEVERITY_COUNT;
 
   return {
-    severityCount: combinedRiskKpi.severityCount ?? EMPTY_SEVERITY_COUNT,
+    severityCount,
     loading,
     error,
     isModuleDisabled,

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/privileged_access_detection/pad_chart/hooks/pad_heatmap_interval_hooks.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/privileged_access_detection/pad_chart/hooks/pad_heatmap_interval_hooks.test.ts
@@ -25,7 +25,7 @@ describe('useIntervalForHeatmap', () => {
   });
 
   it('returns a minimum of three hours for our bucket ranges, no matter how short the query range', () => {
-    const now = moment.now().valueOf();
+    const now = moment().toISOString();
     mockUseGlobalTime.mockReturnValue({
       from: now,
       to: now,
@@ -35,8 +35,8 @@ describe('useIntervalForHeatmap', () => {
   });
 
   it('in the case of a 30 day interval, returns buckets that are 24 hours in length, as we want to compute 30 buckets', () => {
-    const now = moment.now().valueOf();
-    const thirtyDaysAgo = moment().subtract(30, 'days').valueOf();
+    const now = moment().toISOString();
+    const thirtyDaysAgo = moment().subtract(30, 'days').toISOString();
     mockUseGlobalTime.mockReturnValue({
       from: thirtyDaysAgo,
       to: now,
@@ -46,10 +46,10 @@ describe('useIntervalForHeatmap', () => {
   });
 
   it('in the case of a 90 day interval, returns buckets that are 24 hours in length, as we still want to compute 30 buckets', () => {
-    const now = moment.now().valueOf();
-    const thirtyDaysAgo = moment().subtract(90, 'days').valueOf();
+    const now = moment().toISOString();
+    const ninetyDaysAgo = moment().subtract(90, 'days').toISOString();
     mockUseGlobalTime.mockReturnValue({
-      from: thirtyDaysAgo,
+      from: ninetyDaysAgo,
       to: now,
     });
     const interval = useIntervalForHeatmap();

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/recent_anomalies/anomaly_heatmap_interval.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/recent_anomalies/anomaly_heatmap_interval.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import datemath from '@elastic/datemath';
 import { useGlobalTime } from '../../../common/containers/use_global_time';
 
 /**
@@ -13,10 +14,28 @@ import { useGlobalTime } from '../../../common/containers/use_global_time';
  * However, the lowest possible interval that will return is 3 (which equates to 3 hours), which means it is possible
  * for fewer buckets than 30.
  *
+ * An optional `timeRangeOverride` can be supplied on surfaces that hide the
+ * global date picker (e.g. the Entity Analytics home page) to compute the
+ * interval over a fixed range instead of the global picker's range. Values
+ * may be either absolute ISO strings or relative datemath expressions like
+ * `"now-30d"`.
+ *
  * @return a number representing the number of hours per interval.
  */
-export const useIntervalForHeatmap = () => {
-  const { from, to } = useGlobalTime();
+export const useIntervalForHeatmap = (timeRangeOverride?: { from: string; to: string }) => {
+  const { from: globalFrom, to: globalTo } = useGlobalTime();
+
+  const from = timeRangeOverride?.from ?? globalFrom;
+  const to = timeRangeOverride?.to ?? globalTo;
+
+  const resolveToMillis = (value: string): number => {
+    const parsed = datemath.parse(value)?.valueOf();
+    if (typeof parsed === 'number' && Number.isFinite(parsed)) {
+      return parsed;
+    }
+    const native = new Date(value).getTime();
+    return Number.isFinite(native) ? native : Date.now();
+  };
 
   const millisecondsToHours = (millis: number) => {
     return Number((millis / (1000 * 60 * 60)).toFixed(0));
@@ -24,7 +43,7 @@ export const useIntervalForHeatmap = () => {
 
   const maximumNumberOfBuckets = 30;
   const minimumNumberOfBucketInterval = 3;
-  const hoursInRange = millisecondsToHours(new Date(to).getTime() - new Date(from).getTime());
+  const hoursInRange = millisecondsToHours(resolveToMillis(to) - resolveToMillis(from));
   const bucketInterval = Number((hoursInRange / maximumNumberOfBuckets).toFixed(0));
   return bucketInterval < minimumNumberOfBucketInterval
     ? minimumNumberOfBucketInterval

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/recent_anomalies/anomaly_severity_filter.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/recent_anomalies/anomaly_severity_filter.tsx
@@ -29,40 +29,37 @@ export const AnomalySeverityFilter: React.FC<SeverityFilterProps> = ({
   const { euiTheme } = useEuiTheme();
 
   return (
-    <EuiFlexGroup>
-      <EuiPanel paddingSize="s" grow={false} hasBorder hasShadow={false}>
-        <EuiFlexGroup alignItems={'center'}>
-          <p css={{ fontWeight: euiTheme.font.weight.bold }}>{'Anomaly score'}</p>
-          {anomalyBands.map((band) => {
-            if (band.hidden) {
-              return (
-                <EuiFlexItem
-                  key={`${band.start}-${band.end}`}
-                  css={{ cursor: 'pointer' }}
-                  onClick={() => toggleHiddenBand(band)}
-                  grow={false}
-                >
-                  <EuiFlexGroup alignItems={'center'} gutterSize={'xs'}>
-                    <EuiIcon type={'eyeSlash'} aria-hidden={true} />
-                    <EuiText size={'s'} color={euiTheme.colors.textSubdued}>
-                      <p>{`${band.start}-${band.end}`}</p>
-                    </EuiText>
-                  </EuiFlexGroup>
-                </EuiFlexItem>
-              );
-            }
+    <EuiPanel paddingSize="s" grow={false} hasBorder hasShadow={false}>
+      <EuiFlexGroup alignItems={'center'} responsive={false} wrap>
+        <p css={{ fontWeight: euiTheme.font.weight.bold }}>{'Anomaly score'}</p>
+        {anomalyBands.map((band) => {
+          if (band.hidden) {
             return (
-              <EuiHealth
+              <EuiFlexItem
                 key={`${band.start}-${band.end}`}
                 css={{ cursor: 'pointer' }}
                 onClick={() => toggleHiddenBand(band)}
-                color={band.color}
-              >{`${band.start}-${band.end}`}</EuiHealth>
+                grow={false}
+              >
+                <EuiFlexGroup alignItems={'center'} gutterSize={'xs'} responsive={false}>
+                  <EuiIcon type={'eyeSlash'} aria-hidden={true} />
+                  <EuiText size={'s'} color={euiTheme.colors.textSubdued}>
+                    <p>{`${band.start}-${band.end}`}</p>
+                  </EuiText>
+                </EuiFlexGroup>
+              </EuiFlexItem>
             );
-          })}
-        </EuiFlexGroup>
-      </EuiPanel>
-      <EuiFlexItem />
-    </EuiFlexGroup>
+          }
+          return (
+            <EuiHealth
+              key={`${band.start}-${band.end}`}
+              css={{ cursor: 'pointer' }}
+              onClick={() => toggleHiddenBand(band)}
+              color={band.color}
+            >{`${band.start}-${band.end}`}</EuiHealth>
+          );
+        })}
+      </EuiFlexGroup>
+    </EuiPanel>
   );
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/recent_anomalies/hooks/recent_anomalies_esql_source_query_hooks.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/recent_anomalies/hooks/recent_anomalies_esql_source_query_hooks.ts
@@ -140,9 +140,10 @@ export const useRecentAnomaliesDataEsqlSource = ({
   viewBy,
   watchlistId,
   spaceId,
-}: EsqlSourceParams & { rowLabels?: string[] }) => {
+  timeRange,
+}: EsqlSourceParams & { rowLabels?: string[]; timeRange?: { from: string; to: string } }) => {
   const euidApi = useEntityStoreEuidApi();
-  const interval = useIntervalForHeatmap();
+  const interval = useIntervalForHeatmap(timeRange);
 
   if (!euidApi || !spaceId || !rowLabels) return undefined;
   const formattedLabels = rowLabels.map((each) => `"${each}"`).join(', ');

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/recent_anomalies/hooks/recent_anomalies_query_hooks.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/recent_anomalies/hooks/recent_anomalies_query_hooks.ts
@@ -10,7 +10,10 @@ import { getESQLResults, prettifyQuery } from '@kbn/esql-utils';
 import { i18n } from '@kbn/i18n';
 import { useMemo } from 'react';
 import { ML_ANOMALIES_INDEX } from '../../../../../common/constants';
-import { useEsqlGlobalFilterQuery } from '../../../../common/hooks/esql/use_esql_global_filter';
+import {
+  useEsqlFixedRangeFilterQuery,
+  useEsqlGlobalFilterQuery,
+} from '../../../../common/hooks/esql/use_esql_global_filter';
 import { esqlResponseToRecords } from '../../../../common/utils/esql';
 import { useKibana } from '../../../../common/lib/kibana';
 import { useErrorToast } from '../../../../common/hooks/use_error_toast';
@@ -27,14 +30,38 @@ export interface EntityMetadata {
   entityType: string;
 }
 
+interface FixedTimeRange {
+  from: string;
+  to: string;
+}
+
+/**
+ * Internal helper: pick between the global-date-picker filter and a fixed
+ * range filter. Both underlying hooks must be called unconditionally to obey
+ * the rules of hooks; only the selected value is returned.
+ */
+const useRecentAnomaliesFilterQuery = (timeRange?: FixedTimeRange) => {
+  const globalFilterQuery = useEsqlGlobalFilterQuery();
+  const fixedFilterQuery = useEsqlFixedRangeFilterQuery(
+    timeRange?.from ?? 'now-15m',
+    timeRange?.to ?? 'now'
+  );
+  return timeRange ? fixedFilterQuery : globalFilterQuery;
+};
+
 const useRecentAnomaliesTopRowsQuery = (params: {
   anomalyBands: AnomalyBand[];
   viewBy: ViewByMode;
   watchlistId?: string;
   spaceId?: string;
+  /**
+   * When provided, this time range is used for filtering instead of the
+   * global date picker's range. Used on surfaces that hide the picker.
+   */
+  timeRange?: FixedTimeRange;
 }) => {
   const search = useKibana().services.data.search.search;
-  const filterQuery = useEsqlGlobalFilterQuery();
+  const filterQuery = useRecentAnomaliesFilterQuery(params.timeRange);
   const rowField = params.viewBy === 'jobId' ? 'job_id' : 'entity_id';
 
   const topRowsEsqlSource = useRecentAnomaliesTopRowsEsqlSource({
@@ -85,9 +112,14 @@ export const useRecentAnomaliesQuery = (params: {
   viewBy: ViewByMode;
   watchlistId?: string;
   spaceId?: string;
+  /**
+   * When provided, this time range is used for filtering instead of the
+   * global date picker's range. Used on surfaces that hide the picker.
+   */
+  timeRange?: FixedTimeRange;
 }) => {
   const search = useKibana().services.data.search.search;
-  const filterQuery = useEsqlGlobalFilterQuery();
+  const filterQuery = useRecentAnomaliesFilterQuery(params.timeRange);
 
   const {
     rowLabels,
@@ -99,6 +131,7 @@ export const useRecentAnomaliesQuery = (params: {
   const anomalyDataEsqlSource = useRecentAnomaliesDataEsqlSource({
     ...params,
     rowLabels,
+    timeRange: params.timeRange,
   });
 
   const {

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/recent_anomalies/job_id_list.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/recent_anomalies/job_id_list.tsx
@@ -1,0 +1,84 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiFlexGroup, EuiFlexItem, EuiLink, EuiText } from '@elastic/eui';
+import { css } from '@emotion/react';
+import { i18n } from '@kbn/i18n';
+import { ML_PAGES, useMlManagementHref } from '@kbn/ml-plugin/public';
+import { useKibana } from '../../../common/lib/kibana';
+import { getAnomalyChartStyling } from './anomaly_chart_styling';
+
+interface JobIdListProps {
+  jobIds: string[];
+  compressed?: boolean;
+}
+
+const JobIdLink: React.FC<{ jobId: string }> = ({ jobId }) => {
+  const {
+    services: { ml },
+  } = useKibana();
+
+  const jobUrl = useMlManagementHref(ml, {
+    page: ML_PAGES.ANOMALY_DETECTION_JOBS_MANAGE,
+    pageState: {
+      jobId: [jobId],
+    },
+  });
+
+  if (!jobUrl) {
+    return <>{jobId}</>;
+  }
+
+  return (
+    <EuiLink
+      href={jobUrl}
+      target="_blank"
+      data-test-subj="recentAnomaliesJobIdLink"
+      aria-label={i18n.translate(
+        'xpack.securitySolution.entityAnalytics.recentAnomalies.jobIdLinkAriaLabel',
+        {
+          defaultMessage: 'Open anomaly detection job {jobId}',
+          values: { jobId },
+        }
+      )}
+    >
+      {jobId}
+    </EuiLink>
+  );
+};
+
+export const JobIdList: React.FC<JobIdListProps> = ({ jobIds, compressed = false }) => {
+  const styling = getAnomalyChartStyling(compressed);
+
+  return (
+    <EuiFlexItem
+      css={css`
+        margin-top: ${styling.heightOfTopLegend}px;
+        height: ${styling.heightOfEntityNamesList(jobIds.length)}px;
+      `}
+      grow={false}
+    >
+      <EuiFlexGroup gutterSize={'none'} direction={'column'} justifyContent={'center'}>
+        {jobIds.map((jobId) => (
+          <EuiFlexItem
+            key={jobId}
+            css={css`
+              justify-content: center;
+              height: ${styling.heightOfEachCell}px;
+            `}
+            grow={false}
+          >
+            <EuiText textAlign={'right'} size={'s'}>
+              <JobIdLink jobId={jobId} />
+            </EuiText>
+          </EuiFlexItem>
+        ))}
+      </EuiFlexGroup>
+    </EuiFlexItem>
+  );
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/recent_anomalies/recent_anomalies_chart.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/recent_anomalies/recent_anomalies_chart.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 import React, { useState } from 'react';
-import { EuiFlexGroup, EuiFlexItem, EuiSelect, EuiText } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiSelect } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { useGlobalTime } from '../../../common/containers/use_global_time';
 import { AnomalySeverityFilter } from './anomaly_severity_filter';
@@ -13,51 +13,26 @@ import { useRecentAnomaliesQuery } from './hooks/recent_anomalies_query_hooks';
 import type { ViewByMode } from './hooks/recent_anomalies_esql_source_query_hooks';
 import { useAnomalyBands } from './anomaly_bands';
 import { EntityNameList } from './entity_name_list';
+import { JobIdList } from './job_id_list';
 import { AnomalyHeatmap } from './anomaly_heatmap';
-import { getAnomalyChartStyling } from './anomaly_chart_styling';
 import { useQueryInspector } from '../../../common/components/page/manage_query';
 import { RecentAnomaliesHeatmapNoResults } from './recent_anomalies_heatmap_no_results';
 
 const RECENT_ANOMALIES_QUERY_ID = 'recent-anomalies-query';
 const RECENT_ANOMALIES_CONTEXT_ID = 'RecentAnomalies-table';
 
+/**
+ * The Entity Analytics home page hides the global date picker. The Recent
+ * Anomalies panel on that page is intentionally pinned to a fixed 30-day
+ * window so it always shows recent ML activity regardless of the hidden
+ * global time state.
+ */
+export const RECENT_ANOMALIES_TIME_RANGE = { from: 'now-30d', to: 'now' } as const;
+
 const VIEW_BY_OPTIONS = [
   { value: 'entity' as const, text: 'Entity' },
   { value: 'jobId' as const, text: 'Job ID' },
 ];
-
-const LabelList: React.FC<{ labels: string[]; compressed?: boolean }> = ({
-  labels,
-  compressed = false,
-}) => {
-  const styling = getAnomalyChartStyling(compressed);
-  return (
-    <EuiFlexItem
-      css={css`
-        margin-top: ${styling.heightOfTopLegend}px;
-        height: ${styling.heightOfEntityNamesList(labels.length)}px;
-      `}
-      grow={false}
-    >
-      <EuiFlexGroup gutterSize={'none'} direction={'column'} justifyContent={'center'}>
-        {labels.map((label) => (
-          <EuiFlexItem
-            key={label}
-            css={css`
-              justify-content: center;
-              height: ${styling.heightOfEachCell}px;
-            `}
-            grow={false}
-          >
-            <EuiText textAlign={'right'} size="s">
-              {label}
-            </EuiText>
-          </EuiFlexItem>
-        ))}
-      </EuiFlexGroup>
-    </EuiFlexItem>
-  );
-};
 
 interface RecentAnomaliesChartProps {
   watchlistId?: string;
@@ -78,6 +53,7 @@ export const RecentAnomaliesChart: React.FC<RecentAnomaliesChartProps> = ({
     viewBy,
     watchlistId,
     spaceId,
+    timeRange: RECENT_ANOMALIES_TIME_RANGE,
   });
 
   useQueryInspector({
@@ -94,7 +70,17 @@ export const RecentAnomaliesChart: React.FC<RecentAnomaliesChartProps> = ({
 
   return (
     <>
-      <EuiFlexGroup gutterSize="m" alignItems="center">
+      <EuiFlexGroup
+        gutterSize="m"
+        alignItems="center"
+        responsive={false}
+        wrap
+        css={css`
+          & > .euiFlexItem {
+            flex-shrink: 0;
+          }
+        `}
+      >
         <EuiFlexItem grow={false}>
           <EuiSelect
             prepend="View by"
@@ -105,7 +91,9 @@ export const RecentAnomaliesChart: React.FC<RecentAnomaliesChartProps> = ({
             compressed
           />
         </EuiFlexItem>
-        <AnomalySeverityFilter anomalyBands={bands} toggleHiddenBand={toggleHiddenBand} />
+        <EuiFlexItem grow={false}>
+          <AnomalySeverityFilter anomalyBands={bands} toggleHiddenBand={toggleHiddenBand} />
+        </EuiFlexItem>
       </EuiFlexGroup>
       <EuiFlexGroup>
         {viewBy === 'entity' && entityMetadata ? (
@@ -115,7 +103,7 @@ export const RecentAnomaliesChart: React.FC<RecentAnomaliesChartProps> = ({
             compressed
           />
         ) : (
-          <LabelList labels={rowLabels} compressed />
+          <JobIdList jobIds={rowLabels} compressed />
         )}
         <AnomalyHeatmap
           anomalyBands={bands}

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_score_donut_chart/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_score_donut_chart/index.test.tsx
@@ -11,6 +11,17 @@ import { render } from '@testing-library/react';
 import React from 'react';
 import { RiskScoreDonutChart } from '.';
 import { TestProviders } from '../../../common/mock';
+import { DonutChart } from '../../../common/components/charts/donutchart';
+
+jest.mock('../../../common/components/charts/donutchart', () => {
+  const actual = jest.requireActual('../../../common/components/charts/donutchart');
+  return {
+    ...actual,
+    DonutChart: jest.fn(() => <div data-test-subj="mock-donut-chart" />),
+  };
+});
+
+const mockDonutChart = DonutChart as unknown as jest.Mock;
 
 const severityCount: SeverityCount = {
   [RiskSeverity.Low]: 1,
@@ -21,6 +32,10 @@ const severityCount: SeverityCount = {
 };
 
 describe('RiskScoreDonutChart', () => {
+  beforeEach(() => {
+    mockDonutChart.mockClear();
+  });
+
   it('renders legends', () => {
     const { getByTestId } = render(
       <TestProviders>
@@ -33,5 +48,38 @@ describe('RiskScoreDonutChart', () => {
     expect(getByTestId('legend')).toHaveTextContent('Moderate');
     expect(getByTestId('legend')).toHaveTextContent('High');
     expect(getByTestId('legend')).toHaveTextContent('Critical');
+  });
+
+  it('does not pass an onPartitionClick handler to the donut when none is provided', () => {
+    render(
+      <TestProviders>
+        <RiskScoreDonutChart severityCount={severityCount} showLegend={false} />
+      </TestProviders>
+    );
+
+    expect(mockDonutChart).toHaveBeenCalled();
+    const props = mockDonutChart.mock.calls[0][0];
+    expect(props.onPartitionClick).toBeUndefined();
+  });
+
+  it('invokes the onPartitionClick callback with the clicked RiskSeverity', () => {
+    const onPartitionClick = jest.fn();
+
+    render(
+      <TestProviders>
+        <RiskScoreDonutChart
+          severityCount={severityCount}
+          showLegend={false}
+          onPartitionClick={onPartitionClick}
+        />
+      </TestProviders>
+    );
+
+    expect(mockDonutChart).toHaveBeenCalled();
+    const props = mockDonutChart.mock.calls[0][0];
+    expect(typeof props.onPartitionClick).toBe('function');
+
+    props.onPartitionClick(RiskSeverity.Critical);
+    expect(onPartitionClick).toHaveBeenCalledWith(RiskSeverity.Critical);
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_score_donut_chart/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_score_donut_chart/index.tsx
@@ -6,7 +6,7 @@
  */
 
 import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
-import React from 'react';
+import React, { useCallback } from 'react';
 import styled from '@emotion/styled';
 import { i18n } from '@kbn/i18n';
 import { ChartLabel } from '../../../overview/components/detection_response/alerts_by_status/chart_label';
@@ -15,8 +15,9 @@ import { DonutChart } from '../../../common/components/charts/donutchart';
 import { Legend } from '../../../common/components/charts/legend';
 import { useRiskScoreFillColor } from './use_risk_score_fill_color';
 import type { SeverityCount } from '../severity/types';
+import type { RiskSeverity } from '../../../../common/search_strategy';
 
-const DONUT_HEIGHT = 120;
+const DONUT_HEIGHT = 150;
 
 const DonutContainer = styled(EuiFlexItem)`
   padding-right: ${({ theme: { euiTheme } }) => euiTheme.size.m};
@@ -30,14 +31,27 @@ const StyledLegendItems = styled(EuiFlexItem)`
 interface RiskScoreDonutChartProps {
   severityCount: SeverityCount;
   showLegend?: boolean;
+  /**
+   * When provided, clicking a donut partition invokes this callback with the
+   * clicked risk level so the caller can add a corresponding global filter.
+   */
+  onPartitionClick?: (level: RiskSeverity) => void;
 }
 
 export const RiskScoreDonutChart = ({
   severityCount,
   showLegend = true,
+  onPartitionClick,
 }: RiskScoreDonutChartProps) => {
   const [donutChartData, legendItems, total] = useRiskDonutChartData(severityCount);
   const fillColor = useRiskScoreFillColor();
+
+  const handlePartitionClick = useCallback(
+    (level: string) => {
+      onPartitionClick?.(level as RiskSeverity);
+    },
+    [onPartitionClick]
+  );
 
   return (
     <EuiFlexGroup responsive={false} data-test-subj="risk-score-donut-chart">
@@ -57,6 +71,7 @@ export const RiskScoreDonutChart = ({
           )}
           title={<ChartLabel count={total} />}
           totalCount={total}
+          onPartitionClick={onPartitionClick ? handlePartitionClick : undefined}
         />
       </DonutContainer>
     </EuiFlexGroup>

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/severity/common/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/severity/common/index.tsx
@@ -12,12 +12,15 @@ import { css } from '@emotion/react';
 
 import { RISK_SEVERITY_COLOUR } from '../../../common/utils';
 import { HoverPopover } from '../../../../common/components/hover_popover';
-import type { RiskSeverity } from '../../../../../common/search_strategy';
+import {
+  RiskSeverity,
+  type RiskSeverity as RiskSeverityType,
+} from '../../../../../common/search_strategy';
 
 const RiskBadge = styled('div', {
   shouldForwardProp: (prop) => !['severity', 'hideBackgroundColor'].includes(prop),
 })<{
-  severity: RiskSeverity;
+  severity: RiskSeverityType;
   hideBackgroundColor: boolean;
 }>`
   ${({ theme: { euiTheme }, color, severity, hideBackgroundColor }) => css`
@@ -39,7 +42,7 @@ const TooltipContainer = styled.div`
 `;
 
 export const RiskScoreLevel: React.FC<{
-  severity: RiskSeverity;
+  severity: RiskSeverityType;
   hideBackgroundColor?: boolean;
   toolTipContent?: JSX.Element;
   ['data-test-subj']?: string;
@@ -69,11 +72,14 @@ export const RiskScoreLevel: React.FC<{
 RiskScoreLevel.displayName = 'RiskScoreLevel';
 
 const RiskScoreBadge: React.FC<{
-  severity: RiskSeverity;
+  severity: RiskSeverityType;
   hideBackgroundColor?: boolean;
   ['data-test-subj']?: string;
 }> = React.memo(({ severity, hideBackgroundColor = false, 'data-test-subj': dataTestSubj }) => {
   const { euiTheme } = useEuiTheme();
+  const healthColor =
+    RISK_SEVERITY_COLOUR[severity as keyof typeof RISK_SEVERITY_COLOUR] ??
+    RISK_SEVERITY_COLOUR[RiskSeverity.Unknown];
   return (
     <RiskBadge
       color={euiTheme.colors.backgroundBaseDanger}
@@ -84,7 +90,7 @@ const RiskScoreBadge: React.FC<{
       <EuiTextColor color="default">
         <EuiHealth
           className="eui-alignMiddle eui-textNoWrap"
-          color={RISK_SEVERITY_COLOUR[severity]}
+          color={healthColor}
           textSize="inherit"
         >
           {severity}

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/watchlists/components/hooks/use_risk_levels_esql_query.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/watchlists/components/hooks/use_risk_levels_esql_query.test.ts
@@ -10,10 +10,18 @@ import { useQuery } from '@kbn/react-query';
 import { useRiskLevelsEsqlQuery } from './use_risk_levels_esql_query';
 import { useKibana } from '../../../../../common/lib/kibana';
 import { useEsqlGlobalFilterQuery } from '../../../../../common/hooks/esql/use_esql_global_filter';
+import { useGlobalFilterQuery } from '../../../../../common/hooks/use_global_filter_query';
 import { useRiskEngineStatus } from '../../../../api/hooks/use_risk_engine_status';
 
 jest.mock('@kbn/esql-utils', () => ({
   prettifyQuery: jest.fn((query) => query),
+  getESQLResults: jest.fn(async () => ({
+    response: {
+      columns: [{ name: 'count' }, { name: 'level' }],
+      values: [],
+    },
+    params: {},
+  })),
 }));
 
 jest.mock('@kbn/react-query', () => ({
@@ -32,6 +40,10 @@ jest.mock('../../../../../common/hooks/esql/use_esql_global_filter', () => ({
   useEsqlGlobalFilterQuery: jest.fn(),
 }));
 
+jest.mock('../../../../../common/hooks/use_global_filter_query', () => ({
+  useGlobalFilterQuery: jest.fn(),
+}));
+
 jest.mock('../../../../api/hooks/use_risk_engine_status', () => ({
   useRiskEngineStatus: jest.fn(),
 }));
@@ -39,6 +51,7 @@ jest.mock('../../../../api/hooks/use_risk_engine_status', () => ({
 describe('useRiskLevelsEsqlQuery', () => {
   const mockUseKibana = useKibana as jest.Mock;
   const mockUseEsqlGlobalFilterQuery = useEsqlGlobalFilterQuery as jest.Mock;
+  const mockUseGlobalFilterQuery = useGlobalFilterQuery as jest.Mock;
   const mockUseRiskEngineStatus = useRiskEngineStatus as jest.Mock;
   const mockUseQuery = useQuery as jest.Mock;
 
@@ -58,7 +71,8 @@ describe('useRiskLevelsEsqlQuery', () => {
       },
     });
 
-    mockUseEsqlGlobalFilterQuery.mockReturnValue('mock-filter');
+    mockUseEsqlGlobalFilterQuery.mockReturnValue('mock-filter-with-time');
+    mockUseGlobalFilterQuery.mockReturnValue({ filterQuery: 'mock-filter-no-time' });
 
     mockUseRiskEngineStatus.mockReturnValue({
       data: { risk_engine_status: 'STARTED' },
@@ -138,5 +152,31 @@ describe('useRiskLevelsEsqlQuery', () => {
 
     const options = mockUseQuery.mock.calls[0][2];
     expect(options.enabled).toBe(false);
+  });
+
+  it('uses the ESQL global time filter by default', async () => {
+    renderHook(() => useRiskLevelsEsqlQuery({ spaceId: 'default' }));
+
+    const queryFn = mockUseQuery.mock.calls[0][1];
+    const getEsqlResults = jest.requireMock('@kbn/esql-utils').getESQLResults;
+
+    await queryFn({ signal: undefined });
+
+    expect(getEsqlResults).toHaveBeenCalledWith(
+      expect.objectContaining({ filter: 'mock-filter-with-time' })
+    );
+  });
+
+  it('skips the global time filter when applyGlobalTimeFilter is false', async () => {
+    renderHook(() => useRiskLevelsEsqlQuery({ spaceId: 'default', applyGlobalTimeFilter: false }));
+
+    const queryFn = mockUseQuery.mock.calls[0][1];
+    const getEsqlResults = jest.requireMock('@kbn/esql-utils').getESQLResults;
+
+    await queryFn({ signal: undefined });
+
+    expect(getEsqlResults).toHaveBeenCalledWith(
+      expect.objectContaining({ filter: 'mock-filter-no-time' })
+    );
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/watchlists/components/hooks/use_risk_levels_esql_query.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/watchlists/components/hooks/use_risk_levels_esql_query.ts
@@ -13,6 +13,7 @@ import type { ESQLSearchParams, ESQLSearchResponse } from '@kbn/es-types';
 import { useErrorToast } from '../../../../../common/hooks/use_error_toast';
 import { useKibana } from '../../../../../common/lib/kibana';
 import { useEsqlGlobalFilterQuery } from '../../../../../common/hooks/esql/use_esql_global_filter';
+import { useGlobalFilterQuery } from '../../../../../common/hooks/use_global_filter_query';
 import { esqlResponseToRecords } from '../../../../../common/utils/esql';
 import { useRiskEngineStatus } from '../../../../api/hooks/use_risk_engine_status';
 import { getWatchlistRiskLevelsQueryBodyV2 } from '../queries/watchlist_risk_level_query';
@@ -23,16 +24,26 @@ export const useRiskLevelsEsqlQuery = ({
   watchlistId,
   skip,
   spaceId,
+  applyGlobalTimeFilter = true,
 }: {
   watchlistId?: string;
   skip?: boolean;
   spaceId: string;
+  /**
+   * When true (default), the query is filtered by the global date picker's
+   * time range. Set to false on surfaces where the date picker is hidden or
+   * intentionally decoupled (e.g. the Entity Analytics home page), so the
+   * query returns risk levels across all time.
+   */
+  applyGlobalTimeFilter?: boolean;
 }) => {
   const { data } = useKibana().services;
 
   const index = getEntitiesAlias(ENTITY_LATEST, spaceId);
 
-  const filterQuery = useEsqlGlobalFilterQuery();
+  const esqlGlobalFilterQuery = useEsqlGlobalFilterQuery();
+  const { filterQuery: filterQueryNoTime } = useGlobalFilterQuery();
+  const filterQuery = applyGlobalTimeFilter ? esqlGlobalFilterQuery : filterQueryNoTime;
 
   const query = `FROM ${index} ${getWatchlistRiskLevelsQueryBodyV2(watchlistId || undefined)}`;
 

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/pages/entity_analytics_home_page.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/pages/entity_analytics_home_page.tsx
@@ -13,9 +13,9 @@ import {
   EuiLoadingSpinner,
   EuiPanel,
   EuiTitle,
-  useIsWithinBreakpoints,
   EuiButtonIcon,
 } from '@elastic/eui';
+import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { useLoadConnectors } from '@kbn/inference-connectors';
@@ -66,7 +66,16 @@ const getDefaultQuery = ({ query, filters }: EntitiesBaseURLQuery): URLQuery => 
   filters,
   pageFilters: [],
   sort: [['@timestamp', 'desc']],
+  pageIndex: 0,
 });
+
+const riskPanelFlexItemStyle = css`
+  min-width: 460px;
+`;
+
+const anomaliesPanelFlexItemStyle = css`
+  min-width: 500px;
+`;
 
 export const EntityAnalyticsHomePage = () => {
   const { telemetry, agentBuilder, http } = useKibana().services;
@@ -117,23 +126,28 @@ export const EntityAnalyticsHomePage = () => {
     [newDataViewPickerEnabled, oldIsSourcererLoading, entityDataViewLoading]
   );
 
-  const location = useLocation();
+  // Only subscribe to `search` rather than the whole `location` object so this
+  // component doesn't re-render (and re-create callbacks) on unrelated URL
+  // updates like flyout params.
+  const { search } = useLocation();
   const history = useHistory();
   const getSecuritySolutionUrl = useGetSecuritySolutionUrl();
 
   const selectedWatchlistId = useMemo(() => {
-    const params = new URLSearchParams(location.search);
+    const params = new URLSearchParams(search);
     return params.get('watchlistId') || undefined;
-  }, [location.search]);
+  }, [search]);
 
   const selectedWatchlistName = useMemo(() => {
-    const params = new URLSearchParams(location.search);
+    const params = new URLSearchParams(search);
     return params.get('watchlistName') || undefined;
-  }, [location.search]);
+  }, [search]);
 
   const setSelectedWatchlist = useCallback(
     (id?: string, name?: string) => {
-      const params = new URLSearchParams(location.search);
+      // Read the latest search from `history.location` to keep this callback's
+      // reference stable across unrelated URL updates.
+      const params = new URLSearchParams(history.location.search);
       if (id) {
         params.set('watchlistId', id);
       } else {
@@ -144,9 +158,9 @@ export const EntityAnalyticsHomePage = () => {
       } else {
         params.delete('watchlistName');
       }
-      history.replace({ ...location, search: params.toString() });
+      history.replace({ ...history.location, search: params.toString() });
     },
-    [location, history]
+    [history]
   );
 
   const indicesExist = useMemo(
@@ -154,7 +168,6 @@ export const EntityAnalyticsHomePage = () => {
     [entityDataViewLoading, newDataViewPickerEnabled, oldIndicesExist]
   );
 
-  const isXlScreen = useIsWithinBreakpoints(['l', 'xl']);
   const showEmptyPrompt = !indicesExist;
 
   const { data: entityStoreStatusData } = useEntityStoreStatus();
@@ -196,6 +209,7 @@ export const EntityAnalyticsHomePage = () => {
           dataView={entityDataView}
           id={InputsModelId.global}
           sourcererDataViewSpec={oldSourcererDataViewSpec}
+          hideDatePicker
         />
       </FiltersGlobal>
 
@@ -262,20 +276,17 @@ export const EntityAnalyticsHomePage = () => {
             )}
 
             <EuiFlexItem>
-              <EuiFlexGroup
-                direction={isXlScreen ? 'row' : 'column'}
-                responsive={false}
-                gutterSize="l"
-              >
-                <EuiFlexItem grow={1}>
+              <EuiFlexGroup wrap gutterSize="m">
+                <EuiFlexItem grow={3} css={riskPanelFlexItemStyle}>
                   <EuiPanel hasBorder>
                     <DynamicRiskLevelPanel
                       watchlistId={selectedWatchlistId}
                       watchlistName={selectedWatchlistName}
+                      entityDataView={entityDataView}
                     />
                   </EuiPanel>
                 </EuiFlexItem>
-                <EuiFlexItem grow={2}>
+                <EuiFlexItem grow={5} css={anomaliesPanelFlexItemStyle}>
                   <EuiPanel hasBorder>
                     <EntityAnalyticsRecentAnomalies watchlistId={selectedWatchlistId} />
                   </EuiPanel>

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/left/tabs/insights_tab.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/left/tabs/insights_tab.tsx
@@ -10,7 +10,8 @@ import { EuiButtonGroup, EuiSpacer } from '@elastic/eui';
 import type { EuiButtonGroupOptionProps } from '@elastic/eui/src/components/button/button_group/button_group';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
-import { useExpandableFlyoutApi, useExpandableFlyoutState } from '@kbn/expandable-flyout';
+import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
+import { useStableExpandableFlyoutState } from '../../../shared/hooks/use_stable_expandable_flyout_state';
 import { useAttackDetailsContext } from '../../context';
 import { AttackDetailsLeftPanelKey } from '../../constants/panel_keys';
 import {
@@ -51,7 +52,7 @@ const insightsSubTabButtons: EuiButtonGroupOptionProps[] = [
 export const InsightsTab = memo(() => {
   const { attackId, indexName } = useAttackDetailsContext();
   const { openLeftPanel } = useExpandableFlyoutApi();
-  const panels = useExpandableFlyoutState();
+  const panels = useStableExpandableFlyoutState();
   const activeSubTabId = panels.left?.path?.subTab ?? ENTITIES_TAB_ID;
 
   const onChangeSubTab = useCallback(

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/tabs/insights_tab.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/tabs/insights_tab.tsx
@@ -10,8 +10,9 @@ import { EuiButtonGroup, EuiSpacer } from '@elastic/eui';
 import type { EuiButtonGroupOptionProps } from '@elastic/eui/src/components/button/button_group/button_group';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { useExpandableFlyoutApi, useExpandableFlyoutState } from '@kbn/expandable-flyout';
+import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { buildDataTableRecord, type EsHitRecord } from '@kbn/discover-utils';
+import { useStableExpandableFlyoutState } from '../../../shared/hooks/use_stable_expandable_flyout_state';
 import { useKibana } from '../../../../common/lib/kibana';
 import {
   INSIGHTS_TAB_BUTTON_GROUP_TEST_ID,
@@ -86,7 +87,7 @@ export const InsightsTab = memo(() => {
   const hit = useMemo(() => buildDataTableRecord(searchHit as EsHitRecord), [searchHit]);
   const isEventKindSignal = getField(getFieldsData('event.kind')) === EventKind.signal;
   const { openLeftPanel } = useExpandableFlyoutApi();
-  const panels = useExpandableFlyoutState();
+  const panels = useStableExpandableFlyoutState();
   const activeInsightsId = panels.left?.path?.subTab ?? ENTITIES_TAB_ID;
 
   // insight tabs based on whether document is alert or non-alert

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/tabs/visualize_tab.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/tabs/visualize_tab.tsx
@@ -8,13 +8,13 @@
 import React, { memo, useState, useCallback, useEffect } from 'react';
 import { EuiButtonGroup, EuiSpacer } from '@elastic/eui';
 import type { EuiButtonGroupOptionProps } from '@elastic/eui/src/components/button/button_group/button_group';
-import { useExpandableFlyoutState } from '@kbn/expandable-flyout';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import {
   uiMetricService,
   GRAPH_INVESTIGATION,
 } from '@kbn/cloud-security-posture-common/utils/ui_metrics';
+import { useStableExpandableFlyoutState } from '../../../shared/hooks/use_stable_expandable_flyout_state';
 import { useDocumentDetailsContext } from '../../shared/context';
 import {
   VISUALIZE_TAB_BUTTON_GROUP_TEST_ID,
@@ -88,7 +88,7 @@ const graphVisualizationButton: EuiButtonGroupOptionProps = {
 export const VisualizeTab = memo(() => {
   const { getFieldsData, dataAsNestedObject, dataFormattedForFieldBrowser } =
     useDocumentDetailsContext();
-  const panels = useExpandableFlyoutState();
+  const panels = useStableExpandableFlyoutState();
   const [activeVisualizationId, setActiveVisualizationId] = useState(
     panels.left?.path?.subTab ?? SESSION_VIEW_ID
   );

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/generic_right/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/generic_right/index.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useCallback, useEffect, useMemo } from 'react';
+import React, { memo, useCallback, useEffect, useMemo } from 'react';
 import type { FlyoutPanelProps } from '@kbn/expandable-flyout';
 import { METRIC_TYPE } from '@kbn/analytics';
 import {
@@ -69,7 +69,9 @@ export interface GenericEntityPanelExpandableFlyoutProps extends FlyoutPanelProp
   params: GenericEntityPanelProps;
 }
 
-export const GenericEntityPanel = (params: GenericEntityPanelProps) => {
+export const GenericEntityPanel = memo(function GenericEntityPanel(
+  params: GenericEntityPanelProps
+) {
   const { isPreviewMode, scopeId, isEngineMetadataExist } = params;
 
   // When you destructuring params in the function signature TypeScript loses track
@@ -229,6 +231,6 @@ export const GenericEntityPanel = (params: GenericEntityPanelProps) => {
       />
     </>
   );
-};
+});
 
 GenericEntityPanel.displayName = 'GenericEntityPanel';

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/index.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useCallback, useMemo } from 'react';
+import React, { memo, useCallback, useMemo } from 'react';
 import type { FlyoutPanelProps } from '@kbn/expandable-flyout';
 import { useHasMisconfigurations } from '@kbn/cloud-security-posture/src/hooks/use_has_misconfigurations';
 import { useHasVulnerabilities } from '@kbn/cloud-security-posture/src/hooks/use_has_vulnerabilities';
@@ -80,13 +80,13 @@ const FIRST_RECORD_PAGINATION = {
   querySize: 1,
 };
 
-export const HostPanel = ({
+export const HostPanel = memo(function HostPanel({
   contextID,
   scopeId,
   isPreviewMode = false,
   hostName,
   entityId,
-}: HostPanelProps) => {
+}: HostPanelProps) {
   const { uiSettings } = useKibana().services;
   const euidApi = useEntityStoreEuidApi();
   const assetInventoryEnabled = uiSettings.get(ENABLE_ASSET_INVENTORY_SETTING, true);
@@ -346,6 +346,6 @@ export const HostPanel = ({
       )}
     </>
   );
-};
+});
 
 HostPanel.displayName = 'HostPanel';

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/service_right/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/service_right/index.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useCallback, useMemo } from 'react';
+import React, { memo, useCallback, useMemo } from 'react';
 import type { FlyoutPanelProps } from '@kbn/expandable-flyout';
 import { TableId } from '@kbn/securitysolution-data-table';
 import { noop } from 'lodash/fp';
@@ -59,13 +59,13 @@ const FIRST_RECORD_PAGINATION = {
   querySize: 1,
 };
 
-export const ServicePanel = ({
+export const ServicePanel = memo(function ServicePanel({
   contextID,
   scopeId,
   entityId,
   serviceName,
   isPreviewMode = false,
-}: ServicePanelProps) => {
+}: ServicePanelProps) {
   const safeContextID = contextID ?? scopeId ?? 'service-panel';
   const entityStoreV2Enabled = useUiSetting<boolean>(FF_ENABLE_ENTITY_STORE_V2);
   const serviceStoreIdentityFields = useMemo(
@@ -232,6 +232,6 @@ export const ServicePanel = ({
       </FlyoutBody>
     </>
   );
-};
+});
 
 ServicePanel.displayName = 'ServicePanel';

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/shared/components/entity_source_value.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/shared/components/entity_source_value.test.tsx
@@ -1,0 +1,173 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { TestProviders } from '../../../../common/mock';
+import {
+  EntitySourceValue,
+  TruncatedBadgeList,
+  formatEntitySource,
+  toEntitySourceArray,
+} from './entity_source_value';
+
+describe('formatEntitySource', () => {
+  it('replaces underscores with spaces and capitalizes each word', () => {
+    expect(formatEntitySource('entityanalytics_okta')).toBe('Entityanalytics Okta');
+    expect(formatEntitySource('entityanalytics_entra_id')).toBe('Entityanalytics Entra Id');
+  });
+
+  it('capitalizes a single-word token', () => {
+    expect(formatEntitySource('okta')).toBe('Okta');
+    expect(formatEntitySource('azure')).toBe('Azure');
+  });
+
+  it('leaves an empty string unchanged', () => {
+    expect(formatEntitySource('')).toBe('');
+  });
+});
+
+describe('toEntitySourceArray', () => {
+  it('returns an empty array for null or undefined', () => {
+    expect(toEntitySourceArray(undefined)).toEqual([]);
+    expect(toEntitySourceArray(null)).toEqual([]);
+  });
+
+  it('wraps a string value in an array', () => {
+    expect(toEntitySourceArray('okta')).toEqual(['okta']);
+  });
+
+  it('returns an array of strings unchanged', () => {
+    expect(toEntitySourceArray(['okta', 'entra_id'])).toEqual(['okta', 'entra_id']);
+  });
+
+  it('filters out non-string entries from an array', () => {
+    expect(toEntitySourceArray(['okta', 2, null, undefined, 'entra_id'])).toEqual([
+      'okta',
+      'entra_id',
+    ]);
+  });
+
+  it('returns an empty array for unsupported types', () => {
+    expect(toEntitySourceArray(42)).toEqual([]);
+    expect(toEntitySourceArray(true)).toEqual([]);
+    expect(toEntitySourceArray({})).toEqual([]);
+  });
+});
+
+describe('EntitySourceValue', () => {
+  it('renders the empty placeholder when values is empty', () => {
+    const { container } = render(
+      <TestProviders>
+        <EntitySourceValue values={[]} />
+      </TestProviders>
+    );
+
+    expect(container.textContent).toContain('—');
+  });
+
+  it('renders a single formatted value as plain text without an overflow affordance', () => {
+    render(
+      <TestProviders>
+        <EntitySourceValue values={['entityanalytics_okta']} />
+      </TestProviders>
+    );
+
+    expect(screen.getByText('Entityanalytics Okta')).toBeInTheDocument();
+    expect(screen.queryByText('entityanalytics_okta')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('entitySourceValue-more')).not.toBeInTheDocument();
+  });
+
+  it('renders only the first formatted value inline and collapses the rest into a +N overflow badge', () => {
+    render(
+      <TestProviders>
+        <EntitySourceValue values={['okta', 'entra_id', 'active_directory']} />
+      </TestProviders>
+    );
+
+    expect(screen.getByText('Okta')).toBeInTheDocument();
+    expect(screen.getByTestId('entitySourceValue-more')).toHaveTextContent('+2');
+    expect(screen.getByTestId('entitySourceValue-more')).not.toHaveTextContent('more');
+  });
+
+  it('exposes the remaining formatted values via the overflow tooltip', async () => {
+    render(
+      <TestProviders>
+        <EntitySourceValue values={['okta', 'entra_id', 'active_directory']} />
+      </TestProviders>
+    );
+
+    fireEvent.mouseOver(screen.getByTestId('entitySourceValue-more'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Entra Id, Active Directory')).toBeInTheDocument();
+    });
+  });
+});
+
+describe('TruncatedBadgeList', () => {
+  it('renders the empty placeholder when values is empty', () => {
+    const { container } = render(
+      <TestProviders>
+        <TruncatedBadgeList values={[]} data-test-subj="custom" />
+      </TestProviders>
+    );
+
+    expect(container.textContent).toContain('—');
+  });
+
+  it('renders the first value as plain text and a +N overflow badge', () => {
+    render(
+      <TestProviders>
+        <TruncatedBadgeList values={['a', 'b', 'c']} data-test-subj="custom" />
+      </TestProviders>
+    );
+
+    expect(screen.getByText('a')).toBeInTheDocument();
+    expect(screen.getByTestId('custom-more')).toHaveTextContent('+2');
+  });
+
+  it('honors a custom maxVisible to render more inline values before collapsing', () => {
+    render(
+      <TestProviders>
+        <TruncatedBadgeList values={['a', 'b', 'c']} maxVisible={2} data-test-subj="custom" />
+      </TestProviders>
+    );
+
+    expect(screen.getByText('a')).toBeInTheDocument();
+    expect(screen.getByText('b')).toBeInTheDocument();
+    expect(screen.getByTestId('custom-more')).toHaveTextContent('+1');
+  });
+
+  it('applies formatValue to both the inline value and the overflow tooltip list', async () => {
+    render(
+      <TestProviders>
+        <TruncatedBadgeList
+          values={['okta', 'entra_id']}
+          formatValue={formatEntitySource}
+          data-test-subj="custom"
+        />
+      </TestProviders>
+    );
+
+    expect(screen.getByText('Okta')).toBeInTheDocument();
+    fireEvent.mouseOver(screen.getByTestId('custom-more'));
+    await waitFor(() => {
+      expect(screen.getByText('Entra Id')).toBeInTheDocument();
+    });
+  });
+
+  it('exposes the hidden count on the overflow badge via aria-label for screen readers', () => {
+    render(
+      <TestProviders>
+        <TruncatedBadgeList values={['a', 'b', 'c']} data-test-subj="custom" />
+      </TestProviders>
+    );
+
+    expect(screen.getByTestId('custom-more')).toHaveAttribute('aria-label', '2 more');
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/shared/components/entity_source_value.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/shared/components/entity_source_value.tsx
@@ -1,0 +1,175 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { memo, useMemo } from 'react';
+import { EuiBadge, EuiFlexGroup, EuiFlexItem, EuiText, EuiToolTip } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { startCase } from 'lodash';
+import { getEmptyTagValue } from '../../../../common/components/empty_value';
+
+/**
+ * Normalizes a field value that can arrive from the Entity Store API as a
+ * single string, an array of strings, `null`, or `undefined` into a clean
+ * `string[]`. Non-string array entries are filtered out.
+ *
+ * The Zod client type for `entity.source` is `string`, but the underlying ES
+ * mapping is a `keyword`, so the API can return an array at runtime.
+ */
+export const toEntitySourceArray = (value: unknown): string[] => {
+  if (value == null) return [];
+  if (Array.isArray(value)) {
+    return value.filter((v): v is string => typeof v === 'string');
+  }
+  if (typeof value === 'string') return [value];
+  return [];
+};
+
+/**
+ * Formats a raw `entity.source` token for display. Replaces word separators
+ * (underscores, hyphens, camelCase boundaries) with spaces and capitalizes the
+ * first letter of each word, e.g. `entityanalytics_okta` -> `Entityanalytics
+ * Okta`.
+ */
+export const formatEntitySource = (value: string): string => startCase(value);
+
+const DEFAULT_OVERFLOW_LABEL = (count: number): string => `+${count}`;
+
+const DEFAULT_OVERFLOW_ARIA_LABEL = (count: number): string =>
+  i18n.translate(
+    'xpack.securitySolution.flyout.entityDetails.shared.truncatedBadgeList.overflowAria',
+    {
+      defaultMessage: '{count} more',
+      values: { count },
+    }
+  );
+
+interface TruncatedBadgeListProps {
+  /**
+   * Raw (already resolved) values to render. Empty arrays render the shared
+   * em-dash placeholder so the grid cell never collapses to zero height.
+   */
+  values: string[];
+  /**
+   * How many values to render inline as plain text before collapsing the
+   * remainder into a single `+N` overflow badge. Defaults to `1`, matching
+   * the Entity Analytics flyout's summary grid where only the first value is
+   * visible and every extra value is surfaced via the tooltip.
+   */
+  maxVisible?: number;
+  /**
+   * Optional pre-render formatter applied to each value. Use this to keep raw
+   * tokens (e.g. `entityanalytics_okta`) in the data and only humanize them
+   * at render time. The formatted value is also what the overflow tooltip
+   * lists.
+   */
+  formatValue?: (value: string) => string;
+  /**
+   * Optional title shown above the overflow tooltip content (e.g.
+   * `"Additional data sources"`). The content itself is always the
+   * comma-joined list of hidden values.
+   */
+  overflowTooltipTitle?: string;
+  'data-test-subj'?: string;
+}
+
+/**
+ * Renders a list of string values with the first `maxVisible` shown inline as
+ * plain text and any overflow collapsed into a single hollow `+N` badge whose
+ * tooltip lists the remaining values. The visible value(s) stay as plain text
+ * so the cell reads like a normal field, and the badge signals "there are
+ * more values here" without competing for visual weight with the value
+ * itself.
+ *
+ * Used anywhere we show an `entity.source`-style multi-valued field in a
+ * compact cell (flyout summary grid, entities data grid, agent builder
+ * entity attachment tables) so every surface shares the exact same visual.
+ */
+export const TruncatedBadgeList = memo(
+  ({
+    values,
+    maxVisible = 1,
+    formatValue,
+    overflowTooltipTitle,
+    'data-test-subj': dataTestSubj,
+  }: TruncatedBadgeListProps) => {
+    const formattedValues = useMemo(
+      () => (formatValue ? values.map(formatValue) : values),
+      [values, formatValue]
+    );
+
+    if (formattedValues.length === 0) {
+      return <EuiText size="s">{getEmptyTagValue()}</EuiText>;
+    }
+
+    const safeMaxVisible = Math.max(1, maxVisible);
+    const visible = formattedValues.slice(0, safeMaxVisible);
+    const hidden = formattedValues.slice(safeMaxVisible);
+
+    const overflowTestSubj = dataTestSubj ? `${dataTestSubj}-more` : undefined;
+
+    return (
+      <EuiFlexGroup
+        gutterSize="xs"
+        alignItems="center"
+        responsive={false}
+        wrap
+        data-test-subj={dataTestSubj}
+      >
+        {visible.map((value) => (
+          <EuiFlexItem grow={false} key={value}>
+            <EuiText size="s">{value}</EuiText>
+          </EuiFlexItem>
+        ))}
+        {hidden.length > 0 && (
+          <EuiFlexItem grow={false}>
+            <EuiToolTip position="top" title={overflowTooltipTitle} content={hidden.join(', ')}>
+              <EuiBadge
+                color="hollow"
+                data-test-subj={overflowTestSubj}
+                aria-label={DEFAULT_OVERFLOW_ARIA_LABEL(hidden.length)}
+              >
+                {DEFAULT_OVERFLOW_LABEL(hidden.length)}
+              </EuiBadge>
+            </EuiToolTip>
+          </EuiFlexItem>
+        )}
+      </EuiFlexGroup>
+    );
+  }
+);
+TruncatedBadgeList.displayName = 'TruncatedBadgeList';
+
+interface EntitySourceValueProps {
+  values: string[];
+  'data-test-subj'?: string;
+}
+
+const DATA_SOURCE_OVERFLOW_TOOLTIP_TITLE = i18n.translate(
+  'xpack.securitySolution.flyout.entityDetails.grid.dataSourceOverflowTitle',
+  { defaultMessage: 'Additional data sources' }
+);
+
+/**
+ * Renders `entity.source` values using the shared badge list UX. Raw tokens
+ * are run through `formatEntitySource` so the inline badge and tooltip list
+ * are both human-readable (e.g. `entityanalytics_okta` -> `Entityanalytics
+ * Okta`).
+ *
+ * Accepts a normalized `string[]` (use `toEntitySourceArray` to normalize the
+ * raw field value).
+ */
+export const EntitySourceValue = memo(
+  ({ values, 'data-test-subj': dataTestSubj = 'entitySourceValue' }: EntitySourceValueProps) => (
+    <TruncatedBadgeList
+      values={values}
+      formatValue={formatEntitySource}
+      overflowTooltipTitle={DATA_SOURCE_OVERFLOW_TOOLTIP_TITLE}
+      data-test-subj={dataTestSubj}
+    />
+  )
+);
+EntitySourceValue.displayName = 'EntitySourceValue';

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/shared/components/entity_summary_grid.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/shared/components/entity_summary_grid.test.tsx
@@ -39,6 +39,14 @@ const entityWithWatchlists = {
   },
 } as unknown as Entity;
 
+const entityWithMultipleSources = {
+  ...mockEntityRecord,
+  entity: {
+    ...mockEntityRecord.entity,
+    source: ['okta', 'entityanalytics_okta'],
+  },
+} as unknown as Entity;
+
 describe('EntitySummaryGrid', () => {
   it('renders four panels', () => {
     const { getByText } = render(
@@ -63,14 +71,28 @@ describe('EntitySummaryGrid', () => {
     expect(getByText('test-entity-id-host-abc123')).toBeInTheDocument();
   });
 
-  it('displays data source', () => {
-    const { getByText } = render(
+  it('displays data source formatted (capitalized, separators replaced with spaces)', () => {
+    const { getByText, queryByText } = render(
       <TestProviders>
         <EntitySummaryGrid entityRecord={entityWithSource} />
       </TestProviders>
     );
 
-    expect(getByText('logs-endpoint')).toBeInTheDocument();
+    expect(getByText('Logs Endpoint')).toBeInTheDocument();
+    expect(queryByText('logs-endpoint')).not.toBeInTheDocument();
+  });
+
+  it('displays first data source inline and a "+N" overflow badge when entity.source is an array', () => {
+    const { getByText, queryByText, getByTestId } = render(
+      <TestProviders>
+        <EntitySummaryGrid entityRecord={entityWithMultipleSources} />
+      </TestProviders>
+    );
+
+    expect(getByText('Okta')).toBeInTheDocument();
+    expect(queryByText('okta')).not.toBeInTheDocument();
+    expect(queryByText('entityanalytics_okta')).not.toBeInTheDocument();
+    expect(getByTestId('entitySourceValue-more')).toHaveTextContent('+1');
   });
 
   it('renders asset criticality badge', () => {
@@ -133,13 +155,13 @@ describe('EntitySummaryGrid', () => {
     expect(getByText('First Watchlist')).toBeInTheDocument();
   });
 
-  it('displays +N More for additional watchlists', () => {
-    const { getByText } = render(
+  it('displays a +N overflow badge for additional watchlists', () => {
+    const { getByTestId } = render(
       <TestProviders>
         <EntitySummaryGrid entityRecord={entityWithWatchlists} />
       </TestProviders>
     );
 
-    expect(getByText(/\+1.*More/)).toBeInTheDocument();
+    expect(getByTestId('entityWatchlistsCell-more')).toHaveTextContent('+1');
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/shared/components/entity_summary_grid.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/shared/components/entity_summary_grid.tsx
@@ -7,7 +7,6 @@
 
 import React, { memo, useMemo, useState } from 'react';
 import {
-  EuiButtonEmpty,
   EuiButtonIcon,
   EuiCopy,
   EuiFlexGrid,
@@ -19,7 +18,6 @@ import {
   EuiText,
   EuiToolTip,
 } from '@elastic/eui';
-import { FormattedMessage } from '@kbn/i18n-react';
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
 import type { Entity } from '../../../../../common/api/entity_analytics';
@@ -29,6 +27,12 @@ import type { CriticalityLevelWithUnassigned } from '../../../../../common/entit
 import { useGetWatchlists } from '../../../../entity_analytics/api/hooks/use_get_watchlists';
 import { getWatchlistName } from '../../../../../common/entity_analytics/watchlists/constants';
 import { getEmptyTagValue } from '../../../../common/components/empty_value';
+import { EntitySourceValue, TruncatedBadgeList, toEntitySourceArray } from './entity_source_value';
+
+const WATCHLISTS_OVERFLOW_TOOLTIP_TITLE = i18n.translate(
+  'xpack.securitySolution.flyout.entityDetails.grid.watchlistsOverflowTitle',
+  { defaultMessage: 'Additional watchlists' }
+);
 
 interface EntitySummaryGridProps {
   entityRecord: Entity;
@@ -100,7 +104,7 @@ export const EntitySummaryGrid = memo(
               { defaultMessage: 'Data source' }
             )}
           >
-            <EuiText size="s">{entityRecord.entity?.source ?? getEmptyTagValue()}</EuiText>
+            <EntitySourceValue values={toEntitySourceArray(entityRecord.entity?.source)} />
           </SummaryPanel>
           <SummaryPanel
             label={i18n.translate(
@@ -202,7 +206,7 @@ const WatchlistsCell = memo(({ watchlistIds }: { watchlistIds: string[] }) => {
     return map;
   }, [watchlistsData]);
 
-  const resolvedNames = useMemo(() => {
+  const resolvedNames = useMemo<string[]>(() => {
     if (watchlistIds.length === 0) return [];
     return watchlistIds
       .map((id) => {
@@ -210,35 +214,15 @@ const WatchlistsCell = memo(({ watchlistIds }: { watchlistIds: string[] }) => {
         // If all we have is the ID, the watchlist has likely been deleted
         return watchlistName !== id ? watchlistName : undefined;
       })
-      .filter((name) => name !== undefined);
+      .filter((name): name is string => name !== undefined);
   }, [watchlistIds, watchlistNamesById]);
 
-  if (resolvedNames.length === 0) {
-    return <EuiText size="s">{getEmptyTagValue()}</EuiText>;
-  }
-
-  const firstName = resolvedNames[0];
-  const moreCount = resolvedNames.length - 1;
-
   return (
-    <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false} wrap>
-      <EuiFlexItem grow={false}>
-        <EuiText size="s">{firstName}</EuiText>
-      </EuiFlexItem>
-      {moreCount > 0 && (
-        <EuiFlexItem grow={false}>
-          <EuiToolTip content={resolvedNames.slice(1).join(', ')}>
-            <EuiButtonEmpty size="xs" flush="left">
-              {`+${moreCount} `}
-              <FormattedMessage
-                id="xpack.securitySolution.flyout.entityDetails.grid.watchlistsMore"
-                defaultMessage="More"
-              />
-            </EuiButtonEmpty>
-          </EuiToolTip>
-        </EuiFlexItem>
-      )}
-    </EuiFlexGroup>
+    <TruncatedBadgeList
+      values={resolvedNames}
+      overflowTooltipTitle={WATCHLISTS_OVERFLOW_TOOLTIP_TITLE}
+      data-test-subj="entityWatchlistsCell"
+    />
   );
 });
 WatchlistsCell.displayName = 'WatchlistsCell';

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/index.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useCallback, useMemo } from 'react';
+import React, { memo, useCallback, useMemo } from 'react';
 import type { FlyoutPanelProps } from '@kbn/expandable-flyout';
 import { useHasMisconfigurations } from '@kbn/cloud-security-posture/src/hooks/use_has_misconfigurations';
 import { TableId } from '@kbn/securitysolution-data-table';
@@ -81,13 +81,13 @@ const FIRST_RECORD_PAGINATION = {
   querySize: 1,
 };
 
-export const UserPanel = ({
+export const UserPanel = memo(function UserPanel({
   contextID,
   scopeId,
   isPreviewMode = false,
   userName,
   entityId: entityIdProp,
-}: UserPanelProps) => {
+}: UserPanelProps) {
   const { uiSettings } = useKibana().services;
   const euidApi = useEntityStoreEuidApi();
   const assetInventoryEnabled = uiSettings.get(ENABLE_ASSET_INVENTORY_SETTING, true);
@@ -348,6 +348,6 @@ export const UserPanel = ({
       )}
     </>
   );
-};
+});
 
 UserPanel.displayName = 'UserPanel';

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/watchlists_right/hooks/use_watchlist_form_state_shared.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/watchlists_right/hooks/use_watchlist_form_state_shared.ts
@@ -6,8 +6,8 @@
  */
 
 import { useEffect, useRef } from 'react';
-import { useExpandableFlyoutState } from '@kbn/expandable-flyout';
 import type { CreateWatchlistRequestBodyInput } from '../../../../../common/api/entity_analytics/watchlists/management/create.gen';
+import { useStableExpandableFlyoutState } from '../../../shared/hooks/use_stable_expandable_flyout_state';
 import { WatchlistsFlyoutKey } from '../../shared/constants';
 import { MAX_WATCHLIST_DESCRIPTION_LENGTH, MAX_WATCHLIST_NAME_LENGTH } from '../constants';
 
@@ -43,7 +43,7 @@ export const getWatchlistFieldLengthValidation = (watchlist: CreateWatchlistRequ
 });
 
 export const useResetEditsOnFlyoutOpen = (setHasUserEdits: (value: boolean) => void) => {
-  const { right } = useExpandableFlyoutState();
+  const { right } = useStableExpandableFlyoutState();
   const wasOpenRef = useRef(false);
 
   useEffect(() => {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/shared/components/flyout_navigation.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/shared/components/flyout_navigation.tsx
@@ -15,15 +15,12 @@ import {
   useEuiTheme,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
-import {
-  useExpandableFlyoutApi,
-  useExpandableFlyoutHistory,
-  useExpandableFlyoutState,
-} from '@kbn/expandable-flyout';
+import { useExpandableFlyoutApi, useExpandableFlyoutHistory } from '@kbn/expandable-flyout';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
 import { FlyoutHistory } from './flyout_history';
 import { getProcessedHistory } from '../utils/history_utils';
+import { useStableExpandableFlyoutState } from '../hooks/use_stable_expandable_flyout_state';
 import {
   COLLAPSE_DETAILS_BUTTON_TEST_ID,
   EXPAND_DETAILS_BUTTON_TEST_ID,
@@ -64,7 +61,7 @@ export const FlyoutNavigation: FC<FlyoutNavigationProps> = memo(
     const history = useExpandableFlyoutHistory();
     const historyArray = useMemo(() => getProcessedHistory({ history, maxCount: 10 }), [history]);
 
-    const panels = useExpandableFlyoutState();
+    const panels = useStableExpandableFlyoutState();
     const isExpanded: boolean = !!panels.left;
 
     const { closeLeftPanel } = useExpandableFlyoutApi();

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/shared/hooks/use_stable_expandable_flyout_state.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/shared/hooks/use_stable_expandable_flyout_state.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useRef } from 'react';
+import deepEqual from 'fast-deep-equal';
+import { useExpandableFlyoutState } from '@kbn/expandable-flyout';
+
+/**
+ * Wrapper around `@kbn/expandable-flyout`'s `useExpandableFlyoutState` that
+ * returns the previous reference when the newly selected value is deep-equal
+ * to the previously returned one.
+ *
+ * The shared package dispatches twice in a row when a panel is opened from
+ * Security Solution code (`openRightPanelAction` followed by an echoed
+ * `urlChangedAction` after URL sync). The second dispatch carries identical
+ * content but produces fresh object references, which causes subscribers of
+ * `useExpandableFlyoutState()` to re-render even though nothing meaningful
+ * changed.
+ *
+ * Using this hook does not prevent the owning component from rendering once
+ * per echo (the underlying `useSelector` has already triggered a render before
+ * our check runs). It does however keep derived values, memoized children and
+ * downstream hook dependencies reference-stable across the echo, which stops
+ * the cascade into the rest of the tree.
+ */
+export const useStableExpandableFlyoutState = (): ReturnType<typeof useExpandableFlyoutState> => {
+  const raw = useExpandableFlyoutState();
+  const ref = useRef(raw);
+  if (ref.current !== raw && deepEqual(ref.current, raw)) {
+    return ref.current;
+  }
+  ref.current = raw;
+  return raw;
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/plugin.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/plugin.tsx
@@ -81,7 +81,6 @@ import {
   registerRuleAttachment,
 } from './agent_builder/attachment_types';
 import type { SecurityCanvasEmbeddedBundle } from './agent_builder/components/security_redux_embedded_provider';
-import { registerWorkflowSteps } from './workflows/step_types';
 
 export class Plugin implements IPlugin<PluginSetup, PluginStart, SetupPlugins, StartPlugins> {
   private config: SecuritySolutionUiConfigType;

--- a/x-pack/solutions/security/plugins/security_solution/public/plugin.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/plugin.tsx
@@ -74,8 +74,14 @@ import { isSecuritySolutionAccessible } from './helpers_access';
 import { generateIndicatorAttachmentType } from './cases/attachments/indicator/utils/attachments';
 import { defaultDeepLinks } from './app/links/default_deep_links';
 import { AIValueReportLocatorDefinition } from '../common/locators/ai_value_report/locator';
-import { registerAttachmentUiDefinitions } from './agent_builder/attachment_types';
-import { registerRuleAttachment } from './agent_builder/attachment_types/rule_attachment';
+import {
+  registerAttachmentUiDefinitions,
+  registerEntityAnalyticsDashboardAttachment,
+  registerEntityAttachment,
+  registerRuleAttachment,
+} from './agent_builder/attachment_types';
+import type { SecurityCanvasEmbeddedBundle } from './agent_builder/components/security_redux_embedded_provider';
+import { registerWorkflowSteps } from './workflows/step_types';
 
 export class Plugin implements IPlugin<PluginSetup, PluginStart, SetupPlugins, StartPlugins> {
   private config: SecuritySolutionUiConfigType;
@@ -95,6 +101,7 @@ export class Plugin implements IPlugin<PluginSetup, PluginStart, SetupPlugins, S
   private _discoverFlyoutServicesPromise?: Promise<StartServices>;
   private _startedSubPluginsPromise?: Promise<StartedSubPlugins>;
   private _discoverFlyoutStorePromise?: Promise<SecurityAppStore>;
+  private _securityCanvasContextPromise?: Promise<SecurityCanvasEmbeddedBundle>;
 
   constructor(private readonly initializerContext: PluginInitializerContext) {
     this.config = this.initializerContext.config.get<SecuritySolutionUiConfigType>();
@@ -298,6 +305,23 @@ export class Plugin implements IPlugin<PluginSetup, PluginStart, SetupPlugins, S
         application: core.application,
         aiRuleCreation: this.services.aiRuleCreation,
       });
+      registerEntityAnalyticsDashboardAttachment({
+        attachments: plugins.agentBuilder.attachments,
+        application: core.application,
+        agentBuilder: plugins.agentBuilder,
+        chrome: core.chrome,
+        searchSession: plugins.data.search.session,
+      });
+      registerEntityAttachment({
+        attachments: plugins.agentBuilder.attachments,
+        application: core.application,
+        agentBuilder: plugins.agentBuilder,
+        chrome: core.chrome,
+        experimentalFeatures: this.experimentalFeatures,
+        resolveSecurityCanvasContext: () =>
+          this.getSecurityCanvasContext(core, plugins as StartPluginsDependencies),
+        searchSession: plugins.data.search.session,
+      });
     }
 
     // Enable CPS picker only for individual dashboard views (not the listing page).
@@ -366,6 +390,35 @@ export class Plugin implements IPlugin<PluginSetup, PluginStart, SetupPlugins, S
     }
 
     return this._discoverFlyoutStorePromise;
+  }
+
+  /**
+   * Lazily resolves the Redux store + flattened `StartServices` bundle used by
+   * `SecurityReduxEmbeddedProvider` on Agent Builder Canvas surfaces. Start-time work
+   * (sub-plugin bootstrap, services generation) is deferred until the user opens the canvas —
+   * the rest of Agent Builder and the label-only/inline paths must not pay that cost.
+   *
+   * Memoized in a class field so concurrent Preview clicks collapse to a single boot; the
+   * cache is cleared on failure so a retry can recover.
+   */
+  private getSecurityCanvasContext(
+    coreStart: CoreStart,
+    startPlugins: StartPluginsDependencies
+  ): Promise<SecurityCanvasEmbeddedBundle> {
+    if (!this._securityCanvasContextPromise) {
+      this._securityCanvasContextPromise = (async () => {
+        const startedSubPlugins = await this.ensureStartedSubPlugins(coreStart, startPlugins);
+        const [store, kibanaServices] = await Promise.all([
+          this.store(coreStart, startPlugins, startedSubPlugins),
+          this.services.generateServices(coreStart, startPlugins),
+        ]);
+        return { store, kibanaServices };
+      })().catch((e) => {
+        this._securityCanvasContextPromise = undefined;
+        throw e;
+      });
+    }
+    return this._securityCanvasContextPromise;
   }
 
   public async registerDiscoverSharedFeatures(

--- a/x-pack/solutions/security/plugins/security_solution/public/sourcerer/containers/use_init_sourcerer.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/sourcerer/containers/use_init_sourcerer.tsx
@@ -20,9 +20,6 @@ import { useDataView } from '../../common/containers/source/use_data_view';
 import type { State } from '../../common/store/types';
 import { useSourcererDataView } from '.';
 import { useSyncSourcererUrlState } from '../../data_view_manager/hooks/use_sync_url_state';
-import { useIsExperimentalFeatureEnabled } from '../../common/hooks/use_experimental_features';
-
-const defaultInitResult = { browserFields: {} };
 
 export const useInitSourcerer = (
   scopeId:
@@ -31,15 +28,6 @@ export const useInitSourcerer = (
     | PageScope.attacks
     | PageScope.explore = PageScope.default
 ) => {
-  const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
-
-  /* eslint-disable react-hooks/rules-of-hooks */
-  // NOTE: skipping the entire hook on purpose when the new picker is enabled
-  // will be removed as part of the cleanup in https://github.com/elastic/security-team/issues/11959
-  if (newDataViewPickerEnabled) {
-    return defaultInitResult;
-  }
-
   const dispatch = useDispatch();
   const initialTimelineSourcerer = useRef(true);
   const initialDetectionSourcerer = useRef(true);
@@ -248,20 +236,22 @@ export const useInitSourcerer = (
     } else if (
       scopeId === PageScope.alerts &&
       signalIndexNameSourcerer != null &&
-      initialTimelineSourcerer.current &&
+      initialDetectionSourcerer.current &&
       defaultDataView.id.length > 0
     ) {
       initialDetectionSourcerer.current = false;
-      sourcererActions.setSelectedDataView({
-        id: PageScope.alerts,
-        selectedDataViewId: defaultDataView.id,
-        selectedPatterns: getScopePatternListSelection(
-          defaultDataView,
-          PageScope.alerts,
-          signalIndexNameSourcerer,
-          true
-        ),
-      });
+      dispatch(
+        sourcererActions.setSelectedDataView({
+          id: PageScope.alerts,
+          selectedDataViewId: defaultDataView.id,
+          selectedPatterns: getScopePatternListSelection(
+            defaultDataView,
+            PageScope.alerts,
+            signalIndexNameSourcerer,
+            true
+          ),
+        })
+      );
     }
   }, [
     defaultDataView,

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/attachments/entity.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/attachments/entity.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { SECURITY_ENTITY_RISK_SCORE_TOOL_ID } from '../tools';
-import { createEntityAttachmentType } from './entity';
+import { createEntityAttachmentType, MAX_ENTITIES_PER_ATTACHMENT } from './entity';
 
 describe('createEntityAttachmentType', () => {
   const attachmentType = createEntityAttachmentType();
@@ -115,6 +115,226 @@ describe('createEntityAttachmentType', () => {
         expect(result.error).toBeDefined();
       }
     });
+
+    describe('single-entity risk stats (riskStats / resolutionRiskStats)', () => {
+      // Mirrors the stripped shape produced by
+      // `stripRiskRecordForAttachment` in the server-side tool.
+      const buildRiskStats = (overrides: Record<string, unknown> = {}) => ({
+        '@timestamp': '2024-05-01T00:00:00Z',
+        id_field: 'user.name',
+        id_value: 'user:982675@github',
+        calculated_level: 'Low',
+        calculated_score: 89.617,
+        calculated_score_norm: 34.57,
+        category_1_score: 25,
+        category_1_count: 2,
+        category_2_score: 5,
+        category_2_count: 1,
+        notes: [],
+        modifiers: [],
+        score_type: 'base',
+        ...overrides,
+      });
+
+      it('preserves riskStats on the validated payload (regression: must not be stripped)', async () => {
+        const riskStats = buildRiskStats();
+        const input = {
+          identifierType: 'user',
+          identifier: 'haylee-anderson',
+          attachmentLabel: 'Risk Entity',
+          riskStats,
+        };
+
+        const result = await attachmentType.validate(input);
+
+        expect(result.valid).toBe(true);
+        if (result.valid) {
+          // The validator MUST echo the risk stats back — this is what
+          // reaches `AttachmentStateManager.add` and, eventually, the
+          // client-side `RiskSummaryMini`. If this ever regresses the
+          // chat card silently falls back to the entity-store-derived
+          // zero-category shape.
+          expect(result.data).toEqual(
+            expect.objectContaining({ riskStats: expect.objectContaining(riskStats) })
+          );
+        }
+      });
+
+      it('preserves both riskStats and resolutionRiskStats on the validated payload', async () => {
+        const riskStats = buildRiskStats();
+        const resolutionRiskStats = buildRiskStats({
+          calculated_level: 'Critical',
+          calculated_score_norm: 95,
+          category_1_score: 80,
+          category_1_count: 12,
+          score_type: 'resolution',
+        });
+
+        const result = await attachmentType.validate({
+          identifierType: 'host',
+          identifier: 'server1',
+          riskStats,
+          resolutionRiskStats,
+        });
+
+        expect(result.valid).toBe(true);
+        if (result.valid) {
+          expect(result.data).toEqual(
+            expect.objectContaining({
+              riskStats: expect.objectContaining(riskStats),
+              resolutionRiskStats: expect.objectContaining(resolutionRiskStats),
+            })
+          );
+        }
+      });
+
+      it('preserves forward-compatible risk-stats fields via passthrough', async () => {
+        // `stripRiskRecordForAttachment` may surface new optional fields
+        // in the future; passthrough ensures we do not have to change the
+        // schema for each additive field before the client can consume it.
+        const riskStats = buildRiskStats({ future_field: 'future-value' });
+
+        const result = await attachmentType.validate({
+          identifierType: 'host',
+          identifier: 'server1',
+          riskStats,
+        });
+
+        expect(result.valid).toBe(true);
+        if (result.valid) {
+          const data = result.data as { riskStats: Record<string, unknown> };
+          expect(data.riskStats.future_field).toBe('future-value');
+        }
+      });
+
+      it('still validates when riskStats is omitted (backward compatibility)', async () => {
+        const input = {
+          identifierType: 'user',
+          identifier: 'haylee-anderson',
+          attachmentLabel: 'Risk Entity',
+        };
+
+        const result = await attachmentType.validate(input);
+
+        expect(result.valid).toBe(true);
+        if (result.valid) {
+          expect(result.data).toEqual(input);
+          expect(result.data).not.toHaveProperty('riskStats');
+          expect(result.data).not.toHaveProperty('resolutionRiskStats');
+        }
+      });
+
+      it('returns invalid when riskStats is missing required fields', async () => {
+        const result = await attachmentType.validate({
+          identifierType: 'user',
+          identifier: 'haylee-anderson',
+          // Missing calculated_level / calculated_score / etc. — must be
+          // rejected so the client never sees a partially-shaped payload
+          // that would trip `isValidRiskStats` only at render time.
+          riskStats: { category_1_score: 10 },
+        });
+
+        expect(result.valid).toBe(false);
+      });
+
+      it('returns invalid when riskStats uses a wrong type for a required field', async () => {
+        const result = await attachmentType.validate({
+          identifierType: 'user',
+          identifier: 'haylee-anderson',
+          riskStats: buildRiskStats({ calculated_score_norm: 'not-a-number' }),
+        });
+
+        expect(result.valid).toBe(false);
+      });
+
+      it('does not accept riskStats on the multi-entity payload shape', async () => {
+        // The multi-entity branch intentionally does not carry risk stats
+        // (the aggregate renderer fetches its own per-row summary). If
+        // a caller tries to embed them here, Zod strips the field to
+        // match the declared shape — documenting the split so reviewers
+        // understand why multi-entity payloads omit the breakdown.
+        const result = await attachmentType.validate({
+          entities: [{ identifierType: 'host', identifier: 'hostname-1' }],
+          riskStats: {
+            calculated_level: 'Low',
+            calculated_score: 0,
+            calculated_score_norm: 0,
+            category_1_score: 0,
+            category_1_count: 0,
+          },
+        });
+
+        expect(result.valid).toBe(true);
+        if (result.valid) {
+          expect(result.data).not.toHaveProperty('riskStats');
+        }
+      });
+    });
+
+    describe('multi-entity (entities list)', () => {
+      it('returns valid when entities array contains a single item', async () => {
+        const input = {
+          entities: [{ identifierType: 'host', identifier: 'hostname-1' }],
+          attachmentLabel: '1 risk entity',
+        };
+
+        const result = await attachmentType.validate(input);
+
+        expect(result.valid).toBe(true);
+        if (result.valid) {
+          expect(result.data).toEqual(input);
+        }
+      });
+
+      it('returns valid when entities array contains mixed types', async () => {
+        const input = {
+          entities: [
+            { identifierType: 'host', identifier: 'hostname-1' },
+            { identifierType: 'user', identifier: 'username-1' },
+            { identifierType: 'service', identifier: 'service-1' },
+            { identifierType: 'generic', identifier: 'generic-1' },
+          ],
+        };
+
+        const result = await attachmentType.validate(input);
+
+        expect(result.valid).toBe(true);
+      });
+
+      it('returns invalid when entities array is empty', async () => {
+        const input = { entities: [] };
+
+        const result = await attachmentType.validate(input);
+
+        expect(result.valid).toBe(false);
+      });
+
+      it(`returns invalid when entities array exceeds MAX_ENTITIES_PER_ATTACHMENT (${MAX_ENTITIES_PER_ATTACHMENT})`, async () => {
+        const input = {
+          entities: Array.from({ length: MAX_ENTITIES_PER_ATTACHMENT + 1 }, (_, i) => ({
+            identifierType: 'host' as const,
+            identifier: `host-${i}`,
+          })),
+        };
+
+        const result = await attachmentType.validate(input);
+
+        expect(result.valid).toBe(false);
+      });
+
+      it('returns invalid when an entity in the list is malformed', async () => {
+        const input = {
+          entities: [
+            { identifierType: 'host', identifier: 'hostname-1' },
+            { identifierType: 'invalid', identifier: 'oops' },
+          ],
+        };
+
+        const result = await attachmentType.validate(input);
+
+        expect(result.valid).toBe(false);
+      });
+    });
   });
 
   describe('getTools', () => {
@@ -132,10 +352,43 @@ describe('createEntityAttachmentType', () => {
     it('returns expected description', () => {
       const description = attachmentType.getAgentDescription?.();
 
-      expect(description).toContain('risk entity');
-      expect(description).toContain('RISK ENTITY DATA');
+      expect(description).toContain('risk entit');
       expect(description).toContain('identifierType');
       expect(description).toContain('identifier');
+    });
+
+    it('mentions both single and list payload shapes', () => {
+      const description = attachmentType.getAgentDescription?.();
+
+      expect(description).toContain('entities');
+    });
+
+    it('instructs the agent to emit <render_attachment> so the inline renderer fires', () => {
+      const description = attachmentType.getAgentDescription?.();
+
+      expect(description).toContain('<render_attachment');
+    });
+
+    it('uses the platform attribute names `id` and `version`, not the legacy `attachment_id` attribute', () => {
+      const description = attachmentType.getAgentDescription?.();
+
+      expect(description).toContain('id="ATTACHMENT_ID"');
+      expect(description).toContain('version="VERSION"');
+      expect(description).not.toMatch(/<render_attachment[^>]*\battachment_id=/);
+    });
+
+    it('points the agent at the manifest `attachment_id` and `current_version` fields (not synthesis)', () => {
+      const description = attachmentType.getAgentDescription?.();
+
+      expect(description).toContain('attachment_id');
+      expect(description).toContain('current_version');
+      expect(description?.toLowerCase()).toContain('verbatim');
+    });
+
+    it('does not leak the removed {riskEntityData} placeholder', () => {
+      const description = attachmentType.getAgentDescription?.();
+
+      expect(description).not.toContain('{riskEntityData}');
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/attachments/entity.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/attachments/entity.ts
@@ -10,10 +10,89 @@ import { SecurityAgentBuilderAttachments } from '../../../common/constants';
 import { SECURITY_ENTITY_RISK_SCORE_TOOL_ID } from '../tools';
 import { securityAttachmentDataSchema } from './security_attachment_data_schema';
 
-const riskEntityAttachmentDataSchema = securityAttachmentDataSchema.extend({
+/**
+ * Maximum number of entities allowed in a single multi-entity attachment.
+ * Keeps chat payloads bounded and caps the client-side fetch fan-out in the
+ * rich renderer's multi-entity table.
+ */
+export const MAX_ENTITIES_PER_ATTACHMENT = 50;
+
+const entityIdentifierSchema = z.object({
   identifierType: z.enum(['host', 'user', 'service', 'generic']),
   identifier: z.string().min(1),
+  /**
+   * Canonical `entity.id` value from the entity store (for example
+   * `user:name@host@namespace`). When set, the rich-card lookup targets this
+   * field directly instead of the per-type identity field, which is required
+   * for local users where `entity.name` is a composite that does not match
+   * `user.name`. Optional for backward compatibility with older payloads.
+   */
+  entityStoreId: z.string().min(1).optional(),
 });
+
+/**
+ * Subset of `EntityRiskScoreRecord` that `security.get_entity` embeds on the
+ * attachment payload so the chat card's `RiskSummaryMini` can render the
+ * contributions table without a client-side round-trip to the risk index.
+ *
+ * The required fields mirror the client guard in
+ * `public/agent_builder/attachment_types/entity_attachment/payload.ts`
+ * (`isValidRiskStats`) so anything that passes this schema will also pass
+ * the client validation. `.passthrough()` is used so we can evolve the
+ * server-side stripper (see `stripRiskRecordForAttachment` in
+ * `entity_attachment_utils.ts`) without also bumping this schema every
+ * time a new optional field is introduced.
+ *
+ * IMPORTANT: Zod strips unknown keys by default. If the server-side tool
+ * embeds new fields on the attachment, they must either be declared here
+ * or the schema must keep `.passthrough()` — otherwise the
+ * `AttachmentStateManager` validator silently drops them before the
+ * payload is persisted and the client never sees them.
+ */
+const riskStatsPayloadSchema = z
+  .object({
+    '@timestamp': z.string().optional(),
+    id_field: z.string().optional(),
+    id_value: z.string().optional(),
+    calculated_level: z.string(),
+    calculated_score: z.number(),
+    calculated_score_norm: z.number(),
+    category_1_score: z.number(),
+    category_1_count: z.number(),
+    category_2_score: z.number().optional(),
+    category_2_count: z.number().optional(),
+    notes: z.array(z.unknown()).optional(),
+    criticality_modifier: z.number().optional(),
+    criticality_level: z.string().optional(),
+    modifiers: z.array(z.unknown()).optional(),
+    score_type: z.string().optional(),
+  })
+  .passthrough();
+
+/**
+ * Entity attachment payload. Two backward-compatible shapes are supported:
+ *
+ * 1. Single-entity (legacy): `{ identifierType, identifier, entityStoreId?,
+ *    attachmentLabel?, riskStats?, resolutionRiskStats? }`. Rendered as a
+ *    single card. The optional `riskStats`/`resolutionRiskStats` fields carry
+ *    the risk breakdown fetched server-side from the risk time-series index.
+ * 2. Multi-entity: `{ entities: [{ identifierType, identifier, entityStoreId? }, ...], attachmentLabel? }`.
+ *    Rendered as a table. Capped at {@link MAX_ENTITIES_PER_ATTACHMENT}.
+ *    Deliberately does not carry risk stats — the multi-entity renderer
+ *    fetches its own summary per row from the entity store.
+ */
+const riskEntityAttachmentDataSchema = z.union([
+  securityAttachmentDataSchema.extend({
+    identifierType: z.enum(['host', 'user', 'service', 'generic']),
+    identifier: z.string().min(1),
+    entityStoreId: z.string().min(1).optional(),
+    riskStats: riskStatsPayloadSchema.optional(),
+    resolutionRiskStats: riskStatsPayloadSchema.optional(),
+  }),
+  securityAttachmentDataSchema.extend({
+    entities: z.array(entityIdentifierSchema).min(1).max(MAX_ENTITIES_PER_ATTACHMENT),
+  }),
+]);
 
 /**
  * Creates the definition for the `entity` attachment type.
@@ -32,16 +111,36 @@ export const createEntityAttachmentType = (): AttachmentTypeDefinition => {
     format: () => ({}),
     getTools: () => [SECURITY_ENTITY_RISK_SCORE_TOOL_ID],
     getAgentDescription: () => {
-      const description = `You have access to a risk entity that needs to be evaluated. The entity has an identifierType and identifier that you should use to query the risk score.
+      return `You have access to one or more risk entities that need to be evaluated. Each entity has an identifierType and identifier that you should use to query the risk score.
 
-RISK ENTITY DATA:
-{riskEntityData}
+## PAYLOAD SHAPES
+The attachment data is one of two shapes:
+- Single entity: top-level \`identifierType\` + \`identifier\` (+ optional \`attachmentLabel\`).
+- Multi-entity: an \`entities\` array of \`{ identifierType, identifier }\` objects (+ optional \`attachmentLabel\`).
+Handle both shapes.
 
----
+## INLINE RENDERING (REQUIRED)
+When a ${SecurityAgentBuilderAttachments.entity} attachment is present in the conversation, you MUST render it inline using the exact custom XML element shown below. The element name is literally \`render_attachment\` and the attribute names are literally \`id\` and \`version\` — do not rename, translate, or abbreviate them.
 
-1. Extract the identifierType and identifier from the provided risk entity attachment.
-2. Use the available tools to gather context about the alert and provide a response.`;
-      return description;
+Assemble the tag by substituting \`ATTACHMENT_ID\` with the value of the attachment's \`attachment_id\` field from the conversation's attachment manifest, and \`VERSION\` with the value of the \`current_version\` field:
+
+    <render_attachment id="ATTACHMENT_ID" version="VERSION" />
+
+For example, given a manifest entry \`{ "attachment_id": "security.entity:user:a1b2…", "current_version": 3 }\`, the tag you emit is literally:
+
+    <render_attachment id="security.entity:user:a1b2…" version="3" />
+
+Rules:
+- Copy \`attachment_id\` and \`current_version\` VERBATIM from the manifest. Never invent, guess, rewrite, or paraphrase them, and never construct an id from the entity name, email, or other fields.
+- Put the \`<render_attachment>\` tag on its OWN LINE, with a blank line before and after it. Do not wrap it in backticks, quotes, code fences, or surrounding prose.
+- Emit the \`<render_attachment>\` tag BEFORE your prose summary so the user sees the rich entity card or table first.
+- Render each ${SecurityAgentBuilderAttachments.entity} attachment at most once per turn.
+- Only omit the render tag if the user explicitly asks you not to show the entity card/table.
+
+## ANALYSIS STEPS
+1. Extract the \`identifierType\` and \`identifier\` (or list of them) from the attachment.
+2. Use the available tools (e.g. risk score, asset criticality, entity store lookup) to gather context.
+3. After emitting the \`<render_attachment>\` tag, provide a concise prose summary of the findings.`;
     },
   };
 };

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/attachments/entity_analytics_dashboard.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/attachments/entity_analytics_dashboard.test.ts
@@ -1,0 +1,114 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Attachment } from '@kbn/agent-builder-common/attachments';
+import { agentBuilderMocks } from '@kbn/agent-builder-plugin/server/mocks';
+import { SecurityAgentBuilderAttachments } from '../../../common/constants';
+import {
+  createEntityAnalyticsDashboardAttachmentType,
+  type EntityAnalyticsDashboardAttachmentData,
+} from './entity_analytics_dashboard';
+
+describe('createEntityAnalyticsDashboardAttachmentType', () => {
+  const attachmentType = createEntityAnalyticsDashboardAttachmentType();
+  const formatContext = agentBuilderMocks.attachments.createFormatContextMock();
+
+  describe('validate', () => {
+    it('returns valid when dashboard data includes entities and severity_count', async () => {
+      const input = {
+        attachmentLabel: 'EA overview',
+        severity_count: {
+          Critical: 1,
+          High: 2,
+          Moderate: 3,
+          Low: 4,
+          Unknown: 5,
+        },
+        entities: [
+          {
+            entity_type: 'user' as const,
+            entity_id: 'euid-1',
+            entity_name: 'alice',
+            risk_score_norm: 72,
+            risk_level: 'High',
+          },
+        ],
+      };
+
+      const result = await attachmentType.validate(input);
+
+      expect(result.valid).toBe(true);
+      if (result.valid) {
+        const data = result.data as EntityAnalyticsDashboardAttachmentData;
+        expect(data.entities).toHaveLength(1);
+        expect(data.severity_count?.High).toBe(2);
+      }
+    });
+
+    it('returns valid when entities array is empty', async () => {
+      const input = {
+        entities: [],
+        severity_count: {
+          Critical: 0,
+          High: 0,
+          Moderate: 0,
+          Low: 0,
+          Unknown: 0,
+        },
+      };
+
+      const result = await attachmentType.validate(input);
+
+      expect(result.valid).toBe(true);
+    });
+
+    it('returns invalid when severity_count omits a required level', async () => {
+      const input = {
+        entities: [],
+        severity_count: {
+          Critical: 0,
+          High: 0,
+        },
+      };
+
+      const result = await attachmentType.validate(input);
+
+      expect(result.valid).toBe(false);
+    });
+  });
+
+  describe('format', () => {
+    it('getRepresentation includes attachment id and dashboard summary', async () => {
+      const attachment: Attachment<
+        SecurityAgentBuilderAttachments.entityAnalyticsDashboard,
+        EntityAnalyticsDashboardAttachmentData
+      > = {
+        id: 'dash-1',
+        type: SecurityAgentBuilderAttachments.entityAnalyticsDashboard,
+        data: {
+          attachmentLabel: 'Snapshot',
+          entities: [
+            {
+              entity_type: 'host',
+              entity_id: 'euid-host',
+              entity_name: 'web-1',
+            },
+          ],
+        },
+      };
+
+      const formatted = await attachmentType.format(attachment, formatContext);
+
+      const representation = await formatted.getRepresentation?.();
+      expect(representation?.type).toBe('text');
+      if (representation?.type === 'text') {
+        expect(representation.value).toContain('id: "dash-1"');
+        expect(representation.value).toContain('web-1');
+      }
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/attachments/entity_analytics_dashboard.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/attachments/entity_analytics_dashboard.ts
@@ -1,0 +1,144 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Attachment } from '@kbn/agent-builder-common/attachments';
+import type { AttachmentTypeDefinition } from '@kbn/agent-builder-server/attachments';
+import { z } from '@kbn/zod/v4';
+import { SecurityAgentBuilderAttachments } from '../../../common/constants';
+import { securityAttachmentDataSchema } from './security_attachment_data_schema';
+
+const entityListRowSchema = z.object({
+  entity_type: z.enum(['host', 'user', 'service', 'generic']),
+  entity_id: z.string().min(1),
+  entity_name: z.string().optional(),
+  source: z.unknown().optional(),
+  risk_score_norm: z.number().optional(),
+  risk_level: z.string().optional(),
+  criticality: z.string().optional(),
+  first_seen: z.string().optional(),
+  last_seen: z.string().optional(),
+});
+
+const severityCountSchema = z.object({
+  Critical: z.number().int().min(0),
+  High: z.number().int().min(0),
+  Moderate: z.number().int().min(0),
+  Low: z.number().int().min(0),
+  Unknown: z.number().int().min(0),
+});
+
+const anomalyHighlightSchema = z.object({
+  title: z.string().min(1),
+  body: z.string().optional(),
+});
+
+const entityAnalyticsDashboardAttachmentDataSchema = securityAttachmentDataSchema.extend({
+  summary: z.string().max(8000).optional(),
+  time_range_label: z.string().max(256).optional(),
+  watchlist_id: z.string().max(512).optional(),
+  watchlist_name: z.string().max(512).optional(),
+  severity_count: severityCountSchema.optional(),
+  distribution_note: z.string().max(2000).optional(),
+  anomaly_highlights: z.array(anomalyHighlightSchema).max(25).optional(),
+  entities: z.array(entityListRowSchema).max(100),
+});
+
+export type EntityAnalyticsDashboardAttachmentData = z.infer<
+  typeof entityAnalyticsDashboardAttachmentDataSchema
+>;
+
+const isEntityAnalyticsDashboardAttachmentData = (
+  data: unknown
+): data is EntityAnalyticsDashboardAttachmentData => {
+  return entityAnalyticsDashboardAttachmentDataSchema.safeParse(data).success;
+};
+
+const formatDashboardForAgent = (
+  attachmentId: string,
+  data: EntityAnalyticsDashboardAttachmentData
+): string => {
+  const lines = [
+    `Entity analytics dashboard "${
+      data.attachmentLabel ?? 'Entity Analytics'
+    }" (id: "${attachmentId}")`,
+  ];
+  if (data.time_range_label) {
+    lines.push(`Time context: ${data.time_range_label}`);
+  }
+  if (data.watchlist_id || data.watchlist_name) {
+    lines.push(
+      `Watchlist: ${data.watchlist_name ?? data.watchlist_id ?? '—'} (${
+        data.watchlist_id ?? 'no id'
+      })`
+    );
+  }
+  if (data.severity_count) {
+    lines.push(
+      `Risk level counts — Critical: ${data.severity_count.Critical}, High: ${data.severity_count.High}, Moderate: ${data.severity_count.Moderate}, Low: ${data.severity_count.Low}, Unknown: ${data.severity_count.Unknown}`
+    );
+  }
+  if (data.distribution_note) {
+    lines.push(`Distribution note: ${data.distribution_note}`);
+  }
+  if (data.summary) {
+    lines.push(`Summary: ${data.summary.slice(0, 500)}${data.summary.length > 500 ? '…' : ''}`);
+  }
+  if (data.anomaly_highlights?.length) {
+    lines.push(`Highlights: ${data.anomaly_highlights.map((h) => h.title).join('; ')}`);
+  }
+  lines.push(`Entities in snapshot: ${data.entities.length}`);
+  data.entities.slice(0, 20).forEach((e, i) => {
+    lines.push(
+      `${i + 1}. [${e.entity_type}] ${e.entity_name ?? e.entity_id} (EUID: ${e.entity_id})`
+    );
+  });
+  if (data.entities.length > 20) {
+    lines.push(`…and ${data.entities.length - 20} more (see Canvas).`);
+  }
+  return lines.join('\n');
+};
+
+export const createEntityAnalyticsDashboardAttachmentType = (): AttachmentTypeDefinition => {
+  return {
+    id: SecurityAgentBuilderAttachments.entityAnalyticsDashboard,
+    validate: (input) => {
+      const parseResult = entityAnalyticsDashboardAttachmentDataSchema.safeParse(input);
+      if (parseResult.success) {
+        return { valid: true, data: parseResult.data };
+      } else {
+        return { valid: false, error: parseResult.error.message };
+      }
+    },
+    format: (attachment: Attachment<string, unknown>) => {
+      const data = attachment.data;
+      if (!isEntityAnalyticsDashboardAttachmentData(data)) {
+        throw new Error(
+          `Invalid entity analytics dashboard attachment data for attachment ${attachment.id}`
+        );
+      }
+      return {
+        getRepresentation: () => {
+          return { type: 'text', value: formatDashboardForAgent(attachment.id, data) };
+        },
+      };
+    },
+    getTools: () => [],
+    getAgentDescription: () => {
+      return `A security Entity Analytics dashboard snapshot attachment mirrors the built-in Security → Entity Analytics home experience in Canvas: entity risk level counts with the same donut/table visuals as the product, an optional "recent anomalies" style highlight list you author from investigation context, and the entities table. Use it when the user wants to show, open, view, or explore the **Entity Analytics dashboard/home/overview** (the **product Entity Analytics page** / same IA as that navigation entry), not only when they say "create". This precedence applies only when the user has NOT used explicit dashboard/home/overview phrasing: if the prompt contains phrases like \`entity analytics dashboard\`, \`EA dashboard\`, \`entity analytics home/overview/landing\`, or \`show/open/view Entity Analytics\`, use this attachment even when the same prompt also mentions list/ranking/top-N framing. **Do not** use this type when the user only asked for a **list**, **ranking**, **table**, **top N**, **multiple entities**, **hosts and users**, **riskiest entities**, **top entities**, **entities in the system**, or similar **set-of-entities** framing without clearly wanting that **home/overview** page — for those, the "${SecurityAgentBuilderAttachments.entity}" attachment that security.search_entities and security.get_entity emit automatically is sufficient (the rich renderer shows an entities table for 2+ rows and a single-entity card for 1 row). Only add this dashboard type on top of that when they also asked for the EA page experience. Do not confuse this with composing a new Kibana saved Dashboard (dashboard-management skill). Summarize in prose and reference the attachment id. Create with the attachments.add tool, type "${SecurityAgentBuilderAttachments.entityAnalyticsDashboard}", JSON fields: optional attachmentLabel, summary, time_range_label, watchlist_id, watchlist_name, severity_count (object with integer counts for Critical, High, Moderate, Low, Unknown — prefer real totals when inferable; otherwise bucket entities from your search and set distribution_note explaining the scope), optional distribution_note, optional anomaly_highlights as { title, body? }[], entities as row objects { entity_type, entity_id, entity_name?, source?, risk_score_norm?, risk_level?, criticality?, first_seen?, last_seen? } (may be empty when only KPIs/highlights matter). \`last_seen\` is the entity store record's top-level \`@timestamp\` (always present for entities in the store); use it — not \`entity.lifecycle.last_activity\` — because the lifecycle field can be missing for freshly upserted entities.
+
+## Inline rendering (REQUIRED after attachments.add)
+A successful \`attachments.add\` returns \`{ id, current_version }\`. The element name is literally \`render_attachment\` and the attribute names are literally \`id\` and \`version\` — do not rename them. Emit the tag on its OWN LINE, with a BLANK LINE before and after it, by substituting the values from the \`attachments.add\` result into this exact template:
+
+    <render_attachment id="<id from attachments.add>" version="<current_version from attachments.add>" />
+
+Rules:
+- Copy \`id\` and \`current_version\` VERBATIM from the \`attachments.add\` tool result. Never synthesize an id from the user's prompt, the \`attachmentLabel\`, or any other field; never guess the id format.
+- Do not wrap the tag in backticks, quotes, or a code fence.
+- Without this tag the UI only shows "Attachment added: …" text and the user cannot open the Canvas — that is incorrect.`;
+    },
+  };
+};

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/attachments/register_attachments.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/attachments/register_attachments.ts
@@ -9,6 +9,7 @@ import type { AgentBuilderPluginSetup } from '@kbn/agent-builder-plugin/server';
 import { createRuleAttachmentType } from './rule';
 import { createAlertAttachmentType } from './alert';
 import { createEntityAttachmentType } from './entity';
+import { createEntityAnalyticsDashboardAttachmentType } from './entity_analytics_dashboard';
 
 /**
  * Registers all security agent builder attachments with the agentBuilder plugin
@@ -16,5 +17,6 @@ import { createEntityAttachmentType } from './entity';
 export const registerAttachments = async (agentBuilder: AgentBuilderPluginSetup) => {
   agentBuilder.attachments.registerType(createAlertAttachmentType());
   agentBuilder.attachments.registerType(createEntityAttachmentType());
+  agentBuilder.attachments.registerType(createEntityAnalyticsDashboardAttachmentType());
   agentBuilder.attachments.registerType(createRuleAttachmentType());
 };

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/entity_analytics/entity_analytics_skill.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/entity_analytics/entity_analytics_skill.ts
@@ -28,19 +28,118 @@ export interface EntityAnalyticsSkillsContext {
   logger: Logger;
 }
 
+// The "Inline rendering" sections below follow a strict copy-verbatim
+// contract: the entity tools (security.get_entity / security.search_entities)
+// embed a pre-formatted `renderTag` string in their `ToolResultType.other`
+// payload (see `buildRenderAttachmentTag` in
+// server/agent_builder/tools/entity_analytics/entity_attachment_utils.ts)
+// and the skill instructs the model to paste that exact string onto its own
+// line. We do NOT ask the model to assemble a `<render_attachment>` tag from
+// `attachmentId` / `version` any more — doing so has empirically produced
+// hallucinated ids (e.g. `security.entity:single:<email>`) which contain
+// `@` / `.` and shatter the upstream HTML tokenizer in
+// remark-parse-no-trim (its openTag regex rejects underscores, and the
+// autolink / email inline tokenizers run before the HTML tokenizer so any
+// URL-shaped substring breaks the tag into multiple AST nodes). The skill
+// also keeps the "blank line between <render_attachment> and prose" rule
+// as a second line of defense; removing it depends on a platform-side
+// fix to `createTagParser`
+// (x-pack/platform/plugins/shared/agent_builder/public/application/components/
+// conversations/conversation_rounds/round_response/markdown_plugins/utils.ts)
+// that is out of scope for this plugin.
 const entityStoreV2Content = `
 This skill provides a guide to investigating specific security entities (hosts, users, services, generic) by entity ID (EUID)
 or by surfacing risky entities based on their risk scores, asset criticality levels and other behavioral and lifecycle attributes.
 
+## Rich attachments — overview
+
+Two rich attachment types are available for entity analytics answers:
+
+- \`security.entity\` — unified entity attachment emitted **automatically** as a side effect of \`security.get_entity\` (single-entity profile) and \`security.search_entities\` (multi-entity result). The renderer dynamically shows:
+  - a **single-entity card** (flyout-shaped sections with summary, risk, resolution, insights) when the attachment represents **one** entity, or
+  - an **entities table** (Canvas UI) when the attachment represents **two or more** entities.
+  You never call \`attachments.add\` for this type — just render the tag returned by the tool result.
+- \`security.entity_analytics_dashboard\` — an explicit **Entity Analytics home/overview** Canvas snapshot (risk level donut + highlights + entities together). You call \`attachments.add\` with this type **only** when the user explicitly asks to **show / open / view / display** the **Entity Analytics dashboard / home / overview / landing** product page.
+
+**Never duplicate the attachment in prose.** Whichever rich attachment you render (the correct one depends on the user's ask — see the "Choosing the right rich attachment" table and the "Dashboard trigger" rule below), the Canvas you embedded IS the user-facing presentation. Your prose reply is for narrative and recommendations only — it must NOT restate what the attachment already shows.
+
+For \`security.entity\` (single-entity card or multi-entity table):
+
+- Do NOT emit an "Entity Overview" / "Entity Profile" / field-by-field markdown block after a single-entity card — the card already lists those fields.
+- Do NOT emit a ranked markdown table (e.g. columns like \`| Entity | Type | Risk score | Risk level | Criticality |\`) after an entities table — the table Canvas is the ranking.
+- Do NOT repeat the per-entity summary once per row in prose after the table — the rows in the attachment already cover that.
+- DO write a short prose narrative alongside the attachment: 1–3 sentences for a single-entity card (why this entity is / is not risky, what drove the score, what to investigate next), or 2–4 bullets for a list (top-level takeaways, biggest outliers, recommended follow-ups).
+
+For \`security.entity_analytics_dashboard\` (Entity Analytics home/overview snapshot):
+
+- Do NOT restate the \`severity_count\` buckets (Critical / High / Moderate / Low / Unknown) as a markdown table — the donut and breakdown panel already show them.
+- Do NOT re-list the \`anomaly_highlights\` titles/bodies as bullets — the highlights panel already shows them.
+- Do NOT repeat the per-row entities list in markdown after the dashboard's entities table — the Canvas already shows it.
+- DO write 2–4 sentences interpreting the snapshot: what the risk distribution looks like, biggest outliers worth flagging, and recommended follow-ups.
+
+### Dashboard trigger — MUST use \`security.entity_analytics_dashboard\`
+
+If the user's prompt contains any of these phrase families (case-insensitive substring match is enough):
+
+- \`entity analytics dashboard\`, \`EA dashboard\`
+- \`entity analytics home\`, \`entity analytics overview\`, \`entity analytics landing\`
+- \`show\` / \`open\` / \`view\` / \`display\` / \`bring up\` **Entity Analytics** (the product page, not a generic Kibana dashboard)
+
+…then you **MUST** call \`attachments.add\` with \`type: 'security.entity_analytics_dashboard'\` **in addition to** any \`security.search_entities\` / \`security.get_entity\` calls used to populate it. Emitting only the \`security.entity\` table or card is **incorrect** for these prompts — the user explicitly asked for the Entity Analytics product-page Canvas, which is a different rich view.
+
+This rule takes **precedence** over the "do not use the dashboard for list / ranking / top-N questions" guidance elsewhere in this skill. If the literal dashboard / home / overview phrasing is present, emit the dashboard even when the same prompt also includes list / ranking / top-N framing.
+
+## Mandatory — \`<render_attachment>\` (otherwise there is **no** Preview / Canvas)
+
+Rich attachments do **not** show the interactive pill, **Preview**, or **Canvas** unless you **embed** them in your **assistant markdown** in the **same turn**.
+
+\`security.get_entity\` and \`security.search_entities\` return an \`other\` result that contains a ready-made \`renderTag\` string, for example:
+
+\`\`\`json
+{ "attachmentId": "security.entity:user:<hex>", "version": 1, "renderTag": "<render_attachment id=\\"security.entity:user:<hex>\\" version=\\"1\\" />" }
+\`\`\`
+
+To render the attachment you **copy the value of \`renderTag\` EXACTLY** onto its own line in your reply — byte-for-byte, including the quoting. Do not rewrite it, do not reformat it, do not substitute the id with anything you inferred from the question (email, username, host name, prose description), do not wrap it in backticks/quotes/code fences.
+
+For \`security.entity_analytics_dashboard\` the \`attachments.add\` tool returns \`{ id, current_version }\` on its result. No \`renderTag\` is provided for that path, so you assemble the tag by substituting those values verbatim into this exact template:
+
+\`<render_attachment id="<id from attachments.add>" version="<current_version from attachments.add>" />\`
+
+Rules:
+- **Copy from the tool's own result.** If the tool's \`other\` result contains a \`renderTag\`, copy that string verbatim. If a dashboard \`attachments.add\` call succeeded, copy \`id\` and \`current_version\` verbatim into the template above. Never invent an id; never derive one from the user's prompt or any other field.
+- **No \`renderTag\`, no tag.** If the tool result did not include a \`renderTag\` (e.g. \`security.get_entity\` resolved multiple candidates and fell back to an RLIKE match — no single-entity attachment was stored), do NOT emit a \`<render_attachment>\` tag. Write prose only.
+- **One \`<render_attachment>\` per attachment.** If you emit an entity attachment AND add a dashboard attachment, output two tags (one per id/version pair).
+- **Without** these tags, the UI only shows subdued italic text like **Attachment added: …** — the user **cannot** open the Canvas. **That is incorrect** for these attachment types.
+- ALWAYS insert a BLANK LINE between the \`<render_attachment>\` tag and any following prose. Without this blank line, the prose will be dropped by the markdown parser.
+
+## Choosing the right rich attachment
+
+| What the user wants | Typical phrases | Attachment | Canvas / UI pattern |
+| --- | --- | --- | --- |
+| **Single entity** — details, profile, card, flyout for one identity | **this** host, named EUID, **details**, **profile**, **deep dive**, **entity card**, **card**, **flyout**, "tell me about **that** user", **the** riskiest **host** when they mean **one** winner | \`security.entity\` (emitted automatically by \`security.get_entity\`) | **Entity card** — flyout-shaped sections (summary, risk, resolution, insights). |
+| **Multiple entities** — list, set, table, ranking, comparison | **list**, **table**, **which**/**who are** **hosts**/**users**/**entities** (plural entity nouns), **top** N, **rank**, **compare**, **enumerate**, "**entities** that…", "**hosts** sorted by risk", **compound asks** naming **two+ entity kinds** (**hosts and users**) | \`security.entity\` (emitted automatically by \`security.search_entities\` when 2+ entities are returned) | **Entities table** — Canvas shows the full multi-entity table. |
+| **Entity Analytics product page** experience | **Entity Analytics dashboard / home / overview / landing page**, **show/open/view Entity Analytics**, **risk level breakdown donut with highlights**, **same layout as Entity Analytics** (product page) | \`security.entity_analytics_dashboard\` (explicit \`attachments.add\`) | **Dashboard snapshot** — two-column Canvas with donut, highlights panel, and entities table. |
+
+**Key principle — do not manually add \`security.entity\`:** the tools emit this attachment as a side effect. Your job is to render the \`<render_attachment>\` tag returned in the tool's \`other\` result. The **single-vs-table** experience is selected automatically by the renderer based on how many entities the attachment contains.
+
+**Precedence — Security Entity Analytics page vs Kibana "dashboard"**
+- If they mean the **built-in Security → Entity Analytics** experience (same IA as the product **Entity Analytics** page): phrases like **show / open / view / display / bring up** the **Entity Analytics** **dashboard**, **home**, **overview**, or **landing** page → call \`attachments.add\` with \`security.entity_analytics_dashboard\`. This is a **snapshot of that product page** in chat Canvas — **not** composing a **new Kibana saved Dashboard** (Lens panels, \`dashboard-management\` skill). Do **not** wait for the user to say "create"; **show/open/view** that page is enough.
+- **Does not** apply when the user only says **show**/**tell me**/**what are** together with **risky**/**riskiest**/**top** **hosts**, **users**, **entities** without naming the **Entity Analytics** product page — those are list/ranking asks satisfied by the \`security.entity\` attachment that \`security.search_entities\` emits automatically.
+- Only use Kibana dashboard composition when they clearly want a **new or edited Kibana Dashboard** saved object (panels, Lens, \`manage_dashboard\`, etc.) — not merely the word "dashboard" next to "Entity Analytics".
+
 ## When to Use This Skill
 
 Use this skill when:
-- Investigating the current behavior of a specific entity using its ID (EUID)
-- Looking up the current profile for a specific entity using its ID (EUID), including risk score, asset criticality and watchlists
-- Analyzing the historical behavior of a specific entity using its ID (EUID)
-- Analyzing changes in an entity's risk score or behavior over time
-- Discovering the riskiest entities in the environment based on risk scores and criticality levels
-- Surfacing entities that require further investigation based on their attributes and behaviors
+- The user **explicitly** asks to **show**, **open**, **view**, or **walk through** the **Entity Analytics** **home**, **overview**, **landing**, or **built-in Entity Analytics dashboard** (the **product page** / same IA as Security → Entity Analytics navigation) → \`security.entity_analytics_dashboard\` after gathering entity data.
+- They want **one entity's details / card / profile / flyout-style** view → \`security.get_entity\` (which emits the \`security.entity\` attachment as a single-entity card).
+- They want a **list / table / ranking** of entities (plural or set framing) → \`security.search_entities\` (which emits the \`security.entity\` attachment as an entities table when 2+ rows are returned).
+- One message names **several entity kinds** to compare or rank (e.g. **riskiest hosts and users**) → run \`security.search_entities\` per type (or with multiple \`entityTypes\`), and the tool will emit an aggregate \`security.entity\` attachment.
+- Investigating the current behavior of a specific entity using its ID (EUID).
+- Looking up the current profile for a specific entity using its ID (EUID), including risk score, asset criticality and watchlists.
+- Analyzing the historical behavior of a specific entity using its ID (EUID).
+- Analyzing changes in an entity's risk score or behavior over time.
+- Discovering the riskiest entities in the environment based on risk scores and criticality levels.
+- Surfacing entities that require further investigation based on their attributes and behaviors.
 
 ## Available Tools
 
@@ -59,6 +158,8 @@ Use this skill when:
     - entity.attributes.asset - whether this entity is an asset
     - entity.behaviors.rule_names - detection rules associated with this entity
     - entity.behaviors.anomaly_job_ids - anomaly detection jobs that have detected this entity
+    - entity.source - multi-value list of integration/data source keys that produced this entity. Values are heterogeneous and may be vendor keys (e.g. \`aws\`, \`okta\`, \`crowdstrike\`), dataset keys (e.g. \`aws.cloudtrail\`, \`aws.guardduty\`, \`okta.system\`), or integration keys (e.g. \`entityanalytics_okta\`, \`entityanalytics_entra_id\`, \`island_browser\`). Always stored lowercase.
+    - entity.namespace - normalized **single-value** vendor namespace, user entities only. Collapses the heterogeneous \`entity.source\` values into canonical names: \`okta\`, \`entra_id\`, \`microsoft_365\`, \`active_directory\`, \`local\`, \`unknown\`, or pass-through of \`event.module\` (e.g. \`aws\`, \`gcp\`) when no dedicated mapping exists.
     - entity.lifecycle.first_seen - first time this entity has been seen in the entity store
     - entity.lifecycle.last_activity - last time this entity has been active in the entity store
     - risk_score_inputs - the alert inputs that contributed to the risk score calculation for this entity.
@@ -67,6 +168,20 @@ Use this skill when:
     If multiple results are returned:
       - Provide a summary of the FIRST result.
       - You MUST mention the other results found and provide the COMPLETE entity ID for each
+
+#### Inline rendering (REQUIRED when a single entity is resolved)
+When \`security.get_entity\` resolves exactly one entity, its \`other\` result includes a \`renderTag\` field alongside \`attachmentId\` and \`version\`. Copy that \`renderTag\` string **verbatim** onto its own line, then a BLANK LINE, then your prose summary:
+
+    <contents of the renderTag field from the tool's other result — copy byte-for-byte>
+
+    <your prose summary here>
+
+Rules:
+- **Copy \`renderTag\` verbatim.** It already contains the correct attachment id and version — do not modify, reorder, or paraphrase any character. Do not build the tag yourself from \`attachmentId\` and \`version\`, do not replace the id with anything derived from the user's prompt (name, email, prose description).
+- Emit the \`<render_attachment>\` tag BEFORE your prose summary so the user sees the rich entity card first.
+- ALWAYS insert a BLANK LINE between the \`<render_attachment>\` tag and any following prose. Without this blank line, the prose will be dropped by the markdown parser.
+- Render each \`security.entity\` attachment at most once per turn.
+- When \`security.get_entity\` resolves multiple candidates (fallback RLIKE match), no attachment is stored and the \`other\` result contains no \`renderTag\`. In that case, **do not emit a \`<render_attachment>\` tag** — write prose only.
 
 ### Search Entities Tool
 - \`security.search_entities\` - Search the entity store for security entities (host, user, service, generic) matching specific criteria.
@@ -77,47 +192,126 @@ Use this skill when:
     - entity attributes (watchlists, managed status, MFA status, asset)
     - entity behaviors (behavior rule names, anomaly job IDs)
     - entity lifecycle timestamps (first seen, last activity)
+    - data source (entity.source) - pass the raw lowercase integration key(s) via the \`sources\` parameter. Matching is **exact-or-prefix**: \`sources: ['aws']\` matches \`aws\`, \`aws.cloudtrail\`, \`aws.guardduty\`, \`aws.s3access\`, etc. (a single vendor key is usually enough — do not fan out into \`['aws', 'aws.cloudtrail']\`). Always use the stored key, not a pretty-printed label (pass \`island_browser\`, not \`Island Browser\`).
+    - normalized user vendor (entity.namespace) - pass canonical values via the \`namespaces\` parameter; e.g. \`namespaces: ['okta']\`. Canonical values are \`okta\`, \`entra_id\`, \`microsoft_365\`, \`active_directory\`, \`local\`, \`unknown\`, or pass-through of \`event.module\` (e.g. \`aws\`, \`gcp\`). \`entity.namespace\` only exists on **user** entities — for host/service/generic entities use \`sources\` instead. When a canonical namespace exists for the vendor the user named, prefer \`namespaces\` over \`sources\` for user queries (it is single-valued and already normalized).
     Do NOT use this tool if the entity ID (EUID) is known; use the \`security.get_entity\` tool instead.
     ALWAYS use real entities from the entity store, do not invent entities.
     ALWAYS use the \`security.get_entity\` after using this tool to get the full profile for each entity found.
+
+#### Inline rendering (REQUIRED when an aggregate attachment is emitted)
+When \`security.search_entities\` stores an aggregate \`security.entity\` attachment, its \`other\` result includes a \`renderTag\` field alongside \`attachmentId\` and \`version\`. Copy that \`renderTag\` string **verbatim** onto its own line, then a BLANK LINE, then your prose summary:
+
+    <contents of the renderTag field from the tool's other result — copy byte-for-byte>
+
+    <your prose summary here>
+
+Rules:
+- **Copy \`renderTag\` verbatim.** It already contains the correct attachment id and version — do not modify it, do not build your own tag from \`attachmentId\` and \`version\`, do not derive the id from entity names, emails, vendor keys, or any other prose.
+- Emit the \`<render_attachment>\` tag BEFORE your prose summary so the user sees the table first.
+- ALWAYS insert a BLANK LINE between the \`<render_attachment>\` tag and any following prose. Without this blank line, the prose will be dropped by the markdown parser.
+- Render each \`security.entity\` attachment at most once per turn.
+- The rendered table REPLACES the prose markdown table for the list — do not also print the
+  markdown columns described in Step 3 when the inline table is shown. A short narrative
+  (top-level takeaways, outliers worth flagging) still belongs in the prose.
+- If the \`other\` result contains no \`renderTag\`, **do not emit a \`<render_attachment>\` tag**. Write prose only.
+- When exactly one entity is returned and you are about to follow up with \`security.get_entity\`, prefer rendering the tag from the \`get_entity\` result instead (richer card payload) — skip the \`search_entities\` render tag to avoid duplicate pills in that turn.
+
+### Vendor source cheat sheet
+
+When the user names a vendor or platform (AWS, Okta, Azure, Microsoft 365, Active Directory, endpoint/local, CrowdStrike, Google Workspace, Jamf, ...), use these mappings to fill \`namespaces\` and/or \`sources\`. Values are the raw lowercase keys stored in the entity store — never pretty-printed labels.
+
+- **AWS** → \`namespaces: ['aws']\` (pass-through) + \`sources: ['aws']\` (prefix covers \`aws.cloudtrail\`, \`aws.guardduty\`, \`aws.s3access\`, etc.).
+- **Okta** → \`namespaces: ['okta']\` + \`sources: ['okta', 'entityanalytics_okta']\` (prefix also covers \`okta.system\`).
+- **Azure AD / Entra ID** → \`namespaces: ['entra_id']\` + \`sources: ['azure', 'entityanalytics_entra_id']\`.
+- **Microsoft 365** → \`namespaces: ['microsoft_365']\` + \`sources: ['o365', 'o365_metrics']\`.
+- **Active Directory** → \`namespaces: ['active_directory']\` + \`sources: ['entityanalytics_ad']\`.
+- **Endpoint / local accounts** → \`namespaces: ['local']\` + \`sources: ['endpoint', 'system']\`.
+- **CrowdStrike** → \`sources: ['crowdstrike']\` (no canonical namespace; also applies to host entities).
+- **Google Workspace** → \`sources: ['google_workspace']\` (no canonical namespace).
+- **Jamf** → \`sources: ['jamf', 'jamf_protect']\` (no canonical namespace).
+
+For vendors not listed here, try \`namespaces: ['<event.module>']\` on user entities (pass-through) or \`sources: ['<lowercase vendor key>']\` — a single prefix key is enough thanks to exact-or-prefix matching.
 
 ## Entity Analysis Investigation Steps
 
 ### 1. Find entities to investigate
 - If entity ID (EUID) is known, continue directly to the next step
 - If not, use \`security.search_entities\` to find entities. Always use real entities from the entity store, do not invent entities.
-- You MUST call \`security.search_entities\` with a 'riskScoreMin' parameter if the user is asking about risk scores or riskiness.
-- You MUST call \`security.search_entities\` with a 'criticalityLevels' parameter if the user is asking about criticality.
+- ONLY pass \`riskScoreMin\` when the user explicitly specified a numeric floor (e.g. "users with score above 70", "hosts over 85"). Omit it otherwise — by default the tool sorts by \`entity.risk.calculated_score_norm DESC\`, so the riskiest rows come first. Note: the default \`riskScore\` sort only ranks entities that have a computed risk score (rows with \`calculated_score_norm IS NULL\` are excluded because ranking is not meaningful for unscored entities). When the user wants unscored entities to appear alongside scored ones, pass \`sortBy: 'criticality'\` — that path keeps unscored entities at the bottom via \`criticality_rank = 0\`.
+- Criticality intent splits into **filter** vs **sort**, and you must pick the right parameter:
+  - Pass \`criticalityLevels\` to **filter** results down to one or more specific levels — e.g. "show high-impact users", "only extreme_impact hosts", "critical or high assets". Use this when the user restricts which levels are in scope.
+  - Pass \`sortBy: 'criticality'\` to **order / rank / list top-N** entities **by criticality** (extreme_impact > high_impact > medium_impact > low_impact, with risk score as the tiebreaker; entities with no asset criticality land last). Use this when the user says "by criticality", "sorted by criticality", "rank by criticality", "top N by criticality", etc.
+  - Do **NOT** stuff all four values into \`criticalityLevels\` (\`['extreme_impact','high_impact','medium_impact','low_impact']\`) to simulate a sort — that is a no-op filter and the tool will still sort by risk score. Use \`sortBy: 'criticality'\` instead.
+  - The two parameters compose: \`criticalityLevels: ['high_impact','extreme_impact']\` + \`sortBy: 'criticality'\` restricts to those tiers AND orders them (extreme above high, risk score as tiebreaker).
 - ONLY call \`security.search_entities\` with a 'riskScoreChangeInterval' parameter if the user is asking about changes or jumps in risk score.
 
+#### Source-scoped search strategy
+
+When the user names a vendor / platform (AWS, Okta, Azure, Microsoft 365, CrowdStrike, Google Workspace, Jamf, ...), pick the right filter using the "Vendor source cheat sheet" above:
+
+1. **User entities + vendor has a canonical namespace** (Okta, Entra ID, Microsoft 365, Active Directory, local/endpoint, or a pass-through vendor like AWS/GCP) — **try \`namespaces\` first**. It is single-valued and already normalized, so it is the most reliable filter.
+2. **If the namespace search returns zero rows**, retry with \`sources\` using the prefix key(s) from the cheat sheet. Because matching is exact-or-prefix, \`sources: ['aws']\` is enough — do **not** expand into \`['aws', 'aws.cloudtrail', 'aws.guardduty']\`.
+3. **User entities + vendor has no canonical namespace** (CrowdStrike, Google Workspace, Jamf, ...) — skip \`namespaces\` and go straight to \`sources\` with the prefix key.
+4. **Host / service / generic entities** — those types do not have \`entity.namespace\`. Skip \`namespaces\` entirely and use \`sources\` directly (e.g. \`sources: ['crowdstrike']\` for CrowdStrike hosts).
+5. **If both attempts still return zero entities**, follow the current fallback: report "no matching entities" and do NOT invent entities. You may mention which sources/namespaces the user does have, but only when a prior tool call already surfaced that information.
+
 ### 2. Get entity profiles
-For each entity ID, you MUST call \`security.get_entity\` get the full entity profile
+How aggressively you call \`security.get_entity\` depends on how many entities step 1 produced:
+
+- **2+ entities returned** — prefer the inline table rendered from the aggregate
+  \`security.entity\` attachment (see "Inline rendering" above). Do NOT loop
+  \`security.get_entity\` over every row just to populate the table: the aggregate attachment is
+  already sufficient for the user to drill in. Only call \`security.get_entity\` when the user
+  explicitly asks for per-entity profiles, risk score inputs, behavior history, or anomaly
+  details, or when the investigation narrative clearly requires enrichment for a specific
+  entity you are calling out in the prose.
+- **Exactly 1 entity returned** — still call \`security.get_entity\` to pull the enriched
+  profile (risk inputs, history, behaviors). The single-entity attachment id is deterministic,
+  so \`get_entity\` bumps the existing attachment's version instead of creating a duplicate.
+- **Entity ID already known (step 1 skipped)** — call \`security.get_entity\` directly.
+
+General guidance when you do call \`security.get_entity\`:
 
 - Identify if any time interval or specific date is needed for historical analysis
 - Use \`security.get_entity\` to get the full entity profile, including risk score inputs
 - If more than one profile is returned for an entity, order them chronologically to build a picture of entity behavior over time
 
-You MUST use the \`security.get_entity\` tool to get entity profiles for EACH entity found in step 1. For example,
-if 10 entities are found using \`security.search_entities\`, you MUST call \`security.get_entity\` 10 times to get the full profiles for each entity.
-
 ### 3. Interpret and summarize output
-- For \`security.get_entity\` tool results, summarize the current profile and identify whether the entity is considered risky
-- If the result contains 'risk_score_inputs', summarize the alerts that contributed to the risk score calculation
-- If the result contains 'profile_history', summarize the history of this entity over time, which may include:
-  - Whether the risk score has increased or decreased over time
-  - Whether the entity asset criticality has become more or less critical over time
-  - Whether the entity has been added to or removed from watchlists over time
-  - Whether the entity has exhibited new behaviors or stopped exhibiting certain behaviors over time
-- For \`security.search_entities\` tool results, summarize results in a table format. The table MUST have the following columns if data is available for them:
-  - risk score
-  - asset criticality
-  - first_seen
-  - last_seen
-  Include columns for behavioral attributes if data exists and column is relevant to the user's prompt
+
+The rendered \`security.entity\` attachment IS the user-facing profile (single-entity card) or ranking (entities table). Follow the "Never duplicate the attachment in prose" principle from the Rich attachments overview — do NOT re-emit the attachment's contents as markdown.
+
+Keep prose short and narrative-only:
+
+- For \`security.get_entity\` (single entity) results, write 1–3 sentences covering whether the entity is risky, what is driving the score, and what to investigate next. Do NOT produce an "Entity Overview" / field-by-field markdown block — those fields are already in the card.
+  - When the result contains \`risk_score_inputs\`, one sentence on the top alert(s) contributing to the score is enough. Do NOT paste the full list of inputs as markdown.
+  - When the result contains \`profile_history\`, one sentence on the overall trend (increasing / decreasing / stable) is enough, plus a brief callout of any significant change in risk level, asset criticality, watchlist membership, or behaviors.
+- For \`security.search_entities\` (multi-entity) results, write 2–4 bullets with top-level takeaways: highest-risk row(s), biggest criticality gaps, outliers worth flagging, and recommended follow-ups. Do NOT re-list every row in markdown (columns like \`risk score\`, \`asset criticality\`, \`first_seen\`, \`last_seen\`) — the entities-table Canvas already shows those columns.
 
 ### 4. Provide recommendation
 - Recommend investigating external activities for user entities
 - Recommend investigating vulnerabilities and exposures for host and service entities
+
+## Entity Analytics dashboard snapshot (Canvas UI)
+
+When the user **explicitly** asked to open the **Entity Analytics home/overview** product experience in chat — same information architecture as Security → Entity Analytics home: **entity risk levels** with donut + breakdown table, **recent anomalies / highlights**, and **entities** — **not** when their ask is only **which entities are riskiest** / **top N** / **list entities** (those are satisfied by the automatic \`security.entity\` attachment from \`security.search_entities\`):
+
+1. Use \`security.search_entities\` (and \`security.get_entity\` as needed) so the snapshot reflects **real** entity store data aligned with the user's filters (entity types, risk, criticality, watchlists, time hints in the question).
+2. Call \`attachments.add\` with \`type\` set to exactly \`security.entity_analytics_dashboard\` and \`data\` containing:
+   - \`attachmentLabel\`: short title tailored to the request (for example, "High-risk users — last 7 days").
+   - \`summary\` (optional): 1–3 sentences interpreting the snapshot for this question.
+   - \`time_range_label\` (optional): **omit this field unless the user explicitly named a time window** (e.g. "last 24 hours", "past week", "since yesterday", "in the last 90 days", a specific date or date range). When you do set it, use plain language matching the user's window (for example, "Last 24 hours", "Last 90 days", "Since 2025-01-01"). **Never** populate it with generic filler like \`"Current"\`, \`"Now"\`, \`"Today"\`, \`"All time"\`, \`"Latest"\`, \`"Recent"\`, or a restatement of the attachment title — in those cases leave the field unset so the dashboard renders without a time caption.
+   - \`watchlist_id\` / \`watchlist_name\` (optional): when the user or your filters scoped a watchlist (copy from tool/API output when present).
+   - \`severity_count\` (optional but recommended): object \`{ "Critical", "High", "Moderate", "Low", "Unknown" }\` with **non-negative integer** counts. Prefer counts that match the environment when you can infer them reliably from tool outputs. If you only have a **sample** (for example entities returned by \`security.search_entities\`), **bucket those rows by \`risk_level\`**, set the counts from that sample, and set \`distribution_note\` to state clearly that counts reflect that sample (for example, "Counts are from the 50 entities returned for this question, not a full-environment rollup").
+   - \`anomaly_highlights\` (optional): array of \`{ "title", "body"? }\` for the right-hand panel — summarize notable risk changes, criticality, watchlist membership, or detection-driven signals **derived from the tools** (this replaces live ML anomaly charts when those are not available).
+   - \`entities\`: array of row objects \`{ entity_type, entity_id, entity_name?, source?, risk_score_norm?, risk_level?, criticality?, first_seen?, last_seen? }\`. Order by the importance you describe in prose. \`last_seen\` is the entity store record's top-level \`@timestamp\` (always present); do not use \`entity.lifecycle.last_activity\` because that field can be absent for freshly upserted entities. May be empty only when the user asked purely for KPI-style framing and you still supply \`severity_count\` and/or highlights.
+3. In your **markdown message**, on its own line (with a BLANK LINE before and after), assemble the tag by substituting the \`id\` and \`current_version\` fields from the \`attachments.add\` result VERBATIM into this exact template:
+
+   \`<render_attachment id="<id from attachments.add>" version="<current_version from attachments.add>" />\`
+
+   Copy those two values byte-for-byte from the tool result. Never invent an id, never derive it from \`attachmentLabel\`, \`summary\`, or any entity name. \`attachments.add\` does NOT return a \`renderTag\`, so for this path you use the template above — do not try to copy a \`renderTag\` that is not there.
+4. The UI shows an **inline** pill and **Preview → Canvas** with the same two-column **risk / highlights** layout as the product home page — **only** with the tag from step 3.
+5. Still write a concise narrative in the message; use the attachment for the structured dashboard view and deep investigation via **Open Entity Analytics in Security**.
+6. If the underlying \`security.search_entities\` also emitted an aggregate \`security.entity\` attachment (2+ entities), you **must render both** tags in the same turn — the entities table and the dashboard snapshot are complementary. Render the table by copying the \`renderTag\` from the \`search_entities\` \`other\` result verbatim, and render the dashboard using the \`attachments.add\` template above. Rendering only the \`security.entity\` table while claiming in prose that it is the Entity Analytics dashboard is **incorrect**.
 
 ## Examples
 
@@ -126,38 +320,121 @@ if 10 entities are found using \`security.search_entities\`, you MUST call \`sec
 User query: Which users have the highest risk scores?
 
 Steps:
-1. Use the 'security.search_entities' tool to get the top N users sorted by their normalized risk scores.
-2. For each user, use the 'security.get_entity' tool to get their full profile. If 10 entities are returned, you MUST call the 'security.get_entity' tool 10 times to get each user's profile.
-3. Present the results in a table format showing entity ID, risk score, risk level, asset criticality level and any watchlists they belong to.
+1. Use \`security.search_entities\` to get the top N users sorted by their normalized risk scores. When 2+ users are returned the tool emits an aggregate \`security.entity\` attachment.
+2. Optionally use \`security.get_entity\` for specific rows when you need richer context for prose callouts.
+3. Copy the \`renderTag\` string verbatim from the \`search_entities\` \`other\` result onto its own line — the renderer shows the entities table Canvas.
+4. Write a short narrative calling out the highest-risk users, biggest criticality gaps, and suggested follow-ups.
 
 ### Example 2: Risk Score Changes Over Time
 
 User query: Who has had the biggest increase in risk score over the last 90 days?
 
 Steps:
-1. Use the 'security.search_entities' tool with a riskScoreChangeInterval of '90d' to find entities with risk score changes.
-2. Analyze the results and identify which entities have had significant (greater than ${ENTITY_RISK_SCORE_SIGNIFICANT_CHANGE_THRESHOLD} score change)
-   increases in risk score.
-3. For each entity with significant risk score change, use the 'security.get_entity' tool with an interval of '90d' to get their full profile history.
-4. Present the findings in a table format showing entity ID, previous risk score, current risk score, risk score change, and a summary of how their risk score has changed over the interval.
+1. Use \`security.search_entities\` with a riskScoreChangeInterval of '90d' to find entities with risk score changes.
+2. Analyze the results and identify which entities have had significant (greater than ${ENTITY_RISK_SCORE_SIGNIFICANT_CHANGE_THRESHOLD} score change) increases in risk score.
+3. For each entity with significant risk score change, use \`security.get_entity\` with an interval of '90d' to get their full profile history.
+4. Copy the \`renderTag\` string verbatim from the \`search_entities\` \`other\` result onto its own line (entities table Canvas) and summarize in prose the previous vs current risk scores, the magnitude of change, and the drivers.
 
 ### Example 3: High Impact Assets
 
 User query: What are the riskiest hosts in my environment that are high impact?
 
 Steps:
-1. Use the 'security.search_entities' tool to get the top N hosts sorted by their normalized risk scores, using parameter
-criticalityLevels: ['high_impact', 'extreme_impact'] to filter for high impact.
-2. Present the results in a table format showing entity ID, risk score, risk level, and asset criticality level
+1. Use \`security.search_entities\` to get the top N hosts sorted by their normalized risk scores, using parameter \`criticalityLevels: ['high_impact', 'extreme_impact']\` to filter for high impact.
+2. Copy the \`renderTag\` string verbatim from the \`search_entities\` \`other\` result onto its own line so the user gets the entities table Canvas.
+3. Summarize in prose the riskiest hosts and why their criticality matters.
+
+### Example 3b: Top N Entities By Criticality
+
+User query: List the top 5 entities by criticality.
+
+Steps:
+1. Use \`security.search_entities\` with \`sortBy: 'criticality'\` and \`maxResults: 5\`. Do NOT pass \`criticalityLevels\` — the user did not restrict the levels, they asked for a ranking across all of them. (Stuffing all four levels into \`criticalityLevels\` is a no-op filter and would leave the tool sorting by risk score, which is NOT what the user asked for.)
+2. Copy the \`renderTag\` string verbatim from the \`search_entities\` \`other\` result onto its own line so the user gets the entities table Canvas — the rows will come back ordered extreme_impact → high_impact → medium_impact → low_impact, with risk score as the tiebreaker within each tier.
+3. In prose, call out which criticality tiers are represented in the top N and the riskiest entity inside the highest tier; recommend follow-ups for the extreme_impact rows first.
 
 ### Example 4: Risk Score History
 
 User query: Has Cielo39's risk score changed significantly?
 
 Steps:
-1. Use the 'security.get_entity' tool with an interval of '30d' to fetch Cielo39's current profile and profile_history for the last 30 days
-2. Analyze the risk scores in the profile history along with the current risk score to determine if the change in risk score is significant (e.g., greater than ${ENTITY_RISK_SCORE_SIGNIFICANT_CHANGE_THRESHOLD} points).
-3. Summarize the trends in risk score changes (stable, increasing, decreasing) and present findings in a concise format showing the previous risk scores, current risk score, and whether the change is significant.
+1. Use \`security.get_entity\` with an interval of '30d' to fetch Cielo39's current profile and profile_history for the last 30 days.
+2. Copy the \`renderTag\` string verbatim from the \`get_entity\` \`other\` result onto its own line so the user sees the entity card — that card is the profile view.
+3. Analyze the risk scores in the profile history along with the current risk score to determine if the change in risk score is significant (e.g., greater than ${ENTITY_RISK_SCORE_SIGNIFICANT_CHANGE_THRESHOLD} points).
+4. Summarize in 1–3 sentences of prose: the overall trend (stable / increasing / decreasing), whether the change crosses the significance threshold, and what to investigate next. Do NOT re-list the entity's fields as an "Entity Overview" markdown block — the entity card already shows them.
+
+### Example 5a: Users From a Specific Vendor (namespace-first)
+
+User query: Who are my riskiest AWS users?
+
+Steps:
+1. The query is about **user** entities and AWS has a canonical namespace (pass-through), so try the normalized field first: \`security.search_entities\` with \`entityTypes: ['user']\` and \`namespaces: ['aws']\`. Do NOT set \`riskScoreMin\` — the user did not give a numeric floor, and the tool defaults to sorting by risk score descending.
+2. **If step 1 returns zero rows**, retry with \`sources: ['aws']\` (exact-or-prefix matching also covers \`aws.cloudtrail\`, \`aws.guardduty\`, \`aws.s3access\`, etc.) — do NOT fan out into \`['aws', 'aws.cloudtrail', 'aws.guardduty']\`.
+3. When 2+ entities are returned, render the inline aggregate \`security.entity\` attachment (see "Inline rendering" rules) instead of repeating a markdown table.
+4. In the prose, name the vendor the user filtered on (e.g. "6 AWS users scored above 70") and call out the riskiest entries the user may want to investigate. If both attempts returned zero, report "no matching entities" per the fallback in Investigation Step 1.
+
+### Example 5b: Hosts From a Specific Data Source (sources-only)
+
+User query: Can I get all hosts coming from CrowdStrike?
+
+Steps:
+1. Host entities have no \`entity.namespace\`, and CrowdStrike has no canonical namespace anyway — so skip \`namespaces\` and use \`security.search_entities\` with \`entityTypes: ['host']\` and \`sources: ['crowdstrike']\`. Exact-or-prefix matching covers both \`crowdstrike\` and any \`crowdstrike.*\` dataset variants. Use the raw lowercase integration key, never a pretty-printed label (so \`island_browser\`, not \`Island Browser\`).
+2. When 2+ entities are returned, render the inline aggregate \`security.entity\` attachment (see "Inline rendering" rules) instead of repeating the markdown table.
+3. In the prose, name the data source the user filtered on (e.g. "9 hosts are sourced from CrowdStrike") and call out the riskiest entries the user may want to investigate.
+
+### Example 6: Single-entity card for the riskiest host
+
+User query: Show me the entity card for the most risky host.
+
+Steps:
+1. Use \`security.search_entities\` with \`entityTypes: ["host"]\`, sort implicitly by risk (tool returns highest risk first), and \`maxResults: 1\`.
+2. Use \`security.get_entity\` for that host's EUID — this emits a single-entity \`security.entity\` attachment that renders as the entity card.
+3. Copy the \`renderTag\` string verbatim from \`get_entity\`'s \`other\` result onto its own line in your reply. Skip the render tag on the \`search_entities\` result — the follow-up \`get_entity\` bumps the same attachment pill with the richer card payload, so rendering both would duplicate the pill.
+4. Summarize in prose why this host is the riskiest among hosts in scope.
+
+### Example 7: "Details / profile" vs "List / compare" wording
+
+- User: "**Details** on the riskiest host", "**more about** that host", "**profile** / **deep dive** for this user" → treat like Example 6: one winner, \`security.get_entity\` emits the single-entity card. Render the tag from \`get_entity\`.
+- User: "**List** the **five** riskiest hosts", "**compare** these hosts", "**who are** the riskiest users", "**show** risky **hosts**" → \`security.search_entities\` with matching \`maxResults\`; the tool emits the aggregate \`security.entity\` attachment (entities table) when 2+ rows are returned. Render the tag from \`search_entities\`.
+
+### Example 8: List question with only one matching entity
+
+User query: List all critical-risk hosts in my tenant (filters are strict and only **one** host matches).
+
+Steps:
+1. Use \`security.search_entities\` with the requested filters. Only one entity comes back.
+2. Use \`security.get_entity\` for that single host — this bumps the same attachment's version with the richer card payload, so the user sees one pill (not two) in the conversation.
+3. Copy the \`renderTag\` string verbatim from the \`get_entity\` \`other\` result onto its own line. Skip the render tag on the \`search_entities\` result to avoid duplicating the pill. The single-entity card is the correct Canvas for a one-row list.
+
+### Example 9: "Riskiest entities in the system" (generic plural)
+
+User query: Show the riskiest entities in the system.
+
+Steps:
+1. Use \`security.search_entities\` with \`entityTypes\` spanning the kinds you will rank (e.g. \`["host","user","service"]\`) or aligned with the user's scope, \`maxResults\` per investigation norms, ordered by risk.
+2. Copy the \`renderTag\` string verbatim from the \`search_entities\` \`other\` result onto its own line (entities table Canvas). **Do not** add \`security.entity_analytics_dashboard\` — the user did **not** ask to open the **Entity Analytics home/overview** page by name.
+3. In prose, highlight the top riskiest entities and recommend follow-ups.
+
+### Example 10: Riskiest hosts **and** users (multi-type, one message)
+
+User query: Show me the most riskiest hosts and users in my system.
+
+Steps:
+1. Use \`security.search_entities\` with \`entityTypes: ["host", "user"]\` (or run one call per type when the user wants explicit parity) and \`maxResults\` for how many rows to show. Omit \`riskScoreMin\` — the user did not specify a numeric floor, and the tool defaults to sorting by risk score descending.
+2. Copy the \`renderTag\` string verbatim from the \`search_entities\` \`other\` result onto its own line — the entities table Canvas handles the mixed host/user list.
+3. In prose, summarize the highest-risk entities of each type.
+
+### Example 11: Entity Analytics dashboard / home page
+
+User query: Show me the Entity Analytics dashboard.
+
+Steps:
+1. Use \`security.search_entities\` to gather a representative sample of entities (and optionally \`security.get_entity\` for highlights you want to call out).
+2. Call \`attachments.add\` with \`type\` \`security.entity_analytics_dashboard\` and populate \`severity_count\`, \`anomaly_highlights\`, and \`entities\` from the tool outputs (see "Entity Analytics dashboard snapshot").
+3. Take the \`id\` and \`current_version\` from the \`attachments.add\` result and substitute them VERBATIM into \`<render_attachment id="<id>" version="<current_version>" />\`; output that on its own line in the reply so the user sees the dashboard Canvas.
+4. You may **also** render the aggregate \`security.entity\` tag from \`search_entities\` in the same turn — copy the \`renderTag\` string verbatim from its \`other\` result. The entities table and the dashboard snapshot are complementary views.
+
+**Common mistake:** rendering only the \`security.entity\` entities table (titled e.g. "Top 10 Riskiest Users") and claiming in prose that it is the Entity Analytics dashboard. That is **wrong** — always render the \`security.entity_analytics_dashboard\` tag from \`attachments.add\` (and optionally the \`security.entity\` tag as a complement) when the user's prompt matches the "Dashboard trigger" phrases.
 
 ## Best Practices
 - Always use \`calculated_score_norm\` (0-100) when reporting risk scores
@@ -167,6 +444,8 @@ Steps:
 - Higher scores indicate greater risk to the organization
 - A change in risk score greater than ${ENTITY_RISK_SCORE_SIGNIFICANT_CHANGE_THRESHOLD} points over an interval is considered significant
 - An entity is considered high impact if its criticality level is "high_impact" or "extreme_impact"
+- Data source values (\`entity.source\`) are lowercase integration keys (e.g. \`crowdstrike\`, \`island_browser\`, \`aws\`, \`aws.cloudtrail\`, \`entityanalytics_okta\`). The inline table renders them title-cased for display, but you MUST always filter using the raw key when calling \`security.search_entities\`. The \`sources\` parameter matches exactly or as a \`<value>.*\` prefix, so a single vendor key (e.g. \`['aws']\`) covers its dataset variants — do not fan out into \`['aws', 'aws.cloudtrail']\`.
+- Normalized user namespaces (\`entity.namespace\`) are canonical values: \`okta\`, \`entra_id\`, \`microsoft_365\`, \`active_directory\`, \`local\`, \`unknown\`, or pass-through of \`event.module\` (e.g. \`aws\`, \`gcp\`). Use the \`namespaces\` parameter only for **user** entities; prefer it over \`sources\` when a canonical namespace exists, and fall back to \`sources\` when the namespace search returns zero rows or the vendor has no canonical namespace. See the "Vendor source cheat sheet".
 - Document your analysis process and reasoning clearly
 - Avoid listing noisy raw data; highlight the most relevant signals
 - Offer a short explanation of why a risk score is considered high or low
@@ -174,17 +453,6 @@ Steps:
   - Investigate relevant alerts contributing to risk score
   - Investigate external activities and movement for risky user entities
   - Investigating vulnerabilities and exposures for risky host and service entities
-
-## Response formats
-
-### Top N entities
-Provide a short table with the key fields:
-
-| Entity | Type | Risk score (0-100) | Risk level | Criticality |
-| --- | --- | --- | --- | --- |
-| <id_value> | <entity_type> | <calculated_score_norm> | <calculated_level> | <criticality_level or "unknown"> |
-
-Then add 1-2 bullets with key observations (e.g., highest criticality, biggest score gap, which entities to investigate further).
 `;
 
 const legacyContent = `
@@ -283,10 +551,10 @@ export const getEntityAnalyticsSkill = (ctx: EntityAnalyticsSkillsContext) =>
     id: 'entity-analytics',
     name: 'entity-analytics',
     basePath: 'skills/security/entities',
-    description: `Guide to finding and investigating security entities (hosts, users, services, generic).
-      Analyze how an entity's risk score, criticality, behaviors and attributes have changed over time (e.g. last 90 days).
-      Analyze how alerts contribute to an entity's risk score.
-      Discover risky entities based on risk score, risk level, criticality level, watchlists, access behaviors, privilege attributes.`,
+    description:
+      'Security entity investigations (hosts, users, services, generic): entity store search/get_entity, risk and criticality. ' +
+      'Rich attachments: `security.entity` (emitted automatically by search_entities/get_entity — renders as a single-entity card for 1 entity and as an entities table for 2+ entities); `security.entity_analytics_dashboard` (explicit attachments.add — only when the user asks to show/open/view the Entity Analytics home/overview product page). After each tool result that emits a rich attachment, output `<render_attachment id=… version=… />` in markdown (required for Preview/Canvas UI). ' +
+      'Risk history, alert contributions, watchlists, behaviors, discovering risky entities.',
     content: `
 # Entity Analysis Guide
 

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/entity_analytics/entity_attachment_utils.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/entity_analytics/entity_attachment_utils.test.ts
@@ -1,0 +1,253 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  ATTACHMENT_IDENTIFIER_TYPES,
+  buildListEntityAttachmentId,
+  buildRenderAttachmentTag,
+  buildSingleEntityAttachmentId,
+  describeAttachmentForRow,
+  ENTITY_STORE_ENTITY_ID_FIELD,
+  ENTITY_STORE_ENTITY_NAME_FIELD,
+  ENTITY_STORE_ENTITY_TYPE_FIELD,
+  type AttachmentIdentifierType,
+} from './entity_attachment_utils';
+import { SecurityAgentBuilderAttachments } from '../../../../common/constants';
+
+describe('buildSingleEntityAttachmentId', () => {
+  it('produces an id with the expected prefix and a 64-char hex hash', () => {
+    const id = buildSingleEntityAttachmentId('user', 'lena.medhurst@acmecrm.com');
+    expect(id).toMatch(new RegExp(`^${SecurityAgentBuilderAttachments.entity}:user:[a-f0-9]{64}$`));
+  });
+
+  it('is deterministic for the same (type, identifier) pair', () => {
+    const a = buildSingleEntityAttachmentId('user', 'lena.medhurst@acmecrm.com');
+    const b = buildSingleEntityAttachmentId('user', 'lena.medhurst@acmecrm.com');
+    expect(a).toBe(b);
+  });
+
+  it('produces different ids for different identifier types', () => {
+    const userId = buildSingleEntityAttachmentId('user', 'same-identifier');
+    const hostId = buildSingleEntityAttachmentId('host', 'same-identifier');
+    expect(userId).not.toBe(hostId);
+  });
+
+  it('produces different ids for different identifier values', () => {
+    const a = buildSingleEntityAttachmentId('user', 'alice');
+    const b = buildSingleEntityAttachmentId('user', 'bob');
+    expect(a).not.toBe(b);
+  });
+
+  it.each(ATTACHMENT_IDENTIFIER_TYPES)(
+    'contains no autolink-triggering characters after the type prefix for type %s',
+    (identifierType: AttachmentIdentifierType) => {
+      const id = buildSingleEntityAttachmentId(identifierType, 'lena.medhurst@acmecrm.com');
+      const suffix = id.slice(
+        `${SecurityAgentBuilderAttachments.entity}:${identifierType}:`.length
+      );
+      expect(suffix).toMatch(/^[a-f0-9]{64}$/);
+      expect(suffix).not.toMatch(/[@.:/]/);
+    }
+  );
+});
+
+describe('buildListEntityAttachmentId', () => {
+  it('produces an id with the expected prefix and a 64-char hex hash', () => {
+    const id = buildListEntityAttachmentId([
+      { identifierType: 'user', identifier: 'alice' },
+      { identifierType: 'host', identifier: 'server1' },
+    ]);
+    expect(id).toMatch(new RegExp(`^${SecurityAgentBuilderAttachments.entity}:list:[a-f0-9]{64}$`));
+  });
+
+  it('is stable regardless of entity ordering', () => {
+    const a = buildListEntityAttachmentId([
+      { identifierType: 'user', identifier: 'alice' },
+      { identifierType: 'host', identifier: 'server1' },
+    ]);
+    const b = buildListEntityAttachmentId([
+      { identifierType: 'host', identifier: 'server1' },
+      { identifierType: 'user', identifier: 'alice' },
+    ]);
+    expect(a).toBe(b);
+  });
+});
+
+describe('buildRenderAttachmentTag', () => {
+  it('returns a <render_attachment> tag with the id and version attributes the platform parser expects', () => {
+    const attachmentId = buildSingleEntityAttachmentId('user', 'lena.medhurst@acmecrm.com');
+    const tag = buildRenderAttachmentTag({ attachmentId, version: 1 });
+    expect(tag).toBe(`<render_attachment id="${attachmentId}" version="1" />`);
+  });
+
+  it('uses the platform `id` attribute, not the legacy `attachment_id`', () => {
+    // Guards the previous bug where entity.ts agent description used
+    // `attachment_id="..."`, which the platform markdown parser ignores.
+    const tag = buildRenderAttachmentTag({
+      attachmentId: buildSingleEntityAttachmentId('host', 'server-1'),
+      version: 2,
+    });
+    expect(tag).toContain(' id="');
+    expect(tag).toContain(' version="2"');
+    expect(tag).not.toContain('attachment_id=');
+  });
+
+  it('does not contain autolink-triggering characters for any entity identifier type', () => {
+    // `@`, `.`, `/`, whitespace all break the upstream HTML tokenizer in
+    // remark-parse-no-trim because the inline autolink / email tokenizers
+    // fire before the HTML tokenizer and shatter the tag across AST nodes.
+    // The hash guarantee is what keeps buildRenderAttachmentTag safe.
+    ATTACHMENT_IDENTIFIER_TYPES.forEach((identifierType: AttachmentIdentifierType) => {
+      const attachmentId = buildSingleEntityAttachmentId(
+        identifierType,
+        'lena.medhurst@acmecrm.com'
+      );
+      const tag = buildRenderAttachmentTag({ attachmentId, version: 3 });
+      const attrValueMatch = tag.match(/ id="([^"]+)"/);
+      expect(attrValueMatch).not.toBeNull();
+      const idInTag = attrValueMatch![1];
+      expect(idInTag).toMatch(/^[a-z0-9:.]+$/);
+      expect(idInTag).not.toMatch(/[@\s<>/]/);
+    });
+  });
+
+  it('throws when given an unsafe attachmentId (hash bypass regression)', () => {
+    // If a future refactor emits an unhashed id, the interpolation inside
+    // buildRenderAttachmentTag would pass `@` or `.` through and re-trigger
+    // the original "render_attachment renders as literal text" bug. This
+    // test locks the runtime guard so a regression fails loudly at the
+    // source, not silently at the markdown parser.
+    expect(() =>
+      buildRenderAttachmentTag({
+        attachmentId: 'security.entity:user:james.barton@acmecrm.com',
+        version: 1,
+      })
+    ).toThrow(/unsafe attachmentId/);
+    expect(() =>
+      buildRenderAttachmentTag({
+        attachmentId: 'security.entity:user:foo bar',
+        version: 1,
+      })
+    ).toThrow(/unsafe attachmentId/);
+    expect(() =>
+      buildRenderAttachmentTag({
+        attachmentId: 'security.entity:user:<script>',
+        version: 1,
+      })
+    ).toThrow(/unsafe attachmentId/);
+  });
+
+  it('accepts hashed ids produced by buildListEntityAttachmentId', () => {
+    const attachmentId = buildListEntityAttachmentId([
+      { identifierType: 'user', identifier: 'lena.medhurst@acmecrm.com' },
+      { identifierType: 'host', identifier: 'LAPTOP-SALES04' },
+    ]);
+    expect(() => buildRenderAttachmentTag({ attachmentId, version: 1 })).not.toThrow();
+    expect(buildRenderAttachmentTag({ attachmentId, version: 7 })).toBe(
+      `<render_attachment id="${attachmentId}" version="7" />`
+    );
+  });
+});
+
+describe('render-tag-safe attachment id regression', () => {
+  // Locks the invariant that buildRenderAttachmentTag's safe-interpolation
+  // depends on: every id emitted by either id-builder must match
+  // `security.entity:<type>:<64 hex>` and must NOT contain `@` or any other
+  // character the upstream HTML tokenizer treats specially.
+  const EMAIL_LIKE_INPUTS = [
+    'james.barton@acmecrm.com',
+    "Lena Medhurst@Lena's MacBook Pro",
+    'local user@local',
+    'https://evil.example/path',
+    '<script>alert(1)</script>',
+  ];
+
+  it.each(ATTACHMENT_IDENTIFIER_TYPES)(
+    'buildSingleEntityAttachmentId hides email-shaped identifiers behind a hex hash for type %s',
+    (identifierType: AttachmentIdentifierType) => {
+      EMAIL_LIKE_INPUTS.forEach((input) => {
+        const id = buildSingleEntityAttachmentId(identifierType, input);
+        expect(id).toMatch(
+          new RegExp(`^${SecurityAgentBuilderAttachments.entity}:${identifierType}:[a-f0-9]{64}$`)
+        );
+        expect(id).not.toContain('@');
+        expect(id).not.toMatch(/\s/);
+      });
+    }
+  );
+
+  it('buildListEntityAttachmentId hides email-shaped identifiers behind a hex hash', () => {
+    const id = buildListEntityAttachmentId([
+      { identifierType: 'user', identifier: 'james.barton@acmecrm.com' },
+      { identifierType: 'host', identifier: 'LAPTOP-SALES04@corp' },
+    ]);
+    expect(id).toMatch(new RegExp(`^${SecurityAgentBuilderAttachments.entity}:list:[a-f0-9]{64}$`));
+    expect(id).not.toContain('@');
+    expect(id).not.toMatch(/\s/);
+  });
+});
+
+describe('describeAttachmentForRow', () => {
+  const columns = [
+    { name: ENTITY_STORE_ENTITY_TYPE_FIELD },
+    { name: ENTITY_STORE_ENTITY_ID_FIELD },
+    { name: ENTITY_STORE_ENTITY_NAME_FIELD },
+  ];
+
+  it('includes the raw entity.id as entityStoreId when present', () => {
+    const row = [
+      'user',
+      "user:Lena Medhurst@Lena's MacBook Pro@local",
+      "Lena Medhurst@Lena's MacBook Pro",
+    ];
+    const descriptor = describeAttachmentForRow({ columns, row });
+    expect(descriptor).toEqual({
+      identifierType: 'user',
+      identifier: "Lena Medhurst@Lena's MacBook Pro",
+      attachmentLabel: "user: Lena Medhurst@Lena's MacBook Pro",
+      entityStoreId: "user:Lena Medhurst@Lena's MacBook Pro@local",
+    });
+  });
+
+  it('omits entityStoreId when entity.id is missing from the row', () => {
+    const row = ['host', null, 'LAPTOP-SALES04'];
+    const descriptor = describeAttachmentForRow({ columns, row });
+    expect(descriptor).toEqual({
+      identifierType: 'host',
+      identifier: 'LAPTOP-SALES04',
+      attachmentLabel: 'host: LAPTOP-SALES04',
+    });
+    expect(descriptor).not.toHaveProperty('entityStoreId');
+  });
+
+  it('omits entityStoreId when entity.id is an empty string', () => {
+    const row = ['host', '', 'LAPTOP-SALES04'];
+    const descriptor = describeAttachmentForRow({ columns, row });
+    expect(descriptor).not.toHaveProperty('entityStoreId');
+  });
+
+  it('falls back to the stripped entity.id for the identifier when entity.name is missing', () => {
+    const row = ['host', 'host:LAPTOP-SALES04', null];
+    const descriptor = describeAttachmentForRow({ columns, row });
+    expect(descriptor).toEqual({
+      identifierType: 'host',
+      identifier: 'LAPTOP-SALES04',
+      attachmentLabel: 'host: LAPTOP-SALES04',
+      entityStoreId: 'host:LAPTOP-SALES04',
+    });
+  });
+
+  it('returns null when the entity type cell is not a known identifier type', () => {
+    const row = ['unknown', 'whatever:x', 'whatever'];
+    expect(describeAttachmentForRow({ columns, row })).toBeNull();
+  });
+
+  it('returns null when neither entity.name nor entity.id yield an identifier', () => {
+    const row = ['user', null, null];
+    expect(describeAttachmentForRow({ columns, row })).toBeNull();
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/entity_analytics/entity_attachment_utils.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/entity_analytics/entity_attachment_utils.ts
@@ -1,0 +1,337 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createHash } from 'crypto';
+import type { Logger } from '@kbn/logging';
+import type { AttachmentStateManager } from '@kbn/agent-builder-server/attachments';
+import { renderAttachmentElement } from '@kbn/agent-builder-common/tools/custom_rendering';
+import type { EntityRiskScoreRecord } from '../../../../common/api/entity_analytics/common';
+import { SecurityAgentBuilderAttachments } from '../../../../common/constants';
+
+export const ENTITY_STORE_ENTITY_TYPE_FIELD = 'entity.EngineMetadata.Type';
+export const ENTITY_STORE_ENTITY_ID_FIELD = 'entity.id';
+export const ENTITY_STORE_ENTITY_NAME_FIELD = 'entity.name';
+
+export const ATTACHMENT_IDENTIFIER_TYPES = ['host', 'user', 'service', 'generic'] as const;
+export type AttachmentIdentifierType = (typeof ATTACHMENT_IDENTIFIER_TYPES)[number];
+
+export const isAttachmentIdentifierType = (value: unknown): value is AttachmentIdentifierType =>
+  typeof value === 'string' && (ATTACHMENT_IDENTIFIER_TYPES as readonly string[]).includes(value);
+
+/**
+ * Strips the `{type}:` prefix from a canonical entity id so the attachment
+ * receives the bare identity value the rich renderer expects (host.name,
+ * user.name, service.name). For `generic` entities we keep the full id because
+ * those records are matched on `entity.id` directly.
+ */
+export const stripEntityIdPrefix = (
+  entityId: string,
+  identifierType: AttachmentIdentifierType
+): string => {
+  if (identifierType === 'generic') {
+    return entityId;
+  }
+  const prefix = `${identifierType}:`;
+  return entityId.startsWith(prefix) ? entityId.slice(prefix.length) : entityId;
+};
+
+/**
+ * Fields we keep from `EntityRiskScoreRecord` when embedding a risk doc on
+ * an entity attachment. We drop the heavy `inputs`, `related_entities`, and
+ * `calculation_run_id` fields because the chat card's `RiskSummaryMini` only
+ * needs the score/category/modifier/criticality breakdown to render, and
+ * those extra fields can be megabytes in size.
+ */
+export type EntityAttachmentRiskStats = Pick<
+  EntityRiskScoreRecord,
+  | '@timestamp'
+  | 'id_field'
+  | 'id_value'
+  | 'calculated_level'
+  | 'calculated_score'
+  | 'calculated_score_norm'
+  | 'category_1_score'
+  | 'category_1_count'
+  | 'category_2_score'
+  | 'category_2_count'
+  | 'notes'
+  | 'criticality_modifier'
+  | 'criticality_level'
+  | 'modifiers'
+  | 'score_type'
+>;
+
+/**
+ * Optional enrichment bits the tool can layer onto an attachment descriptor
+ * after running side queries (risk index, resolution group). Split out from
+ * `EntityAttachmentDescriptor` so the pure row-to-identifier extractor stays
+ * free of side-effectful fetches.
+ */
+export interface EntityAttachmentEnrichment {
+  riskStats?: EntityAttachmentRiskStats;
+  resolutionRiskStats?: EntityAttachmentRiskStats;
+}
+
+export interface EntityAttachmentDescriptor {
+  identifierType: AttachmentIdentifierType;
+  identifier: string;
+  attachmentLabel: string;
+  /**
+   * Canonical `entity.id` from the entity store row (e.g.
+   * `user:name@host@namespace`), carried verbatim onto the attachment so the
+   * rich renderer can filter the store by `entity.id` directly. Required to
+   * resolve local users where `entity.name` is a composite and does not match
+   * `user.name`. Absent only when the underlying row did not project
+   * `entity.id` (older snapshots / custom queries).
+   */
+  entityStoreId?: string;
+  /**
+   * Full risk breakdown (category scores/counts, modifiers, criticality)
+   * embedded on the attachment so the chat card's risk summary table can
+   * render without spinning up a Redux-backed search-strategy call on the
+   * client. See `stripRiskRecordForAttachment` for the exact projection.
+   */
+  riskStats?: EntityAttachmentRiskStats;
+  /**
+   * Resolution-group risk breakdown (only populated when the entity is part
+   * of a resolution group with more than one member). Feeds the "Resolution
+   * group risk score" block in the chat card.
+   */
+  resolutionRiskStats?: EntityAttachmentRiskStats;
+}
+
+/**
+ * Returns a minimal risk-doc projection suitable for embedding in an entity
+ * attachment payload. Returns `undefined` when the record is missing so
+ * callers can drop the field entirely instead of embedding `null`s.
+ */
+export const stripRiskRecordForAttachment = (
+  record: EntityRiskScoreRecord | undefined
+): EntityAttachmentRiskStats | undefined => {
+  if (!record) {
+    return undefined;
+  }
+
+  return {
+    '@timestamp': record['@timestamp'],
+    id_field: record.id_field,
+    id_value: record.id_value,
+    calculated_level: record.calculated_level,
+    calculated_score: record.calculated_score,
+    calculated_score_norm: record.calculated_score_norm,
+    category_1_score: record.category_1_score,
+    category_1_count: record.category_1_count,
+    ...(record.category_2_score !== undefined ? { category_2_score: record.category_2_score } : {}),
+    ...(record.category_2_count !== undefined ? { category_2_count: record.category_2_count } : {}),
+    notes: record.notes,
+    ...(record.criticality_modifier !== undefined
+      ? { criticality_modifier: record.criticality_modifier }
+      : {}),
+    ...(record.criticality_level !== undefined
+      ? { criticality_level: record.criticality_level }
+      : {}),
+    ...(record.modifiers !== undefined ? { modifiers: record.modifiers } : {}),
+    ...(record.score_type !== undefined ? { score_type: record.score_type } : {}),
+  };
+};
+
+export const getRowValue = (
+  columns: Array<{ name: string }>,
+  row: unknown[],
+  columnName: string
+): unknown => {
+  const idx = columns.findIndex((col) => col.name === columnName);
+  return idx >= 0 ? row[idx] : undefined;
+};
+
+/**
+ * Derives the attachment payload from a resolved entity row. Returns `null`
+ * when we cannot extract a trustworthy identifier (e.g. missing type) so the
+ * caller can skip the attachment side-effect instead of emitting garbage.
+ *
+ * The optional `enrichment` argument lets callers fold in async-fetched
+ * extras (risk stats, resolution stats) without re-walking `columns`.
+ * Kept optional so existing call sites — and the row-only unit tests —
+ * don't need to supply enrichment when they only care about identity.
+ */
+export const describeAttachmentForRow = ({
+  columns,
+  row,
+  enrichment,
+}: {
+  columns: Array<{ name: string }>;
+  row: unknown[];
+  enrichment?: EntityAttachmentEnrichment;
+}): EntityAttachmentDescriptor | null => {
+  const rawType = getRowValue(columns, row, ENTITY_STORE_ENTITY_TYPE_FIELD);
+  if (!isAttachmentIdentifierType(rawType)) {
+    return null;
+  }
+
+  const rawId = getRowValue(columns, row, ENTITY_STORE_ENTITY_ID_FIELD);
+  const rawName = getRowValue(columns, row, ENTITY_STORE_ENTITY_NAME_FIELD);
+
+  const entityStoreId = typeof rawId === 'string' && rawId.length > 0 ? rawId : undefined;
+  const bareFromId = entityStoreId ? stripEntityIdPrefix(entityStoreId, rawType) : undefined;
+  const bareName = typeof rawName === 'string' && rawName.length > 0 ? rawName : undefined;
+
+  const identifier = bareName ?? bareFromId;
+  if (!identifier) {
+    return null;
+  }
+
+  return {
+    identifierType: rawType,
+    identifier,
+    attachmentLabel: `${rawType}: ${identifier}`,
+    ...(entityStoreId ? { entityStoreId } : {}),
+    ...(enrichment?.riskStats ? { riskStats: enrichment.riskStats } : {}),
+    ...(enrichment?.resolutionRiskStats
+      ? { resolutionRiskStats: enrichment.resolutionRiskStats }
+      : {}),
+  };
+};
+
+/**
+ * Builds the deterministic attachment id used for a single-entity
+ * `security.entity` attachment. Matches the scheme used by
+ * `security.get_entity` so a later call for the same entity bumps the shared
+ * attachment version rather than creating a new record.
+ *
+ * We hash the identifier because agent_builder's markdown pipeline
+ * (remark-parse-no-trim + createTagParser in
+ * x-pack/platform/plugins/shared/agent_builder/public/application/components/
+ * conversations/conversation_rounds/round_response/markdown_plugins/utils.ts)
+ * cannot recognise `<render_attachment id="..." />` when the id contains
+ * characters that trigger inline autolinking (e.g. `@` in user ids auto-links
+ * to `mailto:`). When that happens the tag is shattered across multiple AST
+ * nodes and is rendered as literal text instead of as the rich attachment.
+ * Hashing produces a pure hex id that is safe for inline placement. Remove
+ * once the upstream parser recognises `<render_attachment>` as an HTML tag
+ * and no longer depends on autolink-safe ids.
+ */
+export const buildSingleEntityAttachmentId = (
+  identifierType: AttachmentIdentifierType,
+  identifier: string
+): string => {
+  const hash = createHash('sha256').update(`${identifierType}:${identifier}`).digest('hex');
+  return `${SecurityAgentBuilderAttachments.entity}:${identifierType}:${hash}`;
+};
+
+/**
+ * Builds a deterministic attachment id for a multi-entity search result. The
+ * hash is derived from the sorted `"{type}:{identifier}"` pairs so two
+ * searches that surface the same cohort converge on the same attachment and
+ * `update` bumps the version instead of piling up new pills.
+ */
+export const buildListEntityAttachmentId = (
+  entities: Array<{ identifierType: AttachmentIdentifierType; identifier: string }>
+): string => {
+  const serialized = entities
+    .map((e) => `${e.identifierType}:${e.identifier}`)
+    .sort()
+    .join('\n');
+  const hash = createHash('sha256').update(serialized).digest('hex');
+  return `${SecurityAgentBuilderAttachments.entity}:list:${hash}`;
+};
+
+/**
+ * Any character outside this set risks triggering the upstream markdown
+ * autolinker / email tokenizer (they run before the HTML tokenizer in
+ * `remark-parse-no-trim` and shatter inline `<render_attachment>` tags
+ * whose `id` contains `@` or URL-shaped substrings). Our `buildSingle*` and
+ * `buildList*` helpers already emit `security.entity:<type>:<hex>`, which
+ * satisfies this pattern, so the regex is a belt-and-braces regression
+ * detector — not a substitute for hashing.
+ */
+const AUTOLINK_SAFE_ATTACHMENT_ID_PATTERN = /^[a-z0-9:.]+$/;
+
+/**
+ * Returns a pre-formatted `<render_attachment id="..." version="..." />`
+ * string the model can copy verbatim into its reply.
+ *
+ * Why pre-format server-side:
+ * - Asking the model to assemble the tag from `attachmentId` / `version`
+ *   has empirically produced hallucinated ids containing `@` or
+ *   email-shaped substrings, which the upstream markdown pipeline
+ *   shatters across multiple inline AST nodes (see the long comment on
+ *   `buildSingleEntityAttachmentId` for mechanics). A ready-made string
+ *   removes that degree of freedom.
+ * - Using `renderAttachmentElement.tagName` / `.attributes` (from the
+ *   platform common package) keeps this string in lockstep with whatever
+ *   the markdown parser expects, so a future rename on the platform side
+ *   does not silently desynchronise security-emitted tags.
+ *
+ * Callers MUST pass an id produced by `buildSingleEntityAttachmentId` or
+ * `buildListEntityAttachmentId`; the assertion below fires otherwise so
+ * a future refactor that bypasses hashing surfaces immediately instead
+ * of shipping a broken tag to the client.
+ */
+export const buildRenderAttachmentTag = ({
+  attachmentId,
+  version,
+}: {
+  attachmentId: string;
+  version: number;
+}): string => {
+  if (!AUTOLINK_SAFE_ATTACHMENT_ID_PATTERN.test(attachmentId)) {
+    throw new Error(
+      `buildRenderAttachmentTag received an unsafe attachmentId "${attachmentId}" — ` +
+        `expected a hashed id from buildSingleEntityAttachmentId / buildListEntityAttachmentId.`
+    );
+  }
+  const { tagName } = renderAttachmentElement;
+  const { attachmentId: idAttr, version: versionAttr } = renderAttachmentElement.attributes;
+  return `<${tagName} ${idAttr}="${attachmentId}" ${versionAttr}="${version}" />`;
+};
+
+/**
+ * Creates or refreshes a `security.entity` attachment with the provided id
+ * and data. Uses the deterministic id so repeated lookups in the same
+ * conversation bump the version instead of piling up pills. Failures are
+ * logged and swallowed — the tool result itself is still useful without the
+ * inline card.
+ */
+export const ensureEntityAttachment = async ({
+  attachments,
+  id,
+  data,
+  description,
+  logger,
+}: {
+  attachments: AttachmentStateManager;
+  id: string;
+  data: Record<string, unknown>;
+  description: string;
+  logger: Logger;
+}): Promise<{ attachmentId: string; version: number } | null> => {
+  try {
+    const existing = attachments.getAttachmentRecord(id);
+    if (existing) {
+      const updated = await attachments.update(id, { data, description });
+      if (!updated) {
+        return null;
+      }
+      return { attachmentId: updated.id, version: updated.current_version };
+    }
+
+    const created = await attachments.add({
+      id,
+      type: SecurityAgentBuilderAttachments.entity,
+      data,
+      description,
+    });
+    return { attachmentId: created.id, version: created.current_version };
+  } catch (error) {
+    logger.warn(
+      `Failed to persist security.entity attachment for ${id}: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    );
+    return null;
+  }
+};

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/entity_analytics/get_entity_tool.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/entity_analytics/get_entity_tool.test.ts
@@ -5,7 +5,12 @@
  * 2.0.
  */
 
-import { ToolResultType, type ErrorResult, type EsqlResults } from '@kbn/agent-builder-common';
+import {
+  ToolResultType,
+  type ErrorResult,
+  type EsqlResults,
+  type OtherResult,
+} from '@kbn/agent-builder-common';
 import { executeEsql } from '@kbn/agent-builder-genai-utils';
 import type { ToolHandlerStandardReturn } from '@kbn/agent-builder-server/tools';
 import type { coreMock } from '@kbn/core/server/mocks';
@@ -17,7 +22,10 @@ import {
   setupMockCoreStartServices,
 } from '../../__mocks__/test_helpers';
 import type { ExperimentalFeatures } from '../../../../common';
+import type { EntityRiskScoreRecord } from '../../../../common/api/entity_analytics/common';
+import { SecurityAgentBuilderAttachments } from '../../../../common/constants';
 import { ENTITY_ANALYTICS_AI_TOOL_USAGE_EVENT } from '../../../lib/telemetry/event_based/events';
+import { buildRenderAttachmentTag, buildSingleEntityAttachmentId } from './entity_attachment_utils';
 import { getEntityTool, SECURITY_GET_ENTITY_TOOL_ID } from './get_entity_tool';
 
 jest.mock('../../utils/get_agent_builder_resource_availability', () => ({
@@ -34,6 +42,16 @@ const mockExperimentalFeatures = {
   entityAnalyticsEntityStoreV2: true,
 } as ExperimentalFeatures;
 
+const buildEmptyRiskSearchResponse = () => ({
+  took: 1,
+  timed_out: false,
+  _shards: { total: 1, successful: 1, skipped: 0, failed: 0 },
+  hits: {
+    hits: [] as Array<{ _id: string; _index: string; _source: unknown }>,
+    total: { value: 0, relation: 'eq' as const },
+  },
+});
+
 describe('getEntityTool', () => {
   const { mockCore, mockLogger, mockEsClient, mockRequest } = createToolTestMocks();
   const tool = getEntityTool(mockCore, mockLogger, mockExperimentalFeatures);
@@ -45,6 +63,12 @@ describe('getEntityTool', () => {
     mockGetAgentBuilderResourceAvailability.mockResolvedValue({
       status: 'available',
     });
+    // Default to an empty risk index so existing tests that don't care
+    // about the attachment payload's risk enrichment still pass. The
+    // risk enrichment path issues `esClient.asCurrentUser.search` against
+    // the time-series risk index; mocking a zero-hit response is the
+    // cheapest safe default.
+    mockEsClient.asCurrentUser.search.mockResolvedValue(buildEmptyRiskSearchResponse());
   });
 
   describe('schema', () => {
@@ -482,11 +506,13 @@ describe('getEntityTool', () => {
 
     it('returns error result when no entity is found', async () => {
       (executeEsql as jest.Mock)
-        // 1. Exact match — nothing found
+        // 1. Exact id match — nothing found
         .mockResolvedValueOnce({ columns: [{ name: 'entity.id', type: 'keyword' }], values: [] })
-        // 2. entity.id RLIKE fallback — also nothing found
+        // 2. Exact name match — nothing found
+        .mockResolvedValueOnce({ columns: [{ name: 'entity.name', type: 'keyword' }], values: [] })
+        // 3. entity.id RLIKE fallback — also nothing found
         .mockResolvedValueOnce({ columns: [{ name: 'entity.id', type: 'keyword' }], values: [] })
-        // 3. entity.name RLIKE fallback — also nothing found
+        // 4. entity.name RLIKE fallback — also nothing found
         .mockResolvedValueOnce({ columns: [{ name: 'entity.name', type: 'keyword' }], values: [] });
 
       const result = (await tool.handler(
@@ -494,7 +520,7 @@ describe('getEntityTool', () => {
         createToolHandlerContext(mockRequest, mockEsClient, mockLogger)
       )) as ToolHandlerStandardReturn;
 
-      expect(executeEsql).toHaveBeenCalledTimes(3);
+      expect(executeEsql).toHaveBeenCalledTimes(4);
       expect(result.results).toHaveLength(1);
       const errorResult = result.results[0] as ErrorResult;
       expect(errorResult.type).toBe(ToolResultType.error);
@@ -503,9 +529,11 @@ describe('getEntityTool', () => {
 
     it('returns LIKE fallback results when exact match finds no entity', async () => {
       (executeEsql as jest.Mock)
-        // 1. Exact match — empty
+        // 1. Exact id match — empty
         .mockResolvedValueOnce({ columns: [{ name: 'entity.id', type: 'keyword' }], values: [] })
-        // 2. LIKE fallback
+        // 2. Exact name match — empty
+        .mockResolvedValueOnce({ columns: [{ name: 'entity.name', type: 'keyword' }], values: [] })
+        // 3. LIKE fallback
         .mockResolvedValueOnce({
           columns: [
             { name: 'entity.id', type: 'keyword' },
@@ -519,8 +547,8 @@ describe('getEntityTool', () => {
         createToolHandlerContext(mockRequest, mockEsClient, mockLogger)
       )) as ToolHandlerStandardReturn;
 
-      expect(executeEsql).toHaveBeenCalledTimes(2);
-      const rlikeQuery = (executeEsql as jest.Mock).mock.calls[1][0].query;
+      expect(executeEsql).toHaveBeenCalledTimes(3);
+      const rlikeQuery = (executeEsql as jest.Mock).mock.calls[2][0].query;
       expect(rlikeQuery).toContain('RLIKE ".*server1.*"');
       expect(rlikeQuery).toContain('LIMIT 5');
       expect(result.results).toHaveLength(1);
@@ -531,11 +559,13 @@ describe('getEntityTool', () => {
 
     it('uses raw entityId (not normalized) as the RLIKE pattern', async () => {
       (executeEsql as jest.Mock)
-        // 1. Exact match — empty
+        // 1. Exact id match — empty
         .mockResolvedValueOnce({ columns: [], values: [] })
-        // 2. entity.id RLIKE fallback — empty (just checking query shape)
+        // 2. Exact name match — empty
         .mockResolvedValueOnce({ columns: [], values: [] })
-        // 3. entity.name RLIKE fallback — empty
+        // 3. entity.id RLIKE fallback — empty (just checking query shape)
+        .mockResolvedValueOnce({ columns: [], values: [] })
+        // 4. entity.name RLIKE fallback — empty
         .mockResolvedValueOnce({ columns: [], values: [] });
 
       await tool.handler(
@@ -543,18 +573,20 @@ describe('getEntityTool', () => {
         createToolHandlerContext(mockRequest, mockEsClient, mockLogger)
       );
 
-      const rlikeQuery = (executeEsql as jest.Mock).mock.calls[1][0].query;
+      const rlikeQuery = (executeEsql as jest.Mock).mock.calls[2][0].query;
       expect(rlikeQuery).toContain('RLIKE ".*server1.*"');
       expect(rlikeQuery).not.toContain('RLIKE ".*host:server1.*"');
     });
 
     it('returns entity.name RLIKE fallback results when entity.id searches find nothing', async () => {
       (executeEsql as jest.Mock)
-        // 1. Exact match — empty
+        // 1. Exact id match — empty
         .mockResolvedValueOnce({ columns: [{ name: 'entity.id', type: 'keyword' }], values: [] })
-        // 2. entity.id RLIKE fallback — empty
+        // 2. Exact name match — empty
+        .mockResolvedValueOnce({ columns: [{ name: 'entity.name', type: 'keyword' }], values: [] })
+        // 3. entity.id RLIKE fallback — empty
         .mockResolvedValueOnce({ columns: [{ name: 'entity.id', type: 'keyword' }], values: [] })
-        // 3. entity.name RLIKE fallback — returns a match
+        // 4. entity.name RLIKE fallback — returns a match
         .mockResolvedValueOnce({
           columns: [
             { name: 'entity.id', type: 'keyword' },
@@ -568,8 +600,8 @@ describe('getEntityTool', () => {
         createToolHandlerContext(mockRequest, mockEsClient, mockLogger)
       )) as ToolHandlerStandardReturn;
 
-      expect(executeEsql).toHaveBeenCalledTimes(3);
-      const nameQuery = (executeEsql as jest.Mock).mock.calls[2][0].query;
+      expect(executeEsql).toHaveBeenCalledTimes(4);
+      const nameQuery = (executeEsql as jest.Mock).mock.calls[3][0].query;
       expect(nameQuery).toContain('entity.name RLIKE ".*server1.*"');
       expect(nameQuery).toContain('user.full_name RLIKE ".*server1.*"');
       expect(nameQuery).toContain('LIMIT 5');
@@ -581,11 +613,14 @@ describe('getEntityTool', () => {
 
     it('returns user.full_name RLIKE match when user is found by full name', async () => {
       (executeEsql as jest.Mock)
-        // 1. Exact match — empty
+        // 1. Exact id match — empty
         .mockResolvedValueOnce({ columns: [{ name: 'entity.id', type: 'keyword' }], values: [] })
-        // 2. entity.id RLIKE fallback — empty
+        // 2. Exact name match — empty (this test specifically exercises the RLIKE
+        // fallback, so the exact-name rung is mocked as a miss to force fall-through)
+        .mockResolvedValueOnce({ columns: [{ name: 'entity.name', type: 'keyword' }], values: [] })
+        // 3. entity.id RLIKE fallback — empty
         .mockResolvedValueOnce({ columns: [{ name: 'entity.id', type: 'keyword' }], values: [] })
-        // 3. entity.name / user.full_name RLIKE fallback — returns a user entity matched by full name
+        // 4. entity.name / user.full_name RLIKE fallback — returns a user entity matched by full name
         .mockResolvedValueOnce({
           columns: [
             { name: 'entity.id', type: 'keyword' },
@@ -600,8 +635,8 @@ describe('getEntityTool', () => {
         createToolHandlerContext(mockRequest, mockEsClient, mockLogger)
       )) as ToolHandlerStandardReturn;
 
-      expect(executeEsql).toHaveBeenCalledTimes(3);
-      const nameQuery = (executeEsql as jest.Mock).mock.calls[2][0].query;
+      expect(executeEsql).toHaveBeenCalledTimes(4);
+      const nameQuery = (executeEsql as jest.Mock).mock.calls[3][0].query;
       expect(nameQuery).toContain('user.full_name RLIKE ".*John Doe.*"');
       expect(result.results).toHaveLength(1);
       const esqlResult = result.results[0] as EsqlResults;
@@ -612,11 +647,13 @@ describe('getEntityTool', () => {
 
     it('uses raw entityId (not normalized) as the entity.name RLIKE pattern', async () => {
       (executeEsql as jest.Mock)
-        // 1. Exact match — empty
+        // 1. Exact id match — empty
         .mockResolvedValueOnce({ columns: [], values: [] })
-        // 2. entity.id RLIKE fallback — empty
+        // 2. Exact name match — empty
         .mockResolvedValueOnce({ columns: [], values: [] })
-        // 3. entity.name RLIKE fallback — empty (just checking query shape)
+        // 3. entity.id RLIKE fallback — empty
+        .mockResolvedValueOnce({ columns: [], values: [] })
+        // 4. entity.name RLIKE fallback — empty (just checking query shape)
         .mockResolvedValueOnce({ columns: [], values: [] });
 
       await tool.handler(
@@ -624,7 +661,7 @@ describe('getEntityTool', () => {
         createToolHandlerContext(mockRequest, mockEsClient, mockLogger)
       );
 
-      const nameQuery = (executeEsql as jest.Mock).mock.calls[2][0].query;
+      const nameQuery = (executeEsql as jest.Mock).mock.calls[3][0].query;
       expect(nameQuery).toContain('entity.name RLIKE ".*server1.*"');
       expect(nameQuery).toContain('user.full_name RLIKE ".*server1.*"');
       expect(nameQuery).not.toContain('entity.name RLIKE ".*host:server1.*"');
@@ -633,11 +670,13 @@ describe('getEntityTool', () => {
 
     it('escapes regex metacharacters in the entity.name RLIKE pattern', async () => {
       (executeEsql as jest.Mock)
-        // 1. Exact match — empty
+        // 1. Exact id match — empty
         .mockResolvedValueOnce({ columns: [], values: [] })
-        // 2. entity.id RLIKE fallback — empty
+        // 2. Exact name match — empty
         .mockResolvedValueOnce({ columns: [], values: [] })
-        // 3. entity.name RLIKE fallback — empty
+        // 3. entity.id RLIKE fallback — empty
+        .mockResolvedValueOnce({ columns: [], values: [] })
+        // 4. entity.name RLIKE fallback — empty
         .mockResolvedValueOnce({ columns: [], values: [] });
 
       await tool.handler(
@@ -645,18 +684,20 @@ describe('getEntityTool', () => {
         createToolHandlerContext(mockRequest, mockEsClient, mockLogger)
       );
 
-      const nameQuery = (executeEsql as jest.Mock).mock.calls[2][0].query;
+      const nameQuery = (executeEsql as jest.Mock).mock.calls[3][0].query;
       expect(nameQuery).toContain('entity.name RLIKE ".*server\\\\.1\\\\*test.*"');
       expect(nameQuery).toContain('user.full_name RLIKE ".*server\\\\.1\\\\*test.*"');
     });
 
     it('escapes regex metacharacters in the entity.id RLIKE pattern', async () => {
       (executeEsql as jest.Mock)
-        // 1. Exact match — empty
+        // 1. Exact id match — empty
         .mockResolvedValueOnce({ columns: [], values: [] })
-        // 2. entity.id RLIKE fallback — empty
+        // 2. Exact name match — empty
         .mockResolvedValueOnce({ columns: [], values: [] })
-        // 3. entity.name RLIKE fallback — empty
+        // 3. entity.id RLIKE fallback — empty
+        .mockResolvedValueOnce({ columns: [], values: [] })
+        // 4. entity.name RLIKE fallback — empty
         .mockResolvedValueOnce({ columns: [], values: [] });
 
       await tool.handler(
@@ -664,15 +705,17 @@ describe('getEntityTool', () => {
         createToolHandlerContext(mockRequest, mockEsClient, mockLogger)
       );
 
-      const rlikeQuery = (executeEsql as jest.Mock).mock.calls[1][0].query;
+      const rlikeQuery = (executeEsql as jest.Mock).mock.calls[2][0].query;
       expect(rlikeQuery).toContain('RLIKE ".*server\\\\.1\\\\*test.*"');
     });
 
     it('uses resolved entity.id from RLIKE result for subsequent snapshot queries', async () => {
       (executeEsql as jest.Mock)
-        // 1. Exact match — empty
+        // 1. Exact id match — empty
         .mockResolvedValueOnce({ columns: [], values: [] })
-        // 2. RLIKE fallback — returns entity with a prefixed ID
+        // 2. Exact name match — empty
+        .mockResolvedValueOnce({ columns: [], values: [] })
+        // 3. RLIKE fallback — returns entity with a prefixed ID
         .mockResolvedValueOnce({
           columns: [
             { name: 'entity.id', type: 'keyword' },
@@ -680,7 +723,7 @@ describe('getEntityTool', () => {
           ],
           values: [['host:server1', 'server1']],
         })
-        // 3. Interval snapshot
+        // 4. Interval snapshot
         .mockResolvedValueOnce({ columns: [{ name: '@timestamp', type: 'date' }], values: [] });
 
       await tool.handler(
@@ -688,16 +731,18 @@ describe('getEntityTool', () => {
         createToolHandlerContext(mockRequest, mockEsClient, mockLogger)
       );
 
-      expect(executeEsql).toHaveBeenCalledTimes(3);
-      const snapshotQuery = (executeEsql as jest.Mock).mock.calls[2][0].query;
+      expect(executeEsql).toHaveBeenCalledTimes(4);
+      const snapshotQuery = (executeEsql as jest.Mock).mock.calls[3][0].query;
       expect(snapshotQuery).toContain('WHERE entity.id == "host:server1"');
     });
 
     it('returns one result per RLIKE entity with profile_history when interval is provided', async () => {
       (executeEsql as jest.Mock)
-        // 1. Exact match — empty
+        // 1. Exact id match — empty
         .mockResolvedValueOnce({ columns: [], values: [] })
-        // 2. RLIKE fallback — 2 entities (no risk score, so no extra enrichment calls)
+        // 2. Exact name match — empty
+        .mockResolvedValueOnce({ columns: [], values: [] })
+        // 3. RLIKE fallback — 2 entities (no risk score, so no extra enrichment calls)
         .mockResolvedValueOnce({
           columns: [
             { name: 'entity.id', type: 'keyword' },
@@ -708,12 +753,12 @@ describe('getEntityTool', () => {
             ['host:server10', 'server10'],
           ],
         })
-        // 3. Interval snapshot for host:server1
+        // 4. Interval snapshot for host:server1
         .mockResolvedValueOnce({
           columns: [{ name: '@timestamp', type: 'date' }],
           values: [['2024-01-01T00:00:00Z']],
         })
-        // 4. Interval snapshot for host:server10
+        // 5. Interval snapshot for host:server10
         .mockResolvedValueOnce({
           columns: [{ name: '@timestamp', type: 'date' }],
           values: [['2024-01-02T00:00:00Z']],
@@ -724,7 +769,7 @@ describe('getEntityTool', () => {
         createToolHandlerContext(mockRequest, mockEsClient, mockLogger)
       )) as ToolHandlerStandardReturn;
 
-      expect(executeEsql).toHaveBeenCalledTimes(4);
+      expect(executeEsql).toHaveBeenCalledTimes(5);
       expect(result.results).toHaveLength(2);
 
       const [r1, r2] = result.results as EsqlResults[];
@@ -738,16 +783,18 @@ describe('getEntityTool', () => {
       expect(r2.data.columns.map((c) => c.name)).toContain('profile_history');
 
       // Each snapshot query uses the entity.id from the respective RLIKE result row
-      const snapshotCalls = (executeEsql as jest.Mock).mock.calls.slice(2);
+      const snapshotCalls = (executeEsql as jest.Mock).mock.calls.slice(3);
       expect(snapshotCalls[0][0].query).toContain('WHERE entity.id == "host:server1"');
       expect(snapshotCalls[1][0].query).toContain('WHERE entity.id == "host:server10"');
     });
 
     it('returns one result per RLIKE entity when date is provided with early exit', async () => {
       (executeEsql as jest.Mock)
-        // 1. Exact match — empty
+        // 1. Exact id match — empty
         .mockResolvedValueOnce({ columns: [], values: [] })
-        // 2. RLIKE fallback — 2 entities (with risk score; date path exits before risk score fetch)
+        // 2. Exact name match — empty
+        .mockResolvedValueOnce({ columns: [], values: [] })
+        // 3. RLIKE fallback — 2 entities (with risk score; date path exits before risk score fetch)
         .mockResolvedValueOnce({
           columns: [
             { name: 'entity.id', type: 'keyword' },
@@ -759,12 +806,12 @@ describe('getEntityTool', () => {
             ['host:server10', 'server10', 60.0],
           ],
         })
-        // 3. Date snapshot for host:server1
+        // 4. Date snapshot for host:server1
         .mockResolvedValueOnce({
           columns: [{ name: '@timestamp', type: 'date' }],
           values: [['2024-01-15T10:00:00Z']],
         })
-        // 4. Date snapshot for host:server10
+        // 5. Date snapshot for host:server10
         .mockResolvedValueOnce({
           columns: [{ name: '@timestamp', type: 'date' }],
           values: [['2024-01-15T11:00:00Z']],
@@ -775,7 +822,7 @@ describe('getEntityTool', () => {
         createToolHandlerContext(mockRequest, mockEsClient, mockLogger)
       )) as ToolHandlerStandardReturn;
 
-      expect(executeEsql).toHaveBeenCalledTimes(4);
+      expect(executeEsql).toHaveBeenCalledTimes(5);
       expect(result.results).toHaveLength(2);
 
       const [r1, r2] = result.results as EsqlResults[];
@@ -865,6 +912,7 @@ describe('getEntityTool', () => {
         (executeEsql as jest.Mock)
           .mockResolvedValueOnce({ columns: [], values: [] })
           .mockResolvedValueOnce({ columns: [], values: [] })
+          .mockResolvedValueOnce({ columns: [], values: [] })
           .mockResolvedValueOnce({ columns: [], values: [] });
 
         await tool.handler(
@@ -921,6 +969,889 @@ describe('getEntityTool', () => {
           ENTITY_ANALYTICS_AI_TOOL_USAGE_EVENT.eventType,
           expect.objectContaining({ entityTypes: [] })
         );
+      });
+    });
+  });
+
+  describe('entity attachment side effect', () => {
+    const expectedAttachmentId = buildSingleEntityAttachmentId('host', 'server1');
+
+    const exactHitResponse = {
+      columns: [
+        { name: 'entity.id', type: 'keyword' },
+        { name: 'entity.name', type: 'keyword' },
+        { name: 'entity.EngineMetadata.Type', type: 'keyword' },
+      ],
+      values: [['host:server1', 'server1', 'host']],
+    };
+
+    it('creates a security.entity attachment on exact single hit and appends an other result', async () => {
+      (executeEsql as jest.Mock).mockResolvedValueOnce(exactHitResponse);
+
+      const context = createToolHandlerContext(mockRequest, mockEsClient, mockLogger);
+      (context.attachments.getAttachmentRecord as jest.Mock).mockReturnValueOnce(undefined);
+      (context.attachments.add as jest.Mock).mockResolvedValueOnce({
+        id: expectedAttachmentId,
+        current_version: 1,
+      });
+
+      const result = (await tool.handler(
+        { entityType: 'host', entityId: 'server1' },
+        context
+      )) as ToolHandlerStandardReturn;
+
+      expect(context.attachments.add).toHaveBeenCalledTimes(1);
+      expect(context.attachments.add).toHaveBeenCalledWith({
+        id: expectedAttachmentId,
+        type: SecurityAgentBuilderAttachments.entity,
+        data: {
+          identifierType: 'host',
+          identifier: 'server1',
+          attachmentLabel: 'host: server1',
+          entityStoreId: 'host:server1',
+        },
+        description: 'host: server1',
+      });
+      expect(context.attachments.update).not.toHaveBeenCalled();
+
+      expect(result.results).toHaveLength(2);
+      expect(result.results[0].type).toBe(ToolResultType.esqlResults);
+      const otherResult = result.results[1] as OtherResult<{
+        attachmentId: string;
+        version: number;
+        renderTag: string;
+      }>;
+      expect(otherResult.type).toBe(ToolResultType.other);
+      expect(otherResult.data).toEqual({
+        attachmentId: expectedAttachmentId,
+        version: 1,
+        renderTag: buildRenderAttachmentTag({
+          attachmentId: expectedAttachmentId,
+          version: 1,
+        }),
+      });
+    });
+
+    it('updates the existing attachment (bumping version) on a repeat exact hit for the same entity', async () => {
+      (executeEsql as jest.Mock).mockResolvedValueOnce(exactHitResponse);
+
+      const context = createToolHandlerContext(mockRequest, mockEsClient, mockLogger);
+      (context.attachments.getAttachmentRecord as jest.Mock).mockReturnValueOnce({
+        id: expectedAttachmentId,
+        current_version: 1,
+      });
+      (context.attachments.update as jest.Mock).mockResolvedValueOnce({
+        id: expectedAttachmentId,
+        current_version: 2,
+      });
+
+      const result = (await tool.handler(
+        { entityType: 'host', entityId: 'server1' },
+        context
+      )) as ToolHandlerStandardReturn;
+
+      expect(context.attachments.update).toHaveBeenCalledTimes(1);
+      expect(context.attachments.update).toHaveBeenCalledWith(expectedAttachmentId, {
+        data: {
+          identifierType: 'host',
+          identifier: 'server1',
+          attachmentLabel: 'host: server1',
+          entityStoreId: 'host:server1',
+        },
+        description: 'host: server1',
+      });
+      expect(context.attachments.add).not.toHaveBeenCalled();
+
+      const otherResult = result.results[1] as OtherResult<{
+        attachmentId: string;
+        version: number;
+        renderTag: string;
+      }>;
+      expect(otherResult.type).toBe(ToolResultType.other);
+      expect(otherResult.data).toEqual({
+        attachmentId: expectedAttachmentId,
+        version: 2,
+        renderTag: buildRenderAttachmentTag({
+          attachmentId: expectedAttachmentId,
+          version: 2,
+        }),
+      });
+    });
+
+    it('creates an attachment when the entity.id RLIKE fallback returns a single row whose stripped id equals the input', async () => {
+      (executeEsql as jest.Mock)
+        // 1. Exact id match — empty (input "server1" vs stored "host:server1")
+        .mockResolvedValueOnce({ columns: [{ name: 'entity.id', type: 'keyword' }], values: [] })
+        // 2. Exact name match — empty
+        .mockResolvedValueOnce({ columns: [{ name: 'entity.name', type: 'keyword' }], values: [] })
+        // 3. entity.id RLIKE fallback — single match where stripped id equals the user input
+        .mockResolvedValueOnce({
+          columns: [
+            { name: 'entity.id', type: 'keyword' },
+            { name: 'entity.name', type: 'keyword' },
+            { name: 'entity.EngineMetadata.Type', type: 'keyword' },
+          ],
+          values: [['host:server1', 'server1', 'host']],
+        });
+
+      const context = createToolHandlerContext(mockRequest, mockEsClient, mockLogger);
+      (context.attachments.getAttachmentRecord as jest.Mock).mockReturnValueOnce(undefined);
+      (context.attachments.add as jest.Mock).mockResolvedValueOnce({
+        id: expectedAttachmentId,
+        current_version: 1,
+      });
+
+      const result = (await tool.handler(
+        { entityId: 'server1' },
+        context
+      )) as ToolHandlerStandardReturn;
+
+      expect(context.attachments.add).toHaveBeenCalledTimes(1);
+      expect(context.attachments.add).toHaveBeenCalledWith({
+        id: expectedAttachmentId,
+        type: SecurityAgentBuilderAttachments.entity,
+        data: {
+          identifierType: 'host',
+          identifier: 'server1',
+          attachmentLabel: 'host: server1',
+          entityStoreId: 'host:server1',
+        },
+        description: 'host: server1',
+      });
+
+      expect(result.results).toHaveLength(2);
+      expect(result.results[0].type).toBe(ToolResultType.esqlResults);
+      const otherResult = result.results[1] as OtherResult<{
+        attachmentId: string;
+        version: number;
+        renderTag: string;
+      }>;
+      expect(otherResult.type).toBe(ToolResultType.other);
+      expect(otherResult.data).toEqual({
+        attachmentId: expectedAttachmentId,
+        version: 1,
+        renderTag: buildRenderAttachmentTag({
+          attachmentId: expectedAttachmentId,
+          version: 1,
+        }),
+      });
+    });
+
+    it('creates an attachment when resolved via exact entity.name match', async () => {
+      const expectedHostAttachmentId = buildSingleEntityAttachmentId('host', 'LAPTOP-SALES04');
+
+      (executeEsql as jest.Mock)
+        // 1. Exact id match — empty (the input is the canonical name, not the id)
+        .mockResolvedValueOnce({ columns: [{ name: 'entity.id', type: 'keyword' }], values: [] })
+        // 2. Exact name match — single hit
+        .mockResolvedValueOnce({
+          columns: [
+            { name: 'entity.id', type: 'keyword' },
+            { name: 'entity.name', type: 'keyword' },
+            { name: 'entity.EngineMetadata.Type', type: 'keyword' },
+          ],
+          values: [['host:LAPTOP-SALES04', 'LAPTOP-SALES04', 'host']],
+        });
+
+      const context = createToolHandlerContext(mockRequest, mockEsClient, mockLogger);
+      (context.attachments.getAttachmentRecord as jest.Mock).mockReturnValueOnce(undefined);
+      (context.attachments.add as jest.Mock).mockResolvedValueOnce({
+        id: expectedHostAttachmentId,
+        current_version: 1,
+      });
+
+      const result = (await tool.handler(
+        { entityId: 'LAPTOP-SALES04' },
+        context
+      )) as ToolHandlerStandardReturn;
+
+      const nameExactQuery = (executeEsql as jest.Mock).mock.calls[1][0].query;
+      expect(nameExactQuery).toContain('entity.name == "LAPTOP-SALES04"');
+      expect(nameExactQuery).toContain('MV_CONTAINS(user.full_name, "LAPTOP-SALES04")');
+      expect(nameExactQuery).toContain('MV_CONTAINS(host.name, "LAPTOP-SALES04")');
+      expect(nameExactQuery).toContain('LIMIT 2');
+
+      expect(context.attachments.add).toHaveBeenCalledTimes(1);
+      expect(context.attachments.add).toHaveBeenCalledWith({
+        id: expectedHostAttachmentId,
+        type: SecurityAgentBuilderAttachments.entity,
+        data: {
+          identifierType: 'host',
+          identifier: 'LAPTOP-SALES04',
+          attachmentLabel: 'host: LAPTOP-SALES04',
+          entityStoreId: 'host:LAPTOP-SALES04',
+        },
+        description: 'host: LAPTOP-SALES04',
+      });
+
+      expect(result.results).toHaveLength(2);
+      expect(result.results[0].type).toBe(ToolResultType.esqlResults);
+      const otherResult = result.results[1] as OtherResult<{
+        attachmentId: string;
+        version: number;
+        renderTag: string;
+      }>;
+      expect(otherResult.type).toBe(ToolResultType.other);
+      expect(otherResult.data).toEqual({
+        attachmentId: expectedHostAttachmentId,
+        version: 1,
+        renderTag: buildRenderAttachmentTag({
+          attachmentId: expectedHostAttachmentId,
+          version: 1,
+        }),
+      });
+    });
+
+    it('creates an attachment when resolved via exact user.full_name match', async () => {
+      const expectedUserAttachmentId = buildSingleEntityAttachmentId('user', 'jdoe');
+
+      (executeEsql as jest.Mock)
+        // 1. Exact id match — empty
+        .mockResolvedValueOnce({ columns: [{ name: 'entity.id', type: 'keyword' }], values: [] })
+        // 2. Exact name match — single hit via user.full_name
+        .mockResolvedValueOnce({
+          columns: [
+            { name: 'entity.id', type: 'keyword' },
+            { name: 'entity.name', type: 'keyword' },
+            { name: 'entity.EngineMetadata.Type', type: 'keyword' },
+            { name: 'user.full_name', type: 'keyword' },
+          ],
+          values: [['user:jdoe', 'jdoe', 'user', 'John Doe']],
+        });
+
+      const context = createToolHandlerContext(mockRequest, mockEsClient, mockLogger);
+      (context.attachments.getAttachmentRecord as jest.Mock).mockReturnValueOnce(undefined);
+      (context.attachments.add as jest.Mock).mockResolvedValueOnce({
+        id: expectedUserAttachmentId,
+        current_version: 1,
+      });
+
+      const result = (await tool.handler(
+        { entityId: 'John Doe' },
+        context
+      )) as ToolHandlerStandardReturn;
+
+      const nameExactQuery = (executeEsql as jest.Mock).mock.calls[1][0].query;
+      expect(nameExactQuery).toContain('MV_CONTAINS(user.full_name, "John Doe")');
+
+      expect(context.attachments.add).toHaveBeenCalledTimes(1);
+      expect(context.attachments.add).toHaveBeenCalledWith({
+        id: expectedUserAttachmentId,
+        type: SecurityAgentBuilderAttachments.entity,
+        data: {
+          identifierType: 'user',
+          identifier: 'jdoe',
+          attachmentLabel: 'user: jdoe',
+          entityStoreId: 'user:jdoe',
+        },
+        description: 'user: jdoe',
+      });
+
+      expect(result.results).toHaveLength(2);
+      expect(result.results[1].type).toBe(ToolResultType.other);
+    });
+
+    it('creates an attachment when resolved via exact host.name match (historical hostname)', async () => {
+      // Simulates a renamed host: the queried id only survives in the
+      // multi-valued `host.name` array, while `entity.name` holds the newer
+      // canonical name. MV_CONTAINS(host.name, ...) must still resolve the
+      // row so the rich attachment is created under the current entity.name.
+      const expectedHostAttachmentId = buildSingleEntityAttachmentId('host', 'LAPTOP-SALES05');
+
+      (executeEsql as jest.Mock)
+        // 1. Exact id match — empty
+        .mockResolvedValueOnce({ columns: [{ name: 'entity.id', type: 'keyword' }], values: [] })
+        // 2. Exact name match — single hit via host.name (historical value)
+        .mockResolvedValueOnce({
+          columns: [
+            { name: 'entity.id', type: 'keyword' },
+            { name: 'entity.name', type: 'keyword' },
+            { name: 'entity.EngineMetadata.Type', type: 'keyword' },
+            { name: 'host.name', type: 'keyword' },
+          ],
+          values: [
+            ['host:LAPTOP-SALES05', 'LAPTOP-SALES05', 'host', ['LAPTOP-SALES04', 'LAPTOP-SALES05']],
+          ],
+        });
+
+      const context = createToolHandlerContext(mockRequest, mockEsClient, mockLogger);
+      (context.attachments.getAttachmentRecord as jest.Mock).mockReturnValueOnce(undefined);
+      (context.attachments.add as jest.Mock).mockResolvedValueOnce({
+        id: expectedHostAttachmentId,
+        current_version: 1,
+      });
+
+      const result = (await tool.handler(
+        { entityId: 'LAPTOP-SALES04' },
+        context
+      )) as ToolHandlerStandardReturn;
+
+      const nameExactQuery = (executeEsql as jest.Mock).mock.calls[1][0].query;
+      expect(nameExactQuery).toContain('MV_CONTAINS(host.name, "LAPTOP-SALES04")');
+
+      expect(context.attachments.add).toHaveBeenCalledTimes(1);
+      expect(context.attachments.add).toHaveBeenCalledWith({
+        id: expectedHostAttachmentId,
+        type: SecurityAgentBuilderAttachments.entity,
+        data: {
+          identifierType: 'host',
+          identifier: 'LAPTOP-SALES05',
+          attachmentLabel: 'host: LAPTOP-SALES05',
+          entityStoreId: 'host:LAPTOP-SALES05',
+        },
+        description: 'host: LAPTOP-SALES05',
+      });
+
+      expect(result.results).toHaveLength(2);
+      expect(result.results[1].type).toBe(ToolResultType.other);
+    });
+
+    it('carries the composite entity.id on the attachment for a local user so the client can rehydrate by entity.id', async () => {
+      const compositeEntityId = "user:Lena Medhurst@Lena's MacBook Pro@local";
+      const compositeEntityName = "Lena Medhurst@Lena's MacBook Pro";
+      const expectedLocalUserAttachmentId = buildSingleEntityAttachmentId(
+        'user',
+        compositeEntityName
+      );
+
+      (executeEsql as jest.Mock)
+        // 1. Exact id match — empty (the input is the bare name, not the id)
+        .mockResolvedValueOnce({ columns: [{ name: 'entity.id', type: 'keyword' }], values: [] })
+        // 2. Exact name match — the composite entity.name hit
+        .mockResolvedValueOnce({
+          columns: [
+            { name: 'entity.id', type: 'keyword' },
+            { name: 'entity.name', type: 'keyword' },
+            { name: 'entity.EngineMetadata.Type', type: 'keyword' },
+          ],
+          values: [[compositeEntityId, compositeEntityName, 'user']],
+        });
+
+      const context = createToolHandlerContext(mockRequest, mockEsClient, mockLogger);
+      (context.attachments.getAttachmentRecord as jest.Mock).mockReturnValueOnce(undefined);
+      (context.attachments.add as jest.Mock).mockResolvedValueOnce({
+        id: expectedLocalUserAttachmentId,
+        current_version: 1,
+      });
+
+      await tool.handler({ entityId: compositeEntityName }, context);
+
+      expect(context.attachments.add).toHaveBeenCalledTimes(1);
+      expect(context.attachments.add).toHaveBeenCalledWith({
+        id: expectedLocalUserAttachmentId,
+        type: SecurityAgentBuilderAttachments.entity,
+        data: {
+          identifierType: 'user',
+          identifier: compositeEntityName,
+          attachmentLabel: `user: ${compositeEntityName}`,
+          entityStoreId: compositeEntityId,
+        },
+        description: `user: ${compositeEntityName}`,
+      });
+    });
+
+    it('does not create an attachment when exact name match returns two rows (ambiguous)', async () => {
+      (executeEsql as jest.Mock)
+        // 1. Exact id match — empty
+        .mockResolvedValueOnce({ columns: [{ name: 'entity.id', type: 'keyword' }], values: [] })
+        // 2. Exact name match — two rows (a host and a user share the same name)
+        .mockResolvedValueOnce({
+          columns: [
+            { name: 'entity.id', type: 'keyword' },
+            { name: 'entity.name', type: 'keyword' },
+            { name: 'entity.EngineMetadata.Type', type: 'keyword' },
+          ],
+          values: [
+            ['host:bob', 'bob', 'host'],
+            ['user:bob', 'bob', 'user'],
+          ],
+        });
+
+      const context = createToolHandlerContext(mockRequest, mockEsClient, mockLogger);
+
+      const result = (await tool.handler(
+        { entityId: 'bob' },
+        context
+      )) as ToolHandlerStandardReturn;
+
+      expect(context.attachments.add).not.toHaveBeenCalled();
+      expect(context.attachments.update).not.toHaveBeenCalled();
+      expect(result.results).toHaveLength(2);
+      expect(result.results[0].type).toBe(ToolResultType.esqlResults);
+      expect(result.results[1].type).toBe(ToolResultType.esqlResults);
+    });
+
+    it('does not create an attachment when entity.id RLIKE single hit has a non-matching stripped id', async () => {
+      (executeEsql as jest.Mock)
+        // 1. Exact id match — empty
+        .mockResolvedValueOnce({ columns: [{ name: 'entity.id', type: 'keyword' }], values: [] })
+        // 2. Exact name match — empty
+        .mockResolvedValueOnce({ columns: [{ name: 'entity.name', type: 'keyword' }], values: [] })
+        // 3. entity.id RLIKE single hit, but the stripped id ("server1") does NOT
+        // equal the user input ("server"), so this is a true substring match and
+        // should not authoritatively render a card.
+        .mockResolvedValueOnce({
+          columns: [
+            { name: 'entity.id', type: 'keyword' },
+            { name: 'entity.name', type: 'keyword' },
+            { name: 'entity.EngineMetadata.Type', type: 'keyword' },
+          ],
+          values: [['host:server1', 'server1', 'host']],
+        });
+
+      const context = createToolHandlerContext(mockRequest, mockEsClient, mockLogger);
+
+      const result = (await tool.handler(
+        { entityId: 'server' },
+        context
+      )) as ToolHandlerStandardReturn;
+
+      expect(context.attachments.add).not.toHaveBeenCalled();
+      expect(context.attachments.update).not.toHaveBeenCalled();
+      expect(result.results).toHaveLength(1);
+      expect(result.results[0].type).toBe(ToolResultType.esqlResults);
+    });
+
+    it('does not create an attachment when the match came from the entity.name RLIKE fallback', async () => {
+      (executeEsql as jest.Mock)
+        // 1. Exact id match — empty
+        .mockResolvedValueOnce({ columns: [{ name: 'entity.id', type: 'keyword' }], values: [] })
+        // 2. Exact name match — empty
+        .mockResolvedValueOnce({ columns: [{ name: 'entity.name', type: 'keyword' }], values: [] })
+        // 3. entity.id RLIKE fallback — empty
+        .mockResolvedValueOnce({ columns: [{ name: 'entity.id', type: 'keyword' }], values: [] })
+        // 4. entity.name RLIKE fallback — single match
+        .mockResolvedValueOnce({
+          columns: [
+            { name: 'entity.id', type: 'keyword' },
+            { name: 'entity.name', type: 'keyword' },
+            { name: 'entity.EngineMetadata.Type', type: 'keyword' },
+          ],
+          values: [['host:server1', 'server1', 'host']],
+        });
+
+      const context = createToolHandlerContext(mockRequest, mockEsClient, mockLogger);
+
+      const result = (await tool.handler(
+        { entityType: 'host', entityId: 'server1' },
+        context
+      )) as ToolHandlerStandardReturn;
+
+      expect(context.attachments.add).not.toHaveBeenCalled();
+      expect(context.attachments.update).not.toHaveBeenCalled();
+      expect(result.results).toHaveLength(1);
+      expect(result.results[0].type).toBe(ToolResultType.esqlResults);
+    });
+
+    it('does not create an attachment when zero hits are returned', async () => {
+      (executeEsql as jest.Mock)
+        .mockResolvedValueOnce({ columns: [], values: [] })
+        .mockResolvedValueOnce({ columns: [], values: [] })
+        .mockResolvedValueOnce({ columns: [], values: [] })
+        .mockResolvedValueOnce({ columns: [], values: [] });
+
+      const context = createToolHandlerContext(mockRequest, mockEsClient, mockLogger);
+
+      const result = (await tool.handler(
+        { entityType: 'host', entityId: 'server1' },
+        context
+      )) as ToolHandlerStandardReturn;
+
+      expect(context.attachments.add).not.toHaveBeenCalled();
+      expect(context.attachments.update).not.toHaveBeenCalled();
+      expect(result.results).toHaveLength(1);
+      expect(result.results[0].type).toBe(ToolResultType.error);
+    });
+
+    it('skips the attachment when the resolved row has an unknown entity type', async () => {
+      (executeEsql as jest.Mock).mockResolvedValueOnce({
+        columns: [
+          { name: 'entity.id', type: 'keyword' },
+          { name: 'entity.name', type: 'keyword' },
+          { name: 'entity.EngineMetadata.Type', type: 'keyword' },
+        ],
+        values: [['device:d1', 'd1', 'device']],
+      });
+
+      const context = createToolHandlerContext(mockRequest, mockEsClient, mockLogger);
+
+      const result = (await tool.handler({ entityId: 'd1' }, context)) as ToolHandlerStandardReturn;
+
+      expect(context.attachments.add).not.toHaveBeenCalled();
+      expect(context.attachments.update).not.toHaveBeenCalled();
+      expect(result.results).toHaveLength(1);
+      expect(result.results[0].type).toBe(ToolResultType.esqlResults);
+    });
+
+    it('keeps the other result when enrichment fails on the happy path', async () => {
+      (executeEsql as jest.Mock)
+        // 1. Entity lookup with a risk score (triggers enrichment)
+        .mockResolvedValueOnce({
+          columns: [
+            { name: 'entity.id', type: 'keyword' },
+            { name: 'entity.name', type: 'keyword' },
+            { name: 'entity.EngineMetadata.Type', type: 'keyword' },
+            { name: 'entity.risk.calculated_score_norm', type: 'double' },
+          ],
+          values: [['host:server1', 'server1', 'host', 75.5]],
+        })
+        // 2. Risk score inputs query fails
+        .mockRejectedValueOnce(new Error('risk index unavailable'));
+
+      const context = createToolHandlerContext(mockRequest, mockEsClient, mockLogger);
+      (context.attachments.getAttachmentRecord as jest.Mock).mockReturnValueOnce(undefined);
+      (context.attachments.add as jest.Mock).mockResolvedValueOnce({
+        id: expectedAttachmentId,
+        current_version: 1,
+      });
+
+      const result = (await tool.handler(
+        { entityType: 'host', entityId: 'server1' },
+        context
+      )) as ToolHandlerStandardReturn;
+
+      expect(context.attachments.add).toHaveBeenCalledTimes(1);
+      expect(result.results).toHaveLength(2);
+      expect(result.results[0].type).toBe(ToolResultType.esqlResults);
+      expect(result.results[1].type).toBe(ToolResultType.other);
+    });
+
+    describe('attachment risk stats enrichment', () => {
+      const buildRiskRecord = (
+        override: Partial<EntityRiskScoreRecord> = {}
+      ): EntityRiskScoreRecord =>
+        ({
+          '@timestamp': '2024-05-01T00:00:00Z',
+          id_field: 'host.name',
+          id_value: 'host:server1',
+          calculated_level: 'High',
+          calculated_score: 50,
+          calculated_score_norm: 75,
+          category_1_score: 45,
+          category_1_count: 6,
+          category_2_score: 5,
+          category_2_count: 1,
+          notes: [],
+          inputs: [
+            {
+              id: 'alert-1',
+              index: '.alerts-security.alerts-default',
+              category: '',
+              description: '',
+              risk_score: 0,
+              timestamp: '',
+            },
+          ],
+          score_type: 'base',
+          ...override,
+        } as unknown as EntityRiskScoreRecord);
+
+      const buildRiskSearchResponse = (records: EntityRiskScoreRecord[]) => ({
+        took: 1,
+        timed_out: false,
+        _shards: { total: 1, successful: 1, skipped: 0, failed: 0 },
+        hits: {
+          hits: records.map((risk, index) => ({
+            _id: `risk-doc-${index}`,
+            _index: 'risk-score.risk-score-default',
+            _source: { host: { risk } },
+          })),
+          total: { value: records.length, relation: 'eq' as const },
+        },
+      });
+
+      const primaryHitResponse = {
+        columns: [
+          { name: 'entity.id', type: 'keyword' },
+          { name: 'entity.name', type: 'keyword' },
+          { name: 'entity.EngineMetadata.Type', type: 'keyword' },
+        ],
+        values: [['host:server1', 'server1', 'host']],
+      };
+
+      const createEntityStoreStartMock = (group: {
+        group_size: number;
+        target: Record<string, unknown>;
+      }) => ({
+        createResolutionClient: jest.fn().mockReturnValue({
+          getResolutionGroup: jest.fn().mockResolvedValue(group),
+        }),
+      });
+
+      it('embeds the primary risk stats on the attachment data (and strips inputs)', async () => {
+        (executeEsql as jest.Mock).mockResolvedValueOnce(primaryHitResponse);
+
+        mockEsClient.asCurrentUser.search.mockResolvedValueOnce(
+          buildRiskSearchResponse([buildRiskRecord()])
+        );
+
+        const context = createToolHandlerContext(mockRequest, mockEsClient, mockLogger);
+        (context.attachments.getAttachmentRecord as jest.Mock).mockReturnValueOnce(undefined);
+        (context.attachments.add as jest.Mock).mockResolvedValueOnce({
+          id: expectedAttachmentId,
+          current_version: 1,
+        });
+
+        await tool.handler({ entityType: 'host', entityId: 'server1' }, context);
+
+        expect(context.attachments.add).toHaveBeenCalledTimes(1);
+        const addCall = (context.attachments.add as jest.Mock).mock.calls[0][0];
+        expect(addCall.data.riskStats).toBeDefined();
+        expect(addCall.data.riskStats).toEqual(
+          expect.objectContaining({
+            calculated_level: 'High',
+            calculated_score: 50,
+            calculated_score_norm: 75,
+            category_1_score: 45,
+            category_1_count: 6,
+            category_2_score: 5,
+            category_2_count: 1,
+          })
+        );
+        // `inputs` (and any other heavy fields) must never reach the
+        // attachment payload — keeps the persisted state small.
+        expect(addCall.data.riskStats).not.toHaveProperty('inputs');
+        expect(addCall.data.resolutionRiskStats).toBeUndefined();
+      });
+
+      it('queries the risk time-series index with both V2 (prefixed EUID) and V1 (bare name) candidates and excludes resolution docs', async () => {
+        (executeEsql as jest.Mock).mockResolvedValueOnce(primaryHitResponse);
+
+        mockEsClient.asCurrentUser.search.mockResolvedValueOnce(
+          buildRiskSearchResponse([buildRiskRecord()])
+        );
+
+        const context = createToolHandlerContext(mockRequest, mockEsClient, mockLogger);
+        (context.attachments.getAttachmentRecord as jest.Mock).mockReturnValueOnce(undefined);
+        (context.attachments.add as jest.Mock).mockResolvedValueOnce({
+          id: expectedAttachmentId,
+          current_version: 1,
+        });
+
+        await tool.handler({ entityType: 'host', entityId: 'server1' }, context);
+
+        expect(mockEsClient.asCurrentUser.search).toHaveBeenCalledTimes(1);
+        const searchCall = mockEsClient.asCurrentUser.search.mock.calls[0][0] as {
+          index: string;
+          ignore_unavailable?: boolean;
+          size: number;
+          query: {
+            bool: { filter: unknown[]; must_not?: unknown[] };
+          };
+        };
+        expect(searchCall.index).toBe('risk-score.risk-score-default');
+        expect(searchCall.size).toBe(1);
+        // `ignore_unavailable: true` keeps spaces without a risk engine from
+        // tripping `index_not_found_exception` — the tool's availability gate
+        // only guarantees the entity-store index, not the risk time-series
+        // one, so a missing risk index should degrade to "no risk stats"
+        // rather than throw.
+        expect(searchCall.ignore_unavailable).toBe(true);
+        // Filter matches both the prefixed EUID (V2 `user.risk.id_value`
+        // convention — mirrored for hosts) and the bare identifier (V1
+        // convention), which is how the flyout stays robust across
+        // deployments. We mirror that here.
+        expect(searchCall.query.bool.filter).toContainEqual({
+          terms: { 'host.risk.id_value': ['host:server1', 'server1'] },
+        });
+        // The primary fetch explicitly excludes resolution-group docs so
+        // the card reflects the entity's own score rather than the
+        // resolution override.
+        expect(searchCall.query.bool.must_not).toContainEqual({
+          term: { 'host.risk.score_type': 'resolution' },
+        });
+      });
+
+      it('embeds both primary and resolution risk stats when the entity is part of a resolution group', async () => {
+        (executeEsql as jest.Mock).mockResolvedValueOnce(primaryHitResponse);
+
+        const primaryRecord = buildRiskRecord({
+          score_type: 'base',
+          calculated_level: 'High',
+          calculated_score_norm: 75,
+          category_1_score: 45,
+          category_1_count: 6,
+        });
+        const resolutionRecord = buildRiskRecord({
+          score_type: 'resolution',
+          calculated_level: 'Critical',
+          calculated_score_norm: 95,
+          category_1_score: 80,
+          category_1_count: 12,
+          id_value: 'host:server-canonical',
+        });
+        mockEsClient.asCurrentUser.search
+          .mockResolvedValueOnce(buildRiskSearchResponse([primaryRecord]))
+          .mockResolvedValueOnce(buildRiskSearchResponse([resolutionRecord]));
+
+        const entityStoreStart = createEntityStoreStartMock({
+          group_size: 2,
+          target: {
+            entity: {
+              EngineMetadata: { Type: 'host' },
+              id: 'host:server-canonical',
+              name: 'server-canonical',
+            },
+          },
+        });
+        mockCore.getStartServices.mockResolvedValueOnce([
+          mockCoreStart,
+          { entityStore: entityStoreStart },
+          {},
+        ]);
+
+        const context = createToolHandlerContext(mockRequest, mockEsClient, mockLogger);
+        (context.attachments.getAttachmentRecord as jest.Mock).mockReturnValueOnce(undefined);
+        (context.attachments.add as jest.Mock).mockResolvedValueOnce({
+          id: expectedAttachmentId,
+          current_version: 1,
+        });
+
+        await tool.handler({ entityType: 'host', entityId: 'server1' }, context);
+
+        expect(entityStoreStart.createResolutionClient).toHaveBeenCalledTimes(1);
+        // Resolution group is keyed on the entity-store `entity.id`, not
+        // the stripped identifier.
+        const resolutionClient = entityStoreStart.createResolutionClient.mock.results[0].value;
+        expect(resolutionClient.getResolutionGroup).toHaveBeenCalledWith('host:server1');
+
+        // Two risk-index queries: one for the primary (no-resolution) doc,
+        // one for the resolution doc keyed on the group target's id(s).
+        expect(mockEsClient.asCurrentUser.search).toHaveBeenCalledTimes(2);
+        const resolutionSearchCall = mockEsClient.asCurrentUser.search.mock.calls[1][0] as {
+          query: { bool: { filter: Array<Record<string, unknown>> } };
+        };
+        expect(resolutionSearchCall.query.bool.filter).toContainEqual({
+          terms: { 'host.risk.id_value': ['host:server-canonical', 'server-canonical'] },
+        });
+        expect(resolutionSearchCall.query.bool.filter).toContainEqual({
+          term: { 'host.risk.score_type': 'resolution' },
+        });
+
+        const addCall = (context.attachments.add as jest.Mock).mock.calls[0][0];
+        expect(addCall.data.riskStats).toEqual(
+          expect.objectContaining({
+            calculated_level: 'High',
+            calculated_score_norm: 75,
+          })
+        );
+        expect(addCall.data.resolutionRiskStats).toEqual(
+          expect.objectContaining({
+            calculated_level: 'Critical',
+            calculated_score_norm: 95,
+            category_1_score: 80,
+            category_1_count: 12,
+          })
+        );
+        expect(addCall.data.resolutionRiskStats).not.toHaveProperty('inputs');
+      });
+
+      it('does not fetch a resolution risk doc when the group only has one member', async () => {
+        (executeEsql as jest.Mock).mockResolvedValueOnce(primaryHitResponse);
+
+        mockEsClient.asCurrentUser.search.mockResolvedValueOnce(
+          buildRiskSearchResponse([buildRiskRecord()])
+        );
+
+        const entityStoreStart = createEntityStoreStartMock({
+          group_size: 1,
+          target: {
+            entity: { EngineMetadata: { Type: 'host' }, id: 'host:server1', name: 'server1' },
+          },
+        });
+        mockCore.getStartServices.mockResolvedValueOnce([
+          mockCoreStart,
+          { entityStore: entityStoreStart },
+          {},
+        ]);
+
+        const context = createToolHandlerContext(mockRequest, mockEsClient, mockLogger);
+        (context.attachments.getAttachmentRecord as jest.Mock).mockReturnValueOnce(undefined);
+        (context.attachments.add as jest.Mock).mockResolvedValueOnce({
+          id: expectedAttachmentId,
+          current_version: 1,
+        });
+
+        await tool.handler({ entityType: 'host', entityId: 'server1' }, context);
+
+        // Only the primary risk-index query should run for a solo group.
+        expect(mockEsClient.asCurrentUser.search).toHaveBeenCalledTimes(1);
+        const addCall = (context.attachments.add as jest.Mock).mock.calls[0][0];
+        expect(addCall.data.resolutionRiskStats).toBeUndefined();
+      });
+
+      it('omits riskStats when the risk index has no document for the entity', async () => {
+        (executeEsql as jest.Mock).mockResolvedValueOnce(primaryHitResponse);
+
+        mockEsClient.asCurrentUser.search.mockResolvedValueOnce(buildRiskSearchResponse([]));
+
+        const context = createToolHandlerContext(mockRequest, mockEsClient, mockLogger);
+        (context.attachments.getAttachmentRecord as jest.Mock).mockReturnValueOnce(undefined);
+        (context.attachments.add as jest.Mock).mockResolvedValueOnce({
+          id: expectedAttachmentId,
+          current_version: 1,
+        });
+
+        await tool.handler({ entityType: 'host', entityId: 'server1' }, context);
+
+        const addCall = (context.attachments.add as jest.Mock).mock.calls[0][0];
+        expect(addCall.data.riskStats).toBeUndefined();
+        expect(addCall.data.resolutionRiskStats).toBeUndefined();
+      });
+
+      it('still creates the attachment (without risk stats) when the risk index query throws', async () => {
+        (executeEsql as jest.Mock).mockResolvedValueOnce(primaryHitResponse);
+
+        mockEsClient.asCurrentUser.search.mockRejectedValueOnce(
+          new Error('risk index unavailable')
+        );
+
+        const context = createToolHandlerContext(mockRequest, mockEsClient, mockLogger);
+        (context.attachments.getAttachmentRecord as jest.Mock).mockReturnValueOnce(undefined);
+        (context.attachments.add as jest.Mock).mockResolvedValueOnce({
+          id: expectedAttachmentId,
+          current_version: 1,
+        });
+
+        await tool.handler({ entityType: 'host', entityId: 'server1' }, context);
+
+        expect(context.attachments.add).toHaveBeenCalledTimes(1);
+        const addCall = (context.attachments.add as jest.Mock).mock.calls[0][0];
+        expect(addCall.data.riskStats).toBeUndefined();
+      });
+
+      it('embeds primary risk stats when the resolution fetch fails but the primary succeeds', async () => {
+        (executeEsql as jest.Mock).mockResolvedValueOnce(primaryHitResponse);
+
+        mockEsClient.asCurrentUser.search.mockResolvedValueOnce(
+          buildRiskSearchResponse([buildRiskRecord()])
+        );
+
+        const entityStoreStart = {
+          createResolutionClient: jest.fn().mockReturnValue({
+            getResolutionGroup: jest
+              .fn()
+              .mockRejectedValueOnce(new Error('resolution index unavailable')),
+          }),
+        };
+        mockCore.getStartServices.mockResolvedValueOnce([
+          mockCoreStart,
+          { entityStore: entityStoreStart },
+          {},
+        ]);
+
+        const context = createToolHandlerContext(mockRequest, mockEsClient, mockLogger);
+        (context.attachments.getAttachmentRecord as jest.Mock).mockReturnValueOnce(undefined);
+        (context.attachments.add as jest.Mock).mockResolvedValueOnce({
+          id: expectedAttachmentId,
+          current_version: 1,
+        });
+
+        await tool.handler({ entityType: 'host', entityId: 'server1' }, context);
+
+        const addCall = (context.attachments.add as jest.Mock).mock.calls[0][0];
+        expect(addCall.data.riskStats).toBeDefined();
+        expect(addCall.data.resolutionRiskStats).toBeUndefined();
       });
     });
   });

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/entity_analytics/get_entity_tool.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/entity_analytics/get_entity_tool.ts
@@ -18,17 +18,30 @@ import {
 import type { Logger } from '@kbn/logging';
 import type { ElasticsearchClient } from '@kbn/core/server';
 import type { ExperimentalFeatures } from '../../../../common';
+import type { EntityRiskScoreRecord } from '../../../../common/api/entity_analytics/common';
 import { IdentifierType } from '../../../../common/api/entity_analytics/common/common.gen';
 import { DEFAULT_ALERTS_INDEX, ESSENTIAL_ALERT_FIELDS } from '../../../../common/constants';
+import { EntityType } from '../../../../common/entity_analytics/types';
 import { getRiskScoreTimeSeriesIndex } from '../../../../common/entity_analytics/risk_engine/indices';
 import type { SecuritySolutionPluginCoreSetupDependencies } from '../../../plugin_contract';
 import { getAgentBuilderResourceAvailability } from '../../utils/get_agent_builder_resource_availability';
 import { ENTITY_ANALYTICS_AI_TOOL_USAGE_EVENT } from '../../../lib/telemetry/event_based/events';
 import { securityTool } from '../constants';
+import {
+  buildRenderAttachmentTag,
+  buildSingleEntityAttachmentId,
+  describeAttachmentForRow,
+  ensureEntityAttachment,
+  getRowValue,
+  isAttachmentIdentifierType,
+  stripEntityIdPrefix,
+  ENTITY_STORE_ENTITY_TYPE_FIELD,
+  ENTITY_STORE_ENTITY_ID_FIELD,
+  stripRiskRecordForAttachment,
+  type EntityAttachmentRiskStats,
+} from './entity_attachment_utils';
 
 const ENTITY_STORE_RISK_SCORE_NORMALIZED_FIELD = 'entity.risk.calculated_score_norm';
-const ENTITY_STORE_ENTITY_TYPE_FIELD = 'entity.EngineMetadata.Type';
-const ENTITY_STORE_ENTITY_ID_FIELD = 'entity.id';
 
 const schema = z.object({
   entityType: IdentifierType.describe(
@@ -38,7 +51,9 @@ const schema = z.object({
     .string()
     .min(1)
     .describe(
-      'The entity id (EUID) to fetch. Supports both prefixed and non-prefixed forms (for example "host:server1" and "server1").'
+      'The entity id (EUID), canonical entity.name, or user.full_name to fetch. ' +
+        'Examples: "host:server1" (prefixed EUID), "server1" (non-prefixed), ' +
+        '"LAPTOP-SALES04" (entity.name), "John Doe" (user.full_name).'
     ),
   interval: z
     .string()
@@ -83,14 +98,6 @@ export const normalizeEntityId = (
   return entityId.startsWith(prefix) ? entityId : `${prefix}${entityId}`;
 };
 
-const getRowValue = (
-  columns: Array<{ name: string }>,
-  row: unknown[],
-  columnName: string
-): unknown => {
-  const idx = columns.findIndex((col) => col.name === columnName);
-  return idx >= 0 ? row[idx] : undefined;
-};
 interface GetAlertIdsFromRiskScoreIndexParams {
   entityId: string;
   entityType: string;
@@ -167,6 +174,241 @@ const getAlertIdsFromRiskScoreIndex = async ({
   return ids.filter((id): id is string => typeof id === 'string');
 };
 
+/**
+ * Maps the entity-store identifier type to the risk-index `EntityType` enum.
+ * Returns `null` when the type is unsupported (e.g. unknown types or types
+ * without a dedicated risk index mapping) so the caller can skip the
+ * enrichment instead of issuing a doomed query.
+ */
+const identifierTypeToRiskEntityType = (
+  identifierType: z.infer<typeof IdentifierType>
+): EntityType | null => {
+  switch (identifierType) {
+    case 'host':
+      return EntityType.host;
+    case 'user':
+      return EntityType.user;
+    case 'service':
+      return EntityType.service;
+    case 'generic':
+      return EntityType.generic;
+    default:
+      return null;
+  }
+};
+
+interface RiskStatsPair {
+  riskStats?: EntityAttachmentRiskStats;
+  resolutionRiskStats?: EntityAttachmentRiskStats;
+}
+
+interface FetchRiskStatsForAttachmentParams {
+  identifierType: z.infer<typeof IdentifierType>;
+  identifier: string;
+  entityStoreEntityId: string;
+  esClient: ElasticsearchClient;
+  spaceId: string;
+  logger: Logger;
+  createResolutionClient?: (
+    esClient: ElasticsearchClient,
+    namespace: string
+  ) => {
+    getResolutionGroup: (
+      entityId: string
+    ) => Promise<{ group_size: number; target: Record<string, unknown> }>;
+  };
+}
+
+const dedupeNonEmptyStrings = (values: Array<string | undefined>): string[] => {
+  const out = new Set<string>();
+  for (const value of values) {
+    if (typeof value === 'string' && value.length > 0) {
+      out.add(value);
+    }
+  }
+  return [...out];
+};
+
+/**
+ * Direct search against the risk score time-series index for the latest
+ * matching risk document.
+ *
+ * We filter on `<type>.risk.id_value` — the same field the entity-details
+ * flyout uses with Entity Store V2 — and pass multiple `id_value` candidates
+ * through a `terms` clause so we tolerate both V2 (prefixed EUID, e.g.
+ * `user:982675@github`) and V1 (bare name, e.g. `haylee-anderson`) data
+ * shapes without a second round-trip.
+ */
+const searchRiskDocForCandidates = async ({
+  esClient,
+  spaceId,
+  logger,
+  entityType,
+  idCandidates,
+  scoreType,
+  debugLabel,
+}: {
+  esClient: ElasticsearchClient;
+  spaceId: string;
+  logger: Logger;
+  entityType: EntityType;
+  idCandidates: string[];
+  scoreType: 'base' | 'resolution';
+  debugLabel: string;
+}): Promise<EntityRiskScoreRecord | undefined> => {
+  if (idCandidates.length === 0) {
+    return undefined;
+  }
+
+  const idValueField = `${entityType}.risk.id_value`;
+  const scoreTypeField = `${entityType}.risk.score_type`;
+
+  try {
+    const response = await esClient.search<Record<EntityType, { risk: EntityRiskScoreRecord }>>({
+      index: getRiskScoreTimeSeriesIndex(spaceId),
+      ignore_unavailable: true,
+      size: 1,
+      sort: [{ '@timestamp': { order: 'desc' } }],
+      query: {
+        bool: {
+          filter: [
+            { terms: { [idValueField]: idCandidates } },
+            ...(scoreType === 'resolution' ? [{ term: { [scoreTypeField]: 'resolution' } }] : []),
+          ],
+          ...(scoreType === 'base'
+            ? { must_not: [{ term: { [scoreTypeField]: 'resolution' } }] }
+            : {}),
+        },
+      },
+    });
+
+    return response.hits.hits[0]?._source?.[entityType]?.risk;
+  } catch (error) {
+    logger.debug(
+      `Failed to fetch ${scoreType} risk score for attachment ${debugLabel}: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    );
+    return undefined;
+  }
+};
+
+/**
+ * Fetches the full risk breakdown for an entity (and, when part of a
+ * resolution group, the group's resolution risk doc) and returns the
+ * stripped shapes that can be embedded in the `security.entity` attachment.
+ *
+ * The client-side chat card uses these to drive `RiskSummaryMini` without
+ * spinning up a search-strategy call through Redux. Failures are logged and
+ * swallowed — the attachment is still useful without the detailed breakdown.
+ */
+const fetchRiskStatsForAttachment = async ({
+  identifierType,
+  identifier,
+  entityStoreEntityId,
+  esClient,
+  spaceId,
+  logger,
+  createResolutionClient,
+}: FetchRiskStatsForAttachmentParams): Promise<RiskStatsPair> => {
+  const entityType = identifierTypeToRiskEntityType(identifierType);
+  if (!entityType) {
+    return {};
+  }
+
+  const debugLabel = `${identifierType}:${identifier}`;
+  const primaryCandidates = dedupeNonEmptyStrings([entityStoreEntityId, identifier]);
+
+  const primary = await searchRiskDocForCandidates({
+    esClient,
+    spaceId,
+    logger,
+    entityType,
+    idCandidates: primaryCandidates,
+    scoreType: 'base',
+    debugLabel,
+  });
+
+  let resolution: EntityRiskScoreRecord | undefined;
+  if (createResolutionClient) {
+    try {
+      const resolutionClient = createResolutionClient(esClient, spaceId);
+      const group = await resolutionClient.getResolutionGroup(entityStoreEntityId);
+
+      // Only look up a resolution doc when the entity actually participates
+      // in a multi-entity group. For standalone entities `group_size === 1`
+      // and there is no meaningful resolution score to display.
+      if (group.group_size > 1) {
+        // Single target, multiple possible `id_value` representations (V2
+        // prefixed EUID, V1 `entity.name`, and `<type>.name` fallbacks) — the
+        // `terms` clause inside `searchRiskDocForCandidates` OR-matches
+        // whichever shape the resolution risk doc was indexed with, so
+        // `size: 1` still returns the latest doc for this one target.
+        const targetCandidates = getResolutionTargetRiskIdCandidates(group.target);
+        resolution = await searchRiskDocForCandidates({
+          esClient,
+          spaceId,
+          logger,
+          entityType,
+          idCandidates: targetCandidates,
+          scoreType: 'resolution',
+          debugLabel: `${debugLabel} (resolution)`,
+        });
+      }
+    } catch (error) {
+      logger.debug(
+        `Failed to look up resolution group for attachment ${debugLabel}: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+    }
+  }
+
+  return {
+    riskStats: stripRiskRecordForAttachment(primary),
+    resolutionRiskStats: stripRiskRecordForAttachment(resolution),
+  };
+};
+
+/**
+ * Collects the identifier values we should feed into the risk index lookup
+ * for a resolution-group target. The target document is the raw `_source`
+ * from the latest-entities index, so we walk the shape to gather every
+ * candidate the risk doc could be keyed on:
+ *
+ * - `entity.id` — V2's prefixed EUID (matches `<type>.risk.id_value`).
+ * - `entity.name` — the display name (matches legacy V1 risk docs keyed
+ *   off `<type>.name`).
+ * - `host.name`/`user.name`/`service.name` as last-ditch fallbacks for
+ *   targets that don't carry the `entity` block.
+ */
+const getResolutionTargetRiskIdCandidates = (target: Record<string, unknown>): string[] => {
+  const entity = target.entity as
+    | { EngineMetadata?: { Type?: unknown }; id?: unknown; name?: unknown }
+    | undefined;
+
+  const candidates: Array<string | undefined> = [];
+
+  if (typeof entity?.id === 'string') {
+    candidates.push(entity.id);
+  }
+  if (typeof entity?.name === 'string') {
+    candidates.push(entity.name);
+  }
+
+  const nameFields = ['host.name', 'user.name', 'service.name'];
+  for (const field of nameFields) {
+    const [first, second] = field.split('.');
+    const namespace = target[first] as Record<string, unknown> | undefined;
+    const value = namespace?.[second];
+    if (typeof value === 'string') {
+      candidates.push(value);
+    }
+  }
+
+  return dedupeNonEmptyStrings(candidates);
+};
+
 interface FindEntityByIdParams {
   entityIndex: string;
   entityId: string;
@@ -174,38 +416,76 @@ interface FindEntityByIdParams {
   esClient: ElasticsearchClient;
 }
 
+type MatchSource = 'exact_id' | 'exact_name' | 'rlike_id' | 'rlike_name';
+
+interface FindEntityByIdResult {
+  source: MatchSource;
+  query: string;
+  columns: Array<{ name: string; type: string }>;
+  values: unknown[][];
+}
+
 const findEntityById = async ({
   entityIndex,
   entityId,
   entityType,
   esClient,
-}: FindEntityByIdParams) => {
+}: FindEntityByIdParams): Promise<FindEntityByIdResult> => {
   const normalizedEntityId = normalizeEntityId(entityId, entityType);
-  const escapedEntityId = escapeEsqlString(normalizedEntityId);
-  const query = `FROM ${entityIndex} | WHERE entity.id == "${escapedEntityId}" | LIMIT 1`;
-  const { columns, values } = await executeEsql({ query, esClient });
+  const escapedNormalized = escapeEsqlString(normalizedEntityId);
 
-  if (values.length === 0) {
-    const rlikePattern = escapeEsqlRlikePattern(entityId);
-    const likeQuery = `FROM ${entityIndex} | WHERE entity.id RLIKE ".*${rlikePattern}.*" | LIMIT 5`;
-    const { columns: likeColumns, values: likeValues } = await executeEsql({
-      query: likeQuery,
-      esClient,
-    });
-
-    if (likeValues.length === 0) {
-      const nameQuery = `FROM ${entityIndex} | WHERE entity.name RLIKE ".*${rlikePattern}.*" OR user.full_name RLIKE ".*${rlikePattern}.*" | LIMIT 5`;
-      const { columns: nameColumns, values: nameValues } = await executeEsql({
-        query: nameQuery,
-        esClient,
-      });
-      return { query: nameQuery, columns: nameColumns, values: nameValues };
-    }
-
-    return { query: likeQuery, columns: likeColumns, values: likeValues };
+  // 1. Exact id match (canonical key, uses prefix if entityType provided)
+  const idQuery = `FROM ${entityIndex} | WHERE entity.id == "${escapedNormalized}" | LIMIT 1`;
+  const idHit = await executeEsql({ query: idQuery, esClient });
+  if (idHit.values.length > 0) {
+    return { source: 'exact_id', query: idQuery, columns: idHit.columns, values: idHit.values };
   }
 
-  return { query, columns, values };
+  // 2. Exact name match against entity.name, user.full_name, or host.name.
+  // `user.full_name` and `host.name` are multi-valued `collect` fields in the
+  // entity store, so we use MV_CONTAINS instead of `==` (which returns null
+  // with a warning on MV inputs). LIMIT 2 still detects display-name
+  // collisions so we can suppress the rich entity card and let the LLM
+  // disambiguate.
+  const escapedRaw = escapeEsqlString(entityId);
+  const nameExactQuery =
+    `FROM ${entityIndex} ` +
+    `| WHERE entity.name == "${escapedRaw}" ` +
+    `OR MV_CONTAINS(user.full_name, "${escapedRaw}") ` +
+    `OR MV_CONTAINS(host.name, "${escapedRaw}") ` +
+    `| LIMIT 2`;
+  const nameExactHit = await executeEsql({ query: nameExactQuery, esClient });
+  if (nameExactHit.values.length > 0) {
+    return {
+      source: 'exact_name',
+      query: nameExactQuery,
+      columns: nameExactHit.columns,
+      values: nameExactHit.values,
+    };
+  }
+
+  // 3. entity.id RLIKE fallback (substring match)
+  const rlikePattern = escapeEsqlRlikePattern(entityId);
+  const likeQuery = `FROM ${entityIndex} | WHERE entity.id RLIKE ".*${rlikePattern}.*" | LIMIT 5`;
+  const likeHit = await executeEsql({ query: likeQuery, esClient });
+  if (likeHit.values.length > 0) {
+    return {
+      source: 'rlike_id',
+      query: likeQuery,
+      columns: likeHit.columns,
+      values: likeHit.values,
+    };
+  }
+
+  // 4. entity.name / user.full_name RLIKE fallback (substring match)
+  const nameQuery = `FROM ${entityIndex} | WHERE entity.name RLIKE ".*${rlikePattern}.*" OR user.full_name RLIKE ".*${rlikePattern}.*" | LIMIT 5`;
+  const nameHit = await executeEsql({ query: nameQuery, esClient });
+  return {
+    source: 'rlike_name',
+    query: nameQuery,
+    columns: nameHit.columns,
+    values: nameHit.values,
+  };
 };
 
 interface EnrichEntityResultParams {
@@ -312,7 +592,9 @@ export const getEntityTool = (
   return {
     id: SECURITY_GET_ENTITY_TOOL_ID,
     type: ToolType.builtin,
-    description: `Retrieve profile for security entity (user, host, service, generic) from the Entity store using entity ID (EUID). Includes the alerts that contributed to the risk score if the entity has a risk score.`,
+    description: `Retrieve profile for security entity (user, host, service, generic) from the Entity store using entity ID (EUID). Includes the alerts that contributed to the risk score if the entity has a risk score.
+
+When exactly one entity is resolved, this tool also stores a \`security.entity\` attachment (creating new or updating existing) and its \`other\` result includes a pre-formatted \`renderTag\` string. To show the rich entity card inline, copy that \`renderTag\` string verbatim onto its own line in your reply BEFORE your prose summary. Do NOT assemble the tag yourself from \`attachmentId\` and \`version\`, and do NOT substitute the id with anything derived from the user's prompt. When the query resolves multiple candidates (fallback match) no attachment is stored, no \`renderTag\` is returned, and you must not emit a render tag in that case.`,
     schema,
     tags: ['security', 'entity-store', 'entity-analytics'],
     availability: {
@@ -356,7 +638,7 @@ export const getEntityTool = (
         }
       },
     },
-    handler: async (params, { spaceId, esClient }) => {
+    handler: async (params, { spaceId, esClient, attachments }) => {
       logger.debug(
         `${SECURITY_GET_ENTITY_TOOL_ID} tool called with parameters ${JSON.stringify(params)}`
       );
@@ -372,7 +654,7 @@ export const getEntityTool = (
         const normalizedEntityId = normalizeEntityId(entityId, entityType);
         const entityIndex = getEntitiesAlias(ENTITY_LATEST, spaceId);
 
-        const { query, columns, values } = await findEntityById({
+        const { source, query, columns, values } = await findEntityById({
           entityIndex,
           entityId,
           entityType,
@@ -392,6 +674,100 @@ export const getEntityTool = (
           };
         }
 
+        // Persist a rich entity attachment only for high-confidence single-row
+        // matches. Exact id/name matches are always trusted; the entity.id RLIKE
+        // fallback is also trusted when the single resolved row's stripped id
+        // equals the user input (i.e. the LLM forgot the "{type}:" prefix).
+        // The entity.name RLIKE fallback stays excluded — display-name substring
+        // matches are too ambiguous to authoritatively render a card for.
+        const isRlikeIdPrefixMatch = (): boolean => {
+          if (source !== 'rlike_id' || values.length !== 1) {
+            return false;
+          }
+          const row = values[0];
+          const rawType = getRowValue(columns, row, ENTITY_STORE_ENTITY_TYPE_FIELD);
+          const rawId = getRowValue(columns, row, ENTITY_STORE_ENTITY_ID_FIELD);
+          if (!isAttachmentIdentifierType(rawType) || typeof rawId !== 'string') {
+            return false;
+          }
+          return stripEntityIdPrefix(rawId, rawType) === entityId;
+        };
+
+        const shouldCreateAttachment =
+          values.length === 1 &&
+          (source === 'exact_id' || source === 'exact_name' || isRlikeIdPrefixMatch());
+
+        const attachmentResult = shouldCreateAttachment
+          ? await (async () => {
+              const baseDescriptor = describeAttachmentForRow({ columns, row: values[0] });
+              if (!baseDescriptor) {
+                return null;
+              }
+
+              // Fetch the real risk breakdown so the chat card's
+              // contributions table mirrors the flyout instead of showing
+              // zeros (the entity store only stores high-level scores).
+              // We prefer the entity-store `entity.id` for the resolution
+              // lookup because the resolution group is keyed on that field.
+              const rowEntityStoreId = getRowValue(
+                columns,
+                values[0],
+                ENTITY_STORE_ENTITY_ID_FIELD
+              );
+              const [, startPlugins] = await core.getStartServices();
+              const entityStoreStart = startPlugins.entityStore;
+              const enrichment = await fetchRiskStatsForAttachment({
+                identifierType: baseDescriptor.identifierType,
+                identifier: baseDescriptor.identifier,
+                entityStoreEntityId: typeof rowEntityStoreId === 'string' ? rowEntityStoreId : '',
+                esClient: client,
+                spaceId,
+                logger,
+                createResolutionClient: entityStoreStart?.createResolutionClient,
+              });
+
+              const descriptor = describeAttachmentForRow({
+                columns,
+                row: values[0],
+                enrichment,
+              });
+              if (!descriptor) {
+                return null;
+              }
+
+              return ensureEntityAttachment({
+                attachments,
+                id: buildSingleEntityAttachmentId(descriptor.identifierType, descriptor.identifier),
+                data: {
+                  identifierType: descriptor.identifierType,
+                  identifier: descriptor.identifier,
+                  attachmentLabel: descriptor.attachmentLabel,
+                  ...(descriptor.entityStoreId ? { entityStoreId: descriptor.entityStoreId } : {}),
+                  ...(descriptor.riskStats ? { riskStats: descriptor.riskStats } : {}),
+                  ...(descriptor.resolutionRiskStats
+                    ? { resolutionRiskStats: descriptor.resolutionRiskStats }
+                    : {}),
+                },
+                description: descriptor.attachmentLabel,
+                logger,
+              });
+            })()
+          : null;
+
+        const attachmentSideEffectResults = attachmentResult
+          ? [
+              {
+                tool_result_id: getToolResultId(),
+                type: ToolResultType.other as const,
+                data: {
+                  attachmentId: attachmentResult.attachmentId,
+                  version: attachmentResult.version,
+                  renderTag: buildRenderAttachmentTag(attachmentResult),
+                },
+              },
+            ]
+          : [];
+
         try {
           const enrichedResults = await Promise.all(
             values.map((row) =>
@@ -400,7 +776,7 @@ export const getEntityTool = (
           );
           success = true;
           entitiesReturned = enrichedResults.length;
-          return { results: enrichedResults };
+          return { results: [...enrichedResults, ...attachmentSideEffectResults] };
         } catch (error) {
           logger.debug(
             `Error enriching entity results: ${
@@ -410,11 +786,14 @@ export const getEntityTool = (
           success = true;
           entitiesReturned = values.length;
           return {
-            results: values.map((row) => ({
-              tool_result_id: getToolResultId(),
-              type: ToolResultType.esqlResults,
-              data: { query, columns, values: [row] },
-            })),
+            results: [
+              ...values.map((row) => ({
+                tool_result_id: getToolResultId(),
+                type: ToolResultType.esqlResults,
+                data: { query, columns, values: [row] },
+              })),
+              ...attachmentSideEffectResults,
+            ],
           };
         }
       } catch (error) {

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/entity_analytics/search_entities_tool.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/entity_analytics/search_entities_tool.test.ts
@@ -5,7 +5,12 @@
  * 2.0.
  */
 
-import { ToolResultType, type ErrorResult, type EsqlResults } from '@kbn/agent-builder-common';
+import {
+  ToolResultType,
+  type ErrorResult,
+  type EsqlResults,
+  type OtherResult,
+} from '@kbn/agent-builder-common';
 import { executeEsql } from '@kbn/agent-builder-genai-utils';
 import type { ToolHandlerStandardReturn } from '@kbn/agent-builder-server/tools';
 import type { coreMock } from '@kbn/core/server/mocks';
@@ -17,7 +22,13 @@ import {
   setupMockCoreStartServices,
 } from '../../__mocks__/test_helpers';
 import type { ExperimentalFeatures } from '../../../../common';
+import { SecurityAgentBuilderAttachments } from '../../../../common/constants';
 import { ENTITY_ANALYTICS_AI_TOOL_USAGE_EVENT } from '../../../lib/telemetry/event_based/events';
+import {
+  buildListEntityAttachmentId,
+  buildRenderAttachmentTag,
+  buildSingleEntityAttachmentId,
+} from './entity_attachment_utils';
 import { searchEntitiesTool, SECURITY_SEARCH_ENTITIES_TOOL_ID } from './search_entities_tool';
 
 jest.mock('../../utils/get_agent_builder_resource_availability', () => ({
@@ -106,6 +117,21 @@ describe('searchEntitiesTool', () => {
       expect(result.success).toBe(false);
     });
 
+    it('accepts sortBy: "riskScore"', () => {
+      const result = tool.schema.safeParse({ sortBy: 'riskScore' });
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts sortBy: "criticality"', () => {
+      const result = tool.schema.safeParse({ sortBy: 'criticality' });
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects unknown sortBy values', () => {
+      const result = tool.schema.safeParse({ sortBy: 'firstSeen' });
+      expect(result.success).toBe(false);
+    });
+
     it('accepts watchlists', () => {
       const result = tool.schema.safeParse({ watchlists: ['vip', 'threat-actors'] });
       expect(result.success).toBe(true);
@@ -113,6 +139,30 @@ describe('searchEntitiesTool', () => {
 
     it('rejects empty watchlist string', () => {
       const result = tool.schema.safeParse({ watchlists: [''] });
+      expect(result.success).toBe(false);
+    });
+
+    it('accepts sources (raw integration keys)', () => {
+      const result = tool.schema.safeParse({
+        sources: ['crowdstrike', 'island_browser'],
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects empty source string', () => {
+      const result = tool.schema.safeParse({ sources: [''] });
+      expect(result.success).toBe(false);
+    });
+
+    it('accepts namespaces (canonical vendor namespaces)', () => {
+      const result = tool.schema.safeParse({
+        namespaces: ['okta', 'entra_id', 'aws'],
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects empty namespace string', () => {
+      const result = tool.schema.safeParse({ namespaces: [''] });
       expect(result.success).toBe(false);
     });
 
@@ -275,7 +325,13 @@ describe('searchEntitiesTool', () => {
       expect(query).toContain(EXPECTED_KEEP_CLAUSE);
       expect(query).toContain(EXPECTED_SORT_CLAUSE);
       expect(query).toContain('LIMIT 10');
-      expect(query).not.toContain('WHERE');
+      // The default risk-score sort always pairs with an IS NOT NULL guard so
+      // that ES|QL's NULLS-FIRST DESC ordering doesn't fill LIMIT N with
+      // unscored entities. The test still asserts that no caller-driven filter
+      // clauses (identity / risk floor) were emitted for empty params.
+      expect(query).toContain('WHERE entity.risk.calculated_score_norm IS NOT NULL');
+      expect(query).not.toContain('WHERE entity.EngineMetadata.Type');
+      expect(query).not.toContain('WHERE entity.risk.calculated_score_norm >=');
 
       expect(result.results).toHaveLength(2);
       expect(result.results[0].type).toBe(ToolResultType.esqlResults);
@@ -298,13 +354,237 @@ describe('searchEntitiesTool', () => {
       mockSingleEntityResponse();
 
       await tool.handler(
-        { riskScoreMin: 70, riskScoreMax: 100 },
+        { riskScoreMin: 70, riskScoreMax: 95 },
         createToolHandlerContext(mockRequest, mockEsClient, mockLogger)
       );
 
       const { query } = (executeEsql as jest.Mock).mock.calls[0][0];
       expect(query).toContain('WHERE entity.risk.calculated_score_norm >= 70');
-      expect(query).toContain('WHERE entity.risk.calculated_score_norm <= 100');
+      expect(query).toContain('WHERE entity.risk.calculated_score_norm <= 95');
+    });
+
+    it('treats riskScoreMin:0 as "no floor" and does not emit a calculated_score_norm >= clause (keeps null-scored entities)', async () => {
+      mockSingleEntityResponse();
+
+      await tool.handler(
+        { riskScoreMin: 0 },
+        createToolHandlerContext(mockRequest, mockEsClient, mockLogger)
+      );
+
+      const { query } = (executeEsql as jest.Mock).mock.calls[0][0];
+      expect(query).not.toContain('entity.risk.calculated_score_norm >=');
+    });
+
+    it('still emits the >= clause when riskScoreMin is strictly positive', async () => {
+      mockSingleEntityResponse();
+
+      await tool.handler(
+        { riskScoreMin: 1 },
+        createToolHandlerContext(mockRequest, mockEsClient, mockLogger)
+      );
+
+      const { query } = (executeEsql as jest.Mock).mock.calls[0][0];
+      expect(query).toContain('WHERE entity.risk.calculated_score_norm >= 1');
+    });
+
+    it('does not emit the >= clause when riskScoreMin is omitted', async () => {
+      mockSingleEntityResponse();
+
+      await tool.handler(
+        { entityTypes: ['user'] },
+        createToolHandlerContext(mockRequest, mockEsClient, mockLogger)
+      );
+
+      const { query } = (executeEsql as jest.Mock).mock.calls[0][0];
+      expect(query).not.toContain('entity.risk.calculated_score_norm >=');
+    });
+
+    it('still emits riskScoreMax when it is set to 0 (upper bound is not ambiguous)', async () => {
+      mockSingleEntityResponse();
+
+      await tool.handler(
+        { riskScoreMax: 0 },
+        createToolHandlerContext(mockRequest, mockEsClient, mockLogger)
+      );
+
+      const { query } = (executeEsql as jest.Mock).mock.calls[0][0];
+      expect(query).toContain('WHERE entity.risk.calculated_score_norm <= 0');
+    });
+
+    it('drops riskScoreMax when it is 100 (no upper bound needed, preserves NULL rows)', async () => {
+      mockSingleEntityResponse();
+
+      await tool.handler(
+        { riskScoreMax: 100 },
+        createToolHandlerContext(mockRequest, mockEsClient, mockLogger)
+      );
+
+      const { query } = (executeEsql as jest.Mock).mock.calls[0][0];
+      expect(query).not.toContain('entity.risk.calculated_score_norm <=');
+    });
+
+    it('still emits riskScoreMax when it is 99 (regression)', async () => {
+      mockSingleEntityResponse();
+
+      await tool.handler(
+        { riskScoreMax: 99 },
+        createToolHandlerContext(mockRequest, mockEsClient, mockLogger)
+      );
+
+      const { query } = (executeEsql as jest.Mock).mock.calls[0][0];
+      expect(query).toContain('WHERE entity.risk.calculated_score_norm <= 99');
+    });
+
+    it('drops both firstSeen bounds when firstSeenAfter === firstSeenBefore (zero-width window)', async () => {
+      mockSingleEntityResponse();
+
+      await tool.handler(
+        {
+          firstSeenAfter: '2024-06-15T12:00:00Z',
+          firstSeenBefore: '2024-06-15T12:00:00Z',
+        },
+        createToolHandlerContext(mockRequest, mockEsClient, mockLogger)
+      );
+
+      const { query } = (executeEsql as jest.Mock).mock.calls[0][0];
+      expect(query).not.toContain('entity.lifecycle.first_seen >=');
+      expect(query).not.toContain('entity.lifecycle.first_seen <=');
+    });
+
+    it('drops both lastSeen bounds when lastSeenAfter === lastSeenBefore (zero-width window)', async () => {
+      mockSingleEntityResponse();
+
+      await tool.handler(
+        {
+          lastSeenAfter: '2024-06-15T12:00:00Z',
+          lastSeenBefore: '2024-06-15T12:00:00Z',
+        },
+        createToolHandlerContext(mockRequest, mockEsClient, mockLogger)
+      );
+
+      const { query } = (executeEsql as jest.Mock).mock.calls[0][0];
+      expect(query).not.toContain('entity.lifecycle.last_activity >=');
+      expect(query).not.toContain('entity.lifecycle.last_activity <=');
+    });
+
+    it('still emits both lifecycle bounds when the firstSeen values differ (regression)', async () => {
+      mockSingleEntityResponse();
+
+      await tool.handler(
+        {
+          firstSeenAfter: '2024-01-01T00:00:00Z',
+          firstSeenBefore: '2024-12-31T23:59:59Z',
+        },
+        createToolHandlerContext(mockRequest, mockEsClient, mockLogger)
+      );
+
+      const { query } = (executeEsql as jest.Mock).mock.calls[0][0];
+      expect(query).toContain('WHERE entity.lifecycle.first_seen >= "2024-01-01T00:00:00Z"');
+      expect(query).toContain('WHERE entity.lifecycle.first_seen <= "2024-12-31T23:59:59Z"');
+    });
+
+    it('drops firstSeenAfter when it is at or before the 2000-01-01 epoch cutoff', async () => {
+      mockSingleEntityResponse();
+
+      await tool.handler(
+        { firstSeenAfter: '1970-01-01T00:00:00Z' },
+        createToolHandlerContext(mockRequest, mockEsClient, mockLogger)
+      );
+
+      const { query } = (executeEsql as jest.Mock).mock.calls[0][0];
+      expect(query).not.toContain('entity.lifecycle.first_seen >=');
+    });
+
+    it('drops firstSeenAfter exactly at 2000-01-01 (cutoff boundary)', async () => {
+      mockSingleEntityResponse();
+
+      await tool.handler(
+        { firstSeenAfter: '2000-01-01T00:00:00Z' },
+        createToolHandlerContext(mockRequest, mockEsClient, mockLogger)
+      );
+
+      const { query } = (executeEsql as jest.Mock).mock.calls[0][0];
+      expect(query).not.toContain('entity.lifecycle.first_seen >=');
+    });
+
+    it('keeps firstSeenAfter just past the cutoff (regression)', async () => {
+      mockSingleEntityResponse();
+
+      await tool.handler(
+        { firstSeenAfter: '2000-01-02T00:00:00Z' },
+        createToolHandlerContext(mockRequest, mockEsClient, mockLogger)
+      );
+
+      const { query } = (executeEsql as jest.Mock).mock.calls[0][0];
+      expect(query).toContain('WHERE entity.lifecycle.first_seen >= "2000-01-02T00:00:00Z"');
+    });
+
+    it('drops firstSeenBefore when it is strictly after now (year 9999 sentinel)', async () => {
+      mockSingleEntityResponse();
+
+      await tool.handler(
+        { firstSeenBefore: '9999-12-31T23:59:59Z' },
+        createToolHandlerContext(mockRequest, mockEsClient, mockLogger)
+      );
+
+      const { query } = (executeEsql as jest.Mock).mock.calls[0][0];
+      expect(query).not.toContain('entity.lifecycle.first_seen <=');
+    });
+
+    it('drops firstSeenBefore when it is strictly after now (year 2099 sentinel)', async () => {
+      mockSingleEntityResponse();
+
+      await tool.handler(
+        { firstSeenBefore: '2099-12-31T23:59:59Z' },
+        createToolHandlerContext(mockRequest, mockEsClient, mockLogger)
+      );
+
+      const { query } = (executeEsql as jest.Mock).mock.calls[0][0];
+      expect(query).not.toContain('entity.lifecycle.first_seen <=');
+    });
+
+    it('keeps firstSeenBefore when it is in the past (regression)', async () => {
+      mockSingleEntityResponse();
+
+      await tool.handler(
+        { firstSeenBefore: '2020-01-01T00:00:00Z' },
+        createToolHandlerContext(mockRequest, mockEsClient, mockLogger)
+      );
+
+      const { query } = (executeEsql as jest.Mock).mock.calls[0][0];
+      expect(query).toContain('WHERE entity.lifecycle.first_seen <= "2020-01-01T00:00:00Z"');
+    });
+
+    it('drops lastSeenAfter / lastSeenBefore using the same rule (parity with firstSeen*)', async () => {
+      mockSingleEntityResponse();
+
+      await tool.handler(
+        {
+          lastSeenAfter: '1970-01-01T00:00:00Z',
+          lastSeenBefore: '2099-12-31T23:59:59Z',
+        },
+        createToolHandlerContext(mockRequest, mockEsClient, mockLogger)
+      );
+
+      const { query } = (executeEsql as jest.Mock).mock.calls[0][0];
+      expect(query).not.toContain('entity.lifecycle.last_activity >=');
+      expect(query).not.toContain('entity.lifecycle.last_activity <=');
+    });
+
+    it('keeps the genuine half when only one bound is a sentinel', async () => {
+      mockSingleEntityResponse();
+
+      await tool.handler(
+        {
+          firstSeenAfter: '2024-01-01T00:00:00Z',
+          firstSeenBefore: '9999-12-31T23:59:59Z',
+        },
+        createToolHandlerContext(mockRequest, mockEsClient, mockLogger)
+      );
+
+      const { query } = (executeEsql as jest.Mock).mock.calls[0][0];
+      expect(query).toContain('WHERE entity.lifecycle.first_seen >= "2024-01-01T00:00:00Z"');
+      expect(query).not.toContain('entity.lifecycle.first_seen <=');
     });
 
     it('includes risk level filter in query', async () => {
@@ -331,6 +611,240 @@ describe('searchEntitiesTool', () => {
       expect(query).toContain('WHERE asset.criticality IN ("high_impact", "extreme_impact")');
     });
 
+    describe('sortBy', () => {
+      const EXPECTED_CRITICALITY_RANK_EVAL =
+        'EVAL criticality_rank = CASE(' +
+        'asset.criticality == "extreme_impact", 4, ' +
+        'asset.criticality == "high_impact", 3, ' +
+        'asset.criticality == "medium_impact", 2, ' +
+        'asset.criticality == "low_impact", 1, ' +
+        '0)';
+      const EXPECTED_CRITICALITY_SORT_CLAUSE =
+        'SORT criticality_rank DESC, entity.risk.calculated_score_norm DESC';
+
+      it('defaults to risk score sort and emits no criticality_rank EVAL when sortBy is omitted', async () => {
+        mockSingleEntityResponse();
+
+        await tool.handler({}, createToolHandlerContext(mockRequest, mockEsClient, mockLogger));
+
+        const { query } = (executeEsql as jest.Mock).mock.calls[0][0];
+        expect(query).toContain(EXPECTED_SORT_CLAUSE);
+        expect(query).not.toContain('criticality_rank');
+      });
+
+      it('keeps risk score sort when sortBy is explicitly "riskScore"', async () => {
+        mockSingleEntityResponse();
+
+        await tool.handler(
+          { sortBy: 'riskScore' },
+          createToolHandlerContext(mockRequest, mockEsClient, mockLogger)
+        );
+
+        const { query } = (executeEsql as jest.Mock).mock.calls[0][0];
+        expect(query).toContain(EXPECTED_SORT_CLAUSE);
+        expect(query).not.toContain('criticality_rank');
+      });
+
+      it('emits criticality_rank EVAL and composite SORT when sortBy is "criticality"', async () => {
+        mockSingleEntityResponse();
+
+        await tool.handler(
+          { sortBy: 'criticality' },
+          createToolHandlerContext(mockRequest, mockEsClient, mockLogger)
+        );
+
+        const { query } = (executeEsql as jest.Mock).mock.calls[0][0];
+        expect(query).toContain(EXPECTED_CRITICALITY_RANK_EVAL);
+        expect(query).toContain(EXPECTED_CRITICALITY_SORT_CLAUSE);
+        // Plain risk-score SORT should not be present when ordering by criticality.
+        expect(query).not.toMatch(/SORT entity\.risk\.calculated_score_norm DESC$/m);
+      });
+
+      it('applies the EVAL before the SORT so criticality_rank is defined when sorting', async () => {
+        mockSingleEntityResponse();
+
+        await tool.handler(
+          { sortBy: 'criticality' },
+          createToolHandlerContext(mockRequest, mockEsClient, mockLogger)
+        );
+
+        const { query } = (executeEsql as jest.Mock).mock.calls[0][0];
+        const evalIdx = query.indexOf(EXPECTED_CRITICALITY_RANK_EVAL);
+        const sortIdx = query.indexOf(EXPECTED_CRITICALITY_SORT_CLAUSE);
+        expect(evalIdx).toBeGreaterThan(-1);
+        expect(sortIdx).toBeGreaterThan(evalIdx);
+      });
+
+      it('does not leak criticality_rank into the KEEP projection', async () => {
+        mockSingleEntityResponse();
+
+        await tool.handler(
+          { sortBy: 'criticality' },
+          createToolHandlerContext(mockRequest, mockEsClient, mockLogger)
+        );
+
+        const { query } = (executeEsql as jest.Mock).mock.calls[0][0];
+        expect(query).toContain(EXPECTED_KEEP_CLAUSE);
+        // The KEEP list is an exact field enumeration, so criticality_rank
+        // is dropped from the projected columns after the SORT consumes it.
+        expect(query).not.toMatch(/KEEP[^\n]*criticality_rank/);
+      });
+
+      it('composes sortBy: "criticality" with criticalityLevels filter', async () => {
+        mockSingleEntityResponse();
+
+        await tool.handler(
+          {
+            sortBy: 'criticality',
+            criticalityLevels: ['extreme_impact', 'high_impact'],
+          },
+          createToolHandlerContext(mockRequest, mockEsClient, mockLogger)
+        );
+
+        const { query } = (executeEsql as jest.Mock).mock.calls[0][0];
+        expect(query).toContain('WHERE asset.criticality IN ("extreme_impact", "high_impact")');
+        expect(query).toContain(EXPECTED_CRITICALITY_RANK_EVAL);
+        expect(query).toContain(EXPECTED_CRITICALITY_SORT_CLAUSE);
+      });
+
+      it('drops riskScoreChangeInterval silently when sortBy: "criticality" is set (sortBy wins)', async () => {
+        mockSingleEntityResponse();
+
+        await tool.handler(
+          { sortBy: 'criticality', riskScoreChangeInterval: '30d' },
+          createToolHandlerContext(mockRequest, mockEsClient, mockLogger)
+        );
+
+        expect(executeEsql).toHaveBeenCalledTimes(1);
+        const { query } = (executeEsql as jest.Mock).mock.calls[0][0];
+        expect(query).toContain(EXPECTED_CRITICALITY_RANK_EVAL);
+        expect(query).toContain(EXPECTED_CRITICALITY_SORT_CLAUSE);
+        expect(query).not.toContain('risk_score_change');
+        expect(query).not.toContain('STATS');
+      });
+
+      it('drops riskScoreChangeInterval silently when sortBy: "riskScore" is set (sortBy wins)', async () => {
+        mockSingleEntityResponse();
+
+        await tool.handler(
+          { sortBy: 'riskScore', riskScoreChangeInterval: '7d' },
+          createToolHandlerContext(mockRequest, mockEsClient, mockLogger)
+        );
+
+        expect(executeEsql).toHaveBeenCalledTimes(1);
+        const { query } = (executeEsql as jest.Mock).mock.calls[0][0];
+        expect(query).toContain(EXPECTED_SORT_CLAUSE);
+        expect(query).not.toContain('risk_score_change');
+        expect(query).not.toContain('STATS');
+      });
+
+      it('handles the full ChatGPT over-fill shape gracefully (criticality sort, no STATS, no lifecycle, no <= 100)', async () => {
+        mockSingleEntityResponse();
+
+        await tool.handler(
+          {
+            entityTypes: ['user'],
+            sortBy: 'criticality',
+            maxResults: 5,
+            riskScoreChangeInterval: '1d',
+            riskScoreMax: 100,
+            riskScoreMin: 0,
+            firstSeenAfter: '1970-01-01T00:00:00Z',
+            firstSeenBefore: '2099-12-31T23:59:59Z',
+            lastSeenAfter: '1970-01-01T00:00:00Z',
+            lastSeenBefore: '2099-12-31T23:59:59Z',
+            managedOnly: false,
+            mfaEnabledOnly: false,
+            assetOnly: false,
+            riskLevels: [],
+            criticalityLevels: [],
+            sources: [],
+            watchlists: [],
+            namespaces: [],
+          },
+          createToolHandlerContext(mockRequest, mockEsClient, mockLogger)
+        );
+
+        expect(executeEsql).toHaveBeenCalledTimes(1);
+        const { query } = (executeEsql as jest.Mock).mock.calls[0][0];
+        expect(query).toContain(EXPECTED_CRITICALITY_RANK_EVAL);
+        expect(query).toContain(EXPECTED_CRITICALITY_SORT_CLAUSE);
+        expect(query).not.toContain('risk_score_change');
+        expect(query).not.toContain('STATS');
+        expect(query).not.toContain('entity.risk.calculated_score_norm <=');
+        expect(query).not.toContain('entity.lifecycle.first_seen >=');
+        expect(query).not.toContain('entity.lifecycle.first_seen <=');
+        expect(query).not.toContain('entity.lifecycle.last_activity >=');
+        expect(query).not.toContain('entity.lifecycle.last_activity <=');
+        expect(query).toContain('WHERE entity.EngineMetadata.Type IN ("user")');
+        expect(query).toContain('LIMIT 5');
+      });
+
+      it('adds entity.risk.calculated_score_norm IS NOT NULL when sortBy is omitted (default risk-score sort)', async () => {
+        mockSingleEntityResponse();
+
+        await tool.handler(
+          { entityTypes: ['user'] },
+          createToolHandlerContext(mockRequest, mockEsClient, mockLogger)
+        );
+
+        const { query } = (executeEsql as jest.Mock).mock.calls[0][0];
+        // ES|QL sorts NULL FIRST in DESC, so the default risk-score sort is
+        // paired with an IS NOT NULL guard so that LIMIT N doesn't get filled
+        // with unscored rows at the top of a "top N riskiest" ranking.
+        expect(query).toContain('WHERE entity.risk.calculated_score_norm IS NOT NULL');
+        expect(query).toContain(EXPECTED_SORT_CLAUSE);
+      });
+
+      it('adds entity.risk.calculated_score_norm IS NOT NULL when sortBy is explicit "riskScore"', async () => {
+        mockSingleEntityResponse();
+
+        await tool.handler(
+          { sortBy: 'riskScore' },
+          createToolHandlerContext(mockRequest, mockEsClient, mockLogger)
+        );
+
+        const { query } = (executeEsql as jest.Mock).mock.calls[0][0];
+        expect(query).toContain('WHERE entity.risk.calculated_score_norm IS NOT NULL');
+        expect(query).toContain(EXPECTED_SORT_CLAUSE);
+      });
+
+      it('does NOT add the IS NOT NULL guard when sortBy is "criticality" (criticality_rank handles nulls)', async () => {
+        mockSingleEntityResponse();
+
+        await tool.handler(
+          { sortBy: 'criticality' },
+          createToolHandlerContext(mockRequest, mockEsClient, mockLogger)
+        );
+
+        const { query } = (executeEsql as jest.Mock).mock.calls[0][0];
+        // The criticality branch deliberately keeps unscored entities in the
+        // result set; they land at the bottom because criticality_rank defaults
+        // to 0 for rows without an asset.criticality match.
+        expect(query).not.toContain('entity.risk.calculated_score_norm IS NOT NULL');
+        expect(query).toContain(EXPECTED_CRITICALITY_RANK_EVAL);
+        expect(query).toContain(EXPECTED_CRITICALITY_SORT_CLAUSE);
+      });
+
+      it('keeps exactly one IS NOT NULL guard when riskScoreChangeInterval is set (no duplication with the default branch)', async () => {
+        mockSingleEntityResponse();
+
+        await tool.handler(
+          { riskScoreChangeInterval: '30d' },
+          createToolHandlerContext(mockRequest, mockEsClient, mockLogger)
+        );
+
+        const { query } = (executeEsql as jest.Mock).mock.calls[0][0];
+        // The two branches are mutually exclusive via `else if`, so the
+        // riskScoreChangeInterval path should emit exactly one IS NOT NULL
+        // clause — not one from its own branch plus another from the default
+        // risk-score fallback.
+        const matches = query.match(/WHERE entity\.risk\.calculated_score_norm IS NOT NULL/g);
+        expect(matches).not.toBeNull();
+        expect(matches).toHaveLength(1);
+      });
+    });
+
     it('includes watchlist filter using MV_CONTAINS in query', async () => {
       mockSingleEntityResponse();
 
@@ -342,6 +856,86 @@ describe('searchEntitiesTool', () => {
       const { query } = (executeEsql as jest.Mock).mock.calls[0][0];
       expect(query).toContain('MV_CONTAINS(entity.attributes.watchlists, "vip")');
       expect(query).toContain('MV_CONTAINS(entity.attributes.watchlists, "threat-actors")');
+    });
+
+    it('includes data source filter using exact-or-prefix match on entity.source', async () => {
+      mockSingleEntityResponse();
+
+      await tool.handler(
+        { sources: ['crowdstrike', 'island_browser'] },
+        createToolHandlerContext(mockRequest, mockEsClient, mockLogger)
+      );
+
+      const { query } = (executeEsql as jest.Mock).mock.calls[0][0];
+      expect(query).toContain(
+        'WHERE (MV_CONTAINS(entity.source, "crowdstrike") OR entity.source LIKE "crowdstrike.*") OR (MV_CONTAINS(entity.source, "island_browser") OR entity.source LIKE "island_browser.*")'
+      );
+    });
+
+    it('expands a single-vendor source to exact-or-prefix match (e.g. "aws" matches "aws.cloudtrail")', async () => {
+      mockSingleEntityResponse();
+
+      await tool.handler(
+        { sources: ['aws'] },
+        createToolHandlerContext(mockRequest, mockEsClient, mockLogger)
+      );
+
+      const { query } = (executeEsql as jest.Mock).mock.calls[0][0];
+      expect(query).toContain(
+        'WHERE (MV_CONTAINS(entity.source, "aws") OR entity.source LIKE "aws.*")'
+      );
+    });
+
+    it('does not include entity.source filter when sources param is absent', async () => {
+      mockSingleEntityResponse();
+
+      await tool.handler(
+        { entityTypes: ['host'] },
+        createToolHandlerContext(mockRequest, mockEsClient, mockLogger)
+      );
+
+      const { query } = (executeEsql as jest.Mock).mock.calls[0][0];
+      expect(query).not.toContain('MV_CONTAINS(entity.source');
+      expect(query).not.toContain('entity.source LIKE');
+    });
+
+    it('includes namespace filter using IN list on entity.namespace', async () => {
+      mockSingleEntityResponse();
+
+      await tool.handler(
+        { namespaces: ['okta', 'entra_id'] },
+        createToolHandlerContext(mockRequest, mockEsClient, mockLogger)
+      );
+
+      const { query } = (executeEsql as jest.Mock).mock.calls[0][0];
+      expect(query).toContain('WHERE entity.namespace IN ("okta", "entra_id")');
+    });
+
+    it('combines sources (prefix) and namespaces filters in the same query', async () => {
+      mockSingleEntityResponse();
+
+      await tool.handler(
+        { entityTypes: ['user'], sources: ['aws'], namespaces: ['aws'] },
+        createToolHandlerContext(mockRequest, mockEsClient, mockLogger)
+      );
+
+      const { query } = (executeEsql as jest.Mock).mock.calls[0][0];
+      expect(query).toContain(
+        'WHERE (MV_CONTAINS(entity.source, "aws") OR entity.source LIKE "aws.*")'
+      );
+      expect(query).toContain('WHERE entity.namespace IN ("aws")');
+    });
+
+    it('does not include entity.namespace filter when namespaces param is absent', async () => {
+      mockSingleEntityResponse();
+
+      await tool.handler(
+        { entityTypes: ['user'] },
+        createToolHandlerContext(mockRequest, mockEsClient, mockLogger)
+      );
+
+      const { query } = (executeEsql as jest.Mock).mock.calls[0][0];
+      expect(query).not.toContain('entity.namespace');
     });
 
     it('includes managedOnly filter in query', async () => {
@@ -654,6 +1248,7 @@ describe('searchEntitiesTool', () => {
           riskLevels: ['High', 'Critical'],
           criticalityLevels: ['extreme_impact'],
           watchlists: ['vip'],
+          sources: ['crowdstrike'],
           managedOnly: true,
           mfaEnabledOnly: true,
           assetOnly: true,
@@ -670,6 +1265,9 @@ describe('searchEntitiesTool', () => {
       expect(query).toContain('WHERE entity.risk.calculated_level IN ("High", "Critical")');
       expect(query).toContain('WHERE asset.criticality IN ("extreme_impact")');
       expect(query).toContain('MV_CONTAINS(entity.attributes.watchlists, "vip")');
+      expect(query).toContain(
+        'WHERE (MV_CONTAINS(entity.source, "crowdstrike") OR entity.source LIKE "crowdstrike.*")'
+      );
       expect(query).toContain('WHERE entity.attributes.managed == true');
       expect(query).toContain('WHERE entity.attributes.mfa_enabled == true');
       expect(query).toContain('WHERE entity.attributes.asset == true');
@@ -677,6 +1275,359 @@ describe('searchEntitiesTool', () => {
       expect(query).toContain(EXPECTED_KEEP_CLAUSE);
       expect(query).toContain(EXPECTED_SORT_CLAUSE);
       expect(query).toContain('LIMIT 5');
+    });
+  });
+
+  describe('entity attachment side effect', () => {
+    const multiRowResponse = {
+      columns: [
+        { name: 'entity.id', type: 'keyword' },
+        { name: 'entity.name', type: 'keyword' },
+        { name: 'entity.EngineMetadata.Type', type: 'keyword' },
+      ],
+      values: [
+        ['host:server1', 'server1', 'host'],
+        ['host:server2', 'server2', 'host'],
+        ['user:alice', 'alice', 'user'],
+      ],
+    };
+
+    const expectedListEntities = [
+      {
+        identifierType: 'host' as const,
+        identifier: 'server1',
+        entityStoreId: 'host:server1',
+      },
+      {
+        identifierType: 'host' as const,
+        identifier: 'server2',
+        entityStoreId: 'host:server2',
+      },
+      {
+        identifierType: 'user' as const,
+        identifier: 'alice',
+        entityStoreId: 'user:alice',
+      },
+    ];
+    const expectedListAttachmentId = buildListEntityAttachmentId(expectedListEntities);
+
+    const singleRowResponse = {
+      columns: [
+        { name: 'entity.id', type: 'keyword' },
+        { name: 'entity.name', type: 'keyword' },
+        { name: 'entity.EngineMetadata.Type', type: 'keyword' },
+      ],
+      values: [['host:server1', 'server1', 'host']],
+    };
+
+    const expectedSingleAttachmentId = buildSingleEntityAttachmentId('host', 'server1');
+
+    it('creates a list attachment when 3 rows are returned and appends an other result', async () => {
+      (executeEsql as jest.Mock).mockResolvedValueOnce(multiRowResponse);
+
+      const context = createToolHandlerContext(mockRequest, mockEsClient, mockLogger);
+      (context.attachments.getAttachmentRecord as jest.Mock).mockReturnValueOnce(undefined);
+      (context.attachments.add as jest.Mock).mockResolvedValueOnce({
+        id: expectedListAttachmentId,
+        current_version: 1,
+      });
+
+      const result = (await tool.handler({}, context)) as ToolHandlerStandardReturn;
+
+      expect(context.attachments.add).toHaveBeenCalledTimes(1);
+      expect(context.attachments.add).toHaveBeenCalledWith({
+        id: expectedListAttachmentId,
+        type: SecurityAgentBuilderAttachments.entity,
+        data: {
+          entities: expectedListEntities,
+          attachmentLabel: 'Entity search results',
+        },
+        description: 'Entity search results (3)',
+      });
+      expect(context.attachments.update).not.toHaveBeenCalled();
+
+      // 3 esqlResults rows + 1 other side-effect
+      expect(result.results).toHaveLength(4);
+      expect(result.results[0].type).toBe(ToolResultType.esqlResults);
+      expect(result.results[1].type).toBe(ToolResultType.esqlResults);
+      expect(result.results[2].type).toBe(ToolResultType.esqlResults);
+
+      const otherResult = result.results[3] as OtherResult<{
+        attachmentId: string;
+        version: number;
+        renderTag: string;
+      }>;
+      expect(otherResult.type).toBe(ToolResultType.other);
+      expect(otherResult.data).toEqual({
+        attachmentId: expectedListAttachmentId,
+        version: 1,
+        renderTag: buildRenderAttachmentTag({
+          attachmentId: expectedListAttachmentId,
+          version: 1,
+        }),
+      });
+    });
+
+    it('creates a single-entity attachment (via add) when exactly 1 row is returned', async () => {
+      (executeEsql as jest.Mock).mockResolvedValueOnce(singleRowResponse);
+
+      const context = createToolHandlerContext(mockRequest, mockEsClient, mockLogger);
+      (context.attachments.getAttachmentRecord as jest.Mock).mockReturnValueOnce(undefined);
+      (context.attachments.add as jest.Mock).mockResolvedValueOnce({
+        id: expectedSingleAttachmentId,
+        current_version: 1,
+      });
+
+      const result = (await tool.handler({}, context)) as ToolHandlerStandardReturn;
+
+      expect(context.attachments.add).toHaveBeenCalledTimes(1);
+      expect(context.attachments.add).toHaveBeenCalledWith({
+        id: expectedSingleAttachmentId,
+        type: SecurityAgentBuilderAttachments.entity,
+        data: {
+          identifierType: 'host',
+          identifier: 'server1',
+          attachmentLabel: 'host: server1',
+          entityStoreId: 'host:server1',
+        },
+        description: 'host: server1',
+      });
+      expect(context.attachments.update).not.toHaveBeenCalled();
+
+      expect(result.results).toHaveLength(2);
+      expect(result.results[0].type).toBe(ToolResultType.esqlResults);
+      const otherResult = result.results[1] as OtherResult<{
+        attachmentId: string;
+        version: number;
+        renderTag: string;
+      }>;
+      expect(otherResult.type).toBe(ToolResultType.other);
+      expect(otherResult.data).toEqual({
+        attachmentId: expectedSingleAttachmentId,
+        version: 1,
+        renderTag: buildRenderAttachmentTag({
+          attachmentId: expectedSingleAttachmentId,
+          version: 1,
+        }),
+      });
+    });
+
+    it('updates the existing single-entity attachment (bumping version) when it already exists', async () => {
+      (executeEsql as jest.Mock).mockResolvedValueOnce(singleRowResponse);
+
+      const context = createToolHandlerContext(mockRequest, mockEsClient, mockLogger);
+      (context.attachments.getAttachmentRecord as jest.Mock).mockReturnValueOnce({
+        id: expectedSingleAttachmentId,
+        current_version: 1,
+      });
+      (context.attachments.update as jest.Mock).mockResolvedValueOnce({
+        id: expectedSingleAttachmentId,
+        current_version: 2,
+      });
+
+      const result = (await tool.handler({}, context)) as ToolHandlerStandardReturn;
+
+      expect(context.attachments.update).toHaveBeenCalledTimes(1);
+      expect(context.attachments.update).toHaveBeenCalledWith(expectedSingleAttachmentId, {
+        data: {
+          identifierType: 'host',
+          identifier: 'server1',
+          attachmentLabel: 'host: server1',
+          entityStoreId: 'host:server1',
+        },
+        description: 'host: server1',
+      });
+      expect(context.attachments.add).not.toHaveBeenCalled();
+
+      const otherResult = result.results[1] as OtherResult<{
+        attachmentId: string;
+        version: number;
+        renderTag: string;
+      }>;
+      expect(otherResult.type).toBe(ToolResultType.other);
+      expect(otherResult.data).toEqual({
+        attachmentId: expectedSingleAttachmentId,
+        version: 2,
+        renderTag: buildRenderAttachmentTag({
+          attachmentId: expectedSingleAttachmentId,
+          version: 2,
+        }),
+      });
+    });
+
+    it('filters out rows with an invalid entity.EngineMetadata.Type but still creates the attachment for the valid ones', async () => {
+      (executeEsql as jest.Mock).mockResolvedValueOnce({
+        columns: [
+          { name: 'entity.id', type: 'keyword' },
+          { name: 'entity.name', type: 'keyword' },
+          { name: 'entity.EngineMetadata.Type', type: 'keyword' },
+        ],
+        values: [
+          ['host:server1', 'server1', 'host'],
+          ['device:d1', 'd1', 'device'], // unknown type — must be skipped
+          ['user:alice', 'alice', 'user'],
+        ],
+      });
+
+      const filteredEntities = [
+        {
+          identifierType: 'host' as const,
+          identifier: 'server1',
+          entityStoreId: 'host:server1',
+        },
+        {
+          identifierType: 'user' as const,
+          identifier: 'alice',
+          entityStoreId: 'user:alice',
+        },
+      ];
+      const filteredAttachmentId = buildListEntityAttachmentId(filteredEntities);
+
+      const context = createToolHandlerContext(mockRequest, mockEsClient, mockLogger);
+      (context.attachments.getAttachmentRecord as jest.Mock).mockReturnValueOnce(undefined);
+      (context.attachments.add as jest.Mock).mockResolvedValueOnce({
+        id: filteredAttachmentId,
+        current_version: 1,
+      });
+
+      const result = (await tool.handler({}, context)) as ToolHandlerStandardReturn;
+
+      expect(context.attachments.add).toHaveBeenCalledTimes(1);
+      expect(context.attachments.add).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: filteredAttachmentId,
+          type: SecurityAgentBuilderAttachments.entity,
+          data: {
+            entities: filteredEntities,
+            attachmentLabel: 'Entity search results',
+          },
+          description: 'Entity search results (2)',
+        })
+      );
+
+      // 3 esqlResults rows preserved + 1 other side-effect
+      expect(result.results).toHaveLength(4);
+      const otherResult = result.results[3] as OtherResult<{
+        attachmentId: string;
+        version: number;
+        renderTag: string;
+      }>;
+      expect(otherResult.type).toBe(ToolResultType.other);
+      expect(otherResult.data).toEqual({
+        attachmentId: filteredAttachmentId,
+        version: 1,
+        renderTag: buildRenderAttachmentTag({
+          attachmentId: filteredAttachmentId,
+          version: 1,
+        }),
+      });
+    });
+
+    it('does not create an attachment when every row has an invalid entity.EngineMetadata.Type', async () => {
+      (executeEsql as jest.Mock).mockResolvedValueOnce({
+        columns: [
+          { name: 'entity.id', type: 'keyword' },
+          { name: 'entity.name', type: 'keyword' },
+          { name: 'entity.EngineMetadata.Type', type: 'keyword' },
+        ],
+        values: [
+          ['device:d1', 'd1', 'device'],
+          ['device:d2', 'd2', 'device'],
+        ],
+      });
+
+      const context = createToolHandlerContext(mockRequest, mockEsClient, mockLogger);
+
+      const result = (await tool.handler({}, context)) as ToolHandlerStandardReturn;
+
+      expect(context.attachments.add).not.toHaveBeenCalled();
+      expect(context.attachments.update).not.toHaveBeenCalled();
+
+      expect(result.results).toHaveLength(2);
+      result.results.forEach((r) => {
+        expect(r.type).toBe(ToolResultType.esqlResults);
+      });
+    });
+
+    it('omits entityStoreId from the attachment payload when the row has no entity.id', async () => {
+      // Rows without an entity.id still produce a usable attachment via
+      // entity.name, but the payload should not carry a synthetic entity
+      // store id — the client falls back to per-type identity filtering.
+      (executeEsql as jest.Mock).mockResolvedValueOnce({
+        columns: [
+          { name: 'entity.name', type: 'keyword' },
+          { name: 'entity.EngineMetadata.Type', type: 'keyword' },
+        ],
+        values: [['server1', 'host']],
+      });
+
+      const context = createToolHandlerContext(mockRequest, mockEsClient, mockLogger);
+      (context.attachments.getAttachmentRecord as jest.Mock).mockReturnValueOnce(undefined);
+      (context.attachments.add as jest.Mock).mockResolvedValueOnce({
+        id: expectedSingleAttachmentId,
+        current_version: 1,
+      });
+
+      await tool.handler({}, context);
+
+      expect(context.attachments.add).toHaveBeenCalledTimes(1);
+      const addCall = (context.attachments.add as jest.Mock).mock.calls[0][0];
+      expect(addCall.data).toEqual({
+        identifierType: 'host',
+        identifier: 'server1',
+        attachmentLabel: 'host: server1',
+      });
+      expect(addCall.data).not.toHaveProperty('entityStoreId');
+    });
+
+    it('does not create an attachment when riskScoreChangeInterval is set (STATS branch limitation)', async () => {
+      // The STATS projection drops the identity columns, so descriptors
+      // cannot be derived reliably — we skip the attachment side-effect.
+      (executeEsql as jest.Mock).mockResolvedValueOnce({
+        columns: [
+          { name: 'entity.id', type: 'keyword' },
+          { name: 'risk_score_change', type: 'double' },
+        ],
+        values: [
+          ['host:server1', 25.0],
+          ['host:server2', 40.5],
+        ],
+      });
+
+      const context = createToolHandlerContext(mockRequest, mockEsClient, mockLogger);
+
+      const result = (await tool.handler(
+        { riskScoreChangeInterval: '30d' },
+        context
+      )) as ToolHandlerStandardReturn;
+
+      expect(context.attachments.add).not.toHaveBeenCalled();
+      expect(context.attachments.update).not.toHaveBeenCalled();
+      expect(result.results).toHaveLength(2);
+      result.results.forEach((r) => {
+        expect(r.type).toBe(ToolResultType.esqlResults);
+      });
+    });
+
+    it('does not create an attachment when zero rows are returned (returns the existing error result)', async () => {
+      (executeEsql as jest.Mock).mockResolvedValueOnce({
+        columns: [{ name: 'entity.id', type: 'keyword' }],
+        values: [],
+      });
+
+      const context = createToolHandlerContext(mockRequest, mockEsClient, mockLogger);
+
+      const result = (await tool.handler(
+        { riskLevels: ['Critical'] },
+        context
+      )) as ToolHandlerStandardReturn;
+
+      expect(context.attachments.add).not.toHaveBeenCalled();
+      expect(context.attachments.update).not.toHaveBeenCalled();
+      expect(result.results).toHaveLength(1);
+      const errorResult = result.results[0] as ErrorResult;
+      expect(errorResult.type).toBe(ToolResultType.error);
+      expect(errorResult.data.message).toContain('No entities found');
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/entity_analytics/search_entities_tool.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/entity_analytics/search_entities_tool.ts
@@ -16,6 +16,7 @@ import {
   ENTITY_LATEST,
 } from '@kbn/entity-store/server';
 import type { Logger } from '@kbn/logging';
+import type { AttachmentStateManager } from '@kbn/agent-builder-server/attachments';
 import {
   IdentifierType,
   EntityRiskLevels,
@@ -26,6 +27,14 @@ import type { SecuritySolutionPluginCoreSetupDependencies } from '../../../plugi
 import { getAgentBuilderResourceAvailability } from '../../utils/get_agent_builder_resource_availability';
 import { ENTITY_ANALYTICS_AI_TOOL_USAGE_EVENT } from '../../../lib/telemetry/event_based/events';
 import { securityTool } from '../constants';
+import {
+  buildListEntityAttachmentId,
+  buildRenderAttachmentTag,
+  buildSingleEntityAttachmentId,
+  describeAttachmentForRow,
+  ensureEntityAttachment,
+  type EntityAttachmentDescriptor,
+} from './entity_attachment_utils';
 
 const ENTITY_STORE_KEEP_FIELDS = [
   '@timestamp',
@@ -96,7 +105,11 @@ const schema = z.object({
     .max(100)
     .optional()
     .describe(
-      'Minimum normalized risk score (0-100). Only returns entities with entity.risk.calculated_score_norm >= this value.'
+      'Minimum normalized risk score (1-100). When >0, only returns entities with entity.risk.calculated_score_norm >= this value. ' +
+        'Pass 0 or omit this parameter to apply no lower bound. ' +
+        'Note: the default sort is "riskScore", which by itself already excludes entities whose score is NULL — ' +
+        'if the user wants unscored entities alongside scored ones, use sortBy: "criticality" instead of lowering riskScoreMin. ' +
+        'Only set a positive floor when the user explicitly asked for a score threshold (e.g. "above 70").'
     ),
   riskScoreMax: z
     .number()
@@ -121,6 +134,30 @@ const schema = z.object({
     .optional()
     .describe(
       'Filter for entities that belong to any of the specified watchlists (entity.attributes.watchlists).'
+    ),
+  sources: z
+    .array(z.string().min(1))
+    .optional()
+    .describe(
+      'Filter for entities whose multi-value `entity.source` field matches ANY of the given values either exactly ' +
+        'or as a "<value>.*" prefix. For example `sources: ["aws"]` matches entities with `entity.source` of ' +
+        '"aws", "aws.cloudtrail", "aws.guardduty", "aws.s3access", etc. Values are the raw lowercase integration ' +
+        'keys from the entity store (e.g. "crowdstrike", "okta", "entityanalytics_okta", "island_browser") — do ' +
+        'not pretty-print (pass "island_browser", not "Island Browser"). For user entities prefer the normalized ' +
+        '`namespaces` parameter when possible; fall back to `sources` when no canonical namespace exists or when ' +
+        'searching host/service/generic entities.'
+    ),
+  namespaces: z
+    .array(z.string().min(1))
+    .optional()
+    .describe(
+      'Filter user entities by normalized vendor namespace (`entity.namespace`). This is single-value and ' +
+        'collapses heterogeneous source keys into canonical names. Known canonical values: "okta" (from okta / ' +
+        'entityanalytics_okta), "entra_id" (from azure / entityanalytics_entra_id), "microsoft_365" (from o365 / ' +
+        'o365_metrics), "active_directory" (from entityanalytics_ad), "local" (non-IDP endpoint/system accounts), ' +
+        '"unknown" (missing source), plus pass-through of `event.module` for vendors without a dedicated mapping ' +
+        '(e.g. "aws", "gcp"). Only effective on user entities; host/service/generic rows do not have ' +
+        '`entity.namespace` and will be filtered out when this parameter is set.'
     ),
   managedOnly: z
     .boolean()
@@ -185,10 +222,111 @@ const schema = z.object({
     .max(100)
     .optional()
     .describe('Maximum number of entities to return (1-100, default 10).'),
+  sortBy: z
+    .enum(['riskScore', 'criticality'])
+    .optional()
+    .describe(
+      'Field to order results by (always DESC). Defaults to "riskScore" (entity.risk.calculated_score_norm). ' +
+        'Sorting by "riskScore" (default or explicit) implicitly excludes entities whose ' +
+        'entity.risk.calculated_score_norm IS NULL — ranking is not meaningful for unscored entities. ' +
+        'Use sortBy: "criticality" if you need unscored entities to appear (their criticality_rank defaults to 0 so they land last). ' +
+        'Use "criticality" when the user explicitly asks to order, rank, sort, or list top-N entities BY criticality ' +
+        '(extreme_impact > high_impact > medium_impact > low_impact; entities with no asset.criticality land last; ' +
+        'risk score is the tiebreaker within a tier). ' +
+        'Do NOT pass all four criticalityLevels to simulate a sort — that is a no-op filter. ' +
+        'Ignored when riskScoreChangeInterval is set (that flow always sorts by risk_score_change DESC).'
+    ),
 });
 type ToolParams = z.infer<typeof schema>;
 
 export const SECURITY_SEARCH_ENTITIES_TOOL_ID = securityTool('search_entities');
+
+const SENTINEL_LOWER_BOUND_CUTOFF_MS = Date.parse('2000-01-01T00:00:00Z');
+
+const parseIsoMs = (value: string | undefined): number | null => {
+  if (!value) return null;
+  const ms = Date.parse(value);
+  return Number.isFinite(ms) ? ms : null;
+};
+
+const isVacuousLowerBound = (value: string | undefined): boolean => {
+  const ms = parseIsoMs(value);
+  return ms !== null && ms <= SENTINEL_LOWER_BOUND_CUTOFF_MS;
+};
+
+const isVacuousUpperBound = (value: string | undefined, nowMs: number): boolean => {
+  const ms = parseIsoMs(value);
+  return ms !== null && ms > nowMs;
+};
+
+/**
+ * Silently sanitises a handful of "over-fill" patterns that some LLMs (most notably
+ * ChatGPT-class models) produce on the wire. Without this, perfectly reasonable user
+ * intent (e.g. "top 5 users by criticality") gets turned into a different query or
+ * silently filtered out because ES|QL comparisons against NULL are false. We would
+ * rather drop the problematic parameter than reject the call and force the model
+ * into a rejection loop.
+ */
+const normalizeParams = (params: ToolParams, logger: Logger): ToolParams => {
+  const dropped: string[] = [];
+  const out: ToolParams = { ...params };
+
+  if (out.sortBy && out.riskScoreChangeInterval) {
+    dropped.push('riskScoreChangeInterval');
+    out.riskScoreChangeInterval = undefined;
+  }
+
+  if (out.riskScoreMax !== undefined && out.riskScoreMax >= 100) {
+    dropped.push('riskScoreMax');
+    out.riskScoreMax = undefined;
+  }
+
+  // Treat "epoch-style" lower bounds and any strictly-future upper bound as
+  // sentinels. These restrict nothing for populated rows but, because ES|QL
+  // evaluates any NULL comparison to NULL (falsy in WHERE), silently drop
+  // entities whose lifecycle timestamps are not populated. Prune per field so
+  // mixed genuine/sentinel inputs keep the legitimate half.
+  const nowMs = Date.now();
+
+  if (isVacuousLowerBound(out.firstSeenAfter)) {
+    dropped.push('firstSeenAfter');
+    out.firstSeenAfter = undefined;
+  }
+  if (isVacuousUpperBound(out.firstSeenBefore, nowMs)) {
+    dropped.push('firstSeenBefore');
+    out.firstSeenBefore = undefined;
+  }
+  if (isVacuousLowerBound(out.lastSeenAfter)) {
+    dropped.push('lastSeenAfter');
+    out.lastSeenAfter = undefined;
+  }
+  if (isVacuousUpperBound(out.lastSeenBefore, nowMs)) {
+    dropped.push('lastSeenBefore');
+    out.lastSeenBefore = undefined;
+  }
+
+  if (out.firstSeenAfter && out.firstSeenBefore && out.firstSeenAfter === out.firstSeenBefore) {
+    dropped.push('firstSeenAfter', 'firstSeenBefore');
+    out.firstSeenAfter = undefined;
+    out.firstSeenBefore = undefined;
+  }
+
+  if (out.lastSeenAfter && out.lastSeenBefore && out.lastSeenAfter === out.lastSeenBefore) {
+    dropped.push('lastSeenAfter', 'lastSeenBefore');
+    out.lastSeenAfter = undefined;
+    out.lastSeenBefore = undefined;
+  }
+
+  if (dropped.length > 0) {
+    logger.debug(
+      `${SECURITY_SEARCH_ENTITIES_TOOL_ID} normalized over-filled params; dropped: ${dropped.join(
+        ', '
+      )}`
+    );
+  }
+
+  return out;
+};
 
 const escapeEsqlString = (value: string) => value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
 
@@ -199,6 +337,23 @@ const buildInListClause = (field: string, values: string[]): string => {
 
 const buildMvContainsClause = (field: string, values: string[]): string =>
   values.map((v) => `MV_CONTAINS(${field}, "${escapeEsqlString(v)}")`).join(' OR ');
+
+/**
+ * Builds a WHERE clause fragment matching `entity.source` against any of the given values
+ * either exactly or as a "<value>.*" prefix. `entity.source` is multi-valued and may carry
+ * vendor keys (`"aws"`), dataset keys (`"aws.cloudtrail"`), or integration keys
+ * (`"entityanalytics_okta"`), so exact-only matching misses dataset-shaped variants. ESQL
+ * `LIKE` on a multi-value keyword field returns true if ANY value matches the pattern, and
+ * we anchor the prefix with a trailing `.` to avoid false positives on unrelated prefixes
+ * (e.g. `"awsome_*"` will not match `sources: ["aws"]`).
+ */
+const buildSourceMatchClause = (values: string[]): string =>
+  values
+    .map((v) => {
+      const esc = escapeEsqlString(v);
+      return `(MV_CONTAINS(entity.source, "${esc}") OR entity.source LIKE "${esc}.*")`;
+    })
+    .join(' OR ');
 
 const intervalToEsql = (interval: string) => {
   const match = interval.match(/^(\d+)([smhdwM])$/);
@@ -239,6 +394,7 @@ const buildRiskAndAssetCriticalityFilterClauses = ({
   riskLevels,
   riskScoreChangeInterval,
   criticalityLevels,
+  sortBy,
 }: ToolParams) => {
   const clauses: string[] = [];
   if (riskScoreChangeInterval) {
@@ -246,8 +402,21 @@ const buildRiskAndAssetCriticalityFilterClauses = ({
     clauses.push(
       `WHERE @timestamp >= DATE_TRUNC(1 day, ${intervalToEsql(riskScoreChangeInterval)})`
     );
+  } else if (sortBy === undefined || sortBy === 'riskScore') {
+    // ES|QL sorts NULL FIRST in DESC, so without this guard a plain
+    // `SORT calculated_score_norm DESC | LIMIT N` query surfaces N unscored
+    // entities at the top of the list. Mirror the IS NOT NULL filter already
+    // used by the riskScoreChangeInterval branch so the default / explicit
+    // `sortBy: 'riskScore'` ranking is meaningful. The `sortBy: 'criticality'`
+    // branch does not need this because `criticality_rank` defaults to 0 for
+    // null-risk entities, which deterministically lands them last.
+    clauses.push(`WHERE entity.risk.calculated_score_norm IS NOT NULL`);
   }
-  if (riskScoreMin != null) {
+  // Treat `riskScoreMin: 0` as "no floor" rather than `>= 0`. In ES|QL any comparison
+  // against NULL is false, so emitting `calculated_score_norm >= 0` would silently drop
+  // every entity whose risk score hasn't been computed yet. Only emit the filter when
+  // the caller asks for a strictly positive floor.
+  if (riskScoreMin != null && riskScoreMin > 0) {
     clauses.push(`WHERE entity.risk.calculated_score_norm >= ${riskScoreMin}`);
   }
   if (riskScoreMax != null) {
@@ -264,6 +433,8 @@ const buildRiskAndAssetCriticalityFilterClauses = ({
 
 const buildAttributeFilterClauses = ({
   watchlists,
+  sources,
+  namespaces,
   managedOnly,
   mfaEnabledOnly,
   assetOnly,
@@ -271,6 +442,12 @@ const buildAttributeFilterClauses = ({
   const clauses: string[] = [];
   if (watchlists && watchlists.length > 0) {
     clauses.push(`WHERE ${buildMvContainsClause('entity.attributes.watchlists', watchlists)}`);
+  }
+  if (sources && sources.length > 0) {
+    clauses.push(`WHERE ${buildSourceMatchClause(sources)}`);
+  }
+  if (namespaces && namespaces.length > 0) {
+    clauses.push(`WHERE ${buildInListClause('entity.namespace', namespaces)}`);
   }
   if (managedOnly === true) {
     clauses.push(`WHERE entity.attributes.managed == true`);
@@ -317,9 +494,38 @@ const buildStatsClause = ({ riskScoreChangeInterval }: ToolParams): string[] => 
   return [];
 };
 
-const buildSortClause = ({ riskScoreChangeInterval }: ToolParams): string[] => {
+const buildEvalClause = ({ sortBy, riskScoreChangeInterval }: ToolParams): string[] => {
+  if (riskScoreChangeInterval) {
+    return [];
+  }
+
+  // `asset.criticality` is a keyword, so alphabetical ordering would surface
+  // `medium_impact` above `high_impact`. Project a numeric rank so the SORT
+  // reflects the operator-facing ordering (extreme > high > medium > low),
+  // with NULL/unknown criticality landing at the bottom via the default `0`.
+  if (sortBy === 'criticality') {
+    return [
+      `EVAL criticality_rank = CASE(` +
+        `asset.criticality == "extreme_impact", 4, ` +
+        `asset.criticality == "high_impact", 3, ` +
+        `asset.criticality == "medium_impact", 2, ` +
+        `asset.criticality == "low_impact", 1, ` +
+        `0)`,
+    ];
+  }
+
+  return [];
+};
+
+const buildSortClause = ({ sortBy, riskScoreChangeInterval }: ToolParams): string[] => {
   if (riskScoreChangeInterval) {
     return [`SORT risk_score_change DESC`];
+  }
+
+  if (sortBy === 'criticality') {
+    // Risk score is the tiebreaker so "top N by criticality" still surfaces
+    // the riskiest high-impact entity above a quieter one within the same tier.
+    return [`SORT criticality_rank DESC, entity.risk.calculated_score_norm DESC`];
   }
 
   // default to sorting by risk score
@@ -357,12 +563,110 @@ const buildQuery = (
     ...buildLifecycleFilterClauses(params),
     ...buildRiskAndAssetCriticalityFilterClauses(params),
     ...buildStatsClause(params),
+    ...buildEvalClause(params),
     ...buildSortClause(params),
     ...buildKeepClause(params),
     `LIMIT ${params.maxResults ?? 10}`,
   ];
 
   return clauses.join('\n| ');
+};
+
+const MULTI_ENTITY_ATTACHMENT_LABEL = 'Entity search results';
+
+/**
+ * Builds the optional `ToolResultType.other` side-effect results that
+ * announce the inline `security.entity` attachment for this search call.
+ *
+ * The attachment is skipped when the `riskScoreChangeInterval` branch is
+ * active (the STATS projection drops the identity columns, so descriptors
+ * cannot be derived reliably), or when no row yields a valid descriptor.
+ * When exactly one descriptor is produced we reuse the single-entity id
+ * scheme used by `security.get_entity` so the two tools converge on the
+ * same attachment/version instead of creating duplicates.
+ */
+const buildAttachmentSideEffectResults = async ({
+  params,
+  columns,
+  values,
+  attachments,
+  logger,
+}: {
+  params: ToolParams;
+  columns: Array<{ name: string }>;
+  values: unknown[][];
+  attachments: AttachmentStateManager;
+  logger: Logger;
+}): Promise<
+  Array<{
+    tool_result_id: string;
+    type: typeof ToolResultType.other;
+    data: { attachmentId: string; version: number; renderTag: string };
+  }>
+> => {
+  if (params.riskScoreChangeInterval) {
+    return [];
+  }
+
+  const descriptors = values
+    .map((row) => describeAttachmentForRow({ columns, row }))
+    .filter((d): d is EntityAttachmentDescriptor => d !== null);
+
+  if (descriptors.length === 0) {
+    return [];
+  }
+
+  let id: string;
+  let data: Record<string, unknown>;
+  let description: string;
+
+  if (descriptors.length === 1) {
+    const [descriptor] = descriptors;
+    id = buildSingleEntityAttachmentId(descriptor.identifierType, descriptor.identifier);
+    data = {
+      identifierType: descriptor.identifierType,
+      identifier: descriptor.identifier,
+      attachmentLabel: descriptor.attachmentLabel,
+      ...(descriptor.entityStoreId ? { entityStoreId: descriptor.entityStoreId } : {}),
+    };
+    description = descriptor.attachmentLabel;
+  } else {
+    const entities = descriptors.map(({ identifierType, identifier, entityStoreId }) => ({
+      identifierType,
+      identifier,
+      ...(entityStoreId ? { entityStoreId } : {}),
+    }));
+    id = buildListEntityAttachmentId(entities);
+    data = {
+      entities,
+      attachmentLabel: MULTI_ENTITY_ATTACHMENT_LABEL,
+    };
+    description = `${MULTI_ENTITY_ATTACHMENT_LABEL} (${entities.length})`;
+  }
+
+  const attachmentResult = await ensureEntityAttachment({
+    attachments,
+    id,
+    data,
+    description,
+    logger,
+  });
+
+  if (!attachmentResult) {
+    return [];
+  }
+
+  return [
+    {
+      tool_result_id: getToolResultId(),
+      type: ToolResultType.other,
+      data: {
+        attachmentId: attachmentResult.attachmentId,
+        version: attachmentResult.version,
+        renderTag: buildRenderAttachmentTag(attachmentResult),
+      },
+    },
+  ];
 };
 
 export const searchEntitiesTool = (
@@ -374,8 +678,14 @@ export const searchEntitiesTool = (
     id: SECURITY_SEARCH_ENTITIES_TOOL_ID,
     type: ToolType.builtin,
     description: `Search entity store for security entities (host, user, service, generic).
-    Supports filtering by normalized risk score, asset criticality, entity attributes, and lifecycle timestamps.
+    Supports filtering by normalized risk score, asset criticality, entity attributes, lifecycle timestamps,
+    and data source via two complementary parameters:
+      - "sources" matches the multi-value "entity.source" field exactly or as a "<value>.*" prefix (e.g. ["aws"] matches "aws", "aws.cloudtrail", "aws.guardduty").
+      - "namespaces" matches the normalized single-value "entity.namespace" field on user entities (canonical values: okta, entra_id, microsoft_365, active_directory, local, unknown, or pass-through of event.module like "aws").
+    Prefer "namespaces" for user queries when a canonical vendor exists; fall back to "sources" for vendors without a namespace mapping and for host/service/generic entities.
     Use this tool to find entities matching specific criteria.
+    When this tool stores a "security.entity" attachment (2+ entities returned, or a single-entity attachment shared with security.get_entity), its "other" result includes a pre-formatted \`renderTag\` string alongside \`attachmentId\` and \`version\`. To render the attachment inline, copy that \`renderTag\` string VERBATIM onto its own line in your markdown reply — do NOT assemble the tag yourself from \`attachmentId\` and \`version\`, and do NOT derive the id from entity names, emails, vendor keys, or any other prose. If the \`other\` result contains no \`renderTag\`, do NOT emit a \`<render_attachment>\` tag. You never call attachments.add with "security.entity" — the tool emits it as a side effect.
+    When the user asks to show, open, view, or summarize the Entity Analytics dashboard/home/overview (built-in Security page), use these results (and optional security.get_entity) then call attachments.add with type "security.entity_analytics_dashboard" so the UI shows Preview→Canvas (see entity-analytics skill). Do not treat that as a request to compose a new Kibana saved dashboard.
     Do NOT use if entity ID (EUID) is known; use the "security.get_entity" tool instead.`,
     tags: ['security', 'entity-store', 'entity-analytics'],
     schema,
@@ -419,7 +729,7 @@ export const searchEntitiesTool = (
         }
       },
     },
-    handler: async (params, { spaceId, esClient }) => {
+    handler: async (params, { spaceId, esClient, attachments }) => {
       logger.debug(
         `${SECURITY_SEARCH_ENTITIES_TOOL_ID} tool called with parameters ${JSON.stringify(params)}`
       );
@@ -429,6 +739,8 @@ export const searchEntitiesTool = (
       let errorMessage: string | undefined;
 
       try {
+        const normalized = normalizeParams(params, logger);
+
         const client = esClient.asCurrentUser;
         const entityIndex = getEntitiesAlias(ENTITY_LATEST, spaceId);
         const entitySnapshotIndex = getHistorySnapshotIndexPattern(spaceId);
@@ -436,7 +748,7 @@ export const searchEntitiesTool = (
           index: entitySnapshotIndex,
         });
         const query = buildQuery(
-          params,
+          normalized,
           entityIndex,
           snapshotIndexExists ? entitySnapshotIndex : undefined
         );
@@ -458,14 +770,24 @@ export const searchEntitiesTool = (
           };
         }
 
+        const esqlResultEntries = values.map((_, rowIdx) => ({
+          tool_result_id: getToolResultId(),
+          type: ToolResultType.esqlResults as const,
+          data: { query, columns, values: [values[rowIdx]] },
+        }));
+
+        const attachmentSideEffectResults = await buildAttachmentSideEffectResults({
+          params: normalized,
+          columns,
+          values,
+          attachments,
+          logger,
+        });
+
         success = true;
         entitiesReturned = values.length;
         return {
-          results: values.map((_, rowIdx) => ({
-            tool_result_id: getToolResultId(),
-            type: ToolResultType.esqlResults as const,
-            data: { query, columns, values: [values[rowIdx]] },
-          })),
+          results: [...esqlResultEntries, ...attachmentSideEffectResults],
         };
       } catch (error) {
         errorMessage = error instanceof Error ? error.message : 'Unknown error';

--- a/x-pack/solutions/security/plugins/security_solution/tsconfig.json
+++ b/x-pack/solutions/security/plugins/security_solution/tsconfig.json
@@ -292,7 +292,6 @@
     "@kbn/search-inference-endpoints",
     "@kbn/shared-ux-column-presets",
     "@kbn/core-overlays-browser",
-    "@kbn/workflows-management-plugin",
     "@kbn/core-application-browser-mocks",
   ]
 }

--- a/x-pack/solutions/security/plugins/security_solution/tsconfig.json
+++ b/x-pack/solutions/security/plugins/security_solution/tsconfig.json
@@ -292,5 +292,7 @@
     "@kbn/search-inference-endpoints",
     "@kbn/shared-ux-column-presets",
     "@kbn/core-overlays-browser",
+    "@kbn/workflows-management-plugin",
+    "@kbn/core-application-browser-mocks",
   ]
 }

--- a/x-pack/solutions/security/plugins/timelines/public/hooks/use_add_to_timeline.ts
+++ b/x-pack/solutions/security/plugins/timelines/public/hooks/use_add_to_timeline.ts
@@ -80,7 +80,7 @@ export const getDropTargetCoordinate = (): Position | null => {
  */
 export const getDraggableCoordinate = (draggableId: DraggableId): Position | null => {
   // The placeholder in the "Drop anything highlighted here to build an OR query":
-  const draggable = document.querySelector(`[data-rbd-draggable-id="${draggableId}"]`);
+  const draggable = document.querySelector(`[data-rfd-draggable-id="${draggableId}"]`);
 
   if (draggable != null) {
     return getPosition(draggable);

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/screens/agent_builder.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/screens/agent_builder.ts
@@ -12,6 +12,11 @@ export const AGENT_BUILDER_SIDEBAR_PANEL = '[data-test-subj="sidebarPanel"]';
 export const AGENT_BUILDER_CONVERSATION_INPUT_EDITOR =
   '[data-test-subj="agentBuilderConversationInputEditor"]';
 
+export const ENTITY_ATTACHMENT_CARD_ACTIONS = '[data-test-subj="entityAttachmentCardActions"]';
+
+export const ENTITY_ATTACHMENT_OPEN_ENTITY_ANALYTICS_ACTION =
+  '[data-test-subj="entityAttachmentOpenEntityAnalyticsAction"]';
+
 export const CREATE_RULE_BUTTON = '[data-test-subj="create-rule-button"]';
 
 export const CREATE_RULE_CONTEXT_MENU_POPOVER =


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[EA] Add Chat-First experience to Entity Analytics (#264985)](https://github.com/elastic/kibana/pull/264985)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Paulo Silva","email":"paulo.henrique@elastic.co"},"sourceCommit":{"committedDate":"2026-04-24T15:18:34Z","message":"[EA] Add Chat-First experience to Entity Analytics (#264985)\n\nNote: This is a combined work of\nhttps://github.com/elastic/kibana/pull/264849 and\nhttps://github.com/elastic/kibana/pull/264939\n\n## Summary\n\nIntroduces a rich visual renderer for `security.entity` attachments in\nAgent Builder, gated behind the `entityAttachmentRichRenderer`\nexperimental flag.\n\nKey changes:\n- Supports both single-entity (card) and multi-entity (table) payload\nshapes in the UI and server-side validation.\n- Updates the `security.get_entity` tool to automatically persist a\n`security.entity` attachment as a side effect when a single entity is\nresolved.\n\n## Screenshots\n\n### Entity Analytics Table Attachment\n\n<img width=\"601\" height=\"665\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/08502c67-fb5a-4143-96d1-03a445b5fc7d\"\n/>\n\n### Entity Analytics Card Attachment\n\n<img width=\"668\" height=\"699\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/f83fb6ab-138b-493e-9f19-9facbd533138\"\n/>\n\n### Entity Analytics Dashboard Attachment\n\n<img width=\"1221\" height=\"826\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/dd300123-e72d-4979-8b49-ee855fb5bfbc\"\n/>\n\n---------\n\nCo-authored-by: YulNaumenko <jo.naumenko@gmail.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: jaredburgettelastic <jared.burgett@elastic.co>","sha":"bd98c9f51c3094a6f70c18ccfd069e344f11d15b","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:feature","Team:Cloud Security","ci:build-cloud-image","ci:cloud-deploy","Team:Entity Analytics","backport:version","v9.4.0","evals:entity-analytics","v9.5.0"],"title":"[EA] Add Chat-First experience to Entity Analytics","number":264985,"url":"https://github.com/elastic/kibana/pull/264985","mergeCommit":{"message":"[EA] Add Chat-First experience to Entity Analytics (#264985)\n\nNote: This is a combined work of\nhttps://github.com/elastic/kibana/pull/264849 and\nhttps://github.com/elastic/kibana/pull/264939\n\n## Summary\n\nIntroduces a rich visual renderer for `security.entity` attachments in\nAgent Builder, gated behind the `entityAttachmentRichRenderer`\nexperimental flag.\n\nKey changes:\n- Supports both single-entity (card) and multi-entity (table) payload\nshapes in the UI and server-side validation.\n- Updates the `security.get_entity` tool to automatically persist a\n`security.entity` attachment as a side effect when a single entity is\nresolved.\n\n## Screenshots\n\n### Entity Analytics Table Attachment\n\n<img width=\"601\" height=\"665\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/08502c67-fb5a-4143-96d1-03a445b5fc7d\"\n/>\n\n### Entity Analytics Card Attachment\n\n<img width=\"668\" height=\"699\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/f83fb6ab-138b-493e-9f19-9facbd533138\"\n/>\n\n### Entity Analytics Dashboard Attachment\n\n<img width=\"1221\" height=\"826\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/dd300123-e72d-4979-8b49-ee855fb5bfbc\"\n/>\n\n---------\n\nCo-authored-by: YulNaumenko <jo.naumenko@gmail.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: jaredburgettelastic <jared.burgett@elastic.co>","sha":"bd98c9f51c3094a6f70c18ccfd069e344f11d15b"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/264985","number":264985,"mergeCommit":{"message":"[EA] Add Chat-First experience to Entity Analytics (#264985)\n\nNote: This is a combined work of\nhttps://github.com/elastic/kibana/pull/264849 and\nhttps://github.com/elastic/kibana/pull/264939\n\n## Summary\n\nIntroduces a rich visual renderer for `security.entity` attachments in\nAgent Builder, gated behind the `entityAttachmentRichRenderer`\nexperimental flag.\n\nKey changes:\n- Supports both single-entity (card) and multi-entity (table) payload\nshapes in the UI and server-side validation.\n- Updates the `security.get_entity` tool to automatically persist a\n`security.entity` attachment as a side effect when a single entity is\nresolved.\n\n## Screenshots\n\n### Entity Analytics Table Attachment\n\n<img width=\"601\" height=\"665\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/08502c67-fb5a-4143-96d1-03a445b5fc7d\"\n/>\n\n### Entity Analytics Card Attachment\n\n<img width=\"668\" height=\"699\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/f83fb6ab-138b-493e-9f19-9facbd533138\"\n/>\n\n### Entity Analytics Dashboard Attachment\n\n<img width=\"1221\" height=\"826\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/dd300123-e72d-4979-8b49-ee855fb5bfbc\"\n/>\n\n---------\n\nCo-authored-by: YulNaumenko <jo.naumenko@gmail.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: jaredburgettelastic <jared.burgett@elastic.co>","sha":"bd98c9f51c3094a6f70c18ccfd069e344f11d15b"}}]}] BACKPORT-->