### PR TITLE
[9.4] [Lens] Add APM error tracking for chart render failures (#265354)

### DIFF
--- a/x-pack/platform/plugins/shared/lens/public/react_embeddable/data_loader.ts
+++ b/x-pack/platform/plugins/shared/lens/public/react_embeddable/data_loader.ts
@@ -36,6 +36,7 @@ import {
   tap,
   type Subscription,
 } from 'rxjs';
+import { apm } from '@elastic/apm-rum';
 import { getEditPath } from '../../common/constants';
 import { prepareCallbacks } from './expressions/callbacks';
 import { getExpressionRendererParams } from './expressions/expression_params';
@@ -326,6 +327,29 @@ export function loadEmbeddableData(
       .pipe(debounceTime(0))
       .subscribe((fetchContext) => reload('searchContext' as ReloadReason, fetchContext)),
     mergedSubscriptions.pipe(debounceTime(0)).subscribe(reload),
+    // Capture blocking errors in APM for observability
+    internalApi.blockingError$
+      .pipe(filter((error): error is Error => error != null))
+      .subscribe((error) => {
+        const currentState = getState();
+        const parentContext = getParentContext(parentApi);
+        const meta = parentContext?.meta as Record<string, string | undefined> | undefined;
+        const transaction = apm.getCurrentTransaction();
+        if (transaction) {
+          const span = transaction.startSpan('lens-chart-error', 'lens-embeddable');
+          if (span) {
+            span.addLabels({
+              kibana_meta_lens_metric_type: currentState.attributes?.visualizationType ?? 'unknown',
+              kibana_meta_lens_profile_id: meta?.profile_id ?? 'unknown',
+              kibana_meta_lens_metric_id: meta?.metric_id ?? 'unknown',
+            });
+            apm.captureError(error);
+            // @ts-expect-error RUM types don't include outcome
+            span.outcome = 'failure';
+            span.end();
+          }
+        }
+      }),
     // make sure to reload on viewMode change
     api.viewMode$.subscribe(() => {
       // only reload if drilldowns are set


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Lens] Add APM error tracking for chart render failures (#265354)](https://github.com/elastic/kibana/pull/265354)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Cauê Marcondes","email":"55978943+cauemarcondes@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-04-24T13:47:22Z","message":"[Lens] Add APM error tracking for chart render failures (#265354)\n\n## Summary\n\nAdds automatic APM error tracking for Lens chart renders at the\nembeddable level, so every consumer (Discover, Dashboard, Cases, etc.)\nbenefits without code changes.\n\nWhen a Lens chart fails to render (e.g., an Elasticsearch\n`verification_exception`), a `lens-chart-error` span is created within\nthe current page transaction with:\n- `event.outcome: failure`\n- The error captured via `apm.captureError()`\n- Labels: `kibana_meta_lens_metric_type`, `kibana_meta_lens_profile_id`,\n`kibana_meta_lens_metric_id`\n\nThe span is fire-and-forget — created and immediately ended in the\n`blockingError# Backport

This will backport the following commits from `main` to `9.4`:
{{{{raw}}}} - [[Lens] Add APM error tracking for chart render failures (#265354)](https://github.com/elastic/kibana/pull/265354){{{{/raw}}}}

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT  subscription. This keeps the implementation simple with\nno async lifecycle management, no edge cases around interleaving\nreloads, and no orphaned spans.\n\n<img width=\"1532\" height=\"1954\" alt=\"Screenshot 2026-04-23 at 15 02 21\"\nsrc=\"https://github.com/user-attachments/assets/f6124952-9582-4de2-8a75-c607b1643951\"\n/>\n<img width=\"1491\" height=\"1144\" alt=\"Screenshot 2026-04-23 at 15 02 32\"\nsrc=\"https://github.com/user-attachments/assets/c974c7d6-9936-4740-98b1-ba2c31bfdf85\"\n/>\n\n\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\n---------\n\nCo-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>","sha":"5f425ddd4dcbbcd719266a2a61ee0281b492290f","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","v9.4.0","v9.5.0"],"title":"[Lens] Add APM error tracking for chart render failures","number":265354,"url":"https://github.com/elastic/kibana/pull/265354","mergeCommit":{"message":"[Lens] Add APM error tracking for chart render failures (#265354)\n\n## Summary\n\nAdds automatic APM error tracking for Lens chart renders at the\nembeddable level, so every consumer (Discover, Dashboard, Cases, etc.)\nbenefits without code changes.\n\nWhen a Lens chart fails to render (e.g., an Elasticsearch\n`verification_exception`), a `lens-chart-error` span is created within\nthe current page transaction with:\n- `event.outcome: failure`\n- The error captured via `apm.captureError()`\n- Labels: `kibana_meta_lens_metric_type`, `kibana_meta_lens_profile_id`,\n`kibana_meta_lens_metric_id`\n\nThe span is fire-and-forget — created and immediately ended in the\n`blockingError# Backport

This will backport the following commits from `main` to `9.4`:
{{{{raw}}}} - [[Lens] Add APM error tracking for chart render failures (#265354)](https://github.com/elastic/kibana/pull/265354){{{{/raw}}}}

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT  subscription. This keeps the implementation simple with\nno async lifecycle management, no edge cases around interleaving\nreloads, and no orphaned spans.\n\n<img width=\"1532\" height=\"1954\" alt=\"Screenshot 2026-04-23 at 15 02 21\"\nsrc=\"https://github.com/user-attachments/assets/f6124952-9582-4de2-8a75-c607b1643951\"\n/>\n<img width=\"1491\" height=\"1144\" alt=\"Screenshot 2026-04-23 at 15 02 32\"\nsrc=\"https://github.com/user-attachments/assets/c974c7d6-9936-4740-98b1-ba2c31bfdf85\"\n/>\n\n\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\n---------\n\nCo-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>","sha":"5f425ddd4dcbbcd719266a2a61ee0281b492290f"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/265354","number":265354,"mergeCommit":{"message":"[Lens] Add APM error tracking for chart render failures (#265354)\n\n## Summary\n\nAdds automatic APM error tracking for Lens chart renders at the\nembeddable level, so every consumer (Discover, Dashboard, Cases, etc.)\nbenefits without code changes.\n\nWhen a Lens chart fails to render (e.g., an Elasticsearch\n`verification_exception`), a `lens-chart-error` span is created within\nthe current page transaction with:\n- `event.outcome: failure`\n- The error captured via `apm.captureError()`\n- Labels: `kibana_meta_lens_metric_type`, `kibana_meta_lens_profile_id`,\n`kibana_meta_lens_metric_id`\n\nThe span is fire-and-forget — created and immediately ended in the\n`blockingError# Backport

This will backport the following commits from `main` to `9.4`:
{{{{raw}}}} - [[Lens] Add APM error tracking for chart render failures (#265354)](https://github.com/elastic/kibana/pull/265354){{{{/raw}}}}

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT  subscription. This keeps the implementation simple with\nno async lifecycle management, no edge cases around interleaving\nreloads, and no orphaned spans.\n\n<img width=\"1532\" height=\"1954\" alt=\"Screenshot 2026-04-23 at 15 02 21\"\nsrc=\"https://github.com/user-attachments/assets/f6124952-9582-4de2-8a75-c607b1643951\"\n/>\n<img width=\"1491\" height=\"1144\" alt=\"Screenshot 2026-04-23 at 15 02 32\"\nsrc=\"https://github.com/user-attachments/assets/c974c7d6-9936-4740-98b1-ba2c31bfdf85\"\n/>\n\n\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\n---------\n\nCo-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>","sha":"5f425ddd4dcbbcd719266a2a61ee0281b492290f"}}]}] BACKPORT-->