### PR TITLE
[8.19][Search] fix(search-applications): remove markup rendering from doc explorer

### DIFF
--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/applications/components/search_application/docs_explorer/field_value_cell.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/applications/components/search_application/docs_explorer/field_value_cell.tsx
@@ -7,44 +7,22 @@
 
 import React from 'react';
 
-import { css } from '@emotion/react';
-
-import { useEuiTheme, transparentize } from '@elastic/eui';
-
-import { FieldValue, isFieldValue } from './convert_results';
+import type { FieldValue } from './convert_results';
+import { isFieldValue } from './convert_results';
 
 export interface FieldValueCellProps {
   value: FieldValue | string | number | boolean | null;
 }
 
 export const FieldValueCell: React.FC<FieldValueCellProps> = ({ value }) => {
-  const { euiTheme, colorMode } = useEuiTheme();
-
   if (isFieldValue(value)) {
     if (value.snippet) {
-      const [snippet] = value.snippet;
-      // https://github.com/elastic/eui/blob/c4afd758e4c42ba6b12ea58ccfd6486d5f544afb/src/components/mark/mark.styles.ts#L29-L36
-      const transparency = { DARK: 0.3, LIGHT: 0.1 };
-      return (
-        <span
-          // eslint-disable-next-line react/no-danger
-          dangerouslySetInnerHTML={{ __html: snippet }}
-          css={css`
-            & em {
-              font-style: normal;
-              font-weight: ${euiTheme.font.weight.bold};
-              background-color: ${transparentize(euiTheme.colors.primary, transparency[colorMode])};
-              color: ${euiTheme.colors.text};
-            }
-          `}
-        />
-      );
+      return <span>{JSON.stringify(value.snippet)}</span>;
     }
     return (
       <FieldValueCell value={value.raw as Exclude<FieldValueCellProps['value'], FieldValue>} />
     );
   }
-
   if (typeof value === 'string') {
     return <span>{value}</span>;
   }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Search] fix(search-applications): remove markup rendering from doc explorer (#265319)](https://github.com/elastic/kibana/pull/265319)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Rodney Norris","email":"rodney.norris@elastic.co"},"sourceCommit":{"committedDate":"2026-04-23T20:58:12Z","message":"[Search] fix(search-applications): remove markup rendering from doc explorer (#265319)\n\n## Summary\n\nRemoves field rendering from Search Applications docs explorer.\n\nSearch Applications had code in the docs explorer that would render\nmarkup if the field had a `.snippet`. Removed this entire handling as it\nwas not needed and the entire Search Applications feature is deprecated.\n\n### Screenshots\n\nBefore:\n<img width=\"3358\" height=\"1834\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/baba58b5-d194-4802-8da8-a555e17ea6e3\"\n/>\n\nAfter:\n<img width=\"1915\" height=\"729\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/d3878b66-29ee-41be-8b5a-80089ac8fd62\"\n/>\n<img width=\"1915\" height=\"729\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/0cfea704-5523-4619-b26c-09bf40a5a1c4\"\n/>\n\n### Checklist\n\n- [ ] ~Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n## Release note\n\nFixes Search Applications document explorer to not render markup from\nfields.","sha":"81486d17cb1c8df23db94ad456f418940b12b3ab","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Search","Team:EnterpriseSearch","backport:all-open","v9.5.0"],"title":"[Search] fix(search-applications): remove markup rendering from doc explorer","number":265319,"url":"https://github.com/elastic/kibana/pull/265319","mergeCommit":{"message":"[Search] fix(search-applications): remove markup rendering from doc explorer (#265319)\n\n## Summary\n\nRemoves field rendering from Search Applications docs explorer.\n\nSearch Applications had code in the docs explorer that would render\nmarkup if the field had a `.snippet`. Removed this entire handling as it\nwas not needed and the entire Search Applications feature is deprecated.\n\n### Screenshots\n\nBefore:\n<img width=\"3358\" height=\"1834\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/baba58b5-d194-4802-8da8-a555e17ea6e3\"\n/>\n\nAfter:\n<img width=\"1915\" height=\"729\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/d3878b66-29ee-41be-8b5a-80089ac8fd62\"\n/>\n<img width=\"1915\" height=\"729\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/0cfea704-5523-4619-b26c-09bf40a5a1c4\"\n/>\n\n### Checklist\n\n- [ ] ~Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n## Release note\n\nFixes Search Applications document explorer to not render markup from\nfields.","sha":"81486d17cb1c8df23db94ad456f418940b12b3ab"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/265319","number":265319,"mergeCommit":{"message":"[Search] fix(search-applications): remove markup rendering from doc explorer (#265319)\n\n## Summary\n\nRemoves field rendering from Search Applications docs explorer.\n\nSearch Applications had code in the docs explorer that would render\nmarkup if the field had a `.snippet`. Removed this entire handling as it\nwas not needed and the entire Search Applications feature is deprecated.\n\n### Screenshots\n\nBefore:\n<img width=\"3358\" height=\"1834\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/baba58b5-d194-4802-8da8-a555e17ea6e3\"\n/>\n\nAfter:\n<img width=\"1915\" height=\"729\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/d3878b66-29ee-41be-8b5a-80089ac8fd62\"\n/>\n<img width=\"1915\" height=\"729\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/0cfea704-5523-4619-b26c-09bf40a5a1c4\"\n/>\n\n### Checklist\n\n- [ ] ~Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n## Release note\n\nFixes Search Applications document explorer to not render markup from\nfields.","sha":"81486d17cb1c8df23db94ad456f418940b12b3ab"}}]}] BACKPORT-->