### PR TITLE
[Fleet] Clean adopted adopted feature flag

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/common/experimental_features.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/experimental_features.ts
@@ -7,7 +7,7 @@
 
 const _allowedExperimentalValues = {
   showExperimentalShipperOptions: false,
-  useSpaceAwareness: true,
+
   enableAutomaticAgentUpgrades: true,
   enableSyncIntegrationsOnRemote: true,
   enableSSLSecrets: true,

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/assets/assets.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/assets/assets.tsx
@@ -10,7 +10,7 @@ import { Redirect } from 'react-router-dom';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { EuiFlexGroup, EuiFlexItem, EuiLink, EuiSpacer, EuiTitle, EuiCallOut } from '@elastic/eui';
 
-import { ExperimentalFeaturesService } from '../../../../../../../services';
+
 
 import type {
   EsAssetReference,
@@ -59,7 +59,7 @@ export const AssetsPage = ({ packageInfo, refetchPackageInfo }: AssetsPanelProps
   const { spaceId } = useFleetStatus();
   const config = useConfig();
 
-  const { useSpaceAwareness } = ExperimentalFeaturesService.get();
+
 
   const customAssetsExtension = useUIExtension(packageInfo.name, 'package-detail-assets');
 
@@ -254,13 +254,11 @@ export const AssetsPage = ({ packageInfo, refetchPackageInfo }: AssetsPanelProps
                 }}
               />
             </p>
-            {useSpaceAwareness ? (
-              <InstallKibanaAssetsButton
-                installInfo={pkgInstallationInfo}
-                title={packageInfo.title}
-                onSuccess={forceRefreshAssets}
-              />
-            ) : null}
+            <InstallKibanaAssetsButton
+              installInfo={pkgInstallationInfo}
+              title={packageInfo.title}
+              onSuccess={forceRefreshAssets}
+            />
           </EuiCallOut>
 
           <EuiSpacer size="m" />

--- a/x-pack/platform/plugins/shared/fleet/public/hooks/use_space_settings_context.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/hooks/use_space_settings_context.test.tsx
@@ -8,7 +8,7 @@
 import React from 'react';
 
 import { createFleetTestRendererMock } from '../mock';
-import { ExperimentalFeaturesService } from '../services';
+
 
 import { useGetSpaceSettings } from './use_request';
 import {
@@ -29,9 +29,6 @@ describe('useSpaceSettingsContext', () => {
     );
   }
   beforeEach(() => {
-    jest.mocked(ExperimentalFeaturesService.get).mockReturnValue({
-      useSpaceAwareness: true,
-    } as any);
     jest.mocked(useGetSpaceSettings).mockReturnValue({} as any);
   });
   it('should return default defaultNamespace if no restrictions', () => {

--- a/x-pack/platform/plugins/shared/fleet/public/hooks/use_space_settings_context.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/hooks/use_space_settings_context.tsx
@@ -7,8 +7,6 @@
 
 import React, { createContext, useContext } from 'react';
 
-import { ExperimentalFeaturesService } from '../services';
-
 import { useAuthz } from './use_authz';
 import { useGetSpaceSettings } from './use_request';
 
@@ -25,14 +23,13 @@ export const SpaceSettingsContextProvider: React.FC<{
   enabled?: boolean;
   children?: React.ReactNode;
 }> = ({ enabled = true, children }) => {
-  const useSpaceAwareness = ExperimentalFeaturesService.get()?.useSpaceAwareness ?? false;
   const authz = useAuthz();
   const isAllowed =
     authz.fleet.allAgentPolicies ||
     authz.fleet.allSettings ||
     authz.integrations.writeIntegrationPolicies;
   const spaceSettingsReq = useGetSpaceSettings({
-    enabled: useSpaceAwareness && enabled && isAllowed,
+    enabled: enabled && isAllowed,
   });
 
   const settings = React.useMemo(() => {

--- a/x-pack/platform/plugins/shared/fleet/server/config.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/config.test.ts
@@ -170,7 +170,7 @@ describe('Config schema', () => {
 
     it('should only add one deprecation when enabling an existing experimental feature with enableExperimental', () => {
       const res = applyConfigDeprecations({
-        enableExperimental: ['useSpaceAwareness'],
+        enableExperimental: ['enableAutoInstallContentPackages'],
       });
 
       expect(res.messages).toMatchInlineSnapshot(`
@@ -197,7 +197,7 @@ describe('Config schema', () => {
     it('should not add a deprecation when enabling an existing experimental feature with experimentalFeatures', () => {
       const res = applyConfigDeprecations({
         experimentalFeatures: {
-          useSpaceAwareness: true,
+          enableAutoInstallContentPackages: true,
         },
       });
 

--- a/x-pack/platform/plugins/shared/fleet/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/plugin.ts
@@ -381,15 +381,9 @@ export class FleetPlugin
 
     core.status.set(this.fleetStatus$.asObservable());
 
-    const experimentalFeatures = parseExperimentalConfigValue(
-      config.enableExperimental ?? [],
-      config.experimentalFeatures || {}
-    );
-    const requireAllSpaces = experimentalFeatures.useSpaceAwareness ? false : true;
+    const requireAllSpaces = false;
 
-    registerSavedObjects(core.savedObjects, {
-      useSpaceAwareness: experimentalFeatures.useSpaceAwareness,
-    });
+    registerSavedObjects(core.savedObjects);
     registerEncryptedSavedObjects(deps.encryptedSavedObjects);
 
     // Register feature

--- a/x-pack/platform/plugins/shared/fleet/server/routes/app/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/app/index.ts
@@ -11,7 +11,7 @@ import type { RequestHandler } from '@kbn/core/server';
 import type { TypeOf } from '@kbn/config-schema';
 import { schema } from '@kbn/config-schema';
 
-import type { ExperimentalFeatures } from '../../../common/experimental_features';
+
 import type { FleetAuthzRouter } from '../../services/security';
 import { APP_API_ROUTES } from '../../constants';
 import { ALL_SPACES_ID, API_VERSIONS } from '../../../common/constants';
@@ -168,10 +168,7 @@ export const GenerateServiceTokenResponseSchema = schema.object({
   value: schema.string(),
 });
 
-export const registerRoutes = (
-  router: FleetAuthzRouter,
-  experimentalFeatures: ExperimentalFeatures
-) => {
+export const registerRoutes = (router: FleetAuthzRouter) => {
   router.versioned
     .get({
       path: '/internal/fleet/telemetry/usage',
@@ -193,29 +190,27 @@ export const registerRoutes = (
       },
       getTelemetryUsageHandler
     );
-  if (experimentalFeatures.useSpaceAwareness) {
-    router.versioned
-      .post({
-        path: APP_API_ROUTES.SPACE_AWARENESS_MIGRATION,
-        access: 'internal',
-        security: {
-          authz: {
-            requiredPrivileges: [
-              FLEET_API_PRIVILEGES.AGENTS.ALL,
-              FLEET_API_PRIVILEGES.AGENT_POLICIES.ALL,
-              FLEET_API_PRIVILEGES.SETTINGS.ALL,
-            ],
-          },
+  router.versioned
+    .post({
+      path: APP_API_ROUTES.SPACE_AWARENESS_MIGRATION,
+      access: 'internal',
+      security: {
+        authz: {
+          requiredPrivileges: [
+            FLEET_API_PRIVILEGES.AGENTS.ALL,
+            FLEET_API_PRIVILEGES.AGENT_POLICIES.ALL,
+            FLEET_API_PRIVILEGES.SETTINGS.ALL,
+          ],
         },
-      })
-      .addVersion(
-        {
-          version: API_VERSIONS.internal.v1,
-          validate: {},
-        },
-        postEnableSpaceAwarenessHandler
-      );
-  }
+      },
+    })
+    .addVersion(
+      {
+        version: API_VERSIONS.internal.v1,
+        validate: {},
+      },
+      postEnableSpaceAwarenessHandler
+    );
   router.versioned
     .get({
       path: APP_API_ROUTES.CHECK_PERMISSIONS_PATTERN,

--- a/x-pack/platform/plugins/shared/fleet/server/routes/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/index.ts
@@ -43,7 +43,7 @@ export function registerRoutes(
     config.experimentalFeatures || {}
   );
   // Always register app routes for permissions checking
-  registerAppRoutes(fleetAuthzRouter, experimentalFeatures);
+  registerAppRoutes(fleetAuthzRouter);
 
   // The upload package route is only authorized for the superuser
   registerEPMRoutes(fleetAuthzRouter, config);
@@ -52,7 +52,7 @@ export function registerRoutes(
   registerAgentPolicyRoutes(fleetAuthzRouter, experimentalFeatures);
   registerPackagePolicyRoutes(fleetAuthzRouter);
   registerOutputRoutes(fleetAuthzRouter);
-  registerSettingsRoutes(fleetAuthzRouter, experimentalFeatures);
+  registerSettingsRoutes(fleetAuthzRouter);
   registerDataStreamRoutes(fleetAuthzRouter);
   registerPreconfigurationRoutes(fleetAuthzRouter);
   registerFleetServerHostRoutes(fleetAuthzRouter);

--- a/x-pack/platform/plugins/shared/fleet/server/routes/settings/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/settings/index.ts
@@ -7,7 +7,7 @@
 
 import path from 'path';
 
-import type { ExperimentalFeatures } from '../../../common/experimental_features';
+
 import { API_VERSIONS } from '../../../common/constants';
 import type { FleetAuthzRouter } from '../../services/security';
 import { SETTINGS_API_ROUTES } from '../../constants';
@@ -33,12 +33,8 @@ import {
   putSpaceSettingsHandler,
 } from './settings_handler';
 
-export const registerRoutes = (
-  router: FleetAuthzRouter,
-  experimentalFeatures: ExperimentalFeatures
-) => {
-  if (experimentalFeatures.useSpaceAwareness) {
-    router.versioned
+export const registerRoutes = (router: FleetAuthzRouter) => {
+  router.versioned
       // @ts-ignore https://github.com/elastic/kibana/issues/203170
       .get({
         path: SETTINGS_API_ROUTES.SPACE_INFO_PATTERN,
@@ -113,7 +109,6 @@ export const registerRoutes = (
         },
         putSpaceSettingsHandler
       );
-  }
 
   router.versioned
     .get({

--- a/x-pack/platform/plugins/shared/fleet/server/saved_objects/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/saved_objects/index.ts
@@ -129,10 +129,7 @@ import { disableBrowserInputWhenBothEnabled } from './model_versions/synthetics_
  * Please update typings in `/common/types` as well as
  * schemas in `/server/types` if mappings are updated.
  */
-export const getSavedObjectTypes = (
-  options = { useSpaceAwareness: false }
-): { [key: string]: SavedObjectsType } => {
-  const { useSpaceAwareness } = options;
+export const getSavedObjectTypes = (): { [key: string]: SavedObjectsType } => {
 
   return {
     [FLEET_SETUP_LOCK_TYPE]: {
@@ -1535,7 +1532,7 @@ export const getSavedObjectTypes = (
       name: PRECONFIGURATION_DELETION_RECORD_SAVED_OBJECT_TYPE,
       indexPattern: INGEST_SAVED_OBJECT_INDEX,
       hidden: false,
-      namespaceType: useSpaceAwareness ? 'single' : 'agnostic',
+      namespaceType: 'single',
       management: {
         importableAndExportable: false,
       },
@@ -1818,11 +1815,8 @@ export const getSavedObjectTypes = (
   };
 };
 
-export function registerSavedObjects(
-  savedObjects: SavedObjectsServiceSetup,
-  options = { useSpaceAwareness: false }
-) {
-  const savedObjectTypes = getSavedObjectTypes({ useSpaceAwareness: options.useSpaceAwareness });
+export function registerSavedObjects(savedObjects: SavedObjectsServiceSetup) {
+  const savedObjectTypes = getSavedObjectTypes();
   Object.values(savedObjectTypes).forEach((type) => {
     savedObjects.registerType(type);
   });

--- a/x-pack/platform/plugins/shared/fleet/server/services/backfill_agentless.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/backfill_agentless.test.ts
@@ -23,9 +23,7 @@ jest.mock('./settings', () => ({
 jest.mock('./app_context', () => {
   return {
     appContextService: {
-      getExperimentalFeatures: () => ({
-        useSpaceAwareness: true,
-      }),
+      getExperimentalFeatures: () => ({}),
       getLogger: () => ({
         debug: jest.fn(),
       }),

--- a/x-pack/platform/plugins/shared/fleet/server/services/cloud_connector.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/cloud_connector.test.ts
@@ -52,11 +52,12 @@ describe('CloudConnectorService', () => {
     // Setup mocks
     mockLogger = loggerMock.create();
     mockAppContextService.getLogger = jest.fn().mockReturnValue(mockLogger);
-    mockAppContextService.getExperimentalFeatures = jest.fn().mockReturnValue({
-      useSpaceAwareness: false,
-    });
+    mockAppContextService.getExperimentalFeatures = jest.fn().mockReturnValue({});
 
     mockSoClient = createSavedObjectClientMock();
+    mockAppContextService.getInternalUserSOClientForSpaceId = jest
+      .fn()
+      .mockReturnValue(mockSoClient);
     mockEsClient = elasticsearchServiceMock.createElasticsearchClient();
     service = new CloudConnectorService();
   });

--- a/x-pack/platform/plugins/shared/fleet/server/services/download_source.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/download_source.test.ts
@@ -209,7 +209,7 @@ describe('Download Service', () => {
     mockedAppContextService.getLogger.mockReturnValue(mockedLogger);
     jest
       .mocked(appContextService.getExperimentalFeatures)
-      .mockReturnValue({ useSpaceAwareness: true } as any);
+      .mockReturnValue({} as any);
     mockedAppContextService.getEncryptedSavedObjectsSetup.mockReturnValue({
       canEncrypt: true,
     } as any);

--- a/x-pack/platform/plugins/shared/fleet/server/services/preconfiguration/outputs.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/preconfiguration/outputs.test.ts
@@ -30,9 +30,7 @@ const mockedOutputService = outputService as jest.Mocked<typeof outputService>;
 
 jest.mock('../app_context', () => ({
   appContextService: {
-    getExperimentalFeatures: jest.fn().mockReturnValue({
-      useSpaceAwareness: false,
-    }),
+    getExperimentalFeatures: jest.fn().mockReturnValue({}),
     getInternalUserSOClient: jest.fn(),
     getInternalUserSOClientWithoutSpaceExtension: jest.fn(),
     getLogger: () =>

--- a/x-pack/platform/plugins/shared/fleet/server/services/settings.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/settings.test.ts
@@ -589,7 +589,7 @@ describe('createDefaultSettings', () => {
 
     const result = createDefaultSettings();
 
-    expect(result).toEqual({ prerelease_integrations_enabled: true });
+    expect(result).toEqual({ prerelease_integrations_enabled: true, use_space_awareness_migration_status: 'success' });
   });
 
   it('should return default settings with prerelease_integrations_enabled set to false if config.prereleaseEnabledByDefault is false', () => {
@@ -608,7 +608,7 @@ describe('createDefaultSettings', () => {
 
     const result = createDefaultSettings();
 
-    expect(result).toEqual({ prerelease_integrations_enabled: false });
+    expect(result).toEqual({ prerelease_integrations_enabled: false, use_space_awareness_migration_status: 'success' });
   });
 
   it('should return default settings with prerelease_integrations_enabled as false if config is not defined', () => {
@@ -616,10 +616,10 @@ describe('createDefaultSettings', () => {
 
     const result = createDefaultSettings();
 
-    expect(result).toEqual({ prerelease_integrations_enabled: false });
+    expect(result).toEqual({ prerelease_integrations_enabled: false, use_space_awareness_migration_status: 'success' });
   });
 
-  it('should return default settings with use_space_awareness_migration_status:success if feature flag is enabled', () => {
+  it('should return default settings with use_space_awareness_migration_status:success', () => {
     mockedAppContextService.getConfig.mockReturnValue({
       prereleaseEnabledByDefault: true,
       enabled: true,
@@ -632,10 +632,6 @@ describe('createDefaultSettings', () => {
         },
       },
     });
-
-    mockedAppContextService.getExperimentalFeatures.mockReturnValueOnce({
-      useSpaceAwareness: true,
-    } as any);
 
     const result = createDefaultSettings();
 
@@ -668,6 +664,7 @@ describe('createDefaultSettings', () => {
     expect(result).toEqual({
       integration_knowledge_enabled: true,
       prerelease_integrations_enabled: true,
+      use_space_awareness_migration_status: 'success',
     });
   });
 
@@ -693,6 +690,7 @@ describe('createDefaultSettings', () => {
     expect(result).toEqual({
       integration_knowledge_enabled: true,
       prerelease_integrations_enabled: true,
+      use_space_awareness_migration_status: 'success',
     });
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/server/services/settings.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/settings.ts
@@ -194,9 +194,7 @@ export function createDefaultSettings(): BaseSettings {
     prerelease_integrations_enabled: !!config?.prereleaseEnabledByDefault,
   };
 
-  if (appContextService.getExperimentalFeatures().useSpaceAwareness) {
-    settings.use_space_awareness_migration_status = 'success';
-  }
+  settings.use_space_awareness_migration_status = 'success';
 
   if (
     config?.experimentalFeatures?.integrationKnowledge ??

--- a/x-pack/platform/plugins/shared/fleet/server/services/spaces/helper.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/spaces/helper.test.ts
@@ -6,19 +6,12 @@
  */
 
 import type { Settings } from '../../types';
-import { appContextService } from '../app_context';
 import { getSettingsOrUndefined } from '../settings';
 
 import { isSpaceAwarenessEnabled, isSpaceAwarenessMigrationPending } from './helpers';
 
 jest.mock('../app_context');
 jest.mock('../settings');
-
-function mockFeatureFlag(val: boolean) {
-  jest.mocked(appContextService.getExperimentalFeatures).mockReturnValue({
-    useSpaceAwareness: val,
-  } as any);
-}
 
 function mockGetSettings(settings?: Partial<Settings>) {
   if (settings) {
@@ -30,16 +23,10 @@ function mockGetSettings(settings?: Partial<Settings>) {
 
 describe('isSpaceAwarenessEnabled', () => {
   beforeEach(() => {
-    jest.mocked(appContextService.getExperimentalFeatures).mockReset();
     jest.mocked(getSettingsOrUndefined).mockReset();
   });
-  it('should return false if feature flag is disabled', async () => {
-    mockFeatureFlag(false);
-    await expect(isSpaceAwarenessEnabled()).resolves.toBe(false);
-  });
 
-  it('should return false if feature flag is enabled but user did not optin', async () => {
-    mockFeatureFlag(true);
+  it('should return false if user did not optin', async () => {
     mockGetSettings({
       use_space_awareness_migration_status: undefined,
     });
@@ -48,16 +35,14 @@ describe('isSpaceAwarenessEnabled', () => {
     expect(res).toBe(false);
   });
 
-  it('should return false if feature flag is enabled and settings do not exists', async () => {
-    mockFeatureFlag(true);
+  it('should return false if settings do not exist', async () => {
     mockGetSettings();
     const res = await isSpaceAwarenessEnabled();
 
     expect(res).toBe(false);
   });
 
-  it('should return true if feature flag is enabled and user optin', async () => {
-    mockFeatureFlag(true);
+  it('should return true if user optin', async () => {
     mockGetSettings({
       use_space_awareness_migration_status: 'success',
     });
@@ -65,22 +50,21 @@ describe('isSpaceAwarenessEnabled', () => {
 
     expect(res).toBe(true);
   });
+
+  it('should return false if settings lookup throws', async () => {
+    jest.mocked(getSettingsOrUndefined).mockRejectedValue(new Error('SO client not available'));
+    const res = await isSpaceAwarenessEnabled();
+
+    expect(res).toBe(false);
+  });
 });
 
 describe('isSpaceAwarenessMigrationPending', () => {
   beforeEach(() => {
-    jest.mocked(appContextService.getExperimentalFeatures).mockReset();
     jest.mocked(getSettingsOrUndefined).mockReset();
   });
-  it('should return false if feature flag is disabled', async () => {
-    mockFeatureFlag(false);
-    const res = await isSpaceAwarenessMigrationPending();
 
-    expect(res).toBe(false);
-  });
-
-  it('should return false if feature flag is enabled but user did not optin', async () => {
-    mockFeatureFlag(true);
+  it('should return false if user did not optin', async () => {
     mockGetSettings({
       use_space_awareness_migration_status: undefined,
     });
@@ -89,16 +73,14 @@ describe('isSpaceAwarenessMigrationPending', () => {
     expect(res).toBe(false);
   });
 
-  it('should return false if feature flag is enabled and settings do not exists', async () => {
-    mockFeatureFlag(true);
+  it('should return false if settings do not exist', async () => {
     mockGetSettings();
     const res = await isSpaceAwarenessMigrationPending();
 
     expect(res).toBe(false);
   });
 
-  it('should return false if feature flag is enabled and migration is complete', async () => {
-    mockFeatureFlag(true);
+  it('should return false if migration is complete', async () => {
     mockGetSettings({
       use_space_awareness_migration_status: 'success',
     });
@@ -107,8 +89,7 @@ describe('isSpaceAwarenessMigrationPending', () => {
     expect(res).toBe(false);
   });
 
-  it('should return true if feature flag is enabled and migration is in progress', async () => {
-    mockFeatureFlag(true);
+  it('should return true if migration is in progress', async () => {
     mockGetSettings({
       use_space_awareness_migration_status: 'pending',
       use_space_awareness_migration_started_at: new Date().toISOString(),
@@ -118,8 +99,7 @@ describe('isSpaceAwarenessMigrationPending', () => {
     expect(res).toBe(true);
   });
 
-  it('should return false if feature flag is enabled and an old migration is in progress', async () => {
-    mockFeatureFlag(true);
+  it('should return false if an old migration is in progress', async () => {
     mockGetSettings({
       use_space_awareness_migration_status: 'pending',
       use_space_awareness_migration_started_at: new Date(Date.now() - 60 * 60 * 1000).toISOString(),

--- a/x-pack/platform/plugins/shared/fleet/server/services/spaces/helpers.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/spaces/helpers.ts
@@ -23,31 +23,28 @@ export const PENDING_MIGRATION_TIMEOUT = 60 * 60 * 1000;
  * Return true if user optin for the space awareness feature.
  */
 export async function isSpaceAwarenessEnabled(): Promise<boolean> {
-  if (!appContextService.getExperimentalFeatures().useSpaceAwareness) {
-    return false;
-  }
   const cache = getIsSpaceAwarenessEnabledCache();
   if (typeof cache === 'boolean') {
     return cache;
   }
 
-  const settings = await getSettingsOrUndefined(appContextService.getInternalUserSOClient());
+  try {
+    const settings = await getSettingsOrUndefined(appContextService.getInternalUserSOClient());
 
-  // @ts-expect-error upgrade typescript v5.9.3
-  const res = settings?.use_space_awareness_migration_status === 'success' ?? false;
-  setIsSpaceAwarenessEnabledCache(res);
+    // @ts-expect-error upgrade typescript v5.9.3
+    const res = settings?.use_space_awareness_migration_status === 'success' ?? false;
+    setIsSpaceAwarenessEnabledCache(res);
 
-  return res;
+    return res;
+  } catch (e) {
+    return false;
+  }
 }
 
 /**
  * Return true if space awareness migration is currently running
  */
 export async function isSpaceAwarenessMigrationPending(): Promise<boolean> {
-  if (!appContextService.getExperimentalFeatures().useSpaceAwareness) {
-    return false;
-  }
-
   const settings = await getSettingsOrUndefined(appContextService.getInternalUserSOClient());
 
   if (

--- a/x-pack/platform/plugins/shared/fleet/server/services/spaces/policy_namespaces.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/spaces/policy_namespaces.test.ts
@@ -41,12 +41,6 @@ describe('validatePolicyNamespaceForSpace', () => {
     return client;
   }
 
-  beforeEach(() => {
-    jest
-      .mocked(appContextService.getExperimentalFeatures)
-      .mockReturnValue({ useSpaceAwareness: true } as any);
-  });
-
   it('should retrieve settings based on given spaceId', async () => {
     const soClient = createSavedsClientMock();
     await validatePolicyNamespaceForSpace({
@@ -112,17 +106,6 @@ describe('validatePolicyNamespaceForSpace', () => {
     ).rejects.toThrowError(/Invalid namespace, supported namespace prefixes: tata, test, toto/);
   });
 
-  it('should not validate if feature flag is off', async () => {
-    jest
-      .mocked(appContextService.getExperimentalFeatures)
-      .mockReturnValue({ useSpaceAwareness: false } as any);
-    createSavedsClientMock({ allowed_namespace_prefixes: ['tata', 'test', 'toto'] });
-
-    await validatePolicyNamespaceForSpace({
-      spaceId: 'test1',
-      namespace: 'notvalid',
-    });
-  });
 });
 
 const packagePolicy1 = {

--- a/x-pack/platform/plugins/shared/fleet/server/services/spaces/policy_namespaces.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/spaces/policy_namespaces.ts
@@ -28,10 +28,6 @@ export async function validatePolicyNamespaceForSpace({
   namespace: string;
   spaceId?: string;
 }) {
-  const experimentalFeature = appContextService.getExperimentalFeatures();
-  if (!experimentalFeature.useSpaceAwareness) {
-    return;
-  }
   const settings = await getSpaceSettings(spaceId);
   if (!settings.allowed_namespace_prefixes || settings.allowed_namespace_prefixes.length === 0) {
     return;
@@ -61,10 +57,6 @@ export async function validateAdditionalDatastreamsPermissionsForSpace({
   additionalDatastreamsPermissions?: string[];
   spaceId?: string;
 }) {
-  const experimentalFeature = appContextService.getExperimentalFeatures();
-  if (!experimentalFeature.useSpaceAwareness) {
-    return;
-  }
   const settings = await getSpaceSettings(spaceId);
   if (
     !settings.allowed_namespace_prefixes ||


### PR DESCRIPTION
## Summary

Clean adopted feature flag adopted feature flag `useSpaceAwareness`. The migration to enable space awareness on legacy cluster is still here, and we still have a code path without space awareness 