### PR TITLE
[Workflows] Add editor settings popover and Workflows section in Advanced Settings

### DIFF
--- a/src/platform/packages/shared/kbn-management/settings/components/field_category/categories.tsx
+++ b/src/platform/packages/shared/kbn-management/settings/components/field_category/categories.tsx
@@ -9,6 +9,8 @@
 
 import React from 'react';
 
+import { EuiCallOut } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 import type {
   CategorizedFields,
   UnsavedFieldChanges,
@@ -18,6 +20,25 @@ import type {
 import type { FieldRowProps } from '@kbn/management-settings-components-field-row';
 import { FieldRow } from '@kbn/management-settings-components-field-row';
 import { FieldCategory, type FieldCategoryProps } from './category';
+
+const CATEGORY_NOTICES: Record<string, React.ReactNode> = {
+  workflows: (
+    <EuiCallOut
+      title={i18n.translate('management.settings.fieldCategories.workflows.warningTitle', {
+        defaultMessage: 'System workflow settings',
+      })}
+      color="warning"
+      iconType="warning"
+    >
+      <p>
+        {i18n.translate('management.settings.fieldCategories.workflows.warningBody', {
+          defaultMessage:
+            'System workflows are managed by Elastic and power core platform features. Editing, disabling, or deleting them may cause unexpected behaviour or break product functionality. Enable these settings only if you know what you are doing.',
+        })}
+      </p>
+    </EuiCallOut>
+  ),
+};
 
 /**
  * Props for the {@link FieldCategories} component.
@@ -51,6 +72,7 @@ export const FieldCategories = ({
       <FieldCategory
         key={category}
         fieldCount={categoryCounts[category]}
+        notice={CATEGORY_NOTICES[category]}
         {...{ category, onClearQuery }}
       >
         {fields.map((field) => (

--- a/src/platform/packages/shared/kbn-management/settings/components/field_category/category.tsx
+++ b/src/platform/packages/shared/kbn-management/settings/components/field_category/category.tsx
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { ReactElement } from 'react';
+import type { ReactElement, ReactNode } from 'react';
 import React, { Children } from 'react';
 
 import { EuiFlexGroup, EuiFlexItem, EuiSplitPanel, EuiTitle, useEuiTheme } from '@elastic/eui';
@@ -31,6 +31,8 @@ export interface FieldCategoryProps
   children:
     | ReactElement<FieldRowProps, 'FieldRow'>
     | Array<ReactElement<FieldRowProps, 'FieldRow'>>;
+  /** Optional notice to display between the category header and fields. */
+  notice?: ReactNode;
 }
 
 /**
@@ -39,7 +41,7 @@ export interface FieldCategoryProps
  * @param props - the props to pass to the {@link FieldCategory} component.
  */
 export const FieldCategory = (props: FieldCategoryProps) => {
-  const { category, fieldCount, onClearQuery, children } = props;
+  const { category, fieldCount, onClearQuery, children, notice } = props;
   const {
     euiTheme: { size },
   } = useEuiTheme();
@@ -68,6 +70,7 @@ export const FieldCategory = (props: FieldCategoryProps) => {
           </EuiFlexItem>
         </EuiFlexGroup>
       </EuiSplitPanel.Inner>
+      {notice && <EuiSplitPanel.Inner color="plain">{notice}</EuiSplitPanel.Inner>}
       <EuiSplitPanel.Inner>{children}</EuiSplitPanel.Inner>
     </EuiSplitPanel.Outer>
   );

--- a/src/platform/packages/shared/kbn-workflows/common/constants.ts
+++ b/src/platform/packages/shared/kbn-workflows/common/constants.ts
@@ -19,6 +19,8 @@ export const WORKFLOWS_UI_SETTING_ID = 'workflows:ui:enabled';
 export const WORKFLOWS_UI_VISUAL_EDITOR_SETTING_ID = 'workflows:ui:visualEditor:enabled';
 export const WORKFLOWS_UI_EXECUTION_GRAPH_SETTING_ID = 'workflows:ui:executionGraph:enabled';
 export const WORKFLOWS_UI_SHOW_EXECUTOR_SETTING_ID = 'workflows:ui:showExecutor:enabled';
+export const WORKFLOWS_SHOW_SYSTEM_WORKFLOWS_SETTING_ID = 'workflows:ui:showSystemWorkflows';
+export const WORKFLOWS_SHOW_SYSTEM_EXECUTIONS_SETTING_ID = 'workflows:ui:showSystemExecutions';
 
 /**
  * Feature flag ID for enabling / disabling the workflow execution stats bar UI

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/editor_settings_popover.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/editor_settings_popover.tsx
@@ -1,0 +1,117 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import {
+  EuiButtonIcon,
+  EuiCheckbox,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiPopover,
+  EuiPopoverTitle,
+  EuiToolTip,
+  useGeneratedHtmlId,
+} from '@elastic/eui';
+import React, { useCallback, useState } from 'react';
+import { i18n } from '@kbn/i18n';
+import type { monaco } from '@kbn/monaco';
+
+interface EditorSettingsPopoverProps {
+  editorRef: React.MutableRefObject<monaco.editor.IStandaloneCodeEditor | null>;
+}
+
+export function EditorSettingsPopover({ editorRef }: EditorSettingsPopoverProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [showIndentGuides, setShowIndentGuides] = useState(true);
+  const [showWhitespace, setShowWhitespace] = useState(false);
+
+  const indentGuidesCheckboxId = useGeneratedHtmlId({ prefix: 'wf-editor-setting-indent-guides' });
+  const whitespaceCheckboxId = useGeneratedHtmlId({ prefix: 'wf-editor-setting-whitespace' });
+  const popoverTitleId = useGeneratedHtmlId({ prefix: 'wf-editor-settings-title' });
+
+  const handleIndentGuidesChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const enabled = e.target.checked;
+      setShowIndentGuides(enabled);
+      editorRef.current?.updateOptions({
+        guides: { indentation: enabled },
+      });
+    },
+    [editorRef]
+  );
+
+  const handleWhitespaceChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const enabled = e.target.checked;
+      setShowWhitespace(enabled);
+      editorRef.current?.updateOptions({
+        renderWhitespace: enabled ? 'all' : 'none',
+      });
+    },
+    [editorRef]
+  );
+
+  const label = i18n.translate('workflows.yamlEditor.editorSettings.label', {
+    defaultMessage: 'Editor settings',
+  });
+
+  return (
+    <EuiPopover
+      css={{ marginLeft: '8px' }}
+      data-test-subj="workflowYamlEditorSettingsPopover"
+      aria-labelledby={popoverTitleId}
+      isOpen={isOpen}
+      closePopover={() => setIsOpen(false)}
+      anchorPosition="upRight"
+      panelPaddingSize="none"
+      button={
+        <EuiToolTip content={label} delay="long" disableScreenReaderOutput>
+          <EuiButtonIcon
+            size="xs"
+            iconType="controlsHorizontal"
+            data-test-subj="workflowYamlEditorSettingsButton"
+            onClick={() => setIsOpen(!isOpen)}
+            aria-label={label}
+            color="primary"
+          />
+        </EuiToolTip>
+      }
+    >
+      <EuiPopoverTitle id={popoverTitleId} paddingSize="s">
+        {label}
+      </EuiPopoverTitle>
+      <EuiFlexGroup
+        direction="column"
+        gutterSize="s"
+        css={{ padding: '8px 12px 12px' }}
+        responsive={false}
+      >
+        <EuiFlexItem>
+          <EuiCheckbox
+            id={indentGuidesCheckboxId}
+            label={i18n.translate('workflows.yamlEditor.editorSettings.showIndentGuides', {
+              defaultMessage: 'Show indent guides',
+            })}
+            checked={showIndentGuides}
+            onChange={handleIndentGuidesChange}
+          />
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiCheckbox
+            id={whitespaceCheckboxId}
+            label={i18n.translate('workflows.yamlEditor.editorSettings.showWhitespace', {
+              defaultMessage: 'Show whitespace characters',
+            })}
+            checked={showWhitespace}
+            onChange={handleWhitespaceChange}
+          />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </EuiPopover>
+  );
+}

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/workflow_yaml_editor.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/workflow_yaml_editor.tsx
@@ -30,6 +30,7 @@ import {
   useWorkflowIdDecorations,
 } from './decorations';
 import { DocumentationLink } from './documentation_link';
+import { EditorSettingsPopover } from './editor_settings_popover';
 import type { ExtraAction } from './extra_actions_bar';
 import { ExtraActionsBar } from './extra_actions_bar';
 import { useAgentBuilderIntegration } from './hooks/use_agent_builder_integration';
@@ -119,6 +120,7 @@ const editorOptions: monaco.editor.IStandaloneEditorConstructionOptions = {
   fontSize: 14,
   lineHeight: 23, // default ~21px + 2px
   renderWhitespace: 'none',
+  guides: { indentation: true },
   wordWrap: 'on',
   wordWrapColumn: 80,
   wrappingIndent: 'indent',
@@ -649,8 +651,13 @@ export const WorkflowYAMLEditor = ({
         content: <KeyboardShortcutsPopover />,
         showInReadOnly: true,
       },
+      {
+        id: 'editor-settings',
+        content: <EditorSettingsPopover editorRef={editorRef} />,
+        showInReadOnly: true,
+      },
     ],
-    [openActionsPopover]
+    [openActionsPopover, editorRef]
   );
 
   // These were triggering rerendering of the actions containers on every scroll, because they were

--- a/src/platform/plugins/shared/workflows_management/server/ui_settings.ts
+++ b/src/platform/plugins/shared/workflows_management/server/ui_settings.ts
@@ -10,7 +10,11 @@
 import { schema } from '@kbn/config-schema';
 import type { CoreSetup } from '@kbn/core/server';
 import { i18n } from '@kbn/i18n';
-import { WORKFLOWS_UI_SETTING_ID } from '@kbn/workflows/common/constants';
+import {
+  WORKFLOWS_UI_SETTING_ID,
+  WORKFLOWS_SHOW_SYSTEM_WORKFLOWS_SETTING_ID,
+  WORKFLOWS_SHOW_SYSTEM_EXECUTIONS_SETTING_ID,
+} from '@kbn/workflows/common/constants';
 import type { WorkflowsServerPluginSetupDeps } from './types';
 import { WORKFLOWS_DOCUMENTATION_URL } from '../common';
 
@@ -48,6 +52,37 @@ export const registerUISettings = (
       readonly: false,
       requiresPageReload: true,
       category: ['general'],
+    },
+
+    [WORKFLOWS_SHOW_SYSTEM_WORKFLOWS_SETTING_ID]: {
+      name: i18n.translate('workflowsManagement.uiSettings.showSystemWorkflows.name', {
+        defaultMessage: 'Show system workflows',
+      }),
+      description: i18n.translate('workflowsManagement.uiSettings.showSystemWorkflows.description', {
+        defaultMessage: 'Display internal system workflows in the Workflows list.',
+      }),
+      schema: schema.boolean(),
+      value: false,
+      type: 'boolean',
+      requiresPageReload: false,
+      category: ['workflows'],
+    },
+
+    [WORKFLOWS_SHOW_SYSTEM_EXECUTIONS_SETTING_ID]: {
+      name: i18n.translate('workflowsManagement.uiSettings.showSystemExecutions.name', {
+        defaultMessage: 'Show system workflow executions',
+      }),
+      description: i18n.translate(
+        'workflowsManagement.uiSettings.showSystemExecutions.description',
+        {
+          defaultMessage: 'Display execution history for internal system workflows.',
+        }
+      ),
+      schema: schema.boolean(),
+      value: false,
+      type: 'boolean',
+      requiresPageReload: false,
+      category: ['workflows'],
     },
   });
 };


### PR DESCRIPTION
## Summary

- Adds an **Editor Settings** popover icon to the YAML editor bottom bar (to the right of the keyboard shortcuts icon), with two toggles:
  - **Show indent guides** — vertical grey lines at each indent level (on by default)
  - **Show whitespace characters** — dots for every space (off by default)
- Adds a **Workflows** section to Advanced Settings (`/app/management/kibana/settings`) with two boolean toggles:
  - Show system workflows
  - Show system workflow executions
- The Workflows settings section includes an EUI warning callout explaining the risks of interacting with system workflows
- Extends the shared `FieldCategory` component with an optional `notice` prop for rendering category-level notices

## Test plan

- [ ] Open the Workflow YAML editor — verify indent guide lines are visible by default
- [ ] Click the settings icon (⊞) in the bottom bar — popover opens with two checkboxes
- [ ] Toggle "Show indent guides" off — vertical lines disappear from the editor
- [ ] Toggle "Show whitespace characters" on — dots appear for every space
- [ ] Navigate to Advanced Settings → verify a "Workflows" section exists separate from General
- [ ] Verify the warning callout is shown above the two toggles in the Workflows section
- [ ] Toggle both settings in Advanced Settings — verify values persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)