### PR TITLE
[Reporting] Retry CSV tasks on transport disconnects

### DIFF
--- a/src/platform/packages/private/kbn-generate-csv/src/generate_csv.test.ts
+++ b/src/platform/packages/private/kbn-generate-csv/src/generate_csv.test.ts
@@ -1794,6 +1794,70 @@ describe('CsvGenerator', () => {
     `);
   });
 
+  it('throws a retryable task run error for transport connection failures', async () => {
+    mockDataClient.search = jest.fn().mockImplementation(() => {
+      const err = new Error('Connection closed while reading the body');
+      (err as Error & { code?: string }).code = 'ECONNRESET';
+      throw err;
+    });
+
+    const generateCsv = new CsvGenerator(
+      createMockJob({ columns: ['date', 'ip', 'message'] }),
+      mockConfig,
+      mockTaskInstanceFields,
+      {
+        es: mockEsClient,
+        data: mockDataClient,
+        uiSettings: uiSettingsClient,
+      },
+      {
+        searchSourceStart: mockSearchSourceService,
+        fieldFormatsRegistry: mockFieldFormatsRegistry,
+      },
+      new CancellationToken(),
+      mockLogger,
+      stream,
+      false, // isServerless
+      jobId
+    );
+
+    await expect(generateCsv.generateData()).rejects.toThrow(
+      'CSV export search error: Connection closed while reading the body'
+    );
+  });
+
+  it('throws a retryable task run error for transport failures by code only', async () => {
+    mockDataClient.search = jest.fn().mockImplementation(() => {
+      const err = new Error('upstream request failed');
+      (err as Error & { cause?: unknown }).cause = { code: 'ETIMEDOUT' };
+      throw err;
+    });
+
+    const generateCsv = new CsvGenerator(
+      createMockJob({ columns: ['date', 'ip', 'message'] }),
+      mockConfig,
+      mockTaskInstanceFields,
+      {
+        es: mockEsClient,
+        data: mockDataClient,
+        uiSettings: uiSettingsClient,
+      },
+      {
+        searchSourceStart: mockSearchSourceService,
+        fieldFormatsRegistry: mockFieldFormatsRegistry,
+      },
+      new CancellationToken(),
+      mockLogger,
+      stream,
+      false, // isServerless
+      jobId
+    );
+
+    await expect(generateCsv.generateData()).rejects.toThrow(
+      'CSV export search error: upstream request failed'
+    );
+  });
+
   it('handles unknown errors', async () => {
     const streamWriteSpy = jest.spyOn(stream, 'write');
     mockDataClient.search = jest.fn().mockImplementation(() => {

--- a/src/platform/packages/private/kbn-generate-csv/src/generate_csv.ts
+++ b/src/platform/packages/private/kbn-generate-csv/src/generate_csv.ts
@@ -53,6 +53,65 @@ interface Dependencies {
   fieldFormatsRegistry: IFieldFormatsRegistry;
 }
 
+const RETRYABLE_TRANSPORT_ERROR_CODES = new Set([
+  'ECONNABORTED',
+  'ECONNRESET',
+  'ECONNREFUSED',
+  'EPIPE',
+  'ETIMEDOUT',
+  'UND_ERR_CONNECT_TIMEOUT',
+  'UND_ERR_HEADERS_TIMEOUT',
+  'UND_ERR_SOCKET',
+]);
+
+const RETRYABLE_TRANSPORT_ERROR_MESSAGES = [
+  'connection closed while reading the body',
+  'socket hang up',
+  'request timed out',
+  'connect timeout',
+];
+
+const getErrorCode = (error: unknown): string | undefined => {
+  if (!error || typeof error !== 'object') {
+    return;
+  }
+
+  const code = (error as { code?: unknown }).code;
+  if (typeof code === 'string') {
+    return code;
+  }
+};
+
+const getErrorMessage = (error: unknown): string => {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (typeof error === 'string') {
+    return error;
+  }
+  return String(error);
+};
+
+const isRetryableTransportError = (error: unknown): boolean => {
+  const message = getErrorMessage(error).toLowerCase();
+  if (RETRYABLE_TRANSPORT_ERROR_MESSAGES.some((snippet) => message.includes(snippet))) {
+    return true;
+  }
+
+  const code = getErrorCode(error);
+  if (code && RETRYABLE_TRANSPORT_ERROR_CODES.has(code)) {
+    return true;
+  }
+
+  const cause =
+    error && typeof error === 'object' ? (error as { cause?: unknown }).cause : undefined;
+  if (cause) {
+    return isRetryableTransportError(cause);
+  }
+
+  return false;
+};
+
 export class CsvGenerator {
   private csvContainsFormulas = false;
   private maxSizeReached = false;
@@ -464,6 +523,10 @@ export class CsvGenerator {
         warnings.push(i18nTexts.escapedFormulaValuesMessage);
       }
     } catch (err) {
+      if (isRetryableTransportError(err)) {
+        throw createTaskRunError(err instanceof Error ? err : new Error(String(err)));
+      }
+
       logger.error(err, { tags: [this.jobId] });
       if (err instanceof esErrors.ResponseError) {
         if ([401, 403].includes(err.statusCode ?? 0)) {


### PR DESCRIPTION
This pull request enhances the error handling in the CSV export functionality to better detect and handle retryable transport errors during CSV generation. It introduces utility functions to identify network-related errors and ensures that such errors are surfaced as retryable task run errors. Additionally, the test suite is expanded to cover these scenarios.

**Error Handling Improvements:**

* Added utility functions (`isRetryableTransportError`, `getErrorCode`, and `getErrorMessage`) in `generate_csv.ts` to detect retryable network/transport errors based on error codes and message content.
* Updated the `CsvGenerator.generateData` method to throw a retryable task run error when a retryable transport error is detected, improving robustness and reliability of CSV exports.

**Test Coverage:**

* Added tests in `generate_csv.test.ts` to verify that retryable transport errors (by code and by message content) are correctly detected and throw the expected errors.## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



