### PR TITLE
[8.19] [Security Solution] Fix flaky bulk edit alert suppression Cypress tests on MKI (#265262)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation/components/alert_suppression_edit/components/alert_suppression_edit.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation/components/alert_suppression_edit/components/alert_suppression_edit.tsx
@@ -21,6 +21,7 @@ interface AlertSuppressionEditProps {
   disabledText?: string;
   warningText?: string;
   fullWidth?: boolean;
+  isLoading?: boolean;
 }
 
 export const AlertSuppressionEdit = memo(function AlertSuppressionEdit({
@@ -30,6 +31,7 @@ export const AlertSuppressionEdit = memo(function AlertSuppressionEdit({
   disabledText,
   warningText,
   fullWidth,
+  isLoading,
 }: AlertSuppressionEditProps): JSX.Element {
   const [{ [ALERT_SUPPRESSION_FIELDS_FIELD_NAME]: suppressionFields }] = useFormData<{
     [ALERT_SUPPRESSION_FIELDS_FIELD_NAME]: string[];
@@ -44,6 +46,7 @@ export const AlertSuppressionEdit = memo(function AlertSuppressionEdit({
         labelAppend={labelAppend}
         disabled={disabled}
         fullWidth={fullWidth}
+        isLoading={isLoading}
       />
       {warningText && (
         <EuiText size="xs" color="warning" data-test-subj="alertSuppressionWarning">

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation/components/alert_suppression_edit/components/suppression_fields_selector.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation/components/alert_suppression_edit/components/suppression_fields_selector.tsx
@@ -18,6 +18,7 @@ interface SuppressionFieldsSelectorProps {
   labelAppend?: React.ReactNode;
   disabled?: boolean;
   fullWidth?: boolean;
+  isLoading?: boolean;
 }
 
 export function SuppressionFieldsSelector({
@@ -25,6 +26,7 @@ export function SuppressionFieldsSelector({
   labelAppend,
   disabled,
   fullWidth,
+  isLoading,
 }: SuppressionFieldsSelectorProps): JSX.Element {
   return (
     <EuiFormRow
@@ -41,6 +43,7 @@ export function SuppressionFieldsSelector({
             browserFields: suppressibleFields,
             isDisabled: disabled,
             fullWidth,
+            isLoading,
           }}
         />
       </>

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation_ui/components/multi_select_fields/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation_ui/components/multi_select_fields/index.tsx
@@ -18,6 +18,7 @@ interface MultiSelectAutocompleteProps {
   field: FieldHook;
   fullWidth?: boolean;
   dataTestSubj?: string;
+  isLoading?: boolean;
 }
 
 const FIELD_COMBO_BOX_WIDTH = 410;
@@ -30,6 +31,7 @@ export const MultiSelectAutocompleteComponent: React.FC<MultiSelectAutocompleteP
   field,
   fullWidth = false,
   dataTestSubj,
+  isLoading,
 }: MultiSelectAutocompleteProps) => {
   const comboBoxRef = useRef<EuiComboBox<unknown>>();
   const fieldEuiFieldProps = useMemo(
@@ -40,10 +42,11 @@ export const MultiSelectAutocompleteComponent: React.FC<MultiSelectAutocompleteP
       placeholder: FIELD_PLACEHOLDER,
       onCreateOption: undefined,
       ...(fullWidth ? {} : { style: { width: `${FIELD_COMBO_BOX_WIDTH}px` } }),
-      isDisabled,
+      isDisabled: isDisabled || isLoading,
+      isLoading,
       ref: comboBoxRef,
     }),
-    [browserFields, isDisabled, fullWidth, comboBoxRef]
+    [browserFields, isDisabled, isLoading, fullWidth, comboBoxRef]
   );
 
   /**
@@ -54,10 +57,10 @@ export const MultiSelectAutocompleteComponent: React.FC<MultiSelectAutocompleteP
    * options lits.
    */
   useEffect(() => {
-    if (isDisabled) {
+    if (isDisabled || isLoading) {
       comboBoxRef.current?.closeList();
     }
-  }, [isDisabled]);
+  }, [isDisabled, isLoading]);
 
   return (
     <ComboBoxField

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/bulk_actions/forms/set_alert_suppression_form.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/bulk_actions/forms/set_alert_suppression_form.tsx
@@ -84,7 +84,7 @@ export const SetAlertSuppressionForm = React.memo(function SetAlertSuppressionFo
   const { uiSettings } = useKibana().services;
   const defaultPatterns = uiSettings.get<string[]>(DEFAULT_INDEX_KEY);
 
-  const [_, { indexPatterns }] = useFetchIndex(defaultPatterns, false);
+  const [isFetchingIndexFields, { indexPatterns }] = useFetchIndex(defaultPatterns, false);
   const suppressibleFields = useTermsAggregationFields(indexPatterns?.fields);
 
   const handleSubmit = async () => {
@@ -129,7 +129,11 @@ export const SetAlertSuppressionForm = React.memo(function SetAlertSuppressionFo
       </EuiFlexGroup>
       <EuiSpacer size="l" />
 
-      <AlertSuppressionEdit suppressibleFields={suppressibleFields} fullWidth />
+      <AlertSuppressionEdit
+        suppressibleFields={suppressibleFields}
+        isLoading={isFetchingIndexFields}
+        fullWidth
+      />
     </BulkEditFormWrapper>
   );
 });

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/create_new_rule.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/create_new_rule.ts
@@ -937,8 +937,16 @@ export const fillAlertSuppressionFields = (fields: string[]) => {
   cy.get(ALERT_SUPPRESSION_FIELDS_COMBO_BOX).should('not.be.disabled');
   cy.get(ALERT_SUPPRESSION_FIELDS_COMBO_BOX).click();
   fields.forEach((field) => {
-    cy.get(ALERT_SUPPRESSION_FIELDS_COMBO_BOX).type(`${field}{downArrow}{enter}{esc}`);
+    cy.get(ALERT_SUPPRESSION_FIELDS_COMBO_BOX).type(field);
+    // Using a click instead of keyboard navigation to avoid potential focus loss when page is still loading
+    cy.contains(COMBO_BOX_OPTION, field).click();
+    // Wait for the field to be selected as a pill before closing the dropdown,
+    // otherwise {esc} can race with {enter} and cancel the selection
+    cy.get(ALERT_SUPPRESSION_FIELDS_COMBO_BOX)
+      .find('[data-test-subj="euiComboBoxPill"]')
+      .should('contain.text', field);
   });
+  cy.get(ALERT_SUPPRESSION_FIELDS_COMBO_BOX).type('{esc}');
 };
 
 export const clearAlertSuppressionFields = () => {

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/create_new_rule.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/create_new_rule.ts
@@ -946,7 +946,10 @@ export const fillAlertSuppressionFields = (fields: string[]) => {
       .find('[data-test-subj="euiComboBoxPill"]')
       .should('contain.text', field);
   });
-  cy.get(ALERT_SUPPRESSION_FIELDS_COMBO_BOX).type('{esc}');
+  // Intentionally NOT typing {esc} to close the dropdown: on the rule edit form,
+  // {esc} can race with the just-clicked option's onChange and remove the new pill
+  // from form state before the next interaction commits the value. The dropdown
+  // closes naturally when the next action (e.g. the save button click) shifts focus.
 };
 
 export const clearAlertSuppressionFields = () => {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Security Solution] Fix flaky bulk edit alert suppression Cypress tests on MKI (#265262)](https://github.com/elastic/kibana/pull/265262)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Nikita Indik","email":"nikita.indik@elastic.co"},"sourceCommit":{"committedDate":"2026-04-24T18:57:05Z","message":"[Security Solution] Fix flaky bulk edit alert suppression Cypress tests on MKI (#265262)\n\n## Summary\n\nThis PR fixes flaky Cypress test that's failing in MKI periodic pipeline. The test is testing a bulk action to add alert suppression to rules. Test fails because it tries to use to select a dropdown item, while the request that fetches the data for the dropdown is still in flight.\n\n<img width=\"1920\" height=\"1113\" alt=\"Bulk Edit - Alert Suppression -- Rules without suppression -- Set alert suppression (failed)\" src=\"https://github.com/user-attachments/assets/4955c446-a5d8-4fbc-bde4-209f78da1eae\" />\n\nThe main fix is to disable the dropdown while loading is in progress. An additional fix is to use a click to select a dropdown item instead of doing it via keyboard. Keyboard focus can potentially switch to something else during page load.\n\n🟢 [Ran a bunch of times](https://buildkite.com/elastic/kibana-serverless-security-solution-quality-gate-rule-management/builds?branch=refs%2Fpull%2F265262) through the MKI pipeline (where it used to fail)\n🟢 [Ran](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/11874) through a normal Flaky Test Runner too.\n🟢 Normal CI pipeline also lookin' nice and green.","sha":"3b58004490dd91cfb51c22c062dca0e313a5dcc6","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["test","release_note:skip","Team:Detections and Resp","Team: SecuritySolution","Team:Detection Rule Management","backport:version","v9.4.0","v9.5.0","v9.3.4","v9.2.9","v8.19.15"],"title":"[Security Solution] Fix flaky bulk edit alert suppression Cypress tests on MKI","number":265262,"url":"https://github.com/elastic/kibana/pull/265262","mergeCommit":{"message":"[Security Solution] Fix flaky bulk edit alert suppression Cypress tests on MKI (#265262)\n\n## Summary\n\nThis PR fixes flaky Cypress test that's failing in MKI periodic pipeline. The test is testing a bulk action to add alert suppression to rules. Test fails because it tries to use to select a dropdown item, while the request that fetches the data for the dropdown is still in flight.\n\n<img width=\"1920\" height=\"1113\" alt=\"Bulk Edit - Alert Suppression -- Rules without suppression -- Set alert suppression (failed)\" src=\"https://github.com/user-attachments/assets/4955c446-a5d8-4fbc-bde4-209f78da1eae\" />\n\nThe main fix is to disable the dropdown while loading is in progress. An additional fix is to use a click to select a dropdown item instead of doing it via keyboard. Keyboard focus can potentially switch to something else during page load.\n\n🟢 [Ran a bunch of times](https://buildkite.com/elastic/kibana-serverless-security-solution-quality-gate-rule-management/builds?branch=refs%2Fpull%2F265262) through the MKI pipeline (where it used to fail)\n🟢 [Ran](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/11874) through a normal Flaky Test Runner too.\n🟢 Normal CI pipeline also lookin' nice and green.","sha":"3b58004490dd91cfb51c22c062dca0e313a5dcc6"}},"sourceBranch":"main","suggestedTargetBranches":["9.2","8.19"],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/265614","number":265614,"state":"MERGED","mergeCommit":{"sha":"59aafc7dda4f752243b14738a73c66f9485feb0e","message":"[9.4] [Security Solution] Fix flaky bulk edit alert suppression Cypress tests on MKI (#265262) (#265614)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.4`:\n- [[Security Solution] Fix flaky bulk edit alert suppression Cypress\ntests on MKI (#265262)](https://github.com/elastic/kibana/pull/265262)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Nikita Indik <nikita.indik@elastic.co>"}},{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/265262","number":265262,"mergeCommit":{"message":"[Security Solution] Fix flaky bulk edit alert suppression Cypress tests on MKI (#265262)\n\n## Summary\n\nThis PR fixes flaky Cypress test that's failing in MKI periodic pipeline. The test is testing a bulk action to add alert suppression to rules. Test fails because it tries to use to select a dropdown item, while the request that fetches the data for the dropdown is still in flight.\n\n<img width=\"1920\" height=\"1113\" alt=\"Bulk Edit - Alert Suppression -- Rules without suppression -- Set alert suppression (failed)\" src=\"https://github.com/user-attachments/assets/4955c446-a5d8-4fbc-bde4-209f78da1eae\" />\n\nThe main fix is to disable the dropdown while loading is in progress. An additional fix is to use a click to select a dropdown item instead of doing it via keyboard. Keyboard focus can potentially switch to something else during page load.\n\n🟢 [Ran a bunch of times](https://buildkite.com/elastic/kibana-serverless-security-solution-quality-gate-rule-management/builds?branch=refs%2Fpull%2F265262) through the MKI pipeline (where it used to fail)\n🟢 [Ran](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/11874) through a normal Flaky Test Runner too.\n🟢 Normal CI pipeline also lookin' nice and green.","sha":"3b58004490dd91cfb51c22c062dca0e313a5dcc6"}},{"branch":"9.3","label":"v9.3.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/265613","number":265613,"state":"MERGED","mergeCommit":{"sha":"b0ac00c637c5c4773c6f00516bcc400cf40e3e9b","message":"[9.3] [Security Solution] Fix flaky bulk edit alert suppression Cypress tests on MKI (#265262) (#265613)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.3`:\n- [[Security Solution] Fix flaky bulk edit alert suppression Cypress\ntests on MKI (#265262)](https://github.com/elastic/kibana/pull/265262)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Nikita Indik <nikita.indik@elastic.co>"}},{"branch":"9.2","label":"v9.2.9","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.15","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->