### PR TITLE
[Security Solution] Fix flaky ES|QL rule edit Cypress tests

### DIFF
--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/rule_edit/esql_rule.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/rule_edit/esql_rule.cy.ts
@@ -55,8 +55,7 @@ const rule = getEsqlRule();
 const expectedValidEsqlQuery =
   'from auditbeat* | stats _count=count(event.category) by event.category';
 
-// FLAKY: https://github.com/elastic/kibana/issues/244043
-describe.skip(
+describe(
   'Detection ES|QL rules, edit',
   {
     tags: ['@ess', '@serverless', '@skipInServerlessMKI'],

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/create_new_rule.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/create_new_rule.ts
@@ -448,8 +448,12 @@ export const fillAboutRuleWithOverrideAndContinue = (rule: RuleCreateProps) => {
 
 export const fillOverrideEsqlRuleName = (value: string) => {
   cy.get(RULE_NAME_OVERRIDE_FOR_ESQL).within(() => {
-    cy.get(COMBO_BOX_INPUT).type(`${value}{enter}`);
+    cy.get(COMBO_BOX_INPUT).should('not.be.disabled');
+    cy.get(COMBO_BOX_INPUT).click();
+    cy.get(COMBO_BOX_INPUT).type(value);
   });
+
+  cy.contains(COMBO_BOX_OPTION, value).click();
 };
 
 // called after import rule from saved timeline
@@ -966,13 +970,14 @@ export const fillAlertSuppressionFields = (fields: string[], checkFieldsInComboB
     cy.get(ALERT_SUPPRESSION_FIELDS_COMBO_BOX).type(field);
     // Using a click instead of keyboard navigation to avoid potential focus loss when page is still loading
     cy.contains(COMBO_BOX_OPTION, field).click();
-    // Wait for the field to be selected as a pill before closing the dropdown,
-    // otherwise {esc} can race with {enter} and cancel the selection
     cy.get(ALERT_SUPPRESSION_FIELDS_COMBO_BOX)
       .find('[data-test-subj="euiComboBoxPill"]')
       .should('contain.text', field);
   });
-  cy.get(ALERT_SUPPRESSION_FIELDS_COMBO_BOX).type('{esc}');
+  // Intentionally NOT typing {esc} to close the dropdown: on the rule edit form,
+  // {esc} can race with the just-clicked option's onChange and remove the new pill
+  // from form state before the next interaction commits the value. The dropdown
+  // closes naturally when the next action (e.g. the save button click) shifts focus.
 };
 
 export const clearAlertSuppressionFields = () => {


### PR DESCRIPTION
Closes #244043

## Summary

Fixes the flaky `Detection ES|QL rules, edit` Cypress suite that was `describe.skip`ed in issue #244043.

### Root cause

`fillAlertSuppressionFields` helper ended with `cy.get(...).type('{esc}')` to close the combo-box dropdown. On the rule edit form, where the combo-box already has a pre-existing pill, `{esc}` raced with the just-clicked option's `onChange` and removed the **new** pill from the form state — so on save, only the pre-existing field was persisted.

### Validation

🟢 Flaky test runner: 100 ESS + 100 Serverless runs, all green: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/11924