### PR TITLE
[9.4] [Discover] [Embeddable] Handle ES|QL controls for by-value Discover panels (#264240)

### DIFF
--- a/src/platform/packages/shared/kbn-esql-utils/index.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/index.ts
@@ -72,6 +72,7 @@ export {
   isComputedColumn,
   getQuerySummary,
   getEsqlControls,
+  getAllEsqlControls,
   type ESQLStatsQueryMeta,
 } from './src';
 

--- a/src/platform/packages/shared/kbn-esql-utils/moon.yml
+++ b/src/platform/packages/shared/kbn-esql-utils/moon.yml
@@ -34,7 +34,6 @@ dependsOn:
   - '@kbn/index-management-shared-types'
   - '@kbn/licensing-types'
   - '@kbn/controls-constants'
-  - '@kbn/utility-types'
   - '@kbn/presentation-publishing'
   - '@kbn/controls-schemas'
 tags:

--- a/src/platform/packages/shared/kbn-esql-utils/src/index.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/index.ts
@@ -74,7 +74,7 @@ export {
 } from './utils/cascaded_documents_helpers/utils';
 export { getProjectRoutingFromEsqlQuery } from './utils/set_instructions_helpers';
 export { isComputedColumn, getQuerySummary } from './utils/get_query_summary';
-export { getEsqlControls } from './utils/get_esql_controls';
+export { getAllEsqlControls, getEsqlControls } from './utils/get_esql_controls';
 
 // Callback functions
 export * from './utils/callbacks';

--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/get_esql_controls.test.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/get_esql_controls.test.ts
@@ -12,7 +12,7 @@ import { ESQL_CONTROL } from '@kbn/controls-constants';
 import { EsqlControlType, ESQLVariableType } from '@kbn/esql-types';
 import type { PresentationContainer } from '@kbn/presentation-publishing';
 import { getMockPresentationContainer } from '@kbn/presentation-publishing/interfaces/containers/mocks';
-import { getEsqlControls } from './get_esql_controls';
+import { getAllEsqlControls, getEsqlControls } from './get_esql_controls';
 import type { OptionsListESQLControlState } from '@kbn/controls-schemas';
 
 const createPresentationContainer = (children: unknown[]) =>
@@ -44,6 +44,34 @@ const createControlApi = (
   applySerializedState: () => undefined,
 });
 
+describe('getAllEsqlControls', () => {
+  it('returns all valid ES|QL controls', () => {
+    const matchingState = createControlState('status');
+    const otherState = createControlState('host');
+    const noVariableState = createControlState('');
+    const presentationContainer = createPresentationContainer([
+      createControlApi('matching-control', matchingState),
+      createControlApi('other-control', otherState),
+      createControlApi('empty-variable-control', noVariableState),
+      createControlApi('wrong-type-control', matchingState, 'RANGE_SLIDER_CONTROL'),
+      { uuid: 'no-serialize', type: ESQL_CONTROL },
+      { type: ESQL_CONTROL, serializeState: () => matchingState },
+      null,
+    ]);
+
+    expect(getAllEsqlControls(presentationContainer)).toStrictEqual({
+      'matching-control': {
+        type: ESQL_CONTROL,
+        ...matchingState,
+      },
+      'other-control': {
+        type: ESQL_CONTROL,
+        ...otherState,
+      },
+    });
+  });
+});
+
 describe('getEsqlControls', () => {
   it('returns undefined when query is not an ES|QL query', () => {
     const presentationContainer = createPresentationContainer([]);
@@ -56,7 +84,7 @@ describe('getEsqlControls', () => {
     expect(getEsqlControls(presentationContainer, kqlQuery)).toBeUndefined();
   });
 
-  it('returns only matching ES|QL controls with valid APIs', () => {
+  it('returns only matching ES|QL controls used by the query', () => {
     const matchingState = createControlState('status');
     const nonMatchingState = createControlState('host');
     const noVariableState = createControlState('');

--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/get_esql_controls.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/get_esql_controls.ts
@@ -7,7 +7,6 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { Serializable } from '@kbn/utility-types';
 import type { AggregateQuery, Query } from '@kbn/es-query';
 import { isOfAggregateQueryType } from '@kbn/es-query';
 import type { OptionsListESQLControlState } from '@kbn/controls-schemas';
@@ -20,6 +19,44 @@ import {
 import { ESQL_CONTROL } from '@kbn/controls-constants';
 import { getESQLQueryVariables } from './query_parsing_helpers';
 
+type EsqlControlState = OptionsListESQLControlState & {
+  type: typeof ESQL_CONTROL;
+};
+
+interface EsqlControlsState {
+  [uuid: string]: EsqlControlState;
+}
+
+export function getAllEsqlControls(
+  presentationContainer: PresentationContainer
+): EsqlControlsState {
+  const esqlControlsState: EsqlControlsState = {};
+
+  for (const api of Object.values(presentationContainer.children$.getValue())) {
+    if (
+      !(
+        apiHasType(api) &&
+        api.type === ESQL_CONTROL &&
+        apiHasUniqueId(api) &&
+        apiHasSerializableState(api)
+      )
+    ) {
+      continue;
+    }
+
+    const controlState = api.serializeState() as OptionsListESQLControlState;
+    const variableName = controlState.variable_name;
+    if (!variableName) continue;
+
+    esqlControlsState[api.uuid] = {
+      ...controlState,
+      type: ESQL_CONTROL,
+    };
+  }
+
+  return esqlControlsState;
+}
+
 export function getEsqlControls(
   presentationContainer: PresentationContainer,
   query: AggregateQuery | Query | undefined
@@ -28,35 +65,9 @@ export function getEsqlControls(
 
   const usedVariables = getESQLQueryVariables(query.esql);
 
-  const esqlControlState = Object.values(presentationContainer.children$.getValue()).reduce(
-    (acc: { [uuid: string]: Serializable }, api, index) => {
-      if (
-        !(
-          apiHasType(api) &&
-          api.type === ESQL_CONTROL &&
-          apiHasUniqueId(api) &&
-          apiHasSerializableState(api)
-        )
-      ) {
-        return acc;
-      }
-
-      const controlState = api.serializeState() as OptionsListESQLControlState;
-      const variableName = controlState.variable_name;
-      if (!variableName) return acc;
-      const isUsed = usedVariables.includes(variableName);
-      if (!isUsed) return acc;
-
-      return {
-        ...acc,
-        [api.uuid]: {
-          type: api.type,
-          ...controlState,
-        },
-      };
-    },
-    {}
+  return Object.fromEntries(
+    Object.entries(getAllEsqlControls(presentationContainer)).filter(([, control]) =>
+      usedVariables.includes(control.variable_name)
+    )
   );
-
-  return esqlControlState;
 }

--- a/src/platform/packages/shared/kbn-esql-utils/tsconfig.json
+++ b/src/platform/packages/shared/kbn-esql-utils/tsconfig.json
@@ -33,7 +33,6 @@
     "@kbn/index-management-shared-types",
     "@kbn/licensing-types",
     "@kbn/controls-constants",
-    "@kbn/utility-types",
     "@kbn/presentation-publishing",
     "@kbn/controls-schemas",
   ]

--- a/src/platform/plugins/shared/discover/public/__mocks__/services.ts
+++ b/src/platform/plugins/shared/discover/public/__mocks__/services.ts
@@ -319,7 +319,7 @@ export function createDiscoverServicesMock(): DiscoverServices {
       isEmbeddedEditor: jest.fn(() => false),
       canSaveToDashboard: jest.fn(() => false),
       transferBackToEditor: jest.fn(),
-      getByValueInput: jest.fn(),
+      getByValueTab: jest.fn(),
       clearEditorState: jest.fn(),
     },
     alertingVTwo: {

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/save_discover_table_button.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/save_discover_table_button.tsx
@@ -17,6 +17,7 @@ import {
 import type { OnSaveProps } from '@kbn/saved-objects-plugin/public';
 import {
   selectTabSavedSearch,
+  useCurrentTabSelector,
   useInternalStateGetState,
   useRuntimeStateManager,
 } from '../../state_management/redux';
@@ -35,6 +36,7 @@ const BUTTON_LABEL = i18n.translate('discover.saveDiscoverTable.buttonLabel', {
 
 export function SaveDiscoverTableButton() {
   const [showSaveModal, setShowSaveModal] = useState(false);
+  const controlGroupState = useCurrentTabSelector((tab) => tab.attributes.controlGroupState);
   const getState = useInternalStateGetState();
   const services = useDiscoverServices();
   const runtimeStateManager = useRuntimeStateManager();
@@ -58,12 +60,15 @@ export function SaveDiscoverTableButton() {
       const attributes = toSavedSearchAttributes(savedSearch, searchSourceJSON);
 
       services.embeddableEditor.transferBackToEditor(TransferAction.SaveByValue, {
-        state: { ...attributes, title: newTitle, description: newDescription, references },
+        state: {
+          byValueState: { ...attributes, title: newTitle, description: newDescription, references },
+          controlGroupState,
+        },
         app: 'dashboards',
         path: dashboardId && dashboardId !== 'new' ? `#/view/${dashboardId}` : '#/create',
       });
     },
-    [getState, services, runtimeStateManager]
+    [getState, runtimeStateManager, services, controlGroupState]
   );
 
   return (

--- a/src/platform/plugins/shared/discover/public/application/main/components/top_nav/save_discover_session/on_save_discover_session.test.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/top_nav/save_discover_session/on_save_discover_session.test.tsx
@@ -180,7 +180,7 @@ describe('onSaveDiscoverSession', () => {
         dataView: dataViewMock,
         services,
       });
-      jest.spyOn(services.embeddableEditor, 'getByValueInput').mockReturnValue(byValueTab);
+      jest.spyOn(services.embeddableEditor, 'getByValueTab').mockReturnValue(byValueTab);
       jest.spyOn(services.embeddableEditor, 'isEmbeddedEditor').mockReturnValue(true);
 
       const onSaveCb = jest.fn();

--- a/src/platform/plugins/shared/discover/public/application/main/components/top_nav/use_top_nav_links.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/top_nav/use_top_nav_links.tsx
@@ -297,11 +297,16 @@ export const useTopNavLinks = ({
             runtimeStateManager,
             onSaveCb: isEmbeddedEditor
               ? (saveState) => {
-                  const action = saveState
-                    ? TransferAction.SaveSession
-                    : TransferAction.SaveByValue;
-
-                  services.embeddableEditor.transferBackToEditor(action, { state: saveState });
+                  if (saveState) {
+                    services.embeddableEditor.transferBackToEditor(TransferAction.SaveByValue, {
+                      state: {
+                        byValueState: saveState,
+                        controlGroupState: currentTab.attributes.controlGroupState,
+                      },
+                    });
+                  } else {
+                    services.embeddableEditor.transferBackToEditor(TransferAction.SaveSession);
+                  }
                 }
               : undefined,
           });
@@ -389,6 +394,7 @@ export const useTopNavLinks = ({
     hasUnsavedChanges,
     transitionFromDataViewToESQL,
     persistedDiscoverSession,
+    currentTab.attributes.controlGroupState,
   ]);
 
   return useMemo((): AppMenuConfig => {

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/actions/tabs.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/actions/tabs.ts
@@ -364,7 +364,7 @@ export const initializeTabs = createInternalStateAsyncThunk(
       setBreadcrumbs({ services, titleBreadcrumbText: persistedDiscoverSession.title });
     }
 
-    const byValueEmbeddableTab = services.embeddableEditor.getByValueInput();
+    const byValueEmbeddableTab = services.embeddableEditor.getByValueTab();
     const byValueEmbeddableTabState = byValueEmbeddableTab
       ? fromSavedObjectTabToTabState({ tab: byValueEmbeddableTab })
       : undefined;

--- a/src/platform/plugins/shared/discover/public/embeddable/actions/add_discover_session_panel_action.test.ts
+++ b/src/platform/plugins/shared/discover/public/embeddable/actions/add_discover_session_panel_action.test.ts
@@ -1,0 +1,141 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { coreMock } from '@kbn/core/public/mocks';
+import { ESQL_CONTROL } from '@kbn/controls-constants';
+import { getMockPresentationContainer } from '@kbn/presentation-publishing/interfaces/containers/mocks';
+import type { EmbeddableApiContext } from '@kbn/presentation-publishing';
+import type { ActionExecutionContext, Trigger } from '@kbn/ui-actions-plugin/public';
+import { embeddablePluginMock } from '@kbn/embeddable-plugin/public/mocks';
+import type { OptionsListESQLControlState } from '@kbn/controls-schemas';
+import { BehaviorSubject } from 'rxjs';
+import { AddDiscoverSessionPanelAction } from './add_discover_session_panel_action';
+import { mockControlState } from '../../__mocks__/esql_controls';
+
+jest.mock('uuid', () => ({
+  v4: jest.fn(() => 'generated-uuid'),
+}));
+
+const createEsqlControlApi = (uuid: string, state: OptionsListESQLControlState) => ({
+  uuid,
+  type: ESQL_CONTROL,
+  serializeState: () => state,
+  applySerializedState: () => undefined,
+});
+
+const createDiscoverSessionTabState = () => ({
+  id: 'generated-uuid',
+  label: 'New Discover session',
+  sort: [],
+  columns: [],
+  isTextBasedQuery: true,
+  grid: {},
+  hideChart: false,
+  hideTable: false,
+  serializedSearchSource: {},
+});
+
+describe('AddDiscoverSessionPanelAction', () => {
+  const trigger: Trigger = { id: 'TEST_TRIGGER' };
+  const application = coreMock.createStart().application;
+  const locator = {
+    getLocation: jest.fn().mockResolvedValue({ app: 'discover', path: '/new-discover-session' }),
+  };
+  const navigateToEditor = jest.fn();
+  const embeddable = {
+    ...embeddablePluginMock.createStartContract(),
+    getStateTransfer: jest.fn().mockReturnValue({
+      navigateToEditor,
+    }),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    locator.getLocation.mockResolvedValue({ app: 'discover', path: '/new-discover-session' });
+    embeddable.getStateTransfer.mockReturnValue({ navigateToEditor });
+  });
+
+  const createAction = ({ embeddableApi }: { embeddableApi: unknown }) => {
+    const action = new AddDiscoverSessionPanelAction(application, locator as never, embeddable);
+    const actionContext: ActionExecutionContext<EmbeddableApiContext> = {
+      embeddable: embeddableApi as EmbeddableApiContext,
+      trigger,
+    };
+
+    return {
+      action,
+      actionContext,
+    };
+  };
+
+  it('passes dashboard ESQL controls when the embeddable is a presentation container', async () => {
+    const { type: _type, ...dashboardControlState } = mockControlState.panel1;
+    const serializedDashboardControlState: OptionsListESQLControlState = {
+      ...dashboardControlState,
+      variable_name: 'host.name',
+      title: 'Host name',
+    };
+    const dashboardControlGroupState = {
+      dashboardControl: {
+        ...serializedDashboardControlState,
+        type: ESQL_CONTROL,
+      },
+    };
+    const embeddableApi = {
+      ...getMockPresentationContainer(),
+      children$: new BehaviorSubject<Record<string, unknown>>({}),
+      getAppContext: jest.fn().mockReturnValue({
+        currentAppId: 'dashboard',
+        getCurrentPath: jest.fn().mockReturnValue('/dashboard/edit'),
+      }),
+    };
+    embeddableApi.children$.next({
+      dashboardControl: createEsqlControlApi('dashboardControl', serializedDashboardControlState),
+    });
+    const { action, actionContext } = createAction({ embeddableApi });
+
+    await action.execute(actionContext);
+
+    expect(navigateToEditor).toHaveBeenCalledWith('discover', {
+      path: '/new-discover-session',
+      state: {
+        valueInput: {
+          discoverSessionTab: createDiscoverSessionTabState(),
+          dashboardControlGroupState,
+        },
+        originatingApp: 'dashboard',
+        originatingPath: '/dashboard/edit',
+      },
+    });
+  });
+
+  it('leaves dashboardControlGroupState undefined when the embeddable is not a presentation container', async () => {
+    const embeddableApi = {
+      getAppContext: jest.fn().mockReturnValue({
+        currentAppId: 'dashboard',
+        getCurrentPath: jest.fn().mockReturnValue('/dashboard/edit'),
+      }),
+    };
+    const { action, actionContext } = createAction({ embeddableApi });
+
+    await action.execute(actionContext);
+
+    expect(navigateToEditor).toHaveBeenCalledWith('discover', {
+      path: '/new-discover-session',
+      state: {
+        valueInput: {
+          discoverSessionTab: createDiscoverSessionTabState(),
+          dashboardControlGroupState: undefined,
+        },
+        originatingApp: 'dashboard',
+        originatingPath: '/dashboard/edit',
+      },
+    });
+  });
+});

--- a/src/platform/plugins/shared/discover/public/embeddable/actions/add_discover_session_panel_action.ts
+++ b/src/platform/plugins/shared/discover/public/embeddable/actions/add_discover_session_panel_action.ts
@@ -14,14 +14,19 @@ import {
   apiCanAccessViewMode,
   apiHasAppContext,
   apiIsOfType,
+  apiIsPresentationContainer,
   getInheritedViewMode,
 } from '@kbn/presentation-publishing';
 
 import type { Action, ActionExecutionContext } from '@kbn/ui-actions-plugin/public';
 import { ADD_PANEL_VISUALIZATION_GROUP, type EmbeddableStart } from '@kbn/embeddable-plugin/public';
 import type { DiscoverSessionTab } from '@kbn/saved-search-plugin/common';
+import { getAllEsqlControls } from '@kbn/esql-utils';
+import type { ControlPanelsState } from '@kbn/control-group-renderer';
+import type { OptionsListESQLControlState } from '@kbn/controls-schemas';
 import type { DiscoverAppLocator } from '../../../common';
 import { ACTION_ADD_DISCOVER_SESSION_PANEL } from '../constants';
+import type { DiscoverSessionByValueInput } from '../../plugin_imports/embeddable_editor_service';
 
 export class AddDiscoverSessionPanelAction implements Action<EmbeddableApiContext> {
   public id = ACTION_ADD_DISCOVER_SESSION_PANEL;
@@ -51,7 +56,7 @@ export class AddDiscoverSessionPanelAction implements Action<EmbeddableApiContex
     const { app, path } = await this.locator.getLocation({});
     const stateTransfer = this.embeddable.getStateTransfer();
 
-    const valueInput: DiscoverSessionTab = {
+    const discoverSessionTab: DiscoverSessionTab = {
       id: uuidv4(),
       label: i18n.translate('discover.savedSearchEmbeddable.action.addPanel.byValueTabName', {
         defaultMessage: 'New Discover session',
@@ -63,6 +68,12 @@ export class AddDiscoverSessionPanelAction implements Action<EmbeddableApiContex
       hideChart: false,
       hideTable: false,
       serializedSearchSource: {},
+    };
+    const valueInput: DiscoverSessionByValueInput = {
+      discoverSessionTab,
+      dashboardControlGroupState: apiIsPresentationContainer(embeddableApi)
+        ? (getAllEsqlControls(embeddableApi) as ControlPanelsState<OptionsListESQLControlState>)
+        : undefined,
     };
 
     const appContext = apiHasAppContext(embeddableApi) ? embeddableApi.getAppContext() : undefined;

--- a/src/platform/plugins/shared/discover/public/embeddable/initialize_edit_api.test.ts
+++ b/src/platform/plugins/shared/discover/public/embeddable/initialize_edit_api.test.ts
@@ -9,14 +9,28 @@
 
 import { createSearchSourceMock } from '@kbn/data-plugin/public/mocks';
 import type { DataView } from '@kbn/data-views-plugin/common';
+import { ESQL_CONTROL } from '@kbn/controls-constants';
 import { dataViewMock } from '@kbn/discover-utils/src/__mocks__';
+import { getMockPresentationContainer } from '@kbn/presentation-publishing/interfaces/containers/mocks';
 import { VIEW_MODE } from '@kbn/saved-search-plugin/common';
+import type { OptionsListESQLControlState } from '@kbn/controls-schemas';
+import { BehaviorSubject } from 'rxjs';
 
 import { dataViewAdHoc } from '../__mocks__/data_view_complex';
+import { mockControlState } from '../__mocks__/esql_controls';
 import { discoverServiceMock } from '../__mocks__/services';
 import { getAppTarget, initializeEditApi } from './initialize_edit_api';
 import { getDiscoverLocatorParams } from './utils/get_discover_locator_params';
 import { getMockedSearchApi } from './__mocks__/get_mocked_api';
+import { fromSavedSearchToSavedObjectTab } from '../application/main/state_management/redux';
+import * as getDiscoverLocatorParamsModule from './utils/get_discover_locator_params';
+
+const createEsqlControlApi = (uuid: string, state: OptionsListESQLControlState) => ({
+  uuid,
+  type: ESQL_CONTROL,
+  serializeState: () => state,
+  applySerializedState: () => undefined,
+});
 
 describe('initialize edit api', () => {
   const searchSource = createSearchSourceMock({ index: dataViewMock });
@@ -153,6 +167,8 @@ describe('initialize edit api', () => {
 
   describe('on edit', () => {
     const mockedParentApi = {
+      ...getMockPresentationContainer(),
+      children$: new BehaviorSubject<Record<string, unknown>>({}),
       getAppContext: jest.fn().mockReturnValue({
         getCurrentPath: jest.fn().mockReturnValue('/current-parent-path'),
         currentAppId: 'dashboard',
@@ -177,6 +193,8 @@ describe('initialize edit api', () => {
         path: '/mock-url-for-onedit',
         state: {},
       });
+
+      mockedParentApi.children$.next({});
     });
 
     it('should call navigateToEditor', async () => {
@@ -194,11 +212,13 @@ describe('initialize edit api', () => {
       expect(mockedNavigate).toHaveBeenCalledTimes(1);
       expect(mockedNavigate).toHaveBeenCalledWith('discover', {
         path: '/mock-url-for-onedit',
-        state: expect.objectContaining({
+        state: {
           embeddableId: 'test',
+          valueInput: undefined,
+          searchSessionId: undefined,
           originatingApp: 'dashboard',
           originatingPath: '/current-parent-path',
-        }),
+        },
       });
     });
 
@@ -214,12 +234,10 @@ describe('initialize edit api', () => {
 
       await editApi?.onEdit();
 
-      expect(discoverServiceMock.locator.getLocation).toHaveBeenCalledWith(
-        expect.objectContaining({
-          savedSearchId: 'test-id',
-          tab: { id: 'tab-1' },
-        })
-      );
+      expect(discoverServiceMock.locator.getLocation).toHaveBeenCalledWith({
+        savedSearchId: 'test-id',
+        tab: { id: 'tab-1' },
+      });
     });
 
     it('should not pass a tab param when getSelectedTabId returns undefined', async () => {
@@ -253,6 +271,77 @@ describe('initialize edit api', () => {
       await editApi?.onEdit();
 
       expect(discoverServiceMock.locator.getLocation).toHaveBeenCalledWith({});
+    });
+
+    it('should pass controls to Discover for by-value embeddables', async () => {
+      mockedApi.savedObjectId$.next(undefined);
+      const { type: _type, ...controlState } = mockControlState.panel1;
+
+      const partialApi = {
+        ...mockedApi,
+        parentApi: mockedParentApi,
+        getSelectedTabId: () => 'tab-2',
+      };
+      const controlsState = {
+        panel1: {
+          ...controlState,
+          type: ESQL_CONTROL,
+          variable_name: 'host.name',
+          title: 'Host name',
+        },
+      };
+      const locatorParams = getDiscoverLocatorParams(partialApi);
+      const getDiscoverLocatorParamsSpy = jest
+        .spyOn(getDiscoverLocatorParamsModule, 'getDiscoverLocatorParams')
+        .mockReturnValue({
+          ...locatorParams,
+          esqlControls: controlsState,
+        });
+      mockedParentApi.children$.next({
+        panel1: createEsqlControlApi('panel1', {
+          ...controlState,
+          variable_name: 'host.name',
+          title: 'Host name',
+        }),
+      });
+      const editApi = initializeEditApi({
+        uuid: 'test',
+        parentApi: mockedParentApi,
+        partialApi,
+        isEditable: () => true,
+        discoverServices: discoverServiceMock,
+        getTitle: () => 'test-title',
+      });
+
+      await editApi?.onEdit();
+
+      const expectedValueInput = fromSavedSearchToSavedObjectTab({
+        tab: {
+          id: 'test',
+          label: 'test-title',
+        },
+        savedSearch: {
+          ...savedSearch,
+          controlGroupJson: JSON.stringify(controlsState),
+        },
+        services: discoverServiceMock,
+      });
+
+      expect(getDiscoverLocatorParamsSpy).toHaveBeenCalledWith(partialApi);
+      expect(discoverServiceMock.locator.getLocation).toHaveBeenCalledWith({});
+      expect(mockedNavigate).toHaveBeenCalledWith('discover', {
+        path: '/mock-url-for-onedit',
+        state: {
+          embeddableId: 'test',
+          valueInput: {
+            discoverSessionTab: expectedValueInput,
+            dashboardControlGroupState: controlsState,
+          },
+          searchSessionId: undefined,
+          originatingApp: 'dashboard',
+          originatingPath: '/current-parent-path',
+        },
+      });
     });
   });
 });

--- a/src/platform/plugins/shared/discover/public/embeddable/initialize_edit_api.ts
+++ b/src/platform/plugins/shared/discover/public/embeddable/initialize_edit_api.ts
@@ -15,11 +15,15 @@ import type {
   PublishesSavedObjectId,
   PublishingSubject,
 } from '@kbn/presentation-publishing';
-import { apiHasAppContext } from '@kbn/presentation-publishing';
+import { apiHasAppContext, apiIsPresentationContainer } from '@kbn/presentation-publishing';
+import { getAllEsqlControls } from '@kbn/esql-utils';
+import type { ControlPanelsState } from '@kbn/control-group-renderer';
+import type { OptionsListESQLControlState } from '@kbn/controls-schemas';
 import type { DiscoverServices } from '../build_services';
 import type { PublishesSavedSearch, PublishesSelectedTabId } from './types';
 import { getDiscoverLocatorParams } from './utils/get_discover_locator_params';
 import { fromSavedSearchToSavedObjectTab } from '../application/main/state_management/redux';
+import type { DiscoverSessionByValueInput } from '../plugin_imports/embeddable_editor_service';
 
 type SavedSearchPartialApi = PublishesSavedSearch &
   PublishesSavedObjectId &
@@ -88,27 +92,37 @@ export function initializeEditApi({
     onEdit: async () => {
       const stateTransfer = discoverServices.embeddable.getStateTransfer();
       const isByReference = Boolean(partialApi.savedObjectId$.getValue());
-      const valueInput = isByReference
+      const locatorParams = getDiscoverLocatorParams({ ...partialApi, parentApi });
+      const valueInput: DiscoverSessionByValueInput | undefined = isByReference
         ? undefined
-        : fromSavedSearchToSavedObjectTab({
-            tab: {
-              id: uuid,
-              label:
-                getTitle() ||
-                i18n.translate('discover.embeddable.byValueTabName', {
-                  defaultMessage: 'By-value Discover session',
-                }),
-            },
-            savedSearch: partialApi.savedSearch$.getValue(),
-            services: discoverServices,
-          });
+        : {
+            discoverSessionTab: fromSavedSearchToSavedObjectTab({
+              tab: {
+                id: uuid,
+                label:
+                  getTitle() ||
+                  i18n.translate('discover.embeddable.byValueTabName', {
+                    defaultMessage: 'By-value Discover session',
+                  }),
+              },
+              savedSearch: {
+                ...partialApi.savedSearch$.getValue(),
+                controlGroupJson: locatorParams.esqlControls
+                  ? JSON.stringify(locatorParams.esqlControls)
+                  : undefined,
+              },
+              services: discoverServices,
+            }),
+            dashboardControlGroupState: apiIsPresentationContainer(parentApi)
+              ? (getAllEsqlControls(parentApi) as ControlPanelsState<OptionsListESQLControlState>)
+              : undefined,
+          };
+
       let app: string;
       let path: string | undefined;
 
       if (isByReference) {
-        ({ app, path } = await discoverServices.locator.getLocation(
-          getDiscoverLocatorParams(partialApi)
-        ));
+        ({ app, path } = await discoverServices.locator.getLocation(locatorParams));
       } else {
         ({ app, path } = await discoverServices.locator.getLocation({}));
       }

--- a/src/platform/plugins/shared/discover/public/plugin_imports/embeddable_editor_service.test.ts
+++ b/src/platform/plugins/shared/discover/public/plugin_imports/embeddable_editor_service.test.ts
@@ -1,0 +1,308 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { SEARCH_EMBEDDABLE_TYPE } from '@kbn/discover-utils';
+import type { SavedSearchByValueAttributes } from '@kbn/saved-search-plugin/common';
+import { coreMock } from '@kbn/core/public/mocks';
+import { ESQL_CONTROL } from '@kbn/controls-constants';
+import type { OptionsListESQLControlState } from '@kbn/controls-schemas';
+import type { ControlPanelsState } from '@kbn/control-group-renderer';
+import type { EmbeddableEditorState, EmbeddableStateTransfer } from '@kbn/embeddable-plugin/public';
+import { embeddablePluginMock } from '@kbn/embeddable-plugin/public/mocks';
+import { EmbeddableEditorService, TransferAction } from './embeddable_editor_service';
+import { mockControlState } from '../__mocks__/esql_controls';
+
+describe('EmbeddableEditorService', () => {
+  const createApplication = ({
+    show = true,
+    createNew = true,
+  }: {
+    show?: boolean;
+    createNew?: boolean;
+  } = {}) => {
+    const application = coreMock.createStart().application;
+
+    return {
+      ...application,
+      capabilities: {
+        ...application.capabilities,
+        dashboard_v2: {
+          ...application.capabilities.dashboard_v2,
+          show,
+          createNew,
+        },
+      },
+    };
+  };
+
+  const createStateTransfer = (incomingState?: EmbeddableEditorState): EmbeddableStateTransfer => {
+    const embeddableStateTransfer = embeddablePluginMock.createStartContract().getStateTransfer();
+
+    jest.mocked(embeddableStateTransfer.getIncomingEditorState).mockReturnValue(incomingState);
+
+    return embeddableStateTransfer;
+  };
+
+  const createService = ({
+    incomingState,
+    application = createApplication(),
+  }: {
+    incomingState?: EmbeddableEditorState;
+    application?: ReturnType<typeof createApplication>;
+  } = {}) => {
+    const embeddableStateTransfer = createStateTransfer(incomingState);
+    const service = new EmbeddableEditorService(embeddableStateTransfer, application);
+
+    return { service, embeddableStateTransfer };
+  };
+
+  const createIncomingState = (
+    overrides: Partial<EmbeddableEditorState> = {}
+  ): EmbeddableEditorState => ({
+    originatingApp: 'dashboard',
+    ...overrides,
+  });
+
+  const createByValueState = (
+    overrides: Partial<SavedSearchByValueAttributes> = {}
+  ): SavedSearchByValueAttributes => ({
+    title: 'Saved search',
+    sort: [],
+    columns: [],
+    description: '',
+    grid: {},
+    hideChart: false,
+    hideTable: false,
+    isTextBasedQuery: false,
+    kibanaSavedObjectMeta: {
+      searchSourceJSON: '{}',
+    },
+    tabs: [],
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('allows saving to dashboard only when not embedded and dashboard capabilities are enabled', () => {
+    const standaloneService = createService().service;
+    const embeddedService = createService({
+      incomingState: createIncomingState({
+        originatingPath: '/app/dashboards',
+      }),
+    }).service;
+    const noShowCapabilityService = createService({
+      application: createApplication({ show: false }),
+    }).service;
+    const noCreateCapabilityService = createService({
+      application: createApplication({ createNew: false }),
+    }).service;
+
+    expect(standaloneService.canSaveToDashboard()).toBe(true);
+    expect(embeddedService.canSaveToDashboard()).toBe(false);
+    expect(noShowCapabilityService.canSaveToDashboard()).toBe(false);
+    expect(noCreateCapabilityService.canSaveToDashboard()).toBe(false);
+  });
+
+  it('exposes the incoming by-value editor state and clears it once', () => {
+    const byValueTab = { id: 'tab-1' };
+    const incomingState = createIncomingState({
+      originatingPath: '/app/dashboards',
+      embeddableId: 'panel-1',
+      valueInput: {
+        discoverSessionTab: byValueTab,
+        dashboardControlGroupState: undefined,
+      },
+    });
+    const { service, embeddableStateTransfer } = createService({ incomingState });
+
+    expect(service.isEmbeddedEditor()).toBe(true);
+    expect(service.isByValueEditor()).toBe(true);
+    expect(service.getByValueTab()).toBe(byValueTab);
+
+    service.clearEditorState();
+    service.clearEditorState();
+
+    expect(embeddableStateTransfer.clearEditorState).toHaveBeenCalledTimes(1);
+    expect(embeddableStateTransfer.clearEditorState).toHaveBeenCalledWith('discover');
+    expect(service.isEmbeddedEditor()).toBe(false);
+  });
+
+  it.each([TransferAction.Cancel, TransferAction.SaveSession] as const)(
+    'navigates back with no serialized state for action %s',
+    (action) => {
+      const incomingState = createIncomingState({
+        originatingPath: '/app/dashboards#/edit',
+        embeddableId: 'panel-1',
+      });
+      const { service, embeddableStateTransfer } = createService({ incomingState });
+
+      service.transferBackToEditor(action);
+
+      expect(embeddableStateTransfer.clearEditorState).toHaveBeenCalledWith('discover');
+      expect(embeddableStateTransfer.navigateToWithEmbeddablePackages).toHaveBeenCalledWith(
+        'dashboard',
+        {
+          path: '/app/dashboards#/edit',
+          state: [],
+        }
+      );
+    }
+  );
+
+  it('serializes by-value state and control packages when navigating back to the editor', () => {
+    const byValueState = createByValueState();
+    const controlGroupState: ControlPanelsState<OptionsListESQLControlState> = {
+      controlA: {
+        ...mockControlState.panel1,
+        variable_name: 'host.name',
+        title: 'Host name',
+      },
+      controlB: {
+        ...mockControlState.panel1,
+        variable_name: 'service.name',
+        title: 'Service name',
+        order: 1,
+      },
+    };
+    const incomingState = createIncomingState({
+      originatingPath: '/app/dashboards#/edit',
+      embeddableId: 'panel-42',
+    });
+    const { service, embeddableStateTransfer } = createService({ incomingState });
+
+    service.transferBackToEditor(TransferAction.SaveByValue, {
+      state: {
+        byValueState,
+        controlGroupState,
+      },
+    });
+
+    expect(embeddableStateTransfer.navigateToWithEmbeddablePackages).toHaveBeenCalledWith(
+      'dashboard',
+      {
+        path: '/app/dashboards#/edit',
+        state: [
+          {
+            type: ESQL_CONTROL,
+            serializedState: controlGroupState.controlA,
+            embeddableId: 'controlA',
+          },
+          {
+            type: ESQL_CONTROL,
+            serializedState: controlGroupState.controlB,
+            embeddableId: 'controlB',
+          },
+          {
+            type: SEARCH_EMBEDDABLE_TYPE,
+            serializedState: {
+              attributes: byValueState,
+            },
+            embeddableId: 'panel-42',
+          },
+        ],
+      }
+    );
+  });
+
+  it('reuses dashboard panel ids for SaveByValue controls with duplicate variables', () => {
+    const byValueState = createByValueState();
+    const controlGroupState: ControlPanelsState<OptionsListESQLControlState> = {
+      discoverControlA: {
+        ...mockControlState.panel1,
+        variable_name: 'host.name',
+        title: 'Updated host name',
+      },
+      discoverControlB: {
+        ...mockControlState.panel1,
+        variable_name: 'service.name',
+        title: 'Updated service name',
+      },
+      discoverControlC: {
+        ...mockControlState.panel1,
+        variable_name: 'cloud.region',
+        title: 'Cloud region',
+      },
+    };
+    const dashboardControlGroupState: ControlPanelsState<OptionsListESQLControlState> = {
+      dashboardHostPanel: {
+        ...mockControlState.panel1,
+        variable_name: 'host.name',
+        title: 'Original host name',
+      },
+      dashboardServicePanel: {
+        ...mockControlState.panel1,
+        variable_name: 'service.name',
+        title: 'Original service name',
+      },
+      dashboardOtherPanel: {
+        ...mockControlState.panel1,
+        variable_name: 'event.dataset',
+        title: 'Original event dataset',
+      },
+    };
+    const incomingState = createIncomingState({
+      originatingPath: '/app/dashboards#/edit',
+      embeddableId: 'panel-42',
+      valueInput: {
+        discoverSessionTab: { id: 'tab-1' },
+        dashboardControlGroupState,
+      },
+    });
+    const { service, embeddableStateTransfer } = createService({ incomingState });
+
+    service.transferBackToEditor(TransferAction.SaveByValue, {
+      state: {
+        byValueState,
+        controlGroupState,
+      },
+    });
+
+    expect(embeddableStateTransfer.navigateToWithEmbeddablePackages).toHaveBeenCalledWith(
+      'dashboard',
+      {
+        path: '/app/dashboards#/edit',
+        state: [
+          {
+            type: ESQL_CONTROL,
+            serializedState: controlGroupState.discoverControlA,
+            embeddableId: 'dashboardHostPanel',
+          },
+          {
+            type: ESQL_CONTROL,
+            serializedState: controlGroupState.discoverControlB,
+            embeddableId: 'dashboardServicePanel',
+          },
+          {
+            type: ESQL_CONTROL,
+            serializedState: controlGroupState.discoverControlC,
+            embeddableId: 'discoverControlC',
+          },
+          {
+            type: SEARCH_EMBEDDABLE_TYPE,
+            serializedState: {
+              attributes: byValueState,
+            },
+            embeddableId: 'panel-42',
+          },
+        ],
+      }
+    );
+  });
+
+  it('does not navigate when there is no editor origin and no explicit destination', () => {
+    const { service, embeddableStateTransfer } = createService();
+
+    service.transferBackToEditor(TransferAction.Cancel);
+
+    expect(embeddableStateTransfer.clearEditorState).not.toHaveBeenCalled();
+    expect(embeddableStateTransfer.navigateToWithEmbeddablePackages).not.toHaveBeenCalled();
+  });
+});

--- a/src/platform/plugins/shared/discover/public/plugin_imports/embeddable_editor_service.ts
+++ b/src/platform/plugins/shared/discover/public/plugin_imports/embeddable_editor_service.ts
@@ -13,6 +13,15 @@ import type {
 import { SEARCH_EMBEDDABLE_TYPE } from '@kbn/discover-utils';
 import type { EmbeddableEditorState, EmbeddableStateTransfer } from '@kbn/embeddable-plugin/public';
 import type { ApplicationStart } from '@kbn/core/public';
+import type { OptionsListESQLControlState } from '@kbn/controls-schemas';
+import type { ControlPanelState, ControlPanelsState } from '@kbn/control-group-renderer';
+import { ESQL_CONTROL } from '@kbn/controls-constants';
+import type { SearchEmbeddablePanelApiState } from '../embeddable';
+
+export interface DiscoverSessionByValueInput {
+  discoverSessionTab: DiscoverSessionTab | undefined;
+  dashboardControlGroupState: ControlPanelsState<OptionsListESQLControlState> | undefined;
+}
 
 /**
  * Specifies the action to be taken for navigating back to an editor.
@@ -32,10 +41,27 @@ export enum TransferAction {
   SaveByValue,
 }
 
-interface TransferOptions {
-  state?: SavedSearchByValueAttributes;
+interface TransferOptionsBase {
   path?: string;
   app?: string;
+}
+
+interface ByValueTransferOptions extends TransferOptionsBase {
+  state: {
+    byValueState: SavedSearchByValueAttributes;
+    controlGroupState: ControlPanelsState<OptionsListESQLControlState> | undefined;
+  };
+}
+
+type CombinedTransferOptions = ByValueTransferOptions | TransferOptionsBase;
+
+type DiscoverTransferSerializedState =
+  | ControlPanelState<OptionsListESQLControlState>
+  | SearchEmbeddablePanelApiState;
+
+interface GetSerializedStateResult {
+  serializedState: SearchEmbeddablePanelApiState | undefined;
+  controlGroupState: ControlPanelsState<OptionsListESQLControlState>;
 }
 
 export class EmbeddableEditorService {
@@ -57,8 +83,8 @@ export class EmbeddableEditorService {
 
   public isEmbeddedEditor = (): boolean => Boolean(this.embeddableState);
 
-  public getByValueInput = (): DiscoverSessionTab | undefined =>
-    this.embeddableState?.valueInput as DiscoverSessionTab | undefined;
+  public getByValueTab = (): DiscoverSessionTab | undefined =>
+    this.getByValueInput().discoverSessionTab;
 
   /**
    * Resets the embeddable transfer state, ensuring it is cleared in storage and then dropped in memory.
@@ -70,40 +96,101 @@ export class EmbeddableEditorService {
     }
   };
 
-  public transferBackToEditor(
-    action: TransferAction.Cancel | TransferAction.SaveSession,
-    options?: Omit<TransferOptions, 'state'>
-  ): void;
+  public transferBackToEditor(action: TransferAction.Cancel | TransferAction.SaveSession): void;
   public transferBackToEditor(
     action: TransferAction.SaveByValue,
-    options: Required<Pick<TransferOptions, 'state'>> & Omit<TransferOptions, 'state'>
+    options: ByValueTransferOptions
   ): void;
-  public transferBackToEditor(action: TransferAction, options?: TransferOptions): void;
   /**
    * Initiates a navigation back to the editing application, either cancelling the current action to return
    * or passing a state for an embeddable to receive an updated view.
    *
    * **NOTE**: Cancelling will never pass an updated state, so the state param is ignored for cancel actions.
    */
-  public transferBackToEditor(action: TransferAction, options?: TransferOptions) {
+  public transferBackToEditor(action: TransferAction, options?: CombinedTransferOptions) {
     const app = options?.app || this.embeddableState?.originatingApp;
     const path = options?.path || this.embeddableState?.originatingPath;
+    const { serializedState, controlGroupState } = this.getSerializedState(action, options);
+    const controlPackages = Object.entries(controlGroupState).map(
+      ([embeddableId, controlPanelState]) => ({
+        type: ESQL_CONTROL,
+        serializedState: controlPanelState,
+        embeddableId,
+      })
+    );
 
     if (app && path) {
       this.embeddableStateTransfer.clearEditorState('discover');
-      this.embeddableStateTransfer.navigateToWithEmbeddablePackages(app, {
-        path,
-        state:
-          action !== TransferAction.Cancel
+      this.embeddableStateTransfer.navigateToWithEmbeddablePackages<DiscoverTransferSerializedState>(
+        app,
+        {
+          path,
+          state: serializedState
             ? [
+                ...controlPackages,
                 {
                   type: SEARCH_EMBEDDABLE_TYPE,
-                  serializedState: { attributes: options?.state },
+                  serializedState,
                   embeddableId: this.embeddableState?.embeddableId,
                 },
               ]
             : [],
-      });
+        }
+      );
     }
   }
+
+  private getSerializedState(
+    action: TransferAction,
+    options?: CombinedTransferOptions
+  ): GetSerializedStateResult {
+    if (action === TransferAction.SaveByValue) {
+      const { state } = options as ByValueTransferOptions;
+      return {
+        serializedState: { attributes: state.byValueState },
+        controlGroupState: reconcileControlGroupState({
+          controlGroupState: state.controlGroupState ?? {},
+          dashboardControlGroupState: this.getByValueInput().dashboardControlGroupState,
+        }),
+      };
+    }
+
+    return { serializedState: undefined, controlGroupState: {} };
+  }
+
+  private getByValueInput(): DiscoverSessionByValueInput {
+    return this.embeddableState?.valueInput
+      ? (this.embeddableState.valueInput as DiscoverSessionByValueInput)
+      : { discoverSessionTab: undefined, dashboardControlGroupState: undefined };
+  }
 }
+
+const reconcileControlGroupState = ({
+  controlGroupState,
+  dashboardControlGroupState,
+}: {
+  controlGroupState: ControlPanelsState<OptionsListESQLControlState>;
+  dashboardControlGroupState: ControlPanelsState<OptionsListESQLControlState> | undefined;
+}): ControlPanelsState<OptionsListESQLControlState> => {
+  if (!dashboardControlGroupState) {
+    return controlGroupState;
+  }
+
+  const dashboardPanelIdsByVariable = Object.fromEntries(
+    Object.entries(dashboardControlGroupState).map(([dashboardPanelId, dashboardPanelState]) => [
+      dashboardPanelState.variable_name,
+      dashboardPanelId,
+    ])
+  );
+
+  return Object.entries(controlGroupState).reduce<ControlPanelsState<OptionsListESQLControlState>>(
+    (acc, [discoverPanelId, panelState]) => {
+      const nextPanelId = dashboardPanelIdsByVariable[panelState.variable_name] ?? discoverPanelId;
+
+      acc[nextPanelId] = panelState;
+
+      return acc;
+    },
+    {}
+  );
+};

--- a/src/platform/plugins/shared/discover/public/utils/breadcrumbs.test.ts
+++ b/src/platform/plugins/shared/discover/public/utils/breadcrumbs.test.ts
@@ -55,7 +55,7 @@ describe('Breadcrumbs', () => {
       beforeEach(() => {
         jest.spyOn(discoverServiceMock.embeddableEditor, 'isByValueEditor').mockReturnValue(true);
         jest
-          .spyOn(discoverServiceMock.embeddableEditor, 'getByValueInput')
+          .spyOn(discoverServiceMock.embeddableEditor, 'getByValueTab')
           .mockReturnValue({ label: 'Mock Label' } as DiscoverSessionTab);
       });
 
@@ -82,7 +82,7 @@ describe('Breadcrumbs', () => {
       beforeEach(() => {
         jest.spyOn(discoverServiceMock.embeddableEditor, 'isByValueEditor').mockReturnValue(false);
         jest
-          .spyOn(discoverServiceMock.embeddableEditor, 'getByValueInput')
+          .spyOn(discoverServiceMock.embeddableEditor, 'getByValueTab')
           .mockReturnValue(undefined);
       });
 

--- a/src/platform/plugins/shared/discover/public/utils/breadcrumbs.ts
+++ b/src/platform/plugins/shared/discover/public/utils/breadcrumbs.ts
@@ -61,7 +61,7 @@ export function setBreadcrumbs({
 }) {
   const embeddable = services.embeddableEditor;
   const isEmbeddedEditor = embeddable.isEmbeddedEditor();
-  const byValueTitle = embeddable.getByValueInput()?.label;
+  const byValueTitle = embeddable.getByValueTab()?.label;
 
   const breadcrumbTitle = byValueTitle || titleBreadcrumbText;
 

--- a/src/platform/test/functional/apps/discover/esql_4/_esql_controls.ts
+++ b/src/platform/test/functional/apps/discover/esql_4/_esql_controls.ts
@@ -18,11 +18,13 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const dashboardPanelActions = getService('dashboardPanelActions');
   const testSubjects = getService('testSubjects');
   const browser = getService('browser');
+  const esql = getService('esql');
 
-  const { dashboard, dashboardControls, discover } = getPageObjects([
+  const { dashboard, dashboardControls, discover, timePicker } = getPageObjects([
     'dashboard',
     'dashboardControls',
     'discover',
+    'timePicker',
   ]);
 
   describe('discover esql controls', () => {
@@ -31,6 +33,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         defaultIndex: 'logstash-*',
         enableESQL: true,
       });
+      await timePicker.setDefaultAbsoluteRangeViaUiSettings();
 
       await kibanaServer.savedObjects.cleanStandardList();
       await security.testUser.setRoles(['kibana_admin', 'test_logstash_reader']);
@@ -45,9 +48,13 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       );
     });
 
-    describe('when adding an ES|QL panel with controls in dashboards and exploring it in discover', () => {
+    after(async () => {
+      await timePicker.resetDefaultAbsoluteRangeViaUiSettings();
+    });
+
+    describe('when adding an ES|QL panel with controls in Dashboard and exploring it in Discover', () => {
       it('should retain the controls and their state', async () => {
-        // Navigate to a dasbhoard with an ESQL control
+        // Navigate to a dashboard with an ES|QL control
         await dashboard.navigateToApp();
         await dashboard.loadSavedDashboard('ES|QL controls fixture dashboard');
         await dashboard.waitForRenderComplete();
@@ -73,20 +80,20 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
     });
 
-    describe('when unlinking a ES|QL panel with controls and explorting it in discover', () => {
+    const addUnlinkedSavedSearch = async () => {
+      await dashboard.navigateToApp();
+      await dashboard.clickNewDashboard();
+
+      await dashboardAddPanel.addSavedSearch('ESQL control unlink test');
+      await dashboard.waitForRenderComplete();
+
+      await dashboardPanelActions.unlinkFromLibrary('ESQL control unlink test');
+      await dashboard.waitForRenderComplete();
+    };
+
+    describe('when viewing an unlinked by-value ES|QL panel in Discover', () => {
       it('should retain the controls and their state', async () => {
-        // Go to dashboards
-        await dashboard.navigateToApp();
-        await dashboard.clickNewDashboard();
-
-        // Add the saved search
-        await dashboardAddPanel.addSavedSearch('ESQL control unlink test');
-
-        // Unlink the saved search
-        await dashboardPanelActions.clickPanelActionByTitle(
-          'embeddablePanelAction-unlinkFromLibrary',
-          'ESQL control unlink test'
-        );
+        await addUnlinkedSavedSearch();
 
         // Save dashboard and go to view mode
         await dashboard.saveDashboard('ESQL control unlink test dashboard');
@@ -101,6 +108,173 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         // Verify that we are in discover and the control exists
         await discover.expectOnDiscover();
         expect(await dashboardControls.getControlsCount()).to.be(1);
+      });
+    });
+
+    describe('when editing an unlinked by-value ES|QL panel in Discover', () => {
+      it('should persist updated control selections after saving', async () => {
+        await addUnlinkedSavedSearch();
+
+        expect(await dashboardControls.getControlsCount()).to.be(1);
+
+        const initialDashboardControlId = (await dashboardControls.getAllControlIds())[0];
+        expect(
+          await dashboardControls.optionsListGetSelectionsString(initialDashboardControlId)
+        ).to.be('AE');
+
+        await dashboardPanelActions.editPanelByTitle('ESQL control unlink test');
+        await discover.expectOnDiscover();
+        await discover.waitUntilTabIsLoaded();
+
+        const discoverControlId = (await dashboardControls.getAllControlIds())[0];
+        expect(await dashboardControls.optionsListGetSelectionsString(discoverControlId)).to.be(
+          'AE'
+        );
+
+        await dashboardControls.optionsListOpenPopover(discoverControlId, true);
+        await dashboardControls.optionsListPopoverSelectOption('CN');
+        await dashboardControls.optionsListEnsurePopoverIsClosed(discoverControlId);
+        await discover.waitUntilTabIsLoaded();
+
+        expect(await dashboardControls.optionsListGetSelectionsString(discoverControlId)).to.be(
+          'CN'
+        );
+
+        await discover.clickSaveSearchButton();
+        await dashboard.waitForRenderComplete();
+
+        expect(await dashboardPanelActions.getPanelWrapper('ESQL control unlink test')).to.be.ok();
+        expect(await dashboardControls.getControlsCount()).to.be(1);
+
+        const updatedDashboardControlId = (await dashboardControls.getAllControlIds())[0];
+        expect(
+          await dashboardControls.optionsListGetSelectionsString(updatedDashboardControlId)
+        ).to.be('CN');
+      });
+
+      it('should discard control selection changes after cancelling', async () => {
+        await addUnlinkedSavedSearch();
+
+        expect(await dashboardControls.getControlsCount()).to.be(1);
+
+        const initialDashboardControlId = (await dashboardControls.getAllControlIds())[0];
+        expect(
+          await dashboardControls.optionsListGetSelectionsString(initialDashboardControlId)
+        ).to.be('AE');
+
+        await dashboardPanelActions.editPanelByTitle('ESQL control unlink test');
+        await discover.expectOnDiscover();
+        await discover.waitUntilTabIsLoaded();
+
+        const discoverControlId = (await dashboardControls.getAllControlIds())[0];
+        await dashboardControls.optionsListOpenPopover(discoverControlId, true);
+        await dashboardControls.optionsListPopoverSelectOption('CN');
+        await dashboardControls.optionsListEnsurePopoverIsClosed(discoverControlId);
+        await discover.waitUntilTabIsLoaded();
+
+        expect(await dashboardControls.optionsListGetSelectionsString(discoverControlId)).to.be(
+          'CN'
+        );
+
+        await discover.clickCancelButton();
+        await dashboard.waitForRenderComplete();
+
+        expect(await dashboardPanelActions.getPanelWrapper('ESQL control unlink test')).to.be.ok();
+        expect(await dashboardControls.getControlsCount()).to.be(1);
+
+        const unchangedDashboardControlId = (await dashboardControls.getAllControlIds())[0];
+        expect(
+          await dashboardControls.optionsListGetSelectionsString(unchangedDashboardControlId)
+        ).to.be('AE');
+      });
+    });
+
+    describe('when saving a Discover table with ES|QL controls to a dashboard', () => {
+      it('should create a dashboard with the Discover table and the selected control state', async () => {
+        await discover.navigateToApp();
+        await discover.loadSavedSearch('ESQL control unlink test');
+        await discover.waitUntilTabIsLoaded();
+
+        expect(await dashboardControls.getControlsCount()).to.be(1);
+
+        const discoverControlId = (await dashboardControls.getAllControlIds())[0];
+        expect(await dashboardControls.optionsListGetSelectionsString(discoverControlId)).to.be(
+          'AE'
+        );
+
+        await dashboardControls.optionsListOpenPopover(discoverControlId, true);
+        await dashboardControls.optionsListPopoverSelectOption('CN');
+        await dashboardControls.optionsListEnsurePopoverIsClosed(discoverControlId);
+        await discover.waitUntilTabIsLoaded();
+
+        expect(await dashboardControls.optionsListGetSelectionsString(discoverControlId)).to.be(
+          'CN'
+        );
+
+        await discover.clickSaveDiscoverTableToDashboard('ESQL control by-value table');
+
+        await dashboard.waitForRenderComplete();
+        await dashboard.verifyNoRenderErrors();
+
+        expect(
+          await dashboardPanelActions.getPanelWrapper('ESQL control by-value table')
+        ).to.be.ok();
+        expect(await dashboardControls.getControlsCount()).to.be(1);
+
+        const dashboardControlId = (await dashboardControls.getAllControlIds())[0];
+        expect(await dashboardControls.optionsListGetSelectionsString(dashboardControlId)).to.be(
+          'CN'
+        );
+      });
+    });
+
+    describe('when saving a new by-value Discover session panel back to a dashboard with matching controls', () => {
+      it('should update the existing dashboard control instead of creating a duplicate', async () => {
+        await addUnlinkedSavedSearch();
+
+        expect(await dashboardControls.getControlsCount()).to.be(1);
+
+        const initialDashboardControlId = (await dashboardControls.getAllControlIds())[0];
+        expect(
+          await dashboardControls.optionsListGetSelectionsString(initialDashboardControlId)
+        ).to.be('AE');
+
+        await dashboardAddPanel.clickAddDiscoverPanel();
+        await discover.expectOnDiscover();
+        await discover.waitUntilTabIsLoaded();
+        await discover.selectTextBaseLang();
+        await discover.waitUntilTabIsLoaded();
+
+        await esql.openEsqlControlFlyout('FROM logstash-* | WHERE geo.dest == ');
+        await testSubjects.setValue('esqlVariableName', '?geo_dest');
+        await testSubjects.setValue('esqlControlLabel', 'Updated destination');
+        await testSubjects.waitForEnabled('saveEsqlControlsFlyoutButton');
+        await testSubjects.click('saveEsqlControlsFlyoutButton');
+
+        await discover.waitUntilTabIsLoaded();
+
+        expect(await dashboardControls.getControlsCount()).to.be(1);
+
+        const discoverControlId = (await dashboardControls.getAllControlIds())[0];
+        await dashboardControls.optionsListOpenPopover(discoverControlId, true);
+        await dashboardControls.optionsListPopoverSelectOption('CN');
+        await dashboardControls.optionsListEnsurePopoverIsClosed(discoverControlId);
+        await discover.waitUntilTabIsLoaded();
+
+        expect(await dashboardControls.optionsListGetSelectionsString(discoverControlId)).to.be(
+          'CN'
+        );
+
+        await discover.clickSaveSearchButton();
+        await dashboard.waitForRenderComplete();
+
+        expect(await dashboardControls.getControlsCount()).to.be(1);
+
+        const updatedDashboardControlId = (await dashboardControls.getAllControlIds())[0];
+        expect(updatedDashboardControlId).to.be(initialDashboardControlId);
+        expect(
+          await dashboardControls.optionsListGetSelectionsString(updatedDashboardControlId)
+        ).to.be('CN');
       });
     });
   });

--- a/src/platform/test/functional/page_objects/discover_page.ts
+++ b/src/platform/test/functional/page_objects/discover_page.ts
@@ -47,12 +47,9 @@ export class DiscoverPageObject extends FtrService {
 
   /** Ensures that navigation to discover has completed */
   public async expectOnDiscover() {
-    await this.retry.waitFor('discover app menu items to be present', async () => {
-      return (
-        (await this.appMenu.menuItemExists('discoverNewButton')) &&
-        (await this.appMenu.menuItemExists('discoverOpenButton'))
-      );
-    });
+    await this.retry.waitFor('discover app to be rendered', () =>
+      this.testSubjects.exists('discoverSavedSearchTitle', { allowHidden: true })
+    );
   }
 
   public async isOnDashboardsEditMode() {
@@ -172,6 +169,9 @@ export class DiscoverPageObject extends FtrService {
       await this.testSubjects.click(`dashboard-picker-option-${existing}`);
     }
     await this.clickConfirmSavedSearch();
+    if (await this.testSubjects.exists('appLeaveConfirmModal', { timeout: 1000 })) {
+      await this.testSubjects.click('confirmModalConfirmButton');
+    }
     await this.header.waitUntilLoadingHasFinished();
   }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Discover] [Embeddable] Handle ES|QL controls for by-value Discover panels (#264240)](https://github.com/elastic/kibana/pull/264240)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Davis McPhee","email":"davis.mcphee@elastic.co"},"sourceCommit":{"committedDate":"2026-04-24T13:03:34Z","message":"[Discover] [Embeddable] Handle ES|QL controls for by-value Discover panels (#264240)\n\n## Summary\n\nES|QL controls were being dropped when moving a by-value Discover\nsession between Discover and Dashboard, breaking the query on\nnavigation. This PR wires controls through both directions of the\nediting flow:\n\n- **Discover → Dashboard:** `SaveDiscoverTableButton` and\n`useTopNavLinks` now pass the current tab's `controlGroupState`\nalongside `byValueState` when calling `transferBackToEditor`, so the\ndashboard can reconstruct the control group panel when the session is\nsaved back by-value.\n- **Dashboard → Discover:** `initializeEditApi` reads `esqlControls`\nfrom the locator params and serializes them into `controlGroupJson` on\nthe saved search used to build `valueInput`, so controls are restored\nwhen the panel is opened for editing.\n\nBy-reference panels continue through the locator path unchanged.\n\n### How to test\n\n1. Add a by-value Discover session panel to a dashboard.\n2. Edit the panel, switch to ES|QL, and add a query with a control.\n3. Save and return — the control panel should render alongside the\nDiscover panel.\n4. Edit the panel again — Discover should open with the control restored\nand the query working.\n5. Confirm by-reference panels don't regress.\n\nResolves #252194.\n\n### Checklist\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Stratou <efstratia.kalafateli@elastic.co>","sha":"fcf3880b6dfbb27b44c354f83db7d1d512ff0009","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:DataDiscovery","backport:version","v9.4.0","v9.5.0"],"title":"[Discover] [Embeddable] Handle ES|QL controls for by-value Discover panels","number":264240,"url":"https://github.com/elastic/kibana/pull/264240","mergeCommit":{"message":"[Discover] [Embeddable] Handle ES|QL controls for by-value Discover panels (#264240)\n\n## Summary\n\nES|QL controls were being dropped when moving a by-value Discover\nsession between Discover and Dashboard, breaking the query on\nnavigation. This PR wires controls through both directions of the\nediting flow:\n\n- **Discover → Dashboard:** `SaveDiscoverTableButton` and\n`useTopNavLinks` now pass the current tab's `controlGroupState`\nalongside `byValueState` when calling `transferBackToEditor`, so the\ndashboard can reconstruct the control group panel when the session is\nsaved back by-value.\n- **Dashboard → Discover:** `initializeEditApi` reads `esqlControls`\nfrom the locator params and serializes them into `controlGroupJson` on\nthe saved search used to build `valueInput`, so controls are restored\nwhen the panel is opened for editing.\n\nBy-reference panels continue through the locator path unchanged.\n\n### How to test\n\n1. Add a by-value Discover session panel to a dashboard.\n2. Edit the panel, switch to ES|QL, and add a query with a control.\n3. Save and return — the control panel should render alongside the\nDiscover panel.\n4. Edit the panel again — Discover should open with the control restored\nand the query working.\n5. Confirm by-reference panels don't regress.\n\nResolves #252194.\n\n### Checklist\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Stratou <efstratia.kalafateli@elastic.co>","sha":"fcf3880b6dfbb27b44c354f83db7d1d512ff0009"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/264240","number":264240,"mergeCommit":{"message":"[Discover] [Embeddable] Handle ES|QL controls for by-value Discover panels (#264240)\n\n## Summary\n\nES|QL controls were being dropped when moving a by-value Discover\nsession between Discover and Dashboard, breaking the query on\nnavigation. This PR wires controls through both directions of the\nediting flow:\n\n- **Discover → Dashboard:** `SaveDiscoverTableButton` and\n`useTopNavLinks` now pass the current tab's `controlGroupState`\nalongside `byValueState` when calling `transferBackToEditor`, so the\ndashboard can reconstruct the control group panel when the session is\nsaved back by-value.\n- **Dashboard → Discover:** `initializeEditApi` reads `esqlControls`\nfrom the locator params and serializes them into `controlGroupJson` on\nthe saved search used to build `valueInput`, so controls are restored\nwhen the panel is opened for editing.\n\nBy-reference panels continue through the locator path unchanged.\n\n### How to test\n\n1. Add a by-value Discover session panel to a dashboard.\n2. Edit the panel, switch to ES|QL, and add a query with a control.\n3. Save and return — the control panel should render alongside the\nDiscover panel.\n4. Edit the panel again — Discover should open with the control restored\nand the query working.\n5. Confirm by-reference panels don't regress.\n\nResolves #252194.\n\n### Checklist\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Stratou <efstratia.kalafateli@elastic.co>","sha":"fcf3880b6dfbb27b44c354f83db7d1d512ff0009"}}]}] BACKPORT-->