### PR TITLE
[Observability Onboarding] Add `helm repo update` to Kubernetes Elastic Agent onboarding flow script

### DIFF
--- a/x-pack/solutions/observability/plugins/observability_onboarding/public/application/quickstart_flows/kubernetes/build_helm_command.test.ts
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/public/application/quickstart_flows/kubernetes/build_helm_command.test.ts
@@ -24,6 +24,7 @@ describe('buildHelmCommand', () => {
     const command = buildHelmCommand(baseParams);
 
     expect(command).toContain('helm repo add elastic https://helm.elastic.co/');
+    expect(command).toContain('helm repo update elastic');
     expect(command).toContain('helm install elastic-agent elastic/elastic-agent');
     expect(command).toContain('--version 9.1.0');
     expect(command).toContain(

--- a/x-pack/solutions/observability/plugins/observability_onboarding/public/application/quickstart_flows/kubernetes/build_helm_command.ts
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/public/application/quickstart_flows/kubernetes/build_helm_command.ts
@@ -44,6 +44,7 @@ export function buildHelmCommand({
 
   return `
     helm repo add elastic https://helm.elastic.co/ && \
+    helm repo update elastic && \
     helm install elastic-agent elastic/elastic-agent --version ${elasticAgentVersionInfo.agentBaseVersion} \
       -n kube-system \
       --set outputs.default.url=${escapedElasticsearchUrl} \


### PR DESCRIPTION
## Summary
Closes https://github.com/elastic/observability-dev/issues/5324

This PR adds `helm repo update elastic` between `helm repo` add and `helm install` in `buildHelmCommand()`

<!--ONMERGE {"backportTargets":["9.2","9.3","9.4"]} ONMERGE-->