### PR TITLE
[AI Infra] Extend GenAI Settings Scout page navigation timeout

### DIFF
--- a/x-pack/platform/plugins/private/gen_ai_settings/test/scout/ui/fixtures/page_objects/gen_ai_settings_page.ts
+++ b/x-pack/platform/plugins/private/gen_ai_settings/test/scout/ui/fixtures/page_objects/gen_ai_settings_page.ts
@@ -28,9 +28,9 @@ export class GenAiSettingsPage {
       await this.page.gotoApp('management/ai/genAiSettings');
       await this.page.testSubj.waitForSelector('genAiSettingsPage', {
         state: 'visible',
-        timeout: 3_000,
+        timeout: 10_000,
       });
-    }).toPass({ timeout: 30_000, intervals: [500, 1_000, 2_000] });
+    }).toPass({ timeout: 35_000, intervals: [500, 1_000, 2_000] });
   }
 
   /**


### PR DESCRIPTION
## Summary

Extends the timeout values in the `GenAiSettingsPage.navigateTo()` page object to give the page sufficient time to load.

The retry logic introduced in #260496 used a 3s inner `waitForSelector` timeout, which was too short on slower VMs — the page could fail to appear within that window even though it would have loaded given more time. This meant the retry loop was bailing out prematurely rather than waiting long enough per attempt.

Changes:
- `waitForSelector` timeout: `3_000` → `10_000` ms
- `.toPass` outer timeout: `30_000` → `35_000` ms (accommodates 3 full retry attempts of up to 10s each, with intervals of 500ms / 1s / 2s between them)

Relates to #260496

### Checklist


- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Low risk — test-only change, no production code affected.

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->