### PR TITLE
[Synthetics] Unskip and stabilize filter monitors scout test FilterMonitors - filters monitors by tags with AND/OR logic

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/test/scout/ui/tests/filter_monitors.spec.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/test/scout/ui/tests/filter_monitors.spec.ts
@@ -12,7 +12,7 @@ import { test } from '../fixtures';
 const FIRST_TAG = 'a';
 const SECOND_TAG = 'b';
 
-test.describe('FilterMonitors', { tag: tags.stateful.classic }, () => {
+test.describe('FilterMonitors', { tag: [...tags.stateful.classic] }, () => {
   test.beforeAll(async ({ syntheticsServices }) => {
     await syntheticsServices.cleanUp();
   });
@@ -45,22 +45,44 @@ test.describe('FilterMonitors', { tag: tags.stateful.classic }, () => {
       await pageObjects.syntheticsApp.refreshOverview();
     });
 
+    // EuiSelectable re-renders the option list on each selection, and a positional
+    // click on the next option can miss if it lands during a re-render. This helper
+    // re-checks state before clicking, so it won't toggle off an already-selected
+    // option — safe to retry until aria-checked settles on "true".
+    const selectTagOption = async (tagName: string) => {
+      const option = page.getByRole('option', { name: tagName });
+      await expect
+        .poll(
+          async () => {
+            if ((await option.getAttribute('aria-checked')) === 'true') return 'true';
+            await option.click();
+            return option.getAttribute('aria-checked');
+          },
+          { timeout: 15_000, intervals: [250, 500, 1000] }
+        )
+        .toBe('true');
+    };
+
     await test.step('filter by tags with AND', async () => {
       await page.getByLabel('expands filter group for Tags filter').click();
-      await page.getByRole('option', { name: FIRST_TAG }).click();
-      await page.getByRole('option', { name: SECOND_TAG }).click();
+
+      await selectTagOption(FIRST_TAG);
+      await selectTagOption(SECOND_TAG);
+
       await page.testSubj.click('tagsLogicalOperatorSwitch');
       await page.testSubj.click('o11yFieldValueSelectionApplyButton');
+      await expect(page.getByLabel('expands filter group for Tags filter')).toBeVisible();
 
-      await expect(page.getByText('Showing 1 Monitor')).toBeVisible({ timeout: 10_000 });
+      await expect(page.getByText('Showing 1 Monitor')).toBeVisible({ timeout: 30_000 });
     });
 
     await test.step('filter by tags with OR', async () => {
       await page.getByLabel('expands filter group for Tags filter').click();
       await page.testSubj.click('tagsLogicalOperatorSwitch');
       await page.testSubj.click('o11yFieldValueSelectionApplyButton');
+      await expect(page.getByLabel('expands filter group for Tags filter')).toBeVisible();
 
-      await expect(page.getByText('Showing 2 Monitors')).toBeVisible({ timeout: 10_000 });
+      await expect(page.getByText('Showing 2 Monitors')).toBeVisible({ timeout: 30_000 });
     });
   });
 });


### PR DESCRIPTION
### Resolves [#257334](https://github.com/elastic/kibana/issues/257334)
* Unskips the FilterMonitors scout test that was skipped due to Failing test: FilterMonitors - filters monitors by tags with AND/OR logic #257334
* Adds a wait for the filter label to be visible after clicking Apply, ensuring the popover has closed before asserting on filtered results
* Increases assertion timeouts from 10s to 30s to accommodate slower CI environments
* Wraps each tag option click in a state-checking poll helper

Same changes were implemented to [v8.19 by this PR](https://github.com/elastic/kibana/pull/262563). I also added backports for v9.3 and v9.4 to keep branches consistent.

**How it works each poll iteration:**
1. Read the option's current aria-checked attribute
2. If already "true", return immediately — no click (this is what makes it safe: we never click an already-selected option, so we can't accidentally toggle it off)
3. Otherwise, click, then re-read the attribute
4. Poll passes as soon as the attribute settles on "true"

This recovers from the re-render race: if the first click's event was lost because the target DOM node was replaced mid-click, the next poll iteration resolves the locator fresh and clicks on the current node.

- [x] Passed 55 consecutive local runs with zero failures

<!--ONMERGE {"backportTargets":["9.3","9.4"]} ONMERGE-->