### PR TITLE
[9.4] [Inference] Show global default row for unset features (#264164)

### DIFF
--- a/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/settings/feature_section.tsx
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/settings/feature_section.tsx
@@ -25,6 +25,8 @@ import { SubFeatureCard } from './sub_feature_card';
 interface FeatureSettingItem {
   endpointIds: string[];
   feature: InferenceFeatureConfig;
+  hasSavedObject: boolean;
+  isFeatureDirty: boolean;
 }
 
 interface FeatureSectionProps {
@@ -36,6 +38,7 @@ interface FeatureSectionProps {
   invalidEndpointIds: Set<string>;
   isTechPreview?: boolean;
   isBeta?: boolean;
+  globalDefaultId: string;
 }
 
 export const FeatureSection: React.FC<FeatureSectionProps> = ({
@@ -47,6 +50,7 @@ export const FeatureSection: React.FC<FeatureSectionProps> = ({
   invalidEndpointIds,
   isTechPreview = false,
   isBeta = false,
+  globalDefaultId,
 }) => {
   return (
     <EuiFlexGroup gutterSize="m" direction="column">
@@ -108,7 +112,7 @@ export const FeatureSection: React.FC<FeatureSectionProps> = ({
           </EuiText>
         ) : (
           <EuiFlexGroup direction="column" gutterSize="xl">
-            {features.map(({ endpointIds, feature }) => (
+            {features.map(({ endpointIds, feature, hasSavedObject, isFeatureDirty }) => (
               <EuiFlexItem key={feature.featureId} grow={false}>
                 <SubFeatureCard
                   featureId={feature.featureId}
@@ -116,6 +120,9 @@ export const FeatureSection: React.FC<FeatureSectionProps> = ({
                   endpointIds={endpointIds}
                   onEndpointsChange={onEndpointsChange}
                   invalidEndpointIds={invalidEndpointIds}
+                  globalDefaultId={globalDefaultId}
+                  hasSavedObject={hasSavedObject}
+                  isFeatureDirty={isFeatureDirty}
                 />
               </EuiFlexItem>
             ))}

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/settings/model_settings.test.tsx
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/settings/model_settings.test.tsx
@@ -72,6 +72,8 @@ const defaultFormState = {
     },
   ],
   invalidEndpointIds: new Set<string>(),
+  hasSavedObject: { child_1: false },
+  dirtyFeatureIds: new Set<string>(),
   updateEndpoints: jest.fn(),
   save: jest.fn(),
   resetSection: jest.fn(),
@@ -377,26 +379,20 @@ describe('ModelSettings', () => {
       </Router>
     );
 
-    // Trigger navigation while dirty to invoke the history block
     act(() => {
       history.push('/some-other-page');
     });
 
-    // The unsaved changes modal should appear
     await waitFor(() => {
       expect(screen.getByTestId('unsavedChangesModal')).toBeInTheDocument();
     });
 
-    // Click "Discard changes"
     fireEvent.click(screen.getByText('Discard changes'));
 
-    // defaultModelSettings.reset should be called
     expect(resetDefaultModel).toHaveBeenCalledTimes(1);
 
-    // navigateToUrl should be called with the pending destination
     expect(mockNavigateToUrl).toHaveBeenCalledWith('/some-other-page', expect.any(Object));
 
-    // Modal should be closed
     await waitFor(() => {
       expect(screen.queryByTestId('unsavedChangesModal')).not.toBeInTheDocument();
     });
@@ -425,7 +421,6 @@ describe('ModelSettings', () => {
       expect(screen.getByTestId('unsavedChangesModal')).toBeInTheDocument();
     });
 
-    // Click "Cancel"
     fireEvent.click(screen.getByText('Cancel'));
 
     expect(mockNavigateToUrl).not.toHaveBeenCalled();

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/settings/model_settings.tsx
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/settings/model_settings.tsx
@@ -38,12 +38,15 @@ export const ModelSettings: React.FC = () => {
     assignments,
     sections,
     invalidEndpointIds,
+    hasSavedObject,
+    dirtyFeatureIds,
     updateEndpoints,
     save: saveFeatures,
     resetSection,
   } = useModelSettingsForm();
 
   const defaultModelSettings = useDefaultModelSettings();
+  const globalDefaultId = defaultModelSettings.savedState.defaultModelId;
   const { data: connectors, isLoading: connectorsLoading } = useConnectors();
   const {
     services: { application, http },
@@ -214,12 +217,15 @@ export const ModelSettings: React.FC = () => {
                     features={section.children.map((f) => ({
                       endpointIds: assignments[f.featureId] ?? f.recommendedEndpoints,
                       feature: f,
+                      hasSavedObject: hasSavedObject[f.featureId] ?? false,
+                      isFeatureDirty: dirtyFeatureIds.has(f.featureId),
                     }))}
                     onReset={() => setResetParentKey(section.featureId)}
                     onEndpointsChange={updateEndpoints}
                     invalidEndpointIds={invalidEndpointIds}
                     isBeta={section.isBeta}
                     isTechPreview={section.isTechPreview}
+                    globalDefaultId={globalDefaultId}
                   />
                   <EuiSpacer size="xl" />
                 </React.Fragment>

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/settings/sub_feature_card.test.tsx
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/settings/sub_feature_card.test.tsx
@@ -145,7 +145,12 @@ describe('SubFeatureCard', () => {
   const renderCard = (
     endpointIds: string[],
     overrides?: Partial<InferenceFeatureConfig>,
-    invalidEndpointIds: Set<string> = new Set()
+    extra?: {
+      invalidEndpointIds?: Set<string>;
+      globalDefaultId?: string;
+      hasSavedObject?: boolean;
+      isFeatureDirty?: boolean;
+    }
   ) =>
     render(
       <Wrapper>
@@ -154,7 +159,10 @@ describe('SubFeatureCard', () => {
           feature={{ ...feature, ...overrides }}
           endpointIds={endpointIds}
           onEndpointsChange={onEndpointsChange}
-          invalidEndpointIds={invalidEndpointIds}
+          invalidEndpointIds={extra?.invalidEndpointIds ?? new Set()}
+          globalDefaultId={extra?.globalDefaultId ?? 'NO_DEFAULT_MODEL'}
+          hasSavedObject={extra?.hasSavedObject ?? true}
+          isFeatureDirty={extra?.isFeatureDirty ?? false}
         />
       </Wrapper>
     );
@@ -335,6 +343,60 @@ describe('SubFeatureCard', () => {
       renderCard(['azure-1']);
 
       expect(screen.getByText('Azure GPT')).toBeInTheDocument();
+    });
+  });
+
+  describe('global default row', () => {
+    it('does not render greyed row when feature has a saved object', () => {
+      renderCard(['ep-1'], undefined, {
+        globalDefaultId: 'ep-3',
+        hasSavedObject: true,
+        isFeatureDirty: false,
+      });
+
+      expect(screen.queryByTestId('global-default-row-test_feature')).not.toBeInTheDocument();
+    });
+
+    it('does not render greyed row when global default is unset', () => {
+      renderCard(['ep-1'], undefined, {
+        globalDefaultId: 'NO_DEFAULT_MODEL',
+        hasSavedObject: false,
+        isFeatureDirty: false,
+      });
+
+      expect(screen.queryByTestId('global-default-row-test_feature')).not.toBeInTheDocument();
+    });
+
+    it('renders greyed row with badge when no saved object, default set, and not dirty', () => {
+      renderCard(['ep-1'], undefined, {
+        globalDefaultId: 'ep-3',
+        hasSavedObject: false,
+        isFeatureDirty: false,
+      });
+
+      expect(screen.getByTestId('global-default-row-test_feature')).toBeInTheDocument();
+      expect(screen.getByTestId('global-default-badge-test_feature')).toBeInTheDocument();
+    });
+
+    it('renders greyed row without badge when feature has been edited', () => {
+      renderCard(['ep-1'], undefined, {
+        globalDefaultId: 'ep-3',
+        hasSavedObject: false,
+        isFeatureDirty: true,
+      });
+
+      expect(screen.getByTestId('global-default-row-test_feature')).toBeInTheDocument();
+      expect(screen.queryByTestId('global-default-badge-test_feature')).not.toBeInTheDocument();
+    });
+
+    it('hides the per-endpoint Default badge when the global default row is shown', () => {
+      renderCard(['ep-1', 'ep-2'], undefined, {
+        globalDefaultId: 'ep-3',
+        hasSavedObject: false,
+        isFeatureDirty: false,
+      });
+
+      expect(screen.queryByText('Default')).not.toBeInTheDocument();
     });
   });
 });

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/settings/sub_feature_card.tsx
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/settings/sub_feature_card.tsx
@@ -33,7 +33,7 @@ import { InferenceConnectorType } from '@kbn/inference-common';
 import { SERVICE_PROVIDERS } from '@kbn/inference-endpoint-ui-common';
 import type { ServiceProviderKeys } from '@kbn/inference-endpoint-ui-common';
 import { css } from '@emotion/react';
-import * as translations from '../../../common/translations';
+import { NO_DEFAULT_MODEL } from '../../../common/constants';
 import { useRegisteredFeatures } from '../../hooks/use_registered_features';
 import { getProviderKeyForCreator } from '../../utils/eis_utils';
 import type { InferenceFeatureResponse as InferenceFeatureConfig } from '../../../common/types';
@@ -71,6 +71,9 @@ interface SubFeatureCardProps {
   endpointIds: string[];
   onEndpointsChange: (featureId: string, newEndpointIds: string[]) => void;
   invalidEndpointIds: Set<string>;
+  globalDefaultId: string;
+  hasSavedObject: boolean;
+  isFeatureDirty: boolean;
 }
 
 export const SubFeatureCard: React.FC<SubFeatureCardProps> = ({
@@ -79,6 +82,9 @@ export const SubFeatureCard: React.FC<SubFeatureCardProps> = ({
   endpointIds,
   onEndpointsChange,
   invalidEndpointIds,
+  globalDefaultId,
+  hasSavedObject,
+  isFeatureDirty,
 }) => {
   const { data: connectors = [] } = useConnectors();
   const { features: registeredFeatures } = useRegisteredFeatures();
@@ -117,6 +123,9 @@ export const SubFeatureCard: React.FC<SubFeatureCardProps> = ({
   const hasOverflow = endpointIds.length > COLLAPSED_COUNT;
   const visibleEndpoints = isExpanded ? endpointIds : endpointIds.slice(0, COLLAPSED_COUNT);
   const hiddenCount = endpointIds.length - COLLAPSED_COUNT;
+  const showGlobalDefaultRow = !hasSavedObject && globalDefaultId !== NO_DEFAULT_MODEL;
+  const { icon: globalDefaultIcon = 'compute', label: globalDefaultLabel = globalDefaultId } =
+    endpointDisplayMap.get(globalDefaultId) ?? {};
   const canAddMore =
     !feature.maxNumberOfEndpoints || endpointIds.length < feature.maxNumberOfEndpoints;
 
@@ -225,13 +234,71 @@ export const SubFeatureCard: React.FC<SubFeatureCardProps> = ({
         >
           <EuiPanel color="subdued" paddingSize="s" hasBorder={false}>
             <EuiText size="xs" color="subdued">
-              <strong>{translations.SETTINGS_ASSIGNED_MODELS}</strong>
+              <strong>
+                {i18n.translate('xpack.searchInferenceEndpoints.settings.assignedModels', {
+                  defaultMessage: 'Assigned models',
+                })}
+              </strong>
             </EuiText>
             <EuiSpacer size="s" />
 
             <EuiDragDropContext onDragEnd={handleDragEnd}>
               <div ref={listRef}>
                 <EuiSplitPanel.Outer hasBorder>
+                  {showGlobalDefaultRow && (
+                    <>
+                      <EuiSplitPanel.Inner
+                        paddingSize="s"
+                        color="subdued"
+                        data-test-subj={`global-default-row-${featureId}`}
+                      >
+                        <EuiFlexGroup alignItems="center" gutterSize="s">
+                          <EuiFlexItem grow={false}>
+                            <EuiPanel color="transparent" paddingSize="none">
+                              <EuiIcon type="lock" size="s" color="subdued" aria-hidden />
+                            </EuiPanel>
+                          </EuiFlexItem>
+                          <EuiFlexItem grow={false}>
+                            <EuiIcon type={globalDefaultIcon} size="m" aria-hidden />
+                          </EuiFlexItem>
+                          <EuiFlexItem grow>
+                            <EuiToolTip
+                              title={globalDefaultLabel}
+                              content={globalDefaultId}
+                              position="top"
+                            >
+                              <EuiText
+                                size="s"
+                                color="subdued"
+                                tabIndex={0}
+                                css={css`
+                                  overflow: hidden;
+                                  text-overflow: ellipsis;
+                                  white-space: nowrap;
+                                `}
+                              >
+                                <span>{globalDefaultLabel}</span>
+                              </EuiText>
+                            </EuiToolTip>
+                          </EuiFlexItem>
+                          {!isFeatureDirty && (
+                            <EuiFlexItem grow={false}>
+                              <EuiBadge
+                                color="hollow"
+                                data-test-subj={`global-default-badge-${featureId}`}
+                              >
+                                {i18n.translate(
+                                  'xpack.searchInferenceEndpoints.settings.globalDefaultBadge',
+                                  { defaultMessage: 'Global default' }
+                                )}
+                              </EuiBadge>
+                            </EuiFlexItem>
+                          )}
+                        </EuiFlexGroup>
+                      </EuiSplitPanel.Inner>
+                      <EuiHorizontalRule margin="none" />
+                    </>
+                  )}
                   <EuiDroppable droppableId={`assigned-models-${featureId}`} spacing="none">
                     {visibleEndpoints.map((endpointId, index) => (
                       <EuiDraggable
@@ -311,10 +378,15 @@ export const SubFeatureCard: React.FC<SubFeatureCardProps> = ({
                                       </EuiText>
                                     </EuiToolTip>
                                   </EuiFlexItem>
-                                  {index === 0 && (
+                                  {index === 0 && !showGlobalDefaultRow && (
                                     <EuiFlexItem grow={false}>
                                       <EuiBadge color="hollow">
-                                        {translations.SETTINGS_DEFAULT_BADGE}
+                                        {i18n.translate(
+                                          'xpack.searchInferenceEndpoints.settings.defaultBadge',
+                                          {
+                                            defaultMessage: 'Default',
+                                          }
+                                        )}
                                       </EuiBadge>
                                     </EuiFlexItem>
                                   )}

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/settings/use_model_settings_form.test.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/settings/use_model_settings_form.test.ts
@@ -266,4 +266,47 @@ describe('useModelSettingsForm', () => {
 
     expect(result.current.isLoading).toBe(true);
   });
+
+  it('hasSavedObject reflects which features have saved settings', () => {
+    mockUseInferenceSettings.mockReturnValue({
+      data: {
+        data: {
+          features: [{ feature_id: 'child_1', endpoints: [{ id: 'saved-1' }] }],
+        },
+      },
+      isLoading: false,
+    });
+
+    const { result } = renderHook(() => useModelSettingsForm());
+
+    expect(result.current.hasSavedObject).toEqual({ child_1: true, child_2: false });
+  });
+
+  it('hasSavedObject treats empty saved endpoints as no saved object', () => {
+    mockUseInferenceSettings.mockReturnValue({
+      data: {
+        data: {
+          features: [{ feature_id: 'child_1', endpoints: [] }],
+        },
+      },
+      isLoading: false,
+    });
+
+    const { result } = renderHook(() => useModelSettingsForm());
+
+    expect(result.current.hasSavedObject).toEqual({ child_1: false, child_2: false });
+  });
+
+  it('dirtyFeatureIds contains only features whose assignments differ from defaults', () => {
+    const { result } = renderHook(() => useModelSettingsForm());
+
+    expect(result.current.dirtyFeatureIds.size).toBe(0);
+
+    act(() => {
+      result.current.updateEndpoints('child_1', ['endpoint-x']);
+    });
+
+    expect(result.current.dirtyFeatureIds.has('child_1')).toBe(true);
+    expect(result.current.dirtyFeatureIds.has('child_2')).toBe(false);
+  });
 });

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/settings/use_model_settings_form.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/settings/use_model_settings_form.ts
@@ -24,6 +24,8 @@ export interface ModelSettingsForm {
   assignments: Assignments;
   sections: FeatureSection[];
   invalidEndpointIds: Set<string>;
+  hasSavedObject: Record<string, boolean>;
+  dirtyFeatureIds: ReadonlySet<string>;
   updateEndpoints: (featureId: string, endpointIds: string[]) => void;
   save: () => void;
   resetSection: (sectionId: string) => void;
@@ -113,13 +115,27 @@ export const useModelSettingsForm = (): ModelSettingsForm => {
     [registeredFeatures]
   );
 
-  const defaultAssignments = useMemo((): Assignments => {
-    const savedMap = new Map<string, string[]>(
-      (settingsData?.data?.features ?? [])
-        .map((f): [string, string[]] => [f.feature_id, (f.endpoints ?? []).map((e) => e.id)])
-        .filter(([, ids]) => ids.length > 0)
-    );
+  const savedMap = useMemo(
+    () =>
+      new Map<string, string[]>(
+        (settingsData?.data?.features ?? [])
+          .map((f): [string, string[]] => [f.feature_id, (f.endpoints ?? []).map((e) => e.id)])
+          .filter(([, ids]) => ids.length > 0)
+      ),
+    [settingsData]
+  );
 
+  const hasSavedObject = useMemo(
+    () =>
+      Object.fromEntries(
+        sections.flatMap(({ children }) =>
+          children.map((f): [string, boolean] => [f.featureId, savedMap.has(f.featureId)])
+        )
+      ),
+    [sections, savedMap]
+  );
+
+  const defaultAssignments = useMemo((): Assignments => {
     return Object.fromEntries(
       sections.flatMap(({ children }) =>
         children.map((f): [string, string[]] => [
@@ -128,7 +144,7 @@ export const useModelSettingsForm = (): ModelSettingsForm => {
         ])
       )
     );
-  }, [settingsData, sections, recommendedEndpointsById]);
+  }, [savedMap, sections, recommendedEndpointsById]);
 
   const [assignments, setAssignments] = useState<Assignments>(defaultAssignments);
 
@@ -141,10 +157,18 @@ export const useModelSettingsForm = (): ModelSettingsForm => {
     [settingsData]
   );
 
-  const isDirty = useMemo(
-    () => JSON.stringify(assignments) !== JSON.stringify(defaultAssignments),
-    [assignments, defaultAssignments]
-  );
+  const dirtyFeatureIds = useMemo(() => {
+    const ids = new Set<string>();
+    for (const [featureId, ids$] of Object.entries(assignments)) {
+      const defaults = defaultAssignments[featureId];
+      if (!defaults || !arraysEqual(ids$, defaults)) {
+        ids.add(featureId);
+      }
+    }
+    return ids;
+  }, [assignments, defaultAssignments]);
+
+  const isDirty = dirtyFeatureIds.size > 0;
 
   const updateEndpoints = useCallback((featureId: string, endpointIds: string[]) => {
     setAssignments((prev) => ({ ...prev, [featureId]: endpointIds }));
@@ -185,6 +209,8 @@ export const useModelSettingsForm = (): ModelSettingsForm => {
     assignments,
     sections,
     invalidEndpointIds,
+    hasSavedObject,
+    dirtyFeatureIds,
     updateEndpoints,
     save,
     resetSection,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Inference] Show global default row for unset features (#264164)](https://github.com/elastic/kibana/pull/264164)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Sander Philipse","email":"94373878+sphilipse@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-04-22T18:29:14Z","message":"[Inference] Show global default row for unset features (#264164)\n\n## Summary\n\nThis makes the actual behavior of the feature visible to the user.\n\nWhen a feature has no saved endpoint selection but a global default\nmodel is configured, render a greyed-out row in the SubFeatureCard\nshowing the global default will be used. A \"Global default\" badge marks\nit until the user makes an edit. Hide the per-endpoint \"Default\" badge\nwhile the global-default row is shown to avoid conflicting signals.\n<img width=\"1326\" height=\"866\" alt=\"Screenshot 2026-04-17 at 18 55 06\"\nsrc=\"https://github.com/user-attachments/assets/992fe079-e2c9-4314-b103-c30832620d2d\"\n/>\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Saikat Sarkar <saikat.sarkar@elastic.co>","sha":"e2ab6058df444cc3982acdd018b2e9683d43ce97","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","Team:Search","backport:version","v9.4.0","v9.5.0"],"title":"[Inference] Show global default row for unset features","number":264164,"url":"https://github.com/elastic/kibana/pull/264164","mergeCommit":{"message":"[Inference] Show global default row for unset features (#264164)\n\n## Summary\n\nThis makes the actual behavior of the feature visible to the user.\n\nWhen a feature has no saved endpoint selection but a global default\nmodel is configured, render a greyed-out row in the SubFeatureCard\nshowing the global default will be used. A \"Global default\" badge marks\nit until the user makes an edit. Hide the per-endpoint \"Default\" badge\nwhile the global-default row is shown to avoid conflicting signals.\n<img width=\"1326\" height=\"866\" alt=\"Screenshot 2026-04-17 at 18 55 06\"\nsrc=\"https://github.com/user-attachments/assets/992fe079-e2c9-4314-b103-c30832620d2d\"\n/>\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Saikat Sarkar <saikat.sarkar@elastic.co>","sha":"e2ab6058df444cc3982acdd018b2e9683d43ce97"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/264164","number":264164,"mergeCommit":{"message":"[Inference] Show global default row for unset features (#264164)\n\n## Summary\n\nThis makes the actual behavior of the feature visible to the user.\n\nWhen a feature has no saved endpoint selection but a global default\nmodel is configured, render a greyed-out row in the SubFeatureCard\nshowing the global default will be used. A \"Global default\" badge marks\nit until the user makes an edit. Hide the per-endpoint \"Default\" badge\nwhile the global-default row is shown to avoid conflicting signals.\n<img width=\"1326\" height=\"866\" alt=\"Screenshot 2026-04-17 at 18 55 06\"\nsrc=\"https://github.com/user-attachments/assets/992fe079-e2c9-4314-b103-c30832620d2d\"\n/>\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Saikat Sarkar <saikat.sarkar@elastic.co>","sha":"e2ab6058df444cc3982acdd018b2e9683d43ce97"}}]}] BACKPORT-->