### PR TITLE
[ResponseOps] Broken css in rule detail page

### DIFF
--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rule_details/components/rule_definition.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rule_details/components/rule_definition.tsx
@@ -260,8 +260,11 @@ export const RuleDefinition: React.FunctionComponent<RuleDefinitionProps> = memo
           <EuiDescriptionList
             compressed={true}
             type="column"
+            columnWidths={[1, 3]}
             listItems={ruleDefinitionList}
             css={{ alignItems: 'start' }}
+            titleProps={{ css: { minWidth: 0 } }}
+            descriptionProps={{ css: { minWidth: 0, overflowWrap: 'break-word' } }}
           />
         </EuiPanel>
       </EuiFlexItem>


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/265702

After the fix:

<img width="1556" height="825" alt="Screenshot 2026-04-27 at 14 04 54" src="https://github.com/user-attachments/assets/a95ed0d0-d86e-40ad-ac5e-29b8965cf6d2" />



<!--ONMERGE {"backportTargets":["9.3","9.4"]} ONMERGE-->