### PR TITLE
[ML] Flaky FTR test fix

### DIFF
--- a/x-pack/platform/test/functional/services/ml/anomalies_table.ts
+++ b/x-pack/platform/test/functional/services/ml/anomalies_table.ts
@@ -152,10 +152,10 @@ export function MachineLearningAnomaliesTableProvider({ getService }: FtrProvide
     },
 
     async ensureAnomalyActionDiscoverButtonClicked(rowIndex: number) {
-      await retry.tryForTime(10 * 1000, async () => {
+      await retry.tryForTime(30 * 1000, async () => {
         await this.ensureAnomalyActionsMenuOpen(rowIndex);
         await testSubjects.click('mlAnomaliesListRowAction_viewInDiscoverButton');
-        await testSubjects.existOrFail('discoverLayoutResizableContainer');
+        await testSubjects.existOrFail('discoverLayoutResizableContainer', { timeout: 10 * 1000 });
       });
     },
 


### PR DESCRIPTION
## Summary

Fixes the flaky FTR test tracked in https://github.com/elastic/kibana/issues/262341.

**Test:** `machine learning - anomaly detection single metric viewer with entity fields should click the Discover action in the anomaly table`

### Root cause fixed (A)

`ensureAnomalyActionDiscoverButtonClicked` in `anomalies_table.ts` had a structural timing bug introduced when the function was refactored to accept a `rowIndex` parameter (commit `e49ded918d32`). The original fix for the same function in `single_metric_viewer.ts` (commit `c830fbb39ba3`, July 2024) was never carried over.

**Two-part problem:**

1. **`existOrFail` had no explicit timeout**, so it used the default `timeouts.try` = 2 minutes. A single failed attempt consumed the entire budget.
2. **The outer `tryForTime` was only 10 seconds**, which is less than one `existOrFail` run. After the first failed attempt, the retry loop immediately gave up because `Date.now() - start > 10 000` was already true.

**Fix:** Mirror the `c830fbb39ba3` fix:
- `tryForTime`: 10 s → **30 s** (room for multiple attempts)
- `existOrFail`: add `{ timeout: 10 * 1000 }` so each attempt fails fast, leaving budget for retries

### Why `ensureAnomalyActionsMenuOpen` stays inside the retry block

Keeping it inside is intentional: if the click is a no-op (see Root Cause C below), the user is still on the ML page and the menu needs to be re-opened before clicking again.

---

## Other potential contributing factors (not fixed here, for future reference)

### Root Cause B — `discoverLayoutResizableContainer` may not exist in Static layout mode

`discoverLayoutResizableContainer` is the `data-test-subj` on `EuiResizableContainer` inside `PanelsResizable` (`panels_resizable.tsx:198`). It is only rendered when Discover's `ResizableLayout` is in `ResizableLayoutMode.Resizable` mode.

`discover_resizable_layout.tsx:72-73` switches to `PanelsStatic` (which does **not** have this test subject) when:
```ts
const layoutMode =
    isMobile || isSidebarCollapsed ? ResizableLayoutMode.Static : ResizableLayoutMode.Resizable;
```

If the CI browser viewport is ≤ 767 px wide, `useIsWithinBreakpoints(['xs', 's'])` returns `true`, `PanelsStatic` is used, and `discoverLayoutResizableContainer` never appears. A more resilient test would use a test subject that exists in both layout modes (e.g., `dscPage`).

### Root Cause C — "View in Discover" href may be `undefined` when the button is clicked

`links_menu.tsx` generates the Discover URL through two sequential async operations:
1. `getDataViewIdFromName()` → sets `dataViewIdWithTemporary`
2. `discoverLocator.getRedirectUrl()` → sets `openInDiscoverUrl`

The button renders as `href={openInDiscoverUrl}` and is `disabled` until the URL is ready. Clicking a disabled `EuiContextMenuItem` (or one with `href={undefined}`) does nothing — no navigation occurs. If the test clicks faster than both async calls complete, it is silently a no-op.

The retry loop in `ensureAnomalyActionDiscoverButtonClicked` is designed to handle exactly this case, but the too-short budget (Root Cause A) meant it couldn't.

---

## Checklist

- [x] Unit or functional tests were updated
- [x] The PR description includes the appropriate Release Notes section

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->