### PR TITLE
[Security Solution] Warn gracefully when alerts index not found in risk score maintainer

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/maintainer/risk_score_maintainer.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/maintainer/risk_score_maintainer.ts
@@ -359,6 +359,16 @@ const executeEntityTypeRun = async ({
     }
   };
 
+  const alertsIndexExists = await runContext.esClient.indices.exists({
+    index: runConfig.alertsIndex,
+  });
+  if (!alertsIndexExists) {
+    runLogger.warn(
+      `Skipping risk scoring run: alerts index "${runConfig.alertsIndex}" does not exist yet.`
+    );
+    return;
+  }
+
   runLogger.debug('starting base scoring/reset pass');
   // Stage 1: score base entity risk and update lookup docs.
   const alertFilters = buildAlertFilters(runConfig.configuration, entityType, runLogger);


### PR DESCRIPTION
## Summary

The alerts index (`.alerts-security.alerts-<space>`) is lazily created on space setup, so it may not exist on the first risk scoring run after a space is created. Previously this resulted in a noisy `index_not_found_exception` error log.

This change adds a proactive existence check at the start of each per-entity-type scoring run. If the index is absent, the run is skipped with a `WARN` log and no error is surfaced.

### Before
```
[ERROR][plugins.securitySolution] [risk_score_maintainer][user][run:b2ee13ee] base scoring failed: index_not_found_exception
    Root causes:
        index_not_found_exception: no such index [.alerts-security.alerts-mark]
```

### After
```
[WARN][plugins.securitySolution] [risk_score_maintainer][user][run:b2ee13ee] Skipping risk scoring run: alerts index ".alerts-security.alerts-mark" does not exist yet.
```

## Testing

1. Create a new Kibana space
2. Enable the risk engine in that space
3. Observe that the first maintainer run logs a `WARN` instead of `ERROR`