### PR TITLE
[kbn-code-owners] Add `security-pds-deployment` team under `security` area

### DIFF
--- a/src/platform/packages/private/kbn-code-owners/src/code_owner_areas.ts
+++ b/src/platform/packages/private/kbn-code-owners/src/code_owner_areas.ts
@@ -83,6 +83,7 @@ export const CODE_OWNER_AREA_MAPPINGS: { [area in CodeOwnerArea]: string[] } = {
     'elastic/security-engineering-productivity',
     'elastic/security-entity-analytics',
     'elastic/security-generative-ai',
+    'elastic/security-pds-deployment',
     'elastic/security-service-integrations',
     'elastic/security-solution',
     'elastic/security-threat-hunting',


### PR DESCRIPTION
This PR adds the new [Security Deployment (Platform Delivery And Success) team](https://github.com/orgs/elastic/teams/security-pds-deployment) (`elastic/security-pds-deployment`) to our code owners <> solution area mapping.