### PR TITLE
i18n.translate stub to interpolate values in standalone side-navigation package

### DIFF
--- a/src/platform/kbn-ui/side-navigation/packaging/react/services/i18n.tsx
+++ b/src/platform/kbn-ui/side-navigation/packaging/react/services/i18n.tsx
@@ -18,12 +18,21 @@ import React from 'react';
  * and will render their `defaultMessage` values through this stub.
  */
 
-/** No-op `i18n.translate` that returns `defaultMessage`. */
+/** No-op `i18n.translate` that returns `defaultMessage` with interpolated values. */
 export const translate = (
   _id: string,
   options?: { defaultMessage?: string; values?: Record<string, unknown> }
 ) => {
-  return options?.defaultMessage ?? _id;
+  const msg = options?.defaultMessage ?? _id;
+
+  if (options?.values) {
+    return Object.entries(options.values).reduce(
+      (result, [key, val]) => result.replace(new RegExp(`\\{${key}\\}`, 'g'), String(val)),
+      msg
+    );
+  }
+
+  return msg;
 };
 
 /** No-op `FormattedMessage` component that renders `defaultMessage`. */


### PR DESCRIPTION
## Summary

The standalone `@kbn/ui-side-navigation` package bundles a stub implementation of `i18n.translate` for use outside of Kibana. This stub returns `defaultMessage` without interpolating `values`, causing `{label}` placeholders to appear literally in the DOM for several `aria-label` attributes and screen-reader instructions.

Affected aria-labels:
- `aria-label="{label} homepage"` (logo link)
- `aria-label="Side panel for {label}"` (side panel region)
- `"You are in the {label} secondary menu side panel..."` (screen-reader instructions)

The `FormattedMessage` component in the same stub file already performs `{key}` → `value` replacement correctly,  `translate` was the only function missing this logic.


### Fix

Added value interpolation to the `translate` stub in `packaging/react/services/i18n.tsx`, matching the existing `FormattedMessage` implementation.


## Testing

- Rebuilt the bundle locally and verified in a consumer app that all three `{label}` occurrences render correctly (e.g. `"Home homepage"`, `"Side panel for Organization"`)



