### PR TITLE
[Streams] Fix flaky Advanced tab Scout tests

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/fixtures/page_objects/streams_app.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/fixtures/page_objects/streams_app.ts
@@ -142,7 +142,10 @@ export class StreamsApp {
   }
 
   async gotoAdvancedTab(streamName: string) {
-    await this.gotoStreamManagementTab(streamName, 'advanced');
+    // Navigate to a stable tab first, then open Advanced to avoid races from direct URL nav
+    await this.gotoDataRetentionTab(streamName);
+    await this.page.getByRole('tab', { name: 'Advanced' }).click();
+    await this.page.waitForURL(/\/advanced/);
   }
 
   async gotoAttachmentsTab(streamName: string) {

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_advanced/license_basic.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_advanced/license_basic.spec.ts
@@ -58,11 +58,7 @@ test.describe('Advanced tab with basic license', { tag: [...tags.stateful.classi
     );
 
     await browserAuth.loginAsAdmin();
-    await pageObjects.streams.gotoDataRetentionTab(WIRED_STREAM);
-
-    // Navigate to the Advanced tab from a stable page to avoid race conditions
-    await page.getByRole('tab', { name: 'Advanced' }).click();
-    await page.waitForURL(/\/advanced/);
+    await pageObjects.streams.gotoAdvancedTab(WIRED_STREAM);
 
     // Verify the Advanced tab is visible
     await expect(page.getByRole('tab', { name: 'Advanced' })).toBeVisible();
@@ -103,11 +99,7 @@ test.describe('Advanced tab with basic license', { tag: [...tags.stateful.classi
     );
 
     await browserAuth.loginAsAdmin();
-    await pageObjects.streams.gotoDataRetentionTab(CLASSIC_STREAM);
-
-    // Navigate to the Advanced tab from a stable page to avoid race conditions
-    await page.getByRole('tab', { name: 'Advanced' }).click();
-    await page.waitForURL(/\/advanced/);
+    await pageObjects.streams.gotoAdvancedTab(CLASSIC_STREAM);
 
     // Verify the Advanced tab is visible
     await expect(page.getByRole('tab', { name: 'Advanced' })).toBeVisible();

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_advanced/license_basic.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_advanced/license_basic.spec.ts
@@ -21,8 +21,7 @@ const WIRED_STREAM = 'logs.otel';
  * The StreamDescription and StreamDiscoveryConfiguration components should not
  * render when the license doesn't support significant events features.
  */
-// Failing: See https://github.com/elastic/kibana/issues/263153
-test.describe.skip('Advanced tab with basic license', { tag: [...tags.stateful.classic] }, () => {
+test.describe('Advanced tab with basic license', { tag: [...tags.stateful.classic] }, () => {
   test.beforeAll(async ({ logsSynthtraceEsClient, apiServices }) => {
     // Generate logs to create a classic stream
     await generateLogsData(logsSynthtraceEsClient)({ index: CLASSIC_STREAM });
@@ -59,7 +58,11 @@ test.describe.skip('Advanced tab with basic license', { tag: [...tags.stateful.c
     );
 
     await browserAuth.loginAsAdmin();
-    await pageObjects.streams.gotoAdvancedTab(WIRED_STREAM);
+    await pageObjects.streams.gotoDataRetentionTab(WIRED_STREAM);
+
+    // Navigate to the Advanced tab from a stable page to avoid race conditions
+    await page.getByRole('tab', { name: 'Advanced' }).click();
+    await page.waitForURL(/\/advanced/);
 
     // Verify the Advanced tab is visible
     await expect(page.getByRole('tab', { name: 'Advanced' })).toBeVisible();
@@ -100,7 +103,11 @@ test.describe.skip('Advanced tab with basic license', { tag: [...tags.stateful.c
     );
 
     await browserAuth.loginAsAdmin();
-    await pageObjects.streams.gotoAdvancedTab(CLASSIC_STREAM);
+    await pageObjects.streams.gotoDataRetentionTab(CLASSIC_STREAM);
+
+    // Navigate to the Advanced tab from a stable page to avoid race conditions
+    await page.getByRole('tab', { name: 'Advanced' }).click();
+    await page.waitForURL(/\/advanced/);
 
     // Verify the Advanced tab is visible
     await expect(page.getByRole('tab', { name: 'Advanced' })).toBeVisible();

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_advanced/permissions_classic.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_advanced/permissions_classic.spec.ts
@@ -21,6 +21,11 @@ test.describe(
       await generateLogsData(logsSynthtraceEsClient)({ index: CLASSIC_STREAM });
     });
 
+    test.beforeEach(async ({ pageObjects }) => {
+      // Navigate to a stable tab first to avoid race conditions
+      await pageObjects.streams.gotoDataRetentionTab(CLASSIC_STREAM);
+    });
+
     test.afterAll(async ({ apiServices, logsSynthtraceEsClient }) => {
       await apiServices.streams.deleteStream(CLASSIC_STREAM);
       await logsSynthtraceEsClient.clean();
@@ -28,11 +33,10 @@ test.describe(
 
     test('should NOT show Advanced tab for viewer role on classic stream', async ({
       browserAuth,
-      pageObjects,
       page,
     }) => {
       await browserAuth.loginAsViewer();
-      await pageObjects.streams.gotoDataRetentionTab(CLASSIC_STREAM);
+      await page.reload();
 
       // Verify the Advanced tab is not visible for viewer
       await expect(page.getByRole('tab', { name: 'Advanced' })).toBeHidden();
@@ -40,11 +44,10 @@ test.describe(
 
     test('should NOT show Advanced tab for editor role on classic stream', async ({
       browserAuth,
-      pageObjects,
       page,
     }) => {
       await browserAuth.loginAs('editor');
-      await pageObjects.streams.gotoDataRetentionTab(CLASSIC_STREAM);
+      await page.reload();
 
       // Verify the Advanced tab is not visible for editor
       await expect(page.getByRole('tab', { name: 'Advanced' })).toBeHidden();
@@ -56,7 +59,7 @@ test.describe(
       page,
     }) => {
       await browserAuth.loginAsAdmin();
-      await pageObjects.streams.gotoAdvancedTab(CLASSIC_STREAM);
+      await page.reload();
 
       // Verify the Advanced tab is visible for admin
       await expect(page.getByRole('tab', { name: 'Advanced' })).toBeVisible();


### PR DESCRIPTION
Closes #263153
Closes #264160

## Summary

Both issues are caused by the same race condition: Playwright navigates directly to the `Advanced` management tab via URL, then immediately asserts on tab visibility. The React app still needs to:
1. Fetch stream definition via API
2. Evaluate privileges / license
3. Compute visible tabs
4. Render the EUI tab bar

On slow CI runners this window occasionally exceeds the 10s timeout — the screenshot shows the tab has appeared *just after* timeout.

## Fix

- **license_basic.spec.ts** (#263153): Unskip and replace `gotoAdvancedTab` (direct URL nav) with `gotoDataRetentionTab` + click the Advanced tab. The Retention tab is always present, so the page is fully stable before the click.
- **permissions_classic.spec.ts** (#264160): Align with the already-working `permissions_wired.spec.ts` pattern — navigate to Retention in `beforeEach`, then each test changes role, reloads, and asserts.

## Verify

- [ ] Scout CI for `streams_app` data_advanced tests
- [ ] on-merge / flaky-test-runner