### PR TITLE
[Inference] Consolidate model list retrieval

### DIFF
--- a/x-pack/platform/plugins/shared/search_inference_endpoints/server/inference_endpoints.test.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/server/inference_endpoints.test.ts
@@ -5,12 +5,7 @@
  * 2.0.
  */
 
-import type {
-  ISavedObjectsRepository,
-  IUiSettingsClient,
-  Logger,
-  SavedObject,
-} from '@kbn/core/server';
+import type { ISavedObjectsRepository, Logger, SavedObject } from '@kbn/core/server';
 import { SavedObjectsErrorHelpers } from '@kbn/core/server';
 import {
   type InferenceConnector,
@@ -18,14 +13,10 @@ import {
   defaultInferenceEndpoints,
 } from '@kbn/inference-common';
 import { loggingSystemMock } from '@kbn/core/server/mocks';
-import {
-  GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR,
-  GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR_DEFAULT_ONLY,
-} from '@kbn/management-settings-ids';
 import type { InferenceFeatureConfig } from './types';
 import type { InferenceSettingsAttributes } from '../common/types';
 import { InferenceFeatureRegistry } from './inference_feature_registry';
-import { getForFeature, getForFeatureWithDefault } from './inference_endpoints';
+import { getForFeature } from './inference_endpoints';
 
 const createValidFeature = (
   overrides: Partial<InferenceFeatureConfig> = {}
@@ -460,203 +451,6 @@ describe('getForFeature', () => {
       endpoints: [createConnector('gp_so')],
       warnings: [],
       soEntryFound: true,
-    });
-  });
-});
-
-interface UiSettings {
-  defaultConnectorId?: string;
-  defaultConnectorOnly?: boolean;
-}
-
-const createUiSettingsClient = ({
-  defaultConnectorId,
-  defaultConnectorOnly,
-}: UiSettings = {}): IUiSettingsClient =>
-  ({
-    get: jest.fn(async (key: string) => {
-      if (key === GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR) return defaultConnectorId;
-      if (key === GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR_DEFAULT_ONLY)
-        return defaultConnectorOnly ?? false;
-      return undefined;
-    }),
-  } as unknown as IUiSettingsClient);
-
-describe('getForFeatureWithDefault', () => {
-  let registry: InferenceFeatureRegistry;
-  let logger: Logger;
-
-  beforeEach(() => {
-    logger = loggingSystemMock.createLogger();
-    registry = new InferenceFeatureRegistry(logger);
-  });
-
-  it('returns only the default connector when defaultConnectorOnly is set', async () => {
-    registry.register(createValidFeature({ featureId: 'f1', recommendedEndpoints: ['rec1'] }));
-    const result = await getForFeatureWithDefault({
-      registry,
-      soClient: createSoClient(),
-      uiSettingsClient: createUiSettingsClient({
-        defaultConnectorId: 'default-id',
-        defaultConnectorOnly: true,
-      }),
-      getConnectorById: createGetConnectorById(['default-id', 'rec1']),
-      featureId: 'f1',
-      logger,
-    });
-    expect(result).toEqual({
-      endpoints: [createConnector('default-id')],
-      warnings: [],
-      soEntryFound: false,
-    });
-  });
-
-  it('returns an empty list when defaultConnectorOnly is set but no default is configured', async () => {
-    registry.register(createValidFeature({ featureId: 'f1', recommendedEndpoints: ['rec1'] }));
-    const result = await getForFeatureWithDefault({
-      registry,
-      soClient: createSoClient(),
-      uiSettingsClient: createUiSettingsClient({ defaultConnectorOnly: true }),
-      getConnectorById: createGetConnectorById(['rec1']),
-      featureId: 'f1',
-      logger,
-    });
-    expect(result).toEqual({ endpoints: [], warnings: [], soEntryFound: false });
-  });
-
-  it('returns an empty list when defaultConnectorOnly is set with the NO_DEFAULT_CONNECTOR sentinel', async () => {
-    registry.register(createValidFeature({ featureId: 'f1', recommendedEndpoints: ['rec1'] }));
-    const result = await getForFeatureWithDefault({
-      registry,
-      soClient: createSoClient(),
-      uiSettingsClient: createUiSettingsClient({
-        defaultConnectorId: 'NO_DEFAULT_CONNECTOR',
-        defaultConnectorOnly: true,
-      }),
-      getConnectorById: createGetConnectorById(['rec1']),
-      featureId: 'f1',
-      logger,
-    });
-    expect(result).toEqual({ endpoints: [], warnings: [], soEntryFound: false });
-  });
-
-  it('returns an empty list when defaultConnectorOnly is set but the default connector lookup fails', async () => {
-    registry.register(createValidFeature({ featureId: 'f1', recommendedEndpoints: ['rec1'] }));
-    const result = await getForFeatureWithDefault({
-      registry,
-      soClient: createSoClient(),
-      uiSettingsClient: createUiSettingsClient({
-        defaultConnectorId: 'missing',
-        defaultConnectorOnly: true,
-      }),
-      getConnectorById: createGetConnectorById(['rec1']),
-      featureId: 'f1',
-      logger,
-    });
-    expect(result).toEqual({ endpoints: [], warnings: [], soEntryFound: false });
-  });
-
-  it('prepends the default connector when no SO entry is found', async () => {
-    registry.register(createValidFeature({ featureId: 'f1', recommendedEndpoints: ['rec1'] }));
-    const result = await getForFeatureWithDefault({
-      registry,
-      soClient: createSoClient(),
-      uiSettingsClient: createUiSettingsClient({ defaultConnectorId: 'default-id' }),
-      getConnectorById: createGetConnectorById(['default-id', 'rec1']),
-      featureId: 'f1',
-      logger,
-    });
-    expect(result).toEqual({
-      endpoints: [createConnector('default-id'), createConnector('rec1')],
-      warnings: [],
-      soEntryFound: false,
-    });
-  });
-
-  it('deduplicates the default connector when already present in the resolved endpoints', async () => {
-    registry.register(
-      createValidFeature({ featureId: 'f1', recommendedEndpoints: ['default-id'] })
-    );
-    const result = await getForFeatureWithDefault({
-      registry,
-      soClient: createSoClient(),
-      uiSettingsClient: createUiSettingsClient({ defaultConnectorId: 'default-id' }),
-      getConnectorById: createGetConnectorById(['default-id']),
-      featureId: 'f1',
-      logger,
-    });
-    expect(result).toEqual({
-      endpoints: [createConnector('default-id')],
-      warnings: [],
-      soEntryFound: false,
-    });
-  });
-
-  it('ignores the default connector when an SO entry was found', async () => {
-    registry.register(createValidFeature({ featureId: 'f1' }));
-    const result = await getForFeatureWithDefault({
-      registry,
-      soClient: createSoClient([{ feature_id: 'f1', endpoints: [{ id: 'so_ep' }] }]),
-      uiSettingsClient: createUiSettingsClient({ defaultConnectorId: 'default-id' }),
-      getConnectorById: createGetConnectorById(['default-id', 'so_ep']),
-      featureId: 'f1',
-      logger,
-    });
-    expect(result).toEqual({
-      endpoints: [createConnector('so_ep')],
-      warnings: [],
-      soEntryFound: true,
-    });
-  });
-
-  it('ignores the NO_DEFAULT_CONNECTOR sentinel when resolving feature endpoints', async () => {
-    registry.register(createValidFeature({ featureId: 'f1', recommendedEndpoints: ['rec1'] }));
-    const result = await getForFeatureWithDefault({
-      registry,
-      soClient: createSoClient(),
-      uiSettingsClient: createUiSettingsClient({ defaultConnectorId: 'NO_DEFAULT_CONNECTOR' }),
-      getConnectorById: createGetConnectorById(['rec1']),
-      featureId: 'f1',
-      logger,
-    });
-    expect(result).toEqual({
-      endpoints: [createConnector('rec1')],
-      warnings: [],
-      soEntryFound: false,
-    });
-  });
-
-  it('returns the feature endpoints unchanged when the default connector lookup fails', async () => {
-    registry.register(createValidFeature({ featureId: 'f1', recommendedEndpoints: ['rec1'] }));
-    const result = await getForFeatureWithDefault({
-      registry,
-      soClient: createSoClient(),
-      uiSettingsClient: createUiSettingsClient({ defaultConnectorId: 'missing' }),
-      getConnectorById: createGetConnectorById(['rec1']),
-      featureId: 'f1',
-      logger,
-    });
-    expect(result).toEqual({
-      endpoints: [createConnector('rec1')],
-      warnings: [],
-      soEntryFound: false,
-    });
-  });
-
-  it('returns the feature endpoints when no default is configured', async () => {
-    registry.register(createValidFeature({ featureId: 'f1', recommendedEndpoints: ['rec1'] }));
-    const result = await getForFeatureWithDefault({
-      registry,
-      soClient: createSoClient(),
-      uiSettingsClient: createUiSettingsClient(),
-      getConnectorById: createGetConnectorById(['rec1']),
-      featureId: 'f1',
-      logger,
-    });
-    expect(result).toEqual({
-      endpoints: [createConnector('rec1')],
-      warnings: [],
-      soEntryFound: false,
     });
   });
 });

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/server/inference_endpoints.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/server/inference_endpoints.ts
@@ -5,20 +5,14 @@
  * 2.0.
  */
 
-import type { ISavedObjectsRepository, IUiSettingsClient, Logger } from '@kbn/core/server';
+import type { ISavedObjectsRepository, Logger } from '@kbn/core/server';
 import { SavedObjectsErrorHelpers } from '@kbn/core/server';
 import { i18n } from '@kbn/i18n';
 import { type InferenceConnector, defaultInferenceEndpoints } from '@kbn/inference-common';
-import {
-  GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR,
-  GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR_DEFAULT_ONLY,
-} from '@kbn/management-settings-ids';
 import { INFERENCE_SETTINGS_SO_TYPE, INFERENCE_SETTINGS_ID } from '../common/constants';
 import type { InferenceSettingsAttributes } from '../common/types';
 import type { InferenceFeatureRegistry } from './inference_feature_registry';
 import type { ResolvedInferenceEndpoints } from './types';
-
-const NO_DEFAULT_CONNECTOR = 'NO_DEFAULT_CONNECTOR';
 
 /**
  * Returns the resolved inference endpoints for a feature.
@@ -51,83 +45,6 @@ export const getForFeature = async (
     endpoints: result.endpoints,
     warnings: [...resolveWarnings, ...result.warnings],
     soEntryFound,
-  };
-};
-
-/**
- * Resolves endpoints for a feature and layers on the global default AI connector
- * configured via advanced settings (`GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR` and
- * `GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR_DEFAULT_ONLY`).
- *
- * - When `defaultOnly` is set, only the default connector is returned (or an empty list).
- * - When the feature has no admin-configured SO override, the default connector is
- *   prepended to the resolved endpoints.
- * - When an SO override exists for the feature, the default is ignored.
- *
- * Kept in sync with the HTTP route at `GET /internal/search_inference_endpoints/connectors`.
- */
-export const getForFeatureWithDefault = async ({
-  registry,
-  soClient,
-  uiSettingsClient,
-  getConnectorById,
-  featureId,
-  logger,
-}: {
-  registry: InferenceFeatureRegistry;
-  soClient: ISavedObjectsRepository;
-  uiSettingsClient: IUiSettingsClient;
-  getConnectorById: (id: string) => Promise<InferenceConnector>;
-  featureId: string;
-  logger: Logger;
-}): Promise<ResolvedInferenceEndpoints> => {
-  const [defaultConnectorId, defaultConnectorOnly] = await Promise.all([
-    uiSettingsClient.get<string>(GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR),
-    uiSettingsClient.get<boolean>(GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR_DEFAULT_ONLY),
-  ]);
-
-  const hasDefault =
-    typeof defaultConnectorId === 'string' &&
-    defaultConnectorId.length > 0 &&
-    defaultConnectorId !== NO_DEFAULT_CONNECTOR;
-
-  const fetchDefault = async (): Promise<InferenceConnector | undefined> => {
-    if (!hasDefault) return undefined;
-    try {
-      return await getConnectorById(defaultConnectorId);
-    } catch (e) {
-      logger.warn(`Failed to load default connector "${defaultConnectorId}": ${e.message}`);
-      return undefined;
-    }
-  };
-
-  if (defaultConnectorOnly) {
-    const defaultConnector = await fetchDefault();
-    return {
-      endpoints: defaultConnector ? [defaultConnector] : [],
-      warnings: [],
-      soEntryFound: false,
-    };
-  }
-
-  const result = await getForFeature(registry, soClient, getConnectorById, featureId, logger);
-
-  if (result.soEntryFound || !hasDefault) {
-    return result;
-  }
-
-  const defaultConnector = await fetchDefault();
-  if (!defaultConnector) {
-    return result;
-  }
-
-  return {
-    endpoints: [
-      defaultConnector,
-      ...result.endpoints.filter((c) => c.connectorId !== defaultConnector.connectorId),
-    ],
-    warnings: result.warnings,
-    soEntryFound: false,
   };
 };
 

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/server/lib/resolve_models_for_feature.test.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/server/lib/resolve_models_for_feature.test.ts
@@ -1,0 +1,354 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { IUiSettingsClient, Logger } from '@kbn/core/server';
+import { loggingSystemMock } from '@kbn/core/server/mocks';
+import { type InferenceConnector, InferenceConnectorType } from '@kbn/inference-common';
+import {
+  GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR,
+  GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR_DEFAULT_ONLY,
+} from '@kbn/management-settings-ids';
+import { resolveModelsForFeature } from './resolve_models_for_feature';
+import type { ResolvedInferenceEndpoints } from '../types';
+
+const inferenceConnector = (connectorId: string): InferenceConnector => ({
+  type: InferenceConnectorType.Inference,
+  name: connectorId,
+  connectorId,
+  config: {},
+  capabilities: {},
+  isInferenceEndpoint: true,
+  isPreconfigured: false,
+});
+
+interface UiSettings {
+  defaultConnectorId?: string;
+  defaultConnectorOnly?: boolean;
+}
+
+const createUiSettingsClient = ({
+  defaultConnectorId,
+  defaultConnectorOnly,
+}: UiSettings = {}): IUiSettingsClient =>
+  ({
+    get: jest.fn(async (key: string) => {
+      if (key === GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR) return defaultConnectorId;
+      if (key === GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR_DEFAULT_ONLY)
+        return defaultConnectorOnly ?? false;
+      return undefined;
+    }),
+  } as unknown as IUiSettingsClient);
+
+describe('resolveModelsForFeature', () => {
+  let logger: Logger;
+  let getForFeature: jest.Mock;
+  let getConnectorList: jest.Mock;
+  let getConnectorById: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    logger = loggingSystemMock.createLogger();
+    getForFeature = jest.fn();
+    getConnectorList = jest.fn();
+    getConnectorById = jest.fn();
+  });
+
+  const resolve = (uiSettings: UiSettings = {}, featureId = 'my_feature') =>
+    resolveModelsForFeature({
+      getForFeature,
+      getConnectorList,
+      getConnectorById,
+      uiSettingsClient: createUiSettingsClient(uiSettings),
+      featureId,
+      logger,
+    });
+
+  it('returns SO-configured endpoints as-is when soEntryFound is true', async () => {
+    const resolved = inferenceConnector('feature-ep');
+    getForFeature.mockResolvedValue({
+      endpoints: [resolved],
+      warnings: [],
+      soEntryFound: true,
+    } satisfies ResolvedInferenceEndpoints);
+    getConnectorList.mockResolvedValue([resolved, inferenceConnector('other')]);
+
+    const result = await resolve();
+
+    expect(result).toEqual({
+      connectors: [resolved],
+      warnings: [],
+      soEntryFound: true,
+    });
+  });
+
+  it('marks recommended endpoints with isRecommended and appends the rest of the catalog', async () => {
+    const recommended = inferenceConnector('rec-ep');
+    const other = inferenceConnector('noise');
+    getForFeature.mockResolvedValue({
+      endpoints: [recommended],
+      warnings: [],
+      soEntryFound: false,
+    });
+    getConnectorList.mockResolvedValue([recommended, other]);
+
+    const result = await resolve();
+
+    expect(result).toEqual({
+      connectors: [{ ...recommended, isRecommended: true }, other],
+      warnings: [],
+      soEntryFound: false,
+    });
+  });
+
+  it('returns the catalog alone when there are no recommendations or SO override', async () => {
+    const a = inferenceConnector('a');
+    const b = inferenceConnector('b');
+    getForFeature.mockResolvedValue({
+      endpoints: [],
+      warnings: [],
+      soEntryFound: false,
+    });
+    getConnectorList.mockResolvedValue([a, b]);
+
+    const result = await resolve();
+
+    expect(result).toEqual({
+      connectors: [a, b],
+      warnings: [],
+      soEntryFound: false,
+    });
+  });
+
+  it('returns an empty list when SO explicitly configures no endpoints', async () => {
+    getForFeature.mockResolvedValue({
+      endpoints: [],
+      warnings: [],
+      soEntryFound: true,
+    });
+    getConnectorList.mockResolvedValue([inferenceConnector('a')]);
+
+    const result = await resolve();
+
+    expect(result).toEqual({
+      connectors: [],
+      warnings: [],
+      soEntryFound: true,
+    });
+  });
+
+  it('returns only the default connector when defaultConnectorOnly is set', async () => {
+    const defaultConnector = inferenceConnector('default-id');
+    getConnectorById.mockResolvedValue(defaultConnector);
+
+    const result = await resolve({ defaultConnectorId: 'default-id', defaultConnectorOnly: true });
+
+    expect(getConnectorById).toHaveBeenCalledWith('default-id');
+    expect(getForFeature).not.toHaveBeenCalled();
+    expect(getConnectorList).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      connectors: [defaultConnector],
+      warnings: [],
+      soEntryFound: false,
+    });
+  });
+
+  it('returns an empty list when defaultConnectorOnly is set but no default is configured', async () => {
+    const result = await resolve({ defaultConnectorOnly: true });
+
+    expect(getConnectorById).not.toHaveBeenCalled();
+    expect(getForFeature).not.toHaveBeenCalled();
+    expect(getConnectorList).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      connectors: [],
+      warnings: [],
+      soEntryFound: false,
+    });
+  });
+
+  it('returns an empty list when defaultConnectorOnly is set but the default connector lookup fails', async () => {
+    getConnectorById.mockRejectedValue(new Error('Connector not found'));
+
+    const result = await resolve({ defaultConnectorId: 'missing', defaultConnectorOnly: true });
+
+    expect(result).toEqual({
+      connectors: [],
+      warnings: [],
+      soEntryFound: false,
+    });
+  });
+
+  it('returns an empty list when defaultConnectorOnly is set with the NO_DEFAULT_CONNECTOR sentinel', async () => {
+    const result = await resolve({
+      defaultConnectorId: 'NO_DEFAULT_CONNECTOR',
+      defaultConnectorOnly: true,
+    });
+
+    expect(getConnectorById).not.toHaveBeenCalled();
+    expect(result).toEqual({ connectors: [], warnings: [], soEntryFound: false });
+  });
+
+  it('prepends the default connector when soEntryFound is false and a default is configured', async () => {
+    const recommended = inferenceConnector('rec');
+    const other = inferenceConnector('other');
+    const defaultConnector = inferenceConnector('default');
+    getForFeature.mockResolvedValue({
+      endpoints: [recommended],
+      warnings: [],
+      soEntryFound: false,
+    });
+    getConnectorList.mockResolvedValue([recommended, other]);
+    getConnectorById.mockResolvedValue(defaultConnector);
+
+    const result = await resolve({ defaultConnectorId: 'default' });
+
+    expect(getConnectorById).toHaveBeenCalledWith('default');
+    expect(result).toEqual({
+      connectors: [defaultConnector, { ...recommended, isRecommended: true }, other],
+      warnings: [],
+      soEntryFound: false,
+    });
+  });
+
+  it('replaces an existing entry when the default connector is already in the merged list', async () => {
+    const recommended = inferenceConnector('rec');
+    const defaultInCatalog = inferenceConnector('default');
+    getForFeature.mockResolvedValue({
+      endpoints: [recommended],
+      warnings: [],
+      soEntryFound: false,
+    });
+    getConnectorList.mockResolvedValue([recommended, defaultInCatalog]);
+    getConnectorById.mockResolvedValue(defaultInCatalog);
+
+    const result = await resolve({ defaultConnectorId: 'default' });
+
+    expect(result).toEqual({
+      connectors: [defaultInCatalog, { ...recommended, isRecommended: true }],
+      warnings: [],
+      soEntryFound: false,
+    });
+  });
+
+  it('ignores the default connector when soEntryFound is true', async () => {
+    const resolved = inferenceConnector('feature-ep');
+    getForFeature.mockResolvedValue({
+      endpoints: [resolved],
+      warnings: [],
+      soEntryFound: true,
+    });
+    getConnectorList.mockResolvedValue([resolved]);
+
+    const result = await resolve({ defaultConnectorId: 'default' });
+
+    expect(getConnectorById).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      connectors: [resolved],
+      warnings: [],
+      soEntryFound: true,
+    });
+  });
+
+  it('returns the merged list without the default connector when its lookup fails', async () => {
+    const recommended = inferenceConnector('rec');
+    getForFeature.mockResolvedValue({
+      endpoints: [recommended],
+      warnings: [],
+      soEntryFound: false,
+    });
+    getConnectorList.mockResolvedValue([recommended]);
+    getConnectorById.mockRejectedValue(new Error('Default connector unavailable'));
+
+    const result = await resolve({ defaultConnectorId: 'default' });
+
+    expect(result).toEqual({
+      connectors: [{ ...recommended, isRecommended: true }],
+      warnings: [],
+      soEntryFound: false,
+    });
+  });
+
+  it('falls back to the catalog when getForFeature fails', async () => {
+    const a = inferenceConnector('a');
+    const b = inferenceConnector('b');
+    getForFeature.mockRejectedValue(new Error('SO unavailable'));
+    getConnectorList.mockResolvedValue([a, b]);
+
+    const result = await resolve();
+
+    expect(result).toEqual({
+      connectors: [a, b],
+      warnings: [],
+      soEntryFound: false,
+    });
+  });
+
+  it('falls back to the feature endpoints when getConnectorList fails', async () => {
+    const resolved = inferenceConnector('feature-ep');
+    getForFeature.mockResolvedValue({
+      endpoints: [resolved],
+      warnings: [],
+      soEntryFound: true,
+    });
+    getConnectorList.mockRejectedValue(new Error('Inference API unavailable'));
+
+    const result = await resolve();
+
+    expect(result).toEqual({
+      connectors: [resolved],
+      warnings: [],
+      soEntryFound: true,
+    });
+  });
+
+  it('returns an empty result when both getForFeature and getConnectorList fail', async () => {
+    getForFeature.mockRejectedValue(new Error('SO unavailable'));
+    getConnectorList.mockRejectedValue(new Error('Inference API unavailable'));
+
+    const result = await resolve();
+
+    expect(result).toEqual({
+      connectors: [],
+      warnings: [],
+      soEntryFound: false,
+    });
+  });
+
+  it('ignores the NO_DEFAULT_CONNECTOR sentinel when resolving feature endpoints', async () => {
+    const recommended = inferenceConnector('rec');
+    getForFeature.mockResolvedValue({
+      endpoints: [recommended],
+      warnings: [],
+      soEntryFound: false,
+    });
+    getConnectorList.mockResolvedValue([recommended]);
+
+    const result = await resolve({ defaultConnectorId: 'NO_DEFAULT_CONNECTOR' });
+
+    expect(getConnectorById).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      connectors: [{ ...recommended, isRecommended: true }],
+      warnings: [],
+      soEntryFound: false,
+    });
+  });
+
+  it('propagates warnings from getForFeature', async () => {
+    const recommended = inferenceConnector('rec');
+    getForFeature.mockResolvedValue({
+      endpoints: [recommended],
+      warnings: ['Inference endpoint "missing-ep" was not found in Elasticsearch.'],
+      soEntryFound: false,
+    });
+    getConnectorList.mockResolvedValue([recommended]);
+
+    const result = await resolve();
+
+    expect(result.warnings).toEqual([
+      'Inference endpoint "missing-ep" was not found in Elasticsearch.',
+    ]);
+  });
+});

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/server/lib/resolve_models_for_feature.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/server/lib/resolve_models_for_feature.ts
@@ -1,0 +1,112 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { IUiSettingsClient, Logger } from '@kbn/core/server';
+import type { InferenceConnector } from '@kbn/inference-common';
+import {
+  GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR,
+  GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR_DEFAULT_ONLY,
+} from '@kbn/management-settings-ids';
+import { mergeConnectors, type ApiInferenceConnector } from './merge_connectors';
+import type { ResolvedInferenceEndpoints } from '../types';
+
+const NO_DEFAULT_CONNECTOR = 'NO_DEFAULT_CONNECTOR';
+
+export interface ResolvedConnectorsForFeature {
+  connectors: ApiInferenceConnector[];
+  warnings: string[];
+  soEntryFound: boolean;
+}
+
+/**
+ * Resolves the full, ordered model list for a feature.
+ *
+ * The priority resolution is:
+ *   - If the default only setting is enabled, return just the default connector (or nothing if not set).
+ *   - If there's a saved object entry for the feature, return that list
+ *   - If there's a global default, return that and the feature-recommended models with isRecommended set to true, followed by the rest of the available models
+ *   - If there's no global default, return the feature-recommended models with isRecommended set to true, followed by the rest of the available models
+ *   - If there are no recommended models and no global default, return the full list of available models
+ *
+ * Used by both the `GET /internal/search_inference_endpoints/connectors`
+ * HTTP endpoint and the `endpoints.getForFeature` server-side contract.
+ *
+ * @param getForFeature  Resolves feature-specific endpoints (without the global default).
+ * @param getConnectorList  Returns the full connector catalog.
+ * @param getConnectorById  Fetches a single connector by ID (used for the global default).
+ * @param uiSettingsClient  Scoped UI-settings client to read the default connector setting.
+ * @param featureId  The feature to resolve connectors for.
+ * @param logger  Logger for warnings/errors.
+ */
+export const resolveModelsForFeature = async ({
+  getForFeature,
+  getConnectorList,
+  getConnectorById,
+  uiSettingsClient,
+  featureId,
+  logger,
+}: {
+  getForFeature: (featureId: string) => Promise<ResolvedInferenceEndpoints>;
+  getConnectorList: () => Promise<InferenceConnector[]>;
+  getConnectorById: (id: string) => Promise<InferenceConnector>;
+  uiSettingsClient: IUiSettingsClient;
+  featureId: string;
+  logger: Logger;
+}): Promise<ResolvedConnectorsForFeature> => {
+  const [defaultConnectorId, defaultConnectorOnly] = await Promise.all([
+    uiSettingsClient.get<string>(GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR),
+    uiSettingsClient.get<boolean>(GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR_DEFAULT_ONLY),
+  ]);
+
+  const fetchConnectorById = async (id: string): Promise<InferenceConnector | undefined> => {
+    try {
+      return await getConnectorById(id);
+    } catch (e) {
+      logger.warn(`Failed to load default connector "${id}": ${e.message}`);
+      return undefined;
+    }
+  };
+
+  if (defaultConnectorOnly) {
+    if (!defaultConnectorId || defaultConnectorId === NO_DEFAULT_CONNECTOR) {
+      return { connectors: [], warnings: [], soEntryFound: false };
+    }
+    const connector = await fetchConnectorById(defaultConnectorId);
+    return {
+      connectors: connector ? [connector] : [],
+      warnings: [],
+      soEntryFound: false,
+    };
+  }
+
+  const [featureResult, allConnectors] = await Promise.all([
+    getForFeature(featureId).catch((e): ResolvedInferenceEndpoints => {
+      logger.error(`Failed to resolve endpoints for feature "${featureId}": ${e.message}`);
+      return { endpoints: [], warnings: [], soEntryFound: false };
+    }),
+    getConnectorList().catch((e): InferenceConnector[] => {
+      logger.error(`Failed to load connector list: ${e.message}`);
+      return [];
+    }),
+  ]);
+
+  const { soEntryFound } = featureResult;
+  const merged = mergeConnectors(featureResult.endpoints, allConnectors, soEntryFound);
+
+  let connectors: ApiInferenceConnector[] = merged;
+  if (!soEntryFound && defaultConnectorId && defaultConnectorId !== NO_DEFAULT_CONNECTOR) {
+    const defaultConnector = await fetchConnectorById(defaultConnectorId);
+    if (defaultConnector) {
+      connectors = [
+        defaultConnector,
+        ...merged.filter((c) => c.connectorId !== defaultConnectorId),
+      ];
+    }
+  }
+
+  return { connectors, warnings: featureResult.warnings, soEntryFound };
+};

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/server/plugin.ts
@@ -20,10 +20,8 @@ import type { SearchInferenceEndpointsConfig } from './config';
 import { DynamicConnectorsPoller } from './lib/dynamic_connectors';
 import { defineRoutes } from './routes';
 import { InferenceFeatureRegistry } from './inference_feature_registry';
-import {
-  getForFeature as getForFeatureFn,
-  getForFeatureWithDefault as getForFeatureWithDefaultFn,
-} from './inference_endpoints';
+import { getForFeature as getForFeatureFn } from './inference_endpoints';
+import { resolveModelsForFeature } from './lib/resolve_models_for_feature';
 import { createInferenceSettingsSavedObjectType } from './saved_objects/inference_settings';
 import type {
   SearchInferenceEndpointsPluginSetup,
@@ -180,20 +178,30 @@ export class SearchInferenceEndpointsPlugin
         register: featureRegistry.register.bind(featureRegistry),
       },
       endpoints: {
-        getForFeature: (featureId: string, request: KibanaRequest) => {
+        getForFeature: async (featureId: string, request: KibanaRequest) => {
           const soClient = core.savedObjects.createInternalRepository([INFERENCE_SETTINGS_SO_TYPE]);
           const uiSettingsClient = core.uiSettings.asScopedToClient(
             core.savedObjects.getScopedClient(request)
           );
           const getConnectorById = (id: string) => plugins.inference.getConnectorById(id, request);
-          return getForFeatureWithDefaultFn({
-            registry: featureRegistry,
-            soClient,
-            uiSettingsClient,
+          const resolveFeatureEndpoints = (fId: string) =>
+            getForFeatureFn(featureRegistry, soClient, getConnectorById, fId, this.logger);
+          const getConnectorList = () => plugins.inference.getConnectorList(request);
+
+          const result = await resolveModelsForFeature({
+            getForFeature: resolveFeatureEndpoints,
+            getConnectorList,
             getConnectorById,
+            uiSettingsClient,
             featureId,
             logger: this.logger,
           });
+
+          return {
+            endpoints: result.connectors,
+            warnings: result.warnings,
+            soEntryFound: result.soEntryFound,
+          };
         },
       },
     };

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/server/routes/inference_connectors.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/server/routes/inference_connectors.ts
@@ -8,15 +8,11 @@
 import type { IRouter, KibanaRequest, Logger } from '@kbn/core/server';
 import { schema } from '@kbn/config-schema';
 import type { InferenceConnector } from '@kbn/inference-common';
-import {
-  GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR,
-  GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR_DEFAULT_ONLY,
-} from '@kbn/management-settings-ids';
 import { APIRoutes } from '../../common/types';
 import { ROUTE_VERSIONS } from '../../common/constants';
 import type { ResolvedInferenceEndpoints } from '../types';
 import { errorHandler } from '../utils/error_handler';
-import { mergeConnectors, type ApiInferenceConnector } from '../lib/merge_connectors';
+import { resolveModelsForFeature } from '../lib/resolve_models_for_feature';
 
 export const defineInferenceConnectorsRoute = ({
   logger,
@@ -62,62 +58,20 @@ export const defineInferenceConnectorsRoute = ({
       errorHandler(logger)(async (context, request, response) => {
         const { featureId } = request.query;
         const uiSettingsClient = (await context.core).uiSettings.client;
-        const [defaultConnectorId, defaultConnectorOnly] = await Promise.all([
-          uiSettingsClient.get<string>(GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR),
-          uiSettingsClient.get<boolean>(GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR_DEFAULT_ONLY),
-        ]);
 
-        const fetchConnectorById = async (id: string): Promise<InferenceConnector | undefined> => {
-          try {
-            return await getConnectorById(id, request);
-          } catch (e) {
-            logger.warn(`Failed to load default connector "${id}": ${e.message}`);
-            return undefined;
-          }
-        };
-
-        if (defaultConnectorOnly) {
-          if (!defaultConnectorId || defaultConnectorId === 'NO_DEFAULT_CONNECTOR') {
-            return response.ok({ body: { connectors: [], soEntryFound: false } });
-          }
-          const connector = await fetchConnectorById(defaultConnectorId);
-          return response.ok({
-            body: {
-              connectors: connector ? [connector] : [],
-              soEntryFound: false,
-            },
-          });
-        }
-
-        const [featureResult, allConnectors] = await Promise.all([
-          getForFeature(featureId, request).catch((e): ResolvedInferenceEndpoints => {
-            logger.error(`Failed to resolve endpoints for feature "${featureId}": ${e.message}`);
-            return { endpoints: [], warnings: [], soEntryFound: false };
-          }),
-          getConnectorList(request).catch((e): InferenceConnector[] => {
-            logger.error(`Failed to load connector list: ${e.message}`);
-            return [];
-          }),
-        ]);
-
-        const { soEntryFound } = featureResult;
-        const merged = mergeConnectors(featureResult.endpoints, allConnectors, soEntryFound);
-
-        let connectors: ApiInferenceConnector[] = merged;
-        if (!soEntryFound && defaultConnectorId && defaultConnectorId !== 'NO_DEFAULT_CONNECTOR') {
-          const defaultConnector = await fetchConnectorById(defaultConnectorId);
-          if (defaultConnector) {
-            connectors = [
-              defaultConnector,
-              ...merged.filter((c) => c.connectorId !== defaultConnectorId),
-            ];
-          }
-        }
+        const result = await resolveModelsForFeature({
+          getForFeature: (fId) => getForFeature(fId, request),
+          getConnectorList: () => getConnectorList(request),
+          getConnectorById: (id) => getConnectorById(id, request),
+          uiSettingsClient,
+          featureId,
+          logger,
+        });
 
         return response.ok({
           body: {
-            connectors,
-            soEntryFound,
+            connectors: result.connectors,
+            soEntryFound: result.soEntryFound,
           },
         });
       })


### PR DESCRIPTION
## Summary 

Replaces the duplicated default-connector + recommended-endpoint merge logic in `getForFeatureWithDefault` and the
`GET /internal/search_inference_endpoints/connectors` route with a single `resolveModelsForFeature` helper. Both the plugin's `endpoints.getForFeature` contract and the HTTP route now go through this helper.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->