### PR TITLE
[9.4] [Discover][Metrics]: Implement dimension pruning on ds switch to avoid unexpected errors (#265464)

### DIFF
--- a/src/platform/packages/shared/kbn-scout/src/playwright/page_objects/discover_app.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/page_objects/discover_app.ts
@@ -14,7 +14,7 @@ import { expect } from '..';
 import { KibanaCodeEditorWrapper } from '../ui_components';
 
 export class DiscoverApp {
-  private readonly codeEditor: KibanaCodeEditorWrapper;
+  public readonly codeEditor: KibanaCodeEditorWrapper;
 
   constructor(private readonly page: ScoutPage) {
     this.codeEditor = new KibanaCodeEditorWrapper(page);

--- a/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/observability/metrics/hooks/index.ts
+++ b/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/observability/metrics/hooks/index.ts
@@ -12,3 +12,4 @@ export { useMetricsGridFullScreen } from './use_metrics_grid_fullscreen';
 export { useMetricFieldsFilter } from './use_metric_fields_filter';
 export { useDiscoverFieldForBreakdown } from './use_discover_field_for_breakdown';
 export { useFetchMetricsData } from './use_fetch_metrics_data';
+export { useDimensionsWipe } from './use_dimensions_wipe';

--- a/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/observability/metrics/hooks/use_dimensions_wipe.test.ts
+++ b/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/observability/metrics/hooks/use_dimensions_wipe.test.ts
@@ -1,0 +1,333 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { renderHook } from '@testing-library/react';
+import type { Dimension } from '../../../../types';
+import { useDimensionsWipe, type UseDimensionsWipeParams } from './use_dimensions_wipe';
+
+const dim = (name: string): Dimension => ({ name });
+
+const baseParams = (overrides: Partial<UseDimensionsWipeParams> = {}): UseDimensionsWipeParams => ({
+  selectedDimensions: [dim('host.name'), dim('environment')],
+  allDimensions: [dim('host.name')],
+  isLoading: false,
+  hasError: false,
+  breakdownField: undefined,
+  onSelectedDimensionsChange: jest.fn(),
+  onBreakdownFieldChange: jest.fn(),
+  ...overrides,
+});
+
+describe('useDimensionsWipe', () => {
+  describe('on a fresh, successful response', () => {
+    it('prunes selectedDimensions to the intersection with allDimensions', () => {
+      const onSelectedDimensionsChange = jest.fn();
+      renderHook(() => useDimensionsWipe(baseParams({ onSelectedDimensionsChange })));
+
+      expect(onSelectedDimensionsChange).toHaveBeenCalledTimes(1);
+      expect(onSelectedDimensionsChange).toHaveBeenCalledWith([dim('host.name')]);
+    });
+
+    it('calls onSelectedDimensionsChange with an empty array when no selection survives', () => {
+      const onSelectedDimensionsChange = jest.fn();
+      renderHook(() =>
+        useDimensionsWipe(
+          baseParams({
+            selectedDimensions: [dim('environment')],
+            allDimensions: [dim('host.name')],
+            onSelectedDimensionsChange,
+          })
+        )
+      );
+
+      expect(onSelectedDimensionsChange).toHaveBeenCalledTimes(1);
+      expect(onSelectedDimensionsChange).toHaveBeenCalledWith([]);
+    });
+
+    it('does not call any callback when every selection is already in the universe', () => {
+      const onSelectedDimensionsChange = jest.fn();
+      const onBreakdownFieldChange = jest.fn();
+      renderHook(() =>
+        useDimensionsWipe(
+          baseParams({
+            selectedDimensions: [dim('host.name')],
+            allDimensions: [dim('host.name'), dim('environment')],
+            onSelectedDimensionsChange,
+            onBreakdownFieldChange,
+          })
+        )
+      );
+
+      expect(onSelectedDimensionsChange).not.toHaveBeenCalled();
+      expect(onBreakdownFieldChange).not.toHaveBeenCalled();
+    });
+
+    it('does not call any callback when there are no selected dimensions', () => {
+      const onSelectedDimensionsChange = jest.fn();
+      const onBreakdownFieldChange = jest.fn();
+      renderHook(() =>
+        useDimensionsWipe(
+          baseParams({
+            selectedDimensions: [],
+            onSelectedDimensionsChange,
+            onBreakdownFieldChange,
+          })
+        )
+      );
+
+      expect(onSelectedDimensionsChange).not.toHaveBeenCalled();
+      expect(onBreakdownFieldChange).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('breakdown propagation', () => {
+    it('does not change the breakdown when the current one survives the prune', () => {
+      const onSelectedDimensionsChange = jest.fn();
+      const onBreakdownFieldChange = jest.fn();
+      renderHook(() =>
+        useDimensionsWipe(
+          baseParams({
+            selectedDimensions: [dim('host.name'), dim('environment'), dim('container.id')],
+            allDimensions: [dim('host.name'), dim('container.id')],
+            breakdownField: 'container.id',
+            onSelectedDimensionsChange,
+            onBreakdownFieldChange,
+          })
+        )
+      );
+
+      expect(onSelectedDimensionsChange).toHaveBeenCalledWith([
+        dim('host.name'),
+        dim('container.id'),
+      ]);
+      expect(onBreakdownFieldChange).not.toHaveBeenCalled();
+    });
+
+    it('falls back to pruned[0]?.name when the current breakdown does not survive', () => {
+      const onBreakdownFieldChange = jest.fn();
+      renderHook(() =>
+        useDimensionsWipe(
+          baseParams({
+            selectedDimensions: [dim('environment'), dim('host.name')],
+            allDimensions: [dim('host.name')],
+            breakdownField: 'environment',
+            onBreakdownFieldChange,
+          })
+        )
+      );
+
+      expect(onBreakdownFieldChange).toHaveBeenCalledTimes(1);
+      expect(onBreakdownFieldChange).toHaveBeenCalledWith('host.name');
+    });
+
+    it('clears the breakdown when no selection survives the prune', () => {
+      const onBreakdownFieldChange = jest.fn();
+      renderHook(() =>
+        useDimensionsWipe(
+          baseParams({
+            selectedDimensions: [dim('environment')],
+            allDimensions: [dim('host.name')],
+            breakdownField: 'environment',
+            onBreakdownFieldChange,
+          })
+        )
+      );
+
+      expect(onBreakdownFieldChange).toHaveBeenCalledWith(undefined);
+    });
+
+    it('proposes a new default breakdown when there was none and a prune happens', () => {
+      const onBreakdownFieldChange = jest.fn();
+      renderHook(() =>
+        useDimensionsWipe(
+          baseParams({
+            selectedDimensions: [dim('host.name'), dim('environment')],
+            allDimensions: [dim('host.name')],
+            breakdownField: undefined,
+            onBreakdownFieldChange,
+          })
+        )
+      );
+
+      expect(onBreakdownFieldChange).toHaveBeenCalledWith('host.name');
+    });
+
+    it('does not require onBreakdownFieldChange', () => {
+      const onSelectedDimensionsChange = jest.fn();
+      expect(() =>
+        renderHook(() =>
+          useDimensionsWipe(
+            baseParams({
+              breakdownField: 'environment',
+              onSelectedDimensionsChange,
+              onBreakdownFieldChange: undefined,
+            })
+          )
+        )
+      ).not.toThrow();
+      expect(onSelectedDimensionsChange).toHaveBeenCalledWith([dim('host.name')]);
+    });
+  });
+
+  describe('gates', () => {
+    it('does not act while a fetch is in flight (allDimensions can be stale)', () => {
+      const onSelectedDimensionsChange = jest.fn();
+      const onBreakdownFieldChange = jest.fn();
+      renderHook(() =>
+        useDimensionsWipe(
+          baseParams({ isLoading: true, onSelectedDimensionsChange, onBreakdownFieldChange })
+        )
+      );
+
+      expect(onSelectedDimensionsChange).not.toHaveBeenCalled();
+      expect(onBreakdownFieldChange).not.toHaveBeenCalled();
+    });
+
+    it('does not act when the last fetch errored', () => {
+      const onSelectedDimensionsChange = jest.fn();
+      const onBreakdownFieldChange = jest.fn();
+      renderHook(() =>
+        useDimensionsWipe(
+          baseParams({ hasError: true, onSelectedDimensionsChange, onBreakdownFieldChange })
+        )
+      );
+
+      expect(onSelectedDimensionsChange).not.toHaveBeenCalled();
+      expect(onBreakdownFieldChange).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('reactivity', () => {
+    it('fires the wipe when allDimensions changes to expose a new orphan', () => {
+      const onSelectedDimensionsChange = jest.fn();
+      const onBreakdownFieldChange = jest.fn();
+      const selectedDimensions = [dim('host.name'), dim('environment')];
+
+      const { rerender } = renderHook(
+        ({ allDimensions }: { allDimensions: Dimension[] }) =>
+          useDimensionsWipe(
+            baseParams({
+              selectedDimensions,
+              allDimensions,
+              breakdownField: 'environment',
+              onSelectedDimensionsChange,
+              onBreakdownFieldChange,
+            })
+          ),
+        { initialProps: { allDimensions: [dim('host.name'), dim('environment')] } }
+      );
+      expect(onSelectedDimensionsChange).not.toHaveBeenCalled();
+
+      rerender({ allDimensions: [dim('host.name')] });
+
+      expect(onSelectedDimensionsChange).toHaveBeenCalledTimes(1);
+      expect(onSelectedDimensionsChange).toHaveBeenCalledWith([dim('host.name')]);
+      expect(onBreakdownFieldChange).toHaveBeenCalledWith('host.name');
+    });
+
+    it('fires the wipe when transitioning from loading to a successful response', () => {
+      const onSelectedDimensionsChange = jest.fn();
+      const selectedDimensions = [dim('host.name'), dim('environment')];
+      const allDimensions = [dim('host.name')];
+
+      const { rerender } = renderHook(
+        ({ isLoading }: { isLoading: boolean }) =>
+          useDimensionsWipe(
+            baseParams({
+              selectedDimensions,
+              allDimensions,
+              isLoading,
+              onSelectedDimensionsChange,
+            })
+          ),
+        { initialProps: { isLoading: true } }
+      );
+      expect(onSelectedDimensionsChange).not.toHaveBeenCalled();
+
+      rerender({ isLoading: false });
+
+      expect(onSelectedDimensionsChange).toHaveBeenCalledTimes(1);
+    });
+
+    it('fires the wipe when transitioning from error to a successful response', () => {
+      const onSelectedDimensionsChange = jest.fn();
+      const selectedDimensions = [dim('host.name'), dim('environment')];
+      const allDimensions = [dim('host.name')];
+
+      const { rerender } = renderHook(
+        ({ hasError }: { hasError: boolean }) =>
+          useDimensionsWipe(
+            baseParams({
+              selectedDimensions,
+              allDimensions,
+              hasError,
+              onSelectedDimensionsChange,
+            })
+          ),
+        { initialProps: { hasError: true } }
+      );
+      expect(onSelectedDimensionsChange).not.toHaveBeenCalled();
+
+      rerender({ hasError: false });
+
+      expect(onSelectedDimensionsChange).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not fire when only breakdownField changes and there are no orphans', () => {
+      const onSelectedDimensionsChange = jest.fn();
+      const onBreakdownFieldChange = jest.fn();
+      const selectedDimensions = [dim('host.name')];
+      const allDimensions = [dim('host.name')];
+
+      const { rerender } = renderHook(
+        ({ breakdownField }: { breakdownField: string | undefined }) =>
+          useDimensionsWipe(
+            baseParams({
+              selectedDimensions,
+              allDimensions,
+              breakdownField,
+              onSelectedDimensionsChange,
+              onBreakdownFieldChange,
+            })
+          ),
+        { initialProps: { breakdownField: 'host.name' as string | undefined } }
+      );
+      expect(onSelectedDimensionsChange).not.toHaveBeenCalled();
+
+      rerender({ breakdownField: undefined });
+
+      expect(onSelectedDimensionsChange).not.toHaveBeenCalled();
+      expect(onBreakdownFieldChange).not.toHaveBeenCalled();
+    });
+
+    it('does not fire again when only unrelated inputs change (deps stay equal)', () => {
+      const onSelectedDimensionsChange = jest.fn();
+      const selectedDimensions = [dim('host.name')];
+      const allDimensions = [dim('host.name')];
+
+      const { rerender } = renderHook(
+        ({ isLoading }: { isLoading: boolean }) =>
+          useDimensionsWipe(
+            baseParams({
+              selectedDimensions,
+              allDimensions,
+              isLoading,
+              onSelectedDimensionsChange,
+            })
+          ),
+        { initialProps: { isLoading: false } }
+      );
+      expect(onSelectedDimensionsChange).not.toHaveBeenCalled();
+
+      rerender({ isLoading: false });
+
+      expect(onSelectedDimensionsChange).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/observability/metrics/hooks/use_dimensions_wipe.ts
+++ b/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/observability/metrics/hooks/use_dimensions_wipe.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { useEffect } from 'react';
+import type { Dimension } from '../../../../types';
+
+export interface UseDimensionsWipeParams {
+  /** What the user wants (intent), as persisted in `useMetricsExperienceState`. */
+  selectedDimensions: Dimension[];
+  /** What the active stream actually emits (from `METRICS_INFO`). */
+  allDimensions: Dimension[];
+  /** Skip while a fetch is in flight; `allDimensions` may still be from the previous stream. */
+  isLoading: boolean;
+  /** Skip when the last fetch errored; pruning would discard intent based on invalid data. */
+  hasError: boolean;
+  /**
+   * Discover's current breakdown field. Used to decide whether the wipe
+   * needs to update it: if the current breakdown survives the prune we
+   * leave it untouched.
+   */
+  breakdownField: string | undefined;
+  /** Called with the pruned subset of `selectedDimensions`. */
+  onSelectedDimensionsChange: (pruned: Dimension[]) => void;
+  /**
+   * Called only when the current `breakdownField` does NOT survive the
+   * prune. Receives the new default (`pruned[0]?.name`, possibly
+   * `undefined`).
+   */
+  onBreakdownFieldChange?: (next: string | undefined) => void;
+}
+
+/**
+ * Wipe orphan selections when the active stream changes.
+ *
+ * The grid keeps `selectedDimensions` (intent) in URL state, persisted
+ * across stream switches. After a successful `METRICS_INFO` fetch we know
+ * the per-stream universe (`allDimensions`); any selection outside that
+ * universe is pruned. If the current `breakdownField` no longer maps to a
+ * surviving selection, we also propose a new default to Discover.
+ *
+ * We only act on a fresh, successful response (gates on `isLoading` and
+ * `hasError`) to avoid discarding intent based on stale or invalid data.
+ */
+export function useDimensionsWipe({
+  selectedDimensions,
+  allDimensions,
+  isLoading,
+  hasError,
+  breakdownField,
+  onSelectedDimensionsChange,
+  onBreakdownFieldChange,
+}: UseDimensionsWipeParams): void {
+  useEffect(() => {
+    if (isLoading || hasError || selectedDimensions.length === 0) {
+      return;
+    }
+    const pruned = selectedDimensions.filter((dimension) =>
+      allDimensions.some((available) => available.name === dimension.name)
+    );
+    if (pruned.length === selectedDimensions.length) {
+      return;
+    }
+    onSelectedDimensionsChange(pruned);
+
+    const breakdownSurvived =
+      breakdownField != null && pruned.some((dimension) => dimension.name === breakdownField);
+    if (!breakdownSurvived) {
+      onBreakdownFieldChange?.(pruned[0]?.name);
+    }
+  }, [
+    allDimensions,
+    selectedDimensions,
+    isLoading,
+    hasError,
+    breakdownField,
+    onSelectedDimensionsChange,
+    onBreakdownFieldChange,
+  ]);
+}

--- a/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/observability/metrics/hooks/use_fetch_metrics_data.test.ts
+++ b/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/observability/metrics/hooks/use_fetch_metrics_data.test.ts
@@ -78,7 +78,10 @@ const createDefaultParams = (overrides?: Record<string, unknown>) => ({
   fetchParams: getFetchParamsMock({
     query: { esql: 'TS metrics-*' },
     dataView: {
-      getFieldByName: jest.fn(),
+      // Default to "every requested field exists" so the appliedDimensions
+      // derivation in useFetchMetricsData (#264957) is a no-op for existing
+      // tests. Tests that exercise the prune behavior override this per-test.
+      getFieldByName: jest.fn((name: string) => ({ name })),
       getIndexPattern: () => 'metrics-*',
       isTimeBased: () => true,
     } as any,
@@ -463,6 +466,133 @@ describe('useFetchMetricsData', () => {
       await waitFor(() => {
         expect(mockExecuteEsqlQuery).toHaveBeenCalledTimes(2);
       });
+    });
+  });
+
+  describe('appliedDimensions vs selectedDimensions (#264957)', () => {
+    const { buildMetricsInfoQuery: buildMetricsInfoQueryMock } = jest.requireMock(
+      '@kbn/esql-utils'
+    ) as { buildMetricsInfoQuery: jest.Mock };
+
+    it('passes no dimensions to the query when none of the selected ones exist on the current data view', async () => {
+      const params = createDefaultParams();
+      params.selectedDimensionNames = [hostDimension];
+      // Stream B does not carry `host.name` — simulate the issue scenario.
+      (params.fetchParams.dataView as any).getFieldByName = jest.fn(() => undefined);
+
+      const { result } = renderHook(() => useFetchMetricsData(params));
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(buildMetricsInfoQueryMock).toHaveBeenLastCalledWith('TS metrics-*', []);
+      expect(result.current.activeDimensions).toEqual([]);
+      // Intent must not be mutated — the caller still sees the original array.
+      expect(params.selectedDimensionNames).toEqual([hostDimension]);
+    });
+
+    it('keeps only the subset of selected dimensions that exist on the current data view', async () => {
+      const params = createDefaultParams();
+      params.selectedDimensionNames = [hostDimension, serviceDimension];
+      // Only `host.name` exists on the current data view.
+      (params.fetchParams.dataView as any).getFieldByName = jest.fn((name: string) =>
+        name === 'host.name' ? { name } : undefined
+      );
+
+      const { result } = renderHook(() => useFetchMetricsData(params));
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(buildMetricsInfoQueryMock).toHaveBeenLastCalledWith('TS metrics-*', ['host.name']);
+      expect(result.current.activeDimensions).toEqual([hostDimension]);
+    });
+
+    it('passes all selected dimensions when they all exist on the current data view', async () => {
+      const params = createDefaultParams();
+      params.selectedDimensionNames = [hostDimension, serviceDimension];
+      // Default mock returns a stub field for every requested name.
+
+      const { result } = renderHook(() => useFetchMetricsData(params));
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(buildMetricsInfoQueryMock).toHaveBeenLastCalledWith('TS metrics-*', [
+        'host.name',
+        'service.name',
+      ]);
+      expect(result.current.activeDimensions).toEqual([hostDimension, serviceDimension]);
+    });
+
+    it('does not validate when dataView is undefined (fetch is already gated by shouldFetch)', async () => {
+      const params = createDefaultParams({ dataView: undefined });
+      params.selectedDimensionNames = [hostDimension];
+
+      renderHook(() => useFetchMetricsData(params));
+
+      await act(async () => {
+        await new Promise((r) => setTimeout(r, 50));
+      });
+
+      // No fetch happens because the effect bails out when dataView is missing.
+      expect(mockExecuteEsqlQuery).not.toHaveBeenCalled();
+    });
+
+    it('does not invoke getFieldByName when there are no selected dimensions', async () => {
+      const params = createDefaultParams();
+      const getFieldByName = jest.fn((name: string) => ({ name }));
+      (params.fetchParams.dataView as any).getFieldByName = getFieldByName;
+
+      const { result } = renderHook(() => useFetchMetricsData(params));
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      // The validation memo short-circuits when selectedDimensionNames is empty/undefined,
+      // so getFieldByName is only reached by the unrelated getFieldType helper inside the
+      // parser (which doesn't run for the empty document set used here).
+      expect(getFieldByName).not.toHaveBeenCalled();
+      expect(result.current.activeDimensions).toEqual([]);
+    });
+
+    it('refetches when the applied set changes after a data view switch', async () => {
+      const params = createDefaultParams();
+      params.selectedDimensionNames = [hostDimension];
+
+      const { rerender } = renderHook(
+        (props: ReturnType<typeof createDefaultParams>) => useFetchMetricsData(props),
+        { initialProps: params }
+      );
+
+      await waitFor(() => {
+        expect(mockExecuteEsqlQuery).toHaveBeenCalledTimes(1);
+      });
+
+      // Switch to a data view that doesn't carry `host.name` — same intent,
+      // different applied set, so we expect a refetch with the pruned dimensions.
+      const switchedParams = {
+        ...params,
+        fetchParams: {
+          ...params.fetchParams,
+          dataView: {
+            getFieldByName: jest.fn(() => undefined),
+            getIndexPattern: () => 'metrics-*',
+            isTimeBased: () => true,
+          } as any,
+        },
+      };
+      rerender(switchedParams);
+
+      await waitFor(() => {
+        expect(mockExecuteEsqlQuery).toHaveBeenCalledTimes(2);
+      });
+
+      expect(buildMetricsInfoQueryMock).toHaveBeenLastCalledWith('TS metrics-*', []);
     });
   });
 

--- a/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/observability/metrics/hooks/use_fetch_metrics_data.ts
+++ b/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/observability/metrics/hooks/use_fetch_metrics_data.ts
@@ -40,14 +40,28 @@ export function useFetchMetricsData({
 
   const shouldFetch = isComponentVisible && !!esql && !hasTransformationalCommand(esql);
 
-  const selectedDimensions = useMemo(
-    () => selectedDimensionNames?.map((dimension) => dimension.name),
-    [selectedDimensionNames]
+  // Pre-fetch defense against dimensions the active stream does not map.
+  // Pushing a field name that is not in the dataView into the
+  // `WHERE TO_STRING(field) IS NOT NULL` clause breaks the query and surfaces
+  // "Unable to load visualization". The post-fetch state wipe (against
+  // `allDimensions`) lives in `MetricsExperienceGrid` via `useDimensionsWipe`.
+  const appliedDimensions = useMemo(() => {
+    if (!selectedDimensionNames?.length || !fetchParams.dataView) {
+      return selectedDimensionNames;
+    }
+    return selectedDimensionNames.filter(
+      (dimension) => fetchParams.dataView!.getFieldByName(dimension.name) != null
+    );
+  }, [selectedDimensionNames, fetchParams.dataView]);
+
+  const appliedDimensionNames = useMemo(
+    () => appliedDimensions?.map((dimension) => dimension.name),
+    [appliedDimensions]
   );
 
   const metricsInfoQuery = useMemo(
-    () => buildMetricsInfoQuery(esql, selectedDimensions),
-    [esql, selectedDimensions]
+    () => buildMetricsInfoQuery(esql, appliedDimensionNames),
+    [esql, appliedDimensionNames]
   );
 
   const [{ value, error, loading }, executeFetch] = useAsyncFn(
@@ -85,7 +99,7 @@ export function useFetchMetricsData({
 
       return {
         ...sortedMetrics,
-        activeDimensions: selectedDimensionNames ?? [],
+        activeDimensions: appliedDimensions ?? [],
       };
     },
     [
@@ -97,7 +111,7 @@ export function useFetchMetricsData({
       services.data.search.search,
       services.uiSettings,
       trackMetricsInfo,
-      selectedDimensionNames,
+      appliedDimensions,
     ]
   );
 
@@ -112,7 +126,6 @@ export function useFetchMetricsData({
     };
   }, [
     shouldFetch,
-    selectedDimensionNames,
     fetchParams.dataView,
     fetchParams.timeRange,
     fetchParams.abortController,

--- a/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/observability/metrics/metrics_experience_grid.test.tsx
+++ b/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/observability/metrics/metrics_experience_grid.test.tsx
@@ -34,7 +34,12 @@ jest.mock('@kbn/ebt-tools', () => ({
     onPageReady: jest.fn(),
   }),
 }));
-jest.mock('./hooks');
+jest.mock('./hooks', () => ({
+  ...jest.requireActual('./hooks'),
+  useMetricsGridFullScreen: jest.fn(),
+  useMetricFieldsFilter: jest.fn(),
+  useDiscoverFieldForBreakdown: jest.fn(),
+}));
 jest.mock('./hooks/use_fetch_metrics_data', () => ({
   useFetchMetricsData: jest.fn(),
 }));
@@ -324,5 +329,89 @@ describe('MetricsExperienceGrid', () => {
     });
 
     expect(onToggleFullscreen).toHaveBeenCalled();
+  });
+
+  describe('wipe orphan dimensions on stream switch (#264957)', () => {
+    // Smoke tests only: these assert the grid wires `useDimensionsWipe`
+    // correctly (selection + breakdown callbacks reach Discover). The full
+    // matrix of wipe scenarios lives in `use_dimensions_wipe.test.ts`.
+    const hostName: Dimension = { name: 'host.name' };
+    const environment: Dimension = { name: 'environment' };
+
+    it('prunes selectedDimensions and proposes a default breakdown via onBreakdownFieldChange', () => {
+      const onDimensionsChange = jest.fn();
+      const onBreakdownFieldChange = jest.fn();
+
+      useMetricsExperienceStateMock.mockReturnValue({
+        currentPage: 0,
+        selectedDimensions: [hostName, environment],
+        onDimensionsChange,
+        onPageChange: jest.fn(),
+        isFullscreen: false,
+        searchTerm: '',
+        onSearchTermChange: jest.fn(),
+        onToggleFullscreen: jest.fn(),
+        profileId: 'test-profile-id',
+      });
+
+      // Stream's universe only has `host.name`; `environment` is mapped but
+      // not emitted by this stream, so it must be wiped.
+      useFetchMetricsDataMock.mockReturnValue({
+        metricItems,
+        allDimensions: [hostName],
+        activeDimensions: [hostName],
+        loading: false,
+        error: null,
+      });
+
+      render(
+        <MetricsExperienceGrid {...defaultProps} onBreakdownFieldChange={onBreakdownFieldChange} />,
+        { wrapper: IntlProvider }
+      );
+
+      expect(onDimensionsChange).toHaveBeenCalledWith([hostName]);
+      // Discover had no breakdown yet, so the wipe proposes the first
+      // surviving dimension.
+      expect(onBreakdownFieldChange).toHaveBeenCalledWith('host.name');
+    });
+
+    it('does not touch the breakdown when the current breakdownField survives the prune', () => {
+      const onDimensionsChange = jest.fn();
+      const onBreakdownFieldChange = jest.fn();
+
+      useMetricsExperienceStateMock.mockReturnValue({
+        currentPage: 0,
+        selectedDimensions: [hostName, environment],
+        onDimensionsChange,
+        onPageChange: jest.fn(),
+        isFullscreen: false,
+        searchTerm: '',
+        onSearchTermChange: jest.fn(),
+        onToggleFullscreen: jest.fn(),
+        profileId: 'test-profile-id',
+      });
+
+      useFetchMetricsDataMock.mockReturnValue({
+        metricItems,
+        allDimensions: [hostName],
+        activeDimensions: [hostName],
+        loading: false,
+        error: null,
+      });
+
+      // Discover already breaks down by `host.name`, which survives the
+      // prune; the wipe must leave it untouched.
+      render(
+        <MetricsExperienceGrid
+          {...defaultProps}
+          breakdownField="host.name"
+          onBreakdownFieldChange={onBreakdownFieldChange}
+        />,
+        { wrapper: IntlProvider }
+      );
+
+      expect(onDimensionsChange).toHaveBeenCalledWith([hostName]);
+      expect(onBreakdownFieldChange).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/observability/metrics/metrics_experience_grid.tsx
+++ b/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/observability/metrics/metrics_experience_grid.tsx
@@ -20,7 +20,7 @@ import { SearchButton } from '../../toolbar/right_side_actions/search_button';
 import { MetricsExperienceGridContent } from './metrics_experience_grid_content';
 import { MetricsInfoError } from './metrics_info_error';
 import type { Dimension, UnifiedMetricsGridProps } from '../../../types';
-import { useDiscoverFieldForBreakdown, useMetricFieldsFilter } from './hooks';
+import { useDimensionsWipe, useDiscoverFieldForBreakdown, useMetricFieldsFilter } from './hooks';
 import { isSuppressedFetchError } from './utils/is_suppressed_fetch_error';
 
 export const MetricsExperienceGrid = ({
@@ -78,6 +78,16 @@ export const MetricsExperienceGrid = ({
     },
     [onDimensionsChange, onBreakdownFieldChange]
   );
+
+  useDimensionsWipe({
+    selectedDimensions,
+    allDimensions,
+    isLoading: isDiscoverLoading,
+    hasError: metricsInfoError != null,
+    breakdownField,
+    onSelectedDimensionsChange: onDimensionsChange,
+    onBreakdownFieldChange,
+  });
 
   const { onPageReady } = usePerformanceContext();
   useEffect(() => {

--- a/src/platform/plugins/shared/discover/test/scout/ui/fixtures/metrics_experience/constants.ts
+++ b/src/platform/plugins/shared/discover/test/scout/ui/fixtures/metrics_experience/constants.ts
@@ -11,6 +11,7 @@ import { tags } from '@kbn/scout';
 import type { KibanaRole } from '@kbn/scout';
 
 export const METRICS_TEST_INDEX_NAME = 'test-metrics-experience';
+export const METRICS_TEST_INDEX_NAME_OTHER = 'test-metrics-experience-other';
 export const METRICS_TEST_INDEX_PATTERN = 'test-metrics-*';
 
 // The Security serverless viewer role only grants read access to `metrics-endpoint.metadata_current_*`.
@@ -37,6 +38,7 @@ export const METRICS_FLYOUT_DIMENSION_ITEM_DATA_TEST_SUBJ =
 
 export const ESQL_QUERIES = {
   TS: `TS ${METRICS_TEST_INDEX_NAME}`,
+  TS_OTHER: `TS ${METRICS_TEST_INDEX_NAME_OTHER}`,
   TS_WILDCARD: `TS ${METRICS_TEST_INDEX_PATTERN}`,
   FROM: `FROM ${METRICS_TEST_INDEX_NAME}`,
 };
@@ -47,6 +49,8 @@ export const RECOMMENDED_QUERY_LABELS = {
 
 export const METRICS_DIMENSION_FIELDS = {
   DEFAULT_BREAKDOWN: 'dimension_0',
+  /** Dimension emitted by `DEFAULT_CONFIG` but not by `DIMENSIONS_WIPE_CONFIG`. */
+  ONLY_IN_A: 'dimension_1',
 } as const;
 
 export const DATA_VIEW_NAME = METRICS_TEST_INDEX_NAME;

--- a/src/platform/plugins/shared/discover/test/scout/ui/fixtures/metrics_experience/generators/metrics_tsdb_index.ts
+++ b/src/platform/plugins/shared/discover/test/scout/ui/fixtures/metrics_experience/generators/metrics_tsdb_index.ts
@@ -10,7 +10,7 @@
 import type { EsClient } from '@kbn/scout';
 import type { MappingTimeSeriesMetricType } from '@elastic/elasticsearch/lib/api/types';
 import { errors } from '@elastic/elasticsearch';
-import { METRICS_TEST_INDEX_NAME } from '../constants';
+import { METRICS_TEST_INDEX_NAME, METRICS_TEST_INDEX_NAME_OTHER } from '../constants';
 
 export interface MetricDefinition {
   readonly name: string;
@@ -55,6 +55,21 @@ export const DEFAULT_CONFIG: MetricsIndexConfig = {
   indexName: METRICS_TEST_INDEX_NAME,
   dimensions: generateDimensions(30),
   metrics: [...generateMetrics(23, 'gauge'), ...generateMetrics(22, 'counter')],
+  timeRange: INDEX_TIME_RANGE,
+};
+
+/**
+ * Companion TSDB index emitting a dimension set that overlaps with
+ * `DEFAULT_CONFIG` only on `dimension_0`, so switching between the two
+ * exercises the dimensions wipe path.
+ */
+export const DIMENSIONS_WIPE_CONFIG: MetricsIndexConfig = {
+  indexName: METRICS_TEST_INDEX_NAME_OTHER,
+  dimensions: [
+    { name: 'dimension_0', values: ['shared_v0', 'shared_v1', 'shared_v2'] },
+    { name: 'dimension_only_in_b', values: ['b_v0', 'b_v1', 'b_v2'] },
+  ],
+  metrics: [...generateMetrics(3, 'gauge'), ...generateMetrics(2, 'counter')],
   timeRange: INDEX_TIME_RANGE,
 };
 

--- a/src/platform/plugins/shared/discover/test/scout/ui/parallel_tests/global.setup.ts
+++ b/src/platform/plugins/shared/discover/test/scout/ui/parallel_tests/global.setup.ts
@@ -9,7 +9,10 @@
 
 import { globalSetupHook } from '@kbn/scout';
 import { getSynthtraceClient } from '@kbn/scout-synthtrace';
-import { createMetricsTestIndexIfNeeded } from '../fixtures/metrics_experience';
+import {
+  createMetricsTestIndexIfNeeded,
+  DIMENSIONS_WIPE_CONFIG,
+} from '../fixtures/metrics_experience';
 import {
   TRACES,
   richTrace,
@@ -37,6 +40,17 @@ globalSetupHook(
       created
         ? '[setup:metrics] metrics test index created successfully'
         : '[setup:metrics] metrics test index already exists, skipping'
+    );
+
+    // Companion index for stream-switch coverage
+    log.debug(
+      '[setup:metrics] creating companion metrics test index (only if it does not exist)...'
+    );
+    const createdOther = await createMetricsTestIndexIfNeeded(esClient, DIMENSIONS_WIPE_CONFIG);
+    log.debug(
+      createdOther
+        ? '[setup:metrics] companion metrics test index created successfully'
+        : '[setup:metrics] companion metrics test index already exists, skipping'
     );
 
     // Traces Experience setup (not supported in serverless security or search - no Fleet/APM privileges)

--- a/src/platform/plugins/shared/discover/test/scout/ui/parallel_tests/metrics_experience/dimensions_wipe.spec.ts
+++ b/src/platform/plugins/shared/discover/test/scout/ui/parallel_tests/metrics_experience/dimensions_wipe.spec.ts
@@ -1,0 +1,118 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { expect } from '@kbn/scout/ui';
+import { spaceTest, testData, DEFAULT_TIME_RANGE } from '../../fixtures/metrics_experience';
+
+spaceTest.describe(
+  'Metrics in Discover - Dimensions wipe on stream switch',
+  {
+    tag: testData.METRICS_EXPERIENCE_TAGS,
+  },
+  () => {
+    spaceTest.beforeAll(async ({ scoutSpace }) => {
+      await scoutSpace.savedObjects.load(testData.KBN_ARCHIVE);
+      await scoutSpace.uiSettings.setDefaultIndex(testData.DATA_VIEW_NAME);
+      await scoutSpace.uiSettings.setDefaultTime(DEFAULT_TIME_RANGE);
+    });
+
+    spaceTest.beforeEach(async ({ browserAuth, pageObjects }) => {
+      await browserAuth.loginAsViewer();
+      await pageObjects.discover.goto();
+    });
+
+    spaceTest.afterAll(async ({ scoutSpace }) => {
+      await scoutSpace.uiSettings.unset('defaultIndex', 'timepicker:timeDefaults');
+      await scoutSpace.savedObjects.cleanStandardList();
+    });
+
+    spaceTest(
+      'drops a selected dimension when switching to a stream that does not emit it, and keeps the chart rendered',
+      async ({ pageObjects, page }) => {
+        const { discover, metricsExperience } = pageObjects;
+        const { ONLY_IN_A } = testData.METRICS_DIMENSION_FIELDS;
+
+        // TODO: Move to Discover PO (issue: https://github.com/elastic/kibana/issues/265472)
+        const submitEsqlQuery = async (query: string) => {
+          await discover.codeEditor.setCodeEditorValue(query);
+          await page.testSubj.click('querySubmitButton');
+          await discover.waitUntilSearchingHasFinished();
+        };
+
+        await spaceTest.step('select a dimension on the first stream', async () => {
+          await discover.writeAndSubmitEsqlQuery(testData.ESQL_QUERIES.TS);
+          await expect(metricsExperience.grid).toBeVisible();
+          await expect(metricsExperience.getCardByIndex(0)).toBeVisible();
+          await metricsExperience.breakdownSelector.selectDimension(ONLY_IN_A);
+          await expect(
+            metricsExperience.breakdownSelector.getToggleWithSelection(ONLY_IN_A)
+          ).toBeVisible();
+          await expect(metricsExperience.getCardByIndex(0)).toBeVisible();
+        });
+
+        await spaceTest.step('switch to a stream that does not emit it', async () => {
+          await submitEsqlQuery(testData.ESQL_QUERIES.TS_OTHER);
+          await expect(metricsExperience.grid).toBeVisible();
+          await expect(metricsExperience.getCardByIndex(0)).toBeVisible();
+          await expect(
+            metricsExperience.breakdownSelector.getToggleWithSelection(ONLY_IN_A)
+          ).toBeHidden();
+        });
+
+        await spaceTest.step(
+          'switch back to first stream and confirm the dropped dimension is not auto-restored',
+          async () => {
+            await submitEsqlQuery(testData.ESQL_QUERIES.TS);
+            await expect(metricsExperience.grid).toBeVisible();
+            await expect(metricsExperience.getCardByIndex(0)).toBeVisible();
+            await expect(
+              metricsExperience.breakdownSelector.getToggleWithSelection(ONLY_IN_A)
+            ).toBeHidden();
+          }
+        );
+      }
+    );
+
+    spaceTest(
+      'preserves the breakdown when the dimension is shared across streams',
+      async ({ pageObjects, page }) => {
+        const { discover, metricsExperience } = pageObjects;
+        const { DEFAULT_BREAKDOWN } = testData.METRICS_DIMENSION_FIELDS;
+
+        const submitEsqlQuery = async (query: string) => {
+          await discover.codeEditor.setCodeEditorValue(query);
+          await page.testSubj.click('querySubmitButton');
+          await discover.waitUntilSearchingHasFinished();
+        };
+
+        await spaceTest.step('select a shared dimension on the first stream', async () => {
+          await discover.writeAndSubmitEsqlQuery(testData.ESQL_QUERIES.TS);
+          await expect(metricsExperience.grid).toBeVisible();
+          await expect(metricsExperience.getCardByIndex(0)).toBeVisible();
+          await metricsExperience.breakdownSelector.selectDimension(DEFAULT_BREAKDOWN);
+          await expect(
+            metricsExperience.breakdownSelector.getToggleWithSelection(DEFAULT_BREAKDOWN)
+          ).toBeVisible();
+        });
+
+        await spaceTest.step(
+          'switch to a stream that still emits it and keep the selection',
+          async () => {
+            await submitEsqlQuery(testData.ESQL_QUERIES.TS_OTHER);
+            await expect(metricsExperience.grid).toBeVisible();
+            await expect(metricsExperience.getCardByIndex(0)).toBeVisible();
+            await expect(
+              metricsExperience.breakdownSelector.getToggleWithSelection(DEFAULT_BREAKDOWN)
+            ).toBeVisible();
+          }
+        );
+      }
+    );
+  }
+);

--- a/src/platform/plugins/shared/discover/test/scout/ui/parallel_tests/metrics_experience/readme.md
+++ b/src/platform/plugins/shared/discover/test/scout/ui/parallel_tests/metrics_experience/readme.md
@@ -4,7 +4,9 @@ Scout UI tests for the Metrics in Discover feature.
 
 ## Data strategy
 
-All tests use a single dynamically created TSDB index (`test-metrics-experience`) with 45 metric fields (23 gauge + 22 counter) and 30 dimensions. The index is created once in `global.setup.ts` via `createMetricsTestIndexIfNeeded` and reused across all specs.
+Most tests use a single dynamically created TSDB index (`test-metrics-experience`) with 45 metric fields (23 gauge + 22 counter) and 30 dimensions. The index is created once in `global.setup.ts` via `createMetricsTestIndexIfNeeded` and reused across all specs.
+
+A companion TSDB index (`test-metrics-experience-other`) is also created in `global.setup.ts` from `DIMENSIONS_WIPE_CONFIG`. It deliberately emits a different dimension set (only the shared `dimension_0` plus a `dimension_only_in_b`), and is used by `dimensions_wipe.spec.ts` to exercise stream switches across heterogeneous dimension sets.
 
 A matching data view is loaded from `kbn_archives/metrics_data_view.json` in each spec's `beforeAll` hook. This keeps the suite fully self-contained with no dependency on external ES archives.
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Discover][Metrics]: Implement dimension pruning on ds switch to avoid unexpected errors (#265464)](https://github.com/elastic/kibana/pull/265464)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Lucas Francisco López","email":"lucaslopezf@gmail.com"},"sourceCommit":{"committedDate":"2026-04-27T12:02:17Z","message":"[Discover][Metrics]: Implement dimension pruning on ds switch to avoid unexpected errors (#265464)\n\n## Summary\n\nCloses #264957\n\nFollow up issue: https://github.com/elastic/kibana/issues/265472\n\n## Summary\n\nWhen the user switched between metric streams in the Metrics Experience,\ntwo\nrelated bugs surfaced:\n\n1. **Query crash**: A `selectedDimension` persisted from the previous\nstream\n   could leak into the `WHERE TO_STRING(field) IS NOT NULL` clause of\n`METRICS_INFO`. If that field was not mapped on the new stream's data\nview,\n   Elasticsearch rejected the query and the UI rendered \"Unable to load\n   visualization\".\n2. **Ghost UI state**: A selected dimension that the new stream does not\nemit\nstayed \"ticked\" in the toolbar and propagated to Discover's\n`breakdownField`,\nso the user saw a breakdown that no longer applied to the data on\nscreen.\n\nThis PR introduces a small, layered fix that keeps the user's persisted\nintent\n(`selectedDimensions` in URL state) coherent with what the active stream\ncan\nactually render.\n\n## Strategy\n\nThe package now models three distinct concepts:\n\n- **Intent**: `selectedDimensions`, what the user wants. Persisted in\nURL.\n- **Applied**: the subset that is safe to push to Elasticsearch right\nnow\n  (mapping safety against the current `dataView`).\n- **Universe**: `allDimensions`, what the active stream actually emits\n  (returned by `METRICS_INFO`).\n\nTwo defenses keep these three in sync:\n\n### 1. Pre-fetch defense (mapping safety)\n\nLives in `hooks/use_fetch_metrics_data.ts`.\nBefore building the query, we filter `selectedDimensions` against\n`dataView.getFieldByName(...)` so the `WHERE` clause never references a\nfield\nthat is not mapped on the current data view. This eliminates the crash\nclass.\nWe do **not** mutate `selectedDimensions` here, the user's intent is\npreserved and only the query payload is filtered.\n\n### 2. Post-fetch wipe (universe coherence)\n\nLives in `hooks/use_dimensions_wipe.ts` and is wired into the grid in\n[`metrics_experience_grid.tsx`](./metrics_experience_grid.tsx). After a\nfresh,\nsuccessful `METRICS_INFO` response we know the per-stream universe and\ncan\nprune any selection that falls outside it. Two important nuances:\n\n- **Gates**: The wipe only runs when `!isLoading && !hasError &&\nselection\nis non-empty`. Pruning during loading or after an error would discard\nintent\n  based on stale or invalid data.\n- **Breakdown survival**: Discover only supports a single\n`breakdownField`.\n  If the current breakdown still maps to a surviving selection\n(`breakdownSurvived`), we leave it untouched. Only when it does not\nsurvive\ndo we propose a new default (`pruned[0]?.name`, possibly `undefined`).\nThis\n  avoids spurious updates to Discover's app state.\n\n### Toolbar ↔ Discover mirroring\n\nThe grid wraps the toolbar's `onChange` so the **first** selected\ndimension is\nmirrored as Discover's `breakdownField`. Discover supports a single\nbreakdown\nand the multi-select toolbar can hold N — picking the first dimension is\nthe\ndeterministic mapping.\n\n### Demo\n\n\nhttps://github.com/user-attachments/assets/e329b7ec-e660-414a-b681-c7f6f0e31007\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"362165c9c0f78bc03bb63c1a6568aefa323d6e80","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport:version","Feature:Metrics in Discover","Team:obs-exploration","v9.4.0","v9.5.0"],"title":"[Discover][Metrics]: Implement dimension pruning on ds switch to avoid unexpected errors","number":265464,"url":"https://github.com/elastic/kibana/pull/265464","mergeCommit":{"message":"[Discover][Metrics]: Implement dimension pruning on ds switch to avoid unexpected errors (#265464)\n\n## Summary\n\nCloses #264957\n\nFollow up issue: https://github.com/elastic/kibana/issues/265472\n\n## Summary\n\nWhen the user switched between metric streams in the Metrics Experience,\ntwo\nrelated bugs surfaced:\n\n1. **Query crash**: A `selectedDimension` persisted from the previous\nstream\n   could leak into the `WHERE TO_STRING(field) IS NOT NULL` clause of\n`METRICS_INFO`. If that field was not mapped on the new stream's data\nview,\n   Elasticsearch rejected the query and the UI rendered \"Unable to load\n   visualization\".\n2. **Ghost UI state**: A selected dimension that the new stream does not\nemit\nstayed \"ticked\" in the toolbar and propagated to Discover's\n`breakdownField`,\nso the user saw a breakdown that no longer applied to the data on\nscreen.\n\nThis PR introduces a small, layered fix that keeps the user's persisted\nintent\n(`selectedDimensions` in URL state) coherent with what the active stream\ncan\nactually render.\n\n## Strategy\n\nThe package now models three distinct concepts:\n\n- **Intent**: `selectedDimensions`, what the user wants. Persisted in\nURL.\n- **Applied**: the subset that is safe to push to Elasticsearch right\nnow\n  (mapping safety against the current `dataView`).\n- **Universe**: `allDimensions`, what the active stream actually emits\n  (returned by `METRICS_INFO`).\n\nTwo defenses keep these three in sync:\n\n### 1. Pre-fetch defense (mapping safety)\n\nLives in `hooks/use_fetch_metrics_data.ts`.\nBefore building the query, we filter `selectedDimensions` against\n`dataView.getFieldByName(...)` so the `WHERE` clause never references a\nfield\nthat is not mapped on the current data view. This eliminates the crash\nclass.\nWe do **not** mutate `selectedDimensions` here, the user's intent is\npreserved and only the query payload is filtered.\n\n### 2. Post-fetch wipe (universe coherence)\n\nLives in `hooks/use_dimensions_wipe.ts` and is wired into the grid in\n[`metrics_experience_grid.tsx`](./metrics_experience_grid.tsx). After a\nfresh,\nsuccessful `METRICS_INFO` response we know the per-stream universe and\ncan\nprune any selection that falls outside it. Two important nuances:\n\n- **Gates**: The wipe only runs when `!isLoading && !hasError &&\nselection\nis non-empty`. Pruning during loading or after an error would discard\nintent\n  based on stale or invalid data.\n- **Breakdown survival**: Discover only supports a single\n`breakdownField`.\n  If the current breakdown still maps to a surviving selection\n(`breakdownSurvived`), we leave it untouched. Only when it does not\nsurvive\ndo we propose a new default (`pruned[0]?.name`, possibly `undefined`).\nThis\n  avoids spurious updates to Discover's app state.\n\n### Toolbar ↔ Discover mirroring\n\nThe grid wraps the toolbar's `onChange` so the **first** selected\ndimension is\nmirrored as Discover's `breakdownField`. Discover supports a single\nbreakdown\nand the multi-select toolbar can hold N — picking the first dimension is\nthe\ndeterministic mapping.\n\n### Demo\n\n\nhttps://github.com/user-attachments/assets/e329b7ec-e660-414a-b681-c7f6f0e31007\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"362165c9c0f78bc03bb63c1a6568aefa323d6e80"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/265757","number":265757,"state":"OPEN"},{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/265464","number":265464,"mergeCommit":{"message":"[Discover][Metrics]: Implement dimension pruning on ds switch to avoid unexpected errors (#265464)\n\n## Summary\n\nCloses #264957\n\nFollow up issue: https://github.com/elastic/kibana/issues/265472\n\n## Summary\n\nWhen the user switched between metric streams in the Metrics Experience,\ntwo\nrelated bugs surfaced:\n\n1. **Query crash**: A `selectedDimension` persisted from the previous\nstream\n   could leak into the `WHERE TO_STRING(field) IS NOT NULL` clause of\n`METRICS_INFO`. If that field was not mapped on the new stream's data\nview,\n   Elasticsearch rejected the query and the UI rendered \"Unable to load\n   visualization\".\n2. **Ghost UI state**: A selected dimension that the new stream does not\nemit\nstayed \"ticked\" in the toolbar and propagated to Discover's\n`breakdownField`,\nso the user saw a breakdown that no longer applied to the data on\nscreen.\n\nThis PR introduces a small, layered fix that keeps the user's persisted\nintent\n(`selectedDimensions` in URL state) coherent with what the active stream\ncan\nactually render.\n\n## Strategy\n\nThe package now models three distinct concepts:\n\n- **Intent**: `selectedDimensions`, what the user wants. Persisted in\nURL.\n- **Applied**: the subset that is safe to push to Elasticsearch right\nnow\n  (mapping safety against the current `dataView`).\n- **Universe**: `allDimensions`, what the active stream actually emits\n  (returned by `METRICS_INFO`).\n\nTwo defenses keep these three in sync:\n\n### 1. Pre-fetch defense (mapping safety)\n\nLives in `hooks/use_fetch_metrics_data.ts`.\nBefore building the query, we filter `selectedDimensions` against\n`dataView.getFieldByName(...)` so the `WHERE` clause never references a\nfield\nthat is not mapped on the current data view. This eliminates the crash\nclass.\nWe do **not** mutate `selectedDimensions` here, the user's intent is\npreserved and only the query payload is filtered.\n\n### 2. Post-fetch wipe (universe coherence)\n\nLives in `hooks/use_dimensions_wipe.ts` and is wired into the grid in\n[`metrics_experience_grid.tsx`](./metrics_experience_grid.tsx). After a\nfresh,\nsuccessful `METRICS_INFO` response we know the per-stream universe and\ncan\nprune any selection that falls outside it. Two important nuances:\n\n- **Gates**: The wipe only runs when `!isLoading && !hasError &&\nselection\nis non-empty`. Pruning during loading or after an error would discard\nintent\n  based on stale or invalid data.\n- **Breakdown survival**: Discover only supports a single\n`breakdownField`.\n  If the current breakdown still maps to a surviving selection\n(`breakdownSurvived`), we leave it untouched. Only when it does not\nsurvive\ndo we propose a new default (`pruned[0]?.name`, possibly `undefined`).\nThis\n  avoids spurious updates to Discover's app state.\n\n### Toolbar ↔ Discover mirroring\n\nThe grid wraps the toolbar's `onChange` so the **first** selected\ndimension is\nmirrored as Discover's `breakdownField`. Discover supports a single\nbreakdown\nand the multi-select toolbar can hold N — picking the first dimension is\nthe\ndeterministic mapping.\n\n### Demo\n\n\nhttps://github.com/user-attachments/assets/e329b7ec-e660-414a-b681-c7f6f0e31007\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"362165c9c0f78bc03bb63c1a6568aefa323d6e80"}}]}] BACKPORT-->