### PR TITLE
[Sig Events] Add KI identification agent skill and tools

### DIFF
--- a/x-pack/platform/plugins/private/gen_ai_settings/public/components/ai_assistant_visibility/ai_assistant_visibility.tsx
+++ b/x-pack/platform/plugins/private/gen_ai_settings/public/components/ai_assistant_visibility/ai_assistant_visibility.tsx
@@ -15,12 +15,14 @@ import {
 import { AIChatExperience } from '@kbn/ai-assistant-common';
 import { useSettingsContext } from '../../contexts/settings_context';
 import { useKibana } from '../../hooks/use_kibana';
+import { useFieldRowProviderProps } from '../../hooks/use_field_row_provider_props';
 
 export const AIAssistantVisibility: React.FC = () => {
   const { fields, handleFieldChange, unsavedChanges } = useSettingsContext();
   const {
-    services: { settings, notifications, docLinks, application },
+    services: { application },
   } = useKibana();
+  const fieldRowProviderProps = useFieldRowProviderProps();
 
   const field = fields[AI_ASSISTANT_PREFERRED_AI_ASSISTANT_TYPE];
   const chatExperienceField = fields[AI_CHAT_EXPERIENCE_TYPE];
@@ -53,11 +55,7 @@ export const AIAssistantVisibility: React.FC = () => {
     <>
       <EuiSpacer size="l" />
       <EuiSpacer size="l" />
-      <FieldRowProvider
-        links={docLinks.links.management}
-        showDanger={(message: string) => notifications.toasts.addDanger(message)}
-        validateChange={(key: string, value: any) => settings.client.validateValue(key, value)}
-      >
+      <FieldRowProvider {...fieldRowProviderProps}>
         <FieldRow
           field={field}
           isSavingEnabled={!!canEditAdvancedSettings}

--- a/x-pack/platform/plugins/private/gen_ai_settings/public/components/chat_experience/chat_experience.tsx
+++ b/x-pack/platform/plugins/private/gen_ai_settings/public/components/chat_experience/chat_experience.tsx
@@ -9,11 +9,12 @@ import React, { useMemo, useEffect, useRef } from 'react';
 import { EuiSpacer, EuiLink } from '@elastic/eui';
 import { FieldRow, FieldRowProvider } from '@kbn/management-settings-components-field-row';
 import { AI_CHAT_EXPERIENCE_TYPE } from '@kbn/management-settings-ids';
-import { AIChatExperience } from '@kbn/ai-assistant-common';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { AGENT_BUILDER_EVENT_TYPES } from '@kbn/agent-builder-common/telemetry';
 import { useSettingsContext } from '../../contexts/settings_context';
 import { useKibana } from '../../hooks/use_kibana';
+import { useFieldRowProviderProps } from '../../hooks/use_field_row_provider_props';
+import { isAIChatExperience } from '../../utils/chat_experience';
 
 const TELEMETRY_SOURCE = 'stack_management' as const;
 const SKIP_STEP_REACHED_ONCE_SESSION_STORAGE_KEY =
@@ -33,16 +34,6 @@ const reportTelemetryEvent = (
   payload: Record<string, unknown>
 ): void => {
   analytics?.reportEvent(eventType, payload);
-};
-
-/**
- * Type guard to check if a value is a valid AIChatExperience
- */
-const isAIChatExperience = (value: unknown): value is AIChatExperience => {
-  return (
-    typeof value === 'string' &&
-    (value === AIChatExperience.Classic || value === AIChatExperience.Agent)
-  );
 };
 
 const consumeSkipStepReachedOnce = (
@@ -66,8 +57,9 @@ const consumeSkipStepReachedOnce = (
 export const ChatExperience: React.FC = () => {
   const { fields, handleFieldChange, unsavedChanges } = useSettingsContext();
   const {
-    services: { settings, notifications, docLinks, application, analytics },
+    services: { docLinks, application, analytics },
   } = useKibana();
+  const fieldRowProviderProps = useFieldRowProviderProps();
 
   const field = fields[AI_CHAT_EXPERIENCE_TYPE];
   const canEditAdvancedSettings = Boolean(application.capabilities.advancedSettings?.save);
@@ -128,11 +120,7 @@ export const ChatExperience: React.FC = () => {
   return (
     <>
       <EuiSpacer size="l" />
-      <FieldRowProvider
-        links={docLinks.links.management}
-        showDanger={(message: string) => notifications.toasts.addDanger(message)}
-        validateChange={(key: string, value: any) => settings.client.validateValue(key, value)}
-      >
+      <FieldRowProvider {...fieldRowProviderProps}>
         <FieldRow
           field={fieldWithDescription}
           isSavingEnabled={canEditAdvancedSettings}

--- a/x-pack/platform/plugins/private/gen_ai_settings/public/components/gen_ai_settings_app.tsx
+++ b/x-pack/platform/plugins/private/gen_ai_settings/public/components/gen_ai_settings_app.tsx
@@ -24,7 +24,6 @@ import { getSpaceIdFromPath } from '@kbn/spaces-utils';
 import { isEmpty } from 'lodash';
 import { AI_CHAT_EXPERIENCE_TYPE } from '@kbn/management-settings-ids';
 import { AIChatExperience } from '@kbn/ai-assistant-common';
-import { AGENT_BUILDER_EVENT_TYPES } from '@kbn/agent-builder-common/telemetry';
 import { useEnabledFeatures } from '../contexts/enabled_features_context';
 import { useKibana } from '../hooks/use_kibana';
 import { GoToSpacesButton } from './go_to_spaces_button';
@@ -36,16 +35,11 @@ import { PrePromptWorkflowSection } from './pre_prompt_workflow_section';
 import { DocumentationSection } from './documentation';
 import { AnonymizationProfilesSection } from './anonymization_profiles_section';
 import { TokenUsageTracking } from './token_usage_tracking/token_usage_tracking';
+import { useSaveWithTelemetry } from '../hooks/use_save_with_telemetry';
 
 interface GenAiSettingsAppProps {
   setBreadcrumbs: ManagementAppMountParams['setBreadcrumbs'];
 }
-
-const TELEMETRY_SOURCE = 'stack_management' as const;
-
-const isAIChatExperience = (value: unknown): value is AIChatExperience =>
-  typeof value === 'string' &&
-  (value === AIChatExperience.Classic || value === AIChatExperience.Agent);
 
 export const GenAiSettingsApp: React.FC<GenAiSettingsAppProps> = ({ setBreadcrumbs }) => {
   const { services } = useKibana();
@@ -105,65 +99,7 @@ export const GenAiSettingsApp: React.FC<GenAiSettingsAppProps> = ({ setBreadcrum
     });
   }, [application, http.basePath, isPermissionsBased]);
 
-  async function handleSave() {
-    const savedChatExperience = isAIChatExperience(chatExperienceField?.savedValue)
-      ? chatExperienceField.savedValue
-      : undefined;
-    const defaultChatExperience = isAIChatExperience(chatExperienceField?.defaultValue)
-      ? (chatExperienceField.defaultValue as AIChatExperience)
-      : undefined;
-    const unsavedChatExperience = isAIChatExperience(
-      unsavedChanges[AI_CHAT_EXPERIENCE_TYPE]?.unsavedValue
-    )
-      ? (unsavedChanges[AI_CHAT_EXPERIENCE_TYPE]?.unsavedValue as AIChatExperience)
-      : undefined;
-    const normalizedSavedChatExperience = savedChatExperience ?? AIChatExperience.Agent;
-
-    // Telemetry should compare the effective "before" and "after" values.
-    // - "before" should include the default if there is no saved value.
-    // - "after" should reflect the unsaved change, or fall back to "before" if unchanged.
-    const telemetryBeforeChatExperience =
-      savedChatExperience ?? defaultChatExperience ?? AIChatExperience.Agent;
-    const telemetryAfterChatExperience = unsavedChatExperience ?? telemetryBeforeChatExperience;
-    const shouldTrackOptInConfirmed =
-      telemetryBeforeChatExperience !== AIChatExperience.Agent &&
-      telemetryAfterChatExperience === AIChatExperience.Agent;
-    const shouldTrackOptOut =
-      telemetryBeforeChatExperience === AIChatExperience.Agent &&
-      telemetryAfterChatExperience !== AIChatExperience.Agent;
-
-    const needsReload = await saveAll();
-    if (shouldTrackOptInConfirmed) {
-      analytics?.reportEvent(AGENT_BUILDER_EVENT_TYPES.OptInAction, {
-        action: 'confirmed',
-        source: TELEMETRY_SOURCE,
-      });
-    }
-    if (shouldTrackOptOut) {
-      analytics?.reportEvent(AGENT_BUILDER_EVENT_TYPES.OptOut, {
-        source: TELEMETRY_SOURCE,
-      });
-    }
-    if (needsReload) {
-      // Only skip `step_reached` after reload if it could have been reported on this page load.
-      // This prevents suppressing the Agent -> Classic transition, where `step_reached` should be
-      // emitted after reload.
-      const shouldSkipStepReachedOnReload =
-        normalizedSavedChatExperience === AIChatExperience.Classic &&
-        !(savedChatExperience === undefined && defaultChatExperience === AIChatExperience.Agent);
-
-      if (shouldSkipStepReachedOnReload) {
-        try {
-          // We reload the page after saving; without this one-shot flag, `ChatExperience` would emit
-          // `step_reached` both before and after the reload.
-          window.sessionStorage.setItem('gen_ai_settings:skip_step_reached_once', `${Date.now()}`);
-        } catch {
-          // ignore
-        }
-      }
-      window.location.reload();
-    }
-  }
+  const handleSave = useSaveWithTelemetry({ fields, unsavedChanges, saveAll, analytics });
 
   return (
     <>

--- a/x-pack/platform/plugins/private/gen_ai_settings/public/components/pre_prompt_workflow_section/pre_prompt_workflow_section.tsx
+++ b/x-pack/platform/plugins/private/gen_ai_settings/public/components/pre_prompt_workflow_section/pre_prompt_workflow_section.tsx
@@ -9,7 +9,6 @@ import React from 'react';
 import { EuiSpacer, EuiSplitPanel, EuiTitle } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { useQuery } from '@kbn/react-query';
 import {
   AGENT_BUILDER_EXPERIMENTAL_FEATURES_SETTING_ID,
   AGENT_BUILDER_PRE_PROMPT_WORKFLOW_IDS,
@@ -17,6 +16,7 @@ import {
 import { WORKFLOWS_UI_SETTING_ID } from '@kbn/workflows';
 import { useSettingsContext } from '../../contexts/settings_context';
 import { useKibana } from '../../hooks/use_kibana';
+import { usePrePromptWorkflows } from '../../hooks/use_pre_prompt_workflows';
 import { PrePromptWorkflowPicker } from './pre_prompt_workflow_picker';
 
 function toStringArray(value: unknown): string[] {
@@ -40,19 +40,8 @@ export const PrePromptWorkflowSection: React.FC = () => {
     agentBuilder && isWorkflowUiEnabled && isAgentBuilderExperimentalFeaturesEnabled;
 
   const field = fields[AGENT_BUILDER_PRE_PROMPT_WORKFLOW_IDS];
-  const isPickerEnabled = field && shouldRender;
-
-  const { data: workflows = [], isLoading } = useQuery({
-    queryKey: ['genAiSettings', 'prePromptWorkflows'],
-    enabled: isPickerEnabled,
-    queryFn: async () => {
-      if (!agentBuilder) {
-        return [];
-      }
-      const response = await agentBuilder.tools.listWorkflows({ page: 1, limit: 1000 });
-      return response.results.map((workflow) => ({ id: workflow.id, name: workflow.name }));
-    },
-  });
+  const isPickerEnabled = Boolean(field && shouldRender);
+  const { workflows, isLoading } = usePrePromptWorkflows({ enabled: isPickerEnabled });
 
   if (!field || !shouldRender || !agentBuilder) {
     return null;

--- a/x-pack/platform/plugins/private/gen_ai_settings/public/components/token_usage_tracking/token_usage_tracking.tsx
+++ b/x-pack/platform/plugins/private/gen_ai_settings/public/components/token_usage_tracking/token_usage_tracking.tsx
@@ -11,12 +11,14 @@ import { FieldRow, FieldRowProvider } from '@kbn/management-settings-components-
 import { GEN_AI_SETTINGS_TOKEN_USAGE_TRACKING } from '@kbn/management-settings-ids';
 import { useSettingsContext } from '../../contexts/settings_context';
 import { useKibana } from '../../hooks/use_kibana';
+import { useFieldRowProviderProps } from '../../hooks/use_field_row_provider_props';
 
 export const TokenUsageTracking: React.FC = () => {
   const { fields, handleFieldChange, unsavedChanges } = useSettingsContext();
   const {
-    services: { settings, notifications, docLinks, application },
+    services: { application },
   } = useKibana();
+  const fieldRowProviderProps = useFieldRowProviderProps();
 
   const field = fields[GEN_AI_SETTINGS_TOKEN_USAGE_TRACKING];
 
@@ -29,11 +31,7 @@ export const TokenUsageTracking: React.FC = () => {
   return (
     <>
       <EuiSpacer size="l" />
-      <FieldRowProvider
-        links={docLinks.links.management}
-        showDanger={(message: string) => notifications.toasts.addDanger(message)}
-        validateChange={(key: string, value: any) => settings.client.validateValue(key, value)}
-      >
+      <FieldRowProvider {...fieldRowProviderProps}>
         <FieldRow
           field={field}
           isSavingEnabled={!!canEditAdvancedSettings}

--- a/x-pack/platform/plugins/private/gen_ai_settings/public/contexts/settings_context.tsx
+++ b/x-pack/platform/plugins/private/gen_ai_settings/public/contexts/settings_context.tsx
@@ -214,9 +214,7 @@ const useSettings = ({ settingsKeys }: { settingsKeys: string[] }) => {
     setUnsavedChanges((changes) => ({ ...changes, [id]: change }));
   };
 
-  function cleanUnsavedChanges() {
-    setUnsavedChanges({});
-  }
+  const cleanUnsavedChanges = React.useCallback(() => setUnsavedChanges({}), []);
 
   const setValidationErrors = React.useCallback(
     (errors: ValidationError[] | ((current: ValidationError[]) => ValidationError[])) => {
@@ -244,9 +242,13 @@ const useSettings = ({ settingsKeys }: { settingsKeys: string[] }) => {
 export { SettingsContext, useSettingsContext };
 
 /**
- * Field-specific hook for settings context with automatic validation error management
- * @param fieldNames - Array of field names this hook instance is responsible for
- * @param validationFn - Optional validation function that will be called automatically when dependencies change
+ * Field-specific hook for settings context with automatic validation error management.
+ *
+ * @param fieldNames - Array of field names this hook instance is responsible for.
+ *   **Must be a stable reference** (module-level constant or `useMemo`) — the array is used
+ *   directly in dependency arrays and a new array identity on every render will cause
+ *   infinite re-renders.
+ * @param validationFn - Optional validation function called automatically when `validationDeps` change
  * @param validationDeps - Dependencies for the validation function
  * @returns Settings context with field-scoped validation error management
  */
@@ -256,16 +258,12 @@ export const useFieldSettingsContext = <T extends any[]>(
   validationDeps?: T
 ) => {
   const context = useSettingsContext();
+  const { setValidationErrors: contextSetValidationErrors } = context;
 
   // Validate that we have field names
   if (!fieldNames || fieldNames.length === 0) {
     throw new Error('useFieldSettingsContext requires at least one field name');
   }
-
-  // Memoize field names to ensure stable reference
-  const fieldNamesString = JSON.stringify(fieldNames);
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const stableFieldNames = React.useMemo(() => fieldNames, [fieldNamesString]);
 
   // Track last validation errors to prevent unnecessary updates
   const lastValidationErrorsRef = React.useRef<ValidationError[]>([]);
@@ -275,14 +273,14 @@ export const useFieldSettingsContext = <T extends any[]>(
     (errors: ValidationError[]) => {
       // Validate that all errors belong to the allowed fields
       const invalidErrors = errors.filter(
-        (error) => error.field && !stableFieldNames.includes(error.field)
+        (error) => error.field && !fieldNames.includes(error.field)
       );
 
       if (invalidErrors.length > 0) {
         const invalidFields = invalidErrors.map((e) => e.field).join(', ');
         throw new Error(
           `Validation errors contain fields not managed by this hook instance. ` +
-            `Invalid fields: ${invalidFields}. Allowed fields: ${stableFieldNames.join(', ')}`
+            `Invalid fields: ${invalidFields}. Allowed fields: ${fieldNames.join(', ')}`
         );
       }
 
@@ -298,19 +296,15 @@ export const useFieldSettingsContext = <T extends any[]>(
       if (errorsChanged) {
         lastValidationErrorsRef.current = errors;
 
-        // Set the validation errors using the original context method
-        context.setValidationErrors((currentErrors) => {
-          // Remove any existing errors for our fields
+        contextSetValidationErrors((currentErrors) => {
           const otherErrors = currentErrors.filter(
-            (error) => !error.field || !stableFieldNames.includes(error.field)
+            (error) => !error.field || !fieldNames.includes(error.field)
           );
-          // Add the new errors for our fields
           return [...otherErrors, ...errors];
         });
       }
     },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [context.setValidationErrors, stableFieldNames]
+    [contextSetValidationErrors, fieldNames]
   );
 
   // Auto-run validation function when dependencies change
@@ -327,17 +321,14 @@ export const useFieldSettingsContext = <T extends any[]>(
       : [setValidationErrors, validationFn]
   );
 
-  // Automatically clear errors for our fields when the hook unmounts
   React.useEffect(() => {
     return () => {
-      context.setValidationErrors((currentErrors) =>
-        currentErrors.filter((error) => !error.field || !stableFieldNames.includes(error.field))
+      contextSetValidationErrors((currentErrors) =>
+        currentErrors.filter((error) => !error.field || !fieldNames.includes(error.field))
       );
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [context.setValidationErrors, stableFieldNames]);
+  }, [contextSetValidationErrors, fieldNames]);
 
-  // Return the context with our field-scoped validation function
   return {
     ...context,
     setValidationErrors,

--- a/x-pack/platform/plugins/private/gen_ai_settings/public/hooks/use_connector_exists.ts
+++ b/x-pack/platform/plugins/private/gen_ai_settings/public/hooks/use_connector_exists.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { useEffect, useState } from 'react';
+import { useQuery } from '@kbn/react-query';
 import { NO_DEFAULT_CONNECTOR } from '../../common/constants';
 import { useKibana } from './use_kibana';
 
@@ -22,37 +22,24 @@ export function useConnectorExists(connectorId: string): {
     services: { genAiSettingsApi },
   } = useKibana();
 
-  const [exists, setExists] = useState(true);
-  const [loading, setLoading] = useState(false);
+  const enabled = Boolean(connectorId) && connectorId !== NO_DEFAULT_CONNECTOR;
 
-  useEffect(() => {
-    if (!connectorId || connectorId === NO_DEFAULT_CONNECTOR) {
-      setExists(true);
-      setLoading(false);
-      return;
-    }
-
-    const controller = new AbortController();
-    setLoading(true);
-
-    genAiSettingsApi('GET /internal/gen_ai_settings/connectors/{connectorId}', {
-      signal: controller.signal,
-      params: { path: { connectorId } },
-    })
-      .then(() => {
-        setExists(true);
-      })
-      .catch((e) => {
-        if (e?.name !== 'AbortError') {
-          setExists(false);
-        }
-      })
-      .finally(() => {
-        setLoading(false);
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ['connectorExists', connectorId],
+    enabled,
+    queryFn: async ({ signal }) => {
+      await genAiSettingsApi('GET /internal/gen_ai_settings/connectors/{connectorId}', {
+        signal,
+        params: { path: { connectorId } },
       });
+      return true;
+    },
+    retry: false,
+  });
 
-    return () => controller.abort();
-  }, [connectorId, genAiSettingsApi]);
+  if (!enabled) {
+    return { exists: true, loading: false };
+  }
 
-  return { exists, loading };
+  return { exists: isError ? false : data ?? true, loading: isLoading };
 }

--- a/x-pack/platform/plugins/private/gen_ai_settings/public/hooks/use_field_row_provider_props.ts
+++ b/x-pack/platform/plugins/private/gen_ai_settings/public/hooks/use_field_row_provider_props.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useKibana } from './use_kibana';
+
+export const useFieldRowProviderProps = () => {
+  const {
+    services: { settings, notifications, docLinks },
+  } = useKibana();
+
+  return {
+    links: docLinks.links.management,
+    showDanger: (message: string) => notifications.toasts.addDanger(message),
+    validateChange: (key: string, value: unknown) => settings.client.validateValue(key, value),
+  };
+};

--- a/x-pack/platform/plugins/private/gen_ai_settings/public/hooks/use_pre_prompt_workflows.ts
+++ b/x-pack/platform/plugins/private/gen_ai_settings/public/hooks/use_pre_prompt_workflows.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useQuery } from '@kbn/react-query';
+import { useKibana } from './use_kibana';
+
+interface Workflow {
+  id: string;
+  name: string;
+}
+
+export function usePrePromptWorkflows({ enabled }: { enabled: boolean }): {
+  workflows: Workflow[];
+  isLoading: boolean;
+} {
+  const {
+    services: { agentBuilder },
+  } = useKibana();
+
+  const { data: workflows = [], isLoading } = useQuery({
+    queryKey: ['genAiSettings', 'prePromptWorkflows'],
+    enabled,
+    queryFn: async () => {
+      if (!agentBuilder) {
+        return [];
+      }
+      const response = await agentBuilder.tools.listWorkflows({ page: 1, limit: 1000 });
+      return response.results.map((workflow) => ({ id: workflow.id, name: workflow.name }));
+    },
+  });
+
+  return { workflows, isLoading };
+}

--- a/x-pack/platform/plugins/private/gen_ai_settings/public/hooks/use_save_with_telemetry.ts
+++ b/x-pack/platform/plugins/private/gen_ai_settings/public/hooks/use_save_with_telemetry.ts
@@ -1,0 +1,105 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useRef, useCallback } from 'react';
+import type { FieldDefinition, UnsavedFieldChange } from '@kbn/management-settings-types';
+import { AI_CHAT_EXPERIENCE_TYPE } from '@kbn/management-settings-ids';
+import { AIChatExperience } from '@kbn/ai-assistant-common';
+import { AGENT_BUILDER_EVENT_TYPES } from '@kbn/agent-builder-common/telemetry';
+import { isAIChatExperience } from '../utils/chat_experience';
+
+const TELEMETRY_SOURCE = 'stack_management' as const;
+
+type AnalyticsService =
+  | { reportEvent: (eventType: string, payload: Record<string, unknown>) => void }
+  | undefined;
+
+interface UseSaveWithTelemetryProps {
+  fields: Record<string, FieldDefinition>;
+  unsavedChanges: Record<string, UnsavedFieldChange>;
+  saveAll: () => Promise<boolean>;
+  analytics: AnalyticsService;
+}
+
+/**
+ * Returns a stable save handler that derives and fires telemetry events around the chat experience
+ * transition before delegating to `saveAll`. All mutable values are captured via refs so the
+ * returned function identity never changes between renders.
+ */
+export function useSaveWithTelemetry({
+  fields,
+  unsavedChanges,
+  saveAll,
+  analytics,
+}: UseSaveWithTelemetryProps): () => Promise<void> {
+  const fieldsRef = useRef(fields);
+  fieldsRef.current = fields;
+  const unsavedChangesRef = useRef(unsavedChanges);
+  unsavedChangesRef.current = unsavedChanges;
+  const saveAllRef = useRef(saveAll);
+  saveAllRef.current = saveAll;
+  const analyticsRef = useRef(analytics);
+  analyticsRef.current = analytics;
+
+  return useCallback(async () => {
+    const currentFields = fieldsRef.current;
+    const currentUnsavedChanges = unsavedChangesRef.current;
+    const chatExperienceField = currentFields[AI_CHAT_EXPERIENCE_TYPE];
+
+    const savedChatExperience = isAIChatExperience(chatExperienceField?.savedValue)
+      ? chatExperienceField.savedValue
+      : undefined;
+    const defaultChatExperience = isAIChatExperience(chatExperienceField?.defaultValue)
+      ? (chatExperienceField.defaultValue as AIChatExperience)
+      : undefined;
+    const unsavedChatExperience = isAIChatExperience(
+      currentUnsavedChanges[AI_CHAT_EXPERIENCE_TYPE]?.unsavedValue
+    )
+      ? (currentUnsavedChanges[AI_CHAT_EXPERIENCE_TYPE]?.unsavedValue as AIChatExperience)
+      : undefined;
+    const normalizedSavedChatExperience = savedChatExperience ?? AIChatExperience.Agent;
+
+    const telemetryBeforeChatExperience =
+      savedChatExperience ?? defaultChatExperience ?? AIChatExperience.Agent;
+    const telemetryAfterChatExperience = unsavedChatExperience ?? telemetryBeforeChatExperience;
+    const shouldTrackOptInConfirmed =
+      telemetryBeforeChatExperience !== AIChatExperience.Agent &&
+      telemetryAfterChatExperience === AIChatExperience.Agent;
+    const shouldTrackOptOut =
+      telemetryBeforeChatExperience === AIChatExperience.Agent &&
+      telemetryAfterChatExperience !== AIChatExperience.Agent;
+
+    const needsReload = await saveAllRef.current();
+
+    const currentAnalytics = analyticsRef.current;
+    if (shouldTrackOptInConfirmed) {
+      currentAnalytics?.reportEvent(AGENT_BUILDER_EVENT_TYPES.OptInAction, {
+        action: 'confirmed',
+        source: TELEMETRY_SOURCE,
+      });
+    }
+    if (shouldTrackOptOut) {
+      currentAnalytics?.reportEvent(AGENT_BUILDER_EVENT_TYPES.OptOut, {
+        source: TELEMETRY_SOURCE,
+      });
+    }
+    if (needsReload) {
+      const shouldSkipStepReachedOnReload =
+        normalizedSavedChatExperience === AIChatExperience.Classic &&
+        !(savedChatExperience === undefined && defaultChatExperience === AIChatExperience.Agent);
+
+      if (shouldSkipStepReachedOnReload) {
+        try {
+          window.sessionStorage.setItem('gen_ai_settings:skip_step_reached_once', `${Date.now()}`);
+        } catch {
+          // ignore
+        }
+      }
+      window.location.reload();
+    }
+  }, []); // reads all values through refs at call-time — stable across renders
+}

--- a/x-pack/platform/plugins/private/gen_ai_settings/public/utils/chat_experience.ts
+++ b/x-pack/platform/plugins/private/gen_ai_settings/public/utils/chat_experience.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { AIChatExperience } from '@kbn/ai-assistant-common';
+
+export const isAIChatExperience = (value: unknown): value is AIChatExperience =>
+  typeof value === 'string' &&
+  (value === AIChatExperience.Classic || value === AIChatExperience.Agent);


### PR DESCRIPTION
## Summary

### What
Adds a KI (Knowledge Indicator) identification agent skill and three supporting tools (`ki_identification_start`, `ki_identification_cancel`, `ki_identification_status`) to the Sig Events agent builder, enabling agents to manage knowledge indicator identification tasks end-to-end.

### Why
Sig Events agents need the ability to initiate, monitor, and cancel KI identification tasks programmatically. This closes #265654.

### Changes

- **New agent skill** — `ki_identification_management` skill with description text and skill prompt added to `streams/server/agent_builder/skills/`
- **Three new tools** with handlers and full test coverage:
  - `ki_identification_start` — initiates a KI identification task
  - `ki_identification_cancel` — cancels an in-progress task
  - `ki_identification_status` — polls task status
- **AI assistant refactoring** — extracted logic from large components into focused hooks:
  - `use_pre_prompt_workflows.ts`
  - `use_save_with_telemetry.ts`
  - `use_field_row_provider_props.ts`
  - Simplified `chat_experience.tsx`, `gen_ai_settings_app.tsx`, `settings_context.tsx`, `use_connector_exists.ts`
- **Telemetry** — added EBT event types and schema for KI identification actions
- **Streams locator** — refactored `streams_locator.ts` with test coverage (`get_streams_location.test.ts`)
- **Allow list** — registered new tools in `agent-builder-server/allow_lists.ts`

---

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

- **AI assistant regressions** (low-medium): The refactoring extracts logic from several large components into hooks. Behaviour should be identical, but UI rendering paths changed. Covered by component-level tests; recommend manual smoke test of the AI assistant settings panel.
- **KI identification tools** (low): Additive only — new tools registered in allow list, no existing functionality removed or changed.

### Release note

> Adds KI identification management skill and tools to the Sig Events agent, enabling agents to start, cancel, and check the status of knowledge indicator identification tasks.