### PR TITLE
fix(streams): LLM test proxy should read request body on end

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/fixtures/llm_proxy.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/fixtures/llm_proxy.ts
@@ -119,8 +119,14 @@ async function getRequestBody(request: http.IncomingMessage): Promise<ChatComple
       data += chunk.toString();
     });
 
-    request.on('close', () => {
-      resolve(JSON.parse(data));
+    // Use 'end' (not 'close'). The request body stream completes on 'end'; with keep-alive
+    // the connection stays open and 'close' is not a reliable signal for a full body read.
+    request.on('end', () => {
+      try {
+        resolve(data ? JSON.parse(data) : ({} as ChatCompletionStreamParams));
+      } catch (error) {
+        reject(error);
+      }
     });
 
     request.on('error', (error) => {


### PR DESCRIPTION
## Summary
Fixes flaky/failing Scout tests where `LlmProxy` interceptors for `partition_logs` were never hit (`waitForAllInterceptorsToHaveBeenCalled` timed out with interceptors still pending).

**Root cause:** `getRequestBody` resolved the parsed JSON on the request stream `close` event. The body stream is complete when `end` fires; with HTTP keep-alive the connection often stays open, so `close` is an unreliable and late signal. The request handler then ran too late (or the behavior was racy), so the proxy did not match handlers in time.

**Change:** resolve (and `JSON.parse`) the body on `end`, with a try/catch for parse errors.

## Issues
- Closes https://github.com/elastic/kibana/issues/263570
- Closes https://github.com/elastic/kibana/issues/263715

## Testing
- `node scripts/check_changes.ts`

Made with [Cursor](https://cursor.com)