### PR TITLE
[Dashboard] Fix flaky test Does not warn when only the prefix matches

### DIFF
--- a/src/platform/test/functional/apps/dashboard/group4/dashboard_save.ts
+++ b/src/platform/test/functional/apps/dashboard/group4/dashboard_save.ts
@@ -132,8 +132,10 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       it('Does not warn when only the prefix matches', async function () {
-        await dashboard.saveDashboard(dashboardName.split(' ')[0]);
-
+        await dashboard.switchToEditMode();
+        await dashboard.enterDashboardSaveModalApplyUpdatesAndClickSave(`${dashboardName} copy`, {
+          waitDialogIsClosed: false,
+        });
         await dashboard.expectDuplicateTitleWarningDisplayed({ displayed: false });
       });
     });


### PR DESCRIPTION
Resolves #https://github.com/elastic/kibana/issues/260932

Fixes a flaky failure in _"Does not warn when only the prefix matches"._

The issue was caused by inconsistent save flows between tests, leading to unstable UI state and missing save menu elements during execution.

### Changes
Replaced `saveDashboard` helper with direct save modal flow (`enterDashboardSaveModalApplyUpdatesAndClickSave`)
Updated test title prefix to a safer value to avoid unintended name collisions

### Result
Consistent UI state across both tests
No missing save menu / secondary button issues
More stable prefix matching scenario

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->