### PR TITLE
fix(streams): stabilize Scout AI suggestions tests (LLM proxy race)

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/fixtures/llm_proxy.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/fixtures/llm_proxy.ts
@@ -154,9 +154,9 @@ export class LlmProxy {
         if (matchingInterceptor) {
           this.log.info(`Handling interceptor "${matchingInterceptor.name}"`);
           matchingInterceptor.handle(request, response, requestBody);
-
-          this.log.debug(`Removing interceptor "${matchingInterceptor.name}"`);
-          pull(this.interceptors, matchingInterceptor);
+          // Do not remove the interceptor here: `completeAfterIntercept` may still be
+          // streaming the HTTP response. `waitForAllInterceptorsToHaveBeenCalled` must
+          // observe an empty list only after the response is fully written.
           return;
         }
 
@@ -282,9 +282,12 @@ export class LlmProxy {
     waitForIntercept: () => Promise<LlmResponseSimulator>;
     completeAfterIntercept: () => Promise<LlmResponseSimulator>;
   } {
+    type InterceptorEntry = RequestInterceptor & { handle: RequestHandler };
+    let interceptorEntry!: InterceptorEntry;
+
     const waitForInterceptPromise = Promise.race([
       new Promise<LlmResponseSimulator>((outerResolve) => {
-        this.interceptors.push({
+        interceptorEntry = {
           name,
           when,
           handle: (_request, response, requestBody) => {
@@ -337,7 +340,8 @@ export class LlmProxy {
 
             outerResolve(simulator);
           },
-        });
+        };
+        this.interceptors.push(interceptorEntry);
       }),
       new Promise<never>((_, reject) =>
         setTimeout(() => reject(new Error(`Interceptor "${name}" was not called`)), 30000)
@@ -365,21 +369,25 @@ export class LlmProxy {
           return [llmMessage];
         }
 
-        const llmMessage = isFunction(responseChunks)
-          ? responseChunks(simulator.requestBody)
-          : responseChunks;
+        try {
+          const llmMessage = isFunction(responseChunks)
+            ? responseChunks(simulator.requestBody)
+            : responseChunks;
 
-        if (simulator.stream) {
-          const parsedChunks = getParsedChunks(llmMessage);
-          for (const chunk of parsedChunks) {
-            await simulator.next(chunk);
+          if (simulator.stream) {
+            const parsedChunks = getParsedChunks(llmMessage);
+            for (const chunk of parsedChunks) {
+              await simulator.next(chunk);
+            }
+          } else {
+            await simulator.rawWrite(JSON.stringify(createOpenAIResponse(llmMessage)));
           }
-        } else {
-          await simulator.rawWrite(JSON.stringify(createOpenAIResponse(llmMessage)));
-        }
 
-        await simulator.complete();
-        return simulator;
+          await simulator.complete();
+          return simulator;
+        } finally {
+          pull(this.interceptors, interceptorEntry);
+        }
       },
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any;


### PR DESCRIPTION
## Summary

Flaky Scout failures (e.g. kibana-pull-request builds **263893**, **263943**) showed `locator.waitFor timeout — streamsAppNoSuggestionsCallout` in `ai_suggestions_generation.spec.ts`.

## Root cause

`waitForAllInterceptorsToHaveBeenCalled()` treated an interceptor as finished when it was **removed** from the proxy queue. Removal happened in the HTTP request handler immediately after `handle()` returned, but `completeAfterIntercept()` was still streaming the response body. Tests then asserted on UI that depends on the full LLM response, racing the stream and causing intermittent timeouts (especially on the empty-suggestions path).

## Fix

- Stop removing interceptors in the request handler.
- Remove the interceptor in `completeAfterIntercept` after the simulated response is fully written (`finally` so cleanup runs on errors too).

## Validation

- `node scripts/eslint` on the touched file
- `node scripts/check_changes.ts`

Note: full Buildkite job logs were not pulled here; diagnosis is from code path analysis aligned with the failure signature.