### PR TITLE
[9.3] [HTTP] Safer client calls and new browser `buildPath` utility (#257230)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -933,6 +933,7 @@ module.exports = {
     {
       files: ['**/*.{js,mjs,ts,tsx}'],
       rules: {
+        '@kbn/eslint/no_unsafe_dynamic_http_path': 'warn',
         'no-restricted-imports': ['error', ...RESTRICTED_IMPORTS],
         '@kbn/eslint/no_deprecated_imports': ['warn', ...DEPRECATED_IMPORTS],
         'no-restricted-modules': [

--- a/examples/routing_example/public/services.ts
+++ b/examples/routing_example/public/services.ts
@@ -14,7 +14,7 @@ import type {
   ThemeServiceStart,
   UserProfileService,
 } from '@kbn/core/public';
-import type { IHttpFetchError } from '@kbn/core-http-browser';
+import { buildPath, type IHttpFetchError } from '@kbn/core-http-browser';
 import {
   RANDOM_NUMBER_ROUTE_PATH,
   RANDOM_NUMBER_BETWEEN_ROUTE_PATH,
@@ -66,7 +66,7 @@ export function getServices(core: CoreStart): Services {
     },
     postMessage: async (message: string, id: string) => {
       try {
-        await core.http.post(`${POST_MESSAGE_ROUTE_PATH}/${id}`, {
+        await core.http.post(buildPath(`${POST_MESSAGE_ROUTE_PATH}/{id}`, { id }), {
           body: JSON.stringify({ message }),
         });
       } catch (e) {

--- a/packages/kbn-eslint-plugin-eslint/index.js
+++ b/packages/kbn-eslint-plugin-eslint/index.js
@@ -18,6 +18,7 @@ module.exports = {
     no_trailing_import_slash: require('./rules/no_trailing_import_slash'),
     no_constructor_args_in_property_initializers: require('./rules/no_constructor_args_in_property_initializers'),
     no_this_in_property_initializers: require('./rules/no_this_in_property_initializers'),
+    no_unsafe_dynamic_http_path: require('./rules/no_unsafe_dynamic_http_path'),
     no_unsafe_console: require('./rules/no_unsafe_console'),
     no_unsafe_hash: require('./rules/no_unsafe_hash'),
     require_kibana_feature_privileges_naming: require('./rules/require_kibana_feature_privileges_naming'),

--- a/packages/kbn-eslint-plugin-eslint/rules/no_unsafe_dynamic_http_path.js
+++ b/packages/kbn-eslint-plugin-eslint/rules/no_unsafe_dynamic_http_path.js
@@ -1,0 +1,311 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+const tsEstree = require('@typescript-eslint/typescript-estree');
+const esTypes = tsEstree.AST_NODE_TYPES;
+
+/** @typedef {import("eslint").Rule.RuleModule} Rule */
+/** @typedef {import("@typescript-eslint/typescript-estree").TSESTree.CallExpression} CallExpression */
+/** @typedef {import("@typescript-eslint/typescript-estree").TSESTree.Expression} Expression */
+/** @typedef {import("@typescript-eslint/typescript-estree").TSESTree.MemberExpression} MemberExpression */
+/** @typedef {import("@typescript-eslint/typescript-estree").TSESTree.Node} Node */
+
+const HTTP_REQUEST_METHOD_NAMES = new Set([
+  'delete',
+  'fetch',
+  'get',
+  'head',
+  'options',
+  'patch',
+  'post',
+  'put',
+]);
+const WARN_MSG =
+  'Dangerous use of dynamic http path. Use buildPath() from `@kbn/core-http-browser` or encodeURIComponent() so path params are encoded safely.';
+const ALL_CAPS_IDENTIFIER_PATTERN = /^[A-Z][A-Z0-9_]*$/;
+
+/**
+ * Limitations:
+ * - This rule only inspects inline path expressions passed directly as the first argument to `http` request calls,
+ *   or inline `path` properties in the object overload (for example `http.get({ path: ... })`).
+ * - It does not perform data-flow analysis, so `const path = \`/api/${id}\`; http.delete(path)` is not flagged.
+ * - It only targets standard HTTP verb calls and `http.fetch(...)` on `http`-like receivers
+ *   (`http`, `this.http`, `foo.http`, etc.).
+ * - It treats `encodeURIComponent(...)` as a safe escape hatch, but it does not verify that callers are
+ *   encoding the correct path segment or using the best API shape for the route.
+ */
+
+/**
+ * @param {Node} node
+ * @returns {node is MemberExpression}
+ */
+const isMemberExpression = (node) => node.type === esTypes.MemberExpression;
+
+/**
+ * @param {Node} node
+ * @returns {boolean}
+ */
+const isHttpReference = (node) => {
+  if (node.type === esTypes.Identifier) {
+    return node.name === 'http';
+  }
+
+  if (!isMemberExpression(node) || node.computed || node.property.type !== esTypes.Identifier) {
+    return false;
+  }
+
+  if (node.property.name === 'http') {
+    return true;
+  }
+
+  return isHttpReference(node.object);
+};
+
+/**
+ * @param {Node} node
+ * @returns {boolean}
+ */
+const isUsingEncodeURIComponent = (node) => {
+  if (node.type === esTypes.CallExpression) {
+    const { callee } = node;
+
+    if (callee.type === esTypes.Identifier) {
+      return callee.name === 'encodeURIComponent';
+    }
+
+    return (
+      callee.type === esTypes.MemberExpression &&
+      !callee.computed &&
+      callee.property.type === esTypes.Identifier &&
+      callee.property.name === 'encodeURIComponent'
+    );
+  }
+
+  if (node.type === esTypes.BinaryExpression && node.operator === '+') {
+    return isUsingEncodeURIComponent(node.left) && isUsingEncodeURIComponent(node.right);
+  }
+
+  if (node.type === esTypes.ConditionalExpression) {
+    return isUsingEncodeURIComponent(node.consequent) && isUsingEncodeURIComponent(node.alternate);
+  }
+
+  return false;
+};
+
+/**
+ * @param {Node} node
+ * @returns {boolean}
+ */
+const isAllCapsIdentifier = (node) => {
+  return node.type === esTypes.Identifier && ALL_CAPS_IDENTIFIER_PATTERN.test(node.name);
+};
+
+/**
+ * @param {Node} node
+ * @returns {boolean}
+ */
+const isSafePathPrefixReference = (node) => {
+  if (isAllCapsIdentifier(node)) {
+    return true;
+  }
+
+  if (
+    node.type !== esTypes.MemberExpression ||
+    node.computed ||
+    node.property.type !== esTypes.Identifier
+  ) {
+    return false;
+  }
+
+  return isSafePathPrefixReference(node.object);
+};
+
+/**
+ * @param {Node} node
+ * @returns {boolean}
+ */
+const isPathExpressionStartingWithSlash = (node) => {
+  if (node.type === esTypes.Literal) {
+    return typeof node.value === 'string' && node.value.startsWith('/');
+  }
+
+  if (node.type === esTypes.TemplateLiteral) {
+    const cooked = node.quasis[0].value.cooked;
+    return typeof cooked === 'string' && cooked.startsWith('/');
+  }
+
+  if (node.type === esTypes.BinaryExpression && node.operator === '+') {
+    return isPathExpressionStartingWithSlash(node.left);
+  }
+
+  if (node.type === esTypes.ConditionalExpression) {
+    return (
+      isPathExpressionStartingWithSlash(node.consequent) &&
+      isPathExpressionStartingWithSlash(node.alternate)
+    );
+  }
+
+  return false;
+};
+
+/**
+ * @param {Node} node
+ * @returns {boolean}
+ */
+const isSafePathSegmentExpression = (node) => {
+  if (node.type === esTypes.Literal) {
+    return true;
+  }
+
+  if (isUsingEncodeURIComponent(node)) {
+    return true;
+  }
+
+  if (node.type === esTypes.TemplateLiteral) {
+    return isSafeTemplateLiteralPath(node);
+  }
+
+  if (node.type === esTypes.BinaryExpression && node.operator === '+') {
+    return (
+      (isSafePathSegmentExpression(node.left) && isSafePathSegmentExpression(node.right)) ||
+      (isSafePathPrefixReference(node.left) &&
+        isPathExpressionStartingWithSlash(node.right) &&
+        isSafePathSegmentExpression(node.right))
+    );
+  }
+
+  if (node.type === esTypes.ConditionalExpression) {
+    return (
+      isSafePathSegmentExpression(node.consequent) && isSafePathSegmentExpression(node.alternate)
+    );
+  }
+
+  return false;
+};
+
+/**
+ * @param {import("@typescript-eslint/typescript-estree").TSESTree.TemplateLiteral} node
+ * @returns {boolean}
+ */
+function isSafeTemplateLiteralPath(node) {
+  return node.expressions.every((expression, index) => {
+    if (isSafePathSegmentExpression(expression)) {
+      return true;
+    }
+
+    const afterExpr = node.quasis[1]?.value.cooked;
+    return (
+      index === 0 &&
+      isSafePathPrefixReference(expression) &&
+      node.quasis[0].value.cooked === '' &&
+      typeof afterExpr === 'string' &&
+      afterExpr.startsWith('/')
+    );
+  });
+}
+
+/**
+ * @param {Expression} node
+ * @returns {boolean}
+ */
+const isDynamicPathExpression = (node) => {
+  if (node.type === esTypes.TemplateLiteral) {
+    return !isSafePathSegmentExpression(node);
+  }
+
+  if (node.type === esTypes.BinaryExpression && node.operator === '+') {
+    return !isSafePathSegmentExpression(node);
+  }
+
+  if (node.type === esTypes.ConditionalExpression) {
+    return !isSafePathSegmentExpression(node);
+  }
+
+  return false;
+};
+
+/**
+ * @param {CallExpression} node
+ * @returns {boolean}
+ */
+const isHttpRequestCall = (node) => {
+  if (
+    node.callee.type !== esTypes.MemberExpression ||
+    node.callee.computed ||
+    node.callee.property.type !== esTypes.Identifier ||
+    !HTTP_REQUEST_METHOD_NAMES.has(node.callee.property.name)
+  ) {
+    return false;
+  }
+
+  return isHttpReference(node.callee.object);
+};
+
+/**
+ * @param {Expression | import("@typescript-eslint/typescript-estree").TSESTree.SpreadElement} node
+ * @returns {Expression | undefined}
+ */
+const getPathExpression = (node) => {
+  if (node.type === esTypes.SpreadElement) {
+    return undefined;
+  }
+
+  if (node.type !== esTypes.ObjectExpression) {
+    return node;
+  }
+
+  for (const property of node.properties) {
+    if (property.type !== esTypes.Property || property.computed || property.kind !== 'init') {
+      continue;
+    }
+
+    const isPathKey =
+      (property.key.type === esTypes.Identifier && property.key.name === 'path') ||
+      (property.key.type === esTypes.Literal && property.key.value === 'path');
+
+    if (isPathKey) {
+      return property.value;
+    }
+  }
+
+  return undefined;
+};
+
+/** @type {Rule} */
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Disallow dynamically building inline paths in http request calls so callers use buildPath instead',
+    },
+    schema: [],
+  },
+  create(context) {
+    return {
+      CallExpression(_) {
+        const node = /** @type {CallExpression} */ (_);
+        if (!isHttpRequestCall(node) || node.arguments.length === 0) {
+          return;
+        }
+
+        const [firstArgument] = node.arguments;
+        const pathExpression = getPathExpression(firstArgument);
+        if (!pathExpression || !isDynamicPathExpression(pathExpression)) {
+          return;
+        }
+
+        context.report({
+          node: pathExpression,
+          message: WARN_MSG,
+        });
+      },
+    };
+  },
+};

--- a/packages/kbn-eslint-plugin-eslint/rules/no_unsafe_dynamic_http_path.test.js
+++ b/packages/kbn-eslint-plugin-eslint/rules/no_unsafe_dynamic_http_path.test.js
@@ -1,0 +1,171 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+const { RuleTester } = require('eslint');
+const dedent = require('dedent');
+const rule = require('./no_unsafe_dynamic_http_path');
+
+const ruleTester = new RuleTester({
+  parser: require.resolve('@typescript-eslint/parser'),
+  parserOptions: {
+    sourceType: 'module',
+    ecmaVersion: 2018,
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
+});
+
+const WARN_MSG =
+  'Dangerous use of dynamic http path. Use buildPath() from `@kbn/core-http-browser` or encodeURIComponent() so path params are encoded safely.';
+
+ruleTester.run('@kbn/eslint/no_unsafe_dynamic_http_path', rule, {
+  valid: [
+    {
+      code: dedent`
+        http.delete('/api/dashboards/123');
+      `,
+    },
+    {
+      code: dedent`
+        http.delete(buildPath('/api/dashboards/{id}', { id }));
+      `,
+    },
+    {
+      code: ['const path = `/api/dashboards/${id}`;', 'http.delete(path);'].join('\n'),
+    },
+    {
+      code: 'http.post(`/api/dashboards/${encodeURIComponent(id)}`);',
+    },
+    {
+      code: dedent`
+        client.delete(\`/api/dashboards/\${id}\`);
+      `,
+    },
+    {
+      code: 'http.delete(`/api/dashboards/${encodeURIComponent(id)}`);',
+    },
+    {
+      code: dedent`
+        http.delete('/api/dashboards/' + encodeURIComponent(id));
+      `,
+    },
+    {
+      code: dedent`
+        http.get({ path: buildPath('/api/dashboards/{id}', { id }) });
+      `,
+    },
+    {
+      code: dedent`
+        http.put({ path: '/api/dashboards/' + encodeURIComponent(id) });
+      `,
+    },
+    {
+      code: dedent`
+        http.patch({ 'path': '/api/dashboards/' + encodeURIComponent(id), body });
+      `,
+    },
+    {
+      code: dedent`
+        http.fetch(buildPath('/api/dashboards/{id}', { id }), { method: 'DELETE' });
+      `,
+    },
+    {
+      code: dedent`
+        http.fetch({ path: buildPath('/api/dashboards/{id}', { id }), method: 'POST', body });
+      `,
+    },
+    {
+      code: dedent`
+        http.fetch({ body: '/api/dashboards/' + id, method: 'POST' });
+      `,
+    },
+    {
+      code: [
+        'return await this.http.delete<void>(',
+        '  `${INTERNAL_ROUTES.JOBS.DELETE_PREFIX}/${encodeURIComponent(jobId)}`',
+        ');',
+      ].join('\n'),
+    },
+    {
+      code: dedent`
+        return await this.http.delete<void>(
+          INTERNAL_ROUTES.JOBS.DELETE_PREFIX + '/' + encodeURIComponent(jobId)
+        );
+      `,
+    },
+    {
+      code: 'http.get({ path: `${MY_CONSTANT.path}/${encodeURIComponent(id)}` });',
+    },
+  ],
+  invalid: [
+    {
+      code: 'http.delete(`/api/dashboards/${id}`);',
+      errors: [{ line: 1, message: WARN_MSG }],
+    },
+    {
+      code: 'this.http.get(`/api/dashboards/${id}`);',
+      errors: [{ line: 1, message: WARN_MSG }],
+    },
+    {
+      code: dedent`
+        Legacy.shims.http.post('/api/dashboards/' + id);
+      `,
+      errors: [{ line: 1, message: WARN_MSG }],
+    },
+    {
+      code: dedent`
+        getServices().http.put({ path: basePath + '/' + id });
+      `,
+      errors: [{ line: 1, message: WARN_MSG }],
+    },
+    {
+      code: "http.options(condition ? `/api/dashboards/${id}` : '/api/dashboards/default');",
+      errors: [{ line: 1, message: WARN_MSG }],
+    },
+    {
+      code: "http.head({ path: condition ? `/api/dashboards/${id}` : '/api/dashboards/default' });",
+      errors: [{ line: 1, message: WARN_MSG }],
+    },
+    {
+      code: dedent`
+        http.patch({ 'path': '/api/dashboards/' + id, body });
+      `,
+      errors: [{ line: 1, message: WARN_MSG }],
+    },
+    {
+      code: dedent`
+        http.fetch('/api/dashboards/' + id, { method: 'DELETE' });
+      `,
+      errors: [{ line: 1, message: WARN_MSG }],
+    },
+    {
+      code: "this.http.fetch({ path: `/api/dashboards/${id}`, method: 'POST', body });",
+      errors: [{ line: 1, message: WARN_MSG }],
+    },
+    {
+      code: 'this.http.delete(`${INTERNAL_ROUTES.JOBS.DELETE_PREFIX}/${jobId}`);',
+      errors: [{ line: 1, message: WARN_MSG }],
+    },
+    {
+      code: dedent`
+        this.http.delete(INTERNAL_ROUTES.JOBS.DELETE_PREFIX + '/' + jobId);
+      `,
+      errors: [{ line: 1, message: WARN_MSG }],
+    },
+    {
+      code: 'this.http.get(`${prefix}/${encodeURIComponent(id)}`);',
+      errors: [{ line: 1, message: WARN_MSG }],
+    },
+    {
+      code: 'this.http.get(`${MY_CONSTANT.path}/${MY_CONSTANT.path2}`);',
+      errors: [{ line: 1, message: WARN_MSG }],
+    },
+  ],
+});

--- a/src/core/packages/http/browser/index.ts
+++ b/src/core/packages/http/browser/index.ts
@@ -30,4 +30,4 @@ export type {
   IHttpInterceptController,
 } from './src/types';
 
-export { isHttpFetchError } from './src/utils';
+export { buildPath, isHttpFetchError } from './src/utils';

--- a/src/core/packages/http/browser/src/utils.test.ts
+++ b/src/core/packages/http/browser/src/utils.test.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { buildPath } from './utils';
+
+describe('buildPath', () => {
+  it('encodes required path parameters', () => {
+    expect(
+      buildPath('/api/myapi/{id}/{name?}', {
+        id: '../../test',
+      })
+    ).toBe('/api/myapi/..%2F..%2Ftest');
+  });
+
+  it('encodes two required path parameters', () => {
+    expect(
+      buildPath('/api/myapi/{id}/{name}', {
+        id: 'hello//',
+        name: '//world',
+      })
+    ).toBe('/api/myapi/hello%2F%2F/%2F%2Fworld');
+  });
+
+  it('adds optional path segments when the parameter is present', () => {
+    expect(buildPath('/api/myapi/{section}/{id?}', { section: 'test', id: 'tada' })).toBe(
+      '/api/myapi/test/tada'
+    );
+  });
+
+  it('removes optional path segments when the parameter is missing', () => {
+    expect(buildPath('/api/myapi/{section}/{id?}', { section: 'test' })).toBe('/api/myapi/test');
+  });
+
+  it('removes optional path segments when the parameter is undefined', () => {
+    const params: { section: string; id: string | undefined } = {
+      section: 'test',
+      id: undefined,
+    };
+
+    expect(buildPath('/api/myapi/{section}/{id?}', params)).toBe('/api/myapi/test');
+  });
+
+  it('encodes multi-segment path parameters', () => {
+    expect(
+      buildPath('/api/myapi/{filePath*}', {
+        filePath: 'nested/folder/my file.txt',
+      })
+    ).toBe('/api/myapi/nested/folder/my%20file.txt');
+  });
+
+  it('encodes counted multi-segment path parameters from arrays', () => {
+    expect(
+      buildPath('/api/myapi/{coordinates*2}', {
+        coordinates: ['north east', 'south/west'],
+      })
+    ).toBe('/api/myapi/north%20east/south%2Fwest');
+  });
+
+  it('throws when a counted multi-segment path parameter has the wrong number of segments', () => {
+    expect(() => buildPath('/api/myapi/{coordinates*2}', { coordinates: 'only-one' })).toThrow(
+      'Expected 2 path segment(s) for parameter: coordinates, received 1'
+    );
+  });
+
+  it('throws when unsupported path template syntax remains unresolved', () => {
+    expect(() => buildPath('/api/myapi/{filePath?*}', { filePath: 'nested/file.txt' })).toThrow(
+      'Unsupported path template syntax: {filePath?*}'
+    );
+  });
+
+  it('throws when a required path parameter is missing', () => {
+    expect(() => buildPath('/api/dashboards/{id}', {})).toThrow(
+      'Missing required path parameter: id'
+    );
+  });
+});

--- a/src/core/packages/http/browser/src/utils.ts
+++ b/src/core/packages/http/browser/src/utils.ts
@@ -13,3 +13,89 @@ import type { IHttpFetchError } from './types';
 export function isHttpFetchError<T>(error: T | IHttpFetchError): error is IHttpFetchError {
   return error instanceof Error && 'request' in error && 'name' in error;
 }
+
+type HttpPathParamPrimitive = string | number | boolean;
+type HttpPathParamValue = HttpPathParamPrimitive | readonly HttpPathParamPrimitive[];
+type HttpPathParams = Record<string, HttpPathParamValue | undefined>;
+
+const OPTIONAL_PATH_SEGMENT_REGEX = /\/\{(\w+)\?\}/g;
+const REQUIRED_PATH_PARAM_REGEX = /\{(\w+)(\*(\d*))?\}/g;
+const UNSUPPORTED_PATH_TEMPLATE_REGEX = /\{[^}]+\}/;
+
+const encodePathSegment = (value: HttpPathParamPrimitive) => encodeURIComponent(String(value));
+
+const getMultiSegmentValues = (value: HttpPathParamValue) =>
+  Array.isArray(value) ? value : String(value).split('/');
+
+const serializePathParam = (
+  paramName: string,
+  value: HttpPathParamValue,
+  segmentCount?: number
+) => {
+  if (segmentCount == null) {
+    if (Array.isArray(value)) {
+      throw new Error(`Expected a single path segment for parameter: ${paramName}`);
+    }
+
+    return encodePathSegment(value as HttpPathParamPrimitive);
+  }
+
+  // Wildcard params represent multiple path segments, so string inputs are split on `/`
+  // before each segment is encoded and re-joined.
+  const segments = getMultiSegmentValues(value);
+
+  if (segmentCount > -1 && segments.length !== segmentCount) {
+    throw new Error(
+      `Expected ${segmentCount} path segment(s) for parameter: ${paramName}, received ${segments.length}`
+    );
+  }
+
+  return segments.map(encodePathSegment).join('/');
+};
+/**
+ * Builds a URL path from a route template by URI-encoding path params.
+ *
+ * @example
+ * buildPath('/api/dashboards/{id}', { id: '../../../internal/security/users/foo' });
+ * // '/api/dashboards/..%2F..%2F..%2Finternal%2Fsecurity%2Fusers%2Ffoo'
+ *
+ * @example
+ * buildPath('/api/files/{filePath*}', { filePath: 'nested/folder/my file.txt' });
+ * // '/api/files/nested/folder/my%20file.txt'
+ *
+ * @public
+ */
+export function buildPath(path: string, params: HttpPathParams = {}) {
+  const pathWithOptionalSegments = path.replace(OPTIONAL_PATH_SEGMENT_REGEX, (match, paramName) => {
+    const value = params[paramName];
+    return value == null ? '' : `/${serializePathParam(paramName, value)}`;
+  });
+
+  const builtPath = pathWithOptionalSegments.replace(
+    REQUIRED_PATH_PARAM_REGEX,
+    (match, paramName, multiSegmentMatch, segmentCountMatch) => {
+      const value = params[paramName];
+
+      if (value == null) {
+        throw new Error(`Missing required path parameter: ${paramName}`);
+      }
+
+      const segmentCount =
+        multiSegmentMatch == null
+          ? undefined
+          : segmentCountMatch === ''
+          ? -1
+          : Number(segmentCountMatch);
+
+      return serializePathParam(paramName, value, segmentCount);
+    }
+  );
+
+  const unsupportedToken = builtPath.match(UNSUPPORTED_PATH_TEMPLATE_REGEX)?.[0];
+
+  if (unsupportedToken) {
+    throw new Error(`Unsupported path template syntax: ${unsupportedToken}`);
+  }
+
+  return builtPath;
+}

--- a/src/platform/packages/shared/content-management/favorites/favorites_public/src/favorites_client.ts
+++ b/src/platform/packages/shared/content-management/favorites/favorites_public/src/favorites_client.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { HttpStart } from '@kbn/core-http-browser';
+import { type HttpStart } from '@kbn/core-http-browser';
 import type { UsageCollectionStart } from '@kbn/usage-collection-plugin/public';
 import type { UserProfileServiceStart } from '@kbn/core-user-profile-browser';
 import type {

--- a/src/platform/packages/shared/home/sample_data_card/src/services.tsx
+++ b/src/platform/packages/shared/home/sample_data_card/src/services.tsx
@@ -121,7 +121,7 @@ export const SampleDataCardKibanaProvider: FC<PropsWithChildren<KibanaDependenci
       application.navigateToUrl(http.basePath.prepend(targetUrl));
     },
     installSampleDataSet: async (id, defaultIndex) => {
-      await http.post(`${SAMPLE_DATA_API}/${id}`);
+      await http.post(`${SAMPLE_DATA_API}/${encodeURIComponent(id)}`);
 
       if (uiSettings.isDefault('defaultIndex')) {
         uiSettings.set('defaultIndex', defaultIndex);
@@ -130,7 +130,7 @@ export const SampleDataCardKibanaProvider: FC<PropsWithChildren<KibanaDependenci
       clearDataViewsCache();
     },
     removeSampleDataSet: async (id, defaultIndex) => {
-      await http.delete(`${SAMPLE_DATA_API}/${id}`);
+      await http.delete(`${SAMPLE_DATA_API}/${encodeURIComponent(id)}`);
 
       if (
         !uiSettings.isDefault('defaultIndex') &&

--- a/src/platform/plugins/shared/dashboard/moon.yml
+++ b/src/platform/plugins/shared/dashboard/moon.yml
@@ -111,6 +111,7 @@ dependsOn:
   - '@kbn/cps'
   - '@kbn/scout'
   - '@kbn/test'
+  - '@kbn/core-http-browser'
 tags:
   - plugin
   - prod

--- a/src/platform/plugins/shared/dashboard/public/dashboard_client/dashboard_client.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_client/dashboard_client.ts
@@ -8,6 +8,7 @@
  */
 
 import { LRUCache } from 'lru-cache';
+import { buildPath } from '@kbn/core-http-browser';
 import { SavedObjectNotFound } from '@kbn/kibana-utils-plugin/public';
 import type { DeleteResult } from '@kbn/content-management-plugin/common';
 import type { Reference } from '@kbn/content-management-utils';
@@ -34,6 +35,9 @@ const cache = new LRUCache<string, DashboardReadResponseBody>({
   ttl: CACHE_TTL,
 });
 
+const buildDashboardPath = (id: string) => buildPath(`${DASHBOARD_API_PATH}/{id}`, { id });
+// const buildDashboardAppPath = (id: string) => buildPath(`${DASHBOARD_APP_API_PATH}/{id}`, { id });
+
 export const dashboardClient = {
   create: async (
     dashboardState: DashboardState,
@@ -56,7 +60,7 @@ export const dashboardClient = {
   },
   delete: async (id: string): Promise<DeleteResult> => {
     cache.delete(id);
-    return coreServices.http.delete(`${DASHBOARD_API_PATH}/${id}`, {
+    return coreServices.http.delete(buildDashboardPath(id), {
       version: DASHBOARD_API_VERSION,
     });
   },
@@ -66,7 +70,7 @@ export const dashboardClient = {
     }
 
     const result = await coreServices.http
-      .get<DashboardReadResponseBody>(`${DASHBOARD_API_PATH}/${id}`, {
+      .get<DashboardReadResponseBody>(buildDashboardPath(id), {
         version: DASHBOARD_API_VERSION,
         query: {
           allowUnmappedKeys: true,
@@ -103,7 +107,7 @@ export const dashboardClient = {
   },
   update: async (id: string, dashboardState: DashboardState, references: Reference[]) => {
     const updateResponse = await coreServices.http.put<DashboardUpdateResponseBody>(
-      `${DASHBOARD_API_PATH}/${id}`,
+      buildDashboardPath(id),
       {
         version: DASHBOARD_API_VERSION,
         query: {

--- a/src/platform/plugins/shared/dashboard/tsconfig.json
+++ b/src/platform/plugins/shared/dashboard/tsconfig.json
@@ -108,7 +108,8 @@
     "@kbn/core-chrome-layout-utils",
     "@kbn/cps",
     "@kbn/scout",
-    "@kbn/test"
+    "@kbn/test",
+    "@kbn/core-http-browser"
   ],
   "exclude": ["target/**/*"]
 }

--- a/src/platform/plugins/shared/dashboard_markdown/moon.yml
+++ b/src/platform/plugins/shared/dashboard_markdown/moon.yml
@@ -27,6 +27,7 @@ dependsOn:
   - '@kbn/embeddable-plugin'
   - '@kbn/config-schema'
   - '@kbn/presentation-publishing-schemas'
+  - '@kbn/core-http-browser'
 tags:
   - plugin
   - prod

--- a/src/platform/plugins/shared/dashboard_markdown/tsconfig.json
+++ b/src/platform/plugins/shared/dashboard_markdown/tsconfig.json
@@ -15,6 +15,7 @@
     "@kbn/embeddable-plugin",
     "@kbn/config-schema",
     "@kbn/presentation-publishing-schemas",
+    "@kbn/core-http-browser",
   ],
   "exclude": ["target/**/*"]
 }

--- a/src/platform/plugins/shared/data/public/search/search_interceptor/search_interceptor.ts
+++ b/src/platform/plugins/shared/data/public/search/search_interceptor/search_interceptor.ts
@@ -52,6 +52,7 @@ import type {
   UserProfileService,
 } from '@kbn/core/public';
 
+import { buildPath } from '@kbn/core-http-browser';
 import { toMountPoint } from '@kbn/react-kibana-mount';
 import type { KibanaServerError } from '@kbn/kibana-utils-plugin/public';
 import { AbortError } from '@kbn/kibana-utils-plugin/public';
@@ -358,7 +359,15 @@ export class SearchInterceptor {
         });
 
     const sendCancelRequest = once(() =>
-      this.deps.http.delete(`/internal/search/${strategy}/${id}`, { version: '1' })
+      this.deps.http.delete(
+        buildPath('/internal/search/{strategy}/{id}', {
+          strategy,
+          id: id as string,
+        }),
+        {
+          version: '1',
+        }
+      )
     );
 
     const cancel = async () => {
@@ -481,7 +490,10 @@ export class SearchInterceptor {
 
     return this.deps.http
       .post<IKibanaSearchResponse | ErrorResponseBase>(
-        `/internal/search/${strategy}${request.id ? `/${request.id}` : ''}`,
+        buildPath('/internal/search/{strategy}/{id?}', {
+          strategy,
+          id: request.id,
+        }),
         {
           version: '1',
           signal: abortSignal,

--- a/src/platform/plugins/shared/home/public/application/sample_data_client.ts
+++ b/src/platform/plugins/shared/home/public/application/sample_data_client.ts
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { buildPath } from '@kbn/core-http-browser';
 import { getServices } from './kibana_services';
 
 const sampleDataUrl = '/api/sample_data';
@@ -30,7 +31,7 @@ export async function installSampleDataSet(id: string, sampleDataDefaultIndex: s
 }
 
 export async function uninstallSampleDataSet(id: string, sampleDataDefaultIndex: string) {
-  await getServices().http.delete(`${sampleDataUrl}/${id}`);
+  await getServices().http.delete(buildPath(`${sampleDataUrl}/{id}`, { id }));
 
   const uiSettings = getServices().uiSettings;
 

--- a/x-pack/platform/plugins/private/canvas/moon.yml
+++ b/x-pack/platform/plugins/private/canvas/moon.yml
@@ -74,6 +74,7 @@ dependsOn:
   - '@kbn/deeplinks-analytics'
   - '@kbn/core-saved-objects-api-server'
   - '@kbn/visualizations-common'
+  - '@kbn/core-http-browser'
 tags:
   - plugin
   - prod

--- a/x-pack/platform/plugins/private/canvas/public/services/canvas_custom_element_service.ts
+++ b/x-pack/platform/plugins/private/canvas/public/services/canvas_custom_element_service.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { buildPath } from '@kbn/core-http-browser';
 import { API_ROUTE_CUSTOM_ELEMENT } from '../../common/lib';
 import type { CustomElement } from '../../types';
 import { coreServices } from './kibana_services';
@@ -31,14 +32,14 @@ class CanvasCustomElementService {
   }
 
   public async update(id: string, element: Partial<CustomElement>) {
-    await coreServices.http.put(`${this.apiPath}/${id}`, {
+    await coreServices.http.put(buildPath(`${this.apiPath}/{id}`, { id }), {
       body: JSON.stringify(element),
       version: '1',
     });
   }
 
   public async remove(id: string) {
-    await coreServices.http.delete(`${this.apiPath}/${id}`, { version: '1' });
+    await coreServices.http.delete(buildPath(`${this.apiPath}/{id}`, { id }), { version: '1' });
   }
 
   public async find(searchTerm: string): Promise<CustomElementFindResponse> {

--- a/x-pack/platform/plugins/private/canvas/public/services/canvas_workpad_service.ts
+++ b/x-pack/platform/plugins/private/canvas/public/services/canvas_workpad_service.ts
@@ -6,6 +6,7 @@
  */
 
 import type { SavedObjectsResolveResponse, SavedObject } from '@kbn/core-saved-objects-api-server';
+import { buildPath } from '@kbn/core-http-browser';
 import {
   API_ROUTE_TEMPLATES,
   API_ROUTE_WORKPAD,
@@ -69,7 +70,9 @@ class CanvasWorkpadService {
   private apiPath = `${API_ROUTE_WORKPAD}`;
 
   public async get(id: string): Promise<CanvasWorkpad> {
-    const workpad = await coreServices.http.get<any>(`${this.apiPath}/${id}`, { version: '1' });
+    const workpad = await coreServices.http.get<any>(buildPath(`${this.apiPath}/{id}`, { id }), {
+      version: '1',
+    });
 
     return { css: DEFAULT_WORKPAD_CSS, variables: [], ...workpad };
   }
@@ -110,7 +113,7 @@ class CanvasWorkpadService {
   }
 
   public async create(workpad: CanvasWorkpad): Promise<CanvasWorkpad> {
-    return coreServices.http.post(this.apiPath, {
+    return await coreServices.http.post(this.apiPath, {
       body: JSON.stringify({
         ...sanitizeWorkpad({ ...workpad }),
         assets: workpad.assets || {},
@@ -121,7 +124,7 @@ class CanvasWorkpadService {
   }
 
   public async import(workpad: CanvasWorkpad): Promise<CanvasWorkpad> {
-    return coreServices.http.post(`${this.apiPath}/import`, {
+    return await coreServices.http.post(`${this.apiPath}/import`, {
       body: JSON.stringify({
         ...sanitizeWorkpad({ ...workpad }),
         assets: workpad.assets || {},
@@ -132,21 +135,21 @@ class CanvasWorkpadService {
   }
 
   public async createFromTemplate(templateId: string): Promise<CanvasWorkpad> {
-    return coreServices.http.post(this.apiPath, {
+    return await coreServices.http.post(this.apiPath, {
       body: JSON.stringify({ templateId }),
       version: '1',
     });
   }
 
   public async findTemplates(): Promise<TemplateFindResponse> {
-    return coreServices.http.get(API_ROUTE_TEMPLATES, { version: '1' });
+    return await coreServices.http.get(API_ROUTE_TEMPLATES, { version: '1' });
   }
 
   public async find(searchTerm: string): Promise<WorkpadFindResponse> {
     // TODO: this shouldn't be necessary.  Check for usage.
     const validSearchTerm = typeof searchTerm === 'string' && searchTerm.length > 0;
 
-    return coreServices.http.get(`${this.apiPath}/find`, {
+    return await coreServices.http.get(`${this.apiPath}/find`, {
       query: {
         perPage: 10000,
         name: validSearchTerm ? searchTerm : '',
@@ -156,25 +159,27 @@ class CanvasWorkpadService {
   }
 
   public async remove(id: string) {
-    coreServices.http.delete(`${this.apiPath}/${id}`, { version: '1' });
+    return await coreServices.http.delete(buildPath(`${this.apiPath}/{id}`, { id }), {
+      version: '1',
+    });
   }
 
   public async update(id: string, workpad: CanvasWorkpad) {
-    coreServices.http.put(`${this.apiPath}/${id}`, {
+    return await coreServices.http.put(buildPath(`${this.apiPath}/{id}`, { id }), {
       body: JSON.stringify({ ...sanitizeWorkpad({ ...workpad }) }),
       version: '1',
     });
   }
 
   public async updateWorkpad(id: string, workpad: CanvasWorkpad) {
-    coreServices.http.put(`${API_ROUTE_WORKPAD_STRUCTURES}/${id}`, {
+    return await coreServices.http.put(buildPath(`${API_ROUTE_WORKPAD_STRUCTURES}/{id}`, { id }), {
       body: JSON.stringify({ ...sanitizeWorkpad({ ...workpad }) }),
       version: '1',
     });
   }
 
   public async updateAssets(id: string, assets: CanvasWorkpad['assets']) {
-    coreServices.http.put(`${API_ROUTE_WORKPAD_ASSETS}/${id}`, {
+    return await coreServices.http.put(buildPath(`${API_ROUTE_WORKPAD_ASSETS}/{id}`, { id }), {
       body: JSON.stringify(assets),
       version: '1',
     });

--- a/x-pack/platform/plugins/private/canvas/tsconfig.json
+++ b/x-pack/platform/plugins/private/canvas/tsconfig.json
@@ -81,7 +81,8 @@
     "@kbn/content-management-utils",
     "@kbn/deeplinks-analytics",
     "@kbn/core-saved-objects-api-server",
-    "@kbn/visualizations-common"
+    "@kbn/visualizations-common",
+    "@kbn/core-http-browser"
   ],
   "exclude": ["target/**/*"]
 }

--- a/x-pack/platform/plugins/private/logstash/moon.yml
+++ b/x-pack/platform/plugins/private/logstash/moon.yml
@@ -31,6 +31,7 @@ dependsOn:
   - '@kbn/react-kibana-context-render'
   - '@kbn/core-plugins-browser'
   - '@kbn/scout'
+  - '@kbn/core-http-browser'
 tags:
   - plugin
   - prod

--- a/x-pack/platform/plugins/private/logstash/public/services/pipeline/pipeline_service.js
+++ b/x-pack/platform/plugins/private/logstash/public/services/pipeline/pipeline_service.js
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { buildPath } from '@kbn/core-http-browser';
 import { ROUTES } from '../../../common/constants';
 import { Pipeline } from '../../models/pipeline';
 
@@ -32,7 +33,7 @@ export class PipelineService {
 
   deletePipeline(id) {
     return this.http
-      .delete(`${ROUTES.API_ROOT}/pipeline/${id}`)
+      .delete(buildPath(`${ROUTES.API_ROOT}/pipeline/{id}`, { id }))
       .then(() => this.pipelinesService.addToRecentlyDeleted(id))
       .catch((e) => {
         throw e.message;

--- a/x-pack/platform/plugins/private/logstash/tsconfig.json
+++ b/x-pack/platform/plugins/private/logstash/tsconfig.json
@@ -19,7 +19,8 @@
     "@kbn/code-editor",
     "@kbn/react-kibana-context-render",
     "@kbn/core-plugins-browser",
-    "@kbn/scout"
+    "@kbn/scout",
+    "@kbn/core-http-browser"
   ],
   "exclude": ["target/**/*"]
 }

--- a/x-pack/platform/plugins/shared/lens/moon.yml
+++ b/x-pack/platform/plugins/shared/lens/moon.yml
@@ -147,6 +147,7 @@ dependsOn:
   - '@kbn/unified-tabs'
   - '@kbn/esql-composer'
   - '@kbn/cps'
+  - '@kbn/core-http-browser'
 tags:
   - plugin
   - prod

--- a/x-pack/platform/plugins/shared/lens/public/persistence/lens_client.ts
+++ b/x-pack/platform/plugins/shared/lens/public/persistence/lens_client.ts
@@ -6,6 +6,7 @@
  */
 
 import type { HttpStart } from '@kbn/core/public';
+import { buildPath } from '@kbn/core-http-browser';
 import type { Reference } from '@kbn/content-management-utils';
 import type { LensConfigBuilder } from '@kbn/lens-embeddable-utils/config_builder';
 import type { LensApiState } from '@kbn/lens-embeddable-utils/config_builder/schema';
@@ -54,9 +55,12 @@ export class LensClient {
       data,
       meta,
       id: responseId,
-    } = await this.http.get<LensGetResponseBody>(`${LENS_VIS_API_PATH}/${id}`, {
-      version: LENS_API_VERSION,
-    });
+    } = await this.http.get<LensGetResponseBody>(
+      buildPath(`${LENS_VIS_API_PATH}/{id}`, { id }),
+      {
+        version: LENS_API_VERSION,
+      }
+    );
 
     const chartType = this.builder?.getType(data);
 
@@ -181,7 +185,7 @@ export class LensClient {
           };
 
     const { data, meta, ...rest } = await this.http.put<LensUpdateResponseBody>(
-      `${LENS_VIS_API_PATH}/${id}`,
+      buildPath(`${LENS_VIS_API_PATH}/{id}`, { id }),
       {
         body: JSON.stringify(body),
         query: options,
@@ -216,10 +220,13 @@ export class LensClient {
   }
 
   async delete(id: string): Promise<{ success: boolean }> {
-    const response = await this.http.delete(`${LENS_VIS_API_PATH}/${id}`, {
-      asResponse: true,
-      version: LENS_API_VERSION,
-    });
+    const response = await this.http.delete(
+      buildPath(`${LENS_VIS_API_PATH}/{id}`, { id }),
+      {
+        asResponse: true,
+        version: LENS_API_VERSION,
+      }
+    );
     const success = response.response?.ok ?? false;
 
     return { success };

--- a/x-pack/platform/plugins/shared/lens/tsconfig.json
+++ b/x-pack/platform/plugins/shared/lens/tsconfig.json
@@ -135,6 +135,7 @@
     "@kbn/unified-tabs",
     "@kbn/esql-composer",
     "@kbn/cps",
+    "@kbn/core-http-browser",
   ],
   "exclude": ["target/**/*"]
 }

--- a/x-pack/platform/plugins/shared/osquery/moon.yml
+++ b/x-pack/platform/plugins/shared/osquery/moon.yml
@@ -78,6 +78,7 @@ dependsOn:
   - '@kbn/core-http-server'
   - '@kbn/react-query'
   - '@kbn/react-kibana-mount'
+  - '@kbn/core-http-browser'
 tags:
   - plugin
   - prod

--- a/x-pack/platform/plugins/shared/osquery/public/packs/use_delete_pack.ts
+++ b/x-pack/platform/plugins/shared/osquery/public/packs/use_delete_pack.ts
@@ -8,6 +8,7 @@
 import { useMutation, useQueryClient } from '@kbn/react-query';
 import { i18n } from '@kbn/i18n';
 
+import { buildPath } from '@kbn/core-http-browser';
 import { API_VERSIONS } from '../../common/constants';
 import { useKibana } from '../common/lib/kibana';
 import { PLUGIN_ID } from '../../common';
@@ -31,7 +32,7 @@ export const useDeletePack = ({ packId, withRedirect }: UseDeletePackProps) => {
 
   return useMutation(
     () =>
-      http.delete(`/api/osquery/packs/${packId}`, {
+      http.delete(buildPath('/api/osquery/packs/{packId}', { packId }), {
         version: API_VERSIONS.public.v1,
       }),
     {

--- a/x-pack/platform/plugins/shared/osquery/public/saved_queries/use_delete_saved_query.ts
+++ b/x-pack/platform/plugins/shared/osquery/public/saved_queries/use_delete_saved_query.ts
@@ -8,6 +8,7 @@
 import { useMutation, useQueryClient } from '@kbn/react-query';
 import { i18n } from '@kbn/i18n';
 
+import { buildPath } from '@kbn/core-http-browser';
 import { API_VERSIONS } from '../../common/constants';
 import { useKibana } from '../common/lib/kibana';
 import { PLUGIN_ID } from '../../common';
@@ -30,7 +31,7 @@ export const useDeleteSavedQuery = ({ savedQueryId }: UseDeleteSavedQueryProps) 
 
   return useMutation(
     () =>
-      http.delete(`/api/osquery/saved_queries/${savedQueryId}`, {
+      http.delete(buildPath('/api/osquery/saved_queries/{savedQueryId}', { savedQueryId }), {
         version: API_VERSIONS.public.v1,
       }),
     {

--- a/x-pack/platform/plugins/shared/osquery/tsconfig.json
+++ b/x-pack/platform/plugins/shared/osquery/tsconfig.json
@@ -85,6 +85,7 @@
     "@kbn/setup-node-env",
     "@kbn/core-http-server",
     "@kbn/react-query",
-    "@kbn/react-kibana-mount"
+    "@kbn/react-kibana-mount",
+    "@kbn/core-http-browser"
   ]
 }

--- a/x-pack/solutions/observability/plugins/observability/public/components/annotations/hooks/use_delete_annotation.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/components/annotations/hooks/use_delete_annotation.tsx
@@ -13,6 +13,7 @@ import { toMountPoint } from '@kbn/react-kibana-mount';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
 import { RedirectAppLinks } from '@kbn/shared-ux-link-redirect-app';
+import { buildPath } from '@kbn/core-http-browser';
 import type { Annotation } from '../../../../common/annotations';
 import { useKibana } from '../../../utils/kibana_react';
 
@@ -31,7 +32,7 @@ export function useDeleteAnnotation() {
     ['deleteAnnotation'],
     async ({ annotations }) => {
       for (const annotation of annotations) {
-        await http.delete(`/api/observability/annotation/${annotation.id}`);
+        await http.delete(buildPath('/api/observability/annotation/{id}', { id: annotation.id }));
       }
       return Promise.resolve();
     },

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/api/connector/delete_connector_api_logic.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/api/connector/delete_connector_api_logic.ts
@@ -4,6 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+import { buildPath } from '@kbn/core-http-browser';
 import { i18n } from '@kbn/i18n';
 
 import type { DeleteConnectorResponse } from '../../../../../common/types/connectors';
@@ -27,11 +28,14 @@ export const deleteConnector = async ({
   connectorName,
   shouldDeleteIndex = false,
 }: DeleteConnectorApiLogicArgs): Promise<DeleteConnectorApiLogicResponse> => {
-  await HttpLogic.values.http.delete(`/internal/enterprise_search/connectors/${connectorId}`, {
-    query: {
-      shouldDeleteIndex,
-    },
-  });
+  await HttpLogic.values.http.delete(
+    buildPath('/internal/enterprise_search/connectors/{connectorId}', { connectorId }),
+    {
+      query: {
+        shouldDeleteIndex,
+      },
+    }
+  );
   return { connectorName };
 };
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[HTTP] Safer client calls and new browser `buildPath` utility (#257230)](https://github.com/elastic/kibana/pull/257230)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jean-Louis Leysens","email":"jeanlouis.leysens@elastic.co"},"sourceCommit":{"committedDate":"2026-04-03T08:55:07Z","message":"[HTTP] Safer client calls and new browser `buildPath` utility (#257230)\n\n- Create a new best-effort ESLint rule that checks if `http<method>`\ncalls are used dangerously: direct path injection\n- Adds a new `buildPath` utility that can be used with server-side\nroutes `/api/myapi/{id}` to safely build and encode path parameters\n(**bonus**: server-side path `const`s can be reused by the client\ndirectly, no need to build these separately by hand)\n- Updates existing usages\n\n### No unsafe `http` path usage\n\nWill flag usages of `http` like:\n\n```ts\ncore.http.delete(`/api/myapi/${id}`, {...});\n```\n\nWith a message to use `buildPath` or `encodeURIComponent` in order to\nsafely encode parameters.\n\n### `buildPath`\n\nNot strictly needed in this PR, this utility allows for using server\nside paths like `/api/myapi/{id}` in a parameterised fashion like:\n\n```ts\nimport { buildPath } from '@kbn/core-http-browser';\n\nbuildPath('/api/dashboard/{id}' /* same as { path: ... } server side */, { id })\n// => /api/dashboard/encoded-id\n```\n\nHappy to exclude this utility if it simplifies things.\n\n(Made with cursor y'all)\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: coderabbitai[bot] <136622811+coderabbitai[bot]@users.noreply.github.com>\nCo-authored-by: Gerard Soldevila <gerard.soldevila@elastic.co>","sha":"2d722842cd669722e2b340b94f4ccb7a65169a09","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Core","release_note:skip","backport missing","backport:all-open","v9.4.0","v9.5.0","v9.3.4","v8.19.15"],"title":"[HTTP] Safer client calls and new browser `buildPath` utility","number":257230,"url":"https://github.com/elastic/kibana/pull/257230","mergeCommit":{"message":"[HTTP] Safer client calls and new browser `buildPath` utility (#257230)\n\n- Create a new best-effort ESLint rule that checks if `http<method>`\ncalls are used dangerously: direct path injection\n- Adds a new `buildPath` utility that can be used with server-side\nroutes `/api/myapi/{id}` to safely build and encode path parameters\n(**bonus**: server-side path `const`s can be reused by the client\ndirectly, no need to build these separately by hand)\n- Updates existing usages\n\n### No unsafe `http` path usage\n\nWill flag usages of `http` like:\n\n```ts\ncore.http.delete(`/api/myapi/${id}`, {...});\n```\n\nWith a message to use `buildPath` or `encodeURIComponent` in order to\nsafely encode parameters.\n\n### `buildPath`\n\nNot strictly needed in this PR, this utility allows for using server\nside paths like `/api/myapi/{id}` in a parameterised fashion like:\n\n```ts\nimport { buildPath } from '@kbn/core-http-browser';\n\nbuildPath('/api/dashboard/{id}' /* same as { path: ... } server side */, { id })\n// => /api/dashboard/encoded-id\n```\n\nHappy to exclude this utility if it simplifies things.\n\n(Made with cursor y'all)\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: coderabbitai[bot] <136622811+coderabbitai[bot]@users.noreply.github.com>\nCo-authored-by: Gerard Soldevila <gerard.soldevila@elastic.co>","sha":"2d722842cd669722e2b340b94f4ccb7a65169a09"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/257230","number":257230,"mergeCommit":{"message":"[HTTP] Safer client calls and new browser `buildPath` utility (#257230)\n\n- Create a new best-effort ESLint rule that checks if `http<method>`\ncalls are used dangerously: direct path injection\n- Adds a new `buildPath` utility that can be used with server-side\nroutes `/api/myapi/{id}` to safely build and encode path parameters\n(**bonus**: server-side path `const`s can be reused by the client\ndirectly, no need to build these separately by hand)\n- Updates existing usages\n\n### No unsafe `http` path usage\n\nWill flag usages of `http` like:\n\n```ts\ncore.http.delete(`/api/myapi/${id}`, {...});\n```\n\nWith a message to use `buildPath` or `encodeURIComponent` in order to\nsafely encode parameters.\n\n### `buildPath`\n\nNot strictly needed in this PR, this utility allows for using server\nside paths like `/api/myapi/{id}` in a parameterised fashion like:\n\n```ts\nimport { buildPath } from '@kbn/core-http-browser';\n\nbuildPath('/api/dashboard/{id}' /* same as { path: ... } server side */, { id })\n// => /api/dashboard/encoded-id\n```\n\nHappy to exclude this utility if it simplifies things.\n\n(Made with cursor y'all)\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: coderabbitai[bot] <136622811+coderabbitai[bot]@users.noreply.github.com>\nCo-authored-by: Gerard Soldevila <gerard.soldevila@elastic.co>","sha":"2d722842cd669722e2b340b94f4ccb7a65169a09"}},{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.3","label":"v9.3.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/265250","number":265250,"state":"OPEN"},{"branch":"8.19","label":"v8.19.15","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/265249","number":265249,"state":"OPEN"}]}] BACKPORT-->