### PR TITLE
[Inference] Fix token usage dashboard creation

### DIFF
--- a/x-pack/platform/plugins/private/gen_ai_settings/public/components/gen_ai_settings_app.test.tsx
+++ b/x-pack/platform/plugins/private/gen_ai_settings/public/components/gen_ai_settings_app.test.tsx
@@ -20,6 +20,7 @@ import {
   AGENT_BUILDER_EXPERIMENTAL_FEATURES_SETTING_ID,
   AI_ASSISTANT_PREFERRED_AI_ASSISTANT_TYPE,
   AI_CHAT_EXPERIENCE_TYPE,
+  GEN_AI_SETTINGS_TOKEN_USAGE_TRACKING,
 } from '@kbn/management-settings-ids';
 import { WORKFLOWS_UI_SETTING_ID } from '@kbn/workflows';
 
@@ -65,6 +66,10 @@ describe('GenAiSettingsApp', () => {
       type: 'select',
       options: ['default'],
     },
+    [GEN_AI_SETTINGS_TOKEN_USAGE_TRACKING]: {
+      value: false,
+      type: 'boolean',
+    },
     ...overrides,
   });
 
@@ -92,6 +97,7 @@ describe('GenAiSettingsApp', () => {
       securitySolutionAssistant: { 'ai-assistant': true },
       agentBuilder: { show: true },
       anonymization: { show: true, manage: true },
+      advancedSettings: { show: true, save: true },
     };
 
     // Mock feature flags to enable AI Agents by default
@@ -497,6 +503,96 @@ describe('GenAiSettingsApp', () => {
     await waitFor(() => {
       expect(reportEvent).toHaveBeenCalledWith(AGENT_BUILDER_EVENT_TYPES.OptOut, {
         source: 'stack_management',
+      });
+    });
+  });
+
+  describe('Token usage tracking', () => {
+    it('installs the token usage dashboard when the user turns the setting on', async () => {
+      mockUseEnabledFeatures.mockReturnValue(createFeatureFlagsMock());
+
+      coreStart.settings.client.getAll.mockReturnValue(createSettingsMock() as any);
+
+      const genAiSettingsApi = jest.fn().mockResolvedValue({ installed: true });
+
+      renderComponent({}, { genAiSettingsApi });
+
+      const tokenUsageSwitch = await screen.findByTestId(
+        `management-settings-editField-${GEN_AI_SETTINGS_TOKEN_USAGE_TRACKING}`
+      );
+      fireEvent.click(tokenUsageSwitch);
+
+      const saveButton = await screen.findByTestId('genAiSettingsSaveBarBottomBarActionsButton');
+      fireEvent.click(saveButton);
+
+      await waitFor(() => {
+        expect(genAiSettingsApi).toHaveBeenCalledWith(
+          'POST /internal/gen_ai_settings/install_token_usage_dashboard',
+          { signal: null }
+        );
+      });
+    });
+
+    it('does not install the dashboard when token usage tracking is not changed', async () => {
+      mockUseEnabledFeatures.mockReturnValue(createFeatureFlagsMock());
+
+      coreStart.settings.client.getAll.mockReturnValue(
+        createSettingsMock({
+          [AI_CHAT_EXPERIENCE_TYPE]: {
+            value: AIChatExperience.Classic,
+            userValue: AIChatExperience.Agent,
+            type: 'select',
+            options: [AIChatExperience.Classic, AIChatExperience.Agent],
+          },
+        }) as any
+      );
+
+      const genAiSettingsApi = jest.fn().mockResolvedValue({ installed: false });
+
+      renderComponent({}, { genAiSettingsApi });
+
+      const chatExperienceSelect = await screen.findByTestId(
+        `management-settings-editField-${AI_CHAT_EXPERIENCE_TYPE}`
+      );
+      fireEvent.change(chatExperienceSelect, { target: { value: AIChatExperience.Classic } });
+
+      const saveButton = await screen.findByTestId('genAiSettingsSaveBarBottomBarActionsButton');
+      fireEvent.click(saveButton);
+
+      await waitFor(() => {
+        expect(saveButton).toBeInTheDocument();
+      });
+
+      expect(genAiSettingsApi).not.toHaveBeenCalled();
+    });
+
+    it('shows a danger toast when the install request fails', async () => {
+      mockUseEnabledFeatures.mockReturnValue(createFeatureFlagsMock());
+
+      coreStart.settings.client.getAll.mockReturnValue(createSettingsMock() as any);
+
+      const genAiSettingsApi = jest
+        .fn()
+        .mockRejectedValue(Object.assign(new Error('boom'), { body: { message: 'boom' } }));
+      const addDanger = jest.spyOn(coreStart.notifications.toasts, 'addDanger');
+
+      renderComponent({}, { genAiSettingsApi });
+
+      const tokenUsageSwitch = await screen.findByTestId(
+        `management-settings-editField-${GEN_AI_SETTINGS_TOKEN_USAGE_TRACKING}`
+      );
+      fireEvent.click(tokenUsageSwitch);
+
+      const saveButton = await screen.findByTestId('genAiSettingsSaveBarBottomBarActionsButton');
+      fireEvent.click(saveButton);
+
+      await waitFor(() => {
+        expect(addDanger).toHaveBeenCalledWith(
+          expect.objectContaining({
+            title: 'Failed to install token usage dashboard',
+            text: 'boom',
+          })
+        );
       });
     });
   });

--- a/x-pack/platform/plugins/private/gen_ai_settings/public/components/gen_ai_settings_app.tsx
+++ b/x-pack/platform/plugins/private/gen_ai_settings/public/components/gen_ai_settings_app.tsx
@@ -22,7 +22,10 @@ import { FormattedMessage } from '@kbn/i18n-react';
 import type { ManagementAppMountParams } from '@kbn/management-plugin/public';
 import { getSpaceIdFromPath } from '@kbn/spaces-utils';
 import { isEmpty } from 'lodash';
-import { AI_CHAT_EXPERIENCE_TYPE } from '@kbn/management-settings-ids';
+import {
+  AI_CHAT_EXPERIENCE_TYPE,
+  GEN_AI_SETTINGS_TOKEN_USAGE_TRACKING,
+} from '@kbn/management-settings-ids';
 import { AIChatExperience } from '@kbn/ai-assistant-common';
 import { AGENT_BUILDER_EVENT_TYPES } from '@kbn/agent-builder-common/telemetry';
 import { useEnabledFeatures } from '../contexts/enabled_features_context';
@@ -49,7 +52,8 @@ const isAIChatExperience = (value: unknown): value is AIChatExperience =>
 
 export const GenAiSettingsApp: React.FC<GenAiSettingsAppProps> = ({ setBreadcrumbs }) => {
   const { services } = useKibana();
-  const { application, http, productDocBase, analytics } = services;
+  const { application, http, productDocBase, analytics, genAiSettingsApi, notifications } =
+    services;
   const {
     showSpacesIntegration,
     isPermissionsBased,
@@ -106,6 +110,9 @@ export const GenAiSettingsApp: React.FC<GenAiSettingsAppProps> = ({ setBreadcrum
   }, [application, http.basePath, isPermissionsBased]);
 
   async function handleSave() {
+    const tokenUsageTrackingTurnedOn =
+      unsavedChanges[GEN_AI_SETTINGS_TOKEN_USAGE_TRACKING]?.unsavedValue === true;
+
     const savedChatExperience = isAIChatExperience(chatExperienceField?.savedValue)
       ? chatExperienceField.savedValue
       : undefined;
@@ -133,6 +140,22 @@ export const GenAiSettingsApp: React.FC<GenAiSettingsAppProps> = ({ setBreadcrum
       telemetryAfterChatExperience !== AIChatExperience.Agent;
 
     const needsReload = await saveAll();
+
+    if (tokenUsageTrackingTurnedOn) {
+      try {
+        await genAiSettingsApi('POST /internal/gen_ai_settings/install_token_usage_dashboard', {
+          signal: null,
+        });
+      } catch (error) {
+        notifications.toasts.addDanger({
+          title: i18n.translate('xpack.gen_ai_settings.tokenUsageTracking.installDashboardError', {
+            defaultMessage: 'Failed to install token usage dashboard',
+          }),
+          text: error?.body?.message ?? error?.message,
+        });
+      }
+    }
+
     if (shouldTrackOptInConfirmed) {
       analytics?.reportEvent(AGENT_BUILDER_EVENT_TYPES.OptInAction, {
         action: 'confirmed',

--- a/x-pack/platform/plugins/private/gen_ai_settings/server/routes/get_global_gen_ai_settings_route_repository.ts
+++ b/x-pack/platform/plugins/private/gen_ai_settings/server/routes/get_global_gen_ai_settings_route_repository.ts
@@ -6,10 +6,12 @@
  */
 
 import { connectorRoutes } from './connectors/route';
+import { installTokenUsageDashboardRoutes } from './install_token_usage_dashboard/route';
 
 export function getGlobalGenAiSettingsServerRouteRepository() {
   return {
     ...connectorRoutes,
+    ...installTokenUsageDashboardRoutes,
   };
 }
 

--- a/x-pack/platform/plugins/private/gen_ai_settings/server/routes/install_token_usage_dashboard/route.ts
+++ b/x-pack/platform/plugins/private/gen_ai_settings/server/routes/install_token_usage_dashboard/route.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { GEN_AI_SETTINGS_TOKEN_USAGE_TRACKING } from '@kbn/management-settings-ids';
+import { createGenAiSettingsServerRoute } from '../create_gen_ai_settings_server_route';
+
+const installTokenUsageDashboardRoute = createGenAiSettingsServerRoute({
+  endpoint: 'POST /internal/gen_ai_settings/install_token_usage_dashboard',
+  security: {
+    authz: {
+      requiredPrivileges: ['manage_advanced_settings'],
+    },
+  },
+  handler: async (resources): Promise<{ installed: boolean }> => {
+    const { request, plugins } = resources;
+
+    const coreStart = await plugins.core.start();
+    const uiSettingsClient = coreStart.uiSettings.asScopedToClient(
+      coreStart.savedObjects.getScopedClient(request)
+    );
+
+    const isEnabled = await uiSettingsClient.get<boolean>(GEN_AI_SETTINGS_TOKEN_USAGE_TRACKING);
+    if (!isEnabled) {
+      return { installed: false };
+    }
+
+    const inferenceStart = await plugins.inference.start();
+    await inferenceStart.installTokenUsageDashboard();
+
+    return { installed: true };
+  },
+});
+
+export const installTokenUsageDashboardRoutes = {
+  ...installTokenUsageDashboardRoute,
+};

--- a/x-pack/platform/plugins/shared/inference/server/dashboard/install_dashboard.ts
+++ b/x-pack/platform/plugins/shared/inference/server/dashboard/install_dashboard.ts
@@ -8,9 +8,19 @@
 import type { ISavedObjectsImporter, Logger } from '@kbn/core/server';
 import { Readable } from 'stream';
 
-const DATA_VIEW_ID = 'inference-token-usage';
-const DASHBOARD_ID = 'inference-token-usage';
+const DATA_VIEW_ID = 'kibana-inference-token-usage';
+const DASHBOARD_ID = 'kibana-inference-token-usage';
 const INDEX_PATTERN = '.kibana-inference-token-usage';
+
+// Pin the dashboard SO to versions past the legacy embeddable migrations.
+// Without these, the SO migrator runs Lens migrations from 7.13.1 onward,
+// which expect the pre-8.6 `indexpattern` datasource shape and crash on the
+// modern `formBased` shape we build below.
+const CORE_MIGRATION_VERSION = '8.8.0';
+const DASHBOARD_TYPE_MIGRATION_VERSION = '10.3.0';
+// Index-pattern's latest legacy migration is 7.11.0 — going higher than that
+// trips the "more recent version of Kibana" check on import.
+const INDEX_PATTERN_TYPE_MIGRATION_VERSION = '7.11.0';
 
 export const installTokenUsageDashboard = async (
   savedObjectsImporter: ISavedObjectsImporter,
@@ -54,6 +64,8 @@ function buildDataView() {
     type: 'index-pattern',
     id: DATA_VIEW_ID,
     managed: true,
+    coreMigrationVersion: CORE_MIGRATION_VERSION,
+    typeMigrationVersion: INDEX_PATTERN_TYPE_MIGRATION_VERSION,
     attributes: {
       name: 'Inference Token Usage',
       title: INDEX_PATTERN,
@@ -105,7 +117,7 @@ function buildMetricPanel({ panelId, title, field, x, y }: MetricPanelConfig) {
         hidePanelTitles: false,
         attributes: {
           title,
-          visualizationType: 'lnsMetricNew',
+          visualizationType: 'lnsMetric',
           type: 'lens',
           references: [
             {
@@ -119,6 +131,7 @@ function buildMetricPanel({ panelId, title, field, x, y }: MetricPanelConfig) {
               layerId,
               layerType: 'data',
               metricAccessor: colMetric,
+              secondaryTrend: { type: 'none' },
             },
             datasourceStates: {
               formBased: {
@@ -144,6 +157,8 @@ function buildMetricPanel({ panelId, title, field, x, y }: MetricPanelConfig) {
             },
             query: { query: '', language: 'kuery' },
             filters: [],
+            internalReferences: [],
+            adHocDataViews: {},
           },
         },
         enhancements: {},
@@ -175,7 +190,7 @@ function buildCountMetricPanel() {
         hidePanelTitles: false,
         attributes: {
           title,
-          visualizationType: 'lnsMetricNew',
+          visualizationType: 'lnsMetric',
           type: 'lens',
           references: [
             {
@@ -189,6 +204,7 @@ function buildCountMetricPanel() {
               layerId,
               layerType: 'data',
               metricAccessor: colMetric,
+              secondaryTrend: { type: 'none' },
             },
             datasourceStates: {
               formBased: {
@@ -214,6 +230,8 @@ function buildCountMetricPanel() {
             },
             query: { query: '', language: 'kuery' },
             filters: [],
+            internalReferences: [],
+            adHocDataViews: {},
           },
         },
         enhancements: {},
@@ -329,6 +347,8 @@ function buildXYPanel({ panelId, title, valueField, splitField, x, y, w, h }: XY
             },
             query: { query: '', language: 'kuery' },
             filters: [],
+            internalReferences: [],
+            adHocDataViews: {},
           },
         },
         enhancements: {},
@@ -443,6 +463,8 @@ function buildTablePanel({ panelId, title, bucketField, bucketLabel, x, y }: Tab
             },
             query: { query: '', language: 'kuery' },
             filters: [],
+            internalReferences: [],
+            adHocDataViews: {},
           },
         },
         enhancements: {},
@@ -517,6 +539,8 @@ function buildDashboard() {
     type: 'dashboard',
     id: DASHBOARD_ID,
     managed: true,
+    coreMigrationVersion: CORE_MIGRATION_VERSION,
+    typeMigrationVersion: DASHBOARD_TYPE_MIGRATION_VERSION,
     attributes: {
       title: '[Elastic] Inference Token Usage',
       description:

--- a/x-pack/platform/plugins/shared/inference/server/mocks.ts
+++ b/x-pack/platform/plugins/shared/inference/server/mocks.ts
@@ -18,6 +18,7 @@ const createStartContractMock = (): jest.Mocked<InferenceServerStart> => {
     getConnectorByIdWithoutClientRequest: jest.fn(),
     getInferenceEndpoints: jest.fn(),
     getInferenceEndpointById: jest.fn(),
+    installTokenUsageDashboard: jest.fn(),
   };
 };
 

--- a/x-pack/platform/plugins/shared/inference/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/inference/server/plugin.ts
@@ -129,10 +129,19 @@ export class InferencePlugin
     this.endpointIdCache.setEsClient(core.elasticsearch.client.asInternalUser);
     this.tokenUsageLogger.setEsClient(core.elasticsearch.client.asInternalUser);
 
-    const internalRepository = core.savedObjects.createInternalRepository();
-    const internalClient = new SavedObjectsClient(internalRepository);
-    const savedObjectsImporter = core.savedObjects.createImporter(internalClient);
-    installTokenUsageDashboard(savedObjectsImporter, this.logger).catch((e) => {
+    const installDashboardIfTokenUsageTrackingEnabled = async () => {
+      const internalRepository = core.savedObjects.createInternalRepository();
+      const internalClient = new SavedObjectsClient(internalRepository);
+      const uiSettingsClient = core.uiSettings.asScopedToClient(internalClient);
+      const isEnabled = await uiSettingsClient.get<boolean>(GEN_AI_SETTINGS_TOKEN_USAGE_TRACKING);
+      if (!isEnabled) {
+        return;
+      }
+      const savedObjectsImporter = core.savedObjects.createImporter(internalClient);
+      await installTokenUsageDashboard(savedObjectsImporter, this.logger);
+    };
+
+    installDashboardIfTokenUsageTrackingEnabled().catch((e) => {
       this.logger.error(`Failed to install token usage dashboard: ${e.message}`);
     });
 
@@ -324,6 +333,12 @@ export class InferencePlugin
       getInferenceEndpointById: async (inferenceId: string) => {
         const esClient = core.elasticsearch.client.asInternalUser;
         return getInferenceEndpointById({ inferenceId, esClient });
+      },
+      installTokenUsageDashboard: async () => {
+        const internalRepository = core.savedObjects.createInternalRepository();
+        const internalClient = new SavedObjectsClient(internalRepository);
+        const savedObjectsImporter = core.savedObjects.createImporter(internalClient);
+        await installTokenUsageDashboard(savedObjectsImporter, this.logger);
       },
     };
   }

--- a/x-pack/platform/plugins/shared/inference/server/types.ts
+++ b/x-pack/platform/plugins/shared/inference/server/types.ts
@@ -214,6 +214,15 @@ export interface InferenceServerStart {
    * @throws Error if the endpoint does not exist
    */
   getInferenceEndpointById: (inferenceId: string) => Promise<InferenceEndpoint>;
+
+  /**
+   * Installs the managed inference token usage dashboard (and its data view) into
+   * the default space. Idempotent: existing assets are overwritten.
+   *
+   * Callers are responsible for gating this on whether token usage tracking is
+   * enabled — the inference plugin no longer self-installs the dashboard.
+   */
+  installTokenUsageDashboard: () => Promise<void>;
 }
 
 /**


### PR DESCRIPTION
## Summary

This fixes the token usage dashboard creation by properly using versioned assets for Lens panel creation. 

It also gates dashboard creation behind the UI settings flag, so users don't get pre-populated dashboards by default.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
