### PR TITLE
[kbn-evals] Increase Scout server readiness timeout and improve wait logging

### DIFF
--- a/x-pack/platform/packages/shared/kbn-evals/src/cli/commands/start.ts
+++ b/x-pack/platform/packages/shared/kbn-evals/src/cli/commands/start.ts
@@ -41,7 +41,8 @@ import {
 const SCOUT_LOCAL_CONFIG = '.scout/servers/local.json';
 const SCOUT_READY_POLL_INTERVAL_MS = 3000;
 const SCOUT_READY_DEFAULT_TIMEOUT_MS = 600_000;
-const SCOUT_READY_TIMEOUT_MS = Number(process.env.SCOUT_READY_TIMEOUT_MS) || SCOUT_READY_DEFAULT_TIMEOUT_MS;
+const SCOUT_READY_TIMEOUT_MS =
+  Number(process.env.SCOUT_READY_TIMEOUT_MS) || SCOUT_READY_DEFAULT_TIMEOUT_MS;
 
 const fetchCcmApiKey = (log: ToolingLog): string => {
   const envKey = process.env.KIBANA_EIS_CCM_API_KEY;

--- a/x-pack/platform/packages/shared/kbn-evals/src/cli/commands/start.ts
+++ b/x-pack/platform/packages/shared/kbn-evals/src/cli/commands/start.ts
@@ -40,7 +40,8 @@ import {
 
 const SCOUT_LOCAL_CONFIG = '.scout/servers/local.json';
 const SCOUT_READY_POLL_INTERVAL_MS = 3000;
-const SCOUT_READY_TIMEOUT_MS = 180_000;
+const SCOUT_READY_DEFAULT_TIMEOUT_MS = 600_000;
+const SCOUT_READY_TIMEOUT_MS = Number(process.env.SCOUT_READY_TIMEOUT_MS) || SCOUT_READY_DEFAULT_TIMEOUT_MS;
 
 const fetchCcmApiKey = (log: ToolingLog): string => {
   const envKey = process.env.KIBANA_EIS_CCM_API_KEY;
@@ -86,8 +87,13 @@ const isEdotRunningViaDocker = (): boolean => {
 const waitForScoutReady = async (repoRoot: string, log: ToolingLog): Promise<void> => {
   const configPath = Path.join(repoRoot, SCOUT_LOCAL_CONFIG);
   const startTime = Date.now();
+  const timeoutSec = Math.round(SCOUT_READY_TIMEOUT_MS / 1000);
   let esUrl: string | undefined;
   let kbnUrl: string | undefined;
+  let lastLogAt = 0;
+  let esReady = false;
+
+  log.info(`Waiting up to ${timeoutSec}s for Scout (ES + Kibana) to become ready...`);
 
   while (Date.now() - startTime < SCOUT_READY_TIMEOUT_MS) {
     if (!esUrl && Fs.existsSync(configPath)) {
@@ -106,15 +112,37 @@ const waitForScoutReady = async (repoRoot: string, log: ToolingLog): Promise<voi
         probeHttp(esUrl),
         probeHttp(`${kbnUrl}/api/status`),
       ]);
+
+      if (!esReady && esOk) {
+        esReady = true;
+        const elapsed = Math.round((Date.now() - startTime) / 1000);
+        log.info(`  ES ready (${elapsed}s). Waiting for Kibana...`);
+      }
+
       if (esOk && kbnOk) {
+        const elapsed = Math.round((Date.now() - startTime) / 1000);
+        log.info(`  Both services ready (${elapsed}s).`);
         return;
       }
+    }
+
+    const elapsed = Date.now() - startTime;
+    if (elapsed - lastLogAt >= 30_000) {
+      const elapsedSec = Math.round(elapsed / 1000);
+      const pending = !esUrl ? 'config' : !esReady ? 'ES + Kibana' : 'Kibana';
+      log.info(`  Still waiting for ${pending}... (${elapsedSec}s / ${timeoutSec}s)`);
+      lastLogAt = elapsed;
     }
 
     await new Promise((r) => setTimeout(r, SCOUT_READY_POLL_INTERVAL_MS));
   }
 
-  throw new Error(`Scout did not become ready within ${SCOUT_READY_TIMEOUT_MS / 1000}s`);
+  const pending = !esUrl ? 'Scout config' : !esReady ? 'ES + Kibana' : 'Kibana';
+  throw new Error(
+    `Scout did not become ready within ${timeoutSec}s (waiting for: ${pending}). ` +
+      'If Kibana is building bundles, set SCOUT_READY_TIMEOUT_MS to a higher value ' +
+      '(e.g. SCOUT_READY_TIMEOUT_MS=900000 for 15 minutes).'
+  );
 };
 
 /**


### PR DESCRIPTION
## Summary

The hardcoded 180s readiness timeout in `evals start` is insufficient when Kibana needs to build bundles (e.g., after Node.js version changes, upstream merges, or fresh checkouts). Bundle compilation can easily take 5-10 minutes, causing `waitForScoutReady` to throw before Kibana finishes starting.

**Changes:**

- Increase default timeout from 180s to 600s (10 minutes)
- Support `SCOUT_READY_TIMEOUT_MS` env var for custom override (e.g., `SCOUT_READY_TIMEOUT_MS=900000` for 15 minutes)
- Add progress logging every 30s showing which service is still pending and elapsed time
- Track ES and Kibana readiness separately so users know exactly what's blocking startup
- Improve the error message on timeout to suggest the env var workaround

**Before:**
```
ERROR Error: Scout did not become ready within 180s
```

**After:**
```
info Waiting up to 600s for Scout (ES + Kibana) to become ready...
info   Still waiting for ES + Kibana... (30s / 600s)
info   ES ready (35s). Waiting for Kibana...
info   Still waiting for Kibana... (60s / 600s)
info   Still waiting for Kibana... (90s / 600s)
info   Both services ready (105s).
```

## Risk Matrix

| Risk | Severity | Probability | Explanation |
|------|----------|-------------|-------------|
| Timeout too long masks real failures | Low | Low | 600s is still bounded; users can lower via env var; 30s progress logs make hangs visible |


Made with [Cursor](https://cursor.com)