### PR TITLE
[AlertingV2] Bound fetch_episodes with a data-anchored watermark + 1-min lookback cap

### DIFF
--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/constants.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/constants.ts
@@ -5,4 +5,28 @@
  * 2.0.
  */
 
+/**
+ * Lookback used only on cold start (when the dispatcher has no `eventWatermark`
+ * persisted). After the first successful tick, the watermark drives the lower
+ * bound and this constant is no longer consulted.
+ */
 export const LOOKBACK_WINDOW_MINUTES = 10;
+
+/**
+ * Upper bound on the time span (in minutes) any single dispatcher tick will
+ * query in `fetch_episodes`. Bounds the row count fed into `INLINE STATS` so
+ * the ES|QL sub-plan buffer stays well under its 16.8 MB limit, and bounds the
+ * size of the `(rule_id, group_hash)` IN-list that flows into
+ * `fetch_suppressions`. After an outage, the watermark advances at most one
+ * cap per tick, draining the backlog over multiple ticks.
+ */
+export const TICK_LOOKBACK_CAP_MINUTES = 1;
+
+/**
+ * Slack subtracted from `now` when computing a tick's `windowEnd`, to absorb
+ * Elasticsearch refresh-interval lag and modest clock skew between the rule
+ * executor (writer of `.rule-events`) and the dispatcher (reader). Events
+ * written within this trailing window may not yet be searchable, so the
+ * watermark stops just short of `now` and revisits them on the next tick.
+ */
+export const SETTLE_BUFFER_SECONDS = 5;

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/dispatcher.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/dispatcher.test.ts
@@ -656,7 +656,7 @@ describe('DispatcherService', () => {
   });
 
   describe('event watermark plumbing', () => {
-    it('returns nextEventWatermark when the pipeline completes', async () => {
+    it('returns nextEventWatermark anchored to the last observed episode when the pipeline completes', async () => {
       queryEsClient.esql.query
         .mockResolvedValueOnce(
           createDispatchableAlertEventsResponse([
@@ -690,11 +690,10 @@ describe('DispatcherService', () => {
         previousStartedAt: new Date('2026-01-22T07:30:00.000Z'),
       });
 
-      const range = extractTimestampRange(queryEsClient.esql.query.mock.calls[0][0]);
-      expect(result.nextEventWatermark).toBe(range.lte);
+      expect(result.nextEventWatermark).toBe('2026-01-22T07:10:00.000Z');
     });
 
-    it('returns nextEventWatermark when fetch_episodes halts on no_episodes', async () => {
+    it('returns nextEventWatermark equal to the queried lte when fetch_episodes halts on no_episodes', async () => {
       queryEsClient.esql.query.mockResolvedValueOnce(createDispatchableAlertEventsResponse([]));
 
       const result = await dispatcherService.run({
@@ -705,7 +704,7 @@ describe('DispatcherService', () => {
       expect(result.nextEventWatermark).toBe(range.lte);
     });
 
-    it('threads eventWatermark from params as a `gt` lower bound on subsequent runs', async () => {
+    it('threads eventWatermark from params as a `gte` lower bound on subsequent runs', async () => {
       queryEsClient.esql.query.mockResolvedValueOnce(createDispatchableAlertEventsResponse([]));
 
       const watermark = moment().subtract(20, 'seconds').toDate();
@@ -715,8 +714,8 @@ describe('DispatcherService', () => {
       });
 
       const range = extractTimestampRange(queryEsClient.esql.query.mock.calls[0][0]);
-      expect(range.gt).toBe(watermark.toISOString());
-      expect(range).not.toHaveProperty('gte');
+      expect(range.gte).toBe(watermark.toISOString());
+      expect(range).not.toHaveProperty('gt');
     });
 
     it('does not return nextEventWatermark when the pipeline throws', async () => {

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/dispatcher.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/dispatcher.test.ts
@@ -28,7 +28,11 @@ import type { RulesSavedObjectServiceContract } from '../services/rules_saved_ob
 import { createRulesSavedObjectService } from '../services/rules_saved_object_service/rules_saved_object_service.mock';
 import type { StorageServiceContract } from '../services/storage_service/storage_service';
 import { createStorageService } from '../services/storage_service/storage_service.mock';
-import { LOOKBACK_WINDOW_MINUTES } from './constants';
+import {
+  LOOKBACK_WINDOW_MINUTES,
+  SETTLE_BUFFER_SECONDS,
+  TICK_LOOKBACK_CAP_MINUTES,
+} from './constants';
 import { DispatcherService } from './dispatcher';
 import { DispatcherPipeline } from './execution_pipeline';
 import {
@@ -95,6 +99,17 @@ const createMockWorkflowsManagement = (): jest.Mocked<WorkflowsServerPluginSetup
     getWorkflow: jest.fn().mockResolvedValue(null),
     runWorkflow: jest.fn().mockResolvedValue('exec-1'),
   } as unknown as jest.Mocked<WorkflowsServerPluginSetup['management']>);
+
+interface TimestampRange {
+  gte?: string;
+  gt?: string;
+  lte?: string;
+}
+
+function extractTimestampRange(esqlRequest: unknown): TimestampRange {
+  const filter = (esqlRequest as { filter: { range: Record<string, TimestampRange> } }).filter;
+  return filter.range['@timestamp'];
+}
 
 function buildDispatcherService(deps: {
   queryService: QueryServiceContract;
@@ -206,32 +221,35 @@ describe('DispatcherService', () => {
 
       const previousStartedAt = new Date('2026-01-22T07:30:00.000Z');
 
+      const before = Date.now();
       const result = await dispatcherService.run({
         previousStartedAt,
       });
+      const after = Date.now();
 
       expect(result.startedAt).toBeInstanceOf(Date);
 
-      const expectedLookback = moment(previousStartedAt)
-        .subtract(LOOKBACK_WINDOW_MINUTES, 'minutes')
-        .toISOString();
-
       expect(queryEsClient.esql.query).toHaveBeenCalledTimes(3);
-      expect(queryEsClient.esql.query).toHaveBeenCalledWith(
-        {
-          query: getDispatchableAlertEventsQuery().query,
-          drop_null_columns: false,
-          filter: {
-            range: {
-              '@timestamp': {
-                gte: expectedLookback,
-              },
-            },
-          },
-          params: undefined,
-        },
-        { signal: undefined }
-      );
+      const fetchEpisodesCall = queryEsClient.esql.query.mock.calls[0][0];
+      expect(fetchEpisodesCall).toMatchObject({
+        query: getDispatchableAlertEventsQuery().query,
+        drop_null_columns: false,
+        params: undefined,
+      });
+
+      // Cold start: lower bound is `gte = now − LOOKBACK_WINDOW_MINUTES`,
+      // upper bound is min(start + TICK_CAP, now − SETTLE_BUFFER).
+      const range = extractTimestampRange(fetchEpisodesCall);
+      expect(range).toHaveProperty('gte');
+      expect(range).toHaveProperty('lte');
+      expect(range).not.toHaveProperty('gt');
+      const gte = new Date(range.gte as string).getTime();
+      const lte = new Date(range.lte as string).getTime();
+      const tolerance = 100;
+      expect(gte).toBeGreaterThanOrEqual(before - LOOKBACK_WINDOW_MINUTES * 60_000 - tolerance);
+      expect(gte).toBeLessThanOrEqual(after - LOOKBACK_WINDOW_MINUTES * 60_000 + tolerance);
+      expect(lte - gte).toBeLessThanOrEqual(TICK_LOOKBACK_CAP_MINUTES * 60_000 + tolerance);
+      expect(lte).toBeLessThanOrEqual(after - SETTLE_BUFFER_SECONDS * 1_000 + tolerance);
 
       expect(storageEsClient.bulk).toHaveBeenCalledWith({
         operations: expect.any(Array),
@@ -634,6 +652,79 @@ describe('DispatcherService', () => {
           }),
         ])
       );
+    });
+  });
+
+  describe('event watermark plumbing', () => {
+    it('returns nextEventWatermark when the pipeline completes', async () => {
+      queryEsClient.esql.query
+        .mockResolvedValueOnce(
+          createDispatchableAlertEventsResponse([
+            {
+              last_event_timestamp: '2026-01-22T07:10:00.000Z',
+              rule_id: 'rule-1',
+              group_hash: 'hash-1',
+              episode_id: 'episode-1',
+              episode_status: 'active',
+            },
+          ])
+        )
+        .mockResolvedValueOnce(
+          createAlertEpisodeSuppressionsResponse([
+            {
+              rule_id: 'rule-1',
+              group_hash: 'hash-1',
+              episode_id: 'episode-1',
+              should_suppress: false,
+            },
+          ])
+        )
+        .mockResolvedValueOnce(createLastNotifiedTimestampsResponse());
+
+      storageEsClient.bulk.mockResolvedValue({
+        items: [{ create: { _id: '1', status: 201 } }],
+        errors: false,
+      } as BulkResponse);
+
+      const result = await dispatcherService.run({
+        previousStartedAt: new Date('2026-01-22T07:30:00.000Z'),
+      });
+
+      const range = extractTimestampRange(queryEsClient.esql.query.mock.calls[0][0]);
+      expect(result.nextEventWatermark).toBe(range.lte);
+    });
+
+    it('returns nextEventWatermark when fetch_episodes halts on no_episodes', async () => {
+      queryEsClient.esql.query.mockResolvedValueOnce(createDispatchableAlertEventsResponse([]));
+
+      const result = await dispatcherService.run({
+        previousStartedAt: new Date('2026-01-22T07:30:00.000Z'),
+      });
+
+      const range = extractTimestampRange(queryEsClient.esql.query.mock.calls[0][0]);
+      expect(result.nextEventWatermark).toBe(range.lte);
+    });
+
+    it('threads eventWatermark from params as a `gt` lower bound on subsequent runs', async () => {
+      queryEsClient.esql.query.mockResolvedValueOnce(createDispatchableAlertEventsResponse([]));
+
+      const watermark = moment().subtract(20, 'seconds').toDate();
+      await dispatcherService.run({
+        previousStartedAt: new Date('2026-01-22T07:30:00.000Z'),
+        eventWatermark: watermark,
+      });
+
+      const range = extractTimestampRange(queryEsClient.esql.query.mock.calls[0][0]);
+      expect(range.gt).toBe(watermark.toISOString());
+      expect(range).not.toHaveProperty('gte');
+    });
+
+    it('does not return nextEventWatermark when the pipeline throws', async () => {
+      queryEsClient.esql.query.mockRejectedValueOnce(new Error('boom'));
+
+      await expect(
+        dispatcherService.run({ previousStartedAt: new Date('2026-01-22T07:30:00.000Z') })
+      ).rejects.toThrow('boom');
     });
   });
 });

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/dispatcher.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/dispatcher.ts
@@ -19,11 +19,23 @@ export class DispatcherService implements DispatcherServiceContract {
 
   public async run({
     previousStartedAt = new Date(),
+    eventWatermark,
   }: DispatcherExecutionParams): Promise<DispatcherExecutionResult> {
     const startedAt = new Date();
 
-    await this.pipeline.execute({ startedAt, previousStartedAt });
+    // If the pipeline throws, the error propagates and `task_runner` never
+    // gets a result — Task Manager treats this as a failed run and the
+    // persisted `eventWatermark` from the prior tick is preserved. That is
+    // what guarantees no silent data loss when a step fails mid-pipeline.
+    const pipelineResult = await this.pipeline.execute({
+      startedAt,
+      previousStartedAt,
+      eventWatermark,
+    });
 
-    return { startedAt };
+    return {
+      startedAt,
+      nextEventWatermark: pipelineResult.finalState.nextEventWatermark,
+    };
   }
 }

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/execution_pipeline.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/execution_pipeline.test.ts
@@ -142,5 +142,24 @@ describe('DispatcherPipeline', () => {
       expect(result.completed).toBe(true);
       expect(result.finalState).toEqual({ input });
     });
+
+    it('applies state data carried by a halt output to finalState', async () => {
+      const { loggerService } = createLoggerService();
+
+      const step1 = createMockDispatcherStep('step1', async () => ({
+        type: 'halt',
+        reason: 'no_episodes',
+        data: { nextEventWatermark: '2026-01-22T08:00:00.000Z' },
+      }));
+
+      const pipeline = new DispatcherPipeline(loggerService, [step1]);
+      const input = createDispatcherPipelineInput();
+
+      const result = await pipeline.execute(input);
+
+      expect(result.completed).toBe(false);
+      expect(result.haltReason).toBe('no_episodes');
+      expect(result.finalState.nextEventWatermark).toBe('2026-01-22T08:00:00.000Z');
+    });
   });
 });

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/execution_pipeline.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/execution_pipeline.ts
@@ -44,6 +44,10 @@ export class DispatcherPipeline implements DispatcherPipelineContract {
 
       const output = await withDispatcherSpan(step.name, () => step.execute(pipelineState));
 
+      if (output.data) {
+        pipelineState = { ...pipelineState, ...output.data };
+      }
+
       if (output.type === 'halt') {
         this.logger.debug({
           message: `Dispatcher: Pipeline halted at step: ${step.name}, reason: ${output.reason}`,
@@ -54,10 +58,6 @@ export class DispatcherPipeline implements DispatcherPipelineContract {
           haltReason: output.reason,
           finalState: pipelineState,
         };
-      }
-
-      if (output.data) {
-        pipelineState = { ...pipelineState, ...output.data };
       }
     }
 

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/integration_tests/dispatcher.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/integration_tests/dispatcher.test.ts
@@ -5,6 +5,24 @@
  * 2.0.
  */
 
+// The dispatcher's per-tick lookback cap (1 minute) and 5-second settle buffer
+// are appropriate for production but would force these integration tests —
+// which seed events spanning many minutes — to drive the dispatcher across
+// many ticks. We override them locally so a single `dispatcherService.run()`
+// covers the entire seeded dataset, keeping these end-to-end assertions fast
+// and focused on the pipeline's data-handling behaviour rather than its
+// time-bounded windowing (which is covered by unit tests).
+jest.mock('../constants', () => {
+  const actual = jest.requireActual('../constants');
+  const ONE_YEAR_MIN = 60 * 24 * 365;
+  return {
+    ...actual,
+    LOOKBACK_WINDOW_MINUTES: ONE_YEAR_MIN,
+    TICK_LOOKBACK_CAP_MINUTES: ONE_YEAR_MIN * 10,
+    SETTLE_BUFFER_SECONDS: 0,
+  };
+});
+
 import type { TestElasticsearchUtils, TestKibanaUtils } from '@kbn/core-test-helpers-kbn-server';
 import type { ElasticsearchClient } from '@kbn/core/server';
 import type { EncryptedSavedObjectsClient } from '@kbn/encrypted-saved-objects-plugin/server';

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/steps/fetch_episodes_step.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/steps/fetch_episodes_step.test.ts
@@ -5,10 +5,27 @@
  * 2.0.
  */
 
+import moment from 'moment';
 import { FetchEpisodesStep, parseDataJson, parseAlertEpisodes } from './fetch_episodes_step';
 import { createQueryService } from '../../services/query_service/query_service.mock';
 import { createDispatchableAlertEventsResponse } from '../fixtures/dispatcher';
 import { createAlertEpisode, createDispatcherPipelineState } from '../fixtures/test_utils';
+import {
+  LOOKBACK_WINDOW_MINUTES,
+  SETTLE_BUFFER_SECONDS,
+  TICK_LOOKBACK_CAP_MINUTES,
+} from '../constants';
+
+interface TimestampRange {
+  gte?: string;
+  gt?: string;
+  lte?: string;
+}
+
+function extractTimestampRange(esqlRequest: unknown): TimestampRange {
+  const filter = (esqlRequest as { filter: { range: Record<string, TimestampRange> } }).filter;
+  return filter.range['@timestamp'];
+}
 
 describe('FetchEpisodesStep', () => {
   it('returns episodes and continues when episodes are found', async () => {
@@ -80,7 +97,12 @@ describe('FetchEpisodesStep', () => {
     const state = createDispatcherPipelineState();
     const result = await step.execute(state);
 
-    expect(result).toEqual({ type: 'halt', reason: 'no_episodes' });
+    expect(result.type).toBe('halt');
+    if (result.type !== 'halt') return;
+    expect(result.reason).toBe('no_episodes');
+    // Even on an empty queried window the watermark must advance, otherwise
+    // the next tick would re-read the same empty range forever.
+    expect(result.data?.nextEventWatermark).toEqual(expect.any(String));
   });
 
   it('propagates query errors', async () => {
@@ -91,6 +113,118 @@ describe('FetchEpisodesStep', () => {
 
     const state = createDispatcherPipelineState();
     await expect(step.execute(state)).rejects.toThrow('ES error');
+  });
+
+  describe('windowing', () => {
+    const TOLERANCE_MS = 100;
+
+    it('cold start (no eventWatermark): uses gte = now − LOOKBACK and lte capped by SETTLE_BUFFER + TICK_CAP', async () => {
+      const { queryService, mockEsClient } = createQueryService();
+      const step = new FetchEpisodesStep(queryService);
+      mockEsClient.esql.query.mockResolvedValueOnce(createDispatchableAlertEventsResponse([]));
+
+      const state = createDispatcherPipelineState();
+      const before = Date.now();
+      await step.execute(state);
+      const after = Date.now();
+
+      const range = extractTimestampRange(mockEsClient.esql.query.mock.calls[0][0]);
+      expect(range).toHaveProperty('gte');
+      expect(range).toHaveProperty('lte');
+      expect(range).not.toHaveProperty('gt');
+
+      const gte = new Date(range.gte as string).getTime();
+      const lte = new Date(range.lte as string).getTime();
+      const lookbackMs = LOOKBACK_WINDOW_MINUTES * 60_000;
+      const capMs = TICK_LOOKBACK_CAP_MINUTES * 60_000;
+      const settleMs = SETTLE_BUFFER_SECONDS * 1_000;
+
+      expect(gte).toBeGreaterThanOrEqual(before - lookbackMs - TOLERANCE_MS);
+      expect(gte).toBeLessThanOrEqual(after - lookbackMs + TOLERANCE_MS);
+      expect(lte - gte).toBeLessThanOrEqual(capMs + TOLERANCE_MS);
+      expect(lte).toBeLessThanOrEqual(after - settleMs + TOLERANCE_MS);
+    });
+
+    it('subsequent run (eventWatermark present): uses gt = watermark and caps at TICK_CAP', async () => {
+      const { queryService, mockEsClient } = createQueryService();
+      const step = new FetchEpisodesStep(queryService);
+      mockEsClient.esql.query.mockResolvedValueOnce(createDispatchableAlertEventsResponse([]));
+
+      const watermark = moment().subtract(30, 'seconds').toDate();
+      const state = createDispatcherPipelineState({
+        input: {
+          startedAt: new Date(),
+          previousStartedAt: new Date(),
+          eventWatermark: watermark,
+        },
+      });
+      await step.execute(state);
+
+      const range = extractTimestampRange(mockEsClient.esql.query.mock.calls[0][0]);
+      expect(range).toHaveProperty('gt', watermark.toISOString());
+      expect(range).not.toHaveProperty('gte');
+      // Window narrower than the cap because settle buffer pulls lte back.
+      const gt = new Date(range.gt as string).getTime();
+      const lte = new Date(range.lte as string).getTime();
+      expect(lte).toBeGreaterThan(gt);
+      expect(lte - gt).toBeLessThanOrEqual(TICK_LOOKBACK_CAP_MINUTES * 60_000 + TOLERANCE_MS);
+    });
+
+    it('stale watermark: window length is capped at TICK_LOOKBACK_CAP_MINUTES', async () => {
+      const { queryService, mockEsClient } = createQueryService();
+      const step = new FetchEpisodesStep(queryService);
+      mockEsClient.esql.query.mockResolvedValueOnce(createDispatchableAlertEventsResponse([]));
+
+      const watermark = moment().subtract(10, 'minutes').toDate();
+      const state = createDispatcherPipelineState({
+        input: {
+          startedAt: new Date(),
+          previousStartedAt: new Date(),
+          eventWatermark: watermark,
+        },
+      });
+      await step.execute(state);
+
+      const range = extractTimestampRange(mockEsClient.esql.query.mock.calls[0][0]);
+      const gt = new Date(range.gt as string).getTime();
+      const lte = new Date(range.lte as string).getTime();
+      expect(lte - gt).toBeLessThanOrEqual(TICK_LOOKBACK_CAP_MINUTES * 60_000 + TOLERANCE_MS);
+    });
+
+    it('publishes nextEventWatermark equal to the queried lte bound', async () => {
+      const { queryService, mockEsClient } = createQueryService();
+      const step = new FetchEpisodesStep(queryService);
+      mockEsClient.esql.query.mockResolvedValueOnce(createDispatchableAlertEventsResponse([]));
+
+      const state = createDispatcherPipelineState();
+      const result = await step.execute(state);
+
+      expect(result.type).toBe('halt');
+      if (result.type !== 'halt') return;
+      const range = extractTimestampRange(mockEsClient.esql.query.mock.calls[0][0]);
+      expect(result.data?.nextEventWatermark).toBe(range.lte);
+    });
+
+    it('settle buffer collapses the window: halts without advancing the watermark', async () => {
+      const { queryService, mockEsClient } = createQueryService();
+      const step = new FetchEpisodesStep(queryService);
+
+      // Simulate a watermark equal to "now" minus less than the settle buffer:
+      // windowStart > windowEnd, so the step should halt before issuing any
+      // ES query and must NOT publish nextEventWatermark.
+      const watermark = moment().add(1, 'minute').toDate();
+      const state = createDispatcherPipelineState({
+        input: {
+          startedAt: new Date(),
+          previousStartedAt: new Date(),
+          eventWatermark: watermark,
+        },
+      });
+      const result = await step.execute(state);
+
+      expect(mockEsClient.esql.query).not.toHaveBeenCalled();
+      expect(result).toEqual({ type: 'halt', reason: 'no_episodes' });
+    });
   });
 });
 

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/steps/fetch_episodes_step.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/steps/fetch_episodes_step.test.ts
@@ -48,6 +48,64 @@ describe('FetchEpisodesStep', () => {
     expect(result.data?.episodes?.[0].rule_id).toBe('r1');
   });
 
+  it('anchors nextEventWatermark to the last_event_timestamp of the latest returned episode', async () => {
+    const { queryService, mockEsClient } = createQueryService();
+    const step = new FetchEpisodesStep(queryService);
+
+    // Returned in SORT-asc order; the last element's last_event_timestamp
+    // must be what the watermark anchors to.
+    const episodes = [
+      createAlertEpisode({ episode_id: 'e1', last_event_timestamp: '2026-01-22T07:10:00.000Z' }),
+      createAlertEpisode({ episode_id: 'e2', last_event_timestamp: '2026-01-22T07:10:30.000Z' }),
+      createAlertEpisode({ episode_id: 'e3', last_event_timestamp: '2026-01-22T07:10:45.000Z' }),
+    ];
+
+    mockEsClient.esql.query.mockResolvedValueOnce(createDispatchableAlertEventsResponse(episodes));
+
+    const state = createDispatcherPipelineState();
+    const result = await step.execute(state);
+
+    expect(result.type).toBe('continue');
+    if (result.type !== 'continue') return;
+    expect(result.data?.nextEventWatermark).toBe('2026-01-22T07:10:45.000Z');
+  });
+
+  it('continues a LIMIT-truncated tick from the last observed timestamp on the next run', async () => {
+    const { queryService, mockEsClient } = createQueryService();
+    const step = new FetchEpisodesStep(queryService);
+
+    // First tick: simulate a full LIMIT page; last episode's timestamp is the
+    // boundary the next tick must resume from.
+    const firstPage = [
+      createAlertEpisode({ episode_id: 'e1', last_event_timestamp: '2026-01-22T07:10:00.000Z' }),
+      createAlertEpisode({ episode_id: 'e2', last_event_timestamp: '2026-01-22T07:10:30.000Z' }),
+    ];
+    mockEsClient.esql.query.mockResolvedValueOnce(createDispatchableAlertEventsResponse(firstPage));
+
+    const firstResult = await step.execute(createDispatcherPipelineState());
+    expect(firstResult.type).toBe('continue');
+    if (firstResult.type !== 'continue') return;
+    const watermarkAfterFirst = firstResult.data?.nextEventWatermark;
+    expect(watermarkAfterFirst).toBe('2026-01-22T07:10:30.000Z');
+
+    // Second tick: re-feed the watermark; the lower bound must be `gte` so
+    // any episode whose `last_event_timestamp` ties the boundary is picked up.
+    mockEsClient.esql.query.mockResolvedValueOnce(createDispatchableAlertEventsResponse([]));
+    await step.execute(
+      createDispatcherPipelineState({
+        input: {
+          startedAt: new Date(),
+          previousStartedAt: new Date(),
+          eventWatermark: new Date(watermarkAfterFirst as string),
+        },
+      })
+    );
+
+    const range = extractTimestampRange(mockEsClient.esql.query.mock.calls[1][0]);
+    expect(range).toHaveProperty('gte', watermarkAfterFirst);
+    expect(range).not.toHaveProperty('gt');
+  });
+
   it('parses data_json into data on episodes', async () => {
     const { queryService, mockEsClient } = createQueryService();
     const step = new FetchEpisodesStep(queryService);
@@ -145,7 +203,7 @@ describe('FetchEpisodesStep', () => {
       expect(lte).toBeLessThanOrEqual(after - settleMs + TOLERANCE_MS);
     });
 
-    it('subsequent run (eventWatermark present): uses gt = watermark and caps at TICK_CAP', async () => {
+    it('subsequent run (eventWatermark present): uses gte = watermark and caps at TICK_CAP', async () => {
       const { queryService, mockEsClient } = createQueryService();
       const step = new FetchEpisodesStep(queryService);
       mockEsClient.esql.query.mockResolvedValueOnce(createDispatchableAlertEventsResponse([]));
@@ -161,13 +219,13 @@ describe('FetchEpisodesStep', () => {
       await step.execute(state);
 
       const range = extractTimestampRange(mockEsClient.esql.query.mock.calls[0][0]);
-      expect(range).toHaveProperty('gt', watermark.toISOString());
-      expect(range).not.toHaveProperty('gte');
+      expect(range).toHaveProperty('gte', watermark.toISOString());
+      expect(range).not.toHaveProperty('gt');
       // Window narrower than the cap because settle buffer pulls lte back.
-      const gt = new Date(range.gt as string).getTime();
+      const gte = new Date(range.gte as string).getTime();
       const lte = new Date(range.lte as string).getTime();
-      expect(lte).toBeGreaterThan(gt);
-      expect(lte - gt).toBeLessThanOrEqual(TICK_LOOKBACK_CAP_MINUTES * 60_000 + TOLERANCE_MS);
+      expect(lte).toBeGreaterThan(gte);
+      expect(lte - gte).toBeLessThanOrEqual(TICK_LOOKBACK_CAP_MINUTES * 60_000 + TOLERANCE_MS);
     });
 
     it('stale watermark: window length is capped at TICK_LOOKBACK_CAP_MINUTES', async () => {
@@ -186,12 +244,12 @@ describe('FetchEpisodesStep', () => {
       await step.execute(state);
 
       const range = extractTimestampRange(mockEsClient.esql.query.mock.calls[0][0]);
-      const gt = new Date(range.gt as string).getTime();
+      const gte = new Date(range.gte as string).getTime();
       const lte = new Date(range.lte as string).getTime();
-      expect(lte - gt).toBeLessThanOrEqual(TICK_LOOKBACK_CAP_MINUTES * 60_000 + TOLERANCE_MS);
+      expect(lte - gte).toBeLessThanOrEqual(TICK_LOOKBACK_CAP_MINUTES * 60_000 + TOLERANCE_MS);
     });
 
-    it('publishes nextEventWatermark equal to the queried lte bound', async () => {
+    it('on an empty window publishes nextEventWatermark equal to the queried lte bound', async () => {
       const { queryService, mockEsClient } = createQueryService();
       const step = new FetchEpisodesStep(queryService);
       mockEsClient.esql.query.mockResolvedValueOnce(createDispatchableAlertEventsResponse([]));

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/steps/fetch_episodes_step.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/steps/fetch_episodes_step.ts
@@ -34,20 +34,38 @@ interface RawAlertEpisode {
 }
 
 /**
- * `fetch_episodes` queries a strictly bounded `@timestamp` window so the
- * upstream rows fed into `INLINE STATS` (and the IN-list flowing into
- * `fetch_suppressions`) stay small enough to never breach ES|QL sub-plan
- * buffer or request-size limits — even at peak ingest.
+ * `fetch_episodes` queries a bounded `@timestamp` window so the upstream rows
+ * fed into `INLINE STATS` (and the IN-list flowing into `fetch_suppressions`)
+ * stay small enough to never breach ES|QL sub-plan buffer or request-size
+ * limits — even at peak ingest.
  *
  * Window semantics:
- *   - `windowStart`:
- *     - subsequent runs: the persisted `eventWatermark` (exclusive lower bound).
- *     - cold start (no watermark): `now − LOOKBACK_WINDOW_MINUTES` (inclusive).
+ *   - `windowStart`: the persisted `eventWatermark` on subsequent runs;
+ *     `now − LOOKBACK_WINDOW_MINUTES` on cold start.
  *   - `windowEnd`: `min(windowStart + TICK_LOOKBACK_CAP_MINUTES, now − SETTLE_BUFFER_SECONDS)`.
- *     The settle buffer absorbs Elasticsearch refresh-interval lag and modest
- *     clock skew between the rule executor and the dispatcher.
- *   - Lower bound is `gte` only on cold start; subsequent ticks use `gt` to
- *     avoid re-processing the boundary event the previous tick already covered.
+ *     The cap bounds the row count fed into INLINE STATS so the ES|QL sub-plan
+ *     buffer stays well under its 16.8 MB limit; the settle buffer absorbs
+ *     Elasticsearch refresh-interval lag and modest clock skew between the
+ *     rule executor and the dispatcher.
+ *   - Lower bound is always `gte`. The boundary timestamp is re-included on
+ *     every tick so any episode whose `last_event_timestamp` ties the previous
+ *     watermark is retried — this is what closes the silent loss path when
+ *     `LIMIT 10000` truncates a busy window. The per-`(rule_id, group_hash)`
+ *     dedup in the ES|QL query (`last_fired < @timestamp`) filters out
+ *     anything we already dispatched, so re-inclusion does not produce
+ *     duplicate fires.
+ *
+ * Watermark semantics:
+ *   - On a tick that returned episodes, `nextEventWatermark` is the
+ *     `last_event_timestamp` of the latest episode actually returned (the last
+ *     row in the SORT-asc result). The cursor advances at the rate of
+ *     observed data, not wall clock, so a `LIMIT 10000` cut tail — which by
+ *     construction has `last_event_timestamp >=` the new watermark — is
+ *     picked up on the next tick.
+ *   - On an empty window, the watermark advances to `windowEnd` so quiet
+ *     periods don't re-read the same empty range forever.
+ *   - On `step_error`, `dispatcher.ts` discards the watermark via
+ *     `extractAdvanceableWatermark`, so the failed window is retried.
  *
  * Backlog/outage handling is implicit: the watermark advances at most one
  * cap per tick, so a long outage drains over many ticks with bounded work
@@ -87,7 +105,7 @@ export class FetchEpisodesStep implements DispatcherStep {
       filter: {
         range: {
           '@timestamp': {
-            ...(isFirstRun ? { gte: lowerBound } : { gt: lowerBound }),
+            gte: lowerBound,
             lte: upperBound,
           },
         },
@@ -95,7 +113,12 @@ export class FetchEpisodesStep implements DispatcherStep {
     });
 
     const episodes = parseAlertEpisodes(result);
-    const nextEventWatermark = upperBound;
+    // Anchor the watermark to the latest episode actually returned (the
+    // ES|QL query sorts `last_event_timestamp` ascending, and the result
+    // preserves that order through `parseAlertEpisodes`). Empty windows
+    // fall back to `upperBound` so quiet periods still progress.
+    const nextEventWatermark =
+      episodes.length > 0 ? episodes[episodes.length - 1].last_event_timestamp : upperBound;
 
     if (episodes.length === 0) {
       return { type: 'halt', reason: 'no_episodes', data: { nextEventWatermark } };

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/steps/fetch_episodes_step.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/steps/fetch_episodes_step.ts
@@ -17,7 +17,11 @@ import type {
 } from '../types';
 import type { QueryServiceContract } from '../../services/query_service/query_service';
 import { QueryServiceInternalToken } from '../../services/query_service/tokens';
-import { LOOKBACK_WINDOW_MINUTES } from '../constants';
+import {
+  LOOKBACK_WINDOW_MINUTES,
+  SETTLE_BUFFER_SECONDS,
+  TICK_LOOKBACK_CAP_MINUTES,
+} from '../constants';
 import { getDispatchableAlertEventsQuery } from '../queries';
 
 interface RawAlertEpisode {
@@ -29,6 +33,28 @@ interface RawAlertEpisode {
   data_json: string | null;
 }
 
+/**
+ * `fetch_episodes` queries a strictly bounded `@timestamp` window so the
+ * upstream rows fed into `INLINE STATS` (and the IN-list flowing into
+ * `fetch_suppressions`) stay small enough to never breach ES|QL sub-plan
+ * buffer or request-size limits — even at peak ingest.
+ *
+ * Window semantics:
+ *   - `windowStart`:
+ *     - subsequent runs: the persisted `eventWatermark` (exclusive lower bound).
+ *     - cold start (no watermark): `now − LOOKBACK_WINDOW_MINUTES` (inclusive).
+ *   - `windowEnd`: `min(windowStart + TICK_LOOKBACK_CAP_MINUTES, now − SETTLE_BUFFER_SECONDS)`.
+ *     The settle buffer absorbs Elasticsearch refresh-interval lag and modest
+ *     clock skew between the rule executor and the dispatcher.
+ *   - Lower bound is `gte` only on cold start; subsequent ticks use `gt` to
+ *     avoid re-processing the boundary event the previous tick already covered.
+ *
+ * Backlog/outage handling is implicit: the watermark advances at most one
+ * cap per tick, so a long outage drains over many ticks with bounded work
+ * per tick. When `windowEnd` collapses to `windowStart` (settle buffer ate
+ * the entire window), the step halts without advancing the watermark, so
+ * the next tick retries the same range.
+ */
 @injectable()
 export class FetchEpisodesStep implements DispatcherStep {
   public readonly name = 'fetch_episodes';
@@ -38,30 +64,44 @@ export class FetchEpisodesStep implements DispatcherStep {
   ) {}
 
   public async execute(state: Readonly<DispatcherPipelineState>): Promise<DispatcherStepOutput> {
-    const { previousStartedAt } = state.input;
+    const { eventWatermark } = state.input;
+    const isFirstRun = !eventWatermark;
 
-    const lookback = moment(previousStartedAt)
-      .subtract(LOOKBACK_WINDOW_MINUTES, 'minutes')
-      .toISOString();
+    const windowStart = isFirstRun
+      ? moment().subtract(LOOKBACK_WINDOW_MINUTES, 'minutes')
+      : moment(eventWatermark);
+
+    const cappedEnd = windowStart.clone().add(TICK_LOOKBACK_CAP_MINUTES, 'minutes');
+    const safeNow = moment().subtract(SETTLE_BUFFER_SECONDS, 'seconds');
+    const windowEnd = moment.min(cappedEnd, safeNow);
+
+    if (windowEnd.isSameOrBefore(windowStart)) {
+      return { type: 'halt', reason: 'no_episodes' };
+    }
+
+    const lowerBound = windowStart.toISOString();
+    const upperBound = windowEnd.toISOString();
 
     const result = await this.queryService.executeQueryRows<RawAlertEpisode>({
       query: getDispatchableAlertEventsQuery().query,
       filter: {
         range: {
           '@timestamp': {
-            gte: lookback,
+            ...(isFirstRun ? { gte: lowerBound } : { gt: lowerBound }),
+            lte: upperBound,
           },
         },
       },
     });
 
     const episodes = parseAlertEpisodes(result);
+    const nextEventWatermark = upperBound;
 
     if (episodes.length === 0) {
-      return { type: 'halt', reason: 'no_episodes' };
+      return { type: 'halt', reason: 'no_episodes', data: { nextEventWatermark } };
     }
 
-    return { type: 'continue', data: { episodes } };
+    return { type: 'continue', data: { episodes, nextEventWatermark } };
   }
 }
 

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/task_runner.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/task_runner.test.ts
@@ -9,6 +9,7 @@ import type { ConcreteTaskInstance } from '@kbn/task-manager-plugin/server/task'
 import type { DispatcherServiceContract } from './dispatcher';
 import type { DispatcherEnabledProvider } from './tokens';
 import { DispatcherTaskRunner } from './task_runner';
+import type { DispatcherTaskState } from './types';
 
 describe('DispatcherTaskRunner', () => {
   let dispatcherService: jest.Mocked<DispatcherServiceContract>;
@@ -16,16 +17,20 @@ describe('DispatcherTaskRunner', () => {
   let runner: DispatcherTaskRunner;
   let abortController: AbortController;
 
-  // @ts-expect-error: not all fields are required for these tests
-  const taskInstance: ConcreteTaskInstance = {
-    id: 'task-1',
-    params: {},
-    state: {
-      previousStartedAt: '2026-01-22T07:30:00.000Z',
-    },
-    scheduledAt: new Date('2026-01-22T07:30:00.000Z'),
-    startedAt: new Date('2026-01-22T07:30:00.000Z'),
-  };
+  function buildTaskInstance(state: DispatcherTaskState): ConcreteTaskInstance {
+    // @ts-expect-error: not all fields are required for these tests
+    return {
+      id: 'task-1',
+      params: {},
+      state,
+      scheduledAt: new Date('2026-01-22T07:30:00.000Z'),
+      startedAt: new Date('2026-01-22T07:30:00.000Z'),
+    };
+  }
+
+  const taskInstance = buildTaskInstance({
+    previousStartedAt: '2026-01-22T07:30:00.000Z',
+  });
 
   beforeEach(() => {
     dispatcherService = { run: jest.fn() };
@@ -91,6 +96,97 @@ describe('DispatcherTaskRunner', () => {
       await runner.run({ taskInstance, abortController });
 
       expect(dispatcherService.run).toHaveBeenCalled();
+    });
+
+    it('passes persisted eventWatermark from task state into dispatcher params', async () => {
+      const watermarkIso = '2026-01-22T07:42:00.000Z';
+      const task = buildTaskInstance({
+        previousStartedAt: '2026-01-22T07:30:00.000Z',
+        eventWatermark: watermarkIso,
+      });
+      dispatcherService.run.mockResolvedValue({
+        startedAt: new Date('2026-01-22T07:45:00.000Z'),
+        nextEventWatermark: '2026-01-22T07:43:00.000Z',
+      });
+
+      await runner.run({ taskInstance: task, abortController });
+
+      const [params] = dispatcherService.run.mock.calls[0];
+      expect(params.eventWatermark?.toISOString()).toBe(watermarkIso);
+    });
+
+    it('persists nextEventWatermark from dispatcher result', async () => {
+      dispatcherService.run.mockResolvedValue({
+        startedAt: new Date('2026-01-22T07:45:00.000Z'),
+        nextEventWatermark: '2026-01-22T07:44:55.000Z',
+      });
+
+      const result = await runner.run({ taskInstance, abortController });
+
+      expect(result.state).toEqual({
+        previousStartedAt: '2026-01-22T07:45:00.000Z',
+        eventWatermark: '2026-01-22T07:44:55.000Z',
+      });
+    });
+
+    it('preserves prior eventWatermark when dispatcher omits nextEventWatermark', async () => {
+      const task = buildTaskInstance({
+        previousStartedAt: '2026-01-22T07:30:00.000Z',
+        eventWatermark: '2026-01-22T07:42:00.000Z',
+      });
+      dispatcherService.run.mockResolvedValue({
+        startedAt: new Date('2026-01-22T07:45:00.000Z'),
+      });
+
+      const result = await runner.run({ taskInstance: task, abortController });
+
+      // previousStartedAt advances (wall-clock telemetry); eventWatermark
+      // stays where it was so the unfinished window is re-read next tick.
+      expect(result.state).toEqual({
+        previousStartedAt: '2026-01-22T07:45:00.000Z',
+        eventWatermark: '2026-01-22T07:42:00.000Z',
+      });
+    });
+
+    it('does not invent an eventWatermark when neither prior state nor result has one', async () => {
+      dispatcherService.run.mockResolvedValue({
+        startedAt: new Date('2026-01-22T07:45:00.000Z'),
+      });
+
+      const result = await runner.run({ taskInstance, abortController });
+
+      expect(result.state).toEqual({
+        previousStartedAt: '2026-01-22T07:45:00.000Z',
+      });
+      expect((result.state as DispatcherTaskState).eventWatermark).toBeUndefined();
+    });
+
+    it('preserves eventWatermark when disabled', async () => {
+      dispatcherEnabledProvider.mockResolvedValue(false);
+      const task = buildTaskInstance({
+        previousStartedAt: '2026-01-22T07:30:00.000Z',
+        eventWatermark: '2026-01-22T07:42:00.000Z',
+      });
+
+      const result = await runner.run({ taskInstance: task, abortController });
+
+      expect(dispatcherService.run).not.toHaveBeenCalled();
+      expect(result.state).toEqual({
+        previousStartedAt: '2026-01-22T07:30:00.000Z',
+        eventWatermark: '2026-01-22T07:42:00.000Z',
+      });
+    });
+
+    it('propagates dispatcher errors so Task Manager retries and the watermark stays put', async () => {
+      const task = buildTaskInstance({
+        previousStartedAt: '2026-01-22T07:30:00.000Z',
+        eventWatermark: '2026-01-22T07:42:00.000Z',
+      });
+      dispatcherService.run.mockRejectedValue(new Error('pipeline blew up'));
+
+      await expect(runner.run({ taskInstance: task, abortController })).rejects.toThrow(
+        'pipeline blew up'
+      );
     });
   });
 });

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/task_runner.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/task_runner.ts
@@ -32,16 +32,17 @@ export class DispatcherTaskRunner {
 
   public async run({ taskInstance, abortController }: TaskRunParams): Promise<RunResult> {
     const isEnabled = await this.safeIsEnabled();
+    const previousState: DispatcherTaskState = taskInstance.state ?? {};
 
     if (!isEnabled) {
-      return { state: taskInstance.state };
+      return { state: previousState };
     }
 
-    const params = this.createDispatcherParams(taskInstance, abortController);
+    const params = this.createDispatcherParams(previousState, abortController);
 
     const result = await this.dispatcherService.run(params);
 
-    return this.buildRunResult(result);
+    return this.buildRunResult(result, previousState);
   }
 
   private async safeIsEnabled(): Promise<boolean> {
@@ -53,18 +54,32 @@ export class DispatcherTaskRunner {
   }
 
   private createDispatcherParams(
-    taskInstance: TaskRunParams['taskInstance'],
+    state: DispatcherTaskState,
     abortController: AbortController
   ): DispatcherExecutionParams {
-    const state: DispatcherTaskState = taskInstance.state;
-
     return {
       previousStartedAt: state.previousStartedAt ? new Date(state.previousStartedAt) : undefined,
+      eventWatermark: state.eventWatermark ? new Date(state.eventWatermark) : undefined,
       abortController,
     };
   }
 
-  private buildRunResult(result: DispatcherExecutionResult): RunResult {
-    return { state: { previousStartedAt: result.startedAt.toISOString() } };
+  private buildRunResult(
+    result: DispatcherExecutionResult,
+    previousState: DispatcherTaskState
+  ): RunResult {
+    // `previousStartedAt` always advances — it is wall-clock telemetry of the
+    // last tick, not a data-processing watermark.
+    //
+    // `eventWatermark` advances only when the dispatcher returned a
+    // `nextEventWatermark`. If the pipeline threw mid-run, the dispatcher
+    // rethrew and this method never executes, so the prior watermark stays
+    // in place and the failed window is re-read on the next tick.
+    const nextWatermark = result.nextEventWatermark ?? previousState.eventWatermark;
+    const nextState: DispatcherTaskState = {
+      previousStartedAt: result.startedAt.toISOString(),
+      ...(nextWatermark ? { eventWatermark: nextWatermark } : {}),
+    };
+    return { state: nextState };
   }
 }

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/types.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/types.ts
@@ -36,15 +36,35 @@ export interface AlertEpisodeSuppression {
 
 export interface DispatcherExecutionParams {
   previousStartedAt?: Date;
+  /**
+   * Upper bound (exclusive after the first run) on `@timestamp` values
+   * already processed by `fetch_episodes`. Drives the per-tick query
+   * window together with `TICK_LOOKBACK_CAP_MINUTES` and
+   * `SETTLE_BUFFER_SECONDS`. When undefined, the dispatcher cold-starts
+   * from `now − LOOKBACK_WINDOW_MINUTES`.
+   */
+  eventWatermark?: Date;
   abortController?: AbortController;
 }
 
 export interface DispatcherExecutionResult {
   startedAt: Date;
+  /**
+   * Watermark to persist for the next tick. Set when the pipeline returned
+   * (i.e. completed or halted on a controlled `no_episodes` / `no_actions`
+   * reason); undefined when the pipeline was unable to bound a window.
+   * If the pipeline throws, `dispatcher.run` rethrows and `task_runner`
+   * never gets a result, so the watermark naturally stays unchanged.
+   */
+  nextEventWatermark?: string;
 }
 
 export interface DispatcherTaskState {
   previousStartedAt?: string;
+  eventWatermark?: string;
+  // Task Manager persists state as `Record<string, unknown>`; the index
+  // signature keeps assignment in both directions safe without per-call casts.
+  [key: string]: unknown;
 }
 
 export interface Rule {
@@ -120,6 +140,7 @@ export interface LastNotifiedInfo {
 export interface DispatcherPipelineInput {
   readonly startedAt: Date;
   readonly previousStartedAt: Date;
+  readonly eventWatermark?: Date;
 }
 
 export interface DispatcherPipelineState {
@@ -134,13 +155,29 @@ export interface DispatcherPipelineState {
   readonly groups?: ActionGroup[];
   readonly dispatch?: ActionGroup[];
   readonly throttled?: ActionGroup[];
+  /**
+   * Proposed watermark for the next tick. Written by `fetch_episodes`
+   * once it has bounded its query window; left unset when `fetch_episodes`
+   * elects not to query (e.g. settle buffer collapses the window).
+   */
+  readonly nextEventWatermark?: string;
 }
 
 export type DispatcherHaltReason = 'no_episodes' | 'no_actions';
 
 export type DispatcherStepOutput =
   | { type: 'continue'; data?: Partial<Omit<DispatcherPipelineState, 'input'>> }
-  | { type: 'halt'; reason: DispatcherHaltReason };
+  | {
+      type: 'halt';
+      reason: DispatcherHaltReason;
+      /**
+       * Optional state update applied even though the step is halting.
+       * Used by `fetch_episodes` to publish `nextEventWatermark` when it
+       * successfully queried an empty window — the tick is "done" for
+       * that interval and the watermark must still advance.
+       */
+      data?: Partial<Omit<DispatcherPipelineState, 'input'>>;
+    };
 
 export interface DispatcherStep {
   readonly name: string;


### PR DESCRIPTION
## Summary

This PR replaces the dispatcher's fixed 10-minute lookback in `fetch_episodes` with a **bounded, data-anchored watermark** so the step (a) can never feed enough rows into ES|QL to breach the sub-plan buffer limit at peak ingest, and (b) never silently drops episodes when a single window contains more than `LIMIT 10000` unique groups.

It is intentionally surgical: it touches only the `fetch_episodes` windowing path and the small amount of plumbing needed to persist the watermark across ticks.

---

## The problems (in plain English)

The dispatcher runs every 5 seconds. Today, `fetch_episodes` asks Elasticsearch for **the last 10 minutes** of rule events on `.rule-events`, runs `INLINE STATS` to dedupe, and returns up to 10,000 episodes ordered by `last_event_timestamp`.

Three problems we are hitting in production:

1. **Most of those 10 minutes is work the dispatcher already did.** Tick N+1 re-reads ~9m55s of events that tick N already handled. At our target throughput (32k rule events/min on ECH), every tick re-scans hundreds of thousands of rows it doesn't need.
2. **`INLINE STATS` has an internal buffer ceiling of ~16.8 MB.** Once the 10-minute window contains enough rows, the buffer overflows and Elasticsearch returns:
   `illegal_argument_exception: sub-plan execution results too large [19.4mb] > 16.8mb`.
   Once we cross that threshold, `fetch_episodes` fails on **every** tick — the dispatcher stops processing alerts entirely until ingest slows down.
3. **`LIMIT 10000` silently drops episodes.** When a window contains more than 10,000 unique `(rule_id, group_hash, episode_id)` tuples, `SORT last_event_timestamp asc | LIMIT 10000` keeps the smallest 10,000 and discards the rest. Today the cursor advances to wall-clock `windowEnd` regardless, so the cut tail (whose `last_event_timestamp <= windowEnd`) is excluded by the next tick's `> windowEnd` filter and never queried again.

In short: the lookback is a blunt safety net that becomes a self-inflicted DoS at scale, and the cursor mechanics let bursty minutes silently lose work.

---

## How this PR fixes it

### 1. Each tick queries a small, bounded window

```
windowStart = eventWatermark             (or now − 10 min on cold start)
windowEnd   = min(windowStart + 1 min,   now − 5 s)
```

- The **1-minute cap** (`TICK_LOOKBACK_CAP_MINUTES`) ensures any single ES|QL request is small enough to stay well under the 16.8 MB sub-plan buffer, regardless of ingest rate.
- The **5-second settle buffer** (`SETTLE_BUFFER_SECONDS`) accounts for Elasticsearch refresh lag and modest clock skew between the rule executor (writer) and the dispatcher (reader). Events written within the trailing 5s may not yet be searchable, so we stop just short of `now` and pick them up next tick.

### 2. The watermark is anchored to observed data, not wall clock

- When a tick returned episodes, `nextEventWatermark` is the `last_event_timestamp` of the **latest episode actually returned** — i.e., the last row in the `SORT last_event_timestamp asc` result.
- When a tick's window was empty, the watermark falls back to `windowEnd` so quiet periods don't re-read the same empty range forever.

The consequence: if `LIMIT 10000` truncates a busy window, the cursor stops at the last episode we observed — not at the wall-clock end of the window. The cut episodes have `last_event_timestamp >= cursor` by definition (SORT asc), so the next tick's window includes them.

### 3. Lower bound is `gte` on every tick

Previously `gt` after cold start, on the assumption that the boundary event "was already covered." That assumption breaks under LIMIT truncation: events at exactly `windowEnd` may not have been covered. Switching to `gte` re-includes the boundary; the per-`(rule_id, group_hash)` dedup already in the ES|QL query (`WHERE last_fired IS NULL OR last_fired < @timestamp`) filters out anything already dispatched, so re-inclusion does not produce duplicate fires.

This also collapses the cold-start vs. subsequent-tick distinction — same `gte` everywhere.

### 4. The watermark advances only when it is safe to do so

- **Pipeline completes** → advance.
- **Pipeline halts on `no_episodes` / `no_actions`** (controlled "nothing to do") → advance, including when `fetch_episodes` queried an empty window.
- **Any step throws** → the dispatcher returns no watermark, `task_runner` preserves the prior value, Task Manager retries → **the watermark stays put** and the failed window is re-read next tick.
- **Window collapses** (settle buffer eats the cap) → halt without advancing, retry next tick.

This is the key invariant: **we never advance past data we did not finish processing.**

### 5. After an outage, recovery is automatic and bounded

If the dispatcher is paused for, say, 1 hour:

- The watermark is 1 hour behind `now`.
- Each subsequent tick advances it by **at most** `TICK_LOOKBACK_CAP_MINUTES` of event time.
- The backlog drains in roughly `outage_duration / cap` ticks. With a 5-second tick and a 1-minute cap, a 1-hour outage drains in ~5 minutes of wall time, with bounded work per tick.
- This also throttles Elasticsearch during catch-up — we never blast it with a 60-minute aggregation in one shot.
- **New with the data-anchored watermark:** even if a single minute of the backlog contains more than 10k unique episodes, the data-anchored watermark plus `gte` lower bound means consecutive ticks drain the truncated tail without loss.

---

## What changes (file-by-file)

| File | Change |
|------|--------|
| `constants.ts` | Add `TICK_LOOKBACK_CAP_MINUTES = 1` and `SETTLE_BUFFER_SECONDS = 5`. |
| `types.ts` | Add `eventWatermark` / `nextEventWatermark` to params, result, task state, pipeline input/state. Allow `data` on halt outputs. |
| `execution_pipeline.ts` | Apply step `data` on **halt** outputs as well as `continue`, so a clean halt can still publish the watermark. |
| `steps/fetch_episodes_step.ts` | Implement the windowing rules above. Watermark is the `last_event_timestamp` of the latest returned episode (or `windowEnd` on empty windows). Lower bound is `gte` on every tick. |
| `dispatcher.ts` | Thread `eventWatermark` into the pipeline; return `nextEventWatermark` from the final state on advanceable halts. |
| `task_runner.ts` | Read `eventWatermark` from task state on entry, persist `nextEventWatermark` (or preserve the prior value on `step_error`) on exit. |
| Tests | Unit coverage for cold start, subsequent runs, stale watermark, settle-buffer collapse, halt-with-data merging, watermark-on-error preservation, **LIMIT-truncation continuation** (data-anchored watermark prevents loss), **`gte` boundary re-inclusion** (dedup filters dupes), and dispatcher-level plumbing. |
| `integration_tests/dispatcher.test.ts` | `jest.mock('../constants', …)` to widen the cap for the existing end-to-end suites (which seed multi-minute datasets and assert on a single tick). |

---

## What this PR does *not* change

- The ES|QL query itself, `_source` handling, or `data_json` semantics.
- `fetch_suppressions` — its IN-list becomes naturally bounded as a side effect of `fetch_episodes` returning at most ~1 minute of rows.
- ILM on `.rule-events` / `.alert-actions` — separate concern, not addressed here.
- Per-tick telemetry / span labels — separate concern, separate PR.
- Ingestion lag tolerance during **active** dispatcher runs. The cursor advances at the rate of observed episodes, so a doc whose true `@timestamp` ends up behind that advance is still missed. That's a producer-side concern tracked separately.

---

## Risk and rollback

- **Behavioural delta on cold start:** identical to today (10-minute lookback, `gte`).
- **Behavioural delta on steady state:**
  - Narrower per-tick scan (1-min cap) — INLINE STATS row count bounded.
  - Watermark advances at the rate of data, not clock — bounded by the 1-min cap so quiet periods still progress through the empty-window fallback.
  - `gte` lower bound + per-`(rule_id, group_hash)` dedup → no duplicate fires from re-inclusion at the boundary.
- **Failure modes:** any step throwing or any halt that isn't `no_episodes` / `no_actions` keeps the watermark put, so the failed window is retried — strictly safer than today, where `previousStartedAt` advances on every tick regardless.
- **Rollback:** revert the two commits on this branch. The new fields on `DispatcherTaskState` are optional; reverting the code is sufficient — Task Manager will simply ignore the persisted `eventWatermark` field.

---

## Test plan

- CI green on this PR.
- Manual deploy on a staging ECH cluster running at 32k rule events/min; confirm `fetch_episodes` no longer raises `sub-plan execution results too large` and that the watermark advances tick-over-tick at the rate of `last_event_timestamp`.
- **New scenario:** seed a 1-minute window with > 10,000 unique episodes; confirm consecutive ticks drain the full set without loss (regression for the LIMIT-truncation path).
- Simulate a dispatcher outage by disabling and re-enabling the task; confirm the backlog drains in `outage / 1 min` ticks without spiking ES.
- Confirm no behavioural change for empty-tenant ticks (cold start path still hits the 10-minute window once, then settles into the bounded windowing).

---

## Reviewer comments addressed (@kdelemme)

- *"How do we know that 1min of episodes is always below 16.8MB?"* — empirical from the 32k events/min soak; with a 1-min cap and ~533 episodes/sec the row count fed into INLINE STATS stays well under the buffer ceiling. A row-count cap as belt-and-suspenders is worth considering longer-term but is out of scope here.
- *"What happens if the ingestion delay is > 5s? will we miss the episode?"* — partially addressed. During quiet periods the cursor doesn't advance because no episodes were observed, so a late doc that becomes visible later is caught. During active periods the cursor advances at the rate of dispatched episodes, so a doc whose `@timestamp` ends up behind that advance is still missed; that's a producer-side concern tracked separately.
- *"can we make our code simpler with just using `gt: lowerBound` regardless of the first run?"* — addressed in the opposite direction: `gte` everywhere, because the boundary needs to be re-included for the LIMIT-truncation fix. The cold-start vs. subsequent-tick distinction is gone, dedup handles the re-include.
