### PR TITLE
Remove deprecated serverless search ES project types

### DIFF
--- a/src/platform/packages/shared/kbn-es/src/cli_commands/serverless.ts
+++ b/src/platform/packages/shared/kbn-es/src/cli_commands/serverless.ts
@@ -158,6 +158,12 @@ export const serverless: Command = {
         `Invalid projectType '${options.esProjectType}', supported values: ${supportedProjectTypesStr}`
       );
     }
+
+    // Normalize 'elasticsearch' alias to 'elasticsearch_general_purpose'
+    if (options.esProjectType === 'elasticsearch') {
+      options.esProjectType = 'elasticsearch_general_purpose' as typeof options.esProjectType;
+    }
+
     // also provide the Kibana project type, e.g. for role file selection
     options.projectType = kbnProjectTypeFromEs.get(options.esProjectType) as ServerlessProjectType;
 

--- a/src/platform/packages/shared/kbn-es/src/utils/docker.ts
+++ b/src/platform/packages/shared/kbn-es/src/utils/docker.ts
@@ -77,10 +77,9 @@ export const serverlessProjectTypes = ['es', 'oblt', 'security', 'workplaceai'] 
 export type ServerlessProjectType = (typeof serverlessProjectTypes)[number];
 
 export const esServerlessProjectTypes = [
+  'elasticsearch',
   'elasticsearch_general_purpose',
-  'elasticsearch_search',
   'elasticsearch_vector',
-  'elasticsearch_timeseries',
   'observability',
   'security',
   'workplaceai',
@@ -123,10 +122,9 @@ export const esSettingsProjectTypeFromKbn = new Map<string, string>([
 ]);
 
 export const kbnProjectTypeFromEs = new Map<string, string>([
+  ['elasticsearch', 'es'],
   ['elasticsearch_general_purpose', 'es'],
-  ['elasticsearch_search', 'es'],
   ['elasticsearch_vector', 'es'],
-  ['elasticsearch_timeseries', 'es'],
   ['observability', 'oblt'],
   ['security', 'security'],
   ['workplaceai', 'workplaceai'],


### PR DESCRIPTION
## Summary

Removes `elasticsearch_search` and `elasticsearch_timeseries` from the supported ES serverless project types. Adds `elasticsearch` as an alias that normalizes to `elasticsearch_general_purpose` at startup. This aligns the Kibana project types with actually existing Serverless project types.

