### PR TITLE
[skills] Sync validate-oas include-path list with Buildkite source of truth

### DIFF
--- a/.agents/skills/validate-oas/SKILL.md
+++ b/.agents/skills/validate-oas/SKILL.md
@@ -50,11 +50,11 @@ node scripts/capture_oas_snapshot \
   --include-path /api/spaces \
   --include-path /api/streams \
   --include-path /api/fleet \
-  --include-path /api/saved_objects/_import \
-  --include-path /api/saved_objects/_export \
+  --include-path /api/saved_objects \
   --include-path /api/maintenance_window \
   --include-path /api/agent_builder \
-  --include-path /api/workflows
+  --include-path /api/workflows \
+  --include-path /api/security/entity_store
 ```
 
 3. Rebuild the final OAS documents:
@@ -104,11 +104,11 @@ node scripts/capture_oas_snapshot \
   --include-path /api/spaces \
   --include-path /api/streams \
   --include-path /api/fleet \
-  --include-path /api/saved_objects/_import \
-  --include-path /api/saved_objects/_export \
+  --include-path /api/saved_objects \
   --include-path /api/maintenance_window \
   --include-path /api/agent_builder \
-  --include-path /api/workflows
+  --include-path /api/workflows \
+  --include-path /api/security/entity_store
 cd oas_docs && make api-docs
 ```
 


### PR DESCRIPTION
Sync the `validate-oas` skill's `capture_oas_snapshot` include-path list with `.buildkite/scripts/steps/checks/capture_oas_snapshot.sh`, the source of truth for what CI captures.

## Why

The skill doc had drifted from CI in two places:

- Buildkite passes a single broader `--include-path /api/saved_objects` whereas the skill listed `/api/saved_objects/_import` and `/api/saved_objects/_export` separately, so any saved-objects route outside import/export went uncaptured when developers followed the skill.
- Buildkite includes `--include-path /api/security/entity_store`; the skill omitted it entirely.

Surfaced during the OAS structural re-verify audit on 2026-04-27. The skill itself already names `capture_oas_snapshot.sh` as source of truth, so this brings it into agreement.

## What changed

Both code blocks in `.agents/skills/validate-oas/SKILL.md` (the "Refresh flow" step and the "Commands" section) now match Buildkite verbatim. No other wording changed.

Co-Authored-By: Claude Opus 4.7