### PR TITLE
[Security Solution] Kibana #262284 (kibana-262284)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/components/header_title.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/components/header_title.test.tsx
@@ -6,7 +6,8 @@
  */
 
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ATTACK_DISCOVERY_AD_HOC_RULE_ID } from '@kbn/elastic-assistant-common';
 
 import { HeaderTitle } from './header_title';
 import { TestProviders } from '../../../common/mock';
@@ -17,6 +18,7 @@ import {
   HEADER_ALERTS_BLOCK_TEST_ID,
   HEADER_ASSIGNEES_BLOCK_TEST_ID,
   HEADER_BADGE_TEST_ID,
+  HEADER_TITLE_LINK_TEST_ID,
 } from '../constants/test_ids';
 
 jest.mock('../hooks/use_header_data', () => ({
@@ -31,8 +33,35 @@ jest.mock('../hooks/use_navigate_to_attack_details_left_panel', () => ({
   useNavigateToAttackDetailsLeftPanel: jest.fn(),
 }));
 
+jest.mock('../../../attack_discovery/pages/settings_flyout/schedule/details_flyout', () => ({
+  DetailsFlyout: ({
+    scheduleId,
+    onClose,
+  }: {
+    scheduleId: string;
+    onClose: () => void;
+  }) => (
+    <div
+      data-test-subj="attack-details-schedule-details-flyout"
+      data-schedule-id={scheduleId}
+    >
+      <button data-test-subj="attack-details-mock-close-schedule-details" onClick={onClose} />
+    </div>
+  ),
+}));
+
 jest.mock('../../../flyout_v2/shared/components/flyout_title', () => ({
-  FlyoutTitle: ({ title }: { title: string }) => <div data-test-subj="flyout-title">{title}</div>,
+  FlyoutTitle: ({
+    title,
+    isLink,
+  }: {
+    title: string;
+    isLink?: boolean;
+  }) => (
+    <div data-is-link={isLink ? 'true' : 'false'} data-test-subj="flyout-title">
+      {title}
+    </div>
+  ),
 }));
 
 jest.mock('../../../common/components/formatted_date', () => ({
@@ -78,6 +107,7 @@ describe('HeaderTitle', () => {
     });
     mockedUseAttackDetailsContext.mockReturnValue({
       attackId: 'attack-1',
+      attack: { alertRuleUuid: undefined },
       searchHit: { _index: '.alerts-security.alerts-default', _id: 'attack-1' },
     });
     mockedUseNavigateToAttackDetailsLeftPanel.mockReturnValue(jest.fn());
@@ -152,5 +182,76 @@ describe('HeaderTitle', () => {
 
     expect(screen.getByTestId(HEADER_ASSIGNEES_BLOCK_TEST_ID)).toBeInTheDocument();
     expect(screen.getByTestId('assignees')).toBeInTheDocument();
+  });
+
+  it('renders the attack name as a link when the attack is tied to a schedule', () => {
+    mockedUseAttackDetailsContext.mockReturnValue({
+      attackId: 'attack-1',
+      attack: { alertRuleUuid: 'attack-discovery-schedule-uuid' },
+      searchHit: { _index: '.alerts-security.alerts-default', _id: 'attack-1' },
+    });
+
+    render(
+      <TestProviders>
+        <HeaderTitle />
+      </TestProviders>
+    );
+
+    expect(screen.getByTestId(HEADER_TITLE_LINK_TEST_ID)).toBeInTheDocument();
+    expect(screen.getByTestId('flyout-title')).toHaveAttribute('data-is-link', 'true');
+  });
+
+  it('opens the schedule details flyout when the title link is clicked', () => {
+    mockedUseAttackDetailsContext.mockReturnValue({
+      attackId: 'attack-1',
+      attack: { alertRuleUuid: 'attack-discovery-schedule-uuid' },
+      searchHit: { _index: '.alerts-security.alerts-default', _id: 'attack-1' },
+    });
+
+    render(
+      <TestProviders>
+        <HeaderTitle />
+      </TestProviders>
+    );
+
+    fireEvent.click(screen.getByTestId(HEADER_TITLE_LINK_TEST_ID));
+
+    const flyout = screen.getByTestId('attack-details-schedule-details-flyout');
+    expect(flyout).toHaveAttribute('data-schedule-id', 'attack-discovery-schedule-uuid');
+  });
+
+  it('closes the schedule details flyout when DetailsFlyout calls onClose', () => {
+    mockedUseAttackDetailsContext.mockReturnValue({
+      attackId: 'attack-1',
+      attack: { alertRuleUuid: 'attack-discovery-schedule-uuid' },
+      searchHit: { _index: '.alerts-security.alerts-default', _id: 'attack-1' },
+    });
+
+    render(
+      <TestProviders>
+        <HeaderTitle />
+      </TestProviders>
+    );
+
+    fireEvent.click(screen.getByTestId(HEADER_TITLE_LINK_TEST_ID));
+    fireEvent.click(screen.getByTestId('attack-details-mock-close-schedule-details'));
+    expect(screen.queryByTestId('attack-details-schedule-details-flyout')).not.toBeInTheDocument();
+  });
+
+  it('does not show a schedule link for ad hoc attack runs', () => {
+    mockedUseAttackDetailsContext.mockReturnValue({
+      attackId: 'attack-1',
+      attack: { alertRuleUuid: ATTACK_DISCOVERY_AD_HOC_RULE_ID },
+      searchHit: { _index: '.alerts-security.alerts-default', _id: 'attack-1' },
+    });
+
+    render(
+      <TestProviders>
+        <HeaderTitle />
+      </TestProviders>
+    );
+
+    expect(screen.queryByTestId(HEADER_TITLE_LINK_TEST_ID)).not.toBeInTheDocument();
+    expect(screen.getByTestId('flyout-title')).toHaveAttribute('data-is-link', 'false');
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/components/header_title.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/components/header_title.test.tsx
@@ -238,6 +238,22 @@ describe('HeaderTitle', () => {
     expect(screen.queryByTestId('attack-details-schedule-details-flyout')).not.toBeInTheDocument();
   });
 
+  it('does not show a schedule link when alertRuleUuid is empty', () => {
+    mockedUseAttackDetailsContext.mockReturnValue({
+      attackId: 'attack-1',
+      attack: { alertRuleUuid: '' },
+      searchHit: { _index: '.alerts-security.alerts-default', _id: 'attack-1' },
+    });
+
+    render(
+      <TestProviders>
+        <HeaderTitle />
+      </TestProviders>
+    );
+
+    expect(screen.queryByTestId(HEADER_TITLE_LINK_TEST_ID)).not.toBeInTheDocument();
+  });
+
   it('does not show a schedule link for ad hoc attack runs', () => {
     mockedUseAttackDetailsContext.mockReturnValue({
       attackId: 'attack-1',

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/components/header_title.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/components/header_title.test.tsx
@@ -254,4 +254,21 @@ describe('HeaderTitle', () => {
     expect(screen.queryByTestId(HEADER_TITLE_LINK_TEST_ID)).not.toBeInTheDocument();
     expect(screen.getByTestId('flyout-title')).toHaveAttribute('data-is-link', 'false');
   });
+
+  it('does not show a schedule link when attack data is unavailable', () => {
+    mockedUseAttackDetailsContext.mockReturnValue({
+      attackId: 'attack-1',
+      attack: null,
+      searchHit: { _index: '.alerts-security.alerts-default', _id: 'attack-1' },
+    });
+
+    render(
+      <TestProviders>
+        <HeaderTitle />
+      </TestProviders>
+    );
+
+    expect(screen.queryByTestId(HEADER_TITLE_LINK_TEST_ID)).not.toBeInTheDocument();
+    expect(screen.getByTestId('flyout-title')).toHaveAttribute('data-is-link', 'false');
+  });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/components/header_title.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/components/header_title.tsx
@@ -5,10 +5,11 @@
  * 2.0.
  */
 
-import React, { memo } from 'react';
-import { EuiBadge, EuiFlexGroup, EuiFlexItem, EuiSpacer } from '@elastic/eui';
+import React, { memo, useCallback, useMemo, useState } from 'react';
+import { EuiBadge, EuiFlexGroup, EuiFlexItem, EuiLink, EuiSpacer } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
+import { ATTACK_DISCOVERY_AD_HOC_RULE_ID } from '@kbn/elastic-assistant-common';
 import { flyoutHeaderBlockStyles } from '../../../flyout_v2/document/constants/styles';
 import { FlyoutTitle } from '../../../flyout_v2/shared/components/flyout_title';
 import { PreferenceFormattedDate } from '../../../common/components/formatted_date';
@@ -16,10 +17,12 @@ import { Status } from './status';
 import { Assignees } from './assignees';
 import { Notes } from '../../../flyout_v2/shared/components/notes';
 import { AlertHeaderBlock } from '../../../flyout_v2/shared/components/alert_header_block';
+import { DetailsFlyout } from '../../../attack_discovery/pages/settings_flyout/schedule/details_flyout';
 import {
   HEADER_ALERTS_BLOCK_TEST_ID,
   HEADER_ASSIGNEES_BLOCK_TEST_ID,
   HEADER_BADGE_TEST_ID,
+  HEADER_TITLE_LINK_TEST_ID,
   HEADER_TITLE_TEST_ID,
 } from '../constants/test_ids';
 import { useHeaderData } from '../hooks/use_header_data';
@@ -33,13 +36,62 @@ const ATTACK_HEADER_BADGE = i18n.translate(
   }
 );
 
+const OPEN_SCHEDULE_DETAILS_LABEL = i18n.translate(
+  'xpack.securitySolution.attackDetailsFlyout.header.title.openScheduleDetails',
+  {
+    defaultMessage: 'Open attack discovery schedule details',
+  }
+);
+
 /**
  * Header data for the Attack details flyout
  */
 export const HeaderTitle = memo(() => {
   const { title, timestamp, alertsCount } = useHeaderData();
-  const { attackId } = useAttackDetailsContext();
+  const { attackId, attack } = useAttackDetailsContext();
   const openNotesTab = useNavigateToAttackDetailsLeftPanel({ tab: 'notes' });
+  const [scheduleDetailsId, setScheduleDetailsId] = useState<string | undefined>(undefined);
+
+  const scheduleIdForLink = useMemo(() => {
+    const uuid = attack?.alertRuleUuid;
+    if (uuid == null || uuid === ATTACK_DISCOVERY_AD_HOC_RULE_ID) {
+      return undefined;
+    }
+    return uuid;
+  }, [attack?.alertRuleUuid]);
+
+  const onOpenScheduleDetails = useCallback(
+    (ev: React.MouseEvent) => {
+      ev.preventDefault();
+      if (scheduleIdForLink) {
+        setScheduleDetailsId(scheduleIdForLink);
+      }
+    },
+    [scheduleIdForLink]
+  );
+
+  const onCloseScheduleDetails = useCallback(() => setScheduleDetailsId(undefined), []);
+
+  const titleNode = useMemo(
+    () =>
+      scheduleIdForLink ? (
+        <EuiLink
+          aria-label={OPEN_SCHEDULE_DETAILS_LABEL}
+          data-test-subj={HEADER_TITLE_LINK_TEST_ID}
+          onClick={onOpenScheduleDetails}
+        >
+          <FlyoutTitle
+            data-test-subj={HEADER_TITLE_TEST_ID}
+            isLink
+            title={title}
+            iconType={'bolt'}
+          />
+        </EuiLink>
+      ) : (
+        <FlyoutTitle data-test-subj={HEADER_TITLE_TEST_ID} title={title} iconType={'bolt'} />
+      ),
+    [onOpenScheduleDetails, scheduleIdForLink, title]
+  );
 
   return (
     <>
@@ -49,7 +101,7 @@ export const HeaderTitle = memo(() => {
           <EuiSpacer size="xs" />
         </>
       )}
-      <FlyoutTitle data-test-subj={HEADER_TITLE_TEST_ID} title={title} iconType={'bolt'} />
+      {titleNode}
       <EuiSpacer size="s" />
       <EuiBadge
         aria-label={ATTACK_HEADER_BADGE}
@@ -104,6 +156,9 @@ export const HeaderTitle = memo(() => {
           </EuiFlexGroup>
         </EuiFlexItem>
       </EuiFlexGroup>
+      {scheduleDetailsId && (
+        <DetailsFlyout scheduleId={scheduleDetailsId} onClose={onCloseScheduleDetails} />
+      )}
     </>
   );
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/components/header_title.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/components/header_title.tsx
@@ -18,6 +18,7 @@ import { Assignees } from './assignees';
 import { Notes } from '../../../flyout_v2/shared/components/notes';
 import { AlertHeaderBlock } from '../../../flyout_v2/shared/components/alert_header_block';
 import { DetailsFlyout } from '../../../attack_discovery/pages/settings_flyout/schedule/details_flyout';
+import { OPEN_SCHEDULE_DETAILS } from '../../../attack_discovery/pages/results/attack_discovery_panel/panel_header/primary_interactions/title/translations';
 import {
   HEADER_ALERTS_BLOCK_TEST_ID,
   HEADER_ASSIGNEES_BLOCK_TEST_ID,
@@ -33,13 +34,6 @@ const ATTACK_HEADER_BADGE = i18n.translate(
   'xpack.securitySolution.attackDetailsFlyout.header.badge.attackLabel',
   {
     defaultMessage: 'Attack',
-  }
-);
-
-const OPEN_SCHEDULE_DETAILS_LABEL = i18n.translate(
-  'xpack.securitySolution.attackDetailsFlyout.header.title.openScheduleDetails',
-  {
-    defaultMessage: 'Open attack discovery schedule details',
   }
 );
 
@@ -76,7 +70,7 @@ export const HeaderTitle = memo(() => {
     () =>
       scheduleIdForLink ? (
         <EuiLink
-          aria-label={OPEN_SCHEDULE_DETAILS_LABEL}
+          aria-label={OPEN_SCHEDULE_DETAILS}
           data-test-subj={HEADER_TITLE_LINK_TEST_ID}
           onClick={onOpenScheduleDetails}
         >

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/components/header_title.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/components/header_title.tsx
@@ -54,7 +54,7 @@ export const HeaderTitle = memo(() => {
 
   const scheduleIdForLink = useMemo(() => {
     const uuid = attack?.alertRuleUuid;
-    if (uuid == null || uuid === ATTACK_DISCOVERY_AD_HOC_RULE_ID) {
+    if (!uuid || uuid === ATTACK_DISCOVERY_AD_HOC_RULE_ID) {
       return undefined;
     }
     return uuid;

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/constants/test_ids.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/constants/test_ids.ts
@@ -16,6 +16,7 @@ export const STATUS_POPOVER_BUTTON_TEST_ID =
   `${ATTACK_DETAILS_FLYOUT_PREFIX}-status-popover-button` as const;
 export const STATUS_POPOVER_TEST_ID = `${ATTACK_DETAILS_FLYOUT_PREFIX}-status-popover` as const;
 export const HEADER_TITLE_TEST_ID = `${ATTACK_DETAILS_FLYOUT_PREFIX}-header-title` as const;
+export const HEADER_TITLE_LINK_TEST_ID = `${ATTACK_DETAILS_FLYOUT_PREFIX}-header-title-link` as const;
 export const HEADER_ALERTS_BLOCK_TEST_ID =
   `${ATTACK_DETAILS_FLYOUT_PREFIX}-header-alerts-block` as const;
 export const HEADER_STATUS_BLOCK_TEST_ID =


### PR DESCRIPTION
## Description

Closes #262284

Here’s what’s in place for **elastic/kibana#262284** (issue text wasn’t available here; behavior matches the prior orchestrator intent: **make the attack title in the Attack details flyout open the schedule details flyout when the attack comes from a scheduled run**).

## Changes

- See the **commit diff** for this branch for the exact edits.
<!-- agent_output: agent_output.md -->

## Verification steps

### Local checks

1. `node scripts/check_changes.ts` from the repo root (or worktree after `yarn kbn bootstrap` if needed).
2. Run targeted **Jest**, **ESLint**, and `type_check` for the diff (see `AGENTS.md`).

### Expected outcome (from task)

- Behavior and UX match the issue requirements and any maintainer clarification in the thread.
- Automated checks relevant to touched areas pass (lint, typecheck, and tests for changed code).
- Draft PR references #262284 and is suitable for independent review and merge.

---

_Draft PR · `scripts/orchestrator` (body uses `agent_output.md` next to `task.json` when present) · task `kibana-262284` · base `main`_
