### PR TITLE
Remove 9.2 from open branches

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,7 @@
   ],
   "ignorePaths": ["**/__fixtures__/**", "**/fixtures/**"],
   "enabledManagers": ["npm", "github-actions", "custom.regex", "devcontainer"],
-  "baseBranches": ["main", "9.4", "9.3", "9.2", "8.19"],
+  "baseBranches": ["main", "9.4", "9.3", "8.19"],
   "labels": ["release_note:skip", "backport:all-open"],
   "prConcurrentLimit": 0,
   "prHourlyLimit": 0,

--- a/versions.json
+++ b/versions.json
@@ -17,11 +17,6 @@
       "branchType": "release"
     },
     {
-      "version": "9.2.9",
-      "branch": "9.2",
-      "branchType": "release"
-    },
-    {
       "version": "8.19.15",
       "branch": "8.19",
       "branchType": "release"


### PR DESCRIPTION
## Summary

The 9.2 branch is no longer actively maintained. The `backport:all-open` label still targets it, causing unnecessary backport PRs. This PR removes 9.2 from:

- **`versions.json`** — so `backport:all-open` stops targeting the 9.2 branch
- **`renovate.json`** — so Renovate stops opening dependency update PRs against 9.2


Made with [Cursor](https://cursor.com)