### PR TITLE
[8.19] [CI] Skip redundant webpack pre-build in CI steps (#262983)

### DIFF
--- a/.buildkite/scripts/steps/build_kibana.sh
+++ b/.buildkite/scripts/steps/build_kibana.sh
@@ -2,6 +2,10 @@
 
 set -euo pipefail
 
+# Skip building shared webpack bundles during bootstrap because
+# node scripts/build rebuilds them in production mode with --dist
+export KBN_BOOTSTRAP_NO_PREBUILT=true
+
 .buildkite/scripts/bootstrap.sh
 .buildkite/scripts/build_kibana.sh
 .buildkite/scripts/post_build_kibana.sh

--- a/.buildkite/scripts/steps/fleet/install_all_packages.sh
+++ b/.buildkite/scripts/steps/fleet/install_all_packages.sh
@@ -9,4 +9,5 @@ echo '--- Installing all packages'
 node scripts/functional_tests \
   --debug \
   --bail \
+  --kibana-install-dir "$KIBANA_BUILD_LOCATION" \
   --config x-pack/platform/test/fleet_packages/config.ts

--- a/.buildkite/scripts/steps/functional/common.sh
+++ b/.buildkite/scripts/steps/functional/common.sh
@@ -6,6 +6,10 @@ set -euo pipefail
 
 source .buildkite/scripts/common/util.sh
 
+# All functional/integration test steps run Kibana from the distributable,
+# so dev-mode webpack bundles built during bootstrap are never used.
+export KBN_BOOTSTRAP_NO_PREBUILT=true
+
 .buildkite/scripts/bootstrap.sh
 .buildkite/scripts/download_build_artifacts.sh
 .buildkite/scripts/setup_es_snapshot_cache.sh

--- a/.buildkite/scripts/steps/on_merge_build_and_metrics.sh
+++ b/.buildkite/scripts/steps/on_merge_build_and_metrics.sh
@@ -2,6 +2,10 @@
 
 set -euo pipefail
 
+# node scripts/build rebuilds shared webpack bundles in production mode,
+# so skip the dev-mode pre-build during bootstrap.
+export KBN_BOOTSTRAP_NO_PREBUILT=true
+
 .buildkite/scripts/bootstrap.sh
 .buildkite/scripts/build_kibana.sh
 .buildkite/scripts/post_build_kibana.sh

--- a/src/dev/kbn_pm/src/commands/bootstrap/bootstrap_command.mjs
+++ b/src/dev/kbn_pm/src/commands/bootstrap/bootstrap_command.mjs
@@ -52,6 +52,9 @@ export const command = {
     --no-vscode          By default bootstrap updates the .vscode directory to include commonly useful vscode
                           settings for local development. Disable this process either pass this flag or set
                           the KBN_BOOTSTRAP_NO_VSCODE=true environment variable.
+    --no-prebuilt        Skip building shared webpack bundles (ui-shared-deps, monaco). Use when a
+                          subsequent distribution build will rebuild them in production mode anyway.
+                          Also settable via KBN_BOOTSTRAP_NO_PREBUILT=true.
     --allow-root         Required supplementary flag if you're running bootstrap as root.
     --quiet              Prevent logging more than basic success/error messages
   `,
@@ -66,6 +69,8 @@ export const command = {
     const vscodeConfig =
       !IS_CI && (args.getBooleanValue('vscode') ?? !process.env.KBN_BOOTSTRAP_NO_VSCODE);
     const forceInstall = args.getBooleanValue('force-install');
+    const skipPrebuilt =
+      args.getBooleanValue('prebuilt') === false || !!process.env.KBN_BOOTSTRAP_NO_PREBUILT;
     const shouldInstall =
       forceInstall || !(await areNodeModulesPresent()) || !(await checkYarnIntegrity(log));
 
@@ -110,19 +115,29 @@ export const command = {
       }
     });
 
+    if (skipPrebuilt) {
+      log.info('skipping pre-built webpack bundles (--no-prebuilt)');
+    }
+
     await Promise.all([
-      time('prepare webpack bundles for packages', async () => {
-        log.info('pre-build webpack bundles');
-        await moonRun([':build-webpack'], {
-          pipe: !quiet,
-          quiet,
-          noCache: forceInstall,
-        });
-        log.success('relevant versions extracted for packages and shared webpack bundles built');
-      }),
-      time('run install scripts', async () => {
-        await runInstallScripts(log, { quiet });
-      }),
+      skipPrebuilt
+        ? undefined
+        : time('prepare webpack bundles for packages', async () => {
+            log.info('pre-build webpack bundles');
+            await moonRun([':build-webpack'], {
+              pipe: !quiet,
+              quiet,
+              noCache: forceInstall,
+            });
+            log.success(
+              'relevant versions extracted for packages and shared webpack bundles built'
+            );
+          }),
+      shouldInstall
+        ? time('run install scripts', async () => {
+            await runInstallScripts(log, { quiet });
+          })
+        : undefined,
     ]);
 
     await time('sort package json', async () => {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[CI] Skip redundant webpack pre-build in CI steps (#262983)](https://github.com/elastic/kibana/pull/262983)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Shahzad","email":"shahzad31comp@gmail.com"},"sourceCommit":{"committedDate":"2026-04-15T14:28:41Z","message":"[CI] Skip redundant webpack pre-build in CI steps (#262983)\n\n## Summary\n\nDuring CI, `kbn bootstrap` builds shared webpack bundles\n(`@kbn/ui-shared-deps-npm`, `@kbn/ui-shared-deps-src`, `@kbn/monaco`) in\ndevelopment mode. In several CI steps these dev-mode bundles are never\nused — they are either overwritten by a production build or ignored\nbecause Kibana runs from the distributable.\n\nThis PR:\n\n* Adds a `--no-prebuilt` flag (and `KBN_BOOTSTRAP_NO_PREBUILT` env var)\nto `kbn bootstrap` that skips the webpack pre-build step\n* Sets `KBN_BOOTSTRAP_NO_PREBUILT=true` in:\n* **Build Kibana Distribution** (`build_kibana.sh`) — `node\nscripts/build` immediately rebuilds bundles in production mode with\n`--dist --no-cache`\n* **On-merge build** (`on_merge_build_and_metrics.sh`) — same\nbootstrap-then-build pattern\n* **All functional/integration test steps** (`common.sh`) — these run\nKibana from the distributable (`KIBANA_BUILD_LOCATION`), which contains\nits own production webpack bundles\n* Fixes the fleet packages test (`install_all_packages.sh`) to use\n`--kibana-install-dir` like every other `common.sh` consumer, since it\nwas previously running from source unnecessarily\n\n### Evidence from CI logs\n\nCompared bootstrap timing between PR build #427957 (with this change)\nand baseline build #427942 (without):\n\n**Build Kibana Distribution step:**\n\n| Phase | Baseline | This PR |\n| --- | --- | --- |\n| Bootstrap dev webpack | ~30s | **skipped** |\n| Dist production webpack (kept) | ~32s | ~32s |\n| **Savings** | | **~30s** |\n\n**FTR / functional test steps (6-sample comparison):**\n\n| | This PR (webpack skipped) | Baseline (webpack from moon cache) |\n| --- | --- | --- |\n| Bootstrap avg | ~37s | ~41s |\n| **Savings per step** | | **~4s** |\n\nIn FTR steps the webpack pre-build only takes ~5s (moon's remote cache\nprovides the artifacts), so the per-step saving is smaller than in the\nbuild step where `--no-cache` forces a full rebuild.\n\n### Scope of savings\n\n* **Build steps** (PR build + on-merge): **~30s each** (webpack rebuilt\nfrom scratch with `--no-cache`)\n* **Functional/integration test steps** (~200 parallel steps): **~4s\neach** (moon cache made the old prebuild cheap)\n* **Aggregate CI agent-time saved**: ~14 minutes per PR build (~1 min\nfrom build steps + ~13 min from ~200 FTR steps × 4s)\n\n### Safety\n\n* Steps that run from source (Jest, type checking, linting) call\n`bootstrap.sh` directly without `common.sh`, so they are unaffected and\ncontinue to build dev webpack bundles\n* `node scripts/build` always rebuilds shared webpack bundles in\nproduction mode with `--no-cache`, independent of bootstrap\n* Only one FTR config uses `alwaysUseSource` (`config.status.ts`) — it\nruns through `ftr_configs.sh` which sources `common.sh`, but the test\nonly exercises HTTP status endpoints and does not require the webpack\nbundles to start\n\n## Test plan\n\n* CI \"Build Kibana Distribution\" step passes ✅ (build #427957)\n* `skipping pre-built webpack bundles (--no-prebuilt)` appears during\nbootstrap in build and functional test steps ✅\n* The dist build `building shared packages with webpack` still runs and\ncompletes ✅\n* Functional/integration test steps pass (FTR config groups, Scout) —\n175+ steps passed, 0 failures (build #427957, still running)\n* Fleet packages test — runs on a separate daily pipeline\n(`packages_daily.yml`), not validated in PR builds\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"6e4b63e89890e7bd24a89b363b1ac345539f09b1","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:all-open","author:actionable-obs","v9.5.0"],"title":"[CI] Skip redundant webpack pre-build in CI steps","number":262983,"url":"https://github.com/elastic/kibana/pull/262983","mergeCommit":{"message":"[CI] Skip redundant webpack pre-build in CI steps (#262983)\n\n## Summary\n\nDuring CI, `kbn bootstrap` builds shared webpack bundles\n(`@kbn/ui-shared-deps-npm`, `@kbn/ui-shared-deps-src`, `@kbn/monaco`) in\ndevelopment mode. In several CI steps these dev-mode bundles are never\nused — they are either overwritten by a production build or ignored\nbecause Kibana runs from the distributable.\n\nThis PR:\n\n* Adds a `--no-prebuilt` flag (and `KBN_BOOTSTRAP_NO_PREBUILT` env var)\nto `kbn bootstrap` that skips the webpack pre-build step\n* Sets `KBN_BOOTSTRAP_NO_PREBUILT=true` in:\n* **Build Kibana Distribution** (`build_kibana.sh`) — `node\nscripts/build` immediately rebuilds bundles in production mode with\n`--dist --no-cache`\n* **On-merge build** (`on_merge_build_and_metrics.sh`) — same\nbootstrap-then-build pattern\n* **All functional/integration test steps** (`common.sh`) — these run\nKibana from the distributable (`KIBANA_BUILD_LOCATION`), which contains\nits own production webpack bundles\n* Fixes the fleet packages test (`install_all_packages.sh`) to use\n`--kibana-install-dir` like every other `common.sh` consumer, since it\nwas previously running from source unnecessarily\n\n### Evidence from CI logs\n\nCompared bootstrap timing between PR build #427957 (with this change)\nand baseline build #427942 (without):\n\n**Build Kibana Distribution step:**\n\n| Phase | Baseline | This PR |\n| --- | --- | --- |\n| Bootstrap dev webpack | ~30s | **skipped** |\n| Dist production webpack (kept) | ~32s | ~32s |\n| **Savings** | | **~30s** |\n\n**FTR / functional test steps (6-sample comparison):**\n\n| | This PR (webpack skipped) | Baseline (webpack from moon cache) |\n| --- | --- | --- |\n| Bootstrap avg | ~37s | ~41s |\n| **Savings per step** | | **~4s** |\n\nIn FTR steps the webpack pre-build only takes ~5s (moon's remote cache\nprovides the artifacts), so the per-step saving is smaller than in the\nbuild step where `--no-cache` forces a full rebuild.\n\n### Scope of savings\n\n* **Build steps** (PR build + on-merge): **~30s each** (webpack rebuilt\nfrom scratch with `--no-cache`)\n* **Functional/integration test steps** (~200 parallel steps): **~4s\neach** (moon cache made the old prebuild cheap)\n* **Aggregate CI agent-time saved**: ~14 minutes per PR build (~1 min\nfrom build steps + ~13 min from ~200 FTR steps × 4s)\n\n### Safety\n\n* Steps that run from source (Jest, type checking, linting) call\n`bootstrap.sh` directly without `common.sh`, so they are unaffected and\ncontinue to build dev webpack bundles\n* `node scripts/build` always rebuilds shared webpack bundles in\nproduction mode with `--no-cache`, independent of bootstrap\n* Only one FTR config uses `alwaysUseSource` (`config.status.ts`) — it\nruns through `ftr_configs.sh` which sources `common.sh`, but the test\nonly exercises HTTP status endpoints and does not require the webpack\nbundles to start\n\n## Test plan\n\n* CI \"Build Kibana Distribution\" step passes ✅ (build #427957)\n* `skipping pre-built webpack bundles (--no-prebuilt)` appears during\nbootstrap in build and functional test steps ✅\n* The dist build `building shared packages with webpack` still runs and\ncompletes ✅\n* Functional/integration test steps pass (FTR config groups, Scout) —\n175+ steps passed, 0 failures (build #427957, still running)\n* Fleet packages test — runs on a separate daily pipeline\n(`packages_daily.yml`), not validated in PR builds\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"6e4b63e89890e7bd24a89b363b1ac345539f09b1"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/262983","number":262983,"mergeCommit":{"message":"[CI] Skip redundant webpack pre-build in CI steps (#262983)\n\n## Summary\n\nDuring CI, `kbn bootstrap` builds shared webpack bundles\n(`@kbn/ui-shared-deps-npm`, `@kbn/ui-shared-deps-src`, `@kbn/monaco`) in\ndevelopment mode. In several CI steps these dev-mode bundles are never\nused — they are either overwritten by a production build or ignored\nbecause Kibana runs from the distributable.\n\nThis PR:\n\n* Adds a `--no-prebuilt` flag (and `KBN_BOOTSTRAP_NO_PREBUILT` env var)\nto `kbn bootstrap` that skips the webpack pre-build step\n* Sets `KBN_BOOTSTRAP_NO_PREBUILT=true` in:\n* **Build Kibana Distribution** (`build_kibana.sh`) — `node\nscripts/build` immediately rebuilds bundles in production mode with\n`--dist --no-cache`\n* **On-merge build** (`on_merge_build_and_metrics.sh`) — same\nbootstrap-then-build pattern\n* **All functional/integration test steps** (`common.sh`) — these run\nKibana from the distributable (`KIBANA_BUILD_LOCATION`), which contains\nits own production webpack bundles\n* Fixes the fleet packages test (`install_all_packages.sh`) to use\n`--kibana-install-dir` like every other `common.sh` consumer, since it\nwas previously running from source unnecessarily\n\n### Evidence from CI logs\n\nCompared bootstrap timing between PR build #427957 (with this change)\nand baseline build #427942 (without):\n\n**Build Kibana Distribution step:**\n\n| Phase | Baseline | This PR |\n| --- | --- | --- |\n| Bootstrap dev webpack | ~30s | **skipped** |\n| Dist production webpack (kept) | ~32s | ~32s |\n| **Savings** | | **~30s** |\n\n**FTR / functional test steps (6-sample comparison):**\n\n| | This PR (webpack skipped) | Baseline (webpack from moon cache) |\n| --- | --- | --- |\n| Bootstrap avg | ~37s | ~41s |\n| **Savings per step** | | **~4s** |\n\nIn FTR steps the webpack pre-build only takes ~5s (moon's remote cache\nprovides the artifacts), so the per-step saving is smaller than in the\nbuild step where `--no-cache` forces a full rebuild.\n\n### Scope of savings\n\n* **Build steps** (PR build + on-merge): **~30s each** (webpack rebuilt\nfrom scratch with `--no-cache`)\n* **Functional/integration test steps** (~200 parallel steps): **~4s\neach** (moon cache made the old prebuild cheap)\n* **Aggregate CI agent-time saved**: ~14 minutes per PR build (~1 min\nfrom build steps + ~13 min from ~200 FTR steps × 4s)\n\n### Safety\n\n* Steps that run from source (Jest, type checking, linting) call\n`bootstrap.sh` directly without `common.sh`, so they are unaffected and\ncontinue to build dev webpack bundles\n* `node scripts/build` always rebuilds shared webpack bundles in\nproduction mode with `--no-cache`, independent of bootstrap\n* Only one FTR config uses `alwaysUseSource` (`config.status.ts`) — it\nruns through `ftr_configs.sh` which sources `common.sh`, but the test\nonly exercises HTTP status endpoints and does not require the webpack\nbundles to start\n\n## Test plan\n\n* CI \"Build Kibana Distribution\" step passes ✅ (build #427957)\n* `skipping pre-built webpack bundles (--no-prebuilt)` appears during\nbootstrap in build and functional test steps ✅\n* The dist build `building shared packages with webpack` still runs and\ncompletes ✅\n* Functional/integration test steps pass (FTR config groups, Scout) —\n175+ steps passed, 0 failures (build #427957, still running)\n* Fleet packages test — runs on a separate daily pipeline\n(`packages_daily.yml`), not validated in PR builds\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"6e4b63e89890e7bd24a89b363b1ac345539f09b1"}},{"url":"https://github.com/elastic/kibana/pull/265940","number":265940,"branch":"9.3","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/265941","number":265941,"branch":"9.4","state":"OPEN"}]}] BACKPORT-->