### PR TITLE
[8.19] [Scout] Use Kibana's `babel-register` when running Playwright (#264927)

### DIFF
--- a/.buildkite/scripts/steps/test/scout/run_test_lane.sh
+++ b/.buildkite/scripts/steps/test/scout/run_test_lane.sh
@@ -140,6 +140,7 @@ run_scout_tests() {
     "SCOUT_TARGET_LOCATION=$SCOUT_TEST_TARGET_LOCATION"
     "SCOUT_TARGET_ARCH=$SCOUT_TEST_TARGET_ARCH"
     "SCOUT_TARGET_DOMAIN=$SCOUT_TEST_TARGET_DOMAIN"
+    "NODE_OPTIONS=${NODE_OPTIONS:-} --require=@kbn/babel-register/install"
   )
 
   local start_time

--- a/src/platform/packages/shared/kbn-scout/src/playwright/cli_wrapper/common.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/cli_wrapper/common.ts
@@ -10,6 +10,7 @@
 import { REPO_ROOT } from '@kbn/repo-info';
 import { spawn, type SpawnOptions } from 'node:child_process';
 import type { ToolingLog } from '@kbn/tooling-log';
+import { withKibanaBabelRegister } from '../utils';
 
 export interface PlaywrightCLIResult {
   exitCode: number;
@@ -27,7 +28,9 @@ export async function runPlaywrightCLI(
   const playwrightBinPath = './node_modules/.bin/playwright';
   const options: SpawnOptions = {
     cwd: REPO_ROOT,
-    env: env ? { ...process.env, ...env } : process.env,
+    env: withKibanaBabelRegister(
+      env ? { ...process.env, ...env } : { ...process.env }
+    ) as NodeJS.ProcessEnv,
     stdio: log ? 'pipe' : 'inherit',
   };
 

--- a/src/platform/packages/shared/kbn-scout/src/playwright/runner/run_tests.test.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/runner/run_tests.test.ts
@@ -14,6 +14,12 @@ import { ScoutTestTarget } from '@kbn/scout-info';
 
 jest.mock('../utils', () => ({
   execPromise: jest.fn(),
+  withKibanaBabelRegister: jest.fn((env = {}) => ({
+    ...env,
+    NODE_OPTIONS: [env.NODE_OPTIONS, '--require=@kbn/babel-register/install']
+      .filter(Boolean)
+      .join(' '),
+  })),
 }));
 
 describe('getPlaywrightProject', () => {
@@ -46,7 +52,6 @@ describe('hasTestsInPlaywrightConfig', () => {
 
   beforeEach(() => {
     mockLog = {
-      debug: jest.fn(),
       info: jest.fn(),
       error: jest.fn(),
     } as unknown as ToolingLog;
@@ -72,8 +77,14 @@ describe('hasTestsInPlaywrightConfig', () => {
       'configPath/playwright.config.ts'
     );
 
-    expect(mockLog.debug).toHaveBeenCalledWith(
-      `scout: running 'SCOUT_REPORTER_ENABLED=false playwright test pwArgs --list'`
+    expect(execPromiseMock).toHaveBeenCalledWith(
+      'playwright test pwArgs --list',
+      expect.objectContaining({
+        env: expect.objectContaining({
+          SCOUT_REPORTER_ENABLED: 'false',
+          NODE_OPTIONS: expect.stringContaining('--require=@kbn/babel-register/install'),
+        }),
+      })
     );
     expect(mockLog.info).toHaveBeenCalledTimes(2);
     expect(mockLog.info).toHaveBeenNthCalledWith(1, 'scout: Validate Playwright config has tests');

--- a/src/platform/packages/shared/kbn-scout/src/playwright/runner/run_tests.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/runner/run_tests.ts
@@ -24,7 +24,7 @@ import {
 import { getConfigRootDir, loadServersConfig } from '../../servers/configs';
 import { getExtraKbnOpts } from '../../servers/run_kibana_server';
 import type { ScoutPlaywrightProjects } from '../types';
-import { execPromise, getPlaywrightGrepTag } from '../utils';
+import { execPromise, getPlaywrightGrepTag, withKibanaBabelRegister } from '../utils';
 import type { RunTestsOptions } from './flags';
 
 export const getPlaywrightProject = (
@@ -66,10 +66,10 @@ async function runPlaywrightTest(
     cmd,
     args,
     cwd: resolve(REPO_ROOT),
-    env: {
+    env: withKibanaBabelRegister({
       ...process.env,
       ...env,
-    },
+    }),
     wait: true,
   });
 }
@@ -82,10 +82,14 @@ export async function hasTestsInPlaywrightConfig(
 ): Promise<number> {
   log.info(`scout: Validate Playwright config has tests`);
   try {
-    const validationCmd = ['SCOUT_REPORTER_ENABLED=false', cmd, ...cmdArgs, '--list'].join(' ');
-    log.debug(`scout: running '${validationCmd}'`);
+    const validationCmd = [cmd, ...cmdArgs, '--list'].join(' ');
 
-    const result = await execPromise(validationCmd);
+    const result = await execPromise(validationCmd, {
+      env: withKibanaBabelRegister({
+        ...process.env,
+        SCOUT_REPORTER_ENABLED: 'false',
+      }) as NodeJS.ProcessEnv,
+    });
     const lastLine = result.stdout.trim().split('\n').pop() || '';
 
     log.info(`scout: ${lastLine}`);

--- a/src/platform/packages/shared/kbn-scout/src/playwright/utils/index.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/utils/index.ts
@@ -7,6 +7,12 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export { isValidUTCDate, formatTime, getPlaywrightGrepTag, execPromise } from './runner_utils';
+export {
+  isValidUTCDate,
+  formatTime,
+  getPlaywrightGrepTag,
+  execPromise,
+  withKibanaBabelRegister,
+} from './runner_utils';
 export { resolveSelector, type SelectorInput } from './locator_helper';
 export { checkA11y, type RunA11yScanOptions } from './axe';

--- a/src/platform/packages/shared/kbn-scout/src/playwright/utils/runner_utils.test.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/utils/runner_utils.test.ts
@@ -7,7 +7,12 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { isValidUTCDate, formatTime, getPlaywrightGrepTag } from './runner_utils';
+import {
+  isValidUTCDate,
+  formatTime,
+  getPlaywrightGrepTag,
+  withKibanaBabelRegister,
+} from './runner_utils';
 import moment from 'moment';
 import { ScoutTestTarget } from '@kbn/scout-info';
 jest.mock('moment', () => {
@@ -68,5 +73,67 @@ describe('getPlaywrightGrepTag', () => {
     const testTarget = new ScoutTestTarget('cloud', 'stateful', 'classic');
     const result = getPlaywrightGrepTag(testTarget);
     expect(result).toBe('@cloud-stateful-classic');
+  });
+});
+
+describe('withKibanaBabelRegister', () => {
+  const originalNodeOptions = process.env.NODE_OPTIONS;
+
+  afterEach(() => {
+    if (originalNodeOptions === undefined) {
+      delete process.env.NODE_OPTIONS;
+    } else {
+      process.env.NODE_OPTIONS = originalNodeOptions;
+    }
+  });
+
+  it('sets NODE_OPTIONS to only the kbn babel-register --require when none is present', () => {
+    delete process.env.NODE_OPTIONS;
+
+    const result = withKibanaBabelRegister({ FOO: 'bar' });
+
+    expect(result.FOO).toBe('bar');
+    expect(result.NODE_OPTIONS).toBe('--require=@kbn/babel-register/install');
+  });
+
+  it('appends the kbn babel-register --require to caller-provided NODE_OPTIONS', () => {
+    delete process.env.NODE_OPTIONS;
+
+    const result = withKibanaBabelRegister({
+      NODE_OPTIONS: '--max-old-space-size=4096',
+    });
+
+    expect(result.NODE_OPTIONS).toBe(
+      '--max-old-space-size=4096 --require=@kbn/babel-register/install'
+    );
+  });
+
+  it('appends to process.env.NODE_OPTIONS when the input env does not set NODE_OPTIONS', () => {
+    process.env.NODE_OPTIONS = '--max-old-space-size=4096';
+
+    const result = withKibanaBabelRegister({});
+
+    expect(result.NODE_OPTIONS).toBe(
+      '--max-old-space-size=4096 --require=@kbn/babel-register/install'
+    );
+  });
+
+  it('is idempotent when the --require is already present', () => {
+    delete process.env.NODE_OPTIONS;
+
+    const existing = '--max-old-space-size=4096 --require=@kbn/babel-register/install';
+    const result = withKibanaBabelRegister({ NODE_OPTIONS: existing });
+
+    expect(result.NODE_OPTIONS).toBe(existing);
+  });
+
+  it('prefers the env-provided NODE_OPTIONS over process.env', () => {
+    process.env.NODE_OPTIONS = '--inspect';
+
+    const result = withKibanaBabelRegister({ NODE_OPTIONS: '--max-old-space-size=4096' });
+
+    expect(result.NODE_OPTIONS).toBe(
+      '--max-old-space-size=4096 --require=@kbn/babel-register/install'
+    );
   });
 });

--- a/src/platform/packages/shared/kbn-scout/src/playwright/utils/runner_utils.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/utils/runner_utils.ts
@@ -14,6 +14,25 @@ import { testTargets, type ScoutTestTarget } from '@kbn/scout-info';
 
 export const execPromise = promisify(exec);
 
+const BABEL_REGISTER_REQUIRE = '--require=@kbn/babel-register/install';
+
+/**
+ * Returns a new env object with `--require=@kbn/babel-register/install` appended
+ * to `NODE_OPTIONS`, so that Playwright (spawned as a binary) and any worker
+ * processes it forks internally use Kibana's Babel transpilation for CommonJS
+ * imports. Idempotent when the flag is already present.
+ */
+export function withKibanaBabelRegister(
+  env: Record<string, string | undefined> = {}
+): Record<string, string | undefined> {
+  const existing = env.NODE_OPTIONS ?? process.env.NODE_OPTIONS ?? '';
+  const alreadyPresent = existing.includes(BABEL_REGISTER_REQUIRE);
+  const NODE_OPTIONS = alreadyPresent
+    ? existing
+    : [existing, BABEL_REGISTER_REQUIRE].filter(Boolean).join(' ');
+  return { ...env, NODE_OPTIONS };
+}
+
 export const isValidUTCDate = (date: string): boolean => {
   return !isNaN(Date.parse(date)) && new Date(date).toISOString() === date;
 };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Scout] Use Kibana's `babel-register` when running Playwright (#264927)](https://github.com/elastic/kibana/pull/264927)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Cesare de Cal","email":"cesare.decal@elastic.co"},"sourceCommit":{"committedDate":"2026-04-23T08:10:30Z","message":"[Scout] Use Kibana's `babel-register` when running Playwright (#264927)\n\nWe wrap Playwright calls in Scout with `@kbn/babel-register/install` so\nspecs and their imports transpile through Kibana's Babel config. This\nmatches what we already\n[do](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-dev-utils/src/worker/index.ts#L37)\nfor forked TS workers.","sha":"1753e986e4c4ab335459e4de1d11464011fe103f","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","backport:all-open","v9.5.0","v9.3.4","v9.2.9"],"title":"[Scout] Use Kibana's `babel-register` when running Playwright","number":264927,"url":"https://github.com/elastic/kibana/pull/264927","mergeCommit":{"message":"[Scout] Use Kibana's `babel-register` when running Playwright (#264927)\n\nWe wrap Playwright calls in Scout with `@kbn/babel-register/install` so\nspecs and their imports transpile through Kibana's Babel config. This\nmatches what we already\n[do](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-dev-utils/src/worker/index.ts#L37)\nfor forked TS workers.","sha":"1753e986e4c4ab335459e4de1d11464011fe103f"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/264927","number":264927,"mergeCommit":{"message":"[Scout] Use Kibana's `babel-register` when running Playwright (#264927)\n\nWe wrap Playwright calls in Scout with `@kbn/babel-register/install` so\nspecs and their imports transpile through Kibana's Babel config. This\nmatches what we already\n[do](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-dev-utils/src/worker/index.ts#L37)\nfor forked TS workers.","sha":"1753e986e4c4ab335459e4de1d11464011fe103f"}},{"branch":"9.3","label":"v9.3.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/265204","number":265204,"state":"MERGED","mergeCommit":{"sha":"3f1aeca90c10b85ce4ba29805ff7c4c80a88328f","message":"[9.3] [Scout] Use Kibana's `babel-register` when running Playwright (#264927) (#265204)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.3`:\n- [[Scout] Use Kibana's `babel-register` when running Playwright\n(#264927)](https://github.com/elastic/kibana/pull/264927)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Cesare de Cal <cesare.decal@elastic.co>"}},{"branch":"9.2","label":"v9.2.9","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/265203","number":265203,"state":"MERGED","mergeCommit":{"sha":"ea900bf1d0c3e8e6e1c2366f38283fc170e8b730","message":"[9.2] [Scout] Use Kibana's `babel-register` when running Playwright (#264927) (#265203)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.2`:\n- [[Scout] Use Kibana's `babel-register` when running Playwright\n(#264927)](https://github.com/elastic/kibana/pull/264927)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Cesare de Cal <cesare.decal@elastic.co>"}},{"url":"https://github.com/elastic/kibana/pull/265205","number":265205,"branch":"9.4","state":"OPEN"}]}] BACKPORT-->