### PR TITLE
[Entity Analytics][Leads generation] Improve error states for ES index-level permission denials

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/common/entity_analytics/lead_generation/constants.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/entity_analytics/lead_generation/constants.ts
@@ -17,4 +17,4 @@ export const DISABLE_LEAD_GENERATION_URL = `${LEAD_GENERATION_URL}/disable` as c
 export type LeadGenerationMode = 'adhoc' | 'scheduled';
 
 export const getLeadsIndexName = (spaceId: string, mode: LeadGenerationMode = 'adhoc'): string =>
-  `.entity-analytics.entity-leads-${mode}.entity-${spaceId}`;
+  `.entity_analytics.entity-leads-${mode}.entity-${spaceId}`;

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/lead_generation/lead_data_client.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/lead_generation/lead_data_client.test.ts
@@ -163,6 +163,25 @@ describe('LeadDataClient', () => {
 
       expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('Failed to persist leads'));
     });
+
+    it('re-throws when ES returns security_exception so callers can surface the 403', async () => {
+      const securityException = {
+        statusCode: 403,
+        body: { error: { type: 'security_exception', reason: 'access denied' } },
+        meta: { body: { error: { type: 'security_exception', reason: 'access denied' } } },
+      };
+      esClient.bulk.mockRejectedValueOnce(securityException);
+
+      await expect(
+        client.createLeads({
+          leads: [makeTestLead()],
+          executionId: 'exec-5',
+          sourceType: 'adhoc',
+        })
+      ).rejects.toBe(securityException);
+
+      expect(logger.warn).not.toHaveBeenCalled();
+    });
   });
 
   describe('findLeads', () => {
@@ -246,6 +265,29 @@ describe('LeadDataClient', () => {
 
       const result = await client.findLeads({});
       expect(result).toEqual({ leads: [], total: 0, page: 1, perPage: 20 });
+    });
+
+    it('returns empty results when error type is index_not_found_exception', async () => {
+      const indexNotFound = {
+        statusCode: 404,
+        body: { error: { type: 'index_not_found_exception', reason: 'no such index' } },
+        meta: { body: { error: { type: 'index_not_found_exception', reason: 'no such index' } } },
+      };
+      esClient.search.mockRejectedValueOnce(indexNotFound);
+
+      const result = await client.findLeads({});
+      expect(result).toEqual({ leads: [], total: 0, page: 1, perPage: 20 });
+    });
+
+    it('re-throws when ES returns security_exception so the route can return 403', async () => {
+      const securityException = {
+        statusCode: 403,
+        body: { error: { type: 'security_exception', reason: 'access denied' } },
+        meta: { body: { error: { type: 'security_exception', reason: 'access denied' } } },
+      };
+      esClient.search.mockRejectedValueOnce(securityException);
+
+      await expect(client.findLeads({})).rejects.toBe(securityException);
     });
   });
 
@@ -355,6 +397,29 @@ describe('LeadDataClient', () => {
         totalLeads: 0,
         lastRun: null,
       });
+    });
+
+    it('returns defaults for any generic ES error', async () => {
+      esClient.search.mockRejectedValueOnce(new Error('cluster timeout'));
+
+      const status = await client.getStatus();
+      expect(status).toEqual({
+        isEnabled: false,
+        indexExists: false,
+        totalLeads: 0,
+        lastRun: null,
+      });
+    });
+
+    it('re-throws when ES returns security_exception so the route can return 403', async () => {
+      const securityException = {
+        statusCode: 403,
+        body: { error: { type: 'security_exception', reason: 'access denied' } },
+        meta: { body: { error: { type: 'security_exception', reason: 'access denied' } } },
+      };
+      esClient.search.mockRejectedValueOnce(securityException);
+
+      await expect(client.getStatus()).rejects.toBe(securityException);
     });
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/lead_generation/lead_data_client.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/lead_generation/lead_data_client.test.ts
@@ -11,6 +11,12 @@ import type { LeadDataClient } from './lead_data_client';
 import { getLeadsIndexName } from '../../../../common/entity_analytics/lead_generation/constants';
 import type { Lead } from '../../../../common/entity_analytics/lead_generation/types';
 
+const makeEsSecurityException = () => ({
+  statusCode: 403,
+  body: { error: { type: 'security_exception', reason: 'access denied' } },
+  meta: { body: { error: { type: 'security_exception', reason: 'access denied' } } },
+});
+
 const makeTestLead = (overrides: Partial<Lead> = {}): Lead => ({
   id: 'lead-1',
   title: 'Test Lead',
@@ -165,11 +171,7 @@ describe('LeadDataClient', () => {
     });
 
     it('re-throws when ES returns security_exception so callers can surface the 403', async () => {
-      const securityException = {
-        statusCode: 403,
-        body: { error: { type: 'security_exception', reason: 'access denied' } },
-        meta: { body: { error: { type: 'security_exception', reason: 'access denied' } } },
-      };
+      const securityException = makeEsSecurityException();
       esClient.bulk.mockRejectedValueOnce(securityException);
 
       await expect(
@@ -280,11 +282,7 @@ describe('LeadDataClient', () => {
     });
 
     it('re-throws when ES returns security_exception so the route can return 403', async () => {
-      const securityException = {
-        statusCode: 403,
-        body: { error: { type: 'security_exception', reason: 'access denied' } },
-        meta: { body: { error: { type: 'security_exception', reason: 'access denied' } } },
-      };
+      const securityException = makeEsSecurityException();
       esClient.search.mockRejectedValueOnce(securityException);
 
       await expect(client.findLeads({})).rejects.toBe(securityException);
@@ -412,11 +410,7 @@ describe('LeadDataClient', () => {
     });
 
     it('re-throws when ES returns security_exception so the route can return 403', async () => {
-      const securityException = {
-        statusCode: 403,
-        body: { error: { type: 'security_exception', reason: 'access denied' } },
-        meta: { body: { error: { type: 'security_exception', reason: 'access denied' } } },
-      };
+      const securityException = makeEsSecurityException();
       esClient.search.mockRejectedValueOnce(securityException);
 
       await expect(client.getStatus()).rejects.toBe(securityException);
@@ -441,6 +435,15 @@ describe('LeadDataClient', () => {
           query: { match_all: {} },
         })
       );
+    });
+
+    it('re-throws when ES returns security_exception so the disable route can return 403', async () => {
+      const securityException = makeEsSecurityException();
+      esClient.deleteByQuery.mockRejectedValueOnce(securityException);
+
+      await expect(client.deleteAllLeads()).rejects.toBe(securityException);
+
+      expect(logger.warn).not.toHaveBeenCalled();
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/lead_generation/lead_data_client.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/lead_generation/lead_data_client.ts
@@ -65,6 +65,18 @@ export interface LeadDataClient {
 }
 
 // ---------------------------------------------------------------------------
+// ES error classification helpers
+// ---------------------------------------------------------------------------
+
+const getEsErrorType = (e: unknown): string | undefined =>
+  (e as { meta?: { body?: { error?: { type?: string } } } })?.meta?.body?.error?.type;
+
+const isEsSecurityException = (e: unknown): boolean => getEsErrorType(e) === 'security_exception';
+
+const isEsIndexNotFoundException = (e: unknown): boolean =>
+  getEsErrorType(e) === 'index_not_found_exception';
+
+// ---------------------------------------------------------------------------
 // Staleness computation (timestamp-based, computed at read time)
 // ---------------------------------------------------------------------------
 
@@ -231,6 +243,9 @@ export const createLeadDataClient = ({
         ignore_unavailable: true,
       });
     } catch (e) {
+      if (isEsSecurityException(e)) {
+        throw e;
+      }
       logger.warn(`[LeadGeneration] Failed to persist leads to "${indexName}": ${e}`);
     }
   };
@@ -277,11 +292,11 @@ export const createLeadDataClient = ({
 
       return { leads, total, page, perPage };
     } catch (e) {
-      const isIndexNotFound =
-        (e as { meta?: { body?: { error?: { type?: string } } } })?.meta?.body?.error?.type ===
-        'index_not_found_exception';
+      if (isEsSecurityException(e)) {
+        throw e;
+      }
       const errorMessage = e instanceof Error ? e.message : String(e);
-      if (isIndexNotFound) {
+      if (isEsIndexNotFoundException(e)) {
         logger.debug(`[LeadGeneration] Leads indices not available yet: ${errorMessage}`);
       } else {
         logger.error(`[LeadGeneration] Unable to find leads due to error: ${errorMessage}`);
@@ -387,6 +402,9 @@ export const createLeadDataClient = ({
         lastRun = (latestHit._source as Record<string, unknown>).timestamp as string;
       }
     } catch (e) {
+      if (isEsSecurityException(e)) {
+        throw e;
+      }
       logger.debug(`[LeadGeneration] Status check — indices not available: ${e}`);
     }
 

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/lead_generation/lead_data_client.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/lead_generation/lead_data_client.ts
@@ -426,6 +426,9 @@ export const createLeadDataClient = ({
       });
       logger.info(`[LeadGeneration] Deleted all leads from space "${spaceId}"`);
     } catch (e) {
+      if (isEsSecurityException(e)) {
+        throw e;
+      }
       logger.warn(`[LeadGeneration] Failed to delete all leads: ${e}`);
     }
   };

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/lead_generation/routes/bulk_update_leads.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/lead_generation/routes/bulk_update_leads.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { loggingSystemMock } from '@kbn/core/server/mocks';
+import { APP_ID } from '../../../../../common';
 import { bulkUpdateLeadsRoute } from './bulk_update_leads';
 import { BULK_UPDATE_LEADS_URL } from '../../../../../common/entity_analytics/lead_generation/constants';
 import {
@@ -30,6 +31,14 @@ describe('bulkUpdateLeadsRoute', () => {
     const { clients } = requestContextMock.createTools();
     context = requestContextMock.convertContext(requestContextMock.create({ ...clients }));
     bulkUpdateLeadsRoute(server.router, logger);
+  });
+
+  describe('route security config', () => {
+    it('declares the required Kibana privileges so users without Security Solution access are rejected', () => {
+      const [routeConfig] = server.router.versioned.post.mock.calls[0];
+      const authz = routeConfig.security?.authz as { requiredPrivileges?: unknown } | undefined;
+      expect(authz?.requiredPrivileges).toEqual(['securitySolution', `${APP_ID}-entity-analytics`]);
+    });
   });
 
   it('returns 200 with updated count', async () => {
@@ -70,5 +79,22 @@ describe('bulkUpdateLeadsRoute', () => {
 
     const response = await server.inject(request, context);
     expect(response.status).toEqual(500);
+  });
+
+  it('returns 403 when ES denies write access to the leads index', async () => {
+    mockBulkUpdateLeads.mockRejectedValueOnce({
+      statusCode: 403,
+      body: { error: { type: 'security_exception', reason: 'access denied' } },
+      meta: { body: { error: { type: 'security_exception', reason: 'access denied' } } },
+    });
+
+    const request = requestMock.create({
+      method: 'post',
+      path: BULK_UPDATE_LEADS_URL,
+      body: { ids: ['a'], status: 'dismissed' },
+    });
+
+    const response = await server.inject(request, context);
+    expect(response.status).toEqual(403);
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/lead_generation/routes/bulk_update_leads.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/lead_generation/routes/bulk_update_leads.test.ts
@@ -20,6 +20,12 @@ jest.mock('../lead_data_client', () => ({
   createLeadDataClient: () => ({ bulkUpdateLeads: mockBulkUpdateLeads }),
 }));
 
+const makeEsSecurityException = () => ({
+  statusCode: 403,
+  body: { error: { type: 'security_exception', reason: 'access denied' } },
+  meta: { body: { error: { type: 'security_exception', reason: 'access denied' } } },
+});
+
 describe('bulkUpdateLeadsRoute', () => {
   let server: ReturnType<typeof serverMock.create>;
   let context: ReturnType<typeof requestContextMock.convertContext>;
@@ -82,11 +88,7 @@ describe('bulkUpdateLeadsRoute', () => {
   });
 
   it('returns 403 when ES denies write access to the leads index', async () => {
-    mockBulkUpdateLeads.mockRejectedValueOnce({
-      statusCode: 403,
-      body: { error: { type: 'security_exception', reason: 'access denied' } },
-      meta: { body: { error: { type: 'security_exception', reason: 'access denied' } } },
-    });
+    mockBulkUpdateLeads.mockRejectedValueOnce(makeEsSecurityException());
 
     const request = requestMock.create({
       method: 'post',

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/lead_generation/routes/disable_lead_generation.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/lead_generation/routes/disable_lead_generation.test.ts
@@ -7,6 +7,7 @@
 
 import { loggingSystemMock } from '@kbn/core/server/mocks';
 import { taskManagerMock } from '@kbn/task-manager-plugin/server/mocks';
+import { APP_ID } from '../../../../../common';
 import { disableLeadGenerationRoute } from './disable_lead_generation';
 import { DISABLE_LEAD_GENERATION_URL } from '../../../../../common/entity_analytics/lead_generation/constants';
 import {
@@ -35,6 +36,14 @@ describe('disableLeadGenerationRoute', () => {
     mockTaskManagerStart = taskManagerMock.createStart();
     getStartServicesMock = jest.fn().mockResolvedValue([{}, { taskManager: mockTaskManagerStart }]);
     disableLeadGenerationRoute(server.router, logger, getStartServicesMock);
+  });
+
+  describe('route security config', () => {
+    it('declares the required Kibana privileges so users without Security Solution access are rejected', () => {
+      const [routeConfig] = server.router.versioned.post.mock.calls[0];
+      const authz = routeConfig.security?.authz as { requiredPrivileges?: unknown } | undefined;
+      expect(authz?.requiredPrivileges).toEqual(['securitySolution', `${APP_ID}-entity-analytics`]);
+    });
   });
 
   it('returns 200 and removes the task', async () => {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/lead_generation/routes/dismiss_lead.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/lead_generation/routes/dismiss_lead.test.ts
@@ -20,6 +20,12 @@ jest.mock('../lead_data_client', () => ({
   createLeadDataClient: () => ({ dismissLead: mockDismissLead }),
 }));
 
+const makeEsSecurityException = () => ({
+  statusCode: 403,
+  body: { error: { type: 'security_exception', reason: 'access denied' } },
+  meta: { body: { error: { type: 'security_exception', reason: 'access denied' } } },
+});
+
 describe('dismissLeadRoute', () => {
   let server: ReturnType<typeof serverMock.create>;
   let context: ReturnType<typeof requestContextMock.convertContext>;
@@ -82,11 +88,7 @@ describe('dismissLeadRoute', () => {
   });
 
   it('returns 403 when ES denies write access to the leads index', async () => {
-    mockDismissLead.mockRejectedValueOnce({
-      statusCode: 403,
-      body: { error: { type: 'security_exception', reason: 'access denied' } },
-      meta: { body: { error: { type: 'security_exception', reason: 'access denied' } } },
-    });
+    mockDismissLead.mockRejectedValueOnce(makeEsSecurityException());
 
     const request = requestMock.create({
       method: 'post',

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/lead_generation/routes/dismiss_lead.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/lead_generation/routes/dismiss_lead.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { loggingSystemMock } from '@kbn/core/server/mocks';
+import { APP_ID } from '../../../../../common';
 import { dismissLeadRoute } from './dismiss_lead';
 import { DISMISS_LEAD_URL } from '../../../../../common/entity_analytics/lead_generation/constants';
 import {
@@ -30,6 +31,14 @@ describe('dismissLeadRoute', () => {
     const { clients } = requestContextMock.createTools();
     context = requestContextMock.convertContext(requestContextMock.create({ ...clients }));
     dismissLeadRoute(server.router, logger);
+  });
+
+  describe('route security config', () => {
+    it('declares the required Kibana privileges so users without Security Solution access are rejected', () => {
+      const [routeConfig] = server.router.versioned.post.mock.calls[0];
+      const authz = routeConfig.security?.authz as { requiredPrivileges?: unknown } | undefined;
+      expect(authz?.requiredPrivileges).toEqual(['securitySolution', `${APP_ID}-entity-analytics`]);
+    });
   });
 
   it('returns 200 with success when lead is dismissed', async () => {
@@ -70,5 +79,22 @@ describe('dismissLeadRoute', () => {
 
     const response = await server.inject(request, context);
     expect(response.status).toEqual(500);
+  });
+
+  it('returns 403 when ES denies write access to the leads index', async () => {
+    mockDismissLead.mockRejectedValueOnce({
+      statusCode: 403,
+      body: { error: { type: 'security_exception', reason: 'access denied' } },
+      meta: { body: { error: { type: 'security_exception', reason: 'access denied' } } },
+    });
+
+    const request = requestMock.create({
+      method: 'post',
+      path: DISMISS_LEAD_URL,
+      params: { id: 'lead-1' },
+    });
+
+    const response = await server.inject(request, context);
+    expect(response.status).toEqual(403);
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/lead_generation/routes/enable_lead_generation.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/lead_generation/routes/enable_lead_generation.test.ts
@@ -7,6 +7,7 @@
 
 import { loggingSystemMock } from '@kbn/core/server/mocks';
 import { taskManagerMock } from '@kbn/task-manager-plugin/server/mocks';
+import { APP_ID } from '../../../../../common';
 import { enableLeadGenerationRoute } from './enable_lead_generation';
 import { ENABLE_LEAD_GENERATION_URL } from '../../../../../common/entity_analytics/lead_generation/constants';
 import {
@@ -40,6 +41,14 @@ describe('enableLeadGenerationRoute', () => {
     mockTaskManagerStart = taskManagerMock.createStart();
     getStartServicesMock = jest.fn().mockResolvedValue([{}, { taskManager: mockTaskManagerStart }]);
     enableLeadGenerationRoute(server.router, logger, getStartServicesMock);
+  });
+
+  describe('route security config', () => {
+    it('declares the required Kibana privileges so users without Security Solution access are rejected', () => {
+      const [routeConfig] = server.router.versioned.post.mock.calls[0];
+      const authz = routeConfig.security?.authz as { requiredPrivileges?: unknown } | undefined;
+      expect(authz?.requiredPrivileges).toEqual(['securitySolution', `${APP_ID}-entity-analytics`]);
+    });
   });
 
   it('returns 200, creates indices, and starts the task', async () => {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/lead_generation/routes/generate_leads.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/lead_generation/routes/generate_leads.ts
@@ -73,6 +73,10 @@ export const generateLeadsRoute = (
             `[LeadGeneration] Connector resolved successfully (connectorId=${connectorId}, executionUuid=${executionUuid})`
           );
 
+          // The pipeline runs in the background after the 202 is returned.
+          // ES index-level permission errors (security_exception) thrown by
+          // createLeads are caught here, not propagated to the HTTP response.
+          // They surface via the status endpoint's `lastError` field instead.
           void (async () => {
             try {
               await runLeadGenerationPipeline({

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/lead_generation/routes/get_lead_generation_status.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/lead_generation/routes/get_lead_generation_status.test.ts
@@ -7,6 +7,7 @@
 
 import { loggingSystemMock } from '@kbn/core/server/mocks';
 import { taskManagerMock } from '@kbn/task-manager-plugin/server/mocks';
+import { APP_ID } from '../../../../../common';
 import { getLeadGenerationStatusRoute } from './get_lead_generation_status';
 import { LEAD_GENERATION_STATUS_URL } from '../../../../../common/entity_analytics/lead_generation/constants';
 import {
@@ -40,6 +41,14 @@ describe('getLeadGenerationStatusRoute', () => {
     mockTaskManagerStart = taskManagerMock.createStart();
     getStartServicesMock = jest.fn().mockResolvedValue([{}, { taskManager: mockTaskManagerStart }]);
     getLeadGenerationStatusRoute(server.router, logger, getStartServicesMock);
+  });
+
+  describe('route security config', () => {
+    it('declares the required Kibana privileges so users without Security Solution access are rejected', () => {
+      const [routeConfig] = server.router.versioned.get.mock.calls[0];
+      const authz = routeConfig.security?.authz as { requiredPrivileges?: unknown } | undefined;
+      expect(authz?.requiredPrivileges).toEqual(['securitySolution', `${APP_ID}-entity-analytics`]);
+    });
   });
 
   it('returns 200 with engine status when task exists (isEnabled: true)', async () => {
@@ -81,7 +90,7 @@ describe('getLeadGenerationStatusRoute', () => {
     expect(mockGetStatus).toHaveBeenCalledWith({ isEnabled: false });
   });
 
-  it('returns 500 on error', async () => {
+  it('returns 500 on generic error', async () => {
     mockGetStatus.mockRejectedValueOnce(new Error('status check failed'));
 
     const request = requestMock.create({
@@ -91,5 +100,21 @@ describe('getLeadGenerationStatusRoute', () => {
 
     const response = await server.inject(request, context);
     expect(response.status).toEqual(500);
+  });
+
+  it('returns 403 when ES denies read access to the leads index', async () => {
+    mockGetStatus.mockRejectedValueOnce({
+      statusCode: 403,
+      body: { error: { type: 'security_exception', reason: 'access denied' } },
+      meta: { body: { error: { type: 'security_exception', reason: 'access denied' } } },
+    });
+
+    const request = requestMock.create({
+      method: 'get',
+      path: LEAD_GENERATION_STATUS_URL,
+    });
+
+    const response = await server.inject(request, context);
+    expect(response.status).toEqual(403);
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/lead_generation/routes/get_lead_generation_status.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/lead_generation/routes/get_lead_generation_status.test.ts
@@ -21,6 +21,12 @@ jest.mock('../lead_data_client', () => ({
   createLeadDataClient: () => ({ getStatus: mockGetStatus }),
 }));
 
+const makeEsSecurityException = () => ({
+  statusCode: 403,
+  body: { error: { type: 'security_exception', reason: 'access denied' } },
+  meta: { body: { error: { type: 'security_exception', reason: 'access denied' } } },
+});
+
 jest.mock('../tasks', () => ({
   getLeadGenerationTaskId: (spaceId: string) =>
     `entity_analytics:lead_generation:engine:${spaceId}:1.0.0`,
@@ -103,11 +109,7 @@ describe('getLeadGenerationStatusRoute', () => {
   });
 
   it('returns 403 when ES denies read access to the leads index', async () => {
-    mockGetStatus.mockRejectedValueOnce({
-      statusCode: 403,
-      body: { error: { type: 'security_exception', reason: 'access denied' } },
-      meta: { body: { error: { type: 'security_exception', reason: 'access denied' } } },
-    });
+    mockGetStatus.mockRejectedValueOnce(makeEsSecurityException());
 
     const request = requestMock.create({
       method: 'get',

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/lead_generation/routes/get_leads.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/lead_generation/routes/get_leads.test.ts
@@ -20,6 +20,12 @@ jest.mock('../lead_data_client', () => ({
   createLeadDataClient: () => ({ findLeads: mockFindLeads }),
 }));
 
+const makeEsSecurityException = () => ({
+  statusCode: 403,
+  body: { error: { type: 'security_exception', reason: 'access denied' } },
+  meta: { body: { error: { type: 'security_exception', reason: 'access denied' } } },
+});
+
 describe('getLeadsRoute', () => {
   let server: ReturnType<typeof serverMock.create>;
   let context: ReturnType<typeof requestContextMock.convertContext>;
@@ -132,11 +138,7 @@ describe('getLeadsRoute', () => {
   });
 
   it('returns 403 when ES denies read access to the leads index', async () => {
-    mockFindLeads.mockRejectedValueOnce({
-      statusCode: 403,
-      body: { error: { type: 'security_exception', reason: 'access denied' } },
-      meta: { body: { error: { type: 'security_exception', reason: 'access denied' } } },
-    });
+    mockFindLeads.mockRejectedValueOnce(makeEsSecurityException());
 
     const request = requestMock.create({
       method: 'get',

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/lead_generation/routes/get_leads.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/lead_generation/routes/get_leads.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { loggingSystemMock } from '@kbn/core/server/mocks';
+import { APP_ID } from '../../../../../common';
 import { getLeadsRoute } from './get_leads';
 import { GET_LEADS_URL } from '../../../../../common/entity_analytics/lead_generation/constants';
 import {
@@ -30,6 +31,14 @@ describe('getLeadsRoute', () => {
     const { clients } = requestContextMock.createTools();
     context = requestContextMock.convertContext(requestContextMock.create({ ...clients }));
     getLeadsRoute(server.router, logger);
+  });
+
+  describe('route security config', () => {
+    it('declares the required Kibana privileges so users without Security Solution access are rejected', () => {
+      const [routeConfig] = server.router.versioned.get.mock.calls[0];
+      const authz = routeConfig.security?.authz as { requiredPrivileges?: unknown } | undefined;
+      expect(authz?.requiredPrivileges).toEqual(['securitySolution', `${APP_ID}-entity-analytics`]);
+    });
   });
 
   it('returns 200 with paginated leads', async () => {
@@ -109,7 +118,7 @@ describe('getLeadsRoute', () => {
     );
   });
 
-  it('returns 500 when data client throws', async () => {
+  it('returns 500 when data client throws a generic error', async () => {
     mockFindLeads.mockRejectedValueOnce(new Error('ES failure'));
 
     const request = requestMock.create({
@@ -120,5 +129,22 @@ describe('getLeadsRoute', () => {
 
     const response = await server.inject(request, context);
     expect(response.status).toEqual(500);
+  });
+
+  it('returns 403 when ES denies read access to the leads index', async () => {
+    mockFindLeads.mockRejectedValueOnce({
+      statusCode: 403,
+      body: { error: { type: 'security_exception', reason: 'access denied' } },
+      meta: { body: { error: { type: 'security_exception', reason: 'access denied' } } },
+    });
+
+    const request = requestMock.create({
+      method: 'get',
+      path: GET_LEADS_URL,
+      query: {},
+    });
+
+    const response = await server.inject(request, context);
+    expect(response.status).toEqual(403);
   });
 });


### PR DESCRIPTION
## Summary

This PR improves the error handling in the Lead Generation feature when Elasticsearch index-level permissions are missing. Previously, `security_exception` errors from ES were silently swallowed, resulting in either empty data responses (misleading 200s) or unhelpful 500 errors. After this change, those errors propagate as proper HTTP 403 responses with an actionable message.

---

## Background

The Lead Generation feature stores leads in `.entity-analytics.entity-leads-*` indices. Two separate permission layers protect these APIs:

1. **Kibana feature privileges** (`securitySolution` + `${APP_ID}-entity-analytics`) — enforced by the Kibana framework before the handler runs. Missing this results in a Kibana-level 403.
2. **Elasticsearch index-level privileges** — enforced by ES when `esClient.asCurrentUser` executes a query. Missing `read`/`write` access on the leads indices causes ES to return a `security_exception` with status 403.

Layer 1 was already correctly configured on all routes. Layer 2 was silently absorbed.

---

## What was broken

In `lead_data_client.ts`, the `findLeads`, `getStatus`, and `createLeads` methods all had catch blocks that swallowed every error:

```typescript
// findLeads (before)
} catch (e) {
  // checked only for index_not_found_exception; security_exception was also silently absorbed
  logger.error(`Unable to find leads due to error: ${e}`);
  return { leads: [], total: 0, page, perPage }; //  misleading 200 OK
}
```

A user without `.entity-analytics.entity-leads-*` read access would get back an empty list with a 200 OK instead of a 403 "access denied" response. For `createLeads`, the write would silently fail with only a log warning.

### API flow before fix

```
GET /internal/entity_analytics/leads

returns { leads: [], total: 0 }   200 OK with empty data
```

---


### API flow after fix

```
GET /internal/entity_analytics/leads
transformError -> HTTP 403
- > frontend useQuery onError → toast: "security_exception: indices:data/read/search (...)  
    is unauthorized for user [...]"
```

`index_not_found_exception` continues to be swallowed and returns an empty result, which is the intended behaviour before the indices are first created.

---

## Testing steps (before fix)

1. Create a Kibana role with `securitySolution` feature access but **no** access to `.entity-analytics.entity-leads-*` ES indices.
2. Log in as a user with that role.
3. `GET /internal/entity_analytics/leads` — returns `200 { leads: [], total: 0 }` instead of `403`.
4. `GET /internal/entity_analytics/leads/status` — returns `200 { isEnabled: false, indexExists: false, ... }` instead of `403`.

## Testing steps (after fix)

Same setup:
3. `GET /internal/entity_analytics/leads` -> `403 security_exception: indices:data/read/search is unauthorized`
4. `GET /internal/entity_analytics/leads/status` -> `403 security_exception: ...`
5. UI: toast notification displays the permission error rather than showing empty leads.


<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->