### PR TITLE
Upgrade EUI to v114.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "@elastic/elasticsearch": "9.3.4",
     "@elastic/ems-client": "8.7.0",
     "@elastic/esql": "3.0.0",
-    "@elastic/eui": "114.2.0",
+    "@elastic/eui": "114.3.0",
     "@elastic/eui-theme-borealis": "7.0.0",
     "@elastic/filesaver": "1.1.2",
     "@elastic/kibana-d3-color": "npm:@elastic/kibana-d3-color@2.0.1",

--- a/src/platform/packages/private/kbn-ui-shared-deps-npm/version_dependencies.txt
+++ b/src/platform/packages/private/kbn-ui-shared-deps-npm/version_dependencies.txt
@@ -18,7 +18,7 @@
 @elastic/esql@3.0.0
 @elastic/eui-theme-borealis@7.0.0
 @elastic/eui-theme-common@9.0.0
-@elastic/eui@114.2.0
+@elastic/eui@114.3.0
 @elastic/numeral@2.5.1
 @elastic/prismjs-esql@1.1.2
 @emotion/babel-plugin@11.13.5

--- a/yarn.lock
+++ b/yarn.lock
@@ -2408,10 +2408,10 @@
     chroma-js "^2.4.2"
     lodash "^4.17.21"
 
-"@elastic/eui@114.2.0":
-  version "114.2.0"
-  resolved "https://registry.yarnpkg.com/@elastic/eui/-/eui-114.2.0.tgz#04551190586b09ed5d0de86dae3cfe2468b1178a"
-  integrity sha512-jFHflSzBdD8bEV9JaeFlB7mkV8+sh21MwMD4EsV5KVuRGYKgNUjGj1uxitMlYICFIG0qwcCa/YWvY8pUnskBoA==
+"@elastic/eui@114.3.0":
+  version "114.3.0"
+  resolved "https://registry.yarnpkg.com/@elastic/eui/-/eui-114.3.0.tgz#15ed4744e7531036bc0243ee5c012671838338d3"
+  integrity sha512-dWrs5ULxUajc5wouiIIyb/NeaLDpFiyYrsbp4yscGmj8zj942y5KmFlaIWHQmEalmNjCSBf5h7wKx9px+MnMWg==
   dependencies:
     "@elastic/eui-theme-common" "9.0.0"
     "@elastic/prismjs-esql" "^1.1.2"


### PR DESCRIPTION
## Dependency updates

- `@elastic/eui` - v114.2.0 ⏩ v114.3.0

---

## Package updates

## [`v114.3.0`](https://github.com/elastic/eui/releases/v114.3.0)

- Updated `productDashboard` icon. ([#9607](https://github.com/elastic/eui/pull/9607))
- Updated `EuiStepsHorizontal` to prevent steps being clickable when `status="disabled"` ([#9574](https://github.com/elastic/eui/pull/9574))

**Bug fixes**

- Fixed broken SVG for `chartPie` icon. ([#9607](https://github.com/elastic/eui/pull/9607))
- Fixed a bug in `EuiDataGrid` that caused the scroll position to reset when using middle mouse button to scroll the container. ([#9613](https://github.com/elastic/eui/pull/9613))
- Fixed `EuiFlyout` to compare `pushMinBreakpoint` against the container's width, instead of the viewport width, when the `container` prop is provided. This ensures app-scoped flyouts switch between push and overlay modes based on the space actually available inside their container. ([#9592](https://github.com/elastic/eui/pull/9592))

**Accessibility**

- Fixed duplicate screen reader output for `EuiStepsHorizontal` ([#9574](https://github.com/elastic/eui/pull/9574))