### PR TITLE
[Fleet] replace env:HOSTNAME by HOSTNAME

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/components/add_collector_flyout.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/components/add_collector_flyout.tsx
@@ -170,7 +170,7 @@ export const AddCollectorFlyout: React.FunctionComponent<AddCollectorFlyoutProps
   const [collectorGroupOverridden, setCollectorGroupOverridden] = useState(false);
   const [serviceName, setServiceName] = useState('otel-collector-group');
   const [serviceNameOverridden, setServiceNameOverridden] = useState(false);
-  const [collectorDisplayName, setCollectorDisplayName] = useState('${env:HOSTNAME}');
+  const [collectorDisplayName, setCollectorDisplayName] = useState('${HOSTNAME}');
   const [configDescription, setConfigDescription] = useState('');
   const [tags, setTags] = useState('');
   const [environment, setEnvironment] = useState('');


### PR DESCRIPTION
## Summary

Follow up after https://github.com/elastic/kibana/pull/262196

`${env:HOSTNAME}` is not a native Linux shell syntax—it’s a tool-specific interpolation format.
In the OpenTelemetry Collector config, the syntax `${env:HOSTNAME}` is not the standard environment variable format the Collector expects. That `${env:...}` style comes from tools like Visual Studio Code, not from OTel itself.

The Collector uses its own env var expansion, which looks like: `${HOSTNAME}` 

<img width="1783" height="864" alt="image" src="https://github.com/user-attachments/assets/53ad49f2-91d3-4db8-8898-51148bd3491e" />





<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->