### PR TITLE
Increase timeout for OTel Kubernetes onboarding test

### DIFF
--- a/x-pack/solutions/observability/plugins/observability_onboarding/e2e/playwright/stateful/kubernetes_otel.spec.ts
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/e2e/playwright/stateful/kubernetes_otel.spec.ts
@@ -36,8 +36,8 @@ const INSTRUMENTED_APP_NAME = 'java-app';
  */
 test(
   'Otel Kubernetes',
-  { timeout: 10 * 60 * 1000 },
   async ({ page, onboardingHomePage, otelKubernetesFlowPage, wiredStreamsSelector }) => {
+    test.setTimeout(10 * 60 * 1000);
     assertEnv(process.env.ARTIFACTS_FOLDER, 'ARTIFACTS_FOLDER is not defined.');
 
     const isLogsEssentialsMode = process.env.LOGS_ESSENTIALS_MODE === 'true';

--- a/x-pack/solutions/observability/plugins/observability_onboarding/e2e/playwright/stateful/kubernetes_otel.spec.ts
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/e2e/playwright/stateful/kubernetes_otel.spec.ts
@@ -34,114 +34,116 @@ const INSTRUMENTED_APP_NAME = 'java-app';
 /**
  * Kubernetes onboarding with OTel can be slow — increase test timeout to 10 minutes.
  */
-test(
-  'Otel Kubernetes',
-  async ({ page, onboardingHomePage, otelKubernetesFlowPage, wiredStreamsSelector }) => {
-    test.setTimeout(10 * 60 * 1000);
-    assertEnv(process.env.ARTIFACTS_FOLDER, 'ARTIFACTS_FOLDER is not defined.');
+test('Otel Kubernetes', async ({
+  page,
+  onboardingHomePage,
+  otelKubernetesFlowPage,
+  wiredStreamsSelector,
+}) => {
+  test.setTimeout(10 * 60 * 1000);
+  assertEnv(process.env.ARTIFACTS_FOLDER, 'ARTIFACTS_FOLDER is not defined.');
 
-    const isLogsEssentialsMode = process.env.LOGS_ESSENTIALS_MODE === 'true';
-    const useWiredStreams = process.env.USE_WIRED_STREAMS === 'true';
-    const fileName = 'code_snippet_otel_kubernetes.sh';
-    const outputPath = path.join(__dirname, '..', process.env.ARTIFACTS_FOLDER, fileName);
+  const isLogsEssentialsMode = process.env.LOGS_ESSENTIALS_MODE === 'true';
+  const useWiredStreams = process.env.USE_WIRED_STREAMS === 'true';
+  const fileName = 'code_snippet_otel_kubernetes.sh';
+  const outputPath = path.join(__dirname, '..', process.env.ARTIFACTS_FOLDER, fileName);
 
-    await onboardingHomePage.selectKubernetesUseCase();
-    await onboardingHomePage.selectOtelKubernetesQuickstart();
+  await onboardingHomePage.selectKubernetesUseCase();
+  await onboardingHomePage.selectOtelKubernetesQuickstart();
 
-    await otelKubernetesFlowPage.copyHelmRepositorySnippetToClipboard();
-    const helmRepoSnippet = (await page.evaluate('navigator.clipboard.readText()')) as string;
+  await otelKubernetesFlowPage.copyHelmRepositorySnippetToClipboard();
+  const helmRepoSnippet = (await page.evaluate('navigator.clipboard.readText()')) as string;
 
-    if (useWiredStreams) {
-      await wiredStreamsSelector.selectWiredStreamsMode();
-    }
-
-    await otelKubernetesFlowPage.copyInstallStackSnippetToClipboard();
-    const installStackSnippet = (await page.evaluate('navigator.clipboard.readText()')) as string;
-
-    let codeSnippet: string;
-
-    if (!isLogsEssentialsMode && !useWiredStreams) {
-      /**
-       * Getting the snippets and replacing placeholder
-       * with the values used by Ensemble
-       */
-      await otelKubernetesFlowPage.switchInstrumentationInstructions('java');
-      const annotateAllResourceSnippet = (
-        await otelKubernetesFlowPage.getAnnotateAllResourceSnippet()
-      )?.replace('my-namespace', INSTRUMENTED_APP_CONTAINER_NAMESPACE);
-      const restartDeploymentSnippet = (await otelKubernetesFlowPage.getRestartDeploymentSnippet())
-        ?.split('\n')[0]
-        ?.replace('myapp', INSTRUMENTED_APP_NAME)
-        ?.replace('my-namespace', INSTRUMENTED_APP_CONTAINER_NAMESPACE);
-      /**
-       * Adding timeout so Ensemble waits for the
-       * pods to be created before instrumenting the app
-       */
-      const sleepSnippet = `sleep 120`;
-
-      codeSnippet = `${helmRepoSnippet}\n${installStackSnippet}\n${sleepSnippet}\n${annotateAllResourceSnippet}\n${restartDeploymentSnippet}`;
-    } else {
-      codeSnippet = `${helmRepoSnippet}\n${installStackSnippet}`;
-    }
-
-    /**
-     * Ensemble story watches for the code snippet file
-     * to be created and then executes it
-     */
-    fs.writeFileSync(outputPath, codeSnippet);
-
-    /**
-     * The page waits for the browser window to lose
-     * focus as a signal to start checking for incoming data
-     */
-    await page.evaluate('window.dispatchEvent(new Event("blur"))');
-
-    /**
-     * Wait for the data received indicator to appear.
-     * The flow now uses DataIngestStatus which polls for data
-     * after the blur event and shows "We are monitoring your cluster"
-     * once both logs and metrics have arrived.
-     */
-    await otelKubernetesFlowPage.assertDataReceivedIndicator();
-
-    /**
-     * Additional buffer to ensure data has propagated
-     * to dashboards and Discover before navigating.
-     */
-    await page.waitForTimeout(2 * 60000);
-
-    /**
-     * Wired streams only reroutes logs (to logs.otel); metrics and traces are
-     * unaffected. So for wired streams we validate log delivery via Discover and
-     * the Streams page, and intentionally skip the Cluster Overview dashboard
-     * and APM Service Inventory checks. Dashboard/APM validation is already
-     * covered by the non-wired test variants.
-     *
-     * Both "wired streams" and "wired streams + logs essentials" fall into this
-     * single branch because the validation path is identical for both.
-     */
-    if (useWiredStreams) {
-      await otelKubernetesFlowPage.clickExploreLogsCTA();
-      await assertDiscoverHasData(page, { assertHitCount: true });
-      await assertStreamHasData(page, 'logs.otel');
-    } else if (!isLogsEssentialsMode) {
-      const otelKubernetesOverviewDashboardPage = new OtelKubernetesOverviewDashboardPage(
-        await otelKubernetesFlowPage.openClusterOverviewDashboardInNewTab()
-      );
-
-      await otelKubernetesOverviewDashboardPage.assertNodesPanelNotEmpty();
-
-      const apmServiceInventoryPage = new ApmServiceInventoryPage(
-        await otelKubernetesFlowPage.openServiceInventoryInNewTab()
-      );
-
-      const serviceTestId = 'serviceLink_opentelemetry/java/elastic';
-
-      await apmServiceInventoryPage.page.getByTestId(serviceTestId).click();
-      await apmServiceInventoryPage.assertTransactionExists();
-    } else {
-      await otelKubernetesFlowPage.clickExploreLogsCTA();
-      await assertDiscoverHasData(page);
-    }
+  if (useWiredStreams) {
+    await wiredStreamsSelector.selectWiredStreamsMode();
   }
-);
+
+  await otelKubernetesFlowPage.copyInstallStackSnippetToClipboard();
+  const installStackSnippet = (await page.evaluate('navigator.clipboard.readText()')) as string;
+
+  let codeSnippet: string;
+
+  if (!isLogsEssentialsMode && !useWiredStreams) {
+    /**
+     * Getting the snippets and replacing placeholder
+     * with the values used by Ensemble
+     */
+    await otelKubernetesFlowPage.switchInstrumentationInstructions('java');
+    const annotateAllResourceSnippet = (
+      await otelKubernetesFlowPage.getAnnotateAllResourceSnippet()
+    )?.replace('my-namespace', INSTRUMENTED_APP_CONTAINER_NAMESPACE);
+    const restartDeploymentSnippet = (await otelKubernetesFlowPage.getRestartDeploymentSnippet())
+      ?.split('\n')[0]
+      ?.replace('myapp', INSTRUMENTED_APP_NAME)
+      ?.replace('my-namespace', INSTRUMENTED_APP_CONTAINER_NAMESPACE);
+    /**
+     * Adding timeout so Ensemble waits for the
+     * pods to be created before instrumenting the app
+     */
+    const sleepSnippet = `sleep 120`;
+
+    codeSnippet = `${helmRepoSnippet}\n${installStackSnippet}\n${sleepSnippet}\n${annotateAllResourceSnippet}\n${restartDeploymentSnippet}`;
+  } else {
+    codeSnippet = `${helmRepoSnippet}\n${installStackSnippet}`;
+  }
+
+  /**
+   * Ensemble story watches for the code snippet file
+   * to be created and then executes it
+   */
+  fs.writeFileSync(outputPath, codeSnippet);
+
+  /**
+   * The page waits for the browser window to lose
+   * focus as a signal to start checking for incoming data
+   */
+  await page.evaluate('window.dispatchEvent(new Event("blur"))');
+
+  /**
+   * Wait for the data received indicator to appear.
+   * The flow now uses DataIngestStatus which polls for data
+   * after the blur event and shows "We are monitoring your cluster"
+   * once both logs and metrics have arrived.
+   */
+  await otelKubernetesFlowPage.assertDataReceivedIndicator();
+
+  /**
+   * Additional buffer to ensure data has propagated
+   * to dashboards and Discover before navigating.
+   */
+  await page.waitForTimeout(2 * 60000);
+
+  /**
+   * Wired streams only reroutes logs (to logs.otel); metrics and traces are
+   * unaffected. So for wired streams we validate log delivery via Discover and
+   * the Streams page, and intentionally skip the Cluster Overview dashboard
+   * and APM Service Inventory checks. Dashboard/APM validation is already
+   * covered by the non-wired test variants.
+   *
+   * Both "wired streams" and "wired streams + logs essentials" fall into this
+   * single branch because the validation path is identical for both.
+   */
+  if (useWiredStreams) {
+    await otelKubernetesFlowPage.clickExploreLogsCTA();
+    await assertDiscoverHasData(page, { assertHitCount: true });
+    await assertStreamHasData(page, 'logs.otel');
+  } else if (!isLogsEssentialsMode) {
+    const otelKubernetesOverviewDashboardPage = new OtelKubernetesOverviewDashboardPage(
+      await otelKubernetesFlowPage.openClusterOverviewDashboardInNewTab()
+    );
+
+    await otelKubernetesOverviewDashboardPage.assertNodesPanelNotEmpty();
+
+    const apmServiceInventoryPage = new ApmServiceInventoryPage(
+      await otelKubernetesFlowPage.openServiceInventoryInNewTab()
+    );
+
+    const serviceTestId = 'serviceLink_opentelemetry/java/elastic';
+
+    await apmServiceInventoryPage.page.getByTestId(serviceTestId).click();
+    await apmServiceInventoryPage.assertTransactionExists();
+  } else {
+    await otelKubernetesFlowPage.clickExploreLogsCTA();
+    await assertDiscoverHasData(page);
+  }
+});

--- a/x-pack/solutions/observability/plugins/observability_onboarding/e2e/playwright/stateful/kubernetes_otel.spec.ts
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/e2e/playwright/stateful/kubernetes_otel.spec.ts
@@ -31,115 +31,117 @@ test.beforeEach(async ({ page, onboardingHomePage }) => {
 const INSTRUMENTED_APP_CONTAINER_NAMESPACE = 'java';
 const INSTRUMENTED_APP_NAME = 'java-app';
 
-test('Otel Kubernetes', async ({
-  page,
-  onboardingHomePage,
-  otelKubernetesFlowPage,
-  wiredStreamsSelector,
-}) => {
-  assertEnv(process.env.ARTIFACTS_FOLDER, 'ARTIFACTS_FOLDER is not defined.');
+/**
+ * Kubernetes onboarding with OTel can be slow — increase test timeout to 10 minutes.
+ */
+test(
+  'Otel Kubernetes',
+  { timeout: 10 * 60 * 1000 },
+  async ({ page, onboardingHomePage, otelKubernetesFlowPage, wiredStreamsSelector }) => {
+    assertEnv(process.env.ARTIFACTS_FOLDER, 'ARTIFACTS_FOLDER is not defined.');
 
-  const isLogsEssentialsMode = process.env.LOGS_ESSENTIALS_MODE === 'true';
-  const useWiredStreams = process.env.USE_WIRED_STREAMS === 'true';
-  const fileName = 'code_snippet_otel_kubernetes.sh';
-  const outputPath = path.join(__dirname, '..', process.env.ARTIFACTS_FOLDER, fileName);
+    const isLogsEssentialsMode = process.env.LOGS_ESSENTIALS_MODE === 'true';
+    const useWiredStreams = process.env.USE_WIRED_STREAMS === 'true';
+    const fileName = 'code_snippet_otel_kubernetes.sh';
+    const outputPath = path.join(__dirname, '..', process.env.ARTIFACTS_FOLDER, fileName);
 
-  await onboardingHomePage.selectKubernetesUseCase();
-  await onboardingHomePage.selectOtelKubernetesQuickstart();
+    await onboardingHomePage.selectKubernetesUseCase();
+    await onboardingHomePage.selectOtelKubernetesQuickstart();
 
-  await otelKubernetesFlowPage.copyHelmRepositorySnippetToClipboard();
-  const helmRepoSnippet = (await page.evaluate('navigator.clipboard.readText()')) as string;
+    await otelKubernetesFlowPage.copyHelmRepositorySnippetToClipboard();
+    const helmRepoSnippet = (await page.evaluate('navigator.clipboard.readText()')) as string;
 
-  if (useWiredStreams) {
-    await wiredStreamsSelector.selectWiredStreamsMode();
-  }
+    if (useWiredStreams) {
+      await wiredStreamsSelector.selectWiredStreamsMode();
+    }
 
-  await otelKubernetesFlowPage.copyInstallStackSnippetToClipboard();
-  const installStackSnippet = (await page.evaluate('navigator.clipboard.readText()')) as string;
+    await otelKubernetesFlowPage.copyInstallStackSnippetToClipboard();
+    const installStackSnippet = (await page.evaluate('navigator.clipboard.readText()')) as string;
 
-  let codeSnippet: string;
+    let codeSnippet: string;
 
-  if (!isLogsEssentialsMode && !useWiredStreams) {
+    if (!isLogsEssentialsMode && !useWiredStreams) {
+      /**
+       * Getting the snippets and replacing placeholder
+       * with the values used by Ensemble
+       */
+      await otelKubernetesFlowPage.switchInstrumentationInstructions('java');
+      const annotateAllResourceSnippet = (
+        await otelKubernetesFlowPage.getAnnotateAllResourceSnippet()
+      )?.replace('my-namespace', INSTRUMENTED_APP_CONTAINER_NAMESPACE);
+      const restartDeploymentSnippet = (await otelKubernetesFlowPage.getRestartDeploymentSnippet())
+        ?.split('\n')[0]
+        ?.replace('myapp', INSTRUMENTED_APP_NAME)
+        ?.replace('my-namespace', INSTRUMENTED_APP_CONTAINER_NAMESPACE);
+      /**
+       * Adding timeout so Ensemble waits for the
+       * pods to be created before instrumenting the app
+       */
+      const sleepSnippet = `sleep 120`;
+
+      codeSnippet = `${helmRepoSnippet}\n${installStackSnippet}\n${sleepSnippet}\n${annotateAllResourceSnippet}\n${restartDeploymentSnippet}`;
+    } else {
+      codeSnippet = `${helmRepoSnippet}\n${installStackSnippet}`;
+    }
+
     /**
-     * Getting the snippets and replacing placeholder
-     * with the values used by Ensemble
+     * Ensemble story watches for the code snippet file
+     * to be created and then executes it
      */
-    await otelKubernetesFlowPage.switchInstrumentationInstructions('java');
-    const annotateAllResourceSnippet = (
-      await otelKubernetesFlowPage.getAnnotateAllResourceSnippet()
-    )?.replace('my-namespace', INSTRUMENTED_APP_CONTAINER_NAMESPACE);
-    const restartDeploymentSnippet = (await otelKubernetesFlowPage.getRestartDeploymentSnippet())
-      ?.split('\n')[0]
-      ?.replace('myapp', INSTRUMENTED_APP_NAME)
-      ?.replace('my-namespace', INSTRUMENTED_APP_CONTAINER_NAMESPACE);
+    fs.writeFileSync(outputPath, codeSnippet);
+
     /**
-     * Adding timeout so Ensemble waits for the
-     * pods to be created before instrumenting the app
+     * The page waits for the browser window to lose
+     * focus as a signal to start checking for incoming data
      */
-    const sleepSnippet = `sleep 120`;
+    await page.evaluate('window.dispatchEvent(new Event("blur"))');
 
-    codeSnippet = `${helmRepoSnippet}\n${installStackSnippet}\n${sleepSnippet}\n${annotateAllResourceSnippet}\n${restartDeploymentSnippet}`;
-  } else {
-    codeSnippet = `${helmRepoSnippet}\n${installStackSnippet}`;
+    /**
+     * Wait for the data received indicator to appear.
+     * The flow now uses DataIngestStatus which polls for data
+     * after the blur event and shows "We are monitoring your cluster"
+     * once both logs and metrics have arrived.
+     */
+    await otelKubernetesFlowPage.assertDataReceivedIndicator();
+
+    /**
+     * Additional buffer to ensure data has propagated
+     * to dashboards and Discover before navigating.
+     */
+    await page.waitForTimeout(2 * 60000);
+
+    /**
+     * Wired streams only reroutes logs (to logs.otel); metrics and traces are
+     * unaffected. So for wired streams we validate log delivery via Discover and
+     * the Streams page, and intentionally skip the Cluster Overview dashboard
+     * and APM Service Inventory checks. Dashboard/APM validation is already
+     * covered by the non-wired test variants.
+     *
+     * Both "wired streams" and "wired streams + logs essentials" fall into this
+     * single branch because the validation path is identical for both.
+     */
+    if (useWiredStreams) {
+      await otelKubernetesFlowPage.clickExploreLogsCTA();
+      await assertDiscoverHasData(page, { assertHitCount: true });
+      await assertStreamHasData(page, 'logs.otel');
+    } else if (!isLogsEssentialsMode) {
+      const otelKubernetesOverviewDashboardPage = new OtelKubernetesOverviewDashboardPage(
+        await otelKubernetesFlowPage.openClusterOverviewDashboardInNewTab()
+      );
+
+      await otelKubernetesOverviewDashboardPage.assertNodesPanelNotEmpty();
+
+      const apmServiceInventoryPage = new ApmServiceInventoryPage(
+        await otelKubernetesFlowPage.openServiceInventoryInNewTab()
+      );
+
+      const serviceTestId = 'serviceLink_opentelemetry/java/elastic';
+
+      await apmServiceInventoryPage.page.getByTestId(serviceTestId).click();
+      await apmServiceInventoryPage.assertTransactionExists();
+    } else {
+      await otelKubernetesFlowPage.clickExploreLogsCTA();
+      await assertDiscoverHasData(page);
+    }
   }
-
-  /**
-   * Ensemble story watches for the code snippet file
-   * to be created and then executes it
-   */
-  fs.writeFileSync(outputPath, codeSnippet);
-
-  /**
-   * The page waits for the browser window to lose
-   * focus as a signal to start checking for incoming data
-   */
-  await page.evaluate('window.dispatchEvent(new Event("blur"))');
-
-  /**
-   * Wait for the data received indicator to appear.
-   * The flow now uses DataIngestStatus which polls for data
-   * after the blur event and shows "We are monitoring your cluster"
-   * once both logs and metrics have arrived.
-   */
-  await otelKubernetesFlowPage.assertDataReceivedIndicator();
-
-  /**
-   * Additional buffer to ensure data has propagated
-   * to dashboards and Discover before navigating.
-   */
-  await page.waitForTimeout(2 * 60000);
-
-  /**
-   * Wired streams only reroutes logs (to logs.otel); metrics and traces are
-   * unaffected. So for wired streams we validate log delivery via Discover and
-   * the Streams page, and intentionally skip the Cluster Overview dashboard
-   * and APM Service Inventory checks. Dashboard/APM validation is already
-   * covered by the non-wired test variants.
-   *
-   * Both "wired streams" and "wired streams + logs essentials" fall into this
-   * single branch because the validation path is identical for both.
-   */
-  if (useWiredStreams) {
-    await otelKubernetesFlowPage.clickExploreLogsCTA();
-    await assertDiscoverHasData(page, { assertHitCount: true });
-    await assertStreamHasData(page, 'logs.otel');
-  } else if (!isLogsEssentialsMode) {
-    const otelKubernetesOverviewDashboardPage = new OtelKubernetesOverviewDashboardPage(
-      await otelKubernetesFlowPage.openClusterOverviewDashboardInNewTab()
-    );
-
-    await otelKubernetesOverviewDashboardPage.assertNodesPanelNotEmpty();
-
-    const apmServiceInventoryPage = new ApmServiceInventoryPage(
-      await otelKubernetesFlowPage.openServiceInventoryInNewTab()
-    );
-
-    const serviceTestId = 'serviceLink_opentelemetry/java/elastic';
-
-    await apmServiceInventoryPage.page.getByTestId(serviceTestId).click();
-    await apmServiceInventoryPage.assertTransactionExists();
-  } else {
-    await otelKubernetesFlowPage.clickExploreLogsCTA();
-    await assertDiscoverHasData(page);
-  }
-});
+);


### PR DESCRIPTION
Increases the test-level timeout to 10 minutes since Kubernetes onboarding with OTel can be slow.