### PR TITLE
[CI] Speed up file_casing quick check by replacing minimatch with picomatch

### DIFF
--- a/src/dev/precommit_hook/check_file_casing.js
+++ b/src/dev/precommit_hook/check_file_casing.js
@@ -9,7 +9,7 @@
 
 import { readFileSync, writeFileSync, existsSync } from 'fs';
 import { basename, join } from 'path';
-import { minimatch } from 'minimatch';
+import picomatch from 'picomatch';
 
 import { createFailError } from '@kbn/dev-cli-errors';
 import { REPO_ROOT } from '@kbn/repo-info';
@@ -97,7 +97,7 @@ export async function checkFileCasing(log, paths, getExpectedCasing, options = {
   } = options;
 
   const violations = [];
-  const isIgnoredPath = (path) => ignorePatterns.some((pattern) => minimatch(path, pattern));
+  const isIgnoredPath = ignorePatterns.length > 0 ? picomatch(ignorePatterns) : () => false;
 
   const pathsToValidate = uniq(
     paths


### PR DESCRIPTION
## Summary

The `file_casing` quick check takes **~6m 43s** in CI, making it one of the slowest checks in the `quick_checks` step. This PR fixes the root cause: **3.8 million redundant pattern compilations**.

### The problem

`check_file_casing.js` expands ~104K file paths into ~128K segment paths (every directory segment along every file path), then for each segment runs:

```js
const isIgnoredPath = (path) => ignorePatterns.some((pattern) => minimatch(path, pattern));
```

This calls `minimatch(path, pattern)` which **re-parses and re-compiles the glob pattern from scratch on every invocation**. With 128K paths x 30 patterns = ~3.8M pattern compilations per run.

### The fix

Replace `minimatch` with `picomatch`, which compiles all patterns once into a single optimized regex-based matcher:

```js
const isIgnoredPath = ignorePatterns.length > 0 ? picomatch(ignorePatterns) : () => false;
```

`picomatch` is already a direct dependency in `package.json` (v4.0.4).

### Benchmark results (local, on the full Kibana repo)

| Approach | Filter time (128K paths) | Speedup |
|---|---|---|
| **Current** (`minimatch()` per call) | 24,703 ms – 964,454 ms | baseline |
| **New** (`picomatch` compiled) | 513 – 702 ms | **48x – 1,374x faster** |

- **Correctness**: Verified across all 127,760 segment paths — zero differences in output between `minimatch` and `picomatch`.
- **CI impact estimate**: `file_casing.sh` should drop from **~6m 43s to under 1 minute**.

### How it was tested

- Ran the full ignore-pattern filter on all 127,760 segment paths locally
- Compared output of old (`minimatch`) vs new (`picomatch`) — identical results
- All extglob patterns (e.g. `**/+([A-Z_]).md`, `**/{Dockerfile,docker-compose.yml}`) verified compatible

<!--ONMERGE {"backportTargets":["8.19","9.2","9.3","9.4"]} ONMERGE-->