### PR TITLE
[OAS Docs] Fix greedy regex in toTarget() that produces invalid JSONPath for path-level schemas

### DIFF
--- a/oas_docs/scripts/generate_required_field_fixes.js
+++ b/oas_docs/scripts/generate_required_field_fixes.js
@@ -105,7 +105,7 @@ function collectBugs(spec) {
 function toTarget(jsonpath) {
   return jsonpath
     .replace(/\.components\.schemas\.([\w-]+)/g, ".components.schemas['$1']")
-    .replace(/\.paths\.(\/[^\s[\]]+)/g, (_, s) => `.paths['${s}']`)
+    .replace(/\.paths\.(\/[^.\s[\]]+)/g, (_, s) => `.paths['${s}']`)
     .replace(/\.content\.([^\s.'[\]]+\/[^\s.'[\]]+)/g, (_, s) => `.content['${s}']`);
 }
 


### PR DESCRIPTION
## Summary

Fixes a latent bug in `generate_required_field_fixes.js` introduced in #265298.

The `toTarget()` function converts the walker's dot-notation JSONPaths into bracket-notation targets for the Bump overlay engine. The regex for `$.paths[...]` keys was too greedy:

```js
// Before (broken)
.replace(/\.paths\.(\/[^\s[\]]+)/g, ...)

// After (fixed)  
.replace(/\.paths\.(\/[^.\s[\]]+)/g, ...)
```

The missing `.` in the exclusion set caused the regex to capture everything after the leading `/` — including `.get.responses.200.content.application/json...` — crammed into the path key, producing invalid JSONPath:

```
// Broken output
$.paths['/api/dashboards.get.responses.200.content[\'application/json\']...'].required

// Correct output
$.paths['/api/dashboards'].get.responses.200.content['application/json']...required
```

The Bump overlay engine then rejected this with:
```
JSONPathSyntaxError: Expected "," or "]" but "a" found.
```

## Why wasn't this caught in #265298?

The bug only fires when a **path-level** schema has an `x-oas-optional` field listed in its `required` array. The current codebase has no such occurrences (the script reports 0 schemas affected), so CI passed. The bug was first triggered when adding Dashboards/Visualizations endpoints to the OAS capture scope.

## Test plan

- [ ] Run `make api-docs-fix-required` — should complete without error and report 0 schemas (matching current state)
- [ ] Confirm `make api-docs` completes without a `JSONPathSyntaxError`

Made with [Cursor](https://cursor.com)

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->