### PR TITLE
Fix: [Security Solution][Bug] Connector ID does not get auto-rendered once get cleared, on the 'Add connector' modal on the Attack discovery page

### DIFF
--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/action_connector_form/connector_form_fields_global.test.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/action_connector_form/connector_form_fields_global.test.tsx
@@ -249,6 +249,32 @@ describe('ConnectorFormFieldsGlobal', () => {
     });
   });
 
+  it('auto-populates connector ID from name again after clearing both fields', async () => {
+    render(
+      <FormTestProvider onSubmit={onSubmit}>
+        <ConnectorFormFieldsGlobal canSave={true} isEdit={false} />
+      </FormTestProvider>
+    );
+
+    const nameInput = screen.getByTestId('nameInput');
+    const idInput = screen.getByTestId('connectorIdInput');
+
+    await userEvent.type(nameInput, 'First Name');
+    await waitFor(() => {
+      expect(idInput).toHaveValue('first-name');
+    });
+
+    // Clearing the ID marks the form as using a custom identifier; clearing both restores auto-slug.
+    await userEvent.clear(idInput);
+    await userEvent.clear(nameInput);
+
+    await userEvent.type(nameInput, 'Second Name');
+
+    await waitFor(() => {
+      expect(idInput).toHaveValue('second-name');
+    });
+  });
+
   it('truncates auto-populated connector ID to 36 characters', async () => {
     render(
       <FormTestProvider onSubmit={onSubmit}>

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/action_connector_form/connector_form_fields_global.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/action_connector_form/connector_form_fields_global.tsx
@@ -196,8 +196,16 @@ const ConnectorFormFieldsGlobalComponent: React.FC<ConnectorFormFieldsProps> = (
 }) => {
   const { http } = useKibana().services;
   const { setFieldValue } = useFormContext();
-  const [{ name }] = useFormData<ConnectorFormData>({ watch: ['name', 'id'] });
+  const [{ name, id }] = useFormData<ConnectorFormData>({ watch: ['name', 'id'] });
   const [usingCustomIdentifier, setUsingCustomIdentifier] = useState(false);
+
+  // If the user cleared the ID while the name was still set, `usingCustomIdentifier` becomes true.
+  // After they clear both fields, we should resume auto-slug from the name (same as a fresh form).
+  useEffect(() => {
+    if (!isEdit && name === '' && id === '') {
+      setUsingCustomIdentifier(false);
+    }
+  }, [name, id, isEdit]);
 
   useEffect(() => {
     if (!isEdit && !usingCustomIdentifier && name) {


### PR DESCRIPTION
## Description
Fixes https://github.com/elastic/kibana/issues/262517

### Issue Context
**Describe the bug:**
Connector ID does not get auto-rendered once get cleared, on the 'Add connector' modal on the Attack discovery page

**Build Details:**
```
VERSION: 9.4.0

BUILD: 100529

COMMIT: cade0cce5af93413a77c7412556d3d9be0a69f3e
```

**Pre Conditions:**
1. Kibana 9.4.0-snapshot must be available.

**Steps to reproduce:**
1. Navigate to `Security`>` Attack Discovery`
2. Click on the settings icon present on the page.
3. Attack discovery settings flyout opens.
4. Click on `Add Connector`
5. Select a connector
6. Add connector name
7. Observe that the connector ID is also getting rendered.
8. Now, clear the connector ID and name. Now again enter the connector name.
9. Observe that the connector ID does not get auto-rendered once get cleared, on the add connector modal on the attack discovery page.

**Current behaviour:**
Connector ID does not get auto-rendered once get cleared, on the 'Add connector' modal on the Attack discovery page

**Expected behaviour:**
The Connector ID should get auto-rendered when the Connector name is added after clearing out the Connector ID

**Screen recording:**

https://github.com/user-attachments/assets/df54077b-0df9-4bea-91a7-d1e254defa8e


### Testing
Please verify the fix according to the original issue.