### PR TITLE
[9.4] [ResponseOps][Connectors] Set the event action to resolve on the PD connector when the run when setting is set to Recovered (#263413)

### DIFF
--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/pagerduty/pagerduty_params.test.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/pagerduty/pagerduty_params.test.tsx
@@ -7,6 +7,9 @@
 
 import React from 'react';
 import { mountWithIntl } from '@kbn/test-jest-helpers';
+import { screen, within } from '@testing-library/react';
+import { renderWithI18n } from '@kbn/test-jest-helpers';
+import type { PagerDutyActionParams } from '../types';
 import { EventActionOptions, SeverityActionOptions } from '../types';
 import PagerDutyParamsFields from './pagerduty_params';
 
@@ -130,5 +133,77 @@ describe('PagerDutyParamsFields renders', () => {
     expect(wrapper.find('[data-test-subj="groupInput"]').length > 0).toBeFalsy();
     expect(wrapper.find('[data-test-subj="sourceInput"]').length > 0).toBeFalsy();
     expect(wrapper.find('[data-test-subj="summaryInput"]').length > 0).toBeFalsy();
+  });
+
+  describe('selected action group "recovered"', () => {
+    const renderWithRecoveredGroup = (
+      params: Partial<PagerDutyActionParams> = {
+        eventAction: EventActionOptions.RESOLVE,
+        dedupKey: 'test-dedup',
+      }
+    ) =>
+      renderWithI18n(
+        <PagerDutyParamsFields
+          actionParams={params}
+          errors={{ summary: [], timestamp: [], dedupKey: [] }}
+          editAction={() => {}}
+          index={0}
+          selectedActionGroupId="recovered"
+        />
+      );
+
+    test('event action dropdown is disabled and only shows Resolve', () => {
+      renderWithRecoveredGroup();
+
+      const select = screen.getByTestId('eventActionSelect');
+      expect(select).toBeDisabled();
+      expect(select).toHaveValue('resolve');
+
+      const options = within(select).getAllByRole('option');
+      expect(options).toHaveLength(1);
+      expect(options[0]).toHaveValue('resolve');
+    });
+
+    test('dedupKey field is still rendered', () => {
+      renderWithRecoveredGroup();
+
+      const dedupKeyInput = screen.getByTestId('dedupKeyInput');
+      expect(dedupKeyInput).toBeInTheDocument();
+      expect(dedupKeyInput).toHaveValue('test-dedup');
+    });
+
+    test('trigger-only fields are not rendered', () => {
+      renderWithRecoveredGroup();
+
+      expect(screen.queryByTestId('summaryInput')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('severitySelect')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('timestampInput')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('componentInput')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('groupInput')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('sourceInput')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('customDetailsJsonEditor')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('linksList')).not.toBeInTheDocument();
+    });
+  });
+
+  test('event action dropdown shows all options when selectedActionGroupId is not "recovered"', () => {
+    renderWithI18n(
+      <PagerDutyParamsFields
+        actionParams={{ eventAction: EventActionOptions.TRIGGER, dedupKey: 'test' }}
+        errors={{ summary: [], timestamp: [], dedupKey: [] }}
+        editAction={() => {}}
+        index={0}
+        selectedActionGroupId="default"
+      />
+    );
+
+    const select = screen.getByTestId('eventActionSelect');
+    expect(select).not.toBeDisabled();
+
+    const options = within(select).getAllByRole('option');
+    expect(options).toHaveLength(3);
+    expect(options[0]).toHaveValue('trigger');
+    expect(options[1]).toHaveValue('resolve');
+    expect(options[2]).toHaveValue('acknowledge');
   });
 });

--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/pagerduty/pagerduty_params.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/pagerduty/pagerduty_params.tsx
@@ -20,6 +20,7 @@ import { isUndefined } from 'lodash';
 import type { ActionParamsProps } from '@kbn/triggers-actions-ui-plugin/public';
 import { JsonEditorWithMessageVariables } from '@kbn/triggers-actions-ui-plugin/public';
 import { TextFieldWithMessageVariables } from '@kbn/triggers-actions-ui-plugin/public';
+import { RecoveredActionGroup } from '@kbn/alerting-types';
 import type { PagerDutyActionParams } from '../types';
 import { LinksList } from './links_list';
 import { OPTIONAL_LABEL } from './translations';
@@ -30,6 +31,7 @@ const PagerDutyParamsFields: React.FunctionComponent<ActionParamsProps<PagerDuty
   index,
   messageVariables,
   errors,
+  selectedActionGroupId,
 }) => {
   const { euiTheme } = useEuiTheme();
 
@@ -125,6 +127,11 @@ const PagerDutyParamsFields: React.FunctionComponent<ActionParamsProps<PagerDuty
     Number(errors.timestamp.length) > 0 &&
     timestamp !== undefined;
 
+  const isRecoveredAction = selectedActionGroupId === RecoveredActionGroup.id;
+  const filteredEventActionOptions = isRecoveredAction
+    ? eventActionOptions.filter((option) => option.value === 'resolve')
+    : eventActionOptions;
+
   return (
     <>
       <EuiFlexGroup>
@@ -141,12 +148,13 @@ const PagerDutyParamsFields: React.FunctionComponent<ActionParamsProps<PagerDuty
             <EuiSelect
               fullWidth
               data-test-subj="eventActionSelect"
-              options={eventActionOptions}
-              hasNoInitialSelection={isUndefined(eventAction)}
+              options={filteredEventActionOptions}
+              hasNoInitialSelection={!isRecoveredAction && isUndefined(eventAction)}
               value={eventAction}
               onChange={(e) => {
                 editAction('eventAction', e.target.value, index);
               }}
+              disabled={isRecoveredAction}
             />
           </EuiFormRow>
         </EuiFlexItem>


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[ResponseOps][Connectors] Set the event action to resolve on the PD connector when the run when setting is set to Recovered (#263413)](https://github.com/elastic/kibana/pull/263413)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Georgiana-Andreea Onoleață","email":"georgiana.onoleata@elastic.co"},"sourceCommit":{"committedDate":"2026-04-28T07:21:00Z","message":"[ResponseOps][Connectors] Set the event action to resolve on the PD connector when the run when setting is set to Recovered (#263413)\n\nCloses https://github.com/elastic/kibana/issues/260802 \n\n## Summary\n\n- when the `run when` setting is set to Recovered, the PagerDuty's\nconnector event action dropdown is now locked to Resolve and it is\ndisabled, preventing users from selecting an invalid action.\n\n<img width=\"1368\" height=\"553\" alt=\"Screenshot 2026-04-15 at 14 24 16\"\nsrc=\"https://github.com/user-attachments/assets/0a910a4a-a469-4d84-a9a2-c9fae53b52a3\"\n/>\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"7b81448718e016cb2f6e5a6cd53ead1e6543bc12","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:skip","Team:ResponseOps","backport:version","v9.4.0","v9.5.0"],"title":"[ResponseOps][Connectors] Set the event action to resolve on the PD connector when the run when setting is set to Recovered","number":263413,"url":"https://github.com/elastic/kibana/pull/263413","mergeCommit":{"message":"[ResponseOps][Connectors] Set the event action to resolve on the PD connector when the run when setting is set to Recovered (#263413)\n\nCloses https://github.com/elastic/kibana/issues/260802 \n\n## Summary\n\n- when the `run when` setting is set to Recovered, the PagerDuty's\nconnector event action dropdown is now locked to Resolve and it is\ndisabled, preventing users from selecting an invalid action.\n\n<img width=\"1368\" height=\"553\" alt=\"Screenshot 2026-04-15 at 14 24 16\"\nsrc=\"https://github.com/user-attachments/assets/0a910a4a-a469-4d84-a9a2-c9fae53b52a3\"\n/>\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"7b81448718e016cb2f6e5a6cd53ead1e6543bc12"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/263413","number":263413,"mergeCommit":{"message":"[ResponseOps][Connectors] Set the event action to resolve on the PD connector when the run when setting is set to Recovered (#263413)\n\nCloses https://github.com/elastic/kibana/issues/260802 \n\n## Summary\n\n- when the `run when` setting is set to Recovered, the PagerDuty's\nconnector event action dropdown is now locked to Resolve and it is\ndisabled, preventing users from selecting an invalid action.\n\n<img width=\"1368\" height=\"553\" alt=\"Screenshot 2026-04-15 at 14 24 16\"\nsrc=\"https://github.com/user-attachments/assets/0a910a4a-a469-4d84-a9a2-c9fae53b52a3\"\n/>\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"7b81448718e016cb2f6e5a6cd53ead1e6543bc12"}}]}] BACKPORT-->