### PR TITLE
[Osquery] Export results split: phase 1+2 (foundation + stream core)

### DIFF
--- a/x-pack/platform/plugins/shared/osquery/common/experimental_features.ts
+++ b/x-pack/platform/plugins/shared/osquery/common/experimental_features.ts
@@ -25,6 +25,11 @@ export const allowedExperimentalValues = Object.freeze({
    * adding KQL search, document flyout, per-row actions, and column curation.
    */
   unifiedDataTable: true,
+  /**
+   * Enables the "Export Results" button and server-side streaming export endpoints
+   * for downloading osquery results as NDJSON, JSON, or CSV files.
+   */
+  exportResults: false,
 });
 
 type ExperimentalFeatures = { [K in keyof typeof allowedExperimentalValues]: boolean };

--- a/x-pack/platform/plugins/shared/osquery/common/utils/flatten_osquery_hit.test.ts
+++ b/x-pack/platform/plugins/shared/osquery/common/utils/flatten_osquery_hit.test.ts
@@ -1,0 +1,119 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { flattenOsqueryHit, getNestedOrFlat } from './flatten_osquery_hit';
+import type { ResultEdges } from '../search_strategy';
+
+describe('flatten_osquery_hit', () => {
+  describe('getNestedOrFlat', () => {
+    it('resolves nested paths', () => {
+      expect(getNestedOrFlat('a.b', { a: { b: 'value' } })).toBe('value');
+    });
+
+    it('resolves flat dot-notation keys', () => {
+      expect(getNestedOrFlat('a.b', { 'a.b': 'flat-value' })).toBe('flat-value');
+    });
+
+    it('returns undefined for missing paths', () => {
+      expect(getNestedOrFlat('missing', { other: 'value' })).toBeUndefined();
+    });
+
+    it('returns undefined for non-object source', () => {
+      expect(getNestedOrFlat('path', null)).toBeUndefined();
+    });
+  });
+
+  describe('flattenOsqueryHit', () => {
+    it('flattens edge.fields, unwrapping single-element arrays', () => {
+      const edge = {
+        _id: '1',
+        _index: 'test',
+        fields: {
+          'osquery.pid': [1234],
+          'osquery.name': ['test-process'],
+          'osquery.tags': ['a', 'b'],
+        },
+      } as unknown as ResultEdges[number];
+
+      const result = flattenOsqueryHit(edge);
+      expect(result['osquery.pid']).toBe(1234);
+      expect(result['osquery.name']).toBe('test-process');
+      expect(result['osquery.tags']).toEqual(['a', 'b']);
+    });
+
+    it('extracts agent fields from _source when not in fields', () => {
+      const edge = {
+        _id: '1',
+        _index: 'test',
+        fields: {},
+        _source: {
+          agent: { name: 'host-1', id: 'agent-123' },
+        },
+      } as unknown as ResultEdges[number];
+
+      const result = flattenOsqueryHit(edge);
+      expect(result['agent.name']).toBe('host-1');
+      expect(result['agent.id']).toBe('agent-123');
+    });
+
+    it('prefers existing fields over _source agent values', () => {
+      const edge = {
+        _id: '1',
+        _index: 'test',
+        fields: {
+          'agent.name': ['from-fields'],
+          'agent.id': ['agent-from-fields'],
+        },
+        _source: {
+          agent: { name: 'from-source', id: 'agent-from-source' },
+        },
+      } as unknown as ResultEdges[number];
+
+      const result = flattenOsqueryHit(edge);
+      expect(result['agent.name']).toBe('from-fields');
+      expect(result['agent.id']).toBe('agent-from-fields');
+    });
+
+    it('applies ECS mapping from _source', () => {
+      const edge = {
+        _id: '1',
+        _index: 'test',
+        fields: { 'osquery.pid': [1234] },
+        _source: { process: { pid: 1234 } },
+      } as unknown as ResultEdges[number];
+
+      const ecsMapping = { 'process.pid': { field: 'pid' } };
+
+      const result = flattenOsqueryHit(edge, ecsMapping);
+      expect(result['process.pid']).toBe(1234);
+    });
+
+    it('JSON-stringifies array/object ECS mapping values', () => {
+      const edge = {
+        _id: '1',
+        _index: 'test',
+        fields: {},
+        _source: { tags: ['a', 'b'] },
+      } as unknown as ResultEdges[number];
+
+      const ecsMapping = { tags: { field: 'tags' } };
+
+      const result = flattenOsqueryHit(edge, ecsMapping);
+      expect(result.tags).toBe(JSON.stringify(['a', 'b'], null, 2));
+    });
+
+    it('handles empty edge gracefully', () => {
+      const edge = {
+        _id: '1',
+        _index: 'test',
+      } as unknown as ResultEdges[number];
+
+      const result = flattenOsqueryHit(edge);
+      expect(result).toEqual({});
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/osquery/common/utils/flatten_osquery_hit.ts
+++ b/x-pack/platform/plugins/shared/osquery/common/utils/flatten_osquery_hit.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { get, isArray, isObject } from 'lodash/fp';
+import type { ECSMapping } from '@kbn/osquery-io-ts-types';
+import type { ResultEdges } from '../search_strategy';
+
+/**
+ * Resolves a dot-notation path from a source object.
+ * Uses lodash `get` which resolves both nested paths (e.g., source.process.pid)
+ * and flat dot-notation keys (e.g., source['process.pid']), preferring flat keys
+ * when both exist. Falls back to a direct property lookup if `get` returns undefined.
+ */
+export function getNestedOrFlat(path: string, source: unknown): unknown {
+  const nested = get(path, source);
+  if (nested !== undefined) return nested;
+
+  if (source && typeof source === 'object') {
+    return (source as Record<string, unknown>)[path];
+  }
+
+  return undefined;
+}
+
+export function flattenOsqueryHit(
+  edge: ResultEdges[number],
+  ecsMapping?: ECSMapping
+): Record<string, unknown> {
+  const flattened: Record<string, unknown> = {};
+
+  if (edge.fields) {
+    for (const [key, value] of Object.entries(edge.fields)) {
+      flattened[key] = isArray(value) && value.length === 1 ? value[0] : value;
+    }
+  }
+
+  const agentFields = ['agent.name', 'agent.id'] as const;
+  for (const field of agentFields) {
+    if (flattened[field] === undefined && edge._source) {
+      const parts = field.split('.');
+      const nested = (edge._source as Record<string, unknown>)?.[parts[0]];
+      if (nested && typeof nested === 'object') {
+        const value = (nested as Record<string, unknown>)[parts[1]];
+        if (value !== undefined) {
+          flattened[field] = isArray(value) && value.length === 1 ? value[0] : value;
+        }
+      }
+    }
+  }
+
+  if (ecsMapping && edge._source) {
+    const ecsMappingKeys = Object.keys(ecsMapping);
+    for (const key of ecsMappingKeys) {
+      const sourceValue = getNestedOrFlat(key, edge._source);
+      if (sourceValue !== undefined) {
+        if (isArray(sourceValue) || isObject(sourceValue)) {
+          try {
+            flattened[key] = JSON.stringify(sourceValue, null, 2);
+          } catch {
+            flattened[key] = sourceValue;
+          }
+        } else {
+          flattened[key] = sourceValue;
+        }
+      }
+    }
+  }
+
+  return flattened;
+}

--- a/x-pack/platform/plugins/shared/osquery/common/utils/flatten_osquery_hit.ts
+++ b/x-pack/platform/plugins/shared/osquery/common/utils/flatten_osquery_hit.ts
@@ -40,15 +40,10 @@ export function flattenOsqueryHit(
 
   const agentFields = ['agent.name', 'agent.id'] as const;
   for (const field of agentFields) {
-    if (flattened[field] === undefined && edge._source) {
-      const parts = field.split('.');
-      const nested = (edge._source as Record<string, unknown>)?.[parts[0]];
-      if (nested && typeof nested === 'object') {
-        const value = (nested as Record<string, unknown>)[parts[1]];
-        if (value !== undefined) {
-          flattened[field] = isArray(value) && value.length === 1 ? value[0] : value;
-        }
-      }
+    if (flattened[field] !== undefined) continue;
+    const value = getNestedOrFlat(field, edge._source);
+    if (value !== undefined) {
+      flattened[field] = isArray(value) && value.length === 1 ? value[0] : value;
     }
   }
 

--- a/x-pack/platform/plugins/shared/osquery/moon.yml
+++ b/x-pack/platform/plugins/shared/osquery/moon.yml
@@ -89,6 +89,7 @@ dependsOn:
   - '@kbn/core-http-browser'
   - '@kbn/core-logging-server-mocks'
   - '@kbn/core-http-request-handler-context-server'
+  - '@kbn/core-security-server'
 tags:
   - plugin
   - prod

--- a/x-pack/platform/plugins/shared/osquery/moon.yml
+++ b/x-pack/platform/plugins/shared/osquery/moon.yml
@@ -87,6 +87,8 @@ dependsOn:
   - '@kbn/core-chrome-browser'
   - '@kbn/scout'
   - '@kbn/core-http-browser'
+  - '@kbn/core-logging-server-mocks'
+  - '@kbn/core-http-request-handler-context-server'
 tags:
   - plugin
   - prod

--- a/x-pack/platform/plugins/shared/osquery/public/results/transform_results.ts
+++ b/x-pack/platform/plugins/shared/osquery/public/results/transform_results.ts
@@ -6,77 +6,17 @@
  */
 
 import type { DataTableRecord, EsHitRecord } from '@kbn/discover-utils';
-import { get, isArray, isObject } from 'lodash/fp';
 import type { ECSMapping } from '@kbn/osquery-io-ts-types';
 import type { ResultEdges } from '../../common/search_strategy';
 
-/**
- * Resolves a dot-notation path from a source object.
- * Uses lodash `get` which resolves both nested paths (e.g., source.process.pid)
- * and flat dot-notation keys (e.g., source['process.pid']), preferring flat keys
- * when both exist. Falls back to a direct property lookup if `get` returns undefined.
- */
-export function getNestedOrFlat(path: string, source: unknown): unknown {
-  const nested = get(path, source);
-  if (nested !== undefined) return nested;
+import { flattenOsqueryHit } from '../../common/utils/flatten_osquery_hit';
 
-  if (source && typeof source === 'object') {
-    return (source as Record<string, unknown>)[path];
-  }
-
-  return undefined;
-}
+// Re-export from common for backward compatibility
+export { flattenOsqueryHit, getNestedOrFlat } from '../../common/utils/flatten_osquery_hit';
 
 interface TransformEdgesToRecordsOptions {
   edges: ResultEdges;
   ecsMapping?: ECSMapping;
-}
-
-export function flattenOsqueryHit(
-  edge: ResultEdges[number],
-  ecsMapping?: ECSMapping
-): Record<string, unknown> {
-  const flattened: Record<string, unknown> = {};
-
-  if (edge.fields) {
-    for (const [key, value] of Object.entries(edge.fields)) {
-      flattened[key] = isArray(value) && value.length === 1 ? value[0] : value;
-    }
-  }
-
-  const agentFields = ['agent.name', 'agent.id'] as const;
-  for (const field of agentFields) {
-    if (flattened[field] === undefined && edge._source) {
-      const parts = field.split('.');
-      const nested = (edge._source as Record<string, unknown>)?.[parts[0]];
-      if (nested && typeof nested === 'object') {
-        const value = (nested as Record<string, unknown>)[parts[1]];
-        if (value !== undefined) {
-          flattened[field] = isArray(value) && value.length === 1 ? value[0] : value;
-        }
-      }
-    }
-  }
-
-  if (ecsMapping && edge._source) {
-    const ecsMappingKeys = Object.keys(ecsMapping);
-    for (const key of ecsMappingKeys) {
-      const sourceValue = getNestedOrFlat(key, edge._source);
-      if (sourceValue !== undefined) {
-        if (isArray(sourceValue) || isObject(sourceValue)) {
-          try {
-            flattened[key] = JSON.stringify(sourceValue, null, 2);
-          } catch {
-            flattened[key] = sourceValue;
-          }
-        } else {
-          flattened[key] = sourceValue;
-        }
-      }
-    }
-  }
-
-  return flattened;
 }
 
 export function transformEdgesToRecords({

--- a/x-pack/platform/plugins/shared/osquery/server/lib/export_results_to_stream.test.ts
+++ b/x-pack/platform/plugins/shared/osquery/server/lib/export_results_to_stream.test.ts
@@ -1,0 +1,1180 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { Subject } from 'rxjs';
+import type { ElasticsearchClient } from '@kbn/core/server';
+import { loggingSystemMock } from '@kbn/core-logging-server-mocks';
+
+import { exportResultsToStream } from './export_results_to_stream';
+import { createCsvFormatter } from './format_results';
+import type { ResultFormatter, ExportMetadata } from './format_results';
+
+/**
+ * Collects all data from a stream until it ends.
+ * Rejects if the stream emits an error.
+ */
+const collectStream = (stream: NodeJS.ReadableStream): Promise<string> =>
+  new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    stream.on('data', (chunk) => chunks.push(Buffer.from(chunk)));
+    stream.on('end', () => resolve(Buffer.concat(chunks).toString()));
+    stream.on('error', reject);
+  });
+
+/**
+ * Waits for a stream to close (either end or destroy).
+ * Does not reject on error — use this when you expect stream destruction.
+ */
+const waitForStreamClose = (stream: NodeJS.ReadableStream): Promise<void> =>
+  new Promise((resolve) => {
+    stream.on('close', resolve);
+    stream.on('end', resolve);
+    stream.on('error', resolve);
+    (stream as import('stream').PassThrough).resume();
+  });
+
+const createMockEsClient = () =>
+  ({
+    openPointInTime: jest.fn().mockResolvedValue({ id: 'test-pit-id' }),
+    closePointInTime: jest.fn().mockResolvedValue({}),
+    search: jest.fn(),
+  } as unknown as jest.Mocked<ElasticsearchClient>);
+
+const createMockFormatter = (): ResultFormatter => ({
+  contentType: 'application/ndjson',
+  fileExtension: 'ndjson',
+  opening: jest.fn().mockReturnValue('{"_meta":{}}\n'),
+  row: jest.fn().mockImplementation((record) => JSON.stringify(record) + '\n'),
+  closing: jest.fn().mockReturnValue(null),
+});
+
+const createMockHit = (id: string, fields: Record<string, unknown[]> = {}) => ({
+  _id: id,
+  _index: 'test-index',
+  _source: { agent: { id: `agent-${id}` } },
+  fields,
+  sort: [id],
+});
+
+const metadata: ExportMetadata = {
+  action_id: 'test-action',
+  timestamp: '2024-01-01T00:00:00.000Z',
+  exported_by: 'test-user',
+  format: 'ndjson',
+};
+
+describe('exportResultsToStream', () => {
+  let esClient: jest.Mocked<ElasticsearchClient>;
+  let logger: ReturnType<typeof loggingSystemMock.createLogger>;
+  let aborted$: Subject<void>;
+
+  beforeEach(() => {
+    esClient = createMockEsClient() as jest.Mocked<ElasticsearchClient>;
+    logger = loggingSystemMock.createLogger();
+    aborted$ = new Subject<void>();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('PIT lifecycle', () => {
+    it('should open PIT with correct index and keep_alive before searching', async () => {
+      (esClient.search as jest.Mock).mockResolvedValueOnce({
+        hits: { hits: [], total: { value: 0 } },
+      });
+
+      await exportResultsToStream({
+        esClient,
+        index: 'logs-osquery_manager.result-default',
+        query: { match_all: {} },
+        formatter: createMockFormatter(),
+        metadata,
+        aborted$,
+        logger,
+      });
+
+      expect(esClient.openPointInTime).toHaveBeenCalledWith(
+        {
+          index: 'logs-osquery_manager.result-default',
+          keep_alive: '5m',
+        },
+        { signal: expect.any(AbortSignal) }
+      );
+    });
+
+    it('should close PIT after stream completes', async () => {
+      (esClient.search as jest.Mock).mockResolvedValueOnce({
+        hits: { hits: [], total: { value: 0 } },
+      });
+
+      const result = await exportResultsToStream({
+        esClient,
+        index: 'test-index',
+        query: { match_all: {} },
+        formatter: createMockFormatter(),
+        metadata,
+        aborted$,
+        logger,
+      });
+
+      await collectStream(result as NodeJS.ReadableStream);
+
+      expect(esClient.closePointInTime).toHaveBeenCalledWith({ id: 'test-pit-id' });
+    });
+
+    it('should close PIT when max results limit is exceeded', async () => {
+      (esClient.search as jest.Mock).mockResolvedValueOnce({
+        hits: { hits: [createMockHit('1')], total: { value: 600_000 } },
+      });
+
+      await exportResultsToStream({
+        esClient,
+        index: 'test-index',
+        query: { match_all: {} },
+        formatter: createMockFormatter(),
+        metadata,
+        aborted$,
+        logger,
+      });
+
+      expect(esClient.closePointInTime).toHaveBeenCalledWith({ id: 'test-pit-id' });
+    });
+
+    it('should close PIT when ES search error occurs mid-stream', async () => {
+      (esClient.search as jest.Mock)
+        .mockResolvedValueOnce({
+          hits: { hits: [createMockHit('1')], total: { value: 2 } },
+        })
+        .mockRejectedValueOnce(new Error('ES cluster unavailable'));
+
+      const result = await exportResultsToStream({
+        esClient,
+        index: 'test-index',
+        query: { match_all: {} },
+        formatter: createMockFormatter(),
+        metadata,
+        aborted$,
+        logger,
+      });
+
+      await waitForStreamClose(result as NodeJS.ReadableStream);
+
+      expect(esClient.closePointInTime).toHaveBeenCalledWith({ id: 'test-pit-id' });
+    });
+
+    it('should not close PIT twice when cleanup is called multiple times', async () => {
+      (esClient.search as jest.Mock).mockResolvedValueOnce({
+        hits: { hits: [], total: { value: 0 } },
+      });
+
+      const result = await exportResultsToStream({
+        esClient,
+        index: 'test-index',
+        query: { match_all: {} },
+        formatter: createMockFormatter(),
+        metadata,
+        aborted$,
+        logger,
+      });
+
+      await collectStream(result as NodeJS.ReadableStream);
+
+      expect(esClient.closePointInTime).toHaveBeenCalledTimes(1);
+    });
+
+    it('should log debug when PIT close fails', async () => {
+      (esClient.search as jest.Mock).mockResolvedValueOnce({
+        hits: { hits: [], total: { value: 0 } },
+      });
+      (esClient.closePointInTime as jest.Mock).mockRejectedValueOnce(
+        new Error('PIT already expired')
+      );
+
+      const result = await exportResultsToStream({
+        esClient,
+        index: 'test-index',
+        query: { match_all: {} },
+        formatter: createMockFormatter(),
+        metadata,
+        aborted$,
+        logger,
+      });
+
+      await collectStream(result as NodeJS.ReadableStream);
+
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('Failed to close PIT'));
+    });
+  });
+
+  describe('max result guardrail', () => {
+    it('should return error object when total exceeds 500,000', async () => {
+      (esClient.search as jest.Mock).mockResolvedValueOnce({
+        hits: { hits: [createMockHit('1')], total: { value: 500_001 } },
+      });
+
+      const result = await exportResultsToStream({
+        esClient,
+        index: 'test-index',
+        query: { match_all: {} },
+        formatter: createMockFormatter(),
+        metadata,
+        aborted$,
+        logger,
+      });
+
+      expect('statusCode' in result).toBe(true);
+      if ('statusCode' in result) {
+        expect(result.statusCode).toBe(400);
+        expect(result.message).toContain('500,000');
+      }
+    });
+
+    it('should include the actual count in the error message when limit exceeded', async () => {
+      (esClient.search as jest.Mock).mockResolvedValueOnce({
+        hits: { hits: [], total: { value: 600_000 } },
+      });
+
+      const result = await exportResultsToStream({
+        esClient,
+        index: 'test-index',
+        query: { match_all: {} },
+        formatter: createMockFormatter(),
+        metadata,
+        aborted$,
+        logger,
+      });
+
+      expect('statusCode' in result).toBe(true);
+      if ('statusCode' in result) {
+        expect(result.message).toContain('600,000');
+      }
+    });
+
+    it('should return stream (not error) when total equals 500,000 exactly', async () => {
+      (esClient.search as jest.Mock).mockResolvedValueOnce({
+        hits: { hits: [], total: { value: 500_000 } },
+      });
+
+      const result = await exportResultsToStream({
+        esClient,
+        index: 'test-index',
+        query: { match_all: {} },
+        formatter: createMockFormatter(),
+        metadata,
+        aborted$,
+        logger,
+      });
+
+      expect('statusCode' in result).toBe(false);
+      // Drain the stream to clean up
+      await collectStream(result as NodeJS.ReadableStream);
+    });
+
+    it('should handle numeric total (not object) correctly', async () => {
+      (esClient.search as jest.Mock).mockResolvedValueOnce({
+        hits: { hits: [], total: 200 },
+      });
+
+      const result = await exportResultsToStream({
+        esClient,
+        index: 'test-index',
+        query: { match_all: {} },
+        formatter: createMockFormatter(),
+        metadata,
+        aborted$,
+        logger,
+      });
+
+      expect('statusCode' in result).toBe(false);
+      await collectStream(result as NodeJS.ReadableStream);
+    });
+
+    it('should handle missing total (treats as 0) and not return error', async () => {
+      (esClient.search as jest.Mock).mockResolvedValueOnce({
+        hits: { hits: [], total: undefined },
+      });
+
+      const result = await exportResultsToStream({
+        esClient,
+        index: 'test-index',
+        query: { match_all: {} },
+        formatter: createMockFormatter(),
+        metadata,
+        aborted$,
+        logger,
+      });
+
+      expect('statusCode' in result).toBe(false);
+      await collectStream(result as NodeJS.ReadableStream);
+    });
+  });
+
+  describe('search_after pagination', () => {
+    it('should stream all results from first page when total fits in one page', async () => {
+      const hits = [
+        createMockHit('1', { 'osquery.name': ['alice'] }),
+        createMockHit('2', { 'osquery.name': ['bob'] }),
+      ];
+
+      (esClient.search as jest.Mock)
+        .mockResolvedValueOnce({
+          hits: { hits, total: { value: 2 } },
+        })
+        .mockResolvedValueOnce({
+          hits: { hits: [], total: { value: 2 } },
+        });
+
+      const formatter = createMockFormatter();
+
+      const result = await exportResultsToStream({
+        esClient,
+        index: 'test-index',
+        query: { match_all: {} },
+        formatter,
+        metadata,
+        aborted$,
+        logger,
+      });
+
+      await collectStream(result as NodeJS.ReadableStream);
+
+      expect(formatter.row).toHaveBeenCalledTimes(2);
+    });
+
+    it('should paginate using search_after when first page has results', async () => {
+      const page1Hits = [createMockHit('1'), createMockHit('2')];
+      const page2Hits = [createMockHit('3')];
+
+      (esClient.search as jest.Mock)
+        .mockResolvedValueOnce({
+          hits: { hits: page1Hits, total: { value: 3 } },
+        })
+        .mockResolvedValueOnce({
+          hits: { hits: page2Hits, total: { value: 3 } },
+        })
+        .mockResolvedValueOnce({
+          hits: { hits: [], total: { value: 3 } },
+        });
+
+      const formatter = createMockFormatter();
+
+      const result = await exportResultsToStream({
+        esClient,
+        index: 'test-index',
+        query: { match_all: {} },
+        formatter,
+        metadata,
+        aborted$,
+        logger,
+      });
+
+      await collectStream(result as NodeJS.ReadableStream);
+
+      expect(formatter.row).toHaveBeenCalledTimes(3);
+    });
+
+    it('should pass the sort value of the last hit as search_after for subsequent pages', async () => {
+      const page1Hits = [createMockHit('hit-a'), createMockHit('hit-b')];
+
+      (esClient.search as jest.Mock)
+        .mockResolvedValueOnce({
+          hits: { hits: page1Hits, total: { value: 2 } },
+        })
+        .mockResolvedValueOnce({
+          hits: { hits: [], total: { value: 2 } },
+        });
+
+      const formatter = createMockFormatter();
+
+      const result = await exportResultsToStream({
+        esClient,
+        index: 'test-index',
+        query: { match_all: {} },
+        formatter,
+        metadata,
+        aborted$,
+        logger,
+      });
+
+      await collectStream(result as NodeJS.ReadableStream);
+
+      // Second search call should include search_after from last hit of page1
+      expect(esClient.search).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({ search_after: ['hit-b'] }),
+        expect.anything()
+      );
+    });
+
+    it('should stop pagination when an empty page is returned', async () => {
+      const hits = [createMockHit('1')];
+
+      (esClient.search as jest.Mock)
+        .mockResolvedValueOnce({
+          hits: { hits, total: { value: 1 } },
+        })
+        .mockResolvedValueOnce({
+          hits: { hits: [], total: { value: 1 } },
+        });
+
+      const formatter = createMockFormatter();
+
+      const result = await exportResultsToStream({
+        esClient,
+        index: 'test-index',
+        query: { match_all: {} },
+        formatter,
+        metadata,
+        aborted$,
+        logger,
+      });
+
+      await collectStream(result as NodeJS.ReadableStream);
+
+      // First page search (synchronous in exportResultsToStream) + one pagination call that returns empty
+      expect(esClient.search).toHaveBeenCalledTimes(2);
+    });
+
+    it('should request only agent source when ecsMapping is not provided', async () => {
+      (esClient.search as jest.Mock).mockResolvedValueOnce({
+        hits: { hits: [], total: { value: 0 } },
+      });
+
+      const result = await exportResultsToStream({
+        esClient,
+        index: 'test-index',
+        query: { match_all: {} },
+        formatter: createMockFormatter(),
+        metadata,
+        aborted$,
+        logger,
+      });
+
+      await collectStream(result as NodeJS.ReadableStream);
+
+      expect(esClient.search).toHaveBeenCalledWith(
+        expect.objectContaining({
+          _source: ['agent'],
+        }),
+        expect.anything()
+      );
+    });
+
+    it('should request full source when ecsMapping is provided', async () => {
+      (esClient.search as jest.Mock).mockResolvedValueOnce({
+        hits: { hits: [], total: { value: 0 } },
+      });
+
+      const result = await exportResultsToStream({
+        esClient,
+        index: 'test-index',
+        query: { match_all: {} },
+        formatter: createMockFormatter(),
+        metadata,
+        aborted$,
+        logger,
+        ecsMapping: { 'process.pid': { field: 'pid' } },
+      });
+
+      await collectStream(result as NodeJS.ReadableStream);
+
+      expect(esClient.search).toHaveBeenCalledWith(
+        expect.objectContaining({
+          _source: true,
+        }),
+        expect.anything()
+      );
+    });
+  });
+
+  describe('formatter integration', () => {
+    it('should call opening() with enriched metadata including total_results', async () => {
+      (esClient.search as jest.Mock).mockResolvedValueOnce({
+        hits: { hits: [], total: { value: 42 } },
+      });
+
+      const formatter = createMockFormatter();
+
+      const result = await exportResultsToStream({
+        esClient,
+        index: 'test-index',
+        query: { match_all: {} },
+        formatter,
+        metadata,
+        aborted$,
+        logger,
+      });
+
+      await collectStream(result as NodeJS.ReadableStream);
+
+      expect(formatter.opening).toHaveBeenCalledWith(
+        expect.objectContaining({ total_results: 42 })
+      );
+    });
+
+    it('should call finalizeColumns with deduplicated first-page records', async () => {
+      const hitWithDuplicates = createMockHit('1', {
+        'osquery.pid': ['123'],
+        'osquery.pid.number': [123],
+        'osquery.pid.text': ['123'],
+        'osquery.name': ['proc'],
+      });
+
+      (esClient.search as jest.Mock)
+        .mockResolvedValueOnce({
+          hits: { hits: [hitWithDuplicates], total: { value: 1 } },
+        })
+        .mockResolvedValueOnce({
+          hits: { hits: [], total: { value: 1 } },
+        });
+
+      const formatter = createMockFormatter();
+      formatter.finalizeColumns = jest.fn();
+
+      const result = await exportResultsToStream({
+        esClient,
+        index: 'test-index',
+        query: { match_all: {} },
+        formatter,
+        metadata,
+        aborted$,
+        logger,
+      });
+
+      await collectStream(result as NodeJS.ReadableStream);
+
+      expect(formatter.finalizeColumns).toHaveBeenCalledWith([
+        {
+          'agent.id': 'agent-1',
+          'osquery.pid.number': 123,
+          'osquery.name': 'proc',
+        },
+      ]);
+    });
+
+    it('should call row() with isFirst=true for the first row and isFirst=false for subsequent rows', async () => {
+      const hits = [createMockHit('1'), createMockHit('2'), createMockHit('3')];
+
+      (esClient.search as jest.Mock)
+        .mockResolvedValueOnce({
+          hits: { hits, total: { value: 3 } },
+        })
+        .mockResolvedValueOnce({
+          hits: { hits: [], total: { value: 3 } },
+        });
+
+      const formatter = createMockFormatter();
+
+      const result = await exportResultsToStream({
+        esClient,
+        index: 'test-index',
+        query: { match_all: {} },
+        formatter,
+        metadata,
+        aborted$,
+        logger,
+      });
+
+      await collectStream(result as NodeJS.ReadableStream);
+
+      const rowCalls = (formatter.row as jest.Mock).mock.calls;
+      expect(rowCalls[0][1]).toBe(true); // first row
+      expect(rowCalls[1][1]).toBe(false); // second row
+      expect(rowCalls[2][1]).toBe(false); // third row
+    });
+
+    it('should call closing() at the end of stream and write its output', async () => {
+      (esClient.search as jest.Mock)
+        .mockResolvedValueOnce({
+          hits: { hits: [createMockHit('1')], total: { value: 1 } },
+        })
+        .mockResolvedValueOnce({
+          hits: { hits: [], total: { value: 1 } },
+        });
+
+      const formatter = createMockFormatter();
+      (formatter.closing as jest.Mock).mockReturnValue(']}\n');
+
+      const result = await exportResultsToStream({
+        esClient,
+        index: 'test-index',
+        query: { match_all: {} },
+        formatter,
+        metadata,
+        aborted$,
+        logger,
+      });
+
+      const output = await collectStream(result as NodeJS.ReadableStream);
+
+      expect(formatter.closing).toHaveBeenCalled();
+      expect(output).toContain(']}\n');
+    });
+
+    it('should write opening content to stream when opening() returns non-null', async () => {
+      (esClient.search as jest.Mock).mockResolvedValueOnce({
+        hits: { hits: [], total: { value: 0 } },
+      });
+
+      const formatter = createMockFormatter();
+      (formatter.opening as jest.Mock).mockReturnValue('OPENING_CONTENT\n');
+
+      const result = await exportResultsToStream({
+        esClient,
+        index: 'test-index',
+        query: { match_all: {} },
+        formatter,
+        metadata,
+        aborted$,
+        logger,
+      });
+
+      const output = await collectStream(result as NodeJS.ReadableStream);
+
+      expect(output).toContain('OPENING_CONTENT');
+    });
+
+    it('should write nothing for opening when opening() returns null', async () => {
+      (esClient.search as jest.Mock).mockResolvedValueOnce({
+        hits: { hits: [], total: { value: 0 } },
+      });
+
+      const formatter = createMockFormatter();
+      (formatter.opening as jest.Mock).mockReturnValue(null);
+      (formatter.closing as jest.Mock).mockReturnValue(null);
+
+      const result = await exportResultsToStream({
+        esClient,
+        index: 'test-index',
+        query: { match_all: {} },
+        formatter,
+        metadata,
+        aborted$,
+        logger,
+      });
+
+      const output = await collectStream(result as NodeJS.ReadableStream);
+
+      expect(output).toBe('');
+    });
+
+    it('should track isFirst correctly across page boundaries', async () => {
+      const page1Hits = [createMockHit('p1-1')];
+      const page2Hits = [createMockHit('p2-1'), createMockHit('p2-2')];
+
+      (esClient.search as jest.Mock)
+        .mockResolvedValueOnce({
+          hits: { hits: page1Hits, total: { value: 3 } },
+        })
+        .mockResolvedValueOnce({
+          hits: { hits: page2Hits, total: { value: 3 } },
+        })
+        .mockResolvedValueOnce({
+          hits: { hits: [], total: { value: 3 } },
+        });
+
+      const formatter = createMockFormatter();
+      (formatter.opening as jest.Mock).mockReturnValue(null);
+
+      const result = await exportResultsToStream({
+        esClient,
+        index: 'test-index',
+        query: { match_all: {} },
+        formatter,
+        metadata,
+        aborted$,
+        logger,
+      });
+
+      await collectStream(result as NodeJS.ReadableStream);
+
+      const rowCalls = (formatter.row as jest.Mock).mock.calls;
+      expect(rowCalls).toHaveLength(3);
+      expect(rowCalls[0][1]).toBe(true); // first row across pages
+      expect(rowCalls[1][1]).toBe(false);
+      expect(rowCalls[2][1]).toBe(false);
+    });
+  });
+
+  describe('empty results', () => {
+    it('should return a stream (not error) when no results found', async () => {
+      (esClient.search as jest.Mock).mockResolvedValueOnce({
+        hits: { hits: [], total: { value: 0 } },
+      });
+
+      const result = await exportResultsToStream({
+        esClient,
+        index: 'test-index',
+        query: { match_all: {} },
+        formatter: createMockFormatter(),
+        metadata,
+        aborted$,
+        logger,
+      });
+
+      expect('statusCode' in result).toBe(false);
+      await collectStream(result as NodeJS.ReadableStream);
+    });
+
+    it('should write opening and closing but no rows when result set is empty', async () => {
+      (esClient.search as jest.Mock).mockResolvedValueOnce({
+        hits: { hits: [], total: { value: 0 } },
+      });
+
+      const formatter = createMockFormatter();
+      (formatter.closing as jest.Mock).mockReturnValue('CLOSING\n');
+
+      const result = await exportResultsToStream({
+        esClient,
+        index: 'test-index',
+        query: { match_all: {} },
+        formatter,
+        metadata,
+        aborted$,
+        logger,
+      });
+
+      const output = await collectStream(result as NodeJS.ReadableStream);
+
+      expect(formatter.row).not.toHaveBeenCalled();
+      expect(output).toContain('{"_meta":');
+      expect(output).toContain('CLOSING');
+    });
+
+    it('should produce a zero-byte body for CSV when result set is empty', async () => {
+      (esClient.search as jest.Mock).mockResolvedValueOnce({
+        hits: { hits: [], total: { value: 0 } },
+      });
+
+      const result = await exportResultsToStream({
+        esClient,
+        index: 'test-index',
+        query: { match_all: {} },
+        formatter: createCsvFormatter(),
+        metadata: { ...metadata, format: 'csv' },
+        aborted$,
+        logger,
+      });
+
+      const output = await collectStream(result as NodeJS.ReadableStream);
+
+      expect(output).toBe('');
+    });
+
+    it('should end stream cleanly when result set is empty', async () => {
+      (esClient.search as jest.Mock).mockResolvedValueOnce({
+        hits: { hits: [], total: { value: 0 } },
+      });
+
+      const result = await exportResultsToStream({
+        esClient,
+        index: 'test-index',
+        query: { match_all: {} },
+        formatter: createMockFormatter(),
+        metadata,
+        aborted$,
+        logger,
+      });
+
+      await expect(collectStream(result as NodeJS.ReadableStream)).resolves.toBeDefined();
+    });
+  });
+
+  describe('abort handling', () => {
+    it('should destroy the stream when aborted$ emits', async () => {
+      (esClient.search as jest.Mock).mockResolvedValueOnce({
+        hits: { hits: [createMockHit('1')], total: { value: 1 } },
+      });
+
+      const result = await exportResultsToStream({
+        esClient,
+        index: 'test-index',
+        query: { match_all: {} },
+        formatter: createMockFormatter(),
+        metadata,
+        aborted$,
+        logger,
+      });
+
+      aborted$.next();
+
+      expect((result as import('stream').PassThrough).destroyed).toBe(true);
+    });
+
+    it('should close PIT after abort and stream cleanup', async () => {
+      // Hold the second search so we can abort mid-stream
+      let resolveSecondSearch!: (value: unknown) => void;
+
+      (esClient.search as jest.Mock)
+        .mockResolvedValueOnce({
+          hits: { hits: [createMockHit('1')], total: { value: 2 } },
+        })
+        .mockImplementationOnce(
+          () =>
+            new Promise((resolve) => {
+              resolveSecondSearch = resolve;
+            })
+        );
+
+      const result = await exportResultsToStream({
+        esClient,
+        index: 'test-index',
+        query: { match_all: {} },
+        formatter: createMockFormatter(),
+        metadata,
+        aborted$,
+        logger,
+      });
+
+      // Let the stream start (setTimeout fires and first page processes)
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      // Abort while second search is pending
+      aborted$.next();
+      resolveSecondSearch({ hits: { hits: [], total: { value: 2 } } });
+
+      await waitForStreamClose(result as NodeJS.ReadableStream);
+
+      expect(esClient.closePointInTime).toHaveBeenCalled();
+    });
+
+    it('should not write rows after abort', async () => {
+      const hits = Array.from({ length: 5 }, (_, i) => createMockHit(String(i)));
+
+      (esClient.search as jest.Mock).mockResolvedValueOnce({
+        hits: { hits, total: { value: 5 } },
+      });
+
+      const formatter = createMockFormatter();
+
+      const result = await exportResultsToStream({
+        esClient,
+        index: 'test-index',
+        query: { match_all: {} },
+        formatter,
+        metadata,
+        aborted$,
+        logger,
+      });
+
+      // Abort before the deferred setTimeout fires
+      aborted$.next();
+
+      await waitForStreamClose(result as NodeJS.ReadableStream);
+
+      expect(formatter.row).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('ES search error mid-stream', () => {
+    it('should destroy the stream when search throws during pagination', async () => {
+      (esClient.search as jest.Mock)
+        .mockResolvedValueOnce({
+          hits: { hits: [createMockHit('1')], total: { value: 5 } },
+        })
+        .mockRejectedValueOnce(new Error('Connection reset'));
+
+      const result = await exportResultsToStream({
+        esClient,
+        index: 'test-index',
+        query: { match_all: {} },
+        formatter: createMockFormatter(),
+        metadata,
+        aborted$,
+        logger,
+      });
+
+      await waitForStreamClose(result as NodeJS.ReadableStream);
+
+      expect((result as import('stream').PassThrough).destroyed).toBe(true);
+    });
+
+    it('should log the error when search throws during streaming', async () => {
+      (esClient.search as jest.Mock)
+        .mockResolvedValueOnce({
+          hits: { hits: [createMockHit('1')], total: { value: 5 } },
+        })
+        .mockRejectedValueOnce(new Error('Shard failure'));
+
+      const result = await exportResultsToStream({
+        esClient,
+        index: 'test-index',
+        query: { match_all: {} },
+        formatter: createMockFormatter(),
+        metadata,
+        aborted$,
+        logger,
+      });
+
+      await waitForStreamClose(result as NodeJS.ReadableStream);
+
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining('Export stream error'),
+        expect.objectContaining({
+          labels: expect.objectContaining({ action_id: 'test-action' }),
+        })
+      );
+    });
+
+    it('should log structured labels (action_id, format, total_results) on stream error', async () => {
+      (esClient.search as jest.Mock)
+        .mockResolvedValueOnce({
+          hits: { hits: [createMockHit('1')], total: { value: 17 } },
+        })
+        .mockRejectedValueOnce(new Error('Connection reset'));
+
+      const result = await exportResultsToStream({
+        esClient,
+        index: 'test-index',
+        query: { match_all: {} },
+        formatter: createMockFormatter(),
+        metadata: {
+          action_id: 'action-log-test',
+          timestamp: '2024-01-01T00:00:00.000Z',
+          exported_by: 'test-user',
+          format: 'csv',
+        },
+        aborted$,
+        logger,
+      });
+
+      await waitForStreamClose(result as NodeJS.ReadableStream);
+
+      expect(logger.error).toHaveBeenCalledWith('Export stream error: Connection reset', {
+        labels: {
+          action_id: 'action-log-test',
+          format: 'csv',
+          total_results: 17,
+        },
+      });
+    });
+
+    it('should include execution_count in labels for scheduled-query exports', async () => {
+      (esClient.search as jest.Mock)
+        .mockResolvedValueOnce({
+          hits: { hits: [createMockHit('1')], total: { value: 3 } },
+        })
+        .mockRejectedValueOnce(new Error('Shard unavailable'));
+
+      const result = await exportResultsToStream({
+        esClient,
+        index: 'test-index',
+        query: { match_all: {} },
+        formatter: createMockFormatter(),
+        metadata: {
+          action_id: 'schedule-xyz',
+          timestamp: '2024-01-01T00:00:00.000Z',
+          exported_by: 'test-user',
+          format: 'ndjson',
+          execution_count: 42,
+        },
+        aborted$,
+        logger,
+      });
+
+      await waitForStreamClose(result as NodeJS.ReadableStream);
+
+      expect(logger.error).toHaveBeenCalledWith('Export stream error: Shard unavailable', {
+        labels: {
+          action_id: 'schedule-xyz',
+          format: 'ndjson',
+          total_results: 3,
+          execution_count: 42,
+        },
+      });
+    });
+
+    it('should not log error when stream is destroyed due to abort', async () => {
+      // Hold the second search so we control when it resolves
+      let resolveSecondSearch!: (value: unknown) => void;
+
+      (esClient.search as jest.Mock)
+        .mockResolvedValueOnce({
+          hits: { hits: [createMockHit('1')], total: { value: 2 } },
+        })
+        .mockImplementationOnce(
+          () =>
+            new Promise((resolve) => {
+              resolveSecondSearch = resolve;
+            })
+        );
+
+      const result = await exportResultsToStream({
+        esClient,
+        index: 'test-index',
+        query: { match_all: {} },
+        formatter: createMockFormatter(),
+        metadata,
+        aborted$,
+        logger,
+      });
+
+      // Allow stream loop to start
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      // Abort while second search is pending, then resolve it
+      aborted$.next();
+      resolveSecondSearch({ hits: { hits: [], total: { value: 2 } } });
+
+      await waitForStreamClose(result as NodeJS.ReadableStream);
+
+      expect(logger.error).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('backpressure handling', () => {
+    it('should pause and await drain when stream.write returns false', async () => {
+      const hits = [createMockHit('1'), createMockHit('2'), createMockHit('3')];
+
+      (esClient.search as jest.Mock)
+        .mockResolvedValueOnce({
+          hits: { hits, total: { value: 3 } },
+        })
+        .mockResolvedValueOnce({
+          hits: { hits: [], total: { value: 3 } },
+        });
+
+      const result = (await exportResultsToStream({
+        esClient,
+        index: 'test-index',
+        query: { match_all: {} },
+        formatter: createMockFormatter(),
+        metadata,
+        aborted$,
+        logger,
+      })) as import('stream').PassThrough;
+
+      // Intercept write() after the first row to return false, then emit 'drain'
+      // on the next tick so the loop can continue.
+      let writeCount = 0;
+      const realWrite = result.write.bind(result);
+      jest.spyOn(result, 'write').mockImplementation((chunk: unknown, ...rest: unknown[]) => {
+        writeCount += 1;
+        // Return false on row 2 so the loop awaits drain; accept normally for others.
+        if (writeCount === 3) {
+          // Schedule a drain emission on the next microtask.
+          setImmediate(() => result.emit('drain'));
+
+          return false;
+        }
+
+        return realWrite(chunk as string, ...(rest as []));
+      });
+
+      await collectStream(result);
+
+      // All 3 rows plus the opening write should have been attempted.
+      // Loop paused on write #3 and resumed after drain.
+      expect(writeCount).toBeGreaterThanOrEqual(4);
+    });
+
+    it('should not attach a drain listener when all writes succeed (fast consumer)', async () => {
+      const hits = [createMockHit('1'), createMockHit('2')];
+
+      (esClient.search as jest.Mock)
+        .mockResolvedValueOnce({
+          hits: { hits, total: { value: 2 } },
+        })
+        .mockResolvedValueOnce({
+          hits: { hits: [], total: { value: 2 } },
+        });
+
+      const result = (await exportResultsToStream({
+        esClient,
+        index: 'test-index',
+        query: { match_all: {} },
+        formatter: createMockFormatter(),
+        metadata,
+        aborted$,
+        logger,
+      })) as import('stream').PassThrough;
+
+      const onceSpy = jest.spyOn(result, 'once');
+
+      await collectStream(result);
+
+      // No drain listener should have been installed because every write
+      // returned true (real PassThrough default highWaterMark).
+      const drainListens = onceSpy.mock.calls.filter((call) => call[0] === 'drain');
+      expect(drainListens).toHaveLength(0);
+    });
+
+    it('should exit cleanly when abort fires while awaiting drain', async () => {
+      const hits = [createMockHit('1'), createMockHit('2'), createMockHit('3')];
+
+      (esClient.search as jest.Mock).mockResolvedValueOnce({
+        hits: { hits, total: { value: 3 } },
+      });
+
+      const result = (await exportResultsToStream({
+        esClient,
+        index: 'test-index',
+        query: { match_all: {} },
+        formatter: createMockFormatter(),
+        metadata,
+        aborted$,
+        logger,
+      })) as import('stream').PassThrough;
+
+      // Make the second write return false — and never emit drain. Abort fires instead.
+      let writeCount = 0;
+      jest.spyOn(result, 'write').mockImplementation(() => {
+        writeCount += 1;
+        if (writeCount === 2) {
+          // Fire abort once the loop is awaiting drain
+          setImmediate(() => aborted$.next());
+
+          return false;
+        }
+
+        return true;
+      });
+
+      await waitForStreamClose(result);
+
+      expect(result.destroyed).toBe(true);
+      expect(logger.error).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('openPointInTime error', () => {
+    it('should throw when openPointInTime fails', async () => {
+      (esClient.openPointInTime as jest.Mock).mockRejectedValueOnce(new Error('Index not found'));
+
+      await expect(
+        exportResultsToStream({
+          esClient,
+          index: 'test-index',
+          query: { match_all: {} },
+          formatter: createMockFormatter(),
+          metadata,
+          aborted$,
+          logger,
+        })
+      ).rejects.toThrow('Index not found');
+    });
+
+    it('should not attempt to close PIT when openPointInTime fails', async () => {
+      (esClient.openPointInTime as jest.Mock).mockRejectedValueOnce(new Error('Cluster down'));
+
+      await expect(
+        exportResultsToStream({
+          esClient,
+          index: 'test-index',
+          query: { match_all: {} },
+          formatter: createMockFormatter(),
+          metadata,
+          aborted$,
+          logger,
+        })
+      ).rejects.toThrow();
+
+      expect(esClient.closePointInTime).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/osquery/server/lib/export_results_to_stream.test.ts
+++ b/x-pack/platform/plugins/shared/osquery/server/lib/export_results_to_stream.test.ts
@@ -557,6 +557,47 @@ describe('exportResultsToStream', () => {
       ]);
     });
 
+    it('warns once when CSV pagination introduces a field absent from the first page', async () => {
+      const hit1 = createMockHit('1', { 'osquery.common': ['a'] });
+      const hit2 = createMockHit('2', {
+        'osquery.common': ['b'],
+        'osquery.appears_late': ['late'],
+      });
+
+      (esClient.search as jest.Mock)
+        .mockResolvedValueOnce({
+          hits: { hits: [hit1], total: { value: 2 } },
+        })
+        .mockResolvedValueOnce({
+          hits: { hits: [hit2], total: { value: 2 } },
+        })
+        .mockResolvedValueOnce({
+          hits: { hits: [], total: { value: 2 } },
+        });
+
+      const result = await exportResultsToStream({
+        esClient,
+        index: 'test-index',
+        query: { match_all: {} },
+        formatter: createCsvFormatter(),
+        metadata: { ...metadata, format: 'csv' },
+        aborted$,
+        logger,
+      });
+
+      await collectStream(result as NodeJS.ReadableStream);
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('first result page'),
+        expect.objectContaining({
+          labels: expect.objectContaining({
+            example_field: 'osquery.appears_late',
+            format: 'csv',
+          }),
+        })
+      );
+    });
+
     it('should call row() with isFirst=true for the first row and isFirst=false for subsequent rows', async () => {
       const hits = [createMockHit('1'), createMockHit('2'), createMockHit('3')];
 
@@ -746,7 +787,7 @@ describe('exportResultsToStream', () => {
       expect(output).toContain('CLOSING');
     });
 
-    it('should produce a zero-byte body for CSV when result set is empty', async () => {
+    it('should produce a zero-byte body for CSV when result set is empty and no csv_columns hint', async () => {
       (esClient.search as jest.Mock).mockResolvedValueOnce({
         hits: { hits: [], total: { value: 0 } },
       });
@@ -764,6 +805,30 @@ describe('exportResultsToStream', () => {
       const output = await collectStream(result as NodeJS.ReadableStream);
 
       expect(output).toBe('');
+    });
+
+    it('should emit CSV header only when result set is empty but csv_columns is provided', async () => {
+      (esClient.search as jest.Mock).mockResolvedValueOnce({
+        hits: { hits: [], total: { value: 0 } },
+      });
+
+      const result = await exportResultsToStream({
+        esClient,
+        index: 'test-index',
+        query: { match_all: {} },
+        formatter: createCsvFormatter(),
+        metadata: {
+          ...metadata,
+          format: 'csv',
+          csv_columns: ['agent.name', 'process.pid'],
+        },
+        aborted$,
+        logger,
+      });
+
+      const output = await collectStream(result as NodeJS.ReadableStream);
+
+      expect(output).toBe('agent.name,process.pid\n');
     });
 
     it('should end stream cleanly when result set is empty', async () => {

--- a/x-pack/platform/plugins/shared/osquery/server/lib/export_results_to_stream.ts
+++ b/x-pack/platform/plugins/shared/osquery/server/lib/export_results_to_stream.ts
@@ -179,6 +179,37 @@ export async function exportResultsToStream({
       formatter.finalizeColumns(firstPageRecords);
     }
 
+    const firstPageKeyUnion = new Set<string>();
+    for (const record of firstPageRecords) {
+      for (const key of Object.keys(record)) {
+        firstPageKeyUnion.add(key);
+      }
+    }
+
+    let warnedKeysBeyondFirstPage = false;
+    const warnIfRecordHasUnseenKeys = (record: Record<string, unknown>) => {
+      if (!formatter.finalizeColumns || warnedKeysBeyondFirstPage) return;
+      for (const key of Object.keys(record)) {
+        if (!firstPageKeyUnion.has(key)) {
+          warnedKeysBeyondFirstPage = true;
+          logger.warn(
+            'CSV export row contains field(s) not present in the first result page; those columns are omitted from the header and all rows.',
+            {
+              labels: {
+                action_id: metadata.action_id,
+                format: metadata.format,
+                example_field: key,
+                ...(metadata.execution_count != null
+                  ? { execution_count: metadata.execution_count }
+                  : {}),
+              },
+            }
+          );
+          break;
+        }
+      }
+    };
+
     // Defer streaming to the next macrotask tick so the route handler can
     // attach the returned PassThrough to the HTTP response before any writes
     // occur. A macrotask (setImmediate) rather than a microtask is required
@@ -230,6 +261,7 @@ export async function exportResultsToStream({
           for (const hit of page.hits.hits) {
             if (signal.aborted) break;
             const flattened = deduplicateFields(flattenOsqueryHit(hit, ecsMapping));
+            warnIfRecordHasUnseenKeys(flattened);
             await writeWithBackpressure(stream, formatter.row(flattened, isFirstRow), signal);
             isFirstRow = false;
           }

--- a/x-pack/platform/plugins/shared/osquery/server/lib/export_results_to_stream.ts
+++ b/x-pack/platform/plugins/shared/osquery/server/lib/export_results_to_stream.ts
@@ -19,6 +19,10 @@ import type { ResultFormatter, ExportMetadata } from './format_results';
 const EXPORT_PAGE_SIZE = 1_000;
 const MAX_EXPORT_RESULTS = 500_000;
 
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
 /**
  * Deduplicates osquery multi-field sub-fields (.text, .number) from a flattened record.
  * ES returns both `osquery.pid` (text) and `osquery.pid.number` (long) for the same value.
@@ -116,7 +120,7 @@ export async function exportResultsToStream({
       } catch (e) {
         // Leaked PITs consume cluster memory until keep_alive expires (5m).
         // Surface at warn so cluster-memory pressure is visible in ops dashboards.
-        logger.warn(`Failed to close PIT ${pitId}: ${e.message}`);
+        logger.warn(`Failed to close PIT ${pitId}: ${getErrorMessage(e)}`);
       }
 
       pitId = undefined;
@@ -245,7 +249,8 @@ export async function exportResultsToStream({
           // cannot be changed. Log structured meta so support can correlate the
           // truncated download with server state. `labels` is the ECS-standard
           // field for plugin-specific custom key/value pairs in log meta.
-          logger.error(`Export stream error: ${e.message}`, {
+          const errorMessage = getErrorMessage(e);
+          logger.error(`Export stream error: ${errorMessage}`, {
             labels: {
               action_id: enrichedMetadata.action_id,
               format: enrichedMetadata.format,
@@ -255,7 +260,7 @@ export async function exportResultsToStream({
                 : {}),
             },
           });
-          stream.destroy(e);
+          stream.destroy(e instanceof Error ? e : new Error(errorMessage));
         }
       } finally {
         await cleanup();

--- a/x-pack/platform/plugins/shared/osquery/server/lib/export_results_to_stream.ts
+++ b/x-pack/platform/plugins/shared/osquery/server/lib/export_results_to_stream.ts
@@ -1,0 +1,273 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { PassThrough } from 'stream';
+import { once } from 'events';
+
+import type { ElasticsearchClient, Logger } from '@kbn/core/server';
+import type { estypes } from '@elastic/elasticsearch';
+import type { Observable } from 'rxjs';
+import type { ECSMapping } from '@kbn/osquery-io-ts-types';
+
+import { flattenOsqueryHit } from '../../common/utils/flatten_osquery_hit';
+import type { ResultFormatter, ExportMetadata } from './format_results';
+
+const EXPORT_PAGE_SIZE = 1_000;
+const MAX_EXPORT_RESULTS = 500_000;
+
+/**
+ * Deduplicates osquery multi-field sub-fields (.text, .number) from a flattened record.
+ * ES returns both `osquery.pid` (text) and `osquery.pid.number` (long) for the same value.
+ * For exports, we keep the `.number` variant (typed) when it exists and drop `.text`,
+ * matching the deduplication logic in UnifiedResultsTable.
+ */
+function deduplicateFields(record: Record<string, unknown>): Record<string, unknown> {
+  const keys = Object.keys(record);
+  const result: Record<string, unknown> = {};
+
+  for (const key of keys) {
+    // Skip .text sub-fields — the parent field has the same value
+    if (key.endsWith('.text')) {
+      const parent = key.slice(0, -5);
+      if (parent in record) continue;
+    }
+
+    // Skip parent osquery.* fields when a .number sub-field exists (prefer typed value)
+    if (key.startsWith('osquery.') && !key.endsWith('.number') && !key.endsWith('.text')) {
+      if (`${key}.number` in record) continue;
+    }
+
+    result[key] = record[key];
+  }
+
+  return result;
+}
+
+/**
+ * Writes a chunk to a PassThrough and honours Node stream backpressure.
+ * If `write()` returns false, awaits the `drain` event before resolving.
+ * If the abort signal fires while awaiting drain, resolves without writing more.
+ */
+async function writeWithBackpressure(
+  stream: PassThrough,
+  chunk: string,
+  signal: AbortSignal
+): Promise<void> {
+  const ok = stream.write(chunk);
+  if (ok || signal.aborted) return;
+
+  try {
+    await once(stream, 'drain', { signal });
+  } catch {
+    // AbortError — the caller's loop checks `signal.aborted` and will exit cleanly.
+  }
+}
+
+export interface ExportResultsToStreamOptions {
+  esClient: ElasticsearchClient;
+  index: string;
+  query: estypes.QueryDslQueryContainer;
+  formatter: ResultFormatter;
+  metadata: ExportMetadata;
+  aborted$: Observable<void>;
+  logger: Logger;
+  /**
+   * ECS field mapping from the saved query / action. When provided, rows are
+   * enriched with ECS-mapped columns pulled from `_source` so that the export
+   * matches the UI's column set.
+   */
+  ecsMapping?: ECSMapping;
+}
+
+export interface ExportResultsError {
+  statusCode: number;
+  message: string;
+}
+
+export async function exportResultsToStream({
+  esClient,
+  index,
+  query,
+  formatter,
+  metadata,
+  aborted$,
+  logger,
+  ecsMapping,
+}: ExportResultsToStreamOptions): Promise<PassThrough | ExportResultsError> {
+  const stream = new PassThrough();
+  const abortController = new AbortController();
+
+  const abortSubscription = aborted$.subscribe(() => {
+    abortController.abort();
+    stream.destroy();
+  });
+
+  let pitId: string | undefined;
+
+  const cleanup = async () => {
+    abortSubscription.unsubscribe();
+    if (pitId) {
+      try {
+        await esClient.closePointInTime({ id: pitId });
+      } catch (e) {
+        // Leaked PITs consume cluster memory until keep_alive expires (5m).
+        // Surface at warn so cluster-memory pressure is visible in ops dashboards.
+        logger.warn(`Failed to close PIT ${pitId}: ${e.message}`);
+      }
+
+      pitId = undefined;
+    }
+  };
+
+  try {
+    const pitResponse = await esClient.openPointInTime(
+      {
+        index,
+        keep_alive: '5m',
+      },
+      { signal: abortController.signal }
+    );
+    pitId = pitResponse.id;
+
+    // First page — check total count
+    const firstPage = await esClient.search(
+      {
+        pit: { id: pitId, keep_alive: '5m' },
+        query,
+        size: EXPORT_PAGE_SIZE,
+        track_total_hits: true,
+        fields: ['elastic_agent.*', 'agent.*', 'osquery.*'],
+        sort: [{ '@timestamp': { order: 'desc' as const } }, '_doc'],
+        _source: ecsMapping ? true : ['agent'],
+      },
+      { signal: abortController.signal }
+    );
+
+    const total =
+      typeof firstPage.hits.total === 'number'
+        ? firstPage.hits.total
+        : firstPage.hits.total?.value ?? 0;
+
+    if (total > MAX_EXPORT_RESULTS) {
+      await cleanup();
+
+      return {
+        statusCode: 400,
+        message: `Export limited to ${MAX_EXPORT_RESULTS.toLocaleString()} results. Found ${total.toLocaleString()}. Please add filters to narrow results.`,
+      };
+    }
+
+    // Update metadata with total and start streaming asynchronously
+    const enrichedMetadata = { ...metadata, total_results: total };
+
+    // Pre-flatten first-page rows so formatters can pre-scan column shape
+    // before any bytes are written to the stream. This fixes the CSV header
+    // being locked to only row 1's keys — the CSV formatter now sees the
+    // column union of the first page.
+    const firstPageRecords = firstPage.hits.hits.map((hit) =>
+      deduplicateFields(flattenOsqueryHit(hit, ecsMapping))
+    );
+    if (formatter.finalizeColumns) {
+      formatter.finalizeColumns(firstPageRecords);
+    }
+
+    // Defer streaming to the next macrotask tick so the route handler can
+    // attach the returned PassThrough to the HTTP response before any writes
+    // occur. A macrotask (setImmediate) rather than a microtask is required
+    // because consumers (and tests) install listeners/spies on the returned
+    // stream synchronously after the await returns — a microtask would fire
+    // before those listeners are in place.
+    setImmediate(async () => {
+      const signal = abortController.signal;
+
+      try {
+        let isFirstRow = true;
+
+        // Write opening (metadata header, JSON opening bracket, etc.)
+        const opening = formatter.opening(enrichedMetadata);
+        if (opening) {
+          await writeWithBackpressure(stream, opening, signal);
+        }
+
+        // Process first page
+        for (const record of firstPageRecords) {
+          if (signal.aborted) break;
+          await writeWithBackpressure(stream, formatter.row(record, isFirstRow), signal);
+          isFirstRow = false;
+        }
+
+        // Get search_after from last hit
+        let searchAfter =
+          firstPage.hits.hits.length > 0
+            ? firstPage.hits.hits[firstPage.hits.hits.length - 1].sort
+            : undefined;
+
+        // Page through remaining results
+        while (searchAfter && !signal.aborted) {
+          const page = await esClient.search(
+            {
+              pit: { id: pitId!, keep_alive: '5m' },
+              query,
+              size: EXPORT_PAGE_SIZE,
+              fields: ['elastic_agent.*', 'agent.*', 'osquery.*'],
+              sort: [{ '@timestamp': { order: 'desc' as const } }, '_doc'],
+              search_after: searchAfter,
+              _source: ecsMapping ? true : ['agent'],
+            },
+            { signal }
+          );
+
+          if (page.hits.hits.length === 0) break;
+
+          for (const hit of page.hits.hits) {
+            if (signal.aborted) break;
+            const flattened = deduplicateFields(flattenOsqueryHit(hit, ecsMapping));
+            await writeWithBackpressure(stream, formatter.row(flattened, isFirstRow), signal);
+            isFirstRow = false;
+          }
+
+          searchAfter =
+            page.hits.hits.length > 0 ? page.hits.hits[page.hits.hits.length - 1].sort : undefined;
+        }
+
+        // Write closing (JSON closing bracket, etc.)
+        const closing = formatter.closing();
+        if (closing) {
+          await writeWithBackpressure(stream, closing, signal);
+        }
+      } catch (e) {
+        if (!signal.aborted) {
+          // Headers have already been sent by this point, so the HTTP status code
+          // cannot be changed. Log structured meta so support can correlate the
+          // truncated download with server state. `labels` is the ECS-standard
+          // field for plugin-specific custom key/value pairs in log meta.
+          logger.error(`Export stream error: ${e.message}`, {
+            labels: {
+              action_id: enrichedMetadata.action_id,
+              format: enrichedMetadata.format,
+              total_results: enrichedMetadata.total_results,
+              ...(enrichedMetadata.execution_count != null
+                ? { execution_count: enrichedMetadata.execution_count }
+                : {}),
+            },
+          });
+          stream.destroy(e);
+        }
+      } finally {
+        await cleanup();
+        if (!stream.destroyed) {
+          stream.end();
+        }
+      }
+    });
+
+    return stream;
+  } catch (e) {
+    await cleanup();
+    throw e;
+  }
+}

--- a/x-pack/platform/plugins/shared/osquery/server/lib/format_results.test.ts
+++ b/x-pack/platform/plugins/shared/osquery/server/lib/format_results.test.ts
@@ -124,9 +124,23 @@ describe('format_results', () => {
   });
 
   describe('createCsvFormatter', () => {
-    it('returns null from opening', () => {
+    it('returns null from opening when metadata format is not csv', () => {
       const formatter = createCsvFormatter();
       expect(formatter.opening(metadata)).toBeNull();
+    });
+
+    it('emits header-only CSV when total_results is zero and csv_columns is set', () => {
+      const formatter = createCsvFormatter();
+      formatter.finalizeColumns?.([]);
+      const csvMeta: ExportMetadata = {
+        action_id: 'a1',
+        timestamp: '2024-01-01T00:00:00.000Z',
+        exported_by: 'user',
+        format: 'csv',
+        total_results: 0,
+        csv_columns: ['agent.name', 'process.pid'],
+      };
+      expect(formatter.opening(csvMeta)).toBe('agent.name,process.pid\n');
     });
 
     it('returns null from closing (CSV is data-only)', () => {

--- a/x-pack/platform/plugins/shared/osquery/server/lib/format_results.test.ts
+++ b/x-pack/platform/plugins/shared/osquery/server/lib/format_results.test.ts
@@ -1,0 +1,218 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  createNdjsonFormatter,
+  createJsonFormatter,
+  createCsvFormatter,
+  createFormatter,
+} from './format_results';
+import type { ExportMetadata } from './format_results';
+
+const metadata: ExportMetadata = {
+  action_id: 'test-action-123',
+  query: 'SELECT pid, name FROM processes',
+  timestamp: '2024-01-01T00:00:00.000Z',
+  exported_by: 'analyst@elastic.co',
+  format: 'ndjson',
+  total_results: 42,
+};
+
+const record1 = { 'osquery.pid': 1234, 'osquery.name': 'kibana', 'agent.name': 'host-1' };
+const record2 = { 'osquery.pid': 5678, 'osquery.name': 'elastic-agent', 'agent.name': 'host-2' };
+
+describe('format_results', () => {
+  describe('createNdjsonFormatter', () => {
+    it('writes metadata as first line', () => {
+      const formatter = createNdjsonFormatter();
+      const opening = formatter.opening(metadata);
+      expect(opening).not.toBeNull();
+      const parsed = JSON.parse(opening!);
+      expect(parsed._meta.action_id).toBe('test-action-123');
+      expect(parsed._meta.total_results).toBe(42);
+    });
+
+    it('writes one JSON line per row', () => {
+      const formatter = createNdjsonFormatter();
+      const line = formatter.row(record1, true);
+      expect(line).toBe(JSON.stringify(record1) + '\n');
+    });
+
+    it('has no closing', () => {
+      const formatter = createNdjsonFormatter();
+      expect(formatter.closing()).toBeNull();
+    });
+
+    it('has correct content type and extension', () => {
+      const formatter = createNdjsonFormatter();
+      expect(formatter.contentType).toBe('application/ndjson');
+      expect(formatter.fileExtension).toBe('ndjson');
+    });
+  });
+
+  describe('createJsonFormatter', () => {
+    it('writes valid JSON array wrapper', () => {
+      const formatter = createJsonFormatter();
+      const opening = formatter.opening(metadata);
+      expect(opening).toContain('"_meta"');
+      expect(opening).toContain('"results":[');
+    });
+
+    it('does not prepend comma to first row', () => {
+      const formatter = createJsonFormatter();
+      const line = formatter.row(record1, true);
+      expect(line).not.toMatch(/^,/);
+      expect(line).toBe(JSON.stringify(record1) + '\n');
+    });
+
+    it('prepends comma to subsequent rows', () => {
+      const formatter = createJsonFormatter();
+      const line = formatter.row(record2, false);
+      expect(line).toBe(',' + JSON.stringify(record2) + '\n');
+    });
+
+    it('produces valid JSON when combined', () => {
+      const formatter = createJsonFormatter();
+      const output =
+        formatter.opening(metadata)! +
+        formatter.row(record1, true) +
+        formatter.row(record2, false) +
+        formatter.closing()!;
+      const parsed = JSON.parse(output);
+      expect(parsed._meta.action_id).toBe('test-action-123');
+      expect(parsed.results).toHaveLength(2);
+      expect(parsed.results[0]['osquery.pid']).toBe(1234);
+    });
+
+    it('produces valid JSON with empty results', () => {
+      const formatter = createJsonFormatter();
+      const output = formatter.opening(metadata)! + formatter.closing()!;
+      const parsed = JSON.parse(output);
+      expect(parsed.results).toEqual([]);
+    });
+
+    it('has correct content type and extension', () => {
+      const formatter = createJsonFormatter();
+      expect(formatter.contentType).toBe('application/json');
+      expect(formatter.fileExtension).toBe('json');
+    });
+  });
+
+  describe('createCsvFormatter', () => {
+    it('returns null from opening', () => {
+      const formatter = createCsvFormatter();
+      expect(formatter.opening(metadata)).toBeNull();
+    });
+
+    it('returns null from closing (CSV is data-only)', () => {
+      const formatter = createCsvFormatter();
+      formatter.opening(metadata);
+      formatter.row(record1, true);
+      expect(formatter.closing()).toBeNull();
+    });
+
+    it('emits only data when opening/row/closing are combined', () => {
+      const formatter = createCsvFormatter();
+      const opening = formatter.opening(metadata);
+      const firstRow = formatter.row(record1, true);
+      const secondRow = formatter.row(record2, false);
+      const closing = formatter.closing();
+
+      const output = (opening ?? '') + firstRow + secondRow + (closing ?? '');
+      const lines = output.split('\n').filter(Boolean);
+
+      expect(lines).toEqual([
+        'osquery.pid,osquery.name,agent.name',
+        '1234,kibana,host-1',
+        '5678,elastic-agent,host-2',
+      ]);
+      expect(output).not.toContain('_export.');
+      expect(output).not.toContain('_meta');
+    });
+
+    it('writes header row on first data row', () => {
+      const formatter = createCsvFormatter();
+      formatter.opening(metadata);
+      const row = formatter.row(record1, true);
+      const lines = row.split('\n').filter(Boolean);
+      expect(lines[0]).toBe('osquery.pid,osquery.name,agent.name');
+      expect(lines[1]).toBe('1234,kibana,host-1');
+    });
+
+    it('writes data without header on subsequent rows', () => {
+      const formatter = createCsvFormatter();
+      formatter.opening(metadata);
+      formatter.row(record1, true); // sets columns
+      const row = formatter.row(record2, false);
+      expect(row).toBe('5678,elastic-agent,host-2\n');
+    });
+
+    it('uses first-page column union order from finalizeColumns', () => {
+      const formatter = createCsvFormatter();
+      formatter.finalizeColumns?.([
+        { a: 'r1a', b: 'r1b' },
+        { b: 'r2b', c: 'r2c' },
+      ]);
+
+      const first = formatter.row({ b: 'rXb', c: 'rXc', a: 'rXa' }, true);
+      const next = formatter.row({ a: 'n1', c: 'n3' }, false);
+
+      expect(first).toBe('a,b,c\nrXa,rXb,rXc\n');
+      expect(next).toBe('n1,,n3\n');
+    });
+
+    it('escapes fields with commas', () => {
+      const formatter = createCsvFormatter();
+      const row = formatter.row({ field: 'value,with,commas' }, true);
+      expect(row).toContain('"value,with,commas"');
+    });
+
+    it('escapes fields with double quotes', () => {
+      const formatter = createCsvFormatter();
+      const row = formatter.row({ field: 'value "with" quotes' }, true);
+      expect(row).toContain('"value ""with"" quotes"');
+    });
+
+    it('quotes object values and escapes embedded newlines', () => {
+      const formatter = createCsvFormatter();
+      const row = formatter.row({ field: { note: 'line1\nline2' } }, true);
+      const lines = row.split('\n').filter(Boolean);
+      expect(lines[0]).toBe('field');
+      expect(lines[1]).toContain('"{""note"":""line1\\nline2""}"');
+    });
+
+    it('handles null and undefined values', () => {
+      const formatter = createCsvFormatter();
+      const row = formatter.row({ a: null, b: undefined, c: '' }, true);
+      const lines = row.split('\n').filter(Boolean);
+      expect(lines[1]).toBe(',,');
+    });
+
+    it('has correct content type and extension', () => {
+      const formatter = createCsvFormatter();
+      expect(formatter.contentType).toBe('text/csv');
+      expect(formatter.fileExtension).toBe('csv');
+    });
+  });
+
+  describe('createFormatter', () => {
+    it('returns ndjson formatter', () => {
+      const formatter = createFormatter('ndjson');
+      expect(formatter.contentType).toBe('application/ndjson');
+    });
+
+    it('returns json formatter', () => {
+      const formatter = createFormatter('json');
+      expect(formatter.contentType).toBe('application/json');
+    });
+
+    it('returns csv formatter', () => {
+      const formatter = createFormatter('csv');
+      expect(formatter.contentType).toBe('text/csv');
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/osquery/server/lib/format_results.test.ts
+++ b/x-pack/platform/plugins/shared/osquery/server/lib/format_results.test.ts
@@ -10,6 +10,8 @@ import {
   createJsonFormatter,
   createCsvFormatter,
   createFormatter,
+  parseExportFormat,
+  SUPPORTED_EXPORT_FORMATS,
 } from './format_results';
 import type { ExportMetadata } from './format_results';
 
@@ -26,6 +28,25 @@ const record1 = { 'osquery.pid': 1234, 'osquery.name': 'kibana', 'agent.name': '
 const record2 = { 'osquery.pid': 5678, 'osquery.name': 'elastic-agent', 'agent.name': 'host-2' };
 
 describe('format_results', () => {
+  describe('parseExportFormat', () => {
+    it('accepts supported formats', () => {
+      expect(parseExportFormat('ndjson')).toBe('ndjson');
+      expect(parseExportFormat('json')).toBe('json');
+      expect(parseExportFormat('csv')).toBe('csv');
+    });
+
+    it('returns undefined for invalid, empty, or missing values', () => {
+      expect(parseExportFormat('xml')).toBeUndefined();
+      expect(parseExportFormat('NDJSON')).toBeUndefined();
+      expect(parseExportFormat('')).toBeUndefined();
+      expect(parseExportFormat(undefined)).toBeUndefined();
+    });
+
+    it('lists every supported format in SUPPORTED_EXPORT_FORMATS', () => {
+      expect(SUPPORTED_EXPORT_FORMATS).toEqual(['ndjson', 'json', 'csv']);
+    });
+  });
+
   describe('createNdjsonFormatter', () => {
     it('writes metadata as first line', () => {
       const formatter = createNdjsonFormatter();

--- a/x-pack/platform/plugins/shared/osquery/server/lib/format_results.ts
+++ b/x-pack/platform/plugins/shared/osquery/server/lib/format_results.ts
@@ -7,6 +7,25 @@
 
 export type ExportFormat = 'ndjson' | 'json' | 'csv';
 
+/** Supported values for `format` query param; use with `parseExportFormat`. */
+export const SUPPORTED_EXPORT_FORMATS: readonly ExportFormat[] = ['ndjson', 'json', 'csv'] as const;
+
+/**
+ * Parses a request `format` string into a typed export format.
+ * Returns `undefined` when missing or not supported (caller should return 400).
+ */
+export function parseExportFormat(value: string | undefined): ExportFormat | undefined {
+  if (value === undefined || value === '') {
+    return undefined;
+  }
+
+  if ((SUPPORTED_EXPORT_FORMATS as readonly string[]).includes(value)) {
+    return value as ExportFormat;
+  }
+
+  return undefined;
+}
+
 export interface ExportMetadata {
   action_id: string;
   query?: string;
@@ -141,5 +160,9 @@ export function createFormatter(format: ExportFormat): ResultFormatter {
       return createJsonFormatter();
     case 'csv':
       return createCsvFormatter();
+    default: {
+      const exhaustive: never = format;
+      throw new Error(`Unsupported export format: ${String(exhaustive)}`);
+    }
   }
 }

--- a/x-pack/platform/plugins/shared/osquery/server/lib/format_results.ts
+++ b/x-pack/platform/plugins/shared/osquery/server/lib/format_results.ts
@@ -1,0 +1,145 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export type ExportFormat = 'ndjson' | 'json' | 'csv';
+
+export interface ExportMetadata {
+  action_id: string;
+  query?: string;
+  timestamp: string;
+  exported_by: string;
+  format: ExportFormat;
+  total_results?: number;
+  /** Schedule execution count — only set for scheduled-query exports. */
+  execution_count?: number;
+}
+
+export interface ResultFormatter {
+  opening: (metadata: ExportMetadata) => string | null;
+  row: (record: Record<string, unknown>, isFirst: boolean) => string;
+  closing: () => string | null;
+  contentType: string;
+  fileExtension: string;
+  /**
+   * Optional pre-scan hook. Called once with all first-page records before any
+   * bytes are written so the formatter can compute stable state (e.g. the CSV
+   * column union) from more than just row 1. Heterogeneous osquery tables
+   * across agents frequently have columns that only appear in later rows, so
+   * a single-row capture would silently drop fields.
+   */
+  finalizeColumns?: (firstPageRecords: Array<Record<string, unknown>>) => void;
+}
+
+// --- NDJSON ---
+
+export function createNdjsonFormatter(): ResultFormatter {
+  return {
+    contentType: 'application/ndjson',
+    fileExtension: 'ndjson',
+    opening(metadata) {
+      return JSON.stringify({ _meta: metadata }) + '\n';
+    },
+    row(record) {
+      return JSON.stringify(record) + '\n';
+    },
+    closing() {
+      return null;
+    },
+  };
+}
+
+// --- JSON ---
+
+export function createJsonFormatter(): ResultFormatter {
+  return {
+    contentType: 'application/json',
+    fileExtension: 'json',
+    opening(metadata) {
+      return `{"_meta":${JSON.stringify(metadata)},"results":[\n`;
+    },
+    row(record, isFirst) {
+      const line = JSON.stringify(record);
+
+      return isFirst ? line + '\n' : ',' + line + '\n';
+    },
+    closing() {
+      return ']}\n';
+    },
+  };
+}
+
+// --- CSV ---
+
+function escapeCsvField(value: unknown): string {
+  if (value === null || value === undefined) {
+    return '';
+  }
+
+  const str = typeof value === 'object' ? JSON.stringify(value) : String(value);
+
+  // Quote if the field contains comma, double-quote, newline, or carriage return
+  if (str.includes(',') || str.includes('"') || str.includes('\n') || str.includes('\r')) {
+    return '"' + str.replace(/"/g, '""') + '"';
+  }
+
+  return str;
+}
+
+export function createCsvFormatter(): ResultFormatter {
+  let columns: string[] | null = null;
+
+  return {
+    contentType: 'text/csv',
+    fileExtension: 'csv',
+    finalizeColumns(firstPageRecords) {
+      const seen = new Set<string>();
+      const union: string[] = [];
+      // Preserve insertion order — first occurrence wins — so the column
+      // ordering matches the first row's shape with extras appended.
+      for (const record of firstPageRecords) {
+        for (const key of Object.keys(record)) {
+          if (!seen.has(key)) {
+            seen.add(key);
+            union.push(key);
+          }
+        }
+      }
+
+      columns = union;
+    },
+    opening() {
+      return null;
+    },
+    row(record, isFirst) {
+      if (isFirst) {
+        if (!columns) columns = Object.keys(record);
+        const header = columns.map(escapeCsvField).join(',') + '\n';
+        const row = columns.map((col) => escapeCsvField(record[col])).join(',') + '\n';
+
+        return header + row;
+      }
+
+      if (!columns) columns = Object.keys(record);
+
+      return columns.map((col) => escapeCsvField(record[col])).join(',') + '\n';
+    },
+    closing() {
+      return null;
+    },
+  };
+}
+
+export function createFormatter(format: ExportFormat): ResultFormatter {
+  switch (format) {
+    case 'ndjson':
+      return createNdjsonFormatter();
+    case 'json':
+      return createJsonFormatter();
+    case 'csv':
+      return createCsvFormatter();
+  }
+}

--- a/x-pack/platform/plugins/shared/osquery/server/lib/format_results.ts
+++ b/x-pack/platform/plugins/shared/osquery/server/lib/format_results.ts
@@ -35,6 +35,11 @@ export interface ExportMetadata {
   total_results?: number;
   /** Schedule execution count — only set for scheduled-query exports. */
   execution_count?: number;
+  /**
+   * When set (CSV + ECS mapping + zero hits), `opening` emits this header row so
+   * an empty export is not a 0-byte file. Column order matches `flattenOsqueryHit`.
+   */
+  csv_columns?: string[];
 }
 
 export interface ResultFormatter {
@@ -130,7 +135,18 @@ export function createCsvFormatter(): ResultFormatter {
 
       columns = union;
     },
-    opening() {
+    opening(metadata) {
+      if (
+        metadata.format === 'csv' &&
+        metadata.total_results === 0 &&
+        metadata.csv_columns &&
+        metadata.csv_columns.length > 0
+      ) {
+        columns = [...metadata.csv_columns];
+
+        return metadata.csv_columns.map(escapeCsvField).join(',') + '\n';
+      }
+
       return null;
     },
     row(record, isFirst) {

--- a/x-pack/platform/plugins/shared/osquery/server/routes/export/create_export_route_handler.test.ts
+++ b/x-pack/platform/plugins/shared/osquery/server/routes/export/create_export_route_handler.test.ts
@@ -1,0 +1,167 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { PassThrough } from 'stream';
+import { NEVER, of } from 'rxjs';
+import type { KibanaRequest } from '@kbn/core/server';
+import { httpServerMock } from '@kbn/core/server/mocks';
+import { loggingSystemMock } from '@kbn/core-logging-server-mocks';
+import type { DataRequestHandlerContext } from '@kbn/data-plugin/server';
+import type { RequestHandlerContext } from '@kbn/core-http-request-handler-context-server';
+
+import { allowedExperimentalValues } from '../../../common';
+import type { OsqueryAppContext } from '../../lib/osquery_app_context_services';
+import { createExportRouteHandler, type ExportRouteParams } from './create_export_route_handler';
+
+jest.mock('../../lib/export_results_to_stream', () => ({
+  exportResultsToStream: jest.fn(),
+}));
+
+jest.mock('../../lib/get_user_info', () => ({
+  getUserInfo: jest.fn().mockResolvedValue({ username: 'test-user' }),
+}));
+
+jest.mock('../../utils/get_internal_saved_object_client', () => ({
+  createInternalSavedObjectsClientForSpaceId: jest.fn().mockResolvedValue({}),
+}));
+
+import { exportResultsToStream } from '../../lib/export_results_to_stream';
+
+const mockExportResultsToStream = exportResultsToStream as jest.MockedFunction<
+  typeof exportResultsToStream
+>;
+
+const auditLoggerLog = jest.fn();
+
+const baseParams: ExportRouteParams = {
+  baseFilter: 'action_id: "abc"',
+  metadata: { action_id: 'abc', query: 'SELECT 1' },
+  fileNamePrefix: 'osquery-results-test',
+};
+
+const createContext = () =>
+  ({
+    core: Promise.resolve({
+      elasticsearch: {
+        client: {
+          asCurrentUser: {},
+        },
+      },
+      security: {
+        audit: {
+          logger: {
+            log: auditLoggerLog,
+          },
+        },
+      },
+    }),
+  } as unknown as RequestHandlerContext & DataRequestHandlerContext);
+
+type ExportHandlerRequest = KibanaRequest<
+  unknown,
+  { format?: string },
+  { kuery?: string; agentIds?: string[]; esFilters?: unknown[] } | null
+>;
+
+const createExportRequest = (options: {
+  query?: Record<string, string | undefined>;
+  body?: Record<string, unknown> | null;
+}): ExportHandlerRequest =>
+  ({
+    ...httpServerMock.createKibanaRequest({
+      query: options.query ?? {},
+      body: options.body ?? {},
+    }),
+    events: { aborted$: of(), completed$: NEVER },
+  } as unknown as ExportHandlerRequest);
+
+const createOsqueryContext = (exportResults: boolean): OsqueryAppContext =>
+  ({
+    logFactory: { get: () => loggingSystemMock.createLogger() },
+    experimentalFeatures: { ...allowedExperimentalValues, exportResults },
+    security: {} as OsqueryAppContext['security'],
+    service: {
+      getIntegrationNamespaces: undefined,
+    },
+    getStartServices: jest.fn(),
+    config: jest.fn(),
+    telemetryEventsSender: {},
+    licensing: {},
+  } as unknown as OsqueryAppContext);
+
+describe('createExportRouteHandler', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    auditLoggerLog.mockClear();
+    const stream = new PassThrough();
+    stream.end();
+    mockExportResultsToStream.mockResolvedValue(stream);
+  });
+
+  it('returns forbidden when exportResults experimental flag is disabled', async () => {
+    const handler = createExportRouteHandler(createOsqueryContext(false));
+    const response = httpServerMock.createResponseFactory();
+    const request = createExportRequest({
+      query: { format: 'csv' },
+      body: {},
+    });
+
+    await handler(createContext(), request, response, baseParams);
+
+    expect(response.forbidden).toHaveBeenCalledWith({
+      body: { message: 'Export results feature is not enabled' },
+    });
+    expect(mockExportResultsToStream).not.toHaveBeenCalled();
+  });
+
+  it('returns badRequest when kuery is invalid', async () => {
+    const handler = createExportRouteHandler(createOsqueryContext(true));
+    const response = httpServerMock.createResponseFactory();
+    const request = createExportRequest({
+      query: { format: 'csv' },
+      body: { kuery: 'field: "' },
+    });
+
+    await handler(createContext(), request, response, baseParams);
+
+    expect(response.badRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({
+          message: expect.stringMatching(/^Invalid kuery:/),
+        }),
+      })
+    );
+    expect(mockExportResultsToStream).not.toHaveBeenCalled();
+  });
+
+  it('writes an audit event when export succeeds', async () => {
+    const handler = createExportRouteHandler(createOsqueryContext(true));
+    const response = httpServerMock.createResponseFactory();
+    const request = createExportRequest({
+      query: { format: 'ndjson' },
+      body: {},
+    });
+
+    await handler(createContext(), request, response, baseParams);
+
+    expect(auditLoggerLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: 'Osquery export started',
+        event: expect.objectContaining({
+          action: 'osquery_export',
+          category: ['database'],
+          type: ['access'],
+        }),
+        labels: expect.objectContaining({
+          action_id: 'abc',
+          format: 'ndjson',
+        }),
+      })
+    );
+    expect(response.ok).toHaveBeenCalled();
+  });
+});

--- a/x-pack/platform/plugins/shared/osquery/server/routes/export/create_export_route_handler.ts
+++ b/x-pack/platform/plugins/shared/osquery/server/routes/export/create_export_route_handler.ts
@@ -1,0 +1,176 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { KibanaRequest, KibanaResponseFactory } from '@kbn/core/server';
+import type { DataRequestHandlerContext } from '@kbn/data-plugin/server';
+import type { RequestHandlerContext } from '@kbn/core-http-request-handler-context-server';
+import type { estypes } from '@elastic/elasticsearch';
+import type { ECSMapping } from '@kbn/osquery-io-ts-types';
+
+import type { Filter } from '@kbn/es-query';
+import { buildQueryFromFilters } from '@kbn/es-query';
+
+import { escapeKuery } from '@kbn/es-query';
+import { OSQUERY_INTEGRATION_NAME } from '../../../common';
+import { getQueryFilter } from '../../utils/build_query';
+import { buildIndexNameWithNamespace } from '../../utils/build_index_name_with_namespace';
+import { createInternalSavedObjectsClientForSpaceId } from '../../utils/get_internal_saved_object_client';
+import { exportResultsToStream } from '../../lib/export_results_to_stream';
+import { createFormatter } from '../../lib/format_results';
+import type { ExportFormat, ExportMetadata } from '../../lib/format_results';
+import { getUserInfo } from '../../lib/get_user_info';
+import type { OsqueryAppContext } from '../../lib/osquery_app_context_services';
+
+export interface ExportRouteParams {
+  /** KQL base filter (e.g. `action_id: "abc"` or `schedule_id: "x" AND ...`) */
+  baseFilter: string;
+  /** Metadata fields specific to this export type */
+  metadata: Pick<ExportMetadata, 'action_id' | 'query' | 'execution_count'>;
+  /** Filename prefix (e.g. `osquery-results-{id}` or `osquery-scheduled-results-{id}-{count}`) */
+  fileNamePrefix: string;
+  /**
+   * ECS mapping from the originating action/saved query. Plumbed into the
+   * row-flattener so the export surfaces the same ECS-mapped columns users
+   * see in the UI.
+   */
+  ecsMapping?: ECSMapping;
+}
+
+export const createExportRouteHandler =
+  (osqueryContext: OsqueryAppContext) =>
+  async (
+    context: RequestHandlerContext & DataRequestHandlerContext,
+    request: KibanaRequest<
+      unknown,
+      { format: string },
+      { kuery?: string; agentIds?: string[]; esFilters?: unknown[] } | null
+    >,
+    response: KibanaResponseFactory,
+    params: ExportRouteParams
+  ) => {
+    const { baseFilter, metadata: routeMetadata, fileNamePrefix, ecsMapping } = params;
+    const format = request.query.format as ExportFormat;
+    const kuery = request.body?.kuery;
+    const agentIds = request.body?.agentIds;
+    const esFilters = request.body?.esFilters;
+
+    const logger = osqueryContext.logFactory.get('export_results');
+
+    // Build filter query. Every clause is wrapped in parens defensively so
+    // that KQL precedence cannot allow a user-supplied `kuery` to escape the
+    // action_id / schedule_id gate (e.g. `foo OR action_id: "other"`).
+    let filter = `(${baseFilter})`;
+    if (agentIds && agentIds.length > 0) {
+      const agentFilter = agentIds.map((id) => `agent.id: ${escapeKuery(id)}`).join(' OR ');
+      filter += ` AND (${agentFilter})`;
+    }
+
+    if (kuery) {
+      filter += ` AND (${kuery})`;
+    }
+
+    const kqlFilterClause = getQueryFilter({ filter });
+
+    // Build ES filter clauses from SearchBar filter pills. An invalid pill must
+    // NOT fall through to an unfiltered export — silently returning the full
+    // dataset when the user asked for a narrowed one is a correctness hazard.
+    let esFilterClauses: estypes.QueryDslQueryContainer[] = [];
+    if (esFilters && esFilters.length > 0) {
+      try {
+        const built = buildQueryFromFilters(esFilters as unknown as Filter[], undefined);
+        esFilterClauses = built.filter as estypes.QueryDslQueryContainer[];
+      } catch (e) {
+        logger.warn(`Invalid esFilters in export request: ${e.message}`);
+
+        return response.badRequest({
+          body: {
+            message: `Invalid esFilters: ${e.message}`,
+          },
+        });
+      }
+    }
+
+    // Resolve space-aware index
+    let index = `logs-${OSQUERY_INTEGRATION_NAME}.result*`;
+
+    if (osqueryContext?.service?.getIntegrationNamespaces) {
+      const spaceScopedClient = await createInternalSavedObjectsClientForSpaceId(
+        osqueryContext,
+        request
+      );
+      const integrationNamespaces = await osqueryContext.service.getIntegrationNamespaces(
+        [OSQUERY_INTEGRATION_NAME],
+        spaceScopedClient,
+        logger
+      );
+
+      const osqueryNamespaces = integrationNamespaces[OSQUERY_INTEGRATION_NAME];
+      if (osqueryNamespaces && osqueryNamespaces.length > 0) {
+        index = osqueryNamespaces
+          .map((namespace) =>
+            buildIndexNameWithNamespace(`logs-${OSQUERY_INTEGRATION_NAME}.result*`, namespace)
+          )
+          .join(',');
+      }
+    }
+
+    // Get user info for metadata
+    const user = await getUserInfo({
+      request,
+      security: osqueryContext.security,
+      logger,
+    });
+
+    const coreContext = await context.core;
+    const esClient = coreContext.elasticsearch.client.asCurrentUser;
+
+    const formatter = createFormatter(format);
+    const timestamp = new Date().toISOString();
+    const fileName = `${fileNamePrefix}-${timestamp.replace(/[:.]/g, '-')}.${
+      formatter.fileExtension
+    }`;
+
+    const result = await exportResultsToStream({
+      esClient,
+      index,
+      query: { bool: { filter: [kqlFilterClause, ...esFilterClauses] } },
+      formatter,
+      metadata: {
+        ...routeMetadata,
+        timestamp,
+        exported_by: user?.username ?? 'unknown',
+        format,
+      },
+      aborted$: request.events.aborted$,
+      logger,
+      ecsMapping,
+    });
+
+    // Check if we got an error (max results exceeded)
+    if ('statusCode' in result) {
+      return response.badRequest({
+        body: { message: result.message },
+      });
+    }
+
+    // Audit trail for data egress. Export streams complete asynchronously after
+    // this handler returns, so this is a "started" entry; the stream itself
+    // logs per-export errors separately with the same action_id correlation.
+    logger.info(
+      `Osquery export started: action_id=${routeMetadata.action_id} format=${format} user=${
+        user?.username ?? 'unknown'
+      } execution_count=${routeMetadata.execution_count ?? 'n/a'}`
+    );
+
+    return response.ok({
+      body: result,
+      headers: {
+        'Content-Disposition': `attachment; filename="${fileName}"`,
+        'Content-Type': formatter.contentType,
+      },
+    });
+  };

--- a/x-pack/platform/plugins/shared/osquery/server/routes/export/create_export_route_handler.ts
+++ b/x-pack/platform/plugins/shared/osquery/server/routes/export/create_export_route_handler.ts
@@ -10,6 +10,7 @@ import type { DataRequestHandlerContext } from '@kbn/data-plugin/server';
 import type { RequestHandlerContext } from '@kbn/core-http-request-handler-context-server';
 import type { estypes } from '@elastic/elasticsearch';
 import type { ECSMapping } from '@kbn/osquery-io-ts-types';
+import type { AuditEvent } from '@kbn/core-security-server';
 
 import type { Filter } from '@kbn/es-query';
 import { buildQueryFromFilters } from '@kbn/es-query';
@@ -50,7 +51,7 @@ export const createExportRouteHandler =
     context: RequestHandlerContext & DataRequestHandlerContext,
     request: KibanaRequest<
       unknown,
-      { format: string },
+      { format?: string },
       { kuery?: string; agentIds?: string[]; esFilters?: unknown[] } | null
     >,
     response: KibanaResponseFactory,
@@ -63,6 +64,12 @@ export const createExportRouteHandler =
     const esFilters = request.body?.esFilters;
 
     const logger = osqueryContext.logFactory.get('export_results');
+
+    if (!osqueryContext.experimentalFeatures.exportResults) {
+      return response.forbidden({
+        body: { message: 'Export results feature is not enabled' },
+      });
+    }
 
     if (!format) {
       return response.badRequest({
@@ -85,7 +92,17 @@ export const createExportRouteHandler =
       filter += ` AND (${kuery})`;
     }
 
-    const kqlFilterClause = getQueryFilter({ filter });
+    let kqlFilterClause: estypes.QueryDslQueryContainer;
+    try {
+      kqlFilterClause = getQueryFilter({ filter });
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      logger.warn(`Invalid kuery in export request: ${message}`);
+
+      return response.badRequest({
+        body: { message: `Invalid kuery: ${message}` },
+      });
+    }
 
     // Build ES filter clauses from SearchBar filter pills. An invalid pill must
     // NOT fall through to an unfiltered export — silently returning the full
@@ -147,6 +164,11 @@ export const createExportRouteHandler =
       formatter.fileExtension
     }`;
 
+    const csvColumnsForEmptyExport =
+      format === 'csv' && ecsMapping
+        ? (['agent.name', 'agent.id', ...Object.keys(ecsMapping)] as string[])
+        : undefined;
+
     const result = await exportResultsToStream({
       esClient,
       index,
@@ -157,6 +179,7 @@ export const createExportRouteHandler =
         timestamp,
         exported_by: user?.username ?? 'unknown',
         format,
+        ...(csvColumnsForEmptyExport ? { csv_columns: csvColumnsForEmptyExport } : {}),
       },
       aborted$: request.events.aborted$,
       logger,
@@ -170,14 +193,26 @@ export const createExportRouteHandler =
       });
     }
 
-    // Audit trail for data egress. Export streams complete asynchronously after
-    // this handler returns, so this is a "started" entry; the stream itself
-    // logs per-export errors separately with the same action_id correlation.
-    logger.info(
-      `Osquery export started: action_id=${routeMetadata.action_id} format=${format} user=${
-        user?.username ?? 'unknown'
-      } execution_count=${routeMetadata.execution_count ?? 'n/a'}`
-    );
+    // Audit trail for data egress (no PII in application logs). Stream errors
+    // are logged separately with action_id correlation. Use Core request context
+    // (not deprecated plugins.security.audit).
+    const auditEvent: AuditEvent = {
+      message: 'Osquery export started',
+      event: {
+        action: 'osquery_export',
+        category: ['database'],
+        type: ['access'],
+        outcome: 'unknown',
+      },
+      labels: {
+        action_id: routeMetadata.action_id,
+        format,
+        ...(routeMetadata.execution_count != null
+          ? { execution_count: routeMetadata.execution_count }
+          : {}),
+      },
+    };
+    coreContext.security.audit.logger.log(auditEvent);
 
     return response.ok({
       body: result,

--- a/x-pack/platform/plugins/shared/osquery/server/routes/export/create_export_route_handler.ts
+++ b/x-pack/platform/plugins/shared/osquery/server/routes/export/create_export_route_handler.ts
@@ -20,8 +20,12 @@ import { getQueryFilter } from '../../utils/build_query';
 import { buildIndexNameWithNamespace } from '../../utils/build_index_name_with_namespace';
 import { createInternalSavedObjectsClientForSpaceId } from '../../utils/get_internal_saved_object_client';
 import { exportResultsToStream } from '../../lib/export_results_to_stream';
-import { createFormatter } from '../../lib/format_results';
-import type { ExportFormat, ExportMetadata } from '../../lib/format_results';
+import {
+  createFormatter,
+  parseExportFormat,
+  SUPPORTED_EXPORT_FORMATS,
+} from '../../lib/format_results';
+import type { ExportMetadata } from '../../lib/format_results';
 import { getUserInfo } from '../../lib/get_user_info';
 import type { OsqueryAppContext } from '../../lib/osquery_app_context_services';
 
@@ -53,12 +57,20 @@ export const createExportRouteHandler =
     params: ExportRouteParams
   ) => {
     const { baseFilter, metadata: routeMetadata, fileNamePrefix, ecsMapping } = params;
-    const format = request.query.format as ExportFormat;
+    const format = parseExportFormat(request.query.format);
     const kuery = request.body?.kuery;
     const agentIds = request.body?.agentIds;
     const esFilters = request.body?.esFilters;
 
     const logger = osqueryContext.logFactory.get('export_results');
+
+    if (!format) {
+      return response.badRequest({
+        body: {
+          message: `Invalid format: must be one of ${SUPPORTED_EXPORT_FORMATS.join(', ')}`,
+        },
+      });
+    }
 
     // Build filter query. Every clause is wrapped in parens defensively so
     // that KQL precedence cannot allow a user-supplied `kuery` to escape the
@@ -84,11 +96,12 @@ export const createExportRouteHandler =
         const built = buildQueryFromFilters(esFilters as unknown as Filter[], undefined);
         esFilterClauses = built.filter as estypes.QueryDslQueryContainer[];
       } catch (e) {
-        logger.warn(`Invalid esFilters in export request: ${e.message}`);
+        const message = e instanceof Error ? e.message : String(e);
+        logger.warn(`Invalid esFilters in export request: ${message}`);
 
         return response.badRequest({
           body: {
-            message: `Invalid esFilters: ${e.message}`,
+            message: `Invalid esFilters: ${message}`,
           },
         });
       }

--- a/x-pack/platform/plugins/shared/osquery/tsconfig.json
+++ b/x-pack/platform/plugins/shared/osquery/tsconfig.json
@@ -95,6 +95,8 @@
     "@kbn/core-notifications-browser",
     "@kbn/core-chrome-browser",
     "@kbn/scout",
-    "@kbn/core-http-browser"
+    "@kbn/core-http-browser",
+    "@kbn/core-logging-server-mocks",
+    "@kbn/core-http-request-handler-context-server"
   ]
 }

--- a/x-pack/platform/plugins/shared/osquery/tsconfig.json
+++ b/x-pack/platform/plugins/shared/osquery/tsconfig.json
@@ -97,6 +97,7 @@
     "@kbn/scout",
     "@kbn/core-http-browser",
     "@kbn/core-logging-server-mocks",
-    "@kbn/core-http-request-handler-context-server"
+    "@kbn/core-http-request-handler-context-server",
+    "@kbn/core-security-server"
   ]
 }


### PR DESCRIPTION
## Summary

This PR introduces the backend foundation for osquery result export as the first slice of the implementation. 

- Adds a new `exportResults` experimental flag in `common/experimental_features.ts` (default `false`).
- Moves shared flattening utilities from UI-only code to `common/utils/flatten_osquery_hit.ts` and keeps re-exports in `public/results/transform_results.ts` for backward compatibility.
- Introduces core streaming export infrastructure in `server/lib/export_results_to_stream.ts`:
  - PIT lifecycle management
  - `search_after` pagination
  - request abort cleanup
  - 500k guardrail
  - backpressure-aware streaming writes
  - osquery field deduplication (`.text` removal / `.number` preference)
- Adds format converters in `server/lib/format_results.ts` for `ndjson`, `json`, and `csv`.
- Adds shared route-handler scaffold in `server/routes/export/create_export_route_handler.ts` (actual route registration/API endpoints intentionally deferred to phase 3+4).
- Updates plugin dependencies in `moon.yml` and `tsconfig.json` for new test/runtime imports.


```mermaid
flowchart TB
  subgraph config["Configuration & shared types"]
    EF["common/experimental_features.ts<br/>exportResults: false"]
  end

  subgraph common_layer["Common (browser + server)"]
    FO["common/utils/flatten_osquery_hit.ts<br/>flattenOsqueryHit, getNestedOrFlat"]
  end

  subgraph public_layer["Public (UI)"]
    TR["public/results/transform_results.ts<br/>re-exports from common"]
  end

  subgraph server_format["Server — serialization"]
    FR["server/lib/format_results.ts<br/>parseExportFormat, createFormatter<br/>NDJSON / JSON / CSV"]
  end

  subgraph server_stream["Server — Elasticsearch streaming"]
    ERS["server/lib/export_results_to_stream.ts<br/>PIT + search_after, 500k cap<br/>abort, backpressure, field dedup"]
  end

  subgraph server_route["Server — HTTP scaffold (phase 3+4: wire routes)"]
    CEH["server/routes/export/create_export_route_handler.ts"]
  end

  subgraph deferred["Not in phase 1+2"]
    HTTP["POST …/_export routes"]
    UI["UI entry points"]
  end

  EF -.-> HTTP
  EF -.-> UI

  FO --> TR
  FO --> ERS
  FR --> ERS
  FR --> CEH
  ERS --> CEH
  CEH -.-> HTTP
  ```

## Scope in this phase

Included:
- Foundation flag + shared flatten helper extraction
- Stream core + format converters
- Shared handler factory/scaffold
- Unit tests for all above

Not included:
- Public export API route registration and API integration tests (phase 3+4)
- UI entry points (kebab menu/modal/hook/table integration) (phase 5+6)


## Closes

Closes: https://github.com/elastic/security-team/issues/16761 
Closes: https://github.com/elastic/security-team/issues/16762

## Follow-ups

- Phase 3+4 PR: export request schema + live/scheduled routes + route wiring + API tests.
- Phase 5+6 PR: UI integration (kebab/modal/hook/results table) + UI tests.
