### PR TITLE
[9.4] [One Workflow] immediate PENDING workflows cancellation (#264288)

### DIFF
--- a/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/run_workflow.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/run_workflow.test.ts
@@ -34,7 +34,19 @@ describe('runWorkflow', () => {
   let mockGetLastFailedStepContext: jest.Mock;
   let mockGetWorkflowExecutionStatus: jest.Mock;
   let mockGetWorkflowExecution: jest.Mock;
+  let mockGetWorkflowExecutionFromState: jest.Mock;
   let mockEmitEvent: jest.Mock;
+  let mockRuntimeStart: jest.Mock;
+
+  const nonTerminalExecutionForFreshFetch = {
+    id: workflowRunId,
+    workflowId: 'wf-1',
+    spaceId,
+    status: ExecutionStatus.RUNNING,
+    isTestRun: false,
+    workflowDefinition: { name: 'Test Workflow', steps: [] },
+    triggeredBy: 'manual',
+  };
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -47,15 +59,22 @@ describe('runWorkflow', () => {
     mockGetLastFailedStepContext = jest.fn().mockReturnValue(undefined);
     mockGetWorkflowExecutionStatus = jest.fn();
     mockGetWorkflowExecution = jest.fn();
+    mockGetWorkflowExecutionFromState = jest
+      .fn()
+      .mockReturnValue(nonTerminalExecutionForFreshFetch);
+    mockRuntimeStart = jest.fn().mockResolvedValue(undefined);
 
     mockSetupDependencies.mockResolvedValue({
       workflowRuntime: {
-        start: jest.fn().mockResolvedValue(undefined),
+        start: mockRuntimeStart,
         getWorkflowExecutionStatus: mockGetWorkflowExecutionStatus,
         getWorkflowExecution: mockGetWorkflowExecution,
       },
       stepExecutionRuntimeFactory: {},
-      workflowExecutionState: { getLastFailedStepContext: mockGetLastFailedStepContext },
+      workflowExecutionState: {
+        getLastFailedStepContext: mockGetLastFailedStepContext,
+        getWorkflowExecution: mockGetWorkflowExecutionFromState,
+      },
       workflowLogger: {},
       nodesFactory: {},
       workflowExecutionGraph: {},
@@ -84,7 +103,6 @@ describe('runWorkflow', () => {
     };
     mockGetWorkflowExecutionStatus.mockReturnValue(ExecutionStatus.FAILED);
     mockGetWorkflowExecution.mockReturnValue(failedExecution);
-    mockGetWorkflowExecutionById.mockResolvedValue(failedExecution);
     mockGetLastFailedStepContext.mockReturnValue({
       stepId: 'step_1',
       stepName: 'HTTP request',
@@ -103,6 +121,7 @@ describe('runWorkflow', () => {
       })
     ).rejects.toThrow('Step failed');
 
+    expect(mockGetWorkflowExecutionFromState).toHaveBeenCalled();
     expect(mockGetWorkflowExecutionStatus).toHaveBeenCalled();
     expect(mockGetWorkflowExecution).toHaveBeenCalled();
     expect(mockEmitEvent).toHaveBeenCalledTimes(1);
@@ -148,7 +167,6 @@ describe('runWorkflow', () => {
     };
     mockGetWorkflowExecutionStatus.mockReturnValue(ExecutionStatus.FAILED);
     mockGetWorkflowExecution.mockReturnValue(failedExecution);
-    mockGetWorkflowExecutionById.mockResolvedValue(failedExecution);
     // getLastFailedStepContext returns undefined: no step caused the failure
     mockGetLastFailedStepContext.mockReturnValue(undefined);
 
@@ -174,7 +192,7 @@ describe('runWorkflow', () => {
   it('does not emit when execution status is not FAILED', async () => {
     mockWorkflowExecutionLoop.mockRejectedValueOnce(new Error('Step failed'));
     mockGetWorkflowExecutionStatus.mockReturnValue(ExecutionStatus.COMPLETED);
-    mockGetWorkflowExecutionById.mockResolvedValue({
+    mockGetWorkflowExecution.mockReturnValue({
       id: workflowRunId,
       status: ExecutionStatus.COMPLETED,
       isTestRun: false,
@@ -226,5 +244,38 @@ describe('runWorkflow', () => {
     ).rejects.toThrow('Step failed');
 
     expect(mockEmitEvent).not.toHaveBeenCalled();
+  });
+
+  it('returns without starting runtime when execution is already CANCELLED (e.g. cancel won race)', async () => {
+    const cancelledExecution = {
+      id: workflowRunId,
+      workflowId: 'wf-1',
+      spaceId,
+      status: ExecutionStatus.CANCELLED,
+      isTestRun: false,
+      workflowDefinition: { name: 'Test Workflow', steps: [] },
+      triggeredBy: 'manual',
+    };
+    mockGetWorkflowExecutionFromState.mockReturnValue(cancelledExecution);
+    const reportWorkflowExecution = jest.fn().mockResolvedValue(undefined);
+
+    await runWorkflow({
+      workflowRunId,
+      spaceId,
+      taskAbortController: new AbortController(),
+      logger: logger as Logger,
+      config: { logging: { console: false }, http: { allowedHosts: ['*'] } } as any,
+      fakeRequest,
+      dependencies,
+      meteringService: { reportWorkflowExecution } as any,
+    });
+
+    expect(mockRuntimeStart).not.toHaveBeenCalled();
+    expect(mockWorkflowExecutionLoop).not.toHaveBeenCalled();
+    expect(reportWorkflowExecution).toHaveBeenCalledTimes(1);
+    expect(reportWorkflowExecution).toHaveBeenCalledWith(
+      cancelledExecution,
+      dependencies.cloudSetup
+    );
   });
 });

--- a/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/run_workflow.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/run_workflow.ts
@@ -9,7 +9,11 @@
 
 import apm from 'elastic-apm-node';
 import type { KibanaRequest, Logger } from '@kbn/core/server';
-import { ExecutionStatus, isEventDrivenWorkflowTriggerSource } from '@kbn/workflows';
+import {
+  ExecutionStatus,
+  isEventDrivenWorkflowTriggerSource,
+  isTerminalStatus,
+} from '@kbn/workflows';
 import { setupDependencies } from './setup_dependencies';
 import type { WorkflowsExecutionEngineConfig } from '../config';
 import { emitWorkflowExecutionFailedEventIfFailed } from '../lib/emit_workflow_execution_failed_event';
@@ -65,39 +69,44 @@ export async function runWorkflow({
   );
   setupSpan?.end();
 
+  const execution = workflowExecutionState.getWorkflowExecution();
+  if (isTerminalStatus(execution.status)) {
+    logger.debug(
+      `Skipping workflow run ${workflowRunId}: execution already terminal [${execution.status}]`
+    );
+    if (meteringService) {
+      void meteringService.reportWorkflowExecution(execution, dependencies.cloudSetup);
+    }
+    return;
+  }
+
   // Execution-time gate: skip event-driven runs when the kill switch is disabled
   if (isEventDrivenExecutionEnabled) {
-    const execution = await workflowExecutionRepository.getWorkflowExecutionById(
-      workflowRunId,
-      spaceId
-    );
-    if (execution) {
-      const triggeredBy = execution.triggeredBy;
-      const isEventDriven = isEventDrivenWorkflowTriggerSource(triggeredBy);
-      if (isEventDriven && !isEventDrivenExecutionEnabled()) {
-        const cancelledAt = new Date().toISOString();
-        await workflowExecutionRepository.updateWorkflowExecution({
-          id: workflowRunId,
+    const triggeredBy = execution.triggeredBy;
+    const isEventDriven = isEventDrivenWorkflowTriggerSource(triggeredBy);
+    if (isEventDriven && !isEventDrivenExecutionEnabled()) {
+      const cancelledAt = new Date().toISOString();
+      await workflowExecutionRepository.updateWorkflowExecution({
+        id: workflowRunId,
+        status: ExecutionStatus.SKIPPED,
+        cancellationReason: 'Event-driven execution disabled by operator',
+        cancelledAt,
+        cancelledBy: 'system',
+      });
+      logger.debug(
+        `Event-driven execution is disabled; skipping workflow run ${workflowRunId} (triggeredBy: ${triggeredBy}).`
+      );
+      telemetryClient.reportEventDrivenExecutionSuppressed({
+        workflowExecution: {
+          ...execution,
           status: ExecutionStatus.SKIPPED,
           cancellationReason: 'Event-driven execution disabled by operator',
           cancelledAt,
           cancelledBy: 'system',
-        });
-        logger.debug(
-          `Event-driven execution is disabled; skipping workflow run ${workflowRunId} (triggeredBy: ${triggeredBy}).`
-        );
-        telemetryClient.reportEventDrivenExecutionSuppressed({
-          workflowExecution: {
-            ...execution,
-            status: ExecutionStatus.SKIPPED,
-            cancellationReason: 'Event-driven execution disabled by operator',
-            cancelledAt,
-            cancelledBy: 'system',
-          },
-          logTriggerEventsEnabled: workflowsExecutionEngine?.isLogTriggerEventsEnabled() ?? false,
-        });
-        return;
-      }
+        },
+        logTriggerEventsEnabled: workflowsExecutionEngine?.isLogTriggerEventsEnabled() ?? false,
+      });
+      return;
     }
   }
 

--- a/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/setup_dependencies.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/setup_dependencies.test.ts
@@ -200,4 +200,33 @@ describe('setupDependencies', () => {
       });
     });
   });
+
+  it('throws when the workflow execution document is missing', async () => {
+    const mockFakeRequest = { headers: {} } as KibanaRequest;
+    mockWorkflowExecutionRepository.getWorkflowExecutionById = jest.fn().mockResolvedValue(null);
+
+    const mockScopedClient = {
+      search: jest.fn(),
+      index: jest.fn(),
+    } as unknown as ElasticsearchClient;
+    mockDependencies.coreStart.elasticsearch.client.asScoped = jest.fn().mockReturnValue({
+      asCurrentUser: mockScopedClient,
+    });
+
+    await expect(
+      setupDependencies(
+        workflowRunId,
+        spaceId,
+        mockLogger,
+        mockConfig,
+        mockDependencies,
+        mockFakeRequest
+      )
+    ).rejects.toThrow(`Workflow execution with ID ${workflowRunId} not found`);
+
+    expect(mockWorkflowExecutionRepository.getWorkflowExecutionById).toHaveBeenCalledWith(
+      workflowRunId,
+      spaceId
+    );
+  });
 });

--- a/src/platform/plugins/shared/workflows_execution_engine/server/plugin.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/plugin.ts
@@ -17,7 +17,7 @@ import type {
   Plugin,
   PluginInitializerContext,
 } from '@kbn/core/server';
-import { ExecutionStatus, WorkflowRepository } from '@kbn/workflows';
+import { ExecutionStatus, isTerminalStatus, WorkflowRepository } from '@kbn/workflows';
 import type {
   ConcurrencySettings,
   EsWorkflowExecution,
@@ -907,16 +907,9 @@ export class WorkflowsExecutionEnginePlugin
         throw new WorkflowExecutionNotFoundError(workflowExecutionId);
       }
 
-      if (
-        [ExecutionStatus.CANCELLED, ExecutionStatus.COMPLETED, ExecutionStatus.FAILED].includes(
-          workflowExecution.status
-        )
-      ) {
-        // Already in a terminal state or being canceled
+      if (isTerminalStatus(workflowExecution.status)) {
         return;
       }
-
-      const cancelledAt = new Date().toISOString();
 
       if (workflowExecution.status === ExecutionStatus.WAITING_FOR_INPUT) {
         await cancelWaitingWorkflow({
@@ -931,9 +924,12 @@ export class WorkflowsExecutionEnginePlugin
 
       await workflowExecutionRepository.updateWorkflowExecution({
         id: workflowExecution.id,
+        ...(workflowExecution.status === ExecutionStatus.PENDING
+          ? { status: ExecutionStatus.CANCELLED }
+          : {}),
         cancelRequested: true,
         cancellationReason: 'Cancelled by user',
-        cancelledAt,
+        cancelledAt: new Date().toISOString(),
         cancelledBy: 'system', // TODO: set user if available
       });
       await workflowTaskManager.forceRunIdleTasks(workflowExecution.id);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[One Workflow] immediate PENDING workflows cancellation (#264288)](https://github.com/elastic/kibana/pull/264288)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Hashem","email":"11019955+h88@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-04-28T07:59:51Z","message":"[One Workflow] immediate PENDING workflows cancellation (#264288)\n\nFix PENDING workflow cancel by terminalizing cancel API and guarding\nrunWorkflow + some minor optimizations to the cancellation impl\n\nFixes https://github.com/elastic/security-team/issues/16902","sha":"307b1bd79923be66292a7a38d6fef62ccc9b01a2","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:version","Team:One Workflow","v9.4.0","v9.5.0"],"title":"[One Workflow] immediate PENDING workflows cancellation","number":264288,"url":"https://github.com/elastic/kibana/pull/264288","mergeCommit":{"message":"[One Workflow] immediate PENDING workflows cancellation (#264288)\n\nFix PENDING workflow cancel by terminalizing cancel API and guarding\nrunWorkflow + some minor optimizations to the cancellation impl\n\nFixes https://github.com/elastic/security-team/issues/16902","sha":"307b1bd79923be66292a7a38d6fef62ccc9b01a2"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/264288","number":264288,"mergeCommit":{"message":"[One Workflow] immediate PENDING workflows cancellation (#264288)\n\nFix PENDING workflow cancel by terminalizing cancel API and guarding\nrunWorkflow + some minor optimizations to the cancellation impl\n\nFixes https://github.com/elastic/security-team/issues/16902","sha":"307b1bd79923be66292a7a38d6fef62ccc9b01a2"}}]}] BACKPORT-->