### PR TITLE
[Inference] Fix some stack connectors not showing up in Add Model popover

### DIFF
--- a/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/settings/add_model_popover.test.tsx
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/settings/add_model_popover.test.tsx
@@ -12,16 +12,12 @@ import { I18nProvider } from '@kbn/i18n-react';
 import { QueryClient, QueryClientProvider } from '@kbn/react-query';
 import { InferenceConnectorType } from '@kbn/inference-common';
 import type { InferenceConnector } from '@kbn/inference-common';
-import type { InferenceAPIConfigResponse } from '@kbn/ml-trained-models-utils';
 import { AddModelPopover } from './add_model_popover';
 import { useConnectors } from '../../hooks/use_connectors';
-import { useQueryInferenceEndpoints } from '../../hooks/use_inference_endpoints';
 
 jest.mock('../../hooks/use_connectors');
-jest.mock('../../hooks/use_inference_endpoints');
 
 const mockUseConnectors = useConnectors as jest.Mock;
-const mockUseQueryInferenceEndpoints = useQueryInferenceEndpoints as jest.Mock;
 
 const Wrapper = ({ children }: { children: React.ReactNode }) => {
   const queryClient = new QueryClient();
@@ -47,12 +43,8 @@ const createConnector = (overrides: Partial<InferenceConnector>): InferenceConne
 
 /**
  * Connectors returned by useConnectors():
- * - Stack connectors (OpenAI, Bedrock) — always chat_completion
+ * - Stack connectors (OpenAI, Bedrock, Gemini) — always chat_completion
  * - ES inference endpoints with chat_completion task type
- *
- * The server-side /internal/inference/connectors endpoint only returns
- * chat_completion inference endpoints, so non-chat_completion endpoints
- * (like text_embedding or completion) are NOT present here.
  */
 const mockConnectors: InferenceConnector[] = [
   createConnector({
@@ -91,50 +83,14 @@ const mockConnectors: InferenceConnector[] = [
     config: {},
     isInferenceEndpoint: false,
   }),
+  createConnector({
+    connectorId: 'stack-gemini-1',
+    name: 'My Gemini Connector',
+    type: InferenceConnectorType.Gemini,
+    config: {},
+    isInferenceEndpoint: false,
+  }),
 ];
-
-/**
- * Inference endpoints returned by useQueryInferenceEndpoints():
- * - ALL ES inference endpoints regardless of task type
- * - Includes the same chat_completion endpoints that appear in connectors,
- *   plus non-chat_completion endpoints (text_embedding, completion, etc.)
- */
-const mockInferenceEndpoints = [
-  // These overlap with connectors above — the merge deduplicates them
-  {
-    inference_id: 'ep-1',
-    service: 'openai',
-    task_type: 'chat_completion',
-    service_settings: { model_id: 'gpt-4o' },
-  },
-  {
-    inference_id: 'ep-2',
-    service: 'openai',
-    task_type: 'chat_completion',
-    service_settings: { model_id: 'gpt-4o-mini' },
-  },
-  {
-    inference_id: 'ep-eis',
-    service: 'elastic',
-    task_type: 'chat_completion',
-    service_settings: { model_id: 'claude-sonnet' },
-    metadata: { display: { name: 'Claude Sonnet', model_creator: 'Anthropic' } },
-  },
-  // These are ONLY in inference endpoints — not in connectors
-  {
-    inference_id: 'ep-embed',
-    service: 'elastic',
-    task_type: 'text_embedding',
-    service_settings: { model_id: 'e5' },
-    metadata: { display: { name: 'E5 Embedding' } },
-  },
-  {
-    inference_id: 'ep-completion',
-    service: 'openai',
-    task_type: 'completion',
-    service_settings: { model_id: 'gpt-4o-completion' },
-  },
-] as InferenceAPIConfigResponse[];
 
 describe('AddModelPopover', () => {
   const onAdd = jest.fn();
@@ -142,7 +98,6 @@ describe('AddModelPopover', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockUseConnectors.mockReturnValue({ data: mockConnectors });
-    mockUseQueryInferenceEndpoints.mockReturnValue({ data: mockInferenceEndpoints });
   });
 
   it('renders the add model button', () => {
@@ -180,50 +135,7 @@ describe('AddModelPopover', () => {
     expect(screen.getByText('OpenAI GPT-4o-mini')).toBeInTheDocument();
   });
 
-  it('shows non-chat_completion inference endpoints via the endpoints source', () => {
-    render(
-      <Wrapper>
-        <AddModelPopover existingEndpointIds={[]} onAdd={onAdd} taskType="text_embedding" />
-      </Wrapper>
-    );
-
-    fireEvent.click(screen.getByTestId('add-model-button'));
-
-    // text_embedding endpoint comes from useQueryInferenceEndpoints, not from useConnectors
-    expect(screen.getByText('E5 Embedding')).toBeInTheDocument();
-    expect(screen.queryByText('OpenAI GPT-4o')).not.toBeInTheDocument();
-    expect(screen.queryByText('My OpenAI Connector')).not.toBeInTheDocument();
-  });
-
-  it('shows completion inference endpoints via the endpoints source', () => {
-    render(
-      <Wrapper>
-        <AddModelPopover existingEndpointIds={[]} onAdd={onAdd} taskType="completion" />
-      </Wrapper>
-    );
-
-    fireEvent.click(screen.getByTestId('add-model-button'));
-
-    // completion endpoint comes from useQueryInferenceEndpoints, not from useConnectors
-    expect(screen.getByText('gpt-4o-completion')).toBeInTheDocument();
-    expect(screen.queryByText('OpenAI GPT-4o')).not.toBeInTheDocument();
-  });
-
-  it('lists stack connectors for chat_completion task type', () => {
-    render(
-      <Wrapper>
-        <AddModelPopover existingEndpointIds={[]} onAdd={onAdd} taskType="chat_completion" />
-      </Wrapper>
-    );
-
-    fireEvent.click(screen.getByTestId('add-model-button'));
-
-    expect(screen.getByText('My OpenAI Connector')).toBeInTheDocument();
-    expect(screen.getByText('My Bedrock Connector')).toBeInTheDocument();
-    expect(screen.getByText('OpenAI GPT-4o')).toBeInTheDocument();
-  });
-
-  it('lists all models when no task type filter', () => {
+  it('lists all connectors returned by useConnectors (stack OpenAI, Bedrock, Gemini, and chat_completion endpoints)', () => {
     render(
       <Wrapper>
         <AddModelPopover existingEndpointIds={[]} onAdd={onAdd} />
@@ -232,31 +144,10 @@ describe('AddModelPopover', () => {
 
     fireEvent.click(screen.getByTestId('add-model-button'));
 
-    // Stack connectors
     expect(screen.getByText('My OpenAI Connector')).toBeInTheDocument();
     expect(screen.getByText('My Bedrock Connector')).toBeInTheDocument();
-    // chat_completion inference endpoints (from connectors)
+    expect(screen.getByText('My Gemini Connector')).toBeInTheDocument();
     expect(screen.getByText('OpenAI GPT-4o')).toBeInTheDocument();
-    // non-chat_completion inference endpoints (from inference endpoints, filled in by merge)
-    expect(screen.getByText('E5 Embedding')).toBeInTheDocument();
-    expect(screen.getByText('gpt-4o-completion')).toBeInTheDocument();
-  });
-
-  it('deduplicates: connector representation wins over inference endpoint', () => {
-    // ep-1 exists in both connectors (name='OpenAI GPT-4o') and inference endpoints
-    // (model_id='gpt-4o'). The connector name should be used.
-    render(
-      <Wrapper>
-        <AddModelPopover existingEndpointIds={[]} onAdd={onAdd} taskType="chat_completion" />
-      </Wrapper>
-    );
-
-    fireEvent.click(screen.getByTestId('add-model-button'));
-
-    // Connector name is used, not the model_id from inference endpoint
-    expect(screen.getByText('OpenAI GPT-4o')).toBeInTheDocument();
-    // Should not show the raw model_id as a separate entry
-    expect(screen.queryByText('gpt-4o')).not.toBeInTheDocument();
   });
 
   it('calls onAdd with the selected connector ID', () => {
@@ -267,25 +158,12 @@ describe('AddModelPopover', () => {
     );
 
     fireEvent.click(screen.getByTestId('add-model-button'));
-    fireEvent.click(screen.getByText('My OpenAI Connector'));
+    fireEvent.click(screen.getByText('My Gemini Connector'));
 
-    expect(onAdd).toHaveBeenCalledWith('stack-openai-1');
+    expect(onAdd).toHaveBeenCalledWith('stack-gemini-1');
   });
 
-  it('calls onAdd with inference endpoint ID for non-connector endpoints', () => {
-    render(
-      <Wrapper>
-        <AddModelPopover existingEndpointIds={[]} onAdd={onAdd} taskType="completion" />
-      </Wrapper>
-    );
-
-    fireEvent.click(screen.getByTestId('add-model-button'));
-    fireEvent.click(screen.getByText('gpt-4o-completion'));
-
-    expect(onAdd).toHaveBeenCalledWith('ep-completion');
-  });
-
-  it('shows disambiguation suffix when multiple models share a name', () => {
+  it('shows disambiguation suffix when multiple connectors share a name', () => {
     const duplicateConnectors = [
       createConnector({
         connectorId: 'ep-a',
@@ -303,7 +181,6 @@ describe('AddModelPopover', () => {
       }),
     ];
     mockUseConnectors.mockReturnValue({ data: duplicateConnectors });
-    mockUseQueryInferenceEndpoints.mockReturnValue({ data: [] });
 
     render(
       <Wrapper>
@@ -317,7 +194,7 @@ describe('AddModelPopover', () => {
     expect(screen.getByText('My Connector (ep-b)')).toBeInTheDocument();
   });
 
-  it('handles empty connectors gracefully, showing only inference endpoints', () => {
+  it('handles empty connectors gracefully', () => {
     mockUseConnectors.mockReturnValue({ data: [] });
 
     render(
@@ -328,22 +205,6 @@ describe('AddModelPopover', () => {
 
     fireEvent.click(screen.getByTestId('add-model-button'));
 
-    expect(screen.getByText('E5 Embedding')).toBeInTheDocument();
-    expect(screen.getByText('gpt-4o-completion')).toBeInTheDocument();
-  });
-
-  it('handles empty inference endpoints gracefully, showing only connectors', () => {
-    mockUseQueryInferenceEndpoints.mockReturnValue({ data: [] });
-
-    render(
-      <Wrapper>
-        <AddModelPopover existingEndpointIds={[]} onAdd={onAdd} />
-      </Wrapper>
-    );
-
-    fireEvent.click(screen.getByTestId('add-model-button'));
-
-    expect(screen.getByText('My OpenAI Connector')).toBeInTheDocument();
-    expect(screen.getByText('My Bedrock Connector')).toBeInTheDocument();
+    expect(screen.getByTestId('add-model-search')).toBeInTheDocument();
   });
 });

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/settings/add_model_popover.test.tsx
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/settings/add_model_popover.test.tsx
@@ -10,12 +10,14 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { EuiThemeProvider } from '@elastic/eui';
 import { I18nProvider } from '@kbn/i18n-react';
 import { QueryClient, QueryClientProvider } from '@kbn/react-query';
+import { InferenceConnectorType } from '@kbn/inference-common';
+import type { InferenceConnector } from '@kbn/inference-common';
 import { AddModelPopover } from './add_model_popover';
-import { useQueryInferenceEndpoints } from '../../hooks/use_inference_endpoints';
+import { useConnectors } from '../../hooks/use_connectors';
 
-jest.mock('../../hooks/use_inference_endpoints');
+jest.mock('../../hooks/use_connectors');
 
-const mockUseQueryInferenceEndpoints = useQueryInferenceEndpoints as jest.Mock;
+const mockUseConnectors = useConnectors as jest.Mock;
 
 const Wrapper = ({ children }: { children: React.ReactNode }) => {
   const queryClient = new QueryClient();
@@ -28,43 +30,61 @@ const Wrapper = ({ children }: { children: React.ReactNode }) => {
   );
 };
 
-const mockEndpoints = [
-  {
-    inference_id: 'ep-1',
-    service: 'openai',
-    task_type: 'chat_completion',
-    service_settings: { model_id: 'gpt-4o' },
-  },
-  {
-    inference_id: 'ep-2',
-    service: 'openai',
-    task_type: 'chat_completion',
-    service_settings: { model_id: 'gpt-4o-mini' },
-  },
-  {
-    inference_id: 'ep-eis',
-    service: 'elastic',
-    task_type: 'chat_completion',
-    service_settings: { model_id: 'claude-sonnet' },
-    metadata: {
-      display: {
-        name: 'Claude Sonnet',
-        model_creator: 'Anthropic',
-      },
-    },
-  },
-  {
-    inference_id: 'ep-eis-no-meta',
-    service: 'elastic',
-    task_type: 'chat_completion',
-    service_settings: { model_id: 'some-model' },
-  },
-  {
-    inference_id: 'ep-embed',
-    service: 'elastic',
-    task_type: 'text_embedding',
-    service_settings: { model_id: 'e5' },
-  },
+const createConnector = (overrides: Partial<InferenceConnector>): InferenceConnector => ({
+  type: InferenceConnectorType.Inference,
+  name: 'test-connector',
+  connectorId: 'test-id',
+  config: {},
+  capabilities: {},
+  isInferenceEndpoint: true,
+  isPreconfigured: false,
+  ...overrides,
+});
+
+const mockConnectors: InferenceConnector[] = [
+  createConnector({
+    connectorId: 'ep-1',
+    name: 'OpenAI GPT-4o',
+    type: InferenceConnectorType.Inference,
+    config: { taskType: 'chat_completion', service: 'openai' },
+    isInferenceEndpoint: true,
+  }),
+  createConnector({
+    connectorId: 'ep-2',
+    name: 'OpenAI GPT-4o-mini',
+    type: InferenceConnectorType.Inference,
+    config: { taskType: 'chat_completion', service: 'openai' },
+    isInferenceEndpoint: true,
+  }),
+  createConnector({
+    connectorId: 'ep-eis',
+    name: 'Claude Sonnet',
+    type: InferenceConnectorType.Inference,
+    config: { taskType: 'chat_completion', service: 'elastic', modelCreator: 'Anthropic' },
+    isInferenceEndpoint: true,
+    isEis: true,
+  }),
+  createConnector({
+    connectorId: 'ep-embed',
+    name: 'E5 Embedding',
+    type: InferenceConnectorType.Inference,
+    config: { taskType: 'text_embedding', service: 'elastic' },
+    isInferenceEndpoint: true,
+  }),
+  createConnector({
+    connectorId: 'stack-openai-1',
+    name: 'My OpenAI Connector',
+    type: InferenceConnectorType.OpenAI,
+    config: { apiProvider: 'OpenAI' },
+    isInferenceEndpoint: false,
+  }),
+  createConnector({
+    connectorId: 'stack-bedrock-1',
+    name: 'My Bedrock Connector',
+    type: InferenceConnectorType.Bedrock,
+    config: {},
+    isInferenceEndpoint: false,
+  }),
 ];
 
 describe('AddModelPopover', () => {
@@ -72,7 +92,7 @@ describe('AddModelPopover', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockUseQueryInferenceEndpoints.mockReturnValue({ data: mockEndpoints });
+    mockUseConnectors.mockReturnValue({ data: mockConnectors });
   });
 
   it('renders the add model button', () => {
@@ -106,8 +126,8 @@ describe('AddModelPopover', () => {
 
     fireEvent.click(screen.getByTestId('add-model-button'));
 
-    expect(screen.queryByText('gpt-4o')).not.toBeInTheDocument();
-    expect(screen.getByText('gpt-4o-mini')).toBeInTheDocument();
+    expect(screen.queryByText('OpenAI GPT-4o')).not.toBeInTheDocument();
+    expect(screen.getByText('OpenAI GPT-4o-mini')).toBeInTheDocument();
   });
 
   it('filters by task type when provided', () => {
@@ -119,10 +139,26 @@ describe('AddModelPopover', () => {
 
     fireEvent.click(screen.getByTestId('add-model-button'));
 
-    expect(screen.queryByText('gpt-4o')).not.toBeInTheDocument();
+    expect(screen.getByText('E5 Embedding')).toBeInTheDocument();
+    expect(screen.queryByText('OpenAI GPT-4o')).not.toBeInTheDocument();
+    expect(screen.queryByText('My OpenAI Connector')).not.toBeInTheDocument();
   });
 
-  it('uses display name for EIS endpoints with metadata', () => {
+  it('lists stack connectors for chat_completion task type', () => {
+    render(
+      <Wrapper>
+        <AddModelPopover existingEndpointIds={[]} onAdd={onAdd} taskType="chat_completion" />
+      </Wrapper>
+    );
+
+    fireEvent.click(screen.getByTestId('add-model-button'));
+
+    expect(screen.getByText('My OpenAI Connector')).toBeInTheDocument();
+    expect(screen.getByText('My Bedrock Connector')).toBeInTheDocument();
+    expect(screen.getByText('OpenAI GPT-4o')).toBeInTheDocument();
+  });
+
+  it('lists all connectors when no task type filter', () => {
     render(
       <Wrapper>
         <AddModelPopover existingEndpointIds={[]} onAdd={onAdd} />
@@ -131,10 +167,13 @@ describe('AddModelPopover', () => {
 
     fireEvent.click(screen.getByTestId('add-model-button'));
 
-    expect(screen.getByText('Claude Sonnet')).toBeInTheDocument();
+    expect(screen.getByText('My OpenAI Connector')).toBeInTheDocument();
+    expect(screen.getByText('My Bedrock Connector')).toBeInTheDocument();
+    expect(screen.getByText('OpenAI GPT-4o')).toBeInTheDocument();
+    expect(screen.getByText('E5 Embedding')).toBeInTheDocument();
   });
 
-  it('falls back to model_id for EIS endpoints without display metadata', () => {
+  it('calls onAdd with the selected connector ID', () => {
     render(
       <Wrapper>
         <AddModelPopover existingEndpointIds={[]} onAdd={onAdd} />
@@ -142,39 +181,29 @@ describe('AddModelPopover', () => {
     );
 
     fireEvent.click(screen.getByTestId('add-model-button'));
+    fireEvent.click(screen.getByText('My OpenAI Connector'));
 
-    expect(screen.getByText('some-model')).toBeInTheDocument();
+    expect(onAdd).toHaveBeenCalledWith('stack-openai-1');
   });
 
-  it('calls onAdd with the selected endpoint inference_id', () => {
-    render(
-      <Wrapper>
-        <AddModelPopover existingEndpointIds={[]} onAdd={onAdd} />
-      </Wrapper>
-    );
-
-    fireEvent.click(screen.getByTestId('add-model-button'));
-    fireEvent.click(screen.getByText('gpt-4o-mini'));
-
-    expect(onAdd).toHaveBeenCalledWith('ep-2');
-  });
-
-  it('shows disambiguation suffix when multiple endpoints share a model name', () => {
-    const duplicateEndpoints = [
-      {
-        inference_id: 'ep-a',
-        service: 'openai',
-        task_type: 'chat_completion',
-        service_settings: { model_id: 'gpt-4o' },
-      },
-      {
-        inference_id: 'ep-b',
-        service: 'openai',
-        task_type: 'chat_completion',
-        service_settings: { model_id: 'gpt-4o' },
-      },
+  it('shows disambiguation suffix when multiple connectors share a name', () => {
+    const duplicateConnectors = [
+      createConnector({
+        connectorId: 'ep-a',
+        name: 'My Connector',
+        type: InferenceConnectorType.Inference,
+        config: { taskType: 'chat_completion', service: 'openai' },
+        isInferenceEndpoint: true,
+      }),
+      createConnector({
+        connectorId: 'ep-b',
+        name: 'My Connector',
+        type: InferenceConnectorType.Inference,
+        config: { taskType: 'chat_completion', service: 'openai' },
+        isInferenceEndpoint: true,
+      }),
     ];
-    mockUseQueryInferenceEndpoints.mockReturnValue({ data: duplicateEndpoints });
+    mockUseConnectors.mockReturnValue({ data: duplicateConnectors });
 
     render(
       <Wrapper>
@@ -184,7 +213,7 @@ describe('AddModelPopover', () => {
 
     fireEvent.click(screen.getByTestId('add-model-button'));
 
-    expect(screen.getByText('gpt-4o (ep-a)')).toBeInTheDocument();
-    expect(screen.getByText('gpt-4o (ep-b)')).toBeInTheDocument();
+    expect(screen.getByText('My Connector (ep-a)')).toBeInTheDocument();
+    expect(screen.getByText('My Connector (ep-b)')).toBeInTheDocument();
   });
 });

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/settings/add_model_popover.test.tsx
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/settings/add_model_popover.test.tsx
@@ -12,12 +12,16 @@ import { I18nProvider } from '@kbn/i18n-react';
 import { QueryClient, QueryClientProvider } from '@kbn/react-query';
 import { InferenceConnectorType } from '@kbn/inference-common';
 import type { InferenceConnector } from '@kbn/inference-common';
+import type { InferenceAPIConfigResponse } from '@kbn/ml-trained-models-utils';
 import { AddModelPopover } from './add_model_popover';
 import { useConnectors } from '../../hooks/use_connectors';
+import { useQueryInferenceEndpoints } from '../../hooks/use_inference_endpoints';
 
 jest.mock('../../hooks/use_connectors');
+jest.mock('../../hooks/use_inference_endpoints');
 
 const mockUseConnectors = useConnectors as jest.Mock;
+const mockUseQueryInferenceEndpoints = useQueryInferenceEndpoints as jest.Mock;
 
 const Wrapper = ({ children }: { children: React.ReactNode }) => {
   const queryClient = new QueryClient();
@@ -41,6 +45,15 @@ const createConnector = (overrides: Partial<InferenceConnector>): InferenceConne
   ...overrides,
 });
 
+/**
+ * Connectors returned by useConnectors():
+ * - Stack connectors (OpenAI, Bedrock) — always chat_completion
+ * - ES inference endpoints with chat_completion task type
+ *
+ * The server-side /internal/inference/connectors endpoint only returns
+ * chat_completion inference endpoints, so non-chat_completion endpoints
+ * (like text_embedding or completion) are NOT present here.
+ */
 const mockConnectors: InferenceConnector[] = [
   createConnector({
     connectorId: 'ep-1',
@@ -65,13 +78,6 @@ const mockConnectors: InferenceConnector[] = [
     isEis: true,
   }),
   createConnector({
-    connectorId: 'ep-embed',
-    name: 'E5 Embedding',
-    type: InferenceConnectorType.Inference,
-    config: { taskType: 'text_embedding', service: 'elastic' },
-    isInferenceEndpoint: true,
-  }),
-  createConnector({
     connectorId: 'stack-openai-1',
     name: 'My OpenAI Connector',
     type: InferenceConnectorType.OpenAI,
@@ -87,12 +93,56 @@ const mockConnectors: InferenceConnector[] = [
   }),
 ];
 
+/**
+ * Inference endpoints returned by useQueryInferenceEndpoints():
+ * - ALL ES inference endpoints regardless of task type
+ * - Includes the same chat_completion endpoints that appear in connectors,
+ *   plus non-chat_completion endpoints (text_embedding, completion, etc.)
+ */
+const mockInferenceEndpoints = [
+  // These overlap with connectors above — the merge deduplicates them
+  {
+    inference_id: 'ep-1',
+    service: 'openai',
+    task_type: 'chat_completion',
+    service_settings: { model_id: 'gpt-4o' },
+  },
+  {
+    inference_id: 'ep-2',
+    service: 'openai',
+    task_type: 'chat_completion',
+    service_settings: { model_id: 'gpt-4o-mini' },
+  },
+  {
+    inference_id: 'ep-eis',
+    service: 'elastic',
+    task_type: 'chat_completion',
+    service_settings: { model_id: 'claude-sonnet' },
+    metadata: { display: { name: 'Claude Sonnet', model_creator: 'Anthropic' } },
+  },
+  // These are ONLY in inference endpoints — not in connectors
+  {
+    inference_id: 'ep-embed',
+    service: 'elastic',
+    task_type: 'text_embedding',
+    service_settings: { model_id: 'e5' },
+    metadata: { display: { name: 'E5 Embedding' } },
+  },
+  {
+    inference_id: 'ep-completion',
+    service: 'openai',
+    task_type: 'completion',
+    service_settings: { model_id: 'gpt-4o-completion' },
+  },
+] as InferenceAPIConfigResponse[];
+
 describe('AddModelPopover', () => {
   const onAdd = jest.fn();
 
   beforeEach(() => {
     jest.clearAllMocks();
     mockUseConnectors.mockReturnValue({ data: mockConnectors });
+    mockUseQueryInferenceEndpoints.mockReturnValue({ data: mockInferenceEndpoints });
   });
 
   it('renders the add model button', () => {
@@ -130,7 +180,7 @@ describe('AddModelPopover', () => {
     expect(screen.getByText('OpenAI GPT-4o-mini')).toBeInTheDocument();
   });
 
-  it('filters by task type when provided', () => {
+  it('shows non-chat_completion inference endpoints via the endpoints source', () => {
     render(
       <Wrapper>
         <AddModelPopover existingEndpointIds={[]} onAdd={onAdd} taskType="text_embedding" />
@@ -139,9 +189,24 @@ describe('AddModelPopover', () => {
 
     fireEvent.click(screen.getByTestId('add-model-button'));
 
+    // text_embedding endpoint comes from useQueryInferenceEndpoints, not from useConnectors
     expect(screen.getByText('E5 Embedding')).toBeInTheDocument();
     expect(screen.queryByText('OpenAI GPT-4o')).not.toBeInTheDocument();
     expect(screen.queryByText('My OpenAI Connector')).not.toBeInTheDocument();
+  });
+
+  it('shows completion inference endpoints via the endpoints source', () => {
+    render(
+      <Wrapper>
+        <AddModelPopover existingEndpointIds={[]} onAdd={onAdd} taskType="completion" />
+      </Wrapper>
+    );
+
+    fireEvent.click(screen.getByTestId('add-model-button'));
+
+    // completion endpoint comes from useQueryInferenceEndpoints, not from useConnectors
+    expect(screen.getByText('gpt-4o-completion')).toBeInTheDocument();
+    expect(screen.queryByText('OpenAI GPT-4o')).not.toBeInTheDocument();
   });
 
   it('lists stack connectors for chat_completion task type', () => {
@@ -158,7 +223,7 @@ describe('AddModelPopover', () => {
     expect(screen.getByText('OpenAI GPT-4o')).toBeInTheDocument();
   });
 
-  it('lists all connectors when no task type filter', () => {
+  it('lists all models when no task type filter', () => {
     render(
       <Wrapper>
         <AddModelPopover existingEndpointIds={[]} onAdd={onAdd} />
@@ -167,10 +232,31 @@ describe('AddModelPopover', () => {
 
     fireEvent.click(screen.getByTestId('add-model-button'));
 
+    // Stack connectors
     expect(screen.getByText('My OpenAI Connector')).toBeInTheDocument();
     expect(screen.getByText('My Bedrock Connector')).toBeInTheDocument();
+    // chat_completion inference endpoints (from connectors)
     expect(screen.getByText('OpenAI GPT-4o')).toBeInTheDocument();
+    // non-chat_completion inference endpoints (from inference endpoints, filled in by merge)
     expect(screen.getByText('E5 Embedding')).toBeInTheDocument();
+    expect(screen.getByText('gpt-4o-completion')).toBeInTheDocument();
+  });
+
+  it('deduplicates: connector representation wins over inference endpoint', () => {
+    // ep-1 exists in both connectors (name='OpenAI GPT-4o') and inference endpoints
+    // (model_id='gpt-4o'). The connector name should be used.
+    render(
+      <Wrapper>
+        <AddModelPopover existingEndpointIds={[]} onAdd={onAdd} taskType="chat_completion" />
+      </Wrapper>
+    );
+
+    fireEvent.click(screen.getByTestId('add-model-button'));
+
+    // Connector name is used, not the model_id from inference endpoint
+    expect(screen.getByText('OpenAI GPT-4o')).toBeInTheDocument();
+    // Should not show the raw model_id as a separate entry
+    expect(screen.queryByText('gpt-4o')).not.toBeInTheDocument();
   });
 
   it('calls onAdd with the selected connector ID', () => {
@@ -186,7 +272,20 @@ describe('AddModelPopover', () => {
     expect(onAdd).toHaveBeenCalledWith('stack-openai-1');
   });
 
-  it('shows disambiguation suffix when multiple connectors share a name', () => {
+  it('calls onAdd with inference endpoint ID for non-connector endpoints', () => {
+    render(
+      <Wrapper>
+        <AddModelPopover existingEndpointIds={[]} onAdd={onAdd} taskType="completion" />
+      </Wrapper>
+    );
+
+    fireEvent.click(screen.getByTestId('add-model-button'));
+    fireEvent.click(screen.getByText('gpt-4o-completion'));
+
+    expect(onAdd).toHaveBeenCalledWith('ep-completion');
+  });
+
+  it('shows disambiguation suffix when multiple models share a name', () => {
     const duplicateConnectors = [
       createConnector({
         connectorId: 'ep-a',
@@ -204,6 +303,7 @@ describe('AddModelPopover', () => {
       }),
     ];
     mockUseConnectors.mockReturnValue({ data: duplicateConnectors });
+    mockUseQueryInferenceEndpoints.mockReturnValue({ data: [] });
 
     render(
       <Wrapper>
@@ -215,5 +315,35 @@ describe('AddModelPopover', () => {
 
     expect(screen.getByText('My Connector (ep-a)')).toBeInTheDocument();
     expect(screen.getByText('My Connector (ep-b)')).toBeInTheDocument();
+  });
+
+  it('handles empty connectors gracefully, showing only inference endpoints', () => {
+    mockUseConnectors.mockReturnValue({ data: [] });
+
+    render(
+      <Wrapper>
+        <AddModelPopover existingEndpointIds={[]} onAdd={onAdd} />
+      </Wrapper>
+    );
+
+    fireEvent.click(screen.getByTestId('add-model-button'));
+
+    expect(screen.getByText('E5 Embedding')).toBeInTheDocument();
+    expect(screen.getByText('gpt-4o-completion')).toBeInTheDocument();
+  });
+
+  it('handles empty inference endpoints gracefully, showing only connectors', () => {
+    mockUseQueryInferenceEndpoints.mockReturnValue({ data: [] });
+
+    render(
+      <Wrapper>
+        <AddModelPopover existingEndpointIds={[]} onAdd={onAdd} />
+      </Wrapper>
+    );
+
+    fireEvent.click(screen.getByTestId('add-model-button'));
+
+    expect(screen.getByText('My OpenAI Connector')).toBeInTheDocument();
+    expect(screen.getByText('My Bedrock Connector')).toBeInTheDocument();
   });
 });

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/settings/add_model_popover.tsx
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/settings/add_model_popover.tsx
@@ -11,53 +11,41 @@ import { EuiButtonEmpty, EuiIcon, EuiPopover, EuiSelectable } from '@elastic/eui
 import { i18n } from '@kbn/i18n';
 import type { EuiSelectableOption } from '@elastic/eui';
 import { useConnectors } from '../../hooks/use_connectors';
-import { useQueryInferenceEndpoints } from '../../hooks/use_inference_endpoints';
-import { mergeConnectorsAndEndpoints } from '../../utils/connector_display';
+import { getConnectorIcon } from '../../utils/connector_display';
 
 interface AddModelPopoverProps {
   existingEndpointIds: string[];
   onAdd: (endpointId: string) => void;
-  taskType?: string;
   panelWidth?: number;
 }
 
 export const AddModelPopover: React.FC<AddModelPopoverProps> = ({
   existingEndpointIds,
   onAdd,
-  taskType,
   panelWidth,
 }) => {
   const { data: connectors = [] } = useConnectors();
-  const { data: inferenceEndpoints = [] } = useQueryInferenceEndpoints();
   const [isOpen, setIsOpen] = useState(false);
-
-  const allModels = useMemo(
-    () => mergeConnectorsAndEndpoints(connectors, inferenceEndpoints),
-    [connectors, inferenceEndpoints]
-  );
 
   const options: EuiSelectableOption[] = useMemo(() => {
     const existingSet = new Set(existingEndpointIds);
-    const available = allModels.filter(
-      (model) =>
-        !existingSet.has(model.id) && (!taskType || model.taskType === taskType)
-    );
+    const available = connectors.filter((connector) => !existingSet.has(connector.connectorId));
 
-    const nameToCount = allModels.reduce<Map<string, number>>((acc, model) => {
-      acc.set(model.name, (acc.get(model.name) ?? 0) + 1);
+    const nameToCount = connectors.reduce<Map<string, number>>((acc, connector) => {
+      acc.set(connector.name, (acc.get(connector.name) ?? 0) + 1);
       return acc;
     }, new Map());
 
-    return available.map((model) => {
-      const count = nameToCount.get(model.name) ?? 1;
-      const label = count > 1 ? `${model.name} (${model.id})` : model.name;
+    return available.map((connector) => {
+      const count = nameToCount.get(connector.name) ?? 1;
+      const label = count > 1 ? `${connector.name} (${connector.connectorId})` : connector.name;
       return {
         label,
-        key: model.id,
-        prepend: <EuiIcon type={model.icon} size="s" aria-hidden />,
+        key: connector.connectorId,
+        prepend: <EuiIcon type={getConnectorIcon(connector)} size="s" aria-hidden />,
       };
     });
-  }, [allModels, existingEndpointIds, taskType]);
+  }, [connectors, existingEndpointIds]);
 
   const handleChange = useCallback(
     (newOptions: EuiSelectableOption[]) => {

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/settings/add_model_popover.tsx
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/settings/add_model_popover.tsx
@@ -11,7 +11,8 @@ import { EuiButtonEmpty, EuiIcon, EuiPopover, EuiSelectable } from '@elastic/eui
 import { i18n } from '@kbn/i18n';
 import type { EuiSelectableOption } from '@elastic/eui';
 import { useConnectors } from '../../hooks/use_connectors';
-import { getConnectorIcon, getConnectorTaskType } from '../../utils/connector_display';
+import { useQueryInferenceEndpoints } from '../../hooks/use_inference_endpoints';
+import { mergeConnectorsAndEndpoints } from '../../utils/connector_display';
 
 interface AddModelPopoverProps {
   existingEndpointIds: string[];
@@ -27,33 +28,36 @@ export const AddModelPopover: React.FC<AddModelPopoverProps> = ({
   panelWidth,
 }) => {
   const { data: connectors = [] } = useConnectors();
+  const { data: inferenceEndpoints = [] } = useQueryInferenceEndpoints();
   const [isOpen, setIsOpen] = useState(false);
+
+  const allModels = useMemo(
+    () => mergeConnectorsAndEndpoints(connectors, inferenceEndpoints),
+    [connectors, inferenceEndpoints]
+  );
 
   const options: EuiSelectableOption[] = useMemo(() => {
     const existingSet = new Set(existingEndpointIds);
-    const available = connectors.filter(
-      (connector) =>
-        !existingSet.has(connector.connectorId) &&
-        (!taskType || getConnectorTaskType(connector) === taskType)
+    const available = allModels.filter(
+      (model) =>
+        !existingSet.has(model.id) && (!taskType || model.taskType === taskType)
     );
 
-    const nameToCount = connectors.reduce<Map<string, number>>((acc, connector) => {
-      acc.set(connector.name, (acc.get(connector.name) ?? 0) + 1);
+    const nameToCount = allModels.reduce<Map<string, number>>((acc, model) => {
+      acc.set(model.name, (acc.get(model.name) ?? 0) + 1);
       return acc;
     }, new Map());
 
-    return available.map((connector) => {
-      const count = nameToCount.get(connector.name) ?? 1;
-      const icon = getConnectorIcon(connector);
-      const baseName = connector.name;
-      const label = count > 1 ? `${baseName} (${connector.connectorId})` : baseName;
+    return available.map((model) => {
+      const count = nameToCount.get(model.name) ?? 1;
+      const label = count > 1 ? `${model.name} (${model.id})` : model.name;
       return {
         label,
-        key: connector.connectorId,
-        prepend: <EuiIcon type={icon} size="s" aria-hidden />,
+        key: model.id,
+        prepend: <EuiIcon type={model.icon} size="s" aria-hidden />,
       };
     });
-  }, [connectors, existingEndpointIds, taskType]);
+  }, [allModels, existingEndpointIds, taskType]);
 
   const handleChange = useCallback(
     (newOptions: EuiSelectableOption[]) => {

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/settings/add_model_popover.tsx
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/settings/add_model_popover.tsx
@@ -10,16 +10,8 @@ import { css } from '@emotion/react';
 import { EuiButtonEmpty, EuiIcon, EuiPopover, EuiSelectable } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import type { EuiSelectableOption } from '@elastic/eui';
-import { SERVICE_PROVIDERS } from '@kbn/inference-endpoint-ui-common';
-import type { ServiceProviderKeys } from '@kbn/inference-endpoint-ui-common';
-import { useQueryInferenceEndpoints } from '../../hooks/use_inference_endpoints';
-import { getModelId } from '../../utils/get_model_id';
-import {
-  isEisEndpoint,
-  getModelName,
-  getModelCreator,
-  getProviderKeyForCreator,
-} from '../../utils/eis_utils';
+import { useConnectors } from '../../hooks/use_connectors';
+import { getConnectorIcon, getConnectorTaskType } from '../../utils/connector_display';
 
 interface AddModelPopoverProps {
   existingEndpointIds: string[];
@@ -34,45 +26,34 @@ export const AddModelPopover: React.FC<AddModelPopoverProps> = ({
   taskType,
   panelWidth,
 }) => {
-  const { data: inferenceEndpoints = [] } = useQueryInferenceEndpoints();
+  const { data: connectors = [] } = useConnectors();
   const [isOpen, setIsOpen] = useState(false);
 
   const options: EuiSelectableOption[] = useMemo(() => {
     const existingSet = new Set(existingEndpointIds);
-    const available = inferenceEndpoints.filter(
-      (endpoint) =>
-        !existingSet.has(endpoint.inference_id) && (!taskType || endpoint.task_type === taskType)
+    const available = connectors.filter(
+      (connector) =>
+        !existingSet.has(connector.connectorId) &&
+        (!taskType || getConnectorTaskType(connector) === taskType)
     );
 
-    const modelToCount = inferenceEndpoints.reduce<Map<string, number>>((acc, ep) => {
-      const modelId = getModelId(ep) ?? ep.inference_id;
-      acc.set(modelId, (acc.get(modelId) ?? 0) + 1);
+    const nameToCount = connectors.reduce<Map<string, number>>((acc, connector) => {
+      acc.set(connector.name, (acc.get(connector.name) ?? 0) + 1);
       return acc;
     }, new Map());
 
-    return available.map((endpoint) => {
-      const modelId = getModelId(endpoint) ?? endpoint.inference_id;
-      const count = modelToCount.get(modelId) ?? 1;
-      let icon: string;
-      let baseName: string;
-      if (isEisEndpoint(endpoint)) {
-        const creator = getModelCreator(endpoint);
-        const providerKey = getProviderKeyForCreator(creator);
-        icon = (providerKey && SERVICE_PROVIDERS[providerKey]?.icon) ?? 'compute';
-        baseName = getModelName(endpoint);
-      } else {
-        const provider = SERVICE_PROVIDERS[endpoint.service as ServiceProviderKeys];
-        icon = provider?.icon ?? 'compute';
-        baseName = modelId;
-      }
-      const label = count > 1 ? `${baseName} (${endpoint.inference_id})` : baseName;
+    return available.map((connector) => {
+      const count = nameToCount.get(connector.name) ?? 1;
+      const icon = getConnectorIcon(connector);
+      const baseName = connector.name;
+      const label = count > 1 ? `${baseName} (${connector.connectorId})` : baseName;
       return {
         label,
-        key: endpoint.inference_id,
+        key: connector.connectorId,
         prepend: <EuiIcon type={icon} size="s" aria-hidden />,
       };
     });
-  }, [inferenceEndpoints, existingEndpointIds, taskType]);
+  }, [connectors, existingEndpointIds, taskType]);
 
   const handleChange = useCallback(
     (newOptions: EuiSelectableOption[]) => {

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/settings/sub_feature_card.tsx
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/settings/sub_feature_card.tsx
@@ -416,7 +416,6 @@ export const SubFeatureCard: React.FC<SubFeatureCardProps> = ({
                   <AddModelPopover
                     existingEndpointIds={endpointIds}
                     onAdd={handleAdd}
-                    taskType={feature.taskType}
                     panelWidth={listWidth}
                   />
                 </EuiFlexItem>

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/settings/sub_feature_card.tsx
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/settings/sub_feature_card.tsx
@@ -28,42 +28,16 @@ import {
   euiDragDropReorder,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import type { InferenceConnector } from '@kbn/inference-common';
-import { InferenceConnectorType } from '@kbn/inference-common';
-import { SERVICE_PROVIDERS } from '@kbn/inference-endpoint-ui-common';
-import type { ServiceProviderKeys } from '@kbn/inference-endpoint-ui-common';
 import { css } from '@emotion/react';
 import { NO_DEFAULT_MODEL } from '../../../common/constants';
 import { useRegisteredFeatures } from '../../hooks/use_registered_features';
-import { getProviderKeyForCreator } from '../../utils/eis_utils';
+import { getConnectorIcon } from '../../utils/connector_display';
 import type { InferenceFeatureResponse as InferenceFeatureConfig } from '../../../common/types';
 import { AddModelPopover } from './add_model_popover';
 import { CopyToModal } from './copy_to_modal';
 import { useConnectors } from '../../hooks/use_connectors';
 
 const COLLAPSED_COUNT = 5;
-
-const getConnectorIcon = (connector: InferenceConnector): string => {
-  let key: string | undefined;
-  switch (connector.type) {
-    case InferenceConnectorType.OpenAI:
-      key = connector.config?.apiProvider === 'Azure OpenAI' ? 'azureopenai' : 'openai';
-      break;
-    case InferenceConnectorType.Bedrock:
-      key = 'amazonbedrock';
-      break;
-    case InferenceConnectorType.Gemini:
-      key = 'googlevertexai';
-      break;
-    case InferenceConnectorType.Inference:
-      key =
-        getProviderKeyForCreator(connector.config?.modelCreator) ??
-        connector.config?.service ??
-        connector.config?.provider;
-      break;
-  }
-  return SERVICE_PROVIDERS[key as ServiceProviderKeys]?.icon ?? 'compute';
-};
 
 interface SubFeatureCardProps {
   featureId: string;

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/public/utils/connector_display.test.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/public/utils/connector_display.test.ts
@@ -7,12 +7,7 @@
 
 import { InferenceConnectorType } from '@kbn/inference-common';
 import type { InferenceConnector } from '@kbn/inference-common';
-import type { InferenceAPIConfigResponse } from '@kbn/ml-trained-models-utils';
-import {
-  getConnectorIcon,
-  getConnectorTaskType,
-  mergeConnectorsAndEndpoints,
-} from './connector_display';
+import { getConnectorIcon } from './connector_display';
 
 const createConnector = (overrides: Partial<InferenceConnector>): InferenceConnector => ({
   type: InferenceConnectorType.Inference,
@@ -23,48 +18,6 @@ const createConnector = (overrides: Partial<InferenceConnector>): InferenceConne
   isInferenceEndpoint: true,
   isPreconfigured: false,
   ...overrides,
-});
-
-describe('getConnectorTaskType', () => {
-  it('returns chat_completion for stack OpenAI connectors', () => {
-    const connector = createConnector({
-      type: InferenceConnectorType.OpenAI,
-      isInferenceEndpoint: false,
-    });
-    expect(getConnectorTaskType(connector)).toBe('chat_completion');
-  });
-
-  it('returns chat_completion for stack Bedrock connectors', () => {
-    const connector = createConnector({
-      type: InferenceConnectorType.Bedrock,
-      isInferenceEndpoint: false,
-    });
-    expect(getConnectorTaskType(connector)).toBe('chat_completion');
-  });
-
-  it('returns chat_completion for stack Gemini connectors', () => {
-    const connector = createConnector({
-      type: InferenceConnectorType.Gemini,
-      isInferenceEndpoint: false,
-    });
-    expect(getConnectorTaskType(connector)).toBe('chat_completion');
-  });
-
-  it('returns config.taskType for inference endpoint connectors', () => {
-    const connector = createConnector({
-      isInferenceEndpoint: true,
-      config: { taskType: 'text_embedding' },
-    });
-    expect(getConnectorTaskType(connector)).toBe('text_embedding');
-  });
-
-  it('returns undefined when inference endpoint connector has no taskType', () => {
-    const connector = createConnector({
-      isInferenceEndpoint: true,
-      config: {},
-    });
-    expect(getConnectorTaskType(connector)).toBeUndefined();
-  });
 });
 
 describe('getConnectorIcon', () => {
@@ -90,109 +43,5 @@ describe('getConnectorIcon', () => {
       config: { service: 'unknown_service_xyz' },
     });
     expect(getConnectorIcon(connector)).toBe('compute');
-  });
-});
-
-describe('mergeConnectorsAndEndpoints', () => {
-  const connectors: InferenceConnector[] = [
-    createConnector({
-      connectorId: 'ep-1',
-      name: 'Connector EP-1',
-      config: { taskType: 'chat_completion', service: 'openai' },
-    }),
-    createConnector({
-      connectorId: 'stack-openai',
-      name: 'My Stack OpenAI',
-      type: InferenceConnectorType.OpenAI,
-      isInferenceEndpoint: false,
-      config: { apiProvider: 'OpenAI' },
-    }),
-  ];
-
-  const endpoints = [
-    // Overlaps with connector ep-1
-    {
-      inference_id: 'ep-1',
-      service: 'openai',
-      task_type: 'chat_completion',
-      service_settings: { model_id: 'gpt-4o' },
-    },
-    // New — not in connectors
-    {
-      inference_id: 'ep-embed',
-      service: 'elastic',
-      task_type: 'text_embedding',
-      service_settings: { model_id: 'e5' },
-      metadata: { display: { name: 'E5 Embedding' } },
-    },
-    // New — not in connectors
-    {
-      inference_id: 'ep-completion',
-      service: 'openai',
-      task_type: 'completion',
-      service_settings: { model_id: 'gpt-4o-completion' },
-    },
-  ] as InferenceAPIConfigResponse[];
-
-  it('includes all connectors', () => {
-    const result = mergeConnectorsAndEndpoints(connectors, endpoints);
-    const ids = result.map((r) => r.id);
-    expect(ids).toContain('ep-1');
-    expect(ids).toContain('stack-openai');
-  });
-
-  it('includes inference endpoints not present in connectors', () => {
-    const result = mergeConnectorsAndEndpoints(connectors, endpoints);
-    const ids = result.map((r) => r.id);
-    expect(ids).toContain('ep-embed');
-    expect(ids).toContain('ep-completion');
-  });
-
-  it('does not duplicate overlapping entries', () => {
-    const result = mergeConnectorsAndEndpoints(connectors, endpoints);
-    const ep1Entries = result.filter((r) => r.id === 'ep-1');
-    expect(ep1Entries).toHaveLength(1);
-  });
-
-  it('uses connector display name for overlapping entries', () => {
-    const result = mergeConnectorsAndEndpoints(connectors, endpoints);
-    const ep1 = result.find((r) => r.id === 'ep-1');
-    // Connector name wins over inference endpoint model_id
-    expect(ep1?.name).toBe('Connector EP-1');
-  });
-
-  it('uses inference endpoint display name for non-connector entries', () => {
-    const result = mergeConnectorsAndEndpoints(connectors, endpoints);
-    const embed = result.find((r) => r.id === 'ep-embed');
-    expect(embed?.name).toBe('E5 Embedding');
-  });
-
-  it('falls back to model_id for endpoints without display name metadata', () => {
-    const result = mergeConnectorsAndEndpoints(connectors, endpoints);
-    const completion = result.find((r) => r.id === 'ep-completion');
-    expect(completion?.name).toBe('gpt-4o-completion');
-  });
-
-  it('preserves task type from each source', () => {
-    const result = mergeConnectorsAndEndpoints(connectors, endpoints);
-    expect(result.find((r) => r.id === 'ep-1')?.taskType).toBe('chat_completion');
-    expect(result.find((r) => r.id === 'stack-openai')?.taskType).toBe('chat_completion');
-    expect(result.find((r) => r.id === 'ep-embed')?.taskType).toBe('text_embedding');
-    expect(result.find((r) => r.id === 'ep-completion')?.taskType).toBe('completion');
-  });
-
-  it('handles empty connectors', () => {
-    const result = mergeConnectorsAndEndpoints([], endpoints);
-    expect(result).toHaveLength(3);
-  });
-
-  it('handles empty endpoints', () => {
-    const result = mergeConnectorsAndEndpoints(connectors, []);
-    expect(result).toHaveLength(2);
-  });
-
-  it('handles both empty', () => {
-    const result = mergeConnectorsAndEndpoints([], []);
-    expect(result).toHaveLength(0);
   });
 });

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/public/utils/connector_display.test.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/public/utils/connector_display.test.ts
@@ -1,0 +1,198 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { InferenceConnectorType } from '@kbn/inference-common';
+import type { InferenceConnector } from '@kbn/inference-common';
+import type { InferenceAPIConfigResponse } from '@kbn/ml-trained-models-utils';
+import {
+  getConnectorIcon,
+  getConnectorTaskType,
+  mergeConnectorsAndEndpoints,
+} from './connector_display';
+
+const createConnector = (overrides: Partial<InferenceConnector>): InferenceConnector => ({
+  type: InferenceConnectorType.Inference,
+  name: 'test-connector',
+  connectorId: 'test-id',
+  config: {},
+  capabilities: {},
+  isInferenceEndpoint: true,
+  isPreconfigured: false,
+  ...overrides,
+});
+
+describe('getConnectorTaskType', () => {
+  it('returns chat_completion for stack OpenAI connectors', () => {
+    const connector = createConnector({
+      type: InferenceConnectorType.OpenAI,
+      isInferenceEndpoint: false,
+    });
+    expect(getConnectorTaskType(connector)).toBe('chat_completion');
+  });
+
+  it('returns chat_completion for stack Bedrock connectors', () => {
+    const connector = createConnector({
+      type: InferenceConnectorType.Bedrock,
+      isInferenceEndpoint: false,
+    });
+    expect(getConnectorTaskType(connector)).toBe('chat_completion');
+  });
+
+  it('returns chat_completion for stack Gemini connectors', () => {
+    const connector = createConnector({
+      type: InferenceConnectorType.Gemini,
+      isInferenceEndpoint: false,
+    });
+    expect(getConnectorTaskType(connector)).toBe('chat_completion');
+  });
+
+  it('returns config.taskType for inference endpoint connectors', () => {
+    const connector = createConnector({
+      isInferenceEndpoint: true,
+      config: { taskType: 'text_embedding' },
+    });
+    expect(getConnectorTaskType(connector)).toBe('text_embedding');
+  });
+
+  it('returns undefined when inference endpoint connector has no taskType', () => {
+    const connector = createConnector({
+      isInferenceEndpoint: true,
+      config: {},
+    });
+    expect(getConnectorTaskType(connector)).toBeUndefined();
+  });
+});
+
+describe('getConnectorIcon', () => {
+  it('returns openai icon for OpenAI connectors', () => {
+    const connector = createConnector({
+      type: InferenceConnectorType.OpenAI,
+      config: { apiProvider: 'OpenAI' },
+    });
+    expect(getConnectorIcon(connector)).not.toBe('compute');
+  });
+
+  it('returns azureopenai icon for Azure OpenAI connectors', () => {
+    const connector = createConnector({
+      type: InferenceConnectorType.OpenAI,
+      config: { apiProvider: 'Azure OpenAI' },
+    });
+    expect(getConnectorIcon(connector)).not.toBe('compute');
+  });
+
+  it('returns compute fallback for unknown provider', () => {
+    const connector = createConnector({
+      type: InferenceConnectorType.Inference,
+      config: { service: 'unknown_service_xyz' },
+    });
+    expect(getConnectorIcon(connector)).toBe('compute');
+  });
+});
+
+describe('mergeConnectorsAndEndpoints', () => {
+  const connectors: InferenceConnector[] = [
+    createConnector({
+      connectorId: 'ep-1',
+      name: 'Connector EP-1',
+      config: { taskType: 'chat_completion', service: 'openai' },
+    }),
+    createConnector({
+      connectorId: 'stack-openai',
+      name: 'My Stack OpenAI',
+      type: InferenceConnectorType.OpenAI,
+      isInferenceEndpoint: false,
+      config: { apiProvider: 'OpenAI' },
+    }),
+  ];
+
+  const endpoints = [
+    // Overlaps with connector ep-1
+    {
+      inference_id: 'ep-1',
+      service: 'openai',
+      task_type: 'chat_completion',
+      service_settings: { model_id: 'gpt-4o' },
+    },
+    // New — not in connectors
+    {
+      inference_id: 'ep-embed',
+      service: 'elastic',
+      task_type: 'text_embedding',
+      service_settings: { model_id: 'e5' },
+      metadata: { display: { name: 'E5 Embedding' } },
+    },
+    // New — not in connectors
+    {
+      inference_id: 'ep-completion',
+      service: 'openai',
+      task_type: 'completion',
+      service_settings: { model_id: 'gpt-4o-completion' },
+    },
+  ] as InferenceAPIConfigResponse[];
+
+  it('includes all connectors', () => {
+    const result = mergeConnectorsAndEndpoints(connectors, endpoints);
+    const ids = result.map((r) => r.id);
+    expect(ids).toContain('ep-1');
+    expect(ids).toContain('stack-openai');
+  });
+
+  it('includes inference endpoints not present in connectors', () => {
+    const result = mergeConnectorsAndEndpoints(connectors, endpoints);
+    const ids = result.map((r) => r.id);
+    expect(ids).toContain('ep-embed');
+    expect(ids).toContain('ep-completion');
+  });
+
+  it('does not duplicate overlapping entries', () => {
+    const result = mergeConnectorsAndEndpoints(connectors, endpoints);
+    const ep1Entries = result.filter((r) => r.id === 'ep-1');
+    expect(ep1Entries).toHaveLength(1);
+  });
+
+  it('uses connector display name for overlapping entries', () => {
+    const result = mergeConnectorsAndEndpoints(connectors, endpoints);
+    const ep1 = result.find((r) => r.id === 'ep-1');
+    // Connector name wins over inference endpoint model_id
+    expect(ep1?.name).toBe('Connector EP-1');
+  });
+
+  it('uses inference endpoint display name for non-connector entries', () => {
+    const result = mergeConnectorsAndEndpoints(connectors, endpoints);
+    const embed = result.find((r) => r.id === 'ep-embed');
+    expect(embed?.name).toBe('E5 Embedding');
+  });
+
+  it('falls back to model_id for endpoints without display name metadata', () => {
+    const result = mergeConnectorsAndEndpoints(connectors, endpoints);
+    const completion = result.find((r) => r.id === 'ep-completion');
+    expect(completion?.name).toBe('gpt-4o-completion');
+  });
+
+  it('preserves task type from each source', () => {
+    const result = mergeConnectorsAndEndpoints(connectors, endpoints);
+    expect(result.find((r) => r.id === 'ep-1')?.taskType).toBe('chat_completion');
+    expect(result.find((r) => r.id === 'stack-openai')?.taskType).toBe('chat_completion');
+    expect(result.find((r) => r.id === 'ep-embed')?.taskType).toBe('text_embedding');
+    expect(result.find((r) => r.id === 'ep-completion')?.taskType).toBe('completion');
+  });
+
+  it('handles empty connectors', () => {
+    const result = mergeConnectorsAndEndpoints([], endpoints);
+    expect(result).toHaveLength(3);
+  });
+
+  it('handles empty endpoints', () => {
+    const result = mergeConnectorsAndEndpoints(connectors, []);
+    expect(result).toHaveLength(2);
+  });
+
+  it('handles both empty', () => {
+    const result = mergeConnectorsAndEndpoints([], []);
+    expect(result).toHaveLength(0);
+  });
+});

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/public/utils/connector_display.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/public/utils/connector_display.ts
@@ -5,18 +5,11 @@
  * 2.0.
  */
 
-import type { InferenceAPIConfigResponse } from '@kbn/ml-trained-models-utils';
 import type { InferenceConnector } from '@kbn/inference-common';
 import { InferenceConnectorType } from '@kbn/inference-common';
 import { SERVICE_PROVIDERS } from '@kbn/inference-endpoint-ui-common';
 import type { ServiceProviderKeys } from '@kbn/inference-endpoint-ui-common';
-import {
-  isEisEndpoint,
-  getModelName,
-  getModelCreator,
-  getProviderKeyForCreator,
-} from './eis_utils';
-import { getModelId } from './get_model_id';
+import { getProviderKeyForCreator } from './eis_utils';
 
 /**
  * Returns the icon identifier for a given connector, suitable for use with EuiIcon.
@@ -41,94 +34,4 @@ export const getConnectorIcon = (connector: InferenceConnector): string => {
       break;
   }
   return SERVICE_PROVIDERS[key as ServiceProviderKeys]?.icon ?? 'compute';
-};
-
-/**
- * Returns the task type of a connector.
- *
- * Stack connectors (OpenAI, Bedrock, Gemini) are inherently chat_completion connectors.
- * ES inference endpoint connectors store their task type in `config.taskType`.
- */
-export const getConnectorTaskType = (connector: InferenceConnector): string | undefined => {
-  if (connector.isInferenceEndpoint) {
-    return connector.config?.taskType;
-  }
-  // Stack connectors (OpenAI, Bedrock, Gemini) are always chat_completion
-  return 'chat_completion';
-};
-
-/** Normalised item used by the Add Model popover. */
-export interface ModelOption {
-  id: string;
-  name: string;
-  icon: string;
-  taskType: string | undefined;
-}
-
-/**
- * Returns the icon for a raw ES inference endpoint (not wrapped in an InferenceConnector).
- */
-const getEndpointIcon = (endpoint: InferenceAPIConfigResponse): string => {
-  if (isEisEndpoint(endpoint)) {
-    const creator = getModelCreator(endpoint);
-    const providerKey = getProviderKeyForCreator(creator);
-    return (providerKey && SERVICE_PROVIDERS[providerKey]?.icon) ?? 'compute';
-  }
-  const provider = SERVICE_PROVIDERS[endpoint.service as ServiceProviderKeys];
-  return provider?.icon ?? 'compute';
-};
-
-/**
- * Returns the display name for a raw ES inference endpoint.
- */
-const getEndpointName = (endpoint: InferenceAPIConfigResponse): string => {
-  if (isEisEndpoint(endpoint)) {
-    return getModelName(endpoint);
-  }
-  return getModelId(endpoint) ?? endpoint.inference_id;
-};
-
-/**
- * Merges connectors (from `useConnectors`, which includes stack connectors
- * and `chat_completion` inference endpoints) with the full set of ES inference
- * endpoints (from `useQueryInferenceEndpoints`, all task types).
- *
- * Connectors are the primary source because they carry richer display information.
- * Inference endpoints that are not already represented as connectors are added so
- * that non-`chat_completion` task types (e.g. `completion`, `text_embedding`) are
- * still available for selection.
- */
-export const mergeConnectorsAndEndpoints = (
-  connectors: InferenceConnector[],
-  inferenceEndpoints: InferenceAPIConfigResponse[]
-): ModelOption[] => {
-  const seen = new Set<string>();
-  const items: ModelOption[] = [];
-
-  // 1. Add all connectors first (stack connectors + chat_completion inference endpoints).
-  for (const connector of connectors) {
-    seen.add(connector.connectorId);
-    items.push({
-      id: connector.connectorId,
-      name: connector.name,
-      icon: getConnectorIcon(connector),
-      taskType: getConnectorTaskType(connector),
-    });
-  }
-
-  // 2. Add inference endpoints that weren't already covered by connectors.
-  //    This covers non-chat_completion task types (completion, text_embedding, etc.).
-  for (const endpoint of inferenceEndpoints) {
-    if (!seen.has(endpoint.inference_id)) {
-      seen.add(endpoint.inference_id);
-      items.push({
-        id: endpoint.inference_id,
-        name: getEndpointName(endpoint),
-        icon: getEndpointIcon(endpoint),
-        taskType: endpoint.task_type,
-      });
-    }
-  }
-
-  return items;
 };

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/public/utils/connector_display.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/public/utils/connector_display.ts
@@ -5,11 +5,18 @@
  * 2.0.
  */
 
+import type { InferenceAPIConfigResponse } from '@kbn/ml-trained-models-utils';
 import type { InferenceConnector } from '@kbn/inference-common';
 import { InferenceConnectorType } from '@kbn/inference-common';
 import { SERVICE_PROVIDERS } from '@kbn/inference-endpoint-ui-common';
 import type { ServiceProviderKeys } from '@kbn/inference-endpoint-ui-common';
-import { getProviderKeyForCreator } from './eis_utils';
+import {
+  isEisEndpoint,
+  getModelName,
+  getModelCreator,
+  getProviderKeyForCreator,
+} from './eis_utils';
+import { getModelId } from './get_model_id';
 
 /**
  * Returns the icon identifier for a given connector, suitable for use with EuiIcon.
@@ -48,4 +55,80 @@ export const getConnectorTaskType = (connector: InferenceConnector): string | un
   }
   // Stack connectors (OpenAI, Bedrock, Gemini) are always chat_completion
   return 'chat_completion';
+};
+
+/** Normalised item used by the Add Model popover. */
+export interface ModelOption {
+  id: string;
+  name: string;
+  icon: string;
+  taskType: string | undefined;
+}
+
+/**
+ * Returns the icon for a raw ES inference endpoint (not wrapped in an InferenceConnector).
+ */
+const getEndpointIcon = (endpoint: InferenceAPIConfigResponse): string => {
+  if (isEisEndpoint(endpoint)) {
+    const creator = getModelCreator(endpoint);
+    const providerKey = getProviderKeyForCreator(creator);
+    return (providerKey && SERVICE_PROVIDERS[providerKey]?.icon) ?? 'compute';
+  }
+  const provider = SERVICE_PROVIDERS[endpoint.service as ServiceProviderKeys];
+  return provider?.icon ?? 'compute';
+};
+
+/**
+ * Returns the display name for a raw ES inference endpoint.
+ */
+const getEndpointName = (endpoint: InferenceAPIConfigResponse): string => {
+  if (isEisEndpoint(endpoint)) {
+    return getModelName(endpoint);
+  }
+  return getModelId(endpoint) ?? endpoint.inference_id;
+};
+
+/**
+ * Merges connectors (from `useConnectors`, which includes stack connectors
+ * and `chat_completion` inference endpoints) with the full set of ES inference
+ * endpoints (from `useQueryInferenceEndpoints`, all task types).
+ *
+ * Connectors are the primary source because they carry richer display information.
+ * Inference endpoints that are not already represented as connectors are added so
+ * that non-`chat_completion` task types (e.g. `completion`, `text_embedding`) are
+ * still available for selection.
+ */
+export const mergeConnectorsAndEndpoints = (
+  connectors: InferenceConnector[],
+  inferenceEndpoints: InferenceAPIConfigResponse[]
+): ModelOption[] => {
+  const seen = new Set<string>();
+  const items: ModelOption[] = [];
+
+  // 1. Add all connectors first (stack connectors + chat_completion inference endpoints).
+  for (const connector of connectors) {
+    seen.add(connector.connectorId);
+    items.push({
+      id: connector.connectorId,
+      name: connector.name,
+      icon: getConnectorIcon(connector),
+      taskType: getConnectorTaskType(connector),
+    });
+  }
+
+  // 2. Add inference endpoints that weren't already covered by connectors.
+  //    This covers non-chat_completion task types (completion, text_embedding, etc.).
+  for (const endpoint of inferenceEndpoints) {
+    if (!seen.has(endpoint.inference_id)) {
+      seen.add(endpoint.inference_id);
+      items.push({
+        id: endpoint.inference_id,
+        name: getEndpointName(endpoint),
+        icon: getEndpointIcon(endpoint),
+        taskType: endpoint.task_type,
+      });
+    }
+  }
+
+  return items;
 };

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/public/utils/connector_display.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/public/utils/connector_display.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { InferenceConnector } from '@kbn/inference-common';
+import { InferenceConnectorType } from '@kbn/inference-common';
+import { SERVICE_PROVIDERS } from '@kbn/inference-endpoint-ui-common';
+import type { ServiceProviderKeys } from '@kbn/inference-endpoint-ui-common';
+import { getProviderKeyForCreator } from './eis_utils';
+
+/**
+ * Returns the icon identifier for a given connector, suitable for use with EuiIcon.
+ */
+export const getConnectorIcon = (connector: InferenceConnector): string => {
+  let key: string | undefined;
+  switch (connector.type) {
+    case InferenceConnectorType.OpenAI:
+      key = connector.config?.apiProvider === 'Azure OpenAI' ? 'azureopenai' : 'openai';
+      break;
+    case InferenceConnectorType.Bedrock:
+      key = 'amazonbedrock';
+      break;
+    case InferenceConnectorType.Gemini:
+      key = 'googlevertexai';
+      break;
+    case InferenceConnectorType.Inference:
+      key =
+        getProviderKeyForCreator(connector.config?.modelCreator) ??
+        connector.config?.service ??
+        connector.config?.provider;
+      break;
+  }
+  return SERVICE_PROVIDERS[key as ServiceProviderKeys]?.icon ?? 'compute';
+};
+
+/**
+ * Returns the task type of a connector.
+ *
+ * Stack connectors (OpenAI, Bedrock, Gemini) are inherently chat_completion connectors.
+ * ES inference endpoint connectors store their task type in `config.taskType`.
+ */
+export const getConnectorTaskType = (connector: InferenceConnector): string | undefined => {
+  if (connector.isInferenceEndpoint) {
+    return connector.config?.taskType;
+  }
+  // Stack connectors (OpenAI, Bedrock, Gemini) are always chat_completion
+  return 'chat_completion';
+};

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/test/scout_inference_test/ui/fixtures/mocks.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/test/scout_inference_test/ui/fixtures/mocks.ts
@@ -10,42 +10,77 @@ import type { ScoutPage } from '@kbn/scout';
 const CONNECTORS_ROUTE = '**/internal/inference/connectors';
 const ENDPOINTS_ROUTE = '**/internal/inference_endpoints/endpoints';
 
-export async function mockConnectors(page: ScoutPage) {
+interface MockEndpoint {
+  inference_id: string;
+  task_type: string;
+  service: string;
+  service_settings?: Record<string, unknown>;
+  metadata?: {
+    display?: { name?: string; model_creator?: string };
+    [key: string]: unknown;
+  };
+}
+
+const STACK_CONNECTOR = {
+  connectorId: 'mock-connector',
+  name: 'Mock Connector',
+  type: '.gen-ai',
+  config: {},
+  capabilities: {},
+  isPreconfigured: false,
+};
+
+// Mirrors the server-side transformation in getConnectorList: chat_completion
+// inference endpoints surface in /internal/inference/connectors as Inference-type
+// connectors so the Add Model popover can list them alongside stack connectors.
+const endpointsAsConnectors = (endpoints: MockEndpoint[]) =>
+  endpoints
+    .filter((ep) => ep.task_type === 'chat_completion')
+    .map((ep) => ({
+      connectorId: ep.inference_id,
+      name: ep.metadata?.display?.name ?? ep.inference_id,
+      type: '.inference',
+      config: {
+        inferenceId: ep.inference_id,
+        taskType: ep.task_type,
+        service: ep.service,
+        serviceSettings: ep.service_settings,
+        modelCreator: ep.metadata?.display?.model_creator,
+      },
+      capabilities: {},
+      isInferenceEndpoint: true,
+      isPreconfigured: !!ep.metadata?.display?.name,
+      isEis: ep.service === 'elastic',
+    }));
+
+const fulfillConnectors = async (page: ScoutPage, connectors: unknown[]) => {
   await page.route(CONNECTORS_ROUTE, async (route) => {
     await route.fulfill({
       status: 200,
       contentType: 'application/json',
-      body: JSON.stringify({
-        connectors: [
-          {
-            connectorId: 'mock-connector',
-            name: 'Mock Connector',
-            type: '.gen-ai',
-            config: {},
-            capabilities: {},
-            isPreconfigured: false,
-          },
-        ],
-      }),
+      body: JSON.stringify({ connectors }),
     });
   });
+};
+
+export async function mockConnectors(page: ScoutPage) {
+  await fulfillConnectors(page, [STACK_CONNECTOR]);
 }
 
 export async function mockEmptyConnectors(page: ScoutPage) {
-  await page.route(CONNECTORS_ROUTE, async (route) => {
-    await route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ connectors: [] }),
-    });
-  });
+  await fulfillConnectors(page, []);
 }
 
 export async function unmockConnectors(page: ScoutPage) {
   await page.unroute(CONNECTORS_ROUTE);
 }
 
-export async function mockInferenceEndpoints(page: ScoutPage, endpoints: unknown[]) {
+export async function mockInferenceEndpoints(page: ScoutPage, endpoints: MockEndpoint[]) {
+  // Re-mock the connectors route so the Add Model popover (which reads from
+  // /internal/inference/connectors only) sees the same endpoint set.
+  await page.unroute(CONNECTORS_ROUTE);
+  await fulfillConnectors(page, [STACK_CONNECTOR, ...endpointsAsConnectors(endpoints)]);
+
   await page.route(ENDPOINTS_ROUTE, async (route) => {
     await route.fulfill({
       status: 200,


### PR DESCRIPTION
## Summary

This fixes some stack connectors not showing up in the Add Model popover.

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->