### PR TITLE
[scout][fix] return unique serverRunFlags entries per config

### DIFF
--- a/src/platform/packages/shared/kbn-scout/src/tests_discovery/tag_utils.test.ts
+++ b/src/platform/packages/shared/kbn-scout/src/tests_discovery/tag_utils.test.ts
@@ -119,13 +119,12 @@ describe('getServerRunFlagsFromTags', () => {
     expect(result).toContain('--arch stateful --domain classic');
   });
 
-  it('returns one flag per tag when multiple tags map to same arch/domain', () => {
+  it('dedupes flags when multiple tag aliases map to the same arch/domain', () => {
     const result = getServerRunFlagsFromTags([
       '@local-stateful-classic',
       '@cloud-stateful-classic',
     ]);
-    expect(result).toContain('--arch stateful --domain classic');
-    expect(result).toHaveLength(2);
+    expect(result).toEqual(['--arch stateful --domain classic']);
   });
 
   it('returns only flags for supported arch/domain combinations', () => {

--- a/src/platform/packages/shared/kbn-scout/src/tests_discovery/tag_utils.ts
+++ b/src/platform/packages/shared/kbn-scout/src/tests_discovery/tag_utils.ts
@@ -48,7 +48,10 @@ export const collectUniqueTags = (
   return Array.from(tagSet);
 };
 
-// Converts tags to server run flags
+// Converts tags to server run flags. The result is deduplicated by (arch, domain) because
+// multiple tag aliases (e.g. `@local-stateful-classic` and `@cloud-stateful-classic`) can
+// resolve to the same target; consumers iterate the flags to fan out test runs and would
+// otherwise execute the same (arch, domain) twice.
 export const getServerRunFlagsFromTags = (testTags: string[]): string[] => {
   const supportedArchDomainCombos: [ScoutTargetArch, ScoutTargetDomain][] = [
     ['stateful', 'classic'],
@@ -62,7 +65,7 @@ export const getServerRunFlagsFromTags = (testTags: string[]): string[] => {
   ];
   // TODO: Uncomment above to run tests for these targets in CI
 
-  return [...new Set(testTags)]
+  const flags = [...new Set(testTags)]
     .map((tag) => ScoutTestTarget.fromPlaywrightTag(tag))
     .filter((target) =>
       supportedArchDomainCombos.some(
@@ -70,4 +73,6 @@ export const getServerRunFlagsFromTags = (testTags: string[]): string[] => {
       )
     )
     .map((target) => `--arch ${target.arch} --domain ${target.domain}`);
+
+  return [...new Set(flags)];
 };


### PR DESCRIPTION
## Summary

Today `@local-stateful-classic` and `@cloud-stateful-classic` both map to `stateful/classic` , and the function under configs discovery intentionally returns both. 

This PR fixes duplicates so we have only unique `serverRunFlags` entries

It should solve some issues, e.g. flaky-test-runnuer for Scout picks up workers based on these entries.

Current sample (before fix):

```json
      {
        "path": "x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/api/playwright.config.ts",
        "hasTests": true,
        "tags": [
          "@local-stateful-classic",
          "@cloud-stateful-classic"
        ],
        "serverRunFlags": [
          "--arch stateful --domain classic",
          "--arch stateful --domain classic"
        ],
        "usesParallelWorkers": false
      },
```





<!--ONMERGE {"backportTargets":["8.19","9.2","9.3","9.4"]} ONMERGE-->