### PR TITLE
Gracefully handle deprecated telemetry config

### DIFF
--- a/src/platform/plugins/shared/telemetry/moon.yml
+++ b/src/platform/plugins/shared/telemetry/moon.yml
@@ -46,6 +46,7 @@ dependsOn:
   - '@kbn/logging'
   - '@kbn/core-security-server'
   - '@kbn/telemetry-config'
+  - '@kbn/config'
 tags:
   - plugin
   - prod

--- a/src/platform/plugins/shared/telemetry/server/config/config.test.ts
+++ b/src/platform/plugins/shared/telemetry/server/config/config.test.ts
@@ -7,7 +7,23 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { applyDeprecations, configDeprecationFactory } from '@kbn/config';
+import { configDeprecationsMock } from '@kbn/core/server/mocks';
 import { config } from './config';
+
+const applyConfigDeprecations = (telemetrySettings: Record<string, unknown> = {}) => {
+  const deprecationContext = configDeprecationsMock.createContext();
+  const deprecations = config.deprecations!(configDeprecationFactory);
+  const { config: migrated } = applyDeprecations(
+    { telemetry: telemetrySettings },
+    deprecations.map((deprecation) => ({
+      deprecation,
+      path: 'telemetry',
+      context: deprecationContext,
+    }))
+  );
+  return migrated as Record<string, Record<string, unknown>>;
+};
 
 describe('config', () => {
   const baseContext = {
@@ -61,5 +77,52 @@ describe('config', () => {
         ).toThrow();
       }
     );
+  });
+
+  describe('deprecations: telemetry.enabled', () => {
+    describe('when telemetry.enabled is set to a falsy value, the plugin stays enabled and telemetry is opted out', () => {
+      test.each([false, 'false', 'False', 'FALSE'])(
+        'migrates telemetry.enabled: %p → removes enabled, sets optIn and allowChangingOptInStatus to false',
+        (enabledValue) => {
+          const migrated = applyConfigDeprecations({ enabled: enabledValue });
+
+          expect(migrated.telemetry.enabled).toBeUndefined();
+          expect(migrated.telemetry.optIn).toBe(false);
+          expect(migrated.telemetry.allowChangingOptInStatus).toBe(false);
+        }
+      );
+
+      test.each([false, 'false', 'False', 'FALSE'])(
+        'also disables tracing and metrics when telemetry.enabled: %p',
+        (enabledValue) => {
+          const migrated = applyConfigDeprecations({ enabled: enabledValue });
+
+          const telemetry = migrated.telemetry as Record<string, Record<string, unknown>>;
+          expect(telemetry.tracing?.enabled).toBe(false);
+          expect(telemetry.metrics?.enabled).toBe(false);
+        }
+      );
+    });
+
+    describe('when telemetry.enabled is absent or truthy, the deprecation does not fire', () => {
+      test('does not modify config when telemetry.enabled is not set', () => {
+        const migrated = applyConfigDeprecations({});
+
+        expect(migrated.telemetry.enabled).toBeUndefined();
+        expect(migrated.telemetry.optIn).toBeUndefined();
+        expect(migrated.telemetry.allowChangingOptInStatus).toBeUndefined();
+      });
+
+      test.each([true, 'true', 'True', 'TRUE'])(
+        'does not modify config when telemetry.enabled: %p',
+        (enabledValue) => {
+          const migrated = applyConfigDeprecations({ enabled: enabledValue });
+
+          expect(migrated.telemetry.enabled).toBe(enabledValue);
+          expect(migrated.telemetry.optIn).toBeUndefined();
+          expect(migrated.telemetry.allowChangingOptInStatus).toBeUndefined();
+        }
+      );
+    });
   });
 });

--- a/src/platform/plugins/shared/telemetry/server/config/config.ts
+++ b/src/platform/plugins/shared/telemetry/server/config/config.ts
@@ -76,7 +76,11 @@ export const config: PluginConfigDescriptor<TelemetryConfigType> = {
   },
   deprecations: () => [
     (cfg) => {
-      if (cfg.telemetry?.enabled === false) {
+      const raw = cfg.telemetry?.enabled;
+      const isDisabling =
+        raw === false || (typeof raw === 'string' && raw.toLowerCase() === 'false');
+
+      if (isDisabling) {
         return {
           set: [
             { path: 'telemetry.optIn', value: false },

--- a/src/platform/plugins/shared/telemetry/tsconfig.json
+++ b/src/platform/plugins/shared/telemetry/tsconfig.json
@@ -41,6 +41,7 @@
     "@kbn/logging",
     "@kbn/core-security-server",
     "@kbn/telemetry-config",
+    "@kbn/config",
   ],
   "exclude": [
     "target/**/*",


### PR DESCRIPTION
## Summary

Informed from [internal slack thread](https://elastic.slack.com/archives/C0D8P2XK5/p1777023957119899)

`telemetry.enabled` is a deprecated config key. Its intended migration path is to translate a value of `false` into `telemetry.optIn: false` + `telemetry.allowChangingOptInStatus: false` and then remove the key, so that the telemetry plugin itself continues to load while honoring the user's intent to opt out. This allows dependent plugins — including `security_solution`, `fleet`, and others that declare `telemetry` as a `requiredPlugin` — to continue functioning normally.

## The bug

The deprecation handler was checking for the disabled case with strict equality:

```ts
if (cfg.telemetry?.enabled === false) { ... }
```

This did not account for the string `"false"`, which is a valid YAML value and one that `@kbn/config-schema`'s `schema.boolean()` type explicitly coerces to the boolean `false`. The two systems run at different moments in the startup pipeline:

1. **Deprecations run first**, against the raw, pre-schema config object coming directly from `kibana.yml`. At this point `"false"` is still a string, so `"false" === false` evaluates to `false` and the migration is silently skipped.
2. **Schema validation runs second**, inside `ConfigService.isEnabledAtPath`. Here `schema.boolean()` coerces the string `"false"` to the boolean `false`, causing `isEnabledAtPath` to return `false` and mark the plugin as disabled.

Because the plugin is disabled, every plugin that lists `telemetry` in its `requiredPlugins` is also transitively disabled — including `security_solution`, making it completely non-functional with no obvious error pointing to the root cause.

## The fix

The deprecation handler is updated to match any value that `schema.boolean()` would coerce to `false` — both the native boolean and any case-insensitive string variant — before schema validation has a chance to run, this ensures the migration fires regardless of how the value is expressed in `kibana.yml` (`false`, `"false"`, `"False"`, `"FALSE"`), removes `telemetry.enabled` from the config before `isEnabledAtPath` inspects it, and applies the correct opt-out semantics via `optIn` and `allowChangingOptInStatus`. The OpenTelemetry sub-configs (`tracing.enabled`, `metrics.enabled`) are also set to `false` for consistency.

## Tests

A new `deprecations: telemetry.enabled` suite is added to `config.test.ts`. It drives the deprecation function directly through `applyDeprecations` (the same code path core uses at startup), and asserts:

- All four falsy variants (`false`, `"false"`, `"False"`, `"FALSE"`) trigger the migration, unset `enabled`, and correctly populate `optIn`, `allowChangingOptInStatus`, `tracing.enabled`, and `metrics.enabled`.
- Absent or truthy values (`undefined`, `true`, `"true"`, `"True"`, `"TRUE"`) leave the config unchanged.

<!--ONMERGE {"backportTargets":["8.19","9.2","9.3","9.4"]} ONMERGE-->