### PR TITLE
Fix: [Security Solution][Bug] Connector ID does not get auto-rendered once get cleared, on the 'Add connector' modal on the Attack discovery page

### DIFF
--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/action_connector_form/connector_form_fields_global.test.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/action_connector_form/connector_form_fields_global.test.tsx
@@ -249,6 +249,32 @@ describe('ConnectorFormFieldsGlobal', () => {
     });
   });
 
+  it('re-applies auto-generated connector ID after name and id were cleared', async () => {
+    render(
+      <FormTestProvider onSubmit={onSubmit}>
+        <ConnectorFormFieldsGlobal canSave={true} isEdit={false} />
+      </FormTestProvider>
+    );
+
+    const nameInput = screen.getByTestId('nameInput');
+    const idInput = screen.getByTestId('connectorIdInput');
+
+    await userEvent.type(nameInput, 'First Name');
+
+    await waitFor(() => {
+      expect(idInput).toHaveValue('first-name');
+    });
+
+    await userEvent.clear(nameInput);
+    await userEvent.clear(idInput);
+
+    await userEvent.type(nameInput, 'Second Name');
+
+    await waitFor(() => {
+      expect(idInput).toHaveValue('second-name');
+    });
+  });
+
   it('truncates auto-populated connector ID to 36 characters', async () => {
     render(
       <FormTestProvider onSubmit={onSubmit}>

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/action_connector_form/connector_form_fields_global.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/action_connector_form/connector_form_fields_global.tsx
@@ -196,8 +196,15 @@ const ConnectorFormFieldsGlobalComponent: React.FC<ConnectorFormFieldsProps> = (
 }) => {
   const { http } = useKibana().services;
   const { setFieldValue } = useFormContext();
-  const [{ name }] = useFormData<ConnectorFormData>({ watch: ['name', 'id'] });
+  const [{ name, id }] = useFormData<ConnectorFormData>({ watch: ['name', 'id'] });
   const [usingCustomIdentifier, setUsingCustomIdentifier] = useState(false);
+
+  useEffect(() => {
+    const isEmpty = (value: string | undefined) => value == null || value === '';
+    if (!isEdit && isEmpty(name) && isEmpty(id)) {
+      setUsingCustomIdentifier(false);
+    }
+  }, [name, id, isEdit]);
 
   useEffect(() => {
     if (!isEdit && !usingCustomIdentifier && name) {


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/262517

# PR summary: Fix connector ID auto-fill after clearing fields (Attack discovery / Add connector)

## What changed

The **Add connector** flow (Stack Management and embedded UIs such as **Security → Attack discovery → Settings → Add connector**) uses `ConnectorFormFieldsGlobal` in `triggers_actions_ui`. Connector ID is auto-derived from the connector name unless the user edits the ID (`usingCustomIdentifier`).

Clearing the ID while a name was still set set `usingCustomIdentifier` to `true` (because `'' !== toSlugIdentifier(name)`). After the user also cleared the name, that flag stayed `true`, so typing a new name no longer updated the ID.

**Fix:** When creating a connector (`!isEdit`), if both **name** and **id** are empty, reset `usingCustomIdentifier` to `false` so slug auto-fill works again. The form already watches `id` via `useFormData`.

## Files

- `x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/action_connector_form/connector_form_fields_global.tsx` — reset logic
- `x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/action_connector_form/connector_form_fields_global.test.tsx` — regression test

## Verification

1. **Unit tests**

   ```bash
   node scripts/jest /absolute/path/to/worktree/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/action_connector_form/connector_form_fields_global.test.tsx
   ```

   (Use an absolute path if your worktree is not the primary Kibana checkout; otherwise relative `x-pack/...` is fine.)

2. **Manual (Attack discovery)**

   Security → Attack discovery → settings → Add connector → pick a type → enter name (ID fills) → clear ID and name → enter name again → ID should auto-fill.


---

_PR developed with Cursor + Headless Orchestrator_