### PR TITLE
Fix: [Security Solution][Attacks/Alerts] Link attack name in attack details flyout to schedule details

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/components/header_title.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/components/header_title.test.tsx
@@ -7,6 +7,8 @@
 
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ATTACK_DISCOVERY_AD_HOC_RULE_ID } from '@kbn/elastic-assistant-common';
 
 import { HeaderTitle } from './header_title';
 import { TestProviders } from '../../../common/mock';
@@ -17,6 +19,7 @@ import {
   HEADER_ALERTS_BLOCK_TEST_ID,
   HEADER_ASSIGNEES_BLOCK_TEST_ID,
   HEADER_BADGE_TEST_ID,
+  HEADER_TITLE_SCHEDULE_LINK_TEST_ID,
 } from '../constants/test_ids';
 
 jest.mock('../hooks/use_header_data', () => ({
@@ -32,7 +35,19 @@ jest.mock('../hooks/use_navigate_to_attack_details_left_panel', () => ({
 }));
 
 jest.mock('../../../flyout_v2/shared/components/flyout_title', () => ({
-  FlyoutTitle: ({ title }: { title: string }) => <div data-test-subj="flyout-title">{title}</div>,
+  FlyoutTitle: ({ title, isLink }: { title: string; isLink?: boolean }) => (
+    <div data-test-subj="flyout-title" data-is-link={isLink === true ? 'true' : 'false'}>
+      {title}
+    </div>
+  ),
+}));
+
+jest.mock('../../../attack_discovery/pages/settings_flyout/schedule/details_flyout', () => ({
+  DetailsFlyout: ({ scheduleId, onClose }: { scheduleId: string; onClose: () => void }) => (
+    <div data-test-subj="schedule-details-flyout-mock" data-schedule-id={scheduleId}>
+      <button type="button" data-test-subj="schedule-details-close" onClick={onClose} />
+    </div>
+  ),
 }));
 
 jest.mock('../../../common/components/formatted_date', () => ({
@@ -78,6 +93,7 @@ describe('HeaderTitle', () => {
     });
     mockedUseAttackDetailsContext.mockReturnValue({
       attackId: 'attack-1',
+      attack: { alertRuleUuid: ATTACK_DISCOVERY_AD_HOC_RULE_ID },
       searchHit: { _index: '.alerts-security.alerts-default', _id: 'attack-1' },
     });
     mockedUseNavigateToAttackDetailsLeftPanel.mockReturnValue(jest.fn());
@@ -152,5 +168,56 @@ describe('HeaderTitle', () => {
 
     expect(screen.getByTestId(HEADER_ASSIGNEES_BLOCK_TEST_ID)).toBeInTheDocument();
     expect(screen.getByTestId('assignees')).toBeInTheDocument();
+  });
+
+  it('renders the title as a plain title when the attack is ad hoc', () => {
+    render(
+      <TestProviders>
+        <HeaderTitle />
+      </TestProviders>
+    );
+
+    expect(screen.queryByTestId(HEADER_TITLE_SCHEDULE_LINK_TEST_ID)).not.toBeInTheDocument();
+    expect(screen.getByTestId('flyout-title')).toHaveAttribute('data-is-link', 'false');
+  });
+
+  it('renders the title as a link for scheduled attacks', () => {
+    mockedUseAttackDetailsContext.mockReturnValue({
+      attackId: 'attack-1',
+      attack: { alertRuleUuid: 'attack-discovery-schedule-rule-uuid' },
+      searchHit: { _index: '.alerts-security.alerts-default', _id: 'attack-1' },
+    });
+
+    render(
+      <TestProviders>
+        <HeaderTitle />
+      </TestProviders>
+    );
+
+    expect(screen.getByTestId(HEADER_TITLE_SCHEDULE_LINK_TEST_ID)).toBeInTheDocument();
+    expect(screen.getByTestId('flyout-title')).toHaveAttribute('data-is-link', 'true');
+  });
+
+  it('opens the schedule details flyout when the title link is clicked', async () => {
+    mockedUseAttackDetailsContext.mockReturnValue({
+      attackId: 'attack-1',
+      attack: { alertRuleUuid: 'attack-discovery-schedule-rule-uuid' },
+      searchHit: { _index: '.alerts-security.alerts-default', _id: 'attack-1' },
+    });
+
+    const user = userEvent.setup();
+
+    render(
+      <TestProviders>
+        <HeaderTitle />
+      </TestProviders>
+    );
+
+    await user.click(screen.getByTestId(HEADER_TITLE_SCHEDULE_LINK_TEST_ID));
+
+    expect(screen.getByTestId('schedule-details-flyout-mock')).toHaveAttribute(
+      'data-schedule-id',
+      'attack-discovery-schedule-rule-uuid'
+    );
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/components/header_title.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/components/header_title.tsx
@@ -5,10 +5,11 @@
  * 2.0.
  */
 
-import React, { memo } from 'react';
-import { EuiBadge, EuiFlexGroup, EuiFlexItem, EuiSpacer } from '@elastic/eui';
+import React, { memo, useCallback, useMemo, useState } from 'react';
+import { EuiBadge, EuiFlexGroup, EuiFlexItem, EuiLink, EuiSpacer } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
+import { ATTACK_DISCOVERY_AD_HOC_RULE_ID } from '@kbn/elastic-assistant-common';
 import { flyoutHeaderBlockStyles } from '../../../flyout_v2/document/constants/styles';
 import { FlyoutTitle } from '../../../flyout_v2/shared/components/flyout_title';
 import { PreferenceFormattedDate } from '../../../common/components/formatted_date';
@@ -20,11 +21,14 @@ import {
   HEADER_ALERTS_BLOCK_TEST_ID,
   HEADER_ASSIGNEES_BLOCK_TEST_ID,
   HEADER_BADGE_TEST_ID,
+  HEADER_TITLE_SCHEDULE_LINK_TEST_ID,
   HEADER_TITLE_TEST_ID,
 } from '../constants/test_ids';
 import { useHeaderData } from '../hooks/use_header_data';
 import { useAttackDetailsContext } from '../context';
 import { useNavigateToAttackDetailsLeftPanel } from '../hooks/use_navigate_to_attack_details_left_panel';
+import { DetailsFlyout } from '../../../attack_discovery/pages/settings_flyout/schedule/details_flyout';
+import { OPEN_SCHEDULE_DETAILS } from '../../../attack_discovery/pages/results/attack_discovery_panel/panel_header/primary_interactions/title/translations';
 
 const ATTACK_HEADER_BADGE = i18n.translate(
   'xpack.securitySolution.attackDetailsFlyout.header.badge.attackLabel',
@@ -38,8 +42,28 @@ const ATTACK_HEADER_BADGE = i18n.translate(
  */
 export const HeaderTitle = memo(() => {
   const { title, timestamp, alertsCount } = useHeaderData();
-  const { attackId } = useAttackDetailsContext();
+  const { attackId, attack } = useAttackDetailsContext();
   const openNotesTab = useNavigateToAttackDetailsLeftPanel({ tab: 'notes' });
+  const [scheduleDetailsId, setScheduleDetailsId] = useState<string | undefined>();
+
+  const alertRuleUuid = attack?.alertRuleUuid;
+  const isScheduled = useMemo(
+    () => alertRuleUuid != null && alertRuleUuid !== ATTACK_DISCOVERY_AD_HOC_RULE_ID,
+    [alertRuleUuid]
+  );
+
+  const openScheduleDetails = useCallback(() => {
+    if (alertRuleUuid == null) {
+      return;
+    }
+    setScheduleDetailsId(alertRuleUuid);
+  }, [alertRuleUuid]);
+
+  const closeScheduleDetails = useCallback(() => setScheduleDetailsId(undefined), []);
+
+  const titleBlock = (
+    <FlyoutTitle data-test-subj={HEADER_TITLE_TEST_ID} title={title} iconType={'bolt'} />
+  );
 
   return (
     <>
@@ -49,7 +73,22 @@ export const HeaderTitle = memo(() => {
           <EuiSpacer size="xs" />
         </>
       )}
-      <FlyoutTitle data-test-subj={HEADER_TITLE_TEST_ID} title={title} iconType={'bolt'} />
+      {isScheduled ? (
+        <EuiLink
+          aria-label={OPEN_SCHEDULE_DETAILS}
+          data-test-subj={HEADER_TITLE_SCHEDULE_LINK_TEST_ID}
+          onClick={openScheduleDetails}
+        >
+          <FlyoutTitle
+            data-test-subj={HEADER_TITLE_TEST_ID}
+            title={title}
+            iconType={'bolt'}
+            isLink
+          />
+        </EuiLink>
+      ) : (
+        titleBlock
+      )}
       <EuiSpacer size="s" />
       <EuiBadge
         aria-label={ATTACK_HEADER_BADGE}
@@ -104,6 +143,9 @@ export const HeaderTitle = memo(() => {
           </EuiFlexGroup>
         </EuiFlexItem>
       </EuiFlexGroup>
+      {scheduleDetailsId != null && (
+        <DetailsFlyout scheduleId={scheduleDetailsId} onClose={closeScheduleDetails} />
+      )}
     </>
   );
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/constants/test_ids.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/constants/test_ids.ts
@@ -16,6 +16,8 @@ export const STATUS_POPOVER_BUTTON_TEST_ID =
   `${ATTACK_DETAILS_FLYOUT_PREFIX}-status-popover-button` as const;
 export const STATUS_POPOVER_TEST_ID = `${ATTACK_DETAILS_FLYOUT_PREFIX}-status-popover` as const;
 export const HEADER_TITLE_TEST_ID = `${ATTACK_DETAILS_FLYOUT_PREFIX}-header-title` as const;
+export const HEADER_TITLE_SCHEDULE_LINK_TEST_ID =
+  `${ATTACK_DETAILS_FLYOUT_PREFIX}-header-title-schedule-link` as const;
 export const HEADER_ALERTS_BLOCK_TEST_ID =
   `${ATTACK_DETAILS_FLYOUT_PREFIX}-header-alerts-block` as const;
 export const HEADER_STATUS_BLOCK_TEST_ID =


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/262284

## Summary

The attack details flyout header now treats the attack title like the alert flyout treats the rule name: **scheduled** attacks show the title as an **EuiLink** that opens the existing **schedule details flyout** (`DetailsFlyout`) for the backing alerting rule (`attack.alertRuleUuid`). **Ad hoc** attacks (sentinel ID `attack_discovery_ad_hoc_rule_id`) keep a non-linked title.

## Changes

- `flyout/attack_details/components/header_title.tsx`: Link styling via `FlyoutTitle` `isLink`, click opens `DetailsFlyout`; state holds which schedule ID is open for close handling.
- `flyout/attack_details/constants/test_ids.ts`: Added `HEADER_TITLE_SCHEDULE_LINK_TEST_ID` for tests and automation.
- `flyout/attack_details/components/header_title.test.tsx`: Coverage for ad hoc vs scheduled title and opening the mocked schedule flyout.

Reuse: same schedule identification and `DetailsFlyout` wiring as `attack_discovery/pages/results/attack_discovery_panel/.../title/index.tsx`, and copy for “Open schedule details” aria-label from that panel.

## Verification

```bash
node scripts/eslint --fix $(git diff --name-only -- '*.tsx' '*.ts')

node scripts/jest x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/components/header_title.test.tsx
```

Manual: Open Attacks → open a scheduled attack’s details flyout → title should appear as a link → click opens the schedule details flyout for that schedule.


---

_PR developed with Cursor + Headless Orchestrator_