### PR TITLE
[9.3] chore(deps): bump `@xmldom/xmldom` from `0.8.12` to `0.8.13` (#266009)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -15339,9 +15339,9 @@
   integrity sha512-CJDxIgE5I0FH+ttq/Fxy6nRpxP70+e2O048EPe85J2use3XKdatVM7dDVvFNjQudd9B49NPoZ+8PG49zj4Er8Q==
 
 "@xmldom/xmldom@^0.8.10":
-  version "0.8.10"
-  resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.8.10.tgz#a1337ca426aa61cef9fe15b5b28e340a72f6fa99"
-  integrity sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==
+  version "0.8.13"
+  resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.8.13.tgz#00d1dd940b218dff2e49309d410d8bb212159225"
+  integrity sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==
 
 "@xobotyi/scrollbar-width@^1.9.5":
   version "1.9.5"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [chore(deps): bump `@xmldom/xmldom` from `0.8.12` to `0.8.13` (#266009)](https://github.com/elastic/kibana/pull/266009)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Aleh Zasypkin","email":"aleh.zasypkin@elastic.co"},"sourceCommit":{"committedDate":"2026-04-28T11:53:00Z","message":"chore(deps): bump `@xmldom/xmldom` from `0.8.12` to `0.8.13` (#266009)\n\n## Summary\n\nBump `@xmldom/xmldom` from `0.8.12` to `0.8.13`.","sha":"eecb12bc3e96377ff60015d36b94ac9fd9adb3f4","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","dependencies","backport:all-open","v9.5.0"],"title":"chore(deps): bump `@xmldom/xmldom` from `0.8.12` to `0.8.13`","number":266009,"url":"https://github.com/elastic/kibana/pull/266009","mergeCommit":{"message":"chore(deps): bump `@xmldom/xmldom` from `0.8.12` to `0.8.13` (#266009)\n\n## Summary\n\nBump `@xmldom/xmldom` from `0.8.12` to `0.8.13`.","sha":"eecb12bc3e96377ff60015d36b94ac9fd9adb3f4"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/266009","number":266009,"mergeCommit":{"message":"chore(deps): bump `@xmldom/xmldom` from `0.8.12` to `0.8.13` (#266009)\n\n## Summary\n\nBump `@xmldom/xmldom` from `0.8.12` to `0.8.13`.","sha":"eecb12bc3e96377ff60015d36b94ac9fd9adb3f4"}},{"url":"https://github.com/elastic/kibana/pull/266051","number":266051,"branch":"8.19","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/266052","number":266052,"branch":"9.4","state":"OPEN"}]}] BACKPORT-->