### PR TITLE
Fix: [Security Solution][Bug] Connector ID does not get auto-rendered once get cleared, on the 'Add connector' modal on the Attack discovery page

### DIFF
--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/action_connector_form/connector_form_fields_global.test.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/action_connector_form/connector_form_fields_global.test.tsx
@@ -249,6 +249,41 @@ describe('ConnectorFormFieldsGlobal', () => {
     });
   });
 
+  it('resumes auto-populating connector ID if both name and ID are cleared', async () => {
+    render(
+      <FormTestProvider onSubmit={onSubmit}>
+        <ConnectorFormFieldsGlobal canSave={true} isEdit={false} />
+      </FormTestProvider>
+    );
+
+    const nameInput = screen.getByTestId('nameInput');
+    const idInput = screen.getByTestId('connectorIdInput');
+
+    // Type name, ID gets auto-populated
+    await userEvent.type(nameInput, 'My Connector');
+    await waitFor(() => {
+      expect(idInput).toHaveValue('my-connector');
+    });
+
+    // Clear ID, stops auto-populating
+    await userEvent.clear(idInput);
+    await waitFor(() => {
+      expect(idInput).toHaveValue('');
+    });
+
+    // Clear name, both are now empty, should resume auto-populating
+    await userEvent.clear(nameInput);
+    await waitFor(() => {
+      expect(nameInput).toHaveValue('');
+    });
+
+    // Type name again, ID should get auto-populated
+    await userEvent.type(nameInput, 'New Connector');
+    await waitFor(() => {
+      expect(idInput).toHaveValue('new-connector');
+    });
+  });
+
   it('truncates auto-populated connector ID to 36 characters', async () => {
     render(
       <FormTestProvider onSubmit={onSubmit}>

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/action_connector_form/connector_form_fields_global.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/action_connector_form/connector_form_fields_global.tsx
@@ -196,8 +196,14 @@ const ConnectorFormFieldsGlobalComponent: React.FC<ConnectorFormFieldsProps> = (
 }) => {
   const { http } = useKibana().services;
   const { setFieldValue } = useFormContext();
-  const [{ name }] = useFormData<ConnectorFormData>({ watch: ['name', 'id'] });
+  const [{ name, id }] = useFormData<ConnectorFormData>({ watch: ['name', 'id'] });
   const [usingCustomIdentifier, setUsingCustomIdentifier] = useState(false);
+
+  useEffect(() => {
+    if (!name && !id) {
+      setUsingCustomIdentifier(false);
+    }
+  }, [name, id]);
 
   useEffect(() => {
     if (!isEdit && !usingCustomIdentifier && name) {


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/262517

## Summary
Fixed a bug where the connector ID does not get auto-rendered when the user clears both the connector ID and name, and then enters the connector name again.

The issue was that `usingCustomIdentifier` state in `ConnectorFormFieldsGlobal` was not being reset to `false` when both the connector name and ID were cleared. To fix this, an effect was added to reset `usingCustomIdentifier` to `false` when both `name` and `id` are empty. This ensures the connector ID resumes auto-populating from the connector name.

## Changed Files
- `x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/action_connector_form/connector_form_fields_global.tsx`: Added an effect to reset `usingCustomIdentifier` when both `name` and `id` are empty.
- `x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/action_connector_form/connector_form_fields_global.test.tsx`: Added a test case to verify that auto-populating resumes when both name and ID are cleared.

## Verification Steps
1. Navigate to `Security` > `Attack Discovery`.
2. Click on the settings icon present on the page to open the Attack discovery settings flyout.
3. Click on `Add Connector`.
4. Select a connector.
5. Add a connector name and observe that the connector ID is auto-rendered.
6. Clear the connector ID field.
7. Clear the connector name field.
8. Enter a connector name again.
9. Verify that the connector ID gets auto-rendered this time.

---

_PR developed with Cursor + Gemini 3.1 Pro_