### PR TITLE
Fix: [Security Solution][Attacks/Alerts] Link attack name in attack details flyout to schedule details

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/components/header_title.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/components/header_title.test.tsx
@@ -6,13 +6,14 @@
  */
 
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 
 import { HeaderTitle } from './header_title';
 import { TestProviders } from '../../../common/mock';
 import { useHeaderData } from '../hooks/use_header_data';
 import { useAttackDetailsContext } from '../context';
 import { useNavigateToAttackDetailsLeftPanel } from '../hooks/use_navigate_to_attack_details_left_panel';
+import { ATTACK_DISCOVERY_AD_HOC_RULE_ID } from '@kbn/elastic-assistant-common';
 import {
   HEADER_ALERTS_BLOCK_TEST_ID,
   HEADER_ASSIGNEES_BLOCK_TEST_ID,
@@ -32,7 +33,11 @@ jest.mock('../hooks/use_navigate_to_attack_details_left_panel', () => ({
 }));
 
 jest.mock('../../../flyout_v2/shared/components/flyout_title', () => ({
-  FlyoutTitle: ({ title }: { title: string }) => <div data-test-subj="flyout-title">{title}</div>,
+  FlyoutTitle: ({ title, isLink }: { title: string; isLink?: boolean }) => (
+    <div data-test-subj="flyout-title" data-is-link={isLink}>
+      {title}
+    </div>
+  ),
 }));
 
 jest.mock('../../../common/components/formatted_date', () => ({
@@ -65,6 +70,15 @@ jest.mock('../../../flyout_v2/shared/components/alert_header_block', () => ({
   }) => <div data-test-subj={dataTestSubj}>{children}</div>,
 }));
 
+jest.mock('../../../attack_discovery/pages/settings_flyout/schedule/details_flyout', () => ({
+  DetailsFlyout: ({ scheduleId, onClose }: { scheduleId: string; onClose: () => void }) => (
+    <div data-test-subj="schedule-details-flyout">
+      <span data-test-subj="schedule-id">{scheduleId}</span>
+      <button data-test-subj="close-schedule-details" onClick={onClose} />
+    </div>
+  ),
+}));
+
 const mockedUseHeaderData = useHeaderData as jest.Mock;
 const mockedUseAttackDetailsContext = useAttackDetailsContext as jest.Mock;
 const mockedUseNavigateToAttackDetailsLeftPanel = useNavigateToAttackDetailsLeftPanel as jest.Mock;
@@ -75,6 +89,7 @@ describe('HeaderTitle', () => {
       title: 'Suspicious PowerShell Activity',
       timestamp: '2024-10-10T10:00:00.000Z',
       alertsCount: 3,
+      alertRuleUuid: 'schedule-id-123',
     });
     mockedUseAttackDetailsContext.mockReturnValue({
       attackId: 'attack-1',
@@ -107,14 +122,53 @@ describe('HeaderTitle', () => {
     expect(screen.getByTestId('formatted-date')).toBeInTheDocument();
   });
 
-  it('renders the header title', () => {
+  it('renders the header title as a link when alertRuleUuid is valid', () => {
     render(
       <TestProviders>
         <HeaderTitle />
       </TestProviders>
     );
 
-    expect(screen.getByTestId('flyout-title')).toHaveTextContent('Suspicious PowerShell Activity');
+    const titleEl = screen.getByTestId('flyout-title');
+    expect(titleEl).toHaveTextContent('Suspicious PowerShell Activity');
+    expect(titleEl).toHaveAttribute('data-is-link', 'true');
+  });
+
+  it('renders the header title as plain text when alertRuleUuid is ad-hoc', () => {
+    mockedUseHeaderData.mockReturnValue({
+      title: 'Ad-hoc Attack',
+      timestamp: '2024-10-10T10:00:00.000Z',
+      alertsCount: 3,
+      alertRuleUuid: ATTACK_DISCOVERY_AD_HOC_RULE_ID,
+    });
+    render(
+      <TestProviders>
+        <HeaderTitle />
+      </TestProviders>
+    );
+
+    const titleEl = screen.getByTestId('flyout-title');
+    expect(titleEl).toHaveTextContent('Ad-hoc Attack');
+    expect(titleEl).not.toHaveAttribute('data-is-link', 'true');
+  });
+
+  it('opens and closes the schedule details flyout when title is clicked', () => {
+    render(
+      <TestProviders>
+        <HeaderTitle />
+      </TestProviders>
+    );
+
+    expect(screen.queryByTestId('schedule-details-flyout')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('flyout-title'));
+
+    expect(screen.getByTestId('schedule-details-flyout')).toBeInTheDocument();
+    expect(screen.getByTestId('schedule-id')).toHaveTextContent('schedule-id-123');
+
+    fireEvent.click(screen.getByTestId('close-schedule-details'));
+
+    expect(screen.queryByTestId('schedule-details-flyout')).not.toBeInTheDocument();
   });
 
   it('renders the alerts count', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/components/header_title.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/components/header_title.tsx
@@ -5,10 +5,11 @@
  * 2.0.
  */
 
-import React, { memo } from 'react';
-import { EuiBadge, EuiFlexGroup, EuiFlexItem, EuiSpacer } from '@elastic/eui';
+import React, { memo, useCallback, useState } from 'react';
+import { EuiBadge, EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiLink } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
+import { ATTACK_DISCOVERY_AD_HOC_RULE_ID } from '@kbn/elastic-assistant-common';
 import { flyoutHeaderBlockStyles } from '../../../flyout_v2/document/constants/styles';
 import { FlyoutTitle } from '../../../flyout_v2/shared/components/flyout_title';
 import { PreferenceFormattedDate } from '../../../common/components/formatted_date';
@@ -16,6 +17,7 @@ import { Status } from './status';
 import { Assignees } from './assignees';
 import { Notes } from '../../../flyout_v2/shared/components/notes';
 import { AlertHeaderBlock } from '../../../flyout_v2/shared/components/alert_header_block';
+import { DetailsFlyout as ScheduleDetailsFlyout } from '../../../attack_discovery/pages/settings_flyout/schedule/details_flyout';
 import {
   HEADER_ALERTS_BLOCK_TEST_ID,
   HEADER_ASSIGNEES_BLOCK_TEST_ID,
@@ -37,9 +39,21 @@ const ATTACK_HEADER_BADGE = i18n.translate(
  * Header data for the Attack details flyout
  */
 export const HeaderTitle = memo(() => {
-  const { title, timestamp, alertsCount } = useHeaderData();
+  const { title, timestamp, alertsCount, alertRuleUuid } = useHeaderData();
   const { attackId } = useAttackDetailsContext();
   const openNotesTab = useNavigateToAttackDetailsLeftPanel({ tab: 'notes' });
+
+  const [scheduleDetailsId, setScheduleDetailsId] = useState<string | undefined>(undefined);
+
+  const isScheduled = alertRuleUuid != null && alertRuleUuid !== ATTACK_DISCOVERY_AD_HOC_RULE_ID;
+
+  const openScheduleDetails = useCallback(() => {
+    if (alertRuleUuid) {
+      setScheduleDetailsId(alertRuleUuid);
+    }
+  }, [alertRuleUuid]);
+
+  const closeScheduleDetails = useCallback(() => setScheduleDetailsId(undefined), []);
 
   return (
     <>
@@ -49,7 +63,13 @@ export const HeaderTitle = memo(() => {
           <EuiSpacer size="xs" />
         </>
       )}
-      <FlyoutTitle data-test-subj={HEADER_TITLE_TEST_ID} title={title} iconType={'bolt'} />
+      {isScheduled ? (
+        <EuiLink onClick={openScheduleDetails}>
+          <FlyoutTitle data-test-subj={HEADER_TITLE_TEST_ID} title={title} iconType={'bolt'} isLink />
+        </EuiLink>
+      ) : (
+        <FlyoutTitle data-test-subj={HEADER_TITLE_TEST_ID} title={title} iconType={'bolt'} />
+      )}
       <EuiSpacer size="s" />
       <EuiBadge
         aria-label={ATTACK_HEADER_BADGE}
@@ -104,6 +124,10 @@ export const HeaderTitle = memo(() => {
           </EuiFlexGroup>
         </EuiFlexItem>
       </EuiFlexGroup>
+
+      {scheduleDetailsId && (
+        <ScheduleDetailsFlyout scheduleId={scheduleDetailsId} onClose={closeScheduleDetails} />
+      )}
     </>
   );
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/hooks/use_header_data.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/hooks/use_header_data.test.ts
@@ -42,6 +42,8 @@ describe('useHeaderData', () => {
           return { key: 'value' };
         case ALERT_WORKFLOW_ASSIGNEE_IDS:
           return ['user-1'];
+        case 'kibana.alert.rule.uuid':
+          return 'schedule-uuid-1';
         default:
           return null;
       }
@@ -57,6 +59,7 @@ describe('useHeaderData', () => {
     expect(result.current.alertsCount).toBe(1);
     expect(result.current.replacements).toEqual({ key: 'value' });
     expect(result.current.assignees).toEqual(['user-1']);
+    expect(result.current.alertRuleUuid).toBe('schedule-uuid-1');
   });
 
   it('should normalize alertIds array correctly', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/hooks/use_header_data.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/hooks/use_header_data.ts
@@ -6,7 +6,7 @@
  */
 
 import { useMemo } from 'react';
-import { ALERT_WORKFLOW_ASSIGNEE_IDS } from '@kbn/rule-data-utils';
+import { ALERT_RULE_UUID, ALERT_WORKFLOW_ASSIGNEE_IDS } from '@kbn/rule-data-utils';
 import { useAttackDetailsContext } from '../context';
 import { getField } from '../../document_details/shared/utils';
 
@@ -59,6 +59,11 @@ export const useHeaderData = () => {
     return normalizeToStringArray(value);
   }, [getFieldsData]);
 
+  const alertRuleUuid = useMemo(
+    () => getField(getFieldsData(ALERT_RULE_UUID)) as string | undefined,
+    [getFieldsData]
+  );
+
   return useMemo(
     () => ({
       title,
@@ -67,7 +72,8 @@ export const useHeaderData = () => {
       alertsCount: alertIds.length,
       replacements,
       assignees,
+      alertRuleUuid,
     }),
-    [title, timestamp, nonDuplicatedAlertIds, alertIds.length, replacements, assignees]
+    [title, timestamp, nonDuplicatedAlertIds, alertIds.length, replacements, assignees, alertRuleUuid]
   );
 };


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/262284

# PR Summary

This PR aligns the Attacks and Alerts experiences by linking the attack name in the attack details flyout header to its corresponding schedule details flyout.

### Important Changed Files
- `x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/hooks/use_header_data.ts`: Updated hook to extract and return `alertRuleUuid` from the attack document fields.
- `x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/components/header_title.tsx`: Modified `HeaderTitle` component to conditionally render `FlyoutTitle` wrapped in an `EuiLink`. Clicking the title will now open the `ScheduleDetailsFlyout` using the `alertRuleUuid` (if the attack is generated by a schedule).

### Verification Steps
1. Navigate to the **Attacks** page in the Security Solution.
2. Click on a scheduled attack to open the attack details flyout.
3. In the attack details flyout header, verify the attack name is a clickable link.
4. Click the attack name link.
5. Verify that the schedule details flyout opens on top, displaying the configuration and logs for the schedule that generated the attack.

---

_PR developed with Cursor + Gemini 3.1 Pro_