### PR TITLE
Fix: [Security Solution][Bug] Connector ID does not get auto-rendered once get cleared, on the 'Add connector' modal on the Attack discovery page

### DIFF
--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/action_connector_form/connector_form_fields_global.test.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/action_connector_form/connector_form_fields_global.test.tsx
@@ -267,4 +267,44 @@ describe('ConnectorFormFieldsGlobal', () => {
       expect(idValue.endsWith('-')).toBe(false);
     });
   });
+
+  it('resumes auto-populating connector ID if the ID field is cleared', async () => {
+    render(
+      <FormTestProvider onSubmit={onSubmit}>
+        <ConnectorFormFieldsGlobal canSave={true} isEdit={false} />
+      </FormTestProvider>
+    );
+
+    const nameInput = screen.getByTestId('nameInput');
+    const idInput = screen.getByTestId('connectorIdInput');
+
+    await userEvent.type(nameInput, 'My New Connector');
+
+    await waitFor(() => {
+      expect(idInput).toHaveValue('my-new-connector');
+    });
+
+    // Manually change the ID
+    await userEvent.clear(idInput);
+    await userEvent.type(idInput, 'custom-id');
+
+    // Change the name, ID should not auto-populate
+    await userEvent.clear(nameInput);
+    await userEvent.type(nameInput, 'Another Name');
+
+    await waitFor(() => {
+      expect(idInput).toHaveValue('custom-id');
+    });
+
+    // Clear the ID field
+    await userEvent.clear(idInput);
+
+    // Change the name again, ID should resume auto-populating
+    await userEvent.clear(nameInput);
+    await userEvent.type(nameInput, 'Final Name');
+
+    await waitFor(() => {
+      expect(idInput).toHaveValue('final-name');
+    });
+  });
 });

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/action_connector_form/connector_form_fields_global.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/action_connector_form/connector_form_fields_global.tsx
@@ -210,7 +210,7 @@ const ConnectorFormFieldsGlobalComponent: React.FC<ConnectorFormFieldsProps> = (
     (e: React.ChangeEvent<HTMLInputElement>) => {
       const newValue = e.target.value;
       const expectedValue = toSlugIdentifier(name || '');
-      setUsingCustomIdentifier(newValue !== expectedValue);
+      setUsingCustomIdentifier(newValue !== '' && newValue !== expectedValue);
       setFieldValue('id', newValue);
     },
     [name, setFieldValue]


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/262517

## Summary
Fixed a bug where the connector ID field in the "Add connector" modal would not auto-populate after being cleared. The issue was that clearing the ID field preserved the `usingCustomIdentifier` flag as `true`, preventing future auto-generation when the name field was updated. This was fixed by ensuring `usingCustomIdentifier` is set to `false` when the ID field is cleared (i.e. when `newValue === ''`).

## Verification Steps
1. Navigate to `Security` > `Attack Discovery`.
2. Click on the settings icon present on the page to open the Attack discovery settings flyout.
3. Click on `Add Connector`.
4. Select a connector type (e.g. OpenAI).
5. Enter a name in the "Connector name" field. Observe that the "Connector ID" field is auto-populated.
6. Clear the "Connector ID" field.
7. Clear the "Connector name" field.
8. Enter a new name in the "Connector name" field.
9. Observe that the "Connector ID" field now auto-populates again, matching the new name.

---

_PR developed with Cursor_