### PR TITLE
Fix: [Security Solution][Attacks/Alerts] Link attack name in attack details flyout to schedule details

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/components/header_title.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/components/header_title.test.tsx
@@ -65,6 +65,12 @@ jest.mock('../../../flyout_v2/shared/components/alert_header_block', () => ({
   }) => <div data-test-subj={dataTestSubj}>{children}</div>,
 }));
 
+jest.mock('../../../attack_discovery/pages/settings_flyout/schedule/details_flyout', () => ({
+  DetailsFlyout: ({ scheduleId }: { scheduleId: string }) => (
+    <div data-test-subj="details-flyout">{scheduleId}</div>
+  ),
+}));
+
 const mockedUseHeaderData = useHeaderData as jest.Mock;
 const mockedUseAttackDetailsContext = useAttackDetailsContext as jest.Mock;
 const mockedUseNavigateToAttackDetailsLeftPanel = useNavigateToAttackDetailsLeftPanel as jest.Mock;
@@ -152,5 +158,44 @@ describe('HeaderTitle', () => {
 
     expect(screen.getByTestId(HEADER_ASSIGNEES_BLOCK_TEST_ID)).toBeInTheDocument();
     expect(screen.getByTestId('assignees')).toBeInTheDocument();
+  });
+
+  it('renders the title as a link and opens schedule details when clicked for scheduled attacks', () => {
+    mockedUseHeaderData.mockReturnValue({
+      title: 'Scheduled Attack',
+      timestamp: '2024-10-10T10:00:00.000Z',
+      alertsCount: 1,
+      alertRuleUuid: 'some-schedule-id',
+    });
+
+    render(
+      <TestProviders>
+        <HeaderTitle />
+      </TestProviders>
+    );
+
+    const link = screen.getByTestId(`${HEADER_TITLE_TEST_ID}Link`);
+    expect(link).toBeInTheDocument();
+
+    link.click();
+
+    expect(screen.getByTestId('details-flyout')).toHaveTextContent('some-schedule-id');
+  });
+
+  it('does not render the title as a link for ad-hoc attacks', () => {
+    mockedUseHeaderData.mockReturnValue({
+      title: 'Ad-hoc Attack',
+      timestamp: '2024-10-10T10:00:00.000Z',
+      alertsCount: 1,
+      alertRuleUuid: 'attack_discovery_ad_hoc_rule_id',
+    });
+
+    render(
+      <TestProviders>
+        <HeaderTitle />
+      </TestProviders>
+    );
+
+    expect(screen.queryByTestId(`${HEADER_TITLE_TEST_ID}Link`)).not.toBeInTheDocument();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/components/header_title.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/components/header_title.tsx
@@ -5,10 +5,11 @@
  * 2.0.
  */
 
-import React, { memo } from 'react';
-import { EuiBadge, EuiFlexGroup, EuiFlexItem, EuiSpacer } from '@elastic/eui';
+import React, { memo, useCallback, useMemo, useState } from 'react';
+import { EuiBadge, EuiFlexGroup, EuiFlexItem, EuiLink, EuiSpacer } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
+import { ATTACK_DISCOVERY_AD_HOC_RULE_ID } from '@kbn/elastic-assistant-common';
 import { flyoutHeaderBlockStyles } from '../../../flyout_v2/document/constants/styles';
 import { FlyoutTitle } from '../../../flyout_v2/shared/components/flyout_title';
 import { PreferenceFormattedDate } from '../../../common/components/formatted_date';
@@ -16,6 +17,7 @@ import { Status } from './status';
 import { Assignees } from './assignees';
 import { Notes } from '../../../flyout_v2/shared/components/notes';
 import { AlertHeaderBlock } from '../../../flyout_v2/shared/components/alert_header_block';
+import { DetailsFlyout } from '../../../attack_discovery/pages/settings_flyout/schedule/details_flyout';
 import {
   HEADER_ALERTS_BLOCK_TEST_ID,
   HEADER_ASSIGNEES_BLOCK_TEST_ID,
@@ -37,9 +39,24 @@ const ATTACK_HEADER_BADGE = i18n.translate(
  * Header data for the Attack details flyout
  */
 export const HeaderTitle = memo(() => {
-  const { title, timestamp, alertsCount } = useHeaderData();
+  const { title, timestamp, alertsCount, alertRuleUuid } = useHeaderData();
   const { attackId } = useAttackDetailsContext();
   const openNotesTab = useNavigateToAttackDetailsLeftPanel({ tab: 'notes' });
+
+  const [isScheduleDetailsOpen, setIsScheduleDetailsOpen] = useState(false);
+
+  const isScheduled = useMemo(
+    () => alertRuleUuid != null && alertRuleUuid !== ATTACK_DISCOVERY_AD_HOC_RULE_ID,
+    [alertRuleUuid]
+  );
+
+  const openScheduleDetails = useCallback(() => {
+    setIsScheduleDetailsOpen(true);
+  }, []);
+
+  const closeScheduleDetails = useCallback(() => {
+    setIsScheduleDetailsOpen(false);
+  }, []);
 
   return (
     <>
@@ -49,7 +66,13 @@ export const HeaderTitle = memo(() => {
           <EuiSpacer size="xs" />
         </>
       )}
-      <FlyoutTitle data-test-subj={HEADER_TITLE_TEST_ID} title={title} iconType={'bolt'} />
+      {isScheduled ? (
+        <EuiLink onClick={openScheduleDetails} data-test-subj={`${HEADER_TITLE_TEST_ID}Link`}>
+          <FlyoutTitle data-test-subj={HEADER_TITLE_TEST_ID} title={title} iconType={'bolt'} isLink />
+        </EuiLink>
+      ) : (
+        <FlyoutTitle data-test-subj={HEADER_TITLE_TEST_ID} title={title} iconType={'bolt'} />
+      )}
       <EuiSpacer size="s" />
       <EuiBadge
         aria-label={ATTACK_HEADER_BADGE}
@@ -104,6 +127,9 @@ export const HeaderTitle = memo(() => {
           </EuiFlexGroup>
         </EuiFlexItem>
       </EuiFlexGroup>
+      {isScheduleDetailsOpen && typeof alertRuleUuid === 'string' && (
+        <DetailsFlyout scheduleId={alertRuleUuid} onClose={closeScheduleDetails} />
+      )}
     </>
   );
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/hooks/use_header_data.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/hooks/use_header_data.ts
@@ -14,6 +14,7 @@ const FIELD_ATTACK_TITLE = 'kibana.alert.attack_discovery.title' as const;
 const FIELD_TIMESTAMP = '@timestamp' as const;
 const FIELD_ALERT_IDS = 'kibana.alert.attack_discovery.alert_ids' as const;
 const FIELD_REPLACEMENTS = 'kibana.alert.attack_discovery.replacements' as const;
+const FIELD_ALERT_RULE_UUID = 'kibana.alert.rule.uuid' as const;
 
 const EMPTY_REPLACEMENTS = {};
 
@@ -59,6 +60,11 @@ export const useHeaderData = () => {
     return normalizeToStringArray(value);
   }, [getFieldsData]);
 
+  const alertRuleUuid = useMemo(
+    () => getField(getFieldsData(FIELD_ALERT_RULE_UUID)),
+    [getFieldsData]
+  );
+
   return useMemo(
     () => ({
       title,
@@ -67,7 +73,8 @@ export const useHeaderData = () => {
       alertsCount: alertIds.length,
       replacements,
       assignees,
+      alertRuleUuid,
     }),
-    [title, timestamp, nonDuplicatedAlertIds, alertIds.length, replacements, assignees]
+    [title, timestamp, nonDuplicatedAlertIds, alertIds.length, replacements, assignees, alertRuleUuid]
   );
 };


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/262284

## Summary
This PR aligns the Attacks and Alerts experiences by making the attack name in the attack details flyout header a clickable link that opens the corresponding schedule details flyout.

### Changed Files
- `x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/components/header_title.tsx`: Updated to render the attack title as a clickable link when the attack is generated by a schedule. Clicking the link opens the `DetailsFlyout`.
- `x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/hooks/use_header_data.ts`: Added `alertRuleUuid` to the returned header data to identify the schedule that generated the attack.

## Verification Steps
1. Navigate to the **Security > Attacks** page in Kibana.
2. Ensure you have at least one attack generated by a scheduled Attack Discovery rule (not an ad-hoc run).
3. Click on the attack to open the attack details flyout.
4. Verify that the attack name in the header is rendered as a clickable link.
5. Click the attack name link.
6. Verify that the schedule details flyout opens and displays the details for the specific schedule that generated the attack.
7. For an ad-hoc attack, verify that the attack name is not a link.

---

_PR developed with Cursor_