### PR TITLE
[Chrome Next] Add documentation link to app menu

### DIFF
--- a/src/core/packages/chrome/browser-components/src/chrome_next/app_header/hooks/use_app_header_menu.ts
+++ b/src/core/packages/chrome/browser-components/src/chrome_next/app_header/hooks/use_app_header_menu.ts
@@ -12,20 +12,51 @@ import type { AppMenuConfig, AppMenuItemType } from '@kbn/core-chrome-app-menu-c
 import { APP_MENU_SHARE_ID, getTooltip } from '@kbn/core-chrome-app-menu-components';
 import { useChromeService } from '@kbn/core-chrome-browser-context';
 import { useObservable } from '@kbn/use-observable';
+import { i18n } from '@kbn/i18n';
 import { useAppMenu, useNextHeader } from '../../../shared/chrome_hooks';
 
 const createFeedbackMenuItem = (feedbackHandler: () => void): AppMenuItemType => ({
-  label: 'Feedback',
+  label: i18n.translate('chrome.appHeader.feedbackMenuItemLabel', {
+    defaultMessage: 'Feedback',
+  }),
   id: 'feedback',
   iconType: 'comment',
   order: 1,
   run: feedbackHandler,
 });
 
+const createDocumentationMenuItem = (href: string): AppMenuItemType => ({
+  label: i18n.translate('chrome.appHeader.documentationMenuItemLabel', {
+    defaultMessage: 'Documentation',
+  }),
+  id: 'documentation',
+  iconType: 'documentation',
+  order: 2,
+  href,
+  target: '_blank',
+});
+
 interface ResolvedAppMenu {
   menu: AppMenuConfig | undefined;
   shareItem: AppMenuItemType | undefined;
 }
+
+const useStaticItems = () => {
+  const chrome = useChromeService();
+  const feedbackHandler = useObservable(chrome.getFeedbackHandler$(), undefined);
+  const documentationLink = useObservable(chrome.getAppDocumentationLink$(), undefined);
+
+  return useMemo(() => {
+    const staticItems: AppMenuItemType[] = [];
+    if (feedbackHandler) {
+      staticItems.push(createFeedbackMenuItem(feedbackHandler));
+    }
+    if (documentationLink) {
+      staticItems.push(createDocumentationMenuItem(documentationLink));
+    }
+    return staticItems;
+  }, [feedbackHandler, documentationLink]);
+};
 
 const useResolvedAppMenu = (): ResolvedAppMenu => {
   const config = useNextHeader();
@@ -58,12 +89,11 @@ export function useAppHeaderMenu(): {
   staticItems: AppMenuItemType[];
 } {
   const { menu } = useResolvedAppMenu();
-  const chrome = useChromeService();
-  const feedbackHandler = useObservable(chrome.getFeedbackHandler$(), undefined);
+  const staticItems = useStaticItems();
 
   return {
     config: menu,
-    staticItems: feedbackHandler ? [createFeedbackMenuItem(feedbackHandler)] : [],
+    staticItems,
   };
 }
 

--- a/src/core/packages/chrome/browser-components/src/chrome_next/app_header/hooks/use_app_header_menu.ts
+++ b/src/core/packages/chrome/browser-components/src/chrome_next/app_header/hooks/use_app_header_menu.ts
@@ -45,17 +45,25 @@ const useStaticItems = () => {
   const chrome = useChromeService();
   const feedbackHandler = useObservable(chrome.getFeedbackHandler$(), undefined);
   const documentationLink = useObservable(chrome.getAppDocumentationLink$(), undefined);
+  const helpExtension = useObservable(chrome.getHelpExtension$(), undefined);
 
   return useMemo(() => {
     const staticItems: AppMenuItemType[] = [];
+
     if (feedbackHandler) {
       staticItems.push(createFeedbackMenuItem(feedbackHandler));
     }
-    if (documentationLink) {
-      staticItems.push(createDocumentationMenuItem(documentationLink));
+
+    const docLink =
+      documentationLink ??
+      helpExtension?.links?.find((link) => link.linkType === 'documentation')?.href;
+
+    if (docLink) {
+      staticItems.push(createDocumentationMenuItem(docLink));
     }
+
     return staticItems;
-  }, [feedbackHandler, documentationLink]);
+  }, [feedbackHandler, documentationLink, helpExtension]);
 };
 
 const useResolvedAppMenu = (): ResolvedAppMenu => {

--- a/src/core/packages/chrome/browser-internal/src/chrome_api.tsx
+++ b/src/core/packages/chrome/browser-internal/src/chrome_api.tsx
@@ -8,7 +8,7 @@
  */
 
 import React, { type ReactNode } from 'react';
-import { type Observable, distinctUntilChanged, map, shareReplay } from 'rxjs';
+import { type Observable, combineLatest, distinctUntilChanged, map, shareReplay } from 'rxjs';
 import type { ChromeNextAiButton } from '@kbn/core-chrome-browser';
 import type { RecentlyAccessedService } from '@kbn/recently-accessed';
 import { SidebarServiceProvider } from '@kbn/core-chrome-sidebar-context';
@@ -138,6 +138,18 @@ export function createChromeApi({ state, services, sidebar }: ChromeApiDeps): In
     registerGlobalHelpExtensionMenuLink: (link) => state.help.globalMenuLinks.add(link),
     getHelpMenuLinks$: () => services.navControls.getHelpMenuLinks$(),
     setHelpMenuLinks: services.navControls.setHelpMenuLinks,
+    registerAppDocumentationLink: state.appDocumentationLink.set,
+    getAppDocumentationLink$: () =>
+      combineLatest([state.appDocumentationLink.$, state.help.extension.$]).pipe(
+        map(([explicitLink, extension]) => {
+          if (explicitLink) {
+            return explicitLink;
+          }
+          const docLink = extension?.links?.find((link) => link.linkType === 'documentation');
+          return docLink?.href;
+        }),
+        distinctUntilChanged()
+      ),
 
     // Custom Nav Link
     getCustomNavLink$: () => state.customNavLink.$,

--- a/src/core/packages/chrome/browser-internal/src/chrome_api.tsx
+++ b/src/core/packages/chrome/browser-internal/src/chrome_api.tsx
@@ -8,7 +8,7 @@
  */
 
 import React, { type ReactNode } from 'react';
-import { type Observable, combineLatest, distinctUntilChanged, map, shareReplay } from 'rxjs';
+import { type Observable, distinctUntilChanged, map, shareReplay } from 'rxjs';
 import type { ChromeNextAiButton } from '@kbn/core-chrome-browser';
 import type { RecentlyAccessedService } from '@kbn/recently-accessed';
 import { SidebarServiceProvider } from '@kbn/core-chrome-sidebar-context';
@@ -139,17 +139,7 @@ export function createChromeApi({ state, services, sidebar }: ChromeApiDeps): In
     getHelpMenuLinks$: () => services.navControls.getHelpMenuLinks$(),
     setHelpMenuLinks: services.navControls.setHelpMenuLinks,
     registerAppDocumentationLink: state.appDocumentationLink.set,
-    getAppDocumentationLink$: () =>
-      combineLatest([state.appDocumentationLink.$, state.help.extension.$]).pipe(
-        map(([explicitLink, extension]) => {
-          if (explicitLink) {
-            return explicitLink;
-          }
-          const docLink = extension?.links?.find((link) => link.linkType === 'documentation');
-          return docLink?.href;
-        }),
-        distinctUntilChanged()
-      ),
+    getAppDocumentationLink$: () => state.appDocumentationLink.$,
 
     // Custom Nav Link
     getCustomNavLink$: () => state.customNavLink.$,

--- a/src/core/packages/chrome/browser-internal/src/side_effects/app_change_handler.ts
+++ b/src/core/packages/chrome/browser-internal/src/side_effects/app_change_handler.ts
@@ -46,6 +46,9 @@ export function setupAppChangeHandler({
     // Reset help
     state.help.extension.set(undefined);
 
+    // Reset app documentation link
+    state.appDocumentationLink.set(undefined);
+
     // Reset document title
     docTitle.reset();
 

--- a/src/core/packages/chrome/browser-internal/src/state/chrome_state.ts
+++ b/src/core/packages/chrome/browser-internal/src/state/chrome_state.ts
@@ -79,6 +79,9 @@ export interface ChromeState {
     globalMenuLinks: ArrayState<ChromeGlobalHelpExtensionMenuLink>;
   };
 
+  /** App documentation link registered by the current app */
+  appDocumentationLink: State<string | undefined>;
+
   /** Feedback handler registered by the feedback plugin */
   feedbackHandler: State<(() => void) | undefined>;
 
@@ -131,6 +134,9 @@ export function createChromeState({ application, docLinks }: ChromeStateDeps): C
   const helpSupportUrl = createState<string>(docLinks.links.kibana.askElastic);
   const globalHelpMenuLinks = createArrayState<ChromeGlobalHelpExtensionMenuLink>();
 
+  // App Documentation Link
+  const appDocumentationLink = createState<string | undefined>(undefined);
+
   // Feedback
   const feedbackHandler = createState<(() => void) | undefined>(undefined);
 
@@ -166,6 +172,7 @@ export function createChromeState({ application, docLinks }: ChromeStateDeps): C
       supportUrl: helpSupportUrl,
       globalMenuLinks: globalHelpMenuLinks,
     },
+    appDocumentationLink,
     feedbackHandler,
     newsfeedHandler,
   };

--- a/src/core/packages/chrome/browser/src/contracts.ts
+++ b/src/core/packages/chrome/browser/src/contracts.ts
@@ -237,14 +237,12 @@ export interface ChromeStart {
 
   /**
    * Register an app-specific documentation link to be shown in the app menu.
-   * Falls back to the documentation link from the help extension if not set.
    */
   registerAppDocumentationLink(link: string): void;
 
   /**
-   * Get an observable of the current app documentation link.
-   * Returns the link registered via {@link ChromeStart.registerAppDocumentationLink} if set,
-   * otherwise falls back to the documentation link from the help extension.
+   * Get an observable of the app documentation link registered via
+   * {@link ChromeStart.registerAppDocumentationLink}, or `undefined` if none is set.
    */
   getAppDocumentationLink$(): Observable<string | undefined>;
 

--- a/src/core/packages/chrome/browser/src/contracts.ts
+++ b/src/core/packages/chrome/browser/src/contracts.ts
@@ -236,6 +236,19 @@ export interface ChromeStart {
   setHelpExtension(helpExtension?: ChromeHelpExtension): void;
 
   /**
+   * Register an app-specific documentation link to be shown in the app menu.
+   * Falls back to the documentation link from the help extension if not set.
+   */
+  registerAppDocumentationLink(link: string): void;
+
+  /**
+   * Get an observable of the current app documentation link.
+   * Returns the link registered via {@link ChromeStart.registerAppDocumentationLink} if set,
+   * otherwise falls back to the documentation link from the help extension.
+   */
+  getAppDocumentationLink$(): Observable<string | undefined>;
+
+  /**
    * Override the default support URL shown in the help menu
    * @param url The updated support URL
    */


### PR DESCRIPTION
## Summary

This PR adds documentation link as an static item to app menu. If the link isn't set via the new API then it will fallback to documentation link set by help menu API.

<img width="432" height="256" alt="Screenshot 2026-04-28 at 15 01 56" src="https://github.com/user-attachments/assets/beaeb7db-a339-4aab-8b76-4ac7cdc94e3a" />
