### PR TITLE
[ES|QL] Do not report unknown column errors on promql command

### DIFF
--- a/src/platform/packages/shared/kbn-esql-language/src/commands/registry/promql/validate.test.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/registry/promql/validate.test.ts
@@ -164,19 +164,8 @@ describe('PROMQL Validation', () => {
       );
     });
 
-    test.each([
-      [
-        'unknown metric name reports unknown column',
-        'PROMQL index=timeseries_index step=5m start=?_tstart end=?_tend (rate(bytess[5m]))',
-        ['Unknown column "bytess"'],
-      ],
-      [
-        'unknown metric name without index reports unknown column',
-        'PROMQL step=5m (rate(bytes))',
-        ['Unknown column "bytes"'],
-      ],
-    ])('%s', (_title, query, expected) => {
-      promqlExpectErrors(query, expected);
+    test('unknown metric name does not report an error', () => {
+      promqlExpectErrors('PROMQL step=5m start=?_tstart end=?_tend (rate(unknown_metric[5m]))', []);
     });
 
     test('grouping is not allowed on non-aggregation functions', () => {

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/registry/promql/validate.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/registry/promql/validate.ts
@@ -15,12 +15,7 @@ import type {
   ESQLLocation,
 } from '@elastic/esql/types';
 import { isIdentifier, isList, isSource, Walker } from '@elastic/esql';
-import type {
-  PromQLBinaryExpression,
-  PromQLFunction,
-  PromQLLabelName,
-  PromQLSelector,
-} from '@elastic/esql';
+import type { PromQLBinaryExpression, PromQLFunction } from '@elastic/esql';
 import type { ICommandContext } from '../types';
 import { getMessageFromId } from '../../definitions/utils';
 import {
@@ -31,7 +26,6 @@ import {
 import { getPromqlExpressionType } from '../../definitions/utils/expressions';
 import { sourceExists } from '../../definitions/utils/sources';
 import { errors } from '../../definitions/utils/errors';
-import { validateColumnForCommand } from '../../definitions/utils/validation/column';
 import type { ESQLMessage, PromQLFunctionDefinition } from '../../definitions/types';
 import {
   getPromqlFunctionArityCheck,

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/registry/promql/validate.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/registry/promql/validate.ts
@@ -186,8 +186,7 @@ export const validate = (
     });
   }
 
-  const shouldValidateColumns = hasQuery && !command.query?.incomplete;
-  return [...messages, ...validatePromqlQuery(command, _context, shouldValidateColumns)];
+  return [...messages, ...validatePromqlQuery(command)];
 };
 
 // ============================================================================
@@ -435,11 +434,7 @@ function extractTrailingParamFromQuery(
 // PromQL query validation (walker-based)
 // ============================================================================
 
-function validatePromqlQuery(
-  command: ESQLAstPromqlCommand,
-  context?: ICommandContext,
-  shouldValidateColumns: boolean = false
-): ESQLMessage[] {
+function validatePromqlQuery(command: ESQLAstPromqlCommand): ESQLMessage[] {
   const queryNode = command.query;
 
   if (!queryNode || queryNode.incomplete) {
@@ -447,8 +442,6 @@ function validatePromqlQuery(
   }
 
   const messages: ESQLMessage[] = [];
-  const selectors: PromQLSelector[] = [];
-  const groupingArgs: PromQLLabelName[] = [];
 
   // ES|QL Walker needed: command.query can be ESQLParens/ESQLFunction wrapping PromQL content.
   Walker.walk(queryNode, {
@@ -462,11 +455,6 @@ function validatePromqlQuery(
           ...getMatchingSignatureErrors(fn, definition),
           ...getGroupingErrors(fn)
         );
-        if (fn.grouping) groupingArgs.push(...fn.grouping.args);
-      },
-
-      visitPromqlSelector: (selector) => {
-        selectors.push(selector);
       },
 
       visitPromqlBinaryExpression: (binary) => {
@@ -475,11 +463,6 @@ function validatePromqlQuery(
       },
     },
   });
-
-  if (context && shouldValidateColumns) {
-    const completeSelectors = selectors.filter(({ incomplete }) => !incomplete);
-    messages.push(...getColumnErrors(completeSelectors, groupingArgs, command.name, context));
-  }
 
   return messages;
 }
@@ -588,29 +571,6 @@ function getBinaryOperatorTypeErrors(
       locations: getPromqlNodeLocation(mismatchedNode, binary.location),
     }),
   ];
-}
-
-/* Returns errors for PromQL column references (metrics, labels, grouping) not found in ES|QL columns. */
-function getColumnErrors(
-  selectors: PromQLSelector[],
-  groupingArgs: PromQLLabelName[],
-  commandName: string,
-  context: ICommandContext
-): ESQLMessage[] {
-  const metrics = selectors.map(({ metric }) => metric);
-  const labels = selectors.flatMap(
-    ({ labelMap }) => labelMap?.args.map(({ labelName }) => labelName) ?? []
-  );
-
-  const columns = [...metrics, ...labels, ...groupingArgs].filter((node) => isIdentifier(node));
-
-  return columns.flatMap((column) =>
-    validateColumnForCommand(
-      { ...column, text: column.name, incomplete: !!column.incomplete },
-      commandName,
-      context
-    )
-  );
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/265998
## Summary
PromQL command do not fail when using unknown columns inside its query. No matter what `unmapped_fields` setting value is.

This PR disables the columns validation for PromQL

### Before
<img width="1917" height="845" alt="image" src="https://github.com/user-attachments/assets/564478cf-6850-4d39-95fb-dbe17e887f0c" />

### After
<img width="1910" height="920" alt="image" src="https://github.com/user-attachments/assets/3689b23c-8dbc-4ab2-94dd-edfa2b7d9ff6" />



