### PR TITLE
Fix: [Security Solution][Attacks/Alerts][Bug] "Run ad-hoc" attack discovery button text is truncated

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/header/run/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/header/run/index.tsx
@@ -22,7 +22,6 @@ const runButtonStyles = css`
   border-bottom-right-radius: 0;
   border-top-right-radius: 0;
   min-width: 74px;
-  width: 74px;
 `;
 
 const RunComponent: React.FC<Props> = ({ isLoading, onGenerate, isDisabled }) => (


### PR DESCRIPTION
## Summary

Addresses https://github.com/elastic/kibana/issues/262298

# PR Summary

## Changes Made
- Removed the fixed `width: 74px;` constraint from the "Run" Attack discovery button in the page header to prevent text truncation while keeping `min-width: 74px;`. 

## Why
- The button had a hardcoded `width: 74px` which was insufficient to render the "Run" text along with its play icon and padding, especially causing truncation of the button's title. Removing the fixed width allows the button to expand naturally based on its text, accommodating longer translations or the existing label without truncation.

## Verification Steps
1. Start Kibana and log in.
2. Ensure the feature flags `securitySolution.attackDiscoveryAlertsEnabled` and `securitySolution.assistantAttackDiscoverySchedulingEnabled` are enabled (if required).
3. Navigate to the Security Solution and open the **Attack Discovery** page.
4. Locate the "Run" button in the top header actions area (next to the settings gear icon).
5. Verify that the "Run" text inside the button is fully visible and not truncated with an ellipsis.
6. Verify that the "Run" button combined with the Settings button forms a unified split-button look without layout breakage.

---

_PR developed with Cursor_