### PR TITLE
Fix: [Security Solution] [Bug] Attack Discovery shows internal date math string “now/w” for “This week” time range instead of readable date

### DIFF
--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/utils/get_attack_discovery_loading_message/index.test.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/utils/get_attack_discovery_loading_message/index.test.ts
@@ -11,6 +11,8 @@ import {
   AI_IS_CURRENTLY_ANALYZING,
   AI_IS_CURRENTLY_ANALYZING_FROM,
   AI_IS_CURRENTLY_ANALYZING_RANGE,
+  START_OF_THE_WEEK,
+  NOW,
 } from './translations';
 
 describe('getAttackDiscoveryLoadingMessage', () => {
@@ -50,6 +52,22 @@ describe('getAttackDiscoveryLoadingMessage', () => {
       AI_IS_CURRENTLY_ANALYZING_FROM({
         alertsCount: 15,
         from: '2025-01-01T00:00:00Z',
+      })
+    );
+  });
+
+  it('returns AI_IS_CURRENTLY_ANALYZING_RANGE when start and end are date math expressions', () => {
+    const result = getAttackDiscoveryLoadingMessage({
+      alertsCount: 10,
+      start: 'now/w',
+      end: 'now',
+    });
+
+    expect(result).toBe(
+      AI_IS_CURRENTLY_ANALYZING_RANGE({
+        alertsCount: 10,
+        start: START_OF_THE_WEEK(),
+        end: NOW(),
       })
     );
   });

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/utils/get_attack_discovery_loading_message/index.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/utils/get_attack_discovery_loading_message/index.ts
@@ -8,6 +8,39 @@
 import { DEFAULT_END, DEFAULT_START } from '../../alerts/get_open_and_acknowledged_alerts_query';
 import * as i18n from './translations';
 
+export const formatDatemath = (date: string): string => {
+  switch (date) {
+    case 'now/d':
+      return i18n.START_OF_THE_DAY();
+    case 'now/w':
+      return i18n.START_OF_THE_WEEK();
+    case 'now/M':
+      return i18n.START_OF_THE_MONTH();
+    case 'now/y':
+      return i18n.START_OF_THE_YEAR();
+    case 'now-15m':
+      return i18n.FIFTEEN_MINUTES_AGO();
+    case 'now-30m':
+      return i18n.THIRTY_MINUTES_AGO();
+    case 'now-1h':
+      return i18n.ONE_HOUR_AGO();
+    case 'now-24h':
+      return i18n.TWENTY_FOUR_HOURS_AGO();
+    case 'now-7d':
+      return i18n.SEVEN_DAYS_AGO();
+    case 'now-30d':
+      return i18n.THIRTY_DAYS_AGO();
+    case 'now-90d':
+      return i18n.NINETY_DAYS_AGO();
+    case 'now-1y':
+      return i18n.ONE_YEAR_AGO();
+    case 'now':
+      return i18n.NOW();
+    default:
+      return date;
+  }
+};
+
 export const getAttackDiscoveryLoadingMessage = ({
   alertsCount,
   end,
@@ -21,10 +54,13 @@ export const getAttackDiscoveryLoadingMessage = ({
     return i18n.AI_IS_CURRENTLY_ANALYZING(alertsCount);
   }
 
-  if (end != null && start != null) {
-    return i18n.AI_IS_CURRENTLY_ANALYZING_RANGE({ alertsCount, end, start });
-  } else if (start != null) {
-    return i18n.AI_IS_CURRENTLY_ANALYZING_FROM({ alertsCount, from: start });
+  const formattedStart = start != null ? formatDatemath(start) : start;
+  const formattedEnd = end != null ? formatDatemath(end) : end;
+
+  if (formattedEnd != null && formattedStart != null) {
+    return i18n.AI_IS_CURRENTLY_ANALYZING_RANGE({ alertsCount, end: formattedEnd, start: formattedStart });
+  } else if (formattedStart != null) {
+    return i18n.AI_IS_CURRENTLY_ANALYZING_FROM({ alertsCount, from: formattedStart });
   } else {
     return i18n.AI_IS_CURRENTLY_ANALYZING(alertsCount);
   }

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/utils/get_attack_discovery_loading_message/translations.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/utils/get_attack_discovery_loading_message/translations.ts
@@ -47,3 +47,68 @@ export const AI_IS_CURRENTLY_ANALYZING_RANGE = ({
       values: { alertsCount, end, start },
     }
   );
+
+export const START_OF_THE_DAY = () =>
+  i18n.translate('xpack.elasticAssistantCommon.attackDiscovery.getLoadingMessage.startOfTheDay', {
+    defaultMessage: 'the start of the day',
+  });
+
+export const START_OF_THE_WEEK = () =>
+  i18n.translate('xpack.elasticAssistantCommon.attackDiscovery.getLoadingMessage.startOfTheWeek', {
+    defaultMessage: 'the start of the week',
+  });
+
+export const START_OF_THE_MONTH = () =>
+  i18n.translate('xpack.elasticAssistantCommon.attackDiscovery.getLoadingMessage.startOfTheMonth', {
+    defaultMessage: 'the start of the month',
+  });
+
+export const START_OF_THE_YEAR = () =>
+  i18n.translate('xpack.elasticAssistantCommon.attackDiscovery.getLoadingMessage.startOfTheYear', {
+    defaultMessage: 'the start of the year',
+  });
+
+export const FIFTEEN_MINUTES_AGO = () =>
+  i18n.translate('xpack.elasticAssistantCommon.attackDiscovery.getLoadingMessage.fifteenMinutesAgo', {
+    defaultMessage: '15 minutes ago',
+  });
+
+export const THIRTY_MINUTES_AGO = () =>
+  i18n.translate('xpack.elasticAssistantCommon.attackDiscovery.getLoadingMessage.thirtyMinutesAgo', {
+    defaultMessage: '30 minutes ago',
+  });
+
+export const ONE_HOUR_AGO = () =>
+  i18n.translate('xpack.elasticAssistantCommon.attackDiscovery.getLoadingMessage.oneHourAgo', {
+    defaultMessage: '1 hour ago',
+  });
+
+export const TWENTY_FOUR_HOURS_AGO = () =>
+  i18n.translate('xpack.elasticAssistantCommon.attackDiscovery.getLoadingMessage.twentyFourHoursAgo', {
+    defaultMessage: '24 hours ago',
+  });
+
+export const SEVEN_DAYS_AGO = () =>
+  i18n.translate('xpack.elasticAssistantCommon.attackDiscovery.getLoadingMessage.sevenDaysAgo', {
+    defaultMessage: '7 days ago',
+  });
+
+export const THIRTY_DAYS_AGO = () =>
+  i18n.translate('xpack.elasticAssistantCommon.attackDiscovery.getLoadingMessage.thirtyDaysAgo', {
+    defaultMessage: '30 days ago',
+  });
+
+export const NINETY_DAYS_AGO = () =>
+  i18n.translate('xpack.elasticAssistantCommon.attackDiscovery.getLoadingMessage.ninetyDaysAgo', {
+    defaultMessage: '90 days ago',
+  });
+
+export const ONE_YEAR_AGO = () =>
+  i18n.translate('xpack.elasticAssistantCommon.attackDiscovery.getLoadingMessage.oneYearAgo', {
+    defaultMessage: '1 year ago',
+  });
+
+export const NOW = () =>
+  i18n.translate('xpack.elasticAssistantCommon.attackDiscovery.getLoadingMessage.now', {
+    defaultMessage: 'now',
+  });


### PR DESCRIPTION
## Summary

Addresses https://github.com/elastic/kibana/issues/243591

### Summary
Fixed an issue where Attack Discovery showed internal date math strings like "now/w" instead of readable text in the loading banner. Added logic to translate common date math strings into user-friendly text.

### Changed Files
- `x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/utils/get_attack_discovery_loading_message/translations.ts`
  - Added new translation strings for common datemath expressions like "the start of the week", "the start of the day", etc.
- `x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/utils/get_attack_discovery_loading_message/index.ts`
  - Updated `getAttackDiscoveryLoadingMessage` to map unformatted date math strings into localized user-friendly strings before embedding them into the result message.

### Verification Steps
1. Navigate to **Security → Attack discovery**.
2. At the top-right time filter, select **This week**.
3. Click **Run** to start an Attack Discovery job.
4. Observe the banner text while loading: it should say “AI is analysing up to [X] alerts from the start of the week to now…” instead of showing "now/w".
5. Change the time filter to **Last 7 days** and run again.
6. Observe the banner text: it should say “AI is analysing up to [X] alerts from 7 days ago to now…”.

---

_PR developed with Cursor_