### PR TITLE
Fix: [Security Solution] [Bug] No message shown to user why the 'Generate Button' is not available on Attack Discovery tab when privilege for AI is set to NONE

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/empty_states/empty_prompt/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/empty_states/empty_prompt/index.test.tsx
@@ -83,6 +83,39 @@ describe('EmptyPrompt', () => {
     });
   });
 
+  describe('when aiConnectorsCount is null and hasAssistantPrivilege is false', () => {
+    beforeEach(() => {
+      (useAssistantAvailability as jest.Mock).mockReturnValue({
+        hasAssistantPrivilege: false,
+        isAssistantEnabled: true,
+      });
+
+      render(
+        <TestProviders>
+          <EmptyPrompt
+            aiConnectorsCount={null} // <--  null
+            attackDiscoveriesCount={0} // <-- no discoveries
+            isLoading={false} // <-- not loading
+            isDisabled={false}
+            onGenerate={onGenerate}
+          />
+        </TestProviders>
+      );
+    });
+
+    it('renders the empty prompt avatar', () => {
+      const emptyPromptAvatar = screen.getByTestId('emptyPromptAvatar');
+
+      expect(emptyPromptAvatar).toBeInTheDocument();
+    });
+
+    it('renders the disabled generate button', () => {
+      const generateButton = screen.getByTestId('generate');
+
+      expect(generateButton).toBeDisabled();
+    });
+  });
+
   describe('when aiConnectorsCount is null', () => {
     beforeEach(() => {
       (useAssistantAvailability as jest.Mock).mockReturnValue({

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/empty_states/empty_prompt/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/empty_states/empty_prompt/index.tsx
@@ -17,6 +17,7 @@ import { css } from '@emotion/react';
 import { AssistantBeacon } from '@kbn/ai-assistant-icon';
 import React, { useMemo } from 'react';
 
+import { useAssistantAvailability } from '../../../../../assistant/use_assistant_availability';
 import { Generate } from '../generate';
 import type { SettingsOverrideOptions } from '../../history/types';
 import * as i18n from './translations';
@@ -95,11 +96,13 @@ const EmptyPromptComponent: React.FC<Props> = ({
     []
   );
 
+  const { hasAssistantPrivilege } = useAssistantAvailability();
+
   const actions = useMemo(() => {
     return <Generate isLoading={isLoading} isDisabled={isDisabled} onGenerate={onGenerate} />;
   }, [isDisabled, isLoading, onGenerate]);
 
-  if (isLoading || aiConnectorsCount == null || attackDiscoveriesCount > 0) {
+  if (isLoading || (aiConnectorsCount == null && hasAssistantPrivilege) || attackDiscoveriesCount > 0) {
     return null;
   }
 

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/empty_states/empty_prompt/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/empty_states/empty_prompt/translations.ts
@@ -55,3 +55,10 @@ export const SELECT_A_CONNECTOR = i18n.translate(
     defaultMessage: 'Select a connector',
   }
 );
+
+export const MISSING_PRIVILEGES = i18n.translate(
+  'xpack.securitySolution.attackDiscovery.pages.emptyPrompt.missingPrivilegesTooltip',
+  {
+    defaultMessage: 'Missing privileges',
+  }
+);

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/empty_states/generate/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/empty_states/generate/index.test.tsx
@@ -10,8 +10,15 @@ import React from 'react';
 
 import { Generate } from '.';
 import * as i18n from '../empty_prompt/translations';
+import { useAssistantAvailability } from '../../../../../assistant/use_assistant_availability';
+
+jest.mock('../../../../../assistant/use_assistant_availability');
 
 describe('Generate Component', () => {
+  beforeEach(() => {
+    (useAssistantAvailability as jest.Mock).mockReturnValue({ hasAssistantPrivilege: true });
+  });
+
   it('calls onGenerate when the button is clicked', () => {
     const onGenerate = jest.fn();
 
@@ -41,6 +48,19 @@ describe('Generate Component', () => {
 
     await waitFor(() => {
       expect(screen.getByText(i18n.SELECT_A_CONNECTOR)).toBeInTheDocument();
+    });
+  });
+
+  it('shows missing privileges tooltip when hasAssistantPrivilege is false', async () => {
+    (useAssistantAvailability as jest.Mock).mockReturnValue({ hasAssistantPrivilege: false });
+    render(<Generate isLoading={false} isDisabled={false} onGenerate={jest.fn()} />);
+
+    expect(screen.getByTestId('generate')).toBeDisabled();
+
+    fireEvent.mouseOver(screen.getByTestId('generate'));
+
+    await waitFor(() => {
+      expect(screen.getByText(i18n.MISSING_PRIVILEGES)).toBeInTheDocument();
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/empty_states/generate/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/empty_states/generate/index.tsx
@@ -8,6 +8,7 @@
 import { EuiButton, EuiToolTip } from '@elastic/eui';
 import React from 'react';
 
+import { useAssistantAvailability } from '../../../../../assistant/use_assistant_availability';
 import * as i18n from '../empty_prompt/translations';
 import type { SettingsOverrideOptions } from '../../history/types';
 
@@ -18,11 +19,18 @@ interface Props {
 }
 
 const GenerateComponent: React.FC<Props> = ({ isLoading, isDisabled = false, onGenerate }) => {
-  const disabled = isLoading || isDisabled;
+  const { hasAssistantPrivilege } = useAssistantAvailability();
+  const disabled = isLoading || isDisabled || !hasAssistantPrivilege;
+
+  const tooltipContent = !hasAssistantPrivilege
+    ? i18n.MISSING_PRIVILEGES
+    : disabled
+    ? i18n.SELECT_A_CONNECTOR
+    : null;
 
   return (
     <EuiToolTip
-      content={disabled ? i18n.SELECT_A_CONNECTOR : null}
+      content={tooltipContent}
       data-test-subj="generateTooltip"
     >
       <EuiButton


### PR DESCRIPTION
## Summary

Addresses https://github.com/elastic/kibana/issues/183123

## Description

This PR fixes an issue where the "Generate" button and its empty prompt were completely hidden on the Attack Discovery page when the user's AI privileges were set to NONE. 

When the user lacks AI privileges (`hasAssistantPrivilege === false`), the connector fetch fails, leaving `aiConnectorsCount` as `null`. Previously, `EmptyPrompt` would return `null` early when `aiConnectorsCount == null`, resulting in a blank screen.

The fix updates `EmptyPrompt` and `Generate` components to explicitly check `hasAssistantPrivilege`. When missing, the prompt will now render, and the "Generate" button will be visible but disabled, providing a tooltip explaining that the user lacks the necessary privileges.

### Changed Files
- `x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/empty_states/empty_prompt/index.tsx`: Updated to render the empty prompt when `aiConnectorsCount` is null but the user lacks AI privileges (`hasAssistantPrivilege === false`).
- `x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/empty_states/generate/index.tsx`: Updated to check for `hasAssistantPrivilege` and render a `MISSING_PRIVILEGES` tooltip when disabled due to lack of privileges.
- `x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/empty_states/empty_prompt/translations.ts`: Added the `MISSING_PRIVILEGES` translation string.

## Verification Steps

1. Create a custom role with the AI privilege set to **NONE**.
2. Create a custom user and assign the above custom role.
3. Log in to Kibana with the custom user.
4. Navigate to **Security -> Attack Discovery**.
5. Observe that the empty prompt ("No results match your search criteria") is rendered instead of a blank screen.
6. Hover over the **Generate** button inside the empty prompt and verify it is disabled.
7. Verify that the tooltip on the **Generate** button says "Missing privileges" instead of "Select a connector".

---

_PR developed with Cursor_