### PR TITLE
[EDR Workflows][Endpoint exception move] Fix new endpoint exceptions form OR operator usage

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/artifact_list_page/components/artifact_flyout.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/artifact_list_page/components/artifact_flyout.tsx
@@ -44,11 +44,11 @@ import { ManagementPageLoader } from '../../management_page_loader';
 import type { ExceptionsListApiClient } from '../../../services/exceptions_list/exceptions_list_api_client';
 import { useKibana, useToasts } from '../../../../common/lib/kibana';
 import { createExceptionListItemForCreate } from '../../../../../common/endpoint/service/artifacts/utils';
-import { useWithArtifactSubmitData } from '../hooks/use_with_artifact_submit_data';
 import { useIsArtifactAllowedPerPolicyUsage } from '../hooks/use_is_artifact_allowed_per_policy_usage';
 import { useGetArtifact } from '../../../hooks/artifacts';
 import { ArtifactConfirmModal } from './artifact_confirm_modal';
 import { useUserPrivileges } from '../../../../common/components/user_privileges';
+import { useCreateOrUpdateArtifact } from '../hooks/use_artifact_update_or_create';
 
 export const ARTIFACT_FLYOUT_LABELS = Object.freeze({
   flyoutEditTitle: i18n.translate('xpack.securitySolution.artifactListPage.flyoutEditTitle', {
@@ -233,11 +233,11 @@ export const ArtifactFlyout = memo<ArtifactFlyoutProps>(
     const isEditFlow = urlParams.show === 'edit';
     const formMode: ArtifactFormComponentProps['mode'] = isEditFlow ? 'edit' : 'create';
 
-    const {
-      isLoading: internalIsSubmittingData,
-      mutateAsync: submitData,
-      error: internalSubmitError,
-    } = useWithArtifactSubmitData(apiClient, formMode);
+    const [internalSubmitError, setInternalSubmitError] = useState<IHttpFetchError | undefined>(
+      undefined
+    );
+    const { isLoading: internalIsSubmittingData, createOrUpdateArtifact } =
+      useCreateOrUpdateArtifact(apiClient);
 
     const { mutateAsync: markInsightAsRemediated } = useMarkInsightAsRemediated(
       sourceInsight?.back_url
@@ -300,10 +300,16 @@ export const ArtifactFlyout = memo<ArtifactFlyoutProps>(
     }, [isSubmittingData, onClose, setUrlParams, urlParams]);
 
     const handleFormComponentOnChange: ArtifactFormComponentProps['onChange'] = useCallback(
-      ({ item: updatedItem, isValid, confirmModalLabels }) => {
+      ({
+        item: updatedItem,
+        additionalEntries: updatedAdditionalEntries,
+        isValid,
+        confirmModalLabels,
+      }) => {
         if (isMounted()) {
           setFormState({
             item: updatedItem,
+            additionalEntries: updatedAdditionalEntries,
             isValid,
             confirmModalLabels,
           });
@@ -369,22 +375,28 @@ export const ArtifactFlyout = memo<ArtifactFlyoutProps>(
           });
       } else if (formState.confirmModalLabels) {
         setShowConfirmModal(true);
-      } else {
-        submitData(formState.item).then(handleSuccess);
+      } else if (createOrUpdateArtifact) {
+        createOrUpdateArtifact(formState.item, formState.additionalEntries)
+          .then((createdOrUpdatedItems) => handleSuccess(createdOrUpdatedItems[0]))
+          .catch((err) => setInternalSubmitError(err));
       }
     }, [
-      formMode,
-      formState.item,
+      submitHandler,
       formState.confirmModalLabels,
+      formState.item,
+      formState.additionalEntries,
+      formMode,
       handleSuccess,
       isMounted,
-      submitData,
-      submitHandler,
+      createOrUpdateArtifact,
     ]);
 
     const confirmModalOnSuccess = useCallback(
-      () => submitData(formState.item).then(handleSuccess),
-      [submitData, formState.item, handleSuccess]
+      () =>
+        createOrUpdateArtifact?.(formState.item, formState.additionalEntries)
+          .then((createdOrUpdatedItems) => handleSuccess(createdOrUpdatedItems[0]))
+          .catch((err) => setInternalSubmitError(err)),
+      [createOrUpdateArtifact, formState.additionalEntries, formState.item, handleSuccess]
     );
 
     const confirmModal = useMemo(() => {
@@ -491,6 +503,7 @@ export const ArtifactFlyout = memo<ArtifactFlyoutProps>(
               onChange={handleFormComponentOnChange}
               disabled={isSubmittingData}
               item={formState.item}
+              additionalEntries={formState.additionalEntries}
               error={submitError ?? undefined}
               mode={formMode}
             />

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/artifact_list_page/hooks/use_artifact_update_or_create.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/artifact_list_page/hooks/use_artifact_update_or_create.test.ts
@@ -1,0 +1,243 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook, act } from '@testing-library/react';
+import type { HttpSetup } from '@kbn/core/public';
+import type { EntriesArray } from '@kbn/securitysolution-io-ts-list-types';
+import { ExceptionsListApiClient } from '../../../services/exceptions_list/exceptions_list_api_client';
+import {
+  getFakeListId,
+  getFakeListDefinition,
+  getFakeHttpService,
+} from '../../../hooks/test_utils';
+import { getExceptionListItemSchemaMock } from '@kbn/lists-plugin/common/schemas/response/exception_list_item_schema.mock';
+import { useCreateOrUpdateArtifact } from './use_artifact_update_or_create';
+
+const renderAndWaitForHook = async (apiClient: ExceptionsListApiClient) => {
+  let hookResult: ReturnType<typeof renderHook<ReturnType<typeof useCreateOrUpdateArtifact>, void>>;
+  await act(async () => {
+    hookResult = renderHook(() => useCreateOrUpdateArtifact(apiClient));
+  });
+  // Re-render to pick up the ref value set by useEffect
+  hookResult!.rerender();
+  return hookResult!;
+};
+
+const createEntry = (field: string, value: string): EntriesArray => [
+  {
+    field,
+    operator: 'included' as const,
+    type: 'match' as const,
+    value,
+  },
+];
+
+describe('useCreateOrUpdateArtifact', () => {
+  let fakeHttpServices: jest.Mocked<HttpSetup>;
+  let apiClient: ExceptionsListApiClient;
+
+  beforeEach(() => {
+    fakeHttpServices = getFakeHttpService();
+    apiClient = new ExceptionsListApiClient(
+      fakeHttpServices,
+      getFakeListId(),
+      getFakeListDefinition()
+    );
+  });
+
+  it('should return createOrUpdateArtifact function and isLoading as false', async () => {
+    const { result } = await renderAndWaitForHook(apiClient);
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.createOrUpdateArtifact).not.toBeNull();
+  });
+
+  describe('when creating a new item without additional entries groups', () => {
+    it('should call create API once', async () => {
+      const newItem = {
+        ...getExceptionListItemSchemaMock(),
+        list_id: getFakeListId(),
+      };
+      const { id: _, ...createItem } = newItem;
+
+      const createdItem = { ...newItem, id: 'new-id' };
+      fakeHttpServices.post.mockResolvedValueOnce(createdItem);
+
+      const { result } = await renderAndWaitForHook(apiClient);
+
+      let items: (typeof createdItem)[];
+      await act(async () => {
+        items = await result.current.createOrUpdateArtifact!(createItem, undefined);
+      });
+
+      expect(items!).toEqual([createdItem]);
+      expect(fakeHttpServices.post).toHaveBeenCalledTimes(1);
+      expect(fakeHttpServices.put).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when updating an existing item without additional entries groups', () => {
+    it('should call update API once', async () => {
+      const existingItem = {
+        ...getExceptionListItemSchemaMock(),
+        list_id: getFakeListId(),
+        id: 'existing-id',
+      };
+
+      fakeHttpServices.put.mockResolvedValueOnce(existingItem);
+
+      const { result } = await renderAndWaitForHook(apiClient);
+
+      let items: (typeof existingItem)[];
+      await act(async () => {
+        items = await result.current.createOrUpdateArtifact!(existingItem, undefined);
+      });
+
+      expect(items!).toEqual([existingItem]);
+      expect(fakeHttpServices.put).toHaveBeenCalledTimes(1);
+      expect(fakeHttpServices.post).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when creating a new item with additional entries groups (OR operator)', () => {
+    it('should call create API for each item', async () => {
+      const newItem = {
+        ...getExceptionListItemSchemaMock(),
+        list_id: getFakeListId(),
+      };
+      const { id: _, ...createItem } = newItem;
+
+      const additionalEntries: EntriesArray[] = [
+        createEntry('file.path', '/bin/bash'),
+        createEntry('process.name', 'curl'),
+      ];
+
+      const createdItem1 = { ...newItem, id: 'id-1' };
+      const createdItem2 = { ...newItem, id: 'id-2' };
+      const createdItem3 = { ...newItem, id: 'id-3' };
+      fakeHttpServices.post
+        .mockResolvedValueOnce(createdItem1)
+        .mockResolvedValueOnce(createdItem2)
+        .mockResolvedValueOnce(createdItem3);
+
+      const { result } = await renderAndWaitForHook(apiClient);
+
+      let items: (typeof createdItem1)[];
+      await act(async () => {
+        items = await result.current.createOrUpdateArtifact!(createItem, additionalEntries);
+      });
+
+      expect(items!).toEqual([createdItem1, createdItem2, createdItem3]);
+      expect(fakeHttpServices.post).toHaveBeenCalledTimes(3);
+      expect(fakeHttpServices.put).not.toHaveBeenCalled();
+    });
+
+    it('should copy metadata from original item to additional items', async () => {
+      const newItem = {
+        ...getExceptionListItemSchemaMock(),
+        list_id: getFakeListId(),
+        name: 'Test Exception',
+        description: 'Test description',
+        os_types: ['windows' as const],
+        tags: ['policy:all'],
+      };
+      const { id: _, ...createItem } = newItem;
+
+      const additionalEntries: EntriesArray[] = [createEntry('file.path', '/test')];
+
+      fakeHttpServices.post
+        .mockResolvedValueOnce({ ...newItem, id: 'id-1' })
+        .mockResolvedValueOnce({ ...newItem, id: 'id-2' });
+
+      const { result } = await renderAndWaitForHook(apiClient);
+
+      await act(async () => {
+        await result.current.createOrUpdateArtifact!(createItem, additionalEntries);
+      });
+
+      // Verify the second POST (additional item) has the same metadata
+      const secondCallBody = JSON.parse(
+        (fakeHttpServices.post.mock.calls[1] as unknown as [string, { body: string }])[1].body
+      );
+      expect(secondCallBody.name).toBe('Test Exception');
+      expect(secondCallBody.description).toBe('Test description');
+      expect(secondCallBody.os_types).toEqual(['windows']);
+      expect(secondCallBody.tags).toEqual(['policy:all']);
+      expect(secondCallBody.entries).toEqual(additionalEntries[0]);
+    });
+  });
+
+  describe('when updating an existing item with additional entries groups (edit + OR)', () => {
+    it('should call update for the first item and create for additional items', async () => {
+      const existingItem = {
+        ...getExceptionListItemSchemaMock(),
+        list_id: getFakeListId(),
+        id: 'existing-id',
+      };
+
+      const additionalEntries: EntriesArray[] = [createEntry('file.path', '/new')];
+
+      const updatedItem = { ...existingItem };
+      const createdItem = { ...existingItem, id: 'new-id' };
+      fakeHttpServices.put.mockResolvedValueOnce(updatedItem);
+      fakeHttpServices.post.mockResolvedValueOnce(createdItem);
+
+      const { result } = await renderAndWaitForHook(apiClient);
+
+      let items: (typeof existingItem)[];
+      await act(async () => {
+        items = await result.current.createOrUpdateArtifact!(existingItem, additionalEntries);
+      });
+
+      expect(items!).toEqual([updatedItem, createdItem]);
+      expect(fakeHttpServices.put).toHaveBeenCalledTimes(1);
+      expect(fakeHttpServices.post).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('when an empty additional entries array is provided', () => {
+    it('should only submit the primary item', async () => {
+      const newItem = {
+        ...getExceptionListItemSchemaMock(),
+        list_id: getFakeListId(),
+      };
+      const { id: _, ...createItem } = newItem;
+
+      fakeHttpServices.post.mockResolvedValueOnce({ ...newItem, id: 'id-1' });
+
+      const { result } = await renderAndWaitForHook(apiClient);
+
+      await act(async () => {
+        await result.current.createOrUpdateArtifact!(createItem, []);
+      });
+
+      expect(fakeHttpServices.post).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('error handling', () => {
+    it('should set isLoading back to false on error', async () => {
+      const newItem = {
+        ...getExceptionListItemSchemaMock(),
+        list_id: getFakeListId(),
+      };
+      const { id: _, ...createItem } = newItem;
+
+      fakeHttpServices.post.mockRejectedValueOnce(new Error('API error'));
+
+      const { result } = await renderAndWaitForHook(apiClient);
+
+      await act(async () => {
+        await expect(result.current.createOrUpdateArtifact!(createItem, undefined)).rejects.toThrow(
+          'API error'
+        );
+      });
+
+      expect(result.current.isLoading).toBe(false);
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/artifact_list_page/hooks/use_artifact_update_or_create.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/artifact_list_page/hooks/use_artifact_update_or_create.ts
@@ -32,8 +32,6 @@ export const useCreateOrUpdateArtifact = (
   const addOrUpdateArtifactRef = useRef<CreateOrUpdateArtifactsFunction | null>(null);
 
   useEffect(() => {
-    const abortCtrl = new AbortController();
-
     const onCreateOrUpdateArtifact: CreateOrUpdateArtifactsFunction = async (
       item,
       additionalEntriesGroups
@@ -86,7 +84,6 @@ export const useCreateOrUpdateArtifact = (
 
     return (): void => {
       setIsLoading(false);
-      abortCtrl.abort();
     };
   }, [apiClient]);
 

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/artifact_list_page/hooks/use_artifact_update_or_create.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/artifact_list_page/hooks/use_artifact_update_or_create.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import type {
+  CreateExceptionListItemSchema,
+  EntriesArray,
+  ExceptionListItemSchema,
+} from '@kbn/securitysolution-io-ts-list-types';
+import type { ExceptionsListApiClient } from '../../../services/exceptions_list/exceptions_list_api_client';
+
+export type CreateOrUpdateArtifactsFunction = (
+  item: ExceptionListItemSchema | CreateExceptionListItemSchema,
+  additionalEntriesGroups: EntriesArray[] | undefined
+) => Promise<ExceptionListItemSchema[]>;
+
+/**
+ * Hook for adding and/or updating an artifact. It calls multiple create APIs if
+ * there are additional entries arrays.
+ */
+export const useCreateOrUpdateArtifact = (
+  apiClient: ExceptionsListApiClient
+): {
+  isLoading: boolean;
+  createOrUpdateArtifact: CreateOrUpdateArtifactsFunction | null;
+} => {
+  const [isLoading, setIsLoading] = useState(false);
+  const addOrUpdateArtifactRef = useRef<CreateOrUpdateArtifactsFunction | null>(null);
+
+  useEffect(() => {
+    const abortCtrl = new AbortController();
+
+    const onCreateOrUpdateArtifact: CreateOrUpdateArtifactsFunction = async (
+      item,
+      additionalEntriesGroups
+    ) => {
+      try {
+        setIsLoading(true);
+
+        const additionalItems: CreateExceptionListItemSchema[] = additionalEntriesGroups
+          ? additionalEntriesGroups.map((entries) => ({
+              entries,
+
+              name: item.name,
+              description: item.description,
+              list_id: item.list_id,
+              namespace_type: item.namespace_type,
+              os_types: item.os_types,
+              tags: item.tags,
+              type: item.type,
+              comments: item.comments,
+              expire_time: item.expire_time,
+              meta: item.meta,
+            }))
+          : [];
+
+        const items: (ExceptionListItemSchema | CreateExceptionListItemSchema)[] = [
+          item,
+          ...additionalItems,
+        ];
+
+        const itemsAdded = await Promise.all(
+          items.map((_item: ExceptionListItemSchema | CreateExceptionListItemSchema) => {
+            if ('id' in _item && _item.id != null) {
+              return apiClient.update(_item as ExceptionListItemSchema);
+            } else {
+              return apiClient.create(_item as CreateExceptionListItemSchema);
+            }
+          })
+        );
+
+        setIsLoading(false);
+
+        return itemsAdded;
+      } catch (e) {
+        setIsLoading(false);
+        throw e;
+      }
+    };
+
+    addOrUpdateArtifactRef.current = onCreateOrUpdateArtifact;
+
+    return (): void => {
+      setIsLoading(false);
+      abortCtrl.abort();
+    };
+  }, [apiClient]);
+
+  return { isLoading, createOrUpdateArtifact: addOrUpdateArtifactRef.current };
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/artifact_list_page/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/artifact_list_page/types.ts
@@ -9,6 +9,7 @@ import type { IHttpFetchError } from '@kbn/core-http-browser';
 import type {
   ExceptionListItemSchema,
   CreateExceptionListItemSchema,
+  EntriesArray,
 } from '@kbn/securitysolution-io-ts-list-types';
 
 export interface ArtifactListPageUrlParams {
@@ -23,6 +24,11 @@ export interface ArtifactListPageUrlParams {
 
 export interface ArtifactFormComponentProps {
   item: ExceptionListItemSchema | CreateExceptionListItemSchema;
+  /** Contains an array of additional entries for artifacts that
+   * use OR operator. When using OR operator, the first condition group is
+   * in `item`, while additional condition groups ORed together are in `additionalEntries`.
+   */
+  additionalEntries?: EntriesArray[];
   mode: 'edit' | 'create';
   /** signals that the form should be made disabled (ex. while an update/create api call is in flight) */
   disabled: boolean;
@@ -35,6 +41,7 @@ export interface ArtifactFormComponentProps {
 export interface ArtifactFormComponentOnChangeCallbackProps {
   isValid: boolean;
   item: ExceptionListItemSchema | CreateExceptionListItemSchema;
+  additionalEntries?: EntriesArray[];
   confirmModalLabels?: ArtifactConfirmModalLabelProps;
 }
 

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/endpoint_exceptions/view/components/endpoint_exceptions_flyout.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/endpoint_exceptions/view/components/endpoint_exceptions_flyout.test.tsx
@@ -15,7 +15,10 @@ import type { AppContextTestRender } from '../../../../../common/mock/endpoint';
 import { createAppRootMockRenderer } from '../../../../../common/mock/endpoint';
 
 import { useFetchIndex } from '../../../../../common/containers/source';
-import { useCreateArtifact } from '../../../../hooks/artifacts/use_create_artifact';
+import {
+  useCreateOrUpdateArtifact,
+  type CreateOrUpdateArtifactsFunction,
+} from '../../../../components/artifact_list_page/hooks/use_artifact_update_or_create';
 
 import { useToasts } from '../../../../../common/lib/kibana';
 import type { AddOrUpdateExceptionItemsFunc } from '../../../../../detection_engine/rule_exceptions/logic/use_close_alerts';
@@ -30,7 +33,7 @@ import { licenseService } from '../../../../../common/hooks/use_license';
 
 jest.mock('../../../../../common/lib/kibana');
 jest.mock('../../../../../common/containers/source');
-jest.mock('../../../../hooks/artifacts/use_create_artifact');
+jest.mock('../../../../components/artifact_list_page/hooks/use_artifact_update_or_create');
 jest.mock('../../../../../detection_engine/rule_exceptions/logic/use_close_alerts');
 jest.mock('../../../../../detections/containers/detection_engine/alerts/use_signal_index');
 jest.mock('../../../../../detections/containers/detection_engine/alerts/use_alerts_privileges');
@@ -48,7 +51,7 @@ describe('Endpoint exceptions flyout', () => {
   let renderResult: ReturnType<AppContextTestRender['render']>;
   let mockOnCancel: jest.Mock;
   let mockOnConfirm: jest.Mock;
-  let mockMutateAsync: jest.Mock;
+  let mockCreateOrUpdateArtifact: jest.MockedFunction<CreateOrUpdateArtifactsFunction>;
   let mockCloseAlerts: jest.MockedFunction<AddOrUpdateExceptionItemsFunc>;
   let alertData: AlertData;
 
@@ -75,11 +78,11 @@ describe('Endpoint exceptions flyout', () => {
       remove: jest.fn(),
     });
 
-    mockMutateAsync = jest.fn().mockImplementation((exception) => exception);
-    (useCreateArtifact as jest.Mock).mockImplementation(() => {
+    mockCreateOrUpdateArtifact = jest.fn().mockImplementation((exception) => [exception]);
+    (useCreateOrUpdateArtifact as jest.Mock).mockImplementation(() => {
       return {
         isLoading: false,
-        mutateAsync: mockMutateAsync,
+        createOrUpdateArtifact: mockCreateOrUpdateArtifact,
       };
     });
 
@@ -267,7 +270,7 @@ describe('Endpoint exceptions flyout', () => {
     });
 
     it('should disable submit button while saving artifact', async () => {
-      (useCreateArtifact as jest.Mock).mockImplementation(() => {
+      (useCreateOrUpdateArtifact as jest.Mock).mockImplementation(() => {
         return { isLoading: true, mutateAsync: jest.fn() };
       });
 
@@ -290,7 +293,7 @@ describe('Endpoint exceptions flyout', () => {
       });
     });
 
-    it('should call submitData and onConfirm when exception is submitted successfully', async () => {
+    it('should call createOrUpdateArtifact and onConfirm when exception is submitted successfully', async () => {
       render({ alertData, isAlertDataLoading: false });
 
       const nameInput = renderResult.getByTestId('endpointExceptions-form-name-input');
@@ -301,7 +304,7 @@ describe('Endpoint exceptions flyout', () => {
       await userEvent.click(confirmButton);
 
       await waitFor(() => {
-        expect(mockMutateAsync).toHaveBeenCalled();
+        expect(mockCreateOrUpdateArtifact).toHaveBeenCalled();
         expect(useToasts().addSuccess).toHaveBeenCalled();
         expect(mockOnConfirm).toHaveBeenCalledWith(true, false, false);
       });
@@ -319,8 +322,9 @@ describe('Endpoint exceptions flyout', () => {
       const confirmButton = renderResult.getByTestId('add-endpoint-exception-confirm-button');
       await userEvent.click(confirmButton);
 
-      expect(mockMutateAsync).toHaveBeenCalledWith(
-        expect.objectContaining({ os_types: ['macos'] })
+      expect(mockCreateOrUpdateArtifact).toHaveBeenCalledWith(
+        expect.objectContaining({ os_types: ['macos'] }),
+        undefined
       );
     });
 
@@ -336,14 +340,15 @@ describe('Endpoint exceptions flyout', () => {
       const confirmButton = renderResult.getByTestId('add-endpoint-exception-confirm-button');
       await userEvent.click(confirmButton);
 
-      expect(mockMutateAsync).toHaveBeenCalledWith(
-        expect.objectContaining({ os_types: ['windows', 'macos'] })
+      expect(mockCreateOrUpdateArtifact).toHaveBeenCalledWith(
+        expect.objectContaining({ os_types: ['windows', 'macos'] }),
+        undefined
       );
     });
 
     it('should show error toast when submission fails', async () => {
       const mockError = new Error('Submission failed');
-      mockMutateAsync.mockRejectedValue(mockError);
+      mockCreateOrUpdateArtifact.mockRejectedValue(mockError);
 
       render({ alertData, isAlertDataLoading: false });
 
@@ -355,7 +360,7 @@ describe('Endpoint exceptions flyout', () => {
       await userEvent.click(confirmButton);
 
       await waitFor(() => {
-        expect(mockMutateAsync).toHaveBeenCalled();
+        expect(mockCreateOrUpdateArtifact).toHaveBeenCalled();
         expect(useToasts().addError).toHaveBeenCalledWith(mockError, expect.any(Object));
         expect(mockOnConfirm).not.toHaveBeenCalled();
       });
@@ -380,7 +385,7 @@ describe('Endpoint exceptions flyout', () => {
         await userEvent.click(confirmButton);
 
         await waitFor(() => {
-          expect(mockMutateAsync).toHaveBeenCalled();
+          expect(mockCreateOrUpdateArtifact).toHaveBeenCalled();
           expect(mockOnConfirm).toHaveBeenCalledWith(
             true, // didRuleChange
             false, // didCloseAlert
@@ -398,7 +403,7 @@ describe('Endpoint exceptions flyout', () => {
         await userEvent.click(confirmButton);
 
         await waitFor(() => {
-          expect(mockMutateAsync).toHaveBeenCalled();
+          expect(mockCreateOrUpdateArtifact).toHaveBeenCalled();
           expect(mockOnConfirm).toHaveBeenCalledWith(
             true, // didRuleChange
             true, // didCloseAlert
@@ -421,7 +426,7 @@ describe('Endpoint exceptions flyout', () => {
         await userEvent.click(confirmButton);
 
         await waitFor(() => {
-          expect(mockMutateAsync).toHaveBeenCalled();
+          expect(mockCreateOrUpdateArtifact).toHaveBeenCalled();
           expect(mockOnConfirm).toHaveBeenCalledWith(
             true, // didRuleChange
             false, // didCloseAlert
@@ -454,7 +459,7 @@ describe('Endpoint exceptions flyout', () => {
       await userEvent.click(confirmButton);
 
       expect(renderResult.getByTestId('endpointExceptionConfirmModal')).toBeInTheDocument();
-      expect(mockMutateAsync).not.toHaveBeenCalled();
+      expect(mockCreateOrUpdateArtifact).not.toHaveBeenCalled();
       expect(mockOnConfirm).not.toHaveBeenCalled();
     });
 
@@ -468,7 +473,7 @@ describe('Endpoint exceptions flyout', () => {
       await userEvent.click(cancelButton);
 
       expect(renderResult.getByTestId('addEndpointExceptionFlyout')).toBeInTheDocument();
-      expect(mockMutateAsync).not.toHaveBeenCalled();
+      expect(mockCreateOrUpdateArtifact).not.toHaveBeenCalled();
       expect(mockOnConfirm).not.toHaveBeenCalled();
     });
 
@@ -481,7 +486,7 @@ describe('Endpoint exceptions flyout', () => {
       const submitButton = renderResult.getByTestId('endpointExceptionConfirmModal-submitButton');
       await userEvent.click(submitButton);
 
-      expect(mockMutateAsync).toHaveBeenCalled();
+      expect(mockCreateOrUpdateArtifact).toHaveBeenCalled();
       expect(mockOnConfirm).toHaveBeenCalled();
     });
   });

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/endpoint_exceptions/view/components/endpoint_exceptions_flyout.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/endpoint_exceptions/view/components/endpoint_exceptions_flyout.tsx
@@ -180,7 +180,6 @@ export const EndpointExceptionsFlyout: React.FC<EndpointExceptionsFlyoutProps> =
           </h2>
         </EuiTitle>
       </EuiFlyoutHeader>
-      {isFormValid}
 
       <EuiFlyoutBody>
         {exception && (

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/endpoint_exceptions/view/components/endpoint_exceptions_flyout.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/endpoint_exceptions/view/components/endpoint_exceptions_flyout.tsx
@@ -21,7 +21,11 @@ import {
   useGeneratedHtmlId,
 } from '@elastic/eui';
 import { ENDPOINT_ARTIFACT_LISTS } from '@kbn/securitysolution-list-constants';
-import type { CreateExceptionListItemSchema } from '@kbn/securitysolution-io-ts-list-types';
+import type {
+  CreateExceptionListItemSchema,
+  EntriesArray,
+} from '@kbn/securitysolution-io-ts-list-types';
+import { useCreateOrUpdateArtifact } from '../../../../components/artifact_list_page/hooks/use_artifact_update_or_create';
 import {
   addGlobalPolicyTag,
   removeGlobalPolicyTag,
@@ -33,7 +37,6 @@ import { ExceptionItemsFlyoutAlertsActions } from '../../../../../detection_engi
 import { ARTIFACT_FLYOUT_LABELS } from '../../../../components/artifact_list_page/components/artifact_flyout';
 import type { AddExceptionFlyoutProps } from '../../../../../detection_engine/rule_exceptions/components/add_exception_flyout';
 import { ArtifactConfirmModal } from '../../../../components/artifact_list_page/components/artifact_confirm_modal';
-import { useCreateArtifact } from '../../../../hooks/artifacts';
 import { useHttp, useToasts } from '../../../../../common/lib/kibana';
 import type {
   ArtifactConfirmModalLabelProps,
@@ -71,12 +74,14 @@ export const EndpointExceptionsFlyout: React.FC<EndpointExceptionsFlyoutProps> =
   );
   const toasts = useToasts();
   const http = useHttp();
-  const { isLoading: isSubmittingData, mutateAsync: submitData } = useCreateArtifact(
+  const { isLoading: isSubmittingData, createOrUpdateArtifact } = useCreateOrUpdateArtifact(
     EndpointExceptionsApiClient.getInstance(http)
   );
+
   const [isClosingAlerts, closeAlerts] = useCloseAlertsFromExceptions();
 
   const [exception, setException] = useState<CreateExceptionListItemSchema>();
+  const [additionalEntries, setAdditionalEntries] = useState<EntriesArray[]>();
   const exceptionArrayWrapper = useMemo(() => (exception ? [exception] : []), [exception]);
   const [isFormValid, setIsFormValid] = useState(false);
   const [showConfirmModal, setShowConfirmModal] = useState<boolean>(false);
@@ -119,12 +124,18 @@ export const EndpointExceptionsFlyout: React.FC<EndpointExceptionsFlyoutProps> =
     if (!formState) return;
     setIsFormValid(formState.isValid);
     setException(formState.item);
+    setAdditionalEntries(formState.additionalEntries);
     setConfirmModalLabels(formState.confirmModalLabels);
   }, []);
 
   const submitException = useCallback(async (): Promise<void> => {
+    if (!createOrUpdateArtifact) return;
+
     try {
-      const addedException = await submitData(exception as CreateExceptionListItemSchema);
+      const addedExceptions = await createOrUpdateArtifact(
+        exception as CreateExceptionListItemSchema,
+        additionalEntries
+      );
 
       const { shouldCloseAlerts, alertIdToClose, ruleStaticIds } = prepareToCloseAlerts({
         alertData,
@@ -135,25 +146,28 @@ export const EndpointExceptionsFlyout: React.FC<EndpointExceptionsFlyoutProps> =
         selectedRulesToAddTo: [],
       });
 
-      if (closeAlerts != null && shouldCloseAlerts) {
-        await closeAlerts(ruleStaticIds, [addedException], alertIdToClose, bulkCloseIndex);
+      if (closeAlerts != null && shouldCloseAlerts && addedExceptions) {
+        await closeAlerts(ruleStaticIds, addedExceptions, alertIdToClose, bulkCloseIndex);
       }
 
-      toasts.addSuccess(ENDPOINT_EXCEPTIONS_PAGE_LABELS.flyoutCreateSubmitSuccess(addedException));
+      toasts.addSuccess(
+        ENDPOINT_EXCEPTIONS_PAGE_LABELS.flyoutCreateSubmitSuccess(addedExceptions[0])
+      );
       onConfirm(true, closeSingleAlert, bulkCloseAlerts);
     } catch (error) {
       toasts.addError(error, getCreationErrorMessage(error));
     }
   }, [
+    additionalEntries,
     alertData,
     bulkCloseAlerts,
     bulkCloseIndex,
     closeAlerts,
     closeSingleAlert,
+    createOrUpdateArtifact,
     exception,
     onConfirm,
     rules,
-    submitData,
     toasts,
   ]);
 
@@ -188,6 +202,7 @@ export const EndpointExceptionsFlyout: React.FC<EndpointExceptionsFlyoutProps> =
             error={undefined}
             disabled={false}
             item={exception}
+            additionalEntries={additionalEntries}
             mode="create"
             onChange={handleOnChange}
           />

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/endpoint_exceptions/view/components/endpoint_exceptions_form.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/endpoint_exceptions/view/components/endpoint_exceptions_form.test.tsx
@@ -401,6 +401,46 @@ describe('Endpoint exceptions form', () => {
           expect(renderResult.getByTestId('duplicate-fields-warning-message')).toBeInTheDocument();
         });
       });
+
+      it('should show warning text when duplicate fields are added in second OR group', async () => {
+        formProps.item.entries = [
+          {
+            field: 'timestamp',
+            operator: 'included',
+            type: 'match',
+            value: '3',
+          },
+        ];
+        formProps.additionalEntries = [
+          [
+            {
+              field: 'cheese',
+              operator: 'included',
+              type: 'match',
+              value: 'some value',
+            },
+          ],
+          [
+            {
+              field: 'process.name',
+              operator: 'included',
+              type: 'match',
+              value: 'some value',
+            },
+            {
+              field: 'process.name',
+              operator: 'excluded',
+              type: 'match',
+              value: 'some other value',
+            },
+          ],
+        ];
+        render();
+
+        await waitFor(() => {
+          expect(renderResult.getByTestId('duplicate-fields-warning-message')).toBeInTheDocument();
+        });
+      });
     });
 
     describe('wildcard with wrong operator', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/endpoint_exceptions/view/components/endpoint_exceptions_form.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/endpoint_exceptions/view/components/endpoint_exceptions_form.tsx
@@ -22,7 +22,11 @@ import {
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 
-import type { ExceptionListItemSchema, OsTypeArray } from '@kbn/securitysolution-io-ts-list-types';
+import type {
+  EntriesArray,
+  ExceptionListItemSchema,
+  OsTypeArray,
+} from '@kbn/securitysolution-io-ts-list-types';
 import {
   hasWrongOperatorWithWildcard,
   hasPartialCodeSignatureEntry,
@@ -102,19 +106,28 @@ const defaultConditionEntry = (): ExceptionListItemSchema['entries'] => [
   },
 ];
 
-const cleanupEntries = (item: ArtifactFormComponentProps['item']) =>
-  item.entries.forEach(
-    (e: ArtifactFormComponentProps['item']['entries'][number] & { id?: string }) => {
-      delete e.id;
-    }
-  );
+const cleanupEntries = (multipleEntriesArrays: EntriesArray[]) =>
+  multipleEntriesArrays.forEach((entries) => {
+    entries.forEach(
+      (e: ArtifactFormComponentProps['item']['entries'][number] & { id?: string }) => {
+        delete e.id;
+      }
+    );
+  });
 
 export type EndpointExceptionsFormProps = ArtifactFormComponentProps & {
   allowSelectOs?: boolean;
 };
 
 export const EndpointExceptionsForm: React.FC<EndpointExceptionsFormProps> = memo(
-  ({ allowSelectOs = true, item: exception, onChange, mode, error: submitError }) => {
+  ({
+    allowSelectOs = true,
+    item: exception,
+    additionalEntries,
+    onChange,
+    mode,
+    error: submitError,
+  }) => {
     const getTestId = useTestIdGenerator('endpointExceptions-form');
     const { http } = useKibana().services;
 
@@ -174,16 +187,22 @@ export const EndpointExceptionsForm: React.FC<EndpointExceptionsFormProps> = mem
     }, [hasCommentError, hasNameError, exception.entries]);
 
     const processChanged = useCallback(
-      (updatedItem?: Partial<ArtifactFormComponentProps['item']>) => {
+      (
+        updatedItem?: Partial<ArtifactFormComponentProps['item']>,
+        updatedAdditionalEntries?: EntriesArray[]
+      ) => {
         const item = updatedItem
           ? {
               ...exception,
               ...updatedItem,
             }
           : exception;
-        cleanupEntries(item);
+        const addEntries = updatedAdditionalEntries ? updatedAdditionalEntries : additionalEntries;
+        cleanupEntries([item.entries]);
+        cleanupEntries(addEntries ?? []);
         onChange({
           item,
+          additionalEntries: addEntries,
           isValid: isFormValid && areConditionsValid && hasFormChanged,
           confirmModalLabels: hasWildcardWithWrongOperator
             ? CONFIRM_WARNING_MODAL_LABELS(
@@ -198,11 +217,12 @@ export const EndpointExceptionsForm: React.FC<EndpointExceptionsFormProps> = mem
         });
       },
       [
-        areConditionsValid,
         exception,
-        hasFormChanged,
-        isFormValid,
+        additionalEntries,
         onChange,
+        isFormValid,
+        areConditionsValid,
+        hasFormChanged,
         hasWildcardWithWrongOperator,
       ]
     );
@@ -213,7 +233,7 @@ export const EndpointExceptionsForm: React.FC<EndpointExceptionsFormProps> = mem
         ? (exception.entries as ExceptionListItemSchema['entries'])
         : defaultConditionEntry();
 
-      cleanupEntries(ef);
+      cleanupEntries([ef.entries]);
 
       setAreConditionsValid(!!exception.entries.length);
       return ef;
@@ -387,9 +407,14 @@ export const EndpointExceptionsForm: React.FC<EndpointExceptionsFormProps> = mem
       (arg: OnChangeProps) => {
         const isCalledWithoutChanges =
           (!hasFormChanged && arg.exceptionItems[0] === undefined) ||
-          isEqual(arg.exceptionItems[0]?.entries, exception?.entries);
+          (isEqual(arg.exceptionItems[0]?.entries, exception?.entries) &&
+            isEqual(
+              arg.exceptionItems.slice(1).map((i) => i.entries),
+              additionalEntries ?? []
+            ));
 
         if (isCalledWithoutChanges) {
+          // todo: for OR groups
           const addedFields = arg.exceptionItems[0]?.entries.map((e) => e.field) || [''];
 
           setHasDuplicateFields(computeHasDuplicateFields(getAddedFieldsCounts(addedFields)));
@@ -417,16 +442,21 @@ export const EndpointExceptionsForm: React.FC<EndpointExceptionsFormProps> = mem
                 ...exception,
                 entries: [{ field: '', operator: 'included', type: 'match', value: '' }],
               };
+
+        const updatedAdditionalEntries: EntriesArray[] = arg.exceptionItems
+          .slice(1)
+          .map((item) => item.entries as EntriesArray);
+
         const hasValidConditions =
           arg.exceptionItems[0] !== undefined
             ? !(arg.errorExists && !arg.exceptionItems[0]?.entries?.length)
             : false;
 
         setAreConditionsValid(hasValidConditions);
-        processChanged(updatedItem);
+        processChanged(updatedItem, updatedAdditionalEntries);
         if (!hasFormChanged) setHasFormChanged(true);
       },
-      [exception, hasFormChanged, processChanged]
+      [additionalEntries, exception, hasFormChanged, processChanged]
     );
 
     const exceptionBuilderComponentMemo = useMemo(

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/endpoint_exceptions/view/components/endpoint_exceptions_form.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/endpoint_exceptions/view/components/endpoint_exceptions_form.tsx
@@ -239,6 +239,13 @@ export const EndpointExceptionsForm: React.FC<EndpointExceptionsFormProps> = mem
       return ef;
     }, [exception]);
 
+    const [initialExceptions] = useState(() => [
+      endpointExceptionItem,
+      ...(additionalEntries
+        ? additionalEntries.map((entries) => ({ ...endpointExceptionItem, entries }))
+        : []),
+    ]);
+
     const handleOnChangeName = useCallback(
       (event: React.ChangeEvent<HTMLInputElement>) => {
         if (!exception) return;
@@ -414,10 +421,15 @@ export const EndpointExceptionsForm: React.FC<EndpointExceptionsFormProps> = mem
             ));
 
         if (isCalledWithoutChanges) {
-          // todo: for OR groups
-          const addedFields = arg.exceptionItems[0]?.entries.map((e) => e.field) || [''];
+          const addedFieldGroups: string[][] = arg.exceptionItems.map(
+            (item) => item?.entries.map((e) => e.field) || ['']
+          );
 
-          setHasDuplicateFields(computeHasDuplicateFields(getAddedFieldsCounts(addedFields)));
+          setHasDuplicateFields(
+            addedFieldGroups.some((addedFields) =>
+              computeHasDuplicateFields(getAddedFieldsCounts(addedFields))
+            )
+          );
           return;
         } else {
           setHasDuplicateFields(false);
@@ -465,7 +477,7 @@ export const EndpointExceptionsForm: React.FC<EndpointExceptionsFormProps> = mem
           allowLargeValueLists: false,
           httpService: http,
           autocompleteService: autocompleteSuggestions,
-          exceptionListItems: [endpointExceptionItem as ExceptionListItemSchema],
+          exceptionListItems: initialExceptions as ExceptionListItemSchema[],
           listType: ENDPOINT_EXCEPTIONS_LIST_DEFINITION.type,
           listId: ENDPOINT_EXCEPTIONS_LIST_DEFINITION.list_id,
           listNamespaceType: 'agnostic',
@@ -482,7 +494,7 @@ export const EndpointExceptionsForm: React.FC<EndpointExceptionsFormProps> = mem
       [
         http,
         autocompleteSuggestions,
-        endpointExceptionItem,
+        initialExceptions,
         indexPatterns,
         handleOnBuilderChange,
         exception.os_types,


### PR DESCRIPTION
## Summary

The goal to keep the old behavior (without feature flag) of creating Endpoint exceptions with OR operator: the condition groups connected with OR operators are separated into multiple artifacts on create/edit.

> [!note]
> Changes are behind FF `xpack.securitySolution.enableExperimental.endpointExceptionsMovedUnderManagement`, which will be enabled with v9.4.0.


## Deployments for testing

Deployed from PR https://github.com/elastic/kibana/pull/266165

- serverless (from commit https://github.com/elastic/kibana/pull/266165/changes/b7f9ecf786e9032b70aca1217def6f3489a205ea): [credentials](https://p.elstc.co/?8905c022a1bbc925#4gkKmMrFcJwX8sht5SiTH6MTNMZ7y2Jc1EpgAALpSb4G)
- cloud (from one later commit https://github.com/elastic/kibana/pull/266165/commits/9d62edc7492fb13e43916b9dec59a533fbe75a89): [credentials](https://p.elstc.co/?24653b1b5c93fd95#9Zh4TFNzf4MbHib2jqt4UxEgXzhH14pzxoo8EkXTgjcC)

## Screen recording

https://github.com/user-attachments/assets/2a427f09-bdf1-4e7b-8de6-e9d1abf6abb6



### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->