### PR TITLE
skip flaky test: #262047

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/test/scout/ui/parallel_tests/settings/custom_links_template_validation.spec.ts
+++ b/x-pack/solutions/observability/plugins/apm/test/scout/ui/parallel_tests/settings/custom_links_template_validation.spec.ts
@@ -22,7 +22,10 @@ const templateUrl =
 const getExpectedUrl = (serviceName: string, environment: string) =>
   `http://scoutURLExample.com/ftw/app/apm/services/${serviceName}/transactions/view?comparisonEnabled=true&environment=${environment}`;
 
-test.describe.serial(
+// When unskipping, consider this used to be `test.describe.serial`
+// but there's no skip that preserves that. Consider not using serial.
+// Flaky: https://github.com/elastic/kibana/issues/262047
+test.describe.skip(
   'Custom links template validation',
   { tag: [...tags.stateful.classic, ...tags.serverless.observability.complete] },
   () => {


### PR DESCRIPTION
## Summary
Skips flaky test https://github.com/elastic/kibana/issues/262047
Playwright tests with `.serial` cannot be skipped properly, there's no skip on the serial variant, so I had to manually skip it. 