### PR TITLE
Unskip flaky tags accessibility test

### DIFF
--- a/x-pack/platform/test/accessibility/apps/group3/tags.ts
+++ b/x-pack/platform/test/accessibility/apps/group3/tags.ts
@@ -16,7 +16,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const browser = getService('browser');
 
   // FLAKY: https://github.com/elastic/kibana/issues/244018
-  describe.skip('Kibana Tags Page Accessibility', () => {
+  describe('Kibana Tags Page Accessibility', () => {
     before(async () => {
       await PageObjects.settings.navigateTo();
       await testSubjects.click('tags');


### PR DESCRIPTION
## Summary
- Unskips the "Kibana Tags Page Accessibility" test that was previously skipped due to flakiness (https://github.com/elastic/kibana/issues/244018)
- Removes the `describe.skip` wrapper so the test runs in CI again

## Test plan
- [x] Verify the tags accessibility test passes in CI
- [x] Monitor for flakiness over subsequent runs

<!--ONMERGE {"backportTargets":["8.19","9.2","9.3","9.4"]} ONMERGE-->