### PR TITLE
Fix: [Security Solution] [Bug] Attack Discovery shows internal date math string “now/w” for “This week” time range instead of readable date

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/loading_callout/loading_messages/get_formatted_time/index.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/loading_callout/loading_messages/get_formatted_time/index.test.ts
@@ -26,13 +26,33 @@ describe('getFormattedDate', () => {
     expect(result).toBeNull();
   });
 
-  it('returns the original date if it cannot be parsed', () => {
+  it('returns "now" if date is "now"', () => {
     const result = getFormattedDate({
-      date: 'now', // <-- this relative date cannot be parsed
+      date: 'now',
       dateFormat: 'YYYY-MM-DD',
     });
 
     expect(result).toBe('now');
+  });
+
+  it('parses datemath and returns the formatted date', () => {
+    const result = getFormattedDate({
+      date: 'now/w',
+      dateFormat: 'YYYY-MM-DD',
+    });
+
+    // We can't strictly match the current week start because datemath relies on current time,
+    // so we mock or just check it returns a formatted string.
+    expect(result).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it('returns the original date if it cannot be parsed by moment or datemath', () => {
+    const result = getFormattedDate({
+      date: 'invalid-date',
+      dateFormat: 'YYYY-MM-DD',
+    });
+
+    expect(result).toBe('invalid-date');
   });
 
   it('returns the formatted date if the date is valid', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/loading_callout/loading_messages/get_formatted_time/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/loading_callout/loading_messages/get_formatted_time/index.ts
@@ -6,6 +6,7 @@
  */
 
 import moment from 'moment';
+import datemath from '@elastic/datemath';
 
 export const getFormattedDate = ({
   date,
@@ -18,13 +19,22 @@ export const getFormattedDate = ({
     return null;
   }
 
+  if (date === 'now') {
+    return date;
+  }
+
   // strictly parse the date, which will fail for dates like formatted like 'now':
   const strictParsed = moment(date, moment.ISO_8601, true);
 
-  if (!strictParsed.isValid()) {
-    return date; // return the original date if it cannot be parsed
+  if (strictParsed.isValid()) {
+    // return the formatted date per the time zone:
+    return strictParsed.format(dateFormat);
   }
 
-  // return the formatted date per the time zone:
-  return moment(date).format(dateFormat);
+  const datemathParsed = datemath.parse(date);
+  if (datemathParsed != null && datemathParsed.isValid()) {
+    return datemathParsed.format(dateFormat);
+  }
+
+  return date; // return the original date if it cannot be parsed
 };


### PR DESCRIPTION
## Summary

Addresses https://github.com/elastic/kibana/issues/243591

# PR Summary

## Changes

- Updated the `getFormattedDate` utility in `get_formatted_time/index.ts` to parse datemath strings (e.g. `now/w`, `now-7d`) using `@elastic/datemath`.
- Datemath parsing correctly transforms relative time ranges into absolute human-readable formatted dates (e.g. "from Apr 20, 2026 to Apr 27, 2026" instead of "from now/w to now...").
- Preserved the literal string `now` to retain the user-friendly format "...to now" where applicable.

## Most Important Changed Files

- `x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/loading_callout/loading_messages/get_formatted_time/index.ts`: Updated to support datemath parsing using `@elastic/datemath`.
- `x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/loading_callout/loading_messages/get_formatted_time/index.test.ts`: Added tests to verify correct datemath formatting and `"now"` preservation.

## Verification Steps

1. Start up a Kibana instance with a SNAPSHOT build locally.
2. Navigate to **Security → Attack discovery**.
3. At the top-right time filter, select **Last 7 days**.
4. Click **Run** to start an Attack Discovery job.
5. Observe the banner text in the loading callout. It should read “AI is analysing up to 200 alerts from [absolute date] to now…” (instead of showing `now-7d`).
6. Change the time filter to **This week** and run the job again.
7. Observe the banner text again. It should read “AI is analysing up to 200 alerts from [absolute date] to now…” rather than showing the internal `now/w` math string.


---

_PR developed with Cursor_