### PR TITLE
[Chrome Next] Remove color prop from primary item in app menu

### DIFF
--- a/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/components/app_menu_action_button.tsx
+++ b/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/components/app_menu_action_button.tsx
@@ -10,7 +10,6 @@
 import React, { useRef, type MouseEvent } from 'react';
 import { SplitButtonWithNotification } from '@kbn/split-button';
 import { upperFirst } from 'lodash';
-import type { EuiButtonColor } from '@elastic/eui';
 import { EuiButton, EuiHideFor, EuiToolTip, useEuiTheme } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { getRouterLinkProps } from '@kbn/router-utils';
@@ -59,7 +58,6 @@ export const AppMenuActionButton = (props: AppMenuActionButtonProps) => {
   const showTooltip = Boolean(content || title);
 
   const splitButtonProps = 'splitButtonProps' in props ? props.splitButtonProps : undefined;
-  const colorProp = 'color' in props ? props.color : undefined;
 
   const {
     items: splitButtonItems,
@@ -129,7 +127,7 @@ export const AppMenuActionButton = (props: AppMenuActionButtonProps) => {
   const buttonCss = css`
     background-color: ${isPopoverOpen
       ? getIsSelectedColor({
-          color: colorProp as EuiButtonColor,
+          color: 'text',
           euiTheme,
           isFilled: false,
         })
@@ -163,7 +161,7 @@ export const AppMenuActionButton = (props: AppMenuActionButtonProps) => {
         iconSide="left"
         isSelected={isPopoverOpen}
         css={buttonCss}
-        color={colorProp}
+        color="text"
       >
         {itemText}
       </EuiButton>

--- a/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/types.ts
+++ b/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/types.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { EuiButtonColor, EuiHideForProps, IconType } from '@elastic/eui';
+import type { EuiHideForProps, IconType } from '@elastic/eui';
 import type { SplitButtonWithNotificationProps } from '@kbn/split-button';
 
 /**
@@ -251,13 +251,6 @@ export type AppMenuPopoverItem = Omit<
   labelBadgeText?: string;
 };
 
-type AppMenuActionButton = Omit<AppMenuItemCommon, 'order' | 'overflow' | 'separator'> & {
-  /**
-   * The color of the button.
-   */
-  color?: EuiButtonColor;
-};
-
 /**
  * Primary action button type. Can be either a simple button or a split button.
  */
@@ -265,7 +258,7 @@ export type AppMenuPrimaryActionItem =
   /**
    * The main part of the button should never open a popover.
    */
-  Omit<AppMenuActionButton, 'items'> & {
+  Omit<AppMenuItemCommon, 'order' | 'overflow' | 'separator'> & {
     /**
      * Subset of SplitButtonWithNotificationProps.
      */


### PR DESCRIPTION
## Summary

This PR removes the ability to set color for primary item in app menu and always sets it to `text`.


