### PR TITLE
Fix: [Security Solution] [Bug] Error for the empty body under D3 connector is not shown until the user explicitly clicks and then leaves the body text box empty

### DIFF
--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/d3security/params.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/d3security/params.tsx
@@ -34,7 +34,10 @@ const D3ParamsFields: React.FunctionComponent<ActionParamsProps<D3SecurityAction
     if (!subAction) {
       editAction('subAction', isTest ? SUB_ACTION.TEST : SUB_ACTION.RUN, index);
     }
-  }, [editAction, index, isTest, subAction]);
+    if (body === undefined) {
+      editSubActionParams({ body: '' });
+    }
+  }, [editAction, index, isTest, subAction, body, editSubActionParams]);
 
   const editSubActionParams = useCallback(
     (params: D3SecurityRunActionParams) => {


### PR DESCRIPTION
## Summary

Addresses https://github.com/elastic/kibana/issues/221906

### Summary
This PR fixes an issue where the empty body error under the D3 connector is not shown until the user explicitly clicks and leaves the body text box. This was caused by the `body` parameter being initialized as `undefined`, which prevented the validation error from being displayed immediately by the `JsonEditorWithMessageVariables` component.

We've updated `params.tsx` for the D3 connector to correctly initialize `body` as an empty string (`''`) on mount if it is undefined, allowing the validation error to appear right away.

**Changed Files:**
- `x-pack/platform/plugins/shared/stack_connectors/public/connector_types/d3security/params.tsx`: Added an effect to initialize `body` to an empty string.

### Verification Steps
1. Make sure you are running a Kibana 9.1.0 snapshot or a local environment.
2. Navigate to **Attack Discovery** under the Security tab.
3. Click on the settings icon.
4. Click **Create a schedule** (or **Create rule**).
5. Under the 'Select a connector type', select the **D3** connector.
6. Observe that an error message is now shown immediately for the empty body text box, even before clicking on it.
7. Click on the text box and leave it empty to verify the error remains.

---

_PR developed with Cursor_