### PR TITLE
fix(streams): suppress error toast on dissect suggestion abort

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/steps/blocks/action/dissect/use_dissect_pattern_suggestion.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/steps/blocks/action/dissect/use_dissect_pattern_suggestion.tsx
@@ -8,6 +8,7 @@
 import useAsyncFn from 'react-use/lib/useAsyncFn';
 import { lastValueFrom } from 'rxjs';
 import type { useAbortController } from '@kbn/react-hooks';
+import { isRequestAbortedError } from '@kbn/server-route-repository-client';
 import { useFetchErrorToast } from '../../../../../../../../hooks/use_fetch_error_toast';
 import { NoSuggestionsError, isNoSuggestionsError } from '../utils/no_suggestions_error';
 import {
@@ -116,7 +117,7 @@ export function useDissectPatternSuggestion(
         };
       } catch (error) {
         finishTrackingAndReport(0, [0]);
-        if (!isNoSuggestionsError(error)) {
+        if (!isNoSuggestionsError(error) && !isRequestAbortedError(error)) {
           showFetchErrorToast(error as Error);
         }
         throw error;


### PR DESCRIPTION
When navigating away from a running dissect suggestion, an error toast "signal is aborted without reason" was shown because the abort error was not being filtered before showing the toast.

This adds the same \ check already used in the grok suggestion hook and review suggestions form.

Fixes https://github.com/elastic/observability-error-backlog/issues/738

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->