### PR TITLE
[Entity Analytics] Only use alerts index for risk score preview

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_score_management/risk_score_preview_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_score_management/risk_score_preview_section.tsx
@@ -22,18 +22,16 @@ import {
 } from '@elastic/eui';
 import type { BoolQuery } from '@kbn/es-query';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { PageScope } from '../../../data_view_manager/constants';
 import type { EntityType } from '../../../../common/entity_analytics/types';
 import { EntityTypeToIdentifierField } from '../../../../common/entity_analytics/types';
 import type { EntityRiskScoreRecord } from '../../../../common/api/entity_analytics/common';
 import { RISK_SCORE_INDEX_PATTERN } from '../../../../common/entity_analytics/risk_engine';
+import { getAlertsIndex } from '../../../../common/entity_analytics/utils';
 import { RiskScorePreviewTable } from './risk_score_preview_table';
 import * as i18n from '../../translations';
 import { useRiskScorePreview } from '../../api/hooks/use_preview_risk_scores';
-import { useSourcererDataView } from '../../../sourcerer/containers';
 import { EntityIconByType } from '../entity_store/helpers';
-import { useIsExperimentalFeatureEnabled } from '../../../common/hooks/use_experimental_features';
-import { useDataView } from '../../../data_view_manager/hooks/use_data_view';
+import { useSpaceId } from '../../../common/hooks/use_space_id';
 import { useEntityAnalyticsTypes } from '../../hooks/use_enabled_entity_types';
 import type { AlertFilter } from './common';
 
@@ -171,22 +169,16 @@ const RiskEnginePreview: React.FC<{
     bool: { must: [], filter: [], should: [], must_not: [] },
   });
 
-  const { sourcererDataView: oldSourcererDataView } = useSourcererDataView(PageScope.alerts);
-
-  const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
-  const { dataView: experimentalDataView } = useDataView(PageScope.alerts);
-
-  const sourcererDataView = newDataViewPickerEnabled ? experimentalDataView : oldSourcererDataView;
+  const spaceId = useSpaceId();
 
   const { data, isLoading, refetch, isError } = useRiskScorePreview({
-    data_view_id: sourcererDataView?.title,
+    data_view_id: spaceId ? getAlertsIndex(spaceId) : undefined,
     filter: filters,
     range: {
       start: from,
       end: to,
     },
     exclude_alert_statuses: includeClosedAlerts ? [] : ['closed'],
-    // Pass filters to API (will only work once backend PR merges)
     filters: alertFilters && alertFilters.length > 0 ? alertFilters : undefined,
   });
 


### PR DESCRIPTION
## Summary

Risk scoring works off of the alerts index so risk score preview only needs to handle the alerts index. This updates the API call to the preview API to only pass the alerts index.

## To Verify

1. Start ES and Kibana
2. Navigate to Security -> Manage -> Entity Analytics
3. In the network tab, you should see the request to the preview API and only the alerts index passed instead of the security solution dataview:

<img width="2109" height="631" alt="Screenshot 2026-04-28 at 10 27 53 AM" src="https://github.com/user-attachments/assets/fa3baa31-8cfd-4af3-8fc7-e3a3b8fab7a0" />

4. Verify that previews are still generated when you have alerts data with entity store entities:

<img width="1187" height="885" alt="Screenshot 2026-04-28 at 10 40 43 AM" src="https://github.com/user-attachments/assets/266aded6-37ba-46fe-b144-7d89d8fb4f59" />


<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->