### PR TITLE
Fix: [Security Solution] [Bug] The name of a few connectors is wrong in actions for the schedule Attack Discovery

### DIFF
--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/d3security/d3security.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/d3security/d3security.tsx
@@ -24,7 +24,7 @@ export function getConnectorType(): D3SecurityConnector {
     actionTypeTitle: i18n.translate(
       'xpack.stackConnectors.components.d3security.connectorTypeTitle',
       {
-        defaultMessage: 'D3 data',
+        defaultMessage: 'D3 Security',
       }
     ),
     validateParams: async (

--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/es_index/es_index.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/es_index/es_index.tsx
@@ -23,7 +23,7 @@ export function getConnectorType(): ConnectorTypeModel<EsIndexConfig, unknown, I
       defaultMessage: 'Index data into Elasticsearch.',
     }),
     actionTypeTitle: i18n.translate('xpack.stackConnectors.components.index.connectorTypeTitle', {
-      defaultMessage: 'Index data',
+      defaultMessage: 'Index',
     }),
     actionConnectorFields: lazy(() => import('./es_index_connector')),
     actionParamsFields: lazy(() => import('./es_index_params')),

--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/pagerduty/pagerduty.test.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/pagerduty/pagerduty.test.tsx
@@ -27,7 +27,7 @@ beforeAll(() => {
 describe('connectorTypeRegistry.get() works', () => {
   test('connector type static data is as expected', () => {
     expect(connectorTypeModel.id).toEqual(CONNECTOR_TYPE_ID);
-    expect(connectorTypeModel.actionTypeTitle).toEqual('Send to PagerDuty');
+    expect(connectorTypeModel.actionTypeTitle).toEqual('PagerDuty');
   });
 });
 

--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/pagerduty/pagerduty.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/pagerduty/pagerduty.tsx
@@ -33,7 +33,7 @@ export function getConnectorType(): ConnectorTypeModel<
     actionTypeTitle: i18n.translate(
       'xpack.stackConnectors.components.pagerDuty.connectorTypeTitle',
       {
-        defaultMessage: 'Send to PagerDuty',
+        defaultMessage: 'PagerDuty',
       }
     ),
     validateParams: async (

--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/server_log/server_log.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/server_log/server_log.tsx
@@ -24,7 +24,7 @@ export function getConnectorType(): ConnectorTypeModel<unknown, unknown, ServerL
     actionTypeTitle: i18n.translate(
       'xpack.stackConnectors.components.serverLog.connectorTypeTitle',
       {
-        defaultMessage: 'Send to Server log',
+        defaultMessage: 'Server log',
       }
     ),
     validateParams: (

--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/swimlane/swimlane.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/swimlane/swimlane.tsx
@@ -24,7 +24,7 @@ export const SW_SELECT_MESSAGE_TEXT = i18n.translate(
 export const SW_ACTION_TYPE_TITLE = i18n.translate(
   'xpack.stackConnectors.components.swimlane.connectorTypeTitle',
   {
-    defaultMessage: 'Create Swimlane Record',
+    defaultMessage: 'Swimlane',
   }
 );
 

--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/teams/teams.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/teams/teams.tsx
@@ -22,7 +22,7 @@ export function getConnectorType(): ConnectorTypeModel<unknown, TeamsSecrets, Te
       defaultMessage: 'Send a message to a Microsoft Teams channel.',
     }),
     actionTypeTitle: i18n.translate('xpack.stackConnectors.components.teams.connectorTypeTitle', {
-      defaultMessage: 'Send a message to a Microsoft Teams channel.',
+      defaultMessage: 'Microsoft',
     }),
     validateParams: async (
       actionParams: TeamsActionParams

--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/torq/translations.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/torq/translations.ts
@@ -65,7 +65,7 @@ export const TORQ_SELECT_MESSAGE = i18n.translate(
 export const TORQ_ACTION_TYPE_TITLE = i18n.translate(
   'xpack.stackConnectors.torqAction.actionTypeTitle',
   {
-    defaultMessage: 'Alert data',
+    defaultMessage: 'Torq',
   }
 );
 

--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/webhook/webhook.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/webhook/webhook.tsx
@@ -28,7 +28,7 @@ export function getConnectorType(): ConnectorTypeModel<
       defaultMessage: 'Send a request to a web service.',
     }),
     actionTypeTitle: i18n.translate('xpack.stackConnectors.components.webhook.connectorTypeTitle', {
-      defaultMessage: 'Webhook data',
+      defaultMessage: 'Webhook',
     }),
     validateParams: async (
       actionParams: WebhookActionParams,

--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/xmatters/xmatters.test.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/xmatters/xmatters.test.tsx
@@ -27,7 +27,7 @@ beforeAll(() => {
 describe('connectorTypeRegistry.get() works', () => {
   test('connector type static data is as expected', () => {
     expect(connectorTypeModel.id).toEqual(CONNECTOR_TYPE_ID);
-    expect(connectorTypeModel.actionTypeTitle).toEqual('xMatters data');
+    expect(connectorTypeModel.actionTypeTitle).toEqual('xMatters');
   });
 });
 

--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/xmatters/xmatters.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/xmatters/xmatters.tsx
@@ -29,7 +29,7 @@ export function getConnectorType(): ConnectorTypeModel<
     actionTypeTitle: i18n.translate(
       'xpack.stackConnectors.components.xmatters.connectorTypeTitle',
       {
-        defaultMessage: 'xMatters data',
+        defaultMessage: 'xMatters',
       }
     ),
     validateParams: async (


### PR DESCRIPTION
## Summary

Addresses https://github.com/elastic/kibana/issues/222971

# PR Summary

## Description
This PR fixes an issue where the connector type names were displayed incorrectly in the Attack Discovery schedule actions dropdown. The `actionTypeTitle` for several connectors was set to descriptive phrases (e.g., "Index data", "Send to PagerDuty") instead of the actual connector names. This PR updates the `actionTypeTitle` for the following connectors to match their expected names:
- D3 Security (was "D3 data")
- Index (was "Index data")
- Microsoft (was "Send a message to a Microsoft Teams channel.")
- PagerDuty (was "Send to PagerDuty")
- Server log (was "Send to Server log")
- Swimlane (was "Create Swimlane Record")
- Torq (was "Alert data")
- Webhook (was "Webhook data")
- xMatters (was "xMatters data")

## Verification Steps
1. Start Kibana and ensure the Security Solution is enabled.
2. Navigate to **Security -> Attack Discovery**.
3. Click on the settings icon and navigate to the **Schedule** tab.
4. Click on the connectors dropdown under the **Actions** section.
5. Verify that the names of the connectors are displayed correctly as listed above (e.g., "D3 Security", "Index", "Microsoft", "PagerDuty", "Server log", "Swimlane", "Torq", "Webhook", "xMatters").


---

_PR developed with Cursor_