### PR TITLE
Fix: [AI4SOC] [Bug] The count of total alerts is mismatched under the settings flyout for attack discovery if alerts have more than one tag

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/alert_selection/alert_summary_tab/get_alert_summary_lens_attributes/index.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/alert_selection/alert_summary_tab/get_alert_summary_lens_attributes/index.test.ts
@@ -62,7 +62,6 @@ describe('getAlertSummaryLensAttributes', () => {
             },
             {
               columnId: 'count',
-              summaryRow: 'sum',
             },
           ],
           layerId: '094d6c10-a28a-4780-8a0c-5789b73e4cef',

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/alert_selection/alert_summary_tab/get_alert_summary_lens_attributes/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/alert_selection/alert_summary_tab/get_alert_summary_lens_attributes/index.ts
@@ -69,7 +69,6 @@ export const getAlertSummaryLensAttributes = ({
         },
         {
           columnId: 'count',
-          summaryRow: 'sum',
         },
       ],
       layerId: LAYER_ID,


### PR DESCRIPTION
## Summary

Addresses https://github.com/elastic/kibana/issues/221227

### Description

This PR fixes a bug in the Attack Discovery settings flyout where the total count of alerts displayed in the "Alert summary" table's summary row was incorrect when grouping by array fields (such as `tags`).

When the ES|QL query groups by an array field, it "explodes" the array, meaning an alert with multiple tags is counted in multiple buckets. Because the Lens datatable was configured with `summaryRow: 'sum'`, it summed the counts of all buckets, resulting in a total that exceeded the actual number of alerts analyzed. 

Since Lens datatable only receives the aggregated data and cannot determine the true number of unique alerts, the `summaryRow: 'sum'` configuration has been removed to prevent displaying an inaccurate total count.

### Verification Steps

1. Navigate to the Attack Discovery page in a Serverless or Stateful environment.
2. Ensure you have alerts with multiple tags (e.g., an alert with `tag1` and `tag2`).
3. Click the **Settings** button to open the Attack Discovery settings flyout.
4. In the **Alert summary** tab, select `tags` from the field dropdown.
5. Verify that the table displays the counts for each tag correctly.
6. Verify that there is no longer a "Sum" row at the bottom of the table displaying an incorrect total count.

---

_PR developed with Cursor_