### PR TITLE
Fix: [Security Solution] [Bug] The action names are not shown in the tooltip when user hovers on the actions provided for each parameter under the attack discovery tab

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_markdown_formatter/field_markdown_renderer/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_markdown_formatter/field_markdown_renderer/index.tsx
@@ -51,26 +51,24 @@ export const getFieldMarkdownRenderer = (disableActions: boolean, scopeId?: stri
       [euiTheme.font.scale.s, flyoutPanelProps, onEntityClick, value]
     );
 
-    return (
+    return disableActions ? (
       <EuiToolTip content={name} data-test-subj="fieldMarkdownRendererToolTip" position="top">
-        {disableActions ? (
-          <EuiBadge color="hollow" data-test-subj="disabledActionsBadge" iconType={icon}>
-            {value}
-          </EuiBadge>
-        ) : (
-          <DraggableBadge
-            contextId="fieldMarkdownRenderer"
-            scopeId={scopeId}
-            eventId=""
-            iconType={icon}
-            isAggregatable={false}
-            field={name}
-            value={value}
-          >
-            {entityButton}
-          </DraggableBadge>
-        )}
+        <EuiBadge color="hollow" data-test-subj="disabledActionsBadge" iconType={icon}>
+          {value}
+        </EuiBadge>
       </EuiToolTip>
+    ) : (
+      <DraggableBadge
+        contextId="fieldMarkdownRenderer"
+        scopeId={scopeId}
+        eventId=""
+        iconType={icon}
+        isAggregatable={false}
+        field={name}
+        value={value}
+      >
+        {entityButton}
+      </DraggableBadge>
     );
   };
 


### PR DESCRIPTION
## Summary

Addresses https://github.com/elastic/kibana/issues/214711

## Description
Fixed a bug where the parameter name was incorrectly displayed in the tooltip when hovering over actions inside the Attack Discovery tab. The issue was caused by an outer `EuiToolTip` component incorrectly wrapping both the parameter badge and its hover actions. The `EuiToolTip` wrapper was removed from the active state, so now tooltips correctly display the action names instead of the parameter name.

## Changed Files
- `x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_markdown_formatter/field_markdown_renderer/index.tsx`: Removed the `EuiToolTip` wrapper when `disableActions` is false, ensuring it does not override the inner action tooltips rendered by `CellActionsRenderer`.

## Verification Steps
1. Ensure you have an AI connector configured in your Kibana instance.
2. Navigate to **Security** -> **Attack Discovery**.
3. Generate a new Attack Discovery entry (or open an existing one).
4. Hover over any parameter badge (e.g. host name or user name) in the generated results to display its actions (like "Filter in", "Filter out", etc).
5. Hover over the individual action buttons.
6. Verify that the tooltip now correctly displays the action name (e.g. "Filter in") instead of the parameter name.

---

_PR developed with Cursor_