### PR TITLE
Fix: [Security Solution] [Bug] Non required Filter In/ Filter out options are available for the discovery response 

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_markdown_formatter/field_markdown_renderer/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_markdown_formatter/field_markdown_renderer/index.tsx
@@ -66,6 +66,7 @@ export const getFieldMarkdownRenderer = (disableActions: boolean, scopeId?: stri
             isAggregatable={false}
             field={name}
             value={value}
+            hideFilter={true}
           >
             {entityButton}
           </DraggableBadge>

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/cell_actions/cell_actions_renderer.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/cell_actions/cell_actions_renderer.tsx
@@ -35,6 +35,7 @@ export const ProviderContentWrapper = styled.span`
 
 export interface CellActionsRendererProps {
   hideTopN?: boolean;
+  hideFilter?: boolean;
   field: string;
   value?: string | number | null;
   queryValue?: string | null;
@@ -87,6 +88,7 @@ Content.displayName = 'Content';
 export const CellActionsRenderer = React.memo<CellActionsRendererProps>(
   ({
     hideTopN = false,
+    hideFilter = false,
     field,
     value,
     children,
@@ -112,8 +114,13 @@ export const CellActionsRenderer = React.memo<CellActionsRendererProps>(
     }, [value, field, queryValue]);
 
     const disabledActionTypes = useMemo(
-      () => (hideTopN ? [SecurityCellActionType.SHOW_TOP_N] : []),
-      [hideTopN]
+      () => {
+        const types: SecurityCellActionType[] = [];
+        if (hideTopN) types.push(SecurityCellActionType.SHOW_TOP_N);
+        if (hideFilter) types.push(SecurityCellActionType.FILTER);
+        return types;
+      },
+      [hideTopN, hideFilter]
     );
 
     const content = useMemo(

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/draggables/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/draggables/index.tsx
@@ -51,6 +51,8 @@ const DraggableBadgeComponent: React.FC<BadgeType> = ({
   scopeId,
   tooltipContent,
   queryValue,
+  hideTopN,
+  hideFilter,
 }) =>
   value != null ? (
     <CellActionsRenderer
@@ -59,6 +61,8 @@ const DraggableBadgeComponent: React.FC<BadgeType> = ({
       scopeId={scopeId}
       tooltipContent={tooltipContent}
       queryValue={queryValue}
+      hideTopN={hideTopN}
+      hideFilter={hideFilter}
     >
       <Badge iconType={iconType} color="hollow" title="">
         {children ? children : value !== '' ? value : getEmptyStringTag()}


### PR DESCRIPTION
## Summary

Addresses https://github.com/elastic/kibana/issues/183119

# PR Summary

This PR fixes an issue where the "Filter In / Filter Out" options were incorrectly available for the discovery response in the 'Attack Discovery' tab, which when clicked applied filters to the alerts and hosts tabs.

## Changes
- `x-pack/solutions/security/plugins/security_solution/public/common/components/cell_actions/cell_actions_renderer.tsx`: Added a `hideFilter` prop to `CellActionsRendererProps` that disables the `SecurityCellActionType.FILTER` action when set to true.
- `x-pack/solutions/security/plugins/security_solution/public/common/components/draggables/index.tsx`: Added `hideFilter` to `DraggableBadgeComponent` and passed it down to `CellActionsRenderer`.
- `x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_markdown_formatter/field_markdown_renderer/index.tsx`: Passed `hideFilter={true}` to `DraggableBadge` to disable the "Filter In / Filter Out" options for the fields rendered in the discovery response.

## Verification Steps
1. Navigate to the **Security** app in Kibana.
2. Go to the **Attack Discovery** tab.
3. Click on the **Generate** button to create a discovery response.
4. Hover over or click on the fields (badges) inside the generated discovery response.
5. Verify that the "Filter In" and "Filter Out" options are no longer available in the actions menu for these fields.

---

_PR developed with Cursor_