### PR TITLE
[Entity Analytics] Show individual risk score for solo entities in resolution-grouped table

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/grouping/entity_group_renderer.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/grouping/entity_group_renderer.test.tsx
@@ -71,7 +71,15 @@ describe('createGroupPanelRenderer', () => {
   describe('RESOLUTION group', () => {
     it('renders target entity name from metadata', () => {
       const metadata: TargetMetadataMap = new Map([
-        ['target-entity-id', { name: 'bernicehuel', type: EntityType.user, riskScore: null }],
+        [
+          'target-entity-id',
+          {
+            name: 'bernicehuel',
+            type: EntityType.user,
+            riskScore: null,
+            individualRiskScore: null,
+          },
+        ],
       ]);
       const bucket = createMockBucket({ key: 'target-entity-id' });
       const renderer = createGroupPanelRenderer(metadata);
@@ -84,7 +92,10 @@ describe('createGroupPanelRenderer', () => {
 
     it('renders entity id subtitle when metadata has target name', () => {
       const metadata: TargetMetadataMap = new Map([
-        ['user:james@example.com', { name: 'james-hue', type: EntityType.user, riskScore: null }],
+        [
+          'user:james@example.com',
+          { name: 'james-hue', type: EntityType.user, riskScore: null, individualRiskScore: null },
+        ],
       ]);
       const bucket = createMockBucket({
         key: 'user:james@example.com',
@@ -128,7 +139,15 @@ describe('createGroupPanelRenderer', () => {
 
     it('renders expand button when metadata has name and type', () => {
       const metadata: TargetMetadataMap = new Map([
-        ['target-id', { name: 'test-entity', type: EntityType.user, riskScore: null }],
+        [
+          'target-id',
+          {
+            name: 'test-entity',
+            type: EntityType.user,
+            riskScore: null,
+            individualRiskScore: null,
+          },
+        ],
       ]);
       const bucket = createMockBucket({ key: 'target-id' });
       const renderer = createGroupPanelRenderer(metadata);
@@ -165,7 +184,15 @@ describe('createGroupPanelRenderer', () => {
 
       // Phase 2: metadata arrived — new renderer shows target name + flyout button
       const metadata: TargetMetadataMap = new Map([
-        ['target-id', { name: 'alice-target', type: EntityType.user, riskScore: 85.0 }],
+        [
+          'target-id',
+          {
+            name: 'alice-target',
+            type: EntityType.user,
+            riskScore: 85.0,
+            individualRiskScore: null,
+          },
+        ],
       ]);
       const rendererAfter = createGroupPanelRenderer(metadata);
       rerender(<>{rendererAfter(ENTITY_GROUPING_OPTIONS.RESOLUTION, bucket)}</>);
@@ -208,7 +235,10 @@ describe('createGroupStatsRenderer', () => {
   describe('RESOLUTION group', () => {
     it('returns entities count + risk score stats (2 items)', () => {
       const metadata: TargetMetadataMap = new Map([
-        ['target-id', { name: 'test', type: EntityType.user, riskScore: 85.42 }],
+        [
+          'target-id',
+          { name: 'test', type: EntityType.user, riskScore: 85.42, individualRiskScore: null },
+        ],
       ]);
       const bucket = createMockBucket({ key: 'target-id', doc_count: 4 });
       const renderer = createGroupStatsRenderer(metadata);
@@ -221,7 +251,10 @@ describe('createGroupStatsRenderer', () => {
 
     it('risk score badge shows value from metadata', () => {
       const metadata: TargetMetadataMap = new Map([
-        ['target-id', { name: 'test', type: EntityType.user, riskScore: 73.1829 }],
+        [
+          'target-id',
+          { name: 'test', type: EntityType.user, riskScore: 73.1829, individualRiskScore: null },
+        ],
       ]);
       const bucket = createMockBucket({ key: 'target-id', doc_count: 3 });
       const renderer = createGroupStatsRenderer(metadata);
@@ -248,7 +281,10 @@ describe('createGroupStatsRenderer', () => {
 
     it('risk score badge shows N/A when both metadata and bucket score are null', () => {
       const metadata: TargetMetadataMap = new Map([
-        ['target-id', { name: 'test', type: EntityType.user, riskScore: null }],
+        [
+          'target-id',
+          { name: 'test', type: EntityType.user, riskScore: null, individualRiskScore: null },
+        ],
       ]);
       const bucket = createMockBucket({ key: 'target-id', doc_count: 1 });
       const renderer = createGroupStatsRenderer(metadata);
@@ -282,12 +318,64 @@ describe('createGroupStatsRenderer', () => {
 
       // Phase 2: metadata arrived — shows actual risk score
       const metadata: TargetMetadataMap = new Map([
-        ['target-id', { name: 'test', type: EntityType.user, riskScore: 92.5 }],
+        [
+          'target-id',
+          { name: 'test', type: EntityType.user, riskScore: 92.5, individualRiskScore: null },
+        ],
       ]);
       const rendererAfter = createGroupStatsRenderer(metadata);
       const statsAfter = rendererAfter(ENTITY_GROUPING_OPTIONS.RESOLUTION, bucket);
       rerender(<TestProviders>{statsAfter[1].component}</TestProviders>);
       expect(screen.getByText('92.50')).toBeInTheDocument();
+    });
+
+    it('solo entity falls back to individual risk score when group score is null', () => {
+      const metadata: TargetMetadataMap = new Map([
+        [
+          'solo-id',
+          { name: 'solo', type: EntityType.user, riskScore: null, individualRiskScore: 42.5 },
+        ],
+      ]);
+      const bucket = createMockBucket({ key: 'solo-id', doc_count: 1 });
+      const renderer = createGroupStatsRenderer(metadata);
+      const stats = renderer(ENTITY_GROUPING_OPTIONS.RESOLUTION, bucket);
+
+      render(<TestProviders>{stats[1].component}</TestProviders>);
+
+      expect(screen.getByText('42.50')).toBeInTheDocument();
+    });
+
+    it('solo entity with no group or individual score shows N/A', () => {
+      const metadata: TargetMetadataMap = new Map([
+        [
+          'solo-id',
+          { name: 'solo', type: EntityType.user, riskScore: null, individualRiskScore: null },
+        ],
+      ]);
+      const bucket = createMockBucket({ key: 'solo-id', doc_count: 1 });
+      const renderer = createGroupStatsRenderer(metadata);
+      const stats = renderer(ENTITY_GROUPING_OPTIONS.RESOLUTION, bucket);
+
+      render(<TestProviders>{stats[1].component}</TestProviders>);
+
+      expect(screen.getByText('N/A')).toBeInTheDocument();
+    });
+
+    it('group score wins when both group and individual scores are present', () => {
+      const metadata: TargetMetadataMap = new Map([
+        [
+          'target-id',
+          { name: 'test', type: EntityType.user, riskScore: 90.0, individualRiskScore: 10.0 },
+        ],
+      ]);
+      const bucket = createMockBucket({ key: 'target-id', doc_count: 3 });
+      const renderer = createGroupStatsRenderer(metadata);
+      const stats = renderer(ENTITY_GROUPING_OPTIONS.RESOLUTION, bucket);
+
+      render(<TestProviders>{stats[1].component}</TestProviders>);
+
+      expect(screen.getByText('90.00')).toBeInTheDocument();
+      expect(screen.queryByText('10.00')).not.toBeInTheDocument();
     });
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/grouping/entity_group_renderer.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/grouping/entity_group_renderer.test.tsx
@@ -361,6 +361,23 @@ describe('createGroupStatsRenderer', () => {
       expect(screen.getByText('N/A')).toBeInTheDocument();
     });
 
+    it('multi-entity group with no group score does NOT fall back to individual score', () => {
+      const metadata: TargetMetadataMap = new Map([
+        [
+          'target-id',
+          { name: 'target', type: EntityType.user, riskScore: null, individualRiskScore: 42.5 },
+        ],
+      ]);
+      const bucket = createMockBucket({ key: 'target-id', doc_count: 3 });
+      const renderer = createGroupStatsRenderer(metadata);
+      const stats = renderer(ENTITY_GROUPING_OPTIONS.RESOLUTION, bucket);
+
+      render(<TestProviders>{stats[1].component}</TestProviders>);
+
+      expect(screen.getByText('N/A')).toBeInTheDocument();
+      expect(screen.queryByText('42.50')).not.toBeInTheDocument();
+    });
+
     it('group score wins when both group and individual scores are present', () => {
       const metadata: TargetMetadataMap = new Map([
         [

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/grouping/entity_group_renderer.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/grouping/entity_group_renderer.tsx
@@ -199,7 +199,9 @@ export const createGroupStatsRenderer = (targetMetadata: TargetMetadataMap) => {
     if (selectedGroup === ENTITY_GROUPING_OPTIONS.RESOLUTION) {
       const entityId = String(bucket.key_as_string ?? bucket.key);
       const metadata = targetMetadata.get(entityId);
-      const riskScore = metadata?.riskScore ?? bucket.resolutionRiskScore?.value ?? null;
+      const groupScore = metadata?.riskScore ?? bucket.resolutionRiskScore?.value;
+      const individualScore = metadata?.individualRiskScore;
+      const riskScore = groupScore ?? individualScore ?? null;
 
       stats.push({
         title: riskScoreLabel,

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/grouping/entity_group_renderer.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/grouping/entity_group_renderer.tsx
@@ -200,7 +200,8 @@ export const createGroupStatsRenderer = (targetMetadata: TargetMetadataMap) => {
       const entityId = String(bucket.key_as_string ?? bucket.key);
       const metadata = targetMetadata.get(entityId);
       const groupScore = metadata?.riskScore ?? bucket.resolutionRiskScore?.value;
-      const individualScore = metadata?.individualRiskScore;
+      const isSoloGroup = bucket.doc_count === 1;
+      const individualScore = isSoloGroup ? metadata?.individualRiskScore : undefined;
       const riskScore = groupScore ?? individualScore ?? null;
 
       stats.push({

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/grouping/use_fetch_grouped_data.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/grouping/use_fetch_grouped_data.test.ts
@@ -32,6 +32,31 @@ describe('parseTargetMetadataHits', () => {
       name: 'alice',
       type: EntityType.user,
       riskScore: 85.5,
+      individualRiskScore: null,
+    });
+  });
+
+  it('extracts individualRiskScore from entity.risk.calculated_score_norm', () => {
+    const hits = [
+      {
+        _source: {
+          entity: {
+            id: 'user:solo@okta',
+            name: 'solo',
+            EngineMetadata: { Type: EntityType.user },
+            risk: { calculated_score_norm: 67.25 },
+          },
+        },
+      },
+    ];
+
+    const result = parseTargetMetadataHits(hits);
+
+    expect(result.get('user:solo@okta')).toEqual({
+      name: 'solo',
+      type: EntityType.user,
+      riskScore: null,
+      individualRiskScore: 67.25,
     });
   });
 
@@ -67,11 +92,13 @@ describe('parseTargetMetadataHits', () => {
       name: 'alice',
       type: EntityType.user,
       riskScore: null,
+      individualRiskScore: null,
     });
     expect(result.get('host:srv-01')).toEqual({
       name: 'srv-01',
       type: EntityType.host,
       riskScore: 42.0,
+      individualRiskScore: null,
     });
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/grouping/use_fetch_grouped_data.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/entities_table/grouping/use_fetch_grouped_data.ts
@@ -32,6 +32,7 @@ export interface TargetEntityMetadata {
   name: string;
   type: EntityType;
   riskScore: number | null;
+  individualRiskScore: number | null;
 }
 
 export type TargetMetadataMap = Map<string, TargetEntityMetadata>;
@@ -43,6 +44,9 @@ interface TargetEntitySource {
     id?: string;
     name?: string;
     EngineMetadata?: { Type?: EntityType };
+    risk?: {
+      calculated_score_norm?: number;
+    };
     relationships?: {
       resolution?: {
         risk?: {
@@ -56,13 +60,14 @@ interface TargetEntitySource {
 export const parseTargetMetadataHits = (hits: Array<{ _source?: unknown }>): TargetMetadataMap => {
   const result: TargetMetadataMap = new Map();
   for (const hit of hits) {
-    const { id, name, EngineMetadata, relationships } =
+    const { id, name, EngineMetadata, risk, relationships } =
       (hit._source as TargetEntitySource)?.entity ?? {};
     const type = EngineMetadata?.Type;
     const riskScore = relationships?.resolution?.risk?.calculated_score_norm ?? null;
+    const individualRiskScore = risk?.calculated_score_norm ?? null;
 
     if (id && name && type) {
-      result.set(id, { name, type, riskScore });
+      result.set(id, { name, type, riskScore, individualRiskScore });
     }
   }
   return result;
@@ -148,6 +153,7 @@ export const useFetchTargetMetadata = (entityIds: string[]): TargetMetadataMap =
               ENTITY_FIELDS.ENTITY_ID,
               ENTITY_FIELDS.ENTITY_NAME,
               ENTITY_FIELDS.ENTITY_TYPE,
+              ENTITY_FIELDS.ENTITY_RISK,
               ENTITY_FIELDS.RESOLUTION_RISK_SCORE,
             ],
             query: {


### PR DESCRIPTION
## Summary

When the entities table is grouped by resolution, each group renders a "Risk score" badge sourced from `entity.relationships.resolution.risk.calculated_score_norm`. That field is only populated for entities with at least one resolution alias — solo entities (no aliases) end up with an empty badge.

This PR adds a UI-only fallback: when the resolution-group risk score is missing, the badge falls back to the entity's individual risk score (`entity.risk.calculated_score_norm`). Group score still wins when present.

The underlying data-model question (whether solo entities should be conceptually treated as groups-of-one) is tracked separately in #266057 and is intentionally out of scope here.

Related: #266057

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

- **Sorting**: solo entities will continue to sort by the (null) group score in the resolution grouping query. This is intentional — keeping the fix minimal. Severity: low.

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->