### PR TITLE
Fix: [Security Solution] [Bug] Wrong tool tip text for Generate Button on Attack Discovery when RBAC privilege for Connectors is set to NONE

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/header/actions/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/header/actions/index.tsx
@@ -17,11 +17,12 @@ import { Settings } from '../settings';
 interface Props {
   isDisabled?: boolean;
   isLoading: boolean;
+  hasConnectorsPrivilege?: boolean;
   onGenerate: (overrideOptions?: SettingsOverrideOptions) => Promise<void>;
   openFlyout: (tabId: string) => void;
 }
 
-const ActionsComponent: React.FC<Props> = ({ isLoading, onGenerate, openFlyout, isDisabled }) => {
+const ActionsComponent: React.FC<Props> = ({ isLoading, onGenerate, openFlyout, isDisabled, hasConnectorsPrivilege = true }) => {
   const { euiTheme } = useEuiTheme();
 
   const runSettingsGroup = css`
@@ -37,7 +38,7 @@ const ActionsComponent: React.FC<Props> = ({ isLoading, onGenerate, openFlyout, 
     <EuiFlexGroup alignItems="center" data-test-subj="actions" gutterSize="xs" responsive={false}>
       <EuiFlexItem grow={false}>
         <div css={runSettingsGroup}>
-          <Run isLoading={isLoading} isDisabled={isDisabled} onGenerate={onGenerate} />
+          <Run isLoading={isLoading} isDisabled={isDisabled} hasConnectorsPrivilege={hasConnectorsPrivilege} onGenerate={onGenerate} />
           <Settings isLoading={isLoading} openFlyout={openFlyout} />
         </div>
       </EuiFlexItem>

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/header/run/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/header/run/index.test.tsx
@@ -8,7 +8,7 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import React from 'react';
 
-import { RUN, RUN_TOOLTIP, DISABLED_TOOLTIP } from './translations';
+import { RUN, RUN_TOOLTIP, DISABLED_TOOLTIP, NO_CONNECTORS_PRIVILEGE } from './translations';
 import { Run } from '.';
 
 const defaultProps = {
@@ -37,13 +37,23 @@ describe('Run', () => {
     });
   });
 
-  it('renders the tooltip on hover with the disabled text when isDisabled is true', async () => {
-    render(<Run {...defaultProps} isDisabled={true} />);
+  it('renders the tooltip on hover with the disabled text when isDisabled is true and has privileges', async () => {
+    render(<Run {...defaultProps} isDisabled={true} hasConnectorsPrivilege={true} />);
 
     fireEvent.mouseOver(screen.getByTestId('run'));
 
     await waitFor(() => {
       expect(screen.getByTestId('runTooltip')).toHaveTextContent(DISABLED_TOOLTIP);
+    });
+  });
+
+  it('renders the tooltip on hover with the no privileges text when isDisabled is true and lacks privileges', async () => {
+    render(<Run {...defaultProps} isDisabled={true} hasConnectorsPrivilege={false} />);
+
+    fireEvent.mouseOver(screen.getByTestId('run'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('runTooltip')).toHaveTextContent(NO_CONNECTORS_PRIVILEGE);
     });
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/header/run/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/header/run/index.tsx
@@ -16,6 +16,7 @@ interface Props {
   isLoading: boolean;
   onGenerate: (overrideOptions?: SettingsOverrideOptions) => Promise<void>;
   isDisabled?: boolean;
+  hasConnectorsPrivilege?: boolean;
 }
 
 const runButtonStyles = css`
@@ -25,9 +26,9 @@ const runButtonStyles = css`
   width: 74px;
 `;
 
-const RunComponent: React.FC<Props> = ({ isLoading, onGenerate, isDisabled }) => (
+const RunComponent: React.FC<Props> = ({ isLoading, onGenerate, isDisabled, hasConnectorsPrivilege = true }) => (
   <EuiToolTip
-    content={isDisabled ? i18n.DISABLED_TOOLTIP : i18n.RUN_TOOLTIP}
+    content={isDisabled ? (hasConnectorsPrivilege ? i18n.DISABLED_TOOLTIP : i18n.NO_CONNECTORS_PRIVILEGE) : i18n.RUN_TOOLTIP}
     data-test-subj="runTooltip"
     position="bottom"
   >

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/header/run/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/header/run/translations.ts
@@ -27,3 +27,10 @@ export const DISABLED_TOOLTIP = i18n.translate(
     defaultMessage: 'To run ad-hoc Attack discoveries, select a connector in settings',
   }
 );
+
+export const NO_CONNECTORS_PRIVILEGE = i18n.translate(
+  'xpack.securitySolution.attackDiscovery.pages.header.run.noConnectorsPrivilege',
+  {
+    defaultMessage: 'You do not have permission to use connectors. Reach out to your admin to get access.',
+  }
+);

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/index.tsx
@@ -55,7 +55,7 @@ export const ID = 'attackDiscoveryQuery';
 
 const AttackDiscoveryPageComponent: React.FC = () => {
   const {
-    services: { uiSettings, settings },
+    services: { uiSettings, settings, application },
   } = useKibana();
 
   const { http } = useAssistantContext();
@@ -64,6 +64,8 @@ const AttackDiscoveryPageComponent: React.FC = () => {
     featureId: 'attack_discovery',
     settings,
   });
+
+  const hasConnectorsPrivilege = application.capabilities.actions?.show === true;
 
   // for showing / hiding anonymized data:
   const [showAnonymized, setShowAnonymized] = useState<boolean>(false);
@@ -250,12 +252,13 @@ const AttackDiscoveryPageComponent: React.FC = () => {
     >
       <div data-test-subj="attackDiscoveryPage">
         <HeaderPage border title={pageTitle}>
-          <Actions
-            isLoading={isLoading}
-            onGenerate={onGenerate}
-            openFlyout={openFlyout}
-            isDisabled={connectorId == null}
-          />
+        <Actions
+          isLoading={isLoading}
+          onGenerate={onGenerate}
+          openFlyout={openFlyout}
+          isDisabled={connectorId == null}
+          hasConnectorsPrivilege={hasConnectorsPrivilege}
+        />
           <EuiSpacer size={'s'} />
         </HeaderPage>
 
@@ -274,6 +277,7 @@ const AttackDiscoveryPageComponent: React.FC = () => {
           onGenerate={onGenerate}
           onToggleShowAnonymized={onToggleShowAnonymized}
           showAnonymized={showAnonymized}
+          hasConnectorsPrivilege={hasConnectorsPrivilege}
         />
 
         {showFlyout && (

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/empty_states/empty_prompt/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/empty_states/empty_prompt/index.tsx
@@ -25,6 +25,7 @@ interface Props {
   aiConnectorsCount: number | null; // null when connectors are not configured
   attackDiscoveriesCount: number;
   isDisabled?: boolean;
+  hasConnectorsPrivilege?: boolean;
   isLoading: boolean;
   onGenerate: (overrideOptions?: SettingsOverrideOptions) => Promise<void>;
 }
@@ -34,6 +35,7 @@ const EmptyPromptComponent: React.FC<Props> = ({
   attackDiscoveriesCount,
   isLoading,
   isDisabled = false,
+  hasConnectorsPrivilege = true,
   onGenerate,
 }) => {
   const historyTitle = useMemo(
@@ -96,8 +98,8 @@ const EmptyPromptComponent: React.FC<Props> = ({
   );
 
   const actions = useMemo(() => {
-    return <Generate isLoading={isLoading} isDisabled={isDisabled} onGenerate={onGenerate} />;
-  }, [isDisabled, isLoading, onGenerate]);
+    return <Generate isLoading={isLoading} isDisabled={isDisabled} hasConnectorsPrivilege={hasConnectorsPrivilege} onGenerate={onGenerate} />;
+  }, [isDisabled, isLoading, hasConnectorsPrivilege, onGenerate]);
 
   if (isLoading || aiConnectorsCount == null || attackDiscoveriesCount > 0) {
     return null;

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/empty_states/empty_prompt/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/empty_states/empty_prompt/translations.ts
@@ -55,3 +55,10 @@ export const SELECT_A_CONNECTOR = i18n.translate(
     defaultMessage: 'Select a connector',
   }
 );
+
+export const NO_CONNECTORS_PRIVILEGE = i18n.translate(
+  'xpack.securitySolution.attackDiscovery.pages.emptyPrompt.noConnectorsPrivilege',
+  {
+    defaultMessage: 'You do not have permission to use connectors. Reach out to your admin to get access.',
+  }
+);

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/empty_states/generate/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/empty_states/generate/index.test.tsx
@@ -34,13 +34,23 @@ describe('Generate Component', () => {
     expect(screen.getByTestId('generate')).toBeDisabled();
   });
 
-  it('shows tooltip content when the button is disabled', async () => {
-    render(<Generate isLoading={false} isDisabled={true} onGenerate={jest.fn()} />);
+  it('shows SELECT_A_CONNECTOR tooltip content when the button is disabled and has privileges', async () => {
+    render(<Generate isLoading={false} isDisabled={true} hasConnectorsPrivilege={true} onGenerate={jest.fn()} />);
 
     fireEvent.mouseOver(screen.getByTestId('generate'));
 
     await waitFor(() => {
       expect(screen.getByText(i18n.SELECT_A_CONNECTOR)).toBeInTheDocument();
+    });
+  });
+
+  it('shows NO_CONNECTORS_PRIVILEGE tooltip content when the button is disabled and lacks privileges', async () => {
+    render(<Generate isLoading={false} isDisabled={true} hasConnectorsPrivilege={false} onGenerate={jest.fn()} />);
+
+    fireEvent.mouseOver(screen.getByTestId('generate'));
+
+    await waitFor(() => {
+      expect(screen.getByText(i18n.NO_CONNECTORS_PRIVILEGE)).toBeInTheDocument();
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/empty_states/generate/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/empty_states/generate/index.tsx
@@ -13,16 +13,17 @@ import type { SettingsOverrideOptions } from '../../history/types';
 
 interface Props {
   isDisabled?: boolean;
+  hasConnectorsPrivilege?: boolean;
   isLoading: boolean;
   onGenerate: (overrideOptions?: SettingsOverrideOptions) => Promise<void>;
 }
 
-const GenerateComponent: React.FC<Props> = ({ isLoading, isDisabled = false, onGenerate }) => {
+const GenerateComponent: React.FC<Props> = ({ isLoading, isDisabled = false, hasConnectorsPrivilege = true, onGenerate }) => {
   const disabled = isLoading || isDisabled;
 
   return (
     <EuiToolTip
-      content={disabled ? i18n.SELECT_A_CONNECTOR : null}
+      content={disabled ? (hasConnectorsPrivilege ? i18n.SELECT_A_CONNECTOR : i18n.NO_CONNECTORS_PRIVILEGE) : null}
       data-test-subj="generateTooltip"
     >
       <EuiButton

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/empty_states/no_alerts/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/empty_states/no_alerts/index.tsx
@@ -22,11 +22,12 @@ import * as i18n from './translations';
 
 interface Props {
   isDisabled: boolean;
+  hasConnectorsPrivilege?: boolean;
   isLoading: boolean;
   onGenerate: (overrideOptions?: SettingsOverrideOptions) => Promise<void>;
 }
 
-const NoAlertsComponent: React.FC<Props> = ({ isDisabled, isLoading, onGenerate }) => {
+const NoAlertsComponent: React.FC<Props> = ({ isDisabled, isLoading, hasConnectorsPrivilege = true, onGenerate }) => {
   const title = useMemo(
     () => (
       <EuiFlexGroup
@@ -97,7 +98,7 @@ const NoAlertsComponent: React.FC<Props> = ({ isDisabled, isLoading, onGenerate 
       </EuiFlexItem>
 
       <EuiFlexItem grow={false}>
-        <Generate isDisabled={isDisabled} isLoading={isLoading} onGenerate={onGenerate} />
+        <Generate isDisabled={isDisabled} isLoading={isLoading} hasConnectorsPrivilege={hasConnectorsPrivilege} onGenerate={onGenerate} />
       </EuiFlexItem>
     </EuiFlexGroup>
   );

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/history/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/history/index.tsx
@@ -51,6 +51,7 @@ interface Props {
   onGenerate: (overrideOptions?: SettingsOverrideOptions) => Promise<void>;
   onToggleShowAnonymized: () => void;
   showAnonymized: boolean;
+  hasConnectorsPrivilege?: boolean;
 }
 
 const HistoryComponent: React.FC<Props> = ({
@@ -59,6 +60,7 @@ const HistoryComponent: React.FC<Props> = ({
   onGenerate,
   onToggleShowAnonymized,
   showAnonymized,
+  hasConnectorsPrivilege = true,
 }) => {
   const { assistantAvailability, http } = useAssistantContext();
 
@@ -243,6 +245,7 @@ const HistoryComponent: React.FC<Props> = ({
           aiConnectorsCount={aiConnectors?.length ?? null}
           attackDiscoveriesCount={data?.total ?? 0}
           isDisabled={!aiConnectors?.length}
+          hasConnectorsPrivilege={hasConnectorsPrivilege}
           isLoading={isLoading}
           onGenerate={onGenerate}
         />


### PR DESCRIPTION
## Summary

Addresses https://github.com/elastic/kibana/issues/183117

## Fix Summary
Fixed the tooltip text for the 'Generate' and 'Run' buttons on the Attack Discovery page when the user lacks the 'Connectors' RBAC privilege. 

Previously, the tooltip always suggested to "Select a connector" when the buttons were disabled. Now, it checks whether the user has the required Connectors permissions (`capabilities.actions.show`). If the user does not have this privilege, the tooltip correctly informs them: "You do not have permission to use connectors. Reach out to your admin to get access."

### Verification Steps
1. Create a custom role in Kibana with `Security` > `Attack Discovery` privilege set to `All`, but `Connectors` set to `None`.
2. Create a test user and assign them this custom role.
3. Log in as the test user.
4. Navigate to **Security -> Attack Discovery**.
5. Hover over the disabled **Generate** button in the empty state (if no alerts are found) or the **Run** button at the top right.
6. Verify the tooltip text reads: "You do not have permission to use connectors. Reach out to your admin to get access." instead of "Select a connector".

---

_PR developed with Cursor_