### PR TITLE
[One Workflow] Fix editor selection highlight

### DIFF
--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/styles/use_workflows_monaco_theme.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/styles/use_workflows_monaco_theme.ts
@@ -47,6 +47,7 @@ export function useWorkflowsMonacoTheme() {
         'editorIndentGuide.activeBackground1': euiTheme.colors.borderBaseDisabled,
         // Transparent backgrounds, they are set by the styles of the editor container behind.
         'editor.background': '#00000000',
+        'editor.selectionBackground': chroma(transparentize(euiTheme.colors.primary, 0.1)).hex(),
         'editorGutter.background': '#00000000',
         'minimap.background': '#00000000',
         'diffEditor.unchangedRegionBackground': '#00000000',

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/workflow_yaml_editor.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/workflow_yaml_editor.tsx
@@ -127,6 +127,7 @@ const editorOptions: monaco.editor.IStandaloneEditorConstructionOptions = {
   fontSize: 14,
   lineHeight: 23, // default ~21px + 2px
   renderWhitespace: 'none',
+  roundedSelection: false,
   wordWrap: 'on',
   wordWrapColumn: 80,
   wrappingIndent: 'indent',


### PR DESCRIPTION
## Summary

Fixes two things:

- The selection highlighting colour was not visible enough. Overridden the EUI selection colour for the Workflows theme.

- Multi-line selections in the workflow YAML editor visually extended one character before and after the actual selection. The selected text was correct (copy/paste worked as expected), but the painted background was misleading.

## Root cause
- Monaco's default `roundedSelection: true` renders multi-line selections as a single connected rounded shape, insetting/outsetting the corners by ~1 character to make the shape look continuous across line boundaries.
- The problem was not identified before because `editor.selectionBackground` was too faint to notice.

## Changes
- `use_workflows_monaco_theme.ts`: use `chroma(...).hex('rgba')` so the intended 10% alpha on `editor.selectionBackground` is preserved.
- `workflow_yaml_editor.tsx`: set `roundedSelection: false` so multi-line selections are drawn as straight per-line rectangles aligned to the actually-selected text.

## Screenshots:

Before:

<img width="195" height="101" alt="Captura de pantalla 2026-04-28 a les 16 44 11" src="https://github.com/user-attachments/assets/209d2889-7eb7-4a1b-b7c0-f41caba965d9" />

---

After adding `editor.selectionBackground` colour (notice an extra character is highlighted before and after selection):

<img width="195" height="101" alt="Captura de pantalla 2026-04-28 a les 16 48 20" src="https://github.com/user-attachments/assets/102b8c96-0ff1-4976-bd72-57bf7cf4225c" />

---

After adding `roundedSelection: false`:

<img width="195" height="101" alt="Captura de pantalla 2026-04-28 a les 16 49 07" src="https://github.com/user-attachments/assets/f7b425fa-a9d7-4a89-8740-a012e121a4b2" />


<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->