### PR TITLE
[Agent Builder] Fix issue correctly propagating inference error status codes through the converse API

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/server/routes/wrap_handler.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/routes/wrap_handler.test.ts
@@ -1,0 +1,101 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { kibanaResponseFactory } from '@kbn/core/server';
+import { httpServerMock, loggingSystemMock } from '@kbn/core/server/mocks';
+import { createInternalError } from '@kbn/agent-builder-common';
+import { createInferenceRequestError, createInferenceProviderError } from '@kbn/inference-common';
+import { getHandlerWrapper } from './wrap_handler';
+
+describe('getHandlerWrapper', () => {
+  const logger = loggingSystemMock.createLogger();
+  const wrapHandler = getHandlerWrapper({ logger });
+
+  const createCtx = () =>
+    ({
+      core: Promise.resolve({}),
+      licensing: Promise.resolve({
+        license: { status: 'active', hasAtLeast: jest.fn().mockReturnValue(true) },
+      }),
+    } as any);
+
+  const req = httpServerMock.createKibanaRequest();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('uses the AgentBuilderError statusCode when available', async () => {
+    const handler = wrapHandler(async () => {
+      throw createInternalError('boom', { statusCode: 418, traceId: 'trace-1' });
+    });
+
+    const result: any = await handler(createCtx(), req, kibanaResponseFactory);
+
+    expect(result.status).toBe(418);
+    expect(result.payload).toMatchObject({
+      message: 'boom',
+      attributes: { trace_id: 'trace-1' },
+    });
+  });
+
+  it('propagates the status of an InferenceTaskRequestError (e.g. 404 from connector lookup)', async () => {
+    const message =
+      "No connector or inference endpoint found for ID '.anthropic-claude-3.7-sonnet-chat_completion'";
+    const handler = wrapHandler(async () => {
+      throw createInferenceRequestError(message, 404);
+    });
+
+    const result: any = await handler(createCtx(), req, kibanaResponseFactory);
+
+    expect(result.status).toBe(404);
+    expect(result.payload).toEqual({ message });
+  });
+
+  it('propagates the status of an InferenceTaskProviderError (e.g. 410 from upstream)', async () => {
+    const handler = wrapHandler(async () => {
+      throw createInferenceProviderError('Model is no longer supported', { status: 410 });
+    });
+
+    const result: any = await handler(createCtx(), req, kibanaResponseFactory);
+
+    expect(result.status).toBe(410);
+    expect(result.payload).toEqual({ message: 'Model is no longer supported' });
+  });
+
+  it('falls back to 500 for an inference error with no usable status', async () => {
+    const handler = wrapHandler(async () => {
+      throw createInferenceProviderError('something went wrong');
+    });
+
+    const result: any = await handler(createCtx(), req, kibanaResponseFactory);
+
+    expect(result.status).toBe(500);
+    expect(result.payload).toMatchObject({ message: 'something went wrong' });
+  });
+
+  it('falls back to 500 for an inference error with status outside 4xx/5xx', async () => {
+    const handler = wrapHandler(async () => {
+      throw createInferenceProviderError('not really an error', { status: 200 });
+    });
+
+    const result: any = await handler(createCtx(), req, kibanaResponseFactory);
+
+    expect(result.status).toBe(500);
+  });
+
+  it('falls back to 500 for unknown errors', async () => {
+    const handler = wrapHandler(async () => {
+      throw new Error('mystery');
+    });
+
+    const result: any = await handler(createCtx(), req, kibanaResponseFactory);
+
+    expect(result.status).toBe(500);
+    expect(result.payload).toMatchObject({ message: 'mystery' });
+  });
+});

--- a/x-pack/platform/plugins/shared/agent_builder/server/routes/wrap_handler.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/routes/wrap_handler.ts
@@ -7,6 +7,7 @@
 
 import type { Logger, RequestHandler } from '@kbn/core/server';
 import { isAgentBuilderError } from '@kbn/agent-builder-common';
+import { isInferenceError } from '@kbn/inference-common';
 import { isValidLicense } from '../../common/license';
 import type { AgentBuilderHandlerContext } from '../request_handler_context';
 
@@ -52,6 +53,20 @@ export const getHandlerWrapper =
       try {
         return await handler(ctx, req, res);
       } catch (e) {
+        // Inference errors must be checked before agent builder errors:
+        // both share the same `ServerSentEventError` base class, so `isAgentBuilderError`
+        // also matches inference errors. Inference errors carry `meta.status` (not
+        // `meta.statusCode`), so we propagate that status when present.
+        if (isInferenceError(e)) {
+          const status = e.meta?.status;
+          if (typeof status === 'number' && status >= 400 && status < 600) {
+            logger.error(e);
+            return res.customError({
+              body: { message: e.message },
+              statusCode: status,
+            });
+          }
+        }
         if (isAgentBuilderError(e)) {
           logger.error(e);
           return res.customError({
@@ -63,15 +78,14 @@ export const getHandlerWrapper =
             },
             statusCode: e.meta?.statusCode ?? 500,
           });
-        } else {
-          logger.error(`Unexpected error in handler: ${e.stack ?? e.message}`);
-          return res.customError({
-            body: {
-              message: e.message ?? 'An unexpected error occurred',
-            },
-            statusCode: 500,
-          });
         }
+        logger.error(`Unexpected error in handler: ${e.stack ?? e.message}`);
+        return res.customError({
+          body: {
+            message: e.message ?? 'An unexpected error occurred',
+          },
+          statusCode: 500,
+        });
       }
     };
   };

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/utils/errors.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/utils/errors.test.ts
@@ -7,7 +7,7 @@
 
 import { AgentExecutionErrorCode } from '@kbn/agent-builder-common/agents';
 import { isAgentExecutionError } from '@kbn/agent-builder-common/base/errors';
-import { createInferenceProviderError } from '@kbn/inference-common';
+import { createInferenceProviderError, createInferenceRequestError } from '@kbn/inference-common';
 import { convertError, isRecoverableError } from './errors';
 
 describe('errors', () => {
@@ -42,6 +42,20 @@ describe('errors', () => {
         expect(
           'statusCode' in converted.meta ? converted.meta.statusCode : undefined
         ).toBeUndefined();
+      });
+    });
+
+    describe('InferenceTaskRequestError', () => {
+      it('propagates 404 when the inference endpoint cannot be resolved', () => {
+        const message =
+          "No connector or inference endpoint found for ID '.anthropic-claude-3.7-sonnet-chat_completion'";
+        const err = createInferenceRequestError(message, 404);
+        const converted = convertError(err);
+
+        expect(isAgentExecutionError(converted)).toBe(true);
+        expect(converted.meta.errCode).toBe(AgentExecutionErrorCode.connectorError);
+        expect('statusCode' in converted.meta ? converted.meta.statusCode : undefined).toBe(404);
+        expect(converted.message).toBe(message);
       });
     });
 

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/utils/errors.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/utils/errors.test.ts
@@ -12,99 +12,19 @@ import { convertError, isRecoverableError } from './errors';
 
 describe('errors', () => {
   describe('convertError', () => {
-    describe('connector errors with "Status code: XXX. Message:" format', () => {
-      it('propagates 401 as connectorError with statusCode 401', () => {
-        const message =
-          'Error calling connector: Status code: 401. Message: Unauthorized API Error - No cookie auth credentials found';
-        const err = new Error(message);
+    describe('InferenceTaskProviderError', () => {
+      it.each([401, 403, 404, 410, 502])('propagates status %i as connectorError', (status) => {
+        const message = `Received an unsuccessful status code for request from inference entity id [some-id] status [${status}]. Error message: [...]`;
+        const err = createInferenceProviderError(message, { status });
         const converted = convertError(err);
 
         expect(isAgentExecutionError(converted)).toBe(true);
         expect(converted.meta.errCode).toBe(AgentExecutionErrorCode.connectorError);
-        expect('statusCode' in converted.meta ? converted.meta.statusCode : undefined).toBe(401);
+        expect('statusCode' in converted.meta ? converted.meta.statusCode : undefined).toBe(status);
         expect(converted.message).toBe(message);
       });
 
-      it('propagates 403 as connectorError with statusCode 403', () => {
-        const message =
-          'Error calling connector: Status code: 403. Message: Organization is not authorized to access any resource';
-        const err = new Error(message);
-        const converted = convertError(err);
-
-        expect(converted.meta.errCode).toBe(AgentExecutionErrorCode.connectorError);
-        expect('statusCode' in converted.meta ? converted.meta.statusCode : undefined).toBe(403);
-        expect(converted.message).toBe(message);
-      });
-
-      it('propagates 404 as connectorError with statusCode 404', () => {
-        const message = 'Error calling connector: Status code: 404. Message: Not found';
-        const err = new Error(message);
-        const converted = convertError(err);
-
-        expect(converted.meta.errCode).toBe(AgentExecutionErrorCode.connectorError);
-        expect('statusCode' in converted.meta ? converted.meta.statusCode : undefined).toBe(404);
-      });
-
-      it('propagates 502 as connectorError with statusCode 502', () => {
-        const message =
-          'Error calling connector: Status code: 502. Message: Bad Gateway - upstream unavailable';
-        const err = new Error(message);
-        const converted = convertError(err);
-
-        expect(converted.meta.errCode).toBe(AgentExecutionErrorCode.connectorError);
-        expect('statusCode' in converted.meta ? converted.meta.statusCode : undefined).toBe(502);
-      });
-    });
-
-    describe('ES inference API errors with "status [XXX]" format', () => {
-      it('propagates 403 from an inference entity error', () => {
-        const message =
-          'Error calling connector: event: error\ndata: {"error":{"code":"forbidden","message":"Received an unsuccessful status code for request from inference entity id [.gp-llm-v2-chat_completion] status [403]. Error message: [Organization is not authorized to access any resource]","type":"error"}}';
-        const err = new Error(message);
-        const converted = convertError(err);
-
-        expect(isAgentExecutionError(converted)).toBe(true);
-        expect(converted.meta.errCode).toBe(AgentExecutionErrorCode.connectorError);
-        expect('statusCode' in converted.meta ? converted.meta.statusCode : undefined).toBe(403);
-        expect(converted.message).toBe(message);
-      });
-
-      it('propagates 401 from an inference authentication error', () => {
-        const message =
-          'Error calling connector: Received an authentication error status code for request from inference entity id [openai-chat_completion-uuid] status [401]. Error message: [Incorrect API key provided]';
-        const err = new Error(message);
-        const converted = convertError(err);
-
-        expect(converted.meta.errCode).toBe(AgentExecutionErrorCode.connectorError);
-        expect('statusCode' in converted.meta ? converted.meta.statusCode : undefined).toBe(401);
-      });
-
-      it('returns unknownError when inference status code is outside 4xx/5xx range', () => {
-        const message = 'Error calling connector: status [200] for inference entity id [some-id]';
-        const err = new Error(message);
-        const converted = convertError(err);
-
-        expect(converted.meta.errCode).toBe(AgentExecutionErrorCode.unknownError);
-        expect(
-          'statusCode' in converted.meta ? converted.meta.statusCode : undefined
-        ).toBeUndefined();
-      });
-    });
-
-    describe('InferenceTaskProviderError (structured) errors', () => {
-      it('propagates 410 from a structured inference provider error without a connector prefix', () => {
-        const message =
-          'Received an unsuccessful status code for request from inference entity id [.anthropic-claude-3.7-sonnet-chat_completion] status [410]. Error message: [Model is no longer supported, please use a different model.]';
-        const err = createInferenceProviderError(message, { status: 410 });
-        const converted = convertError(err);
-
-        expect(isAgentExecutionError(converted)).toBe(true);
-        expect(converted.meta.errCode).toBe(AgentExecutionErrorCode.connectorError);
-        expect('statusCode' in converted.meta ? converted.meta.statusCode : undefined).toBe(410);
-        expect(converted.message).toBe(message);
-      });
-
-      it('falls back to unknownError when structured provider error has no usable status', () => {
+      it('returns unknownError when status is missing', () => {
         const err = createInferenceProviderError('something went wrong');
         const converted = convertError(err);
 
@@ -113,10 +33,20 @@ describe('errors', () => {
           'statusCode' in converted.meta ? converted.meta.statusCode : undefined
         ).toBeUndefined();
       });
+
+      it('returns unknownError when status is outside 4xx/5xx range', () => {
+        const err = createInferenceProviderError('unexpected status', { status: 200 });
+        const converted = convertError(err);
+
+        expect(converted.meta.errCode).toBe(AgentExecutionErrorCode.unknownError);
+        expect(
+          'statusCode' in converted.meta ? converted.meta.statusCode : undefined
+        ).toBeUndefined();
+      });
     });
 
-    describe('non-connector and unparseable errors', () => {
-      it('returns unknownError for generic errors without connector prefix', () => {
+    describe('non-inference errors', () => {
+      it('returns unknownError for generic errors', () => {
         const err = new Error('Something went wrong');
         const converted = convertError(err);
 
@@ -126,35 +56,12 @@ describe('errors', () => {
         ).toBeUndefined();
         expect(converted.message).toBe('Something went wrong');
       });
-
-      it('returns unknownError when message has "Error calling connector:" but no parseable status', () => {
-        const message = 'Error calling connector: something went wrong';
-        const err = new Error(message);
-        const converted = convertError(err);
-
-        expect(converted.meta.errCode).toBe(AgentExecutionErrorCode.unknownError);
-        expect(
-          'statusCode' in converted.meta ? converted.meta.statusCode : undefined
-        ).toBeUndefined();
-      });
-
-      it('returns unknownError when status code is outside 4xx/5xx range', () => {
-        const message = 'Error calling connector: Status code: 200. Message: OK';
-        const err = new Error(message);
-        const converted = convertError(err);
-
-        expect(converted.meta.errCode).toBe(AgentExecutionErrorCode.unknownError);
-        expect(
-          'statusCode' in converted.meta ? converted.meta.statusCode : undefined
-        ).toBeUndefined();
-      });
     });
   });
 
   describe('isRecoverableError', () => {
     it('returns false for connectorError so it is not retried as recoverable', () => {
-      const message = 'Error calling connector: Status code: 401. Message: Unauthorized API Error';
-      const err = new Error(message);
+      const err = createInferenceProviderError('upstream failure', { status: 401 });
       const converted = convertError(err);
 
       expect(isRecoverableError(converted)).toBe(false);

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/utils/errors.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/utils/errors.test.ts
@@ -7,6 +7,7 @@
 
 import { AgentExecutionErrorCode } from '@kbn/agent-builder-common/agents';
 import { isAgentExecutionError } from '@kbn/agent-builder-common/base/errors';
+import { createInferenceProviderError } from '@kbn/inference-common';
 import { convertError, isRecoverableError } from './errors';
 
 describe('errors', () => {
@@ -81,6 +82,30 @@ describe('errors', () => {
       it('returns unknownError when inference status code is outside 4xx/5xx range', () => {
         const message = 'Error calling connector: status [200] for inference entity id [some-id]';
         const err = new Error(message);
+        const converted = convertError(err);
+
+        expect(converted.meta.errCode).toBe(AgentExecutionErrorCode.unknownError);
+        expect(
+          'statusCode' in converted.meta ? converted.meta.statusCode : undefined
+        ).toBeUndefined();
+      });
+    });
+
+    describe('InferenceTaskProviderError (structured) errors', () => {
+      it('propagates 410 from a structured inference provider error without a connector prefix', () => {
+        const message =
+          'Received an unsuccessful status code for request from inference entity id [.anthropic-claude-3.7-sonnet-chat_completion] status [410]. Error message: [Model is no longer supported, please use a different model.]';
+        const err = createInferenceProviderError(message, { status: 410 });
+        const converted = convertError(err);
+
+        expect(isAgentExecutionError(converted)).toBe(true);
+        expect(converted.meta.errCode).toBe(AgentExecutionErrorCode.connectorError);
+        expect('statusCode' in converted.meta ? converted.meta.statusCode : undefined).toBe(410);
+        expect(converted.message).toBe(message);
+      });
+
+      it('falls back to unknownError when structured provider error has no usable status', () => {
+        const err = createInferenceProviderError('something went wrong');
         const converted = convertError(err);
 
         expect(converted.meta.errCode).toBe(AgentExecutionErrorCode.unknownError);

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/utils/errors.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/utils/errors.test.ts
@@ -24,7 +24,7 @@ describe('errors', () => {
         expect(converted.message).toBe(message);
       });
 
-      it('returns unknownError when status is missing', () => {
+      it('returns unknownError when status is missing, preserving the message', () => {
         const err = createInferenceProviderError('something went wrong');
         const converted = convertError(err);
 
@@ -32,9 +32,10 @@ describe('errors', () => {
         expect(
           'statusCode' in converted.meta ? converted.meta.statusCode : undefined
         ).toBeUndefined();
+        expect(converted.message).toBe('something went wrong');
       });
 
-      it('returns unknownError when status is outside 4xx/5xx range', () => {
+      it('returns unknownError when status is outside 4xx/5xx range, preserving the message', () => {
         const err = createInferenceProviderError('unexpected status', { status: 200 });
         const converted = convertError(err);
 
@@ -42,6 +43,7 @@ describe('errors', () => {
         expect(
           'statusCode' in converted.meta ? converted.meta.statusCode : undefined
         ).toBeUndefined();
+        expect(converted.message).toBe('unexpected status');
       });
     });
 

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/utils/errors.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/utils/errors.ts
@@ -24,28 +24,6 @@ const recoverableErrorCodes = [
   ErrCodes.emptyResponse,
 ];
 
-/** Matches "Status code: xxx" in connector error messages */
-const CONNECTOR_STATUS_CODE_REGEXP = /Status code: ([0-9]{3})/i;
-/** Matches "status [xxx]" in ES inference API error messages */
-const INFERENCE_STATUS_CODE_REGEXP = /status \[([0-9]{3})\]/i;
-
-/**
- * Parses connector error messages and returns the HTTP status code when present
- * (4xx, 5xx) so it can be propagated to the client.
- */
-const parseConnectorStatusCode = (message: string): number | null => {
-  if (!message.includes('Error calling connector:')) {
-    return null;
-  }
-  const match =
-    CONNECTOR_STATUS_CODE_REGEXP.exec(message) ?? INFERENCE_STATUS_CODE_REGEXP.exec(message);
-  if (!match) {
-    return null;
-  }
-  const statusCode = parseInt(match[1], 10);
-  return statusCode >= 400 && statusCode < 600 ? statusCode : null;
-};
-
 /**
  * Converts an error which occurred during the execution of the agent to our error format,
  * leveraging the errors which are already processed by the inference plugin for some of them.
@@ -73,12 +51,6 @@ export const convertError = (error: Error): AgentBuilderAgentExecutionError => {
         statusCode: status,
       });
     }
-  }
-  const connectorStatusCode = parseConnectorStatusCode(error.message);
-  if (connectorStatusCode !== null) {
-    return createAgentExecutionError(error.message, ErrCodes.connectorError, {
-      statusCode: connectorStatusCode,
-    });
   }
   return createAgentExecutionError(error.message, ErrCodes.unknownError, {});
 };

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/utils/errors.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/utils/errors.ts
@@ -10,7 +10,7 @@ import {
   isToolValidationError,
   isContextLengthExceededError,
 } from '@kbn/inference-common/src/chat_complete/errors';
-import { isInferenceProviderError } from '@kbn/inference-common';
+import { isInferenceProviderError, isInferenceRequestError } from '@kbn/inference-common';
 import type { AgentBuilderAgentExecutionError } from '@kbn/agent-builder-common/base/errors';
 import { AgentExecutionErrorCode as ErrCodes } from '@kbn/agent-builder-common/agents';
 import {
@@ -44,7 +44,7 @@ export const convertError = (error: Error): AgentBuilderAgentExecutionError => {
   } else if (isContextLengthExceededError(error)) {
     return createAgentExecutionError(error.message, ErrCodes.contextLengthExceeded, {});
   }
-  if (isInferenceProviderError(error)) {
+  if (isInferenceProviderError(error) || isInferenceRequestError(error)) {
     const status = error.meta?.status;
     if (typeof status === 'number' && status >= 400 && status < 600) {
       return createAgentExecutionError(error.message, ErrCodes.connectorError, {

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/utils/errors.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/utils/errors.ts
@@ -10,6 +10,7 @@ import {
   isToolValidationError,
   isContextLengthExceededError,
 } from '@kbn/inference-common/src/chat_complete/errors';
+import { isInferenceProviderError } from '@kbn/inference-common';
 import type { AgentBuilderAgentExecutionError } from '@kbn/agent-builder-common/base/errors';
 import { AgentExecutionErrorCode as ErrCodes } from '@kbn/agent-builder-common/agents';
 import {
@@ -64,6 +65,14 @@ export const convertError = (error: Error): AgentBuilderAgentExecutionError => {
     });
   } else if (isContextLengthExceededError(error)) {
     return createAgentExecutionError(error.message, ErrCodes.contextLengthExceeded, {});
+  }
+  if (isInferenceProviderError(error)) {
+    const status = error.meta?.status;
+    if (typeof status === 'number' && status >= 400 && status < 600) {
+      return createAgentExecutionError(error.message, ErrCodes.connectorError, {
+        statusCode: status,
+      });
+    }
   }
   const connectorStatusCode = parseConnectorStatusCode(error.message);
   if (connectorStatusCode !== null) {


### PR DESCRIPTION
## Summary

Fixes two cases where the /api/agent_builder/converse API returned a 500 Internal Server Error when the underlying inference service surfaced a structured error with a usable HTTP status. Both issues stemmed from the wrap handler boundary not knowing how to translate InferenceTaskErrors into HTTP responses.

### What changed

  - `server/routes/wrap_handler.ts` — added a branch that recognizes any InferenceTaskError with a 4xx/5xx meta.status and
  propagates it as the route's status code. The branch runs before the existing isAgentBuilderError check because both errors share the same ServerSentEventError base class — without the explicit ordering, isAgentBuilderError would match inference errors first and try to read meta.statusCode (which inference errors don't have) and fall back to 500.
  - `server/services/execution/run_agent/utils/errors.ts` — replaced fragile error-message regex parsing in convertError with
  structured isInferenceProviderError / isInferenceRequestError checks that read meta.status directly. The previous regex-based approach silently dropped inference errors that arrived without an "Error calling connector:" prefix (e.g., SSE in-stream error events).
  - Tests — added `wrap_handler.test.ts` and rewrote `errors.test.ts` to use real structured error constructors
  (`createInferenceProviderError`, `createInferenceRequestError`) instead of synthetic plain Error instances.

### Issues fixed

  - 404 — connector/inference endpoint not found. When a request supplied an inference_id that didn't resolve to a known
  connector, get_connector_by_id.ts throws an InferenceTaskRequestError(message, 404) from inside resolveServices. This happens before the langgraph runs, so the in-graph convertError never saw it; the error escaped synchronously to wrap_handler, where it was treated as a generic error and turned into a 500.
  - 410 — model no longer supported. When the upstream inference service rejected a request mid-stream (e.g., a deprecated model returning 410 from EIS), the SSE error event flowed through process_openai_stream.ts → stream_errors.ts → convertUpstreamError without the "Error calling connector:" prefix. The agent_builder's parseConnectorStatusCode required that prefix as a gate, so it returned null and the error became unknownError with no statusCode, which the wrap handler defaulted to 500. The structured InferenceTaskProviderError already carried meta.status = 410, but no one was reading it.

 ### Test plan

  - `node scripts/jest x-pack/platform/plugins/shared/agent_builder/server/routes/wrap_handler.test.ts`
  - `node scripts/jest x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/utils/errors.test.ts`
  - Manually verify with a deprecated inference ID:
  
```
  POST kbn://api/agent_builder/converse
  { "input": "...", "agent_id": "elastic-ai-agent", "inference_id": ".anthropic-claude-3.7-sonnet-chat_completion" }
```

  - Confirm the response is now a 410 (model deprecated) or 404 (endpoint not found) instead of 500, with the original upstream error message preserved.

Created with the assistance of Claude Code / Opus 4.7. 

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->