### PR TITLE
Add inspect button to risk chart and anomaly explorer

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/anomalies_panel.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/anomalies_panel.test.tsx
@@ -40,4 +40,14 @@ describe('AnomaliesPanel', () => {
     expect(link).toBeInTheDocument();
     expect(link).toHaveAttribute('href', MOCK_ML_HREF);
   });
+
+  it('should render the inspect button', () => {
+    render(
+      <TestProviders>
+        <EntityAnalyticsRecentAnomalies />
+      </TestProviders>
+    );
+
+    expect(screen.getByTestId('inspect-icon-button')).toBeInTheDocument();
+  });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/anomalies_panel.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/anomalies_panel.tsx
@@ -11,10 +11,12 @@ import { FormattedMessage } from '@kbn/i18n-react';
 import { ML_PAGES, useMlHref } from '@kbn/ml-plugin/public';
 import {
   RecentAnomaliesChart,
+  RECENT_ANOMALIES_QUERY_ID,
   RECENT_ANOMALIES_TIME_RANGE,
 } from '../recent_anomalies/recent_anomalies_chart';
 import { useKibana } from '../../../common/lib/kibana';
 import { useSpaceId } from '../../../common/hooks/use_space_id';
+import { InspectButton, InspectButtonContainer } from '../../../common/components/inspect';
 
 const useRecentAnomaliesMlExplorerUrl = () => {
   // The Entity Analytics home page hides the global date picker; keep the
@@ -42,34 +44,51 @@ export const EntityAnalyticsRecentAnomalies: React.FC<{ watchlistId?: string }> 
   const anomalyExplorerUrl = useRecentAnomaliesMlExplorerUrl();
   const spaceId = useSpaceId();
   return (
-    <EuiFlexItem data-test-subj="recent-anomalies-panel">
-      <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
-        <EuiFlexItem grow={false}>
-          <EuiTitle size="s">
-            <h3>
-              <FormattedMessage
-                id="xpack.securitySolution.entityAnalytics.homePage.recentAnomalies"
-                defaultMessage="Recent anomalies"
-              />
-            </h3>
-          </EuiTitle>
-        </EuiFlexItem>
-        <EuiFlexItem grow={false}>
-          <EuiButtonEmpty
-            color={'primary'}
-            iconType={'popout'}
-            href={anomalyExplorerUrl}
-            target="_blank"
-          >
-            <FormattedMessage
-              id="xpack.securitySolution.entityAnalytics.homePage.recentAnomalies.viewAllInAnomalyExplorer"
-              defaultMessage="Open in Anomaly Explorer"
-            />
-          </EuiButtonEmpty>
-        </EuiFlexItem>
-      </EuiFlexGroup>
-      <EuiSpacer size={'m'} />
-      <RecentAnomaliesChart watchlistId={watchlistId} spaceId={spaceId} />
-    </EuiFlexItem>
+    <InspectButtonContainer>
+      <EuiFlexItem data-test-subj="recent-anomalies-panel">
+        <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
+          <EuiFlexItem grow={false}>
+            <EuiTitle size="s">
+              <h3>
+                <FormattedMessage
+                  id="xpack.securitySolution.entityAnalytics.homePage.recentAnomalies"
+                  defaultMessage="Recent anomalies"
+                />
+              </h3>
+            </EuiTitle>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiFlexGroup gutterSize="none" alignItems="center">
+              <EuiFlexItem grow={false}>
+                <InspectButton
+                  queryId={RECENT_ANOMALIES_QUERY_ID}
+                  title={
+                    <FormattedMessage
+                      id="xpack.securitySolution.entityAnalytics.homePage.recentAnomalies"
+                      defaultMessage="Recent anomalies"
+                    />
+                  }
+                />
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiButtonEmpty
+                  color={'primary'}
+                  iconType={'popout'}
+                  href={anomalyExplorerUrl}
+                  target="_blank"
+                >
+                  <FormattedMessage
+                    id="xpack.securitySolution.entityAnalytics.homePage.recentAnomalies.viewAllInAnomalyExplorer"
+                    defaultMessage="Open in Anomaly Explorer"
+                  />
+                </EuiButtonEmpty>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+        <EuiSpacer size={'m'} />
+        <RecentAnomaliesChart watchlistId={watchlistId} spaceId={spaceId} />
+      </EuiFlexItem>
+    </InspectButtonContainer>
   );
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/dynamic_risk_level_panel.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/dynamic_risk_level_panel.test.tsx
@@ -65,11 +65,15 @@ describe('DynamicRiskLevelPanel', () => {
         [RiskSeverity.Critical]: 5,
       },
       loading: false,
+      refetch: jest.fn(),
+      inspect: { dsl: ['mock-dsl'], response: ['mock-response'] },
     });
 
     mockUseRiskLevelsEsqlQuery.mockReturnValue({
       records: [],
       isLoading: false,
+      refetch: jest.fn(),
+      inspect: { dsl: ['mock-dsl'], response: ['mock-response'] },
     });
   });
 
@@ -95,6 +99,18 @@ describe('DynamicRiskLevelPanel', () => {
     );
 
     expect(screen.getByText('VIP users risk levels')).toBeInTheDocument();
+  });
+
+  it('renders the inspect button', () => {
+    mockUseKibana.mockReturnValue(buildKibanaServices(jest.fn(), true));
+
+    render(
+      <TestProviders>
+        <DynamicRiskLevelPanel />
+      </TestProviders>
+    );
+
+    expect(screen.getByTestId('inspect-icon-button')).toBeInTheDocument();
   });
 
   it('threads an onPartitionClick handler to the donut that adds a global filter for entity.risk.calculated_level', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/dynamic_risk_level_panel.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/dynamic_risk_level_panel.tsx
@@ -19,6 +19,11 @@ import { useCombinedRiskScoreKpi } from './use_combined_risk_score_kpi';
 import { useKibana, useUiSetting } from '../../../common/lib/kibana';
 import { useRiskLevelsEsqlQuery } from '../watchlists/components/hooks/use_risk_levels_esql_query';
 import { esqlRecordsToSeverityCount, type EsqlSeverityRecord } from '../../common/utils';
+import { useGlobalTime } from '../../../common/containers/use_global_time';
+import { useQueryInspector } from '../../../common/components/page/manage_query';
+import { InspectButton, InspectButtonContainer } from '../../../common/components/inspect';
+
+const ENTITY_RISK_LEVEL_QUERY_ID = 'entity-risk-level-query';
 
 // Wide "all time" range used to neutralize the global date picker on the
 // Entity Analytics home page, where the picker is intentionally hidden and
@@ -44,6 +49,7 @@ export const DynamicRiskLevelPanel: React.FC<DynamicRiskLevelPanelProps> = ({
   const hasWatchlist = !!watchlistId;
   const { filterManager } = useKibana().services.data.query;
   const isEntityStoreV2Enabled = useUiSetting<boolean>(FF_ENABLE_ENTITY_STORE_V2) === true;
+  const { setQuery, deleteQuery } = useGlobalTime();
 
   const useLegacy = !isEntityStoreV2Enabled;
 
@@ -69,6 +75,15 @@ export const DynamicRiskLevelPanel: React.FC<DynamicRiskLevelPanelProps> = ({
 
   const loading = useLegacy ? combinedRiskStats.loading : riskLevelsStats.isLoading;
 
+  useQueryInspector({
+    queryId: ENTITY_RISK_LEVEL_QUERY_ID,
+    inspect: useLegacy ? combinedRiskStats.inspect : riskLevelsStats.inspect,
+    loading,
+    refetch: useLegacy ? combinedRiskStats.refetch : riskLevelsStats.refetch,
+    setQuery,
+    deleteQuery,
+  });
+
   const handlePartitionClick = useCallback(
     (level: RiskSeverity) => {
       filterManager.addFilters([
@@ -85,48 +100,53 @@ export const DynamicRiskLevelPanel: React.FC<DynamicRiskLevelPanelProps> = ({
     [filterManager]
   );
 
+  const title = hasWatchlist ? (
+    <FormattedMessage
+      id="xpack.securitySolution.entityAnalytics.dynamicRiskLevel.watchlistTitle"
+      defaultMessage="{watchlistName} risk levels"
+      values={{ watchlistName: watchlistName ?? watchlistId }}
+    />
+  ) : (
+    <FormattedMessage
+      id="xpack.securitySolution.entityAnalytics.dynamicRiskLevel.entityTitle"
+      defaultMessage="Entity risk levels"
+    />
+  );
+
   return (
-    <EuiFlexGroup direction="column" gutterSize="m" css={{ height: '100%' }}>
-      <EuiFlexItem grow={false}>
-        <EuiFlexGroup alignItems="center" css={{ minHeight: 40 }}>
-          <EuiTitle size="s">
-            <h3>
-              {hasWatchlist ? (
-                <FormattedMessage
-                  id="xpack.securitySolution.entityAnalytics.dynamicRiskLevel.watchlistTitle"
-                  defaultMessage="{watchlistName} risk levels"
-                  values={{
-                    watchlistName: watchlistName ?? watchlistId,
-                  }}
-                />
-              ) : (
-                <FormattedMessage
-                  id="xpack.securitySolution.entityAnalytics.dynamicRiskLevel.entityTitle"
-                  defaultMessage="Entity risk levels"
-                />
-              )}
-            </h3>
-          </EuiTitle>
-        </EuiFlexGroup>
-      </EuiFlexItem>
-      <EuiFlexItem>
-        <EuiFlexGroup alignItems="center" gutterSize="none">
-          <EuiFlexItem grow={3}>
-            <RiskLevelBreakdownTable
-              severityCount={severityCount}
-              loading={loading}
-              entityDataView={entityDataView}
-            />
-          </EuiFlexItem>
-          <EuiFlexItem grow={2}>
-            <RiskScoreDonutChart
-              showLegend={false}
-              severityCount={severityCount}
-              onPartitionClick={handlePartitionClick}
-            />
-          </EuiFlexItem>
-        </EuiFlexGroup>
-      </EuiFlexItem>
-    </EuiFlexGroup>
+    <InspectButtonContainer>
+      <EuiFlexGroup direction="column" gutterSize="m" css={{ height: '100%' }}>
+        <EuiFlexItem grow={false}>
+          <EuiFlexGroup alignItems="center" justifyContent="spaceBetween" css={{ minHeight: 40 }}>
+            <EuiFlexItem grow={false}>
+              <EuiTitle size="s">
+                <h3>{title}</h3>
+              </EuiTitle>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <InspectButton queryId={ENTITY_RISK_LEVEL_QUERY_ID} title={title} />
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiFlexGroup alignItems="center" gutterSize="none">
+            <EuiFlexItem grow={3}>
+              <RiskLevelBreakdownTable
+                severityCount={severityCount}
+                loading={loading}
+                entityDataView={entityDataView}
+              />
+            </EuiFlexItem>
+            <EuiFlexItem grow={2}>
+              <RiskScoreDonutChart
+                showLegend={false}
+                severityCount={severityCount}
+                onPartitionClick={handlePartitionClick}
+              />
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </InspectButtonContainer>
   );
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/use_combined_risk_score_kpi.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/home/use_combined_risk_score_kpi.ts
@@ -15,6 +15,7 @@ import { useGlobalFilterQuery } from '../../../common/hooks/use_global_filter_qu
 import { useGlobalTime } from '../../../common/containers/use_global_time';
 import { useUiSetting } from '../../../common/lib/kibana';
 import type { SeverityCount } from '../severity/types';
+import type { InspectResponse } from '../../../types';
 
 const mergeSeverityCounts = (
   a: SeverityCount | undefined,
@@ -33,6 +34,7 @@ interface UseCombinedRiskScoreKpiResult {
   error: unknown;
   isModuleDisabled: boolean;
   refetch: () => void;
+  inspect: InspectResponse;
 }
 
 interface UseCombinedRiskScoreKpiOptions {
@@ -118,11 +120,22 @@ export const useCombinedRiskScoreKpi = (
     ? mergeSeverityCounts(hostStoreKpi.severityCount, userStoreKpi.severityCount)
     : combinedRiskKpi.severityCount ?? EMPTY_SEVERITY_COUNT;
 
+  const inspect: InspectResponse = useMemo(() => {
+    if (entityStoreV2Enabled) {
+      return {
+        dsl: [...hostStoreKpi.inspect.dsl, ...userStoreKpi.inspect.dsl],
+        response: [...hostStoreKpi.inspect.response, ...userStoreKpi.inspect.response],
+      };
+    }
+    return combinedRiskKpi.inspect;
+  }, [entityStoreV2Enabled, hostStoreKpi.inspect, userStoreKpi.inspect, combinedRiskKpi.inspect]);
+
   return {
     severityCount,
     loading,
     error,
     isModuleDisabled,
     refetch,
+    inspect,
   };
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/recent_anomalies/hooks/recent_anomalies_query_hooks.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/recent_anomalies/hooks/recent_anomalies_query_hooks.ts
@@ -7,6 +7,7 @@
 
 import { useQuery } from '@kbn/react-query';
 import { getESQLResults, prettifyQuery } from '@kbn/esql-utils';
+import type { ESQLSearchResponse } from '@kbn/es-types';
 import { i18n } from '@kbn/i18n';
 import { useMemo } from 'react';
 import { ML_ANOMALIES_INDEX } from '../../../../../common/constants';
@@ -143,21 +144,21 @@ export const useRecentAnomaliesQuery = (params: {
   } = useQuery<{
     anomalyRecords: Array<Record<string, unknown>>;
     rowLabels: string[];
+    rawResponse?: ESQLSearchResponse;
   }>(
     [filterQuery, anomalyDataEsqlSource, rowLabels],
     async ({ signal }) => {
       if (!anomalyDataEsqlSource || !rowLabels || rowLabels.length === 0) {
         return { anomalyRecords: [], rowLabels: [] };
       }
+      const esqlResult = await getESQLResults({
+        esqlQuery: anomalyDataEsqlSource,
+        search,
+        signal,
+        filter: filterQuery,
+      });
       const anomalyRecords = esqlResponseToRecords<Record<string, string | number>>(
-        (
-          await getESQLResults({
-            esqlQuery: anomalyDataEsqlSource,
-            search,
-            signal,
-            filter: filterQuery,
-          })
-        ).response
+        esqlResult.response
       ).map((eachRawRecord) => ({
         ...eachRawRecord,
         '@timestamp': new Date(eachRawRecord['@timestamp']).getTime(),
@@ -165,6 +166,7 @@ export const useRecentAnomaliesQuery = (params: {
       return {
         anomalyRecords: anomalyRecords ?? [],
         rowLabels: rowLabels ?? [],
+        rawResponse: esqlResult.response,
       };
     },
     {
@@ -185,9 +187,9 @@ export const useRecentAnomaliesQuery = (params: {
           2
         ),
       ],
-      response: data ? [JSON.stringify(data, null, 2)] : [],
+      response: data?.rawResponse ? [JSON.stringify(data.rawResponse, null, 2)] : [],
     };
-  }, [data, anomalyDataEsqlSource]);
+  }, [data?.rawResponse, anomalyDataEsqlSource]);
 
   useErrorToast(
     i18n.translate('xpack.securitySolution.entityAnalytics.recentAnomalies.queryError', {

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/recent_anomalies/hooks/recent_anomalies_query_hooks.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/recent_anomalies/hooks/recent_anomalies_query_hooks.ts
@@ -73,38 +73,42 @@ const useRecentAnomaliesTopRowsQuery = (params: {
   const { isLoading, data, isError } = useQuery(
     [filterQuery, topRowsEsqlSource],
     async ({ signal }) => {
-      if (!topRowsEsqlSource) return [];
-      return esqlResponseToRecords<Record<string, string>>(
-        (
-          await getESQLResults({
-            esqlQuery: topRowsEsqlSource,
-            search,
-            signal,
-            filter: filterQuery,
-          })
-        )?.response
-      );
+      if (!topRowsEsqlSource) return { records: [], rawResponse: undefined };
+      const esqlResult = await getESQLResults({
+        esqlQuery: topRowsEsqlSource,
+        search,
+        signal,
+        filter: filterQuery,
+      });
+      return {
+        records: esqlResponseToRecords<Record<string, string>>(esqlResult?.response),
+        rawResponse: esqlResult?.response,
+      };
     },
     { enabled: !!topRowsEsqlSource }
   );
 
+  const records = data?.records;
+
   const entityMetadata: EntityMetadata[] | undefined = useMemo(
     () =>
       params.viewBy === 'entity'
-        ? data?.map((record) => ({
+        ? records?.map((record) => ({
             entityId: record.entity_id,
             entityName: record.entity_name,
             entityType: record.entity_type,
           }))
         : undefined,
-    [data, params.viewBy]
+    [records, params.viewBy]
   );
 
   return {
     isLoading,
-    rowLabels: data?.map((each) => each[rowField]),
+    rowLabels: records?.map((each) => each[rowField]),
     entityMetadata,
     isError,
+    rawResponse: data?.rawResponse,
+    esqlSource: topRowsEsqlSource,
   };
 };
 
@@ -127,6 +131,8 @@ export const useRecentAnomaliesQuery = (params: {
     entityMetadata,
     isError: isTopRowsError,
     isLoading: isTopRowsLoading,
+    rawResponse: topRowsRawResponse,
+    esqlSource: topRowsEsqlSource,
   } = useRecentAnomaliesTopRowsQuery(params);
 
   const anomalyDataEsqlSource = useRecentAnomaliesDataEsqlSource({
@@ -134,6 +140,8 @@ export const useRecentAnomaliesQuery = (params: {
     rowLabels,
     timeRange: params.timeRange,
   });
+
+  const hasAnomaliesData = rowLabels && rowLabels.length > 0;
 
   const {
     isLoading: isAnomaliesLoading,
@@ -148,7 +156,7 @@ export const useRecentAnomaliesQuery = (params: {
   }>(
     [filterQuery, anomalyDataEsqlSource, rowLabels],
     async ({ signal }) => {
-      if (!anomalyDataEsqlSource || !rowLabels || rowLabels.length === 0) {
+      if (!anomalyDataEsqlSource || !hasAnomaliesData) {
         return { anomalyRecords: [], rowLabels: [] };
       }
       const esqlResult = await getESQLResults({
@@ -176,20 +184,30 @@ export const useRecentAnomaliesQuery = (params: {
   );
 
   const inspect = useMemo(() => {
+    // when there are no anomalies, rowLabels comes back empty from the top-rows query,
+    // so the main query never actually runs. In that case, we use the top-rows query's esql source and raw response.
+    const esqlSource = hasAnomaliesData ? anomalyDataEsqlSource : topRowsEsqlSource;
+    const rawResponse = hasAnomaliesData ? data?.rawResponse : topRowsRawResponse;
     return {
       dsl: [
         JSON.stringify(
           {
             index: [ML_ANOMALIES_INDEX],
-            body: prettifyQuery(anomalyDataEsqlSource ?? ''),
+            body: prettifyQuery(esqlSource ?? ''),
           },
           null,
           2
         ),
       ],
-      response: data?.rawResponse ? [JSON.stringify(data.rawResponse, null, 2)] : [],
+      response: rawResponse ? [JSON.stringify(rawResponse, null, 2)] : [],
     };
-  }, [data?.rawResponse, anomalyDataEsqlSource]);
+  }, [
+    data?.rawResponse,
+    anomalyDataEsqlSource,
+    topRowsRawResponse,
+    topRowsEsqlSource,
+    hasAnomaliesData,
+  ]);
 
   useErrorToast(
     i18n.translate('xpack.securitySolution.entityAnalytics.recentAnomalies.queryError', {

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/recent_anomalies/recent_anomalies_chart.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/recent_anomalies/recent_anomalies_chart.tsx
@@ -18,7 +18,7 @@ import { AnomalyHeatmap } from './anomaly_heatmap';
 import { useQueryInspector } from '../../../common/components/page/manage_query';
 import { RecentAnomaliesHeatmapNoResults } from './recent_anomalies_heatmap_no_results';
 
-const RECENT_ANOMALIES_QUERY_ID = 'recent-anomalies-query';
+export const RECENT_ANOMALIES_QUERY_ID = 'recent-anomalies-query';
 const RECENT_ANOMALIES_CONTEXT_ID = 'RecentAnomalies-table';
 
 /**


### PR DESCRIPTION
## Summary

Adding Inspect button to risk chart and anomaly explorer on Entity Analytics home page.

- Updated `useCombinedRiskScoreKpi` to return an inspect object, combining the inspect responses from both host and user KPI queries when Entity Store V2 is enabled
- Updated `useRecentAnomaliesQuery` to capture the raw ESQL search response and use it in the inspect object, so the inspect panel shows the actual Elasticsearch response rather than the post-processed data
  - Also for the recent anomalies the `RecentAnomaliesTopRowsQuery` is executed first and if there is no anomaly data then the `RecentAnomaliesQuery` is never actually executed. So `useRecentAnomaliesQuery` was also updated to return the data from `RecentAnomaliesTopRowsQuery` on the inspect object if there is no anomaly data 

### How to test

1. Start Elasticsearch and Kibana
2. Navigate to the Entity Analytics home page
3. Hover over the _Entity risk levels_ section and click the inspect button — verify the modal opens and shows the expected data
4. Hover over the _Recent anomalies_ section and click the inspect button — verify the modal opens and shows the expected data
5. Seed some data 
      <details>
        <summary>Commands used (from security-documents-generator)</summary>
        
      ```
      #!/bin/bash
      # Usage: ./populate_entity_store
      # remember to add your base path to the KIBANA_URL if you are using a base path
      KIBANA_URL='https://elastic:changeme@localhost:5601/'
      
      H=(-H 'Content-Type: application/json' -H 'x-elastic-internal-origin: Kibana' -H 'kbn-xsrf: true')
      
      printf "\nEnabling entity store v2\n"
      curl -k -X POST "${H[@]}" "${KIBANA_URL}/api/security/entity_store/install?apiVersion=2023-10-31" -d '{}'
      
      # Initialize maintainers (this triggers the setup phase)
      printf "\nInitializing entity maintainers\n"
      curl -k -X POST "${H[@]}" "${KIBANA_URL}/internal/security/entity_store/entity_maintainers/init?apiVersion=2" \
        -d '{}'
      
      printf "\nAdding organization data\n"
      yarn start organization-quick
      
      printf "\nWaiting 1 minute so entity store can run\n"
      sleep 60
      
      printf "\nEnriching entity store data\n"
      yarn start generate-entity-maintainers-data --quick
      
      printf "\nDone 🚀\n"
      ``` 
      ```
      yarn start generate-entity-ai-insights --v2 --correlate-with-entity-store
      ```
      </details>
6. Repeat steps 3 and 4

<img width="613" height="332" alt="Screenshot 2026-04-28 at 11 35 02 AM" src="https://github.com/user-attachments/assets/b1f3c893-5ddd-4923-a0c3-e0916d9efcbd" />
<img width="1003" height="334" alt="Screenshot 2026-04-28 at 11 35 07 AM" src="https://github.com/user-attachments/assets/b24382f8-570b-45f8-b5db-30e438dcde41" />

https://github.com/user-attachments/assets/6d8b92c0-34da-4366-aab1-f2e213983c51

https://github.com/user-attachments/assets/b4039a11-9bd2-474a-96bb-221445332aff



<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->