### PR TITLE
[8.19] [CI] avoid running serverless image builds on non-main PRs (#266090)

### DIFF
--- a/.buildkite/scripts/pipelines/pull_request/pipeline.ts
+++ b/.buildkite/scripts/pipelines/pull_request/pipeline.ts
@@ -217,10 +217,12 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
     }
 
     if (
-      GITHUB_PR_LABELS.includes('ci:project-deploy-elasticsearch') ||
-      GITHUB_PR_LABELS.includes('ci:project-deploy-observability') ||
-      GITHUB_PR_LABELS.includes('ci:project-deploy-security') ||
-      (await doAnyChangesMatch([/^\.buildkite\/pipelines\/pull_request\/deploy_project\.yml/]))
+      process.env.GITHUB_PR_TARGET_BRANCH?.match(/^main$/) &&
+      (GITHUB_PR_LABELS.includes('ci:project-deploy-elasticsearch') ||
+        GITHUB_PR_LABELS.includes('ci:project-deploy-observability') ||
+        GITHUB_PR_LABELS.includes('ci:project-deploy-log_essentials') ||
+        GITHUB_PR_LABELS.includes('ci:project-deploy-security') ||
+        GITHUB_PR_LABELS.includes('ci:project-deploy-ai4soc'))
     ) {
       pipeline.push(
         getPipeline('.buildkite/pipelines/pull_request/deploy_project.yml', cancelable)


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[CI] avoid running serverless image builds on non-main PRs (#266090)](https://github.com/elastic/kibana/pull/266090)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Alex Szabo","email":"alex.szabo@elastic.co"},"sourceCommit":{"committedDate":"2026-04-28T14:33:35Z","message":"[CI] avoid running serverless image builds on non-main PRs (#266090)\n\n## Summary\nIt seems backport PRs are getting some `ci:project-deploy-observability`\nadded by an automation, causing backport PRs to fail on serverless image\nbuilds - this shouldn't be an issue because we only build serverless\nfrom main.\n\nThis PR only adds these build steps if the PR's target is `main`.","sha":"c80dba7cd59f75828c06634501dd37c6f3be1fb3","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Operations","release_note:skip","backport:all-open","v9.4.0","v9.5.0","v9.3.4"],"title":"[CI] avoid running serverless image builds on non-main PRs","number":266090,"url":"https://github.com/elastic/kibana/pull/266090","mergeCommit":{"message":"[CI] avoid running serverless image builds on non-main PRs (#266090)\n\n## Summary\nIt seems backport PRs are getting some `ci:project-deploy-observability`\nadded by an automation, causing backport PRs to fail on serverless image\nbuilds - this shouldn't be an issue because we only build serverless\nfrom main.\n\nThis PR only adds these build steps if the PR's target is `main`.","sha":"c80dba7cd59f75828c06634501dd37c6f3be1fb3"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/266131","number":266131,"state":"MERGED","mergeCommit":{"sha":"8fe91bd874a60f701710837b5ffd3ce011e4da0c","message":"[9.4] [CI] avoid running serverless image builds on non-main PRs (#266090) (#266131)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.4`:\n- [[CI] avoid running serverless image builds on non-main PRs\n(#266090)](https://github.com/elastic/kibana/pull/266090)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Alex Szabo <alex.szabo@elastic.co>"}},{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/266090","number":266090,"mergeCommit":{"message":"[CI] avoid running serverless image builds on non-main PRs (#266090)\n\n## Summary\nIt seems backport PRs are getting some `ci:project-deploy-observability`\nadded by an automation, causing backport PRs to fail on serverless image\nbuilds - this shouldn't be an issue because we only build serverless\nfrom main.\n\nThis PR only adds these build steps if the PR's target is `main`.","sha":"c80dba7cd59f75828c06634501dd37c6f3be1fb3"}},{"branch":"9.3","label":"v9.3.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/266129","number":266129,"state":"MERGED","mergeCommit":{"sha":"2abc01f8354cfb43c5cf56199050a23645fd1ae0","message":"[9.3] [CI] avoid running serverless image builds on non-main PRs (#266090) (#266129)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.3`:\n- [[CI] avoid running serverless image builds on non-main PRs\n(#266090)](https://github.com/elastic/kibana/pull/266090)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Alex Szabo <alex.szabo@elastic.co>"}}]}] BACKPORT-->