### PR TITLE
Switch closes:rna workflow off project-membership check

### DIFF
--- a/.github/workflows/add-rna-closes-label.yml
+++ b/.github/workflows/add-rna-closes-label.yml
@@ -12,18 +12,41 @@ jobs:
       contents: read
 
     steps:
-      - name: Label if PR closes an issue on the RNA Program Board
+      - name: Label if PR closes an RnA program issue
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
+          # Heuristic stand-in for "issue is on the RNA Program Board (project 2076)":
+          # any issue in elastic/rna-program, OR any elastic/kibana issue carrying
+          # Feature:AlertingV2. Project-board membership itself isn't readable by
+          # the default GITHUB_TOKEN — Projects v2 are org-owned and require
+          # read:project scope, which the workflow can't grant itself.
           script: |
             const label = "closes:rna";
-            const rnaBoardNumber = 2076;
+            const RNA_REPO = "elastic/rna-program";
+            const KIBANA_REPO = "elastic/kibana";
+            const KIBANA_TRIGGER_LABELS = ["Feature:AlertingV2"];
             const prNumber = context.payload.pull_request.number;
 
             const existingLabels = context.payload.pull_request.labels.map(l => l.name);
             if (existingLabels.includes(label)) {
               return;
             }
+
+            const isRnaIssue = (repoNameWithOwner, issueLabels) => {
+              if (repoNameWithOwner === RNA_REPO) return true;
+              if (repoNameWithOwner === KIBANA_REPO &&
+                  issueLabels.some(name => KIBANA_TRIGGER_LABELS.includes(name))) {
+                return true;
+              }
+              return false;
+            };
+
+            const applyLabel = () => github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              labels: [label],
+            });
 
             const { repository } = await github.graphql(`
               query($owner: String!, $repo: String!, $prNumber: Int!) {
@@ -32,11 +55,8 @@ jobs:
                     body
                     closingIssuesReferences(first: 10) {
                       nodes {
-                        projectItems(first: 20) {
-                          nodes {
-                            project { number }
-                          }
-                        }
+                        repository { nameWithOwner }
+                        labels(first: 30) { nodes { name } }
                       }
                     }
                   }
@@ -50,57 +70,59 @@ jobs:
 
             const pr = repository.pullRequest;
 
-            const isOnRnaBoard = (issue) =>
-              issue.projectItems.nodes.some(item => item.project.number === rnaBoardNumber);
-
             // Check closingIssuesReferences first (works for PRs targeting default branch)
-            if (pr.closingIssuesReferences.nodes.some(isOnRnaBoard)) {
-              await github.rest.issues.addLabels({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: prNumber,
-                labels: [label],
-              });
+            const matched = pr.closingIssuesReferences.nodes.some(issue =>
+              isRnaIssue(
+                issue.repository.nameWithOwner,
+                issue.labels.nodes.map(l => l.name),
+              )
+            );
+            if (matched) {
+              await applyLabel();
               return;
             }
 
             // Fallback: parse issue references from PR body
             const body = pr.body || "";
-            const pattern = /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)[\s:]*(?:https:\/\/github\.com\/([^/]+\/[^/]+)\/issues\/(\d+)|#(\d+))/gi;
+            const pattern = /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)[\s:]*(?:https:\/\/github\.com\/([^/]+\/[^/]+)\/issues\/(\d+)|([^\s\/#]+\/[^\s\/#]+)#(\d+)|#(\d+))/gi;
             const issueRefs = [];
             let match;
             while ((match = pattern.exec(body)) !== null) {
               if (match[1] && match[2]) {
                 const [owner, repo] = match[1].split("/");
                 issueRefs.push({ owner, repo, number: parseInt(match[2]) });
-              } else if (match[3]) {
-                issueRefs.push({ owner: context.repo.owner, repo: context.repo.repo, number: parseInt(match[3]) });
+              } else if (match[3] && match[4]) {
+                const [owner, repo] = match[3].split("/");
+                issueRefs.push({ owner, repo, number: parseInt(match[4]) });
+              } else if (match[5]) {
+                issueRefs.push({ owner: context.repo.owner, repo: context.repo.repo, number: parseInt(match[5]) });
               }
             }
 
             for (const ref of issueRefs) {
+              const repoNameWithOwner = `${ref.owner}/${ref.repo}`;
+
+              // rna-program: matches without needing label data
+              if (repoNameWithOwner === RNA_REPO) {
+                await applyLabel();
+                return;
+              }
+              if (repoNameWithOwner !== KIBANA_REPO) continue;
+
               try {
                 const { repository: issueRepo } = await github.graphql(`
                   query($owner: String!, $repo: String!, $number: Int!) {
                     repository(owner: $owner, name: $repo) {
                       issue(number: $number) {
-                        projectItems(first: 20) {
-                          nodes {
-                            project { number }
-                          }
-                        }
+                        labels(first: 30) { nodes { name } }
                       }
                     }
                   }
                 `, ref);
 
-                if (isOnRnaBoard(issueRepo.issue)) {
-                  await github.rest.issues.addLabels({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    issue_number: prNumber,
-                    labels: [label],
-                  });
+                const issueLabels = (issueRepo?.issue?.labels?.nodes || []).map(l => l.name);
+                if (isRnaIssue(repoNameWithOwner, issueLabels)) {
+                  await applyLabel();
                   return;
                 }
               } catch (e) {


### PR DESCRIPTION
## Summary

The workflow added in #256557 has been silently no-op'ing since merge: GraphQL `projectItems` returns empty for the default `GITHUB_TOKEN` (Projects v2 are org-owned and require `read:project`, which is not grantable inside a workflow). All `closes:rna` labels in the period since ship were applied manually.

## Change

Replace the project-membership check with a heuristic readable on the default token:

- closing issue in `elastic/rna-program`, **OR**
- closing issue in `elastic/kibana` with `Feature:AlertingV2`

Body-regex fallback also extended to match `elastic/rna-program#N` shorthand (was URL-form or bare `#N` only). This makes the fallback robust even if `closingIssuesReferences` declines to surface private cross-repo nodes to the public-repo `GITHUB_TOKEN`.

## Recall over the past 2 weeks

12 RNA Program Board issues were closed with closing PRs in that window; the heuristic catches 9. The 3 misses are kibana V2 alerting issues that didn't carry `Feature:AlertingV2`. Recoverable with labeling habit; a label-hygiene pass on existing V2 alerting issues would push recall to 100% on this dataset.

## Verification plan

- [ ] After merge, observe a real PR closing an `elastic/rna-program` issue and confirm `closes:rna` is applied by `github-actions[bot]`
- [ ] Observe a kibana PR closing a `Feature:AlertingV2`-labeled issue and confirm same

🤖 Generated with [Claude Code](https://claude.com/claude-code)