### PR TITLE
bump serialize-javascript to 7.0.5 through resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "**/pixelmatch": "5.3.0",
     "**/qs": "6.15.0",
     "**/remark-parse/trim": "1.0.1",
+    "**/serialize-javascript": "7.0.5",
     "**/sharp": "0.34.5",
     "**/typescript": "5.9.3",
     "**/util": "0.12.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -32658,12 +32658,10 @@ send@~0.19.0, send@~0.19.1:
     range-parser "~1.2.1"
     statuses "~2.0.2"
 
-serialize-javascript@^6.0.2:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-6.0.2.tgz#defa1e055c83bf6d59ea805d8da862254eb6a6c2"
-  integrity sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==
-  dependencies:
-    randombytes "^2.1.0"
+serialize-javascript@7.0.5, serialize-javascript@^6.0.2:
+  version "7.0.5"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-7.0.5.tgz#c798cc0552ffbb08981914a42a8756e339d0d5b1"
+  integrity sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==
 
 serve-index@^1.9.1:
   version "1.9.1"


### PR DESCRIPTION
Added resolution override for `serialize-javascript` version 7.0.5


<!--ONMERGE {"backportTargets":["8.19","9.3","9.4"]} ONMERGE-->