### PR TITLE
[9.3] [Fleet] Fix missing fields for `enabled:false` inputs in agentless deployment modes (#265106)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/form.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/form.test.tsx
@@ -471,6 +471,181 @@ describe('useOnSubmit', () => {
         expect(metricsInput?.enabled).toBe(true);
       });
     });
+
+    it('should auto-enable a single disabled input when switching to agentless deployment mode', async () => {
+      // Single-input agentless package whose stream has enabled:false in the spec.
+      // The simplified UX shows no toggle, so the input must be auto-enabled so that
+      // configuration fields are visible and the integration can actually be deployed.
+      const packageInfoWithDisabledInputs: PackageInfo = {
+        ...packageInfo,
+        data_streams: [
+          {
+            type: 'logs',
+            dataset: 'test.access',
+            path: 'access',
+            release: 'ga',
+            package: 'apache',
+            ingest_pipeline: 'default',
+            title: 'Apache access logs',
+            streams: [
+              {
+                input: 'logfile',
+                enabled: false,
+                vars: [],
+              },
+            ],
+          },
+        ] as any,
+        policy_templates: [
+          {
+            name: 'apache',
+            title: 'Apache',
+            description: 'Apache integration',
+            deployment_modes: {
+              default: { enabled: true },
+              agentless: { enabled: true },
+            },
+            inputs: [
+              {
+                type: 'logfile',
+                title: 'Log files',
+                description: 'Collect Apache log files',
+                deployment_modes: ['default', 'agentless'],
+              },
+            ],
+          },
+        ],
+      };
+
+      (useConfig as MockFn).mockReturnValue({
+        agentless: { enabled: true },
+      } as any);
+
+      renderResult = testRenderer.renderHook(() =>
+        useOnSubmit({
+          agentCount: 0,
+          packageInfo: packageInfoWithDisabledInputs,
+          withSysMonitoring: false,
+          selectedPolicyTab: SelectedPolicyTab.NEW,
+          newAgentPolicy: { name: 'test', namespace: '', supports_agentless: true },
+          queryParamsPolicyId: undefined,
+          hasFleetAddAgentsPrivileges: true,
+          setNewAgentPolicy: jest.fn(),
+          setSelectedPolicyTab: jest.fn(),
+        })
+      );
+
+      await waitFor(() => new Promise((resolve) => resolve(null)));
+
+      // Verify input starts disabled (stream has enabled:false in spec)
+      await waitFor(() => {
+        const { packagePolicy } = renderResult.result.current;
+        const logfileInput = packagePolicy.inputs.find((input: any) => input.type === 'logfile');
+        expect(logfileInput?.enabled).toBe(false);
+      });
+
+      act(() => {
+        renderResult.result.current.handleSetupTechnologyChange('agentless' as any);
+      });
+
+      await waitFor(() => {
+        const { packagePolicy } = renderResult.result.current;
+        const logfileInput = packagePolicy.inputs.find((input: any) => input.type === 'logfile');
+        // Single agentless input should be auto-enabled so config fields are visible
+        expect(logfileInput?.enabled).toBe(true);
+        expect(logfileInput?.streams.every((s: any) => s.enabled)).toBe(true);
+      });
+    });
+
+    it('should not auto-enable disabled inputs for multi-input agentless packages', async () => {
+      // Multi-input package: the user should be able to choose which inputs to enable,
+      // so we must not blindly enable everything when switching to agentless.
+      const packageInfoMultiInput: PackageInfo = {
+        ...packageInfo,
+        data_streams: [
+          {
+            type: 'logs',
+            dataset: 'test.access',
+            path: 'access',
+            release: 'ga',
+            package: 'apache',
+            ingest_pipeline: 'default',
+            title: 'Apache access logs',
+            streams: [{ input: 'logfile', enabled: false, vars: [] }],
+          },
+          {
+            type: 'metrics',
+            dataset: 'test.metrics',
+            path: 'metrics',
+            release: 'ga',
+            package: 'apache',
+            ingest_pipeline: 'default',
+            title: 'Apache metrics',
+            streams: [{ input: 'apache/metrics', enabled: false, vars: [] }],
+          },
+        ] as any,
+        policy_templates: [
+          {
+            name: 'apache',
+            title: 'Apache',
+            description: 'Apache integration',
+            deployment_modes: {
+              default: { enabled: true },
+              agentless: { enabled: true },
+            },
+            inputs: [
+              {
+                type: 'logfile',
+                title: 'Log files',
+                description: 'Collect Apache log files',
+                deployment_modes: ['default', 'agentless'],
+              },
+              {
+                type: 'apache/metrics',
+                title: 'Metrics',
+                description: 'Collect Apache metrics',
+                deployment_modes: ['default', 'agentless'],
+              },
+            ],
+          },
+        ],
+      };
+
+      (useConfig as MockFn).mockReturnValue({
+        agentless: { enabled: true },
+      } as any);
+
+      renderResult = testRenderer.renderHook(() =>
+        useOnSubmit({
+          agentCount: 0,
+          packageInfo: packageInfoMultiInput,
+          withSysMonitoring: false,
+          selectedPolicyTab: SelectedPolicyTab.NEW,
+          newAgentPolicy: { name: 'test', namespace: '', supports_agentless: true },
+          queryParamsPolicyId: undefined,
+          hasFleetAddAgentsPrivileges: true,
+          setNewAgentPolicy: jest.fn(),
+          setSelectedPolicyTab: jest.fn(),
+        })
+      );
+
+      await waitFor(() => new Promise((resolve) => resolve(null)));
+
+      act(() => {
+        renderResult.result.current.handleSetupTechnologyChange('agentless' as any);
+      });
+
+      await waitFor(() => {
+        const { packagePolicy } = renderResult.result.current;
+        const logfileInput = packagePolicy.inputs.find((input: any) => input.type === 'logfile');
+        const metricsInput = packagePolicy.inputs.find(
+          (input: any) => input.type === 'apache/metrics'
+        );
+        // Multi-input packages are not auto-enabled; user must enable them explicitly
+        expect(logfileInput?.enabled).toBe(false);
+        expect(metricsInput?.enabled).toBe(false);
+      });
+    });
   });
 
   describe('updateAgentlessCloudConnectorConfig', () => {

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/form.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/form.tsx
@@ -488,7 +488,17 @@ export function useOnSubmit({
     isAgentlessIntegration(packageInfo) && selectedSetupTechnology === SetupTechnology.AGENTLESS;
 
   const newInputs = useMemo(() => {
-    return packagePolicy.inputs.map((input, i) => {
+    // For single-input agentless integrations the simplified UX shows no enable/disable
+    // toggle, so if the input is disabled by default the user has no way to enable it or
+    // see any configuration fields.  Auto-enable it when switching to agentless.
+    const agentlessAllowedInputCount = isAgentlessSelected
+      ? packagePolicy.inputs.filter((inp) =>
+          isInputAllowedForDeploymentMode(inp, 'agentless', packageInfo)
+        ).length
+      : 0;
+    const isSingleAgentlessInput = agentlessAllowedInputCount === 1;
+
+    return packagePolicy.inputs.map((input) => {
       if (
         isInputAllowedForDeploymentMode(
           input,
@@ -496,6 +506,13 @@ export function useOnSubmit({
           packageInfo
         )
       ) {
+        if (isAgentlessSelected && !input.enabled && isSingleAgentlessInput) {
+          return {
+            ...input,
+            enabled: true,
+            streams: input.streams.map((stream) => ({ ...stream, enabled: true })),
+          };
+        }
         return input;
       } else {
         return { ...input, enabled: false };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
- [[Fleet] Fix missing fields for `enabled:false` inputs in agentless deployment modes (#265106)](https://github.com/elastic/kibana/pull/265106)

<!--- Backport version: 9.4.3 -->

### Questions ?

Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Mason Herron","email":"46727170+Supplementing@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-04-23T21:40:56Z","message":"[Fleet] Fix missing fields for `enabled:false` inputs in agentless deployment modes (#265106)\n\n## Summary\n\nCloses #261788\n\nThis PR fixes an issue where when selecting agentless deployment mode on\nan integration, if the inputs have `enabled:false`, configuration fields\nwould be hidden and the user would not be able to deploy the\nintegration. This PR now checks that the input is allowed for agentless\nand if so, auto-enables it and all its streams. This mirrors the\nbehavior existing in `simplified_package_policy_helper.ts`","sha":"1895f404b32e31b124ff9c86f6d337034eca7a9b","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport:version","v9.4.0","v9.3.0"],"title":"[Fleet] Fix missing fields for `enabled:false` inputs in agentless deployment modes","number":265106,"url":"https://github.com/elastic/kibana/pull/265106","mergeCommit":{"message":"[Fleet] Fix missing fields for `enabled:false` inputs in agentless deployment modes (#265106)","sha":"1895f404b32e31b124ff9c86f6d337034eca7a9b"}},"targetPullRequest":{"number":0,"url":"","branch":"9.3"}}] BACKPORT-->