### PR TITLE
[Chrome Next] Close popover when opening a link

### DIFF
--- a/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/types.ts
+++ b/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/types.ts
@@ -134,7 +134,7 @@ type AppMenuLinkItem = AppMenuItemBase & {
   /**
    * The HTML target attribute for the item. Only used if `items` is not provided.
    */
-  target: string;
+  target?: string;
   /**
    * Function to run when the item is clicked. Only used if `items` is not provided.
    */

--- a/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/utils.tsx
+++ b/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/utils.tsx
@@ -176,7 +176,7 @@ export const mapAppMenuItemToPanelItem = (
       return;
     }
 
-    const shouldClosePopover = !item?.href && childPanelId === undefined && onClose;
+    const shouldClosePopover = childPanelId === undefined && onClose;
 
     const triggerElement = event.currentTarget as HTMLElement;
     item.run?.({


### PR DESCRIPTION
## Summary

This PR fixes an issue where clicking on an external link popover child item would not close the popover. It also changes `target` to be optional as it's not needed for internal links.
