### PR TITLE
[Lens ES|QL] Remove missing values options for dimensions editor ui

### DIFF
--- a/x-pack/platform/plugins/shared/lens/public/visualizations/xy/toolbar/appearance_settings/appearance_settings.test.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/visualizations/xy/toolbar/appearance_settings/appearance_settings.test.tsx
@@ -51,10 +51,13 @@ describe('Appearance settings', () => {
     overrideProps?: Partial<{
       state: XYVisualizationState;
       setState: (newState: XYVisualizationState) => void;
+      frame: FramePublicAPI;
     }>
   ) => {
     const state = testState();
-    return render(<XyAppearanceSettings setState={jest.fn()} state={state} {...overrideProps} />);
+    return render(
+      <XyAppearanceSettings setState={jest.fn()} state={state} frame={frame} {...overrideProps} />
+    );
   };
 
   it.each<{
@@ -110,4 +113,17 @@ describe('Appearance settings', () => {
       }
     }
   );
+
+  it('hides missing values fitting controls for text-based (ES|QL) datasource', () => {
+    frame.datasourceLayers = {
+      first: createMockDatasource('textBased', {
+        isTextBasedLanguage: jest.fn(() => true),
+      }).publicAPIMock,
+    };
+    const state = testState();
+    (state.layers[0] as XYDataLayerConfig).seriesType = 'line';
+    renderComponent({ state });
+
+    expect(screen.queryByText('Missing values')).not.toBeInTheDocument();
+  });
 });

--- a/x-pack/platform/plugins/shared/lens/public/visualizations/xy/toolbar/appearance_settings/appearance_settings.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/visualizations/xy/toolbar/appearance_settings/appearance_settings.tsx
@@ -8,6 +8,7 @@
 import React from 'react';
 import { i18n } from '@kbn/i18n';
 import { PointVisibilityOptions } from '@kbn/expression-xy-plugin/public';
+import type { VisualizationToolbarProps } from '@kbn/lens-common';
 import { BarOrientationSettings } from '../../../../shared_components/bar_orientation';
 import { ToolbarDivider } from '../../../../shared_components/toolbar_divider';
 import { MissingValuesOptions } from './missing_values_option';
@@ -47,10 +48,11 @@ export function getValueLabelDisableReason({
   });
 }
 
-export const XyAppearanceSettings: React.FC<{
-  state: XYVisualizationState;
-  setState: (newState: XYVisualizationState) => void;
-}> = ({ state, setState }) => {
+export const XyAppearanceSettings: React.FC<VisualizationToolbarProps<XYVisualizationState>> = ({
+  state,
+  setState,
+  frame,
+}) => {
   const dataLayers = getDataLayers(state.layers);
   const isAreaPercentage = dataLayers.some(
     ({ seriesType }) => seriesType === 'area_percentage_stacked'
@@ -58,7 +60,10 @@ export const XyAppearanceSettings: React.FC<{
 
   const isHasNonBarSeries = hasNonBarSeries(dataLayers);
 
-  const isFittingEnabled = isHasNonBarSeries && !isAreaPercentage;
+  const hasTextBasedDatasource = dataLayers.some(
+    (layer) => frame.datasourceLayers[layer.layerId]?.isTextBasedLanguage() === true
+  );
+  const isFittingEnabled = isHasNonBarSeries && !isAreaPercentage && !hasTextBasedDatasource;
   const isCurveTypeEnabled = isHasNonBarSeries || isAreaPercentage;
 
   const isHorizontal = isHorizontalChart(state.layers);


### PR DESCRIPTION
## Summary

The Missing value and end values options require null buckets to be provided as explained in https://github.com/elastic/kibana/issues/223199.

The DSL charts support this via the **include empty buckets** options that has es send all buckets even null buckets in the response. As ES|QL does not support this we should temporarily remove these options for the ES|QL charts.

https://github.com/user-attachments/assets/3414ee38-69f2-46fd-9859-e5a2159d4208

When https://github.com/elastic/kibana/issues/264861 is fixed we should restore these settings.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.