### PR TITLE
[9.1] Gracefully handle deprecated telemetry config (#266029)

### DIFF
--- a/src/platform/plugins/shared/telemetry/moon.yml
+++ b/src/platform/plugins/shared/telemetry/moon.yml
@@ -47,6 +47,7 @@ dependsOn:
   - '@kbn/logging'
   - '@kbn/core-security-server'
   - '@kbn/telemetry-config'
+  - '@kbn/config'
 tags:
   - plugin
   - prod

--- a/src/platform/plugins/shared/telemetry/server/config/config.test.ts
+++ b/src/platform/plugins/shared/telemetry/server/config/config.test.ts
@@ -7,7 +7,23 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { applyDeprecations, configDeprecationFactory } from '@kbn/config';
+import { configDeprecationsMock } from '@kbn/core/server/mocks';
 import { config } from './config';
+
+const applyConfigDeprecations = (telemetrySettings: Record<string, unknown> = {}) => {
+  const deprecationContext = configDeprecationsMock.createContext();
+  const deprecations = config.deprecations!(configDeprecationFactory);
+  const { config: migrated } = applyDeprecations(
+    { telemetry: telemetrySettings },
+    deprecations.map((deprecation) => ({
+      deprecation,
+      path: 'telemetry',
+      context: deprecationContext,
+    }))
+  );
+  return migrated as Record<string, Record<string, unknown>>;
+};
 
 describe('config', () => {
   const baseContext = {
@@ -61,5 +77,52 @@ describe('config', () => {
         ).toThrow();
       }
     );
+  });
+
+  describe('deprecations: telemetry.enabled', () => {
+    describe('when telemetry.enabled is set to a falsy value, the plugin stays enabled and telemetry is opted out', () => {
+      test.each([false, 'false', 'False', 'FALSE'])(
+        'migrates telemetry.enabled: %p → removes enabled, sets optIn and allowChangingOptInStatus to false',
+        (enabledValue) => {
+          const migrated = applyConfigDeprecations({ enabled: enabledValue });
+
+          expect(migrated.telemetry.enabled).toBeUndefined();
+          expect(migrated.telemetry.optIn).toBe(false);
+          expect(migrated.telemetry.allowChangingOptInStatus).toBe(false);
+        }
+      );
+
+      test.each([false, 'false', 'False', 'FALSE'])(
+        'also disables tracing and metrics when telemetry.enabled: %p',
+        (enabledValue) => {
+          const migrated = applyConfigDeprecations({ enabled: enabledValue });
+
+          const telemetry = migrated.telemetry as Record<string, Record<string, unknown>>;
+          expect(telemetry.tracing?.enabled).toBe(false);
+          expect(telemetry.metrics?.enabled).toBe(false);
+        }
+      );
+    });
+
+    describe('when telemetry.enabled is absent or truthy, the deprecation does not fire', () => {
+      test('does not modify config when telemetry.enabled is not set', () => {
+        const migrated = applyConfigDeprecations({});
+
+        expect(migrated.telemetry.enabled).toBeUndefined();
+        expect(migrated.telemetry.optIn).toBeUndefined();
+        expect(migrated.telemetry.allowChangingOptInStatus).toBeUndefined();
+      });
+
+      test.each([true, 'true', 'True', 'TRUE'])(
+        'does not modify config when telemetry.enabled: %p',
+        (enabledValue) => {
+          const migrated = applyConfigDeprecations({ enabled: enabledValue });
+
+          expect(migrated.telemetry.enabled).toBe(enabledValue);
+          expect(migrated.telemetry.optIn).toBeUndefined();
+          expect(migrated.telemetry.allowChangingOptInStatus).toBeUndefined();
+        }
+      );
+    });
   });
 });

--- a/src/platform/plugins/shared/telemetry/server/config/config.ts
+++ b/src/platform/plugins/shared/telemetry/server/config/config.ts
@@ -73,7 +73,11 @@ export const config: PluginConfigDescriptor<TelemetryConfigType> = {
   },
   deprecations: () => [
     (cfg) => {
-      if (cfg.telemetry?.enabled === false) {
+      const raw = cfg.telemetry?.enabled;
+      const isDisabling =
+        raw === false || (typeof raw === 'string' && raw.toLowerCase() === 'false');
+
+      if (isDisabling) {
         return {
           set: [
             { path: 'telemetry.optIn', value: false },

--- a/src/platform/plugins/shared/telemetry/tsconfig.json
+++ b/src/platform/plugins/shared/telemetry/tsconfig.json
@@ -41,6 +41,7 @@
     "@kbn/logging",
     "@kbn/core-security-server",
     "@kbn/telemetry-config",
+    "@kbn/config",
   ],
   "exclude": [
     "target/**/*",


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [Gracefully handle deprecated telemetry config (#266029)](https://github.com/elastic/kibana/pull/266029)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Eyo O. Eyo","email":"7893459+eokoneyo@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-04-28T16:07:25Z","message":"Gracefully handle deprecated telemetry config (#266029)\n\n## Summary\n\nInformed from [internal slack\nthread](https://elastic.slack.com/archives/C0D8P2XK5/p1777023957119899)\n\n`telemetry.enabled` is a deprecated config key. Its intended migration\npath is to translate a value of `false` into `telemetry.optIn: false` +\n`telemetry.allowChangingOptInStatus: false` and then remove the key, so\nthat the telemetry plugin itself continues to load while honoring the\nuser's intent to opt out. This allows dependent plugins — including\n`security_solution`, `fleet`, and others that declare `telemetry` as a\n`requiredPlugin` — to continue functioning normally.\n\n## The bug\n\nThe deprecation handler was checking for the disabled case with strict\nequality:\n\n```ts\nif (cfg.telemetry?.enabled === false) { ... }\n```\n\nThis did not account for the string `\"false\"`, which is a valid YAML\nvalue and one that `@kbn/config-schema`'s `schema.boolean()` type\nexplicitly coerces to the boolean `false`. The two systems run at\ndifferent moments in the startup pipeline:\n\n1. **Deprecations run first**, against the raw, pre-schema config object\ncoming directly from `kibana.yml`. At this point `\"false\"` is still a\nstring, so `\"false\" === false` evaluates to `false` and the migration is\nsilently skipped.\n2. **Schema validation runs second**, inside\n`ConfigService.isEnabledAtPath`. Here `schema.boolean()` coerces the\nstring `\"false\"` to the boolean `false`, causing `isEnabledAtPath` to\nreturn `false` and mark the plugin as disabled.\n\nBecause the plugin is disabled, every plugin that lists `telemetry` in\nits `requiredPlugins` is also transitively disabled — including\n`security_solution`, making it completely non-functional with no obvious\nerror pointing to the root cause.\n\n## The fix\n\nThe deprecation handler is updated to match any value that\n`schema.boolean()` would coerce to `false` — both the native boolean and\nany case-insensitive string variant — before schema validation has a\nchance to run, this ensures the migration fires regardless of how the\nvalue is expressed in `kibana.yml` (`false`, `\"false\"`, `\"False\"`,\n`\"FALSE\"`), removes `telemetry.enabled` from the config before\n`isEnabledAtPath` inspects it, and applies the correct opt-out semantics\nvia `optIn` and `allowChangingOptInStatus`. The OpenTelemetry\nsub-configs (`tracing.enabled`, `metrics.enabled`) are also set to\n`false` for consistency.\n\n## Tests\n\nA new `deprecations: telemetry.enabled` suite is added to\n`config.test.ts`. It drives the deprecation function directly through\n`applyDeprecations` (the same code path core uses at startup), and\nasserts:\n\n- All four falsy variants (`false`, `\"false\"`, `\"False\"`, `\"FALSE\"`)\ntrigger the migration, unset `enabled`, and correctly populate `optIn`,\n`allowChangingOptInStatus`, `tracing.enabled`, and `metrics.enabled`.\n- Absent or truthy values (`undefined`, `true`, `\"true\"`, `\"True\"`,\n`\"TRUE\"`) leave the config unchanged.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"6f3c8892b7bbc83cc9b4bd0f4eda8b3f4ea536eb","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Core","release_note:skip","backport:all-open","v9.4.0","v9.5.0","v9.3.4","v9.2.9"],"title":"Gracefully handle deprecated telemetry config","number":266029,"url":"https://github.com/elastic/kibana/pull/266029","mergeCommit":{"message":"Gracefully handle deprecated telemetry config (#266029)\n\n## Summary\n\nInformed from [internal slack\nthread](https://elastic.slack.com/archives/C0D8P2XK5/p1777023957119899)\n\n`telemetry.enabled` is a deprecated config key. Its intended migration\npath is to translate a value of `false` into `telemetry.optIn: false` +\n`telemetry.allowChangingOptInStatus: false` and then remove the key, so\nthat the telemetry plugin itself continues to load while honoring the\nuser's intent to opt out. This allows dependent plugins — including\n`security_solution`, `fleet`, and others that declare `telemetry` as a\n`requiredPlugin` — to continue functioning normally.\n\n## The bug\n\nThe deprecation handler was checking for the disabled case with strict\nequality:\n\n```ts\nif (cfg.telemetry?.enabled === false) { ... }\n```\n\nThis did not account for the string `\"false\"`, which is a valid YAML\nvalue and one that `@kbn/config-schema`'s `schema.boolean()` type\nexplicitly coerces to the boolean `false`. The two systems run at\ndifferent moments in the startup pipeline:\n\n1. **Deprecations run first**, against the raw, pre-schema config object\ncoming directly from `kibana.yml`. At this point `\"false\"` is still a\nstring, so `\"false\" === false` evaluates to `false` and the migration is\nsilently skipped.\n2. **Schema validation runs second**, inside\n`ConfigService.isEnabledAtPath`. Here `schema.boolean()` coerces the\nstring `\"false\"` to the boolean `false`, causing `isEnabledAtPath` to\nreturn `false` and mark the plugin as disabled.\n\nBecause the plugin is disabled, every plugin that lists `telemetry` in\nits `requiredPlugins` is also transitively disabled — including\n`security_solution`, making it completely non-functional with no obvious\nerror pointing to the root cause.\n\n## The fix\n\nThe deprecation handler is updated to match any value that\n`schema.boolean()` would coerce to `false` — both the native boolean and\nany case-insensitive string variant — before schema validation has a\nchance to run, this ensures the migration fires regardless of how the\nvalue is expressed in `kibana.yml` (`false`, `\"false\"`, `\"False\"`,\n`\"FALSE\"`), removes `telemetry.enabled` from the config before\n`isEnabledAtPath` inspects it, and applies the correct opt-out semantics\nvia `optIn` and `allowChangingOptInStatus`. The OpenTelemetry\nsub-configs (`tracing.enabled`, `metrics.enabled`) are also set to\n`false` for consistency.\n\n## Tests\n\nA new `deprecations: telemetry.enabled` suite is added to\n`config.test.ts`. It drives the deprecation function directly through\n`applyDeprecations` (the same code path core uses at startup), and\nasserts:\n\n- All four falsy variants (`false`, `\"false\"`, `\"False\"`, `\"FALSE\"`)\ntrigger the migration, unset `enabled`, and correctly populate `optIn`,\n`allowChangingOptInStatus`, `tracing.enabled`, and `metrics.enabled`.\n- Absent or truthy values (`undefined`, `true`, `\"true\"`, `\"True\"`,\n`\"TRUE\"`) leave the config unchanged.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"6f3c8892b7bbc83cc9b4bd0f4eda8b3f4ea536eb"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/266169","number":266169,"state":"MERGED","mergeCommit":{"sha":"4610967af866b4d2edc9256af84714fab30ca88d","message":"[9.4] Gracefully handle deprecated telemetry config (#266029) (#266169)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.4`:\n- [Gracefully handle deprecated telemetry config\n(#266029)](https://github.com/elastic/kibana/pull/266029)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Eyo O. Eyo <7893459+eokoneyo@users.noreply.github.com>"}},{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/266029","number":266029,"mergeCommit":{"message":"Gracefully handle deprecated telemetry config (#266029)\n\n## Summary\n\nInformed from [internal slack\nthread](https://elastic.slack.com/archives/C0D8P2XK5/p1777023957119899)\n\n`telemetry.enabled` is a deprecated config key. Its intended migration\npath is to translate a value of `false` into `telemetry.optIn: false` +\n`telemetry.allowChangingOptInStatus: false` and then remove the key, so\nthat the telemetry plugin itself continues to load while honoring the\nuser's intent to opt out. This allows dependent plugins — including\n`security_solution`, `fleet`, and others that declare `telemetry` as a\n`requiredPlugin` — to continue functioning normally.\n\n## The bug\n\nThe deprecation handler was checking for the disabled case with strict\nequality:\n\n```ts\nif (cfg.telemetry?.enabled === false) { ... }\n```\n\nThis did not account for the string `\"false\"`, which is a valid YAML\nvalue and one that `@kbn/config-schema`'s `schema.boolean()` type\nexplicitly coerces to the boolean `false`. The two systems run at\ndifferent moments in the startup pipeline:\n\n1. **Deprecations run first**, against the raw, pre-schema config object\ncoming directly from `kibana.yml`. At this point `\"false\"` is still a\nstring, so `\"false\" === false` evaluates to `false` and the migration is\nsilently skipped.\n2. **Schema validation runs second**, inside\n`ConfigService.isEnabledAtPath`. Here `schema.boolean()` coerces the\nstring `\"false\"` to the boolean `false`, causing `isEnabledAtPath` to\nreturn `false` and mark the plugin as disabled.\n\nBecause the plugin is disabled, every plugin that lists `telemetry` in\nits `requiredPlugins` is also transitively disabled — including\n`security_solution`, making it completely non-functional with no obvious\nerror pointing to the root cause.\n\n## The fix\n\nThe deprecation handler is updated to match any value that\n`schema.boolean()` would coerce to `false` — both the native boolean and\nany case-insensitive string variant — before schema validation has a\nchance to run, this ensures the migration fires regardless of how the\nvalue is expressed in `kibana.yml` (`false`, `\"false\"`, `\"False\"`,\n`\"FALSE\"`), removes `telemetry.enabled` from the config before\n`isEnabledAtPath` inspects it, and applies the correct opt-out semantics\nvia `optIn` and `allowChangingOptInStatus`. The OpenTelemetry\nsub-configs (`tracing.enabled`, `metrics.enabled`) are also set to\n`false` for consistency.\n\n## Tests\n\nA new `deprecations: telemetry.enabled` suite is added to\n`config.test.ts`. It drives the deprecation function directly through\n`applyDeprecations` (the same code path core uses at startup), and\nasserts:\n\n- All four falsy variants (`false`, `\"false\"`, `\"False\"`, `\"FALSE\"`)\ntrigger the migration, unset `enabled`, and correctly populate `optIn`,\n`allowChangingOptInStatus`, `tracing.enabled`, and `metrics.enabled`.\n- Absent or truthy values (`undefined`, `true`, `\"true\"`, `\"True\"`,\n`\"TRUE\"`) leave the config unchanged.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"6f3c8892b7bbc83cc9b4bd0f4eda8b3f4ea536eb"}},{"branch":"9.3","label":"v9.3.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/266168","number":266168,"state":"MERGED","mergeCommit":{"sha":"fdd4c41436ee3a13499d866d94ff88805b7ad9dc","message":"[9.3] Gracefully handle deprecated telemetry config (#266029) (#266168)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.3`:\n- [Gracefully handle deprecated telemetry config\n(#266029)](https://github.com/elastic/kibana/pull/266029)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Eyo O. Eyo <7893459+eokoneyo@users.noreply.github.com>"}},{"branch":"9.2","label":"v9.2.9","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/266167","number":266167,"state":"MERGED","mergeCommit":{"sha":"6a91826faf03a194ed2ab7845e3007be59f91e3f","message":"[9.2] Gracefully handle deprecated telemetry config (#266029) (#266167)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.2`:\n- [Gracefully handle deprecated telemetry config\n(#266029)](https://github.com/elastic/kibana/pull/266029)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Eyo O. Eyo <7893459+eokoneyo@users.noreply.github.com>"}}]}] BACKPORT-->