### PR TITLE
[Advanced settings] Prevent browser history pollution on search input keystroke

### DIFF
--- a/src/platform/packages/shared/kbn-management/settings/application/application.test.tsx
+++ b/src/platform/packages/shared/kbn-management/settings/application/application.test.tsx
@@ -60,6 +60,33 @@ describe('Settings application', () => {
     });
   });
 
+  it('calls addUrlToHistory once per change event when typing, not once per character', async () => {
+    const services: SettingsApplicationServices = createSettingsApplicationServicesMock();
+
+    const { getByTestId } = render(wrap(<SettingsApplication />, services));
+
+    const searchBar = getByTestId(DATA_TEST_SUBJ_SETTINGS_SEARCH_BAR);
+
+    // Simulate typing characters one at a time, as a user would
+    const characters = ['t', 'te', 'tes', 'test'];
+    for (const value of characters) {
+      act(() => {
+        fireEvent.change(searchBar, { target: { value } });
+      });
+    }
+
+    await waitFor(() => {
+      // addUrlToHistory must have been called exactly once per change event (one per character typed),
+      // never more — confirming we're replacing the history entry rather than pushing new ones.
+      expect(services.addUrlToHistory).toHaveBeenCalledTimes(characters.length);
+      // Each call should reflect the full current query at that point, not accumulate
+      expect(services.addUrlToHistory).toHaveBeenNthCalledWith(1, '?query=t');
+      expect(services.addUrlToHistory).toHaveBeenNthCalledWith(2, '?query=te');
+      expect(services.addUrlToHistory).toHaveBeenNthCalledWith(3, '?query=tes');
+      expect(services.addUrlToHistory).toHaveBeenNthCalledWith(4, '?query=test');
+    });
+  });
+
   it('renders the empty state when no settings match the query', async () => {
     const { getByTestId } = render(wrap(<SettingsApplication />));
 

--- a/src/platform/packages/shared/kbn-management/settings/application/application.test.tsx
+++ b/src/platform/packages/shared/kbn-management/settings/application/application.test.tsx
@@ -9,6 +9,7 @@
 
 import React from 'react';
 import { act, fireEvent, render, waitFor } from '@testing-library/react';
+import { of } from 'rxjs';
 import {
   SettingsApplication,
   DATA_TEST_SUBJ_SETTINGS_TITLE,
@@ -24,9 +25,33 @@ import { DATA_TEST_SUBJ_PREFIX_TAB } from './tab';
 import { DATA_TEST_SUBJ_SETTINGS_CATEGORY } from '@kbn/management-settings-components-field-category/category';
 import { wrap, createSettingsApplicationServicesMock } from './mocks';
 import type { SettingsApplicationServices } from './services';
+import { SettingsApplicationKibanaProvider } from './services';
+import { KibanaRootContextProvider } from '@kbn/react-kibana-context-root';
+import { userProfileServiceMock } from '@kbn/core-user-profile-browser-mocks';
+import type { Space } from '@kbn/spaces-plugin/common';
+import {
+  analyticsServiceMock,
+  applicationServiceMock,
+  chromeServiceMock,
+  docLinksServiceMock,
+  i18nServiceMock,
+  notificationServiceMock,
+  scopedHistoryMock,
+  themeServiceMock,
+  uiSettingsServiceMock,
+} from '@kbn/core/public/mocks';
 
 const spaceCategories = ['general', 'dashboard', 'notifications'];
 const globalCategories = ['custom branding'];
+
+const createRootMock = () => {
+  return {
+    analytics: analyticsServiceMock.createAnalyticsServiceStart(),
+    i18n: i18nServiceMock.createStartContract(),
+    theme: themeServiceMock.createStartContract(),
+    userProfile: userProfileServiceMock.createStart(),
+  };
+};
 
 describe('Settings application', () => {
   beforeEach(() => {
@@ -45,45 +70,67 @@ describe('Settings application', () => {
     }
   });
 
-  it('fires addUrlToHistory when a query is typed in the search bar', async () => {
-    const services: SettingsApplicationServices = createSettingsApplicationServicesMock();
+  it('replaces history while typing so browser back does not step through each character', async () => {
+    const history = scopedHistoryMock.create({ pathname: '', search: '' });
+    const activeSpace: Space = {
+      id: 'default',
+      name: 'Default',
+      disabledFeatures: [],
+      solution: 'classic',
+    };
+    const application = applicationServiceMock.createStartContract();
+    application.capabilities = {
+      advancedSettings: { show: true, save: true },
+      globalSettings: { show: true, save: true },
+      filterSettings: { bySolutionView: false },
+    } as any;
 
-    const { getByTestId } = render(wrap(<SettingsApplication />, services));
+    const { getByTestId } = render(
+      <KibanaRootContextProvider {...createRootMock()}>
+        <SettingsApplicationKibanaProvider
+          docLinks={docLinksServiceMock.createStartContract()}
+          notifications={{ toasts: notificationServiceMock.createStartContract().toasts }}
+          userProfile={userProfileServiceMock.createStart()}
+          theme={themeServiceMock.createStartContract()}
+          i18n={i18nServiceMock.createStartContract()}
+          settings={{
+            client: uiSettingsServiceMock.createStartContract(),
+            globalClient: uiSettingsServiceMock.createStartContract(),
+          }}
+          history={history}
+          sectionRegistry={{
+            getSpacesSections: () => [],
+            getGlobalSections: () => [],
+          }}
+          application={application}
+          chrome={chromeServiceMock.createStartContract()}
+          spaces={{
+            getActiveSpace: () => Promise.resolve(activeSpace),
+            getActiveSpace$: () => of(activeSpace),
+          }}
+        >
+          <SettingsApplication />
+        </SettingsApplicationKibanaProvider>
+      </KibanaRootContextProvider>
+    );
 
     const searchBar = getByTestId(DATA_TEST_SUBJ_SETTINGS_SEARCH_BAR);
-    act(() => {
-      fireEvent.change(searchBar, { target: { value: 'test' } });
-    });
 
-    await waitFor(() => {
-      expect(services.addUrlToHistory).toHaveBeenCalledWith('?query=test');
-    });
-  });
-
-  it('calls addUrlToHistory once per change event when typing, not once per character', async () => {
-    const services: SettingsApplicationServices = createSettingsApplicationServicesMock();
-
-    const { getByTestId } = render(wrap(<SettingsApplication />, services));
-
-    const searchBar = getByTestId(DATA_TEST_SUBJ_SETTINGS_SEARCH_BAR);
-
-    // Simulate typing characters one at a time, as a user would
-    const characters = ['t', 'te', 'tes', 'test'];
-    for (const value of characters) {
+    // Simulate typing characters one at a time, as a user would.
+    const valuesByKeystroke = ['t', 'te', 'tes', 'test'];
+    for (const value of valuesByKeystroke) {
       act(() => {
         fireEvent.change(searchBar, { target: { value } });
       });
     }
 
     await waitFor(() => {
-      // addUrlToHistory must have been called exactly once per change event (one per character typed),
-      // never more — confirming we're replacing the history entry rather than pushing new ones.
-      expect(services.addUrlToHistory).toHaveBeenCalledTimes(characters.length);
-      // Each call should reflect the full current query at that point, not accumulate
-      expect(services.addUrlToHistory).toHaveBeenNthCalledWith(1, '?query=t');
-      expect(services.addUrlToHistory).toHaveBeenNthCalledWith(2, '?query=te');
-      expect(services.addUrlToHistory).toHaveBeenNthCalledWith(3, '?query=tes');
-      expect(services.addUrlToHistory).toHaveBeenNthCalledWith(4, '?query=test');
+      expect(history.push).not.toHaveBeenCalled();
+      expect(history.replace).toHaveBeenCalledTimes(valuesByKeystroke.length);
+      expect(history.replace).toHaveBeenNthCalledWith(1, { pathname: '', search: '?query=t' });
+      expect(history.replace).toHaveBeenNthCalledWith(2, { pathname: '', search: '?query=te' });
+      expect(history.replace).toHaveBeenNthCalledWith(3, { pathname: '', search: '?query=tes' });
+      expect(history.replace).toHaveBeenNthCalledWith(4, { pathname: '', search: '?query=test' });
     });
   });
 

--- a/src/platform/packages/shared/kbn-management/settings/application/moon.yml
+++ b/src/platform/packages/shared/kbn-management/settings/application/moon.yml
@@ -37,6 +37,7 @@ dependsOn:
   - '@kbn/core-chrome-browser'
   - '@kbn/core-user-profile-browser-mocks'
   - '@kbn/spaces-plugin'
+  - '@kbn/core'
 tags:
   - shared-browser
   - package

--- a/src/platform/packages/shared/kbn-management/settings/application/services.tsx
+++ b/src/platform/packages/shared/kbn-management/settings/application/services.tsx
@@ -218,7 +218,7 @@ export const SettingsApplicationKibanaProvider: FC<
     isCustomSetting,
     isOverriddenSetting,
     subscribeToUpdates,
-    addUrlToHistory: (url: string) => history.push({ pathname: '', search: url }),
+    addUrlToHistory: (url: string) => history.replace({ pathname: '', search: url }),
     getActiveSpace: spaces.getActiveSpace,
     subscribeToActiveSpace: (fn: () => void) => {
       return spaces.getActiveSpace$().subscribe(fn);

--- a/src/platform/packages/shared/kbn-management/settings/application/tsconfig.json
+++ b/src/platform/packages/shared/kbn-management/settings/application/tsconfig.json
@@ -37,5 +37,6 @@
     "@kbn/core-chrome-browser",
     "@kbn/core-user-profile-browser-mocks",
     "@kbn/spaces-plugin",
+    "@kbn/core",
   ]
 }


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/251672

## Summary
- Each keystroke in the Advanced Settings search bar was calling `history.push`, adding a new browser history entry per character typed. Pressing the back button would then step through each intermediate query state instead of navigating away from the page.
- Fixed by switching from `history.push` to `history.replace` in `addUrlToHistory`, so each keystroke replaces the current history entry rather than stacking a new one.

### Test plan
- Manual: Navigate to Stack Management → Advanced Settings. Type a multi-character query in the search bar. Press the browser back button — the page should navigate away in a single click.
- Automated: Added a Jest unit test in `application.test.tsx` that simulates typing a query character by character and asserts `addUrlToHistory` is called exactly once per change event, with the correct full query string each time. Run with:
  `node scripts/jest src/platform/packages/shared/kbn-management/settings/application/application.test.tsx`

### Evidence 
- See the screen recording attached to the original issue report for the "Before" behavior.
- After applying the fix, a single back-button click navigates away from the page even after typing a multi-character query.


https://github.com/user-attachments/assets/763c144e-c157-44eb-976d-1d71786c168a




<!--ONMERGE {"backportTargets":["8.19","9.2","9.3","9.4"]} ONMERGE-->