### PR TITLE
[9.4] [CI] Parallelize bootstrap and artifact download in CI steps (#263470)

### DIFF
--- a/.buildkite/scripts/build_kibana.sh
+++ b/.buildkite/scripts/build_kibana.sh
@@ -4,8 +4,9 @@ set -euo pipefail
 
 source .buildkite/scripts/common/util.sh
 
-echo "--- Clean up cached images to free up space"
-clean_cached_images
+echo "--- Clean up cached images to free up space (running in background)"
+clean_cached_images >/dev/null 2>&1 &
+cleanup_pid=$!
 
 export KBN_NP_PLUGINS_BUILT=true
 
@@ -21,11 +22,11 @@ is_pr_with_label "ci:build-cdn-assets" || BUILD_ARGS+=("--skip-cdn-assets")
 echo "> node scripts/build" "${BUILD_ARGS[@]}"
 node scripts/build "${BUILD_ARGS[@]}"
 
+# Ensure docker cleanup finished before archiving
+wait $cleanup_pid || true
+
 echo "--- Archive Kibana Distribution"
 version="$(jq -r '.version' package.json)"
 linuxBuild="$KIBANA_DIR/target/kibana-$version-SNAPSHOT-linux-x86_64.tar.zst"
-installDir="$KIBANA_DIR/install/kibana"
-mkdir -p "$installDir"
-tar -xf "$linuxBuild" -I zstd -C "$installDir" --strip=1
 mkdir -p "$KIBANA_BUILD_LOCATION"
-cp -pR install/kibana/. "$KIBANA_BUILD_LOCATION/"
+tar -xf "$linuxBuild" -I zstd -C "$KIBANA_BUILD_LOCATION" --strip=1

--- a/.buildkite/scripts/steps/functional/common.sh
+++ b/.buildkite/scripts/steps/functional/common.sh
@@ -10,8 +10,30 @@ source .buildkite/scripts/common/util.sh
 # so dev-mode webpack bundles built during bootstrap are never used.
 export KBN_BOOTSTRAP_NO_PREBUILT=true
 
-.buildkite/scripts/bootstrap.sh
-.buildkite/scripts/download_build_artifacts.sh
+# Bootstrap and artifact download are independent — run them in parallel.
+# Bootstrap installs node_modules; the download fetches the pre-built Kibana distributable.
+download_log=$(mktemp)
+.buildkite/scripts/download_build_artifacts.sh >"$download_log" 2>&1 &
+download_pid=$!
+
+bootstrap_exit=0
+.buildkite/scripts/bootstrap.sh || bootstrap_exit=$?
+
+download_exit=0
+wait $download_pid || download_exit=$?
+
+cat "$download_log"
+rm -f "$download_log"
+
+if [[ $bootstrap_exit -ne 0 ]]; then
+  echo "Bootstrap failed with exit code $bootstrap_exit"
+  exit $bootstrap_exit
+fi
+
+if [[ $download_exit -ne 0 ]]; then
+  echo "Artifact download failed with exit code $download_exit"
+  exit $download_exit
+fi
 .buildkite/scripts/setup_es_snapshot_cache.sh
 
 is_test_execution_step


### PR DESCRIPTION
## Summary

Backport of #263470 to 9.4.

Excludes the `custom-checkout` plugin change in `base.yml` which is incompatible with version branches — moon's git VCS operations fail with `fatal: ambiguous argument '9.4'` in shallow single-branch clones on non-main branches.

### Changes included
- Parallelize bootstrap and artifact download in `common.sh` (~33s saved per FTR step)
- Background docker image cleanup in `build_kibana.sh` (~21s saved)
- Simplify archive extraction in `build_kibana.sh` (~3s saved)

### Change excluded
- `base.yml` custom-checkout plugin (~15s saved, but breaks version-branch builds)

Replaces #265977.

Made with [Cursor](https://cursor.com)