### PR TITLE
[8.19] chore(deps): bump `dompurify` from `3.3.2` to `3.4.1` (#265833)

### DIFF
--- a/oas_docs/package-lock.json
+++ b/oas_docs/package-lock.json
@@ -1300,13 +1300,10 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.2.tgz",
-      "integrity": "sha512-6obghkliLdmKa56xdbLOpUZ43pAR6xFy1uOrxBaIDjT+yaRuuybLjGS9eVBoSR/UPU5fq3OXClEHLJNGvbxKpQ==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.1.tgz",
+      "integrity": "sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
-      "engines": {
-        "node": ">=20"
-      },
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }

--- a/package.json
+++ b/package.json
@@ -1180,7 +1180,7 @@
     "deepmerge": "4.3.1",
     "del": "6.1.1",
     "diff": "8.0.3",
-    "dompurify": "3.3.2",
+    "dompurify": "3.4.1",
     "dotenv": "17.2.4",
     "elastic-apm-node": "4.13.0",
     "email-addresses": "5.0.0",

--- a/src/dev/license_checker/config.ts
+++ b/src/dev/license_checker/config.ts
@@ -85,7 +85,7 @@ export const PER_PACKAGE_ALLOWED_LICENSES = {
   'openpgp@5.11.3': ['LGPL-3.0+'],
   '@img/sharp-libvips-linuxmusl-x64@1.2.3': ['LGPL-3.0-or-later'],
   '@img/sharp-libvips-linux-x64@1.2.3': ['LGPL-3.0-or-later'],
-  'dompurify@3.3.2': ['(MPL-2.0 OR Apache-2.0)'],
+  'dompurify@3.4.1': ['(MPL-2.0 OR Apache-2.0)'],
 };
 // Globally overrides a license for a given package@version
 export const LICENSE_OVERRIDES = {

--- a/src/platform/packages/private/kbn-ui-shared-deps-src/version_dependencies.txt
+++ b/src/platform/packages/private/kbn-ui-shared-deps-src/version_dependencies.txt
@@ -55,7 +55,7 @@ css-loader@7.1.2
 css-tree@1.1.3
 cssesc@3.0.0
 csstype@3.1.2
-dompurify@3.3.2
+dompurify@3.4.1
 electron-to-chromium@1.5.321
 enhanced-resolve@5.20.0
 error-stack-parser@2.0.6

--- a/yarn.lock
+++ b/yarn.lock
@@ -18900,10 +18900,10 @@ domhandler@^5.0.1, domhandler@^5.0.2, domhandler@^5.0.3:
   dependencies:
     domelementtype "^2.3.0"
 
-dompurify@3.3.2, dompurify@^3.2.4:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.3.2.tgz#58c515d0f8508b8749452a028aa589ad80b36325"
-  integrity sha512-6obghkliLdmKa56xdbLOpUZ43pAR6xFy1uOrxBaIDjT+yaRuuybLjGS9eVBoSR/UPU5fq3OXClEHLJNGvbxKpQ==
+dompurify@3.4.1, dompurify@^3.2.4:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.4.1.tgz#521d04483ac12631b2aedf434a5f5390933b8789"
+  integrity sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==
   optionalDependencies:
     "@types/trusted-types" "^2.0.7"
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [chore(deps): bump `dompurify` from `3.3.2` to `3.4.1` (#265833)](https://github.com/elastic/kibana/pull/265833)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Aleh Zasypkin","email":"aleh.zasypkin@elastic.co"},"sourceCommit":{"committedDate":"2026-04-29T07:31:08Z","message":"chore(deps): bump `dompurify` from `3.3.2` to `3.4.1` (#265833)\n\n## Summary\n\nBump `dompurify` from `3.3.2` to `3.4.1`.","sha":"47728d62d3b26c91d8421ac546b010529a620b7b","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","dependencies","backport:all-open","v9.5.0"],"title":"chore(deps): bump `dompurify` from `3.3.2` to `3.4.1`","number":265833,"url":"https://github.com/elastic/kibana/pull/265833","mergeCommit":{"message":"chore(deps): bump `dompurify` from `3.3.2` to `3.4.1` (#265833)\n\n## Summary\n\nBump `dompurify` from `3.3.2` to `3.4.1`.","sha":"47728d62d3b26c91d8421ac546b010529a620b7b"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/265833","number":265833,"mergeCommit":{"message":"chore(deps): bump `dompurify` from `3.3.2` to `3.4.1` (#265833)\n\n## Summary\n\nBump `dompurify` from `3.3.2` to `3.4.1`.","sha":"47728d62d3b26c91d8421ac546b010529a620b7b"}},{"url":"https://github.com/elastic/kibana/pull/266276","number":266276,"branch":"9.4","state":"OPEN"}]}] BACKPORT-->