### PR TITLE
chore(eslint): enforce some accessibility-related rules at the `error` level

### DIFF
--- a/packages/kbn-eslint-config/.eslintrc.js
+++ b/packages/kbn-eslint-config/.eslintrc.js
@@ -391,5 +391,12 @@ module.exports = {
         message: 'For client-side, please use `useEuiTheme` instead.',
       },
     ],
+
+    /**
+     * a11y-related rules:
+     * all existing violations were fixed; keep this as error to prevent new ones.
+     */
+    '@elastic/eui/prefer-eui-icon-tip': 'error',
+    '@elastic/eui/sr-output-disabled-tooltip': 'error',
   },
 };


### PR DESCRIPTION
## Summary

This PR enforces two accessibility (a11y) related ESLint rules at the `error` level in the shared `@kbn/eslint-config` configuration:

- **`@elastic/eui/prefer-eui-icon-tip`** — ensures `EuiIconTip` is preferred over manual icon+tooltip implementations for better accessibility.
- **`@elastic/eui/sr-output-disabled-tooltip`** — ensures disabled tooltips have accessible screen reader output.

All pre-existing violations of these rules have been fixed prior to this change. Setting them to `error` (instead of `warn` or off) prevents future regressions.

### Changes

- `packages/kbn-eslint-config/.eslintrc.js`: Added the two rules under the `a11y-related rules` comment block.