### PR TITLE
[Agent Builder] increase cycle quota and add reminder

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/action_utils.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/action_utils.ts
@@ -42,14 +42,16 @@ const stripLangGraphErrorSuffix = (content: string): string =>
   content.replace(LANGGRAPH_ERROR_SUFFIX, '');
 
 export const processResearchResponse = (
-  message: AIMessageChunk
+  message: AIMessageChunk,
+  { cycle }: { cycle: number }
 ): ToolCallAction | HandoverAction | AgentErrorAction => {
   const textContent = extractTextContent(message);
   if (message.tool_calls?.length) {
-    return toolCallAction(
-      extractToolCallsWithReasoning(message),
-      textContent.trim().length ? textContent : undefined
-    );
+    return toolCallAction({
+      toolCalls: extractToolCallsWithReasoning(message),
+      message: textContent.trim().length ? textContent : undefined,
+      cycle,
+    });
   } else {
     if (textContent) {
       return handoverAction(textContent);
@@ -73,7 +75,8 @@ export const processResearchResponse = (
  * - All interrupted tools are returned as a single `ToolPromptAction` containing all prompts
  */
 export const processToolNodeResponse = (
-  toolNodeResult: BaseMessage[]
+  toolNodeResult: BaseMessage[],
+  { cycle }: { cycle: number }
 ): (ExecuteToolAction | ToolPromptAction)[] => {
   const toolMessages = toolNodeResult.filter(isToolMessage);
 
@@ -93,13 +96,14 @@ export const processToolNodeResponse = (
 
   if (completedMessages.length > 0) {
     actions.push(
-      executeToolAction(
-        completedMessages.map((msg) => ({
+      executeToolAction({
+        toolResults: completedMessages.map((msg) => ({
           toolCallId: msg.tool_call_id,
           content: stripLangGraphErrorSuffix(extractTextContent(msg)),
           artifact: msg.artifact,
-        }))
-      )
+        })),
+        cycle,
+      })
     );
   }
 

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/actions.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/actions.ts
@@ -40,11 +40,13 @@ export interface ToolCallAction {
   tool_call_group_id: string;
   tool_calls: ToolCallWithReasoning[];
   message?: string;
+  cycle?: number;
 }
 
 export interface ExecuteToolAction {
   type: AgentActionType.ExecuteTool;
   tool_results: ToolCallResult[];
+  cycle?: number;
 }
 
 export interface ToolPromptEntry {
@@ -141,22 +143,35 @@ export function errorAction(error: AgentBuilderAgentExecutionError): AgentErrorA
   };
 }
 
-export function toolCallAction(
-  toolCalls: ToolCallWithReasoning[],
-  message?: string
-): ToolCallAction {
+export function toolCallAction({
+  toolCalls,
+  message,
+  cycle,
+}: {
+  toolCalls: ToolCallWithReasoning[];
+  message?: string;
+  cycle?: number;
+}): ToolCallAction {
   return {
     type: AgentActionType.ToolCall,
     tool_calls: toolCalls,
     tool_call_group_id: uuidv4(),
     message,
+    cycle,
   };
 }
 
-export function executeToolAction(toolResults: ToolCallResult[]): ExecuteToolAction {
+export function executeToolAction({
+  toolResults,
+  cycle,
+}: {
+  toolResults: ToolCallResult[];
+  cycle?: number;
+}): ExecuteToolAction {
   return {
     type: AgentActionType.ExecuteTool,
     tool_results: toolResults,
+    cycle,
   };
 }
 

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/answer_agent_structured.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/answer_agent_structured.ts
@@ -75,6 +75,7 @@ export const createAnswerAgentStructured = ({
       const prompt = await promptFactory.getStructuredAnswerPrompt({
         actions: state.mainActions,
         answerActions: state.answerActions,
+        cycleLimit: state.cycleLimit,
       });
 
       let response = await structuredModel.invoke(prompt);

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/graph.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/graph.ts
@@ -121,15 +121,17 @@ export const createAgentGraph = ({
     try {
       const response = await researcherModel.invoke(
         await promptFactory.getMainPrompt({
+          cycleLimit: state.cycleLimit,
           actions: state.mainActions,
         })
       );
 
-      const action = processResearchResponse(response);
+      const currentCycle = state.currentCycle + 1;
+      const action = processResearchResponse(response, { cycle: currentCycle });
 
       return {
         mainActions: [action],
-        currentCycle: state.currentCycle + 1,
+        currentCycle,
         errorCount: 0,
       };
     } catch (error) {
@@ -183,7 +185,7 @@ export const createAgentGraph = ({
 
     const toolCallMessage = createToolCallMessage(lastAction.tool_calls, lastAction.message);
     const toolNodeResult = await toolNode.invoke([toolCallMessage], {});
-    const actions = processToolNodeResponse(toolNodeResult);
+    const actions = processToolNodeResponse(toolNodeResult, { cycle: state.currentCycle });
 
     return {
       mainActions: actions,

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/graph.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/graph.ts
@@ -237,6 +237,7 @@ export const createAgentGraph = ({
         await promptFactory.getAnswerPrompt({
           actions: state.mainActions,
           answerActions: state.answerActions,
+          cycleLimit: state.cycleLimit,
         })
       );
 

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/prompts/answer_agent.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/prompts/answer_agent.ts
@@ -21,7 +21,7 @@ type AnswerAgentPromptParams = PromptFactoryParams & AnswerAgentPromptRuntimePar
 export const getAnswerAgentPrompt = async (
   params: AnswerAgentPromptParams
 ): Promise<BaseMessageLike[]> => {
-  const { actions, answerActions, processedConversation, resultTransformer } = params;
+  const { actions, cycleLimit, answerActions, processedConversation, resultTransformer } = params;
 
   // Generate messages from the conversation's rounds, with optional compaction summary
   // sourced from processedConversation.compactionSummary (set during compaction phase).
@@ -34,7 +34,7 @@ export const getAnswerAgentPrompt = async (
   return [
     ['system', getAnswerSystemMessage(params)],
     ...previousRoundsAsMessages,
-    ...formatResearcherActionHistory({ actions }),
+    ...formatResearcherActionHistory({ actions, cycleLimit }),
     ...formatAnswerActionHistory({ actions: answerActions }),
   ];
 };
@@ -109,6 +109,7 @@ export const getStructuredAnswerPrompt = async (
     answerActions,
     capabilities,
     processedConversation,
+    cycleLimit,
     resultTransformer,
   } = params;
   const { attachmentTypes, versionedAttachmentPresentation } = processedConversation;
@@ -170,7 +171,7 @@ ${visEnabled ? renderVisualizationPrompt() : 'No custom renderers available'}
 - [ ] No internal tool process or names revealed (unless user asked).`),
     ],
     ...previousRoundsAsMessages,
-    ...formatResearcherActionHistory({ actions }),
+    ...formatResearcherActionHistory({ actions, cycleLimit }),
     ...formatAnswerActionHistory({ actions: answerActions }),
   ];
 };

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/prompts/research_agent.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/prompts/research_agent.ts
@@ -22,7 +22,7 @@ type ResearchAgentPromptParams = PromptFactoryParams & ResearchAgentPromptRuntim
 export const getResearchAgentPrompt = async (
   params: ResearchAgentPromptParams
 ): Promise<BaseMessageLike[]> => {
-  const { actions, processedConversation, resultTransformer } = params;
+  const { actions, cycleLimit, processedConversation, resultTransformer } = params;
 
   // Generate messages from the conversation's rounds, optionally
   // injecting a compaction summary for older compacted rounds.
@@ -37,7 +37,7 @@ export const getResearchAgentPrompt = async (
   return [
     ['system', await getAgentSystemMessage(params)],
     ...previousRoundsAsMessages,
-    ...formatResearcherActionHistory({ actions }),
+    ...formatResearcherActionHistory({ actions, cycleLimit }),
   ];
 };
 

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/prompts/types.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/prompts/types.ts
@@ -30,6 +30,7 @@ export interface PromptFactoryParams {
 }
 
 export interface ResearchAgentPromptRuntimeParams {
+  cycleLimit: number;
   actions: ResearchAgentAction[];
 }
 

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/prompts/types.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/prompts/types.ts
@@ -35,6 +35,7 @@ export interface ResearchAgentPromptRuntimeParams {
 }
 
 export interface AnswerAgentPromptRuntimeParams {
+  cycleLimit: number;
   actions: ResearchAgentAction[];
   answerActions: AnswerAgentAction[];
 }

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/prompts/utils/actions.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/prompts/utils/actions.test.ts
@@ -76,7 +76,7 @@ describe('formatResearcherActionHistory', () => {
       makeExecuteToolAction([{ toolCallId: 'c1', content: 'result' }]),
     ];
 
-    const messages = formatResearcherActionHistory({ actions });
+    const messages = formatResearcherActionHistory({ actions, cycleLimit: 100 });
 
     const aiMsg = messages[0];
     expect(isAIMessage(aiMsg as AIMessage)).toBe(true);
@@ -92,7 +92,7 @@ describe('formatResearcherActionHistory', () => {
       makeExecuteToolAction([{ toolCallId: 'c1', content: 'result' }]),
     ];
 
-    const messages = formatResearcherActionHistory({ actions });
+    const messages = formatResearcherActionHistory({ actions, cycleLimit: 100 });
 
     const aiMsg = messages[0];
     expect(isAIMessage(aiMsg as AIMessage)).toBe(true);
@@ -111,7 +111,7 @@ describe('formatResearcherActionHistory', () => {
       ]),
     ];
 
-    const messages = formatResearcherActionHistory({ actions });
+    const messages = formatResearcherActionHistory({ actions, cycleLimit: 100 });
 
     const aiMsg = messages[0] as AIMessage;
     expect(aiMsg.tool_calls).toHaveLength(2);
@@ -126,7 +126,7 @@ describe('formatResearcherActionHistory', () => {
       makeBackgroundExecutionCompleteAction(makeCompletedExecution()),
     ];
 
-    const messages = formatResearcherActionHistory({ actions });
+    const messages = formatResearcherActionHistory({ actions, cycleLimit: 100 });
 
     // Tool call (AI) + tool result + background notice (user message)
     const lastMessage = messages[messages.length - 1];
@@ -140,7 +140,7 @@ describe('formatResearcherActionHistory', () => {
       makeBackgroundExecutionCompleteAction(makeFailedExecution()),
     ];
 
-    const messages = formatResearcherActionHistory({ actions });
+    const messages = formatResearcherActionHistory({ actions, cycleLimit: 100 });
 
     expect(messages).toHaveLength(1);
     expect(isHumanMessage(messages[0] as any)).toBe(true);

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/prompts/utils/actions.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/prompts/utils/actions.ts
@@ -34,8 +34,10 @@ import {
 
 export const formatResearcherActionHistory = ({
   actions,
+  cycleLimit,
 }: {
   actions: ResearchAgentAction[];
+  cycleLimit: number;
 }): BaseMessageLike[] => {
   const formatted: BaseMessageLike[] = [];
 
@@ -56,6 +58,12 @@ export const formatResearcherActionHistory = ({
           createToolResultMessage({ content: result.content, toolCallId: result.toolCallId })
         )
       );
+
+      // Add system reminder about being close to the limit when only 5 cycles left.
+      const remainingCycles = cycleLimit - action.cycle!;
+      if (remainingCycles === 5 || remainingCycles === 1) {
+        formatted.push(createCycleLimitSystemMessage(remainingCycles));
+      }
     }
     if (isHandoverAction(action)) {
       // returns a single [AI, user] tuple
@@ -71,6 +79,14 @@ export const formatResearcherActionHistory = ({
   }
 
   return formatted;
+};
+
+const createCycleLimitSystemMessage = (cycle: number): BaseMessage => {
+  return createUserMessage(`<system-notice>
+You action budget is almost expired for that round. You only have ${cycle} cycles (tool calls) left before the execution will be terminated.
+Finish what you are doing in that budget and proceed to respond to the user before reaching the end of the cycles.
+Interrupt your current action if necessary to make sure you finish before termination.
+</system-notice>`);
 };
 
 export const formatAnswerActionHistory = ({

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/run_chat_agent.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/run_chat_agent.ts
@@ -68,7 +68,7 @@ export type RunChatAgentFn = (
 /*
  * Max number of agent cycles allowed before forcing an answer.
  */
-const CYCLE_LIMIT = 15;
+const CYCLE_LIMIT = 30;
 
 /**
  * Create the handler function for the default agentBuilder agent.
@@ -430,6 +430,6 @@ const createInitializerCommand = ({
 
 const getRecursionLimit = (cycleLimit: number): number => {
   // langchain's recursionLimit is basically the number of nodes we can traverse before hitting a recursion limit error
-  // we have two steps per cycle (agent node + tool call node), and then a few other steps (prepare + answering), and some extra buffer
-  return cycleLimit * 2 + 8;
+  // in practice we have three steps per cycle (agent node + tool call node + background work), and then a few other steps (prepare + answering), and some extra buffer
+  return Math.ceil(cycleLimit * 3.5 + 20);
 };

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/utils/round_to_actions.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/utils/round_to_actions.ts
@@ -31,38 +31,38 @@ export const roundToActions = ({
 
     if (completed.length > 0) {
       actions.push(
-        toolCallAction(
-          completed.map((step) => ({
+        toolCallAction({
+          toolCalls: completed.map((step) => ({
             toolName: toolIdMapping.get(step.tool_id) ?? step.tool_id,
             toolCallId: step.tool_call_id,
             args: step.params,
             reasoning: getStepReasoning(reasoningSteps, step.tool_call_id),
           })),
-          groupMessage
-        )
+          message: groupMessage,
+        })
       );
       actions.push(
-        executeToolAction(
-          completed.map((step) => ({
+        executeToolAction({
+          toolResults: completed.map((step) => ({
             toolCallId: step.tool_call_id,
             content: JSON.stringify({ results: step.results }),
             artifact: { results: step.results },
-          }))
-        )
+          })),
+        })
       );
     }
 
     if (pending.length > 0) {
       actions.push(
-        toolCallAction(
-          pending.map((step) => ({
+        toolCallAction({
+          toolCalls: pending.map((step) => ({
             toolName: toolIdMapping.get(step.tool_id) ?? step.tool_id,
             toolCallId: step.tool_call_id,
             args: step.params,
             reasoning: getStepReasoning(reasoningSteps, step.tool_call_id),
           })),
-          groupMessage
-        )
+          message: groupMessage,
+        })
       );
     }
   }


### PR DESCRIPTION
## Summary

- Increase the agent cycle limit from 15 to 30
- Fix the graph recursion limit count
- Expose a system reminder to the agent when cycle budget is running low

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->