### PR TITLE
[Agent Builder] [ESQL tool] create a visualization attachment instead of a `<visualization/>` tag

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/tools/custom_rendering.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/tools/custom_rendering.ts
@@ -7,11 +7,21 @@
 
 import type { ChartType } from '@kbn/visualization-utils';
 
+/**
+ * @deprecated Legacy renderer attributes for the `<visualization />` tag.
+ * New visualization rendering should create a `visualization` attachment and
+ * render it with `<render_attachment />`.
+ */
 export interface VisualizationElementAttributes {
   toolResultId?: string;
   chartType?: ChartType;
 }
 
+/**
+ * @deprecated Legacy `<visualization />` custom-rendering tag.
+ * New visualization rendering should create a `visualization` attachment and
+ * render it with `renderAttachmentElement`.
+ */
 export const visualizationElement = {
   tagName: 'visualization',
   attributes: {

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/markdown_plugins/visualization_plugin.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/markdown_plugins/visualization_plugin.tsx
@@ -22,6 +22,11 @@ import { VisualizeESQL } from '../../../../tools/esql/visualize_esql';
 import { VisualizeLens } from '../../../../tools/esql/visualize_lens';
 import { createTagParser, findToolResult } from './utils';
 
+/**
+ * @deprecated Supports legacy `<visualization />` tags in existing conversations.
+ * New visualization rendering should use `create_visualization` to create a
+ * visualization attachment, then render it with `<render_attachment />`.
+ */
 export const visualizationTagParser = createTagParser({
   tagName: visualizationElement.tagName,
   getAttributes: (value, extractAttr) => ({
@@ -42,6 +47,11 @@ export const visualizationTagParser = createTagParser({
   }),
 });
 
+/**
+ * @deprecated Supports legacy `<visualization />` tags in existing conversations.
+ * New visualization rendering should use visualization attachments rendered via
+ * `<render_attachment />`.
+ */
 export function createVisualizationRenderer({
   startDependencies,
   stepsFromCurrentRound,

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/esql/visualize_esql/index.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/esql/visualize_esql/index.tsx
@@ -12,6 +12,7 @@ import React from 'react';
 import type { EsqlResults } from '@kbn/agent-builder-common/tools/tool_result';
 import type { TimeRange } from '@kbn/agent-builder-common';
 import type { UiActionsStart } from '@kbn/ui-actions-plugin/public';
+import { EuiBadge } from '@elastic/eui';
 import { useLensInput } from './use_lens_input';
 import { BaseVisualization } from '../shared/base_visualization';
 
@@ -43,12 +44,15 @@ export function VisualizeESQL({
   });
 
   return (
-    <BaseVisualization
-      lens={lens}
-      uiActions={uiActions}
-      lensInput={lensInput}
-      setLensInput={setLensInput}
-      isLoading={isLoading}
-    />
+    <>
+      <EuiBadge color="subdued">Legacy</EuiBadge>
+      <BaseVisualization
+        lens={lens}
+        uiActions={uiActions}
+        lensInput={lensInput}
+        setLensInput={setLensInput}
+        isLoading={isLoading}
+      />
+    </>
   );
 }

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/esql/visualize_lens/index.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/esql/visualize_lens/index.tsx
@@ -9,7 +9,7 @@ import type { DataViewsServicePublic } from '@kbn/data-views-plugin/public/types
 import type { LensPublicStart } from '@kbn/lens-plugin/public';
 import type { TimeRange } from '@kbn/es-query';
 import React from 'react';
-import { EuiCallOut } from '@elastic/eui';
+import { EuiBadge, EuiCallOut } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import type { UiActionsStart } from '@kbn/ui-actions-plugin/public';
 import { useLensInput } from './use_lens_input';
@@ -49,14 +49,16 @@ export function VisualizeLens({
       </EuiCallOut>
     );
   }
-
   return (
-    <BaseVisualization
-      lens={lens}
-      uiActions={uiActions}
-      lensInput={lensInput}
-      setLensInput={setLensInput}
-      isLoading={isLoading}
-    />
+    <>
+      <EuiBadge color="subdued">New attachment</EuiBadge>
+      <BaseVisualization
+        lens={lens}
+        uiActions={uiActions}
+        lensInput={lensInput}
+        setLensInput={setLensInput}
+        isLoading={isLoading}
+      />
+    </>
   );
 }

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/prompts/utils/visualizations.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/prompts/utils/visualizations.ts
@@ -5,46 +5,62 @@
  * 2.0.
  */
 
-import { ToolResultType } from '@kbn/agent-builder-common';
-import { visualizationElement } from '@kbn/agent-builder-common/tools/custom_rendering';
-import { ChartType } from '@kbn/visualization-utils';
+import { platformCoreTools, ToolResultType } from '@kbn/agent-builder-common';
+import { renderAttachmentElement } from '@kbn/agent-builder-common/tools/custom_rendering';
+import { SupportedChartType } from '@kbn/agent-builder-common/tools/tool_result';
 
 export const renderVisualizationPrompt = () => {
   const { esqlResults } = ToolResultType;
-  const { tagName, attributes } = visualizationElement;
-  const chartTypeNames = Object.values(ChartType)
+  const { tagName, attributes } = renderAttachmentElement;
+  const chartTypeNames = Object.values(SupportedChartType)
     .map((chartType) => `\`${chartType}\``)
     .join(', ');
 
-  return `### RENDERING VISUALIZATIONS
-      When a tool call returns a result of type "${esqlResults}", you may render a visualization in the UI by emitting a custom XML element:
+  return `### RENDERING VISUALIZATION ATTACHMENTS
+      When a tool call returns a result of type "${esqlResults}", you may render a visualization in the UI by creating a visualization attachment and emitting a custom XML element for that attachment:
 
-      <${tagName} ${attributes.toolResultId}="TOOL_RESULT_ID_HERE" />
+      <${tagName} ${attributes.attachmentId}="ATTACHMENT_ID_HERE" />
+
+      Use \`${platformCoreTools.createVisualization}\` to create the visualization attachment from the ES|QL result. Pass the ES|QL query from the tool result to \`${platformCoreTools.createVisualization}\` using its \`esql\` parameter. After \`${platformCoreTools.createVisualization}\` returns \`data.attachment_id\`, copy that attachment ID into the \`${attributes.attachmentId}\` attribute.
 
       **Rules**
-      * The \`<${tagName}>\` element must only be used to render tool results of type \`${esqlResults}\`.
-      * You can specify an optional chart type by adding the \`${attributes.chartType}\` attribute with one of the following values: ${chartTypeNames}.
-      * If the user does NOT specify a chart type in their message, you MUST omit the \`chart-type\` attribute. The system will choose an appropriate chart type automatically.
-      * You must copy the \`tool_result_id\` from the tool's response into the \`${attributes.toolResultId}\` element attribute verbatim.
-      * Do not invent, alter, or guess \`tool_result_id\`. You must use the exact id provided in the tool response.
+      * This rendering flow must only be used to render tool results of type \`${esqlResults}\`.
+      * Do not render \`${esqlResults}\` results directly with a custom visualization tag; render the visualization attachment with \`<${tagName}>\`.
+      * You can specify an optional chart type in the \`${platformCoreTools.createVisualization}\` call using one of the following values: ${chartTypeNames}.
+      * If the user does NOT specify a chart type in their message, omit \`chartType\`. The tool will choose an appropriate chart type automatically.
+      * You must copy the \`attachment_id\` from the \`${platformCoreTools.createVisualization}\` response into the \`${attributes.attachmentId}\` element attribute verbatim.
+      * Do not invent, alter, or guess \`attachment_id\`. You must use the exact id provided in the tool response.
       * You must not include any other attributes or content within the \`<${tagName}>\` element.
+      * If \`${platformCoreTools.createVisualization}\` does not return \`data.attachment_id\`, do not render an inline visualization; explain that the visualization could not be persisted as an attachment.
 
       **Example Usage:**
 
       Tool response includes:
       {
-        "tool_result_id": "LiDoF1",
+        "tool_result_id": "EsqlResult1",
         "type": "${esqlResults}",
         "data": {
-          "source": "esql",
           "query": "FROM traces-apm* | STATS count() BY BUCKET(@timestamp, 1h)",
-          "result": { "columns": [...], "values": [...] }
+          "columns": [...],
+          "values": [...]
+        }
+      }
+
+      First call \`${platformCoreTools.createVisualization}\`:
+      {
+        "query": "Show count over time",
+        "esql": "FROM traces-apm* | STATS count() BY BUCKET(@timestamp, 1h)"
+      }
+
+      The \`${platformCoreTools.createVisualization}\` response includes:
+      {
+        "type": "visualization",
+        "data": {
+          "attachment_id": "LiDoF1",
+          "version": 1
         }
       }
 
       To visualize this response your reply should be:
-      <${tagName} ${attributes.toolResultId}="LiDoF1"/>
-
-      To visualize this response as a bar chart your reply should be:
-      <${tagName} ${attributes.toolResultId}="LiDoF1" ${attributes.chartType}="${ChartType.Bar}"/>`;
+      <${tagName} ${attributes.attachmentId}="LiDoF1"/>`;
 };

--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/skills/visualization_creation_skill.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/skills/visualization_creation_skill.ts
@@ -69,7 +69,7 @@ Do **not** use this skill when:
 
 4. **Interpret output and preserve artifacts**
    - Save successful \`data.attachment_id\` values for follow-up operations.
-   - If the tool returns \`data.attachment_id\`, include that ID in your response so the visualization attachment can be rendered in the conversation.
+   - If the tool returns \`data.attachment_id\`, render that visualization inline with \`<render_attachment id="ATTACHMENT_ID"/>\` when the user should see the chart immediately.
    - If \`attachment_id\` is missing, report that persistence failed and treat the result as non-reusable.
 
 ## Inline Rendering Guidelines


### PR DESCRIPTION
## Summary

Updates Agent Builder visualization rendering guidance to stop creating new legacy `<visualization />` tags. When an ES|QL tool result should be visualized, the prompt now guides the agent to call `create_visualization`, use the returned `attachment_id`, and render the visualization through `<render_attachment id="..." />`.

Also marks the legacy `<visualization />` custom renderer as deprecated in code while preserving support for existing conversations that already contain those tags.

## Changes
Updated visualization prompt guidance to use visualization attachments instead of direct `<visualization />` rendering.
Updated visualization creation skill guidance to render returned visualization attachments with `<render_attachment />`.
Added deprecation comments for:
`visualizationElement`
`VisualizationElementAttributes`
`visualizationTagParser`
`createVisualizationRenderer`

### What Has Been Affected
1. New Agent Builder responses should stop emitting legacy <visualization tool-result-id="..." /> tags for ES|QL results.
2. ES|QL visualization flows should now go through create_visualization, create a visualization attachment, and render it with <render_attachment id="..." />.
3. Existing conversations that already contain <visualization /> tags should continue rendering, but that path is now marked deprecated.

### Example Prompts To Check

> Use ES|QL to query logs or metrics data, aggregate counts over time, and render the result as a bar chart.

> Create a metric showing the average flight ticket price.

> Use ES|QL to show request count over time from logs-* and visualize it.

> Run an ES|QL query for top 10 hosts by document count and show it as a bar chart.

> Create a line chart showing average system.cpu.total.pct over time grouped by host.name.

> Use ES|QL to validate the query first, then create a visualization from it.

Expected behavior: the agent should call create_visualization, then render the returned attachment with <render_attachment id="..." />, not emit <visualization tool-result-id="..." />.

To easily test, I've temporarily pushed a [commit](https://github.com/elastic/kibana/pull/266305/commits/174124a5bc216ba6a74e8827d826e665b8e1ec57) with badges, so you can see which one you actually are receiving. Once we finish testing, I'll revert this commit:

<img width="588" height="548" alt="Screenshot 2026-04-29 at 12 07 32" src="https://github.com/user-attachments/assets/62606f7a-450b-4784-8f99-545b6364d8d5" />
<img width="590" height="440" alt="Screenshot 2026-04-29 at 12 07 23" src="https://github.com/user-attachments/assets/c16e64c5-0999-4c23-b5ff-65fa2c6bd529" />

From now on, you should only receive 'New attachment' badges, no 'Legacy'