### PR TITLE
[Streams] Guard classic stream management page and doc count calls on index privileges

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_management/classic.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_management/classic.tsx
@@ -7,7 +7,7 @@
 import React from 'react';
 import { i18n } from '@kbn/i18n';
 import type { Streams } from '@kbn/streams-schema';
-import { EuiBadgeGroup, EuiFlexGroup, EuiToolTip } from '@elastic/eui';
+import { EuiBadgeGroup, EuiCallOut, EuiFlexGroup, EuiToolTip } from '@elastic/eui';
 import { useStreamsAppParams } from '../../../../hooks/use_streams_app_params';
 import { useStreamsPrivileges } from '../../../../hooks/use_streams_privileges';
 import { RedirectTo } from '../../../redirect_to';
@@ -75,6 +75,42 @@ export function ClassicStreamDetailManagement({
     definition,
     refreshDefinition,
   });
+
+  if (!definition.privileges.view_index_metadata) {
+    return (
+      <>
+        <StreamsAppPageTemplate.Header
+          bottomBorder="extended"
+          pageTitle={
+            <EuiFlexGroup gutterSize="s" alignItems="center">
+              {key}
+              <EuiBadgeGroup gutterSize="s">
+                <ClassicStreamBadge />
+                <LifecycleBadge lifecycle={definition.effective_lifecycle} />
+              </EuiBadgeGroup>
+            </EuiFlexGroup>
+          }
+        />
+        <StreamsAppPageTemplate.Body>
+          <EuiCallOut
+            announceOnMount
+            title={i18n.translate('xpack.streams.classicStreamOverview.noPrivileges.title', {
+              defaultMessage: "Data stream couldn't be loaded",
+            })}
+            color="danger"
+            iconType="error"
+          >
+            <p>
+              {i18n.translate('xpack.streams.classicStreamOverview.noPrivileges.description', {
+                defaultMessage:
+                  "You don't have the required privileges to view this stream. Make sure you have sufficient view_index_metadata privileges.",
+              })}
+            </p>
+          </EuiCallOut>
+        </StreamsAppPageTemplate.Body>
+      </>
+    );
+  }
 
   if (!definition.data_stream_exists) {
     return (

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_management/wrapper.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_management/wrapper.tsx
@@ -108,6 +108,8 @@ export function Wrapper({
     })
   );
 
+  const canMonitor = Streams.ingest.all.GetResponse.is(definition) && definition.privileges.monitor;
+
   const { getStreamDocCounts } = useStreamDocCountsFetch({
     groupTotalCountByTimestamp: false,
     getCanReadFailureStore: () =>
@@ -116,11 +118,21 @@ export function Wrapper({
         : false,
     numDataPoints: STREAMS_HISTOGRAM_NUM_DATA_POINTS,
   });
-  const docCountsFetch = getStreamDocCounts(streamId);
 
-  const countResult = useAsync(() => docCountsFetch.docCount, [docCountsFetch]);
-  const failedDocsResult = useAsync(() => docCountsFetch.failedDocCount, [docCountsFetch]);
-  const degradedDocsResult = useAsync(() => docCountsFetch.degradedDocCount, [docCountsFetch]);
+  const docCountsFetch = canMonitor ? getStreamDocCounts(streamId) : null;
+
+  const countResult = useAsync(
+    () => docCountsFetch?.docCount ?? Promise.resolve([]),
+    [docCountsFetch]
+  );
+  const failedDocsResult = useAsync(
+    () => docCountsFetch?.failedDocCount ?? Promise.resolve([]),
+    [docCountsFetch]
+  );
+  const degradedDocsResult = useAsync(
+    () => docCountsFetch?.degradedDocCount ?? Promise.resolve([]),
+    [docCountsFetch]
+  );
 
   const docCount = countResult?.value?.find((stat) => stat.stream === streamId)?.count ?? 0;
   const degradedDocCount =
@@ -177,17 +189,19 @@ export function Wrapper({
       ),
     });
   }
-  streamBadges.push({
-    key: 'quality',
-    node: (
-      <DatasetQualityIndicator
-        quality={quality}
-        isLoading={isQualityLoading}
-        verbose={true}
-        showTooltip={true}
-      />
-    ),
-  });
+  if (canMonitor) {
+    streamBadges.push({
+      key: 'quality',
+      node: (
+        <DatasetQualityIndicator
+          quality={quality}
+          isLoading={isQualityLoading}
+          verbose={true}
+          showTooltip={true}
+        />
+      ),
+    });
+  }
 
   return (
     <>


### PR DESCRIPTION
## Summary

Fixes 403 Forbidden errors captured in APM when users without sufficient Elasticsearch index privileges navigate to the Streams management UI.

Two gaps were identified:

- **`ClassicStreamDetailManagement` lacked a `view_index_metadata` guard.** `WiredStreamDetailManagement` already returns an error callout when `definition.privileges.view_index_metadata` is false (preventing the `Wrapper` from mounting and firing API calls). Classic streams had no equivalent check, so any user with Streams app access could reach the management page and trigger API calls regardless of their ES index privileges.

- **`Wrapper` made doc count API calls unconditionally.** `GET /internal/streams/doc_counts/{total,degraded,failed}` all use `scopedClusterClient.asCurrentUser` internally, meaning they require the ES `monitor` index privilege beyond the Kibana-level `read_stream` check. Users with `view_index_metadata` but not `monitor` would pass the management page guard yet still receive a 403 toast from these calls. The `canMonitor` flag now gates both the API calls and the quality badge in the stream header.

## Test plan

- [ ] Verify a user with only `view_index_metadata` on a wired stream sees the no-privileges callout (existing behaviour, no change)
- [ ] Verify a user with only `view_index_metadata` on a classic stream now sees the no-privileges callout instead of 403 toasts
- [ ] Verify a user with `view_index_metadata` but not `monitor` sees the management tabs without the quality indicator badge, with no 403 errors
- [ ] Verify a user with full privileges sees the management tabs and quality indicator as before

Closes elastic/observability-error-backlog#735

🤖 Generated with [Claude Code](https://claude.com/claude-code)