### PR TITLE
Add Core ownership for kbn-change-history

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -968,6 +968,7 @@ x-pack/platform/packages/shared/kbn-ai-tools @elastic/appex-ai-infra
 x-pack/platform/packages/shared/kbn-ai-tools-cli @elastic/appex-ai-infra
 x-pack/platform/packages/shared/kbn-alerting-comparators @elastic/response-ops
 x-pack/platform/packages/shared/kbn-apm-types @elastic/obs-presentation-team
+x-pack/platform/packages/shared/kbn-change-history @elastic/security-detection-rule-management @elastic/kibana-core
 x-pack/platform/packages/shared/kbn-classic-stream-flyout @elastic/kibana-management
 x-pack/platform/packages/shared/kbn-content-packs-schema @elastic/obs-onboarding-team
 x-pack/platform/packages/shared/kbn-data-forge @elastic/actionable-obs-team


### PR DESCRIPTION
## Summary

Adds `@elastic/kibana-core` as a CODEOWNER for `x-pack/platform/packages/shared/kbn-change-history` alongside `@elastic/security-detection-rule-management`.

## Validation

- Checked CODEOWNERS diff
- Attempted `node scripts/check_changes.ts`, but this checkout does not contain that script

## Risk

Low. CODEOWNERS-only change.

(Made with cursor y'all)

Made with [Cursor](https://cursor.com)