### PR TITLE
[Fleet] Fix custom dataset fallback templates for integration packages

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/common/experimental_features.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/experimental_features.ts
@@ -33,6 +33,7 @@ const _allowedExperimentalValues = {
   enableOTelVerifier: true, // When enabled, OTel-based cloud connector permission verification is active.
   enableResolveDependencies: false, // When enabled, the resolve dependencies step will be available during package installation.
   enableOtelUI: false, // When enabled, OTel-specific UI elements (e.g. Collector Config tab) will be shown.
+  enableCustomDatasetTemplateMigration: false, // When enabled, installs missing index templates for existing integration policies with custom datasets on startup.
 };
 
 /**

--- a/x-pack/platform/plugins/shared/fleet/server/integration_tests/package_policy_custom_dataset.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/integration_tests/package_policy_custom_dataset.test.ts
@@ -1,0 +1,369 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import Path from 'path';
+
+import type { TestElasticsearchUtils, TestKibanaUtils } from '@kbn/core-test-helpers-kbn-server';
+import { createRootWithCorePlugins, createTestServers } from '@kbn/core-test-helpers-kbn-server';
+
+import { packagePolicyService } from '../services/package_policy';
+import { ensureCustomDatasetTemplatesForIntegrationPolicies } from '../services/setup/ensure_fleet_global_es_assets';
+import { waitForFleetSetup, useDockerRegistry } from './helpers';
+
+// These tests require a running Elasticsearch + Kibana with the Fleet plugin and
+// a Docker-based package registry serving a test integration package that exposes
+// a `data_stream.dataset` variable.
+//
+// Run with:
+//   node scripts/jest_integration x-pack/platform/plugins/shared/fleet/server/integration_tests/package_policy_custom_dataset.test.ts
+
+const logFilePath = Path.join(__dirname, 'logs_custom_dataset.log');
+
+const TEST_PACKAGE_NAME = 'log'; // bundled "Custom Logs" package exposes data_stream.dataset var
+const TEST_PACKAGE_VERSION = '2.3.0'; // adjust to bundled version
+const DEFAULT_DATASET = 'log.log'; // default dataset for the log package
+const CUSTOM_DATASET = 'my_custom_log';
+const AGENT_POLICY_ID = 'test-agent-policy-custom-dataset';
+
+describe('Integration package policy with custom dataset', () => {
+  let esServer: TestElasticsearchUtils;
+  let kbnServer: TestKibanaUtils;
+
+  const registryUrl = useDockerRegistry();
+
+  const startServers = async (extraConfig?: Record<string, unknown>) => {
+    const { startES } = createTestServers({
+      adjustTimeout: (t) => jest.setTimeout(t),
+      settings: { es: { license: 'trial' }, kbn: {} },
+    });
+
+    esServer = await startES();
+
+    const root = createRootWithCorePlugins(
+      {
+        xpack: {
+          fleet: {
+            registryUrl: await registryUrl,
+            ...extraConfig,
+          },
+        },
+        logging: {
+          appenders: {
+            file: {
+              type: 'file',
+              fileName: logFilePath,
+              layout: { type: 'json' },
+            },
+          },
+          loggers: [
+            { name: 'root', appenders: ['file'] },
+            { name: 'plugins.fleet', level: 'all' },
+          ],
+        },
+      },
+      { oss: false }
+    );
+
+    await root.preboot();
+    const coreSetup = await root.setup();
+    const coreStart = await root.start();
+
+    kbnServer = { root, coreSetup, coreStart, stop: async () => root.shutdown() };
+    await waitForFleetSetup(root);
+  };
+
+  const stopServers = async () => {
+    if (kbnServer) await kbnServer.stop();
+    if (esServer) await esServer.stop();
+  };
+
+  // -----------------------------------------------------------------------
+  // Helpers
+  // -----------------------------------------------------------------------
+
+  const getSoClient = () => kbnServer.coreStart.savedObjects.getUnsafeInternalClient();
+  const getEsClient = () => kbnServer.coreStart.elasticsearch.client.asInternalUser;
+
+  const createAgentPolicy = async () => {
+    const soClient = getSoClient();
+    const esClient = getEsClient();
+    const { agentPolicyService } = await import('../services/agent_policy');
+    return agentPolicyService.create(soClient, esClient, {
+      id: AGENT_POLICY_ID,
+      name: 'Test agent policy for custom dataset',
+      namespace: 'default',
+    });
+  };
+
+  const createCustomDatasetPolicy = async (customDataset: string = CUSTOM_DATASET) => {
+    const soClient = getSoClient();
+    const esClient = getEsClient();
+    return packagePolicyService.create(
+      soClient,
+      esClient,
+      {
+        name: `custom-dataset-policy-${customDataset}`,
+        namespace: 'default',
+        enabled: true,
+        policy_ids: [AGENT_POLICY_ID],
+        inputs: [
+          {
+            type: 'logfile',
+            enabled: true,
+            streams: [
+              {
+                enabled: true,
+                data_stream: { type: 'logs', dataset: DEFAULT_DATASET },
+                vars: {
+                  paths: { value: ['/tmp/test.log'], type: 'text' },
+                  'data_stream.dataset': { value: customDataset, type: 'text' },
+                },
+              },
+            ],
+          },
+        ],
+        package: { name: TEST_PACKAGE_NAME, title: 'Custom Logs', version: TEST_PACKAGE_VERSION },
+      },
+      { skipEnsureInstalled: false }
+    );
+  };
+
+  const getIndexTemplate = async (name: string) => {
+    try {
+      const esClient = getEsClient();
+      const result = await esClient.indices.getIndexTemplate({ name });
+      return result.index_templates?.[0] ?? null;
+    } catch (err) {
+      if (err?.statusCode === 404 || err?.meta?.statusCode === 404) return null;
+      throw err;
+    }
+  };
+
+  // -----------------------------------------------------------------------
+  // Tests
+  // -----------------------------------------------------------------------
+
+  beforeAll(async () => {
+    await startServers();
+    await createAgentPolicy();
+  }, 5 * 60 * 1000);
+
+  afterAll(async () => {
+    await stopServers();
+  });
+
+  describe('Scenario 1 — Template installed on policy create', () => {
+    let policyId: string;
+
+    afterAll(async () => {
+      if (policyId) {
+        await packagePolicyService.delete(getSoClient(), getEsClient(), [policyId]);
+      }
+    });
+
+    it('creates an index template scoped to the custom dataset', async () => {
+      const policy = await createCustomDatasetPolicy();
+      policyId = policy.id;
+
+      const template = await getIndexTemplate(`logs-${CUSTOM_DATASET}`);
+
+      expect(template).not.toBeNull();
+      expect(template!.index_template.index_patterns).toContain(`logs-${CUSTOM_DATASET}-*`);
+      expect(template!.index_template.priority).toBe(200);
+      expect(template!.index_template._meta?.package?.name).toBe(TEST_PACKAGE_NAME);
+    });
+  });
+
+  describe('Scenario 2 — Default dataset policy is unaffected', () => {
+    let policyId: string;
+
+    afterAll(async () => {
+      if (policyId) {
+        await packagePolicyService.delete(getSoClient(), getEsClient(), [policyId]);
+      }
+    });
+
+    it('does not create an extra template for the default dataset', async () => {
+      const soClient = getSoClient();
+      const esClient = getEsClient();
+      const policy = await packagePolicyService.create(
+        soClient,
+        esClient,
+        {
+          name: 'default-dataset-policy',
+          namespace: 'default',
+          enabled: true,
+          policy_ids: [AGENT_POLICY_ID],
+          inputs: [
+            {
+              type: 'logfile',
+              enabled: true,
+              streams: [
+                {
+                  enabled: true,
+                  data_stream: { type: 'logs', dataset: DEFAULT_DATASET },
+                  vars: {
+                    paths: { value: ['/tmp/test.log'], type: 'text' },
+                    'data_stream.dataset': { value: DEFAULT_DATASET, type: 'text' },
+                  },
+                },
+              ],
+            },
+          ],
+          package: {
+            name: TEST_PACKAGE_NAME,
+            title: 'Custom Logs',
+            version: TEST_PACKAGE_VERSION,
+          },
+        },
+        { skipEnsureInstalled: false }
+      );
+      policyId = policy.id;
+
+      // The package-level template for the default dataset should be installed by the
+      // package install step, not by our new code. No separate custom template.
+      const customTemplate = await getIndexTemplate(`logs-${DEFAULT_DATASET}`);
+      // This may or may not exist depending on the package, but it should NOT have been
+      // installed by our integration custom-dataset code (verify meta if present).
+      if (customTemplate) {
+        // If a template exists for the default dataset it was installed by package install, not our path.
+        // We just confirm no duplicate was created by verifying there is at most one template.
+        const result = await getEsClient().indices.getIndexTemplate({
+          name: `logs-${DEFAULT_DATASET}`,
+        });
+        expect(result.index_templates).toHaveLength(1);
+      }
+    });
+  });
+
+  describe('Scenario 3 — Template removed on policy delete', () => {
+    it('removes the index template when the only policy using the custom dataset is deleted', async () => {
+      const policy = await createCustomDatasetPolicy('my_nginx_to_delete');
+      const templateName = `logs-my_nginx_to_delete`;
+
+      const templateBefore = await getIndexTemplate(templateName);
+      expect(templateBefore).not.toBeNull();
+
+      await packagePolicyService.delete(getSoClient(), getEsClient(), [policy.id]);
+
+      const templateAfter = await getIndexTemplate(templateName);
+      expect(templateAfter).toBeNull();
+    });
+  });
+
+  describe('Scenario 4 — Template preserved when two policies share the same custom dataset', () => {
+    it('keeps the template alive until the last policy using it is deleted', async () => {
+      const sharedDataset = 'my_shared_nginx';
+      const policy1 = await createCustomDatasetPolicy(sharedDataset);
+      const policy2 = await createCustomDatasetPolicy(sharedDataset);
+
+      // Delete first policy — template should survive because policy2 still uses it
+      await packagePolicyService.delete(getSoClient(), getEsClient(), [policy1.id]);
+      const templateAfterFirst = await getIndexTemplate(`logs-${sharedDataset}`);
+      expect(templateAfterFirst).not.toBeNull();
+
+      // Delete second policy — template should now be removed
+      await packagePolicyService.delete(getSoClient(), getEsClient(), [policy2.id]);
+      const templateAfterBoth = await getIndexTemplate(`logs-${sharedDataset}`);
+      expect(templateAfterBoth).toBeNull();
+    });
+  });
+
+  describe('Scenario 5 — Idempotency: two policies use the same custom dataset', () => {
+    let policy1Id: string;
+    let policy2Id: string;
+
+    afterAll(async () => {
+      await packagePolicyService.delete(getSoClient(), getEsClient(), [policy1Id, policy2Id]);
+    });
+
+    it('creates only one index template and does not error on the second policy create', async () => {
+      const sharedDataset = 'my_idempotent_nginx';
+
+      const policy1 = await createCustomDatasetPolicy(sharedDataset);
+      policy1Id = policy1.id;
+
+      // Second create should succeed without error (idempotent skip)
+      const policy2 = await createCustomDatasetPolicy(sharedDataset);
+      policy2Id = policy2.id;
+
+      const esClient = getEsClient();
+      const result = await esClient.indices.getIndexTemplate({
+        name: `logs-${sharedDataset}`,
+      });
+      expect(result.index_templates).toHaveLength(1);
+    });
+  });
+
+  describe('Scenario 6 — Layer 1 migration (feature flag enabled)', () => {
+    let policyId: string;
+
+    afterAll(async () => {
+      if (policyId) {
+        await packagePolicyService.delete(getSoClient(), getEsClient(), [policyId]);
+      }
+    });
+
+    it('installs missing template for pre-existing policy and is idempotent', async () => {
+      const migrationDataset = 'my_migration_nginx';
+      const policy = await createCustomDatasetPolicy(migrationDataset);
+      policyId = policy.id;
+
+      // Simulate pre-fix state: manually delete the template
+      await getEsClient().indices.deleteIndexTemplate({ name: `logs-${migrationDataset}` });
+      expect(await getIndexTemplate(`logs-${migrationDataset}`)).toBeNull();
+
+      // Run the migration
+      await ensureCustomDatasetTemplatesForIntegrationPolicies({
+        soClient: getSoClient(),
+        esClient: getEsClient(),
+        logger: kbnServer.coreStart.logging.get('test.migration'),
+      });
+
+      // Template should be re-installed
+      const templateAfter = await getIndexTemplate(`logs-${migrationDataset}`);
+      expect(templateAfter).not.toBeNull();
+      expect(templateAfter!.index_template.priority).toBe(200);
+
+      // Run again — should be idempotent (no error)
+      await expect(
+        ensureCustomDatasetTemplatesForIntegrationPolicies({
+          soClient: getSoClient(),
+          esClient: getEsClient(),
+          logger: kbnServer.coreStart.logging.get('test.migration'),
+        })
+      ).resolves.not.toThrow();
+    });
+  });
+
+  describe('Scenario 7 — Package upgrade reinstalls custom-dataset templates', () => {
+    // This scenario is a structural test: verify that upgrading the package policy
+    // triggers reinstallation of custom-dataset templates. Full package version cycling
+    // is dependent on the registry serving two versions, so we verify the upgrade
+    // code path is wired correctly by checking the template exists after a forced upgrade
+    // (force=true re-installs even if no version change in test environments).
+    it('template exists after policy is upgraded', async () => {
+      const upgradeDataset = 'my_upgrade_nginx';
+      const policy = await createCustomDatasetPolicy(upgradeDataset);
+
+      try {
+        // Manually delete the template to simulate stale state
+        await getEsClient().indices.deleteIndexTemplate({ name: `logs-${upgradeDataset}` });
+
+        // Trigger a no-op upgrade (same version) with force=true to exercise the upgrade path
+        await packagePolicyService.upgrade(getSoClient(), getEsClient(), policy.id, {
+          force: true,
+        });
+
+        const template = await getIndexTemplate(`logs-${upgradeDataset}`);
+        expect(template).not.toBeNull();
+      } finally {
+        await packagePolicyService.delete(getSoClient(), getEsClient(), [policy.id]);
+      }
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/fleet/server/integration_tests/package_policy_custom_dataset.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/integration_tests/package_policy_custom_dataset.test.ts
@@ -6,26 +6,27 @@
  */
 
 import Path from 'path';
+import fs from 'fs';
 
 import type { TestElasticsearchUtils, TestKibanaUtils } from '@kbn/core-test-helpers-kbn-server';
 import { createRootWithCorePlugins, createTestServers } from '@kbn/core-test-helpers-kbn-server';
+import { loggerMock } from '@kbn/logging-mocks';
 
 import { packagePolicyService } from '../services/package_policy';
 import { ensureCustomDatasetTemplatesForIntegrationPolicies } from '../services/setup/ensure_fleet_global_es_assets';
-import { waitForFleetSetup, useDockerRegistry } from './helpers';
 
-// These tests require a running Elasticsearch + Kibana with the Fleet plugin and
-// a Docker-based package registry serving a test integration package that exposes
-// a `data_stream.dataset` variable.
-//
-// Run with:
-//   node scripts/jest_integration x-pack/platform/plugins/shared/fleet/server/integration_tests/package_policy_custom_dataset.test.ts
+import { waitForFleetSetup, useDockerRegistry, getSupertestWithAdminUser } from './helpers';
 
 const logFilePath = Path.join(__dirname, 'logs_custom_dataset.log');
 
-const TEST_PACKAGE_NAME = 'log'; // bundled "Custom Logs" package exposes data_stream.dataset var
-const TEST_PACKAGE_VERSION = '2.3.0'; // adjust to bundled version
-const DEFAULT_DATASET = 'log.log'; // default dataset for the log package
+const TEST_PACKAGE_ZIP = Path.resolve(
+  __dirname,
+  '../../cypress/packages/logs_integration-1.0.0.zip'
+);
+const TEST_PACKAGE_NAME = 'logs_integration';
+const TEST_PACKAGE_VERSION = '1.0.0';
+// Default dataset for the logs_integration package data stream (path: log → dataset: logs_integration.log)
+const DEFAULT_DATASET = 'logs_integration.log';
 const CUSTOM_DATASET = 'my_custom_log';
 const AGENT_POLICY_ID = 'test-agent-policy-custom-dataset';
 
@@ -33,9 +34,11 @@ describe('Integration package policy with custom dataset', () => {
   let esServer: TestElasticsearchUtils;
   let kbnServer: TestKibanaUtils;
 
-  const registryUrl = useDockerRegistry();
+  // Docker registry is still needed for Fleet's own packages (fleet_server, system, etc.)
+  // that are auto-installed during setup.
+  useDockerRegistry();
 
-  const startServers = async (extraConfig?: Record<string, unknown>) => {
+  const startServers = async () => {
     const { startES } = createTestServers({
       adjustTimeout: (t) => jest.setTimeout(t),
       settings: { es: { license: 'trial' }, kbn: {} },
@@ -46,10 +49,7 @@ describe('Integration package policy with custom dataset', () => {
     const root = createRootWithCorePlugins(
       {
         xpack: {
-          fleet: {
-            registryUrl: await registryUrl,
-            ...extraConfig,
-          },
+          fleet: {},
         },
         logging: {
           appenders: {
@@ -87,6 +87,30 @@ describe('Integration package policy with custom dataset', () => {
 
   const getSoClient = () => kbnServer.coreStart.savedObjects.getUnsafeInternalClient();
   const getEsClient = () => kbnServer.coreStart.elasticsearch.client.asInternalUser;
+
+  const installTestPackage = async () => {
+    const zipBuffer = fs.readFileSync(TEST_PACKAGE_ZIP);
+    const response = await getSupertestWithAdminUser(
+      kbnServer.root,
+      'post',
+      '/api/fleet/epm/packages'
+    )
+      .set('Content-Type', 'application/zip')
+      .set('kbn-xsrf', 'true')
+      .send(zipBuffer)
+      .expect(200);
+    return response.body;
+  };
+
+  const uninstallTestPackage = async () => {
+    await getSupertestWithAdminUser(
+      kbnServer.root,
+      'delete',
+      `/api/fleet/epm/packages/${TEST_PACKAGE_NAME}/${TEST_PACKAGE_VERSION}`
+    )
+      .set('kbn-xsrf', 'true')
+      .send();
+  };
 
   const createAgentPolicy = async () => {
     const soClient = getSoClient();
@@ -126,7 +150,11 @@ describe('Integration package policy with custom dataset', () => {
             ],
           },
         ],
-        package: { name: TEST_PACKAGE_NAME, title: 'Custom Logs', version: TEST_PACKAGE_VERSION },
+        package: {
+          name: TEST_PACKAGE_NAME,
+          title: 'Logs Integration Package',
+          version: TEST_PACKAGE_VERSION,
+        },
       },
       { skipEnsureInstalled: false }
     );
@@ -149,10 +177,12 @@ describe('Integration package policy with custom dataset', () => {
 
   beforeAll(async () => {
     await startServers();
+    await installTestPackage();
     await createAgentPolicy();
   }, 5 * 60 * 1000);
 
   afterAll(async () => {
+    await uninstallTestPackage();
     await stopServers();
   });
 
@@ -216,7 +246,7 @@ describe('Integration package policy with custom dataset', () => {
           ],
           package: {
             name: TEST_PACKAGE_NAME,
-            title: 'Custom Logs',
+            title: 'Logs Integration Package',
             version: TEST_PACKAGE_VERSION,
           },
         },
@@ -224,14 +254,11 @@ describe('Integration package policy with custom dataset', () => {
       );
       policyId = policy.id;
 
-      // The package-level template for the default dataset should be installed by the
-      // package install step, not by our new code. No separate custom template.
-      const customTemplate = await getIndexTemplate(`logs-${DEFAULT_DATASET}`);
-      // This may or may not exist depending on the package, but it should NOT have been
-      // installed by our integration custom-dataset code (verify meta if present).
-      if (customTemplate) {
-        // If a template exists for the default dataset it was installed by package install, not our path.
-        // We just confirm no duplicate was created by verifying there is at most one template.
+      // A template may exist for the default dataset (installed by the package install step),
+      // but it should NOT have been created by our custom-dataset code. If a template exists,
+      // verify there is only one (no duplicate created by our path).
+      const defaultTemplate = await getIndexTemplate(`logs-${DEFAULT_DATASET}`);
+      if (defaultTemplate) {
         const result = await getEsClient().indices.getIndexTemplate({
           name: `logs-${DEFAULT_DATASET}`,
         });
@@ -321,7 +348,7 @@ describe('Integration package policy with custom dataset', () => {
       await ensureCustomDatasetTemplatesForIntegrationPolicies({
         soClient: getSoClient(),
         esClient: getEsClient(),
-        logger: kbnServer.coreStart.logging.get('test.migration'),
+        logger: loggerMock.create(),
       });
 
       // Template should be re-installed
@@ -334,18 +361,17 @@ describe('Integration package policy with custom dataset', () => {
         ensureCustomDatasetTemplatesForIntegrationPolicies({
           soClient: getSoClient(),
           esClient: getEsClient(),
-          logger: kbnServer.coreStart.logging.get('test.migration'),
+          logger: loggerMock.create(),
         })
       ).resolves.not.toThrow();
     });
   });
 
   describe('Scenario 7 — Package upgrade reinstalls custom-dataset templates', () => {
-    // This scenario is a structural test: verify that upgrading the package policy
-    // triggers reinstallation of custom-dataset templates. Full package version cycling
-    // is dependent on the registry serving two versions, so we verify the upgrade
-    // code path is wired correctly by checking the template exists after a forced upgrade
-    // (force=true re-installs even if no version change in test environments).
+    // Verifies that upgrading the package policy triggers reinstallation of custom-dataset
+    // templates. Full version cycling requires the registry to serve two versions; instead
+    // we verify the upgrade code path by deleting the template first and running a forced
+    // upgrade (force=true re-installs even without a version change in test environments).
     it('template exists after policy is upgraded', async () => {
       const upgradeDataset = 'my_upgrade_nginx';
       const policy = await createCustomDatasetPolicy(upgradeDataset);

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/input_type_packages.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/input_type_packages.test.ts
@@ -1474,6 +1474,20 @@ describe('removeAssetsForInputPackagePolicy', () => {
       release: 'ga' as const,
       package: 'nginx',
       path: 'access',
+      elasticsearch: {
+        'index_template.mappings': { dynamic: false },
+        'index_template.settings': { number_of_shards: 1 },
+      },
+      streams: [
+        {
+          input: 'logfile',
+          vars: [{ name: 'paths', type: 'text' }],
+          title: 'Nginx access log stream',
+          description: 'Collect nginx access logs',
+          enabled: true,
+          template_path: 'log.yml.hbs',
+        },
+      ],
     };
 
     const TEST_PKG_INFO = {
@@ -1566,11 +1580,18 @@ describe('removeAssetsForInputPackagePolicy', () => {
       const callArgs = jest.mocked(installIndexTemplatesAndPipelines).mock.calls[0][0];
       expect(callArgs.onlyForDataStreams).toHaveLength(1);
       const customDs = callArgs.onlyForDataStreams![0];
+
+      // Custom name is applied
       expect(customDs.dataset).toBe('my_nginx');
       expect(customDs.path).toBe('my_nginx');
-      // Original fields preserved
+
+      // All original fields from the package data stream are preserved —
+      // wrong values here mean wrong mappings in the installed template
       expect(customDs.type).toBe('logs');
       expect(customDs.title).toBe('Nginx access logs');
+      expect(customDs.elasticsearch).toEqual(NGINX_DATA_STREAM.elasticsearch);
+      expect(customDs.streams).toEqual(NGINX_DATA_STREAM.streams);
+
       expect(jest.mocked(optimisticallyAddEsAssetReferences)).toHaveBeenCalledTimes(1);
     });
 
@@ -1628,6 +1649,67 @@ describe('removeAssetsForInputPackagePolicy', () => {
       expect(jest.mocked(installIndexTemplatesAndPipelines)).not.toHaveBeenCalled();
     });
 
+    it('preserves dataset_is_prefix on the synthesized data stream passed to installIndexTemplatesAndPipelines', async () => {
+      const promDataStream = {
+        type: 'metrics',
+        dataset: 'prometheus.collector',
+        title: 'Prometheus metrics',
+        release: 'ga' as const,
+        package: 'prometheus',
+        path: 'collector',
+        dataset_is_prefix: true,
+      };
+      const promPkgInfo = {
+        type: 'integration',
+        name: 'prometheus',
+        version: '1.0.0',
+        data_streams: [promDataStream],
+      };
+      const promPolicy = {
+        id: 'policy-prom',
+        inputs: [
+          {
+            streams: [
+              {
+                data_stream: { dataset: 'prometheus.collector', type: 'metrics' },
+                vars: { 'data_stream.dataset': { value: 'my_prom' } },
+              },
+            ],
+          },
+        ],
+      } as any;
+      jest.mocked(getInstalledPackageWithAssets).mockResolvedValue({
+        installation: {
+          name: 'prometheus',
+          version: '1.0.0',
+          installed_es: [],
+          installed_kibana: [],
+        },
+        packageInfo: promPkgInfo,
+        assetsMap: new Map(),
+        paths: [],
+      } as any);
+
+      const mockedLogger = jest.mocked(appContextService.getLogger());
+      await installAssetsForIntegrationPackagePolicyCustomDatasets({
+        pkgInfo: promPkgInfo as any,
+        packagePolicy: promPolicy,
+        soClient: savedObjectsClientMock.create(),
+        esClient: {} as ElasticsearchClient,
+        force: false,
+        logger: mockedLogger,
+      });
+
+      expect(jest.mocked(installIndexTemplatesAndPipelines)).toHaveBeenCalledTimes(1);
+      const callArgs = jest.mocked(installIndexTemplatesAndPipelines).mock.calls[0][0];
+      const customDs = callArgs.onlyForDataStreams![0];
+
+      expect(customDs.dataset).toBe('my_prom');
+      expect(customDs.path).toBe('my_prom');
+      expect(customDs.dataset_is_prefix).toBe(true);
+      expect(customDs.type).toBe('metrics');
+    });
+
     it('throws when index template owned by different package and force=false', async () => {
       jest.mocked(dataStreamService).getMatchingIndexTemplate.mockResolvedValue({
         name: 'logs-my_nginx',
@@ -1644,6 +1726,26 @@ describe('removeAssetsForInputPackagePolicy', () => {
           logger: mockedLogger,
         })
       ).rejects.toThrow('force flag is required');
+    });
+
+    it('skips install and logs warn when user-created template (no _meta.package) exists', async () => {
+      jest.mocked(dataStreamService).getMatchingIndexTemplate.mockResolvedValue({
+        name: 'logs-my_nginx',
+        // No _meta.package — user-created template
+      } as any);
+      const mockedLogger = jest.mocked(appContextService.getLogger());
+      await installAssetsForIntegrationPackagePolicyCustomDatasets({
+        pkgInfo: TEST_PKG_INFO as any,
+        packagePolicy: POLICY_WITH_CUSTOM_DATASET,
+        soClient: savedObjectsClientMock.create(),
+        esClient: {} as ElasticsearchClient,
+        force: false,
+        logger: mockedLogger,
+      });
+      expect(jest.mocked(installIndexTemplatesAndPipelines)).not.toHaveBeenCalled();
+      expect(mockedLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('user-managed template')
+      );
     });
   });
 
@@ -1691,6 +1793,18 @@ describe('removeAssetsForInputPackagePolicy', () => {
         my_nginx: 'logs-my_nginx-*',
         'nginx.access': 'logs-nginx.access-*',
       },
+    };
+
+    const MOCK_INSTALLATION_WITH_COMPONENT_TEMPLATES = {
+      ...MOCK_INSTALLATION,
+      installed_es: [
+        { id: 'logs-my_nginx', type: 'index_template' },
+        { id: 'logs-my_nginx@package', type: 'component_template' },
+        { id: 'logs-my_nginx@mappings', type: 'component_template' },
+        { id: 'logs-my_nginx@settings', type: 'component_template' },
+        { id: 'logs-my_nginx_extra', type: 'index_template' }, // should NOT be cleaned up
+        { id: 'logs-nginx.access', type: 'index_template' }, // different dataset, not cleaned up
+      ],
     };
 
     beforeEach(() => {
@@ -1773,6 +1887,42 @@ describe('removeAssetsForInputPackagePolicy', () => {
         })
       ).resolves.not.toThrow();
       expect(mockedLogger.warn).toHaveBeenCalled();
+    });
+
+    it('includes @package, @mappings, @settings component templates in cleanup but not prefix-colliding datasets', async () => {
+      jest
+        .mocked(getInstallation)
+        .mockResolvedValue(MOCK_INSTALLATION_WITH_COMPONENT_TEMPLATES as any);
+      const mockedLogger = jest.mocked(appContextService.getLogger());
+      await removeAssetsForIntegrationPackagePolicyCustomDatasets({
+        packageInfo: TEST_PKG_INFO as any,
+        packagePolicy: POLICY,
+        soClient: savedObjectsClientMock.create(),
+        esClient: {} as ElasticsearchClient,
+        logger: mockedLogger,
+      });
+
+      expect(cleanupAssetsMock).toHaveBeenCalledTimes(1);
+      const cleanupCall = cleanupAssetsMock.mock.calls[0];
+      const installedEsPassedToCleanup = cleanupCall[1].installed_es;
+
+      // All four my_nginx assets should be included
+      expect(installedEsPassedToCleanup).toEqual(
+        expect.arrayContaining([
+          { id: 'logs-my_nginx', type: 'index_template' },
+          { id: 'logs-my_nginx@package', type: 'component_template' },
+          { id: 'logs-my_nginx@mappings', type: 'component_template' },
+          { id: 'logs-my_nginx@settings', type: 'component_template' },
+        ])
+      );
+      // The prefix-colliding dataset and unrelated dataset must NOT be included
+      expect(installedEsPassedToCleanup).not.toEqual(
+        expect.arrayContaining([
+          { id: 'logs-my_nginx_extra', type: 'index_template' },
+          { id: 'logs-nginx.access', type: 'index_template' },
+        ])
+      );
+      expect(installedEsPassedToCleanup).toHaveLength(4);
     });
   });
 

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/input_type_packages.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/input_type_packages.test.ts
@@ -12,6 +12,7 @@ import { appContextService } from '../../app_context';
 import { PackageNotFoundError } from '../../../errors';
 
 import { dataStreamService } from '../../data_streams';
+import { packagePolicyService } from '../../package_policy';
 
 import { getInstalledPackageWithAssets, getInstallation } from './get';
 import { installIndexTemplatesAndPipelines } from './install_index_template_pipeline';
@@ -20,6 +21,9 @@ import {
   installAssetsForInputPackagePolicy,
   removeAssetsForInputPackagePolicy,
   isInputPackageDatasetUsedByMultiplePolicies,
+  getCustomDatasetStreams,
+  installAssetsForIntegrationPackagePolicyCustomDatasets,
+  removeAssetsForIntegrationPackagePolicyCustomDatasets,
 } from './input_type_packages';
 import { cleanupAssets } from './remove';
 
@@ -28,6 +32,11 @@ jest.mock('./get');
 jest.mock('./install_index_template_pipeline');
 jest.mock('./es_assets_reference');
 jest.mock('./remove');
+jest.mock('../../package_policy', () => ({
+  packagePolicyService: {
+    list: jest.fn(),
+  },
+}));
 
 const cleanupAssetsMock = cleanupAssets as jest.MockedFunction<typeof cleanupAssets>;
 
@@ -1298,6 +1307,473 @@ describe('removeAssetsForInputPackagePolicy', () => {
       logger: mockedLogger,
     });
     expect(mockedLogger.error).toBeCalled();
+  });
+
+  describe('getCustomDatasetStreams', () => {
+    const NGINX_DATA_STREAM = {
+      type: 'logs',
+      dataset: 'nginx.access',
+      title: 'Nginx access logs',
+      release: 'ga' as const,
+      package: 'nginx',
+      path: 'access',
+    };
+
+    const TEST_PKG_INFO_INTEGRATION = {
+      type: 'integration',
+      name: 'nginx',
+      version: '1.0.0',
+      data_streams: [NGINX_DATA_STREAM],
+    };
+
+    it('returns empty array when no streams have a custom dataset', () => {
+      const policy = {
+        inputs: [
+          {
+            streams: [
+              {
+                data_stream: { dataset: 'nginx.access', type: 'logs' },
+                vars: { 'data_stream.dataset': { value: 'nginx.access' } },
+              },
+            ],
+          },
+        ],
+      } as any;
+      expect(getCustomDatasetStreams(policy, TEST_PKG_INFO_INTEGRATION as any)).toEqual([]);
+    });
+
+    it('returns empty array when DATASET_VAR_NAME var is absent', () => {
+      const policy = {
+        inputs: [
+          {
+            streams: [
+              {
+                data_stream: { dataset: 'nginx.access', type: 'logs' },
+                vars: {},
+              },
+            ],
+          },
+        ],
+      } as any;
+      expect(getCustomDatasetStreams(policy, TEST_PKG_INFO_INTEGRATION as any)).toEqual([]);
+    });
+
+    it('returns empty array when DATASET_VAR_NAME var is empty string', () => {
+      const policy = {
+        inputs: [
+          {
+            streams: [
+              {
+                data_stream: { dataset: 'nginx.access', type: 'logs' },
+                vars: { 'data_stream.dataset': { value: '' } },
+              },
+            ],
+          },
+        ],
+      } as any;
+      expect(getCustomDatasetStreams(policy, TEST_PKG_INFO_INTEGRATION as any)).toEqual([]);
+    });
+
+    it('returns one entry when one stream has a custom dataset', () => {
+      const policy = {
+        inputs: [
+          {
+            streams: [
+              {
+                data_stream: { dataset: 'nginx.access', type: 'logs' },
+                vars: { 'data_stream.dataset': { value: 'my_nginx' } },
+              },
+            ],
+          },
+        ],
+      } as any;
+      const result = getCustomDatasetStreams(policy, TEST_PKG_INFO_INTEGRATION as any);
+      expect(result).toHaveLength(1);
+      expect(result[0].customDatasetName).toBe('my_nginx');
+      expect(result[0].originalDataStream).toEqual(NGINX_DATA_STREAM);
+    });
+
+    it('returns only customized entries when policy has mixed streams', () => {
+      const ACCESS_DS = { ...NGINX_DATA_STREAM, dataset: 'nginx.access', path: 'access' };
+      const ERROR_DS = {
+        type: 'logs',
+        dataset: 'nginx.error',
+        title: 'Nginx error logs',
+        release: 'ga' as const,
+        package: 'nginx',
+        path: 'error',
+      };
+      const pkgInfo = {
+        type: 'integration',
+        name: 'nginx',
+        version: '1.0.0',
+        data_streams: [ACCESS_DS, ERROR_DS],
+      };
+      const policy = {
+        inputs: [
+          {
+            streams: [
+              {
+                data_stream: { dataset: 'nginx.access', type: 'logs' },
+                vars: { 'data_stream.dataset': { value: 'my_nginx_access' } },
+              },
+              {
+                // default dataset — no custom override
+                data_stream: { dataset: 'nginx.error', type: 'logs' },
+                vars: { 'data_stream.dataset': { value: 'nginx.error' } },
+              },
+            ],
+          },
+        ],
+      } as any;
+      const result = getCustomDatasetStreams(policy, pkgInfo as any);
+      expect(result).toHaveLength(1);
+      expect(result[0].customDatasetName).toBe('my_nginx_access');
+      expect(result[0].originalDataStream.dataset).toBe('nginx.access');
+    });
+
+    it('preserves dataset_is_prefix on the originalDataStream entry', () => {
+      const promDs = {
+        type: 'metrics',
+        dataset: 'prometheus.collector',
+        title: 'Prometheus metrics',
+        release: 'ga' as const,
+        package: 'prometheus',
+        path: 'collector',
+        dataset_is_prefix: true,
+      };
+      const pkgInfo = {
+        type: 'integration',
+        name: 'prometheus',
+        version: '1.0.0',
+        data_streams: [promDs],
+      };
+      const policy = {
+        inputs: [
+          {
+            streams: [
+              {
+                data_stream: { dataset: 'prometheus.collector', type: 'metrics' },
+                vars: { 'data_stream.dataset': { value: 'my_prom' } },
+              },
+            ],
+          },
+        ],
+      } as any;
+      const result = getCustomDatasetStreams(policy, pkgInfo as any);
+      expect(result).toHaveLength(1);
+      expect(result[0].originalDataStream.dataset_is_prefix).toBe(true);
+    });
+  });
+
+  describe('installAssetsForIntegrationPackagePolicyCustomDatasets', () => {
+    const NGINX_DATA_STREAM = {
+      type: 'logs',
+      dataset: 'nginx.access',
+      title: 'Nginx access logs',
+      release: 'ga' as const,
+      package: 'nginx',
+      path: 'access',
+    };
+
+    const TEST_PKG_INFO = {
+      type: 'integration',
+      name: 'nginx',
+      version: '1.0.0',
+      data_streams: [NGINX_DATA_STREAM],
+    };
+
+    const POLICY_WITH_CUSTOM_DATASET = {
+      id: 'policy-1',
+      inputs: [
+        {
+          streams: [
+            {
+              data_stream: { dataset: 'nginx.access', type: 'logs' },
+              vars: { 'data_stream.dataset': { value: 'my_nginx' } },
+            },
+          ],
+        },
+      ],
+    } as any;
+
+    beforeEach(() => {
+      jest.mocked(installIndexTemplatesAndPipelines).mockClear();
+      jest.mocked(optimisticallyAddEsAssetReferences).mockClear();
+      jest.mocked(dataStreamService).getMatchingDataStreams.mockResolvedValue([]);
+      jest.mocked(dataStreamService).getMatchingIndexTemplate.mockResolvedValue(null);
+      jest.mocked(installIndexTemplatesAndPipelines).mockResolvedValue(undefined as any);
+      jest.mocked(optimisticallyAddEsAssetReferences).mockResolvedValue(undefined as any);
+      jest.mocked(getInstalledPackageWithAssets).mockResolvedValue({
+        installation: { name: 'nginx', version: '1.0.0', installed_es: [], installed_kibana: [] },
+        packageInfo: TEST_PKG_INFO,
+        assetsMap: new Map(),
+        paths: [],
+      } as any);
+    });
+
+    it('does nothing for non-integration packages', async () => {
+      const mockedLogger = jest.mocked(appContextService.getLogger());
+      await installAssetsForIntegrationPackagePolicyCustomDatasets({
+        pkgInfo: { type: 'input' } as any,
+        packagePolicy: POLICY_WITH_CUSTOM_DATASET,
+        soClient: savedObjectsClientMock.create(),
+        esClient: {} as ElasticsearchClient,
+        force: false,
+        logger: mockedLogger,
+      });
+      expect(jest.mocked(installIndexTemplatesAndPipelines)).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when no streams have a custom dataset', async () => {
+      const mockedLogger = jest.mocked(appContextService.getLogger());
+      const policyNoCustom = {
+        id: 'policy-1',
+        inputs: [
+          {
+            streams: [
+              {
+                data_stream: { dataset: 'nginx.access', type: 'logs' },
+                vars: { 'data_stream.dataset': { value: 'nginx.access' } },
+              },
+            ],
+          },
+        ],
+      } as any;
+      await installAssetsForIntegrationPackagePolicyCustomDatasets({
+        pkgInfo: TEST_PKG_INFO as any,
+        packagePolicy: policyNoCustom,
+        soClient: savedObjectsClientMock.create(),
+        esClient: {} as ElasticsearchClient,
+        force: false,
+        logger: mockedLogger,
+      });
+      expect(jest.mocked(installIndexTemplatesAndPipelines)).not.toHaveBeenCalled();
+    });
+
+    it('happy path: installs template with synthesized custom data stream', async () => {
+      const mockedLogger = jest.mocked(appContextService.getLogger());
+      await installAssetsForIntegrationPackagePolicyCustomDatasets({
+        pkgInfo: TEST_PKG_INFO as any,
+        packagePolicy: POLICY_WITH_CUSTOM_DATASET,
+        soClient: savedObjectsClientMock.create(),
+        esClient: {} as ElasticsearchClient,
+        force: false,
+        logger: mockedLogger,
+      });
+
+      expect(jest.mocked(installIndexTemplatesAndPipelines)).toHaveBeenCalledTimes(1);
+      const callArgs = jest.mocked(installIndexTemplatesAndPipelines).mock.calls[0][0];
+      expect(callArgs.onlyForDataStreams).toHaveLength(1);
+      const customDs = callArgs.onlyForDataStreams![0];
+      expect(customDs.dataset).toBe('my_nginx');
+      expect(customDs.path).toBe('my_nginx');
+      // Original fields preserved
+      expect(customDs.type).toBe('logs');
+      expect(customDs.title).toBe('Nginx access logs');
+      expect(jest.mocked(optimisticallyAddEsAssetReferences)).toHaveBeenCalledTimes(1);
+    });
+
+    it('skips install (idempotent) when template exists and belongs to same package', async () => {
+      jest.mocked(dataStreamService).getMatchingIndexTemplate.mockResolvedValue({
+        name: 'logs-my_nginx',
+        _meta: { package: { name: 'nginx' } },
+      } as any);
+      const mockedLogger = jest.mocked(appContextService.getLogger());
+      await installAssetsForIntegrationPackagePolicyCustomDatasets({
+        pkgInfo: TEST_PKG_INFO as any,
+        packagePolicy: POLICY_WITH_CUSTOM_DATASET,
+        soClient: savedObjectsClientMock.create(),
+        esClient: {} as ElasticsearchClient,
+        force: false,
+        logger: mockedLogger,
+      });
+      expect(jest.mocked(installIndexTemplatesAndPipelines)).not.toHaveBeenCalled();
+    });
+
+    it('throws when data stream is owned by different package and force=false', async () => {
+      jest
+        .mocked(dataStreamService)
+        .getMatchingDataStreams.mockResolvedValue([
+          { name: 'logs-my_nginx-default', _meta: { package: { name: 'other_package' } } },
+        ] as any);
+      const mockedLogger = jest.mocked(appContextService.getLogger());
+      await expect(
+        installAssetsForIntegrationPackagePolicyCustomDatasets({
+          pkgInfo: TEST_PKG_INFO as any,
+          packagePolicy: POLICY_WITH_CUSTOM_DATASET,
+          soClient: savedObjectsClientMock.create(),
+          esClient: {} as ElasticsearchClient,
+          force: false,
+          logger: mockedLogger,
+        })
+      ).rejects.toThrow('force flag is required');
+    });
+
+    it('skips install when data stream owned by different package and force=true', async () => {
+      jest
+        .mocked(dataStreamService)
+        .getMatchingDataStreams.mockResolvedValue([
+          { name: 'logs-my_nginx-default', _meta: { package: { name: 'other_package' } } },
+        ] as any);
+      const mockedLogger = jest.mocked(appContextService.getLogger());
+      await installAssetsForIntegrationPackagePolicyCustomDatasets({
+        pkgInfo: TEST_PKG_INFO as any,
+        packagePolicy: POLICY_WITH_CUSTOM_DATASET,
+        soClient: savedObjectsClientMock.create(),
+        esClient: {} as ElasticsearchClient,
+        force: true,
+        logger: mockedLogger,
+      });
+      expect(jest.mocked(installIndexTemplatesAndPipelines)).not.toHaveBeenCalled();
+    });
+
+    it('throws when index template owned by different package and force=false', async () => {
+      jest.mocked(dataStreamService).getMatchingIndexTemplate.mockResolvedValue({
+        name: 'logs-my_nginx',
+        _meta: { package: { name: 'other_package' } },
+      } as any);
+      const mockedLogger = jest.mocked(appContextService.getLogger());
+      await expect(
+        installAssetsForIntegrationPackagePolicyCustomDatasets({
+          pkgInfo: TEST_PKG_INFO as any,
+          packagePolicy: POLICY_WITH_CUSTOM_DATASET,
+          soClient: savedObjectsClientMock.create(),
+          esClient: {} as ElasticsearchClient,
+          force: false,
+          logger: mockedLogger,
+        })
+      ).rejects.toThrow('force flag is required');
+    });
+  });
+
+  describe('removeAssetsForIntegrationPackagePolicyCustomDatasets', () => {
+    const NGINX_DATA_STREAM = {
+      type: 'logs',
+      dataset: 'nginx.access',
+      title: 'Nginx access logs',
+      release: 'ga' as const,
+      package: 'nginx',
+      path: 'access',
+    };
+
+    const TEST_PKG_INFO = {
+      type: 'integration',
+      name: 'nginx',
+      version: '1.0.0',
+      status: 'installed',
+      data_streams: [NGINX_DATA_STREAM],
+    };
+
+    const POLICY = {
+      id: 'policy-1',
+      inputs: [
+        {
+          streams: [
+            {
+              data_stream: { dataset: 'nginx.access', type: 'logs' },
+              vars: { 'data_stream.dataset': { value: 'my_nginx' } },
+            },
+          ],
+        },
+      ],
+    } as any;
+
+    const MOCK_INSTALLATION = {
+      name: 'nginx',
+      version: '1.0.0',
+      installed_es: [
+        { id: 'logs-my_nginx', type: 'index_template' },
+        { id: 'logs-nginx.access', type: 'index_template' },
+      ],
+      installed_kibana: [],
+      es_index_patterns: {
+        my_nginx: 'logs-my_nginx-*',
+        'nginx.access': 'logs-nginx.access-*',
+      },
+    };
+
+    beforeEach(() => {
+      jest.mocked(getInstallation).mockResolvedValue(MOCK_INSTALLATION as any);
+      jest.mocked(cleanupAssetsMock).mockResolvedValue(undefined as any);
+      jest.mocked(packagePolicyService.list as jest.Mock).mockResolvedValue({ items: [] });
+    });
+
+    it('does nothing for non-integration packages', async () => {
+      const mockedLogger = jest.mocked(appContextService.getLogger());
+      await removeAssetsForIntegrationPackagePolicyCustomDatasets({
+        packageInfo: { type: 'input', name: 'logs', version: '1.0.0', status: 'installed' } as any,
+        packagePolicy: POLICY,
+        soClient: savedObjectsClientMock.create(),
+        esClient: {} as ElasticsearchClient,
+        logger: mockedLogger,
+      });
+      expect(cleanupAssetsMock).not.toHaveBeenCalled();
+    });
+
+    it('calls cleanupAssets when policy is the sole user of the custom dataset', async () => {
+      const mockedLogger = jest.mocked(appContextService.getLogger());
+      await removeAssetsForIntegrationPackagePolicyCustomDatasets({
+        packageInfo: TEST_PKG_INFO as any,
+        packagePolicy: POLICY,
+        soClient: savedObjectsClientMock.create(),
+        esClient: {} as ElasticsearchClient,
+        logger: mockedLogger,
+      });
+      expect(cleanupAssetsMock).toHaveBeenCalledWith(
+        'my_nginx',
+        expect.objectContaining({
+          installed_es: [{ id: 'logs-my_nginx', type: 'index_template' }],
+        }),
+        expect.objectContaining({ name: 'nginx' }),
+        expect.anything(),
+        expect.anything()
+      );
+    });
+
+    it('skips cleanup when another policy for the same package still uses the same custom dataset', async () => {
+      const otherPolicy = {
+        id: 'policy-2',
+        package: { name: 'nginx', version: '1.0.0' },
+        inputs: [
+          {
+            streams: [
+              {
+                data_stream: { dataset: 'nginx.access', type: 'logs' },
+                vars: { 'data_stream.dataset': { value: 'my_nginx' } },
+              },
+            ],
+          },
+        ],
+      };
+      jest.mocked(packagePolicyService.list as jest.Mock).mockResolvedValue({
+        items: [otherPolicy],
+      });
+      const mockedLogger = jest.mocked(appContextService.getLogger());
+      await removeAssetsForIntegrationPackagePolicyCustomDatasets({
+        packageInfo: TEST_PKG_INFO as any,
+        packagePolicy: POLICY,
+        soClient: savedObjectsClientMock.create(),
+        esClient: {} as ElasticsearchClient,
+        logger: mockedLogger,
+      });
+      expect(cleanupAssetsMock).not.toHaveBeenCalled();
+    });
+
+    it('logs warning and does not throw when installation is not found', async () => {
+      jest.mocked(getInstallation).mockResolvedValue(null as any);
+      const mockedLogger = jest.mocked(appContextService.getLogger());
+      await expect(
+        removeAssetsForIntegrationPackagePolicyCustomDatasets({
+          packageInfo: TEST_PKG_INFO as any,
+          packagePolicy: POLICY,
+          soClient: savedObjectsClientMock.create(),
+          esClient: {} as ElasticsearchClient,
+          logger: mockedLogger,
+        })
+      ).resolves.not.toThrow();
+      expect(mockedLogger.warn).toHaveBeenCalled();
+    });
   });
 
   describe('isInputPackageDatasetUsedByMultiplePolicies', () => {

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/input_type_packages.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/input_type_packages.ts
@@ -23,6 +23,8 @@ import {
 } from '../../../../common/constants';
 import { PackagePolicyValidationError, PackageNotFoundError, FleetError } from '../../../errors';
 
+import { packagePolicyService } from '../..';
+
 import { dataStreamService } from '../..';
 
 import * as Registry from '../registry';
@@ -331,6 +333,289 @@ export async function removeAssetsForInputPackagePolicy(opts: {
         `Failed to remove assets for input package ${packageInfo.name}:${packageInfo.version}: ${error.message}`
       );
     }
+  }
+}
+
+/**
+ * Returns the subset of streams in an integration package policy where the user has
+ * overridden `data_stream.dataset` with a custom value different from the package default.
+ */
+export function getCustomDatasetStreams(
+  packagePolicy: NewPackagePolicy | PackagePolicy,
+  pkgInfo: PackageInfo
+): Array<{ originalDataStream: RegistryDataStream; customDatasetName: string }> {
+  const results: Array<{ originalDataStream: RegistryDataStream; customDatasetName: string }> = [];
+  for (const input of packagePolicy.inputs) {
+    for (const stream of input.streams ?? []) {
+      const customVal = stream.vars?.[DATASET_VAR_NAME]?.value;
+      if (!customVal || customVal === stream.data_stream.dataset) continue;
+      const originalDataStream = pkgInfo.data_streams?.find(
+        (ds) => ds.dataset === stream.data_stream.dataset
+      );
+      if (originalDataStream) {
+        results.push({ originalDataStream, customDatasetName: customVal });
+      }
+    }
+  }
+  return results;
+}
+
+/**
+ * Installs index templates and pipelines for integration package policies that override
+ * `data_stream.dataset`. Mirrors the behavior of `installAssetsForInputPackagePolicy` but
+ * synthesizes a custom RegistryDataStream from the original rather than building one from scratch.
+ */
+export async function installAssetsForIntegrationPackagePolicyCustomDatasets(opts: {
+  pkgInfo: PackageInfo;
+  logger: Logger;
+  packagePolicy: NewPackagePolicy | PackagePolicy;
+  esClient: ElasticsearchClient;
+  soClient: SavedObjectsClientContract;
+  force: boolean;
+}) {
+  const { pkgInfo, logger, packagePolicy, esClient, soClient, force } = opts;
+
+  if (pkgInfo.type !== 'integration') return;
+
+  const customStreams = getCustomDatasetStreams(packagePolicy, pkgInfo);
+  if (customStreams.length === 0) return;
+
+  for (const { originalDataStream, customDatasetName } of customStreams) {
+    const customDataStream: RegistryDataStream = {
+      ...originalDataStream,
+      dataset: customDatasetName,
+      path: customDatasetName,
+    };
+
+    const existingDataStreams = await dataStreamService.getMatchingDataStreams(esClient, {
+      type: customDataStream.type,
+      dataset: customDatasetName,
+    });
+
+    if (existingDataStreams.length) {
+      const fromDifferentPackage = checkExistingDataStreamsAreFromDifferentPackage(
+        pkgInfo,
+        existingDataStreams
+      );
+      if (fromDifferentPackage && !force) {
+        const streamIndexPattern = dataStreamService.streamPartsToIndexPattern({
+          type: customDataStream.type,
+          dataset: customDatasetName,
+        });
+        throw new PackagePolicyValidationError(
+          `Datastreams matching "${streamIndexPattern}" already exist and are not managed by this package, force flag is required`
+        );
+      }
+      if (fromDifferentPackage && force) {
+        logger.info(
+          `Data stream for dataset ${customDatasetName} already exists, but is managed by a different package, skipping index template creation`
+        );
+        continue;
+      }
+      if (!force) {
+        logger.info(
+          `Data stream for dataset ${customDatasetName} already exists, skipping index template creation`
+        );
+        continue;
+      }
+    }
+
+    const existingIndexTemplate = await dataStreamService.getMatchingIndexTemplate(esClient, {
+      type: customDataStream.type,
+      dataset: customDatasetName,
+    });
+
+    if (existingIndexTemplate) {
+      const ownedByDifferentPackage =
+        existingIndexTemplate._meta?.package?.name &&
+        existingIndexTemplate._meta.package.name !== pkgInfo.name;
+      if (ownedByDifferentPackage && !force) {
+        throw new PackagePolicyValidationError(
+          `Index template "${customDataStream.type}-${customDatasetName}" already exist and is not managed by this package, force flag is required`
+        );
+      }
+      if (ownedByDifferentPackage && force) {
+        logger.info(
+          `Index template "${customDataStream.type}-${customDatasetName}" already exists, but is managed by a different package, skipping index template creation`
+        );
+        continue;
+      }
+      if (!force) {
+        logger.info(
+          `Index template "${customDataStream.type}-${customDatasetName}" already exists, skipping index template creation`
+        );
+        continue;
+      }
+    }
+
+    const installedPkgWithAssets = await getInstalledPackageWithAssets({
+      savedObjectsClient: soClient,
+      pkgName: pkgInfo.name,
+      logger,
+    });
+
+    if (!installedPkgWithAssets) {
+      throw new PackageNotFoundError(
+        `Error while creating index templates: unable to find installed package ${pkgInfo.name}`
+      );
+    }
+
+    try {
+      let packageInstallContext: import('../../../../common/types').PackageInstallContext;
+      if (installedPkgWithAssets.installation.version !== pkgInfo.version) {
+        const pkg = await Registry.getPackage(pkgInfo.name, pkgInfo.version, {
+          ignoreUnverified: force,
+        });
+        const archiveIterator = createArchiveIteratorFromMap(pkg.assetsMap);
+        packageInstallContext = {
+          packageInfo: pkg.packageInfo,
+          paths: pkg.paths,
+          archiveIterator,
+        };
+      } else {
+        const archiveIterator = createArchiveIteratorFromMap(installedPkgWithAssets.assetsMap);
+        packageInstallContext = {
+          packageInfo: installedPkgWithAssets.packageInfo,
+          paths: installedPkgWithAssets.paths,
+          archiveIterator,
+        };
+      }
+
+      await installIndexTemplatesAndPipelines({
+        installedPkg: installedPkgWithAssets.installation,
+        packageInstallContext,
+        esReferences: installedPkgWithAssets.installation.installed_es || [],
+        savedObjectsClient: soClient,
+        esClient,
+        logger,
+        onlyForDataStreams: [customDataStream],
+      });
+
+      await optimisticallyAddEsAssetReferences(
+        soClient,
+        installedPkgWithAssets.installation.name,
+        [],
+        generateESIndexPatterns([customDataStream])
+      );
+    } catch (error) {
+      logger.warn(`installAssetsForIntegrationPackagePolicyCustomDatasets error: ${error}`);
+    }
+  }
+}
+
+/**
+ * Removes index templates and pipelines installed for a custom `data_stream.dataset` on an
+ * integration package policy, but only when no other policy for the same package still uses
+ * the same custom dataset name for the same data stream type.
+ */
+export async function removeAssetsForIntegrationPackagePolicyCustomDatasets(opts: {
+  packageInfo: PackageInfo;
+  packagePolicy: PackagePolicy;
+  logger: Logger;
+  esClient: ElasticsearchClient;
+  soClient: SavedObjectsClientContract;
+}) {
+  const { packageInfo, packagePolicy, logger, esClient, soClient } = opts;
+
+  if (packageInfo.type !== 'integration' || packageInfo.status !== 'installed') return;
+
+  const customStreams = getCustomDatasetStreams(packagePolicy, packageInfo);
+  if (customStreams.length === 0) return;
+
+  logger.info(
+    `Removing custom dataset assets for integration package ${packageInfo.name}:${packageInfo.version}`
+  );
+
+  try {
+    const installation = await getInstallation({
+      savedObjectsClient: soClient,
+      pkgName: packageInfo.name,
+    });
+
+    if (!installation) {
+      logger.warn(`${packageInfo.name} is not installed, skipping custom dataset asset removal`);
+      return;
+    }
+
+    // Load all other policies for the same package to check if the custom dataset is still in use
+    const { items: allPolicies } = await packagePolicyService.list(soClient, {
+      kuery: `ingest-package-policies.package.name: "${packageInfo.name}"`,
+      perPage: 10000,
+    });
+
+    const {
+      installed_es: installedEs,
+      installed_kibana: installedKibana,
+      es_index_patterns: esIndexPatterns,
+    } = installation;
+
+    for (const { originalDataStream, customDatasetName } of customStreams) {
+      // Check if any OTHER policy for the same package still uses this custom dataset
+      // for the same data stream type. Exact match (not regex) to avoid prefix collisions.
+      const stillInUse = allPolicies
+        .filter((p) => p.id !== packagePolicy.id)
+        .some((p) =>
+          getCustomDatasetStreams(p, packageInfo).some(
+            (s) =>
+              s.customDatasetName === customDatasetName &&
+              s.originalDataStream.type === originalDataStream.type
+          )
+        );
+
+      if (stillInUse) {
+        logger.info(
+          `Custom dataset "${customDatasetName}" is still used by another policy, skipping asset removal`
+        );
+        continue;
+      }
+
+      // Use exact string match (not word-boundary regex) to avoid collisions between
+      // dataset names that share a prefix (e.g. "nginx" vs "nginx_extra").
+      const filteredInstalledEs = installedEs.filter((asset) => {
+        const parts = asset.id.split('-');
+        // Index template IDs have the form "{type}-{dataset}" — match the dataset part exactly
+        return parts.length >= 2 && parts.slice(1).join('-') === customDatasetName;
+      });
+      const filteredInstalledKibana = installedKibana.filter((asset) => {
+        const parts = asset.id.split('-');
+        return parts.length >= 2 && parts.slice(1).join('-') === customDatasetName;
+      });
+      const filteredEsIndexPatterns: Record<string, string> = {};
+      if (esIndexPatterns?.[customDatasetName]) {
+        filteredEsIndexPatterns[customDatasetName] = esIndexPatterns[customDatasetName];
+      }
+
+      if (
+        filteredInstalledEs.length === 0 &&
+        filteredInstalledKibana.length === 0 &&
+        Object.keys(filteredEsIndexPatterns).length === 0
+      ) {
+        logger.info(
+          `No tracked assets found for custom dataset "${customDatasetName}", skipping cleanup`
+        );
+        continue;
+      }
+
+      const installationToDelete = {
+        ...installation,
+        installed_es: filteredInstalledEs,
+        installed_kibana: filteredInstalledKibana,
+        es_index_patterns: filteredEsIndexPatterns,
+        package_assets: [],
+      };
+
+      await cleanupAssets(
+        customDatasetName,
+        installationToDelete,
+        installation,
+        esClient,
+        soClient
+      );
+    }
+  } catch (error) {
+    logger.error(
+      `Failed to remove custom dataset assets for integration package ${packageInfo.name}:${packageInfo.version}: ${error.message}`
+    );
   }
 }
 

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/input_type_packages.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/input_type_packages.ts
@@ -426,23 +426,32 @@ export async function installAssetsForIntegrationPackagePolicyCustomDatasets(opt
     });
 
     if (existingIndexTemplate) {
-      const ownedByDifferentPackage =
-        existingIndexTemplate._meta?.package?.name &&
-        existingIndexTemplate._meta.package.name !== pkgInfo.name;
+      const templateName = `${customDataStream.type}-${customDatasetName}`;
+      const existingOwner = existingIndexTemplate._meta?.package?.name;
+      const ownedByDifferentPackage = existingOwner && existingOwner !== pkgInfo.name;
+      const isUserCreated = !existingOwner;
+
       if (ownedByDifferentPackage && !force) {
         throw new PackagePolicyValidationError(
-          `Index template "${customDataStream.type}-${customDatasetName}" already exist and is not managed by this package, force flag is required`
+          `Index template "${templateName}" already exist and is not managed by this package, force flag is required`
         );
       }
       if (ownedByDifferentPackage && force) {
         logger.info(
-          `Index template "${customDataStream.type}-${customDatasetName}" already exists, but is managed by a different package, skipping index template creation`
+          `Index template "${templateName}" already exists, but is managed by a different package, skipping index template creation`
+        );
+        continue;
+      }
+      if (isUserCreated) {
+        logger.warn(
+          `Index template "${templateName}" already exists and was not created by Fleet, skipping index template creation to avoid overwriting user-managed template`
         );
         continue;
       }
       if (!force) {
+        // Same package owns it — idempotent skip
         logger.info(
-          `Index template "${customDataStream.type}-${customDatasetName}" already exists, skipping index template creation`
+          `Index template "${templateName}" already exists, skipping index template creation`
         );
         continue;
       }
@@ -569,17 +578,19 @@ export async function removeAssetsForIntegrationPackagePolicyCustomDatasets(opts
         continue;
       }
 
-      // Use exact string match (not word-boundary regex) to avoid collisions between
-      // dataset names that share a prefix (e.g. "nginx" vs "nginx_extra").
-      const filteredInstalledEs = installedEs.filter((asset) => {
-        const parts = asset.id.split('-');
-        // Index template IDs have the form "{type}-{dataset}" — match the dataset part exactly
-        return parts.length >= 2 && parts.slice(1).join('-') === customDatasetName;
-      });
-      const filteredInstalledKibana = installedKibana.filter((asset) => {
-        const parts = asset.id.split('-');
-        return parts.length >= 2 && parts.slice(1).join('-') === customDatasetName;
-      });
+      // Match asset IDs where the dataset name is followed by end-of-string or '@'
+      // (component template suffixes like @package, @mappings, @settings).
+      // This avoids prefix collisions (e.g. "nginx" matching "nginx_extra") while
+      // correctly matching "logs-my_nginx", "logs-my_nginx@package", etc.
+      const datasetSuffixRegex = new RegExp(
+        `${customDatasetName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(@|$)`
+      );
+      const filteredInstalledEs = installedEs.filter((asset) =>
+        datasetSuffixRegex.test(asset.id.replace(/^[^-]+-/, ''))
+      );
+      const filteredInstalledKibana = installedKibana.filter((asset) =>
+        datasetSuffixRegex.test(asset.id.replace(/^[^-]+-/, ''))
+      );
       const filteredEsIndexPatterns: Record<string, string> = {};
       if (esIndexPatterns?.[customDatasetName]) {
         filteredEsIndexPatterns[customDatasetName] = esIndexPatterns[customDatasetName];

--- a/x-pack/platform/plugins/shared/fleet/server/services/package_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/package_policy.ts
@@ -4478,7 +4478,7 @@ export function _validateRestrictedFieldsNotModifiedOrThrow(opts: {
             oldStream?.vars?.[DATASET_VAR_NAME] &&
             oldStream?.vars[DATASET_VAR_NAME]?.value !== stream?.vars?.[DATASET_VAR_NAME]?.value
           ) {
-            // seeing this error in dev? Package policy must be called with prepareInputPackagePolicyDataset function first in UI code
+            // seeing this error in dev? For input packages, the policy must be called with prepareInputPackagePolicyDataset function first in UI code
             appContextService
               .getLogger()
               .debug(
@@ -4490,7 +4490,7 @@ export function _validateRestrictedFieldsNotModifiedOrThrow(opts: {
             throw new PackagePolicyValidationError(
               i18n.translate('xpack.fleet.updatePackagePolicy.datasetCannotBeModified', {
                 defaultMessage:
-                  'Package policy dataset cannot be modified for input only packages, please create a new package policy.',
+                  'Package policy dataset cannot be modified, please create a new package policy.',
               })
             );
           }

--- a/x-pack/platform/plugins/shared/fleet/server/services/package_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/package_policy.ts
@@ -194,7 +194,12 @@ import type {
   RunExternalCallbacksPackagePolicyArgument,
   RunExternalCallbacksPackagePolicyResponse,
 } from './package_policy_service';
-import { installAssetsForInputPackagePolicy } from './epm/packages/input_type_packages';
+import {
+  installAssetsForInputPackagePolicy,
+  installAssetsForIntegrationPackagePolicyCustomDatasets,
+  removeAssetsForIntegrationPackagePolicyCustomDatasets,
+  getCustomDatasetStreams,
+} from './epm/packages/input_type_packages';
 import { auditLoggingService } from './audit_logging';
 import {
   extractAndUpdateSecrets,
@@ -698,6 +703,17 @@ class PackagePolicyClientImpl implements PackagePolicyClient {
 
     if (pkgInfo.type === 'input') {
       await installAssetsForInputPackagePolicy({
+        soClient,
+        esClient,
+        pkgInfo,
+        packagePolicy: enrichedPackagePolicy,
+        force: !!options?.force,
+        logger,
+      });
+    }
+
+    if (pkgInfo.type === 'integration') {
+      await installAssetsForIntegrationPackagePolicyCustomDatasets({
         soClient,
         esClient,
         pkgInfo,
@@ -2099,6 +2115,33 @@ class PackagePolicyClientImpl implements PackagePolicyClient {
           }
         }
 
+        if (
+          pkgInfo &&
+          pkgInfo.type === 'integration' &&
+          oldPackagePolicy.package &&
+          oldPackagePolicy.package.version !== pkgInfo.version
+        ) {
+          assetsToInstallFn.push(async () => {
+            const updatedPackagePolicy = await this.get(soClient, id);
+
+            if (!updatedPackagePolicy) {
+              return;
+            }
+
+            const customStreams = getCustomDatasetStreams(updatedPackagePolicy, pkgInfo);
+            if (customStreams.length === 0) return;
+
+            await installAssetsForIntegrationPackagePolicyCustomDatasets({
+              logger,
+              soClient,
+              esClient,
+              pkgInfo,
+              packagePolicy: updatedPackagePolicy,
+              force: true,
+            });
+          });
+        }
+
         if (!options?.fromBulkUpgrade) {
           // Handle component template/mappings updates for experimental features, e.g. synthetic source
           await handleExperimentalDatastreamFeatureOptIn({ soClient, esClient, packagePolicy });
@@ -2457,6 +2500,8 @@ class PackagePolicyClientImpl implements PackagePolicyClient {
         .catch((error) => logger.error(`Error deleting previous versions: ${error}`));
       logger.debug(`Attempted to delete previous versions ${JSON.stringify(response)}`);
 
+      const integrationAssetCleanupPromises: Array<Promise<void>> = [];
+
       statuses.forEach(({ id, success, error }) => {
         const packagePolicy = packagePolicies.find((p) => p.id === id);
         if (success && packagePolicy) {
@@ -2485,6 +2530,30 @@ class PackagePolicyClientImpl implements PackagePolicyClient {
               );
             }
           }
+
+          if (packagePolicy.package?.name && packagePolicy.package?.version) {
+            integrationAssetCleanupPromises.push(
+              getPackageInfo({
+                savedObjectsClient: soClient,
+                pkgName: packagePolicy.package.name,
+                pkgVersion: packagePolicy.package.version,
+              })
+                .then((pkgInfo) =>
+                  removeAssetsForIntegrationPackagePolicyCustomDatasets({
+                    packageInfo: pkgInfo,
+                    packagePolicy,
+                    esClient,
+                    soClient,
+                    logger,
+                  })
+                )
+                .catch((err) =>
+                  logger.error(
+                    `Failed to remove custom dataset assets for policy ${id}: ${err.message}`
+                  )
+                )
+            );
+          }
         } else if (!success && error) {
           result.push({
             id,
@@ -2496,6 +2565,8 @@ class PackagePolicyClientImpl implements PackagePolicyClient {
           });
         }
       });
+
+      await Promise.all(integrationAssetCleanupPromises);
     }
 
     if (!options?.skipUnassignFromAgentPolicies) {
@@ -4377,17 +4448,20 @@ export function _validateRestrictedFieldsNotModifiedOrThrow(opts: {
 }) {
   const { pkgInfo, oldPackagePolicy, packagePolicyUpdate } = opts;
 
-  if (pkgInfo.type !== 'input') return;
-
   const { namespace, inputs } = packagePolicyUpdate;
-  if (namespace && namespace !== oldPackagePolicy.namespace) {
-    throw new PackagePolicyValidationError(
-      i18n.translate('xpack.fleet.updatePackagePolicy.namespaceCannotBeModified', {
-        defaultMessage:
-          'Package policy namespace cannot be modified for input only packages, please create a new package policy.',
-      })
-    );
+
+  if (pkgInfo.type === 'input') {
+    if (namespace && namespace !== oldPackagePolicy.namespace) {
+      throw new PackagePolicyValidationError(
+        i18n.translate('xpack.fleet.updatePackagePolicy.namespaceCannotBeModified', {
+          defaultMessage:
+            'Package policy namespace cannot be modified for input only packages, please create a new package policy.',
+        })
+      );
+    }
   }
+
+  if (pkgInfo.type !== 'input' && pkgInfo.type !== 'integration') return;
 
   if (inputs) {
     for (const input of inputs) {
@@ -4422,6 +4496,7 @@ export function _validateRestrictedFieldsNotModifiedOrThrow(opts: {
           }
 
           if (
+            pkgInfo.type === 'input' &&
             oldStream &&
             oldStream?.vars?.[DATA_STREAM_TYPE_VAR_NAME] &&
             oldStream?.vars[DATA_STREAM_TYPE_VAR_NAME]?.value !==

--- a/x-pack/platform/plugins/shared/fleet/server/services/setup.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/setup.ts
@@ -64,7 +64,10 @@ import { updateDeprecatedComponentTemplates } from './setup/update_deprecated_co
 import { createCCSIndexPatterns } from './setup/fleet_synced_integrations';
 import { ensureCorrectAgentlessSettingsIds } from './agentless_settings_ids';
 import { getSpaceAwareSaveobjectsClients } from './epm/kibana/assets/saved_objects';
-import { ensureFleetGlobalEsAssets } from './setup/ensure_fleet_global_es_assets';
+import {
+  ensureFleetGlobalEsAssets,
+  ensureCustomDatasetTemplatesForIntegrationPolicies,
+} from './setup/ensure_fleet_global_es_assets';
 
 export interface SetupStatus {
   isInitialized: boolean;
@@ -192,6 +195,15 @@ async function createSetupSideEffects(
     }
   );
   stepSpan?.end();
+
+  if (appContextService.getExperimentalFeatures().enableCustomDatasetTemplateMigration) {
+    stepSpan = apm.startSpan(
+      'Migrate custom dataset templates for integration policies',
+      'preconfiguration'
+    );
+    await ensureCustomDatasetTemplatesForIntegrationPolicies({ soClient, esClient, logger });
+    stepSpan?.end();
+  }
 
   // Ensure that required packages are always installed even if they're left out of the config
   const preconfiguredPackageNames = new Set(packages.map((pkg) => pkg.name));

--- a/x-pack/platform/plugins/shared/fleet/server/services/setup/ensure_fleet_global_es_assets.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/setup/ensure_fleet_global_es_assets.ts
@@ -15,6 +15,12 @@ import {
 
 import { appContextService } from '../app_context';
 import { scheduleSetupTask } from '../../tasks/setup/schedule';
+import { packagePolicyService } from '../package_policy';
+import { getPackageInfo } from '../epm/packages';
+import {
+  getCustomDatasetStreams,
+  installAssetsForIntegrationPackagePolicyCustomDatasets,
+} from '../epm/packages/input_type_packages';
 
 interface GlobalAssetResult {
   isCreated: boolean;
@@ -68,4 +74,83 @@ export async function ensureFleetGlobalEsAssets(
       }
     }
   }
+}
+
+/**
+ * Layer 1 migration: scans all existing integration package policies and installs missing
+ * index templates for any that have a custom `data_stream.dataset` override. Idempotent —
+ * skips silently if the template already exists and is owned by the same package.
+ *
+ * Gated behind the `enableCustomDatasetTemplateMigration` experimental feature flag.
+ */
+export async function ensureCustomDatasetTemplatesForIntegrationPolicies({
+  logger,
+  soClient,
+  esClient,
+}: {
+  logger: Logger;
+  soClient: SavedObjectsClientContract;
+  esClient: ElasticsearchClient;
+}) {
+  logger.debug('Checking for integration policies with custom datasets missing index templates');
+
+  const { items: allPolicies } = await packagePolicyService.list(soClient, {
+    perPage: 10000,
+  });
+
+  const integrationPolicies = allPolicies.filter((p) => p.package?.name && p.package?.version);
+
+  for (const policy of integrationPolicies) {
+    if (!policy.package?.name || !policy.package?.version) continue;
+
+    let pkgInfo;
+    try {
+      pkgInfo = await getPackageInfo({
+        savedObjectsClient: soClient,
+        pkgName: policy.package.name,
+        pkgVersion: policy.package.version,
+      });
+    } catch (err) {
+      logger.debug(
+        `Skipping migration for policy ${policy.id}: could not resolve package info: ${err.message}`
+      );
+      continue;
+    }
+
+    if (pkgInfo.type !== 'integration') continue;
+
+    const customStreams = getCustomDatasetStreams(policy, pkgInfo);
+    if (customStreams.length === 0) continue;
+
+    // Pre-validate dataset names before attempting install to avoid noisy errors
+    const invalidDatasets = customStreams
+      .map((s) => s.customDatasetName)
+      .filter((name) => /[^a-z0-9_.]/.test(name));
+
+    if (invalidDatasets.length > 0) {
+      logger.warn(
+        `Skipping migration for policy ${policy.id} (package: ${policy.package.name}): ` +
+          `invalid dataset name(s): ${invalidDatasets.join(', ')}`
+      );
+      continue;
+    }
+
+    try {
+      await installAssetsForIntegrationPackagePolicyCustomDatasets({
+        pkgInfo,
+        packagePolicy: policy,
+        esClient,
+        soClient,
+        logger,
+        force: false,
+      });
+    } catch (err) {
+      logger.warn(
+        `Migration: failed to install custom dataset templates for policy ${policy.id} ` +
+          `(package: ${policy.package.name}): ${err.message}`
+      );
+    }
+  }
+
+  logger.debug('Finished checking integration policies with custom datasets');
 }


### PR DESCRIPTION

🚧 POC for  https://github.com/elastic/kibana/issues/160775 🚧

## Summary

Automatically create dataset fallback templates for integration packages


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

- Possible naming conflicts
- Enabling migration for existing environments


