### PR TITLE
[9.4] chore(deps): bump `simple-git` from `3.32.3` to `3.36.0` (#265751)

### DIFF
--- a/package.json
+++ b/package.json
@@ -2148,7 +2148,7 @@
     "sass-loader": "10.5.2",
     "selenium-webdriver": "4.41.0",
     "sharp": "0.34.5",
-    "simple-git": "3.32.3",
+    "simple-git": "3.36.0",
     "simple-statistics": "7.8.8",
     "sinon": "21.0.1",
     "sort-package-json": "3.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12513,6 +12513,18 @@
   resolved "https://registry.yarnpkg.com/@sideway/pinpoint/-/pinpoint-2.0.0.tgz#cff8ffadc372ad29fd3f78277aeb29e632cc70df"
   integrity sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==
 
+"@simple-git/args-pathspec@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@simple-git/args-pathspec/-/args-pathspec-1.0.3.tgz#9ef4a2ad5f49ab4056362d03f93f775b93118ca5"
+  integrity sha512-ngJMaHlsWDTfjyq9F3VIQ8b7NXbBLq5j9i5bJ6XLYtD6qlDXT7fdKY2KscWWUF8t18xx052Y/PUO1K1TRc9yKA==
+
+"@simple-git/argv-parser@^1.1.0":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@simple-git/argv-parser/-/argv-parser-1.1.1.tgz#275b839c6eeb5030872c73b1ea839a416885da9d"
+  integrity sha512-Q9lBcfQ+VQCpQqGJFHe5yooOS5hGdLFFbJ5R+R5aDsnkPCahtn1hSkMcORX65J2Z5lxSkD0lQorMsncuBQxYUw==
+  dependencies:
+    "@simple-git/args-pathspec" "^1.0.3"
+
 "@sinclair/typebox@^0.27.8":
   version "0.27.8"
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.27.8.tgz#6667fac16c436b5434a387a34dedb013198f6e6e"
@@ -32942,13 +32954,15 @@ simple-bin-help@^1.8.0:
   resolved "https://registry.yarnpkg.com/simple-bin-help/-/simple-bin-help-1.8.0.tgz#21bb82c6bccd9fa8678f9c0fadf2956b54e2160a"
   integrity sha512-0LxHn+P1lF5r2WwVB/za3hLRIsYoLaNq1CXqjbrs3ZvLuvlWnRKrUjEWzV7umZL7hpQ7xULiQMV+0iXdRa5iFg==
 
-simple-git@3.32.3:
-  version "3.32.3"
-  resolved "https://registry.yarnpkg.com/simple-git/-/simple-git-3.32.3.tgz#1dd6030fd03df4533a9e5a941314335e6265055d"
-  integrity sha512-56a5oxFdWlsGygOXHWrG+xjj5w9ZIt2uQbzqiIGdR/6i5iococ7WQ/bNPzWxCJdEUGUCmyMH0t9zMpRJTaKxmw==
+simple-git@3.36.0:
+  version "3.36.0"
+  resolved "https://registry.yarnpkg.com/simple-git/-/simple-git-3.36.0.tgz#019b28c0a35847ee34299c6fb63770ab1b2dffb7"
+  integrity sha512-cGQjLjK8bxJw4QuYT7gxHw3/IouVESbhahSsHrX97MzCL1gu2u7oy38W6L2ZIGECEfIBG4BabsWDPjBxJENv9Q==
   dependencies:
     "@kwsites/file-exists" "^1.1.1"
     "@kwsites/promise-deferred" "^1.1.1"
+    "@simple-git/args-pathspec" "^1.0.3"
+    "@simple-git/argv-parser" "^1.1.0"
     debug "^4.4.0"
 
 simple-sha256@^1.1.0:


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [chore(deps): bump `simple-git` from `3.32.3` to `3.36.0` (#265751)](https://github.com/elastic/kibana/pull/265751)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Aleh Zasypkin","email":"aleh.zasypkin@elastic.co"},"sourceCommit":{"committedDate":"2026-04-29T07:33:34Z","message":"chore(deps): bump `simple-git` from `3.32.3` to `3.36.0` (#265751)\n\n## Summary\n\nBump `simple-git` from `3.32.3` to `3.36.0`.","sha":"6105946ba22e2fa287b0c562f9033b3c904bfeed","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","dependencies","backport:all-open","v9.5.0"],"title":"chore(deps): bump `simple-git` from `3.32.3` to `3.36.0`","number":265751,"url":"https://github.com/elastic/kibana/pull/265751","mergeCommit":{"message":"chore(deps): bump `simple-git` from `3.32.3` to `3.36.0` (#265751)\n\n## Summary\n\nBump `simple-git` from `3.32.3` to `3.36.0`.","sha":"6105946ba22e2fa287b0c562f9033b3c904bfeed"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/265751","number":265751,"mergeCommit":{"message":"chore(deps): bump `simple-git` from `3.32.3` to `3.36.0` (#265751)\n\n## Summary\n\nBump `simple-git` from `3.32.3` to `3.36.0`.","sha":"6105946ba22e2fa287b0c562f9033b3c904bfeed"}}]}] BACKPORT-->