### PR TITLE
[CI] Use highmem agents for serverless workflows in pointer compression

### DIFF
--- a/.buildkite/pipelines/node_pointer_compression.yml
+++ b/.buildkite/pipelines/node_pointer_compression.yml
@@ -507,7 +507,7 @@ steps:
       imageProject: elastic-images-prod
       provider: gcp
       enableNestedVirtualization: true
-      machineType: n2-standard-4
+      machineType: n2-highmem-4
       diskSizeGb: 120
     depends_on:
       - build


### PR DESCRIPTION
## Summary
These tests are losing agents at a very high rate, producing failed builds.

We're using similarly memory-bumped agents in the on-merge pipeline as well, adopting this practise in the pointer-compression pipeline now.