### PR TITLE
DEX Skills POC

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-server/allow_lists.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-server/allow_lists.ts
@@ -44,6 +44,13 @@ export const AGENT_BUILDER_BUILTIN_TOOLS = [
   `${internalNamespaces.security}.alerts`,
   `${internalNamespaces.security}.get_entity`,
   `${internalNamespaces.security}.search_entities`,
+  `${internalNamespaces.security}.core.get_rule_details`,
+  `${internalNamespaces.security}.core.search_alerts_by_rule`,
+  `${internalNamespaces.security}.core.aggregate_alerts_for_rule`,
+  `${internalNamespaces.security}.core.preview_rule`,
+  `${internalNamespaces.security}.core.find_noisy_rules`,
+  `${internalNamespaces.security}.core.propose_action`,
+  `${internalNamespaces.security}.core.review_prebuilt_rules_to_install`,
 
   // Streams – read
   `${internalNamespaces.streams}.list_streams`,
@@ -128,6 +135,10 @@ export const AGENT_BUILDER_BUILTIN_SKILLS = [
   'alert-analysis',
   'detection-rule-edit',
   'threat-hunting',
+  'fix-false-positive-alerts',
+  'fix-rule-execution-failures',
+  'install-relevant-prebuilt-rules',
+  'find-noisy-rules',
 
   // O11Y
   'observability.rca',

--- a/x-pack/solutions/security/plugins/security_solution/common/agent_builder/action_recommendation.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/agent_builder/action_recommendation.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod/v4';
+import { CreateRuleExceptionListItemProps } from '@kbn/securitysolution-exceptions-common/api';
+
+export const actionProposalStatusSchema = z.enum(['pending', 'applied', 'dismissed', 'failed']);
+
+export const actionProposalMetricsSchema = z
+  .record(z.string(), z.union([z.string(), z.number()]))
+  .optional();
+
+export const ruleChangeIntentSchema = z.enum([
+  'query_tuning',
+  'disable',
+  'schedule_change',
+  'metadata_change',
+  'other',
+]);
+
+export const ruleChangePayloadSchema = z.object({
+  action_type: z.literal('rule_change'),
+  rule_id: z.string(),
+  current: z.unknown(), // full RuleResponse JSON — validated client-side
+  proposed_changes: z
+    .record(z.string(), z.unknown())
+    .refine((value) => Object.keys(value).length > 0, {
+      message: '`proposed_changes` must include at least one field.',
+    }),
+  changed_fields: z.array(z.string()).min(1),
+  intent: ruleChangeIntentSchema.optional(),
+});
+
+export const ruleInstallPayloadSchema = z.object({
+  action_type: z.literal('rule_install'),
+  rules: z
+    .array(
+      z.object({
+        rule_id: z.string(), // prebuilt-rule signature id
+        version: z.number().int().positive().optional(),
+        name: z.string(),
+        description: z.string().optional(),
+        severity: z.string().optional(),
+        mitre: z.array(z.string()).optional(),
+        why: z.string().optional(),
+      })
+    )
+    .min(1),
+});
+
+export const ruleExceptionAddPayloadSchema = z.object({
+  action_type: z.literal('rule_exception_add'),
+  rule_id: z.string(),
+  rule_name: z.string().optional(),
+  items: z.array(CreateRuleExceptionListItemProps).min(1),
+});
+
+export const actionProposalPayloadSchema = z.discriminatedUnion('action_type', [
+  ruleChangePayloadSchema,
+  ruleInstallPayloadSchema,
+  ruleExceptionAddPayloadSchema,
+]);
+
+export const actionProposalDataSchema = z.object({
+  attachmentLabel: z.string().optional(),
+  status: actionProposalStatusSchema,
+  summary: z.string(),
+  reason: z.string().optional(),
+  metrics: actionProposalMetricsSchema,
+  applied_at: z.string().optional(),
+  applied_by: z.string().optional(),
+  error: z.string().optional(),
+  payload: actionProposalPayloadSchema,
+});
+
+export type ActionProposalData = z.infer<typeof actionProposalDataSchema>;
+export type ActionProposalPayload = z.infer<typeof actionProposalPayloadSchema>;
+export type ActionProposalStatus = z.infer<typeof actionProposalStatusSchema>;
+export type RuleChangeIntent = z.infer<typeof ruleChangeIntentSchema>;
+export type RuleChangePayload = z.infer<typeof ruleChangePayloadSchema>;
+export type RuleInstallPayload = z.infer<typeof ruleInstallPayloadSchema>;
+export type RuleExceptionAddPayload = z.infer<typeof ruleExceptionAddPayloadSchema>;

--- a/x-pack/solutions/security/plugins/security_solution/common/constants.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/constants.ts
@@ -719,6 +719,7 @@ export enum SecurityAgentBuilderAttachments {
   alert = 'security.alert',
   entity = 'security.entity',
   rule = 'security.rule',
+  actionProposal = 'security.action_proposal',
 }
 
 export const SECURITY_RULE_ATTACHMENT_ID = 'ai-rule-creation';

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/action_proposal.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/attachment_types/action_proposal.tsx
@@ -1,0 +1,1034 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useCallback, useId, useState } from 'react';
+import { useQueryClient } from '@kbn/react-query';
+import { i18n } from '@kbn/i18n';
+import {
+  EuiAccordion,
+  EuiBadge,
+  EuiBasicTable,
+  EuiButton,
+  EuiButtonEmpty,
+  EuiCallOut,
+  EuiCodeBlock,
+  EuiErrorBoundary,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiIcon,
+  EuiLoadingSpinner,
+  EuiPanel,
+  EuiSpacer,
+  EuiText,
+  EuiTitle,
+} from '@elastic/eui';
+import type {
+  AttachmentRenderProps,
+  AttachmentServiceStartContract,
+} from '@kbn/agent-builder-browser/attachments';
+import type { Attachment } from '@kbn/agent-builder-common/attachments';
+import { buildPath, type HttpStart } from '@kbn/core-http-browser';
+import type { NotificationsStart } from '@kbn/core-notifications-browser';
+import type { ApplicationStart } from '@kbn/core-application-browser';
+import type { EuiBasicTableColumn } from '@elastic/eui';
+import {
+  EXCEPTIONS_UI_EDIT_PRIVILEGES,
+  RULES_UI_EDIT_PRIVILEGE,
+} from '@kbn/security-solution-features/constants';
+import type { RuleResponse } from '../../../common/api/detection_engine/model/rule_schema';
+import type {
+  ActionProposalData,
+  ActionProposalPayload,
+  ActionProposalStatus,
+  RuleChangePayload,
+  RuleExceptionAddPayload,
+  RuleInstallPayload,
+} from '../../../common/agent_builder/action_recommendation';
+import {
+  SecurityAgentBuilderAttachments,
+  DETECTION_ENGINE_RULES_URL,
+  DETECTION_ENGINE_RULES_URL_FIND,
+} from '../../../common/constants';
+import { PERFORM_RULE_INSTALLATION_URL } from '../../../common/api/detection_engine/prebuilt_rules';
+import { RuleDiffTab } from '../../detection_engine/rule_management/components/rule_details/rule_diff_tab';
+import { ExceptionItemCardConditions } from '../../detection_engine/rule_exceptions/components/exception_item_card/conditions';
+import { hasCapabilities } from '../../common/lib/capabilities';
+
+interface RuleInstallEntry {
+  rule_id: string;
+  name: string;
+  description?: string;
+  severity?: string;
+  mitre?: string[];
+  why?: string;
+  version?: number;
+}
+
+type ActionProposalAttachment = Attachment<string, ActionProposalData>;
+
+// ────────────────────────────────────────────────────────────────────────────
+// Factory dependencies — injected at plugin start.
+// Button handlers close over these to make HTTP calls with the user's session.
+// ────────────────────────────────────────────────────────────────────────────
+
+interface ActionProposalDeps {
+  http: HttpStart;
+  notifications: NotificationsStart;
+  application: ApplicationStart;
+}
+
+// Match the query keys used by Security Solution's rule hooks
+// (use_fetch_rule_by_id_query.ts and use_find_rules_query.ts) so an open rule
+// details page or rules list page automatically refetches after Approve.
+const RULE_BY_ID_QUERY_KEY_PREFIX = ['GET', DETECTION_ENGINE_RULES_URL] as const;
+const RULES_LIST_QUERY_KEY_PREFIX = ['GET', DETECTION_ENGINE_RULES_URL_FIND] as const;
+
+const invalidateRuleCachesForPayload = (
+  queryClient: ReturnType<typeof useQueryClient>,
+  payload: ActionProposalPayload
+): void => {
+  const ruleIds: string[] = [];
+  switch (payload.action_type) {
+    case 'rule_change':
+      ruleIds.push(payload.rule_id);
+      break;
+    case 'rule_exception_add':
+      ruleIds.push(payload.rule_id);
+      break;
+    case 'rule_install':
+      // Installed prebuilt rules become regular rules; invalidating the list is
+      // enough since the user doesn't have specific rule IDs cached yet.
+      break;
+  }
+
+  // Invalidate the per-rule cache for each affected rule id.
+  for (const id of ruleIds) {
+    queryClient.invalidateQueries([...RULE_BY_ID_QUERY_KEY_PREFIX, id]);
+  }
+  // Always invalidate the list — any of these actions can change list state
+  // (counts, severity, install set).
+  queryClient.invalidateQueries(RULES_LIST_QUERY_KEY_PREFIX);
+};
+
+// ────────────────────────────────────────────────────────────────────────────
+// Per-action execution. Each case calls a Detection Engine API via http.fetch —
+// which originates in the browser with the user's session, so auth "just works".
+// ────────────────────────────────────────────────────────────────────────────
+
+const fetchLiveRule = async (http: HttpStart, ruleId: string) =>
+  (await http.fetch(DETECTION_ENGINE_RULES_URL, {
+    method: 'GET',
+    version: '2023-10-31',
+    query: { id: ruleId },
+  })) as Record<string, unknown>;
+
+const sortKeysDeep = (value: unknown): unknown => {
+  if (Array.isArray(value)) {
+    return value.map(sortKeysDeep);
+  }
+
+  if (value && typeof value === 'object') {
+    return Object.keys(value as Record<string, unknown>)
+      .sort()
+      .reduce<Record<string, unknown>>((acc, key) => {
+        acc[key] = sortKeysDeep((value as Record<string, unknown>)[key]);
+        return acc;
+      }, {});
+  }
+
+  return value;
+};
+
+const areEquivalentValues = (left: unknown, right: unknown): boolean =>
+  JSON.stringify(sortKeysDeep(left)) === JSON.stringify(sortKeysDeep(right));
+
+const executeRuleChange = async (payload: RuleChangePayload, http: HttpStart) => {
+  const snapshot = parseAsObject(payload.current);
+  if (!snapshot) {
+    throw new Error(
+      'The proposal is missing a valid current rule snapshot. Ask the agent to re-analyse and propose again.'
+    );
+  }
+
+  const liveRule = await fetchLiveRule(http, payload.rule_id);
+  const hasDiverged = payload.changed_fields.some(
+    (field) => !areEquivalentValues(liveRule[field], snapshot[field])
+  );
+
+  if (hasDiverged) {
+    throw new Error(
+      'The rule has changed since this proposal was generated. Ask the agent to re-analyse and propose again.'
+    );
+  }
+
+  await http.fetch(DETECTION_ENGINE_RULES_URL, {
+    method: 'PATCH',
+    version: '2023-10-31',
+    body: JSON.stringify({
+      id: payload.rule_id,
+      ...payload.proposed_changes,
+    }),
+  });
+};
+
+const executeRuleInstall = async (payload: RuleInstallPayload, http: HttpStart) => {
+  await http.fetch(PERFORM_RULE_INSTALLATION_URL, {
+    method: 'POST',
+    version: '1',
+    body: JSON.stringify({
+      mode: 'SPECIFIC_RULES',
+      rules: payload.rules.map((r) => ({
+        rule_id: r.rule_id,
+        version: r.version ?? 1,
+      })),
+    }),
+  });
+};
+
+const executeRuleExceptionAdd = async (payload: RuleExceptionAddPayload, http: HttpStart) => {
+  await http.fetch(
+    buildPath(`${DETECTION_ENGINE_RULES_URL}/{id}/exceptions`, { id: payload.rule_id }),
+    {
+      method: 'POST',
+      version: '2023-10-31',
+      body: JSON.stringify({
+        items: payload.items,
+      }),
+    }
+  );
+};
+
+async function executeAction(payload: ActionProposalPayload, http: HttpStart): Promise<void> {
+  switch (payload.action_type) {
+    case 'rule_change':
+      return executeRuleChange(payload, http);
+    case 'rule_exception_add':
+      return executeRuleExceptionAdd(payload, http);
+    case 'rule_install':
+      return executeRuleInstall(payload, http);
+  }
+}
+
+const canApproveAction = (
+  payload: ActionProposalPayload,
+  application: ApplicationStart
+): boolean => {
+  switch (payload.action_type) {
+    case 'rule_exception_add':
+      return hasCapabilities(application.capabilities, EXCEPTIONS_UI_EDIT_PRIVILEGES);
+    case 'rule_change':
+    case 'rule_install':
+      return hasCapabilities(application.capabilities, RULES_UI_EDIT_PRIVILEGE);
+  }
+};
+
+// ────────────────────────────────────────────────────────────────────────────
+// Shared layout bits
+// ────────────────────────────────────────────────────────────────────────────
+
+const ProposalHeader: React.FC<{ summary: string; reason?: string }> = ({ summary, reason }) => (
+  <>
+    <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
+      <EuiFlexItem grow={false}>
+        <EuiIcon type="wrench" size="m" aria-hidden={true} />
+      </EuiFlexItem>
+      <EuiFlexItem>
+        <EuiTitle size="xxs">
+          <h6>{summary}</h6>
+        </EuiTitle>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+    {reason && (
+      <>
+        <EuiSpacer size="xs" />
+        <EuiText size="xs" color="subdued">
+          {reason}
+        </EuiText>
+      </>
+    )}
+  </>
+);
+
+const StatusBanner: React.FC<{
+  status: ActionProposalStatus;
+  appliedBy?: string;
+  appliedAt?: string;
+  error?: string;
+}> = ({ status, appliedBy, appliedAt, error }) => {
+  if (status === 'applied') {
+    const who = appliedBy ? ` by ${appliedBy}` : '';
+    const when = appliedAt ? ` at ${new Date(appliedAt).toLocaleString()}` : '';
+    return (
+      <EuiCallOut
+        size="s"
+        iconType="check"
+        color="success"
+        announceOnMount={false}
+        title={i18n.translate('xpack.securitySolution.agentBuilder.actionProposal.appliedTitle', {
+          defaultMessage: 'Applied{who}{when}',
+          values: { who, when },
+        })}
+      />
+    );
+  }
+  if (status === 'dismissed') {
+    return (
+      <EuiCallOut
+        size="s"
+        iconType="cross"
+        color="primary"
+        announceOnMount={false}
+        title={i18n.translate('xpack.securitySolution.agentBuilder.actionProposal.dismissedTitle', {
+          defaultMessage: 'Dismissed',
+        })}
+      />
+    );
+  }
+  if (status === 'failed') {
+    return (
+      <EuiCallOut
+        size="s"
+        iconType="warning"
+        color="danger"
+        announceOnMount={false}
+        title={i18n.translate('xpack.securitySolution.agentBuilder.actionProposal.failedTitle', {
+          defaultMessage: 'Failed to apply',
+        })}
+      >
+        {error && <EuiText size="xs">{error}</EuiText>}
+      </EuiCallOut>
+    );
+  }
+  return null;
+};
+
+const MetricsRow: React.FC<{ metrics?: Record<string, unknown> }> = ({ metrics }) => {
+  if (!metrics) return null;
+  const entries = Object.entries(metrics).filter(
+    ([, v]) => typeof v === 'number' || typeof v === 'string'
+  );
+  if (entries.length === 0) return null;
+  return (
+    <>
+      <EuiSpacer size="s" />
+      <EuiFlexGroup gutterSize="s" responsive={false} wrap>
+        {entries.map(([key, value]) => (
+          <EuiFlexItem grow={false} key={key}>
+            <EuiBadge color="hollow">{`${key}: ${String(value)}`}</EuiBadge>
+          </EuiFlexItem>
+        ))}
+      </EuiFlexGroup>
+    </>
+  );
+};
+
+const ChangedFieldsRow: React.FC<{ fields: string[] }> = ({ fields }) => {
+  if (fields.length === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      <EuiText size="xs" color="subdued">
+        {i18n.translate(
+          'xpack.securitySolution.agentBuilder.actionProposal.ruleChange.changedFields',
+          {
+            defaultMessage: 'Changes',
+          }
+        )}
+      </EuiText>
+      <EuiSpacer size="xs" />
+      <EuiFlexGroup gutterSize="xs" responsive={false} wrap>
+        {fields.map((field) => (
+          <EuiFlexItem grow={false} key={field}>
+            <EuiBadge color="hollow">{field}</EuiBadge>
+          </EuiFlexItem>
+        ))}
+      </EuiFlexGroup>
+    </>
+  );
+};
+
+const ApproveDismissButtons: React.FC<{
+  disabled: boolean;
+  isLoading: boolean;
+  onApprove: () => void;
+  onDismiss: () => void;
+  approveLabel?: string;
+  approveColor?: 'primary' | 'danger';
+  /** When false, the Approve button is hidden (user lacks privilege). Dismiss stays visible. */
+  canApprove: boolean;
+}> = ({
+  disabled,
+  isLoading,
+  onApprove,
+  onDismiss,
+  approveLabel,
+  approveColor = 'primary',
+  canApprove,
+}) => (
+  <EuiFlexGroup gutterSize="s" responsive={false} alignItems="center">
+    {canApprove && (
+      <EuiFlexItem grow={false}>
+        <EuiButton
+          color={approveColor}
+          fill
+          size="s"
+          iconType="check"
+          onClick={onApprove}
+          disabled={disabled}
+          isLoading={isLoading}
+        >
+          {approveLabel ??
+            i18n.translate('xpack.securitySolution.agentBuilder.actionProposal.approve', {
+              defaultMessage: 'Approve',
+            })}
+        </EuiButton>
+      </EuiFlexItem>
+    )}
+    <EuiFlexItem grow={false}>
+      <EuiButtonEmpty
+        size="s"
+        iconType="cross"
+        onClick={onDismiss}
+        disabled={disabled || isLoading}
+      >
+        {i18n.translate('xpack.securitySolution.agentBuilder.actionProposal.dismiss', {
+          defaultMessage: 'Dismiss',
+        })}
+      </EuiButtonEmpty>
+    </EuiFlexItem>
+    {!canApprove && (
+      <EuiFlexItem grow={false}>
+        <EuiText size="xs" color="subdued">
+          {i18n.translate('xpack.securitySolution.agentBuilder.actionProposal.noPrivilegeHint', {
+            defaultMessage: 'You do not have permission to apply this action.',
+          })}
+        </EuiText>
+      </EuiFlexItem>
+    )}
+  </EuiFlexGroup>
+);
+
+// ────────────────────────────────────────────────────────────────────────────
+// Per-action views
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Parse a raw value (object or stringified-JSON) into a plain record, or null
+ * if it isn't one.
+ */
+const parseAsObject = (raw: unknown): Record<string, unknown> | null => {
+  let candidate: unknown = raw;
+  if (typeof candidate === 'string') {
+    try {
+      candidate = JSON.parse(candidate);
+    } catch {
+      return null;
+    }
+  }
+  if (!candidate || typeof candidate !== 'object' || Array.isArray(candidate)) {
+    return null;
+  }
+  return candidate as Record<string, unknown>;
+};
+
+const isDisableRuleChange = (payload: RuleChangePayload): boolean =>
+  payload.intent === 'disable' || payload.proposed_changes.enabled === false;
+
+/**
+ * Ensure the rule object has the fields `RuleDiffTab`'s internal normalizeRule
+ * touches without guarding — notably `threat` (runs `.filter()`) and `tags`.
+ * Missing values default to empty arrays so the diff view doesn't crash on a
+ * partial rule payload from the LLM.
+ */
+const withSafeDefaults = (rule: Record<string, unknown>): RuleResponse =>
+  ({
+    ...rule,
+    threat: Array.isArray(rule.threat) ? rule.threat : [],
+    tags: Array.isArray(rule.tags) ? rule.tags : [],
+  } as RuleResponse);
+
+/**
+ * Validate + normalize the `current` rule. Must have at least name and type.
+ */
+const normalizeCurrentRule = (raw: unknown): RuleResponse | null => {
+  const obj = parseAsObject(raw);
+  if (!obj) return null;
+  if (typeof obj.name !== 'string' || typeof obj.type !== 'string') return null;
+  return withSafeDefaults(obj);
+};
+
+const getRuleName = (raw: unknown, fallbackRuleId: string): string => {
+  const obj = parseAsObject(raw);
+  return typeof obj?.name === 'string' ? obj.name : fallbackRuleId;
+};
+
+const mergePatchValue = (base: unknown, patch: unknown): unknown => {
+  if (
+    base &&
+    typeof base === 'object' &&
+    !Array.isArray(base) &&
+    patch &&
+    typeof patch === 'object' &&
+    !Array.isArray(patch)
+  ) {
+    const baseObject = base as Record<string, unknown>;
+    return Object.keys(patch as Record<string, unknown>).reduce<Record<string, unknown>>(
+      (acc, key) => {
+        acc[key] = mergePatchValue(baseObject[key], (patch as Record<string, unknown>)[key]);
+        return acc;
+      },
+      { ...baseObject }
+    );
+  }
+
+  return patch;
+};
+
+/**
+ * Produce the proposed rule by merging the agent's `proposed_changes` payload
+ * onto the `current` rule. That way the payload acts as a patch — the agent
+ * only needs to supply the fields it is changing and the rest is inherited.
+ */
+const buildProposedRule = (
+  current: RuleResponse,
+  proposedChanges: Record<string, unknown>
+): RuleResponse =>
+  withSafeDefaults(
+    mergePatchValue(current as unknown as Record<string, unknown>, proposedChanges) as Record<
+      string,
+      unknown
+    >
+  );
+
+/**
+ * Fallback when `RuleDiffTab` can't render (e.g. the agent produced a partial
+ * rule shape). Shows only the changed_fields with before/after values plus the
+ * raw JSON in code blocks so the user can still inspect + approve.
+ */
+const RuleChangeFallback: React.FC<{ payload: RuleChangePayload }> = ({ payload }) => {
+  const pickField = (rule: unknown, field: string): string => {
+    if (!rule || typeof rule !== 'object') return '—';
+    const v = (rule as Record<string, unknown>)[field];
+    if (v === undefined || v === null) return '—';
+    return typeof v === 'string' ? v : JSON.stringify(v);
+  };
+  return (
+    <EuiCallOut
+      size="s"
+      iconType="warning"
+      color="warning"
+      title={i18n.translate(
+        'xpack.securitySolution.agentBuilder.actionProposal.ruleUpdate.fallbackTitle',
+        { defaultMessage: 'Diff view unavailable — showing field-level changes' }
+      )}
+    >
+      <EuiText size="xs">
+        {i18n.translate(
+          'xpack.securitySolution.agentBuilder.actionProposal.ruleUpdate.fallbackBody',
+          {
+            defaultMessage:
+              'The proposal payload did not include a full rule object. The core change is shown below.',
+          }
+        )}
+      </EuiText>
+      <EuiSpacer size="s" />
+      {(payload.changed_fields.length > 0 ? payload.changed_fields : ['query']).map((field) => (
+        <div key={field}>
+          <EuiText size="xs">
+            <strong>{field}</strong>
+          </EuiText>
+          <EuiFlexGroup gutterSize="s" alignItems="flexStart" responsive={false}>
+            <EuiFlexItem>
+              <EuiText size="xs" color="subdued">
+                {'Current'}
+              </EuiText>
+              <EuiCodeBlock fontSize="s" paddingSize="s" overflowHeight={120}>
+                {pickField(payload.current, field)}
+              </EuiCodeBlock>
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <EuiText size="xs" color="subdued">
+                {'Proposed'}
+              </EuiText>
+              <EuiCodeBlock fontSize="s" paddingSize="s" overflowHeight={120}>
+                {pickField(payload.proposed_changes, field)}
+              </EuiCodeBlock>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+          <EuiSpacer size="xs" />
+        </div>
+      ))}
+    </EuiCallOut>
+  );
+};
+
+const RuleChangeView: React.FC<{
+  payload: RuleChangePayload;
+  status: ActionProposalStatus;
+  isLoading: boolean;
+  canApprove: boolean;
+  onApprove: () => void;
+  onDismiss: () => void;
+}> = ({ payload, status, isLoading, canApprove, onApprove, onDismiss }) => {
+  const detailsAccordionId = useId();
+  const current = normalizeCurrentRule(payload.current);
+  const ruleName = getRuleName(payload.current, payload.rule_id);
+  const proposed = current ? buildProposedRule(current, payload.proposed_changes) : null;
+  const canDiff = current !== null && proposed !== null;
+  const isDisable = isDisableRuleChange(payload);
+  const detailsButtonLabel = canDiff
+    ? i18n.translate('xpack.securitySolution.agentBuilder.actionProposal.ruleChange.reviewDiff', {
+        defaultMessage: 'Review full diff',
+      })
+    : i18n.translate(
+        'xpack.securitySolution.agentBuilder.actionProposal.ruleChange.reviewDetails',
+        {
+          defaultMessage: 'Review change details',
+        }
+      );
+
+  return (
+    <>
+      <EuiSpacer size="s" />
+      {isDisable && (
+        <>
+          <EuiCallOut
+            size="s"
+            iconType="warning"
+            color="warning"
+            announceOnMount={false}
+            title={i18n.translate(
+              'xpack.securitySolution.agentBuilder.actionProposal.ruleChange.disableTitle',
+              {
+                defaultMessage: 'Disable {ruleName}',
+                values: { ruleName },
+              }
+            )}
+          >
+            <EuiText size="s">
+              {i18n.translate(
+                'xpack.securitySolution.agentBuilder.actionProposal.ruleChange.disableDescription',
+                {
+                  defaultMessage:
+                    'Approving this proposal disables the rule so it stops running until someone re-enables it.',
+                }
+              )}
+            </EuiText>
+          </EuiCallOut>
+          <EuiSpacer size="s" />
+        </>
+      )}
+      <ChangedFieldsRow fields={payload.changed_fields} />
+      <EuiSpacer size="s" />
+      <EuiAccordion
+        id={detailsAccordionId}
+        initialIsOpen={false}
+        buttonContent={detailsButtonLabel}
+        paddingSize="s"
+      >
+        {canDiff ? (
+          <EuiErrorBoundary>
+            <RuleDiffTab
+              oldRule={current}
+              newRule={proposed}
+              leftDiffSideLabel={i18n.translate(
+                'xpack.securitySolution.agentBuilder.actionProposal.ruleUpdate.currentLabel',
+                { defaultMessage: 'Current rule' }
+              )}
+              leftDiffSideDescription={i18n.translate(
+                'xpack.securitySolution.agentBuilder.actionProposal.ruleUpdate.currentDescription',
+                { defaultMessage: 'The rule as it currently runs.' }
+              )}
+              rightDiffSideLabel={i18n.translate(
+                'xpack.securitySolution.agentBuilder.actionProposal.ruleUpdate.proposedLabel',
+                { defaultMessage: 'Proposed' }
+              )}
+              rightDiffSideDescription={i18n.translate(
+                'xpack.securitySolution.agentBuilder.actionProposal.ruleUpdate.proposedDescription',
+                { defaultMessage: "The agent's proposed change. Not yet applied." }
+              )}
+            />
+          </EuiErrorBoundary>
+        ) : (
+          <RuleChangeFallback payload={payload} />
+        )}
+      </EuiAccordion>
+      {status === 'pending' && (
+        <>
+          <EuiSpacer size="s" />
+          <ApproveDismissButtons
+            disabled={false}
+            isLoading={isLoading}
+            canApprove={canApprove}
+            onApprove={onApprove}
+            onDismiss={onDismiss}
+            approveColor={isDisable ? 'danger' : 'primary'}
+            approveLabel={i18n.translate(
+              isDisable
+                ? 'xpack.securitySolution.agentBuilder.actionProposal.ruleChange.disable'
+                : 'xpack.securitySolution.agentBuilder.actionProposal.ruleChange.apply',
+              {
+                defaultMessage: isDisable ? 'Disable rule' : 'Apply rule change',
+              }
+            )}
+          />
+        </>
+      )}
+    </>
+  );
+};
+
+const RuleInstallView: React.FC<{
+  payload: RuleInstallPayload;
+  status: ActionProposalStatus;
+  isLoading: boolean;
+  canApprove: boolean;
+  onApprove: () => void;
+  onDismiss: () => void;
+}> = ({ payload, status, isLoading, canApprove, onApprove, onDismiss }) => {
+  const columns: Array<EuiBasicTableColumn<RuleInstallEntry>> = [
+    {
+      field: 'name',
+      name: i18n.translate(
+        'xpack.securitySolution.agentBuilder.actionProposal.ruleInstall.colName',
+        { defaultMessage: 'Rule' }
+      ),
+      render: (name: string, item: RuleInstallEntry) => (
+        <EuiFlexGroup direction="column" gutterSize="none">
+          <EuiFlexItem>
+            <EuiText size="s">
+              <strong>{name}</strong>
+            </EuiText>
+          </EuiFlexItem>
+          {item.why && (
+            <EuiFlexItem>
+              <EuiText size="xs" color="subdued">
+                {item.why}
+              </EuiText>
+            </EuiFlexItem>
+          )}
+        </EuiFlexGroup>
+      ),
+    },
+    {
+      field: 'severity',
+      name: i18n.translate(
+        'xpack.securitySolution.agentBuilder.actionProposal.ruleInstall.colSeverity',
+        { defaultMessage: 'Severity' }
+      ),
+      width: '120px',
+      render: (severity?: string) =>
+        severity ? <EuiBadge color="hollow">{severity}</EuiBadge> : null,
+    },
+  ];
+
+  return (
+    <>
+      <EuiSpacer size="s" />
+      <EuiBasicTable<RuleInstallEntry>
+        items={payload.rules}
+        columns={columns}
+        tableLayout="auto"
+        compressed
+        tableCaption={i18n.translate(
+          'xpack.securitySolution.agentBuilder.actionProposal.ruleInstall.tableCaption',
+          { defaultMessage: 'Rules included in this installation proposal' }
+        )}
+      />
+      {status === 'pending' && (
+        <>
+          <EuiSpacer size="s" />
+          <ApproveDismissButtons
+            disabled={false}
+            isLoading={isLoading}
+            canApprove={canApprove}
+            onApprove={onApprove}
+            onDismiss={onDismiss}
+            approveLabel={i18n.translate(
+              'xpack.securitySolution.agentBuilder.actionProposal.ruleInstall.install',
+              { defaultMessage: 'Install rules' }
+            )}
+          />
+        </>
+      )}
+    </>
+  );
+};
+
+const RuleExceptionProposalItem: React.FC<{
+  index: number;
+  item: RuleExceptionAddPayload['items'][number];
+}> = ({ index, item }) => (
+  <>
+    <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
+      <EuiFlexItem grow={false}>
+        <EuiBadge color="hollow">{item.type}</EuiBadge>
+      </EuiFlexItem>
+      <EuiFlexItem>
+        <EuiText size="s">
+          <strong>{item.name}</strong>
+        </EuiText>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+    {item.description ? (
+      <>
+        <EuiSpacer size="xs" />
+        <EuiText size="xs" color="subdued">
+          {item.description}
+        </EuiText>
+      </>
+    ) : null}
+    <EuiSpacer size="xs" />
+    <ExceptionItemCardConditions
+      os={item.os_types}
+      entries={item.entries}
+      dataTestSubj={`actionProposalRuleExceptionConditions-${index}`}
+    />
+  </>
+);
+
+const RuleExceptionAddView: React.FC<{
+  payload: RuleExceptionAddPayload;
+  status: ActionProposalStatus;
+  isLoading: boolean;
+  canApprove: boolean;
+  onApprove: () => void;
+  onDismiss: () => void;
+}> = ({ payload, status, isLoading, canApprove, onApprove, onDismiss }) => {
+  const ruleName = payload.rule_name ?? payload.rule_id;
+
+  return (
+    <>
+      <EuiSpacer size="s" />
+      <EuiCallOut
+        size="s"
+        iconType="plusInCircle"
+        color="primary"
+        announceOnMount={false}
+        title={i18n.translate(
+          'xpack.securitySolution.agentBuilder.actionProposal.ruleExceptionAdd.title',
+          {
+            defaultMessage:
+              'Add {count} exception {count, plural, one {item} other {items}} to {ruleName}',
+            values: {
+              count: payload.items.length,
+              ruleName,
+            },
+          }
+        )}
+      >
+        <EuiText size="s">
+          {i18n.translate(
+            'xpack.securitySolution.agentBuilder.actionProposal.ruleExceptionAdd.description',
+            {
+              defaultMessage:
+                'Approving this proposal adds the exception items to the rule default exception list. If the rule does not have one yet, it will be created automatically.',
+            }
+          )}
+        </EuiText>
+      </EuiCallOut>
+      <EuiSpacer size="s" />
+      {payload.items.map((item, index) => (
+        <React.Fragment key={item.item_id ?? `${item.name}-${item.description}`}>
+          {index > 0 ? <EuiSpacer size="m" /> : null}
+          <RuleExceptionProposalItem index={index} item={item} />
+        </React.Fragment>
+      ))}
+      {status === 'pending' && (
+        <>
+          <EuiSpacer size="s" />
+          <ApproveDismissButtons
+            disabled={false}
+            isLoading={isLoading}
+            canApprove={canApprove}
+            onApprove={onApprove}
+            onDismiss={onDismiss}
+            approveLabel={i18n.translate(
+              'xpack.securitySolution.agentBuilder.actionProposal.ruleExceptionAdd.apply',
+              {
+                defaultMessage: payload.items.length === 1 ? 'Add exception' : 'Add exceptions',
+              }
+            )}
+          />
+        </>
+      )}
+    </>
+  );
+};
+
+// ────────────────────────────────────────────────────────────────────────────
+// Dispatch — main inline renderer
+// ────────────────────────────────────────────────────────────────────────────
+
+const ActionProposalInlineContent: React.FC<
+  AttachmentRenderProps<ActionProposalAttachment> & { deps: ActionProposalDeps }
+> = ({ attachment, deps }) => {
+  const data = attachment.data;
+  // Local state — optimistic update. Platform currently has no client-side
+  // attachment-data-update API, so the applied/dismissed state is session-local.
+  // Reloading the conversation will show the server-side status (still pending)
+  // until the Agent Builder team adds an updateAttachmentData primitive.
+  const [status, setStatus] = useState<ActionProposalStatus>(data.status);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | undefined>(data.error);
+  const [appliedAt, setAppliedAt] = useState<string | undefined>(data.applied_at);
+  const queryClient = useQueryClient();
+
+  const handleApprove = useCallback(async () => {
+    setIsLoading(true);
+    setError(undefined);
+    try {
+      await executeAction(data.payload, deps.http);
+      // Refresh any rule details / list pages that may be open so they show
+      // the new rule state without a manual reload.
+      invalidateRuleCachesForPayload(queryClient, data.payload);
+      const now = new Date().toISOString();
+      setStatus('applied');
+      setAppliedAt(now);
+      deps.notifications.toasts.addSuccess({
+        title: i18n.translate('xpack.securitySolution.agentBuilder.actionProposal.successToast', {
+          defaultMessage: '{summary} applied',
+          values: { summary: data.summary },
+        }),
+      });
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      setStatus('failed');
+      setError(message);
+      deps.notifications.toasts.addDanger({
+        title: i18n.translate('xpack.securitySolution.agentBuilder.actionProposal.errorToast', {
+          defaultMessage: 'Failed to apply',
+        }),
+        text: message,
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  }, [data, deps, queryClient]);
+
+  const handleDismiss = useCallback(() => {
+    setStatus('dismissed');
+  }, []);
+
+  // Privilege gate: proposal types map to different APIs. Server-side routes still
+  // enforce authz independently; this is about not offering a button the user's
+  // click would fail on.
+  const canApprove = canApproveAction(data.payload, deps.application);
+
+  let body: React.ReactNode;
+  switch (data.payload.action_type) {
+    case 'rule_change':
+      body = (
+        <RuleChangeView
+          payload={data.payload}
+          status={status}
+          isLoading={isLoading}
+          canApprove={canApprove}
+          onApprove={handleApprove}
+          onDismiss={handleDismiss}
+        />
+      );
+      break;
+    case 'rule_exception_add':
+      body = (
+        <RuleExceptionAddView
+          payload={data.payload}
+          status={status}
+          isLoading={isLoading}
+          canApprove={canApprove}
+          onApprove={handleApprove}
+          onDismiss={handleDismiss}
+        />
+      );
+      break;
+    case 'rule_install':
+      body = (
+        <RuleInstallView
+          payload={data.payload}
+          status={status}
+          isLoading={isLoading}
+          canApprove={canApprove}
+          onApprove={handleApprove}
+          onDismiss={handleDismiss}
+        />
+      );
+      break;
+    default:
+      body = (
+        <EuiText size="s" color="subdued">
+          {i18n.translate('xpack.securitySolution.agentBuilder.actionProposal.unknownAction', {
+            defaultMessage: 'Unsupported action type.',
+          })}
+        </EuiText>
+      );
+  }
+
+  return (
+    <EuiPanel paddingSize="m" hasBorder>
+      <ProposalHeader summary={data.summary} reason={data.reason} />
+      {body}
+      <MetricsRow metrics={data.metrics} />
+      <EuiSpacer size="s" />
+      <StatusBanner
+        status={status}
+        appliedBy={data.applied_by}
+        appliedAt={appliedAt}
+        error={error}
+      />
+      {isLoading && (
+        <>
+          <EuiSpacer size="xs" />
+          <EuiFlexGroup alignItems="center" gutterSize="s">
+            <EuiFlexItem grow={false}>
+              <EuiLoadingSpinner size="s" />
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <EuiText size="xs" color="subdued">
+                {i18n.translate(
+                  'xpack.securitySolution.agentBuilder.actionProposal.applyingLabel',
+                  { defaultMessage: 'Applying…' }
+                )}
+              </EuiText>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </>
+      )}
+    </EuiPanel>
+  );
+};
+
+// ────────────────────────────────────────────────────────────────────────────
+// Registration
+// ────────────────────────────────────────────────────────────────────────────
+
+export const registerActionProposalAttachment = ({
+  attachments,
+  http,
+  notifications,
+  application,
+}: {
+  attachments: AttachmentServiceStartContract;
+  http: HttpStart;
+  notifications: NotificationsStart;
+  application: ApplicationStart;
+}): void => {
+  const deps: ActionProposalDeps = { http, notifications, application };
+  attachments.addAttachmentType<ActionProposalAttachment>(
+    SecurityAgentBuilderAttachments.actionProposal,
+    {
+      getLabel: (attachment) =>
+        attachment.data?.summary ??
+        i18n.translate('xpack.securitySolution.agentBuilder.actionProposal.label', {
+          defaultMessage: 'Action proposal',
+        }),
+      getIcon: () => 'wrench',
+      renderInlineContent: (props) => <ActionProposalInlineContent {...props} deps={deps} />,
+    }
+  );
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/plugin.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/plugin.tsx
@@ -76,6 +76,7 @@ import { defaultDeepLinks } from './app/links/default_deep_links';
 import { AIValueReportLocatorDefinition } from '../common/locators/ai_value_report/locator';
 import { registerAttachmentUiDefinitions } from './agent_builder/attachment_types';
 import { registerRuleAttachment } from './agent_builder/attachment_types/rule_attachment';
+import { registerActionProposalAttachment } from './agent_builder/attachment_types/action_proposal';
 
 export class Plugin implements IPlugin<PluginSetup, PluginStart, SetupPlugins, StartPlugins> {
   private config: SecuritySolutionUiConfigType;
@@ -297,6 +298,12 @@ export class Plugin implements IPlugin<PluginSetup, PluginStart, SetupPlugins, S
         attachments: plugins.agentBuilder.attachments,
         application: core.application,
         aiRuleCreation: this.services.aiRuleCreation,
+      });
+      registerActionProposalAttachment({
+        attachments: plugins.agentBuilder.attachments,
+        http: core.http,
+        notifications: core.notifications,
+        application: core.application,
       });
     }
 

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/attachments/action_proposal.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/attachments/action_proposal.ts
@@ -1,0 +1,100 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { AttachmentTypeDefinition } from '@kbn/agent-builder-server/attachments';
+import type { Attachment } from '@kbn/agent-builder-common/attachments';
+import { SecurityAgentBuilderAttachments } from '../../../common/constants';
+import {
+  actionProposalDataSchema as actionProposalSchema,
+  type ActionProposalData,
+} from '../../../common/agent_builder/action_recommendation';
+export type {
+  ActionProposalData,
+  ActionProposalStatus,
+  RuleChangePayload,
+  RuleExceptionAddPayload,
+  RuleInstallPayload,
+} from '../../../common/agent_builder/action_recommendation';
+import { SECURITY_PROPOSE_ACTION_TOOL_ID } from '../tools/core';
+
+const isActionProposalData = (data: unknown): data is ActionProposalData =>
+  actionProposalSchema.safeParse(data).success;
+
+/**
+ * Generic "action proposal" attachment. A skill that wants the user to approve a
+ * mutation (rule update, prebuilt-rule install, exception add, delete, toggle, ...)
+ * writes one of these via `attachments.add`. The client renderer dispatches on
+ * `payload.action_type` to an action-specific view with Approve / Dismiss buttons.
+ * The button handler performs the mutation via `http.fetch` — from the browser,
+ * using the user's real session — so the mutation is authenticated correctly and
+ * audit-attributed to the user.
+ *
+ * Skills MUST NOT call mutation APIs directly. They only create proposals.
+ */
+export const createActionProposalAttachmentType = (): AttachmentTypeDefinition => {
+  return {
+    id: SecurityAgentBuilderAttachments.actionProposal,
+    validate: (input) => {
+      const result = actionProposalSchema.safeParse(input);
+      if (result.success) {
+        return { valid: true, data: result.data };
+      }
+      return { valid: false, error: result.error.message };
+    },
+    format: (attachment: Attachment<string, unknown>) => {
+      const data = attachment.data;
+      if (!isActionProposalData(data)) {
+        throw new Error(`Invalid action-proposal attachment data for ${attachment.id}`);
+      }
+      return {
+        getRepresentation: () => ({
+          type: 'text' as const,
+          value: formatActionProposal(data),
+        }),
+      };
+    },
+    getAgentDescription:
+      () => `This attachment type represents an ACTION PROPOSAL waiting for user approval. The user sees it rendered in chat with action-specific UI (for example: a diff for rule_change or a rules table for rule_install) plus Approve / Dismiss buttons.
+
+Key rules for agents:
+1. Prefer the \`security.core.propose_action\` tool to create these attachments so skills stay focused on reasoning rather than handcrafting payload JSON.
+2. If there is already a pending proposal for the same rule and the same strategy, and the user asks for another compatible change ("also lower the severity", "make it run every 5m", "add one more exception item"), call \`security.core.propose_action\` again so the server updates the existing pending proposal instead of creating a second card.
+3. If the user's new request is clearly unrelated to the current proposal's goal, start a new flow instead of forcing it into the existing proposal.
+4. MUST NOT call mutation APIs directly. Mutations happen in the browser on user click.
+5. After creating or updating the proposal, render the attachment inline and stop — wait for the user.
+6. If the user reopens the conversation later and the attachment is already \`applied\` or \`dismissed\`, do not re-propose; acknowledge the prior decision.
+`,
+    getTools: () => [SECURITY_PROPOSE_ACTION_TOOL_ID],
+  };
+};
+
+const formatActionProposal = (data: ActionProposalData): string => {
+  const base = `[action proposal] status=${data.status} | ${data.payload.action_type}: ${data.summary}`;
+  if (data.payload.action_type === 'rule_change') {
+    const details = [
+      `rule_id=${data.payload.rule_id}`,
+      ...(data.payload.changed_fields.length > 0
+        ? [`changed_fields=${data.payload.changed_fields.join(',')}`]
+        : []),
+    ];
+
+    if (data.reason) return `${base}\n${details.join(' | ')}\nReason: ${data.reason}`;
+    return `${base}\n${details.join(' | ')}`;
+  }
+  if (data.payload.action_type === 'rule_exception_add') {
+    const details = [
+      `rule_id=${data.payload.rule_id}`,
+      `items=${data.payload.items.length}`,
+      ...data.payload.items.slice(0, 3).map((item) => `item=${item.name}`),
+    ];
+
+    if (data.reason) return `${base}\n${details.join(' | ')}\nReason: ${data.reason}`;
+    return `${base}\n${details.join(' | ')}`;
+  }
+  if (data.reason) return `${base}\nReason: ${data.reason}`;
+  return base;
+};

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/attachments/alert.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/attachments/alert.ts
@@ -81,10 +81,15 @@ SECURITY ALERT DATA:
 Complete in order:
 
 1. Extract alert id(s): _id
-2. Extract rule name: kibana.alert.rule.name
-3. Extract entities: host.name, user.name, service.name
-4. Extract MITRE fields: kibana.alert.rule.threat.tactic.id, kibana.alert.rule.threat.technique.id, threat.tactic.id
-5. Use the available tools to gather context about the alert and provide a response.`;
+2. Extract rule id: kibana.alert.rule.uuid (this is the rule's saved-object id)
+3. Extract rule name: kibana.alert.rule.name
+4. Extract entities: host.name, user.name, service.name
+5. Extract MITRE fields: kibana.alert.rule.threat.tactic.id, kibana.alert.rule.threat.technique.id, threat.tactic.id
+
+Then pick the skill matching the user's intent:
+- If the user asks "is this a false positive?" / "why is this noisy?" / "can you tune the rule that produced this alert?" → load the fix-false-positive-alerts skill from the skills/security/alerts/rules directory. The skill will hydrate the rule (using the extracted kibana.alert.rule.uuid) and propose a tuning change on it.
+- For alert triage / investigation / correlation → load the alert-analysis skill from the skills/security/alerts directory.
+- Otherwise use the available tools directly to answer.`;
       return description;
     },
   };

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/attachments/register_attachments.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/attachments/register_attachments.ts
@@ -9,6 +9,7 @@ import type { AgentBuilderPluginSetup } from '@kbn/agent-builder-plugin/server';
 import { createRuleAttachmentType } from './rule';
 import { createAlertAttachmentType } from './alert';
 import { createEntityAttachmentType } from './entity';
+import { createActionProposalAttachmentType } from './action_proposal';
 
 /**
  * Registers all security agent builder attachments with the agentBuilder plugin
@@ -17,4 +18,5 @@ export const registerAttachments = async (agentBuilder: AgentBuilderPluginSetup)
   agentBuilder.attachments.registerType(createAlertAttachmentType());
   agentBuilder.attachments.registerType(createEntityAttachmentType());
   agentBuilder.attachments.registerType(createRuleAttachmentType());
+  agentBuilder.attachments.registerType(createActionProposalAttachmentType());
 };

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/attachments/rule.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/attachments/rule.ts
@@ -19,6 +19,8 @@ export const ruleAttachmentDataSchema = securityAttachmentDataSchema.extend({
 });
 
 const DETECTION_RULE_SKILL_NAME_ID = 'detection-rule-edit';
+const FIX_FP_SKILL_NAME_ID = 'fix-false-positive-alerts';
+const FIX_RULE_FAILURES_SKILL_NAME_ID = 'fix-rule-execution-failures';
 
 type RuleAttachmentData = z.infer<typeof ruleAttachmentDataSchema>;
 
@@ -67,10 +69,15 @@ SECURITY RULE DATA:
 {ruleData}
 
 ---
-Complete in order:
+Pick the skill that matches the user's intent and load it with read_skill before doing anything else. Do NOT default to an alerts-triage skill just because the user mentions the word "alerts" — if the attachment is a rule and the user is asking about the rule's behavior, the rule-focused skills below are the correct entry point.
 
-1. When asked to modify, update, or create a detection rule, ALWAYS read the ${DETECTION_RULE_SKILL_NAME_ID} skill from the skills/security/rules directory.
-2. Use the available tools to research, create, or edit the rule and provide a response.`;
+If there is ALSO a pending security.action_proposal attachment in the conversation for this same rule and the user is clearly tweaking that proposed remediation ("also...", "instead...", "change the proposal to..."), prefer continuing that pending proposal flow rather than switching to a generic rule-editing experience, as long as the new request still fits the proposal's goal.
+
+- If the user asks "is this a false positive?" / "are these alerts noisy?" / "can you tune this rule?" / "reduce false positives on this rule" / any intent to DIAGNOSE NOISE on an attached rule and propose a tuning fix → load the ${FIX_FP_SKILL_NAME_ID} skill from the skills/security/alerts/rules directory.
+- If the user says the rule is BROKEN, FAILING, throwing EXECUTION ERRORS, or asks whether to STOP / DISABLE it because of failures → load the ${FIX_RULE_FAILURES_SKILL_NAME_ID} skill from the skills/security/alerts/rules directory.
+- If the user asks to CREATE, EDIT, or UPDATE the rule itself (change its name, tags, severity, MITRE mappings, query syntax, etc.) → load the ${DETECTION_RULE_SKILL_NAME_ID} skill from the skills/security/rules directory.
+
+If the intent is ambiguous, prefer ${FIX_FP_SKILL_NAME_ID} whenever the user is asking about the rule's ALERT VOLUME or QUALITY (false positives, noise, tuning), prefer ${FIX_RULE_FAILURES_SKILL_NAME_ID} when the user is asking about RULE FAILURES OR WHETHER TO STOP THE RULE, and prefer ${DETECTION_RULE_SKILL_NAME_ID} when the user is asking about the rule's CONFIGURATION.`;
       return description;
     },
   };

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/find_noisy_rules/find_noisy_rules_skill.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/find_noisy_rules/find_noisy_rules_skill.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { defineSkillType } from '@kbn/agent-builder-server/skills/type_definition';
+import { attachmentTools } from '@kbn/agent-builder-common';
+import {
+  SECURITY_FIND_NOISY_RULES_TOOL_ID,
+  SECURITY_GET_RULE_DETAILS_TOOL_ID,
+} from '../../tools/core';
+import { SecurityAgentBuilderAttachments } from '../../../../common/constants';
+
+export const getFindNoisyRulesSkill = () =>
+  defineSkillType({
+    id: 'find-noisy-rules',
+    name: 'find-noisy-rules',
+    basePath: 'skills/security/alerts/rules',
+    description:
+      'Discover the detection rules producing the most alerts in a recent time window. Use when the user asks "which rules are noisy?", "show top N rules by alerts", "what rules fire the most in the last hour", or similar. Returns an inline ranked table; on user pick, attaches the chosen rule by-reference so the next user message can naturally hand off to a tuning skill (fix-false-positive-alerts, etc.).',
+    content: SKILL_CONTENT,
+    getRegistryTools: () => [
+      SECURITY_FIND_NOISY_RULES_TOOL_ID,
+      SECURITY_GET_RULE_DETAILS_TOOL_ID,
+      attachmentTools.add,
+    ],
+  });
+
+const SKILL_CONTENT = `# Find Noisy Rules
+
+## When to use this skill
+
+Use when the user asks something like:
+- "which rules are noisy?"
+- "show top 3 rules by alerts in the last hour"
+- "what rules fire the most?"
+- "find loudest detections this week"
+
+## Hard rules
+
+1. **MUST NOT** create any \`security.action_proposal\` attachment in this skill. This skill discovers rules; it does not propose mutations. Tuning is a separate skill (\`fix-false-positive-alerts\`).
+2. **MUST** render the result as a compact table inside the agent's reply, not as an attachment. Read-only data stays inline.
+3. **MUST NOT** auto-attach all returned rules. Only attach a rule when the user explicitly picks one.
+
+## Workflow
+
+### Step 1 — Resolve window and N
+
+Default \`timeframe_hours = 1\` and \`top_n = 3\`. If the user specifies a different window ("last 24h", "this week") or count ("top 5"), use those.
+
+### Step 2 — Call the tool
+
+Call \`security.core.find_noisy_rules\` with the resolved parameters.
+
+### Step 3 — Render
+
+Format the result as a Markdown table with columns: index, rule name, severity, alert count, enabled. Include the rule_id in a way the user can reference (e.g. show last 8 chars of the id, or include them in a foot-line per row). End with a one-line invitation: "Reply with the row number or rule name to look closer at one of these."
+
+If \`rules\` is empty, say "No alerts in the last \${hours} hours" and stop.
+
+### Step 4 — On user pick, attach by-reference
+
+When the user picks a rule (by row number, name, or partial id), call \`attachment.add\` with:
+
+\`\`\`
+{
+  type: "${SecurityAgentBuilderAttachments.rule}",
+  origin: "<rule_id>",
+  description: "Rule: <rule name>"
+}
+\`\`\`
+
+The \`origin\` field is what makes it by-reference — the platform resolves the live rule and keeps the attachment fresh as the rule changes.
+
+Then say: "I've attached rule <name>. What would you like to do? Common options: tune false positives, check execution errors, view alerts."
+
+### Step 5 — Stop
+
+Do NOT load the tuning skill yourself or call any tuning tool. The user's next message will trigger the right downstream skill (\`fix-false-positive-alerts\`, \`fix-rule-execution-failures\`, \`detection-rule-edit\`) based on their intent and the now-attached rule.
+`;

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/find_noisy_rules/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/find_noisy_rules/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { getFindNoisyRulesSkill } from './find_noisy_rules_skill';

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/fix_false_positive_alerts/fix_false_positive_alerts_skill.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/fix_false_positive_alerts/fix_false_positive_alerts_skill.ts
@@ -1,0 +1,224 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { defineSkillType } from '@kbn/agent-builder-server/skills/type_definition';
+import { attachmentTools } from '@kbn/agent-builder-common';
+import {
+  SECURITY_GET_RULE_DETAILS_TOOL_ID,
+  SECURITY_SEARCH_ALERTS_BY_RULE_TOOL_ID,
+  SECURITY_AGGREGATE_ALERTS_FOR_RULE_TOOL_ID,
+  SECURITY_PREVIEW_RULE_TOOL_ID,
+  SECURITY_PROPOSE_ACTION_TOOL_ID,
+} from '../../tools/core';
+
+export const getFixFalsePositiveAlertsSkill = () =>
+  defineSkillType({
+    id: 'fix-false-positive-alerts',
+    name: 'fix-false-positive-alerts',
+    basePath: 'skills/security/alerts/rules',
+    description:
+      'Diagnose whether a detection rule is producing false-positive alerts and propose a focused remediation. Use when the user attaches a rule (or an alert) and asks whether it is noisy, whether a specific pattern is a false positive, asks to tune a rule, asks to add an exception, or asks for a compatible follow-up tweak to an existing false-positive proposal. By default the skill publishes an action-proposal attachment in chat, but it can also be used in a staged way by callers that explicitly ask for reasoning-only output or structured action JSON without creating a card.',
+    content: SKILL_CONTENT,
+    getRegistryTools: () => [
+      SECURITY_GET_RULE_DETAILS_TOOL_ID,
+      SECURITY_SEARCH_ALERTS_BY_RULE_TOOL_ID,
+      SECURITY_AGGREGATE_ALERTS_FOR_RULE_TOOL_ID,
+      SECURITY_PREVIEW_RULE_TOOL_ID,
+      // attachment_read is still needed to resolve the attached rule; proposal
+      // creation now goes through a shared proposer tool so this skill's logic
+      // stays reusable for later deterministic flows.
+      attachmentTools.read,
+      SECURITY_PROPOSE_ACTION_TOOL_ID,
+    ],
+  });
+
+const SKILL_CONTENT = `# Fix False Positive Alerts
+
+## When to use this skill
+
+Use this skill when the user:
+- Attaches a detection rule (or an alert) and asks "is this a false positive?" / "why is this rule noisy?" / "can you tune this rule?"
+- Asks to reduce false positives on a specific rule.
+- Asks to add an exception instead of changing the rule query.
+- Follows up on an existing false-positive tuning proposal for that same rule with another compatible tweak such as "also lower the severity" or "make it run every 5m".
+
+This skill's primary job is to reduce noise without unnecessarily weakening the detection. Start with the smallest change justified by the alert analysis. That may be a query-level exclusion or a rule exception item. Compatible follow-up changes that still support the same goal can be folded into the same pending proposal when they stay within the same strategy. Unrelated rule-editing requests (name, tags, MITRE mappings, etc.) should not be silently absorbed into this remediation flow.
+
+## Hard rules (must follow exactly)
+
+1. **MUST NOT** perform any rule mutation yourself. You never apply the change. You only propose. The user approves the action by clicking a button in the action-proposal attachment — that browser click is what performs the actual mutation (which is why the approval flow is out-of-agent, not a tool call).
+2. **MUST** run \`security.core.preview_rule\` BEFORE creating or updating a proposal that changes the rule query. If the preview's \`is_improved\` is false, or \`is_over_tuned\` is true, DO NOT propose that query change — tell the user why and stop.
+3. **MUST** produce at most one remediation strategy for the current turn. Do not mix query tuning and exception creation in a single answer.
+4. **MUST** default to full proposal mode unless the caller explicitly asks for a staged output such as reasoning-only or action-json-only.
+
+## Operating modes
+
+This skill supports three modes. The caller decides the mode explicitly. If the caller does not say otherwise, use **Proposal mode**.
+
+### Mode A — Proposal mode (default chat behavior)
+
+Use all stages below. At the end, call \`security.core.propose_action\`, render the returned attachment inline, and briefly explain the recommendation.
+
+### Mode B — Reasoning-only mode
+
+If the caller explicitly asks for assessment only, reasoning only, diagnosis only, or says not to create a proposal yet:
+- resolve only the missing context
+- analyze the rule and alerts
+- choose the best remediation strategy
+- stop before proposal creation
+
+Return compact JSON only:
+
+\`\`\`json
+{
+  "context": {
+    "rule_id": "<saved-object rule id>",
+    "signals": ["<high-signal observations>"]
+  },
+  "reasoning": {
+    "recommended_strategy": "rule_change | rule_exception_add | no_action",
+    "confidence": "low | medium | high",
+    "reason": "<why this is the safest next step>"
+  }
+}
+\`\`\`
+
+### Mode C — Action JSON only
+
+If the caller explicitly asks for a proposed action without creating a card:
+- do the same analysis as Proposal mode
+- stop before calling \`security.core.propose_action\`
+- return structured action JSON only
+
+Return compact JSON only:
+
+\`\`\`json
+{
+  "summary": "<stable one-line summary>",
+  "reason": "<one sentence on why this action should help>",
+  "action": {
+    "action_type": "rule_change | rule_exception_add",
+    "rule_id": "<saved-object rule id>",
+    "...": "action-specific fields"
+  }
+}
+\`\`\`
+
+## Workflow
+
+Treat the workflow below as staged. A caller can stop after Step 4 for Reasoning-only mode, stop after Step 5 for Action JSON only, or continue through Step 5 and Step 6 for Proposal mode.
+
+### Step 1 — Resolve context
+
+Two entry points. Handle whichever you have:
+
+**Rule attached:** Read the rule attachment with \`attachment_read\`. Parse \`data.text\` as JSON. The \`.id\` field is the rule's saved-object id — this is the \`rule_id\` to pass to every tool below.
+
+**Alert attached (no rule):** Extract \`kibana.alert.rule.uuid\` from the alert — that is the \`rule_id\`. Call \`security.core.get_rule_details\` with that \`rule_id\` to fetch the rule (you need its full JSON in the next step).
+
+**Caller-provided context:** If the caller already supplied a reliable saved-object \`rule_id\`, normalized rule JSON, alert summary, or dominant entities, reuse that input and only fetch what is still missing.
+
+### Step 2 — Assess noise
+
+Call \`security.core.search_alerts_by_rule\` and \`security.core.aggregate_alerts_for_rule\` with the resolved \`rule_id\`. Inspect the results:
+- If the total count is low (< 10 in the default window), tell the user the rule is not noisy and stop.
+- Otherwise, look at the aggregation buckets. A single dominant bucket in \`by_parent_process\`, \`by_user\`, or \`by_host\` is a strong signal for an exclusion target. Parent process is usually the highest-value signal (it identifies a specific benign automation, e.g. \`ci-runner\`, \`puppet\`, \`ansible-playbook\`).
+
+### Step 3 — Hypothesise an exclusion
+
+Pick the field + values that look most like benign activity. Examples:
+- \`process.parent.name\` is \`["ci-runner"]\` — 87% of alerts came from this parent.
+- \`user.name\` is \`["svc-backup"]\` — service account responsible for most alerts.
+
+Prefer narrow exclusions. Never exclude on \`host.name\` alone unless the narrative justifies excluding an entire host.
+
+### Step 4 — Choose the strategy
+
+Choose **query change** when:
+- the fix naturally belongs in the rule logic,
+- the user asks to tune or change the query,
+- or you need to change rule fields like \`query\`, \`language\`, \`severity\`, \`interval\`, or \`from\`.
+
+Choose **rule exception** when:
+- the user explicitly asks for an exception,
+- or the safest fix is a narrow reusable exception item on one or more concrete fields/values.
+
+If you choose **query change**, call \`security.core.preview_rule\` with the hypothesised exclusions. Read the \`verdict\`:
+- \`is_improved = false\` → pick a different field or values; do not propose this change.
+- \`is_over_tuned = true\` → the exclusion is too broad; narrow it or pick a different field.
+- Good reduction → proceed to Step 5.
+
+If you choose **rule exception**, you can proceed directly to Step 5 using the field/value pattern you identified.
+
+### Step 5 — Materialize the recommendation
+
+Build a proposed remediation for the selected strategy.
+
+For **query change**:
+- First-turn diagnosis usually changes only \`query\` (and sometimes \`language\`).
+- Later compatible follow-ups on the same rule can add fields like \`severity\`, \`risk_score\`, \`interval\`, or \`from\` when they still support the same noise-reduction plan.
+
+For **rule exception**:
+- Create one or more exception items with a clear \`name\`, \`description\`, and \`entries\`.
+- Prefer simple, narrowly scoped entries such as \`match\`, \`match_any\`, \`exists\`, or \`wildcard\`.
+- Use \`operator: "included"\` for the standard "suppress alerts when this benign condition is present" case.
+
+Do NOT absorb unrelated metadata edits like renaming the rule, changing tags, or MITRE mappings into this remediation flow.
+
+In **Action JSON only** mode, stop here and return structured JSON using the same fields that would be passed to the proposer tool.
+
+In **Proposal mode**, create the proposal with the shared proposer tool:
+
+\`\`\`
+// Query change
+security.core.propose_action({
+  action_type: "rule_change",
+  rule_id: "<saved-object rule id>",
+  proposed_changes: {
+    "query": "<updated query string>"
+  },
+  intent: "query_tuning",
+  summary: "<stable one-line summary for the overall tuning plan, e.g. 'Tune Rule X to reduce false positives'>",
+  reason: "<one sentence — which entity you excluded and why>",
+  metrics: {
+    "original_count": <n>,
+    "surviving_count": <m>,
+    "reduction_percent": <p>
+  }
+})
+\`\`\`
+
+\`\`\`
+// Rule exception
+security.core.propose_action({
+  action_type: "rule_exception_add",
+  rule_id: "<saved-object rule id>",
+  items: [
+    {
+      "name": "Exclude ci-runner parent process",
+      "description": "Suppress alerts triggered by known benign CI automation",
+      "type": "simple",
+      "entries": [
+        {
+          "type": "match",
+          "field": "process.parent.name",
+          "operator": "included",
+          "value": "ci-runner"
+        }
+      ]
+    }
+  ],
+  summary: "Add exception to reduce false positives on Rule X",
+  reason: "<one sentence — which entity you excluded and why>",
+})
+\`\`\`
+
+Then render the returned attachment inline: \`<render_attachment id="<returned attachment id>" />\`. If a pending proposal with the same strategy for this rule already exists, the tool will update that same attachment instead of creating a second card. If the user switches strategies (for example from query tuning to adding an exception), create a separate proposal card. Briefly tell the user what you propose and why, and let them know they can click **Approve** on the attachment to apply the change (or **Dismiss** to discard it).
+
+### Step 6 — Stop
+
+That is the end of the skill's work for this turn. Do NOT call any further mutation tools. In Proposal mode, the user's click on the Approve button executes the change in the browser, attributed to the user. If the user follows up with another compatible "also..." change for the same remediation and the same strategy, call \`security.core.propose_action\` again so the pending proposal is updated in place. If the user pivots from query tuning to exceptions (or the reverse), create a new proposal instead of forcing both strategies into one card. In Reasoning-only or Action JSON only mode, stop after returning the requested JSON and do not render an attachment.`;

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/fix_false_positive_alerts/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/fix_false_positive_alerts/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { getFixFalsePositiveAlertsSkill } from './fix_false_positive_alerts_skill';

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/fix_rule_execution_failures/fix_rule_execution_failures_skill.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/fix_rule_execution_failures/fix_rule_execution_failures_skill.ts
@@ -1,0 +1,186 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { defineSkillType } from '@kbn/agent-builder-server/skills/type_definition';
+import { attachmentTools } from '@kbn/agent-builder-common';
+import {
+  SECURITY_GET_RULE_DETAILS_TOOL_ID,
+  SECURITY_PROPOSE_ACTION_TOOL_ID,
+} from '../../tools/core';
+
+export const getFixRuleExecutionFailuresSkill = () =>
+  defineSkillType({
+    id: 'fix-rule-execution-failures',
+    name: 'fix-rule-execution-failures',
+    basePath: 'skills/security/alerts/rules',
+    description:
+      'Diagnose a broken or repeatedly failing detection rule and propose a safe next action. Use it both for the first remediation recommendation and for compatible follow-up tweaks to that same remediation proposal. By default the skill publishes an action-proposal attachment in chat, but it can also be used in a staged way by callers that explicitly ask for reasoning-only output or structured action JSON without creating a card.',
+    content: SKILL_CONTENT,
+    getRegistryTools: () => [
+      SECURITY_GET_RULE_DETAILS_TOOL_ID,
+      SECURITY_PROPOSE_ACTION_TOOL_ID,
+      attachmentTools.read,
+    ],
+  });
+
+const SKILL_CONTENT = `# Fix Rule Execution Failures
+
+## When to use this skill
+
+Use this skill when the user:
+- Attaches a rule and says it is broken, failing, throwing execution errors, or should be stopped for now.
+- Describes a rule failure and wants you to recommend either a fix or a temporary stop-gap.
+- Follows up on an existing rule-failure remediation proposal for that same rule with another compatible stabilizing tweak.
+
+This skill only produces proposals. It never mutates a rule directly. Its goal is to stabilize or safely contain a failing rule. Compatible follow-up changes can be folded into the same pending remediation proposal. Unrelated metadata edits should not be silently absorbed into this remediation flow.
+
+## Hard rules
+
+1. **MUST NOT** call any mutation API directly. Only create a proposal via \`security.core.propose_action\`.
+2. **MUST** choose at most one remediation strategy for the current turn:
+   - \`rule_change\` with \`intent: "query_tuning"\` when there is a clear, narrow, low-risk query fix.
+   - \`rule_change\` with \`intent: "disable"\` and \`proposed_changes.enabled = false\` when the failure is persistent, unclear, unsafe to patch blindly, or the user explicitly wants the rule stopped.
+3. **MUST** default to full proposal mode unless the caller explicitly asks for a staged output such as reasoning-only or action-json-only.
+
+## Operating modes
+
+This skill supports three modes. The caller decides the mode explicitly. If the caller does not say otherwise, use **Proposal mode**.
+
+### Mode A — Proposal mode (default chat behavior)
+
+Use all stages below. At the end, call \`security.core.propose_action\`, render the returned attachment inline, and briefly explain the recommendation.
+
+### Mode B — Reasoning-only mode
+
+If the caller explicitly asks for assessment only, reasoning only, diagnosis only, or says not to create a proposal yet:
+- resolve only the missing context
+- analyze the failure shape
+- choose the safest remediation strategy
+- stop before proposal creation
+
+Return compact JSON only:
+
+\`\`\`json
+{
+  "context": {
+    "rule_id": "<saved-object rule id>",
+    "failure_signals": ["<key observations>"]
+  },
+  "reasoning": {
+    "recommended_strategy": "rule_change | disable | no_action",
+    "confidence": "low | medium | high",
+    "reason": "<why this is the safest next step>"
+  }
+}
+\`\`\`
+
+### Mode C — Action JSON only
+
+If the caller explicitly asks for a proposed action without creating a card:
+- do the same analysis as Proposal mode
+- stop before calling \`security.core.propose_action\`
+- return structured action JSON only
+
+Return compact JSON only:
+
+\`\`\`json
+{
+  "summary": "<stable one-line summary>",
+  "reason": "<one sentence on why this action should help>",
+  "action": {
+    "action_type": "rule_change",
+    "rule_id": "<saved-object rule id>",
+    "...": "action-specific fields"
+  }
+}
+\`\`\`
+
+## Workflow
+
+### Step 1 — Resolve the rule
+
+Preferred path:
+- If a rule attachment is present, read it with \`attachment_read\` and parse \`data.text\` as JSON. The \`.id\` field is the saved-object id for the rule.
+
+Fallback:
+- If the user already gave you the saved-object rule id, use it directly.
+- Otherwise, if you only have the rule id from some other context, call \`security.core.get_rule_details\`.
+
+Caller-provided context:
+- If the caller already supplied a reliable saved-object \`rule_id\`, normalized rule JSON, or a structured failure summary, reuse that input and only fetch what is still missing.
+
+### Step 2 — Decide whether this is a fix or a disable
+
+Use the user's failure description plus the current rule shape to decide:
+
+Choose **query change** only when all of the following are true:
+- The user described a specific query problem you can fix safely in one step.
+- The fix is narrow and localized to the query or language.
+- You can explain the exact change in one sentence.
+
+Typical examples:
+- The query references a field that is wrong and you can replace it with the intended one.
+- The query needs a small exclusion to avoid a broken data source or benign pattern.
+- The language setting is wrong for the current query string.
+
+Choose **disable rule** when any of the following is true:
+- The user explicitly asks to stop the rule.
+- The failure is persistent but the safe fix is unclear.
+- The error suggests broader investigation is needed outside a simple query edit.
+- A speculative query patch would be riskier than pausing the rule.
+
+### Step 3 — Build the remediation
+
+#### If proposing a query change
+
+Call:
+
+\`\`\`
+security.core.propose_action({
+  action_type: "rule_change",
+  rule_id: "<saved-object rule id>",
+  proposed_changes: {
+    "query": "<new query>"
+  },
+  intent: "query_tuning",
+  summary: "<short title>",
+  reason: "<one sentence on what failed and why this query fix should help>"
+})
+\`\`\`
+
+Only use this when you are confident about the exact query. Compatible follow-up stabilizing changes on the same rule can add fields such as \`language\`, \`interval\`, or \`from\` by calling the tool again. Do NOT absorb unrelated metadata edits into this remediation flow.
+
+#### If proposing to disable the rule
+
+Call:
+
+\`\`\`
+security.core.propose_action({
+  action_type: "rule_change",
+  rule_id: "<saved-object rule id>",
+  proposed_changes: {
+    "enabled": false
+  },
+  intent: "disable",
+  summary: "<short title>",
+  reason: "<one sentence on why disabling is the safest immediate action>"
+})
+\`\`\`
+
+In **Action JSON only** mode, stop here and return structured JSON using the same fields that would be passed to the proposer tool.
+
+### Step 4 — Render and stop
+
+In **Proposal mode**, render the returned attachment inline with \`<render_attachment id="<returned attachment id>" />\`. If a pending rule-change proposal for this rule already exists, the tool will update that same attachment instead of creating a second card.
+
+Tell the user, briefly:
+- what you are proposing,
+- why this is the safest next step,
+- and that they can click **Approve** to apply it.
+
+If the user follows up with another compatible stabilizing "also..." change for the same remediation, call \`security.core.propose_action\` again so the pending proposal is updated in place. In Reasoning-only or Action JSON only mode, stop after returning the requested JSON and do not render an attachment.
+`;

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/fix_rule_execution_failures/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/fix_rule_execution_failures/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { getFixRuleExecutionFailuresSkill } from './fix_rule_execution_failures_skill';

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/index.ts
@@ -9,4 +9,7 @@ export { alertAnalysisSkill } from './alert_analysis';
 export { threatHuntingSkill } from './threat_hunting';
 export { createAutomaticTroubleshootingSkill } from './automatic_troubleshooting';
 export { getDetectionRuleEditSkill } from './detection_rule_edit';
+export { getFixFalsePositiveAlertsSkill } from './fix_false_positive_alerts';
+export { getFixRuleExecutionFailuresSkill } from './fix_rule_execution_failures';
+export { getInstallRelevantPrebuiltRulesSkill } from './install_relevant_prebuilt_rules';
 export { registerSkills } from './register_skills';

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/install_relevant_prebuilt_rules/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/install_relevant_prebuilt_rules/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { getInstallRelevantPrebuiltRulesSkill } from './install_relevant_prebuilt_rules_skill';

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/install_relevant_prebuilt_rules/install_relevant_prebuilt_rules_skill.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/install_relevant_prebuilt_rules/install_relevant_prebuilt_rules_skill.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { defineSkillType } from '@kbn/agent-builder-server/skills/type_definition';
+import {
+  SECURITY_PROPOSE_ACTION_TOOL_ID,
+  SECURITY_REVIEW_PREBUILT_RULES_TO_INSTALL_TOOL_ID,
+} from '../../tools/core';
+
+export const getInstallRelevantPrebuiltRulesSkill = () =>
+  defineSkillType({
+    id: 'install-relevant-prebuilt-rules',
+    name: 'install-relevant-prebuilt-rules',
+    basePath: 'skills/security/alerts/rules',
+    description:
+      'Recommend and propose installation of relevant prebuilt detection rules. This MVP uses lightweight matching against installable prebuilt rule names and tags, then creates a rule-install proposal the user can approve from chat.',
+    content: SKILL_CONTENT,
+    getRegistryTools: () => [
+      SECURITY_REVIEW_PREBUILT_RULES_TO_INSTALL_TOOL_ID,
+      SECURITY_PROPOSE_ACTION_TOOL_ID,
+    ],
+  });
+
+const SKILL_CONTENT = `# Install Relevant Prebuilt Rules
+
+## When to use this skill
+
+Use this skill when the user:
+- Asks which prebuilt rules should be installed for a use case, integration, or threat theme.
+- Wants you to install a small relevant set of prebuilt rules from chat.
+
+This MVP skill uses lightweight matching against installable prebuilt rule names and tags. It is intentionally simple and exists to exercise the shared proposal flow and a different attachment UI.
+
+## Hard rules
+
+1. **MUST NOT** install rules directly. Only create a proposal via \`security.core.propose_action\`.
+2. **MUST** inspect candidate rules first with \`security.core.review_prebuilt_rules_to_install\`.
+3. **MUST** propose a small set, usually 1-5 rules, not a giant bulk install.
+
+## Workflow
+
+### Step 1 — Derive simple search hints
+
+From the user's request, derive:
+- \`tags\`: short category hints such as \`["Elastic", "Cloud"]\`, \`["Linux"]\`, \`["Execution"]\`
+- \`names\`: short name fragments only when the user gave a clear product or technique name
+
+Do not overfit. If the request is broad, prefer tags over names.
+
+### Step 2 — Review installable candidates
+
+Call:
+
+\`\`\`
+security.core.review_prebuilt_rules_to_install({
+  tags: [...],
+  names: [...],
+  limit: 10
+})
+\`\`\`
+
+Inspect the returned candidates and choose the most relevant subset.
+
+### Step 3 — Create the install proposal
+
+Call:
+
+\`\`\`
+security.core.propose_action({
+  action_type: "rule_install",
+  summary: "<short title>",
+  reason: "<one sentence on why these rules are relevant>",
+  rules: [
+    { rule_id: "<prebuilt rule signature id>", version: <version>, why: "<short per-rule note>" }
+  ]
+})
+\`\`\`
+
+Only include rules you can justify. If the candidates are weak or obviously unrelated, explain that and stop instead of forcing a proposal.
+
+### Step 4 — Render and stop
+
+Render the returned attachment inline with \`<render_attachment id="<returned attachment id>" />\`.
+
+After rendering the attachment, keep the reply very short:
+- 1-2 short sentences only
+- explain the overall theme of the selected rules at a high level
+- tell the user that clicking **Approve** will install them
+
+Do **NOT** repeat the selected rules as a markdown table, bullet list, or second detailed summary after rendering the attachment. The attachment is the canonical detailed view.`;

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/register_skills.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/register_skills.ts
@@ -14,8 +14,12 @@ import { getDetectionRuleEditSkill } from './detection_rule_edit';
 import { getEntityAnalyticsSkill } from './entity_analytics';
 import { threatHuntingSkill } from './threat_hunting';
 import { alertAnalysisSkill } from './alert_analysis';
+import { getFixFalsePositiveAlertsSkill } from './fix_false_positive_alerts';
+import { getFixRuleExecutionFailuresSkill } from './fix_rule_execution_failures';
 import type { EntityAnalyticsRoutesDeps } from '../../lib/entity_analytics/types';
 import { getSecurityMlJobsSkill } from './security_ml_jobs';
+import { getInstallRelevantPrebuiltRulesSkill } from './install_relevant_prebuilt_rules';
+import { getFindNoisyRulesSkill } from './find_noisy_rules';
 
 interface RegisterSkillsOpts {
   agentBuilder: AgentBuilderPluginSetup;
@@ -59,4 +63,8 @@ export const registerSkills = async ({
 
   await agentBuilder.skills.register(threatHuntingSkill);
   await agentBuilder.skills.register(alertAnalysisSkill);
+  agentBuilder.skills.register(getFixFalsePositiveAlertsSkill());
+  agentBuilder.skills.register(getFixRuleExecutionFailuresSkill());
+  agentBuilder.skills.register(getInstallRelevantPrebuiltRulesSkill());
+  agentBuilder.skills.register(getFindNoisyRulesSkill());
 };

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/core/aggregate_alerts_for_rule.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/core/aggregate_alerts_for_rule.ts
@@ -1,0 +1,137 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod/v4';
+import { ToolType } from '@kbn/agent-builder-common';
+import { ToolResultType } from '@kbn/agent-builder-common/tools/tool_result';
+import type { BuiltinToolDefinition } from '@kbn/agent-builder-server';
+import type { Logger } from '@kbn/logging';
+import { DEFAULT_ALERTS_INDEX } from '../../../../common/constants';
+import { securityTool } from '../constants';
+import { getAgentBuilderResourceAvailability } from '../../utils/get_agent_builder_resource_availability';
+import type { SecuritySolutionPluginCoreSetupDependencies } from '../../../plugin_contract';
+
+export const SECURITY_AGGREGATE_ALERTS_FOR_RULE_TOOL_ID = securityTool(
+  'core.aggregate_alerts_for_rule'
+);
+
+const aggregateAlertsForRuleSchema = z.object({
+  rule_id: z
+    .string()
+    .describe('The rule saved-object id (matches `kibana.alert.rule.uuid` on alerts).'),
+  timeframe_hours: z
+    .number()
+    .int()
+    .min(1)
+    .max(720)
+    .default(24)
+    .describe('Look-back window in hours. Defaults to last 24 hours.'),
+  bucket_size: z
+    .number()
+    .int()
+    .min(1)
+    .max(50)
+    .default(10)
+    .describe('Number of top buckets to return per aggregation.'),
+});
+
+interface BucketResult {
+  value: string;
+  count: number;
+}
+
+const extractBuckets = (aggBuckets: unknown): BucketResult[] => {
+  if (!Array.isArray(aggBuckets)) return [];
+  return aggBuckets
+    .filter(
+      (b): b is { key: string; doc_count: number } =>
+        typeof b === 'object' && b !== null && typeof (b as { key?: unknown }).key === 'string'
+    )
+    .map((b) => ({ value: b.key, count: b.doc_count }));
+};
+
+export const aggregateAlertsForRuleTool = (
+  core: SecuritySolutionPluginCoreSetupDependencies,
+  logger: Logger
+): BuiltinToolDefinition<typeof aggregateAlertsForRuleSchema> => ({
+  id: SECURITY_AGGREGATE_ALERTS_FOR_RULE_TOOL_ID,
+  type: ToolType.builtin,
+  description: `Aggregate recent alerts produced by a rule, grouped by the entities most useful for FP tuning: host.name, user.name, process.parent.name, process.name. Returns top buckets for each. A single dominant parent process or host in the results is the strongest signal for choosing an exclusion target.`,
+  schema: aggregateAlertsForRuleSchema,
+  tags: ['security', 'detection', 'alerts'],
+  availability: {
+    cacheMode: 'space',
+    handler: async ({ request }) => getAgentBuilderResourceAvailability({ core, request, logger }),
+  },
+  handler: async (
+    { rule_id: ruleId, timeframe_hours: timeframeHours, bucket_size: bucketSize },
+    { esClient, spaceId }
+  ) => {
+    try {
+      const index = `${DEFAULT_ALERTS_INDEX}-${spaceId}`;
+      const response = await esClient.asCurrentUser.search({
+        index,
+        size: 0,
+        track_total_hits: true,
+        query: {
+          bool: {
+            filter: [
+              { term: { 'kibana.alert.rule.uuid': ruleId } },
+              {
+                range: {
+                  '@timestamp': { gte: `now-${timeframeHours}h`, lte: 'now' },
+                },
+              },
+            ],
+          },
+        },
+        aggs: {
+          by_host: { terms: { field: 'host.name', size: bucketSize } },
+          by_user: { terms: { field: 'user.name', size: bucketSize } },
+          by_parent_process: {
+            terms: { field: 'process.parent.name', size: bucketSize },
+          },
+          by_process: { terms: { field: 'process.name', size: bucketSize } },
+        },
+      });
+
+      const total =
+        typeof response.hits.total === 'number'
+          ? response.hits.total
+          : response.hits.total?.value ?? 0;
+
+      const aggs = (response.aggregations ?? {}) as Record<string, { buckets?: unknown }>;
+
+      return {
+        results: [
+          {
+            type: ToolResultType.other,
+            data: {
+              rule_id: ruleId,
+              timeframe_hours: timeframeHours,
+              total,
+              by_host: extractBuckets(aggs.by_host?.buckets),
+              by_user: extractBuckets(aggs.by_user?.buckets),
+              by_parent_process: extractBuckets(aggs.by_parent_process?.buckets),
+              by_process: extractBuckets(aggs.by_process?.buckets),
+            },
+          },
+        ],
+      };
+    } catch (error) {
+      logger.error(`aggregate_alerts_for_rule failed: ${error.message}`, error);
+      return {
+        results: [
+          {
+            type: ToolResultType.error,
+            data: { message: `Failed to aggregate alerts: ${error.message}` },
+          },
+        ],
+      };
+    }
+  },
+});

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/core/find_noisy_rules.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/core/find_noisy_rules.ts
@@ -1,0 +1,156 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod/v4';
+import { ToolType } from '@kbn/agent-builder-common';
+import { ToolResultType } from '@kbn/agent-builder-common/tools/tool_result';
+import type { BuiltinToolDefinition } from '@kbn/agent-builder-server';
+import type { Logger } from '@kbn/logging';
+import { DEFAULT_ALERTS_INDEX } from '../../../../common/constants';
+import { readRules } from '../../../lib/detection_engine/rule_management/logic/detection_rules_client/read_rules';
+import { convertAlertingRuleToRuleResponse } from '../../../lib/detection_engine/rule_management/logic/detection_rules_client/converters/convert_alerting_rule_to_rule_response';
+import { securityTool } from '../constants';
+import { getAgentBuilderResourceAvailability } from '../../utils/get_agent_builder_resource_availability';
+import type { SecuritySolutionPluginCoreSetupDependencies } from '../../../plugin_contract';
+
+export const SECURITY_FIND_NOISY_RULES_TOOL_ID = securityTool('core.find_noisy_rules');
+
+const findNoisyRulesSchema = z.object({
+  timeframe_hours: z
+    .number()
+    .int()
+    .min(1)
+    .max(720)
+    .default(1)
+    .describe('Look-back window in hours. Defaults to 1.'),
+  top_n: z
+    .number()
+    .int()
+    .min(1)
+    .max(20)
+    .default(3)
+    .describe('How many top rules to return, ranked by alert count. Defaults to 3.'),
+});
+
+interface NoisyRule {
+  rule_id: string;
+  name: string;
+  severity?: string;
+  enabled?: boolean;
+  alert_count: number;
+}
+
+export const findNoisyRulesTool = (
+  core: SecuritySolutionPluginCoreSetupDependencies,
+  logger: Logger
+): BuiltinToolDefinition<typeof findNoisyRulesSchema> => ({
+  id: SECURITY_FIND_NOISY_RULES_TOOL_ID,
+  type: ToolType.builtin,
+  description: `Return the top-N detection rules by alert volume in a recent time window. Use this when the user asks which rules are noisy / firing the most / producing the most alerts. Returns rule_id, name, severity, enabled, and alert_count for each, ordered descending by alert_count.`,
+  schema: findNoisyRulesSchema,
+  tags: ['security', 'detection', 'alerts'],
+  availability: {
+    cacheMode: 'space',
+    handler: async ({ request }) => getAgentBuilderResourceAvailability({ core, request, logger }),
+  },
+  handler: async ({ timeframe_hours: timeframeHours, top_n: topN }, { esClient, request, spaceId }) => {
+    try {
+      const index = `${DEFAULT_ALERTS_INDEX}-${spaceId}`;
+      const response = await esClient.asCurrentUser.search({
+        index,
+        size: 0,
+        track_total_hits: false,
+        query: {
+          bool: {
+            filter: [
+              { range: { '@timestamp': { gte: `now-${timeframeHours}h`, lte: 'now' } } },
+            ],
+          },
+        },
+        aggs: {
+          by_rule: {
+            terms: { field: 'kibana.alert.rule.uuid', size: topN },
+          },
+        },
+      });
+
+      const buckets = (response.aggregations as { by_rule?: { buckets?: Array<{ key: string; doc_count: number }> } } | undefined)
+        ?.by_rule?.buckets ?? [];
+
+      if (buckets.length === 0) {
+        return {
+          results: [
+            {
+              type: ToolResultType.other,
+              data: {
+                timeframe_hours: timeframeHours,
+                top_n: topN,
+                rules: [] as NoisyRule[],
+                note: `No alerts found in the last ${timeframeHours}h.`,
+              },
+            },
+          ],
+        };
+      }
+
+      const [, startPlugins] = await core.getStartServices();
+      const rulesClient = await startPlugins.alerting.getRulesClientWithRequest(request);
+
+      const rules: NoisyRule[] = await Promise.all(
+        buckets.map(async (bucket) => {
+          try {
+            const rule = await readRules({ rulesClient, id: bucket.key, ruleId: undefined });
+            if (!rule) {
+              return {
+                rule_id: bucket.key,
+                name: '<unknown rule — possibly deleted>',
+                alert_count: bucket.doc_count,
+              };
+            }
+            const ruleResponse = convertAlertingRuleToRuleResponse(rule);
+            return {
+              rule_id: bucket.key,
+              name: ruleResponse.name,
+              severity: ruleResponse.severity,
+              enabled: ruleResponse.enabled,
+              alert_count: bucket.doc_count,
+            };
+          } catch {
+            return {
+              rule_id: bucket.key,
+              name: '<rule metadata unavailable>',
+              alert_count: bucket.doc_count,
+            };
+          }
+        })
+      );
+
+      return {
+        results: [
+          {
+            type: ToolResultType.other,
+            data: {
+              timeframe_hours: timeframeHours,
+              top_n: topN,
+              rules,
+            },
+          },
+        ],
+      };
+    } catch (error) {
+      logger.error(`find_noisy_rules failed: ${error.message}`, error);
+      return {
+        results: [
+          {
+            type: ToolResultType.error,
+            data: { message: `Failed to find noisy rules: ${error.message}` },
+          },
+        ],
+      };
+    }
+  },
+});

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/core/get_rule_details.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/core/get_rule_details.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod/v4';
+import { ToolType } from '@kbn/agent-builder-common';
+import { ToolResultType } from '@kbn/agent-builder-common/tools/tool_result';
+import type { BuiltinToolDefinition } from '@kbn/agent-builder-server';
+import type { Logger } from '@kbn/logging';
+import { readRules } from '../../../lib/detection_engine/rule_management/logic/detection_rules_client/read_rules';
+import { convertAlertingRuleToRuleResponse } from '../../../lib/detection_engine/rule_management/logic/detection_rules_client/converters/convert_alerting_rule_to_rule_response';
+import { securityTool } from '../constants';
+import { getAgentBuilderResourceAvailability } from '../../utils/get_agent_builder_resource_availability';
+import type { SecuritySolutionPluginCoreSetupDependencies } from '../../../plugin_contract';
+
+export const SECURITY_GET_RULE_DETAILS_TOOL_ID = securityTool('core.get_rule_details');
+
+const getRuleDetailsSchema = z.object({
+  rule_id: z
+    .string()
+    .describe(
+      'The saved-object id of the detection rule (the `id` field on the rule, NOT `rule_id`).'
+    ),
+});
+
+export const getRuleDetailsTool = (
+  core: SecuritySolutionPluginCoreSetupDependencies,
+  logger: Logger
+): BuiltinToolDefinition<typeof getRuleDetailsSchema> => ({
+  id: SECURITY_GET_RULE_DETAILS_TOOL_ID,
+  type: ToolType.builtin,
+  description: `Fetch the full JSON of a detection rule by its saved-object id. Returns name, description, query, language, index, tags, severity, risk_score, threat, interval, from, enabled, and all other rule fields.`,
+  schema: getRuleDetailsSchema,
+  tags: ['security', 'detection', 'rule'],
+  availability: {
+    cacheMode: 'space',
+    handler: async ({ request }) => getAgentBuilderResourceAvailability({ core, request, logger }),
+  },
+  handler: async ({ rule_id: ruleId }, { request }) => {
+    try {
+      const [, startPlugins] = await core.getStartServices();
+      const rulesClient = await startPlugins.alerting.getRulesClientWithRequest(request);
+      const rule = await readRules({ rulesClient, id: ruleId, ruleId: undefined });
+      if (!rule) {
+        return {
+          results: [
+            {
+              type: ToolResultType.error,
+              data: { message: `Rule not found: ${ruleId}` },
+            },
+          ],
+        };
+      }
+      const ruleResponse = convertAlertingRuleToRuleResponse(rule);
+      return {
+        results: [
+          {
+            type: ToolResultType.other,
+            data: { rule: ruleResponse },
+          },
+        ],
+      };
+    } catch (error) {
+      logger.error(`get_rule_details failed: ${error.message}`, error);
+      return {
+        results: [
+          {
+            type: ToolResultType.error,
+            data: { message: `Failed to fetch rule: ${error.message}` },
+          },
+        ],
+      };
+    }
+  },
+});

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/core/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/core/index.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { getRuleDetailsTool, SECURITY_GET_RULE_DETAILS_TOOL_ID } from './get_rule_details';
+export {
+  searchAlertsByRuleTool,
+  SECURITY_SEARCH_ALERTS_BY_RULE_TOOL_ID,
+} from './search_alerts_by_rule';
+export {
+  aggregateAlertsForRuleTool,
+  SECURITY_AGGREGATE_ALERTS_FOR_RULE_TOOL_ID,
+} from './aggregate_alerts_for_rule';
+export { previewRuleTool, SECURITY_PREVIEW_RULE_TOOL_ID } from './preview_rule';
+export { findNoisyRulesTool, SECURITY_FIND_NOISY_RULES_TOOL_ID } from './find_noisy_rules';
+export { proposeActionTool, SECURITY_PROPOSE_ACTION_TOOL_ID } from './propose_action';
+export {
+  reviewPrebuiltRulesToInstallTool,
+  SECURITY_REVIEW_PREBUILT_RULES_TO_INSTALL_TOOL_ID,
+} from './review_prebuilt_rules_to_install';

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/core/preview_rule.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/core/preview_rule.ts
@@ -1,0 +1,165 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod/v4';
+import { ToolType } from '@kbn/agent-builder-common';
+import { ToolResultType } from '@kbn/agent-builder-common/tools/tool_result';
+import type { BuiltinToolDefinition } from '@kbn/agent-builder-server';
+import type { Logger } from '@kbn/logging';
+import { DEFAULT_ALERTS_INDEX } from '../../../../common/constants';
+import { securityTool } from '../constants';
+import { getAgentBuilderResourceAvailability } from '../../utils/get_agent_builder_resource_availability';
+import type { SecuritySolutionPluginCoreSetupDependencies } from '../../../plugin_contract';
+
+export const SECURITY_PREVIEW_RULE_TOOL_ID = securityTool('core.preview_rule');
+
+// Stage 1 MVP: lightweight simulator. Counts how many of the rule's already-produced
+// alerts in the look-back window would survive a proposed exclusion filter. This
+// gives the agent a real, quantitative signal to reason over without depending on
+// the full detection-engine preview infrastructure. Stage 2 will swap this out for
+// a true preview that re-runs the rule against live source data.
+
+const exclusionSchema = z.object({
+  field: z
+    .string()
+    .describe(
+      'Alert field to exclude on, e.g. `process.parent.name`, `user.name`, `host.name`, `process.name`.'
+    ),
+  values: z
+    .array(z.string())
+    .min(1)
+    .describe(
+      'Values on `field` to exclude. An alert matches if its value for `field` is in this list.'
+    ),
+});
+
+const previewRuleSchema = z.object({
+  rule_id: z.string().describe('The rule saved-object id.'),
+  exclusions: z
+    .array(exclusionSchema)
+    .min(1)
+    .describe(
+      'List of exclusion filters to evaluate. An alert is considered filtered-out if it matches ANY of the exclusions.'
+    ),
+  timeframe_hours: z.number().int().min(1).max(720).default(24),
+});
+
+export const previewRuleTool = (
+  core: SecuritySolutionPluginCoreSetupDependencies,
+  logger: Logger
+): BuiltinToolDefinition<typeof previewRuleSchema> => ({
+  id: SECURITY_PREVIEW_RULE_TOOL_ID,
+  type: ToolType.builtin,
+  description: `Simulate how much a proposed exclusion would reduce a rule's alert volume, by counting the rule's recent alerts before and after applying the exclusion filter to the existing alerts index. Returns original count, surviving count, reduction, and reduction percentage. MUST be called before proposing a query change to the user, to verify the change actually reduces noise without dropping volume to zero.`,
+  schema: previewRuleSchema,
+  tags: ['security', 'detection', 'preview'],
+  availability: {
+    cacheMode: 'space',
+    handler: async ({ request }) => getAgentBuilderResourceAvailability({ core, request, logger }),
+  },
+  handler: async (
+    { rule_id: ruleId, exclusions, timeframe_hours: timeframeHours },
+    { esClient, spaceId }
+  ) => {
+    try {
+      const index = `${DEFAULT_ALERTS_INDEX}-${spaceId}`;
+      const baseFilter = [
+        { term: { 'kibana.alert.rule.uuid': ruleId } },
+        {
+          range: {
+            '@timestamp': { gte: `now-${timeframeHours}h`, lte: 'now' },
+          },
+        },
+      ];
+
+      const exclusionShoulds = exclusions.map((ex) => ({
+        terms: { [ex.field]: ex.values },
+      }));
+
+      const [originalResp, survivingResp] = await Promise.all([
+        esClient.asCurrentUser.search({
+          index,
+          size: 0,
+          track_total_hits: true,
+          query: { bool: { filter: baseFilter } },
+        }),
+        esClient.asCurrentUser.search({
+          index,
+          size: 0,
+          track_total_hits: true,
+          query: {
+            bool: {
+              filter: baseFilter,
+              must_not: [
+                {
+                  bool: {
+                    should: exclusionShoulds,
+                    minimum_should_match: 1,
+                  },
+                },
+              ],
+            },
+          },
+        }),
+      ]);
+
+      const asCount = (v: unknown) =>
+        typeof v === 'number' ? v : (v as { value?: number })?.value ?? 0;
+      const originalCount = asCount(originalResp.hits.total);
+      const survivingCount = asCount(survivingResp.hits.total);
+      const reduction = originalCount - survivingCount;
+      const reductionPercent =
+        originalCount > 0 ? Math.round((reduction / originalCount) * 1000) / 10 : 0;
+
+      const isImproved = reduction > 0;
+      const isOverTuned = originalCount > 0 && survivingCount === 0;
+      let verdict: string;
+      if (originalCount === 0) {
+        verdict = 'No alerts in the window — cannot evaluate.';
+      } else if (!isImproved) {
+        verdict = 'No improvement — exclusion did not filter any alerts.';
+      } else if (isOverTuned) {
+        verdict =
+          'Over-tuned — exclusion removes ALL alerts. Likely too broad; consider narrower exclusion or a different field.';
+      } else {
+        verdict = `Would reduce alerts from ${originalCount} to ${survivingCount} (${reductionPercent}% reduction).`;
+      }
+
+      return {
+        results: [
+          {
+            type: ToolResultType.other,
+            data: {
+              rule_id: ruleId,
+              timeframe_hours: timeframeHours,
+              exclusions,
+              original_count: originalCount,
+              surviving_count: survivingCount,
+              reduction,
+              reduction_percent: reductionPercent,
+              is_improved: isImproved,
+              is_over_tuned: isOverTuned,
+              verdict,
+              simulation_note:
+                'This is a simulation over the existing alerts index — not a full rule preview. Stage 2 upgrades to real preview.',
+            },
+          },
+        ],
+      };
+    } catch (error) {
+      logger.error(`preview_rule failed: ${error.message}`, error);
+      return {
+        results: [
+          {
+            type: ToolResultType.error,
+            data: { message: `Failed to simulate rule preview: ${error.message}` },
+          },
+        ],
+      };
+    }
+  },
+});

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/core/propose_action.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/core/propose_action.ts
@@ -1,0 +1,616 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod/v4';
+import { ToolType } from '@kbn/agent-builder-common';
+import { getLatestVersion } from '@kbn/agent-builder-common/attachments';
+import { ToolResultType } from '@kbn/agent-builder-common/tools/tool_result';
+import type { BuiltinToolDefinition } from '@kbn/agent-builder-server';
+import type { Logger } from '@kbn/logging';
+import { CreateRuleExceptionListItemProps } from '@kbn/securitysolution-exceptions-common/api';
+import {
+  actionProposalDataSchema,
+  actionProposalMetricsSchema,
+  ruleChangeIntentSchema,
+  type ActionProposalData,
+} from '../../../../common/agent_builder/action_recommendation';
+import { PatchRuleRequestBody } from '../../../../common/api/detection_engine/rule_management/crud/patch_rule/patch_rule_route.gen';
+import { validatePatchRuleRequestBody } from '../../../../common/api/detection_engine/rule_management/crud/patch_rule/request_schema_validation';
+import { SecurityAgentBuilderAttachments } from '../../../../common/constants';
+import { convertAlertingRuleToRuleResponse } from '../../../lib/detection_engine/rule_management/logic/detection_rules_client/converters/convert_alerting_rule_to_rule_response';
+import { convertPrebuiltRuleAssetToRuleResponse } from '../../../lib/detection_engine/rule_management/logic/detection_rules_client/converters/convert_prebuilt_rule_asset_to_rule_response';
+import { readRules } from '../../../lib/detection_engine/rule_management/logic/detection_rules_client/read_rules';
+import { createPrebuiltRuleAssetsClient } from '../../../lib/detection_engine/prebuilt_rules/logic/rule_assets/prebuilt_rule_assets_client';
+import { securityTool } from '../constants';
+import { getAgentBuilderResourceAvailability } from '../../utils/get_agent_builder_resource_availability';
+import type { SecuritySolutionPluginCoreSetupDependencies } from '../../../plugin_contract';
+
+export const SECURITY_PROPOSE_ACTION_TOOL_ID = securityTool('core.propose_action');
+
+const installRuleSelectionSchema = z.object({
+  rule_id: z.string().describe('Prebuilt rule signature id.'),
+  version: z
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .describe('Specific prebuilt rule version to install. Defaults to latest if omitted.'),
+  why: z.string().optional().describe('Optional short per-rule note shown in the proposal table.'),
+});
+
+const commonActionSchema = z.object({
+  summary: z
+    .string()
+    .min(1)
+    .describe('Short user-facing summary shown in the proposal attachment header.'),
+  reason: z
+    .string()
+    .optional()
+    .describe('Optional one or two sentence explanation of why this action is being proposed.'),
+  metrics: actionProposalMetricsSchema.describe(
+    'Optional metrics badges to render with the proposal.'
+  ),
+});
+
+const proposeActionSchema = commonActionSchema.extend({
+  action_type: z
+    .enum(['rule_change', 'rule_exception_add', 'rule_install'])
+    .describe('The kind of action proposal to create.'),
+  rule_id: z.string().optional().describe('Saved-object id of the live rule to change.'),
+  proposed_changes: z
+    .record(z.string(), z.unknown())
+    .optional()
+    .describe('Patch object containing the rule fields to change.'),
+  items: z
+    .array(CreateRuleExceptionListItemProps)
+    .min(1)
+    .optional()
+    .describe('Exception items to add to the rule default exception list.'),
+  intent: ruleChangeIntentSchema
+    .optional()
+    .describe('Optional hint describing why this rule change is being proposed.'),
+  rules: z
+    .array(installRuleSelectionSchema)
+    .min(1)
+    .max(20)
+    .optional()
+    .describe('Rules to include in a rule_install proposal.'),
+});
+
+type ProposeAction = z.infer<typeof proposeActionSchema>;
+
+type RuleChangeAction = ProposeAction & {
+  action_type: 'rule_change';
+  rule_id: string;
+  proposed_changes: Record<string, unknown>;
+};
+type RuleExceptionAddAction = ProposeAction & {
+  action_type: 'rule_exception_add';
+  rule_id: string;
+  items: Array<z.infer<typeof CreateRuleExceptionListItemProps>>;
+};
+type InstallAction = ProposeAction & {
+  action_type: 'rule_install';
+  rules: Array<z.infer<typeof installRuleSelectionSchema>>;
+};
+
+type RuleScopedActionType = 'rule_change' | 'rule_exception_add';
+
+interface PendingRuleProposal {
+  attachmentId: string;
+  createdAt: string;
+  data: ActionProposalData;
+}
+
+const mergePatchValue = (base: unknown, patch: unknown): unknown => {
+  if (
+    base &&
+    typeof base === 'object' &&
+    !Array.isArray(base) &&
+    patch &&
+    typeof patch === 'object' &&
+    !Array.isArray(patch)
+  ) {
+    const baseObject = base as Record<string, unknown>;
+    return Object.keys(patch as Record<string, unknown>).reduce<Record<string, unknown>>(
+      (acc, key) => {
+        acc[key] = mergePatchValue(baseObject[key], (patch as Record<string, unknown>)[key]);
+        return acc;
+      },
+      { ...baseObject }
+    );
+  }
+
+  return patch;
+};
+
+const mergeActionMetrics = (
+  existing: z.infer<typeof actionProposalMetricsSchema>,
+  incoming: z.infer<typeof actionProposalMetricsSchema>
+) => {
+  if (!existing && !incoming) {
+    return undefined;
+  }
+
+  return {
+    ...(existing ?? {}),
+    ...(incoming ?? {}),
+  };
+};
+
+const toRuleChangeAction = (action: ProposeAction): RuleChangeAction => {
+  if (action.action_type !== 'rule_change' || !action.rule_id || !action.proposed_changes) {
+    throw new Error('`rule_change` proposals require `rule_id` and `proposed_changes`.');
+  }
+
+  if (Object.keys(action.proposed_changes).length === 0) {
+    throw new Error(
+      '`rule_change` proposals must include at least one field in `proposed_changes`.'
+    );
+  }
+
+  if ('id' in action.proposed_changes || 'rule_id' in action.proposed_changes) {
+    throw new Error(
+      '`proposed_changes` must not contain `id` or `rule_id`; pass the rule id separately.'
+    );
+  }
+
+  const patchPayload = {
+    id: action.rule_id,
+    ...action.proposed_changes,
+  };
+  const parseResult = PatchRuleRequestBody.safeParse(patchPayload);
+  if (!parseResult.success) {
+    throw new Error(`Invalid rule change payload: ${parseResult.error.message}`);
+  }
+
+  const validationErrors = validatePatchRuleRequestBody(parseResult.data);
+  if (validationErrors.length > 0) {
+    throw new Error(`Invalid rule change payload: ${validationErrors.join('; ')}`);
+  }
+
+  return action as RuleChangeAction;
+};
+
+const toInstallAction = (action: ProposeAction): InstallAction => {
+  if (action.action_type !== 'rule_install' || !action.rules?.length) {
+    throw new Error('`rule_install` proposals require at least one entry in `rules`.');
+  }
+
+  return action as InstallAction;
+};
+
+const toRuleExceptionAddAction = (action: ProposeAction): RuleExceptionAddAction => {
+  if (action.action_type !== 'rule_exception_add' || !action.rule_id || !action.items?.length) {
+    throw new Error('`rule_exception_add` proposals require `rule_id` and at least one item.');
+  }
+
+  return action as RuleExceptionAddAction;
+};
+
+const getCurrentRule = async ({
+  core,
+  request,
+  ruleId,
+}: {
+  core: SecuritySolutionPluginCoreSetupDependencies;
+  request: Parameters<
+    NonNullable<BuiltinToolDefinition<typeof proposeActionSchema>['handler']>
+  >[1]['request'];
+  ruleId: string;
+}) => {
+  const [, startPlugins] = await core.getStartServices();
+  const rulesClient = await startPlugins.alerting.getRulesClientWithRequest(request);
+  const rule = await readRules({ rulesClient, id: ruleId, ruleId: undefined });
+
+  if (!rule) {
+    throw new Error(`Rule not found: ${ruleId}`);
+  }
+
+  return convertAlertingRuleToRuleResponse(rule);
+};
+
+const resolveInstallRules = async ({
+  core,
+  request,
+  rules,
+}: {
+  core: SecuritySolutionPluginCoreSetupDependencies;
+  request: Parameters<
+    NonNullable<BuiltinToolDefinition<typeof proposeActionSchema>['handler']>
+  >[1]['request'];
+  rules: Array<{ rule_id: string; version?: number; why?: string }>;
+}) => {
+  const [coreStart] = await core.getStartServices();
+  const soClient = coreStart.savedObjects.getScopedClient(request);
+  const ruleAssetsClient = createPrebuiltRuleAssetsClient(soClient);
+
+  const requestedRuleIds = rules.map(({ rule_id: ruleId }) => ruleId);
+  const latestVersions = await ruleAssetsClient.fetchLatestVersions({ ruleIds: requestedRuleIds });
+  const latestVersionMap = new Map(latestVersions.map((version) => [version.rule_id, version]));
+
+  const versionsToFetch = rules.map((rule) => {
+    if (rule.version != null) {
+      return { rule_id: rule.rule_id, version: rule.version };
+    }
+
+    const latest = latestVersionMap.get(rule.rule_id);
+    if (!latest) {
+      throw new Error(`Unable to find installable prebuilt rule: ${rule.rule_id}`);
+    }
+
+    return latest;
+  });
+
+  const requestedWhyMap = new Map(rules.map((rule) => [rule.rule_id, rule.why]));
+  const assets = await ruleAssetsClient.fetchAssetsByVersion(versionsToFetch);
+  const assetMap = new Map(assets.map((asset) => [asset.rule_id, asset]));
+
+  return versionsToFetch.map(({ rule_id: ruleId, version }) => {
+    const asset = assetMap.get(ruleId);
+    if (!asset) {
+      throw new Error(`Unable to load prebuilt rule asset: ${ruleId}`);
+    }
+
+    const rule = convertPrebuiltRuleAssetToRuleResponse(asset);
+    return {
+      rule_id: ruleId,
+      version,
+      name: rule.name,
+      description: rule.description,
+      severity: rule.severity,
+      mitre: rule.threat?.map((threat) => threat.tactic.name),
+      why: requestedWhyMap.get(ruleId),
+    };
+  });
+};
+
+const findPendingRuleProposal = ({
+  attachments,
+  actionType,
+  ruleId,
+}: {
+  attachments: Parameters<
+    NonNullable<BuiltinToolDefinition<typeof proposeActionSchema>['handler']>
+  >[1]['attachments'];
+  actionType: RuleScopedActionType;
+  ruleId: string;
+}): PendingRuleProposal | undefined => {
+  return attachments.getActive().reduce<PendingRuleProposal | undefined>((latest, attachment) => {
+    if (attachment.type !== SecurityAgentBuilderAttachments.actionProposal) {
+      return latest;
+    }
+
+    const latestVersion = getLatestVersion(attachment);
+    if (!latestVersion) {
+      return latest;
+    }
+
+    const parseResult = actionProposalDataSchema.safeParse(latestVersion.data);
+    if (!parseResult.success) {
+      return latest;
+    }
+
+    const data = parseResult.data;
+    if (
+      data.status !== 'pending' ||
+      data.payload.action_type !== actionType ||
+      data.payload.rule_id !== ruleId
+    ) {
+      return latest;
+    }
+
+    if (!latest) {
+      return {
+        attachmentId: attachment.id,
+        createdAt: latestVersion.created_at,
+        data,
+      };
+    }
+
+    return latest.createdAt > latestVersion.created_at
+      ? latest
+      : {
+          attachmentId: attachment.id,
+          createdAt: latestVersion.created_at,
+          data,
+        };
+  }, undefined);
+};
+
+const buildRuleChangeAttachmentData = ({
+  action,
+  currentRule,
+  existingProposal,
+}: {
+  action: RuleChangeAction;
+  currentRule: Awaited<ReturnType<typeof getCurrentRule>>;
+  existingProposal?: ActionProposalData;
+}) => {
+  const existingRuleChangePayload =
+    existingProposal?.payload.action_type === 'rule_change' ? existingProposal.payload : undefined;
+  const reason = action.reason ?? existingProposal?.reason;
+  const metrics = mergeActionMetrics(existingProposal?.metrics, action.metrics);
+  const intent = action.intent ?? existingRuleChangePayload?.intent;
+
+  return {
+    status: 'pending' as const,
+    summary: action.summary,
+    ...(reason && { reason }),
+    ...(metrics && { metrics }),
+    payload: {
+      action_type: 'rule_change' as const,
+      rule_id: action.rule_id,
+      current: currentRule,
+      proposed_changes: action.proposed_changes,
+      changed_fields: Object.keys(action.proposed_changes),
+      ...(intent && { intent }),
+    },
+  };
+};
+
+const buildRuleExceptionAddAttachmentData = ({
+  action,
+  currentRule,
+  existingProposal,
+}: {
+  action: RuleExceptionAddAction;
+  currentRule: Awaited<ReturnType<typeof getCurrentRule>>;
+  existingProposal?: ActionProposalData;
+}) => {
+  const reason = action.reason ?? existingProposal?.reason;
+  const metrics = mergeActionMetrics(existingProposal?.metrics, action.metrics);
+
+  return {
+    status: 'pending' as const,
+    summary: action.summary,
+    ...(reason && { reason }),
+    ...(metrics && { metrics }),
+    payload: {
+      action_type: 'rule_exception_add' as const,
+      rule_id: action.rule_id,
+      rule_name: currentRule.name,
+      items: action.items,
+    },
+  };
+};
+
+const buildAttachmentData = async ({
+  action,
+  core,
+  request,
+}: {
+  action: ProposeAction;
+  core: SecuritySolutionPluginCoreSetupDependencies;
+  request: Parameters<
+    NonNullable<BuiltinToolDefinition<typeof proposeActionSchema>['handler']>
+  >[1]['request'];
+}) => {
+  switch (action.action_type) {
+    case 'rule_change': {
+      const ruleChangeAction = toRuleChangeAction(action);
+      const currentRule = await getCurrentRule({
+        core,
+        request,
+        ruleId: ruleChangeAction.rule_id,
+      });
+      return buildRuleChangeAttachmentData({
+        action: ruleChangeAction,
+        currentRule,
+      });
+    }
+    case 'rule_exception_add': {
+      const ruleExceptionAction = toRuleExceptionAddAction(action);
+      const currentRule = await getCurrentRule({
+        core,
+        request,
+        ruleId: ruleExceptionAction.rule_id,
+      });
+      return buildRuleExceptionAddAttachmentData({
+        action: ruleExceptionAction,
+        currentRule,
+      });
+    }
+    case 'rule_install': {
+      const installAction = toInstallAction(action);
+      const installRules = await resolveInstallRules({
+        core,
+        request,
+        rules: installAction.rules,
+      });
+      return {
+        status: 'pending' as const,
+        summary: installAction.summary,
+        reason: installAction.reason,
+        metrics: installAction.metrics,
+        payload: {
+          action_type: 'rule_install' as const,
+          rules: installRules,
+        },
+      };
+    }
+  }
+};
+
+const createOrUpdateProposalAttachment = async ({
+  action,
+  attachments,
+  core,
+  request,
+}: {
+  action: ProposeAction;
+  attachments: Parameters<
+    NonNullable<BuiltinToolDefinition<typeof proposeActionSchema>['handler']>
+  >[1]['attachments'];
+  core: SecuritySolutionPluginCoreSetupDependencies;
+  request: Parameters<
+    NonNullable<BuiltinToolDefinition<typeof proposeActionSchema>['handler']>
+  >[1]['request'];
+}) => {
+  if (action.action_type === 'rule_change') {
+    const ruleChangeAction = toRuleChangeAction(action);
+    const existingProposal = findPendingRuleProposal({
+      attachments,
+      actionType: 'rule_change',
+      ruleId: ruleChangeAction.rule_id,
+    });
+
+    const mergedRuleChangeAction = existingProposal
+      ? toRuleChangeAction({
+          ...ruleChangeAction,
+          proposed_changes: mergePatchValue(
+            existingProposal.data.payload.action_type === 'rule_change'
+              ? existingProposal.data.payload.proposed_changes
+              : {},
+            ruleChangeAction.proposed_changes
+          ) as Record<string, unknown>,
+        })
+      : ruleChangeAction;
+
+    const currentRule = await getCurrentRule({
+      core,
+      request,
+      ruleId: mergedRuleChangeAction.rule_id,
+    });
+    const data = buildRuleChangeAttachmentData({
+      action: mergedRuleChangeAction,
+      currentRule,
+      existingProposal: existingProposal?.data,
+    });
+
+    if (!existingProposal) {
+      return attachments.add({
+        type: SecurityAgentBuilderAttachments.actionProposal,
+        data,
+        description: data.summary,
+      });
+    }
+
+    const updated = await attachments.update(existingProposal.attachmentId, {
+      data,
+      description: data.summary,
+    });
+
+    if (!updated) {
+      throw new Error(
+        `Failed to update action proposal attachment: ${existingProposal.attachmentId}`
+      );
+    }
+
+    return updated;
+  }
+
+  if (action.action_type === 'rule_exception_add') {
+    const ruleExceptionAction = toRuleExceptionAddAction(action);
+    const existingProposal = findPendingRuleProposal({
+      attachments,
+      actionType: 'rule_exception_add',
+      ruleId: ruleExceptionAction.rule_id,
+    });
+
+    const mergedRuleExceptionAction = toRuleExceptionAddAction({
+      ...ruleExceptionAction,
+      items:
+        existingProposal?.data.payload.action_type === 'rule_exception_add'
+          ? [...existingProposal.data.payload.items, ...ruleExceptionAction.items]
+          : ruleExceptionAction.items,
+    });
+
+    const currentRule = await getCurrentRule({
+      core,
+      request,
+      ruleId: mergedRuleExceptionAction.rule_id,
+    });
+    const data = buildRuleExceptionAddAttachmentData({
+      action: mergedRuleExceptionAction,
+      currentRule,
+      existingProposal: existingProposal?.data,
+    });
+
+    if (!existingProposal) {
+      return attachments.add({
+        type: SecurityAgentBuilderAttachments.actionProposal,
+        data,
+        description: data.summary,
+      });
+    }
+
+    const updated = await attachments.update(existingProposal.attachmentId, {
+      data,
+      description: data.summary,
+    });
+
+    if (!updated) {
+      throw new Error(
+        `Failed to update action proposal attachment: ${existingProposal.attachmentId}`
+      );
+    }
+
+    return updated;
+  }
+
+  {
+    const data = await buildAttachmentData({ action, core, request });
+    return attachments.add({
+      type: SecurityAgentBuilderAttachments.actionProposal,
+      data,
+      description: action.summary,
+    });
+  }
+};
+
+export const proposeActionTool = (
+  core: SecuritySolutionPluginCoreSetupDependencies,
+  logger: Logger
+): BuiltinToolDefinition<typeof proposeActionSchema> => ({
+  id: SECURITY_PROPOSE_ACTION_TOOL_ID,
+  type: ToolType.builtin,
+  description:
+    'Create or update a typed security.action_proposal attachment for an intended live action. Use this after reasoning through the problem; it builds the proposal payload server-side so skills do not need to handcraft attachment JSON. For rule changes and rule-exception additions, a pending proposal with the same action type for the same rule is updated instead of creating a second card.',
+  schema: proposeActionSchema,
+  tags: ['security', 'proposal', 'rule', 'prebuilt-rules'],
+  availability: {
+    cacheMode: 'space',
+    handler: async ({ request }) => getAgentBuilderResourceAvailability({ core, request, logger }),
+  },
+  handler: async (action, { attachments, request }) => {
+    try {
+      const created = await createOrUpdateProposalAttachment({
+        action,
+        attachments,
+        core,
+        request,
+      });
+
+      return {
+        results: [
+          {
+            type: ToolResultType.other,
+            data: {
+              success: true,
+              attachmentId: created.id,
+              version: created.current_version,
+              action_type: action.action_type,
+            },
+          },
+        ],
+      };
+    } catch (error) {
+      logger.error(`propose_action failed: ${error.message}`, error);
+      return {
+        results: [
+          {
+            type: ToolResultType.error,
+            data: {
+              message: `Failed to create action proposal: ${error.message}`,
+            },
+          },
+        ],
+      };
+    }
+  },
+});

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/core/review_prebuilt_rules_to_install.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/core/review_prebuilt_rules_to_install.ts
@@ -1,0 +1,120 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod/v4';
+import { ToolType } from '@kbn/agent-builder-common';
+import { ToolResultType } from '@kbn/agent-builder-common/tools/tool_result';
+import type { BuiltinToolDefinition } from '@kbn/agent-builder-server';
+import type { Logger } from '@kbn/logging';
+import { convertPrebuiltRuleAssetToRuleResponse } from '../../../lib/detection_engine/rule_management/logic/detection_rules_client/converters/convert_prebuilt_rule_asset_to_rule_response';
+import { createPrebuiltRuleAssetsClient } from '../../../lib/detection_engine/prebuilt_rules/logic/rule_assets/prebuilt_rule_assets_client';
+import { createPrebuiltRuleObjectsClient } from '../../../lib/detection_engine/prebuilt_rules/logic/rule_objects/prebuilt_rule_objects_client';
+import { securityTool } from '../constants';
+import { getAgentBuilderResourceAvailability } from '../../utils/get_agent_builder_resource_availability';
+import type { SecuritySolutionPluginCoreSetupDependencies } from '../../../plugin_contract';
+
+export const SECURITY_REVIEW_PREBUILT_RULES_TO_INSTALL_TOOL_ID = securityTool(
+  'core.review_prebuilt_rules_to_install'
+);
+
+const reviewPrebuiltRulesToInstallSchema = z.object({
+  tags: z
+    .array(z.string())
+    .optional()
+    .describe('Optional tags to match against prebuilt rule tags.'),
+  names: z
+    .array(z.string())
+    .optional()
+    .describe('Optional name fragments or exact names to match against prebuilt rule names.'),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(20)
+    .default(10)
+    .describe('Maximum number of candidate rules to return.'),
+});
+
+export const reviewPrebuiltRulesToInstallTool = (
+  core: SecuritySolutionPluginCoreSetupDependencies,
+  logger: Logger
+): BuiltinToolDefinition<typeof reviewPrebuiltRulesToInstallSchema> => ({
+  id: SECURITY_REVIEW_PREBUILT_RULES_TO_INSTALL_TOOL_ID,
+  type: ToolType.builtin,
+  description:
+    'List installable prebuilt detection rules, optionally filtered by tags or names. This is a lightweight reader intended for skills that want to propose rule installation from chat.',
+  schema: reviewPrebuiltRulesToInstallSchema,
+  tags: ['security', 'prebuilt-rules', 'install'],
+  availability: {
+    cacheMode: 'space',
+    handler: async ({ request }) => getAgentBuilderResourceAvailability({ core, request, logger }),
+  },
+  handler: async ({ tags = [], names = [], limit }, { request }) => {
+    try {
+      const [coreStart, startPlugins] = await core.getStartServices();
+      const soClient = coreStart.savedObjects.getScopedClient(request);
+      const rulesClient = await startPlugins.alerting.getRulesClientWithRequest(request);
+      const ruleAssetsClient = createPrebuiltRuleAssetsClient(soClient);
+      const ruleObjectsClient = createPrebuiltRuleObjectsClient(rulesClient);
+
+      const installedVersions = await ruleObjectsClient.fetchInstalledRuleVersions();
+      const installedRuleIds = new Set(installedVersions.map((rule) => rule.rule_id));
+      const filter =
+        tags.length > 0 || names.length > 0
+          ? {
+              fields: {
+                ...(names.length > 0 ? { name: { include: { values: names } } } : {}),
+                ...(tags.length > 0 ? { tags: { include: { values: tags } } } : {}),
+              },
+            }
+          : undefined;
+
+      const latestVersions = await ruleAssetsClient.fetchLatestVersions({ filter });
+      const installableVersions = latestVersions
+        .filter((rule) => !installedRuleIds.has(rule.rule_id))
+        .slice(0, limit);
+      const assets = await ruleAssetsClient.fetchAssetsByVersion(installableVersions);
+
+      const rules = assets.map((asset) => {
+        const rule = convertPrebuiltRuleAssetToRuleResponse(asset);
+        return {
+          rule_id: rule.rule_id,
+          version: rule.version,
+          name: rule.name,
+          description: rule.description,
+          severity: rule.severity,
+          tags: rule.tags,
+          mitre: rule.threat?.map((threat) => threat.tactic.name),
+        };
+      });
+
+      return {
+        results: [
+          {
+            type: ToolResultType.other,
+            data: {
+              total_candidates: rules.length,
+              rules,
+            },
+          },
+        ],
+      };
+    } catch (error) {
+      logger.error(`review_prebuilt_rules_to_install failed: ${error.message}`, error);
+      return {
+        results: [
+          {
+            type: ToolResultType.error,
+            data: {
+              message: `Failed to review installable prebuilt rules: ${error.message}`,
+            },
+          },
+        ],
+      };
+    }
+  },
+});

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/core/search_alerts_by_rule.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/core/search_alerts_by_rule.ts
@@ -1,0 +1,129 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod/v4';
+import { ToolType } from '@kbn/agent-builder-common';
+import { ToolResultType } from '@kbn/agent-builder-common/tools/tool_result';
+import type { BuiltinToolDefinition } from '@kbn/agent-builder-server';
+import type { Logger } from '@kbn/logging';
+import { DEFAULT_ALERTS_INDEX } from '../../../../common/constants';
+import { securityTool } from '../constants';
+import { getAgentBuilderResourceAvailability } from '../../utils/get_agent_builder_resource_availability';
+import type { SecuritySolutionPluginCoreSetupDependencies } from '../../../plugin_contract';
+
+export const SECURITY_SEARCH_ALERTS_BY_RULE_TOOL_ID = securityTool('core.search_alerts_by_rule');
+
+const searchAlertsByRuleSchema = z.object({
+  rule_id: z
+    .string()
+    .describe('The rule saved-object id (matches `kibana.alert.rule.uuid` on alerts).'),
+  size: z
+    .number()
+    .int()
+    .min(1)
+    .max(100)
+    .default(20)
+    .describe('Maximum number of alert documents to return.'),
+  timeframe_hours: z
+    .number()
+    .int()
+    .min(1)
+    .max(720)
+    .default(24)
+    .describe('Look-back window in hours. Defaults to last 24 hours.'),
+});
+
+const SOURCE_FIELDS = [
+  '@timestamp',
+  'kibana.alert.rule.name',
+  'kibana.alert.rule.uuid',
+  'kibana.alert.severity',
+  'kibana.alert.risk_score',
+  'host.name',
+  'user.name',
+  'process.name',
+  'process.parent.name',
+  'process.command_line',
+  'source.ip',
+  'destination.ip',
+  'event.action',
+  'event.category',
+];
+
+export const searchAlertsByRuleTool = (
+  core: SecuritySolutionPluginCoreSetupDependencies,
+  logger: Logger
+): BuiltinToolDefinition<typeof searchAlertsByRuleSchema> => ({
+  id: SECURITY_SEARCH_ALERTS_BY_RULE_TOOL_ID,
+  type: ToolType.builtin,
+  description: `Fetch a sample of recent alerts produced by a specific detection rule. Returns the most recent alert documents (sorted by @timestamp desc) and the total count for the time window. Use this to see what the rule is currently producing and decide whether the volume is elevated.`,
+  schema: searchAlertsByRuleSchema,
+  tags: ['security', 'detection', 'alerts'],
+  availability: {
+    cacheMode: 'space',
+    handler: async ({ request }) => getAgentBuilderResourceAvailability({ core, request, logger }),
+  },
+  handler: async (
+    { rule_id: ruleId, size, timeframe_hours: timeframeHours },
+    { esClient, spaceId }
+  ) => {
+    try {
+      const index = `${DEFAULT_ALERTS_INDEX}-${spaceId}`;
+      const response = await esClient.asCurrentUser.search({
+        index,
+        size,
+        sort: [{ '@timestamp': { order: 'desc' } }],
+        track_total_hits: true,
+        _source: SOURCE_FIELDS,
+        query: {
+          bool: {
+            filter: [
+              { term: { 'kibana.alert.rule.uuid': ruleId } },
+              {
+                range: {
+                  '@timestamp': { gte: `now-${timeframeHours}h`, lte: 'now' },
+                },
+              },
+            ],
+          },
+        },
+      });
+
+      const total =
+        typeof response.hits.total === 'number'
+          ? response.hits.total
+          : response.hits.total?.value ?? 0;
+
+      return {
+        results: [
+          {
+            type: ToolResultType.other,
+            data: {
+              rule_id: ruleId,
+              timeframe_hours: timeframeHours,
+              total,
+              alerts: response.hits.hits.map((hit) => ({
+                _id: hit._id,
+                ...(typeof hit._source === 'object' && hit._source !== null ? hit._source : {}),
+              })),
+            },
+          },
+        ],
+      };
+    } catch (error) {
+      logger.error(`search_alerts_by_rule failed: ${error.message}`, error);
+      return {
+        results: [
+          {
+            type: ToolResultType.error,
+            data: { message: `Failed to search alerts: ${error.message}` },
+          },
+        ],
+      };
+    }
+  },
+});

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/index.ts
@@ -23,3 +23,17 @@ export {
   createDetectionRuleTool,
   SECURITY_CREATE_DETECTION_RULE_TOOL_ID,
 } from './create_detection_rule_tool';
+export {
+  getRuleDetailsTool,
+  SECURITY_GET_RULE_DETAILS_TOOL_ID,
+  searchAlertsByRuleTool,
+  SECURITY_SEARCH_ALERTS_BY_RULE_TOOL_ID,
+  aggregateAlertsForRuleTool,
+  SECURITY_AGGREGATE_ALERTS_FOR_RULE_TOOL_ID,
+  previewRuleTool,
+  SECURITY_PREVIEW_RULE_TOOL_ID,
+  proposeActionTool,
+  SECURITY_PROPOSE_ACTION_TOOL_ID,
+  reviewPrebuiltRulesToInstallTool,
+  SECURITY_REVIEW_PREBUILT_RULES_TO_INSTALL_TOOL_ID,
+} from './core';

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/register_tools.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/register_tools.ts
@@ -13,6 +13,15 @@ import { attackDiscoverySearchTool } from './attack_discovery_search_tool';
 import { entityRiskScoreTool, getEntityTool, searchEntitiesTool } from './entity_analytics';
 import { alertsTool } from './alerts_tool';
 import { createDetectionRuleTool } from './create_detection_rule_tool';
+import {
+  getRuleDetailsTool,
+  searchAlertsByRuleTool,
+  aggregateAlertsForRuleTool,
+  previewRuleTool,
+  findNoisyRulesTool,
+  proposeActionTool,
+  reviewPrebuiltRulesToInstallTool,
+} from './core';
 import type { SecuritySolutionPluginCoreSetupDependencies } from '../../plugin_contract';
 
 /**
@@ -31,4 +40,13 @@ export const registerTools = async (
   agentBuilder.tools.register(alertsTool(core, logger));
   agentBuilder.tools.register(getEntityTool(core, logger, experimentalFeatures));
   agentBuilder.tools.register(searchEntitiesTool(core, logger, experimentalFeatures));
+
+  // security.core.* shared DEX tools
+  agentBuilder.tools.register(getRuleDetailsTool(core, logger));
+  agentBuilder.tools.register(searchAlertsByRuleTool(core, logger));
+  agentBuilder.tools.register(aggregateAlertsForRuleTool(core, logger));
+  agentBuilder.tools.register(previewRuleTool(core, logger));
+  agentBuilder.tools.register(findNoisyRulesTool(core, logger));
+  agentBuilder.tools.register(proposeActionTool(core, logger));
+  agentBuilder.tools.register(reviewPrebuiltRulesToInstallTool(core, logger));
 };

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rules_monitoring_overview_panel.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rules_monitoring_overview_panel.cy.ts
@@ -24,7 +24,7 @@ import {
 
 const TEST_INDEX = 'test_monitoring_panel_index';
 
-describe.skip(
+describe(
   'Rules Monitoring Overview Panel',
   { tags: ['@ess', '@serverless', '@skipInServerlessMKI'] },
   () => {


### PR DESCRIPTION
# Detection Engine skills on Agent Builder — PoC

> **Status:** Proof of concept. The code is exploratory and **not production-ready**. The point of this work is to demonstrate the **user experience** and the **skill-interaction model**, not to ship production logic. See "Known limitations" below for what is intentionally fake or missing.

https://github.com/user-attachments/assets/9231bc0d-0190-485f-b3eb-e3ddd1f15121



https://github.com/user-attachments/assets/2386b751-0bf5-4d06-a1ad-8e01717c7980



## Why this exists

We want to learn what it feels like to build skills for Detection Engine on top of Agent Builder, before committing to a full architecture. The PoC is meant to:

- show how rule-related skills can compose in a single chat conversation
- exercise the "agent proposes, user approves" pattern end-to-end
- surface the platform gaps that block making this real
- give the team something concrete to react to

It is **not** a finished feature.

## What this PoC demonstrates

1. **Propose-then-approve.** Skills never mutate rules directly. They produce typed *action proposals* the user clicks Approve on. The mutation runs in the browser with the user's session — auth and audit attribution come for free.
2. **Skill interaction through attachments/chat context** Discovery, diagnosis, and remediation are separate skills. They don't call each other; they hand off through attachments and conversation context. A user flows naturally from "which rules are noisy?" → "tune the first one" → review and apply, without ever naming a skill.
3. **A typed action descriptor.** `rule_change`, `rule_exception_add`, and `rule_install` share one envelope. One renderer dispatches on `action_type`. One shared `propose_action` tool builds them.
4. **Reasoning, action, and execution as separate layers.** Skills do LLM reasoning. The action descriptor is deterministic. Execution is browser-side. The architecture justification lives in `agent_builder_action_proposals.md` (the RFC).

## Components at a glance

### Skills

`server/agent_builder/skills/`

| Skill | Triggered when... | What it does |
|---|---|---|
| `find-noisy-rules` | "which rules are noisy?", "top rules by alerts" | Returns an inline ranked table. On user pick, attaches the rule by-reference. **Discovery only — never proposes a mutation.** |
| `fix-false-positive-alerts` | rule attached + "is this noisy / can you tune this?" | Diagnoses noise, picks query-tuning vs. exception, calls preview, creates a `rule_change` or `rule_exception_add` proposal. |
| `fix-rule-execution-failures` | rule attached + "this rule is failing / disable it" | Decides between a narrow query fix and disabling the rule, creates a `rule_change` proposal with the matching intent. |
| `install-relevant-prebuilt-rules` | "what prebuilt rules should I install for X?" | Suggests a small set, creates a `rule_install` proposal.  |

### Core tools

`server/agent_builder/tools/core/`. Reusable across skills, prefixed `security.core.*`:

| Tool | Purpose |
|---|---|
| `find_noisy_rules` | Top-N rules by alert volume in a window. |
| `get_rule_details` | Fetch a rule by saved-object id. |
| `search_alerts_by_rule` | Sample of recent alerts for a rule. |
| `aggregate_alerts_for_rule` | Top buckets by host / user / parent process / process — picks exclusion targets. |
| `preview_rule` | Counter that simulates how many of the rule's *existing* alerts would survive an exclusion filter. **Not a true preview.** |
| `propose_action` | Single shared tool that creates **or merges into** a pending action proposal attachment. |
| `review_prebuilt_rules_to_install` | List installable prebuilt rules filtered by tags / names. |

### Attachment

`security.action_proposal` (`server/agent_builder/attachments/action_proposal.ts` + `public/agent_builder/attachment_types/action_proposal.tsx`).

One attachment type, three action shapes via a discriminated union on `action_type`:

- `rule_change` — full rule diff via `RuleDiffTab`
- `rule_exception_add` — exception conditions card
- `rule_install` — table of rules to install

Each card has **Approve** and **Dismiss**. Approve fires the live Detection Engine API call from the browser, invalidates open rule pages via React Query, and toasts.
