### PR TITLE
[Automatic Import] Preselect selected categories for edit integrations

### DIFF
--- a/x-pack/platform/plugins/shared/automatic_import/common/model/api/data_streams/data_stream.gen.ts
+++ b/x-pack/platform/plugins/shared/automatic_import/common/model/api/data_streams/data_stream.gen.ts
@@ -14,205 +14,231 @@
  *   version: 1
  */
 
-import { z } from '@kbn/zod/v4';
+import { z, lazySchema } from '@kbn/zod/v4';
 
 import { SafeIdentifier, NonEmptyString } from '../../primitive.gen';
 import { OriginalSource, LangSmithOptions } from '../../common_attributes.gen';
 
+export const DeleteDataStreamRequestParams = lazySchema(() =>
+  z.object({
+    /**
+     * The integration identifier
+     */
+    integration_id: SafeIdentifier,
+    /**
+     * The data stream identifier
+     */
+    data_stream_id: SafeIdentifier,
+  })
+);
 export type DeleteDataStreamRequestParams = z.infer<typeof DeleteDataStreamRequestParams>;
-export const DeleteDataStreamRequestParams = z.object({
-  /**
-   * The integration identifier
-   */
-  integration_id: SafeIdentifier,
-  /**
-   * The data stream identifier
-   */
-  data_stream_id: SafeIdentifier,
-});
 export type DeleteDataStreamRequestParamsInput = z.input<typeof DeleteDataStreamRequestParams>;
 
+export const GetDataStreamResultsRequestParams = lazySchema(() =>
+  z.object({
+    /**
+     * The integration identifier
+     */
+    integration_id: SafeIdentifier,
+    /**
+     * The data stream identifier
+     */
+    data_stream_id: SafeIdentifier,
+  })
+);
 export type GetDataStreamResultsRequestParams = z.infer<typeof GetDataStreamResultsRequestParams>;
-export const GetDataStreamResultsRequestParams = z.object({
-  /**
-   * The integration identifier
-   */
-  integration_id: SafeIdentifier,
-  /**
-   * The data stream identifier
-   */
-  data_stream_id: SafeIdentifier,
-});
 export type GetDataStreamResultsRequestParamsInput = z.input<
   typeof GetDataStreamResultsRequestParams
 >;
 
+export const GetDataStreamResultsResponse = lazySchema(() =>
+  z
+    .object({
+      /**
+       * The ingest pipeline as a JSON string.
+       */
+      ingest_pipeline: NonEmptyString,
+      /**
+       * Results array as JSON objects.
+       */
+      results: z.array(z.object({}).catchall(z.unknown())).max(10000),
+    })
+    .strict()
+);
 export type GetDataStreamResultsResponse = z.infer<typeof GetDataStreamResultsResponse>;
-export const GetDataStreamResultsResponse = z
-  .object({
-    /**
-     * The ingest pipeline as a JSON string.
-     */
-    ingest_pipeline: NonEmptyString,
-    /**
-     * Results array as JSON objects.
-     */
-    results: z.array(z.object({}).catchall(z.unknown())).max(10000),
-  })
-  .strict();
 
+export const ReanalyzeDataStreamRequestParams = lazySchema(() =>
+  z.object({
+    /**
+     * The integration identifier
+     */
+    integration_id: SafeIdentifier,
+    /**
+     * The data stream identifier
+     */
+    data_stream_id: SafeIdentifier,
+  })
+);
 export type ReanalyzeDataStreamRequestParams = z.infer<typeof ReanalyzeDataStreamRequestParams>;
-export const ReanalyzeDataStreamRequestParams = z.object({
-  /**
-   * The integration identifier
-   */
-  integration_id: SafeIdentifier,
-  /**
-   * The data stream identifier
-   */
-  data_stream_id: SafeIdentifier,
-});
 export type ReanalyzeDataStreamRequestParamsInput = z.input<
   typeof ReanalyzeDataStreamRequestParams
 >;
 
-export type ReanalyzeDataStreamRequestBody = z.infer<typeof ReanalyzeDataStreamRequestBody>;
-export const ReanalyzeDataStreamRequestBody = z.object({
-  /**
-   * The inference connector ID to use for the reanalysis task.
-   */
-  connectorId: NonEmptyString,
-  /**
-   * The LangSmith tracing options
-   */
-  langSmithOptions: LangSmithOptions.optional(),
-});
-export type ReanalyzeDataStreamRequestBodyInput = z.input<typeof ReanalyzeDataStreamRequestBody>;
-
-export type ReanalyzeDataStreamResponse = z.infer<typeof ReanalyzeDataStreamResponse>;
-export const ReanalyzeDataStreamResponse = z
-  .object({
+export const ReanalyzeDataStreamRequestBody = lazySchema(() =>
+  z.object({
     /**
-     * Indicates if the reanalysis was scheduled successfully.
+     * The inference connector ID to use for the reanalysis task.
      */
-    success: z.boolean().optional(),
-  })
-  .strict();
-
-export type StopAutoImportDataStreamRequestParams = z.infer<
-  typeof StopAutoImportDataStreamRequestParams
->;
-export const StopAutoImportDataStreamRequestParams = z.object({
-  /**
-   * The integration identifier
-   */
-  integration_id: SafeIdentifier,
-  /**
-   * The data stream identifier
-   */
-  data_stream_id: SafeIdentifier,
-});
-export type StopAutoImportDataStreamRequestParamsInput = z.input<
-  typeof StopAutoImportDataStreamRequestParams
->;
-
-export type UpdateDataStreamPipelineRequestParams = z.infer<
-  typeof UpdateDataStreamPipelineRequestParams
->;
-export const UpdateDataStreamPipelineRequestParams = z.object({
-  /**
-   * The integration identifier
-   */
-  integration_id: SafeIdentifier,
-  /**
-   * The data stream identifier
-   */
-  data_stream_id: SafeIdentifier,
-});
-export type UpdateDataStreamPipelineRequestParamsInput = z.input<
-  typeof UpdateDataStreamPipelineRequestParams
->;
-
-export type UpdateDataStreamPipelineRequestBody = z.infer<
-  typeof UpdateDataStreamPipelineRequestBody
->;
-export const UpdateDataStreamPipelineRequestBody = z
-  .object({
-    /**
-     * JSON string (max 10MiB) or pipeline object. When an object, `processors` is capped at 10000 entries.
-     */
-    ingest_pipeline: z.union([
-      z.string().max(10485760),
-      z
-        .object({
-          processors: z.array(z.object({}).catchall(z.unknown())).max(10000).optional(),
-        })
-        .catchall(z.unknown()),
-    ]),
-  })
-  .strict();
-export type UpdateDataStreamPipelineRequestBodyInput = z.input<
-  typeof UpdateDataStreamPipelineRequestBody
->;
-
-export type UpdateDataStreamPipelineResponse = z.infer<typeof UpdateDataStreamPipelineResponse>;
-export const UpdateDataStreamPipelineResponse = z
-  .object({
-    ingest_pipeline: z.object({}).catchall(z.unknown()),
-    results: z.array(z.object({}).catchall(z.unknown())).max(10000),
-  })
-  .strict();
-
-export type UploadSamplesToDataStreamRequestParams = z.infer<
-  typeof UploadSamplesToDataStreamRequestParams
->;
-export const UploadSamplesToDataStreamRequestParams = z.object({
-  /**
-   * The integration identifier
-   */
-  integration_id: SafeIdentifier,
-  /**
-   * The data stream identifier
-   */
-  data_stream_id: SafeIdentifier,
-});
-export type UploadSamplesToDataStreamRequestParamsInput = z.input<
-  typeof UploadSamplesToDataStreamRequestParams
->;
-
-export type UploadSamplesToDataStreamRequestBody = z.infer<
-  typeof UploadSamplesToDataStreamRequestBody
->;
-export const UploadSamplesToDataStreamRequestBody = z
-  .object({
-    /**
-     * Log lines to upload when the source is a file (omit when using sourceIndex).
-     */
-    samples: z.array(z.string()).max(1000).optional(),
-    /**
-     * Index name to pick samples from.
-     */
-    sourceIndex: z.string().min(1).max(100).optional(),
-    /**
-     * The original source of the samples (file name or index name)
-     */
-    originalSource: OriginalSource,
+    connectorId: NonEmptyString,
     /**
      * The LangSmith tracing options
      */
     langSmithOptions: LangSmithOptions.optional(),
   })
-  .strict();
+);
+export type ReanalyzeDataStreamRequestBody = z.infer<typeof ReanalyzeDataStreamRequestBody>;
+export type ReanalyzeDataStreamRequestBodyInput = z.input<typeof ReanalyzeDataStreamRequestBody>;
+
+export const ReanalyzeDataStreamResponse = lazySchema(() =>
+  z
+    .object({
+      /**
+       * Indicates if the reanalysis was scheduled successfully.
+       */
+      success: z.boolean().optional(),
+    })
+    .strict()
+);
+export type ReanalyzeDataStreamResponse = z.infer<typeof ReanalyzeDataStreamResponse>;
+
+export const StopAutoImportDataStreamRequestParams = lazySchema(() =>
+  z.object({
+    /**
+     * The integration identifier
+     */
+    integration_id: SafeIdentifier,
+    /**
+     * The data stream identifier
+     */
+    data_stream_id: SafeIdentifier,
+  })
+);
+export type StopAutoImportDataStreamRequestParams = z.infer<
+  typeof StopAutoImportDataStreamRequestParams
+>;
+export type StopAutoImportDataStreamRequestParamsInput = z.input<
+  typeof StopAutoImportDataStreamRequestParams
+>;
+
+export const UpdateDataStreamPipelineRequestParams = lazySchema(() =>
+  z.object({
+    /**
+     * The integration identifier
+     */
+    integration_id: SafeIdentifier,
+    /**
+     * The data stream identifier
+     */
+    data_stream_id: SafeIdentifier,
+  })
+);
+export type UpdateDataStreamPipelineRequestParams = z.infer<
+  typeof UpdateDataStreamPipelineRequestParams
+>;
+export type UpdateDataStreamPipelineRequestParamsInput = z.input<
+  typeof UpdateDataStreamPipelineRequestParams
+>;
+
+export const UpdateDataStreamPipelineRequestBody = lazySchema(() =>
+  z
+    .object({
+      /**
+       * JSON string (max 10MiB) or pipeline object. When an object, `processors` is capped at 10000 entries.
+       */
+      ingest_pipeline: z.union([
+        z.string().max(10485760),
+        z
+          .object({
+            processors: z.array(z.object({}).catchall(z.unknown())).max(10000).optional(),
+          })
+          .catchall(z.unknown()),
+      ]),
+    })
+    .strict()
+);
+export type UpdateDataStreamPipelineRequestBody = z.infer<
+  typeof UpdateDataStreamPipelineRequestBody
+>;
+export type UpdateDataStreamPipelineRequestBodyInput = z.input<
+  typeof UpdateDataStreamPipelineRequestBody
+>;
+
+export const UpdateDataStreamPipelineResponse = lazySchema(() =>
+  z
+    .object({
+      ingest_pipeline: z.object({}).catchall(z.unknown()),
+      results: z.array(z.object({}).catchall(z.unknown())).max(10000),
+    })
+    .strict()
+);
+export type UpdateDataStreamPipelineResponse = z.infer<typeof UpdateDataStreamPipelineResponse>;
+
+export const UploadSamplesToDataStreamRequestParams = lazySchema(() =>
+  z.object({
+    /**
+     * The integration identifier
+     */
+    integration_id: SafeIdentifier,
+    /**
+     * The data stream identifier
+     */
+    data_stream_id: SafeIdentifier,
+  })
+);
+export type UploadSamplesToDataStreamRequestParams = z.infer<
+  typeof UploadSamplesToDataStreamRequestParams
+>;
+export type UploadSamplesToDataStreamRequestParamsInput = z.input<
+  typeof UploadSamplesToDataStreamRequestParams
+>;
+
+export const UploadSamplesToDataStreamRequestBody = lazySchema(() =>
+  z
+    .object({
+      /**
+       * Log lines to upload when the source is a file (omit when using sourceIndex).
+       */
+      samples: z.array(z.string()).max(1000).optional(),
+      /**
+       * Index name to pick samples from.
+       */
+      sourceIndex: z.string().min(1).max(100).optional(),
+      /**
+       * The original source of the samples (file name or index name)
+       */
+      originalSource: OriginalSource,
+      /**
+       * The LangSmith tracing options
+       */
+      langSmithOptions: LangSmithOptions.optional(),
+    })
+    .strict()
+);
+export type UploadSamplesToDataStreamRequestBody = z.infer<
+  typeof UploadSamplesToDataStreamRequestBody
+>;
 export type UploadSamplesToDataStreamRequestBodyInput = z.input<
   typeof UploadSamplesToDataStreamRequestBody
 >;
 
+export const UploadSamplesToDataStreamResponse = lazySchema(() =>
+  z
+    .object({
+      /**
+       * Indicates if the samples are uploaded successfully.
+       */
+      success: z.boolean().optional(),
+    })
+    .strict()
+);
 export type UploadSamplesToDataStreamResponse = z.infer<typeof UploadSamplesToDataStreamResponse>;
-export const UploadSamplesToDataStreamResponse = z
-  .object({
-    /**
-     * Indicates if the samples are uploaded successfully.
-     */
-    success: z.boolean().optional(),
-  })
-  .strict();

--- a/x-pack/platform/plugins/shared/automatic_import/common/model/api/integrations/integration.gen.ts
+++ b/x-pack/platform/plugins/shared/automatic_import/common/model/api/integrations/integration.gen.ts
@@ -14,7 +14,7 @@
  *   version: 1
  */
 
-import { z } from '@kbn/zod/v4';
+import { z, lazySchema } from '@kbn/zod/v4';
 
 import { NonEmptyString, SafeIdentifier, SemVer } from '../../primitive.gen';
 import {
@@ -28,221 +28,245 @@ import {
 /**
  * The intent of the download request.
  */
+export const DownloadIntent = lazySchema(() => z.enum(['download', 'install']));
 export type DownloadIntent = z.infer<typeof DownloadIntent>;
-export const DownloadIntent = z.enum(['download', 'install']);
 export type DownloadIntentEnum = typeof DownloadIntent.enum;
 export const DownloadIntentEnum = DownloadIntent.enum;
 
+export const ApproveIntegrationRequest = lazySchema(() =>
+  z
+    .object({
+      /**
+       * The version of the integration
+       */
+      version: SemVer,
+      /**
+       * The categories of the integration
+       */
+      categories: z.array(NonEmptyString).min(1).max(50),
+      /**
+       * The LangSmith tracing options
+       */
+      langSmithOptions: LangSmithOptions.optional(),
+    })
+    .strict()
+);
 export type ApproveIntegrationRequest = z.infer<typeof ApproveIntegrationRequest>;
-export const ApproveIntegrationRequest = z
-  .object({
-    /**
-     * The version of the integration
-     */
-    version: SemVer,
-    /**
-     * The categories of the integration
-     */
-    categories: z.array(NonEmptyString).min(1).max(50),
-    /**
-     * The LangSmith tracing options
-     */
-    langSmithOptions: LangSmithOptions.optional(),
-  })
-  .strict();
 
+export const ApproveAutoImportIntegrationRequestParams = lazySchema(() =>
+  z.object({
+    /**
+     * The integration identifier
+     */
+    integration_id: SafeIdentifier,
+  })
+);
 export type ApproveAutoImportIntegrationRequestParams = z.infer<
   typeof ApproveAutoImportIntegrationRequestParams
 >;
-export const ApproveAutoImportIntegrationRequestParams = z.object({
-  /**
-   * The integration identifier
-   */
-  integration_id: SafeIdentifier,
-});
 export type ApproveAutoImportIntegrationRequestParamsInput = z.input<
   typeof ApproveAutoImportIntegrationRequestParams
 >;
 
+export const ApproveAutoImportIntegrationRequestBody = lazySchema(() => ApproveIntegrationRequest);
 export type ApproveAutoImportIntegrationRequestBody = z.infer<
   typeof ApproveAutoImportIntegrationRequestBody
 >;
-export const ApproveAutoImportIntegrationRequestBody = ApproveIntegrationRequest;
 export type ApproveAutoImportIntegrationRequestBodyInput = z.input<
   typeof ApproveAutoImportIntegrationRequestBody
 >;
 
+export const CreateAutoImportIntegrationRequestBody = lazySchema(() =>
+  z
+    .object({
+      /**
+       * The connector id
+       */
+      connectorId: NonEmptyString,
+      /**
+       * The integration id
+       */
+      integrationId: SafeIdentifier,
+      /**
+       * The title of the integration
+       */
+      title: NonEmptyString,
+      /**
+       * The description of the integration
+       */
+      description: NonEmptyString,
+      /**
+       * The LangSmith tracing options
+       */
+      langSmithOptions: LangSmithOptions.optional(),
+      /**
+       * The logo of the integration
+       */
+      logo: NonEmptyString.optional(),
+      /**
+       * The data streams of the integration
+       */
+      dataStreams: z.array(DataStream).max(50).optional(),
+    })
+    .strict()
+);
 export type CreateAutoImportIntegrationRequestBody = z.infer<
   typeof CreateAutoImportIntegrationRequestBody
 >;
-export const CreateAutoImportIntegrationRequestBody = z
-  .object({
-    /**
-     * The connector id
-     */
-    connectorId: NonEmptyString,
-    /**
-     * The integration id
-     */
-    integrationId: SafeIdentifier,
-    /**
-     * The title of the integration
-     */
-    title: NonEmptyString,
-    /**
-     * The description of the integration
-     */
-    description: NonEmptyString,
-    /**
-     * The LangSmith tracing options
-     */
-    langSmithOptions: LangSmithOptions.optional(),
-    /**
-     * The logo of the integration
-     */
-    logo: NonEmptyString.optional(),
-    /**
-     * The data streams of the integration
-     */
-    dataStreams: z.array(DataStream).max(50).optional(),
-  })
-  .strict();
 export type CreateAutoImportIntegrationRequestBodyInput = z.input<
   typeof CreateAutoImportIntegrationRequestBody
 >;
 
+export const CreateAutoImportIntegrationResponse = lazySchema(() =>
+  z
+    .object({
+      /**
+       * The integration id created in state.
+       */
+      integration_id: NonEmptyString.optional(),
+    })
+    .strict()
+);
 export type CreateAutoImportIntegrationResponse = z.infer<
   typeof CreateAutoImportIntegrationResponse
 >;
-export const CreateAutoImportIntegrationResponse = z
-  .object({
-    /**
-     * The integration id created in state.
-     */
-    integration_id: NonEmptyString.optional(),
-  })
-  .strict();
 
+export const DeleteAutoImportIntegrationRequestParams = lazySchema(() =>
+  z.object({
+    /**
+     * The integration identifier
+     */
+    integration_id: SafeIdentifier,
+  })
+);
 export type DeleteAutoImportIntegrationRequestParams = z.infer<
   typeof DeleteAutoImportIntegrationRequestParams
 >;
-export const DeleteAutoImportIntegrationRequestParams = z.object({
-  /**
-   * The integration identifier
-   */
-  integration_id: SafeIdentifier,
-});
 export type DeleteAutoImportIntegrationRequestParamsInput = z.input<
   typeof DeleteAutoImportIntegrationRequestParams
 >;
 
+export const DownloadAutoImportIntegrationRequestQuery = lazySchema(() =>
+  z.object({
+    /**
+     * The intent of the download request. When set to 'install', install telemetry is reported.
+     */
+    intent: DownloadIntent.optional(),
+  })
+);
 export type DownloadAutoImportIntegrationRequestQuery = z.infer<
   typeof DownloadAutoImportIntegrationRequestQuery
 >;
-export const DownloadAutoImportIntegrationRequestQuery = z.object({
-  /**
-   * The intent of the download request. When set to 'install', install telemetry is reported.
-   */
-  intent: DownloadIntent.optional(),
-});
 export type DownloadAutoImportIntegrationRequestQueryInput = z.input<
   typeof DownloadAutoImportIntegrationRequestQuery
 >;
 
+export const DownloadAutoImportIntegrationRequestParams = lazySchema(() =>
+  z.object({
+    /**
+     * The integration identifier
+     */
+    integration_id: SafeIdentifier,
+  })
+);
 export type DownloadAutoImportIntegrationRequestParams = z.infer<
   typeof DownloadAutoImportIntegrationRequestParams
 >;
-export const DownloadAutoImportIntegrationRequestParams = z.object({
-  /**
-   * The integration identifier
-   */
-  integration_id: SafeIdentifier,
-});
 export type DownloadAutoImportIntegrationRequestParamsInput = z.input<
   typeof DownloadAutoImportIntegrationRequestParams
 >;
 
+export const GetAllAutoImportIntegrationsResponse = lazySchema(() =>
+  z.array(AllIntegrationsResponseIntegration)
+);
 export type GetAllAutoImportIntegrationsResponse = z.infer<
   typeof GetAllAutoImportIntegrationsResponse
 >;
-export const GetAllAutoImportIntegrationsResponse = z.array(AllIntegrationsResponseIntegration);
 
+export const GetAutoImportIntegrationRequestParams = lazySchema(() =>
+  z.object({
+    /**
+     * The integration identifier
+     */
+    integration_id: SafeIdentifier,
+  })
+);
 export type GetAutoImportIntegrationRequestParams = z.infer<
   typeof GetAutoImportIntegrationRequestParams
 >;
-export const GetAutoImportIntegrationRequestParams = z.object({
-  /**
-   * The integration identifier
-   */
-  integration_id: SafeIdentifier,
-});
 export type GetAutoImportIntegrationRequestParamsInput = z.input<
   typeof GetAutoImportIntegrationRequestParams
 >;
 
+export const GetAutoImportIntegrationResponse = lazySchema(() =>
+  z
+    .object({
+      integrationResponse: IntegrationResponse,
+    })
+    .strict()
+);
 export type GetAutoImportIntegrationResponse = z.infer<typeof GetAutoImportIntegrationResponse>;
-export const GetAutoImportIntegrationResponse = z
-  .object({
-    integrationResponse: IntegrationResponse,
-  })
-  .strict();
 
+export const UpdateAutoImportIntegrationRequestParams = lazySchema(() =>
+  z.object({
+    /**
+     * The integration identifier
+     */
+    integration_id: SafeIdentifier,
+  })
+);
 export type UpdateAutoImportIntegrationRequestParams = z.infer<
   typeof UpdateAutoImportIntegrationRequestParams
 >;
-export const UpdateAutoImportIntegrationRequestParams = z.object({
-  /**
-   * The integration identifier
-   */
-  integration_id: SafeIdentifier,
-});
 export type UpdateAutoImportIntegrationRequestParamsInput = z.input<
   typeof UpdateAutoImportIntegrationRequestParams
 >;
 
+export const UpdateAutoImportIntegrationRequestBody = lazySchema(() =>
+  z
+    .object({
+      /**
+       * Integration description
+       */
+      description: NonEmptyString.optional(),
+      /**
+       * Integration logo image blob
+       */
+      logo: NonEmptyString.optional(),
+      /**
+       * The LangSmith tracing options
+       */
+      langSmithOptions: LangSmithOptions.optional(),
+      /**
+       * The data streams of the integration
+       */
+      dataStreams: z
+        .array(
+          z
+            .object({
+              /**
+               * The description of the data stream
+               */
+              description: NonEmptyString.optional(),
+              /**
+               * The input types of the data stream
+               */
+              inputTypes: z.array(InputType).max(100).optional(),
+              /**
+               * The raw samples of the data stream
+               */
+              rawSamples: z.array(NonEmptyString).max(1000).optional(),
+            })
+            .strict()
+        )
+        .max(50)
+        .optional(),
+    })
+    .strict()
+);
 export type UpdateAutoImportIntegrationRequestBody = z.infer<
   typeof UpdateAutoImportIntegrationRequestBody
 >;
-export const UpdateAutoImportIntegrationRequestBody = z
-  .object({
-    /**
-     * Integration description
-     */
-    description: NonEmptyString.optional(),
-    /**
-     * Integration logo image blob
-     */
-    logo: NonEmptyString.optional(),
-    /**
-     * The LangSmith tracing options
-     */
-    langSmithOptions: LangSmithOptions.optional(),
-    /**
-     * The data streams of the integration
-     */
-    dataStreams: z
-      .array(
-        z
-          .object({
-            /**
-             * The description of the data stream
-             */
-            description: NonEmptyString.optional(),
-            /**
-             * The input types of the data stream
-             */
-            inputTypes: z.array(InputType).max(100).optional(),
-            /**
-             * The raw samples of the data stream
-             */
-            rawSamples: z.array(NonEmptyString).max(1000).optional(),
-          })
-          .strict()
-      )
-      .max(50)
-      .optional(),
-  })
-  .strict();
 export type UpdateAutoImportIntegrationRequestBodyInput = z.input<
   typeof UpdateAutoImportIntegrationRequestBody
 >;

--- a/x-pack/platform/plugins/shared/automatic_import/common/model/api/integrations/integration.test.ts
+++ b/x-pack/platform/plugins/shared/automatic_import/common/model/api/integrations/integration.test.ts
@@ -672,6 +672,23 @@ describe('integration schemas', () => {
       expectParseSuccess(result);
     });
 
+    it('accepts integrationResponse with optional categories', () => {
+      const payload = {
+        integrationResponse: {
+          integrationId: 'integration-123',
+          title: 'Test Integration',
+          description: 'Integration for testing purposes',
+          status: 'pending' as const,
+          dataStreams: [],
+          categories: ['security'],
+        },
+      };
+
+      const result = GetAutoImportIntegrationResponse.safeParse(payload);
+      expectParseSuccess(result);
+      expect(result.data.integrationResponse.categories).toEqual(['security']);
+    });
+
     it('strips unknown properties in integrationResponse', () => {
       const payload = {
         integrationResponse: {

--- a/x-pack/platform/plugins/shared/automatic_import/common/model/common_attributes.gen.ts
+++ b/x-pack/platform/plugins/shared/automatic_import/common/model/common_attributes.gen.ts
@@ -14,72 +14,170 @@
  *   version: not applicable
  */
 
-import { z } from '@kbn/zod/v4';
+import { z, lazySchema } from '@kbn/zod/v4';
 
 import { SafeIdentifier, NonEmptyString } from './primitive.gen';
 
 /**
  * The input type object with its settings.
  */
+export const InputType = lazySchema(() =>
+  z.object({
+    /**
+     * The name of the input type
+     */
+    name: z.enum([
+      'aws-cloudwatch',
+      'aws-s3',
+      'azure-blob-storage',
+      'azure-eventhub',
+      'cloudfoundry',
+      'filestream',
+      'gcp-pubsub',
+      'gcs',
+      'http_endpoint',
+      'journald',
+      'kafka',
+      'tcp',
+      'udp',
+    ]),
+  })
+);
 export type InputType = z.infer<typeof InputType>;
-export const InputType = z.object({
-  /**
-   * The name of the input type
-   */
-  name: z.enum([
-    'aws-cloudwatch',
-    'aws-s3',
-    'azure-blob-storage',
-    'azure-eventhub',
-    'cloudfoundry',
-    'filestream',
-    'gcp-pubsub',
-    'gcs',
-    'http_endpoint',
-    'journald',
-    'kafka',
-    'tcp',
-    'udp',
-  ]),
-});
 
 /**
  * The data stream object with its settings.
  */
+export const DataStream = lazySchema(() =>
+  z.object({
+    /**
+     * The ID of the data stream
+     */
+    dataStreamId: SafeIdentifier,
+    /**
+     * The title of the data stream
+     */
+    title: NonEmptyString,
+    /**
+     * The description of the data stream
+     */
+    description: NonEmptyString,
+    /**
+     * The input types of the data stream
+     */
+    inputTypes: z.array(InputType).max(100),
+  })
+);
 export type DataStream = z.infer<typeof DataStream>;
-export const DataStream = z.object({
-  /**
-   * The ID of the data stream
-   */
-  dataStreamId: SafeIdentifier,
-  /**
-   * The title of the data stream
-   */
-  title: NonEmptyString,
-  /**
-   * The description of the data stream
-   */
-  description: NonEmptyString,
-  /**
-   * The input types of the data stream
-   */
-  inputTypes: z.array(InputType).max(100),
-});
 
 /**
  * The integration object with its settings.
  */
+export const Integration = lazySchema(() =>
+  z
+    .object({
+      /**
+       * The ID of the integration
+       */
+      integrationId: SafeIdentifier,
+      /**
+       * The data streams of the integration
+       */
+      dataStreams: z.array(DataStream).max(10).optional(),
+      /**
+       * The logo of the integration
+       */
+      logo: z.string().optional(),
+      /**
+       * The description of the integration
+       */
+      description: NonEmptyString,
+      /**
+       * The title of the integration
+       */
+      title: NonEmptyString,
+    })
+    .strict()
+);
 export type Integration = z.infer<typeof Integration>;
-export const Integration = z
-  .object({
+
+/**
+ * The type of the original source.
+ */
+export const OriginalSourceType = lazySchema(() => z.enum(['index', 'file']));
+export type OriginalSourceType = z.infer<typeof OriginalSourceType>;
+export type OriginalSourceTypeEnum = typeof OriginalSourceType.enum;
+export const OriginalSourceTypeEnum = OriginalSourceType.enum;
+
+/**
+ * The original source of the samples.
+ */
+export const OriginalSource = lazySchema(() =>
+  z.object({
+    /**
+     * The type of the original source
+     */
+    sourceType: OriginalSourceType,
+    /**
+     * The value of the original source (e.g. index name or filename)
+     */
+    sourceValue: NonEmptyString,
+  })
+);
+export type OriginalSource = z.infer<typeof OriginalSource>;
+
+/**
+ * The status of the task
+ */
+export const TaskStatus = lazySchema(() =>
+  z.enum(['pending', 'processing', 'completed', 'approved', 'failed', 'cancelled', 'deleting'])
+);
+export type TaskStatus = z.infer<typeof TaskStatus>;
+export type TaskStatusEnum = typeof TaskStatus.enum;
+export const TaskStatusEnum = TaskStatus.enum;
+
+/**
+ * The data stream response object with its settings.
+ */
+export const DataStreamResponse = lazySchema(() =>
+  z.object({
+    /**
+     * The ID of the data stream
+     */
+    dataStreamId: NonEmptyString,
+    /**
+     * The title of the data stream
+     */
+    title: NonEmptyString,
+    /**
+     * The description of the data stream
+     */
+    description: NonEmptyString,
+    /**
+     * The input types of the data stream
+     */
+    inputTypes: z.array(InputType).max(100),
+    /**
+     * The status of the data stream
+     */
+    status: TaskStatus,
+  })
+);
+export type DataStreamResponse = z.infer<typeof DataStreamResponse>;
+
+/**
+ * The integration response object with its settings.
+ */
+export const IntegrationResponse = lazySchema(() =>
+  z.object({
     /**
      * The ID of the integration
      */
-    integrationId: SafeIdentifier,
+    integrationId: NonEmptyString,
     /**
-     * The data streams of the integration
+     * The title of the integration
      */
-    dataStreams: z.array(DataStream).max(10).optional(),
+    title: NonEmptyString,
     /**
      * The logo of the integration
      */
@@ -89,181 +187,97 @@ export const Integration = z
      */
     description: NonEmptyString,
     /**
-     * The title of the integration
+     * The version of the integration
      */
-    title: NonEmptyString,
+    version: z.string().optional(),
+    /**
+     * The ID of the connector associated with this integration
+     */
+    connectorId: z.string().optional(),
+    /**
+     * The username of the user who created the integration
+     */
+    createdBy: z.string().optional(),
+    /**
+     * The profile UID of the user who created the integration
+     */
+    createdByProfileUid: z.string().optional(),
+    /**
+     * The data streams of the integration
+     */
+    dataStreams: z.array(DataStreamResponse),
+    /**
+     * The categories of the integration
+     */
+    categories: z.array(z.string()).optional(),
+    /**
+     * The status of the integration
+     */
+    status: TaskStatus,
   })
-  .strict();
-
-/**
- * The type of the original source.
- */
-export type OriginalSourceType = z.infer<typeof OriginalSourceType>;
-export const OriginalSourceType = z.enum(['index', 'file']);
-export type OriginalSourceTypeEnum = typeof OriginalSourceType.enum;
-export const OriginalSourceTypeEnum = OriginalSourceType.enum;
-
-/**
- * The original source of the samples.
- */
-export type OriginalSource = z.infer<typeof OriginalSource>;
-export const OriginalSource = z.object({
-  /**
-   * The type of the original source
-   */
-  sourceType: OriginalSourceType,
-  /**
-   * The value of the original source (e.g. index name or filename)
-   */
-  sourceValue: NonEmptyString,
-});
-
-/**
- * The status of the task
- */
-export type TaskStatus = z.infer<typeof TaskStatus>;
-export const TaskStatus = z.enum([
-  'pending',
-  'processing',
-  'completed',
-  'approved',
-  'failed',
-  'cancelled',
-  'deleting',
-]);
-export type TaskStatusEnum = typeof TaskStatus.enum;
-export const TaskStatusEnum = TaskStatus.enum;
-
-/**
- * The data stream response object with its settings.
- */
-export type DataStreamResponse = z.infer<typeof DataStreamResponse>;
-export const DataStreamResponse = z.object({
-  /**
-   * The ID of the data stream
-   */
-  dataStreamId: NonEmptyString,
-  /**
-   * The title of the data stream
-   */
-  title: NonEmptyString,
-  /**
-   * The description of the data stream
-   */
-  description: NonEmptyString,
-  /**
-   * The input types of the data stream
-   */
-  inputTypes: z.array(InputType).max(100),
-  /**
-   * The status of the data stream
-   */
-  status: TaskStatus,
-});
-
-/**
- * The integration response object with its settings.
- */
+);
 export type IntegrationResponse = z.infer<typeof IntegrationResponse>;
-export const IntegrationResponse = z.object({
-  /**
-   * The ID of the integration
-   */
-  integrationId: NonEmptyString,
-  /**
-   * The title of the integration
-   */
-  title: NonEmptyString,
-  /**
-   * The logo of the integration
-   */
-  logo: z.string().optional(),
-  /**
-   * The description of the integration
-   */
-  description: NonEmptyString,
-  /**
-   * The version of the integration
-   */
-  version: z.string().optional(),
-  /**
-   * The ID of the connector associated with this integration
-   */
-  connectorId: z.string().optional(),
-  /**
-   * The username of the user who created the integration
-   */
-  createdBy: z.string().optional(),
-  /**
-   * The profile UID of the user who created the integration
-   */
-  createdByProfileUid: z.string().optional(),
-  /**
-   * The data streams of the integration
-   */
-  dataStreams: z.array(DataStreamResponse),
-  /**
-   * The status of the integration
-   */
-  status: TaskStatus,
-});
 
 /**
  * The integration object with its settings.
  */
+export const AllIntegrationsResponseIntegration = lazySchema(() =>
+  z.object({
+    /**
+     * The ID of the integration
+     */
+    integrationId: NonEmptyString,
+    /**
+     * The title of the integration
+     */
+    title: NonEmptyString,
+    /**
+     * The logo of the integration (base64 encoded SVG)
+     */
+    logo: z.string().optional(),
+    /**
+     * The number of data streams of the integration
+     */
+    totalDataStreamCount: z.number().int(),
+    /**
+     * The number of successful data streams of the integration
+     */
+    successfulDataStreamCount: z.number().int(),
+    /**
+     * The version of the integration
+     */
+    version: z.string().optional(),
+    /**
+     * The username of the user who created the integration
+     */
+    createdBy: NonEmptyString,
+    /**
+     * The profile UID of the user who created the integration
+     */
+    createdByProfileUid: z.string().optional(),
+    /**
+     * The status of the integration
+     */
+    status: TaskStatus,
+  })
+);
 export type AllIntegrationsResponseIntegration = z.infer<typeof AllIntegrationsResponseIntegration>;
-export const AllIntegrationsResponseIntegration = z.object({
-  /**
-   * The ID of the integration
-   */
-  integrationId: NonEmptyString,
-  /**
-   * The title of the integration
-   */
-  title: NonEmptyString,
-  /**
-   * The logo of the integration (base64 encoded SVG)
-   */
-  logo: z.string().optional(),
-  /**
-   * The number of data streams of the integration
-   */
-  totalDataStreamCount: z.number().int(),
-  /**
-   * The number of successful data streams of the integration
-   */
-  successfulDataStreamCount: z.number().int(),
-  /**
-   * The version of the integration
-   */
-  version: z.string().optional(),
-  /**
-   * The username of the user who created the integration
-   */
-  createdBy: NonEmptyString,
-  /**
-   * The profile UID of the user who created the integration
-   */
-  createdByProfileUid: z.string().optional(),
-  /**
-   * The status of the integration
-   */
-  status: TaskStatus,
-});
 
 /**
  * The LangSmith options object.
  */
+export const LangSmithOptions = lazySchema(() =>
+  z
+    .object({
+      /**
+       * The project name.
+       */
+      projectName: z.string(),
+      /**
+       * The apiKey to use for tracing.
+       */
+      apiKey: z.string(),
+    })
+    .strict()
+);
 export type LangSmithOptions = z.infer<typeof LangSmithOptions>;
-export const LangSmithOptions = z
-  .object({
-    /**
-     * The project name.
-     */
-    projectName: z.string(),
-    /**
-     * The apiKey to use for tracing.
-     */
-    apiKey: z.string(),
-  })
-  .strict();

--- a/x-pack/platform/plugins/shared/automatic_import/common/model/common_attributes.schema.yaml
+++ b/x-pack/platform/plugins/shared/automatic_import/common/model/common_attributes.schema.yaml
@@ -185,6 +185,11 @@ components:
               description: The data streams of the integration
               items:
                 $ref: "#/components/schemas/DataStreamResponse"
+            categories:
+              description: The categories of the integration
+              type: array
+              items:
+                type: string
             status:
               description: The status of the integration
               $ref: "#/components/schemas/TaskStatus"

--- a/x-pack/platform/plugins/shared/automatic_import/common/model/common_attributes.test.ts
+++ b/x-pack/platform/plugins/shared/automatic_import/common/model/common_attributes.test.ts
@@ -554,6 +554,17 @@ describe('common attributes schemas', () => {
       expect(result.data.logo).toBeUndefined();
     });
 
+    it('accepts integration with categories (optional)', () => {
+      const payload = {
+        ...validIntegrationResponse,
+        categories: ['security', 'observability'],
+      };
+
+      const result = IntegrationResponse.safeParse(payload);
+      expectParseSuccess(result);
+      expect(result.data.categories).toEqual(['security', 'observability']);
+    });
+
     it('accepts empty data streams array', () => {
       const payload = {
         ...validIntegrationResponse,

--- a/x-pack/platform/plugins/shared/automatic_import/common/model/primitive.gen.ts
+++ b/x-pack/platform/plugins/shared/automatic_import/common/model/primitive.gen.ts
@@ -14,37 +14,41 @@
  *   version: not applicable
  */
 
-import { z } from '@kbn/zod/v4';
+import { z, lazySchema } from '@kbn/zod/v4';
 import { isNonEmptyString } from '@kbn/zod-helpers/v4';
 
 /**
  * A string that does not contain only whitespace characters
  */
+export const NonEmptyString = lazySchema(() => z.string().min(1).superRefine(isNonEmptyString));
 export type NonEmptyString = z.infer<typeof NonEmptyString>;
-export const NonEmptyString = z.string().min(1).superRefine(isNonEmptyString);
 
 /**
  * An identifier containing only alphanumeric characters and underscores
  */
+export const SafeIdentifier = lazySchema(() =>
+  z
+    .string()
+    .min(1)
+    .max(255)
+    .regex(/^[a-zA-Z0-9_]+$/)
+);
 export type SafeIdentifier = z.infer<typeof SafeIdentifier>;
-export const SafeIdentifier = z
-  .string()
-  .min(1)
-  .max(255)
-  .regex(/^[a-zA-Z0-9_]+$/);
 
 /**
  * A semantic version string (e.g. 1.0.0 or 1.0.0-beta).
  */
+export const SemVer = lazySchema(() =>
+  z
+    .string()
+    .min(5)
+    .max(20)
+    .regex(/^\d+\.\d+\.\d+(-[a-zA-Z0-9]+(\.[a-zA-Z0-9]+)*)?$/)
+);
 export type SemVer = z.infer<typeof SemVer>;
-export const SemVer = z
-  .string()
-  .min(5)
-  .max(20)
-  .regex(/^\d+\.\d+\.\d+(-[a-zA-Z0-9]+(\.[a-zA-Z0-9]+)*)?$/);
 
 /**
  * A universally unique identifier
  */
+export const UUID = lazySchema(() => z.string().uuid());
 export type UUID = z.infer<typeof UUID>;
-export const UUID = z.string().uuid();

--- a/x-pack/platform/plugins/shared/automatic_import/server/services/automatic_import_service.ts
+++ b/x-pack/platform/plugins/shared/automatic_import/server/services/automatic_import_service.ts
@@ -245,6 +245,7 @@ export class AutomaticImportService {
       createdByProfileUid: integrationSO.created_by_profile_uid,
       status: deriveIntegrationStatus(integrationSO, dataStreamsSO),
       dataStreams: dataStreamsResponses,
+      categories: integrationSO.metadata.categories,
     };
     return integrationResponse;
   }

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/components/manage_integrations_table.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/components/manage_integrations_table.tsx
@@ -268,6 +268,7 @@ export const ManageIntegrationsTable: React.FC<{
           title: string;
           version?: string;
           dataStreams: DataStreamResponse[];
+          categories?: string[];
         };
       }>(`/api/automatic_import/integrations/${encodeURIComponent(integrationId)}`, {
         version: '1',
@@ -278,6 +279,7 @@ export const ManageIntegrationsTable: React.FC<{
         title: integrationResponse.title,
         version: integrationResponse.version,
         dataStreams: integrationResponse.dataStreams ?? [],
+        categories: integrationResponse.categories,
       };
     },
     [http]

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/components/review_approve_modal.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/components/review_approve_modal.tsx
@@ -259,9 +259,8 @@ export const ReviewApproveModal: React.FC<{
 
     const selected = savedIds
       .map((id) => categoryOptions.find((opt) => String(opt.value) === id))
-      .filter(
-        (opt): opt is EuiComboBoxOptionOption =>
-          Boolean(opt && typeof opt.value === 'string' && opt.value.length > 0)
+      .filter((opt): opt is EuiComboBoxOptionOption =>
+        Boolean(opt && typeof opt.value === 'string' && opt.value.length > 0)
       );
 
     if (selected.length > 0) {

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/components/review_approve_modal.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/components/review_approve_modal.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   EuiBadge,
   EuiBasicTable,
@@ -58,6 +58,7 @@ export interface ReviewIntegrationDetails {
   title: string;
   version?: string;
   dataStreams: ReviewDataStream[];
+  categories?: string[];
 }
 
 const MAX_VISIBLE_COLLECTION_METHODS = 1;
@@ -174,6 +175,7 @@ export const ReviewApproveModal: React.FC<{
     useState<ReviewDataStream | null>(null);
   const [selectedCategories, setSelectedCategories] = useState<EuiComboBoxOptionOption[]>([]);
   const [autoInstallAfterApproval, setAutoInstallAfterApproval] = useState(true);
+  const savedCategoriesAppliedRef = useRef(false);
 
   const autoInstallCheckboxId = useMemo(
     () => htmlIdGenerator('manageIntegrationReviewAutoInstall')(),
@@ -233,10 +235,40 @@ export const ReviewApproveModal: React.FC<{
       setReviewError(null);
       setSelectedDataStreamForFlyout(null);
       setSelectedCategories([]);
+      savedCategoriesAppliedRef.current = false;
       setAutoInstallAfterApproval(true);
       loadReviewDetails();
     }
   }, [isOpen, loadReviewDetails]);
+
+  useEffect(() => {
+    if (
+      !isOpen ||
+      !reviewDetails ||
+      savedCategoriesAppliedRef.current ||
+      categoryOptions.length === 0
+    ) {
+      return;
+    }
+
+    const savedIds = reviewDetails.categories;
+    if (!savedIds?.length) {
+      savedCategoriesAppliedRef.current = true;
+      return;
+    }
+
+    const selected = savedIds
+      .map((id) => categoryOptions.find((opt) => String(opt.value) === id))
+      .filter(
+        (opt): opt is EuiComboBoxOptionOption =>
+          Boolean(opt && typeof opt.value === 'string' && opt.value.length > 0)
+      );
+
+    if (selected.length > 0) {
+      setSelectedCategories(selected);
+    }
+    savedCategoriesAppliedRef.current = true;
+  }, [isOpen, reviewDetails, categoryOptions]);
 
   const closeModal = useCallback(() => {
     if (isApproving) {

--- a/x-pack/platform/plugins/shared/fleet/test/scout_automatic_import/ui/tests/manage_integrations_table.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout_automatic_import/ui/tests/manage_integrations_table.spec.ts
@@ -237,9 +237,7 @@ test.describe('Manage Integrations Table', { tag: tags.stateful.classic }, () =>
     await pageObjects.manageIntegrationsTable.openActionsMenu('Completed Integration');
     await pageObjects.manageIntegrationsTable.getReviewApproveMenuItem().click();
     await expect(pageObjects.manageIntegrationsTable.getReviewApproveModal()).toBeVisible();
-    await expect(
-      pageObjects.manageIntegrationsTable.getReviewApproveInstallButton()
-    ).toBeEnabled();
+    await expect(pageObjects.manageIntegrationsTable.getReviewApproveInstallButton()).toBeEnabled();
   });
 
   test('Approve button is disabled until version and category are filled', async ({

--- a/x-pack/platform/plugins/shared/fleet/test/scout_automatic_import/ui/tests/manage_integrations_table.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout_automatic_import/ui/tests/manage_integrations_table.spec.ts
@@ -84,7 +84,11 @@ async function mockIntegrationsList(page: ScoutPage, items: unknown[]) {
   );
 }
 
-async function mockIntegrationDetails(page: ScoutPage, integrationId: string) {
+async function mockIntegrationDetails(
+  page: ScoutPage,
+  integrationId: string,
+  options?: { categories?: string[] }
+) {
   await page.route(`**/api/automatic_import/integrations/${integrationId}`, (route) =>
     route.fulfill({
       status: 200,
@@ -94,6 +98,7 @@ async function mockIntegrationDetails(page: ScoutPage, integrationId: string) {
           title: 'Completed Integration',
           version: '1.0.0',
           dataStreams: [],
+          ...(options?.categories ? { categories: options.categories } : {}),
         },
       }),
     })
@@ -211,6 +216,30 @@ test.describe('Manage Integrations Table', { tag: tags.stateful.classic }, () =>
       .getReviewApproveInlineBtn('Completed Integration')
       .click();
     await expect(pageObjects.manageIntegrationsTable.getReviewApproveModal()).toBeVisible();
+  });
+
+  test('Review modal pre-selects categories returned by the integration API', async ({
+    page,
+    pageObjects,
+  }) => {
+    await mockIntegrationsList(page, [MOCK_COMPLETED]);
+    await mockIntegrationDetails(page, MOCK_COMPLETED.integrationId, {
+      categories: ['security'],
+    });
+    await page.route('**/api/fleet/epm/categories**', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ items: [{ id: 'security', title: 'Security', count: 1 }] }),
+      })
+    );
+    await pageObjects.manageIntegrationsTable.navigateTo();
+    await pageObjects.manageIntegrationsTable.openActionsMenu('Completed Integration');
+    await pageObjects.manageIntegrationsTable.getReviewApproveMenuItem().click();
+    await expect(pageObjects.manageIntegrationsTable.getReviewApproveModal()).toBeVisible();
+    await expect(
+      pageObjects.manageIntegrationsTable.getReviewApproveInstallButton()
+    ).toBeEnabled();
   });
 
   test('Approve button is disabled until version and category are filled', async ({


### PR DESCRIPTION
## Summary

When editing an integration that was already approved (e.g. after adding data streams), **Review & approve** still required choosing categories again even though they were saved on the integration at first approval. This PR **exposes saved categories on `GET` integration** and **pre-selects them in the Fleet review modal** so re-approval does not force a redundant category selection.

## Changes

### API / model

- **`IntegrationResponse`** includes optional **`categories: string[]`** (same source as `metadata.categories` on the integration saved object).
- Schema: `x-pack/platform/plugins/shared/automatic_import/common/model/common_attributes.schema.yaml`
- Zod: `x-pack/platform/plugins/shared/automatic_import/common/model/common_attributes.gen.ts`
- **`getIntegrationById`** adds `categories: integrationSO.metadata.categories` to the returned payload.
  - `x-pack/platform/plugins/shared/automatic_import/server/services/automatic_import_service.ts`

### Fleet UI

- **`fetchIntegrationReviewDetails`** forwards `categories` from the integration GET response.
  - `x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/components/manage_integrations_table.tsx`
- **`ReviewIntegrationDetails`** includes optional `categories`; **`ReviewApproveModal`** maps saved IDs to EPM category options once review details and category list are available.
  - `x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/components/review_approve_modal.tsx`

### Tests

- Zod / model: `common_attributes.test.ts`, `integration.test.ts` (automatic import common model)
- Scout UI: optional `categories` on integration mock helper + test **Review modal pre-selects categories returned by the integration API**
  - `x-pack/platform/plugins/shared/fleet/test/scout_automatic_import/ui/tests/manage_integrations_table.spec.ts`

## How to verify

1. Create an integration, complete analysis, **Review & approve** with at least one category, approve.
2. Edit the integration, add a data stream, wait until ready for review again, open **Review & approve**.
3. Confirm **categories are pre-selected** and you can approve after setting a valid version (change categories only if desired).


https://github.com/user-attachments/assets/ec6f97ed-10cd-4bb0-bba1-070c20393c8f




<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->