### PR TITLE
[FIPS] Adjusted shard limit test

### DIFF
--- a/src/core/server/integration_tests/saved_objects/migrations/group3/actions/es_errors.test.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/group3/actions/es_errors.test.ts
@@ -140,7 +140,17 @@ describe('Elasticsearch Errors', () => {
   });
   describe('isClusterShardLimitExceeded', () => {
     beforeAll(async () => {
-      await client.cluster.putSettings({ persistent: { cluster: { max_shards_per_node: 1 } } });
+      // Compute the current shard count so we can set the limit to exactly
+      // that value. Adding any new shard will then exceed the limit regardless
+      // of how many system indices the cluster has (which differs between
+      // FIPS and non-FIPS environments).
+      const stats = await client.cluster.stats();
+      const numDataNodes = stats.nodes.count.data ?? 1;
+      const totalShards = stats.indices.shards.total ?? 0;
+      const maxShardsPerNode = Math.floor(totalShards / numDataNodes);
+      await client.cluster.putSettings({
+        persistent: { cluster: { max_shards_per_node: maxShardsPerNode } },
+      });
     });
     afterAll(async () => {
       await client.cluster.putSettings({ persistent: { cluster: { max_shards_per_node: null } } });


### PR DESCRIPTION
## Summary

In FIPS mode, Elasticsearch runs with more system indices than in a standard environment, so we need to calculate the limit exactly.


### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


__Fixes: https://github.com/elastic/kibana/issues/204303__