### PR TITLE
[SLO] Fix invalid annotation icon causing chart error on alert detail

### DIFF
--- a/x-pack/solutions/observability/plugins/slo/public/components/slo/error_rate_chart/use_lens_definition.ts
+++ b/x-pack/solutions/observability/plugins/slo/public/components/slo/error_rate_chart/use_lens_definition.ts
@@ -137,7 +137,7 @@ export function useLensDefinition({
                       },
                       lineWidth: 2,
                       color: euiTheme.colors.danger,
-                      icon: 'warning',
+                      icon: 'alert',
                     },
                     {
                       type: 'manual',
@@ -176,7 +176,7 @@ export function useLensDefinition({
                     },
                     lineWidth: 2,
                     color: euiTheme.colors.danger,
-                    icon: 'warning',
+                    icon: 'alert',
                   },
                 ],
                 ignoreGlobalFilters: true,


### PR DESCRIPTION
## Summary

`'warning'` is not a valid icon value for Lens `manual_point_event_annotation`. 
The allowed set includes `'alert'`, `'bell'`, `'bolt'`, and others, but not `'warning'`. This caused a validation error and prevented the burn rate chart from rendering on the SLO alert detail page.

This was probably introduced in [Replace deprecated EUI icons in files owned by @elastic/actionable-obs-team](https://github.com/elastic/kibana/pull/255622), which replaced the deprecated EUI icon name `alert` with `warning` across the codebase. The rename was correct for EUI components, but the Lens annotation icon set is independent of EUI and has its own fixed allowed values, where `'alert'` is valid but `'warning'` is not.

The fix restores `icon: 'alert'` for both annotation occurrences in the Lens definition.

|Before|After|
|-|-|
|<img width="1507" height="938" alt="chart_error_before" src="https://github.com/user-attachments/assets/88fe02db-b5ef-409b-b7e3-f4a8de4d3e2f" />|<img width="1506" height="937" alt="chart_error_after" src="https://github.com/user-attachments/assets/c15f88ae-a482-4ba4-a80e-cf41b89b9b6e" />|


<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->