### PR TITLE
[Transforms] Update max_page_search_size default to 5000

### DIFF
--- a/x-pack/platform/plugins/private/transform/common/constants.ts
+++ b/x-pack/platform/plugins/private/transform/common/constants.ts
@@ -240,7 +240,7 @@ export const TRANSFORM_HEALTH_CHECK_NAMES: Record<
 export const DEFAULT_CONTINUOUS_MODE_DELAY = '60s';
 export const DEFAULT_TRANSFORM_FREQUENCY = '1m';
 export const DEFAULT_TRANSFORM_SETTINGS_DOCS_PER_SECOND = null;
-export const DEFAULT_TRANSFORM_SETTINGS_MAX_PAGE_SEARCH_SIZE = 500;
+export const DEFAULT_TRANSFORM_SETTINGS_MAX_PAGE_SEARCH_SIZE = 5000;
 
 // Used in the transform list's expanded row for the messages and issues table.
 export const TIME_FORMAT = 'YYYY-MM-DD HH:mm:ss';

--- a/x-pack/platform/plugins/private/transform/public/app/common/request.test.ts
+++ b/x-pack/platform/plugins/private/transform/public/app/common/request.test.ts
@@ -400,7 +400,7 @@ describe('Transform: Common', () => {
   test('getCreateTransformSettingsRequestBody() skips default settings', () => {
     const transformDetailsState: Partial<StepDetailsExposedState> = {
       transformSettingsDocsPerSecond: null,
-      transformSettingsMaxPageSearchSize: 500,
+      transformSettingsMaxPageSearchSize: 5000,
     };
 
     const request = getCreateTransformSettingsRequestBody(transformDetailsState);

--- a/x-pack/platform/plugins/private/transform/public/app/common/request.test.ts
+++ b/x-pack/platform/plugins/private/transform/public/app/common/request.test.ts
@@ -243,7 +243,7 @@ describe('Transform: Common', () => {
       transformId: 'the-transform-id',
       transformDescription: 'the-transform-description',
       transformFrequency: '1m',
-      transformSettingsMaxPageSearchSize: 500,
+      transformSettingsMaxPageSearchSize: 5000,
       transformSettingsDocsPerSecond: null,
       destinationIndex: 'the-destination-index',
       destinationIngestPipeline: 'the-destination-ingest-pipeline',

--- a/x-pack/platform/plugins/private/transform/public/app/sections/create_transform/components/step_details/step_details_form.tsx
+++ b/x-pack/platform/plugins/private/transform/public/app/sections/create_transform/components/step_details/step_details_form.tsx
@@ -31,7 +31,10 @@ import { CreateDataViewForm } from '@kbn/ml-data-view-utils/components/create_da
 import { DestinationIndexForm } from '@kbn/ml-creation-wizard-utils/components/destination_index_form';
 
 import { retentionPolicyMaxAgeInvalidErrorMessage } from '../../../../common/validators/messages';
-import { DEFAULT_TRANSFORM_FREQUENCY } from '../../../../../../common/constants';
+import {
+  DEFAULT_TRANSFORM_FREQUENCY,
+  DEFAULT_TRANSFORM_SETTINGS_MAX_PAGE_SEARCH_SIZE,
+} from '../../../../../../common/constants';
 import type { TransformId } from '../../../../../../common/types/transform';
 import { isValidIndexName } from '../../../../../../common/utils/es_utils';
 
@@ -807,7 +810,7 @@ export const StepDetailsForm: FC<StepDetailsFormProps> = React.memo(
                   'xpack.transform.stepDetailsForm.editFlyoutFormMaxPageSearchSizePlaceholderText',
                   {
                     defaultMessage: 'Default: {defaultValue}',
-                    values: { defaultValue: 500 },
+                    values: { defaultValue: DEFAULT_TRANSFORM_SETTINGS_MAX_PAGE_SEARCH_SIZE },
                   }
                 )}
                 value={


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/265128

## Summary

This value got updated to have a new default, this PR just changes that value.