### PR TITLE
[Console] Add telemetry to import/export actions

### DIFF
--- a/src/platform/plugins/shared/console/public/application/containers/main/constants.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/main/constants.ts
@@ -25,3 +25,6 @@ export const INITIAL_TOUR_CONFIG = {
 };
 
 export const EXPORT_FILE_NAME = 'console_export';
+
+export const IMPORT_REQUESTS_METRIC_ID = 'import_requests';
+export const EXPORT_REQUESTS_METRIC_ID = 'export_requests';

--- a/src/platform/plugins/shared/console/public/application/containers/main/import_confirm_modal.tsx
+++ b/src/platform/plugins/shared/console/public/application/containers/main/import_confirm_modal.tsx
@@ -12,6 +12,7 @@ import { i18n } from '@kbn/i18n';
 import { EuiConfirmModal, useGeneratedHtmlId } from '@elastic/eui';
 import { useEditorActionContext } from '../../contexts';
 import { useServicesContext } from '../../contexts';
+import { IMPORT_REQUESTS_METRIC_ID } from './constants';
 
 interface ImportConfirmModalProps {
   onClose: () => void;
@@ -21,17 +22,18 @@ interface ImportConfirmModalProps {
 export const ImportConfirmModal = ({ onClose, fileContent }: ImportConfirmModalProps) => {
   const dispatch = useEditorActionContext();
   const {
-    services: { notifications },
+    services: { notifications, trackUiMetric },
   } = useServicesContext();
 
   const modalTitleId = useGeneratedHtmlId();
 
   const onConfirmImport = useCallback(() => {
-    // Import the file content
     dispatch({
       type: 'setFileToImport',
       payload: fileContent as string,
     });
+
+    trackUiMetric.count(IMPORT_REQUESTS_METRIC_ID);
 
     notifications.toasts.addSuccess(
       i18n.translate('console.notification.fileImportedSuccessfully', {
@@ -40,7 +42,7 @@ export const ImportConfirmModal = ({ onClose, fileContent }: ImportConfirmModalP
     );
 
     onClose();
-  }, [fileContent, onClose, dispatch, notifications.toasts]);
+  }, [fileContent, onClose, dispatch, notifications.toasts, trackUiMetric]);
 
   return (
     <EuiConfirmModal

--- a/src/platform/plugins/shared/console/public/application/containers/main/main.tsx
+++ b/src/platform/plugins/shared/console/public/application/containers/main/main.tsx
@@ -57,6 +57,7 @@ import {
   INITIAL_TOUR_CONFIG,
   FILES_TOUR_STEP,
   EXPORT_FILE_NAME,
+  EXPORT_REQUESTS_METRIC_ID,
 } from './constants';
 
 interface MainProps {
@@ -128,7 +129,7 @@ export function Main({ currentTabProp, isEmbeddable = false }: MainProps) {
 
   const {
     docLinks,
-    services: { notifications, routeHistory },
+    services: { notifications, routeHistory, trackUiMetric },
   } = useServicesContext();
 
   const [tourStepProps, actions, tourState] = useEuiTour(
@@ -271,12 +272,13 @@ export function Main({ currentTabProp, isEmbeddable = false }: MainProps) {
                     <EuiButtonEmpty
                       iconType="upload"
                       disabled={inputEditorValue === ''}
-                      onClick={() =>
+                      onClick={() => {
                         downloadFileAs(EXPORT_FILE_NAME, {
                           content: inputEditorValue,
                           type: 'text/plain',
-                        })
-                      }
+                        });
+                        trackUiMetric.count(EXPORT_REQUESTS_METRIC_ID);
+                      }}
                       size="xs"
                       data-test-subj="consoleExportButton"
                       aria-label={MAIN_PANEL_LABELS.exportButtonTooltip}


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/242885

## Summary

This PR adds telemetry count data on import/export actions in console. This will help give some insight to the request-converter team on whether the feature is being used and if there's anything they can do to improve things their end.