### PR TITLE
ci: Lint changed files first for early gate cancellation

### DIFF
--- a/.buildkite/scripts/steps/lint.sh
+++ b/.buildkite/scripts/steps/lint.sh
@@ -6,6 +6,46 @@ source .buildkite/scripts/common/util.sh
 
 .buildkite/scripts/bootstrap.sh
 
+# On PRs, run eslint on changed files first for a fast gate signal.
+# If issues are found, cancel downstream steps immediately instead of
+# waiting ~17 min for the full 90k-file lint to finish.
+gate_already_failed=false
+if is_pr; then
+  echo '--- Lint: quick check (changed files only)'
+  set +e
+  set_git_merge_base
+  merge_base_ok=$?
+  set -e
+
+  if [[ "$merge_base_ok" == "0" && -n "${GITHUB_PR_MERGE_BASE:-}" ]]; then
+    changed_lint_files=$(git diff --name-only "$GITHUB_PR_MERGE_BASE"...HEAD -- '*.js' '*.mjs' '*.ts' '*.tsx' 2>/dev/null || true)
+
+    if [[ -n "$changed_lint_files" ]]; then
+      file_count=$(echo "$changed_lint_files" | wc -l | tr -d ' ')
+      echo "Found $file_count changed JS/TS file(s) to quick-check"
+
+      set +e
+      echo "$changed_lint_files" | xargs node scripts/eslint --no-cache --fix
+      quick_eslint_exit=$?
+      set -e
+
+      quick_fix_changes="$(git status --porcelain -- '*.js' '*.mjs' '*.ts' '*.tsx')"
+
+      if [[ "$quick_eslint_exit" != "0" || -n "$quick_fix_changes" ]]; then
+        echo "❌ ESLint issues found in changed files — cancelling downstream steps early"
+        .buildkite/scripts/steps/gate_failure/cancel.sh || true
+        gate_already_failed=true
+      else
+        echo "quick eslint check passed ✅"
+      fi
+    else
+      echo "No JS/TS files changed, skipping quick check"
+    fi
+  else
+    echo "Could not resolve merge base, skipping quick check"
+  fi
+fi
+
 echo '--- Lint: stylelint'
 node scripts/stylelint
 echo "stylelint ✅"


### PR DESCRIPTION
## Summary

The **Linting** CI step currently lints all ~90,000 JS/TS files (`eslint_all_files --no-cache`) before it can signal a gate failure and cancel downstream steps. This means FTR tests, Scout tests, and other expensive jobs run for **17+ minutes** of wasted compute before being cancelled when there's a lint error.

This PR adds a **quick pre-check** that runs immediately after bootstrap:

1. Resolves the PR merge base (typically already cached in Buildkite metadata)
2. Gets the list of changed JS/TS files via `git diff --name-only`
3. Runs `eslint --no-cache --fix` on just those files (seconds, not minutes)
4. If issues are found or `--fix` modifies files → **immediately cancels downstream steps** via `cancel.sh`
5. The full lint continues afterward for auto-fix, commit, and push

### Impact

In [build 435506](https://buildkite.com/elastic/kibana-pull-request/builds/435506), the Linting step took **22 minutes** to report a single auto-fixable formatting issue. Downstream steps ran for ~20 minutes before being cancelled. With this change, the cancellation would have happened in **~5 seconds** after bootstrap.

### Safety

- The quick check is **PR-only** (skipped on merge builds)
- If merge base resolution fails, it gracefully falls back to the existing full-lint-only behavior
- The full lint still runs regardless, so auto-fix/commit/push behavior is unchanged
- `cancel.ts` already handles "already cancelled" steps gracefully, so the duplicate cancel from `post_command.sh` is harmless

## Test plan

- [ ] Verify quick check runs on a PR with changed JS/TS files and reports results
- [ ] Verify downstream steps are cancelled early when quick check finds issues
- [ ] Verify full lint still runs and auto-fixes/commits/pushes after early cancellation
- [ ] Verify no-op when merge base can't be resolved (graceful fallback)
- [ ] Verify no-op on non-PR builds (on-merge pipeline)

Made with [Cursor](https://cursor.com)