### PR TITLE
[9.4] [SigEvents] Fix known issues (#266001)

### DIFF
--- a/x-pack/platform/plugins/shared/streams/server/lib/sig_events/read_significant_events_from_alerts_indices.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/sig_events/read_significant_events_from_alerts_indices.ts
@@ -139,7 +139,8 @@ export async function readSignificantEventsFromAlertsIndices(
       throw err;
     });
 
-  if (!response.aggregations || !isArray(response.aggregations.by_rule.buckets)) {
+  const byRuleBuckets = response.aggregations?.by_rule?.buckets;
+  if (!byRuleBuckets || !isArray(byRuleBuckets)) {
     return {
       significant_events: queryLinks.map((queryLink) => ({
         ...toStreamQuery(queryLink),
@@ -156,30 +157,32 @@ export async function readSignificantEventsFromAlertsIndices(
     };
   }
 
-  const aggregatedBuckets = response.aggregations.aggregated_occurrences.buckets;
+  const aggregatedBuckets = response.aggregations?.aggregated_occurrences?.buckets;
   const aggregatedOccurrences = isArray(aggregatedBuckets)
     ? aggregatedBuckets.map((bucket) => ({ date: bucket.key_as_string, count: bucket.doc_count }))
     : [];
 
-  const significantEvents = response.aggregations.by_rule.buckets.map((bucket) => {
-    const ruleId = bucket.key;
-    const queryLink = queryLinkByRuleId[ruleId];
-    const occurrences = get(bucket, 'occurrences.buckets');
-    const changePoints = get(bucket, 'change_points') ?? {};
+  const significantEvents = byRuleBuckets
+    .filter((bucket) => queryLinkByRuleId[bucket.key] !== undefined)
+    .map((bucket) => {
+      const ruleId = bucket.key;
+      const queryLink = queryLinkByRuleId[ruleId];
+      const occurrences = get(bucket, 'occurrences.buckets');
+      const changePoints = get(bucket, 'change_points') ?? {};
 
-    return {
-      ...toStreamQuery(queryLink),
-      stream_name: queryLink.stream_name,
-      occurrences: isArray(occurrences)
-        ? occurrences.map((occurrence) => ({
-            date: occurrence.key_as_string,
-            count: occurrence.doc_count,
-          }))
-        : [],
-      rule_backed: queryLink.rule_backed,
-      change_points: changePoints,
-    };
-  });
+      return {
+        ...toStreamQuery(queryLink),
+        stream_name: queryLink.stream_name,
+        occurrences: isArray(occurrences)
+          ? occurrences.map((occurrence) => ({
+              date: occurrence.key_as_string,
+              count: occurrence.doc_count,
+            }))
+          : [],
+        rule_backed: queryLink.rule_backed,
+        change_points: changePoints,
+      };
+    });
 
   const foundSignificantEventsIds = significantEvents.map((event) => event.id);
   const notFoundSignificantEvents = queryLinks

--- a/x-pack/platform/plugins/shared/streams/server/lib/sig_events/rules/esql/common.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/sig_events/rules/esql/common.ts
@@ -6,3 +6,11 @@
  */
 
 export const MAX_ALERTS_PER_EXECUTION = 1_000;
+// Aligned with the default rule evaluation interval (1 min) with a 2x overlap
+// to avoid missing events that arrive slightly out of order.
+export const MATCH_LOOKBACK_MINUTES = 2;
+// Upper bound on accumulated dedup IDs to prevent unbounded state growth.
+// A doc spans at most MATCH_LOOKBACK_MINUTES windows (1-min interval), +1 for
+// scheduling jitter / TM backpressure. Even if an evicted ID reappears,
+// alertWithPersistence uses a deterministic _id so ES rejects the duplicate.
+export const MAX_DEDUP_IDS = MAX_ALERTS_PER_EXECUTION * (MATCH_LOOKBACK_MINUTES + 1);

--- a/x-pack/platform/plugins/shared/streams/server/lib/sig_events/rules/esql/executor.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/sig_events/rules/esql/executor.ts
@@ -15,7 +15,7 @@ import type { PersistenceServices } from '@kbn/rule-registry-plugin/server';
 import { isEmpty } from 'lodash';
 import moment from 'moment';
 import objectHash from 'object-hash';
-import { MAX_ALERTS_PER_EXECUTION } from './common';
+import { MAX_ALERTS_PER_EXECUTION, MAX_DEDUP_IDS, MATCH_LOOKBACK_MINUTES } from './common';
 import { buildEsqlSearchRequest } from './lib/build_esql_search_request';
 import { executeEsqlRequest } from './lib/execute_esql_request';
 import type { EsqlRuleInstanceState, EsqlRuleParams } from './types';
@@ -42,7 +42,7 @@ export async function getRuleExecutor(
   const esqlRequest = buildEsqlSearchRequest({
     query: params.query,
     timestampField: params.timestampField,
-    from: now.clone().subtract(2, 'minutes').toISOString(),
+    from: now.clone().subtract(MATCH_LOOKBACK_MINUTES, 'minutes').toISOString(),
     to: now.clone().toISOString(),
     previousOriginalDocumentIds,
   });
@@ -56,7 +56,7 @@ export async function getRuleExecutor(
   if (results.length === 0) {
     return {
       state: {
-        previousOriginalDocumentIds: [],
+        previousOriginalDocumentIds,
       },
     };
   }
@@ -92,9 +92,13 @@ export async function getRuleExecutor(
     (alert) => alertDocIdToDocumentIdMap.get(alert._id)!
   );
 
+  // Previous IDs come first, new IDs are appended — slice(-N) keeps the most recent ones.
+  const mergedIds = [...new Set([...previousOriginalDocumentIds, ...originalDocumentIds])];
+
   return {
     state: {
-      previousOriginalDocumentIds: originalDocumentIds,
+      previousOriginalDocumentIds:
+        mergedIds.length > MAX_DEDUP_IDS ? mergedIds.slice(-MAX_DEDUP_IDS) : mergedIds,
     },
   };
 }

--- a/x-pack/platform/plugins/shared/streams/server/routes/sig_events/queries/route.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/sig_events/queries/route.ts
@@ -15,7 +15,7 @@ import {
   validateEsqlQueryForStreamOrThrow,
 } from '../../../lib/sig_events/validate_esql_query';
 import { createServerRoute } from '../../create_server_route';
-import { assertEnterpriseLicense } from '../../utils/assert_enterprise_license';
+import { assertSignificantEventsAccess } from '../../utils/assert_significant_events_access';
 
 export interface ListQueriesResponse {
   queries: StreamQuery[];
@@ -53,9 +53,11 @@ const listQueriesRoute = createServerRoute({
       requiredPrivileges: [STREAMS_API_PRIVILEGES.read],
     },
   },
-  async handler({ params, request, getScopedClients }): Promise<ListQueriesResponse> {
-    const { getQueryClient, streamsClient, licensing } = await getScopedClients({ request });
-    await assertEnterpriseLicense(licensing);
+  async handler({ params, request, getScopedClients, server }): Promise<ListQueriesResponse> {
+    const { getQueryClient, streamsClient, licensing, uiSettingsClient } = await getScopedClients({
+      request,
+    });
+    await assertSignificantEventsAccess({ server, licensing, uiSettingsClient });
     await streamsClient.ensureStream(params.path.name);
 
     const {
@@ -94,13 +96,15 @@ const upsertQueryRoute = createServerRoute({
     }),
     body: upsertStreamQueryRequestSchema,
   }),
-  handler: async ({ params, request, getScopedClients }): Promise<UpsertQueryResponse> => {
-    const { streamsClient, getQueryClient, licensing } = await getScopedClients({ request });
+  handler: async ({ params, request, getScopedClients, server }): Promise<UpsertQueryResponse> => {
+    const { streamsClient, getQueryClient, licensing, uiSettingsClient } = await getScopedClients({
+      request,
+    });
     const {
       path: { name: streamName, queryId },
       body,
     } = params;
-    await assertEnterpriseLicense(licensing);
+    await assertSignificantEventsAccess({ server, licensing, uiSettingsClient });
 
     const definition = await streamsClient.getStream(streamName);
 
@@ -147,11 +151,17 @@ const deleteQueryRoute = createServerRoute({
       queryId: z.string(),
     }),
   }),
-  handler: async ({ params, request, getScopedClients, logger }): Promise<DeleteQueryResponse> => {
-    const { streamsClient, getQueryClient, licensing } = await getScopedClients({
+  handler: async ({
+    params,
+    request,
+    getScopedClients,
+    logger,
+    server,
+  }): Promise<DeleteQueryResponse> => {
+    const { streamsClient, getQueryClient, licensing, uiSettingsClient } = await getScopedClients({
       request,
     });
-    await assertEnterpriseLicense(licensing);
+    await assertSignificantEventsAccess({ server, licensing, uiSettingsClient });
 
     const {
       path: { queryId, name: streamName },
@@ -213,9 +223,12 @@ const bulkQueriesRoute = createServerRoute({
     request,
     getScopedClients,
     logger,
+    server,
   }): Promise<BulkUpdateAssetsResponse> => {
-    const { streamsClient, getQueryClient, licensing } = await getScopedClients({ request });
-    await assertEnterpriseLicense(licensing);
+    const { streamsClient, getQueryClient, licensing, uiSettingsClient } = await getScopedClients({
+      request,
+    });
+    await assertSignificantEventsAccess({ server, licensing, uiSettingsClient });
 
     const {
       path: { name: streamName },


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[SigEvents] Fix known issues (#266001)](https://github.com/elastic/kibana/pull/266001)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Francesco Fagnani","email":"fagnani.francesco@gmail.com"},"sourceCommit":{"committedDate":"2026-04-29T10:46:17Z","message":"[SigEvents] Fix known issues (#266001)\n\n## Summary\n\nFixes critical issues from\nhttps://github.com/elastic/kibana/issues/262947 that should be\nbackported to 9.4 (1, 4 and 8).\n\n**Rule executor dedup state reset:** A single quiet execution (no ES|QL\nmatches) wiped `previousOriginalDocumentIds` to `[]`, causing duplicate\nalerts when documents re-appeared in the next lookback window. Now\npreserves existing IDs on empty results and merges new IDs with previous\non non-empty results. Caps the accumulated set at `MAX_DEDUP_IDS` (5000)\nto prevent unbounded state growth.\n\n**Aggregation crash on partial data:**\n`readSignificantEventsFromAlertsIndices` accessed\n`response.aggregations.by_rule.buckets` without optional chaining, if\n`aggregations` existed but `by_rule` was missing (shard failure, partial\nagg), a `TypeError` crashed the request. Also skips orphan buckets where\nthe rule ID has no matching query link (stale/orphaned alert docs).\n\n**Public query routes missing access check:** All 4 public query CRUD\nroutes (`GET`, `PUT`, `DELETE`, `POST _bulk`) only called\n`assertEnterpriseLicense` but not `assertSignificantEventsAccess`,\nallowing query management even when significant events was disabled.\nAdded the missing check to all handlers, consistent with internal\nroutes.","sha":"3dc9b9a645f418a1c28e01f8a767de65ea3e5dd8","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport:version","v9.4.0","author:actionable-obs","Feature:SigEvents","Team:SigEvents","v9.5.0"],"title":"[SigEvents] Fix known issues","number":266001,"url":"https://github.com/elastic/kibana/pull/266001","mergeCommit":{"message":"[SigEvents] Fix known issues (#266001)\n\n## Summary\n\nFixes critical issues from\nhttps://github.com/elastic/kibana/issues/262947 that should be\nbackported to 9.4 (1, 4 and 8).\n\n**Rule executor dedup state reset:** A single quiet execution (no ES|QL\nmatches) wiped `previousOriginalDocumentIds` to `[]`, causing duplicate\nalerts when documents re-appeared in the next lookback window. Now\npreserves existing IDs on empty results and merges new IDs with previous\non non-empty results. Caps the accumulated set at `MAX_DEDUP_IDS` (5000)\nto prevent unbounded state growth.\n\n**Aggregation crash on partial data:**\n`readSignificantEventsFromAlertsIndices` accessed\n`response.aggregations.by_rule.buckets` without optional chaining, if\n`aggregations` existed but `by_rule` was missing (shard failure, partial\nagg), a `TypeError` crashed the request. Also skips orphan buckets where\nthe rule ID has no matching query link (stale/orphaned alert docs).\n\n**Public query routes missing access check:** All 4 public query CRUD\nroutes (`GET`, `PUT`, `DELETE`, `POST _bulk`) only called\n`assertEnterpriseLicense` but not `assertSignificantEventsAccess`,\nallowing query management even when significant events was disabled.\nAdded the missing check to all handlers, consistent with internal\nroutes.","sha":"3dc9b9a645f418a1c28e01f8a767de65ea3e5dd8"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/266001","number":266001,"mergeCommit":{"message":"[SigEvents] Fix known issues (#266001)\n\n## Summary\n\nFixes critical issues from\nhttps://github.com/elastic/kibana/issues/262947 that should be\nbackported to 9.4 (1, 4 and 8).\n\n**Rule executor dedup state reset:** A single quiet execution (no ES|QL\nmatches) wiped `previousOriginalDocumentIds` to `[]`, causing duplicate\nalerts when documents re-appeared in the next lookback window. Now\npreserves existing IDs on empty results and merges new IDs with previous\non non-empty results. Caps the accumulated set at `MAX_DEDUP_IDS` (5000)\nto prevent unbounded state growth.\n\n**Aggregation crash on partial data:**\n`readSignificantEventsFromAlertsIndices` accessed\n`response.aggregations.by_rule.buckets` without optional chaining, if\n`aggregations` existed but `by_rule` was missing (shard failure, partial\nagg), a `TypeError` crashed the request. Also skips orphan buckets where\nthe rule ID has no matching query link (stale/orphaned alert docs).\n\n**Public query routes missing access check:** All 4 public query CRUD\nroutes (`GET`, `PUT`, `DELETE`, `POST _bulk`) only called\n`assertEnterpriseLicense` but not `assertSignificantEventsAccess`,\nallowing query management even when significant events was disabled.\nAdded the missing check to all handlers, consistent with internal\nroutes.","sha":"3dc9b9a645f418a1c28e01f8a767de65ea3e5dd8"}}]}] BACKPORT-->