### PR TITLE
SIEM Readiness - hide tabs UI

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/siem_readiness/pages/visibility_section_tabs.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_readiness/pages/visibility_section_tabs.tsx
@@ -9,6 +9,7 @@ import React from 'react';
 import { EuiTabbedContent, type EuiTabbedContentTab } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import type { MainCategories } from '@kbn/siem-readiness';
+import { css } from '@emotion/react';
 import type { VisibilityTabId } from './visibility_section_boxes';
 import { CoverageTab } from './tabs/coverage_tab/coverage_tab';
 import { QualityTab } from './tabs/quality/quality_tab';
@@ -65,6 +66,14 @@ export const VisibilitySectionTabs: React.FC<VisibilitySectionTabsProps> = ({
       tabs={tabs}
       selectedTab={selectedTab}
       onTabClick={(tab) => onTabSelect(tab.id as VisibilityTabId)}
+      // hides the tabs element as we are using the EuiTabbedContent component just for its content switching logic, and not for the actual tab UI
+      // users can still click on the cards to switch between them
+      css={css`
+        .euiTabs[role='tablist'] {
+          height: 0;
+          overflow: hidden;
+        }
+      `}
     />
   );
 };


### PR DESCRIPTION
## Summary

Hiding tabs element as per design request [ticket](https://github.com/elastic/security-team/issues/16812), keeping only the cards for navigation

**before**
<img width="1339" height="894" alt="image" src="https://github.com/user-attachments/assets/024d2f8b-d385-4265-a9be-91c947923ffb" />


**after**
<img width="1340" height="922" alt="image" src="https://github.com/user-attachments/assets/d9555568-00f6-42de-a739-69e107725b7b" />

