### PR TITLE
[Fleet] Fix integrations disappearing after refresh with category/agentless filter

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/hooks/index.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/hooks/index.test.tsx
@@ -55,7 +55,7 @@ describe('useBrowseIntegrationHook', () => {
       isLoadingAppendCustomIntegrations: false,
       eprPackageLoadingError: undefined,
       eprCategoryLoadingError: undefined,
-      filteredCards: cards,
+      allCards: cards,
       availableSubCategories: [],
     });
   };
@@ -325,6 +325,84 @@ describe('useBrowseIntegrationHook', () => {
         { id: 'cloud', title: 'Cloud', count: 1 },
         { id: 'security', title: 'Security', count: 1 },
       ]);
+    });
+  });
+
+  describe('Stale-state regression (issue #265510)', () => {
+    it('shows correct results after category changes when initial URL has a category', () => {
+      // Simulate hard refresh with ?category=apm: useAvailablePackages returns allCards
+      // (all packages, no pre-filtering). useBrowseIntegrationHook applies category
+      // from live URL. When URL changes to security, security cards must be visible.
+      const cards = [
+        { id: 'apm-1', name: 'apm', title: 'APM', categories: ['apm'] },
+        { id: 'security-1', name: 'security', title: 'Security App', categories: ['security'] },
+      ];
+
+      mockUseAvailablePackages(cards as IntegrationCardItem[]);
+
+      // Simulate URL now showing security category (user changed from apm)
+      (useUrlCategories as jest.Mock).mockReturnValue({
+        category: 'security',
+        subCategory: undefined,
+      });
+      (useUrlFilters as jest.Mock).mockReturnValue({
+        q: undefined,
+        sort: undefined,
+        status: undefined,
+      });
+
+      const { result } = renderHook(() =>
+        useBrowseIntegrationHook({ prereleaseIntegrationsEnabled: false })
+      );
+
+      // Must show security cards, not 0 results
+      expect(result.current.filteredCards).toHaveLength(1);
+      expect(result.current.filteredCards[0].categories).toContain('security');
+    });
+
+    it('shows non-agentless packages after agentless filter is removed', () => {
+      // Simulate hard refresh with ?setupMethod=agentless: useAvailablePackages returns
+      // allCards (all packages). When user removes the agentless filter, non-agentless
+      // packages must become visible.
+      const cards = [
+        {
+          id: 'regular-1',
+          name: 'nginx',
+          title: 'Nginx',
+          categories: ['web'],
+          supportsAgentless: false,
+          type: 'integration',
+        },
+        {
+          id: 'agentless-1',
+          name: 'aws',
+          title: 'AWS',
+          categories: ['cloud'],
+          supportsAgentless: true,
+          type: 'integration',
+        },
+      ];
+
+      mockUseAvailablePackages(cards as IntegrationCardItem[]);
+
+      // URL no longer has setupMethod filter (user removed it)
+      (useUrlCategories as jest.Mock).mockReturnValue({
+        category: '',
+        subCategory: undefined,
+      });
+      (useUrlFilters as jest.Mock).mockReturnValue({
+        q: undefined,
+        sort: undefined,
+        status: undefined,
+        setupMethod: undefined,
+      });
+
+      const { result } = renderHook(() =>
+        useBrowseIntegrationHook({ prereleaseIntegrationsEnabled: false })
+      );
+
+      // Both cards must be visible when agentless filter is removed
+      expect(result.current.filteredCards).toHaveLength(2);
     });
   });
 

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/hooks/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/hooks/index.tsx
@@ -54,8 +54,6 @@ export function useBrowseIntegrationHook({
       // TODO implement recent-old and old-recent sorting when we have a date field
       return originalFilteredCards;
     }
-
-    return sortedCards;
   }, [originalFilteredCards, urlFilters.sort]);
 
   // Cards filtered by non-category filters (search, status, setup method, signal).

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/hooks/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/hooks/index.tsx
@@ -31,7 +31,7 @@ export function useBrowseIntegrationHook({
     isLoadingAppendCustomIntegrations,
     eprPackageLoadingError,
     eprCategoryLoadingError,
-    filteredCards: originalFilteredCards,
+    allCards: originalFilteredCards,
   } = useAvailablePackages({ prereleaseIntegrationsEnabled });
 
   const urlFilters = useUrlFilters();

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/home/hooks/use_available_packages.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/home/hooks/use_available_packages.test.tsx
@@ -96,6 +96,7 @@ jest.mock('..', () => ({
     description: item.description || '',
     categories: item.categories || [],
     url: `/detail/${item.name}`,
+    supportsAgentless: item.supportsAgentless,
   }),
 }));
 
@@ -612,6 +613,105 @@ describe('useAvailablePackages', () => {
       );
 
       expect(result.current.eprCategoryLoadingError).toBe(error);
+    });
+  });
+
+  describe('allCards', () => {
+    it('should return allCards regardless of selectedCategory', () => {
+      mockUseBuildIntegrationsUrl.mockReturnValue({
+        initialSelectedCategory: 'web',
+        initialSubcategory: undefined,
+        initialOnlyAgentless: false,
+        setUrlandPushHistory: mockSetUrlandPushHistory,
+        setUrlandReplaceHistory: mockSetUrlandReplaceHistory,
+        getHref: mockGetHref,
+        getAbsolutePath: mockGetAbsolutePath,
+        searchParam: '',
+        addBasePath: mockAddBasePath,
+      });
+      mockUseGetPackagesQuery.mockReturnValue({
+        data: {
+          items: [
+            {
+              ...mockBasicPackage,
+              id: 'web-pkg',
+              name: 'web-pkg',
+              title: 'Web Pkg',
+              categories: ['web'],
+            },
+            {
+              ...mockBasicPackage,
+              id: 'sec-pkg',
+              name: 'sec-pkg',
+              title: 'Sec Pkg',
+              categories: ['security'],
+            },
+          ],
+        },
+        isLoading: false,
+        error: null,
+      });
+
+      const { result } = renderHook(() =>
+        useAvailablePackages({ prereleaseIntegrationsEnabled: false })
+      );
+
+      // filteredCards should be restricted to web category
+      expect(result.current.filteredCards).toHaveLength(1);
+      expect(result.current.filteredCards[0].categories).toContain('web');
+
+      // allCards should contain both packages regardless of category filter
+      expect(result.current.allCards).toHaveLength(2);
+    });
+
+    it('should return allCards regardless of onlyAgentlessFilter', () => {
+      mockUseAgentless.mockReturnValue({ isAgentlessEnabled: true });
+      mockUseBuildIntegrationsUrl.mockReturnValue({
+        initialSelectedCategory: '',
+        initialSubcategory: undefined,
+        initialOnlyAgentless: true,
+        setUrlandPushHistory: mockSetUrlandPushHistory,
+        setUrlandReplaceHistory: mockSetUrlandReplaceHistory,
+        getHref: mockGetHref,
+        getAbsolutePath: mockGetAbsolutePath,
+        searchParam: '',
+        addBasePath: mockAddBasePath,
+      });
+
+      const nonAgentlessPkg = {
+        ...mockBasicPackage,
+        id: 'regular',
+        name: 'regular',
+        title: 'Regular',
+      };
+      const agentlessPkg = {
+        ...mockBasicPackage,
+        id: 'agentless-only',
+        name: 'agentless-only',
+        title: 'Agentless Only',
+        supportsAgentless: true,
+      };
+
+      mockUseMergeEprPackagesWithReplacements.mockReturnValue([nonAgentlessPkg, agentlessPkg]);
+
+      // mapToCard mock preserves supportsAgentless from the item
+      jest.mock('..', () => ({
+        mapToCard: ({ item }: any) => ({
+          id: item.id,
+          title: item.title || item.name,
+          description: item.description || '',
+          categories: item.categories || [],
+          url: `/detail/${item.name}`,
+          supportsAgentless: item.supportsAgentless,
+        }),
+      }));
+
+      const { result } = renderHook(() =>
+        useAvailablePackages({ prereleaseIntegrationsEnabled: false })
+      );
+
+      // allCards should contain all packages regardless of agentless filter
+      expect(result.current.allCards).toHaveLength(2);
     });
   });
 

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/home/hooks/use_available_packages.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/home/hooks/use_available_packages.tsx
@@ -210,39 +210,39 @@ export const useAvailablePackages = ({
       preference === 'agent' ? [] : replacementCustomIntegrations || []
     );
 
-  const cards: IntegrationCardItem[] = useMemo(() => {
+  // All cards before any filter (no agentless filter, no category filter).
+  // Used by useBrowseIntegrationHook which applies both filters from the live URL.
+  const allCards: IntegrationCardItem[] = useMemo(() => {
     const eprAndCustomPackages = [...mergedEprPackages, ...(appendCustomIntegrations || [])];
-
-    return (
-      eprAndCustomPackages
-        // If only showing agentless integrations, filter out non-agentless ones
-        .filter((item) => {
-          if (isAgentlessEnabled && onlyAgentlessFilter) {
-            return 'supportsAgentless' in item && item.supportsAgentless === true;
-          }
-          return true;
+    return eprAndCustomPackages
+      .map((item) =>
+        mapToCard({
+          getAbsolutePath,
+          getHref,
+          item,
+          addBasePath,
+          packageVerificationKeyId,
         })
-        .map((item) => {
-          return mapToCard({
-            getAbsolutePath,
-            getHref,
-            item,
-            addBasePath,
-            packageVerificationKeyId,
-          });
-        })
-        .sort((a, b) => a.title.localeCompare(b.title))
-    );
+      )
+      .sort((a, b) => a.title.localeCompare(b.title));
   }, [
     addBasePath,
     appendCustomIntegrations,
     getAbsolutePath,
     getHref,
     mergedEprPackages,
-    onlyAgentlessFilter,
-    isAgentlessEnabled,
     packageVerificationKeyId,
   ]);
+
+  // Cards with the agentless filter applied (used by the old home page and
+  // its category sidebar counts). Derived from allCards so the sort/map work
+  // is not duplicated.
+  const cards: IntegrationCardItem[] = useMemo(() => {
+    if (isAgentlessEnabled && onlyAgentlessFilter) {
+      return allCards.filter((item) => item.supportsAgentless === true);
+    }
+    return allCards;
+  }, [allCards, isAgentlessEnabled, onlyAgentlessFilter]);
 
   // Packages to show
   // Filters out based on selected category and subcategory (if any)
@@ -318,5 +318,6 @@ export const useAvailablePackages = ({
     eprPackageLoadingError,
     eprCategoryLoadingError,
     filteredCards,
+    allCards,
   };
 };


### PR DESCRIPTION
## Summary

Fixes two related stale-state bugs on the Browse Integrations page (Closes #265510).

`useAvailablePackages` was snapshotting `selectedCategory` and `onlyAgentlessFilter` from the URL into `useState` at mount and never re-syncing. The Browse Integrations hook (`useBrowseIntegrationHook`) received a pre-filtered card list as input and applied its own live-URL-driven filters on top — producing 0 results when the two states diverged after navigation.

**Bug A — Category filter**
1. Refresh page with `?category=apm` → `useAvailablePackages` pre-filters to APM cards only
2. User navigates to Security → `useBrowseIntegrationHook` filters the APM-only deck for security → 0 results

**Bug B — Agentless filter (same root cause)**
1. Refresh page with `?setupMethod=agentless` → `useAvailablePackages` pre-filters to agentless cards only
2. User removes the filter → `useBrowseIntegrationHook` skips the filter but still only sees agentless cards → non-agentless packages invisible

**Fix:** Expose `allCards` (merged packages before either filter) from `useAvailablePackages`. `useBrowseIntegrationHook` already applied both filters correctly from live URL state — it just needed an unfiltered input deck.

No regression to the old home page or add-integration flyout, which both continue to use `filteredCards`.

## Changes

- `use_available_packages.tsx` — split `cards` memo into `allCards` (no filters) + `cards` (agentless filter applied for old home page); expose `allCards` in return value
- `browse_integrations/hooks/index.tsx` — destructure `allCards` instead of `filteredCards`

## Test plan

- [ ] Refresh page integrations page with `?category=apm`, then click a different category — results should appear
- [ ] Refresh page with `?setupMethod=agentless`, then remove the filter — non-agentless integrations should reappear
- [ ] All existing integration filter/sort/search behaviour unchanged
- Unit tests added for both regression scenarios in `browse_integrations/hooks/index.test.tsx`
- Unit tests added for `allCards` return value in `use_available_packages.test.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://github.com/user-attachments/assets/5f86d5c4-e890-4336-aa15-d8339302992a




<!--ONMERGE {"backportTargets":["9.3","9.4"]} ONMERGE-->