### PR TITLE
[Synthetics] Fix monitor detail flyout location selector

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/monitor_detail_flyout.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/monitor_detail_flyout.tsx
@@ -6,6 +6,7 @@
  */
 
 import {
+  EuiBadge,
   EuiButton,
   EuiButtonEmpty,
   EuiFlexGroup,
@@ -14,7 +15,6 @@ import {
   EuiFlyoutBody,
   EuiFlyoutFooter,
   EuiFlyoutHeader,
-  EuiHealth,
   EuiLoadingSpinner,
   EuiPageSection,
   EuiPanel,
@@ -202,6 +202,7 @@ function LocationScopeBadges({
   currentLocation: string;
   setCurrentLocation: (location: string, locationId: string) => void;
 }) {
+  const { euiTheme } = useEuiTheme();
   return (
     <EuiPageSection bottomBorder="extended" paddingSize="s">
       <EuiTitle size="xxxs">
@@ -211,21 +212,51 @@ function LocationScopeBadges({
       <EuiFlexGroup wrap responsive={false} gutterSize="xs">
         {locations.map((loc) => {
           const isSelected = loc.label === currentLocation;
+          const onClick = isSelected ? undefined : () => setCurrentLocation(loc.label, loc.id);
+          // The shared health color uses `colors.disabled` for pending, which is
+          // nearly invisible on the filled primary background of the selected
+          // badge. Lift it to a near-white shade so the dot stays legible while
+          // keeping the unselected pending color subtle as designed.
+          const dotColor =
+            isSelected && loc.status === 'pending' ? euiTheme.colors.emptyShade : loc.color;
           return (
             <EuiFlexItem grow={false} key={loc.id}>
-              <EuiButton
-                size="s"
-                color={isSelected ? 'primary' : 'text'}
-                fill={isSelected}
-                onClick={() => {
-                  if (!isSelected) setCurrentLocation(loc.label, loc.id);
-                }}
+              <EuiBadge
+                color={isSelected ? 'primary' : 'hollow'}
+                {...(onClick
+                  ? {
+                      onClick,
+                      onClickAriaLabel: i18n.translate(
+                        'xpack.synthetics.flyout.selectLocationAriaLabel',
+                        {
+                          defaultMessage: 'Select location {label}',
+                          values: { label: loc.label },
+                        }
+                      ),
+                    }
+                  : {})}
                 data-test-subj={`syntheticsLocationButton-${loc.id}`}
               >
-                <EuiHealth color={loc.color}>
+                <span
+                  css={{
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    gap: euiTheme.size.xs,
+                  }}
+                >
+                  <span
+                    aria-hidden="true"
+                    css={{
+                      width: 8,
+                      height: 8,
+                      borderRadius: '50%',
+                      backgroundColor: dotColor,
+                      flexShrink: 0,
+                    }}
+                  />
                   {loc.label} · {loc.status}
-                </EuiHealth>
-              </EuiButton>
+                </span>
+              </EuiBadge>
             </EuiFlexItem>
           );
         })}


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/266387

## Summary

The per-location selector in the overview detail flyout rendered each location as a fill="primary" EuiButton, which produced an oversized, CTA-like blue button — especially noticeable when there is only one location and it is selected by default, or when the location label is long (e.g. private locations with a UUID suffix). Nesting EuiHealth inside the filled button also caused a status/color clash.

- Replace the EuiButton with EuiBadge (matches the function name LocationScopeBadges and is visually compact), primary when selected and hollow otherwise.
- Render the status dot as a manually-colored span instead of EuiHealth/iconType so its color isn't forced to inherit the badge text color (EuiBadge sets color="inherit" on its icon), preserving the green/red/gray status semantics from useMonitorHealthColor.
- Lift the pending dot to colors.emptyShade only when the badge is selected, since the shared `colors.disabled` is invisible on the primary fill; unselected stays subtle as designed.
- Drop click handler/aria label on the active badge (was a no-op) and keep data-test-subj=syntheticsLocationButton-<id> for existing tests.

## Screenshots


<img width="300" height="300" alt="Screenshot 2026-04-29 at 15 56 37" src="https://github.com/user-attachments/assets/a95c2b1b-34e5-4729-8eb5-c085ef7d2410" />

<img width="300" height="300" alt="Screenshot 2026-04-29 at 15 56 58" src="https://github.com/user-attachments/assets/8b779cda-897d-4e01-9dbd-460a23e9fc8b" />

<img width="300" height="300" alt="Screenshot 2026-04-29 at 15 57 21" src="https://github.com/user-attachments/assets/e578f2bf-3587-4a52-9a5f-7e7f8a6ebd5c" />

