### PR TITLE
[Cases][Templates] Extend cases search by template field label

### DIFF
--- a/x-pack/platform/plugins/shared/cases/public/components/all_cases/translations.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/all_cases/translations.ts
@@ -102,7 +102,7 @@ export const INCIDENT_MANAGEMENT_SYSTEM = i18n.translate('xpack.cases.caseTable.
 
 export const SEARCH_PLACEHOLDER = i18n.translate('xpack.cases.caseTable.searchPlaceholder', {
   defaultMessage:
-    'Search cases or filter by field, e.g. "Effort estimate":3, "Start Date":01/01/2024',
+    'Free text, field label, or field:value. Use "" for multi-word, e.g. network Priority:high "Start date":01/01/2025',
 });
 
 export const CLOSED = i18n.translate('xpack.cases.caseTable.closed', {

--- a/x-pack/platform/plugins/shared/cases/server/client/cases/search.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/cases/search.ts
@@ -23,7 +23,11 @@ import type { CasesClient, CasesClientArgs } from '..';
 import { LICENSING_CASE_ASSIGNMENT_FEATURE } from '../../common/constants';
 import type { CasesSearchParams } from '../types';
 import { validateSearchCasesCustomFields } from './validators';
-import { resolveExtendedFieldFilters } from '../../services/cases/extended_field_search_utils';
+import {
+  resolveExtendedFieldFilters,
+  tokenizeSearchForLabels,
+  resolveFieldLabelSearch,
+} from '../../services/cases/extended_field_search_utils';
 import { enrichCasesWithFieldLabels } from './utils';
 
 /**
@@ -139,18 +143,22 @@ export const search = async (
         })
       : [];
 
+    const templateMetadata = templateSOs.map((so) => ({
+      templateId: so.attributes.templateId,
+      templateVersion: so.attributes.templateVersion,
+      fieldNames: so.attributes.fieldNames,
+    }));
+
     const rawFilters = paramArgs.extendedFieldFilters;
     const resolvedExtendedFieldFilters =
       rawFilters && rawFilters.length > 0
-        ? resolveExtendedFieldFilters(
-            rawFilters,
-            templateSOs.map((so) => ({
-              templateId: so.attributes.templateId,
-              templateVersion: so.attributes.templateVersion,
-              fieldNames: so.attributes.fieldNames,
-            }))
-          )
+        ? resolveExtendedFieldFilters(rawFilters, templateMetadata)
         : undefined;
+
+    const fieldLabelResults = paramArgs.search
+      ? resolveFieldLabelSearch(tokenizeSearchForLabels(paramArgs.search), templateMetadata)
+      : [];
+    const resolvedFieldLabelFilters = fieldLabelResults.length > 0 ? fieldLabelResults : undefined;
 
     const [cases, statusStats] = await Promise.all([
       caseService.searchCasesGroupedByID({
@@ -161,6 +169,7 @@ export const search = async (
         },
         namespaces,
         extendedFieldFilters: resolvedExtendedFieldFilters,
+        fieldLabelFilters: resolvedFieldLabelFilters,
       }),
       caseService.getCaseStatusStats({
         searchOptions: statusStatsOptions,

--- a/x-pack/platform/plugins/shared/cases/server/services/cases/extended_field_search_utils.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/cases/extended_field_search_utils.test.ts
@@ -1464,8 +1464,14 @@ describe('resolveFieldLabelSearch', () => {
     ]);
   });
 
-  it('bare word substring-matches partial labels', () => {
+  it('exact token does not substring-match partial labels', () => {
     const result = resolveFieldLabelSearch([{ text: 'start', exact: true }], templates);
+
+    expect(result).toEqual([]);
+  });
+
+  it('substring token matches partial labels', () => {
+    const result = resolveFieldLabelSearch([{ text: 'start', exact: false }], templates);
 
     expect(result).toHaveLength(2);
     expect(result).toEqual(

--- a/x-pack/platform/plugins/shared/cases/server/services/cases/extended_field_search_utils.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/cases/extended_field_search_utils.test.ts
@@ -5,11 +5,16 @@
  * 2.0.
  */
 
+import type { estypes } from '@elastic/elasticsearch';
 import {
   resolveExtendedFieldFilters,
   buildExtendedFieldRuntimeMappings,
   buildExtendedFieldFilterClauses,
   parseDateFilterToRange,
+  tokenizeSearchForLabels,
+  resolveFieldLabelSearch,
+  buildFieldLabelRuntimeMappings,
+  buildFieldLabelExistsClauses,
 } from './extended_field_search_utils';
 
 describe('resolveExtendedFieldFilters', () => {
@@ -1361,5 +1366,281 @@ describe('buildExtendedFieldFilterClauses', () => {
         },
       },
     ]);
+  });
+});
+
+describe('tokenizeSearchForLabels', () => {
+  it('splits bare words into exact tokens', () => {
+    expect(tokenizeSearchForLabels('priority region')).toEqual([
+      { text: 'priority', exact: true },
+      { text: 'region', exact: true },
+    ]);
+  });
+
+  it('extracts quoted phrases as substring tokens', () => {
+    expect(tokenizeSearchForLabels('"Start date"')).toEqual([{ text: 'start date', exact: false }]);
+  });
+
+  it('handles mixed quoted and bare tokens (quoted extracted first)', () => {
+    expect(tokenizeSearchForLabels('priority "Start date" region')).toEqual([
+      { text: 'start date', exact: false },
+      { text: 'priority', exact: true },
+      { text: 'region', exact: true },
+    ]);
+  });
+
+  it('lowercases all tokens', () => {
+    expect(tokenizeSearchForLabels('Priority "Effort Level"')).toEqual([
+      { text: 'effort level', exact: false },
+      { text: 'priority', exact: true },
+    ]);
+  });
+
+  it('returns empty array for empty string', () => {
+    expect(tokenizeSearchForLabels('')).toEqual([]);
+  });
+
+  it('returns empty array for whitespace-only string', () => {
+    expect(tokenizeSearchForLabels('   ')).toEqual([]);
+  });
+
+  it('ignores empty quoted strings', () => {
+    expect(tokenizeSearchForLabels('"" priority')).toEqual([{ text: 'priority', exact: true }]);
+  });
+
+  it('trims whitespace inside quoted strings', () => {
+    expect(tokenizeSearchForLabels('"  Start date  "')).toEqual([
+      { text: 'start date', exact: false },
+    ]);
+  });
+});
+
+describe('resolveFieldLabelSearch', () => {
+  const templates = [
+    {
+      templateId: 'tmpl-a',
+      templateVersion: 1,
+      fieldNames: [
+        { name: 'priority', label: 'Priority', type: 'keyword', control: 'SELECT_BASIC' },
+        { name: 'region', label: 'Region', type: 'keyword', control: 'SELECT_BASIC' },
+        {
+          name: 'start_date',
+          label: 'Start date operation',
+          type: 'date',
+          control: 'DATE_PICKER',
+        },
+        {
+          name: 'end_date',
+          label: 'End date',
+          type: 'date',
+          control: 'DATE_PICKER',
+        },
+      ],
+    },
+    {
+      templateId: 'tmpl-b',
+      templateVersion: 1,
+      fieldNames: [
+        {
+          name: 'start_security',
+          label: 'Start date security',
+          type: 'date',
+          control: 'DATE_PICKER',
+        },
+      ],
+    },
+  ];
+
+  it('resolves bare word to matching full label', () => {
+    const result = resolveFieldLabelSearch([{ text: 'priority', exact: true }], templates);
+
+    expect(result).toEqual([
+      {
+        storageKey: 'priority_as_keyword',
+        esType: 'keyword',
+        control: 'SELECT_BASIC',
+        templateVersions: [{ id: 'tmpl-a', version: 1 }],
+      },
+    ]);
+  });
+
+  it('bare word substring-matches partial labels', () => {
+    const result = resolveFieldLabelSearch([{ text: 'start', exact: true }], templates);
+
+    expect(result).toHaveLength(2);
+    expect(result).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ storageKey: 'start_date_as_date' }),
+        expect.objectContaining({ storageKey: 'start_security_as_date' }),
+      ])
+    );
+  });
+
+  it('matches quoted substring token against labels containing the text', () => {
+    const result = resolveFieldLabelSearch([{ text: 'start date', exact: false }], templates);
+
+    expect(result).toHaveLength(2);
+    expect(result).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ storageKey: 'start_date_as_date' }),
+        expect.objectContaining({ storageKey: 'start_security_as_date' }),
+      ])
+    );
+  });
+
+  it('does not match quoted substring that does not appear in any label', () => {
+    const result = resolveFieldLabelSearch(
+      [{ text: 'nonexistent field', exact: false }],
+      templates
+    );
+
+    expect(result).toEqual([]);
+  });
+
+  it('quoted "start date" matches "Start date operation" and "Start date security" but not "End date"', () => {
+    const result = resolveFieldLabelSearch([{ text: 'start date', exact: false }], templates);
+
+    const storageKeys = result.map((r) => r.storageKey);
+    expect(storageKeys).toContain('start_date_as_date');
+    expect(storageKeys).toContain('start_security_as_date');
+    expect(storageKeys).not.toContain('end_date_as_date');
+  });
+
+  it('deduplicates storage keys across multiple tokens', () => {
+    const result = resolveFieldLabelSearch(
+      [
+        { text: 'priority', exact: true },
+        { text: 'priority', exact: true },
+      ],
+      templates
+    );
+
+    expect(result).toHaveLength(1);
+  });
+
+  it('returns empty for empty tokens', () => {
+    expect(resolveFieldLabelSearch([], templates)).toEqual([]);
+  });
+
+  it('returns empty for empty templates', () => {
+    expect(resolveFieldLabelSearch([{ text: 'priority', exact: true }], [])).toEqual([]);
+  });
+
+  it('is case-insensitive for label matching', () => {
+    const result = resolveFieldLabelSearch([{ text: 'PRIORITY', exact: true }], templates);
+
+    expect(result).toEqual([expect.objectContaining({ storageKey: 'priority_as_keyword' })]);
+  });
+});
+
+describe('buildFieldLabelRuntimeMappings', () => {
+  it('builds runtime mappings for resolved label filters', () => {
+    const mappings = buildFieldLabelRuntimeMappings([
+      {
+        storageKey: 'priority_as_keyword',
+        esType: 'keyword',
+        control: 'SELECT_BASIC',
+        templateVersions: [{ id: 'tmpl-a', version: 1 }],
+      },
+    ]);
+
+    expect(mappings).toHaveProperty('ef_priority_as_keyword');
+    expect(mappings.ef_priority_as_keyword.type).toBe('keyword');
+  });
+
+  it('builds DATE_PICKER runtime field as keyword type', () => {
+    const mappings = buildFieldLabelRuntimeMappings([
+      {
+        storageKey: 'start_date_as_date',
+        esType: 'date',
+        control: 'DATE_PICKER',
+        templateVersions: [{ id: 'tmpl-a', version: 1 }],
+      },
+    ]);
+
+    expect(mappings.ef_start_date_as_date.type).toBe('keyword');
+  });
+});
+
+describe('buildFieldLabelExistsClauses', () => {
+  it('builds exists + template-scoped clause for a single label filter', () => {
+    const clauses = buildFieldLabelExistsClauses([
+      {
+        storageKey: 'priority_as_keyword',
+        esType: 'keyword',
+        control: 'SELECT_BASIC',
+        templateVersions: [{ id: 'tmpl-a', version: 1 }],
+      },
+    ]);
+
+    expect(clauses).toEqual([
+      {
+        bool: {
+          filter: [
+            { exists: { field: 'ef_priority_as_keyword' } },
+            {
+              bool: {
+                should: [
+                  {
+                    bool: {
+                      must: [
+                        { term: { 'cases.template.id': 'tmpl-a' } },
+                        { term: { 'cases.template.version': 1 } },
+                      ],
+                    },
+                  },
+                ],
+                minimum_should_match: 1,
+              },
+            },
+          ],
+        },
+      },
+    ]);
+  });
+
+  it('builds multiple clauses for multiple label filters', () => {
+    const clauses = buildFieldLabelExistsClauses([
+      {
+        storageKey: 'priority_as_keyword',
+        esType: 'keyword',
+        control: 'SELECT_BASIC',
+        templateVersions: [{ id: 'tmpl-a', version: 1 }],
+      },
+      {
+        storageKey: 'region_as_keyword',
+        esType: 'keyword',
+        control: 'SELECT_BASIC',
+        templateVersions: [{ id: 'tmpl-a', version: 1 }],
+      },
+    ]);
+
+    expect(clauses).toHaveLength(2);
+    expect(clauses[0]).toHaveProperty('bool.filter.0.exists.field', 'ef_priority_as_keyword');
+    expect(clauses[1]).toHaveProperty('bool.filter.0.exists.field', 'ef_region_as_keyword');
+  });
+
+  it('includes multiple template versions in OR logic', () => {
+    const clauses = buildFieldLabelExistsClauses([
+      {
+        storageKey: 'priority_as_keyword',
+        esType: 'keyword',
+        control: 'SELECT_BASIC',
+        templateVersions: [
+          { id: 'tmpl-a', version: 1 },
+          { id: 'tmpl-a', version: 2 },
+        ],
+      },
+    ]);
+
+    const filterArray = clauses[0]?.bool?.filter as estypes.QueryDslQueryContainer[];
+    const shouldClauses = filterArray[1]?.bool?.should as
+      | estypes.QueryDslQueryContainer[]
+      | undefined;
+    expect(shouldClauses).toHaveLength(2);
+  });
+
+  it('returns empty array for empty input', () => {
+    expect(buildFieldLabelExistsClauses([])).toEqual([]);
   });
 });

--- a/x-pack/platform/plugins/shared/cases/server/services/cases/extended_field_search_utils.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/cases/extended_field_search_utils.ts
@@ -22,6 +22,18 @@ export interface ResolvedExtendedFieldFilter {
   templateVersions: Array<{ id: string; version: number }>;
 }
 
+export interface LabelSearchToken {
+  text: string;
+  exact: boolean;
+}
+
+export interface ResolvedFieldLabelFilter {
+  storageKey: string;
+  esType: string;
+  control: string;
+  templateVersions: Array<{ id: string; version: number }>;
+}
+
 type RuntimeType = 'keyword' | 'long' | 'double' | 'date';
 
 const ES_TYPE_TO_RUNTIME_TYPE: Record<string, RuntimeType> = {
@@ -109,48 +121,7 @@ export const resolveExtendedFieldFilters = (
   extendedFieldFilters: ExtendedFieldFilter[],
   templates: Array<Pick<Template, 'fieldNames' | 'templateId' | 'templateVersion'>>
 ): ResolvedExtendedFieldFilter[][] => {
-  // labelKey → storageKey → { meta, templateVersions[] }
-  const labelToMetas = new Map<
-    string,
-    Map<
-      string,
-      {
-        storageKey: string;
-        esType: string;
-        control: string;
-        templateVersions: Array<{ id: string; version: number }>;
-      }
-    >
-  >();
-
-  for (const template of templates) {
-    for (const field of template.fieldNames ?? []) {
-      const labelKey = field.label.toLowerCase();
-      const storageKey = `${field.name}_as_${field.type}`;
-
-      let byStorageKey = labelToMetas.get(labelKey);
-      if (byStorageKey == null) {
-        byStorageKey = new Map();
-        labelToMetas.set(labelKey, byStorageKey);
-      }
-
-      let entry = byStorageKey.get(storageKey);
-      if (entry == null) {
-        entry = {
-          storageKey,
-          esType: field.type,
-          control: field.control,
-          templateVersions: [],
-        };
-        byStorageKey.set(storageKey, entry);
-      }
-
-      entry.templateVersions.push({
-        id: template.templateId,
-        version: template.templateVersion,
-      });
-    }
-  }
+  const labelToMetas = buildLabelToMetasIndex(templates);
 
   return extendedFieldFilters.flatMap(({ label, value }) => {
     const metas = labelToMetas.get(label.toLowerCase());
@@ -287,4 +258,180 @@ export const buildExtendedFieldFilterClauses = (
     if (clauses.length === 1) return clauses;
 
     return [{ bool: { should: clauses, minimum_should_match: 1 } }];
+  });
+
+/**
+ * Parses the search string into tokens for field-label matching.
+ * - Quoted phrases ("Start date") become substring-match tokens (exact: false)
+ * - Bare words (priority) become exact full-label match tokens (exact: true)
+ * Tokens already consumed by label:value syntax should not be present in the input.
+ */
+export const tokenizeSearchForLabels = (search: string): LabelSearchToken[] => {
+  const tokens: LabelSearchToken[] = [];
+  const withoutQuoted = search.replace(/"([^"]*)"/g, (_match, quoted: string) => {
+    const trimmed = quoted.trim();
+    if (trimmed.length > 0) {
+      tokens.push({ text: trimmed.toLowerCase(), exact: false });
+    }
+    return '';
+  });
+
+  for (const word of withoutQuoted.split(/\s+/)) {
+    const trimmed = word.trim();
+    if (trimmed.length > 0) {
+      tokens.push({ text: trimmed.toLowerCase(), exact: true });
+    }
+  }
+
+  return tokens;
+};
+
+type LabelToMetasMap = Map<
+  string,
+  Map<
+    string,
+    {
+      storageKey: string;
+      esType: string;
+      control: string;
+      templateVersions: Array<{ id: string; version: number }>;
+    }
+  >
+>;
+
+const buildLabelToMetasIndex = (
+  templates: Array<Pick<Template, 'fieldNames' | 'templateId' | 'templateVersion'>>
+): LabelToMetasMap => {
+  const labelToMetas: LabelToMetasMap = new Map();
+
+  for (const template of templates) {
+    for (const field of template.fieldNames ?? []) {
+      const labelKey = field.label.toLowerCase();
+      const storageKey = `${field.name}_as_${field.type}`;
+
+      let byStorageKey = labelToMetas.get(labelKey);
+      if (byStorageKey == null) {
+        byStorageKey = new Map();
+        labelToMetas.set(labelKey, byStorageKey);
+      }
+
+      let entry = byStorageKey.get(storageKey);
+      if (entry == null) {
+        entry = {
+          storageKey,
+          esType: field.type,
+          control: field.control,
+          templateVersions: [],
+        };
+        byStorageKey.set(storageKey, entry);
+      }
+
+      entry.templateVersions.push({
+        id: template.templateId,
+        version: template.templateVersion,
+      });
+    }
+  }
+
+  return labelToMetas;
+};
+
+/**
+ * Resolves search tokens against template field labels.
+ * - exact tokens: full label must equal the token text
+ * - substring tokens (quoted): label must contain the token text
+ */
+export const resolveFieldLabelSearch = (
+  tokens: LabelSearchToken[],
+  templates: Array<Pick<Template, 'fieldNames' | 'templateId' | 'templateVersion'>>
+): ResolvedFieldLabelFilter[] => {
+  if (tokens.length === 0 || templates.length === 0) return [];
+
+  const labelToMetas = buildLabelToMetasIndex(templates);
+  const seen = new Set<string>();
+  const results: ResolvedFieldLabelFilter[] = [];
+
+  for (const token of tokens) {
+    const matchingMetas: Array<{
+      storageKey: string;
+      esType: string;
+      control: string;
+      templateVersions: Array<{ id: string; version: number }>;
+    }> = [];
+
+    const normalizedText = token.text.toLowerCase();
+
+    for (const [labelKey, metas] of labelToMetas) {
+      if (labelKey.includes(normalizedText)) {
+        matchingMetas.push(...metas.values());
+      }
+    }
+
+    for (const meta of matchingMetas) {
+      if (!seen.has(meta.storageKey)) {
+        seen.add(meta.storageKey);
+        results.push({
+          storageKey: meta.storageKey,
+          esType: meta.esType,
+          control: meta.control,
+          templateVersions: meta.templateVersions,
+        });
+      }
+    }
+  }
+
+  return results;
+};
+
+/** Builds runtime field mappings for field-label existence queries. */
+export const buildFieldLabelRuntimeMappings = (
+  resolvedLabels: ResolvedFieldLabelFilter[]
+): Record<string, estypes.MappingRuntimeField> => {
+  const runtimeMappings: Record<string, estypes.MappingRuntimeField> = {};
+
+  for (const { storageKey, esType, control } of resolvedLabels) {
+    const runtimeType = control === DATE_PICKER ? 'keyword' : mapToRuntimeType(esType);
+    runtimeMappings[`ef_${storageKey}`] = {
+      type: runtimeType,
+      script: {
+        source: buildPainlessScript(storageKey, runtimeType, control),
+      },
+    };
+  }
+
+  return runtimeMappings;
+};
+
+/**
+ * Builds ES query clauses that check for the existence of extended fields
+ * (field has any value), scoped to the correct template versions.
+ * All clauses are OR'd — any matching label is sufficient.
+ */
+export const buildFieldLabelExistsClauses = (
+  resolvedLabels: ResolvedFieldLabelFilter[]
+): estypes.QueryDslQueryContainer[] =>
+  resolvedLabels.flatMap((resolved): estypes.QueryDslQueryContainer[] => {
+    const fieldName = `ef_${resolved.storageKey}`;
+
+    const existsClause: estypes.QueryDslQueryContainer = {
+      exists: { field: fieldName },
+    };
+
+    const templateVersionFilters = resolved.templateVersions.map(({ id, version }) => ({
+      bool: {
+        must: [
+          { term: { 'cases.template.id': id } },
+          { term: { 'cases.template.version': version } },
+        ],
+      },
+    }));
+
+    const templateFilter: estypes.QueryDslQueryContainer = {
+      bool: {
+        should: templateVersionFilters,
+        minimum_should_match: 1,
+      },
+    };
+
+    return [{ bool: { filter: [existsClause, templateFilter] } }];
   });

--- a/x-pack/platform/plugins/shared/cases/server/services/cases/extended_field_search_utils.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/cases/extended_field_search_utils.ts
@@ -362,7 +362,9 @@ export const resolveFieldLabelSearch = (
     const normalizedText = token.text.toLowerCase();
 
     for (const [labelKey, metas] of labelToMetas) {
-      if (labelKey.includes(normalizedText)) {
+      const isMatch = token.exact ? labelKey === normalizedText : labelKey.includes(normalizedText);
+
+      if (isMatch) {
         matchingMetas.push(...metas.values());
       }
     }

--- a/x-pack/platform/plugins/shared/cases/server/services/cases/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/cases/index.ts
@@ -57,8 +57,14 @@ import {
 import type { AttachmentService } from '../attachments';
 import type { AggregationBuilder, AggregationResponse } from '../../client/metrics/types';
 import { createCaseError, isSOError } from '../../common/error';
-import type { ResolvedExtendedFieldFilter } from './extended_field_search_utils';
-import { buildExtendedFieldRuntimeMappings } from './extended_field_search_utils';
+import type {
+  ResolvedExtendedFieldFilter,
+  ResolvedFieldLabelFilter,
+} from './extended_field_search_utils';
+import {
+  buildExtendedFieldRuntimeMappings,
+  buildFieldLabelRuntimeMappings,
+} from './extended_field_search_utils';
 import type {
   CasePersistedAttributes,
   CaseSavedObjectTransformed,
@@ -274,10 +280,12 @@ export class CasesService {
     caseOptions,
     namespaces,
     extendedFieldFilters,
+    fieldLabelFilters,
   }: {
     caseOptions: SavedObjectFindOptionsKueryNode;
     namespaces: string[];
     extendedFieldFilters?: ResolvedExtendedFieldFilter[][];
+    fieldLabelFilters?: ResolvedFieldLabelFilter[];
   }): Promise<CasesMapWithPageInfo> {
     const caseIdsByAttachmentSearch = await this.getCaseIdsByAttachmentSearch(
       namespaces,
@@ -289,21 +297,34 @@ export class CasesService {
       searchFields: caseOptions.searchFields,
       caseIds: caseIdsByAttachmentSearch,
       extendedFieldFilters,
+      fieldLabelFilters,
     });
 
     const filterQuery = caseOptions.filter ? toElasticsearchQuery(caseOptions.filter) : undefined;
     const query = mergeSearchQuery(searchQuery, filterQuery);
 
-    const runtimeMappings =
+    const extendedFieldRuntimeMappings =
       extendedFieldFilters && extendedFieldFilters.length > 0
         ? buildExtendedFieldRuntimeMappings(extendedFieldFilters)
-        : undefined;
+        : {};
+
+    const fieldLabelRuntimeMappings =
+      fieldLabelFilters && fieldLabelFilters.length > 0
+        ? buildFieldLabelRuntimeMappings(fieldLabelFilters)
+        : {};
+
+    const runtimeMappings = {
+      ...extendedFieldRuntimeMappings,
+      ...fieldLabelRuntimeMappings,
+    };
+
+    const hasRuntimeMappings = Object.keys(runtimeMappings).length > 0;
 
     const cases = await this.searchCases({
       type: [CASE_SAVED_OBJECT],
       namespaces,
       query,
-      ...(runtimeMappings ? { runtime_mappings: runtimeMappings } : {}),
+      ...(hasRuntimeMappings ? { runtime_mappings: runtimeMappings } : {}),
       ...convertFindQueryParams(caseOptions),
     });
 

--- a/x-pack/platform/plugins/shared/cases/server/services/cases/utils.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/cases/utils.test.ts
@@ -556,3 +556,113 @@ describe('constructSearchQuery with extendedFieldFilters', () => {
     });
   });
 });
+
+describe('constructSearchQuery with fieldLabelFilters', () => {
+  const labelFilter = {
+    storageKey: 'priority_as_keyword',
+    esType: 'keyword',
+    control: 'SELECT_BASIC',
+    templateVersions: [{ id: 'tmpl-a', version: 1 }],
+  };
+
+  it('adds label-existence clauses to shouldClauses when fieldLabelFilters provided alone', () => {
+    const result = constructSearchQuery({
+      caseIds: [],
+      fieldLabelFilters: [labelFilter],
+    });
+
+    expect(result).toEqual({
+      bool: {
+        should: [
+          {
+            bool: {
+              filter: [
+                { exists: { field: 'ef_priority_as_keyword' } },
+                {
+                  bool: {
+                    should: [
+                      {
+                        bool: {
+                          must: [
+                            { term: { 'cases.template.id': 'tmpl-a' } },
+                            { term: { 'cases.template.version': 1 } },
+                          ],
+                        },
+                      },
+                    ],
+                    minimum_should_match: 1,
+                  },
+                },
+              ],
+            },
+          },
+        ],
+        minimum_should_match: 1,
+      },
+    });
+  });
+
+  it('ORs label-existence clauses with free-text search clauses', () => {
+    const result = constructSearchQuery({
+      search: 'test',
+      searchFields: [`${CASE_SAVED_OBJECT}.title`],
+      caseIds: [],
+      fieldLabelFilters: [labelFilter],
+    });
+
+    const shouldClauses = result?.bool?.should as estypes.QueryDslQueryContainer[] | undefined;
+    expect(shouldClauses).toBeDefined();
+    expect(shouldClauses!.length).toBeGreaterThanOrEqual(3);
+
+    const existsClause = shouldClauses!.find(
+      (c: estypes.QueryDslQueryContainer) =>
+        (c?.bool?.filter as estypes.QueryDslQueryContainer[])?.[0]?.exists?.field ===
+        'ef_priority_as_keyword'
+    );
+    expect(existsClause).toBeDefined();
+
+    const multiMatchClause = shouldClauses!.find(
+      (c: estypes.QueryDslQueryContainer) => c?.multi_match != null
+    );
+    expect(multiMatchClause).toBeDefined();
+  });
+
+  it('combines fieldLabelFilters (should) with extendedFieldFilters (filter) correctly', () => {
+    const result = constructSearchQuery({
+      caseIds: [],
+      fieldLabelFilters: [labelFilter],
+      extendedFieldFilters: [
+        [
+          {
+            storageKey: 'region_as_keyword',
+            value: 'emea',
+            esType: 'keyword',
+            control: 'TEXT',
+            templateVersions: [{ id: 'tmpl-a', version: 1 }],
+          },
+        ],
+      ],
+    });
+
+    expect(result?.bool?.filter).toBeDefined();
+    const filter = result!.bool!.filter as estypes.QueryDslQueryContainer[];
+    expect(filter).toHaveLength(2);
+
+    const shouldWrapper = filter[0];
+    expect(shouldWrapper?.bool?.should).toBeDefined();
+    const shouldClauses = shouldWrapper!.bool!.should as estypes.QueryDslQueryContainer[];
+    const innerFilter = shouldClauses[0]?.bool?.filter as estypes.QueryDslQueryContainer[];
+    expect(innerFilter?.[0]?.exists?.field).toBe('ef_priority_as_keyword');
+
+    const extendedFilter = filter[1];
+    const extFilterClauses = extendedFilter?.bool?.filter as estypes.QueryDslQueryContainer[];
+    expect(extFilterClauses?.[0]?.term?.ef_region_as_keyword).toBeDefined();
+  });
+
+  it('returns undefined when no search, caseIds, extendedFieldFilters, or fieldLabelFilters', () => {
+    const result = constructSearchQuery({
+      caseIds: [],
+    });
+    expect(result).toBeUndefined();
+  });
+});

--- a/x-pack/platform/plugins/shared/cases/server/services/cases/utils.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/cases/utils.ts
@@ -8,8 +8,14 @@ import type { estypes } from '@elastic/elasticsearch';
 import { CASE_COMMENT_SAVED_OBJECT, CASE_SAVED_OBJECT } from '../../../common/constants';
 import type { FindOptions } from '../../common/types';
 import { DEFAULT_PER_PAGE } from '../../routes/api';
-import type { ResolvedExtendedFieldFilter } from './extended_field_search_utils';
-import { buildExtendedFieldFilterClauses } from './extended_field_search_utils';
+import type {
+  ResolvedExtendedFieldFilter,
+  ResolvedFieldLabelFilter,
+} from './extended_field_search_utils';
+import {
+  buildExtendedFieldFilterClauses,
+  buildFieldLabelExistsClauses,
+} from './extended_field_search_utils';
 
 export const DEFAULT_CASE_SEARCH_FIELDS = [
   `${CASE_SAVED_OBJECT}.title`,
@@ -82,11 +88,13 @@ export const constructSearchQuery = ({
   searchFields,
   caseIds,
   extendedFieldFilters,
+  fieldLabelFilters,
 }: {
   search?: string;
   searchFields?: string[];
   caseIds: string[];
   extendedFieldFilters?: ResolvedExtendedFieldFilter[][];
+  fieldLabelFilters?: ResolvedFieldLabelFilter[];
 }): estypes.QueryDslQueryContainer | undefined => {
   const caseSearchFields = searchFields?.filter((field) =>
     DEFAULT_CASE_SEARCH_FIELDS.includes(field)
@@ -94,8 +102,9 @@ export const constructSearchQuery = ({
   const nestedFields = searchFields?.filter((field) => DEFAULT_CASE_NESTED_FIELDS.includes(field));
 
   const hasExtendedFieldFilters = extendedFieldFilters && extendedFieldFilters.length > 0;
+  const hasFieldLabelFilters = fieldLabelFilters && fieldLabelFilters.length > 0;
 
-  if (!search && !caseIds.length && !hasExtendedFieldFilters) {
+  if (!search && !caseIds.length && !hasExtendedFieldFilters && !hasFieldLabelFilters) {
     return undefined;
   }
 
@@ -141,6 +150,10 @@ export const constructSearchQuery = ({
         [`_id`]: caseIds.map((id) => `${CASE_SAVED_OBJECT}:${id}`),
       },
     });
+  }
+
+  if (hasFieldLabelFilters) {
+    shouldClauses.push(...buildFieldLabelExistsClauses(fieldLabelFilters));
   }
 
   if (hasExtendedFieldFilters) {


### PR DESCRIPTION
### What & Why
Extends the Cases search bar to also match against template extended field labels. Previously, free-text input only searched title, description, and incremental ID. Now the server tokenizes the search string and checks each token (substring match) against known template field labels — returning cases that have any extended field whose label contains the search term. Quoted phrases like "Start date" are treated as a single multi-word token. Results are OR'd with the existing free-text search, so no existing behavior changes. The search bar placeholder was updated to communicate all three capabilities: free text, field label, and field:value filtering.

### How to Test
 - Create a template with extended fields (e.g., "Priority", "Start date operation", "End date").
 - Create cases using that template and fill in the extended fields.
 - Type priority in the All Cases search bar — cases with a "Priority" field should appear alongside title/description matches.
 - Type start — cases with fields containing "start" in the label (e.g., "Start date operation") should appear, but not "End date".
 - Type "start date" (with quotes) — only fields whose label contains the phrase "start date" should match.
 - Combine: priority:high network should filter by Priority=high AND return cases matching "network" in title/description or as a field label.
 - 
### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

