### PR TITLE
[content list] Add saved object provider services

### DIFF
--- a/src/platform/packages/shared/content-management/content_editor/src/services.test.tsx
+++ b/src/platform/packages/shared/content-management/content_editor/src/services.test.tsx
@@ -9,8 +9,6 @@
 
 import React from 'react';
 import { render } from '@testing-library/react';
-import { QueryClient, QueryClientProvider } from '@kbn/react-query';
-import { UserProfilesProvider } from '@kbn/content-management-user-profiles';
 import type { ContentEditorKibanaDependencies, TagSelectorProps } from './services';
 import { ContentEditorKibanaProvider, useServices } from './services';
 
@@ -43,28 +41,19 @@ const createCoreMock = (): ContentEditorKibanaDependencies['core'] =>
     },
   } as unknown as ContentEditorKibanaDependencies['core']);
 
-const createWrapper = (
-  savedObjectsTagging: ContentEditorKibanaDependencies['savedObjectsTagging']
-) => {
-  const queryClient = new QueryClient();
-
-  return ({ children }: { children: React.ReactNode }) => (
-    <QueryClientProvider client={queryClient}>
-      <UserProfilesProvider
-        bulkGetUserProfiles={jest.fn()}
-        getUserProfile={jest.fn()}
-        suggestUserProfiles={jest.fn()}
+// `ContentEditorKibanaProvider` self-provides `QueryClientProvider` and
+// `UserProfilesKibanaProvider`, so no consumer-side wrapping is required.
+const createWrapper =
+  (savedObjectsTagging: ContentEditorKibanaDependencies['savedObjectsTagging']) =>
+  ({ children }: { children: React.ReactNode }) =>
+    (
+      <ContentEditorKibanaProvider
+        core={createCoreMock()}
+        savedObjectsTagging={savedObjectsTagging}
       >
-        <ContentEditorKibanaProvider
-          core={createCoreMock()}
-          savedObjectsTagging={savedObjectsTagging}
-        >
-          {children}
-        </ContentEditorKibanaProvider>
-      </UserProfilesProvider>
-    </QueryClientProvider>
-  );
-};
+        {children}
+      </ContentEditorKibanaProvider>
+    );
 
 const TagListConsumer = ({ tagIds }: { tagIds: string[] }) => {
   const { TagList } = useServices();

--- a/src/platform/packages/shared/content-management/content_editor/src/services.tsx
+++ b/src/platform/packages/shared/content-management/content_editor/src/services.tsx
@@ -17,20 +17,20 @@ import {
 import { QueryClient, QueryClientProvider, useQueryClient } from '@kbn/react-query';
 
 /**
- * Module-level React Query client for content-editor flows.
+ * Create a React Query client for a single content-editor provider instance.
  *
- * Self-provided by {@link ContentEditorKibanaProvider} so consumers don't have
- * to wrap separately. The same instance is forwarded into the system flyout the
- * editor opens, so user-profile queries inside the flyout share cache with
- * queries made by the editor body.
+ * Called inside a `useMemo` so each mounted {@link ContentEditorKibanaProvider}
+ * gets its own client that can be garbage-collected on unmount, avoiding
+ * unbounded cache growth when multiple instances are mounted across the app.
  */
-const contentEditorQueryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      retry: false,
+const createContentEditorQueryClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
     },
-  },
-});
+  });
 
 import type { EuiComboBoxProps } from '@elastic/eui';
 import type { AnalyticsServiceStart } from '@kbn/core-analytics-browser';
@@ -158,13 +158,20 @@ export interface ContentEditorKibanaDependencies {
  */
 export const ContentEditorKibanaProvider: FC<
   PropsWithChildren<ContentEditorKibanaDependencies>
-> = ({ children, ...services }) => (
-  <QueryClientProvider client={contentEditorQueryClient}>
-    <UserProfilesKibanaProvider core={services.core}>
-      <ContentEditorKibanaProviderInner {...services}>{children}</ContentEditorKibanaProviderInner>
-    </UserProfilesKibanaProvider>
-  </QueryClientProvider>
-);
+> = ({ children, ...services }) => {
+  // Create a per-instance QueryClient so the cache is released when this
+  // provider unmounts, preventing unbounded memory growth across multiple
+  // mounted ContentEditorKibanaProvider trees.
+  const queryClient = useMemo(() => createContentEditorQueryClient(), []);
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <UserProfilesKibanaProvider core={services.core}>
+        <ContentEditorKibanaProviderInner {...services}>{children}</ContentEditorKibanaProviderInner>
+      </UserProfilesKibanaProvider>
+    </QueryClientProvider>
+  );
+};
 
 /**
  * Inner body of {@link ContentEditorKibanaProvider}.

--- a/src/platform/packages/shared/content-management/content_editor/src/services.tsx
+++ b/src/platform/packages/shared/content-management/content_editor/src/services.tsx
@@ -10,10 +10,27 @@
 import type { FC, PropsWithChildren, ReactNode } from 'react';
 import React, { useCallback, useContext, useMemo } from 'react';
 import {
+  UserProfilesKibanaProvider,
   UserProfilesProvider,
   useUserProfilesServices,
 } from '@kbn/content-management-user-profiles';
-import { QueryClientProvider, useQueryClient } from '@kbn/react-query';
+import { QueryClient, QueryClientProvider, useQueryClient } from '@kbn/react-query';
+
+/**
+ * Module-level React Query client for content-editor flows.
+ *
+ * Self-provided by {@link ContentEditorKibanaProvider} so consumers don't have
+ * to wrap separately. The same instance is forwarded into the system flyout the
+ * editor opens, so user-profile queries inside the flyout share cache with
+ * queries made by the editor body.
+ */
+const contentEditorQueryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: false,
+    },
+  },
+});
 
 import type { EuiComboBoxProps } from '@elastic/eui';
 import type { AnalyticsServiceStart } from '@kbn/core-analytics-browser';
@@ -124,10 +141,41 @@ export interface ContentEditorKibanaDependencies {
 
 /**
  * Kibana-specific Provider that maps to known dependency types.
+ *
+ * Self-provides every external context the editor needs so consumers can drop
+ * it into any provider tree without thinking about ancestry:
+ *
+ * - {@link QueryClientProvider} — the inner body uses `useQueryClient()` to
+ *   forward the client into the system flyout it opens, so user-profile
+ *   queries inside the flyout work without an outer `QueryClientProvider`.
+ * - {@link UserProfilesKibanaProvider} — the inner body reads profile services
+ *   via `useUserProfilesServices()` for the same forwarding reason.
+ *
+ * When this provider is itself rendered under another `QueryClientProvider`
+ * or `UserProfilesProvider` (e.g. legacy `TableListViewKibanaProvider`), the
+ * inner providers shadow the outer with semantically equivalent values derived
+ * from the same `core` services, so nesting is harmless.
  */
 export const ContentEditorKibanaProvider: FC<
   PropsWithChildren<ContentEditorKibanaDependencies>
-> = ({ children, ...services }) => {
+> = ({ children, ...services }) => (
+  <QueryClientProvider client={contentEditorQueryClient}>
+    <UserProfilesKibanaProvider core={services.core}>
+      <ContentEditorKibanaProviderInner {...services}>{children}</ContentEditorKibanaProviderInner>
+    </UserProfilesKibanaProvider>
+  </QueryClientProvider>
+);
+
+/**
+ * Inner body of {@link ContentEditorKibanaProvider}.
+ *
+ * Split from the public provider so `useUserProfilesServices()` reads from
+ * the {@link UserProfilesKibanaProvider} rendered by the outer wrapper.
+ */
+const ContentEditorKibanaProviderInner: FC<PropsWithChildren<ContentEditorKibanaDependencies>> = ({
+  children,
+  ...services
+}) => {
   const { core, savedObjectsTagging } = services;
   const { overlays, notifications, rendering } = core;
   const { openSystemFlyout: coreOpenFlyout } = overlays;

--- a/src/platform/packages/shared/content-management/content_editor/src/services.tsx
+++ b/src/platform/packages/shared/content-management/content_editor/src/services.tsx
@@ -167,7 +167,9 @@ export const ContentEditorKibanaProvider: FC<
   return (
     <QueryClientProvider client={queryClient}>
       <UserProfilesKibanaProvider core={services.core}>
-        <ContentEditorKibanaProviderInner {...services}>{children}</ContentEditorKibanaProviderInner>
+        <ContentEditorKibanaProviderInner {...services}>
+          {children}
+        </ContentEditorKibanaProviderInner>
       </UserProfilesKibanaProvider>
     </QueryClientProvider>
   );

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-assembly/src/assembly.test.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-assembly/src/assembly.test.ts
@@ -381,7 +381,7 @@ describe('createComponent with resolve', () => {
     label: string;
   }
 
-  column.createComponent<CustomColumnProps>({
+  const CustomColumn = column.createComponent<CustomColumnProps>({
     resolve: (attributes, context) => ({
       field: attributes.field,
       label: `${context.prefix}: ${attributes.label}`,
@@ -407,6 +407,8 @@ describe('createComponent with resolve', () => {
       preset: undefined,
       instanceId: 'custom',
       attributes: { field: 'size', label: 'Size' },
+      // componentType is required to look up the per-component resolver.
+      componentType: CustomColumn as unknown as (...args: unknown[]) => unknown,
     };
     const result = column.resolve(part, { prefix: 'Col' });
     expect(result).toEqual({ field: 'size', label: 'Col: Size' });
@@ -419,10 +421,141 @@ describe('createComponent with resolve', () => {
       preset: 'name',
       instanceId: 'name',
       attributes: { label: 'Title' },
+      componentType: CustomColumn as unknown as (...args: unknown[]) => unknown,
     };
     // Should use the preset resolver, not the custom one.
     const result = column.resolve(part, { prefix: 'Col' });
     expect(result).toEqual({ field: 'title', label: 'Col: Title' });
+  });
+});
+
+describe('createComponent — per-instance resolver isolation', () => {
+  // Regression: previously `customResolver` was a single shared closure slot.
+  // A second `createComponent({ resolve })` call for the same part would
+  // silently overwrite the first, so both components would dispatch to the
+  // newest resolver (the recents-filter global-resolver bug).
+  //
+  // The fix keys resolvers on the component function reference stored in
+  // `ParsedPart.componentType`. Each component gets its own entry; resolvers
+  // are independent.
+
+  interface FilterOutput {
+    label: string;
+  }
+
+  it('resolves two custom components with different resolvers independently', () => {
+    const asm = defineAssembly({ name: 'IsolationTest' });
+    const part = asm.definePart<Record<never, never>, FilterOutput, void>({ name: 'filter' });
+
+    const CompA = part.createComponent<Record<never, never>>({
+      resolve: () => ({ label: 'source-A' }),
+    });
+    const CompB = part.createComponent<Record<never, never>>({
+      resolve: () => ({ label: 'source-B' }),
+    });
+
+    const partA = {
+      type: 'part' as const,
+      part: 'filter',
+      preset: undefined,
+      instanceId: 'filter-0',
+      attributes: {},
+      componentType: CompA as unknown as (...args: unknown[]) => unknown,
+    };
+    const partB = {
+      type: 'part' as const,
+      part: 'filter',
+      preset: undefined,
+      instanceId: 'filter-1',
+      attributes: {},
+      componentType: CompB as unknown as (...args: unknown[]) => unknown,
+    };
+
+    expect(part.resolve(partA)).toEqual({ label: 'source-A' });
+    expect(part.resolve(partB)).toEqual({ label: 'source-B' });
+  });
+
+  it('resolver for the first component is not overwritten when a second component is created', () => {
+    const asm = defineAssembly({ name: 'OverwriteTest' });
+    const part = asm.definePart<Record<never, never>, FilterOutput, void>({ name: 'filter' });
+
+    const CompA = part.createComponent<Record<never, never>>({
+      resolve: () => ({ label: 'A' }),
+    });
+
+    // Creating CompB must not change how CompA resolves.
+    part.createComponent<Record<never, never>>({
+      resolve: () => ({ label: 'B' }),
+    });
+
+    const partA = {
+      type: 'part' as const,
+      part: 'filter',
+      preset: undefined,
+      instanceId: 'filter-0',
+      attributes: {},
+      componentType: CompA as unknown as (...args: unknown[]) => unknown,
+    };
+
+    // CompA should still resolve to 'A', not 'B'.
+    expect(part.resolve(partA)).toEqual({ label: 'A' });
+  });
+
+  it('resolves two custom skeleton resolvers independently', () => {
+    const asm = defineAssembly({ name: 'SkeletonIsolationTest' });
+    const part = asm.definePart<Record<never, never>, FilterOutput, void>({ name: 'filter' });
+
+    const CompA = part.createComponent<Record<never, never>>({
+      resolve: () => ({ label: 'A' }),
+      skeleton: () => ({ shape: 'text', width: '30%' }),
+    });
+    const CompB = part.createComponent<Record<never, never>>({
+      resolve: () => ({ label: 'B' }),
+      skeleton: () => ({ shape: 'rectangle', width: '60%' }),
+    });
+
+    const partA = {
+      type: 'part' as const,
+      part: 'filter',
+      preset: undefined,
+      instanceId: 'filter-0',
+      attributes: {},
+      componentType: CompA as unknown as (...args: unknown[]) => unknown,
+    };
+    const partB = {
+      type: 'part' as const,
+      part: 'filter',
+      preset: undefined,
+      instanceId: 'filter-1',
+      attributes: {},
+      componentType: CompB as unknown as (...args: unknown[]) => unknown,
+    };
+
+    expect(part.resolveSkeleton(partA)).toEqual({ shape: 'text', width: '30%' });
+    expect(part.resolveSkeleton(partB)).toEqual({ shape: 'rectangle', width: '60%' });
+  });
+
+  it('falls back to undefined when componentType is absent (hand-constructed ParsedPart)', () => {
+    const asm = defineAssembly({ name: 'FallbackTest' });
+    const part = asm.definePart<Record<never, never>, FilterOutput, void>({ name: 'filter' });
+
+    part.createComponent<Record<never, never>>({ resolve: () => ({ label: 'A' }) });
+
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    // No componentType: simulates a hand-constructed part or legacy usage.
+    const partWithoutType = {
+      type: 'part' as const,
+      part: 'filter',
+      preset: undefined,
+      instanceId: 'filter-0',
+      attributes: {},
+    };
+
+    // Without componentType there is no way to look up the resolver.
+    const result = part.resolve(partWithoutType);
+    expect(result).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('No resolver found'));
+    warnSpy.mockRestore();
   });
 });
 
@@ -575,7 +708,7 @@ describe('resolveSkeleton', () => {
     width?: string;
   }
 
-  column.createComponent<CustomColumnProps>({
+  const CustomColumn = column.createComponent<CustomColumnProps>({
     resolve: (attrs) => ({ field: attrs.field }),
     skeleton: (attrs) => ({ shape: 'rectangle', width: attrs.width ?? '100%' }),
   });
@@ -632,6 +765,7 @@ describe('resolveSkeleton', () => {
       preset: 'sort',
       instanceId: 'sort',
       attributes: { field: 'sort' },
+      componentType: CustomColumn as unknown as (...args: unknown[]) => unknown,
     };
     const result = column.resolveSkeleton(part, { theme: 'light' });
     expect(result).toEqual({ shape: 'rectangle', width: '100%' });
@@ -644,6 +778,7 @@ describe('resolveSkeleton', () => {
       preset: undefined,
       instanceId: 'custom',
       attributes: { field: 'bytes', width: '80px' },
+      componentType: CustomColumn as unknown as (...args: unknown[]) => unknown,
     };
     const result = column.resolveSkeleton(part, { theme: 'light' });
     expect(result).toEqual({ shape: 'rectangle', width: '80px' });

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-assembly/src/assembly.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-assembly/src/assembly.ts
@@ -150,23 +150,22 @@ export interface PartFactory<
   parseChildren: (children: ReactNode) => ParsedPart[];
 
   /**
-   * Create a component without a preset (e.g., custom columns).
+   * Create a component without a preset (e.g., custom columns or custom filters).
    *
-   * Use this for parts that get their identity from `props.id` rather
-   * than a static preset name. Optionally provide a `resolve` callback
-   * to handle custom parts in `part.resolve()`, eliminating the need
-   * for manual casts in consumer code.
-   *
-   * Optionally provide a `skeleton` callback — the fallback skeleton
-   * resolver invoked by {@link resolveSkeleton} when no preset skeleton
-   * is registered.
+   * Each call returns a **unique** `FC` reference. When a `resolve` or `skeleton`
+   * callback is provided, it is bound exclusively to that component reference.
+   * This means multiple `createComponent` calls for the same part — e.g. two
+   * `RecentsFilter` instances from different history sources — each dispatch to
+   * their own resolver independently. The resolver is looked up from the
+   * component function carried on the parsed part (`ParsedPart.componentType`),
+   * so there is no global shared slot that can be overwritten.
    *
    * @template P - The component's props type.
    * @param options - Optional configuration.
-   * @param options.resolve - Fallback resolver for parts without a preset.
+   * @param options.resolve - Resolver bound to this specific component instance.
    *   Return `undefined` to signal that the part should be skipped.
-   * @param options.skeleton - Fallback skeleton resolver for parts without
-   *   a preset skeleton. Return `undefined` to defer to renderer inference.
+   * @param options.skeleton - Skeleton resolver bound to this specific component instance.
+   *   Return `undefined` to defer to renderer inference.
    * @returns An `FC<P>` that returns `null`.
    */
   createComponent: <P>(options?: {
@@ -344,15 +343,20 @@ export const defineAssembly = <const TName extends string>(config: {
       (attributes: Record<string, unknown>, context: TContext) => SkeletonOutput | undefined
     >();
 
-    // Fallback resolver for custom parts (registered via `createComponent`).
-    let customResolver:
-      | ((attributes: Record<string, unknown>, context: TContext) => TOutput | undefined)
-      | undefined;
+    // Per-component resolver map: each `createComponent` call registers its
+    // resolver keyed by the unique FC it returns. This ensures two components
+    // from different `createComponent` calls (e.g. two `RecentsFilter`
+    // instances bound to different sources) each use their own resolver
+    // rather than the last-registered one.
+    const componentResolvers = new WeakMap<
+      (...args: unknown[]) => unknown,
+      (attributes: Record<string, unknown>, context: TContext) => TOutput | undefined
+    >();
 
-    // Fallback skeleton resolver for custom parts.
-    let customSkeletonResolver:
-      | ((attributes: Record<string, unknown>, context: TContext) => SkeletonOutput | undefined)
-      | undefined;
+    const componentSkeletonResolvers = new WeakMap<
+      (...args: unknown[]) => unknown,
+      (attributes: Record<string, unknown>, context: TContext) => SkeletonOutput | undefined
+    >();
 
     return {
       createPreset: <K extends keyof TPresetMap & string>(definition: {
@@ -394,9 +398,16 @@ export const defineAssembly = <const TName extends string>(config: {
           return resolver(part.attributes, context);
         }
 
-        // Fall back to the custom component resolver.
-        if (customResolver) {
-          return customResolver(part.attributes, context);
+        // Look up the resolver keyed to the exact component function that
+        // produced this part. This ensures that two `createComponent` calls
+        // with different `resolve` functions (e.g. two RecentsFilter instances
+        // bound to different sources) each dispatch to their own resolver
+        // rather than sharing the last-registered one.
+        if (part.componentType) {
+          const componentResolver = componentResolvers.get(part.componentType);
+          if (componentResolver) {
+            return componentResolver(part.attributes, context);
+          }
         }
 
         if (process.env.NODE_ENV !== 'production') {
@@ -418,9 +429,13 @@ export const defineAssembly = <const TName extends string>(config: {
           return resolver(part.attributes, context);
         }
 
-        // Fall back to the custom component skeleton resolver.
-        if (customSkeletonResolver) {
-          return customSkeletonResolver(part.attributes, context);
+        // Look up the skeleton resolver keyed to the exact component function,
+        // mirroring the per-component lookup in `resolve`.
+        if (part.componentType) {
+          const componentSkeletonResolver = componentSkeletonResolvers.get(part.componentType);
+          if (componentSkeletonResolver) {
+            return componentSkeletonResolver(part.attributes, context);
+          }
         }
 
         // Absence of a skeleton resolver is the expected normal case — most
@@ -442,40 +457,36 @@ export const defineAssembly = <const TName extends string>(config: {
         resolve?: (attributes: P, context: TContext) => TOutput | undefined;
         skeleton?: (attributes: P, context: TContext) => SkeletonOutput | undefined;
       }): FC<P> => {
-        if (options?.resolve) {
-          if (process.env.NODE_ENV !== 'production' && customResolver) {
-            // eslint-disable-next-line no-console
-            console.warn(
-              `[${config.name}] createComponent({ resolve }) called more than once ` +
-                `for part "${partDefinition.name}". The previous custom resolver will be overwritten.`
-            );
-          }
-
-          customResolver = options.resolve as (
-            attributes: Record<string, unknown>,
-            context: TContext
-          ) => TOutput | undefined;
-        }
-
-        if (options?.skeleton) {
-          if (process.env.NODE_ENV !== 'production' && customSkeletonResolver) {
-            // eslint-disable-next-line no-console
-            console.warn(
-              `[${config.name}] createComponent({ skeleton }) called more than once ` +
-                `for part "${partDefinition.name}". The previous custom skeleton resolver will be overwritten.`
-            );
-          }
-
-          customSkeletonResolver = options.skeleton as (
-            attributes: Record<string, unknown>,
-            context: TContext
-          ) => SkeletonOutput | undefined;
-        }
-
-        return createDeclarativeComponent<P>({
+        // Each call produces a unique component function. Resolvers are keyed
+        // to that function so that multiple `createComponent` calls for the
+        // same part (e.g. two RecentsFilter instances from different sources)
+        // each dispatch to their own resolver independently.
+        const component = createDeclarativeComponent<P>({
           assembly: config.name,
           part: partDefinition.name,
         });
+
+        if (options?.resolve) {
+          componentResolvers.set(
+            component as unknown as (...args: unknown[]) => unknown,
+            options.resolve as (
+              attributes: Record<string, unknown>,
+              context: TContext
+            ) => TOutput | undefined
+          );
+        }
+
+        if (options?.skeleton) {
+          componentSkeletonResolvers.set(
+            component as unknown as (...args: unknown[]) => unknown,
+            options.skeleton as (
+              attributes: Record<string, unknown>,
+              context: TContext
+            ) => SkeletonOutput | undefined
+          );
+        }
+
+        return component;
       },
 
       tagComponent: <C extends (...args: any[]) => null>(

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-assembly/src/parsing.test.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-assembly/src/parsing.test.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { createElement, Fragment } from 'react';
+import { createElement, Fragment, memo, forwardRef } from 'react';
 import { parseDeclarativeChildren } from './parsing';
 import { createDeclarativeComponent } from './factory';
 
@@ -478,6 +478,51 @@ describe('parseDeclarativeChildren', () => {
           attributes: { label: 'Title' },
         })
       );
+    });
+  });
+
+  describe('componentType unwrapping', () => {
+    it('should set componentType to the bare function for a plain component.', () => {
+      const children = createElement(NameColumn, { label: 'Title' });
+      const result = parseDeclarativeChildren(children, assembly);
+
+      expect(result[0]).toEqual(expect.objectContaining({ componentType: NameColumn }));
+    });
+
+    it('should unwrap a React.memo wrapper to the inner function.', () => {
+      const MemoColumn = memo(NameColumn) as any;
+      // Assembly Symbols are not standard statics so React.memo does not hoist
+      // them automatically — assign them to the wrapper so getPartType sees them.
+      Object.assign(MemoColumn, NameColumn);
+      const children = createElement(MemoColumn, { label: 'Title' });
+      const result = parseDeclarativeChildren(children, assembly);
+
+      expect(result[0]).toEqual(expect.objectContaining({ componentType: NameColumn }));
+    });
+
+    it('should unwrap a React.forwardRef wrapper to the render function.', () => {
+      const renderFn = (props: { label: string }, _ref: unknown) => null;
+      const RefColumn = forwardRef(renderFn) as any;
+      // Assign assembly statics to the wrapper so getPartType recognises it.
+      Object.assign(RefColumn, NameColumn);
+
+      const children = createElement(RefColumn, { label: 'Title' });
+      const result = parseDeclarativeChildren(children, assembly);
+
+      expect(result[0]).toEqual(expect.objectContaining({ componentType: renderFn }));
+    });
+
+    it('should unwrap nested memo(forwardRef(fn)) to the inner render function.', () => {
+      const renderFn = (props: { label: string }, _ref: unknown) => null;
+      const RefColumn = forwardRef(renderFn) as any;
+      const MemoRefColumn = memo(RefColumn) as any;
+      // Assign assembly statics to the outermost wrapper (memo copies them inward).
+      Object.assign(MemoRefColumn, NameColumn);
+
+      const children = createElement(MemoRefColumn, { label: 'Title' });
+      const result = parseDeclarativeChildren(children, assembly);
+
+      expect(result[0]).toEqual(expect.objectContaining({ componentType: renderFn }));
     });
   });
 });

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-assembly/src/parsing.test.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-assembly/src/parsing.test.ts
@@ -62,6 +62,7 @@ describe('parseDeclarativeChildren', () => {
           preset: 'name',
           instanceId: 'name',
           attributes: { label: 'Title' },
+          componentType: NameColumn,
         },
       ]);
     });

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-assembly/src/parsing.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-assembly/src/parsing.ts
@@ -115,6 +115,34 @@ export const parseDeclarativeChildren = (children: ReactNode, assembly: string):
 };
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Component type helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Recursively unwraps `React.memo` and `React.forwardRef` wrappers to reach
+ * the underlying render function.
+ *
+ * - `React.memo` wraps as `{ $$typeof: REACT_MEMO_TYPE, type: <inner> }`.
+ * - `React.forwardRef` wraps as `{ $$typeof: REACT_FORWARD_REF_TYPE, render: <inner> }`.
+ *
+ * The loop handles arbitrarily deep nesting (e.g. `memo(forwardRef(fn))`).
+ * Returns `undefined` if the final unwrapped value is not a function.
+ */
+const unwrapComponentType = (
+  type: unknown
+): ((...args: unknown[]) => unknown) | undefined => {
+  let current = type;
+  while (current !== null && typeof current === 'object') {
+    // React.memo wraps as { $$typeof, type }; forwardRef wraps as { $$typeof, render }.
+    const wrapped = current as Record<string, unknown>;
+    current = wrapped.type ?? wrapped.render;
+  }
+  return typeof current === 'function'
+    ? (current as (...args: unknown[]) => unknown)
+    : undefined;
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Core child walker
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -172,22 +200,9 @@ const walkChildren = (children: ReactNode, assembly: string): ParsedItem[] => {
     // HTML tags were filtered by `getPartType` above), but consumers may wrap
     // their component in `React.memo(...)` or `React.forwardRef(...)`, which
     // produce an object with `$$typeof` rather than a bare function. Unwrap
-    // those wrappers so the resolver WeakMap lookup works regardless of how the
-    // component was decorated.
-    const rawType = child.type as unknown;
-    let componentFn: ((...args: unknown[]) => unknown) | undefined;
-
-    if (typeof rawType === 'function') {
-      componentFn = rawType as (...args: unknown[]) => unknown;
-    } else if (rawType !== null && typeof rawType === 'object') {
-      // React.memo wraps as { $$typeof: REACT_MEMO_TYPE, type: <inner> }
-      // React.forwardRef wraps as { $$typeof: REACT_FORWARD_REF_TYPE, render: <inner> }
-      const wrapped = rawType as Record<string, unknown>;
-      const inner = wrapped.type ?? wrapped.render;
-      if (typeof inner === 'function') {
-        componentFn = inner as (...args: unknown[]) => unknown;
-      }
-    }
+    // those wrappers recursively so the resolver WeakMap lookup works regardless
+    // of how deeply the component was decorated (e.g. memo(forwardRef(fn))).
+    const componentFn = unwrapComponentType(child.type as unknown);
     const displayName =
       componentFn !== undefined
         ? (componentFn as unknown as { displayName?: string }).displayName

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-assembly/src/parsing.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-assembly/src/parsing.ts
@@ -54,6 +54,16 @@ export interface ParsedPart {
   instanceId: string;
   /** The component's props as declared in JSX. */
   attributes: Record<string, unknown>;
+  /**
+   * The original component function from the React element's `type` field.
+   *
+   * Carried through from parsing so that the resolver can look up the
+   * per-component-instance resolver registered via `createComponent`. This
+   * is the only way to distinguish two custom parts that share the same
+   * part name but were created by different `createComponent` calls — the
+   * component function reference is unique per call.
+   */
+  componentType?: (...args: unknown[]) => unknown;
 }
 
 /**
@@ -162,9 +172,13 @@ const walkChildren = (children: ReactNode, assembly: string): ParsedItem[] => {
     // (string HTML tags were filtered by `getPartType` above), but
     // TypeScript's React types don't model `displayName` on
     // `JSXElementConstructor`, so a cast through `unknown` is needed.
+    const componentFn =
+      typeof child.type === 'function'
+        ? (child.type as unknown as (...args: unknown[]) => unknown)
+        : undefined;
     const displayName =
-      typeof child.type !== 'string'
-        ? (child.type as unknown as { displayName?: string }).displayName
+      componentFn !== undefined
+        ? (componentFn as unknown as { displayName?: string }).displayName
         : undefined;
     const seenIds = getSeenIds(partName);
 
@@ -192,7 +206,14 @@ const walkChildren = (children: ReactNode, assembly: string): ParsedItem[] => {
     seenIds.add(instanceId);
 
     // Props are the attributes -- no parser transformation.
-    result.push({ type: 'part', part: partName, preset, instanceId, attributes: props });
+    result.push({
+      type: 'part',
+      part: partName,
+      preset,
+      instanceId,
+      attributes: props,
+      componentType: componentFn,
+    });
   };
 
   Children.forEach(children, processChild);

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-assembly/src/parsing.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-assembly/src/parsing.ts
@@ -128,18 +128,14 @@ export const parseDeclarativeChildren = (children: ReactNode, assembly: string):
  * The loop handles arbitrarily deep nesting (e.g. `memo(forwardRef(fn))`).
  * Returns `undefined` if the final unwrapped value is not a function.
  */
-const unwrapComponentType = (
-  type: unknown
-): ((...args: unknown[]) => unknown) | undefined => {
+const unwrapComponentType = (type: unknown): ((...args: unknown[]) => unknown) | undefined => {
   let current = type;
   while (current !== null && typeof current === 'object') {
     // React.memo wraps as { $$typeof, type }; forwardRef wraps as { $$typeof, render }.
     const wrapped = current as Record<string, unknown>;
     current = wrapped.type ?? wrapped.render;
   }
-  return typeof current === 'function'
-    ? (current as (...args: unknown[]) => unknown)
-    : undefined;
+  return typeof current === 'function' ? (current as (...args: unknown[]) => unknown) : undefined;
 };
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-assembly/src/parsing.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-assembly/src/parsing.ts
@@ -168,14 +168,26 @@ const walkChildren = (children: ReactNode, assembly: string): ParsedItem[] => {
     const preset = getPresetId(child, assembly);
     // Empty strings are treated as "no explicit id" (falsy check below).
     const propsId = typeof props.id === 'string' ? props.id : undefined;
-    // `child.type` is a declarative component function at this point
-    // (string HTML tags were filtered by `getPartType` above), but
-    // TypeScript's React types don't model `displayName` on
-    // `JSXElementConstructor`, so a cast through `unknown` is needed.
-    const componentFn =
-      typeof child.type === 'function'
-        ? (child.type as unknown as (...args: unknown[]) => unknown)
-        : undefined;
+    // `child.type` is a declarative component function at this point (string
+    // HTML tags were filtered by `getPartType` above), but consumers may wrap
+    // their component in `React.memo(...)` or `React.forwardRef(...)`, which
+    // produce an object with `$$typeof` rather than a bare function. Unwrap
+    // those wrappers so the resolver WeakMap lookup works regardless of how the
+    // component was decorated.
+    const rawType = child.type as unknown;
+    let componentFn: ((...args: unknown[]) => unknown) | undefined;
+
+    if (typeof rawType === 'function') {
+      componentFn = rawType as (...args: unknown[]) => unknown;
+    } else if (rawType !== null && typeof rawType === 'object') {
+      // React.memo wraps as { $$typeof: REACT_MEMO_TYPE, type: <inner> }
+      // React.forwardRef wraps as { $$typeof: REACT_FORWARD_REF_TYPE, render: <inner> }
+      const wrapped = rawType as Record<string, unknown>;
+      const inner = wrapped.type ?? wrapped.render;
+      if (typeof inner === 'function') {
+        componentFn = inner as (...args: unknown[]) => unknown;
+      }
+    }
     const displayName =
       componentFn !== undefined
         ? (componentFn as unknown as { displayName?: string }).displayName

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/README.md
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/README.md
@@ -105,6 +105,108 @@ This is the same signature expected by `TableListView.findItems`.
 
 > **Note:** The `refs` parameter (for tag filtering) is not yet supported in the new `ContentListProvider` architecture. Only `searchQuery` is forwarded in this initial version. Tag filtering support is planned for a future release.
 
+## Saved-object listing services
+
+`ContentListClientProvider` is a generic primitive — it accepts plain `services`/`features`/`contentEditor`/`findItems` args. For typical saved-object listings (Dashboards, Maps, Visualize, Graph, etc.) the wiring of those args is repetitive: build a tags service from the tagging API, instantiate a favorites client, decorate `findItems` with EBT performance metrics, format duplicate-title validators, and so on.
+
+The `services/` folder ships small, single-purpose helpers — one per capability area. Each helper builds exactly one piece of the args you already pass to `ContentListClientProvider`. They are not a wrapper, hook, or "preset"; they are the building blocks of the existing API surface.
+
+Each subfolder is named after the `ContentListClientProvider` field it serves:
+
+| Helper                                | Subfolder                | Fills                                |
+| ------------------------------------- | ------------------------ | ------------------------------------ |
+| `createTagsService(api)`              | `services/tags/`         | `services.tags`                      |
+| `createFavoritesService(opts)`        | `services/favorites/`    | `services.favorites`                 |
+| `createUserProfilesService(profile)`  | `services/user_profiles/`| `services.userProfiles`              |
+| `createContentInsightsService(opts)` + `<SavedObjectActivityRow>` | `services/content_insights/` | `contentEditor.appendRows`            |
+| `createDuplicateTitleValidator(opts)` | `services/duplicate_title/` | `contentEditor.customValidators.title`|
+| `useRecentlyAccessedDecoration(src)`  | `services/recently_accessed/` | `findItems` decoration + `features.flags` + a closure-bound `RecentsFilter` |
+| `withPerformanceMetrics(fn, opts)`    | `services/performance_metrics/` | wraps `findItems` / `onDelete` |
+
+Each helper is tested in isolation and is independently optional. Use one, several, or none — `ContentListClientProvider` accepts the raw types either way.
+
+### Composing them in a consumer
+
+```tsx
+import {
+  ContentListClientProvider,
+  createTagsService,
+  createFavoritesService,
+  createUserProfilesService,
+  createContentInsightsService,
+  createDuplicateTitleValidator,
+  useRecentlyAccessedDecoration,
+  withPerformanceMetrics,
+  SavedObjectActivityRow,
+} from '@kbn/content-list-provider-client';
+
+const tags = createTagsService(savedObjectsTagging.getTaggingApi()?.ui);
+const favorites = createFavoritesService({
+  appId: 'dashboards',
+  savedObjectType: 'dashboard',
+  http: coreServices.http,
+  userProfile: coreServices.userProfile,
+  usageCollection: usageCollectionService,
+});
+const userProfiles = createUserProfilesService(coreServices.userProfile);
+const insights = createContentInsightsService({
+  http: coreServices.http,
+  logger,
+  domainId: 'dashboard',
+});
+const search = useMemo(
+  () =>
+    withPerformanceMetrics(rawSearch, {
+      analytics: coreServices.analytics,
+      eventName: SAVED_OBJECT_LOADED_TIME,
+      savedObjectType: 'dashboard',
+    }),
+  [rawSearch]
+);
+const recents = useRecentlyAccessedDecoration(getDashboardRecentlyAccessedService());
+
+return (
+  <ContentListClientProvider
+    services={{ uiSettings: core.uiSettings, tags, favorites, userProfiles }}
+    findItems={async (q, opts) => recents.decorate(await search(q, opts))}
+    features={{ flags: [recents.flag] }}
+    contentEditor={{
+      openContentEditor,
+      onSave: updateItemMeta,
+      customValidators: {
+        title: [
+          createDuplicateTitleValidator({
+            findCurrentTitle: (id) =>
+              findService.findById(id).then((r) =>
+                r.status === 'error' ? undefined : r.attributes.title
+              ),
+            checkForDuplicate: ({ title, lastSavedTitle }) =>
+              checkForDuplicateDashboardTitle({
+                title,
+                lastSavedTitle,
+                copyOnSave: false,
+                isTitleDuplicateConfirmed: false,
+              }),
+          }),
+        ],
+      },
+      appendRows: (item) => (
+        <SavedObjectActivityRow service={insights} item={item} entityNamePlural="dashboards" />
+      ),
+    }}
+  >
+    <ContentListToolbar>
+      <Filters>
+        <Filters.Starred />
+        <recents.RecentsFilter />
+        <Filters.Tags />
+      </Filters>
+    </ContentListToolbar>
+    <ContentListTable>{/* ... */}</ContentListTable>
+  </ContentListClientProvider>
+);
+```
+
 ## Exports
 
 ```typescript
@@ -122,8 +224,22 @@ export type {
   TableListViewFindItemsResult,
   SavedObjectReference,
 } from './types';
+
+// Saved-object listing services (see "Saved-object listing services" above).
+export {
+  createTagsService,
+  createFavoritesService,
+  createUserProfilesService,
+  createContentInsightsService,
+  SavedObjectActivityRow,
+  createDuplicateTitleValidator,
+  useRecentlyAccessedDecoration,
+  RecentsFilterRenderer,
+  withPerformanceMetrics,
+} from './services';
 ```
 
 ## Related Packages
 
 - [`@kbn/content-list-provider`](../kbn-content-list-provider) — Core provider and hooks.
+- [`@kbn/content-list-toolbar`](../kbn-content-list-toolbar) — Toolbar components consumed by `<recents.RecentsFilter />`.

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/index.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/index.ts
@@ -26,3 +26,32 @@ export type {
   TableListViewFindItemsResult,
   SavedObjectReference,
 } from './src/types';
+
+// Saved-object listing services — small, single-purpose helpers that build
+// args for `ContentListClientProvider`. See `services/<area>/` and the
+// README for how each helper maps to a `ContentListClientProviderProps`
+// field.
+export {
+  createTagsService,
+  type TagsApi,
+  createFavoritesService,
+  type FavoritesServiceOptions,
+  createUserProfilesService,
+  createContentInsightsService,
+  type ContentInsightsServiceOptions,
+  SavedObjectActivityRow,
+  type SavedObjectActivityRowProps,
+  createDuplicateTitleValidator,
+  type DuplicateTitleValidatorOptions,
+  type TitleValidator,
+  useRecentlyAccessedDecoration,
+  type RecentlyAccessedDecoration,
+  type RecentDecoration,
+  type DecorableFindItemsResult,
+  RecentsFilterRenderer,
+  type RecentsFilterRendererProps,
+  type RecentlyAccessedEntry,
+  type RecentlyAccessedHistorySource,
+  withPerformanceMetrics,
+  type PerformanceMetricsOptions,
+} from './src/services';

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/moon.yml
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/moon.yml
@@ -18,12 +18,22 @@ project:
   sourceRoot: src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client
 dependsOn:
   - '@kbn/content-list-provider'
+  - '@kbn/content-list-toolbar'
   - '@kbn/content-management-table-list-view-common'
   - '@kbn/management-settings-ids'
   - '@kbn/content-management-favorites-public'
   - '@kbn/content-management-tags'
   - '@kbn/content-management-content-editor'
+  - '@kbn/content-management-content-insights-public'
+  - '@kbn/ebt-tools'
   - '@kbn/i18n'
+  - '@kbn/i18n-react'
+  - '@kbn/logging'
+  - '@kbn/user-profile-components'
+  - '@kbn/core-analytics-browser'
+  - '@kbn/core-http-browser'
+  - '@kbn/core-user-profile-browser'
+  - '@kbn/usage-collection-plugin'
 tags:
   - shared-browser
   - package

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/services/content_insights/content_insights_service.test.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/services/content_insights/content_insights_service.test.ts
@@ -12,33 +12,40 @@ import type { Logger } from '@kbn/logging';
 import { ContentInsightsClient } from '@kbn/content-management-content-insights-public';
 import { createContentInsightsService } from './content_insights_service';
 
-jest.mock('@kbn/content-management-content-insights-public', () => {
-  const actual = jest.requireActual('@kbn/content-management-content-insights-public');
-  return {
-    ...actual,
-    ContentInsightsClient: jest.fn().mockImplementation(function MockClient(this: unknown) {
-      Object.assign(this as object, { __isMock: true });
-    }),
-  };
-});
-
 describe('createContentInsightsService', () => {
-  const http = {} as HttpStart;
-  const logger = { get: jest.fn().mockReturnValue({ warn: jest.fn() }) } as unknown as Logger;
+  const http = {
+    get: jest.fn(),
+    post: jest.fn(),
+  } as unknown as jest.Mocked<HttpStart>;
+  const childLogger = { warn: jest.fn() };
+  const logger = {
+    get: jest.fn().mockReturnValue(childLogger),
+  } as unknown as jest.Mocked<Logger>;
 
   beforeEach(() => {
-    (ContentInsightsClient as unknown as jest.Mock).mockClear();
+    jest.clearAllMocks();
   });
 
-  it('instantiates `ContentInsightsClient` with the supplied core services and domain id', () => {
+  it('returns a real `ContentInsightsClient` configured for the supplied domain id', async () => {
+    http.post.mockResolvedValue(undefined);
+    http.get.mockResolvedValue({ result: { count: 7 } });
+
     const service = createContentInsightsService({
       http,
       logger,
       domainId: 'dashboard',
     });
 
-    expect(ContentInsightsClient).toHaveBeenCalledTimes(1);
-    expect(ContentInsightsClient).toHaveBeenCalledWith({ http, logger }, { domainId: 'dashboard' });
-    expect(service).toMatchObject({ __isMock: true });
+    service.track('dash-1', 'viewed');
+    await expect(service.getStats('dash-1', 'viewed')).resolves.toEqual({ count: 7 });
+
+    expect(service).toBeInstanceOf(ContentInsightsClient);
+    expect(logger.get).toHaveBeenCalledWith('content_insights_client');
+    expect(http.post).toHaveBeenCalledWith(
+      '/internal/content_management/insights/dashboard/dash-1/viewed'
+    );
+    expect(http.get).toHaveBeenCalledWith(
+      '/internal/content_management/insights/dashboard/dash-1/viewed/stats'
+    );
   });
 });

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/services/content_insights/content_insights_service.test.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/services/content_insights/content_insights_service.test.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { HttpStart } from '@kbn/core-http-browser';
+import type { Logger } from '@kbn/logging';
+import { ContentInsightsClient } from '@kbn/content-management-content-insights-public';
+import { createContentInsightsService } from './content_insights_service';
+
+jest.mock('@kbn/content-management-content-insights-public', () => {
+  const actual = jest.requireActual('@kbn/content-management-content-insights-public');
+  return {
+    ...actual,
+    ContentInsightsClient: jest.fn().mockImplementation(function MockClient(this: unknown) {
+      Object.assign(this as object, { __isMock: true });
+    }),
+  };
+});
+
+describe('createContentInsightsService', () => {
+  const http = {} as HttpStart;
+  const logger = { get: jest.fn().mockReturnValue({ warn: jest.fn() }) } as unknown as Logger;
+
+  beforeEach(() => {
+    (ContentInsightsClient as unknown as jest.Mock).mockClear();
+  });
+
+  it('instantiates `ContentInsightsClient` with the supplied core services and domain id', () => {
+    const service = createContentInsightsService({
+      http,
+      logger,
+      domainId: 'dashboard',
+    });
+
+    expect(ContentInsightsClient).toHaveBeenCalledTimes(1);
+    expect(ContentInsightsClient).toHaveBeenCalledWith({ http, logger }, { domainId: 'dashboard' });
+    expect(service).toMatchObject({ __isMock: true });
+  });
+});

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/services/content_insights/content_insights_service.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/services/content_insights/content_insights_service.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { HttpStart } from '@kbn/core-http-browser';
+import type { Logger } from '@kbn/logging';
+import {
+  ContentInsightsClient,
+  type ContentInsightsClientPublic,
+} from '@kbn/content-management-content-insights-public';
+
+/**
+ * Options for {@link createContentInsightsService}.
+ */
+export interface ContentInsightsServiceOptions {
+  /** Core HTTP service. */
+  http: HttpStart;
+  /** Logger used for warnings on tracking failures. */
+  logger: Logger;
+  /** Domain identifier (e.g. `'dashboard'`, `'visualization'`) used to scope insights. */
+  domainId: string;
+}
+
+/**
+ * Build a content-insights service for {@link SavedObjectActivityRow} from the
+ * standard core services.
+ *
+ * Returns the upstream {@link ContentInsightsClient} typed as
+ * {@link ContentInsightsClientPublic} so consumers can substitute their own
+ * implementation if needed.
+ *
+ * The returned service is intended for use with `<SavedObjectActivityRow>` —
+ * pass it as the component's `service` prop from `contentEditor.appendRows`.
+ *
+ * @example
+ * ```ts
+ * const insights = createContentInsightsService({
+ *   http: coreServices.http,
+ *   logger,
+ *   domainId: 'dashboard',
+ * });
+ * ```
+ */
+export const createContentInsightsService = ({
+  http,
+  logger,
+  domainId,
+}: ContentInsightsServiceOptions): ContentInsightsClientPublic =>
+  new ContentInsightsClient({ http, logger }, { domainId });

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/services/content_insights/index.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/services/content_insights/index.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export { createContentInsightsService } from './content_insights_service';
+export type { ContentInsightsServiceOptions } from './content_insights_service';
+export { SavedObjectActivityRow } from './saved_object_activity_row';
+export type { SavedObjectActivityRowProps } from './saved_object_activity_row';

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/services/content_insights/saved_object_activity_row.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/services/content_insights/saved_object_activity_row.test.tsx
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
+import type { ContentInsightsClientPublic } from '@kbn/content-management-content-insights-public';
+import type { UserContentCommonSchema } from '@kbn/content-management-table-list-view-common';
+import { SavedObjectActivityRow } from './saved_object_activity_row';
+
+jest.mock('@kbn/content-management-content-insights-public', () => ({
+  ContentInsightsProvider: ({
+    contentInsightsClient,
+    children,
+  }: {
+    contentInsightsClient: unknown;
+    children: React.ReactNode;
+  }) => (
+    <div
+      data-test-subj="contentInsightsProvider"
+      data-client-id={(contentInsightsClient as { id?: string })?.id ?? ''}
+    >
+      {children}
+    </div>
+  ),
+  ActivityView: ({ entityNamePlural }: { entityNamePlural?: string }) => (
+    <div data-test-subj="activityView">activity:{entityNamePlural}</div>
+  ),
+  ViewsStats: ({ item }: { item: { id: string } }) => (
+    <div data-test-subj="viewsStats">views:{item.id}</div>
+  ),
+}));
+
+describe('SavedObjectActivityRow', () => {
+  const service = { id: 'svc-1' } as unknown as ContentInsightsClientPublic;
+  const item = {
+    id: 'item-a',
+    type: 'dashboard',
+    references: [],
+    updatedAt: '2024-01-01',
+    attributes: { title: 'A' },
+  } as UserContentCommonSchema;
+
+  it('renders ActivityView and ViewsStats inside a ContentInsightsProvider seeded with the supplied service', () => {
+    render(
+      <IntlProvider locale="en">
+        <SavedObjectActivityRow service={service} item={item} entityNamePlural="dashboards" />
+      </IntlProvider>
+    );
+
+    const provider = screen.getByTestId('contentInsightsProvider');
+    expect(provider).toBeInTheDocument();
+    expect(provider.dataset.clientId).toBe('svc-1');
+    expect(screen.getByTestId('activityView')).toHaveTextContent('activity:dashboards');
+    expect(screen.getByTestId('viewsStats')).toHaveTextContent('views:item-a');
+  });
+});

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/services/content_insights/saved_object_activity_row.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/services/content_insights/saved_object_activity_row.tsx
@@ -1,0 +1,93 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import { EuiFormRow, EuiIconTip, EuiSpacer } from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n-react';
+import {
+  ActivityView,
+  ContentInsightsProvider,
+  ViewsStats,
+  type ContentInsightsClientPublic,
+} from '@kbn/content-management-content-insights-public';
+import type { UserContentCommonSchema } from '@kbn/content-management-table-list-view-common';
+
+/**
+ * Props for {@link SavedObjectActivityRow}.
+ */
+export interface SavedObjectActivityRowProps {
+  /**
+   * Content-insights client for this listing's domain (typically built with
+   * {@link createContentInsightsService}). Wrapped in a fresh
+   * `ContentInsightsProvider` so the component works inside the content
+   * editor flyout, which renders outside the listing's React tree.
+   */
+  service: ContentInsightsClientPublic;
+  /**
+   * The item being inspected. The row reads `createdBy`, `createdAt`,
+   * `updatedBy`, `updatedAt`, and `managed` for the activity card and uses
+   * `id` to fetch view stats.
+   */
+  item: UserContentCommonSchema;
+  /** Plural entity label used by the activity card's "no creator/updater" tip. */
+  entityNamePlural?: string;
+}
+
+/**
+ * Activity row for the content editor flyout — renders the shared
+ * `ActivityView` plus `ViewsStats` inside a `ContentInsightsProvider`.
+ *
+ * Drop into `contentEditor.appendRows`:
+ *
+ * ```tsx
+ * contentEditor={{
+ *   appendRows: (item) => (
+ *     <SavedObjectActivityRow service={insights} item={item} entityNamePlural="dashboards" />
+ *   ),
+ * }}
+ * ```
+ *
+ * Wraps a fresh provider on every mount because the flyout renders outside
+ * the listing's tree, so we cannot rely on a parent provider being in scope.
+ */
+export const SavedObjectActivityRow = ({
+  service,
+  item,
+  entityNamePlural,
+}: SavedObjectActivityRowProps) => (
+  <ContentInsightsProvider contentInsightsClient={service}>
+    <EuiFormRow
+      fullWidth
+      label={
+        <>
+          <FormattedMessage
+            id="contentListProviderClient.contentEditor.activityLabel"
+            defaultMessage="Activity"
+          />{' '}
+          <EuiIconTip
+            type="info"
+            iconProps={{ style: { verticalAlign: 'bottom' } }}
+            content={
+              <FormattedMessage
+                id="contentListProviderClient.contentEditor.activityLabelHelpText"
+                defaultMessage="Activity data is auto-generated and cannot be updated."
+              />
+            }
+          />
+        </>
+      }
+    >
+      <>
+        <ActivityView {...{ item, entityNamePlural }} />
+        <EuiSpacer size="s" />
+        <ViewsStats {...{ item }} />
+      </>
+    </EuiFormRow>
+  </ContentInsightsProvider>
+);

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/services/content_insights/saved_object_activity_row.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/services/content_insights/saved_object_activity_row.tsx
@@ -67,7 +67,7 @@ export const SavedObjectActivityRow = ({
       label={
         <>
           <FormattedMessage
-            id="contentListProviderClient.contentEditor.activityLabel"
+            id="contentManagement.contentListProviderClient.contentEditor.activityLabel"
             defaultMessage="Activity"
           />{' '}
           <EuiIconTip
@@ -75,7 +75,7 @@ export const SavedObjectActivityRow = ({
             iconProps={{ style: { verticalAlign: 'bottom' } }}
             content={
               <FormattedMessage
-                id="contentListProviderClient.contentEditor.activityLabelHelpText"
+                id="contentManagement.contentListProviderClient.contentEditor.activityLabelHelpText"
                 defaultMessage="Activity data is auto-generated and cannot be updated."
               />
             }

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/services/duplicate_title/duplicate_title_validator.test.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/services/duplicate_title/duplicate_title_validator.test.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { createDuplicateTitleValidator } from './duplicate_title_validator';
+
+describe('createDuplicateTitleValidator', () => {
+  it('bails (returns undefined) when called without an id', async () => {
+    const findCurrentTitle = jest.fn();
+    const checkForDuplicate = jest.fn();
+
+    const validator = createDuplicateTitleValidator({ findCurrentTitle, checkForDuplicate });
+
+    await expect(validator.fn('any', '')).resolves.toBeUndefined();
+    expect(findCurrentTitle).not.toHaveBeenCalled();
+    expect(checkForDuplicate).not.toHaveBeenCalled();
+  });
+
+  it('bails when `findCurrentTitle` returns `undefined` (item missing or in error state)', async () => {
+    const findCurrentTitle = jest.fn().mockResolvedValue(undefined);
+    const checkForDuplicate = jest.fn();
+
+    const validator = createDuplicateTitleValidator({ findCurrentTitle, checkForDuplicate });
+
+    await expect(validator.fn('new-title', 'id-1')).resolves.toBeUndefined();
+    expect(checkForDuplicate).not.toHaveBeenCalled();
+  });
+
+  it('returns the default warning string when `checkForDuplicate` resolves to `false`', async () => {
+    const findCurrentTitle = jest.fn().mockResolvedValue('Existing');
+    const checkForDuplicate = jest.fn().mockResolvedValue(false);
+
+    const validator = createDuplicateTitleValidator({ findCurrentTitle, checkForDuplicate });
+
+    await expect(validator.fn('Duplicate', 'id-1')).resolves.toBe(
+      'Saving "Duplicate" creates a duplicate title.'
+    );
+    expect(checkForDuplicate).toHaveBeenCalledWith({
+      id: 'id-1',
+      title: 'Duplicate',
+      lastSavedTitle: 'Existing',
+    });
+  });
+
+  it('returns the formatted warning when `checkForDuplicate` throws (alternative idiom)', async () => {
+    const findCurrentTitle = jest.fn().mockResolvedValue('Existing');
+    const checkForDuplicate = jest.fn().mockRejectedValue(new Error('boom'));
+
+    const validator = createDuplicateTitleValidator({
+      findCurrentTitle,
+      checkForDuplicate,
+      getDuplicateTitleWarning: (value) => `BAD: ${value}`,
+    });
+
+    await expect(validator.fn('Duplicate', 'id-1')).resolves.toBe('boom');
+    // Without an error message on the throw, falls back to the formatter.
+    const validator2 = createDuplicateTitleValidator({
+      findCurrentTitle,
+      checkForDuplicate: jest.fn().mockRejectedValue({}),
+      getDuplicateTitleWarning: (value) => `BAD: ${value}`,
+    });
+    await expect(validator2.fn('Duplicate', 'id-1')).resolves.toBe('BAD: Duplicate');
+  });
+
+  it('returns undefined when the title is unique (`checkForDuplicate` resolves true or void)', async () => {
+    const findCurrentTitle = jest.fn().mockResolvedValue('Existing');
+
+    const okTrue = createDuplicateTitleValidator({
+      findCurrentTitle,
+      checkForDuplicate: jest.fn().mockResolvedValue(true),
+    });
+    await expect(okTrue.fn('Unique', 'id-1')).resolves.toBeUndefined();
+
+    const okVoid = createDuplicateTitleValidator({
+      findCurrentTitle,
+      checkForDuplicate: jest.fn().mockResolvedValue(undefined),
+    });
+    await expect(okVoid.fn('Unique', 'id-1')).resolves.toBeUndefined();
+  });
+});

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/services/duplicate_title/duplicate_title_validator.test.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/services/duplicate_title/duplicate_title_validator.test.ts
@@ -50,21 +50,28 @@ describe('createDuplicateTitleValidator', () => {
   it('returns the formatted warning when `checkForDuplicate` throws (alternative idiom)', async () => {
     const findCurrentTitle = jest.fn().mockResolvedValue('Existing');
     const checkForDuplicate = jest.fn().mockRejectedValue(new Error('boom'));
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
 
-    const validator = createDuplicateTitleValidator({
-      findCurrentTitle,
-      checkForDuplicate,
-      getDuplicateTitleWarning: (value) => `BAD: ${value}`,
-    });
+    try {
+      const validator = createDuplicateTitleValidator({
+        findCurrentTitle,
+        checkForDuplicate,
+        getDuplicateTitleWarning: (value) => `BAD: ${value}`,
+      });
 
-    await expect(validator.fn('Duplicate', 'id-1')).resolves.toBe('boom');
-    // Without an error message on the throw, falls back to the formatter.
-    const validator2 = createDuplicateTitleValidator({
-      findCurrentTitle,
-      checkForDuplicate: jest.fn().mockRejectedValue({}),
-      getDuplicateTitleWarning: (value) => `BAD: ${value}`,
-    });
-    await expect(validator2.fn('Duplicate', 'id-1')).resolves.toBe('BAD: Duplicate');
+      await expect(validator.fn('Duplicate', 'id-1')).resolves.toBe('BAD: Duplicate');
+
+      // Without an error message on the throw, still falls back to the formatter.
+      const validator2 = createDuplicateTitleValidator({
+        findCurrentTitle,
+        checkForDuplicate: jest.fn().mockRejectedValue({}),
+        getDuplicateTitleWarning: (value) => `BAD: ${value}`,
+      });
+      await expect(validator2.fn('Duplicate', 'id-1')).resolves.toBe('BAD: Duplicate');
+      expect(warnSpy).toHaveBeenCalledTimes(2);
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 
   it('returns undefined when the title is unique (`checkForDuplicate` resolves true or void)', async () => {

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/services/duplicate_title/duplicate_title_validator.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/services/duplicate_title/duplicate_title_validator.ts
@@ -63,7 +63,8 @@ const defaultDuplicateTitleWarning = (value: string): string =>
  * Bails when `findCurrentTitle` returns `undefined` (item not found / in
  * error state — leave validation to the save handler). Otherwise calls
  * `checkForDuplicate` and converts a `false` resolution or thrown error into
- * the warning string returned by `getDuplicateTitleWarning`.
+ * the warning string returned by `getDuplicateTitleWarning`. Unexpected errors
+ * are logged to the console (dev only) and treated the same as a duplicate.
  *
  * @example
  * ```ts
@@ -111,9 +112,15 @@ export const createDuplicateTitleValidator = ({
       }
       return undefined;
     } catch (e) {
-      // Some upstream check functions throw on duplicate rather than
-      // returning `false`. Either way, surface the formatted warning.
-      return e?.message ?? getDuplicateTitleWarning(value);
+      // Some upstream check functions throw on duplicate rather than returning
+      // `false`. Always return the formatted warning so non-duplicate errors
+      // don't leak raw technical messages into the UI. Log unexpected errors
+      // in development so they don't silently disappear.
+      if (process.env.NODE_ENV !== 'production' && e?.message) {
+        // eslint-disable-next-line no-console
+        console.warn('[createDuplicateTitleValidator] unexpected error during title check:', e);
+      }
+      return getDuplicateTitleWarning(value);
     }
   },
 });

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/services/duplicate_title/duplicate_title_validator.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/services/duplicate_title/duplicate_title_validator.ts
@@ -50,7 +50,7 @@ export interface DuplicateTitleValidatorOptions {
 }
 
 const defaultDuplicateTitleWarning = (value: string): string =>
-  i18n.translate('contentListProviderClient.duplicateTitleValidator.warning', {
+  i18n.translate('contentManagement.contentListProviderClient.duplicateTitleValidator.warning', {
     defaultMessage: 'Saving "{value}" creates a duplicate title.',
     values: { value },
   });

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/services/duplicate_title/duplicate_title_validator.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/services/duplicate_title/duplicate_title_validator.ts
@@ -114,9 +114,9 @@ export const createDuplicateTitleValidator = ({
     } catch (e) {
       // Some upstream check functions throw on duplicate rather than returning
       // `false`. Always return the formatted warning so non-duplicate errors
-      // don't leak raw technical messages into the UI. Log unexpected errors
-      // in development so they don't silently disappear.
-      if (process.env.NODE_ENV !== 'production' && e?.message) {
+      // don't leak raw technical messages into the UI. Log any thrown value in
+      // development so failures are visible regardless of `message` shape.
+      if (process.env.NODE_ENV !== 'production') {
         // eslint-disable-next-line no-console
         console.warn('[createDuplicateTitleValidator] unexpected error during title check:', e);
       }

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/services/duplicate_title/duplicate_title_validator.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/services/duplicate_title/duplicate_title_validator.ts
@@ -1,0 +1,119 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { i18n } from '@kbn/i18n';
+
+/**
+ * Shape of a single entry in
+ * `OpenContentEditorParams['customValidators']['title']`.
+ *
+ * Re-declared locally to avoid importing the editor package's
+ * `OpenContentEditorParams` (its `customValidators` is typed as a record of
+ * arrays and would force the consumer to wrap this in another array).
+ */
+export interface TitleValidator {
+  type: 'warning' | 'error';
+  fn: (value: string, id: string) => Promise<string | undefined>;
+}
+
+/**
+ * Options for {@link createDuplicateTitleValidator}.
+ */
+export interface DuplicateTitleValidatorOptions {
+  /**
+   * Lookup callback returning the current saved title for the item identified
+   * by `id`, or `undefined` if the item cannot be found / is in an error
+   * state. Used as `lastSavedTitle` so the consumer's check can ignore
+   * "duplicates" against the item being edited.
+   */
+  findCurrentTitle: (id: string) => Promise<string | undefined>;
+  /**
+   * Returns `true` when the new title is valid (no duplicate exists). Throw
+   * or resolve to `false` when a duplicate is detected.
+   */
+  checkForDuplicate: (args: {
+    id: string;
+    title: string;
+    lastSavedTitle: string;
+  }) => Promise<boolean | void>;
+  /**
+   * Optional formatter for the warning message. Defaults to a generic
+   * "Saving \"{value}\" creates a duplicate title." string.
+   */
+  getDuplicateTitleWarning?: (value: string) => string;
+}
+
+const defaultDuplicateTitleWarning = (value: string): string =>
+  i18n.translate('contentListProviderClient.duplicateTitleValidator.warning', {
+    defaultMessage: 'Saving "{value}" creates a duplicate title.',
+    values: { value },
+  });
+
+/**
+ * Build a `customValidators.title` warning entry that flags duplicate titles
+ * during inline editing in the content editor flyout.
+ *
+ * Bails when called without an `id` (new items haven't been persisted yet).
+ * Bails when `findCurrentTitle` returns `undefined` (item not found / in
+ * error state — leave validation to the save handler). Otherwise calls
+ * `checkForDuplicate` and converts a `false` resolution or thrown error into
+ * the warning string returned by `getDuplicateTitleWarning`.
+ *
+ * @example
+ * ```ts
+ * const validator = createDuplicateTitleValidator({
+ *   findCurrentTitle: async (id) => {
+ *     const dashboard = await findService.findById(id);
+ *     return dashboard.status === 'error' ? undefined : dashboard.attributes.title;
+ *   },
+ *   checkForDuplicate: ({ title, lastSavedTitle }) =>
+ *     checkForDuplicateDashboardTitle({
+ *       title,
+ *       lastSavedTitle,
+ *       copyOnSave: false,
+ *       isTitleDuplicateConfirmed: false,
+ *     }),
+ *   getDuplicateTitleWarning: (value) =>
+ *     dashboardListingErrorStrings.getDuplicateTitleWarning(value),
+ * });
+ *
+ * <ContentListClientProvider
+ *   contentEditor={{ customValidators: { title: [validator] } }}
+ * />
+ * ```
+ */
+export const createDuplicateTitleValidator = ({
+  findCurrentTitle,
+  checkForDuplicate,
+  getDuplicateTitleWarning = defaultDuplicateTitleWarning,
+}: DuplicateTitleValidatorOptions): TitleValidator => ({
+  type: 'warning',
+  fn: async (value, id) => {
+    if (!id) {
+      return undefined;
+    }
+
+    const lastSavedTitle = await findCurrentTitle(id);
+    if (lastSavedTitle === undefined) {
+      return undefined;
+    }
+
+    try {
+      const ok = await checkForDuplicate({ id, title: value, lastSavedTitle });
+      if (ok === false) {
+        return getDuplicateTitleWarning(value);
+      }
+      return undefined;
+    } catch (e) {
+      // Some upstream check functions throw on duplicate rather than
+      // returning `false`. Either way, surface the formatted warning.
+      return e?.message ?? getDuplicateTitleWarning(value);
+    }
+  },
+});

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/services/duplicate_title/index.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/services/duplicate_title/index.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export { createDuplicateTitleValidator } from './duplicate_title_validator';
+export type { DuplicateTitleValidatorOptions, TitleValidator } from './duplicate_title_validator';

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/services/favorites/favorites_service.test.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/services/favorites/favorites_service.test.ts
@@ -10,29 +10,30 @@
 import type { HttpStart } from '@kbn/core-http-browser';
 import type { UserProfileServiceStart } from '@kbn/core-user-profile-browser';
 import type { UsageCollectionStart } from '@kbn/usage-collection-plugin/public';
+import { of } from 'rxjs';
 import { FavoritesClient } from '@kbn/content-management-favorites-public';
 import { createFavoritesService } from './favorites_service';
 
-jest.mock('@kbn/content-management-favorites-public', () => {
-  const actual = jest.requireActual('@kbn/content-management-favorites-public');
-  return {
-    ...actual,
-    FavoritesClient: jest.fn().mockImplementation(function MockFavoritesClient(this: unknown) {
-      Object.assign(this as object, { __isMock: true });
-    }),
-  };
-});
-
 describe('createFavoritesService', () => {
-  const http = {} as HttpStart;
-  const userProfile = {} as UserProfileServiceStart;
-  const usageCollection = {} as UsageCollectionStart;
+  const http = {
+    get: jest.fn(),
+    post: jest.fn(),
+  } as unknown as jest.Mocked<HttpStart>;
+  const userProfile = {
+    getEnabled$: jest.fn(),
+  } as unknown as jest.Mocked<UserProfileServiceStart>;
+  const usageCollection = {
+    reportUiCounter: jest.fn(),
+  } as unknown as jest.Mocked<UsageCollectionStart>;
 
   beforeEach(() => {
-    (FavoritesClient as unknown as jest.Mock).mockClear();
+    jest.clearAllMocks();
+    userProfile.getEnabled$.mockReturnValue(of(true));
   });
 
-  it('constructs a `FavoritesClient` with the supplied app id, saved object type, and core deps', () => {
+  it('returns a real `FavoritesClient` configured for the supplied favorite type', async () => {
+    http.get.mockResolvedValue({ favoriteIds: ['dash-1'], favoriteMetadata: {} });
+
     const service = createFavoritesService({
       appId: 'dashboards',
       savedObjectType: 'dashboard',
@@ -41,27 +42,73 @@ describe('createFavoritesService', () => {
       usageCollection,
     });
 
-    expect(FavoritesClient).toHaveBeenCalledTimes(1);
-    expect(FavoritesClient).toHaveBeenCalledWith('dashboards', 'dashboard', {
-      http,
-      userProfile,
-      usageCollection,
+    await expect(service.getFavorites()).resolves.toEqual({
+      favoriteIds: ['dash-1'],
+      favoriteMetadata: {},
     });
-    expect(service).toMatchObject({ __isMock: true });
+
+    expect(service).toBeInstanceOf(FavoritesClient);
+    expect(service.getFavoriteType()).toBe('dashboard');
+    expect(http.get).toHaveBeenCalledWith('/internal/content_management/favorites/dashboard');
   });
 
-  it('omits `usageCollection` when not supplied', () => {
-    createFavoritesService({
+  it('passes metadata through `addFavorite` and reports usage events', async () => {
+    http.post.mockResolvedValue({ favoriteIds: ['map-1'] });
+
+    const service = createFavoritesService<{ title: string }>({
       appId: 'maps',
       savedObjectType: 'map',
       http,
       userProfile,
+      usageCollection,
     });
 
-    expect(FavoritesClient).toHaveBeenCalledWith('maps', 'map', {
+    await expect(
+      service.addFavorite({ id: 'map-1', metadata: { title: 'Road trip' } })
+    ).resolves.toEqual({
+      favoriteIds: ['map-1'],
+    });
+    service.reportAddFavoriteClick();
+    service.reportRemoveFavoriteClick();
+
+    expect(http.post).toHaveBeenCalledWith(
+      '/internal/content_management/favorites/map/map-1/favorite',
+      { body: JSON.stringify({ metadata: { title: 'Road trip' } }) }
+    );
+    expect(usageCollection.reportUiCounter).toHaveBeenNthCalledWith(
+      1,
+      'maps',
+      'click',
+      'add_favorite'
+    );
+    expect(usageCollection.reportUiCounter).toHaveBeenNthCalledWith(
+      2,
+      'maps',
+      'click',
+      'remove_favorite'
+    );
+  });
+
+  it('does not report usage clicks when `usageCollection` is omitted', async () => {
+    http.get.mockResolvedValue({ favoriteIds: [], favoriteMetadata: {} });
+
+    const service = createFavoritesService({
+      appId: 'dashboards',
+      savedObjectType: 'dashboard',
       http,
       userProfile,
-      usageCollection: undefined,
     });
+
+    expect(() => {
+      service.reportAddFavoriteClick();
+      service.reportRemoveFavoriteClick();
+    }).not.toThrow();
+
+    await expect(service.getFavorites()).resolves.toEqual({
+      favoriteIds: [],
+      favoriteMetadata: {},
+    });
+
+    expect(usageCollection.reportUiCounter).not.toHaveBeenCalled();
   });
 });

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/services/favorites/favorites_service.test.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/services/favorites/favorites_service.test.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { HttpStart } from '@kbn/core-http-browser';
+import type { UserProfileServiceStart } from '@kbn/core-user-profile-browser';
+import type { UsageCollectionStart } from '@kbn/usage-collection-plugin/public';
+import { FavoritesClient } from '@kbn/content-management-favorites-public';
+import { createFavoritesService } from './favorites_service';
+
+jest.mock('@kbn/content-management-favorites-public', () => {
+  const actual = jest.requireActual('@kbn/content-management-favorites-public');
+  return {
+    ...actual,
+    FavoritesClient: jest.fn().mockImplementation(function MockFavoritesClient(this: unknown) {
+      Object.assign(this as object, { __isMock: true });
+    }),
+  };
+});
+
+describe('createFavoritesService', () => {
+  const http = {} as HttpStart;
+  const userProfile = {} as UserProfileServiceStart;
+  const usageCollection = {} as UsageCollectionStart;
+
+  beforeEach(() => {
+    (FavoritesClient as unknown as jest.Mock).mockClear();
+  });
+
+  it('constructs a `FavoritesClient` with the supplied app id, saved object type, and core deps', () => {
+    const service = createFavoritesService({
+      appId: 'dashboards',
+      savedObjectType: 'dashboard',
+      http,
+      userProfile,
+      usageCollection,
+    });
+
+    expect(FavoritesClient).toHaveBeenCalledTimes(1);
+    expect(FavoritesClient).toHaveBeenCalledWith('dashboards', 'dashboard', {
+      http,
+      userProfile,
+      usageCollection,
+    });
+    expect(service).toMatchObject({ __isMock: true });
+  });
+
+  it('omits `usageCollection` when not supplied', () => {
+    createFavoritesService({
+      appId: 'maps',
+      savedObjectType: 'map',
+      http,
+      userProfile,
+    });
+
+    expect(FavoritesClient).toHaveBeenCalledWith('maps', 'map', {
+      http,
+      userProfile,
+      usageCollection: undefined,
+    });
+  });
+});

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/services/favorites/favorites_service.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/services/favorites/favorites_service.ts
@@ -18,7 +18,7 @@ import {
 /**
  * Options for {@link createFavoritesService}.
  */
-export interface FavoritesServiceOptions<Metadata extends object | void = void> {
+export interface FavoritesServiceOptions {
   /**
    * Application identifier reported to the favorites usage collector
    * (e.g. `'dashboards'`, `'visualize'`).
@@ -59,7 +59,7 @@ export const createFavoritesService = <Metadata extends object | void = void>({
   http,
   userProfile,
   usageCollection,
-}: FavoritesServiceOptions<Metadata>): FavoritesClientPublic<Metadata> =>
+}: FavoritesServiceOptions): FavoritesClientPublic<Metadata> =>
   new FavoritesClient<Metadata>(appId, savedObjectType, {
     http,
     userProfile,

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/services/favorites/favorites_service.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/services/favorites/favorites_service.ts
@@ -32,12 +32,6 @@ export interface FavoritesServiceOptions<Metadata extends object | void = void> 
   userProfile: UserProfileServiceStart;
   /** Optional usage collection start, used to record click events. */
   usageCollection?: UsageCollectionStart;
-  /**
-   * Generic metadata phantom — pass when the upstream client is parameterized
-   * with metadata for `addFavorite`. Defaults to `void`, matching the most
-   * common case.
-   */
-  metadata?: Metadata;
 }
 
 /**
@@ -65,7 +59,7 @@ export const createFavoritesService = <Metadata extends object | void = void>({
   http,
   userProfile,
   usageCollection,
-}: Omit<FavoritesServiceOptions<Metadata>, 'metadata'>): FavoritesClientPublic<Metadata> =>
+}: FavoritesServiceOptions<Metadata>): FavoritesClientPublic<Metadata> =>
   new FavoritesClient<Metadata>(appId, savedObjectType, {
     http,
     userProfile,

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/services/favorites/favorites_service.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/services/favorites/favorites_service.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { HttpStart } from '@kbn/core-http-browser';
+import type { UserProfileServiceStart } from '@kbn/core-user-profile-browser';
+import type { UsageCollectionStart } from '@kbn/usage-collection-plugin/public';
+import {
+  FavoritesClient,
+  type FavoritesClientPublic,
+} from '@kbn/content-management-favorites-public';
+
+/**
+ * Options for {@link createFavoritesService}.
+ */
+export interface FavoritesServiceOptions<Metadata extends object | void = void> {
+  /**
+   * Application identifier reported to the favorites usage collector
+   * (e.g. `'dashboards'`, `'visualize'`).
+   */
+  appId: string;
+  /** Saved object type that owns the favorited items (e.g. `'dashboard'`). */
+  savedObjectType: string;
+  /** Core HTTP service. */
+  http: HttpStart;
+  /** Core user-profile service — required to gate per-user availability. */
+  userProfile: UserProfileServiceStart;
+  /** Optional usage collection start, used to record click events. */
+  usageCollection?: UsageCollectionStart;
+  /**
+   * Generic metadata phantom — pass when the upstream client is parameterized
+   * with metadata for `addFavorite`. Defaults to `void`, matching the most
+   * common case.
+   */
+  metadata?: Metadata;
+}
+
+/**
+ * Build a favorites service for `ContentListClientProvider`'s
+ * `services.favorites` slot from the standard core services.
+ *
+ * Returns the upstream {@link FavoritesClient} typed as
+ * {@link FavoritesClientPublic} so consumers can substitute their own
+ * implementation if needed.
+ *
+ * @example
+ * ```ts
+ * const favorites = createFavoritesService({
+ *   appId: 'dashboards',
+ *   savedObjectType: 'dashboard',
+ *   http: coreServices.http,
+ *   userProfile: coreServices.userProfile,
+ *   usageCollection: usageCollectionService,
+ * });
+ * ```
+ */
+export const createFavoritesService = <Metadata extends object | void = void>({
+  appId,
+  savedObjectType,
+  http,
+  userProfile,
+  usageCollection,
+}: Omit<FavoritesServiceOptions<Metadata>, 'metadata'>): FavoritesClientPublic<Metadata> =>
+  new FavoritesClient<Metadata>(appId, savedObjectType, {
+    http,
+    userProfile,
+    usageCollection,
+  });

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/services/favorites/index.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/services/favorites/index.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export { createFavoritesService } from './favorites_service';
+export type { FavoritesServiceOptions } from './favorites_service';

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/services/index.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/services/index.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+// Helpers for `services.tags`.
+export { createTagsService, type TagsApi } from './tags';
+
+// Helpers for `services.favorites`.
+export { createFavoritesService, type FavoritesServiceOptions } from './favorites';
+
+// Helpers for `services.userProfiles`.
+export { createUserProfilesService } from './user_profiles';
+
+// Helpers for `contentEditor.appendRows` (activity row).
+export {
+  createContentInsightsService,
+  type ContentInsightsServiceOptions,
+  SavedObjectActivityRow,
+  type SavedObjectActivityRowProps,
+} from './content_insights';
+
+// Helpers for `contentEditor.customValidators`.
+export {
+  createDuplicateTitleValidator,
+  type DuplicateTitleValidatorOptions,
+  type TitleValidator,
+} from './duplicate_title';
+
+// Helpers for `findItems` decoration + `features.flags` (recently-accessed).
+export {
+  useRecentlyAccessedDecoration,
+  type RecentlyAccessedDecoration,
+  type RecentDecoration,
+  type DecorableFindItemsResult,
+  RecentsFilterRenderer,
+  type RecentsFilterRendererProps,
+  type RecentlyAccessedEntry,
+  type RecentlyAccessedHistorySource,
+} from './recently_accessed';
+
+// Helpers for wrapping `findItems` / `onDelete` with EBT performance metrics.
+export { withPerformanceMetrics, type PerformanceMetricsOptions } from './performance_metrics';

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/services/performance_metrics/index.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/services/performance_metrics/index.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export { withPerformanceMetrics } from './with_performance_metrics';
+export type { PerformanceMetricsOptions } from './with_performance_metrics';

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/services/performance_metrics/with_performance_metrics.test.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/services/performance_metrics/with_performance_metrics.test.ts
@@ -1,0 +1,99 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { reportPerformanceMetricEvent } from '@kbn/ebt-tools';
+import type { AnalyticsServiceStart } from '@kbn/core-analytics-browser';
+import { withPerformanceMetrics } from './with_performance_metrics';
+
+jest.mock('@kbn/ebt-tools', () => ({
+  reportPerformanceMetricEvent: jest.fn(),
+}));
+
+describe('withPerformanceMetrics', () => {
+  const analytics = {} as AnalyticsServiceStart;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    let now = 0;
+    jest.spyOn(window.performance, 'now').mockImplementation(() => {
+      const value = now;
+      now += 250;
+      return value;
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("reports the wrapped call's elapsed duration with the supplied event name and saved object type", async () => {
+    const search = jest.fn().mockResolvedValue({ total: 0, hits: [] });
+
+    const wrapped = withPerformanceMetrics(search, {
+      analytics,
+      eventName: 'saved_object_loaded',
+      savedObjectType: 'dashboard',
+    });
+
+    await wrapped('query', { listingLimit: 100 });
+
+    expect(reportPerformanceMetricEvent).toHaveBeenCalledTimes(1);
+    expect(reportPerformanceMetricEvent).toHaveBeenCalledWith(analytics, {
+      eventName: 'saved_object_loaded',
+      duration: 250,
+      meta: { saved_object_type: 'dashboard' },
+    });
+  });
+
+  it('passes the wrapped function arguments through and returns its resolved value', async () => {
+    const result = { total: 1, hits: [{ id: 'a' }] };
+    const search = jest.fn().mockResolvedValue(result);
+
+    const wrapped = withPerformanceMetrics(search, {
+      analytics,
+      eventName: 'saved_object_loaded',
+      savedObjectType: 'dashboard',
+    });
+
+    await expect(wrapped('q', { listingLimit: 50 })).resolves.toBe(result);
+    expect(search).toHaveBeenCalledWith('q', { listingLimit: 50 });
+  });
+
+  it('merges per-call `meta` from the options callback into the EBT event', async () => {
+    const del = jest.fn().mockResolvedValue(undefined);
+
+    const wrapped = withPerformanceMetrics(del, {
+      analytics,
+      eventName: 'saved_object_deleted',
+      savedObjectType: 'dashboard',
+      meta: ([items]) => ({ total: (items as unknown[]).length }),
+    });
+
+    await wrapped([{ id: 'a' }, { id: 'b' }, { id: 'c' }]);
+
+    expect(reportPerformanceMetricEvent).toHaveBeenCalledWith(analytics, {
+      eventName: 'saved_object_deleted',
+      duration: 250,
+      meta: { saved_object_type: 'dashboard', total: 3 },
+    });
+  });
+
+  it('does not report when the wrapped function throws', async () => {
+    const search = jest.fn().mockRejectedValue(new Error('boom'));
+
+    const wrapped = withPerformanceMetrics(search, {
+      analytics,
+      eventName: 'saved_object_loaded',
+      savedObjectType: 'dashboard',
+    });
+
+    await expect(wrapped('q')).rejects.toThrow('boom');
+    expect(reportPerformanceMetricEvent).not.toHaveBeenCalled();
+  });
+});

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/services/performance_metrics/with_performance_metrics.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/services/performance_metrics/with_performance_metrics.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { AnalyticsServiceStart } from '@kbn/core-analytics-browser';
+import { reportPerformanceMetricEvent } from '@kbn/ebt-tools';
+
+/**
+ * Options accepted by {@link withPerformanceMetrics}.
+ */
+export interface PerformanceMetricsOptions {
+  /** Analytics service used to report the EBT event (typically `coreServices.analytics`). */
+  analytics: AnalyticsServiceStart;
+  /**
+   * EBT event name to report — see `SAVED_OBJECT_LOADED_TIME` /
+   * `SAVED_OBJECT_DELETE_TIME` in consumers.
+   */
+  eventName: string;
+  /** Saved object type, recorded as `meta.saved_object_type`. */
+  savedObjectType: string;
+  /**
+   * Extra metadata merged into the EBT event's `meta`. Useful for `total`
+   * counts on bulk operations.
+   */
+  meta?: (args: unknown[], result: unknown) => Record<string, unknown>;
+}
+
+/**
+ * Wrap a function (typically `findItems` or a bulk delete) so that each call
+ * reports a `reportPerformanceMetricEvent` with the elapsed `duration` in ms.
+ *
+ * The wrapped function's return value passes through unchanged. Errors
+ * propagate without reporting — the caller decides whether to count failed
+ * calls as observations.
+ *
+ * @example
+ * ```ts
+ * const search = withPerformanceMetrics(rawSearch, {
+ *   analytics: coreServices.analytics,
+ *   eventName: SAVED_OBJECT_LOADED_TIME,
+ *   savedObjectType: 'dashboard',
+ * });
+ * ```
+ *
+ * @example With per-call meta
+ * ```ts
+ * const deleteMany = withPerformanceMetrics(rawDelete, {
+ *   analytics,
+ *   eventName: SAVED_OBJECT_DELETE_TIME,
+ *   savedObjectType: 'dashboard',
+ *   meta: ([items]) => ({ total: items.length }),
+ * });
+ * ```
+ */
+export const withPerformanceMetrics = <Args extends unknown[], Result>(
+  fn: (...args: Args) => Promise<Result>,
+  { analytics, eventName, savedObjectType, meta }: PerformanceMetricsOptions
+): ((...args: Args) => Promise<Result>) => {
+  return async (...args: Args): Promise<Result> => {
+    const startTime = window.performance.now();
+    const result = await fn(...args);
+    const duration = window.performance.now() - startTime;
+
+    reportPerformanceMetricEvent(analytics, {
+      eventName,
+      duration,
+      meta: {
+        saved_object_type: savedObjectType,
+        ...(meta ? meta(args as unknown[], result) : {}),
+      },
+    });
+
+    return result;
+  };
+};

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/services/recently_accessed/index.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/services/recently_accessed/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export { useRecentlyAccessedDecoration } from './use_recently_accessed_decoration';
+export type {
+  RecentlyAccessedDecoration,
+  RecentDecoration,
+  DecorableFindItemsResult,
+} from './use_recently_accessed_decoration';
+export { RecentsFilterRenderer, type RecentsFilterRendererProps } from './recents_filter_renderer';
+export type { RecentlyAccessedEntry, RecentlyAccessedHistorySource } from './types';

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/services/recently_accessed/recents_filter_renderer.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/services/recently_accessed/recents_filter_renderer.test.tsx
@@ -1,0 +1,108 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Query } from '@elastic/eui';
+import { RecentsFilterRenderer } from './recents_filter_renderer';
+import type { RecentlyAccessedHistorySource } from './types';
+
+describe('RecentsFilterRenderer', () => {
+  const buildSource = (entries: Array<{ id: string }>): RecentlyAccessedHistorySource => ({
+    get: () => entries,
+  });
+
+  it('renders nothing when the recently-accessed source is empty', () => {
+    const { container } = render(
+      <RecentsFilterRenderer
+        service={buildSource([])}
+        query={Query.parse('')}
+        onChange={jest.fn()}
+      />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders the toggle button when the source has entries and uses the supplied label', () => {
+    render(
+      <RecentsFilterRenderer
+        service={buildSource([{ id: 'a' }])}
+        query={Query.parse('')}
+        onChange={jest.fn()}
+        label="Recents!"
+      />
+    );
+    expect(screen.getByRole('button', { name: 'Recents!' })).toBeInTheDocument();
+  });
+
+  it('renders as an unpressed toggle when the filter is inactive', () => {
+    render(
+      <RecentsFilterRenderer
+        service={buildSource([{ id: 'a' }])}
+        query={Query.parse('')}
+        onChange={jest.fn()}
+      />
+    );
+
+    // EUI's single-filter pattern (`isToggle` + `isSelected={active}`) is what
+    // gives the button its `aria-pressed` semantics — assert it directly so a
+    // future regression surfaces here rather than as a screen-reader-only bug.
+    expect(screen.getByRole('button')).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('renders as a pressed toggle when the filter is active', () => {
+    render(
+      <RecentsFilterRenderer
+        service={buildSource([{ id: 'a' }])}
+        query={Query.parse('is:recent')}
+        onChange={jest.fn()}
+      />
+    );
+
+    expect(screen.getByRole('button')).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('adds `is:recent` to the query on click when not yet active', () => {
+    const onChange = jest.fn();
+    render(
+      <RecentsFilterRenderer
+        service={buildSource([{ id: 'a' }])}
+        query={Query.parse('')}
+        onChange={onChange}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange.mock.calls[0][0].text).toContain('is:recent');
+  });
+
+  it('removes `is:recent` from the query on click when already active', () => {
+    const onChange = jest.fn();
+    render(
+      <RecentsFilterRenderer
+        service={buildSource([{ id: 'a' }])}
+        query={Query.parse('is:recent')}
+        onChange={onChange}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange.mock.calls[0][0].text).not.toContain('is:recent');
+  });
+
+  it('no-ops when query/onChange are not supplied (defensive)', () => {
+    expect(() =>
+      render(<RecentsFilterRenderer service={buildSource([{ id: 'a' }])} />)
+    ).not.toThrow();
+  });
+});

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/services/recently_accessed/recents_filter_renderer.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/services/recently_accessed/recents_filter_renderer.tsx
@@ -15,7 +15,7 @@ import type { RecentlyAccessedHistorySource } from './types';
 export const RECENT_FIELD = 'recent';
 
 const defaultLabel = i18n.translate(
-  'contentListProviderClient.recentlyAccessed.recentsFilter.label',
+  'contentManagement.contentListProviderClient.recentlyAccessed.recentsFilter.label',
   { defaultMessage: 'Recent' }
 );
 

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/services/recently_accessed/recents_filter_renderer.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/services/recently_accessed/recents_filter_renderer.tsx
@@ -1,0 +1,101 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React, { useCallback } from 'react';
+import { EuiFilterButton, type Query } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import type { RecentlyAccessedHistorySource } from './types';
+
+export const RECENT_FIELD = 'recent';
+
+const defaultLabel = i18n.translate(
+  'contentListProviderClient.recentlyAccessed.recentsFilter.label',
+  { defaultMessage: 'Recent' }
+);
+
+/**
+ * Props for {@link RecentsFilterRenderer}.
+ *
+ * `EuiSearchBar`'s `custom_component` filters receive `query` and `onChange`.
+ * The toolbar's `filter.createComponent` does not forward declarative
+ * attributes, so the recently-accessed source and label are bound via
+ * closure when the renderer is registered (see
+ * {@link useRecentlyAccessedDecoration}).
+ */
+export interface RecentsFilterRendererProps {
+  /** Query object from `EuiSearchBar`. */
+  query?: Query;
+  /** `onChange` callback from `EuiSearchBar`. */
+  onChange?: (query: Query) => void;
+  /**
+   * Recently-accessed source to read from. The renderer reads `.get()`
+   * synchronously to determine whether to show itself.
+   */
+  service: RecentlyAccessedHistorySource;
+  /** Optional label override. Defaults to "Recent". */
+  label?: string;
+  /** Optional `data-test-subj`. */
+  'data-test-subj'?: string;
+}
+
+/**
+ * Renders an `EuiFilterButton` that toggles `is:recent` in the
+ * `EuiSearchBar` query — visible only when the recently-accessed source has
+ * at least one entry.
+ *
+ * The companion `useRecentlyAccessedDecoration` hook builds a
+ * `filter.createComponent`-wrapped form of this renderer, so consumers
+ * normally do not import this directly.
+ */
+export const RecentsFilterRenderer = ({
+  query,
+  onChange,
+  service,
+  label = defaultLabel,
+  'data-test-subj': dataTestSubj = 'contentListRecentsRenderer',
+}: RecentsFilterRendererProps) => {
+  const active = query?.hasIsClause(RECENT_FIELD) ?? false;
+
+  const handleClick = useCallback(() => {
+    if (!query || !onChange) {
+      return;
+    }
+
+    const nextQuery = active
+      ? query.removeIsClause(RECENT_FIELD)
+      : query.addMustIsClause(RECENT_FIELD);
+
+    onChange(nextQuery);
+  }, [active, onChange, query]);
+
+  // Synchronous read — the source is local-storage backed and the renderer
+  // re-mounts each time the toolbar renders. Mirrors the legacy
+  // `hasRecentlyAccessedMetadata` heuristic from `TableListView`.
+  if (service.get().length === 0) {
+    return null;
+  }
+
+  // Uses EUI's "single filter" pattern (`isToggle` + `isSelected`) so the
+  // button renders with `aria-pressed={active}` semantics and the proper
+  // toggled visual state. `hasActiveFilters` adds EUI's existing
+  // active-highlight on top, matching the treatment used by the starred
+  // filter so both single-filter toggles look and behave the same way.
+  return (
+    <EuiFilterButton
+      isToggle
+      isSelected={active}
+      hasActiveFilters={active}
+      iconType="clockCounter"
+      onClick={handleClick}
+      data-test-subj={dataTestSubj}
+    >
+      {label}
+    </EuiFilterButton>
+  );
+};

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/services/recently_accessed/types.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/services/recently_accessed/types.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+/**
+ * Minimal entry shape needed to compute recency. Compatible with
+ * `RecentlyAccessedHistoryItem` from `@kbn/recently-accessed`.
+ */
+export interface RecentlyAccessedEntry {
+  id: string;
+}
+
+/**
+ * Minimal source contract — anything that can return a most-recent-first
+ * list of `{ id }` entries. Compatible with `RecentlyAccessed` from
+ * `@kbn/recently-accessed` (consumers typically pass that directly).
+ */
+export interface RecentlyAccessedHistorySource<
+  Entry extends RecentlyAccessedEntry = RecentlyAccessedEntry
+> {
+  /** Returns the current most-recent-first list of entries. */
+  get(): Entry[];
+}

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/services/recently_accessed/use_recently_accessed_decoration.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/services/recently_accessed/use_recently_accessed_decoration.test.tsx
@@ -1,0 +1,138 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import { renderHook } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import { useRecentlyAccessedDecoration } from './use_recently_accessed_decoration';
+import type { RecentlyAccessedHistorySource } from './types';
+import { RECENT_FIELD } from './recents_filter_renderer';
+
+// Simulate per-component resolver isolation: each `createComponent` call
+// returns a unique component whose `resolve` is closure-bound to that call.
+// This mirrors the fix in `@kbn/content-list-assembly` where resolvers are
+// keyed by component function rather than stored in a shared slot.
+jest.mock('@kbn/content-list-toolbar', () => ({
+  filter: {
+    createComponent: jest.fn((options?: { resolve?: () => { component: React.FC } }) => {
+      const resolve = options?.resolve;
+      const Component = (props: Record<string, unknown>) => {
+        if (!resolve) {
+          return null;
+        }
+        const { component: Inner } = resolve();
+        return <Inner {...props} />;
+      };
+      Component.displayName = 'MockRecentsFilter';
+      return Component;
+    }),
+  },
+}));
+
+describe('useRecentlyAccessedDecoration', () => {
+  const buildSource = (entries: Array<{ id: string }>): RecentlyAccessedHistorySource => ({
+    get: () => entries,
+  });
+
+  describe('decorate', () => {
+    it('decorates each hit with `recent`/`accessedAt` based on the source order', () => {
+      // Most-recent-first; index 0 is highest score.
+      const source = buildSource([{ id: 'b' }, { id: 'a' }]);
+
+      const { result } = renderHook(() => useRecentlyAccessedDecoration(source));
+
+      const decorated = result.current.decorate({
+        total: 3,
+        hits: [
+          { id: 'a', title: 'A' },
+          { id: 'b', title: 'B' },
+          { id: 'c', title: 'C' },
+        ],
+      });
+
+      expect(decorated.total).toBe(3);
+      expect(decorated.hits).toEqual([
+        { id: 'a', title: 'A', recent: true, accessedAt: 1 },
+        { id: 'b', title: 'B', recent: true, accessedAt: 2 },
+        { id: 'c', title: 'C', recent: false, accessedAt: 0 },
+      ]);
+    });
+
+    it('reads the source fresh on each `decorate` call so subsequent fetches see updates', () => {
+      const entries: Array<{ id: string }> = [];
+      const source: RecentlyAccessedHistorySource = { get: () => entries.slice() };
+
+      const { result } = renderHook(() => useRecentlyAccessedDecoration(source));
+
+      const first = result.current.decorate({ total: 1, hits: [{ id: 'a' }] });
+      expect(first.hits[0]).toMatchObject({ recent: false, accessedAt: 0 });
+
+      entries.push({ id: 'a' });
+      const second = result.current.decorate({ total: 1, hits: [{ id: 'a' }] });
+      expect(second.hits[0]).toMatchObject({ recent: true, accessedAt: 1 });
+    });
+  });
+
+  it('exposes the `flag` entry expected by `features.flags`', () => {
+    const { result } = renderHook(() => useRecentlyAccessedDecoration(buildSource([{ id: 'a' }])));
+    expect(result.current.flag).toEqual({ flagName: RECENT_FIELD, modelKey: 'recent' });
+  });
+
+  describe('RecentsFilter', () => {
+    it('hides itself when the bound source is empty', () => {
+      const source = buildSource([]);
+      const { result } = renderHook(() => useRecentlyAccessedDecoration(source));
+      const { RecentsFilter } = result.current;
+
+      const { container } = render(<RecentsFilter />);
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it('renders the toggle button when the bound source has entries', () => {
+      const source = buildSource([{ id: 'a' }]);
+      const { result } = renderHook(() => useRecentlyAccessedDecoration(source));
+      const { RecentsFilter } = result.current;
+
+      // Mocked `filter.createComponent` forwards props to the inner renderer;
+      // the inner renderer expects `query`/`onChange` from `EuiSearchBar`.
+      // We exercise the visibility branch only.
+      render(<RecentsFilter />);
+      expect(screen.getByRole('button')).toBeInTheDocument();
+    });
+  });
+
+  describe('RecentsFilter — per-source isolation (regression)', () => {
+    // Regression: the assembly's `customResolver` was a shared single slot.
+    // Calling `useRecentlyAccessedDecoration` with a second source overwrote
+    // the first resolver, so both RecentsFilter components would use the newest
+    // source. Verify that each hook invocation produces an independent filter
+    // component that is bound only to its own source.
+
+    it('each RecentsFilter uses its own source independently', () => {
+      const sourceA = buildSource([]);
+      const sourceB = buildSource([{ id: 'x' }]);
+
+      const { result: resultA } = renderHook(() => useRecentlyAccessedDecoration(sourceA));
+      const { result: resultB } = renderHook(() => useRecentlyAccessedDecoration(sourceB));
+
+      // The two RecentsFilter components must be different references because
+      // each `useRecentlyAccessedDecoration` call creates a fresh component
+      // via `filter.createComponent`.
+      expect(resultA.current.RecentsFilter).not.toBe(resultB.current.RecentsFilter);
+
+      // sourceA is empty → filter A hides itself.
+      const { container: containerA } = render(<resultA.current.RecentsFilter />);
+      expect(containerA).toBeEmptyDOMElement();
+
+      // sourceB has an entry → filter B renders the button.
+      render(<resultB.current.RecentsFilter />);
+      expect(screen.getByRole('button')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/services/recently_accessed/use_recently_accessed_decoration.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/services/recently_accessed/use_recently_accessed_decoration.tsx
@@ -1,0 +1,142 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React, { useMemo, type ComponentType } from 'react';
+import { filter } from '@kbn/content-list-toolbar';
+import { RecentsFilterRenderer, RECENT_FIELD } from './recents_filter_renderer';
+import type { RecentlyAccessedHistorySource } from './types';
+
+/**
+ * Minimal shape consumed by {@link RecentlyAccessedDecoration.decorate}.
+ *
+ * Defined locally rather than re-using `TableListViewFindItemsResult` so the
+ * decorator can stay generic over the consumer's hit type without forcing
+ * `TableListViewFindItemsResult` itself to become generic (which would be a
+ * breaking change for existing consumers).
+ */
+export interface DecorableFindItemsResult<Hit extends { id: string }> {
+  total: number;
+  hits: Hit[];
+}
+
+/**
+ * Decoration added to each hit by {@link RecentlyAccessedDecoration.decorate}.
+ * Consumers should extend their item type with these fields so
+ * `Column.UpdatedAt`-style sort fields and `is:recent` filtering work
+ * end-to-end.
+ *
+ * - `recent` powers the toolbar's `is:recent` filter via the strategy's
+ *   generic flag matcher (see `features.flags`).
+ * - `accessedAt` is a numeric score (`history.length - index`) that can drive
+ *   an opt-in "Recently viewed" sort field.
+ */
+export interface RecentDecoration {
+  /** True when the item appears in the recently-accessed history. */
+  recent: boolean;
+  /**
+   * Recency score — higher means more recently viewed. `0` for items not in
+   * the history. A `desc` sort on this field mirrors the legacy
+   * `sortByRecentlyAccessed` ordering.
+   */
+  accessedAt: number;
+}
+
+/**
+ * Result returned by {@link useRecentlyAccessedDecoration}.
+ */
+export interface RecentlyAccessedDecoration {
+  /**
+   * Decorate a `findItems` result with `recent`/`accessedAt` based on the
+   * supplied source. Reads the source synchronously at call time so each
+   * fetch picks up the latest history.
+   */
+  decorate: <Hit extends { id: string }>(
+    result: DecorableFindItemsResult<Hit>
+  ) => DecorableFindItemsResult<Hit & RecentDecoration>;
+  /**
+   * Flag entry to add to `features.flags` so `EuiSearchBar` parses
+   * `is:recent` into `filters.recent`.
+   */
+  flag: { flagName: string; modelKey: keyof RecentDecoration };
+  /**
+   * Declarative filter component for the toolbar's `<Filters>` slot. The
+   * underlying renderer is closure-bound to the supplied source, so consumers
+   * just `<recents.RecentsFilter />` without re-passing the service.
+   */
+  RecentsFilter: ComponentType<Record<never, never>>;
+}
+
+/**
+ * Build the recently-accessed integration for a saved-object listing in one
+ * call: a `findItems` decorator, the `features.flags` entry, and a
+ * toolbar-ready `RecentsFilter` component.
+ *
+ * The supplied `source` is closure-captured by the filter component, so
+ * consumers don't have to forward it themselves. Pass any `{ get(): { id }[] }`
+ * — typically a `RecentlyAccessed` from `@kbn/recently-accessed`.
+ *
+ * @example
+ * ```tsx
+ * const recents = useRecentlyAccessedDecoration(getDashboardRecentlyAccessedService());
+ *
+ * <ContentListClientProvider
+ *   findItems={async (q, opts) => recents.decorate(await rawSearch(q, opts))}
+ *   features={{ flags: [recents.flag] }}
+ * >
+ *   <ContentListToolbar>
+ *     <Filters>
+ *       <Filters.Starred />
+ *       <recents.RecentsFilter />
+ *       <Filters.Tags />
+ *     </Filters>
+ *   </ContentListToolbar>
+ * </ContentListClientProvider>
+ * ```
+ *
+ * The hook is stable across renders for a given `source` reference. When
+ * the source identity changes the bound `RecentsFilter` is rebuilt — pass a
+ * stable singleton (e.g. `getDashboardRecentlyAccessedService()`) in
+ * practice.
+ */
+export const useRecentlyAccessedDecoration = (
+  source: RecentlyAccessedHistorySource
+): RecentlyAccessedDecoration => {
+  const RecentsFilter = useMemo(
+    () =>
+      filter.createComponent<Record<never, never>>({
+        resolve: () => ({
+          type: 'custom_component',
+          component: (props) => <RecentsFilterRenderer {...props} service={source} />,
+        }),
+      }),
+    [source]
+  );
+
+  return useMemo<RecentlyAccessedDecoration>(
+    () => ({
+      decorate: (result) => {
+        const history = source.get();
+        const total = history.length;
+        const scoreById = new Map<string, number>(
+          history.map((entry, index) => [entry.id, total - index])
+        );
+
+        const hits = result.hits.map((hit) => {
+          const accessedAt = scoreById.get(hit.id) ?? 0;
+          return { ...hit, recent: accessedAt > 0, accessedAt };
+        });
+
+        return { ...result, hits };
+      },
+      flag: { flagName: RECENT_FIELD, modelKey: 'recent' },
+      RecentsFilter,
+    }),
+    [RecentsFilter, source]
+  );
+};

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/services/tags/index.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/services/tags/index.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export { createTagsService } from './tags_service';
+export type { TagsApi } from './tags_service';

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/services/tags/tags_service.test.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/services/tags/tags_service.test.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { Tag } from '@kbn/content-management-tags';
+import { createTagsService } from './tags_service';
+
+describe('createTagsService', () => {
+  const tags: Tag[] = [
+    { id: 'a', name: 'A', description: '', color: '#000', managed: false },
+    { id: 'b', name: 'B', description: '', color: '#fff', managed: false },
+  ];
+
+  it('returns a service whose `getTagList` proxies to the supplied tagging API', () => {
+    const getTagList = jest.fn().mockReturnValue(tags);
+
+    const service = createTagsService({ getTagList });
+
+    expect(service?.getTagList()).toBe(tags);
+    expect(getTagList).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns `undefined` when no tagging API is supplied', () => {
+    expect(createTagsService(undefined)).toBeUndefined();
+    expect(createTagsService(null)).toBeUndefined();
+  });
+});

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/services/tags/tags_service.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/services/tags/tags_service.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ContentManagementTagsServices, Tag } from '@kbn/content-management-tags';
+
+/**
+ * Minimal structural type describing the part of `SavedObjectsTaggingApiUi`
+ * needed to fill `services.tags`. Accepting a structural type rather than the
+ * full plugin interface keeps the helper usable from any consumer that can
+ * synthesize a `getTagList()` (e.g. Visualize's flattened tagging API).
+ */
+export interface TagsApi {
+  /** Synchronously return the list of available tags. */
+  getTagList: () => Tag[];
+}
+
+/**
+ * Build a {@link ContentManagementTagsServices} suitable for
+ * `ContentListClientProvider`'s `services.tags` slot from a tagging API.
+ *
+ * Pass `taggingApi.ui` from `SavedObjectsTaggingApi` (see
+ * `@kbn/saved-objects-tagging-oss-plugin/public`) directly:
+ *
+ * ```ts
+ * const tags = createTagsService(savedObjectsTagging.getTaggingApi()?.ui);
+ * ```
+ *
+ * Returns `undefined` when no API is supplied so callers can pass the result
+ * straight through without a guard:
+ *
+ * ```tsx
+ * <ContentListClientProvider services={{ ...core, tags: createTagsService(api) }} />
+ * ```
+ */
+export const createTagsService = (
+  taggingApi: TagsApi | null | undefined
+): ContentManagementTagsServices | undefined => {
+  if (!taggingApi) {
+    return undefined;
+  }
+  return { getTagList: () => taggingApi.getTagList() };
+};

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/services/user_profiles/index.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/services/user_profiles/index.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export { createUserProfilesService } from './user_profiles_service';

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/services/user_profiles/user_profiles_service.test.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/services/user_profiles/user_profiles_service.test.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { UserProfileServiceStart } from '@kbn/core-user-profile-browser';
+import { createUserProfilesService } from './user_profiles_service';
+
+describe('createUserProfilesService', () => {
+  const buildUserProfile = (userProfile: jest.Mock) =>
+    ({ bulkGet: userProfile } as unknown as UserProfileServiceStart);
+
+  it('short-circuits with an empty array when no uids are supplied', async () => {
+    const bulkGet = jest.fn();
+
+    const service = createUserProfilesService(buildUserProfile(bulkGet));
+
+    await expect(service.bulkResolve([])).resolves.toEqual([]);
+    expect(bulkGet).not.toHaveBeenCalled();
+  });
+
+  it('forwards the uids and `dataPath: "avatar"` to `bulkGet` and reshapes the response', async () => {
+    const avatar = { initials: 'AB', color: '#000' };
+    const bulkGet = jest.fn().mockResolvedValue([
+      {
+        uid: 'u1',
+        user: { username: 'alice', email: 'alice@example.com', full_name: 'Alice Smith' },
+        data: { avatar },
+      },
+      {
+        uid: 'u2',
+        user: { username: 'bob' },
+        data: undefined,
+      },
+    ]);
+
+    const service = createUserProfilesService(buildUserProfile(bulkGet));
+    const result = await service.bulkResolve(['u1', 'u2']);
+
+    expect(bulkGet).toHaveBeenCalledTimes(1);
+    const [params] = bulkGet.mock.calls[0];
+    expect(params.dataPath).toBe('avatar');
+    expect(params.uids).toBeInstanceOf(Set);
+    expect(Array.from(params.uids as Set<string>)).toEqual(['u1', 'u2']);
+
+    expect(result).toEqual([
+      {
+        uid: 'u1',
+        user: { username: 'alice', email: 'alice@example.com', full_name: 'Alice Smith' },
+        avatar,
+        email: 'alice@example.com',
+        fullName: 'Alice Smith',
+      },
+      {
+        uid: 'u2',
+        user: { username: 'bob' },
+        avatar: undefined,
+        email: '',
+        fullName: 'bob',
+      },
+    ]);
+  });
+});

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/services/user_profiles/user_profiles_service.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/services/user_profiles/user_profiles_service.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { UserProfileServiceStart } from '@kbn/core-user-profile-browser';
+import type { UserProfileAvatarData } from '@kbn/user-profile-components';
+import type { ContentListUserProfilesServices } from '@kbn/content-list-provider';
+
+/**
+ * Build a {@link ContentListUserProfilesServices} for
+ * `ContentListClientProvider`'s `services.userProfiles` slot from the core
+ * user-profile service.
+ *
+ * The factory wraps `userProfile.bulkGet({ uids, dataPath: 'avatar' })` and
+ * shapes each profile into the `UserProfileEntry` form used by the provider's
+ * `ProfileCache` (`{ uid, user, avatar, email, fullName }`).
+ *
+ * `email` is coalesced to `''` and `fullName` falls back to the username when
+ * unset, matching the convention used by the legacy `TableListView` user
+ * profile filter.
+ *
+ * Calls with an empty `uids` array short-circuit and return `[]` without
+ * issuing a request.
+ *
+ * @example
+ * ```ts
+ * const userProfiles = createUserProfilesService(coreServices.userProfile);
+ * ```
+ */
+export const createUserProfilesService = (
+  userProfile: UserProfileServiceStart
+): ContentListUserProfilesServices => ({
+  bulkResolve: async (uids: string[]) => {
+    if (uids.length === 0) {
+      return [];
+    }
+    const profiles = await userProfile.bulkGet<{
+      avatar?: UserProfileAvatarData;
+    }>({
+      uids: new Set(uids),
+      dataPath: 'avatar',
+    });
+    return profiles.map(({ uid, user, data }) => ({
+      uid,
+      user,
+      avatar: data?.avatar,
+      email: user.email ?? '',
+      fullName: user.full_name ?? user.username,
+    }));
+  },
+});

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/tsconfig.json
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/tsconfig.json
@@ -12,11 +12,21 @@
   ],
   "kbn_references": [
     "@kbn/content-list-provider",
+    "@kbn/content-list-toolbar",
     "@kbn/content-management-table-list-view-common",
     "@kbn/management-settings-ids",
     "@kbn/content-management-favorites-public",
     "@kbn/content-management-tags",
     "@kbn/content-management-content-editor",
-    "@kbn/i18n"
+    "@kbn/content-management-content-insights-public",
+    "@kbn/ebt-tools",
+    "@kbn/i18n",
+    "@kbn/i18n-react",
+    "@kbn/logging",
+    "@kbn/user-profile-components",
+    "@kbn/core-analytics-browser",
+    "@kbn/core-http-browser",
+    "@kbn/core-user-profile-browser",
+    "@kbn/usage-collection-plugin"
   ]
 }

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/action/inspect/inspect_action.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/action/inspect/inspect_action.test.tsx
@@ -63,12 +63,13 @@ describe('inspect action builder', () => {
       expect(result).toBeUndefined();
     });
 
-    it('generates a dynamic name including the item title', () => {
+    it('defaults to a terse "View details" label that ignores the item title', () => {
       const result = buildInspectAction({}, defaultContext);
       const item = { id: '1', title: 'My Dashboard' };
 
       const name = typeof result?.name === 'function' ? result.name(item) : result?.name;
-      expect(name).toContain('My Dashboard');
+      expect(name).toBe('View details');
+      expect(result?.description).toBe('View details');
     });
 
     it('calls onInspect when onClick is triggered', () => {

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/action/inspect/inspect_action.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/action/inspect/inspect_action.tsx
@@ -10,9 +10,17 @@
 import { i18n } from '@kbn/i18n';
 import type { InspectActionProps, ActionOutput, ActionBuilderContext } from '../types';
 
-/** Default i18n-translated description for the inspect action. */
-const DEFAULT_INSPECT_DESCRIPTION = i18n.translate(
-  'contentManagement.contentList.table.action.inspect.description',
+/**
+ * Default i18n-translated label for the inspect action.
+ *
+ * Used as both the `name` (visible text / aria-label) and `description`
+ * (tooltip) on the underlying `DefaultItemAction` so the action reads as
+ * a simple "View details" affordance rather than per-item phrasing like
+ * "View {itemTitle} details". Override with the `label` prop on
+ * `Action.Inspect` when an item-aware label is desired.
+ */
+const DEFAULT_INSPECT_LABEL = i18n.translate(
+  'contentManagement.contentList.table.action.inspect.label',
   { defaultMessage: 'View details' }
 );
 
@@ -34,18 +42,11 @@ export const buildInspectAction = (
   }
 
   const { onInspect } = context.itemConfig;
-
-  const label =
-    attributes.label ??
-    ((item) =>
-      i18n.translate('contentManagement.contentList.table.action.inspect.label', {
-        defaultMessage: 'View {itemTitle} details',
-        values: { itemTitle: item.title },
-      }));
+  const label = attributes.label ?? DEFAULT_INSPECT_LABEL;
 
   return {
     name: label,
-    description: DEFAULT_INSPECT_DESCRIPTION,
+    description: DEFAULT_INSPECT_LABEL,
     icon: 'inspect',
     type: 'icon',
     onClick: (item) => onInspect(item),

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/action/types.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/action/types.ts
@@ -94,6 +94,12 @@ export interface DeleteActionProps {
  * Props for the `Action.Inspect` preset component.
  */
 export interface InspectActionProps {
-  /** Custom label for the inspect action. Defaults to `'View {itemTitle} details'`. */
+  /**
+   * Custom label for the inspect action. Defaults to `'View details'`.
+   *
+   * Pass a function to derive the label from the item (e.g.
+   * `'View {itemTitle} details'`); the default deliberately omits the
+   * item title to keep the icon-button affordance terse.
+   */
   label?: string | ((item: ContentListItem) => ReactNode);
 }

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/index.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/index.ts
@@ -26,6 +26,11 @@ export {
   type TagFilterProps,
 } from './src/filters';
 
+// Toolbar `filter` part factory + context. Consumers use `filter.createComponent`
+// to register custom one-off filters (for shared presets, see `filterPart`
+// configuration in `./src/filters/part`).
+export { filter, type FilterContext } from './src/filters';
+
 // Selection bar component for direct imports.
 export { SelectionBar, type SelectionBarProps } from './src/selection_bar';
 

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/starred/starred_filter_renderer.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/starred/starred_filter_renderer.test.tsx
@@ -62,6 +62,32 @@ describe('StarredFilterRenderer', () => {
     expect(screen.getByText('Starred')).toBeInTheDocument();
   });
 
+  it('renders as an unpressed toggle when the filter is inactive', () => {
+    render(<StarredFilterRenderer query={Query.parse('')} />, {
+      wrapper: createWrapper({ favoritesService: mockFavoritesService }),
+    });
+
+    // EUI's single-filter pattern (`isToggle` + `isSelected={active}`) is what
+    // gives the button its `aria-pressed` semantics — assert it directly so a
+    // future regression surfaces here rather than as a screen-reader-only bug.
+    expect(screen.getByRole('button', { name: 'Starred' })).toHaveAttribute(
+      'aria-pressed',
+      'false'
+    );
+  });
+
+  it('renders as a pressed toggle when the filter is active', () => {
+    const activeQuery = Query.parse('').addMustIsClause('starred');
+    render(<StarredFilterRenderer query={activeQuery} />, {
+      wrapper: createWrapper({ favoritesService: mockFavoritesService }),
+    });
+
+    expect(screen.getByRole('button', { name: 'Starred' })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+  });
+
   it('renders nothing when the favorites service is not available', () => {
     const { container } = render(<StarredFilterRenderer query={Query.parse('')} />, {
       wrapper: createWrapper(),

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/starred/starred_filter_renderer.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/starred/starred_filter_renderer.test.tsx
@@ -82,10 +82,7 @@ describe('StarredFilterRenderer', () => {
       wrapper: createWrapper({ favoritesService: mockFavoritesService }),
     });
 
-    expect(screen.getByRole('button', { name: 'Starred' })).toHaveAttribute(
-      'aria-pressed',
-      'true'
-    );
+    expect(screen.getByRole('button', { name: 'Starred' })).toHaveAttribute('aria-pressed', 'true');
   });
 
   it('renders nothing when the favorites service is not available', () => {

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/starred/starred_filter_renderer.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/starred/starred_filter_renderer.tsx
@@ -68,10 +68,20 @@ export const StarredFilterRenderer = ({
     return null;
   }
 
+  // Uses EUI's "single filter" pattern (`isToggle` + `isSelected`) so the
+  // button renders with `aria-pressed={active}` semantics and the proper
+  // toggled visual state. `hasActiveFilters` adds EUI's existing
+  // active-highlight on top, matching the treatment used by the recents
+  // filter so both single-filter toggles look and behave the same way.
+  // The icon also swaps between `starFilled`/`starEmpty` to reinforce the
+  // toggled state visually — a luxury the recents filter does not have
+  // because EUI doesn't ship a paired filled/empty clock glyph.
   return (
     <EuiFilterButton
-      iconType={active ? 'starFilled' : 'starEmpty'}
+      isToggle
+      isSelected={active}
       hasActiveFilters={active}
+      iconType={active ? 'starFilled' : 'starEmpty'}
       onClick={handleClick}
       data-test-subj={dataTestSubj}
     >


### PR DESCRIPTION
## Summary

The Content List provider packages are intentionally kept free of Kibana-specific dependencies — they don't know about saved objects, tag services, user profiles, or favorites. This PR adds a service layer inside `@kbn/content-list-provider-client` that bridges those Kibana services to the provider's feature API.

Each service is a focused adapter:

| Service | What it does |
|---|---|
| `useTagsService` | Fetches tag metadata for the tags filter and name-column tag chips |
| `useUserProfilesService` | Resolves user profile avatars for the Created By column and filter |
| `useFavoritesService` | Wires the starred/favorites toggle to Kibana's favorites service |
| `useDuplicateTitleValidator` | Checks for duplicate titles during save/rename |
| `useContentInsightsService` | Fetches panel-count and other content metadata for the Dashboard migration |
| `useRecentlyAccessedDecoration` | Decorates `findItems` results with `recent`/`accessedAt` and provides the `RecentsFilter` toolbar component |
| `usePerformanceMetricsService` | Records fetch timing for observability |

Also included in this PR:

- **Content editor service wiring** — the inspect/edit action now receives the richer `ActionCallbackContext` so consumers can open the content editor flyout from the actions column.
- **Assembly resolver isolation fix** — `filter.createComponent` previously stored a single global resolver slot, so two mounted listings with different recently-accessed sources would overwrite each other's filter. Resolvers are now keyed per component reference using a `WeakMap`.

### What changed

- New service modules in `@kbn/content-list-provider-client/src/services/`: favorites, tags, user profiles, duplicate title, performance metrics, content insights, recently accessed.
- Content editor service access wired through the provider; inspect action updated to use `ActionCallbackContext`.
- `filter` re-exported from `@kbn/content-list-toolbar` for service-provided custom filters.
- `ParsedPart.componentType` added to `@kbn/content-list-assembly` to carry the component function reference through parsing.
- `customResolver` single slot replaced with `WeakMap<FC, resolver>` in the assembly factory.

## Stack

1. #266442 — Phase model
2. #266441 — Facade package
3. #266246 — Page shell + proposal stories
4. #266403 — Skeleton loading system
5. **This PR:** Saved object provider services
6. #266518 — Per-row selection gating via SelectionConfig
7. #267373 — Column sizing & full-width page layout
8. #267632 — URL persistence for query and sort state
9. #266519 — MS1.1: Migrate Graph Listing

## Validation

- `node scripts/check_changes.ts`
- `node scripts/type_check --project src/platform/packages/shared/content-management/content_list/kbn-content-list-assembly/tsconfig.json`
- `node scripts/type_check --project src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/tsconfig.json`
- `node scripts/jest src/platform/packages/shared/content-management/content_list/kbn-content-list-assembly/src/assembly.test.ts src/platform/packages/shared/content-management/content_list/kbn-content-list-assembly/src/parsing.test.ts`
- `node scripts/jest src/platform/packages/shared/content-management/content_list/kbn-content-list-provider-client/src/services/recently_accessed/use_recently_accessed_decoration.test.tsx`
