### PR TITLE
[Agent Builder] Exclude bedrock-claude-sonnet-3-7 from smoke tests

### DIFF
--- a/x-pack/platform/test/agent_builder/smoke_tests/tests/index.ts
+++ b/x-pack/platform/test/agent_builder/smoke_tests/tests/index.ts
@@ -14,13 +14,19 @@ import { getPreDiscoveredEisModels, enableCcm } from './eis_helpers';
 const EIS_CCM_API_KEY_ENV = 'KIBANA_EIS_CCM_API_KEY';
 const eisCcmApiKey = process.env[EIS_CCM_API_KEY_ENV];
 
+// Connector IDs present in the Vault blob but no longer reachable upstream.
+// Remove entries here once they're dropped from Vault.
+const EXCLUDED_STATIC_CONNECTOR_IDS = new Set<string>(['bedrock-claude-sonnet-3-7']);
+
 // eslint-disable-next-line import/no-default-export
 export default function (providerContext: FtrProviderContext) {
   const { getService } = providerContext;
   const log = getService('log');
   const es = getService('es');
 
-  const allStaticConnectors = getAvailableConnectors();
+  const allStaticConnectors = getAvailableConnectors().filter(
+    (c) => !EXCLUDED_STATIC_CONNECTOR_IDS.has(c.id)
+  );
   const sampledStaticConnectors = takeRandomLlmSample(allStaticConnectors);
   const allEisModels = getPreDiscoveredEisModels();
   const sampledEisModels = takeRandomLlmSample(allEisModels);


### PR DESCRIPTION
## Summary
- Filter `bedrock-claude-sonnet-3-7` out of the static connectors picked up by the agent builder smoke suite. The model has been retired upstream and the connector now returns 404 when sampled, e.g. `Static Preconfigured Connectors (from Vault) Connector: bedrock-claude-sonnet-3-7 returns an answer for a simple message: Error: expected 200 "OK", got 404 "Not Found"`.
- Workaround until the entry is dropped from the Vault blob (no in-repo metadata path exists today for static connectors — only EIS endpoints carry `metadata.heuristics.end_of_life_date`).
- Once the Vault entry is removed, delete the corresponding line from `EXCLUDED_STATIC_CONNECTOR_IDS`.

## Test plan
- [ ] CI: agent builder smoke tests pass without the 404 on `bedrock-claude-sonnet-3-7`
- [ ] Local sanity: `FTR_GEN_AI_LLM_SAMPLE_SIZE=all` runs of the smoke suite no longer hit the retired connector

🤖 Generated with [Claude Code](https://claude.com/claude-code)