### PR TITLE
[ML] Removing SPARKLINE from identify patterns recommended query

### DIFF
--- a/src/platform/packages/shared/kbn-esql-language/src/commands/registry/options/recommended_queries/index.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/registry/options/recommended_queries/index.ts
@@ -177,8 +177,8 @@ export const getRecommendedQueriesTemplates = ({
               }
             ),
             queryString: timeField
-              ? `${fromCommand} | WHERE ${timeField} <=?_tend and ${timeField} >?_tstart | SAMPLE .001 | STATS Count=COUNT(*)/.001, Sparkline=SPARKLINE(COUNT(*), ${timeField}, 40, ?_tstart, ?_tend) BY Pattern=CATEGORIZE(${categorizationField})| SORT Count DESC`
-              : `${fromCommand} | SAMPLE .001 | STATS Count=COUNT(*)/.001, Sparkline=SPARKLINE(COUNT(*), ${timeField}, 40, ?_tstart, ?_tend) BY Pattern=CATEGORIZE(${categorizationField})| SORT Count DESC`,
+              ? `${fromCommand} | WHERE ${timeField} <=?_tend and ${timeField} >?_tstart | SAMPLE .001 | STATS Count=COUNT(*)/.001 BY Pattern=CATEGORIZE(${categorizationField})| SORT Count DESC`
+              : `${fromCommand} | SAMPLE .001 | STATS Count=COUNT(*)/.001 BY Pattern=CATEGORIZE(${categorizationField})| SORT Count DESC`,
           },
         ]
       : []),


### PR DESCRIPTION
The SPARKLINE command isn't going to make it in for v9.4. So the recommended query for `Identify patterns` needs to be reverted to not use it.

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->