### PR TITLE
Fix: [Security Solution] [Bug] Attack Discovery shows internal date math string “now/w” for “This week” time range instead of readable date

### DIFF
--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/utils/get_attack_discovery_loading_message/index.test.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/utils/get_attack_discovery_loading_message/index.test.ts
@@ -11,6 +11,7 @@ import {
   AI_IS_CURRENTLY_ANALYZING,
   AI_IS_CURRENTLY_ANALYZING_FROM,
   AI_IS_CURRENTLY_ANALYZING_RANGE,
+  AI_IS_CURRENTLY_ANALYZING_THIS_WEEK,
 } from './translations';
 
 describe('getAttackDiscoveryLoadingMessage', () => {
@@ -38,6 +39,16 @@ describe('getAttackDiscoveryLoadingMessage', () => {
         end: '2025-01-02T00:00:00Z',
       })
     );
+  });
+
+  it('returns AI_IS_CURRENTLY_ANALYZING_THIS_WEEK when start is the beginning of this week', () => {
+    const result = getAttackDiscoveryLoadingMessage({
+      alertsCount: 10,
+      start: 'now/w',
+      end: DEFAULT_END,
+    });
+
+    expect(result).toBe(AI_IS_CURRENTLY_ANALYZING_THIS_WEEK(10));
   });
 
   it('returns AI_IS_CURRENTLY_ANALYZING_FROM when only start is provided', () => {

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/utils/get_attack_discovery_loading_message/index.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/utils/get_attack_discovery_loading_message/index.ts
@@ -8,6 +8,8 @@
 import { DEFAULT_END, DEFAULT_START } from '../../alerts/get_open_and_acknowledged_alerts_query';
 import * as i18n from './translations';
 
+const THIS_WEEK_START = 'now/w';
+
 export const getAttackDiscoveryLoadingMessage = ({
   alertsCount,
   end,
@@ -19,6 +21,10 @@ export const getAttackDiscoveryLoadingMessage = ({
 }): string => {
   if (start === DEFAULT_START && end === DEFAULT_END) {
     return i18n.AI_IS_CURRENTLY_ANALYZING(alertsCount);
+  }
+
+  if (start === THIS_WEEK_START && end === DEFAULT_END) {
+    return i18n.AI_IS_CURRENTLY_ANALYZING_THIS_WEEK(alertsCount);
   }
 
   if (end != null && start != null) {

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/utils/get_attack_discovery_loading_message/translations.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/utils/get_attack_discovery_loading_message/translations.ts
@@ -31,6 +31,15 @@ export const AI_IS_CURRENTLY_ANALYZING_FROM = ({
     }
   );
 
+export const AI_IS_CURRENTLY_ANALYZING_THIS_WEEK = (alertsCount: number) =>
+  i18n.translate(
+    'xpack.elasticAssistantCommon.attackDiscovery.getLoadingMessage.aiIsCurrentlyAnalyzingThisWeek',
+    {
+      defaultMessage: `AI is analyzing up to {alertsCount} {alertsCount, plural, =1 {alert} other {alerts}} from the start of the week to now to generate discoveries.`,
+      values: { alertsCount },
+    }
+  );
+
 export const AI_IS_CURRENTLY_ANALYZING_RANGE = ({
   alertsCount,
   end,

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/loading_callout/loading_messages/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/loading_callout/loading_messages/index.test.tsx
@@ -52,6 +52,24 @@ describe('LoadingMessages', () => {
     );
   });
 
+  it('renders a friendly loading message for the current week relative date range', () => {
+    render(
+      <TestProviders>
+        <LoadingMessages
+          alertsContextCount={20}
+          localStorageAttackDiscoveryMaxAlerts={'30'}
+          start={'now/w'}
+          end={'now'}
+        />
+      </TestProviders>
+    );
+    const aiCurrentlyAnalyzing = screen.getByTestId('aisCurrentlyAnalyzing');
+
+    expect(aiCurrentlyAnalyzing).toHaveTextContent(
+      'AI is analyzing up to 20 alerts from the start of the week to now to generate discoveries.'
+    );
+  });
+
   it('renders the expected loading message for an absolute date range', () => {
     render(
       <TestProviders>


### PR DESCRIPTION
## Summary

Addresses https://github.com/elastic/kibana/issues/243591

# Summary

- Updated the shared Attack Discovery loading message helper so the `This week` time range (`now/w` to `now`) renders as "from the start of the week to now" instead of exposing the internal date math string.
- Added focused coverage for the shared helper and Attack Discovery loading callout to prevent regressions in the banner text.

# Verification Steps

1. Start Kibana with Security Solution and Attack Discovery available, including any AI connector setup normally required to run Attack Discovery.
2. Navigate to Security > Attack discovery.
3. Open the time filter and select `This week`.
4. Click `Run` to start an Attack Discovery job.
5. Confirm the in-progress banner says the AI is analyzing alerts "from the start of the week to now" and does not show `now/w`.
6. Change the time filter to `Last 7 days`, run Attack Discovery again, and confirm the existing relative range message still appears as expected.


---

_PR developed with Cursor + GPT-5.5 1M Extra High_