### PR TITLE
Fix: [Security Solution] [Bug] In the non default space, the alerts are querying a non existing index on the attack discovery tab.

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detections/containers/detection_engine/alerts/use_signal_index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/containers/detection_engine/alerts/use_signal_index.test.tsx
@@ -15,12 +15,14 @@ import {
   signalIndexNameSelector,
   signalIndexOutdatedSelector,
 } from '../../../../data_view_manager/redux/selectors';
+import { useSpaceId } from '../../../../common/hooks/use_space_id';
 
 jest.mock('./api');
 jest.mock('../../../../common/hooks/use_app_toasts');
 jest.mock('../../../../common/components/user_privileges/endpoint/use_endpoint_privileges');
 jest.mock('../../../../timelines/components/timeline/tabs/esql');
 jest.mock('../../../../data_view_manager/redux/selectors');
+jest.mock('../../../../common/hooks/use_space_id');
 
 describe('useSignalIndex', () => {
   let appToastsMock: jest.Mocked<ReturnType<typeof useAppToastsMock.create>>;
@@ -29,6 +31,7 @@ describe('useSignalIndex', () => {
     jest.clearAllMocks();
     appToastsMock = useAppToastsMock.create();
     (useAppToasts as jest.Mock).mockReturnValue(appToastsMock);
+    jest.mocked(useSpaceId).mockReturnValue('default');
     jest.spyOn(sourcererSelectors, 'signalIndexName').mockReturnValue(null);
     jest.spyOn(sourcererSelectors, 'signalIndexMappingOutdated').mockReturnValue(null);
   });
@@ -156,11 +159,11 @@ describe('useSignalIndex', () => {
     const spyOnGetSignalIndex = jest.spyOn(api, 'getSignalIndex');
     jest
       .spyOn(sourcererSelectors, 'signalIndexName')
-      .mockReturnValue('mock-signal-index-from-sourcerer');
+      .mockReturnValue('.alerts-security.alerts-default');
     jest.spyOn(sourcererSelectors, 'signalIndexMappingOutdated').mockReturnValue(false);
     jest.spyOn(sourcererSelectors, 'signalIndexMappingOutdated').mockReturnValue(false);
     jest.mocked(signalIndexOutdatedSelector).mockReturnValue(false);
-    jest.mocked(signalIndexNameSelector).mockReturnValue('mock-signal-index-from-sourcerer');
+    jest.mocked(signalIndexNameSelector).mockReturnValue('.alerts-security.alerts-default');
 
     const { result } = renderHook(() => useSignalIndex(), {
       wrapper: TestProvidersWithPrivileges,
@@ -172,7 +175,36 @@ describe('useSignalIndex', () => {
         createDeSignalIndex: result.current.createDeSignalIndex,
         loading: false,
         signalIndexExists: true,
-        signalIndexName: 'mock-signal-index-from-sourcerer',
+        signalIndexName: '.alerts-security.alerts-default',
+        signalIndexMappingOutdated: false,
+      });
+    });
+  });
+
+  test('fetches alerts info when the cached signal index belongs to a different space', async () => {
+    const spyOnGetSignalIndex = jest.spyOn(api, 'getSignalIndex').mockResolvedValue({
+      name: '.alerts-security.alerts-custom-space',
+      index_mapping_outdated: false,
+    });
+    jest.mocked(useSpaceId).mockReturnValue('custom-space');
+    jest
+      .spyOn(sourcererSelectors, 'signalIndexName')
+      .mockReturnValue('.alerts-security.alerts-default');
+    jest.spyOn(sourcererSelectors, 'signalIndexMappingOutdated').mockReturnValue(false);
+    jest.mocked(signalIndexOutdatedSelector).mockReturnValue(false);
+    jest.mocked(signalIndexNameSelector).mockReturnValue('.alerts-security.alerts-default');
+
+    const { result } = renderHook(() => useSignalIndex(), {
+      wrapper: TestProvidersWithPrivileges,
+    });
+
+    await waitFor(() => {
+      expect(spyOnGetSignalIndex).toHaveBeenCalledTimes(1);
+      expect(result.current).toEqual({
+        createDeSignalIndex: result.current.createDeSignalIndex,
+        loading: false,
+        signalIndexExists: true,
+        signalIndexName: '.alerts-security.alerts-custom-space',
         signalIndexMappingOutdated: false,
       });
     });

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/containers/detection_engine/alerts/use_signal_index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/containers/detection_engine/alerts/use_signal_index.tsx
@@ -18,6 +18,8 @@ import * as i18n from './translations';
 import { useAlertsPrivileges } from './use_alerts_privileges';
 import { sourcererSelectors } from '../../../../common/store';
 import type { State } from '../../../../common/store';
+import { useSpaceId } from '../../../../common/hooks/use_space_id';
+import { getAlertsIndex } from '../../../../../common/entity_analytics/utils';
 
 type Func = () => Promise<void>;
 
@@ -42,6 +44,7 @@ export const useSignalIndex = (): ReturnSignalIndex => {
   });
   const { addError } = useAppToasts();
   const { hasIndexRead } = useAlertsPrivileges();
+  const spaceId = useSpaceId();
 
   const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
 
@@ -59,9 +62,15 @@ export const useSignalIndex = (): ReturnSignalIndex => {
   });
   const experimentalSignalIndexName = useSignalIndexName();
 
-  const signalIndexName = newDataViewPickerEnabled
+  const cachedSignalIndexName = newDataViewPickerEnabled
     ? experimentalSignalIndexName
     : oldSignalIndexName;
+  const signalIndexName =
+    cachedSignalIndexName != null &&
+    spaceId != null &&
+    cachedSignalIndexName === getAlertsIndex(spaceId)
+      ? cachedSignalIndexName
+      : null;
 
   useEffect(() => {
     let isSubscribed = true;


### PR DESCRIPTION
## Summary

Addresses https://github.com/elastic/kibana/issues/226127

## Summary

Updated the Security Solution signal index hook so cached alert index names are only reused when they match the active Kibana space. This prevents Attack Discovery settings from querying the default space alerts index after switching to a non-default space.

## Verification Steps

1. Start Kibana with Security Solution and Elastic AI Assistant available, then create a non-default space.
2. Switch to the non-default space and navigate to Security > Attack Discovery.
3. Open the Attack Discovery settings flyout.
4. Confirm the Alert summary and Alerts preview sections load without an index-not-found error and that network/ES|QL requests target `.alerts-security.alerts-<current-space-id>` instead of `.alerts-security.alerts-default`.


---

_PR developed with Cursor + GPT-5.5 1M Extra High_