### PR TITLE
Fix: [Security Solution] [Bug] The name of a few connectors is wrong in actions for the schedule Attack Discovery

### DIFF
--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/d3security/d3security.test.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/d3security/d3security.test.tsx
@@ -26,6 +26,7 @@ beforeAll(() => {
 describe('actionTypeRegistry.get() works', () => {
   test('action type static data is as expected', () => {
     expect(connectorTypeModel.id).toEqual(CONNECTOR_ID);
+    expect(connectorTypeModel.actionTypeTitle).toEqual('D3 Security');
   });
 });
 

--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/d3security/d3security.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/d3security/d3security.tsx
@@ -8,7 +8,11 @@
 import { lazy } from 'react';
 import { i18n } from '@kbn/i18n';
 import type { GenericValidationResult } from '@kbn/triggers-actions-ui-plugin/public/types';
-import { CONNECTOR_ID, SUB_ACTION } from '@kbn/connector-schemas/d3security/constants';
+import {
+  CONNECTOR_ID,
+  CONNECTOR_NAME,
+  SUB_ACTION,
+} from '@kbn/connector-schemas/d3security/constants';
 import type { D3SecurityActionParams, D3SecurityConnector } from './types';
 interface ValidationErrors {
   subAction: string[];
@@ -21,12 +25,7 @@ export function getConnectorType(): D3SecurityConnector {
     selectMessage: i18n.translate('xpack.stackConnectors.components.d3security.selectMessageText', {
       defaultMessage: 'Create event or trigger playbook workflow actions in D3 SOAR.',
     }),
-    actionTypeTitle: i18n.translate(
-      'xpack.stackConnectors.components.d3security.connectorTypeTitle',
-      {
-        defaultMessage: 'D3 data',
-      }
-    ),
+    actionTypeTitle: CONNECTOR_NAME,
     validateParams: async (
       actionParams: D3SecurityActionParams
     ): Promise<GenericValidationResult<ValidationErrors>> => {

--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/es_index/es_index.test.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/es_index/es_index.test.tsx
@@ -28,6 +28,7 @@ describe('connectorTypeRegistry.get() works', () => {
   test('connector type .index is registered', () => {
     expect(connectorTypeModel.id).toEqual(CONNECTOR_TYPE_ID);
     expect(connectorTypeModel.iconClass).toEqual('indexOpen');
+    expect(connectorTypeModel.actionTypeTitle).toEqual('Index');
   });
 });
 

--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/es_index/es_index.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/es_index/es_index.tsx
@@ -12,7 +12,7 @@ import type {
   GenericValidationResult,
 } from '@kbn/triggers-actions-ui-plugin/public';
 import { ALERT_HISTORY_PREFIX } from '@kbn/connector-schemas/es_index/constants';
-import { CONNECTOR_ID } from '@kbn/connector-schemas/es_index/constants';
+import { CONNECTOR_ID, CONNECTOR_NAME } from '@kbn/connector-schemas/es_index/constants';
 import type { EsIndexConfig, IndexActionParams } from '../types';
 
 export function getConnectorType(): ConnectorTypeModel<EsIndexConfig, unknown, IndexActionParams> {
@@ -22,9 +22,7 @@ export function getConnectorType(): ConnectorTypeModel<EsIndexConfig, unknown, I
     selectMessage: i18n.translate('xpack.stackConnectors.components.index.selectMessageText', {
       defaultMessage: 'Index data into Elasticsearch.',
     }),
-    actionTypeTitle: i18n.translate('xpack.stackConnectors.components.index.connectorTypeTitle', {
-      defaultMessage: 'Index data',
-    }),
+    actionTypeTitle: CONNECTOR_NAME,
     actionConnectorFields: lazy(() => import('./es_index_connector')),
     actionParamsFields: lazy(() => import('./es_index_params')),
     validateParams: async (

--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/pagerduty/pagerduty.test.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/pagerduty/pagerduty.test.tsx
@@ -27,7 +27,7 @@ beforeAll(() => {
 describe('connectorTypeRegistry.get() works', () => {
   test('connector type static data is as expected', () => {
     expect(connectorTypeModel.id).toEqual(CONNECTOR_TYPE_ID);
-    expect(connectorTypeModel.actionTypeTitle).toEqual('Send to PagerDuty');
+    expect(connectorTypeModel.actionTypeTitle).toEqual('PagerDuty');
   });
 });
 

--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/pagerduty/pagerduty.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/pagerduty/pagerduty.tsx
@@ -14,7 +14,7 @@ import type {
 } from '@kbn/triggers-actions-ui-plugin/public';
 import { AlertProvidedActionVariables } from '@kbn/triggers-actions-ui-plugin/public';
 import { isPlainObject } from 'lodash';
-import { CONNECTOR_ID } from '@kbn/connector-schemas/pagerduty/constants';
+import { CONNECTOR_ID, CONNECTOR_NAME } from '@kbn/connector-schemas/pagerduty/constants';
 import type { PagerDutyConfig, PagerDutySecrets, PagerDutyActionParams } from '../types';
 import { EventActionOptions } from '../types';
 import { hasMustacheTokens } from './has_mustache_tokens';
@@ -30,12 +30,7 @@ export function getConnectorType(): ConnectorTypeModel<
     selectMessage: i18n.translate('xpack.stackConnectors.components.pagerDuty.selectMessageText', {
       defaultMessage: 'Send an event in PagerDuty.',
     }),
-    actionTypeTitle: i18n.translate(
-      'xpack.stackConnectors.components.pagerDuty.connectorTypeTitle',
-      {
-        defaultMessage: 'Send to PagerDuty',
-      }
-    ),
+    actionTypeTitle: CONNECTOR_NAME,
     validateParams: async (
       actionParams: PagerDutyActionParams
     ): Promise<

--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/server_log/server_log.test.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/server_log/server_log.test.tsx
@@ -28,6 +28,7 @@ describe('connectorTypeRegistry.get() works', () => {
   test('connector type static data is as expected', () => {
     expect(connectorTypeModel.id).toEqual(CONNECTOR_TYPE_ID);
     expect(connectorTypeModel.iconClass).toEqual('logsApp');
+    expect(connectorTypeModel.actionTypeTitle).toEqual('Server log');
   });
 });
 

--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/server_log/server_log.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/server_log/server_log.tsx
@@ -11,7 +11,7 @@ import type {
   ActionTypeModel as ConnectorTypeModel,
   GenericValidationResult,
 } from '@kbn/triggers-actions-ui-plugin/public/types';
-import { CONNECTOR_ID } from '@kbn/connector-schemas/server_log/constants';
+import { CONNECTOR_ID, CONNECTOR_NAME } from '@kbn/connector-schemas/server_log/constants';
 import type { ServerLogActionParams } from '../types';
 
 export function getConnectorType(): ConnectorTypeModel<unknown, unknown, ServerLogActionParams> {
@@ -21,12 +21,7 @@ export function getConnectorType(): ConnectorTypeModel<unknown, unknown, ServerL
     selectMessage: i18n.translate('xpack.stackConnectors.components.serverLog.selectMessageText', {
       defaultMessage: 'Add a message to a Kibana log.',
     }),
-    actionTypeTitle: i18n.translate(
-      'xpack.stackConnectors.components.serverLog.connectorTypeTitle',
-      {
-        defaultMessage: 'Send to Server log',
-      }
-    ),
+    actionTypeTitle: CONNECTOR_NAME,
     validateParams: (
       actionParams: ServerLogActionParams
     ): Promise<GenericValidationResult<Pick<ServerLogActionParams, 'message'>>> => {

--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/swimlane/swimlane.test.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/swimlane/swimlane.test.tsx
@@ -27,6 +27,7 @@ beforeAll(() => {
 describe('connectorTypeRegistry.get() works', () => {
   test('connector type static data is as expected', () => {
     expect(connectorTypeModel.id).toEqual(CONNECTOR_ID);
+    expect(connectorTypeModel.actionTypeTitle).toEqual('Swimlane');
   });
 });
 

--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/swimlane/swimlane.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/swimlane/swimlane.tsx
@@ -11,7 +11,7 @@ import type {
   ActionTypeModel as ConnectorTypeModel,
   GenericValidationResult,
 } from '@kbn/triggers-actions-ui-plugin/public';
-import { CONNECTOR_ID } from '@kbn/connector-schemas/swimlane/constants';
+import { CONNECTOR_ID, CONNECTOR_NAME } from '@kbn/connector-schemas/swimlane/constants';
 import type { SwimlaneConfig, SwimlaneSecrets, SwimlaneActionParams } from './types';
 
 export const SW_SELECT_MESSAGE_TEXT = i18n.translate(
@@ -21,12 +21,7 @@ export const SW_SELECT_MESSAGE_TEXT = i18n.translate(
   }
 );
 
-export const SW_ACTION_TYPE_TITLE = i18n.translate(
-  'xpack.stackConnectors.components.swimlane.connectorTypeTitle',
-  {
-    defaultMessage: 'Create Swimlane Record',
-  }
-);
+export const SW_ACTION_TYPE_TITLE = CONNECTOR_NAME;
 
 export function getConnectorType(): ConnectorTypeModel<
   SwimlaneConfig,

--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/teams/teams.test.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/teams/teams.test.tsx
@@ -27,6 +27,7 @@ beforeAll(async () => {
 describe('connectorTypeRegistry.get() works', () => {
   test('connector type static data is as expected', () => {
     expect(connectorTypeModel.id).toEqual(CONNECTOR_TYPE_ID);
+    expect(connectorTypeModel.actionTypeTitle).toEqual('Microsoft Teams');
   });
 });
 

--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/teams/teams.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/teams/teams.tsx
@@ -11,7 +11,7 @@ import type {
   ActionTypeModel as ConnectorTypeModel,
   GenericValidationResult,
 } from '@kbn/triggers-actions-ui-plugin/public/types';
-import { CONNECTOR_ID } from '@kbn/connector-schemas/teams/constants';
+import { CONNECTOR_ID, CONNECTOR_NAME } from '@kbn/connector-schemas/teams/constants';
 import type { TeamsActionParams, TeamsSecrets } from '../types';
 
 export function getConnectorType(): ConnectorTypeModel<unknown, TeamsSecrets, TeamsActionParams> {
@@ -21,9 +21,7 @@ export function getConnectorType(): ConnectorTypeModel<unknown, TeamsSecrets, Te
     selectMessage: i18n.translate('xpack.stackConnectors.components.teams.selectMessageText', {
       defaultMessage: 'Send a message to a Microsoft Teams channel.',
     }),
-    actionTypeTitle: i18n.translate('xpack.stackConnectors.components.teams.connectorTypeTitle', {
-      defaultMessage: 'Send a message to a Microsoft Teams channel.',
-    }),
+    actionTypeTitle: CONNECTOR_NAME,
     validateParams: async (
       actionParams: TeamsActionParams
     ): Promise<GenericValidationResult<TeamsActionParams>> => {

--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/torq/torq.test.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/torq/torq.test.tsx
@@ -27,6 +27,7 @@ beforeAll(() => {
 describe('actionTypeRegistry.get() works', () => {
   test('action type static data is as expected', () => {
     expect(actionTypeModel.id).toEqual(CONNECTOR_ID);
+    expect(actionTypeModel.actionTypeTitle).toEqual('Torq');
   });
 });
 

--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/torq/torq.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/torq/torq.tsx
@@ -10,7 +10,7 @@ import type {
   GenericValidationResult,
 } from '@kbn/triggers-actions-ui-plugin/public/types';
 import { lazy } from 'react';
-import { CONNECTOR_ID } from '@kbn/connector-schemas/torq/constants';
+import { CONNECTOR_ID, CONNECTOR_NAME } from '@kbn/connector-schemas/torq/constants';
 import type { TorqActionParams, TorqConfig, TorqSecrets } from '../types';
 import * as i18n from './translations';
 
@@ -52,7 +52,7 @@ export function getActionType(): ActionTypeModel<TorqConfig, TorqSecrets, TorqAc
     id: CONNECTOR_ID,
     iconClass: lazy(() => import('./logo')),
     selectMessage: i18n.TORQ_SELECT_MESSAGE,
-    actionTypeTitle: i18n.TORQ_ACTION_TYPE_TITLE,
+    actionTypeTitle: CONNECTOR_NAME,
     validateParams,
     actionConnectorFields: lazy(() => import('./torq_connectors')),
     actionParamsFields: lazy(() => import('./torq_params')),

--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/torq/translations.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/torq/translations.ts
@@ -62,13 +62,6 @@ export const TORQ_SELECT_MESSAGE = i18n.translate(
   }
 );
 
-export const TORQ_ACTION_TYPE_TITLE = i18n.translate(
-  'xpack.stackConnectors.torqAction.actionTypeTitle',
-  {
-    defaultMessage: 'Alert data',
-  }
-);
-
 export const TORQ_TOKEN_HELP_TEXT = i18n.translate(
   'xpack.stackConnectors.torqAction.tokenHelpText',
   {

--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/webhook/webhook.test.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/webhook/webhook.test.tsx
@@ -29,6 +29,7 @@ describe('connectorTypeRegistry.get() works', () => {
   it('connector type static data is as expected', () => {
     expect(connectorTypeModel.id).toEqual(CONNECTOR_TYPE_ID);
     expect(connectorTypeModel.iconClass).toEqual('logoWebhook');
+    expect(connectorTypeModel.actionTypeTitle).toEqual('Webhook');
   });
 });
 

--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/webhook/webhook.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/webhook/webhook.tsx
@@ -12,7 +12,7 @@ import type {
   GenericValidationResult,
 } from '@kbn/triggers-actions-ui-plugin/public/types';
 import { WebhookMethods } from '@kbn/connector-schemas/common/auth/constants';
-import { CONNECTOR_ID } from '@kbn/connector-schemas/webhook/constants';
+import { CONNECTOR_ID, CONNECTOR_NAME } from '@kbn/connector-schemas/webhook/constants';
 import type { WebhookActionParams, WebhookConfig, WebhookSecrets } from '../types';
 import { formDeserializer, formSerializer } from '../lib/webhook/form_serialization';
 
@@ -27,9 +27,7 @@ export function getConnectorType(): ConnectorTypeModel<
     selectMessage: i18n.translate('xpack.stackConnectors.components.webhook.selectMessageText', {
       defaultMessage: 'Send a request to a web service.',
     }),
-    actionTypeTitle: i18n.translate('xpack.stackConnectors.components.webhook.connectorTypeTitle', {
-      defaultMessage: 'Webhook data',
-    }),
+    actionTypeTitle: CONNECTOR_NAME,
     validateParams: async (
       actionParams: WebhookActionParams,
       connectorConfig: WebhookConfig | null

--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/xmatters/xmatters.test.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/xmatters/xmatters.test.tsx
@@ -27,7 +27,7 @@ beforeAll(() => {
 describe('connectorTypeRegistry.get() works', () => {
   test('connector type static data is as expected', () => {
     expect(connectorTypeModel.id).toEqual(CONNECTOR_TYPE_ID);
-    expect(connectorTypeModel.actionTypeTitle).toEqual('xMatters data');
+    expect(connectorTypeModel.actionTypeTitle).toEqual('xMatters');
   });
 });
 

--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/xmatters/xmatters.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/xmatters/xmatters.tsx
@@ -12,7 +12,7 @@ import type {
   GenericValidationResult,
 } from '@kbn/triggers-actions-ui-plugin/public';
 import { AlertProvidedActionVariables } from '@kbn/triggers-actions-ui-plugin/public';
-import { CONNECTOR_ID } from '@kbn/connector-schemas/xmatters/constants';
+import { CONNECTOR_ID, CONNECTOR_NAME } from '@kbn/connector-schemas/xmatters/constants';
 import type { XmattersActionParams, XmattersConfig, XmattersSecrets } from '../types';
 
 export function getConnectorType(): ConnectorTypeModel<
@@ -26,12 +26,7 @@ export function getConnectorType(): ConnectorTypeModel<
     selectMessage: i18n.translate('xpack.stackConnectors.components.xmatters.selectMessageText', {
       defaultMessage: 'Trigger an xMatters workflow.',
     }),
-    actionTypeTitle: i18n.translate(
-      'xpack.stackConnectors.components.xmatters.connectorTypeTitle',
-      {
-        defaultMessage: 'xMatters data',
-      }
-    ),
+    actionTypeTitle: CONNECTOR_NAME,
     validateParams: async (
       actionParams: XmattersActionParams
     ): Promise<


### PR DESCRIPTION
## Summary

Addresses https://github.com/elastic/kibana/issues/222971

## Summary

Updated the shared Stack connector type models so the action connector picker displays canonical connector names instead of action descriptions for D3 Security, Index, Microsoft Teams, PagerDuty, Server log, Swimlane, Torq, Webhook, and xMatters. Added focused connector registry assertions to prevent these labels from regressing.

## Verification Steps

1. Start Kibana with Security Solution enabled and ensure endpoint alerts exist.
2. Navigate to Security > Attack Discovery.
3. Open the settings flyout, then select the Schedule tab.
4. In Actions, open the connector type picker.
5. Confirm the affected connector types are shown as D3 Security, Index, Microsoft Teams, PagerDuty, Server log, Swimlane, Torq, Webhook, and xMatters.


---

_PR developed with Cursor + GPT-5.5 1M Extra High_