### PR TITLE
Fix: [AI4SOC] [Bug] The count of total alerts is mismatched under the settings flyout for attack discovery if alerts have more than one tag

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/alert_selection/alert_summary_tab/get_alert_summary_esql_query/index.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/alert_selection/alert_summary_tab/get_alert_summary_esql_query/index.test.ts
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import { ALERT_RULE_TAGS, ALERT_WORKFLOW_TAGS } from '@kbn/rule-data-utils';
+
 import { getAlertSummaryEsqlQuery } from '.';
 
 describe('getAlertSummaryEsqlQuery', () => {
@@ -42,6 +44,37 @@ describe('getAlertSummaryEsqlQuery', () => {
 | STATS Count = count() by \`kibana.alert.severity\`
 | SORT Count DESC
 | KEEP \`kibana.alert.severity\`, Count\n`
+    );
+  });
+
+  it('converts alert workflow tags to a single value before counting', () => {
+    const query = getAlertSummaryEsqlQuery({
+      alertsIndexPattern: 'alerts-*',
+      maxAlerts: 100,
+      tableStackBy0: ALERT_WORKFLOW_TAGS,
+    });
+
+    expect(query).toBe(
+      `FROM alerts-* METADATA _id, _index, _version, _ignored
+| WHERE kibana.alert.workflow_status IN ("open", "acknowledged") AND kibana.alert.building_block_type IS NULL
+| SORT kibana.alert.risk_score DESC, @timestamp DESC
+| LIMIT 100
+| EVAL \`kibana.alert.workflow_tags\` = MV_CONCAT(MV_SORT(\`kibana.alert.workflow_tags\`), ", ")
+| STATS Count = count() by \`kibana.alert.workflow_tags\`
+| SORT Count DESC
+| KEEP \`kibana.alert.workflow_tags\`, Count\n`
+    );
+  });
+
+  it('converts rule tags to a single value before counting', () => {
+    const query = getAlertSummaryEsqlQuery({
+      alertsIndexPattern: 'alerts-*',
+      maxAlerts: 100,
+      tableStackBy0: ALERT_RULE_TAGS,
+    });
+
+    expect(query).toContain(
+      '| EVAL `kibana.alert.rule.tags` = MV_CONCAT(MV_SORT(`kibana.alert.rule.tags`), ", ")\n| STATS Count = count() by `kibana.alert.rule.tags`'
     );
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/alert_selection/alert_summary_tab/get_alert_summary_esql_query/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/alert_selection/alert_summary_tab/get_alert_summary_esql_query/index.ts
@@ -5,7 +5,17 @@
  * 2.0.
  */
 
+import { ALERT_RULE_TAGS, ALERT_WORKFLOW_TAGS } from '@kbn/rule-data-utils';
+
 import { getEsqlKeepStatement } from './get_esql_keep_statement';
+
+const TAG_FIELDS = new Set([ALERT_RULE_TAGS, ALERT_WORKFLOW_TAGS, 'tags']);
+
+const getSingleValueGroupingStatement = (tableStackBy0: string): string =>
+  TAG_FIELDS.has(tableStackBy0)
+    ? `| EVAL \`${tableStackBy0}\` = MV_CONCAT(MV_SORT(\`${tableStackBy0}\`), ", ")
+`
+    : '';
 
 export const getAlertSummaryEsqlQuery = ({
   alertsIndexPattern,
@@ -19,7 +29,7 @@ export const getAlertSummaryEsqlQuery = ({
 | WHERE kibana.alert.workflow_status IN ("open", "acknowledged") AND kibana.alert.building_block_type IS NULL
 | SORT kibana.alert.risk_score DESC, @timestamp DESC
 | LIMIT ${maxAlerts}
-| STATS Count = count() by \`${tableStackBy0}\`
+${getSingleValueGroupingStatement(tableStackBy0)}| STATS Count = count() by \`${tableStackBy0}\`
 | SORT Count DESC
 ${getEsqlKeepStatement(tableStackBy0)}
 `;


### PR DESCRIPTION
## Summary

Addresses https://github.com/elastic/kibana/issues/221227

## Summary

Fixed the Attack Discovery settings flyout alert summary query so alert tag fields are converted to a single grouped value before aggregation. This prevents alerts with multiple workflow or rule tags from being counted more than once in the summary total.

Important changed file:
- `x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/alert_selection/alert_summary_tab/get_alert_summary_esql_query/index.ts`

## Verification Steps

1. Use an AI4SOC Security Serverless environment with Attack Discovery enabled and an AI connector configured.
2. Ensure there are open or acknowledged security alerts in the selected time range, including at least one alert with two or more alert workflow tags.
3. Navigate to Security > Attack discovery, open the settings flyout, and stay on Alert selection > Alert summary.
4. Set the summary field to the alert tags field, such as `kibana.alert.workflow_tags`.
5. Confirm the total count in the alert summary matches the number of selected alerts to analyze and is not inflated by alerts that have multiple tags.
6. Repeat with `kibana.alert.rule.tags` if rule tags are present, and confirm the total remains consistent.


---

_PR developed with Cursor + GPT-5.5 1M Extra High_