### PR TITLE
Fix: [Security Solution] [Bug] The action names are not shown in the tooltip when user hovers on the actions provided for each parameter under the attack discovery tab

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_markdown_formatter/field_markdown_renderer/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_markdown_formatter/field_markdown_renderer/index.test.tsx
@@ -13,6 +13,21 @@ import { TestProviders } from '../../../../../common/mock';
 import { getFieldMarkdownRenderer } from '.';
 import { createExpandableFlyoutApiMock } from '../../../../../common/mock/expandable_flyout';
 
+jest.mock('@elastic/eui', () => {
+  const actual = jest.requireActual('@elastic/eui');
+  const ReactActual = jest.requireActual('react');
+
+  return {
+    ...actual,
+    EuiToolTip: jest.fn(({ children, content, 'data-test-subj': dataTestSubj }) =>
+      ReactActual.createElement(
+        'span',
+        { 'data-test-subj': dataTestSubj, 'data-tooltip-content': content },
+        children
+      )
+    ),
+  };
+});
 jest.mock('@kbn/expandable-flyout');
 
 describe('getFieldMarkdownRenderer', () => {
@@ -66,6 +81,21 @@ describe('getFieldMarkdownRenderer', () => {
     expect(mockOpenRightPanel).toHaveBeenCalledTimes(1);
   });
 
+  it('does NOT wrap interactive field actions with the field name tooltip', () => {
+    const FieldMarkdownRenderer = getFieldMarkdownRenderer(false);
+    const icon = 'user';
+    const name = 'user.name';
+    const value = 'some.user';
+
+    render(
+      <TestProviders>
+        <FieldMarkdownRenderer icon={icon} name={name} operator={':'} value={value} />
+      </TestProviders>
+    );
+
+    expect(screen.queryByTestId('fieldMarkdownRendererToolTip')).not.toBeInTheDocument();
+  });
+
   it('does NOT render the entity button when flyoutPanelProps is null', () => {
     const FieldMarkdownRenderer = getFieldMarkdownRenderer(false);
     const icon = '';
@@ -98,5 +128,9 @@ describe('getFieldMarkdownRenderer', () => {
     const disabledActionsBadge = screen.getByTestId('disabledActionsBadge');
 
     expect(disabledActionsBadge).toBeInTheDocument();
+    expect(screen.getByTestId('fieldMarkdownRendererToolTip')).toHaveAttribute(
+      'data-tooltip-content',
+      name
+    );
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_markdown_formatter/field_markdown_renderer/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_markdown_formatter/field_markdown_renderer/index.tsx
@@ -51,26 +51,24 @@ export const getFieldMarkdownRenderer = (disableActions: boolean, scopeId?: stri
       [euiTheme.font.scale.s, flyoutPanelProps, onEntityClick, value]
     );
 
-    return (
+    return disableActions ? (
       <EuiToolTip content={name} data-test-subj="fieldMarkdownRendererToolTip" position="top">
-        {disableActions ? (
-          <EuiBadge color="hollow" data-test-subj="disabledActionsBadge" iconType={icon}>
-            {value}
-          </EuiBadge>
-        ) : (
-          <DraggableBadge
-            contextId="fieldMarkdownRenderer"
-            scopeId={scopeId}
-            eventId=""
-            iconType={icon}
-            isAggregatable={false}
-            field={name}
-            value={value}
-          >
-            {entityButton}
-          </DraggableBadge>
-        )}
+        <EuiBadge color="hollow" data-test-subj="disabledActionsBadge" iconType={icon} tabIndex={0}>
+          {value}
+        </EuiBadge>
       </EuiToolTip>
+    ) : (
+      <DraggableBadge
+        contextId="fieldMarkdownRenderer"
+        scopeId={scopeId}
+        eventId=""
+        iconType={icon}
+        isAggregatable={false}
+        field={name}
+        value={value}
+      >
+        {entityButton}
+      </DraggableBadge>
     );
   };
 


### PR DESCRIPTION
## Summary

Addresses https://github.com/elastic/kibana/issues/214711

## Summary

Fixed Attack Discovery entity hover actions so their action tooltips display the action names instead of being masked by the field name tooltip. The key change is in `attack_discovery_markdown_formatter/field_markdown_renderer`, where interactive field badges are no longer wrapped by the field-name tooltip while non-interactive badges still keep that context.

## Verification Steps

1. Start Kibana with Security Solution enabled and configure an AI connector that can generate Attack Discoveries.
2. Navigate to Security > Attack Discovery and generate or open an Attack Discovery result that includes field-rendered entities such as `host.name` or `user.name`.
3. Hover an entity value to reveal its inline actions.
4. Hover each action icon and confirm the tooltip shows the action name, not the field name such as `host.name`.
5. Toggle "Show anonymized values" and confirm non-interactive anonymized badges still show the field name tooltip when hovered.


---

_PR developed with Cursor + GPT-5.5 1M Extra High_