### PR TITLE
[Synthetics] Drop nested Router from embeddable context

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/embeddables/synthetics_embeddable_context.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/embeddables/synthetics_embeddable_context.tsx
@@ -6,8 +6,6 @@
  */
 
 import React from 'react';
-import { createBrowserHistory } from 'history';
-import { Router } from '@kbn/shared-ux-router';
 import type { Subject } from 'rxjs';
 import type { Store } from 'redux';
 import { SyntheticsSharedContext } from '../synthetics/contexts/synthetics_shared_context';
@@ -26,11 +24,7 @@ export const SyntheticsEmbeddableContext: React.FC<
   return (
     <SyntheticsSharedContext {...props} reload$={reload$} reduxStore={reduxStore}>
       <SyntheticsEmbeddableStateContextProvider>
-        <Router history={createBrowserHistory()}>
-          <SyntheticsSettingsContextProvider {...props}>
-            {children}
-          </SyntheticsSettingsContextProvider>
-        </Router>
+        <SyntheticsSettingsContextProvider {...props}>{children}</SyntheticsSettingsContextProvider>
       </SyntheticsEmbeddableStateContextProvider>
     </SyntheticsSharedContext>
   );


### PR DESCRIPTION
## Summary

Closes #266421.

The Synthetics monitors-overview / stats-overview embeddables wrapped their content in a `<Router>` from `@kbn/shared-ux-router`. That wrapper internally renders a `CompatRouter` (and therefore a react-router v6 `<Router>`). Dashboards already mount inside the host app's Router, so this nested a second v6 Router.

[#248851](https://github.com/elastic/kibana/pull/248851) bumped `react-router-dom-v5-compat` from `6.12.0` → `6.30.3`. Newer react-router v6 added an `invariant(!useInRouterContext())` to its base `<Router>`, so adding a Synthetics overview panel now throws:

> Error: You cannot render a `<Router>` inside another `<Router>`. You should never have more than one in your app.

…the moment the panel tries to mount, leaving the panel stuck in an error state after the user fills out the configuration flyout.

This drops the inner Router wrapper from `SyntheticsEmbeddableContext`, matching the pattern other Kibana embeddables (SLO, etc.) already use — they wrap in `KibanaContextProvider` / plugin / theme / query providers but rely on the host dashboard's Router context. The embeddable internals only call v5 hooks (`useHistory`, `useLocation`); those remain backed by the dashboard's Router.

> Note: APM's embeddable wrapper ([apm/public/embeddable/embeddable_context.tsx](https://github.com/elastic/kibana/blob/main/x-pack/solutions/observability/plugins/apm/public/embeddable/embeddable_context.tsx)) uses `RouterProvider` from `@kbn/typed-react-router-config`, which also wraps in `@kbn/shared-ux-router`'s Router and is likely affected by the same regression. Worth a follow-up from the APM team.

## Test plan

- [ ] On a dashboard, *Add panel* → *Monitors overview*, fill out the flyout, click **Save** — panel renders without the Router error.
- [ ] Repeat for *Stats overview*.
- [ ] Saved-dashboard reload still renders both panels.
- [ ] Existing synthetics app routing (Monitors page, monitor detail) is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)