### PR TITLE
Fix: [Security Solution] [Bug] Non required Filter In/ Filter out options are available for the discovery response 

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_markdown_formatter/field_markdown_renderer/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_markdown_formatter/field_markdown_renderer/index.test.tsx
@@ -15,6 +15,17 @@ import { createExpandableFlyoutApiMock } from '../../../../../common/mock/expand
 
 jest.mock('@kbn/expandable-flyout');
 
+const mockDraggableBadge = jest.fn(
+  ({ children, value }: { children?: React.ReactNode; value?: string }) => (
+    <div data-test-subj="draggableBadge">{children ?? value}</div>
+  )
+);
+
+jest.mock('../../../../../common/components/draggables', () => ({
+  DraggableBadge: (props: { children?: React.ReactNode; value?: string }) =>
+    mockDraggableBadge(props),
+}));
+
 describe('getFieldMarkdownRenderer', () => {
   const mockOpenRightPanel = jest.fn();
   const mockUseExpandableFlyoutApi = useExpandableFlyoutApi as jest.MockedFunction<
@@ -98,5 +109,26 @@ describe('getFieldMarkdownRenderer', () => {
     const disabledActionsBadge = screen.getByTestId('disabledActionsBadge');
 
     expect(disabledActionsBadge).toBeInTheDocument();
+  });
+
+  it('hides filter actions on field badges', () => {
+    const FieldMarkdownRenderer = getFieldMarkdownRenderer(false);
+    const icon = 'user';
+    const name = 'user.name';
+    const value = 'some.user';
+
+    render(
+      <TestProviders>
+        <FieldMarkdownRenderer icon={icon} name={name} operator={':'} value={value} />
+      </TestProviders>
+    );
+
+    expect(mockDraggableBadge).toHaveBeenCalledWith(
+      expect.objectContaining({
+        field: name,
+        hideFilters: true,
+        value,
+      })
+    );
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_markdown_formatter/field_markdown_renderer/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_markdown_formatter/field_markdown_renderer/index.tsx
@@ -62,6 +62,7 @@ export const getFieldMarkdownRenderer = (disableActions: boolean, scopeId?: stri
             contextId="fieldMarkdownRenderer"
             scopeId={scopeId}
             eventId=""
+            hideFilters
             iconType={icon}
             isAggregatable={false}
             field={name}

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/cell_actions/cell_actions_renderer.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/cell_actions/cell_actions_renderer.test.tsx
@@ -218,6 +218,19 @@ describe('cell actions renderer', () => {
       });
     });
 
+    describe('when hideFilters is true', () => {
+      it('should set the disabledActionTypes to the SecurityCellActions component', () => {
+        render(
+          <CellActionsRenderer field={field} value={value} hideFilters>
+            {'test children'}
+          </CellActionsRenderer>
+        );
+        expect(MockSecurityCellActions).toHaveBeenCalledWith(
+          expect.objectContaining({ disabledActionTypes: ['security-cellAction-type-filter'] })
+        );
+      });
+    });
+
     scopeIdsWithHoverActions.forEach((scopeId) => {
       test(`it renders hover actions (by default) when scopeId is '${scopeId}'`, async () => {
         const { getByTestId } = render(

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/cell_actions/cell_actions_renderer.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/cell_actions/cell_actions_renderer.tsx
@@ -35,6 +35,7 @@ export const ProviderContentWrapper = styled.span`
 
 export interface CellActionsRendererProps {
   hideTopN?: boolean;
+  hideFilters?: boolean;
   field: string;
   value?: string | number | null;
   queryValue?: string | null;
@@ -81,12 +82,14 @@ Content.displayName = 'Content';
  * @param tooltipPosition - defaults to eui's default tooltip position
  * @param queryValue - defaults to `value`, this query overrides the `queryMatch.value` used by the `DataProvider` that represents the data
  * @param hideTopN - defaults to `false`, when true, the option to aggregate this field will be hidden
+ * @param hideFilters - defaults to `false`, when true, the options to filter for or filter out this field will be hidden
  * @param scopeId - the id of the scope, e.g. `timelineId` or `tableId`
  * @param truncate - defaults to `false`, when true, the content will be truncated
  */
 export const CellActionsRenderer = React.memo<CellActionsRendererProps>(
   ({
     hideTopN = false,
+    hideFilters = false,
     field,
     value,
     children,
@@ -111,10 +114,19 @@ export const CellActionsRenderer = React.memo<CellActionsRendererProps>(
       return { value: value || [], field };
     }, [value, field, queryValue]);
 
-    const disabledActionTypes = useMemo(
-      () => (hideTopN ? [SecurityCellActionType.SHOW_TOP_N] : []),
-      [hideTopN]
-    );
+    const disabledActionTypes = useMemo(() => {
+      const actionTypes: SecurityCellActionType[] = [];
+
+      if (hideTopN) {
+        actionTypes.push(SecurityCellActionType.SHOW_TOP_N);
+      }
+
+      if (hideFilters) {
+        actionTypes.push(SecurityCellActionType.FILTER);
+      }
+
+      return actionTypes;
+    }, [hideFilters, hideTopN]);
 
     const content = useMemo(
       () => (

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/draggables/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/draggables/index.tsx
@@ -51,6 +51,7 @@ const DraggableBadgeComponent: React.FC<BadgeType> = ({
   scopeId,
   tooltipContent,
   queryValue,
+  hideFilters,
 }) =>
   value != null ? (
     <CellActionsRenderer
@@ -59,6 +60,7 @@ const DraggableBadgeComponent: React.FC<BadgeType> = ({
       scopeId={scopeId}
       tooltipContent={tooltipContent}
       queryValue={queryValue}
+      hideFilters={hideFilters}
     >
       <Badge iconType={iconType} color="hollow" title="">
         {children ? children : value !== '' ? value : getEmptyStringTag()}


### PR DESCRIPTION
## Summary

Addresses https://github.com/elastic/kibana/issues/183119

## Summary

Attack Discovery markdown field badges now hide the filter in/filter out cell actions while keeping the rest of the badge interactions available. The change adds a `hideFilters` option to the shared `CellActionsRenderer`/`DraggableBadge` path and enables it for fields rendered inside `AttackDiscoveryMarkdownFormatter`.

## Verification Steps

1. Start Kibana with Security Solution and Attack Discovery available, with a GenAI connector configured for Attack Discovery generation.
2. Navigate to Security > Attack Discovery and generate attack discoveries, or open an existing generated discovery.
3. Hover over or open the actions for field badges in the summary/details response, such as host or user values.
4. Verify the filter in/filter out options are not shown for the Attack Discovery response fields.
5. Verify other intended interactions still work, such as opening host/user entity details from supported field badges and using the Investigate in timeline action.
6. Navigate to Security pages such as Alerts or Hosts and verify no filter was added from interacting with the Attack Discovery response fields.


---

_PR developed with Cursor + GPT-5.5 1M Extra High_