### PR TITLE
Fix: [Security Solution] [Bug] Bulk actions show option to mark alerts as Open, Close and Acknowledged unaware of its state on the Attack Discovery tab

### DIFF
--- a/x-pack/platform/packages/shared/response-ops/alerts-table/components/bulk_actions_toolbar_control.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerts-table/components/bulk_actions_toolbar_control.tsx
@@ -82,28 +82,32 @@ const useBulkActionsToMenuPanelMapper = (
     for (const panel of panels) {
       const selectedAlertItems = selectedIdsToTimelineItemMapper(alerts, rowSelection);
       if (panel.items) {
-        const newItems = panel.items.map((item) => {
-          const isDisabled = isAllSelected && item.disableOnQuery;
-          return {
-            key: item.key,
-            'data-test-subj': item['data-test-subj'],
-            disabled: isDisabled,
-            onClick: item.onClick
-              ? () => {
-                  closeIfPopoverIsOpen();
-                  item.onClick?.(
-                    selectedAlertItems,
-                    isAllSelected,
-                    setIsBulkActionsLoading,
-                    clearSelection,
-                    refresh
-                  );
-                }
-              : undefined,
-            name: isDisabled && item.disabledLabel ? item.disabledLabel : item.label,
-            panel: item.panel,
-          };
-        });
+        const newItems = panel.items
+          .filter((item) => {
+            return item.isVisible ? item.isVisible(selectedAlertItems, isAllSelected) : true;
+          })
+          .map((item) => {
+            const isDisabled = isAllSelected && item.disableOnQuery;
+            return {
+              key: item.key,
+              'data-test-subj': item['data-test-subj'],
+              disabled: isDisabled,
+              onClick: item.onClick
+                ? () => {
+                    closeIfPopoverIsOpen();
+                    item.onClick?.(
+                      selectedAlertItems,
+                      isAllSelected,
+                      setIsBulkActionsLoading,
+                      clearSelection,
+                      refresh
+                    );
+                  }
+                : undefined,
+              name: isDisabled && item.disabledLabel ? item.disabledLabel : item.label,
+              panel: item.panel,
+            };
+          });
         bulkActionPanelsToReturn.push({ ...panel, items: newItems });
       } else {
         const ContentPanel = panel.renderContent({

--- a/x-pack/platform/packages/shared/response-ops/alerts-table/reducers/bulk_actions_reducer.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerts-table/reducers/bulk_actions_reducer.test.tsx
@@ -389,6 +389,51 @@ describe('AlertsDataGrid bulk actions', () => {
       expect(await screen.findByTestId('bulk-actions-header')).toBeInTheDocument();
     });
 
+    it('should hide bulk action items when isVisible returns false for the selected alerts', async () => {
+      const mockVisiblePredicate = jest.fn(() => false);
+      const props: AlertsTableWithBulkActionsContextProps = {
+        ...dataGridPropsWithBulkActions,
+        initialBulkActionsState: {
+          ...createDefaultBulkActionsState(),
+          rowSelection: new Map([[0, { isLoading: false }]]),
+        },
+        additionalBulkActions: [
+          {
+            id: 0,
+            items: [
+              {
+                label: 'Visible Bulk Action',
+                key: 'visibleBulkAction',
+                'data-test-subj': 'visible-bulk-action',
+                disableOnQuery: false,
+                onClick: () => {},
+              },
+              {
+                label: 'Hidden Bulk Action',
+                key: 'hiddenBulkAction',
+                'data-test-subj': 'hidden-bulk-action',
+                disableOnQuery: false,
+                isVisible: mockVisiblePredicate,
+                onClick: () => {},
+              },
+            ],
+          },
+        ],
+      };
+
+      render(<TestComponent {...props} />);
+
+      await userEvent.click(await screen.findByTestId('selectedShowBulkActionsButton'));
+      await waitForEuiPopoverOpen();
+
+      expect(screen.getByText('Visible Bulk Action')).toBeInTheDocument();
+      expect(screen.queryByText('Hidden Bulk Action')).not.toBeInTheDocument();
+      expect(mockVisiblePredicate).toHaveBeenCalledWith(
+        expect.arrayContaining([expect.objectContaining({ _id: 'alert0' })]),
+        false
+      );
+    });
+
     describe('and triggering the "select all" action', () => {
       it('should check that all rows are selected', async () => {
         render(<TestComponent {...dataGridPropsWithBulkActions} />);

--- a/x-pack/platform/packages/shared/response-ops/alerts-table/types.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerts-table/types.ts
@@ -644,6 +644,7 @@ export interface BulkActionsConfig {
   'data-test-subj'?: string;
   disableOnQuery: boolean;
   disabledLabel?: string;
+  isVisible?: (selectedAlerts: TimelineItem[], isAllSelected: boolean) => boolean;
   onClick?: (
     selectedIds: TimelineItem[],
     isAllSelected: boolean,

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/take_action/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/take_action/index.test.tsx
@@ -291,7 +291,7 @@ describe('TakeAction', () => {
           markAsClosed: false,
         },
       },
-    ];
+    ] as const;
 
     it.each(workflowStatuses)(
       'renders correct actions for status $status (single alert selection)',
@@ -327,23 +327,76 @@ describe('TakeAction', () => {
   });
 
   describe('actions when multiple alerts are selected', () => {
-    const alerts = getMockAttackDiscoveryAlerts(); // <-- multiple alerts
-    const testCases = [
+    const workflowStatuses = [
       {
-        testId: 'markAsAcknowledged',
-        description: 'renders mark as acknowledged',
+        status: 'open',
+        expected: {
+          markAsOpen: false,
+          markAsAcknowledged: true,
+          markAsClosed: true,
+        },
       },
       {
-        testId: 'markAsClosed',
-        description: 'renders mark as closed',
+        status: 'acknowledged',
+        expected: {
+          markAsOpen: true,
+          markAsAcknowledged: false,
+          markAsClosed: true,
+        },
       },
       {
-        testId: 'markAsOpen',
-        description: 'renders mark as open',
+        status: 'closed',
+        expected: {
+          markAsOpen: true,
+          markAsAcknowledged: true,
+          markAsClosed: false,
+        },
       },
     ];
 
-    beforeEach(() => {
+    it.each(workflowStatuses)(
+      'renders correct actions when all selected alerts are $status',
+      ({ status, expected }) => {
+        const alerts = getMockAttackDiscoveryAlerts().map((alert) => ({
+          ...alert,
+          alertWorkflowStatus: status,
+        }));
+
+        render(
+          <TestProviders>
+            <TakeAction attackDiscoveries={alerts} setSelectedAttackDiscoveries={jest.fn()} />
+          </TestProviders>
+        );
+
+        openPopover();
+
+        if (expected.markAsOpen) {
+          expect(screen.getByTestId('markAsOpen')).toBeInTheDocument();
+        } else {
+          expect(screen.queryByTestId('markAsOpen')).toBeNull();
+        }
+
+        if (expected.markAsAcknowledged) {
+          expect(screen.getByTestId('markAsAcknowledged')).toBeInTheDocument();
+        } else {
+          expect(screen.queryByTestId('markAsAcknowledged')).toBeNull();
+        }
+
+        if (expected.markAsClosed) {
+          expect(screen.getByTestId('markAsClosed')).toBeInTheDocument();
+        } else {
+          expect(screen.queryByTestId('markAsClosed')).toBeNull();
+        }
+      }
+    );
+
+    it('renders all status actions when selected alerts have mixed statuses', () => {
+      const [firstAlert, secondAlert] = getMockAttackDiscoveryAlerts();
+      const alerts = [
+        { ...firstAlert, alertWorkflowStatus: 'open' as const },
+        { ...secondAlert, alertWorkflowStatus: 'closed' as const },
+      ];
+
       render(
         <TestProviders>
           <TakeAction attackDiscoveries={alerts} setSelectedAttackDiscoveries={jest.fn()} />
@@ -351,10 +404,10 @@ describe('TakeAction', () => {
       );
 
       openPopover();
-    });
 
-    it.each(testCases)('$description', ({ testId }) => {
-      expect(screen.getByTestId(testId)).toBeInTheDocument();
+      expect(screen.getByTestId('markAsOpen')).toBeInTheDocument();
+      expect(screen.getByTestId('markAsAcknowledged')).toBeInTheDocument();
+      expect(screen.getByTestId('markAsClosed')).toBeInTheDocument();
     });
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/take_action/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/take_action/index.tsx
@@ -40,6 +40,8 @@ import { useAttackDiscoveryAttachment } from '../use_attack_discovery_attachment
 import { useAlertsPrivileges } from '../../../../detections/containers/detection_engine/alerts/use_alerts_privileges';
 import { useAttackRunWorkflowContextMenuItems } from '../../../../detections/hooks/attacks/bulk_actions/context_menu_items/use_attack_run_workflow_context_menu_items';
 
+type WorkflowStatus = 'open' | 'acknowledged' | 'closed';
+
 interface Props {
   attackDiscoveries: AttackDiscovery[] | AttackDiscoveryAlert[];
   buttonText?: string;
@@ -49,6 +51,29 @@ interface Props {
   setSelectedAttackDiscoveries: React.Dispatch<React.SetStateAction<Record<string, boolean>>>;
 }
 
+const isWorkflowStatus = (status: string | null | undefined): status is WorkflowStatus =>
+  status === 'open' || status === 'acknowledged' || status === 'closed';
+
+const getSharedAlertWorkflowStatus = (
+  attackDiscoveries: AttackDiscovery[] | AttackDiscoveryAlert[]
+): WorkflowStatus | null => {
+  if (attackDiscoveries.length === 0) {
+    return null;
+  }
+
+  const statuses = attackDiscoveries.map((attackDiscovery) =>
+    isAttackDiscoveryAlert(attackDiscovery) ? attackDiscovery.alertWorkflowStatus : undefined
+  );
+
+  const [firstStatus] = statuses;
+
+  if (!isWorkflowStatus(firstStatus)) {
+    return null;
+  }
+
+  return statuses.every((status) => status === firstStatus) ? firstStatus : null;
+};
+
 const TakeActionComponent: React.FC<Props> = ({
   attackDiscoveries,
   buttonSize = 's',
@@ -57,9 +82,7 @@ const TakeActionComponent: React.FC<Props> = ({
   replacements,
   setSelectedAttackDiscoveries,
 }) => {
-  const [pendingAction, setPendingAction] = useState<'open' | 'acknowledged' | 'closed' | null>(
-    null
-  );
+  const [pendingAction, setPendingAction] = useState<WorkflowStatus | null>(null);
 
   const {
     services: { cases, evals },
@@ -129,7 +152,7 @@ const TakeActionComponent: React.FC<Props> = ({
       workflowStatus,
     }: {
       updateAlerts: boolean;
-      workflowStatus: 'open' | 'acknowledged' | 'closed';
+      workflowStatus: WorkflowStatus;
     }) => {
       setPendingAction(null);
 
@@ -162,7 +185,7 @@ const TakeActionComponent: React.FC<Props> = ({
   );
 
   const onUpdateWorkflowStatus = useCallback(
-    async (workflowStatus: 'open' | 'acknowledged' | 'closed') => {
+    async (workflowStatus: WorkflowStatus) => {
       closePopover();
 
       setPendingAction(workflowStatus);
@@ -306,12 +329,11 @@ const TakeActionComponent: React.FC<Props> = ({
 
   const allItems = useMemo(() => {
     const isSingleAttackDiscovery = attackDiscoveries.length === 1;
-    const firstAttackDiscovery = isSingleAttackDiscovery ? attackDiscoveries[0] : null;
-    const isAlert = firstAttackDiscovery != null && isAttackDiscoveryAlert(firstAttackDiscovery);
+    const sharedWorkflowStatus = getSharedAlertWorkflowStatus(attackDiscoveries);
 
-    const isOpen = isAlert && firstAttackDiscovery.alertWorkflowStatus === 'open';
-    const isAcknowledged = isAlert && firstAttackDiscovery.alertWorkflowStatus === 'acknowledged';
-    const isClosed = isAlert && firstAttackDiscovery.alertWorkflowStatus === 'closed';
+    const isOpen = sharedWorkflowStatus === 'open';
+    const isAcknowledged = sharedWorkflowStatus === 'acknowledged';
+    const isClosed = sharedWorkflowStatus === 'closed';
 
     const markAsOpenItem =
       !isOpen && hasAlertsUpdate
@@ -443,6 +465,7 @@ const TakeActionComponent: React.FC<Props> = ({
   return (
     <>
       <EuiPopover
+        aria-label={i18n.TAKE_ACTION}
         anchorPosition="downCenter"
         button={button}
         closePopover={closePopover}

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/trigger_actions_alert_table/use_alert_actions.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/trigger_actions_alert_table/use_alert_actions.test.tsx
@@ -8,8 +8,9 @@
 import { renderHook } from '@testing-library/react';
 import { useBulkAlertActionItems, type UseBulkAlertActionItemsArgs } from './use_alert_actions';
 import { TableId } from '@kbn/securitysolution-data-table';
+import { ALERT_WORKFLOW_STATUS } from '@kbn/rule-data-utils';
 import { useAppToasts } from '../../../common/hooks/use_app_toasts';
-import { FILTER_ACKNOWLEDGED, FILTER_OPEN } from '../../../../common/types';
+import { FILTER_ACKNOWLEDGED, FILTER_CLOSED, FILTER_OPEN } from '../../../../common/types';
 
 jest.mock('../../../common/hooks/use_app_toasts');
 jest.mock('../../containers/detection_engine/alerts/use_alerts_privileges', () => ({
@@ -35,6 +36,13 @@ function renderUseBulkAlertActionItems(props?: Partial<UseBulkAlertActionItemsAr
   );
 }
 
+const getSelectedAlert = (status: string) => ({
+  _id: `alert-${status}`,
+  _index: 'alerts-index',
+  data: [{ field: ALERT_WORKFLOW_STATUS, value: [status] }],
+  ecs: { _id: `alert-${status}`, _index: 'alerts-index' },
+});
+
 describe('useBulkAlertActionItems', () => {
   const { result } = renderUseBulkAlertActionItems();
 
@@ -51,6 +59,42 @@ describe('useBulkAlertActionItems', () => {
     });
     it('should include "Mark as closed"', () => {
       expect(items.find((item) => item.key === 'close-alert-with-reason')).not.toBeUndefined();
+    });
+  });
+
+  describe('item visibility', () => {
+    it.each([
+      { status: FILTER_OPEN, key: `${FILTER_OPEN}-alert-status` },
+      { status: FILTER_ACKNOWLEDGED, key: `${FILTER_ACKNOWLEDGED}-alert-status` },
+      { status: FILTER_CLOSED, key: 'close-alert-with-reason' },
+    ])('hides "$status" when all selected alerts already have that status', ({ status, key }) => {
+      const { result: hookResult } = renderUseBulkAlertActionItems();
+      const item = hookResult.current.items.find((action) => action.key === key);
+
+      expect(item?.isVisible?.([getSelectedAlert(status)], false)).toBe(false);
+    });
+
+    it('keeps status actions visible for mixed selected alert statuses', () => {
+      const { result: hookResult } = renderUseBulkAlertActionItems();
+      const openItem = hookResult.current.items.find(
+        (item) => item.key === `${FILTER_OPEN}-alert-status`
+      );
+
+      expect(
+        openItem?.isVisible?.(
+          [getSelectedAlert(FILTER_OPEN), getSelectedAlert(FILTER_CLOSED)],
+          false
+        )
+      ).toBe(true);
+    });
+
+    it('keeps status actions visible when all alerts are selected by query', () => {
+      const { result: hookResult } = renderUseBulkAlertActionItems();
+      const openItem = hookResult.current.items.find(
+        (item) => item.key === `${FILTER_OPEN}-alert-status`
+      );
+
+      expect(openItem?.isVisible?.([getSelectedAlert(FILTER_OPEN)], true)).toBe(true);
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/trigger_actions_alert_table/use_alert_actions.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/trigger_actions_alert_table/use_alert_actions.tsx
@@ -8,12 +8,14 @@
 import type {
   BulkActionsConfig,
   BulkActionsPanelConfig,
+  TimelineItem,
 } from '@kbn/response-ops-alerts-table/types';
 import { useCallback, useMemo } from 'react';
 import type { Filter } from '@kbn/es-query';
 import { buildEsQuery } from '@kbn/es-query';
 import type { TableId } from '@kbn/securitysolution-data-table';
 import { useBulkClosingReasonItems } from '@kbn/response-ops-detections-close-reason';
+import { ALERT_WORKFLOW_STATUS } from '@kbn/rule-data-utils';
 import type { AlertClosingReason } from '../../../../common/types';
 import { APM_USER_INTERACTIONS } from '../../../common/lib/apm/constants';
 import { updateAlertStatus } from '../../../common/components/toolbar/bulk_actions/update_alerts';
@@ -37,6 +39,23 @@ export interface UseBulkAlertActionItemsArgs {
   filters: Filter[];
   refetch?: () => void;
 }
+
+const getAlertWorkflowStatus = (alertItem: TimelineItem): AlertWorkflowStatus | undefined => {
+  const status = alertItem.data.find(({ field }) => field === ALERT_WORKFLOW_STATUS)?.value?.[0];
+
+  return status === FILTER_OPEN || status === FILTER_ACKNOWLEDGED || status === FILTER_CLOSED
+    ? (status as AlertWorkflowStatus)
+    : undefined;
+};
+
+const shouldShowStatusAction =
+  (status: AlertWorkflowStatus) => (selectedAlerts: TimelineItem[], isAllSelected: boolean) => {
+    if (isAllSelected || selectedAlerts.length === 0) {
+      return true;
+    }
+
+    return !selectedAlerts.every((alertItem) => getAlertWorkflowStatus(alertItem) === status);
+  };
 
 export const useBulkAlertActionItems = ({
   filters,
@@ -201,7 +220,12 @@ export const useBulkAlertActionItems = ({
           : i18n.BULK_ACTION_ACKNOWLEDGED_SELECTED;
 
       if (status === FILTER_CLOSED) {
-        return alertClosingReasonItem;
+        return alertClosingReasonItem
+          ? {
+              ...alertClosingReasonItem,
+              isVisible: shouldShowStatusAction(status),
+            }
+          : undefined;
       }
 
       return {
@@ -209,6 +233,7 @@ export const useBulkAlertActionItems = ({
         key: `${status}-alert-status`,
         'data-test-subj': `${status}-alert-status`,
         disableOnQuery: false,
+        isVisible: shouldShowStatusAction(status),
         onClick: getOnAction(status),
       };
     },


### PR DESCRIPTION
## Summary

Addresses https://github.com/elastic/kibana/issues/199425

## Summary

Updated the ResponseOps alerts table bulk-action menu so action items can hide themselves based on the currently selected alerts. Security Solution alert status bulk actions now use that visibility hook to hide "Mark as open", "Mark as acknowledged", or "Mark as closed" when every selected alert is already in that workflow state.

Also aligned the Attack Discovery take-action menu for multiple selected discoveries so it hides the current workflow status action when all selected discoveries share the same status.

## Verification Steps

1. In Kibana, configure an AI connector and ensure detection alerts exist.
2. Navigate to Security > Attack Discovery, generate attack discoveries, then open a generated discovery's Alerts tab.
3. Select multiple alerts that all have the same workflow status, such as `open`.
4. Open the "Selected n alerts" bulk-action menu and verify the action for the current status, such as "Mark as open", is not shown, while valid status changes remain available.
5. Change one selected alert to a different status, select alerts with mixed statuses, and verify the bulk menu still offers the available status transitions.


---

_PR developed with Cursor + GPT-5.5 1M Extra High_