### PR TITLE
Fix: [Security Solution] [Bug] Wrong tool tip text for Generate Button on Attack Discovery when RBAC privilege for Connectors is set to NONE

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/header/actions/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/header/actions/index.tsx
@@ -15,13 +15,20 @@ import { Schedule } from '../schedule';
 import { Settings } from '../settings';
 
 interface Props {
+  disabledTooltip?: React.ReactNode;
   isDisabled?: boolean;
   isLoading: boolean;
   onGenerate: (overrideOptions?: SettingsOverrideOptions) => Promise<void>;
   openFlyout: (tabId: string) => void;
 }
 
-const ActionsComponent: React.FC<Props> = ({ isLoading, onGenerate, openFlyout, isDisabled }) => {
+const ActionsComponent: React.FC<Props> = ({
+  disabledTooltip,
+  isLoading,
+  onGenerate,
+  openFlyout,
+  isDisabled,
+}) => {
   const { euiTheme } = useEuiTheme();
 
   const runSettingsGroup = css`
@@ -37,7 +44,12 @@ const ActionsComponent: React.FC<Props> = ({ isLoading, onGenerate, openFlyout, 
     <EuiFlexGroup alignItems="center" data-test-subj="actions" gutterSize="xs" responsive={false}>
       <EuiFlexItem grow={false}>
         <div css={runSettingsGroup}>
-          <Run isLoading={isLoading} isDisabled={isDisabled} onGenerate={onGenerate} />
+          <Run
+            disabledTooltip={disabledTooltip}
+            isLoading={isLoading}
+            isDisabled={isDisabled}
+            onGenerate={onGenerate}
+          />
           <Settings isLoading={isLoading} openFlyout={openFlyout} />
         </div>
       </EuiFlexItem>

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/header/run/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/header/run/index.test.tsx
@@ -47,6 +47,18 @@ describe('Run', () => {
     });
   });
 
+  it('renders a custom disabled tooltip when provided', async () => {
+    render(
+      <Run {...defaultProps} disabledTooltip="Missing connector privileges" isDisabled={true} />
+    );
+
+    fireEvent.mouseOver(screen.getByTestId('run'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('runTooltip')).toHaveTextContent('Missing connector privileges');
+    });
+  });
+
   it('disables the button when isLoading is true', () => {
     render(<Run {...defaultProps} isLoading={true} />);
 

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/header/run/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/header/run/index.tsx
@@ -13,6 +13,7 @@ import type { SettingsOverrideOptions } from '../../results/history/types';
 import * as i18n from './translations';
 
 interface Props {
+  disabledTooltip?: React.ReactNode;
   isLoading: boolean;
   onGenerate: (overrideOptions?: SettingsOverrideOptions) => Promise<void>;
   isDisabled?: boolean;
@@ -25,9 +26,9 @@ const runButtonStyles = css`
   width: 74px;
 `;
 
-const RunComponent: React.FC<Props> = ({ isLoading, onGenerate, isDisabled }) => (
+const RunComponent: React.FC<Props> = ({ disabledTooltip, isLoading, onGenerate, isDisabled }) => (
   <EuiToolTip
-    content={isDisabled ? i18n.DISABLED_TOOLTIP : i18n.RUN_TOOLTIP}
+    content={isDisabled ? disabledTooltip ?? i18n.DISABLED_TOOLTIP : i18n.RUN_TOOLTIP}
     data-test-subj="runTooltip"
     position="bottom"
   >

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/header/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/header/translations.ts
@@ -27,3 +27,11 @@ export const SETTINGS = i18n.translate(
     defaultMessage: 'Settings',
   }
 );
+
+export const MISSING_CONNECTORS_READ_PRIVILEGE_TOOLTIP = i18n.translate(
+  'xpack.securitySolution.attackDiscovery.pages.header.missingConnectorsReadPrivilegeTooltip',
+  {
+    defaultMessage:
+      'To generate Attack discoveries, you need the Management > Actions & Connectors: Read Kibana privilege.',
+  }
+);

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/index.test.tsx
@@ -10,7 +10,7 @@ import { dataViewPluginMocks } from '@kbn/data-views-plugin/public/mocks';
 import { createFilterManagerMock } from '@kbn/data-plugin/public/query/filter_manager/filter_manager.mock';
 import { UpsellingService } from '@kbn/security-solution-upselling/service';
 import { Router } from '@kbn/shared-ux-router';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import useLocalStorage from 'react-use/lib/useLocalStorage';
 
@@ -32,6 +32,7 @@ import { SECURITY_UI_SHOW_PRIVILEGE } from '@kbn/security-solution-features/cons
 import { CALLOUT_TEST_DATA_ID } from './moving_attacks_callout';
 import { useMovingAttacksCallout } from './moving_attacks_callout/use_moving_attacks_callout';
 import { mockUseMovingAttacksCallout } from './moving_attacks_callout/use_moving_attacks_callout.mock';
+import { MISSING_CONNECTORS_READ_PRIVILEGE_TOOLTIP } from './header/translations';
 
 const mockConnectors: unknown[] = [
   {
@@ -117,6 +118,7 @@ const mockUseKibanaReturnValue = {
   services: {
     application: {
       capabilities: {
+        actions: { show: true },
         [SECURITY_FEATURE_ID]: { crud_alerts: true, read_alerts: true },
       },
       navigateToUrl: jest.fn(),
@@ -222,6 +224,9 @@ describe('AttackDiscovery', () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
+    mockUseKibanaReturnValue.services.application.capabilities.actions = { show: true };
+    mockUseKibanaReturnValue.services.uiSettings.get.mockReturnValue(false);
+
     (useLoadConnectors as jest.Mock).mockReturnValue({
       isFetched: true,
       data: mockConnectors,
@@ -263,6 +268,32 @@ describe('AttackDiscovery', () => {
       fireEvent.click(settingsButton);
 
       expect(screen.getByTestId('settingsFlyout')).toBeInTheDocument();
+    });
+  });
+
+  it('shows connector privilege guidance when the user cannot read connectors', async () => {
+    mockUseKibanaReturnValue.services.application.capabilities.actions = { show: false };
+
+    render(
+      <TestProviders>
+        <Router history={historyMock}>
+          <UpsellingProvider upsellingService={mockUpselling}>
+            <AttackDiscoveryPage />
+          </UpsellingProvider>
+        </Router>
+      </TestProviders>
+    );
+
+    const runButton = screen.getByTestId('run');
+
+    expect(runButton).toBeDisabled();
+
+    fireEvent.mouseOver(runButton);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('runTooltip')).toHaveTextContent(
+        MISSING_CONNECTORS_READ_PRIVILEGE_TOOLTIP
+      );
     });
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/index.tsx
@@ -34,8 +34,10 @@ import { useInvalidFilterQuery } from '../../common/hooks/use_invalid_filter_que
 import { useKibana } from '../../common/lib/kibana';
 import { convertToBuildEsQuery } from '../../common/lib/kuery';
 import { SpyRoute } from '../../common/utils/route/spy_routes';
+import { CapabilitiesChecker } from '../../common/lib/capabilities';
 import { useDataView } from '../../data_view_manager/hooks/use_data_view';
 import { Actions } from './header/actions';
+import * as i18n from './header/translations';
 import { CONNECTOR_ID_LOCAL_STORAGE_KEY, getDefaultQuery, getSize } from './helpers';
 import { deserializeQuery } from './local_storage/deserialize_query';
 import { deserializeFilters } from './local_storage/deserialize_filters';
@@ -55,7 +57,7 @@ export const ID = 'attackDiscoveryQuery';
 
 const AttackDiscoveryPageComponent: React.FC = () => {
   const {
-    services: { uiSettings, settings },
+    services: { application, uiSettings, settings },
   } = useKibana();
 
   const { http } = useAssistantContext();
@@ -130,6 +132,15 @@ const AttackDiscoveryPageComponent: React.FC = () => {
     () => getConnectorNameFromId({ aiConnectors, connectorId }),
     [aiConnectors, connectorId]
   );
+
+  const hasConnectorsReadPrivilege = useMemo(
+    () => new CapabilitiesChecker(application.capabilities).has('actions.show'),
+    [application.capabilities]
+  );
+
+  const generateButtonDisabledTooltip = hasConnectorsReadPrivilege
+    ? undefined
+    : i18n.MISSING_CONNECTORS_READ_PRIVILEGE_TOOLTIP;
 
   const { fetchAttackDiscoveries, isLoading } = useAttackDiscovery({
     connectorId,
@@ -251,10 +262,11 @@ const AttackDiscoveryPageComponent: React.FC = () => {
       <div data-test-subj="attackDiscoveryPage">
         <HeaderPage border title={pageTitle}>
           <Actions
+            disabledTooltip={generateButtonDisabledTooltip}
             isLoading={isLoading}
             onGenerate={onGenerate}
             openFlyout={openFlyout}
-            isDisabled={connectorId == null}
+            isDisabled={connectorId == null || !hasConnectorsReadPrivilege}
           />
           <EuiSpacer size={'s'} />
         </HeaderPage>
@@ -270,6 +282,7 @@ const AttackDiscoveryPageComponent: React.FC = () => {
 
         <History
           aiConnectors={aiConnectors}
+          generateButtonDisabledTooltip={generateButtonDisabledTooltip}
           localStorageAttackDiscoveryMaxAlerts={localStorageAttackDiscoveryMaxAlerts}
           onGenerate={onGenerate}
           onToggleShowAnonymized={onToggleShowAnonymized}

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/empty_states/empty_prompt/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/empty_states/empty_prompt/index.tsx
@@ -24,6 +24,7 @@ import * as i18n from './translations';
 interface Props {
   aiConnectorsCount: number | null; // null when connectors are not configured
   attackDiscoveriesCount: number;
+  disabledTooltip?: React.ReactNode;
   isDisabled?: boolean;
   isLoading: boolean;
   onGenerate: (overrideOptions?: SettingsOverrideOptions) => Promise<void>;
@@ -32,6 +33,7 @@ interface Props {
 const EmptyPromptComponent: React.FC<Props> = ({
   aiConnectorsCount,
   attackDiscoveriesCount,
+  disabledTooltip,
   isLoading,
   isDisabled = false,
   onGenerate,
@@ -96,8 +98,15 @@ const EmptyPromptComponent: React.FC<Props> = ({
   );
 
   const actions = useMemo(() => {
-    return <Generate isLoading={isLoading} isDisabled={isDisabled} onGenerate={onGenerate} />;
-  }, [isDisabled, isLoading, onGenerate]);
+    return (
+      <Generate
+        disabledTooltip={disabledTooltip}
+        isLoading={isLoading}
+        isDisabled={isDisabled}
+        onGenerate={onGenerate}
+      />
+    );
+  }, [disabledTooltip, isDisabled, isLoading, onGenerate]);
 
   if (isLoading || aiConnectorsCount == null || attackDiscoveriesCount > 0) {
     return null;

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/empty_states/generate/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/empty_states/generate/index.test.tsx
@@ -43,4 +43,21 @@ describe('Generate Component', () => {
       expect(screen.getByText(i18n.SELECT_A_CONNECTOR)).toBeInTheDocument();
     });
   });
+
+  it('shows custom tooltip content when the button is disabled', async () => {
+    render(
+      <Generate
+        disabledTooltip="Missing connector privileges"
+        isLoading={false}
+        isDisabled={true}
+        onGenerate={jest.fn()}
+      />
+    );
+
+    fireEvent.mouseOver(screen.getByTestId('generate'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Missing connector privileges')).toBeInTheDocument();
+    });
+  });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/empty_states/generate/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/empty_states/generate/index.tsx
@@ -12,17 +12,23 @@ import * as i18n from '../empty_prompt/translations';
 import type { SettingsOverrideOptions } from '../../history/types';
 
 interface Props {
+  disabledTooltip?: React.ReactNode;
   isDisabled?: boolean;
   isLoading: boolean;
   onGenerate: (overrideOptions?: SettingsOverrideOptions) => Promise<void>;
 }
 
-const GenerateComponent: React.FC<Props> = ({ isLoading, isDisabled = false, onGenerate }) => {
+const GenerateComponent: React.FC<Props> = ({
+  disabledTooltip,
+  isLoading,
+  isDisabled = false,
+  onGenerate,
+}) => {
   const disabled = isLoading || isDisabled;
 
   return (
     <EuiToolTip
-      content={disabled ? i18n.SELECT_A_CONNECTOR : null}
+      content={disabled ? disabledTooltip ?? i18n.SELECT_A_CONNECTOR : null}
       data-test-subj="generateTooltip"
     >
       <EuiButton

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/history/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/history/index.tsx
@@ -47,6 +47,7 @@ const EMPTY_QUERY = '';
 
 interface Props {
   aiConnectors: AIConnector[] | undefined;
+  generateButtonDisabledTooltip?: React.ReactNode;
   localStorageAttackDiscoveryMaxAlerts: string | undefined;
   onGenerate: (overrideOptions?: SettingsOverrideOptions) => Promise<void>;
   onToggleShowAnonymized: () => void;
@@ -55,6 +56,7 @@ interface Props {
 
 const HistoryComponent: React.FC<Props> = ({
   aiConnectors,
+  generateButtonDisabledTooltip,
   localStorageAttackDiscoveryMaxAlerts,
   onGenerate,
   onToggleShowAnonymized,
@@ -242,6 +244,7 @@ const HistoryComponent: React.FC<Props> = ({
         <EmptyPrompt
           aiConnectorsCount={aiConnectors?.length ?? null}
           attackDiscoveriesCount={data?.total ?? 0}
+          disabledTooltip={generateButtonDisabledTooltip}
           isDisabled={!aiConnectors?.length}
           isLoading={isLoading}
           onGenerate={onGenerate}


### PR DESCRIPTION
## Summary

Addresses https://github.com/elastic/kibana/issues/183117

## Summary

Updated Attack Discovery generate controls to distinguish between a missing connector selection and missing connector RBAC privileges. When the user lacks the Management > Actions & Connectors: Read privilege, the Run/Generate disabled tooltip now explains the missing privilege instead of asking the user to select a connector.

Most relevant files:
- `x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/index.tsx`
- `x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/header/run/index.tsx`
- `x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/empty_states/generate/index.tsx`

## Verification Steps

1. Create or use a custom role that can access Security Solution and Attack Discovery, but has Management > Actions & Connectors set to None.
2. Assign that role to a test user and log in as that user.
3. Navigate to Security > Attack Discovery.
4. Hover the disabled Run/Generate button.
5. Verify the tooltip explains that the Management > Actions & Connectors: Read Kibana privilege is required, and does not show the generic "Select a connector" message.


---

_PR developed with Cursor + GPT-5.5 1M Extra High_