### PR TITLE
Fix: [Attack Discovery][Scheduling][Bug] Use "Assistant" as an author for the LLM comment that we add in Cases

### DIFF
--- a/x-pack/platform/plugins/shared/cases/server/client/attachments/bulk_create.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/attachments/bulk_create.test.ts
@@ -5,7 +5,13 @@
  * 2.0.
  */
 
-import { comment, actionComment, mockCases, mockCaseUnifiedAttachments } from '../../mocks';
+import {
+  comment,
+  actionComment,
+  mockCases,
+  mockCaseComments,
+  mockCaseUnifiedAttachments,
+} from '../../mocks';
 import { createCasesClientMockArgs } from '../mocks';
 import {
   MAX_COMMENT_LENGTH,
@@ -164,6 +170,60 @@ describe('bulkCreate', () => {
         entities: expect.arrayContaining([
           expect.objectContaining({ owner: SECURITY_SOLUTION_OWNER }),
         ]),
+      })
+    );
+  });
+
+  it('uses the provided internal user override for created attachment attribution', async () => {
+    const assistantUser = {
+      username: 'Assistant',
+      full_name: 'Assistant',
+      email: null,
+    };
+
+    userActionService.getMultipleCasesUserActionsTotal.mockResolvedValue({ [caseId]: 0 });
+
+    const theCase = { ...mockCases[0], id: caseId };
+    caseService.getCase.mockResolvedValue(theCase);
+    caseService.patchCase.mockResolvedValue(theCase);
+    caseService.getAllCaseComments.mockResolvedValue({
+      saved_objects: [],
+      total: 1,
+      per_page: 1,
+      page: 1,
+    });
+    attachmentService.getter.getAllAlertIds.mockResolvedValue(new Set());
+    attachmentService.getter.getAllEventIds.mockResolvedValue(new Set());
+    attachmentService.getter.getCaseAttatchmentStats.mockResolvedValue(
+      new Map([[caseId, { alerts: 0, userComments: 0, events: 0 }]])
+    );
+    attachmentService.bulkCreate.mockResolvedValue({
+      saved_objects: [mockCaseComments[0]],
+    });
+
+    await expect(
+      bulkCreate({ attachments: [comment], caseId, user: assistantUser }, clientArgs)
+    ).resolves.toBeDefined();
+
+    expect(attachmentService.bulkCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        attachments: [
+          expect.objectContaining({
+            attributes: expect.objectContaining({
+              created_by: {
+                email: null,
+                full_name: 'Assistant',
+                username: 'Assistant',
+                profile_uid: undefined,
+              },
+            }),
+          }),
+        ],
+      })
+    );
+    expect(userActionService.creator.bulkCreateAttachmentCreation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user: assistantUser,
       })
     );
   });

--- a/x-pack/platform/plugins/shared/cases/server/client/attachments/bulk_create.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/attachments/bulk_create.ts
@@ -27,7 +27,7 @@ export const bulkCreate = async (
   args: BulkCreateArgs,
   clientArgs: CasesClientArgs
 ): Promise<Case> => {
-  const { attachments, caseId, mode = 'legacy' } = args;
+  const { attachments, caseId, mode = 'legacy', user } = args;
 
   const {
     logger,
@@ -79,7 +79,10 @@ export const bulkCreate = async (
       entities,
     });
 
-    const model = await CaseCommentModel.create(caseId, clientArgs);
+    const model = await CaseCommentModel.create(
+      caseId,
+      user ? { ...clientArgs, user } : clientArgs
+    );
     const updatedModel = await model.bulkCreate({
       attachments: attachmentsWithIds,
     });

--- a/x-pack/platform/plugins/shared/cases/server/client/attachments/types.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/attachments/types.ts
@@ -16,6 +16,7 @@ import type {
   FindAttachmentsQueryParams,
 } from '../../../common/types/api';
 import type { AttachmentMode } from '../../../common/types/domain/attachment/v2';
+import type { User } from '../../common/types/user';
 
 /**
  * The arguments needed for creating a new attachment to a case.
@@ -36,6 +37,7 @@ export interface BulkCreateArgs {
   caseId: string;
   attachments: BulkCreateAttachmentsRequestV2;
   mode?: AttachmentMode;
+  user?: User;
 }
 
 /**

--- a/x-pack/platform/plugins/shared/cases/server/connectors/cases/cases_connector_executor.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/connectors/cases/cases_connector_executor.test.ts
@@ -3513,7 +3513,7 @@ describe('CasesConnectorExecutor', () => {
 
           await connectorExecutorWithFlagOn.execute(paramsWithGroupedAlerts);
 
-          expect(casesClientMock.attachments.bulkCreate).toHaveBeenCalledTimes(3);
+          expect(casesClientMock.attachments.bulkCreate).toHaveBeenCalledTimes(5);
           expect(casesClientMock.attachments.bulkCreate).nthCalledWith(
             1,
             expect.objectContaining({
@@ -3525,6 +3525,11 @@ describe('CasesConnectorExecutor', () => {
                   owner: 'securitySolution',
                 }),
               ]),
+              user: {
+                username: 'Assistant',
+                full_name: 'Assistant',
+                email: null,
+              },
             })
           );
         });
@@ -3547,7 +3552,7 @@ describe('CasesConnectorExecutor', () => {
             reopenClosedCases: true,
           });
 
-          expect(casesClientMock.attachments.bulkCreate).toHaveBeenCalledTimes(1);
+          expect(casesClientMock.attachments.bulkCreate).toHaveBeenCalledTimes(2);
           expect(casesClientMock.attachments.bulkCreate).nthCalledWith(1, {
             caseId: 'mock-id-1',
             attachments: [
@@ -3556,6 +3561,16 @@ describe('CasesConnectorExecutor', () => {
                 owner: 'securitySolution',
                 type: 'user',
               },
+            ],
+            user: {
+              username: 'Assistant',
+              full_name: 'Assistant',
+              email: null,
+            },
+          });
+          expect(casesClientMock.attachments.bulkCreate).nthCalledWith(2, {
+            caseId: 'mock-id-1',
+            attachments: [
               {
                 alertId: ['alert-id-1', 'alert-id-2'],
                 index: ['alert-index-1', 'alert-index-1'],
@@ -3646,7 +3661,7 @@ describe('CasesConnectorExecutor', () => {
 
           await connectorExecutor.execute(paramsWithGroupedAlerts);
 
-          expect(casesClientMock.attachments.bulkCreate).toHaveBeenCalledTimes(1);
+          expect(casesClientMock.attachments.bulkCreate).toHaveBeenCalledTimes(2);
         });
       });
     });

--- a/x-pack/platform/plugins/shared/cases/server/connectors/cases/cases_connector_executor.ts
+++ b/x-pack/platform/plugins/shared/cases/server/connectors/cases/cases_connector_executor.ts
@@ -44,7 +44,8 @@ import {
 } from './utils';
 import type { CasesService } from './cases_service';
 import type { CasesClient } from '../../client';
-import type { BulkCreateArgs as BulkCreateAlertsReq } from '../../client/attachments/types';
+import type { BulkCreateArgs as BulkCreateAttachmentsReq } from '../../client/attachments/types';
+import type { User } from '../../common/types/user';
 import { CasesConnectorError } from './cases_connector_error';
 import {
   AUTO_CREATED_TITLE,
@@ -66,6 +67,12 @@ type GroupedAlertsWithOracleKey = CasesGroupedAlerts & { oracleKey: string };
 type GroupedAlertsWithOracleRecords = GroupedAlertsWithOracleKey & { oracleRecord: OracleRecord };
 type GroupedAlertsWithCaseId = GroupedAlertsWithOracleRecords & { caseId: string };
 type GroupedAlertsWithCases = GroupedAlertsWithCaseId & { theCase: Case };
+
+const ATTACK_DISCOVERY_ASSISTANT_USER: User = {
+  username: 'Assistant',
+  full_name: 'Assistant',
+  email: null,
+};
 
 export class CasesConnectorExecutor {
   private readonly logger: Logger;
@@ -1181,8 +1188,11 @@ export class CasesConnectorExecutor {
       })
     );
 
-    const bulkCreateAlertsRequest: BulkCreateAlertsReq[] = casesUnderAlertLimit.map(
-      ({ theCase, alerts, comments }) => {
+    const { commentRequests, alertRequests } = casesUnderAlertLimit.reduce<{
+      commentRequests: BulkCreateAttachmentsReq[];
+      alertRequests: BulkCreateAttachmentsReq[];
+    }>(
+      (acc, { theCase, alerts, comments }) => {
         const extraComments: AttachmentRequestV2[] =
           comments?.map((comment) =>
             this.isCasesAttachmentsEnabled
@@ -1197,51 +1207,83 @@ export class CasesConnectorExecutor {
                   owner: theCase.owner,
                 }
           ) ?? [];
-        return {
-          caseId: theCase.id,
-          attachments: [
-            ...extraComments,
-            {
-              type: AttachmentType.alert,
-              rule: internallyManagedAlerts
-                ? { id: null, name: null }
-                : { id: rule.id, name: rule.name },
-              /**
-               * Map traverses the array in ascending order.
-               * The order is guaranteed to be the same for
-               * both calls by the ECMA-262 spec.
-               */
-              alertId: alerts.map((alert) => alert._id),
-              index: alerts.map((alert) => alert._index),
-              owner: theCase.owner,
-            },
-          ],
+
+        const alertAttachment: AttachmentRequestV2 = {
+          type: AttachmentType.alert,
+          rule: internallyManagedAlerts
+            ? { id: null, name: null }
+            : { id: rule.id, name: rule.name },
+          /**
+           * Map traverses the array in ascending order.
+           * The order is guaranteed to be the same for
+           * both calls by the ECMA-262 spec.
+           */
+          alertId: alerts.map((alert) => alert._id),
+          index: alerts.map((alert) => alert._index),
+          owner: theCase.owner,
         };
-      }
+
+        if (internallyManagedAlerts && extraComments.length > 0) {
+          acc.commentRequests.push({
+            caseId: theCase.id,
+            attachments: extraComments,
+            user: ATTACK_DISCOVERY_ASSISTANT_USER,
+          });
+          acc.alertRequests.push({
+            caseId: theCase.id,
+            attachments: [alertAttachment],
+          });
+
+          return acc;
+        }
+
+        acc.alertRequests.push({
+          caseId: theCase.id,
+          attachments: [...extraComments, alertAttachment],
+        });
+
+        return acc;
+      },
+      { commentRequests: [], alertRequests: [] }
     );
 
+    const bulkCreateAttachments = async (req: BulkCreateAttachmentsReq) => {
+      if (this.logger.isLevelEnabled('debug')) {
+        const alertIds = req.attachments.flatMap((attachment) => {
+          if ('alertId' in attachment) {
+            const { alertId } = attachment;
+            if (Array.isArray(alertId)) {
+              return alertId;
+            }
+
+            return alertId ? [alertId] : [];
+          }
+
+          return [];
+        });
+
+        this.logger.debug(
+          `[CasesConnector][CasesConnectorExecutor][attachAlertsToCases] Attaching ${req.attachments.length} attachments to case with ID ${req.caseId}`,
+          this.getLogMetadata(params, {
+            labels: { caseId: req.caseId },
+            tags: ['case-connector:attachAlertsToCases', req.caseId, ...alertIds],
+          })
+        );
+      }
+
+      await this.casesClient.attachments.bulkCreate(req);
+    };
+
+    await pMap(commentRequests, bulkCreateAttachments, {
+      concurrency: MAX_CONCURRENT_ES_REQUEST,
+    });
+
     await pMap(
-      bulkCreateAlertsRequest,
+      alertRequests,
       /**
        * attachments.bulkCreate throws an error on errors
        */
-      async (req: BulkCreateAlertsReq) => {
-        if (this.logger.isLevelEnabled('debug')) {
-          this.logger.debug(
-            `[CasesConnector][CasesConnectorExecutor][attachAlertsToCases] Attaching ${req.attachments.length} alerts to case with ID ${req.caseId}`,
-            this.getLogMetadata(params, {
-              labels: { caseId: req.caseId },
-              tags: [
-                'case-connector:attachAlertsToCases',
-                req.caseId,
-                ...(req.attachments as Array<{ alertId: string }>).map(({ alertId }) => alertId),
-              ],
-            })
-          );
-        }
-
-        await this.casesClient.attachments.bulkCreate(req);
-      },
+      bulkCreateAttachments,
       {
         concurrency: MAX_CONCURRENT_ES_REQUEST,
       }

--- a/x-pack/platform/plugins/shared/cases/server/connectors/cases/test_helpers.ts
+++ b/x-pack/platform/plugins/shared/cases/server/connectors/cases/test_helpers.ts
@@ -118,12 +118,32 @@ export const expectCasesToHaveTheCorrectAlertsAttachedWithGroupingAndIncreasedCo
 export const expectCasesToHaveTheCorrectAlertsAttachedWithPredefinedGrouping = (
   casesClientMock: CasesClientMock
 ) => {
-  expect(casesClientMock.attachments.bulkCreate).toHaveBeenCalledTimes(3);
+  const assistantUser = {
+    username: 'Assistant',
+    full_name: 'Assistant',
+    email: null,
+  };
+
+  expect(casesClientMock.attachments.bulkCreate).toHaveBeenCalledTimes(5);
 
   expect(casesClientMock.attachments.bulkCreate).nthCalledWith(1, {
     caseId: 'mock-id-1',
+    attachments: [{ comment: 'comment-1', owner: 'securitySolution', type: 'user' }],
+    user: assistantUser,
+  });
+
+  expect(casesClientMock.attachments.bulkCreate).nthCalledWith(2, {
+    caseId: 'mock-id-2',
     attachments: [
-      { comment: 'comment-1', owner: 'securitySolution', type: 'user' },
+      { comment: 'comment-2', owner: 'securitySolution', type: 'user' },
+      { comment: 'comment-3', owner: 'securitySolution', type: 'user' },
+    ],
+    user: assistantUser,
+  });
+
+  expect(casesClientMock.attachments.bulkCreate).nthCalledWith(3, {
+    caseId: 'mock-id-1',
+    attachments: [
       {
         alertId: ['alert-id-1', 'alert-id-2'],
         index: ['alert-index-1', 'alert-index-1'],
@@ -134,11 +154,9 @@ export const expectCasesToHaveTheCorrectAlertsAttachedWithPredefinedGrouping = (
     ],
   });
 
-  expect(casesClientMock.attachments.bulkCreate).nthCalledWith(2, {
+  expect(casesClientMock.attachments.bulkCreate).nthCalledWith(4, {
     caseId: 'mock-id-2',
     attachments: [
-      { comment: 'comment-2', owner: 'securitySolution', type: 'user' },
-      { comment: 'comment-3', owner: 'securitySolution', type: 'user' },
       {
         alertId: ['alert-id-3', 'alert-id-4'],
         index: ['alert-index-2', 'alert-index-2'],
@@ -149,7 +167,7 @@ export const expectCasesToHaveTheCorrectAlertsAttachedWithPredefinedGrouping = (
     ],
   });
 
-  expect(casesClientMock.attachments.bulkCreate).nthCalledWith(3, {
+  expect(casesClientMock.attachments.bulkCreate).nthCalledWith(5, {
     caseId: 'mock-id-3',
     attachments: [
       {


### PR DESCRIPTION
## Summary

Addresses https://github.com/elastic/security-team/issues/12985

## Summary

Updated the Cases connector path used by Attack Discovery schedules so LLM-generated case comments are created by an internal `Assistant` user instead of the schedule action execution user. Alert attachments still use the normal action execution user path.

Touched the Cases attachment bulk-create internals to support a server-only user override, and added focused coverage for both the override and the Attack Discovery grouped-comment flow.

## Verification Steps

1. Start Kibana with the feature flags enabled:
   ```yaml
   feature_flags.overrides:
     securitySolution.attackDiscoveryAlertsEnabled: true
     securitySolution.assistantAttackDiscoverySchedulingEnabled: true
   ```
2. In Elastic Security, navigate to Attack Discovery and create a schedule with a Cases action.
3. Update the schedule as a non-Assistant user, then wait for the schedule to execute and generate attack discoveries.
4. Open the generated cases from Cases.
5. Confirm the generated LLM attack description comment shows `Assistant` as the author, not the user who last updated the schedule.
6. Confirm the related alert attachments are still present on the generated case.


---

_PR developed with Cursor + GPT-5.5 1M Extra High_