### PR TITLE
fix Failing test: Maps - maps telemetry

### DIFF
--- a/x-pack/platform/plugins/shared/maps/test/scout/api/tests/maps_telemetry.spec.ts
+++ b/x-pack/platform/plugins/shared/maps/test/scout/api/tests/maps_telemetry.spec.ts
@@ -14,6 +14,9 @@ apiTest.describe('Maps - maps telemetry', { tag: [...tags.stateful.classic] }, (
 
   apiTest.beforeAll(async ({ samlAuth, esArchiver, kbnClient }) => {
     cookieHeader = (await samlAuth.asInteractiveUser('viewer')).cookieHeader;
+    // telemtry takes inventory of saved objects
+    // make sure there are no unexpected saved objects before running test
+    await kbnClient.savedObjects.clean({ types: ['dashboard', 'index-pattern', 'map'] });
     await esArchiver.loadIfNeeded(testData.ES_ARCHIVES.logstashFunctional);
     await esArchiver.loadIfNeeded(testData.ES_ARCHIVES.mapsData);
     await kbnClient.importExport.load(testData.KBN_ARCHIVES.maps);


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/265020

"expected 71, received 72" is failing because instance has unexpected saved objects. PR resolves issues by removing all saved object types before running test

<!--ONMERGE {"backportTargets":["8.19","9.2","9.3","9.4"]} ONMERGE-->