### PR TITLE
[8.19] Fix: [Security Solution] [Bug] The cases action is visible under the Attack Discovery tab when CASES privilege is set to NONE (#266127)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/take_action/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/take_action/index.test.tsx
@@ -568,7 +568,7 @@ describe('TakeAction', () => {
       });
     });
 
-    it('disables case actions when the user lacks permissions', () => {
+    it('does not render case actions when the user lacks permissions', () => {
       render(
         <TestProviders>
           <TakeAction {...defaultProps} />
@@ -577,11 +577,8 @@ describe('TakeAction', () => {
 
       openPopover();
 
-      const addToCaseButton = screen.getByTestId('addToCase');
-      const addToExistingCaseButton = screen.getByTestId('addToExistingCase');
-
-      expect(addToCaseButton).toBeDisabled();
-      expect(addToExistingCaseButton).toBeDisabled();
+      expect(screen.queryByTestId('addToCase')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('addToExistingCase')).not.toBeInTheDocument();
     });
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/take_action/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/take_action/index.tsx
@@ -230,23 +230,27 @@ const TakeActionComponent: React.FC<Props> = ({
   const items: React.JSX.Element[] = useMemo(
     () =>
       [
-        <EuiContextMenuItem
-          data-test-subj="addToCase"
-          disabled={addToCaseDisabled}
-          key="addToCase"
-          onClick={onClickAddToNewCase}
-        >
-          {i18n.ADD_TO_NEW_CASE}
-        </EuiContextMenuItem>,
+        !addToCaseDisabled
+          ? [
+              <EuiContextMenuItem
+                data-test-subj="addToCase"
+                disabled={addToCaseDisabled}
+                key="addToCase"
+                onClick={onClickAddToNewCase}
+              >
+                {i18n.ADD_TO_NEW_CASE}
+              </EuiContextMenuItem>,
 
-        <EuiContextMenuItem
-          data-test-subj="addToExistingCase"
-          disabled={addToCaseDisabled}
-          key="addToExistingCase"
-          onClick={onClickAddToExistingCase}
-        >
-          {i18n.ADD_TO_EXISTING_CASE}
-        </EuiContextMenuItem>,
+              <EuiContextMenuItem
+                data-test-subj="addToExistingCase"
+                disabled={addToCaseDisabled}
+                key="addToExistingCase"
+                onClick={onClickAddToExistingCase}
+              >
+                {i18n.ADD_TO_EXISTING_CASE}
+              </EuiContextMenuItem>,
+            ]
+          : [],
 
         attackDiscoveries.length === 1 ? (
           <EuiContextMenuItem


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Fix: [Security Solution] [Bug] The cases action is visible under the Attack Discovery tab when CASES privilege is set to NONE (#266127)](https://github.com/elastic/kibana/pull/266127)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Ievgen Sorokopud","email":"ievgen.sorokopud@elastic.co"},"sourceCommit":{"committedDate":"2026-04-29T16:06:27Z","message":"Fix: [Security Solution] [Bug] The cases action is visible under the Attack Discovery tab when CASES privilege is set to NONE (#266127)\n\n## Summary\n\nAddresses https://github.com/elastic/kibana/issues/183122\n\n# PR Summary\n\n## Description\nThis PR fixes a bug where the \"Add to case\" and \"Add to existing case\"\nactions were visible (but disabled) under the Attack Discovery tab when\nthe user lacked the necessary cases privileges (e.g., when CASES\nprivilege is set to NONE). The actions are now completely hidden if the\nuser does not have the required privileges to create or read cases,\naligning with the expected behavior.\n\n## Changed Files\n-\n`x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/take_action/index.tsx`:\nUpdated the `caseItems` definition to conditionally include the case\nactions only if `addToCaseDisabled` is false (which is derived from the\nuser's cases privileges).\n-\n`x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/take_action/index.test.tsx`:\nUpdated the tests to expect the case actions to not be in the document\nwhen the user lacks permissions, instead of expecting them to be\ndisabled.\n\n## Verification Steps\n1. Start Kibana and Elasticsearch.\n2. Create a custom role with the `CASES` privilege set to `NONE`.\n3. Create a custom user and assign them the custom role.\n4. Log in as the custom user.\n5. Navigate to the 'Attack Discovery' tab under the Security section.\n6. Generate the results.\n7. Click on the \"Take action\" button for any entry received.\n8. Verify that the \"Add to new case\" and \"Add to existing case\" actions\nare **not visible** in the context menu.\n\n---\n\n_PR developed with Cursor_","sha":"501ab67a71e96ad176849f4666921f3b5cad3e0b","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Threat Hunting","Team: SecuritySolution","Team:Threat Hunting:Investigations","Team:Security Generative AI","backport:version","v8.19.0","v9.4.0","v9.5.0"],"title":"Fix: [Security Solution] [Bug] The cases action is visible under the Attack Discovery tab when CASES privilege is set to NONE","number":266127,"url":"https://github.com/elastic/kibana/pull/266127","mergeCommit":{"message":"Fix: [Security Solution] [Bug] The cases action is visible under the Attack Discovery tab when CASES privilege is set to NONE (#266127)\n\n## Summary\n\nAddresses https://github.com/elastic/kibana/issues/183122\n\n# PR Summary\n\n## Description\nThis PR fixes a bug where the \"Add to case\" and \"Add to existing case\"\nactions were visible (but disabled) under the Attack Discovery tab when\nthe user lacked the necessary cases privileges (e.g., when CASES\nprivilege is set to NONE). The actions are now completely hidden if the\nuser does not have the required privileges to create or read cases,\naligning with the expected behavior.\n\n## Changed Files\n-\n`x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/take_action/index.tsx`:\nUpdated the `caseItems` definition to conditionally include the case\nactions only if `addToCaseDisabled` is false (which is derived from the\nuser's cases privileges).\n-\n`x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/take_action/index.test.tsx`:\nUpdated the tests to expect the case actions to not be in the document\nwhen the user lacks permissions, instead of expecting them to be\ndisabled.\n\n## Verification Steps\n1. Start Kibana and Elasticsearch.\n2. Create a custom role with the `CASES` privilege set to `NONE`.\n3. Create a custom user and assign them the custom role.\n4. Log in as the custom user.\n5. Navigate to the 'Attack Discovery' tab under the Security section.\n6. Generate the results.\n7. Click on the \"Take action\" button for any entry received.\n8. Verify that the \"Add to new case\" and \"Add to existing case\" actions\nare **not visible** in the context menu.\n\n---\n\n_PR developed with Cursor_","sha":"501ab67a71e96ad176849f4666921f3b5cad3e0b"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/266463","number":266463,"state":"MERGED","mergeCommit":{"sha":"dcdf8848f021cea04e3728d576a8a63c6d0be3a5","message":"[9.4] Fix: [Security Solution] [Bug] The cases action is visible under the Attack Discovery tab when CASES privilege is set to NONE (#266127) (#266463)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.4`:\n- [Fix: [Security Solution] [Bug] The cases action is visible under the\nAttack Discovery tab when CASES privilege is set to NONE\n(#266127)](https://github.com/elastic/kibana/pull/266127)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Ievgen Sorokopud <ievgen.sorokopud@elastic.co>"}},{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/266127","number":266127,"mergeCommit":{"message":"Fix: [Security Solution] [Bug] The cases action is visible under the Attack Discovery tab when CASES privilege is set to NONE (#266127)\n\n## Summary\n\nAddresses https://github.com/elastic/kibana/issues/183122\n\n# PR Summary\n\n## Description\nThis PR fixes a bug where the \"Add to case\" and \"Add to existing case\"\nactions were visible (but disabled) under the Attack Discovery tab when\nthe user lacked the necessary cases privileges (e.g., when CASES\nprivilege is set to NONE). The actions are now completely hidden if the\nuser does not have the required privileges to create or read cases,\naligning with the expected behavior.\n\n## Changed Files\n-\n`x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/take_action/index.tsx`:\nUpdated the `caseItems` definition to conditionally include the case\nactions only if `addToCaseDisabled` is false (which is derived from the\nuser's cases privileges).\n-\n`x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/take_action/index.test.tsx`:\nUpdated the tests to expect the case actions to not be in the document\nwhen the user lacks permissions, instead of expecting them to be\ndisabled.\n\n## Verification Steps\n1. Start Kibana and Elasticsearch.\n2. Create a custom role with the `CASES` privilege set to `NONE`.\n3. Create a custom user and assign them the custom role.\n4. Log in as the custom user.\n5. Navigate to the 'Attack Discovery' tab under the Security section.\n6. Generate the results.\n7. Click on the \"Take action\" button for any entry received.\n8. Verify that the \"Add to new case\" and \"Add to existing case\" actions\nare **not visible** in the context menu.\n\n---\n\n_PR developed with Cursor_","sha":"501ab67a71e96ad176849f4666921f3b5cad3e0b"}}]}] BACKPORT-->