### PR TITLE
[Entity Analytics] Fixing evals to use updated AD job names

### DIFF
--- a/x-pack/solutions/security/packages/kbn-evals-suite-entity-analytics/src/ml_helpers.ts
+++ b/x-pack/solutions/security/packages/kbn-evals-suite-entity-analytics/src/ml_helpers.ts
@@ -32,15 +32,15 @@ export const securityAuthJobIds = [
 // Privileged Access Detection (PAD) ML module
 export const padModule = 'pad-ml';
 export const padJobIds = [
-  'pad_linux_rare_process_executed_by_user',
-  'pad_linux_high_count_privileged_process_events_by_user',
+  'pad_linux_rare_process_executed_by_user_ea',
+  'pad_linux_high_count_privileged_process_events_by_user_ea',
 ];
 
 // Lateral Movement Detection (LMD) ML module
 export const lmdModule = 'lmd-ml';
 export const lmdJobIds = [
-  'lmd_high_count_remote_file_transfer',
-  'lmd_high_file_size_remote_file_transfer',
+  'lmd_high_count_remote_file_transfer_ea',
+  'lmd_high_file_size_remote_file_transfer_ea',
 ];
 
 // Security PacketBeat ML module
@@ -50,10 +50,10 @@ export const securityPacketBeatJobIds = ['packetbeat_rare_server_domain_ea'];
 // Data Exfiltration Detection (DED) ML module
 export const dedModule = 'ded-ml';
 export const dedJobIds = [
-  'ded_high_bytes_written_to_external_device',
-  'ded_high_bytes_written_to_external_device_airdrop',
-  'ded_high_sent_bytes_destination_geo_country_iso_code',
-  'ded_high_sent_bytes_destination_ip',
+  'ded_high_bytes_written_to_external_device_ea',
+  'ded_high_bytes_written_to_external_device_airdrop_ea',
+  'ded_high_sent_bytes_destination_geo_country_iso_code_ea',
+  'ded_high_sent_bytes_destination_ip_ea',
 ];
 
 interface ModuleJob {


### PR DESCRIPTION
## Summary

When this [PR](https://github.com/elastic/integrations/pull/17626) merged, it updated the remaining AD job names to have the `_ea` suffix. This updates the evals to reference the new names so they will run correctly.

I added the labels to run the evals with the weekly EIS models and the build passed: https://buildkite.com/elastic/kibana-pull-request/builds/435902

<img width="599" height="213" alt="Screenshot 2026-04-29 at 6 40 50 PM" src="https://github.com/user-attachments/assets/f45f5910-898a-48ec-aaf8-9c2227fce403" />
