### PR TITLE
[9.3] [Spaces] Trim whitespace from space names on create/update (#261016)

### DIFF
--- a/x-pack/platform/plugins/shared/spaces/server/spaces_client/spaces_client.test.ts
+++ b/x-pack/platform/plugins/shared/spaces/server/spaces_client/spaces_client.test.ts
@@ -488,6 +488,41 @@ describe('#create', () => {
     );
   });
 
+  test(`trims whitespace from name when creating a space`, async () => {
+    const maxSpaces = 5;
+    const mockDebugLogger = createMockDebugLogger();
+    const mockCallWithRequestRepository = savedObjectsRepositoryMock.create();
+    mockCallWithRequestRepository.create.mockResolvedValue(savedObject);
+    mockCallWithRequestRepository.find.mockResolvedValue({
+      total: maxSpaces - 1,
+    } as any);
+
+    const mockConfig = createMockConfig({
+      enabled: true,
+      maxSpaces,
+      allowFeatureVisibility: true,
+      allowSolutionVisibility: true,
+    });
+
+    const client = new SpacesClient(
+      mockDebugLogger,
+      mockConfig,
+      mockCallWithRequestRepository,
+      [],
+      'traditional',
+      featuresStart,
+      undefined
+    );
+
+    await client.create({ ...spaceToCreate, name: '  foo-name  ' });
+
+    expect(mockCallWithRequestRepository.create).toHaveBeenCalledWith(
+      'space',
+      expect.objectContaining({ name: 'foo-name' }),
+      expect.anything()
+    );
+  });
+
   test(`throws bad request when we are at the maximum number of spaces`, async () => {
     const maxSpaces = 5;
     const mockDebugLogger = createMockDebugLogger();
@@ -806,6 +841,59 @@ describe('#update', () => {
       solution: 'es',
     });
     expect(mockCallWithRequestRepository.get).toHaveBeenCalledWith('space', id);
+  });
+
+  test(`preserves existing leading/trailing whitespace in name when updating a space with the same name`, async () => {
+    const mockDebugLogger = createMockDebugLogger();
+    const mockConfig = createMockConfig();
+    const mockCallWithRequestRepository = savedObjectsRepositoryMock.create();
+    mockCallWithRequestRepository.get.mockResolvedValue({
+      ...savedObject,
+      attributes: { ...(savedObject.attributes as object), name: '  foo-name  ' },
+    });
+
+    const client = new SpacesClient(
+      mockDebugLogger,
+      mockConfig,
+      mockCallWithRequestRepository,
+      [],
+      'traditional',
+      featuresStart,
+      undefined
+    );
+    const id = savedObject.id;
+    await client.update(id, { ...spaceToUpdate, name: '  foo-name  ' });
+
+    expect(mockCallWithRequestRepository.update).toHaveBeenCalledWith(
+      'space',
+      id,
+      expect.objectContaining({ name: '  foo-name  ' })
+    );
+  });
+
+  test(`trims leading/trailing whitespace from name when updating a space with a new name`, async () => {
+    const mockDebugLogger = createMockDebugLogger();
+    const mockConfig = createMockConfig();
+    const mockCallWithRequestRepository = savedObjectsRepositoryMock.create();
+    mockCallWithRequestRepository.get.mockResolvedValue(savedObject);
+
+    const client = new SpacesClient(
+      mockDebugLogger,
+      mockConfig,
+      mockCallWithRequestRepository,
+      [],
+      'traditional',
+      featuresStart,
+      undefined
+    );
+    const id = savedObject.id;
+    await client.update(id, { ...spaceToUpdate, name: '  new-name  ' });
+
+    expect(mockCallWithRequestRepository.update).toHaveBeenCalledWith(
+      'space',
+      id,
+      expect.objectContaining({ name: 'new-name' })
+    );
   });
 
   test('throws bad request when solution property is provided in serverless build', async () => {

--- a/x-pack/platform/plugins/shared/spaces/server/spaces_client/spaces_client.test.ts
+++ b/x-pack/platform/plugins/shared/spaces/server/spaces_client/spaces_client.test.ts
@@ -510,8 +510,7 @@ describe('#create', () => {
       mockCallWithRequestRepository,
       [],
       'traditional',
-      featuresStart,
-      undefined
+      featuresStart
     );
 
     await client.create({ ...spaceToCreate, name: '  foo-name  ' });
@@ -814,7 +813,7 @@ describe('#update', () => {
     const mockDebugLogger = createMockDebugLogger();
     const mockConfig = createMockConfig();
     const mockCallWithRequestRepository = savedObjectsRepositoryMock.create();
-    mockCallWithRequestRepository.get.mockResolvedValueOnce({
+    mockCallWithRequestRepository.get.mockResolvedValue({
       ...savedObject,
       attributes: { ...(savedObject.attributes as object), solution: 'es' },
     });
@@ -858,8 +857,7 @@ describe('#update', () => {
       mockCallWithRequestRepository,
       [],
       'traditional',
-      featuresStart,
-      undefined
+      featuresStart
     );
     const id = savedObject.id;
     await client.update(id, { ...spaceToUpdate, name: '  foo-name  ' });
@@ -883,8 +881,7 @@ describe('#update', () => {
       mockCallWithRequestRepository,
       [],
       'traditional',
-      featuresStart,
-      undefined
+      featuresStart
     );
     const id = savedObject.id;
     await client.update(id, { ...spaceToUpdate, name: '  new-name  ' });

--- a/x-pack/platform/plugins/shared/spaces/server/spaces_client/spaces_client.ts
+++ b/x-pack/platform/plugins/shared/spaces/server/spaces_client/spaces_client.ts
@@ -166,7 +166,7 @@ export class SpacesClient implements ISpacesClient {
     this.debugLogger(`SpacesClient.create(), using RBAC. Attempting to create space`);
 
     const id = space.id;
-    const attributes = this.generateSpaceAttributes(space);
+    const attributes = this.generateSpaceAttributes({ ...space, name: space.name.trim() });
 
     const createdSavedObject = await this.repository.create('space', attributes, { id });
 
@@ -196,7 +196,16 @@ export class SpacesClient implements ISpacesClient {
       throw Boom.badRequest('Unable to update Space, solution property cannot be empty');
     }
 
-    const attributes = this.generateSpaceAttributes(space);
+    const existingSpaceSavedObject = await this.repository.get<SpaceSavedObjectAttributes>(
+      'space',
+      id
+    );
+
+    // Preserve existing leading/trailing whitespace (backwards compatibility for legacy spaces),
+    // but trim if a new name is being set to prevent introducing new whitespace.
+    const existingName = existingSpaceSavedObject.attributes.name as string;
+    const resolvedName = space.name === existingName ? space.name : space.name.trim();
+    const attributes = this.generateSpaceAttributes({ ...space, name: resolvedName });
     await this.repository.update('space', id, attributes);
     const updatedSavedObject = await this.repository.get('space', id);
     return this.transformSavedObjectToSpace(updatedSavedObject);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Spaces] Trim whitespace from space names on create/update (#261016)](https://github.com/elastic/kibana/pull/261016)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Copilot","email":"198982749+Copilot@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-04-29T18:55:51Z","message":"[Spaces] Trim whitespace from space names on create/update (#261016)\n\n- [x] Apply `.trim()` to space name only in `create` path\n- [x] On `update`: preserve existing whitespace if name is unchanged\n(backwards compat), trim if new name is being set\n- [x] Tests for all three scenarios\n- [x] Fix TS2698: cast `savedObject.attributes as object` before spread\nin test\n\n---------\n\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: legrego <3493255+legrego@users.noreply.github.com>\nCo-authored-by: Larry Gregory <larry.gregory@elastic.co>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"8f980c64bc3374eff5b06b6352272020ee5b753f","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Security","Feature:Security/Spaces","💝community","backport:all-open","v9.5.0"],"title":"[Spaces] Trim whitespace from space names on create/update","number":261016,"url":"https://github.com/elastic/kibana/pull/261016","mergeCommit":{"message":"[Spaces] Trim whitespace from space names on create/update (#261016)\n\n- [x] Apply `.trim()` to space name only in `create` path\n- [x] On `update`: preserve existing whitespace if name is unchanged\n(backwards compat), trim if new name is being set\n- [x] Tests for all three scenarios\n- [x] Fix TS2698: cast `savedObject.attributes as object` before spread\nin test\n\n---------\n\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: legrego <3493255+legrego@users.noreply.github.com>\nCo-authored-by: Larry Gregory <larry.gregory@elastic.co>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"8f980c64bc3374eff5b06b6352272020ee5b753f"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/261016","number":261016,"mergeCommit":{"message":"[Spaces] Trim whitespace from space names on create/update (#261016)\n\n- [x] Apply `.trim()` to space name only in `create` path\n- [x] On `update`: preserve existing whitespace if name is unchanged\n(backwards compat), trim if new name is being set\n- [x] Tests for all three scenarios\n- [x] Fix TS2698: cast `savedObject.attributes as object` before spread\nin test\n\n---------\n\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: legrego <3493255+legrego@users.noreply.github.com>\nCo-authored-by: Larry Gregory <larry.gregory@elastic.co>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"8f980c64bc3374eff5b06b6352272020ee5b753f"}},{"url":"https://github.com/elastic/kibana/pull/266494","number":266494,"branch":"9.4","state":"OPEN"}]}] BACKPORT-->