### PR TITLE
[Content List] MS1.1 — Migrate Graph Listing

### DIFF
--- a/.buildkite/scout_ci_config.yml
+++ b/.buildkite/scout_ci_config.yml
@@ -24,6 +24,7 @@ plugins:
     - flyoutSystemExamples
     - gen_ai_settings
     - global_search
+    - graph
     - index_management
     - infra
     - intercepts

--- a/x-pack/platform/plugins/private/graph/moon.yml
+++ b/x-pack/platform/plugins/private/graph/moon.yml
@@ -45,19 +45,21 @@ dependsOn:
   - '@kbn/core-saved-objects-server'
   - '@kbn/content-management-plugin'
   - '@kbn/object-versioning'
-  - '@kbn/content-management-table-list-view-table'
-  - '@kbn/content-management-table-list-view'
+  - '@kbn/content-list'
+  - '@kbn/content-list-page'
+  - '@kbn/content-list-provider-client'
+  - '@kbn/content-management-table-list-view-common'
   - '@kbn/core-ui-settings-browser'
   - '@kbn/react-kibana-mount'
   - '@kbn/content-management-utils'
   - '@kbn/logging'
-  - '@kbn/content-management-table-list-view-common'
   - '@kbn/visualization-utils'
-  - '@kbn/react-kibana-context-render'
   - '@kbn/core-saved-objects-api-server'
   - '@kbn/licensing-types'
   - '@kbn/kql'
   - '@kbn/unified-search-plugin'
+  - '@kbn/scout'
+  - '@kbn/content-list-provider'
 tags:
   - plugin
   - prod
@@ -70,6 +72,7 @@ fileGroups:
     - common/**/*
     - public/**/*
     - server/**/*
+    - test/scout/**/*
     - '!target/**/*'
   jest-config:
     - jest.config.js

--- a/x-pack/platform/plugins/private/graph/public/application.tsx
+++ b/x-pack/platform/plugins/private/graph/public/application.tsx
@@ -19,17 +19,13 @@ import type {
   ScopedHistory,
 } from '@kbn/core/public';
 import ReactDOM from 'react-dom';
-import React from 'react';
 import type { DataPlugin } from '@kbn/data-plugin/public';
 import type { DataViewsContract } from '@kbn/data-views-plugin/public';
 import type { LicensingPluginStart } from '@kbn/licensing-plugin/public';
 import type { NavigationPublicPluginStart as NavigationStart } from '@kbn/navigation-plugin/public';
 import type { Storage } from '@kbn/kibana-utils-plugin/public';
-import { FormattedRelative } from '@kbn/i18n-react';
 import type { Start as InspectorPublicPluginStart } from '@kbn/inspector-plugin/public';
-import { TableListViewKibanaProvider } from '@kbn/content-management-table-list-view-table';
 import type { SpacesApi } from '@kbn/spaces-plugin/public';
-import { KibanaRenderContextProvider } from '@kbn/react-kibana-context-render';
 import type { SavedObjectsManagementPluginStart } from '@kbn/saved-objects-management-plugin/public';
 import type {
   ContentClient,
@@ -118,19 +114,7 @@ export const renderApp = ({ history, element, ...deps }: GraphDependencies) => {
     window.dispatchEvent(new HashChangeEvent('hashchange'));
   });
 
-  const app = (
-    <KibanaRenderContextProvider {...core}>
-      <TableListViewKibanaProvider
-        {...{
-          core,
-          FormattedRelative,
-        }}
-      >
-        {graphRouter(deps)}
-      </TableListViewKibanaProvider>
-    </KibanaRenderContextProvider>
-  );
-  ReactDOM.render(app, element);
+  ReactDOM.render(core.rendering.addContext(graphRouter(deps)), element);
 
   return () => {
     licenseSubscription.unsubscribe();

--- a/x-pack/platform/plugins/private/graph/public/apps/listing_route.tsx
+++ b/x-pack/platform/plugins/private/graph/public/apps/listing_route.tsx
@@ -5,23 +5,32 @@
  * 2.0.
  */
 
-import React, { Fragment, useCallback, useEffect } from 'react';
+import React, { useCallback, useEffect, useMemo } from 'react';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { EuiEmptyPrompt, EuiLink, EuiButton } from '@elastic/eui';
-import type { ApplicationStart } from '@kbn/core/public';
+import { EuiButton } from '@elastic/eui';
 import { useHistory, useLocation } from 'react-router-dom';
-import { TableListView } from '@kbn/content-management-table-list-view';
 import type { UserContentCommonSchema } from '@kbn/content-management-table-list-view-common';
-import { deleteSavedWorkspace, findSavedWorkspace } from '../helpers/saved_workspace_utils';
+import { KibanaContentListPage } from '@kbn/content-list-page';
+import { ContentListClientProvider } from '@kbn/content-list-provider-client';
+import type { TableListViewFindItemsFn } from '@kbn/content-list-provider-client';
+import type { ContentListItem } from '@kbn/content-list-provider';
+import { GraphContentList } from '../components/content_list';
+import { findSavedWorkspace, deleteSavedWorkspace } from '../helpers/saved_workspace_utils';
 import { getEditPath, getEditUrl, getNewPath, setBreadcrumbs } from '../services/url';
-import type { GraphWorkspaceSavedObject } from '../types';
 import type { GraphServices } from '../application';
-
-const SAVED_OBJECTS_LIMIT_SETTING = 'savedObjects:listingLimit';
-const SAVED_OBJECTS_PER_PAGE_SETTING = 'savedObjects:perPage';
+import type { GraphWorkspaceSavedObject } from '../types';
 
 type GraphUserContent = UserContentCommonSchema;
+
+const labels = {
+  entity: i18n.translate('xpack.graph.listing.table.entityName', {
+    defaultMessage: 'graph',
+  }),
+  entityPlural: i18n.translate('xpack.graph.listing.table.entityNamePlural', {
+    defaultMessage: 'graphs',
+  }),
+};
 
 const toTableListViewSavedObject = (savedObject: GraphWorkspaceSavedObject): GraphUserContent => {
   return {
@@ -35,7 +44,6 @@ const toTableListViewSavedObject = (savedObject: GraphWorkspaceSavedObject): Gra
     },
   };
 };
-
 export interface ListingRouteProps {
   deps: Omit<GraphServices, 'savedObjects'>;
 }
@@ -43,153 +51,111 @@ export interface ListingRouteProps {
 export function ListingRoute({
   deps: { chrome, contentClient, coreStart, capabilities, addBasePath, uiSettings },
 }: ListingRouteProps) {
-  const listingLimit = uiSettings.get(SAVED_OBJECTS_LIMIT_SETTING);
-  const initialPageSize = uiSettings.get(SAVED_OBJECTS_PER_PAGE_SETTING);
   const history = useHistory();
   const query = new URLSearchParams(useLocation().search);
-  const initialFilter = query.get('filter') || '';
+  // `?filter=` is a legacy `TableListView` bookmark seed; the canonical key
+  // is now `q`, written by the provider's URL sync.
+  const initialFilter = query.get('filter') ?? '';
+  const canSave = capabilities.graph.save === true;
+  const canDelete = capabilities.graph.delete === true;
+  const basePath = coreStart.http.basePath;
 
   useEffect(() => {
     setBreadcrumbs({ chrome });
   }, [chrome]);
 
-  const createItem = useCallback(() => {
+  const onCreateGraph = useCallback(() => {
     history.push(getNewPath());
   }, [history]);
 
-  const findItems = useCallback(
-    (search: string) => {
-      return findSavedWorkspace(
-        { contentClient, basePath: coreStart.http.basePath },
-        search,
-        listingLimit
-      ).then(({ total, hits }) => ({
-        total,
-        hits: hits.map(toTableListViewSavedObject),
-      }));
+  const findItems: TableListViewFindItemsFn = useCallback(
+    async (searchQuery, options) => {
+      const { total, hits } = await findSavedWorkspace(
+        { contentClient, basePath },
+        searchQuery,
+        options?.listingLimit
+      );
+      return { total, hits: hits.map(toTableListViewSavedObject) };
     },
-    [coreStart.http.basePath, listingLimit, contentClient]
+    [contentClient, basePath]
   );
 
-  const editItem = useCallback(
-    (savedWorkspace: { id: string }) => {
-      history.push(getEditPath(savedWorkspace));
-    },
+  const sampleDataUrl = coreStart.application.getUrlForApp('home', {
+    path: '#/tutorial_directory/sampleData',
+  });
+
+  const createGraphButton = useMemo(
+    () => (
+      <EuiButton
+        fill
+        iconType="plusInCircle"
+        onClick={onCreateGraph}
+        data-test-subj="graphCreateGraphButton"
+      >
+        <FormattedMessage
+          id="xpack.graph.listing.createGraphButtonLabel"
+          defaultMessage="Create graph"
+        />
+      </EuiButton>
+    ),
+    [onCreateGraph]
+  );
+
+  const getHref = useCallback(
+    ({ id }: ContentListItem) => getEditUrl(addBasePath, { id }),
+    [addBasePath]
+  );
+
+  const handleEdit = useCallback(
+    ({ id }: ContentListItem) => history.push(getEditPath({ id })),
     [history]
   );
 
-  const deleteItems = useCallback(
-    async (savedWorkspaces: Array<{ id: string }>) => {
+  const handleDelete = useCallback(
+    async (items: ContentListItem[]) => {
       await deleteSavedWorkspace(
         contentClient,
-        savedWorkspaces.map((cur) => cur.id!)
+        items.map(({ id }) => id)
       );
     },
     [contentClient]
   );
 
-  return (
-    <TableListView<GraphUserContent>
-      id="graph"
-      headingId="graphListingHeading"
-      createItem={capabilities.graph.save ? createItem : undefined}
-      findItems={findItems}
-      deleteItems={capabilities.graph.delete ? deleteItems : undefined}
-      editItem={capabilities.graph.save ? editItem : undefined}
-      initialFilter={initialFilter}
-      initialPageSize={initialPageSize}
-      emptyPrompt={getNoItemsMessage(
-        capabilities.graph.save === false,
-        createItem,
-        coreStart.application
-      )}
-      entityName={i18n.translate('xpack.graph.listing.table.entityName', {
-        defaultMessage: 'graph',
-      })}
-      entityNamePlural={i18n.translate('xpack.graph.listing.table.entityNamePlural', {
-        defaultMessage: 'graphs',
-      })}
-      title={i18n.translate('xpack.graph.listing.graphsTitle', {
-        defaultMessage: 'Graphs',
-      })}
-      getDetailViewLink={({ id }) => getEditUrl(addBasePath, { id })}
-    />
+  const item = useMemo(
+    () => ({
+      getHref,
+      onEdit: canSave ? handleEdit : undefined,
+      onDelete: canDelete ? handleDelete : undefined,
+    }),
+    [canDelete, canSave, getHref, handleDelete, handleEdit]
   );
-}
-
-function getNoItemsMessage(
-  hideWriteControls: boolean,
-  createItem: () => void,
-  application: ApplicationStart
-) {
-  if (hideWriteControls) {
-    return (
-      <EuiEmptyPrompt
-        iconType="graphApp"
-        title={
-          <h1 id="graphListingHeading">
-            <FormattedMessage
-              id="xpack.graph.listing.noItemsMessage"
-              defaultMessage="Looks like you don't have any graphs."
-            />
-          </h1>
-        }
-      />
-    );
-  }
-
-  const sampleDataUrl = `${application.getUrlForApp('home')}#/tutorial_directory/sampleData`;
 
   return (
-    <EuiEmptyPrompt
-      iconType="graphApp"
-      title={
-        <h1 id="graphListingHeading">
-          <FormattedMessage
-            id="xpack.graph.listing.createNewGraph.title"
-            defaultMessage="Create your first graph"
-          />
-        </h1>
-      }
-      body={
-        <Fragment>
-          <p>
-            <FormattedMessage
-              id="xpack.graph.listing.createNewGraph.combineDataViewFromKibanaAppDescription"
-              defaultMessage="Discover patterns and relationships in your Elasticsearch indices."
-            />
-          </p>
-          <p>
-            <FormattedMessage
-              id="xpack.graph.listing.createNewGraph.newToKibanaDescription"
-              defaultMessage="New to Kibana? Get started with {sampleDataInstallLink}."
-              values={{
-                sampleDataInstallLink: (
-                  <EuiLink href={sampleDataUrl}>
-                    <FormattedMessage
-                      id="xpack.graph.listing.createNewGraph.sampleDataInstallLinkText"
-                      defaultMessage="sample data"
-                    />
-                  </EuiLink>
-                ),
-              }}
-            />
-          </p>
-        </Fragment>
-      }
-      actions={
-        <EuiButton
-          onClick={createItem}
-          fill
-          iconType="plusCircle"
-          data-test-subj="graphCreateGraphPromptButton"
-        >
-          <FormattedMessage
-            id="xpack.graph.listing.createNewGraph.createButtonLabel"
-            defaultMessage="Create graph"
-          />
-        </EuiButton>
-      }
-    />
+    <KibanaContentListPage>
+      <KibanaContentListPage.Header
+        title={i18n.translate('xpack.graph.listing.graphsTitle', {
+          defaultMessage: 'Graphs',
+        })}
+        {...(canSave && {
+          actions: createGraphButton,
+        })}
+      />
+      <ContentListClientProvider
+        {...{ labels, findItems, item }}
+        id="graph-listing"
+        isReadOnly={!canSave}
+        services={{ uiSettings }}
+        features={{
+          sorting: { initialSort: { field: 'updatedAt', direction: 'desc' } },
+          pagination: true,
+          selection: canDelete,
+          search: initialFilter ? { initialSearch: initialFilter } : undefined,
+        }}
+      >
+        <KibanaContentListPage.Section>
+          <GraphContentList {...{ canSave, sampleDataUrl, onCreateGraph }} />
+        </KibanaContentListPage.Section>
+      </ContentListClientProvider>
+    </KibanaContentListPage>
   );
 }

--- a/x-pack/platform/plugins/private/graph/public/components/content_list/empty_prompt.tsx
+++ b/x-pack/platform/plugins/private/graph/public/components/content_list/empty_prompt.tsx
@@ -1,0 +1,92 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiLink } from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n-react';
+import { ContentListEmptyState } from '@kbn/content-list';
+
+/**
+ * Props for {@link GraphEmptyPrompt}, shared with {@link GraphContentListProps}
+ * so the listing route can forward them without an extra wrapper.
+ */
+export interface GraphEmptyPromptProps {
+  /** URL to the sample-data installer page. */
+  sampleDataUrl: string;
+  /** Called when the user clicks the "Create graph" button. */
+  onCreateGraph: () => void;
+  /** Whether the user has write access to graph workspaces. */
+  canSave: boolean;
+}
+
+/**
+ * Empty state for the graph content list.
+ *
+ * Shows a read-only message when the user lacks save permissions, or a
+ * create-first prompt with a sample-data link when they can save.
+ */
+export const GraphEmptyPrompt = ({
+  canSave,
+  sampleDataUrl,
+  onCreateGraph,
+}: GraphEmptyPromptProps) => (
+  <ContentListEmptyState
+    iconType="graphApp"
+    title={
+      canSave ? (
+        <FormattedMessage
+          id="xpack.graph.listing.createNewGraph.title"
+          defaultMessage="Create your first graph"
+        />
+      ) : (
+        <FormattedMessage
+          id="xpack.graph.listing.noItemsMessage"
+          defaultMessage="Looks like you don't have any graphs."
+        />
+      )
+    }
+    {...(canSave && {
+      body: (
+        <>
+          <p>
+            <FormattedMessage
+              id="xpack.graph.listing.createNewGraph.combineDataViewFromKibanaAppDescription"
+              defaultMessage="Discover patterns and relationships in your Elasticsearch indices."
+            />
+          </p>
+          <p>
+            <FormattedMessage
+              id="xpack.graph.listing.createNewGraph.newToKibanaDescription"
+              defaultMessage="New to Kibana? Get started with {sampleDataInstallLink}."
+              values={{
+                sampleDataInstallLink: (
+                  <EuiLink href={sampleDataUrl}>
+                    <FormattedMessage
+                      id="xpack.graph.listing.createNewGraph.sampleDataInstallLinkText"
+                      defaultMessage="sample data"
+                    />
+                  </EuiLink>
+                ),
+              }}
+            />
+          </p>
+        </>
+      ),
+      primaryAction: {
+        label: (
+          <FormattedMessage
+            id="xpack.graph.listing.createNewGraph.createButtonLabel"
+            defaultMessage="Create graph"
+          />
+        ),
+        onClick: onCreateGraph,
+        iconType: 'plusCircle',
+        'data-test-subj': 'graphCreateGraphPromptButton',
+      },
+    })}
+  />
+);

--- a/x-pack/platform/plugins/private/graph/public/components/content_list/graph_content_list.tsx
+++ b/x-pack/platform/plugins/private/graph/public/components/content_list/graph_content_list.tsx
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import {
+  ContentList,
+  ContentListTable,
+  ContentListToolbar,
+  ContentListFooter,
+} from '@kbn/content-list';
+import type { GraphEmptyPromptProps } from './empty_prompt';
+import { GraphEmptyPrompt } from './empty_prompt';
+
+const { Column } = ContentListTable;
+
+/**
+ * Props for {@link GraphContentList}.
+ *
+ * Mirrors {@link GraphEmptyPromptProps} so the listing route forwards
+ * `canSave`, `sampleDataUrl`, and `onCreateGraph` straight through.
+ */
+export type GraphContentListProps = GraphEmptyPromptProps;
+
+/**
+ * Visual composition for the graph workspaces list.
+ *
+ * Renders the toolbar, table, footer, and empty state inside the surrounding
+ * `ContentListClientProvider` (configured by the listing route). All data
+ * wiring — `findItems`, item actions, labels, and capability flags — lives at
+ * the route level so this component stays focused on layout.
+ */
+export const GraphContentList = (props: GraphContentListProps) => (
+  <ContentList emptyState={<GraphEmptyPrompt {...props} />}>
+    <ContentListToolbar />
+    <ContentListTable title="Graphs">
+      <Column.Name showDescription />
+      <Column.UpdatedAt />
+      <Column.Actions />
+    </ContentListTable>
+    <ContentListFooter />
+  </ContentList>
+);

--- a/x-pack/platform/plugins/private/graph/public/components/content_list/index.ts
+++ b/x-pack/platform/plugins/private/graph/public/components/content_list/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { GraphContentList } from './graph_content_list';

--- a/x-pack/platform/plugins/private/graph/test/scout/ui/fixtures/constants.ts
+++ b/x-pack/platform/plugins/private/graph/test/scout/ui/fixtures/constants.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * Shared sample graph workspaces and saved-object attributes used by the
+ * graph listing Scout specs. Hoisted into the fixtures module so spec files
+ * can't drift on shape (the `kbnClient.savedObjects.create` payloads have
+ * to stay in lockstep with the `graph-workspace` saved-object schema).
+ */
+
+export const GRAPH_A = { title: 'Graph Alpha', description: 'First test graph' };
+export const GRAPH_B = { title: 'Graph Beta', description: 'Second test graph' };
+
+/**
+ * Required saved-object fields for a `graph-workspace` beyond `title` and
+ * `description`. Empty workspace state is fine for listing-only coverage.
+ */
+export const WORKSPACE_ATTRS = { numLinks: 0, numVertices: 0, wsState: '{}', version: 1 };

--- a/x-pack/platform/plugins/private/graph/test/scout/ui/fixtures/index.ts
+++ b/x-pack/platform/plugins/private/graph/test/scout/ui/fixtures/index.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type {
+  PageObjects,
+  ScoutParallelTestFixtures,
+  ScoutParallelWorkerFixtures,
+} from '@kbn/scout';
+import { spaceTest as spaceBaseTest, createLazyPageObject } from '@kbn/scout';
+import { GraphListingPage } from './page_objects';
+
+export interface GraphTestFixtures extends ScoutParallelTestFixtures {
+  pageObjects: PageObjects & {
+    graphListing: GraphListingPage;
+  };
+}
+
+export const spaceTest = spaceBaseTest.extend<GraphTestFixtures, ScoutParallelWorkerFixtures>({
+  pageObjects: async (
+    {
+      pageObjects,
+      page,
+    }: {
+      pageObjects: GraphTestFixtures['pageObjects'];
+      page: GraphTestFixtures['page'];
+    },
+    use: (pageObjects: GraphTestFixtures['pageObjects']) => Promise<void>
+  ) => {
+    await use({
+      ...pageObjects,
+      graphListing: createLazyPageObject(GraphListingPage, page),
+    });
+  },
+});

--- a/x-pack/platform/plugins/private/graph/test/scout/ui/fixtures/page_objects/graph_listing_page.ts
+++ b/x-pack/platform/plugins/private/graph/test/scout/ui/fixtures/page_objects/graph_listing_page.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ScoutPage, Locator } from '@kbn/scout';
+import { ContentListWrapper } from '@kbn/scout';
+
+/**
+ * Page object for the Graph listing page (`/app/graph#/home`).
+ *
+ * Generic Content List interactions (toolbar search, sort, selection, etc.)
+ * are delegated to {@link ContentListWrapper}; this class only owns
+ * Graph-specific navigation and CTAs.
+ */
+export class GraphListingPage {
+  readonly contentList: ContentListWrapper;
+  readonly createGraphButton: Locator;
+  readonly emptyPromptCreateButton: Locator;
+
+  constructor(private readonly page: ScoutPage) {
+    this.contentList = new ContentListWrapper(page);
+    this.createGraphButton = this.page.testSubj.locator('graphCreateGraphButton');
+    this.emptyPromptCreateButton = this.page.testSubj.locator('graphCreateGraphPromptButton');
+  }
+
+  /** Navigate to the Graph listing page and wait for the header to be visible. */
+  async goto() {
+    await this.page.gotoApp('graph');
+    await this.contentList.waitForReady();
+  }
+}

--- a/x-pack/platform/plugins/private/graph/test/scout/ui/fixtures/page_objects/index.ts
+++ b/x-pack/platform/plugins/private/graph/test/scout/ui/fixtures/page_objects/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { GraphListingPage } from './graph_listing_page';

--- a/x-pack/platform/plugins/private/graph/test/scout/ui/parallel.playwright.config.ts
+++ b/x-pack/platform/plugins/private/graph/test/scout/ui/parallel.playwright.config.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createPlaywrightConfig } from '@kbn/scout';
+
+export default createPlaywrightConfig({
+  testDir: './parallel_tests',
+  workers: 2,
+});

--- a/x-pack/platform/plugins/private/graph/test/scout/ui/parallel_tests/graph_listing.spec.ts
+++ b/x-pack/platform/plugins/private/graph/test/scout/ui/parallel_tests/graph_listing.spec.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/ui';
+import { spaceTest } from '../fixtures';
+import { GRAPH_A, GRAPH_B, WORKSPACE_ATTRS } from '../fixtures/constants';
+
+spaceTest.describe('Graph listing page', { tag: tags.stateful.classic }, () => {
+  // Read and search tests share a stable data set created once per worker.
+  spaceTest.beforeAll(async ({ kbnClient, scoutSpace }) => {
+    await scoutSpace.savedObjects.cleanStandardList();
+    await kbnClient.savedObjects.create({
+      type: 'graph-workspace',
+      attributes: { ...GRAPH_A, ...WORKSPACE_ATTRS },
+      space: scoutSpace.id,
+    });
+    await kbnClient.savedObjects.create({
+      type: 'graph-workspace',
+      attributes: { ...GRAPH_B, ...WORKSPACE_ATTRS },
+      space: scoutSpace.id,
+    });
+  });
+
+  spaceTest.beforeEach(async ({ browserAuth }) => {
+    await browserAuth.loginAsPrivilegedUser();
+  });
+
+  spaceTest.afterAll(async ({ scoutSpace }) => {
+    await scoutSpace.savedObjects.cleanStandardList();
+  });
+
+  spaceTest('renders the page header and saved graphs', async ({ pageObjects }) => {
+    await pageObjects.graphListing.goto();
+    await expect(pageObjects.graphListing.contentList.pageHeader).toBeVisible();
+    await expect(pageObjects.graphListing.contentList.itemLinks).toHaveCount(2);
+  });
+
+  spaceTest('search filters items by title', async ({ pageObjects }) => {
+    await pageObjects.graphListing.goto();
+    await pageObjects.graphListing.contentList.searchFor(GRAPH_A.title);
+    await expect(pageObjects.graphListing.contentList.itemLinks).toHaveCount(1);
+    await expect(
+      pageObjects.graphListing.contentList.itemLinks.filter({ hasText: GRAPH_A.title })
+    ).toHaveCount(1);
+  });
+
+  spaceTest(
+    'create graph button navigates to the workspace editor',
+    async ({ pageObjects, page }) => {
+      await pageObjects.graphListing.goto();
+      await pageObjects.graphListing.createGraphButton.click();
+      await expect(page).toHaveURL(/\/app\/graph#\/workspace\//);
+    }
+  );
+});

--- a/x-pack/platform/plugins/private/graph/test/scout/ui/parallel_tests/graph_listing_delete.spec.ts
+++ b/x-pack/platform/plugins/private/graph/test/scout/ui/parallel_tests/graph_listing_delete.spec.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/ui';
+import { spaceTest } from '../fixtures';
+import { GRAPH_A, GRAPH_B, WORKSPACE_ATTRS } from '../fixtures/constants';
+
+spaceTest.describe('Graph listing page - delete flow', { tag: tags.stateful.classic }, () => {
+  spaceTest.beforeAll(async ({ kbnClient, scoutSpace }) => {
+    await scoutSpace.savedObjects.cleanStandardList();
+    await kbnClient.savedObjects.create({
+      type: 'graph-workspace',
+      attributes: { ...GRAPH_A, ...WORKSPACE_ATTRS },
+      space: scoutSpace.id,
+    });
+    await kbnClient.savedObjects.create({
+      type: 'graph-workspace',
+      attributes: { ...GRAPH_B, ...WORKSPACE_ATTRS },
+      space: scoutSpace.id,
+    });
+  });
+
+  spaceTest.beforeEach(async ({ browserAuth }) => {
+    await browserAuth.loginAsPrivilegedUser();
+  });
+
+  spaceTest.afterAll(async ({ scoutSpace }) => {
+    await scoutSpace.savedObjects.cleanStandardList();
+  });
+
+  spaceTest(
+    'select all and delete removes all graphs and shows empty state',
+    async ({ pageObjects }) => {
+      await pageObjects.graphListing.goto();
+      await expect(pageObjects.graphListing.contentList.itemLinks).toHaveCount(2);
+      await pageObjects.graphListing.contentList.selectAllAndDelete();
+      await expect(pageObjects.graphListing.emptyPromptCreateButton).toBeVisible();
+    }
+  );
+});

--- a/x-pack/platform/plugins/private/graph/tsconfig.json
+++ b/x-pack/platform/plugins/private/graph/tsconfig.json
@@ -1,4 +1,3 @@
-
 {
   "extends": "@kbn/tsconfig-base/tsconfig.json",
   "compilerOptions": {
@@ -10,6 +9,7 @@
     "common/**/*",
     "public/**/*",
     "server/**/*",
+    "test/scout/**/*",
     "../../../../../typings/**/*",
   ],
   "kbn_references": [
@@ -41,19 +41,21 @@
     "@kbn/core-saved-objects-server",
     "@kbn/content-management-plugin",
     "@kbn/object-versioning",
-    "@kbn/content-management-table-list-view-table",
-    "@kbn/content-management-table-list-view",
+    "@kbn/content-list",
+    "@kbn/content-list-page",
+    "@kbn/content-list-provider-client",
+    "@kbn/content-management-table-list-view-common",
     "@kbn/core-ui-settings-browser",
     "@kbn/react-kibana-mount",
     "@kbn/content-management-utils",
     "@kbn/logging",
-    "@kbn/content-management-table-list-view-common",
     "@kbn/visualization-utils",
-    "@kbn/react-kibana-context-render",
     "@kbn/core-saved-objects-api-server",
     "@kbn/licensing-types",
     "@kbn/kql",
     "@kbn/unified-search-plugin",
+    "@kbn/scout",
+    "@kbn/content-list-provider",
   ],
   "exclude": [
     "target/**/*",

--- a/x-pack/platform/test/functional/apps/graph/feature_controls/graph_security.ts
+++ b/x-pack/platform/test/functional/apps/graph/feature_controls/graph_security.ts
@@ -74,7 +74,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       it('landing page shows "Create new graph" button', async () => {
         await common.navigateToApp('graph');
         await header.waitUntilLoadingHasFinished();
-        await testSubjects.existOrFail('graphLandingPage', { timeout: 10000 });
+        await testSubjects.existOrFail('kibana-content-list-page-header', { timeout: 10000 });
         await testSubjects.existOrFail('graphCreateGraphPromptButton');
       });
 
@@ -135,7 +135,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       it('does not show a "Create new Workspace" button', async () => {
         await common.navigateToApp('graph');
         await header.waitUntilLoadingHasFinished();
-        await testSubjects.existOrFail('graphLandingPage', { timeout: 10000 });
+        await testSubjects.existOrFail('kibana-content-list-page-header', { timeout: 10000 });
         await testSubjects.missingOrFail('newItemButton');
       });
 

--- a/x-pack/platform/test/functional/apps/graph/feature_controls/graph_spaces.ts
+++ b/x-pack/platform/test/functional/apps/graph/feature_controls/graph_spaces.ts
@@ -46,7 +46,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
           basePath: '/s/custom_space',
         });
         await header.waitUntilLoadingHasFinished();
-        await testSubjects.existOrFail('graphLandingPage', { timeout: 10000 });
+        await testSubjects.existOrFail('kibana-content-list-page-header', { timeout: 10000 });
         await testSubjects.existOrFail('graphCreateGraphPromptButton');
       });
 

--- a/x-pack/platform/test/functional/apps/graph/graph.ts
+++ b/x-pack/platform/test/functional/apps/graph/graph.ts
@@ -36,8 +36,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     });
 
     after(async () => {
-      await kibanaServer.savedObjects.clean({ types: ['index-pattern'] });
-
+      await kibanaServer.savedObjects.clean({ types: ['graph-workspace', 'index-pattern'] });
       await esArchiver.unload('x-pack/platform/test/fixtures/es_archives/graph/secrepo');
     });
 
@@ -177,13 +176,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       expect(smallVennTerm1).to.be('4');
       expect(smallVennTerm12).to.be(' (4) ');
       expect(smallVennTerm2).to.be('4');
-    });
-
-    it('should delete graph', async function () {
-      await graph.goToListingPage();
-      expect(await graph.getWorkspaceCount()).to.equal(1);
-      await graph.deleteGraph(graphName);
-      expect(await graph.getWorkspaceCount()).to.equal(0);
     });
   });
 }

--- a/x-pack/platform/test/functional/page_objects/graph_page.ts
+++ b/x-pack/platform/test/functional/page_objects/graph_page.ts
@@ -202,21 +202,13 @@ export class GraphPageObject extends FtrService {
     return await this.testSubjects.exists('saveGraphSuccess', { timeout: 10000 });
   }
 
-  async getSearchFilter() {
-    const searchFilter = await this.find.allByCssSelector(
-      '[data-test-subj="graphLandingPage"] .euiFieldSearch'
-    );
-    return searchFilter[0];
-  }
-
   async searchForWorkspaceWithName(name: string) {
     await this.retry.try(async () => {
-      const searchFilter = await this.getSearchFilter();
-      await searchFilter.clearValue();
-      await searchFilter.click();
-      await searchFilter.type(name);
+      const searchBox = await this.testSubjects.find('contentListToolbar-searchBox');
+      await searchBox.clearValue();
+      await searchBox.click();
+      await searchBox.type(name);
       await this.common.pressEnterKey();
-      await this.find.waitForDeletedByCssSelector('.euiBasicTable-loading', 5000);
     });
 
     await this.header.waitUntilLoadingHasFinished();
@@ -225,7 +217,7 @@ export class GraphPageObject extends FtrService {
   async goToListingPage() {
     await this.retry.try(async () => {
       await this.testSubjects.click('breadcrumb graphHomeBreadcrumb first');
-      await this.testSubjects.existOrFail('graphLandingPage', { timeout: 3000 });
+      await this.testSubjects.existOrFail('kibana-content-list-page-header', { timeout: 3000 });
     });
   }
 
@@ -239,24 +231,6 @@ export class GraphPageObject extends FtrService {
     }
     // let force simulation settle down before continuing
     await this.common.sleep(5000);
-  }
-
-  async deleteGraph(name: string) {
-    await this.testSubjects.click('checkboxSelectAll');
-    await this.clickDeleteSelectedWorkspaces();
-    await this.common.clickConfirmOnModal();
-    await this.testSubjects.find('graphCreateGraphPromptButton');
-  }
-
-  async getWorkspaceCount() {
-    const workspaceTitles = await this.find.allByCssSelector(
-      '[data-test-subj^="graphListingTitleLink"]'
-    );
-    return workspaceTitles.length;
-  }
-
-  async clickDeleteSelectedWorkspaces() {
-    await this.testSubjects.click('deleteSelectedItems');
   }
 
   async getVennTerm1() {


### PR DESCRIPTION
## Summary

MS1.1: migrate the Graph plugin's listing page from the legacy `TableListView` to the new `ContentListProvider` / `ContentList` architecture.

The Graph listing previously lived in a monolithic `listing_route.tsx` that rendered `TableListView` directly. This PR replaces it with a focused `GraphContentList` component backed by `ContentListProvider`, using the same composable assembly approach established in the earlier PRs.

### What changed

**Graph plugin**

- `listing_route.tsx` gutted and re-wired: `GraphContentList` replaces the inline `TableListView` usage; the route file is now responsible only for service injection and navigation callbacks.
- New `GraphContentList` component in `public/components/content_list/graph_content_list.tsx` — assembles the content list with columns, actions, and an empty-state prompt.
- New `GraphEmptyPrompt` component in `public/components/content_list/empty_prompt.tsx`.
- `moon.yml` updated to include Scout test config and add `@kbn/content-list-*` dependencies.
- `tsconfig.json` updated to reference the new content list packages.

**Scout UI tests** (new)

- `parallel.playwright.config.ts` — Playwright config for the Graph listing.
- `global.setup.ts` — auth setup.
- `graph_listing_page.ts` — page object for the Graph listing page.
- `graph_listing.spec.ts` — specs covering the listing, empty state, CRUD actions, and search.

**FTR tests** (updated)

- Minor updates to `graph_page.ts`, `graph.ts`, `graph_security.ts`, `graph_spaces.ts` to keep existing FTR tests passing after the component refactor.

## Stack

1. #266442 — Phase model
2. #266441 — Facade package
3. #266246 — Page shell + proposal stories
4. #266403 — Skeleton loading system
5. #266428 — Saved object provider services
6. #266518 — Per-row selection gating via SelectionConfig
7. #267373 — Column sizing & full-width page layout
8. #267632 — URL persistence for query and sort state
9. **This PR:** MS1.1: Migrate Graph Listing

## Validation

- `node scripts/check_changes.ts`
- `node scripts/type_check --project x-pack/platform/plugins/private/graph/tsconfig.json`
- `node scripts/jest x-pack/platform/plugins/private/graph/`
- Scout tests: `node scripts/scout run-tests --arch stateful --domain classic --config x-pack/platform/plugins/private/graph/test/scout/ui/parallel.playwright.config.ts`