### PR TITLE
[9.4] [Search] Allow homepage requests to fail silently (#265915)

### DIFF
--- a/x-pack/solutions/search/plugins/search_homepage/public/components/getting_started_redirect_gate.tsx
+++ b/x-pack/solutions/search/plugins/search_homepage/public/components/getting_started_redirect_gate.tsx
@@ -29,7 +29,7 @@ export const GettingStartedRedirectGate = ({ coreStart, children }: Props) => {
     !visitedGettingStartedPage || visitedGettingStartedPage === 'false'; // visit if null or value is false
 
   const shouldRedirect =
-    storageStats !== undefined &&
+    storageStats != null &&
     ((cloud?.isCloudEnabled ? cloud?.isInTrial() : isTrial) || storageStats.hasNoDocuments) &&
     shouldVisitGettingStartedPage;
 

--- a/x-pack/solutions/search/plugins/search_homepage/public/components/search_homepage/basic_metric_badges.tsx
+++ b/x-pack/solutions/search/plugins/search_homepage/public/components/search_homepage/basic_metric_badges.tsx
@@ -7,14 +7,7 @@
 
 import React from 'react';
 
-import {
-  EuiBadge,
-  EuiFlexGroup,
-  EuiLoadingSpinner,
-  EuiText,
-  EuiTextColor,
-  useEuiTheme,
-} from '@elastic/eui';
+import { EuiBadge, EuiFlexGroup, EuiText, EuiTextColor, useEuiTheme } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { css } from '@emotion/react';
 import { useDashboardsStats } from '../../hooks/api/use_dashboards_stats';
@@ -29,33 +22,47 @@ type BasicMetricPanelType = (typeof BASIC_METRIC_PANEL_TYPES)[number];
 interface BasicMetricPanel {
   type: BasicMetricPanelType;
   title: string;
-  metric?: string | number | Array<string | undefined>;
-  isLoading?: boolean;
+  metric?: string | number | Array<string | undefined> | undefined;
   isError?: boolean;
 }
 
-type BasicMetricPanelProps = Omit<BasicMetricPanel, 'type'>;
-const BasicMetricPanel = ({
-  title,
-  metric,
-  isLoading = false,
-  isError = false,
-}: BasicMetricPanelProps) => {
+const isMetricEmpty = (metric: BasicMetricPanel['metric']): boolean => {
+  if (metric === undefined) {
+    return true;
+  }
+  if (Array.isArray(metric)) {
+    return metric.every((m) => m === undefined);
+  }
+  return false;
+};
+
+interface BasicMetricPanelProps {
+  type: BasicMetricPanelType;
+  title: string;
+  metric?: string | number | Array<string | undefined> | undefined;
+  isError?: boolean;
+}
+
+const BasicMetricPanel = ({ type, title, metric, isError = false }: BasicMetricPanelProps) => {
   const { euiTheme } = useEuiTheme();
+
+  if (!isError && isMetricEmpty(metric)) {
+    return null;
+  }
+
   return (
     <EuiBadge
       color={euiTheme.colors.backgroundBaseSubdued}
       css={css({
         padding: `${euiTheme.size.xs} ${euiTheme.size.m}`,
       })}
+      data-test-subj={`searchHomepageMetricBadge-${type}`}
     >
       <EuiText size="s">
         <EuiTextColor color="subdued">{title}</EuiTextColor>
         &nbsp;&nbsp;
-        {isLoading && <EuiLoadingSpinner size="s" />}
-        {!isLoading && isError && '—'}
-        {!isLoading &&
-          !isError &&
+        {isError && '—'}
+        {!isError &&
           (Array.isArray(metric)
             ? metric.map((m) => {
                 return (m && `${m} `) ?? null;
@@ -67,22 +74,10 @@ const BasicMetricPanel = ({
 };
 
 export const BasicMetricBadges = () => {
-  const {
-    data: storageStats,
-    isLoading: isLoadingStorageStats,
-    isError: isErrorStorageStats,
-  } = useStats();
-  const {
-    data: indicesData,
-    isLoading: isLoadingIndices,
-    isError: isErrorIndicesStats,
-  } = useIndicesStats();
-  const {
-    data: dashboardsData,
-    isLoading: isLoadingDashboards,
-    isError: isErrorDashboards,
-  } = useDashboardsStats();
-  const { tools, agents, isLoading: isLoadingAgents, isError: isErrorAgents } = useAgentCount();
+  const { data: storageStats, isError: isErrorStorageStats } = useStats();
+  const { data: indicesData, isError: isErrorIndicesStats } = useIndicesStats();
+  const { data: dashboardsData, isError: isErrorDashboards } = useDashboardsStats();
+  const { tools, agents, isError: isErrorAgents } = useAgentCount();
 
   const basicPanels: Array<BasicMetricPanel> = [
     {
@@ -90,8 +85,7 @@ export const BasicMetricBadges = () => {
       title: i18n.translate('xpack.searchHomepage.metricPanel.basic.indices.title', {
         defaultMessage: 'Indices',
       }),
-      metric: indicesData?.normalIndices ?? 0,
-      isLoading: isLoadingIndices,
+      metric: indicesData?.normalIndices,
       isError: isErrorIndicesStats,
     },
     {
@@ -99,8 +93,7 @@ export const BasicMetricBadges = () => {
       title: i18n.translate('xpack.searchHomepage.metricPanel.basic.storage.title', {
         defaultMessage: 'Storage',
       }),
-      metric: storageStats?.size ?? '-',
-      isLoading: isLoadingStorageStats,
+      metric: storageStats?.size,
       isError: isErrorStorageStats,
     },
     {
@@ -109,7 +102,7 @@ export const BasicMetricBadges = () => {
         defaultMessage: 'Agent Builder',
       }),
       metric: [
-        agents !== undefined && agents !== null
+        agents != null
           ? i18n.translate('xpack.searchHomepage.metricPanel.basic.agentBuilder.agents', {
               defaultMessage: '{agents, plural, one {# agent} other {# agents}}',
               values: {
@@ -117,7 +110,7 @@ export const BasicMetricBadges = () => {
               },
             })
           : undefined,
-        tools !== undefined && tools !== null
+        tools != null
           ? i18n.translate('xpack.searchHomepage.metricPanel.basic.agentBuilder.tools', {
               defaultMessage: '{tools, plural, one {# tool} other {# tools}}',
               values: {
@@ -126,7 +119,6 @@ export const BasicMetricBadges = () => {
             })
           : undefined,
       ],
-      isLoading: isLoadingAgents,
       isError: isErrorAgents,
     },
     {
@@ -134,20 +126,19 @@ export const BasicMetricBadges = () => {
       title: i18n.translate('xpack.searchHomepage.metricPanel.basic.discover.title', {
         defaultMessage: 'Dashboards',
       }),
-      metric: dashboardsData?.totalDashboards ?? 0,
-      isLoading: isLoadingDashboards,
+      metric: dashboardsData?.totalDashboards,
       isError: isErrorDashboards,
     },
   ];
   return (
-    <EuiFlexGroup gutterSize="s">
+    <EuiFlexGroup gutterSize="s" data-test-subj="searchHomepageMetricBadges">
       {basicPanels.map((panel) => {
         return (
           <BasicMetricPanel
+            type={panel.type}
             title={panel.title}
             metric={panel.metric}
             key={panel.type}
-            isLoading={panel.isLoading}
             isError={panel.isError}
           />
         );

--- a/x-pack/solutions/search/plugins/search_homepage/public/components/search_homepage/metric_panels.tsx
+++ b/x-pack/solutions/search/plugins/search_homepage/public/components/search_homepage/metric_panels.tsx
@@ -10,6 +10,7 @@ import { i18n } from '@kbn/i18n';
 import {
   EuiFlexGrid,
   EuiFlexGroup,
+  EuiFlexItem,
   EuiImage,
   EuiSpacer,
   EuiSplitPanel,
@@ -23,6 +24,7 @@ import type { ApplicationStart } from '@kbn/core/public';
 import { WORKFLOWS_UI_SETTING_ENABLED_ID } from '../../../common';
 import { useAssetBasePath } from '../../hooks/use_asset_base_path';
 import { useKibana } from '../../hooks/use_kibana';
+import { useGetLicenseInfo } from '../../hooks/use_get_license_info';
 
 const PANEL_TYPES = [
   'discover',
@@ -199,6 +201,7 @@ const MetricPanelEmpty = ({ panel }: MetricPanelEmptyProps) => {
 };
 
 export const MetricPanels = () => {
+  const { hasEnterpriseLicense } = useGetLicenseInfo();
   const { services } = useKibana();
   const { chrome, uiSettings } = services;
 
@@ -208,7 +211,7 @@ export const MetricPanels = () => {
     const capabilityChecks: Record<MetricPanelType, boolean> = {
       discover: chrome.navLinks.get('discover') !== undefined,
       dashboards: chrome.navLinks.get('dashboards') !== undefined,
-      agentBuilder: chrome.navLinks.get('agent_builder') !== undefined,
+      agentBuilder: chrome.navLinks.get('agent_builder') !== undefined && hasEnterpriseLicense,
       workflows: isWorkflowsUiEnabled && chrome.navLinks.get('workflows') !== undefined,
       machineLearning:
         chrome.navLinks.get('ml:overview') !== undefined || chrome.navLinks.get('ml') !== undefined,
@@ -216,13 +219,32 @@ export const MetricPanels = () => {
     };
 
     return METRIC_PANEL_ITEMS.filter((panel) => capabilityChecks[panel.type]);
-  }, [chrome.navLinks, isWorkflowsUiEnabled]);
+  }, [chrome.navLinks, isWorkflowsUiEnabled, hasEnterpriseLicense]);
+
+  const gridColumns = useMemo(() => {
+    const count = panels.length;
+    if (count === 1 || count === 2 || count === 4) {
+      return 2;
+    }
+    return 3;
+  }, [panels.length]);
+
+  if (panels.length === 0) {
+    return null;
+  }
 
   return (
-    <EuiFlexGrid gutterSize="l" columns={3} data-test-subj="searchHomepageNavLinksTabGrid">
-      {panels.map((panel, index) => (
-        <MetricPanelEmpty panel={panel} key={panel.type + '-' + index} />
-      ))}
-    </EuiFlexGrid>
+    <EuiFlexItem>
+      <EuiSpacer size="l" />
+      <EuiFlexGrid
+        gutterSize="l"
+        columns={gridColumns}
+        data-test-subj="searchHomepageNavLinksTabGrid"
+      >
+        {panels.map((panel, index) => (
+          <MetricPanelEmpty panel={panel} key={panel.type + '-' + index} />
+        ))}
+      </EuiFlexGrid>
+    </EuiFlexItem>
   );
 };

--- a/x-pack/solutions/search/plugins/search_homepage/public/components/search_homepage/search_homepage_body.tsx
+++ b/x-pack/solutions/search/plugins/search_homepage/public/components/search_homepage/search_homepage_body.tsx
@@ -33,11 +33,8 @@ export const SearchHomepageBody = () => {
       css={css({ padding: `0 ${euiTheme.size.l}` })}
     >
       <EuiFlexGroup gutterSize="l" direction="column">
-        <EuiFlexItem>
-          <EuiSpacer size="l" />
-          <MetricPanels />
-        </EuiFlexItem>
-        {cloud?.isServerlessEnabled && (!isAdmin || !isBillingAdmin) ? null : (
+        <MetricPanels />
+        {cloud?.isCloudEnabled && (!isAdmin || !isBillingAdmin) ? null : (
           <EuiFlexItem>
             <EuiSpacer size="l" />
             <CloudResources />

--- a/x-pack/solutions/search/plugins/search_homepage/public/hooks/api/use_agent_count.test.tsx
+++ b/x-pack/solutions/search/plugins/search_homepage/public/hooks/api/use_agent_count.test.tsx
@@ -93,18 +93,17 @@ describe('useAgentCount', () => {
       });
     });
 
-    it('should not fetch data and return zero values with isError true', async () => {
+    it('should not fetch data and return undefined values when disabled', async () => {
       const { result } = renderHook(() => useAgentCount(), { wrapper });
 
-      await waitFor(() => expect(result.current.isLoading).toBeFalsy());
-      expect(result.current.agents).toBe(0);
-      expect(result.current.tools).toBe(0);
-      expect(result.current.isError).toBe(true);
+      expect(result.current.agents).toBeUndefined();
+      expect(result.current.tools).toBeUndefined();
+      expect(result.current.isError).toBe(false);
       expect(mockAgentsService.list).not.toHaveBeenCalled();
       expect(mockToolsService.list).not.toHaveBeenCalled();
     });
 
-    it('should return isError true for platinum license', async () => {
+    it('should not fetch data for platinum license (not enterprise)', async () => {
       mockUseGetLicenseInfo.mockReturnValue({
         hasEnterpriseLicense: false,
         isTrial: false,
@@ -112,8 +111,11 @@ describe('useAgentCount', () => {
       });
       const { result } = renderHook(() => useAgentCount(), { wrapper });
 
-      await waitFor(() => expect(result.current.isLoading).toBeFalsy());
-      expect(result.current.isError).toBe(true);
+      expect(result.current.agents).toBeUndefined();
+      expect(result.current.tools).toBeUndefined();
+      expect(result.current.isError).toBe(false);
+      expect(mockAgentsService.list).not.toHaveBeenCalled();
+      expect(mockToolsService.list).not.toHaveBeenCalled();
     });
   });
 
@@ -136,6 +138,29 @@ describe('useAgentCount', () => {
       expect(result.current.isError).toBeFalsy();
       expect(result.current.agents).toBe(1);
       expect(result.current.tools).toBe(1);
+    });
+  });
+
+  describe('with 403 forbidden error', () => {
+    it('should return null data when API returns 403', async () => {
+      const error = { body: { message: 'Forbidden', statusCode: 403 } };
+      mockAgentsService.list.mockRejectedValue(error);
+
+      const { result } = renderHook(() => useAgentCount(), { wrapper });
+
+      await waitFor(() => expect(result.current.isLoading).toBeFalsy());
+      expect(result.current.isError).toBe(false);
+      expect(result.current.agents).toBeUndefined();
+      expect(result.current.tools).toBeUndefined();
+    });
+
+    it('should set isError for non-403 errors', async () => {
+      const error = { body: { message: 'Internal Server Error', statusCode: 500 } };
+      mockAgentsService.list.mockRejectedValue(error);
+
+      const { result } = renderHook(() => useAgentCount(), { wrapper });
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
     });
   });
 });

--- a/x-pack/solutions/search/plugins/search_homepage/public/hooks/api/use_agent_count.ts
+++ b/x-pack/solutions/search/plugins/search_homepage/public/hooks/api/use_agent_count.ts
@@ -6,8 +6,10 @@
  */
 
 import { useQuery } from '@kbn/react-query';
+
 import { useKibana } from '../use_kibana';
 import { useGetLicenseInfo } from '../use_get_license_info';
+import { getErrorCode } from '../../utils/get_error_message';
 
 export const useAgentCount = () => {
   const {
@@ -16,25 +18,35 @@ export const useAgentCount = () => {
 
   const { hasEnterpriseLicense } = useGetLicenseInfo();
 
+  const isAvailable = hasEnterpriseLicense && !!agentBuilder;
+
   const { data, isLoading, isError } = useQuery({
     queryKey: ['fetchAgentCount'],
+    retry: false,
     queryFn: async () => {
-      const [agents, tools] = await Promise.all([
-        agentBuilder?.agents.list(),
-        agentBuilder?.tools.list(),
-      ]);
-      return {
-        agents: agents?.length ?? 0,
-        tools: tools?.length ?? 0,
-      };
+      try {
+        const [agents, tools] = await Promise.all([
+          agentBuilder?.agents.list(),
+          agentBuilder?.tools.list(),
+        ]);
+        return {
+          agents: agents?.length,
+          tools: tools?.length,
+        };
+      } catch (error) {
+        if (getErrorCode(error) === 403) {
+          return null;
+        }
+        throw error;
+      }
     },
-    enabled: hasEnterpriseLicense && !!agentBuilder,
+    enabled: isAvailable,
   });
 
   return {
-    tools: data?.tools ?? 0,
-    agents: data?.agents ?? 0,
-    isLoading: hasEnterpriseLicense ? isLoading : false,
-    isError: isError || !hasEnterpriseLicense,
+    tools: data?.tools,
+    agents: data?.agents,
+    isLoading,
+    isError,
   };
 };

--- a/x-pack/solutions/search/plugins/search_homepage/public/hooks/api/use_dashboards_stats.ts
+++ b/x-pack/solutions/search/plugins/search_homepage/public/hooks/api/use_dashboards_stats.ts
@@ -7,33 +7,44 @@
 
 import { useQuery } from '@kbn/react-query';
 import type { UseQueryResult } from '@kbn/react-query';
+
 import { useKibana } from '../use_kibana';
+import { getErrorCode } from '../../utils/get_error_message';
 
 export interface DashboardsStats {
   totalDashboards: number;
 }
 
-export const useDashboardsStats = (): UseQueryResult<DashboardsStats> => {
-  const { http } = useKibana().services;
+export const useDashboardsStats = (): UseQueryResult<DashboardsStats | null> => {
+  const { http, chrome } = useKibana().services;
 
-  const queryResult = useQuery<DashboardsStats>({
+  const hasDashboardsNavLink = chrome.navLinks.get('dashboards') !== undefined;
+
+  const queryResult = useQuery<DashboardsStats | null>({
     queryKey: ['fetchDashboardsStats'],
+    retry: false,
     queryFn: async () => {
-      const response = await http.get<{
-        saved_objects: Array<{ id: string; type: string }>;
-        total: number;
-      }>('/api/saved_objects/_find', {
-        query: {
-          type: 'dashboard',
-          per_page: 10000,
-          fields: 'title',
-        },
-      });
+      try {
+        const response = await http.get<{
+          total: number;
+        }>('/api/saved_objects/_find', {
+          query: {
+            type: 'dashboard',
+            per_page: 0,
+          },
+        });
 
-      return {
-        totalDashboards: response.total,
-      };
+        return {
+          totalDashboards: response.total,
+        };
+      } catch (error) {
+        if (getErrorCode(error) === 403) {
+          return null;
+        }
+        throw error;
+      }
     },
+    enabled: hasDashboardsNavLink,
   });
 
   return {

--- a/x-pack/solutions/search/plugins/search_homepage/public/hooks/api/use_indices_stats.ts
+++ b/x-pack/solutions/search/plugins/search_homepage/public/hooks/api/use_indices_stats.ts
@@ -10,6 +10,7 @@ import type { UseQueryResult } from '@kbn/react-query';
 import type { Index } from '@kbn/index-management-shared-types';
 
 import { useKibana } from '../use_kibana';
+import { getErrorCode } from '../../utils/get_error_message';
 
 export interface IndicesStats {
   totalIndices: number;
@@ -19,16 +20,28 @@ export interface IndicesStats {
 
 const API_BASE_PATH = '/api/index_management';
 
-export const useIndicesStats = (): UseQueryResult<IndicesStats> => {
+export const useIndicesStats = (): UseQueryResult<IndicesStats | null> => {
   const { http } = useKibana().services;
 
-  const queryResult = useQuery<Index[], Error, IndicesStats>({
+  const queryResult = useQuery<Index[] | null, Error, IndicesStats | null>({
     queryKey: ['fetchIndicesStats'],
+    retry: false,
     queryFn: async () => {
-      const response = await http.get<Index[]>(`${API_BASE_PATH}/indices`);
-      return response;
+      try {
+        const response = await http.get<Index[]>(`${API_BASE_PATH}/indices`);
+        return response;
+      } catch (error) {
+        if (getErrorCode(error) === 403) {
+          return null;
+        }
+        throw error;
+      }
     },
     select: (indices) => {
+      if (!indices) {
+        return null;
+      }
+
       const hiddenIndices = indices.filter((index) => index.hidden).length;
       const normalIndices = indices.filter((index) => !index.hidden).length;
       const totalIndices = indices.length;

--- a/x-pack/solutions/search/plugins/search_homepage/public/hooks/api/use_stats.test.tsx
+++ b/x-pack/solutions/search/plugins/search_homepage/public/hooks/api/use_stats.test.tsx
@@ -17,7 +17,13 @@ const mockHttpGet = jest.fn();
 
 const mockUseKibana = useKibana as jest.MockedFunction<typeof useKibana>;
 
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: false,
+    },
+  },
+});
 
 const wrapper: React.FC<React.PropsWithChildren<{}>> = ({ children }) => (
   <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
@@ -88,5 +94,25 @@ describe('useStats', () => {
       size: '0 GB',
       hasNoDocuments: true,
     });
+  });
+
+  it('should return null data when API returns 403', async () => {
+    const error = { body: { message: 'Forbidden', statusCode: 403 } };
+    mockHttpGet.mockRejectedValue(error);
+
+    const { result } = renderHook(() => useStats(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toBeNull();
+  });
+
+  it('should set isError for non-403 errors', async () => {
+    const error = { body: { message: 'Internal Server Error', statusCode: 500 } };
+    mockHttpGet.mockRejectedValue(error);
+
+    const { result } = renderHook(() => useStats(), { wrapper });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.data).toBeUndefined();
   });
 });

--- a/x-pack/solutions/search/plugins/search_homepage/public/hooks/api/use_stats.ts
+++ b/x-pack/solutions/search/plugins/search_homepage/public/hooks/api/use_stats.ts
@@ -7,25 +7,34 @@
 
 import type { UseQueryResult } from '@kbn/react-query';
 import { useQuery } from '@kbn/react-query';
+
 import type { StatsResponse } from '../../../server/types';
 import { useKibana } from '../use_kibana';
-
+import { getErrorCode } from '../../utils/get_error_message';
 export interface SizeStats {
   hasNoDocuments: boolean;
   size: StatsResponse['sizeStats']['size'];
 }
 
-export const useStats = (): UseQueryResult<SizeStats> => {
+export const useStats = (): UseQueryResult<SizeStats | null> => {
   const { http } = useKibana().services;
 
-  const queryResult = useQuery<SizeStats, Error>({
+  const queryResult = useQuery<SizeStats | null, Error>({
     queryKey: ['fetchSizeStats'],
+    retry: false,
     queryFn: async () => {
-      const response = await http.get<StatsResponse>('/internal/search_homepage/stats');
-      return {
-        hasNoDocuments: response.sizeStats.documents === 0,
-        size: response.sizeStats.size,
-      };
+      try {
+        const response = await http.get<StatsResponse>('/internal/search_homepage/stats');
+        return {
+          hasNoDocuments: response.sizeStats.documents === 0,
+          size: response.sizeStats.size,
+        };
+      } catch (error) {
+        if (getErrorCode(error) === 403) {
+          return null;
+        }
+        throw error;
+      }
     },
   });
 

--- a/x-pack/solutions/search/plugins/search_homepage/server/routes/size_stats.ts
+++ b/x-pack/solutions/search/plugins/search_homepage/server/routes/size_stats.ts
@@ -16,7 +16,7 @@ export const registerStatsRoutes = (
   _logger: Logger,
   { isServerless }: RouterContextData
 ): void => {
-  router.get<unknown, unknown, StatsResponse>(
+  router.get<unknown, unknown, StatsResponse | undefined>(
     {
       path: GET_STATS_ROUTE,
       security: {
@@ -33,11 +33,18 @@ export const registerStatsRoutes = (
     async (context, _request, response) => {
       const client = (await context.core).elasticsearch.client;
 
-      const stats = await fetchSizeStats(client, isServerless);
-      return response.ok({
-        headers: { 'content-type': 'application/json' },
-        body: stats,
-      });
+      try {
+        const stats = await fetchSizeStats(client, isServerless);
+        return response.ok({
+          headers: { 'content-type': 'application/json' },
+          body: stats,
+        });
+      } catch (error) {
+        if (error.statusCode === 403) {
+          return response.forbidden({ body: error.message });
+        }
+        throw error;
+      }
     }
   );
 };

--- a/x-pack/solutions/search/plugins/search_homepage/test/scout/ui/fixtures/custom_roles.ts
+++ b/x-pack/solutions/search/plugins/search_homepage/test/scout/ui/fixtures/custom_roles.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { KibanaRole } from '@kbn/scout-search';
+
+/**
+ * Creates a role for a user with limited permissions who can only access
+ * Index Management (Data Management panel) in a specific space.
+ * This role is useful for testing limited permission scenarios on the homepage.
+ */
+export const createDataManagementUserRole = (spaceId: string): KibanaRole => ({
+  elasticsearch: {
+    cluster: ['monitor'],
+    indices: [
+      {
+        names: ['*'],
+        privileges: ['manage'],
+      },
+    ],
+  },
+  kibana: [
+    {
+      base: [],
+      feature: {
+        enterpriseSearch: ['all'],
+      },
+      spaces: [spaceId],
+    },
+  ],
+});

--- a/x-pack/solutions/search/plugins/search_homepage/test/scout/ui/fixtures/index.ts
+++ b/x-pack/solutions/search/plugins/search_homepage/test/scout/ui/fixtures/index.ts
@@ -10,8 +10,10 @@ import type {
   PageObjects,
   ScoutTestFixtures,
   ScoutWorkerFixtures,
+  ScoutParallelTestFixtures,
+  ScoutParallelWorkerFixtures,
 } from '@kbn/scout-search';
-import { test as base, createLazyPageObject } from '@kbn/scout-search';
+import { test as base, spaceTest as spaceBase, createLazyPageObject } from '@kbn/scout-search';
 import { Homepage } from './page_objects/homepage';
 
 export interface ExtendedScoutTestFixtures extends ScoutTestFixtures {
@@ -19,6 +21,12 @@ export interface ExtendedScoutTestFixtures extends ScoutTestFixtures {
     homepage: Homepage;
   };
   browserAuth: BrowserAuthFixture;
+}
+
+export interface ExtendedScoutParallelTestFixtures extends ScoutParallelTestFixtures {
+  pageObjects: ScoutParallelTestFixtures['pageObjects'] & {
+    homepage: Homepage;
+  };
 }
 
 export const test = base.extend<ExtendedScoutTestFixtures, ScoutWorkerFixtures>({
@@ -31,6 +39,28 @@ export const test = base.extend<ExtendedScoutTestFixtures, ScoutWorkerFixtures>(
       page: ExtendedScoutTestFixtures['page'];
     },
     use: (pageObjects: ExtendedScoutTestFixtures['pageObjects']) => Promise<void>
+  ) => {
+    const extendedPageObjects = {
+      ...pageObjects,
+      homepage: createLazyPageObject(Homepage, page),
+    };
+    await use(extendedPageObjects);
+  },
+});
+
+export const spaceTest = spaceBase.extend<
+  ExtendedScoutParallelTestFixtures,
+  ScoutParallelWorkerFixtures
+>({
+  pageObjects: async (
+    {
+      pageObjects,
+      page,
+    }: {
+      pageObjects: ExtendedScoutParallelTestFixtures['pageObjects'];
+      page: ExtendedScoutParallelTestFixtures['page'];
+    },
+    use: (pageObjects: ExtendedScoutParallelTestFixtures['pageObjects']) => Promise<void>
   ) => {
     const extendedPageObjects = {
       ...pageObjects,

--- a/x-pack/solutions/search/plugins/search_homepage/test/scout/ui/fixtures/page_objects/homepage.ts
+++ b/x-pack/solutions/search/plugins/search_homepage/test/scout/ui/fixtures/page_objects/homepage.ts
@@ -126,4 +126,17 @@ export class Homepage {
   async getBodyLinkByText(text: string) {
     return this.page.getByRole('link', { name: text });
   }
+
+  // Metric Badges methods
+  async getMetricBadgesContainer() {
+    return this.page.testSubj.locator('searchHomepageMetricBadges');
+  }
+
+  async getMetricBadges() {
+    return this.page.locator('[data-test-subj^="searchHomepageMetricBadge-"]');
+  }
+
+  async getMetricBadge(type: string) {
+    return this.page.testSubj.locator(`searchHomepageMetricBadge-${type}`);
+  }
 }

--- a/x-pack/solutions/search/plugins/search_homepage/test/scout/ui/parallel_tests/homepage_data_management_user.spec.ts
+++ b/x-pack/solutions/search/plugins/search_homepage/test/scout/ui/parallel_tests/homepage_data_management_user.spec.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { tags } from '@kbn/scout-search';
+import { expect } from '@kbn/scout-search/ui';
+import { spaceTest } from '../fixtures';
+import { createDataManagementUserRole } from '../fixtures/custom_roles';
+
+spaceTest.describe(
+  'Homepage - Limited permissions user',
+  { tag: [...tags.stateful.classic] },
+  () => {
+    spaceTest.beforeAll(async ({ scoutSpace }) => {
+      await scoutSpace.setSolutionView('es');
+    });
+
+    spaceTest.beforeEach(async ({ page, browserAuth, pageObjects, scoutSpace }) => {
+      const role = createDataManagementUserRole(scoutSpace.id);
+      await browserAuth.loginWithCustomRole(role);
+
+      await page.addInitScript(() => {
+        window.sessionStorage.setItem('gettingStartedVisited', 'true');
+      });
+      await pageObjects.homepage.goto();
+    });
+
+    spaceTest(
+      'should only see Data Management panel and Storage/Indices badges',
+      async ({ pageObjects, page }) => {
+        const navigationCards = await pageObjects.homepage.getNavigationCards();
+        await expect(navigationCards).toHaveCount(1);
+
+        const dataManagementCard = page.testSubj.locator('searchHomepageNavLinks-dataManagement');
+        await expect(dataManagementCard).toBeVisible();
+
+        const badges = await pageObjects.homepage.getMetricBadges();
+        await expect(badges).toHaveCount(2);
+
+        const indicesBadge = await pageObjects.homepage.getMetricBadge('indices');
+        await expect(indicesBadge).toBeVisible();
+
+        const storageBadge = await pageObjects.homepage.getMetricBadge('storage');
+        await expect(storageBadge).toBeVisible();
+      }
+    );
+
+    // TODO: Unskip when Workflows sidenav visibility bug is fixed
+    spaceTest.skip(
+      'should only see Data Management in primary sidenav',
+      async ({ page, pageObjects }) => {
+        const { collapsibleNav } = pageObjects;
+
+        // Verify only one nav item in primary navigation
+        const primaryNav = page.testSubj.locator('kbnChromeNav-primaryNavigation');
+        const navItems = primaryNav.locator('[data-test-subj*="nav-item-id-"]');
+        await expect(navItems).toHaveCount(1);
+
+        // Verify it's the Data Management item
+        const dataManagementLink = collapsibleNav.getNavItemById('data_management');
+        await expect(dataManagementLink).toBeVisible();
+      }
+    );
+  }
+);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Search] Allow homepage requests to fail silently (#265915)](https://github.com/elastic/kibana/pull/265915)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Brittany","email":"seialkali@gmail.com"},"sourceCommit":{"committedDate":"2026-04-29T20:58:13Z","message":"[Search] Allow homepage requests to fail silently (#265915)\n\n## Summary\n\nFixes the Search Homepage becoming unusable for users who lack\npermissions to access the `/internal/search_homepage/stats` endpoint.\nWhen this API returned 403 Forbidden, the `GettingStartedRedirectGate`\nwould block rendering indefinitely.\n\nThe fix treats 403 responses as a valid \"no permission\" state by\nreturning `null` from the hooks instead of throwing. The redirect gate\nnow checks `storageStats != null`, allowing it to proceed when the user\nlacks permissions. Other metrics hooks (`useIndicesStats`,\n`useDashboardsStats`, `useAgentCount`) also handle 403s gracefully,\nhiding badges when the user lacks permission, and showing an em-dash for\ngenuine errors.\n\nThis PR also adjusts the number of columns in the metric panel grid\nlayout based on the number of available panels.\n\nAdditionally, the PR also fixes the `CloudResources` visibility\ncondition (`isCloudEnabled` instead of `isServerlessEnabled`).\n\n### Screenshots\n<img width=\"700\" alt=\"Screenshot 2026-04-29 at 14 37 04\"\nsrc=\"https://github.com/user-attachments/assets/bd2e564a-1274-48b3-9d72-6fbf16fc9b06\"\n/>\n<img width=\"700\" alt=\"Screenshot 2026-04-29 at 14 37 33\"\nsrc=\"https://github.com/user-attachments/assets/3fb7724f-3465-4507-965b-8fb18ae1861f\"\n/>\n<img width=\"700\"alt=\"Screenshot 2026-04-29 at 14 37 59\"\nsrc=\"https://github.com/user-attachments/assets/3405e0cd-8124-4c03-b770-8a9b22963321\"\n/>\n<img width=\"700\" alt=\"Screenshot 2026-04-29 at 14 38 25\"\nsrc=\"https://github.com/user-attachments/assets/388fffbc-8d77-4c6c-8523-c39c0a59d1ca\"\n/>\n<img width=\"700\" alt=\"Screenshot 2026-04-29 at 14 40 01\"\nsrc=\"https://github.com/user-attachments/assets/65af9bf8-6f88-46e0-b08b-8c538a693386\"\n/>\n<img width=\"700\" alt=\"Screenshot 2026-04-29 at 14 40 44\"\nsrc=\"https://github.com/user-attachments/assets/4fbb044c-3e4d-4d28-ab90-ebc189b6cb03\"\n/>\n<img width=\"700\" alt=\"Screenshot 2026-04-29 at 14 41 50\"\nsrc=\"https://github.com/user-attachments/assets/699d5c47-1a5e-4b8d-af7e-eba1c67b04ca\"\n/>\n\n### Testing\n\n**NOTE**: When testing, ignore the `Workflows` sidenav item that is\nalways present. This is bug for the One Workflow team, and they have\nbeen made aware of it.\n\nAlso, test this in the cloud deployment that was generated from this PR.\nLocal testing seems to load the home page, even when it doesn't load in\ncloud.\n\n**As an admin user:**\n- [ ] Verify homepage loads without errors for users with full\nprivileges\n\n**As a user with limited privileges:**\nCreate a new user, as well as, a new role with no access to any of the\nfeatures which have a card on the home page, (e.g. Discover, Dashboards,\netc.) and no cluster/index privileges. Assign the new role to the new\nuser, and log in as that user.\n- [ ] Verify homepage loads gracefully for users with restricted\nprivileges\n  - [ ] Confirm no metrics badges show\n- [ ] Verify metric panels section is hidden when user has no access to\nany panel type\n\nGive the role access to the Dashboard feature\n- [ ] Verify the Dashboard panel loads on the homepage and the grid\nlayout has 2 columns\n  - [ ] Verify the Dashboard metric badge shows\n\nAdditionally give the role access to the Discover and Agent Builder\nfeature\n- [ ] Verify you can see the Dashboard, Discover, and Agent Builder\npanels on the homepage and the grid layout now has 3 columns\n  - [ ] Verify the Dashboard and Agent Builder metric badge shows\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] ~Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~\n- [ ]\n~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials~\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] ~If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~\n- [ ] ~This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.~\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] ~The PR description includes the appropriate Release Notes\nsection, and the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)~\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"17b7da549d8c568f736b9660ee29a838a1b52b1c","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Search","ci:cloud-deploy","backport:version","v9.4.0","v9.5.0"],"title":"[Search] Allow homepage requests to fail silently","number":265915,"url":"https://github.com/elastic/kibana/pull/265915","mergeCommit":{"message":"[Search] Allow homepage requests to fail silently (#265915)\n\n## Summary\n\nFixes the Search Homepage becoming unusable for users who lack\npermissions to access the `/internal/search_homepage/stats` endpoint.\nWhen this API returned 403 Forbidden, the `GettingStartedRedirectGate`\nwould block rendering indefinitely.\n\nThe fix treats 403 responses as a valid \"no permission\" state by\nreturning `null` from the hooks instead of throwing. The redirect gate\nnow checks `storageStats != null`, allowing it to proceed when the user\nlacks permissions. Other metrics hooks (`useIndicesStats`,\n`useDashboardsStats`, `useAgentCount`) also handle 403s gracefully,\nhiding badges when the user lacks permission, and showing an em-dash for\ngenuine errors.\n\nThis PR also adjusts the number of columns in the metric panel grid\nlayout based on the number of available panels.\n\nAdditionally, the PR also fixes the `CloudResources` visibility\ncondition (`isCloudEnabled` instead of `isServerlessEnabled`).\n\n### Screenshots\n<img width=\"700\" alt=\"Screenshot 2026-04-29 at 14 37 04\"\nsrc=\"https://github.com/user-attachments/assets/bd2e564a-1274-48b3-9d72-6fbf16fc9b06\"\n/>\n<img width=\"700\" alt=\"Screenshot 2026-04-29 at 14 37 33\"\nsrc=\"https://github.com/user-attachments/assets/3fb7724f-3465-4507-965b-8fb18ae1861f\"\n/>\n<img width=\"700\"alt=\"Screenshot 2026-04-29 at 14 37 59\"\nsrc=\"https://github.com/user-attachments/assets/3405e0cd-8124-4c03-b770-8a9b22963321\"\n/>\n<img width=\"700\" alt=\"Screenshot 2026-04-29 at 14 38 25\"\nsrc=\"https://github.com/user-attachments/assets/388fffbc-8d77-4c6c-8523-c39c0a59d1ca\"\n/>\n<img width=\"700\" alt=\"Screenshot 2026-04-29 at 14 40 01\"\nsrc=\"https://github.com/user-attachments/assets/65af9bf8-6f88-46e0-b08b-8c538a693386\"\n/>\n<img width=\"700\" alt=\"Screenshot 2026-04-29 at 14 40 44\"\nsrc=\"https://github.com/user-attachments/assets/4fbb044c-3e4d-4d28-ab90-ebc189b6cb03\"\n/>\n<img width=\"700\" alt=\"Screenshot 2026-04-29 at 14 41 50\"\nsrc=\"https://github.com/user-attachments/assets/699d5c47-1a5e-4b8d-af7e-eba1c67b04ca\"\n/>\n\n### Testing\n\n**NOTE**: When testing, ignore the `Workflows` sidenav item that is\nalways present. This is bug for the One Workflow team, and they have\nbeen made aware of it.\n\nAlso, test this in the cloud deployment that was generated from this PR.\nLocal testing seems to load the home page, even when it doesn't load in\ncloud.\n\n**As an admin user:**\n- [ ] Verify homepage loads without errors for users with full\nprivileges\n\n**As a user with limited privileges:**\nCreate a new user, as well as, a new role with no access to any of the\nfeatures which have a card on the home page, (e.g. Discover, Dashboards,\netc.) and no cluster/index privileges. Assign the new role to the new\nuser, and log in as that user.\n- [ ] Verify homepage loads gracefully for users with restricted\nprivileges\n  - [ ] Confirm no metrics badges show\n- [ ] Verify metric panels section is hidden when user has no access to\nany panel type\n\nGive the role access to the Dashboard feature\n- [ ] Verify the Dashboard panel loads on the homepage and the grid\nlayout has 2 columns\n  - [ ] Verify the Dashboard metric badge shows\n\nAdditionally give the role access to the Discover and Agent Builder\nfeature\n- [ ] Verify you can see the Dashboard, Discover, and Agent Builder\npanels on the homepage and the grid layout now has 3 columns\n  - [ ] Verify the Dashboard and Agent Builder metric badge shows\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] ~Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~\n- [ ]\n~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials~\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] ~If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~\n- [ ] ~This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.~\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] ~The PR description includes the appropriate Release Notes\nsection, and the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)~\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"17b7da549d8c568f736b9660ee29a838a1b52b1c"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/265915","number":265915,"mergeCommit":{"message":"[Search] Allow homepage requests to fail silently (#265915)\n\n## Summary\n\nFixes the Search Homepage becoming unusable for users who lack\npermissions to access the `/internal/search_homepage/stats` endpoint.\nWhen this API returned 403 Forbidden, the `GettingStartedRedirectGate`\nwould block rendering indefinitely.\n\nThe fix treats 403 responses as a valid \"no permission\" state by\nreturning `null` from the hooks instead of throwing. The redirect gate\nnow checks `storageStats != null`, allowing it to proceed when the user\nlacks permissions. Other metrics hooks (`useIndicesStats`,\n`useDashboardsStats`, `useAgentCount`) also handle 403s gracefully,\nhiding badges when the user lacks permission, and showing an em-dash for\ngenuine errors.\n\nThis PR also adjusts the number of columns in the metric panel grid\nlayout based on the number of available panels.\n\nAdditionally, the PR also fixes the `CloudResources` visibility\ncondition (`isCloudEnabled` instead of `isServerlessEnabled`).\n\n### Screenshots\n<img width=\"700\" alt=\"Screenshot 2026-04-29 at 14 37 04\"\nsrc=\"https://github.com/user-attachments/assets/bd2e564a-1274-48b3-9d72-6fbf16fc9b06\"\n/>\n<img width=\"700\" alt=\"Screenshot 2026-04-29 at 14 37 33\"\nsrc=\"https://github.com/user-attachments/assets/3fb7724f-3465-4507-965b-8fb18ae1861f\"\n/>\n<img width=\"700\"alt=\"Screenshot 2026-04-29 at 14 37 59\"\nsrc=\"https://github.com/user-attachments/assets/3405e0cd-8124-4c03-b770-8a9b22963321\"\n/>\n<img width=\"700\" alt=\"Screenshot 2026-04-29 at 14 38 25\"\nsrc=\"https://github.com/user-attachments/assets/388fffbc-8d77-4c6c-8523-c39c0a59d1ca\"\n/>\n<img width=\"700\" alt=\"Screenshot 2026-04-29 at 14 40 01\"\nsrc=\"https://github.com/user-attachments/assets/65af9bf8-6f88-46e0-b08b-8c538a693386\"\n/>\n<img width=\"700\" alt=\"Screenshot 2026-04-29 at 14 40 44\"\nsrc=\"https://github.com/user-attachments/assets/4fbb044c-3e4d-4d28-ab90-ebc189b6cb03\"\n/>\n<img width=\"700\" alt=\"Screenshot 2026-04-29 at 14 41 50\"\nsrc=\"https://github.com/user-attachments/assets/699d5c47-1a5e-4b8d-af7e-eba1c67b04ca\"\n/>\n\n### Testing\n\n**NOTE**: When testing, ignore the `Workflows` sidenav item that is\nalways present. This is bug for the One Workflow team, and they have\nbeen made aware of it.\n\nAlso, test this in the cloud deployment that was generated from this PR.\nLocal testing seems to load the home page, even when it doesn't load in\ncloud.\n\n**As an admin user:**\n- [ ] Verify homepage loads without errors for users with full\nprivileges\n\n**As a user with limited privileges:**\nCreate a new user, as well as, a new role with no access to any of the\nfeatures which have a card on the home page, (e.g. Discover, Dashboards,\netc.) and no cluster/index privileges. Assign the new role to the new\nuser, and log in as that user.\n- [ ] Verify homepage loads gracefully for users with restricted\nprivileges\n  - [ ] Confirm no metrics badges show\n- [ ] Verify metric panels section is hidden when user has no access to\nany panel type\n\nGive the role access to the Dashboard feature\n- [ ] Verify the Dashboard panel loads on the homepage and the grid\nlayout has 2 columns\n  - [ ] Verify the Dashboard metric badge shows\n\nAdditionally give the role access to the Discover and Agent Builder\nfeature\n- [ ] Verify you can see the Dashboard, Discover, and Agent Builder\npanels on the homepage and the grid layout now has 3 columns\n  - [ ] Verify the Dashboard and Agent Builder metric badge shows\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] ~Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~\n- [ ]\n~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials~\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] ~If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~\n- [ ] ~This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.~\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] ~The PR description includes the appropriate Release Notes\nsection, and the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)~\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"17b7da549d8c568f736b9660ee29a838a1b52b1c"}}]}] BACKPORT-->