### PR TITLE
[ES|QL Controls] Make search box case-insensitive

### DIFF
--- a/src/platform/plugins/shared/controls/public/controls/esql_control/esql_control_manager.ts
+++ b/src/platform/plugins/shared/controls/public/controls/esql_control/esql_control_manager.ts
@@ -242,7 +242,9 @@ export function initializeESQLControlManager(
     .pipe(debounceTime(50))
     .subscribe(([searchString, availableOptions]) => {
       const displayOptions =
-        availableOptions?.filter((option) => option.includes(searchString)) ?? [];
+        availableOptions?.filter((option) =>
+          option.toLowerCase().includes(searchString.toLowerCase())
+        ) ?? [];
       displayedAvailableOptions$.next(displayOptions.map((value) => ({ value })));
       totalCardinality$.next(displayOptions.length);
     });


### PR DESCRIPTION
## Summary

Fixes a bug in ES|QL controls where wildcard searching was case sensitive. Regular data controls do not behave this way, so the UX was jarring.

| Before | After |
| --- | --- |
| <img width="415" height="208" alt="Screenshot 2026-04-29 at 4 11 34 PM" src="https://github.com/user-attachments/assets/3738facd-67b5-4d96-a160-17c538a37206" /> | <img width="432" height="365" alt="Screenshot 2026-04-29 at 4 11 58 PM" src="https://github.com/user-attachments/assets/13e14780-7591-4b24-9a71-c27d84afd85f" /> |

