### PR TITLE
[9.4] [Fleet] Sort package by title instead of name in browse integration UX (#265800)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/hooks/index.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/hooks/index.test.tsx
@@ -142,11 +142,11 @@ describe('useBrowseIntegrationHook', () => {
   });
 
   describe('Sorting', () => {
-    it('sorts integrations A-Z when sort=a-z', () => {
+    it('sorts integrations A-Z by title when sort=a-z', () => {
       const cards = [
-        { id: '1', name: 'Zebra' },
-        { id: '2', name: 'Apache' },
-        { id: '3', name: 'MySQL' },
+        { id: '1', name: 'zebra', title: 'Zebra Integration' },
+        { id: '2', name: 'apache', title: 'Apache HTTP Server' },
+        { id: '3', name: 'mysql', title: 'MySQL Database' },
       ];
 
       mockUseAvailablePackages(cards as IntegrationCardItem[]);
@@ -160,14 +160,18 @@ describe('useBrowseIntegrationHook', () => {
         useBrowseIntegrationHook({ prereleaseIntegrationsEnabled: false })
       );
 
-      expect(result.current.filteredCards.map((c) => c.name)).toEqual(['Apache', 'MySQL', 'Zebra']);
+      expect(result.current.filteredCards.map((c) => c.title)).toEqual([
+        'Apache HTTP Server',
+        'MySQL Database',
+        'Zebra Integration',
+      ]);
     });
 
-    it('sorts integrations Z-A when sort=z-a', () => {
+    it('sorts integrations Z-A by title when sort=z-a', () => {
       const cards = [
-        { id: '1', name: 'Zebra' },
-        { id: '2', name: 'Apache' },
-        { id: '3', name: 'MySQL' },
+        { id: '1', name: 'zebra', title: 'Zebra Integration' },
+        { id: '2', name: 'apache', title: 'Apache HTTP Server' },
+        { id: '3', name: 'mysql', title: 'MySQL Database' },
       ];
 
       mockUseAvailablePackages(cards as IntegrationCardItem[]);
@@ -181,7 +185,11 @@ describe('useBrowseIntegrationHook', () => {
         useBrowseIntegrationHook({ prereleaseIntegrationsEnabled: false })
       );
 
-      expect(result.current.filteredCards.map((c) => c.name)).toEqual(['Zebra', 'MySQL', 'Apache']);
+      expect(result.current.filteredCards.map((c) => c.title)).toEqual([
+        'Zebra Integration',
+        'MySQL Database',
+        'Apache HTTP Server',
+      ]);
     });
   });
 
@@ -401,10 +409,10 @@ describe('useBrowseIntegrationHook', () => {
   describe('Combined filters', () => {
     it('applies deprecated filter and sorting together', () => {
       const cards = [
-        { id: '1', name: 'Zebra', isDeprecated: false },
-        { id: '2', name: 'Apache', isDeprecated: true },
-        { id: '3', name: 'MySQL', isDeprecated: false },
-        { id: '4', name: 'Nginx', isDeprecated: true },
+        { id: '1', name: 'zebra', title: 'Zebra Integration', isDeprecated: false },
+        { id: '2', name: 'apache', title: 'Apache HTTP Server', isDeprecated: true },
+        { id: '3', name: 'mysql', title: 'MySQL Database', isDeprecated: false },
+        { id: '4', name: 'nginx', title: 'Nginx Web Server', isDeprecated: true },
       ];
 
       mockUseAvailablePackages(cards as IntegrationCardItem[]);
@@ -419,7 +427,10 @@ describe('useBrowseIntegrationHook', () => {
       );
 
       expect(result.current.filteredCards).toHaveLength(2);
-      expect(result.current.filteredCards.map((c) => c.name)).toEqual(['Apache', 'Nginx']);
+      expect(result.current.filteredCards.map((c) => c.title)).toEqual([
+        'Apache HTTP Server',
+        'Nginx Web Server',
+      ]);
     });
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/hooks/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/hooks/index.tsx
@@ -44,11 +44,11 @@ export function useBrowseIntegrationHook({
 
     if (sortKey === 'a-z') {
       return [...originalFilteredCards].sort((a, b) => {
-        return a.name.localeCompare(b.name);
+        return a.title.localeCompare(b.title);
       });
     } else if (sortKey === 'z-a') {
       return [...originalFilteredCards].sort((a, b) => {
-        return b.name.localeCompare(a.name);
+        return b.title.localeCompare(a.title);
       });
     } else {
       // TODO implement recent-old and old-recent sorting when we have a date field


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Fleet] Sort package by title instead of name in browse integration UX (#265800)](https://github.com/elastic/kibana/pull/265800)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Nicolas Chaulet","email":"nicolas.chaulet@elastic.co"},"sourceCommit":{"committedDate":"2026-04-27T19:17:19Z","message":"[Fleet] Sort package by title instead of name in browse integration UX (#265800)","sha":"718a46e0cd7c6c170060c0ea93315daac6c06afe","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","Team:Fleet","backport:version","v9.4.0","v9.5.0"],"title":"[Fleet] Sort package by title instead of name in browse integration UX","number":265800,"url":"https://github.com/elastic/kibana/pull/265800","mergeCommit":{"message":"[Fleet] Sort package by title instead of name in browse integration UX (#265800)","sha":"718a46e0cd7c6c170060c0ea93315daac6c06afe"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/265800","number":265800,"mergeCommit":{"message":"[Fleet] Sort package by title instead of name in browse integration UX (#265800)","sha":"718a46e0cd7c6c170060c0ea93315daac6c06afe"}}]}] BACKPORT-->