### PR TITLE
[9.2] Split scout flaky test runs by arch+domain (#265991)

### DIFF
--- a/.buildkite/pipeline-utils/scout/index.ts
+++ b/.buildkite/pipeline-utils/scout/index.ts
@@ -8,6 +8,7 @@
  */
 
 export * from './pick_scout_test_group_run_order';
+export * from './pick_scout_flaky_run_order';
 export * from './paths';
 export * from './test_tracks';
 export * from './test_distribution_strategies';

--- a/.buildkite/pipeline-utils/scout/pick_scout_flaky_run_order.ts
+++ b/.buildkite/pipeline-utils/scout/pick_scout_flaky_run_order.ts
@@ -1,0 +1,195 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import Fs from 'fs';
+import { expandAgentQueue } from '../agent_images';
+import { BuildkiteClient, type BuildkiteCommandStep } from '../buildkite';
+import { collectEnvFromLabels } from '../pr_labels';
+import type { ModuleDiscoveryInfo } from './pick_scout_test_group_run_order';
+
+// Hard ceiling on total Buildkite jobs in a single build; mirrors the value in
+// .buildkite/pipelines/flaky_tests/pipeline.ts. Validated here AFTER fan-out across
+// (arch, domain) modes so the user gets a precise count.
+const MAX_JOBS = 500;
+const FLAKY_SUITE_KEY_PREFIX = 'scout-suite';
+
+export interface ScoutFlakyRequest {
+  type: 'scoutConfig';
+  scoutConfig: string;
+  count: number;
+}
+
+export interface PickScoutFlakyRunOrderOptions {
+  /** Concurrency limit applied to each generated step (mirrors `concurrency` in pipeline.ts). */
+  concurrency: number;
+  /** Concurrency group key (typically the trigger UUID); empty string disables grouping. */
+  concurrencyGroup?: string;
+  /** Step keys the generated steps must wait for (defaults to ['build']). */
+  dependsOn?: string[];
+  /**
+   * Number of Buildkite jobs already reserved by other parts of the build (e.g. FTR/Cypress
+   * suites and fixed-overhead steps like build_kibana / post_stats). Counted against the
+   * MAX_JOBS budget so the planner doesn't expand Scout fan-out past the platform cap.
+   * Defaults to 0 (Scout is the only contributor).
+   */
+  reservedJobs?: number;
+}
+
+// Normalize "./foo/bar.config.ts" -> "foo/bar.config.ts" so it matches manifest entries.
+const normalizeConfigPath = (path: string): string => path.replace(/^\.\//, '');
+
+const indexConfigsByPath = (
+  manifest: ModuleDiscoveryInfo[]
+): Map<string, ModuleDiscoveryInfo['configs'][number]> => {
+  const index = new Map<string, ModuleDiscoveryInfo['configs'][number]>();
+  for (const module of manifest) {
+    for (const config of module.configs) {
+      index.set(config.path, config);
+    }
+  }
+  return index;
+};
+
+const buildSteps = (
+  requests: ScoutFlakyRequest[],
+  configIndex: Map<string, ModuleDiscoveryInfo['configs'][number]>,
+  options: Required<Pick<PickScoutFlakyRunOrderOptions, 'concurrency'>> &
+    Pick<PickScoutFlakyRunOrderOptions, 'concurrencyGroup' | 'dependsOn' | 'reservedJobs'> & {
+      extraEnv: Record<string, string>;
+    }
+): BuildkiteCommandStep[] => {
+  const steps: BuildkiteCommandStep[] = [];
+  let suiteIndex = 0;
+  let scoutJobs = 0;
+  const reservedJobs = options.reservedJobs ?? 0;
+
+  for (const req of requests) {
+    if (!req || req.type !== 'scoutConfig') {
+      throw new Error(`Unexpected request entry: ${JSON.stringify(req)}`);
+    }
+    if (typeof req.scoutConfig !== 'string' || !req.scoutConfig) {
+      throw new Error(`Request is missing 'scoutConfig' string: ${JSON.stringify(req)}`);
+    }
+    if (typeof req.count !== 'number' || req.count <= 0) {
+      throw new Error(`Request 'count' must be a positive number: ${JSON.stringify(req)}`);
+    }
+
+    const normalized = normalizeConfigPath(req.scoutConfig);
+    const entry = configIndex.get(normalized);
+
+    if (!entry) {
+      throw new Error(
+        `scoutConfig '${normalized}' not found in the Scout Playwright configs manifest. ` +
+          `Verify the path is correct and that the discovery step picked it up.`
+      );
+    }
+
+    if (!entry.serverRunFlags || entry.serverRunFlags.length === 0) {
+      throw new Error(
+        `scoutConfig '${normalized}' has no serverRunFlags in the manifest. ` +
+          `Ensure the config has tags that resolve to at least one (arch, domain) mode.`
+      );
+    }
+
+    // Dedupe modes in case the manifest contains duplicate (arch, domain) entries, and
+    // log a warning so the upstream issue is visible.
+    const modes = [...new Set(entry.serverRunFlags)];
+    if (modes.length !== entry.serverRunFlags.length) {
+      console.warn(
+        `⚠️ scoutConfig '${normalized}' had duplicate serverRunFlags in the manifest ` +
+          `(${entry.serverRunFlags.length} entries, ${modes.length} unique). ` +
+          `Deduping for step generation; consider fixing the discovery output.`
+      );
+    }
+
+    for (const mode of modes) {
+      scoutJobs += req.count;
+      if (reservedJobs + scoutJobs > MAX_JOBS) {
+        throw new Error(
+          `Total Buildkite jobs would exceed the platform cap of ${MAX_JOBS} ` +
+            `(${reservedJobs} reserved by FTR/Cypress + fixed steps, ${scoutJobs} from Scout ` +
+            `fan-out across (arch, domain) modes). Lower per-config 'count' values or ` +
+            `request fewer configs in this run.`
+        );
+      }
+
+      steps.push({
+        command: '.buildkite/scripts/steps/test/scout/flaky_configs.sh',
+        env: {
+          SCOUT_CONFIG: normalized,
+          SCOUT_SERVER_RUN_FLAGS: mode,
+          SCOUT_REPORTER_ENABLED: 'true',
+          ...options.extraEnv,
+        },
+        key: `${FLAKY_SUITE_KEY_PREFIX}-${suiteIndex++}`,
+        label: `${normalized} (${mode})`,
+        parallelism: req.count,
+        concurrency: options.concurrency,
+        concurrency_group: options.concurrencyGroup,
+        concurrency_method: 'eager',
+        agents: expandAgentQueue(entry.usesParallelWorkers ? 'n2-8-spot' : 'n2-4-spot'),
+        depends_on: options.dependsOn ?? ['build'],
+        timeout_in_minutes: 60,
+        retry: {
+          automatic: [{ exit_status: '-1', limit: 3 }],
+        },
+      });
+    }
+  }
+
+  return steps;
+};
+
+/**
+ * Reads the Scout Playwright configs manifest from disk, expands each user-requested
+ * `scoutConfig` into one Buildkite step per (arch, domain) mode, and uploads the
+ * resulting steps via the Buildkite agent.
+ *
+ * The manifest must already exist on disk; the caller is responsible for placing it
+ * there (e.g. by downloading the artifact uploaded by the discovery step).
+ */
+export async function pickScoutFlakyRunOrder(
+  scoutConfigsPath: string,
+  requests: ScoutFlakyRequest[],
+  options: PickScoutFlakyRunOrderOptions
+): Promise<void> {
+  if (requests.length === 0) {
+    console.log('No Scout flaky requests to plan; nothing to upload.');
+    return;
+  }
+
+  if (!Fs.existsSync(scoutConfigsPath)) {
+    throw new Error(`Scout configs file not found at ${scoutConfigsPath}`);
+  }
+
+  const manifest = JSON.parse(Fs.readFileSync(scoutConfigsPath, 'utf-8')) as ModuleDiscoveryInfo[];
+
+  const configIndex = indexConfigsByPath(manifest);
+  const extraEnv: Record<string, string> = collectEnvFromLabels();
+
+  const steps = buildSteps(requests, configIndex, {
+    concurrency: options.concurrency,
+    concurrencyGroup: options.concurrencyGroup,
+    dependsOn: options.dependsOn,
+    reservedJobs: options.reservedJobs,
+    extraEnv,
+  });
+
+  if (steps.length === 0) {
+    console.log('Plan produced no steps; skipping upload.');
+    return;
+  }
+
+  console.log(`--- Uploading ${steps.length} Scout flaky steps`);
+  for (const step of steps) {
+    console.log(`  - ${step.label} [parallelism=${step.parallelism}]`);
+  }
+
+  new BuildkiteClient().uploadSteps(steps);
+}

--- a/.buildkite/pipelines/flaky_tests/pick_scout_flaky_run_order.ts
+++ b/.buildkite/pipelines/flaky_tests/pick_scout_flaky_run_order.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import path from 'path';
+import {
+  getKibanaDir,
+  getRequiredEnv,
+  pickScoutFlakyRunOrder,
+  type ScoutFlakyRequest,
+} from '#pipeline-utils';
+
+// The manifest is produced earlier in the same step by `discover_and_plan_flaky.sh`
+// (which runs `scout discover-playwright-configs --save`); we read it directly from
+// disk rather than going through a BK artifact round-trip.
+const MANIFEST_RELATIVE_PATH = path.join('.scout', 'test_configs', 'scout_playwright_configs.json');
+
+const parseRequests = (raw: string): ScoutFlakyRequest[] => {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(`SCOUT_FLAKY_REQUESTS is not valid JSON: ${(err as Error).message}`);
+  }
+  if (!Array.isArray(parsed)) {
+    throw new Error(`SCOUT_FLAKY_REQUESTS must be a JSON array`);
+  }
+  return parsed as ScoutFlakyRequest[];
+};
+
+(async () => {
+  try {
+    const requests = parseRequests(getRequiredEnv('SCOUT_FLAKY_REQUESTS'));
+    const concurrency = parseInt(process.env.SCOUT_FLAKY_CONCURRENCY ?? '25', 10);
+    if (Number.isNaN(concurrency)) {
+      throw new Error(`Invalid SCOUT_FLAKY_CONCURRENCY: ${process.env.SCOUT_FLAKY_CONCURRENCY}`);
+    }
+    const reservedJobs = parseInt(process.env.SCOUT_FLAKY_RESERVED_JOBS ?? '0', 10);
+    if (Number.isNaN(reservedJobs) || reservedJobs < 0) {
+      throw new Error(
+        `Invalid SCOUT_FLAKY_RESERVED_JOBS: ${process.env.SCOUT_FLAKY_RESERVED_JOBS}`
+      );
+    }
+    const concurrencyGroup = process.env.SCOUT_FLAKY_CONCURRENCY_GROUP || undefined;
+
+    const manifestPath = path.resolve(getKibanaDir(), MANIFEST_RELATIVE_PATH);
+
+    await pickScoutFlakyRunOrder(manifestPath, requests, {
+      concurrency,
+      concurrencyGroup,
+      reservedJobs,
+    });
+  } catch (ex) {
+    console.error(`+++ Scout flaky planner error: ${ex.message}`);
+    process.exit(1);
+  }
+})();

--- a/.buildkite/pipelines/flaky_tests/pipeline.ts
+++ b/.buildkite/pipelines/flaky_tests/pipeline.ts
@@ -40,58 +40,6 @@ const MAX_JOBS = 500;
 // they request too many repetitions for a single config.
 const MAX_SCOUT_COUNT_PER_CONFIG = 50;
 
-function getScoutConfigGroupType(configPath: string): string | null {
-  // Match platform paths: x-pack/platform/... or src/platform/...
-  if (/^(x-pack|src)\/platform\//.test(configPath)) {
-    return 'platform';
-  }
-  // Match solution paths: x-pack/solutions/<solution>/plugins/...
-  const match = configPath.match(/^x-pack\/solutions\/([^/]+)\/plugins\//);
-  if (match) {
-    return match[1];
-  }
-  return null;
-}
-
-function getScoutServerRunFlags(configPath: string): string[] {
-  const groupType = getScoutConfigGroupType(configPath);
-
-  if (!groupType) {
-    throw new Error(
-      `Unable to determine scout config group type from path: ${configPath}. ` +
-        `Expected path to match platform pattern (x-pack/platform/... or src/platform/...) ` +
-        `or solution pattern (x-pack/solutions/<solution>/plugins/...)`
-    );
-  }
-
-  if (groupType === 'platform') {
-    return [
-      '--arch stateful --domain classic',
-      '--arch serverless --domain search',
-      '--arch serverless --domain observability_complete',
-      '--arch serverless --domain security_complete',
-    ];
-  }
-
-  if (groupType === 'workplaceai') {
-    return ['--arch serverless --domain workplaceai'];
-  }
-  if (groupType === 'observability') {
-    return [
-      '--arch stateful --domain classic',
-      '--arch serverless --domain observability_complete',
-    ];
-  }
-  if (groupType === 'security') {
-    return ['--arch stateful --domain classic', '--arch serverless --domain security_complete'];
-  }
-  if (groupType === 'search') {
-    return ['--arch stateful --domain classic', '--arch serverless --domain search'];
-  }
-
-  throw new Error(`Unknown solution type: ${groupType}.`);
-}
-
 function getTestSuitesFromJson(json: string) {
   const fail = (errorMsg: string) => {
     console.error('+++ Invalid test config provided');
@@ -182,6 +130,7 @@ function getTestSuitesFromJson(json: string) {
 }
 
 const testSuites = getTestSuitesFromJson(configJson);
+const hasScoutSuites = testSuites.some((t) => t.type === 'scoutConfig' && t.count > 0);
 
 const totalJobs = testSuites.reduce((acc, t) => acc + t.count, BASE_JOBS);
 
@@ -213,8 +162,6 @@ steps.push({
   if: "build.env('KIBANA_BUILD_ID') == null || build.env('KIBANA_BUILD_ID') == ''",
 });
 
-<<<<<<< HEAD
-=======
 if (hasScoutSuites) {
   // Single step that bootstraps Kibana, runs Scout config discovery, and dynamically
   // uploads one BK step per (scoutConfig x arch x domain) mode (parallelism: count).
@@ -252,78 +199,14 @@ if (hasScoutSuites) {
   });
 }
 
->>>>>>> 06d1970ceabe (Split scout flaky test runs by arch+domain (#265991))
 let suiteIndex = 0;
 for (const testSuite of testSuites) {
   if (testSuite.count <= 0) {
     continue;
   }
 
-<<<<<<< HEAD
-  if (testSuite.type === 'ftrConfig') {
-    steps.push({
-      command: `.buildkite/scripts/steps/test/ftr_configs.sh`,
-      env: {
-        FTR_CONFIG: testSuite.ftrConfig,
-      },
-      key: `${TestSuiteType.FTR}-${suiteIndex++}`,
-      label: `${testSuite.ftrConfig}`,
-      parallelism: testSuite.count,
-      concurrency,
-      concurrency_group: process.env.UUID,
-      concurrency_method: 'eager',
-      agents: expandAgentQueue('n2-4-spot'),
-      depends_on: 'build',
-      timeout_in_minutes: 150,
-      retry: {
-        automatic: [{ exit_status: '-1', limit: 3 }],
-      },
-    });
-    continue;
-  }
-
-  if (testSuite.type === 'scoutConfig') {
-    const usesParallelWorkers = testSuite.scoutConfig.endsWith('parallel.playwright.config.ts');
-    const serverRunFlags = getScoutServerRunFlags(testSuite.scoutConfig);
-
-    steps.push({
-      command: `.buildkite/scripts/steps/test/scout/flaky_configs.sh`,
-      env: {
-        SCOUT_CONFIG: testSuite.scoutConfig,
-        SCOUT_REPORTER_ENABLED: 'true',
-        SCOUT_SERVER_RUN_FLAGS: serverRunFlags.join('\n'),
-      },
-      key: `${TestSuiteType.SCOUT}-${suiteIndex++}`,
-      label: `${testSuite.scoutConfig}`,
-      parallelism: testSuite.count,
-      concurrency,
-      concurrency_group: process.env.UUID,
-      concurrency_method: 'eager',
-      agents: expandAgentQueue(usesParallelWorkers ? 'n2-8-spot' : 'n2-4-spot'),
-      depends_on: 'build',
-      timeout_in_minutes: 60,
-      retry: {
-        automatic: [{ exit_status: '-1', limit: 3 }],
-      },
-    });
-    continue;
-  }
-
-  const [category, suiteName] = testSuite.key.split('/');
-  switch (category) {
-    case 'cypress':
-      const group = groups.find((g) => g.key === testSuite.key);
-      if (!group) {
-        throw new Error(
-          `Group configuration was not found in groups.json for the following cypress suite: {${suiteName}}.`
-        );
-      }
-      const agentQueue = suiteName.includes('defend_workflows') ? 'n2-4-virt' : 'n2-4-spot';
-      const diskSizeGb = suiteName.includes('defend_workflows') ? 120 : undefined;
-=======
   switch (testSuite.type) {
     case 'ftrConfig':
->>>>>>> 06d1970ceabe (Split scout flaky test runs by arch+domain (#265991))
       steps.push({
         command: `.buildkite/scripts/steps/test/ftr_configs.sh`,
         env: {

--- a/.buildkite/pipelines/flaky_tests/pipeline.ts
+++ b/.buildkite/pipelines/flaky_tests/pipeline.ts
@@ -34,6 +34,11 @@ if (Number.isNaN(concurrency)) {
 
 const BASE_JOBS = 1;
 const MAX_JOBS = 500;
+// Each scoutConfig now fans out to one Buildkite step per (arch, domain) mode,
+// so a single entry can multiply into many jobs. Cap per-entry runs to keep the
+// total job budget under control and to give users a clear, fast failure when
+// they request too many repetitions for a single config.
+const MAX_SCOUT_COUNT_PER_CONFIG = 50;
 
 function getScoutConfigGroupType(configPath: string): string | null {
   // Match platform paths: x-pack/platform/... or src/platform/...
@@ -145,6 +150,15 @@ function getTestSuitesFromJson(json: string) {
         fail(`testSuite.scoutConfig must be a string`);
       }
 
+      if (count > MAX_SCOUT_COUNT_PER_CONFIG) {
+        fail(
+          `testSuite.count for scoutConfig '${scoutConfig}' is ${count}; ` +
+            `max allowed is ${MAX_SCOUT_COUNT_PER_CONFIG}. ` +
+            `Each Scout request fans out to one job per (arch x domain) mode, ` +
+            `so high counts multiply quickly. Lower the count or split the run.`
+        );
+      }
+
       testSuites.push({
         type: 'scoutConfig',
         scoutConfig,
@@ -199,12 +213,53 @@ steps.push({
   if: "build.env('KIBANA_BUILD_ID') == null || build.env('KIBANA_BUILD_ID') == ''",
 });
 
+<<<<<<< HEAD
+=======
+if (hasScoutSuites) {
+  // Single step that bootstraps Kibana, runs Scout config discovery, and dynamically
+  // uploads one BK step per (scoutConfig x arch x domain) mode (parallelism: count).
+  // Discovery requires a full `yarn kbn bootstrap`, which is too heavy to run inside
+  // pipeline.ts itself; combining discovery + planning here avoids paying for an
+  // extra agent boot and an artifact round-trip just to hand the manifest between
+  // two otherwise-coupled steps.
+  const scoutFlakyRequests = testSuites.filter(
+    (t): t is { type: 'scoutConfig'; scoutConfig: string; count: number } =>
+      t.type === 'scoutConfig' && t.count > 0
+  );
+
+  // Tell the planner how many jobs are already committed by FTR/Cypress + fixed-overhead
+  // steps, so it can refuse to fan out Scout into a build that would bust the platform's
+  // 500-job cap. Mirrors the BASE_JOBS + non-Scout sum used in the pre-flight check above.
+  const reservedJobsForPlanner =
+    BASE_JOBS +
+    testSuites.filter((t) => t.type !== 'scoutConfig').reduce((acc, t) => acc + t.count, 0);
+
+  steps.push({
+    command: '.buildkite/scripts/steps/test/scout/discover_and_plan_flaky.sh',
+    label: 'Discover and plan Scout flaky steps',
+    agents: expandAgentQueue('n2-4-spot'),
+    key: 'scout_flaky_setup',
+    timeout_in_minutes: 30,
+    env: {
+      SCOUT_FLAKY_REQUESTS: JSON.stringify(scoutFlakyRequests),
+      SCOUT_FLAKY_CONCURRENCY: String(concurrency),
+      SCOUT_FLAKY_CONCURRENCY_GROUP: process.env.UUID ?? '',
+      SCOUT_FLAKY_RESERVED_JOBS: String(reservedJobsForPlanner),
+    },
+    retry: {
+      automatic: [{ exit_status: '-1', limit: 3 }],
+    },
+  });
+}
+
+>>>>>>> 06d1970ceabe (Split scout flaky test runs by arch+domain (#265991))
 let suiteIndex = 0;
 for (const testSuite of testSuites) {
   if (testSuite.count <= 0) {
     continue;
   }
 
+<<<<<<< HEAD
   if (testSuite.type === 'ftrConfig') {
     steps.push({
       command: `.buildkite/scripts/steps/test/ftr_configs.sh`,
@@ -265,34 +320,83 @@ for (const testSuite of testSuites) {
       }
       const agentQueue = suiteName.includes('defend_workflows') ? 'n2-4-virt' : 'n2-4-spot';
       const diskSizeGb = suiteName.includes('defend_workflows') ? 120 : undefined;
+=======
+  switch (testSuite.type) {
+    case 'ftrConfig':
+>>>>>>> 06d1970ceabe (Split scout flaky test runs by arch+domain (#265991))
       steps.push({
-        command: `.buildkite/scripts/steps/functional/${suiteName}.sh`,
-        label: group.name,
-        agents: expandAgentQueue(agentQueue, diskSizeGb),
-        key: `${TestSuiteType.CYPRESS}-${suiteIndex++}`,
-        depends_on: 'build',
-        timeout_in_minutes: 150,
+        command: `.buildkite/scripts/steps/test/ftr_configs.sh`,
+        env: {
+          FTR_CONFIG: testSuite.ftrConfig,
+        },
+        key: `${TestSuiteType.FTR}-${suiteIndex++}`,
+        label: `${testSuite.ftrConfig}`,
         parallelism: testSuite.count,
         concurrency,
         concurrency_group: process.env.UUID,
         concurrency_method: 'eager',
+        agents: expandAgentQueue('n2-4-spot'),
+        depends_on: 'build',
+        timeout_in_minutes: 150,
         retry: {
           automatic: [{ exit_status: '-1', limit: 3 }],
-        },
-        env: {
-          // disable split of test cases between parallel jobs when running them in flaky test runner
-          // by setting chunks vars to value 1, which means all test will run in one job
-          CLI_NUMBER: 1,
-          CLI_COUNT: 1,
-          // The security solution cypress tests don't recognize CLI_NUMBER and CLI_COUNT, they use `BUILDKITE_PARALLEL_JOB_COUNT` and `BUILDKITE_PARALLEL_JOB`, which cannot be overridden here.
-          // Use `RUN_ALL_TESTS` to make Security Solution Cypress tests run all tests instead of a subset.
-          RUN_ALL_TESTS: 'true',
         },
       });
       break;
 
-    default:
-      throw new Error(`unknown test suite: ${testSuite.key}`);
+    case 'scoutConfig':
+      // Scout entries are expanded into per-(arch, domain) BK steps by the
+      // 'scout_flaky_setup' step above, which discovers configs and uploads the steps.
+      break;
+
+    case 'group': {
+      const [category, suiteName] = testSuite.key.split('/');
+      switch (category) {
+        case 'cypress':
+          const group = groups.find((g) => g.key === testSuite.key);
+          if (!group) {
+            throw new Error(
+              `Group configuration was not found in groups.json for the following cypress suite: {${suiteName}}.`
+            );
+          }
+          const agentQueue = suiteName.includes('defend_workflows') ? 'n2-4-virt' : 'n2-4-spot';
+          const diskSizeGb = suiteName.includes('defend_workflows') ? 120 : undefined;
+          steps.push({
+            command: `.buildkite/scripts/steps/functional/${suiteName}.sh`,
+            label: group.name,
+            agents: expandAgentQueue(agentQueue, diskSizeGb),
+            key: `${TestSuiteType.CYPRESS}-${suiteIndex++}`,
+            depends_on: 'build',
+            timeout_in_minutes: 150,
+            parallelism: testSuite.count,
+            concurrency,
+            concurrency_group: process.env.UUID,
+            concurrency_method: 'eager',
+            retry: {
+              automatic: [{ exit_status: '-1', limit: 3 }],
+            },
+            env: {
+              // disable split of test cases between parallel jobs when running them in flaky test runner
+              // by setting chunks vars to value 1, which means all test will run in one job
+              CLI_NUMBER: 1,
+              CLI_COUNT: 1,
+              // The security solution cypress tests don't recognize CLI_NUMBER and CLI_COUNT, they use `BUILDKITE_PARALLEL_JOB_COUNT` and `BUILDKITE_PARALLEL_JOB`, which cannot be overridden here.
+              // Use `RUN_ALL_TESTS` to make Security Solution Cypress tests run all tests instead of a subset.
+              RUN_ALL_TESTS: 'true',
+            },
+          });
+          break;
+
+        default:
+          throw new Error(`unknown test suite: ${testSuite.key}`);
+      }
+      break;
+    }
+
+    default: {
+      const exhaustiveCheck: never = testSuite;
+      throw new Error(`unknown testSuite type: ${JSON.stringify(exhaustiveCheck)}`);
+    }
   }
 }
 

--- a/.buildkite/scripts/steps/test/scout/discover_and_plan_flaky.sh
+++ b/.buildkite/scripts/steps/test/scout/discover_and_plan_flaky.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# Combined entry point for the Scout step of the Flaky Test Runner pipeline:
+#   1. Bootstraps Kibana
+#   2. Discovers Playwright configs (writes the manifest to .scout/test_configs/)
+#   3. Uploads the manifest as a BK artifact (kept for debugging visibility)
+#   4. Runs the planner, which reads the manifest from disk and dynamically
+#      uploads one BK step per (scoutConfig x arch x domain) mode.
+#
+# Combining (1)-(4) in a single step avoids paying for a second agent boot and an
+# artifact download just to hand the manifest from one step to another. The generic
+# `.buildkite/scripts/steps/test/scout/discover_playwright_configs.sh` is intentionally
+# left untouched so it can keep being reused by other pipelines.
+
+set -euo pipefail
+
+source .buildkite/scripts/common/util.sh
+.buildkite/scripts/bootstrap.sh
+
+echo '--- Update Scout Test Config Manifests'
+node scripts/scout.js update-test-config-manifests --concurrencyLimit 3
+
+echo '--- Discover Playwright Configs'
+node scripts/scout discover-playwright-configs --include-custom-servers --save
+cp .scout/test_configs/scout_playwright_configs.json scout_playwright_configs.json
+buildkite-agent artifact upload "scout_playwright_configs.json"
+
+echo '--- Plan and upload Scout flaky steps'
+ts-node .buildkite/pipelines/flaky_tests/pick_scout_flaky_run_order.ts

--- a/.buildkite/scripts/steps/test/scout/discover_and_plan_flaky.sh
+++ b/.buildkite/scripts/steps/test/scout/discover_and_plan_flaky.sh
@@ -17,11 +17,17 @@ set -euo pipefail
 source .buildkite/scripts/common/util.sh
 .buildkite/scripts/bootstrap.sh
 
+if [[ "${BUILDKITE_BRANCH:-}" == "main" || "${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-}" == "main" ]]; then
+  SCOUT_DISCOVERY_TARGET="local"
+else
+  SCOUT_DISCOVERY_TARGET="local-stateful-only"
+fi
+
 echo '--- Update Scout Test Config Manifests'
 node scripts/scout.js update-test-config-manifests --concurrencyLimit 3
 
 echo '--- Discover Playwright Configs'
-node scripts/scout discover-playwright-configs --include-custom-servers --save
+node scripts/scout discover-playwright-configs --include-custom-servers --target "$SCOUT_DISCOVERY_TARGET" --save
 cp .scout/test_configs/scout_playwright_configs.json scout_playwright_configs.json
 buildkite-agent artifact upload "scout_playwright_configs.json"
 

--- a/.buildkite/scripts/steps/test/scout/discover_playwright_configs.sh
+++ b/.buildkite/scripts/steps/test/scout/discover_playwright_configs.sh
@@ -11,5 +11,10 @@ node scripts/scout.js update-test-config-manifests --concurrencyLimit 3
 echo '--- Discover Playwright Configs and upload to Buildkite artifacts'
 node scripts/scout discover-playwright-configs --include-custom-servers --save
 cp .scout/test_configs/scout_playwright_configs.json scout_playwright_configs.json
+# Contract: this artifact name is downloaded across BK steps by:
+#   - .buildkite/scripts/steps/test/scout/configs.sh (regular Scout pipeline)
+# Update that caller if you rename it. The flaky-test runner reads the manifest
+# directly from disk in the same step (see discover_and_plan_flaky.sh) and does
+# not depend on the artifact name.
 buildkite-agent artifact upload "scout_playwright_configs.json"
 

--- a/.buildkite/scripts/steps/test/scout/flaky_configs.sh
+++ b/.buildkite/scripts/steps/test/scout/flaky_configs.sh
@@ -4,6 +4,10 @@ set -euo pipefail
 
 source .buildkite/scripts/steps/functional/common.sh
 
+# Each step planned by `pick_scout_flaky_run_order.ts` runs a single (arch, domain) mode for
+# one Scout config. The planner is the sole caller of this script, so both env vars are
+# required and the previous mode-loop / manifest-download logic has been removed.
+
 SCOUT_CONFIG=${SCOUT_CONFIG:-}
 SCOUT_SERVER_RUN_FLAGS=${SCOUT_SERVER_RUN_FLAGS:-}
 
@@ -18,6 +22,7 @@ if [[ -z "$SCOUT_CONFIG" ]]; then
 fi
 
 if [[ -z "$SCOUT_SERVER_RUN_FLAGS" ]]; then
+<<<<<<< HEAD
   echo "Missing SCOUT_SERVER_RUN_FLAGS env var"
   exit 1
 fi
@@ -28,6 +33,15 @@ passed_count=0
 failedModes=()
 
 FINAL_EXIT_CODE=0
+=======
+  echo "Missing SCOUT_SERVER_RUN_FLAGS env var (expected one '--arch X --domain Y' pair)"
+  exit 1
+fi
+
+# Normalize optional leading "./" so logs match planner-emitted labels.
+config_path="${SCOUT_CONFIG#./}"
+mode="$SCOUT_SERVER_RUN_FLAGS"
+>>>>>>> 06d1970ceabe (Split scout flaky test runs by arch+domain (#265991))
 
 run_failed_test_reporter_and_annotate() {
   if ! ls .scout/reports/scout-playwright-test-failures-*/scout-failures-*.ndjson >/dev/null 2>&1; then
@@ -61,47 +75,26 @@ run_failed_test_reporter_and_annotate() {
   ts-node .buildkite/scripts/lifecycle/annotate_test_failures.ts
 }
 
-
 echo "--- Config: $config_path"
-echo "   Modes: $(echo "$config_run_modes" | tr '\n' ' ')"
+echo "    Mode:   $mode"
+echo "--- Running tests: $config_path ($mode)"
 
-while read -r mode; do
-  if [[ -z "$mode" ]]; then
-    continue
-  fi
+# prevent non-zero exit code from breaking the script before reporting runs
+set +e;
+node scripts/scout run-tests $mode --config "$config_path" --kibanaInstallDir "$KIBANA_BUILD_LOCATION"
+EXIT_CODE=$?
+set -e;
 
-  echo "--- Running tests: $config_path ($mode)"
-
-  start=$(date +%s)
-
-  # prevent non-zero exit code from breaking the loop
-  set +e;
-  node scripts/scout run-tests $mode --config "$config_path" --kibanaInstallDir "$KIBANA_BUILD_LOCATION"
-  EXIT_CODE=$?
-  set -e;
-
-  if [[ $EXIT_CODE -ne 0 ]]; then
-    failedModes+=("$mode")
-    FINAL_EXIT_CODE=10  # Ensure we exit with failure if any test fails with (exit code 10 to match FTR)
-    echo "Scout test exited with code $EXIT_CODE for $config_path ($mode)"
-    echo "^^^ +++"
-  else
-    passed_count=$((passed_count + 1))
-  fi
-
-done <<< "$config_run_modes"
-
-if [[ ${#failedModes[@]} -gt 0 ]]; then
-  run_failed_test_reporter_and_annotate
+if [[ $EXIT_CODE -eq 0 ]]; then
+  echo "--- Scout Test Run Complete: $config_path ($mode) ✅"
+  exit 0
 fi
 
-echo "--- Scout Test Run Complete: passed=${passed_count} failed=${#failedModes[@]}"
+echo "Scout test exited with code $EXIT_CODE for $config_path ($mode)"
+echo "^^^ +++"
 
-if [[ ${#failedModes[@]} -gt 0 ]]; then
-  echo "❌ Failed modes:"
-  for mode in "${failedModes[@]}"; do
-    echo "  $mode ❌"
-  done
-fi
+run_failed_test_reporter_and_annotate
 
-exit $FINAL_EXIT_CODE  # Exit with 10 only if there were config failures
+echo "--- Scout Test Run Complete: $config_path ($mode) ❌"
+# Use exit code 10 to match FTR's convention for "tests failed" (vs. infra/setup failure).
+exit 10

--- a/.buildkite/scripts/steps/test/scout/flaky_configs.sh
+++ b/.buildkite/scripts/steps/test/scout/flaky_configs.sh
@@ -22,18 +22,6 @@ if [[ -z "$SCOUT_CONFIG" ]]; then
 fi
 
 if [[ -z "$SCOUT_SERVER_RUN_FLAGS" ]]; then
-<<<<<<< HEAD
-  echo "Missing SCOUT_SERVER_RUN_FLAGS env var"
-  exit 1
-fi
-
-config_path="$SCOUT_CONFIG"
-config_run_modes="$SCOUT_SERVER_RUN_FLAGS"
-passed_count=0
-failedModes=()
-
-FINAL_EXIT_CODE=0
-=======
   echo "Missing SCOUT_SERVER_RUN_FLAGS env var (expected one '--arch X --domain Y' pair)"
   exit 1
 fi
@@ -41,7 +29,6 @@ fi
 # Normalize optional leading "./" so logs match planner-emitted labels.
 config_path="${SCOUT_CONFIG#./}"
 mode="$SCOUT_SERVER_RUN_FLAGS"
->>>>>>> 06d1970ceabe (Split scout flaky test runs by arch+domain (#265991))
 
 run_failed_test_reporter_and_annotate() {
   if ! ls .scout/reports/scout-playwright-test-failures-*/scout-failures-*.ndjson >/dev/null 2>&1; then

--- a/dev_docs/operations/flaky_test_runner.mdx
+++ b/dev_docs/operations/flaky_test_runner.mdx
@@ -19,3 +19,19 @@ If you did want to prove that your test wasn't flaky anymore, the number of runs
 Ultimately, running the flaky test runner enough times to validate that a test isn't flaky just isn't an economically responsible way to fix flakiness so should be a last resort strategy.
 
 If there is reason to believe that a test which was previously flaky is no longer flaky, then the test can just be unskipped. If the test is still flaky then that will be proven shortly enough in CI and Operations will skip the test again.
+
+## Scout: per (arch, domain) execution
+
+When you select a Scout Playwright config in the trigger form, the Flaky Test Runner expands that single request into **one Buildkite step per `(arch, domain)` mode** the config supports (e.g. `--arch stateful --domain classic`, `--arch serverless --domain search`, `--arch serverless --domain security_complete`). Each mode then runs in its own worker with `parallelism` set to the requested run count, so:
+
+- Modes execute in parallel rather than sequentially within a single job, reducing wall-clock time for multi-mode configs.
+- Pass/fail rates are reported per `(arch, domain)` step in the Buildkite UI, making it easy to see which mode is actually flaky.
+- A failure in one mode no longer ties up the worker for the remaining modes.
+
+A single `Discover and plan Scout flaky steps` step bootstraps Kibana, runs Playwright config discovery, and dynamically uploads the per-mode steps. It runs in parallel with `Build Kibana Distribution`, and the per-mode steps it uploads wait for the build to finish before executing.
+
+### Limit per Scout config: 50 runs
+
+Because a single Scout request fans out into multiple Buildkite jobs, the Flaky Test Runner caps the **per-config** run count at **50**. Submitting a higher `count` for a `scoutConfig` entry will fail at pipeline upload with a clear error message.
+
+If you need more repetitions for a specific failure mode, run the Flaky Test Runner multiple times. The Buildkite platform also caps total jobs per build at 500; the planner enforces this limit precisely after fan-out, accounting for FTR/Cypress jobs already in the build, and refuses to upload more steps if the cap would be exceeded.


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [Split scout flaky test runs by arch+domain (#265991)](https://github.com/elastic/kibana/pull/265991)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Dzmitry Lemechko","email":"dzmitry.lemechko@elastic.co"},"sourceCommit":{"committedDate":"2026-04-29T16:28:59Z","message":"Split scout flaky test runs by arch+domain (#265991)\n\n## Summary\n\nblocked by https://github.com/elastic/kibana/pull/266025\n\nWith this PR when a Scout config is selected in the Flaky Test Runner,\nthe runner now expands the request into one Buildkite step per\n`arch+domain` mode the config supports, instead of looping all modes\nserially in a single job.\n\n**Example**: a config supporting `stateful/classic`,\n`serverless/search`, and s`erverless/security_complete` with `count=25`:\n\nbefore: 25 jobs each looping 3 modes serially\nafter: 3 BK steps × 25 parallel jobs = 75 jobs in parallel (capped by\n`KIBANA_FLAKY_TEST_CONCURRENCY`)\n\nWhat it gives us:\n- Faster wall clock: ~3× speedup for typical multi-mode configs , 60 min\ntimeout per step should be enough now\n- Per-mode visibility: each (arch, domain) shows its own pass/fail rate\nin the BK UI.\n- No cross-mode interference: each worker spins up a fresh Kibana/ES\nstack for its single mode.\n\nHow it's wired\n- pipeline.ts — for any run with Scout entries, emits the new `Discover\nand plan Scout flaky steps` step that discovers configs and plans\nexecution steps: uploads BK step per (scoutConfig × arch × domain).\n- `flaky_configs.sh` simplified to a single-mode runner driven by\n`SCOUT_SERVER_RUN_FLAGS`.\n\n**New limit:** 50 runs per Scout config\nBecause a single request now fans out into multiple jobs, each\nscoutConfig entry is capped at count=50 (validated at pipeline upload).\nThe platform-wide 500-jobs-per-build cap is enforced post-fan-out by the\nplanner.\n\n<img width=\"1960\" height=\"499\" alt=\"Screenshot 2026-04-28 at 12 07 13\"\nsrc=\"https://github.com/user-attachments/assets/319d2ac1-edeb-45d8-9a37-512229641330\"\n/>\n\n\nExample run:\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/11965\n\nduplicates will be removed by issues linked above\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"06d1970ceabe44e0e880b0537fdb9408d7610f08","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:all-open","v9.4.0","v9.5.0","v9.3.4"],"title":"Split scout flaky test runs by arch+domain","number":265991,"url":"https://github.com/elastic/kibana/pull/265991","mergeCommit":{"message":"Split scout flaky test runs by arch+domain (#265991)\n\n## Summary\n\nblocked by https://github.com/elastic/kibana/pull/266025\n\nWith this PR when a Scout config is selected in the Flaky Test Runner,\nthe runner now expands the request into one Buildkite step per\n`arch+domain` mode the config supports, instead of looping all modes\nserially in a single job.\n\n**Example**: a config supporting `stateful/classic`,\n`serverless/search`, and s`erverless/security_complete` with `count=25`:\n\nbefore: 25 jobs each looping 3 modes serially\nafter: 3 BK steps × 25 parallel jobs = 75 jobs in parallel (capped by\n`KIBANA_FLAKY_TEST_CONCURRENCY`)\n\nWhat it gives us:\n- Faster wall clock: ~3× speedup for typical multi-mode configs , 60 min\ntimeout per step should be enough now\n- Per-mode visibility: each (arch, domain) shows its own pass/fail rate\nin the BK UI.\n- No cross-mode interference: each worker spins up a fresh Kibana/ES\nstack for its single mode.\n\nHow it's wired\n- pipeline.ts — for any run with Scout entries, emits the new `Discover\nand plan Scout flaky steps` step that discovers configs and plans\nexecution steps: uploads BK step per (scoutConfig × arch × domain).\n- `flaky_configs.sh` simplified to a single-mode runner driven by\n`SCOUT_SERVER_RUN_FLAGS`.\n\n**New limit:** 50 runs per Scout config\nBecause a single request now fans out into multiple jobs, each\nscoutConfig entry is capped at count=50 (validated at pipeline upload).\nThe platform-wide 500-jobs-per-build cap is enforced post-fan-out by the\nplanner.\n\n<img width=\"1960\" height=\"499\" alt=\"Screenshot 2026-04-28 at 12 07 13\"\nsrc=\"https://github.com/user-attachments/assets/319d2ac1-edeb-45d8-9a37-512229641330\"\n/>\n\n\nExample run:\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/11965\n\nduplicates will be removed by issues linked above\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"06d1970ceabe44e0e880b0537fdb9408d7610f08"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/266471","number":266471,"state":"MERGED","mergeCommit":{"sha":"8bb962a7d7ff0299d25004df72df84bc043f1aae","message":"[9.4] Split scout flaky test runs by arch+domain (#265991) (#266471)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.4`:\n- [Split scout flaky test runs by arch+domain\n(#265991)](https://github.com/elastic/kibana/pull/265991)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Dzmitry Lemechko <dzmitry.lemechko@elastic.co>"}},{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/265991","number":265991,"mergeCommit":{"message":"Split scout flaky test runs by arch+domain (#265991)\n\n## Summary\n\nblocked by https://github.com/elastic/kibana/pull/266025\n\nWith this PR when a Scout config is selected in the Flaky Test Runner,\nthe runner now expands the request into one Buildkite step per\n`arch+domain` mode the config supports, instead of looping all modes\nserially in a single job.\n\n**Example**: a config supporting `stateful/classic`,\n`serverless/search`, and s`erverless/security_complete` with `count=25`:\n\nbefore: 25 jobs each looping 3 modes serially\nafter: 3 BK steps × 25 parallel jobs = 75 jobs in parallel (capped by\n`KIBANA_FLAKY_TEST_CONCURRENCY`)\n\nWhat it gives us:\n- Faster wall clock: ~3× speedup for typical multi-mode configs , 60 min\ntimeout per step should be enough now\n- Per-mode visibility: each (arch, domain) shows its own pass/fail rate\nin the BK UI.\n- No cross-mode interference: each worker spins up a fresh Kibana/ES\nstack for its single mode.\n\nHow it's wired\n- pipeline.ts — for any run with Scout entries, emits the new `Discover\nand plan Scout flaky steps` step that discovers configs and plans\nexecution steps: uploads BK step per (scoutConfig × arch × domain).\n- `flaky_configs.sh` simplified to a single-mode runner driven by\n`SCOUT_SERVER_RUN_FLAGS`.\n\n**New limit:** 50 runs per Scout config\nBecause a single request now fans out into multiple jobs, each\nscoutConfig entry is capped at count=50 (validated at pipeline upload).\nThe platform-wide 500-jobs-per-build cap is enforced post-fan-out by the\nplanner.\n\n<img width=\"1960\" height=\"499\" alt=\"Screenshot 2026-04-28 at 12 07 13\"\nsrc=\"https://github.com/user-attachments/assets/319d2ac1-edeb-45d8-9a37-512229641330\"\n/>\n\n\nExample run:\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/11965\n\nduplicates will be removed by issues linked above\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"06d1970ceabe44e0e880b0537fdb9408d7610f08"}},{"branch":"9.3","label":"v9.3.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/266470","number":266470,"state":"MERGED","mergeCommit":{"sha":"3c8f7356ee96fb8daed3b9d5cb46874a2edc61e3","message":"[9.3] Split scout flaky test runs by arch+domain (#265991) (#266470)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.3`:\n- [Split scout flaky test runs by arch+domain\n(#265991)](https://github.com/elastic/kibana/pull/265991)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Dzmitry Lemechko <dzmitry.lemechko@elastic.co>"}}]}] BACKPORT-->