### PR TITLE
Revert "[Fleet] replace env:HOSTNAME by HOSTNAME (#265959)"

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/components/add_collector_flyout.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/components/add_collector_flyout.tsx
@@ -170,7 +170,7 @@ export const AddCollectorFlyout: React.FunctionComponent<AddCollectorFlyoutProps
   const [collectorGroupOverridden, setCollectorGroupOverridden] = useState(false);
   const [serviceName, setServiceName] = useState('otel-collector-group');
   const [serviceNameOverridden, setServiceNameOverridden] = useState(false);
-  const [collectorDisplayName, setCollectorDisplayName] = useState('${HOSTNAME}');
+  const [collectorDisplayName, setCollectorDisplayName] = useState('${env:HOSTNAME}');
   const [configDescription, setConfigDescription] = useState('');
   const [tags, setTags] = useState('');
   const [environment, setEnvironment] = useState('');


### PR DESCRIPTION
Reverts #265959

After encountering https://opentelemetry.io/docs/collector/configuration/#environment-variables, it seems `env:HOSTNAME` is the OTel collector way to specify envvars, so reverting the previous PR.


<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->