### PR TITLE
[9.3] Changing owner of langsmith from AI Infra to Security Threat Hunting (#265023)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -177,7 +177,6 @@
         "eventsource-parser",
         "fast-glob",
         "gpt-tokenizer",
-        "langsmith",
         "openai",
         "@types/json-schema",
         "table",
@@ -543,12 +542,8 @@
       "matchDepNames": [
         "react-fast-compare"
       ],
-      "reviewers": [
-        "team:appex-sharedux"
-      ],
-      "matchBaseBranches": [
-        "main"
-      ],
+      "reviewers": ["team:appex-sharedux"],
+      "matchBaseBranches": ["main"],
       "labels": [
         "Team:SharedUX",
         "release_note:skip",
@@ -558,15 +553,9 @@
       "minimumReleaseAge": "14 days"
     },
     {
-      "matchDepNames": [
-        "react-use"
-      ],
-      "reviewers": [
-        "team:appex-sharedux"
-      ],
-      "matchBaseBranches": [
-        "main"
-      ],
+      "matchDepNames": ["react-use"],
+      "reviewers": ["team:appex-sharedux"],
+      "matchBaseBranches": ["main"],
       "labels": [
         "Team:SharedUX",
         "release_note:skip",
@@ -1962,7 +1951,7 @@
     {
       "groupName": "workflow-yaml",
       "matchDepNames": [
-        "@hey-api/openapi-ts", 
+        "@hey-api/openapi-ts",
         "vscode-languageserver-textdocument",
         "yaml-language-server"
       ],
@@ -1973,8 +1962,8 @@
         "main"
       ],
       "labels": [
-        "Team:One Workflow", 
-        "backport:all-open", 
+        "Team:One Workflow",
+        "backport:all-open",
         "release_note:skip"
       ],
       "minimumReleaseAge": "14 days",
@@ -2300,17 +2289,9 @@
     },
     {
       "groupName": "hjson",
-      "matchDepNames": [
-        "@types/hjson",
-        "hjson"
-      ],
-      "reviewers": [
-        "team:kibana-visualizations",
-        "team:fleet"
-      ],
-      "matchBaseBranches": [
-        "main"
-      ],
+      "matchDepNames": ["@types/hjson", "hjson"],
+      "reviewers": ["team:kibana-visualizations", "team:fleet"],
+      "matchBaseBranches": ["main"],
       "labels": [
         "Feature:Vega",
         "Team:Visualizations",
@@ -4081,11 +4062,7 @@
       ],
       "labels": [
         "release_note:skip",
-        "backport:all-open",
-        "ci:all-cypress-suites",
-        "effort:high",
-        "upgrade-risk:high"
-      ],
+        "backport:all-open","ci:all-cypress-suites", "effort:high", "upgrade-risk:high"],
       "minimumReleaseAge": "14 days",
       "enabled": true
     },
@@ -4197,6 +4174,15 @@
         "release_note:skip",
         "backport:all-open"
       ],
+      "minimumReleaseAge": "14 days",
+      "enabled": true
+    },
+    {
+      "groupName": "langsmith",
+      "matchDepNames": ["langsmith"],
+      "reviewers": ["team:security-threat-hunting"],
+      "matchBaseBranches": ["main"],
+      "labels": ["Team:Threat Hunting"],
       "minimumReleaseAge": "14 days",
       "enabled": true
     },
@@ -4335,20 +4321,9 @@
     },
     {
       "groupName": "antlr4",
-      "matchDepNames": [
-        "antlr4"
-      ],
-      "reviewers": [
-        "team:appex-sharedux",
-        "team:kibana-esql"
-      ],
-      "matchBaseBranches": [
-        "main"
-      ],
-      "labels": [
-        "release_note:skip",
-        "backport:all-open"
-      ],
+      "matchDepNames": ["antlr4"],
+      "reviewers": ["team:appex-sharedux", "team:kibana-esql"],
+      "matchBaseBranches": ["main"],
       "minimumReleaseAge": "14 days",
       "enabled": true
     },
@@ -4676,22 +4651,10 @@
     },
     {
       "groupName": "dotenv",
-      "matchDepNames": [
-        "dotenv"
-      ],
-      "reviewers": [
-        "team:obs-onboarding-team",
-        "team:appex-qa"
-      ],
-      "matchBaseBranches": [
-        "main"
-      ],
-      "labels": [
-        "Team:obs-onboarding",
-        "Team:QA",
-        "release_note:skip",
-        "backport:all-open"
-      ],
+      "matchDepNames": ["dotenv"],
+      "reviewers": ["team:kibana-operations"],
+      "matchBaseBranches": ["main"],
+      "labels": ["Team:Operations"],
       "minimumReleaseAge": "14 days",
       "enabled": true
     },


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Changing owner of langsmith from AI Infra to Security Threat Hunting (#265023)](https://github.com/elastic/kibana/pull/265023)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Kurt","email":"kc13greiner@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-04-28T14:56:31Z","message":"Changing owner of langsmith from AI Infra to Security Threat Hunting (#265023)\n\n## Summary\n\n`langsmith` is only used by @elastic/security-threat-hunting, not\n@elastic/appex-ai-infra\n\nChanging ownership of this dependency.\n\n---------\n\nCo-authored-by: Larry Gregory <lgregorydev@gmail.com>\nCo-authored-by: Larry Gregory <larry.gregory@elastic.co>","sha":"c52bcafa22a15dcc1a8b109128759f731649b83c","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["chore","Team:Security","release_note:skip","backport missing","backport:all-open","v9.5.0"],"title":"Changing owner of langsmith from AI Infra to Security Threat Hunting","number":265023,"url":"https://github.com/elastic/kibana/pull/265023","mergeCommit":{"message":"Changing owner of langsmith from AI Infra to Security Threat Hunting (#265023)\n\n## Summary\n\n`langsmith` is only used by @elastic/security-threat-hunting, not\n@elastic/appex-ai-infra\n\nChanging ownership of this dependency.\n\n---------\n\nCo-authored-by: Larry Gregory <lgregorydev@gmail.com>\nCo-authored-by: Larry Gregory <larry.gregory@elastic.co>","sha":"c52bcafa22a15dcc1a8b109128759f731649b83c"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/265023","number":265023,"mergeCommit":{"message":"Changing owner of langsmith from AI Infra to Security Threat Hunting (#265023)\n\n## Summary\n\n`langsmith` is only used by @elastic/security-threat-hunting, not\n@elastic/appex-ai-infra\n\nChanging ownership of this dependency.\n\n---------\n\nCo-authored-by: Larry Gregory <lgregorydev@gmail.com>\nCo-authored-by: Larry Gregory <larry.gregory@elastic.co>","sha":"c52bcafa22a15dcc1a8b109128759f731649b83c"}}]}] BACKPORT-->