### PR TITLE
[ES|QL] Enables the NL to ES|QL functionality

### DIFF
--- a/src/platform/packages/private/kbn-esql-editor/src/editor_visor/editor_visor.test.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/editor_visor/editor_visor.test.tsx
@@ -16,7 +16,7 @@ import { screen } from '@testing-library/react';
 import { coreMock } from '@kbn/core/public/mocks';
 import { dataPluginMock } from '@kbn/data-plugin/public/mocks';
 import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
-import { QuickSearchVisor, type QuickSearchVisorProps, NL_TO_ESQL_FLAG } from '.';
+import { QuickSearchVisor, type QuickSearchVisorProps } from '.';
 
 jest.mock('@kbn/esql-utils', () => ({
   ...jest.requireActual('@kbn/esql-utils'),
@@ -48,16 +48,7 @@ describe('Quick search visor', () => {
     },
   };
 
-  function renderESQLVisor(
-    testProps: QuickSearchVisorProps,
-    { nlToEsqlEnabled = false }: { nlToEsqlEnabled?: boolean } = {}
-  ) {
-    (corePluginMock.featureFlags.getBooleanValue as jest.Mock).mockImplementation(
-      (key: string, defaultValue: boolean) => {
-        if (key === NL_TO_ESQL_FLAG) return nlToEsqlEnabled;
-        return defaultValue;
-      }
-    );
+  function renderESQLVisor(testProps: QuickSearchVisorProps) {
     return (
       <KibanaContextProvider services={services}>
         <QuickSearchVisor {...testProps} />
@@ -147,11 +138,6 @@ describe('Quick search visor', () => {
     });
   });
 
-  it('should not render the mode selector when nlToEsql flag is disabled', () => {
-    const { queryByTestId } = renderWithI18n(renderESQLVisor({ ...props }));
-    expect(queryByTestId('esqlVisorModeSelect')).not.toBeInTheDocument();
-  });
-
   it('should not render the mode selector when license is not enterprise', async () => {
     const invalidLicense = {
       status: 'active',
@@ -159,27 +145,21 @@ describe('Quick search visor', () => {
       getFeature: jest.fn().mockReturnValue({ isEnabled: false, isAvailable: false }),
     };
     services.esql.getLicense.mockResolvedValue(invalidLicense);
-    const { queryByTestId } = renderWithI18n(
-      renderESQLVisor({ ...props }, { nlToEsqlEnabled: true })
-    );
+    const { queryByTestId } = renderWithI18n(renderESQLVisor({ ...props }));
     await act(async () => {});
     expect(queryByTestId('esqlVisorModeSelect')).not.toBeInTheDocument();
     services.esql.getLicense.mockResolvedValue(validLicense);
   });
 
-  it('should render the mode selector when nlToEsql flag is enabled', async () => {
-    const { getByTestId } = renderWithI18n(
-      renderESQLVisor({ ...props }, { nlToEsqlEnabled: true })
-    );
+  it('should render the mode selector when license is enterprise', async () => {
+    const { getByTestId } = renderWithI18n(renderESQLVisor({ ...props }));
     await waitFor(() => {
       expect(getByTestId('esqlVisorModeSelect')).toBeInTheDocument();
     });
   });
 
   it('should switch to NL mode and show the NL input when connectors are available', async () => {
-    const { getByTestId, queryByTestId } = renderWithI18n(
-      renderESQLVisor({ ...props }, { nlToEsqlEnabled: true })
-    );
+    const { getByTestId, queryByTestId } = renderWithI18n(renderESQLVisor({ ...props }));
 
     await switchToNlMode(getByTestId);
 
@@ -201,9 +181,7 @@ describe('Quick search visor', () => {
       return Promise.resolve([]);
     });
 
-    const { getByTestId } = renderWithI18n(
-      renderESQLVisor({ ...props }, { nlToEsqlEnabled: true })
-    );
+    const { getByTestId } = renderWithI18n(renderESQLVisor({ ...props }));
 
     await switchToNlMode(getByTestId);
 

--- a/src/platform/packages/private/kbn-esql-editor/src/editor_visor/index.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/editor_visor/index.tsx
@@ -30,7 +30,6 @@ import { visorStyles, visorWidthPercentage, dropdownWidthPercentage } from './vi
 import type { ESQLEditorDeps } from '../types';
 import { useNlToEsqlCheck } from '../hooks/use_nl_to_esql_check';
 
-export { NL_TO_ESQL_FLAG } from '../hooks/use_nl_to_esql_check';
 export { VisorMode } from './mode_selector';
 
 export interface QuickSearchVisorProps {

--- a/src/platform/packages/private/kbn-esql-editor/src/hooks/use_nl_to_esql_check.test.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/hooks/use_nl_to_esql_check.test.tsx
@@ -11,7 +11,7 @@ import React from 'react';
 import { renderHook, act } from '@testing-library/react';
 import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
 import { coreMock } from '@kbn/core/public/mocks';
-import { useNlToEsqlCheck, NL_TO_ESQL_FLAG } from './use_nl_to_esql_check';
+import { useNlToEsqlCheck } from './use_nl_to_esql_check';
 
 describe('useNlToEsqlCheck', () => {
   const coreStart = coreMock.createStart();
@@ -42,30 +42,16 @@ describe('useNlToEsqlCheck', () => {
     getLicenseMock.mockResolvedValue(validLicense);
   });
 
-  it('should return false when the feature flag is disabled', () => {
-    (coreStart.featureFlags.getBooleanValue as jest.Mock).mockImplementation(
-      (key: string, defaultValue: boolean) => {
-        if (key === NL_TO_ESQL_FLAG) return false;
-        return defaultValue;
-      }
-    );
-
+  it('should return false when getLicense is not available', () => {
     const { result } = renderHook(() => useNlToEsqlCheck(), {
-      wrapper: createWrapper({ getLicense: getLicenseMock }),
+      wrapper: createWrapper(undefined),
     });
 
     expect(result.current).toBe(false);
     expect(getLicenseMock).not.toHaveBeenCalled();
   });
 
-  it('should return true when the flag is enabled and license is enterprise', async () => {
-    (coreStart.featureFlags.getBooleanValue as jest.Mock).mockImplementation(
-      (key: string, defaultValue: boolean) => {
-        if (key === NL_TO_ESQL_FLAG) return true;
-        return defaultValue;
-      }
-    );
-
+  it('should return true when license is enterprise', async () => {
     const { result } = renderHook(() => useNlToEsqlCheck(), {
       wrapper: createWrapper({ getLicense: getLicenseMock }),
     });
@@ -76,13 +62,7 @@ describe('useNlToEsqlCheck', () => {
     expect(getLicenseMock).toHaveBeenCalledTimes(1);
   });
 
-  it('should return false when the flag is enabled but license is not enterprise', async () => {
-    (coreStart.featureFlags.getBooleanValue as jest.Mock).mockImplementation(
-      (key: string, defaultValue: boolean) => {
-        if (key === NL_TO_ESQL_FLAG) return true;
-        return defaultValue;
-      }
-    );
+  it('should return false when license is not enterprise', async () => {
     getLicenseMock.mockResolvedValue(invalidLicense);
 
     const { result } = renderHook(() => useNlToEsqlCheck(), {

--- a/src/platform/packages/private/kbn-esql-editor/src/hooks/use_nl_to_esql_check.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/hooks/use_nl_to_esql_check.ts
@@ -11,25 +11,22 @@ import { useEffect, useRef, useState } from 'react';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import type { ESQLEditorDeps } from '../types';
 
-export const NL_TO_ESQL_FLAG = 'esql.nlToEsqlEnabled';
-
 export const useNlToEsqlCheck = (): boolean => {
   const kibana = useKibana<ESQLEditorDeps>();
-  const { core, esql } = kibana.services;
+  const { esql } = kibana.services;
   const getLicense = esql?.getLicense;
-  const isNlToEsqlFlagEnabled = core.featureFlags.getBooleanValue(NL_TO_ESQL_FLAG, false);
   const [hasValidLicense, setHasValidLicense] = useState(false);
   const licenseCheckRef = useRef(false);
 
   useEffect(() => {
-    if (!isNlToEsqlFlagEnabled || !getLicense || licenseCheckRef.current) return;
+    if (!getLicense || licenseCheckRef.current) return;
     licenseCheckRef.current = true;
     getLicense().then((license) => {
       setHasValidLicense(
         Boolean(license && license.status === 'active' && license.hasAtLeast('enterprise'))
       );
     });
-  }, [isNlToEsqlFlagEnabled, getLicense]);
+  }, [getLicense]);
 
-  return isNlToEsqlFlagEnabled && hasValidLicense;
+  return hasValidLicense;
 };


### PR DESCRIPTION
## Summary

Enables the natural language to ES|QL functionality in the editor. We decided that we are ready to remove the setting.

<img width="1250" height="135" alt="image" src="https://github.com/user-attachments/assets/0c3faada-bff2-41b2-a8a8-c9541acaa223" />

(the feature is still disabled for basic license)

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios




