### PR TITLE
[9.3] [scout] support starting Kibana server with http2 (#257459)

### DIFF
--- a/src/platform/packages/shared/kbn-scout/README.md
+++ b/src/platform/packages/shared/kbn-scout/README.md
@@ -428,6 +428,20 @@ node scripts/scout start-server --arch <arch> --domain <domain>
 
 This command is useful for manual testing or running tests via an IDE.
 
+#### HTTP/2 Mode
+
+Scout can start Kibana with **HTTP/2 over TLS** enabled. From 9.0 onward Kibana defaults to HTTP/2 whenever TLS is configured, so production-like deployments increasingly run on HTTP/2 rather than HTTP/1.1. Some behaviors differ between the two protocols (e.g. search strategies and other streaming response paths), so use this mode to validate plugin behavior under HTTP/2 or to reproduce TLS-only issues locally.
+
+Enable it via the `http2` server config set; tests don't need any changes.
+
+```bash
+node scripts/scout start-server --arch stateful --domain classic --serverConfigSet http2
+node scripts/scout run-tests --arch stateful --domain classic --serverConfigSet http2 \
+  --config <plugin-path>/test/scout/ui/playwright.config.ts
+```
+
+Supported `--arch`/`--domain` combinations are the ones defined under `src/servers/configs/config_sets/http2/`.
+
 #### Running Servers and Tests Locally
 
 To start the servers locally and run tests in one step, use:

--- a/src/platform/packages/shared/kbn-scout/src/common/services/clients.ts
+++ b/src/platform/packages/shared/kbn-scout/src/common/services/clients.ts
@@ -7,6 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { readFileSync } from 'fs';
+import { CA_CERT_PATH } from '@kbn/dev-utils';
 import { KbnClient } from '@kbn/kbn-client';
 import { createEsClientForTesting } from '@kbn/test-es-server';
 import type { ScoutLogger } from './logger';
@@ -64,7 +66,11 @@ export function getKbnClient(config: ScoutTestConfig, log: ScoutLogger) {
       log,
     });
 
-    kbnClientInstance = new KbnClient({ log, url: kibanaUrl });
+    kbnClientInstance = new KbnClient({
+      log,
+      url: kibanaUrl,
+      ...(config.http2 ? { certificateAuthorities: [readFileSync(CA_CERT_PATH)] } : {}),
+    });
   }
 
   return kbnClientInstance;

--- a/src/platform/packages/shared/kbn-scout/src/common/services/config.ts
+++ b/src/platform/packages/shared/kbn-scout/src/common/services/config.ts
@@ -27,6 +27,11 @@ export function createScoutConfig(
 
   const config = JSON.parse(fs.readFileSync(configPath, 'utf-8')) as ScoutTestConfig;
 
+  if (config.http2) {
+    process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+    process.env.IS_FTR_RUNNER = 'true';
+  }
+
   log.serviceLoaded('config');
 
   return config;

--- a/src/platform/packages/shared/kbn-scout/src/playwright/config/create_config.test.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/config/create_config.test.ts
@@ -58,6 +58,7 @@ describe('createPlaywrightConfig', () => {
       testIdAttribute: 'data-test-subj',
       trace: 'on-first-retry',
       timezoneId: 'GMT',
+      ignoreHTTPSErrors: true,
     });
     expect(config.globalSetup).toBeUndefined();
     expect(config.globalTeardown).toBeUndefined();

--- a/src/platform/packages/shared/kbn-scout/src/playwright/config/create_config.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/config/create_config.ts
@@ -99,6 +99,7 @@ export function createPlaywrightConfig(options: ScoutPlaywrightOptions): Playwri
       // video: 'retain-on-failure',
       // storageState: './output/reports/state.json', // Store session state (like cookies)
       timezoneId: 'GMT',
+      ignoreHTTPSErrors: true,
     },
 
     // Timeout for each test, includes test, hooks and fixtures

--- a/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/worker/api_client.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/worker/api_client.ts
@@ -54,7 +54,7 @@ export const apiClientFixture = coreWorkerFixtures.extend<{}, { apiClient: ApiCl
   apiClient: [
     async ({ config, log }, use) => {
       const kibanaServerUrl = formatUrl(config.hosts.kibana);
-      const testAgent = supertest(kibanaServerUrl);
+      const testAgent = supertest(kibanaServerUrl, config.http2 ? { http2: true } : {});
 
       // Map method names to agent functions
       const methodMap: Record<keyof ApiClientFixture, (url: string) => supertest.Test> = {

--- a/src/platform/packages/shared/kbn-scout/src/servers/configs/config.test.ts
+++ b/src/platform/packages/shared/kbn-scout/src/servers/configs/config.test.ts
@@ -47,6 +47,7 @@ describe('Config.getScoutTestConfig', () => {
 
     const expectedConfig = {
       serverless: false,
+      http2: false,
       uiam: false,
       projectType: undefined,
       isCloud: false,
@@ -106,6 +107,7 @@ describe('Config.getScoutTestConfig', () => {
     const scoutConfig = config.getScoutTestConfig();
     const expectedConfig = {
       serverless: true,
+      http2: false,
       uiam: false,
       projectType: 'es',
       isCloud: false,
@@ -166,6 +168,7 @@ describe('Config.getScoutTestConfig', () => {
     const scoutConfig = config.getScoutTestConfig();
     const expectedConfig = {
       serverless: true,
+      http2: false,
       uiam: true,
       projectType: 'es',
       organizationId: 'org123',

--- a/src/platform/packages/shared/kbn-scout/src/servers/configs/config.ts
+++ b/src/platform/packages/shared/kbn-scout/src/servers/configs/config.ts
@@ -107,6 +107,7 @@ export class Config {
   public getScoutTestConfig(): ScoutTestConfig {
     return {
       serverless: this.get('serverless'),
+      http2: this.get('http2'),
       uiam: this.get('esServerlessOptions.uiam', false),
       projectType: this.get('serverless')
         ? getProjectType(this.get('kbnTestServer.serverArgs'))

--- a/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/http2/serverless/observability_complete.serverless.config.ts
+++ b/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/http2/serverless/observability_complete.serverless.config.ts
@@ -7,4 +7,10 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export { readConfigFile, loadRawServerConfig } from './read_config_file';
+import type { ScoutServerConfig } from '../../../../../types';
+import { servers as defaultServers } from '../../default/serverless/observability_complete.serverless.config';
+
+export const servers: ScoutServerConfig = {
+  ...defaultServers,
+  http2: true,
+};

--- a/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/http2/serverless/observability_logs_essentials.serverless.config.ts
+++ b/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/http2/serverless/observability_logs_essentials.serverless.config.ts
@@ -7,4 +7,10 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export { readConfigFile, loadRawServerConfig } from './read_config_file';
+import type { ScoutServerConfig } from '../../../../../types';
+import { servers as defaultServers } from '../../default/serverless/observability_logs_essentials.serverless.config';
+
+export const servers: ScoutServerConfig = {
+  ...defaultServers,
+  http2: true,
+};

--- a/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/http2/serverless/search.serverless.config.ts
+++ b/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/http2/serverless/search.serverless.config.ts
@@ -7,4 +7,10 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export { readConfigFile, loadRawServerConfig } from './read_config_file';
+import type { ScoutServerConfig } from '../../../../../types';
+import { servers as defaultServers } from '../../default/serverless/search.serverless.config';
+
+export const servers: ScoutServerConfig = {
+  ...defaultServers,
+  http2: true,
+};

--- a/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/http2/serverless/security_complete.serverless.config.ts
+++ b/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/http2/serverless/security_complete.serverless.config.ts
@@ -7,4 +7,10 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export { readConfigFile, loadRawServerConfig } from './read_config_file';
+import type { ScoutServerConfig } from '../../../../../types';
+import { servers as defaultServers } from '../../default/serverless/security_complete.serverless.config';
+
+export const servers: ScoutServerConfig = {
+  ...defaultServers,
+  http2: true,
+};

--- a/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/http2/serverless/security_ease.serverless.config.ts
+++ b/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/http2/serverless/security_ease.serverless.config.ts
@@ -7,4 +7,10 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export { readConfigFile, loadRawServerConfig } from './read_config_file';
+import type { ScoutServerConfig } from '../../../../../types';
+import { servers as defaultServers } from '../../default/serverless/security_ease.serverless.config';
+
+export const servers: ScoutServerConfig = {
+  ...defaultServers,
+  http2: true,
+};

--- a/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/http2/serverless/security_essentials.serverless.config.ts
+++ b/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/http2/serverless/security_essentials.serverless.config.ts
@@ -7,4 +7,10 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export { readConfigFile, loadRawServerConfig } from './read_config_file';
+import type { ScoutServerConfig } from '../../../../../types';
+import { servers as defaultServers } from '../../default/serverless/security_essentials.serverless.config';
+
+export const servers: ScoutServerConfig = {
+  ...defaultServers,
+  http2: true,
+};

--- a/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/http2/serverless/workplaceai.serverless.config.ts
+++ b/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/http2/serverless/workplaceai.serverless.config.ts
@@ -7,4 +7,10 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export { readConfigFile, loadRawServerConfig } from './read_config_file';
+import type { ScoutServerConfig } from '../../../../../types';
+import { servers as defaultServers } from '../../default/serverless/workplaceai.serverless.config';
+
+export const servers: ScoutServerConfig = {
+  ...defaultServers,
+  http2: true,
+};

--- a/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/http2/stateful/classic.stateful.config.ts
+++ b/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/http2/stateful/classic.stateful.config.ts
@@ -7,4 +7,10 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export { readConfigFile, loadRawServerConfig } from './read_config_file';
+import type { ScoutServerConfig } from '../../../../../types';
+import { defaultConfig } from '../../default/stateful/base.config';
+
+export const servers: ScoutServerConfig = {
+  ...defaultConfig,
+  http2: true,
+};

--- a/src/platform/packages/shared/kbn-scout/src/servers/configs/loader/read_config_file.ts
+++ b/src/platform/packages/shared/kbn-scout/src/servers/configs/loader/read_config_file.ts
@@ -12,6 +12,22 @@ import type { ScoutServerConfig } from '../../../types';
 import { Config } from '../config';
 
 /**
+ * Dynamically loads the raw server configuration object from a config file.
+ * @param configPath Path to the configuration file to be loaded.
+ * @returns Raw ScoutServerConfig object before validation
+ */
+export const loadRawServerConfig = async (configPath: string): Promise<ScoutServerConfig> => {
+  const absolutePath = path.resolve(configPath);
+  const configModule = await import(absolutePath);
+
+  if (configModule.servers) {
+    return configModule.servers as ScoutServerConfig;
+  }
+
+  throw new Error(`No 'servers' found in the config file at path: ${absolutePath}`);
+};
+
+/**
  * Dynamically loads server configuration file in the "kbn-scout" framework. It reads
  * and validates the configuration file, ensuring the presence of essential servers
  * information required to initialize the testing environment.
@@ -20,14 +36,8 @@ import { Config } from '../config';
  */
 export const readConfigFile = async (configPath: string): Promise<Config> => {
   try {
-    const absolutePath = path.resolve(configPath);
-    const configModule = await import(absolutePath);
-
-    if (configModule.servers) {
-      return new Config(configModule.servers as ScoutServerConfig);
-    } else {
-      throw new Error(`No 'servers' found in the config file at path: ${absolutePath}`);
-    }
+    const rawConfig = await loadRawServerConfig(configPath);
+    return new Config(rawConfig);
   } catch (error) {
     throw new Error(`Failed to load config from ${configPath}: ${error.message}`);
   }

--- a/src/platform/packages/shared/kbn-scout/src/servers/configs/schema/schema.ts
+++ b/src/platform/packages/shared/kbn-scout/src/servers/configs/schema/schema.ts
@@ -64,6 +64,7 @@ const dockerServerSchema = () =>
 export const schema = Joi.object()
   .keys({
     serverless: Joi.boolean().default(false),
+    http2: Joi.boolean().default(false),
     servers: Joi.object()
       .keys({
         kibana: urlPartsSchema(),

--- a/src/platform/packages/shared/kbn-scout/src/servers/configs/utils/configure_http2.test.ts
+++ b/src/platform/packages/shared/kbn-scout/src/servers/configs/utils/configure_http2.test.ts
@@ -1,0 +1,218 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { CA_CERT_PATH, KBN_CERT_PATH, KBN_KEY_PATH } from '@kbn/dev-utils';
+import type { ScoutServerConfig } from '../../../types';
+import { configureHTTP2 } from './configure_http2';
+
+const createMockConfig = (overrides?: Partial<ScoutServerConfig>): ScoutServerConfig => ({
+  servers: {
+    elasticsearch: { protocol: 'http', hostname: 'localhost', port: 9220 },
+    kibana: { protocol: 'http', hostname: 'localhost', port: 5620 },
+  },
+  dockerServers: {},
+  esTestCluster: {
+    from: 'snapshot',
+    files: [],
+    serverArgs: [
+      'xpack.security.authc.realms.saml.mock-idp.order=0',
+      'xpack.security.authc.realms.saml.mock-idp.idp.metadata.path=/path/to/metadata.xml',
+      'xpack.security.authc.realms.saml.mock-idp.sp.entity_id=http://localhost:5620',
+      'xpack.security.authc.realms.saml.mock-idp.sp.acs=http://localhost:5620/api/security/saml/callback',
+      'xpack.security.authc.realms.saml.mock-idp.sp.logout=http://localhost:5620/logout',
+    ],
+    ssl: false,
+  },
+  kbnTestServer: {
+    buildArgs: [],
+    env: {},
+    sourceArgs: ['--no-base-path'],
+    serverArgs: [
+      '--server.port=5620',
+      '--server.publicBaseUrl=http://localhost:5620',
+      '--newsfeed.service.urlRoot=http://localhost:5620',
+      '--elasticsearch.hosts=http://localhost:9220',
+    ],
+  },
+  ...overrides,
+});
+
+describe('configureHTTP2', () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  describe('environment variables', () => {
+    it('should set IS_FTR_RUNNER and NODE_TLS_REJECT_UNAUTHORIZED', () => {
+      delete process.env.IS_FTR_RUNNER;
+      delete process.env.NODE_TLS_REJECT_UNAUTHORIZED;
+
+      configureHTTP2(createMockConfig());
+
+      expect(process.env.IS_FTR_RUNNER).toBe('true');
+      expect(process.env.NODE_TLS_REJECT_UNAUTHORIZED).toBe('0');
+    });
+  });
+
+  describe('servers.kibana config', () => {
+    it('should change protocol to https', () => {
+      const config = createMockConfig();
+      configureHTTP2(config);
+      expect(config.servers.kibana.protocol).toBe('https');
+    });
+
+    it('should add certificateAuthorities from the dev CA', () => {
+      const config = createMockConfig();
+      configureHTTP2(config);
+      expect(config.servers.kibana.certificateAuthorities).toBeDefined();
+      expect(config.servers.kibana.certificateAuthorities).toHaveLength(1);
+    });
+
+    it('should preserve existing kibana server properties', () => {
+      const config = createMockConfig();
+      configureHTTP2(config);
+      expect(config.servers.kibana.hostname).toBe('localhost');
+      expect(config.servers.kibana.port).toBe(5620);
+    });
+  });
+
+  describe('Kibana serverArgs (TLS setup)', () => {
+    it('should add HTTP/2 and SSL args', () => {
+      const config = createMockConfig();
+      configureHTTP2(config);
+      const { serverArgs } = config.kbnTestServer;
+
+      expect(serverArgs).toContain('--server.protocol=http2');
+      expect(serverArgs).toContain('--server.ssl.enabled=true');
+      expect(serverArgs).toContain(`--server.ssl.key=${KBN_KEY_PATH}`);
+      expect(serverArgs).toContain(`--server.ssl.certificate=${KBN_CERT_PATH}`);
+      expect(serverArgs).toContain(`--server.ssl.certificateAuthorities=${CA_CERT_PATH}`);
+    });
+
+    it('should replace existing server.protocol arg instead of duplicating', () => {
+      const config = createMockConfig();
+      config.kbnTestServer.serverArgs.push('--server.protocol=http1');
+
+      configureHTTP2(config);
+
+      const protocolArgs = config.kbnTestServer.serverArgs.filter((a) =>
+        a.startsWith('--server.protocol=')
+      );
+      expect(protocolArgs).toEqual(['--server.protocol=http2']);
+    });
+  });
+
+  describe('URL rewriting (kbnTestServer.serverArgs)', () => {
+    it('should rewrite Kibana http:// URLs to https://', () => {
+      const config = createMockConfig();
+      configureHTTP2(config);
+      const { serverArgs } = config.kbnTestServer;
+
+      expect(serverArgs).toContain('--server.publicBaseUrl=https://localhost:5620');
+      expect(serverArgs).toContain('--newsfeed.service.urlRoot=https://localhost:5620');
+    });
+
+    it('should not rewrite non-Kibana URLs (e.g. Elasticsearch)', () => {
+      const config = createMockConfig();
+      configureHTTP2(config);
+      const { serverArgs } = config.kbnTestServer;
+
+      expect(serverArgs).toContain('--elasticsearch.hosts=http://localhost:9220');
+    });
+  });
+
+  describe('URL rewriting (esTestCluster.serverArgs)', () => {
+    it('should rewrite SAML SP args from http:// to https://', () => {
+      const config = createMockConfig();
+      configureHTTP2(config);
+      const { serverArgs } = config.esTestCluster;
+
+      expect(serverArgs).toContain(
+        'xpack.security.authc.realms.saml.mock-idp.sp.entity_id=https://localhost:5620'
+      );
+      expect(serverArgs).toContain(
+        'xpack.security.authc.realms.saml.mock-idp.sp.acs=https://localhost:5620/api/security/saml/callback'
+      );
+      expect(serverArgs).toContain(
+        'xpack.security.authc.realms.saml.mock-idp.sp.logout=https://localhost:5620/logout'
+      );
+    });
+
+    it('should not rewrite non-URL SAML args', () => {
+      const config = createMockConfig();
+      configureHTTP2(config);
+      const { serverArgs } = config.esTestCluster;
+
+      expect(serverArgs).toContain(
+        'xpack.security.authc.realms.saml.mock-idp.idp.metadata.path=/path/to/metadata.xml'
+      );
+    });
+  });
+
+  describe('SAML realm SSL CA injection', () => {
+    it('should add ssl.certificate_authorities for detected SAML realms', () => {
+      const config = createMockConfig();
+      configureHTTP2(config);
+      const { serverArgs } = config.esTestCluster;
+
+      expect(serverArgs).toContain(
+        `xpack.security.authc.realms.saml.mock-idp.ssl.certificate_authorities=${CA_CERT_PATH}`
+      );
+    });
+
+    it('should handle realm names with hyphens (e.g. cloud-saml-kibana)', () => {
+      const config = createMockConfig({
+        esTestCluster: {
+          from: 'snapshot',
+          files: [],
+          serverArgs: [
+            'xpack.security.authc.realms.saml.cloud-saml-kibana.order=0',
+            'xpack.security.authc.realms.saml.cloud-saml-kibana.sp.entity_id=http://localhost:5620',
+          ],
+          ssl: false,
+        },
+      });
+
+      configureHTTP2(config);
+
+      expect(config.esTestCluster.serverArgs).toContain(
+        `xpack.security.authc.realms.saml.cloud-saml-kibana.ssl.certificate_authorities=${CA_CERT_PATH}`
+      );
+    });
+
+    it('should not duplicate ssl.certificate_authorities if already present', () => {
+      const sslCaArg = `xpack.security.authc.realms.saml.mock-idp.ssl.certificate_authorities=${CA_CERT_PATH}`;
+      const config = createMockConfig();
+      config.esTestCluster.serverArgs.push(sslCaArg);
+
+      configureHTTP2(config);
+
+      const matches = config.esTestCluster.serverArgs.filter((a) => a === sslCaArg);
+      expect(matches).toHaveLength(1);
+    });
+
+    it('should handle config with no SAML realms', () => {
+      const config = createMockConfig({
+        esTestCluster: {
+          from: 'snapshot',
+          files: [],
+          serverArgs: ['some.other.setting=value'],
+          ssl: false,
+        },
+      });
+
+      expect(() => configureHTTP2(config)).not.toThrow();
+      expect(config.esTestCluster.serverArgs).not.toContainEqual(
+        expect.stringContaining('ssl.certificate_authorities')
+      );
+    });
+  });
+});

--- a/src/platform/packages/shared/kbn-scout/src/servers/configs/utils/configure_http2.ts
+++ b/src/platform/packages/shared/kbn-scout/src/servers/configs/utils/configure_http2.ts
@@ -1,0 +1,140 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { readFileSync } from 'fs';
+import { CA_CERT_PATH, KBN_CERT_PATH, KBN_KEY_PATH } from '@kbn/dev-utils';
+import type { ScoutServerConfig } from '../../../types';
+
+/**
+ * Transforms a Scout server config to enable HTTP/2 with TLS.
+ * Mutates `kbnTestServer.serverArgs` and `esTestCluster.serverArgs` in-place
+ * and returns the modified config.
+ *
+ * Aligned with FTR's `configureHTTP2` in `src/platform/test/common/configure_http2.ts`.
+ */
+export const configureHTTP2 = (config: ScoutServerConfig): ScoutServerConfig => {
+  // Kibana exits on NODE_TLS_REJECT_UNAUTHORIZED warning unless IS_FTR_RUNNER is set
+  // (see src/setup_node_env/exit_on_warning.js)
+  process.env.IS_FTR_RUNNER = 'true';
+  // Required for libraries like supertest that have no API to accept self-signed certs
+  process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+
+  const kibanaHostname = config.servers.kibana.hostname ?? 'localhost';
+  const kibanaPort = config.servers.kibana.port;
+  const certificateAuthorities = [readFileSync(CA_CERT_PATH, 'utf-8')];
+
+  // KbnClient and other test clients read protocol + certificateAuthorities from this config
+  // to build HTTPS agents (see kbn_client_requester.ts)
+  config.servers.kibana = {
+    ...config.servers.kibana,
+    protocol: 'https',
+    certificateAuthorities,
+  };
+
+  const { serverArgs } = config.kbnTestServer;
+
+  // Enable HTTP/2 protocol with TLS on the Kibana server process
+  addOrReplaceArg(serverArgs, 'server.protocol', () => 'http2');
+  addOrReplaceArg(serverArgs, 'server.ssl.enabled', () => 'true');
+  addOrReplaceArg(serverArgs, 'server.ssl.key', () => KBN_KEY_PATH);
+  addOrReplaceArg(serverArgs, 'server.ssl.certificate', () => KBN_CERT_PATH);
+  addOrReplaceArg(serverArgs, 'server.ssl.certificateAuthorities', () => CA_CERT_PATH);
+
+  // Rewrite Kibana URL references (e.g. --server.publicBaseUrl, --newsfeed.service.urlRoot)
+  // from http:// to https:// so they match the TLS-enabled server
+  rewriteKibanaUrlsToHttps(serverArgs, kibanaHostname, kibanaPort);
+
+  const esArgs = config.esTestCluster.serverArgs;
+
+  // SAML realm SP args (sp.entity_id, sp.acs, sp.logout) embed the Kibana base URL;
+  // they must use https:// to match the SAML assertions produced by the mock IDP
+  rewriteKibanaUrlsToHttps(esArgs, kibanaHostname, kibanaPort);
+
+  // ES SAML realm validates HTTPS SP URLs against a trusted CA — without this,
+  // ES rejects the self-signed dev certificate (mirrors FTR's saml.http2.config.ts)
+  addSamlRealmSslCa(esArgs);
+
+  return config;
+};
+
+/**
+ * Rewrites serverArg values that reference the Kibana host:port over http:// to https://.
+ *
+ * Used for both Kibana and ES args. For Kibana, this covers args like `server.publicBaseUrl`
+ * and `newsfeed.service.urlRoot`. For ES, this covers SAML SP args (`sp.entity_id`, `sp.acs`,
+ * `sp.logout`) that must match the actual Kibana protocol.
+ *
+ * Only rewrites URLs matching the exact Kibana hostname:port to avoid accidentally
+ * rewriting Elasticsearch or other service URLs.
+ */
+const rewriteKibanaUrlsToHttps = (
+  serverArgs: string[],
+  hostname: string,
+  port: number | undefined
+) => {
+  const httpKibanaUrl = port ? `http://${hostname}:${port}` : `http://${hostname}`;
+  const httpsKibanaUrl = httpKibanaUrl.replace('http://', 'https://');
+
+  for (let i = 0; i < serverArgs.length; i++) {
+    if (serverArgs[i].includes(httpKibanaUrl)) {
+      serverArgs[i] = serverArgs[i].replaceAll(httpKibanaUrl, httpsKibanaUrl);
+    }
+  }
+};
+
+/**
+ * Detects SAML realm names from ES serverArgs and adds `ssl.certificate_authorities`
+ * so ES trusts Kibana's dev TLS certificate for HTTPS SP URLs.
+ *
+ * Without this, ES cannot validate the SAML SP endpoints (entity_id, acs, logout)
+ * when they use https:// with the dev self-signed certificate.
+ * Mirrors FTR's explicit `ssl.certificate_authorities` in saml.http2.config.ts.
+ */
+const addSamlRealmSslCa = (esArgs: string[]) => {
+  const realmNames = new Set<string>();
+  const realmPattern = /^xpack\.security\.authc\.realms\.saml\.([^.=]+)\./;
+
+  for (const arg of esArgs) {
+    const match = arg.match(realmPattern);
+    if (match) {
+      realmNames.add(match[1]);
+    }
+  }
+
+  for (const realmName of realmNames) {
+    const sslCaArg = `xpack.security.authc.realms.saml.${realmName}.ssl.certificate_authorities=${CA_CERT_PATH}`;
+    if (!esArgs.includes(sslCaArg)) {
+      esArgs.push(sslCaArg);
+    }
+  }
+};
+
+const addOrReplaceArg = (
+  serverArgs: string[],
+  argName: string,
+  replacer: (value: string | undefined) => string | undefined
+) => {
+  const argPrefix = `--${argName}=`;
+  const argIndex = serverArgs.findIndex((value) => value.startsWith(argPrefix));
+
+  if (argIndex === -1) {
+    const newArgValue = replacer(undefined);
+    if (newArgValue !== undefined) {
+      serverArgs.push(`${argPrefix}${newArgValue}`);
+    }
+  } else {
+    const currentArgValue = serverArgs[argIndex].substring(argPrefix.length);
+    const newArgValue = replacer(currentArgValue);
+    if (newArgValue !== undefined) {
+      serverArgs[argIndex] = `${argPrefix}${newArgValue}`;
+    } else {
+      serverArgs.splice(argIndex, 1);
+    }
+  }
+};

--- a/src/platform/packages/shared/kbn-scout/src/servers/configs/utils/index.ts
+++ b/src/platform/packages/shared/kbn-scout/src/servers/configs/utils/index.ts
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+export { configureHTTP2 } from './configure_http2';
 export { detectCustomConfigDir, getConfigRootDir } from './detect_custom_config';
 export { getConfigFilePath } from './get_config_file';
 export { loadServersConfig } from './load_servers_config';

--- a/src/platform/packages/shared/kbn-scout/src/servers/configs/utils/load_servers_config.test.ts
+++ b/src/platform/packages/shared/kbn-scout/src/servers/configs/utils/load_servers_config.test.ts
@@ -10,10 +10,12 @@
 import type { ToolingLog } from '@kbn/tooling-log';
 import fs from 'fs';
 import { loadServersConfig } from '..';
-import type { ScoutTestConfig } from '../../../types';
-import { readConfigFile } from '../loader';
+import type { ScoutServerConfig, ScoutTestConfig } from '../../../types';
+import { loadRawServerConfig } from '../loader';
+import { Config } from '../config';
 import { getConfigFilePath } from './get_config_file';
 import { saveScoutTestConfigOnDisk } from './save_scout_test_config';
+import { configureHTTP2 } from './configure_http2';
 import { ScoutTestTarget } from '@kbn/scout-info';
 
 jest.mock('./get_config_file', () => ({
@@ -21,11 +23,19 @@ jest.mock('./get_config_file', () => ({
 }));
 
 jest.mock('../loader', () => ({
-  readConfigFile: jest.fn(),
+  loadRawServerConfig: jest.fn(),
+}));
+
+jest.mock('../config', () => ({
+  Config: jest.fn(),
 }));
 
 jest.mock('./save_scout_test_config', () => ({
   saveScoutTestConfigOnDisk: jest.fn(),
+}));
+
+jest.mock('./configure_http2', () => ({
+  configureHTTP2: jest.fn((config: ScoutServerConfig) => config),
 }));
 
 jest.mock('fs', () => {
@@ -46,11 +56,22 @@ const mockScoutTestConfig: ScoutTestConfig = {
     password: 'changeme',
   },
   serverless: true,
+  http2: false,
   uiam: false,
   projectType: 'oblt',
   isCloud: true,
   license: 'trial',
   cloudUsersFilePath: '/path/to/users',
+};
+
+const mockRawConfig: ScoutServerConfig = {
+  servers: {
+    elasticsearch: { protocol: 'http', hostname: 'localhost', port: 9220 },
+    kibana: { protocol: 'http', hostname: 'localhost', port: 5620 },
+  },
+  dockerServers: {},
+  esTestCluster: { from: 'snapshot', files: [], serverArgs: [], ssl: false },
+  kbnTestServer: { buildArgs: [], env: {}, sourceArgs: [], serverArgs: [] },
 };
 
 describe('loadServersConfig', () => {
@@ -59,8 +80,11 @@ describe('loadServersConfig', () => {
   const mockTestTarget = new ScoutTestTarget('cloud', 'serverless', 'observability_complete');
   const mockConfigPath = '/mock/config/path.ts';
 
-  const mockClusterConfig = {
+  const mockConfigInstance = {
     getScoutTestConfig: jest.fn().mockReturnValue(mockScoutTestConfig),
+    get: jest.fn(),
+    getAll: jest.fn(),
+    has: jest.fn(),
   };
 
   beforeEach(() => {
@@ -71,27 +95,50 @@ describe('loadServersConfig', () => {
       error: jest.fn(),
     } as unknown as ToolingLog;
     (fs.existsSync as jest.Mock).mockReturnValue(true);
+    (Config as unknown as jest.Mock).mockReturnValue(mockConfigInstance);
   });
 
-  it('should load, save, and return cluster configuration', async () => {
+  it('should load, save, and return cluster configuration without HTTP/2 by default', async () => {
     const configRootDir = '/mock/config/root/default/serverless';
     (getConfigFilePath as jest.Mock).mockReturnValue(mockConfigPath);
-    (readConfigFile as jest.Mock).mockResolvedValue(mockClusterConfig);
+    (loadRawServerConfig as jest.Mock).mockResolvedValue({ ...mockRawConfig });
 
     const result = await loadServersConfig(mockTestTarget, mockLog, configRootDir);
 
     expect(getConfigFilePath).toHaveBeenCalledWith(configRootDir, mockTestTarget);
-    expect(readConfigFile).toHaveBeenCalledWith(mockConfigPath);
-    expect(mockClusterConfig.getScoutTestConfig).toHaveBeenCalled();
+    expect(loadRawServerConfig).toHaveBeenCalledWith(mockConfigPath);
+    expect(configureHTTP2).not.toHaveBeenCalled();
+    expect(Config).toHaveBeenCalled();
+    expect(mockConfigInstance.getScoutTestConfig).toHaveBeenCalled();
     expect(saveScoutTestConfigOnDisk).toHaveBeenCalledWith(mockScoutTestConfig, mockLog);
-    expect(result).toBe(mockClusterConfig);
+    expect(result).toBe(mockConfigInstance);
   });
 
-  it('should throw an error if readConfigFile fails', async () => {
+  it('should apply HTTP/2 when http2 is explicitly true', async () => {
+    const configRootDir = '/mock/config/root/default/serverless';
+    (getConfigFilePath as jest.Mock).mockReturnValue(mockConfigPath);
+    (loadRawServerConfig as jest.Mock).mockResolvedValue({ ...mockRawConfig, http2: true });
+
+    await loadServersConfig(mockTestTarget, mockLog, configRootDir);
+
+    expect(configureHTTP2).toHaveBeenCalled();
+  });
+
+  it('should skip HTTP/2 when http2 is explicitly false', async () => {
+    const configRootDir = '/mock/config/root/default/serverless';
+    (getConfigFilePath as jest.Mock).mockReturnValue(mockConfigPath);
+    (loadRawServerConfig as jest.Mock).mockResolvedValue({ ...mockRawConfig, http2: false });
+
+    await loadServersConfig(mockTestTarget, mockLog, configRootDir);
+
+    expect(configureHTTP2).not.toHaveBeenCalled();
+  });
+
+  it('should throw an error if loadRawServerConfig fails', async () => {
     const configRootDir = '/mock/config/root/default/serverless';
     (getConfigFilePath as jest.Mock).mockReturnValue(mockConfigPath);
     const errorMessage = 'Failed to read config file';
-    (readConfigFile as jest.Mock).mockRejectedValue(new Error(errorMessage));
+    (loadRawServerConfig as jest.Mock).mockRejectedValue(new Error(errorMessage));
 
     await expect(loadServersConfig(mockTestTarget, mockLog, configRootDir)).rejects.toThrow(
       errorMessage
@@ -104,13 +151,13 @@ describe('loadServersConfig', () => {
   it('should load custom config from custom directory', async () => {
     const configRootDir = '/mock/config/root/custom/uiam_local/serverless';
     (getConfigFilePath as jest.Mock).mockReturnValue(mockConfigPath);
-    (readConfigFile as jest.Mock).mockResolvedValue(mockClusterConfig);
+    (loadRawServerConfig as jest.Mock).mockResolvedValue({ ...mockRawConfig });
 
     const result = await loadServersConfig(mockTestTarget, mockLog, configRootDir);
 
     expect(getConfigFilePath).toHaveBeenCalledWith(configRootDir, mockTestTarget);
-    expect(readConfigFile).toHaveBeenCalledWith(mockConfigPath);
-    expect(result).toBe(mockClusterConfig);
+    expect(loadRawServerConfig).toHaveBeenCalledWith(mockConfigPath);
+    expect(result).toBe(mockConfigInstance);
   });
 
   it('should throw error when config file does not exist', async () => {
@@ -123,7 +170,7 @@ describe('loadServersConfig', () => {
     );
 
     expect(getConfigFilePath).toHaveBeenCalledWith(configRootDir, mockTestTarget);
-    expect(readConfigFile).not.toHaveBeenCalled();
+    expect(loadRawServerConfig).not.toHaveBeenCalled();
     expect(saveScoutTestConfigOnDisk).not.toHaveBeenCalled();
   });
 });

--- a/src/platform/packages/shared/kbn-scout/src/servers/configs/utils/load_servers_config.ts
+++ b/src/platform/packages/shared/kbn-scout/src/servers/configs/utils/load_servers_config.ts
@@ -10,15 +10,19 @@
 import type { ToolingLog } from '@kbn/tooling-log';
 import fs from 'fs';
 import type { ScoutTestTarget } from '@kbn/scout-info';
-import type { Config } from '../config';
-import { readConfigFile } from '../loader';
+import { Config } from '../config';
+import { loadRawServerConfig } from '../loader';
 import { getConfigFilePath } from './get_config_file';
 import { saveScoutTestConfigOnDisk } from './save_scout_test_config';
+import { configureHTTP2 } from './configure_http2';
 
 /**
  * Loads server configuration based on the mode, creates "kbn-test" compatible Config
  * instance, that can be used to start local servers and saves its "Scout"-format copy
  * to the disk.
+ *
+ * HTTP/2 is disabled by default. To enable it, set `http2: true` in the server config.
+ *
  * @param testTarget The test target definition (based on location, architecture and domain)
  * @param log Logger instance to report errors or debug information.
  * @param configRootDir The root directory where the config file is located
@@ -43,7 +47,14 @@ export async function loadServersConfig(
     throw new Error(`Config file not found: ${configPath}`);
   }
 
-  const clusterConfig = await readConfigFile(configPath);
+  const rawConfig = await loadRawServerConfig(configPath);
+
+  if (rawConfig.http2 === true) {
+    log.info('scout: Enabling HTTP/2 with TLS for Kibana server');
+    configureHTTP2(rawConfig);
+  }
+
+  const clusterConfig = new Config(rawConfig);
   // construct config for Playwright Test
   const scoutServerConfig = clusterConfig.getScoutTestConfig();
   // save test config to the file

--- a/src/platform/packages/shared/kbn-scout/src/servers/configs/utils/save_scout_test_config.test.ts
+++ b/src/platform/packages/shared/kbn-scout/src/servers/configs/utils/save_scout_test_config.test.ts
@@ -35,6 +35,7 @@ const testServersConfig = {
     password: 'changeme',
   },
   serverless: true,
+  http2: false,
   uiam: false,
   projectType: 'oblt' as ServerlessProjectType,
   isCloud: true,

--- a/src/platform/packages/shared/kbn-scout/src/types/server_config.d.ts
+++ b/src/platform/packages/shared/kbn-scout/src/types/server_config.d.ts
@@ -9,12 +9,17 @@
 
 import type { UrlParts } from './url_parts';
 
+type ServerUrlParts = UrlParts & {
+  certificateAuthorities?: Array<string | Buffer>;
+};
+
 export interface ScoutServerConfig {
   serverless?: boolean;
+  http2?: boolean;
   servers: {
-    kibana: UrlParts;
-    elasticsearch: UrlParts;
-    fleet?: UrlParts;
+    kibana: ServerUrlParts;
+    elasticsearch: ServerUrlParts;
+    fleet?: ServerUrlParts;
   };
   dockerServers: any;
   esTestCluster: {

--- a/src/platform/packages/shared/kbn-scout/src/types/test_config.d.ts
+++ b/src/platform/packages/shared/kbn-scout/src/types/test_config.d.ts
@@ -11,6 +11,7 @@ import type { ServerlessProjectType } from '@kbn/es';
 
 export interface ScoutTestConfig {
   serverless: boolean;
+  http2: boolean;
   uiam: boolean;
   projectType?: ServerlessProjectType;
   organizationId?: string;

--- a/x-pack/platform/test/security_api_integration/packages/helpers/saml/idp_metadata_mock_idp.xml
+++ b/x-pack/platform/test/security_api_integration/packages/helpers/saml/idp_metadata_mock_idp.xml
@@ -30,12 +30,12 @@ foE31cFg</ds:X509Certificate>
       </ds:KeyInfo>
     </md:KeyDescriptor>
     <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
-                            Location="http://localhost:5620/mock_idp/logout"/>
+                            Location="/mock_idp/logout"/>
     <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
-                            Location="http://localhost:5620/mock_idp/logout"/>
+                            Location="/mock_idp/logout"/>
     <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
-                            Location="http://localhost:5620/mock_idp/login"/>
+                            Location="/mock_idp/login"/>
     <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
-                            Location="http://localhost:5620/mock_idp/login"/>
+                            Location="/mock_idp/login"/>
   </md:IDPSSODescriptor>
 </md:EntityDescriptor>


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[scout] support starting Kibana server with http2 (#257459)](https://github.com/elastic/kibana/pull/257459)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Dzmitry Lemechko","email":"dzmitry.lemechko@elastic.co"},"sourceCommit":{"committedDate":"2026-04-20T17:15:58Z","message":"[scout] support starting Kibana server with http2 (#257459)\n\n## Summary\n\ncloses https://github.com/elastic/appex-qa-team/issues/817\n\nThis PR extends Scout configs schema with `http2:boolean`, false by\ndefault. In order to run Kibana in http2 mode, I added custom config set\nwith overrides.\n\nThe stateful IDP metadata file `idp_metadata_mock_idp.xml` had hardcoded\n`http://localhost:5620/mock_idp/login` URLs. When Kibana runs with\nHTTPS, ES redirects the browser to the HTTP URL, which fails because\nKibana only accepts HTTPS. Updated to use relative URLs similar to\nserverless\n\n### How to test:\n\nstart servers:\n\n```bash\nnode scripts/scout start-server --arch stateful --domain classic --serverConfigSet http2\n```\n\nmanually load Kibana (note: use `https`):\n\n```\ngo to https://localhost:5620\n```\n\nrun any existing Scout tests:\n```\nnpx playwright test --project local --grep @local-stateful-classic --config x-pack/platform/plugins/private/discover_enhanced/test/scout/ui/parallel.playwright.config.ts\n```","sha":"77ef904c6bc1ab798fc4919a96e95e8673d2e3a7","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:all-open","v9.4.0","v9.5.0"],"title":"[scout] support starting Kibana server with http2","number":257459,"url":"https://github.com/elastic/kibana/pull/257459","mergeCommit":{"message":"[scout] support starting Kibana server with http2 (#257459)\n\n## Summary\n\ncloses https://github.com/elastic/appex-qa-team/issues/817\n\nThis PR extends Scout configs schema with `http2:boolean`, false by\ndefault. In order to run Kibana in http2 mode, I added custom config set\nwith overrides.\n\nThe stateful IDP metadata file `idp_metadata_mock_idp.xml` had hardcoded\n`http://localhost:5620/mock_idp/login` URLs. When Kibana runs with\nHTTPS, ES redirects the browser to the HTTP URL, which fails because\nKibana only accepts HTTPS. Updated to use relative URLs similar to\nserverless\n\n### How to test:\n\nstart servers:\n\n```bash\nnode scripts/scout start-server --arch stateful --domain classic --serverConfigSet http2\n```\n\nmanually load Kibana (note: use `https`):\n\n```\ngo to https://localhost:5620\n```\n\nrun any existing Scout tests:\n```\nnpx playwright test --project local --grep @local-stateful-classic --config x-pack/platform/plugins/private/discover_enhanced/test/scout/ui/parallel.playwright.config.ts\n```","sha":"77ef904c6bc1ab798fc4919a96e95e8673d2e3a7"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/264492","number":264492,"state":"MERGED","mergeCommit":{"sha":"5a4497368e9256266faf8a83167dff67cc13bc35","message":"[9.4] [scout] support starting Kibana server with http2 (#257459) (#264492)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.4`:\n- [[scout] support starting Kibana server with http2\n(#257459)](https://github.com/elastic/kibana/pull/257459)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Dzmitry Lemechko <dzmitry.lemechko@elastic.co>"}},{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/257459","number":257459,"mergeCommit":{"message":"[scout] support starting Kibana server with http2 (#257459)\n\n## Summary\n\ncloses https://github.com/elastic/appex-qa-team/issues/817\n\nThis PR extends Scout configs schema with `http2:boolean`, false by\ndefault. In order to run Kibana in http2 mode, I added custom config set\nwith overrides.\n\nThe stateful IDP metadata file `idp_metadata_mock_idp.xml` had hardcoded\n`http://localhost:5620/mock_idp/login` URLs. When Kibana runs with\nHTTPS, ES redirects the browser to the HTTP URL, which fails because\nKibana only accepts HTTPS. Updated to use relative URLs similar to\nserverless\n\n### How to test:\n\nstart servers:\n\n```bash\nnode scripts/scout start-server --arch stateful --domain classic --serverConfigSet http2\n```\n\nmanually load Kibana (note: use `https`):\n\n```\ngo to https://localhost:5620\n```\n\nrun any existing Scout tests:\n```\nnpx playwright test --project local --grep @local-stateful-classic --config x-pack/platform/plugins/private/discover_enhanced/test/scout/ui/parallel.playwright.config.ts\n```","sha":"77ef904c6bc1ab798fc4919a96e95e8673d2e3a7"}}]}] BACKPORT-->