### PR TITLE
Fix FTR spot instance zone targeting to reduce preemption retries !!

### DIFF
--- a/.buildkite/pipeline-utils/agent_images.ts
+++ b/.buildkite/pipeline-utils/agent_images.ts
@@ -85,7 +85,7 @@ const expandAgentQueue = (queueName: string = 'n2-4-spot', diskSizeGb?: number) 
   const zonesToUse = 'southamerica-east1-c,asia-south2-a,us-central1-f';
   const additionalProps =
     {
-      spot: { preemptible: true, zones: zonesToUse },
+      spot: { preemptible: true, spotZones: zonesToUse },
       virt: { enableNestedVirtualization: true, spotZones: zonesToUse },
     }[addition] || {};
 


### PR DESCRIPTION
## Summary

Fixes a configuration bug in `expandAgentQueue` where FTR spot instance jobs used `zones` instead of `spotZones`, causing the `gobld` autoscaler to ignore zone preferences and scatter jobs globally — leading to massive GCP preemption rates and wasted CI time.

### The Problem

The `expandAgentQueue` function in `.buildkite/pipeline-utils/agent_images.ts` sets agent targeting rules for dynamically-created FTR jobs. For spot (preemptible) instances, it was using:

```typescript
spot: { preemptible: true, zones: zonesToUse }
```

While **every other preemptible pipeline config** in the repo (50+ YAML files) correctly uses `spotZones`:

```yaml
agents:
  preemptible: true
  spotZones: us-central1-f,us-central1-c,us-central1-a
```

The `gobld` autoscaler treats `zones` and `spotZones` differently for preemptible VMs — `zones` is ignored, while `spotZones` is enforced.

### Impact (data from 4 recent PR builds)

| Metric | `spotZones` (base.yml jobs) | `zones` (FTR jobs) |
|---|---|---|
| Jobs in configured zones | **100%** (32/32) | **~16%** (141/896) |
| Jobs landing in europe-west2 | **0%** | **~22%** |

`europe-west2` is a preemption hotspot — it accounted for the majority of all observed GCP preemptions across builds analyzed:

- **Build 436042**: 3 preempted jobs → all 3 in `europe-west2` (100%)
- **Build 436053**: 3 preempted jobs → all 3 in `europe-west2` (100%)
- **98% of PR builds** experience retries (avg 10.7 jobs/build), with **92% caused by GCP preemptions** (not test failures)
- Average overhead: **~10 minutes per build**, but sometimes 30+ minutes

### The Fix

One-line change: `zones` → `spotZones` for the `spot` addition in `expandAgentQueue`, aligning with the pattern used by all other preemptible configs in the repo.

### Expected Outcome

FTR spot instances will be constrained to `southamerica-east1-c`, `asia-south2-a`, and `us-central1-f` — the zones already configured in the code — instead of scattering across 12+ global zones. This should significantly reduce preemption-related retries and shave ~10 minutes off most PR build times.

## Test plan

- [ ] CI passes on this PR (the fix applies to the pipeline that runs CI itself)
- [ ] Monitor a few subsequent PR builds to verify FTR jobs land in configured zones
- [ ] Verify preemption retry rate drops in the days following merge


Made with [Cursor](https://cursor.com)

<!--ONMERGE {"backportTargets":["8.19","9.2","9.3","9.4"]} ONMERGE-->