### PR TITLE
[8.19] [ILM] Perserve min_* rollover options when using recommended defaults (#264984)

### DIFF
--- a/x-pack/platform/packages/shared/index-lifecycle-management/index_lifecycle_management_common_shared/src/policies.ts
+++ b/x-pack/platform/packages/shared/index-lifecycle-management/index_lifecycle_management_common_shared/src/policies.ts
@@ -74,10 +74,21 @@ export interface RolloverAction {
   max_docs?: number;
   max_primary_shard_size?: string;
   max_primary_shard_docs?: number;
+
   /**
    * @deprecated This will be removed in versions 8+ of the stack
    */
   max_size?: string;
+
+  /**
+   * Currently we do not yet support configuring min_* values in the UI
+   * but they are accepted by the API.
+   */
+  min_age?: string;
+  min_docs?: number;
+  min_size?: string;
+  min_primary_shard_size?: string;
+  min_primary_shard_docs?: number;
 }
 
 export interface SerializedHotPhase extends SerializedPhase {

--- a/x-pack/platform/plugins/private/index_lifecycle_management/public/application/sections/edit_policy/form/deserializer_and_serializer.test.ts
+++ b/x-pack/platform/plugins/private/index_lifecycle_management/public/application/sections/edit_policy/form/deserializer_and_serializer.test.ts
@@ -288,6 +288,61 @@ describe('deserializer and serializer', () => {
     expect(result.phases.hot!.actions.rollover).toEqual(defaultRolloverAction);
   });
 
+  it('preserves rollover fields the UI does not manage when using default rollover', () => {
+    formInternal._meta.hot.isUsingDefaultRollover = true;
+    formInternal.phases.hot!.actions.rollover!.min_primary_shard_size = '5gb';
+    // @ts-expect-error - this is an unknown field that should be preserved by the serializer even when using default rollover
+    formInternal.phases.hot!.actions.rollover!.unknown_setting = 123;
+
+    const result = serializer(formInternal);
+    const rollover = result.phases.hot!.actions.rollover;
+
+    expect(rollover).toEqual(
+      expect.objectContaining({
+        ...defaultRolloverAction,
+        min_primary_shard_size: '5gb',
+        unknown_setting: 123,
+      })
+    );
+    expect(rollover!.max_docs).toBeUndefined();
+    expect(rollover!.max_primary_shard_docs).toBeUndefined();
+    expect(rollover!.max_size).toBeUndefined();
+  });
+
+  it('does not drop rollover min_* fields on save when using default rollover', () => {
+    const policyWithRolloverMinFields: SerializedPolicy = {
+      name: 'policyWithRolloverMinFields',
+      phases: {
+        hot: {
+          min_age: '0ms',
+          actions: {
+            rollover: {
+              max_age: '30d',
+              max_primary_shard_size: '50gb',
+              min_age: '1d',
+              min_docs: 100,
+              min_size: '10gb',
+              min_primary_shard_size: '5gb',
+              min_primary_shard_docs: 50,
+            },
+          },
+        },
+      },
+    };
+
+    const nextSerializer = createSerializer(cloneDeep(policyWithRolloverMinFields));
+    const nextFormInternal = deserializer(cloneDeep(policyWithRolloverMinFields));
+    const result = nextSerializer(nextFormInternal);
+
+    const rollover = result.phases.hot!.actions.rollover!;
+    expect(rollover.min_age).toBe('1d');
+    expect(rollover.min_docs).toBe(100);
+    expect(rollover.min_size).toBe('10gb');
+    expect(rollover.min_primary_shard_size).toBe('5gb');
+    expect(rollover.min_primary_shard_docs).toBe(50);
+    expect(rollover).toEqual(expect.objectContaining(defaultRolloverAction));
+  });
+
   it('removes snapshot_repository when it is unset', () => {
     delete formInternal.phases.hot!.actions.searchable_snapshot;
     delete formInternal.phases.cold!.actions.searchable_snapshot;

--- a/x-pack/platform/plugins/private/index_lifecycle_management/public/application/sections/edit_policy/form/serializer/serializer.ts
+++ b/x-pack/platform/plugins/private/index_lifecycle_management/public/application/sections/edit_policy/form/serializer/serializer.ts
@@ -15,6 +15,7 @@ import { defaultPolicy, defaultRolloverAction } from '../../../../constants';
 import { FormInternal } from '../../types';
 
 import { serializeMigrateAndAllocateActions } from './serialize_migrate_and_allocate_actions';
+import { excludeControlledRolloverThresholds } from './utils';
 
 export const createSerializer =
   (originalPolicy?: SerializedPolicy) =>
@@ -52,7 +53,13 @@ export const createSerializer =
            */
           if (isUsingRollover) {
             if (_meta.hot?.isUsingDefaultRollover) {
+              const existingRollover = hotPhaseActions.rollover;
+              const preservedRolloverFields = excludeControlledRolloverThresholds(
+                existingRollover ?? {}
+              );
+
               hotPhaseActions.rollover = cloneDeep(defaultRolloverAction);
+              Object.assign(hotPhaseActions.rollover, preservedRolloverFields);
             } else {
               // Rollover may not exist if editing an existing policy with initially no rollover configured
               if (!hotPhaseActions.rollover) {

--- a/x-pack/platform/plugins/private/index_lifecycle_management/public/application/sections/edit_policy/form/serializer/utils.test.ts
+++ b/x-pack/platform/plugins/private/index_lifecycle_management/public/application/sections/edit_policy/form/serializer/utils.test.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { excludeControlledRolloverThresholds } from './utils';
+
+describe('excludeControlledRolloverThresholds', () => {
+  it('removes all UI-controlled max_* thresholds', () => {
+    const result = excludeControlledRolloverThresholds({
+      max_age: '30d',
+      max_docs: 1000,
+      max_primary_shard_size: '50gb',
+      max_primary_shard_docs: 500,
+      max_size: '100gb',
+    });
+
+    expect(result).toEqual({});
+  });
+
+  it('preserves min_* fields', () => {
+    const result = excludeControlledRolloverThresholds({
+      max_age: '30d',
+      min_age: '1d',
+      min_docs: 100,
+      min_size: '10gb',
+      min_primary_shard_size: '5gb',
+      min_primary_shard_docs: 50,
+    });
+
+    expect(result).toEqual({
+      min_age: '1d',
+      min_docs: 100,
+      min_size: '10gb',
+      min_primary_shard_size: '5gb',
+      min_primary_shard_docs: 50,
+    });
+  });
+
+  it('preserves unknown fields not managed by the UI', () => {
+    const result = excludeControlledRolloverThresholds({
+      max_age: '30d',
+      // @ts-expect-error - unknown field that should still be preserved
+      unknown_setting: 123,
+    });
+
+    expect(result).toEqual({ unknown_setting: 123 });
+  });
+
+  it('returns an empty object for an empty input', () => {
+    expect(excludeControlledRolloverThresholds({})).toEqual({});
+  });
+});

--- a/x-pack/platform/plugins/private/index_lifecycle_management/public/application/sections/edit_policy/form/serializer/utils.ts
+++ b/x-pack/platform/plugins/private/index_lifecycle_management/public/application/sections/edit_policy/form/serializer/utils.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { RolloverAction } from '@kbn/index-lifecycle-management-common-shared';
+
+const CONTROLLED_ROLLOVER_THRESHOLDS: ReadonlyArray<string> = [
+  'max_age',
+  'max_docs',
+  'max_primary_shard_size',
+  'max_primary_shard_docs',
+  'max_size',
+] satisfies Array<keyof RolloverAction>;
+
+/**
+ * When switching to recommended defaults, we intentionally reset the rollover
+ * thresholds controlled by the UI, but preserve any additional keys that the
+ * UI does not manage (e.g. min_* settings).
+ */
+export const excludeControlledRolloverThresholds = (rolloverAction: RolloverAction) =>
+  Object.entries(rolloverAction).reduce<Record<string, unknown>>((acc, [key, value]) => {
+    if (CONTROLLED_ROLLOVER_THRESHOLDS.includes(key)) {
+      return acc;
+    }
+    acc[key] = value;
+    return acc;
+  }, {});


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[ILM] Perserve min_* rollover options when using recommended defaults (#264984)](https://github.com/elastic/kibana/pull/264984)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Damian Polewski","email":"125268832+damian-polewski@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-04-28T15:07:20Z","message":"[ILM] Perserve min_* rollover options when using recommended defaults (#264984)\n\nCloses #252637\n\n## Summary\n\nThis PR:\n\n- Fixed ILM edit policy serialization to preserve rollover fields not\nmanaged by the UI (e.g. `min_*`) when “recommended defaults” is enabled,\n- Updated default-rollover behavior to reset only UI-managed `max_*`\nrollover thresholds while keeping other existing rollover keys.\n- Added serializer/deserializer unit tests to cover preserving `min_*`\nrollover fields on save with default rollover enabled.","sha":"1c1d7501448964b8a9a38b531efd3efe9094936b","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:ILM","Team:Kibana Management","release_note:skip","backport:all-open","v9.4.0","v9.5.0","v9.3.4","v9.2.9"],"title":"[ILM] Perserve min_* rollover options when using recommended defaults","number":264984,"url":"https://github.com/elastic/kibana/pull/264984","mergeCommit":{"message":"[ILM] Perserve min_* rollover options when using recommended defaults (#264984)\n\nCloses #252637\n\n## Summary\n\nThis PR:\n\n- Fixed ILM edit policy serialization to preserve rollover fields not\nmanaged by the UI (e.g. `min_*`) when “recommended defaults” is enabled,\n- Updated default-rollover behavior to reset only UI-managed `max_*`\nrollover thresholds while keeping other existing rollover keys.\n- Added serializer/deserializer unit tests to cover preserving `min_*`\nrollover fields on save with default rollover enabled.","sha":"1c1d7501448964b8a9a38b531efd3efe9094936b"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/266144","number":266144,"state":"MERGED","mergeCommit":{"sha":"2fefe21587c067a8827607ed22e21f92509c3204","message":"[9.4] [ILM] Perserve min_* rollover options when using recommended defaults (#264984) (#266144)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.4`:\n- [[ILM] Perserve min_* rollover options when using recommended defaults\n(#264984)](https://github.com/elastic/kibana/pull/264984)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Damian Polewski <125268832+damian-polewski@users.noreply.github.com>"}},{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/264984","number":264984,"mergeCommit":{"message":"[ILM] Perserve min_* rollover options when using recommended defaults (#264984)\n\nCloses #252637\n\n## Summary\n\nThis PR:\n\n- Fixed ILM edit policy serialization to preserve rollover fields not\nmanaged by the UI (e.g. `min_*`) when “recommended defaults” is enabled,\n- Updated default-rollover behavior to reset only UI-managed `max_*`\nrollover thresholds while keeping other existing rollover keys.\n- Added serializer/deserializer unit tests to cover preserving `min_*`\nrollover fields on save with default rollover enabled.","sha":"1c1d7501448964b8a9a38b531efd3efe9094936b"}},{"branch":"9.3","label":"v9.3.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/266142","number":266142,"state":"MERGED","mergeCommit":{"sha":"bfe7e03be64635290f52f6e64ad46a23a29bb48d","message":"[9.3] [ILM] Perserve min_* rollover options when using recommended defaults (#264984) (#266142)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.3`:\n- [[ILM] Perserve min_* rollover options when using recommended defaults\n(#264984)](https://github.com/elastic/kibana/pull/264984)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Damian Polewski <125268832+damian-polewski@users.noreply.github.com>"}},{"branch":"9.2","label":"v9.2.9","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/266141","number":266141,"state":"MERGED","mergeCommit":{"sha":"ff5cfadfe468854c4ce281841738322bce5800e2","message":"[9.2] [ILM] Perserve min_* rollover options when using recommended defaults (#264984) (#266141)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.2`:\n- [[ILM] Perserve min_* rollover options when using recommended defaults\n(#264984)](https://github.com/elastic/kibana/pull/264984)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Damian Polewski <125268832+damian-polewski@users.noreply.github.com>"}}]}] BACKPORT-->