### PR TITLE
chore: lazy-load server plugin modules (appex-sharedux)

### DIFF
--- a/src/platform/plugins/shared/navigation/server/index.ts
+++ b/src/platform/plugins/shared/navigation/server/index.ts
@@ -9,8 +9,7 @@
 
 import type { PluginInitializerContext } from '@kbn/core/server';
 
-import { NavigationServerPlugin } from './plugin';
-
 export async function plugin(initContext: PluginInitializerContext) {
+  const { NavigationServerPlugin } = await import('./plugin');
   return new NavigationServerPlugin(initContext);
 }

--- a/x-pack/platform/plugins/private/feedback/server/index.ts
+++ b/x-pack/platform/plugins/private/feedback/server/index.ts
@@ -5,8 +5,7 @@
  * 2.0.
  */
 
-import { FeedbackPlugin } from './plugin';
-
-export function plugin() {
+export async function plugin() {
+  const { FeedbackPlugin } = await import('./plugin');
   return new FeedbackPlugin();
 }


### PR DESCRIPTION
## Summary

Lazy-load server plugin implementations via `await import('./plugin')` (and related entrypoint adjustments) from `server/index.ts`, consistent with https://github.com/elastic/kibana/pull/170856.

The migration in #170856 reduced **startup time by ~4 seconds** in measured scenarios. **Memory savings were not quantified but are expected.**

## CODEOWNERS

- `src/platform/plugins/shared/navigation` → @elastic/appex-sharedux
- `x-pack/platform/plugins/private/feedback` → @elastic/appex-sharedux

## Follow-up

- https://github.com/elastic/kibana/issues/171080 — add an ESLint rule so new plugins follow this pattern.

---

**Disclaimer:** This PR was prepared with AI assistance (Cursor / Claude); please review thoroughly.


<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->