### PR TITLE
chore: lazy-load server plugin modules (kibana-management)

### DIFF
--- a/x-pack/platform/plugins/private/data_usage/server/index.ts
+++ b/x-pack/platform/plugins/private/data_usage/server/index.ts
@@ -11,7 +11,6 @@ import type {
 } from '@kbn/core/server';
 import type { DataUsageConfigType } from './config';
 
-import { DataUsagePlugin } from './plugin';
 import type {
   DataUsageServerSetup,
   DataUsageServerStart,
@@ -35,5 +34,7 @@ export const plugin: PluginInitializer<
   DataUsageServerStart,
   DataUsageSetupDependencies,
   DataUsageStartDependencies
-> = async (pluginInitializerContext: PluginInitializerContext<DataUsageConfigType>) =>
-  await new DataUsagePlugin(pluginInitializerContext);
+> = async (pluginInitializerContext: PluginInitializerContext<DataUsageConfigType>) => {
+  const { DataUsagePlugin } = await import('./plugin');
+  return new DataUsagePlugin(pluginInitializerContext);
+};

--- a/x-pack/platform/plugins/private/grokdebugger/server/config.ts
+++ b/x-pack/platform/plugins/private/grokdebugger/server/config.ts
@@ -5,11 +5,12 @@
  * 2.0.
  */
 
-import { config } from './config';
+import { offeringBasedSchema, schema } from '@kbn/config-schema';
 
-export async function plugin() {
-  const { Plugin } = await import('./plugin');
-  return new Plugin();
-}
-
-export { config };
+export const config = {
+  schema: schema.object({
+    enabled: offeringBasedSchema({
+      serverless: schema.boolean({ defaultValue: true }),
+    }),
+  }),
+};

--- a/x-pack/platform/plugins/private/grokdebugger/server/plugin.ts
+++ b/x-pack/platform/plugins/private/grokdebugger/server/plugin.ts
@@ -5,20 +5,11 @@
  * 2.0.
  */
 
-import { offeringBasedSchema, schema } from '@kbn/config-schema';
 import type { CoreSetup, Plugin as KibanaPlugin } from '@kbn/core/server';
 import type { LicensingPluginSetup } from '@kbn/licensing-plugin/server';
 import type { ILicense } from '@kbn/licensing-types';
 import { KibanaFramework } from './lib/kibana_framework';
 import { registerGrokdebuggerRoutes } from './routes/api/grokdebugger';
-
-export const config = {
-  schema: schema.object({
-    enabled: offeringBasedSchema({
-      serverless: schema.boolean({ defaultValue: true }),
-    }),
-  }),
-};
 
 interface GrokdebuggerServerPluginDependencies {
   licensing: LicensingPluginSetup;

--- a/x-pack/platform/plugins/private/reindex_service/server/index.ts
+++ b/x-pack/platform/plugins/private/reindex_service/server/index.ts
@@ -7,13 +7,12 @@
 
 import type { PluginInitializerContext } from '@kbn/core/server';
 
-import { ReindexServiceServerPlugin } from './plugin';
-
 export type { ReindexServiceServerPluginStart } from './types';
 export { REINDEX_SERVICE_BASE_PATH } from '../common';
 
 export { config } from './config';
 
 export const plugin = async (ctx: PluginInitializerContext) => {
+  const { ReindexServiceServerPlugin } = await import('./plugin');
   return new ReindexServiceServerPlugin(ctx);
 };

--- a/x-pack/platform/plugins/shared/cloud_connect/server/index.ts
+++ b/x-pack/platform/plugins/shared/cloud_connect/server/index.ts
@@ -6,12 +6,12 @@
  */
 
 import type { PluginInitializerContext } from '@kbn/core/server';
-import { CloudConnectedPlugin } from './plugin';
 
 export { config } from './config';
 export type { CloudConnectConfig } from './config';
 
-export function plugin(initializerContext: PluginInitializerContext) {
+export async function plugin(initializerContext: PluginInitializerContext) {
+  const { CloudConnectedPlugin } = await import('./plugin');
   return new CloudConnectedPlugin(initializerContext);
 }
 

--- a/x-pack/platform/plugins/shared/query_activity/server/index.ts
+++ b/x-pack/platform/plugins/shared/query_activity/server/index.ts
@@ -6,9 +6,9 @@
  */
 
 import type { PluginInitializerContext } from '@kbn/core/server';
-import { QueryActivityPlugin } from './plugin';
 
-export function plugin(initializerContext: PluginInitializerContext) {
+export async function plugin(initializerContext: PluginInitializerContext) {
+  const { QueryActivityPlugin } = await import('./plugin');
   return new QueryActivityPlugin(initializerContext);
 }
 


### PR DESCRIPTION
## Summary

Lazy-load server plugin implementations via `await import('./plugin')` (and related entrypoint adjustments) from `server/index.ts`, consistent with https://github.com/elastic/kibana/pull/170856.

The migration in #170856 reduced **startup time by ~4 seconds** in measured scenarios. **Memory savings were not quantified but are expected.**

## CODEOWNERS

- `data_usage`, `grokdebugger`, `reindex_service`, `cloud_connect`, `query_activity` → @elastic/kibana-management

## Follow-up

- https://github.com/elastic/kibana/issues/171080 — add an ESLint rule so new plugins follow this pattern.

---

**Disclaimer:** This PR was prepared with AI assistance (Cursor / Claude); please review thoroughly.


<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->