### PR TITLE
chore: lazy-load server plugin modules (appex-ai-infra)

### DIFF
--- a/x-pack/platform/plugins/private/gen_ai_settings/server/index.ts
+++ b/x-pack/platform/plugins/private/gen_ai_settings/server/index.ts
@@ -6,10 +6,10 @@
  */
 
 import type { PluginInitializerContext } from '@kbn/core/server';
-import { GenAiSettingsPlugin } from './plugin';
 import { config } from '../common/config';
 
-export function plugin(initializerContext: PluginInitializerContext) {
+export async function plugin(initializerContext: PluginInitializerContext) {
+  const { GenAiSettingsPlugin } = await import('./plugin');
   return new GenAiSettingsPlugin(initializerContext);
 }
 

--- a/x-pack/platform/plugins/shared/ai_infra/llm_tasks/server/index.ts
+++ b/x-pack/platform/plugins/shared/ai_infra/llm_tasks/server/index.ts
@@ -13,7 +13,6 @@ import type {
   PluginSetupDependencies,
   PluginStartDependencies,
 } from './types';
-import { LlmTasksPlugin } from './plugin';
 
 export { config } from './config';
 
@@ -30,5 +29,7 @@ export const plugin: PluginInitializer<
   LlmTasksPluginStart,
   PluginSetupDependencies,
   PluginStartDependencies
-> = async (pluginInitializerContext: PluginInitializerContext<LlmTasksConfig>) =>
-  new LlmTasksPlugin(pluginInitializerContext);
+> = async (pluginInitializerContext: PluginInitializerContext<LlmTasksConfig>) => {
+  const { LlmTasksPlugin } = await import('./plugin');
+  return new LlmTasksPlugin(pluginInitializerContext);
+};

--- a/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/index.ts
+++ b/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/index.ts
@@ -13,7 +13,6 @@ import type {
   ProductDocBaseSetupDependencies,
   ProductDocBaseStartDependencies,
 } from './types';
-import { ProductDocBasePlugin } from './plugin';
 
 export { config } from './config';
 
@@ -31,5 +30,6 @@ export const plugin: PluginInitializer<
   ProductDocBaseSetupDependencies,
   ProductDocBaseStartDependencies
 > = async (pluginInitializerContext: PluginInitializerContext<ProductDocBaseConfig>) => {
+  const { ProductDocBasePlugin } = await import('./plugin');
   return new ProductDocBasePlugin(pluginInitializerContext);
 };

--- a/x-pack/platform/plugins/shared/dashboard_agent/server/index.ts
+++ b/x-pack/platform/plugins/shared/dashboard_agent/server/index.ts
@@ -6,8 +6,10 @@
  */
 
 import type { PluginInitializerContext } from '@kbn/core/server';
-import { DashboardAgentPlugin } from './plugin';
 
-export const plugin = (context: PluginInitializerContext) => new DashboardAgentPlugin(context);
+export const plugin = async (context: PluginInitializerContext) => {
+  const { DashboardAgentPlugin } = await import('./plugin');
+  return new DashboardAgentPlugin(context);
+};
 
 export type { DashboardAgentPluginSetup, DashboardAgentPluginStart } from './types';


### PR DESCRIPTION
## Summary

Lazy-load server plugin implementations via `await import('./plugin')` (and related entrypoint adjustments) from `server/index.ts`, consistent with https://github.com/elastic/kibana/pull/170856.

The migration in #170856 reduced **startup time by ~4 seconds** in measured scenarios. **Memory savings were not quantified but are expected.**

## CODEOWNERS

- `gen_ai_settings`, `llm_tasks`, `product_doc_base`, `dashboard_agent` → @elastic/appex-ai-infra

## Follow-up

- https://github.com/elastic/kibana/issues/171080 — add an ESLint rule so new plugins follow this pattern.

---

**Disclaimer:** This PR was prepared with AI assistance (Cursor / Claude); please review thoroughly.


<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->