### PR TITLE
chore: lazy-load server plugin modules (search-kibana)

### DIFF
--- a/x-pack/platform/plugins/shared/content_connectors/server/index.ts
+++ b/x-pack/platform/plugins/shared/content_connectors/server/index.ts
@@ -7,13 +7,13 @@
 
 import type { PluginInitializerContext } from '@kbn/core/server';
 
-import { SearchConnectorsPlugin } from './plugin';
 export { config } from './config';
 
 //  This exports static code and TypeScript types,
 //  as well as, Kibana Platform `plugin()` initializer.
 
-export function plugin(initializerContext: PluginInitializerContext) {
+export async function plugin(initializerContext: PluginInitializerContext) {
+  const { SearchConnectorsPlugin } = await import('./plugin');
   return new SearchConnectorsPlugin(initializerContext);
 }
 

--- a/x-pack/platform/plugins/shared/inference/server/index.ts
+++ b/x-pack/platform/plugins/shared/inference/server/index.ts
@@ -18,7 +18,6 @@ import type {
   InferenceSetupDependencies,
   InferenceStartDependencies,
 } from './types';
-import { InferencePlugin } from './plugin';
 
 export type { InferenceServerSetup, InferenceServerStart };
 export type { InferenceEndpoint } from './util/get_inference_endpoints';
@@ -34,8 +33,10 @@ export const plugin: PluginInitializer<
   InferenceServerStart,
   InferenceSetupDependencies,
   InferenceStartDependencies
-> = async (pluginInitializerContext: PluginInitializerContext<InferenceConfig>) =>
-  new InferencePlugin(pluginInitializerContext);
+> = async (pluginInitializerContext: PluginInitializerContext<InferenceConfig>) => {
+  const { InferencePlugin } = await import('./plugin');
+  return new InferencePlugin(pluginInitializerContext);
+};
 
 export const config: PluginConfigDescriptor<InferenceConfig> = {
   schema: configSchema,

--- a/x-pack/solutions/search/plugins/search_assistant/server/index.ts
+++ b/x-pack/solutions/search/plugins/search_assistant/server/index.ts
@@ -5,11 +5,12 @@
  * 2.0.
  */
 import type { PluginInitializerContext } from '@kbn/core/server';
-import { SearchAssistantPlugin } from './plugin';
 
 export { config } from './config';
 
-export const plugin = (initializerContext: PluginInitializerContext) =>
-  new SearchAssistantPlugin(initializerContext);
+export const plugin = async (initializerContext: PluginInitializerContext) => {
+  const { SearchAssistantPlugin } = await import('./plugin');
+  return new SearchAssistantPlugin(initializerContext);
+};
 
 export type { SearchAssistantPluginSetup, SearchAssistantPluginStart } from './types';

--- a/x-pack/solutions/search/plugins/serverless_search/server/index.ts
+++ b/x-pack/solutions/search/plugins/serverless_search/server/index.ts
@@ -7,13 +7,13 @@
 
 import type { PluginInitializerContext } from '@kbn/core/server';
 
-import { ServerlessSearchPlugin } from './plugin';
 export { config } from './config';
 
 //  This exports static code and TypeScript types,
 //  as well as, Kibana Platform `plugin()` initializer.
 
-export function plugin(initializerContext: PluginInitializerContext) {
+export async function plugin(initializerContext: PluginInitializerContext) {
+  const { ServerlessSearchPlugin } = await import('./plugin');
   return new ServerlessSearchPlugin(initializerContext);
 }
 

--- a/x-pack/solutions/workplaceai/plugins/workplace_ai_app/server/index.ts
+++ b/x-pack/solutions/workplaceai/plugins/workplace_ai_app/server/index.ts
@@ -6,11 +6,11 @@
  */
 
 import type { PluginInitializerContext } from '@kbn/core/server';
-import { WorkplaceAIAppPlugin } from './plugin';
 
 export { config } from './config';
 
-export const plugin = (initializerContext: PluginInitializerContext) => {
+export const plugin = async (initializerContext: PluginInitializerContext) => {
+  const { WorkplaceAIAppPlugin } = await import('./plugin');
   return new WorkplaceAIAppPlugin(initializerContext);
 };
 


### PR DESCRIPTION
## Summary

Lazy-load server plugin implementations via `await import('./plugin')` (and related entrypoint adjustments) from `server/index.ts`, consistent with https://github.com/elastic/kibana/pull/170856.

The migration in #170856 reduced **startup time by ~4 seconds** in measured scenarios. **Memory savings were not quantified but are expected.**

## CODEOWNERS

- `content_connectors`, `inference`, `search_assistant`, `serverless_search` → @elastic/search-kibana
- `workplace_ai_app` → @elastic/search-kibana @elastic/workchat-eng

## Follow-up

- https://github.com/elastic/kibana/issues/171080 — add an ESLint rule so new plugins follow this pattern.

---

**Disclaimer:** This PR was prepared with AI assistance (Cursor / Claude); please review thoroughly.


<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->