### PR TITLE
chore: lazy-load server plugin modules (obs-elastic-brain-team)

### DIFF
--- a/x-pack/platform/plugins/shared/elastic_console/server/index.ts
+++ b/x-pack/platform/plugins/shared/elastic_console/server/index.ts
@@ -9,7 +9,6 @@ import type { FeatureFlagDefinitions } from '@kbn/core-feature-flags-server';
 import type { PluginConfigDescriptor, PluginInitializerContext } from '@kbn/core/server';
 import type { ElasticConsoleConfig } from './config';
 import { configSchema } from './config';
-import { ElasticConsolePlugin } from './plugin';
 import { ELASTIC_CONSOLE_ENABLED_FLAG } from '../common/feature_flags';
 
 export const featureFlags: FeatureFlagDefinitions = [
@@ -26,8 +25,10 @@ export const featureFlags: FeatureFlagDefinitions = [
   },
 ];
 
-export const plugin = async (pluginInitializerContext: PluginInitializerContext) =>
-  new ElasticConsolePlugin(pluginInitializerContext);
+export const plugin = async (pluginInitializerContext: PluginInitializerContext) => {
+  const { ElasticConsolePlugin } = await import('./plugin');
+  return new ElasticConsolePlugin(pluginInitializerContext);
+};
 
 export const config: PluginConfigDescriptor<ElasticConsoleConfig> = {
   schema: configSchema,


### PR DESCRIPTION
## Summary

Lazy-load server plugin implementations via `await import('./plugin')` (and related entrypoint adjustments) from `server/index.ts`, consistent with https://github.com/elastic/kibana/pull/170856.

The migration in #170856 reduced **startup time by ~4 seconds** in measured scenarios. **Memory savings were not quantified but are expected.**

## CODEOWNERS

- `elastic_console` → @elastic/obs-elastic-brain-team

## Follow-up

- https://github.com/elastic/kibana/issues/171080 — add an ESLint rule so new plugins follow this pattern.

---

**Disclaimer:** This PR was prepared with AI assistance (Cursor / Claude); please review thoroughly.


<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->