### PR TITLE
chore: lazy-load server plugin modules (core-analysis)

### DIFF
--- a/x-pack/platform/plugins/shared/entity_manager/server/config.ts
+++ b/x-pack/platform/plugins/shared/entity_manager/server/config.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { PluginConfigDescriptor } from '@kbn/core/server';
+import type { EntityManagerConfig } from '../common/config';
+import { configSchema, exposeToBrowserConfig } from '../common/config';
+
+export const config: PluginConfigDescriptor<EntityManagerConfig> = {
+  schema: configSchema,
+  exposeToBrowser: exposeToBrowserConfig,
+};

--- a/x-pack/platform/plugins/shared/entity_manager/server/index.ts
+++ b/x-pack/platform/plugins/shared/entity_manager/server/index.ts
@@ -8,8 +8,8 @@
 import type { PluginInitializerContext } from '@kbn/core-plugins-server';
 import type { EntityManagerConfig } from '../common/config';
 import type { EntityManagerServerPluginSetup, EntityManagerServerPluginStart } from './plugin';
-import { config } from './plugin';
 import type { EntityManagerRouteRepository } from './routes';
+import { config } from './config';
 
 export type {
   EntityManagerConfig,

--- a/x-pack/platform/plugins/shared/entity_manager/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/entity_manager/server/plugin.ts
@@ -12,12 +12,10 @@ import type {
   KibanaRequest,
   Logger,
   Plugin,
-  PluginConfigDescriptor,
   PluginInitializerContext,
 } from '@kbn/core/server';
 import { registerRoutes } from '@kbn/server-route-repository';
 import type { EntityManagerConfig } from '../common/config';
-import { configSchema, exposeToBrowserConfig } from '../common/config';
 import { EntityClient } from './lib/entity_client';
 import { entityManagerRouteRepository } from './routes';
 import type { EntityManagerRouteDependencies } from './routes/types';
@@ -36,11 +34,6 @@ export interface EntityManagerServerPluginSetup {}
 export interface EntityManagerServerPluginStart {
   getScopedClient: (options: { request: KibanaRequest }) => Promise<EntityClient>;
 }
-
-export const config: PluginConfigDescriptor<EntityManagerConfig> = {
-  schema: configSchema,
-  exposeToBrowser: exposeToBrowserConfig,
-};
 
 export class EntityManagerServerPlugin
   implements


### PR DESCRIPTION
## Summary

Lazy-load server plugin implementations via `await import('./plugin')` (and related entrypoint adjustments) from `server/index.ts`, consistent with https://github.com/elastic/kibana/pull/170856.

The migration in #170856 reduced **startup time by ~4 seconds** in measured scenarios. **Memory savings were not quantified but are expected.**

## CODEOWNERS

- `entity_manager` → @elastic/core-analysis

## Follow-up

- https://github.com/elastic/kibana/issues/171080 — add an ESLint rule so new plugins follow this pattern.

---

**Disclaimer:** This PR was prepared with AI assistance (Cursor / Claude); please review thoroughly.


<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->