### PR TITLE
chore: lazy-load server plugin modules (evals)

### DIFF
--- a/x-pack/platform/plugins/shared/evals/server/index.ts
+++ b/x-pack/platform/plugins/shared/evals/server/index.ts
@@ -13,7 +13,6 @@ import type {
   EvalsSetupDependencies,
   EvalsStartDependencies,
 } from './types';
-import { EvalsPlugin } from './plugin';
 
 export type { EvalsPluginSetup, EvalsPluginStart };
 
@@ -22,7 +21,9 @@ export const plugin: PluginInitializer<
   EvalsPluginStart,
   EvalsSetupDependencies,
   EvalsStartDependencies
-> = async (pluginInitializerContext: PluginInitializerContext<EvalsConfig>) =>
-  new EvalsPlugin(pluginInitializerContext);
+> = async (pluginInitializerContext: PluginInitializerContext<EvalsConfig>) => {
+  const { EvalsPlugin } = await import('./plugin');
+  return new EvalsPlugin(pluginInitializerContext);
+};
 
 export { config } from './config';


### PR DESCRIPTION
## Summary

Lazy-load server plugin implementations via `await import('./plugin')` (and related entrypoint adjustments) from `server/index.ts`, consistent with https://github.com/elastic/kibana/pull/170856.

The migration in #170856 reduced **startup time by ~4 seconds** in measured scenarios. **Memory savings were not quantified but are expected.**

## CODEOWNERS

- `evals` → @elastic/obs-ai-team @elastic/security-generative-ai

## Follow-up

- https://github.com/elastic/kibana/issues/171080 — add an ESLint rule so new plugins follow this pattern.

---

**Disclaimer:** This PR was prepared with AI assistance (Cursor / Claude); please review thoroughly.


<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->