### PR TITLE
chore: lazy-load server plugin modules (streams)

### DIFF
--- a/x-pack/platform/plugins/shared/streams/server/config.ts
+++ b/x-pack/platform/plugins/shared/streams/server/config.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { PluginConfigDescriptor } from '@kbn/core/server';
+import type { StreamsConfig } from '../common/config';
+import { configSchema, exposeToBrowserConfig } from '../common/config';
+
+export const config: PluginConfigDescriptor<StreamsConfig> = {
+  schema: configSchema,
+  exposeToBrowser: exposeToBrowserConfig,
+};

--- a/x-pack/platform/plugins/shared/streams/server/index.ts
+++ b/x-pack/platform/plugins/shared/streams/server/index.ts
@@ -8,8 +8,8 @@
 import type { PluginInitializerContext } from '@kbn/core-plugins-server';
 import type { StreamsConfig } from '../common/config';
 import type { StreamsPluginSetup, StreamsPluginStart } from './plugin';
-import { config } from './plugin';
 import type { StreamsRouteRepository } from './routes';
+import { config } from './config';
 
 export type { StreamsConfig, StreamsPluginSetup, StreamsPluginStart, StreamsRouteRepository };
 export { config };

--- a/x-pack/platform/plugins/shared/streams/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/streams/server/plugin.ts
@@ -11,7 +11,6 @@ import type {
   KibanaRequest,
   Logger,
   Plugin,
-  PluginConfigDescriptor,
   PluginInitializerContext,
 } from '@kbn/core/server';
 import { DEFAULT_APP_CATEGORIES } from '@kbn/core/server';
@@ -27,7 +26,6 @@ import type { RulesClient } from '@kbn/alerting-plugin/server';
 import { LOGS_ECS_STREAM_NAME, ROOT_STREAM_NAMES, Streams } from '@kbn/streams-schema';
 import { isNotFoundError } from '@kbn/es-errors';
 import type { StreamsConfig } from '../common/config';
-import { configSchema, exposeToBrowserConfig } from '../common/config';
 import {
   STREAMS_API_PRIVILEGES,
   STREAMS_CONSUMER,
@@ -80,11 +78,6 @@ import {
 export interface StreamsPluginSetup {}
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface StreamsPluginStart {}
-
-export const config: PluginConfigDescriptor<StreamsConfig> = {
-  schema: configSchema,
-  exposeToBrowser: exposeToBrowserConfig,
-};
 
 export class StreamsPlugin
   implements

--- a/x-pack/platform/plugins/shared/streams_app/server/index.ts
+++ b/x-pack/platform/plugins/shared/streams_app/server/index.ts
@@ -10,7 +10,6 @@ import type {
   PluginInitializerContext,
 } from '@kbn/core/server';
 import type { StreamsAppConfig } from './config';
-import { StreamsAppPlugin } from './plugin';
 import type {
   StreamsAppServerSetup,
   StreamsAppServerStart,
@@ -31,5 +30,7 @@ export const plugin: PluginInitializer<
   StreamsAppServerStart,
   StreamsAppSetupDependencies,
   StreamsAppStartDependencies
-> = async (pluginInitializerContext: PluginInitializerContext<StreamsAppConfig>) =>
-  new StreamsAppPlugin(pluginInitializerContext);
+> = async (pluginInitializerContext: PluginInitializerContext<StreamsAppConfig>) => {
+  const { StreamsAppPlugin } = await import('./plugin');
+  return new StreamsAppPlugin(pluginInitializerContext);
+};


### PR DESCRIPTION
## Summary

Lazy-load server plugin implementations via `await import('./plugin')` (and related entrypoint adjustments) from `server/index.ts`, consistent with https://github.com/elastic/kibana/pull/170856.

The migration in #170856 reduced **startup time by ~4 seconds** in measured scenarios. **Memory savings were not quantified but are expected.**

## CODEOWNERS

- `streams`, `streams_app` → @elastic/obs-onboarding-team @elastic/obs-sig-events-team

## Follow-up

- https://github.com/elastic/kibana/issues/171080 — add an ESLint rule so new plugins follow this pattern.

---

**Disclaimer:** This PR was prepared with AI assistance (Cursor / Claude); please review thoroughly.


<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->