### PR TITLE
chore: lazy-load server plugin modules (apm)

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/server/index.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/index.ts
@@ -129,7 +129,6 @@ export const plugin = async (initContext: PluginInitializerContext) => {
 };
 
 export { APM_SERVER_FEATURE_ID } from '../common/rules/apm_rule_types';
-export { APMPlugin } from './plugin';
 export type { APMPluginSetup } from './types';
 export type {
   APMServerRouteRepository,


### PR DESCRIPTION
## Summary

Lazy-load server plugin implementations via `await import('./plugin')` (and related entrypoint adjustments) from `server/index.ts`, consistent with https://github.com/elastic/kibana/pull/170856.

The migration in #170856 reduced **startup time by ~4 seconds** in measured scenarios. **Memory savings were not quantified but are expected.**

## CODEOWNERS

- `apm` → @elastic/obs-presentation-team

## Follow-up

- https://github.com/elastic/kibana/issues/171080 — add an ESLint rule so new plugins follow this pattern.

---

**Disclaimer:** This PR was prepared with AI assistance (Cursor / Claude); please review thoroughly.


<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->