### PR TITLE
chore: lazy-load server plugin modules (observability_agent_builder)

### DIFF
--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/index.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/index.ts
@@ -7,8 +7,6 @@
 
 import type { PluginInitializerContext } from '@kbn/core/server';
 
-import { ObservabilityAgentBuilderPlugin } from './plugin';
-
 export type {
   ObservabilityAgentBuilderPluginSetup,
   ObservabilityAgentBuilderPluginStart,
@@ -18,5 +16,7 @@ export type {
 
 export type { ObservabilityAgentBuilderServerRouteRepository } from './routes/get_global_observability_agent_builder_route_repository';
 
-export const plugin = (initializerContext: PluginInitializerContext) =>
-  new ObservabilityAgentBuilderPlugin(initializerContext);
+export const plugin = async (initializerContext: PluginInitializerContext) => {
+  const { ObservabilityAgentBuilderPlugin } = await import('./plugin');
+  return new ObservabilityAgentBuilderPlugin(initializerContext);
+};


### PR DESCRIPTION
## Summary

Lazy-load server plugin implementations via `await import('./plugin')` (and related entrypoint adjustments) from `server/index.ts`, consistent with https://github.com/elastic/kibana/pull/170856.

The migration in #170856 reduced **startup time by ~4 seconds** in measured scenarios. **Memory savings were not quantified but are expected.**

## CODEOWNERS

- `observability_agent_builder` → @elastic/obs-ai-team

## Follow-up

- https://github.com/elastic/kibana/issues/171080 — add an ESLint rule so new plugins follow this pattern.

---

**Disclaimer:** This PR was prepared with AI assistance (Cursor / Claude); please review thoroughly.


<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->