### PR TITLE
[Chrome] Show recently viewed dashboards on Dashboards nav hover

### DIFF
--- a/src/core/packages/chrome/browser-components/src/project/sidenav/navigation/navigation.tsx
+++ b/src/core/packages/chrome/browser-components/src/project/sidenav/navigation/navigation.tsx
@@ -8,10 +8,12 @@
  */
 
 import React, { useMemo } from 'react';
-import { map } from 'rxjs';
+import { combineLatest, map } from 'rxjs';
 import { Navigation as NavigationComponent } from '@kbn/ui-side-navigation';
+import type { SecondaryMenuSection } from '@kbn/ui-side-navigation/types';
 import classnames from 'classnames';
 import type { SolutionId } from '@kbn/core-chrome-browser';
+import { i18n } from '@kbn/i18n';
 import { useObservable } from '@kbn/use-observable';
 import { useChromeService } from '@kbn/core-chrome-browser-context';
 import { KibanaSectionErrorBoundary } from '@kbn/shared-ux-error-boundary';
@@ -54,17 +56,51 @@ export const Navigation = (props: ChromeNavigationProps) => {
 // eslint-disable-next-line import/no-default-export
 export default Navigation;
 
+const MAX_RECENT_DASHBOARDS = 5;
+
 const useNavigationItems = (): (NavigationItems & { solutionId: SolutionId }) | null => {
   const chrome = useChromeService();
   const basePath = useBasePath();
 
   const items$ = useMemo(() => {
     const panelStateManager = new PanelStateManager(basePath.get());
-    return chrome.project.getNavigation$().pipe(
-      map((nav) => ({
-        ...toNavigationItems(nav.navigationTree, nav.activeNodes, panelStateManager),
-        solutionId: nav.solutionId,
-      }))
+    return combineLatest([chrome.project.getNavigation$(), chrome.recentlyAccessed.get$()]).pipe(
+      map(([nav, recentlyAccessed]) => {
+        const navItems = toNavigationItems(nav.navigationTree, nav.activeNodes, panelStateManager);
+
+        const recentDashboards = recentlyAccessed
+          .filter((item) => item.link.startsWith('/app/dashboards'))
+          .slice(0, MAX_RECENT_DASHBOARDS);
+
+        if (recentDashboards.length > 0) {
+          const dashboardItem = navItems.navItems.primaryItems.find((item) =>
+            item.href.includes('/app/dashboards')
+          );
+
+          if (dashboardItem) {
+            const recentSection: SecondaryMenuSection = {
+              id: 'recent-dashboards',
+              label: i18n.translate('core.chrome.sideNav.recentlyViewedDashboards', {
+                defaultMessage: 'Recently viewed',
+              }),
+              items: recentDashboards.map((rd) => ({
+                id: `recent-${rd.id}`,
+                label: rd.label,
+                href: basePath.prepend(rd.link),
+                'data-test-subj': `nav-item-recent-dashboard-${rd.id}`,
+              })),
+            };
+
+            dashboardItem.popoverOnly = true;
+            dashboardItem.sections = [recentSection, ...(dashboardItem.sections ?? [])];
+          }
+        }
+
+        return {
+          ...navItems,
+          solutionId: nav.solutionId,
+        };
+      })
     );
   }, [chrome, basePath]);
 

--- a/src/platform/kbn-ui/side-navigation/src/components/navigation.tsx
+++ b/src/platform/kbn-ui/side-navigation/src/components/navigation.tsx
@@ -151,7 +151,9 @@ export const Navigation = ({
                   <SideNav.Popover
                     key={item.id}
                     hasContent={getHasSubmenu(item)}
-                    isSidePanelOpen={!isCollapsed && item.id === openerNode?.id}
+                    isSidePanelOpen={
+                      !isCollapsed && item.id === openerNode?.id && !item.popoverOnly
+                    }
                     isAnyPopoverLocked={isAnyPopoverLocked}
                     label={item.label}
                     trigger={

--- a/src/platform/kbn-ui/side-navigation/src/hooks/use_navigation.ts
+++ b/src/platform/kbn-ui/side-navigation/src/hooks/use_navigation.ts
@@ -51,7 +51,7 @@ export const useNavigation = (
   const visuallyActivePageId = isLogoActive ? logoId : primaryItem?.id;
   const visuallyActiveSubpageId = secondaryItem?.id;
   const openerNode = primaryItem;
-  const isSidePanelOpen = !isCollapsed && !!openerNode?.sections;
+  const isSidePanelOpen = !isCollapsed && !!openerNode?.sections && !openerNode.popoverOnly;
 
   const state: NavigationState = {
     actualActiveItemId,

--- a/src/platform/kbn-ui/side-navigation/types.ts
+++ b/src/platform/kbn-ui/side-navigation/types.ts
@@ -91,6 +91,11 @@ export interface MenuItem {
    */
   badgeType?: BadgeType;
   /**
+   * (optional) When true, sections are only shown in the hover popover and never
+   * in the persistent expanded side panel.
+   */
+  popoverOnly?: boolean;
+  /**
    * (optional) The secondary menu sections belonging to the menu item.
    */
   sections?: SecondaryMenuSection[];


### PR DESCRIPTION
## Summary

Adds an experimental hover popover to the Dashboards entry in the solution side nav (Observability, Search, Workplace AI, etc.) that surfaces a user's most recently accessed dashboards as a quick-access list. Classic nav is unaffected.

Closes https://github.com/elastic/kibana/issues/266489.

### What changed

- **`src/core/packages/chrome/browser-components/.../navigation.tsx`** — `useNavigationItems` now combines `chrome.project.getNavigation$()` with `chrome.recentlyAccessed.get$()` via `combineLatest`. After the nav tree is converted into menu items, recents are filtered for `/app/dashboards` links (capped at 5), and a "Recently viewed" `SecondaryMenuSection` is injected into the resolved Dashboards primary item.
- **`src/platform/kbn-ui/side-navigation/types.ts`** — Adds an optional `popoverOnly?: boolean` flag on `MenuItem`. When true, the item's `sections` are only shown in the hover popover and never in the persistent expanded side panel.
- **`src/platform/kbn-ui/side-navigation/src/hooks/use_navigation.ts`** — `isSidePanelOpen` respects `popoverOnly`, so the active Dashboards item does not pin a side panel when the nav is expanded.
- **`src/platform/kbn-ui/side-navigation/src/components/navigation.tsx`** — Per-item `<SideNav.Popover isSidePanelOpen>` also honours `popoverOnly`, so hover still surfaces the popover content while the nav is expanded.

### Why this shape

- The lookup is done at the chrome layer against the resolved menu items (`href.includes('/app/dashboards')`), so it works across **every solution** that exposes a Dashboards entry — no per-solution `navigation_tree.ts` edits required.
- Subscribing to `recentlyAccessed.get$()` keeps the list reactive: opening a new dashboard updates the popover without remounting the nav.
- The `popoverOnly` flag is a generic primitive on `MenuItem`. Any future caller that wants "hover-only secondary content" (e.g. Discover recents, Alerts shortcuts) can opt in without further plumbing.

## Why experimental

Per the linked issue, this is a deliberate PoC to measure whether users adopt it (clicks from the popover, time-to-dashboard) and whether the pattern is worth propagating to other nav items. No setting/feature flag is added in this PR — feedback welcome on whether to gate it.

## Out of scope / follow-ups

- Generalizing to a config-driven map (`appPrefix → label → maxItems`) once we know the pattern is keeping.
- Surfacing recents on Discover, Alerts, etc.
- If a solution exposes Dashboards as a nested item (rather than a top-level primary item), this PR's lookup will skip it. We can extend the search to `sections` if we discover that case.

## Test plan

- [ ] Unit-level: cover `useNavigationItems` injection logic (recents filtering, capping at 5, no-op when no recents, no-op when no Dashboards item).
- [ ] Manual: in Observability, Search, and Workplace AI views — open 3+ dashboards, hover over Dashboards in collapsed side nav → verify "Recently viewed" section, items navigate correctly, capped at 5.
- [ ] Manual: expand the side nav with Dashboards active → confirm the persistent side panel does **not** show "Recently viewed" (only the hover popover does).
- [ ] Manual: Classic nav unaffected.
- [ ] Accessibility: keyboard hover/focus reaches the popover content; items are reachable via tab.
- [ ] i18n: the new key `core.chrome.sideNav.recentlyViewedDashboards` renders correctly; translations follow up via the standard pipeline.

## Release note

Adds an experimental hover popover that surfaces recently viewed dashboards from the Dashboards entry in the solution side nav.

Made with [Cursor](https://cursor.com)