### PR TITLE
Fix: [Security Solution] Sorting Not Working Alphabetically in Alerts Table

### DIFF
--- a/x-pack/platform/packages/shared/response-ops/alerts-table/hooks/use_sorting.test.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerts-table/hooks/use_sorting.test.ts
@@ -40,6 +40,20 @@ describe('useSorting', () => {
     expect(result.current.sortingColumns).toStrictEqual([{ direction: 'asc', id: 'field' }]);
   });
 
+  it('should replace an existing visible sort with the latest selected column', () => {
+    const { result } = renderHook(() => useSorting(onSortChange, ['@timestamp', 'field']));
+
+    act(() => {
+      result.current.onSort([
+        { id: '@timestamp', direction: 'desc' },
+        { id: 'field', direction: 'asc' },
+      ]);
+    });
+
+    expect(onSortChange).toHaveBeenCalledWith([{ direction: 'asc', id: 'field' }]);
+    expect(result.current.sortingColumns).toStrictEqual([{ direction: 'asc', id: 'field' }]);
+  });
+
   it('should exclude any inactive column from the final sort configuration', () => {
     const { result } = renderHook(() =>
       useSorting(

--- a/x-pack/platform/packages/shared/response-ops/alerts-table/hooks/use_sorting.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerts-table/hooks/use_sorting.ts
@@ -21,6 +21,35 @@ const sortCombinationsToDataGridSort = (
     }))
   );
 
+const getLatestSortingColumn = (
+  sortingConfig: EuiDataGridSorting['columns'],
+  previousSortingConfig: EuiDataGridSorting['columns']
+): EuiDataGridSorting['columns'] => {
+  if (sortingConfig.length <= 1) {
+    return sortingConfig;
+  }
+
+  const previousSortingConfigById = new Map(
+    previousSortingConfig.map((sortItem) => [sortItem.id, sortItem.direction])
+  );
+  const addedSortingColumn = sortingConfig.find(
+    (sortItem) => !previousSortingConfigById.has(sortItem.id)
+  );
+  if (addedSortingColumn) {
+    return [addedSortingColumn];
+  }
+
+  const updatedSortingColumn = sortingConfig.find(
+    (sortItem) => previousSortingConfigById.get(sortItem.id) !== sortItem.direction
+  );
+  if (updatedSortingColumn) {
+    return [updatedSortingColumn];
+  }
+
+  const lastSortingColumn = sortingConfig[sortingConfig.length - 1];
+  return lastSortingColumn ? [lastSortingColumn] : [];
+};
+
 export function useSorting(
   onSortChange: (sort: EuiDataGridSorting['columns']) => void,
   visibleColumns: string[],
@@ -45,10 +74,11 @@ export function useSorting(
 
   const onSort = useCallback<EuiDataGridSorting['onSort']>(
     (sortingConfig) => {
-      onSortChange([...sortingConfig, ...invisibleColumnsSort]);
-      setSortingColumns(sortingConfig);
+      const latestSortingColumn = getLatestSortingColumn(sortingConfig, sortingColumns);
+      onSortChange([...latestSortingColumn, ...invisibleColumnsSort]);
+      setSortingColumns(latestSortingColumn);
     },
-    [onSortChange, invisibleColumnsSort]
+    [onSortChange, invisibleColumnsSort, sortingColumns]
   );
 
   return { sortingColumns, onSort };


### PR DESCRIPTION
## Summary

Addresses https://github.com/elastic/kibana/issues/201467

## Summary

Updated the shared ResponseOps alerts table sorting hook so choosing a new sortable column replaces the existing visible sort instead of adding it behind the default timestamp sort. This makes Security alerts table columns such as Rule Name and Severity reorder as the primary sort when selected.

Added focused unit coverage for the sorting hook to verify that a newly selected column replaces an existing visible sort.

## Verification Steps

1. Start Kibana with Security Solution data that has generated alerts from installed rules.
2. Navigate to Security > Alerts.
3. In the alerts table, click the Rule Name column header and verify the rows reorder alphabetically and only Rule Name shows the active sort indicator.
4. Click the Rule Name header again and verify the alphabetical order reverses.
5. Repeat with the Severity column.
6. Click the timestamp column and verify timestamp sorting still works.


---

_PR developed with Cursor + GPT-5.5 1M Extra High_