### PR TITLE
[Discover] Address flaky doc navigation test

### DIFF
--- a/src/platform/test/functional/apps/context/_discover_navigation.ts
+++ b/src/platform/test/functional/apps/context/_discover_navigation.ts
@@ -122,8 +122,10 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await rowActions[0].click();
       });
 
-      const hasDocHit = await testSubjects.exists('doc-hit');
-      expect(hasDocHit).to.be(true);
+      await retry.try(async () => {
+        const hasDocHit = await testSubjects.exists('doc-hit');
+        expect(hasDocHit).to.be(true);
+      });
 
       await testSubjects.click('~breadcrumb & ~first');
       await discover.waitForDiscoverAppOnScreen();

--- a/x-pack/platform/test/serverless/functional/test_suites/context/_discover_navigation.ts
+++ b/x-pack/platform/test/serverless/functional/test_suites/context/_discover_navigation.ts
@@ -128,8 +128,10 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await rowActions[0].click();
       });
 
-      const hasDocHit = await testSubjects.exists('doc-hit');
-      expect(hasDocHit).to.be(true);
+      await retry.try(async () => {
+        const hasDocHit = await testSubjects.exists('doc-hit');
+        expect(hasDocHit).to.be(true);
+      });
 
       // TODO: Clicking breadcrumbs works differently in Serverless
       await PageObjects.svlCommonNavigation.breadcrumbs.clickBreadcrumb({


### PR DESCRIPTION
- Resolves https://github.com/elastic/kibana/issues/265790

## Summary

Adding retries as we wait.


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.



<!--ONMERGE {"backportTargets":["8.19","9.3","9.4"]} ONMERGE-->