### PR TITLE
[Agent Builder] Add MCP Gateway to proxy external MCP connector tools

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/index.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/index.ts
@@ -6,6 +6,7 @@
  */
 
 export type { AgentBuilderEvent } from './base/events';
+export type { McpGatewayConfig, McpGatewayConnectorConfig } from './mcp_gateway/types';
 export {
   internalNamespaces as toolNamespaces,
   protectedNamespaces as toolReservedNamespaces,

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/mcp_gateway/types.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/mcp_gateway/types.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export interface McpGatewayConnectorConfig {
+  connectorId: string;
+  /**
+   * Slug derived from the connector name at configuration time, used as a stable
+   * prefix for proxied tool names (e.g. "my_connector__list_repos").
+   */
+  connectorSlug: string;
+  enabled: boolean;
+}
+
+export interface McpGatewayConfig {
+  /** Master toggle – when false no tools are proxied regardless of per-connector settings. */
+  enabled: boolean;
+  connectors: McpGatewayConnectorConfig[];
+}

--- a/x-pack/platform/plugins/shared/agent_builder/common/http_api/mcp_gateway.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/common/http_api/mcp_gateway.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { McpGatewayConfig } from '@kbn/agent-builder-common';
+
+export interface GetMcpGatewayConfigResponse {
+  config: McpGatewayConfig;
+}
+
+export interface UpdateMcpGatewayConfigRequest {
+  config: McpGatewayConfig;
+}
+
+export type UpdateMcpGatewayConfigResponse = GetMcpGatewayConfigResponse;

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/connectors/connectors.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/connectors/connectors.tsx
@@ -5,13 +5,14 @@
  * 2.0.
  */
 
-import { EuiButton, EuiText } from '@elastic/eui';
+import { EuiButton, EuiSpacer, EuiText } from '@elastic/eui';
 import { KibanaPageTemplate } from '@kbn/shared-ux-page-kibana-template';
 import React from 'react';
 import { useConnectorsActions } from '../../context/connectors_provider';
 import { labels } from '../../utils/i18n';
 import { AgentBuilderConnectorsTable } from './table/connectors_table';
 import { useHasConnectorsAllPrivileges } from '../../hooks/use_has_connectors_all_privileges';
+import { McpGatewayPanel } from '../mcp_gateway/mcp_gateway_panel';
 
 export const AgentBuilderConnectors = () => {
   const { openCreateFlyout } = useConnectorsActions();
@@ -37,6 +38,8 @@ export const AgentBuilderConnectors = () => {
         ]}
       />
       <KibanaPageTemplate.Section>
+        <McpGatewayPanel />
+        <EuiSpacer size="l" />
         <AgentBuilderConnectorsTable />
       </KibanaPageTemplate.Section>
     </KibanaPageTemplate>

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/mcp_gateway/mcp_gateway_panel.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/mcp_gateway/mcp_gateway_panel.tsx
@@ -1,0 +1,174 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useCallback, useMemo } from 'react';
+import {
+  EuiBasicTable,
+  EuiCallOut,
+  EuiCheckbox,
+  EuiPanel,
+  EuiSkeletonText,
+  EuiSpacer,
+  EuiSwitch,
+  EuiText,
+  EuiTitle,
+} from '@elastic/eui';
+import type { EuiBasicTableColumn } from '@elastic/eui';
+import { CONNECTOR_ID as MCP_CONNECTOR_TYPE } from '@kbn/connector-schemas/mcp/constants';
+import type { McpGatewayConnectorConfig } from '@kbn/agent-builder-common';
+import { labels } from '../../utils/i18n';
+import {
+  useMcpGatewayConfig,
+  useUpdateMcpGatewayConfig,
+} from '../../hooks/tools/use_mcp_gateway_config';
+import { useListConnectors } from '../../hooks/tools/use_mcp_connectors';
+import type { ConnectorItem } from '../../../../common/http_api/tools';
+
+function slugify(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '')
+    .slice(0, 64);
+}
+
+interface ConnectorRow {
+  connectorId: string;
+  connectorName: string;
+  connectorSlug: string;
+  enabled: boolean;
+}
+
+function buildConnectorRows(
+  connectors: readonly ConnectorItem[],
+  gatewayConnectors: McpGatewayConnectorConfig[]
+): ConnectorRow[] {
+  return connectors.map((connector) => {
+    const existing = gatewayConnectors.find((gc) => gc.connectorId === connector.id);
+    return {
+      connectorId: connector.id,
+      connectorName: connector.name,
+      connectorSlug: existing?.connectorSlug ?? slugify(connector.name),
+      enabled: existing?.enabled ?? false,
+    };
+  });
+}
+
+export const McpGatewayPanel: React.FC = () => {
+  const { config, isLoading: isLoadingConfig } = useMcpGatewayConfig();
+  const { updateConfig, isUpdating } = useUpdateMcpGatewayConfig();
+  const { connectors, isLoading: isLoadingConnectors } = useListConnectors({
+    type: MCP_CONNECTOR_TYPE,
+  });
+
+  const rows = useMemo(
+    () => buildConnectorRows(connectors, config.connectors),
+    [connectors, config.connectors]
+  );
+
+  const handleGlobalToggle = useCallback(
+    (enabled: boolean) => {
+      updateConfig({ ...config, enabled });
+    },
+    [config, updateConfig]
+  );
+
+  const handleConnectorToggle = useCallback(
+    (connectorId: string, enabled: boolean) => {
+      const row = rows.find((r) => r.connectorId === connectorId);
+      if (!row) return;
+
+      const existing = config.connectors.find((c) => c.connectorId === connectorId);
+      const updatedConnectors: McpGatewayConnectorConfig[] = existing
+        ? config.connectors.map((c) => (c.connectorId === connectorId ? { ...c, enabled } : c))
+        : [...config.connectors, { connectorId, connectorSlug: row.connectorSlug, enabled }];
+
+      updateConfig({ ...config, connectors: updatedConnectors });
+    },
+    [config, rows, updateConfig]
+  );
+
+  const columns: Array<EuiBasicTableColumn<ConnectorRow>> = [
+    {
+      field: 'connectorName',
+      name: labels.mcpGateway.connectorNameColumn,
+      render: (name: string) => <EuiText size="s">{name}</EuiText>,
+    },
+    {
+      field: 'connectorSlug',
+      name: labels.mcpGateway.toolPrefixColumn,
+      render: (slug: string) => (
+        <EuiText size="s" color="subdued">
+          <code>{slug}__</code>
+        </EuiText>
+      ),
+    },
+    {
+      field: 'enabled',
+      name: labels.mcpGateway.enabledColumn,
+      width: '80px',
+      render: (enabled: boolean, row: ConnectorRow) => (
+        <EuiCheckbox
+          id={`mcp-gateway-connector-${row.connectorId}`}
+          checked={enabled}
+          onChange={(e) => handleConnectorToggle(row.connectorId, e.target.checked)}
+          disabled={!config.enabled || isUpdating}
+          aria-label={`Proxy ${row.connectorName}`}
+        />
+      ),
+    },
+  ];
+
+  const isLoading = isLoadingConfig || isLoadingConnectors;
+
+  return (
+    <EuiPanel hasBorder paddingSize="l">
+      <EuiTitle size="s">
+        <h3>{labels.mcpGateway.panelTitle}</h3>
+      </EuiTitle>
+      <EuiSpacer size="s" />
+      <EuiText size="s" color="subdued">
+        <p>{labels.mcpGateway.panelDescription}</p>
+      </EuiText>
+      <EuiSpacer size="m" />
+
+      {isLoading ? (
+        <EuiSkeletonText lines={3} />
+      ) : (
+        <>
+          <EuiSwitch
+            label={labels.mcpGateway.enabledToggleLabel}
+            checked={config.enabled}
+            onChange={(e) => handleGlobalToggle(e.target.checked)}
+            disabled={isUpdating}
+          />
+
+          {config.enabled && (
+            <>
+              <EuiSpacer size="m" />
+              {connectors.length === 0 ? (
+                <EuiCallOut
+                  size="s"
+                  iconType="iInCircle"
+                  title={labels.mcpGateway.noConnectorsMessage}
+                />
+              ) : (
+                <EuiBasicTable
+                  tableCaption={labels.mcpGateway.panelTitle}
+                  items={rows}
+                  rowHeader="connectorName"
+                  columns={columns}
+                  tableLayout="auto"
+                />
+              )}
+            </>
+          )}
+        </>
+      )}
+    </EuiPanel>
+  );
+};

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/hooks/tools/use_mcp_gateway_config.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/hooks/tools/use_mcp_gateway_config.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useMutation, useQuery, useQueryClient } from '@kbn/react-query';
+import type { McpGatewayConfig } from '@kbn/agent-builder-common';
+import { queryKeys } from '../../query_keys';
+import { useAgentBuilderServices } from '../use_agent_builder_service';
+import { useToasts } from '../use_toasts';
+import { labels } from '../../utils/i18n';
+
+const EMPTY_CONFIG: McpGatewayConfig = { enabled: false, connectors: [] };
+
+export const useMcpGatewayConfig = () => {
+  const { toolsService } = useAgentBuilderServices();
+
+  const { data, isLoading, isError } = useQuery({
+    queryKey: queryKeys.mcpGateway.config,
+    queryFn: () => toolsService.getMcpGatewayConfig(),
+  });
+
+  return {
+    config: data?.config ?? EMPTY_CONFIG,
+    isLoading,
+    isError,
+  };
+};
+
+export const useUpdateMcpGatewayConfig = () => {
+  const { toolsService } = useAgentBuilderServices();
+  const queryClient = useQueryClient();
+  const { addSuccessToast, addErrorToast } = useToasts();
+
+  const { mutateAsync, isLoading } = useMutation({
+    mutationFn: (config: McpGatewayConfig) => toolsService.updateMcpGatewayConfig(config),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.mcpGateway.config });
+      addSuccessToast({ title: labels.mcpGateway.savedSuccessToast });
+    },
+    onError: () => {
+      addErrorToast({ title: labels.mcpGateway.saveErrorToast });
+    },
+  });
+
+  return { updateConfig: mutateAsync, isUpdating: isLoading };
+};

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/query_keys.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/query_keys.ts
@@ -61,4 +61,7 @@ export const queryKeys = {
   connectors: {
     all: ['connectors'] as const,
   },
+  mcpGateway: {
+    config: ['mcpGateway', 'config'] as const,
+  },
 };

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/utils/i18n.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/utils/i18n.ts
@@ -2299,6 +2299,36 @@ export const labels = {
       }),
     },
   },
+  mcpGateway: {
+    panelTitle: i18n.translate('xpack.agentBuilder.mcpGateway.panelTitle', {
+      defaultMessage: 'MCP Gateway',
+    }),
+    panelDescription: i18n.translate('xpack.agentBuilder.mcpGateway.panelDescription', {
+      defaultMessage:
+        "Proxy tools from your MCP connectors through Kibana's own MCP server endpoint, so any MCP client connecting to Kibana automatically sees and can call those tools.",
+    }),
+    enabledToggleLabel: i18n.translate('xpack.agentBuilder.mcpGateway.enabledToggleLabel', {
+      defaultMessage: 'Enable MCP Gateway',
+    }),
+    connectorNameColumn: i18n.translate('xpack.agentBuilder.mcpGateway.connectorNameColumn', {
+      defaultMessage: 'Connector',
+    }),
+    toolPrefixColumn: i18n.translate('xpack.agentBuilder.mcpGateway.toolPrefixColumn', {
+      defaultMessage: 'Tool name prefix',
+    }),
+    enabledColumn: i18n.translate('xpack.agentBuilder.mcpGateway.enabledColumn', {
+      defaultMessage: 'Proxy',
+    }),
+    noConnectorsMessage: i18n.translate('xpack.agentBuilder.mcpGateway.noConnectorsMessage', {
+      defaultMessage: 'No MCP connectors configured. Add a connector to start proxying tools.',
+    }),
+    savedSuccessToast: i18n.translate('xpack.agentBuilder.mcpGateway.savedSuccessToast', {
+      defaultMessage: 'MCP Gateway settings saved',
+    }),
+    saveErrorToast: i18n.translate('xpack.agentBuilder.mcpGateway.saveErrorToast', {
+      defaultMessage: 'Failed to save MCP Gateway settings',
+    }),
+  },
   navigationAbort: {
     title: i18n.translate('xpack.agentBuilder.navigationAbort.title', {
       defaultMessage: 'Abort chat request?',

--- a/x-pack/platform/plugins/shared/agent_builder/public/services/tools/tools_service.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/services/tools/tools_service.ts
@@ -7,6 +7,7 @@
 
 import type { HttpSetup } from '@kbn/core-http-browser';
 import type { ExecuteToolParams } from '@kbn/agent-builder-browser';
+import type { McpGatewayConfig } from '@kbn/agent-builder-common';
 import type {
   ListToolsResponse,
   GetToolResponse,
@@ -31,6 +32,10 @@ import type {
   BulkDeleteConnectorsResponse,
   ValidateNamespaceResponse,
 } from '../../../common/http_api/tools';
+import type {
+  GetMcpGatewayConfigResponse,
+  UpdateMcpGatewayConfigResponse,
+} from '../../../common/http_api/mcp_gateway';
 import { publicApiPath, internalApiPath } from '../../../common/constants';
 
 export class ToolsService {
@@ -182,6 +187,19 @@ export class ToolsService {
     return await this.http.get<ValidateNamespaceResponse>(
       `${internalApiPath}/tools/_validate_namespace`,
       { query: { namespace, connector_id: connectorId } }
+    );
+  }
+
+  async getMcpGatewayConfig() {
+    return await this.http.get<GetMcpGatewayConfigResponse>(
+      `${internalApiPath}/mcp_gateway/config`
+    );
+  }
+
+  async updateMcpGatewayConfig(config: McpGatewayConfig) {
+    return await this.http.put<UpdateMcpGatewayConfigResponse>(
+      `${internalApiPath}/mcp_gateway/config`,
+      { body: JSON.stringify({ config }) }
     );
   }
 }

--- a/x-pack/platform/plugins/shared/agent_builder/server/routes/index.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/routes/index.ts
@@ -20,6 +20,7 @@ import { registerConversationRoutes } from './conversations';
 import { registerAttachmentRoutes } from './attachments';
 import { registerMCPRoutes } from './mcp';
 import { registerA2ARoutes } from './a2a';
+import { registerInternalMcpGatewayRoutes } from './internal/mcp_gateway';
 import { registerSkillsRoutes } from './skills';
 import { registerPluginsRoutes } from './plugins';
 import { registerInternalExecutionRoutes } from './internal/executions';
@@ -39,6 +40,7 @@ export const registerRoutes = (dependencies: RouteDependencies) => {
   registerAttachmentRoutes(dependencies);
   registerMCPRoutes(dependencies);
   registerA2ARoutes(dependencies);
+  registerInternalMcpGatewayRoutes(dependencies);
   registerSkillsRoutes(dependencies);
   registerPluginsRoutes(dependencies);
   registerInternalExecutionRoutes(dependencies);

--- a/x-pack/platform/plugins/shared/agent_builder/server/routes/internal/mcp_gateway.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/routes/internal/mcp_gateway.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema } from '@kbn/config-schema';
+import type { RouteDependencies } from '../types';
+import { getHandlerWrapper } from '../wrap_handler';
+import type {
+  GetMcpGatewayConfigResponse,
+  UpdateMcpGatewayConfigResponse,
+} from '../../../common/http_api/mcp_gateway';
+import { internalApiPath } from '../../../common/constants';
+import { AGENT_BUILDER_READ_SECURITY, AGENT_BUILDER_WRITE_SECURITY } from '../route_security';
+
+const connectorConfigSchema = schema.object({
+  connectorId: schema.string({ minLength: 1 }),
+  connectorSlug: schema.string({ minLength: 1 }),
+  enabled: schema.boolean(),
+});
+
+const gatewayConfigSchema = schema.object({
+  enabled: schema.boolean(),
+  connectors: schema.arrayOf(connectorConfigSchema),
+});
+
+export function registerInternalMcpGatewayRoutes({
+  router,
+  getInternalServices,
+  logger,
+}: RouteDependencies) {
+  const wrapHandler = getHandlerWrapper({ logger });
+
+  router.get(
+    {
+      path: `${internalApiPath}/mcp_gateway/config`,
+      validate: false,
+      options: { access: 'internal' },
+      security: AGENT_BUILDER_READ_SECURITY,
+    },
+    wrapHandler(async (ctx, request, response) => {
+      const { mcpGateway } = getInternalServices();
+      const agentBuilderCtx = await ctx.agentBuilder;
+      const spaceId = agentBuilderCtx.spaces.getSpaceId();
+
+      const config = await mcpGateway.getConfig(spaceId);
+      return response.ok<GetMcpGatewayConfigResponse>({ body: { config } });
+    })
+  );
+
+  router.put(
+    {
+      path: `${internalApiPath}/mcp_gateway/config`,
+      validate: {
+        body: schema.object({ config: gatewayConfigSchema }),
+      },
+      options: { access: 'internal' },
+      security: AGENT_BUILDER_WRITE_SECURITY,
+    },
+    wrapHandler(async (ctx, request, response) => {
+      const { mcpGateway } = getInternalServices();
+      const agentBuilderCtx = await ctx.agentBuilder;
+      const spaceId = agentBuilderCtx.spaces.getSpaceId();
+
+      await mcpGateway.updateConfig(spaceId, request.body.config);
+      const config = await mcpGateway.getConfig(spaceId);
+      return response.ok<UpdateMcpGatewayConfigResponse>({ body: { config } });
+    })
+  );
+}

--- a/x-pack/platform/plugins/shared/agent_builder/server/routes/mcp.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/routes/mcp.ts
@@ -16,9 +16,29 @@ import type { RouteDependencies } from './types';
 import { getHandlerWrapper } from './wrap_handler';
 import { KibanaMcpHttpTransport } from '../utils/mcp/kibana_mcp_http_transport';
 import { MCP_SERVER_PATH } from '../../common/mcp';
+import type { ProxyTool } from '../services/mcp_gateway';
 
 const MCP_SERVER_NAME = 'elastic-mcp-server';
 const MCP_SERVER_VERSION = '0.0.1';
+
+export function filterProxyToolsByNamespace(tools: ProxyTool[], namespaces?: string): ProxyTool[] {
+  if (!namespaces?.trim()) {
+    return tools;
+  }
+
+  const namespaceSet = new Set(
+    namespaces
+      .split(',')
+      .map((ns) => ns.trim())
+      .filter(Boolean)
+  );
+
+  if (namespaceSet.size === 0) {
+    return tools;
+  }
+
+  return tools.filter((tool) => namespaceSet.has(tool.namespace));
+}
 
 export function filterToolsByNamespace(
   tools: InternalToolDefinition[],
@@ -112,7 +132,7 @@ To learn more, refer to the [MCP documentation](https://www.elastic.co/docs/expl
             version: MCP_SERVER_VERSION,
           });
 
-          const { tools: toolService } = getInternalServices();
+          const { tools: toolService, mcpGateway } = getInternalServices();
 
           const registry = await toolService.getRegistry({ request });
           const allTools = await registry.list({});
@@ -137,6 +157,21 @@ To learn more, refer to the [MCP documentation](https://www.elastic.co/docs/expl
                   content: [{ type: 'text' as const, text: JSON.stringify(toolResult) }],
                 };
               }
+            );
+          }
+
+          // Expose proxied tools from configured external MCP connectors
+          const agentBuilderCtx = await ctx.agentBuilder;
+          const spaceId = agentBuilderCtx.spaces.getSpaceId();
+          const allProxyTools = await mcpGateway.getProxyTools({ request, spaceId });
+          const proxyTools = filterProxyToolsByNamespace(allProxyTools, request.query.namespace);
+
+          for (const proxyTool of proxyTools) {
+            server.tool(
+              proxyTool.mcpName,
+              proxyTool.description,
+              proxyTool.schemaShape,
+              proxyTool.execute
             );
           }
 

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/create_services.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/create_services.ts
@@ -30,6 +30,7 @@ import {
   type ConsumptionService,
 } from './metering';
 import { type PluginsService, createPluginsService } from './plugins';
+import { McpGatewayService } from './mcp_gateway';
 
 interface ServiceInstances {
   tools: ToolsService;
@@ -240,6 +241,12 @@ export class ServiceManager {
 
     const consumption = this.services.consumption.start({ elasticsearch, spaces });
 
+    const mcpGateway = new McpGatewayService(
+      elasticsearch.client.asInternalUser,
+      actions,
+      logger.get('mcp-gateway')
+    );
+
     this.internalStart = {
       tools,
       agents,
@@ -257,6 +264,7 @@ export class ServiceManager {
       savedObjects,
       plugins,
       consumption,
+      mcpGateway,
     };
 
     return this.internalStart;

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/mcp_gateway/index.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/mcp_gateway/index.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { McpGatewayService } from './mcp_gateway_service';
+export type { ProxyTool } from './mcp_gateway_service';

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/mcp_gateway/mcp_gateway_service.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/mcp_gateway/mcp_gateway_service.ts
@@ -1,0 +1,139 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod/v4';
+import { fromJSONSchema } from '@kbn/zod/v4/from_json_schema';
+import type { ElasticsearchClient, KibanaRequest, Logger } from '@kbn/core/server';
+import type { PluginStartContract as ActionsPluginStart } from '@kbn/actions-plugin/server';
+import type { McpGatewayConfig } from '@kbn/agent-builder-common';
+import { listMcpTools } from '../tools/tool_types/mcp/tool_type';
+import { McpGatewayConfigStorage } from './storage';
+import { McpGatewayToolsCache } from './tools_cache';
+
+export interface ProxyTool {
+  mcpName: string;
+  description: string;
+  /** Synthetic namespace for filtering: `mcp_gateway.{connectorSlug}` */
+  namespace: string;
+  schemaShape: z.ZodRawShape;
+  execute: (
+    args: Record<string, unknown>
+  ) => Promise<{ content: Array<{ type: 'text'; text: string }> }>;
+}
+
+export class McpGatewayService {
+  private readonly storage: McpGatewayConfigStorage;
+  private readonly toolsCache: McpGatewayToolsCache;
+
+  constructor(
+    private readonly esClient: ElasticsearchClient,
+    private readonly actions: ActionsPluginStart,
+    private readonly logger: Logger
+  ) {
+    this.storage = new McpGatewayConfigStorage(esClient, logger.get('storage'));
+    this.toolsCache = new McpGatewayToolsCache();
+  }
+
+  async getConfig(spaceId: string): Promise<McpGatewayConfig> {
+    return this.storage.getConfig(spaceId);
+  }
+
+  async updateConfig(spaceId: string, config: McpGatewayConfig): Promise<void> {
+    await this.storage.updateConfig(spaceId, config);
+    // Invalidate cache for all changed connectors so tool lists are refreshed promptly
+    for (const connector of config.connectors) {
+      this.toolsCache.invalidate(spaceId, connector.connectorId);
+    }
+  }
+
+  async getProxyTools({
+    request,
+    spaceId,
+  }: {
+    request: KibanaRequest;
+    spaceId: string;
+  }): Promise<ProxyTool[]> {
+    const config = await this.storage.getConfig(spaceId);
+    if (!config.enabled) {
+      return [];
+    }
+
+    const enabledConnectors = config.connectors.filter((c) => c.enabled);
+    const proxyTools: ProxyTool[] = [];
+
+    await Promise.all(
+      enabledConnectors.map(async ({ connectorId, connectorSlug }) => {
+        try {
+          let tools = this.toolsCache.get(spaceId, connectorId);
+          if (!tools) {
+            const result = await listMcpTools({
+              actions: this.actions,
+              request,
+              connectorId,
+            });
+            tools = result.tools;
+            this.toolsCache.set(spaceId, connectorId, tools);
+          }
+
+          for (const tool of tools) {
+            const zodSchema = tool.inputSchema
+              ? ((fromJSONSchema(tool.inputSchema as Record<string, unknown>) ??
+                  z.object({})) as z.ZodObject<z.ZodRawShape>)
+              : z.object({});
+
+            const connectorId_ = connectorId;
+            const toolName = tool.name;
+
+            proxyTools.push({
+              mcpName: `${connectorSlug}__${tool.name}`,
+              description: tool.description ?? `Tool '${tool.name}' from MCP connector`,
+              namespace: `mcp_gateway.${connectorSlug}`,
+              schemaShape: zodSchema.shape,
+              execute: async (args) => {
+                const actionsClient = await this.actions.getActionsClientWithRequest(request);
+                const result = await actionsClient.execute({
+                  actionId: connectorId_,
+                  params: {
+                    subAction: 'callTool',
+                    subActionParams: { name: toolName, arguments: args },
+                  },
+                });
+
+                if (result.status === 'error') {
+                  return {
+                    content: [
+                      {
+                        type: 'text' as const,
+                        text: JSON.stringify({
+                          isError: true,
+                          message: result.message ?? 'MCP tool execution failed',
+                        }),
+                      },
+                    ],
+                  };
+                }
+
+                return {
+                  content: [{ type: 'text' as const, text: JSON.stringify(result.data) }],
+                };
+              },
+            });
+          }
+        } catch (error) {
+          // A failed connector should not break the entire MCP server response
+          this.logger.warn(
+            `MCP Gateway: failed to list tools for connector ${connectorId}: ${
+              error instanceof Error ? error.message : String(error)
+            }`
+          );
+        }
+      })
+    );
+
+    return proxyTools;
+  }
+}

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/mcp_gateway/storage.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/mcp_gateway/storage.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ElasticsearchClient, Logger } from '@kbn/core/server';
+import { isResponseError } from '@kbn/es-errors';
+import type { McpGatewayConfig } from '@kbn/agent-builder-common';
+import { chatSystemIndex } from '@kbn/agent-builder-server';
+
+const INDEX_NAME = chatSystemIndex('mcp-gateway-config');
+
+const DEFAULT_CONFIG: McpGatewayConfig = {
+  enabled: false,
+  connectors: [],
+};
+
+export class McpGatewayConfigStorage {
+  private ensureIndexPromise: Promise<void> | undefined;
+
+  constructor(private readonly esClient: ElasticsearchClient, private readonly logger: Logger) {}
+
+  private ensureIndex(): Promise<void> {
+    if (!this.ensureIndexPromise) {
+      this.ensureIndexPromise = this.createIndex().catch((error) => {
+        // Reset so the next call retries
+        this.ensureIndexPromise = undefined;
+        throw error;
+      });
+    }
+    return this.ensureIndexPromise;
+  }
+
+  private async createIndex(): Promise<void> {
+    try {
+      await this.esClient.indices.create({
+        index: INDEX_NAME,
+        body: {
+          mappings: {
+            dynamic: false,
+            properties: {
+              enabled: { type: 'boolean' },
+              connectors: {
+                type: 'nested',
+                properties: {
+                  connectorId: { type: 'keyword' },
+                  connectorSlug: { type: 'keyword' },
+                  enabled: { type: 'boolean' },
+                },
+              },
+            },
+          },
+        },
+      });
+    } catch (error) {
+      if (
+        isResponseError(error) &&
+        error.body?.error?.type === 'resource_already_exists_exception'
+      ) {
+        return;
+      }
+      this.logger.warn(`Failed to create MCP gateway config index: ${error}`);
+      throw error;
+    }
+  }
+
+  async getConfig(spaceId: string): Promise<McpGatewayConfig> {
+    await this.ensureIndex();
+    try {
+      const result = await this.esClient.get<McpGatewayConfig>({
+        index: INDEX_NAME,
+        id: spaceId,
+      });
+      return result._source ?? DEFAULT_CONFIG;
+    } catch (error) {
+      if (isResponseError(error) && error.statusCode === 404) {
+        return { ...DEFAULT_CONFIG };
+      }
+      throw error;
+    }
+  }
+
+  async updateConfig(spaceId: string, config: McpGatewayConfig): Promise<void> {
+    await this.ensureIndex();
+    await this.esClient.index({
+      index: INDEX_NAME,
+      id: spaceId,
+      document: config,
+      refresh: 'wait_for',
+    });
+  }
+}

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/mcp_gateway/tools_cache.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/mcp_gateway/tools_cache.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Tool } from '@kbn/mcp-client';
+
+const DEFAULT_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+interface CacheEntry {
+  tools: Tool[];
+  expiresAt: number;
+}
+
+/**
+ * In-memory TTL cache for listTools results from external MCP connectors.
+ * Keyed by `{spaceId}:{connectorId}` to isolate results across spaces.
+ */
+export class McpGatewayToolsCache {
+  private readonly cache = new Map<string, CacheEntry>();
+  private readonly ttlMs: number;
+
+  constructor({ ttlMs = DEFAULT_TTL_MS }: { ttlMs?: number } = {}) {
+    this.ttlMs = ttlMs;
+  }
+
+  private key(spaceId: string, connectorId: string): string {
+    return `${spaceId}:${connectorId}`;
+  }
+
+  get(spaceId: string, connectorId: string): Tool[] | undefined {
+    const entry = this.cache.get(this.key(spaceId, connectorId));
+    if (!entry) return undefined;
+    if (Date.now() > entry.expiresAt) {
+      this.cache.delete(this.key(spaceId, connectorId));
+      return undefined;
+    }
+    return entry.tools;
+  }
+
+  set(spaceId: string, connectorId: string, tools: Tool[]): void {
+    this.cache.set(this.key(spaceId, connectorId), {
+      tools,
+      expiresAt: Date.now() + this.ttlMs,
+    });
+  }
+
+  invalidate(spaceId: string, connectorId: string): void {
+    this.cache.delete(this.key(spaceId, connectorId));
+  }
+
+  invalidateAll(): void {
+    this.cache.clear();
+  }
+}

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/types.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/types.ts
@@ -35,6 +35,7 @@ import type { AuditLogService } from '../audit';
 import type { TaskHandler } from './execution';
 import type { MeteringService, ConsumptionServiceStart } from './metering';
 import type { PluginsServiceSetup, PluginsServiceStart } from './plugins';
+import type { McpGatewayService } from './mcp_gateway';
 
 export interface InternalSetupServices {
   tools: ToolsServiceSetup;
@@ -63,6 +64,7 @@ export interface InternalStartServices {
   taskHandler: TaskHandler;
   plugins: PluginsServiceStart;
   consumption: ConsumptionServiceStart;
+  mcpGateway: McpGatewayService;
 }
 
 export interface ServiceSetupDeps {


### PR DESCRIPTION
## Summary

- Adds an **MCP Gateway** feature to Agent Builder that makes all tools from configured external MCP connectors (Stack Connectors) automatically available on Kibana's own MCP server endpoint (`/api/agents/mcp`).
- Any MCP client connecting to Kibana (Claude Desktop, Cursor, etc.) now sees and can call proxied tools alongside the regular registry tools, without the operator needing to individually register each one.
- A new **MCP Gateway** settings panel on the Connectors page lets operators enable/disable the feature globally and toggle it per connector.

## Architecture

**Server side:**
- `McpGatewayService` — orchestrates per-space config storage (ES index `.chat-mcp-gateway-config`), an in-memory TTL cache for `listTools` results (5 min per `spaceId:connectorId`), and builds proxy tool definitions. A failing connector is logged as a warning and skipped; it never breaks the whole MCP response.
- `GET / PUT /internal/agent_builder/mcp_gateway/config` — reads and saves the gateway config for the current space.
- `server/routes/mcp.ts` — after registering registry tools, calls `mcpGateway.getProxyTools()` and registers each result with the MCP server. Proxy tools get a synthetic namespace `mcp_gateway.{connectorSlug}` that clients can use with the existing `?namespace=` filter.

**Client side:**
- `McpGatewayPanel` component on the Connectors page — global on/off `EuiSwitch` + per-connector `EuiCheckbox` table. Auto-saves on each toggle.
- `useMcpGatewayConfig` / `useUpdateMcpGatewayConfig` React Query hooks.

**Naming:** proxied tools are exposed as `{connectorSlug}__{toolName}` (e.g. `my_github__list_repos`), where the slug is derived from the connector name at config-save time.

## Test plan

- [ ] Enable MCP Gateway on the Connectors page and verify proxied tools appear in an MCP client connecting to `/api/agents/mcp`
- [ ] Disable a per-connector toggle and confirm its tools disappear
- [ ] Disable the global toggle and confirm no proxy tools are exposed
- [ ] Verify that a connector that is down logs a warning and the other connectors' tools still load
- [ ] Verify namespace filtering: `?namespace=mcp_gateway.my_connector` returns only that connector's tools
- [ ] Verify the config persists across page reloads
- [ ] Unit tests for `McpGatewayService` (cache hit/miss, error handling, slug generation) — _TODO_

🤖 Generated with [Claude Code](https://claude.com/claude-code)