### PR TITLE
[Discover] Address flaky time field column test

### DIFF
--- a/src/platform/test/functional/apps/discover/group11/_time_field_column.ts
+++ b/src/platform/test/functional/apps/discover/group11/_time_field_column.ts
@@ -76,12 +76,12 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         hideTimeFieldColumnSetting || !hasTimeField ? ['Summary'] : ['@timestamp', 'Summary']
       );
       await discover.saveSearch(`${SEARCH_NO_COLUMNS}${savedSearchSuffix}`);
-      await discover.waitUntilSearchingHasFinished();
+      await discover.waitUntilTabIsLoaded();
 
       const isTimestampUnavailableInSidebar = isEsqlMode && !hasTimeField;
       if (!isTimestampUnavailableInSidebar) {
         await unifiedFieldList.clickFieldListItemAdd('@timestamp');
-        await discover.waitUntilSearchingHasFinished();
+        await discover.waitUntilTabIsLoaded();
         await retry.try(async () => {
           expect(await dataGrid.getHeaderFields()).to.eql(
             !hasTimeField
@@ -93,7 +93,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         });
 
         await discover.saveSearch(`${SEARCH_WITH_ONLY_TIMESTAMP}${savedSearchSuffix}`, true);
-        await discover.waitUntilSearchingHasFinished();
+        await discover.waitUntilTabIsLoaded();
 
         await unifiedFieldList.clickFieldListItemRemove('@timestamp');
         await retry.try(async () => {
@@ -161,7 +161,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       await discover.saveSearch(`${SEARCH_WITH_SELECTED_COLUMNS}${savedSearchSuffix}`);
-      await discover.waitUntilSearchingHasFinished();
+      await discover.waitUntilTabIsLoaded();
 
       await unifiedFieldList.clickFieldListItemAdd('@timestamp');
       await retry.try(async () => {
@@ -172,7 +172,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         `${SEARCH_WITH_SELECTED_COLUMNS_AND_TIMESTAMP}${savedSearchSuffix}`,
         true
       );
-      await discover.waitUntilSearchingHasFinished();
+      await discover.waitUntilTabIsLoaded();
 
       await dataGrid.clickMoveColumnLeft('@timestamp');
       await retry.try(async () => {
@@ -237,7 +237,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
             'doc_table:hideTimeColumn': hideTimeFieldColumnSetting,
           });
           await common.navigateToApp('discover');
-          await discover.waitUntilSearchingHasFinished();
+          await discover.waitUntilTabIsLoaded();
         });
 
         describe('data view mode', () => {
@@ -266,7 +266,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
                 adHoc: true,
                 hasTimeField: false,
               });
-              await discover.waitUntilSearchingHasFinished();
+              await discover.waitUntilTabIsLoaded();
             });
 
             it('should render initial columns correctly', async () => {
@@ -290,6 +290,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         describe('ESQL mode', () => {
           it('should render initial columns correctly', async () => {
             await discover.selectTextBaseLang();
+            await discover.waitUntilTabIsLoaded();
 
             await checkInitialColumns({
               hasTimeField: true,
@@ -303,7 +304,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
             await discover.selectTextBaseLang();
             await monacoEditor.setCodeEditorValue('from logstash-* | limit 10 | drop @timestamp');
             await testSubjects.click('querySubmitButton');
-            await header.waitUntilLoadingHasFinished();
+            await discover.waitUntilTabIsLoaded();
 
             await checkInitialColumns({
               hasTimeField: false,
@@ -315,6 +316,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
           it('should render selected columns correctly', async () => {
             await discover.selectTextBaseLang();
+            await discover.waitUntilTabIsLoaded();
 
             await checkSelectedColumns({
               hasTimeField: true,

--- a/src/platform/test/functional/page_objects/discover_page.ts
+++ b/src/platform/test/functional/page_objects/discover_page.ts
@@ -247,7 +247,7 @@ export class DiscoverPageObject extends FtrService {
     await this.testSubjects.missingOrFail('loadingSpinner', {
       timeout: this.defaultFindTimeout * 10,
     });
-    // does not show "Cancel" button when searching, so we can use it to determine that searching has finished
+    // does not show "Cancel" button, so we can use it to determine that searching has finished
     await this.testSubjects.missingOrFail('queryCancelButton', {
       timeout: this.defaultFindTimeout * 10,
     });

--- a/src/platform/test/functional/page_objects/discover_page.ts
+++ b/src/platform/test/functional/page_objects/discover_page.ts
@@ -248,7 +248,9 @@ export class DiscoverPageObject extends FtrService {
       timeout: this.defaultFindTimeout * 10,
     });
     // does not show "Cancel" button when searching, so we can use it to determine that searching has finished
-    await this.testSubjects.missingOrFail('queryCancelButton');
+    await this.testSubjects.missingOrFail('queryCancelButton', {
+      timeout: this.defaultFindTimeout * 10,
+    });
   }
 
   public async waitUntilTabIsLoaded() {

--- a/src/platform/test/functional/page_objects/discover_page.ts
+++ b/src/platform/test/functional/page_objects/discover_page.ts
@@ -247,6 +247,8 @@ export class DiscoverPageObject extends FtrService {
     await this.testSubjects.missingOrFail('loadingSpinner', {
       timeout: this.defaultFindTimeout * 10,
     });
+    // does not show "Cancel" button when searching, so we can use it to determine that searching has finished
+    await this.testSubjects.missingOrFail('queryCancelButton');
   }
 
   public async waitUntilTabIsLoaded() {


### PR DESCRIPTION
- Closes https://github.com/elastic/kibana/issues/266191

## Summary

Making sure that the loading of the updated query is complete.


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


<!--ONMERGE {"backportTargets":["9.3","9.4"]} ONMERGE-->