### PR TITLE
[Sig Events] Fix query KIs filtering in stream details

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/stream_detail_significant_events_view/knowledge_indicators_table/knowledge_indicators_table.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/stream_detail_significant_events_view/knowledge_indicators_table/knowledge_indicators_table.tsx
@@ -29,6 +29,7 @@ import { DeleteTableItemsModal } from '../delete_table_items_modal';
 import { SparkPlot } from '../../../spark_plot';
 import { TableTitle } from '../../stream_detail_systems/table_title';
 import { getKnowledgeIndicatorItemId } from '../utils/get_knowledge_indicator_item_id';
+import { getKnowledgeIndicatorType } from '../utils/get_knowledge_indicator_type';
 
 interface KnowledgeIndicatorsTableProps {
   definition: Streams.all.Definition;
@@ -78,8 +79,7 @@ export function KnowledgeIndicatorsTable({
         return false;
       }
 
-      const type =
-        knowledgeIndicator.kind === 'feature' ? knowledgeIndicator.feature.type : 'query';
+      const type = getKnowledgeIndicatorType(knowledgeIndicator);
       const matchesType = selectedTypes.length === 0 || selectedTypes.includes(type);
 
       if (!matchesType) {


### PR DESCRIPTION
Filtering by KI type for queries broke when we added STAT queries, this fixes it.