### PR TITLE
[Chrome Next] Add badges popovers

### DIFF
--- a/src/core/packages/chrome/browser-components/src/chrome_next/app_header/app_badge.stories.tsx
+++ b/src/core/packages/chrome/browser-components/src/chrome_next/app_header/app_badge.stories.tsx
@@ -1,0 +1,159 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React, { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+import {
+  EuiBadge,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiHeader,
+  EuiHeaderSection,
+  EuiPageTemplate,
+  EuiPopover,
+  EuiTitle,
+} from '@elastic/eui';
+import type { ChromeNextHeaderBadge } from '@kbn/core-chrome-browser/src';
+import { AppBadge } from './app_badge';
+
+const MAX_VISIBLE_BADGES = 2;
+
+interface AppBadgeStoryProps {
+  title: string;
+  badges: ChromeNextHeaderBadge[];
+}
+
+const HeaderWithBadges = ({ title, badges }: AppBadgeStoryProps) => {
+  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+  const visibleBadges = badges.slice(0, MAX_VISIBLE_BADGES);
+  const overflowBadges = badges.slice(MAX_VISIBLE_BADGES);
+
+  return (
+    <EuiHeader>
+      <EuiHeaderSection>
+        <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false} wrap={false}>
+          <EuiFlexItem grow={false}>
+            <EuiTitle size="xs">
+              <h1>{title}</h1>
+            </EuiTitle>
+          </EuiFlexItem>
+          {visibleBadges.map((badge) => (
+            <EuiFlexItem grow={false} key={badge.label}>
+              <AppBadge badge={badge} />
+            </EuiFlexItem>
+          ))}
+          {overflowBadges.length > 0 && (
+            <EuiFlexItem grow={false}>
+              <EuiPopover
+                aria-label="More badges"
+                button={
+                  <EuiBadge
+                    color="hollow"
+                    onClick={() => setIsPopoverOpen((open) => !open)}
+                    onClickAriaLabel={`Show ${overflowBadges.length} more badges`}
+                  >
+                    +{overflowBadges.length}
+                  </EuiBadge>
+                }
+                isOpen={isPopoverOpen}
+                closePopover={() => setIsPopoverOpen(false)}
+                panelPaddingSize="s"
+              >
+                <EuiFlexGroup direction="column" gutterSize="xs" alignItems="center">
+                  {overflowBadges.map((badge) => (
+                    <EuiFlexItem grow={false} key={badge.label}>
+                      <AppBadge badge={badge} />
+                    </EuiFlexItem>
+                  ))}
+                </EuiFlexGroup>
+              </EuiPopover>
+            </EuiFlexItem>
+          )}
+        </EuiFlexGroup>
+      </EuiHeaderSection>
+    </EuiHeader>
+  );
+};
+
+const meta: Meta<AppBadgeStoryProps> = {
+  title: 'Chrome/App Badge',
+  component: HeaderWithBadges,
+  decorators: [
+    (Story) => (
+      <EuiPageTemplate>
+        <Story />
+      </EuiPageTemplate>
+    ),
+  ],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Badges displayed inline next to the page title in the Chrome header. ' +
+          'Each badge can be a simple label, have a click handler, or open a context menu.',
+      },
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<AppBadgeStoryProps>;
+
+export const Badges: Story = {
+  args: {
+    title: '[Logs] Web Traffic',
+    badges: [
+      { label: 'Beta' },
+      {
+        label: 'Tech Preview',
+        color: 'warning',
+        tooltip: 'This feature is in tech preview and may change.',
+        onClick: action('tech-preview-clicked'),
+        onClickAriaLabel: 'Click to learn more about tech preview',
+      },
+      {
+        label: 'Managed',
+        color: 'primary',
+        popoverWidth: 180,
+        items: [
+          {
+            name: 'View details',
+            icon: 'inspect',
+            onClick: action('view-details-clicked'),
+          },
+          {
+            name: 'Export',
+            icon: 'exportAction',
+            popoverWidth: 180,
+            items: [
+              {
+                name: 'Export as CSV',
+                icon: 'document',
+                onClick: action('export-csv-clicked'),
+              },
+              {
+                name: 'Export as JSON',
+                icon: 'document',
+                onClick: action('export-json-clicked'),
+              },
+            ],
+          },
+          {
+            name: 'Unlink',
+            icon: 'unlink',
+            onClick: action('unlink-clicked'),
+          },
+        ],
+      },
+      { label: 'New', color: 'primary' },
+    ],
+  },
+};

--- a/src/core/packages/chrome/browser-components/src/chrome_next/app_header/app_badge.tsx
+++ b/src/core/packages/chrome/browser-components/src/chrome_next/app_header/app_badge.tsx
@@ -7,11 +7,53 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React, { useMemo } from 'react';
-import { EuiBadge, EuiToolTip } from '@elastic/eui';
-import type { ChromeNextHeaderBadge } from '@kbn/core-chrome-browser/src';
+import React, { useCallback, useMemo, useState } from 'react';
+import { EuiBadge, EuiContextMenu, EuiPopover, EuiToolTip } from '@elastic/eui';
+import type {
+  EuiContextMenuPanelDescriptor,
+  EuiContextMenuPanelItemDescriptor,
+} from '@elastic/eui';
+import type {
+  ChromeNextHeaderBadge,
+  ChromeNextHeaderBadgeMenuItem,
+} from '@kbn/core-chrome-browser/src';
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
+
+/**
+ * Recursively builds flat EuiContextMenu panels from nested badge menu items.
+ */
+const buildPanels = (
+  items: ChromeNextHeaderBadgeMenuItem[],
+  panelId: number,
+  width?: number,
+  title?: string
+): EuiContextMenuPanelDescriptor[] => {
+  const panels: EuiContextMenuPanelDescriptor[] = [];
+  let nextPanelId = panelId + 1;
+
+  const panelItems: EuiContextMenuPanelItemDescriptor[] = items.map((item) => {
+    const { items: childItems, popoverWidth: childWidth, ...rest } = item;
+    if (childItems && childItems.length > 0) {
+      const childPanelId = nextPanelId;
+      const childPanels = buildPanels(childItems, childPanelId, childWidth, item.name);
+      nextPanelId = childPanelId + childPanels.length;
+      panels.push(...childPanels);
+      return { ...rest, panel: childPanelId };
+    }
+
+    return rest;
+  });
+
+  panels.unshift({
+    id: panelId,
+    items: panelItems,
+    ...(title && { title }),
+    ...(width && { width }),
+  });
+
+  return panels;
+};
 
 const useBadgeStyle = () => {
   return useMemo(() => {
@@ -25,12 +67,18 @@ const useBadgeStyle = () => {
 
 export const AppBadge = ({ badge }: { badge: ChromeNextHeaderBadge }) => {
   const { badge: badgeStyle } = useBadgeStyle();
+  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+
+  const closePopover = useCallback(() => setIsPopoverOpen(false), []);
+  const togglePopover = useCallback(() => setIsPopoverOpen((open) => !open), []);
 
   // @ts-expect-error supported for backward compatibility. TODO: Remove it
   if (badge?.renderCustomBadge) {
     // @ts-expect-error supported for backward compatibility. TODO: Remove it
     return badge.renderCustomBadge({ badgeText: badge.label });
   }
+
+  const hasItems = 'items' in badge && badge.items !== undefined;
 
   const badgeOnClickAriaLabel =
     badge?.onClickAriaLabel ??
@@ -40,9 +88,11 @@ export const AppBadge = ({ badge }: { badge: ChromeNextHeaderBadge }) => {
     });
 
   const handleBadgeClick = () => {
-    if (badge?.onClick) {
-      badge.onClick();
+    if (hasItems) {
+      togglePopover();
+      return;
     }
+    badge?.onClick?.();
   };
 
   const badgeComponent = (
@@ -52,16 +102,37 @@ export const AppBadge = ({ badge }: { badge: ChromeNextHeaderBadge }) => {
       color={badge?.color ?? 'hollow'}
       data-test-subj={badge?.['data-test-subj']}
       css={badgeStyle}
+      iconType={hasItems ? 'arrowDown' : undefined}
+      iconSide={hasItems ? 'right' : undefined}
     >
       {badge.label}
     </EuiBadge>
   );
 
-  if (badge?.tooltip) {
-    return <EuiToolTip content={badge.tooltip}>{badgeComponent}</EuiToolTip>;
+  const wrappedBadge = badge?.tooltip ? (
+    <EuiToolTip content={badge.tooltip}>{badgeComponent}</EuiToolTip>
+  ) : (
+    badgeComponent
+  );
+
+  if (hasItems) {
+    return (
+      <EuiPopover
+        button={wrappedBadge}
+        isOpen={isPopoverOpen}
+        closePopover={closePopover}
+        panelPaddingSize="none"
+        aria-label={badge.label}
+      >
+        <EuiContextMenu
+          initialPanelId={0}
+          panels={buildPanels(badge.items, 0, badge.popoverWidth)}
+        />
+      </EuiPopover>
+    );
   }
 
-  return badgeComponent;
+  return wrappedBadge;
 };
 
 AppBadge.displayName = 'AppBadge';

--- a/src/core/packages/chrome/browser-components/src/chrome_next/app_header/app_badges.tsx
+++ b/src/core/packages/chrome/browser-components/src/chrome_next/app_header/app_badges.tsx
@@ -94,9 +94,9 @@ export const AppBadges = memo(() => {
             closePopover={handleClosePopover}
             panelPaddingSize="s"
           >
-            <EuiFlexGroup direction="column" gutterSize="xs">
+            <EuiFlexGroup direction="column" gutterSize="xs" alignItems="center">
               {overflowBadges.map((badge) => (
-                <EuiFlexItem key={badge.label}>
+                <EuiFlexItem grow={false} key={badge.label}>
                   <AppBadge badge={badge} />
                 </EuiFlexItem>
               ))}

--- a/src/core/packages/chrome/browser/index.ts
+++ b/src/core/packages/chrome/browser/index.ts
@@ -59,6 +59,7 @@ export type {
   ChromeNextGlobalSearchConfig,
   ChromeNextHeaderBack,
   ChromeNextHeaderBadge,
+  ChromeNextHeaderBadgeMenuItem,
   ChromeNextHeaderCallout,
   ChromeNextHeaderConfig,
   ChromeNextHeaderGlobalActions,

--- a/src/core/packages/chrome/browser/src/chrome_next/header.ts
+++ b/src/core/packages/chrome/browser/src/chrome_next/header.ts
@@ -8,6 +8,7 @@
  */
 import type { ReactNode } from 'react';
 import type { AppMenuConfig } from '@kbn/core-chrome-app-menu-components';
+import type { IconType } from '@elastic/eui';
 
 /**
  * Unified configuration for the Chrome-controlled Chrome-Next header.
@@ -74,15 +75,52 @@ export interface ChromeNextHeaderBack {
   label?: string;
 }
 
-export interface ChromeNextHeaderBadge {
+interface ChromeNextHeaderBadgeBase {
   label: string;
   /** EUI badge color. `filled` is intentionally excluded. */
   color?: 'hollow' | 'default' | 'primary' | 'success' | 'warning' | 'danger' | 'accent';
   tooltip?: string;
-  onClick?: () => void;
-  onClickAriaLabel?: string;
   'data-test-subj'?: string;
 }
+
+interface ChromeNextHeaderBadgeWithClick extends ChromeNextHeaderBadgeBase {
+  popoverWidth?: never;
+  items?: never;
+  onClick?: () => void;
+  onClickAriaLabel?: string;
+}
+
+interface ChromeNextHeaderPopoverBadge extends ChromeNextHeaderBadgeBase {
+  items: ChromeNextHeaderBadgeMenuItem[];
+  popoverWidth?: number;
+  onClick?: never;
+  onClickAriaLabel?: never;
+}
+
+/**
+ * A menu item for badge context menus.
+ * Leaf items have `onClick`; parent items have nested `items`.
+ */
+export interface ChromeNextHeaderBadgeMenuItem {
+  /** Display label for the menu item. */
+  name: string;
+  /** Optional icon. */
+  icon?: IconType;
+  /** Handler for leaf items. Mutually exclusive with `items`. */
+  onClick?: () => void;
+  /** Nested sub-menu items. Mutually exclusive with `onClick`. */
+  items?: ChromeNextHeaderBadgeMenuItem[];
+  /** Width of the nested sub-menu panel (in px). Only used when `items` is provided. */
+  popoverWidth?: number;
+  /** Test subject identifier. */
+  'data-test-subj'?: string;
+  /** Whether the item is disabled. */
+  disabled?: boolean;
+  /** Optional tooltip content. */
+  toolTipContent?: string;
+}
+
+export type ChromeNextHeaderBadge = ChromeNextHeaderBadgeWithClick | ChromeNextHeaderPopoverBadge;
 
 /**
  * A single metadata slot item — either plain text or an interactive button.

--- a/src/core/packages/chrome/browser/src/chrome_next/index.ts
+++ b/src/core/packages/chrome/browser/src/chrome_next/index.ts
@@ -13,6 +13,7 @@ export type { ChromeNextGlobalSearchConfig } from './global_search';
 export type {
   ChromeNextHeaderBack,
   ChromeNextHeaderBadge,
+  ChromeNextHeaderBadgeMenuItem,
   ChromeNextHeaderCallout,
   ChromeNextHeaderConfig,
   ChromeNextHeaderGlobalActions,

--- a/src/core/packages/chrome/browser/src/index.ts
+++ b/src/core/packages/chrome/browser/src/index.ts
@@ -65,6 +65,7 @@ export type {
   ChromeNextGlobalSearchConfig,
   ChromeNextHeaderBack,
   ChromeNextHeaderBadge,
+  ChromeNextHeaderBadgeMenuItem,
   ChromeNextHeaderCallout,
   ChromeNextHeaderConfig,
   ChromeNextHeaderGlobalActions,


### PR DESCRIPTION
## Summary

This PR adds popover functionality to app badges.

<img width="553" height="214" alt="Screenshot 2026-04-30 at 22 25 55" src="https://github.com/user-attachments/assets/5c8d5030-f02d-493b-b735-9ea1523dc094" />
