### PR TITLE
[9.4] fix(streams): prevent unhandled rejection crash in features identification task (#265496)

### DIFF
--- a/x-pack/platform/plugins/shared/streams/server/lib/tasks/task_definitions/features_identification/index.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/tasks/task_definitions/features_identification/index.ts
@@ -437,11 +437,25 @@ export function createStreamsFeaturesIdentificationTask(taskContext: TaskContext
 
                 const existingFeatures = allExistingFeatures.filter((f) => !isComputedFeature(f));
 
-                const [
-                  { features: inferredFeatures, tokensUsed: totalTokensUsed },
-                  computedFeatures,
-                ] = await Promise.all([
-                  identifyStreamFeatures({
+                // Attach `.catch` eagerly so this floating promise can never
+                // become an unhandled rejection if `identifyStreamFeatures`
+                // throws before we reach the `await`.
+                const computedFeaturesPromise = generateAllComputedFeatures({
+                  stream,
+                  start,
+                  end,
+                  esClient,
+                  logger: taskContext.logger.get('computed_features', streamName),
+                }).catch((err) => {
+                  taskLogger.error(
+                    `Computed features generation failed: ${parseError(err).message}`,
+                    { error: err } as LogMeta
+                  );
+                  return [] as Awaited<ReturnType<typeof generateAllComputedFeatures>>;
+                });
+
+                const { features: inferredFeatures, tokensUsed: totalTokensUsed } =
+                  await identifyStreamFeatures({
                     streamName: stream.name,
                     esClient,
                     start,
@@ -491,20 +505,12 @@ export function createStreamsFeaturesIdentificationTask(taskContext: TaskContext
                       });
                       hasTrackedIteration = true;
                     },
-                  }),
-                  generateAllComputedFeatures({
-                    stream,
-                    start,
-                    end,
-                    esClient,
-                    logger: taskContext.logger.get('computed_features', streamName),
-                  }),
-                ]);
+                  });
 
                 const durationMs = Date.now() - new Date(_task.created_at).getTime();
 
                 const reconciledComputedFeatures = reconcileComputedFeatures({
-                  computedFeatures,
+                  computedFeatures: await computedFeaturesPromise,
                   streamName,
                 });
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [fix(streams): prevent unhandled rejection crash in features identification task (#265496)](https://github.com/elastic/kibana/pull/265496)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Nicolas Ruflin","email":"ruflin@elastic.co"},"sourceCommit":{"committedDate":"2026-04-27T09:00:47Z","message":"fix(streams): prevent unhandled rejection crash in features identification task (#265496)\n\n## Symptom\n\nDuring onboarding, Kibana crashes with an unhandled promise rejection:\n\n    Unhandled Promise rejection detected:\n    {\n      name: 'ResponseError',\n      message: 'index_not_found_exception\\n\\tRoot causes:\\n' +\n        '\\t\\tindex_not_found_exception: no such index [logs.otel]',\n      ...\nat KibanaTransport._request\n(.../@elastic/transport/src/Transport.ts:649:17)\nat processTicksAndRejections (node:internal/process/task_queues:105:5)\n    }\n    Terminating process...\n     server crashed  with status code 1\n\nThe same crash also occurs for `logs.ecs`. The stack has no app-level\nframes — a classic signature of a floating (orphaned) promise whose\nrejection has no `.catch` on its microtask chain.\n\n## Why it started happening\n\nSince #260387 (\"Enable wired streams by default\") the `logs.ecs` and\n`logs.otel` wired stream definitions are present on every fresh install,\nbut their backing data streams are only materialized when the user\nactually onboards data. As a maintainer noted: \"a stream can always be\nmissing its underlying data stream, that's an invariant that's handled\nthroughout the code\". The features identification task violated that\ninvariant in a way that happened to be latent until wired streams were\nenabled by default.\n\n## Root cause\n\n`runFeaturesIdentification` creates a floating promise for the computed\nfeatures path and only attaches its `.catch` later, at the `await` site:\n\n    // line ~151 (before)\n    const computedFeaturesPromise = identifyComputedFeatures({ ... });\n\n    // line ~165 — for-loop that runs `identifyInferredFeatures`\n    for (let i = 0; i < maxIterations; i++) {\n      const result = await identifyInferredFeatures({ ... });\n      ...\n    }\n\n    // line ~213 — catch attached here\nconst reconciled = await computedFeaturesPromise.catch((err) => { ...\n});\n\nBoth code paths ultimately query Elasticsearch using the stream name as\nan index (`logs.otel` / `logs.ecs`):\n\n- `identifyInferredFeatures` -> `fetchSampleDocuments` ->\n`getSampleDocuments`\n- `identifyComputedFeatures` -> `generateAllComputedFeatures` -> e.g.\n`datasetAnalysisGenerator.generate` -> `describeDataset({ index:\nstream.name })`\n\nWhen the backing data stream doesn't exist yet, both reject with\n`index_not_found_exception`. The race is:\n\n1. The for-loop's `await identifyInferredFeatures(...)` throws first.\n2. Control jumps to the outer `catch (error)` on line 224. The `await`\non `computedFeaturesPromise` at line 213 is never reached, so its\n`.catch` is never attached.\n3. `computedFeaturesPromise` rejects a moment later with the same\n`index_not_found_exception`. With no handler attached, Node emits\n`unhandledRejection` and Kibana's policy terminates the process.\n\nThis also explains why the crash consistently surfaces right after\n\"Kibana is now available (was degraded)\": that is when Task Manager\nstarts running the scheduled features identification task against a\nstill-empty backing data stream.\n\n## Fix\n\nAttach `.catch` eagerly at promise creation so the promise can never\nbecome an unhandled rejection, regardless of how the surrounding control\nflow exits. Semantically identical to the previous behavior (same\nwarning log, same `[]` fallback) — just robust against the loop throwing\nbefore the `await`. The later consumer becomes a plain `await\ncomputedFeaturesPromise`.\n\nThis addresses the immediate crash. A follow-up should still make the\nstreams plugin treat `isNotFoundError` as \"no backing data stream yet,\nnothing to analyze\" in `identifyComputedFeatures` and in the inferred-\nfeatures loop, matching the invariant used elsewhere in the plugin (e.g.\n`read_stream.ts`, `wired_stream.getMatchingDataStream`,\n`failure_store/route_helpers.ts`).\n\n## Summary\n\nSummarize your PR. If it involves visual changes include a screenshot or\ngif.\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...","sha":"1133e60c645e4158e8f2b210b42ae01c82e00a52","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","backport:version","v9.4.0","Feature:SigEvents","backport:prev-minor","v9.5.0"],"title":"fix(streams): prevent unhandled rejection crash in features identification task","number":265496,"url":"https://github.com/elastic/kibana/pull/265496","mergeCommit":{"message":"fix(streams): prevent unhandled rejection crash in features identification task (#265496)\n\n## Symptom\n\nDuring onboarding, Kibana crashes with an unhandled promise rejection:\n\n    Unhandled Promise rejection detected:\n    {\n      name: 'ResponseError',\n      message: 'index_not_found_exception\\n\\tRoot causes:\\n' +\n        '\\t\\tindex_not_found_exception: no such index [logs.otel]',\n      ...\nat KibanaTransport._request\n(.../@elastic/transport/src/Transport.ts:649:17)\nat processTicksAndRejections (node:internal/process/task_queues:105:5)\n    }\n    Terminating process...\n     server crashed  with status code 1\n\nThe same crash also occurs for `logs.ecs`. The stack has no app-level\nframes — a classic signature of a floating (orphaned) promise whose\nrejection has no `.catch` on its microtask chain.\n\n## Why it started happening\n\nSince #260387 (\"Enable wired streams by default\") the `logs.ecs` and\n`logs.otel` wired stream definitions are present on every fresh install,\nbut their backing data streams are only materialized when the user\nactually onboards data. As a maintainer noted: \"a stream can always be\nmissing its underlying data stream, that's an invariant that's handled\nthroughout the code\". The features identification task violated that\ninvariant in a way that happened to be latent until wired streams were\nenabled by default.\n\n## Root cause\n\n`runFeaturesIdentification` creates a floating promise for the computed\nfeatures path and only attaches its `.catch` later, at the `await` site:\n\n    // line ~151 (before)\n    const computedFeaturesPromise = identifyComputedFeatures({ ... });\n\n    // line ~165 — for-loop that runs `identifyInferredFeatures`\n    for (let i = 0; i < maxIterations; i++) {\n      const result = await identifyInferredFeatures({ ... });\n      ...\n    }\n\n    // line ~213 — catch attached here\nconst reconciled = await computedFeaturesPromise.catch((err) => { ...\n});\n\nBoth code paths ultimately query Elasticsearch using the stream name as\nan index (`logs.otel` / `logs.ecs`):\n\n- `identifyInferredFeatures` -> `fetchSampleDocuments` ->\n`getSampleDocuments`\n- `identifyComputedFeatures` -> `generateAllComputedFeatures` -> e.g.\n`datasetAnalysisGenerator.generate` -> `describeDataset({ index:\nstream.name })`\n\nWhen the backing data stream doesn't exist yet, both reject with\n`index_not_found_exception`. The race is:\n\n1. The for-loop's `await identifyInferredFeatures(...)` throws first.\n2. Control jumps to the outer `catch (error)` on line 224. The `await`\non `computedFeaturesPromise` at line 213 is never reached, so its\n`.catch` is never attached.\n3. `computedFeaturesPromise` rejects a moment later with the same\n`index_not_found_exception`. With no handler attached, Node emits\n`unhandledRejection` and Kibana's policy terminates the process.\n\nThis also explains why the crash consistently surfaces right after\n\"Kibana is now available (was degraded)\": that is when Task Manager\nstarts running the scheduled features identification task against a\nstill-empty backing data stream.\n\n## Fix\n\nAttach `.catch` eagerly at promise creation so the promise can never\nbecome an unhandled rejection, regardless of how the surrounding control\nflow exits. Semantically identical to the previous behavior (same\nwarning log, same `[]` fallback) — just robust against the loop throwing\nbefore the `await`. The later consumer becomes a plain `await\ncomputedFeaturesPromise`.\n\nThis addresses the immediate crash. A follow-up should still make the\nstreams plugin treat `isNotFoundError` as \"no backing data stream yet,\nnothing to analyze\" in `identifyComputedFeatures` and in the inferred-\nfeatures loop, matching the invariant used elsewhere in the plugin (e.g.\n`read_stream.ts`, `wired_stream.getMatchingDataStream`,\n`failure_store/route_helpers.ts`).\n\n## Summary\n\nSummarize your PR. If it involves visual changes include a screenshot or\ngif.\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...","sha":"1133e60c645e4158e8f2b210b42ae01c82e00a52"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/265496","number":265496,"mergeCommit":{"message":"fix(streams): prevent unhandled rejection crash in features identification task (#265496)\n\n## Symptom\n\nDuring onboarding, Kibana crashes with an unhandled promise rejection:\n\n    Unhandled Promise rejection detected:\n    {\n      name: 'ResponseError',\n      message: 'index_not_found_exception\\n\\tRoot causes:\\n' +\n        '\\t\\tindex_not_found_exception: no such index [logs.otel]',\n      ...\nat KibanaTransport._request\n(.../@elastic/transport/src/Transport.ts:649:17)\nat processTicksAndRejections (node:internal/process/task_queues:105:5)\n    }\n    Terminating process...\n     server crashed  with status code 1\n\nThe same crash also occurs for `logs.ecs`. The stack has no app-level\nframes — a classic signature of a floating (orphaned) promise whose\nrejection has no `.catch` on its microtask chain.\n\n## Why it started happening\n\nSince #260387 (\"Enable wired streams by default\") the `logs.ecs` and\n`logs.otel` wired stream definitions are present on every fresh install,\nbut their backing data streams are only materialized when the user\nactually onboards data. As a maintainer noted: \"a stream can always be\nmissing its underlying data stream, that's an invariant that's handled\nthroughout the code\". The features identification task violated that\ninvariant in a way that happened to be latent until wired streams were\nenabled by default.\n\n## Root cause\n\n`runFeaturesIdentification` creates a floating promise for the computed\nfeatures path and only attaches its `.catch` later, at the `await` site:\n\n    // line ~151 (before)\n    const computedFeaturesPromise = identifyComputedFeatures({ ... });\n\n    // line ~165 — for-loop that runs `identifyInferredFeatures`\n    for (let i = 0; i < maxIterations; i++) {\n      const result = await identifyInferredFeatures({ ... });\n      ...\n    }\n\n    // line ~213 — catch attached here\nconst reconciled = await computedFeaturesPromise.catch((err) => { ...\n});\n\nBoth code paths ultimately query Elasticsearch using the stream name as\nan index (`logs.otel` / `logs.ecs`):\n\n- `identifyInferredFeatures` -> `fetchSampleDocuments` ->\n`getSampleDocuments`\n- `identifyComputedFeatures` -> `generateAllComputedFeatures` -> e.g.\n`datasetAnalysisGenerator.generate` -> `describeDataset({ index:\nstream.name })`\n\nWhen the backing data stream doesn't exist yet, both reject with\n`index_not_found_exception`. The race is:\n\n1. The for-loop's `await identifyInferredFeatures(...)` throws first.\n2. Control jumps to the outer `catch (error)` on line 224. The `await`\non `computedFeaturesPromise` at line 213 is never reached, so its\n`.catch` is never attached.\n3. `computedFeaturesPromise` rejects a moment later with the same\n`index_not_found_exception`. With no handler attached, Node emits\n`unhandledRejection` and Kibana's policy terminates the process.\n\nThis also explains why the crash consistently surfaces right after\n\"Kibana is now available (was degraded)\": that is when Task Manager\nstarts running the scheduled features identification task against a\nstill-empty backing data stream.\n\n## Fix\n\nAttach `.catch` eagerly at promise creation so the promise can never\nbecome an unhandled rejection, regardless of how the surrounding control\nflow exits. Semantically identical to the previous behavior (same\nwarning log, same `[]` fallback) — just robust against the loop throwing\nbefore the `await`. The later consumer becomes a plain `await\ncomputedFeaturesPromise`.\n\nThis addresses the immediate crash. A follow-up should still make the\nstreams plugin treat `isNotFoundError` as \"no backing data stream yet,\nnothing to analyze\" in `identifyComputedFeatures` and in the inferred-\nfeatures loop, matching the invariant used elsewhere in the plugin (e.g.\n`read_stream.ts`, `wired_stream.getMatchingDataStream`,\n`failure_store/route_helpers.ts`).\n\n## Summary\n\nSummarize your PR. If it involves visual changes include a screenshot or\ngif.\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...","sha":"1133e60c645e4158e8f2b210b42ae01c82e00a52"}}]}] BACKPORT-->