### PR TITLE
experiment: try out n4 machineTypes for FTR

### DIFF
--- a/.buildkite/ftr_oblt_serverless_configs.yml
+++ b/.buildkite/ftr_oblt_serverless_configs.yml
@@ -9,7 +9,7 @@ disabled:
   # Empty configs
   - x-pack/solutions/observability/test/serverless/api_integration/configs/config.feature_flags.ts
 
-defaultQueue: 'n2-4-spot'
+defaultQueue: 'n4-4-spot'
 enabled:
   - x-pack/solutions/observability/test/serverless/api_integration/configs/config.ts
   - x-pack/solutions/observability/test/serverless/api_integration/configs/config.logs_essentials.ts

--- a/.buildkite/ftr_oblt_stateful_configs.yml
+++ b/.buildkite/ftr_oblt_stateful_configs.yml
@@ -16,7 +16,7 @@ disabled:
   # Observability AI Assistant local-only tests
   - x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/stateful/oblt.ai_assistant_local.stateful.config.ts
 
-defaultQueue: 'n2-4-spot'
+defaultQueue: 'n4-4-spot'
 enabled:
   - x-pack/solutions/observability/test/alerting_api_integration/observability/config.ts
   - x-pack/solutions/observability/test/api_integration/apis/logs_ui/config.ts

--- a/.buildkite/ftr_platform_stateful_configs.yml
+++ b/.buildkite/ftr_platform_stateful_configs.yml
@@ -61,7 +61,7 @@ disabled:
   - x-pack/platform/test/functional_gen_ai/inference/generate_artifacts.config.ts
   - x-pack/platform/test/agent_builder/smoke_tests/config.stateful.ts
 
-defaultQueue: 'n2-4-spot'
+defaultQueue: 'n4-4-spot'
 enabled:
   - src/platform/test/accessibility/config.ts
   - src/platform/test/analytics/config.ts

--- a/.buildkite/ftr_search_serverless_configs.yml
+++ b/.buildkite/ftr_search_serverless_configs.yml
@@ -2,7 +2,7 @@ disabled:
   # Base config files, only necessary to inform config finding script
   - x-pack/platform/test/serverless/functional/config.search.base.ts
 
-defaultQueue: 'n2-4-spot'
+defaultQueue: 'n4-4-spot'
 enabled:
   - x-pack/solutions/search/test/serverless/api_integration/configs/config.ts
   - x-pack/solutions/search/test/serverless/functional/configs/config.ts

--- a/.buildkite/ftr_search_stateful_configs.yml
+++ b/.buildkite/ftr_search_stateful_configs.yml
@@ -2,7 +2,7 @@ disabled:
   # Base config files, only necessary to inform config finding script
   - x-pack/solutions/search/test/api_integration/config.ts
 
-defaultQueue: 'n2-4-spot'
+defaultQueue: 'n4-4-spot'
 enabled:
   - x-pack/solutions/search/test/functional_search/config.ts
   - x-pack/solutions/search/test/functional_search/config/config.basic.ts

--- a/.buildkite/ftr_security_serverless_configs.yml
+++ b/.buildkite/ftr_security_serverless_configs.yml
@@ -28,7 +28,7 @@ disabled:
   - x-pack/solutions/security/test/serverless/api_integration/configs/config.feature_flags.ts
   - x-pack/solutions/security/test/serverless/functional/configs/config.feature_flags.ts
 
-defaultQueue: 'n2-4-spot'
+defaultQueue: 'n4-4-spot'
 enabled:
   - x-pack/solutions/security/test/serverless/api_integration/configs/config.ts
   - x-pack/solutions/security/test/serverless/api_integration/configs/config.graph.ts
@@ -150,7 +150,7 @@ enabled:
   - x-pack/solutions/security/test/security_solution_api_integration/test_suites/investigation/timeline/trial_license_complete_tier/configs/serverless.config.ts
   - x-pack/solutions/security/test/security_solution_api_integration/test_suites/sources/indices/trial_license_complete_tier/configs/serverless.config.ts
   - x-pack/solutions/security/test/security_solution_api_integration/test_suites/edr_workflows/artifacts/trial_license_complete_tier/configs/serverless.config.ts:
-      queue: n2-4-spot
+      queue: n4-4-spot
   - x-pack/solutions/security/test/security_solution_api_integration/test_suites/edr_workflows/authentication/trial_license_complete_tier/configs/serverless.config.ts
   - x-pack/solutions/security/test/security_solution_api_integration/test_suites/edr_workflows/artifacts/trial_license_complete_tier/configs/endpoint_exceptions_moved_ff.serverless.config.ts
   - x-pack/solutions/security/test/security_solution_api_integration/test_suites/edr_workflows/metadata/trial_license_complete_tier/configs/serverless.config.ts

--- a/.buildkite/ftr_security_stateful_configs.yml
+++ b/.buildkite/ftr_security_stateful_configs.yml
@@ -36,7 +36,7 @@ disabled:
   # Detection Rules Management OOM Testing
   - x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/oom_testing/configs/ess_basic_license.config.ts
 
-defaultQueue: 'n2-4-spot'
+defaultQueue: 'n4-4-spot'
 enabled:
   - x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/detection_engine/actions/trial_license_complete_tier/configs/ess.config.ts
   - x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/detection_engine/alerts/basic_license_essentials_tier/configs/ess.config.ts
@@ -119,7 +119,7 @@ enabled:
   - x-pack/solutions/security/test/security_solution_api_integration/test_suites/investigation/timeline/basic_license_essentials_tier/configs/ess.config.ts
   - x-pack/solutions/security/test/security_solution_api_integration/test_suites/sources/indices/trial_license_complete_tier/configs/ess.config.ts
   - x-pack/solutions/security/test/security_solution_api_integration/test_suites/edr_workflows/artifacts/trial_license_complete_tier/configs/ess.config.ts:
-      queue: n2-4-spot
+      queue: n4-4-spot
   - x-pack/solutions/security/test/security_solution_api_integration/test_suites/edr_workflows/artifacts/trial_license_complete_tier/configs/endpoint_exceptions_moved_ff.ess.config.ts
   - x-pack/solutions/security/test/security_solution_api_integration/test_suites/edr_workflows/authentication/trial_license_complete_tier/configs/ess.config.ts
   - x-pack/solutions/security/test/security_solution_api_integration/test_suites/edr_workflows/metadata/trial_license_complete_tier/configs/ess.config.ts

--- a/.buildkite/ftr_workplace_ai_serverless_configs.yml
+++ b/.buildkite/ftr_workplace_ai_serverless_configs.yml
@@ -6,7 +6,7 @@ disabled:
   - x-pack/solutions/workplaceai/test/serverless/functional/configs/config.feature_flags.ts
   - x-pack/solutions/workplaceai/test/serverless/api_integration/configs/config.feature_flags.ts
 
-defaultQueue: 'n2-4-spot'
+defaultQueue: 'n4-4-spot'
 enabled:
   - x-pack/solutions/workplaceai/test/serverless/api_integration/configs/config.ts
   - x-pack/platform/test/serverless/api_integration/configs/workplaceai/config.group1.ts

--- a/.buildkite/pipeline-utils/agent_images.test.ts
+++ b/.buildkite/pipeline-utils/agent_images.test.ts
@@ -134,7 +134,8 @@ describe('agent_images', () => {
 
       expect(config).toEqual(
         expect.objectContaining({
-          machineType: 'n2-standard-4',
+          machineType: 'n4-standard-4',
+          diskType: 'hyperdisk-balanced',
           preemptible: true,
           provider: DEFAULT_AGENT_IMAGE_CONFIG.provider,
         })
@@ -147,6 +148,7 @@ describe('agent_images', () => {
       expect(config).toEqual(
         expect.objectContaining({
           machineType: 'n2-standard-4',
+          diskType: 'hyperdisk-balanced',
           enableNestedVirtualization: true,
         })
       );
@@ -164,6 +166,7 @@ describe('agent_images', () => {
       expect(config).toEqual(
         expect.objectContaining({
           machineType: 'c2-standard-8',
+          diskType: 'hyperdisk-balanced',
           provider: DEFAULT_AGENT_IMAGE_CONFIG.provider,
         })
       );

--- a/.buildkite/pipeline-utils/agent_images.test.ts
+++ b/.buildkite/pipeline-utils/agent_images.test.ts
@@ -148,10 +148,10 @@ describe('agent_images', () => {
       expect(config).toEqual(
         expect.objectContaining({
           machineType: 'n2-standard-4',
-          diskType: 'hyperdisk-balanced',
           enableNestedVirtualization: true,
         })
       );
+      expect(config).not.toHaveProperty('diskType');
     });
 
     it('uses custom disk size when provided', () => {
@@ -166,11 +166,11 @@ describe('agent_images', () => {
       expect(config).toEqual(
         expect.objectContaining({
           machineType: 'c2-standard-8',
-          diskType: 'hyperdisk-balanced',
           provider: DEFAULT_AGENT_IMAGE_CONFIG.provider,
         })
       );
       expect(config).not.toHaveProperty('preemptible');
+      expect(config).not.toHaveProperty('diskType');
       expect(config).not.toHaveProperty('enableNestedVirtualization');
     });
   });

--- a/.buildkite/pipeline-utils/agent_images.test.ts
+++ b/.buildkite/pipeline-utils/agent_images.test.ts
@@ -136,6 +136,7 @@ describe('agent_images', () => {
         expect.objectContaining({
           machineType: 'n4-standard-4',
           diskType: 'hyperdisk-balanced',
+          zones: 'us-central1-a,us-east4-b,us-east1-b',
           preemptible: true,
           provider: DEFAULT_AGENT_IMAGE_CONFIG.provider,
         })

--- a/.buildkite/pipeline-utils/agent_images.ts
+++ b/.buildkite/pipeline-utils/agent_images.ts
@@ -92,6 +92,7 @@ const expandAgentQueue = (queueName: string = 'n4-4-spot', diskSizeGb?: number) 
   return {
     ...getAgentImageConfig(),
     machineType: `${kind}-standard-${cores}`,
+    diskType: 'hyperdisk-balanced',
     ...(diskSizeGb ? { diskSizeGb } : {}),
     ...additionalProps,
   };

--- a/.buildkite/pipeline-utils/agent_images.ts
+++ b/.buildkite/pipeline-utils/agent_images.ts
@@ -80,7 +80,7 @@ function getAgentImageConfig({ returnYaml = false } = {}): string | BuildkiteAge
   return config;
 }
 
-const expandAgentQueue = (queueName: string = 'n2-4-spot', diskSizeGb?: number) => {
+const expandAgentQueue = (queueName: string = 'n4-4-spot', diskSizeGb?: number) => {
   const [kind, cores, addition] = queueName.split('-');
   const zonesToUse = 'southamerica-east1-c,asia-south2-a,us-central1-f';
   const additionalProps =

--- a/.buildkite/pipeline-utils/agent_images.ts
+++ b/.buildkite/pipeline-utils/agent_images.ts
@@ -95,7 +95,9 @@ const expandAgentQueue = (queueName: string = 'n4-4-spot', diskSizeGb?: number) 
   return {
     ...getAgentImageConfig(),
     machineType: `${kind}-standard-${cores}`,
-    ...(kind === 'n4' ? { diskType: 'hyperdisk-balanced' } : {}),
+    ...(kind === 'n4'
+      ? { diskType: 'hyperdisk-balanced', zones: 'us-central1-a,us-east4-b,us-east1-b' }
+      : {}),
     ...(diskSizeGb ? { diskSizeGb } : {}),
     ...additionalProps,
   };

--- a/.buildkite/pipeline-utils/agent_images.ts
+++ b/.buildkite/pipeline-utils/agent_images.ts
@@ -82,7 +82,10 @@ function getAgentImageConfig({ returnYaml = false } = {}): string | BuildkiteAge
 
 const expandAgentQueue = (queueName: string = 'n4-4-spot', diskSizeGb?: number) => {
   const [kind, cores, addition] = queueName.split('-');
-  const zonesToUse = 'southamerica-east1-c,asia-south2-a,us-central1-f';
+  const zonesToUse =
+    kind === 'n4'
+      ? 'us-central1-a,us-east4-b,us-east1-b'
+      : 'southamerica-east1-c,asia-south2-a,us-central1-f';
   const additionalProps =
     {
       spot: { preemptible: true, zones: zonesToUse },
@@ -92,7 +95,7 @@ const expandAgentQueue = (queueName: string = 'n4-4-spot', diskSizeGb?: number) 
   return {
     ...getAgentImageConfig(),
     machineType: `${kind}-standard-${cores}`,
-    diskType: 'hyperdisk-balanced',
+    ...(kind === 'n4' ? { diskType: 'hyperdisk-balanced' } : {}),
     ...(diskSizeGb ? { diskSizeGb } : {}),
     ...additionalProps,
   };

--- a/.buildkite/pipeline-utils/buildkite/client.ts
+++ b/.buildkite/pipeline-utils/buildkite/client.ts
@@ -52,6 +52,7 @@ export interface BuildkiteAgentTargetingRule {
   minCpuPlatform?: string;
   preemptible?: boolean;
   diskSizeGb?: number;
+  diskType?: string;
 }
 
 export interface BuildkiteCommandStep {

--- a/.buildkite/pipelines/pull_request/agent_builder_smoke_tests.yml
+++ b/.buildkite/pipelines/pull_request/agent_builder_smoke_tests.yml
@@ -11,9 +11,11 @@ steps:
         env:
           FTR_EIS_CCM: '1'
         agents:
-          machineType: n2-standard-2
+          machineType: n4-standard-2
+          diskType: hyperdisk-balanced
+          zones: us-central1-a,us-east4-b,us-east1-b
           preemptible: true
-          spotZones: us-central1-f,us-central1-c,us-central1-b,us-central1-a
+          spotZones: us-central1-a,us-east4-b,us-east1-b
         artifact_paths:
           - 'target/eis_models.json'
         retry:
@@ -38,9 +40,11 @@ steps:
         timeout_in_minutes: 50
         parallelism: 1
         agents:
-          machineType: n2-standard-4
+          machineType: n4-standard-4
+          diskType: hyperdisk-balanced
+          zones: us-central1-a,us-east4-b,us-east1-b
           preemptible: true
-          spotZones: us-central1-f,us-central1-c,us-central1-a
+          spotZones: us-central1-a,us-east4-b,us-east1-b
         retry:
           automatic:
             - exit_status: '-1'

--- a/.buildkite/pipelines/pull_request/ai_infra_gen_ai.yml
+++ b/.buildkite/pipelines/pull_request/ai_infra_gen_ai.yml
@@ -14,9 +14,11 @@ steps:
         timeout_in_minutes: 50
         parallelism: 1
         agents:
-          machineType: n2-standard-4
+          machineType: n4-standard-4
+          diskType: hyperdisk-balanced
+          zones: us-central1-a,us-east4-b,us-east1-b
           preemptible: true
-          spotZones: us-central1-f,us-central1-c,us-central1-a
+          spotZones: us-central1-a,us-east4-b,us-east1-b
         retry:
           automatic:
             - exit_status: '-1'

--- a/.buildkite/pipelines/pull_request/api_contracts.yml
+++ b/.buildkite/pipelines/pull_request/api_contracts.yml
@@ -2,10 +2,11 @@ steps:
   - command: .buildkite/scripts/steps/checks/api_contracts.sh
     label: 'Check API Contracts'
     agents:
-      machineType: c4d-standard-2
+      machineType: n4-standard-2
+      zones: us-central1-a,us-east4-b,us-east1-b
       diskType: hyperdisk-balanced
       preemptible: true
-      spotZones: us-central1-c,us-central1-a
+      spotZones: us-central1-a,us-east4-b,us-east1-b
     key: check_api_contracts
     depends_on: check_oas_snapshot
     timeout_in_minutes: 30

--- a/.buildkite/pipelines/pull_request/apm_cypress.yml
+++ b/.buildkite/pipelines/pull_request/apm_cypress.yml
@@ -3,9 +3,11 @@ steps:
     label: 'APM Cypress Tests'
     key: apm-cypress
     agents:
-      machineType: n2-standard-4
+      machineType: n4-standard-4
+      diskType: hyperdisk-balanced
+      zones: us-central1-a,us-east4-b,us-east1-b
       preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
+      spotZones: us-central1-a,us-east4-b,us-east1-b
     depends_on:
       - build
     timeout_in_minutes: 60

--- a/.buildkite/pipelines/pull_request/base.yml
+++ b/.buildkite/pipelines/pull_request/base.yml
@@ -2,9 +2,9 @@ steps:
   - command: .buildkite/scripts/steps/build_kibana.sh
     label: Build Kibana Distribution
     agents:
-      machineType: c4d-standard-16
+      machineType: n4-standard-16
       diskType: hyperdisk-balanced
-      zones: us-central1-a,us-central1-b,us-central1-c
+      zones: us-central1-a,us-east4-b,us-east1-b
       diskSizeGb: 200
     key: build
     if: "build.env('KIBANA_BUILD_ID') == null || build.env('KIBANA_BUILD_ID') == ''"
@@ -32,9 +32,11 @@ steps:
   - command: .buildkite/scripts/steps/quick_checks.sh
     label: 'Quick Checks'
     agents:
-      machineType: n2d-standard-8
+      machineType: n4-standard-8
+      diskType: hyperdisk-balanced
+      zones: us-central1-a,us-east4-b,us-east1-b
       preemptible: true
-      spotZones: us-central1-b,us-central1-c,us-central1-f
+      spotZones: us-central1-a,us-east4-b,us-east1-b
       diskSizeGb: 105
     key: quick_checks
     timeout_in_minutes: 60
@@ -51,9 +53,11 @@ steps:
     env:
       CHECK_GATE: 'true'
     agents:
-      machineType: n2d-standard-2
+      machineType: n4-standard-2
+      diskType: hyperdisk-balanced
+      zones: us-central1-a,us-east4-b,us-east1-b
       preemptible: true
-      spotZones: us-central1-b,us-central1-c,us-central1-f
+      spotZones: us-central1-a,us-east4-b,us-east1-b
       diskSizeGb: 105
     timeout_in_minutes: 60
     retry:
@@ -64,9 +68,11 @@ steps:
   - command: .buildkite/scripts/steps/lint.sh
     label: 'Linting'
     agents:
-      machineType: n2d-standard-16
+      machineType: n4-standard-16
+      diskType: hyperdisk-balanced
+      zones: us-central1-a,us-east4-b,us-east1-b
       preemptible: true
-      spotZones: us-central1-b,us-central1-c,us-central1-f
+      spotZones: us-central1-a,us-east4-b,us-east1-b
       diskSizeGb: 105
     key: linting
     timeout_in_minutes: 60
@@ -80,9 +86,11 @@ steps:
   - command: .buildkite/scripts/steps/lint_with_types.sh
     label: 'Linting (with types)'
     agents:
-      machineType: n2d-standard-32
+      machineType: n4-standard-32
+      diskType: hyperdisk-balanced
+      zones: us-central1-a,us-east4-b,us-east1-b
       preemptible: true
-      spotZones: us-central1-b,us-central1-c,us-central1-f
+      spotZones: us-central1-a,us-east4-b,us-east1-b
       diskSizeGb: 105
     key: linting_with_types
     timeout_in_minutes: 60
@@ -96,9 +104,11 @@ steps:
   - command: .buildkite/scripts/steps/lint_with_oxlint.sh
     label: 'Linting (with oxlint)'
     agents:
-      machineType: n2d-standard-16
+      machineType: n4-standard-16
+      diskType: hyperdisk-balanced
+      zones: us-central1-a,us-east4-b,us-east1-b
       preemptible: true
-      spotZones: us-central1-b,us-central1-c
+      spotZones: us-central1-a,us-east4-b,us-east1-b
       diskSizeGb: 105
     key: linting_with_oxlint
     timeout_in_minutes: 60
@@ -112,9 +122,11 @@ steps:
   - command: .buildkite/scripts/steps/checks/capture_oas_snapshot.sh
     label: 'Check OAS Snapshot'
     agents:
-      machineType: n2d-standard-2
+      machineType: n4-standard-2
+      diskType: hyperdisk-balanced
+      zones: us-central1-a,us-east4-b,us-east1-b
       preemptible: true
-      spotZones: us-central1-b,us-central1-c,us-central1-f
+      spotZones: us-central1-a,us-east4-b,us-east1-b
     key: check_oas_snapshot
     depends_on:
       - build
@@ -129,9 +141,11 @@ steps:
   - command: .buildkite/scripts/steps/typecheck/check_types.sh
     label: 'Check Types'
     agents:
-      machineType: c3d-standard-8-lssd
+      machineType: n4-standard-8
+      diskType: hyperdisk-balanced
+      zones: us-central1-a,us-east4-b,us-east1-b
       preemptible: true
-      spotZones: us-central1-b,us-central1-c,us-central1-f
+      spotZones: us-central1-a,us-east4-b,us-east1-b
       diskSizeGb: 105
     key: check_types
     timeout_in_minutes: 60
@@ -146,7 +160,9 @@ steps:
     label: 'Pick Test Group Run Order'
     key: pick_test_group_run_order
     agents:
-      machineType: n2-standard-2
+      machineType: n4-standard-2
+      diskType: hyperdisk-balanced
+      zones: us-central1-a,us-east4-b,us-east1-b
       diskSizeGb: 115
     timeout_in_minutes: 15
     env:
@@ -162,7 +178,9 @@ steps:
   - command: .buildkite/scripts/steps/test/scout/test_run_builder.sh
     label: 'Scout Test Run Builder'
     agents:
-      machineType: n2d-standard-8
+      machineType: n4-standard-8
+      diskType: hyperdisk-balanced
+      zones: us-central1-a,us-east4-b,us-east1-b
     key: build_scout_tests
     timeout_in_minutes: 20
     env:
@@ -178,7 +196,9 @@ steps:
   - command: .buildkite/scripts/steps/ci_stats_ready.sh
     label: Mark CI Stats as ready
     agents:
-      machineType: n2-standard-2
+      machineType: n4-standard-2
+      diskType: hyperdisk-balanced
+      zones: us-central1-a,us-east4-b,us-east1-b
     key: ci_stats_ready
     timeout_in_minutes: 10
     depends_on:
@@ -192,10 +212,11 @@ steps:
   - command: .buildkite/scripts/steps/api_docs/build_api_docs.sh
     label: 'Build API Docs'
     agents:
-      machineType: c4d-highmem-4
+      machineType: n4-highmem-4
+      zones: us-central1-a,us-east4-b,us-east1-b
       diskType: hyperdisk-balanced
       preemptible: true
-      spotZones: us-central1-a,us-central1-b,us-central1-c
+      spotZones: us-central1-a,us-east4-b,us-east1-b
       diskSizeGb: 105
     key: build_api_docs
     timeout_in_minutes: 60

--- a/.buildkite/pipelines/pull_request/build_cloud_fips_image.yml
+++ b/.buildkite/pipelines/pull_request/build_cloud_fips_image.yml
@@ -3,7 +3,9 @@ steps:
     label: 'Build Cloud FIPS Image'
     key: build_cloud_fips_image
     agents:
-      machineType: n2-standard-2
+      machineType: n4-standard-2
+      diskType: hyperdisk-balanced
+      zones: us-central1-a,us-east4-b,us-east1-b
       preemptible: true
     depends_on:
       - build

--- a/.buildkite/pipelines/pull_request/build_cloud_image.yml
+++ b/.buildkite/pipelines/pull_request/build_cloud_image.yml
@@ -3,7 +3,9 @@ steps:
     label: 'Build Cloud Image'
     key: build_cloud_image
     agents:
-      machineType: n2-standard-2
+      machineType: n4-standard-2
+      diskType: hyperdisk-balanced
+      zones: us-central1-a,us-east4-b,us-east1-b
       preemptible: true
     depends_on:
       - build

--- a/.buildkite/pipelines/pull_request/build_project.yml
+++ b/.buildkite/pipelines/pull_request/build_project.yml
@@ -3,7 +3,9 @@ steps:
     label: 'Build Project Image'
     key: build_project_image
     agents:
-      machineType: n2-standard-16
+      machineType: n4-standard-16
+      diskType: hyperdisk-balanced
+      zones: us-central1-a,us-east4-b,us-east1-b
       preemptible: true
       diskSizeGb: 150
     timeout_in_minutes: 90

--- a/.buildkite/pipelines/pull_request/check_next_docs.yml
+++ b/.buildkite/pipelines/pull_request/check_next_docs.yml
@@ -3,7 +3,9 @@ steps:
     label: 'Build and Validate Next Docs'
     key: check_next_docs
     agents:
-      machineType: n2-standard-4
+      machineType: n4-standard-4
+      diskType: hyperdisk-balanced
+      zones: us-central1-a,us-east4-b,us-east1-b
       preemptible: true
     timeout_in_minutes: 30
     retry:

--- a/.buildkite/pipelines/pull_request/check_saved_objects.yml
+++ b/.buildkite/pipelines/pull_request/check_saved_objects.yml
@@ -3,9 +3,11 @@ steps:
     label: 'Check changes in Saved Objects'
     key: check_saved_objects
     agents:
-      machineType: n2-standard-2
+      machineType: n4-standard-2
+      diskType: hyperdisk-balanced
+      zones: us-central1-a,us-east4-b,us-east1-b
       preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
+      spotZones: us-central1-a,us-east4-b,us-east1-b
     depends_on:
       - build
     timeout_in_minutes: 20

--- a/.buildkite/pipelines/pull_request/deploy_cloud.yml
+++ b/.buildkite/pipelines/pull_request/deploy_cloud.yml
@@ -3,7 +3,9 @@ steps:
     label: 'Build and Deploy to Cloud'
     key: deploy_cloud
     agents:
-      machineType: n2-standard-2
+      machineType: n4-standard-2
+      diskType: hyperdisk-balanced
+      zones: us-central1-a,us-east4-b,us-east1-b
       preemptible: true
     depends_on:
       - build

--- a/.buildkite/pipelines/pull_request/deploy_project.yml
+++ b/.buildkite/pipelines/pull_request/deploy_project.yml
@@ -3,7 +3,9 @@ steps:
     label: 'Build Project Image'
     key: build_project_image
     agents:
-      machineType: n2-standard-16
+      machineType: n4-standard-16
+      diskType: hyperdisk-balanced
+      zones: us-central1-a,us-east4-b,us-east1-b
       preemptible: true
       diskSizeGb: 150
     timeout_in_minutes: 90
@@ -15,7 +17,9 @@ steps:
     label: 'Deploy Project'
     key: deploy_project
     agents:
-      machineType: n2-standard-4
+      machineType: n4-standard-4
+      diskType: hyperdisk-balanced
+      zones: us-central1-a,us-east4-b,us-east1-b
       preemptible: true
     timeout_in_minutes: 10
     depends_on:

--- a/.buildkite/pipelines/pull_request/fips.yml
+++ b/.buildkite/pipelines/pull_request/fips.yml
@@ -3,9 +3,11 @@ steps:
     label: 'Build FIPS Image'
     key: build_fips_image
     agents:
-      machineType: n2-standard-2
+      machineType: n4-standard-2
+      diskType: hyperdisk-balanced
+      zones: us-central1-a,us-east4-b,us-east1-b
       preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
+      spotZones: us-central1-a,us-east4-b,us-east1-b
     depends_on:
       - build
     timeout_in_minutes: 60

--- a/.buildkite/pipelines/pull_request/fleet_cypress.yml
+++ b/.buildkite/pipelines/pull_request/fleet_cypress.yml
@@ -3,9 +3,11 @@ steps:
     label: 'Fleet Cypress Tests'
     key: fleet-cypress
     agents:
-      machineType: n2-standard-4
+      machineType: n4-standard-4
+      diskType: hyperdisk-balanced
+      zones: us-central1-a,us-east4-b,us-east1-b
       preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
+      spotZones: us-central1-a,us-east4-b,us-east1-b
     depends_on:
       - build
     timeout_in_minutes: 50

--- a/.buildkite/pipelines/pull_request/ftr_bench.yml
+++ b/.buildkite/pipelines/pull_request/ftr_bench.yml
@@ -3,9 +3,9 @@ steps:
     label: 'FTR Bench'
     key: ftr_bench
     agents:
-      machineType: c4d-standard-16
+      machineType: n4-standard-16
       diskType: hyperdisk-balanced
-      zones: us-central1-c,us-central1-a
+      zones: us-central1-a,us-east4-b,us-east1-b
       diskSizeGb: 200
     timeout_in_minutes: 120
     soft_fail: true

--- a/.buildkite/pipelines/pull_request/jest_bench.yml
+++ b/.buildkite/pipelines/pull_request/jest_bench.yml
@@ -3,9 +3,9 @@ steps:
     label: 'Jest Bench'
     key: jest_bench
     agents:
-      machineType: c4d-standard-16
+      machineType: n4-standard-16
       diskType: hyperdisk-balanced
-      zones: us-central1-c,us-central1-a
+      zones: us-central1-a,us-east4-b,us-east1-b
       diskSizeGb: 100
     timeout_in_minutes: 60
     soft_fail: true

--- a/.buildkite/pipelines/pull_request/kbn_handlebars.yml
+++ b/.buildkite/pipelines/pull_request/kbn_handlebars.yml
@@ -3,9 +3,11 @@ steps:
     label: 'Check @kbn/handlebars for upstream differences'
     key: kbn_handlebars
     agents:
-      machineType: n2-standard-2
+      machineType: n4-standard-2
+      diskType: hyperdisk-balanced
+      zones: us-central1-a,us-east4-b,us-east1-b
       preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
+      spotZones: us-central1-a,us-east4-b,us-east1-b
     depends_on:
       - build
     timeout_in_minutes: 5

--- a/.buildkite/pipelines/pull_request/post_build.yml
+++ b/.buildkite/pipelines/pull_request/post_build.yml
@@ -5,4 +5,6 @@ steps:
   - command: .buildkite/scripts/lifecycle/post_build.sh
     label: Post-Build
     agents:
-      machineType: n2-standard-2
+      machineType: n4-standard-2
+      diskType: hyperdisk-balanced
+      zones: us-central1-a,us-east4-b,us-east1-b

--- a/.buildkite/pipelines/pull_request/prompt_changes.yml
+++ b/.buildkite/pipelines/pull_request/prompt_changes.yml
@@ -3,9 +3,11 @@ steps:
     label: 'Check Prompt Changes'
     key: prompt_changes
     agents:
-      machineType: n2-standard-2
+      machineType: n4-standard-2
+      diskType: hyperdisk-balanced
+      zones: us-central1-a,us-east4-b,us-east1-b
       preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
+      spotZones: us-central1-a,us-east4-b,us-east1-b
       diskSizeGb: 115
     timeout_in_minutes: 10
     retry:

--- a/.buildkite/pipelines/pull_request/renovate.yml
+++ b/.buildkite/pipelines/pull_request/renovate.yml
@@ -2,9 +2,11 @@ steps:
   - command: .buildkite/scripts/steps/renovate.sh
     label: 'Renovate validation'
     agents:
-      machineType: n2-highcpu-8
+      machineType: n4-highcpu-8
+      diskType: hyperdisk-balanced
+      zones: us-central1-a,us-east4-b,us-east1-b
       preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
+      spotZones: us-central1-a,us-east4-b,us-east1-b
     key: renovate_validation
     timeout_in_minutes: 60
     retry:

--- a/.buildkite/pipelines/pull_request/response_ops.yml
+++ b/.buildkite/pipelines/pull_request/response_ops.yml
@@ -3,9 +3,11 @@ steps:
     label: 'Rules, Alerts and Exceptions ResponseOps Cypress Tests on Security Solution'
     key: response-ops
     agents:
-      machineType: n2-standard-4
+      machineType: n4-standard-4
+      diskType: hyperdisk-balanced
+      zones: us-central1-a,us-east4-b,us-east1-b
       preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
+      spotZones: us-central1-a,us-east4-b,us-east1-b
     depends_on:
       - build
     timeout_in_minutes: 60

--- a/.buildkite/pipelines/pull_request/response_ops_cases.yml
+++ b/.buildkite/pipelines/pull_request/response_ops_cases.yml
@@ -3,9 +3,11 @@ steps:
     label: 'Cases Cypress Tests on Security Solution'
     key: response-ops-cases
     agents:
-      machineType: n2-standard-4
+      machineType: n4-standard-4
+      diskType: hyperdisk-balanced
+      zones: us-central1-a,us-east4-b,us-east1-b
       preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
+      spotZones: us-central1-a,us-east4-b,us-east1-b
     depends_on:
       - build
     timeout_in_minutes: 60

--- a/.buildkite/pipelines/pull_request/security_solution/ai4dsoc.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/ai4dsoc.yml
@@ -4,9 +4,11 @@ steps:
     key: security-serverless-ai4dsoc
     if: "build.env('GITHUB_PR_TARGET_BRANCH') == 'main'"
     agents:
-      machineType: n2-standard-4
+      machineType: n4-standard-4
+      diskType: hyperdisk-balanced
+      zones: us-central1-a,us-east4-b,us-east1-b
       preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
+      spotZones: us-central1-a,us-east4-b,us-east1-b
     depends_on:
       - build
     timeout_in_minutes: 60

--- a/.buildkite/pipelines/pull_request/security_solution/ai_assistant.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/ai_assistant.yml
@@ -4,9 +4,11 @@ steps:
     key: security-serverless-ai-assistant
     if: "build.env('GITHUB_PR_TARGET_BRANCH') == 'main'"
     agents:
-      machineType: n2-standard-4
+      machineType: n4-standard-4
+      diskType: hyperdisk-balanced
+      zones: us-central1-a,us-east4-b,us-east1-b
       preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
+      spotZones: us-central1-a,us-east4-b,us-east1-b
     depends_on:
       - build
     timeout_in_minutes: 60
@@ -22,9 +24,11 @@ steps:
     label: 'AI Assistant - Security Solution Cypress Tests'
     key: security-ai-assistant
     agents:
-      machineType: n2-standard-4
+      machineType: n4-standard-4
+      diskType: hyperdisk-balanced
+      zones: us-central1-a,us-east4-b,us-east1-b
       preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
+      spotZones: us-central1-a,us-east4-b,us-east1-b
     depends_on:
       - build
     timeout_in_minutes: 60

--- a/.buildkite/pipelines/pull_request/security_solution/asset_inventory.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/asset_inventory.yml
@@ -3,9 +3,11 @@ steps:
     label: 'Asset Inventory Cypress Tests'
     key: asset-inventory
     agents:
-      machineType: n2-standard-4
+      machineType: n4-standard-4
+      diskType: hyperdisk-balanced
+      zones: us-central1-a,us-east4-b,us-east1-b
       preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
+      spotZones: us-central1-a,us-east4-b,us-east1-b
     depends_on:
       - build
     timeout_in_minutes: 60
@@ -22,9 +24,11 @@ steps:
     key: asset-inventory-serverless
     if: "build.env('GITHUB_PR_TARGET_BRANCH') == 'main'"
     agents:
-      machineType: n2-standard-4
+      machineType: n4-standard-4
+      diskType: hyperdisk-balanced
+      zones: us-central1-a,us-east4-b,us-east1-b
       preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
+      spotZones: us-central1-a,us-east4-b,us-east1-b
     depends_on:
       - build
     timeout_in_minutes: 60

--- a/.buildkite/pipelines/pull_request/security_solution/cloud_security_posture.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/cloud_security_posture.yml
@@ -3,9 +3,11 @@ steps:
     label: 'Cloud Security Posture Cypress Tests'
     key: cloud-security-posture
     agents:
-      machineType: n2-standard-4
+      machineType: n4-standard-4
+      diskType: hyperdisk-balanced
+      zones: us-central1-a,us-east4-b,us-east1-b
       preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
+      spotZones: us-central1-a,us-east4-b,us-east1-b
     depends_on:
       - build
     timeout_in_minutes: 60
@@ -22,9 +24,11 @@ steps:
     key: cloud-security-posture-serverless
     if: "build.env('GITHUB_PR_TARGET_BRANCH') == 'main'"
     agents:
-      machineType: n2-standard-4
+      machineType: n4-standard-4
+      diskType: hyperdisk-balanced
+      zones: us-central1-a,us-east4-b,us-east1-b
       preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
+      spotZones: us-central1-a,us-east4-b,us-east1-b
     depends_on:
       - build
     timeout_in_minutes: 60

--- a/.buildkite/pipelines/pull_request/security_solution/cspm_agentless_scout.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/cspm_agentless_scout.yml
@@ -3,9 +3,11 @@ steps:
     label: 'CSPM Agentless Scout E2E Tests'
     key: cspm-agentless-scout
     agents:
-      machineType: n2-standard-8
+      machineType: n4-standard-8
+      diskType: hyperdisk-balanced
+      zones: us-central1-a,us-east4-b,us-east1-b
       preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
+      spotZones: us-central1-a,us-east4-b,us-east1-b
     depends_on:
       - build
     timeout_in_minutes: 60

--- a/.buildkite/pipelines/pull_request/security_solution/cypress_burn.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/cypress_burn.yml
@@ -4,10 +4,12 @@ steps:
     key: defend-workflows-burn
     agents:
       enableNestedVirtualization: true
-      machineType: n2-standard-4
+      machineType: n4-standard-4
+      diskType: hyperdisk-balanced
+      zones: us-central1-a,us-east4-b,us-east1-b
       diskSizeGb: 120
       preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
+      spotZones: us-central1-a,us-east4-b,us-east1-b
     depends_on:
       - build
     timeout_in_minutes: 60
@@ -22,10 +24,12 @@ steps:
     if: "build.env('GITHUB_PR_TARGET_BRANCH') == 'main'"
     agents:
       enableNestedVirtualization: true
-      machineType: n2-standard-4
+      machineType: n4-standard-4
+      diskType: hyperdisk-balanced
+      zones: us-central1-a,us-east4-b,us-east1-b
       diskSizeGb: 120
       preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
+      spotZones: us-central1-a,us-east4-b,us-east1-b
     depends_on:
       - build
     timeout_in_minutes: 60
@@ -38,9 +42,11 @@ steps:
     label: '[Soft fail] Security Solution Cypress tests, burning changed specs'
     key: security-solution-burn
     agents:
-      machineType: n2-standard-4
+      machineType: n4-standard-4
+      diskType: hyperdisk-balanced
+      zones: us-central1-a,us-east4-b,us-east1-b
       preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
+      spotZones: us-central1-a,us-east4-b,us-east1-b
     depends_on:
       - build
     timeout_in_minutes: 60
@@ -53,10 +59,12 @@ steps:
     label: '[Soft fail] Osquery Cypress Tests, burning changed specs'
     key: osquery-cypress-burn
     agents:
-      machineType: n2-standard-4
+      machineType: n4-standard-4
+      diskType: hyperdisk-balanced
+      zones: us-central1-a,us-east4-b,us-east1-b
       diskSizeGb: 120
       preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
+      spotZones: us-central1-a,us-east4-b,us-east1-b
     depends_on:
       - build
     timeout_in_minutes: 50

--- a/.buildkite/pipelines/pull_request/security_solution/defend_workflows.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/defend_workflows.yml
@@ -4,10 +4,12 @@ steps:
     key: defend-workflows
     agents:
       enableNestedVirtualization: true
-      machineType: n2-highmem-4
+      machineType: n4-highmem-4
+      diskType: hyperdisk-balanced
+      zones: us-central1-a,us-east4-b,us-east1-b
       diskSizeGb: 120
       preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
+      spotZones: us-central1-a,us-east4-b,us-east1-b
     depends_on:
       - build
     timeout_in_minutes: 60
@@ -25,10 +27,12 @@ steps:
     if: "build.env('GITHUB_PR_TARGET_BRANCH') == 'main'"
     agents:
       enableNestedVirtualization: true
-      machineType: n2-highmem-4
+      machineType: n4-highmem-4
+      diskType: hyperdisk-balanced
+      zones: us-central1-a,us-east4-b,us-east1-b
       diskSizeGb: 120
       preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
+      spotZones: us-central1-a,us-east4-b,us-east1-b
     depends_on:
       - build
     timeout_in_minutes: 60

--- a/.buildkite/pipelines/pull_request/security_solution/detection_engine.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/detection_engine.yml
@@ -4,9 +4,11 @@ steps:
     key: security-serverless-detection-engine
     if: "build.env('GITHUB_PR_TARGET_BRANCH') == 'main'"
     agents:
-      machineType: n2-standard-4
+      machineType: n4-standard-4
+      diskType: hyperdisk-balanced
+      zones: us-central1-a,us-east4-b,us-east1-b
       preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
+      spotZones: us-central1-a,us-east4-b,us-east1-b
     depends_on:
       - build
     timeout_in_minutes: 60
@@ -23,9 +25,11 @@ steps:
     key: security-serverless-detection-engine-exceptions
     if: "build.env('GITHUB_PR_TARGET_BRANCH') == 'main'"
     agents:
-      machineType: n2-standard-4
+      machineType: n4-standard-4
+      diskType: hyperdisk-balanced
+      zones: us-central1-a,us-east4-b,us-east1-b
       preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
+      spotZones: us-central1-a,us-east4-b,us-east1-b
     depends_on:
       - build
     timeout_in_minutes: 60
@@ -41,9 +45,11 @@ steps:
     label: 'Detection Engine - Security Solution Cypress Tests'
     key: security-detection-engine
     agents:
-      machineType: n2-standard-4
+      machineType: n4-standard-4
+      diskType: hyperdisk-balanced
+      zones: us-central1-a,us-east4-b,us-east1-b
       preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
+      spotZones: us-central1-a,us-east4-b,us-east1-b
     depends_on:
       - build
     timeout_in_minutes: 60
@@ -59,9 +65,11 @@ steps:
     label: 'Detection Engine - Exceptions - Security Solution Cypress Tests'
     key: security-detection-engine-exceptions
     agents:
-      machineType: n2-standard-4
+      machineType: n4-standard-4
+      diskType: hyperdisk-balanced
+      zones: us-central1-a,us-east4-b,us-east1-b
       preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
+      spotZones: us-central1-a,us-east4-b,us-east1-b
     depends_on:
       - build
     timeout_in_minutes: 60

--- a/.buildkite/pipelines/pull_request/security_solution/entity_analytics.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/entity_analytics.yml
@@ -4,9 +4,11 @@ steps:
     key: security-serverless-entity-analytics
     if: "build.env('GITHUB_PR_TARGET_BRANCH') == 'main'"
     agents:
-      machineType: n2-standard-4
+      machineType: n4-standard-4
+      diskType: hyperdisk-balanced
+      zones: us-central1-a,us-east4-b,us-east1-b
       preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
+      spotZones: us-central1-a,us-east4-b,us-east1-b
     depends_on:
       - build
     timeout_in_minutes: 60
@@ -22,9 +24,11 @@ steps:
     label: 'Entity Analytics - Security Solution Cypress Tests'
     key: security-entity-analytics
     agents:
-      machineType: n2-standard-4
+      machineType: n4-standard-4
+      diskType: hyperdisk-balanced
+      zones: us-central1-a,us-east4-b,us-east1-b
       preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
+      spotZones: us-central1-a,us-east4-b,us-east1-b
     depends_on:
       - build
     timeout_in_minutes: 60

--- a/.buildkite/pipelines/pull_request/security_solution/explore.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/explore.yml
@@ -3,9 +3,11 @@ steps:
     label: 'Explore - Security Solution Cypress Tests'
     key: security-explore
     agents:
-      machineType: n2-standard-4
+      machineType: n4-standard-4
+      diskType: hyperdisk-balanced
+      zones: us-central1-a,us-east4-b,us-east1-b
       preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
+      spotZones: us-central1-a,us-east4-b,us-east1-b
     depends_on:
       - build
     timeout_in_minutes: 60
@@ -22,9 +24,11 @@ steps:
     key: security-serverless-explore
     if: "build.env('GITHUB_PR_TARGET_BRANCH') == 'main'"
     agents:
-      machineType: n2-standard-4
+      machineType: n4-standard-4
+      diskType: hyperdisk-balanced
+      zones: us-central1-a,us-east4-b,us-east1-b
       preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
+      spotZones: us-central1-a,us-east4-b,us-east1-b
     depends_on:
       - build
     timeout_in_minutes: 60

--- a/.buildkite/pipelines/pull_request/security_solution/gen_ai_evals.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/gen_ai_evals.yml
@@ -14,9 +14,11 @@ steps:
         timeout_in_minutes: 50
         parallelism: 1
         agents:
-          machineType: n2-standard-4
+          machineType: n4-standard-4
+          diskType: hyperdisk-balanced
+          zones: us-central1-a,us-east4-b,us-east1-b
           preemptible: true
-          spotZones: us-central1-f,us-central1-c,us-central1-a
+          spotZones: us-central1-a,us-east4-b,us-east1-b
         retry:
           automatic:
             - exit_status: '-1'

--- a/.buildkite/pipelines/pull_request/security_solution/investigations.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/investigations.yml
@@ -3,10 +3,12 @@ steps:
     label: 'Investigations - Security Solution Cypress Tests'
     key: security-investigations
     agents:
-      machineType: n2-standard-4
+      machineType: n4-standard-4
+      diskType: hyperdisk-balanced
+      zones: us-central1-a,us-east4-b,us-east1-b
       diskSizeGb: 110
       preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
+      spotZones: us-central1-a,us-east4-b,us-east1-b
     depends_on:
       - build
     timeout_in_minutes: 60
@@ -23,10 +25,12 @@ steps:
     key: security-serverless-investigations
     if: "build.env('GITHUB_PR_TARGET_BRANCH') == 'main'"
     agents:
-      machineType: n2-standard-4
+      machineType: n4-standard-4
+      diskType: hyperdisk-balanced
+      zones: us-central1-a,us-east4-b,us-east1-b
       diskSizeGb: 110
       preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
+      spotZones: us-central1-a,us-east4-b,us-east1-b
     depends_on:
       - build
     timeout_in_minutes: 60

--- a/.buildkite/pipelines/pull_request/security_solution/osquery_cypress.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/osquery_cypress.yml
@@ -3,10 +3,12 @@ steps:
     label: 'Osquery Cypress Tests'
     key: osquery-cypress
     agents:
-      machineType: n2-highmem-4
+      machineType: n4-highmem-4
+      diskType: hyperdisk-balanced
+      zones: us-central1-a,us-east4-b,us-east1-b
       diskSizeGb: 120
       preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
+      spotZones: us-central1-a,us-east4-b,us-east1-b
     depends_on:
       - build
     timeout_in_minutes: 60
@@ -23,10 +25,12 @@ steps:
     key: osquery-serverless
     if: "build.env('GITHUB_PR_TARGET_BRANCH') == 'main'"
     agents:
-      machineType: n2-highmem-4
+      machineType: n4-highmem-4
+      diskType: hyperdisk-balanced
+      zones: us-central1-a,us-east4-b,us-east1-b
       diskSizeGb: 120
       preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
+      spotZones: us-central1-a,us-east4-b,us-east1-b
     depends_on:
       - build
     timeout_in_minutes: 60

--- a/.buildkite/pipelines/pull_request/security_solution/rule_management.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/rule_management.yml
@@ -4,10 +4,12 @@ steps:
     key: security-serverless-rule-management
     if: "build.env('GITHUB_PR_TARGET_BRANCH') == 'main'"
     agents:
-      machineType: n2-standard-4
+      machineType: n4-standard-4
+      diskType: hyperdisk-balanced
+      zones: us-central1-a,us-east4-b,us-east1-b
       diskSizeGb: 120
       preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
+      spotZones: us-central1-a,us-east4-b,us-east1-b
     depends_on:
       - build
     timeout_in_minutes: 60
@@ -24,9 +26,11 @@ steps:
     key: security-serverless-rule-management-prebuilt-customization
     if: "build.env('GITHUB_PR_TARGET_BRANCH') == 'main'"
     agents:
-      machineType: n2-standard-4
+      machineType: n4-standard-4
+      diskType: hyperdisk-balanced
+      zones: us-central1-a,us-east4-b,us-east1-b
       preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
+      spotZones: us-central1-a,us-east4-b,us-east1-b
     depends_on:
       - build
     timeout_in_minutes: 60
@@ -43,9 +47,11 @@ steps:
     key: security-serverless-rule-management-prebuilt-installation
     if: "build.env('GITHUB_PR_TARGET_BRANCH') == 'main'"
     agents:
-      machineType: n2-standard-4
+      machineType: n4-standard-4
+      diskType: hyperdisk-balanced
+      zones: us-central1-a,us-east4-b,us-east1-b
       preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
+      spotZones: us-central1-a,us-east4-b,us-east1-b
     depends_on:
       - build
     timeout_in_minutes: 60
@@ -62,9 +68,11 @@ steps:
     key: security-serverless-rule-management-prebuilt-management
     if: "build.env('GITHUB_PR_TARGET_BRANCH') == 'main'"
     agents:
-      machineType: n2-standard-4
+      machineType: n4-standard-4
+      diskType: hyperdisk-balanced
+      zones: us-central1-a,us-east4-b,us-east1-b
       preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
+      spotZones: us-central1-a,us-east4-b,us-east1-b
     depends_on:
       - build
     timeout_in_minutes: 60
@@ -81,9 +89,11 @@ steps:
     key: security-serverless-rule-management-prebuilt-upgrade
     if: "build.env('GITHUB_PR_TARGET_BRANCH') == 'main'"
     agents:
-      machineType: n2-standard-4
+      machineType: n4-standard-4
+      diskType: hyperdisk-balanced
+      zones: us-central1-a,us-east4-b,us-east1-b
       preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
+      spotZones: us-central1-a,us-east4-b,us-east1-b
     depends_on:
       - build
     timeout_in_minutes: 60
@@ -99,9 +109,11 @@ steps:
     label: 'Rule Management - Security Solution Cypress Tests'
     key: security-rule-management
     agents:
-      machineType: n2-standard-4
+      machineType: n4-standard-4
+      diskType: hyperdisk-balanced
+      zones: us-central1-a,us-east4-b,us-east1-b
       preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
+      spotZones: us-central1-a,us-east4-b,us-east1-b
     depends_on:
       - build
     timeout_in_minutes: 60
@@ -117,9 +129,11 @@ steps:
     label: 'Rule Management - Prebuilt Rules Customization - Security Solution Cypress Tests'
     key: security-rule-management-prebuilt-customization
     agents:
-      machineType: n2-standard-4
+      machineType: n4-standard-4
+      diskType: hyperdisk-balanced
+      zones: us-central1-a,us-east4-b,us-east1-b
       preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
+      spotZones: us-central1-a,us-east4-b,us-east1-b
     depends_on:
       - build
     timeout_in_minutes: 60
@@ -135,9 +149,11 @@ steps:
     label: 'Rule Management - Prebuilt Rules Installation - Security Solution Cypress Tests'
     key: security-rule-management-prebuilt-installation
     agents:
-      machineType: n2-standard-4
+      machineType: n4-standard-4
+      diskType: hyperdisk-balanced
+      zones: us-central1-a,us-east4-b,us-east1-b
       preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
+      spotZones: us-central1-a,us-east4-b,us-east1-b
     depends_on:
       - build
     timeout_in_minutes: 60
@@ -153,9 +169,11 @@ steps:
     label: 'Rule Management - Prebuilt Rules Management - Security Solution Cypress Tests'
     key: security-rule-management-prebuilt-management
     agents:
-      machineType: n2-standard-4
+      machineType: n4-standard-4
+      diskType: hyperdisk-balanced
+      zones: us-central1-a,us-east4-b,us-east1-b
       preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
+      spotZones: us-central1-a,us-east4-b,us-east1-b
     depends_on:
       - build
     timeout_in_minutes: 60
@@ -171,9 +189,11 @@ steps:
     label: 'Rule Management - Prebuilt Rules Upgrade - Security Solution Cypress Tests'
     key: security-rule-management-prebuilt-upgrade
     agents:
-      machineType: n2-standard-4
+      machineType: n4-standard-4
+      diskType: hyperdisk-balanced
+      zones: us-central1-a,us-east4-b,us-east1-b
       preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
+      spotZones: us-central1-a,us-east4-b,us-east1-b
     depends_on:
       - build
     timeout_in_minutes: 60

--- a/.buildkite/pipelines/pull_request/store_moon_cache.yml
+++ b/.buildkite/pipelines/pull_request/store_moon_cache.yml
@@ -5,7 +5,9 @@ steps:
     id: store_cache
     soft_fail: true
     agents:
-      machineType: n2-highcpu-8
+      machineType: n4-highcpu-8
+      diskType: hyperdisk-balanced
+      zones: us-central1-a,us-east4-b,us-east1-b
       diskSizeGb: 95
       image: family/kibana-ubuntu-2404
       imageProject: elastic-images-prod

--- a/.buildkite/pipelines/pull_request/storybooks.yml
+++ b/.buildkite/pipelines/pull_request/storybooks.yml
@@ -2,9 +2,11 @@ steps:
   - command: .buildkite/scripts/steps/storybooks/build_and_upload.sh
     label: 'Build Storybooks'
     agents:
-      machineType: n2-standard-8
+      machineType: n4-standard-8
+      diskType: hyperdisk-balanced
+      zones: us-central1-a,us-east4-b,us-east1-b
       preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
+      spotZones: us-central1-a,us-east4-b,us-east1-b
       diskSizeGb: 105
     key: storybooks
     timeout_in_minutes: 80

--- a/.buildkite/pipelines/pull_request/sync_model_labels.yml
+++ b/.buildkite/pipelines/pull_request/sync_model_labels.yml
@@ -11,7 +11,9 @@ steps:
       image: family/kibana-ubuntu-2404
       imageProject: elastic-images-prod
       provider: gcp
-      machineType: n2-standard-4
+      machineType: n4-standard-4
+      diskType: hyperdisk-balanced
+      zones: us-central1-a,us-east4-b,us-east1-b
     retry:
       automatic:
         - exit_status: '-1'

--- a/.buildkite/pipelines/pull_request/trigger_entity_store_performance.yml
+++ b/.buildkite/pipelines/pull_request/trigger_entity_store_performance.yml
@@ -6,7 +6,9 @@ steps:
       provider: gcp
       image: family/kibana-ubuntu-2404
       imageProject: elastic-images-prod
-      machineType: n2-standard-2
+      machineType: n4-standard-2
+      diskType: hyperdisk-balanced
+      zones: us-central1-a,us-east4-b,us-east1-b
     timeout_in_minutes: 10
     soft_fail: true
     retry:

--- a/.buildkite/pipelines/pull_request/webpack_bundle_analyzer.yml
+++ b/.buildkite/pipelines/pull_request/webpack_bundle_analyzer.yml
@@ -2,9 +2,11 @@ steps:
   - command: .buildkite/scripts/steps/webpack_bundle_analyzer/build_and_upload.sh
     label: 'Build Webpack Bundle Analyzer reports'
     agents:
-      machineType: n2-standard-8
+      machineType: n4-standard-8
+      diskType: hyperdisk-balanced
+      zones: us-central1-a,us-east4-b,us-east1-b
       preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
+      spotZones: us-central1-a,us-east4-b,us-east1-b
     key: webpack_bundle_analyzer
     timeout_in_minutes: 60
     retry:

--- a/.buildkite/pipelines/pull_request/workflows_oom_testing.yml
+++ b/.buildkite/pipelines/pull_request/workflows_oom_testing.yml
@@ -3,9 +3,11 @@ steps:
     label: 'Workflow Schema OOM Prevention'
     key: workflows-oom-testing
     agents:
-      machineType: n2-standard-4
+      machineType: n4-standard-4
+      diskType: hyperdisk-balanced
+      zones: us-central1-a,us-east4-b,us-east1-b
       preemptible: true
-      spotZones: us-central1-f,us-central1-c,us-central1-a
+      spotZones: us-central1-a,us-east4-b,us-east1-b
     depends_on:
       - build
     timeout_in_minutes: 30

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/monitor_detail_flyout.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/monitor_detail_flyout.tsx
@@ -331,7 +331,11 @@ export function MonitorDetailFlyout(props: Props) {
               </EuiTitle>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <EuiToolTip content={isPush ? UNDOCK_LABEL : DOCK_LABEL} display="block">
+              <EuiToolTip
+                content={isPush ? UNDOCK_LABEL : DOCK_LABEL}
+                display="block"
+                disableScreenReaderOutput
+              >
                 <EuiButtonIcon
                   data-test-subj="syntheticsFlyoutToggleMode"
                   iconType={isPush ? 'menuLeft' : 'menuRight'}


### PR DESCRIPTION
## Summary
- Switch all FTR steps in PR pipelines from `n2-standard-4` to `n4-standard-4` spot instances
- Updates `defaultQueue` and per-config queue overrides across all FTR config manifests
- Updates `expandAgentQueue` default parameter for consistency

**This PR will not be merged — it is only for testing n4 machine types.**