### PR TITLE
[Search] Limit string payload sizes for routes

### DIFF
--- a/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/analytics.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/analytics.ts
@@ -122,7 +122,7 @@ export function registerAnalyticsRoutes({
       },
       validate: {
         body: schema.object({
-          keyName: schema.string(),
+          keyName: schema.string({ maxLength: 1000 }),
         }),
         params: schema.object({
           name: schema.string(),

--- a/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/api_keys.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/api_keys.ts
@@ -23,7 +23,7 @@ export function registerApiKeysRoutes({ log, router }: RouteDependencies) {
       },
       validate: {
         body: schema.object({
-          keyName: schema.string(),
+          keyName: schema.string({ maxLength: 1000 }),
         }),
         params: schema.object({
           indexName: schema.string(),

--- a/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/connectors.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/connectors.ts
@@ -73,11 +73,11 @@ export function registerConnectorRoutes({ router, log, getStartServices }: Route
       validate: {
         body: schema.object({
           delete_existing_connector: schema.maybe(schema.boolean()),
-          index_name: schema.maybe(schema.string()),
+          index_name: schema.maybe(schema.string({ maxLength: 255 })),
           is_native: schema.boolean(),
-          language: schema.nullable(schema.string()),
-          name: schema.maybe(schema.string()),
-          service_type: schema.maybe(schema.string()),
+          language: schema.nullable(schema.string({ maxLength: 512 })),
+          name: schema.maybe(schema.string({ maxLength: 1000 })),
+          service_type: schema.maybe(schema.string({ maxLength: 512 })),
         }),
       },
     },
@@ -189,8 +189,8 @@ export function registerConnectorRoutes({ router, log, getStartServices }: Route
       },
       validate: {
         body: schema.recordOf(
-          schema.string(),
-          schema.oneOf([schema.string(), schema.number(), schema.boolean()])
+          schema.string({ maxLength: 1000 }),
+          schema.oneOf([schema.string({ maxLength: 4096 }), schema.number(), schema.boolean()])
         ),
         params: schema.object({
           connectorId: schema.string(),
@@ -219,9 +219,18 @@ export function registerConnectorRoutes({ router, log, getStartServices }: Route
       },
       validate: {
         body: schema.object({
-          access_control: schema.object({ enabled: schema.boolean(), interval: schema.string() }),
-          full: schema.object({ enabled: schema.boolean(), interval: schema.string() }),
-          incremental: schema.object({ enabled: schema.boolean(), interval: schema.string() }),
+          access_control: schema.object({
+            enabled: schema.boolean(),
+            interval: schema.string({ maxLength: 512 }),
+          }),
+          full: schema.object({
+            enabled: schema.boolean(),
+            interval: schema.string({ maxLength: 512 }),
+          }),
+          incremental: schema.object({
+            enabled: schema.boolean(),
+            interval: schema.string({ maxLength: 512 }),
+          }),
         }),
         params: schema.object({
           connectorId: schema.string(),
@@ -368,7 +377,7 @@ export function registerConnectorRoutes({ router, log, getStartServices }: Route
       validate: {
         body: schema.object({
           extract_binary_content: schema.boolean(),
-          name: schema.string(),
+          name: schema.string({ maxLength: 1000 }),
           reduce_whitespace: schema.boolean(),
           run_ml_inference: schema.boolean(),
         }),
@@ -397,7 +406,7 @@ export function registerConnectorRoutes({ router, log, getStartServices }: Route
       validate: {
         body: schema.object({
           extract_binary_content: schema.boolean(),
-          name: schema.string(),
+          name: schema.string({ maxLength: 1000 }),
           reduce_whitespace: schema.boolean(),
           run_ml_inference: schema.boolean(),
         }),
@@ -438,7 +447,7 @@ export function registerConnectorRoutes({ router, log, getStartServices }: Route
         },
       },
       validate: {
-        body: schema.object({ serviceType: schema.string() }),
+        body: schema.object({ serviceType: schema.string({ maxLength: 512 }) }),
         params: schema.object({
           connectorId: schema.string(),
         }),
@@ -465,7 +474,7 @@ export function registerConnectorRoutes({ router, log, getStartServices }: Route
         },
       },
       validate: {
-        body: schema.object({ status: schema.string() }),
+        body: schema.object({ status: schema.string({ maxLength: 512 }) }),
         params: schema.object({
           connectorId: schema.string(),
         }),
@@ -493,8 +502,8 @@ export function registerConnectorRoutes({ router, log, getStartServices }: Route
       },
       validate: {
         body: schema.object({
-          description: schema.nullable(schema.string()),
-          name: schema.string(),
+          description: schema.nullable(schema.string({ maxLength: 4096 })),
+          name: schema.string({ maxLength: 1000 }),
         }),
         params: schema.object({
           connectorId: schema.string(),
@@ -527,17 +536,17 @@ export function registerConnectorRoutes({ router, log, getStartServices }: Route
       },
       validate: {
         body: schema.object({
-          advanced_snippet: schema.string(),
+          advanced_snippet: schema.string({ maxLength: 10000 }),
           filtering_rules: schema.arrayOf(
             schema.object({
-              created_at: schema.string(),
-              field: schema.string(),
-              id: schema.string(),
+              created_at: schema.string({ maxLength: 512 }),
+              field: schema.string({ maxLength: 1000 }),
+              id: schema.string({ maxLength: 512 }),
               order: schema.number(),
-              policy: schema.string(),
-              rule: schema.string(),
-              updated_at: schema.string(),
-              value: schema.string(),
+              policy: schema.string({ maxLength: 512 }),
+              rule: schema.string({ maxLength: 1000 }),
+              updated_at: schema.string({ maxLength: 512 }),
+              value: schema.string({ maxLength: 10000 }),
             }),
             { maxSize: 1000 }
           ),
@@ -573,17 +582,17 @@ export function registerConnectorRoutes({ router, log, getStartServices }: Route
       validate: {
         body: schema.maybe(
           schema.object({
-            advanced_snippet: schema.string(),
+            advanced_snippet: schema.string({ maxLength: 10000 }),
             filtering_rules: schema.arrayOf(
               schema.object({
-                created_at: schema.string(),
-                field: schema.string(),
-                id: schema.string(),
+                created_at: schema.string({ maxLength: 512 }),
+                field: schema.string({ maxLength: 1000 }),
+                id: schema.string({ maxLength: 512 }),
                 order: schema.number(),
-                policy: schema.string(),
-                rule: schema.string(),
-                updated_at: schema.string(),
-                value: schema.string(),
+                policy: schema.string({ maxLength: 512 }),
+                rule: schema.string({ maxLength: 1000 }),
+                updated_at: schema.string({ maxLength: 512 }),
+                value: schema.string({ maxLength: 10000 }),
               }),
               { maxSize: 1000 }
             ),
@@ -987,8 +996,8 @@ export function registerConnectorRoutes({ router, log, getStartServices }: Route
       },
       validate: {
         body: schema.object({
-          connectorName: schema.maybe(schema.string()),
-          connectorType: schema.string(),
+          connectorName: schema.maybe(schema.string({ maxLength: 1000 })),
+          connectorType: schema.string({ maxLength: 512 }),
           isManagedConnector: schema.maybe(schema.boolean()),
         }),
       },

--- a/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/indices.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/indices.ts
@@ -514,19 +514,22 @@ export function registerIndexRoutes({ router, log, ml }: RouteDependencies) {
         body: schema.object({
           field_mappings: schema.maybe(
             schema.arrayOf(
-              schema.object({ sourceField: schema.string(), targetField: schema.string() }),
+              schema.object({
+                sourceField: schema.string({ maxLength: 1000 }),
+                targetField: schema.string({ maxLength: 1000 }),
+              }),
               { maxSize: 10000 }
             )
           ),
-          model_id: schema.string(),
+          model_id: schema.string({ maxLength: 512 }),
           pipeline_definition: schema.maybe(
             schema.object({
-              description: schema.maybe(schema.string()),
+              description: schema.maybe(schema.string({ maxLength: 4096 })),
               processors: schema.arrayOf(schema.any(), { maxSize: 10000 }),
               version: schema.number(),
             })
           ),
-          pipeline_name: schema.string(),
+          pipeline_name: schema.string({ maxLength: 1000 }),
         }),
       },
     },
@@ -597,7 +600,7 @@ export function registerIndexRoutes({ router, log, ml }: RouteDependencies) {
       },
       validate: {
         body: schema.object({
-          pipeline_name: schema.string(),
+          pipeline_name: schema.string({ maxLength: 1000 }),
         }),
         params: schema.object({
           indexName: schema.string(),
@@ -642,8 +645,8 @@ export function registerIndexRoutes({ router, log, ml }: RouteDependencies) {
       },
       validate: {
         body: schema.object({
-          index_name: schema.string(),
-          language: schema.maybe(schema.nullable(schema.string())),
+          index_name: schema.string({ maxLength: 255 }),
+          language: schema.maybe(schema.nullable(schema.string({ maxLength: 512 }))),
         }),
       },
     },
@@ -712,7 +715,7 @@ export function registerIndexRoutes({ router, log, ml }: RouteDependencies) {
         body: schema.object({
           docs: schema.arrayOf(schema.any(), { maxSize: 10000 }),
           pipeline: schema.object({
-            description: schema.maybe(schema.string()),
+            description: schema.maybe(schema.string({ maxLength: 4096 })),
             processors: schema.arrayOf(schema.any(), { maxSize: 10000 }),
           }),
         }),
@@ -901,7 +904,7 @@ export function registerIndexRoutes({ router, log, ml }: RouteDependencies) {
       },
       validate: {
         body: schema.object({
-          description: schema.maybe(schema.string()),
+          description: schema.maybe(schema.string({ maxLength: 4096 })),
           processors: schema.arrayOf(schema.any(), { maxSize: 10000 }),
         }),
         params: schema.object({

--- a/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/search.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/search.ts
@@ -32,6 +32,7 @@ export function registerSearchRoute({ router, log }: RouteDependencies) {
         body: schema.object({
           searchQuery: schema.string({
             defaultValue: '',
+            maxLength: 10000,
           }),
         }),
         params: schema.object({

--- a/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/search_applications.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/search_applications.ts
@@ -123,12 +123,15 @@ export function registerSearchApplicationsRoutes({ log, router }: RouteDependenc
       validate: {
         body: schema.object({
           indices: schema.arrayOf(schema.string({ maxLength: 1000 }), { maxSize: 1000 }),
-          name: schema.maybe(schema.string()),
+          name: schema.maybe(schema.string({ maxLength: 1000 })),
           template: schema.maybe(
             schema.object({
               script: schema.object({
-                source: schema.oneOf([schema.string(), schema.object({}, { unknowns: 'allow' })]),
-                lang: schema.string(),
+                source: schema.oneOf([
+                  schema.string({ maxLength: 10000 }),
+                  schema.object({}, { unknowns: 'allow' }),
+                ]),
+                lang: schema.string({ maxLength: 512 }),
                 params: schema.maybe(schema.object({}, { unknowns: 'allow' })),
                 options: schema.maybe(schema.object({}, { unknowns: 'allow' })),
               }),
@@ -280,7 +283,7 @@ export function registerSearchApplicationsRoutes({ log, router }: RouteDependenc
       },
       validate: {
         body: schema.object({
-          keyName: schema.string(),
+          keyName: schema.string({ maxLength: 1000 }),
         }),
         params: schema.object({
           engine_name: schema.string(),

--- a/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/telemetry.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/telemetry.ts
@@ -34,7 +34,7 @@ export function registerTelemetryRoute({ router, getSavedObjectsService }: Route
             schema.literal('clicked'),
             schema.literal('error'),
           ]),
-          metric: schema.string(),
+          metric: schema.string({ maxLength: 512 }),
         }),
       },
     },

--- a/x-pack/solutions/search/plugins/search_playground/server/routes.ts
+++ b/x-pack/solutions/search/plugins/search_playground/server/routes.ts
@@ -105,14 +105,14 @@ export function defineRoutes(routeOptions: DefineRoutesOptions) {
       validate: {
         body: schema.object({
           data: schema.object({
-            connector_id: schema.string(),
-            indices: schema.string(),
-            prompt: schema.string(),
+            connector_id: schema.string({ maxLength: 255 }),
+            indices: schema.string({ maxLength: 512 }),
+            prompt: schema.string({ maxLength: 4096 }),
             citations: schema.boolean(),
-            elasticsearch_query: schema.string(),
-            summarization_model: schema.maybe(schema.string()),
+            elasticsearch_query: schema.string({ maxLength: 10000 }),
+            summarization_model: schema.maybe(schema.string({ maxLength: 512 })),
             doc_size: schema.number(),
-            source_fields: schema.string(),
+            source_fields: schema.string({ maxLength: 10000 }),
           }),
           messages: schema.any(),
         }),
@@ -263,8 +263,8 @@ export function defineRoutes(routeOptions: DefineRoutesOptions) {
       },
       validate: {
         body: schema.object({
-          search_query: schema.string(),
-          elasticsearch_query: schema.string(),
+          search_query: schema.string({ maxLength: 10000 }),
+          elasticsearch_query: schema.string({ maxLength: 10000 }),
           indices: schema.arrayOf(schema.string(), { minSize: 1, maxSize: 100 }),
           size: schema.maybe(schema.number({ defaultValue: 10, min: 0, max: 100 })),
           from: schema.maybe(schema.number({ defaultValue: 0, min: 0 })),
@@ -399,14 +399,14 @@ export function defineRoutes(routeOptions: DefineRoutesOptions) {
       },
       validate: {
         body: schema.object({
-          query: schema.string(),
-          elasticsearch_query: schema.string(),
+          query: schema.string({ maxLength: 10000 }),
+          elasticsearch_query: schema.string({ maxLength: 10000 }),
           indices: schema.arrayOf(schema.string(), { minSize: 1, maxSize: 100 }),
           size: schema.maybe(schema.number({ defaultValue: 10, min: 0, max: 100 })),
           from: schema.maybe(schema.number({ defaultValue: 0, min: 0 })),
           chat_context: schema.maybe(
             schema.object({
-              source_fields: schema.string(),
+              source_fields: schema.string({ maxLength: 10000 }),
               doc_size: schema.number(),
             })
           ),

--- a/x-pack/solutions/search/plugins/search_query_rules/server/routes.ts
+++ b/x-pack/solutions/search/plugins/search_query_rules/server/routes.ts
@@ -123,12 +123,12 @@ export function defineRoutes({ logger, router }: { logger: Logger; router: IRout
           schema.object({
             rules: schema.arrayOf(
               schema.object({
-                rule_id: schema.string(),
-                type: schema.string(),
+                rule_id: schema.string({ maxLength: 512 }),
+                type: schema.string({ maxLength: 512 }),
                 criteria: schema.arrayOf(
                   schema.object({
-                    type: schema.string(),
-                    metadata: schema.maybe(schema.string()),
+                    type: schema.string({ maxLength: 512 }),
+                    metadata: schema.maybe(schema.string({ maxLength: 4096 })),
                     values: schema.maybe(schema.arrayOf(schema.string(), { maxSize: 100 })),
                   }),
                   { maxSize: 100 }
@@ -138,8 +138,8 @@ export function defineRoutes({ logger, router }: { logger: Logger; router: IRout
                   docs: schema.maybe(
                     schema.arrayOf(
                       schema.object({
-                        _id: schema.string(),
-                        _index: schema.string(),
+                        _id: schema.string({ maxLength: 512 }),
+                        _index: schema.string({ maxLength: 255 }),
                       }),
                       { maxSize: 10000 }
                     )

--- a/x-pack/solutions/search/plugins/search_synonyms/server/routes.ts
+++ b/x-pack/solutions/search/plugins/search_synonyms/server/routes.ts
@@ -401,7 +401,7 @@ export function defineRoutes({ logger, router }: { logger: Logger; router: IRout
           ruleId: schema.string(),
         }),
         body: schema.object({
-          synonyms: schema.string(),
+          synonyms: schema.string({ maxLength: 4096 }),
         }),
       },
     },

--- a/x-pack/solutions/search/plugins/serverless_search/server/routes/connectors_routes.ts
+++ b/x-pack/solutions/search/plugins/serverless_search/server/routes/connectors_routes.ts
@@ -127,7 +127,7 @@ export const registerConnectorsRoutes = ({ logger, http, router }: RouteDependen
       path: '/internal/serverless_search/connectors/{connectorId}/name',
       validate: {
         body: schema.object({
-          name: schema.string(),
+          name: schema.string({ maxLength: 1000 }),
         }),
         params: schema.object({
           connectorId: schema.string(),
@@ -164,7 +164,7 @@ export const registerConnectorsRoutes = ({ logger, http, router }: RouteDependen
       path: '/internal/serverless_search/connectors/{connectorId}/description',
       validate: {
         body: schema.object({
-          description: schema.string(),
+          description: schema.string({ maxLength: 4096 }),
         }),
         params: schema.object({
           connectorId: schema.string(),
@@ -201,7 +201,7 @@ export const registerConnectorsRoutes = ({ logger, http, router }: RouteDependen
       path: '/internal/serverless_search/connectors/{connectorId}/index_name',
       validate: {
         body: schema.object({
-          index_name: schema.string(),
+          index_name: schema.string({ maxLength: 255 }),
         }),
         params: schema.object({
           connectorId: schema.string(),
@@ -239,7 +239,7 @@ export const registerConnectorsRoutes = ({ logger, http, router }: RouteDependen
       path: '/internal/serverless_search/connectors/{connectorId}/service_type',
       validate: {
         body: schema.object({
-          service_type: schema.string(),
+          service_type: schema.string({ maxLength: 512 }),
         }),
         params: schema.object({
           connectorId: schema.string(),
@@ -302,8 +302,8 @@ export const registerConnectorsRoutes = ({ logger, http, router }: RouteDependen
       validate: {
         body: schema.object({
           configuration: schema.recordOf(
-            schema.string(),
-            schema.oneOf([schema.string(), schema.number(), schema.boolean()])
+            schema.string({ maxLength: 1000 }),
+            schema.oneOf([schema.string({ maxLength: 4096 }), schema.number(), schema.boolean()])
           ),
         }),
         params: schema.object({
@@ -401,9 +401,18 @@ export const registerConnectorsRoutes = ({ logger, http, router }: RouteDependen
       path: '/internal/serverless_search/connectors/{connectorId}/scheduling',
       validate: {
         body: schema.object({
-          access_control: schema.object({ enabled: schema.boolean(), interval: schema.string() }),
-          full: schema.object({ enabled: schema.boolean(), interval: schema.string() }),
-          incremental: schema.object({ enabled: schema.boolean(), interval: schema.string() }),
+          access_control: schema.object({
+            enabled: schema.boolean(),
+            interval: schema.string({ maxLength: 512 }),
+          }),
+          full: schema.object({
+            enabled: schema.boolean(),
+            interval: schema.string({ maxLength: 512 }),
+          }),
+          incremental: schema.object({
+            enabled: schema.boolean(),
+            interval: schema.string({ maxLength: 512 }),
+          }),
         }),
         params: schema.object({
           connectorId: schema.string(),
@@ -432,9 +441,9 @@ export const registerConnectorsRoutes = ({ logger, http, router }: RouteDependen
       path: '/internal/serverless_search/connectors/{connectorId}/generate_name',
       validate: {
         body: schema.object({
-          name: schema.string(),
+          name: schema.string({ maxLength: 1000 }),
           is_native: schema.boolean(),
-          service_type: schema.string(),
+          service_type: schema.string({ maxLength: 512 }),
         }),
         params: schema.object({
           connectorId: schema.string(),

--- a/x-pack/solutions/search/plugins/serverless_search/server/routes/indices_routes.ts
+++ b/x-pack/solutions/search/plugins/serverless_search/server/routes/indices_routes.ts
@@ -124,6 +124,7 @@ export const registerIndicesRoutes = ({ logger, router }: RouteDependencies) => 
         body: schema.object({
           searchQuery: schema.string({
             defaultValue: '',
+            maxLength: 10000,
           }),
           trackTotalHits: schema.boolean({ defaultValue: false }),
         }),


### PR DESCRIPTION
## Summary

Updated search plugin routes to limit the size of accepted strings in API payloads.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.



